### PR TITLE
Fix undo after discarding a commit with overlapping uncommitted changes

### DIFF
--- a/crates/but/tests/but/command/undo/undo_uncommit.rs
+++ b/crates/but/tests/but/command/undo/undo_uncommit.rs
@@ -51,6 +51,30 @@ fn can_undo_but_uncommit_commit_delete() {
     });
 }
 
+// Regression test for GB-1772: discarding a commit while an uncommitted change touches the same
+// file left `undo` unable to restore. Restore checks out the snapshot's workdir tree, which
+// already contains the uncommitted change, but `safe_checkout_from_head` was re-applying the
+// still-present uncommitted change on top of it, so the change collided with itself.
+#[test]
+fn can_undo_discard_commit_with_overlapping_uncommitted_change() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata_at_target(&["A"], "origin/main");
+    let path = "new-file.txt";
+
+    env.file(path, "line 1\n");
+    env.but("commit -m 'Add file'").assert().success();
+
+    env.file(path, "line 1\nline 2\n");
+    env.but("commit -m 'Update file'").assert().success();
+
+    // Uncommitted change to the same file that the discarded commit also touches.
+    env.file(path, "line 1\nline 2\nline 3\n");
+
+    run_mutate_undo_roundtrip_test(&env, |env| {
+        env.but("uncommit 1#0 --discard").assert().success();
+    });
+}
+
 #[test]
 fn can_undo_but_uncommit_file_add() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");

--- a/crates/gitbutler-oplog/src/oplog.rs
+++ b/crates/gitbutler-oplog/src/oplog.rs
@@ -746,6 +746,9 @@ fn restore_snapshot(
 
     let before_restore_snapshot_tree_id =
         prepare_snapshot(ctx, exclusive_access.read_permission())?;
+    let before_restore_snapshot_workdir_tree_id =
+        get_v3_workdir_tree(repo.find_tree(before_restore_snapshot_tree_id)?)?
+            .context("Could not get workdir tree of snapshot created before the restore")?;
     let snapshot_commit = repo.find_commit(snapshot_commit_id)?;
 
     let snapshot_tree = snapshot_commit.tree()?;
@@ -830,7 +833,17 @@ fn restore_snapshot(
     but_core::worktree::safe_checkout_from_head(
         workdir_tree_id,
         &gix_repo,
-        but_core::worktree::checkout::Options::default(),
+        but_core::worktree::checkout::Options {
+            // `workdir_tree_id` is the restored snapshot's full workdir tree, so it already
+            // contains the uncommitted changes captured at that point. `safe_checkout_from_head`
+            // otherwise re-applies the current uncommitted changes on top via a 3-way merge whose
+            // base is `HEAD^{tree}`, which makes those changes collide with the identical ones
+            // already in the destination. Using the pre-restore workdir tree as the merge base
+            // means the current uncommitted changes equal the base and cancel out, so the restored
+            // tree is checked out as-is.
+            merge_base_override: Some(before_restore_snapshot_workdir_tree_id),
+            ..Default::default()
+        },
     )?;
 
     // Tracked content now matches the snapshot (untracked files outside the restored diff are


### PR DESCRIPTION
Fixes [GB-1772](https://linear.app/gitbutler/issue/GB-1772/error-undoing-commit-deletion-specified-head-sha-didnt-match-actual).

## The bug

Deleting a commit and then undoing it failed when an uncommitted change touched the same file as the deleted commit. Undo aborted with `Uncommitted files would be overwritten by checkout: "<file>"` (and, on the build in the issue's recording, `Specified HEAD <SHA> didn't match actual HEAD^{tree} <SHA>` — the same defect surfacing through a slightly older restore path).

Reproduction: a branch with two commits touching `parent.txt`, plus an uncommitted edit to `parent.txt`, then discard the top commit and undo.

## Cause

Restore checks out the snapshot's full workdir tree, which already contains the uncommitted changes that were present when the snapshot was taken. `safe_checkout_from_head` additionally tries to preserve the *current* uncommitted changes by 3-way merging them onto the destination, using `HEAD^{tree}` as the merge base. Because the destination already holds those same changes, the merge sees them added on both sides and conflicts with itself.

This regressed when restore stopped passing the pre-restore workdir tree as the checkout baseline.

## Fix

Pass the pre-restore workdir tree as `merge_base_override` — the same mechanism commit/amend already use so consumed changes cancel in the merge. The still-present uncommitted changes then equal the base and cancel out, so the restored tree checks out as-is. No new modes or branches added to the shared checkout primitive.

Added a roundtrip regression test covering discard-commit-with-overlapping-uncommitted-change followed by undo.