### PR TITLE
but status: make change IDs the unmistakable primary commit identifier

### DIFF
--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -34,7 +34,7 @@ use crate::{
         upstream::{self, BranchStatus as UpstreamBranchStatus},
         workspace_target,
     },
-    id::{SegmentWithId, ShortId, StackWithId, TreeChangeWithId},
+    id::{ChangeIdWithShortId, SegmentWithId, ShortId, StackWithId, TreeChangeWithId},
     tui::text::truncate_text,
     utils::{
         InputOutputChannel, OutputChannel, WriteWithUtils, shorten_hex_object_id,
@@ -198,6 +198,7 @@ struct StatusContext<'a> {
     branch_merge_statuses: BTreeMap<String, UpstreamBranchStatus>,
     has_branches: bool,
     is_agent_invocation: bool,
+    render_mode: StatusRenderMode,
     is_paged: bool,
     should_truncate_for_terminal: bool,
     id_map: IdMap,
@@ -566,6 +567,7 @@ fn build_status_context<'a>(
         has_branches,
         is_agent_invocation: matches!(format, OutputFormat::Agent)
             || crate::utils::detect_agent::detect().is_some(),
+        render_mode,
         is_paged,
         should_truncate_for_terminal,
         id_map,
@@ -684,6 +686,15 @@ fn print_hint(
             "Hint: ◐ means rewritten locally vs upstream.",
             crate::theme::get().hint,
         )]))?;
