### PR TITLE
performance(but): avoid rebuilding entire IdMap to get change ID

### DIFF
--- a/crates/but/src/command/commit/move.rs
+++ b/crates/but/src/command/commit/move.rs
@@ -186,6 +186,16 @@ pub fn move_commit_to_commit_with_perm(
         return Ok(());
     }
 
+    let (source_change_ids, target_change_id) = {
+        let repo = ctx.repo.get()?;
+        let source_change_ids = sources
+            .iter()
+            .map(|id| crate::utils::get_change_id_for_commit(&repo, *id))
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        let target_change_id = crate::utils::get_change_id_for_commit(&repo, target)?;
+        (source_change_ids, target_change_id)
+    };
+
     let result = but_api::commit::move_commit::commit_move_with_perm(
         ctx,
         sources.clone(),
@@ -199,24 +209,23 @@ pub fn move_commit_to_commit_with_perm(
     if let Some(out) = out.for_human() {
         let action = if after { "after" } else { "before" };
         if sources.len() == 1 {
-            let refs = theme::new_commit_refs_with_perm(
-                ctx,
-                perm.read_permission(),
-                &[
-                    post_move_id(&result.workspace, sources[0]),
-                    post_move_id(&result.workspace, target),
-                ],
-            )?;
-            writeln!(out, "Moved {} → {action} {}", refs[0], refs[1])?;
-        } else {
-            let target_ref = theme::new_commit_ref_with_perm(
-                ctx,
-                perm.read_permission(),
+            let source = theme::Commit(
+                post_move_id(&result.workspace, sources[0]),
+                Some(source_change_ids[0].clone()),
+            );
+            let target = theme::Commit(
                 post_move_id(&result.workspace, target),
-            )?;
+                Some(target_change_id),
+            );
+            writeln!(out, "Moved {source} → {action} {target}")?;
+        } else {
+            let target = theme::Commit(
+                post_move_id(&result.workspace, target),
+                Some(target_change_id),
+            );
             writeln!(
                 out,
-                "Moved {} commits → {action} {target_ref}",
+                "Moved {} commits → {action} {target}",
                 t.cli_id.paint(sources.len().to_string()),
             )?;
         }
@@ -240,6 +249,12 @@ pub fn move_commit_to_branch_with_perm(
     perm: &mut RepoExclusive,
 ) -> Result<(), anyhow::Error> {
     let target_full_name = gix::refs::FullName::try_from(format!("refs/heads/{target_branch}"))?;
+    let source_change_id = if sources.len() == 1 {
+        let repo = ctx.repo.get()?;
+        Some(crate::utils::get_change_id_for_commit(&repo, sources[0])?)
+    } else {
+        None
+    };
     let result = but_api::commit::move_commit::commit_move_with_perm(
         ctx,
         sources.clone(),
@@ -252,15 +267,14 @@ pub fn move_commit_to_branch_with_perm(
     let t = theme::get();
     if let Some(out) = out.for_human() {
         if sources.len() == 1 {
-            let source_ref = theme::new_commit_ref_with_perm(
-                ctx,
-                perm.read_permission(),
+            let source = theme::Commit(
                 post_move_id(&result.workspace, sources[0]),
-            )?;
+                source_change_id,
+            );
             writeln!(
                 out,
                 "Moved {} → {}",
-                source_ref,
+                source,
                 t.local_branch.paint(format!("[{target_branch}]"))
             )?;
         } else {

--- a/crates/but/src/command/legacy/absorb.rs
+++ b/crates/but/src/command/legacy/absorb.rs
@@ -1,5 +1,5 @@
 use crate::theme::{self, Paint};
-use but_core::{RepositoryExt, sync::RepoExclusive};
+use but_core::sync::RepoExclusive;
 use but_ctx::Context;
 use but_hunk_assignment::{
     AbsorptionTarget, CommitAbsorption, HunkAssignment, JsonAbsorbOutput, JsonCommitAbsorption,
@@ -100,10 +100,7 @@ pub(crate) fn handle(
     // Display the plan (in JSON mode for non-dry-run, collect without writing — we'll
     // combine it with the result in absorb_assignments to avoid a double-write that
     // would overwrite the plan in the JSON buffer).
-    let plan_json = {
-        let repo = ctx.repo.get()?.clone().for_commit_shortening();
-        display_absorption_plan(&absorption_plan, &id_map, &repo, out, dry_run)?
-    };
+    let plan_json = display_absorption_plan(&absorption_plan, &id_map, out, dry_run)?;
 
     if dry_run {
         // Nothing more to do
@@ -218,7 +215,6 @@ fn get_hunk_ranges(assignment: &HunkAssignment) -> Vec<String> {
 fn display_absorption_plan(
     commit_absorptions: &[CommitAbsorption],
     id_map: &IdMap,
-    repo: &gix::Repository,
     out: &mut OutputChannel,
     write_json: bool,
 ) -> anyhow::Result<Option<JsonAbsorbOutput>> {
@@ -293,7 +289,12 @@ fn display_absorption_plan(
             writeln!(
                 out,
                 "Absorbed to commit: {} {}",
-                theme::CommitRef(id_map, repo, absorption.commit_id),
+                theme::Commit(
+                    absorption.commit_id,
+                    id_map
+                        .change_id_ref(absorption.commit_id)
+                        .map(|change_id| change_id.change_id.clone()),
+                ),
                 absorption.commit_summary
             )?;
             writeln!(out, "  ({})", t.hint.paint(absorption.reason.description()))?;

--- a/crates/but/src/command/legacy/branch/show.rs
+++ b/crates/but/src/command/legacy/branch/show.rs
@@ -9,7 +9,7 @@ use crate::{
     args::atoms::{BranchArg, CliIdArg},
     command::legacy::workspace_target,
     theme::{self, Paint},
-    utils::{OutputChannel, shorten_object_id},
+    utils::{OutputChannel, get_change_id_for_commit, shorten_object_id},
 };
 
 pub fn show(
@@ -107,6 +107,10 @@ struct ConflictingFile {
 
 #[derive(Debug, serde::Serialize)]
 struct CommitRef {
+    #[serde(skip)]
+    object_id: gix::ObjectId,
+    #[serde(skip)]
+    change_id: but_core::ChangeId,
     sha: String,
     short_sha: String,
     /// The stable change-ID ref shown by `but status`, when the commit has one.
@@ -245,6 +249,11 @@ fn find_commits_modifying_file(
         if modified_file {
             let author = commit.author()?;
             commits.push(CommitRef {
+                object_id: info.id,
+                change_id: match id_map.change_id_ref(info.id).map(|c| c.change_id.clone()) {
+                    Some(id) => id,
+                    None => get_change_id_for_commit(repo, info.id)?,
+                },
                 sha: info.id.to_string(),
                 short_sha: shorten_object_id(repo, info.id),
                 cli_id: id_map
@@ -309,6 +318,11 @@ fn get_commits_ahead(
         };
 
         commits.push(CommitInfo {
+            object_id: info.id,
+            change_id: match id_map.change_id_ref(info.id).map(|c| c.change_id.clone()) {
+                Some(id) => id,
+                None => get_change_id_for_commit(&repo, info.id)?,
+            },
             sha: info.id.to_string(),
             short_sha: shorten_object_id(&repo, info.id),
             cli_id: id_map
@@ -369,6 +383,10 @@ fn get_uncommitted_files(ctx: &mut Context, branch_arg: &BranchArg) -> anyhow::R
 
 #[derive(Debug, serde::Serialize)]
 struct CommitInfo {
+    #[serde(skip)]
+    object_id: gix::ObjectId,
+    #[serde(skip)]
+    change_id: but_core::ChangeId,
     sha: String,
     short_sha: String,
     /// The stable change-ID ref shown by `but status`, when the commit has one.
@@ -526,7 +544,7 @@ fn output_human(
             writeln!(
                 buf,
                 "{} {}",
-                theme::commit_display_ref(commit.cli_id.as_deref(), &commit.short_sha),
+                theme::Commit(commit.object_id, Some(commit.change_id.clone())),
                 commit.message
             )?;
             writeln!(
@@ -689,7 +707,7 @@ fn output_human(
                         writeln!(
                             buf,
                             "      {} {}",
-                            theme::commit_display_ref(commit.cli_id.as_deref(), &commit.short_sha),
+                            theme::Commit(commit.object_id, Some(commit.change_id.clone())),
                             commit.message
                         )?;
                         writeln!(
@@ -709,7 +727,7 @@ fn output_human(
                         writeln!(
                             buf,
                             "      {} {}",
-                            theme::commit_display_ref(commit.cli_id.as_deref(), &commit.short_sha),
+                            theme::Commit(commit.object_id, Some(commit.change_id.clone())),
                             commit.message
                         )?;
                         writeln!(

--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -18,12 +18,14 @@ use crate::{
     CliId, CliResult, IdMap,
     args::atoms::{BranchArg, BranchOrCommit, CliIdArg, Priority, Purpose, ResolvedCliIdArg},
     bad_input,
-    command::legacy::commit_message_prep::normalize_commit_message,
-    command::legacy::status::assignment::{CLIHunkAssignment, FileAssignment},
+    command::legacy::{
+        commit_message_prep::normalize_commit_message,
+        status::assignment::{CLIHunkAssignment, FileAssignment},
+    },
     legacy::workspace::{HeadInfoBranch, HeadInfoStack},
     theme::{self, Paint},
     tui,
-    utils::{InputOutputChannel, OutputChannel, diff_specs, rejection},
+    utils::{InputOutputChannel, OutputChannel, diff_specs, get_change_id_for_commit, rejection},
 };
 
 type TargetStack = (StackId, HeadInfoStack);
@@ -717,7 +719,10 @@ pub(crate) fn commit(
 
     if let Some(out) = out.for_human() {
         let commit_ref = match outcome.new_commit {
-            Some(id) => theme::new_commit_ref_with_perm(ctx, guard.read_permission(), id)?,
+            Some(id) => {
+                let repo = ctx.repo.get()?;
+                theme::Commit(id, Some(get_change_id_for_commit(&repo, id)?)).to_string()
+            }
             None => t.commit_id.paint("unknown").to_string(),
         };
         writeln!(

--- a/crates/but/src/command/legacy/commit2.rs
+++ b/crates/but/src/command/legacy/commit2.rs
@@ -53,20 +53,21 @@ impl CliOutputHuman for CommitOutcome {
             branch_name,
         } = self;
 
+        // GB-1771 missing change ID here
         match branch_name {
             Some(BranchNameTarget::New(branch_name)) => writeln!(
                 out,
                 "Created commit {} on new branch {}",
-                theme::Commit(new_commit),
+                theme::Commit(new_commit, None),
                 theme::Branch(branch_name),
             )?,
             Some(BranchNameTarget::Existing(branch_name)) => writeln!(
                 out,
                 "Created commit {} on branch {}",
-                theme::Commit(new_commit),
+                theme::Commit(new_commit, None),
                 theme::Branch(branch_name),
             )?,
-            None => writeln!(out, "Created commit {}", theme::Commit(new_commit))?,
+            None => writeln!(out, "Created commit {}", theme::Commit(new_commit, None))?,
         }
 
         Ok(())

--- a/crates/but/src/command/legacy/move2.rs
+++ b/crates/but/src/command/legacy/move2.rs
@@ -50,6 +50,7 @@ pub enum MoveOutcome {
 
 impl CliOutputHuman for MoveOutcome {
     fn on_human(self, out: &mut dyn WriteWithUtils, _theme: &Theme) -> anyhow::Result<()> {
+        // GB-1771 missing change ID here
         match self {
             Self::Commits {
                 sources,
@@ -57,7 +58,10 @@ impl CliOutputHuman for MoveOutcome {
                 target,
                 new_branch_name,
             } => {
-                let sources = sources.into_iter().map(theme::Commit).join(", ");
+                let sources = sources
+                    .into_iter()
+                    .map(|id| theme::Commit(id, None))
+                    .join(", ");
                 write!(out, "Moved {sources}")?;
                 if let Some(new_branch_name) = new_branch_name {
                     write!(out, " to new branch {}", theme::Branch(new_branch_name))?;
@@ -78,8 +82,8 @@ impl CliOutputHuman for MoveOutcome {
                     out,
                     "Moved {} changes from {} to new commit {}",
                     num_changes,
-                    theme::Commit(source_commit_id),
-                    theme::Commit(new_commit_id),
+                    theme::Commit(source_commit_id, None),
+                    theme::Commit(new_commit_id, None),
                 )?;
 
                 if let Some(new_branch_name) = new_branch_name {
@@ -339,7 +343,8 @@ impl Display for MoveTarget {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Commit { commit_id, side } => {
-                write!(f, "{} commit {}", side, theme::Commit(*commit_id))
+                // GB-1771 missing change ID here
+                write!(f, "{} commit {}", side, theme::Commit(*commit_id, None))
             }
             Self::BranchTip { name } => {
                 write!(f, "to the tip of branch {}", theme::Branch(name))

--- a/crates/but/src/command/legacy/resolve.rs
+++ b/crates/but/src/command/legacy/resolve.rs
@@ -82,8 +82,13 @@ fn parse_commit_id(ctx: &mut Context, commit_id_str: &str) -> Result<(gix::Objec
     // Extract the commit OID from the matched CliId
     match &matches[0] {
         CliId::Commit { commit_id, .. } => {
-            let repo = ctx.repo.get()?;
-            let commit_ref = theme::CommitRef(&id_map, &repo, *commit_id).to_string();
+            let commit_ref = theme::Commit(
+                *commit_id,
+                id_map
+                    .change_id_ref(*commit_id)
+                    .map(|change_id| change_id.change_id.clone()),
+            )
+            .to_string();
             Ok((*commit_id, commit_ref))
         }
         _ => bail!("'{commit_id_str}' does not refer to a commit"),
@@ -652,7 +657,14 @@ fn resolve_one_with_ai(
     commit_oid: gix::ObjectId,
 ) -> Result<but_api::resolve::AiResolutionResult> {
     let t = theme::get();
-    let commit_ref = theme::new_commit_ref(ctx, commit_oid)?;
+    let commit_ref = {
+        let repo = ctx.repo.get()?;
+        theme::Commit(
+            commit_oid,
+            Some(crate::utils::get_change_id_for_commit(&repo, commit_oid)?),
+        )
+        .to_string()
+    };
     {
         let mut progress = out.progress_channel();
         writeln!(
@@ -674,7 +686,16 @@ fn resolve_one_with_ai(
             t.success.paint("✓ Resolved"),
             commit_ref,
             t.success.paint("→"),
-            theme::new_commit_ref(ctx, result.new_commit)?,
+            {
+                let repo = ctx.repo.get()?;
+                theme::Commit(
+                    result.new_commit,
+                    Some(crate::utils::get_change_id_for_commit(
+                        &repo,
+                        result.new_commit,
+                    )?),
+                )
+            },
         )?;
         if let Some(summary) = &result.summary {
             writeln!(human_out)?;

--- a/crates/but/src/command/legacy/reword.rs
+++ b/crates/but/src/command/legacy/reword.rs
@@ -13,7 +13,7 @@ use crate::{
     CliResult, IdMap,
     args::atoms::{BranchArg, BranchOrCommit, CliIdArg, Purpose},
     bad_input, tui,
-    utils::OutputChannel,
+    utils::{OutputChannel, get_change_id_for_commit},
 };
 
 pub(crate) fn reword_target(
@@ -209,6 +209,10 @@ fn edit_commit_message_by_id_and_reword_commit(
     .filter(|new_message| should_update_commit_message(&current_message, new_message));
 
     if let Some(new_message) = new_message {
+        let change_id = {
+            let repo = ctx.repo.get()?;
+            get_change_id_for_commit(&repo, commit_oid)?
+        };
         let new_commit_oid = but_api::commit::reword::commit_reword_with_perm(
             ctx,
             commit_oid,
@@ -218,11 +222,7 @@ fn edit_commit_message_by_id_and_reword_commit(
         )?;
 
         if let Some(out) = out.for_human() {
-            let new_commit = crate::theme::new_commit_ref_with_perm(
-                ctx,
-                perm.read_permission(),
-                new_commit_oid.new_commit,
-            )?;
+            let new_commit = crate::theme::Commit(new_commit_oid.new_commit, Some(change_id));
             writeln!(out, "Updated commit message for {new_commit}")?;
         } else if let Some(out) = out.for_json() {
             out.write_value(serde_json::json!({

--- a/crates/but/src/command/legacy/rub/amend.rs
+++ b/crates/but/src/command/legacy/rub/amend.rs
@@ -30,11 +30,17 @@ pub(crate) fn uncommitted_to_commit_with_perm(
         (builder.into_diff_specs(), target_branch)
     };
 
+    let change_id = {
+        let repo = ctx.repo.get()?;
+        crate::utils::get_change_id_for_commit(&repo, oid)?
+    };
     let (new_commit, rejected) =
         amend_diff_specs(ctx, diff_specs, oid, target_branch.as_deref(), perm)?;
     update_workspace_commit(ctx, false)?;
     if let Some(out) = out.for_human() {
-        let new_commit = theme::new_commit_ref_with_perm(ctx, perm.read_permission(), new_commit)?;
+        let new_commit = new_commit
+            .map(|id| theme::Commit(id, Some(change_id)).to_string())
+            .unwrap_or_default();
         writeln!(out, "Amended {description} → {new_commit}")?;
         rejection::write_rejection_report(out, &rejected, target_branch.as_deref())?;
     } else if let Some(out) = out.for_json() {

--- a/crates/but/src/command/legacy/rub/mod.rs
+++ b/crates/but/src/command/legacy/rub/mod.rs
@@ -288,7 +288,13 @@ impl<'a> UncommittedToCommitOperation<'a> {
     pub(crate) fn execute(self, ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Result<()> {
         let result = self.execute_inner(ctx)?;
         if let Some(out) = out.for_human() {
-            let new_commit = theme::new_commit_ref(ctx, result.new_commit)?;
+            let new_commit = if let Some(id) = result.new_commit {
+                let repo = ctx.repo.get()?;
+                theme::Commit(id, Some(crate::utils::get_change_id_for_commit(&repo, id)?))
+                    .to_string()
+            } else {
+                String::new()
+            };
             writeln!(out, "Amended {} → {new_commit}", self.description)?;
         } else if let Some(out) = out.for_json() {
             out.write_value(serde_json::json!({
@@ -455,7 +461,13 @@ impl StackToCommitOperation {
         let result = self.execute_inner(ctx)?;
         if let Some(out) = out.for_human() {
             let t = theme::get();
-            let new_commit = theme::new_commit_ref(ctx, result.new_commit)?;
+            let new_commit = if let Some(id) = result.new_commit {
+                let repo = ctx.repo.get()?;
+                theme::Commit(id, Some(crate::utils::get_change_id_for_commit(&repo, id)?))
+                    .to_string()
+            } else {
+                String::new()
+            };
             writeln!(
                 out,
                 "Amended files assigned to {} → {}",
@@ -485,7 +497,13 @@ impl UncommittedAreaToCommitOperation {
     pub(crate) fn execute(self, ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Result<()> {
         let result = self.execute_inner(ctx)?;
         if let Some(out) = out.for_human() {
-            let new_commit = theme::new_commit_ref(ctx, result.new_commit)?;
+            let new_commit = if let Some(id) = result.new_commit {
+                let repo = ctx.repo.get()?;
+                theme::Commit(id, Some(crate::utils::get_change_id_for_commit(&repo, id)?))
+                    .to_string()
+            } else {
+                String::new()
+            };
             writeln!(out, "Amended uncommitted files → {new_commit}")?;
         } else if let Some(out) = out.for_json() {
             out.write_value(serde_json::json!({
@@ -564,12 +582,17 @@ impl CommitToUncommittedAreaOperation {
     ) -> anyhow::Result<()> {
         self.execute_inner(ctx)?;
         if let Some(out) = out.for_human() {
-            let repo = ctx.repo.get()?;
             if self.commits.len() == 1 {
+                let commit_id = *self.commits.first();
                 writeln!(
                     out,
                     "Uncommitted {}",
-                    theme::CommitRef(id_map, &repo, *self.commits.first())
+                    theme::Commit(
+                        commit_id,
+                        id_map
+                            .change_id_ref(commit_id)
+                            .map(|change_id| change_id.change_id.clone()),
+                    )
                 )?;
             } else {
                 writeln!(out, "Uncommitted {} commits", self.commits.len())?;
@@ -602,11 +625,15 @@ impl CommitToStackOperation {
         self.execute_inner(ctx)?;
         if let Some(out) = out.for_human() {
             let t = theme::get();
-            let repo = ctx.repo.get()?;
             writeln!(
                 out,
                 "Uncommitted {} to {}",
-                theme::CommitRef(id_map, &repo, self.oid),
+                theme::Commit(
+                    self.oid,
+                    id_map
+                        .change_id_ref(self.oid)
+                        .map(|change_id| change_id.change_id.clone()),
+                ),
                 stack_id_to_branch_name(ctx, self.stack)
                     .map(|b| t.local_branch.paint(format!("[{b}]")))
                     .unwrap_or_else(|| t.important.paint("stack")),
@@ -638,13 +665,19 @@ impl SquashCommitsOperation {
     ) -> anyhow::Result<()> {
         let result = self.execute_inner(ctx)?;
         if let Some(out) = out.for_human() {
-            let repo = ctx.repo.get()?;
-            let new_commit = theme::new_commit_ref(ctx, result.new_commit)?;
+            let source_id = *self.sources.first();
+            let source_change_id = id_map
+                .change_id_ref(source_id)
+                .map(|change_id| change_id.change_id.clone());
+            let target_change_id = id_map
+                .change_id_ref(self.destination)
+                .map(|change_id| change_id.change_id.clone());
+            let new_commit = theme::Commit(result.new_commit, target_change_id);
             if self.sources.len() == 1 {
                 writeln!(
                     out,
                     "Squashed {} → {}",
-                    theme::CommitRef(id_map, &repo, *self.sources.first()),
+                    theme::Commit(source_id, source_change_id),
                     new_commit,
                 )?;
             } else {
@@ -688,11 +721,15 @@ impl<'a> MoveCommitToBranchOperation<'a> {
         self.execute_inner(ctx)?;
         if let Some(out) = out.for_human() {
             let t = theme::get();
-            let repo = ctx.repo.get()?;
             writeln!(
                 out,
                 "Moved {} → {}",
-                theme::CommitRef(id_map, &repo, self.oid),
+                theme::Commit(
+                    self.oid,
+                    id_map
+                        .change_id_ref(self.oid)
+                        .map(|change_id| change_id.change_id.clone()),
+                ),
                 t.local_branch.paint(format!("[{}]", self.name))
             )?;
         } else if let Some(out) = out.for_json() {
@@ -771,7 +808,13 @@ impl<'a> BranchToCommitOperation<'a> {
         let result = self.execute_inner(ctx)?;
         if let Some(out) = out.for_human() {
             let t = theme::get();
-            let new_commit = theme::new_commit_ref(ctx, result.new_commit)?;
+            let new_commit = if let Some(id) = result.new_commit {
+                let repo = ctx.repo.get()?;
+                theme::Commit(id, Some(crate::utils::get_change_id_for_commit(&repo, id)?))
+                    .to_string()
+            } else {
+                String::new()
+            };
             writeln!(
                 out,
                 "Amended assigned files {} → {}",
@@ -1498,11 +1541,15 @@ pub(crate) fn handle_uncommit(
                     but_api::commit::discard_commit::commit_discard(ctx, commit_id, DryRun::No)?;
 
                     if !json_mode && let Some(out) = out.for_human() {
-                        let repo = ctx.repo.get()?;
                         writeln!(
                             out,
                             "Discarded {}",
-                            theme::CommitRef(&id_map, &repo, commit_id)
+                            theme::Commit(
+                                commit_id,
+                                id_map
+                                    .change_id_ref(commit_id)
+                                    .map(|change_id| change_id.change_id.clone()),
+                            )
                         )?;
                     }
                 }
@@ -1633,12 +1680,16 @@ fn uncommit_committed_files(
     if !result.failures.is_empty()
         && let Some(out) = out.for_human()
     {
-        let repo = ctx.repo.get()?;
         for failure in &result.failures {
             writeln!(
                 out,
                 "Warning: could not uncommit changes from {}: {}",
-                theme::CommitRef(id_map, &repo, failure.commit_id),
+                theme::Commit(
+                    failure.commit_id,
+                    id_map
+                        .change_id_ref(failure.commit_id)
+                        .map(|change_id| change_id.change_id.clone()),
+                ),
                 failure.error
             )?;
         }

--- a/crates/but/src/command/legacy/rub/squash.rs
+++ b/crates/but/src/command/legacy/rub/squash.rs
@@ -255,6 +255,9 @@ fn squash_commits_internal(
     let snapshot = ctx.create_snapshot(SnapshotDetails::new(OperationKind::SquashCommit), perm)?;
     let source_oids_count = source_oids.len();
     let only_source_commit = source_oids.first().copied();
+    let target_change_id = id_map
+        .change_id_ref(target_oid)
+        .map(|change_id| change_id.change_id.clone());
     let source_oids_to_squash = source_oids;
 
     let squash_result: anyhow::Result<ObjectId> = (|| {
@@ -327,19 +330,19 @@ fn squash_commits_internal(
 
     // Output message based on context
     if let Some(out) = out.for_human() {
-        let repo = ctx.repo.get()?;
-        let new_commit =
-            theme::new_commit_ref_with_perm(ctx, perm.read_permission(), final_commit_oid)?;
+        let new_commit = theme::Commit(final_commit_oid, target_change_id);
         if source_oids_count == 1 {
             // Single commit squash (for backwards compatibility with `but rub`)
+            let source = only_source_commit
+                .context("BUG: Source commits count is one, but first item is none")?;
             writeln!(
                 out,
                 "Squashed {} → {}",
-                theme::CommitRef(
-                    id_map,
-                    &repo,
-                    only_source_commit
-                        .context("BUG: Source commits count is one, but first item is none")?
+                theme::Commit(
+                    source,
+                    id_map
+                        .change_id_ref(source)
+                        .map(|change_id| change_id.change_id.clone()),
                 ),
                 new_commit
             )?

--- a/crates/but/src/command/legacy/show.rs
+++ b/crates/but/src/command/legacy/show.rs
@@ -7,7 +7,9 @@ use but_ctx::access::RepoShared;
 use crate::{
     CLI_DATE, CliId, IdMap,
     theme::{self, Paint},
-    utils::{OutputChannel, shorten_object_id, time::format_relative_time},
+    utils::{
+        OutputChannel, get_change_id_for_commit, shorten_object_id, time::format_relative_time,
+    },
 };
 
 pub(crate) fn show_commit(
@@ -428,6 +430,10 @@ fn show_branch(
 
 #[derive(Debug, serde::Serialize)]
 struct BranchCommitInfo {
+    #[serde(skip)]
+    object_id: gix::ObjectId,
+    #[serde(skip)]
+    change_id: but_core::ChangeId,
     sha: String,
     short_sha: String,
     /// The stable change-ID ref shown by `but status`, when the commit has one.
@@ -447,7 +453,7 @@ impl BranchCommitInfo {
     /// The commit ref for display: the stable change-ID ref when the commit
     /// has one, its short sha otherwise.
     fn display_ref(&self) -> String {
-        theme::commit_display_ref(self.cli_id.as_deref(), &self.short_sha)
+        theme::Commit(self.object_id, Some(self.change_id.clone())).to_string()
     }
 }
 
@@ -546,6 +552,11 @@ fn get_branch_commits(
         };
 
         commits.push(BranchCommitInfo {
+            object_id: info.id,
+            change_id: match id_map.change_id_ref(info.id).map(|c| c.change_id.clone()) {
+                Some(id) => id,
+                None => get_change_id_for_commit(&repo, info.id)?,
+            },
             sha: info.id.to_string(),
             short_sha: shorten_object_id(&repo, info.id),
             cli_id: cli_id_for(info.id),
@@ -569,6 +580,8 @@ fn get_branch_commits(
         let base_message = super::commit_summary(&base_commit);
 
         Some(BranchCommitInfo {
+            object_id: merge_base,
+            change_id: crate::utils::get_change_id_for_commit(&repo, merge_base)?,
             sha: merge_base.to_string(),
             short_sha: shorten_object_id(&repo, merge_base),
             cli_id: None,

--- a/crates/but/src/command/legacy/squash2.rs
+++ b/crates/but/src/command/legacy/squash2.rs
@@ -51,20 +51,24 @@ pub enum SquashOutcome {
 
 impl CliOutputHuman for SquashOutcome {
     fn on_human(self, out: &mut dyn WriteWithUtils, _theme: &Theme) -> anyhow::Result<()> {
+        // GB-1771 missing change ID here
         match self {
             SquashOutcome::Commits {
                 sources,
                 target,
                 new_commit,
             } => {
-                let sources = sources.into_iter().map(theme::Commit).join(", ");
+                let sources = sources
+                    .into_iter()
+                    .map(|id| theme::Commit(id, None))
+                    .join(", ");
 
                 writeln!(
                     out,
                     "Squashed {} into {} to create {}",
                     sources,
-                    theme::Commit(target),
-                    theme::Commit(new_commit)
+                    theme::Commit(target, None),
+                    theme::Commit(new_commit, None)
                 )?;
             }
             SquashOutcome::Branch {
@@ -76,7 +80,7 @@ impl CliOutputHuman for SquashOutcome {
                         out,
                         "Squashed branch {} to create commit {}",
                         theme::Branch(&branch_names[0]),
-                        theme::Commit(new_commit)
+                        theme::Commit(new_commit, None)
                     )?;
                 } else {
                     let branch_names = branch_names.into_iter().map(theme::Branch).join(", ");
@@ -84,7 +88,7 @@ impl CliOutputHuman for SquashOutcome {
                         out,
                         "Squashed branches {} to create commit {}",
                         branch_names,
-                        theme::Commit(new_commit)
+                        theme::Commit(new_commit, None)
                     )?;
                 }
             }
@@ -92,16 +96,19 @@ impl CliOutputHuman for SquashOutcome {
                 writeln!(
                     out,
                     "Amended {} to create {}",
-                    theme::Commit(target),
-                    theme::Commit(new_commit)
+                    theme::Commit(target, None),
+                    theme::Commit(new_commit, None)
                 )?;
             }
             SquashOutcome::Uncommit { sources } => {
-                let commits = sources.into_iter().map(theme::Commit).join(", ");
+                let commits = sources
+                    .into_iter()
+                    .map(|id| theme::Commit(id, None))
+                    .join(", ");
                 writeln!(out, "Uncommitted {commits}")?;
             }
             SquashOutcome::UncommitHunk { source } => {
-                writeln!(out, "Uncommitted from {}", theme::Commit(source))?;
+                writeln!(out, "Uncommitted from {}", theme::Commit(source, None))?;
             }
         };
 

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -23,6 +23,8 @@ use crate::id::{
     file_info::FileInfo, id_usage::UintId, stacks_info::StacksInfo,
     uncommitted_info::UncommittedInfo,
 };
+use crate::theme;
+use crate::utils::get_change_id_for_commit;
 
 mod file_info;
 mod id_usage;
@@ -276,10 +278,6 @@ pub struct ChangeIdWithShortId {
     pub short_id: ShortId,
 }
 
-/// The minimum number of change ID characters displayed for a commit, so that
-/// short IDs remain visually distinctive.
-pub(crate) const MIN_DISPLAYED_CHANGE_ID_CHARS: usize = 3;
-
 impl ChangeIdWithShortId {
     /// The short ID padded with further change ID characters to
     /// [`MIN_DISPLAYED_CHANGE_ID_CHARS`], matching how the change ID is
@@ -287,7 +285,9 @@ impl ChangeIdWithShortId {
     pub fn padded_short_id(&self) -> String {
         let mut id = self.short_id.clone();
         let full = self.change_id.to_string();
-        if let Some(padding) = full.get(id.len()..MIN_DISPLAYED_CHANGE_ID_CHARS.min(full.len())) {
+        if let Some(padding) =
+            full.get(id.len()..theme::MIN_DISPLAYED_CHANGE_ID_CHARS.min(full.len()))
+        {
             id.push_str(padding);
         }
         id
@@ -864,15 +864,7 @@ impl IdMap {
         let commit_id_to_change_id = commit_ids
             .filter_map(|commit_id| {
                 let result = (|| {
-                    let commit = repo.find_commit(commit_id)?;
-                    let commit = commit.decode()?;
-                    let change_id = but_core::commit::Headers::try_from_commit_headers(|| {
-                        commit.extra_headers()
-                    })
-                    .and_then(|headers| headers.change_id)
-                    .unwrap_or_else(|| {
-                        but_core::commit::Headers::synthetic_change_id_from_commit_id(commit_id)
-                    });
+                    let change_id = get_change_id_for_commit(&repo, commit_id)?;
                     Ok::<(gix::ObjectId, ChangeId), anyhow::Error>((commit_id, change_id))
                 })();
 

--- a/crates/but/src/theme.rs
+++ b/crates/but/src/theme.rs
@@ -30,6 +30,7 @@
 use std::{fmt::Display, path::Path, str::FromStr, sync::OnceLock};
 
 use bstr::ByteSlice as _;
+use but_core::ChangeId;
 use colored::{ColoredString, Colorize as _};
 use gix::refs::FullName;
 use ratatui::{
@@ -44,6 +45,10 @@ const MONOKAI_THEME: &[u8] =
     include_bytes!("../assets/syntax-highlighting-themes/Monokai Extended.tmTheme");
 const MONOKAI_THEME_LIGHT: &[u8] =
     include_bytes!("../assets/syntax-highlighting-themes/Monokai Extended Light.tmTheme");
+
+/// The minimum number of change ID characters displayed for a commit, so that
+/// short IDs remain visually distinctive.
+pub(crate) const MIN_DISPLAYED_CHANGE_ID_CHARS: usize = 3;
 
 /// Global theme instance, initialized once at startup.
 static THEME: OnceLock<Theme> = OnceLock::new();
@@ -625,127 +630,25 @@ where
     }
 }
 
-pub struct Commit(pub gix::ObjectId);
+pub struct Commit(pub gix::ObjectId, pub Option<ChangeId>);
 
 impl Display for Commit {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let t = get();
-        write!(
-            f,
-            "{}",
-            t.commit_id.paint(self.0.to_hex_with_len(7).to_string())
-        )
-    }
-}
 
-/// A commit rendered the way `but status` identifies it: by its disambiguated
-/// short change ID, falling back to the short sha for commits without one.
-pub struct CommitRef<'a>(
-    pub &'a crate::IdMap,
-    pub &'a gix::Repository,
-    pub gix::ObjectId,
-);
-
-impl Display for CommitRef<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let CommitRef(id_map, repo, commit_id) = self;
-        let t = get();
-        match id_map.change_id_ref(*commit_id) {
-            Some(change_id) => {
-                // Like status: minimal unique prefix in the change-id style,
-                // the padding in the hint style.
-                let padded = change_id.padded_short_id();
-                let (id, hint) = padded.split_at(change_id.short_id.len());
-                write!(f, "{}{}", t.change_id.paint(id), t.hint.paint(hint))
-            }
-            None => write!(
+        if let Some(change_id) = &self.1 {
+            let s = change_id
+                .get(..MIN_DISPLAYED_CHANGE_ID_CHARS.min(change_id.len()))
+                .unwrap_or_default();
+            write!(f, "{}", t.change_id.paint(s.to_str_lossy()))
+        } else {
+            write!(
                 f,
                 "{}",
-                t.cli_id
-                    .paint(crate::utils::shorten_object_id(repo, *commit_id))
-            ),
+                t.commit_id.paint(self.0.to_hex_with_len(7).to_string())
+            )
         }
     }
-}
-
-/// Render a [`CommitRef`] for a commit that a mutation just created, resolved
-/// against a freshly built [`crate::IdMap`] so the ID matches what the next
-/// `but status` displays (see [`crate::IdMap::change_id_ref`] for why a stale
-/// map must not be used). Renders "no commit was created" (`None`) as the
-/// empty string.
-///
-/// Building the map is not free — it diffs the worktree and persists the
-/// reconciled hunk assignments — so render each created commit only once.
-pub fn new_commit_ref_with_perm(
-    ctx: &but_ctx::Context,
-    perm: &but_core::sync::RepoShared,
-    commit_id: impl Into<Option<gix::ObjectId>>,
-) -> anyhow::Result<String> {
-    let Some(commit_id) = commit_id.into() else {
-        return Ok(String::new());
-    };
-    let mut refs = new_commit_refs_with_perm(ctx, perm, &[commit_id])?;
-    Ok(refs.pop().expect("one ref per commit id"))
-}
-
-/// Paint a commit ref from precomputed parts: the stable change-ID ref when
-/// the commit has one, its short sha otherwise.
-pub fn commit_display_ref(cli_id: Option<&str>, short_sha: &str) -> String {
-    let t = get();
-    match cli_id {
-        Some(cli_id) => t.change_id.paint(cli_id).to_string(),
-        None => t.cli_id.paint(short_sha).to_string(),
-    }
-}
-
-/// Like [`new_commit_ref_with_perm`], for messages that mention several
-/// commits: all refs render from one freshly built [`crate::IdMap`].
-pub fn new_commit_refs_with_perm(
-    ctx: &but_ctx::Context,
-    perm: &but_core::sync::RepoShared,
-    commit_ids: &[gix::ObjectId],
-) -> anyhow::Result<Vec<String>> {
-    if commit_ids.is_empty() {
-        return Ok(Vec::new());
-    }
-    let repo = ctx.repo.get()?;
-    // The mutation has already succeeded when this renders its result, so a
-    // failure to build the map must not fail the command — an agent would
-    // retry a mutation that already happened. Degrade to the sha instead.
-    match crate::IdMap::new_from_context(ctx, None, perm) {
-        Ok(id_map) => Ok(commit_ids
-            .iter()
-            .map(|commit_id| CommitRef(&id_map, &repo, *commit_id).to_string())
-            .collect()),
-        Err(err) => {
-            tracing::warn!(
-                ?err,
-                "could not build an IdMap to identify the resulting commits"
-            );
-            Ok(commit_ids
-                .iter()
-                .map(|commit_id| {
-                    get()
-                        .cli_id
-                        .paint(crate::utils::shorten_object_id(&repo, *commit_id))
-                        .to_string()
-                })
-                .collect())
-        }
-    }
-}
-
-/// Like [`new_commit_ref_with_perm`], for callers that hold no worktree lock.
-///
-/// When several operations run in sequence, an earlier operation's commit may
-/// be rewritten by a later one, so render each ref right after its operation
-/// completes rather than from one map built at the end.
-pub fn new_commit_ref(
-    ctx: &but_ctx::Context,
-    commit_id: impl Into<Option<gix::ObjectId>>,
-) -> anyhow::Result<String> {
-    let guard = ctx.shared_worktree_access();
-    new_commit_ref_with_perm(ctx, guard.read_permission(), commit_id)
 }
 
 pub struct Branch<T>(pub T);

--- a/crates/but/src/utils/mod.rs
+++ b/crates/but/src/utils/mod.rs
@@ -8,7 +8,7 @@ pub use output_channel::{
 };
 
 mod object_id;
-pub use object_id::{shorten_hex_object_id, shorten_object_id};
+pub use object_id::{get_change_id_for_commit, shorten_hex_object_id, shorten_object_id};
 
 pub mod rejection;
 

--- a/crates/but/src/utils/object_id.rs
+++ b/crates/but/src/utils/object_id.rs
@@ -1,3 +1,4 @@
+use but_core::ChangeId;
 use gix::prelude::ObjectIdExt as _;
 
 /// Shorten a commit object id using repository disambiguation (`core.abbrev`), and return
@@ -13,4 +14,20 @@ pub fn shorten_hex_object_id(repo: &gix::Repository, hex: &str) -> String {
     gix::ObjectId::from_hex(hex.as_bytes())
         .map(|oid| shorten_object_id(repo, oid))
         .unwrap_or_else(|_| hex.to_owned())
+}
+
+/// Read commit's change ID or synthesize one based on the commit ID if none is available.
+pub fn get_change_id_for_commit(
+    repo: &gix::Repository,
+    commit_id: gix::ObjectId,
+) -> anyhow::Result<ChangeId> {
+    let commit = repo.find_commit(commit_id)?;
+    let commit = commit.decode()?;
+    Ok(
+        but_core::commit::Headers::try_from_commit_headers(|| commit.extra_headers())
+            .and_then(|headers| headers.change_id)
+            .unwrap_or_else(|| {
+                but_core::commit::Headers::synthetic_change_id_from_commit_id(commit_id)
+            }),
+    )
 }

--- a/crates/but/src/utils/rejection.rs
+++ b/crates/but/src/utils/rejection.rs
@@ -188,7 +188,8 @@ fn write_rejection_body<W: std::fmt::Write + ?Sized>(
         for dependency in &change.dependencies {
             let range = hunk_range_label(&dependency.hunk);
             for commit in &dependency.commits {
-                let id = theme::Commit(commit.commit_id);
+                // GB-1771 missing change ID here
+                let id = theme::Commit(commit.commit_id, None);
                 match &commit.branch {
                     Some(branch) => writeln!(
                         out,

--- a/crates/but/tests/but/command/absorb.rs
+++ b/crates/but/tests/but/command/absorb.rs
@@ -381,11 +381,11 @@ Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "mes
         .stdout_eq(snapbox::str![[r#"
 Found 1 changed file to absorb:
 
-Absorbed to commit: 1#1 partial change to a.txt 2
+Absorbed to commit: 1 partial change to a.txt 2
   (files locked to commit due to hunk range overlap)
     a.txt @1,4 +1,4
 
-Absorbed to commit: 1#0 partial change to a.txt 3
+Absorbed to commit: 1 partial change to a.txt 3
   (files locked to commit due to hunk range overlap)
     a.txt @6,4 +6,4
 

--- a/crates/but/tests/but/command/branch/show.rs
+++ b/crates/but/tests/but/command/branch/show.rs
@@ -79,7 +79,7 @@ Unapplied stack with branches 'A' from workspace
         .stdout_eq(snapbox::str![[r#"
 Branch: A (1 commits ahead)
 
-9477ae7 add A
+tpm add A
     2000-01-02 00:00:00 by author
     1 file changed, 1 insertion, 0 deletions
 
@@ -124,7 +124,7 @@ git checkout gitbutler/workspace
         .stdout_eq(snapbox::str![[r#"
 Branch: origin/remote-feature (1 commits ahead)
 
-ba02e5f Add remote feature
+uwy Add remote feature
     2000-01-02 00:00:00 by author
     0 files changed, 0 insertions, 0 deletions
 
@@ -136,7 +136,7 @@ ba02e5f Add remote feature
         .stdout_eq(snapbox::str![[r#"
 Branch: remote-feature (1 commits ahead)
 
-ba02e5f Add remote feature
+uwy Add remote feature
     2000-01-02 00:00:00 by author
     0 files changed, 0 insertions, 0 deletions
 

--- a/crates/but/tests/but/command/commit.rs
+++ b/crates/but/tests/but/command/commit.rs
@@ -1389,7 +1389,7 @@ fn commit_of_adjacent_insertion_to_independent_branch_names_the_dependency() -> 
         .success()
         .stdout_eq(str![[r#"
 Created new independent branch 'api'
-✓ Created commit 1#0 on branch api
+✓ Created commit 1 on branch api
 Note: 1 change could not be applied:
   M
     conflicts with commits on A (edits touch the same file)

--- a/crates/but/tests/but/command/move.rs
+++ b/crates/but/tests/but/command/move.rs
@@ -40,7 +40,7 @@ fn move_commit_before_another_commit() -> anyhow::Result<()> {
         .assert()
         .success()
         .stdout_eq(str![[r#"
-Moved 1#2 → before 1#1
+Moved 1 → before 1
 
 "#]]);
 
@@ -82,7 +82,7 @@ fn move_commit_after_another_commit() -> anyhow::Result<()> {
     .assert()
     .success()
     .stdout_eq(str![[r#"
-Moved 1#0 → after 1#1
+Moved 1 → after 1
 
 "#]]);
 
@@ -142,7 +142,7 @@ Hint: run `but help` for all commands
     .assert()
     .success()
     .stdout_eq(str![[r#"
-Moved 2 commits → before 1#0
+Moved 2 commits → before 1
 
 "#]]);
 
@@ -220,7 +220,7 @@ Hint: run `but help` for all commands
     .assert()
     .success()
     .stdout_eq(str![[r#"
-Moved 2 commits → after 1#2
+Moved 2 commits → after 1
 
 "#]]);
 
@@ -705,7 +705,7 @@ fn move_cross_stack_works_yay() -> anyhow::Result<()> {
         .assert()
         .success()
         .stdout_eq(str![[r#"
-Moved 1#1 → before 1#0
+Moved 1 → before 1
 
 "#]]);
 


### PR DESCRIPTION
Changes to `theme.rs` introduced a relatively significant performance hit to many commands when formatting output for humans. They'd recompute the entire `IdMap` from context, which entails rebuilding the workspace projection. I measured  a 5-8% performance hit to `but commit` from this computation, which is too much for just output formatting.

This commit somewhat reverts that by reusing pre-mutation change IDs when available, otherwise trying to fetch from an existing `IdMap`, or if that is not available fetching the commit from the repo.

For the most part, we're trusting that change IDs stay the same. This is overall not well structured and we should take more care with the `but2` commands, which I've left unimplemented and deferred for GB-1771.