### PR TITLE
Support no-setup single-branch CLI mode

### DIFF
--- a/crates/but-workspace/src/init.rs
+++ b/crates/but-workspace/src/init.rs
@@ -5,11 +5,43 @@
 //! application can operate on any branch, the target can be set at any time.
 
 use anyhow::{Context as _, Result, bail};
+use bstr::ByteSlice;
 use but_core::{
     RefMetadata,
     git_config::{edit_repo_config, ensure_config_value},
     ref_metadata::ProjectMeta,
 };
+
+/// Infer a default remote-tracking target from repository configuration without changing state.
+///
+/// The repository's unambiguous default push remote is used. Within that remote, its symbolic
+/// `HEAD` is preferred, followed by `main` and `master`. `None` means there is no unambiguous
+/// remote or none of those references exist.
+pub fn infer_default_target_ref(repo: &gix::Repository) -> Result<Option<gix::refs::FullName>> {
+    let Some(remote_name) = repo.remote_default_name(gix::remote::Direction::Push) else {
+        return Ok(None);
+    };
+    let remote_name = remote_name
+        .to_str()
+        .context("default remote name is not UTF-8")?;
+
+    let remote_head_ref = format!("refs/remotes/{remote_name}/HEAD");
+    if let Ok(head_ref) = repo.find_reference(remote_head_ref.as_str())
+        && let Some(branch_name) = head_ref.target().try_name()
+    {
+        return Ok(Some(branch_name.to_owned()));
+    }
+
+    for branch_name in ["main", "master"] {
+        let full_name: gix::refs::FullName =
+            format!("refs/remotes/{remote_name}/{branch_name}").try_into()?;
+        if repo.try_find_reference(full_name.as_ref())?.is_some() {
+            return Ok(Some(full_name));
+        }
+    }
+
+    Ok(None)
+}
 
 /// Make `target_ref` the project's default target and initialize project metadata,
 /// without changing the currently checked out branch.

--- a/crates/but-workspace/src/init.rs
+++ b/crates/but-workspace/src/init.rs
@@ -28,6 +28,7 @@ pub fn infer_default_target_ref(repo: &gix::Repository) -> Result<Option<gix::re
     let remote_head_ref = format!("refs/remotes/{remote_name}/HEAD");
     if let Ok(head_ref) = repo.find_reference(remote_head_ref.as_str())
         && let Some(branch_name) = head_ref.target().try_name()
+        && is_existing_branch_on_remote(repo, branch_name, remote_name)?
     {
         return Ok(Some(branch_name.to_owned()));
     }
@@ -35,12 +36,29 @@ pub fn infer_default_target_ref(repo: &gix::Repository) -> Result<Option<gix::re
     for branch_name in ["main", "master"] {
         let full_name: gix::refs::FullName =
             format!("refs/remotes/{remote_name}/{branch_name}").try_into()?;
-        if repo.try_find_reference(full_name.as_ref())?.is_some() {
+        if is_existing_branch_on_remote(repo, full_name.as_ref(), remote_name)? {
             return Ok(Some(full_name));
         }
     }
 
     Ok(None)
+}
+
+fn is_existing_branch_on_remote(
+    repo: &gix::Repository,
+    ref_name: &gix::refs::FullNameRef,
+    expected_remote: &str,
+) -> Result<bool> {
+    let belongs_to_expected_remote =
+        but_core::extract_remote_name_and_short_name(ref_name, &repo.remote_names())
+            .is_some_and(|(remote_name, _)| remote_name == expected_remote);
+    if !belongs_to_expected_remote {
+        return Ok(false);
+    }
+
+    Ok(repo
+        .try_find_reference(ref_name)?
+        .is_some_and(|mut reference| reference.peel_to_commit().is_ok()))
 }
 
 /// Make `target_ref` the project's default target and initialize project metadata,

--- a/crates/but-workspace/tests/workspace/init.rs
+++ b/crates/but-workspace/tests/workspace/init.rs
@@ -46,6 +46,131 @@ fn stored_meta(repo: &gix::Repository, meta: &VirtualBranchesTomlMetadata) -> Pr
     ProjectMeta::resolve(repo, meta).expect("project metadata is readable")
 }
 
