### PR TITLE
Preserve dependent branches with commits

### DIFF
--- a/crates/but-graph/src/init/post.rs
+++ b/crates/but-graph/src/init/post.rs
@@ -1490,49 +1490,6 @@ impl Graph {
             if branch.category() != Some(Category::LocalBranch) {
                 continue;
             }
-            if repo
-                .try_find_reference(branch.as_ref())
-                .with_context(|| {
-                    format!(
-                        "failed to find ordered ad-hoc branch '{}'",
-                        branch.shorten()
-                    )
-                })?
-                .is_some()
-            {
-                existing_ordered_refs.push(branch);
-            }
-        }
-        if existing_ordered_refs.len() < 2 {
-            return Ok(());
-        }
-
-        let Some((bottom_ref, _)) = existing_ordered_refs.split_last() else {
-            return Ok(());
-        };
-        let Some(mut bottom_reference) = repo
-            .try_find_reference(bottom_ref.as_ref())
-            .with_context(|| {
-                format!(
-                    "failed to find bottom ordered ad-hoc branch '{}'",
-                    bottom_ref.shorten()
-                )
-            })?
-        else {
-            return Ok(());
-        };
-        let bottom_commit_id = bottom_reference
-            .peel_to_id()
-            .with_context(|| {
-                format!(
-                    "failed to peel bottom ordered ad-hoc branch '{}'",
-                    bottom_ref.shorten()
-                )
-            })?
-            .detach();
-
-        let mut matching_refs = Vec::new();
-        for branch in &existing_ordered_refs {
             let Some(mut reference) =
                 repo.try_find_reference(branch.as_ref()).with_context(|| {
                     format!(
@@ -1543,7 +1500,7 @@ impl Graph {
             else {
                 continue;
             };
-            if reference
+            let commit_id = reference
                 .peel_to_id()
                 .with_context(|| {
                     format!(
@@ -1551,31 +1508,75 @@ impl Graph {
                         branch.shorten()
                     )
                 })?
-                .detach()
-                == bottom_commit_id
+                .detach();
+            existing_ordered_refs.push((branch, commit_id));
+        }
+        if existing_ordered_refs.len() < 2 {
+            return Ok(());
+        }
+
+        // Projection needs the complete persisted order to keep walking across commit-owning
+        // boundaries. Same-tip groups below are only the units that need graph reconstruction.
+        self.ad_hoc_branch_stack_orders.push(
+            existing_ordered_refs
+                .iter()
+                .map(|(branch, _)| branch.clone())
+                .collect(),
+        );
+
+        // A persisted stack can cross commit-owning branch boundaries. Rebuild every contiguous
+        // same-tip run independently so an empty run at the top isn't compared to the older tip
+        // of the stack's bottom branch.
+        let mut same_tip_groups: Vec<(ObjectId, Vec<gix::refs::FullName>)> = Vec::new();
+        for (branch, commit_id) in existing_ordered_refs {
+            if let Some((group_commit_id, branches)) = same_tip_groups.last_mut()
+                && *group_commit_id == commit_id
             {
-                matching_refs.push(branch.clone());
+                branches.push(branch);
+            } else {
+                same_tip_groups.push((commit_id, vec![branch]));
             }
         }
-        if matching_refs.len() < 2 {
-            return Ok(());
+
+        for (commit_id, matching_refs) in same_tip_groups {
+            if matching_refs.len() < 2 {
+                continue;
+            }
+            let bottom_ref = matching_refs
+                .last()
+                .context("BUG: same-tip branch group cannot be empty")?;
+            let containing_commit = self.node_weights().find_map(|segment| {
+                segment
+                    .commit_index_of(commit_id)
+                    .filter(|commit_idx| *commit_idx > 0)
+                    .map(|commit_idx| (segment.id, commit_idx))
+            });
+            let bottom_segment_id = if let Some(segment_id) =
+                ad_hoc_order_bottom_segment_id(self, bottom_ref.as_ref(), commit_id)
+            {
+                segment_id
+            } else if let Some((segment_id, commit_idx)) = containing_commit {
+                self.split_segment(
+                    segment_id,
+                    commit_idx,
+                    Some(bottom_ref.clone()),
+                    None,
+                    meta,
+                    worktree_by_branch,
+                )?
+            } else {
+                continue;
+            };
+
+            rebuild_same_tip_segment_chain_by_branch_order(
+                self,
+                bottom_segment_id,
+                matching_refs,
+                entrypoint_ref.as_ref(),
+                meta,
+                worktree_by_branch,
+            )?;
         }
-        self.ad_hoc_branch_stack_orders.push(matching_refs.clone());
-
-        let bottom_segment_id =
-            ad_hoc_order_bottom_segment_id(self, bottom_ref.as_ref(), bottom_commit_id);
-        let Some(bottom_segment_id) = bottom_segment_id else {
-            return Ok(());
-        };
-
-        rebuild_same_tip_segment_chain_by_branch_order(
-            self,
-            bottom_segment_id,
-            matching_refs,
-            entrypoint_ref.as_ref(),
-            meta,
-            worktree_by_branch,
-        )?;
         Ok(())
     }
 }

--- a/crates/but-graph/tests/graph/init/mod.rs
+++ b/crates/but-graph/tests/graph/init/mod.rs
@@ -2088,6 +2088,102 @@ fn ad_hoc_order_does_not_force_diverged_refs_into_empty_stack() -> anyhow::Resul
 }
 
 #[test]
+fn ad_hoc_order_preserves_empty_top_above_commit_owning_branch() -> anyhow::Result<()> {
+    let (tmp, repo) = empty_repo()?;
+    let target_tip = commit(&repo, "target")?;
+    let bottom_tip = commit_with_parent(&repo, "bottom", target_tip)?;
+    let commit_branch_tip = commit_with_parent(&repo, "top", bottom_tip)?;
+    create_branches(
+        &repo,
+        commit_branch_tip,
+        ["refs/heads/empty-top", "refs/heads/commit-branch"],
+    )?;
+    create_branches(&repo, bottom_tip, ["refs/heads/bottom"])?;
+    create_branches(&repo, target_tip, ["refs/heads/main"])?;
+    let meta = in_memory_meta(tmp.as_ref())?;
+
+    let graph = graph_with_branch_order(
+        &repo,
+        &*meta,
+        "refs/heads/empty-top",
+        [
+            "refs/heads/empty-top",
+            "refs/heads/commit-branch",
+            "refs/heads/bottom",
+        ],
+    )?
+    .validated()?;
+
+    snapbox::assert_data_eq!(
+        graph_workspace(&graph.into_workspace()?).to_string(),
+        snapbox::str![[r#"
+⌂:3:empty-top <> ✓!
+└── ≡:3:empty-top {1}
+    ├── :3:empty-top
+    ├── :0:commit-branch
+    │   └── ·4782705
+    ├── :1:bottom
+    │   └── ·dbc3a4c
+    └── :2:main[🌳]
+        └── ·67b14ca
+
+"#]]
+    );
+    Ok(())
+}
+
+#[test]
+fn ad_hoc_order_keeps_lower_empty_branches_after_non_empty_move() -> anyhow::Result<()> {
+    let (tmp, repo) = empty_repo()?;
+    let target_tip = commit(&repo, "target")?;
+    let base_tip = commit_with_parent(&repo, "base", target_tip)?;
+    let commit_branch_tip = commit_with_parent(&repo, "commit branch", base_tip)?;
+    create_branches(&repo, commit_branch_tip, ["refs/heads/commit-branch"])?;
+    create_branches(
+        &repo,
+        base_tip,
+        [
+            "refs/heads/empty-top",
+            "refs/heads/empty-low",
+            "refs/heads/base",
+        ],
+    )?;
+    create_branches(&repo, target_tip, ["refs/heads/main"])?;
+    let meta = in_memory_meta(tmp.as_ref())?;
+
+    let graph = graph_with_branch_order(
+        &repo,
+        &*meta,
+        "refs/heads/commit-branch",
+        [
+            "refs/heads/commit-branch",
+            "refs/heads/empty-top",
+            "refs/heads/empty-low",
+            "refs/heads/base",
+        ],
+    )?
+    .validated()?;
+
+    snapbox::assert_data_eq!(
+        graph_workspace(&graph.into_workspace()?).to_string(),
+        snapbox::str![[r#"
+⌂:0:commit-branch <> ✓!
+└── ≡:0:commit-branch {1}
+    ├── :0:commit-branch
+    │   └── ·5380c0a
+    ├── :3:empty-top
+    ├── :4:empty-low
+    ├── :2:base
+    │   └── ·a5cd64d
+    └── :1:main[🌳]
+        └── ·67b14ca
+
+"#]]
+    );
+    Ok(())
+}
+
+#[test]
 fn ad_hoc_order_scopes_empty_segments_to_active_chain() -> anyhow::Result<()> {
     let (tmp, repo) = empty_repo()?;
     let tip = commit(&repo, "same tip")?;

--- a/e2e/playwright/tests/singleBranch/commitActions.spec.ts
+++ b/e2e/playwright/tests/singleBranch/commitActions.spec.ts
@@ -128,6 +128,39 @@ test("can create an empty dependent branch above the checked-out branch and comm
 	);
 });
 
+test("keeps a commit-owning dependent branch when adding an empty branch above it", async ({
+	page,
+	gitbutler,
+}) => {
+	const localClone = await setupSingleBranchProject(gitbutler, page);
+	const commitBranch = "dependent-with-commit";
+	const emptyTopBranch = "empty-dependent-top";
+	const baseTip = git(localClone, ["rev-parse", SINGLE_BRANCH_NAME]);
+
+	await createDependentBranch(page, commitBranch);
+
+	const fileName = "dependent_with_commit.txt";
+	writeToFile(gitbutler.pathInWorkdir("local-clone", fileName), "dependent branch content\n");
+	await expect(getByTestId(page, "file-list-item").filter({ hasText: fileName })).toBeVisible();
+	await clickByTestId(page, "start-commit-button");
+
+	const title = "dependent branch: add commit";
+	await updateCommitMessage(page, title, "");
+	await clickByTestId(page, "commit-drawer-action-button");
+	await expect(commitRow(page, title)).toBeVisible();
+	const commitBranchTip = git(localClone, ["rev-parse", commitBranch]);
+	expect(commitBranchTip).not.toBe(baseTip);
+
+	await createDependentBranch(page, emptyTopBranch);
+
+	await expectCurrentBranchChip(page, emptyTopBranch);
+	await assertBranch(emptyTopBranch, localClone);
+	expect(git(localClone, ["rev-parse", emptyTopBranch])).toBe(commitBranchTip);
+	expect(git(localClone, ["rev-parse", commitBranch])).toBe(commitBranchTip);
+	expect(git(localClone, ["rev-parse", SINGLE_BRANCH_NAME])).toBe(baseTip);
+	await expectBranchHeaderOrder(page, [emptyTopBranch, commitBranch, SINGLE_BRANCH_NAME]);
+});
+
 test("can create an empty branch below another empty branch between empty branches", async ({
 	page,
 	gitbutler,

--- a/e2e/playwright/tests/singleBranch/moveBranch.spec.ts
+++ b/e2e/playwright/tests/singleBranch/moveBranch.spec.ts
@@ -7,8 +7,10 @@ import {
 	SINGLE_BRANCH_NAME,
 } from "./helpers.ts";
 import { assertBranch, assertCommitSubjects, branchTip } from "../../src/branch.ts";
+import { updateCommitMessage } from "../../src/commit.ts";
+import { writeToFile } from "../../src/file.ts";
 import { test } from "../../src/test.ts";
-import { dragAndDropByLocator, getByTestId } from "../../src/util.ts";
+import { clickByTestId, commitRow, dragAndDropByLocator, getByTestId } from "../../src/util.ts";
 import { expect, type Page } from "@playwright/test";
 import type { GitButler } from "../../src/setup.ts";
 
@@ -83,6 +85,42 @@ test("moving an empty branch above the checked-out branch checks out the new tip
 	await expectBranchHeaderOrder(page, ["empty-a", "empty-b", SINGLE_BRANCH_NAME]);
 	await expectCurrentBranchChip(page, "empty-a");
 	await assertBranch("empty-a", localClone);
+});
+
+test("keeps empty dependent branches when moving their commit-owning branch to the top", async ({
+	page,
+	gitbutler,
+}) => {
+	const localClone = await setupSingleBranchProject(gitbutler, page);
+	const commitBranch = "commit-branch";
+	const emptyLow = "empty-low";
+	const emptyTop = "empty-top";
+
+	await createDependentBranch(page, commitBranch);
+	const fileName = "commit_branch.txt";
+	writeToFile(gitbutler.pathInWorkdir("local-clone", fileName), "commit branch content\n");
+	await expect(getByTestId(page, "file-list-item").filter({ hasText: fileName })).toBeVisible();
+	await clickByTestId(page, "start-commit-button");
+	const commitTitle = "commit branch: add commit";
+	await updateCommitMessage(page, commitTitle, "");
+	await clickByTestId(page, "commit-drawer-action-button");
+	await expect(commitRow(page, commitTitle)).toBeVisible();
+
+	await createDependentBranch(page, emptyLow);
+	await createDependentBranch(page, emptyTop);
+	await expectBranchHeaderOrder(page, [emptyTop, emptyLow, commitBranch, SINGLE_BRANCH_NAME]);
+	const commitTip = branchTip(commitBranch, localClone);
+	expect(branchTip(emptyTop, localClone)).toBe(commitTip);
+	expect(branchTip(emptyLow, localClone)).toBe(commitTip);
+
+	await dragBranchToInsertionDropzone(page, commitBranch, 0);
+
+	await expectBranchHeaderOrder(page, [commitBranch, emptyTop, emptyLow, SINGLE_BRANCH_NAME]);
+	await expectCurrentBranchChip(page, commitBranch);
+	await assertBranch(commitBranch, localClone);
+	expect(branchTip(commitBranch, localClone)).toBe(commitTip);
+	expect(branchTip(emptyTop, localClone)).toBe(branchTip(SINGLE_BRANCH_NAME, localClone));
+	expect(branchTip(emptyLow, localClone)).toBe(branchTip(SINGLE_BRANCH_NAME, localClone));
 });
 
 test("can move a middle non-empty branch above the checked-out branch", async ({


### PR DESCRIPTION
## Why?

Fixes two things in SBM:
- Creating empty branches above stacks would work only sometimes.
- Moving non-empty branches above empty branches in a stack.

## Summary

- preserve commit-owning dependent branches when an empty branch is added above them in single-branch mode
- preserve lower empty dependent branches when their commit-owning branch is moved to the top
- rebuild contiguous same-tip groups while retaining the complete persisted order for workspace traversal
- split ordered lower groups out when their shared commit is embedded inside the moved branch's segment
- add Rust graph snapshots and Playwright regressions for both failure modes
