### PR TITLE
fix(pull): Synchronize configured local target

### DIFF
--- a/crates/but-api/Cargo.toml
+++ b/crates/but-api/Cargo.toml
@@ -155,7 +155,7 @@ objc2-foundation = { version = "0.3.2", default-features = false, features = ["s
 
 [dev-dependencies]
 but-api = { path = ".", features = ["legacy"] }
-but-testsupport.workspace = true
+but-testsupport = { workspace = true, features = ["sandbox-but-api"] }
 gitbutler-oplog.workspace = true
 snapbox.workspace = true
 tempfile.workspace = true

--- a/crates/but-api/src/workspace.rs
+++ b/crates/but-api/src/workspace.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use crate::WorkspaceState;
+use anyhow::Context as _;
 use bstr::ByteSlice;
 use but_api_macros::but_api;
 use but_core::{
@@ -15,7 +16,7 @@ use but_core::{
 };
 use but_error::AnyhowContextExt as _;
 use but_forge::ForgeReview;
-use but_oplog::legacy::{OperationKind, SnapshotDetails};
+use but_oplog::legacy::{LocalTargetSnapshot, OperationKind, SnapshotDetails};
 use but_rebase::graph_rebase::mutate::RelativeTo;
 use but_serde::BStringForFrontend;
 use but_workspace::{
@@ -281,6 +282,31 @@ pub struct WorkspaceIntegrateUpstreamOutcome {
     pub workspace_state: WorkspaceState,
     /// Dirty worktree paths that would conflict when applied onto the resulting workspace head.
     pub worktree_conflicts: Vec<BStringForFrontend>,
+    /// The local branch configured to track the target, if exactly one exists.
+    pub local_target: Option<LocalTargetUpdate>,
+}
+
+/// Result of synchronizing the local branch that uniquely tracks the target.
+#[derive(Debug, Clone)]
+pub struct LocalTargetUpdate {
+    /// Short local branch name.
+    pub branch: String,
+    /// Whether this operation advanced the branch.
+    pub updated: bool,
+    /// Target commit the local branch is synchronized with.
+    pub target_id: gix::ObjectId,
+}
+
+struct LocalTargetUpdatePlan {
+    outcome: Option<LocalTargetUpdate>,
+    edit: Option<LocalTargetRefEdit>,
+}
+
+struct LocalTargetRefEdit {
+    ref_name: gix::refs::FullName,
+    tracking_ref: gix::refs::FullName,
+    previous_tip: gix::ObjectId,
+    current_tip: gix::ObjectId,
 }
 
 /// JSON transport types for workspace APIs.
@@ -359,6 +385,152 @@ pub mod json {
                 worktree_conflicts: value.worktree_conflicts,
             })
         }
+    }
+}
+
+fn plan_local_tracking_target_update(
+    ctx: &but_ctx::Context,
+    repo: &gix::Repository,
+) -> anyhow::Result<LocalTargetUpdatePlan> {
+    let target_ref_name = ctx.project_meta()?.target_ref_or_err()?.clone();
+    let target_tip = repo
+        .try_find_reference(target_ref_name.as_ref())?
+        .with_context(|| format!("target '{}' no longer exists", target_ref_name.shorten()))?
+        .peel_to_id()?
+        .detach();
+    let mut local_ref: Option<gix::Reference<'_>> = None;
+    for candidate in repo.references()?.local_branches()? {
+        let candidate = candidate.map_err(anyhow::Error::from_boxed)?;
+        let tracks_target = match repo
+            .branch_remote_tracking_ref_name(candidate.name(), gix::remote::Direction::Fetch)
+            .transpose()
+        {
+            Ok(Some(tracking_ref)) => tracking_ref.as_ref() == target_ref_name.as_ref(),
+            Ok(None) | Err(_) => false,
+        };
+        if !tracks_target {
+            continue;
+        }
+        if let Some(existing) = &local_ref {
+            anyhow::bail!(
+                "Cannot fast-forward a local target: both '{}' and '{}' are configured to track '{}'",
+                existing.name().shorten(),
+                candidate.name().shorten(),
+                target_ref_name.shorten()
+            );
+        }
+        local_ref = Some(candidate);
+    }
+    let Some(mut local_ref) = local_ref else {
+        return Ok(LocalTargetUpdatePlan {
+            outcome: None,
+            edit: None,
+        });
+    };
+
+    let local_ref_name = local_ref.name().to_owned();
+    let local_tip = local_ref.peel_to_id()?.detach();
+    if local_tip == target_tip {
+        return Ok(LocalTargetUpdatePlan {
+            outcome: Some(LocalTargetUpdate {
+                branch: local_ref_name.shorten().to_string(),
+                updated: false,
+                target_id: target_tip,
+            }),
+            edit: None,
+        });
+    }
+    let merge_base = match repo.merge_base(local_tip, target_tip) {
+        Ok(id) => Some(id.detach()),
+        Err(gix::repository::merge_base::Error::FindMergeBase(_))
+        | Err(gix::repository::merge_base::Error::NotFound { .. }) => None,
+        Err(err) => return Err(err.into()),
+    };
+    if merge_base != Some(local_tip) {
+        anyhow::bail!(
+            "Cannot fast-forward local target '{}' from {local_tip} to {target_tip}: it has diverged from '{}'",
+            local_ref_name.shorten(),
+            target_ref_name.shorten()
+        );
+    }
+    let checkout_probe = but_core::branch::SafeDelete::new(repo)?;
+    if let Some(paths) = checkout_probe.worktree_dirs_with_ref(&local_ref) {
+        anyhow::bail!(
+            "Cannot fast-forward local target '{}' because it is checked out in: {paths:?}",
+            local_ref_name.shorten()
+        );
+    }
+
+    Ok(LocalTargetUpdatePlan {
+        outcome: Some(LocalTargetUpdate {
+            branch: local_ref_name.shorten().to_string(),
+            updated: true,
+            target_id: target_tip,
+        }),
+        edit: Some(LocalTargetRefEdit {
+            ref_name: local_ref_name,
+            tracking_ref: target_ref_name,
+            previous_tip: local_tip,
+            current_tip: target_tip,
+        }),
+    })
+}
+
+impl LocalTargetRefEdit {
+    fn snapshot(&self) -> LocalTargetSnapshot {
+        LocalTargetSnapshot {
+            ref_name: self.ref_name.clone(),
+            tracking_ref: self.tracking_ref.clone(),
+            snapshot_tip: self.previous_tip,
+            expected_tip: self.current_tip,
+        }
+    }
+
+    fn validate(&self, repo: &gix::Repository) -> anyhow::Result<()> {
+        let reference = repo
+            .try_find_reference(self.ref_name.as_ref())?
+            .with_context(|| {
+                format!(
+                    "local target '{}' no longer exists",
+                    self.ref_name.shorten()
+                )
+            })?;
+        let current_tracking_ref = repo
+            .branch_remote_tracking_ref_name(self.ref_name.as_ref(), gix::remote::Direction::Fetch)
+            .transpose()?
+            .with_context(|| {
+                format!(
+                    "local target '{}' no longer has an upstream",
+                    self.ref_name.shorten()
+                )
+            })?;
+        if current_tracking_ref.as_ref() != self.tracking_ref.as_ref() {
+            anyhow::bail!(
+                "local target '{}' now tracks '{}' instead of '{}'",
+                self.ref_name.shorten(),
+                current_tracking_ref.shorten(),
+                self.tracking_ref.shorten()
+            );
+        }
+        let tracking_tip = repo
+            .find_reference(self.tracking_ref.as_ref())?
+            .peel_to_id()?
+            .detach();
+        if tracking_tip != self.current_tip {
+            anyhow::bail!(
+                "target '{}' moved from {} to {tracking_tip} during integration",
+                self.tracking_ref.shorten(),
+                self.current_tip
+            );
+        }
+        let checkout_probe = but_core::branch::SafeDelete::new(repo)?;
+        if let Some(paths) = checkout_probe.worktree_dirs_with_ref(&reference) {
+            anyhow::bail!(
+                "local target '{}' is checked out in: {paths:?}",
+                self.ref_name.shorten()
+            );
+        }
+        Ok(())
     }
 }
 
