### PR TITLE
feat: use GitHub's native stacked PRs where enabled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1247,6 +1247,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "tracing",
  "urlencoding",
 ]
 

--- a/apps/desktop/src/components/forge/ReviewCreation.svelte
+++ b/apps/desktop/src/components/forge/ReviewCreation.svelte
@@ -24,7 +24,7 @@
 	import { type PullRequest } from "$lib/forge/interface/types";
 	import { PrPersistedStore } from "$lib/forge/prContents";
 	import { PR_SERVICE } from "$lib/forge/prService.svelte";
-	import { updatePrDescriptionTables as updatePrStackInfo } from "$lib/forge/shared/prFooter";
+	import { updatePrStackInfo } from "$lib/forge/shared/prFooter";
 	import { showToast } from "$lib/notifications/toasts";
 	import { SETTINGS_SERVICE } from "$lib/settings/appSettings";
 	import { requiresPush } from "$lib/stacks/stack";

--- a/apps/desktop/src/lib/forge/prService.svelte.ts
+++ b/apps/desktop/src/lib/forge/prService.svelte.ts
@@ -12,7 +12,7 @@ import { writable } from "svelte/store";
 import type { BackendApi } from "$lib/state/backendApi";
 import type { QueryOptions } from "$lib/state/butlerModule";
 import type { PostHogWrapper } from "$lib/telemetry/posthog";
-import type { ReviewMergeStatus } from "@gitbutler/but-sdk";
+import type { ForgeReviewUpdate, ReviewMergeStatus } from "@gitbutler/but-sdk";
 import type { StartQueryActionCreatorOptions } from "@reduxjs/toolkit/query";
 
 export const PR_SERVICE = new InjectionToken<PrService>("PrService");
@@ -174,6 +174,15 @@ export class PrService {
 	async setDraft(projectId: string, reviewId: number, draft: boolean) {
 		await this.backendApi.endpoints.setDraft.mutate({ projectId, reviewId, draft });
 	}
+
+	/**
+	 * Sync stack info for the given reviews: description footers and target
+	 * branches, or GitHub's native stacks where the repo has them enabled.
+	 * `reviews` must describe a single stack, ordered bottom-to-top.
+	 */
+	async updateFooters(projectId: string, reviews: ForgeReviewUpdate[]) {
+		await this.backendApi.endpoints.updateReviewFooters.mutate({ projectId, reviews });
+	}
 }
 
 function injectBackendEndpoints(api: BackendApi) {
@@ -245,6 +254,15 @@ function injectBackendEndpoints(api: BackendApi) {
 				extraOptions: { command: "get_review_base_repo_url" },
 				query: (args) => args,
 				providesTags: (_result, _error, args) => providesItem(ReduxTag.PullRequests, args.reviewId),
+			}),
+			updateReviewFooters: build.mutation<
+				void,
+				{ projectId: string; reviews: ForgeReviewUpdate[] }
+			>({
+				extraOptions: { command: "update_review_footers" },
+				query: (args) => args,
+				invalidatesTags: (_res, _err, { reviews }) =>
+					reviews.map((review) => invalidatesItem(ReduxTag.PullRequests, review.number)),
 			}),
 			updateReview: build.mutation<
 				void,

--- a/apps/desktop/src/lib/forge/shared/prFooter.test.ts
+++ b/apps/desktop/src/lib/forge/shared/prFooter.test.ts
@@ -1,37 +1,83 @@
-import { generateFooter } from "$lib/forge/shared/prFooter";
-import { describe, expect, test } from "vitest";
+import { updatePrStackInfo, updateStackPrs } from "$lib/forge/shared/prFooter";
+import { describe, expect, test, vi } from "vitest";
+import type { PrService } from "$lib/forge/prService.svelte";
+import type { Segment } from "@gitbutler/but-sdk";
 
