### PR TITLE
Make pull, resolve, and status output guide conflict resolution

### DIFF
--- a/crates/but/skill/SKILL.md
+++ b/crates/but/skill/SKILL.md
@@ -112,6 +112,12 @@ latest `main` IS `but pull` — it is never `move`, `config target`, `unapply`,
 or raw `git pull`/`git rebase`. The pull output already reports the resulting
 state.
 
+If `but pull` refuses because uncommitted changes conflict with the update,
+park them on a temporary commit (there is no stash, and hand-reverting files
+risks losing work): `but commit <branch> --changes <file-id...> -m "wip"`,
+pull again — the parked commit may come back conflicted for `but resolve` —
+then `but uncommit` it so the changes end up uncommitted again.
+
 ### Commit selected files or hunks
 
 1. `but diff` — use this first for selective dirty commits. It shows file and hunk IDs for uncommitted changes.

--- a/crates/but/skill/SKILL.md
+++ b/crates/but/skill/SKILL.md
@@ -104,7 +104,7 @@ For "get latest from main", "update/sync this workspace", or "pull main":
 
 1. `but pull --check`
 2. If clean, `but pull`
-3. If commits come back conflicted, resolve each one: `but resolve <commit>` (the IDs are in the pull output), edit the files, then `but resolve finish`
+3. If commits come back conflicted, resolve each one oldest-first (the pull output lists them in that order): `but resolve <commit>`, edit the files, then `but resolve finish`. Finishing a lower commit rebases the ones above it, so always work bottom-up.
 
 `but pull` updates applied branches onto the latest target branch (usually
 `main`) and carries uncommitted changes along. Rebasing a branch onto the

--- a/crates/but/skill/SKILL.md
+++ b/crates/but/skill/SKILL.md
@@ -102,13 +102,15 @@ but <mutation> ...
 
 For "get latest from main", "update/sync this workspace", or "pull main":
 
-1. `but status -fv`
-2. `but pull --check`
-3. If clean, `but pull`
-4. `but status -fv`
+1. `but pull --check`
+2. If clean, `but pull`
+3. If commits come back conflicted, resolve each one: `but resolve <commit>` (the IDs are in the pull output), edit the files, then `but resolve finish`
 
 `but pull` updates applied branches onto the latest target branch (usually
-`main`). Do not use raw `git pull` or `git rebase`.
+`main`) and carries uncommitted changes along. Rebasing a branch onto the
+latest `main` IS `but pull` — it is never `move`, `config target`, `unapply`,
+or raw `git pull`/`git rebase`. The pull output already reports the resulting
+state.
 
 ### Commit selected files or hunks
 

--- a/crates/but/skill/references/concepts.md
+++ b/crates/but/skill/references/concepts.md
@@ -261,8 +261,8 @@ When `but pull` causes conflicts, affected commits are marked as conflicted.
 
 ### Resolution Workflow
 
-1. **Identify:** the `but pull` summary lists each conflicted commit's ID (`but status` also shows them)
-2. **Enter mode:** `but resolve <commit-id>` — it prints the conflict regions with line numbers
+1. **Identify:** the `but pull` summary lists each conflicted commit's ID, oldest first (`but status` also shows them)
+2. **Enter mode:** `but resolve <commit-id>` — it prints the conflict regions with line numbers. With several conflicted commits, resolve the oldest first: finishing a lower commit rebases the ones above it
 3. **Fix conflicts:** Edit files, remove conflict markers (`but resolve status` re-lists what remains when several files are conflicted)
 4. **Finalize:** `but resolve finish` or `but resolve cancel` — finish reports leftover markers and the surviving uncommitted changes, so no follow-up check is needed
 

--- a/crates/but/skill/references/concepts.md
+++ b/crates/but/skill/references/concepts.md
@@ -261,11 +261,10 @@ When `but pull` causes conflicts, affected commits are marked as conflicted.
 
 ### Resolution Workflow
 
-1. **Identify:** `but status` shows conflicted commits
-2. **Enter mode:** `but resolve <commit-id>`
-3. **Fix conflicts:** Edit files, remove conflict markers
-4. **Check:** `but resolve status` shows remaining conflicts
-5. **Finalize:** `but resolve finish` or `but resolve cancel`
+1. **Identify:** the `but pull` summary lists each conflicted commit's ID (`but status` also shows them)
+2. **Enter mode:** `but resolve <commit-id>` — it prints the conflict regions with line numbers
+3. **Fix conflicts:** Edit files, remove conflict markers (`but resolve status` re-lists what remains when several files are conflicted)
+4. **Finalize:** `but resolve finish` or `but resolve cancel` — finish reports leftover markers and the surviving uncommitted changes, so no follow-up check is needed
 
 ### During Resolution
 

--- a/crates/but/skill/references/examples.md
+++ b/crates/but/skill/references/examples.md
@@ -202,42 +202,35 @@ but commit bv -m "Add dialog component" --changes <id> # To frontend
 but pull
 
 # Output:
-# Conflict in commit nn on branch feature-x
+# Summary
+# ────────
+#   feature-x - conflicted
+#       nn Add validation
 
-# 2. Check status
-but status -fv
-
-# Output:
-# Branch: feature-x (bu)
-#   nn: Add validation (CONFLICTED)
-
-# 3. Enter resolution mode
+# 2. Enter resolution mode using the commit ID from the pull output
 but resolve nn
 
 # Output:
-# Entering resolution mode for commit nn
-# Fix conflicts in: api/users.js, api/validation.js
+# Checking out conflicted commit nn
+# Conflicted files remaining:
+#   ✗ api/users.js
+#      12│<<<<<<< New base: ...
+#      ...conflict regions with line numbers...
 
-# 4. Read each conflicted file and edit to resolve
+# 3. Edit each conflicted file to resolve
 # IMPORTANT: You MUST edit the files — do NOT just run `but resolve finish`
 # NEVER use `git add`, `git checkout --theirs/--ours`, or any git write command — just edit the files directly with the Edit tool, then `but resolve finish`
-cat api/users.js           # Read to see conflict markers
-# (edit to remove <<<<<<< ======= >>>>>>> markers and keep correct content)
+# (edit to remove <<<<<<< ======= >>>>>>> markers and keep correct content;
+#  with several conflicted files, `but resolve status` re-lists what remains)
 
-# 5. Check progress
-but resolve status
-
-# Output:
-# Remaining conflicts:
-#   api/validation.js
-
-# 6. Continue fixing...
-# (resolve last conflict)
-
-# 7. Finalize
+# 4. Finalize
 but resolve finish
 
-# Back to normal workspace mode
+# Output:
+# ✓ Conflict resolution finalized successfully!
+# No conflict markers remain in the resolved files.
+# Workspace restored; uncommitted changes intact: ...
+# No follow-up status or marker scan needed — finish already reports both.
 ```
 
 ## Example 7: Complete Feature Development Workflow

--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -365,7 +365,7 @@ but resolve cancel --force
 1. `but resolve <commit-id>` — enter resolution mode using the commit ID from the `but pull` summary (or `but status`); the conflict regions are printed with line numbers
 2. Edit the conflicted files — remove `<<<<<<<`, `=======`, `>>>>>>>` markers and keep the correct content (`but resolve status` re-lists what remains when several files are conflicted)
 3. `but resolve finish` — finalize and return to normal mode; the output reports leftover markers and the surviving uncommitted changes, so no follow-up status is needed
-4. If multiple commits are conflicted, repeat steps 1-3 for each one
+4. If multiple commits are conflicted, repeat steps 1-3 for each one, oldest commit first — finishing a lower commit rebases the ones above it
 
 **Important:** Never use `git add`, `git commit`, or other git write commands during conflict resolution. Only use `but resolve` commands and edit files directly.
 

--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -325,7 +325,7 @@ but discard <hunk-id>         # Discard hunk changes
 
 ## Conflict Resolution
 
-When commits have conflicts (shown in `but status` — look for commits marked as conflicted):
+When commits have conflicts (the `but pull` summary lists them; `but status` marks them as conflicted):
 
 ### `but resolve <commit>`
 
@@ -362,12 +362,10 @@ but resolve cancel --force
 
 **Workflow:**
 
-1. `but status` — identify conflicted commits (marked as conflicted in the output)
-2. `but resolve <commit-id>` — enter resolution mode for the conflicted commit
-3. Edit the conflicted files — remove `<<<<<<<`, `=======`, `>>>>>>>` markers and keep the correct content
-4. `but resolve status` — verify no conflicts remain
-5. `but resolve finish` — finalize and return to normal mode
-6. If multiple commits are conflicted, repeat steps 2-5 for each one
+1. `but resolve <commit-id>` — enter resolution mode using the commit ID from the `but pull` summary (or `but status`); the conflict regions are printed with line numbers
+2. Edit the conflicted files — remove `<<<<<<<`, `=======`, `>>>>>>>` markers and keep the correct content (`but resolve status` re-lists what remains when several files are conflicted)
+3. `but resolve finish` — finalize and return to normal mode; the output reports leftover markers and the surviving uncommitted changes, so no follow-up status is needed
+4. If multiple commits are conflicted, repeat steps 1-3 for each one
 
 **Important:** Never use `git add`, `git commit`, or other git write commands during conflict resolution. Only use `but resolve` commands and edit files directly.
 

--- a/crates/but/src/command/legacy/pull/mod.rs
+++ b/crates/but/src/command/legacy/pull/mod.rs
@@ -52,6 +52,15 @@ struct ConflictInfo {
     branch: String,
     files: Vec<String>,
     upstream_commit: Option<String>,
+    #[serde(default)]
+    commits: Vec<ConflictedCommitInfo>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ConflictedCommitInfo {
+    id: String,
+    message: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -64,7 +73,7 @@ struct PullSummary {
 }
 
 pub async fn handle(
-    ctx: &Context,
+    ctx: &mut Context,
     out: &mut OutputChannel,
     check_only: bool,
 ) -> anyhow::Result<()> {
@@ -220,7 +229,7 @@ async fn handle_check(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<
     Ok(())
 }
 
-async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<()> {
+async fn handle_pull(ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Result<()> {
     let t = theme::get();
     let mut pull_result = PullResult {
         status: String::new(),
@@ -468,12 +477,33 @@ async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<(
                 // Set undo command
                 pull_result.undo_command = Some("but undo".to_string());
 
+                // Look up the conflicted commits so the output can name them
+                // directly instead of sending callers through `but status`.
+                let conflicted_commits = if has_conflicts {
+                    crate::command::legacy::resolve::find_conflicted_commits(ctx)
+                        .unwrap_or_default()
+                } else {
+                    Default::default()
+                };
+
                 // Populate conflicts info
                 for branch_name in &conflicted_rebases {
                     pull_result.conflicts.push(ConflictInfo {
                         branch: branch_name.clone(),
                         files: vec![], // TODO: Get actual conflicted files
                         upstream_commit: None,
+                        commits: conflicted_commits
+                            .get(branch_name)
+                            .map(|commits| {
+                                commits
+                                    .iter()
+                                    .map(|commit| ConflictedCommitInfo {
+                                        id: commit.commit_short_id.clone(),
+                                        message: commit.commit_message.clone(),
+                                    })
+                                    .collect()
+                            })
+                            .unwrap_or_default(),
                     });
                 }
 
@@ -534,6 +564,14 @@ async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<(
                             t.local_branch.paint(branch),
                             t.error.paint("conflicted")
                         )?;
+                        for commit in conflicted_commits.get(branch).into_iter().flatten() {
+                            writeln!(
+                                out,
+                                "      {} {}",
+                                t.change_id.paint(&commit.commit_short_id),
+                                t.hint.paint(&commit.commit_message)
+                            )?;
+                        }
                     }
 
                     // Conflict resolution instructions
@@ -542,18 +580,13 @@ async fn handle_pull(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<(
                         writeln!(out, "{}", t.important.paint("To resolve conflicts:"))?;
                         writeln!(
                             out,
-                            "  1. Run {} to see conflicted commits",
-                            t.command_suggestion.paint("`but status`")
-                        )?;
-                        writeln!(
-                            out,
-                            "  2. Run {} to enter resolution mode on any conflicted commit",
+                            "  1. Run {} on a conflicted commit listed above",
                             t.command_suggestion.paint("`but resolve <commit>`")
                         )?;
-                        writeln!(out, "  3. Edit files to resolve the conflicts")?;
+                        writeln!(out, "  2. Edit files to resolve the conflicts")?;
                         writeln!(
                             out,
-                            "  4. Run {} to finalize the resolution",
+                            "  3. Run {} to finalize the resolution",
                             t.command_suggestion.paint("`but resolve finish`")
                         )?;
                     }

--- a/crates/but/src/command/legacy/pull/mod.rs
+++ b/crates/but/src/command/legacy/pull/mod.rs
@@ -2,6 +2,7 @@ mod json;
 
 use std::fmt::Write;
 
+use anyhow::bail;
 use bstr::ByteSlice;
 use but_core::{DryRun, RepositoryExt};
 use but_ctx::Context;
@@ -373,14 +374,32 @@ async fn handle_pull(ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Resu
             writeln!(
                 out,
                 "{}",
-                t.attention
-                    .paint("Please commit or stash them and try again.")
+                t.important
+                    .paint("To update anyway, park them on a temporary commit first:")
+            )?;
+            writeln!(
+                out,
+                "  1. Run {} with the files listed above ({} shows their IDs)",
+                t.command_suggestion
+                    .paint("`but commit <branch> --changes <file-id...> -m \"wip\"`"),
+                t.command_suggestion.paint("`but diff`")
+            )?;
+            writeln!(
+                out,
+                "  2. Run {} again; the parked commit may come back conflicted, ready for {}",
+                t.command_suggestion.paint("`but pull`"),
+                t.command_suggestion.paint("`but resolve`")
+            )?;
+            writeln!(
+                out,
+                "  3. Run {} afterwards to make those changes uncommitted again",
+                t.command_suggestion.paint("`but uncommit <commit>`")
             )?;
         }
         if let Some(out) = out.for_json() {
             out.write_value(&pull_result)?;
         }
