### PR TITLE
Add database table and initial worktree APIs

### DIFF
--- a/crates/but-ctx/src/lib.rs
+++ b/crates/but-ctx/src/lib.rs
@@ -28,6 +28,8 @@ pub use legacy::types::{LegacyProject, LegacyProjectId};
 /// Utilities to control access to the project directory of the context.
 pub mod access;
 
+pub mod worktrees;
+
 /// Conversions from project identifier values into context types.
 mod project_handle;
 /// Project identifier types live in a temporary transition crate while legacy

--- a/crates/but-ctx/src/worktrees.rs
+++ b/crates/but-ctx/src/worktrees.rs
@@ -1,0 +1,214 @@
+//! Enumeration of linked worktrees and their archived state.
+
+use std::{collections::BTreeSet, path::PathBuf};
+
+use anyhow::Result;
+use gix::bstr::BString;
+
+use crate::Context;
+
+/// A usable linked worktree with its archived state and resolved `HEAD`.
+#[derive(Debug, Clone)]
+pub struct WorktreeEntry {
+    /// Whether the worktree is hidden from listings and graph traversal.
+    pub archived: bool,
+    /// The worktree checkout directory.
+    pub path: PathBuf,
+    /// The stable worktree name, i.e. the directory name under `$GIT_COMMON_DIR/worktrees/`,
+    /// which survives `git worktree move`.
+    pub name: BString,
+    /// The branch the worktree has checked out, or `None` for a detached `HEAD`.
+    pub ref_name: Option<gix::refs::FullName>,
+    /// The commit the worktree `HEAD` peels to.
+    pub head: gix::ObjectId,
+}
+
+impl Context {
+    /// List all usable linked worktrees with their archived state and resolved `HEAD`s.
+    ///
+    /// This is the single home of linked-worktree state: every reader - listings, and
+    /// graph building when it seeds extra traversal heads - must go through here or
+    /// [`Self::active_worktrees()`] so archived worktrees are excluded consistently.
+    ///
+    /// With the `worktreeManipulation` feature flag disabled this returns nothing and
+    /// has no side effects.
+    ///
+    /// The first-ever read with the flag enabled *adopts*: every worktree already on
+    /// disk (whether usable or not) is archived, assuming it predates GitButler's
+    /// worktree support, and an explicit marker records that adoption ran even when no
+    /// worktree exists yet. A worktree created after adoption is active until
+    /// explicitly archived; rows are never pruned - stale rows are invisible as
+    /// listings intersect with the worktrees on disk - so a worktree recreated under
+    /// a previously archived name stays archived until explicitly unarchived.
+    ///
+    /// Worktrees that are broken (pruned checkout, unresolvable `HEAD`) and worktrees
+    /// checked out on the workspace ref are never returned.
+    ///
+    /// Errors when the context repository is itself a linked worktree: such a context
+    /// stores its database in the worktree's private git dir, so adoption and archived
+    /// state would silently diverge from the main worktree's database.
+    ///
+    /// Must not be called while a database handle is borrowed.
+    pub fn worktrees_with_state(&self) -> Result<Vec<WorktreeEntry>> {
+        if !self.settings.feature_flags.worktree_manipulation {
+            return Ok(Vec::new());
+        }
+        let repo = self.repo.get()?;
+        // The `commondir` redirect only exists in linked-worktree git dirs; unlike
+        // `Kind::LinkedWorkTree`, which is a path heuristic requiring a literal
+        // `.git` component, this also catches worktrees of bare repositories.
+        if repo.git_dir() != repo.common_dir() {
+            anyhow::bail!(
+                "worktree state must be read from the main worktree - \
+                 a linked-worktree context has its own database, letting adoption \
+                 and archived state diverge"
+            );
+        }
+        let (all_names, mut worktrees) = enumerate_worktrees(&repo)?;
+
+        let mut db = self.db.get_cache_mut()?;
+        let archived = adopt_and_read_archived(&mut db, &all_names)?;
+
+        for wt in &mut worktrees {
+            wt.archived = archived.contains(&wt.name);
+        }
+        Ok(worktrees)
+    }
+
+    /// List all non-archived linked worktrees with their resolved `HEAD`s; every
+    /// returned entry has `archived == false`.
+    ///
+    /// This is [`Self::worktrees_with_state()`] filtered down to active worktrees,
+    /// including its adoption side-effect, flag gating, and linked-worktree error;
+    /// the same caveats apply.
+    pub fn active_worktrees(&self) -> Result<Vec<WorktreeEntry>> {
+        Ok(self
+            .worktrees_with_state()?
+            .into_iter()
+            .filter(|wt| !wt.archived)
+            .collect())
+    }
+}
+
+/// Enumerate the linked worktrees of `repo`, returning the names of ALL of them
+/// (for adoption - a worktree that is unusable today must still be adopted today,
+/// not when it becomes usable) along with the usable entries. The `archived` state
+/// is not yet known and left `false`.
+///
+/// `repo` must be the main worktree, so none of the linked worktrees enumerated
+/// here can be the repository's own.
+fn enumerate_worktrees(repo: &gix::Repository) -> Result<(Vec<BString>, Vec<WorktreeEntry>)> {
+    let mut all_names = Vec::new();
+    let mut out = Vec::new();
+    for proxy in repo.worktrees()? {
+        let name: BString = proxy.id().to_owned();
+        all_names.push(name.clone());
+        let path = match proxy.base() {
+            Ok(path) => path,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                // Missing administrative data - the worktree is prunable.
+                continue;
+            }
+            Err(err) => {
+                tracing::warn!(%name, ?err, "Skipping linked worktree whose checkout location cannot be read");
+                continue;
+            }
+        };
+        match std::fs::metadata(&path) {
+            Ok(meta) if meta.is_dir() => {}
+            Ok(_) => {
+                // The `gitdir` file points at something that is not a directory - prunable.
+                continue;
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                // The checkout was deleted without `git worktree remove` - prunable.
+                continue;
+            }
+            Err(err) => {
+                tracing::warn!(%name, ?err, "Skipping linked worktree whose checkout cannot be inspected");
+                continue;
+            }
+        }
+        let wt_repo = match proxy.into_repo_with_possibly_inaccessible_worktree() {
+            Ok(wt_repo) => wt_repo,
+            Err(err) => {
+                // Unlike the prunable states above, this is never expected.
+                tracing::warn!(%name, ?err, "Skipping linked worktree whose repository cannot be opened");
+                continue;
+            }
+        };
+        let mut head = match wt_repo.head() {
+            Ok(head) => head,
+            Err(err) => {
+                tracing::warn!(%name, ?err, "Skipping linked worktree with an unreadable HEAD");
+                continue;
+            }
+        };
+        let ref_name = head.referent_name().map(ToOwned::to_owned);
+        if ref_name
+            .as_ref()
+            .is_some_and(|name| but_core::is_workspace_ref_name(name.as_ref()))
+        {
+            // The workspace ref is fully managed by GitButler already.
+            continue;
+        }
+        let commit = match head.peel_to_commit() {
+            Ok(commit) => commit,
+            Err(gix::head::peel::to_commit::Error::PeelToObject(
+                gix::head::peel::to_object::Error::Unborn { .. },
+            )) => {
+                // A worktree on an unborn branch has nothing to list yet.
+                continue;
+            }
+            Err(err) => {
+                tracing::warn!(%name, ?err, "Skipping linked worktree whose HEAD cannot be peeled to a commit");
+                continue;
+            }
+        };
+        out.push(WorktreeEntry {
+            archived: false,
+            path,
+            name,
+            ref_name,
+            head: commit.id,
+        });
+    }
+    Ok((all_names, out))
+}
+
+/// Return the names of all archived worktrees, first running the one-time adoption
+/// if it never ran: all `names` currently on disk are archived and the adoption
+/// marker is written, in one transaction.
+///
+/// The marker is explicit so nothing is inferred from the table content: in
+/// particular a project's first worktree, created after adoption already ran with
+/// zero worktrees on disk, starts out active.
+fn adopt_and_read_archived(
+    db: &mut but_db::DbHandle,
+    names: &[BString],
+) -> Result<BTreeSet<BString>> {
+    if !db.worktree_meta().adoption_ran()? {
+        // An immediate transaction avoids the un-retried `SQLITE_BUSY_SNAPSHOT` a
+        // deferred read-then-write would fail with when racing another writer, and
+        // the marker is re-checked under the write lock as several processes may
+        // adopt concurrently right after the feature flag is enabled.
+        let mut trans = db.immediate_transaction()?;
+        if !trans.worktree_meta().adoption_ran()? {
+            trans.worktree_meta_mut().mark_adopted()?;
+            for name in names {
+                trans.worktree_meta_mut().upsert(but_db::WorktreeMeta {
+                    name: name.to_vec(),
+                    archived: true,
+                })?;
+            }
+        }
+        trans.commit()?;
+    }
+    Ok(db
+        .worktree_meta()
+        .list()?
+        .into_iter()
+        .filter(|row| row.archived)
+        .map(|row| BString::from(row.name))
+        .collect())
+}

