### PR TITLE
fix(workspace): Ignore direct managed ancestry

### DIFF
--- a/crates/but-workspace/src/ref_info.rs
+++ b/crates/but-workspace/src/ref_info.rs
@@ -532,24 +532,6 @@ fn ancestor_workspace_commit_if_outside(
     })
 }
 
-#[cfg(test)]
-mod ancestor_workspace_tests {
-    use super::ancestor_workspace_commit_if_outside;
-
-    #[test]
-    fn empty_outside_commits_are_not_ancestor_workspace_state() {
-        let actual = ancestor_workspace_commit_if_outside(
-            Vec::new(),
-            Some((but_graph::SegmentIndex::new(0), 0)),
-        );
-
-        assert!(
-            actual.is_none(),
-            "the managed commit itself must not be reported as an ancestor"
-        );
-    }
-}
-
 /// Gather information about graph and the workspace that might be associated with it,
 /// based on data in `repo` and `meta`. Use `options` to further configure the call.
 ///

--- a/crates/but-workspace/src/ref_info.rs
+++ b/crates/but-workspace/src/ref_info.rs
@@ -517,11 +517,37 @@ pub(crate) fn find_ancestor_workspace_commit(
         }
         false
     });
-    sidx_and_cidx.map(|(sidx, cidx)| AncestorWorkspaceCommit {
+    ancestor_workspace_commit_if_outside(commits_outside, sidx_and_cidx)
+}
+
+fn ancestor_workspace_commit_if_outside(
+    commits_outside: Vec<crate::ref_info::Commit>,
+    sidx_and_cidx: Option<(SegmentIndex, usize)>,
+) -> Option<AncestorWorkspaceCommit> {
+    let (sidx, cidx) = sidx_and_cidx?;
+    (!commits_outside.is_empty()).then_some(AncestorWorkspaceCommit {
         commits_outside,
         segment_with_managed_commit: sidx,
         commit_index_of_managed_commit: cidx,
     })
+}
+
+#[cfg(test)]
+mod ancestor_workspace_tests {
+    use super::ancestor_workspace_commit_if_outside;
+
+    #[test]
+    fn empty_outside_commits_are_not_ancestor_workspace_state() {
+        let actual = ancestor_workspace_commit_if_outside(
+            Vec::new(),
+            Some((but_graph::SegmentIndex::new(0), 0)),
+        );
+
+        assert!(
+            actual.is_none(),
+            "the managed commit itself must not be reported as an ancestor"
+        );
+    }
 }
 
 /// Gather information about graph and the workspace that might be associated with it,

--- a/crates/but-workspace/src/tree_manipulation/discard_worktree_changes.rs
+++ b/crates/but-workspace/src/tree_manipulation/discard_worktree_changes.rs
@@ -340,7 +340,7 @@ mod file {
                             // Thus, all we have to do is to check out the submodule.
                             // TODO(gix): find a way to deal with nested submodules - they should also be checked out which
                             //            isn't done by `gitoxide`, but probably should be an option there.
-                            checkout_repo_worktree(&wt_root, repo)?;
+                            checkout_repo_worktree(&wt_root, &file_path, repo)?;
                         }
                     }
                     std::fs::create_dir(&file_path).or_else(|err| {
@@ -416,6 +416,7 @@ mod file {
 
     fn checkout_repo_worktree(
         parent_worktree_dir: &Path,
+        checkout_destination: &Path,
         mut repo: gix::Repository,
     ) -> anyhow::Result<()> {
         // No need to cache anything, it's just single-use for the most part.
@@ -437,9 +438,8 @@ mod file {
         opts.destination_is_initially_empty = true;
         opts.keep_going = true;
 
-        let checkout_destination = repo.workdir().context("non-bare repository")?.to_owned();
         if !checkout_destination.exists() {
-            std::fs::create_dir(&checkout_destination)?;
+            std::fs::create_dir(checkout_destination)?;
         }
         let sm_repo_dir = gix::path::relativize_with_prefix(
             repo.path().strip_prefix(parent_worktree_dir)?,
@@ -448,7 +448,7 @@ mod file {
         .into_owned();
         let out = gix::worktree::state::checkout(
             &mut index,
-            checkout_destination.clone(),
+            checkout_destination.to_owned(),
             repo,
             &gix::progress::Discard,
             &gix::progress::Discard,

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
@@ -33,6 +33,30 @@ pub fn ref_info(
 }
 
 #[test]
+fn direct_workspace_ref_has_no_ancestor_workspace_commit() -> anyhow::Result<()> {
+    let (repo, meta) = read_only_in_memory_scenario("remote-advanced-ff")?;
+    let workspace_tip = repo.head_id()?.detach();
+    repo.reference(
+        "refs/heads/direct-workspace",
+        workspace_tip,
+        gix::refs::transaction::PreviousValue::MustNotExist,
+        "test direct workspace ref",
+    )?;
+
+    let info = ref_info(
+        repo.find_reference("refs/heads/direct-workspace")?,
+        &meta,
+        standard_options(),
+    )?;
+
+    assert!(
+        info.ancestor_workspace_commit.is_none(),
+        "a ref pointing directly at the managed workspace commit has no outside commits"
+    );
+    Ok(())
+}
+
+#[test]
 fn gerrit_mode_uses_metadata_for_commit_review_urls_and_push_status() -> anyhow::Result<()> {
     let (repo, mut meta) = read_only_in_memory_scenario("remote-advanced-ff")?;
     add_stack(&mut meta, 1, "A", StackState::InWorkspace);

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
@@ -34,8 +34,8 @@ pub fn ref_info(
 
 #[test]
 fn direct_workspace_ref_has_no_ancestor_workspace_commit() -> anyhow::Result<()> {
-    let (repo, meta) = read_only_in_memory_scenario("remote-advanced-ff")?;
-    let workspace_tip = repo.head_id()?.detach();
+    let (_tmp, repo, meta) = writable_scenario("remote-advanced-ff")?;
+    let workspace_tip = repo.head_id()?;
     repo.reference(
         "refs/heads/direct-workspace",
         workspace_tip,
@@ -52,6 +52,41 @@ fn direct_workspace_ref_has_no_ancestor_workspace_commit() -> anyhow::Result<()>
     assert!(
         info.ancestor_workspace_commit.is_none(),
         "a ref pointing directly at the managed workspace commit has no outside commits"
+    );
+    Ok(())
+}
+
+#[test]
+fn advanced_direct_workspace_ref_has_no_ancestor_workspace_commit() -> anyhow::Result<()> {
+    let (_tmp, repo, meta) = writable_scenario("remote-advanced-ff")?;
+    let workspace_tip = repo.head_id()?;
+    let advanced_tip = repo
+        .write_object(gix::objs::Commit {
+            parents: [workspace_tip.detach()].into(),
+            message: "commit outside the workspace".into(),
+            ..repo.head_commit()?.decode()?.to_owned()?
+        })?
+        .detach();
+    repo.reference(
+        "refs/heads/direct-workspace",
+        advanced_tip,
+        gix::refs::transaction::PreviousValue::MustNotExist,
+        "test advanced direct workspace ref",
+    )?;
+
+    let info = ref_info(
+        repo.find_reference("refs/heads/direct-workspace")?,
+        &meta,
+        standard_options(),
+    )?;
+
+    assert!(
+        !info.is_managed_ref,
+        "a direct branch without workspace metadata is ad hoc"
+    );
+    assert!(
+        info.ancestor_workspace_commit.is_none(),
+        "an ad-hoc ref does not interpret managed workspace commits in its ancestry"
     );
     Ok(())
 }
@@ -4398,6 +4433,20 @@ pub(crate) mod utils {
         named_read_only_in_memory_scenario("with-remotes-and-workspace", name)
     }
 
+    pub fn writable_scenario(
+        name: &str,
+    ) -> anyhow::Result<(TempDir, gix::Repository, VirtualBranchesTomlMetadata)> {
+        let tmp = but_testsupport::gix_testtools::scripted_fixture_writable(
+            "scenario/with-remotes-and-workspace.sh",
+        )
+        .map_err(anyhow::Error::from_boxed)?;
+        let repo = but_testsupport::open_repo(&tmp.path().join(name))?;
+        let mut meta =
+            VirtualBranchesTomlMetadata::from_path(repo.path().join("virtual-branches.toml"))?;
+        set_default_target(&repo, &mut meta)?;
+        Ok((tmp, repo, meta))
+    }
+
     pub fn named_read_only_in_memory_scenario(
         script: &str,
         name: &str,
@@ -4407,6 +4456,14 @@ pub(crate) mod utils {
     )> {
         let (repo, mut meta) =
             crate::ref_info::utils::named_read_only_in_memory_scenario(script, name)?;
+        set_default_target(&repo, &mut meta)?;
+        Ok((repo, meta))
+    }
+
+    fn set_default_target(
+        repo: &gix::Repository,
+        meta: &mut VirtualBranchesTomlMetadata,
+    ) -> anyhow::Result<()> {
         let vb = meta.data_mut();
         vb.default_target = Some(Target {
             // For simplicity, we stick to the defaults.
@@ -4421,7 +4478,7 @@ pub(crate) mod utils {
                 .unwrap_or_else(|| gix::hash::Kind::Sha1.null()),
             push_remote_name: None,
         });
-        Ok((repo, meta))
+        Ok(())
     }
 
     pub fn named_writable_scenario_with_description(
@@ -4590,8 +4647,8 @@ pub(crate) mod utils {
         stack_id
     }
 }
-use utils::add_stack;
 pub use utils::read_only_in_memory_scenario;
+use utils::{add_stack, writable_scenario};
 
 use crate::ref_info::{
     utils::standard_options,


### PR DESCRIPTION
## 🧢 Changes

- Report an ancestor workspace commit only when commits actually exist outside it.
- Keep direct and advanced ad-hoc refs out of ancestor-workspace state.
- Restore submodules at the checkout destination already selected by worktree traversal instead of resolving the path again through the repository.
- Cover direct and one-commit-ahead ad-hoc repository scenarios.

## ☕️ Reasoning

Consumers use ancestor-workspace state to decide whether commits outside a managed workspace commit must be reconstructed. That state must be absent when an ad-hoc ref has no reconstructible outside segment.

Submodule discard already receives the authoritative checkout destination from worktree traversal. Resolving it again through the repository can change the path base in a linked worktree and fail with `prefix not found`.

For agentic coding, these fixes prevent automation from reconstructing nonexistent ancestry and make discard behavior reliable from linked worktrees.

## 🧪 Reproduction

```sh
cargo test -p but-workspace direct_workspace_ref_has_no_ancestor_workspace_commit
cargo test -p but-workspace advanced_direct_workspace_ref_has_no_ancestor_workspace_commit
```

Before the ancestry fix, a direct managed-workspace ref produced an `AncestorWorkspaceCommit` with an empty `commits_outside` list. During maintainer validation from a linked worktree, four submodule-discard cases also failed with `prefix not found` before the checkout path correction.

## ✅ Verification

- Repository-level direct and one-commit-ahead ad-hoc ancestry regressions passed.
- Existing submodule-discard coverage passed with the corrected checkout destination.
- The merged PR's Rust tests, lint, blackbox, compatibility, and platform checks passed.
- All merged commits are signed and verified.

Developed with carefully directed, manually reviewed AI assistance. `Allow edits by maintainers` is enabled, so maintainers are welcome to fix wording or make minor cleanup directly; broader review feedback will be incorporated.

Co-Authored-By: GPT-5.6 Sol <codex@openai.com>
