### PR TITLE
Make mutation command output change-id-first like but status

### DIFF
--- a/crates/but/src/command/legacy/absorb.rs
+++ b/crates/but/src/command/legacy/absorb.rs
@@ -15,7 +15,7 @@ use itertools::Itertools;
 use crate::{
     CliId, IdMap,
     id::{UncommittedHunkOrFile, parser::parse_sources},
-    utils::{OutputChannel, shorten_object_id},
+    utils::OutputChannel,
 };
 /// Amends changes into the appropriate commits where they belong.
 ///
@@ -82,7 +82,7 @@ pub(crate) fn handle(
     // would overwrite the plan in the JSON buffer).
     let plan_json = {
         let repo = ctx.repo.get()?.clone().for_commit_shortening();
-        display_absorption_plan(&absorption_plan, &repo, out, dry_run)?
+        display_absorption_plan(&absorption_plan, &id_map, &repo, out, dry_run)?
     };
 
     if dry_run {
@@ -197,6 +197,7 @@ fn get_hunk_ranges(assignment: &HunkAssignment) -> Vec<String> {
 /// in a single JSON write — avoiding a double-write that would overwrite the buffer.
 fn display_absorption_plan(
     commit_absorptions: &[CommitAbsorption],
+    id_map: &IdMap,
     repo: &gix::Repository,
     out: &mut OutputChannel,
     write_json: bool,
@@ -269,14 +270,10 @@ fn display_absorption_plan(
         writeln!(out)?;
 
         for absorption in commit_absorptions {
-            let short_hash = shorten_object_id(repo, absorption.commit_id);
-            let verb = "Absorbed to commit";
-
             writeln!(
                 out,
-                "{}: {} {}",
-                verb,
-                t.commit_id.paint(&short_hash),
+                "Absorbed to commit: {} {}",
+                theme::CommitRef(id_map, repo, absorption.commit_id),
                 absorption.commit_summary
             )?;
             writeln!(out, "  ({})", t.hint.paint(absorption.reason.description()))?;

--- a/crates/but/src/command/legacy/reword.rs
+++ b/crates/but/src/command/legacy/reword.rs
@@ -3,7 +3,6 @@ use bstr::{BString, ByteSlice};
 use but_api::diff::ComputeLineStats;
 use but_core::{DryRun, sync::RepoExclusive};
 use but_ctx::Context;
-use gix::prelude::ObjectIdExt;
 
 use super::{
     ShowDiffInEditor,
@@ -219,13 +218,12 @@ fn edit_commit_message_by_id_and_reword_commit(
         )?;
 
         if let Some(out) = out.for_human() {
-            let repo = ctx.repo.get()?;
-            writeln!(
-                out,
-                "Updated commit message for {} (now {})",
-                commit_oid.attach(&repo).shorten_or_id(),
-                new_commit_oid.new_commit.attach(&repo).shorten_or_id()
+            let new_commit = crate::theme::new_commit_ref_with_perm(
+                ctx,
+                perm.read_permission(),
+                new_commit_oid.new_commit,
             )?;
+            writeln!(out, "Updated commit message for {new_commit}")?;
         } else if let Some(out) = out.for_json() {
             out.write_value(serde_json::json!({
                 "new_commit_id": new_commit_oid.new_commit.to_string(),

--- a/crates/but/src/command/legacy/rub/amend.rs
+++ b/crates/but/src/command/legacy/rub/amend.rs
@@ -7,10 +7,8 @@ use gix::ObjectId;
 use nonempty::NonEmpty;
 
 use crate::{
-    theme::{self, Paint},
-    utils::{
-        OutputChannel, diff_specs::DiffSpecBuilder, rejection, shorten_object_id, split_short_id,
-    },
+    theme,
+    utils::{OutputChannel, diff_specs::DiffSpecBuilder, rejection},
 };
 
 pub(crate) fn uncommitted_to_commit_with_perm(
@@ -35,15 +33,7 @@ pub(crate) fn uncommitted_to_commit_with_perm(
     let (new_commit, rejected) = amend_diff_specs(ctx, diff_specs, oid, perm)?;
     update_workspace_commit(ctx, false)?;
     if let Some(out) = out.for_human() {
-        let repo = ctx.repo.get()?;
-        let new_commit = new_commit
-            .map(|c| {
-                let short = shorten_object_id(&repo, c);
-                let (lead, rest) = split_short_id(&short, 2);
-                let t = theme::get();
-                format!("{}{}", t.cli_id.paint(lead), t.cli_id.paint(rest))
-            })
-            .unwrap_or_default();
+        let new_commit = theme::new_commit_ref_with_perm(ctx, perm.read_permission(), new_commit)?;
         writeln!(out, "Amended {description} → {new_commit}")?;
         rejection::write_rejection_report(out, &rejected, target_branch.as_deref())?;
     } else if let Some(out) = out.for_json() {

--- a/crates/but/src/command/legacy/rub/mod.rs
+++ b/crates/but/src/command/legacy/rub/mod.rs
@@ -28,7 +28,7 @@ use crate::{
     CliError, CliId, IdMap, bad_input,
     command::legacy::rub::assign::stack_id_to_branch_name,
     id::parser::{IdResolutionError, parse_sources_with_disambiguation, prompt_for_disambiguation},
-    utils::{OutputChannel, diff_specs::DiffSpecBuilder, shorten_object_id, split_short_id},
+    utils::{OutputChannel, diff_specs::DiffSpecBuilder, shorten_object_id},
 };
 
 /// A description of a set of hunks.
@@ -285,18 +285,7 @@ impl<'a> UncommittedToCommitOperation<'a> {
     pub(crate) fn execute(self, ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Result<()> {
         let result = self.execute_inner(ctx)?;
         if let Some(out) = out.for_human() {
-            let repo = ctx.repo.get()?;
-            let new_commit = result
-                .new_commit
-                .map(|c| {
-                    let short = shorten_object_id(&repo, c);
-                    let (lead, rest) = split_short_id(&short, 2);
-                    {
-                        let t = theme::get();
-                        format!("{}{}", t.cli_id.paint(lead), t.cli_id.paint(rest))
-                    }
-                })
-                .unwrap_or_default();
+            let new_commit = theme::new_commit_ref(ctx, result.new_commit)?;
             writeln!(out, "Amended {} → {new_commit}", self.description)?;
         } else if let Some(out) = out.for_json() {
             out.write_value(serde_json::json!({
@@ -462,18 +451,7 @@ impl StackToCommitOperation {
         let result = self.execute_inner(ctx)?;
         if let Some(out) = out.for_human() {
             let t = theme::get();
-            let repo = ctx.repo.get()?;
-            let new_commit = result
-                .new_commit
-                .map(|c| {
-                    let short = shorten_object_id(&repo, c);
-                    let (lead, rest) = split_short_id(&short, 2);
-                    {
-                        let t = theme::get();
-                        format!("{}{}", t.cli_id.paint(lead), t.cli_id.paint(rest))
-                    }
-                })
-                .unwrap_or_default();
+            let new_commit = theme::new_commit_ref(ctx, result.new_commit)?;
             writeln!(
                 out,
                 "Amended files assigned to {} → {}",
@@ -503,18 +481,7 @@ impl UncommittedAreaToCommitOperation {
     pub(crate) fn execute(self, ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Result<()> {
         let result = self.execute_inner(ctx)?;
         if let Some(out) = out.for_human() {
-            let repo = ctx.repo.get()?;
-            let new_commit = result
-                .new_commit
-                .map(|c| {
-                    let short = shorten_object_id(&repo, c);
-                    let (lead, rest) = split_short_id(&short, 2);
-                    {
-                        let t = theme::get();
-                        format!("{}{}", t.cli_id.paint(lead), t.cli_id.paint(rest))
-                    }
-                })
-                .unwrap_or_default();
+            let new_commit = theme::new_commit_ref(ctx, result.new_commit)?;
             writeln!(out, "Amended uncommitted files → {new_commit}")?;
         } else if let Some(out) = out.for_json() {
             out.write_value(serde_json::json!({
@@ -585,17 +552,20 @@ impl UncommittedAreaToStackOperation {
 
 impl CommitToUncommittedAreaOperation {
     /// Executes this operation.
-    pub(crate) fn execute(self, ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Result<()> {
+    pub(crate) fn execute(
+        self,
+        ctx: &mut Context,
+        id_map: &IdMap,
+        out: &mut OutputChannel,
+    ) -> anyhow::Result<()> {
         self.execute_inner(ctx)?;
         if let Some(out) = out.for_human() {
-            let t = theme::get();
             let repo = ctx.repo.get()?;
             if self.commits.len() == 1 {
                 writeln!(
                     out,
                     "Uncommitted {}",
-                    t.cli_id
-                        .paint(shorten_object_id(&repo, *self.commits.first()))
+                    theme::CommitRef(id_map, &repo, *self.commits.first())
                 )?;
             } else {
                 writeln!(out, "Uncommitted {} commits", self.commits.len())?;
@@ -619,7 +589,12 @@ impl CommitToUncommittedAreaOperation {
 
 impl CommitToStackOperation {
     /// Executes this operation.
-    pub(crate) fn execute(self, ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Result<()> {
+    pub(crate) fn execute(
+        self,
+        ctx: &mut Context,
+        id_map: &IdMap,
+        out: &mut OutputChannel,
+    ) -> anyhow::Result<()> {
         self.execute_inner(ctx)?;
         if let Some(out) = out.for_human() {
             let t = theme::get();
@@ -627,7 +602,7 @@ impl CommitToStackOperation {
             writeln!(
                 out,
                 "Uncommitted {} to {}",
-                t.cli_id.paint(shorten_object_id(&repo, self.oid)),
+                theme::CommitRef(id_map, &repo, self.oid),
                 stack_id_to_branch_name(ctx, self.stack)
                     .map(|b| t.local_branch.paint(format!("[{b}]")))
                     .unwrap_or_else(|| t.important.paint("stack")),
@@ -651,32 +626,36 @@ impl CommitToStackOperation {
 
 impl SquashCommitsOperation {
     /// Executes this operation.
-    pub(crate) fn execute(self, ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Result<()> {
+    pub(crate) fn execute(
+        self,
+        ctx: &mut Context,
+        id_map: &IdMap,
+        out: &mut OutputChannel,
+    ) -> anyhow::Result<()> {
         let result = self.execute_inner(ctx)?;
         if let Some(out) = out.for_human() {
-            let t = theme::get();
             let repo = ctx.repo.get()?;
+            let new_commit = theme::new_commit_ref(ctx, result.new_commit)?;
             if self.sources.len() == 1 {
                 writeln!(
                     out,
                     "Squashed {} → {}",
-                    t.cli_id
-                        .paint(shorten_object_id(&repo, *self.sources.first())),
-                    t.cli_id.paint(shorten_object_id(&repo, result.new_commit)),
+                    theme::CommitRef(id_map, &repo, *self.sources.first()),
+                    new_commit,
                 )?;
             } else {
                 writeln!(
                     out,
                     "Squashed {} commits → {}",
                     self.sources.len(),
-                    t.cli_id.paint(shorten_object_id(&repo, result.new_commit)),
+                    new_commit,
                 )?;
             }
         } else if let Some(out) = out.for_json() {
             out.write_value(serde_json::json!({
                 "ok": true,
                 "new_commit_id": result.new_commit.to_string(),
-                "squashed_count": 1,
+                "squashed_count": self.sources.len(),
             }))?;
         }
         Ok(())
@@ -696,7 +675,12 @@ impl SquashCommitsOperation {
 
 impl<'a> MoveCommitToBranchOperation<'a> {
     /// Executes this operation.
-    pub(crate) fn execute(self, ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Result<()> {
+    pub(crate) fn execute(
+        self,
+        ctx: &mut Context,
+        id_map: &IdMap,
+        out: &mut OutputChannel,
+    ) -> anyhow::Result<()> {
         self.execute_inner(ctx)?;
         if let Some(out) = out.for_human() {
             let t = theme::get();
@@ -704,7 +688,7 @@ impl<'a> MoveCommitToBranchOperation<'a> {
             writeln!(
                 out,
                 "Moved {} → {}",
-                t.cli_id.paint(shorten_object_id(&repo, self.oid)),
+                theme::CommitRef(id_map, &repo, self.oid),
                 t.local_branch.paint(format!("[{}]", self.name))
             )?;
         } else if let Some(out) = out.for_json() {
@@ -783,18 +767,7 @@ impl<'a> BranchToCommitOperation<'a> {
         let result = self.execute_inner(ctx)?;
         if let Some(out) = out.for_human() {
             let t = theme::get();
-            let repo = ctx.repo.get()?;
-            let new_commit = result
-                .new_commit
-                .map(|c| {
-                    let short = shorten_object_id(&repo, c);
-                    let (lead, rest) = split_short_id(&short, 2);
-                    {
-                        let t = theme::get();
-                        format!("{}{}", t.cli_id.paint(lead), t.cli_id.paint(rest))
-                    }
-                })
-                .unwrap_or_default();
+            let new_commit = theme::new_commit_ref(ctx, result.new_commit)?;
             writeln!(
                 out,
                 "Amended assigned files {} → {}",
@@ -928,7 +901,12 @@ impl<'a> CommittedFileToUncommittedAreaOperation<'a> {
 
 impl<'a> RubOperation<'a> {
     /// Executes this operation, delegating to the wrapped operation payload.
-    pub(crate) fn execute(self, ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Result<()> {
+    pub(crate) fn execute(
+        self,
+        ctx: &mut Context,
+        id_map: &IdMap,
+        out: &mut OutputChannel,
+    ) -> anyhow::Result<()> {
         match self {
             RubOperation::UnassignUncommitted(operation) => operation.execute(ctx, out),
             RubOperation::UncommittedToCommit(operation) => operation.execute(ctx, out),
@@ -940,10 +918,10 @@ impl<'a> RubOperation<'a> {
             RubOperation::UncommittedAreaToCommit(operation) => operation.execute(ctx, out),
             RubOperation::UncommittedAreaToBranch(operation) => operation.execute(ctx, out),
             RubOperation::UncommittedAreaToStack(operation) => operation.execute(ctx, out),
-            RubOperation::CommitToUncommittedArea(operation) => operation.execute(ctx, out),
-            RubOperation::CommitToStack(operation) => operation.execute(ctx, out),
-            RubOperation::SquashCommits(operation) => operation.execute(ctx, out),
-            RubOperation::MoveCommitToBranch(operation) => operation.execute(ctx, out),
+            RubOperation::CommitToUncommittedArea(operation) => operation.execute(ctx, id_map, out),
+            RubOperation::CommitToStack(operation) => operation.execute(ctx, id_map, out),
+            RubOperation::SquashCommits(operation) => operation.execute(ctx, id_map, out),
+            RubOperation::MoveCommitToBranch(operation) => operation.execute(ctx, id_map, out),
             RubOperation::BranchToUncommittedArea(operation) => operation.execute(ctx, out),
             RubOperation::BranchToStack(operation) => operation.execute(ctx, out),
             RubOperation::BranchToCommit(operation) => operation.execute(ctx, out),
@@ -1328,11 +1306,12 @@ pub(crate) fn handle(
 ) -> anyhow::Result<()> {
     let id_map = IdMap::legacy_new_from_context(ctx, None)?;
     let (sources, target) = ids(ctx, &id_map, source_str, target_str, out)?;
-    handle_resolved(ctx, out, sources, target, how_to_combine_messages)
+    handle_resolved(ctx, &id_map, out, sources, target, how_to_combine_messages)
 }
 
 fn handle_resolved(
     ctx: &mut Context,
+    id_map: &IdMap,
     out: &mut OutputChannel,
     sources: Vec<CliId>,
     target: CliId,
@@ -1345,7 +1324,7 @@ fn handle_resolved(
             bail!(makes_no_sense_error(&source, &target))
         };
 
-        operation.execute(ctx, out)?;
+        operation.execute(ctx, id_map, out)?;
     }
     Ok(())
 }
@@ -1519,7 +1498,7 @@ pub(crate) fn handle_uncommit(
                         writeln!(
                             out,
                             "Discarded {}",
-                            t.cli_id.paint(shorten_object_id(&repo, commit_id))
+                            theme::CommitRef(&id_map, &repo, commit_id)
                         )?;
                     }
                 }
@@ -1556,7 +1535,7 @@ pub(crate) fn handle_uncommit(
         .iter()
         .all(|source| matches!(source, CliId::CommittedFile { .. }))
     {
-        return uncommit_committed_files(ctx, out, &sources);
+        return uncommit_committed_files(ctx, &id_map, out, &sources);
     }
 
     // Call the main rub handler with "zz" as target
@@ -1579,6 +1558,7 @@ pub(crate) fn handle_uncommit(
 /// failing the whole operation.
 fn uncommit_committed_files(
     ctx: &mut Context,
+    id_map: &IdMap,
     out: &mut OutputChannel,
     sources: &[CliId],
 ) -> anyhow::Result<()> {
@@ -1633,7 +1613,10 @@ fn uncommit_committed_files(
             .map(|failure| {
                 format!(
                     "{}: {}",
-                    shorten_object_id(&repo, failure.commit_id),
+                    id_map
+                        .change_id_ref(failure.commit_id)
+                        .map(|change_id| change_id.padded_short_id())
+                        .unwrap_or_else(|| shorten_object_id(&repo, failure.commit_id)),
                     failure.error
                 )
             })
@@ -1646,13 +1629,12 @@ fn uncommit_committed_files(
     if !result.failures.is_empty()
         && let Some(out) = out.for_human()
     {
-        let t = theme::get();
         let repo = ctx.repo.get()?;
         for failure in &result.failures {
             writeln!(
                 out,
                 "Warning: could not uncommit changes from {}: {}",
-                t.cli_id.paint(shorten_object_id(&repo, failure.commit_id)),
+                theme::CommitRef(id_map, &repo, failure.commit_id),
                 failure.error
             )?;
         }
@@ -1869,6 +1851,7 @@ pub(crate) fn handle_stage(
 
     handle_resolved(
         ctx,
+        &id_map,
         out,
         files,
         branch,

--- a/crates/but/src/command/legacy/rub/squash.rs
+++ b/crates/but/src/command/legacy/rub/squash.rs
@@ -12,11 +12,7 @@ use gix::ObjectId;
 use crate::theme::{self, Paint};
 
 use super::undo::stack_id_by_commit_id;
-use crate::{
-    CliId, IdMap,
-    command::legacy::ai,
-    utils::{OutputChannel, shorten_object_id},
-};
+use crate::{CliId, IdMap, command::legacy::ai, utils::OutputChannel};
 
 /// Handler for `but squash` command with support for:
 /// 1. Multiple commits: `but squash <commit1> <commit2> <commit3>` - squashes 1 and 2 into 3
@@ -86,6 +82,7 @@ pub(crate) fn handle(
             }
             return handle_multi_commit_squash(
                 ctx,
+                &id_map,
                 out,
                 sources,
                 drop_message,
@@ -102,6 +99,7 @@ pub(crate) fn handle(
             }
             return handle_multi_commit_squash(
                 ctx,
+                &id_map,
                 out,
                 sources,
                 drop_message,
@@ -133,6 +131,7 @@ pub(crate) fn handle(
 
     handle_multi_commit_squash(
         ctx,
+        &id_map,
         out,
         sources,
         drop_message,
@@ -143,8 +142,10 @@ pub(crate) fn handle(
 }
 
 /// Helper function to handle squashing multiple commits
+#[expect(clippy::too_many_arguments)]
 fn handle_multi_commit_squash(
     ctx: &mut Context,
+    id_map: &IdMap,
     out: &mut OutputChannel,
     sources: Vec<CliId>,
     drop_message: bool,
@@ -179,6 +180,7 @@ fn handle_multi_commit_squash(
     // Delegate to the shared squashing logic
     squash_commits_internal(
         ctx,
+        id_map,
         commit_oids,
         target_oid,
         drop_message,
@@ -193,6 +195,7 @@ fn handle_multi_commit_squash(
 #[expect(clippy::too_many_arguments)]
 fn squash_commits_internal(
     ctx: &mut Context,
+    id_map: &IdMap,
     source_oids: Vec<ObjectId>,
     target_oid: ObjectId,
     drop_message: bool,
@@ -323,30 +326,26 @@ fn squash_commits_internal(
     };
 
     // Output message based on context
-    let t = theme::get();
     if let Some(out) = out.for_human() {
         let repo = ctx.repo.get()?;
-        let final_short = shorten_object_id(&repo, final_commit_oid);
+        let new_commit =
+            theme::new_commit_ref_with_perm(ctx, perm.read_permission(), final_commit_oid)?;
         if source_oids_count == 1 {
             // Single commit squash (for backwards compatibility with `but rub`)
             writeln!(
                 out,
                 "Squashed {} → {}",
-                t.cli_id.paint(shorten_object_id(
+                theme::CommitRef(
+                    id_map,
                     &repo,
                     only_source_commit
                         .context("BUG: Source commits count is one, but first item is none")?
-                )),
-                t.cli_id.paint(&final_short)
+                ),
+                new_commit
             )?
         } else {
             // Multiple commits squash
-            writeln!(
-                out,
-                "Squashed {} commits → {}",
-                source_oids_count,
-                t.cli_id.paint(&final_short)
-            )?
+            writeln!(out, "Squashed {source_oids_count} commits → {new_commit}")?
         }
     } else if let Some(out) = out.for_json() {
         out.write_value(serde_json::json!({
@@ -410,6 +409,7 @@ fn squash_branch_commits(
     // Delegate to the shared squashing logic
     squash_commits_internal(
         ctx,
+        id_map,
         source_oids,
         target_oid,
         drop_message,

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -1199,6 +1199,29 @@ impl IdMap {
     pub fn stacks(&self) -> &Vec<StackWithId> {
         self.indexed_stacks.borrow_owner()
     }
+
+    /// The change ID behind the primary identifier `but status` displays for
+    /// `commit_id`, with its disambiguated short form. Returns `None` when the
+    /// sha is the identifier instead, i.e. for commits without a change ID or
+    /// commits this map does not contain.
+    ///
+    /// A commit is only found in a map built while it existed: use the map the
+    /// user's arguments were resolved against for commits they referenced, and
+    /// a freshly built map for commits a mutation just created. Do not
+    /// substitute a stale map for the latter: while plain change-ID prefixes
+    /// stay valid as the workspace changes (the parser matches them by
+    /// prefix), the `#N` collision suffixes are positional and only match
+    /// exactly, so an ID taken from the wrong map can silently identify a
+    /// different commit.
+    pub fn change_id_ref(&self, commit_id: gix::ObjectId) -> Option<&ChangeIdWithShortId> {
+        self.stacks()
+            .iter()
+            .flat_map(|stack| &stack.segments)
+            .flat_map(|segment| &segment.workspace_commits)
+            .find(|commit| commit.commit_id() == commit_id)?
+            .change_id
+            .as_ref()
+    }
 }
 
 fn cli_ids_refer_to_same_entity(lhs: &CliId, rhs: &CliId) -> bool {

--- a/crates/but/src/theme.rs
+++ b/crates/but/src/theme.rs
@@ -629,6 +629,81 @@ impl Display for Commit {
     }
 }
 
+/// A commit rendered the way `but status` identifies it: by its disambiguated
+/// short change ID, falling back to the short sha for commits without one.
+pub struct CommitRef<'a>(
+    pub &'a crate::IdMap,
+    pub &'a gix::Repository,
+    pub gix::ObjectId,
+);
+
+impl Display for CommitRef<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let CommitRef(id_map, repo, commit_id) = self;
+        let t = get();
+        match id_map.change_id_ref(*commit_id) {
+            Some(change_id) => {
+                // Like status: minimal unique prefix in the change-id style,
+                // the padding in the hint style.
+                let padded = change_id.padded_short_id();
+                let (id, hint) = padded.split_at(change_id.short_id.len());
+                write!(f, "{}{}", t.change_id.paint(id), t.hint.paint(hint))
+            }
+            None => write!(
+                f,
+                "{}",
+                t.cli_id
+                    .paint(crate::utils::shorten_object_id(repo, *commit_id))
+            ),
+        }
+    }
+}
+
+/// Render a [`CommitRef`] for a commit that a mutation just created, resolved
+/// against a freshly built [`crate::IdMap`] so the ID matches what the next
+/// `but status` displays (see [`crate::IdMap::change_id_ref`] for why a stale
+/// map must not be used). Renders "no commit was created" (`None`) as the
+/// empty string.
+///
+/// Building the map is not free — it diffs the worktree and persists the
+/// reconciled hunk assignments — so render each created commit only once.
+pub fn new_commit_ref_with_perm(
+    ctx: &but_ctx::Context,
+    perm: &but_core::sync::RepoShared,
+    commit_id: impl Into<Option<gix::ObjectId>>,
+) -> anyhow::Result<String> {
+    let Some(commit_id) = commit_id.into() else {
+        return Ok(String::new());
+    };
+    let repo = ctx.repo.get()?;
+    // The mutation has already succeeded when this renders its result, so a
+    // failure to build the map must not fail the command — an agent would
+    // retry a mutation that already happened. Degrade to the sha instead.
+    match crate::IdMap::new_from_context(ctx, None, perm) {
+        Ok(id_map) => Ok(CommitRef(&id_map, &repo, commit_id).to_string()),
+        Err(err) => {
+            tracing::warn!(?err, "could not build an IdMap to identify the new commit");
+            Ok(get()
+                .cli_id
+                .paint(crate::utils::shorten_object_id(&repo, commit_id))
+                .to_string())
+        }
+    }
+}
+
+/// Like [`new_commit_ref_with_perm`], for callers that hold no worktree lock.
+///
+/// When several operations run in sequence, an earlier operation's commit may
+/// be rewritten by a later one, so render each ref right after its operation
+/// completes rather than from one map built at the end.
+pub fn new_commit_ref(
+    ctx: &but_ctx::Context,
+    commit_id: impl Into<Option<gix::ObjectId>>,
+) -> anyhow::Result<String> {
+    let guard = ctx.shared_worktree_access();
+    new_commit_ref_with_perm(ctx, guard.read_permission(), commit_id)
+}
+
 pub struct Branch<T>(pub T);
 
 impl Display for Branch<FullName> {

--- a/crates/but/src/utils/mod.rs
+++ b/crates/but/src/utils/mod.rs
@@ -8,7 +8,7 @@ pub use output_channel::{
 };
 
 mod object_id;
-pub use object_id::{shorten_hex_object_id, shorten_object_id, split_short_id};
+pub use object_id::{shorten_hex_object_id, shorten_object_id};
 
 pub mod rejection;
 

--- a/crates/but/src/utils/object_id.rs
+++ b/crates/but/src/utils/object_id.rs
@@ -14,12 +14,3 @@ pub fn shorten_hex_object_id(repo: &gix::Repository, hex: &str) -> String {
         .map(|oid| shorten_object_id(repo, oid))
         .unwrap_or_else(|_| hex.to_owned())
 }
-
-/// Split a `short_id` into a leading prefix and remaining suffix for styled output.
-pub fn split_short_id(short_id: &str, prefix_len: usize) -> (&str, &str) {
-    if short_id.len() <= prefix_len {
-        (short_id, "")
-    } else {
-        short_id.split_at(prefix_len)
-    }
-}

--- a/crates/but/tests/but/command/absorb.rs
+++ b/crates/but/tests/but/command/absorb.rs
@@ -44,7 +44,7 @@ fn uncommitted_file() -> anyhow::Result<()> {
         .stdout_eq(snapbox::str![[r#"
 Found 1 changed file to absorb:
 
-Absorbed to commit: f4ea7f8 a.txt
+Absorbed to commit: 1 a.txt
   (files locked to commit due to hunk range overlap)
     a.txt @1,4 +1,4
     a.txt @6,4 +6,4
@@ -127,7 +127,7 @@ n:e a.txt│
         .stdout_eq(snapbox::str![[r#"
 Found 1 changed file to absorb:
 
-Absorbed to commit: f4ea7f8 a.txt
+Absorbed to commit: 1 a.txt
   (files locked to commit due to hunk range overlap)
     a.txt @1,4 +1,4
 
@@ -338,11 +338,11 @@ Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "mes
         .stdout_eq(snapbox::str![[r#"
 Found 1 changed file to absorb:
 
-Absorbed to commit: 889385c partial change to a.txt 2
+Absorbed to commit: 1#1 partial change to a.txt 2
   (files locked to commit due to hunk range overlap)
     a.txt @1,4 +1,4
 
-Absorbed to commit: a7aa4ef partial change to a.txt 3
+Absorbed to commit: 1#0 partial change to a.txt 3
   (files locked to commit due to hunk range overlap)
     a.txt @6,4 +6,4
 
@@ -468,7 +468,7 @@ fn dry_run_shows_plan_without_changes() -> anyhow::Result<()> {
         .stdout_eq(snapbox::str![[r#"
 Found 1 changed file to absorb:
 
-Absorbed to commit: f4ea7f8 a.txt
+Absorbed to commit: 1 a.txt
   (files locked to commit due to hunk range overlap)
     a.txt @1,4 +1,4
     a.txt @6,4 +6,4

--- a/crates/but/tests/but/command/reword.rs
+++ b/crates/but/tests/but/command/reword.rs
@@ -23,7 +23,7 @@ fn reword_commit_with_message_flag() {
         .assert()
         .success()
         .stdout_eq(str![[r#"
-Updated commit message for [..] (now [..])
+Updated commit message for [..]
 
 "#]]);
 
@@ -36,6 +36,25 @@ Updated commit message for [..] (now [..])
 
 "#]]
     );
+}
+
+/// Commits with a change ID are identified by it, matching how `but status`
+/// displays them.
+#[test]
+fn reword_commit_with_change_id_shows_change_id() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
+
+    env.file("new.txt", "content\n");
+    env.but("commit A -m 'add new.txt'").assert().success();
+
+    env.but("reword 1 -m 'reworded'")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Updated commit message for 1
+
+"#]]);
 }
 
 #[test]
@@ -58,7 +77,7 @@ fn reword_commit_with_multiline_message() -> anyhow::Result<()> {
         .assert()
         .success()
         .stdout_eq(str![[r#"
-Updated commit message for [..] (now [..])
+Updated commit message for [..]
 
 "#]]);
 

--- a/crates/but/tests/but/command/rub.rs
+++ b/crates/but/tests/but/command/rub.rs
@@ -512,11 +512,13 @@ fn uncommitted_hunk_to_commit() -> anyhow::Result<()> {
     commit_file_with_worktree_changes_as_two_hunks(&env, "A", "a.txt");
 
     let target_commit = branch_commit_ids(&status_json(&env)?, "A")[0].clone();
+    // The amended commit is identified by its change ID, from a freshly built
+    // map that knows the post-amend workspace.
     env.but(format!("rub zz:a.txt:#0 {target_commit}"))
         .assert()
         .success()
         .stdout_eq(str![[r#"
-Amended [..] → [..]
+Amended [..] → 1
 
 "#]])
         .stderr_eq(str![""]);

--- a/crates/but/tests/but/command/undo.rs
+++ b/crates/but/tests/but/command/undo.rs
@@ -242,7 +242,7 @@ fn can_undo_rewording_commit() {
             .args(["9ac4652", "-m", "reworded"])
             .assert()
             .success()
-            .stdout_eq("Updated commit message for [..] (now [..])\n")
+            .stdout_eq("Updated commit message for [..]\n")
             .stderr_eq("");
     });
 }


### PR DESCRIPTION
`but status` recently made change IDs the primary commit identifier, but mutation commands still reported success in terms of shas. An agent that reads `kyn` from status and gets `a1b2c3d` back from a mutation ends up juggling two vocabularies for the same commit — and worse, may feed shas into follow-up commands where they go stale after every history rewrite.

This converts `reword`, `rub`, `amend`, `squash`, and `absorb` to identify commits by their disambiguated short change ID, exactly as status displays them:

- `IdMap::change_id_ref(oid)` returns the primary identifier status shows for a commit (including `#N` collision suffixes). Its doc records the key invariant: those suffixes are positional and only match exactly, so an ID from a stale map can silently name a different commit.
- `theme::CommitRef` renders it with the same styling as status, falling back to the short sha for commits without a change ID.
- Commits the user referenced render from the map their arguments were resolved against; newly created commits (amend/squash/reword results) render from a freshly built post-mutation map, so the printed ID is what the next `but status` will show.
- Rendering never fails a command whose mutation already landed: a failed map build degrades to the short sha instead of returning an error that would prompt an agent to retry the mutation.

Reword's message drops the sha note (`for kyn (sha 92fced0)` → `for kyn`); the sha is available via `but status -v`. The `2`-suffixed commands, `pick`, `pull`, and adding change-ID fields to JSON output are deliberately left for follow-ups. One JSON bugfix rode along per review: `rub` squash's `squashed_count` reported a hardcoded `1`; it now reports the actual source count, matching `but squash`.
