### PR TITLE
Moving after a mark can follow upwards as well as downwards

### DIFF
--- a/crates/but/src/command/legacy/status/tui/app/mark.rs
+++ b/crates/but/src/command/legacy/status/tui/app/mark.rs
@@ -583,7 +583,7 @@ impl App {
                     selection,
                     self.mode
                         .get_mut_without_updating_backstack_and_i_promise_not_to_change_state(),
-                )? && let Some(new_cursor) = self.cursor.move_down_within_section(
+                )? && let Some(new_cursor) = self.cursor.move_after_mark(
                     &self.status_lines,
                     &self.mode,
                     self.flags.show_files,

--- a/crates/but/src/command/legacy/status/tui/cursor/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/cursor/mod.rs
@@ -12,7 +12,7 @@ use crate::{
             Mode, NormalMode, PickChangesMode, SelectAfterReload,
             app::{
                 CommitSource,
-                mark::{Marks, MarksRef},
+                mark::{MarkableRef, Marks, MarksRef},
                 prefix_match,
             },
             mode::ModeRef,
@@ -507,6 +507,32 @@ impl Cursor {
             .take(next_section_start.saturating_sub(self.0 + 1))
             .find(|(idx, _)| is_cursor_selectable_at_index(*idx, lines, mode, show_files))?;
         Some(Self(idx))
+    }
+
+    #[must_use]
+    pub fn move_after_mark(
+        self,
+        lines: &[StatusOutputLine],
+        mode: &Mode,
+        show_files: FilesStatusFlag,
+    ) -> Option<Self> {
+        let mark_state = |cursor: Self| {
+            cursor
+                .selected_line(lines)
+                .and_then(|line| line.data.cli_id())
+                .and_then(|id| {
+                    MarkableRef::try_from_cli_id(id).map(|_| mode.marks_ref().contains_cli_id(id))
+                })
+        };
+        let current_is_marked = mark_state(self)?;
+        let is_opposite = |cursor| mark_state(cursor) == Some(!current_is_marked);
+
+        self.move_down_within_section(lines, mode, show_files)
+            .filter(|next| is_opposite(*next))
+            .or_else(|| {
+                self.move_up(lines, mode, show_files)
+                    .filter(|previous| is_opposite(*previous))
+            })
     }
 
     /// Moves the cursor to the first selectable row in the next section.

--- a/crates/but/src/command/legacy/status/tui/tests/marking_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/marking_tests.rs
@@ -71,6 +71,62 @@ fn marking_uncommitted_toggles_all_uncommitted_files() {
 }
 
 #[test]
+fn marking_middle_row_uses_neighbor_states() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.file("a.txt", "content");
+    env.file("b.txt", "content");
+    env.file("c.txt", "content");
+
+    let mut tui = test_tui(env);
+
+    tui.reload();
+    tui.input([KeyCode::Down, KeyCode::Down]);
+
+    // Opposite to both neighbors: move down.
+    tui.input(' ').assert_current_line_eq(str!["[..]c.txt"]);
+
+    tui.input([KeyCode::Up, KeyCode::Up]);
+    tui.input(' ').assert_current_line_eq(str!["[..]a.txt"]);
+    tui.input(KeyCode::Down);
+
+    // Same as the next neighbor: move to the previous one.
+    tui.input(' ').assert_current_line_eq(str!["[..]a.txt"]);
+
+    tui.input([KeyCode::Down, KeyCode::Down]);
+    tui.input(' ').assert_current_line_eq(str!["[..]b.txt"]);
+
+    // Same as both neighbors: stay put.
+    tui.input(' ').assert_current_line_eq(str!["[..]b.txt"]);
+
+    tui.input(KeyCode::Up);
+    tui.input(' ').assert_current_line_eq(str!["[..]b.txt"]);
+
+    // Same as the previous neighbor: move to the next one.
+    tui.input(' ').assert_current_line_eq(str!["[..]c.txt"]);
+}
+
+#[test]
+fn marking_section_edge_moves_only_when_neighbor_differs() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
+
+    let mut tui = test_tui(env);
+
+    tui.input('b');
+    for message in ["one", "two"] {
+        tui.input('n');
+        tui.input(KeyCode::Enter);
+        tui.input(message);
+        tui.input(KeyCode::Enter);
+    }
+
+    tui.input(' ').assert_current_line_eq(str!["[..]one[..]"]);
+    tui.input(' ').assert_current_line_eq(str!["[..]one[..]"]);
+    tui.input(' ').assert_current_line_eq(str!["[..]two[..]"]);
+    tui.input(' ').assert_current_line_eq(str!["[..]two[..]"]);
+}
+
+#[test]
 fn multi_squash_marked_commits_into_selected_marked_target() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
     env.setup_metadata(&["A", "B"]);


### PR DESCRIPTION


https://github.com/user-attachments/assets/c03115fb-40c1-4daf-9276-cfdd8d39a080



The following logic is now applied:

If I'm at a segment edge:

- If the only row above/below is now in the opposite state, we move the cursor there
- If the only other row is now the same state, we don't move.

If I'm in the middle:

- If the cursor's row as turned into the same state as it's neighbours, it remains the same.
- If the cursor's row has turned into the opposite state as BOTH it's neighbours, it goes down
- If the cursor's row has turned into the same as one of it's neighbours, it goes to the other neighbour