-// The desktop receives stack segments child -> parent, i.e. [top, ..., base]
-// (104 is the tip, 100 the base). The footer must render top-first with the base
-// numbered 1, and "part X of N" must match each PR's position badge.
-describe("generateFooter", () => {
-	const topToBase = [104, 103, 102, 101, 100];
+// The desktop receives stack segments child -> parent, i.e. [top, ..., base],
+// while the backend expects a single stack ordered bottom-to-top. These tests
+// pin that reordering and the target-branch chaining.
 
-	function listLines(footer: string) {
-		return footer.split("\n").filter((l) => l.startsWith("- "));
-	}
+function stubPrService() {
+	const updateFooters = vi.fn(async () => {});
+	const fetch = vi.fn(async (_projectId: string, number: number) => ({
+		number,
+		body: `body of ${number}`,
+	}));
+	return {
+		service: { fetch, updateFooters } as unknown as PrService,
+		updateFooters,
+	};
+}
 
-	test("lists the stack top-first and numbers the base 1", () => {
-		const footer = generateFooter(100, topToBase, "#");
-		const lines = listLines(footer);
+function segment(branchName: string, prNumber?: number): Segment {
+	return {
+		refName: { displayName: branchName },
+		metadata: { review: { pullRequest: prNumber } },
+	} as unknown as Segment;
+}
 
-		expect(lines[0]).toContain("#104");
-		expect(lines.at(-1)).toContain("#100");
-		expect(footer).toContain("<kbd>&nbsp;1&nbsp;</kbd> #100");
-		expect(footer).toContain("<kbd>&nbsp;5&nbsp;</kbd> #104");
+describe("updatePrStackInfo", () => {
+	test("sends the stack bottom-to-top", async () => {
+		const { service, updateFooters } = stubPrService();
+
+		await updatePrStackInfo(service, "project", [104, 103, 102], "#");
+
+		expect(updateFooters).toHaveBeenCalledOnce();
+		const [, updates] = updateFooters.mock.calls[0] as unknown as [string, { number: number }[]];
+		expect(updates.map((u) => u.number)).toEqual([102, 103, 104]);
 	});
 
-	test("'part X of N' matches the current PR's position badge", () => {
-		expect(generateFooter(100, topToBase, "#")).toContain("part 1 of 5 in a stack");
-		expect(generateFooter(104, topToBase, "#")).toContain("part 5 of 5 in a stack");
-		expect(generateFooter(102, topToBase, "#")).toContain("part 3 of 5 in a stack");
+	test("does nothing for a single PR", async () => {
+		const { service, updateFooters } = stubPrService();
+
+		await updatePrStackInfo(service, "project", [104], "#");
+
+		expect(updateFooters).not.toHaveBeenCalled();
+	});
+});
+
+describe("updateStackPrs", () => {
+	test("chains each PR onto the branch below it, bottom-most onto the base", async () => {
+		const { service, updateFooters } = stubPrService();
+		const topFirst = [segment("top", 3), segment("mid", 2), segment("bottom", 1)];
+
+		await updateStackPrs(service, "project", topFirst, "main", "#");
+
+		expect(updateFooters).toHaveBeenCalledOnce();
+		const [, updates] = updateFooters.mock.calls[0] as unknown as [
+			string,
+			{ number: number; targetBranch: string }[],
+		];
+		expect(updates).toEqual([
+			expect.objectContaining({ number: 1, targetBranch: "main" }),
+			expect.objectContaining({ number: 2, targetBranch: "bottom" }),
+			expect.objectContaining({ number: 3, targetBranch: "mid" }),
+		]);
 	});
 
-	test("marks only the current PR with the indicator", () => {
-		const footer = generateFooter(102, topToBase, "#");
-		const lines = listLines(footer);
+	test("branches without a PR still act as the target of the PR above", async () => {
+		const { service, updateFooters } = stubPrService();
+		const topFirst = [segment("top", 3), segment("mid"), segment("bottom", 1)];
 
-		expect(lines.find((l) => l.includes("#102"))).toContain("👈");
-		expect(lines.find((l) => l.includes("#101"))).not.toContain("👈");
+		await updateStackPrs(service, "project", topFirst, "main", "#");
+
+		const [, updates] = updateFooters.mock.calls[0] as unknown as [
+			string,
+			{ number: number; targetBranch: string }[],
+		];
+		expect(updates).toEqual([
+			expect.objectContaining({ number: 1, targetBranch: "main" }),
+			expect.objectContaining({ number: 3, targetBranch: "mid" }),
+		]);
 	});
 });

--- a/apps/desktop/src/lib/forge/shared/prFooter.ts
+++ b/apps/desktop/src/lib/forge/shared/prFooter.ts
@@ -1,6 +1,6 @@
 import { isDefined } from "@gitbutler/ui/utils/typeguards";
 import type { PrService } from "$lib/forge/prService.svelte";
-import type { Segment } from "@gitbutler/but-sdk";
+import type { ForgeReviewUpdate, Segment } from "@gitbutler/but-sdk";
 
 export const STACKING_FOOTER_BOUNDARY_TOP = "<!-- GitButler Footer Boundary Top -->";
 export const STACKING_FOOTER_BOUNDARY_BOTTOM = "<!-- GitButler Footer Boundary Bottom -->";
@@ -13,37 +13,36 @@ export function unixifyNewlines(target: string): string {
 }
 
 /**
- * Updates a pull request description with a table pointing to other pull
- * requests in the same stack.
+ * Sync stack info onto the pull requests of a stack: description footers, or
+ * GitHub's native stacks where the repo has them enabled (decided backend-side).
+ *
+ * `prNumbers` are expected top-first, as the stack segments are ordered.
  */
-export async function updatePrDescriptionTables(
+export async function updatePrStackInfo(
 	prService: PrService,
 	projectId: string,
 	prNumbers: number[],
 	unitSymbol = "#",
 ) {
-	if (prService && prNumbers.length > 1) {
-		const prs = await Promise.all(
-			prNumbers.map(async (id) => await prService.fetch(projectId, id)),
-		);
-		const updates = prs.filter(isDefined).map((pr) => ({
-			prNumber: pr.number,
-			description: updateBody(pr.body, pr.number, prNumbers, unitSymbol),
-		}));
-		await Promise.all(
-			updates.map(async ({ prNumber, description }) => {
-				await prService.update(projectId, prNumber, { description });
-			}),
-		);
-	}
+	if (prNumbers.length <= 1) return;
+	// The backend expects a single stack ordered bottom-to-top.
+	const bottomToTop = [...prNumbers].reverse();
+	const prs = await Promise.all(
+		bottomToTop.map(async (id) => await prService.fetch(projectId, id)),
+	);
+	const updates: ForgeReviewUpdate[] = prs.filter(isDefined).map((pr) => ({
+		number: pr.number,
+		body: pr.body ?? null,
+		unitSymbol,
+		targetBranch: null,
+	}));
+	await prService.updateFooters(projectId, updates);
 }
 
-type PrUpdate = {
-	prNumber: number;
-	targetBase: string;
-	description: string;
-};
-
+/**
+ * Sync stack info and target branches after the stack structure changed
+ * (e.g. branches were reordered). `branchDetails` are expected top-first.
+ */
 export async function updateStackPrs(
 	prService: PrService,
 	projectId: string,
@@ -52,10 +51,10 @@ export async function updateStackPrs(
 	unitSymbol = "#",
 ) {
 	if (branchDetails.length <= 1) return;
-	const allPrNumbers = branchDetails.map((b) => b.metadata?.review.pullRequest).filter(isDefined);
-	const updates: PrUpdate[] = [];
+	const updates: ForgeReviewUpdate[] = [];
 	let prevBranch: string | undefined = undefined;
 
+	// Walk bottom-to-top, chaining each PR onto the branch below it.
 	for (let i = branchDetails.length - 1; i >= 0; i--) {
 		const details = branchDetails[i];
 		if (!details) continue;
@@ -74,19 +73,16 @@ export async function updateStackPrs(
 		}
 
 		updates.push({
-			prNumber,
-			description: updateBody(pr.body, pr.number, allPrNumbers, unitSymbol),
-			targetBase: prevBranch ?? baseBranchName,
+			number: prNumber,
+			body: pr.body ?? null,
+			unitSymbol,
+			targetBranch: prevBranch ?? baseBranchName,
 		});
 		prevBranch = branchName;
 	}
 
 	if (updates.length > 0) {
-		await Promise.all(
-			updates.map(async ({ prNumber, targetBase, description }) => {
-				await prService.update(projectId, prNumber, { description, targetBase });
-			}),
-		);
+		await prService.updateFooters(projectId, updates);
 	}
 }
 
@@ -120,22 +116,6 @@ export async function unstackPRs(
 }
 
 /**
- * Replaces or inserts a new footer into an existing body of text.
- */
-function updateBody(
-	body: string | undefined,
-	prNumber: number,
-	allPrNumbers: number[],
-	symbol: string,
-) {
-	const head = (body?.split(STACKING_FOOTER_BOUNDARY_TOP).at(0) || "").trim();
-	const tail = (body?.split(STACKING_FOOTER_BOUNDARY_BOTTOM).at(1) || "").trim();
-	const footer = generateFooter(prNumber, allPrNumbers, symbol);
-	const description = head + "\n\n" + footer + "\n\n" + tail;
-	return description;
-}
-
-/**
  * Remove the footer from an existing body of text.
  */
 function clearFooter(body: string | undefined) {
@@ -147,23 +127,4 @@ function clearFooter(body: string | undefined) {
 	const tail = (body?.split(STACKING_FOOTER_BOUNDARY_BOTTOM).at(1) || "").trim();
 	const description = head + "\n\n" + tail;
 	return description;
-}
-
-/**
- * Generates a footer for use in pull request descriptions when part of a stack.
- */
-export function generateFooter(forPrNumber: number, allPrNumbers: number[], symbol: string) {
-	const stackLength = allPrNumbers.length;
-	const stackIndex = allPrNumbers.findIndex((number) => number === forPrNumber);
-	const nth = stackLength - stackIndex;
-	let footer = "";
-	footer += STACKING_FOOTER_BOUNDARY_TOP + "\n";
-	footer += "---\n";
-	footer += `This is **part ${nth} of ${stackLength} in a stack** made with GitButler:\n`;
-	allPrNumbers.forEach((prNumber, i) => {
-		const current = i === stackIndex;
-		footer += `- <kbd>&nbsp;${stackLength - i}&nbsp;</kbd> ${symbol}${prNumber} ${current ? "👈 " : ""}\n`;
-	});
-	footer += STACKING_FOOTER_BOUNDARY_BOTTOM;
-	return footer;
 }

--- a/crates/but-api/src/legacy/forge.rs
+++ b/crates/but-api/src/legacy/forge.rs
@@ -23,6 +23,26 @@ pub fn push_remote_url(project_meta: &ProjectMeta, repo: &gix::Repository) -> Re
     project_meta.push_remote_url(repo)
 }
 
+/// Forge repo info for the base remote, plus the push remote's when it
+/// differs (i.e. when pushing to a fork).
+fn base_and_push_repo_info(
+    project_meta: &ProjectMeta,
+    repo: &gix::Repository,
+) -> Result<(but_forge::ForgeRepoInfo, Option<but_forge::ForgeRepoInfo>)> {
+    let base_remote_url = remote_url(project_meta, repo)?;
+    let push_remote_url = push_remote_url(project_meta, repo)?;
+    let forge_repo_info = but_forge::derive_forge_repo_info(&base_remote_url)
+        .context("No forge could be determined for this repository branch")?;
+    let forge_push_repo_info = if base_remote_url != push_remote_url {
+        let info = but_forge::derive_forge_repo_info(&push_remote_url)
+            .context("Failed to derive forge repository information from the push remote URL.")?;
+        Some(info)
+    } else {
+        None
+    };
+    Ok((forge_repo_info, forge_push_repo_info))
+}
+
 fn review_template_content(file: FileInfo) -> Result<String> {
     if file.size.is_none() {
         return Ok(String::new());
@@ -695,18 +715,8 @@ pub async fn publish_review(
         let ctx = ctx.into_thread_local();
         let project_meta = ctx.project_meta()?;
         let repo = ctx.repo.get()?;
-        let base_remote_url = remote_url(&project_meta, &repo)?;
-        let push_remote_url = push_remote_url(&project_meta, &repo)?;
-        let forge_repo_info = but_forge::derive_forge_repo_info(&base_remote_url)
-            .context("No forge could be determined for this repository branch")?;
-        let forge_push_repo_info = if base_remote_url != push_remote_url {
-            let info = but_forge::derive_forge_repo_info(&push_remote_url).context(
-                "Failed to derive forge repository information from the push remote URL.",
-            )?;
-            Some(info)
-        } else {
-            None
-        };
+        let (forge_repo_info, forge_push_repo_info) =
+            base_and_push_repo_info(&project_meta, &repo)?;
 
         (
             but_forge_storage::Controller::from_path(but_path::app_data_dir()?),
@@ -875,22 +885,25 @@ pub async fn update_review_footers(
     ctx: ThreadSafeContext,
     reviews: Vec<but_forge::ForgeReviewUpdate>,
 ) -> Result<()> {
-    let (storage, forge_repo_info, preferred_forge_user) = {
+    let (storage, forge_repo_info, forge_push_repo_info, preferred_forge_user) = {
         let ctx = ctx.into_thread_local();
         let project_meta = ctx.project_meta()?;
         let repo = ctx.repo.get()?;
-        let forge_repo_info = but_forge::derive_forge_repo_info(&remote_url(&project_meta, &repo)?);
+        let (forge_repo_info, forge_push_repo_info) =
+            base_and_push_repo_info(&project_meta, &repo)?;
 
         (
             but_forge_storage::Controller::from_path(but_path::app_data_dir()?),
             forge_repo_info,
+            forge_push_repo_info,
             ctx.legacy_project.preferred_forge_user.clone(),
         )
     };
 
     but_forge::sync_reviews(
         &preferred_forge_user,
-        &forge_repo_info.context("No forge could be determined for this repository branch")?,
+        &forge_repo_info,
+        &forge_push_repo_info,
         &reviews,
         &storage,
     )

--- a/crates/but-forge/Cargo.toml
+++ b/crates/but-forge/Cargo.toml
@@ -37,6 +37,7 @@ urlencoding.workspace = true
 serde.workspace = true
 serde_json = { workspace = true, features = ["arbitrary_precision"] }
 anyhow.workspace = true
+tracing.workspace = true
 schemars = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/but-forge/src/review.rs
+++ b/crates/but-forge/src/review.rs
@@ -1660,10 +1660,20 @@ impl From<ForgeReviewTargetUpdate> for ForgeReviewUpdate {
 
 /// Update reviews: description footers and, optionally, target/base branches.
 ///
+/// The `reviews` slice must describe a single stack, ordered bottom-to-top
+/// (the review closest to the base branch first).
+///
+/// On GitHub repositories with native stacked PRs enabled (a per-repository
+/// preview feature), the stack is registered with GitHub instead of writing
+/// description footers; any footers left over from before the feature was
+/// enabled are removed. `forge_push_repo_info` is used to detect fork-headed
+/// reviews, which native stacks don't support.
+///
 /// Per-review failures are collected rather than aborting the batch.
 pub async fn sync_reviews(
     preferred_forge_user: &Option<crate::ForgeUser>,
     forge_repo_info: &crate::forge::ForgeRepoInfo,
+    forge_push_repo_info: &Option<crate::forge::ForgeRepoInfo>,
     reviews: &[ForgeReviewUpdate],
     storage: &but_forge_storage::Controller,
 ) -> Result<()> {
@@ -1673,25 +1683,48 @@ pub async fn sync_reviews(
 
     let mut errors: Vec<String> = Vec::new();
 
-    // Skip body updates when no review has footer content (e.g. push-only target updates).
-    let has_footer_content = reviews.iter().any(|r| !r.unit_symbol.is_empty());
+    // Push-only target updates carry no footer content and leave bodies alone.
+    let footer_sync = if reviews.iter().any(|r| !r.unit_symbol.is_empty()) {
+        FooterSync::Write
+    } else {
+        FooterSync::KeepBody
+    };
 
     match forge {
         ForgeName::GitHub => {
             let preferred_account = preferred_forge_user.as_ref().and_then(|user| user.github());
             let pr_numbers: Vec<i64> = reviews.iter().map(|r| r.number).collect();
 
+            let (_, head_repo) = github_head_owner_and_repo(forge_repo_info, forge_push_repo_info);
+            let native_stack = if head_repo.is_none() && pr_numbers.len() >= 2 {
+                but_github::stacks::lookup(preferred_account, owner, repo, pr_numbers[0], storage)
+                    .await
+                    .unwrap_or_else(|err| {
+                        tracing::warn!(
+                            ?err,
+                            "Failed to look up GitHub native stacks; keeping footers"
+                        );
+                        but_github::stacks::StackLookup::Unsupported
+                    })
+            } else {
+                but_github::stacks::StackLookup::Unsupported
+            };
+
+            // GitHub renders native stacks itself, so instead of writing
+            // footers, remove any left over from before the repository had
+            // the feature.
+            let footer_sync = match (&native_stack, footer_sync) {
+                (but_github::stacks::StackLookup::Supported(_), FooterSync::Write) => {
+                    FooterSync::Remove
+                }
+                (_, footer_sync) => footer_sync,
+            };
+
             for review in reviews {
-                let updated_body = if has_footer_content {
-                    Some(update_body(
-                        review.body.as_deref(),
-                        review.number,
-                        &pr_numbers,
-                        &review.unit_symbol,
-                    ))
-                } else {
-                    None
-                };
+                let updated_body = footer_body_update(footer_sync, review, &pr_numbers);
+                if updated_body.is_none() && review.target_branch.is_none() {
+                    continue;
+                }
 
                 let params = but_github::UpdatePullRequestParams {
                     owner,
@@ -1707,6 +1740,23 @@ pub async fn sync_reviews(
                     errors.push(format!("PR #{}: {err}", review.number));
                 }
             }
+
+            // Register the stack with GitHub once the target branches are in
+            // place. Best-effort: a failed registration must not fail the
+            // publish or push that triggered this sync.
+            if let but_github::stacks::StackLookup::Supported(existing) = native_stack
+                && let Err(err) = but_github::stacks::ensure(
+                    preferred_account,
+                    owner,
+                    repo,
+                    &pr_numbers,
+                    existing.as_ref(),
+                    storage,
+                )
+                .await
+            {
+                tracing::warn!(?err, "Failed to register the stack with GitHub");
+            }
         }
         ForgeName::GitLab => {
             let project_id = GitLabProjectId::new(owner, repo);
@@ -1714,16 +1764,7 @@ pub async fn sync_reviews(
             let mr_iids: Vec<i64> = reviews.iter().map(|r| r.number).collect();
 
             for review in reviews {
-                let updated_body = if has_footer_content {
-                    Some(update_body(
-                        review.body.as_deref(),
-                        review.number,
-                        &mr_iids,
-                        &review.unit_symbol,
-                    ))
-                } else {
-                    None
-                };
+                let updated_body = footer_body_update(footer_sync, review, &mr_iids);
 
                 let params = but_gitlab::UpdateMergeRequestParams {
                     project_id: project_id.clone(),
@@ -1746,16 +1787,7 @@ pub async fn sync_reviews(
             let pr_ids: Vec<i64> = reviews.iter().map(|r| r.number).collect();
 
             for review in reviews {
-                let updated_body = if has_footer_content {
-                    Some(update_body(
-                        review.body.as_deref(),
-                        review.number,
-                        &pr_ids,
-                        &review.unit_symbol,
-                    ))
-                } else {
-                    None
-                };
+                let updated_body = footer_body_update(footer_sync, review, &pr_ids);
 
                 let params = but_bitbucket::UpdatePullRequestParams {
                     workspace: owner,
@@ -1817,6 +1849,47 @@ pub fn compute_review_target_updates(
         current_target = branch_name;
     }
     updates
+}
+
+/// What a sync should do to review descriptions.
+#[derive(Debug, Clone, Copy)]
+enum FooterSync {
+    /// Leave bodies untouched (e.g. push-only target updates).
+    KeepBody,
+    /// Write or refresh the stack footer.
+    Write,
+    /// The forge renders the stack natively: only remove leftover footers.
+    Remove,
+}
+
+/// The body update for one review of a stack, per the [`FooterSync`] mode.
+/// `None` means the body should not be touched.
+fn footer_body_update(
+    footer_sync: FooterSync,
+    review: &ForgeReviewUpdate,
+    all_numbers: &[i64],
+) -> Option<String> {
+    match footer_sync {
+        FooterSync::KeepBody => None,
+        FooterSync::Write => Some(update_body(
+            review.body.as_deref(),
+            review.number,
+            all_numbers,
+            &review.unit_symbol,
+        )),
+        FooterSync::Remove => review
+            .body
+            .as_deref()
+            .filter(|body| body.contains(STACKING_FOOTER_BOUNDARY_TOP))
+            .map(|body| {
+                update_body(
+                    Some(body),
+                    review.number,
+                    &[review.number],
+                    &review.unit_symbol,
+                )
+            }),
+    }
 }
 
 /// Replaces or inserts a new footer into an existing body of text.

--- a/crates/but-github/src/client.rs
+++ b/crates/but-github/src/client.rs
@@ -33,8 +33,8 @@ fn ensure_success(response: &reqwest::Response) -> Result<()> {
 }
 
 pub struct GitHubClient {
-    client: reqwest::Client,
-    base_url: String,
+    pub(crate) client: reqwest::Client,
+    pub(crate) base_url: String,
 }
 
 impl GitHubClient {

--- a/crates/but-github/src/lib.rs
+++ b/crates/but-github/src/lib.rs
@@ -9,6 +9,7 @@ pub mod checks;
 mod client;
 mod graphql;
 pub mod pr;
+pub mod stacks;
 pub use client::{
     AutoMergeEnableParams, AutoMergeState, CheckRun, CreatePullRequestParams, GitHubClient,
     GitHubPrLabel, GitHubRepoPermissions, GitHubRepository, GitHubUser, MergeMethod,

--- a/crates/but-github/src/stacks.rs
+++ b/crates/but-github/src/stacks.rs
@@ -1,0 +1,224 @@
+//! GitHub's native stacked-pull-requests API.
+//!
+//! This is a preview feature enabled per repository; every endpoint returns
+//! 404 on repositories that don't have it, which doubles as the detection
+//! mechanism. GitHub models a stack exactly like GitButler does — each PR
+//! targets the branch of the PR below it — so PRs published by GitButler can
+//! be registered as-is.
+
+use std::collections::HashSet;
+use std::sync::{LazyLock, Mutex};
+
+use anyhow::{Context as _, Result, bail};
+use serde::Deserialize;
+
+use crate::client::GitHubClient;
+
+/// A stack of pull requests, ordered bottom (closest to the base branch) to top.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Stack {
+    /// The repository-scoped number used to address the stack.
+    pub number: i64,
+    /// Member pull requests, bottom to top. Merged PRs remain members.
+    pub pull_requests: Vec<StackPullRequest>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct StackPullRequest {
+    pub number: i64,
+}
+
+/// Outcome of asking GitHub for the stack containing a given PR.
+#[derive(Debug, Clone)]
+pub enum StackLookup {
+    /// The repository does not have native stacks enabled.
+    Unsupported,
+    /// Native stacks are enabled; the PR may or may not be in a stack yet.
+    Supported(Option<Stack>),
+}
+
+/// Repositories known to not support native stacks, so repeated syncs don't
+/// re-probe. Only negative results are cached: supported repositories need a
+/// fresh lookup for the stack state anyway, and a repository gaining the
+/// feature mid-process is picked up on the next probe.
+static UNSUPPORTED_CACHE: LazyLock<Mutex<HashSet<String>>> =
+    LazyLock::new(|| Mutex::new(HashSet::new()));
+
+/// Find the stack containing `pr_number`, detecting on the way whether the
+/// repository supports native stacks at all.
+pub async fn lookup(
+    preferred_account: Option<&crate::GithubAccountIdentifier>,
+    owner: &str,
+    repo: &str,
+    pr_number: i64,
+    storage: &but_forge_storage::Controller,
+) -> Result<StackLookup> {
+    let gh = GitHubClient::from_storage(storage, preferred_account)?;
+    // Keyed by host too: the same owner/repo can exist on github.com and an
+    // Enterprise host with different enablement.
+    let cache_key = format!("{}/{owner}/{repo}", gh.base_url);
+    if UNSUPPORTED_CACHE.lock().unwrap().contains(&cache_key) {
+        return Ok(StackLookup::Unsupported);
+    }
+    match gh
+        .stacks_for_pull_request(owner, repo, pr_number)
+        .await
+        .context("Failed to look up GitHub stacks")?
+    {
+        None => {
+            UNSUPPORTED_CACHE.lock().unwrap().insert(cache_key);
+            Ok(StackLookup::Unsupported)
+        }
+        Some(stacks) => Ok(StackLookup::Supported(stacks.into_iter().next())),
+    }
+}
+
+/// Make sure `pull_requests` (ordered bottom to top) are registered as a
+/// stack: create one, or append the members `existing` doesn't have yet.
+/// Each PR must target the head branch of the one before it (the bottom-most
+/// targets the base branch) — GitHub validates the chain.
+pub async fn ensure(
+    preferred_account: Option<&crate::GithubAccountIdentifier>,
+    owner: &str,
+    repo: &str,
+    pull_requests: &[i64],
+    existing: Option<&Stack>,
+    storage: &but_forge_storage::Controller,
+) -> Result<()> {
+    let gh = GitHubClient::from_storage(storage, preferred_account)?;
+    match existing {
+        Some(stack) => {
+            let missing = members_to_add(stack, pull_requests)?;
+            if missing.is_empty() {
+                Ok(())
+            } else {
+                gh.add_to_stack(owner, repo, stack.number, &missing)
+                    .await
+                    .context("Failed to add pull requests to GitHub stack")
+            }
+        }
+        None => gh
+            .create_stack(owner, repo, pull_requests)
+            .await
+            .context("Failed to create GitHub stack"),
+    }
+}
+
+/// The desired PRs that aren't members of the stack yet, in the given order.
+///
+/// The add endpoint can only append above the current top, so this errors when
+/// the missing PRs aren't exactly the tail of `desired` (e.g. a PR was
+/// inserted mid-stack) instead of sending a request GitHub would reject.
+fn members_to_add(stack: &Stack, desired: &[i64]) -> Result<Vec<i64>> {
+    let members: HashSet<i64> = stack.pull_requests.iter().map(|pr| pr.number).collect();
+    let missing: Vec<i64> = desired
+        .iter()
+        .copied()
+        .filter(|number| !members.contains(number))
+        .collect();
+    if desired[desired.len() - missing.len()..] != missing[..] {
+        bail!("the stack's members changed below its top; only appending is supported");
+    }
+    Ok(missing)
+}
+
+#[derive(serde::Serialize)]
+struct StackMembersBody<'a> {
+    pull_requests: &'a [i64],
+}
+
+impl GitHubClient {
+    /// List the stacks containing a PR. `Ok(None)` means the repository does
+    /// not have native stacks enabled (the endpoint 404s).
+    async fn stacks_for_pull_request(
+        &self,
+        owner: &str,
+        repo: &str,
+        pr_number: i64,
+    ) -> Result<Option<Vec<Stack>>> {
+        let url = format!("{}/repos/{}/{}/stacks", self.base_url, owner, repo);
+        let response = self
+            .client
+            .get(&url)
+            .query(&[("pull_request", pr_number)])
+            .send()
+            .await?;
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        if !response.status().is_success() {
+            bail!("Failed to list stacks: {}", response.status());
+        }
+        Ok(Some(response.json().await?))
+    }
+
+    async fn create_stack(&self, owner: &str, repo: &str, pull_requests: &[i64]) -> Result<()> {
+        let url = format!("{}/repos/{}/{}/stacks", self.base_url, owner, repo);
+        let response = self
+            .client
+            .post(&url)
+            .json(&StackMembersBody { pull_requests })
+            .send()
+            .await?;
+        if !response.status().is_success() {
+            bail!("Failed to create stack: {}", response.status());
+        }
+        Ok(())
+    }
+
+    async fn add_to_stack(
+        &self,
+        owner: &str,
+        repo: &str,
+        stack_number: i64,
+        pull_requests: &[i64],
+    ) -> Result<()> {
+        let url = format!(
+            "{}/repos/{}/{}/stacks/{}/add",
+            self.base_url, owner, repo, stack_number
+        );
+        let response = self
+            .client
+            .post(&url)
+            .json(&StackMembersBody { pull_requests })
+            .send()
+            .await?;
+        if !response.status().is_success() {
+            bail!("Failed to add to stack: {}", response.status());
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn members_to_add_skips_existing_members_and_keeps_order() {
+        let stack = Stack {
+            number: 7,
+            pull_requests: vec![
+                StackPullRequest { number: 1 },
+                StackPullRequest { number: 2 },
+            ],
+        };
+        assert_eq!(members_to_add(&stack, &[1, 2, 3, 4]).unwrap(), vec![3, 4]);
+        assert!(members_to_add(&stack, &[1, 2]).unwrap().is_empty());
+    }
+
+    #[test]
+    fn members_to_add_rejects_mid_stack_insertions() {
+        let stack = Stack {
+            number: 7,
+            pull_requests: vec![
+                StackPullRequest { number: 1 },
+                StackPullRequest { number: 3 },
+            ],
+        };
+        assert!(
+            members_to_add(&stack, &[1, 2, 3]).is_err(),
+            "PR 2 sits below the stack top and can't be appended"
+        );
+    }
+}

--- a/crates/but/src/command/legacy/push.rs
+++ b/crates/but/src/command/legacy/push.rs
@@ -1122,7 +1122,10 @@ async fn update_review_targets_for_stacks(ctx: &Context, perm: &RepoShared) -> a
     let base_branch = gitbutler_branch_actions::base::get_base_branch_data(ctx, perm)?;
     let stacks = crate::legacy::workspace::applied_stacks(ctx)?;
 
-    let mut target_updates = Vec::new();
+    // One sync per stack: `sync_reviews` treats each batch as a single
+    // stack ordered bottom-to-top. A failing stack must not keep the
+    // remaining stacks from being reconciled.
+    let mut errors: Vec<anyhow::Error> = Vec::new();
     for stack in &stacks {
         // heads are ordered top-first, so iterate in reverse for bottom-to-top
         let heads: Vec<(String, Option<i64>)> = stack
@@ -1131,19 +1134,32 @@ async fn update_review_targets_for_stacks(ctx: &Context, perm: &RepoShared) -> a
             .rev()
             .map(|branch| (branch.name.clone(), branch.review_id.map(|id| id as i64)))
             .collect();
-        target_updates.extend(but_forge::compute_review_target_updates(
-            &heads,
-            &base_branch.short_name,
-        ));
-    }
+        let target_updates =
+            but_forge::compute_review_target_updates(&heads, &base_branch.short_name);
+        if target_updates.is_empty() {
+            continue;
+        }
 
-    if target_updates.is_empty() {
-        return Ok(());
+        let reviews: Vec<but_forge::ForgeReviewUpdate> =
+            target_updates.into_iter().map(Into::into).collect();
+        if let Err(err) =
+            but_api::legacy::forge::update_review_footers(ctx.to_sync(), reviews).await
+        {
+            errors.push(err);
+        }
     }
-
-    let reviews: Vec<but_forge::ForgeReviewUpdate> =
-        target_updates.into_iter().map(Into::into).collect();
-    but_api::legacy::forge::update_review_footers(ctx.to_sync(), reviews).await
+    match errors.len() {
+        0 => Ok(()),
+        1 => Err(errors.remove(0)),
+        _ => Err(anyhow::anyhow!(
+            "Some stacks failed to sync:\n{}",
+            errors
+                .iter()
+                .map(|err| err.to_string())
+                .collect::<Vec<_>>()
+                .join("\n")
+        )),
+    }
 }
 
 /// Check if a branch contains any conflicted commits


### PR DESCRIPTION
GitHub is rolling out [native stacked pull requests](https://github.github.com/gh-stack/) as a per-repository preview. Its model matches ours exactly — each PR targets the branch of the PR below it — so the PRs GitButler publishes can be registered as a stack as-is.

## What changed

- New `but_github::stacks` module wrapping the stacks REST endpoints: `lookup` (find the stack containing a PR) and `ensure` (create a stack, or append missing members on top).
- Detection is a side effect of the lookup: the endpoints 404 on repositories without the preview, and negative results are cached in-process so repeated syncs don't re-probe.
- `sync_reviews` is the single decision point. On a GitHub repo with the feature enabled it registers the stack natively and removes description footers (GitHub renders the stack itself, including any footers left from before the repo was enabled). Everywhere else — GitLab, Bitbucket, forks (cross-fork stacks are unsupported), non-enabled repos — behavior is unchanged.
- Stack registration is best-effort: a failed create/add logs a warning and never fails the publish or push that triggered it.

## Decisions

- Each `sync_reviews` batch is now explicitly one stack ordered bottom-to-top; the post-push target reconciliation syncs per stack accordingly.
- The desktop's TS footer writers were deleted rather than taught about the new API: `prFooter.ts` now routes through the existing `update_review_footers` command, continuing the migration of forge logic to the Rust side. Command signatures are unchanged, so no SDK regeneration.
- The shared footer decision was folded into one `FooterSync` mode + helper, which also deduplicates the previously triplicated body-update block across the three forge arms.

Not included (deferred): unstacking on tear-off/reorder (the API can only dissolve a stack, not remove a single PR), surfacing native-stack state in the UI, and a "merge whole stack" action.