### PR TITLE
Added an experimental flag for future worktree manipulation functionality

### DIFF
--- a/apps/desktop/src/components/settings/ExperimentalSettings.svelte
+++ b/apps/desktop/src/components/settings/ExperimentalSettings.svelte
@@ -55,6 +55,25 @@
 		</CardGroup.Item>
 	{/if}
 
+	<CardGroup.Item labelFor="worktree-manipulation">
+		{#snippet title()}
+			Worktree manipulation
+		{/snippet}
+		{#snippet caption()}
+			Enable experimental support for working with linked git worktrees.
+		{/snippet}
+		{#snippet actions()}
+			<Toggle
+				id="worktree-manipulation"
+				checked={$settingsStore?.featureFlags.worktreeManipulation}
+				onclick={() =>
+					settingsService.updateFeatureFlags({
+						worktreeManipulation: !$settingsStore?.featureFlags.worktreeManipulation,
+					})}
+			/>
+		{/snippet}
+	</CardGroup.Item>
+
 	<CardGroup.Item labelFor="irc">
 		{#snippet title()}
 			IRC integration

--- a/crates/but-settings/assets/defaults.jsonc
+++ b/crates/but-settings/assets/defaults.jsonc
@@ -29,7 +29,9 @@
 		/// Possible values: "auto", "legacy", "modern".
 		"watchMode": "auto",
 		"writeCommitEvolution": false,
-        "tuiFileBrowser": false
+		"tuiFileBrowser": false,
+		/// Enable experimental worktree manipulation support.
+		"worktreeManipulation": false
 	},
 	// Allows for additional "connect-src" hosts to be included. Requires app restart.
 	"extraCsp": {

--- a/crates/but-settings/src/api.rs
+++ b/crates/but-settings/src/api.rs
@@ -19,6 +19,7 @@ pub struct FeatureFlagsUpdate {
     pub unapply_v3_pgm: Option<bool>,
     pub single_branch: Option<bool>,
     pub irc: Option<bool>,
+    pub worktree_manipulation: Option<bool>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -117,6 +118,7 @@ impl AppSettingsWithDiskSync {
             unapply_v3_pgm,
             single_branch,
             irc,
+            worktree_manipulation,
         }: FeatureFlagsUpdate,
     ) -> Result<()> {
         let mut settings = self.get_mut_enforce_save()?;
@@ -128,6 +130,9 @@ impl AppSettingsWithDiskSync {
         }
         if let Some(irc) = irc {
             settings.feature_flags.irc = irc;
+        }
+        if let Some(worktree_manipulation) = worktree_manipulation {
+            settings.feature_flags.worktree_manipulation = worktree_manipulation;
         }
         settings.save()
     }
@@ -364,6 +369,7 @@ mod tests {
                 unapply_v3_pgm: Some(true),
                 single_branch: None,
                 irc: None,
+                worktree_manipulation: None,
             })
             .unwrap();
 

--- a/crates/but-settings/src/app_settings.rs
+++ b/crates/but-settings/src/app_settings.rs
@@ -52,6 +52,8 @@ pub struct FeatureFlags {
     pub write_commit_evolution: bool,
     /// Show the experimental file browser in the TUI.
     pub tui_file_browser: bool,
+    /// Enable experimental worktree manipulation support.
+    pub worktree_manipulation: bool,
 }
 but_schemars::register_sdk_type!(FeatureFlags);
 

--- a/crates/but-testsupport/src/sandbox.rs
+++ b/crates/but-testsupport/src/sandbox.rs
@@ -514,6 +514,7 @@ impl Sandbox {
                 watch_mode: "auto".into(),
                 write_commit_evolution: true,
                 tui_file_browser: false,
+                worktree_manipulation: false,
             },
             extra_csp: ExtraCsp {
                 hosts: vec![],

--- a/packages/but-sdk/src/generated/graph/index.d.ts
+++ b/packages/but-sdk/src/generated/graph/index.d.ts
@@ -1528,6 +1528,8 @@ export type FeatureFlags = {
   writeCommitEvolution: boolean;
   /** Show the experimental file browser in the TUI. */
   tuiFileBrowser: boolean;
+  /** Enable experimental worktree manipulation support. */
+  worktreeManipulation: boolean;
 };
 
 export type Fetch = {

--- a/packages/but-sdk/src/generated/linear/index.d.ts
+++ b/packages/but-sdk/src/generated/linear/index.d.ts
@@ -1528,6 +1528,8 @@ export type FeatureFlags = {
   writeCommitEvolution: boolean;
   /** Show the experimental file browser in the TUI. */
   tuiFileBrowser: boolean;
+  /** Enable experimental worktree manipulation support. */
+  worktreeManipulation: boolean;
 };
 
 export type Fetch = {


### PR DESCRIPTION
* Closes GB-1754

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #14841 
- <kbd>&nbsp;1&nbsp;</kbd> #14811 👈 
<!-- GitButler Footer Boundary Bottom -->

