### PR TITLE
Explain missing-credentials fetch/push failures

### DIFF
--- a/crates/but-api/src/workspace.rs
+++ b/crates/but-api/src/workspace.rs
@@ -13,6 +13,7 @@ use but_core::{
     DryRun, RefMetadata, extract_remote_name_and_short_name, is_workspace_ref_name,
     sync::{RepoExclusive, RepoShared},
 };
+use but_error::AnyhowContextExt as _;
 use but_forge::ForgeReview;
 use but_oplog::legacy::{OperationKind, SnapshotDetails};
 use but_rebase::graph_rebase::mutate::RelativeTo;
@@ -86,19 +87,39 @@ pub fn workspace_fetch_from_remotes(
         let _fetch_guard = repo_fetch_lock
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let errors = remotes
+        let failures = remotes
             .iter()
             .filter_map(|remote| {
                 gitbutler_git::fetch_with_askpass(&repo_path, remote, askpass_action.clone())
                     .err()
-                    .map(|err| format!("{remote}: {err}"))
+                    .map(|err| (remote, err))
             })
             .collect::<Vec<_>>();
 
-        if errors.is_empty() {
-            Ok(())
-        } else {
-            Err(anyhow::anyhow!(errors.join("\n")))
+        // Keep the failure's own error context (e.g. the `ProjectGitAuth` code and its
+        // user-facing message) intact whenever possible: return a single failure as-is, and
+        // reapply the first failure's code when several failures collapse into one message.
+        match failures.len() {
+            0 => Ok(()),
+            1 => {
+                let (remote, err) = failures.into_iter().next().expect("length checked above");
+                Err(err.context(format!("fetching remote `{remote}` failed")))
+            }
+            _ => {
+                let code = failures
+                    .iter()
+                    .find_map(|(_, err)| err.custom_context().map(|ctx| ctx.code));
+                let joined = failures
+                    .iter()
+                    .map(|(remote, err)| format!("{remote}: {err}"))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                let err = anyhow::anyhow!(joined);
+                Err(match code {
+                    Some(code) => err.context(code),
+                    None => err,
+                })
+            }
         }
     })();
 

--- a/crates/gitbutler-git/src/context.rs
+++ b/crates/gitbutler-git/src/context.rs
@@ -174,7 +174,44 @@ pub fn fetch_with_askpass(
             but_error::Context::new("git fetch failed unexpectedly").with_code(Code::Unknown),
         )
     })??;
-    result.map_err(Into::into)
+    result.map_err(map_needs_authorization)
+}
+
+/// The concrete error type produced by fetch/push through the tokio executor.
+type GitError = crate::Error<crate::repository::Error<crate::tokio::TokioExecutor>>;
+
+/// Convert the error into an anyhow error, giving `NeedsAuthorization` failures a message that
+/// tells the user what to do about it (see [`needs_authorization_message`]); every other error
+/// converts as-is.
+fn map_needs_authorization(err: GitError) -> anyhow::Error {
+    let crate::Error::Backend(crate::repository::RepositoryError::NeedsAuthorization(ref prompt)) =
+        err
+    else {
+        return err.into();
+    };
+    let context = but_error::Context::new(needs_authorization_message(prompt, &err))
+        .with_code(Code::ProjectGitAuth);
+    anyhow::Error::from(err).context(context)
+}
+
+/// Turn the raw askpass prompt of a `NeedsAuthorization` failure into a message that tells the
+/// user what to do about it. Without this, the user sees the prompt Git wanted answered
+/// (e.g. `Username for 'https://github.com': `) with no hint at the actual problem: nothing could
+/// answer the prompt, most commonly because no credential helper is configured. The original error is appended since only this
+/// message reaches the app, while the error chain stays behind in the logs.
+fn needs_authorization_message(prompt: &str, original_error: impl std::fmt::Display) -> String {
+    let prompt = prompt.trim();
+    let credential_url = prompt
+        .strip_prefix("Username for ")
+        .or_else(|| prompt.strip_prefix("Password for "))
+        .map(|url| url.trim_end_matches(':').trim().trim_matches('\''));
+    let advice = match credential_url {
+        Some(url) => format!(
+            "Git couldn't obtain credentials for {url}. Configure a git credential helper (for example Git Credential Manager), or switch the remote to SSH."
+        ),
+        None => format!("Git asked for input and none was provided: {prompt}"),
+    };
+    format!("{advice}\n\nOriginal error: {original_error}")
 }
 
 /// Push the given commit to the provided remote branch.
@@ -252,7 +289,7 @@ where
                     Ok(String::new())
                 }
                 crate::Error::NonFastForward(_) => Err(err).context(Code::GitNonFastForward),
-                _ => Err(err.into()),
+                _ => Err(map_needs_authorization(err)),
             },
         }
 }
@@ -325,7 +362,7 @@ mod tests {
 
     use but_testsupport::{gix_testtools, open_repo};
 
-    use super::remote_tracking_branch_parts;
+    use super::{needs_authorization_message, remote_tracking_branch_parts};
 
     fn repo_with_registered_remotes() -> anyhow::Result<gix::Repository> {
         let fixture_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -333,6 +370,30 @@ mod tests {
         let root = gix_testtools::scripted_fixture_read_only(fixture_path)
             .map_err(anyhow::Error::from_boxed)?;
         Ok(open_repo(&root)?.with_object_memory())
+    }
+
+    #[test]
+    fn needs_authorization_message_extracts_credential_url() {
+        for prompt in [
+            "Username for 'https://github.com': ",
+            "Password for 'https://github.com': ",
+        ] {
+            assert_eq!(
+                needs_authorization_message(prompt, "backend error: original"),
+                "Git couldn't obtain credentials for https://github.com. Configure a git credential helper (for example Git Credential Manager), or switch the remote to SSH.\n\nOriginal error: backend error: original"
+            );
+        }
+    }
+
+    #[test]
+    fn needs_authorization_message_keeps_unrecognized_prompts() {
+        assert_eq!(
+            needs_authorization_message(
+                "Enter passphrase for key '/home/user/.ssh/id_ed25519': ",
+                "backend error: original"
+            ),
+            "Git asked for input and none was provided: Enter passphrase for key '/home/user/.ssh/id_ed25519':\n\nOriginal error: backend error: original"
+        );
     }
 
     #[test]


### PR DESCRIPTION
When git asks for credentials and the askpass flow yields no answer (no credential helper configured, prompt cancelled or timed out), the raw `NeedsAuthorization` error surfaced the askpass prompt text twice through the anyhow chain and gave no hint at the actual problem:

> Fetch - backend error: git requires authorization credentials but none were provided: prompt was "Username for 'https://github.com': " Caused by: 1: git requires authorization credentials but none were provided: ...

This maps the error to a message that names the remote URL and points at the fix, keeping the original error text for debugging:

> Git has no stored credentials for https://github.com. Configure a git credential helper (for example Git Credential Manager), or switch the remote to SSH.
>
> Original error: backend error: git requires authorization credentials but none were provided: prompt was "Username for 'https://github.com': "

The error is tagged with the `ProjectGitAuth` code, so the app classifies it as a soft auth warning — this also applies to background auto-fetches, which decline credential prompts by design.