### PR TITLE
fix(config): Refresh stored target metadata

### DIFF
--- a/crates/but-workspace/src/init.rs
+++ b/crates/but-workspace/src/init.rs
@@ -11,6 +11,38 @@ use but_core::{
     ref_metadata::ProjectMeta,
 };
 
+/// Refresh the stored target commit from the configured remote-tracking ref.
+///
+/// Returns `true` when metadata changed. This does not move refs or alter the
+/// workspace; callers must reject applied stacks and hold exclusive repository
+/// access before invoking it.
+pub fn refresh_target_commit_id(
+    repo: &gix::Repository,
+    meta: &mut impl RefMetadata,
+) -> Result<bool> {
+    let mut project_meta = ProjectMeta::resolve(repo, &*meta)?;
+    let target_ref = project_meta.target_ref_or_err()?.clone();
+    if target_ref.category() != Some(gix::refs::Category::RemoteBranch) {
+        bail!(
+            "target ref '{}' must be a remote tracking branch",
+            target_ref.as_bstr()
+        );
+    }
+    let target_tip = repo
+        .try_find_reference(target_ref.as_ref())?
+        .with_context(|| format!("remote branch '{}' not found", target_ref.as_bstr()))?
+        .peel_to_commit()
+        .with_context(|| format!("failed to peel branch '{}' to commit", target_ref.as_bstr()))?
+        .id;
+    if project_meta.target_commit_id == Some(target_tip) {
+        return Ok(false);
+    }
+
+    project_meta.target_commit_id = Some(target_tip);
+    project_meta.persist(repo, meta)?;
+    Ok(true)
+}
+
 /// Make `target_ref` the project's default target and initialize project metadata,
 /// without changing the currently checked out branch.
 ///

--- a/crates/but-workspace/tests/workspace/init.rs
+++ b/crates/but-workspace/tests/workspace/init.rs
@@ -46,6 +46,13 @@ fn stored_meta(repo: &gix::Repository, meta: &VirtualBranchesTomlMetadata) -> Pr
     ProjectMeta::resolve(repo, meta).expect("project metadata is readable")
 }
 