@@ -521,14 +693,31 @@ pub fn workspace_integrate_upstream_with_perm(
     dry_run: DryRun,
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<WorkspaceIntegrateUpstreamOutcome> {
-    let maybe_oplog_entry = but_oplog::UnmaterializedOplogSnapshot::from_details_with_perm(
-        ctx,
-        SnapshotDetails::new(OperationKind::MergeUpstream),
-        perm.read_permission(),
-        dry_run,
-    );
+    let local_target_plan = {
+        let repo = ctx.repo.get()?;
+        plan_local_tracking_target_update(ctx, &repo)?
+    };
+    let details = SnapshotDetails::new(OperationKind::MergeUpstream);
+    let maybe_oplog_entry = match local_target_plan.edit.as_ref() {
+        Some(edit) => {
+            but_oplog::UnmaterializedOplogSnapshot::from_details_with_local_target_with_perm(
+                ctx,
+                details,
+                &edit.snapshot(),
+                perm.read_permission(),
+                dry_run,
+            )
+        }
+        None => but_oplog::UnmaterializedOplogSnapshot::from_details_with_perm(
+            ctx,
+            details,
+            perm.read_permission(),
+            dry_run,
+        ),
+    };
 
-    let result = workspace_integrate_upstream_only_with_perm(ctx, updates, dry_run, perm);
+    let result =
+        workspace_integrate_upstream_only_with_plan(ctx, updates, dry_run, perm, local_target_plan);
     if let Some(snapshot) = maybe_oplog_entry
         && result.is_ok()
     {
@@ -549,6 +738,20 @@ pub fn workspace_integrate_upstream_only_with_perm(
     updates: Vec<but_workspace::BottomUpdate>,
     dry_run: DryRun,
     perm: &mut RepoExclusive,
+) -> anyhow::Result<WorkspaceIntegrateUpstreamOutcome> {
+    let local_target_plan = {
+        let repo = ctx.repo.get()?;
+        plan_local_tracking_target_update(ctx, &repo)?
+    };
+    workspace_integrate_upstream_only_with_plan(ctx, updates, dry_run, perm, local_target_plan)
+}
+
+fn workspace_integrate_upstream_only_with_plan(
+    ctx: &mut but_ctx::Context,
+    updates: Vec<but_workspace::BottomUpdate>,
+    dry_run: DryRun,
+    perm: &mut RepoExclusive,
+    local_target_plan: LocalTargetUpdatePlan,
 ) -> anyhow::Result<WorkspaceIntegrateUpstreamOutcome> {
     let mut meta = ctx.meta()?;
     let (workspace_state, worktree_conflicts) = {
@@ -578,6 +781,15 @@ pub fn workspace_integrate_upstream_only_with_perm(
         )?;
         let worktree_conflicts = but_workspace::worktree_conflicts_for_rebase(&rebase)?;
 
+        if let Some(edit) = local_target_plan.edit.as_ref() {
+            edit.validate(&repo)?;
+            rebase.queue_reference_update(
+                edit.ref_name.clone(),
+                edit.previous_tip,
+                edit.current_tip,
+            )?;
+        }
+
         if dry_run.into() {
             let replaced_commits = rebase.history.commit_mappings();
             let workspace_state =
@@ -585,6 +797,7 @@ pub fn workspace_integrate_upstream_only_with_perm(
             return Ok(WorkspaceIntegrateUpstreamOutcome {
                 workspace_state,
                 worktree_conflicts,
+                local_target: local_target_plan.outcome,
             });
         }
 
@@ -615,6 +828,7 @@ pub fn workspace_integrate_upstream_only_with_perm(
     Ok(WorkspaceIntegrateUpstreamOutcome {
         workspace_state,
         worktree_conflicts,
+        local_target: local_target_plan.outcome,
     })
 }
 
@@ -623,8 +837,8 @@ mod tests {
     use super::{
         review_integration_hints_from_reviews, target_branch_name, workspace_fetch_from_remotes,
     };
-    use but_core::RefMetadata;
-    use but_testsupport::{CommandExt, git_at_dir, open_repo};
+    use but_core::{DryRun, RefMetadata};
+    use but_testsupport::{CommandExt, Sandbox, git_at_dir, open_repo};
     use std::collections::HashSet;
     use std::path::Path;
 
@@ -678,6 +892,37 @@ mod tests {
         assert!(
             ctx.meta()?.branch_stack_order(main.as_ref())?.is_none(),
             "failed fetch should still prune missing branch-order references"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn workspace_integration_fast_forwards_unique_local_tracking_target() -> anyhow::Result<()> {
+        let env = Sandbox::init_scenario_with_target_and_default_settings(
+            "../../../../but/tests/fixtures/scenario/zero-stacks",
+        );
+        env.setup_metadata(&[]);
+        env.set_target_sha("origin/main");
+        env.invoke_git("config user.name GitButler");
+        env.invoke_git("config user.email gitbutler@example.com");
+        let old_target = env.invoke_git("rev-parse main");
+        env.invoke_git("branch -m main trunk");
+        env.invoke_git("config branch.trunk.remote origin");
+        env.invoke_git("config branch.trunk.merge refs/heads/main");
+        let new_target = env.invoke_git(&format!(
+            "commit-tree {old_target}^{{tree}} -p {old_target} -m upstream-change"
+        ));
+        env.invoke_git(&format!(
+            "update-ref refs/remotes/origin/main {new_target} {old_target}"
+        ));
+        let mut ctx = env.context();
+
+        super::workspace_integrate_upstream(&mut ctx, vec![], DryRun::No)?;
+
+        assert_eq!(
+            env.invoke_git("rev-parse trunk"),
+            new_target,
+            "the shared integration API should advance the unique local branch tracking its target"
         );
         Ok(())
     }

--- a/crates/but-oplog/src/lib.rs
+++ b/crates/but-oplog/src/lib.rs
@@ -68,7 +68,10 @@ pub struct UnmaterializedOplogSnapshot {
 /// legacy types for easy of use, all provided by `gitbutler-oplog`.
 #[cfg(feature = "legacy")]
 pub mod legacy {
-    pub use gitbutler_oplog::entry::{OperationKind, SnapshotDetails, Trailer};
+    pub use gitbutler_oplog::{
+        LocalTargetSnapshot,
+        entry::{OperationKind, SnapshotDetails, Trailer},
+    };
 }
 
 #[cfg(feature = "legacy")]
@@ -99,6 +102,31 @@ mod oplog_snapshot {
             }
 
             let tree_id = match ctx.prepare_snapshot(perm) {
+                Ok(tree_id) => tree_id,
+                Err(err) => {
+                    tracing::warn!(?err, "Failed to prepare unmaterialized oplog snapshot");
+                    return None;
+                }
+            };
+            Some(Self { tree_id, details })
+        }
+
+        /// Create a pending snapshot that also records a guarded local target update.
+        ///
+        /// This has the same dry-run and best-effort behavior as
+        /// [`Self::from_details_with_perm`].
+        pub fn from_details_with_local_target_with_perm(
+            ctx: &but_ctx::Context,
+            details: gitbutler_oplog::entry::SnapshotDetails,
+            local_target: &gitbutler_oplog::LocalTargetSnapshot,
+            perm: &RepoShared,
+            dry_run: DryRun,
+        ) -> Option<Self> {
+            if dry_run.into() {
+                return None;
+            }
+
+            let tree_id = match ctx.prepare_snapshot_with_local_target(local_target, perm) {
                 Ok(tree_id) => tree_id,
                 Err(err) => {
                     tracing::warn!(?err, "Failed to prepare unmaterialized oplog snapshot");

--- a/crates/but-rebase/src/graph_rebase/materialize.rs
+++ b/crates/but-rebase/src/graph_rebase/materialize.rs
@@ -8,6 +8,7 @@ use gix::refs::{
     Target,
     transaction::{Change, LogChange, PreviousValue, RefEdit, RefLog},
 };
+use std::time::Duration;
 
 use crate::graph_rebase::{
     Checkout, MaterializeOutcome, Pick, Step, SuccessfulRebase, util::collect_ordered_parents,
@@ -22,6 +23,7 @@ impl<'ws, 'graph, M: RefMetadata> SuccessfulRebase<'ws, 'graph, M> {
         }
 
         let mut head_reference_update = None;
+        let mut planned_checkouts = Vec::with_capacity(self.checkouts.len());
         for checkout in self.checkouts {
             match checkout {
                 Checkout::Head {
@@ -45,18 +47,7 @@ impl<'ws, 'graph, M: RefMetadata> SuccessfulRebase<'ws, 'graph, M> {
                         }
                     };
                     head_reference_update = new_head_refname;
-
-                    // If the head has changed (which means it's in the
-                    // commit mapping), perform a safe checkout.
-                    safe_checkout_from_head(
-                        new_head,
-                        &repo,
-                        Options {
-                            skip_head_update: true,
-                            merge_base_override,
-                            allow_conflicted_commit_checkout: true,
-                        },
-                    )?;
+                    planned_checkouts.push((new_head, merge_base_override));
                 }
             }
         }
@@ -84,7 +75,26 @@ impl<'ws, 'graph, M: RefMetadata> SuccessfulRebase<'ws, 'graph, M> {
                 deref: false,
             });
         }
-        repo.edit_references(ref_edits)?;
+        let perform_checkouts = || -> Result<()> {
+            for (new_head, merge_base_override) in planned_checkouts {
+                safe_checkout_from_head(
+                    new_head,
+                    &repo,
+                    Options {
+                        skip_head_update: true,
+                        merge_base_override,
+                        allow_conflicted_commit_checkout: true,
+                    },
+                )?;
+            }
+            Ok(())
+        };
+        if self.prepare_ref_edits_before_checkout {
+            with_prepared_reference_transaction(&repo, ref_edits, perform_checkouts)?;
+        } else {
+            perform_checkouts()?;
+            repo.edit_references(ref_edits)?;
+        }
 
         let project_meta = self.workspace.graph.project_meta.clone();
         self.workspace
@@ -131,5 +141,205 @@ impl<'ws, 'graph, M: RefMetadata> SuccessfulRebase<'ws, 'graph, M> {
             workspace: self.workspace,
             meta: self.meta,
         })
+    }
+}
+
+fn with_prepared_reference_transaction<T>(
+    repo: &gix::Repository,
+    edits: Vec<RefEdit>,
+    effect: impl FnOnce() -> Result<T>,
+) -> Result<T> {
+    let (files_timeout, packed_timeout) = reference_lock_timeouts(repo);
+    let transaction = repo
+        .refs
+        .transaction()
+        .prepare(edits, files_timeout, packed_timeout)?;
+    let outcome = effect()?;
+    transaction.commit(repo.committer().transpose()?)?;
+    Ok(outcome)
+}
+
+fn reference_lock_timeouts(
+    repo: &gix::Repository,
+) -> (gix::lock::acquire::Fail, gix::lock::acquire::Fail) {
+    fn read(
+        repo: &gix::Repository,
+        key: &'static gix::config::tree::keys::LockTimeout,
+        default_ms: u64,
+    ) -> gix::lock::acquire::Fail {
+        let mut trusted = gix::config::section::is_trusted;
+        repo.config_snapshot()
+            .plumbing()
+            .integer_filter(key, &mut trusted)
+            .and_then(|value| key.try_into_lock_timeout(value).ok())
+            .unwrap_or_else(|| Duration::from_millis(default_ms).into())
+    }
+
+    (
+        read(repo, &gix::config::tree::Core::FILES_REF_LOCK_TIMEOUT, 100),
+        read(repo, &gix::config::tree::Core::PACKED_REFS_TIMEOUT, 1000),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::{Result, anyhow};
+    use gix::refs::{
+        Target,
+        transaction::{Change, LogChange, PreviousValue, RefEdit},
+    };
+
+    use super::{reference_lock_timeouts, with_prepared_reference_transaction};
+
+    fn repo_with_ref() -> Result<(
+        tempfile::TempDir,
+        gix::Repository,
+        gix::refs::FullName,
+        gix::ObjectId,
+        gix::ObjectId,
+    )> {
+        let dir = tempfile::tempdir()?;
+        gix::init(dir.path())?;
+        let repo = but_testsupport::open_repo(dir.path())?;
+        let old = repo.write_blob(b"old")?.detach();
+        let new = repo.write_blob(b"new")?.detach();
+        let name = gix::refs::FullName::try_from("refs/heads/guarded")?;
+        repo.reference(
+            name.as_ref(),
+            old,
+            PreviousValue::MustNotExist,
+            "create guarded ref",
+        )?;
+        Ok((dir, repo, name, old, new))
+    }
+
+    fn update(name: gix::refs::FullName, old: gix::ObjectId, new: gix::ObjectId) -> RefEdit {
+        RefEdit {
+            name,
+            change: Change::Update {
+                log: LogChange::default(),
+                expected: PreviousValue::MustExistAndMatch(Target::Object(old)),
+                new: Target::Object(new),
+            },
+            deref: false,
+        }
+    }
+
+    #[test]
+    fn prepared_reference_transaction_holds_the_ref_lock_during_the_effect() -> Result<()> {
+        let (_dir, repo, name, old, new) = repo_with_ref()?;
+        with_prepared_reference_transaction(&repo, vec![update(name.clone(), old, new)], || {
+            let competing = repo.reference(
+                name.as_ref(),
+                repo.write_blob(b"competing")?.detach(),
+                PreviousValue::ExistingMustMatch(old.into()),
+                "competing update",
+            );
+            assert!(
+                competing.is_err(),
+                "prepared transaction holds the ref lock"
+            );
+            Ok(())
+        })?;
+        assert_eq!(
+            repo.find_reference(name.as_ref())?.peel_to_id()?.detach(),
+            new
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn failed_effect_drops_the_ref_lock_without_committing() -> Result<()> {
+        let (_dir, repo, name, old, new) = repo_with_ref()?;
+        let err = with_prepared_reference_transaction(
+            &repo,
+            vec![update(name.clone(), old, new)],
+            || Err::<(), _>(anyhow!("injected effect failure")),
+        )
+        .expect_err("effect fails");
+        assert!(err.to_string().contains("injected effect failure"));
+        assert_eq!(
+            repo.find_reference(name.as_ref())?.peel_to_id()?.detach(),
+            old
+        );
+        repo.reference(
+            name.as_ref(),
+            new,
+            PreviousValue::ExistingMustMatch(old.into()),
+            "lock was released",
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn reference_lock_timeouts_match_gix_defaults() -> Result<()> {
+        let (_dir, repo, _name, _old, _new) = repo_with_ref()?;
+        let (files, packed) = reference_lock_timeouts(&repo);
+        assert_eq!(
+            files,
+            std::time::Duration::from_millis(100).into(),
+            "loose refs use gix's default timeout"
+        );
+        assert_eq!(
+            packed,
+            std::time::Duration::from_millis(1000).into(),
+            "packed refs use gix's default timeout"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn reference_lock_timeouts_honor_valid_overrides() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        gix::init(dir.path())?;
+        let repo = gix::open_opts(
+            dir.path(),
+            but_testsupport::open_repo_config()?
+                .config_overrides(["core.filesRefLockTimeout=0", "core.packedRefsTimeout=2500"]),
+        )?;
+        let (files, packed) = reference_lock_timeouts(&repo);
+        assert_eq!(files, gix::lock::acquire::Fail::Immediately);
+        assert_eq!(packed, std::time::Duration::from_millis(2500).into());
+
+        let repo = gix::open_opts(
+            dir.path(),
+            but_testsupport::open_repo_config()?
+                .config_overrides(["core.filesRefLockTimeout=-1", "core.packedRefsTimeout=-1"]),
+        )?;
+        let forever = std::time::Duration::from_secs(u64::MAX).into();
+        assert_eq!(reference_lock_timeouts(&repo), (forever, forever));
+        Ok(())
+    }
+
+    #[test]
+    fn reference_lock_timeouts_ignore_invalid_or_untrusted_values() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let repo = gix::init(dir.path())?;
+        let config_path = repo.git_dir().join("config");
+        use std::io::Write as _;
+        writeln!(
+            std::fs::OpenOptions::new().append(true).open(config_path)?,
+            "[core]\nfilesRefLockTimeout = 0\npackedRefsTimeout = 0"
+        )?;
+
+        let invalid = gix::open_opts(
+            dir.path(),
+            but_testsupport::open_repo_config()?.config_overrides([
+                "core.filesRefLockTimeout=invalid",
+                "core.packedRefsTimeout=invalid",
+            ]),
+        )?;
+        let defaults = (
+            std::time::Duration::from_millis(100).into(),
+            std::time::Duration::from_millis(1000).into(),
+        );
+        assert_eq!(reference_lock_timeouts(&invalid), defaults);
+
+        let untrusted = gix::open_opts(
+            dir.path(),
+            but_testsupport::open_repo_config()?.with(gix::sec::Trust::Reduced),
+        )?;
+        assert_eq!(reference_lock_timeouts(&untrusted), defaults);
+        Ok(())
     }
 }

--- a/crates/but-rebase/src/graph_rebase/mod.rs
+++ b/crates/but-rebase/src/graph_rebase/mod.rs
@@ -13,7 +13,10 @@ use anyhow::{Context, Result, bail};
 use but_core::{RefMetadata, commit::SignCommit};
 use but_graph::init::Overlay;
 pub use creation::GraphEditorOptions;
-use gix::refs::transaction::RefEdit;
+use gix::refs::{
+    Target,
+    transaction::{Change, LogChange, PreviousValue, RefEdit},
+};
 
 use crate::graph_rebase::util::collect_ordered_parents;
 
@@ -284,6 +287,8 @@ pub struct SuccessfulRebase<'ws, 'meta, M: RefMetadata> {
     /// Any reference edits that need to be committed as a result of the history
     /// rewrite
     pub(crate) ref_edits: Vec<RefEdit>,
+    /// Whether exact external ref edits must be prepared before checkout.
+    pub(crate) prepare_ref_edits_before_checkout: bool,
     /// The new step graph
     pub(crate) graph: StepGraph,
     pub(crate) checkouts: Vec<Checkout>,
@@ -296,6 +301,36 @@ pub struct SuccessfulRebase<'ws, 'meta, M: RefMetadata> {
 }
 
 impl<'ws, 'meta, M: RefMetadata> SuccessfulRebase<'ws, 'meta, M> {
+    /// Queue an exact object-reference update in the same transaction as the rebase edits.
+    ///
+    /// The update fails during materialization if the reference no longer points to
+    /// `expected`. A reference already managed by this rebase cannot be queued twice.
+    pub fn queue_reference_update(
+        &mut self,
+        ref_name: gix::refs::FullName,
+        expected: gix::ObjectId,
+        new: gix::ObjectId,
+    ) -> Result<()> {
+        if self
+            .ref_edits
+            .iter()
+            .any(|edit| edit.name.as_ref() == ref_name.as_ref())
+        {
+            bail!("Reference '{ref_name}' already has a pending rebase edit");
+        }
+        self.ref_edits.push(RefEdit {
+            name: ref_name,
+            change: Change::Update {
+                log: LogChange::default(),
+                expected: PreviousValue::MustExistAndMatch(Target::Object(expected)),
+                new: Target::Object(new),
+            },
+            deref: false,
+        });
+        self.prepare_ref_edits_before_checkout = true;
+        Ok(())
+    }
+
     /// Returns the in-memory repository that backs this rebase preview.
     ///
     /// This repository may contain objects that have not been persisted yet,

--- a/crates/but-rebase/src/graph_rebase/rebase.rs
+++ b/crates/but-rebase/src/graph_rebase/rebase.rs
@@ -230,6 +230,7 @@ impl<'ws, 'graph, M: RefMetadata> Editor<'ws, 'graph, M> {
             repo: self.repo,
             initial_references: self.initial_references,
             ref_edits,
+            prepare_ref_edits_before_checkout: false,
             graph: output_graph,
             checkouts: self.checkouts.to_owned(),
             history,

--- a/crates/but-rebase/tests/rebase/graph_rebase/materialize.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/materialize.rs
@@ -452,3 +452,60 @@ fn materialize_does_not_delete_immutable_refs_removed_from_graph() -> Result<()>
 
     Ok(())
 }
+
+#[test]
+fn guarded_reference_mismatch_fails_before_checkout() -> Result<()> {
+    let (repo, _tmpdir, mut meta) = fixture_writable("four-commits")?;
+    let worktree = repo.workdir().expect("fixture has a worktree");
+    let head_before = repo.rev_parse_single("HEAD")?.detach();
+    let expected = repo.rev_parse_single("HEAD~2")?.detach();
+    let desired = repo.rev_parse_single("HEAD~1")?.detach();
+    let guarded_ref = gix::refs::FullName::try_from("refs/heads/local-target")?;
+    repo.reference(
+        guarded_ref.as_ref(),
+        expected,
+        gix::refs::transaction::PreviousValue::MustNotExist,
+        "create guarded test ref",
+    )?;
+
+    let graph =
+        Graph::from_head(&repo, &*meta, project_meta(&*meta), standard_options())?.validated()?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
+    let head_selector = editor.select_commit(head_before)?;
+    editor.replace(head_selector, Step::None)?;
+    let mut rebase = editor.rebase()?;
+    rebase.queue_reference_update(guarded_ref.clone(), expected, desired)?;
+
+    repo.reference(
+        guarded_ref.as_ref(),
+        head_before,
+        gix::refs::transaction::PreviousValue::ExistingMustMatch(expected.into()),
+        "simulate concurrent guarded ref update",
+    )?;
+    let err = rebase
+        .materialize()
+        .expect_err("guarded ref moved after planning");
+
+    assert!(
+        err.to_string().contains("local-target"),
+        "error identifies the guarded ref: {err:#}"
+    );
+    assert_eq!(
+        repo.head_id()?.detach(),
+        head_before,
+        "failed materialization preserves HEAD"
+    );
+    assert!(
+        worktree.join("c").is_file(),
+        "failed materialization preserves the pre-call worktree"
+    );
+    assert_eq!(
+        repo.find_reference(guarded_ref.as_ref())?
+            .peel_to_id()?
+            .detach(),
+        head_before,
+        "failed materialization preserves the concurrent ref update"
+    );
+    Ok(())
+}

--- a/crates/but/src/command/legacy/pull/mod.rs
+++ b/crates/but/src/command/legacy/pull/mod.rs
@@ -22,6 +22,7 @@ struct PullResult {
     status: String,
     upstream_url: Option<String>,
     upstream_commits_found: usize,
+    local_target: Option<String>,
     recent_commits: Vec<CommitInfo>,
     branches_to_update: Vec<BranchUpdateInfo>,
     integrated_branches: Vec<String>,
@@ -226,6 +227,7 @@ async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<(
         status: String::new(),
         upstream_url: None,
         upstream_commits_found: 0,
+        local_target: None,
         recent_commits: vec![],
         branches_to_update: vec![],
         integrated_branches: vec![],
@@ -320,6 +322,12 @@ async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<(
         true
     };
     if !should_check_integration {
+        let outcome = integrate_upstream(ctx, vec![])?;
+        pull_result.local_target = outcome
+            .local_target
+            .as_ref()
+            .map(|target| target.branch.clone());
+        write_local_target_update(out, outcome.local_target.as_ref())?;
         pull_result.status = "up_to_date".to_string();
         if let Some(out) = out.for_human() {
             writeln!(out, "\n{}", t.success.paint("Everything is up to date"))?;
@@ -338,6 +346,12 @@ async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<(
     } = upstream::dry_run_integration(ctx)?;
 
     if base_branch.behind == 0 && !statuses_need_update(&statuses) {
+        let outcome = integrate_upstream(ctx, vec![])?;
+        pull_result.local_target = outcome
+            .local_target
+            .as_ref()
+            .map(|target| target.branch.clone());
+        write_local_target_update(out, outcome.local_target.as_ref())?;
         pull_result.status = "up_to_date".to_string();
         if let Some(out) = out.for_human() {
             writeln!(out, "\n{}", t.success.paint("Everything is up to date"))?;
@@ -421,20 +435,16 @@ async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<(
 
     // Step 3: Actually perform the integration
     if let Some(statuses) = statuses_to_apply {
-        let integration_result = {
-            let updates = but_api::workspace::rebase_stack_bottoms(&current_head_info);
-            let mut ctx = ctx.to_sync().into_thread_local();
-            let mut guard = ctx.exclusive_worktree_access();
-            but_api::workspace::workspace_integrate_upstream_with_perm(
-                &mut ctx,
-                updates,
-                DryRun::No,
-                guard.write_permission(),
-            )
-        };
+        let updates = but_api::workspace::rebase_stack_bottoms(&current_head_info);
+        let integration_result = integrate_upstream(ctx, updates);
 
         match integration_result {
             Ok(outcome) => {
+                pull_result.local_target = outcome
+                    .local_target
+                    .as_ref()
+                    .map(|target| target.branch.clone());
+                write_local_target_update(out, outcome.local_target.as_ref())?;
                 let post_statuses =
                     upstream::classify(&current_head_info, &outcome.workspace_state);
                 // Report detailed results for each resolution
@@ -583,6 +593,37 @@ async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<(
         }
     }
 
+    Ok(())
+}
+
+fn integrate_upstream(
+    ctx: &Context,
+    updates: Vec<but_workspace::BottomUpdate>,
+) -> anyhow::Result<but_api::workspace::WorkspaceIntegrateUpstreamOutcome> {
+    let mut thread_ctx = ctx.to_sync().into_thread_local();
+    let mut guard = thread_ctx.exclusive_worktree_access();
+    but_api::workspace::workspace_integrate_upstream_with_perm(
+        &mut thread_ctx,
+        updates,
+        DryRun::No,
+        guard.write_permission(),
+    )
+}
+
+fn write_local_target_update(
+    out: &mut OutputChannel,
+    target: Option<&but_api::workspace::LocalTargetUpdate>,
+) -> anyhow::Result<()> {
+    let Some(target) = target.filter(|target| target.updated) else {
+        return Ok(());
+    };
+    if let Some(out) = out.for_human() {
+        writeln!(
+            out,
+            "   Fast-forwarded local target {} to {}",
+            target.branch, target.target_id
+        )?;
+    }
     Ok(())
 }
 

--- a/crates/but/tests/but/command/pull.rs
+++ b/crates/but/tests/but/command/pull.rs
@@ -387,6 +387,236 @@ Hint: run `but branch new` to create a new branch to work on
 }
 
 #[test]
+fn pull_local_target_fast_forwards_tracking_branch() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata_at_target(&[], "origin/main");
+    let remote = setup_advanced_remote(&env)?;
+    env.invoke_git("branch -m main trunk");
+
+    assert_eq!(
+        env.invoke_git("rev-parse --symbolic-full-name trunk@{upstream}"),
+        "refs/remotes/origin/main"
+    );
+    assert_eq!(rev_parse(&env, "trunk")?, remote.previous_main);
+
+    let output = pull_json(&env)?;
+    assert_eq!(output["localTarget"], "trunk");
+
+    assert_eq!(rev_parse(&env, "origin/main")?, remote.advanced_target);
+    assert_eq!(rev_parse(&env, "trunk")?, remote.advanced_target);
+    assert_eq!(
+        rev_parse(&env, "gitbutler/workspace^")?,
+        remote.advanced_target
+    );
+
+    Ok(())
+}
+
+#[test]
+fn pull_local_target_undo_redo_restores_tracking_branch() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata_at_target(&[], "origin/main");
+    let remote = setup_advanced_remote(&env)?;
+    env.invoke_git("branch -m main trunk");
+
+    env.but("pull").assert().success();
+    assert_eq!(rev_parse(&env, "trunk")?, remote.advanced_target);
+    assert_eq!(
+        rev_parse(&env, "gitbutler/workspace^")?,
+        remote.advanced_target
+    );
+
+    env.but("undo").assert().success();
+    assert_eq!(rev_parse(&env, "trunk")?, remote.previous_main);
+    assert_eq!(
+        rev_parse(&env, "gitbutler/workspace^")?,
+        remote.previous_main
+    );
+
+    env.but("redo").assert().success();
+    assert_eq!(rev_parse(&env, "trunk")?, remote.advanced_target);
+    assert_eq!(
+        rev_parse(&env, "gitbutler/workspace^")?,
+        remote.advanced_target
+    );
+
+    Ok(())
+}
+
+#[test]
+fn pull_local_target_updates_when_the_workspace_is_already_current() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata_at_target(&[], "origin/main");
+    let remote = setup_advanced_remote(&env)?;
+
+    env.but("pull").assert().success();
+    env.invoke_git(&format!("branch -f main {}", remote.previous_main));
+    assert_eq!(
+        rev_parse(&env, "gitbutler/workspace^")?,
+        remote.advanced_target
+    );
+    assert_eq!(rev_parse(&env, "main")?, remote.previous_main);
+
+    env.but("pull").assert().success();
+    assert_eq!(rev_parse(&env, "main")?, remote.advanced_target);
+    assert_eq!(
+        rev_parse(&env, "gitbutler/workspace^")?,
+        remote.advanced_target
+    );
+
+    env.but("undo").assert().success();
+    assert_eq!(rev_parse(&env, "main")?, remote.previous_main);
+    assert_eq!(
+        rev_parse(&env, "gitbutler/workspace^")?,
+        remote.advanced_target
+    );
+    Ok(())
+}
+
+#[test]
+fn pull_local_target_undo_refuses_new_local_history() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata_at_target(&[], "origin/main");
+    let remote = setup_advanced_remote(&env)?;
+    env.invoke_git("branch -m main trunk");
+
+    env.but("pull").assert().success();
+    env.invoke_git("checkout trunk");
+    env.invoke_git("commit --allow-empty -m local-after-pull");
+    let local_tip = rev_parse(&env, "trunk")?;
+    env.invoke_git("checkout gitbutler/workspace");
+    let workspace_before_undo = rev_parse(&env, "gitbutler/workspace")?;
+
+    assert_command_error(
+        &env,
+        "undo",
+        &[
+            "changed since the snapshot",
+            &local_tip,
+            &remote.advanced_target,
+        ],
+    )?;
+    assert_eq!(rev_parse(&env, "trunk")?, local_tip);
+    assert_eq!(
+        rev_parse(&env, "gitbutler/workspace")?,
+        workspace_before_undo,
+        "failed undo preserves the exact workspace commit"
+    );
+    assert_eq!(
+        rev_parse(&env, "gitbutler/workspace^")?,
+        remote.advanced_target
+    );
+    Ok(())
+}
+
+#[test]
+fn pull_local_target_undo_refuses_a_checked_out_branch() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata_at_target(&[], "origin/main");
+    let remote = setup_advanced_remote(&env)?;
+    env.invoke_git("branch -m main trunk");
+
+    env.but("pull").assert().success();
+    let root = tempfile::tempdir()?;
+    let linked = root.path().join("trunk-worktree");
+    env.invoke_git(&format!("worktree add {} trunk", linked.display()));
+
+    assert_command_error(&env, "undo", &["trunk-worktree"])?;
+    assert_eq!(rev_parse(&env, "trunk")?, remote.advanced_target);
+    assert_eq!(
+        rev_parse(&env, "gitbutler/workspace^")?,
+        remote.advanced_target
+    );
+    Ok(())
+}
+
+#[test]
+fn pull_local_target_leaves_unconfigured_branch_unchanged() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata_at_target(&[], "origin/main");
+    let remote = setup_advanced_remote(&env)?;
+    env.invoke_git("branch --unset-upstream main");
+
+    let output = pull_json(&env)?;
+    assert!(output["localTarget"].is_null());
+
+    assert_eq!(rev_parse(&env, "main")?, remote.previous_main);
+    assert_eq!(rev_parse(&env, "origin/main")?, remote.advanced_target);
+    assert_eq!(
+        rev_parse(&env, "gitbutler/workspace^")?,
+        remote.advanced_target
+    );
+
+    Ok(())
+}
+
+#[test]
+fn pull_local_target_refuses_ambiguous_tracking_branches() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata_at_target(&[], "origin/main");
+    let remote = setup_advanced_remote(&env)?;
+    env.invoke_git("branch trunk main");
+    env.invoke_git("branch --set-upstream-to origin/main trunk");
+
+    assert_command_error(
+        &env,
+        "pull",
+        &["both 'main' and 'trunk' are configured to track 'origin/main'"],
+    )?;
+    assert_eq!(rev_parse(&env, "main")?, remote.previous_main);
+    assert_eq!(rev_parse(&env, "trunk")?, remote.previous_main);
+    assert_eq!(
+        rev_parse(&env, "gitbutler/workspace^")?,
+        remote.previous_main
+    );
+
+    Ok(())
+}
+
+#[test]
+fn pull_local_target_refuses_divergence() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata_at_target(&[], "origin/main");
+    let remote = setup_advanced_remote(&env)?;
+    env.invoke_git("checkout main");
+    env.invoke_git("commit --allow-empty -m local-divergence");
+    let diverged_main = rev_parse(&env, "main")?;
+    env.invoke_git("checkout gitbutler/workspace");
+
+    assert_command_error(
+        &env,
+        "pull",
+        &["has diverged", &diverged_main, &remote.advanced_target],
+    )?;
+    assert_eq!(rev_parse(&env, "main")?, diverged_main);
+    assert_eq!(
+        rev_parse(&env, "gitbutler/workspace^")?,
+        remote.previous_main
+    );
+
+    Ok(())
+}
+
+#[test]
+fn pull_local_target_refuses_checked_out_branch() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata_at_target(&[], "origin/main");
+    let remote = setup_advanced_remote(&env)?;
+    let linked_root = tempfile::tempdir()?;
+    let linked_worktree = linked_root.path().join("main-worktree");
+    env.invoke_git(&format!("worktree add {} main", linked_worktree.display()));
+
+    assert_command_error(&env, "pull", &["checked out", "main-worktree"])?;
+    assert_eq!(rev_parse(&env, "main")?, remote.previous_main);
+    assert_eq!(
+        rev_parse(&env, "gitbutler/workspace^")?,
+        remote.previous_main
+    );
+
+    Ok(())
+}
+
+#[test]
 fn pull_does_not_report_branch_rebase_conflicts_as_worktree_conflicts() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings(
         "pull-branch-and-dirty-worktree-conflict",
@@ -676,7 +906,7 @@ fn pull_does_not_write_conflict_markers_into_uncommitted_files() -> anyhow::Resu
 }
 
 #[test]
-fn pull_reports_worktree_conflict_paths() -> anyhow::Result<()> {
+fn pull_local_target_stays_put_when_worktree_conflicts_block_integration() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings(
         "pull-dirty-worktree-conflicts-with-clean-rebase",
     );
@@ -685,6 +915,7 @@ fn pull_reports_worktree_conflict_paths() -> anyhow::Result<()> {
     // The branch rebases cleanly, but this uncommitted edit conflicts with the upstream change
     // to `shared.txt` on the resulting workspace head.
     env.file("shared.txt", "dirty local\nmore local work\n");
+    let local_target = rev_parse(&env, "main")?;
 
     env.but("pull").assert().success().stdout_eq(str![[r#"
 
@@ -696,6 +927,11 @@ There are uncommitted changes in the worktree that conflict with the updates:
 Please commit or stash them and try again.
 
 "#]]);
+    assert_eq!(
+        rev_parse(&env, "main")?,
+        local_target,
+        "a worktree conflict must stop before the local target moves"
+    );
 
     Ok(())
 }
@@ -739,6 +975,68 @@ fn rev_parse(env: &Sandbox, spec: &str) -> anyhow::Result<String> {
         anyhow::bail!("expected exactly one rev for {spec}, got {values:?}");
     };
     Ok(value.clone())
+}
+
+fn pull_json(env: &Sandbox) -> anyhow::Result<serde_json::Value> {
+    let output = env
+        .but("--format json pull")
+        .allow_json()
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    Ok(serde_json::from_slice(&output)?)
+}
+
+fn assert_command_error(env: &Sandbox, command: &str, expected: &[&str]) -> anyhow::Result<()> {
+    let output = env.but(command).output()?;
+    assert!(!output.status.success());
+    let error = String::from_utf8_lossy(&output.stderr);
+    for text in expected {
+        assert!(error.contains(text), "missing {text:?} in stderr:\n{error}");
+    }
+    Ok(())
+}
+
+struct AdvancedRemote {
+    _root: tempfile::TempDir,
+    previous_main: String,
+    advanced_target: String,
+}
+
+fn setup_advanced_remote(env: &Sandbox) -> anyhow::Result<AdvancedRemote> {
+    let previous_main = rev_parse(env, "main")?;
+    let root = tempfile::tempdir()?;
+    let upstream_git = root.path().join("upstream.git");
+    let upstream_work = root.path().join("upstream-work");
+    env.invoke_git(&format!("init --bare {}", upstream_git.display()));
+    env.invoke_git(&format!("remote set-url origin {}", upstream_git.display()));
+    env.invoke_git("push --set-upstream origin main");
+    env.invoke_git(&format!(
+        "--git-dir={} symbolic-ref HEAD refs/heads/main",
+        upstream_git.display()
+    ));
+    env.invoke_git(&format!(
+        "clone {} {}",
+        upstream_git.display(),
+        upstream_work.display()
+    ));
+    env.invoke_git(&format!(
+        "-C {} -c user.name=Test -c user.email=test@example.com \
+         commit --allow-empty -m upstream-change",
+        upstream_work.display()
+    ));
+    env.invoke_git(&format!("-C {} push origin main", upstream_work.display()));
+    let advanced_target = env.invoke_git(&format!(
+        "--git-dir={} rev-parse main",
+        upstream_git.display()
+    ));
+    Ok(AdvancedRemote {
+        _root: root,
+        previous_main,
+        advanced_target,
+    })
 }
 
 fn rev_parse_all(env: &Sandbox, spec: &str) -> anyhow::Result<Vec<String>> {

--- a/crates/gitbutler-oplog/src/lib.rs
+++ b/crates/gitbutler-oplog/src/lib.rs
@@ -1,8 +1,7 @@
 pub mod entry;
 mod oplog;
-pub use oplog::OplogExt;
-pub use oplog::RestoreKind;
 pub use oplog::peel_restore_snapshot;
+pub use oplog::{LocalTargetSnapshot, OplogExt, RestoreKind};
 mod reflog;
 mod snapshot;
 pub use snapshot::SnapshotExt;

--- a/crates/gitbutler-oplog/src/oplog.rs
+++ b/crates/gitbutler-oplog/src/oplog.rs
@@ -2,6 +2,7 @@ use std::{
     collections::{BTreeSet, HashMap, hash_map::Entry},
     fs,
     str::{FromStr, from_utf8},
+    time::Duration,
 };
 
 use anyhow::{Context as _, Result, anyhow, bail};
@@ -45,6 +46,11 @@ const AUTO_TRACK_LIMIT_BYTES: u64 = 0;
 /// ├── conflicts/…
 /// ├── index/
 /// ├── index-conflicts/…
+/// ├── local_target/
+/// │   ├── expected_tip
+/// │   ├── ref
+/// │   ├── tip
+/// │   └── tracking_ref
 /// ├── target_tree/…
 /// ├── virtual_branches
 /// │   └── [branch-id]
@@ -62,6 +68,12 @@ pub trait OplogExt {
     /// Returns a tree hash of the snapshot. The snapshot is not discoverable until it is committed with [`commit_snapshot`](Self::commit_snapshot())
     /// If there are files that are untracked and larger than `SNAPSHOT_FILE_LIMIT_BYTES`, they are excluded from snapshot creation and restoring.
     fn prepare_snapshot(&self, perm: &RepoShared) -> Result<gix::ObjectId>;
+    /// Prepares a snapshot which also records one local target ref transition.
+    fn prepare_snapshot_with_local_target(
+        &self,
+        local_target: &LocalTargetSnapshot,
+        perm: &RepoShared,
+    ) -> Result<gix::ObjectId>;
 
     /// Commits the snapshot tree that is created with the [`prepare_snapshot`](Self::prepare_snapshot) method,
     /// which yielded the `snapshot_tree_id` for the entire snapshot state.
@@ -150,6 +162,15 @@ impl OplogExt for Context {
         prepare_snapshot(self, perm)
     }
 
+    fn prepare_snapshot_with_local_target(
+        &self,
+        local_target: &LocalTargetSnapshot,
+        perm: &RepoShared,
+    ) -> Result<gix::ObjectId> {
+        prepare_snapshot_with_target(self, perm, Some(local_target))
+            .map(|prepared| prepared.tree_id)
+    }
+
     fn commit_snapshot(
         &self,
         snapshot_tree_id: gix::ObjectId,
@@ -170,7 +191,7 @@ impl OplogExt for Context {
         let PreparedSnapshot {
             tree_id,
             target_base_oid,
-        } = prepare_snapshot_with_target(self, perm.read_permission())?;
+        } = prepare_snapshot_with_target(self, perm.read_permission(), None)?;
         let repo = self.repo.get()?;
         commit_snapshot(self, &repo, tree_id, details, perm, target_base_oid)
     }
@@ -432,7 +453,7 @@ fn restore_index_conflicts(index: &mut gix::index::State, conflict_tree: gix::Id
 }
 
 pub fn prepare_snapshot(ctx: &Context, shared_access: &RepoShared) -> Result<gix::ObjectId> {
-    prepare_snapshot_with_target(ctx, shared_access).map(|prepared| prepared.tree_id)
+    prepare_snapshot_with_target(ctx, shared_access, None).map(|prepared| prepared.tree_id)
 }
 
 struct PreparedSnapshot {
@@ -543,6 +564,7 @@ mod legacy_virtual_branches {
 fn prepare_snapshot_with_target(
     ctx: &Context,
     _shared_access: &RepoShared,
+    local_target: Option<&LocalTargetSnapshot>,
 ) -> Result<PreparedSnapshot> {
     let repo = ctx.repo.get()?;
     let empty_tree_id = repo.empty_tree().id;
@@ -572,6 +594,20 @@ fn prepare_snapshot_with_target(
     snapshot_tree.upsert("target_tree", EntryKind::Tree, target_tree_id)?;
     snapshot_tree.upsert("conflicts", EntryKind::Tree, conflicts_tree_id)?;
     snapshot_tree.upsert("virtual_branches", EntryKind::Tree, empty_tree_id)?;
+    if let Some(local_target) = local_target {
+        for (name, value) in [
+            ("ref", local_target.ref_name.to_string()),
+            ("tracking_ref", local_target.tracking_ref.to_string()),
+            ("tip", local_target.snapshot_tip.to_string()),
+            ("expected_tip", local_target.expected_tip.to_string()),
+        ] {
+            snapshot_tree.upsert(
+                format!("local_target/{name}"),
+                EntryKind::Blob,
+                repo.write_blob(value)?,
+            )?;
+        }
+    }
 
     let legacy_meta_path = {
         let mut legacy_meta = ctx.legacy_meta()?;
@@ -708,6 +744,19 @@ fn commit_snapshot(
     Ok(snapshot_commit_id)
 }
 
+/// A local target ref transition owned by one snapshot.
+#[derive(Debug, Clone)]
+pub struct LocalTargetSnapshot {
+    /// The local branch ref moved by the operation.
+    pub ref_name: gix::refs::FullName,
+    /// The remote-tracking ref which identifies it as the configured local target.
+    pub tracking_ref: gix::refs::FullName,
+    /// The tip restored when this snapshot is selected.
+    pub snapshot_tip: gix::ObjectId,
+    /// The tip which must currently be present before restoring `snapshot_tip`.
+    pub expected_tip: gix::ObjectId,
+}
+
 /// The kind of restore to perform.
 #[derive(Debug, Copy, Clone, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
@@ -743,15 +792,29 @@ fn restore_snapshot(
 ) -> Result<gix::ObjectId> {
     // Use a separate repo without caching so we are sure the 'has commit' checks pick up all changes.
     let repo = ctx.repo.get()?;
-
-    let before_restore_snapshot_tree_id =
-        prepare_snapshot(ctx, exclusive_access.read_permission())?;
+    let snapshot_commit = repo.find_commit(snapshot_commit_id)?;
+    let snapshot_tree = snapshot_commit.tree()?;
+    let local_target_restore = prepare_local_target_restore(&snapshot_tree, &repo)?;
+    let local_target_transaction = local_target_restore
+        .as_ref()
+        .filter(|restore| restore.current_tip != restore.desired_tip)
+        .map(|restore| {
+            let (files_timeout, packed_timeout) = reference_lock_timeouts(&repo);
+            repo.refs
+                .transaction()
+                .prepare([restore.ref_edit()], files_timeout, packed_timeout)
+        })
+        .transpose()?;
+    let before_restore_snapshot_tree_id = match local_target_restore.as_ref() {
+        Some(local_target) => ctx.prepare_snapshot_with_local_target(
+            &local_target.inverse_snapshot(),
+            exclusive_access.read_permission(),
+        )?,
+        None => prepare_snapshot(ctx, exclusive_access.read_permission())?,
+    };
     let before_restore_snapshot_workdir_tree_id =
         get_v3_workdir_tree(repo.find_tree(before_restore_snapshot_tree_id)?)?
             .context("Could not get workdir tree of snapshot created before the restore")?;
-    let snapshot_commit = repo.find_commit(snapshot_commit_id)?;
-
-    let snapshot_tree = snapshot_commit.tree()?;
     let vb_toml_entry = snapshot_tree
         .lookup_entry_by_path("virtual_branches.toml")?
         .context("failed to get virtual_branches.toml blob")?;
@@ -880,6 +943,9 @@ fn restore_snapshot(
         .lookup_entry_by_path("index-conflicts")?
         .map(|entry| entry.id().detach());
     reset_index_to_tree(ctx, index_tree_entry.id().detach(), index_conflicts_tree_id)?;
+    if let Some(transaction) = local_target_transaction {
+        transaction.commit(repo.committer().transpose()?)?;
+    }
 
     let restored_operation = snapshot_commit
         .message_raw()?
@@ -917,6 +983,135 @@ fn restore_snapshot(
         exclusive_access,
         target,
     )
+}
+
+struct LocalTargetRestore {
+    ref_name: gix::refs::FullName,
+    tracking_ref: gix::refs::FullName,
+    current_tip: gix::ObjectId,
+    desired_tip: gix::ObjectId,
+}
+
+fn prepare_local_target_restore(
+    snapshot_tree: &gix::Tree,
+    repo: &gix::Repository,
+) -> Result<Option<LocalTargetRestore>> {
+    let Some(ref_name) = snapshot_blob(snapshot_tree, repo, "local_target/ref")? else {
+        return Ok(None);
+    };
+    let tracking_ref = snapshot_blob(snapshot_tree, repo, "local_target/tracking_ref")?
+        .context("snapshot local target is missing its tracking ref")?;
+    let desired_tip = snapshot_blob(snapshot_tree, repo, "local_target/tip")?
+        .context("snapshot local target is missing its tip")?;
+    let expected_tip = snapshot_blob(snapshot_tree, repo, "local_target/expected_tip")?
+        .context("snapshot local target is missing its expected tip")?;
+    let ref_name = gix::refs::FullName::try_from(gix::bstr::BString::from(ref_name))?;
+    let tracking_ref = gix::refs::FullName::try_from(gix::bstr::BString::from(tracking_ref))?;
+    let desired_tip = gix::ObjectId::from_hex(&desired_tip)?;
+    let expected_tip = gix::ObjectId::from_hex(&expected_tip)?;
+
+    let current_tip = validate_local_target(repo, ref_name.as_ref(), tracking_ref.as_ref())?;
+    if current_tip != desired_tip && current_tip != expected_tip {
+        bail!(
+            "local target '{}' changed since the snapshot: found {current_tip}, expected {expected_tip}",
+            ref_name.shorten()
+        );
+    }
+
+    Ok(Some(LocalTargetRestore {
+        ref_name,
+        tracking_ref,
+        current_tip,
+        desired_tip,
+    }))
+}
+
+impl LocalTargetRestore {
+    fn inverse_snapshot(&self) -> LocalTargetSnapshot {
+        LocalTargetSnapshot {
+            ref_name: self.ref_name.clone(),
+            tracking_ref: self.tracking_ref.clone(),
+            snapshot_tip: self.current_tip,
+            expected_tip: self.desired_tip,
+        }
+    }
+
+    fn ref_edit(&self) -> gix::refs::transaction::RefEdit {
+        gix::refs::transaction::RefEdit {
+            name: self.ref_name.clone(),
+            change: gix::refs::transaction::Change::Update {
+                log: gix::refs::transaction::LogChange::default(),
+                expected: gix::refs::transaction::PreviousValue::MustExistAndMatch(
+                    self.current_tip.into(),
+                ),
+                new: self.desired_tip.into(),
+            },
+            deref: false,
+        }
+    }
+}
+
+fn reference_lock_timeouts(
+    repo: &gix::Repository,
+) -> (gix::lock::acquire::Fail, gix::lock::acquire::Fail) {
+    fn read(
+        repo: &gix::Repository,
+        key: &'static gix::config::tree::keys::LockTimeout,
+        default_ms: u64,
+    ) -> gix::lock::acquire::Fail {
+        let mut trusted = gix::config::section::is_trusted;
+        repo.config_snapshot()
+            .plumbing()
+            .integer_filter(key, &mut trusted)
+            .and_then(|value| key.try_into_lock_timeout(value).ok())
+            .unwrap_or_else(|| Duration::from_millis(default_ms).into())
+    }
+
+    (
+        read(repo, &gix::config::tree::Core::FILES_REF_LOCK_TIMEOUT, 100),
+        read(repo, &gix::config::tree::Core::PACKED_REFS_TIMEOUT, 1000),
+    )
+}
+
+fn validate_local_target(
+    repo: &gix::Repository,
+    ref_name: &gix::refs::FullNameRef,
+    tracking_ref: &gix::refs::FullNameRef,
+) -> Result<gix::ObjectId> {
+    let mut reference = repo
+        .try_find_reference(ref_name)?
+        .with_context(|| format!("local target '{}' no longer exists", ref_name.shorten()))?;
+    let actual_tracking_ref = repo
+        .branch_remote_tracking_ref_name(ref_name, gix::remote::Direction::Fetch)
+        .transpose()?
+        .with_context(|| {
+            format!(
+                "local target '{}' no longer has an upstream",
+                ref_name.shorten()
+            )
+        })?;
+    if actual_tracking_ref.as_ref() != tracking_ref {
+        bail!(
+            "local target '{}' now tracks '{}' instead of '{}'",
+            ref_name.shorten(),
+            actual_tracking_ref.shorten(),
+            tracking_ref.shorten()
+        );
+    }
+    if let Some(paths) = but_core::branch::SafeDelete::new(repo)?.worktree_dirs_with_ref(&reference)
+    {
+        bail!(
+            "local target '{}' is checked out in: {paths:?}",
+            ref_name.shorten()
+        );
+    }
+    Ok(reference.peel_to_id()?.detach())
+}
+
+fn snapshot_blob(tree: &gix::Tree, repo: &gix::Repository, path: &str) -> Result<Option<Vec<u8>>> {
+    tree.lookup_entry_by_path(path)?
+        .map(|entry| Ok(repo.find_blob(entry.id())?.data.to_vec()))
+        .transpose()
 }
 
 /// Restore the state of .git/base_merge_parent and .git/conflicts from the snapshot


### PR DESCRIPTION
# fix(pull): Synchronize configured local target

## 🧢 Changes

- After successful integration, fast-forward the unique safe local branch that
  tracks the target from the shared API used by CLI and GUI clients.
- Leave ambiguous, diverged, or linked-worktree branches untouched, and keep
  state consistent through failures, undo, and redo.

## ☕️ Reasoning

`but pull` could report success while leaving the local target behind its
upstream. New isolated worktrees then started from stale history, especially in
agentic coding workflows.

## 🎫 Affected issues

Fixes: #14823

## 🧪 Reproduction

```sh
but pull
git rev-list --left-right --count master...master@{upstream}
```

Before: `0 N` with `N > 0`, despite pull reporting success. After: `0 0`.

## ✅ Verification

- Focused API, CLI, failure, and undo/redo tests cover safe updates and rejected
  branch states.
- Formatting and Clippy passed; two independent reviews found no important
  issues.
- The integrated candidate passed 570 scoped tests with 14 configured skips,
  the release build, and installed smoke checks inside and outside the sandbox.

Developed with carefully directed, manually reviewed AI assistance.

Co-Authored-By: GPT-5.6 Sol <codex@openai.com>
