### PR TITLE
fix(project): Route linked worktree identity

### DIFF
--- a/crates/but-ctx/src/lib.rs
+++ b/crates/but-ctx/src/lib.rs
@@ -299,12 +299,7 @@ impl Context {
         }
         #[cfg(feature = "legacy")]
         {
-            use anyhow::Context as _;
-            let worktree_dir = repo
-                .workdir()
-                .context("Bare repositories aren't yet supported.")?;
-            let legacy_project = LegacyProject::find_by_worktree_dir(worktree_dir)
-                .unwrap_or_else(|_| default_legacy_project_at_repo(&repo));
+            let legacy_project = legacy_project_for_unclassified_repo(&repo)?;
             let cache_mode = CacheMode::Disk;
             Ok(Context {
                 settings,
@@ -420,12 +415,7 @@ impl Context {
             but_project_handle::gitbutler_storage_path_for_channel(&repo, channel)?;
         #[cfg(feature = "legacy")]
         {
-            use anyhow::Context as _;
-            let worktree_dir = repo
-                .workdir()
-                .context("Bare repositories aren't yet supported.")?;
-            let legacy_project = LegacyProject::find_by_worktree_dir(worktree_dir)
-                .unwrap_or_else(|_| default_legacy_project_at_repo(&repo));
+            let legacy_project = legacy_project_for_unclassified_repo(&repo)?;
             let gitdir = repo.git_dir().to_owned();
             let cache_mode = CacheMode::Disk;
             Ok(Context {
@@ -1044,6 +1034,22 @@ fn app_settings(config_dir: impl AsRef<Path>) -> anyhow::Result<AppSettings> {
         &AppSettings::default_settings_path(config_dir.as_ref()),
         None,
     )
+}
+
+#[cfg(feature = "legacy")]
+fn legacy_project_for_unclassified_repo(repo: &gix::Repository) -> anyhow::Result<LegacyProject> {
+    if repo.git_dir() != repo.common_dir() {
+        anyhow::bail!(
+            "unclassified linked worktree context is unsupported; resolve the registered project explicitly"
+        );
+    }
+    let worktree_dir = repo
+        .workdir()
+        .ok_or_else(|| anyhow!("Bare repositories aren't yet supported."))?;
+    match LegacyProject::find_by_worktree_dir(worktree_dir) {
+        Ok(project) => Ok(project),
+        Err(_) => Ok(default_legacy_project_at_repo(repo)),
+    }
 }
 
 #[cfg(feature = "legacy")]

--- a/crates/but-ctx/tests/ctx/main.rs
+++ b/crates/but-ctx/tests/ctx/main.rs
@@ -2,7 +2,9 @@ use but_core::{RefMetadata as _, WORKSPACE_REF_NAME, ref_metadata::ProjectMeta};
 use but_ctx::{Context, ProjectHandle};
 use but_meta::VirtualBranchesTomlMetadata;
 use but_path::AppChannel;
-use but_testsupport::{CommandExt as _, git, gix_testtools::tempfile::TempDir, open_repo};
+use but_testsupport::{
+    CommandExt as _, git, git_at_dir, gix_testtools::tempfile::TempDir, open_repo,
+};
 use snapbox::ToDebug;
 
 #[test]
@@ -130,6 +132,90 @@ fn discover_with_app_channel_uses_requested_project_data_dir() -> anyhow::Result
         assert_eq!(
             dev_ctx.project_data_dir(),
             dev_ctx.gitdir.join("gitbutler-dev")
+        );
+        Ok(())
+    })
+}
+
+#[test]
+fn linked_worktree_discovery_rejects_unclassified_context() -> anyhow::Result<()> {
+    but_testsupport::isolated_app_data_dir(|| {
+        let tmp = TempDir::new()?;
+        let main_worktree_dir = tmp.path().join("main");
+        let linked_worktree_dir = main_worktree_dir.join(".worktrees/linked");
+
+        git_at_dir(tmp.path())
+            .args(["init"])
+            .arg(&main_worktree_dir)
+            .run();
+        git_at_dir(&main_worktree_dir)
+            .args(["commit", "--allow-empty", "-m", "initial commit"])
+            .run();
+        git_at_dir(&main_worktree_dir)
+            .args(["worktree", "add", "-b", "feature"])
+            .arg(&linked_worktree_dir)
+            .run();
+
+        let registered = gitbutler_project::add(&main_worktree_dir)?.unwrap_project();
+        let err = Context::discover(&linked_worktree_dir)
+            .expect_err("unclassified linked-worktree context must be rejected");
+        assert!(
+            err.to_string().contains("linked worktree"),
+            "the rejection should identify linked-worktree routing: {err:#}"
+        );
+        assert_eq!(
+            gitbutler_project::dangerously_list_projects_without_migration()?.len(),
+            1,
+            "rejected discovery must not register another project"
+        );
+        assert_eq!(
+            registered
+                .open_isolated_repo()?
+                .workdir()
+                .expect("registered repository is non-bare")
+                .canonicalize()?,
+            main_worktree_dir.canonicalize()?,
+            "rejected discovery must not retarget the registered project"
+        );
+        Ok(())
+    })
+}
+
+#[test]
+fn linked_worktree_legacy_context_uses_invocation_checkout() -> anyhow::Result<()> {
+    but_testsupport::isolated_app_data_dir(|| {
+        let tmp = TempDir::new()?;
+        let main_worktree_dir = tmp.path().join("main");
+        let linked_worktree_dir = tmp.path().join("linked");
+
+        git_at_dir(tmp.path())
+            .args(["init"])
+            .arg(&main_worktree_dir)
+            .run();
+        git_at_dir(&main_worktree_dir)
+            .args(["commit", "--allow-empty", "-m", "initial commit"])
+            .run();
+        git_at_dir(&main_worktree_dir)
+            .args(["worktree", "add", "-b", "feature"])
+            .arg(&linked_worktree_dir)
+            .run();
+
+        gitbutler_project::add(&main_worktree_dir)?.unwrap_project();
+        let invocation_repo = gix::discover(&linked_worktree_dir)?;
+        let invocation_project = gitbutler_project::Project::find_by_repository(&invocation_repo)?;
+        let ctx = Context::new_from_legacy_project_and_settings(
+            &invocation_project,
+            but_settings::AppSettings::default(),
+        )?;
+
+        assert_eq!(
+            ctx.repo
+                .get()?
+                .workdir()
+                .expect("linked repository is non-bare")
+                .canonicalize()?,
+            linked_worktree_dir.canonicalize()?,
+            "legacy initialization must retain the invocation checkout"
         );
         Ok(())
     })

--- a/crates/but-project-handle/src/storage_path.rs
+++ b/crates/but-project-handle/src/storage_path.rs
@@ -19,20 +19,26 @@ pub fn storage_path_config_key_for_app_channel(channel: AppChannel) -> &'static 
 }
 
 /// Return the path where per-project GitButler data should be stored for `repo`.
+///
+/// The repository's common Git directory anchors storage so all linked worktrees share it.
 pub fn gitbutler_storage_path(repo: &gix::Repository) -> anyhow::Result<PathBuf> {
     gitbutler_storage_path_for_channel(repo, AppChannel::new())
 }
 
 /// Return the path where per-project GitButler data should be stored for `repo` and `channel`.
+///
+/// The repository's common Git directory anchors storage so all linked worktrees share it.
 pub fn gitbutler_storage_path_for_channel(
     repo: &gix::Repository,
     channel: AppChannel,
 ) -> anyhow::Result<PathBuf> {
-    let git_dir = repo.git_dir();
+    let git_dir = gix::path::normalize(repo.common_dir().into(), repo.git_dir())
+        .unwrap_or(Cow::Borrowed(repo.common_dir()))
+        .into_owned();
     let storage_key = storage_path_config_key_for_channel(&channel);
 
     match repo.config_snapshot().trusted_path(storage_key) {
-        Some(Ok(path)) => resolve_configured_storage_path(git_dir, path.as_ref()),
+        Some(Ok(path)) => resolve_configured_storage_path(&git_dir, path.as_ref()),
         Some(Err(err)) => {
             Err(err).with_context(|| format!("{storage_key} contains an invalid path"))
         }
@@ -110,7 +116,7 @@ fn validate_in_git_storage_path(
     Ok(())
 }
 
-/// Name of the default GitButler storage directory inside the git dir.
+/// Name of the default GitButler storage directory inside the common Git directory.
 pub const DEFAULT_STORAGE_DIR_NAME: &str = "gitbutler";
 
 /// Git-dir-relative path of the refresh sentinel, `gitbutler/REFRESH`.

--- a/crates/but-project-handle/tests/project-handle/storage_path.rs
+++ b/crates/but-project-handle/tests/project-handle/storage_path.rs
@@ -5,7 +5,7 @@ use but_project_handle::{
     ProjectHandle, gitbutler_storage_path, gitbutler_storage_path_for_channel,
     storage_path_config_key, storage_path_config_key_for_app_channel,
 };
-use but_testsupport::{CommandExt as _, git, gix_testtools, open_repo};
+use but_testsupport::{CommandExt as _, git, git_at_dir, gix_testtools, open_repo};
 use gix_testtools::tempfile::TempDir;
 
 fn init_repo() -> anyhow::Result<(TempDir, gix::Repository)> {
@@ -97,6 +97,43 @@ fn storage_path_default_stays_in_git_dir() -> anyhow::Result<()> {
     let expected = repo.git_dir().join(default_storage_dir_name());
 
     assert_eq!(gitbutler_storage_path(&repo)?, expected);
+    Ok(())
+}
+
+#[test]
+fn linked_worktrees_share_configured_storage_path() -> anyhow::Result<()> {
+    let tmp = TempDir::new()?;
+    let main_worktree = tmp.path().join("main");
+    let linked_worktree = tmp.path().join("linked");
+    git_at_dir(tmp.path())
+        .args(["init"])
+        .arg(&main_worktree)
+        .run();
+    git_at_dir(&main_worktree)
+        .args(["commit", "--allow-empty", "-m", "initial commit"])
+        .run();
+    git_at_dir(&main_worktree)
+        .args(["worktree", "add", "-b", "feature"])
+        .arg(&linked_worktree)
+        .run();
+
+    let main_repo = set_git_config(
+        &open_repo(&main_worktree)?,
+        storage_path_config_key(),
+        "gitbutler-custom",
+    )?;
+    let linked_repo = open_repo(&linked_worktree)?;
+    let expected = main_repo.common_dir().join("gitbutler-custom");
+    let main_storage = gitbutler_storage_path(&main_repo)?;
+    let linked_storage = gitbutler_storage_path(&linked_repo)?;
+
+    assert_eq!(main_storage, expected);
+    std::fs::create_dir_all(&main_storage)?;
+    assert_eq!(
+        gix::path::realpath(&linked_storage)?,
+        gix::path::realpath(&main_storage)?,
+        "configured storage remains anchored at the common Git directory"
+    );
     Ok(())
 }
 

--- a/crates/gitbutler-project/src/controller.rs
+++ b/crates/gitbutler-project/src/controller.rs
@@ -62,27 +62,27 @@ fn resolve_project_repo_exact(
 }
 
 #[expect(clippy::result_large_err)]
-fn resolve_project_repo_by_discovery(
-    path: &Path,
-) -> std::result::Result<ResolvedProjectRepo, AddProjectOutcome> {
-    let repo = match gix::discover(path) {
-        Ok(repo) => repo,
-        Err(err) => return Err(AddProjectOutcome::NotAGitRepository(err.to_string())),
-    };
-
-    normalize_project_repo(repo)
+fn discover_project_repo(path: &Path) -> std::result::Result<gix::Repository, AddProjectOutcome> {
+    gix::discover(path).map_err(|err| AddProjectOutcome::NotAGitRepository(err.to_string()))
 }
 
-fn find_existing_project_by_git_dir(
+fn find_existing_project_by_common_git_dir(
     all_projects: &[Project],
-    git_dir: &Path,
+    common_git_dir: &Path,
 ) -> Result<Option<Project>> {
+    let common_git_dir = gix::path::realpath(common_git_dir)?;
     for project in all_projects {
         let project = project
             .clone()
             .migrated()
             .unwrap_or_else(|_| project.clone());
-        if project.git_dir_opt() == Some(git_dir) {
+        let Some(project_git_dir) = project.git_dir_opt() else {
+            continue;
+        };
+        let Ok(project_common_git_dir) = gix::path::realpath(project_git_dir) else {
+            continue;
+        };
+        if project_common_git_dir == common_git_dir {
             return Ok(Some(project));
         }
     }
@@ -190,17 +190,23 @@ impl Controller {
             }
             return Ok(AddProjectOutcome::NotADirectory);
         }
-        let resolved_repo = match resolve_project_repo_by_discovery(&resolved_path) {
+        let repo = match discover_project_repo(&resolved_path) {
             Ok(repo) => repo,
             Err(outcome) => return Ok(outcome),
         };
 
         if let Some(existing_project) =
-            find_existing_project_by_git_dir(&all_projects, resolved_repo.repo.git_dir())?
+            find_existing_project_by_common_git_dir(&all_projects, repo.common_dir())?
         {
-            return Ok(AddProjectOutcome::AlreadyExists(existing_project));
+            return Ok(AddProjectOutcome::AlreadyExists(
+                existing_project.with_repository(&repo)?,
+            ));
         }
 
+        let resolved_repo = match normalize_project_repo(repo) {
+            Ok(repo) => repo,
+            Err(outcome) => return Ok(outcome),
+        };
         self.add(resolved_repo.worktree_dir)
     }
 
@@ -222,7 +228,7 @@ impl Controller {
             .list()
             .context("failed to list projects from storage")?;
         if let Some(existing_project) =
-            find_existing_project_by_git_dir(&all_projects, resolved_repo.repo.git_dir())?
+            find_existing_project_by_common_git_dir(&all_projects, resolved_repo.repo.common_dir())?
         {
             return Ok(AddProjectOutcome::AlreadyExists(existing_project));
         }

--- a/crates/gitbutler-project/src/project.rs
+++ b/crates/gitbutler-project/src/project.rs
@@ -260,8 +260,10 @@ impl Project {
             .context("No project found with the given path")
     }
 
-    /// Finds an existing project by its path or return `None` if there was none. Errors out if not found.
-    // TODO: find by git-dir instead!
+    /// Finds an existing project by path containment or returns `None` if there was no match.
+    ///
+    /// This deliberately does not match sibling linked worktrees. Callers that have explicitly
+    /// classified linked-worktree access can use [`Self::find_by_repository()`] instead.
     pub fn find_by_worktree_dir_opt(worktree_dir: &Path) -> anyhow::Result<Option<Project>> {
         let mut projects = crate::dangerously_list_projects_without_migration()?;
         // Sort projects by longest pathname to shortest.
@@ -290,6 +292,46 @@ impl Project {
             return Ok(None);
         };
         project.migrated().map(Some)
+    }
+
+    /// Find the registered project sharing `repo`'s common Git directory and bind the returned
+    /// metadata to this repository's worktree.
+    ///
+    /// This is an explicit linked-worktree routing boundary. Callers must classify the requested
+    /// operation before using it; general repository discovery should use
+    /// [`Self::find_by_worktree_dir()`] and retain its path-only behavior.
+    pub fn find_by_repository(repo: &gix::Repository) -> anyhow::Result<Project> {
+        Self::find_by_repository_opt(repo)?.context("No project found for the given repository")
+    }
+
+    /// Like [`Self::find_by_repository()`], but returns `None` when there is no common-directory
+    /// match.
+    pub fn find_by_repository_opt(repo: &gix::Repository) -> anyhow::Result<Option<Project>> {
+        let common_git_dir = gix::path::realpath(repo.common_dir())?;
+        for project in crate::dangerously_list_projects_without_migration()? {
+            let Ok(project) = project.migrated() else {
+                continue;
+            };
+            let Ok(project_repo) = project.open_isolated_repo() else {
+                continue;
+            };
+            let Ok(project_common_git_dir) = gix::path::realpath(project_repo.common_dir()) else {
+                continue;
+            };
+            if project_common_git_dir == common_git_dir {
+                return project.with_repository(repo).map(Some);
+            }
+        }
+        Ok(None)
+    }
+
+    pub(crate) fn with_repository(mut self, repo: &gix::Repository) -> anyhow::Result<Self> {
+        self.worktree_dir = repo
+            .workdir()
+            .context("Bare repositories aren't supported")?
+            .to_owned();
+        self.git_dir = repo.git_dir().to_owned();
+        Ok(self)
     }
 }
 

--- a/crates/gitbutler-project/tests/project/main.rs
+++ b/crates/gitbutler-project/tests/project/main.rs
@@ -39,6 +39,71 @@ fn set_storage_path_config(
     Ok(repo)
 }
 
+#[test]
+fn linked_worktree_resolves_registered_project() -> anyhow::Result<()> {
+    let data_dir = support::data_dir();
+    let tmp = tempfile::tempdir()?;
+    let main_worktree_dir = tmp.path().join("main");
+    let linked_worktree_dir = tmp.path().join("linked");
+
+    git_at_dir(tmp.path())
+        .args(["init"])
+        .arg(&main_worktree_dir)
+        .run();
+    git_at_dir(&main_worktree_dir)
+        .args(["commit", "--allow-empty", "-m", "initial commit"])
+        .run();
+    git_at_dir(&main_worktree_dir)
+        .args(["worktree", "add", "-b", "feature"])
+        .arg(&linked_worktree_dir)
+        .run();
+
+    let registered = gitbutler_project::add_at_app_data_dir(data_dir.path(), &main_worktree_dir)?
+        .unwrap_project();
+    assert!(
+        gitbutler_project::Project::find_by_worktree_dir_opt(&linked_worktree_dir)?.is_none(),
+        "path-only lookup must not route unsupported linked-worktree mutations"
+    );
+    let resolved = match gitbutler_project::add_with_best_effort_at_app_data_dir(
+        data_dir.path(),
+        &linked_worktree_dir,
+    )? {
+        gitbutler_project::AddProjectOutcome::AlreadyExists(project) => project,
+        other => panic!("expected the registered project, got {other:?}"),
+    };
+
+    assert_eq!(
+        resolved.id, registered.id,
+        "main and linked worktrees have one registered project identity"
+    );
+    assert_eq!(
+        resolved
+            .open_isolated_repo()?
+            .workdir()
+            .expect("linked repository is non-bare")
+            .canonicalize()?,
+        linked_worktree_dir.canonicalize()?,
+        "the resolved metadata stays bound to the invocation worktree"
+    );
+    assert_eq!(
+        gix::open(&linked_worktree_dir)?
+            .common_dir()
+            .canonicalize()?,
+        registered
+            .open_isolated_repo()?
+            .common_dir()
+            .canonicalize()?,
+        "the registered identity is the repository's common Git directory"
+    );
+    assert_eq!(
+        gitbutler_project::dangerously_list_projects_without_migration_with_path(data_dir.path())?
+            .len(),
+        1,
+        "resolving the linked worktree must not register a second project"
+    );
+    Ok(())
+}
+
 mod add {
     use super::*;
 


### PR DESCRIPTION
# fix(project): Route linked worktree identity

## 🧢 Changes

- Resolve registered project identity through the repository common directory.
- Keep the invoked worktree path for checkout-sensitive operations.
- Share configured GitButler storage across linked worktrees without enabling
  linked-worktree mutations.
- Cover lookup, context construction, and configured storage from linked
  checkouts.

## ☕️ Reasoning

A linked worktree has its own Git directory but belongs to the same repository
and GitButler project. Registry identity and storage are repository-scoped;
worktree files remain checkout-scoped.

This complements the worktree graph support in #14853. That work makes
registered worktree tips visible after context construction; this PR fixes the
earlier lookup needed to construct that context from a linked checkout. It does
not create, register, apply, or mutate worktrees.

For agentic coding, this makes isolated linked checkouts discover the existing
project without broadening their write authority.

## 🧪 Reproduction

```sh
cargo test -p gitbutler-project linked_worktree_resolves_registered_project
```

Before this fix, lookup from the linked checkout did not recognize the project
already registered from the main worktree.

## ✅ Verification

- Four focused regressions cover linked context, shared configured storage, and
  registered-project lookup.
- Rust, Tauri, Windows, SDK, and end-to-end GitHub checks passed.

Developed with carefully directed, manually reviewed AI assistance.

Co-Authored-By: GPT-5.6 Sol <codex@openai.com>