+fn create_remote_branch(repo: &gix::Repository, name: &str) -> anyhow::Result<()> {
+    repo.reference(
+        name,
+        repo.head_id()?.detach(),
+        PreviousValue::Any,
+        "test remote branch",
+    )?;
+    Ok(())
+}
+
+fn set_remote_head(repo: &gix::Repository, target: &str) -> anyhow::Result<()> {
+    repo.edit_reference(gix::refs::transaction::RefEdit {
+        change: gix::refs::transaction::Change::Update {
+            log: gix::refs::transaction::LogChange {
+                mode: gix::refs::transaction::RefLog::AndReference,
+                force_create_reflog: false,
+                message: "test remote HEAD".into(),
+            },
+            expected: PreviousValue::Any,
+            new: gix::refs::Target::Symbolic(target.try_into()?),
+        },
+        name: "refs/remotes/origin/HEAD".try_into()?,
+        deref: false,
+    })?;
+    Ok(())
+}
+
+fn inferred_target(repo: &gix::Repository) -> anyhow::Result<Option<String>> {
+    Ok(but_workspace::init::infer_default_target_ref(repo)?.map(|name| name.to_string()))
+}
+
+#[test]
+fn infers_symbolic_remote_head_first() -> anyhow::Result<()> {
+    let (repo, _meta, _tmp) = scenario();
+    create_remote_branch(&repo, "refs/remotes/origin/trunk")?;
+    set_remote_head(&repo, "refs/remotes/origin/trunk")?;
+
+    assert_eq!(
+        inferred_target(&repo)?,
+        Some("refs/remotes/origin/trunk".into()),
+        "a valid symbolic remote HEAD has the highest priority"
+    );
+    Ok(())
+}
+
+#[test]
+fn malformed_remote_head_falls_back_to_main() -> anyhow::Result<()> {
+    let (repo, _meta, _tmp) = scenario();
+    create_remote_branch(&repo, "refs/remotes/fork/trunk")?;
+    set_remote_head(&repo, "refs/remotes/fork/trunk")?;
+
+    assert_eq!(
+        inferred_target(&repo)?,
+        Some("refs/remotes/origin/main".into()),
+        "a symbolic HEAD pointing at another remote must not change the selected remote"
+    );
+    Ok(())
+}
+
+#[test]
+fn infers_main_without_symbolic_remote_head() -> anyhow::Result<()> {
+    let (repo, _meta, _tmp) = scenario();
+    assert_eq!(
+        inferred_target(&repo)?,
+        Some("refs/remotes/origin/main".into()),
+        "main is the first fallback when remote HEAD is absent"
+    );
+    Ok(())
+}
+
+#[test]
+fn infers_master_when_main_is_absent() -> anyhow::Result<()> {
+    let (repo, _meta, _tmp) = scenario();
+    repo.find_reference("refs/remotes/origin/main")?.delete()?;
+    create_remote_branch(&repo, "refs/remotes/origin/master")?;
+
+    assert_eq!(
+        inferred_target(&repo)?,
+        Some("refs/remotes/origin/master".into()),
+        "master is used only after remote HEAD and main"
+    );
+    Ok(())
+}
+
+#[test]
+fn returns_none_without_a_candidate_branch() -> anyhow::Result<()> {
+    let (repo, _meta, _tmp) = scenario();
+    repo.find_reference("refs/remotes/origin/main")?.delete()?;
+
+    assert_eq!(
+        inferred_target(&repo)?,
+        None,
+        "a default remote without HEAD, main, or master has no inferred target"
+    );
+    Ok(())
+}
+
+#[test]
+fn returns_none_without_an_unambiguous_default_remote() -> anyhow::Result<()> {
+    let tmp = but_testsupport::gix_testtools::tempfile::TempDir::new()?;
+    let repo = gix::init(tmp.path())?;
+    edit_config(Some(&repo), gix::config::Source::Local, |config| {
+        set_config_value(
+            config,
+            "remote.upstream.url",
+            "https://example.com/upstream",
+        )?;
+        set_config_value(config, "remote.fork.url", "https://example.com/fork")?;
+        Ok(())
+    })?;
+    let repo = but_testsupport::open_repo(tmp.path())?;
+
+    assert_eq!(
+        repo.remote_default_name(gix::remote::Direction::Push),
+        None,
+        "two non-origin remotes have no implicit default"
+    );
+    assert_eq!(
+        inferred_target(&repo)?,
+        None,
+        "target inference requires a default remote"
+    );
+    Ok(())
+}
+
 /// Create an empty commit on top of `parent` without updating any reference.
 fn empty_commit_on_top(
     repo: &gix::Repository,

--- a/crates/but/skill/README.md
+++ b/crates/but/skill/README.md
@@ -21,7 +21,8 @@ In non-interactive mode, use `--path` or `--detect`.
 **Requirements:**
 - **GitButler CLI** installed (refer to the docs for installation instructions)
 - **An AI assistant with skills support** such as Agent Skills / `.agents/skills`, Claude Code, OpenCode, Codex, GitHub Copilot, Cursor, Windsurf, or Poolside
-- Repository initialized with GitButler: `but setup` (only for local installs)
+- A Git repository. Managed-workspace mode uses `but setup`; when experimental single-branch
+  mode is enabled, `but` registers the repository and infers its target on first use.
 
 **Updating:**
 

--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -500,7 +500,11 @@ but setup
 but setup --init              # Also initialize a new git repo if none exists
 ```
 
-Converts regular git repo to use GitButler workspace model. Use `--init` in non-interactive environments (CI/CD) to ensure a git repository exists before setup.
+Converts a regular Git repository to the managed GitButler workspace model. Use `--init` in
+non-interactive environments (CI/CD) to ensure a Git repository exists before setup. When the
+experimental single-branch feature is enabled, normal CLI use does not require this command: the
+repository is registered and its target is inferred lazily without checking out
+`gitbutler/workspace` or installing setup hooks.
 
 ### `but teardown`
 

--- a/crates/but/src/command/legacy/branch/mod.rs
+++ b/crates/but/src/command/legacy/branch/mod.rs
@@ -86,6 +86,34 @@ pub fn new(
             .transpose()?
     };
 
+    if resolved_anchor.is_none()
+        && ctx.settings.feature_flags.single_branch
+        && gitbutler_operating_modes::in_outside_workspace_mode(ctx, guard.read_permission())?
+    {
+        let head_name = ctx
+            .repo
+            .get()?
+            .head()?
+            .referent_name()
+            .filter(|name| name.category() == Some(gix::refs::Category::LocalBranch))
+            .context("single-branch branch creation requires HEAD to be a local branch")?
+            .to_owned();
+        let new_ref: gix::refs::FullName = format!("refs/heads/{branch_name}").try_into()?;
+        but_api::branch::branch_create_with_perm(
+            ctx,
+            Some(new_ref),
+            but_api::branch::json::BranchCreatePlacement::Dependent {
+                relative_to: but_api::commit::json::RelativeTo::Reference(head_name),
+                side: but_rebase::graph_rebase::mutate::InsertSide::Above,
+            },
+            guard.write_permission(),
+        )?;
+        if let Some(out) = out.for_human() {
+            writeln!(out, "{} Created branch {branch_name}", t.sym().success)?;
+        }
+        return Ok(());
+    }
+
     let anchor = resolved_anchor
         .clone()
         .map(|anchor| -> CliResult<_> {

--- a/crates/but/src/command/legacy/branch/mod.rs
+++ b/crates/but/src/command/legacy/branch/mod.rs
@@ -5,7 +5,7 @@ use gitbutler_oplog::entry::{OperationKind, SnapshotDetails};
 
 use crate::{
     CliResult, IdMap,
-    args::atoms::{BranchArg, BranchOrCommit, CliIdArg, Purpose},
+    args::atoms::{BranchArg, BranchOrCommit, CliIdArg, Purpose, ResolvedCliIdArg},
     theme::{self, Paint},
     utils::OutputChannel,
 };
@@ -59,7 +59,6 @@ pub fn new(
     branch_name_arg: Option<BranchArg>,
     anchor_arg: Option<CliIdArg>,
 ) -> CliResult<()> {
-    let t = theme::get();
     let mut guard = ctx.exclusive_worktree_access();
 
     let branch_name = if let Some(branch_name_arg) = branch_name_arg {
@@ -108,9 +107,7 @@ pub fn new(
             },
             guard.write_permission(),
         )?;
-        if let Some(out) = out.for_human() {
-            writeln!(out, "{} Created branch {branch_name}", t.sym().success)?;
-        }
+        write_new_branch_output(out, &branch_name, None, anchor_arg)?;
         return Ok(());
     }
 
@@ -143,6 +140,18 @@ pub fn new(
         guard.write_permission(),
     )?;
 
+    write_new_branch_output(out, &branch_name, resolved_anchor.as_ref(), anchor_arg)?;
+
+    Ok(())
+}
+
+fn write_new_branch_output(
+    out: &mut OutputChannel,
+    branch_name: &str,
+    resolved_anchor: Option<&ResolvedCliIdArg>,
+    anchor_arg: Option<CliIdArg>,
+) -> CliResult<()> {
+    let t = theme::get();
     if let Some(out) = out.for_human() {
         if let Some(resolved_anchor) = resolved_anchor {
             writeln!(
@@ -164,7 +173,7 @@ pub fn new(
         writeln!(out, "{branch_name}")?;
     } else if let Some(out) = out.for_json() {
         let value = json::BranchNewOutput {
-            branch: branch_name.clone(),
+            branch: branch_name.to_owned(),
             anchor: anchor_arg,
         };
         out.write_value(value)?;

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -593,14 +593,14 @@ fn build_status_output(
     print_upstream_state(ctx, status_ctx, output)?;
     print_common_merge_base_summary(status_ctx, output)?;
     print_conflicted_files_warning(status_ctx, output)?;
-    let not_on_workspace = matches!(
+    let warn_about_outside_workspace = matches!(
         status_ctx.mode,
         gitbutler_operating_modes::OperatingMode::OutsideWorkspace(_)
-    );
-    print_outside_workspace_warning(not_on_workspace, output)?;
+    ) && !ctx.settings.feature_flags.single_branch;
+    print_outside_workspace_warning(warn_about_outside_workspace, output)?;
     print_hint(
         status_ctx,
-        not_on_workspace,
+        warn_about_outside_workspace,
         has_merged_upstream_branch,
         output,
     )?;

--- a/crates/but/src/legacy/workspace.rs
+++ b/crates/but/src/legacy/workspace.rs
@@ -127,6 +127,7 @@ fn applied_stacks_with_options(
         info,
         metadata.as_ref(),
         object_hash.null(),
+        ctx.settings.feature_flags.single_branch,
     ))
 }
 
@@ -170,17 +171,20 @@ fn head_info_stacks(
     info: RefInfo,
     metadata: Option<&Workspace>,
     null_id: gix::ObjectId,
+    retain_single_branch_id: bool,
 ) -> Vec<HeadInfoStack> {
     info.stacks
         .iter()
-        .filter_map(|stack| match head_info_stack(stack, metadata, null_id) {
-            Ok(stack) => Some(stack),
-            Err(err) => {
-                tracing::warn!(
-                    ?err,
-                    "Skipping head_info stack that the CLI cannot represent"
-                );
-                None
+        .filter_map(|stack| {
+            match head_info_stack(stack, metadata, null_id, retain_single_branch_id) {
+                Ok(stack) => Some(stack),
+                Err(err) => {
+                    tracing::warn!(
+                        ?err,
+                        "Skipping head_info stack that the CLI cannot represent"
+                    );
+                    None
+                }
             }
         })
         .collect()
@@ -190,6 +194,7 @@ fn head_info_stack(
     stack: &branch::Stack,
     metadata: Option<&Workspace>,
     null_id: gix::ObjectId,
+    retain_single_branch_id: bool,
 ) -> anyhow::Result<HeadInfoStack> {
     let branches = stack
         .segments
@@ -210,7 +215,9 @@ fn head_info_stack(
                     .map(|stack| stack.id)
             })
     });
-    let projection_id = stack.id.filter(|id| *id != StackId::single_branch_id());
+    let projection_id = stack
+        .id
+        .filter(|id| retain_single_branch_id || *id != StackId::single_branch_id());
     let id = metadata_id.or(projection_id);
     Ok(HeadInfoStack { id, branches })
 }

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -697,7 +697,14 @@ async fn match_subcommand(
                     interactive,
                 }) => {
                     let status_after = args.status_after && !dry_run && !interactive;
-                    let mut ctx = setup::init_ctx(&args, InitCtxOptions::default(), out)?;
+                    let mut ctx = setup::init_ctx(
+                        &args,
+                        InitCtxOptions {
+                            workspace_check: setup::WorkspaceCheck::Disabled,
+                            ..Default::default()
+                        },
+                        out,
+                    )?;
                     out.begin_status_after(status_after);
                     let result = command::branch::update(
                         &mut ctx,
@@ -724,7 +731,14 @@ async fn match_subcommand(
             workspace,
             new,
         } => {
-            let mut ctx = setup::init_ctx(&args, InitCtxOptions::default(), out)?;
+            let mut ctx = setup::init_ctx(
+                &args,
+                InitCtxOptions {
+                    workspace_check: setup::WorkspaceCheck::Disabled,
+                    ..Default::default()
+                },
+                out,
+            )?;
             command::r#switch::handle(&mut ctx, out, target, workspace, new)
                 .emit_metrics(metrics_ctx)
         }
@@ -1749,7 +1763,14 @@ async fn match_subcommand(
             after,
         } => {
             let status_after = args.status_after;
-            let mut ctx = setup::init_ctx(&args, InitCtxOptions::default(), out)?;
+            let mut ctx = setup::init_ctx(
+                &args,
+                InitCtxOptions {
+                    workspace_check: setup::WorkspaceCheck::Disabled,
+                    ..Default::default()
+                },
+                out,
+            )?;
             out.begin_status_after(status_after);
             let result = command::r#move::handle(&mut ctx, out, &source, &target, after)
                 .emit_metrics(metrics_ctx);

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -40,7 +40,7 @@ use theme::Paint;
 #[cfg(feature = "legacy")]
 use crate::command::legacy::ShowDiffInEditor;
 use crate::{
-    setup::{BackgroundSync, InitCtxOptions},
+    setup::{BackgroundSync, InitCtxOptions, TargetRequirement},
     utils::{OutputChannel, ResultErrorExt, ResultMetricsExt, envs},
 };
 
@@ -551,7 +551,11 @@ async fn match_subcommand(
                     // Other subcommands need a repo context
                     cfg_if! {
                         if #[cfg(feature = "legacy")] {
-                            let mut ctx = setup::init_ctx(&args, InitCtxOptions { background_sync: BackgroundSync::Disabled, ..Default::default() }, out)?;
+                            let mut ctx = setup::init_ctx(&args, InitCtxOptions {
+                                background_sync: BackgroundSync::Disabled,
+                                target_requirement: TargetRequirement::Optional,
+                                ..Default::default()
+                            }, out)?;
                             command::config::exec(&mut ctx, out, cmd)
                                 .await
                                 .emit_metrics(metrics_ctx).map_err(CliError::from)
@@ -693,7 +697,7 @@ async fn match_subcommand(
                     interactive,
                 }) => {
                     let status_after = args.status_after && !dry_run && !interactive;
-                    let mut ctx = but_ctx::Context::discover(&args.current_dir)?;
+                    let mut ctx = setup::init_ctx(&args, InitCtxOptions::default(), out)?;
                     out.begin_status_after(status_after);
                     let result = command::branch::update(
                         &mut ctx,
@@ -720,7 +724,7 @@ async fn match_subcommand(
             workspace,
             new,
         } => {
-            let mut ctx = but_ctx::Context::discover(&args.current_dir)?;
+            let mut ctx = setup::init_ctx(&args, InitCtxOptions::default(), out)?;
             command::r#switch::handle(&mut ctx, out, target, workspace, new)
                 .emit_metrics(metrics_ctx)
         }
@@ -1365,6 +1369,7 @@ async fn match_subcommand(
                 &args,
                 InitCtxOptions {
                     workspace_check: setup::WorkspaceCheck::Disabled,
+                    target_requirement: TargetRequirement::Optional,
                     ..Default::default()
                 },
                 out,
@@ -1744,7 +1749,7 @@ async fn match_subcommand(
             after,
         } => {
             let status_after = args.status_after;
-            let mut ctx = but_ctx::Context::discover(&args.current_dir)?;
+            let mut ctx = setup::init_ctx(&args, InitCtxOptions::default(), out)?;
             out.begin_status_after(status_after);
             let result = command::r#move::handle(&mut ctx, out, &source, &target, after)
                 .emit_metrics(metrics_ctx);

--- a/crates/but/src/setup.rs
+++ b/crates/but/src/setup.rs
@@ -27,6 +27,15 @@ pub(crate) enum WorkspaceCheck {
     Disabled,
 }
 
+#[derive(Default)]
+pub(crate) enum TargetRequirement {
+    /// Ensure a target is configured before returning the context.
+    #[default]
+    Required,
+    /// Allow commands that inspect or set target configuration to run without one.
+    Optional,
+}
+
 /// Options for initializing the context via [`init_ctx`].
 #[derive(Default)]
 pub(crate) struct InitCtxOptions {
@@ -36,6 +45,9 @@ pub(crate) struct InitCtxOptions {
     /// Controls whether to check for workspace commit integrity.
     /// Defaults to `WorkspaceCheck::Enabled`.
     pub workspace_check: WorkspaceCheck,
+    /// Controls whether single-branch initialization must lazily infer a target.
+    /// Defaults to `TargetRequirement::Required`.
+    pub target_requirement: TargetRequirement,
 }
 
 /// Gets or initializes a non-bare repository context.
@@ -54,6 +66,9 @@ pub(crate) struct InitCtxOptions {
 ///   - `workspace_check` - Controls workspace commit integrity checking:
 ///     - `WorkspaceCheck::Enabled` - Check for non-workspace commits on gitbutler/workspace
 ///     - `WorkspaceCheck::Disabled` - Skip workspace commit checking
+///   - `target_requirement` - Controls target initialization in single-branch mode:
+///     - `TargetRequirement::Required` - Infer and persist a missing target
+///     - `TargetRequirement::Optional` - Return a context without requiring a target
 ///
 /// # Returns
 ///
@@ -115,85 +130,125 @@ pub fn init_ctx(
 
             use crate::command::legacy::setup::check_project_setup;
 
-            // Try to find an existing project, or prompt for setup if not found
-            let project = match LegacyProject::find_by_worktree_dir(workdir) {
-                Ok(project) => project,
-                Err(_) => {
-                    let message = format!("No GitButler project found at {}", workdir.display());
-                    match prompt_for_setup(out, &message) {
-                        SetupPromptResult::RunSetup => {
-                            // Run setup
-                            let mut ctx = Context::from_repo_with_settings(
-                                repo.clone(),
-                                app_settings.clone(),
-                            )?;
-                            let mut guard = ctx.exclusive_worktree_access();
-                            crate::command::legacy::setup::repo(
-                                &mut ctx,
-                                &args.current_dir,
-                                out,
-                                guard.write_permission(),
-                            )?;
-                            // Retry finding the project after setup
-                            LegacyProject::find_by_worktree_dir(workdir).map_err(|_| {
-                                anyhow::anyhow!(
-                                    "Setup completed but project still not found at {}",
-                                    workdir.display()
-                                )
-                            })?
-                        }
-                        SetupPromptResult::Declined => {
-                            anyhow::bail!(
-                                "Setup required: {message} - run `but setup` to configure the project"
-                            );
-                        }
+            if app_settings.feature_flags.single_branch {
+                let project = match LegacyProject::find_by_worktree_dir(workdir) {
+                    Ok(project) => project,
+                    Err(_) => match gitbutler_project::add(workdir)? {
+                        gitbutler_project::AddProjectOutcome::Added(project)
+                        | gitbutler_project::AddProjectOutcome::AlreadyExists(project) => project,
+                        outcome => outcome.try_project()?,
+                    },
+                };
+                let mut ctx =
+                    Context::new_from_legacy_project_and_settings(&project, app_settings.clone())?;
+                if matches!(options.target_requirement, TargetRequirement::Required)
+                    && ctx.project_meta()?.target_ref.is_none()
+                {
+                    let target_ref = {
+                        let repo = ctx.repo.get()?;
+                        but_workspace::init::infer_default_target_ref(&repo)?
                     }
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "No target branch is configured and none could be inferred. Run `but config target <remote>/<branch>` to configure one."
+                        )
+                    })?;
+                    but_api::workspace::set_target_ref_and_init_project(
+                        &mut ctx,
+                        target_ref.as_ref(),
+                        None,
+                    )?;
                 }
-            };
 
-            // Check project setup, prompt for setup if needed
-            let mut ctx =
-                Context::new_from_legacy_project_and_settings(&project, app_settings.clone())?;
-            {
-                let mut guard = ctx.exclusive_worktree_access();
-                if let Err(e) = check_project_setup(&ctx, guard.read_permission()) {
-                    let message = e.to_string();
-                    match prompt_for_setup(out, &message) {
-                        SetupPromptResult::RunSetup => {
-                            // Run setup to fix the project configuration
-                            crate::command::legacy::setup::repo(
-                                &mut ctx,
-                                &args.current_dir,
-                                out,
-                                guard.write_permission(),
-                            )?;
-                            // Re-find and re-check the project after setup
-                            let _project =
+                let fetch_interval_minutes = ctx.settings.fetch.auto_fetch_interval_minutes;
+                let last_fetch = ctx
+                    .legacy_project
+                    .project_data_last_fetch
+                    .as_ref()
+                    .map(|f| f.timestamp());
+                (ctx, fetch_interval_minutes, last_fetch)
+            } else {
+                // Try to find an existing project, or prompt for setup if not found
+                let project = match LegacyProject::find_by_worktree_dir(workdir) {
+                    Ok(project) => project,
+                    Err(_) => {
+                        let message =
+                            format!("No GitButler project found at {}", workdir.display());
+                        match prompt_for_setup(out, &message) {
+                            SetupPromptResult::RunSetup => {
+                                // Run setup
+                                let mut ctx = Context::from_repo_with_settings(
+                                    repo.clone(),
+                                    app_settings.clone(),
+                                )?;
+                                let mut guard = ctx.exclusive_worktree_access();
+                                crate::command::legacy::setup::repo(
+                                    &mut ctx,
+                                    &args.current_dir,
+                                    out,
+                                    guard.write_permission(),
+                                )?;
+                                // Retry finding the project after setup
                                 LegacyProject::find_by_worktree_dir(workdir).map_err(|_| {
                                     anyhow::anyhow!(
                                         "Setup completed but project still not found at {}",
                                         workdir.display()
                                     )
-                                })?;
-                            check_project_setup(&ctx, guard.read_permission())?;
-                        }
-                        SetupPromptResult::Declined => {
-                            anyhow::bail!(
-                                "Setup required: {message} - run `but setup` to configure the project"
-                            );
+                                })?
+                            }
+                            SetupPromptResult::Declined => {
+                                anyhow::bail!(
+                                    "Setup required: {message} - run `but setup` to configure the project"
+                                );
+                            }
                         }
                     }
-                }
-                ctx.reload_repo_and_invalidate_workspace(guard.write_permission())?;
-            }
+                };
 
-            let fetch_interval_minutes = ctx.settings.fetch.auto_fetch_interval_minutes;
-            let last_fetch = ctx
-                .legacy_project
-                .project_data_last_fetch
-                .as_ref()
-                .map(|f| f.timestamp());
-            (ctx, fetch_interval_minutes, last_fetch)
+                // Check project setup, prompt for setup if needed
+                let mut ctx =
+                    Context::new_from_legacy_project_and_settings(&project, app_settings.clone())?;
+                {
+                    let mut guard = ctx.exclusive_worktree_access();
+                    if let Err(e) = check_project_setup(&ctx, guard.read_permission()) {
+                        let message = e.to_string();
+                        match prompt_for_setup(out, &message) {
+                            SetupPromptResult::RunSetup => {
+                                // Run setup to fix the project configuration
+                                crate::command::legacy::setup::repo(
+                                    &mut ctx,
+                                    &args.current_dir,
+                                    out,
+                                    guard.write_permission(),
+                                )?;
+                                // Re-find and re-check the project after setup
+                                let _project = LegacyProject::find_by_worktree_dir(workdir)
+                                    .map_err(|_| {
+                                        anyhow::anyhow!(
+                                            "Setup completed but project still not found at {}",
+                                            workdir.display()
+                                        )
+                                    })?;
+                                check_project_setup(&ctx, guard.read_permission())?;
+                            }
+                            SetupPromptResult::Declined => {
+                                anyhow::bail!(
+                                    "Setup required: {message} - run `but setup` to configure the project"
+                                );
+                            }
+                        }
+                    }
+                    ctx.reload_repo_and_invalidate_workspace(guard.write_permission())?;
+                }
+
+                let fetch_interval_minutes = ctx.settings.fetch.auto_fetch_interval_minutes;
+                let last_fetch = ctx
+                    .legacy_project
+                    .project_data_last_fetch
+                    .as_ref()
+                    .map(|f| f.timestamp());
+                (ctx, fetch_interval_minutes, last_fetch)
+            }
         }
         #[cfg(not(feature = "legacy"))]
         {

--- a/crates/but/tests/but/command/branch/new.rs
+++ b/crates/but/tests/but/command/branch/new.rs
@@ -163,6 +163,56 @@ fn with_json_output() {
 }
 
 #[test]
+fn single_branch_outputs_created_branch_for_all_formats() -> anyhow::Result<()> {
+    let env = Sandbox::open_with_default_settings("one-fork");
+
+    env.but("branch new human-feature")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+✓ Created branch human-feature
+
+"#]]);
+
+    env.but("--format shell branch new shell-feature")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+shell-feature
+
+"#]]);
+
+    env.but("--format json branch new json-feature")
+        .allow_json()
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+{
+  "branch": "json-feature"
+}
+
+"#]]);
+
+    let repo = env.open_repo();
+    for branch_name in ["human-feature", "shell-feature", "json-feature"] {
+        let reference_name = format!("refs/heads/{branch_name}");
+        assert!(
+            repo.try_find_reference(reference_name.as_str())?.is_some(),
+            "single-branch creation writes the branch reference"
+        );
+    }
+    assert!(
+        repo.try_find_reference(but_core::WORKSPACE_REF_NAME)?
+            .is_none(),
+        "single-branch creation does not create a managed workspace reference"
+    );
+    Ok(())
+}
+
+#[test]
 fn handles_path_prefix_collision() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
     env.setup_metadata(&["A"]);

--- a/crates/but/tests/but/command/format.rs
+++ b/crates/but/tests/but/command/format.rs
@@ -54,7 +54,7 @@ fn default_command_respects_c_flag_for_setup_checks() -> anyhow::Result<()> {
     env.but("-C repo")
         .assert()
         .stderr_eq(snapbox::str![[r#"
-Error: Setup required: No GitButler project found at repo - run `but setup` to configure the project
+Error: No target branch is configured and none could be inferred. Run `but config target <remote>/<branch>` to configure one.
 
 "#]])
         .failure();
@@ -75,7 +75,7 @@ git config but.alias.default "-C repo status"
     );
 
     env.but("").assert().failure().stderr_eq(snapbox::str![[r#"
-Error: Setup required: No GitButler project found at repo - run `but setup` to configure the project
+Error: No target branch is configured and none could be inferred. Run `but config target <remote>/<branch>` to configure one.
 
 "#]]);
 
@@ -99,7 +99,7 @@ git config but.alias.default "-C repo status"
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
-Error: Setup required: No GitButler project found at repo2 - run `but setup` to configure the project
+Error: No target branch is configured and none could be inferred. Run `but config target <remote>/<branch>` to configure one.
 
 "#]]);
 

--- a/crates/but/tests/but/command/status.rs
+++ b/crates/but/tests/but/command/status.rs
@@ -83,7 +83,7 @@ fn unborn() {
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
-Error: Setup required: No GitButler project found at . - run `but setup` to configure the project
+Error: No target branch is configured and none could be inferred. Run `but config target <remote>/<branch>` to configure one.
 
 "#]]);
 }
@@ -104,7 +104,7 @@ fn first_commit_no_workspace() {
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
-Error: Setup required: No GitButler project found at . - run `but setup` to configure the project
+Error: No target branch is configured and none could be inferred. Run `but config target <remote>/<branch>` to configure one.
 
 "#]]);
 }

--- a/crates/but/tests/but/command/status.rs
+++ b/crates/but/tests/but/command/status.rs
@@ -88,6 +88,29 @@ Error: No target branch is configured and none could be inferred. Run `but confi
 "#]]);
 }
 