+    }
+
+    if status_ctx.is_agent_invocation {
+        let id_hint = if status_ctx.flags.verbose {
+            "Hint: the first token on each line is the ID to use in commands. The sha in parentheses is informational and changes on every amend."
+        } else {
+            "Hint: the first token on each line is the ID to use in commands."
+        };
+        output.hint(Vec::from([Span::styled(id_hint, crate::theme::get().hint)]))?;
     }
 
     let hint_text = if not_on_workspace {
@@ -1385,10 +1396,7 @@ fn print_group(
                     status_ctx,
                     stack_with_id.id,
                     commit.short_id.clone(),
-                    commit
-                        .change_id
-                        .as_ref()
-                        .map(|change_id| change_id.short_id.clone()),
+                    commit.change_id.as_ref(),
                     &inner.inner,
                     CommitChanges::Workspace(&commit.tree_changes_using_repo(&repo)?),
                     classification,
@@ -1516,7 +1524,7 @@ fn print_commit(
     status_ctx: &StatusContext<'_>,
     stack_id: Option<StackId>,
     short_id: ShortId,
-    short_change_id: Option<ShortId>,
+    change_id: Option<&ChangeIdWithShortId>,
     commit: &but_workspace::ref_info::Commit,
     commit_changes: CommitChanges,
     classification: CommitClassification,
@@ -1534,10 +1542,17 @@ fn print_commit(
 
     let upstream_commit = matches!(commit_changes, CommitChanges::Remote(_));
 
+    // One-shot output pads file ID prefixes to match the change ID shown on
+    // the commit line; the TUI keeps the minimal IDs.
+    let padded_file_id_prefix = match status_ctx.render_mode {
+        StatusRenderMode::Oneshot => change_id.map(ChangeIdWithShortId::padded_short_id),
+        StatusRenderMode::Tui(_) => None,
+    };
+
     let (details_line, _) = display_cli_commit_details(
         repo,
         short_id.clone(),
-        short_change_id,
+        change_id,
         commit,
         match commit_changes {
             CommitChanges::Workspace(tree_changes) => !tree_changes.is_empty(),
@@ -1634,7 +1649,9 @@ fn print_commit(
             CommitChanges::Workspace(tree_changes) => {
                 let max_id_width = tree_changes
                     .iter()
-                    .map(|change| change.short_id.len())
+                    .map(|change| {
+                        displayed_file_id(padded_file_id_prefix.as_deref(), &change.short_id).len()
+                    })
                     .max()
                     .unwrap_or(0);
 
@@ -1645,14 +1662,15 @@ fn print_commit(
                         id: short_id.to_owned(),
                     };
 
+                    let display_id = displayed_file_id(padded_file_id_prefix.as_deref(), short_id);
                     let (status, path) = tree_change_display_cli(inner);
                     output.file(
                         Vec::from([Span::raw("┊"), Span::raw("│"), Span::raw("     ")]),
                         FileLineContent {
                             id: Vec::from([
-                                Span::styled(short_id.to_owned(), t.cli_id),
+                                Span::styled(display_id.clone(), t.cli_id),
                                 Span::raw(
-                                    " ".repeat(max_id_width.saturating_sub(short_id.len()) + 1),
+                                    " ".repeat(max_id_width.saturating_sub(display_id.len()) + 1),
                                 ),
                             ]),
                             status: Vec::from([status]),
@@ -1689,6 +1707,15 @@ trait CliDisplay {
     ) -> impl IntoIterator<Item = Span<'static>>;
 }
 
+/// The committed-file ID as displayed: its commit prefix replaced with the
+/// padded change ID shown on the commit line, when one applies.
+fn displayed_file_id(padded_prefix: Option<&str>, short_id: &str) -> String {
+    match (padded_prefix, short_id.split_once(':')) {
+        (Some(prefix), Some((_, rest))) => format!("{prefix}:{rest}"),
+        _ => short_id.to_owned(),
+    }
+}
+
 fn tree_change_display_cli(change: &but_core::TreeChange) -> (Span<'static>, Span<'static>) {
     let path = path_with_color(&change.status, change.path.to_string());
     let status_letter = status_letter(&change.status);
@@ -1709,7 +1736,7 @@ impl CliDisplay for but_core::TreeChange {
 fn display_cli_commit_details(
     repo: &gix::Repository,
     short_id: ShortId,
-    short_change_id: Option<ShortId>,
+    change_id: Option<&ChangeIdWithShortId>,
     commit: &but_workspace::ref_info::Commit,
     has_changes: bool,
     verbose: bool,
@@ -1730,16 +1757,12 @@ fn display_cli_commit_details(
     };
     let start_id = Span::styled(short_id.to_string(), t.cli_id);
 
-    let change_id_spans = if let Some(short_change_id) = short_change_id {
-        let change_id_str = commit.change_id().to_string();
-        let hint_end = 3.min(change_id_str.len());
-        let hint = change_id_str
-            .get(short_change_id.len()..hint_end)
-            .unwrap_or("")
-            .to_string();
+    let change_id_spans = if let Some(change_id) = change_id {
+        let padded = change_id.padded_short_id();
+        let (id, hint) = padded.split_at(change_id.short_id.len());
         vec![
-            Span::styled(short_change_id.to_string(), t.change_id),
-            Span::styled(hint, t.hint),
+            Span::styled(id.to_string(), t.change_id),
+            Span::styled(hint.to_string(), t.hint),
         ]
     } else {
         vec![]
@@ -1762,20 +1785,31 @@ fn display_cli_commit_details(
         let created_at = commit.author.time;
         let formatted_time = created_at.format_or_unix(CLI_DATE);
 
-        let mut change_id_spans = change_id_spans;
-        if !change_id_spans.is_empty() {
-            change_id_spans.push(Span::raw(" "));
-        }
+        // When a change ID is shown it is the primary identifier; the sha is
+        // demoted to a labelled note after the timestamp so the two cannot be
+        // mistaken for one another.
+        let (sha, sha_note) = if change_id_spans.is_empty() {
+            (Vec::from_iter([start_id, end_id]), None)
+        } else {
+            (
+                Vec::new(),
+                Some(Span::styled(
+                    format!(" (sha {}{})", start_id.content, end_id.content),
+                    t.hint,
+                )),
+            )
+        };
 
         (
             CommitLineContent {
                 change_id: change_id_spans,
-                sha: Vec::from_iter([start_id, end_id]),
+                sha,
                 author: Vec::from_iter([Span::raw(" "), Span::raw(commit.author.name.to_string())]),
                 message: Vec::new(),
                 suffix: Vec::from_iter(
                     [Span::raw(" "), Span::styled(formatted_time, t.hint)]
                         .into_iter()
+                        .chain(sha_note)
                         .chain(maybe_with_leading_space(no_changes, conflicted)),
                 ),
             },

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -265,6 +265,24 @@ pub struct ChangeIdWithShortId {
     pub short_id: ShortId,
 }
 
+/// The minimum number of change ID characters displayed for a commit, so that
+/// short IDs remain visually distinctive.
+pub(crate) const MIN_DISPLAYED_CHANGE_ID_CHARS: usize = 3;
+
+impl ChangeIdWithShortId {
+    /// The short ID padded with further change ID characters to
+    /// [`MIN_DISPLAYED_CHANGE_ID_CHARS`], matching how the change ID is
+    /// displayed on commit lines.
+    pub fn padded_short_id(&self) -> String {
+        let mut id = self.short_id.clone();
+        let full = self.change_id.to_string();
+        if let Some(padding) = full.get(id.len()..MIN_DISPLAYED_CHANGE_ID_CHARS.min(full.len())) {
+            id.push_str(padding);
+        }
+        id
+    }
+}
+
 impl From<ChangeId> for ChangeIdWithShortId {
     fn from(value: ChangeId) -> Self {
         Self {

--- a/crates/but/tests/but/command/commit2.rs
+++ b/crates/but/tests/but/command/commit2.rs
@@ -172,7 +172,7 @@ fn can_repeat_message() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄g0 [A]
-┊● 1 b141567 author 2000-01-01 00:00:00 +0000
+┊● 1 author 2000-01-01 00:00:00 +0000 (sha b141567)
 ┊│     add file.txt  with more  text lines
 ┊● 9477ae7 author 2000-01-01 00:00:00 +0000
 ┊│     add A 

--- a/crates/but/tests/but/command/move2.rs
+++ b/crates/but/tests/but/command/move2.rs
@@ -976,7 +976,7 @@ Moved 1 changes from 9ac4652 to new commit 8e35f84 below commit fe12bcd
 ┊╭┄g0 [A]
 ┊●   ywx add second (no changes)
 ┊●   zll add first
-┊│     zl:l A first
+┊│     zll:l A first
 ┊●   1 (no commit message)
 ┊│     1:w A second
 ├╯
@@ -1030,7 +1030,7 @@ Moved 1 changes from fe12bcd to new commit c019027 above commit 9ac4652
 ┊●   1 (no commit message)
 ┊│     1:l A first
 ┊●   ywx add second
-┊│     y:w A second
+┊│     ywx:w A second
 ┊●   d8dfd0f add first (no changes)
 ├╯
 ┊
@@ -1082,7 +1082,7 @@ Moved 1 changes from 9ac4652 to new commit 8e35f84 on new branch 'a-branch-1' be
 ┊╭┄g0 [A]
 ┊●   ywx add second (no changes)
 ┊●   zll add first
-┊│     zl:l A first
+┊│     zll:l A first
 ┊│
 ┊├┄br [a-branch-1]
 ┊●   1 (no commit message)
@@ -1140,7 +1140,7 @@ Moved 1 changes from fe12bcd to new commit c019027 on new branch 'a-branch-1' ab
 ┊│
 ┊├┄g0 [A]
 ┊●   ywx add second
-┊│     y:w A second
+┊│     ywx:w A second
 ┊●   d8dfd0f add first (no changes)
 ├╯
 ┊

--- a/crates/but/tests/but/command/squash2.rs
+++ b/crates/but/tests/but/command/squash2.rs
@@ -177,11 +177,11 @@ fn use_target_message() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊● 1#0 5ab5165 author 2000-01-01 00:00:00 +0000
+┊● 1#0 author 2000-01-01 00:00:00 +0000 (sha 5ab5165)
 ┊│     add two
 ┊│     1#0:o A three
 ┊│     1#0:t A two
-┊● 1#1 ea345ba author 2000-01-01 00:00:00 +0000
+┊● 1#1 author 2000-01-01 00:00:00 +0000 (sha ea345ba)
 ┊│     add one
 ┊│     1#1:k A one
 ├╯
@@ -208,11 +208,11 @@ fn use_source_message() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊● 1#0 c441d34 author 2000-01-01 00:00:00 +0000
+┊● 1#0 author 2000-01-01 00:00:00 +0000 (sha c441d34)
 ┊│     add three
 ┊│     1#0:o A three
 ┊│     1#0:t A two
-┊● 1#1 ea345ba author 2000-01-01 00:00:00 +0000
+┊● 1#1 author 2000-01-01 00:00:00 +0000 (sha ea345ba)
 ┊│     add one
 ┊│     1#1:k A one
 ├╯
@@ -243,7 +243,7 @@ Squashed branch 'a-branch-1' to create commit a694042
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊● 1 a694042 author 2000-01-01 00:00:00 +0000
+┊● 1 author 2000-01-01 00:00:00 +0000 (sha a694042)
 ┊│     squashed a branch
 ┊│     1:k A one
 ┊│     1:o A three
@@ -276,7 +276,7 @@ Squashed branch 'a-branch-1' to create commit 17b59a2
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊● 1 17b59a2 author 2000-01-01 00:00:00 +0000
+┊● 1 author 2000-01-01 00:00:00 +0000 (sha 17b59a2)
 ┊│     add two
 ┊│     1:k A one
 ┊│     1:o A three
@@ -310,24 +310,24 @@ fn squash_whole_branch_into_commit_on_other_branch() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄fi [add-file-branch]
-┊● 1#0 e528488 author 2000-01-01 00:00:00 +0000
+┊● 1#0 author 2000-01-01 00:00:00 +0000 (sha e528488)
 ┊│     add file
 ┊│     1#0:q A file
 ├╯
 ┊
 ┊╭┄ta [target-branch]
-┊● 1#1 d1d6a19 author 2000-01-01 00:00:00 +0000 (no changes)
+┊● 1#1 author 2000-01-01 00:00:00 +0000 (sha d1d6a19) (no changes)
 ┊│     new commit on new branch
 ├╯
 ┊
 ┊╭┄br [a-branch-1]
-┊● 1#2 f55169f author 2000-01-01 00:00:00 +0000
+┊● 1#2 author 2000-01-01 00:00:00 +0000 (sha f55169f)
 ┊│     add three
 ┊│     1#2:o A three
-┊● 1#3 f63361f author 2000-01-01 00:00:00 +0000
+┊● 1#3 author 2000-01-01 00:00:00 +0000 (sha f63361f)
 ┊│     add two
 ┊│     1#3:t A two
-┊● 1#4 ea345ba author 2000-01-01 00:00:00 +0000
+┊● 1#4 author 2000-01-01 00:00:00 +0000 (sha ea345ba)
 ┊│     add one
 ┊│     1#4:k A one
 ├╯
@@ -353,7 +353,7 @@ Squashed branches 'a-branch-1', 'add-file-branch' to create commit 44aa30a
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄ta [target-branch]
-┊● 1 44aa30a author 2000-01-01 00:00:00 +0000
+┊● 1 author 2000-01-01 00:00:00 +0000 (sha 44aa30a)
 ┊│     new commit on new branch
 ┊│     1:q A file
 ┊│     1:k A one
@@ -391,26 +391,26 @@ fn squash_multiple_branches_into_commit_on_one_of_the_branch_sources() {
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄fi [add-file-branch]
-┊● 1#0 e528488 author 2000-01-01 00:00:00 +0000
+┊● 1#0 author 2000-01-01 00:00:00 +0000 (sha e528488)
 ┊│     add file
 ┊│     1#0:q A file
 ├╯
 ┊
 ┊╭┄ta [target-branch]
-┊● 1#1 a489b93 author 2000-01-01 00:00:00 +0000 (no changes)
+┊● 1#1 author 2000-01-01 00:00:00 +0000 (sha a489b93) (no changes)
 ┊│     random commit on target-branch
-┊● 1#2 561a8d8 author 2000-01-01 00:00:00 +0000 (no changes)
+┊● 1#2 author 2000-01-01 00:00:00 +0000 (sha 561a8d8) (no changes)
 ┊│     target commit
 ├╯
 ┊
 ┊╭┄br [a-branch-1]
-┊● 1#3 f55169f author 2000-01-01 00:00:00 +0000
+┊● 1#3 author 2000-01-01 00:00:00 +0000 (sha f55169f)
 ┊│     add three
 ┊│     1#3:o A three
-┊● 1#4 f63361f author 2000-01-01 00:00:00 +0000
+┊● 1#4 author 2000-01-01 00:00:00 +0000 (sha f63361f)
 ┊│     add two
 ┊│     1#4:t A two
-┊● 1#5 ea345ba author 2000-01-01 00:00:00 +0000
+┊● 1#5 author 2000-01-01 00:00:00 +0000 (sha ea345ba)
 ┊│     add one
 ┊│     1#5:k A one
 ├╯
@@ -436,7 +436,7 @@ Squashed branches 'target-branch', 'a-branch-1', 'add-file-branch' to create com
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄ta [target-branch]
-┊● 1 0653794 author 2000-01-01 00:00:00 +0000
+┊● 1 author 2000-01-01 00:00:00 +0000 (sha 0653794)
 ┊│     target commit
 ┊│     1:q A file
 ┊│     1:k A one
@@ -478,7 +478,7 @@ Squashed branch 'a-branch-1' to create commit 7b3d915
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊● 1 7b3d915 author 2000-01-01 00:00:00 +0000
+┊● 1 author 2000-01-01 00:00:00 +0000 (sha 7b3d915)
 ┊│     message from editor
 ┊│     1:k A one
 ┊│     1:o A three
@@ -516,7 +516,7 @@ Squashed branch 'a-branch-1' to create commit abb21d9
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊● 1 abb21d9 author 2000-01-01 00:00:00 +0000
+┊● 1 author 2000-01-01 00:00:00 +0000 (sha abb21d9)
 ┊│     add one  add three  add two
 ┊│     1:k A one
 ┊│     1:o A three

--- a/crates/but/tests/but/command/status.rs
+++ b/crates/but/tests/but/command/status.rs
@@ -1167,6 +1167,7 @@ This notice repeats until the skill is installed. If it still appears after inst
 ┴ 0dc3733 (common base) 2000-01-02 add M
 
 Hint: ◐ means rewritten locally vs upstream.
+Hint: the first token on each line is the ID to use in commands.
 Hint: run `but help` for all commands
 
 "#]]);
@@ -1185,6 +1186,7 @@ Hint: run `but help` for all commands
 ┴ 0dc3733 (common base) 2000-01-02 add M
 
 Hint: ◐ means rewritten locally vs upstream.
+Hint: the first token on each line is the ID to use in commands.
 Hint: run `but help` for all commands
 
 "#]]);
@@ -1306,7 +1308,7 @@ fn status_file_prefixed_with_change_id_when_available_and_commit_id_otherwise() 
 ┊
 ┊╭┄g0 [A]
 ┊●   123 Commit with change ID
-┊│     1:p A B
+┊│     123:p A B
 ┊●   9477ae7 add A
 ┊│     9:t A A
 ├╯
@@ -1385,7 +1387,7 @@ Hint: run `but help` for all commands
 ╭┄zz [uncommitted] (no changes)
 ┊
 ┊╭┄br [a-branch-1]
-┊● 1 5877ef4 author 2000-01-01 00:00:00 +0000
+┊● 1 author 2000-01-01 00:00:00 +0000 (sha 5877ef4)
 ┊│     add files
 ┊│     1:r  A file-0.txt
 ┊│     1:k  A file-1.txt


### PR DESCRIPTION
`but status -v` showed the commit sha directly next to the change ID (`tww 41ef713 …`), which makes it easy for agents to grab the wrong identifier: the sha resolves today but goes stale after any amend, while the change ID is stable.

- Verbose commit lines demote the sha to a labelled note after the timestamp: `kyn Kiril Videlov 2026-07-08 … (sha 50c9fa2)`. Commits without a change ID (e.g. upstream-only) keep the sha as their leading identifier.
- One-shot output pads committed-file ID prefixes to match the change ID shown on the commit line (`k:ww` → `kyn:ww`), so the parent/child linkage is visible without color. The TUI keeps the minimal IDs.
- Agent invocations get one extra hint line spelling out the grammar: the first token on each line is the ID to use in commands, and (in verbose mode) that the parenthesized sha changes on every amend.

Both the padded and minimal ID forms resolve in the parser via prefix matching, so nothing changes for what users can type.

The GitButler skill file update describing the new output format will come in a follow-up PR.