### PR TITLE
fix(pull): Synchronize configured local target

### DIFF
--- a/crates/but/src/command/legacy/pull/mod.rs
+++ b/crates/but/src/command/legacy/pull/mod.rs
@@ -2,9 +2,15 @@ mod json;
 
 use std::fmt::Write;
 
+use anyhow::Context as _;
 use bstr::ByteSlice;
 use but_core::{DryRun, RepositoryExt};
 use but_ctx::Context;
+use gitbutler_oplog::{
+    LocalTargetSnapshot, OplogExt,
+    entry::{OperationKind, SnapshotDetails},
+};
+use gix::refs::transaction::PreviousValue;
 use json::{BaseBranchInfo, BranchStatusInfo, PullCheckOutput, UpstreamCommit, UpstreamInfo};
 use serde::{Deserialize, Serialize};
 
@@ -22,12 +28,34 @@ struct PullResult {
     status: String,
     upstream_url: Option<String>,
     upstream_commits_found: usize,
+    local_target: Option<LocalTargetUpdateInfo>,
     recent_commits: Vec<CommitInfo>,
     branches_to_update: Vec<BranchUpdateInfo>,
     integrated_branches: Vec<String>,
     conflicts: Vec<ConflictInfo>,
     summary: PullSummary,
     undo_command: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct LocalTargetUpdateInfo {
+    status: String,
+    branch: Option<String>,
+    previous_sha: Option<String>,
+    current_sha: String,
+}
+
+struct LocalTargetUpdatePlan {
+    info: LocalTargetUpdateInfo,
+    edit: Option<LocalTargetRefEdit>,
+}
+
+struct LocalTargetRefEdit {
+    ref_name: gix::refs::FullName,
+    tracking_ref: gix::refs::FullName,
+    previous_tip: gix::ObjectId,
+    current_tip: gix::ObjectId,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -226,6 +254,7 @@ async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<(
         status: String::new(),
         upstream_url: None,
         upstream_commits_found: 0,
+        local_target: None,
         recent_commits: vec![],
         branches_to_update: vec![],
         integrated_branches: vec![],
@@ -320,6 +349,11 @@ async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<(
         true
     };
     if !should_check_integration {
+        pull_result.local_target = Some(update_local_target_with_snapshot(
+            ctx,
+            base_branch.current_sha,
+        )?);
+        write_local_target_update(out, pull_result.local_target.as_ref())?;
         pull_result.status = "up_to_date".to_string();
         if let Some(out) = out.for_human() {
             writeln!(out, "\n{}", t.success.paint("Everything is up to date"))?;
@@ -338,6 +372,11 @@ async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<(
     } = upstream::dry_run_integration(ctx)?;
 
     if base_branch.behind == 0 && !statuses_need_update(&statuses) {
+        pull_result.local_target = Some(update_local_target_with_snapshot(
+            ctx,
+            base_branch.current_sha,
+        )?);
+        write_local_target_update(out, pull_result.local_target.as_ref())?;
         pull_result.status = "up_to_date".to_string();
         if let Some(out) = out.for_human() {
             writeln!(out, "\n{}", t.success.paint("Everything is up to date"))?;
@@ -367,9 +406,6 @@ async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<(
                 t.attention
                     .paint("Please commit or stash them and try again.")
             )?;
-        }
-        if let Some(out) = out.for_json() {
-            out.write_value(&pull_result)?;
         }
         None
     } else {
@@ -419,22 +455,28 @@ async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<(
         Some(statuses)
     };
 
+    if statuses_to_apply.is_none() {
+        pull_result.local_target = Some(update_local_target_with_snapshot(
+            ctx,
+            base_branch.current_sha,
+        )?);
+        write_local_target_update(out, pull_result.local_target.as_ref())?;
+        if let Some(out) = out.for_json() {
+            out.write_value(&pull_result)?;
+        }
+        return Ok(());
+    }
+
     // Step 3: Actually perform the integration
     if let Some(statuses) = statuses_to_apply {
-        let integration_result = {
-            let updates = but_api::workspace::rebase_stack_bottoms(&current_head_info);
-            let mut ctx = ctx.to_sync().into_thread_local();
-            let mut guard = ctx.exclusive_worktree_access();
-            but_api::workspace::workspace_integrate_upstream_with_perm(
-                &mut ctx,
-                updates,
-                DryRun::No,
-                guard.write_permission(),
-            )
-        };
+        let updates = but_api::workspace::rebase_stack_bottoms(&current_head_info);
+        let integration_result =
+            integrate_upstream_and_update_local_target(ctx, updates, base_branch.current_sha);
 
         match integration_result {
-            Ok(outcome) => {
+            Ok((outcome, local_target)) => {
+                pull_result.local_target = Some(local_target);
+                write_local_target_update(out, pull_result.local_target.as_ref())?;
                 let post_statuses =
                     upstream::classify(&current_head_info, &outcome.workspace_state);
                 // Report detailed results for each resolution
@@ -583,6 +625,254 @@ async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<(
         }
     }
 
+    Ok(())
+}
+
+fn plan_local_tracking_target_update(
+    ctx: &Context,
+    repo: &gix::Repository,
+    target_tip: gix::ObjectId,
+) -> anyhow::Result<LocalTargetUpdatePlan> {
+    let target_ref_name = ctx.project_meta()?.target_ref_or_err()?.clone();
+
+    let mut local_ref: Option<gix::Reference<'_>> = None;
+    for candidate in repo.references()?.local_branches()? {
+        let candidate = candidate.map_err(anyhow::Error::from_boxed)?;
+        let tracks_target = match repo
+            .branch_remote_tracking_ref_name(candidate.name(), gix::remote::Direction::Fetch)
+            .transpose()
+        {
+            Ok(Some(tracking_ref)) => tracking_ref.as_ref() == target_ref_name.as_ref(),
+            Ok(None) | Err(_) => false,
+        };
+        if !tracks_target {
+            continue;
+        }
+        if let Some(existing) = &local_ref {
+            anyhow::bail!(
+                "Cannot fast-forward a local target: both '{}' and '{}' are configured to track '{}'",
+                existing.name().shorten(),
+                candidate.name().shorten(),
+                target_ref_name.shorten()
+            );
+        }
+        local_ref = Some(candidate);
+    }
+    let Some(mut local_ref) = local_ref else {
+        return Ok(LocalTargetUpdatePlan {
+            info: LocalTargetUpdateInfo {
+                status: "not_configured".to_owned(),
+                branch: None,
+                previous_sha: None,
+                current_sha: target_tip.to_string(),
+            },
+            edit: None,
+        });
+    };
+    let local_ref_name = local_ref.name().to_owned();
+    let local_tip = local_ref.peel_to_id()?.detach();
+    if local_tip == target_tip {
+        return Ok(LocalTargetUpdatePlan {
+            info: LocalTargetUpdateInfo {
+                status: "already_current".to_owned(),
+                branch: Some(local_ref_name.shorten().to_string()),
+                previous_sha: Some(local_tip.to_string()),
+                current_sha: target_tip.to_string(),
+            },
+            edit: None,
+        });
+    }
+
+    let merge_base = match repo.merge_base(local_tip, target_tip) {
+        Ok(id) => Some(id.detach()),
+        Err(gix::repository::merge_base::Error::FindMergeBase(_))
+        | Err(gix::repository::merge_base::Error::NotFound { .. }) => None,
+        Err(err) => return Err(err.into()),
+    };
+    if merge_base != Some(local_tip) {
+        anyhow::bail!(
+            "Cannot fast-forward local target '{}' from {local_tip} to {target_tip}: it has diverged from '{}'",
+            local_ref_name.shorten(),
+            target_ref_name.shorten()
+        );
+    }
+
+    let checkout_probe = but_core::branch::SafeDelete::new(&repo)?;
+    if let Some(paths) = checkout_probe.worktree_dirs_with_ref(&local_ref) {
+        anyhow::bail!(
+            "Cannot fast-forward local target '{}' because it is checked out in: {paths:?}",
+            local_ref_name.shorten()
+        );
+    }
+
+    Ok(LocalTargetUpdatePlan {
+        info: LocalTargetUpdateInfo {
+            status: "fast_forwarded".to_owned(),
+            branch: Some(local_ref_name.shorten().to_string()),
+            previous_sha: Some(local_tip.to_string()),
+            current_sha: target_tip.to_string(),
+        },
+        edit: Some(LocalTargetRefEdit {
+            ref_name: local_ref_name,
+            tracking_ref: target_ref_name,
+            previous_tip: local_tip,
+            current_tip: target_tip,
+        }),
+    })
+}
+
+impl LocalTargetRefEdit {
+    fn snapshot(&self) -> LocalTargetSnapshot {
+        LocalTargetSnapshot {
+            ref_name: self.ref_name.clone(),
+            tracking_ref: self.tracking_ref.clone(),
+            snapshot_tip: self.previous_tip,
+            expected_tip: self.current_tip,
+        }
+    }
+
+    fn apply(&self, repo: &gix::Repository) -> anyhow::Result<()> {
+        repo.reference(
+            self.ref_name.as_ref(),
+            self.current_tip,
+            PreviousValue::ExistingMustMatch(self.previous_tip.into()),
+            "GitButler pull",
+        )?;
+        Ok(())
+    }
+}
+
+fn update_local_target_with_snapshot(
+    ctx: &Context,
+    target_tip: gix::ObjectId,
+) -> anyhow::Result<LocalTargetUpdateInfo> {
+    let mut thread_ctx = ctx.to_sync().into_thread_local();
+    let mut guard = thread_ctx.exclusive_worktree_access();
+    let plan = {
+        let repo = thread_ctx.repo.get()?;
+        plan_local_tracking_target_update(&thread_ctx, &repo, target_tip)?
+    };
+    let Some(edit) = &plan.edit else {
+        return Ok(plan.info.clone());
+    };
+    let snapshot_tree =
+        thread_ctx.prepare_snapshot_with_local_target(&edit.snapshot(), guard.read_permission())?;
+    let snapshot = thread_ctx.prepare_snapshot_commit(
+        snapshot_tree,
+        SnapshotDetails::new(OperationKind::MergeUpstream),
+        guard.read_permission(),
+    )?;
+    let snapshot_id = snapshot.commit_id();
+    fail_pull_before_local_target_effect()?;
+    {
+        let repo = thread_ctx.repo.get()?;
+        edit.apply(&repo)?;
+    }
+    if let Err(publication_err) = thread_ctx.publish_snapshot(snapshot, guard.write_permission()) {
+        thread_ctx
+            .restore_snapshot_state(snapshot_id, guard.write_permission())
+            .with_context(|| {
+                format!(
+                    "failed to roll back the pull after snapshot publication failed: {publication_err:#}"
+                )
+            })?;
+        return Err(publication_err);
+    }
+    Ok(plan.info.clone())
+}
+
+fn integrate_upstream_and_update_local_target(
+    ctx: &Context,
+    updates: Vec<but_workspace::BottomUpdate>,
+    target_tip: gix::ObjectId,
+) -> anyhow::Result<(
+    but_api::workspace::WorkspaceIntegrateUpstreamOutcome,
+    LocalTargetUpdateInfo,
+)> {
+    let mut thread_ctx = ctx.to_sync().into_thread_local();
+    let mut guard = thread_ctx.exclusive_worktree_access();
+    let plan = {
+        let repo = thread_ctx.repo.get()?;
+        plan_local_tracking_target_update(&thread_ctx, &repo, target_tip)?
+    };
+    let Some(edit) = &plan.edit else {
+        let outcome = but_api::workspace::workspace_integrate_upstream_with_perm(
+            &mut thread_ctx,
+            updates,
+            DryRun::No,
+            guard.write_permission(),
+        )?;
+        return Ok((outcome, plan.info));
+    };
+
+    let snapshot_tree =
+        thread_ctx.prepare_snapshot_with_local_target(&edit.snapshot(), guard.read_permission())?;
+    let snapshot = thread_ctx.prepare_snapshot_commit(
+        snapshot_tree,
+        SnapshotDetails::new(OperationKind::MergeUpstream),
+        guard.read_permission(),
+    )?;
+    let snapshot_id = snapshot.commit_id();
+    fail_pull_before_local_target_effect()?;
+    {
+        let repo = thread_ctx.repo.get()?;
+        edit.apply(&repo)?;
+    }
+    let integration_result = but_api::workspace::workspace_integrate_upstream_only_with_perm(
+        &mut thread_ctx,
+        updates,
+        DryRun::No,
+        guard.write_permission(),
+    );
+    let outcome = match integration_result {
+        Ok(outcome) => outcome,
+        Err(integration_err) => {
+            thread_ctx
+                .restore_snapshot_state(snapshot_id, guard.write_permission())
+                .with_context(|| {
+                    format!("failed to roll back pull integration: {integration_err:#}")
+                })?;
+            return Err(integration_err);
+        }
+    };
+    if let Err(publication_err) = thread_ctx.publish_snapshot(snapshot, guard.write_permission()) {
+        thread_ctx
+            .restore_snapshot_state(snapshot_id, guard.write_permission())
+            .with_context(|| {
+                format!(
+                    "failed to roll back pull integration after snapshot publication failed: {publication_err:#}"
+                )
+            })?;
+        return Err(publication_err);
+    }
+    Ok((outcome, plan.info))
+}
+
+fn fail_pull_before_local_target_effect() -> anyhow::Result<()> {
+    #[cfg(debug_assertions)]
+    if std::env::var_os("GITBUTLER_TEST_PULL_FAILURE").as_deref()
+        == Some(std::ffi::OsStr::new("before-local-target"))
+    {
+        anyhow::bail!("injected pull failure before applying the local target");
+    }
+    Ok(())
+}
+
+fn write_local_target_update(
+    out: &mut OutputChannel,
+    update: Option<&LocalTargetUpdateInfo>,
+) -> anyhow::Result<()> {
+    let Some(update) = update.filter(|update| update.status == "fast_forwarded") else {
+        return Ok(());
+    };
+    if let Some(out) = out.for_human() {
+        writeln!(
+            out,
+            "   Fast-forwarded local target {} to {}",
+            update.branch.as_deref().unwrap_or("<unknown>"),
+            update.current_sha
+        )?;
+    }
     Ok(())
 }
 

--- a/crates/but/tests/but/command/pull.rs
+++ b/crates/but/tests/but/command/pull.rs
@@ -4,6 +4,7 @@ use but_core::{
     RefMetadata, WORKSPACE_REF_NAME,
     ref_metadata::{StackId, WorkspaceCommitRelation, WorkspaceStack, WorkspaceStackBranch},
 };
+use gitbutler_oplog::OplogExt;
 use snapbox::str;
 
 use crate::utils::{CommandExt, Sandbox};
@@ -387,6 +388,693 @@ Hint: run `but branch new` to create a new branch to work on
 }
 
 #[test]
+fn pull_local_target_fast_forwards_tracking_branch() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata_at_target(&[], "origin/main");
+    let remote = setup_advanced_remote(&env)?;
+    env.invoke_git("branch -m main trunk");
+
+    assert_eq!(
+        env.invoke_git("rev-parse --symbolic-full-name trunk@{upstream}"),
+        "refs/remotes/origin/main",
+        "the differently named local branch should track the configured remote target"
+    );
+    let local_ref: gix::refs::FullName = "refs/heads/trunk".try_into()?;
+    let target_ref: gix::refs::FullName = "refs/remotes/origin/main".try_into()?;
+    assert_eq!(
+        env.open_repo()
+            .branch_remote_tracking_ref_name(local_ref.as_ref(), gix::remote::Direction::Fetch)
+            .transpose()?
+            .map(|name| name.to_string()),
+        Some(target_ref.to_string()),
+        "repository configuration should map trunk to the project target"
+    );
+
+    assert_eq!(
+        rev_parse(&env, "trunk")?,
+        remote.previous_main,
+        "the local tracking target should begin behind its remote target"
+    );
+
+    let output = env
+        .but("--format json pull")
+        .allow_json()
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let output: serde_json::Value = serde_json::from_slice(&output)?;
+    assert_eq!(output["localTarget"]["status"], "fast_forwarded");
+    assert_eq!(output["localTarget"]["branch"], "trunk");
+    assert_eq!(output["localTarget"]["previousSha"], remote.previous_main);
+    assert_eq!(output["localTarget"]["currentSha"], remote.advanced_target);
+
+    assert_eq!(
+        rev_parse(&env, "origin/main")?,
+        remote.advanced_target,
+        "pull should fetch the advanced remote target"
+    );
+    assert_eq!(
+        rev_parse(&env, "trunk")?,
+        remote.advanced_target,
+        "pull should fast-forward the existing local tracking target"
+    );
+    assert_eq!(
+        rev_parse(&env, "gitbutler/workspace^")?,
+        remote.advanced_target,
+        "pull should also reparent the empty workspace to the advanced target"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn pull_local_target_undo_redo_restores_tracking_branch() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata_at_target(&[], "origin/main");
+    let remote = setup_advanced_remote(&env)?;
+    env.invoke_git("branch -m main trunk");
+
+    env.but("pull")
+        .env("GITBUTLER_TEST_OPLOG_PUBLICATION_FAILURE", "after-head")
+        .assert()
+        .success();
+    assert_eq!(
+        rev_parse(&env, "trunk")?,
+        remote.advanced_target,
+        "pull should fast-forward the local tracking target"
+    );
+    assert_eq!(
+        rev_parse(&env, "gitbutler/workspace^")?,
+        remote.advanced_target,
+        "pull should reparent the workspace to the advanced target"
+    );
+
+    env.but("undo").assert().success();
+    assert_eq!(
+        rev_parse(&env, "trunk")?,
+        remote.previous_main,
+        "undo should restore the local tracking target"
+    );
+    assert_eq!(
+        rev_parse(&env, "gitbutler/workspace^")?,
+        remote.previous_main,
+        "undo should restore the previous workspace base"
+    );
+
+    env.but("redo").assert().success();
+    assert_eq!(
+        rev_parse(&env, "trunk")?,
+        remote.advanced_target,
+        "redo should advance the local tracking target again"
+    );
+    assert_eq!(
+        rev_parse(&env, "gitbutler/workspace^")?,
+        remote.advanced_target,
+        "redo should advance the workspace base again"
+    );
+
+    env.but("undo").assert().success();
+    assert_eq!(
+        rev_parse(&env, "trunk")?,
+        remote.previous_main,
+        "a second undo should restore the local tracking target again"
+    );
+    assert_eq!(
+        rev_parse(&env, "gitbutler/workspace^")?,
+        remote.previous_main,
+        "a second undo should restore the previous workspace base again"
+    );
+
+    env.but("redo").assert().success();
+    assert_eq!(
+        rev_parse(&env, "trunk")?,
+        remote.advanced_target,
+        "a second redo should advance the local tracking target again"
+    );
+    assert_eq!(
+        rev_parse(&env, "gitbutler/workspace^")?,
+        remote.advanced_target,
+        "a second redo should advance the workspace base again"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn pull_local_target_publication_failure_rolls_back_effect() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata_at_target(&[], "origin/main");
+    let remote = setup_advanced_remote(&env)?;
+    env.invoke_git("branch -m main trunk");
+    let workspace_tip = rev_parse(&env, "gitbutler/workspace")?;
+    let ctx = env.context();
+    let oplog_head = ctx.oplog_head()?;
+    let undo_target =
+        but_api::legacy::oplog::get_undo_target_snapshot(&ctx)?.map(|snapshot| snapshot.commit_id);
+
+    env.but("pull")
+        .env("GITBUTLER_TEST_OPLOG_PUBLICATION_FAILURE", "before-head")
+        .assert()
+        .failure();
+
+    assert_eq!(
+        rev_parse(&env, "trunk")?,
+        remote.previous_main,
+        "a prepublication failure must leave the local target unchanged"
+    );
+    assert_eq!(
+        rev_parse(&env, "gitbutler/workspace")?,
+        workspace_tip,
+        "a prepublication failure must leave the workspace unchanged"
+    );
+    assert_eq!(
+        ctx.oplog_head()?,
+        oplog_head,
+        "a failed publication must leave the oplog head unchanged"
+    );
+    assert_eq!(
+        but_api::legacy::oplog::get_undo_target_snapshot(&ctx)?.map(|snapshot| snapshot.commit_id),
+        undo_target,
+        "a failed publication must leave the next undo target unchanged"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn pull_local_target_publication_and_restore_failure_roll_back_everything() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata_at_target(&[], "origin/main");
+    let remote = setup_advanced_remote(&env)?;
+    env.invoke_git("branch -m main trunk");
+    env.file("staged.txt", "staged before pull\n");
+    env.invoke_git("add staged.txt");
+
+    let workspace_tip = rev_parse(&env, "gitbutler/workspace")?;
+    let staged_blob = rev_parse(&env, ":staged.txt")?;
+    let ctx = env.context();
+    let legacy_path = ctx.project_data_dir().join("virtual_branches.toml");
+    let legacy_metadata = std::fs::read(&legacy_path)?;
+    let oplog_head = ctx.oplog_head()?;
+    let undo_target =
+        but_api::legacy::oplog::get_undo_target_snapshot(&ctx)?.map(|snapshot| snapshot.commit_id);
+    let redo_target =
+        but_api::legacy::oplog::get_redo_target_snapshot(&ctx)?.map(|snapshot| snapshot.commit_id);
+
+    env.but("pull")
+        .env("GITBUTLER_TEST_OPLOG_PUBLICATION_FAILURE", "before-head")
+        .env("GITBUTLER_TEST_OPLOG_RESTORE_FAILURE", "after-local-target")
+        .assert()
+        .failure();
+
+    assert_eq!(
+        rev_parse(&env, "trunk")?,
+        remote.previous_main,
+        "combined publication and restore failure must roll back the local target"
+    );
+    assert_eq!(
+        rev_parse(&env, "gitbutler/workspace")?,
+        workspace_tip,
+        "combined publication and restore failure must roll back the workspace"
+    );
+    assert_eq!(
+        rev_parse(&env, ":staged.txt")?,
+        staged_blob,
+        "combined publication and restore failure must preserve the index"
+    );
+    assert_eq!(
+        std::fs::read(&legacy_path)?,
+        legacy_metadata,
+        "combined publication and restore failure must preserve legacy metadata"
+    );
+    assert_eq!(
+        ctx.oplog_head()?,
+        oplog_head,
+        "combined publication and restore failure must leave the oplog head unchanged"
+    );
+    assert_eq!(
+        but_api::legacy::oplog::get_undo_target_snapshot(&ctx)?.map(|snapshot| snapshot.commit_id),
+        undo_target,
+        "combined failure must leave the next undo target unchanged"
+    );
+    assert_eq!(
+        but_api::legacy::oplog::get_redo_target_snapshot(&ctx)?.map(|snapshot| snapshot.commit_id),
+        redo_target,
+        "combined failure must leave the next redo target unchanged"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn pull_local_target_failure_before_effect_does_not_publish() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata_at_target(&[], "origin/main");
+    let remote = setup_advanced_remote(&env)?;
+    env.invoke_git("branch -m main trunk");
+    let workspace_tip = rev_parse(&env, "gitbutler/workspace")?;
+    let ctx = env.context();
+    let oplog_head = ctx.oplog_head()?;
+    let undo_target =
+        but_api::legacy::oplog::get_undo_target_snapshot(&ctx)?.map(|snapshot| snapshot.commit_id);
+
+    env.but("pull")
+        .env("GITBUTLER_TEST_PULL_FAILURE", "before-local-target")
+        .assert()
+        .failure();
+
+    assert_eq!(
+        rev_parse(&env, "trunk")?,
+        remote.previous_main,
+        "failure before the guarded effect must leave the local target unchanged"
+    );
+    assert_eq!(
+        rev_parse(&env, "gitbutler/workspace")?,
+        workspace_tip,
+        "failure before the guarded effect must leave the workspace unchanged"
+    );
+    assert_eq!(
+        ctx.oplog_head()?,
+        oplog_head,
+        "failure before the guarded effect must not publish an oplog operation"
+    );
+    assert_eq!(
+        but_api::legacy::oplog::get_undo_target_snapshot(&ctx)?.map(|snapshot| snapshot.commit_id),
+        undo_target,
+        "failure before the guarded effect must leave the next undo target unchanged"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn pull_snapshot_preparation_does_not_reconcile_stale_legacy_heads() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.invoke_git("branch A main");
+    env.setup_metadata_at_target(&["A"], "origin/main");
+    let _remote = setup_advanced_remote(&env)?;
+    let ctx = env.context();
+    let stale_head = env
+        .open_repo()
+        .rev_parse_single("gitbutler/workspace")?
+        .detach();
+    {
+        let mut legacy = ctx.legacy_meta()?;
+        let stack = legacy
+            .data_mut()
+            .branches
+            .values_mut()
+            .find(|stack| stack.heads.iter().any(|branch| branch.name == "A"))
+            .expect("fixture should contain stack A");
+        stack
+            .heads
+            .iter_mut()
+            .find(|branch| branch.name == "A")
+            .expect("fixture should contain branch A")
+            .head = stale_head;
+        legacy.set_changed_to_necessitate_write();
+        legacy.write_unreconciled()?;
+    }
+    let legacy_path = ctx.project_data_dir().join("virtual_branches.toml");
+    let stale_metadata = std::fs::read(&legacy_path)?;
+    let branch_tip = rev_parse(&env, "A")?;
+
+    env.but("pull")
+        .env("GITBUTLER_TEST_PULL_FAILURE", "before-local-target")
+        .assert()
+        .failure();
+
+    assert_eq!(
+        rev_parse(&env, "A")?,
+        branch_tip,
+        "snapshot preparation must not rewrite the branch ref"
+    );
+    assert_eq!(
+        std::fs::read(&legacy_path)?,
+        stale_metadata,
+        "snapshot preparation must not reconcile stale legacy metadata"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn pull_local_target_undo_publication_failure_rolls_back_restore() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata_at_target(&[], "origin/main");
+    let remote = setup_advanced_remote(&env)?;
+    env.invoke_git("branch -m main trunk");
+
+    env.but("pull").assert().success();
+    let workspace_tip = rev_parse(&env, "gitbutler/workspace")?;
+
+    env.but("undo")
+        .env("GITBUTLER_TEST_OPLOG_PUBLICATION_FAILURE", "before-head")
+        .assert()
+        .failure();
+
+    assert_eq!(
+        rev_parse(&env, "trunk")?,
+        remote.advanced_target,
+        "an inverse-snapshot publication failure must leave the local target unchanged"
+    );
+    assert_eq!(
+        rev_parse(&env, "gitbutler/workspace")?,
+        workspace_tip,
+        "an inverse-snapshot publication failure must leave the workspace unchanged"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn pull_local_target_undo_refuses_new_local_history() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata_at_target(&[], "origin/main");
+    let remote = setup_advanced_remote(&env)?;
+    env.invoke_git("branch -m main trunk");
+
+    env.but("pull").assert().success();
+    env.invoke_git("checkout trunk");
+    env.invoke_git("commit --allow-empty -m local-after-pull");
+    let local_tip = rev_parse(&env, "trunk")?;
+    env.invoke_git("checkout gitbutler/workspace");
+
+    let output = env.but("undo").output()?;
+    assert!(
+        !output.status.success(),
+        "undo must reject local target history created after pull"
+    );
+    let error = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        error.contains("changed since the snapshot")
+            && error.contains(&local_tip)
+            && error.contains(&remote.advanced_target),
+        "the error should identify the unexpected and expected tips; stderr:\n{error}"
+    );
+    assert_eq!(
+        rev_parse(&env, "trunk")?,
+        local_tip,
+        "a local target with new history must not move"
+    );
+    assert_eq!(
+        rev_parse(&env, "gitbutler/workspace^")?,
+        remote.advanced_target,
+        "restore preflight must abort before changing the workspace"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn pull_local_target_undo_refuses_checked_out_branch() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata_at_target(&[], "origin/main");
+    let remote = setup_advanced_remote(&env)?;
+    env.invoke_git("branch -m main trunk");
+
+    env.but("pull").assert().success();
+    let linked_root = tempfile::tempdir()?;
+    let linked_worktree = linked_root.path().join("trunk-worktree");
+    env.invoke_git(&format!("worktree add {} trunk", linked_worktree.display()));
+
+    let output = env.but("undo").output()?;
+    assert!(
+        !output.status.success(),
+        "undo must reject a local target checked out in another worktree"
+    );
+    let error = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        error.contains("checked out") && error.contains("trunk-worktree"),
+        "the error should identify the checked-out target worktree; stderr:\n{error}"
+    );
+    assert_eq!(
+        rev_parse(&env, "trunk")?,
+        remote.advanced_target,
+        "a checked-out local target must not move"
+    );
+    assert_eq!(
+        rev_parse(&env, "gitbutler/workspace^")?,
+        remote.advanced_target,
+        "restore preflight must abort before changing the workspace"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn pull_local_target_undo_rolls_back_ref_when_workspace_restore_fails() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata_at_target(&[], "origin/main");
+    let remote = setup_advanced_remote(&env)?;
+    env.invoke_git("branch -m main trunk");
+    env.invoke_git("config user.name GitButler");
+    env.invoke_git("config user.email gitbutler@example.com");
+
+    env.but("pull").assert().success();
+    let mut ctx = env.context();
+    let undo_target = but_api::legacy::oplog::get_undo_target_snapshot(&ctx)?
+        .expect("pull should create an undo target");
+    let oplog_head = ctx.oplog_head()?;
+    let redo_target =
+        but_api::legacy::oplog::get_redo_target_snapshot(&ctx)?.map(|snapshot| snapshot.commit_id);
+    env.invoke_git("checkout --detach gitbutler/workspace");
+
+    let error = but_api::legacy::oplog::restore_snapshot_with_kind(
+        &mut ctx,
+        but_api::legacy::oplog::RestoreKind::RestoreFromSnapshotViaUndo,
+        undo_target.commit_id,
+    )
+    .expect_err("undo must fail when the workspace is detached");
+    let error = format!("{error:#}");
+    assert!(
+        error.contains("detached HEAD state"),
+        "the restore failure should identify detached HEAD; error:\n{error}"
+    );
+    assert_eq!(
+        rev_parse(&env, "trunk")?,
+        remote.advanced_target,
+        "a failed workspace restore must roll back its attempted local-target restore"
+    );
+    assert_eq!(
+        ctx.oplog_head()?,
+        oplog_head,
+        "a failed restore must leave the oplog head unchanged"
+    );
+    assert_eq!(
+        but_api::legacy::oplog::get_undo_target_snapshot(&ctx)?.map(|snapshot| snapshot.commit_id),
+        Some(undo_target.commit_id),
+        "a failed restore must leave the next undo target unchanged"
+    );
+    assert_eq!(
+        but_api::legacy::oplog::get_redo_target_snapshot(&ctx)?.map(|snapshot| snapshot.commit_id),
+        redo_target,
+        "a failed restore must not create a redo target"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn pull_local_target_restore_failure_does_not_publish() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata_at_target(&[], "origin/main");
+    let remote = setup_advanced_remote(&env)?;
+    env.invoke_git("branch -m main trunk");
+
+    env.but("pull").assert().success();
+    let workspace_tip = rev_parse(&env, "gitbutler/workspace")?;
+    let ctx = env.context();
+    let oplog_head = ctx.oplog_head()?;
+    let undo_target = but_api::legacy::oplog::get_undo_target_snapshot(&ctx)?
+        .expect("pull should create an undo target")
+        .commit_id;
+    let redo_target =
+        but_api::legacy::oplog::get_redo_target_snapshot(&ctx)?.map(|snapshot| snapshot.commit_id);
+
+    env.but("undo")
+        .env("GITBUTLER_TEST_OPLOG_RESTORE_FAILURE", "after-local-target")
+        .assert()
+        .failure();
+
+    assert_eq!(
+        rev_parse(&env, "trunk")?,
+        remote.advanced_target,
+        "a failed restore must roll back the local target"
+    );
+    assert_eq!(
+        rev_parse(&env, "gitbutler/workspace")?,
+        workspace_tip,
+        "a failed restore must roll back the workspace"
+    );
+    assert_eq!(
+        ctx.oplog_head()?,
+        oplog_head,
+        "a failed restore must leave the oplog head unchanged"
+    );
+    assert_eq!(
+        but_api::legacy::oplog::get_undo_target_snapshot(&ctx)?.map(|snapshot| snapshot.commit_id),
+        Some(undo_target),
+        "a failed restore must leave the next undo target unchanged"
+    );
+    assert_eq!(
+        but_api::legacy::oplog::get_redo_target_snapshot(&ctx)?.map(|snapshot| snapshot.commit_id),
+        redo_target,
+        "a failed restore must leave the next redo target unchanged"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn pull_local_target_leaves_unconfigured_branch_unchanged() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata_at_target(&[], "origin/main");
+    let remote = setup_advanced_remote(&env)?;
+    env.invoke_git("branch --unset-upstream main");
+
+    let output = env
+        .but("--format json pull")
+        .allow_json()
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let output: serde_json::Value = serde_json::from_slice(&output)?;
+    assert_eq!(output["localTarget"]["status"], "not_configured");
+    assert!(output["localTarget"]["branch"].is_null());
+    assert!(output["localTarget"]["previousSha"].is_null());
+    assert_eq!(output["localTarget"]["currentSha"], remote.advanced_target);
+
+    assert_eq!(
+        rev_parse(&env, "main")?,
+        remote.previous_main,
+        "an unconfigured local branch must not be inferred from its short name"
+    );
+    assert_eq!(
+        rev_parse(&env, "origin/main")?,
+        remote.advanced_target,
+        "pull should still fetch the configured remote target"
+    );
+    assert_eq!(
+        rev_parse(&env, "gitbutler/workspace^")?,
+        remote.advanced_target,
+        "workspace integration should continue without a local tracking branch"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn pull_local_target_refuses_ambiguous_tracking_branches() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata_at_target(&[], "origin/main");
+    let remote = setup_advanced_remote(&env)?;
+    env.invoke_git("branch trunk main");
+    env.invoke_git("branch --set-upstream-to origin/main trunk");
+
+    let output = env.but("pull").output()?;
+    assert!(
+        !output.status.success(),
+        "pull must reject multiple local branches tracking the configured target"
+    );
+    let error = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        error.contains("both 'main' and 'trunk' are configured to track 'origin/main'"),
+        "the error should identify both ambiguous local branches and their target; stderr:\n{error}"
+    );
+    assert_eq!(
+        rev_parse(&env, "main")?,
+        remote.previous_main,
+        "an ambiguous local target must not move the original tracking branch"
+    );
+    assert_eq!(
+        rev_parse(&env, "trunk")?,
+        remote.previous_main,
+        "an ambiguous local target must not move the alternate tracking branch"
+    );
+    assert_eq!(
+        rev_parse(&env, "gitbutler/workspace^")?,
+        remote.previous_main,
+        "workspace integration must not start after ambiguous local-target preflight"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn pull_local_target_refuses_divergence() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata_at_target(&[], "origin/main");
+    let remote = setup_advanced_remote(&env)?;
+    env.invoke_git("checkout main");
+    env.invoke_git("commit --allow-empty -m local-divergence");
+    let diverged_main = rev_parse(&env, "main")?;
+    env.invoke_git("checkout gitbutler/workspace");
+
+    let output = env.but("pull").output()?;
+    assert!(
+        !output.status.success(),
+        "pull must reject a diverged local target"
+    );
+    let error = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        error.contains("has diverged")
+            && error.contains(&diverged_main)
+            && error.contains(&remote.advanced_target),
+        "the error should identify both diverged tips; stderr:\n{error}"
+    );
+    assert_eq!(
+        rev_parse(&env, "main")?,
+        diverged_main,
+        "a diverged local target must not move"
+    );
+    assert_eq!(
+        rev_parse(&env, "gitbutler/workspace^")?,
+        remote.previous_main,
+        "workspace integration must not start after unsafe local-target preflight"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn pull_local_target_refuses_checked_out_branch() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata_at_target(&[], "origin/main");
+    let remote = setup_advanced_remote(&env)?;
+    let linked_root = tempfile::tempdir()?;
+    let linked_worktree = linked_root.path().join("main-worktree");
+    env.invoke_git(&format!("worktree add {} main", linked_worktree.display()));
+
+    let output = env.but("pull").output()?;
+    assert!(
+        !output.status.success(),
+        "pull must reject a local target checked out in another worktree"
+    );
+    let error = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        error.contains("checked out") && error.contains("main-worktree"),
+        "the error should identify the checked-out target worktree; stderr:\n{error}"
+    );
+    assert_eq!(
+        rev_parse(&env, "main")?,
+        remote.previous_main,
+        "a checked-out local target must not move behind its worktree"
+    );
+    assert_eq!(
+        rev_parse(&env, "gitbutler/workspace^")?,
+        remote.previous_main,
+        "workspace integration must not start after unsafe local-target preflight"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn pull_does_not_report_branch_rebase_conflicts_as_worktree_conflicts() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings(
         "pull-branch-and-dirty-worktree-conflict",
@@ -739,6 +1427,46 @@ fn rev_parse(env: &Sandbox, spec: &str) -> anyhow::Result<String> {
         anyhow::bail!("expected exactly one rev for {spec}, got {values:?}");
     };
     Ok(value.clone())
+}
+
+struct AdvancedRemote {
+    _root: tempfile::TempDir,
+    previous_main: String,
+    advanced_target: String,
+}
+
+fn setup_advanced_remote(env: &Sandbox) -> anyhow::Result<AdvancedRemote> {
+    let previous_main = rev_parse(env, "main")?;
+    let root = tempfile::tempdir()?;
+    let upstream_git = root.path().join("upstream.git");
+    let upstream_work = root.path().join("upstream-work");
+    env.invoke_git(&format!("init --bare {}", upstream_git.display()));
+    env.invoke_git(&format!("remote set-url origin {}", upstream_git.display()));
+    env.invoke_git("push --set-upstream origin main");
+    env.invoke_git(&format!(
+        "--git-dir={} symbolic-ref HEAD refs/heads/main",
+        upstream_git.display()
+    ));
+    env.invoke_git(&format!(
+        "clone {} {}",
+        upstream_git.display(),
+        upstream_work.display()
+    ));
+    env.invoke_git(&format!(
+        "-C {} -c user.name=Test -c user.email=test@example.com \
+         commit --allow-empty -m upstream-change",
+        upstream_work.display()
+    ));
+    env.invoke_git(&format!("-C {} push origin main", upstream_work.display()));
+    let advanced_target = env.invoke_git(&format!(
+        "--git-dir={} rev-parse main",
+        upstream_git.display()
+    ));
+    Ok(AdvancedRemote {
+        _root: root,
+        previous_main,
+        advanced_target,
+    })
 }
 
 fn rev_parse_all(env: &Sandbox, spec: &str) -> anyhow::Result<Vec<String>> {

--- a/crates/gitbutler-oplog/src/lib.rs
+++ b/crates/gitbutler-oplog/src/lib.rs
@@ -1,8 +1,7 @@
 pub mod entry;
 mod oplog;
-pub use oplog::OplogExt;
-pub use oplog::RestoreKind;
 pub use oplog::peel_restore_snapshot;
+pub use oplog::{LocalTargetSnapshot, OplogExt, RestoreKind, UnpublishedSnapshot};
 mod reflog;
 mod snapshot;
 pub use snapshot::SnapshotExt;

--- a/crates/gitbutler-oplog/src/oplog.rs
+++ b/crates/gitbutler-oplog/src/oplog.rs
@@ -45,6 +45,11 @@ const AUTO_TRACK_LIMIT_BYTES: u64 = 0;
 /// ├── conflicts/…
 /// ├── index/
 /// ├── index-conflicts/…
+/// ├── local_target/
+/// │   ├── ref
+/// │   ├── tip
+/// │   ├── tracking_ref
+/// │   └── expected_tip
 /// ├── target_tree/…
 /// ├── virtual_branches
 /// │   └── [branch-id]
@@ -62,6 +67,12 @@ pub trait OplogExt {
     /// Returns a tree hash of the snapshot. The snapshot is not discoverable until it is committed with [`commit_snapshot`](Self::commit_snapshot())
     /// If there are files that are untracked and larger than `SNAPSHOT_FILE_LIMIT_BYTES`, they are excluded from snapshot creation and restoring.
     fn prepare_snapshot(&self, perm: &RepoShared) -> Result<gix::ObjectId>;
+    /// Prepares a snapshot which explicitly owns a local target ref transition.
+    fn prepare_snapshot_with_local_target(
+        &self,
+        local_target: &LocalTargetSnapshot,
+        perm: &RepoShared,
+    ) -> Result<gix::ObjectId>;
 
     /// Commits the snapshot tree that is created with the [`prepare_snapshot`](Self::prepare_snapshot) method,
     /// which yielded the `snapshot_tree_id` for the entire snapshot state.
@@ -78,6 +89,25 @@ pub trait OplogExt {
         details: SnapshotDetails,
         perm: &mut RepoExclusive,
     ) -> Result<gix::ObjectId>;
+    /// Create the snapshot commit object without making it visible in the oplog.
+    fn prepare_snapshot_commit(
+        &self,
+        snapshot_tree_id: gix::ObjectId,
+        details: SnapshotDetails,
+        perm: &RepoShared,
+    ) -> Result<UnpublishedSnapshot>;
+    /// Publish a previously prepared snapshot as the new oplog head.
+    fn publish_snapshot(
+        &self,
+        snapshot: UnpublishedSnapshot,
+        perm: &mut RepoExclusive,
+    ) -> Result<gix::ObjectId>;
+    /// Restore snapshot state without recording another oplog operation.
+    fn restore_snapshot_state(
+        &self,
+        snapshot_commit_id: gix::ObjectId,
+        perm: &mut RepoExclusive,
+    ) -> Result<()>;
 
     /// Creates a snapshot of the current state of the working directory as well as GitButler data.
     /// This is a convenience method that combines [`prepare_snapshot`](Self::prepare_snapshot) and
@@ -118,6 +148,7 @@ pub trait OplogExt {
     ///  - The state of the working directory is checked out from the subtree `workdir` in the snapshot.
     ///  - The state of virtual branches is restored from the blob `virtual_branches.toml` in the snapshot.
     ///  - The state of conflicts (.git/base_merge_parent and .git/conflicts) is restored from the subtree `conflicts` in the snapshot (if not present, existing files are deleted).
+    ///  - The uniquely configured local tracking target is restored for upstream-integration snapshots that recorded it.
     ///
     /// If there are files that are untracked and larger than `SNAPSHOT_FILE_LIMIT_BYTES`, they are excluded from snapshot creation and restoring.
     /// Returns the sha of the created revert snapshot commit or None if snapshots are disabled.
@@ -150,6 +181,15 @@ impl OplogExt for Context {
         prepare_snapshot(self, perm)
     }
 
+    fn prepare_snapshot_with_local_target(
+        &self,
+        local_target: &LocalTargetSnapshot,
+        perm: &RepoShared,
+    ) -> Result<gix::ObjectId> {
+        prepare_snapshot_with_target(self, perm, Some(local_target))
+            .map(|prepared| prepared.tree_id)
+    }
+
     fn commit_snapshot(
         &self,
         snapshot_tree_id: gix::ObjectId,
@@ -161,6 +201,50 @@ impl OplogExt for Context {
         commit_snapshot(self, &repo, snapshot_tree_id, details, perm, target)
     }
 
+    fn prepare_snapshot_commit(
+        &self,
+        snapshot_tree_id: gix::ObjectId,
+        details: SnapshotDetails,
+        _perm: &RepoShared,
+    ) -> Result<UnpublishedSnapshot> {
+        let repo = self.repo.get()?;
+        let target = self.project_meta()?.target_commit_id_or_err()?;
+        prepare_snapshot_commit(self, &repo, snapshot_tree_id, details, target)
+    }
+
+    fn publish_snapshot(
+        &self,
+        snapshot: UnpublishedSnapshot,
+        _perm: &mut RepoExclusive,
+    ) -> Result<gix::ObjectId> {
+        let repo = self.repo.get()?;
+        publish_snapshot(self, &repo, snapshot)
+    }
+
+    fn restore_snapshot_state(
+        &self,
+        snapshot_commit_id: gix::ObjectId,
+        perm: &mut RepoExclusive,
+    ) -> Result<()> {
+        let plan = prepare_snapshot_restore(self, snapshot_commit_id, perm.read_permission())?;
+        match apply_snapshot_restore(self, &plan, RestoreFailureInjection::Allow, perm) {
+            Ok(()) => Ok(()),
+            Err(initial_err) => {
+                tracing::warn!(
+                    ?initial_err,
+                    snapshot_commit_id = %snapshot_commit_id,
+                    "Retrying an internal snapshot rollback after its first restore attempt failed"
+                );
+                apply_snapshot_restore(self, &plan, RestoreFailureInjection::Suppress, perm)
+                    .with_context(|| {
+                        format!(
+                            "snapshot rollback failed after the initial restore error: {initial_err:#}"
+                        )
+                    })
+            }
+        }
+    }
+
     #[instrument(skip(self, details, perm), err(Debug))]
     fn create_snapshot(
         &self,
@@ -170,7 +254,7 @@ impl OplogExt for Context {
         let PreparedSnapshot {
             tree_id,
             target_base_oid,
-        } = prepare_snapshot_with_target(self, perm.read_permission())?;
+        } = prepare_snapshot_with_target(self, perm.read_permission(), None)?;
         let repo = self.repo.get()?;
         commit_snapshot(self, &repo, tree_id, details, perm, target_base_oid)
     }
@@ -432,7 +516,7 @@ fn restore_index_conflicts(index: &mut gix::index::State, conflict_tree: gix::Id
 }
 
 pub fn prepare_snapshot(ctx: &Context, shared_access: &RepoShared) -> Result<gix::ObjectId> {
-    prepare_snapshot_with_target(ctx, shared_access).map(|prepared| prepared.tree_id)
+    prepare_snapshot_with_target(ctx, shared_access, None).map(|prepared| prepared.tree_id)
 }
 
 struct PreparedSnapshot {
@@ -494,12 +578,40 @@ mod legacy_virtual_branches {
         }
     }
 
-    pub(super) fn sync_stack_heads_from_refs(stack: &mut Stack, repo: &gix::Repository) -> bool {
+    pub(super) fn project_stack_heads_from_refs(stack: &mut Stack, repo: &gix::Repository) -> bool {
         let mut changed = false;
         for head in &mut stack.heads {
-            changed |= sync_branch_head_from_ref(head, repo).unwrap_or(false);
+            let Ok(oid_from_ref) = projected_branch_head_oid(head, repo) else {
+                continue;
+            };
+            if oid_from_ref != head.head {
+                head.head = oid_from_ref;
+                changed = true;
+            }
         }
         changed
+    }
+
+    pub(super) fn projected_stack_head_oid(
+        stack: &Stack,
+        default_target_oid: gix::ObjectId,
+        repo: &gix::Repository,
+    ) -> Result<gix::ObjectId> {
+        stack
+            .heads
+            .last()
+            .map(|branch| projected_branch_head_oid(branch, repo))
+            .unwrap_or(Ok(default_target_oid))
+    }
+
+    fn projected_branch_head_oid(
+        branch: &StackBranch,
+        repo: &gix::Repository,
+    ) -> Result<gix::ObjectId> {
+        match repo.try_find_reference(&branch.name)? {
+            Some(mut reference) => Ok(reference.peel_to_commit()?.id),
+            None => Ok(branch.head),
+        }
     }
 
     fn branch_head_oid(branch: &StackBranch, repo: &gix::Repository) -> Result<gix::ObjectId> {
@@ -525,16 +637,6 @@ mod legacy_virtual_branches {
         Ok(())
     }
 
-    fn sync_branch_head_from_ref(branch: &mut StackBranch, repo: &gix::Repository) -> Result<bool> {
-        let oid_from_ref = branch_head_oid(branch, repo)?;
-        if oid_from_ref != branch.head {
-            branch.head = oid_from_ref;
-            Ok(true)
-        } else {
-            Ok(false)
-        }
-    }
-
     fn qualified_reference_name(name: &str) -> String {
         format!("refs/heads/{}", name.trim_matches('/'))
     }
@@ -543,6 +645,7 @@ mod legacy_virtual_branches {
 fn prepare_snapshot_with_target(
     ctx: &Context,
     _shared_access: &RepoShared,
+    local_target: Option<&LocalTargetSnapshot>,
 ) -> Result<PreparedSnapshot> {
     let repo = ctx.repo.get()?;
     let empty_tree_id = repo.empty_tree().id;
@@ -572,13 +675,29 @@ fn prepare_snapshot_with_target(
     snapshot_tree.upsert("target_tree", EntryKind::Tree, target_tree_id)?;
     snapshot_tree.upsert("conflicts", EntryKind::Tree, conflicts_tree_id)?;
     snapshot_tree.upsert("virtual_branches", EntryKind::Tree, empty_tree_id)?;
+    if let Some(local_target) = local_target {
+        let ref_name = repo.write_blob(local_target.ref_name.as_bstr())?;
+        let tip = repo.write_blob(local_target.snapshot_tip.to_string().as_bytes())?;
+        let tracking_ref = repo.write_blob(local_target.tracking_ref.as_bstr())?;
+        let expected_tip = repo.write_blob(local_target.expected_tip.to_string().as_bytes())?;
+        snapshot_tree.upsert("local_target/ref", EntryKind::Blob, ref_name)?;
+        snapshot_tree.upsert("local_target/tip", EntryKind::Blob, tip)?;
+        snapshot_tree.upsert("local_target/tracking_ref", EntryKind::Blob, tracking_ref)?;
+        snapshot_tree.upsert("local_target/expected_tip", EntryKind::Blob, expected_tip)?;
+    }
 
-    let legacy_meta_path = {
-        let mut legacy_meta = ctx.legacy_meta()?;
+    let virtual_branches_content = {
+        let legacy_meta = ctx.legacy_meta()?;
+        let mut snapshot_metadata = legacy_meta.data().clone();
         let mut virtual_branches_changed = false;
-        for stack in legacy_virtual_branches::in_workspace_stacks_mut(legacy_meta.data_mut()) {
-            let stack_head =
-                legacy_virtual_branches::stack_head_oid(stack, default_target_commit_id, &repo)?;
+        for stack in legacy_virtual_branches::in_workspace_stacks_mut(&mut snapshot_metadata) {
+            virtual_branches_changed |=
+                legacy_virtual_branches::project_stack_heads_from_refs(stack, &repo);
+            let stack_head = legacy_virtual_branches::projected_stack_head_oid(
+                stack,
+                default_target_commit_id,
+                &repo,
+            )?;
             let stack_tree = repo.find_commit(stack_head)?.tree_id()?.detach();
             let stack_id = stack.id.to_string();
             let mut stack_tree_cursor =
@@ -587,10 +706,6 @@ fn prepare_snapshot_with_target(
             // commits in virtual branches (tree and commit data)
             // calculate all the commits between branch.head and the target and codify them
             stack_tree_cursor.upsert("tree", EntryKind::Tree, stack_tree)?;
-
-            // If the references are out of sync, now is a good time to update them
-            virtual_branches_changed |=
-                legacy_virtual_branches::sync_stack_heads_from_refs(stack, &repo);
 
             for commit_id in commit_ids_excluding_reachable_from_with_graph(
                 &repo,
@@ -615,19 +730,16 @@ fn prepare_snapshot_with_target(
             }
         }
 
-        if virtual_branches_changed {
-            legacy_meta.set_changed_to_necessitate_write();
-            legacy_meta.write_unreconciled()?;
-        }
-        legacy_meta.path().to_owned()
+        let content = if virtual_branches_changed {
+            toml::to_string(&snapshot_metadata)?.into_bytes()
+        } else {
+            fs::read(legacy_meta.path())?
+        };
+        content
     };
 
-    // The loop above may update the legacy metadata if stored heads drifted from refs, so
-    // snapshot virtual_branches.toml only after that final synchronization attempt.
-    // This is relevant only for snapshot restore.
-    // Create a blob out of `.git/gitbutler/virtual_branches.toml`
-    let vb_content = fs::read(legacy_meta_path)?;
-    let vb_blob_id = repo.write_blob(&vb_content)?;
+    // Snapshot a ref-synchronized projection without reconciling the persisted legacy metadata.
+    let vb_blob_id = repo.write_blob(&virtual_branches_content)?;
     snapshot_tree.upsert("virtual_branches.toml", EntryKind::Blob, vb_blob_id)?;
     // Add the worktree tree
     #[expect(deprecated)]
@@ -676,13 +788,37 @@ fn commit_snapshot(
     _exclusive_access: &mut RepoExclusive,
     target: gix::ObjectId,
 ) -> Result<gix::ObjectId> {
+    let snapshot = prepare_snapshot_commit(ctx, repo, snapshot_tree_id, details, target)?;
+    publish_snapshot(ctx, repo, snapshot)
+}
+
+/// A snapshot commit object which is not yet visible through the oplog head.
+pub struct UnpublishedSnapshot {
+    commit_id: gix::ObjectId,
+    previous_head: Option<gix::ObjectId>,
+    target: gix::ObjectId,
+}
+
+impl UnpublishedSnapshot {
+    /// Return the prepared commit ID so callers can restore its state if publication fails.
+    pub fn commit_id(&self) -> gix::ObjectId {
+        self.commit_id
+    }
+}
+
+fn prepare_snapshot_commit(
+    ctx: &Context,
+    repo: &gix::Repository,
+    snapshot_tree_id: gix::ObjectId,
+    details: SnapshotDetails,
+    target: gix::ObjectId,
+) -> Result<UnpublishedSnapshot> {
     repo.find_tree(snapshot_tree_id)?;
 
     let project_data_dir = ctx.project_data_dir();
     let oplog_state = OplogHandle::new(&project_data_dir);
-    let oplog_head_commit = oplog_state
-        .oplog_head()?
-        .and_then(|head_id| repo.find_commit(head_id).ok());
+    let previous_head = oplog_state.oplog_head()?;
+    let oplog_head_commit = previous_head.and_then(|head_id| repo.find_commit(head_id).ok());
 
     let committer = signature_gix(SignaturePurpose::Committer);
     let author = signature_gix(SignaturePurpose::Author);
@@ -701,11 +837,86 @@ fn commit_snapshot(
         None,
     )?;
 
-    oplog_state.set_oplog_head(snapshot_commit_id)?;
+    Ok(UnpublishedSnapshot {
+        commit_id: snapshot_commit_id,
+        previous_head,
+        target,
+    })
+}
 
-    set_reference_to_oplog(repo.git_dir(), ReflogCommits::new(ctx, target)?)?;
+fn publish_snapshot(
+    ctx: &Context,
+    repo: &gix::Repository,
+    snapshot: UnpublishedSnapshot,
+) -> Result<gix::ObjectId> {
+    let project_data_dir = ctx.project_data_dir();
+    let oplog_state = OplogHandle::new(&project_data_dir);
+    let current_head = oplog_state.oplog_head()?;
+    if current_head != snapshot.previous_head {
+        bail!(
+            "oplog head changed before snapshot publication: found {current_head:?}, expected {:?}",
+            snapshot.previous_head
+        );
+    }
+    let protection = publish_snapshot_head(
+        || oplog_state.set_oplog_head(snapshot.commit_id),
+        || set_reference_to_oplog(repo.git_dir(), ReflogCommits::new(ctx, snapshot.target)?),
+    )?;
+    if let SnapshotProtection::Pending(err) = protection {
+        tracing::warn!(
+            ?err,
+            snapshot_commit_id = %snapshot.commit_id,
+            "Published oplog snapshot without refreshing its GC-protection reflog"
+        );
+    }
 
-    Ok(snapshot_commit_id)
+    Ok(snapshot.commit_id)
+}
+
+enum SnapshotProtection {
+    Current,
+    Pending(anyhow::Error),
+}
+
+/// The oplog head is the publication commit point. Reflog refresh only protects the already
+/// published commit from Git garbage collection, so its failure must not be reported as if the
+/// snapshot were unpublished.
+fn publish_snapshot_head(
+    persist_head: impl FnOnce() -> Result<()>,
+    refresh_gc_protection: impl FnOnce() -> Result<()>,
+) -> Result<SnapshotProtection> {
+    #[cfg(debug_assertions)]
+    if std::env::var_os("GITBUTLER_TEST_OPLOG_PUBLICATION_FAILURE").as_deref()
+        == Some(std::ffi::OsStr::new("before-head"))
+    {
+        bail!("injected oplog failure before publishing the snapshot head");
+    }
+    persist_head()?;
+    #[cfg(debug_assertions)]
+    if std::env::var_os("GITBUTLER_TEST_OPLOG_PUBLICATION_FAILURE").as_deref()
+        == Some(std::ffi::OsStr::new("after-head"))
+    {
+        return Ok(SnapshotProtection::Pending(anyhow!(
+            "injected oplog GC-protection failure after publishing the snapshot head"
+        )));
+    }
+    Ok(match refresh_gc_protection() {
+        Ok(()) => SnapshotProtection::Current,
+        Err(err) => SnapshotProtection::Pending(err),
+    })
+}
+
+/// A local target transition explicitly owned by one oplog snapshot.
+#[derive(Debug, Clone)]
+pub struct LocalTargetSnapshot {
+    /// The local branch ref moved by the operation.
+    pub ref_name: gix::refs::FullName,
+    /// The configured remote-tracking ref which identifies that branch as the local target.
+    pub tracking_ref: gix::refs::FullName,
+    /// The tip stored in this snapshot and restored when it is selected.
+    pub snapshot_tip: gix::ObjectId,
+    /// The tip which must currently be present before restoring `snapshot_tip`.
+    pub expected_tip: gix::ObjectId,
 }
 
 /// The kind of restore to perform.
@@ -741,142 +952,25 @@ fn restore_snapshot(
     restore_kind: RestoreKind,
     exclusive_access: &mut RepoExclusive,
 ) -> Result<gix::ObjectId> {
-    // Use a separate repo without caching so we are sure the 'has commit' checks pick up all changes.
     let repo = ctx.repo.get()?;
-
-    let before_restore_snapshot_tree_id =
-        prepare_snapshot(ctx, exclusive_access.read_permission())?;
     let snapshot_commit = repo.find_commit(snapshot_commit_id)?;
-
-    let snapshot_tree = snapshot_commit.tree()?;
-    let vb_toml_entry = snapshot_tree
-        .lookup_entry_by_path("virtual_branches.toml")?
-        .context("failed to get virtual_branches.toml blob")?;
-    // virtual_branches.toml blob
-    let vb_toml_blob = repo
-        .find_blob(vb_toml_entry.id())
-        .context("failed to convert virtual_branches tree entry to blob")?;
-
-    if let Err(err) = restore_conflicts_tree(&snapshot_tree, &repo) {
-        tracing::warn!("failed to restore conflicts tree - ignoring: {err}")
-    }
-
-    // make sure we reconstitute any commits that were in the snapshot that are not here for some reason
-    // for every entry in the virtual_branches subtree, reconsitute the commits
-    let vb_tree_entry = snapshot_tree
-        .lookup_entry_by_path("virtual_branches")?
-        .context("failed to get virtual_branches tree entry")?;
-    let vb_tree = repo
-        .find_tree(vb_tree_entry.id())
-        .context("failed to convert virtual_branches tree entry to tree")?;
-
-    // walk through all the entries (branches by id)
-    let workspace_ref: &gix::refs::FullNameRef = WORKSPACE_REF_NAME.try_into()?;
-    // The workspace commit to repoint `gitbutler/workspace` at, applied *after* the checkout below.
-    let mut restored_workspace_commit: Option<gix::ObjectId> = None;
-    for branch_entry in vb_tree.iter() {
-        let branch_entry = branch_entry?;
-        let branch_tree = repo
-            .find_tree(branch_entry.id())
-            .context("failed to convert virtual_branches tree entry to tree")?;
-        let branch_name = branch_entry.filename();
-
-        let commits_tree_entry = branch_tree.lookup_entry_by_path("commits")?;
-        // Empty branches (head == target) have no commits, so the snapshot
-        // won't contain a `commits` subtree for them. Skip reconstitution.
-        let Some(commits_tree_entry) = commits_tree_entry else {
-            continue;
-        };
-        let commits_tree = repo
-            .find_tree(commits_tree_entry.id())
-            .context("failed to convert commits tree entry to tree")?;
-
-        // walk through all the commits in the branch
-        for commit_entry in commits_tree.iter() {
-            let commit_entry = commit_entry?;
-            // for each commit, recreate the commit from the commit data if it doesn't exist
-            let commit_id = commit_entry.filename();
-            // check for the oid in the repo
-            let commit_oid = gix::ObjectId::from_hex(commit_id)?;
-            if !repo.has_object(commit_oid) {
-                // commit is not in the repo, let's build it from our data
-                let new_commit_oid = deserialize_commit(commit_entry.id())?;
-                if new_commit_oid != commit_oid {
-                    bail!("commit id mismatch: failed to recreate a commit from its parts");
-                }
-            }
-
-            // TODO: in the next iteration, this of course can't be hardcoded.
-            if branch_name == "workspace" {
-                restored_workspace_commit = Some(commit_oid);
-            }
-        }
-    }
-
-    let head = repo.head()?;
-    let head_ref = head
-        .referent_name()
-        .context("We will not change a worktree in detached HEAD state")?;
-    if head_ref != workspace_ref {
-        bail!("We will not change a worktree which for some reason isn't on the workspace branch");
-    }
-
-    let gix_repo = ctx.clone_repo_for_merging()?;
-    let workdir_tree_id = get_workdir_tree(None, snapshot_commit_id, &gix_repo, ctx)?;
-
-    // Check out the snapshot's worktree while HEAD still points at the pre-restore commit:
-    // safe_checkout diffs from `before_restore_snapshot_workdir_tree_id`, so
-    // the workspace ref is repointed only afterwards (below).
-    but_core::worktree::safe_checkout_from_head(
-        workdir_tree_id,
-        &gix_repo,
-        but_core::worktree::checkout::Options::default(),
-    )?;
-
-    // Tracked content now matches the snapshot (untracked files outside the restored diff are
-    // left in place); repoint gitbutler/workspace at the restored commit.
-    if let Some(commit_oid) = restored_workspace_commit {
-        repo.reference(
-            workspace_ref,
-            commit_oid,
-            gix::refs::transaction::PreviousValue::Any,
-            "restore snapshot workspace ref",
-        )?;
-    }
-
-    // Update virtual_branches.toml with the state from the snapshot
-    let vb_state =
-        legacy_virtual_branches::restore_legacy_metadata_from_toml(ctx, &vb_toml_blob.data)?;
-
-    // Now that legacy metadata has been restored, update references to reflect the restored heads.
-    for stack in legacy_virtual_branches::in_workspace_stacks(vb_state.data()) {
-        for branch in &stack.heads {
-            legacy_virtual_branches::set_reference_to_stored_head(branch, &gix_repo).ok();
-        }
-    }
-    // The restored TOML is the source of truth for the target as well - bring the project
-    // metadata in Git config back in line with it so the restore isn't partial.
-    ctx.resync_project_meta_from_legacy()?;
-    ctx.invalidate_workspace_cache()?;
-
-    // reset the repo index to our index tree
-    let index_tree_entry = snapshot_tree
-        .lookup_entry_by_path("index")?
-        .context("failed to get index tree")?;
-    let index_conflicts_tree_id = snapshot_tree
-        .lookup_entry_by_path("index-conflicts")?
-        .map(|entry| entry.id().detach());
-    reset_index_to_tree(ctx, index_tree_entry.id().detach(), index_conflicts_tree_id)?;
-
-    let restored_operation = snapshot_commit
+    let snapshot_details = snapshot_commit
         .message_raw()?
         .to_str()
         .ok()
-        .and_then(|msg| SnapshotDetails::from_str(msg).ok())
+        .and_then(|msg| SnapshotDetails::from_str(msg).ok());
+    let target_plan =
+        prepare_snapshot_restore(ctx, snapshot_commit_id, exclusive_access.read_permission())?;
+    let before_restore_snapshot_tree_id = match target_plan.local_target_restore.as_ref() {
+        Some(local_target) => ctx.prepare_snapshot_with_local_target(
+            &local_target.inverse_snapshot(),
+            exclusive_access.read_permission(),
+        )?,
+        None => prepare_snapshot(ctx, exclusive_access.read_permission())?,
+    };
+    let restored_operation = snapshot_details
         .map(|d| d.operation)
         .unwrap_or(OperationKind::Unknown);
-
-    // create new snapshot
     let restored_date_ms = snapshot_commit.time()?.seconds * 1000;
     let operation = match restore_kind {
         RestoreKind::RestoreFromSnapshotViaUndo => OperationKind::RestoreFromSnapshotViaUndo,
@@ -894,16 +988,360 @@ fn restore_snapshot(
             Trailer::RestoredDate(restored_date_ms),
         ]),
     };
-    let repo = ctx.repo.get()?;
-    let target = ctx.project_meta()?.target_commit_id_or_err()?;
-    commit_snapshot(
-        ctx,
-        &repo,
+    let restore_snapshot = ctx.prepare_snapshot_commit(
         before_restore_snapshot_tree_id,
         details,
+        exclusive_access.read_permission(),
+    )?;
+    let rollback_plan = prepare_snapshot_restore(
+        ctx,
+        restore_snapshot.commit_id,
+        exclusive_access.read_permission(),
+    )?;
+
+    if let Err(restore_err) = apply_snapshot_restore(
+        ctx,
+        &target_plan,
+        RestoreFailureInjection::Allow,
         exclusive_access,
-        target,
-    )
+    ) {
+        apply_snapshot_restore(
+            ctx,
+            &rollback_plan,
+            RestoreFailureInjection::Suppress,
+            exclusive_access,
+        )
+        .with_context(|| format!("failed to roll back snapshot restore after: {restore_err:#}"))?;
+        return Err(restore_err);
+    }
+
+    match ctx.publish_snapshot(restore_snapshot, exclusive_access) {
+        Ok(snapshot_id) => Ok(snapshot_id),
+        Err(publication_err) => {
+            apply_snapshot_restore(
+                ctx,
+                &rollback_plan,
+                RestoreFailureInjection::Suppress,
+                exclusive_access,
+            )
+            .with_context(|| {
+                format!("failed to roll back unpublished snapshot restore: {publication_err:#}")
+            })?;
+            Err(publication_err)
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum RestoreFailureInjection {
+    Allow,
+    Suppress,
+}
+
+struct SnapshotRestorePlan {
+    snapshot_commit_id: gix::ObjectId,
+    local_target_restore: Option<LocalTargetRestore>,
+    virtual_branches_toml: Vec<u8>,
+    restored_workspace_commit: Option<gix::ObjectId>,
+    workdir_tree_id: gix::ObjectId,
+    index_tree_id: gix::ObjectId,
+    index_conflicts_tree_id: Option<gix::ObjectId>,
+}
+
+fn prepare_snapshot_restore(
+    ctx: &Context,
+    snapshot_commit_id: gix::ObjectId,
+    _shared_access: &RepoShared,
+) -> Result<SnapshotRestorePlan> {
+    let repo = ctx.repo.get()?;
+    let snapshot_tree = repo.find_commit(snapshot_commit_id)?.tree()?;
+    let local_target_restore = prepare_local_target_restore(&snapshot_tree, &repo)?;
+    let virtual_branches_toml = snapshot_tree
+        .lookup_entry_by_path("virtual_branches.toml")?
+        .context("failed to get virtual_branches.toml blob")
+        .and_then(|entry| {
+            repo.find_blob(entry.id())
+                .context("failed to convert virtual_branches tree entry to blob")
+        })?
+        .data
+        .to_vec();
+    let vb_tree_entry = snapshot_tree
+        .lookup_entry_by_path("virtual_branches")?
+        .context("failed to get virtual_branches tree entry")?;
+    let vb_tree = repo
+        .find_tree(vb_tree_entry.id())
+        .context("failed to convert virtual_branches tree entry to tree")?;
+
+    let mut restored_workspace_commit = None;
+    for branch_entry in vb_tree.iter() {
+        let branch_entry = branch_entry?;
+        let branch_tree = repo
+            .find_tree(branch_entry.id())
+            .context("failed to convert virtual_branches tree entry to tree")?;
+        let branch_name = branch_entry.filename();
+        let Some(commits_tree_entry) = branch_tree.lookup_entry_by_path("commits")? else {
+            continue;
+        };
+        let commits_tree = repo
+            .find_tree(commits_tree_entry.id())
+            .context("failed to convert commits tree entry to tree")?;
+        for commit_entry in commits_tree.iter() {
+            let commit_entry = commit_entry?;
+            let commit_oid = gix::ObjectId::from_hex(commit_entry.filename())?;
+            if !repo.has_object(commit_oid) {
+                let new_commit_oid = deserialize_commit(commit_entry.id())?;
+                if new_commit_oid != commit_oid {
+                    bail!("commit id mismatch: failed to recreate a commit from its parts");
+                }
+            }
+            if branch_name == "workspace" {
+                restored_workspace_commit = Some(commit_oid);
+            }
+        }
+    }
+
+    let workspace_ref: &gix::refs::FullNameRef = WORKSPACE_REF_NAME.try_into()?;
+    let head = repo.head()?;
+    let head_ref = head
+        .referent_name()
+        .context("We will not change a worktree in detached HEAD state")?;
+    if head_ref != workspace_ref {
+        bail!("We will not change a worktree which for some reason isn't on the workspace branch");
+    }
+
+    let gix_repo = ctx.clone_repo_for_merging()?;
+    let workdir_tree_id = get_workdir_tree(None, snapshot_commit_id, &gix_repo, ctx)?;
+    let index_tree_id = snapshot_tree
+        .lookup_entry_by_path("index")?
+        .context("failed to get index tree")?
+        .id()
+        .detach();
+    let index_conflicts_tree_id = snapshot_tree
+        .lookup_entry_by_path("index-conflicts")?
+        .map(|entry| entry.id().detach());
+
+    Ok(SnapshotRestorePlan {
+        snapshot_commit_id,
+        local_target_restore,
+        virtual_branches_toml,
+        restored_workspace_commit,
+        workdir_tree_id,
+        index_tree_id,
+        index_conflicts_tree_id,
+    })
+}
+
+fn apply_snapshot_restore(
+    ctx: &Context,
+    plan: &SnapshotRestorePlan,
+    failure_injection: RestoreFailureInjection,
+    _exclusive_access: &mut RepoExclusive,
+) -> Result<()> {
+    let repo = ctx.repo.get()?;
+    let applied_local_target_restore = plan
+        .local_target_restore
+        .as_ref()
+        .map(|local_target| local_target.apply(&repo))
+        .transpose()?
+        .flatten();
+    let restore_result = (|| -> Result<()> {
+        #[cfg(debug_assertions)]
+        if matches!(failure_injection, RestoreFailureInjection::Allow)
+            && std::env::var_os("GITBUTLER_TEST_OPLOG_RESTORE_FAILURE").as_deref()
+                == Some(std::ffi::OsStr::new("after-local-target"))
+        {
+            bail!("injected oplog restore failure after applying the local target");
+        }
+        let snapshot_tree = repo.find_commit(plan.snapshot_commit_id)?.tree()?;
+        if let Err(err) = restore_conflicts_tree(&snapshot_tree, &repo) {
+            tracing::warn!("failed to restore conflicts tree - ignoring: {err}")
+        }
+        let workspace_ref: &gix::refs::FullNameRef = WORKSPACE_REF_NAME.try_into()?;
+        let gix_repo = ctx.clone_repo_for_merging()?;
+        but_core::worktree::safe_checkout_from_head(
+            plan.workdir_tree_id,
+            &gix_repo,
+            but_core::worktree::checkout::Options::default(),
+        )?;
+        if let Some(commit_oid) = plan.restored_workspace_commit {
+            repo.reference(
+                workspace_ref,
+                commit_oid,
+                gix::refs::transaction::PreviousValue::Any,
+                "restore snapshot workspace ref",
+            )?;
+        }
+        let vb_state = legacy_virtual_branches::restore_legacy_metadata_from_toml(
+            ctx,
+            &plan.virtual_branches_toml,
+        )?;
+        for stack in legacy_virtual_branches::in_workspace_stacks(vb_state.data()) {
+            for branch in &stack.heads {
+                legacy_virtual_branches::set_reference_to_stored_head(branch, &gix_repo).ok();
+            }
+        }
+        ctx.resync_project_meta_from_legacy()?;
+        ctx.invalidate_workspace_cache()?;
+        reset_index_to_tree(ctx, plan.index_tree_id, plan.index_conflicts_tree_id)?;
+        Ok(())
+    })();
+    if let Err(restore_err) = &restore_result
+        && let Some(applied_local_target_restore) = applied_local_target_restore
+    {
+        applied_local_target_restore
+            .rollback(&repo)
+            .with_context(|| {
+                format!(
+                    "failed to roll back the local target after snapshot restore failed: {restore_err:#}"
+                )
+            })?;
+    }
+    restore_result
+}
+
+struct LocalTargetRestore {
+    ref_name: gix::refs::FullName,
+    tracking_ref: gix::refs::FullName,
+    current_tip_at_prepare: gix::ObjectId,
+    expected_current_tip: gix::ObjectId,
+    desired_tip: gix::ObjectId,
+}
+
+fn prepare_local_target_restore(
+    snapshot_tree: &gix::Tree,
+    repo: &gix::Repository,
+) -> Result<Option<LocalTargetRestore>> {
+    let Some(ref_name) = snapshot_blob(snapshot_tree, repo, "local_target/ref")? else {
+        return Ok(None);
+    };
+    let tip = snapshot_blob(snapshot_tree, repo, "local_target/tip")?
+        .context("snapshot local target is missing its tip")?;
+    let tracking_ref = snapshot_blob(snapshot_tree, repo, "local_target/tracking_ref")?
+        .context("snapshot local target is missing its tracking ref")?;
+    let expected_current_tip = snapshot_blob(snapshot_tree, repo, "local_target/expected_tip")?
+        .context("snapshot local target is missing its expected current tip")?;
+    let ref_name = gix::refs::FullName::try_from(gix::bstr::BString::from(ref_name))?;
+    let tracking_ref = gix::refs::FullName::try_from(gix::bstr::BString::from(tracking_ref))?;
+    let desired_tip = gix::ObjectId::from_hex(&tip)?;
+    let expected_current_tip = gix::ObjectId::from_hex(&expected_current_tip)?;
+
+    let mut reference = repo
+        .try_find_reference(ref_name.as_ref())?
+        .with_context(|| format!("local target '{}' no longer exists", ref_name.shorten()))?;
+    let current_tracking_ref = repo
+        .branch_remote_tracking_ref_name(ref_name.as_ref(), gix::remote::Direction::Fetch)
+        .transpose()?
+        .with_context(|| {
+            format!(
+                "local target '{}' no longer has an upstream",
+                ref_name.shorten()
+            )
+        })?;
+    if current_tracking_ref.as_ref() != tracking_ref.as_ref() {
+        bail!(
+            "local target '{}' now tracks '{}' instead of '{}'",
+            ref_name.shorten(),
+            current_tracking_ref.shorten(),
+            tracking_ref.shorten()
+        );
+    }
+
+    let current_tip_at_prepare = reference.peel_to_id()?.detach();
+
+    let checkout_probe = but_core::branch::SafeDelete::new(repo)?;
+    if let Some(paths) = checkout_probe.worktree_dirs_with_ref(&reference) {
+        bail!(
+            "local target '{}' is checked out in: {paths:?}",
+            ref_name.shorten()
+        );
+    }
+
+    Ok(Some(LocalTargetRestore {
+        ref_name,
+        tracking_ref,
+        current_tip_at_prepare,
+        expected_current_tip,
+        desired_tip,
+    }))
+}
+
+impl LocalTargetRestore {
+    fn inverse_snapshot(&self) -> LocalTargetSnapshot {
+        LocalTargetSnapshot {
+            ref_name: self.ref_name.clone(),
+            tracking_ref: self.tracking_ref.clone(),
+            snapshot_tip: self.current_tip_at_prepare,
+            expected_tip: self.desired_tip,
+        }
+    }
+
+    fn apply(&self, repo: &gix::Repository) -> Result<Option<AppliedLocalTargetRestore>> {
+        let mut reference = repo
+            .try_find_reference(self.ref_name.as_ref())?
+            .with_context(|| {
+                format!(
+                    "local target '{}' no longer exists",
+                    self.ref_name.shorten()
+                )
+            })?;
+        let current_tip = reference.peel_to_id()?.detach();
+        if current_tip == self.desired_tip {
+            return Ok(None);
+        }
+        if current_tip != self.expected_current_tip {
+            bail!(
+                "local target '{}' changed since the snapshot: found {current_tip}, expected {}",
+                self.ref_name.shorten(),
+                self.expected_current_tip
+            );
+        }
+        let checkout_probe = but_core::branch::SafeDelete::new(repo)?;
+        if let Some(paths) = checkout_probe.worktree_dirs_with_ref(&reference) {
+            bail!(
+                "local target '{}' is checked out in: {paths:?}",
+                self.ref_name.shorten()
+            );
+        }
+        repo.reference(
+            self.ref_name.as_ref(),
+            self.desired_tip,
+            gix::refs::transaction::PreviousValue::ExistingMustMatch(current_tip.into()),
+            "GitButler oplog restore local target",
+        )?;
+        Ok(Some(AppliedLocalTargetRestore {
+            ref_name: self.ref_name.clone(),
+            previous_tip: current_tip,
+            current_tip: self.desired_tip,
+        }))
+    }
+}
+
+struct AppliedLocalTargetRestore {
+    ref_name: gix::refs::FullName,
+    previous_tip: gix::ObjectId,
+    current_tip: gix::ObjectId,
+}
+
+impl AppliedLocalTargetRestore {
+    fn rollback(self, repo: &gix::Repository) -> Result<()> {
+        repo.reference(
+            self.ref_name.as_ref(),
+            self.previous_tip,
+            gix::refs::transaction::PreviousValue::ExistingMustMatch(self.current_tip.into()),
+            "GitButler roll back failed oplog restore local target",
+        )?;
+        Ok(())
+    }
+}
+
+fn snapshot_blob(tree: &gix::Tree, repo: &gix::Repository, path: &str) -> Result<Option<Vec<u8>>> {
+    tree.lookup_entry_by_path(path)?
+        .map(|entry| {
+            repo.find_blob(entry.id())
+                .map(|blob| blob.data.to_vec())
+                .map_err(Into::into)
+        })
+        .transpose()
 }
 
 /// Restore the state of .git/base_merge_parent and .git/conflicts from the snapshot
@@ -1201,5 +1639,59 @@ pub fn peel_restore_snapshot(ctx: &Context, snapshot: &Snapshot) -> Result<Optio
         };
 
         current = ctx.get_snapshot(restored_from)?;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+
+    use anyhow::anyhow;
+
+    use super::{SnapshotProtection, publish_snapshot_head};
+
+    #[test]
+    fn snapshot_head_failure_is_prepublication() {
+        let protection_called = Cell::new(false);
+
+        let result = publish_snapshot_head(
+            || Err(anyhow!("head write failed")),
+            || {
+                protection_called.set(true);
+                Ok(())
+            },
+        );
+
+        assert!(
+            result.is_err(),
+            "failure to persist the oplog head must fail publication"
+        );
+        assert!(
+            !protection_called.get(),
+            "GC protection must not run before the oplog head is published"
+        );
+    }
+
+    #[test]
+    fn snapshot_reflog_failure_keeps_published_head() -> anyhow::Result<()> {
+        let head_persisted = Cell::new(false);
+
+        let result = publish_snapshot_head(
+            || {
+                head_persisted.set(true);
+                Ok(())
+            },
+            || Err(anyhow!("reflog write failed")),
+        )?;
+
+        assert!(
+            head_persisted.get(),
+            "the oplog head is the snapshot publication commit point"
+        );
+        assert!(
+            matches!(result, SnapshotProtection::Pending(_)),
+            "failure of secondary GC protection must not unpublish the snapshot"
+        );
+        Ok(())
     }
 }


### PR DESCRIPTION
## 🧢 Changes

- Resolve the existing local branch that is actually configured to track the fetched target.
  - Fast-forward that branch with ancestry, linked-worktree, and compare-and-swap guards.
  - Leave same-named but unconfigured branches and unrelated invalid tracking entries untouched.
  - Reject ambiguous tracking when multiple local branches target the same remote branch.
  - Cover successful synchronization, divergence, alternate local names, ambiguity, and checked-out-worktree rejection.
- Record the local-target transition in the oplog so undo and redo restore the
  local ref together with workspace, index, and project metadata.
- Keep snapshot preparation state-neutral and roll back the complete unpublished
  effect when integration or publication fails.

## ☕️ Reasoning

The local tracking branch is also a user-visible base for ordinary Git and worktree tooling. A successful pull should leave that ref aligned with its fetched target whenever a fast-forward is safe.

This matters for agentic coding because isolated worktrees are commonly created from the local tracking branch immediately after pulling.

## 🧪 Reproduction

With local `master` behind its configured upstream and not checked out:

```sh
but pull
git rev-parse master 'master@{upstream}'
```

Before this fix, `but pull` reported success while the two object IDs remained different. A worktree subsequently created from `master` therefore started from the stale commit.

## ✅ Verification

- Fourteen focused local-target tests passed.
- The stale snapshot-preparation regression and two oplog publication tests
  passed.
- Failure injection preserves the target ref, workspace, index, legacy
  metadata, oplog head, and next undo/redo selection.
- Formatting and diff checks passed.
- Independent correction review found no Critical or Important issues.

Developed with carefully directed, manually reviewed AI assistance.

Co-Authored-By: GPT-5.6 Sol <codex@openai.com>