--- a/crates/but-ctx/tests/ctx/main.rs
+++ b/crates/but-ctx/tests/ctx/main.rs
@@ -738,3 +738,331 @@ impl From<ProjectMeta> for ProjectMetaView {
         }
     }
 }
+
+#[test]
+fn worktree_adoption_archives_preexisting_worktrees() -> anyhow::Result<()> {
+    let root = TempDir::new()?;
+    gix::init(root.path().join("main"))?;
+    let repo = open_repo(&root.path().join("main"))?;
+    but_testsupport::invoke_bash(
+        "git commit --allow-empty -m M
+         git worktree add -b feat-a ../wt-a
+         git worktree add -b feat-b ../wt-b",
+        &repo,
+    );
+    let mut ctx = Context::from_repo_for_testing(repo)?;
+    ctx.settings.feature_flags.worktree_manipulation = true;
+
+    assert_eq!(
+        active_names(&ctx)?,
+        Vec::<String>::new(),
+        "the first-ever read adopts, archiving all pre-existing worktrees"
+    );
+
+    but_testsupport::invoke_bash(
+        "git worktree add -b feat-c ../wt-c
+         git -C ../wt-c commit --allow-empty -m C1",
+        &*ctx.repo.get()?,
+    );
+    let active = ctx.active_worktrees()?;
+    assert_eq!(
+        active
+            .iter()
+            .map(|wt| wt.name.to_string())
+            .collect::<Vec<_>>(),
+        ["wt-c"],
+        "worktrees created after adoption are active by default"
+    );
+    assert_eq!(
+        active[0]
+            .ref_name
+            .as_ref()
+            .map(|name| name.as_bstr().to_string()),
+        Some("refs/heads/feat-c".into()),
+        "the checked-out branch is recorded for ref-first graph seeding"
+    );
+    assert_eq!(
+        active[0].head,
+        ctx.repo.get()?.rev_parse_single("feat-c")?.detach(),
+        "the head is the worktree's own HEAD, which has advanced past the main one"
+    );
+    assert_eq!(
+        active[0].path.canonicalize()?,
+        root.path().join("wt-c").canonicalize()?,
+        "the checkout path is reported, not the admin dir under .git/worktrees/"
+    );
+    assert_eq!(
+        ctx.worktrees_with_state()?
+            .iter()
+            .map(|wt| (wt.name.to_string(), wt.archived))
+            .collect::<Vec<_>>(),
+        [
+            ("wt-a".to_string(), true),
+            ("wt-b".to_string(), true),
+            ("wt-c".to_string(), false)
+        ],
+        "archived entries are returned with their flag set, not filtered out"
+    );
+
+    {
+        let mut db = ctx.db.get_cache_mut()?;
+        db.worktree_meta_mut().upsert(but_db::WorktreeMeta {
+            name: b"wt-a".to_vec(),
+            archived: false,
+        })?;
+    }
+    assert_eq!(
+        active_names(&ctx)?,
+        ["wt-a", "wt-c"],
+        "unarchiving makes a pre-existing worktree visible again"
+    );
+    Ok(())
+}
+
+fn active_names(ctx: &Context) -> anyhow::Result<Vec<String>> {
+    Ok(ctx
+        .active_worktrees()?
+        .into_iter()
+        .map(|wt| wt.name.to_string())
+        .collect())
+}
+
+#[test]
+fn worktree_manipulation_flag_gates_worktree_state() -> anyhow::Result<()> {
+    let root = TempDir::new()?;
+    gix::init(root.path().join("main"))?;
+    let repo = open_repo(&root.path().join("main"))?;
+    but_testsupport::invoke_bash(
+        "git commit --allow-empty -m M
+         git worktree add -b feat-a ../wt-a",
+        &repo,
+    );
+
+    // Flag off: nothing is returned and no adoption side-effects happen.
+    let ctx = Context::from_repo_for_testing(repo.clone())?;
+    assert_eq!(active_names(&ctx)?, Vec::<String>::new());
+    {
+        let db = ctx.db.get_cache_mut()?;
+        assert!(
+            !db.worktree_meta().adoption_ran()?,
+            "flag off must not adopt"
+        );
+        assert_eq!(
+            db.worktree_meta().list()?.len(),
+            0,
+            "flag off must not touch the worktree_meta table"
+        );
+    }
+
+    // Flag on: the first read adopts (archives) the pre-existing worktree.
+    let mut ctx = Context::from_repo_for_testing(repo)?;
+    ctx.settings.feature_flags.worktree_manipulation = true;
+    assert_eq!(
+        active_names(&ctx)?,
+        Vec::<String>::new(),
+        "pre-existing worktrees are archived at adoption"
+    );
+    let db = ctx.db.get_cache_mut()?;
+    assert!(db.worktree_meta().adoption_ran()?);
+    assert_eq!(
+        db.worktree_meta().list()?.len(),
+        1,
+        "adoption records the pre-existing worktree as archived"
+    );
+    Ok(())
+}
+
+#[test]
+fn worktree_adoption_with_zero_worktrees_is_persisted() -> anyhow::Result<()> {
+    let root = TempDir::new()?;
+    gix::init(root.path().join("main"))?;
+    let repo = open_repo(&root.path().join("main"))?;
+    but_testsupport::invoke_bash("git commit --allow-empty -m M", &repo);
+    let mut ctx = Context::from_repo_for_testing(repo)?;
+    ctx.settings.feature_flags.worktree_manipulation = true;
+
+    assert_eq!(active_names(&ctx)?, Vec::<String>::new());
+
+    // The explicit marker keeps the adoption alive even though it archived
+    // nothing, so a project's first worktree is active instead of being swept
+    // into a re-run of adoption.
+    but_testsupport::invoke_bash(
+        "git worktree add -b feat ../wt-new
+         git worktree add --detach ../wt-detached",
+        &*ctx.repo.get()?,
+    );
+    let active = ctx.active_worktrees()?;
+    assert_eq!(
+        active
+            .iter()
+            .map(|wt| (wt.name.to_string(), wt.ref_name.is_some()))
+            .collect::<Vec<_>>(),
+        [("wt-detached".into(), false), ("wt-new".into(), true)],
+        "a detached worktree is listed like any other, just without a ref name"
+    );
+    Ok(())
+}
+
+#[test]
+fn pruned_worktrees_are_adopted_but_not_returned() -> anyhow::Result<()> {
+    let root = TempDir::new()?;
+    gix::init(root.path().join("main"))?;
+    let repo = open_repo(&root.path().join("main"))?;
+    but_testsupport::invoke_bash(
+        "git commit --allow-empty -m M
+         git worktree add -b feat ../wt-gone",
+        &repo,
+    );
+    std::fs::remove_dir_all(root.path().join("wt-gone"))?;
+
+    let mut ctx = Context::from_repo_for_testing(repo)?;
+    ctx.settings.feature_flags.worktree_manipulation = true;
+    assert_eq!(
+        active_names(&ctx)?,
+        Vec::<String>::new(),
+        "a deleted checkout directory makes the worktree prunable, not active"
+    );
+    {
+        let mut db = ctx.db.get_cache_mut()?;
+        assert_eq!(
+            db.worktree_meta().get(b"wt-gone")?.map(|row| row.archived),
+            Some(true),
+            "the unusable worktree was still archived at adoption"
+        );
+        db.worktree_meta_mut().upsert(but_db::WorktreeMeta {
+            name: b"wt-gone".to_vec(),
+            archived: false,
+        })?;
+    }
+    assert_eq!(
+        active_names(&ctx)?,
+        Vec::<String>::new(),
+        "even unarchived, a pruned checkout is excluded - it is unusable, not merely hidden"
+    );
+    Ok(())
+}
+
+#[test]
+fn unborn_head_worktrees_are_adopted_but_not_returned() -> anyhow::Result<()> {
+    let root = TempDir::new()?;
+    gix::init(root.path().join("main"))?;
+    let repo = open_repo(&root.path().join("main"))?;
+    but_testsupport::invoke_bash(
+        "git commit --allow-empty -m M
+         git worktree add -b feat ../wt-unborn
+         git -C ../wt-unborn symbolic-ref HEAD refs/heads/never-born",
+        &repo,
+    );
+
+    let mut ctx = Context::from_repo_for_testing(repo)?;
+    ctx.settings.feature_flags.worktree_manipulation = true;
+    assert_eq!(
+        active_names(&ctx)?,
+        Vec::<String>::new(),
+        "an unborn HEAD has no commit to list - the worktree is skipped, not an error"
+    );
+    {
+        let mut db = ctx.db.get_cache_mut()?;
+        assert_eq!(
+            db.worktree_meta()
+                .get(b"wt-unborn")?
+                .map(|row| row.archived),
+            Some(true),
+            "the unborn worktree was still archived at adoption"
+        );
+        db.worktree_meta_mut().upsert(but_db::WorktreeMeta {
+            name: b"wt-unborn".to_vec(),
+            archived: false,
+        })?;
+    }
+    assert_eq!(
+        active_names(&ctx)?,
+        Vec::<String>::new(),
+        "even unarchived, an unborn-HEAD worktree is not listed until its branch is born"
+    );
+    Ok(())
+}
+
+#[test]
+fn workspace_ref_worktrees_are_adopted_but_never_returned() -> anyhow::Result<()> {
+    let root = TempDir::new()?;
+    gix::init(root.path().join("main"))?;
+    let repo = open_repo(&root.path().join("main"))?;
+    but_testsupport::invoke_bash(
+        "git commit --allow-empty -m M
+         git branch gitbutler/workspace
+         git worktree add ../wt-ws gitbutler/workspace",
+        &repo,
+    );
+
+    let mut ctx = Context::from_repo_for_testing(repo)?;
+    ctx.settings.feature_flags.worktree_manipulation = true;
+    assert_eq!(active_names(&ctx)?, Vec::<String>::new());
+    {
+        let mut db = ctx.db.get_cache_mut()?;
+        assert_eq!(
+            db.worktree_meta().get(b"wt-ws")?.map(|row| row.archived),
+            Some(true),
+            "a workspace-ref worktree is still adopted like any other"
+        );
+        db.worktree_meta_mut().upsert(but_db::WorktreeMeta {
+            name: b"wt-ws".to_vec(),
+            archived: false,
+        })?;
+    }
+    assert_eq!(
+        active_names(&ctx)?,
+        Vec::<String>::new(),
+        "even unarchived, a worktree on the workspace ref is never listed - \
+         GitButler manages that ref itself"
+    );
+    Ok(())
+}
+
+#[test]
+fn worktree_state_is_unreachable_from_linked_worktree_contexts() -> anyhow::Result<()> {
+    let root = TempDir::new()?;
+    gix::init(root.path().join("main"))?;
+    let repo = open_repo(&root.path().join("main"))?;
+    but_testsupport::invoke_bash(
+        "git commit --allow-empty -m M
+         git worktree add -b feat-a ../wt-a",
+        &repo,
+    );
+
+    // A context opened inside a linked worktree stores its database in the
+    // worktree's private git dir - adoption and archived state written there
+    // would silently diverge from the main worktree's database.
+    let mut ctx = Context::from_repo_for_testing(open_repo(&root.path().join("wt-a"))?)?;
+    assert_eq!(
+        active_names(&ctx)?,
+        Vec::<String>::new(),
+        "with the flag off even a linked-worktree context returns nothing, without erroring"
+    );
+    ctx.settings.feature_flags.worktree_manipulation = true;
+    assert!(
+        ctx.worktrees_with_state()
+            .unwrap_err()
+            .to_string()
+            .contains("main worktree"),
+        "linked-worktree contexts must be refused, not given their own state"
+    );
+
+    // The same holds for worktrees of a bare repository, whose git dirs contain
+    // no `.git` path component for kind heuristics to latch onto.
+    but_testsupport::invoke_bash_at_dir(
+        "git clone --bare main bare.git
+         git -C bare.git worktree add -b feat-bare ../wt-bare",
+        root.path(),
+    );
+    let mut ctx = Context::from_repo_for_testing(open_repo(&root.path().join("wt-bare"))?)?;
+    ctx.settings.feature_flags.worktree_manipulation = true;
+    assert!(
+        ctx.worktrees_with_state()
+            .unwrap_err()
+            .to_string()
+            .contains("main worktree"),
+        "a worktree of a bare repository is still a linked-worktree context"
+    );
+    Ok(())
+}

