### PR TITLE
Run workspace fetch without holding the repo lock

### DIFF
--- a/crates/but-api/src/workspace.rs
+++ b/crates/but-api/src/workspace.rs
@@ -58,12 +58,17 @@ impl TryFrom<but_db::FetchStatus> for WorkspaceFetchStatus {
 /// Fetching continues after an individual remote fails so every configured remote gets an attempt.
 /// If any fetch fails, all errors are persisted and returned together. Credential prompts are
 /// associated with `action`, which defaults to `"unknown"`.
+///
+/// The network fetch runs without any repository lock so other operations stay responsive while
+/// remotes are contacted; exclusive access is only acquired afterwards for the bookkeeping that
+/// reacts to updated remote refs. Within this process, overlapping fetch calls for the same
+/// repository serialize among themselves so concurrent `git fetch` runs cannot trip over Git's
+/// per-ref locks; fetches from other processes are not affected.
 #[but_api(napi)]
 #[instrument(skip_all, err(Debug))]
 pub fn workspace_fetch_from_remotes(
-    ctx: &but_ctx::Context,
+    ctx: &mut but_ctx::Context,
     action: Option<String>,
-    _perm: &mut RepoExclusive,
 ) -> anyhow::Result<()> {
     let askpass_action = Some(action.unwrap_or_else(|| "unknown".to_owned()));
     let fetch_result = (|| {
@@ -75,6 +80,12 @@ pub fn workspace_fetch_from_remotes(
                 .map(|name| name.to_str().map(str::to_owned))
                 .collect::<Result<Vec<_>, _>>()?
         };
+        // Overlapping `git fetch` runs of the same repository can fail on Git's per-ref locks,
+        // so fetches wait for each other while other operations stay unblocked.
+        let repo_fetch_lock = fetch_lock(&ctx.gitdir);
+        let _fetch_guard = repo_fetch_lock
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let errors = remotes
             .iter()
             .filter_map(|remote| {
@@ -97,6 +108,7 @@ pub fn workspace_fetch_from_remotes(
         .as_millis()
         .try_into()
         .map_err(|err| anyhow::anyhow!("fetch timestamp does not fit in the database: {err}"))?;
+    let _guard = ctx.exclusive_worktree_access();
     match &fetch_result {
         Ok(()) => ctx
             .db
@@ -114,6 +126,18 @@ pub fn workspace_fetch_from_remotes(
     ctx.invalidate_workspace_cache()?;
     prune_missing_branch_stack_order(ctx)?;
     fetch_result
+}
+
+/// Return the in-process lock that serializes network fetches for the repository at `gitdir`,
+/// so overlapping fetches wait for each other without blocking other repository operations.
+fn fetch_lock(gitdir: &std::path::Path) -> std::sync::Arc<std::sync::Mutex<()>> {
+    static FETCH_LOCKS: std::sync::Mutex<
+        std::collections::BTreeMap<std::path::PathBuf, std::sync::Arc<std::sync::Mutex<()>>>,
+    > = std::sync::Mutex::new(std::collections::BTreeMap::new());
+    let mut map = FETCH_LOCKS
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    std::sync::Arc::clone(map.entry(gitdir.to_owned()).or_default())
 }
 
 /// Reconcile branch-order metadata against the current local branch refs.
@@ -627,10 +651,8 @@ mod tests {
             .args(["branch", "-D", "feature"])
             .run();
 
-        let mut guard = ctx.exclusive_worktree_access();
-        workspace_fetch_from_remotes(&ctx, None, guard.write_permission())
+        workspace_fetch_from_remotes(&mut ctx, None)
             .expect_err("the configured origin does not exist");
-        drop(guard);
 
         assert!(
             ctx.meta()?.branch_stack_order(main.as_ref())?.is_none(),

--- a/packages/but-sdk/src/generated/graph/index.d.ts
+++ b/packages/but-sdk/src/generated/graph/index.d.ts
@@ -575,6 +575,12 @@ export declare function workspaceCheckout(projectId: string): Promise<BranchChec
  * Fetching continues after an individual remote fails so every configured remote gets an attempt.
  * If any fetch fails, all errors are persisted and returned together. Credential prompts are
  * associated with `action`, which defaults to `"unknown"`.
+ *
+ * The network fetch runs without any repository lock so other operations stay responsive while
+ * remotes are contacted; exclusive access is only acquired afterwards for the bookkeeping that
+ * reacts to updated remote refs. Within this process, overlapping fetch calls for the same
+ * repository serialize among themselves so concurrent `git fetch` runs cannot trip over Git's
+ * per-ref locks; fetches from other processes are not affected.
  */
 export declare function workspaceFetchFromRemotes(projectId: string, action: string | null): Promise<void>
 

--- a/packages/but-sdk/src/generated/linear/index.d.ts
+++ b/packages/but-sdk/src/generated/linear/index.d.ts
@@ -575,6 +575,12 @@ export declare function workspaceCheckout(projectId: string): Promise<BranchChec
  * Fetching continues after an individual remote fails so every configured remote gets an attempt.
  * If any fetch fails, all errors are persisted and returned together. Credential prompts are
  * associated with `action`, which defaults to `"unknown"`.
+ *
+ * The network fetch runs without any repository lock so other operations stay responsive while
+ * remotes are contacted; exclusive access is only acquired afterwards for the bookkeeping that
+ * reacts to updated remote refs. Within this process, overlapping fetch calls for the same
+ * repository serialize among themselves so concurrent `git fetch` runs cannot trip over Git's
+ * per-ref locks; fetches from other processes are not affected.
  */
 export declare function workspaceFetchFromRemotes(projectId: string, action: string | null): Promise<void>
 


### PR DESCRIPTION
Since the new workspace fetch API landed, switching to a project (or reloading the view) has felt noticeably slower. `workspace_fetch_from_remotes` declares an injected `RepoExclusive` permission, so the generated wrappers acquire exclusive repository access before the call — and hold it for the entire serial network fetch of every configured remote. On a repo like ours that is ~4 seconds per fetch, during which `set_project_active`, `changes_in_worktree`, and everything else the view load needs queue behind the lock. Logs show project activation going from ~300ms to up to 9.7s, with back-to-back fetches fired by the auto-fetch-on-mount each holding the lock in turn. The legacy `fetch_from_remotes` never locked during network I/O, which is why fetches of the same duration previously went unnoticed.

Drop the injected permission parameter so the fetch runs without the repo lock, and acquire exclusive access internally only for the post-fetch bookkeeping (fetch-status recording, workspace cache invalidation, branch-order pruning).