### PR TITLE
Update all global agent skills

### DIFF
--- a/crates/but/src/command/skill/freshness.rs
+++ b/crates/but/src/command/skill/freshness.rs
@@ -5,8 +5,8 @@
 use std::path::PathBuf;
 
 use super::{
-    find_format_installations, home_dir, is_current_skill_installation, skill_format_for_agent,
-    skill_format_for_name, write_skill_files,
+    check_skill_status, find_format_installations, home_dir, is_current_skill_installation,
+    skill_format_for_agent, skill_format_for_name, write_skill_files,
 };
 use crate::{
     theme,
@@ -14,6 +14,7 @@ use crate::{
 };
 
 pub(crate) enum AgentSkillNotice {
+    NotInstalled(String),
     Hint(String),
     Updated(String),
     UpdateFailed(String),
@@ -22,27 +23,34 @@ pub(crate) enum AgentSkillNotice {
 impl AgentSkillNotice {
     pub(crate) fn text(&self) -> &str {
         match self {
-            Self::Hint(text) | Self::Updated(text) | Self::UpdateFailed(text) => text,
+            Self::NotInstalled(text)
+            | Self::Hint(text)
+            | Self::Updated(text)
+            | Self::UpdateFailed(text) => text,
         }
     }
 
     fn into_text(self) -> String {
         match self {
-            Self::Hint(text) | Self::Updated(text) | Self::UpdateFailed(text) => text,
+            Self::NotInstalled(text)
+            | Self::Hint(text)
+            | Self::Updated(text)
+            | Self::UpdateFailed(text) => text,
         }
     }
 
     pub(crate) fn is_hint(&self) -> bool {
-        matches!(self, Self::Hint(_))
+        matches!(self, Self::NotInstalled(_) | Self::Hint(_))
     }
 }
 
 pub(crate) fn agent_skill_notice(current_dir: &std::path::Path) -> Option<AgentSkillNotice> {
     let update = agent_skill_freshness_check();
     let hint = agent_skill_install_hint(current_dir);
-    match update {
-        Some(failed @ AgentSkillNotice::UpdateFailed(_)) => Some(failed),
-        update => hint.or(update),
+    match (hint, update) {
+        (Some(missing @ AgentSkillNotice::NotInstalled(_)), _) => Some(missing),
+        (_, Some(failed @ AgentSkillNotice::UpdateFailed(_))) => Some(failed),
+        (hint, update) => hint.or(update),
     }
 }
 
@@ -52,31 +60,39 @@ pub(crate) fn agent_skill_update_notice() -> Option<String> {
 
 /// Skill upkeep for agent commands. Returns `None` when no agent is detected.
 ///
-/// Scans skill installations and updates the detected agent's stale global copy.
+/// Scans skill installations and updates all stale global copies.
 ///
 /// Best-effort by construction: every failure in skill detection or file
 /// updates is logged or turned into an agent-facing line.
 /// Nothing propagates to the command that triggered the check.
 fn agent_skill_freshness_check() -> Option<AgentSkillNotice> {
-    let agent = detect_agent::detect()?;
-    let version = option_env!("VERSION").unwrap_or("dev");
-    let outdated: Vec<_> = agent_skill_installations(agent, None)?
+    detect_agent::detect()?;
+    let result = check_skill_status(None, true, false).ok()?;
+    let outdated: Vec<_> = result
+        .skills
         .into_iter()
-        .filter(|path| !is_current_skill_installation(path, version))
+        .filter(|skill| !skill.up_to_date)
+        .map(|skill| skill.path)
         .collect();
     if outdated.is_empty() {
         return None;
     }
+    let mut update_error = None;
     for path in outdated {
         if let Err(err) = write_skill_files(&path) {
-            tracing::debug!(?err, "failed to update the agent skill");
-            return Some(AgentSkillNotice::UpdateFailed(
-                agent_skill_update_failed_notice(&err),
-            ));
+            tracing::debug!(?err, ?path, "failed to update the agent skill");
+            if update_error.is_none() {
+                update_error = Some(err);
+            }
         }
     }
+    if let Some(err) = update_error {
+        return Some(AgentSkillNotice::UpdateFailed(
+            agent_skill_update_failed_notice(&err),
+        ));
+    }
     Some(AgentSkillNotice::Updated(agent_skill_updated_message(
-        version,
+        &result.cli_version,
     )))
 }
 
@@ -89,7 +105,9 @@ fn agent_skill_install_hint(current_dir: &std::path::Path) -> Option<AgentSkillN
     let installations = agent_skill_installations(agent, workdir.as_deref())?;
     let version = option_env!("VERSION").unwrap_or("dev");
     if installations.is_empty() {
-        Some(AgentSkillNotice::Hint(agent_skill_not_installed_notice()))
+        Some(AgentSkillNotice::NotInstalled(
+            agent_skill_not_installed_notice(),
+        ))
     } else if installations
         .iter()
         .all(|path| is_current_skill_installation(path, version))

--- a/crates/but/tests/but/command/skill.rs
+++ b/crates/but/tests/but/command/skill.rs
@@ -284,18 +284,21 @@ fn agent_skill_notice_reports_a_stale_local_skill_despite_a_current_global_copy(
 }
 
 #[test]
-fn agent_skill_notice_repairs_a_stale_global_skill() {
+fn agent_skill_notice_repairs_another_agents_stale_global_skill() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
     env.setup_metadata(&[]);
     env.but("skill install")
         .env("AI_AGENT", "codex")
         .assert()
         .success();
-    std::fs::write(
-        env.home_dir().join(".codex/skills/gitbutler/SKILL.md"),
-        "---\nname: but\nversion: old\n---\n",
-    )
-    .unwrap();
+    env.but("skill install")
+        .env("AI_AGENT", "claude-code")
+        .assert()
+        .success();
+
+    let claude_skill_path = env.home_dir().join(".claude/skills/gitbutler/SKILL.md");
+    let expected = std::fs::read_to_string(&claude_skill_path).unwrap();
+    std::fs::write(&claude_skill_path, "---\nname: but\nversion: old\n---\n").unwrap();
 
     let output = env
         .but("alias list")
@@ -307,7 +310,80 @@ fn agent_skill_notice_repairs_a_stale_global_skill() {
     assert!(
         stdout.contains("was out of date and was updated")
             && !stdout.contains("but skill check --update"),
-        "a stale global skill should be repaired before a read-only command, got: {stdout}"
+        "another agent's stale global skill should be repaired before a read-only command, got: {stdout}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&claude_skill_path).unwrap(),
+        expected,
+        "the detected agent should refresh other agents' global GitButler skill installations"
+    );
+}
+
+#[test]
+fn unrelated_update_failure_does_not_hide_missing_skill_hint() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
+    env.but("skill install")
+        .env("AI_AGENT", "claude-code")
+        .assert()
+        .success();
+
+    let claude_skill_dir = env.home_dir().join(".claude/skills/gitbutler");
+    std::fs::write(
+        claude_skill_dir.join("SKILL.md"),
+        "---\nname: but\nversion: old\n---\n",
+    )
+    .unwrap();
+    let concepts_path = claude_skill_dir.join("references/concepts.md");
+    std::fs::remove_file(&concepts_path).unwrap();
+    std::fs::create_dir(&concepts_path).unwrap();
+
+    let output = env
+        .but("alias list")
+        .env("AI_AGENT", "codex")
+        .output()
+        .expect("alias list runs");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        stdout.contains("Install the GitButler skill before continuing")
+            && !stdout.contains("auto-update failed"),
+        "another agent's update failure must not hide the caller's missing skill hint, got: {stdout}"
+    );
+
+    env.but("skill install")
+        .env("AI_AGENT", "codex")
+        .assert()
+        .success();
+    let codex_skill_path = env.home_dir().join(".codex/skills/gitbutler/SKILL.md");
+    let expected = std::fs::read_to_string(&codex_skill_path).unwrap();
+    std::fs::write(&codex_skill_path, "---\nname: but\nversion: old\n---\n").unwrap();
+
+    let output = env
+        .but("alias list")
+        .env("AI_AGENT", "codex")
+        .output()
+        .expect("alias list runs");
+    assert_eq!(
+        std::fs::read_to_string(&codex_skill_path).unwrap(),
+        expected,
+        "a failed Claude update should not prevent a later Codex update"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("auto-update failed"),
+        "an unrelated failure should still be reported after other updates finish, got: {stdout}"
+    );
+
+    let output = env
+        .but("alias list")
+        .env("AI_AGENT", "claude-code")
+        .output()
+        .expect("alias list runs");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("auto-update failed"),
+        "an installed caller's update failure should retain its actionable details, got: {stdout}"
     );
 }
 


### PR DESCRIPTION
Automatically refresh every discovered global GitButler skill installation when an agent invokes the CLI, instead of limiting upkeep to the caller’s format.