+#[cfg(feature = "legacy")]
+#[test]
+fn disabled_single_branch_mode_requires_setup_for_unregistered_repository() {
+    let env = Sandbox::open_with_default_settings("one-fork");
+    env.but("config feature single-branch disable")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+✓ Feature flag single-branch is now disabled
+
+"#]]);
+
+    env.but("status")
+        .assert()
+        .failure()
+        .stdout_eq(snapbox::str![])
+        .stderr_eq(snapbox::str![[r#"
+Error: Setup required: No GitButler project found at . - run `but setup` to configure the project
+
+"#]]);
+}
+
 #[test]
 fn first_commit_no_workspace() {
     let env = Sandbox::open_scenario_with_target_and_default_settings("first-commit");

--- a/crates/gitbutler-branch-actions/src/base.rs
+++ b/crates/gitbutler-branch-actions/src/base.rs
@@ -109,18 +109,12 @@ pub fn bootstrap_default_target_if_missing(ctx: &Context) -> Result<bool> {
         return Ok(false);
     }
 
-    let Some(remote_name) = repo.remote_default_name(gix::remote::Direction::Push) else {
-        return Ok(false);
-    };
-    let remote_name = remote_name.to_string();
-
-    let target = match inferred_default_target(&repo, &remote_name) {
+    let target = match inferred_default_target(&repo) {
         Ok(Some(target)) => target,
         Ok(None) => return Ok(false),
         Err(err) => {
             tracing::debug!(
                 error = ?err,
-                remote_name,
                 "failed to infer default target; leaving default target uninitialized"
             );
             return Ok(false);
@@ -411,14 +405,16 @@ pub(crate) fn target_to_base_branch(
 }
 
 /// Infer the default target from the Git repository without mutating workspace refs.
-///
-/// Preference order:
-/// 1. `refs/remotes/<remote>/HEAD`
-/// 2. `refs/remotes/<remote>/main`
-/// 3. `refs/remotes/<remote>/master`
-fn inferred_default_target(repo: &gix::Repository, remote_name: &str) -> Result<Option<Target>> {
+fn inferred_default_target(repo: &gix::Repository) -> Result<Option<Target>> {
+    let Some(target_ref) = but_workspace::init::infer_default_target_ref(repo)? else {
+        return Ok(None);
+    };
+    let remote_names = repo.remote_names();
+    let (remote_name, _) =
+        but_core::extract_remote_name_and_short_name(target_ref.as_ref(), &remote_names)
+            .with_context(|| format!("failed to determine remote for branch '{target_ref}'"))?;
     let remote_url = repo
-        .find_remote(remote_name)
+        .find_remote(remote_name.as_str())
         .ok()
         .and_then(|remote| {
             remote
@@ -427,48 +423,17 @@ fn inferred_default_target(repo: &gix::Repository, remote_name: &str) -> Result<
         })
         .map(|url| url.to_bstring().to_string())
         .unwrap_or_default();
-
-    let remote_head_ref = format!("refs/remotes/{remote_name}/HEAD");
-    if let Ok(mut head_ref) = repo.find_reference(remote_head_ref.as_str())
-        && let Some(branch_name) = head_ref
-            .target()
-            .try_name()
-            .map(|name| name.as_bstr().to_string())
-    {
-        let branch = branch_name
-            .parse()
-            .with_context(|| format!("Remote HEAD resolved to invalid ref '{branch_name}'"))?;
-        let sha = head_ref
-            .peel_to_commit()
-            .context("Remote HEAD did not point to a commit")?
-            .id;
-        return Ok(Some(Target {
-            branch,
-            remote_url,
-            sha,
-            push_remote_name: Some(remote_name.to_owned()),
-        }));
-    }
-
-    for branch_name in ["main", "master"] {
-        let full_name = format!("refs/remotes/{remote_name}/{branch_name}");
-        if let Ok(mut reference) = repo.find_reference(&full_name) {
-            let sha = reference
-                .peel_to_commit()
-                .with_context(|| {
-                    format!("Fallback target '{full_name}' did not point to a commit")
-                })?
-                .id;
-            return Ok(Some(Target {
-                branch: full_name.parse()?,
-                remote_url,
-                sha,
-                push_remote_name: Some(remote_name.to_owned()),
-            }));
-        }
-    }
-
-    Ok(None)
+    let sha = repo
+        .find_reference(target_ref.as_ref())?
+        .peel_to_commit()
+        .with_context(|| format!("inferred target '{target_ref}' did not point to a commit"))?
+        .id;
+    Ok(Some(Target {
+        branch: target_ref.to_string().parse()?,
+        remote_url,
+        sha,
+        push_remote_name: Some(remote_name),
+    }))
 }
 
 fn first_parent_commit_ids_with_limit(


### PR DESCRIPTION
## Why?

Let's allow people to start trying single-branch mode in the CLI

## Summary

- lazily register repositories and infer targets behind the existing `singleBranch` feature flag
- allow status and core CLI workflows to run directly on checked-out local branches
- preserve managed-workspace setup behavior when the feature flag is disabled
