### PR TITLE
feat(but): prefer change ID in default `but status` output

### DIFF
--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -1728,22 +1728,20 @@ fn display_cli_commit_details(
     };
     let start_id = Span::styled(short_id.to_string(), t.cli_id);
 
-    let change_id =
-        if let (Some(short_change_id), Some(change_id)) = (short_change_id, &commit.change_id) {
-            let change_id_str = change_id.to_string();
-            let hint_end = 3.min(change_id_str.len());
-            let hint = change_id_str
-                .get(short_change_id.len()..hint_end)
-                .unwrap_or("")
-                .to_string();
-            vec![
-                Span::styled(short_change_id.to_string(), t.change_id),
-                Span::styled(hint, t.hint),
-                Span::raw(" "),
-            ]
-        } else {
-            vec![]
-        };
+    let change_id_spans = if let Some(short_change_id) = short_change_id {
+        let change_id_str = commit.change_id().to_string();
+        let hint_end = 3.min(change_id_str.len());
+        let hint = change_id_str
+            .get(short_change_id.len()..hint_end)
+            .unwrap_or("")
+            .to_string();
+        vec![
+            Span::styled(short_change_id.to_string(), t.change_id),
+            Span::styled(hint, t.hint),
+        ]
+    } else {
+        vec![]
+    };
 
     let no_changes = if has_changes {
         None
@@ -1761,9 +1759,15 @@ fn display_cli_commit_details(
         // No message when verbose since it goes to the next line
         let created_at = commit.author.time;
         let formatted_time = created_at.format_or_unix(CLI_DATE);
+
+        let mut change_id_spans = change_id_spans;
+        if !change_id_spans.is_empty() {
+            change_id_spans.push(Span::raw(" "));
+        }
+
         (
             CommitLineContent {
-                change_id,
+                change_id: change_id_spans,
                 sha: Vec::from_iter([start_id, end_id]),
                 author: Vec::from_iter([Span::raw(" "), Span::raw(commit.author.name.to_string())]),
                 message: Vec::new(),
@@ -1781,8 +1785,12 @@ fn display_cli_commit_details(
         let message = Span::styled(format!("{}", message.content), message.style);
         (
             CommitLineContent {
-                sha: Vec::from([start_id, end_id]),
-                change_id,
+                sha: if change_id_spans.is_empty() {
+                    Vec::from([start_id, end_id])
+                } else {
+                    vec![]
+                },
+                change_id: change_id_spans,
                 author: Vec::new(),
                 message: Vec::from_iter([Span::raw(" "), message]),
                 suffix: maybe_with_leading_space(no_changes, conflicted),

--- a/crates/but/src/command/legacy/status/tui/tests/commit_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/commit_tests.rs
@@ -84,7 +84,7 @@ fn commiting_with_no_uncommitted_changes() {
         ]);
 
     tui.input(KeyCode::Enter)
-        .assert_current_line_eq(str!["┊●   1 f184fc7 (no commit message) (no changes)"])
+        .assert_current_line_eq(str!["┊●   1 (no commit message) (no changes)"])
         .assert_rendered_term_svg_eq(file![
             "snapshots/commiting_with_no_uncommitted_changes_003.svg"
         ]);
@@ -117,11 +117,11 @@ fn commit_from_unstaged_changes_creates_commit_visible_in_tui() {
 
     with_var("GIT_EDITOR", Some(editor_command), || {
         tui.input(KeyCode::Enter)
-            .assert_current_line_eq(str!["┊●   1 48fdc38 commit from tui test"]);
+            .assert_current_line_eq(str!["┊●   1 commit from tui test"]);
     });
 
     tui.reload()
-        .assert_current_line_eq(str!["┊●   1 48fdc38 commit from tui test"])
+        .assert_current_line_eq(str!["┊●   1 commit from tui test"])
         .assert_rendered_term_svg_eq(file![
             "snapshots/commit_from_unstaged_changes_creates_commit_visible_in_tui_final.svg"
         ]);
@@ -154,11 +154,11 @@ fn commit_from_unstaged_changes_to_new_branch_creates_branch_and_commit() {
 
     with_var("GIT_EDITOR", Some(editor_command), || {
         tui.input('b')
-            .assert_current_line_eq(str!["┊●   1 48fdc38 commit from tui test"]);
+            .assert_current_line_eq(str!["┊●   1 commit from tui test"]);
     });
 
     tui.reload()
-        .assert_current_line_eq(str!["┊●   1 48fdc38 commit from tui test"])
+        .assert_current_line_eq(str!["┊●   1 commit from tui test"])
         .assert_rendered_term_svg_eq(file![
             "snapshots/commit_from_unstaged_changes_to_new_branch_creates_branch_and_commit_final.svg"
         ]);
@@ -197,7 +197,7 @@ fn commit_from_unstaged_changes_with_multiple_hunks_in_same_file_commits_all_cha
 
     with_var("GIT_EDITOR", Some(editor_command.clone()), || {
         tui.input(KeyCode::Enter)
-            .assert_current_line_eq(str!["┊●   1 7f81dac commit from tui test"]);
+            .assert_current_line_eq(str!["┊●   1 commit from tui test"]);
     });
 
     let changed = base
@@ -226,7 +226,7 @@ fn commit_from_unstaged_changes_with_multiple_hunks_in_same_file_commits_all_cha
 
     with_var("GIT_EDITOR", Some(editor_command), || {
         tui.input(KeyCode::Enter)
-            .assert_current_line_eq(str!["┊●   1#0 ab9015b commit from tui test"]);
+            .assert_current_line_eq(str!["┊●   1#0 commit from tui test"]);
     });
 
     let status = tui.env().invoke_git("status --porcelain");
@@ -292,11 +292,11 @@ fn commit_to_commit_above_creates_commit_visible_in_tui() {
 
     with_var("GIT_EDITOR", Some(editor_command), || {
         tui.input(KeyCode::Enter)
-            .assert_current_line_eq(str!["┊●   1 48fdc38 commit from tui test"]);
+            .assert_current_line_eq(str!["┊●   1 commit from tui test"]);
     });
 
     tui.reload()
-        .assert_current_line_eq(str!["┊●   1 48fdc38 commit from tui test"])
+        .assert_current_line_eq(str!["┊●   1 commit from tui test"])
         .assert_rendered_term_svg_eq(file![
             "snapshots/commit_to_commit_above_creates_commit_visible_in_tui_final_002.svg"
         ]);
@@ -333,11 +333,11 @@ fn commit_to_commit_below_creates_commit_visible_in_tui() {
 
     with_var("GIT_EDITOR", Some(editor_command), || {
         tui.input(KeyCode::Enter)
-            .assert_current_line_eq(str!["┊●   1 584b4d0 commit from tui test"]);
+            .assert_current_line_eq(str!["┊●   1 commit from tui test"]);
     });
 
     tui.reload()
-        .assert_current_line_eq(str!["┊●   1 584b4d0 commit from tui test"])
+        .assert_current_line_eq(str!["┊●   1 commit from tui test"])
         .assert_rendered_term_svg_eq(file![
             "snapshots/commit_to_commit_below_creates_commit_visible_in_tui_final.svg"
         ]);
@@ -429,13 +429,13 @@ fn commit_with_inline_reword() {
         .assert_rendered_term_svg_eq(file!["snapshots/commit_with_inline_reword_004.svg"]);
 
     tui.input(KeyCode::Enter)
-        .assert_current_line_eq(str!["┊●   1 6bdd3d2"]);
+        .assert_current_line_eq(str!["┊●   1"]);
 
     tui.input("commit message here")
-        .assert_current_line_eq(str!["┊●   1 6bdd3d2 commit message here"]);
+        .assert_current_line_eq(str!["┊●   1 commit message here"]);
 
     tui.input(KeyCode::Enter)
-        .assert_current_line_eq(str!["┊●   1 072c144 commit message here"]);
+        .assert_current_line_eq(str!["┊●   1 commit message here"]);
 }
 
 #[test]

--- a/crates/but/src/command/legacy/status/tui/tests/discard_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/discard_tests.rs
@@ -125,10 +125,10 @@ fn discard_top_commit_selects_next_commit_in_branch() {
         .assert_current_line_eq(str!["┊╭┄g0 [A]"]);
 
     tui.input('n')
-        .assert_current_line_eq(str!["┊●   1 f184fc7 (no commit message) (no changes)"]);
+        .assert_current_line_eq(str!["┊●   1 (no commit message) (no changes)"]);
 
     tui.input('n')
-        .assert_current_line_eq(str!["┊●   1#0 9638f28 (no commit message) (no changes)"]);
+        .assert_current_line_eq(str!["┊●   1#0 (no commit message) (no changes)"]);
 
     tui.input('x')
         .assert_rendered_contains("Discard commit")
@@ -137,7 +137,7 @@ fn discard_top_commit_selects_next_commit_in_branch() {
     tui.input('y');
 
     tui.reload()
-        .assert_current_line_eq(str!["┊●   1 f184fc7 (no commit message) (no changes)"]);
+        .assert_current_line_eq(str!["┊●   1 (no commit message) (no changes)"]);
 }
 
 #[test]
@@ -344,7 +344,7 @@ fn discard_individual_committed_files_from_local_file_list() {
         "snapshots/discard_individual_committed_files_from_local_file_list_006.svg"
     ]);
     tui.input('y')
-        .assert_current_line_eq(str!["┊●   1 0b42c46 (no commit message) (no changes)"])
+        .assert_current_line_eq(str!["┊●   1 (no commit message) (no changes)"])
         .assert_rendered_term_svg_eq(file![
             "snapshots/discard_individual_committed_files_from_local_file_list_007.svg"
         ])
@@ -432,7 +432,7 @@ fn discard_marked_committed_files_from_local_file_list() {
 
     tui.input('x');
     tui.input('y')
-        .assert_current_line_eq(str!["┊●   1 0b42c46 (no commit message) (no changes)"])
+        .assert_current_line_eq(str!["┊●   1 (no commit message) (no changes)"])
         .assert_backstack_eq([])
         .assert_rendered_term_svg_eq(file![
             "snapshots/discard_marked_committed_files_from_local_file_list_005.svg"

--- a/crates/but/src/command/legacy/status/tui/tests/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/mod.rs
@@ -566,11 +566,11 @@ fn creating_empty_commits() {
 
     tui.input('n')
         .assert_rendered_term_svg_eq(file!["snapshots/creating_empty_commits_002.svg"])
-        .assert_current_line_eq(str!["┊●   1 f184fc7 (no commit message) (no changes)"]);
+        .assert_current_line_eq(str!["┊●   1 (no commit message) (no changes)"]);
 
     tui.input('n')
         .assert_rendered_term_svg_eq(file!["snapshots/creating_empty_commits_003.svg"])
-        .assert_current_line_eq(str!["┊●   1#0 9638f28 (no commit message) (no changes)"]);
+        .assert_current_line_eq(str!["┊●   1#0 (no commit message) (no changes)"]);
 }
 
 #[test]
@@ -589,7 +589,7 @@ fn inline_reword() {
 
     tui.input('n')
         .assert_rendered_term_svg_eq(file!["snapshots/inline_reword_002.svg"])
-        .assert_current_line_eq(str!["┊●   1 f184fc7 (no commit message) (no changes)"]);
+        .assert_current_line_eq(str!["┊●   1 (no commit message) (no changes)"]);
 
     tui.input(KeyCode::Enter)
         .assert_rendered_term_svg_eq(file!["snapshots/inline_reword_003.svg"]);
@@ -599,7 +599,7 @@ fn inline_reword() {
 
     tui.input(KeyCode::Enter)
         .assert_rendered_term_svg_eq(file!["snapshots/inline_reword_005.svg"])
-        .assert_current_line_eq(str!["┊●   1 cb96911 foo (no changes)"]);
+        .assert_current_line_eq(str!["┊●   1 foo (no changes)"]);
 }
 
 #[test]
@@ -826,7 +826,7 @@ fn rubbing() {
         .assert_current_line_eq(str!["┊╭┄g0 [A]"]);
 
     tui.input('n')
-        .assert_current_line_eq(str!["┊●   1 f184fc7 (no commit message) (no changes)"]);
+        .assert_current_line_eq(str!["┊●   1 (no commit message) (no changes)"]);
 
     tui.input([KeyCode::Up, KeyCode::Up])
         .assert_current_line_eq(str!["┊   v A test.txt"]);
@@ -835,7 +835,7 @@ fn rubbing() {
         .assert_current_line_eq(str!["┊   << source >> << noop >> v A test.txt"]);
 
     tui.input(KeyCode::Down).assert_current_line_eq(str![
-        "┊●   << amend >> 1 f184fc7 (no commit message) (no changes)"
+        "┊●   << amend >> 1 (no commit message) (no changes)"
     ]);
 
     tui.input(KeyCode::Down)
@@ -926,12 +926,12 @@ fn commit_file_toggle_on_commit_without_files_is_noop() {
     with_var("GIT_AUTHOR_DATE", Some("2000-01-01T00:00:00Z"), || {
         with_var("GIT_COMMITTER_DATE", Some("2000-01-01T00:00:00Z"), || {
             tui.input('n')
-                .assert_current_line_eq(str!["┊●   1 f184fc7 (no commit message) (no changes)"]);
+                .assert_current_line_eq(str!["┊●   1 (no commit message) (no changes)"]);
         });
     });
 
     tui.input('f')
-        .assert_current_line_eq(str!["┊●   1 f184fc7 (no commit message) (no changes)"]);
+        .assert_current_line_eq(str!["┊●   1 (no commit message) (no changes)"]);
 
     tui.input([KeyCode::Down, KeyCode::Down, KeyCode::Down])
         .assert_current_line_eq(str!["┴ 0dc3733 (common base) 2000-01-02 add M"])
@@ -1177,7 +1177,7 @@ fn consistent_commit_shas_in_tests() {
 
     tui.input('b');
     tui.input('n')
-        .assert_current_line_eq(str!["┊●   1 0b42c46 (no commit message) (no changes)"]);
+        .assert_current_line_eq(str!["┊●   1 (no commit message) (no changes)"]);
 }
 
 #[test]
@@ -1196,12 +1196,12 @@ fn jumping_up_down() {
     }
 
     tui.reload()
-        .assert_current_line_eq("┊●   1#0 0856e2b commit #12 (no changes)");
+        .assert_current_line_eq("┊●   1#0 commit #12 (no changes)");
 
     tui.input((KeyModifiers::CONTROL, 'd'))
-        .assert_current_line_eq("┊●   1#10 f2262ae commit #2 (no changes)");
+        .assert_current_line_eq("┊●   1#10 commit #2 (no changes)");
     tui.input((KeyModifiers::CONTROL, 'u'))
-        .assert_current_line_eq("┊●   1#0 0856e2b commit #12 (no changes)");
+        .assert_current_line_eq("┊●   1#0 commit #12 (no changes)");
 }
 
 #[test]
@@ -1226,7 +1226,7 @@ fn jumping_up_down_non_normal_mode() {
     tui.input('r');
 
     tui.input((KeyModifiers::CONTROL, 'd'))
-        .assert_current_line_eq("┊●   << amend >> 1#9 9a7be93 commit #3 (no changes)");
+        .assert_current_line_eq("┊●   << amend >> 1#9 commit #3 (no changes)");
     tui.input((KeyModifiers::CONTROL, 'u'))
         .assert_current_line_eq("╭┄<< source >> << noop >> zz [uncommitted]");
 }
@@ -1265,9 +1265,9 @@ fn maintains_selection_using_change_id() {
     tui.input(KeyCode::Enter);
     tui.input("target");
     tui.input(KeyCode::Enter)
-        .assert_current_line_eq(str![["┊●   1 f370b92 target (no changes)"]]);
+        .assert_current_line_eq(str!["┊●   1 target (no changes)"]);
 
     // undo the reword, this shouldn't change the selection
     tui.input('u')
-        .assert_current_line_eq(str![["┊●   1 0b42c46 (no commit message) (no changes)"]]);
+        .assert_current_line_eq(str!["┊●   1 (no commit message) (no changes)"]);
 }

--- a/crates/but/src/command/legacy/status/tui/tests/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/mod.rs
@@ -834,9 +834,8 @@ fn rubbing() {
     tui.input('r')
         .assert_current_line_eq(str!["┊   << source >> << noop >> v A test.txt"]);
 
-    tui.input(KeyCode::Down).assert_current_line_eq(str![
-        "┊●   << amend >> 1 (no commit message) (no changes)"
-    ]);
+    tui.input(KeyCode::Down)
+        .assert_current_line_eq(str!["┊●   << amend >> 1 (no commit message) (no changes)"]);
 
     tui.input(KeyCode::Down)
         .assert_current_line_eq(str!["┊●   << amend >> 9477ae7 add A"]);

--- a/crates/but/src/command/legacy/status/tui/tests/move_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/move_tests.rs
@@ -49,10 +49,10 @@ fn move_mode_keeps_selected_commit_and_extension_visible_when_scrolled() {
         .assert_current_line_eq(str!["┊╭┄g0 [A]"]);
 
     tui.input('n')
-        .assert_current_line_eq(str!["┊●   1 f184fc7 (no commit message) (no changes)"]);
+        .assert_current_line_eq(str!["┊●   1 (no commit message) (no changes)"]);
 
     tui.input('n')
-        .assert_current_line_eq(str!["┊●   1#0 9638f28 (no commit message) (no changes)"]);
+        .assert_current_line_eq(str!["┊●   1#0 (no commit message) (no changes)"]);
 
     tui.input([KeyCode::Down, KeyCode::Down])
         .assert_current_line_eq(str!["┊●   9477ae7 add A"]);
@@ -80,10 +80,10 @@ fn move_commit_above_other_commit_reorders_tui() {
         .assert_current_line_eq(str!["┊╭┄g0 [A]"]);
 
     tui.input('n')
-        .assert_current_line_eq(str!["┊●   1 f184fc7 (no commit message) (no changes)"]);
+        .assert_current_line_eq(str!["┊●   1 (no commit message) (no changes)"]);
 
     tui.input('n')
-        .assert_current_line_eq(str!["┊●   1#0 9638f28 (no commit message) (no changes)"]);
+        .assert_current_line_eq(str!["┊●   1#0 (no commit message) (no changes)"]);
 
     tui.input([KeyCode::Down, KeyCode::Down])
         .assert_current_line_eq(str!["┊●   9477ae7 add A"]);
@@ -98,7 +98,7 @@ fn move_commit_above_other_commit_reorders_tui() {
         .assert_current_line_eq(str!["┊│   << move commit above >>"]);
 
     tui.input(KeyCode::Enter)
-        .assert_current_line_eq(str!["┊●   tpm 2c72e58 add A"]);
+        .assert_current_line_eq(str!["┊●   tpm add A"]);
 
     tui = tui.recreate();
     tui.reload().assert_rendered_term_svg_eq(file![
@@ -117,16 +117,16 @@ fn move_commit_down_from_source_selects_next_commit() {
         .assert_current_line_eq(str!["┊╭┄g0 [A]"]);
 
     tui.input('n')
-        .assert_current_line_eq(str!["┊●   1 f184fc7 (no commit message) (no changes)"]);
+        .assert_current_line_eq(str!["┊●   1 (no commit message) (no changes)"]);
 
     tui.input('n')
-        .assert_current_line_eq(str!["┊●   1#0 9638f28 (no commit message) (no changes)"]);
+        .assert_current_line_eq(str!["┊●   1#0 (no commit message) (no changes)"]);
 
     tui.input(KeyCode::Down)
-        .assert_current_line_eq(str!["┊●   1#1 f184fc7 (no commit message) (no changes)"]);
+        .assert_current_line_eq(str!["┊●   1#1 (no commit message) (no changes)"]);
 
     tui.input('m').assert_current_line_eq(str![
-        "┊●   << source >> << noop >> 1#1 f184fc7 (no commit message) (no changes)"
+        "┊●   << source >> << noop >> 1#1 (no commit message) (no changes)"
     ]);
 
     tui.input(KeyCode::Down)

--- a/crates/but/src/command/legacy/status/tui/tests/rub_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/rub_tests.rs
@@ -35,9 +35,8 @@ fn rub_api_uncommitted_to_commit() {
     tui.input('r')
         .assert_current_line_eq(str!["┊   << source >> << noop >> v A test.txt"]);
 
-    tui.input(KeyCode::Down).assert_current_line_eq(str![
-        "┊●   << amend >> 1 (no commit message) (no changes)"
-    ]);
+    tui.input(KeyCode::Down)
+        .assert_current_line_eq(str!["┊●   << amend >> 1 (no commit message) (no changes)"]);
 
     tui.input(KeyCode::Enter)
         .assert_current_line_eq(str!["┊●   1 (no commit message)"])

--- a/crates/but/src/command/legacy/status/tui/tests/rub_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/rub_tests.rs
@@ -27,7 +27,7 @@ fn rub_api_uncommitted_to_commit() {
         .assert_current_line_eq(str!["┊╭┄g0 [A]"]);
 
     tui.input('n')
-        .assert_current_line_eq(str!["┊●   1 f184fc7 (no commit message) (no changes)"]);
+        .assert_current_line_eq(str!["┊●   1 (no commit message) (no changes)"]);
 
     tui.input([KeyCode::Up, KeyCode::Up])
         .assert_current_line_eq(str!["┊   v A test.txt"]);
@@ -36,11 +36,11 @@ fn rub_api_uncommitted_to_commit() {
         .assert_current_line_eq(str!["┊   << source >> << noop >> v A test.txt"]);
 
     tui.input(KeyCode::Down).assert_current_line_eq(str![
-        "┊●   << amend >> 1 f184fc7 (no commit message) (no changes)"
+        "┊●   << amend >> 1 (no commit message) (no changes)"
     ]);
 
     tui.input(KeyCode::Enter)
-        .assert_current_line_eq(str!["┊●   1 6bdd3d2 (no commit message)"])
+        .assert_current_line_eq(str!["┊●   1 (no commit message)"])
         .assert_rendered_term_svg_eq(file!["snapshots/rub_api_uncommitted_to_commit.svg"]);
 }
 

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/can_only_mark_files_from_one_commit_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/can_only_mark_files_from_one_commit_001.svg
@@ -18,11 +18,9 @@
     <text x="146" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
     <text x="50 58 66" y="78" style="fill:#AA00AA;font-weight:bold;">1#0</text>
-    <text x="82" y="78" style="fill:#0000AA;font-weight:bold;">b</text>
-    <text x="90 98 106 114 122 130" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">df06f9</text>
-    <text x="146 154 162" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="178 186 194 202 210 218" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="234 242 250 258 266 274 282 290" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82 90 98" y="96" style="fill:#0000AA;font-weight:bold;">1#0:o</text>
     <text x="114" y="96" style="fill:#CCCCCC;">A</text>
@@ -33,11 +31,9 @@
     <text x="130 138 146" y="114" style="fill:#00AA00;">two</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊●</text>
     <text x="50 58 66" y="132" style="fill:#AA00AA;">1#1</text>
-    <text x="82" y="132" style="fill:#0000AA;font-weight:bold;">4</text>
-    <text x="90 98 106 114 122 130" y="132" style="fill:#CCCCCC;opacity:0.75;">fea983</text>
-    <text x="146 154 162" y="132" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="178 186 194 202 210 218" y="132" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="234 242 250 258 266 274 282 290" y="132" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="82 90 98" y="132" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="132" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="132" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82 90 98" y="150" style="fill:#0000AA;font-weight:bold;">1#1:q</text>
     <text x="114" y="150" style="fill:#CCCCCC;">A</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/can_only_mark_files_from_one_commit_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/can_only_mark_files_from_one_commit_002.svg
@@ -19,11 +19,9 @@
     <text x="146" y="60" style="fill:#CCCCCC;opacity:0.75;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
     <text x="50 58 66" y="78" style="fill:#AA00AA;opacity:0.75;">1#0</text>
-    <text x="82" y="78" style="fill:#0000AA;font-weight:bold;opacity:0.75;">b</text>
-    <text x="90 98 106 114 122 130" y="78" style="fill:#CCCCCC;opacity:0.75;">df06f9</text>
-    <text x="146 154 162" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="178 186 194 202 210 218" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="234 242 250 258 266 274 282 290" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="96" style="fill:#000000;">✔︎</text>
     <text x="66 74 82 90 98" y="96" style="fill:#0000AA;font-weight:bold;">1#0:o</text>
@@ -35,11 +33,9 @@
     <text x="130 138 146" y="114" style="fill:#00AA00;font-weight:bold;">two</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊●</text>
     <text x="50 58 66" y="132" style="fill:#AA00AA;opacity:0.75;">1#1</text>
-    <text x="82" y="132" style="fill:#0000AA;font-weight:bold;opacity:0.75;">4</text>
-    <text x="90 98 106 114 122 130" y="132" style="fill:#CCCCCC;opacity:0.75;">fea983</text>
-    <text x="146 154 162" y="132" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="178 186 194 202 210 218" y="132" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="234 242 250 258 266 274 282 290" y="132" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="82 90 98" y="132" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="132" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="132" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82 90 98" y="150" style="fill:#0000AA;font-weight:bold;opacity:0.75;">1#1:q</text>
     <text x="114" y="150" style="fill:#CCCCCC;opacity:0.75;">A</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/can_only_mark_files_from_one_commit_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/can_only_mark_files_from_one_commit_003.svg
@@ -19,11 +19,9 @@
     <text x="146" y="60" style="fill:#CCCCCC;opacity:0.75;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
     <text x="50 58 66" y="78" style="fill:#AA00AA;opacity:0.75;">1#0</text>
-    <text x="82" y="78" style="fill:#0000AA;font-weight:bold;opacity:0.75;">b</text>
-    <text x="90 98 106 114 122 130" y="78" style="fill:#CCCCCC;opacity:0.75;">df06f9</text>
-    <text x="146 154 162" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="178 186 194 202 210 218" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="234 242 250 258 266 274 282 290" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="96" style="fill:#000000;">✔︎</text>
     <text x="66 74 82 90 98" y="96" style="fill:#0000AA;font-weight:bold;">1#0:o</text>
@@ -35,11 +33,9 @@
     <text x="130 138 146" y="114" style="fill:#00AA00;font-weight:bold;">two</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊●</text>
     <text x="50 58 66" y="132" style="fill:#AA00AA;opacity:0.75;">1#1</text>
-    <text x="82" y="132" style="fill:#0000AA;font-weight:bold;opacity:0.75;">4</text>
-    <text x="90 98 106 114 122 130" y="132" style="fill:#CCCCCC;opacity:0.75;">fea983</text>
-    <text x="146 154 162" y="132" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="178 186 194 202 210 218" y="132" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="234 242 250 258 266 274 282 290" y="132" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="82 90 98" y="132" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="132" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="132" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82 90 98" y="150" style="fill:#0000AA;font-weight:bold;opacity:0.75;">1#1:q</text>
     <text x="114" y="150" style="fill:#CCCCCC;opacity:0.75;">A</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/can_only_mark_files_from_one_commit_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/can_only_mark_files_from_one_commit_004.svg
@@ -20,11 +20,9 @@
     <text x="146" y="60" style="fill:#CCCCCC;opacity:0.75;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
     <text x="50 58 66" y="78" style="fill:#AA00AA;opacity:0.75;">1#0</text>
-    <text x="82" y="78" style="fill:#0000AA;font-weight:bold;opacity:0.75;">b</text>
-    <text x="90 98 106 114 122 130" y="78" style="fill:#CCCCCC;opacity:0.75;">df06f9</text>
-    <text x="146 154 162" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="178 186 194 202 210 218" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="234 242 250 258 266 274 282 290" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10" y="96" style="fill:#FFFFFF;font-weight:bold;">┊</text>
     <text x="18" y="96" style="fill:#000000;font-weight:bold;">✔︎</text>
     <text x="66 74 82 90 98" y="96" style="fill:#0000AA;font-weight:bold;">1#0:o</text>
@@ -36,11 +34,9 @@
     <text x="130 138 146" y="114" style="fill:#00AA00;">two</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊●</text>
     <text x="50 58 66" y="132" style="fill:#AA00AA;opacity:0.75;">1#1</text>
-    <text x="82" y="132" style="fill:#0000AA;font-weight:bold;opacity:0.75;">4</text>
-    <text x="90 98 106 114 122 130" y="132" style="fill:#CCCCCC;opacity:0.75;">fea983</text>
-    <text x="146 154 162" y="132" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="178 186 194 202 210 218" y="132" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="234 242 250 258 266 274 282 290" y="132" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="82 90 98" y="132" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="132" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="132" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82 90 98" y="150" style="fill:#0000AA;font-weight:bold;opacity:0.75;">1#1:q</text>
     <text x="114" y="150" style="fill:#CCCCCC;opacity:0.75;">A</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_file_toggle_on_commit_without_files_is_noop_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_file_toggle_on_commit_without_files_is_noop_final.svg
@@ -18,13 +18,11 @@
     <text x="74" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="78" style="fill:#AA00AA;">1</text>
-    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;">f</text>
-    <text x="74 82 90 98 106 114" y="78" style="fill:#CCCCCC;opacity:0.75;">184fc7</text>
-    <text x="130 138 146" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="162 170 178 186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="290 298 306" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="322 330 338 346 354 362 370 378" y="78" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="66 74 82" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="98 106 114 122 130 138" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="226 234 242" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="258 266 274 282 290 298 306 314" y="78" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="96" style="fill:#0000AA;font-weight:bold;">9</text>
     <text x="58 66 74 82 90 98" y="96" style="fill:#CCCCCC;opacity:0.75;">477ae7</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_from_unstaged_changes_creates_commit_visible_in_tui_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_from_unstaged_changes_creates_commit_visible_in_tui_final.svg
@@ -18,12 +18,10 @@
     <text x="74" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
     <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;">4</text>
-    <text x="74 82 90 98 106 114" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">8fdc38</text>
-    <text x="130 138 146 154 162 170" y="78" style="fill:#FFFFFF;font-weight:bold;">commit</text>
-    <text x="186 194 202 210" y="78" style="fill:#FFFFFF;font-weight:bold;">from</text>
-    <text x="226 234 242" y="78" style="fill:#FFFFFF;font-weight:bold;">tui</text>
-    <text x="258 266 274 282" y="78" style="fill:#FFFFFF;font-weight:bold;">test</text>
+    <text x="66 74 82 90 98 106" y="78" style="fill:#FFFFFF;font-weight:bold;">commit</text>
+    <text x="122 130 138 146" y="78" style="fill:#FFFFFF;font-weight:bold;">from</text>
+    <text x="162 170 178" y="78" style="fill:#FFFFFF;font-weight:bold;">tui</text>
+    <text x="194 202 210 218" y="78" style="fill:#FFFFFF;font-weight:bold;">test</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="96" style="fill:#0000AA;font-weight:bold;">9</text>
     <text x="58 66 74 82 90 98" y="96" style="fill:#CCCCCC;opacity:0.75;">477ae7</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_from_unstaged_changes_to_new_branch_creates_branch_and_commit_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_from_unstaged_changes_to_new_branch_creates_branch_and_commit_final.svg
@@ -18,12 +18,10 @@
     <text x="146" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
     <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;">4</text>
-    <text x="74 82 90 98 106 114" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">8fdc38</text>
-    <text x="130 138 146 154 162 170" y="78" style="fill:#FFFFFF;font-weight:bold;">commit</text>
-    <text x="186 194 202 210" y="78" style="fill:#FFFFFF;font-weight:bold;">from</text>
-    <text x="226 234 242" y="78" style="fill:#FFFFFF;font-weight:bold;">tui</text>
-    <text x="258 266 274 282" y="78" style="fill:#FFFFFF;font-weight:bold;">test</text>
+    <text x="66 74 82 90 98 106" y="78" style="fill:#FFFFFF;font-weight:bold;">commit</text>
+    <text x="122 130 138 146" y="78" style="fill:#FFFFFF;font-weight:bold;">from</text>
+    <text x="162 170 178" y="78" style="fill:#FFFFFF;font-weight:bold;">tui</text>
+    <text x="194 202 210 218" y="78" style="fill:#FFFFFF;font-weight:bold;">test</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="10 18 26" y="114" style="fill:#CCCCCC;">┊├┄</text>
     <text x="34 42" y="114" style="fill:#0000AA;font-weight:bold;">g0</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_to_commit_above_creates_commit_visible_in_tui_final_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_to_commit_above_creates_commit_visible_in_tui_final_002.svg
@@ -18,12 +18,10 @@
     <text x="74" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
     <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;">4</text>
-    <text x="74 82 90 98 106 114" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">8fdc38</text>
-    <text x="130 138 146 154 162 170" y="78" style="fill:#FFFFFF;font-weight:bold;">commit</text>
-    <text x="186 194 202 210" y="78" style="fill:#FFFFFF;font-weight:bold;">from</text>
-    <text x="226 234 242" y="78" style="fill:#FFFFFF;font-weight:bold;">tui</text>
-    <text x="258 266 274 282" y="78" style="fill:#FFFFFF;font-weight:bold;">test</text>
+    <text x="66 74 82 90 98 106" y="78" style="fill:#FFFFFF;font-weight:bold;">commit</text>
+    <text x="122 130 138 146" y="78" style="fill:#FFFFFF;font-weight:bold;">from</text>
+    <text x="162 170 178" y="78" style="fill:#FFFFFF;font-weight:bold;">tui</text>
+    <text x="194 202 210 218" y="78" style="fill:#FFFFFF;font-weight:bold;">test</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="96" style="fill:#0000AA;font-weight:bold;">9</text>
     <text x="58 66 74 82 90 98" y="96" style="fill:#CCCCCC;opacity:0.75;">477ae7</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_to_commit_below_creates_commit_visible_in_tui_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_to_commit_below_creates_commit_visible_in_tui_final.svg
@@ -19,18 +19,14 @@
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="78" style="fill:#AA00AA;">t</text>
     <text x="58 66" y="78" style="fill:#CCCCCC;opacity:0.75;">pm</text>
-    <text x="82" y="78" style="fill:#0000AA;font-weight:bold;">c</text>
-    <text x="90 98 106 114 122 130" y="78" style="fill:#CCCCCC;opacity:0.75;">1d8a48</text>
-    <text x="146 154 162" y="78" style="fill:#CCCCCC;">add</text>
-    <text x="178" y="78" style="fill:#CCCCCC;">A</text>
+    <text x="82 90 98" y="78" style="fill:#CCCCCC;">add</text>
+    <text x="114" y="78" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
     <text x="50" y="96" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66" y="96" style="fill:#0000AA;font-weight:bold;">5</text>
-    <text x="74 82 90 98 106 114" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">84b4d0</text>
-    <text x="130 138 146 154 162 170" y="96" style="fill:#FFFFFF;font-weight:bold;">commit</text>
-    <text x="186 194 202 210" y="96" style="fill:#FFFFFF;font-weight:bold;">from</text>
-    <text x="226 234 242" y="96" style="fill:#FFFFFF;font-weight:bold;">tui</text>
-    <text x="258 266 274 282" y="96" style="fill:#FFFFFF;font-weight:bold;">test</text>
+    <text x="66 74 82 90 98 106" y="96" style="fill:#FFFFFF;font-weight:bold;">commit</text>
+    <text x="122 130 138 146" y="96" style="fill:#FFFFFF;font-weight:bold;">from</text>
+    <text x="162 170 178" y="96" style="fill:#FFFFFF;font-weight:bold;">tui</text>
+    <text x="194 202 210 218" y="96" style="fill:#FFFFFF;font-weight:bold;">test</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="150" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_to_new_branch_from_uncommitted_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_to_new_branch_from_uncommitted_001.svg
@@ -18,11 +18,9 @@
     <text x="146" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
     <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;">2</text>
-    <text x="74 82 90 98 106 114" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">d299ac</text>
-    <text x="130 138 146" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="162 170 178 186 194 202" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="66 74 82" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="98 106 114 122 130 138" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commiting_with_no_uncommitted_changes_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commiting_with_no_uncommitted_changes_003.svg
@@ -18,13 +18,11 @@
     <text x="74" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
     <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;">f</text>
-    <text x="74 82 90 98 106 114" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">184fc7</text>
-    <text x="130 138 146" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="162 170 178 186 194 202" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
-    <text x="290 298 306" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="322 330 338 346 354 362 370 378" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
+    <text x="66 74 82" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="98 106 114 122 130 138" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="226 234 242" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="258 266 274 282 290 298 306 314" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="96" style="fill:#0000AA;font-weight:bold;">9</text>
     <text x="58 66 74 82 90 98" y="96" style="fill:#CCCCCC;opacity:0.75;">477ae7</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/creating_empty_commits_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/creating_empty_commits_002.svg
@@ -18,13 +18,11 @@
     <text x="74" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
     <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;">f</text>
-    <text x="74 82 90 98 106 114" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">184fc7</text>
-    <text x="130 138 146" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="162 170 178 186 194 202" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
-    <text x="290 298 306" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="322 330 338 346 354 362 370 378" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
+    <text x="66 74 82" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="98 106 114 122 130 138" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="226 234 242" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="258 266 274 282 290 298 306 314" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="96" style="fill:#0000AA;font-weight:bold;">9</text>
     <text x="58 66 74 82 90 98" y="96" style="fill:#CCCCCC;opacity:0.75;">477ae7</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/creating_empty_commits_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/creating_empty_commits_003.svg
@@ -18,22 +18,18 @@
     <text x="74" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
     <text x="50 58 66" y="78" style="fill:#AA00AA;font-weight:bold;">1#0</text>
-    <text x="82 90" y="78" style="fill:#0000AA;font-weight:bold;">96</text>
-    <text x="98 106 114 122 130" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">38f28</text>
-    <text x="146 154 162" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="178 186 194 202 210 218" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="234 242 250 258 266 274 282 290" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
-    <text x="306 314 322" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="338 346 354 362 370 378 386 394" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
+    <text x="82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="242 250 258" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="274 282 290 298 306 314 322 330" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
     <text x="50 58 66" y="96" style="fill:#AA00AA;">1#1</text>
-    <text x="82" y="96" style="fill:#0000AA;font-weight:bold;">f</text>
-    <text x="90 98 106 114 122 130" y="96" style="fill:#CCCCCC;opacity:0.75;">184fc7</text>
-    <text x="146 154 162" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="178 186 194 202 210 218" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="234 242 250 258 266 274 282 290" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="306 314 322" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="338 346 354 362 370 378 386 394" y="96" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="82 90 98" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="242 250 258" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="274 282 290 298 306 314 322 330" y="96" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊●</text>
     <text x="50 58" y="114" style="fill:#0000AA;font-weight:bold;">94</text>
     <text x="66 74 82 90 98" y="114" style="fill:#CCCCCC;opacity:0.75;">77ae7</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_hunk_from_detail_view_via_file_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_hunk_from_detail_view_via_file_001.svg
@@ -32,11 +32,9 @@
     <text x="146" y="132" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="150" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
     <text x="50" y="150" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66" y="150" style="fill:#0000AA;font-weight:bold;">0</text>
-    <text x="74 82 90 98 106 114" y="150" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">0d0cfb</text>
-    <text x="130 138 146" y="150" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="162 170 178 186 194 202" y="150" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="218 226 234 242 250 258 266 274" y="150" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="66 74 82" y="150" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="98 106 114 122 130 138" y="150" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="154 162 170 178 186 194 202 210" y="150" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
     <text x="10 18" y="168" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="186" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="204" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_hunk_from_detail_view_via_file_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_hunk_from_detail_view_via_file_002.svg
@@ -32,11 +32,9 @@
     <text x="146" y="132" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="150" style="fill:#AA00AA;">1</text>
-    <text x="66" y="150" style="fill:#0000AA;font-weight:bold;">0</text>
-    <text x="74 82 90 98 106 114" y="150" style="fill:#CCCCCC;opacity:0.75;">0d0cfb</text>
-    <text x="130 138 146" y="150" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="162 170 178 186 194 202" y="150" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="218 226 234 242 250 258 266 274" y="150" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="66 74 82" y="150" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="98 106 114 122 130 138" y="150" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="154 162 170 178 186 194 202 210" y="150" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="168" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="186" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="204" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_hunk_from_detail_view_via_file_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_hunk_from_detail_view_via_file_003.svg
@@ -55,11 +55,9 @@
     <text x="522 530" y="132" style="fill:#CCCCCC;opacity:0.75;">@@</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="150" style="fill:#AA00AA;">1</text>
-    <text x="66" y="150" style="fill:#0000AA;font-weight:bold;">0</text>
-    <text x="74 82 90 98 106 114" y="150" style="fill:#CCCCCC;opacity:0.75;">0d0cfb</text>
-    <text x="130 138 146" y="150" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="162 170 178 186 194 202" y="150" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="218 226 234 242 250 258 266 274" y="150" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="66 74 82" y="150" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="98 106 114 122 130 138" y="150" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="154 162 170 178 186 194 202 210" y="150" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="410" y="150" style="fill:#FFA500;">▌</text>
     <text x="418 426 434 442 450 458 466 474 482 490 498 506 514 522 530" y="150" style="fill:#555555;">───────────────</text>
     <text x="10 18" y="168" style="fill:#CCCCCC;">├╯</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_hunk_from_detail_view_via_file_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_hunk_from_detail_view_via_file_004.svg
@@ -50,11 +50,9 @@
     <text x="802" y="114" style="fill:#555555;">█</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="132" style="fill:#AA00AA;">1</text>
-    <text x="66" y="132" style="fill:#0000AA;font-weight:bold;">0</text>
-    <text x="74 82 90 98 106 114" y="132" style="fill:#CCCCCC;opacity:0.75;">0d0cfb</text>
-    <text x="130 138 146" y="132" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="162 170 178 186 194 202" y="132" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="218 226 234 242 250 258 266 274" y="132" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="66 74 82" y="132" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="98 106 114 122 130 138" y="132" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="154 162 170 178 186 194 202 210" y="132" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="410" y="132" style="fill:#555555;">│</text>
     <text x="418 426" y="132" style="fill:#CCCCCC;opacity:0.75;">@@</text>
     <text x="442 450 458 466" y="132" style="fill:#CCCCCC;opacity:0.75;">-1,0</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_global_file_list_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_global_file_list_001.svg
@@ -18,11 +18,9 @@
     <text x="146" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
     <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;">b</text>
-    <text x="74 82 90 98 106 114" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">1c0d33</text>
-    <text x="130 138 146" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="162 170 178 186 194 202" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="66 74 82" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="98 106 114 122 130 138" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">1:k</text>
     <text x="98" y="96" style="fill:#CCCCCC;">A</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_global_file_list_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_global_file_list_002.svg
@@ -21,11 +21,9 @@
     <text x="146" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="78" style="fill:#AA00AA;">1</text>
-    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;">b</text>
-    <text x="74 82 90 98 106 114" y="78" style="fill:#CCCCCC;opacity:0.75;">1c0d33</text>
-    <text x="130 138 146" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="162 170 178 186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="66 74 82" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="98 106 114 122 130 138" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
     <text x="66 74" y="96" style="fill:#000000;font-weight:bold;">&lt;&lt;</text>
     <text x="90 98 106 114 122 130 138" y="96" style="fill:#000000;font-weight:bold;">discard</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_global_file_list_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_global_file_list_003.svg
@@ -18,11 +18,9 @@
     <text x="146" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="78" style="fill:#AA00AA;">1</text>
-    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;">5</text>
-    <text x="74 82 90 98 106 114" y="78" style="fill:#CCCCCC;opacity:0.75;">fbe863</text>
-    <text x="130 138 146" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="162 170 178 186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="66 74 82" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="98 106 114 122 130 138" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">1:o</text>
     <text x="98" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_global_file_list_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_global_file_list_004.svg
@@ -18,11 +18,9 @@
     <text x="146" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="78" style="fill:#AA00AA;">1</text>
-    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;">c</text>
-    <text x="74 82 90 98 106 114" y="78" style="fill:#CCCCCC;opacity:0.75;">0dfd4e</text>
-    <text x="130 138 146" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="162 170 178 186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="66 74 82" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="98 106 114 122 130 138" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">1:t</text>
     <text x="98" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_global_file_list_005.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_global_file_list_005.svg
@@ -18,13 +18,11 @@
     <text x="146" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
     <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;">0</text>
-    <text x="74 82 90 98 106 114" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">b42c46</text>
-    <text x="130 138 146" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="162 170 178 186 194 202" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
-    <text x="290 298 306" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="322 330 338 346 354 362 370 378" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
+    <text x="66 74 82" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="98 106 114 122 130 138" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="226 234 242" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="258 266 274 282 290 298 306 314" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_001.svg
@@ -18,11 +18,9 @@
     <text x="146" y="60" style="fill:#CCCCCC;opacity:0.75;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="78" style="fill:#AA00AA;opacity:0.75;">1</text>
-    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;opacity:0.75;">b</text>
-    <text x="74 82 90 98 106 114" y="78" style="fill:#CCCCCC;opacity:0.75;">1c0d33</text>
-    <text x="130 138 146" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="162 170 178 186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="66 74 82" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="98 106 114 122 130 138" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">1:k</text>
     <text x="98" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_002.svg
@@ -21,11 +21,9 @@
     <text x="146" y="60" style="fill:#CCCCCC;opacity:0.75;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="78" style="fill:#AA00AA;opacity:0.75;">1</text>
-    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;opacity:0.75;">b</text>
-    <text x="74 82 90 98 106 114" y="78" style="fill:#CCCCCC;opacity:0.75;">1c0d33</text>
-    <text x="130 138 146" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="162 170 178 186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="66 74 82" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="98 106 114 122 130 138" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
     <text x="66 74" y="96" style="fill:#000000;font-weight:bold;">&lt;&lt;</text>
     <text x="90 98 106 114 122 130 138" y="96" style="fill:#000000;font-weight:bold;">discard</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_003.svg
@@ -18,11 +18,9 @@
     <text x="146" y="60" style="fill:#CCCCCC;opacity:0.75;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="78" style="fill:#AA00AA;opacity:0.75;">1</text>
-    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;opacity:0.75;">5</text>
-    <text x="74 82 90 98 106 114" y="78" style="fill:#CCCCCC;opacity:0.75;">fbe863</text>
-    <text x="130 138 146" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="162 170 178 186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="66 74 82" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="98 106 114 122 130 138" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">1:o</text>
     <text x="98" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_004.svg
@@ -19,11 +19,9 @@
     <text x="146" y="60" style="fill:#CCCCCC;opacity:0.75;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="78" style="fill:#AA00AA;opacity:0.75;">1</text>
-    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;opacity:0.75;">5</text>
-    <text x="74 82 90 98 106 114" y="78" style="fill:#CCCCCC;opacity:0.75;">fbe863</text>
-    <text x="130 138 146" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="162 170 178 186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="66 74 82" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="98 106 114 122 130 138" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">1:o</text>
     <text x="98" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_005.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_005.svg
@@ -18,11 +18,9 @@
     <text x="146" y="60" style="fill:#CCCCCC;opacity:0.75;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="78" style="fill:#AA00AA;opacity:0.75;">1</text>
-    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;opacity:0.75;">c</text>
-    <text x="74 82 90 98 106 114" y="78" style="fill:#CCCCCC;opacity:0.75;">0dfd4e</text>
-    <text x="130 138 146" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="162 170 178 186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="66 74 82" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="98 106 114 122 130 138" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">1:t</text>
     <text x="98" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_006.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_006.svg
@@ -19,11 +19,9 @@
     <text x="146" y="60" style="fill:#CCCCCC;opacity:0.75;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="78" style="fill:#AA00AA;opacity:0.75;">1</text>
-    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;opacity:0.75;">c</text>
-    <text x="74 82 90 98 106 114" y="78" style="fill:#CCCCCC;opacity:0.75;">0dfd4e</text>
-    <text x="130 138 146" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="162 170 178 186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="66 74 82" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="98 106 114 122 130 138" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">1:t</text>
     <text x="98" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_007.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_007.svg
@@ -18,13 +18,11 @@
     <text x="146" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
     <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;">0</text>
-    <text x="74 82 90 98 106 114" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">b42c46</text>
-    <text x="130 138 146" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="162 170 178 186 194 202" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
-    <text x="290 298 306" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="322 330 338 346 354 362 370 378" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
+    <text x="66 74 82" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="98 106 114 122 130 138" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="226 234 242" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="258 266 274 282 290 298 306 314" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_global_file_list_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_global_file_list_001.svg
@@ -18,11 +18,9 @@
     <text x="146" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
     <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;">b</text>
-    <text x="74 82 90 98 106 114" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">1c0d33</text>
-    <text x="130 138 146" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="162 170 178 186 194 202" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="66 74 82" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="98 106 114 122 130 138" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">1:k</text>
     <text x="98" y="96" style="fill:#CCCCCC;">A</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_global_file_list_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_global_file_list_002.svg
@@ -20,11 +20,9 @@
     <text x="146" y="60" style="fill:#CCCCCC;opacity:0.75;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="78" style="fill:#AA00AA;opacity:0.75;">1</text>
-    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;opacity:0.75;">b</text>
-    <text x="74 82 90 98 106 114" y="78" style="fill:#CCCCCC;opacity:0.75;">1c0d33</text>
-    <text x="130 138 146" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="162 170 178 186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="66 74 82" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="98 106 114 122 130 138" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="96" style="fill:#000000;">✔︎</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">1:k</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_global_file_list_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_global_file_list_003.svg
@@ -23,11 +23,9 @@
     <text x="146" y="60" style="fill:#CCCCCC;opacity:0.75;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="78" style="fill:#AA00AA;opacity:0.75;">1</text>
-    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;opacity:0.75;">b</text>
-    <text x="74 82 90 98 106 114" y="78" style="fill:#CCCCCC;opacity:0.75;">1c0d33</text>
-    <text x="130 138 146" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="162 170 178 186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="66 74 82" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="98 106 114 122 130 138" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="96" style="fill:#000000;">✔︎</text>
     <text x="66 74" y="96" style="fill:#000000;">&lt;&lt;</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_global_file_list_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_global_file_list_004.svg
@@ -18,11 +18,9 @@
     <text x="146" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="78" style="fill:#AA00AA;">1</text>
-    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;">c</text>
-    <text x="74 82 90 98 106 114" y="78" style="fill:#CCCCCC;opacity:0.75;">0dfd4e</text>
-    <text x="130 138 146" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="162 170 178 186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="66 74 82" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="98 106 114 122 130 138" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">1:t</text>
     <text x="98" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_global_file_list_005.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_global_file_list_005.svg
@@ -18,11 +18,9 @@
     <text x="146" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
     <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;">c</text>
-    <text x="74 82 90 98 106 114" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">0dfd4e</text>
-    <text x="130 138 146" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="162 170 178 186 194 202" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="66 74 82" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="98 106 114 122 130 138" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">1:t</text>
     <text x="98" y="96" style="fill:#CCCCCC;">A</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_local_file_list_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_local_file_list_001.svg
@@ -18,11 +18,9 @@
     <text x="146" y="60" style="fill:#CCCCCC;opacity:0.75;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="78" style="fill:#AA00AA;opacity:0.75;">1</text>
-    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;opacity:0.75;">b</text>
-    <text x="74 82 90 98 106 114" y="78" style="fill:#CCCCCC;opacity:0.75;">1c0d33</text>
-    <text x="130 138 146" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="162 170 178 186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="66 74 82" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="98 106 114 122 130 138" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">1:k</text>
     <text x="98" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_local_file_list_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_local_file_list_002.svg
@@ -20,11 +20,9 @@
     <text x="146" y="60" style="fill:#CCCCCC;opacity:0.75;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="78" style="fill:#AA00AA;opacity:0.75;">1</text>
-    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;opacity:0.75;">b</text>
-    <text x="74 82 90 98 106 114" y="78" style="fill:#CCCCCC;opacity:0.75;">1c0d33</text>
-    <text x="130 138 146" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="162 170 178 186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="66 74 82" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="98 106 114 122 130 138" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="96" style="fill:#000000;">✔︎</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">1:k</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_local_file_list_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_local_file_list_003.svg
@@ -23,11 +23,9 @@
     <text x="146" y="60" style="fill:#CCCCCC;opacity:0.75;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="78" style="fill:#AA00AA;opacity:0.75;">1</text>
-    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;opacity:0.75;">b</text>
-    <text x="74 82 90 98 106 114" y="78" style="fill:#CCCCCC;opacity:0.75;">1c0d33</text>
-    <text x="130 138 146" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="162 170 178 186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="66 74 82" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="98 106 114 122 130 138" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="96" style="fill:#000000;">✔︎</text>
     <text x="66 74" y="96" style="fill:#000000;">&lt;&lt;</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_local_file_list_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_local_file_list_004.svg
@@ -18,11 +18,9 @@
     <text x="146" y="60" style="fill:#CCCCCC;opacity:0.75;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="78" style="fill:#AA00AA;opacity:0.75;">1</text>
-    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;opacity:0.75;">c</text>
-    <text x="74 82 90 98 106 114" y="78" style="fill:#CCCCCC;opacity:0.75;">0dfd4e</text>
-    <text x="130 138 146" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="162 170 178 186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="66 74 82" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="98 106 114 122 130 138" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
     <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">1:t</text>
     <text x="98" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_local_file_list_005.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_local_file_list_005.svg
@@ -18,13 +18,11 @@
     <text x="146" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
     <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;">0</text>
-    <text x="74 82 90 98 106 114" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">b42c46</text>
-    <text x="130 138 146" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="162 170 178 186 194 202" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
-    <text x="290 298 306" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="322 330 338 346 354 362 370 378" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
+    <text x="66 74 82" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="98 106 114 122 130 138" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="226 234 242" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="258 266 274 282 290 298 306 314" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_multiple_commits_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_multiple_commits_final.svg
@@ -18,11 +18,9 @@
     <text x="146" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
     <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;">0</text>
-    <text x="74 82 90 98 106 114" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">707139</text>
-    <text x="130 138 146" y="78" style="fill:#FFFFFF;font-weight:bold;">two</text>
-    <text x="162 170 178" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="194 202 210 218 226 234 242 250" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
+    <text x="66 74 82" y="78" style="fill:#FFFFFF;font-weight:bold;">two</text>
+    <text x="98 106 114" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="130 138 146 154 162 170 178 186" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/inline_reword_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/inline_reword_002.svg
@@ -18,13 +18,11 @@
     <text x="74" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
     <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;">f</text>
-    <text x="74 82 90 98 106 114" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">184fc7</text>
-    <text x="130 138 146" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="162 170 178 186 194 202" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
-    <text x="290 298 306" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="322 330 338 346 354 362 370 378" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
+    <text x="66 74 82" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="98 106 114 122 130 138" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="226 234 242" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="258 266 274 282 290 298 306 314" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="96" style="fill:#0000AA;font-weight:bold;">9</text>
     <text x="58 66 74 82 90 98" y="96" style="fill:#CCCCCC;opacity:0.75;">477ae7</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/inline_reword_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/inline_reword_003.svg
@@ -18,8 +18,6 @@
     <text x="74" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
     <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;">f</text>
-    <text x="74 82 90 98 106 114" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">184fc7</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="96" style="fill:#0000AA;font-weight:bold;">9</text>
     <text x="58 66 74 82 90 98" y="96" style="fill:#CCCCCC;opacity:0.75;">477ae7</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/inline_reword_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/inline_reword_004.svg
@@ -18,9 +18,7 @@
     <text x="74" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
     <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;">f</text>
-    <text x="74 82 90 98 106 114" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">184fc7</text>
-    <text x="130 138 146" y="78" style="fill:#FFFFFF;font-weight:bold;">foo</text>
+    <text x="66 74 82" y="78" style="fill:#FFFFFF;font-weight:bold;">foo</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="96" style="fill:#0000AA;font-weight:bold;">9</text>
     <text x="58 66 74 82 90 98" y="96" style="fill:#CCCCCC;opacity:0.75;">477ae7</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/inline_reword_005.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/inline_reword_005.svg
@@ -18,11 +18,9 @@
     <text x="74" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
     <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;">c</text>
-    <text x="74 82 90 98 106 114" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">b96911</text>
-    <text x="130 138 146" y="78" style="fill:#FFFFFF;font-weight:bold;">foo</text>
-    <text x="162 170 178" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="194 202 210 218 226 234 242 250" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
+    <text x="66 74 82" y="78" style="fill:#FFFFFF;font-weight:bold;">foo</text>
+    <text x="98 106 114" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="130 138 146 154 162 170 178 186" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="96" style="fill:#0000AA;font-weight:bold;">9</text>
     <text x="58 66 74 82 90 98" y="96" style="fill:#CCCCCC;opacity:0.75;">477ae7</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/mark_and_commit_multiple_uncommitted_files_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/mark_and_commit_multiple_uncommitted_files_final.svg
@@ -20,11 +20,9 @@
     <text x="74" y="78" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
     <text x="50" y="96" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66" y="96" style="fill:#0000AA;font-weight:bold;">f</text>
-    <text x="74 82 90 98 106 114" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">4a3970</text>
-    <text x="130 138 146" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="162 170 178 186 194 202" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="218 226 234 242 250 258 266 274" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="66 74 82" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="98 106 114 122 130 138" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="154 162 170 178 186 194 202 210" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
     <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">1:k</text>
     <text x="98" y="114" style="fill:#CCCCCC;">A</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marks_are_maintained_after_leaving_rub_mode_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marks_are_maintained_after_leaving_rub_mode_001.svg
@@ -18,31 +18,25 @@
     <text x="74" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
     <text x="50 58 66" y="78" style="fill:#AA00AA;font-weight:bold;">1#0</text>
-    <text x="82 90" y="78" style="fill:#0000AA;font-weight:bold;">fe</text>
-    <text x="98 106 114 122 130" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">c7f68</text>
-    <text x="146 154 162" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="178 186 194 202 210 218" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="234 242 250 258 266 274 282 290" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
-    <text x="306 314 322" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="338 346 354 362 370 378 386 394" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
+    <text x="82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="242 250 258" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="274 282 290 298 306 314 322 330" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
     <text x="50 58 66" y="96" style="fill:#AA00AA;">1#1</text>
-    <text x="82 90" y="96" style="fill:#0000AA;font-weight:bold;">96</text>
-    <text x="98 106 114 122 130" y="96" style="fill:#CCCCCC;opacity:0.75;">38f28</text>
-    <text x="146 154 162" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="178 186 194 202 210 218" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="234 242 250 258 266 274 282 290" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="306 314 322" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="338 346 354 362 370 378 386 394" y="96" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="82 90 98" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="242 250 258" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="274 282 290 298 306 314 322 330" y="96" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊●</text>
     <text x="50 58 66" y="114" style="fill:#AA00AA;">1#2</text>
-    <text x="82 90" y="114" style="fill:#0000AA;font-weight:bold;">f1</text>
-    <text x="98 106 114 122 130" y="114" style="fill:#CCCCCC;opacity:0.75;">84fc7</text>
-    <text x="146 154 162" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="178 186 194 202 210 218" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="234 242 250 258 266 274 282 290" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="306 314 322" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="338 346 354 362 370 378 386 394" y="114" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="82 90 98" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="242 250 258" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="274 282 290 298 306 314 322 330" y="114" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊●</text>
     <text x="50 58" y="132" style="fill:#0000AA;font-weight:bold;">94</text>
     <text x="66 74 82 90 98" y="132" style="fill:#CCCCCC;opacity:0.75;">77ae7</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marks_are_maintained_after_leaving_rub_mode_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marks_are_maintained_after_leaving_rub_mode_002.svg
@@ -22,33 +22,27 @@
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="78" style="fill:#000000;">✔︎</text>
     <text x="50 58 66" y="78" style="fill:#AA00AA;">1#0</text>
-    <text x="82 90" y="78" style="fill:#0000AA;font-weight:bold;">fe</text>
-    <text x="98 106 114 122 130" y="78" style="fill:#CCCCCC;opacity:0.75;">c7f68</text>
-    <text x="146 154 162" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="178 186 194 202 210 218" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="234 242 250 258 266 274 282 290" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="306 314 322" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="338 346 354 362 370 378 386 394" y="78" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="242 250 258" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="274 282 290 298 306 314 322 330" y="78" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="96" style="fill:#000000;">✔︎</text>
     <text x="50 58 66" y="96" style="fill:#AA00AA;">1#1</text>
-    <text x="82 90" y="96" style="fill:#0000AA;font-weight:bold;">96</text>
-    <text x="98 106 114 122 130" y="96" style="fill:#CCCCCC;opacity:0.75;">38f28</text>
-    <text x="146 154 162" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="178 186 194 202 210 218" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="234 242 250 258 266 274 282 290" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="306 314 322" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="338 346 354 362 370 378 386 394" y="96" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="82 90 98" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="242 250 258" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="274 282 290 298 306 314 322 330" y="96" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="114" style="fill:#000000;">✔︎</text>
     <text x="50 58 66" y="114" style="fill:#AA00AA;">1#2</text>
-    <text x="82 90" y="114" style="fill:#0000AA;font-weight:bold;">f1</text>
-    <text x="98 106 114 122 130" y="114" style="fill:#CCCCCC;opacity:0.75;">84fc7</text>
-    <text x="146 154 162" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="178 186 194 202 210 218" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="234 242 250 258 266 274 282 290" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="306 314 322" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="338 346 354 362 370 378 386 394" y="114" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="82 90 98" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="242 250 258" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="274 282 290 298 306 314 322 330" y="114" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10 18" y="132" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
     <text x="50 58" y="132" style="fill:#0000AA;font-weight:bold;">94</text>
     <text x="66 74 82 90 98" y="132" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">77ae7</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marks_are_maintained_after_leaving_rub_mode_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marks_are_maintained_after_leaving_rub_mode_003.svg
@@ -30,39 +30,33 @@
     <text x="74 82 90 98 106 114" y="78" style="fill:#FFFFFF;">source</text>
     <text x="130 138" y="78" style="fill:#FFFFFF;">&gt;&gt;</text>
     <text x="154 162 170" y="78" style="fill:#AA00AA;">1#0</text>
-    <text x="186 194" y="78" style="fill:#0000AA;font-weight:bold;">fe</text>
-    <text x="202 210 218 226 234" y="78" style="fill:#CCCCCC;opacity:0.75;">c7f68</text>
-    <text x="250 258 266" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="282 290 298 306 314 322" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="338 346 354 362 370 378 386 394" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="410 418 426" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="442 450 458 466 474 482 490 498" y="78" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="218 226 234 242 250 258" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="274 282 290 298 306 314 322 330" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="346 354 362" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="378 386 394 402 410 418 426 434" y="78" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="96" style="fill:#000000;">✔︎</text>
     <text x="50 58" y="96" style="fill:#FFFFFF;">&lt;&lt;</text>
     <text x="74 82 90 98 106 114" y="96" style="fill:#FFFFFF;">source</text>
     <text x="130 138" y="96" style="fill:#FFFFFF;">&gt;&gt;</text>
     <text x="154 162 170" y="96" style="fill:#AA00AA;">1#1</text>
-    <text x="186 194" y="96" style="fill:#0000AA;font-weight:bold;">96</text>
-    <text x="202 210 218 226 234" y="96" style="fill:#CCCCCC;opacity:0.75;">38f28</text>
-    <text x="250 258 266" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="282 290 298 306 314 322" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="338 346 354 362 370 378 386 394" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="410 418 426" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="442 450 458 466 474 482 490 498" y="96" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="186 194 202" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="218 226 234 242 250 258" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="274 282 290 298 306 314 322 330" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="346 354 362" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="378 386 394 402 410 418 426 434" y="96" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="114" style="fill:#000000;">✔︎</text>
     <text x="50 58" y="114" style="fill:#FFFFFF;">&lt;&lt;</text>
     <text x="74 82 90 98 106 114" y="114" style="fill:#FFFFFF;">source</text>
     <text x="130 138" y="114" style="fill:#FFFFFF;">&gt;&gt;</text>
     <text x="154 162 170" y="114" style="fill:#AA00AA;">1#2</text>
-    <text x="186 194" y="114" style="fill:#0000AA;font-weight:bold;">f1</text>
-    <text x="202 210 218 226 234" y="114" style="fill:#CCCCCC;opacity:0.75;">84fc7</text>
-    <text x="250 258 266" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="282 290 298 306 314 322" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="338 346 354 362 370 378 386 394" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="410 418 426" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="442 450 458 466 474 482 490 498" y="114" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="186 194 202" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="218 226 234 242 250 258" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="274 282 290 298 306 314 322 330" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="346 354 362" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="378 386 394 402 410 418 426 434" y="114" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10 18" y="132" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
     <text x="50 58" y="132" style="fill:#000000;font-weight:bold;">&lt;&lt;</text>
     <text x="74 82 90 98 106 114" y="132" style="fill:#000000;font-weight:bold;">squash</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marks_are_maintained_after_leaving_rub_mode_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marks_are_maintained_after_leaving_rub_mode_004.svg
@@ -22,33 +22,27 @@
     <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="78" style="fill:#000000;">✔︎</text>
     <text x="50 58 66" y="78" style="fill:#AA00AA;">1#0</text>
-    <text x="82 90" y="78" style="fill:#0000AA;font-weight:bold;">fe</text>
-    <text x="98 106 114 122 130" y="78" style="fill:#CCCCCC;opacity:0.75;">c7f68</text>
-    <text x="146 154 162" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="178 186 194 202 210 218" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="234 242 250 258 266 274 282 290" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="306 314 322" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="338 346 354 362 370 378 386 394" y="78" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="242 250 258" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="274 282 290 298 306 314 322 330" y="78" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="96" style="fill:#000000;">✔︎</text>
     <text x="50 58 66" y="96" style="fill:#AA00AA;">1#1</text>
-    <text x="82 90" y="96" style="fill:#0000AA;font-weight:bold;">96</text>
-    <text x="98 106 114 122 130" y="96" style="fill:#CCCCCC;opacity:0.75;">38f28</text>
-    <text x="146 154 162" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="178 186 194 202 210 218" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="234 242 250 258 266 274 282 290" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="306 314 322" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="338 346 354 362 370 378 386 394" y="96" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="82 90 98" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="242 250 258" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="274 282 290 298 306 314 322 330" y="96" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="114" style="fill:#000000;">✔︎</text>
     <text x="50 58 66" y="114" style="fill:#AA00AA;">1#2</text>
-    <text x="82 90" y="114" style="fill:#0000AA;font-weight:bold;">f1</text>
-    <text x="98 106 114 122 130" y="114" style="fill:#CCCCCC;opacity:0.75;">84fc7</text>
-    <text x="146 154 162" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="178 186 194 202 210 218" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="234 242 250 258 266 274 282 290" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="306 314 322" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="338 346 354 362 370 378 386 394" y="114" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="82 90 98" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="242 250 258" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="274 282 290 298 306 314 322 330" y="114" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10 18" y="132" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
     <text x="50 58" y="132" style="fill:#0000AA;font-weight:bold;">94</text>
     <text x="66 74 82 90 98" y="132" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">77ae7</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/move_branch_onto_other_branch_reorders_stacks_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/move_branch_onto_other_branch_reorders_stacks_final.svg
@@ -19,10 +19,8 @@
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="78" style="fill:#AA00AA;">x</text>
     <text x="58 66" y="78" style="fill:#CCCCCC;opacity:0.75;">wn</text>
-    <text x="82" y="78" style="fill:#0000AA;font-weight:bold;">a</text>
-    <text x="90 98 106 114 122 130" y="78" style="fill:#CCCCCC;opacity:0.75;">72ac5a</text>
-    <text x="146 154 162" y="78" style="fill:#CCCCCC;">add</text>
-    <text x="178" y="78" style="fill:#CCCCCC;">C</text>
+    <text x="82 90 98" y="78" style="fill:#CCCCCC;">add</text>
+    <text x="114" y="78" style="fill:#CCCCCC;">C</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="10 18 26" y="114" style="fill:#CCCCCC;">┊├┄</text>
     <text x="34 42" y="114" style="fill:#0000AA;font-weight:bold;">h0</text>
@@ -32,10 +30,8 @@
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="132" style="fill:#AA00AA;">t</text>
     <text x="58 66" y="132" style="fill:#CCCCCC;opacity:0.75;">pm</text>
-    <text x="82" y="132" style="fill:#0000AA;font-weight:bold;">b</text>
-    <text x="90 98 106 114 122 130" y="132" style="fill:#CCCCCC;opacity:0.75;">4162d1</text>
-    <text x="146 154 162" y="132" style="fill:#CCCCCC;">add</text>
-    <text x="178" y="132" style="fill:#CCCCCC;">A</text>
+    <text x="82 90 98" y="132" style="fill:#CCCCCC;">add</text>
+    <text x="114" y="132" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊│</text>
     <text x="10 18 26" y="168" style="fill:#CCCCCC;">┊├┄</text>
     <text x="34 42" y="168" style="fill:#0000AA;font-weight:bold;">i0</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/move_branch_to_merge_base_tears_off_branch_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/move_branch_to_merge_base_tears_off_branch_final.svg
@@ -43,10 +43,8 @@
     <text x="10 18" y="222" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="222" style="fill:#AA00AA;">x</text>
     <text x="58 66" y="222" style="fill:#CCCCCC;opacity:0.75;">wn</text>
-    <text x="82" y="222" style="fill:#0000AA;font-weight:bold;">2</text>
-    <text x="90 98 106 114 122 130" y="222" style="fill:#CCCCCC;opacity:0.75;">0b5eda</text>
-    <text x="146 154 162" y="222" style="fill:#CCCCCC;">add</text>
-    <text x="178" y="222" style="fill:#CCCCCC;">C</text>
+    <text x="82 90 98" y="222" style="fill:#CCCCCC;">add</text>
+    <text x="114" y="222" style="fill:#CCCCCC;">C</text>
     <text x="10 18" y="240" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="258" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="276" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/move_commit_above_other_commit_reorders_tui_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/move_commit_above_other_commit_reorders_tui_final.svg
@@ -19,28 +19,22 @@
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="78" style="fill:#AA00AA;">t</text>
     <text x="58 66" y="78" style="fill:#CCCCCC;opacity:0.75;">pm</text>
-    <text x="82" y="78" style="fill:#0000AA;font-weight:bold;">2</text>
-    <text x="90 98 106 114 122 130" y="78" style="fill:#CCCCCC;opacity:0.75;">c72e58</text>
-    <text x="146 154 162" y="78" style="fill:#CCCCCC;">add</text>
-    <text x="178" y="78" style="fill:#CCCCCC;">A</text>
+    <text x="82 90 98" y="78" style="fill:#CCCCCC;">add</text>
+    <text x="114" y="78" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
     <text x="50 58 66" y="96" style="fill:#AA00AA;">1#0</text>
-    <text x="82" y="96" style="fill:#0000AA;font-weight:bold;">7</text>
-    <text x="90 98 106 114 122 130" y="96" style="fill:#CCCCCC;opacity:0.75;">149602</text>
-    <text x="146 154 162" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="178 186 194 202 210 218" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="234 242 250 258 266 274 282 290" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="306 314 322" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="338 346 354 362 370 378 386 394" y="96" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="82 90 98" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="242 250 258" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="274 282 290 298 306 314 322 330" y="96" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊●</text>
     <text x="50 58 66" y="114" style="fill:#AA00AA;">1#1</text>
-    <text x="82" y="114" style="fill:#0000AA;font-weight:bold;">0</text>
-    <text x="90 98 106 114 122 130" y="114" style="fill:#CCCCCC;opacity:0.75;">b42c46</text>
-    <text x="146 154 162" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="178 186 194 202 210 218" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="234 242 250 258 266 274 282 290" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="306 314 322" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="338 346 354 362 370 378 386 394" y="114" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="82 90 98" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="242 250 258" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="274 282 290 298 306 314 322 330" y="114" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="150" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/moves_the_cursor_back_to_a_valid_location_when_going_back_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/moves_the_cursor_back_to_a_valid_location_when_going_back_001.svg
@@ -20,31 +20,25 @@
     <text x="74" y="78" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
     <text x="50 58 66" y="96" style="fill:#AA00AA;font-weight:bold;">1#0</text>
-    <text x="82 90" y="96" style="fill:#0000AA;font-weight:bold;">fe</text>
-    <text x="98 106 114 122 130" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">c7f68</text>
-    <text x="146 154 162" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="178 186 194 202 210 218" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="234 242 250 258 266 274 282 290" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
-    <text x="306 314 322" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="338 346 354 362 370 378 386 394" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
+    <text x="82 90 98" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="242 250 258" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="274 282 290 298 306 314 322 330" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊●</text>
     <text x="50 58 66" y="114" style="fill:#AA00AA;">1#1</text>
-    <text x="82 90" y="114" style="fill:#0000AA;font-weight:bold;">96</text>
-    <text x="98 106 114 122 130" y="114" style="fill:#CCCCCC;opacity:0.75;">38f28</text>
-    <text x="146 154 162" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="178 186 194 202 210 218" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="234 242 250 258 266 274 282 290" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="306 314 322" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="338 346 354 362 370 378 386 394" y="114" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="82 90 98" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="242 250 258" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="274 282 290 298 306 314 322 330" y="114" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊●</text>
     <text x="50 58 66" y="132" style="fill:#AA00AA;">1#2</text>
-    <text x="82 90" y="132" style="fill:#0000AA;font-weight:bold;">f1</text>
-    <text x="98 106 114 122 130" y="132" style="fill:#CCCCCC;opacity:0.75;">84fc7</text>
-    <text x="146 154 162" y="132" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="178 186 194 202 210 218" y="132" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="234 242 250 258 266 274 282 290" y="132" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="306 314 322" y="132" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="338 346 354 362 370 378 386 394" y="132" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="82 90 98" y="132" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="132" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="132" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="242 250 258" y="132" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="274 282 290 298 306 314 322 330" y="132" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊●</text>
     <text x="50 58" y="150" style="fill:#0000AA;font-weight:bold;">94</text>
     <text x="66 74 82 90 98" y="150" style="fill:#CCCCCC;opacity:0.75;">77ae7</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/moves_the_cursor_back_to_a_valid_location_when_going_back_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/moves_the_cursor_back_to_a_valid_location_when_going_back_002.svg
@@ -30,38 +30,32 @@
     <text x="74 82 90 98 106 114" y="96" style="fill:#FFFFFF;">source</text>
     <text x="130 138" y="96" style="fill:#FFFFFF;">&gt;&gt;</text>
     <text x="154 162 170" y="96" style="fill:#AA00AA;">1#0</text>
-    <text x="186 194" y="96" style="fill:#0000AA;font-weight:bold;">fe</text>
-    <text x="202 210 218 226 234" y="96" style="fill:#CCCCCC;opacity:0.75;">c7f68</text>
-    <text x="250 258 266" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="282 290 298 306 314 322" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="338 346 354 362 370 378 386 394" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="410 418 426" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="442 450 458 466 474 482 490 498" y="96" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="186 194 202" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="218 226 234 242 250 258" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="274 282 290 298 306 314 322 330" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="346 354 362" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="378 386 394 402 410 418 426 434" y="96" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="114" style="fill:#000000;">✔︎</text>
     <text x="50 58" y="114" style="fill:#FFFFFF;">&lt;&lt;</text>
     <text x="74 82 90 98 106 114" y="114" style="fill:#FFFFFF;">source</text>
     <text x="130 138" y="114" style="fill:#FFFFFF;">&gt;&gt;</text>
     <text x="154 162 170" y="114" style="fill:#AA00AA;">1#1</text>
-    <text x="186 194" y="114" style="fill:#0000AA;font-weight:bold;">96</text>
-    <text x="202 210 218 226 234" y="114" style="fill:#CCCCCC;opacity:0.75;">38f28</text>
-    <text x="250 258 266" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="282 290 298 306 314 322" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="338 346 354 362 370 378 386 394" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="410 418 426" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="442 450 458 466 474 482 490 498" y="114" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="186 194 202" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="218 226 234 242 250 258" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="274 282 290 298 306 314 322 330" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="346 354 362" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="378 386 394 402 410 418 426 434" y="114" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10 18" y="132" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
     <text x="50 58" y="132" style="fill:#000000;font-weight:bold;">&lt;&lt;</text>
     <text x="74 82 90 98 106 114" y="132" style="fill:#000000;font-weight:bold;">squash</text>
     <text x="130 138" y="132" style="fill:#000000;font-weight:bold;">&gt;&gt;</text>
     <text x="154 162 170" y="132" style="fill:#AA00AA;font-weight:bold;">1#2</text>
-    <text x="186 194" y="132" style="fill:#0000AA;font-weight:bold;">f1</text>
-    <text x="202 210 218 226 234" y="132" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">84fc7</text>
-    <text x="250 258 266" y="132" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="282 290 298 306 314 322" y="132" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="338 346 354 362 370 378 386 394" y="132" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
-    <text x="410 418 426" y="132" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="442 450 458 466 474 482 490 498" y="132" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
+    <text x="186 194 202" y="132" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="218 226 234 242 250 258" y="132" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="274 282 290 298 306 314 322 330" y="132" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="346 354 362" y="132" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="378 386 394 402 410 418 426 434" y="132" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊●</text>
     <text x="50 58" y="150" style="fill:#0000AA;font-weight:bold;">94</text>
     <text x="66 74 82 90 98" y="150" style="fill:#CCCCCC;opacity:0.75;">77ae7</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/moves_the_cursor_back_to_a_valid_location_when_going_back_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/moves_the_cursor_back_to_a_valid_location_when_going_back_003.svg
@@ -34,35 +34,29 @@
     <text x="74 82 90 98 106 114" y="96" style="fill:#FFFFFF;">source</text>
     <text x="130 138" y="96" style="fill:#FFFFFF;">&gt;&gt;</text>
     <text x="154 162 170" y="96" style="fill:#AA00AA;">1#0</text>
-    <text x="186 194" y="96" style="fill:#0000AA;font-weight:bold;">fe</text>
-    <text x="202 210 218 226 234" y="96" style="fill:#CCCCCC;opacity:0.75;">c7f68</text>
-    <text x="250 258 266" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="282 290 298 306 314 322" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="338 346 354 362 370 378 386 394" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="410 418 426" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="442 450 458 466 474 482 490 498" y="96" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="186 194 202" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="218 226 234 242 250 258" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="274 282 290 298 306 314 322 330" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="346 354 362" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="378 386 394 402 410 418 426 434" y="96" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="114" style="fill:#000000;">✔︎</text>
     <text x="50 58" y="114" style="fill:#FFFFFF;">&lt;&lt;</text>
     <text x="74 82 90 98 106 114" y="114" style="fill:#FFFFFF;">source</text>
     <text x="130 138" y="114" style="fill:#FFFFFF;">&gt;&gt;</text>
     <text x="154 162 170" y="114" style="fill:#AA00AA;">1#1</text>
-    <text x="186 194" y="114" style="fill:#0000AA;font-weight:bold;">96</text>
-    <text x="202 210 218 226 234" y="114" style="fill:#CCCCCC;opacity:0.75;">38f28</text>
-    <text x="250 258 266" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="282 290 298 306 314 322" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="338 346 354 362 370 378 386 394" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="410 418 426" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="442 450 458 466 474 482 490 498" y="114" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="186 194 202" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="218 226 234 242 250 258" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="274 282 290 298 306 314 322 330" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="346 354 362" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="378 386 394 402 410 418 426 434" y="114" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊●</text>
     <text x="50 58 66" y="132" style="fill:#AA00AA;">1#2</text>
-    <text x="82 90" y="132" style="fill:#0000AA;font-weight:bold;">f1</text>
-    <text x="98 106 114 122 130" y="132" style="fill:#CCCCCC;opacity:0.75;">84fc7</text>
-    <text x="146 154 162" y="132" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="178 186 194 202 210 218" y="132" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="234 242 250 258 266 274 282 290" y="132" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="306 314 322" y="132" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="338 346 354 362 370 378 386 394" y="132" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="82 90 98" y="132" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="132" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="132" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="242 250 258" y="132" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="274 282 290 298 306 314 322 330" y="132" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊●</text>
     <text x="50 58" y="150" style="fill:#0000AA;font-weight:bold;">94</text>
     <text x="66 74 82 90 98" y="150" style="fill:#CCCCCC;opacity:0.75;">77ae7</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/moves_the_cursor_back_to_a_valid_location_when_going_back_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/moves_the_cursor_back_to_a_valid_location_when_going_back_004.svg
@@ -23,32 +23,26 @@
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="96" style="fill:#000000;">✔︎</text>
     <text x="50 58 66" y="96" style="fill:#AA00AA;">1#0</text>
-    <text x="82 90" y="96" style="fill:#0000AA;font-weight:bold;">fe</text>
-    <text x="98 106 114 122 130" y="96" style="fill:#CCCCCC;opacity:0.75;">c7f68</text>
-    <text x="146 154 162" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="178 186 194 202 210 218" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="234 242 250 258 266 274 282 290" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="306 314 322" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="338 346 354 362 370 378 386 394" y="96" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="82 90 98" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="242 250 258" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="274 282 290 298 306 314 322 330" y="96" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="114" style="fill:#000000;">✔︎</text>
     <text x="50 58 66" y="114" style="fill:#AA00AA;">1#1</text>
-    <text x="82 90" y="114" style="fill:#0000AA;font-weight:bold;">96</text>
-    <text x="98 106 114 122 130" y="114" style="fill:#CCCCCC;opacity:0.75;">38f28</text>
-    <text x="146 154 162" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="178 186 194 202 210 218" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="234 242 250 258 266 274 282 290" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="306 314 322" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="338 346 354 362 370 378 386 394" y="114" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="82 90 98" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="242 250 258" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="274 282 290 298 306 314 322 330" y="114" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊●</text>
     <text x="50 58 66" y="132" style="fill:#AA00AA;">1#2</text>
-    <text x="82 90" y="132" style="fill:#0000AA;font-weight:bold;">f1</text>
-    <text x="98 106 114 122 130" y="132" style="fill:#CCCCCC;opacity:0.75;">84fc7</text>
-    <text x="146 154 162" y="132" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="178 186 194 202 210 218" y="132" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="234 242 250 258 266 274 282 290" y="132" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="306 314 322" y="132" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="338 346 354 362 370 378 386 394" y="132" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="82 90 98" y="132" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="132" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="132" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="242 250 258" y="132" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="274 282 290 298 306 314 322 330" y="132" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊●</text>
     <text x="50 58" y="150" style="fill:#0000AA;font-weight:bold;">94</text>
     <text x="66 74 82 90 98" y="150" style="fill:#CCCCCC;opacity:0.75;">77ae7</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/rub_api_uncommitted_to_commit.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/rub_api_uncommitted_to_commit.svg
@@ -18,11 +18,9 @@
     <text x="74" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
     <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;">6</text>
-    <text x="74 82 90 98 106 114" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">bdd3d2</text>
-    <text x="130 138 146" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="162 170 178 186 194 202" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="66 74 82" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="98 106 114 122 130 138" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="96" style="fill:#0000AA;font-weight:bold;">9</text>
     <text x="58 66 74 82 90 98" y="96" style="fill:#CCCCCC;opacity:0.75;">477ae7</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/rub_multiple_commits_into_uncommitted_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/rub_multiple_commits_into_uncommitted_001.svg
@@ -32,22 +32,18 @@
     <text x="74 82 90 98 106 114" y="78" style="fill:#FFFFFF;">source</text>
     <text x="130 138" y="78" style="fill:#FFFFFF;">&gt;&gt;</text>
     <text x="154 162 170" y="78" style="fill:#AA00AA;">1#0</text>
-    <text x="186" y="78" style="fill:#0000AA;font-weight:bold;">a</text>
-    <text x="194 202 210 218 226 234" y="78" style="fill:#CCCCCC;opacity:0.75;">6018af</text>
-    <text x="250 258 266" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="282 290 298 306 314 322" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="338 346 354 362 370 378 386 394" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="218 226 234 242 250 258" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="274 282 290 298 306 314 322 330" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="96" style="fill:#000000;">✔︎</text>
     <text x="50 58" y="96" style="fill:#FFFFFF;">&lt;&lt;</text>
     <text x="74 82 90 98 106 114" y="96" style="fill:#FFFFFF;">source</text>
     <text x="130 138" y="96" style="fill:#FFFFFF;">&gt;&gt;</text>
     <text x="154 162 170" y="96" style="fill:#AA00AA;">1#1</text>
-    <text x="186" y="96" style="fill:#0000AA;font-weight:bold;">5</text>
-    <text x="194 202 210 218 226 234" y="96" style="fill:#CCCCCC;opacity:0.75;">bd308f</text>
-    <text x="250 258 266" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="282 290 298 306 314 322" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="338 346 354 362 370 378 386 394" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="186 194 202" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="218 226 234 242 250 258" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="274 282 290 298 306 314 322 330" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="150" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/rubbing_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/rubbing_003.svg
@@ -18,13 +18,11 @@
     <text x="74" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="78" style="fill:#AA00AA;">1</text>
-    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;">6</text>
-    <text x="74 82 90 98 106 114" y="78" style="fill:#CCCCCC;opacity:0.75;">78db78</text>
-    <text x="130 138 146" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="162 170 178 186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="290 298 306" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="322 330 338 346 354 362 370 378" y="78" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="66 74 82" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="98 106 114 122 130 138" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="226 234 242" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="258 266 274 282 290 298 306 314" y="78" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="96" style="fill:#0000AA;font-weight:bold;">8</text>
     <text x="58 66 74 82 90 98" y="96" style="fill:#CCCCCC;opacity:0.75;">474410</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/undo_opens_confirm_for_latest_snapshot_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/undo_opens_confirm_for_latest_snapshot_001.svg
@@ -18,11 +18,9 @@
     <text x="74" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
     <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66" y="78" style="fill:#0000AA;font-weight:bold;">6</text>
-    <text x="74 82 90 98 106 114" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">bdd3d2</text>
-    <text x="130 138 146" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="162 170 178 186 194 202" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="218 226 234 242 250 258 266 274" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="66 74 82" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="98 106 114 122 130 138" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="96" style="fill:#0000AA;font-weight:bold;">9</text>
     <text x="58 66 74 82 90 98" y="96" style="fill:#CCCCCC;opacity:0.75;">477ae7</text>

--- a/crates/but/tests/but/command/absorb.rs
+++ b/crates/but/tests/but/command/absorb.rs
@@ -309,13 +309,13 @@ n:5 a.txt│
 ┊   n M a.txt
 ┊
 ┊╭┄g0 [A]
-┊●   1#0 a7aa4ef partial change to a.txt 3
+┊●   1#0 partial change to a.txt 3
 ┊│     1#0:n M a.txt
-┊●   1#1 889385c partial change to a.txt 2
+┊●   1#1 partial change to a.txt 2
 ┊│     1#1:n M a.txt
-┊●   1#2 8dc39e0 partial change to a.txt 1
+┊●   1#2 partial change to a.txt 1
 ┊│     1#2:n M a.txt
-┊●   1#3 f4ea7f8 a.txt
+┊●   1#3 a.txt
 ┊│     1#3:n A a.txt
 ┊●   9477ae7 add A
 ┊│     9:t A A
@@ -360,13 +360,13 @@ Hint: you can run `but undo` to undo these changes
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   1#0 4822140 partial change to a.txt 3
+┊●   1#0 partial change to a.txt 3
 ┊│     1#0:n M a.txt
-┊●   1#1 4593422 partial change to a.txt 2
+┊●   1#1 partial change to a.txt 2
 ┊│     1#1:n M a.txt
-┊●   1#2 8dc39e0 partial change to a.txt 1
+┊●   1#2 partial change to a.txt 1
 ┊│     1#2:n M a.txt
-┊●   1#3 f4ea7f8 a.txt
+┊●   1#3 a.txt
 ┊│     1#3:n A a.txt
 ┊●   9477ae7 add A
 ┊│     9:t A A

--- a/crates/but/tests/but/command/branch/delete.rs
+++ b/crates/but/tests/but/command/branch/delete.rs
@@ -72,10 +72,10 @@ Deleted branch A
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [C]
-┊●   wlx ec33a86 add C
+┊●   wlx add C
 ┊│
 ┊├┄h0 [B]
-┊●   wwm 05d3df1 add B
+┊●   wwm add B
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -108,7 +108,7 @@ Deleted branch B
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [C]
-┊●   wlx 983f317 add C
+┊●   wlx add C
 ┊│
 ┊├┄h0 [A]
 ┊●   9477ae7 add A

--- a/crates/but/tests/but/command/commit.rs
+++ b/crates/but/tests/but/command/commit.rs
@@ -18,7 +18,7 @@ fn commit_moved_file_replaced_by_directory() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   1 25c45c4 Commit everything
+┊●   1 Commit everything
 ┊│     1:q A A/file
 ┊│     1:p R B
 ┊●   9477ae7 add A
@@ -380,7 +380,7 @@ Created blank commit at the tip of branch 'A'
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   1 2594ce3 (no commit message) (no changes)
+┊●   1 (no commit message) (no changes)
 ┊●   9477ae7 add A
 ├╯
 ┊
@@ -586,8 +586,8 @@ Created blank commit above branch 'bottom'
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   ywx 76b24fa add second
-┊●   1 32d198c (no commit message) (no changes)
+┊●   ywx add second
+┊●   1 (no commit message) (no changes)
 ┊│
 ┊├┄bo [bottom]
 ┊●   fe12bcd add first
@@ -632,7 +632,7 @@ Created blank commit at the tip of branch 'A'
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   1 2594ce3 (no commit message) (no changes)
+┊●   1 (no commit message) (no changes)
 ┊●   9477ae7 add A
 ├╯
 ┊
@@ -1568,7 +1568,7 @@ Created new independent branch 'a-branch-1'
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   1 d215849 Add file
+┊●   1 Add file
 ┊│     1:q A file
 ├╯
 ┊

--- a/crates/but/tests/but/command/commit2.rs
+++ b/crates/but/tests/but/command/commit2.rs
@@ -14,7 +14,7 @@ fn no_message_nothing_to_commit() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   1 1049574 (no commit message) (no changes)
+┊●   1 (no commit message) (no changes)
 ┊●   9477ae7 add A
 ├╯
 ┊
@@ -47,7 +47,7 @@ Created commit 7bbfdca on branch 'A'
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   1 7bbfdca (no commit message)
+┊●   1 (no commit message)
 ┊●   9477ae7 add A
 ├╯
 ┊
@@ -116,7 +116,7 @@ fn no_args_single_head_message_from_editor() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   1 d4e7c2a commit from editor
+┊●   1 commit from editor
 ┊●   9477ae7 add A
 ├╯
 ┊
@@ -143,7 +143,7 @@ fn single_head_with_message() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   1 a41148c add file.txt
+┊●   1 add file.txt
 ┊●   9477ae7 add A
 ├╯
 ┊
@@ -229,7 +229,7 @@ fn editor_user_writes_no_message() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   1 3b915b5 (no commit message)
+┊●   1 (no commit message)
 ┊●   9477ae7 add A
 ├╯
 ┊
@@ -278,7 +278,7 @@ fn create_commit_on_new_branch() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   1 d4910f8 (no commit message)
+┊●   1 (no commit message)
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -306,7 +306,7 @@ fn create_commit_on_user_provided_branch() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄fi [file]
-┊●   1 5a6fc56 add first
+┊●   1 add first
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -328,8 +328,8 @@ Hint: run `but help` for all commands
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄fi [file]
-┊●   1#0 49fc2f0 add second
-┊●   1#1 5a6fc56 add first
+┊●   1#0 add second
+┊●   1#1 add first
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -351,12 +351,12 @@ Hint: run `but help` for all commands
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄ot [other]
-┊●   1#0 ed433d3 add third
+┊●   1#0 add third
 ├╯
 ┊
 ┊╭┄fi [file]
-┊●   1#1 49fc2f0 add second
-┊●   1#2 5a6fc56 add first
+┊●   1#1 add second
+┊●   1#2 add first
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -378,13 +378,13 @@ Hint: run `but help` for all commands
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄ot [other]
-┊●   1#0 81bd527 add fourth
-┊●   1#1 ed433d3 add third
+┊●   1#0 add fourth
+┊●   1#1 add third
 ├╯
 ┊
 ┊╭┄fi [file]
-┊●   1#2 49fc2f0 add second
-┊●   1#3 5a6fc56 add first
+┊●   1#2 add second
+┊●   1#3 add first
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -410,7 +410,7 @@ fn create_commit_on_new_branch_with_canned_name() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   1 633b765 add file.txt
+┊●   1 add file.txt
 ├╯
 ┊
 ┊╭┄g0 [A]
@@ -505,7 +505,7 @@ fn empty_flag_to_force_empty_commit_when_changes_exist() {
 ┊   v A changes
 ┊
 ┊╭┄br [a-branch-1]
-┊●   1 341ce70 empty commit despite changes in worktree (no changes)
+┊●   1 empty commit despite changes in worktree (no changes)
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -548,8 +548,8 @@ Hint: run `but help` for all commands
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   ywx 955bee4 add second
-┊●   1 4400448 (no commit message) (no changes)
+┊●   ywx add second
+┊●   1 (no commit message) (no changes)
 ┊●   fe12bcd add first
 ├╯
 ┊
@@ -593,9 +593,9 @@ Hint: run `but help` for all commands
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   ywx eee1eaf add second
-┊●   zll c149530 add first
-┊●   1 8b16ff4 (no commit message) (no changes)
+┊●   ywx add second
+┊●   zll add first
+┊●   1 (no commit message) (no changes)
 ├╯
 ┊
 ┴ 1bbc04b (common base) 2000-01-02 add Base
@@ -641,8 +641,8 @@ Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "mes
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   ywx e38b8f7 add second
-┊●   1 94fecae add file.txt
+┊●   ywx add second
+┊●   1 add file.txt
 ┊●   fe12bcd add first
 ├╯
 ┊
@@ -688,7 +688,7 @@ Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "mes
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   1 092d7a9 add file.txt
+┊●   1 add file.txt
 ┊│
 ┊├┄g0 [A]
 ┊●   9477ae7 add A
@@ -737,9 +737,9 @@ Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "mes
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   ywx d7e6d8f add second
-┊●   zll 12982b7 add first
-┊●   1 bdfeaa4 add file.txt
+┊●   ywx add second
+┊●   zll add first
+┊●   1 add file.txt
 ├╯
 ┊
 ┴ 1bbc04b (common base) 2000-01-02 add Base
@@ -784,10 +784,10 @@ Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "mes
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   tpm 8a3fbb3 add A
+┊●   tpm add A
 ┊│
 ┊├┄br [a-branch-1]
-┊●   1 28e38bd add file.txt
+┊●   1 add file.txt
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -833,11 +833,11 @@ Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "mes
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   ywx d7e6d8f add second
-┊●   zll 12982b7 add first
+┊●   ywx add second
+┊●   zll add first
 ┊│
 ┊├┄br [a-branch-1]
-┊●   1 bdfeaa4 add file.txt
+┊●   1 add file.txt
 ├╯
 ┊
 ┴ 1bbc04b (common base) 2000-01-02 add Base
@@ -1075,7 +1075,7 @@ Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "mes
 ┊   twop A two
 ┊
 ┊╭┄g0 [A]
-┊●   1 f86bb7b (no commit message)
+┊●   1 (no commit message)
 ┊│     1:k A one
 ┊●   9477ae7 add A
 ┊│     9:t A A
@@ -1133,9 +1133,9 @@ q:2 file│
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   1#0 f0a3edc (no commit message)
+┊●   1#0 (no commit message)
 ┊│     1#0:q M file
-┊●   1#1 21b345e (no commit message)
+┊●   1#1 (no commit message)
 ┊│     1#1:q A file
 ┊●   9477ae7 add A
 ┊│     9:t A A
@@ -1160,9 +1160,9 @@ Hint: run `but help` for all commands
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   1#0 f0a3edc (no commit message)
+┊●   1#0 (no commit message)
 ┊│     1#0:q M file
-┊●   1#1 21b345e (no commit message)
+┊●   1#1 (no commit message)
 ┊│     1#1:q A file
 ┊●   9477ae7 add A
 ┊│     9:t A A
@@ -1220,9 +1220,9 @@ q:2 file│
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   1#0 f0a3edc (no commit message)
+┊●   1#0 (no commit message)
 ┊│     1#0:q M file
-┊●   1#1 21b345e (no commit message)
+┊●   1#1 (no commit message)
 ┊│     1#1:q A file
 ┊●   9477ae7 add A
 ┊│     9:t A A
@@ -1247,9 +1247,9 @@ Hint: run `but help` for all commands
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   1#0 f0a3edc (no commit message)
+┊●   1#0 (no commit message)
 ┊│     1#0:q M file
-┊●   1#1 21b345e (no commit message)
+┊●   1#1 (no commit message)
 ┊│     1#1:q A file
 ┊●   9477ae7 add A
 ┊│     9:t A A
@@ -1316,7 +1316,7 @@ Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "mes
 ┊   o A path/other/to/third.txt
 ┊
 ┊╭┄g0 [A]
-┊●   1 e1c5473 (no commit message)
+┊●   1 (no commit message)
 ┊│     1:m A path/to/first.txt
 ┊│     1:r A path/to/second.txt
 ┊●   9477ae7 add A
@@ -1358,7 +1358,7 @@ fn path_prefix_with_mix_of_modifications() {
 ┊   x M dir/to_modify.txt
 ┊
 ┊╭┄g0 [A]
-┊●   1 d199c17 (no commit message)
+┊●   1 (no commit message)
 ┊│     1:l A dir/to_delete.txt
 ┊│     1:n A dir/to_empty.txt
 ┊│     1:x A dir/to_modify.txt
@@ -1381,11 +1381,11 @@ Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "mes
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   1#0 d1a6de8 (no commit message)
+┊●   1#0 (no commit message)
 ┊│     1#0:l D dir/to_delete.txt
 ┊│     1#0:n M dir/to_empty.txt
 ┊│     1#0:x M dir/to_modify.txt
-┊●   1#1 d199c17 (no commit message)
+┊●   1#1 (no commit message)
 ┊│     1#1:l A dir/to_delete.txt
 ┊│     1#1:n A dir/to_empty.txt
 ┊│     1#1:x A dir/to_modify.txt
@@ -1455,7 +1455,7 @@ fn committing_above_an_empty_branch() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   1 75b9f19 add one
+┊●   1 add one
 ┊│
 ┊├┄to [top] (no commits)
 ├╯
@@ -1489,7 +1489,7 @@ fn committing_below_empty_branch_with_empty_branch_below() {
 ┊╭┄to [top] (no commits)
 ┊│
 ┊├┄br [a-branch-1]
-┊●   1 75b9f19 add one
+┊●   1 add one
 ┊│
 ┊├┄mi [middle] (no commits)
 ├╯
@@ -1531,10 +1531,10 @@ fn committing_below_non_top_empty_branch() {
 ┊├┄mi [middle] (no commits)
 ┊│
 ┊├┄br [a-branch-1]
-┊●   1#0 af4ddbe add two
+┊●   1#0 add two
 ┊│
 ┊├┄bo [bottom]
-┊●   1#1 75b9f19 add one
+┊●   1#1 add one
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -1585,7 +1585,7 @@ Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "mes
 ┊╭┄to [top] (no commits)
 ┊│
 ┊├┄br [a-branch-1]
-┊●   1 75b9f19 add one
+┊●   1 add one
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -1609,10 +1609,10 @@ Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "mes
 ┊╭┄to [top] (no commits)
 ┊│
 ┊├┄br [a-branch-1]
-┊●   1#0 af4ddbe add two
+┊●   1#0 add two
 ┊│
 ┊├┄bo [bottom]
-┊●   1#1 75b9f19 add one
+┊●   1#1 add one
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -1650,7 +1650,7 @@ fn commit_to_existing_branch_via_short_code() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   1 2e0e1d8 new commit (no changes)
+┊●   1 new commit (no changes)
 ┊●   9477ae7 add A
 ├╯
 ┊
@@ -1677,7 +1677,7 @@ fn commit_to_new_branch_with_same_name_as_file() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄fi [file]
-┊●   1 46b0823 add file
+┊●   1 add file
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -1715,7 +1715,7 @@ q:3 file│
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   1 d215849 Add file
+┊●   1 Add file
 ┊│     1:q A file
 ├╯
 ┊
@@ -1825,7 +1825,7 @@ fn new_branches_are_created_on_top() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   1 7adb8e6 (no commit message) (no changes)
+┊●   1 (no commit message) (no changes)
 ├╯
 ┊
 ┊╭┄g0 [A]

--- a/crates/but/tests/but/command/commit2.rs
+++ b/crates/but/tests/but/command/commit2.rs
@@ -184,7 +184,7 @@ Hint: run `but help` for all commands
 
 "#]]);
 
-    env.but("show b141567")
+    env.but("show 1")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"

--- a/crates/but/tests/but/command/diff.rs
+++ b/crates/but/tests/but/command/diff.rs
@@ -634,9 +634,9 @@ Hint: run `but help` for all commands
 
 "#]]);
 
-    let commit_id = "da";
+    let change_id = "1#0";
 
-    env.but(format!("diff --format json {commit_id}"))
+    env.but(format!("diff --format json {change_id}"))
         .allow_json()
         .assert()
         .success()

--- a/crates/but/tests/but/command/diff.rs
+++ b/crates/but/tests/but/command/diff.rs
@@ -329,7 +329,7 @@ fn json_target_committed_file() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   1 3f40d29 committed-file-target
+┊●   1 committed-file-target
 ┊│     1:k A committed-other.txt
 ┊│     1:w A committed-target.txt
 ┊●   9477ae7 add A
@@ -610,12 +610,12 @@ fn json_commit_target_tree_change_statuses() -> anyhow::Result<()> {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   1#0 dafe86a status-target
+┊●   1#0 status-target
 ┊│     1#0:nx A added.txt
 ┊│     1#0:nm D deleted.txt
 ┊│     1#0:u  M modified.txt
 ┊│     1#0:o  R renamed-after.txt
-┊●   1#1 db7d00b status-base
+┊●   1#1 status-base
 ┊│     1#1:n A deleted.txt
 ┊│     1#1:u A modified.txt
 ┊│     1#1:z A renamed-before.txt

--- a/crates/but/tests/but/command/expand.rs
+++ b/crates/but/tests/but/command/expand.rs
@@ -141,7 +141,7 @@ fn changing_pushed_commit_does_not_cause_change_id_ambiguity() {
 ┊╭┄┄(upstream: on origin/a-branch-1)
 ┊●   a5caff1 second
 ┊-
-┊◐   123 96b6213 rewritten
+┊◐   123 rewritten
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M

--- a/crates/but/tests/but/command/move.rs
+++ b/crates/but/tests/but/command/move.rs
@@ -114,9 +114,9 @@ fn move_multiple_commits_before_another_commit() -> anyhow::Result<()> {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   1#0 23e1bf8 create e.txt and f.txt
-┊●   1#1 de41286 create c.txt and d.txt
-┊●   1#2 fce8ecc create a.txt and b.txt
+┊●   1#0 create e.txt and f.txt
+┊●   1#1 create c.txt and d.txt
+┊●   1#2 create a.txt and b.txt
 ┊●   9477ae7 add A
 ├╯
 ┊
@@ -158,9 +158,9 @@ Moved 2 commits → before fce8ecc
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   1#0 0e08d58 create a.txt and b.txt
-┊●   1#1 7887784 create e.txt and f.txt
-┊●   1#2 078d9e6 create c.txt and d.txt
+┊●   1#0 create a.txt and b.txt
+┊●   1#1 create e.txt and f.txt
+┊●   1#2 create c.txt and d.txt
 ┊●   9477ae7 add A
 ├╯
 ┊
@@ -192,9 +192,9 @@ fn move_multiple_commits_after_another_commit() -> anyhow::Result<()> {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   1#0 23e1bf8 create e.txt and f.txt
-┊●   1#1 de41286 create c.txt and d.txt
-┊●   1#2 fce8ecc create a.txt and b.txt
+┊●   1#0 create e.txt and f.txt
+┊●   1#1 create c.txt and d.txt
+┊●   1#2 create a.txt and b.txt
 ┊●   9477ae7 add A
 ├╯
 ┊
@@ -236,9 +236,9 @@ Moved 2 commits → after 23e1bf8
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   1#0 05b04e5 create c.txt and d.txt
-┊●   1#1 9f54aec create a.txt and b.txt
-┊●   1#2 d7e5fc7 create e.txt and f.txt
+┊●   1#0 create c.txt and d.txt
+┊●   1#1 create a.txt and b.txt
+┊●   1#2 create e.txt and f.txt
 ┊●   9477ae7 add A
 ├╯
 ┊
@@ -376,10 +376,10 @@ Moved 4 commits → before [..]
 ┊
 ┊╭┄h0 [B]
 ┊●   [..] B: another 10 lines at the bottom
-┊●   zmt c4ee0c5 C: add another 10 lines to new file
-┊●   xkt 4b3d452 C: add 10 lines to new file
-┊●   sxz 90250eb C: new file with 10 lines
-┊●   psr 29bc6a0 A: 10 lines on top
+┊●   zmt C: add another 10 lines to new file
+┊●   xkt C: add 10 lines to new file
+┊●   sxz C: new file with 10 lines
+┊●   psr A: 10 lines on top
 ┊●   62e05ba B: 10 lines at the bottom
 ├╯
 ┊
@@ -519,10 +519,10 @@ Moved 4 commits → after a748762
 ├╯
 ┊
 ┊╭┄h0 [B]
-┊●   zmt 79860aa C: add another 10 lines to new file
-┊●   xkt cb938a1 C: add 10 lines to new file
-┊●   sxz 87f25cc C: new file with 10 lines
-┊●   psr d2689e7 A: 10 lines on top
+┊●   zmt C: add another 10 lines to new file
+┊●   xkt C: add 10 lines to new file
+┊●   sxz C: new file with 10 lines
+┊●   psr A: 10 lines on top
 ┊●   a748762 B: another 10 lines at the bottom
 ┊●   62e05ba B: 10 lines at the bottom
 ├╯
@@ -827,7 +827,7 @@ Moved branch A on top of C.
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   tpm 89a57fc add A
+┊●   tpm add A
 ┊│
 ┊├┄h0 [C]
 ┊●   3842fc0 add C
@@ -991,7 +991,7 @@ Moved branch A on top of C.
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   tpm 89a57fc add A
+┊●   tpm add A
 ┊│
 ┊├┄h0 [C]
 ┊●   3842fc0 add C
@@ -1081,7 +1081,7 @@ Unstacked branch C.
 ├╯
 ┊
 ┊╭┄i0 [C]
-┊●   xwn 661a9b6 add C
+┊●   xwn add C
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M

--- a/crates/but/tests/but/command/move2.rs
+++ b/crates/but/tests/but/command/move2.rs
@@ -37,8 +37,8 @@ Moved fe12bcd above commit 9ac4652
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   zll c6224e6 add first
-┊●   ywx ce8b324 add second
+┊●   zll add first
+┊●   ywx add second
 ├╯
 ┊
 ┴ 1bbc04b (common base) 2000-01-02 add Base
@@ -85,8 +85,8 @@ Moved 9ac4652 below commit fe12bcd
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   zll c6224e6 add first
-┊●   ywx ce8b324 add second
+┊●   zll add first
+┊●   ywx add second
 ├╯
 ┊
 ┴ 1bbc04b (common base) 2000-01-02 add Base
@@ -147,13 +147,13 @@ Moved 2a98cfc, 769f4a8 [..]
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   usn 86218a9 add A13
-┊●   opy 4ba5683 add A12
-┊●   opk 33c2cee add A11
-┊●   vmw 894e57b add A8
-┊●   tpw 1c425d1 add A7
-┊●   vvl 73d652c add A10
-┊●   mzz a6a6cd1 add A9
+┊●   usn add A13
+┊●   opy add A12
+┊●   opk add A11
+┊●   vmw add A8
+┊●   tpw add A7
+┊●   vvl add A10
+┊●   mzz add A9
 ┊●   d60e311 add A6
 ┊●   c67c49e add A5
 ┊●   23c280d add A4
@@ -228,19 +228,19 @@ Moved 2a98cfc, 0748e42, c67c49e [..]
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   usn 6f23074 add A13
-┊●   opy ae30331 add A12
-┊●   opk ad601eb add A11
-┊●   vvl bfcf0d6 add A10
-┊●   mzz a5511fb add A9
-┊●   tpw 79d9420 add A7
-┊●   pyq 651dbaf add A5
-┊●   zpl 33e2190 add A1
-┊●   vmw ddfd694 add A8
-┊●   lyq 88fbf4b add A6
-┊●   mvv 4868a7b add A4
-┊●   tvm c05b7a8 add A3
-┊●   sxq b7e9e54 add A2
+┊●   usn add A13
+┊●   opy add A12
+┊●   opk add A11
+┊●   vvl add A10
+┊●   mzz add A9
+┊●   tpw add A7
+┊●   pyq add A5
+┊●   zpl add A1
+┊●   vmw add A8
+┊●   lyq add A6
+┊●   mvv add A4
+┊●   tvm add A3
+┊●   sxq add A2
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -290,10 +290,10 @@ Moved fe12bcd to new branch 'a-branch-1' above branch 'A'
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   zll c6224e6 add first
+┊●   zll add first
 ┊│
 ┊├┄g0 [A]
-┊●   ywx ce8b324 add second
+┊●   ywx add second
 ├╯
 ┊
 ┴ 1bbc04b (common base) 2000-01-02 add Base
@@ -390,10 +390,10 @@ Moved 9ac4652 to new branch 'a-branch-1' below branch 'A'
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   zll c6224e6 add first
+┊●   zll add first
 ┊│
 ┊├┄br [a-branch-1]
-┊●   ywx ce8b324 add second
+┊●   ywx add second
 ├╯
 ┊
 ┴ 1bbc04b (common base) 2000-01-02 add Base
@@ -770,7 +770,7 @@ Moved 9477ae7 to the tip of branch 'B'
 ├╯
 ┊
 ┊╭┄h0 [B]
-┊●   tpm 22c3ce2 add A
+┊●   tpm add A
 ┊●   d3e2ba3 add B
 ├╯
 ┊
@@ -870,7 +870,7 @@ Moved 9ac4652 to new branch 'new-branch'
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄ne [new-branch]
-┊●   ywx ce8b324 add second
+┊●   ywx add second
 ├╯
 ┊
 ┊╭┄g0 [A]
@@ -921,7 +921,7 @@ Moved 9ac4652 to new branch 'a-branch-1'
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   ywx ce8b324 add second
+┊●   ywx add second
 ├╯
 ┊
 ┊╭┄g0 [A]
@@ -974,10 +974,10 @@ Moved 1 changes from 9ac4652 to new commit 8e35f84 below commit fe12bcd
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   ywx 01a55b8 add second (no changes)
-┊●   zll 12b9152 add first
+┊●   ywx add second (no changes)
+┊●   zll add first
 ┊│     zl:l A first
-┊●   1 8e35f84 (no commit message)
+┊●   1 (no commit message)
 ┊│     1:w A second
 ├╯
 ┊
@@ -1027,9 +1027,9 @@ Moved 1 changes from fe12bcd to new commit c019027 above commit 9ac4652
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   1 c019027 (no commit message)
+┊●   1 (no commit message)
 ┊│     1:l A first
-┊●   ywx 38b1f1a add second
+┊●   ywx add second
 ┊│     y:w A second
 ┊●   d8dfd0f add first (no changes)
 ├╯
@@ -1080,12 +1080,12 @@ Moved 1 changes from 9ac4652 to new commit 8e35f84 on new branch 'a-branch-1' be
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   ywx 01a55b8 add second (no changes)
-┊●   zll 12b9152 add first
+┊●   ywx add second (no changes)
+┊●   zll add first
 ┊│     zl:l A first
 ┊│
 ┊├┄br [a-branch-1]
-┊●   1 8e35f84 (no commit message)
+┊●   1 (no commit message)
 ┊│     1:w A second
 ├╯
 ┊
@@ -1135,11 +1135,11 @@ Moved 1 changes from fe12bcd to new commit c019027 on new branch 'a-branch-1' ab
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   1 c019027 (no commit message)
+┊●   1 (no commit message)
 ┊│     1:l A first
 ┊│
 ┊├┄g0 [A]
-┊●   ywx 38b1f1a add second
+┊●   ywx add second
 ┊│     y:w A second
 ┊●   d8dfd0f add first (no changes)
 ├╯
@@ -1193,7 +1193,7 @@ Moved 1 changes from d3e2ba3 to new commit be174de to the tip of branch 'A'
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   1 be174de (no commit message)
+┊●   1 (no commit message)
 ┊│     1:p A B
 ┊●   9477ae7 add A
 ┊│     9:t A A
@@ -1249,7 +1249,7 @@ Moved 1 changes from 9ac4652 to new commit 8e35f84 on new branch 'new-branch'
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄ne [new-branch]
-┊●   1 8e35f84 (no commit message)
+┊●   1 (no commit message)
 ┊│     1:w A second
 ├╯
 ┊
@@ -1305,7 +1305,7 @@ Moved 1 changes from 9ac4652 to new commit 8e35f84 on new branch 'a-branch-1'
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   1 8e35f84 (no commit message)
+┊●   1 (no commit message)
 ┊│     1:w A second
 ├╯
 ┊
@@ -1347,11 +1347,11 @@ fn move_file_should_be_order_independent() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   1#0 e3d3e3a Prepare for moves!
+┊●   1#0 Prepare for moves!
 ┊│     1#0:u R moved
 ┊│     1#0:p A new/file
 ┊│     1#0:t A unrelated
-┊●   1#1 24ac1e5 Add new file
+┊●   1#1 Add new file
 ┊│     1#1:n A new
 ├╯
 ┊
@@ -1376,12 +1376,12 @@ Moved 2 changes from e3d3e3a to new commit 99ef17e above commit e3d3e3a
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   1#0 99ef17e (no commit message)
+┊●   1#0 (no commit message)
 ┊│     1#0:u R moved
 ┊│     1#0:p A new/file
-┊●   1#1 f94e59f Prepare for moves!
+┊●   1#1 Prepare for moves!
 ┊│     1#1:t A unrelated
-┊●   1#2 24ac1e5 Add new file
+┊●   1#2 Add new file
 ┊│     1#2:n A new
 ├╯
 ┊
@@ -1408,12 +1408,12 @@ Moved 2 changes from e3d3e3a to new commit 99ef17e above commit e3d3e3a
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   1#0 99ef17e (no commit message)
+┊●   1#0 (no commit message)
 ┊│     1#0:u R moved
 ┊│     1#0:p A new/file
-┊●   1#1 f94e59f Prepare for moves!
+┊●   1#1 Prepare for moves!
 ┊│     1#1:t A unrelated
-┊●   1#2 24ac1e5 Add new file
+┊●   1#2 Add new file
 ┊│     1#2:n A new
 ├╯
 ┊
@@ -1506,10 +1506,10 @@ Stacked branch 'B' on top of branch 'C'
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [B]
-┊●   wwm 223f14d add B
+┊●   wwm add B
 ┊│
 ┊├┄h0 [C]
-┊●   wlx 983f317 add C
+┊●   wlx add C
 ┊│
 ┊├┄i0 [A]
 ┊●   9477ae7 add A
@@ -1623,7 +1623,7 @@ Stacked branch 'B' on top of branch 'A'
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [B]
-┊●   lrm e776549 add B
+┊●   lrm add B
 ┊│
 ┊├┄h0 [A]
 ┊●   9477ae7 add A
@@ -1792,7 +1792,7 @@ Unstacked branch 'C'
 ├╯
 ┊
 ┊╭┄i0 [C]
-┊●   wlx db21ee2 add C
+┊●   wlx add C
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -1846,11 +1846,11 @@ Unstacked branch 'B'
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [B]
-┊●   wwm 05d3df1 add B
+┊●   wwm add B
 ├╯
 ┊
 ┊╭┄h0 [C]
-┊●   wlx 983f317 add C
+┊●   wlx add C
 ┊│
 ┊├┄i0 [A]
 ┊●   9477ae7 add A
@@ -1911,10 +1911,10 @@ Unstacked branch 'A'
 ├╯
 ┊
 ┊╭┄h0 [C]
-┊●   wlx ec33a86 add C
+┊●   wlx add C
 ┊│
 ┊├┄i0 [B]
-┊●   wwm 05d3df1 add B
+┊●   wwm add B
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -2025,10 +2025,10 @@ Unstacked branch 'A'
 ├╯
 ┊
 ┊╭┄h0 [C]
-┊●   wlx ec33a86 add C
+┊●   wlx add C
 ┊│
 ┊├┄i0 [B]
-┊●   wwm 05d3df1 add B
+┊●   wwm add B
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M

--- a/crates/but/tests/but/command/pull.rs
+++ b/crates/but/tests/but/command/pull.rs
@@ -38,7 +38,7 @@ Hint: run `but help` for all commands
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [B]
-┊◐   lrm 5542cc3 add B
+┊◐   lrm add B
 ├╯
 ┊
 ┴ 26ecc90 (common base) 2000-01-02 add upstream
@@ -111,7 +111,7 @@ Hint: branches marked `(merged upstream)` have landed; run `but pull` to remove 
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊◐   ozt 3a110f4 add A
+┊◐   ozt add A
 ├╯
 ┊
 ┴ d4cb681 (common base) 2000-01-02 add upstream
@@ -287,7 +287,7 @@ Hint: run `but help` for all commands
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊◐   nyo 6e0f28b A-change (no changes) {conflicted}
+┊◐   nyo A-change (no changes) {conflicted}
 ├╯
 ┊
 ┴ bdfcf28 (common base) 2000-01-02 main-change
@@ -436,7 +436,7 @@ Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "mes
 ┊   o M shared.txt
 ┊
 ┊╭┄g0 [A]
-┊◐   vun 705b03e local change (no changes) {conflicted}
+┊◐   vun local change (no changes) {conflicted}
 ├╯
 ┊
 ┴ 7f73771 (common base) 2000-01-02 upstream change
@@ -500,7 +500,7 @@ Hint: run `but help` for all commands
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊◐   vun 705b03e local change (no changes) {conflicted}
+┊◐   vun local change (no changes) {conflicted}
 ├╯
 ┊
 ┴ 7f73771 (common base) 2000-01-02 upstream change
@@ -565,10 +565,10 @@ To undo this operation:
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊◐   rvk 4a2dd6a top change
+┊◐   rvk top change
 ┊│
 ┊├┄h0 [B]
-┊◐   rou d5fa75c bottom change (no changes) {conflicted}
+┊◐   rou bottom change (no changes) {conflicted}
 ├╯
 ┊
 ┴ 7f73771 (common base) 2000-01-02 upstream change
@@ -633,10 +633,10 @@ To undo this operation:
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊◐   wmr 09bcfd9 top change (no changes) {conflicted}
+┊◐   wmr top change (no changes) {conflicted}
 ┊│
 ┊├┄h0 [B]
-┊◐   trk 7ac1f5a bottom change (no changes) {conflicted}
+┊◐   trk bottom change (no changes) {conflicted}
 ├╯
 ┊
 ┴ e4933d8 (common base) 2000-01-02 upstream change

--- a/crates/but/tests/but/command/rub.rs
+++ b/crates/but/tests/but/command/rub.rs
@@ -250,7 +250,7 @@ fn committed_file_to_uncommitted_area() -> anyhow::Result<()> {
 
 "#]]);
 
-    env.but("rub e8:b.txt zz")
+    env.but("rub 1#0:p zz")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
@@ -1609,7 +1609,7 @@ fn rub_commit_without_message_to_commit() {
 
 "#]]);
 
-    env.but("commit empty --after aec35ac").assert().success();
+    env.but("commit empty --after 1").assert().success();
 
     env.but("status --no-hint")
         .assert()
@@ -1627,7 +1627,7 @@ fn rub_commit_without_message_to_commit() {
 
 "#]]);
 
-    env.but("rub 5e5c05a aec35ac").assert().success();
+    env.but("rub 1#0 1#1").assert().success();
 
     env.but("status --no-hint")
         .assert()
@@ -1652,9 +1652,9 @@ fn rub_commit_to_commit_without_message() -> anyhow::Result<()> {
 
     env.file("one.txt", "one.txt contents");
     env.but("commit -m 'add one.txt'").assert().success();
-    env.but("commit empty --after aec35ac").assert().success();
+    env.but("commit empty --after 1").assert().success();
 
-    env.but("rub aec35ac 5e5c05a").assert().success();
+    env.but("rub 1#1 1#0").assert().success();
 
     let status = status_json(&env)?;
     let branch = status["stacks"]
@@ -2268,7 +2268,7 @@ Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "mes
 
 "#]]);
 
-    env.but("rub zz e3f869d").assert().success();
+    env.but("rub zz 1").assert().success();
 
     env.but("status -f")
         .assert()

--- a/crates/but/tests/but/command/rub.rs
+++ b/crates/but/tests/but/command/rub.rs
@@ -732,7 +732,7 @@ fn uncommit_command_with_discard_on_commit() -> anyhow::Result<()> {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   1 fce8ecc create a.txt and b.txt
+┊●   1 create a.txt and b.txt
 ┊│     1:n A a.txt
 ┊│     1:p A b.txt
 ┊●   9477ae7 add A
@@ -816,7 +816,7 @@ fn uncommit_command_with_discard_on_committed_file() -> anyhow::Result<()> {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   1 fce8ecc create a.txt and b.txt
+┊●   1 create a.txt and b.txt
 ┊│     1:n A a.txt
 ┊│     1:p A b.txt
 ┊●   9477ae7 add A
@@ -860,7 +860,7 @@ Hint: run `but help` for all commands
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   1 993513d create a.txt and b.txt
+┊●   1 create a.txt and b.txt
 ┊│     1:n A a.txt
 ┊●   9477ae7 add A
 ┊│     94:t A A
@@ -1601,7 +1601,7 @@ fn rub_commit_without_message_to_commit() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   1 aec35ac add one.txt
+┊●   1 add one.txt
 ┊●   9477ae7 add A
 ├╯
 ┊
@@ -1618,8 +1618,8 @@ fn rub_commit_without_message_to_commit() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   1#0 5e5c05a (no commit message) (no changes)
-┊●   1#1 aec35ac add one.txt
+┊●   1#0 (no commit message) (no changes)
+┊●   1#1 add one.txt
 ┊●   9477ae7 add A
 ├╯
 ┊
@@ -1636,7 +1636,7 @@ fn rub_commit_without_message_to_commit() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   1 aec35ac add one.txt
+┊●   1 add one.txt
 ┊●   9477ae7 add A
 ├╯
 ┊
@@ -2234,7 +2234,7 @@ fn rubbing_modified_and_renamed_file() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   1 e3f869d add files
+┊●   1 add files
 ┊│     1:q A file
 ┊│     1:k A file-2
 ├╯
@@ -2257,7 +2257,7 @@ Hint: run `but help` for all commands
 ┊   k D file-2
 ┊
 ┊╭┄br [a-branch-1]
-┊●   1 e3f869d add files
+┊●   1 add files
 ┊│     1:q A file
 ┊│     1:k A file-2
 ├╯
@@ -2277,7 +2277,7 @@ Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "mes
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   1 3a32c97 add files
+┊●   1 add files
 ┊│     1:q A file
 ├╯
 ┊
@@ -2305,7 +2305,7 @@ fn committing_modified_and_renamed_file() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   1 e3f869d add files
+┊●   1 add files
 ┊│     1:q A file
 ┊│     1:k A file-2
 ├╯
@@ -2328,7 +2328,7 @@ Hint: run `but help` for all commands
 ┊   k D file-2
 ┊
 ┊╭┄br [a-branch-1]
-┊●   1 e3f869d add files
+┊●   1 add files
 ┊│     1:q A file
 ┊│     1:k A file-2
 ├╯
@@ -2348,10 +2348,10 @@ Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "mes
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   1#0 e419886 change file
+┊●   1#0 change file
 ┊│     1#0:q M file
 ┊│     1#0:k D file-2
-┊●   1#1 e3f869d add files
+┊●   1#1 add files
 ┊│     1#1:q A file
 ┊│     1#1:k A file-2
 ├╯

--- a/crates/but/tests/but/command/squash2.rs
+++ b/crates/but/tests/but/command/squash2.rs
@@ -65,11 +65,11 @@ fn squash_two_commits() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   1#0 f55169f add three
+┊●   1#0 add three
 ┊│     1#0:o A three
-┊●   1#1 f63361f add two
+┊●   1#1 add two
 ┊│     1#1:t A two
-┊●   1#2 ea345ba add one
+┊●   1#2 add one
 ┊│     1#2:k A one
 ├╯
 ┊
@@ -94,10 +94,10 @@ Squashed f55169f into f63361f to create 7251301
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   1#0 7251301 squashed
+┊●   1#0 squashed
 ┊│     1#0:o A three
 ┊│     1#0:t A two
-┊●   1#1 ea345ba add one
+┊●   1#1 add one
 ┊│     1#1:k A one
 ├╯
 ┊
@@ -149,7 +149,7 @@ Squashed f55169f, f63361f into ea345ba to create e355a10
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   1 e355a10 squashed
+┊●   1 squashed
 ┊│     1:k A one
 ┊│     1:o A three
 ┊│     1:t A two
@@ -696,11 +696,11 @@ fn aborts_on_conflicts() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   1#0 d5e51af remove file
+┊●   1#0 remove file
 ┊│     1#0:u D file.txt
-┊●   1#1 5b59611 change file
+┊●   1#1 change file
 ┊│     1#1:u M file.txt
-┊●   1#2 11a2a8a add file
+┊●   1#2 add file
 ┊│     1#2:u A file.txt
 ├╯
 ┊
@@ -730,16 +730,16 @@ fn cannot_squash_into_commits_on_unapplied_branches() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄se [second]
-┊●   1#0 d15f721 add four
+┊●   1#0 add four
 ┊│     1#0:q A four
-┊●   1#1 66a5286 add three
+┊●   1#1 add three
 ┊│     1#1:o A three
 ├╯
 ┊
 ┊╭┄on [one]
-┊●   1#2 f63361f add two
+┊●   1#2 add two
 ┊│     1#2:t A two
-┊●   1#3 ea345ba add one
+┊●   1#3 add one
 ┊│     1#3:k A one
 ├╯
 ┊
@@ -829,10 +829,10 @@ Squashed f55169f into f63361f to create 5ab5165
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   1#0 5ab5165 add two
+┊●   1#0 add two
 ┊│     1#0:o A three
 ┊│     1#0:t A two
-┊●   1#1 ea345ba add one
+┊●   1#1 add one
 ┊│     1#1:k A one
 ├╯
 ┊
@@ -862,11 +862,11 @@ Squashed branch 'one' to create commit 00e6751
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄se [second]
-┊●   1#0 00e6751 add four
+┊●   1#0 add four
 ┊│     1#0:q A four
 ┊│     1#0:k A one
 ┊│     1#0:t A two
-┊●   1#1 66a5286 add three
+┊●   1#1 add three
 ┊│     1#1:o A three
 ├╯
 ┊
@@ -891,7 +891,7 @@ fn amend_uncommitted_files_into_commit() {
 ┊   twop A two
 ┊
 ┊╭┄br [a-branch-1]
-┊●   1 7adb8e6 (no commit message) (no changes)
+┊●   1 (no commit message) (no changes)
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -916,7 +916,7 @@ Amended 7adb8e6 to create d2f176a
 ┊   o A three
 ┊
 ┊╭┄br [a-branch-1]
-┊●   1 d2f176a (no commit message)
+┊●   1 (no commit message)
 ┊│     1:k A one
 ┊│     1:t A two
 ├╯
@@ -942,7 +942,7 @@ fn amend_all_uncommitted_changes_into_commit() {
 ┊   twop A two
 ┊
 ┊╭┄br [a-branch-1]
-┊●   1 7adb8e6 (no commit message) (no changes)
+┊●   1 (no commit message) (no changes)
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -966,7 +966,7 @@ Amended 7adb8e6 to create 0e76889
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   1 0e76889 (no commit message)
+┊●   1 (no commit message)
 ┊│     1:k A one
 ┊│     1:o A three
 ┊│     1:t A two
@@ -1059,11 +1059,11 @@ Amended f55169f to create f55169f
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   1#0 f55169f add three
+┊●   1#0 add three
 ┊│     1#0:o A three
-┊●   1#1 f63361f add two
+┊●   1#1 add two
 ┊│     1#1:t A two
-┊●   1#2 ea345ba add one
+┊●   1#2 add one
 ┊│     1#2:k A one
 ├╯
 ┊
@@ -1093,11 +1093,11 @@ Amended f63361f to create 5ab5165
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   1#0 bb84ecc add three (no changes)
-┊●   1#1 5ab5165 add two
+┊●   1#0 add three (no changes)
+┊●   1#1 add two
 ┊│     1#1:o A three
 ┊│     1#1:t A two
-┊●   1#2 ea345ba add one
+┊●   1#2 add one
 ┊│     1#2:k A one
 ├╯
 ┊
@@ -1119,11 +1119,11 @@ fn cannot_amend_files_from_different_commits() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   1#0 f55169f add three
+┊●   1#0 add three
 ┊│     1#0:o A three
-┊●   1#1 f63361f add two
+┊●   1#1 add two
 ┊│     1#1:t A two
-┊●   1#2 ea345ba add one
+┊●   1#2 add one
 ┊│     1#2:k A one
 ├╯
 ┊
@@ -1163,11 +1163,11 @@ fn cannot_amend_files_in_ways_that_cause_conflicts() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   1#0 beafa55 remove file
+┊●   1#0 remove file
 ┊│     1#0:q D file
-┊●   1#1 623d399 change file
+┊●   1#1 change file
 ┊│     1#1:q M file
-┊●   1#2 5c348d7 add file
+┊●   1#2 add file
 ┊│     1#2:q A file
 ├╯
 ┊
@@ -1207,12 +1207,12 @@ Amended f55169f to create 13baa98
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   1#0 13baa98 add three
+┊●   1#0 add three
 ┊│     1#0:q A file
 ┊│     1#0:o A three
-┊●   1#1 f63361f add two
+┊●   1#1 add two
 ┊│     1#1:t A two
-┊●   1#2 ea345ba add one
+┊●   1#2 add one
 ┊│     1#2:k A one
 ├╯
 ┊
@@ -1269,7 +1269,7 @@ Error: --target cannot be an empty branch
 ┊╭┄mi [middle] (no commits)
 ┊│
 ┊├┄bo [bottom]
-┊●   1 7adb8e6 (no commit message) (no changes)
+┊●   1 (no commit message) (no changes)
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -1325,9 +1325,9 @@ Uncommitted f55169f
 ┊   o A three
 ┊
 ┊╭┄br [a-branch-1]
-┊●   1#0 f63361f add two
+┊●   1#0 add two
 ┊│     1#0:t A two
-┊●   1#1 ea345ba add one
+┊●   1#1 add one
 ┊│     1#1:k A one
 ├╯
 ┊
@@ -1356,11 +1356,11 @@ fn squash_into_zz_to_uncommit_file() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   1#0 f55169f add three
+┊●   1#0 add three
 ┊│     1#0:o A three
-┊●   1#1 f63361f add two
+┊●   1#1 add two
 ┊│     1#1:t A two
-┊●   1#2 ea345ba add one
+┊●   1#2 add one
 ┊│     1#2:k A one
 ├╯
 ┊
@@ -1386,10 +1386,10 @@ Uncommitted from f55169f
 ┊   o A three
 ┊
 ┊╭┄br [a-branch-1]
-┊●   1#0 aba928c add three (no changes)
-┊●   1#1 f63361f add two
+┊●   1#0 add three (no changes)
+┊●   1#1 add two
 ┊│     1#1:t A two
-┊●   1#2 ea345ba add one
+┊●   1#2 add one
 ┊│     1#2:k A one
 ├╯
 ┊
@@ -1421,11 +1421,11 @@ fn cannot_uncommit_files_in_ways_that_cause_conflicts() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   1#0 beafa55 remove file
+┊●   1#0 remove file
 ┊│     1#0:q D file
-┊●   1#1 623d399 change file
+┊●   1#1 change file
 ┊│     1#1:q M file
-┊●   1#2 5c348d7 add file
+┊●   1#2 add file
 ┊│     1#2:q A file
 ├╯
 ┊

--- a/crates/but/tests/but/command/squash2.rs
+++ b/crates/but/tests/but/command/squash2.rs
@@ -79,7 +79,7 @@ Hint: run `but help` for all commands
 
 "#]]);
 
-    env.but("_squash2 f55169f --target f63361f --message 'squashed'")
+    env.but("_squash2 1#0 --target 1#1 --message 'squashed'")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
@@ -109,7 +109,7 @@ Hint: run `but help` for all commands
 
     env.but("undo").assert().success();
 
-    env.but("_squash2 f55169f --target f63361f --message 'squashed' --format json")
+    env.but("_squash2 1#0 --target 1#1 --message 'squashed' --format json")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
@@ -121,7 +121,7 @@ Hint: run `but help` for all commands
 
     env.but("undo").assert().success();
 
-    env.but("_squash2 f55169f --target f63361f --message 'squashed' --format shell")
+    env.but("_squash2 1#0 --target 1#1 --message 'squashed' --format shell")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
@@ -134,7 +134,7 @@ Hint: run `but help` for all commands
 fn squash_multiple_sources() {
     let env = one_branch_three_commits();
 
-    env.but("_squash2 f55169f f63361f --target ea345ba --message 'squashed'")
+    env.but("_squash2 1#0 1#1 --target 1#2 --message 'squashed'")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
@@ -166,7 +166,7 @@ Hint: run `but help` for all commands
 fn use_target_message() {
     let env = one_branch_three_commits();
 
-    env.but("_squash2 f55169f --target f63361f --use-target-message")
+    env.but("_squash2 1#0 --target 1#1 --use-target-message")
         .assert()
         .success();
 
@@ -197,7 +197,7 @@ Hint: run `but help` for all commands
 fn use_source_message() {
     let env = one_branch_three_commits();
 
-    env.but("_squash2 f55169f --target f63361f --use-source-message")
+    env.but("_squash2 1#0 --target 1#1 --use-source-message")
         .assert()
         .success();
 
@@ -261,7 +261,7 @@ Hint: run `but help` for all commands
 fn squash_whole_branch_into_commit_on_same_branch() {
     let env = one_branch_three_commits();
 
-    env.but("_squash2 a-branch-1 -t f63361f --use-target-message")
+    env.but("_squash2 a-branch-1 -t 1#1 --use-target-message")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
@@ -338,7 +338,7 @@ Hint: run `but help` for all commands
 
 "#]]);
 
-    env.but("_squash2 a-branch-1 add-file-branch -t d1d6a19 --use-target-message")
+    env.but("_squash2 a-branch-1 add-file-branch -t 1#1 --use-target-message")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
@@ -421,7 +421,7 @@ Hint: run `but help` for all commands
 
 "#]]);
 
-    env.but("_squash2 target-branch a-branch-1 add-file-branch -t 561a8d8 --use-target-message")
+    env.but("_squash2 target-branch a-branch-1 add-file-branch -t 1#2 --use-target-message")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
@@ -552,7 +552,7 @@ For more information, try '--help'.
 fn cannot_squash_only_target() {
     let env = one_branch_three_commits();
 
-    env.but("_squash2 --target f55169f")
+    env.but("_squash2 --target 1#0")
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
@@ -570,7 +570,7 @@ For more information, try '--help'.
 fn cannot_mix_sources() {
     let env = one_branch_three_commits();
 
-    env.but("_squash2 a-branch-1 f55169f --target ea345ba")
+    env.but("_squash2 a-branch-1 1#0 --target 1#2")
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
@@ -583,7 +583,7 @@ Error: Cannot mix different types of sources
 fn cannot_squash_multiple_commits_without_target() {
     let env = one_branch_three_commits();
 
-    env.but("_squash2 f55169f ea345ba")
+    env.but("_squash2 1#0 1#2")
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
@@ -632,7 +632,7 @@ Error: Need at least 2 commits to squash
 fn cannot_squash_commit_into_itself() {
     let env = one_branch_three_commits();
 
-    env.but("_squash2 f55169f -t f55169f")
+    env.but("_squash2 1#0 -t 1#0")
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
@@ -666,7 +666,7 @@ fn cannot_squash_empty_branch_into_commit() {
 
     env.but("branch new empty-branch").assert().success();
 
-    env.but("_squash2 empty-branch -t 561a8d8")
+    env.but("_squash2 empty-branch -t 1")
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
@@ -710,7 +710,7 @@ Hint: run `but help` for all commands
 
 "#]]);
 
-    env.but("_squash2 d5e51af -t 11a2a8a")
+    env.but("_squash2 1#0 -t 1#2")
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
@@ -751,7 +751,7 @@ Hint: run `but help` for all commands
 
     env.but("unapply second").assert().success();
 
-    env.but("_squash2 f63361f -t d15f721")
+    env.but("_squash2 1#0 -t d15f721")
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
@@ -814,7 +814,7 @@ Error: Need at least 2 commits to squash
 fn squash_with_duplicate_commit_sources() {
     let env = one_branch_three_commits();
 
-    env.but("_squash2 f55169f f55169f -t f63361f -u")
+    env.but("_squash2 1#0 1#0 -t 1#1 -u")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
@@ -847,7 +847,7 @@ Hint: run `but help` for all commands
 fn squash_with_duplicate_branch_sources() {
     let env = two_branches();
 
-    env.but("_squash2 one one -t d15f721 -u")
+    env.but("_squash2 one one -t 1#0 -u")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
@@ -900,7 +900,7 @@ Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "mes
 
 "#]]);
 
-    env.but("_squash2 one two -t 7adb8e6 -u")
+    env.but("_squash2 one two -t 1 -u")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
@@ -951,7 +951,7 @@ Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "mes
 
 "#]]);
 
-    env.but("_squash2 zz -t 7adb8e6 -u")
+    env.but("_squash2 zz -t 1 -u")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
@@ -1016,7 +1016,7 @@ q:d file│
 
 "#]]);
 
-    env.but("_squash2 qs:9 -t bcf07e2 -u")
+    env.but("_squash2 qs:9 -t 1 -u")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
@@ -1044,7 +1044,7 @@ q:d file│
 fn amend_all_uncommitted_changes_when_zz_is_empty() {
     let env = one_branch_three_commits();
 
-    env.but("_squash2 zz -t f55169f -u")
+    env.but("_squash2 zz -t 1#0 -u")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
@@ -1078,7 +1078,7 @@ Hint: run `but help` for all commands
 fn amend_committed_file() {
     let env = one_branch_three_commits();
 
-    env.but("_squash2 f5:or -t f63361f -u")
+    env.but("_squash2 1#0:o -t 1#1 -u")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
@@ -1133,7 +1133,7 @@ Hint: run `but help` for all commands
 
 "#]]);
 
-    env.but("_squash2 f5:or f6:tw -t ea345ba -u")
+    env.but("_squash2 1#0:o 1#1:t -t 1#2 -u")
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
@@ -1177,7 +1177,7 @@ Hint: run `but help` for all commands
 
 "#]]);
 
-    env.but("_squash2 be:qs -t 5c348d7 -u")
+    env.but("_squash2 1#0:q -t 1#2 -u")
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
@@ -1309,7 +1309,7 @@ Hint: --target must be an applied commit, branch, or zz. Run `but status` for ap
 fn squash_into_zz_to_uncommit_commit() {
     let env = one_branch_three_commits();
 
-    env.but("_squash2 f55169f -t zz")
+    env.but("_squash2 1#0 -t zz")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
@@ -1339,7 +1339,7 @@ Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "mes
 
     env.but("undo").assert().success();
 
-    env.but("_squash2 f55169f -t zz --format json")
+    env.but("_squash2 1#0 -t zz --format json")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#""#]]);
@@ -1370,7 +1370,7 @@ Hint: run `but help` for all commands
 
 "#]]);
 
-    env.but("_squash2 f5:or -t zz")
+    env.but("_squash2 1#0:o -t zz")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
@@ -1435,7 +1435,7 @@ Hint: run `but help` for all commands
 
 "#]]);
 
-    env.but("_squash2 5c348d7 -t zz")
+    env.but("_squash2 1#2 -t zz")
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
@@ -1443,7 +1443,7 @@ Error: Cannot uncommit commits that would result in merge conflicts
 
 "#]]);
 
-    env.but("_squash2 5c:qs -t zz")
+    env.but("_squash2 1#2:q -t zz")
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
@@ -1479,7 +1479,7 @@ Error: --use-source-message cannot be used when squashing uncommitted changes
 fn cannot_use_source_message_when_moving_committed_files() {
     let env = one_branch_three_commits();
 
-    env.but("_squash2 f5:or -t f63361f --use-source-message")
+    env.but("_squash2 1#0:o -t 1#1 --use-source-message")
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"

--- a/crates/but/tests/but/command/status.rs
+++ b/crates/but/tests/but/command/status.rs
@@ -1305,7 +1305,7 @@ fn status_file_prefixed_with_change_id_when_available_and_commit_id_otherwise() 
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   123 e1db5a8 Commit with change ID
+┊●   123 Commit with change ID
 ┊│     1:p A B
 ┊●   9477ae7 add A
 ┊│     9:t A A
@@ -1358,7 +1358,7 @@ Hint: run `but branch new` to create a new branch to work on
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊●   1 5877ef4 add files
+┊●   1 add files
 ┊│     1:r  A file-0.txt
 ┊│     1:k  A file-1.txt
 ┊│     1:t  A file-2.txt

--- a/crates/but/tests/but/command/uncommit.rs
+++ b/crates/but/tests/but/command/uncommit.rs
@@ -79,9 +79,9 @@ fn uncommit_different_files_from_different_commits_same_branch() -> anyhow::Resu
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   1#0 3d21fdd add c2
+┊●   1#0 add c2
 ┊│     1#0:w A c2.txt
-┊●   1#1 28b88fc add c1
+┊●   1#1 add c1
 ┊│     1#1:l A c1.txt
 ┊●   9477ae7 add A
 ┊│     9:t A A
@@ -136,8 +136,8 @@ Uncommitted changes
 ┊   w A c2.txt
 ┊
 ┊╭┄g0 [A]
-┊●   1#0 01fc011 add c2 (no changes)
-┊●   1#1 5682e2a add c1 (no changes)
+┊●   1#0 add c2 (no changes)
+┊●   1#1 add c1 (no changes)
 ┊●   9477ae7 add A
 ┊│     9:t A A
 ├╯
@@ -185,7 +185,7 @@ fn uncommit_different_files_from_the_same_commit() -> anyhow::Result<()> {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   1 191c6ed add c1 and c2
+┊●   1 add c1 and c2
 ┊│     1:l A c1.txt
 ┊│     1:w A c2.txt
 ┊●   9477ae7 add A
@@ -239,7 +239,7 @@ Uncommitted changes
 ┊   w A c2.txt
 ┊
 ┊╭┄g0 [A]
-┊●   1 3d256e6 add c1 and c2 (no changes)
+┊●   1 add c1 and c2 (no changes)
 ┊●   9477ae7 add A
 ┊│     9:t A A
 ├╯
@@ -289,11 +289,11 @@ fn uncommit_same_file_from_different_commits_same_branch() -> anyhow::Result<()>
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   1#0 485d867 write v3
+┊●   1#0 write v3
 ┊│     1#0:s M f.txt
-┊●   1#1 adeaad7 write v2
+┊●   1#1 write v2
 ┊│     1#1:s M f.txt
-┊●   1#2 825d09f write v1
+┊●   1#2 write v1
 ┊│     1#2:s A f.txt
 ┊●   9477ae7 add A
 ┊│     9:t A A
@@ -349,9 +349,9 @@ Uncommitted changes
 ┊   s A f.txt
 ┊
 ┊╭┄g0 [A]
-┊●   1#0 ddf33f2 write v3 (no changes)
-┊●   1#1 3212a72 write v2 (no changes)
-┊●   1#2 637ac90 write v1 (no changes)
+┊●   1#0 write v3 (no changes)
+┊●   1#1 write v2 (no changes)
+┊●   1#2 write v1 (no changes)
 ┊●   9477ae7 add A
 ┊│     9:t A A
 ├╯
@@ -399,14 +399,14 @@ fn uncommit_different_files_from_different_commits_different_branches() -> anyho
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊●   1#0 1675e0b add fa
+┊●   1#0 add fa
 ┊│     1#0:s A fa.txt
 ┊●   9477ae7 add A
 ┊│     9:t A A
 ├╯
 ┊
 ┊╭┄h0 [B]
-┊●   1#1 30b330c add fb
+┊●   1#1 add fb
 ┊│     1#1:q A fb.txt
 ┊●   d3e2ba3 add B
 ┊│     d:p A B
@@ -451,13 +451,13 @@ Uncommitted changes
 ┊   q A fb.txt
 ┊
 ┊╭┄g0 [A]
-┊●   1#0 3bbaec6 add fa (no changes)
+┊●   1#0 add fa (no changes)
 ┊●   9477ae7 add A
 ┊│     9:t A A
 ├╯
 ┊
 ┊╭┄h0 [B]
-┊●   1#1 0596eed add fb (no changes)
+┊●   1#1 add fb (no changes)
 ┊●   d3e2ba3 add B
 ┊│     d:p A B
 ├╯

--- a/crates/but/tests/but/command/undo/undo_uncommit.rs
+++ b/crates/but/tests/but/command/undo/undo_uncommit.rs
@@ -10,7 +10,7 @@ fn can_undo_but_uncommit_commit_add() {
     env.but("commit -m 'Add file'").assert().success();
 
     run_mutate_undo_roundtrip_test(&env, |env| {
-        env.but("uncommit 6a30821").assert().success();
+        env.but("uncommit 1").assert().success();
     });
 }
 
@@ -29,7 +29,7 @@ fn can_undo_but_uncommit_commit_modify() {
     env.but("commit -m 'Change file'").assert().success();
 
     run_mutate_undo_roundtrip_test(&env, |env| {
-        env.but("uncommit c0aac71").assert().success();
+        env.but("uncommit 1#0").assert().success();
     });
 }
 
@@ -47,7 +47,7 @@ fn can_undo_but_uncommit_commit_delete() {
     env.but("commit -m 'Remove file'").assert().success();
 
     run_mutate_undo_roundtrip_test(&env, |env| {
-        env.but("uncommit 1f27386").assert().success();
+        env.but("uncommit 1#0").assert().success();
     });
 }
 
@@ -61,7 +61,7 @@ fn can_undo_but_uncommit_file_add() {
     env.but("commit -m 'Add file'").assert().success();
 
     run_mutate_undo_roundtrip_test(&env, |env| {
-        env.but("uncommit 6a:xk").assert().success();
+        env.but("uncommit 1:xk").assert().success();
     });
 }
 
@@ -78,7 +78,7 @@ fn can_undo_but_uncommit_file_modify() {
     env.but("commit -m 'Modify file'").assert().success();
 
     run_mutate_undo_roundtrip_test(&env, |env| {
-        env.but("uncommit 31:xk").assert().success();
+        env.but("uncommit 1#0:xk").assert().success();
     });
 }
 
@@ -95,6 +95,6 @@ fn can_undo_but_uncommit_file_delete() {
     env.but("commit -m 'Remove file'").assert().success();
 
     run_mutate_undo_roundtrip_test(&env, |env| {
-        env.but("uncommit 1f:xk").assert().success();
+        env.but("uncommit 1#0:xk").assert().success();
     });
 }


### PR DESCRIPTION
## 🧢 Changes
Change IDs are overall much better for both agent and user to refer to commits, as they stay stable over edits and moves. So we're leaning into it.

This PR only prefers change ID if it physically exists in the commit. We don't use synthetic change IDs yet as they are not automatically persisted.