### PR TITLE
fix(db): Clone read-only databases in memory

### DIFF
--- a/crates/but-db/Cargo.toml
+++ b/crates/but-db/Cargo.toml
@@ -11,7 +11,7 @@ description = "A place for defining metadata stored in a sqlite file"
 doctest = false
 
 [dependencies]
-rusqlite = { workspace = true, features = ["chrono"] }
+rusqlite = { workspace = true, features = ["backup", "chrono"] }
 serde.workspace = true
 anyhow.workspace = true
 chrono = { workspace = true, features = ["serde"] }
@@ -19,10 +19,10 @@ but-utils.workspace = true
 # other things
 tracing.workspace = true
 backoff.workspace = true
+tempfile.workspace = true
 
 
 [dev-dependencies]
-tempfile = "3.24.0"
 snapbox.workspace = true
 
 # for multi-process migration testing.

--- a/crates/but-db/src/handle.rs
+++ b/crates/but-db/src/handle.rs
@@ -1,7 +1,11 @@
-use std::path::{Path, PathBuf};
+use std::{
+    path::{Path, PathBuf},
+    time::{Duration, Instant},
+};
 
+use anyhow::Context as _;
 use but_utils::OnDemand;
-use rusqlite::OpenFlags;
+use rusqlite::{OpenFlags, backup::StepResult};
 use tracing::instrument;
 
 use crate::{CacheHandle, DbHandle, migration, migration::improve_concurrency};
