### PR TITLE
fix(workspace): Drop preserved anonymous remnants

### DIFF
--- a/crates/but-workspace/src/branch/unapply.rs
+++ b/crates/but-workspace/src/branch/unapply.rs
@@ -468,9 +468,10 @@ pub(crate) mod function {
         workspace_ref_name: &FullNameRef,
         ws_md: &but_core::ref_metadata::Workspace,
         disposition: WorkspaceDisposition,
-        excluded_anonymous_tip_id: Option<gix::ObjectId>,
+        unapplied_branch_tip_id: Option<gix::ObjectId>,
     ) -> anyhow::Result<WorkspaceRefUpdateAfterUnapply> {
-        let future_workspace_tips = future_workspace_tips(ws_md, ws, excluded_anonymous_tip_id)?;
+        let future_workspace_tips =
+            future_workspace_tips(ws_md, ws, repo, unapplied_branch_tip_id)?;
         let remaining_tip_count = future_workspace_tips.len();
         let keep_workspace_commit = match disposition {
             WorkspaceDisposition::KeepWorkspaceCommit
@@ -530,16 +531,14 @@ pub(crate) mod function {
     fn future_workspace_tips(
         ws_md: &but_core::ref_metadata::Workspace,
         ws: &but_graph::Workspace,
-        excluded_anonymous_tip_id: Option<gix::ObjectId>,
+        repo: &gix::Repository,
+        unapplied_branch_tip_id: Option<gix::ObjectId>,
     ) -> anyhow::Result<Vec<crate::commit::merge::Tip>> {
+        let anonymous_tips = anon_stacks_to_preserve(ws, repo, unapplied_branch_tip_id)?;
         let crate::commit::merge::ResolvedTips {
             tips,
             missing_stacks,
-        } = WorkspaceCommit::tips_from_metadata(
-            ws_md.stacks.iter(),
-            anon_stacks_to_preserve(ws, excluded_anonymous_tip_id),
-            &ws.graph,
-        );
+        } = WorkspaceCommit::tips_from_metadata(ws_md.stacks.iter(), anonymous_tips, &ws.graph);
         ensure!(
             missing_stacks.is_empty(),
             "Somehow some of the workspace stacks weren't part of the graph: {missing_stacks:#?}"
@@ -689,14 +688,43 @@ pub(crate) mod function {
     /// Reprojecting after metadata changes can leave old workspace-commit parents visible as
     /// anonymous stacks. If such a stack still has a metadata [stack id](but_core::ref_metadata::StackId),
     /// it is a projected remnant of the old workspace commit rather than independent anonymous work,
-    /// and feeding it back into the merge would preserve the removed stack.
-    fn anon_stacks_to_preserve<'a>(
-        ws: &'a but_graph::Workspace,
-        excluded_tip_id: Option<gix::ObjectId>,
-    ) -> impl Iterator<Item = (usize, crate::commit::merge::Tip)> + 'a {
-        anon_stacks(&ws.stacks)
-            .filter(move |(idx, _)| ws.stacks.get(*idx).is_none_or(|stack| stack.id.is_none()))
-            .filter(move |(_, tip)| excluded_tip_id.is_none_or(|id| tip.commit_id != id))
+    /// and feeding it back into the merge would preserve the removed stack. The same is true when
+    /// the just-unapplied branch ref has advanced beyond its projected workspace tip: the ref
+    /// already preserves that ancestor, so retaining it anonymously would duplicate the stack.
+    fn anon_stacks_to_preserve(
+        ws: &but_graph::Workspace,
+        repo: &gix::Repository,
+        unapplied_branch_tip_id: Option<gix::ObjectId>,
+    ) -> anyhow::Result<Vec<(usize, crate::commit::merge::Tip)>> {
+        let mut preserved = Vec::new();
+        for (idx, tip) in anon_stacks(&ws.stacks) {
+            if ws.stacks.get(idx).is_some_and(|stack| stack.id.is_some()) {
+                continue;
+            }
+            if let Some(branch_tip_id) = unapplied_branch_tip_id
+                && commit_contains(repo, branch_tip_id, tip.commit_id)?
+            {
+                continue;
+            }
+            preserved.push((idx, tip));
+        }
+        Ok(preserved)
+    }
+
+    /// Return whether `tip` is preserved by `commit`, either by identity or ancestry.
+    fn commit_contains(
+        repo: &gix::Repository,
+        commit: gix::ObjectId,
+        tip: gix::ObjectId,
+    ) -> anyhow::Result<bool> {
+        if commit == tip {
+            return Ok(true);
+        }
+        match repo.merge_base(commit, tip) {
+            Ok(base) => Ok(base.detach() == tip),
+            Err(gix::repository::merge_base::Error::NotFound { .. }) => Ok(false),
+            Err(err) => Err(err.into()),
+        }
     }
 
     /// Local tracking branch of target ref or the most recent named stack tip.

--- a/crates/but-workspace/tests/workspace/branch/apply_unapply.rs
+++ b/crates/but-workspace/tests/workspace/branch/apply_unapply.rs
@@ -1260,6 +1260,193 @@ Outcome {
 }
 
 #[test]
+fn unapply_advanced_ref_drops_its_projected_tip_for_every_disposition() -> anyhow::Result<()> {
+    for disposition in [
+        WorkspaceDisposition::KeepWorkspaceCommit,
+        WorkspaceDisposition::KeepWorkspaceReference,
+        WorkspaceDisposition::PreventUnnecessaryWorkspaceReferences,
+        WorkspaceDisposition::PreventUnnecessaryWorkspaceReferencesKeepWorkspaceCommit,
+    ] {
+        let (_tmp, graph, repo, mut meta, _description) =
+            named_writable_scenario_with_description_and_graph(
+                "advanced-stack-and-unnamed-stack-in-workspace",
+                |meta| {
+                    add_stack_with_segments(meta, 1, "outside", StackState::InWorkspace, &[]);
+                },
+            )?;
+        let ws = graph.into_workspace()?;
+        let advanced_ref_tip = id_by_rev(&repo, "outside");
+        let projected_tip = id_by_rev(&repo, "outside~1").detach();
+        let workspace_commit = repo.find_reference(WORKSPACE_REF_NAME)?.peel_to_commit()?;
+        let parents = workspace_commit
+            .parent_ids()
+            .map(|id| id.detach())
+            .collect::<Vec<_>>();
+        let anonymous_tip = parents
+            .iter()
+            .copied()
+            .find(|id| *id != projected_tip)
+            .expect("fixture has an independent anonymous workspace parent");
+
+        let out = but_workspace::branch::unapply(
+            r("refs/heads/outside"),
+            &ws,
+            &repo,
+            &mut meta,
+            unapply_options_with(disposition),
+        )?;
+
+        assert!(out.workspace_changed());
+        assert_eq!(id_by_rev(&repo, "outside"), advanced_ref_tip);
+        let workspace_tip = repo.find_reference(WORKSPACE_REF_NAME)?.peel_to_commit()?;
+        let remaining_parents = workspace_tip
+            .parent_ids()
+            .map(|id| id.detach())
+            .collect::<Vec<_>>();
+        assert!(
+            workspace_tip.id != projected_tip && !remaining_parents.contains(&projected_tip),
+            "the preserved branch contains its projected tip, so disposition {disposition:?} must not retain it anonymously"
+        );
+        assert!(
+            workspace_tip.id == anonymous_tip || remaining_parents.contains(&anonymous_tip),
+            "disposition {disposition:?} must preserve independent anonymous history"
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
+fn unapply_last_advanced_ref_dissolves_unnecessary_workspace() -> anyhow::Result<()> {
+    for disposition in [
+        WorkspaceDisposition::PreventUnnecessaryWorkspaceReferences,
+        WorkspaceDisposition::PreventUnnecessaryWorkspaceReferencesKeepWorkspaceCommit,
+    ] {
+        let (_tmp, _graph, repo, mut meta, _description) =
+            named_writable_scenario_with_description_and_graph(
+                "advanced-stack-and-unnamed-stack-in-workspace",
+                |meta| {
+                    add_stack_with_segments(meta, 1, "outside", StackState::InWorkspace, &[]);
+                },
+            )?;
+        let projected_tip = id_by_rev(&repo, "outside~1").detach();
+        let workspace_commit = repo.find_reference(WORKSPACE_REF_NAME)?.peel_to_commit()?;
+        let mut commit = workspace_commit.decode()?.to_owned()?;
+        commit.parents = vec![projected_tip].into();
+        let workspace_tip = repo.write_object(commit)?.detach();
+        repo.reference(
+            WORKSPACE_REF_NAME,
+            workspace_tip,
+            PreviousValue::Any,
+            "test workspace with only the projected branch"
+                .as_bytes()
+                .as_bstr(),
+        )?;
+        let project_meta = meta
+            .workspace(WORKSPACE_REF_NAME.try_into().expect("valid workspace ref"))?
+            .project_meta();
+        let ws = Graph::from_head(&repo, &meta, project_meta, standard_traversal_options())?
+            .into_workspace()?;
+
+        let out = but_workspace::branch::unapply(
+            r("refs/heads/outside"),
+            &ws,
+            &repo,
+            &mut meta,
+            unapply_options_with(disposition),
+        )?;
+
+        assert_eq!(
+            out.checked_out.as_ref().map(|name| name.as_ref()),
+            Some(r("refs/heads/main")),
+            "disposition {disposition:?} should switch to the local target"
+        );
+        assert!(
+            repo.try_find_reference(WORKSPACE_REF_NAME)?.is_none(),
+            "disposition {disposition:?} should delete the unnecessary workspace ref"
+        );
+        assert!(
+            meta.workspace_opt(r(WORKSPACE_REF_NAME))?.is_some(),
+            "branch unapply currently retains target-bearing workspace metadata after deleting the ref"
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
+fn apply_branch_containing_anonymous_parent_drops_only_anonymous_stack() -> anyhow::Result<()> {
+    let (_tmp, _graph, repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "advanced-stack-and-unnamed-stack-in-workspace",
+            |meta| {
+                add_stack_with_segments(meta, 1, "outside", StackState::InWorkspace, &[]);
+            },
+        )?;
+    let workspace_commit = repo.find_reference(WORKSPACE_REF_NAME)?.peel_to_commit()?;
+    let original_parents = workspace_commit
+        .parent_ids()
+        .map(|id| id.detach())
+        .collect::<Vec<_>>();
+    git(&repo).args(["checkout", "feature"]).run();
+    git(&repo)
+        .args([
+            "merge",
+            "--no-ff",
+            "gitbutler/workspace^1",
+            "outside",
+            "-m",
+            "merge workspace histories",
+        ])
+        .run();
+    let feature_tip = id_by_rev(&repo, "feature");
+    git(&repo).args(["checkout", "gitbutler/workspace"]).run();
+    let project_meta = meta
+        .workspace(WORKSPACE_REF_NAME.try_into().expect("valid workspace ref"))?
+        .project_meta();
+    let ws = Graph::from_head(&repo, &meta, project_meta, standard_traversal_options())?
+        .into_workspace()?;
+
+    let out = but_workspace::branch::apply(
+        r("refs/heads/feature"),
+        ws,
+        &repo,
+        &mut meta,
+        apply_options(),
+    )?;
+
+    assert!(out.workspace_changed());
+    assert_eq!(id_by_rev(&repo, "feature"), feature_tip);
+    assert!(
+        out.workspace
+            .stacks
+            .iter()
+            .all(|stack| stack.ref_name().is_some()),
+        "the contained anonymous parent must not remain projected; original parents were {original_parents:?}\n{}",
+        graph_workspace(&out.workspace)
+    );
+    assert!(
+        out.workspace.refname_is_segment(r("refs/heads/outside")),
+        "apply must preserve the existing named stack instead of erasing its branch identity"
+    );
+    let ws_md = meta.workspace(r(WORKSPACE_REF_NAME))?;
+    assert!(
+        ws_md
+            .find_branch(r("refs/heads/outside"), StackKind::Applied)
+            .is_some(),
+        "apply must preserve the existing named stack in metadata"
+    );
+    assert!(
+        ws_md
+            .find_branch(r("refs/heads/feature"), StackKind::Applied)
+            .is_some(),
+        "the incoming branch must be applied in metadata"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn ws_ref_no_ws_commit_two_stacks_on_same_commit() -> anyhow::Result<()> {
     let (_tmp, graph, repo, mut meta, _description) =
         named_writable_scenario_with_description_and_graph(


### PR DESCRIPTION
## 🧢 Changes

- Drop a projected workspace parent after unapply when the preserved named
  branch already contains that history.
- Keep independent and diverged anonymous workspace history unchanged.
- Cover every workspace disposition and the related multi-parent apply path.

## ☕️ Reasoning

Unapplying a named stack could leave an anonymous lane that preserved no unique
commits. The lane had no usable CLI selector, blocked target changes, and made
agentic coding workflows require manual recovery even though the named branch
already retained the complete history.

The containment check removes only redundant projected history. It remains
conservative when histories diverge, are disjoint, or cannot be compared.

## 🧪 Reproduction

1. Advance a named branch ref beyond its currently projected workspace tip.
2. Unapply that branch, then unapply the remaining empty stack.
3. Run `but status -fv`.

Before this change, status rendered an anonymous lane and then failed with
`Could not find branch CLI id '' in IdMap`; changing the target remained blocked.

## ✅ Verification

- Format check passed.
- All 53 focused apply/unapply tests passed.
- Clippy passed with warnings denied.
- The signed-tip regression test passed.
- A disposable CLI reproduction removed the redundant parent, preserved named
  and component refs plus linked-worktree staged state, and allowed target
  configuration afterward.

Developed with carefully directed, manually reviewed AI assistance.

Co-Authored-By: GPT-5.6 Sol <codex@openai.com>