### PR TITLE
refactor: make the detect_agent module library-ready

### DIFF
--- a/crates/but/src/utils/detect_agent.rs
+++ b/crates/but/src/utils/detect_agent.rs
@@ -7,18 +7,9 @@
 use std::env;
 use std::ffi::OsString;
 
-#[derive(Clone, Copy)]
-struct Variable(&'static str);
-
-impl Variable {
-    fn name(self) -> &'static str {
-        self.0
-    }
-}
-
 macro_rules! environment_variables {
     ($($name:ident = $value:literal),+ $(,)?) => {
-        $(const $name: Variable = Variable($value);)+
+        $(const $name: &str = $value;)+
 
         /// Every environment variable consulted during agent detection.
         pub const ENVIRONMENT_VARIABLES: &[&str] = &[$($value),+];
@@ -73,6 +64,7 @@ environment_variables! {
 
 /// An AI coding agent that may be driving the CLI.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum Agent {
     ClaudeCode,
     ClaudeCodeCowork,
@@ -115,7 +107,7 @@ pub enum Agent {
 
 impl Agent {
     /// A short, stable identifier suitable for telemetry or output-format decisions.
-    pub fn name(self) -> &'static str {
+    pub fn as_str(self) -> &'static str {
         match self {
             Self::ClaudeCode => "claude-code",
             Self::ClaudeCodeCowork => "claude-code-cowork",
@@ -160,8 +152,47 @@ impl Agent {
 
 impl std::fmt::Display for Agent {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.name())
+        f.write_str(self.as_str())
     }
+}
+
+/// Error returned when parsing a string that does not name a known agent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ParseAgentError;
+
+impl std::fmt::Display for ParseAgentError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("unrecognized agent name")
+    }
+}
+
+impl std::error::Error for ParseAgentError {}
+
+impl std::str::FromStr for Agent {
+    type Err = ParseAgentError;
+
+    /// Parse an agent identifier exactly the way detection interprets
+    /// `AI_AGENT` values: normalized (`Claude_Code`, `claude code`, and
+    /// `claude-code@2` all parse to [`Agent::ClaudeCode`]), accepting known
+    /// aliases and version-decorated prefixes such as
+    /// `claude-code_2-1-202_agent`.
+    ///
+    /// Unlike detection this never falls back to [`Agent::Unknown`]:
+    /// unrecognized values are an error.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match_normalized_value(&normalize_agent_value(s)).ok_or(ParseAgentError)
+    }
+}
+
+/// Match an already-normalized identifier against known agents, including
+/// decorated forms.
+fn match_normalized_value(val: &str) -> Option<Agent> {
+    // GitLab decorates Duo CLI with the LSP version between its product
+    // names, for example `gitlab-lsp_7.17.0__duo-cli`.
+    if val.starts_with("gitlab-lsp-") && val.ends_with("-duo-cli") {
+        return Some(Agent::GitLabDuoCli);
+    }
+    match_agent_name(val).or_else(|| match_agent_name_prefix(val))
 }
 
 /// Detect the current AI coding agent from environment variables.
@@ -174,14 +205,17 @@ pub fn detect() -> Option<Agent> {
     detect_with(|key| env::var_os(key))
 }
 
-/// Core detection logic, parameterised over an env-var lookup function for testability.
-fn detect_with(lookup: impl Fn(&str) -> Option<OsString>) -> Option<Agent> {
-    let is_set = |var: Variable| lookup(var.name()).is_some_and(|v| !v.is_empty());
-    let is_value = |var: Variable, expected: &str| {
-        lookup(var.name()).is_some_and(|v| v.to_str() == Some(expected))
-    };
-    let contains = |var: Variable, needle: &str| {
-        lookup(var.name()).is_some_and(|v| v.to_str().is_some_and(|value| value.contains(needle)))
+/// Core detection logic, parameterised over an env-var lookup function.
+///
+/// [`detect`] is this with [`std::env::var_os`] as the lookup; injecting the
+/// lookup keeps detection testable and lets embedders supply a snapshot of the
+/// environment instead of the live process environment.
+pub fn detect_with(lookup: impl Fn(&str) -> Option<OsString>) -> Option<Agent> {
+    let is_set = |var: &str| lookup(var).is_some_and(|v| !v.is_empty());
+    let is_value =
+        |var: &str, expected: &str| lookup(var).is_some_and(|v| v.to_str() == Some(expected));
+    let contains = |var: &str, needle: &str| {
+        lookup(var).is_some_and(|v| v.to_str().is_some_and(|value| value.contains(needle)))
     };
 
     // Generic `AI_AGENT` convention (as documented by `@vercel/detect-agent`).
@@ -311,23 +345,14 @@ fn detect_with(lookup: impl Fn(&str) -> Option<OsString>) -> Option<Agent> {
 /// setting `AI_AGENT` is an explicit "an agent is driving this" signal, so we
 /// keep it even when we can't name the agent.
 fn parse_ai_agent_var(lookup: &impl Fn(&str) -> Option<OsString>) -> Option<Agent> {
-    let val = normalize_agent_value(&lookup(AI_AGENT.name())?.to_string_lossy());
+    let val = normalize_agent_value(&lookup(AI_AGENT)?.to_string_lossy());
     if val.is_empty() {
         return None;
     }
-    // GitLab decorates Duo CLI with the LSP version between its product names,
-    // for example `gitlab-lsp_7.17.0__duo-cli`.
-    if val.starts_with("gitlab-lsp-") && val.ends_with("-duo-cli") {
-        return Some(Agent::GitLabDuoCli);
-    }
-    Some(
-        match_agent_name(&val)
-            .or_else(|| match_agent_name_prefix(&val))
-            .unwrap_or(Agent::Unknown),
-    )
+    Some(match_normalized_value(&val).unwrap_or(Agent::Unknown))
 }
 
-/// Match a normalized `AI_AGENT` value whose leading segments name a known
+/// Match a normalized agent identifier whose leading segments name a known
 /// agent, tolerating trailing decorations that embed a version without the
 /// `@` separator — Claude Code desktop sets e.g. `claude-code_2-1-202_agent`.
 /// Segments are dropped from the end one at a time, so the longest matching
@@ -350,7 +375,7 @@ fn match_agent_name_prefix(val: &str) -> Option<Agent> {
 /// values counts as an agent signal — anything else is ignored (returns `None`)
 /// rather than reported as `Agent::Unknown`, to avoid false positives.
 fn parse_agent_var(lookup: &impl Fn(&str) -> Option<OsString>) -> Option<Agent> {
-    match normalize_agent_value(&lookup(AGENT.name())?.to_string_lossy()).as_str() {
+    match normalize_agent_value(&lookup(AGENT)?.to_string_lossy()).as_str() {
         "goose" => Some(Agent::Goose),
         "amp" => Some(Agent::Amp),
         "crush" => Some(Agent::Crush),

--- a/crates/but/src/utils/detect_agent/tests.rs
+++ b/crates/but/src/utils/detect_agent/tests.rs
@@ -324,7 +324,7 @@ fn ai_agent_accepts_known_aliases() {
             detect_with(env_from(&[("AI_AGENT", name)])),
             Some(agent),
             "AI_AGENT alias {name} should resolve to {}",
-            agent.name(),
+            agent.as_str(),
         );
     }
 }
@@ -357,7 +357,7 @@ fn ai_agent_matches_known_prefix_with_trailing_decorations() {
             detect_with(env_from(&[("AI_AGENT", value)])),
             Some(expected),
             "AI_AGENT={value} should prefix-match {}",
-            expected.name(),
+            expected.as_str(),
         );
     }
 }
@@ -376,7 +376,7 @@ fn ai_agent_strips_version_suffix() {
             detect_with(env_from(&[("AI_AGENT", value)])),
             Some(expected),
             "AI_AGENT={value} should strip the version and resolve to {}",
-            expected.name(),
+            expected.as_str(),
         );
     }
 }
@@ -519,7 +519,7 @@ fn detect_new_invocation_specific_markers() {
             detect_with(env_from(&[(var, value)])),
             Some(expected),
             "{var} should detect {}",
-            expected.name(),
+            expected.as_str(),
         );
     }
 }
@@ -679,12 +679,88 @@ fn agent_name_roundtrip() {
         Agent::Unknown,
     ];
     for agent in agents {
-        let lookup = env_from(&[("AI_AGENT", agent.name())]);
+        // Completeness guard: this wildcard-free match stops compiling when a
+        // variant is added to `Agent`, forcing whoever adds one to revisit
+        // this test — and, by proximity, the `agents` list above.
+        match agent {
+            Agent::ClaudeCode
+            | Agent::ClaudeCodeCowork
+            | Agent::Cursor
+            | Agent::CursorCli
+            | Agent::Codex
+            | Agent::KiroCli
+            | Agent::Junie
+            | Agent::QwenCode
+            | Agent::GitLabDuoCli
+            | Agent::KiloCode
+            | Agent::Hermes
+            | Agent::Devin
+            | Agent::Dirac
+            | Agent::GeminiCli
+            | Agent::GitHubCopilot
+            | Agent::OpenCode
+            | Agent::Poolside
+            | Agent::Augment
+            | Agent::Antigravity
+            | Agent::Replit
+            | Agent::V0
+            | Agent::Crush
+            | Agent::PulumiNeo
+            | Agent::Goose
+            | Agent::Amp
+            | Agent::Cline
+            | Agent::RooCode
+            | Agent::Trae
+            | Agent::TabnineCli
+            | Agent::Pi
+            | Agent::AmazonQ
+            | Agent::CodeBuddy
+            | Agent::GrokBuild
+            | Agent::Warp
+            | Agent::OpenHands
+            | Agent::OpenClaw
+            | Agent::Unknown => {}
+        }
+        let lookup = env_from(&[("AI_AGENT", agent.as_str())]);
         assert_eq!(
             detect_with(lookup),
             Some(agent),
             "roundtrip failed for {}",
-            agent.name()
+            agent.as_str()
         );
+    }
+}
+
+#[test]
+fn from_str_accepts_aliases_and_normalizes() {
+    for (value, expected) in [
+        ("claude-code", Agent::ClaudeCode),
+        ("claude", Agent::ClaudeCode),
+        ("Claude_Code", Agent::ClaudeCode),
+        ("claude-code@2", Agent::ClaudeCode),
+        ("gemini", Agent::GeminiCli),
+    ] {
+        assert_eq!(value.parse(), Ok(expected), "{value:?} should parse");
+    }
+}
+
+#[test]
+fn from_str_matches_detection_leniency() {
+    // The public parse accepts everything the `AI_AGENT` detection path
+    // accepts, including decorated values.
+    for (value, expected) in [
+        ("claude-code_2-1-202_agent", Agent::ClaudeCode),
+        ("gitlab-lsp_7.17.0__duo-cli", Agent::GitLabDuoCli),
+    ] {
+        assert_eq!(value.parse(), Ok(expected), "{value:?} should parse");
+    }
+}
+
+#[test]
+fn from_str_rejects_unknown_names() {
+    // A strict parse: unknown values error instead of resolving to
+    // `Agent::Unknown` the way `AI_AGENT` detection does.
+    for value in ["some-new-agent", "unknown", ""] {
+        assert_eq!(value.parse::<Agent>(), Err(ParseAgentError));
     }
 }

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -615,7 +615,7 @@ impl Event {
         event.insert_prop("$os", Event::normalize_os(env::consts::OS));
         event.insert_prop("Arch", env::consts::ARCH);
         if let Some(agent) = super::detect_agent::detect() {
-            event.insert_prop("agent", agent.name());
+            event.insert_prop("agent", agent.as_str());
         }
         event.clone()
     }


### PR DESCRIPTION
Prepares `detect_agent` for eventual extraction as a standalone, dependency-free crate:

- Replace the `Variable` newtype with plain `&'static str` consts — it added ceremony without type-safety value.
- Rename `Agent::name()` to the conventional `as_str()`.
- Add `impl FromStr for Agent` as the single canonical parser: normalization, known aliases, version-decorated prefixes, and the GitLab Duo decoration all live there, so the public parse contract agrees exactly with what `AI_AGENT` detection accepts. Unrecognized values return a dedicated `ParseAgentError` instead of falling back to `Agent::Unknown` (that policy stays private to detection).
- Make `detect_with` public so embedders and tests can inject an env snapshot.
- Mark `Agent` `#[non_exhaustive]` so adding agents stays semver-compatible. (`ParseAgentError` is deliberately not, so it remains constructible downstream.)

Detection behavior is unchanged. The roundtrip test carries a wildcard-free match over all variants, so adding an agent without revisiting the name/alias coverage is a compile error in the test.