@@ -29,18 +33,27 @@ impl DbHandle {
     /// Open the project database for read-only access if it already exists.
     ///
     /// Unlike [`Self::new_in_directory()`], this never creates parent directories,
-    /// creates the database file, or runs migrations.
+    /// creates the database file, or runs migrations. The returned handle owns a
+    /// writable in-memory clone whose changes are discarded when it is dropped.
     pub fn open_existing_read_only_in_directory(
         db_dir: impl AsRef<Path>,
     ) -> anyhow::Result<Option<Self>> {
         let db_file_path = Self::db_file_path(db_dir);
-        if !db_file_path.exists() {
+        if !db_file_path.try_exists().with_context(|| {
+            format!(
+                "Check whether project database exists at {}",
+                db_file_path.display()
+            )
+        })? {
             return Ok(None);
         }
-        Self::open_existing_read_only_at_path(db_file_path).map(Some)
+        open_existing_read_only_at_path_optional(db_file_path)
     }
 
-    /// Open an existing project database for read-only access.
+    /// Open an existing project database as a writable in-memory clone.
+    ///
+    /// The source is opened read-only and is never migrated. Changes made through
+    /// the returned handle are process-local and discarded when it is dropped.
     #[instrument(
         name = "DbHandle::open_existing_read_only_at_path",
         level = "trace",
@@ -49,9 +62,8 @@ impl DbHandle {
     )]
     pub fn open_existing_read_only_at_path(path: impl Into<PathBuf>) -> anyhow::Result<Self> {
         let path = path.into();
-        let conn = rusqlite::Connection::open_with_flags(&path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
-        let cache = cache_for_db_path(&path);
-        Ok(DbHandle { conn, path, cache })
+        open_existing_read_only_at_path_optional(path.clone())?
+            .ok_or_else(|| anyhow::anyhow!("Project database does not exist at {}", path.display()))
     }
 
     /// A new instance connecting to the project database at the given `path`.
@@ -76,6 +88,153 @@ impl DbHandle {
     }
 }
 
+fn open_existing_read_only_at_path_optional(path: PathBuf) -> anyhow::Result<Option<DbHandle>> {
+    if !path.try_exists().with_context(|| {
+        format!(
+            "Check whether project database exists at {}",
+            path.display()
+        )
+    })? {
+        return Ok(None);
+    }
+
+    let conn = clone_database_into_memory(&path)?;
+
+    let cache = OnDemand::new(|| Ok(CacheHandle::new_at_path(":memory:")));
+    Ok(Some(DbHandle { conn, path, cache }))
+}
+
+fn clone_database_into_memory(path: &Path) -> anyhow::Result<rusqlite::Connection> {
+    clone_database_into_memory_with(path, || Ok(()))
+}
+
+fn clone_database_into_memory_with(
+    path: &Path,
+    mut after_first_snapshot: impl FnMut() -> anyhow::Result<()>,
+) -> anyhow::Result<rusqlite::Connection> {
+    let started = Instant::now();
+    loop {
+        let first = SourceSnapshot::capture(path)?;
+        after_first_snapshot()?;
+        let second = SourceSnapshot::capture(path)?;
+        if first != second {
+            retry_changed_snapshot(started)?;
+            continue;
+        }
+
+        let clone = clone_snapshot_into_memory(&second)?;
+        if second == SourceSnapshot::capture(path)? {
+            return Ok(clone);
+        }
+        retry_changed_snapshot(started)?;
+    }
+}
+
+fn retry_changed_snapshot(started: Instant) -> anyhow::Result<()> {
+    if started.elapsed() >= migration::BUSY_TIMEOUT {
+        anyhow::bail!("Project database kept changing while copying it into memory");
+    }
+    std::thread::sleep(Duration::from_millis(10));
+    Ok(())
+}
+
+fn clone_snapshot_into_memory(snapshot: &SourceSnapshot) -> anyhow::Result<rusqlite::Connection> {
+    let temp_dir = tempfile::tempdir().context("Create private project database snapshot")?;
+    let snapshot_path = temp_dir.path().join(FILE_NAME);
+    std::fs::write(&snapshot_path, &snapshot.database)
+        .context("Materialize private project database snapshot")?;
+    if let Some(wal) = snapshot.wal.as_ref().filter(|wal| !wal.is_empty()) {
+        std::fs::write(sidecar_path(&snapshot_path, "-wal"), wal)
+            .context("Materialize private project database WAL snapshot")?;
+    }
+    clone_materialized_database_into_memory(&snapshot_path)
+}
+
+fn clone_materialized_database_into_memory(path: &Path) -> anyhow::Result<rusqlite::Connection> {
+    let source = rusqlite::Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .with_context(|| {
+            format!(
+                "Open private project database snapshot at {}",
+                path.display()
+            )
+        })?;
+    let page_size: i64 = source
+        .pragma_query_value(None, "page_size", |row| row.get(0))
+        .with_context(|| format!("Read project database page size at {}", path.display()))?;
+
+    let mut conn = rusqlite::Connection::open_in_memory()
+        .context("Create in-memory project database clone")?;
+    conn.pragma_update(None, "page_size", page_size)
+        .context("Match in-memory project database page size")?;
+
+    {
+        let backup = rusqlite::backup::Backup::new(&source, &mut conn)
+            .context("Start in-memory project database backup")?;
+        let mut contention_started = None;
+        loop {
+            match backup
+                .step(128)
+                .context("Copy project database into memory")?
+            {
+                StepResult::Done => break,
+                StepResult::More => contention_started = None,
+                StepResult::Busy => {
+                    let started = contention_started.get_or_insert_with(Instant::now);
+                    if started.elapsed() >= migration::BUSY_TIMEOUT {
+                        anyhow::bail!("Project database stayed busy while copying it into memory");
+                    }
+                    std::thread::sleep(Duration::from_millis(10));
+                }
+                StepResult::Locked => {
+                    let started = contention_started.get_or_insert_with(Instant::now);
+                    if started.elapsed() >= migration::BUSY_TIMEOUT {
+                        anyhow::bail!(
+                            "Project database stayed locked while copying it into memory"
+                        );
+                    }
+                    std::thread::sleep(Duration::from_millis(10));
+                }
+                _ => anyhow::bail!("In-memory project database backup returned an unknown result"),
+            }
+        }
+    }
+    improve_concurrency(&conn).context("Configure in-memory project database clone")?;
+
+    Ok(conn)
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct SourceSnapshot {
+    database: Vec<u8>,
+    wal: Option<Vec<u8>>,
+}
+
+impl SourceSnapshot {
+    fn capture(path: &Path) -> anyhow::Result<Self> {
+        Ok(Self {
+            database: std::fs::read(path)
+                .with_context(|| format!("Read project database at {}", path.display()))?,
+            wal: read_optional(&sidecar_path(path, "-wal"), "WAL")?,
+        })
+    }
+}
+
+fn read_optional(path: &Path, name: &str) -> anyhow::Result<Option<Vec<u8>>> {
+    match std::fs::read(path) {
+        Ok(bytes) => Ok(Some(bytes)),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(err) => {
+            Err(err).with_context(|| format!("Read project database {name} at {}", path.display()))
+        }
+    }
+}
+
+fn sidecar_path(path: &Path, suffix: &str) -> PathBuf {
+    let mut value = path.as_os_str().to_owned();
+    value.push(suffix);
+    value.into()
+}
+
 fn cache_for_db_path(path: &Path) -> OnDemand<CacheHandle> {
     if path == Path::new(":memory:") {
         return OnDemand::new(|| Ok(CacheHandle::new_at_path(":memory:")));
@@ -93,4 +252,85 @@ fn run_migrations(conn: &mut rusqlite::Connection) -> anyhow::Result<()> {
         Ok::<_, migration::Error>(())
     })?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn memory_clone_enables_foreign_keys() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        DbHandle::new_in_directory(tmp.path())?;
+
+        let clone = DbHandle::open_existing_read_only_in_directory(tmp.path())?
+            .expect("source database exists");
+        let enabled: bool = clone
+            .conn
+            .pragma_query_value(None, "foreign_keys", |row| row.get(0))?;
+
+        assert!(
+            enabled,
+            "writable clones must preserve foreign-key enforcement"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn checkpointed_snapshot_retries_concurrent_checkpoint() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        DbHandle::new_in_directory(tmp.path())?;
+        let path = DbHandle::db_file_path(tmp.path());
+        let mut inject_checkpoint = true;
+
+        let conn = clone_database_into_memory_with(&path, || {
+            if inject_checkpoint {
+                inject_checkpoint = false;
+                let mut writer = DbHandle::new_in_directory(tmp.path())?;
+                writer
+                    .branch_order_mut()?
+                    .set_order(&["refs/heads/A".to_owned()])?;
+            }
+            Ok(())
+        })?;
+        let clone = DbHandle {
+            conn,
+            path,
+            cache: OnDemand::new(|| Ok(CacheHandle::new_at_path(":memory:"))),
+        };
+
+        assert_eq!(
+            clone.branch_order().order_for_reference("refs/heads/A")?,
+            Some(vec!["refs/heads/A".to_owned()]),
+            "the retry must deserialize the stable post-checkpoint snapshot"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn source_snapshot_ignores_shm_and_tracks_wal_content() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let path = tmp.path().join("but.sqlite");
+        std::fs::write(&path, b"database")?;
+        let wal_path = sidecar_path(&path, "-wal");
+        let shm_path = sidecar_path(&path, "-shm");
+        std::fs::write(&wal_path, b"wal before")?;
+        std::fs::write(&shm_path, b"before")?;
+        let before = SourceSnapshot::capture(&path)?;
+
+        std::fs::write(&shm_path, b"after state")?;
+        assert_eq!(
+            before,
+            SourceSnapshot::capture(&path)?,
+            "SHM is derived coordination state and must not be copied"
+        );
+
+        std::fs::write(&wal_path, b"wal after")?;
+        assert_ne!(
+            before,
+            SourceSnapshot::capture(&path)?,
+            "snapshot guards must compare durable WAL content"
+        );
+        Ok(())
+    }
 }

--- a/crates/but-db/tests/db/handle.rs
+++ b/crates/but-db/tests/db/handle.rs
@@ -66,6 +66,278 @@ fn read_only_observes_existing_database() -> anyhow::Result<()> {
 }
 
 #[test]
+fn read_only_clone_discards_writes() -> anyhow::Result<()> {
+    let tmp = tempfile::tempdir()?;
+    {
+        let mut source = DbHandle::new_in_directory(tmp.path())?;
+        source
+            .branch_order_mut()?
+            .set_order(&["refs/heads/A".to_owned()])?;
+    }
+
+    {
+        let mut clone = DbHandle::open_existing_read_only_in_directory(tmp.path())?
+            .expect("database was created before read-only open");
+        clone
+            .branch_order_mut()?
+            .set_order(&["refs/heads/A".to_owned(), "refs/heads/B".to_owned()])?;
+        assert_eq!(
+            clone.branch_order().order_for_reference("refs/heads/B")?,
+            Some(vec!["refs/heads/A".to_owned(), "refs/heads/B".to_owned()]),
+            "the private clone should accept process-local writes"
+        );
+    }
+    assert!(
+        !tmp.path().join("but.sqlite-wal").exists() && !tmp.path().join("but.sqlite-shm").exists(),
+        "cloning a checkpointed database must not create source sidecars"
+    );
+
+    let source = DbHandle::new_in_directory(tmp.path())?;
+    assert_eq!(
+        source.branch_order().order_for_reference("refs/heads/B")?,
+        None,
+        "dropping the clone should discard its writes"
+    );
+    assert_eq!(
+        source.branch_order().order_for_reference("refs/heads/A")?,
+        Some(vec!["refs/heads/A".to_owned()]),
+        "the original source state should remain intact"
+    );
+    Ok(())
+}
+
+#[test]
+fn read_only_observes_database_at_uri_sensitive_path() -> anyhow::Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let db_dir = tmp.path().join("project data ? read only");
+    {
+        let mut db = DbHandle::new_in_directory(&db_dir)?;
+        db.branch_order_mut()?
+            .set_order(&["refs/heads/A".to_owned()])?;
+    }
+
+    let db = DbHandle::open_existing_read_only_in_directory(&db_dir)?
+        .expect("database was created before read-only open");
+    assert_eq!(
+        db.branch_order().order_for_reference("refs/heads/A")?,
+        Some(vec!["refs/heads/A".to_owned()])
+    );
+    Ok(())
+}
+
+#[test]
+fn read_only_observes_current_wal_while_writer_remains_open() -> anyhow::Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let mut writer = DbHandle::new_in_directory(tmp.path())?;
+    writer
+        .branch_order_mut()?
+        .set_order(&["refs/heads/A".to_owned()])?;
+    assert!(tmp.path().join("but.sqlite-wal").exists());
+
+    let first = DbHandle::open_existing_read_only_in_directory(tmp.path())?
+        .expect("writer created the database");
+    assert_eq!(
+        first.branch_order().order_for_reference("refs/heads/A")?,
+        Some(vec!["refs/heads/A".to_owned()])
+    );
+
+    writer
+        .branch_order_mut()?
+        .set_order(&["refs/heads/A".to_owned(), "refs/heads/B".to_owned()])?;
+    let second = DbHandle::open_existing_read_only_in_directory(tmp.path())?
+        .expect("writer kept the database open");
+    assert_eq!(
+        second.branch_order().order_for_reference("refs/heads/B")?,
+        Some(vec!["refs/heads/A".to_owned(), "refs/heads/B".to_owned()])
+    );
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn read_only_clone_works_when_directory_mode_overstates_writability() -> anyhow::Result<()> {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let tmp = tempfile::tempdir()?;
+    {
+        let mut writer = DbHandle::new_in_directory(tmp.path())?;
+        writer
+            .branch_order_mut()?
+            .set_order(&["refs/heads/A".to_owned()])?;
+    }
+    let db_path = tmp.path().join("but.sqlite");
+    let wal_path = tmp.path().join("but.sqlite-wal");
+    let shm_path = tmp.path().join("but.sqlite-shm");
+    assert!(
+        !wal_path.exists() && !shm_path.exists(),
+        "a cleanly closed WAL database should start without coordination sidecars"
+    );
+    let original_db = std::fs::read(&db_path)?;
+    let original_dir_permissions = std::fs::metadata(tmp.path())?.permissions();
+
+    // The owner can traverse and read the directory but cannot create files. Group and other
+    // write bits keep Permissions::readonly() false, reproducing a sandbox policy that is stricter
+    // than the visible Unix mode bits.
+    std::fs::set_permissions(tmp.path(), std::fs::Permissions::from_mode(0o577))?;
+    let open_result = (|| -> anyhow::Result<()> {
+        let clone = DbHandle::open_existing_read_only_in_directory(tmp.path())?
+            .expect("database existed before directory writes were denied");
+        assert_eq!(
+            clone.branch_order().order_for_reference("refs/heads/A")?,
+            Some(vec!["refs/heads/A".to_owned()]),
+            "the private snapshot must preserve the last checkpointed state"
+        );
+        Ok(())
+    })();
+    std::fs::set_permissions(tmp.path(), original_dir_permissions)?;
+
+    open_result?;
+    assert_eq!(
+        std::fs::read(&db_path)?,
+        original_db,
+        "the private snapshot must not modify the source database"
+    );
+    assert!(
+        !wal_path.exists() && !shm_path.exists(),
+        "the private snapshot must not create source coordination sidecars"
+    );
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn read_only_clone_opens_physically_read_only_database_without_sidecars() -> anyhow::Result<()> {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let tmp = tempfile::tempdir()?;
+    {
+        let mut writer = DbHandle::new_in_directory(tmp.path())?;
+        writer
+            .branch_order_mut()?
+            .set_order(&["refs/heads/A".to_owned()])?;
+    }
+    let db_path = tmp.path().join("but.sqlite");
+    let wal_path = tmp.path().join("but.sqlite-wal");
+    let shm_path = tmp.path().join("but.sqlite-shm");
+    assert!(!wal_path.exists() && !shm_path.exists());
+    let original_db = std::fs::read(&db_path)?;
+    let original_db_permissions = std::fs::metadata(&db_path)?.permissions();
+    let original_dir_permissions = std::fs::metadata(tmp.path())?.permissions();
+    std::fs::set_permissions(&db_path, std::fs::Permissions::from_mode(0o444))?;
+    std::fs::set_permissions(tmp.path(), std::fs::Permissions::from_mode(0o555))?;
+
+    let open_result = (|| -> anyhow::Result<()> {
+        let clone = DbHandle::open_existing_read_only_in_directory(tmp.path())?
+            .expect("database existed before its directory became read-only");
+        assert_eq!(
+            clone.branch_order().order_for_reference("refs/heads/A")?,
+            Some(vec!["refs/heads/A".to_owned()])
+        );
+        Ok(())
+    })();
+
+    std::fs::set_permissions(tmp.path(), original_dir_permissions)?;
+    std::fs::set_permissions(&db_path, original_db_permissions)?;
+    open_result?;
+    assert_eq!(std::fs::read(&db_path)?, original_db);
+    assert!(
+        !wal_path.exists() && !shm_path.exists(),
+        "opening a physically read-only database must not require sidecars"
+    );
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn read_only_clone_observes_wal_in_physically_read_only_database() -> anyhow::Result<()> {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let source = tempfile::tempdir()?;
+    let mut writer = DbHandle::new_in_directory(source.path())?;
+    writer
+        .branch_order_mut()?
+        .set_order(&["refs/heads/A".to_owned()])?;
+    let tmp = tempfile::tempdir()?;
+    for name in ["but.sqlite", "but.sqlite-wal", "but.sqlite-shm"] {
+        std::fs::copy(source.path().join(name), tmp.path().join(name))?;
+    }
+    let paths = [
+        tmp.path().join("but.sqlite"),
+        tmp.path().join("but.sqlite-wal"),
+        tmp.path().join("but.sqlite-shm"),
+    ];
+    let original_files = paths
+        .iter()
+        .map(|path| Ok((std::fs::read(path)?, std::fs::metadata(path)?.permissions())))
+        .collect::<std::io::Result<Vec<_>>>()?;
+    let original_dir_permissions = std::fs::metadata(tmp.path())?.permissions();
+    for path in &paths {
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o444))?;
+    }
+    std::fs::set_permissions(tmp.path(), std::fs::Permissions::from_mode(0o555))?;
+
+    let open_result = (|| -> anyhow::Result<()> {
+        let clone = DbHandle::open_existing_read_only_in_directory(tmp.path())?
+            .expect("database existed before its directory became read-only");
+        assert_eq!(
+            clone.branch_order().order_for_reference("refs/heads/A")?,
+            Some(vec!["refs/heads/A".to_owned()]),
+            "the in-memory clone must include committed source WAL state"
+        );
+        Ok(())
+    })();
+
+    std::fs::set_permissions(tmp.path(), original_dir_permissions)?;
+    for (path, (_, permissions)) in paths.iter().zip(&original_files) {
+        std::fs::set_permissions(path, permissions.clone())?;
+    }
+    open_result?;
+    for (path, (bytes, _)) in paths.iter().zip(&original_files) {
+        assert_eq!(
+            std::fs::read(path)?,
+            *bytes,
+            "read-only cloning must not modify source state in {}",
+            path.display()
+        );
+    }
+    drop(writer);
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn read_only_reports_unreadable_wal_without_modifying_it() -> anyhow::Result<()> {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let tmp = tempfile::tempdir()?;
+    let mut writer = DbHandle::new_in_directory(tmp.path())?;
+    writer
+        .branch_order_mut()?
+        .set_order(&["refs/heads/A".to_owned()])?;
+    let wal_path = tmp.path().join("but.sqlite-wal");
+    let wal_bytes = std::fs::read(&wal_path)?;
+    let original_permissions = std::fs::metadata(&wal_path)?.permissions();
+    std::fs::set_permissions(&wal_path, std::fs::Permissions::from_mode(0o0))?;
+
+    let err = DbHandle::open_existing_read_only_in_directory(tmp.path())
+        .expect_err("SQLite must report an unreadable WAL instead of returning a partial clone");
+    std::fs::set_permissions(&wal_path, original_permissions)?;
+
+    assert!(
+        err.chain().any(|cause| cause
+            .downcast_ref::<std::io::Error>()
+            .is_some_and(|err| err.kind() == std::io::ErrorKind::PermissionDenied)),
+        "PermissionDenied should remain downcastable in the error chain: {err:#}"
+    );
+    assert_eq!(
+        std::fs::read(&wal_path)?,
+        wal_bytes,
+        "a failed in-memory backup must not modify the source WAL"
+    );
+    Ok(())
+}
+
+#[test]
 fn in_parallel_with_threads() -> anyhow::Result<()> {
     let tmp = tempfile::tempdir()?;
     let num_threads = 2;


### PR DESCRIPTION
# fix(db): Clone read-only databases in memory

## 🧢 Changes

- Capture a stable database-and-WAL snapshot without opening the source through
  SQLite.
- Let SQLite rebuild derived SHM state in private writable storage, then back
  the result into `:memory:`.
- Retry bounded source changes and fail closed rather than returning a mixed
  snapshot.

## ☕️ Reasoning

A WAL database can be readable while its directory cannot create SQLite's
`-shm` coordination file. A normal read-only open then fails; `immutable=1`
avoids the sidecar but ignores WAL-only state and can return stale data.

This PR copies matching database and WAL bytes to private storage, lets SQLite
reconstruct SHM there, and backs the result into a disposable in-memory
connection. Source checks before and after backup prevent a concurrent writer
from producing a mixed snapshot. SHM is excluded because it is derived from the
database and WAL.

The change is isolated to the existing `but-db` observation path. It does not
make mutation commands work with read-only project storage. Relocating project
metadata remains the correct option when writes are intended.

For agentic coding in managed sandboxes, observation can include current WAL
state without granting project-directory writes merely for SQLite coordination.

## 🧪 Reproduction

```sh
cargo test -p but-db read_only_clone_works_when_directory_mode_overstates_writability
```

Before this fix, the observational open failed because SQLite could not create
source-directory coordination state. An immutable open was not a safe fallback
because it omitted committed WAL state.

## ✅ Verification

- Ten focused contracts cover physical read-only state, active WAL data,
  unreadable WAL files, discarded clone writes, and bounded concurrent changes.
- The full `but-db` suite passed: 154 tests, with one pre-existing migration
  stress test ignored.
- Successful and failed paths preserve source database, WAL, and SHM bytes and
  never create a missing source sidecar.
- Clippy, formatting, GitHub Rust/Tauri/Windows/E2E checks, and independent
  read-only review passed.

Developed with carefully directed, manually reviewed AI assistance.

Co-Authored-By: GPT-5.6 Sol <codex@openai.com>
