### PR TITLE
Fix Windows deep link handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1507,6 +1507,7 @@ dependencies = [
  "anyhow",
  "dirs",
  "open",
+ "url",
 ]
 
 [[package]]

--- a/apps/desktop/src/lib/backend/tauri.test.ts
+++ b/apps/desktop/src/lib/backend/tauri.test.ts
@@ -5,6 +5,7 @@ describe("isValidDeepLinkUrl", () => {
 	test("returns true for valid but:// URLs", () => {
 		expect(isValidDeepLinkUrl("but://open")).toBe(true);
 		expect(isValidDeepLinkUrl("but://open?path=/some/path")).toBe(true);
+		expect(isValidDeepLinkUrl("but://open/?path=C:\\some\\path")).toBe(true);
 		expect(isValidDeepLinkUrl("but://open?path=/some/path&other=param")).toBe(true);
 	});
 
@@ -29,7 +30,15 @@ describe("isValidDeepLinkUrl", () => {
 		expect(isValidDeepLinkUrl("but://")).toBe(false);
 		expect(isValidDeepLinkUrl("but://invalid")).toBe(false);
 		expect(isValidDeepLinkUrl("but://invalid-path")).toBe(false);
+		expect(isValidDeepLinkUrl("but://open-other")).toBe(false);
+		expect(isValidDeepLinkUrl("but://open/extra?path=/some/path")).toBe(false);
 		expect(isValidDeepLinkUrl("but://close")).toBe(false);
+	});
+
+	test("returns false for unsupported URL components", () => {
+		expect(isValidDeepLinkUrl("but://user@open?path=/some/path")).toBe(false);
+		expect(isValidDeepLinkUrl("but://open:123?path=/some/path")).toBe(false);
+		expect(isValidDeepLinkUrl("but://open?path=/some/path#fragment")).toBe(false);
 	});
 
 	test("returns false for malformed URLs", () => {
@@ -49,10 +58,24 @@ describe("parseDeepLinkUrl", () => {
 	});
 
 	test("parses open URLs with single query parameter", () => {
-		const result = parseDeepLinkUrl("but://open?path=/some/path" as any);
+		const result = parseDeepLinkUrl("but://open?path=/some/path");
 		expect(result).not.toBeNull();
 		expect(result![0]).toBe("open");
 		expect(result![1].get("path")).toBe("/some/path");
+	});
+
+	test("parses Windows-normalized URLs with a root path", () => {
+		const result = parseDeepLinkUrl("but://open/?path=C:\\some\\path");
+		expect(result).not.toBeNull();
+		expect(result![0]).toBe("open");
+		expect(result![1].get("path")).toBe("C:\\some\\path");
+	});
+
+	test("parses Windows-normalized login URLs", () => {
+		const result = parseDeepLinkUrl("but://login/?access_token=token&t=123");
+		expect(result).not.toBeNull();
+		expect(result![0]).toBe("login");
+		expect(result![1].get("access_token")).toBe("token");
 	});
 
 	test("parses open URLs with multiple query parameters", () => {

--- a/apps/desktop/src/lib/backend/tauri.ts
+++ b/apps/desktop/src/lib/backend/tauri.ts
@@ -99,14 +99,9 @@ function handleDeepLinkUrls(urls: string[], handlers: DeepLinkHandlers) {
 	// We don't care about the previous URLs, only the last one.
 	const url = urls[urls.length - 1];
 	if (!url) return;
-	if (!isValidDeepLinkUrl(url)) {
-		console.warn("Received invalid deep link URL:", url);
-		return;
-	}
-
 	const result = parseDeepLinkUrl(url);
 	if (!result) {
-		console.warn("Failed to parse deep link URL:", url);
+		console.warn("Received invalid deep link URL:", url);
 		return;
 	}
 
@@ -149,41 +144,34 @@ function handleTopLevel(
 	}
 }
 
-const DEEP_LINK_SCHMES = ["but", "but-dev", "but-nightly"] as const;
-type DeepLinkScheme = (typeof DEEP_LINK_SCHMES)[number];
+const DEEP_LINK_SCHEMES = ["but", "but-dev", "but-nightly"] as const;
 
 const DEEP_LINK_TOP_LEVEL_PATHS = ["open", "login"] as const;
 type DeepLinkTopLevelPath = (typeof DEEP_LINK_TOP_LEVEL_PATHS)[number];
-
-type DeepLinkUrl = `${DeepLinkScheme}://${DeepLinkTopLevelPath}${string}`;
 
 function isValidDeepLinkTopLevelPath(path: string): path is DeepLinkTopLevelPath {
 	return DEEP_LINK_TOP_LEVEL_PATHS.includes(path as DeepLinkTopLevelPath);
 }
 
-export function isValidDeepLinkUrl(url: string): url is DeepLinkUrl {
-	const correctScheme = DEEP_LINK_SCHMES.some((scheme) => url.startsWith(`${scheme}://`));
-	if (!correctScheme) return false;
-	const pathPart = url.split("://")[1];
-	if (!pathPart) return false;
-	const correctPath = DEEP_LINK_TOP_LEVEL_PATHS.some((path) => pathPart.startsWith(path));
-	if (!correctPath) return false;
-	return true;
+export function isValidDeepLinkUrl(url: string): boolean {
+	return parseDeepLinkUrl(url) !== null;
 }
 
-export function parseDeepLinkUrl(url: DeepLinkUrl): [DeepLinkTopLevelPath, URLSearchParams] | null {
-	const pathPart = url.split("://")[1];
-	if (!pathPart) return null;
-	const [path, queryString] = pathPart.split("?");
-	if (!path) return null;
-	if (!isValidDeepLinkTopLevelPath(path)) return null;
-	const searchParams = parseSearchParams(queryString ?? "");
+export function parseDeepLinkUrl(url: string): [DeepLinkTopLevelPath, URLSearchParams] | null {
+	let parsedUrl: URL;
+	try {
+		parsedUrl = new URL(url);
+	} catch {
+		return null;
+	}
 
-	return [path, searchParams];
-}
+	const scheme = parsedUrl.protocol.slice(0, -1);
+	if (!DEEP_LINK_SCHEMES.some((validScheme) => validScheme === scheme)) return null;
+	if (!isValidDeepLinkTopLevelPath(parsedUrl.hostname)) return null;
+	if (parsedUrl.pathname !== "" && parsedUrl.pathname !== "/") return null;
+	if (parsedUrl.username || parsedUrl.password || parsedUrl.port || parsedUrl.hash) return null;
 
-function parseSearchParams(queryString: string): URLSearchParams {
-	return new URLSearchParams(queryString);
+	return [parsedUrl.hostname, parsedUrl.searchParams];
 }
 class TauriDiskStore implements DiskStore {
 	constructor(private store: Store) {}

--- a/crates/but-path/Cargo.toml
+++ b/crates/but-path/Cargo.toml
@@ -13,5 +13,6 @@ doctest = false
 anyhow.workspace = true
 dirs = "6.0.0"
 open.workspace = true
+url.workspace = true
 [lints]
 workspace = true

--- a/crates/but-path/src/lib.rs
+++ b/crates/but-path/src/lib.rs
@@ -226,13 +226,7 @@ impl AppChannel {
             .unwrap()
             .as_millis();
 
-        let url = format!(
-            "{}://open?path={}&t={}&new_window={}",
-            scheme,
-            possibly_project_dir.display(),
-            timestamp,
-            if new_window { 1 } else { 0 }
-        );
+        let url = build_open_url(scheme, possibly_project_dir, timestamp, new_window)?;
 
         let cleaned_vars: Vec<(&str, String)> = clean_env_vars(&[
             "APPDIR",
@@ -280,7 +274,7 @@ impl AppChannel {
             // whatever we find. This can be fixed by giving the binaries different names, but as
             // so few users use nightly builds, it's just not worth the effort.
             let mut cmd = Command::new("gitbutler-tauri");
-            cmd.arg(&url);
+            cmd.arg(url.as_str());
             cmd.current_dir(env::temp_dir());
             cmd.envs(cleaned_vars.clone());
 
@@ -303,7 +297,7 @@ impl AppChannel {
         #[cfg(not(target_os = "linux"))]
         {
             let mut cmd_errors = Vec::new();
-            for mut cmd in open::commands(&url) {
+            for mut cmd in open::commands(url.as_str()) {
                 cmd.envs(cleaned_vars.clone());
                 cmd.current_dir(env::temp_dir());
                 if cmd.status().is_ok() {
@@ -318,6 +312,20 @@ impl AppChannel {
         }
         Ok(())
     }
+}
+
+fn build_open_url(
+    scheme: &str,
+    possibly_project_dir: &std::path::Path,
+    timestamp: u128,
+    new_window: bool,
+) -> anyhow::Result<url::Url> {
+    let mut url = url::Url::parse(&format!("{scheme}://open"))?;
+    url.query_pairs_mut()
+        .append_pair("path", &possibly_project_dir.to_string_lossy())
+        .append_pair("t", &timestamp.to_string())
+        .append_pair("new_window", if new_window { "1" } else { "0" });
+    Ok(url)
 }
 
 impl std::str::FromStr for AppChannel {
@@ -351,4 +359,40 @@ fn clean_env_vars<'a, 'b>(
                     .join(":"),
             )
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_open_url;
+
+    #[test]
+    fn open_url_encodes_query_parameters() -> anyhow::Result<()> {
+        let path = std::path::Path::new(r"C:\project & tools\#one");
+        let url = build_open_url("but", path, 123, true)?;
+
+        assert_eq!(
+            url.as_str(),
+            "but://open?path=C%3A%5Cproject+%26+tools%5C%23one&t=123&new_window=1",
+            "reserved path characters are encoded"
+        );
+        assert_eq!(url.scheme(), "but", "the requested app channel is retained");
+        assert_eq!(url.host_str(), Some("open"), "the open command is retained");
+        assert_eq!(
+            url.query_pairs()
+                .collect::<std::collections::HashMap<_, _>>(),
+            std::collections::HashMap::from([
+                (std::borrow::Cow::Borrowed("path"), path.to_string_lossy()),
+                (
+                    std::borrow::Cow::Borrowed("t"),
+                    std::borrow::Cow::Borrowed("123")
+                ),
+                (
+                    std::borrow::Cow::Borrowed("new_window"),
+                    std::borrow::Cow::Borrowed("1"),
+                ),
+            ]),
+            "query values round-trip after encoding"
+        );
+        Ok(())
+    }
 }


### PR DESCRIPTION
Accept Windows-normalized deep links and URL-encode CLI deep-link query parameters.

Fixes #14743