### PR TITLE
Add dirty indicator to project selector

### DIFF
--- a/apps/desktop/src/components/shared/ProjectDirtyDot.svelte
+++ b/apps/desktop/src/components/shared/ProjectDirtyDot.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+	import { WORKTREE_SERVICE } from "$lib/worktree/worktreeService.svelte";
+	import { inject } from "@gitbutler/core/context";
+	import { Tooltip } from "@gitbutler/ui";
+
+	interface Props {
+		projectId: string;
+	}
+
+	const { projectId }: Props = $props();
+
+	const worktreeService = inject(WORKTREE_SERVICE);
+	const hasChangesQuery = $derived(worktreeService.hasChanges(projectId));
+	const hasChanges = $derived(hasChangesQuery.response ?? false);
+</script>
+
+{#if hasChanges}
+	<Tooltip text="Has uncommitted changes">
+		<div class="dirty-dot"></div>
+	</Tooltip>
+{/if}
+
+<style>
+	.dirty-dot {
+		flex-shrink: 0;
+		width: 6px;
+		height: 6px;
+		border-radius: 50%;
+		background-color: var(--clr-pop-60);
+	}
+</style>

--- a/apps/desktop/src/components/views/AppHeader.svelte
+++ b/apps/desktop/src/components/views/AppHeader.svelte
@@ -2,6 +2,7 @@
 	import { goto } from "$app/navigation";
 	import CreateBranchModal from "$components/branch/CreateBranchModal.svelte";
 	import SyncButton from "$components/forge/SyncButton.svelte";
+	import ProjectDirtyDot from "$components/shared/ProjectDirtyDot.svelte";
 	import IntegrateUpstreamModal from "$components/upstream/IntegrateUpstreamModal.svelte";
 	import { BACKEND } from "$lib/backend";
 	import { BASE_BRANCH_SERVICE } from "$lib/baseBranch/baseBranchService.svelte";
@@ -195,7 +196,12 @@
 
 				{#snippet itemSnippet({ item, highlighted })}
 					<SelectItem selected={item.value === projectId} {highlighted}>
-						{item.label}
+						<div class="project-selector-item">
+							<span class="project-selector-item__label">{item.label}</span>
+							{#if item.value}
+								<ProjectDirtyDot projectId={item.value} />
+							{/if}
+						</div>
 					</SelectItem>
 				{/snippet}
 
@@ -376,5 +382,18 @@
 		padding: 0 4px;
 		gap: 4px;
 		color: var(--text-2);
+	}
+
+	.project-selector-item {
+		display: flex;
+		align-items: center;
+		overflow: hidden;
+		gap: 6px;
+	}
+
+	.project-selector-item__label {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
 	}
 </style>

--- a/apps/desktop/src/lib/worktree/worktreeEndpoints.ts
+++ b/apps/desktop/src/lib/worktree/worktreeEndpoints.ts
@@ -87,6 +87,12 @@ export function buildWorktreeEndpoints(build: BackendEndpointBuilder) {
 			},
 		}),
 
+		// ── Worktree Dirty Check ────────────────────────────────────
+		worktreeHasChanges: build.query<boolean, { projectId: string }>({
+			extraOptions: { command: "worktree_has_changes" },
+			query: (args) => args,
+		}),
+
 		// ── Diff ────────────────────────────────────────────────────
 		getDiff: build.query<UnifiedDiff | null, { projectId: string; change: TreeChange }>({
 			extraOptions: { command: "tree_change_diffs" },

--- a/apps/desktop/src/lib/worktree/worktreeService.svelte.ts
+++ b/apps/desktop/src/lib/worktree/worktreeService.svelte.ts
@@ -56,6 +56,15 @@ export class WorktreeService {
 	}
 
 	/**
+	 * A cheap check for whether a project's worktree has any uncommitted
+	 * changes. Unlike `worktreeChanges` this works for projects that are not
+	 * currently open, e.g. for the project selector.
+	 */
+	hasChanges(projectId: string) {
+		return this.backendApi.endpoints.worktreeHasChanges.useQuery({ projectId });
+	}
+
+	/**
 	 * Exposes the worktreeChanges endpoint. This is currently intended to be
 	 * consumed by just the `DependencyService`.
 	 */

--- a/crates/but-api/src/diff.rs
+++ b/crates/but-api/src/diff.rs
@@ -103,6 +103,20 @@ pub fn tree_change_diffs(
     change.unified_patch(&repo, ctx.settings.context_lines)
 }
 
+/// Returns `true` if the project's worktree contains any uncommitted changes.
+///
+/// This is a cheap status check that doesn't compute hunk assignments or
+/// dependencies, suitable for indicators like the project selector.
+///
+/// For lower-level implementation details, see [`but_core::diff::worktree_changes()`].
+#[but_api]
+#[instrument(err(Debug))]
+pub fn worktree_has_changes(ctx: &Context) -> anyhow::Result<bool> {
+    let _guard = ctx.shared_worktree_access();
+    let repo = ctx.repo.get()?;
+    Ok(!but_core::diff::worktree_changes(&repo)?.changes.is_empty())
+}
+
 /// See [`changes_in_worktree_with_perm()`].
 #[but_api(napi)]
 #[instrument(err(Debug))]

--- a/crates/but-server/src/lib.rs
+++ b/crates/but-server/src/lib.rs
@@ -580,6 +580,10 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
             "/changes_in_worktree",
             but_post(diff::changes_in_worktree_cmd),
         )
+        .route(
+            "/worktree_has_changes",
+            but_post(diff::worktree_has_changes_cmd),
+        )
         .route("/assign_hunk", but_post(diff::assign_hunk_cmd))
         .route(
             "/cherry_apply_status",

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -403,6 +403,7 @@ fn main() -> anyhow::Result<()> {
                 legacy::absorb::tauri_absorb::absorb,
                 legacy::absorb::tauri_absorption_plan::absorption_plan,
                 diff::tauri_changes_in_worktree::changes_in_worktree,
+                diff::tauri_worktree_has_changes::worktree_has_changes,
                 diff::tauri_tree_change_diffs::tree_change_diffs,
                 diff::tauri_assign_hunk::assign_hunk,
                 #[cfg(unix)]


### PR DESCRIPTION
## Summary

Adds a small teal dot next to each project in the project selector dropdown
to indicate that the project's worktree has uncommitted (unstaged or staged)
changes. This gives users a quick visual cue about the state of their other
repositories without having to switch to them.

## Changes

### Backend (`crates/but-api`)
- Added a new `worktree_has_changes` API function in `diff.rs` — a cheap
  status check that opens the worktree under shared read access and returns
  `true` if there are any changes. No hunk assignments or dependency graph
  computation is done, so it is fast even for large repos.
- Registered the new command in the Tauri command handler and added a
  `/worktree_has_changes` route to `but-server`.

### Frontend (`apps/desktop`)
- Added a `worktreeHasChanges` Redux query endpoint that calls the new
  backend command.
- Added a `hasChanges(projectId)` convenience method to `WorktreeService`.
- Created `ProjectDirtyDot.svelte` — a tiny component that subscribes to
  the query for a given project and renders a teal dot (using the
  `--clr-pop-50` design token) with a tooltip when changes are present.
- Updated the project selector `itemSnippet` in `AppHeader.svelte` to
  render `ProjectDirtyDot` inline after each project name.

## Screenshots

<img width="1242" height="788" alt="image" src="https://github.com/user-attachments/assets/0948ea90-82bc-45e6-923c-f44a9c2fdafc" />

https://github.com/user-attachments/assets/10695034-494f-45d8-99ee-fd5efb4f7c45

