### PR TITLE
Seed but-graph traversal with non-archived worktree HEADs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1232,11 +1232,9 @@ name = "but-feedback"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "but-core",
  "but-ctx",
  "but-graph",
  "chrono",
- "gix",
  "tempfile",
  "walkdir",
  "zip",

--- a/crates/but-api/src/legacy/workspace.rs
+++ b/crates/but-api/src/legacy/workspace.rs
@@ -28,6 +28,7 @@ use crate::json::HexHash;
 #[but_api(napi, try_from = but_workspace::ui::RefInfo)]
 #[instrument(err(Debug))]
 pub fn head_info(ctx: &but_ctx::Context) -> Result<but_workspace::RefInfo> {
+    let traversal = ctx.graph_options(but_graph::init::Options::limited())?;
     let repo = ctx.clone_repo_for_merging_non_persisting()?;
     let meta = ctx.meta()?;
     let gerrit_mode_enabled = repo.git_settings()?.gitbutler_gerrit_mode.unwrap_or(false);
@@ -43,7 +44,7 @@ pub fn head_info(ctx: &but_ctx::Context) -> Result<but_workspace::RefInfo> {
         &meta,
         but_workspace::ref_info::Options {
             project_meta: ctx.project_meta()?,
-            traversal: but_graph::init::Options::limited(),
+            traversal,
             expensive_commit_info: true,
             gerrit_mode,
         },
@@ -100,24 +101,29 @@ pub(crate) fn stacks_v3_from_ctx(
     // Only prefer a workspace-like ref during edit mode. When HEAD points at
     // `gitbutler/edit`, querying stacks from HEAD would produce entries without stack IDs
     // because the edit branch itself is not part of the workspace metadata.
-    but_workspace::legacy::stacks_v3(&repo, &meta, &ctx.project_meta()?, filter, workspace_ref)
+    let traversal = match workspace_ref {
+        Some(_) => but_graph::init::Options::limited(),
+        None => ctx.graph_options(but_graph::init::Options::limited())?,
+    };
+    but_workspace::legacy::stacks_v3(
+        &repo,
+        &meta,
+        &ctx.project_meta()?,
+        traversal,
+        filter,
+        workspace_ref,
+    )
 }
 
 #[cfg(unix)]
 #[but_api]
 #[instrument(err(Debug))]
 pub fn show_graph_svg(ctx: &Context) -> Result<()> {
+    let mut options = ctx.graph_options(but_graph::init::Options::limited())?;
+    options.collect_tags = true;
     let repo = ctx.open_isolated_repo()?;
     let meta = ctx.meta()?;
-    let graph = but_graph::Graph::from_head(
-        &repo,
-        &meta,
-        ctx.project_meta()?,
-        but_graph::init::Options {
-            collect_tags: true,
-            ..but_graph::init::Options::limited()
-        },
-    )?;
+    let graph = but_graph::Graph::from_head(&repo, &meta, ctx.project_meta()?, options)?;
     graph.open_as_svg();
     Ok(())
 }
@@ -129,10 +135,17 @@ pub fn stack_details(
     ctx: &Context,
     stack_id: Option<StackId>,
 ) -> Result<but_workspace::ui::StackDetails> {
+    let traversal = ctx.graph_options(but_graph::init::Options::limited())?;
     let mut details = {
         let repo = ctx.clone_repo_for_merging_non_persisting()?;
         let meta = ctx.meta()?;
-        but_workspace::legacy::stack_details_v3(stack_id, &repo, &meta, &ctx.project_meta()?)
+        but_workspace::legacy::stack_details_v3(
+            stack_id,
+            &repo,
+            &meta,
+            &ctx.project_meta()?,
+            traversal,
+        )
     }?;
     let repo = ctx.repo.get()?;
     let gerrit_mode = repo.git_settings()?.gitbutler_gerrit_mode.unwrap_or(false);
@@ -423,6 +436,7 @@ pub fn workspace_branch_and_ancestors_push(
     run_hooks: bool,
     push_opts: Vec<but_gerrit::PushFlag>,
 ) -> Result<gitbutler_git::PushResult> {
+    let traversal = ctx.graph_options(but_graph::init::Options::limited())?;
     let repo = ctx.clone_repo_for_merging_non_persisting()?;
     let meta = ctx.meta()?;
     let gerrit_mode_enabled = repo.git_settings()?.gitbutler_gerrit_mode.unwrap_or(false);
@@ -437,7 +451,7 @@ pub fn workspace_branch_and_ancestors_push(
         &meta,
         but_workspace::ref_info::Options {
             project_meta: ctx.project_meta()?,
-            traversal: but_graph::init::Options::limited(),
+            traversal,
             expensive_commit_info: true,
             gerrit_mode,
         },

--- a/crates/but-api/tests/api/legacy_workspace.rs
+++ b/crates/but-api/tests/api/legacy_workspace.rs
@@ -1,0 +1,17 @@
+#[test]
+fn head_info_uses_context_graph_options() -> anyhow::Result<()> {
+    let (repo, _tmp) = crate::support::repo_with_feature_branch()?;
+    let mut ctx = but_ctx::Context::from_repo_for_testing(repo)?.with_memory_app_cache();
+    ctx.settings.feature_flags.worktree_manipulation = true;
+
+    assert!(
+        !ctx.db.get_cache()?.worktree_meta().adoption_ran()?,
+        "worktree adoption has not run before graph options are requested"
+    );
+    but_api::legacy::workspace::head_info(&ctx)?;
+    assert!(
+        ctx.db.get_cache()?.worktree_meta().adoption_ran()?,
+        "head-info construction obtains feature-gated graph options from Context"
+    );
+    Ok(())
+}

--- a/crates/but-api/tests/api/main.rs
+++ b/crates/but-api/tests/api/main.rs
@@ -6,5 +6,7 @@ mod branch_remove;
 mod branch_rename;
 #[cfg(all(feature = "legacy", not(feature = "graph-workspace")))]
 mod forge_pr_association;
+#[cfg(feature = "legacy")]
+mod legacy_workspace;
 mod resolve_ai;
 mod support;

--- a/crates/but-api/tests/api/support.rs
+++ b/crates/but-api/tests/api/support.rs
@@ -146,6 +146,7 @@ pub fn workspace_graph(ctx: &but_ctx::Context) -> anyhow::Result<String> {
 
 #[cfg(not(feature = "graph-workspace"))]
 pub fn fresh_head_info(ctx: &but_ctx::Context) -> anyhow::Result<but_workspace::RefInfo> {
+    let traversal = ctx.graph_options(but_graph::init::Options::limited())?;
     let project_meta = ctx.project_meta()?;
     let meta = ctx.meta()?;
     let repo = ctx.repo.get()?;
@@ -154,7 +155,7 @@ pub fn fresh_head_info(ctx: &but_ctx::Context) -> anyhow::Result<but_workspace::
         &meta,
         but_workspace::ref_info::Options {
             project_meta,
-            traversal: but_graph::init::Options::limited(),
+            traversal,
             expensive_commit_info: true,
             ..Default::default()
         },

--- a/crates/but-cherry-apply/src/lib.rs
+++ b/crates/but-cherry-apply/src/lib.rs
@@ -54,6 +54,8 @@ pub fn cherry_apply_status(
     _perm: &RepoShared,
     subject: ObjectId,
 ) -> Result<CherryApplyStatus> {
+    let mut traversal = ctx.graph_options(Default::default())?;
+    traversal.commits_limit_hint = Some(300);
     let repo = ctx
         .repo
         .get()?
@@ -66,6 +68,7 @@ pub fn cherry_apply_status(
         &repo,
         &meta,
         &ctx.project_meta()?,
+        traversal,
         StacksFilter::InWorkspace,
         None,
     )?;

--- a/crates/but-cherry-apply/tests/cherry_apply/clean_to_both.rs
+++ b/crates/but-cherry-apply/tests/cherry_apply/clean_to_both.rs
@@ -43,7 +43,13 @@ fn can_apply_to_foo_stack() -> anyhow::Result<()> {
             .join("virtual_branches.toml"),
     )?;
     let repo = test_ctx.ctx.repo.get()?;
-    let details = stack_details_v3(Some(foo_id), &repo, &meta, &test_ctx.ctx.project_meta()?)?;
+    let details = stack_details_v3(
+        Some(foo_id),
+        &repo,
+        &meta,
+        &test_ctx.ctx.project_meta()?,
+        test_ctx.ctx.graph_options(Default::default())?,
+    )?;
 
     let has_commit = details
         .branch_details
@@ -87,7 +93,13 @@ fn can_apply_to_bar_stack() -> anyhow::Result<()> {
             .join("virtual_branches.toml"),
     )?;
     let repo = test_ctx.ctx.repo.get()?;
-    let details = stack_details_v3(Some(bar_id), &repo, &meta, &test_ctx.ctx.project_meta()?)?;
+    let details = stack_details_v3(
+        Some(bar_id),
+        &repo,
+        &meta,
+        &test_ctx.ctx.project_meta()?,
+        test_ctx.ctx.graph_options(Default::default())?,
+    )?;
 
     let has_commit = details
         .branch_details

--- a/crates/but-cherry-apply/tests/cherry_apply/conflicts_with_bar.rs
+++ b/crates/but-cherry-apply/tests/cherry_apply/conflicts_with_bar.rs
@@ -45,7 +45,13 @@ fn can_only_apply_to_bar_stack() -> anyhow::Result<()> {
             .join("virtual_branches.toml"),
     )?;
     let repo = test_ctx.ctx.repo.get()?;
-    let details = stack_details_v3(Some(bar_id), &repo, &meta, &test_ctx.ctx.project_meta()?)?;
+    let details = stack_details_v3(
+        Some(bar_id),
+        &repo,
+        &meta,
+        &test_ctx.ctx.project_meta()?,
+        test_ctx.ctx.graph_options(Default::default())?,
+    )?;
 
     let has_commit = details
         .branch_details

--- a/crates/but-ctx/src/lib.rs
+++ b/crates/but-ctx/src/lib.rs
@@ -766,16 +766,7 @@ impl Context {
     }
 
     fn workspace_from_head(&self) -> anyhow::Result<but_graph::Workspace> {
-        let mut options = but_graph::init::Options::limited();
-        // Empty and side-effect free unless the `worktreeManipulation` flag is on.
-        options.worktree_tips = self
-            .active_worktrees()?
-            .into_iter()
-            .map(|worktree| but_graph::init::WorktreeTip {
-                ref_name: worktree.ref_name,
-                id: worktree.head,
-            })
-            .collect();
+        let options = self.graph_options(but_graph::init::Options::limited())?;
         let repo = self.repo.get()?;
         let meta = but_meta::BranchOrderMetadata::from_paths_read_only(
             self.project_data_dir().join("virtual_branches.toml"),

--- a/crates/but-ctx/src/lib.rs
+++ b/crates/but-ctx/src/lib.rs
@@ -766,17 +766,22 @@ impl Context {
     }
 
     fn workspace_from_head(&self) -> anyhow::Result<but_graph::Workspace> {
+        let mut options = but_graph::init::Options::limited();
+        // Empty and side-effect free unless the `worktreeManipulation` flag is on.
+        options.worktree_tips = self
+            .active_worktrees()?
+            .into_iter()
+            .map(|worktree| but_graph::init::WorktreeTip {
+                ref_name: worktree.ref_name,
+                id: worktree.head,
+            })
+            .collect();
         let repo = self.repo.get()?;
         let meta = but_meta::BranchOrderMetadata::from_paths_read_only(
             self.project_data_dir().join("virtual_branches.toml"),
             self.project_data_dir(),
         )?;
-        let graph = but_graph::Graph::from_head(
-            &repo,
-            &meta,
-            self.project_meta()?,
-            but_graph::init::Options::limited(),
-        )?;
+        let graph = but_graph::Graph::from_head(&repo, &meta, self.project_meta()?, options)?;
         graph.into_workspace()
     }
 

--- a/crates/but-ctx/src/worktrees.rs
+++ b/crates/but-ctx/src/worktrees.rs
@@ -24,6 +24,25 @@ pub struct WorktreeEntry {
 }
 
 impl Context {
+    /// Add active linked-worktree tips to `options` when worktree manipulation is enabled.
+    ///
+    /// Like [`Self::active_worktrees()`], this must not be called while a database
+    /// handle is borrowed.
+    pub fn graph_options(
+        &self,
+        mut options: but_graph::init::Options,
+    ) -> Result<but_graph::init::Options> {
+        options
+            .worktree_tips
+            .extend(self.active_worktrees()?.into_iter().map(|worktree| {
+                but_graph::init::WorktreeTip {
+                    ref_name: worktree.ref_name,
+                    id: worktree.head,
+                }
+            }));
+        Ok(options)
+    }
+
     /// List all usable linked worktrees with their archived state and resolved `HEAD`s.
     ///
     /// This is the single home of linked-worktree state: every reader - listings, and

--- a/crates/but-ctx/tests/ctx/main.rs
+++ b/crates/but-ctx/tests/ctx/main.rs
@@ -2,7 +2,10 @@ use but_core::{RefMetadata as _, WORKSPACE_REF_NAME, ref_metadata::ProjectMeta};
 use but_ctx::{Context, ProjectHandle};
 use but_meta::VirtualBranchesTomlMetadata;
 use but_path::AppChannel;
-use but_testsupport::{CommandExt as _, git, gix_testtools::tempfile::TempDir, open_repo};
+use but_testsupport::{
+    CommandExt as _, git, gix_testtools::tempfile::TempDir, graph_tree, open_repo,
+    writable_scenario_slow,
+};
 use snapbox::ToDebug;
 
 #[test]
@@ -1039,6 +1042,10 @@ fn worktree_state_is_unreachable_from_linked_worktree_contexts() -> anyhow::Resu
         Vec::<String>::new(),
         "with the flag off even a linked-worktree context returns nothing, without erroring"
     );
+    assert!(
+        ctx.workspace_and_db().is_ok(),
+        "with the flag off, workspace building in a linked worktree is unaffected"
+    );
     ctx.settings.feature_flags.worktree_manipulation = true;
     assert!(
         ctx.worktrees_with_state()
@@ -1046,6 +1053,19 @@ fn worktree_state_is_unreachable_from_linked_worktree_contexts() -> anyhow::Resu
             .to_string()
             .contains("main worktree"),
         "linked-worktree contexts must be refused, not given their own state"
+    );
+    // A fresh context bypasses the workspace cached by the flag-off call above.
+    // Workspace building inherits the refusal - seeding must not read diverging state.
+    let mut ctx = Context::from_repo_for_testing(open_repo(&root.path().join("wt-a"))?)?;
+    ctx.settings.feature_flags.worktree_manipulation = true;
+    snapbox::assert_data_eq!(
+        ctx.workspace_and_db()
+            .err()
+            .map(|err| err.to_string())
+            .unwrap_or_default(),
+        snapbox::str![
+            "worktree state must be read from the main worktree - a linked-worktree context has its own database, letting adoption and archived state diverge"
+        ]
     );
 
     // The same holds for worktrees of a bare repository, whose git dirs contain
@@ -1063,6 +1083,86 @@ fn worktree_state_is_unreachable_from_linked_worktree_contexts() -> anyhow::Resu
             .to_string()
             .contains("main worktree"),
         "a worktree of a bare repository is still a linked-worktree context"
+    );
+    Ok(())
+}
+
+#[test]
+fn workspace_from_head_seeds_active_worktree_tips() -> anyhow::Result<()> {
+    let (repo, _tmp) = writable_scenario_slow("worktree-seeding");
+    let workspace_graph = |ctx: &Context| -> anyhow::Result<String> {
+        let (_guard, _repo, ws, _db) = ctx.workspace_and_db()?;
+        Ok(graph_tree(&ws.graph).to_string())
+    };
+    let db_state = |ctx: &Context| -> anyhow::Result<String> {
+        let db = ctx.db.get_cache_mut()?;
+        Ok(format!(
+            "adopted: {}, rows: {:?}",
+            db.worktree_meta().adoption_ran()?,
+            db.worktree_meta()
+                .list()?
+                .into_iter()
+                .map(|row| (
+                    String::from_utf8_lossy(&row.name).into_owned(),
+                    row.archived
+                ))
+                .collect::<Vec<_>>()
+        ))
+    };
+
+    // Flag off: no tips are seeded and the database is untouched.
+    let ctx = Context::from_repo_for_testing(repo.clone())?;
+    snapbox::assert_data_eq!(
+        workspace_graph(&ctx)?,
+        snapbox::str![[r#"
+
+└── 👉►:0[0]:main[🌳]
+    └── 🏁·85efbe4 (⌂|1)
+
+"#]]
+    );
+    snapbox::assert_data_eq!(db_state(&ctx)?, snapbox::str!["adopted: false, rows: []"]);
+
+    // Flag on: the first workspace build adopts, archiving the pre-existing
+    // worktrees - archived worktrees are not seeded.
+    let mut ctx = Context::from_repo_for_testing(repo.clone())?;
+    ctx.settings.feature_flags.worktree_manipulation = true;
+    snapbox::assert_data_eq!(
+        workspace_graph(&ctx)?,
+        snapbox::str![[r#"
+
+└── 👉►:0[0]:main[🌳]
+    └── 🏁·85efbe4 (⌂|1)
+
+"#]]
+    );
+    snapbox::assert_data_eq!(
+        db_state(&ctx)?,
+        snapbox::str![[r#"adopted: true, rows: [("wt-a", true), ("wt-b", true)]"#]]
+    );
+
+    // Unarchiving makes a worktree active - like one created after adoption -
+    // and only then is it seeded; the fresh context bypasses the per-context
+    // workspace cache.
+    {
+        let mut db = ctx.db.get_cache_mut()?;
+        db.worktree_meta_mut().upsert(but_db::WorktreeMeta {
+            name: b"wt-b".to_vec(),
+            archived: false,
+        })?;
+    }
+    let mut ctx = Context::from_repo_for_testing(repo)?;
+    ctx.settings.feature_flags.worktree_manipulation = true;
+    snapbox::assert_data_eq!(
+        workspace_graph(&ctx)?,
+        snapbox::str![[r#"
+
+└── ►:1[0]:feat-b[📁wt-b]
+    └── ·7d7d38f (⌂)
+        └── 👉►:0[1]:main[🌳@repo]
+            └── 🏁·85efbe4 (⌂|1)
+
+"#]]
     );
     Ok(())
 }

--- a/crates/but-ctx/tests/fixtures/scenario/worktree-seeding.sh
+++ b/crates/but-ctx/tests/fixtures/scenario/worktree-seeding.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+git init
+
+git commit --allow-empty -m M
+
+# Linked worktrees whose branches are one commit ahead of `main`, so their heads
+# only appear in a graph that seeds worktree tips.
+git worktree add -b feat-a wt-a
+(cd wt-a
+  git commit --allow-empty -m A1
+)
+git worktree add -b feat-b wt-b
+(cd wt-b
+  git commit --allow-empty -m B1
+)

--- a/crates/but-debug/src/command/graph.rs
+++ b/crates/but-debug/src/command/graph.rs
@@ -70,6 +70,7 @@ pub(crate) fn run(
             })
             .collect(),
         dangerously_skip_postprocessing_for_debugging: graph_args.no_post,
+        worktree_tips: vec![],
     };
 
     let graph = match graph_args.ref_name.as_deref() {

--- a/crates/but-feedback/Cargo.toml
+++ b/crates/but-feedback/Cargo.toml
@@ -11,12 +11,10 @@ test = false
 doctest = false
 
 [dependencies]
-but-core.workspace = true
 but-graph.workspace = true
 but-ctx = { workspace = true, features = ["legacy"] }
 
 anyhow.workspace = true
-gix.workspace = true
 zip.workspace = true
 walkdir = "2.5.0"
 chrono.workspace = true

--- a/crates/but-feedback/src/lib.rs
+++ b/crates/but-feedback/src/lib.rs
@@ -3,7 +3,6 @@
 use std::path::PathBuf;
 
 use anyhow::Result;
-use but_core::RefMetadata;
 use but_ctx::{Context, ProjectHandleOrLegacyProjectId};
 
 /// A utility to keep important paths to make archival/zip-file creation easier later.
@@ -32,26 +31,18 @@ impl Archival {
         create_zip_file_from_dir(ctx.workdir_or_gitdir()?, output_file)
     }
 
-    /// Create an anonymous archive commit graph for `repo` and `meta`, such that it doesn't reveal PII.
-    pub fn zip_anonymous_graph(
-        &self,
-        repo: &gix::Repository,
-        meta: &impl RefMetadata,
-    ) -> Result<PathBuf> {
-        let project_meta = but_core::ref_metadata::ProjectMeta::resolve(repo, meta)?;
+    /// Create an anonymous archive commit graph for `ctx`, such that it doesn't reveal PII.
+    pub fn zip_anonymous_graph(&self, ctx: &Context) -> Result<PathBuf> {
+        let mut options = ctx.graph_options(Default::default())?;
+        let repo = ctx.repo.get()?;
+        let meta = ctx.meta()?;
+        let project_meta = ctx.project_meta()?;
         let mut graph =
-            but_graph::Graph::from_head(repo, meta, project_meta.clone(), Default::default())
+            but_graph::Graph::from_head(&repo, &meta, project_meta.clone(), options.clone())
                 .or_else(|_| {
-                    but_graph::Graph::from_head(
-                        repo,
-                        meta,
-                        project_meta,
-                        but_graph::init::Options {
-                            // Assume it fails because of post-processing, try again without.
-                            dangerously_skip_postprocessing_for_debugging: true,
-                            ..Default::default()
-                        },
-                    )
+                    // Assume it fails because of post-processing, try again without.
+                    options.dangerously_skip_postprocessing_for_debugging = true;
+                    but_graph::Graph::from_head(&repo, &meta, project_meta, options)
                 })?;
         let dot_file_contents = graph.anonymize(&repo.remote_names())?.dot_graph_pruned();
         let output_file = self.cache_dir.join(format!(

--- a/crates/but-graph/src/init/mod.rs
+++ b/crates/but-graph/src/init/mod.rs
@@ -484,6 +484,28 @@ pub struct Options {
     ///
     /// This should only be used in case post-processing fails and one wants to preview the version before that.
     pub dangerously_skip_postprocessing_for_debugging: bool,
+    /// Extra reachable tips resolved by the caller from linked-worktree `HEAD`s.
+    ///
+    /// Tips with a ref name are re-resolved through the (possibly overlaid) ref store on
+    /// every traversal so redone traversals see moved refs; the recorded commit id is only
+    /// a fallback for detached worktrees. A ref that no longer resolves is skipped
+    /// entirely - its stale tip is never resurrected.
+    /// These tips queue after all other initial work and are skipped if another tip
+    /// already seeds their commit.
+    ///
+    /// Like all traversal options, they are ignored by [`Graph::from_head()`] when
+    /// `HEAD` is unborn, as no traversal happens there.
+    pub worktree_tips: Vec<WorktreeTip>,
+}
+
+/// A linked-worktree `HEAD` to include as an extra traversal tip, see
+/// [`Options::worktree_tips`].
+#[derive(Debug, Clone)]
+pub struct WorktreeTip {
+    /// The branch the worktree has checked out, if its `HEAD` is symbolic.
+    pub ref_name: Option<gix::refs::FullName>,
+    /// The peeled `HEAD` commit at caller resolution time.
+    pub id: gix::ObjectId,
 }
 
 /// Presets
@@ -769,6 +791,7 @@ impl Graph {
             commits_limit_recharge_location: mut max_commits_recharge_location,
             hard_limit,
             dangerously_skip_postprocessing_for_debugging,
+            worktree_tips,
         } = options;
         let max_limit = Limit::new(limit);
         if ref_name
@@ -786,8 +809,13 @@ impl Graph {
 
         let configured_remote_tracking_branches =
             remotes::configured_remote_tracking_branches(repo)?;
-        let initial_tips =
-            initial_tips_from_tips(repo, tips, &graph.project_meta, extra_target_commit_id);
+        let initial_tips = initial_tips_from_tips(
+            repo,
+            tips,
+            &graph.project_meta,
+            extra_target_commit_id,
+            worktree_tips,
+        )?;
         graph.traversal_tips = initial_tips.tips.clone();
         let refs_by_id = repo.collect_ref_mapping_by_prefix(
             [
@@ -1242,7 +1270,8 @@ fn initial_tips_from_tips(
     mut tips: Vec<Tip>,
     project_meta: &ProjectMeta,
     extra_target_commit_id: Option<gix::ObjectId>,
-) -> InitialTips {
+    worktree_tips: Vec<WorktreeTip>,
+) -> anyhow::Result<InitialTips> {
     let mut auxiliary_integrated_tip_ids = BTreeSet::new();
     if let Some(extra_target) = extra_target_commit_id {
         auxiliary_integrated_tip_ids.insert(extra_target);
@@ -1274,8 +1303,9 @@ fn initial_tips_from_tips(
     let symbolic_remote_names =
         symbolic_remote_names_from_tips(repo, &tips, project_meta, include_tip_refs);
     let target_local_links = target_local_links_from_tips(repo, &tips);
+    let tips = append_worktree_tips(repo, tips, worktree_tips)?;
 
-    InitialTips {
+    Ok(InitialTips {
         tips,
         workspace_tips,
         workspace_ref_names,
@@ -1284,7 +1314,36 @@ fn initial_tips_from_tips(
         frontload_workspace_related_tips,
         target_local_links,
         auxiliary_integrated_tip_ids,
+    })
+}
+
+/// Append caller-provided linked-worktree `HEAD` tips as plain reachable seeds.
+///
+/// They come last so they never claim a commit that other initial work seeds first -
+/// in workspace and ad-hoc priority modes alike - and they don't participate in any
+/// auxiliary tip computations (targets, workspace refs, remotes).
+/// Tips with a ref name are re-resolved through the overlay so redone traversals
+/// (e.g. rebase previews) see moved or dropped refs; the recorded id is the fallback.
+fn append_worktree_tips(
+    repo: &OverlayRepo<'_>,
+    mut tips: Vec<Tip>,
+    worktree_tips: Vec<WorktreeTip>,
+) -> anyhow::Result<Vec<Tip>> {
+    let mut seen_ids: BTreeSet<_> = tips.iter().map(|tip| tip.id).collect();
+    for worktree_tip in worktree_tips {
+        let id = match &worktree_tip.ref_name {
+            Some(name) => match repo.try_find_reference(name.as_ref())? {
+                // The ref was dropped by an overlay or vanished - don't resurrect its old tip.
+                None => continue,
+                Some(mut reference) => reference.peel_to_id()?.detach(),
+            },
+            None => worktree_tip.id,
+        };
+        if seen_ids.insert(id) {
+            tips.push(Tip::new(id));
+        }
     }
+    Ok(tips)
 }
 
 /// Remove anonymous integrated target tips that point to the same commit as a

--- a/crates/but-graph/tests/fixtures/scenarios.sh
+++ b/crates/but-graph/tests/fixtures/scenarios.sh
@@ -66,6 +66,17 @@ git init ambiguous-worktrees
   git worktree add wt-inside-ambiguous-worktree
 )
 
+# A linked worktree whose branch is ahead of `main`, so its head commit is
+# unreachable from any other traversal tip.
+git init worktree-ahead
+(cd worktree-ahead
+  commit M
+  git worktree add -b wt-feature ../worktree-ahead-feature
+  (cd ../worktree-ahead-feature
+    commit W
+  )
+)
+
 # A single root that splits up into 4 branches and merges again
 git init four-diamond
 (cd four-diamond
@@ -1287,6 +1298,18 @@ EOF
     commit init
     git branch unapplied
     setup_target_to_match_main
+    create_workspace_commit_once main
+  )
+
+  # A branch ahead of the workspace base stands in for a linked-worktree HEAD -
+  # unreachable from the workspace or target unless seeded as a worktree tip.
+  git init worktree-ahead
+  (cd worktree-ahead
+    commit init
+    setup_target_to_match_main
+    git checkout -b wt-feature
+      commit W
+    git checkout main
     create_workspace_commit_once main
   )
 

--- a/crates/but-graph/tests/graph/init/mod.rs
+++ b/crates/but-graph/tests/graph/init/mod.rs
@@ -68,6 +68,7 @@ Graph {
         hard_limit: None,
         extra_target_commit_id: None,
         dangerously_skip_postprocessing_for_debugging: false,
+        worktree_tips: [],
     },
     project_meta: ProjectMeta {
         target_ref: None,
@@ -211,6 +212,7 @@ Graph {
         hard_limit: None,
         extra_target_commit_id: None,
         dangerously_skip_postprocessing_for_debugging: false,
+        worktree_tips: [],
     },
     project_meta: ProjectMeta {
         target_ref: None,
@@ -1811,6 +1813,147 @@ fn ambiguous_worktrees() -> anyhow::Result<()> {
 
 "#]]
     );
+    Ok(())
+}
+
+#[test]
+fn worktree_tips_as_extra_traversal_heads() -> anyhow::Result<()> {
+    let (repo, meta) = read_only_in_memory_scenario("worktree-ahead")?;
+    snapbox::assert_data_eq!(
+        visualize_commit_graph_all(&repo)?,
+        snapbox::str![[r#"
+* 9175ab3 (wt-feature) W
+* 85efbe4 (HEAD -> main) M
+
+"#]]
+    );
+
+    // Without worktree tips, the worktree branch head is unreachable and invisible.
+    let graph = Graph::from_head(
+        &repo,
+        &*meta,
+        but_core::ref_metadata::ProjectMeta::default(),
+        standard_options(),
+    )?
+    .validated()?;
+    snapbox::assert_data_eq!(
+        graph_tree(&graph).to_string(),
+        snapbox::str![[r#"
+
+└── 👉►:0[0]:main[🌳]
+    └── 🏁·85efbe4 (⌂|1)
+
+"#]]
+    );
+
+    // With the worktree head as extra tip, its commit and branch join the graph.
+    let wt_head_id = repo.find_reference("wt-feature")?.peel_to_id()?.detach();
+    let with_worktree_tip = |ref_name: Option<gix::refs::FullName>| but_graph::init::Options {
+        worktree_tips: vec![but_graph::init::WorktreeTip {
+            ref_name,
+            id: wt_head_id,
+        }],
+        ..standard_options()
+    };
+    let graph = Graph::from_head(
+        &repo,
+        &*meta,
+        but_core::ref_metadata::ProjectMeta::default(),
+        with_worktree_tip(Some("refs/heads/wt-feature".try_into()?)),
+    )?
+    .validated()?;
+    snapbox::assert_data_eq!(
+        graph_tree(&graph).to_string(),
+        snapbox::str![[r#"
+
+└── ►:1[0]:wt-feature[📁worktree-ahead-feature]
+    └── ·9175ab3 (⌂)
+        └── 👉►:0[1]:main[🌳@repo]
+            └── 🏁·85efbe4 (⌂|1)
+
+"#]]
+    );
+
+    // A detached worktree tip (no ref name) is seeded by commit id alone.
+    let graph = Graph::from_head(
+        &repo,
+        &*meta,
+        but_core::ref_metadata::ProjectMeta::default(),
+        with_worktree_tip(None),
+    )?
+    .validated()?;
+    snapbox::assert_data_eq!(
+        graph_tree(&graph).to_string(),
+        snapbox::str![[r#"
+
+└── ►:1[0]:wt-feature[📁worktree-ahead-feature]
+    └── ·9175ab3 (⌂)
+        └── 👉►:0[1]:main[🌳@repo]
+            └── 🏁·85efbe4 (⌂|1)
+
+"#]]
+    );
+
+    // The re-resolved ref target wins over the recorded id: a stale recorded id -
+    // here main's head, which another tip already seeds and dedup would swallow -
+    // must not keep the ref's current target out of the graph.
+    let graph = Graph::from_head(
+        &repo,
+        &*meta,
+        but_core::ref_metadata::ProjectMeta::default(),
+        but_graph::init::Options {
+            worktree_tips: vec![but_graph::init::WorktreeTip {
+                ref_name: Some("refs/heads/wt-feature".try_into()?),
+                id: repo.head_id()?.detach(),
+            }],
+            ..standard_options()
+        },
+    )?
+    .validated()?;
+    snapbox::assert_data_eq!(
+        graph_tree(&graph).to_string(),
+        snapbox::str![[r#"
+
+└── ►:1[0]:wt-feature[📁worktree-ahead-feature]
+    └── ·9175ab3 (⌂)
+        └── 👉►:0[1]:main[🌳@repo]
+            └── 🏁·85efbe4 (⌂|1)
+
+"#]]
+    );
+
+    // A worktree tip pointing at an already-seeded commit is dropped, and a tip
+    // whose ref vanished is not resurrected from its recorded id - both leave
+    // the graph exactly as if no worktree tips were given.
+    for tip in [
+        but_graph::init::WorktreeTip {
+            ref_name: None,
+            id: repo.head_id()?.detach(),
+        },
+        but_graph::init::WorktreeTip {
+            ref_name: Some("refs/heads/does-not-exist".try_into()?),
+            id: wt_head_id,
+        },
+    ] {
+        let mut options = standard_options();
+        options.worktree_tips = vec![tip];
+        let graph = Graph::from_head(
+            &repo,
+            &*meta,
+            but_core::ref_metadata::ProjectMeta::default(),
+            options,
+        )?
+        .validated()?;
+        snapbox::assert_data_eq!(
+            graph_tree(&graph).to_string(),
+            snapbox::str![[r#"
+
+└── 👉►:0[0]:main[🌳]
+    └── 🏁·85efbe4 (⌂|1)
+
+"#]]
+        );
+    }
     Ok(())
 }
 

--- a/crates/but-graph/tests/graph/init/utils.rs
+++ b/crates/but-graph/tests/graph/init/utils.rs
@@ -157,6 +157,7 @@ pub fn standard_options() -> but_graph::init::Options {
         hard_limit: None,
         extra_target_commit_id: None,
         dangerously_skip_postprocessing_for_debugging: false,
+        worktree_tips: vec![],
     }
 }
 

--- a/crates/but-graph/tests/graph/init/with_workspace.rs
+++ b/crates/but-graph/tests/graph/init/with_workspace.rs
@@ -8080,6 +8080,72 @@ fn shared_target_base_keeps_exact_target_segment_with_inactive_unapplied_branch(
 }
 
 #[test]
+fn worktree_tip_in_workspace_priority_mode() -> anyhow::Result<()> {
+    let (repo, mut meta) = read_only_in_memory_scenario("ws/worktree-ahead")?;
+    snapbox::assert_data_eq!(
+        visualize_commit_graph_all(&repo)?,
+        snapbox::str![[r#"
+* a26ae77 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+| * 26837d3 (wt-feature) W
+|/  
+* fafd9d0 (origin/main, main) init
+
+"#]]
+    );
+    add_workspace(&mut meta);
+
+    // Without the worktree tip, the branch ahead of the base is invisible.
+    let graph =
+        Graph::from_head(&repo, &*meta, project_meta(&*meta), standard_options())?.validated()?;
+    snapbox::assert_data_eq!(
+        graph_tree(&graph).to_string(),
+        snapbox::str![[r#"
+
+├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
+│   └── ·a26ae77 (⌂|🏘|01)
+│       └── ►:2[1]:main <> origin/main →:1:
+│           └── 🏁·fafd9d0 (⌂|🏘|✓|11)
+└── ►:1[0]:origin/main →:2:
+    └── →:2: (main →:1:)
+
+"#]]
+    );
+
+    // Seeding it adds the branch outside the workspace, leaving workspace,
+    // target, and remote computations undisturbed.
+    let mut options = standard_options();
+    options.worktree_tips = vec![but_graph::init::WorktreeTip {
+        ref_name: Some("refs/heads/wt-feature".try_into()?),
+        id: repo.find_reference("wt-feature")?.peel_to_id()?.detach(),
+    }];
+    let graph = Graph::from_head(&repo, &*meta, project_meta(&*meta), options)?.validated()?;
+    snapbox::assert_data_eq!(
+        graph_tree(&graph).to_string(),
+        snapbox::str![[r#"
+
+├── 👉📕►►►:0[0]:gitbutler/workspace[🌳]
+│   └── ·a26ae77 (⌂|🏘|01)
+│       └── ►:2[1]:main <> origin/main →:1:
+│           └── 🏁·fafd9d0 (⌂|🏘|✓|11)
+├── ►:1[0]:origin/main →:2:
+│   └── →:2: (main →:1:)
+└── ►:3[0]:wt-feature
+    └── ·26837d3 (⌂)
+        └── →:2: (main →:1:)
+
+"#]]
+    );
+    snapbox::assert_data_eq!(
+        graph_workspace(&graph.into_workspace()?).to_string(),
+        snapbox::str![[r#"
+📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+
+"#]]
+    );
+    Ok(())
+}
+
+#[test]
 fn unapplied_branch_on_base_no_target() -> anyhow::Result<()> {
     let (repo, mut meta) = read_only_in_memory_scenario("ws/unapplied-branch-on-base")?;
     snapbox::assert_data_eq!(

--- a/crates/but-rebase/tests/rebase/main.rs
+++ b/crates/but-rebase/tests/rebase/main.rs
@@ -939,6 +939,7 @@ pub mod utils {
             hard_limit: None,
             extra_target_commit_id: None,
             dangerously_skip_postprocessing_for_debugging: false,
+            worktree_tips: vec![],
         }
     }
 }

--- a/crates/but-workspace/src/legacy/stacks.rs
+++ b/crates/but-workspace/src/legacy/stacks.rs
@@ -171,6 +171,7 @@ pub fn stacks_v3(
     repo: &gix::Repository,
     meta: &impl RefMetadata,
     project_meta: &ProjectMeta,
+    traversal: but_graph::init::Options,
     filter: StacksFilter,
     ref_name_override: Option<&gix::refs::FullNameRef>,
 ) -> anyhow::Result<Vec<StackEntry>> {
@@ -230,7 +231,7 @@ pub fn stacks_v3(
     let options = ref_info::Options {
         project_meta: project_meta.clone(),
         expensive_commit_info: false,
-        traversal: but_graph::init::Options::limited(),
+        traversal,
         ..Default::default()
     };
     let info = match ref_name_override {
@@ -299,6 +300,7 @@ pub fn stack_details_v3(
     repo: &gix::Repository,
     meta: &impl RefMetadata,
     project_meta: &ProjectMeta,
+    traversal: but_graph::init::Options,
 ) -> anyhow::Result<ui::StackDetails> {
     // Prefer the current `HEAD` projection if it can still see the requested stack, and only fall
     // back to resolving from a surviving ref when that stack is no longer reachable from `HEAD`.
@@ -308,15 +310,18 @@ pub fn stack_details_v3(
             .into_iter()
             .find(|stack| stack.id == Some(stack_id))
     }
-    fn new_ref_info_options(project_meta: &ProjectMeta) -> ref_info::Options<'static> {
+    fn new_ref_info_options(
+        project_meta: &ProjectMeta,
+        traversal: &but_graph::init::Options,
+    ) -> ref_info::Options<'static> {
         ref_info::Options {
             project_meta: project_meta.clone(),
             expensive_commit_info: true,
-            traversal: but_graph::init::Options::limited(),
+            traversal: traversal.clone(),
             ..Default::default()
         }
     }
-    let mut ref_info_options = new_ref_info_options(project_meta);
+    let mut ref_info_options = new_ref_info_options(project_meta, &traversal);
     let mut stack = match stack_id {
         None => {
             // assume single-branch mode.
@@ -343,7 +348,7 @@ pub fn stack_details_v3(
         }
         Some(stack_id) => {
             if let Some(stack) = stack_by_id(
-                head_info(repo, meta, new_ref_info_options(project_meta))?,
+                head_info(repo, meta, new_ref_info_options(project_meta, &traversal))?,
                 stack_id,
             ) {
                 stack
@@ -358,7 +363,11 @@ pub fn stack_details_v3(
                     .with_context(|| {
                         format!("Couldn't find any refs for stack {stack_id} in the repository")
                     })?;
-                let ref_info = ref_info(existing_ref, meta, new_ref_info_options(project_meta))?;
+                let ref_info = ref_info(
+                    existing_ref,
+                    meta,
+                    new_ref_info_options(project_meta, &traversal),
+                )?;
                 stack_by_id(ref_info, stack_id).with_context(|| {
                     format!("Really couldn't find {stack_id} in the current workspace projection")
                 })?

--- a/crates/but-workspace/tests/workspace/branch/apply_unapply.rs
+++ b/crates/but-workspace/tests/workspace/branch/apply_unapply.rs
@@ -6204,6 +6204,7 @@ mod utils {
             hard_limit: None,
             extra_target_commit_id: None,
             dangerously_skip_postprocessing_for_debugging: false,
+            worktree_tips: vec![],
         }
     }
 

--- a/crates/but-workspace/tests/workspace/ref_info/mod.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/mod.rs
@@ -41,6 +41,7 @@ pub fn stacks_v3(
         &meta
             .workspace(WORKSPACE_REF_NAME.try_into()?)?
             .project_meta(),
+        but_graph::init::Options::limited(),
         filter,
         ref_name_override,
     )
@@ -61,6 +62,7 @@ pub fn stack_details_v3(
         &meta
             .workspace(WORKSPACE_REF_NAME.try_into()?)?
             .project_meta(),
+        but_graph::init::Options::limited(),
     )
 }
 

--- a/crates/but/src/command/legacy/status/tui/app/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/app/mod.rs
@@ -1322,12 +1322,14 @@ impl App {
         }
 
         let head_info = {
+            let traversal = ctx.graph_options(Default::default())?;
             let meta = ctx.meta()?;
             but_workspace::head_info(
                 &*ctx.repo.get()?,
                 &meta,
                 but_workspace::ref_info::Options {
                     project_meta: ctx.project_meta()?,
+                    traversal,
                     ..Default::default()
                 },
             )?

--- a/crates/but/src/legacy/workspace.rs
+++ b/crates/but/src/legacy/workspace.rs
@@ -55,6 +55,12 @@ fn head_info(
     let repo = ctx.clone_repo_for_merging_non_persisting()?;
     let object_hash = repo.object_hash();
     let meta = ctx.meta()?;
+    let edit_mode_workspace_ref = edit_mode_workspace_ref(&repo)?;
+    let traversal = if edit_mode_workspace_ref.is_some() {
+        but_graph::init::Options::limited()
+    } else {
+        ctx.graph_options(but_graph::init::Options::limited())?
+    };
     let gerrit_mode_enabled = repo.git_settings()?.gitbutler_gerrit_mode.unwrap_or(false);
     let db = gerrit_mode_enabled
         .then(|| ctx.db.get_cache())
@@ -65,11 +71,11 @@ fn head_info(
     };
     let options = ref_info::Options {
         project_meta: ctx.project_meta()?,
-        traversal: but_graph::init::Options::limited(),
+        traversal,
         expensive_commit_info,
         gerrit_mode,
     };
-    let mut info = match edit_mode_workspace_ref(&repo)? {
+    let mut info = match edit_mode_workspace_ref {
         Some(ref_name) => {
             but_workspace::ref_info(repo.find_reference(ref_name.as_ref())?, &meta, options)
         }

--- a/crates/gitbutler-branch-actions/src/branch.rs
+++ b/crates/gitbutler-branch-actions/src/branch.rs
@@ -26,6 +26,7 @@ pub fn list_branches(
     filter: Option<BranchListingFilter>,
     filter_branch_names: Option<Vec<BranchIdentity>>,
 ) -> Result<Vec<BranchListing>> {
+    let traversal = ctx.graph_options(but_graph::init::Options::limited())?;
     let mut repo = ctx.repo.get()?.clone();
     repo.object_cache_size_if_unset(1024 * 1024);
     let has_filter = filter.is_some();
@@ -77,7 +78,7 @@ pub fn list_branches(
         &meta,
         but_workspace::ref_info::Options {
             project_meta: ctx.project_meta()?,
-            traversal: but_graph::init::Options::limited(),
+            traversal,
             expensive_commit_info: false,
             gerrit_mode,
         },

--- a/crates/gitbutler-branch-actions/tests/branch-actions/support.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/support.rs
@@ -49,6 +49,8 @@ pub fn stack_details(ctx: &Context) -> Vec<(StackId, StackDetails)> {
             &repo,
             &meta,
             &ctx.project_meta().unwrap(),
+            ctx.graph_options(but_graph::init::Options::limited())
+                .unwrap(),
             StacksFilter::default(),
             None,
         )
@@ -66,6 +68,8 @@ pub fn stack_details(ctx: &Context) -> Vec<(StackId, StackDetails)> {
                     &repo,
                     &meta,
                     &ctx.project_meta().unwrap(),
+                    ctx.graph_options(but_graph::init::Options::limited())
+                        .unwrap(),
                 )
             }
             .unwrap();

--- a/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/mod.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/mod.rs
@@ -326,6 +326,7 @@ pub fn create_commit(
             &repo,
             &meta,
             &ctx.project_meta()?,
+            ctx.graph_options(but_graph::init::Options::limited())?,
             but_workspace::legacy::StacksFilter::InWorkspace,
             None,
         )?

--- a/crates/gitbutler-tauri/src/zip.rs
+++ b/crates/gitbutler-tauri/src/zip.rs
@@ -25,11 +25,7 @@ pub fn get_anonymous_graph_path(
 ) -> Result<PathBuf, Error> {
     let ctx: Context = project_id.try_into()?;
     let _guard = ctx.shared_worktree_access();
-    let repo = ctx.repo.get()?;
-    let meta = ctx.meta()?;
-    archival
-        .zip_anonymous_graph(&repo, &meta)
-        .map_err(Into::into)
+    archival.zip_anonymous_graph(&ctx).map_err(Into::into)
 }
 
 #[tauri::command(async)]


### PR DESCRIPTION
This is a continuation into supporting worktrees, especially those that are not
part of the workspace.

* Closes GB-1756