+fn refresh_target(
+    repo: &gix::Repository,
+    meta: &mut VirtualBranchesTomlMetadata,
+) -> anyhow::Result<bool> {
+    but_workspace::init::refresh_target_commit_id(repo, meta)
+}
+
 /// Create an empty commit on top of `parent` without updating any reference.
 fn empty_commit_on_top(
     repo: &gix::Repository,
@@ -249,6 +256,90 @@ fn push_remote_changes_without_changing_target() {
     assert_eq!(after.target_ref, before.target_ref);
     assert_eq!(after.target_commit_id, before.target_commit_id);
     assert_eq!(after.push_remote.as_deref(), Some("fork"));
+}
+
+#[test]
+fn refresh_updates_only_the_target_commit_id_to_the_configured_ref_tip() {
+    let (repo, mut meta, _tmp) = scenario();
+    set_target_ref(&repo, &mut meta, "refs/remotes/origin/main", Some("fork")).unwrap();
+    let stale_target_id = stored_meta(&repo, &meta).target_commit_id.unwrap();
+    let new_target_tip = empty_commit_on_top(&repo, stale_target_id, "advance target");
+    repo.reference(
+        "refs/remotes/origin/main",
+        new_target_tip,
+        PreviousValue::Any,
+        "test",
+    )
+    .unwrap();
+    let head_before = repo.head_id().unwrap().detach();
+    let refs_before = repo
+        .references()
+        .unwrap()
+        .all()
+        .unwrap()
+        .map(|reference| {
+            let reference = reference.unwrap();
+            (reference.name().to_owned(), reference.id())
+        })
+        .collect::<Vec<_>>();
+
+    assert!(
+        refresh_target(&repo, &mut meta).unwrap(),
+        "stale metadata should be updated"
+    );
+
+    let project_meta = stored_meta(&repo, &meta);
+    assert_eq!(
+        project_meta.target_ref.map(|name| name.to_string()),
+        Some("refs/remotes/origin/main".to_string()),
+        "refresh keeps the configured target ref"
+    );
+    assert_eq!(
+        project_meta.target_commit_id,
+        Some(new_target_tip),
+        "refresh stores the configured remote-tracking ref tip"
+    );
+    assert_eq!(
+        project_meta.push_remote.as_deref(),
+        Some("fork"),
+        "refresh preserves the distinct push remote"
+    );
+    assert_eq!(
+        repo.head_id().unwrap().detach(),
+        head_before,
+        "refresh does not move HEAD"
+    );
+    let refs_after = repo
+        .references()
+        .unwrap()
+        .all()
+        .unwrap()
+        .map(|reference| {
+            let reference = reference.unwrap();
+            (reference.name().to_owned(), reference.id())
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        refs_after, refs_before,
+        "refresh does not move local, remote, or workspace refs"
+    );
+}
+
+#[test]
+fn refresh_is_an_idempotent_no_op_when_the_target_is_current() {
+    let (repo, mut meta, _tmp) = scenario();
+    set_target_ref(&repo, &mut meta, "refs/remotes/origin/main", Some("fork")).unwrap();
+    let before = stored_meta(&repo, &meta);
+
+    assert!(
+        !refresh_target(&repo, &mut meta).unwrap(),
+        "current metadata should not be persisted again"
+    );
+    assert_eq!(
+        stored_meta(&repo, &meta),
+        before,
+        "an idempotent refresh preserves all project metadata"
+    );
 }
 
 mod error {

--- a/crates/but/src/args/config.rs
+++ b/crates/but/src/args/config.rs
@@ -102,12 +102,21 @@ pub enum Subcommands {
     /// ```text
     /// but config target upstream/main --push-remote origin
     /// ```
+    ///
+    /// Refresh the stored target commit from the configured remote-tracking ref:
+    ///
+    /// ```text
+    /// but config target --refresh
+    /// ```
     Target {
         /// New target branch to set (e.g., "origin/main")
         branch: Option<String>,
         /// Remote to push branches to (e.g., "origin" for a fork).
         #[clap(long, value_name = "REMOTE", requires = "branch")]
         push_remote: Option<String>,
+        /// Refresh the stored target commit from the configured remote-tracking ref.
+        #[clap(long, conflicts_with = "branch")]
+        refresh: bool,
     },
 
     /// View or set the remote used to push branches.

--- a/crates/but/src/args/tests.rs
+++ b/crates/but/src/args/tests.rs
@@ -479,10 +479,12 @@ mod config_target {
                     Some(ConfigCmd::Target {
                         branch,
                         push_remote,
+                        refresh,
                     }),
             }) => {
                 assert_eq!(branch.as_deref(), Some("upstream/main"));
                 assert_eq!(push_remote.as_deref(), Some("origin"));
+                assert!(!refresh);
             }
             _ => panic!("unexpected command shape"),
         }
@@ -492,13 +494,37 @@ mod config_target {
     fn parses_standalone_push_remote() {
         let args = Args::try_parse_from(["but", "config", "push-remote", "origin"])
             .expect("parse standalone push remote");
-
         assert!(matches!(
             args.cmd,
             Some(Subcommands::Config(ConfigPlatform {
                 cmd: Some(ConfigCmd::PushRemote { remote: Some(remote) }),
             })) if remote == "origin"
         ));
+    }
+
+    #[test]
+    fn parses_target_refresh() {
+        let args = Args::try_parse_from(["but", "config", "target", "--refresh"])
+            .expect("parse target refresh");
+
+        assert!(matches!(
+            args.cmd,
+            Some(Subcommands::Config(ConfigPlatform {
+                cmd: Some(ConfigCmd::Target {
+                    branch: None,
+                    push_remote: None,
+                    refresh: true,
+                }),
+            }))
+        ));
+    }
+
+    #[test]
+    fn refresh_rejects_target_branch() {
+        let err = Args::try_parse_from(["but", "config", "target", "upstream/main", "--refresh"])
+            .expect_err("refresh uses the already configured target");
+
+        assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
     }
 
     #[test]

--- a/crates/but/src/command/config.rs
+++ b/crates/but/src/command/config.rs
@@ -92,7 +92,8 @@ pub async fn exec(
         Some(Subcommands::Target {
             branch,
             push_remote,
-        }) => target_config(ctx, out, branch, push_remote).await,
+            refresh,
+        }) => target_config(ctx, out, branch, push_remote, refresh).await,
         Some(Subcommands::PushRemote { remote }) => push_remote_config(ctx, out, remote),
         Some(Subcommands::Forge { cmd }) => forge_config(out, cmd).await,
         Some(Subcommands::Metrics { status }) => metrics_config(out, status).await,
@@ -1769,10 +1770,11 @@ async fn target_config(
     out: &mut OutputChannel,
     branch: Option<String>,
     push_remote: Option<String>,
+    refresh: bool,
 ) -> Result<()> {
     let t = theme::get();
-    match branch {
-        None => {
+    match (branch, refresh) {
+        (None, false) => {
             #[cfg(feature = "legacy")]
             {
                 let target = {
@@ -1822,7 +1824,77 @@ async fn target_config(
                 }
             }
         }
-        Some(new_branch) => {
+        (None, true) => {
+            let (changed, target_id) = {
+                let mut guard = ctx.exclusive_worktree_access();
+                let (repo, ws, db) =
+                    ctx.workspace_mut_and_db_with_perm(guard.write_permission())?;
+                if !ws.stacks.is_empty() {
+                    if let Some(out) = out.for_human() {
+                        writeln!(
+                            out,
+                            "{}",
+                            t.important
+                                .paint("\nThe following branches are currently applied:\n")
+                        )?;
+                        for stack in &ws.stacks {
+                            writeln!(
+                                out,
+                                "{} Applied branch: {}",
+                                t.hint.paint("•"),
+                                t.config_value.paint(stack.ref_name().map_or_else(
+                                    || "ANONYMOUS".to_string(),
+                                    |rn| rn.shorten().to_string()
+                                ))
+                            )?;
+                        }
+                        writeln!(
+                            out,
+                            "\n{}\n",
+                            t.attention.paint(
+                                "Please unapply all branches before refreshing target metadata."
+                            )
+                        )?;
+                    }
+                    anyhow::bail!(
+                        "Cannot refresh target metadata while there are applied branches. Please unapply all branches first."
+                    );
+                }
+                drop((repo, ws, db));
+
+                let (changed, target_id) = {
+                    let repo = ctx.repo.get()?;
+                    let mut meta = ctx.meta()?;
+                    let changed = but_workspace::init::refresh_target_commit_id(&repo, &mut meta)?;
+                    let target_id = ctx.project_meta()?.target_commit_id_or_err()?;
+                    (changed, target_id)
+                };
+                ctx.invalidate_workspace_cache()?;
+                (changed, target_id)
+            };
+
+            if let Some(out) = out.for_human() {
+                writeln!(
+                    out,
+                    "{} {} {}",
+                    t.sym().success,
+                    if changed {
+                        "Refreshed target SHA to"
+                    } else {
+                        "Target SHA is already current at"
+                    },
+                    t.config_value.paint(target_id.to_string())
+                )?;
+            } else if let Some(out) = out.for_shell() {
+                writeln!(out, "{target_id}")?;
+            } else if let Some(out) = out.for_json() {
+                out.write_value(serde_json::json!({
+                    "refreshed": changed,
+                    "sha": target_id.to_string(),
+                }))?;
+            }
+        }
+        (Some(new_branch), false) => {
             // refuse to run if there are any applied branches. if so, ask user to unapply first.
             let (guard, _, ws, _) = ctx.workspace_and_db()?;
             if !ws.stacks.is_empty() {
@@ -1878,9 +1950,19 @@ async fn target_config(
                     .with_context(|| format!("Failed to find push remote '{push_remote}'"))?;
             }
 
-            let target_ref: gix::refs::FullName = format!("refs/remotes/{new_branch}")
-                .try_into()
-                .context("Invalid target branch name")?;
+            let target_ref: gix::refs::FullName = if new_branch.starts_with("refs/") {
+                new_branch
+                    .as_str()
+                    .try_into()
+                    .context("Invalid target branch name")?
+            } else {
+                format!("refs/remotes/{new_branch}")
+                    .try_into()
+                    .context("Invalid target branch name")?
+            };
+            if target_ref.category() != Some(gix::refs::Category::RemoteBranch) {
+                anyhow::bail!("Target branch must be a remote tracking branch");
+            }
             drop((guard, ws));
             but_api::workspace::set_target_ref_and_init_project(
                 ctx,
@@ -1888,6 +1970,7 @@ async fn target_config(
                 push_remote,
             )?;
         }
+        (Some(_), true) => unreachable!("clap rejects --refresh with a branch"),
     }
 
     Ok(())

--- a/crates/but/tests/but/command/config.rs
+++ b/crates/but/tests/but/command/config.rs
@@ -1,3 +1,9 @@
+#[cfg(feature = "legacy")]
+use std::fs;
+
+#[cfg(feature = "legacy")]
+use but_core::RepositoryExt as _;
+
 use crate::utils::{CommandExt as _, Sandbox};
 use snapbox::str;
 
@@ -9,7 +15,7 @@ fn target_configures_distinct_push_remote_for_fork() {
     env.invoke_git("remote add upstream .");
     env.invoke_git("update-ref refs/remotes/upstream/main refs/remotes/origin/main");
 
-    env.but("config target upstream/main --push-remote origin")
+    env.but("config target refs/remotes/upstream/main --push-remote origin")
         .assert()
         .success();
 
@@ -20,6 +26,165 @@ fn target_configures_distinct_push_remote_for_fork() {
     assert_eq!(
         env.invoke_git("config --local --get gitbutler.project.pushRemote"),
         "origin"
+    );
+}
+
+#[cfg(feature = "legacy")]
+#[test]
+fn target_refresh_updates_only_metadata_and_is_idempotent() {
+    let env = Sandbox::open_with_default_settings("repo-with-remote-and-head");
+    env.but("setup").assert().success();
+    env.invoke_git("remote add upstream .");
+    env.invoke_git("update-ref refs/remotes/upstream/main refs/remotes/origin/main");
+    env.but("config target upstream/main --push-remote origin")
+        .assert()
+        .success();
+    env.invoke_bash(
+        r#"
+new_target=$(printf 'advance target\n' | git commit-tree refs/remotes/upstream/main^{tree} -p refs/remotes/upstream/main)
+git update-ref refs/remotes/upstream/main "$new_target"
+"#,
+    );
+
+    let expected_target = env.invoke_git("rev-parse refs/remotes/upstream/main");
+    let refs_before = env.invoke_git("show-ref");
+    let head_before = env.invoke_git("rev-parse HEAD");
+    let index_before = env.invoke_git("ls-files --stage");
+    let worktree_before = env.invoke_git("status --porcelain=v2 --untracked-files=all");
+
+    env.but("config target --refresh").assert().success();
+
+    assert_eq!(
+        env.invoke_git("config --local --get gitbutler.project.targetRef"),
+        "refs/remotes/upstream/main"
+    );
+    assert_eq!(
+        env.invoke_git("config --local --get gitbutler.project.targetCommitId"),
+        expected_target
+    );
+    assert_eq!(
+        env.invoke_git("config --local --get gitbutler.project.pushRemote"),
+        "origin"
+    );
+    assert_eq!(
+        env.invoke_git("show-ref"),
+        refs_before,
+        "refresh does not move local, remote, or workspace refs"
+    );
+    assert_eq!(
+        env.invoke_git("rev-parse HEAD"),
+        head_before,
+        "refresh does not move HEAD"
+    );
+    assert_eq!(
+        env.invoke_git("ls-files --stage"),
+        index_before,
+        "refresh does not alter the index"
+    );
+    assert_eq!(
+        env.invoke_git("status --porcelain=v2 --untracked-files=all"),
+        worktree_before,
+        "refresh does not alter the worktree"
+    );
+
+    let repo = env.open_repo();
+    let config_path = repo.path().join("config");
+    let metadata_path = repo
+        .gitbutler_storage_path()
+        .unwrap()
+        .join("virtual_branches.toml");
+    let config_after_first_refresh = fs::read(&config_path).unwrap();
+    let metadata_after_first_refresh = fs::read(&metadata_path).unwrap();
+
+    env.but("config target --refresh").assert().success();
+
+    assert_eq!(
+        fs::read(config_path).unwrap(),
+        config_after_first_refresh,
+        "a current target does not rewrite repository config"
+    );
+    assert_eq!(
+        fs::read(metadata_path).unwrap(),
+        metadata_after_first_refresh,
+        "a current target does not rewrite legacy metadata"
+    );
+}
+
+#[cfg(feature = "legacy")]
+#[test]
+fn target_refresh_rejects_named_stacks_before_metadata_writes() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
+
+    assert_refresh_rejected_without_metadata_writes(&env);
+}
+
+#[cfg(feature = "legacy")]
+#[test]
+fn target_refresh_rejects_anonymous_stacks_before_metadata_writes() {
+    let env =
+        Sandbox::init_scenario_with_target_and_default_settings("one-stack-anonymous-segment");
+
+    assert_refresh_rejected_without_metadata_writes(&env);
+}
+
+#[cfg(feature = "legacy")]
+fn assert_refresh_rejected_without_metadata_writes(env: &Sandbox) {
+    let repo = env.open_repo();
+    let config_path = repo.path().join("config");
+    let metadata_path = repo
+        .gitbutler_storage_path()
+        .unwrap()
+        .join("virtual_branches.toml");
+    let config_before = fs::read(&config_path).unwrap();
+    let metadata_before = fs::read(&metadata_path).unwrap();
+    let refs_before = env.invoke_git("show-ref");
+    let head_before = env.invoke_git("rev-parse HEAD");
+    let index_before = env.invoke_git("ls-files --stage");
+    let worktree_before = env.invoke_git("status --porcelain=v2 --untracked-files=all");
+
+    let output = env.but("config target --refresh").output().unwrap();
+    assert!(
+        !output.status.success(),
+        "refresh should reject applied branches"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(
+            "Cannot refresh target metadata while there are applied branches. Please unapply all branches first."
+        ),
+        "unexpected stderr: {stderr}"
+    );
+
+    assert_eq!(
+        fs::read(config_path).unwrap(),
+        config_before,
+        "rejection happens before repository config is written"
+    );
+    assert_eq!(
+        fs::read(metadata_path).unwrap(),
+        metadata_before,
+        "rejection happens before legacy metadata is written"
+    );
+    assert_eq!(
+        env.invoke_git("show-ref"),
+        refs_before,
+        "rejection does not move refs"
+    );
+    assert_eq!(
+        env.invoke_git("rev-parse HEAD"),
+        head_before,
+        "rejection does not move HEAD"
+    );
+    assert_eq!(
+        env.invoke_git("ls-files --stage"),
+        index_before,
+        "rejection does not alter the index"
+    );
+    assert_eq!(
+        env.invoke_git("status --porcelain=v2 --untracked-files=all"),
+        worktree_before,
+        "rejection does not alter the worktree"
     );
 }
 


### PR DESCRIPTION
## 🧢 Changes

- Add `but config target --refresh` to update the stored target commit from the
  already configured remote-tracking ref.
- Keep `but config target --push-remote <remote>` working without a positional
  target branch.
- Preserve target identity, refs, workspace, branch tips, index, and worktree.
- Reject refresh while named or anonymous stacks are applied, and reject a
  simultaneous target change.
- Normalize fully qualified remote-ref input.

## ☕️ Reasoning

Fetching can advance the configured remote-tracking ref while the project keeps
an older stored target commit. Re-selecting the same target intentionally
preserves that commit, leaving no supported metadata-only repair.

An explicit refresh provides a bounded recovery path without pulling, moving a
protected local default branch, or disturbing workspace state. This is useful
for human and agentic coding workflows that separate remote refresh from
workspace integration.

## 🧪 Reproduction

```sh
but pull --check
but config target --refresh
```

Before this fix, the first command could advance the configured tracking ref
while the stored target commit remained stale. Re-selecting the same target was
intentionally a no-op.

## ✅ Verification

- Focused workspace, parser, CLI, and push-remote compatibility tests passed.
- The tests cover idempotence, applied-stack rejection, and preservation of
  refs, HEAD, workspace, index, worktree, target name, and push remote.
- Formatting, warnings-denied Clippy with `--no-default-features`, focused diff
  review, and commit-signature verification passed.

Developed with carefully directed, manually reviewed AI assistance.

Co-Authored-By: GPT-5.6 Sol <codex@openai.com>
