### PR TITLE
fix(desktop): prevent double unapply dispatch and stale lane

### DIFF
--- a/apps/desktop/src/components/branch/BranchHeaderContextMenu.svelte
+++ b/apps/desktop/src/components/branch/BranchHeaderContextMenu.svelte
@@ -375,11 +375,8 @@
 					disabled={isReadOnly || !isOpenWorkspace}
 					caption={!isOpenWorkspace ? "Only available in workspace mode" : undefined}
 					onclick={async () => {
-						try {
-							await stackService.unapply({ projectId, stackId });
-						} finally {
-							close();
-						}
+						close();
+						await stackService.unapply({ projectId, stackId });
 					}}
 				/>
 			</ContextMenuSection>

--- a/apps/desktop/src/lib/stacks/stackEndpoints.ts
+++ b/apps/desktop/src/lib/stacks/stackEndpoints.ts
@@ -684,6 +684,7 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 				invalidatesList(ReduxTag.WorktreeChanges),
 				invalidatesList(ReduxTag.HeadSha),
 				invalidatesList(ReduxTag.BranchListing),
+				invalidatesList(ReduxTag.Stacks),
 			],
 		}),
 		updateBranchName: build.mutation<


### PR DESCRIPTION
## Problem

Unapplying a stack could produce a confusing `branch with ID ... not found` error even though the unapply itself succeeded.

Two UI issues combined to cause this:

1. **The branch header context menu stayed open while the unapply ran.** The click handler only closed the menu after the mutation resolved, and unapply takes over a second (oplog snapshot + checkout). During that window the menu sat frozen with "Unapply Stack" still clickable — a second click dispatched `unapply_stack` again for the same stack.
2. **The lane didn't disappear after a successful unapply.** The `unapply` mutation never invalidated the `Stacks` tag, so the workspace query wasn't refetched and the unapplied lane lingered on screen until the file watcher happened to refresh it. Every other workspace-shape mutation (`apply`, `branch_remove`, `move_branch`, `tear_off_branch`, ...) already invalidates this tag — `unapply_stack` was the one exception.

The second dispatch raced in while the first was still running; the first one deleted the stack, and the second failed with `BranchNotFound`, surfacing as an error toast.

## Fix

- Close the context menu before dispatching the unapply, so there is no frozen-open menu to click twice.
- Add `invalidatesList(ReduxTag.Stacks)` to the `unapply` mutation, so the lane is removed through normal query invalidation like every sibling mutation.