--- a/crates/but-db/src/lib.rs
+++ b/crates/but-db/src/lib.rs
@@ -80,6 +80,7 @@ pub use table::{
     forge_reviews::ForgeReview,
     ci_checks::CiCheck,
     virtual_branches::{VbBranchTarget, VbStack, VbStackHead, VbState, VirtualBranchesSnapshot, VirtualBranchesHandle, VirtualBranchesHandleMut},
+    worktree_meta::{WorktreeMeta, WorktreeMetaHandle, WorktreeMetaHandleMut},
 };
 
 /// The *retryable* error type used by [`backoff()`] for SQLite operations.
@@ -138,6 +139,7 @@ pub const MIGRATIONS: &[&[M<'static>]] = &[
     table::forge_reviews::M,
     table::ci_checks::M,
     table::virtual_branches::M,
+    table::worktree_meta::M,
 ];
 
 /// A migration and all the necessary data associated with it to perform it once.

--- a/crates/but-db/src/table/mod.rs
+++ b/crates/but-db/src/table/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod forge_reviews;
 pub(crate) mod gerrit_metadata;
 pub(crate) mod hunk_assignments;
 pub(crate) mod virtual_branches;
+pub(crate) mod worktree_meta;
 
 /// Move migrations that relate to tables that don't have their module anymore here.
 pub(crate) const M_FULLY_REMOVED: &[M<'static>] = &[

--- a/crates/but-db/src/table/worktree_meta.rs
+++ b/crates/but-db/src/table/worktree_meta.rs
@@ -1,0 +1,136 @@
+#![allow(missing_docs)]
+
+use rusqlite::OptionalExtension;
+use serde::{Deserialize, Serialize};
+
+use crate::{DbHandle, M, SchemaVersion, Transaction};
+
+pub(crate) const M: &[M<'static>] = &[
+    M::up(
+        20260715161258,
+        SchemaVersion::Zero,
+        "CREATE TABLE `worktree_meta`(
+	`name` BLOB NOT NULL PRIMARY KEY,
+	`archived` BOOL NOT NULL DEFAULT FALSE
+);",
+    ),
+    M::up(
+        20260716175500,
+        SchemaVersion::Zero,
+        "CREATE TABLE `worktree_adoption`(
+	`id` INTEGER PRIMARY KEY CHECK (`id` = 1),
+	`adopted_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);",
+    ),
+];
+
+/// Tests are in `but-db/tests/db/table/worktree_meta.rs`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct WorktreeMeta {
+    /// The git worktree name, i.e. the directory name under `$GIT_COMMON_DIR/worktrees/`.
+    pub name: Vec<u8>,
+    /// Whether the worktree is hidden from listings and graph traversal.
+    pub archived: bool,
+}
+
+impl DbHandle {
+    pub fn worktree_meta(&self) -> WorktreeMetaHandle<'_> {
+        WorktreeMetaHandle { conn: &self.conn }
+    }
+
+    pub fn worktree_meta_mut(&mut self) -> WorktreeMetaHandleMut<'_> {
+        WorktreeMetaHandleMut { conn: &self.conn }
+    }
+}
+
+impl<'conn> Transaction<'conn> {
+    pub fn worktree_meta(&self) -> WorktreeMetaHandle<'_> {
+        WorktreeMetaHandle { conn: self.inner() }
+    }
+
+    pub fn worktree_meta_mut(&mut self) -> WorktreeMetaHandleMut<'_> {
+        WorktreeMetaHandleMut { conn: self.inner() }
+    }
+}
+
+pub struct WorktreeMetaHandle<'conn> {
+    conn: &'conn rusqlite::Connection,
+}
+
+pub struct WorktreeMetaHandleMut<'conn> {
+    conn: &'conn rusqlite::Connection,
+}
+
+impl WorktreeMetaHandle<'_> {
+    /// Get a WorktreeMeta entry by name (primary key).
+    pub fn get(&self, name: &[u8]) -> rusqlite::Result<Option<WorktreeMeta>> {
+        let mut stmt = self
+            .conn
+            .prepare("SELECT name, archived FROM worktree_meta WHERE name = ?1")?;
+
+        let result = stmt
+            .query_row([name], |row| {
+                Ok(WorktreeMeta {
+                    name: row.get(0)?,
+                    archived: row.get(1)?,
+                })
+            })
+            .optional()?;
+
+        Ok(result)
+    }
+
+    /// List all WorktreeMeta entries.
+    pub fn list(&self) -> rusqlite::Result<Vec<WorktreeMeta>> {
+        let mut stmt = self
+            .conn
+            .prepare("SELECT name, archived FROM worktree_meta ORDER BY name")?;
+
+        let rows = stmt.query_map([], |row| {
+            Ok(WorktreeMeta {
+                name: row.get(0)?,
+                archived: row.get(1)?,
+            })
+        })?;
+
+        rows.collect()
+    }
+
+    /// Whether the one-time adoption of pre-existing worktrees has run for this
+    /// project - see [`WorktreeMetaHandleMut::mark_adopted()`].
+    pub fn adoption_ran(&self) -> rusqlite::Result<bool> {
+        self.conn.query_row(
+            "SELECT EXISTS(SELECT 1 FROM worktree_adoption WHERE id = 1)",
+            [],
+            |row| row.get(0),
+        )
+    }
+}
+
+impl WorktreeMetaHandleMut<'_> {
+    /// Enable read-only access functions.
+    pub fn to_ref(&self) -> WorktreeMetaHandle<'_> {
+        WorktreeMetaHandle { conn: self.conn }
+    }
+
+    /// Insert or replace a WorktreeMeta entry.
+    pub fn upsert(&mut self, meta: WorktreeMeta) -> rusqlite::Result<()> {
+        self.conn.execute(
+            "INSERT OR REPLACE INTO worktree_meta (name, archived) VALUES (?1, ?2)",
+            rusqlite::params![meta.name, meta.archived],
+        )?;
+        Ok(())
+    }
+
+    /// Record that the one-time adoption of pre-existing worktrees has run.
+    ///
+    /// Idempotent - marking again has no effect. The row's `adopted_at` column is
+    /// filled by the database as a debugging breadcrumb; nothing reads it.
+    pub fn mark_adopted(&mut self) -> rusqlite::Result<()> {
+        self.conn.execute(
+            "INSERT OR IGNORE INTO worktree_adoption (id) VALUES (1)",
+            [],
+        )?;
+        Ok(())
+    }
+}

--- a/crates/but-db/tests/db/migration.rs
+++ b/crates/but-db/tests/db/migration.rs
@@ -596,6 +596,18 @@ CREATE TABLE `workflows`(
 	`summary` TEXT
 );
 
+-- table worktree_adoption
+CREATE TABLE `worktree_adoption`(
+	`id` INTEGER PRIMARY KEY CHECK (`id` = 1),
+	`adopted_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- table worktree_meta
+CREATE TABLE `worktree_meta`(
+	`name` BLOB NOT NULL PRIMARY KEY,
+	`archived` BOOL NOT NULL DEFAULT FALSE
+);
+
 -- index idx_branch_order_parent_ref_name
 CREATE INDEX `idx_branch_order_parent_ref_name` ON `branch_order`(`parent_ref_name`);
 
@@ -665,6 +677,8 @@ Text("20260624170000")
 Text("20260626120000")
 Text("20260626120100")
 Text("20260715120000")
+Text("20260715161258")
+Text("20260716175500")
 
 Table: hunk_assignments
 hunk_header | path | path_bytes | stack_id | id | branch_ref
@@ -713,6 +727,12 @@ branch_ref_name | parent_ref_name
 
 Table: fetch_status
 singleton | last_attempted_ms | last_successful_ms | last_error
+
+Table: worktree_meta
+name | archived
+
+Table: worktree_adoption
+id | adopted_at
 
 
 "#]]

--- a/crates/but-db/tests/db/table/mod.rs
+++ b/crates/but-db/tests/db/table/mod.rs
@@ -10,6 +10,7 @@ mod forge_review;
 mod gerrit_metadata;
 mod hunk_assignments;
 mod virtual_branches;
+mod worktree_meta;
 
 /// Return a valid DB handle with all migrations applied, ready for use, and *in-memory* only.
 fn in_memory_db() -> DbHandle {

--- a/crates/but-db/tests/db/table/worktree_meta.rs
+++ b/crates/but-db/tests/db/table/worktree_meta.rs
@@ -1,0 +1,146 @@
+use but_db::WorktreeMeta;
+
+use crate::table::in_memory_db;
+
+#[test]
+fn get_nonexistent() -> anyhow::Result<()> {
+    let db = in_memory_db();
+
+    let result = db.worktree_meta().get(b"missing")?;
+    assert!(result.is_none());
+    assert_eq!(db.worktree_meta().list()?, vec![]);
+
+    Ok(())
+}
+
+#[test]
+fn upsert_and_get() -> anyhow::Result<()> {
+    let mut db = in_memory_db();
+
+    let meta = WorktreeMeta {
+        name: b"wt-one".to_vec(),
+        archived: true,
+    };
+    db.worktree_meta_mut().upsert(meta.clone())?;
+
+    let retrieved = db.worktree_meta().get(&meta.name)?;
+    assert_eq!(retrieved, Some(meta.clone()));
+
+    // Upsert replaces the existing row.
+    let unarchived = WorktreeMeta {
+        archived: false,
+        ..meta.clone()
+    };
+    db.worktree_meta_mut().upsert(unarchived.clone())?;
+    assert_eq!(db.worktree_meta().get(&meta.name)?, Some(unarchived));
+
+    Ok(())
+}
+
+#[test]
+fn list_is_sorted_by_name() -> anyhow::Result<()> {
+    let mut db = in_memory_db();
+
+    for (name, archived) in [(&b"b"[..], false), (b"a", true), (b"c", false)] {
+        db.worktree_meta_mut().upsert(WorktreeMeta {
+            name: name.to_vec(),
+            archived,
+        })?;
+    }
+
+    let names: Vec<_> = db
+        .worktree_meta()
+        .list()?
+        .into_iter()
+        .map(|m| m.name)
+        .collect();
+    assert_eq!(names, vec![b"a".to_vec(), b"b".to_vec(), b"c".to_vec()]);
+
+    Ok(())
+}
+
+#[test]
+fn non_utf8_names_roundtrip() -> anyhow::Result<()> {
+    let mut db = in_memory_db();
+
+    let meta = WorktreeMeta {
+        name: vec![0xff, 0xfe, b'w', b't'],
+        archived: false,
+    };
+    db.worktree_meta_mut().upsert(meta.clone())?;
+
+    assert_eq!(db.worktree_meta().get(&meta.name)?, Some(meta));
+
+    Ok(())
+}
+
+#[test]
+fn adoption_marker() -> anyhow::Result<()> {
+    let mut db = in_memory_db();
+
+    assert!(
+        !db.worktree_meta().adoption_ran()?,
+        "adoption never ran on a fresh database"
+    );
+
+    db.worktree_meta_mut().mark_adopted()?;
+    assert!(db.worktree_meta().adoption_ran()?);
+
+    db.worktree_meta_mut().mark_adopted()?;
+    assert!(
+        db.worktree_meta().adoption_ran()?,
+        "marking again is a no-op"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn adoption_marker_transaction_rollback() -> anyhow::Result<()> {
+    let mut db = in_memory_db();
+
+    let mut trans = db.transaction()?;
+    trans.worktree_meta_mut().mark_adopted()?;
+    assert!(trans.worktree_meta().adoption_ran()?);
+    trans.rollback()?;
+
+    assert!(!db.worktree_meta().adoption_ran()?);
+
+    Ok(())
+}
+
+#[test]
+fn with_transaction() -> anyhow::Result<()> {
+    let mut db = in_memory_db();
+
+    let meta = WorktreeMeta {
+        name: b"wt-one".to_vec(),
+        archived: true,
+    };
+
+    let mut trans = db.transaction()?;
+    trans.worktree_meta_mut().upsert(meta.clone())?;
+    assert_eq!(trans.worktree_meta().get(&meta.name)?, Some(meta.clone()));
+    trans.commit()?;
+
+    assert_eq!(db.worktree_meta().get(&meta.name)?, Some(meta));
+
+    Ok(())
+}
+
+#[test]
+fn transaction_rollback() -> anyhow::Result<()> {
+    let mut db = in_memory_db();
+
+    let meta = WorktreeMeta {
+        name: b"wt-one".to_vec(),
+        archived: false,
+    };
+    let mut trans = db.transaction()?;
+    trans.worktree_meta_mut().upsert(meta.clone())?;
+    trans.rollback()?;
+
+    assert_eq!(db.worktree_meta().get(&meta.name)?, None);
+
+    Ok(())
+}

--- a/crates/but-serde/src/lib.rs
+++ b/crates/but-serde/src/lib.rs
@@ -50,6 +50,30 @@ pub mod bstring_lossy {
     }
 }
 
+/// Use on `PathBuf` fields that should serialize as JSON strings, degrading
+/// lossily instead of failing on paths that are not valid UTF-8 (which is what
+/// serde's built-in `Path` serialization does).
+///
+/// ```rust
+/// #[derive(serde::Serialize)]
+/// struct Example {
+///     #[serde(with = "but_serde::path_lossy")]
+///     path: std::path::PathBuf,
+/// }
+/// ```
+pub mod path_lossy {
+    use std::path::Path;
+
+    use serde::Serialize;
+
+    pub fn serialize<S>(v: &Path, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        v.to_string_lossy().serialize(s)
+    }
+}
+
 /// Use on `gix::refs::FullName` fields that should serialize as JSON strings.
 ///
 /// ```rust

--- a/crates/but-workspace/src/lib.rs
+++ b/crates/but-workspace/src/lib.rs
@@ -71,6 +71,8 @@ pub use upstream_integration::{
 mod worktree;
 pub use worktree::worktree_conflicts_for_rebase;
 
+pub mod worktrees;
+
 pub mod workspace;
 
 /// Information about refs, as seen from within or outsie of a workspace.

--- a/crates/but-workspace/src/worktrees.rs
+++ b/crates/but-workspace/src/worktrees.rs
@@ -1,0 +1,124 @@
+//! Listing and metadata operations for linked git worktrees (experimental).
+//!
+//! Linked worktrees are identified by their stable *name*, i.e. the directory name
+//! under `$GIT_COMMON_DIR/worktrees/`, which survives `git worktree move`.
+//!
+//! Enumeration and archived-state reconciliation are centralized in `but-ctx` -
+//! callers pass the result in as [`WorktreeSource`]s so this crate stays independent
+//! of it. The `worktree_meta` table only stores *explicitly set* archived state
+//! plus the one-time adoption marker; a worktree without a row is active.
+
+use std::path::PathBuf;
+
+use bstr::{BStr, BString};
+use serde::Serialize;
+
+/// A non-archived linked worktree, presented like a single-branch stack.
+///
+/// This is intentionally slimmer than a workspace stack - linked worktrees have no
+/// push status or remote tracking information of their own, and their commits
+/// against the target are not computed yet.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorktreeStack {
+    /// The stable worktree name, i.e. the directory name under `$GIT_COMMON_DIR/worktrees/`.
+    #[serde(with = "but_serde::bstring_lossy")]
+    pub name: BString,
+    /// The worktree checkout directory.
+    #[serde(with = "but_serde::path_lossy")]
+    pub path: PathBuf,
+    /// The branch the worktree has checked out, or `None` for a detached `HEAD`.
+    #[serde(with = "but_serde::fullname_lossy_opt")]
+    pub ref_name: Option<gix::refs::FullName>,
+    /// The commit the worktree `HEAD` peels to.
+    #[serde(with = "but_serde::object_id")]
+    pub head: gix::ObjectId,
+}
+
+/// An archived linked worktree, listed with identity information only.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchivedWorktree {
+    /// The stable worktree name, i.e. the directory name under `$GIT_COMMON_DIR/worktrees/`.
+    #[serde(with = "but_serde::bstring_lossy")]
+    pub name: BString,
+    /// The worktree checkout directory.
+    #[serde(with = "but_serde::path_lossy")]
+    pub path: PathBuf,
+    /// The branch the worktree has checked out, or `None` for a detached `HEAD`.
+    #[serde(with = "but_serde::fullname_lossy_opt")]
+    pub ref_name: Option<gix::refs::FullName>,
+}
+
+/// All usable linked worktrees, separated by archived state.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorktreeListing {
+    /// Non-archived worktrees.
+    pub active: Vec<WorktreeStack>,
+    /// Archived worktrees, hidden from the workspace but still on disk.
+    pub archived: Vec<ArchivedWorktree>,
+}
+
+/// A usable linked worktree as input to [`list_worktrees()`].
+///
+/// Callers typically map this from `but-ctx`'s reconciled worktree enumeration.
+#[derive(Debug, Clone)]
+pub struct WorktreeSource {
+    /// Whether the worktree is archived.
+    pub archived: bool,
+    /// The worktree checkout directory.
+    pub path: PathBuf,
+    /// The stable worktree name, i.e. the directory name under `$GIT_COMMON_DIR/worktrees/`.
+    pub name: BString,
+    /// The branch the worktree has checked out, or `None` for a detached `HEAD`.
+    pub ref_name: Option<gix::refs::FullName>,
+    /// The commit the worktree `HEAD` peels to.
+    pub head: gix::ObjectId,
+}
+
+/// Produce a listing of all worktrees in `sources`, splitting them by archived state.
+pub fn list_worktrees(sources: Vec<WorktreeSource>) -> WorktreeListing {
+    let mut active = Vec::new();
+    let mut archived = Vec::new();
+    for source in sources {
+        let WorktreeSource {
+            archived: is_archived,
+            path,
+            name,
+            ref_name,
+            head,
+        } = source;
+        if is_archived {
+            archived.push(ArchivedWorktree {
+                name,
+                path,
+                ref_name,
+            });
+        } else {
+            active.push(WorktreeStack {
+                name,
+                path,
+                ref_name,
+                head,
+            });
+        }
+    }
+    WorktreeListing { active, archived }
+}
+
+/// Persist the archived state of the worktree named `name`.
+///
+/// This is an upsert - a worktree without a row is simply active, so archiving
+/// creates its row on demand.
+pub fn set_worktree_archived(
+    db: &mut but_db::DbHandle,
+    name: &BStr,
+    archived: bool,
+) -> anyhow::Result<()> {
+    db.worktree_meta_mut().upsert(but_db::WorktreeMeta {
+        name: name.to_vec(),
+        archived,
+    })?;
+    Ok(())
+}

--- a/crates/but-workspace/tests/fixtures/scenario/worktree-listing.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/worktree-listing.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+git init
+
+echo "base" >base && git add . && git commit -m "base"
+echo "m1" >m1 && git add . && git commit -m "m1"
+
+# A linked worktree 'wt-a' on 'feat-a', forked before the target tip,
+# with one extra commit and an uncommitted change.
+git worktree add -b feat-a wt-a HEAD~1
+(cd wt-a
+  echo "a1" >a1 && git add a1 && git commit -m "a1"
+  echo "dirty" >>a1
+)
+
+# A linked worktree 'wt-b' for tests to archive.
+git worktree add -b feat-b wt-b HEAD~1
+
+# A linked worktree 'wt-detached' on a detached HEAD at the base commit.
+git worktree add --detach wt-detached HEAD~1
+
+# A linked worktree 'wt-gone' whose checkout was removed from disk (prunable).
+git worktree add -b feat-gone wt-gone HEAD~1
+rm -rf wt-gone

--- a/crates/but-workspace/tests/workspace/main.rs
+++ b/crates/but-workspace/tests/workspace/main.rs
@@ -14,5 +14,6 @@ mod tree_manipulation;
 mod ui;
 mod upstream_integration;
 mod worktree;
+mod worktrees;
 
 mod utils;

--- a/crates/but-workspace/tests/workspace/worktrees.rs
+++ b/crates/but-workspace/tests/workspace/worktrees.rs
@@ -1,0 +1,144 @@
+use anyhow::Result;
+use bstr::BString;
+use but_workspace::worktrees::{WorktreeSource, list_worktrees, set_worktree_archived};
+
+use crate::utils::writable_scenario_slow;
+
+/// Build [`WorktreeSource`]s with the archived state taken from `db`'s
+/// `worktree_meta` table. Unlike `but-ctx`, prunable worktrees are not skipped -
+/// [`list_worktrees()`] is agnostic to the caller's enumeration policy.
+fn worktree_sources(repo: &gix::Repository, db: &but_db::DbHandle) -> Result<Vec<WorktreeSource>> {
+    let mut out = Vec::new();
+    for proxy in repo.worktrees()? {
+        let name: BString = proxy.id().to_owned();
+        let path = proxy.base()?;
+        let wt_repo = proxy.into_repo_with_possibly_inaccessible_worktree()?;
+        let mut head = wt_repo.head()?;
+        let ref_name = head.referent_name().map(ToOwned::to_owned);
+        let id = head.peel_to_commit()?.id;
+        out.push(WorktreeSource {
+            archived: db
+                .worktree_meta()
+                .get(&name)?
+                .is_some_and(|row| row.archived),
+            path,
+            name,
+            ref_name,
+            head: id,
+        });
+    }
+    out.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(out)
+}
+
+#[test]
+fn list_worktrees_splits_by_archived_state() -> Result<()> {
+    let (repo, _tmp) = writable_scenario_slow("worktree-listing");
+    let mut db = but_db::DbHandle::new_at_path(":memory:")?;
+
+    let sources = worktree_sources(&repo, &db)?;
+    assert_eq!(
+        sources.len(),
+        4,
+        "the pruned 'wt-gone' still enumerates - only its checkout is missing"
+    );
+    let listing = list_worktrees(sources);
+    assert_eq!(
+        listing
+            .active
+            .iter()
+            .map(|wt| wt.name.to_string())
+            .collect::<Vec<_>>(),
+        ["wt-a", "wt-b", "wt-detached", "wt-gone"],
+        "worktrees without explicitly set archived state list as active"
+    );
+    assert_eq!(listing.archived.len(), 0);
+
+    set_worktree_archived(&mut db, "wt-b".into(), true)?;
+    let sources = worktree_sources(&repo, &db)?;
+    let listing = list_worktrees(sources);
+
+    let active_names: Vec<_> = listing
+        .active
+        .iter()
+        .map(|wt| wt.name.to_string())
+        .collect();
+    assert_eq!(
+        active_names,
+        ["wt-a", "wt-detached", "wt-gone"],
+        "non-archived worktrees are listed as stacks, pruned checkouts included"
+    );
+    let archived_names: Vec<_> = listing
+        .archived
+        .iter()
+        .map(|wt| wt.name.to_string())
+        .collect();
+    assert_eq!(archived_names, ["wt-b"], "archived worktrees are split out");
+    assert_eq!(
+        listing.archived[0]
+            .ref_name
+            .as_ref()
+            .map(|name| name.as_bstr().to_string()),
+        Some("refs/heads/feat-b".into()),
+        "archived worktrees keep their identity information"
+    );
+
+    let wt_a = &listing.active[0];
+    assert_eq!(
+        wt_a.ref_name
+            .as_ref()
+            .map(|name| name.as_bstr().to_string()),
+        Some("refs/heads/feat-a".into())
+    );
+    assert_eq!(wt_a.head, repo.rev_parse_single("feat-a")?.detach());
+    assert_eq!(
+        wt_a.path.file_name().and_then(|name| name.to_str()),
+        Some("wt-a"),
+        "the checkout path is reported"
+    );
+
+    let detached = &listing.active[1];
+    assert_eq!(
+        detached.ref_name, None,
+        "a detached-HEAD worktree lists without a ref name"
+    );
+    assert_eq!(
+        detached.head,
+        repo.rev_parse_single("@~1")?.detach(),
+        "the detached HEAD is resolved directly"
+    );
+
+    set_worktree_archived(&mut db, "wt-b".into(), false)?;
+    let sources = worktree_sources(&repo, &db)?;
+    let listing = list_worktrees(sources);
+    assert_eq!(
+        listing
+            .active
+            .iter()
+            .map(|wt| wt.name.to_string())
+            .collect::<Vec<_>>(),
+        ["wt-a", "wt-b", "wt-detached", "wt-gone"],
+        "unarchiving brings the worktree back into the active listing"
+    );
+    Ok(())
+}
+
+#[test]
+fn set_worktree_archived_upserts_rows() -> Result<()> {
+    let mut db = but_db::DbHandle::new_at_path(":memory:")?;
+
+    set_worktree_archived(&mut db, "wt".into(), true)?;
+    assert_eq!(
+        db.worktree_meta().get(b"wt")?.map(|row| row.archived),
+        Some(true),
+        "archiving creates the row on demand"
+    );
+
+    set_worktree_archived(&mut db, "wt".into(), false)?;
+    assert_eq!(
+        db.worktree_meta().get(b"wt")?.map(|row| row.archived),
+        Some(false),
+        "the same call unarchives"
+    );
+    Ok(())
+}


### PR DESCRIPTION
* Closes GB-1755

This PR is part of a series that is rebuilding the prototype for worktrees in GitButler.

This PR introduces the infrastructure for listing PRs, combining them with data in the database that describes whether certain worktrees should be considered archived.

The reason for having this "archived" status is that it allows us to avoid flooding the user with worktrees that they might not be interested in all the time.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #14841 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #14811 
<!-- GitButler Footer Boundary Bottom -->

