### PR TITLE
Show change ID next to commit SHA in commit details

### DIFF
--- a/apps/desktop/src/components/commit/CommitDetails.svelte
+++ b/apps/desktop/src/components/commit/CommitDetails.svelte
@@ -57,7 +57,7 @@
 		<Tooltip text="Copy commit SHA">
 			<CopyButton
 				class="copy-sha"
-				text={commit.id}
+				text={commit.id.slice(0, 7)}
 				onclick={() => {
 					clipboardService.write(commit.id, {
 						message: "Commit SHA copied",
@@ -65,6 +65,21 @@
 				}}
 			/>
 		</Tooltip>
+		{#if commit.changeId}
+			{@const changeId = commit.changeId}
+			<span class="divider">•</span>
+			<Tooltip text="Change ID: {changeId}">
+				<CopyButton
+					class="copy-change-id"
+					text={changeId.slice(0, 3)}
+					onclick={() => {
+						clipboardService.write(changeId, {
+							message: "Change ID copied",
+						});
+					}}
+				/>
+			</Tooltip>
+		{/if}
 	</div>
 
 	{#if description && description.trim()}

--- a/apps/desktop/src/components/stack/AbsorbPlanModal.svelte
+++ b/apps/desktop/src/components/stack/AbsorbPlanModal.svelte
@@ -106,7 +106,7 @@
 									</p>
 									<CopyButton
 										class="text-12 clr-text-2"
-										text={commitAbsorption.commitId}
+										text={commitAbsorption.commitId.slice(0, 7)}
 										onclick={() => {
 											clipboardService.write(commitAbsorption.commitId, {
 												message: "Commit ID copied",

--- a/packages/ui/src/lib/components/CopyButton.svelte
+++ b/packages/ui/src/lib/components/CopyButton.svelte
@@ -1,18 +1,13 @@
 <script lang="ts" module>
 	export interface Props {
 		/**
-		 * The text to display and copy
+		 * The label to display; copying is up to the caller's `onclick`
 		 */
 		text: string;
 		/**
 		 * Optional prefix to display before the text (e.g., "upstream")
 		 */
 		prefix?: string;
-		/**
-		 * Whether to show only the first 7 characters (useful for SHAs)
-		 * @default true
-		 */
-		shortenText?: boolean;
 		/**
 		 * Callback when the button is clicked
 		 */
@@ -27,15 +22,13 @@
 <script lang="ts">
 	import Icon from "$components/Icon.svelte";
 
-	const { text, prefix, shortenText = true, onclick, class: className }: Props = $props();
-
-	const displayText = $derived(shortenText ? text.substring(0, 7) : text);
+	const { text, prefix, onclick, class: className }: Props = $props();
 </script>
 
 <button type="button" class="copy-btn underline-dotted {className}" {onclick}>
 	<span>
 		{#if prefix}{prefix}
-		{/if}{displayText}
+		{/if}{text}
 	</span>
 	<Icon name="copy" size={14} />
 </button>

--- a/packages/ui/src/lib/components/SimpleCommitRow.svelte
+++ b/packages/ui/src/lib/components/SimpleCommitRow.svelte
@@ -63,13 +63,13 @@
 			{/if}
 
 			<div class="details text-11">
-				<CopyButton class="details-btn" text={sha} onclick={onCopy} />
+				<CopyButton class="details-btn" text={sha.slice(0, 7)} onclick={onCopy} />
 
 				{#if upstreamSha}
 					<span class="details-divider">•</span>
 					<CopyButton
 						class="details-btn"
-						text={upstreamSha}
+						text={upstreamSha.slice(0, 7)}
 						prefix="upstream"
 						onclick={onCopyUpstream}
 					/>


### PR DESCRIPTION
Now that the CLI is change-id-first, the desktop app shows each commit's change ID alongside its SHA in the commit details view.

- Displays the first 3 characters (matching the CLI's minimum display length), with the full change ID visible on hover and copied on click.
- `CopyButton` now just renders the label it's given: callers pass already-truncated text and own copying via `onclick` (which they already did), removing the `shortenText` knob and its hardcoded 7-char truncation.
- Hidden for upstream commits without a change ID.

cc @PavelLaptev - this was needed because when using agents, it may say to the user "i added the changes in `tww`" and then the user may not know which commit "tww" is. 
<img width="490" height="147" alt="Screenshot 2026-07-17 at 11 16 48" src="https://github.com/user-attachments/assets/5d94833c-cd02-4ed6-856c-6312c39af5a7" />

