### PR TITLE
Lite: improved uncommitted files

### DIFF
--- a/apps/lite/ui/src/hotkeys.ts
+++ b/apps/lite/ui/src/hotkeys.ts
@@ -139,10 +139,6 @@ export const workspaceHotkeys = {
 } satisfies Record<string, HotkeyWithMeta>;
 
 export const outlineHotkeys = {
-	absorb: {
-		hotkey: "A",
-		meta: { group: "Uncommitted changes", name: "Absorb" },
-	},
 	amendCommit: {
 		hotkey: "Shift+A",
 		meta: { group: "Commit", name: "Amend commit" },
@@ -188,9 +184,6 @@ export const outlineHotkeys = {
 		hotkey: globalThis.window.lite.platform === "darwin" ? "Mod+Backspace" : "Delete",
 		meta: { group: "Commit", name: "Delete commit" },
 	},
-	composeCommitMessageFromChanges: {
-		hotkey: "R",
-	},
 	moveCommitDown: {
 		hotkey: "Alt+ArrowDown",
 		meta: { group: "Commit", name: "Move commit down" },
@@ -218,9 +211,6 @@ export const outlineHotkeys = {
 	selectBranch: {
 		hotkey: "T",
 		meta: { group: "Workspace", name: "Jump to branch" },
-	},
-	selectChanges: {
-		hotkey: "Z",
 	},
 } satisfies Record<string, HotkeyWithMeta>;
 

--- a/apps/lite/ui/src/hotkeys.ts
+++ b/apps/lite/ui/src/hotkeys.ts
@@ -118,11 +118,17 @@ export const workspaceHotkeys = {
 			name: "Update workspace (rebases all stacks)",
 		},
 	},
-	focusPreviousSelectionScope: {
+	focusHorizontalSelectionScopeLeft: {
 		hotkey: "Mod+Alt+ArrowLeft",
 	},
-	focusNextSelectionScope: {
+	focusHorizontalSelectionScopeRight: {
 		hotkey: "Mod+Alt+ArrowRight",
+	},
+	focusVerticalSelectionScopeUp: {
+		hotkey: "Mod+Alt+ArrowUp",
+	},
+	focusVerticalSelectionScopeDown: {
+		hotkey: "Mod+Alt+ArrowDown",
 	},
 	settings: {
 		hotkey: "Mod+,",

--- a/apps/lite/ui/src/outline/mode.ts
+++ b/apps/lite/ui/src/outline/mode.ts
@@ -6,9 +6,11 @@ import {
 	commitOperand,
 	operandEquals,
 	type Operand,
+	uncommittedChangesOperand,
 } from "#ui/operands.ts";
 import { OperationType } from "#ui/operations/operation.ts";
 import type { SelectionState } from "#ui/projects/project.ts";
+import type { SelectionScope } from "#ui/selection-scopes.ts";
 import { AbsorptionTarget } from "@gitbutler/but-sdk";
 
 /** @public */
@@ -61,11 +63,20 @@ export const pointerTransferMode = ({
 	operationType,
 });
 
-export const getTransferTarget = (mode: TransferMode, selection: Operand | null): Operand | null =>
+export const getTransferTarget = (
+	mode: TransferMode,
+	outlineSelection: Operand | null,
+	detailsSelectionScope: SelectionScope | null,
+): Operand | null =>
 	Match.value(mode).pipe(
 		Match.tagsExhaustive({
 			Pointer: (mode) => mode.target,
-			Keyboard: () => selection,
+			Keyboard: () =>
+				Match.value(detailsSelectionScope).pipe(
+					Match.when("uncommitted-files", () => uncommittedChangesOperand),
+					Match.when("outline", () => outlineSelection),
+					Match.orElse(() => null),
+				),
 		}),
 	);
 

--- a/apps/lite/ui/src/projects/project.ts
+++ b/apps/lite/ui/src/projects/project.ts
@@ -38,6 +38,7 @@ export type Dialog =
 	| { _tag: "Settings" };
 
 export type SelectionState = {
+	uncommittedFiles: string | null;
 	outline: Operand | null;
 	files: string | null;
 	diff: HunkOperand | null;
@@ -52,6 +53,7 @@ type WorkspaceState = {
 };
 
 const createInitialSelectionState = (): SelectionState => ({
+	uncommittedFiles: null,
 	outline: null,
 	files: null,
 	diff: null,
@@ -92,6 +94,12 @@ const hunkOperandIdentityKey = (operand: HunkOperand): string =>
 	operandIdentityKey(hunkOperand(operand));
 
 export const projectReducers = {
+	selectUncommittedFiles: (state: ProjectState, { selection }: { selection: string | null }) => {
+		const workspaceState = state.workspace;
+		if (workspaceState.selection.uncommittedFiles === selection) return;
+
+		workspaceState.selection.uncommittedFiles = selection;
+	},
 	selectOutline: (state: ProjectState, { selection }: { selection: Operand | null }) => {
 		const workspaceState = state.workspace;
 		if (
@@ -200,6 +208,7 @@ export const projectReducers = {
 				sources,
 				operationType: operationType ?? "into",
 				restoreSelection: {
+					uncommittedFiles: workspaceState.selection.uncommittedFiles,
 					outline: workspaceState.selection.outline,
 					files: workspaceState.selection.files,
 					diff: workspaceState.selection.diff,
@@ -215,6 +224,7 @@ export const projectReducers = {
 		workspaceState.mode = absorbOutlineMode({
 			source,
 			restoreSelection: {
+				uncommittedFiles: workspaceState.selection.uncommittedFiles,
 				outline: workspaceState.selection.outline,
 				files: workspaceState.selection.files,
 				diff: workspaceState.selection.diff,
@@ -388,6 +398,15 @@ export const projectSelectors = {
 	selectFilesVisible: (state: ProjectState) => state.filesVisible,
 	selectDetailsFullWindow: (state: ProjectState) => state.detailsFullWindow,
 	selectDialogState: (state: ProjectState) => state.dialog,
+	selectSelectionUncommittedFiles: (
+		state: ProjectState,
+		navigationIndex: NavigationIndex<string>,
+	) =>
+		resolveNavigationIndexSelection(
+			navigationIndex,
+			state.workspace.selection.uncommittedFiles,
+			(path) => path,
+		),
 	selectIsSelectedOutline: (
 		state: ProjectState,
 		navigationIndex: NavigationIndex<Operand>,

--- a/apps/lite/ui/src/projects/project.ts
+++ b/apps/lite/ui/src/projects/project.ts
@@ -404,6 +404,8 @@ const selectCheckedCommitOperands = createSelector(selectCheckedCommits, (checke
 
 export const projectSelectors = {
 	selectFilesVisible: (state: ProjectState) => state.filesVisible,
+	selectCanShowFiles: (state: ProjectState) =>
+		state.workspace.detailsSelectionScope !== "uncommitted-files",
 	selectDetailsFullWindow: (state: ProjectState) => state.detailsFullWindow,
 	selectDetailsSelectionScope: (state: ProjectState) => state.workspace.detailsSelectionScope,
 	selectDialogState: (state: ProjectState) => state.dialog,

--- a/apps/lite/ui/src/projects/project.ts
+++ b/apps/lite/ui/src/projects/project.ts
@@ -25,6 +25,7 @@ import {
 	type TransferMode,
 } from "#ui/outline/mode.ts";
 import { navigationIndexIncludes, type NavigationIndex } from "#ui/workspace/navigation-index.ts";
+import type { SelectionScope } from "#ui/selection-scopes.ts";
 import { createSelector } from "@reduxjs/toolkit";
 import type { AbsorptionTarget, RelativeTo } from "@gitbutler/but-sdk";
 import { Match } from "effect";
@@ -44,9 +45,12 @@ export type SelectionState = {
 	diff: HunkOperand | null;
 };
 
+type DetailsSelectionScope = Extract<SelectionScope, "uncommitted-files" | "outline">;
+
 type WorkspaceState = {
 	checkedCommitIds: Record<string, true>;
 	commitTarget: RelativeTo | null;
+	detailsSelectionScope: DetailsSelectionScope | null;
 	highlightedCommitIds: Array<string>;
 	mode: OutlineMode;
 	selection: SelectionState;
@@ -62,6 +66,7 @@ const createInitialSelectionState = (): SelectionState => ({
 const createInitialWorkspaceState = (): WorkspaceState => ({
 	checkedCommitIds: {},
 	commitTarget: null,
+	detailsSelectionScope: null,
 	highlightedCommitIds: [],
 	mode: defaultOutlineMode,
 	selection: createInitialSelectionState(),
@@ -94,6 +99,9 @@ const hunkOperandIdentityKey = (operand: HunkOperand): string =>
 	operandIdentityKey(hunkOperand(operand));
 
 export const projectReducers = {
+	setDetailsSelectionScope: (state: ProjectState, { scope }: { scope: DetailsSelectionScope }) => {
+		state.workspace.detailsSelectionScope = scope;
+	},
 	selectUncommittedFiles: (state: ProjectState, { selection }: { selection: string | null }) => {
 		const workspaceState = state.workspace;
 		if (workspaceState.selection.uncommittedFiles === selection) return;
@@ -397,6 +405,7 @@ const selectCheckedCommitOperands = createSelector(selectCheckedCommits, (checke
 export const projectSelectors = {
 	selectFilesVisible: (state: ProjectState) => state.filesVisible,
 	selectDetailsFullWindow: (state: ProjectState) => state.detailsFullWindow,
+	selectDetailsSelectionScope: (state: ProjectState) => state.workspace.detailsSelectionScope,
 	selectDialogState: (state: ProjectState) => state.dialog,
 	selectSelectionUncommittedFiles: (
 		state: ProjectState,

--- a/apps/lite/ui/src/projects/state.ts
+++ b/apps/lite/ui/src/projects/state.ts
@@ -42,6 +42,7 @@ export const projectSlice = createSlice({
 	name: "project",
 	initialState,
 	reducers: {
+		setDetailsSelectionScope: withProject(projectReducers.setDetailsSelectionScope),
 		selectUncommittedFiles: withProject(projectReducers.selectUncommittedFiles),
 		selectOutline: withProject(projectReducers.selectOutline),
 		selectFiles: withProject(projectReducers.selectFiles),
@@ -72,6 +73,7 @@ export const projectSlice = createSlice({
 	selectors: {
 		selectFilesVisible: fromProject(projectSelectors.selectFilesVisible),
 		selectDetailsFullWindow: fromProject(projectSelectors.selectDetailsFullWindow),
+		selectDetailsSelectionScope: fromProject(projectSelectors.selectDetailsSelectionScope),
 		selectDialogState: fromProject(projectSelectors.selectDialogState),
 		selectSelectionUncommittedFiles: fromProject(projectSelectors.selectSelectionUncommittedFiles),
 		selectIsSelectedOutline: fromProject(projectSelectors.selectIsSelectedOutline),

--- a/apps/lite/ui/src/projects/state.ts
+++ b/apps/lite/ui/src/projects/state.ts
@@ -42,6 +42,7 @@ export const projectSlice = createSlice({
 	name: "project",
 	initialState,
 	reducers: {
+		selectUncommittedFiles: withProject(projectReducers.selectUncommittedFiles),
 		selectOutline: withProject(projectReducers.selectOutline),
 		selectFiles: withProject(projectReducers.selectFiles),
 		selectDiff: withProject(projectReducers.selectDiff),
@@ -72,6 +73,7 @@ export const projectSlice = createSlice({
 		selectFilesVisible: fromProject(projectSelectors.selectFilesVisible),
 		selectDetailsFullWindow: fromProject(projectSelectors.selectDetailsFullWindow),
 		selectDialogState: fromProject(projectSelectors.selectDialogState),
+		selectSelectionUncommittedFiles: fromProject(projectSelectors.selectSelectionUncommittedFiles),
 		selectIsSelectedOutline: fromProject(projectSelectors.selectIsSelectedOutline),
 		selectSelectionOutline: fromProject(projectSelectors.selectSelectionOutline),
 		selectSelectionFiles: fromProject(projectSelectors.selectSelectionFiles),

--- a/apps/lite/ui/src/projects/state.ts
+++ b/apps/lite/ui/src/projects/state.ts
@@ -72,6 +72,7 @@ export const projectSlice = createSlice({
 	},
 	selectors: {
 		selectFilesVisible: fromProject(projectSelectors.selectFilesVisible),
+		selectCanShowFiles: fromProject(projectSelectors.selectCanShowFiles),
 		selectDetailsFullWindow: fromProject(projectSelectors.selectDetailsFullWindow),
 		selectDetailsSelectionScope: fromProject(projectSelectors.selectDetailsSelectionScope),
 		selectDialogState: fromProject(projectSelectors.selectDialogState),

--- a/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
@@ -181,7 +181,7 @@ export const CommitForm: FC<{
 		},
 	]);
 
-	useHotkey("Escape", () => focusSelectionScope("outline"), {
+	useHotkey("Escape", () => focusSelectionScope("uncommitted-files"), {
 		target: commitTextareaRef,
 		conflictBehavior: "allow",
 	});

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -962,6 +962,9 @@ const Diff: FC<{
 	const didScrollToViaFileRef = useRef(false);
 
 	const dispatch = useAppDispatch();
+	const canShowFiles = useAppSelector((state) =>
+		projectSlice.selectors.selectCanShowFiles(state, projectId),
+	);
 	const files = filesItems.map((item) => item.path);
 	const filesNavigationIndex: NavigationIndex<string> = {
 		items: files,
@@ -1073,7 +1076,7 @@ const Diff: FC<{
 	return (
 		<div className={styles.diffTab}>
 			<div className={styles.actions}>
-				<FilesToggle className={getButtonClassName({})}>Toggle files</FilesToggle>
+				{canShowFiles && <FilesToggle className={getButtonClassName({})}>Toggle files</FilesToggle>}
 
 				<Toolbar.Root aria-label="Diff controls" className={styles.diffControls}>
 					<ToggleGroupStyles>
@@ -1495,9 +1498,13 @@ export const Details: FC<
 	const detailsFullWindow = useAppSelector((state) =>
 		projectSlice.selectors.selectDetailsFullWindow(state, projectId),
 	);
-	const filesVisible = useAppSelector((state) =>
+	const filesVisibleState = useAppSelector((state) =>
 		projectSlice.selectors.selectFilesVisible(state, projectId),
 	);
+	const canShowFiles = useAppSelector((state) =>
+		projectSlice.selectors.selectCanShowFiles(state, projectId),
+	);
+	const filesVisible = canShowFiles && filesVisibleState;
 	const [commitBodyCollapsed, setCommitBodyCollapsed] = useState(true);
 	const [branchTab, setBranchTab] = useState<BranchTab>("diff");
 	const commitBodyId = useId();

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -27,7 +27,6 @@ import { decodeBytes } from "#ui/api/bytes.ts";
 import { commitBody, commitTitle, shortCommitId } from "#ui/commit.ts";
 import {
 	branchFileParent,
-	uncommittedChangesFileParent,
 	commitFileParent,
 	FileOperand,
 	fileOperand,
@@ -708,12 +707,6 @@ const Title: FC<{
 					)}
 				</SuspenseQuery>
 			),
-			UncommittedChanges: () => (
-				<div className={styles.title}>
-					<Icon name="file-diff" />
-					<h3 className={classes("text-15", "text-semibold")}>Uncommitted changes</h3>
-				</div>
-			),
 			File: ({ path }) => (
 				<div className={styles.title}>
 					<Icon name="file" />
@@ -981,7 +974,6 @@ const Diff: FC<{
 	const changesetKey = Match.value(outlineSelection).pipe(
 		Match.tags({
 			Branch: ({ branchRef }) => decodeBytes(branchRef),
-			UncommittedChanges: () => "uncommittedChanges",
 			File: ({ path }) => path,
 			Commit: ({ commitId }) => commitId,
 		}),
@@ -990,7 +982,6 @@ const Diff: FC<{
 	const fileParent = Match.value(outlineSelection).pipe(
 		Match.tags({
 			Branch: ({ branchRef }) => branchFileParent({ branchRef }),
-			UncommittedChanges: () => uncommittedChangesFileParent,
 			File: ({ parent }) => parent,
 			Commit: ({ commitId }) => commitFileParent({ commitId }),
 		}),
@@ -1625,16 +1616,6 @@ export const Details: FC<
 										renderDiff({
 											changes: commitDetails.changes,
 											filesItems: getCommitFileRowItems({ commitDetails }),
-										})
-									}
-								</SuspenseQuery>
-							),
-							UncommittedChanges: () => (
-								<SuspenseQuery {...changesInWorktreeQueryOptions(projectId)}>
-									{({ data: worktreeChanges }) =>
-										renderDiff({
-											changes: worktreeChanges.changes,
-											filesItems: getChangesFileRowItems(worktreeChanges),
 										})
 									}
 								</SuspenseQuery>

--- a/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.module.css
@@ -1,9 +1,3 @@
-.section {
-	padding: 6px;
-	border-radius: var(--radius-l);
-	background-color: var(--bg-2);
-}
-
 .tree {
 	display: flex;
 	flex-direction: column;

--- a/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.tsx
@@ -129,6 +129,7 @@ export const FilesTree: FC<
 		onFileSelection: (selection: string) => void;
 		navigationIndex: NavigationIndex<string>;
 		fileParent: FileParent;
+		emptyLabel?: string;
 	} & ComponentProps<"div">
 > = ({
 	items,
@@ -137,6 +138,7 @@ export const FilesTree: FC<
 	projectId,
 	navigationIndex,
 	fileParent,
+	emptyLabel = "No changes.",
 	ref: refProp,
 	...props
 }) => {
@@ -169,7 +171,7 @@ export const FilesTree: FC<
 				{items.length === 0 ? (
 					<Row interactive={false}>
 						<RowLabelContainer>
-							<RowLabel className={rowStyles.fadedText}>No changes.</RowLabel>
+							<RowLabel className={rowStyles.fadedText}>{emptyLabel}</RowLabel>
 						</RowLabelContainer>
 					</Row>
 				) : (

--- a/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.tsx
@@ -167,52 +167,50 @@ export const FilesTree: FC<
 			className={classes(props.className, styles.tree)}
 			ref={useMergedRefs(refProp, ref)}
 		>
-			<div className={styles.section}>
-				{items.length === 0 ? (
-					<Row interactive={false}>
-						<RowLabelContainer>
-							<RowLabel className={rowStyles.fadedText}>{emptyLabel}</RowLabel>
-						</RowLabelContainer>
-					</Row>
-				) : (
-					// oxlint-disable-next-line jsx-a11y/prefer-tag-over-role -- Tree items need ARIA group semantics.
-					<div role="group">
-						{items.map((item) => (
-							<TreeItem
-								key={item.path}
-								isSelected={selection !== null && selection === item.path}
-								aria-label={
-									item._tag === "Change"
-										? `${item.change.status.type} ${item.change.path}`
-										: `Conflict ${item.path}`
-								}
-								path={item.path}
-								render={
-									<OperationSourceC
-										projectId={projectId}
-										source={fileOperand({ parent: fileParent, path: item.path })}
-										outline="outside"
-										render={
-											<FileRow
-												item={item}
-												headInfoIndex={headInfoIndex}
-												inert={!navigationIndexIncludes(navigationIndex, item.path, (path) => path)}
-												isSelected={selection !== null && selection === item.path}
-												onSelect={() => onFileSelection(item.path)}
-												projectId={projectId}
-												fileParent={fileParent}
-												branchNameByCommitId={(cid) =>
-													headInfoIndex?.commitContextById(cid)?.segment.refName?.displayName
-												}
-											/>
-										}
-									/>
-								}
-							/>
-						))}
-					</div>
-				)}
-			</div>
+			{items.length === 0 ? (
+				<Row interactive={false}>
+					<RowLabelContainer>
+						<RowLabel className={rowStyles.fadedText}>{emptyLabel}</RowLabel>
+					</RowLabelContainer>
+				</Row>
+			) : (
+				// oxlint-disable-next-line jsx-a11y/prefer-tag-over-role -- Tree items need ARIA group semantics.
+				<div role="group">
+					{items.map((item) => (
+						<TreeItem
+							key={item.path}
+							isSelected={selection !== null && selection === item.path}
+							aria-label={
+								item._tag === "Change"
+									? `${item.change.status.type} ${item.change.path}`
+									: `Conflict ${item.path}`
+							}
+							path={item.path}
+							render={
+								<OperationSourceC
+									projectId={projectId}
+									source={fileOperand({ parent: fileParent, path: item.path })}
+									outline="outside"
+									render={
+										<FileRow
+											item={item}
+											headInfoIndex={headInfoIndex}
+											inert={!navigationIndexIncludes(navigationIndex, item.path, (path) => path)}
+											isSelected={selection !== null && selection === item.path}
+											onSelect={() => onFileSelection(item.path)}
+											projectId={projectId}
+											fileParent={fileParent}
+											branchNameByCommitId={(cid) =>
+												headInfoIndex?.commitContextById(cid)?.segment.refName?.displayName
+											}
+										/>
+									}
+								/>
+							}
+						/>
+					))}
+				</div>
+			)}
 		</div>
 	);
 };

--- a/apps/lite/ui/src/routes/project/$id/workspace/OperationControls.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OperationControls.tsx
@@ -16,7 +16,6 @@ import {
 } from "#ui/operations/operation.ts";
 import { projectSlice } from "#ui/projects/state.ts";
 import { operandLabel, operandsLabel } from "#ui/routes/project/$id/workspace/operandLabel.ts";
-import {} from "#ui/selection-scopes.ts";
 import { useAppDispatch, useAppSelector } from "#ui/store.ts";
 import { Button, Toggle, ToggleGroup, Tooltip } from "@base-ui/react";
 import { useHotkeys, type UseHotkeyDefinition } from "@tanstack/react-hotkeys";
@@ -288,6 +287,9 @@ const TransferKeyboardOperationControls: FC<{
 	mode: KeyboardTransferMode;
 	outlineNavigationIndex: NavigationIndex<Operand>;
 }> = ({ headInfoIndex, projectId, mode, outlineNavigationIndex }) => {
+	const detailsSelectionScope = useAppSelector((state) =>
+		projectSlice.selectors.selectDetailsSelectionScope(state, projectId),
+	);
 	const selection = useAppSelector((state) =>
 		projectSlice.selectors.selectSelectionOutline(state, projectId, outlineNavigationIndex),
 	);
@@ -295,7 +297,7 @@ const TransferKeyboardOperationControls: FC<{
 	const dispatch = useAppDispatch();
 	const { mutate: runOperation } = useRunOperation();
 
-	const target = getTransferTarget(keyboardTransferMode(mode), selection);
+	const target = getTransferTarget(keyboardTransferMode(mode), selection, detailsSelectionScope);
 	if (!target) return null;
 
 	const operations = getOperations(mode.sources, target);

--- a/apps/lite/ui/src/routes/project/$id/workspace/OperationControls.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OperationControls.tsx
@@ -16,7 +16,7 @@ import {
 } from "#ui/operations/operation.ts";
 import { projectSlice } from "#ui/projects/state.ts";
 import { operandLabel, operandsLabel } from "#ui/routes/project/$id/workspace/operandLabel.ts";
-import { focusSelectionScope } from "#ui/selection-scopes.ts";
+import {} from "#ui/selection-scopes.ts";
 import { useAppDispatch, useAppSelector } from "#ui/store.ts";
 import { Button, Toggle, ToggleGroup, Tooltip } from "@base-ui/react";
 import { useHotkeys, type UseHotkeyDefinition } from "@tanstack/react-hotkeys";
@@ -141,7 +141,6 @@ const CheckedCommitOperationControls: FC<{ checkedCommitCount: number; projectId
 
 	const cancel = () => {
 		dispatch(projectSlice.actions.clearCheckedCommits({ projectId }));
-		focusSelectionScope("outline");
 	};
 
 	return (
@@ -174,14 +173,12 @@ const AbsorbOperationControls: FC<{
 
 	const run = () => {
 		dispatch(projectSlice.actions.exitMode({ projectId }));
-		focusSelectionScope("outline");
 
 		absorb(absorptionPlan);
 	};
 
 	const cancel = () => {
 		dispatch(projectSlice.actions.cancelMode({ projectId }));
-		focusSelectionScope("outline");
 	};
 
 	return (
@@ -242,7 +239,6 @@ const TransferTypeToggleGroup: FC<{
 		const nextOperationType = value[0] as OperationType;
 
 		setOperationType(nextOperationType);
-		focusSelectionScope("outline");
 	};
 
 	return (
@@ -307,7 +303,6 @@ const TransferKeyboardOperationControls: FC<{
 
 	const run = () => {
 		dispatch(projectSlice.actions.exitMode({ projectId }));
-		focusSelectionScope("outline");
 
 		if (!operation) return;
 
@@ -316,7 +311,6 @@ const TransferKeyboardOperationControls: FC<{
 
 	const cancel = () => {
 		dispatch(projectSlice.actions.cancelMode({ projectId }));
-		focusSelectionScope("outline");
 	};
 
 	return (

--- a/apps/lite/ui/src/routes/project/$id/workspace/Outline.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Outline.tsx
@@ -15,7 +15,7 @@ import { TooltipPopup } from "#ui/components/Tooltip.tsx";
 import { globalHotkeys, workspaceHotkeys } from "#ui/hotkeys.ts";
 import { branchOperand, type BranchOperand, type Operand } from "#ui/operands.ts";
 import { projectSlice } from "#ui/projects/state.ts";
-import { focusSelectionScope, type SelectionScope } from "#ui/selection-scopes.ts";
+import { focusSelectionScope } from "#ui/selection-scopes.ts";
 import { useAppDispatch, useAppSelector } from "#ui/store.ts";
 import { formatRelativeTime } from "#ui/time.ts";
 import type { NavigationIndex } from "#ui/workspace/navigation-index.ts";
@@ -383,19 +383,11 @@ export const Outline: FC<
 
 			<OutlineTree
 				className={styles.outlineTree}
-				data-selection-scope={"outline" satisfies SelectionScope}
 				navigationIndex={navigationIndex}
 				absorptionTargetCommitIds={absorptionTargetCommitIds}
 				headInfoIndex={headInfoIndex}
 				projectId={projectId}
 				commitTarget={commitTarget?.relativeTo ?? null}
-				// Focus on page load.
-				ref={(el) => {
-					// Don't steal focus if this component is mounted later on.
-					if (document.activeElement !== document.body) return;
-
-					el?.focus({ focusVisible: false });
-				}}
 			/>
 		</div>
 	);

--- a/apps/lite/ui/src/routes/project/$id/workspace/Outline.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Outline.tsx
@@ -26,14 +26,9 @@ import { useHotkeys } from "@tanstack/react-hotkeys";
 import { Match } from "effect";
 import { type ComponentProps, type FC, useState } from "react";
 import { ToggleGroupStyles, ToggleStyles } from "#ui/components/ToggleGroup.tsx";
-import {
-	buildCommitTargetComboboxItems,
-	selectCommitTargetComboboxItem,
-} from "#ui/routes/project/$id/workspace/OutlineTree/commitTargetComboboxItems.ts";
 import { OutlineTree } from "#ui/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx";
 import styles from "./Outline.module.css";
 import { TopLeftControls } from "#ui/routes/project/$id/workspace/TopLeftControls.tsx";
-import { CommitForm } from "#ui/routes/project/$id/workspace/CommitForm.tsx";
 
 const ActivitySpinner: FC = () => {
 	const fetchingCount = useIsFetching();
@@ -153,18 +148,6 @@ export const Outline: FC<
 	const { data: guiSettings } = useQuery(guiSettingsQueryOptions);
 	const { data: workspaceFetchStatus } = useQuery(workspaceFetchStatusQueryOptions(projectId));
 	const headInfoIndex = headInfo ? getHeadInfoIndex(headInfo) : undefined;
-	const commitTargetState = useAppSelector((state) =>
-		projectSlice.selectors.selectCommitTarget(state, projectId),
-	);
-	const targetComboboxItems = buildCommitTargetComboboxItems({
-		headInfo,
-		headInfoIndex,
-		commitTargetState,
-	});
-	const commitTarget = selectCommitTargetComboboxItem({
-		items: targetComboboxItems,
-		commitTargetState,
-	});
 	const rebaseUpdates =
 		headInfo?.stacks.flatMap((stack): Array<BottomUpdate> => {
 			const relativeTo = stackBottomRelativeTo(stack);
@@ -381,12 +364,6 @@ export const Outline: FC<
 						Branches
 					</Toggle>
 				</ToggleGroup>
-
-				<CommitForm
-					projectId={projectId}
-					commitTarget={commitTarget}
-					targetComboboxItems={targetComboboxItems}
-				/>
 			</div>
 
 			<OutlineTree
@@ -394,9 +371,9 @@ export const Outline: FC<
 				navigationIndex={navigationIndex}
 				uncommittedFilesNavigationIndex={uncommittedFilesNavigationIndex}
 				absorptionTargetCommitIds={absorptionTargetCommitIds}
+				headInfo={headInfo}
 				headInfoIndex={headInfoIndex}
 				projectId={projectId}
-				commitTarget={commitTarget?.relativeTo ?? null}
 			/>
 		</div>
 	);

--- a/apps/lite/ui/src/routes/project/$id/workspace/Outline.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Outline.tsx
@@ -5,7 +5,6 @@ import {
 	workspaceFetchQueryOptions,
 	workspaceFetchStatusQueryOptions,
 } from "#ui/api/queries.ts";
-import { getHeadInfoIndex } from "#ui/api/ref-info.ts";
 import { stackBottomRelativeTo } from "#ui/api/stack.ts";
 import { getButtonClassName } from "#ui/components/Button.tsx";
 import { classes } from "#ui/components/classes.ts";
@@ -147,7 +146,6 @@ export const Outline: FC<
 	const { data: headInfo } = useQuery(headInfoQueryOptions(projectId));
 	const { data: guiSettings } = useQuery(guiSettingsQueryOptions);
 	const { data: workspaceFetchStatus } = useQuery(workspaceFetchStatusQueryOptions(projectId));
-	const headInfoIndex = headInfo ? getHeadInfoIndex(headInfo) : undefined;
 	const rebaseUpdates =
 		headInfo?.stacks.flatMap((stack): Array<BottomUpdate> => {
 			const relativeTo = stackBottomRelativeTo(stack);
@@ -371,8 +369,6 @@ export const Outline: FC<
 				navigationIndex={navigationIndex}
 				uncommittedFilesNavigationIndex={uncommittedFilesNavigationIndex}
 				absorptionTargetCommitIds={absorptionTargetCommitIds}
-				headInfo={headInfo}
-				headInfoIndex={headInfoIndex}
 				projectId={projectId}
 			/>
 		</div>

--- a/apps/lite/ui/src/routes/project/$id/workspace/Outline.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Outline.tsx
@@ -93,10 +93,18 @@ export const Outline: FC<
 	{
 		absorptionTargetCommitIds: ReadonlySet<string>;
 		navigationIndex: NavigationIndex<Operand>;
+		uncommittedFilesNavigationIndex: NavigationIndex<string>;
 		project: ProjectForFrontend;
 		projectId: string;
 	} & ComponentProps<"div">
-> = ({ absorptionTargetCommitIds, navigationIndex, project, projectId, ...restProps }) => {
+> = ({
+	absorptionTargetCommitIds,
+	navigationIndex,
+	uncommittedFilesNavigationIndex,
+	project,
+	projectId,
+	...restProps
+}) => {
 	const dispatch = useAppDispatch();
 	const toastManager = Toast.useToastManager();
 	const isDefaultMode = useAppSelector(
@@ -384,6 +392,7 @@ export const Outline: FC<
 			<OutlineTree
 				className={styles.outlineTree}
 				navigationIndex={navigationIndex}
+				uncommittedFilesNavigationIndex={uncommittedFilesNavigationIndex}
 				absorptionTargetCommitIds={absorptionTargetCommitIds}
 				headInfoIndex={headInfoIndex}
 				projectId={projectId}

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.module.css
@@ -42,10 +42,12 @@
 	display: flex;
 	flex-grow: 1;
 	flex-direction: column;
+	min-height: 0;
 }
 
 .uncommittedChangesTree {
 	flex-grow: 1;
+	overflow: auto;
 }
 
 .stacks {

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.module.css
@@ -29,11 +29,23 @@
 }
 
 .panel {
+	display: flex;
+	flex-direction: column;
 	padding-inline: var(--panel-padding-inline);
 	padding-block: var(--panel-padding-block);
 	overflow: auto;
 	scroll-padding-block: var(--panel-padding-block);
 	scroll-padding-inline: var(--panel-padding-inline);
+}
+
+.uncommittedChanges {
+	display: flex;
+	flex-grow: 1;
+	flex-direction: column;
+}
+
+.uncommittedChangesTree {
+	flex-grow: 1;
 }
 
 .stacks {

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
@@ -1,7 +1,7 @@
 import rowStyles from "../Row.module.css";
 import { changesInWorktreeQueryOptions, headInfoQueryOptions } from "#ui/api/queries.ts";
 import { relativeToEquals } from "#ui/api/relative-to.ts";
-import { getHeadInfoIndex, type HeadInfoIndex } from "#ui/api/ref-info.ts";
+import { getHeadInfoIndex } from "#ui/api/ref-info.ts";
 import { commitIsDiverged, commitTitle } from "#ui/commit.ts";
 import {
 	branchOperand,
@@ -33,7 +33,6 @@ import {
 	Stack,
 	PushStatus,
 	WorkspaceState,
-	type RefInfo,
 } from "@gitbutler/but-sdk";
 import { useQuery } from "@tanstack/react-query";
 import { Match } from "effect";
@@ -606,21 +605,20 @@ const Stacks: FC<{
 export const OutlineTree: FC<
 	{
 		projectId: string;
-		headInfo: RefInfo | undefined;
 		navigationIndex: NavigationIndex<Operand>;
 		uncommittedFilesNavigationIndex: NavigationIndex<string>;
 		absorptionTargetCommitIds: ReadonlySet<string>;
-		headInfoIndex: HeadInfoIndex | undefined;
 	} & ComponentProps<"div">
 > = ({
 	projectId,
-	headInfo,
 	navigationIndex,
 	uncommittedFilesNavigationIndex,
 	absorptionTargetCommitIds,
-	headInfoIndex,
 	...props
 }) => {
+	const { data: headInfo } = useQuery(headInfoQueryOptions(projectId));
+	const headInfoIndex = headInfo ? getHeadInfoIndex(headInfo) : undefined;
+
 	const commitTargetState = useAppSelector((state) =>
 		projectSlice.selectors.selectCommitTarget(state, projectId),
 	);

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
@@ -25,7 +25,11 @@ import { useOperationDropTarget } from "#ui/routes/project/$id/workspace/useOper
 import { NavigationIndexContext } from "#ui/routes/project/$id/workspace/OutlineNavigationIndexContext.ts";
 import { useAppDispatch, useAppSelector, useAppStore } from "#ui/store.ts";
 import { classes } from "#ui/components/classes.ts";
-import { navigationIndexIncludes, type NavigationIndex } from "#ui/workspace/navigation-index.ts";
+import {
+	buildIndexByKey,
+	navigationIndexIncludes,
+	type NavigationIndex,
+} from "#ui/workspace/navigation-index.ts";
 import { mergeProps, Tooltip, useRender } from "@base-ui/react";
 import {
 	BranchReference,
@@ -45,14 +49,12 @@ import { getOperation, OperationType, useDryRunOperation } from "#ui/operations/
 import { GraphSegment, GraphSegmentStatus } from "#ui/components/GraphSegment.tsx";
 import { segmentBottomRelativeTo } from "#ui/api/stack.ts";
 import { assert } from "#ui/assert.ts";
-import { useMergedRefs } from "@base-ui/utils/useMergedRefs";
 import { CommitRow } from "./CommitRow.tsx";
 import { BranchRow } from "./BranchRow.tsx";
 import { StackRow } from "./StackRow.tsx";
 import { useOutlineTreeHotkeys } from "./hotkeys.ts";
 import { UncommittedChangesRow } from "./UncommittedChangesRow.tsx";
-import { FileRow } from "../FileRow.tsx";
-import { getChangesFileRowItems, type FileRowItem } from "../file-row.ts";
+import { getChangesFileRowItems } from "../file-row.ts";
 import {
 	canRemoveBranchReference,
 	downstackPushStatusesFromSegments,
@@ -61,6 +63,7 @@ import {
 import { checkedRange, navigationIndexRange } from "#ui/checking.ts";
 import { TooltipPopup } from "#ui/components/Tooltip.tsx";
 import { SelectionScope } from "#ui/selection-scopes.ts";
+import { FilesTree } from "#ui/routes/project/$id/workspace/FilesTree.tsx";
 
 const DryRunWorkspaceContext = createContext<WorkspaceState | null>(null);
 
@@ -204,115 +207,56 @@ const OperandC: FC<
 
 const UncommittedChanges: FC<{
 	projectId: string;
-	checkCommit: (evt: { commitId: string; shiftKey: boolean }) => void;
-}> = ({ projectId, checkCommit }) => {
-	const navigationIndex = assert(use(NavigationIndexContext));
+}> = ({ projectId }) => {
+	const outlineNavigationIndex = assert(use(NavigationIndexContext));
+	const dispatch = useAppDispatch();
 
 	const { data: worktreeChanges } = useQuery(changesInWorktreeQueryOptions(projectId));
 	const fileRowItems = worktreeChanges ? getChangesFileRowItems(worktreeChanges) : [];
 
-	const { data: headInfo } = useQuery(headInfoQueryOptions(projectId));
-	const headInfoIndex = headInfo ? getHeadInfoIndex(headInfo) : null;
 	const selection = useAppSelector((state) =>
-		projectSlice.selectors.selectSelectionOutline(state, projectId, navigationIndex),
+		projectSlice.selectors.selectSelectionOutline(state, projectId, outlineNavigationIndex),
 	);
-
-	const uncommittedFilesHotkeysRef = useRef<HTMLDivElement>(null);
-	useOutlineTreeHotkeys({
-		navigationIndex,
-		projectId,
-		ref: uncommittedFilesHotkeysRef,
-		checkCommit,
-	});
+	const fileSelection =
+		selection?._tag === "File" && selection.parent._tag === "UncommittedChanges"
+			? selection.path
+			: null;
+	const navigationItems = outlineNavigationIndex.items.flatMap((item) =>
+		item._tag === "File" && item.parent._tag === "UncommittedChanges" ? [item.path] : [],
+	);
+	const navigationIndex: NavigationIndex<string> = {
+		items: navigationItems,
+		indexByKey: buildIndexByKey(navigationItems, (path) => path),
+	};
 
 	return (
 		<div>
 			<UncommittedChangesRow changes={worktreeChanges?.changes ?? []} projectId={projectId} />
 
-			<div
-				tabIndex={0}
-				role="tree"
-				aria-activedescendant={selection ? treeItemId(selection) : undefined}
-				className={styles.tree}
+			<FilesTree
 				data-selection-scope={"uncommitted-files" satisfies SelectionScope}
-				// Focus on page load.
-				ref={useMergedRefs(uncommittedFilesHotkeysRef, (el) => {
+				emptyLabel="Nothing to commit"
+				fileParent={uncommittedChangesFileParent}
+				items={fileRowItems}
+				navigationIndex={navigationIndex}
+				onFileSelection={(selection) =>
+					dispatch(
+						projectSlice.actions.selectOutline({
+							projectId,
+							selection: fileOperand({ parent: uncommittedChangesFileParent, path: selection }),
+						}),
+					)
+				}
+				projectId={projectId}
+				ref={(el) => {
 					// Don't steal focus if this component is mounted later on.
 					if (document.activeElement !== document.body) return;
 
 					el?.focus({ focusVisible: false });
-				})}
-			>
-				{(worktreeChanges?.changes.length ?? 0) === 0 ? (
-					<Row interactive={false}>
-						<RowLabelContainer>
-							<RowLabel className={rowStyles.fadedText}>Nothing to commit</RowLabel>
-						</RowLabelContainer>
-					</Row>
-				) : (
-					// oxlint-disable-next-line jsx-a11y/prefer-tag-over-role -- Tree items need ARIA group semantics.
-					<div role="group">
-						{fileRowItems.map((item) => (
-							<UncommittedFileRow
-								key={item.path}
-								item={item}
-								projectId={projectId}
-								headInfoIndex={headInfoIndex ?? undefined}
-								branchNameByCommitId={(cid) =>
-									headInfoIndex?.commitContextById(cid)?.segment.refName?.displayName
-								}
-							/>
-						))}
-					</div>
-				)}
-			</div>
+				}}
+				selection={fileSelection}
+			/>
 		</div>
-	);
-};
-
-const UncommittedFileRow: FC<{
-	item: FileRowItem;
-	projectId: string;
-	headInfoIndex: HeadInfoIndex | undefined;
-	branchNameByCommitId: (commitId: string) => string | undefined;
-}> = ({ item, projectId, headInfoIndex, branchNameByCommitId }) => {
-	const operand = fileOperand({
-		parent: uncommittedChangesFileParent,
-		path: item.path,
-	});
-	const navigationIndex = assert(use(NavigationIndexContext));
-	const isSelected = useAppSelector((state) =>
-		projectSlice.selectors.selectIsSelectedOutline(state, projectId, navigationIndex, operand),
-	);
-	const dispatch = useAppDispatch();
-
-	return (
-		<TreeItem
-			projectId={projectId}
-			operand={operand}
-			aria-label={item.path}
-			render={
-				<OperandC
-					projectId={projectId}
-					operand={operand}
-					outline="outside"
-					render={
-						<FileRow
-							item={item}
-							projectId={projectId}
-							fileParent={uncommittedChangesFileParent}
-							headInfoIndex={headInfoIndex}
-							branchNameByCommitId={branchNameByCommitId}
-							inert={!navigationIndexIncludes(navigationIndex, operand, operandIdentityKey)}
-							isSelected={isSelected}
-							onSelect={() => {
-								dispatch(projectSlice.actions.selectOutline({ projectId, selection: operand }));
-							}}
-						/>
-					}
-				/>
-			}
-		/>
 	);
 };
 
@@ -748,7 +692,7 @@ export const OutlineTree: FC<
 									outline="inside"
 									render={
 										<div className={styles.panel}>
-											<UncommittedChanges projectId={projectId} checkCommit={checkCommit} />
+											<UncommittedChanges projectId={projectId} />
 										</div>
 									}
 								/>

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
@@ -158,7 +158,15 @@ const OperationTarget: FC<
 	});
 
 	return (
-		<Tooltip.Root open={activeOperation?.tooltip !== undefined} disableHoverablePopup>
+		<Tooltip.Root
+			open={activeOperation?.tooltip !== undefined}
+			disableHoverablePopup
+			onOpenChange={(_, eventDetails) => {
+				// Allow escape to bubble up from tree so it triggers the cancel
+				// operation shortcut.
+				if (eventDetails.reason === "escape-key") eventDetails.allowPropagation();
+			}}
+		>
 			<Tooltip.Trigger
 				{...props}
 				render={

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
@@ -233,7 +233,7 @@ const UncommittedChanges: FC<{
 				tabIndex={0}
 				role="tree"
 				aria-activedescendant={selection ? treeItemId(selection) : undefined}
-				className={classes(styles.section, styles.tree)}
+				className={styles.tree}
 				data-selection-scope={"uncommitted-files" satisfies SelectionScope}
 				// Focus on page load.
 				ref={useMergedRefs(uncommittedFilesHotkeysRef, (el) => {

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
@@ -219,6 +219,14 @@ const UncommittedChanges: FC<{
 
 			<FilesTree
 				data-selection-scope={"uncommitted-files" satisfies SelectionScope}
+				onFocus={() =>
+					dispatch(
+						projectSlice.actions.setDetailsSelectionScope({
+							projectId,
+							scope: "uncommitted-files",
+						}),
+					)
+				}
 				emptyLabel="Nothing to commit"
 				fileParent={uncommittedChangesFileParent}
 				items={fileRowItems}
@@ -508,6 +516,7 @@ const Stacks: FC<{
 	checkCommit: (evt: { commitId: string; shiftKey: boolean }) => void;
 }> = ({ projectId, commitTarget, checkCommit }) => {
 	const navigationIndex = assert(use(NavigationIndexContext));
+	const dispatch = useAppDispatch();
 	const { data: headInfo } = useQuery(headInfoQueryOptions(projectId));
 	const selection = useAppSelector((state) =>
 		projectSlice.selectors.selectSelectionOutline(state, projectId, navigationIndex),
@@ -557,6 +566,9 @@ const Stacks: FC<{
 				aria-activedescendant={selection ? treeItemId(selection) : undefined}
 				className={classes(styles.tree, styles.stacks)}
 				data-selection-scope={"outline" satisfies SelectionScope}
+				onFocus={() =>
+					dispatch(projectSlice.actions.setDetailsSelectionScope({ projectId, scope: "outline" }))
+				}
 				ref={hotkeysRef}
 			>
 				{(headInfo?.stacks.toReversed() ?? []).map((stack) => (

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
@@ -60,6 +60,7 @@ import {
 } from "#ui/segment.ts";
 import { checkedRange, navigationIndexRange } from "#ui/checking.ts";
 import { TooltipPopup } from "#ui/components/Tooltip.tsx";
+import { SelectionScope } from "#ui/selection-scopes.ts";
 
 const DryRunWorkspaceContext = createContext<WorkspaceState | null>(null);
 
@@ -203,7 +204,10 @@ const OperandC: FC<
 
 const UncommittedChanges: FC<{
 	projectId: string;
-}> = ({ projectId }) => {
+	checkCommit: (evt: { commitId: string; shiftKey: boolean }) => void;
+}> = ({ projectId, checkCommit }) => {
+	const navigationIndex = assert(use(NavigationIndexContext));
+
 	const { data: worktreeChanges } = useQuery(changesInWorktreeQueryOptions(projectId));
 	const fileRowItems = worktreeChanges ? getChangesFileRowItems(worktreeChanges) : [];
 
@@ -211,39 +215,65 @@ const UncommittedChanges: FC<{
 
 	const { data: headInfo } = useQuery(headInfoQueryOptions(projectId));
 	const headInfoIndex = headInfo ? getHeadInfoIndex(headInfo) : null;
+	const selection = useAppSelector((state) =>
+		projectSlice.selectors.selectSelectionOutline(state, projectId, navigationIndex),
+	);
+
+	const uncommittedFilesHotkeysRef = useRef<HTMLDivElement>(null);
+	useOutlineTreeHotkeys({
+		navigationIndex,
+		projectId,
+		ref: uncommittedFilesHotkeysRef,
+		checkCommit,
+	});
 
 	return (
-		<TreeItem
-			projectId={projectId}
-			operand={operand}
-			aria-label={`Uncommitted changes (${worktreeChanges?.changes.length ?? 0})`}
-			className={styles.section}
-		>
-			<UncommittedChangesRow changes={worktreeChanges?.changes ?? []} projectId={projectId} />
+		<div
+			tabIndex={0}
+			role="tree"
+			aria-activedescendant={selection ? treeItemId(selection) : undefined}
+			className={styles.tree}
+			data-selection-scope={"uncommitted-files" satisfies SelectionScope}
+			// Focus on page load.
+			ref={useMergedRefs(uncommittedFilesHotkeysRef, (el) => {
+				// Don't steal focus if this component is mounted later on.
+				if (document.activeElement !== document.body) return;
 
-			{(worktreeChanges?.changes.length ?? 0) === 0 ? (
-				<Row interactive={false}>
-					<RowLabelContainer>
-						<RowLabel className={rowStyles.fadedText}>Nothing to commit</RowLabel>
-					</RowLabelContainer>
-				</Row>
-			) : (
-				// oxlint-disable-next-line jsx-a11y/prefer-tag-over-role -- Tree items need ARIA group semantics.
-				<div role="group">
-					{fileRowItems.map((item) => (
-						<UncommittedFileRow
-							key={item.path}
-							item={item}
-							projectId={projectId}
-							headInfoIndex={headInfoIndex ?? undefined}
-							branchNameByCommitId={(cid) =>
-								headInfoIndex?.commitContextById(cid)?.segment.refName?.displayName
-							}
-						/>
-					))}
-				</div>
-			)}
-		</TreeItem>
+				el?.focus({ focusVisible: false });
+			})}
+		>
+			<TreeItem
+				projectId={projectId}
+				operand={operand}
+				aria-label={`Uncommitted changes (${worktreeChanges?.changes.length ?? 0})`}
+				className={styles.section}
+			>
+				<UncommittedChangesRow changes={worktreeChanges?.changes ?? []} projectId={projectId} />
+
+				{(worktreeChanges?.changes.length ?? 0) === 0 ? (
+					<Row interactive={false}>
+						<RowLabelContainer>
+							<RowLabel className={rowStyles.fadedText}>Nothing to commit</RowLabel>
+						</RowLabelContainer>
+					</Row>
+				) : (
+					// oxlint-disable-next-line jsx-a11y/prefer-tag-over-role -- Tree items need ARIA group semantics.
+					<div role="group">
+						{fileRowItems.map((item) => (
+							<UncommittedFileRow
+								key={item.path}
+								item={item}
+								projectId={projectId}
+								headInfoIndex={headInfoIndex ?? undefined}
+								branchNameByCommitId={(cid) =>
+									headInfoIndex?.commitContextById(cid)?.segment.refName?.displayName
+								}
+							/>
+						))}
+					</div>
+				)}
+			</TreeItem>
+		</div>
 	);
 };
 
@@ -563,12 +593,10 @@ const Stacks: FC<{
 }> = ({ projectId, commitTarget, checkCommit }) => {
 	const navigationIndex = assert(use(NavigationIndexContext));
 	const { data: headInfo } = useQuery(headInfoQueryOptions(projectId));
+	const selection = useAppSelector((state) =>
+		projectSlice.selectors.selectSelectionOutline(state, projectId, navigationIndex),
+	);
 	const dryRunOperation = useAppSelector((state) => {
-		const selection = projectSlice.selectors.selectSelectionOutline(
-			state,
-			projectId,
-			navigationIndex,
-		);
 		const outlineMode = projectSlice.selectors.selectOutlineModeState(state, projectId);
 
 		return Match.value(outlineMode).pipe(
@@ -597,9 +625,24 @@ const Stacks: FC<{
 	});
 	const dryRunWorkspace = dryRunOperationResult?.workspace ?? null;
 
+	const hotkeysRef = useRef<HTMLDivElement>(null);
+	useOutlineTreeHotkeys({
+		navigationIndex,
+		projectId,
+		ref: hotkeysRef,
+		checkCommit,
+	});
+
 	return (
 		<DryRunWorkspaceContext value={dryRunWorkspace}>
-			<div className={styles.stacks}>
+			<div
+				tabIndex={0}
+				role="tree"
+				aria-activedescendant={selection ? treeItemId(selection) : undefined}
+				className={classes(styles.tree, styles.stacks)}
+				data-selection-scope={"outline" satisfies SelectionScope}
+				ref={hotkeysRef}
+			>
 				{(headInfo?.stacks.toReversed() ?? []).map((stack) => (
 					<StackC
 						key={stack.id}
@@ -628,12 +671,8 @@ export const OutlineTree: FC<
 	navigationIndex,
 	absorptionTargetCommitIds,
 	headInfoIndex,
-	ref: refProp,
 	...props
 }) => {
-	const selection = useAppSelector((state) =>
-		projectSlice.selectors.selectSelectionOutline(state, projectId, navigationIndex),
-	);
 	const hasCheckedCommits = useAppSelector((state) =>
 		headInfoIndex
 			? projectSlice.selectors.selectHasCheckedCommits(state, projectId, headInfoIndex)
@@ -685,14 +724,6 @@ export const OutlineTree: FC<
 		panelIds: ["uncommitted-changes-panel", "stacks-panel"] satisfies Array<PanelId>,
 	});
 
-	const hotkeysRef = useRef<HTMLDivElement>(null);
-	useOutlineTreeHotkeys({
-		navigationIndex,
-		projectId,
-		ref: hotkeysRef,
-		checkCommit,
-	});
-
 	return (
 		<NavigationIndexContext value={navigationIndex}>
 			<AbsorptionTargetCommitIdsContext value={absorptionTargetCommitIds}>
@@ -700,14 +731,10 @@ export const OutlineTree: FC<
 					{...props}
 					id={layoutId}
 					orientation="vertical"
-					tabIndex={0}
-					role="tree"
-					aria-activedescendant={selection ? treeItemId(selection) : undefined}
 					data-has-checked-commits={hasCheckedCommits || undefined}
 					className={classes(props.className, styles.tree)}
 					defaultLayout={outlineLayout.defaultLayout}
 					onLayoutChanged={outlineLayout.onLayoutChanged}
-					elementRef={useMergedRefs(refProp, hotkeysRef)}
 				>
 					<Panel
 						id={"uncommitted-changes-panel" satisfies PanelId}
@@ -722,7 +749,7 @@ export const OutlineTree: FC<
 							outline="inside"
 							render={
 								<div className={styles.panel}>
-									<UncommittedChanges projectId={projectId} />
+									<UncommittedChanges projectId={projectId} checkCommit={checkCommit} />
 								</div>
 							}
 						/>

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
@@ -122,6 +122,10 @@ const OperationTarget: FC<
 			navigationIndex,
 		);
 		const outlineMode = projectSlice.selectors.selectOutlineModeState(state, projectId);
+		const detailsSelectionScope = projectSlice.selectors.selectDetailsSelectionScope(
+			state,
+			projectId,
+		);
 
 		return Match.value(outlineMode).pipe(
 			Match.tags({
@@ -135,7 +139,7 @@ const OperationTarget: FC<
 				Transfer: ({ value: mode }): ActiveOperation | null => {
 					if (mode.operationType === null) return null;
 
-					const target = getTransferTarget(mode, selection);
+					const target = getTransferTarget(mode, selection, detailsSelectionScope);
 					const isActive = target !== null && operandEquals(target, operand);
 					if (!isActive) return null;
 
@@ -540,13 +544,17 @@ const Stacks: FC<{
 	);
 	const dryRunOperation = useAppSelector((state) => {
 		const outlineMode = projectSlice.selectors.selectOutlineModeState(state, projectId);
+		const detailsSelectionScope = projectSlice.selectors.selectDetailsSelectionScope(
+			state,
+			projectId,
+		);
 
 		return Match.value(outlineMode).pipe(
 			Match.tags({
 				Transfer: ({ value: mode }) => {
 					if (mode.operationType === null) return;
 
-					const target = getTransferTarget(mode, selection);
+					const target = getTransferTarget(mode, selection, detailsSelectionScope);
 					if (!target) return;
 
 					return getOperation({

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
@@ -211,8 +211,6 @@ const UncommittedChanges: FC<{
 	const { data: worktreeChanges } = useQuery(changesInWorktreeQueryOptions(projectId));
 	const fileRowItems = worktreeChanges ? getChangesFileRowItems(worktreeChanges) : [];
 
-	const operand = uncommittedChangesOperand;
-
 	const { data: headInfo } = useQuery(headInfoQueryOptions(projectId));
 	const headInfoIndex = headInfo ? getHeadInfoIndex(headInfo) : null;
 	const selection = useAppSelector((state) =>
@@ -228,28 +226,23 @@ const UncommittedChanges: FC<{
 	});
 
 	return (
-		<div
-			tabIndex={0}
-			role="tree"
-			aria-activedescendant={selection ? treeItemId(selection) : undefined}
-			className={styles.tree}
-			data-selection-scope={"uncommitted-files" satisfies SelectionScope}
-			// Focus on page load.
-			ref={useMergedRefs(uncommittedFilesHotkeysRef, (el) => {
-				// Don't steal focus if this component is mounted later on.
-				if (document.activeElement !== document.body) return;
+		<div>
+			<UncommittedChangesRow changes={worktreeChanges?.changes ?? []} projectId={projectId} />
 
-				el?.focus({ focusVisible: false });
-			})}
-		>
-			<TreeItem
-				projectId={projectId}
-				operand={operand}
-				aria-label={`Uncommitted changes (${worktreeChanges?.changes.length ?? 0})`}
-				className={styles.section}
+			<div
+				tabIndex={0}
+				role="tree"
+				aria-activedescendant={selection ? treeItemId(selection) : undefined}
+				className={classes(styles.section, styles.tree)}
+				data-selection-scope={"uncommitted-files" satisfies SelectionScope}
+				// Focus on page load.
+				ref={useMergedRefs(uncommittedFilesHotkeysRef, (el) => {
+					// Don't steal focus if this component is mounted later on.
+					if (document.activeElement !== document.body) return;
+
+					el?.focus({ focusVisible: false });
+				})}
 			>
-				<UncommittedChangesRow changes={worktreeChanges?.changes ?? []} projectId={projectId} />
-
 				{(worktreeChanges?.changes.length ?? 0) === 0 ? (
 					<Row interactive={false}>
 						<RowLabelContainer>
@@ -272,7 +265,7 @@ const UncommittedChanges: FC<{
 						))}
 					</div>
 				)}
-			</TreeItem>
+			</div>
 		</div>
 	);
 };

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
@@ -8,7 +8,6 @@ import {
 	uncommittedChangesOperand,
 	uncommittedChangesFileParent,
 	commitOperand,
-	fileOperand,
 	operandIdentityKey,
 	stackOperand,
 	type Operand,
@@ -25,11 +24,7 @@ import { useOperationDropTarget } from "#ui/routes/project/$id/workspace/useOper
 import { NavigationIndexContext } from "#ui/routes/project/$id/workspace/OutlineNavigationIndexContext.ts";
 import { useAppDispatch, useAppSelector, useAppStore } from "#ui/store.ts";
 import { classes } from "#ui/components/classes.ts";
-import {
-	buildIndexByKey,
-	navigationIndexIncludes,
-	type NavigationIndex,
-} from "#ui/workspace/navigation-index.ts";
+import { navigationIndexIncludes, type NavigationIndex } from "#ui/workspace/navigation-index.ts";
 import { mergeProps, Tooltip, useRender } from "@base-ui/react";
 import {
 	BranchReference,
@@ -206,28 +201,17 @@ const OperandC: FC<
 };
 
 const UncommittedChanges: FC<{
+	navigationIndex: NavigationIndex<string>;
 	projectId: string;
-}> = ({ projectId }) => {
-	const outlineNavigationIndex = assert(use(NavigationIndexContext));
+}> = ({ navigationIndex, projectId }) => {
 	const dispatch = useAppDispatch();
 
 	const { data: worktreeChanges } = useQuery(changesInWorktreeQueryOptions(projectId));
 	const fileRowItems = worktreeChanges ? getChangesFileRowItems(worktreeChanges) : [];
 
-	const selection = useAppSelector((state) =>
-		projectSlice.selectors.selectSelectionOutline(state, projectId, outlineNavigationIndex),
+	const fileSelection = useAppSelector((state) =>
+		projectSlice.selectors.selectSelectionUncommittedFiles(state, projectId, navigationIndex),
 	);
-	const fileSelection =
-		selection?._tag === "File" && selection.parent._tag === "UncommittedChanges"
-			? selection.path
-			: null;
-	const navigationItems = outlineNavigationIndex.items.flatMap((item) =>
-		item._tag === "File" && item.parent._tag === "UncommittedChanges" ? [item.path] : [],
-	);
-	const navigationIndex: NavigationIndex<string> = {
-		items: navigationItems,
-		indexByKey: buildIndexByKey(navigationItems, (path) => path),
-	};
 
 	return (
 		<div>
@@ -240,12 +224,7 @@ const UncommittedChanges: FC<{
 				items={fileRowItems}
 				navigationIndex={navigationIndex}
 				onFileSelection={(selection) =>
-					dispatch(
-						projectSlice.actions.selectOutline({
-							projectId,
-							selection: fileOperand({ parent: uncommittedChangesFileParent, path: selection }),
-						}),
-					)
+					dispatch(projectSlice.actions.selectUncommittedFiles({ projectId, selection }))
 				}
 				projectId={projectId}
 				ref={(el) => {
@@ -599,6 +578,7 @@ export const OutlineTree: FC<
 		projectId: string;
 		commitTarget: RelativeTo | null;
 		navigationIndex: NavigationIndex<Operand>;
+		uncommittedFilesNavigationIndex: NavigationIndex<string>;
 		absorptionTargetCommitIds: ReadonlySet<string>;
 		headInfoIndex: HeadInfoIndex | undefined;
 	} & ComponentProps<"div">
@@ -606,6 +586,7 @@ export const OutlineTree: FC<
 	projectId,
 	commitTarget,
 	navigationIndex,
+	uncommittedFilesNavigationIndex,
 	absorptionTargetCommitIds,
 	headInfoIndex,
 	...props
@@ -692,7 +673,10 @@ export const OutlineTree: FC<
 									outline="inside"
 									render={
 										<div className={styles.panel}>
-											<UncommittedChanges projectId={projectId} />
+											<UncommittedChanges
+												navigationIndex={uncommittedFilesNavigationIndex}
+												projectId={projectId}
+											/>
 										</div>
 									}
 								/>

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
@@ -743,14 +743,22 @@ export const OutlineTree: FC<
 						minSize={120}
 						groupResizeBehavior="preserve-pixel-size"
 					>
-						<OperandC
+						<OperationSourceC
 							projectId={projectId}
-							operand={uncommittedChangesOperand}
+							source={uncommittedChangesOperand}
 							outline="inside"
 							render={
-								<div className={styles.panel}>
-									<UncommittedChanges projectId={projectId} checkCommit={checkCommit} />
-								</div>
+								<OperationTarget
+									enabled
+									projectId={projectId}
+									operand={uncommittedChangesOperand}
+									outline="inside"
+									render={
+										<div className={styles.panel}>
+											<UncommittedChanges projectId={projectId} checkCommit={checkCommit} />
+										</div>
+									}
+								/>
 							}
 						/>
 					</Panel>

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
@@ -225,10 +225,11 @@ const UncommittedChanges: FC<{
 	);
 
 	return (
-		<div>
+		<div className={styles.uncommittedChanges}>
 			<UncommittedChangesRow changes={worktreeChanges?.changes ?? []} projectId={projectId} />
 
 			<FilesTree
+				className={styles.uncommittedChangesTree}
 				data-selection-scope={"uncommitted-files" satisfies SelectionScope}
 				onFocus={() =>
 					dispatch(

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
@@ -33,6 +33,7 @@ import {
 	Stack,
 	PushStatus,
 	WorkspaceState,
+	type RefInfo,
 } from "@gitbutler/but-sdk";
 import { useQuery } from "@tanstack/react-query";
 import { Match } from "effect";
@@ -59,6 +60,14 @@ import { checkedRange, navigationIndexRange } from "#ui/checking.ts";
 import { TooltipPopup } from "#ui/components/Tooltip.tsx";
 import { SelectionScope } from "#ui/selection-scopes.ts";
 import { FilesTree } from "#ui/routes/project/$id/workspace/FilesTree.tsx";
+import {
+	CommitForm,
+	type CommitTargetComboboxItem,
+} from "#ui/routes/project/$id/workspace/CommitForm.tsx";
+import {
+	buildCommitTargetComboboxItems,
+	selectCommitTargetComboboxItem,
+} from "./commitTargetComboboxItems.ts";
 
 const DryRunWorkspaceContext = createContext<WorkspaceState | null>(null);
 
@@ -202,8 +211,10 @@ const OperandC: FC<
 
 const UncommittedChanges: FC<{
 	navigationIndex: NavigationIndex<string>;
+	commitTarget: CommitTargetComboboxItem | null;
 	projectId: string;
-}> = ({ navigationIndex, projectId }) => {
+	targetComboboxItems: Array<CommitTargetComboboxItem>;
+}> = ({ navigationIndex, commitTarget, projectId, targetComboboxItems }) => {
 	const dispatch = useAppDispatch();
 
 	const { data: worktreeChanges } = useQuery(changesInWorktreeQueryOptions(projectId));
@@ -242,6 +253,12 @@ const UncommittedChanges: FC<{
 					el?.focus({ focusVisible: false });
 				}}
 				selection={fileSelection}
+			/>
+
+			<CommitForm
+				projectId={projectId}
+				commitTarget={commitTarget}
+				targetComboboxItems={targetComboboxItems}
 			/>
 		</div>
 	);
@@ -588,7 +605,7 @@ const Stacks: FC<{
 export const OutlineTree: FC<
 	{
 		projectId: string;
-		commitTarget: RelativeTo | null;
+		headInfo: RefInfo | undefined;
 		navigationIndex: NavigationIndex<Operand>;
 		uncommittedFilesNavigationIndex: NavigationIndex<string>;
 		absorptionTargetCommitIds: ReadonlySet<string>;
@@ -596,13 +613,25 @@ export const OutlineTree: FC<
 	} & ComponentProps<"div">
 > = ({
 	projectId,
-	commitTarget,
+	headInfo,
 	navigationIndex,
 	uncommittedFilesNavigationIndex,
 	absorptionTargetCommitIds,
 	headInfoIndex,
 	...props
 }) => {
+	const commitTargetState = useAppSelector((state) =>
+		projectSlice.selectors.selectCommitTarget(state, projectId),
+	);
+	const commitTargetComboboxItems = buildCommitTargetComboboxItems({
+		headInfo,
+		headInfoIndex,
+		commitTargetState,
+	});
+	const commitTarget = selectCommitTargetComboboxItem({
+		items: commitTargetComboboxItems,
+		commitTargetState,
+	});
 	const hasCheckedCommits = useAppSelector((state) =>
 		headInfoIndex
 			? projectSlice.selectors.selectHasCheckedCommits(state, projectId, headInfoIndex)
@@ -669,8 +698,8 @@ export const OutlineTree: FC<
 					<Panel
 						id={"uncommitted-changes-panel" satisfies PanelId}
 						className={styles.uncommittedChangesOuterPanel}
-						defaultSize={200}
-						minSize={120}
+						defaultSize={280}
+						minSize={200}
 						groupResizeBehavior="preserve-pixel-size"
 					>
 						<OperationSourceC
@@ -687,7 +716,9 @@ export const OutlineTree: FC<
 										<div className={styles.panel}>
 											<UncommittedChanges
 												navigationIndex={uncommittedFilesNavigationIndex}
+												commitTarget={commitTarget}
 												projectId={projectId}
+												targetComboboxItems={commitTargetComboboxItems}
 											/>
 										</div>
 									}
@@ -699,7 +730,11 @@ export const OutlineTree: FC<
 					<Separator className={styles.resizeHandle} />
 
 					<Panel id={"stacks-panel" satisfies PanelId} className={styles.panel} minSize={120}>
-						<Stacks projectId={projectId} commitTarget={commitTarget} checkCommit={checkCommit} />
+						<Stacks
+							projectId={projectId}
+							commitTarget={commitTarget?.relativeTo ?? null}
+							checkCommit={checkCommit}
+						/>
 					</Panel>
 				</Group>
 			</AbsorptionTargetCommitIdsContext>

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/UncommittedChangesRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/UncommittedChangesRow.tsx
@@ -17,8 +17,14 @@ import { Toolbar } from "@base-ui/react";
 import { AbsorptionTarget, TreeChange, UnifiedPatch } from "@gitbutler/but-sdk";
 import { FC } from "react";
 import { getRowButtonClassName } from "../Row-utils.ts";
-import { RowBubble, RowBubbleGroup, RowLabel, RowLabelContainer, RowToolbar } from "../Row.tsx";
-import { ItemRow } from "./ItemRow.tsx";
+import {
+	Row,
+	RowBubble,
+	RowBubbleGroup,
+	RowLabel,
+	RowLabelContainer,
+	RowToolbar,
+} from "../Row.tsx";
 import { useQueries } from "@tanstack/react-query";
 import { treeChangeDiffsQueryOptions } from "#ui/api/queries.ts";
 
@@ -100,12 +106,11 @@ export const UncommittedChangesRow: FC<{
 	];
 
 	return (
-		<ItemRow
-			projectId={projectId}
-			operand={operand}
+		<Row
 			onContextMenu={(event) => {
 				void showNativeContextMenu(event, menuItems);
 			}}
+			interactive={false}
 		>
 			<RowLabelContainer>
 				<RowLabel heading>Uncommitted changes</RowLabel>
@@ -137,6 +142,6 @@ export const UncommittedChangesRow: FC<{
 					</Toolbar.Button>
 				</Toolbar.Root>
 			)}
-		</ItemRow>
+		</Row>
 	);
 };

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/UncommittedChangesRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/UncommittedChangesRow.tsx
@@ -1,7 +1,6 @@
 import { useDiscardWorktreeChanges } from "#ui/api/mutations.ts";
 import { Icon } from "#ui/components/Icon.tsx";
 import { createDiffSpec } from "#ui/operations/diff-specs.ts";
-import { outlineHotkeys, selectionOperationHotkeys, toElectronAccelerator } from "#ui/hotkeys.ts";
 import {
 	nativeMenuItem,
 	nativeMenuSeparator,
@@ -90,12 +89,10 @@ export const UncommittedChangesRow: FC<{
 			label: "Cut Changes",
 			enabled: changes.length > 0,
 			onSelect: cutChanges,
-			accelerator: toElectronAccelerator(selectionOperationHotkeys.cut.hotkey),
 		}),
 		nativeMenuSeparator,
 		nativeMenuItem({
 			label: "Absorb",
-			accelerator: toElectronAccelerator(outlineHotkeys.absorb.hotkey),
 			onSelect: absorb,
 		}),
 		nativeMenuItem({

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/hotkeys.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/hotkeys.ts
@@ -12,27 +12,14 @@ import { decodeBytes } from "#ui/api/bytes.ts";
 import { getHeadInfoIndex } from "#ui/api/ref-info.ts";
 import { commitForgeUrl } from "#ui/commit.ts";
 import { outlineHotkeys } from "#ui/hotkeys.ts";
-import {
-	branchOperand,
-	commitOperand,
-	operandIdentityKey,
-	uncommittedChangesOperand,
-	type Operand,
-} from "#ui/operands.ts";
+import { branchOperand, commitOperand, operandIdentityKey, type Operand } from "#ui/operands.ts";
 import { projectSlice } from "#ui/projects/state.ts";
-import { focusSelectionScope, useNavigationIndexHotkeys } from "#ui/selection-scopes.ts";
+import { useNavigationIndexHotkeys } from "#ui/selection-scopes.ts";
 import { useAppDispatch, useAppSelector, useAppStore } from "#ui/store.ts";
 import { type NavigationIndex } from "#ui/workspace/navigation-index.ts";
 import { prForgeUrl } from "#ui/pr.ts";
 import { stackBottomRelativeTo } from "#ui/api/stack.ts";
-import {
-	AbsorptionTarget,
-	BranchReference,
-	BottomUpdate,
-	InsertSide,
-	RelativeTo,
-	Segment,
-} from "@gitbutler/but-sdk";
+import { BranchReference, BottomUpdate, InsertSide, RelativeTo, Segment } from "@gitbutler/but-sdk";
 import { UseHotkeyDefinition, useHotkeys } from "@tanstack/react-hotkeys";
 import { useQuery } from "@tanstack/react-query";
 import { Match } from "effect";
@@ -143,10 +130,6 @@ export const useOutlineTreeHotkeys = ({
 
 	const openBranchPicker = () => {
 		dispatch(projectSlice.actions.openDialog({ projectId, dialog: { _tag: "BranchPicker" } }));
-	};
-
-	const enterAbsorbMode = (source: Operand, sourceTarget: AbsorptionTarget) => {
-		dispatch(projectSlice.actions.enterAbsorbMode({ projectId, source, sourceTarget }));
 	};
 
 	const amendCommit = () => {
@@ -375,7 +358,6 @@ export const useOutlineTreeHotkeys = ({
 	const defaultOutlineHotkeysEnabled = isDefaultMode;
 	const isSelectedCommit = selection?._tag === "Commit";
 	const isSelectedBranch = selection?._tag === "Branch";
-	const isSelectedChanges = selection?._tag === "UncommittedChanges";
 	const canPushSelectedBranch =
 		!!selectedPushContext &&
 		!isWorkspaceBranchAndAncestorsPushPending &&
@@ -415,16 +397,6 @@ export const useOutlineTreeHotkeys = ({
 			},
 		},
 		{
-			hotkey: outlineHotkeys.selectChanges.hotkey,
-			callback: () => {
-				dispatch(
-					projectSlice.actions.selectOutline({ projectId, selection: uncommittedChangesOperand }),
-				);
-				focusSelectionScope("outline");
-			},
-			options: { conflictBehavior: "allow" },
-		},
-		{
 			hotkey: outlineHotkeys.composeCommitMessage.hotkey,
 			callback: () => {
 				focusCommitMessageInput();
@@ -461,17 +433,6 @@ export const useOutlineTreeHotkeys = ({
 							enabled: defaultOutlineHotkeysEnabled,
 							target: ref,
 							meta: outlineHotkeys.renameBranch.meta,
-						},
-					},
-				],
-				UncommittedChanges: (): Array<UseHotkeyDefinition> => [
-					{
-						hotkey: outlineHotkeys.composeCommitMessageFromChanges.hotkey,
-						callback: focusCommitMessageInput,
-						options: {
-							conflictBehavior: "allow",
-							enabled: defaultOutlineHotkeysEnabled,
-							target: ref,
 						},
 					},
 				],
@@ -653,17 +614,5 @@ export const useOutlineTreeHotkeys = ({
 						]
 					: [],
 		),
-		{
-			hotkey: outlineHotkeys.absorb.hotkey,
-			callback: () => {
-				enterAbsorbMode(uncommittedChangesOperand, { type: "all" });
-			},
-			options: {
-				conflictBehavior: "allow",
-				enabled: defaultOutlineHotkeysEnabled && isSelectedChanges,
-				target: ref,
-				meta: outlineHotkeys.absorb.meta,
-			},
-		},
 	]);
 };

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/hotkeys.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/hotkeys.ts
@@ -402,8 +402,7 @@ export const useOutlineTreeHotkeys = ({
 			);
 			return checkedCommits.length > 0 ? checkedCommits : [operand];
 		},
-		selectSectionPredicate: (operand) =>
-			operand._tag === "Branch" || operand._tag === "UncommittedChanges",
+		selectSectionPredicate: (operand) => operand._tag === "Branch",
 	});
 
 	useHotkeys([

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
@@ -6,8 +6,9 @@ import {
 } from "#ui/api/queries.ts";
 import { useRestoreSnapshot } from "#ui/api/mutations.ts";
 import {
-	focusAdjacentSelectionScope,
+	focusHorizontalSelectionScope,
 	focusSelectionScope,
+	focusVerticalSelectionScope,
 	getFocusedSelectionScope,
 	SelectionScope,
 } from "#ui/selection-scopes.ts";
@@ -74,6 +75,9 @@ const useWorkspaceHotkeys = (projectId: string) => {
 		(state) => projectSlice.selectors.selectOutlineModeState(state, projectId)._tag === "Default",
 	);
 	const outlineVisible = !detailsFullWindow;
+	const outlineSelectionScope = useAppSelector((state) =>
+		projectSlice.selectors.selectDetailsSelectionScope(state, projectId),
+	);
 
 	const { isPending: isRestoreSnapshotPending, mutate: restoreSnapshot } = useRestoreSnapshot({
 		projectId,
@@ -127,19 +131,43 @@ const useWorkspaceHotkeys = (projectId: string) => {
 			},
 		},
 		{
-			hotkey: workspaceHotkeys.focusPreviousSelectionScope.hotkey,
+			hotkey: workspaceHotkeys.focusHorizontalSelectionScopeLeft.hotkey,
 			callback: () => {
-				focusAdjacentSelectionScope({ filesVisible, offset: -1, outlineVisible });
+				focusHorizontalSelectionScope({
+					filesVisible,
+					offset: -1,
+					outlineSelectionScope,
+					outlineVisible,
+				});
 			},
 			options: {
 				conflictBehavior: "allow",
 			},
 		},
 		{
-			hotkey: workspaceHotkeys.focusNextSelectionScope.hotkey,
+			hotkey: workspaceHotkeys.focusHorizontalSelectionScopeRight.hotkey,
 			callback: () => {
-				focusAdjacentSelectionScope({ filesVisible, offset: 1, outlineVisible });
+				focusHorizontalSelectionScope({
+					filesVisible,
+					offset: 1,
+					outlineSelectionScope,
+					outlineVisible,
+				});
 			},
+			options: {
+				conflictBehavior: "allow",
+			},
+		},
+		{
+			hotkey: workspaceHotkeys.focusVerticalSelectionScopeUp.hotkey,
+			callback: () => focusVerticalSelectionScope(-1),
+			options: {
+				conflictBehavior: "allow",
+			},
+		},
+		{
+			hotkey: workspaceHotkeys.focusVerticalSelectionScopeDown.hotkey,
+			callback: () => focusVerticalSelectionScope(1),
 			options: {
 				conflictBehavior: "allow",
 			},

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
@@ -38,7 +38,6 @@ import {
 	type BranchOperand,
 	type Operand,
 	uncommittedChangesFileParent,
-	uncommittedChangesOperand,
 } from "#ui/operands.ts";
 import { Details } from "./Details.tsx";
 import styles from "./WorkspacePage.module.css";
@@ -165,7 +164,6 @@ const buildOutlineNavigationIndex = ({
 	absorptionTargetCommitIds: ReadonlySet<string>;
 }): NavigationIndex<Operand> => {
 	const allItems = (): Array<Operand> => [
-		uncommittedChangesOperand,
 		...(worktreeChanges?.changes.map((change) =>
 			fileOperand({ parent: uncommittedChangesFileParent, path: change.path }),
 		) ?? []),

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
@@ -31,11 +31,13 @@ import { Group, Panel, Separator, useDefaultLayout } from "react-resizable-panel
 import {
 	branchOperand,
 	commitOperand,
+	fileOperand,
 	operandContains,
 	operandEquals,
 	operandIdentityKey,
 	type BranchOperand,
 	type Operand,
+	uncommittedChangesFileParent,
 } from "#ui/operands.ts";
 import { Details } from "./Details.tsx";
 import styles from "./WorkspacePage.module.css";
@@ -368,15 +370,35 @@ const WorkspacePage: FC = () => {
 		outlineMode,
 		absorptionTargetCommitIds,
 	});
-
 	const outlineSelection = useAppSelector((state) =>
 		projectSlice.selectors.selectSelectionOutline(state, projectId, outlineNavigationIndex),
 	);
 
 	const { data: worktreeChanges } = useQuery(changesInWorktreeQueryOptions(projectId));
 	const uncommittedFilesNavigationIndex = buildUncommittedFilesNavigationIndex({ worktreeChanges });
+	const uncommittedFilesSelection = useAppSelector((state) =>
+		projectSlice.selectors.selectSelectionUncommittedFiles(
+			state,
+			projectId,
+			uncommittedFilesNavigationIndex,
+		),
+	);
 
-	const deferredOutlineSelection = useDeferredValue(outlineSelection);
+	const detailsSelectionScope = useAppSelector((state) =>
+		projectSlice.selectors.selectDetailsSelectionScope(state, projectId),
+	);
+	const detailsSelection = Match.value(detailsSelectionScope).pipe(
+		Match.when("outline", () => outlineSelection),
+		Match.when("uncommitted-files", () =>
+			uncommittedFilesSelection === null
+				? null
+				: fileOperand({ parent: uncommittedChangesFileParent, path: uncommittedFilesSelection }),
+		),
+		Match.when(null, () => null),
+		Match.exhaustive,
+	);
+
+	const deferredDetailsSelection = useDeferredValue(detailsSelection);
 
 	const { data: projects } = useSuspenseQuery(listProjectsQueryOptions);
 
@@ -429,8 +451,8 @@ const WorkspacePage: FC = () => {
 
 				<Panel id={"details-panel" satisfies PanelId} className={styles.panel}>
 					<Details
-						key={deferredOutlineSelection ? operandIdentityKey(deferredOutlineSelection) : null}
-						outlineSelection={deferredOutlineSelection}
+						key={deferredDetailsSelection ? operandIdentityKey(deferredDetailsSelection) : null}
+						outlineSelection={deferredDetailsSelection}
 					/>
 				</Panel>
 			</Group>

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
@@ -31,13 +31,11 @@ import { Group, Panel, Separator, useDefaultLayout } from "react-resizable-panel
 import {
 	branchOperand,
 	commitOperand,
-	fileOperand,
 	operandContains,
 	operandEquals,
 	operandIdentityKey,
 	type BranchOperand,
 	type Operand,
-	uncommittedChangesFileParent,
 } from "#ui/operands.ts";
 import { Details } from "./Details.tsx";
 import styles from "./WorkspacePage.module.css";
@@ -152,23 +150,26 @@ const hasAnyOperation = (sources: Array<Operand>, target: Operand) => {
 	return !!operations.into || !!operations.above || !!operations.below;
 };
 
+const buildUncommittedFilesNavigationIndex = ({
+	worktreeChanges,
+}: {
+	worktreeChanges: WorktreeChanges | undefined;
+}): NavigationIndex<string> => {
+	const items = worktreeChanges?.changes.map((change) => change.path) ?? [];
+	return { items, indexByKey: buildIndexByKey(items, (path) => path) };
+};
+
 const buildOutlineNavigationIndex = ({
 	headInfo,
-	worktreeChanges,
 	outlineMode,
 	absorptionTargetCommitIds,
 }: {
 	headInfo: RefInfo | undefined;
-	worktreeChanges: WorktreeChanges | undefined;
 	outlineMode: OutlineMode;
 	absorptionTargetCommitIds: ReadonlySet<string>;
 }): NavigationIndex<Operand> => {
-	const allItems = (): Array<Operand> => [
-		...(worktreeChanges?.changes.map((change) =>
-			fileOperand({ parent: uncommittedChangesFileParent, path: change.path }),
-		) ?? []),
-
-		...(headInfo?.stacks
+	const allItems = (): Array<Operand> =>
+		headInfo?.stacks
 			.toReversed()
 			.flatMap((stack) =>
 				stack.segments.flatMap(
@@ -179,8 +180,7 @@ const buildOutlineNavigationIndex = ({
 						...segment.commits.map((commit) => commitOperand({ commitId: commit.id })),
 					],
 				),
-			) ?? []),
-	];
+			) ?? [];
 
 	const filteredItems = Match.value(outlineMode).pipe(
 		Match.tagsExhaustive({
@@ -354,7 +354,6 @@ const WorkspacePage: FC = () => {
 		Match.orElse(() => null),
 	);
 	const { data: headInfo } = useQuery(headInfoQueryOptions(projectId));
-	const { data: worktreeChanges } = useQuery(changesInWorktreeQueryOptions(projectId));
 	const [absorptionPlanQuery] = useQueries({
 		queries: (absorptionPlanTarget ? [absorptionPlanTarget] : []).map((target) =>
 			absorptionPlanQueryOptions({ projectId, target }),
@@ -366,7 +365,6 @@ const WorkspacePage: FC = () => {
 
 	const outlineNavigationIndex = buildOutlineNavigationIndex({
 		headInfo,
-		worktreeChanges,
 		outlineMode,
 		absorptionTargetCommitIds,
 	});
@@ -374,6 +372,9 @@ const WorkspacePage: FC = () => {
 	const outlineSelection = useAppSelector((state) =>
 		projectSlice.selectors.selectSelectionOutline(state, projectId, outlineNavigationIndex),
 	);
+
+	const { data: worktreeChanges } = useQuery(changesInWorktreeQueryOptions(projectId));
+	const uncommittedFilesNavigationIndex = buildUncommittedFilesNavigationIndex({ worktreeChanges });
 
 	const deferredOutlineSelection = useDeferredValue(outlineSelection);
 
@@ -419,6 +420,7 @@ const WorkspacePage: FC = () => {
 							projectId={projectId}
 							project={selectedProject}
 							navigationIndex={outlineNavigationIndex}
+							uncommittedFilesNavigationIndex={uncommittedFilesNavigationIndex}
 							absorptionTargetCommitIds={absorptionTargetCommitIds}
 						/>
 					</Panel>

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
@@ -66,8 +66,11 @@ const useWorkspaceHotkeys = (projectId: string) => {
 	const dialog = useAppSelector((state) =>
 		projectSlice.selectors.selectDialogState(state, projectId),
 	);
-	const filesVisible = useAppSelector((state) =>
+	const filesVisibleState = useAppSelector((state) =>
 		projectSlice.selectors.selectFilesVisible(state, projectId),
+	);
+	const canShowFiles = useAppSelector((state) =>
+		projectSlice.selectors.selectCanShowFiles(state, projectId),
 	);
 	const activeElement = useActiveElement();
 	const focusedSelectionScope = getFocusedSelectionScope(activeElement);
@@ -78,6 +81,7 @@ const useWorkspaceHotkeys = (projectId: string) => {
 	const outlineSelectionScope = useAppSelector((state) =>
 		projectSlice.selectors.selectDetailsSelectionScope(state, projectId),
 	);
+	const filesVisible = canShowFiles && filesVisibleState;
 
 	const { isPending: isRestoreSnapshotPending, mutate: restoreSnapshot } = useRestoreSnapshot({
 		projectId,
@@ -127,6 +131,7 @@ const useWorkspaceHotkeys = (projectId: string) => {
 			},
 			options: {
 				conflictBehavior: "allow",
+				enabled: canShowFiles,
 				meta: workspaceHotkeys.toggleFiles.meta,
 			},
 		},

--- a/apps/lite/ui/src/selection-scopes.ts
+++ b/apps/lite/ui/src/selection-scopes.ts
@@ -5,7 +5,6 @@ import { projectSlice } from "#ui/projects/state.ts";
 import { useAppDispatch } from "#ui/store.ts";
 import { getAdjacent, type NavigationIndex } from "#ui/workspace/navigation-index.ts";
 import { useHotkeySequences, useHotkeys } from "@tanstack/react-hotkeys";
-import { assert } from "#ui/assert.ts";
 
 export type SelectionScope = "uncommitted-files" | "outline" | "files" | "diff";
 const allSelectionScopes: Array<SelectionScope> = ["uncommitted-files", "outline", "files", "diff"];
@@ -27,19 +26,25 @@ export const focusSelectionScope = (selectionScope: SelectionScope) => {
 		?.focus({ focusVisible: false });
 };
 
-export const focusAdjacentSelectionScope = ({
+export const focusHorizontalSelectionScope = ({
 	filesVisible,
 	offset,
+	outlineSelectionScope,
 	outlineVisible,
 }: {
 	filesVisible: boolean;
 	offset: -1 | 1;
+	outlineSelectionScope: Extract<SelectionScope, "uncommitted-files" | "outline"> | null;
 	outlineVisible: boolean;
 }) => {
 	const currentSelectionScope = getFocusedSelectionScope(document.activeElement);
+	const currentOutlineSelectionScope =
+		currentSelectionScope === "uncommitted-files" || currentSelectionScope === "outline"
+			? currentSelectionScope
+			: outlineSelectionScope;
 
 	const orderedSelectionScopes: Array<SelectionScope> = [
-		...(outlineVisible ? (["uncommitted-files", "outline"] satisfies Array<SelectionScope>) : []),
+		...(outlineVisible ? [currentOutlineSelectionScope ?? "outline"] : []),
 		...(filesVisible ? (["files"] satisfies Array<SelectionScope>) : []),
 		"diff",
 	];
@@ -50,14 +55,22 @@ export const focusAdjacentSelectionScope = ({
 
 		if (nextSelectionScope !== undefined) focusSelectionScope(nextSelectionScope);
 	} else {
-		const curr = orderedSelectionScopes.indexOf(currentSelectionScope);
-		// This shouldn't ever fail.
-		const nextSelectionScope = assert(
-			orderedSelectionScopes.at((curr + offset) % orderedSelectionScopes.length),
-		);
-
-		focusSelectionScope(nextSelectionScope);
+		const nextIndex = orderedSelectionScopes.indexOf(currentSelectionScope) + offset;
+		const nextSelectionScope = nextIndex < 0 ? undefined : orderedSelectionScopes.at(nextIndex);
+		if (nextSelectionScope !== undefined) focusSelectionScope(nextSelectionScope);
 	}
+};
+
+export const focusVerticalSelectionScope = (offset: -1 | 1) => {
+	const currentSelectionScope = getFocusedSelectionScope(document.activeElement);
+	const orderedSelectionScopes: Array<SelectionScope> = ["uncommitted-files", "outline"];
+	const currentIndex =
+		currentSelectionScope === null ? -1 : orderedSelectionScopes.indexOf(currentSelectionScope);
+	if (currentIndex === -1) return;
+
+	const nextIndex = currentIndex + offset;
+	const nextSelectionScope = nextIndex < 0 ? undefined : orderedSelectionScopes.at(nextIndex);
+	if (nextSelectionScope !== undefined) focusSelectionScope(nextSelectionScope);
 };
 
 export const useNavigationIndexHotkeys = <T>({

--- a/apps/lite/ui/src/selection-scopes.ts
+++ b/apps/lite/ui/src/selection-scopes.ts
@@ -7,8 +7,8 @@ import { getAdjacent, type NavigationIndex } from "#ui/workspace/navigation-inde
 import { useHotkeySequences, useHotkeys } from "@tanstack/react-hotkeys";
 import { assert } from "#ui/assert.ts";
 
-export type SelectionScope = "outline" | "files" | "diff";
-const allSelectionScopes: Array<SelectionScope> = ["outline", "files", "diff"];
+export type SelectionScope = "uncommitted-files" | "outline" | "files" | "diff";
+const allSelectionScopes: Array<SelectionScope> = ["uncommitted-files", "outline", "files", "diff"];
 
 const isSelectionScope = (id: string): id is SelectionScope =>
 	allSelectionScopes.includes(id as SelectionScope);
@@ -39,7 +39,7 @@ export const focusAdjacentSelectionScope = ({
 	const currentSelectionScope = getFocusedSelectionScope(document.activeElement);
 
 	const orderedSelectionScopes: Array<SelectionScope> = [
-		...(outlineVisible ? (["outline"] satisfies Array<SelectionScope>) : []),
+		...(outlineVisible ? (["uncommitted-files", "outline"] satisfies Array<SelectionScope>) : []),
 		...(filesVisible ? (["files"] satisfies Array<SelectionScope>) : []),
 		"diff",
 	];


### PR DESCRIPTION
Towards [GB-1732: Show uncommitted files in outline panel aka sidebar](https://linear.app/gitbutler/issue/GB-1732/show-uncommitted-files-in-outline-panel-aka-sidebar)

@samhh This PR should be in a good place, but I'm keen for a thorough code review.

There's a bunch of small things to think about still (see below) but I don't think there are any blockers, so if it looks good then please merge in my absence and I'll get back on it when I return. Cheers!

For when I return:
- [ ] selection scope focus indicator e.g. when empty
- [ ] bug: on click, flash on focus change (pointer down) before selection changes (pointer up) - not sure how we can avoid this
- [ ] restore ability to absorb/cut all uncommitted files, either via replacement shortcuts OR multi-selection
- [ ] clicking on header should forward focus to tree OR widen scope of tree element
- [ ] decouple headers from `Row` (`Row` is designed for selectable rows, not headers)
- [ ] rename outline tree to stacks tree
- [ ] rename outline mode to ??
- [ ] rename outline panel to ??
- [x] can we remove commit targets now?
- [ ] can we refine selection types? `Operand` is much wider than we need now
- [ ] all-in-one diff (@samhh probably best you do this one)
- [ ] drag area includes commit form
- [ ] uncommitted file as active source: outline is clipped due to scroll area