### PR TITLE
Preserve empty branch ownership when reordering

### DIFF
--- a/crates/but-api/tests/api/branch_move.rs
+++ b/crates/but-api/tests/api/branch_move.rs
@@ -5,7 +5,9 @@ use crate::support::{
     assert_workspace_ref, create_empty_branch_above, repo_with_feature_branch, write_file,
 };
 
-fn context_with_three_branch_stack() -> anyhow::Result<(but_ctx::Context, tempfile::TempDir)> {
+fn context_with_three_branch_stack_options(
+    empty_top_branch: bool,
+) -> anyhow::Result<(but_ctx::Context, tempfile::TempDir)> {
     let tmp = tempfile::tempdir()?;
     git_at_dir(tmp.path()).args(["init", "-b", "main"]).run();
     git_at_dir(tmp.path())
@@ -28,6 +30,9 @@ fn context_with_three_branch_stack() -> anyhow::Result<(but_ctx::Context, tempfi
         git_at_dir(tmp.path())
             .args(["checkout", "-b", branch])
             .run();
+        if empty_top_branch && branch == "C" {
+            continue;
+        }
         let file_name = format!("{branch}.txt");
         write_file(tmp.path(), &file_name, &format!("{branch}\n"))?;
         git_at_dir(tmp.path()).args(["add", &file_name]).run();
@@ -52,6 +57,14 @@ fn context_with_three_branch_stack() -> anyhow::Result<(but_ctx::Context, tempfi
     ])?;
     drop(meta);
     Ok((ctx, tmp))
+}
+
+fn context_with_three_branch_stack() -> anyhow::Result<(but_ctx::Context, tempfile::TempDir)> {
+    context_with_three_branch_stack_options(false)
+}
+
+fn context_with_empty_top_branch() -> anyhow::Result<(but_ctx::Context, tempfile::TempDir)> {
+    context_with_three_branch_stack_options(true)
 }
 
 #[cfg(not(feature = "graph-workspace"))]
@@ -206,6 +219,57 @@ fn successful_branch_move_returns_and_persists_reordered_stack() -> anyhow::Resu
         ctx.meta()?.branch_stack_order(tip.as_ref())?,
         Some(vec![tip, subject, target]),
         "the successful materialization should persist the new order"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn move_empty_top_branch_below_middle_preserves_commit_ownership() -> anyhow::Result<()> {
+    let (mut ctx, _tmp) = context_with_empty_top_branch()?;
+    let bottom: gix::refs::FullName = "refs/heads/A".try_into()?;
+    let middle: gix::refs::FullName = "refs/heads/B".try_into()?;
+    let empty_top: gix::refs::FullName = "refs/heads/C".try_into()?;
+    let middle_tip_before = ctx.repo.get()?.rev_parse_single(middle.as_ref())?.detach();
+    assert_eq!(
+        ctx.repo
+            .get()?
+            .rev_parse_single(empty_top.as_ref())?
+            .detach(),
+        middle_tip_before,
+        "the top branch starts empty"
+    );
+
+    // The branch dropzone below B targets A, making the requested order B, C, A (tip to base).
+    let result =
+        but_api::branch::move_branch(&mut ctx, empty_top.as_ref(), bottom.as_ref(), DryRun::No)?;
+
+    assert_workspace_ref(&result.workspace, "refs/heads/B");
+    #[cfg(not(feature = "graph-workspace"))]
+    assert_eq!(workspace_branch_names(&result.workspace), ["B", "C", "A"]);
+
+    let repo = ctx.repo.get()?;
+    let bottom_tip = repo.rev_parse_single(bottom.as_ref())?.detach();
+    assert_eq!(
+        repo.rev_parse_single(middle.as_ref())?.detach(),
+        middle_tip_before,
+        "the middle branch keeps owning its commit"
+    );
+    assert_eq!(
+        repo.rev_parse_single(empty_top.as_ref())?.detach(),
+        bottom_tip,
+        "the moved branch stays empty at its new position"
+    );
+    assert_eq!(
+        repo.head_name()?.as_ref(),
+        Some(&middle),
+        "HEAD follows the new stack tip"
+    );
+    drop(repo);
+    assert_eq!(
+        ctx.meta()?.branch_stack_order(middle.as_ref())?,
+        Some(vec![middle, empty_top, bottom]),
+        "the persisted order matches the ownership-preserving ref move"
     );
 
     Ok(())

--- a/crates/but-workspace/src/branch/move_branch.rs
+++ b/crates/but-workspace/src/branch/move_branch.rs
@@ -224,10 +224,11 @@ pub(super) mod function {
     ///
     /// In single-branch (ad-hoc) mode there is no workspace commit, and the tip-to-base order of
     /// branches lives in the `branch_order` metadata table rather than in workspace metadata. Empty
-    /// branches can therefore move through metadata alone, while branches with commits also require
-    /// a graph rewrite. The reordered chain is returned in [`Outcome::branch_stack_order`] for the
-    /// caller to persist (via [`RefMetadata::set_branch_stack_order`]) rather than being written
-    /// here, so callers can skip persistence for dry-run previews.
+    /// branches can therefore move through metadata alone when their refs already share a target,
+    /// while branches with commits or empty branches crossing commits also require a graph rewrite.
+    /// The reordered chain is returned in [`Outcome::branch_stack_order`] for the caller to persist
+    /// (via [`RefMetadata::set_branch_stack_order`]) rather than being written here, so callers can
+    /// skip persistence for dry-run previews.
     fn move_branch_in_single_branch_mode<'ws, 'meta, M: RefMetadata>(
         mut successful_rebase: SuccessfulRebase<'ws, 'meta, M>,
         workspace: but_graph::Workspace,
@@ -245,6 +246,12 @@ pub(super) mod function {
         if !subject_segment.commits.is_empty() && !same_stack(source_stack, destination_stack) {
             bail!("Moving a non-empty branch in single-branch mode is not yet supported");
         }
+        // Reordering same-target empty refs only changes which empty segment is displayed first.
+        // If their targets differ, however, the subject crosses commit-owning segments and its ref
+        // must move with it or those commits would be projected as belonging to the empty branch.
+        let move_requires_graph_update = !subject_segment.commits.is_empty()
+            || successful_rebase.reference_target(subject_branch_name)?
+                != successful_rebase.reference_target(target_branch_name)?;
         let existing_order = {
             let (_repo, meta) = successful_rebase.repo_and_meta_mut();
             if !meta.can_persist_branch_stack_order() {
@@ -292,7 +299,7 @@ pub(super) mod function {
             });
         }
 
-        if !subject_segment.commits.is_empty() {
+        if move_requires_graph_update {
             let (_, target_segment) = destination;
             let target_segment_ref_name = target_segment
                 .ref_name()

--- a/e2e/playwright/scripts/project-in-single-branch-three-branch-stack.sh
+++ b/e2e/playwright/scripts/project-in-single-branch-three-branch-stack.sh
@@ -7,6 +7,7 @@ echo "DATA DIR $E2E_TEST_APP_DATA_DIR"
 echo "BUT $BUT"
 
 head_branch="${1:-C}"
+empty_top_branch="${2:-false}"
 
 # Setup a remote project. GitButler currently requires projects to have a remote.
 mkdir remote-project
@@ -38,9 +39,11 @@ git add B.txt
 git commit -m "B: first commit"
 
 git checkout -b C
-echo "C" > C.txt
-git add C.txt
-git commit -m "C: first commit"
+if [ "$empty_top_branch" != "true" ]; then
+  echo "C" > C.txt
+  git add C.txt
+  git commit -m "C: first commit"
+fi
 
 python3 - .git/gitbutler/but.sqlite <<'PYTHON'
 import sqlite3

--- a/e2e/playwright/tests/singleBranch/moveBranch.spec.ts
+++ b/e2e/playwright/tests/singleBranch/moveBranch.spec.ts
@@ -174,6 +174,41 @@ test("can move the checked-out top branch down within its stack", async ({ page,
 	await assertCommitSubjects(["B: first commit", "C: first commit", "A: first commit"], localClone);
 });
 
+test("keeps an empty top branch empty when moving it below a commit-owning branch", async ({
+	page,
+	gitbutler,
+}) => {
+	const localClone = await setupThreeBranchStackProject(gitbutler, page, "C", true);
+	const bTipBefore = branchTip("B", localClone);
+	const aTipBefore = branchTip("A", localClone);
+
+	await expect(getByTestId(page, "branch-card")).toHaveCount(3);
+	await expectCurrentBranchChip(page, "C");
+	await expectBranchHeaderOrder(page, ["C", "B", "A"]);
+	expect(branchTip("C", localClone)).toBe(bTipBefore);
+
+	const bCard = getByTestId(page, "branch-card").filter({ has: branchHeader(page, "B") });
+	const cCard = getByTestId(page, "branch-card").filter({ has: branchHeader(page, "C") });
+	await expect(
+		bCard.getByTestId("commit-row").filter({ hasText: "B: first commit" }),
+	).toBeVisible();
+	await expect(cCard.getByTestId("commit-row")).toHaveCount(0);
+
+	// Moving C below B drops it immediately above A. C must move to A's tip so B keeps its commit.
+	await dragBranchToInsertionDropzone(page, "C", 1);
+
+	await expectBranchHeaderOrder(page, ["B", "C", "A"]);
+	await expectCurrentBranchChip(page, "B");
+	await assertBranch("B", localClone);
+	expect(branchTip("B", localClone)).toBe(bTipBefore);
+	expect(branchTip("C", localClone)).toBe(aTipBefore);
+	await expect(
+		bCard.getByTestId("commit-row").filter({ hasText: "B: first commit" }),
+	).toBeVisible();
+	await expect(cCard.getByTestId("commit-row")).toHaveCount(0);
+	await assertCommitSubjects(["B: first commit", "A: first commit"], localClone);
+});
+
 test("can move a bottom non-empty branch above the checked-out middle branch", async ({
 	page,
 	gitbutler,
@@ -198,8 +233,12 @@ async function setupThreeBranchStackProject(
 	gitbutler: GitButler,
 	page: Page,
 	headBranch = "C",
+	emptyTopBranch = false,
 ): Promise<string> {
-	await gitbutler.runScript("project-in-single-branch-three-branch-stack.sh", [headBranch]);
+	await gitbutler.runScript("project-in-single-branch-three-branch-stack.sh", [
+		headBranch,
+		emptyTopBranch.toString(),
+	]);
 	const localClone = gitbutler.pathInWorkdir("local-clone");
 	await openSingleBranchWorkspace(page);
 	return localClone;


### PR DESCRIPTION
## Why?
In single-branch mode: Dragging an empty branch (B) under a non-empty branch (A), would result in B owning the commits from A and A becoming empty.

That's no longer the case.

## Summary

- move empty ad-hoc branch refs when a reorder crosses commit-owning segments
- preserve metadata-only reorders for empty branches that already share a commit target
- add API and Playwright regressions for `A <- B <- C (empty)` becoming `A <- C (empty) <- B`
