### PR TITLE
Lite: one weird trick to fix compiler memoization

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
@@ -351,6 +351,8 @@ const WorkspacePage: FC = () => {
 		Match.tags({ Absorb: ({ sourceTarget }) => sourceTarget }),
 		Match.orElse(() => null),
 	);
+	const { data: headInfo } = useQuery(headInfoQueryOptions(projectId));
+	const { data: worktreeChanges } = useQuery(changesInWorktreeQueryOptions(projectId));
 	const [absorptionPlanQuery] = useQueries({
 		queries: (absorptionPlanTarget ? [absorptionPlanTarget] : []).map((target) =>
 			absorptionPlanQueryOptions({ projectId, target }),
@@ -359,9 +361,6 @@ const WorkspacePage: FC = () => {
 	const absorptionTargetCommitIds = new Set(
 		absorptionPlanQuery?.data?.map(({ commitId }) => commitId),
 	);
-
-	const { data: headInfo } = useQuery(headInfoQueryOptions(projectId));
-	const { data: worktreeChanges } = useQuery(changesInWorktreeQueryOptions(projectId));
 
 	const outlineNavigationIndex = buildOutlineNavigationIndex({
 		headInfo,


### PR DESCRIPTION
Fixes a performance regression from https://github.com/gitbutlerapp/gitbutler/pull/14799 where moving selection would re-render every row.

[Reduced test case](https://playground.react.dev/#N4Igzg9grgTgxgUxALhHCA7MAXABAYQgFsAHTBDbZXAMX1wF5cAKASkYD5dgAdDH7Oix4Aho1xQwCAIJsA3HwFCcuACYIYASwBuCVTRjFp4jAgDuuAMoJszEawX9BmFQCNxkhACF5i58NwYBDAoABs8JgAzZnUtXX1DImkAGlxXB0UnIOxYDFwAHlUdDmAgkPCAX3yAeiLtDkcKuRBktExIzQBzFBBePNxq6vRSTVCRbE1MAFkIdWoeEBFQ0IW+CpbwAAsIMwBJSg0MJbAUSOOECqA)