-        None
+        bail!("nothing was updated; uncommitted changes conflict with the incoming updates");
     } else {
         pull_result.status = "updating".to_string();
 

--- a/crates/but/src/command/legacy/pull/mod.rs
+++ b/crates/but/src/command/legacy/pull/mod.rs
@@ -496,11 +496,28 @@ async fn handle_pull(ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Resu
                 // Set undo command
                 pull_result.undo_command = Some("but undo".to_string());
 
+                // The integration ran on its own thread-local context, so this
+                // context's cached repository and workspace still predate the
+                // rebase. Reload before rendering, or the conflicted commits
+                // fall back to sha refs that don't match what status shows.
+                if has_conflicts {
+                    let mut guard = ctx.exclusive_worktree_access();
+                    if let Err(err) =
+                        ctx.reload_repo_and_invalidate_workspace(guard.write_permission())
+                    {
+                        tracing::warn!(?err, "could not reload the workspace after integration");
+                    }
+                }
+
                 // Look up the conflicted commits so the output can name them
                 // directly instead of sending callers through `but status`.
                 let conflicted_commits = if has_conflicts {
-                    crate::command::legacy::resolve::find_conflicted_commits(ctx)
-                        .unwrap_or_default()
+                    crate::command::legacy::resolve::find_conflicted_commits(ctx).unwrap_or_else(
+                        |err| {
+                            tracing::warn!(?err, "could not look up conflicted commits");
+                            Default::default()
+                        },
+                    )
                 } else {
                     Default::default()
                 };

--- a/crates/but/src/command/legacy/pull/mod.rs
+++ b/crates/but/src/command/legacy/pull/mod.rs
@@ -599,7 +599,7 @@ async fn handle_pull(ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Resu
                         writeln!(out, "{}", t.important.paint("To resolve conflicts:"))?;
                         writeln!(
                             out,
-                            "  1. Run {} on a conflicted commit listed above",
+                            "  1. Run {} on a conflicted commit listed above — oldest first (they are listed bottom-up)",
                             t.command_suggestion.paint("`but resolve <commit>`")
                         )?;
                         writeln!(out, "  2. Edit files to resolve the conflicts")?;

--- a/crates/but/src/command/legacy/resolve.rs
+++ b/crates/but/src/command/legacy/resolve.rs
@@ -246,20 +246,23 @@ fn show_conflicted_files(ctx: &mut Context, out: &mut OutputChannel) -> Result<b
     let mut still_conflicted = Vec::new();
     let mut resolved = Vec::new();
 
+    // Contents are only needed to print conflict regions in human output;
+    // JSON output keeps just the paths.
+    let keep_content = !out.is_json();
     for (change, _) in &initially_conflicted {
         let file_path = repo_path.join(change.path.to_str_lossy().as_ref());
         if file_path.exists() {
             match std::fs::read_to_string(&file_path) {
                 Ok(content) => {
                     if has_conflict_markers(&content) {
-                        still_conflicted.push(change);
+                        still_conflicted.push((change, keep_content.then_some(content)));
                     } else {
                         resolved.push(change);
                     }
                 }
                 Err(_) => {
                     // If we can't read the file, consider it still conflicted
-                    still_conflicted.push(change);
+                    still_conflicted.push((change, None));
                 }
             }
         } else {
@@ -284,13 +287,16 @@ fn show_conflicted_files(ctx: &mut Context, out: &mut OutputChannel) -> Result<b
                 "{}:",
                 t.attention.paint("Conflicted files remaining")
             )?;
-            for change in &still_conflicted {
+            for (change, content) in &still_conflicted {
                 writeln!(
                     human_out,
                     "  {} {}",
                     t.sym().error,
                     t.attention.paint(change.path.to_str_lossy())
                 )?;
+                if let Some(content) = content {
+                    write_conflict_regions(human_out, content)?;
+                }
             }
         }
         if !resolved.is_empty() {
@@ -312,7 +318,7 @@ fn show_conflicted_files(ctx: &mut Context, out: &mut OutputChannel) -> Result<b
     if let Some(out) = out.for_json() {
         let conflicted_list: Vec<String> = still_conflicted
             .iter()
-            .map(|change| change.path.to_str_lossy().to_string())
+            .map(|(change, _)| change.path.to_str_lossy().to_string())
             .collect();
         let resolved_list: Vec<String> = resolved
             .iter()
@@ -336,6 +342,59 @@ fn has_conflict_markers(content: &str) -> bool {
     content.lines().any(|line| line.starts_with("<<<<<<<"))
 }
 
+/// Print the conflict-marker regions of a conflicted file with line numbers,
+/// so resolving does not require a separate read of the file. Large conflicts
+/// are summarized as line ranges instead of quoted in full.
+fn write_conflict_regions<W: std::fmt::Write + ?Sized>(
+    out: &mut W,
+    content: &str,
+) -> std::fmt::Result {
+    const MAX_QUOTED_LINES: usize = 60;
+    let t = theme::get();
+    let lines: Vec<&str> = content.lines().collect();
+
+    let mut regions: Vec<(usize, usize)> = Vec::new();
+    let mut start = None;
+    for (index, line) in lines.iter().enumerate() {
+        if line.starts_with("<<<<<<<") && start.is_none() {
+            start = Some(index);
+        } else if line.starts_with(">>>>>>>")
+            && let Some(from) = start.take()
+        {
+            regions.push((from, index));
+        }
+    }
+    // A start marker whose closing marker was lost (e.g. to a partial manual
+    // edit) still deserves line numbers; treat it as running to end of file.
+    if let Some(from) = start {
+        regions.push((from, lines.len().saturating_sub(1)));
+    }
+
+    let quoted_lines: usize = regions.iter().map(|(from, to)| to - from + 1).sum();
+    if quoted_lines > MAX_QUOTED_LINES {
+        let ranges = regions
+            .iter()
+            .map(|(from, to)| format!("{}-{}", from + 1, to + 1))
+            .collect::<Vec<_>>()
+            .join(", ");
+        writeln!(
+            out,
+            "      {}",
+            t.hint.paint(format!("conflicts at lines {ranges}"))
+        )?;
+        return Ok(());
+    }
+
+    for (from, to) in regions {
+        for (index, line) in lines.iter().enumerate().take(to + 1).skip(from) {
+            // The file content comes from the repository and is untrusted;
+            // strip control characters so it cannot inject terminal escapes.
+            writeln!(out, "    {:>4}│{}", index + 1, sanitize_terminal_text(line))?;
+        }
+    }
+    Ok(())
+}
+
 fn finish_resolution(ctx: &mut Context, out: &mut OutputChannel) -> Result<()> {
     let t = theme::get();
     // Check if we're in edit mode
@@ -347,6 +406,12 @@ fn finish_resolution(ctx: &mut Context, out: &mut OutputChannel) -> Result<()> {
 
     // Capture conflicted commits BEFORE the rebase
     let conflicts_before = find_conflicted_commits(ctx)?;
+
+    // Note files that still contain conflict markers, so the finish output can
+    // answer the "did I leave markers behind?" question without a re-scan.
+    // The scan may false-positive on legitimate content, so it warns rather
+    // than refusing to finalize.
+    let files_with_markers = files_with_conflict_markers(ctx)?;
 
     // Save and return to workspace, capturing the rebase output
     save_edit_and_return_to_workspace_with_output(ctx)
@@ -363,12 +428,76 @@ fn finish_resolution(ctx: &mut Context, out: &mut OutputChannel) -> Result<()> {
             human_out,
             "The commit has been updated with your resolved changes."
         )?;
+        if files_with_markers.is_empty() {
+            writeln!(
+                human_out,
+                "{}",
+                t.success
+                    .paint("No conflict markers remain in the resolved files.")
+            )?;
+        } else {
+            for path in &files_with_markers {
+                writeln!(
+                    human_out,
+                    "{} {} still contains conflict markers — resolve it again if that was not intentional",
+                    t.sym().error,
+                    t.attention.paint(sanitize_terminal_text(path))
+                )?;
+            }
+        }
+
+        let uncommitted = uncommitted_worktree_paths(ctx);
+        match uncommitted {
+            Ok(paths) if paths.is_empty() => {
+                writeln!(human_out, "Workspace restored; no uncommitted changes.")?;
+            }
+            Ok(paths) => {
+                writeln!(
+                    human_out,
+                    "Workspace restored; uncommitted changes intact: {}",
+                    paths.join(", ")
+                )?;
+            }
+            Err(_) => {}
+        }
     }
 
     // Check for new conflicts introduced during the rebase
     check_for_new_conflicts_after_rebase(ctx, out, conflicts_before)?;
 
     Ok(())
+}
+
+/// Paths of initially-conflicted files that still contain conflict markers in
+/// the edit-mode worktree.
+fn files_with_conflict_markers(ctx: &mut Context) -> Result<Vec<String>> {
+    let conflicted_files = edit_initial_index_state(ctx)?;
+    let repo = ctx.repo.get()?;
+    let repo_path = repo.workdir().context("No workdir")?;
+
+    Ok(conflicted_files
+        .iter()
+        .filter(|(_, conflict)| conflict.is_some())
+        .filter_map(|(change, _)| {
+            let path = change.path.to_str_lossy().to_string();
+            let content = std::fs::read_to_string(repo_path.join(&path)).ok()?;
+            has_conflict_markers(&content).then_some(path)
+        })
+        .collect())
+}
+
+/// Paths with uncommitted worktree changes, for the finish summary. Sorted
+/// for stable output, sanitized because paths come from the repository.
+fn uncommitted_worktree_paths(ctx: &mut Context) -> Result<Vec<String>> {
+    let repo = ctx.repo.get()?;
+    let changes = but_core::diff::worktree_changes(&repo)?;
+    let mut paths: Vec<String> = changes
+        .changes
+        .iter()
+        .map(|change| sanitize_terminal_text(&change.path.to_str_lossy()))
+        .collect();
+    paths.sort();
+    Ok(paths)
 }
 
 fn cancel_resolution(ctx: &mut Context, out: &mut OutputChannel, force: bool) -> Result<()> {
@@ -549,7 +678,7 @@ fn resolve_one_with_ai(
         )?;
         if let Some(summary) = &result.summary {
             writeln!(human_out)?;
-            writeln!(human_out, "{}", sanitize_model_text(summary))?;
+            writeln!(human_out, "{}", sanitize_terminal_text(summary))?;
         }
         writeln!(human_out)?;
         for file in &result.files {
@@ -562,7 +691,7 @@ fn resolve_one_with_ai(
             writeln!(
                 human_out,
                 "    {}",
-                t.hint.paint(sanitize_model_text(&file.reasoning))
+                t.hint.paint(sanitize_terminal_text(&file.reasoning))
             )?;
         }
         writeln!(human_out)?;
@@ -573,7 +702,10 @@ fn resolve_one_with_ai(
 
 /// Strip control characters (including ANSI escape sequences) from
 /// model-authored text before printing it to the terminal.
-fn sanitize_model_text(text: &str) -> String {
+/// Strip control characters (keeping newlines and tabs) from text that will
+/// be written to the terminal but originates outside this program - model
+/// output or repository file content.
+fn sanitize_terminal_text(text: &str) -> String {
     text.chars()
         .filter(|c| !c.is_control() || matches!(c, '\n' | '\t'))
         .collect()
@@ -703,15 +835,19 @@ pub(crate) fn find_conflicted_commits(
                 let commit = repo.find_commit(oid)?;
 
                 if commit.is_conflicted() {
-                    let message = commit
-                        .message_bstr()
-                        .to_string()
-                        .lines()
-                        .next()
-                        .context("Commit has no message")?
-                        .chars()
-                        .take(50)
-                        .collect::<String>();
+                    // Commit messages can come from untrusted upstreams and
+                    // end up on the terminal (pull summary, resolve listing).
+                    let message = sanitize_terminal_text(
+                        &commit
+                            .message_bstr()
+                            .to_string()
+                            .lines()
+                            .next()
+                            .context("Commit has no message")?
+                            .chars()
+                            .take(50)
+                            .collect::<String>(),
+                    );
 
                     let conflicted = ConflictedCommit {
                         commit_oid: oid,
@@ -977,4 +1113,53 @@ fn show_workflow_help(out: &mut OutputChannel) -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::write_conflict_regions;
+
+    fn render(content: &str) -> String {
+        let mut out = String::new();
+        write_conflict_regions(&mut out, content).unwrap();
+        out
+    }
+
+    #[test]
+    fn prints_terminated_regions_with_line_numbers() {
+        let out = render("context\n<<<<<<< ours\nx\n=======\ny\n>>>>>>> theirs\ntrailer\n");
+        assert!(out.contains("2│<<<<<<< ours"));
+        assert!(out.contains("6│>>>>>>> theirs"));
+        assert!(
+            !out.contains("context"),
+            "lines outside the region stay out"
+        );
+    }
+
+    #[test]
+    fn unterminated_region_runs_to_end_of_file() {
+        let out = render("<<<<<<< ours\nx\nlast line\n");
+        assert!(out.contains("1│<<<<<<< ours"));
+        assert!(out.contains("3│last line"));
+    }
+
+    #[test]
+    fn strips_control_characters_from_conflict_lines() {
+        let out = render("<<<<<<< ours\n\u{1b}[31mred\u{7}\n>>>>>>> theirs\n");
+        assert!(!out.contains('\u{1b}'));
+        assert!(!out.contains('\u{7}'));
+        assert!(out.contains("[31mred"));
+    }
+
+    #[test]
+    fn oversized_conflicts_summarize_as_line_ranges() {
+        let mut content = String::from("<<<<<<< ours\n");
+        for index in 0..70 {
+            content.push_str(&format!("line {index}\n"));
+        }
+        content.push_str(">>>>>>> theirs\n");
+        let out = render(&content);
+        assert!(out.contains("conflicts at lines 1-72"));
+        assert!(!out.contains("line 3"));
+    }
 }

--- a/crates/but/src/command/legacy/resolve.rs
+++ b/crates/but/src/command/legacy/resolve.rs
@@ -581,10 +581,10 @@ fn sanitize_model_text(text: &str) -> String {
 
 /// Structure to hold information about a conflicted commit
 #[derive(Debug)]
-struct ConflictedCommit {
-    commit_oid: gix::ObjectId,
-    commit_short_id: String,
-    commit_message: String,
+pub(crate) struct ConflictedCommit {
+    pub(crate) commit_oid: gix::ObjectId,
+    pub(crate) commit_short_id: String,
+    pub(crate) commit_message: String,
 }
 
 /// Check for new conflicts introduced during rebase and report them
@@ -667,7 +667,9 @@ fn check_for_new_conflicts_after_rebase(
 }
 
 /// Find all conflicted commits across all stacks, grouped by branch
-fn find_conflicted_commits(ctx: &mut Context) -> Result<BTreeMap<String, Vec<ConflictedCommit>>> {
+pub(crate) fn find_conflicted_commits(
+    ctx: &mut Context,
+) -> Result<BTreeMap<String, Vec<ConflictedCommit>>> {
     use gix::{prelude::ObjectIdExt as _, revision::walk::Sorting};
 
     let stacks = crate::legacy::workspace::applied_stacks(ctx)?;

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -679,12 +679,14 @@ fn print_hint(
 
     // Determine what hint to show based on workspace state
     let has_uncommitted_files = !status_ctx.worktree_changes.is_empty();
+    let mut shown_situational_hint = false;
 
     if should_explain_rewritten_commit_marker(status_ctx) {
         output.hint(Vec::from([Span::styled(
             "Hint: ◐ means rewritten locally vs upstream.",
             crate::theme::get().hint,
         )]))?;
+        shown_situational_hint = true;
     }
 
     if status_ctx.is_agent_invocation {
@@ -706,24 +708,35 @@ fn print_hint(
             ),
             crate::theme::get().hint,
         )]))?;
+        shown_situational_hint = true;
     }
 
     let hint_text = if not_on_workspace {
-        "Hint: run `but setup` to switch back to GitButler managed mode."
+        Some("Hint: run `but setup` to switch back to GitButler managed mode.")
     } else if has_merged_upstream_branch {
-        "Hint: branches marked `(merged upstream)` have landed; run `but pull` to remove them, or start new work on another branch"
+        Some(
+            "Hint: branches marked `(merged upstream)` have landed; run `but pull` to remove them, or start new work on another branch",
+        )
     } else if !status_ctx.has_branches {
-        "Hint: run `but branch new` to create a new branch to work on"
+        Some("Hint: run `but branch new` to create a new branch to work on")
     } else if has_uncommitted_files {
-        "Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m \"message\" --changes <id>` to commit them"
+        Some(
+            "Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m \"message\" --changes <id>` to commit them",
+        )
+    } else if shown_situational_hint {
+        // The generic catch-all adds nothing when a situational hint is
+        // already on screen.
+        None
     } else {
-        "Hint: run `but help` for all commands"
+        Some("Hint: run `but help` for all commands")
     };
 
-    output.hint(Vec::from([Span::styled(
-        hint_text,
-        crate::theme::get().hint,
-    )]))?;
+    if let Some(hint_text) = hint_text {
+        output.hint(Vec::from([Span::styled(
+            hint_text,
+            crate::theme::get().hint,
+        )]))?;
+    }
 
     Ok(())
 }

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -696,6 +696,18 @@ fn print_hint(
         output.hint(Vec::from([Span::styled(id_hint, crate::theme::get().hint)]))?;
     }
 
+    // The ⏫ marker alone reads as a configuration mismatch to some agents,
+    // which then try to repoint the target instead of pulling.
+    if let Some(upstream) = &status_ctx.upstream_state {
+        output.hint(Vec::from([Span::styled(
+            format!(
+                "Hint: {} moved ahead; run `but pull` to update the workspace",
+                upstream.target_name
+            ),
+            crate::theme::get().hint,
+        )]))?;
+    }
+
     let hint_text = if not_on_workspace {
         "Hint: run `but setup` to switch back to GitButler managed mode."
     } else if has_merged_upstream_branch {
@@ -887,7 +899,8 @@ fn print_upstream_state(
     if status_ctx.flags.show_upstream {
         // When showing detailed commits, only show count in summary
         let mut upstream_summary = Vec::from([Span::raw(format!(
-            "(upstream) ⏫ {} {}",
+            "(upstream: {}) ⏫ {} {}",
+            upstream.target_name,
             upstream.behind_count,
             if upstream.behind_count == 1 {
                 "commit"
@@ -938,7 +951,8 @@ fn print_upstream_state(
         let mut upstream_summary = Vec::from([
             Span::styled(upstream.latest_commit.clone(), t.hint),
             Span::raw(format!(
-                " (upstream) ⏫ {} {}",
+                " (upstream: {}) ⏫ {} {}",
+                upstream.target_name,
                 upstream.behind_count,
                 if upstream.behind_count == 1 {
                     "commit"

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -698,7 +698,7 @@ fn print_hint(
         output.hint(Vec::from([Span::styled(id_hint, crate::theme::get().hint)]))?;
     }
 
-    // The ⏫ marker alone reads as a configuration mismatch to some agents,
+    // A behind-count alone reads as a configuration mismatch to some agents,
     // which then try to repoint the target instead of pulling.
     if let Some(upstream) = &status_ctx.upstream_state {
         output.hint(Vec::from([Span::styled(
@@ -912,7 +912,7 @@ fn print_upstream_state(
     if status_ctx.flags.show_upstream {
         // When showing detailed commits, only show count in summary
         let mut upstream_summary = Vec::from([Span::raw(format!(
-            "(upstream: {}) ⏫ {} {}",
+            "(upstream: {}) {} new {}",
             upstream.target_name,
             upstream.behind_count,
             if upstream.behind_count == 1 {
@@ -964,7 +964,7 @@ fn print_upstream_state(
         let mut upstream_summary = Vec::from([
             Span::styled(upstream.latest_commit.clone(), t.hint),
             Span::raw(format!(
-                " (upstream: {}) ⏫ {} {}",
+                " (upstream: {}) {} new {}",
                 upstream.target_name,
                 upstream.behind_count,
                 if upstream.behind_count == 1 {

--- a/crates/but/src/command/legacy/status/output.rs
+++ b/crates/but/src/command/legacy/status/output.rs
@@ -334,7 +334,7 @@ pub(super) struct StatusOutputLine {
     /// ┊●   3dd0f00 (no commit message) (no changes)                   | Some("┊●   ")
     /// ├╯                                                              | Some("├╯ ")
     /// ┊                                                               | Some("┊ ")
-    /// ┊● 7cd07f6 (upstream) ⏫ 1 new commits (checked 34 seconds ago) | Some("┊● ")
+    /// ┊● 7cd07f6 (upstream: origin/main) 1 new commit (checked 34 seconds ago) | Some("┊● ")
     /// ├╯ 8678259 [origin/main] 2026-03-11 nix                         | Some("├╯ ")
     pub(super) connector: Option<Vec<Span<'static>>>,
     /// The content of the line such as the commit, branch, or file.

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/cannot_select_merged_branches_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/cannot_select_merged_branches_001.svg
@@ -39,10 +39,11 @@
     <text x="10" y="204" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="204" style="fill:#00AA00;">●</text>
     <text x="34 42 50 58 66 74 82" y="204" style="fill:#CCCCCC;opacity:0.75;">9354ac4</text>
-    <text x="98 106 114 122 130 138 146 154 162 170" y="204" style="fill:#CCCCCC;opacity:0.75;">(upstream)</text>
-    <text x="186" y="204" style="fill:#CCCCCC;opacity:0.75;">⏫</text>
-    <text x="210" y="204" style="fill:#CCCCCC;opacity:0.75;">2</text>
-    <text x="226 234 242 250 258 266 274" y="204" style="fill:#CCCCCC;opacity:0.75;">commits</text>
+    <text x="98 106 114 122 130 138 146 154 162 170" y="204" style="fill:#CCCCCC;opacity:0.75;">(upstream:</text>
+    <text x="186 194 202 210 218 226 234 242 250 258 266 274" y="204" style="fill:#CCCCCC;opacity:0.75;">origin/main)</text>
+    <text x="290" y="204" style="fill:#CCCCCC;opacity:0.75;">2</text>
+    <text x="306 314 322" y="204" style="fill:#CCCCCC;opacity:0.75;">new</text>
+    <text x="338 346 354 362 370 378 386" y="204" style="fill:#CCCCCC;opacity:0.75;">commits</text>
     <text x="10 18" y="222" style="fill:#CCCCCC;">├╯</text>
     <text x="34 42 50 58 66 74 82" y="222" style="fill:#CCCCCC;opacity:0.75;">efc9211</text>
     <text x="98 106 114 122 130 138 146" y="222" style="fill:#CCCCCC;">(common</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/cannot_select_merged_branches_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/cannot_select_merged_branches_002.svg
@@ -39,10 +39,11 @@
     <text x="10" y="204" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="204" style="fill:#00AA00;">●</text>
     <text x="34 42 50 58 66 74 82" y="204" style="fill:#CCCCCC;opacity:0.75;">9354ac4</text>
-    <text x="98 106 114 122 130 138 146 154 162 170" y="204" style="fill:#CCCCCC;opacity:0.75;">(upstream)</text>
-    <text x="186" y="204" style="fill:#CCCCCC;opacity:0.75;">⏫</text>
-    <text x="210" y="204" style="fill:#CCCCCC;opacity:0.75;">2</text>
-    <text x="226 234 242 250 258 266 274" y="204" style="fill:#CCCCCC;opacity:0.75;">commits</text>
+    <text x="98 106 114 122 130 138 146 154 162 170" y="204" style="fill:#CCCCCC;opacity:0.75;">(upstream:</text>
+    <text x="186 194 202 210 218 226 234 242 250 258 266 274" y="204" style="fill:#CCCCCC;opacity:0.75;">origin/main)</text>
+    <text x="290" y="204" style="fill:#CCCCCC;opacity:0.75;">2</text>
+    <text x="306 314 322" y="204" style="fill:#CCCCCC;opacity:0.75;">new</text>
+    <text x="338 346 354 362 370 378 386" y="204" style="fill:#CCCCCC;opacity:0.75;">commits</text>
     <text x="10 18" y="222" style="fill:#CCCCCC;">├╯</text>
     <text x="34 42 50 58 66 74 82" y="222" style="fill:#CCCCCC;opacity:0.75;">efc9211</text>
     <text x="98 106 114 122 130 138 146" y="222" style="fill:#CCCCCC;">(common</text>

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -740,8 +740,8 @@ async fn match_subcommand(
         },
         #[cfg(feature = "legacy")]
         Subcommands::Pull { check } => {
-            let ctx = setup::init_ctx(&args, InitCtxOptions::default(), out)?;
-            command::legacy::pull::handle(&ctx, out, check)
+            let mut ctx = setup::init_ctx(&args, InitCtxOptions::default(), out)?;
+            command::legacy::pull::handle(&mut ctx, out, check)
                 .await
                 .emit_metrics(metrics_ctx)
                 .map_err(CliError::from)
@@ -757,8 +757,8 @@ async fn match_subcommand(
                     "Assuming you meant to check for upstream work, running `but pull --check`"
                 )
             )?;
-            let ctx = setup::init_ctx(&args, InitCtxOptions::default(), out)?;
-            command::legacy::pull::handle(&ctx, out, true)
+            let mut ctx = setup::init_ctx(&args, InitCtxOptions::default(), out)?;
+            command::legacy::pull::handle(&mut ctx, out, true)
                 .await
                 .emit_metrics(metrics_ctx)
                 .map_err(CliError::from)
@@ -783,7 +783,7 @@ async fn match_subcommand(
                 let mut progress = out.progress_channel();
                 writeln!(progress, "Pulling latest...")?;
                 let mut pull_out = OutputChannel::new(OutputFormat::None);
-                command::legacy::pull::handle(&ctx, &mut pull_out, false).await?;
+                command::legacy::pull::handle(&mut ctx, &mut pull_out, false).await?;
                 writeln!(progress, "Pull complete.")?;
             }
             out.begin_status_after(status_after);

--- a/crates/but/tests/but/command/pull.rs
+++ b/crates/but/tests/but/command/pull.rs
@@ -25,7 +25,7 @@ fn pull_prunes_integrated_stack_and_keeps_remaining_stack_parent() -> anyhow::Re
 ┊●   lrm add B
 ├╯
 ┊
-┊● 26ecc90 (upstream: origin/main) ⏫ 2 commits
+┊● 26ecc90 (upstream: origin/main) 2 new commits
 ├╯ 26ecc90 (common base) 2000-01-02 add upstream
 
 Hint: origin/main moved ahead; run `but pull` to update the workspace
@@ -98,7 +98,7 @@ fn pull_prunes_integrated_branch_from_partial_stack() -> anyhow::Result<()> {
 ┊●   rkq add C
 ├╯
 ┊
-┊● d4cb681 (upstream: origin/main) ⏫ 2 commits
+┊● d4cb681 (upstream: origin/main) 2 new commits
 ├╯ 0dc3733 (common base) 2000-01-02 add M
 
 Hint: origin/main moved ahead; run `but pull` to update the workspace
@@ -183,7 +183,7 @@ fn pull_check_uses_workspace_dry_run_for_partial_stack() -> anyhow::Result<()> {
 ┊●   rkq add C
 ├╯
 ┊
-┊● d4cb681 (upstream: origin/main) ⏫ 2 commits
+┊● d4cb681 (upstream: origin/main) 2 new commits
 ├╯ 0dc3733 (common base) 2000-01-02 add M
 
 Hint: origin/main moved ahead; run `but pull` to update the workspace
@@ -230,7 +230,7 @@ Run `but pull` to update your branches
 ┊●   rkq add C
 ├╯
 ┊
-┊● d4cb681 (upstream: origin/main) ⏫ 2 commits (checked 0 seconds ago)
+┊● d4cb681 (upstream: origin/main) 2 new commits (checked 0 seconds ago)
 ├╯ 0dc3733 (common base) 2000-01-02 add M
 
 Hint: origin/main moved ahead; run `but pull` to update the workspace
@@ -254,7 +254,7 @@ fn pull_check_reports_conflicted_branches_as_rebasable() -> anyhow::Result<()> {
 ┊●   nyo A-change
 ├╯
 ┊
-┊● bdfcf28 (upstream: origin/main) ⏫ 1 commit
+┊● bdfcf28 (upstream: origin/main) 1 new commit
 ├╯ efc9211 (common base) 2000-01-02 base
 
 Hint: origin/main moved ahead; run `but pull` to update the workspace
@@ -316,7 +316,7 @@ fn pull_reparents_workspace_to_target_after_all_stacks_integrate() -> anyhow::Re
 ┊╭┄h0 [B] (no commits)
 ├╯
 ┊
-┊● 7e5d4e1 (upstream: origin/main) ⏫ 3 commits
+┊● 7e5d4e1 (upstream: origin/main) 3 new commits
 ├╯ 7e5d4e1 (common base) 2000-01-02 add upstream
 
 Hint: origin/main moved ahead; run `but pull` to update the workspace
@@ -406,7 +406,7 @@ fn pull_does_not_report_branch_rebase_conflicts_as_worktree_conflicts() -> anyho
 ┊●   vun local change
 ├╯
 ┊
-┊● 7f73771 (upstream: origin/main) ⏫ 1 commit
+┊● 7f73771 (upstream: origin/main) 1 new commit
 ├╯ 7f73771 (common base) 2000-01-02 upstream change
 
 Hint: origin/main moved ahead; run `but pull` to update the workspace
@@ -466,7 +466,7 @@ fn pull_json_reports_branch_rebase_conflicts_as_successful_integration() -> anyh
 ┊●   vun local change
 ├╯
 ┊
-┊● 7f73771 (upstream: origin/main) ⏫ 1 commit
+┊● 7f73771 (upstream: origin/main) 1 new commit
 ├╯ 7f73771 (common base) 2000-01-02 upstream change
 
 Hint: origin/main moved ahead; run `but pull` to update the workspace
@@ -533,7 +533,7 @@ fn pull_reports_conflict_in_lower_branch_of_stack() -> anyhow::Result<()> {
 ┊●   [..] bottom change
 ├╯
 ┊
-┊● 7f73771 (upstream: origin/main) ⏫ 1 commit
+┊● 7f73771 (upstream: origin/main) 1 new commit
 ├╯ 7f73771 (common base) 2000-01-02 upstream change
 
 Hint: origin/main moved ahead; run `but pull` to update the workspace
@@ -601,7 +601,7 @@ fn pull_reports_conflicts_in_multiple_branches_of_stack() -> anyhow::Result<()> 
 ┊●   [..] bottom change
 ├╯
 ┊
-┊● e4933d8 (upstream: origin/main) ⏫ 1 commit
+┊● e4933d8 (upstream: origin/main) 1 new commit
 ├╯ [..] (common base) 2000-01-02 upstream change
 
 Hint: origin/main moved ahead; run `but pull` to update the workspace

--- a/crates/but/tests/but/command/pull.rs
+++ b/crates/but/tests/but/command/pull.rs
@@ -549,12 +549,12 @@ Summary
 ────────
   A - rebased
   B - conflicted
+      d5fa75c [conflict] bottom change
 
 To resolve conflicts:
-  1. Run `but status` to see conflicted commits
-  2. Run `but resolve <commit>` to enter resolution mode on any conflicted commit
-  3. Edit files to resolve the conflicts
-  4. Run `but resolve finish` to finalize the resolution
+  1. Run `but resolve <commit>` on a conflicted commit listed above
+  2. Edit files to resolve the conflicts
+  3. Run `but resolve finish` to finalize the resolution
 
 To undo this operation:
   Run `but undo`
@@ -616,13 +616,15 @@ Rebase resulted in some conflicts
 Summary
 ────────
   A - conflicted
+      7ac1f5a [conflict] bottom change
+      09bcfd9 [conflict] top change
   B - conflicted
+      7ac1f5a [conflict] bottom change
 
 To resolve conflicts:
-  1. Run `but status` to see conflicted commits
-  2. Run `but resolve <commit>` to enter resolution mode on any conflicted commit
-  3. Edit files to resolve the conflicts
-  4. Run `but resolve finish` to finalize the resolution
+  1. Run `but resolve <commit>` on a conflicted commit listed above
+  2. Edit files to resolve the conflicts
+  3. Run `but resolve finish` to finalize the resolution
 
 To undo this operation:
   Run `but undo`

--- a/crates/but/tests/but/command/pull.rs
+++ b/crates/but/tests/but/command/pull.rs
@@ -692,14 +692,17 @@ fn pull_reports_worktree_conflict_paths() -> anyhow::Result<()> {
     // to `shared.txt` on the resulting workspace head.
     env.file("shared.txt", "dirty local\nmore local work\n");
 
-    env.but("pull").assert().success().stdout_eq(str![[r#"
+    env.but("pull").assert().failure().stdout_eq(str![[r#"
 
 Found 1 upstream commits on origin/main
    [..] upstream change
 
 There are uncommitted changes in the worktree that conflict with the updates:
   shared.txt
-Please commit or stash them and try again.
+To update anyway, park them on a temporary commit first:
+  1. Run `but commit <branch> --changes <file-id...> -m "wip"` with the files listed above (`but diff` shows their IDs)
+  2. Run `but pull` again; the parked commit may come back conflicted, ready for `but resolve`
+  3. Run `but uncommit <commit>` afterwards to make those changes uncommitted again
 
 "#]]);
 

--- a/crates/but/tests/but/command/pull.rs
+++ b/crates/but/tests/but/command/pull.rs
@@ -29,7 +29,6 @@ fn pull_prunes_integrated_stack_and_keeps_remaining_stack_parent() -> anyhow::Re
 ├╯ 26ecc90 (common base) 2000-01-02 add upstream
 
 Hint: origin/main moved ahead; run `but pull` to update the workspace
-Hint: run `but help` for all commands
 
 "#]]);
 
@@ -259,7 +258,6 @@ fn pull_check_reports_conflicted_branches_as_rebasable() -> anyhow::Result<()> {
 ├╯ efc9211 (common base) 2000-01-02 base
 
 Hint: origin/main moved ahead; run `but pull` to update the workspace
-Hint: run `but help` for all commands
 
 "#]]);
 
@@ -322,7 +320,6 @@ fn pull_reparents_workspace_to_target_after_all_stacks_integrate() -> anyhow::Re
 ├╯ 7e5d4e1 (common base) 2000-01-02 add upstream
 
 Hint: origin/main moved ahead; run `but pull` to update the workspace
-Hint: run `but help` for all commands
 
 "#]]);
 
@@ -473,7 +470,6 @@ fn pull_json_reports_branch_rebase_conflicts_as_successful_integration() -> anyh
 ├╯ 7f73771 (common base) 2000-01-02 upstream change
 
 Hint: origin/main moved ahead; run `but pull` to update the workspace
-Hint: run `but help` for all commands
 
 "#]]);
 
@@ -541,7 +537,6 @@ fn pull_reports_conflict_in_lower_branch_of_stack() -> anyhow::Result<()> {
 ├╯ 7f73771 (common base) 2000-01-02 upstream change
 
 Hint: origin/main moved ahead; run `but pull` to update the workspace
-Hint: run `but help` for all commands
 
 "#]]);
 
@@ -610,7 +605,6 @@ fn pull_reports_conflicts_in_multiple_branches_of_stack() -> anyhow::Result<()> 
 ├╯ [..] (common base) 2000-01-02 upstream change
 
 Hint: origin/main moved ahead; run `but pull` to update the workspace
-Hint: run `but help` for all commands
 
 "#]]);
 

--- a/crates/but/tests/but/command/pull.rs
+++ b/crates/but/tests/but/command/pull.rs
@@ -556,7 +556,7 @@ Summary
       d5fa75c [conflict] bottom change
 
 To resolve conflicts:
-  1. Run `but resolve <commit>` on a conflicted commit listed above
+  1. Run `but resolve <commit>` on a conflicted commit listed above — oldest first (they are listed bottom-up)
   2. Edit files to resolve the conflicts
   3. Run `but resolve finish` to finalize the resolution
 
@@ -626,7 +626,7 @@ Summary
       7ac1f5a [conflict] bottom change
 
 To resolve conflicts:
-  1. Run `but resolve <commit>` on a conflicted commit listed above
+  1. Run `but resolve <commit>` on a conflicted commit listed above — oldest first (they are listed bottom-up)
   2. Edit files to resolve the conflicts
   3. Run `but resolve finish` to finalize the resolution
 

--- a/crates/but/tests/but/command/pull.rs
+++ b/crates/but/tests/but/command/pull.rs
@@ -25,9 +25,10 @@ fn pull_prunes_integrated_stack_and_keeps_remaining_stack_parent() -> anyhow::Re
 ┊●   lrm add B
 ├╯
 ┊
-┊● 26ecc90 (upstream) ⏫ 2 commits
+┊● 26ecc90 (upstream: origin/main) ⏫ 2 commits
 ├╯ 26ecc90 (common base) 2000-01-02 add upstream
 
+Hint: origin/main moved ahead; run `but pull` to update the workspace
 Hint: run `but help` for all commands
 
 "#]]);
@@ -98,9 +99,10 @@ fn pull_prunes_integrated_branch_from_partial_stack() -> anyhow::Result<()> {
 ┊●   rkq add C
 ├╯
 ┊
-┊● d4cb681 (upstream) ⏫ 2 commits
+┊● d4cb681 (upstream: origin/main) ⏫ 2 commits
 ├╯ 0dc3733 (common base) 2000-01-02 add M
 
+Hint: origin/main moved ahead; run `but pull` to update the workspace
 Hint: branches marked `(merged upstream)` have landed; run `but pull` to remove them, or start new work on another branch
 
 "#]]);
@@ -182,9 +184,10 @@ fn pull_check_uses_workspace_dry_run_for_partial_stack() -> anyhow::Result<()> {
 ┊●   rkq add C
 ├╯
 ┊
-┊● d4cb681 (upstream) ⏫ 2 commits
+┊● d4cb681 (upstream: origin/main) ⏫ 2 commits
 ├╯ 0dc3733 (common base) 2000-01-02 add M
 
+Hint: origin/main moved ahead; run `but pull` to update the workspace
 Hint: branches marked `(merged upstream)` have landed; run `but pull` to remove them, or start new work on another branch
 
 "#]]);
@@ -228,9 +231,10 @@ Run `but pull` to update your branches
 ┊●   rkq add C
 ├╯
 ┊
-┊● d4cb681 (upstream) ⏫ 2 commits (checked [..])
+┊● d4cb681 (upstream: origin/main) ⏫ 2 commits (checked 0 seconds ago)
 ├╯ 0dc3733 (common base) 2000-01-02 add M
 
+Hint: origin/main moved ahead; run `but pull` to update the workspace
 Hint: branches marked `(merged upstream)` have landed; run `but pull` to remove them, or start new work on another branch
 
 "#]]);
@@ -251,9 +255,10 @@ fn pull_check_reports_conflicted_branches_as_rebasable() -> anyhow::Result<()> {
 ┊●   nyo A-change
 ├╯
 ┊
-┊● bdfcf28 (upstream) ⏫ 1 commit
+┊● bdfcf28 (upstream: origin/main) ⏫ 1 commit
 ├╯ efc9211 (common base) 2000-01-02 base
 
+Hint: origin/main moved ahead; run `but pull` to update the workspace
 Hint: run `but help` for all commands
 
 "#]]);
@@ -313,9 +318,10 @@ fn pull_reparents_workspace_to_target_after_all_stacks_integrate() -> anyhow::Re
 ┊╭┄h0 [B] (no commits)
 ├╯
 ┊
-┊● 7e5d4e1 (upstream) ⏫ 3 commits
+┊● 7e5d4e1 (upstream: origin/main) ⏫ 3 commits
 ├╯ 7e5d4e1 (common base) 2000-01-02 add upstream
 
+Hint: origin/main moved ahead; run `but pull` to update the workspace
 Hint: run `but help` for all commands
 
 "#]]);
@@ -403,9 +409,10 @@ fn pull_does_not_report_branch_rebase_conflicts_as_worktree_conflicts() -> anyho
 ┊●   vun local change
 ├╯
 ┊
-┊● 7f73771 (upstream) ⏫ 1 commit
+┊● 7f73771 (upstream: origin/main) ⏫ 1 commit
 ├╯ 7f73771 (common base) 2000-01-02 upstream change
 
+Hint: origin/main moved ahead; run `but pull` to update the workspace
 Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "message" --changes <id>` to commit them
 
 "#]]);
@@ -462,9 +469,10 @@ fn pull_json_reports_branch_rebase_conflicts_as_successful_integration() -> anyh
 ┊●   vun local change
 ├╯
 ┊
-┊● 7f73771 (upstream) ⏫ 1 commit
+┊● 7f73771 (upstream: origin/main) ⏫ 1 commit
 ├╯ 7f73771 (common base) 2000-01-02 upstream change
 
+Hint: origin/main moved ahead; run `but pull` to update the workspace
 Hint: run `but help` for all commands
 
 "#]]);
@@ -529,9 +537,10 @@ fn pull_reports_conflict_in_lower_branch_of_stack() -> anyhow::Result<()> {
 ┊●   [..] bottom change
 ├╯
 ┊
-┊● 7f73771 (upstream) ⏫ 1 commit
+┊● 7f73771 (upstream: origin/main) ⏫ 1 commit
 ├╯ 7f73771 (common base) 2000-01-02 upstream change
 
+Hint: origin/main moved ahead; run `but pull` to update the workspace
 Hint: run `but help` for all commands
 
 "#]]);
@@ -597,9 +606,10 @@ fn pull_reports_conflicts_in_multiple_branches_of_stack() -> anyhow::Result<()> 
 ┊●   [..] bottom change
 ├╯
 ┊
-┊● [..] (upstream) ⏫ 1 commit
+┊● e4933d8 (upstream: origin/main) ⏫ 1 commit
 ├╯ [..] (common base) 2000-01-02 upstream change
 
+Hint: origin/main moved ahead; run `but pull` to update the workspace
 Hint: run `but help` for all commands
 
 "#]]);

--- a/crates/but/tests/but/command/pull.rs
+++ b/crates/but/tests/but/command/pull.rs
@@ -553,7 +553,7 @@ Summary
 ────────
   A - rebased
   B - conflicted
-      d5fa75c [conflict] bottom change
+      rou [conflict] bottom change
 
 To resolve conflicts:
   1. Run `but resolve <commit>` on a conflicted commit listed above — oldest first (they are listed bottom-up)
@@ -620,10 +620,10 @@ Rebase resulted in some conflicts
 Summary
 ────────
   A - conflicted
-      7ac1f5a [conflict] bottom change
-      09bcfd9 [conflict] top change
+      trk [conflict] bottom change
+      wmr [conflict] top change
   B - conflicted
-      7ac1f5a [conflict] bottom change
+      trk [conflict] bottom change
 
 To resolve conflicts:
   1. Run `but resolve <commit>` on a conflicted commit listed above — oldest first (they are listed bottom-up)

--- a/crates/but/tests/but/command/resolve.rs
+++ b/crates/but/tests/but/command/resolve.rs
@@ -29,7 +29,42 @@ fn resolve_status_and_finish_work_in_edit_mode() -> anyhow::Result<()> {
     env.but("resolve finish")
         .assert()
         .success()
-        .stderr_eq(str![""]);
+        .stderr_eq(str![""])
+        .stdout_eq(str![[r#"
+✓ Conflict resolution finalized successfully!
+The commit has been updated with your resolved changes.
+No conflict markers remain in the resolved files.
+Workspace restored; uncommitted changes intact: test-file.txt
+
+"#]]);
+
+    assert_eq!(current_branch_name(&env)?, "gitbutler/workspace");
+    Ok(())
+}
+
+#[test]
+fn resolve_finish_reports_leftover_markers_and_uncommitted_paths() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    enter_edit_mode_with_conflicted_commit(&env)?;
+
+    // A "resolution" that leaves conflict markers behind.
+    env.file(
+        "test-file.txt",
+        "<<<<<<< ours\nline 2\n=======\nline two\n>>>>>>> theirs\n",
+    );
+    env.invoke_git("add test-file.txt");
+
+    env.but("resolve finish")
+        .assert()
+        .success()
+        .stderr_eq(str![""])
+        .stdout_eq(str![[r#"
+✓ Conflict resolution finalized successfully!
+The commit has been updated with your resolved changes.
+✗ test-file.txt still contains conflict markers — resolve it again if that was not intentional
+Workspace restored; uncommitted changes intact: test-file.txt
+
+"#]]);
 
     assert_eq!(current_branch_name(&env)?, "gitbutler/workspace");
     Ok(())

--- a/crates/but/tests/but/command/snapshots/status/two-worktrees/status-with-worktrees-verbose.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/two-worktrees/status-with-worktrees-verbose.stdout.term.svg
@@ -57,7 +57,7 @@
 </tspan>
     <tspan x="10px" y="316px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>┊</tspan><tspan class="fg-green">●</tspan><tspan> </tspan><tspan class="dimmed">8dc508f</tspan><tspan> (upstream: origin/main) ⏫ 1 commit</tspan>
+    <tspan x="10px" y="334px"><tspan>┊</tspan><tspan class="fg-green">●</tspan><tspan> </tspan><tspan class="dimmed">8dc508f</tspan><tspan> (upstream: origin/main) 1 new commit</tspan>
 </tspan>
     <tspan x="10px" y="352px"><tspan>├╯ </tspan><tspan class="dimmed">8dc508f</tspan><tspan> (common base) </tspan><tspan class="dimmed">2000-01-02</tspan><tspan> M-advanced</tspan>
 </tspan>

--- a/crates/but/tests/but/command/snapshots/status/two-worktrees/status-with-worktrees-verbose.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/two-worktrees/status-with-worktrees-verbose.stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="434px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="416px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -65,9 +65,7 @@
 </tspan>
     <tspan x="10px" y="388px"><tspan class="dimmed">Hint: origin/main moved ahead; run `but pull` to update the workspace</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan class="dimmed">Hint: run `but help` for all commands</tspan>
-</tspan>
-    <tspan x="10px" y="424px">
+    <tspan x="10px" y="406px">
 </tspan>
   </text>
 

--- a/crates/but/tests/but/command/snapshots/status/two-worktrees/status-with-worktrees-verbose.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/two-worktrees/status-with-worktrees-verbose.stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="416px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="434px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -57,15 +57,17 @@
 </tspan>
     <tspan x="10px" y="316px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>┊</tspan><tspan class="fg-green">●</tspan><tspan> </tspan><tspan class="dimmed">8dc508f</tspan><tspan> (upstream) ⏫ 1 commit</tspan>
+    <tspan x="10px" y="334px"><tspan>┊</tspan><tspan class="fg-green">●</tspan><tspan> </tspan><tspan class="dimmed">8dc508f</tspan><tspan> (upstream: origin/main) ⏫ 1 commit</tspan>
 </tspan>
     <tspan x="10px" y="352px"><tspan>├╯ </tspan><tspan class="dimmed">8dc508f</tspan><tspan> (common base) </tspan><tspan class="dimmed">2000-01-02</tspan><tspan> M-advanced</tspan>
 </tspan>
     <tspan x="10px" y="370px">
 </tspan>
-    <tspan x="10px" y="388px"><tspan class="dimmed">Hint: run `but help` for all commands</tspan>
+    <tspan x="10px" y="388px"><tspan class="dimmed">Hint: origin/main moved ahead; run `but pull` to update the workspace</tspan>
 </tspan>
-    <tspan x="10px" y="406px">
+    <tspan x="10px" y="406px"><tspan class="dimmed">Hint: run `but help` for all commands</tspan>
+</tspan>
+    <tspan x="10px" y="424px">
 </tspan>
   </text>
 

--- a/crates/but/tests/but/command/snapshots/status/two-worktrees/status-with-worktrees.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/two-worktrees/status-with-worktrees.stdout.term.svg
@@ -51,7 +51,7 @@
 </tspan>
     <tspan x="10px" y="262px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>┊</tspan><tspan class="fg-green">●</tspan><tspan> </tspan><tspan class="dimmed">8dc508f</tspan><tspan> (upstream: origin/main) ⏫ 1 commit</tspan>
+    <tspan x="10px" y="280px"><tspan>┊</tspan><tspan class="fg-green">●</tspan><tspan> </tspan><tspan class="dimmed">8dc508f</tspan><tspan> (upstream: origin/main) 1 new commit</tspan>
 </tspan>
     <tspan x="10px" y="298px"><tspan>├╯ </tspan><tspan class="dimmed">8dc508f</tspan><tspan> (common base) </tspan><tspan class="dimmed">2000-01-02</tspan><tspan> M-advanced</tspan>
 </tspan>

--- a/crates/but/tests/but/command/snapshots/status/two-worktrees/status-with-worktrees.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/two-worktrees/status-with-worktrees.stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="362px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="380px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -51,15 +51,17 @@
 </tspan>
     <tspan x="10px" y="262px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>┊</tspan><tspan class="fg-green">●</tspan><tspan> </tspan><tspan class="dimmed">8dc508f</tspan><tspan> (upstream) ⏫ 1 commit</tspan>
+    <tspan x="10px" y="280px"><tspan>┊</tspan><tspan class="fg-green">●</tspan><tspan> </tspan><tspan class="dimmed">8dc508f</tspan><tspan> (upstream: origin/main) ⏫ 1 commit</tspan>
 </tspan>
     <tspan x="10px" y="298px"><tspan>├╯ </tspan><tspan class="dimmed">8dc508f</tspan><tspan> (common base) </tspan><tspan class="dimmed">2000-01-02</tspan><tspan> M-advanced</tspan>
 </tspan>
     <tspan x="10px" y="316px">
 </tspan>
-    <tspan x="10px" y="334px"><tspan class="dimmed">Hint: run `but help` for all commands</tspan>
+    <tspan x="10px" y="334px"><tspan class="dimmed">Hint: origin/main moved ahead; run `but pull` to update the workspace</tspan>
 </tspan>
-    <tspan x="10px" y="352px">
+    <tspan x="10px" y="352px"><tspan class="dimmed">Hint: run `but help` for all commands</tspan>
+</tspan>
+    <tspan x="10px" y="370px">
 </tspan>
   </text>
 

--- a/crates/but/tests/but/command/snapshots/status/two-worktrees/status-with-worktrees.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/two-worktrees/status-with-worktrees.stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="380px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="362px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -59,9 +59,7 @@
 </tspan>
     <tspan x="10px" y="334px"><tspan class="dimmed">Hint: origin/main moved ahead; run `but pull` to update the workspace</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan class="dimmed">Hint: run `but help` for all commands</tspan>
-</tspan>
-    <tspan x="10px" y="370px">
+    <tspan x="10px" y="352px">
 </tspan>
   </text>
 

--- a/crates/but/tests/but/command/snapshots/status/upstream/status-upstream-detailed.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/upstream/status-upstream-detailed.stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="416px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="398px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -62,9 +62,7 @@
 </tspan>
     <tspan x="10px" y="370px"><tspan class="dimmed">Hint: origin/main moved ahead; run `but pull` to update the workspace</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan class="dimmed">Hint: run `but help` for all commands</tspan>
-</tspan>
-    <tspan x="10px" y="406px">
+    <tspan x="10px" y="388px">
 </tspan>
   </text>
 

--- a/crates/but/tests/but/command/snapshots/status/upstream/status-upstream-detailed.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/upstream/status-upstream-detailed.stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="398px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="416px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -34,7 +34,7 @@
 </tspan>
     <tspan x="10px" y="118px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>┊╭┄(upstream) ⏫ 10 commits</tspan>
+    <tspan x="10px" y="136px"><tspan>┊╭┄(upstream: origin/main) ⏫ 10 commits</tspan>
 </tspan>
     <tspan x="10px" y="154px"><tspan>┊</tspan><tspan class="fg-green">●</tspan><tspan> </tspan><tspan class="fg-cyan">801d97d</tspan><tspan> </tspan><tspan class="dimmed">add upstream-10</tspan>
 </tspan>
@@ -60,9 +60,11 @@
 </tspan>
     <tspan x="10px" y="352px">
 </tspan>
-    <tspan x="10px" y="370px"><tspan class="dimmed">Hint: run `but help` for all commands</tspan>
+    <tspan x="10px" y="370px"><tspan class="dimmed">Hint: origin/main moved ahead; run `but pull` to update the workspace</tspan>
 </tspan>
-    <tspan x="10px" y="388px">
+    <tspan x="10px" y="388px"><tspan class="dimmed">Hint: run `but help` for all commands</tspan>
+</tspan>
+    <tspan x="10px" y="406px">
 </tspan>
   </text>
 

--- a/crates/but/tests/but/command/snapshots/status/upstream/status-upstream-detailed.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/upstream/status-upstream-detailed.stdout.term.svg
@@ -34,7 +34,7 @@
 </tspan>
     <tspan x="10px" y="118px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>┊╭┄(upstream: origin/main) ⏫ 10 commits</tspan>
+    <tspan x="10px" y="136px"><tspan>┊╭┄(upstream: origin/main) 10 new commits</tspan>
 </tspan>
     <tspan x="10px" y="154px"><tspan>┊</tspan><tspan class="fg-green">●</tspan><tspan> </tspan><tspan class="fg-cyan">801d97d</tspan><tspan> </tspan><tspan class="dimmed">add upstream-10</tspan>
 </tspan>

--- a/crates/but/tests/but/command/snapshots/status/upstream/status-upstream-merge-status-conflicted.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/upstream/status-upstream-merge-status-conflicted.stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="272px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="254px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -47,9 +47,7 @@
 </tspan>
     <tspan x="10px" y="226px"><tspan class="dimmed">Hint: origin/main moved ahead; run `but pull` to update the workspace</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan class="dimmed">Hint: run `but help` for all commands</tspan>
-</tspan>
-    <tspan x="10px" y="262px">
+    <tspan x="10px" y="244px">
 </tspan>
   </text>
 

--- a/crates/but/tests/but/command/snapshots/status/upstream/status-upstream-merge-status-conflicted.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/upstream/status-upstream-merge-status-conflicted.stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="254px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="272px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -35,7 +35,7 @@
 </tspan>
     <tspan x="10px" y="118px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>┊╭┄(upstream) ⏫ 1 commit</tspan>
+    <tspan x="10px" y="136px"><tspan>┊╭┄(upstream: origin/main) ⏫ 1 commit</tspan>
 </tspan>
     <tspan x="10px" y="154px"><tspan>┊</tspan><tspan class="fg-green">●</tspan><tspan> </tspan><tspan class="fg-cyan">bdfcf28</tspan><tspan> </tspan><tspan class="dimmed">main-change</tspan>
 </tspan>
@@ -45,9 +45,11 @@
 </tspan>
     <tspan x="10px" y="208px">
 </tspan>
-    <tspan x="10px" y="226px"><tspan class="dimmed">Hint: run `but help` for all commands</tspan>
+    <tspan x="10px" y="226px"><tspan class="dimmed">Hint: origin/main moved ahead; run `but pull` to update the workspace</tspan>
 </tspan>
-    <tspan x="10px" y="244px">
+    <tspan x="10px" y="244px"><tspan class="dimmed">Hint: run `but help` for all commands</tspan>
+</tspan>
+    <tspan x="10px" y="262px">
 </tspan>
   </text>
 

--- a/crates/but/tests/but/command/snapshots/status/upstream/status-upstream-merge-status-conflicted.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/upstream/status-upstream-merge-status-conflicted.stdout.term.svg
@@ -35,7 +35,7 @@
 </tspan>
     <tspan x="10px" y="118px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>┊╭┄(upstream: origin/main) ⏫ 1 commit</tspan>
+    <tspan x="10px" y="136px"><tspan>┊╭┄(upstream: origin/main) 1 new commit</tspan>
 </tspan>
     <tspan x="10px" y="154px"><tspan>┊</tspan><tspan class="fg-green">●</tspan><tspan> </tspan><tspan class="fg-cyan">bdfcf28</tspan><tspan> </tspan><tspan class="dimmed">main-change</tspan>
 </tspan>

--- a/crates/but/tests/but/command/snapshots/status/upstream/status-upstream-merge-status-integrated.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/upstream/status-upstream-merge-status-integrated.stdout.term.svg
@@ -42,7 +42,7 @@
 </tspan>
     <tspan x="10px" y="190px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>┊╭┄(upstream: origin/main) ⏫ 2 commits</tspan>
+    <tspan x="10px" y="208px"><tspan>┊╭┄(upstream: origin/main) 2 new commits</tspan>
 </tspan>
     <tspan x="10px" y="226px"><tspan>┊</tspan><tspan class="fg-green">●</tspan><tspan> </tspan><tspan class="fg-cyan">9354ac4</tspan><tspan> </tspan><tspan class="dimmed">main-advance</tspan>
 </tspan>

--- a/crates/but/tests/but/command/snapshots/status/upstream/status-upstream-merge-status-integrated.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/upstream/status-upstream-merge-status-integrated.stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="1037px" height="344px" xmlns="http://www.w3.org/2000/svg">
+<svg width="1037px" height="362px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -42,7 +42,7 @@
 </tspan>
     <tspan x="10px" y="190px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>┊╭┄(upstream) ⏫ 2 commits</tspan>
+    <tspan x="10px" y="208px"><tspan>┊╭┄(upstream: origin/main) ⏫ 2 commits</tspan>
 </tspan>
     <tspan x="10px" y="226px"><tspan>┊</tspan><tspan class="fg-green">●</tspan><tspan> </tspan><tspan class="fg-cyan">9354ac4</tspan><tspan> </tspan><tspan class="dimmed">main-advance</tspan>
 </tspan>
@@ -54,9 +54,11 @@
 </tspan>
     <tspan x="10px" y="298px">
 </tspan>
-    <tspan x="10px" y="316px"><tspan class="dimmed">Hint: branches marked `(merged upstream)` have landed; run `but pull` to remove them, or start new work on another branch</tspan>
+    <tspan x="10px" y="316px"><tspan class="dimmed">Hint: origin/main moved ahead; run `but pull` to update the workspace</tspan>
 </tspan>
-    <tspan x="10px" y="334px">
+    <tspan x="10px" y="334px"><tspan class="dimmed">Hint: branches marked `(merged upstream)` have landed; run `but pull` to remove them, or start new work on another branch</tspan>
+</tspan>
+    <tspan x="10px" y="352px">
 </tspan>
   </text>
 

--- a/crates/but/tests/but/command/snapshots/status/upstream/status-upstream-summary.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/upstream/status-upstream-summary.stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="218px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="236px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -34,15 +34,17 @@
 </tspan>
     <tspan x="10px" y="118px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>┊</tspan><tspan class="fg-green">●</tspan><tspan> </tspan><tspan class="dimmed">801d97d</tspan><tspan> (upstream) ⏫ 10 commits</tspan>
+    <tspan x="10px" y="136px"><tspan>┊</tspan><tspan class="fg-green">●</tspan><tspan> </tspan><tspan class="dimmed">801d97d</tspan><tspan> (upstream: origin/main) ⏫ 10 commits</tspan>
 </tspan>
     <tspan x="10px" y="154px"><tspan>├╯ </tspan><tspan class="dimmed">801d97d</tspan><tspan> (common base) </tspan><tspan class="dimmed">2000-01-02</tspan><tspan> add upstream-10</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>
-    <tspan x="10px" y="190px"><tspan class="dimmed">Hint: run `but help` for all commands</tspan>
+    <tspan x="10px" y="190px"><tspan class="dimmed">Hint: origin/main moved ahead; run `but pull` to update the workspace</tspan>
 </tspan>
-    <tspan x="10px" y="208px">
+    <tspan x="10px" y="208px"><tspan class="dimmed">Hint: run `but help` for all commands</tspan>
+</tspan>
+    <tspan x="10px" y="226px">
 </tspan>
   </text>
 

--- a/crates/but/tests/but/command/snapshots/status/upstream/status-upstream-summary.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/upstream/status-upstream-summary.stdout.term.svg
@@ -34,7 +34,7 @@
 </tspan>
     <tspan x="10px" y="118px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>┊</tspan><tspan class="fg-green">●</tspan><tspan> </tspan><tspan class="dimmed">801d97d</tspan><tspan> (upstream: origin/main) ⏫ 10 commits</tspan>
+    <tspan x="10px" y="136px"><tspan>┊</tspan><tspan class="fg-green">●</tspan><tspan> </tspan><tspan class="dimmed">801d97d</tspan><tspan> (upstream: origin/main) 10 new commits</tspan>
 </tspan>
     <tspan x="10px" y="154px"><tspan>├╯ </tspan><tspan class="dimmed">801d97d</tspan><tspan> (common base) </tspan><tspan class="dimmed">2000-01-02</tspan><tspan> add upstream-10</tspan>
 </tspan>

--- a/crates/but/tests/but/command/snapshots/status/upstream/status-upstream-summary.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/upstream/status-upstream-summary.stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="236px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="218px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -42,9 +42,7 @@
 </tspan>
     <tspan x="10px" y="190px"><tspan class="dimmed">Hint: origin/main moved ahead; run `but pull` to update the workspace</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan class="dimmed">Hint: run `but help` for all commands</tspan>
-</tspan>
-    <tspan x="10px" y="226px">
+    <tspan x="10px" y="208px">
 </tspan>
   </text>
 

--- a/crates/but/tests/but/command/snapshots/status/upstream/status-upstream-truncates-after-8.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/upstream/status-upstream-truncates-after-8.stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="416px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="398px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -62,9 +62,7 @@
 </tspan>
     <tspan x="10px" y="370px"><tspan class="dimmed">Hint: origin/main moved ahead; run `but pull` to update the workspace</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan class="dimmed">Hint: run `but help` for all commands</tspan>
-</tspan>
-    <tspan x="10px" y="406px">
+    <tspan x="10px" y="388px">
 </tspan>
   </text>
 

--- a/crates/but/tests/but/command/snapshots/status/upstream/status-upstream-truncates-after-8.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/upstream/status-upstream-truncates-after-8.stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="398px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="416px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -34,7 +34,7 @@
 </tspan>
     <tspan x="10px" y="118px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>┊╭┄(upstream) ⏫ 10 commits</tspan>
+    <tspan x="10px" y="136px"><tspan>┊╭┄(upstream: origin/main) ⏫ 10 commits</tspan>
 </tspan>
     <tspan x="10px" y="154px"><tspan>┊</tspan><tspan class="fg-green">●</tspan><tspan> </tspan><tspan class="fg-cyan">801d97d</tspan><tspan> </tspan><tspan class="dimmed">add upstream-10</tspan>
 </tspan>
@@ -60,9 +60,11 @@
 </tspan>
     <tspan x="10px" y="352px">
 </tspan>
-    <tspan x="10px" y="370px"><tspan class="dimmed">Hint: run `but help` for all commands</tspan>
+    <tspan x="10px" y="370px"><tspan class="dimmed">Hint: origin/main moved ahead; run `but pull` to update the workspace</tspan>
 </tspan>
-    <tspan x="10px" y="388px">
+    <tspan x="10px" y="388px"><tspan class="dimmed">Hint: run `but help` for all commands</tspan>
+</tspan>
+    <tspan x="10px" y="406px">
 </tspan>
   </text>
 

--- a/crates/but/tests/but/command/snapshots/status/upstream/status-upstream-truncates-after-8.stdout.term.svg
+++ b/crates/but/tests/but/command/snapshots/status/upstream/status-upstream-truncates-after-8.stdout.term.svg
@@ -34,7 +34,7 @@
 </tspan>
     <tspan x="10px" y="118px"><tspan>┊</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>┊╭┄(upstream: origin/main) ⏫ 10 commits</tspan>
+    <tspan x="10px" y="136px"><tspan>┊╭┄(upstream: origin/main) 10 new commits</tspan>
 </tspan>
     <tspan x="10px" y="154px"><tspan>┊</tspan><tspan class="fg-green">●</tspan><tspan> </tspan><tspan class="fg-cyan">801d97d</tspan><tspan> </tspan><tspan class="dimmed">add upstream-10</tspan>
 </tspan>

--- a/crates/but/tests/but/command/status.rs
+++ b/crates/but/tests/but/command/status.rs
@@ -585,7 +585,6 @@ fn status_upstream_and_merge_base_messages_truncate_when_unpaged() {
 ├╯ 9fd740d (common base) 2000-01-02 add merge-base-message-that-is-intentio…
 
 Hint: origin/main moved ahead; run `but pull` to update the workspace
-Hint: run `but help` for all commands
 
 "#]]);
 }
@@ -1180,7 +1179,6 @@ This notice repeats until the skill is installed. If it still appears after inst
 
 Hint: ◐ means rewritten locally vs upstream.
 Hint: the first token on each line is the ID to use in commands.
-Hint: run `but help` for all commands
 
 "#]]);
 
@@ -1199,7 +1197,6 @@ Hint: run `but help` for all commands
 
 Hint: ◐ means rewritten locally vs upstream.
 Hint: the first token on each line is the ID to use in commands.
-Hint: run `but help` for all commands
 
 "#]]);
 }

--- a/crates/but/tests/but/command/status.rs
+++ b/crates/but/tests/but/command/status.rs
@@ -579,11 +579,12 @@ fn status_upstream_and_merge_base_messages_truncate_when_unpaged() {
 ┊●   lvx add A
 ├╯
 ┊
-┊╭┄(upstream) ⏫ 1 commit
+┊╭┄(upstream: origin/main) ⏫ 1 commit
 ┊● 67247ca add upstream-commit-message-that-is-intentionally-very-very-long-to-exc…
 ┊┊
 ├╯ 9fd740d (common base) 2000-01-02 add merge-base-message-that-is-intentio…
 
+Hint: origin/main moved ahead; run `but pull` to update the workspace
 Hint: run `but help` for all commands
 
 "#]]);
@@ -628,9 +629,10 @@ fn status_marks_merged_upstream_without_upstream_flag() {
 ┊●   kyl B-change
 ├╯
 ┊
-┊● 9354ac4 (upstream) ⏫ 2 commits
+┊● 9354ac4 (upstream: origin/main) ⏫ 2 commits
 ├╯ efc9211 (common base) 2000-01-02 base
 
+Hint: origin/main moved ahead; run `but pull` to update the workspace
 Hint: branches marked `(merged upstream)` have landed; run `but pull` to remove them, or start new work on another branch
 
 "#]]);
@@ -662,9 +664,10 @@ Applied remote branch 'origin/document-but-pr-skill' to workspace
 ┊╭┄do [document-but-pr-skill] (merged upstream) (no commits)
 ├╯
 ┊
-┊● 55165db (upstream) ⏫ 1 commit
+┊● 55165db (upstream: origin/main) ⏫ 1 commit
 ├╯ 55165db (common base) 2000-01-02 merge document-but-pr-skill
 
+Hint: origin/main moved ahead; run `but pull` to update the workspace
 Hint: branches marked `(merged upstream)` have landed; run `but pull` to remove them, or start new work on another branch
 
 "#]]);
@@ -745,9 +748,10 @@ fn unmerged_empty_branch_above_merged_one_is_not_treated_as_merged() {
 ┊├┄bo [bottom] (merged upstream) (no commits)
 ├╯
 ┊
-┊● 334227d (upstream) ⏫ 1 commit
+┊● 334227d (upstream: origin/main) ⏫ 1 commit
 ├╯ 334227d (common base) 2000-01-02 merge bottom
 
+Hint: origin/main moved ahead; run `but pull` to update the workspace
 Hint: branches marked `(merged upstream)` have landed; run `but pull` to remove them, or start new work on another branch
 
 "#]]);
@@ -908,12 +912,13 @@ fn status_upstream_prunes_untracked_integrated_branch() {
 ┊●   kyl B-change
 ├╯
 ┊
-┊╭┄(upstream) ⏫ 2 commits
+┊╭┄(upstream: origin/main) ⏫ 2 commits
 ┊● 9354ac4 main-advance
 ┊● 756ee31 A-change
 ┊┊
 ├╯ efc9211 (common base) 2000-01-02 base
 
+Hint: origin/main moved ahead; run `but pull` to update the workspace
 Hint: branches marked `(merged upstream)` have landed; run `but pull` to remove them, or start new work on another branch
 
 "#]]);
@@ -953,12 +958,13 @@ fn status_upstream_prunes_metadata_tracked_integrated_branches() {
 ┊╭┄ex [extra-untracked] ○ empty (no commits)
 ├╯
 ┊
-┊╭┄(upstream) ⏫ 2 commits
+┊╭┄(upstream: origin/main) ⏫ 2 commits
 ┊● 9354ac4 main-advance
 ┊● 756ee31 A-change
 ┊┊
 ├╯ efc9211 (common base) 2000-01-02 base
 
+Hint: origin/main moved ahead; run `but pull` to update the workspace
 Hint: branches marked `(merged upstream)` have landed; run `but pull` to remove them, or start new work on another branch
 
 "#]]);
@@ -1004,12 +1010,13 @@ fn status_upstream_prunes_with_different_bases() {
 ┊●   tpp M1
 ├╯
 ┊
-┊╭┄(upstream) ⏫ 2 commits
+┊╭┄(upstream: origin/main) ⏫ 2 commits
 ┊● ba5149e M2
 ┊● 6daac93 M1
 ┊┊
 ├╯ efc9211 (common base) 2000-01-02 base
 
+Hint: origin/main moved ahead; run `but pull` to update the workspace
 Hint: branches marked `(merged upstream)` have landed; run `but pull` to remove them, or start new work on another branch
 
 "#]]);

--- a/crates/but/tests/but/command/status.rs
+++ b/crates/but/tests/but/command/status.rs
@@ -579,7 +579,7 @@ fn status_upstream_and_merge_base_messages_truncate_when_unpaged() {
 ┊●   lvx add A
 ├╯
 ┊
-┊╭┄(upstream: origin/main) ⏫ 1 commit
+┊╭┄(upstream: origin/main) 1 new commit
 ┊● 67247ca add upstream-commit-message-that-is-intentionally-very-very-long-to-exc…
 ┊┊
 ├╯ 9fd740d (common base) 2000-01-02 add merge-base-message-that-is-intentio…
@@ -628,7 +628,7 @@ fn status_marks_merged_upstream_without_upstream_flag() {
 ┊●   kyl B-change
 ├╯
 ┊
-┊● 9354ac4 (upstream: origin/main) ⏫ 2 commits
+┊● 9354ac4 (upstream: origin/main) 2 new commits
 ├╯ efc9211 (common base) 2000-01-02 base
 
 Hint: origin/main moved ahead; run `but pull` to update the workspace
@@ -663,7 +663,7 @@ Applied remote branch 'origin/document-but-pr-skill' to workspace
 ┊╭┄do [document-but-pr-skill] (merged upstream) (no commits)
 ├╯
 ┊
-┊● 55165db (upstream: origin/main) ⏫ 1 commit
+┊● 55165db (upstream: origin/main) 1 new commit
 ├╯ 55165db (common base) 2000-01-02 merge document-but-pr-skill
 
 Hint: origin/main moved ahead; run `but pull` to update the workspace
@@ -747,7 +747,7 @@ fn unmerged_empty_branch_above_merged_one_is_not_treated_as_merged() {
 ┊├┄bo [bottom] (merged upstream) (no commits)
 ├╯
 ┊
-┊● 334227d (upstream: origin/main) ⏫ 1 commit
+┊● 334227d (upstream: origin/main) 1 new commit
 ├╯ 334227d (common base) 2000-01-02 merge bottom
 
 Hint: origin/main moved ahead; run `but pull` to update the workspace
@@ -911,7 +911,7 @@ fn status_upstream_prunes_untracked_integrated_branch() {
 ┊●   kyl B-change
 ├╯
 ┊
-┊╭┄(upstream: origin/main) ⏫ 2 commits
+┊╭┄(upstream: origin/main) 2 new commits
 ┊● 9354ac4 main-advance
 ┊● 756ee31 A-change
 ┊┊
@@ -957,7 +957,7 @@ fn status_upstream_prunes_metadata_tracked_integrated_branches() {
 ┊╭┄ex [extra-untracked] ○ empty (no commits)
 ├╯
 ┊
-┊╭┄(upstream: origin/main) ⏫ 2 commits
+┊╭┄(upstream: origin/main) 2 new commits
 ┊● 9354ac4 main-advance
 ┊● 756ee31 A-change
 ┊┊
@@ -1009,7 +1009,7 @@ fn status_upstream_prunes_with_different_bases() {
 ┊●   tpp M1
 ├╯
 ┊
-┊╭┄(upstream: origin/main) ⏫ 2 commits
+┊╭┄(upstream: origin/main) 2 new commits
 ┊● ba5149e M2
 ┊● 6daac93 M1
 ┊┊


### PR DESCRIPTION
Improves the conflict-resolution flow across `but pull`, `but resolve`, and `but status`, based on transcript analysis of coding-agent sessions working through update-with-conflicts tasks.

## What changed

- `but pull` lists each conflicted commit under its branch — change-id ref and message, oldest first — and the resolution steps point at those IDs. The commits are also included in the JSON output (`conflicts[].commits`, additive). Rendering happens after a context reload so the refs match what `status` and `resolve` display.
- `but resolve <commit>` prints the conflict regions with line numbers on entry; oversized conflicts summarize as line ranges instead.
- `but resolve finish` reports whether conflict markers remain in the resolved files (warning, not refusal) and which worktree paths are still uncommitted.
- `but status` names the target ref on the upstream line — `(upstream: origin/main) 2 new commits` — and hints at `but pull` when the target moved ahead. The `⏫` glyph is gone, and the generic help hint yields when a situational hint is already shown.
- A pull refused because uncommitted changes conflict with the update now spells out the supported route (park on a temporary commit → pull → resolve → uncommit) instead of suggesting a stash that does not exist, and exits non-zero.
- The skill's update recipe slims to check → pull → resolve-from-pull-output, explains bottom-up resolution ordering, and covers the refusal route; the reference docs are aligned with the new outputs.

## Why

Agents misread the old output in reproducible ways: the unnamed target on the status graph read as stale configuration (they reached for `config target` and `unapply` instead of pulling), the branch-only conflict summary forced a status round trip before every `resolve`, a bare "finalized successfully" triggered marker-scan and re-hash verification sprees, and the "commit or stash" suggestion sent them hunting for a stash that does not exist — some then hand-reverted files to sneak past the check, keeping the only copy of the user's work in conversation memory. Each change states the fact whose absence caused the misread, at the moment it is needed.

## Behavior notes

- Refused pulls now exit 1; `but clean --pull` consequently stops when the pull refuses instead of continuing past it.
- `conflicts[].commits` is an additive JSON field; nothing existing changed shape.
- The status/pull snapshot churn is mechanical fallout from the output rewording.