### PR TITLE
Agent experience: scoped selectors, leaner skill, self-explanatory outputs

### DIFF
--- a/crates/but/skill/SKILL.md
+++ b/crates/but/skill/SKILL.md
@@ -11,46 +11,7 @@ Use GitButler CLI (`but`) as the default version-control interface.
 
 ## Start Here
 
-Choose the first command by task:
-
-```bash
-# Selected dirty files/hunks:
-but diff
-
-# Commit order, branch layout, conflict overview:
-but status
-
-# Per-commit file details, amend/split details:
-but status -fv
-```
-
-For "commit just/only/specific changes on a new branch", use the fast path:
-
-```bash
-but diff
-but commit <branch> -c -m "<msg>" --changes <id>,<id>
-```
-
-`but commit <branch> -c ... --changes ...` creates the branch and prints the resulting workspace state. Do not run a separate `but branch new`, staging command, status command, or verification diff unless the returned output lacks information you need.
-
-`--changes` (or `-p`) takes comma-separated file or hunk IDs from `but diff` / `but status -fv`. A hunk ID is written `<file-id>:<hunk-id>` (e.g. `qs:5`, copied from `but diff`) — the part after the colon is the hunk's ID, **not** a line range (`qs:16-40` is invalid). Do not invent flags like `--hunk` / `--hunks` / `--ids`, pass a line range, or pass the IDs as positional arguments.
-
-The first token on each status line is that line's ID — pass it to commands as-is. Commit IDs are stable change IDs that survive history edits (`amend`, `squash`, `move`, `uncommit`, `reword`); commits without a change ID (e.g. upstream-only) lead with a sha prefix instead, which goes stale after history edits. The `(sha …)` shown on verbose commit lines is informational — do not pass it to commands. CLI IDs may be a single character when unambiguous; copy them exactly from command output. Longer unambiguous prefixes also work.
-
-## Non-Negotiable Rules
-
-1. Use `but` for all write operations. Never run `git add`, `git commit`, `git push`, `git checkout`, `git merge`, `git rebase`, `git stash`, or `git cherry-pick`. If the user says a `git` write command, translate it to `but` and run that. Exceptions: `git add -- <path>` to mark a conflicted uncommitted file resolved (see "Conflicts in uncommitted files"), and a worktree-local Git commit when `but commit` reports that linked worktrees are unsupported. Never run `but setup` from a linked worktree.
-2. After mutations, read the returned output for the updated workspace state — it replaces a follow-up status command.
-3. You may chain `but commit` mutations with `&&` to make several commits from one diff; they stack in the order you write them, so the first `but commit` is the oldest of the new commits and each later one goes on top (newest). File/hunk IDs copied from the original output generally remain usable across commits, and branch IDs are stable. History edits (`amend`, `squash`, `move`, `uncommit`, `reword`) may also run in sequence off one status read when every commit ref involved is a change-ID ref — those stay valid across the edits. Run them one at a time when a ref is sha-based or `#N`-suffixed (those go stale after a history edit, and a stale sha can silently resolve to the wrong commit), or when the next command needs IDs the previous one prints (e.g. recommitting after `but uncommit --diff`). Take follow-up refs from the returned workspace state. If a chained command cannot resolve an ID, re-read with `but status`/`but diff` and retry.
-4. Use CLI IDs from `but diff` / `but status` / `but status -fv` / `but show`; never hardcode IDs.
-5. Do not run `but status` or `but status -fv` as routine preflight for selected dirty-file or hunk commits. Start with `but diff`; use compact `but status` for commit order, branch/stack placement, or conflict overview. Use `but status -fv` when file/hunk IDs or per-commit file details matter.
-6. For "commit these selected changes on a new branch", prefer one command: `but commit <branch> -c -m "<msg>" --changes <ids>`.
-7. Never commit or push to a branch marked `(merged upstream)`; run `but pull` to remove it, or create/use another branch for new work.
-8. In non-interactive CLI workflows, do not narrate progress between routine commands. Execute the needed `but` commands and give a concise final summary.
-
-## Choose Inspection By Task
-
-Start with the narrowest inspection that answers the task. Avoid ritual status checks.
+Choose the narrowest first command by task; avoid ritual status checks:
 
 ```bash
 # Selected dirty files/hunks:
@@ -68,184 +29,143 @@ but show <id>
 
 Do not run plain `but status` and then `but status -fv` unless the compact output lacks file/hunk details needed for the task.
 
-Perform mutations with IDs from `diff`, `status`, `status -fv`, or `show`:
+For "commit just/only/specific changes on a new branch", use the fast path:
 
 ```bash
-but <mutation> ...
+but diff
+but commit <branch> -c -m "<msg>" --changes <id>,<id>
 ```
+
+`but commit <branch> -c ... --changes ...` creates the branch and prints the resulting workspace state. Do not run a separate `but branch new`, staging command, status command, or verification diff unless the returned output lacks information you need.
+
+## IDs
+
+The first token on each `but diff` / `but status` line is that line's ID — pass it to commands as-is; never hardcode or invent IDs. IDs may be a single character when unambiguous; copy them exactly from command output.
+
+- `--changes` (or `-p`) takes comma-separated file or hunk IDs. A hunk ID is written `<file-id>:<hunk-id>` (e.g. `qs:5`, copied from `but diff`) — the part after the colon is the hunk's ID, **not** a line range (`qs:16-40` is invalid). Do not invent flags like `--hunk` / `--hunks` / `--ids`, pass a line range, or pass the IDs as positional arguments.
+- Commit IDs are stable change IDs that survive history edits (`amend`, `squash`, `move`, `uncommit`, `reword`). Commits without a change ID (e.g. upstream-only) lead with a sha prefix instead, and `#N`-suffixed refs disambiguate duplicates — both go stale after history edits, and a stale sha can silently resolve to the wrong commit. The `(sha …)` on verbose commit lines is informational — do not pass it to commands.
+- File/hunk IDs copied from one diff read generally remain usable across chained commits; branch IDs are stable. If an ID stops resolving, re-read `but status`/`but diff` and retry.
+
+**Chaining:** you may chain mutations with `&&` off one inspection read. Chained `but commit` calls stack in the order written — the first is oldest, each later one goes on top. History edits may run in sequence when every commit ref involved is a change-ID ref; run them one at a time when a ref is sha-based or `#N`-suffixed, or when the next command needs IDs the previous one prints (e.g. recommitting after `but uncommit --diff`). Take follow-up refs from the returned workspace state.
+
+## Non-Negotiable Rules
+
+1. Use `but` for all write operations. Never run `git add`, `git commit`, `git push`, `git checkout`, `git merge`, `git rebase`, `git stash`, or `git cherry-pick`. If the user says a `git` write command, translate it to `but` and run that. Exceptions: `git add -- <path>` to mark a conflicted uncommitted file resolved (see "Conflicts in uncommitted files"), and a worktree-local Git commit when `but commit` reports that linked worktrees are unsupported. Never run `but setup` from a linked worktree.
+2. After a mutation, read the workspace state it returned — it replaces a follow-up status command. Re-run `but status`/`but diff` only if that output lacks the ID you need or files changed since.
+3. Never commit or push to a branch marked `(merged upstream)`; run `but pull` to remove it, or create/use another branch for new work.
+4. In non-interactive CLI workflows, do not narrate progress between routine commands. Execute the needed `but` commands and give a concise final summary.
+5. Avoid `--help` probes; use this skill and `references/reference.md` first. Only use `--help` after a command fails or required syntax is missing from the installed references.
 
 ## Command Patterns
 
 - Commit: `but commit <branch> -m "<msg>" --changes <id>,<id>`
-- Several commits from one diff: chain `but commit` calls - `but commit <branch> -m "<msg>" --changes <id>,<id> && but commit <branch> -m "<msg>" --changes <id>,<id>` (commits stack oldest-first in the order you write them — first call is oldest; file/hunk IDs from the initial output generally remain usable; refresh if an ID stops resolving)
-- `but commit -a` is accepted as a no-op compatibility flag; GitButler already includes uncommitted changes by default.
+- Several commits from one diff: chain `but commit` calls with `&&` (commits stack oldest-first in the order written)
 - Commit + create branch: `but commit <branch> -c -m "<msg>" --changes <id>`
-- Commit at a specific history position: `but commit <branch> -m "<msg>" --changes <id>,<id> --before <commit-or-branch-id>` or `--after <commit-or-branch-id>`
+- Commit at a specific history position: `... --before <commit-or-branch-id>` or `--after <commit-or-branch-id>`
+- `but commit -a` is accepted as a no-op compatibility flag; GitButler already includes uncommitted changes by default.
 - Amend: `but amend <commit-id> --changes <file-or-hunk-id>,<file-or-hunk-id>`
 - Uncommit and show resulting dirty diff: `but uncommit <commit-id> --diff`
 - Insert empty commit: `but commit empty [-m "<msg>"] [<target>]`
 - Squash commits: `but squash <source-commit-id> [<source-commit-id>...] <target-commit-id> [-m "<msg>"]`
 - Reorder commits: `but move <source-commit-id> <target-commit-id>` (**commit IDs**, not branch names)
-- Reorder multiple commits as a group: `but move <source-commit-id>,<source-commit-id> <target-commit-id>` (comma-separated commit IDs)
-- Move commit to branch top: `but move <commit-id> <branch-name-or-id>` (puts that commit at the top/newest position of the branch)
-- Move multiple commits to branch top: `but move <commit-id>,<commit-id> <branch-name-or-id>` (commit IDs only; not branches)
+- Reorder a block: `but move <source-commit-id>,<source-commit-id> <target-commit-id>` (comma-separated commit IDs)
+- Move commit to branch top: `but move <commit-id> <branch-name-or-id>`
 - Stack branches: `but move <branch-name-or-id> <target-branch-name-or-id>` (**branch names or branch CLI IDs**)
-- Tear off a branch: `but move <branch-name-or-id> zz` (`zz` = uncommitted; branch name or branch CLI ID)
+- Tear off a branch: `but move <branch-name-or-id> zz` (`zz` = uncommitted)
 - Push: `but push <branch-name>` — always specify the branch; bare `but push` pushes ALL branches when run non-interactively
 - Pull: `but pull --check` then `but pull`
-- Create PR: `but pr new <branch-id> [-m "Title..."] [-F pr_message.txt] [-t] [--draft]` — auto-pushes before creating the PR; do not run `but push` first
-- Manage PRs: `but pr auto-merge <selector>`, `but pr set-draft <selector>`, `but pr set-ready <selector>`
+- Create PR: `but pr new <branch-id> [-m "Title..."] [-F pr_message.txt] [-t] [--draft]` — auto-pushes first; do not run `but push` before it
 
 ## Task Recipes
 
 ### Update workspace from main
 
-For "get latest from main", "update/sync this workspace", or "pull main":
+For "get latest from main", "update/sync this workspace", "rebase onto main", or "pull main":
 
 1. `but pull --check`
 2. If clean, `but pull`
-3. If commits come back conflicted, resolve each one oldest-first (the pull output lists them in that order): `but resolve <commit>`, edit the files, then `but resolve finish`. Finishing a lower commit rebases the ones above it, so always work bottom-up.
+3. If commits come back conflicted, resolve them oldest-first following the printed instructions: `but resolve <commit>`, edit the files, `but resolve finish`. Finishing a lower commit rebases the ones above it, so always work bottom-up.
 
-`but pull` updates applied branches onto the latest target branch (usually
-`main`) and carries uncommitted changes along. Rebasing a branch onto the
-latest `main` IS `but pull` — it is never `move`, `config target`, `unapply`,
-or raw `git pull`/`git rebase`. The pull output already reports the resulting
-state.
-
-If `but pull` refuses because uncommitted changes conflict with the update,
-park them on a temporary commit (there is no stash, and hand-reverting files
-risks losing work): `but commit <branch> --changes <file-id...> -m "wip"`,
-pull again — the parked commit may come back conflicted for `but resolve` —
-then `but uncommit` it so the changes end up uncommitted again.
+Rebasing applied branches onto the latest target IS `but pull` — never `move`, `config target`, `unapply`, or raw `git pull`/`git rebase`. It carries uncommitted changes along, and its output reports the resulting state. If it refuses because uncommitted changes conflict, park them as printed: `but commit <branch> --changes <ids> -m "wip"`, pull again, then `but uncommit` the parked commit (there is no stash; do not hand-revert files).
 
 ### Commit selected files or hunks
 
-1. `but diff` — use this first for selective dirty commits. It shows file and hunk IDs for uncommitted changes.
-2. Use file IDs when whole files belong in the commit. When only part of a file belongs, commit its hunks by ID — `<file-id>:<hunk-id>` from `but diff` (e.g. `qs:5`), not the whole file ID and not a line range. Do not run plain `but status` first.
-3. For a new branch, use one command: `but commit <branch> -c -m "<msg>" --changes <id1>,<id2>`.
-   For an existing branch, omit `-c`: `but commit <branch> -m "<msg>" --changes <id1>,<id2>`.
-   Omit IDs you don't want committed.
-   Creating a new branch with `-c` does not require a prior `but branch` or `but status -fv`.
-4. **Check the returned status** for remaining uncommitted changes. If the file still appears as uncommitted or assigned to another branch after commit, it may be dependency-locked. See "Stacked dependency / commit-lock recovery" below.
+1. `but diff` — shows file and hunk IDs for uncommitted changes. Do not run plain `but status` first.
+2. Use file IDs when whole files belong in the commit; use hunk IDs (`<file-id>:<hunk-id>`) when only part of a file belongs. Omit IDs you don't want committed.
+3. New branch: `but commit <branch> -c -m "<msg>" --changes <id1>,<id2>` (no prior `but branch new` needed). Existing branch: omit `-c`.
+4. **Check the returned status** for remaining uncommitted changes. If a file you committed still shows as uncommitted, it may be dependency-locked — see "Stacked dependency / commit-lock recovery".
 
 Edge case: if wanted and unwanted edits are in the same diff hunk, GitButler cannot split that hunk by ID. Only when the task requires keeping part of that hunk uncommitted, temporarily edit the working tree to isolate the wanted lines, commit with `--changes`, then restore the leftover lines so they remain uncommitted.
 
 ### Amend into existing commit
 
-1. `but status -fv` (or `but show <branch-id>`)
-2. Locate file/hunk IDs and target commit ID.
-3. `but amend <commit-id> --changes <file-or-hunk-id>,<file-or-hunk-id>`; use one command for multiple files/hunks that belong in the same commit. To amend into several different commits, chain the amends with `&&` in one shell call when every target is a change-ID ref — those survive each amend, so one status read is enough (e.g. `but amend <id1> --changes <a> && but amend <id2> --changes <b> && but amend <id3> --changes <c>`). If any target is sha-based or `#N`-suffixed, run the amends one at a time and take fresh refs from each returned status — those refs go stale after every history edit.
+1. `but status -fv` (or `but show <branch-id>`) — locate file/hunk IDs and target commit IDs.
+2. `but amend <commit-id> --changes <id>,<id>` — one command per target commit. For several target commits, chain the amends with `&&` when every target is a change-ID ref; otherwise run them one at a time with fresh refs from each returned status.
 
 ### Split an existing commit
 
 Use this when an existing commit should be replaced by selected smaller commits.
 
 1. `but status -fv` when you need the source commit, branch name, or placement anchor.
-2. `but uncommit <source-commit-id> --diff` to expose that commit's changes as uncommitted changes and print committable file/hunk IDs.
-3. Pick replacement commit contents from the dirty diff printed by `but uncommit --diff`, not from the old committed diff.
-4. Create the replacement commits in the requested order, oldest first, by chaining `but commit` calls (file/hunk IDs from the diff stay usable across commits):
-   `but commit <branch> -m "<message 1>" --changes <id>,<id> && but commit <branch> -m "<message 2>" --changes <id>,<id>`
-   Each new commit goes to the TOP of the stack. So if you split a commit that had other commits above it, the replacements are now sitting above those preserved commits.
-5. **If any commit must stay ABOVE the replacements (a preserved top commit), put it back on top instead of fighting anchors.** Do not anchor the replacements with `--before <top>`/`--after <top>`: a sha-based or `#N`-suffixed anchor goes stale as `but uncommit` and each insert rewrite history (and `--before <branch>` just puts commits on top of the branch). Instead, take the preserved commit's ref from the workspace state the last `but commit` printed, then `but move <preserved-commit-id> <branch>` to lift it back to the top/newest (for several preserved commits, list every one, oldest first: `but move <id1>,<id2>,<id3> <branch>`).
-6. Leave unwanted changes uncommitted. The returned workspace state shows the resulting commit order; if it matches the request, stop.
+2. `but uncommit <source-commit-id> --diff` exposes the commit's changes as uncommitted and prints committable file/hunk IDs.
+3. Pick replacement contents from that dirty diff, not from the old committed diff.
+4. Create the replacement commits oldest-first by chaining `but commit` calls. Each new commit goes to the TOP of the stack — if the split commit had commits above it, the replacements now sit above those preserved commits.
+5. **If a commit must stay ABOVE the replacements, put it back on top instead of fighting anchors.** Do not anchor with `--before <top>`/`--after <top>` (sha/`#N` anchors go stale as each insert rewrites history; `--before <branch>` just puts commits on top of the branch). Take the preserved commit's ref from the last returned workspace state, then `but move <preserved-commit-id> <branch>` (several: `but move <id1>,<id2> <branch>`, oldest first).
+6. Leave unwanted changes uncommitted. Remember the returned state lists commits newest first: replacements created oldest-first therefore appear in reverse request order under the preserved commits — that is correct; do not reorder them. Stop when the history matches.
 
 ### Reorder commits
 
-`but move` supports both commit reordering and branch stack operations. Use commit IDs when reordering commits.
-`but status` displays commits newest/top first, while task specs often list history oldest to newest. Use `but status -fv` only if you also need file-level details.
+`but status` displays commits newest/top first, while task specs often list history oldest to newest — translate before moving.
 
-1. `but status`
-2. `but move <source-commit-id> <target-commit-id>` places source immediately before target in oldest-to-newest history. In `but status`, source appears directly below target.
-3. `but move <source-commit-id> <target-commit-id> --after` places source immediately after target in oldest-to-newest history. In `but status`, source appears directly above target.
-4. `but move <source-commit-id> <branch-name-or-id>` moves source to branch top/newest.
-5. `but move <source-commit-id>,<source-commit-id> <target-commit-id>` moves multiple commit sources together. Multi-source moves accept comma-separated commit IDs only, not branch names.
-
-For explicit final-order tasks, run `but status` once to get commit IDs. If the task names an adjacent commit block, do not sort the whole branch or move block members one by one: preserve the block's internal oldest-to-newest order, find the commit that should immediately follow the block in the requested oldest-to-newest order, then run one block move: `but move <oldest-block-id>,<newest-block-id> <following-commit-id>`. After a successful block move, stop if the returned status shows the requested order; do not move the anchor or any member of that block again.
-
-For other explicit reorders, translate the requested order into the newest-to-oldest order shown by `but status`, then make the smallest set of moves. Prefer the default before/below form because it matches the status display: `but move <source> <newer-neighbor>` places source directly below its newer neighbor. Use a branch target only when a commit must become top/newest, and use `--after` only when it clearly avoids extra moves.
+1. `but status` once to get commit IDs (use `-fv` only if you also need file details).
+2. `but move <source> <target-commit>` places source immediately before target in oldest-to-newest history (directly below it in `but status`). `--after` places it immediately after (directly above). `but move <source> <branch>` moves it to branch top/newest.
+3. For an adjacent block, keep the block's internal order and run ONE move: `but move <oldest-block-id>,<newest-block-id> <following-commit-id>` — do not sort the whole branch or move members one by one. After a successful block move, stop if the returned status shows the requested order; do not move the anchor or block members again.
+4. For other reorders, make the smallest set of moves; prefer the default before/below form because it matches the status display.
 
 ### Squash commits
 
-Use this when multiple existing commits should become one commit.
-
-1. `but status` to get commit IDs and current order. Use `but status -fv` only if you also need per-commit file details.
-2. Put the result/target commit last: `but squash <source-commit-id> [<source-commit-id>...] <target-commit-id> -m "<new message>"`.
-3. For multiple independent squash groups, prefer newer/top groups first; change-ID refs from one status read stay valid across squashes (the target keeps its ref), so the groups may run in sequence — take fresh refs from the returned status only when a ref is sha-based or `#N`-suffixed.
-4. After the final squash, stop if returned status shows the requested history; do not run `--help`, `status`, or `status -fv` only to reconfirm.
+1. `but status` for commit IDs and order.
+2. Put the result/target commit last: `but squash <source> [<source>...] <target> -m "<new message>"`.
+3. Multiple independent groups may run in sequence off one status read (targets keep their change-ID refs); prefer newer/top groups first. Take fresh refs only when a ref is sha-based or `#N`-suffixed.
+4. Stop when the returned status shows the requested history; do not re-verify with extra status calls.
 
 ### Stack existing branches
 
-To make one existing branch depend on (stack on top of) another, use top-level `move`:
+To make one existing branch depend on another: `but move <child-branch> <parent-branch>` (branch **names** or branch CLI IDs — commit reordering uses commit IDs). To unstack: `but move <branch> zz`.
 
-```bash
-but move feature/frontend feature/backend
-```
-
-This moves the frontend branch on top of the backend branch in one step.
-
-**DO NOT** use `uncommit` + `branch delete` + `branch new -a` to stack existing branches. That approach fails because git branch names persist even after `but branch delete`. Always use `but move <branch> <target-branch>`.
-
-**To unstack** (make a stacked branch independent again):
-
-```bash
-but move feature/logging zz
-```
-
-**Note:** branch stack/tear-off operations use branch **names** (like `feature/frontend`) or branch CLI IDs, while commit reordering uses commit **IDs** (like `nn`). Do NOT use `but undo` to unstack — it may revert more than intended and lose commits.
+**DO NOT** stack via `uncommit` + `branch delete` + `branch new -a` (git branch names persist after delete and it loses work), and do not use `but undo` to unstack.
 
 ### Create or manage pull requests
 
-`but pr new <branch-id>` pushes the branch and creates a pull request in one step. Do not run `but push` first. Agents must provide `-F pr_message.txt`, `-t`, or `-m` with real newline characters (zsh/bash: `-m $'Title\n\nBody'`) so the command does not open an editor. If forge auth is missing, run `but config forge auth`.
+`but pr new <branch-id>` pushes the branch and creates the PR in one step — no prior `but push`. Provide `-F pr_message.txt`, `-t`, or `-m` with real newlines (zsh/bash: `-m $'Title\n\nBody'`) so no editor opens. If forge auth is missing, run `but config forge auth`.
 
-For independent, unstacked branches, another forge tool may be okay if the user asked for it or `but pr` is unavailable. Still prefer `but pr new` when you are already working from GitButler branch IDs.
-
-For stacked branches, `but pr` is mandatory. Create and manage stacked PRs with GitButler so PR bases match the stack and GitButler can maintain the stack metadata in PR description footers. Do not create stacked PRs with `gh pr create` or other forge tools.
-
-To publish a whole stack, create the PR from the top branch you want published:
-
-```bash
-but pr new <top-branch-id> -t
-```
-
-That creates or updates reviews for that branch and its dependencies in stack order. Use `but pr auto-merge <selector>`, `but pr set-draft <selector>`, and `but pr set-ready <selector>` for follow-up PR management; selectors can be branch names, branch IDs, stack IDs, or numeric review IDs.
+For stacked branches `but pr` is mandatory (it sets PR bases and stack metadata; `gh pr create` breaks that). To publish a whole stack: `but pr new <top-branch-id> -t`. Manage with `but pr auto-merge|set-draft|set-ready <selector>`. See `references/reference.md` for details.
 
 ### Stacked dependency / commit-lock recovery
 
-A **dependency lock** occurs when a file was originally committed on branch A, but you're trying to commit changes to it on branch B. Symptoms:
-- `but commit` succeeds but the file still appears in `uncommittedChanges` in the returned status
-- The file still shows as "uncommitted" in the status output
+A **dependency lock**: a file was originally committed on branch A, and you're committing changes to it on branch B. Symptom: `but commit` succeeds but the file still shows as uncommitted in the returned status.
 
-**Recovery:** Stack your branch on the dependency branch, then commit:
+Recovery: stack your branch on the dependency branch, then commit:
 
-1. `but status -fv` — identify which branch originally owns the file (check commit history).
-2. `but move <your-branch-name> <dependency-branch-name>` — stack your branch on the dependency. Uses full branch **names**, not CLI IDs.
-3. `but status -fv` — the file should now be committable. Commit it.
-4. `but commit <branch> -m "<msg>" --changes <id>`
+1. `but status -fv` — identify which branch's commits own the file.
+2. `but move <your-branch-name> <dependency-branch-name>` (full branch **names**).
+3. Commit the file: `but commit <branch> -m "<msg>" --changes <id>`.
 
-**If `but move <branch> <target-branch>` fails:** Do NOT try `uncommit`, `squash`, or `undo` to work around it — these will leave the workspace in a worse state. Instead, re-run `but status -fv` to confirm both branches still exist and are applied, then retry with exact branch names from the status output.
+If that `but move` fails, do NOT try `uncommit`, `squash`, or `undo` as a workaround — re-run `but status -fv` to confirm both branches exist and are applied, then retry with exact branch names.
 
-### Resolve conflicts after reorder/move
+### Resolve conflicted commits (after pull, move, or reorder)
 
-**NEVER use `git add`, `git commit`, `git checkout --theirs`, `git checkout --ours`, or any git write commands during resolution.** Only use `but resolve` commands and edit files directly with the Edit tool.
+**NEVER use `git add`, `git commit`, `git checkout --theirs/--ours`, or any git write command during resolution.** Only `but resolve` commands plus direct file edits.
 
-If `but move` causes conflicts (conflicted commits in status):
-
-1. `but status -fv` — find commits marked as conflicted.
-2. `but resolve <commit-id>` — enter resolution mode. This puts conflict markers in the files.
-3. **Read the conflicted files** to see the `<<<<<<<` / `=======` / `>>>>>>>` markers.
-4. **Edit the files** to resolve conflicts by choosing the correct content and removing markers.
-5. `but resolve finish` — finalize. Do NOT run this without editing the files first.
-6. Repeat for any remaining conflicted commits.
-
-**Common mistakes:** Do NOT use `but amend` on conflicted commits (it won't work). Do NOT skip step 4 — you must actually edit the files to remove conflict markers before finishing.
+1. Find conflicted commits: the `but pull` summary lists them oldest-first; otherwise `but status` marks them.
+2. `but resolve <commit-id>` — enters resolution mode and prints the conflict regions.
+3. **Edit the files** to remove `<<<<<<<` / `=======` / `>>>>>>>` markers and keep the correct content. Do NOT skip this; do NOT use `but amend` on conflicted commits.
+4. `but resolve finish` — reports leftover markers and surviving uncommitted changes; no follow-up status needed.
+5. Repeat for remaining conflicted commits, oldest first — finishing a lower commit rebases the ones above it.
 
 ### Conflicts in uncommitted files
 
-`but status` lists uncommitted files with unresolved merge conflicts marked
-`{conflicted}`; they are excluded from committable changes. These conflicts are
-outside `but resolve` mode. Choose the desired contents or delete the file, then
-run `git add -- <path>` to mark it resolved. This is the one case where using
-`git add` is permitted.
+`but status` marks uncommitted files with unresolved merge conflicts `{conflicted}`; they are excluded from committable changes and outside `but resolve` mode. Choose the desired contents or delete the file, then `git add -- <path>` to mark it resolved (the one permitted `git add`).
 
 ## Git-to-But Map
 
@@ -258,14 +178,11 @@ run `git add -- <path>` to mark it resolved. This is the one case where using
 | `git rebase -i` | `but move`, `but squash`, `but reword` |
 | `git rebase --onto` | `but move <branch> <new-base>` |
 | `git cherry-pick` | `but pick` |
-| `gh pr create` | `but pr new <branch-id>` (pushes the branch, then creates the PR; no separate `but push`) |
+| `gh pr create` | `but pr new <branch-id>` |
 
 ## Notes
 
-- Use plain `but status` for commit order, branch/stack placement, and conflict overview. Escalate to `but status -fv` only when file/hunk IDs or per-commit file details are needed.
 - Read-only git inspection (`git log`, `git blame`, `git show --stat`) is allowed.
-- After a successful mutation, trust the workspace state it printed. Re-run `but status` or `but status -fv` only if that output lacks the ID you need or files changed since.
-- Avoid `--help` probes; use this skill and `references/reference.md` first. Only use `--help` after a command fails or required syntax is missing from the installed references.
 - If `but` prints an `AGENT ACTION REQUIRED` skill warning, run the suggested command once, then reload/use the GitButler skill. If it repeats, report it instead of retrying.
 - For command syntax and flags: `references/reference.md`
 - For workspace model: `references/concepts.md`

--- a/crates/but/skill/SKILL.md
+++ b/crates/but/skill/SKILL.md
@@ -73,7 +73,7 @@ The first token on each `but diff` / `but status` line is that line's ID — pas
 - Stack branches: `but move <branch-name-or-id> <target-branch-name-or-id>` (**branch names or branch CLI IDs**)
 - Tear off a branch: `but move <branch-name-or-id> zz` (`zz` = uncommitted)
 - Push: `but push <branch-name>` — always specify the branch; bare `but push` pushes ALL branches when run non-interactively
-- Pull: `but pull --check` then `but pull`
+- Pull (update workspace from the target): `but pull` — the output reports the result; `--check` is only a dry-run preview
 - Create PR: `but pr new <branch-id> [-m "Title..."] [-F pr_message.txt] [-t] [--draft]` — auto-pushes first; do not run `but push` before it
 
 ## Task Recipes
@@ -82,11 +82,12 @@ The first token on each `but diff` / `but status` line is that line's ID — pas
 
 For "get latest from main", "update/sync this workspace", "rebase onto main", or "pull main":
 
-1. `but pull --check`
-2. If clean, `but pull`
-3. If commits come back conflicted, resolve them oldest-first following the printed instructions: `but resolve <commit>`, edit the files, `but resolve finish`. Finishing a lower commit rebases the ones above it, so always work bottom-up.
+1. `but pull` — one command; no preflight needed. Its output reports the resulting state, it refuses safely when uncommitted changes conflict, and `but undo` reverts it.
+2. If commits come back conflicted, resolve them oldest-first following the printed instructions: `but resolve <commit>`, edit the files, `but resolve finish`. Finishing a lower commit rebases the ones above it, so always work bottom-up.
 
-Rebasing applied branches onto the latest target IS `but pull` — never `move`, `config target`, `unapply`, or raw `git pull`/`git rebase`. It carries uncommitted changes along, and its output reports the resulting state. If it refuses because uncommitted changes conflict, park them as printed: `but commit <branch> --changes <ids> -m "wip"`, pull again, then `but uncommit` the parked commit (there is no stash; do not hand-revert files).
+Use `but pull --check` only to answer "would this conflict?" without updating (a dry-run preview), not as a step before every pull.
+
+Rebasing applied branches onto the latest target IS `but pull` — never `move`, `config target`, `unapply`, or raw `git pull`/`git rebase`. The base shown in status is the last FETCHED state: when `git log` shows `main` (local or remote) ahead of it, that is exactly the update `but pull` fetches and applies — the target setting is not stale and repointing it is never the fix. Pull carries uncommitted changes along, and its output reports the resulting state. If it refuses because uncommitted changes conflict, park them as printed: `but commit <branch> --changes <ids> -m "wip"`, pull again, then `but uncommit` the parked commit (there is no stash; do not hand-revert files).
 
 ### Commit selected files or hunks
 

--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -391,11 +391,12 @@ Use this for "get latest from main" in a GitButler workspace.
 
 ```bash
 but pull                      # Fetch and rebase applied branches
-but pull --check              # Check if can merge cleanly (no changes)
+but pull --check              # Dry-run preview: report what would happen, change nothing
 ```
 
-Run `but pull --check` first, then `but pull` if clean. Do not use raw
-`git pull` or `git rebase`.
+Run `but pull` directly; its output reports the result and `but undo`
+reverts it. Use `--check` only when you want a preview without updating.
+Do not use raw `git pull` or `git rebase`.
 
 ### `but pr`
 

--- a/crates/but/src/command/agent/policy.rs
+++ b/crates/but/src/command/agent/policy.rs
@@ -199,9 +199,9 @@ pub(super) fn render_managed_policy_block(answers: &WizardAnswers) -> String {
             &mut body,
             "Update from the target branch automatically",
             &[
-                "When GitButler status shows new changes on the target branch, run `but pull --check`.",
-                "If the check is clean and the update affects only this session's branches, update the workspace with `but pull`.",
-                "If the check reports conflicts or the update would affect another agent's branch, ask before updating.",
+                "When GitButler status shows new changes on the target branch and the workspace holds only this session's branches, update with `but pull` directly — its output reports the result and `but undo` reverts it.",
+                "If an update you started on your own initiative reports conflicted commits, stop and ask before resolving them (`but undo` reverts the pull if the user prefers).",
+                "When other agents' branches are applied, run `but pull --check` first and ask before updating if it reports conflicts or their branches would move.",
                 "If the user asks you to handle update conflicts, use GitButler's conflict tools. Ask before resolving semantic conflicts, dependency updates, generated files, or conflicts involving another person's work.",
             ],
         );

--- a/crates/but/src/command/agent/tests.rs
+++ b/crates/but/src/command/agent/tests.rs
@@ -323,8 +323,8 @@ fn generated_policy_expands_selected_tuning_recipes() {
     assert!(policy.contains("Keep tests with the behavior they verify"));
     assert!(policy.contains("Use `but move` for branch stacking and restacking"));
     assert!(policy.contains("create pull requests with `but pr`, not `gh`"));
-    assert!(policy.contains("run `but pull --check`"));
-    assert!(policy.contains("update the workspace with `but pull`"));
+    assert!(policy.contains("update with `but pull` directly"));
+    assert!(policy.contains("run `but pull --check` first and ask before updating"));
     assert!(policy.contains("create it as a draft with GitButler"));
     assert!(
         policy

--- a/crates/but/src/command/config.rs
+++ b/crates/but/src/command/config.rs
@@ -1805,7 +1805,19 @@ async fn target_config(
                             t.hint.paint("SHA"),
                             target_branch.base_sha
                         )?;
-                        writeln!(out, "\n{}:", t.hint.paint("To change target branch"))?;
+                        writeln!(
+                            out,
+                            "\n{}",
+                            t.hint.paint(
+                                "New commits on the remote arrive via `but pull` — the target setting is not what makes the workspace current."
+                            )
+                        )?;
+                        writeln!(
+                            out,
+                            "{}:",
+                            t.hint
+                                .paint("To point the workspace at a different branch entirely")
+                        )?;
                         writeln!(
                             out,
                             "  {}",

--- a/crates/but/src/command/legacy/absorb.rs
+++ b/crates/but/src/command/legacy/absorb.rs
@@ -39,13 +39,33 @@ pub(crate) fn handle(
     let mut guard = ctx.exclusive_worktree_access();
     let id_map = IdMap::new_from_context(ctx, None, guard.read_permission())?;
     let source: Option<CliId> = source
-        .and_then(|s| parse_sources(ctx, &id_map, s).ok())
-        .and_then(|s| {
-            s.into_iter().find(|s| {
-                matches!(s, CliId::UncommittedHunkOrFile { .. })
-                    || matches!(s, CliId::Branch { .. })
-            })
-        });
+        .map(|s| -> anyhow::Result<CliId> {
+            // Uncommitted selectors resolve in the uncommitted namespace first
+            // so later commits cannot shadow them; branch selectors resolve in
+            // the full namespace. A selector that names neither is an error —
+            // silently falling back to absorbing everything is never intended.
+            let resolved =
+                match crate::id::parser::resolve_uncommitted_part(ctx, &id_map, s) {
+                    Ok(ids) if !ids.is_empty() => ids,
+                    _ => parse_sources(ctx, &id_map, s)?,
+                };
+            let mut acceptable = resolved.into_iter().filter(|id| {
+                matches!(id, CliId::UncommittedHunkOrFile { .. })
+                    || matches!(id, CliId::Branch { .. })
+            });
+            let first = acceptable.next().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "'{s}' does not name an uncommitted change or branch; refusing to absorb everything"
+                )
+            })?;
+            if acceptable.next().is_some() {
+                anyhow::bail!(
+                    "'{s}' is ambiguous - it matches more than one uncommitted change. Use more characters to disambiguate."
+                );
+            }
+            Ok(first)
+        })
+        .transpose()?;
 
     let target = if let Some(source) = source {
         match source {

--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -250,43 +250,29 @@ fn resolve_file_ids(
     let mut errors = Vec::new();
 
     for file_id in file_ids {
-        // Resolve in the uncommitted file/hunk namespace only, so a commit or
-        // branch ID minted after the file ID was printed cannot shadow it.
-        let cli_ids = match id_map.parse_uncommitted_using_context(file_id, ctx) {
+        // Resolve in the uncommitted namespace (with the shared full-namespace
+        // fallback for container selectors), so a commit or branch ID minted
+        // after the file ID was printed cannot shadow it.
+        let cli_ids = match crate::id::parser::resolve_uncommitted_part(ctx, id_map, file_id) {
             Ok(ids) => ids,
             Err(e) => {
-                errors.push(format!("'{file_id}': {e}"));
+                if e.downcast_ref::<crate::id::parser::IdResolutionError>()
+                    .is_some()
+                {
+                    errors.push(format!("{e}"));
+                } else {
+                    errors.push(format!("'{file_id}': {e}"));
+                }
                 continue;
             }
         };
 
-        let cli_ids = if cli_ids.is_empty() {
-            // Nothing uncommitted matches directly. Container selectors this
-            // parser does not model may still resolve to uncommitted files in
-            // the full namespace; anything else is worth a targeted error.
-            let full = id_map.parse_using_context(file_id, ctx).unwrap_or_default();
-            if !full.is_empty()
-                && full
-                    .iter()
-                    .all(|id| matches!(id, CliId::UncommittedHunkOrFile(_)))
-            {
-                full
-            } else if let Some(other) = full.first() {
-                errors.push(format!(
-                    "'{}' is {} but must be an uncommitted file or hunk",
-                    file_id,
-                    other.kind_for_humans()
-                ));
-                continue;
-            } else {
-                errors.push(line_range_hunk_hint(file_id).unwrap_or_else(|| {
-                    format!("'{file_id}' not found. Run 'but status' to see available file IDs.")
-                }));
-                continue;
-            }
-        } else {
-            cli_ids
-        };
+        if cli_ids.is_empty() {
+            errors.push(line_range_hunk_hint(file_id).unwrap_or_else(|| {
+                format!("'{file_id}' not found. Run 'but status' to see available file IDs.")
+            }));
+            continue;
+        }
 
         if cli_ids.len() > 1 {
             errors.push(format!(

--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -250,7 +250,9 @@ fn resolve_file_ids(
     let mut errors = Vec::new();
 
     for file_id in file_ids {
-        let cli_ids = match id_map.parse_using_context(file_id, ctx) {
+        // Resolve in the uncommitted file/hunk namespace only, so a commit or
+        // branch ID minted after the file ID was printed cannot shadow it.
+        let cli_ids = match id_map.parse_uncommitted_using_context(file_id, ctx) {
             Ok(ids) => ids,
             Err(e) => {
                 errors.push(format!("'{file_id}': {e}"));
@@ -258,12 +260,33 @@ fn resolve_file_ids(
             }
         };
 
-        if cli_ids.is_empty() {
-            errors.push(line_range_hunk_hint(file_id).unwrap_or_else(|| {
-                format!("'{file_id}' not found. Run 'but status' to see available file IDs.")
-            }));
-            continue;
-        }
+        let cli_ids = if cli_ids.is_empty() {
+            // Nothing uncommitted matches directly. Container selectors this
+            // parser does not model may still resolve to uncommitted files in
+            // the full namespace; anything else is worth a targeted error.
+            let full = id_map.parse_using_context(file_id, ctx).unwrap_or_default();
+            if !full.is_empty()
+                && full
+                    .iter()
+                    .all(|id| matches!(id, CliId::UncommittedHunkOrFile(_)))
+            {
+                full
+            } else if let Some(other) = full.first() {
+                errors.push(format!(
+                    "'{}' is {} but must be an uncommitted file or hunk",
+                    file_id,
+                    other.kind_for_humans()
+                ));
+                continue;
+            } else {
+                errors.push(line_range_hunk_hint(file_id).unwrap_or_else(|| {
+                    format!("'{file_id}' not found. Run 'but status' to see available file IDs.")
+                }));
+                continue;
+            }
+        } else {
+            cli_ids
+        };
 
         if cli_ids.len() > 1 {
             errors.push(format!(

--- a/crates/but/src/command/legacy/discard.rs
+++ b/crates/but/src/command/legacy/discard.rs
@@ -14,7 +14,7 @@ use gitbutler_oplog::{
 
 use crate::{
     CliId, IdMap,
-    id::parser::parse_sources,
+    id::parser::parse_uncommitted_sources,
     utils::{OutputChannel, diff_specs},
 };
 
@@ -28,8 +28,8 @@ pub fn handle(ctx: &mut Context, out: &mut OutputChannel, id: &str) -> Result<()
     let id_map = IdMap::new_from_context(ctx, None, guard.read_permission())?;
 
     // Resolve the ID to get file information
-    let resolved_ids =
-        parse_sources(ctx, &id_map, id).with_context(|| format!("Could not resolve ID '{id}'"))?;
+    let resolved_ids = parse_uncommitted_sources(ctx, &id_map, id)
+        .with_context(|| format!("Could not resolve ID '{id}'"))?;
 
     if resolved_ids.is_empty() {
         bail!("No entity found for the given ID");

--- a/crates/but/src/command/legacy/pull/mod.rs
+++ b/crates/but/src/command/legacy/pull/mod.rs
@@ -616,7 +616,7 @@ async fn handle_pull(ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Resu
                         writeln!(out, "{}", t.important.paint("To resolve conflicts:"))?;
                         writeln!(
                             out,
-                            "  1. Run {} on a conflicted commit listed above — oldest first (they are listed bottom-up)",
+                            "  1. Run {} on a conflicted commit listed above — oldest first (they are listed bottom-up). Worktree files show no conflict markers until this checks the commit out",
                             t.command_suggestion.paint("`but resolve <commit>`")
                         )?;
                         writeln!(out, "  2. Edit files to resolve the conflicts")?;

--- a/crates/but/src/command/legacy/rub/mod.rs
+++ b/crates/but/src/command/legacy/rub/mod.rs
@@ -1805,8 +1805,8 @@ pub(crate) fn handle_stage(
 ) -> anyhow::Result<()> {
     let t = theme::get();
     let id_map = IdMap::legacy_new_from_context(ctx, None)?;
-    let files =
-        parse_sources_with_disambiguation(ctx, &id_map, file_or_hunk_str, out).map_err(|err| {
+    let files = parse_uncommitted_sources_with_disambiguation(ctx, &id_map, file_or_hunk_str, out)
+        .map_err(|err| {
             stage_resolution_error(err, |err| {
                 StageBadInput::file_or_hunk(file_or_hunk_str, err)
             })
@@ -1990,7 +1990,7 @@ pub(crate) fn handle_unstage(
 ) -> anyhow::Result<()> {
     let t = theme::get();
     let id_map = IdMap::legacy_new_from_context(ctx, None)?;
-    let files = parse_sources_with_disambiguation(ctx, &id_map, file_or_hunk_str, out)?;
+    let files = parse_uncommitted_sources_with_disambiguation(ctx, &id_map, file_or_hunk_str, out)?;
 
     // Validate that all files are uncommitted or a path prefix
     for file in &files {
@@ -2025,12 +2025,16 @@ pub(crate) fn handle_unstage(
         }
     }
 
-    // Call the main rub handler with "zz" as target to unassign
-    handle(
+    // Unassign the already-resolved files directly; re-parsing the raw string
+    // through the full namespace could hit the very shadowing the scoped
+    // resolution above just avoided.
+    let target = id_map.uncommitted().clone();
+    handle_resolved(
         ctx,
+        &id_map,
         out,
-        file_or_hunk_str,
-        "zz",
+        files,
+        target,
         MessageCombinationStrategy::KeepBoth,
     )
 }

--- a/crates/but/src/command/legacy/rub/mod.rs
+++ b/crates/but/src/command/legacy/rub/mod.rs
@@ -27,7 +27,10 @@ use nonempty::NonEmpty;
 use crate::{
     CliError, CliId, IdMap, bad_input,
     command::legacy::rub::assign::stack_id_to_branch_name,
-    id::parser::{IdResolutionError, parse_sources_with_disambiguation, prompt_for_disambiguation},
+    id::parser::{
+        IdResolutionError, parse_sources_with_disambiguation,
+        parse_uncommitted_sources_with_disambiguation, prompt_for_disambiguation,
+    },
     utils::{OutputChannel, diff_specs::DiffSpecBuilder, shorten_object_id},
 };
 
@@ -1664,7 +1667,7 @@ pub(crate) fn handle_amend(
     let id_map = IdMap::new_from_context(ctx, None, guard.read_permission())?;
     let mut files = Vec::new();
     for file_str in file_strs {
-        files.extend(parse_sources_with_disambiguation(
+        files.extend(parse_uncommitted_sources_with_disambiguation(
             ctx, &id_map, file_str, out,
         )?);
     }

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -691,9 +691,9 @@ fn print_hint(
 
     if status_ctx.is_agent_invocation {
         let id_hint = if status_ctx.flags.verbose {
-            "Hint: the first token on each line is the ID to use in commands. The sha in parentheses is informational and changes on every amend."
+            "Hint: commits are listed newest first. The first token on each line is the ID to use in commands. The sha in parentheses is informational and changes on every amend."
         } else {
-            "Hint: the first token on each line is the ID to use in commands."
+            "Hint: commits are listed newest first. The first token on each line is the ID to use in commands."
         };
         output.hint(Vec::from([Span::styled(id_hint, crate::theme::get().hint)]))?;
     }

--- a/crates/but/src/command/skill/mod.rs
+++ b/crates/but/src/command/skill/mod.rs
@@ -599,7 +599,8 @@ fn find_all_installations(
         // relative workdir. Absolutize it so discovered installation paths can
         // be handed to context-free operations (`check --update` reinstalls
         // each outdated path without a repository context).
-        let workdir = std::path::absolute(workdir).unwrap_or_else(|_| workdir.to_path_buf());
+        let workdir = std::path::absolute(workdir)
+            .with_context(|| format!("Could not absolutize repository workdir {workdir:?}"))?;
         base_dirs.push((workdir, SCOPE_LOCAL));
     }
 

--- a/crates/but/src/command/skill/mod.rs
+++ b/crates/but/src/command/skill/mod.rs
@@ -595,7 +595,12 @@ fn find_all_installations(
         && let Ok(repo) = ctx.repo.get()
         && let Some(workdir) = repo.workdir()
     {
-        base_dirs.push((workdir.to_path_buf(), SCOPE_LOCAL));
+        // A repository discovered from a relative working directory reports a
+        // relative workdir. Absolutize it so discovered installation paths can
+        // be handed to context-free operations (`check --update` reinstalls
+        // each outdated path without a repository context).
+        let workdir = std::path::absolute(workdir).unwrap_or_else(|_| workdir.to_path_buf());
+        base_dirs.push((workdir, SCOPE_LOCAL));
     }
 
     // Scan each base directory for the formats valid in its scope, so a

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -933,6 +933,67 @@ impl IdMap {
         })]
     }
 
+    /// Like [IdMap::parse_element], but matches only uncommitted files and
+    /// their containers: exact filenames, `dir/` path prefixes, uncommitted
+    /// file IDs, the `zz` uncommitted area, and explicit `@{stack}` selectors.
+    /// Commit and branch IDs never match, so they cannot shadow a file ID.
+    fn parse_element_uncommitted<'a>(
+        &'a self,
+        element: &str,
+    ) -> anyhow::Result<Vec<Box<dyn Node<'a> + 'a>>> {
+        if element.is_empty() {
+            return Ok(vec![]);
+        }
+        if element.strip_suffix("@{stack}").is_some() {
+            // Explicit stack selectors (e.g. `A@{stack}:file`) address staged,
+            // still-uncommitted files; the literal suffix cannot collide with
+            // a generated file ID.
+            return self.parse_element(element);
+        }
+        if element.ends_with('/') {
+            return Ok(self.parse_uncommitted_path_prefix(None, element));
+        }
+
+        // Exact filenames win over generated IDs, mirroring `parse_element`.
+        let mut matches = self.parse_uncommitted_filename(None, element);
+        if element == UNCOMMITTED {
+            #[derive(Debug)]
+            struct Unstaged {}
+            impl<'a> Node<'a> for Unstaged {
+                fn parse(
+                    self: Box<Self>,
+                    element: &str,
+                    id_map: &'a IdMap,
+                    _changes_in_commit_fn: &mut ChangesInCommitFn<'a>,
+                ) -> anyhow::Result<Vec<Box<dyn Node<'a> + 'a>>> {
+                    Ok(id_map.parse_uncommitted_filename(None, element))
+                }
+
+                fn to_cli_id(
+                    self: Box<Self>,
+                    _short_id: &str,
+                    id_map: &IdMap,
+                ) -> anyhow::Result<Option<CliId>> {
+                    Ok(Some(id_map.uncommitted.clone()))
+                }
+            }
+            matches.push(Box::new(Unstaged {}));
+        }
+        if matches.is_empty() {
+            let element_bstring = BString::from(element);
+            for (reverse_hex, uncommitted_file) in self
+                .uncommitted_files
+                .range(ChangeId::from(element_bstring.clone())..)
+            {
+                if !reverse_hex.starts_with(&element_bstring) {
+                    break;
+                }
+                matches.push(Box::new(uncommitted_file));
+            }
+        }
+        Ok(matches)
+    }
+
     fn parse_element<'a>(&'a self, element: &str) -> anyhow::Result<Vec<Box<dyn Node<'a> + 'a>>> {
         if element.is_empty() {
             return Ok(vec![]);
@@ -1117,7 +1178,33 @@ impl IdMap {
     pub fn parse<'a>(
         &'a self,
         entity: &str,
+        changes_in_commit_fn: ChangesInCommitFn<'a>,
+    ) -> anyhow::Result<Vec<CliId>> {
+        self.parse_with(entity, changes_in_commit_fn, Self::parse_element)
+    }
+
+    /// Like [IdMap::parse], but the leading element resolves only against
+    /// uncommitted files and hunks — commits, branches, and stacks never
+    /// match. Use this for selectors that must name uncommitted changes
+    /// (e.g. `--changes`), so a file ID handed out by an earlier command
+    /// cannot be shadowed by a commit change ID minted in between.
+    pub fn parse_uncommitted<'a>(
+        &'a self,
+        entity: &str,
+        changes_in_commit_fn: ChangesInCommitFn<'a>,
+    ) -> anyhow::Result<Vec<CliId>> {
+        self.parse_with(
+            entity,
+            changes_in_commit_fn,
+            Self::parse_element_uncommitted,
+        )
+    }
+
+    fn parse_with<'a>(
+        &'a self,
+        entity: &str,
         mut changes_in_commit_fn: ChangesInCommitFn<'a>,
+        parse_element: impl Fn(&'a Self, &str) -> anyhow::Result<Vec<Box<dyn Node<'a> + 'a>>>,
     ) -> anyhow::Result<Vec<CliId>> {
         let mut cli_ids = Vec::new();
         if let Some((lhs, rhs)) = entity.split_once(':') {
@@ -1126,7 +1213,7 @@ impl IdMap {
                 // colons to be specified in the middle part (e.g.
                 // `a:filename:with:colon:b` will parse to `a`,
                 // `filename:with:colon`, `b`).
-                for node in self.parse_element(lhs)? {
+                for node in parse_element(self, lhs)? {
                     for node in node.parse(mhs, self, &mut changes_in_commit_fn)? {
                         for node in node.parse(rhs, self, &mut changes_in_commit_fn)? {
                             if let Some(cli_id) = node.to_cli_id(entity, self)? {
@@ -1136,7 +1223,7 @@ impl IdMap {
                     }
                 }
             } else {
-                for node in self.parse_element(lhs)? {
+                for node in parse_element(self, lhs)? {
                     for node in node.parse(rhs, self, &mut changes_in_commit_fn)? {
                         if let Some(cli_id) = node.to_cli_id(entity, self)? {
                             cli_ids.push(cli_id);
@@ -1145,7 +1232,7 @@ impl IdMap {
                 }
             }
         } else {
-            for node in self.parse_element(entity)? {
+            for node in parse_element(self, entity)? {
                 if let Some(cli_id) = node.to_cli_id(entity, self)? {
                     cli_ids.push(cli_id);
                 }
@@ -1182,6 +1269,21 @@ impl IdMap {
     pub fn parse_using_context(&self, entity: &str, ctx: &Context) -> anyhow::Result<Vec<CliId>> {
         let repo = &*ctx.repo.get()?;
         self.parse_using_repo(entity, repo)
+    }
+
+    /// Convenience for [IdMap::parse_uncommitted] if a [Context] is available.
+    pub fn parse_uncommitted_using_context(
+        &self,
+        entity: &str,
+        ctx: &Context,
+    ) -> anyhow::Result<Vec<CliId>> {
+        let repo = &*ctx.repo.get()?;
+        self.parse_uncommitted(
+            entity,
+            Box::new(move |commit_id, parent_id| {
+                but_core::diff::tree_changes(repo, parent_id, commit_id)
+            }),
+        )
     }
 
     /// Returns the [`CliId::Stack`] for a given `stack_id`, if it exists.

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -936,7 +936,11 @@ impl IdMap {
     /// Like [IdMap::parse_element], but matches only uncommitted files and
     /// their containers: exact filenames, `dir/` path prefixes, uncommitted
     /// file IDs, the `zz` uncommitted area, and explicit `@{stack}` selectors.
-    /// Commit and branch IDs never match, so they cannot shadow a file ID.
+    /// Commit change IDs never shadow a file ID here, while an element that
+    /// exactly equals a displayed branch or stack ID deliberately matches
+    /// nothing — those IDs are stable and were never shown for a file, so
+    /// resolving them to a file by hex-prefix accident would silently act on
+    /// the wrong target.
     fn parse_element_uncommitted<'a>(
         &'a self,
         element: &str,
@@ -954,44 +958,56 @@ impl IdMap {
             return Ok(self.parse_uncommitted_path_prefix(None, element));
         }
 
-        // Exact filenames win over generated IDs, mirroring `parse_element`.
-        let mut matches = self.parse_uncommitted_filename(None, element);
+        // Exact filenames win over generated IDs, mirroring `parse_element`
+        // (which returns filename matches before ever considering `zz`).
+        let matches = self.parse_uncommitted_filename(None, element);
+        if !matches.is_empty() {
+            return Ok(matches);
+        }
+        let mut matches = matches;
         if element == UNCOMMITTED {
-            #[derive(Debug)]
-            struct Unstaged {}
-            impl<'a> Node<'a> for Unstaged {
-                fn parse(
-                    self: Box<Self>,
-                    element: &str,
-                    id_map: &'a IdMap,
-                    _changes_in_commit_fn: &mut ChangesInCommitFn<'a>,
-                ) -> anyhow::Result<Vec<Box<dyn Node<'a> + 'a>>> {
-                    Ok(id_map.parse_uncommitted_filename(None, element))
-                }
-
-                fn to_cli_id(
-                    self: Box<Self>,
-                    _short_id: &str,
-                    id_map: &IdMap,
-                ) -> anyhow::Result<Option<CliId>> {
-                    Ok(Some(id_map.uncommitted.clone()))
-                }
-            }
             matches.push(Box::new(Unstaged {}));
         }
-        if matches.is_empty() {
-            let element_bstring = BString::from(element);
-            for (reverse_hex, uncommitted_file) in self
-                .uncommitted_files
-                .range(ChangeId::from(element_bstring.clone())..)
-            {
-                if !reverse_hex.starts_with(&element_bstring) {
-                    break;
-                }
-                matches.push(Box::new(uncommitted_file));
-            }
+        if matches.is_empty() && !self.is_displayed_branch_or_stack_id(element) {
+            matches = self.uncommitted_file_id_prefix_matches(element);
         }
         Ok(matches)
+    }
+
+    /// Whether `element` is exactly a branch segment or stack short ID
+    /// currently in this map. Unlike commit change IDs (random, minted after
+    /// the fact), these are displayed to the user, so a selector equal to one
+    /// refers to that entity — never to a file that happens to share the
+    /// prefix.
+    fn is_displayed_branch_or_stack_id(&self, element: &str) -> bool {
+        self.indexed_stacks
+            .borrow_owner()
+            .iter()
+            .flat_map(|stack| stack.segments.iter())
+            .any(|segment| segment.short_id == element)
+            || self
+                .stack_ids
+                .values()
+                .any(|id| matches!(id, CliId::Stack { id, .. } if id == element))
+    }
+
+    /// All uncommitted files whose full reverse-hex ID starts with `element`.
+    fn uncommitted_file_id_prefix_matches<'a>(
+        &'a self,
+        element: &str,
+    ) -> Vec<Box<dyn Node<'a> + 'a>> {
+        let mut matches = Vec::<Box<dyn Node<'a> + 'a>>::new();
+        let element_bstring = BString::from(element);
+        for (reverse_hex, uncommitted_file) in self
+            .uncommitted_files
+            .range(ChangeId::from(element_bstring.clone())..)
+        {
+            if !reverse_hex.starts_with(&element_bstring) {
+                break;
+            }
+            matches.push(Box::new(uncommitted_file));
+        }
+        matches
     }
 
     fn parse_element<'a>(&'a self, element: &str) -> anyhow::Result<Vec<Box<dyn Node<'a> + 'a>>> {
@@ -1119,26 +1135,6 @@ impl IdMap {
             }
         }
         if element == UNCOMMITTED {
-            #[derive(Debug)]
-            struct Unstaged {}
-            impl<'a> Node<'a> for Unstaged {
-                fn parse(
-                    self: Box<Self>,
-                    element: &str,
-                    id_map: &'a IdMap,
-                    _changes_in_commit_fn: &mut ChangesInCommitFn<'a>,
-                ) -> anyhow::Result<Vec<Box<dyn Node<'a> + 'a>>> {
-                    Ok(id_map.parse_uncommitted_filename(None, element))
-                }
-
-                fn to_cli_id(
-                    self: Box<Self>,
-                    _short_id: &str,
-                    id_map: &IdMap,
-                ) -> anyhow::Result<Option<CliId>> {
-                    Ok(Some(id_map.uncommitted.clone()))
-                }
-            }
             matches.push(Box::new(Unstaged {}));
         }
 
@@ -1152,19 +1148,36 @@ impl IdMap {
         // We should consider namespacing the branch short IDs as this problem will only grow with
         // the introduction of change IDs for commits.
         if matches.is_empty() {
-            let element_bstring = BString::from(element);
-            for (reverse_hex, uncommitted_file) in self
-                .uncommitted_files
-                .range(ChangeId::from(element_bstring.clone())..)
-            {
-                if !reverse_hex.starts_with(&element_bstring) {
-                    break;
-                }
-                matches.push(Box::new(uncommitted_file));
-            }
+            matches = self.uncommitted_file_id_prefix_matches(element);
         }
 
         Ok(matches)
+    }
+}
+
+/// The `zz` uncommitted-area sentinel as a parse node: children are unstaged
+/// filenames, and by itself it resolves to [`CliId::Uncommitted`]. Shared by
+/// the full and the uncommitted-scoped element parsers so the sentinel cannot
+/// drift between them.
+#[derive(Debug)]
+struct Unstaged {}
+
+impl<'a> Node<'a> for Unstaged {
+    fn parse(
+        self: Box<Self>,
+        element: &str,
+        id_map: &'a IdMap,
+        _changes_in_commit_fn: &mut ChangesInCommitFn<'a>,
+    ) -> anyhow::Result<Vec<Box<dyn Node<'a> + 'a>>> {
+        Ok(id_map.parse_uncommitted_filename(None, element))
+    }
+
+    fn to_cli_id(
+        self: Box<Self>,
+        _short_id: &str,
+        id_map: &IdMap,
+    ) -> anyhow::Result<Option<CliId>> {
+        Ok(Some(id_map.uncommitted.clone()))
     }
 }
 
@@ -1183,11 +1196,16 @@ impl IdMap {
         self.parse_with(entity, changes_in_commit_fn, Self::parse_element)
     }
 
-    /// Like [IdMap::parse], but the leading element resolves only against
-    /// uncommitted files and hunks — commits, branches, and stacks never
-    /// match. Use this for selectors that must name uncommitted changes
-    /// (e.g. `--changes`), so a file ID handed out by an earlier command
-    /// cannot be shadowed by a commit change ID minted in between.
+    /// Like [IdMap::parse], but the leading element resolves in the
+    /// uncommitted namespace: commit change IDs and branch/stack short IDs
+    /// never shadow a file ID. Use this for selectors that must name
+    /// uncommitted changes (e.g. `--changes`), so a file ID handed out by an
+    /// earlier command cannot be invalidated by a commit minted in between.
+    ///
+    /// Container selectors still surface their containers: bare `zz` yields
+    /// [`CliId::Uncommitted`], `dir/` yields [`CliId::PathPrefix`], and
+    /// `X@{stack}` resolves through the full parser (and can yield
+    /// [`CliId::Stack`]); callers validate the kinds they accept.
     pub fn parse_uncommitted<'a>(
         &'a self,
         entity: &str,
@@ -1271,6 +1289,20 @@ impl IdMap {
         self.parse_using_repo(entity, repo)
     }
 
+    /// Convenience for [IdMap::parse_uncommitted] if a [gix::Repository] is available.
+    pub fn parse_uncommitted_using_repo<'a>(
+        &'a self,
+        entity: &str,
+        repo: &'a gix::Repository,
+    ) -> anyhow::Result<Vec<CliId>> {
+        self.parse_uncommitted(
+            entity,
+            Box::new(move |commit_id, parent_id| {
+                but_core::diff::tree_changes(repo, parent_id, commit_id)
+            }),
+        )
+    }
+
     /// Convenience for [IdMap::parse_uncommitted] if a [Context] is available.
     pub fn parse_uncommitted_using_context(
         &self,
@@ -1278,12 +1310,7 @@ impl IdMap {
         ctx: &Context,
     ) -> anyhow::Result<Vec<CliId>> {
         let repo = &*ctx.repo.get()?;
-        self.parse_uncommitted(
-            entity,
-            Box::new(move |commit_id, parent_id| {
-                but_core::diff::tree_changes(repo, parent_id, commit_id)
-            }),
-        )
+        self.parse_uncommitted_using_repo(entity, repo)
     }
 
     /// Returns the [`CliId::Stack`] for a given `stack_id`, if it exists.

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -33,6 +33,17 @@ mod uncommitted_info;
 #[cfg(test)]
 mod tests;
 
+/// Which namespace an element resolves in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SourceScope {
+    /// Match commits, branches, stacks, and uncommitted files alike.
+    Any,
+    /// Match only uncommitted files and hunks (plus their explicit containers
+    /// `zz`, `dir/`, and `@{stack}`), so commit and branch IDs minted after a
+    /// file ID was printed cannot shadow it.
+    UncommittedOnly,
+}
+
 /// A helper to indicate that this is a short-id as a user would see.
 pub(crate) type ShortId = String;
 
@@ -933,47 +944,6 @@ impl IdMap {
         })]
     }
 
-    /// Like [IdMap::parse_element], but matches only uncommitted files and
-    /// their containers: exact filenames, `dir/` path prefixes, uncommitted
-    /// file IDs, the `zz` uncommitted area, and explicit `@{stack}` selectors.
-    /// Commit change IDs never shadow a file ID here, while an element that
-    /// exactly equals a displayed branch or stack ID deliberately matches
-    /// nothing — those IDs are stable and were never shown for a file, so
-    /// resolving them to a file by hex-prefix accident would silently act on
-    /// the wrong target.
-    fn parse_element_uncommitted<'a>(
-        &'a self,
-        element: &str,
-    ) -> anyhow::Result<Vec<Box<dyn Node<'a> + 'a>>> {
-        if element.is_empty() {
-            return Ok(vec![]);
-        }
-        if element.strip_suffix("@{stack}").is_some() {
-            // Explicit stack selectors (e.g. `A@{stack}:file`) address staged,
-            // still-uncommitted files; the literal suffix cannot collide with
-            // a generated file ID.
-            return self.parse_element(element);
-        }
-        if element.ends_with('/') {
-            return Ok(self.parse_uncommitted_path_prefix(None, element));
-        }
-
-        // Exact filenames win over generated IDs, mirroring `parse_element`
-        // (which returns filename matches before ever considering `zz`).
-        let matches = self.parse_uncommitted_filename(None, element);
-        if !matches.is_empty() {
-            return Ok(matches);
-        }
-        let mut matches = matches;
-        if element == UNCOMMITTED {
-            matches.push(Box::new(Unstaged {}));
-        }
-        if matches.is_empty() && !self.is_displayed_branch_or_stack_id(element) {
-            matches = self.uncommitted_file_id_prefix_matches(element);
-        }
-        Ok(matches)
-    }
-
     /// Whether `element` is exactly a branch segment or stack short ID
     /// currently in this map. Unlike commit change IDs (random, minted after
     /// the fact), these are displayed to the user, so a selector equal to one
@@ -1010,7 +980,11 @@ impl IdMap {
         matches
     }
 
-    fn parse_element<'a>(&'a self, element: &str) -> anyhow::Result<Vec<Box<dyn Node<'a> + 'a>>> {
+    fn parse_element_scoped<'a>(
+        &'a self,
+        element: &str,
+        scope: SourceScope,
+    ) -> anyhow::Result<Vec<Box<dyn Node<'a> + 'a>>> {
         if element.is_empty() {
             return Ok(vec![]);
         }
@@ -1038,13 +1012,15 @@ impl IdMap {
         let mut matches = Vec::<Box<dyn Node<'a> + 'a>>::new();
 
         // Branches match if they match exactly. Likewise for uncommitted, uncommitted files.
-        for stack_with_id in self.indexed_stacks.borrow_owner().iter() {
-            for segment_with_id in stack_with_id.segments.iter() {
-                if segment_with_id
-                    .branch_name()
-                    .is_some_and(|branch_name| branch_name == element)
-                {
-                    matches.push(Box::new(segment_with_id));
+        if scope == SourceScope::Any {
+            for stack_with_id in self.indexed_stacks.borrow_owner().iter() {
+                for segment_with_id in stack_with_id.segments.iter() {
+                    if segment_with_id
+                        .branch_name()
+                        .is_some_and(|branch_name| branch_name == element)
+                    {
+                        matches.push(Box::new(segment_with_id));
+                    }
                 }
             }
         }
@@ -1055,6 +1031,40 @@ impl IdMap {
             return Ok(matches);
         }
 
+        if scope == SourceScope::Any {
+            self.push_generated_id_matches(element, &mut matches);
+        }
+        if element == UNCOMMITTED {
+            matches.push(Box::new(Unstaged {}));
+        }
+
+        // We only match against uncommitted files if there are no other matches. The reason for
+        // this is that we want prefix matching for uncommitted files to make the IDs "stable under
+        // shortening". However, as the reverse hex IDs of uncommitted files may collide with branch
+        // names and/or branch short IDs, we only match against uncommitted files if there are no
+        // other matches. This allows branch name short IDs to be prefixes of uncommitted file short
+        // IDs — and in the uncommitted scope, where container IDs never match, an element that
+        // exactly equals a displayed branch or stack ID deliberately matches nothing rather than
+        // resolving to a file it was never shown for.
+        if matches.is_empty() {
+            if scope == SourceScope::UncommittedOnly
+                && self.is_displayed_branch_or_stack_id(element)
+            {
+                return Ok(vec![]);
+            }
+            matches = self.uncommitted_file_id_prefix_matches(element);
+        }
+
+        Ok(matches)
+    }
+
+    /// Commit, stack-ID, and branch-short-ID matches for `element`, appended
+    /// to `matches`. Only meaningful in the full namespace.
+    fn push_generated_id_matches<'a>(
+        &'a self,
+        element: &str,
+        matches: &mut Vec<Box<dyn Node<'a> + 'a>>,
+    ) {
         // Match against commits
         let maybe_element_hex_prefix = if element
             .chars()
@@ -1134,24 +1144,6 @@ impl IdMap {
                 }
             }
         }
-        if element == UNCOMMITTED {
-            matches.push(Box::new(Unstaged {}));
-        }
-
-        // We only match against uncommitted files if there are no other matches. The reason for
-        // this is that we want prefix matching for uncommitted files to make the IDs "stable under
-        // shortening". However, as the reverse hex IDs of uncommitted files may collide with branch
-        // names and/or branch short IDs, we only match against uncommitted files if there are no
-        // other matches. This allows branch name short IDs to be prefixes of uncommitted file short
-        // IDs.
-        //
-        // We should consider namespacing the branch short IDs as this problem will only grow with
-        // the introduction of change IDs for commits.
-        if matches.is_empty() {
-            matches = self.uncommitted_file_id_prefix_matches(element);
-        }
-
-        Ok(matches)
     }
 }
 
@@ -1193,7 +1185,7 @@ impl IdMap {
         entity: &str,
         changes_in_commit_fn: ChangesInCommitFn<'a>,
     ) -> anyhow::Result<Vec<CliId>> {
-        self.parse_with(entity, changes_in_commit_fn, Self::parse_element)
+        self.parse_with(entity, changes_in_commit_fn, SourceScope::Any)
     }
 
     /// Like [IdMap::parse], but the leading element resolves in the
@@ -1204,25 +1196,21 @@ impl IdMap {
     ///
     /// Container selectors still surface their containers: bare `zz` yields
     /// [`CliId::Uncommitted`], `dir/` yields [`CliId::PathPrefix`], and
-    /// `X@{stack}` resolves through the full parser (and can yield
+    /// `X@{stack}` resolves its stack (and can yield
     /// [`CliId::Stack`]); callers validate the kinds they accept.
     pub fn parse_uncommitted<'a>(
         &'a self,
         entity: &str,
         changes_in_commit_fn: ChangesInCommitFn<'a>,
     ) -> anyhow::Result<Vec<CliId>> {
-        self.parse_with(
-            entity,
-            changes_in_commit_fn,
-            Self::parse_element_uncommitted,
-        )
+        self.parse_with(entity, changes_in_commit_fn, SourceScope::UncommittedOnly)
     }
 
     fn parse_with<'a>(
         &'a self,
         entity: &str,
         mut changes_in_commit_fn: ChangesInCommitFn<'a>,
-        parse_element: impl Fn(&'a Self, &str) -> anyhow::Result<Vec<Box<dyn Node<'a> + 'a>>>,
+        scope: SourceScope,
     ) -> anyhow::Result<Vec<CliId>> {
         let mut cli_ids = Vec::new();
         if let Some((lhs, rhs)) = entity.split_once(':') {
@@ -1231,7 +1219,7 @@ impl IdMap {
                 // colons to be specified in the middle part (e.g.
                 // `a:filename:with:colon:b` will parse to `a`,
                 // `filename:with:colon`, `b`).
-                for node in parse_element(self, lhs)? {
+                for node in self.parse_element_scoped(lhs, scope)? {
                     for node in node.parse(mhs, self, &mut changes_in_commit_fn)? {
                         for node in node.parse(rhs, self, &mut changes_in_commit_fn)? {
                             if let Some(cli_id) = node.to_cli_id(entity, self)? {
@@ -1241,7 +1229,7 @@ impl IdMap {
                     }
                 }
             } else {
-                for node in parse_element(self, lhs)? {
+                for node in self.parse_element_scoped(lhs, scope)? {
                     for node in node.parse(rhs, self, &mut changes_in_commit_fn)? {
                         if let Some(cli_id) = node.to_cli_id(entity, self)? {
                             cli_ids.push(cli_id);
@@ -1250,7 +1238,7 @@ impl IdMap {
                 }
             }
         } else {
-            for node in parse_element(self, entity)? {
+            for node in self.parse_element_scoped(entity, scope)? {
                 if let Some(cli_id) = node.to_cli_id(entity, self)? {
                     cli_ids.push(cli_id);
                 }

--- a/crates/but/src/id/parser.rs
+++ b/crates/but/src/id/parser.rs
@@ -21,6 +21,53 @@ impl std::fmt::Display for IdResolutionError {
 
 impl std::error::Error for IdResolutionError {}
 
+/// Which namespace source selectors resolve in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SourceScope {
+    /// Match commits, branches, stacks, and uncommitted files alike.
+    Any,
+    /// Match only uncommitted files and hunks, so commit and branch IDs
+    /// minted after a file ID was printed cannot shadow it.
+    UncommittedOnly,
+}
+
+fn parse_scoped(
+    ctx: &mut Context,
+    id_map: &IdMap,
+    part: &str,
+    scope: SourceScope,
+) -> anyhow::Result<Vec<CliId>> {
+    match scope {
+        SourceScope::Any => id_map.parse_using_context(part, ctx),
+        SourceScope::UncommittedOnly => {
+            let scoped = id_map.parse_uncommitted_using_context(part, ctx)?;
+            if !scoped.is_empty() {
+                return Ok(scoped);
+            }
+            // Nothing uncommitted matches directly. Container selectors the
+            // scoped parser does not model may still resolve to uncommitted
+            // files in the full namespace; anything else gets a targeted error.
+            let full = id_map.parse_using_context(part, ctx)?;
+            if !full.is_empty()
+                && full
+                    .iter()
+                    .all(|id| matches!(id, CliId::UncommittedHunkOrFile(_)))
+            {
+                return Ok(full);
+            }
+            if let Some(other) = full.first() {
+                return Err(IdResolutionError::new(format!(
+                    "'{}' is {} but must be an uncommitted file or hunk",
+                    part,
+                    other.kind_for_humans()
+                ))
+                .into());
+            }
+            Ok(vec![])
+        }
+    }
+}
+
 pub(crate) fn parse_sources(
     ctx: &mut Context,
     id_map: &IdMap,
@@ -152,9 +199,31 @@ pub fn parse_sources_with_disambiguation(
     source: &str,
     out: &mut OutputChannel,
 ) -> anyhow::Result<Vec<CliId>> {
+    parse_sources_with_disambiguation_scoped(ctx, id_map, source, out, SourceScope::Any)
+}
+
+/// Like [parse_sources_with_disambiguation], but selectors resolve only
+/// against uncommitted files and hunks. Use for arguments that must name
+/// uncommitted changes, such as `--changes`.
+pub(crate) fn parse_uncommitted_sources_with_disambiguation(
+    ctx: &mut Context,
+    id_map: &IdMap,
+    source: &str,
+    out: &mut OutputChannel,
+) -> anyhow::Result<Vec<CliId>> {
+    parse_sources_with_disambiguation_scoped(ctx, id_map, source, out, SourceScope::UncommittedOnly)
+}
+
+fn parse_sources_with_disambiguation_scoped(
+    ctx: &mut Context,
+    id_map: &IdMap,
+    source: &str,
+    out: &mut OutputChannel,
+    scope: SourceScope,
+) -> anyhow::Result<Vec<CliId>> {
     // Check if it's a list (contains ',')
     if source.contains(',') {
-        return parse_list_with_disambiguation(ctx, id_map, source, out);
+        return parse_list_with_disambiguation(ctx, id_map, source, out, scope);
     }
 
     // Check if it's a valid range (e.g., "g0-h2" where both sides are uncommitted files).
@@ -167,7 +236,7 @@ pub fn parse_sources_with_disambiguation(
     }
 
     // Single source (including strings with dashes that aren't valid ranges)
-    let source_result = id_map.parse_using_context(source, ctx)?;
+    let source_result = parse_scoped(ctx, id_map, source, scope)?;
     if source_result.is_empty() {
         return Err(IdResolutionError::new(format!(
             "Source '{source}' not found. If you just performed a Git operation (squash, rebase, etc.), try running 'but status' to refresh the current state."
@@ -190,6 +259,7 @@ fn parse_list_with_disambiguation(
     id_map: &IdMap,
     source: &str,
     out: &mut OutputChannel,
+    scope: SourceScope,
 ) -> anyhow::Result<Vec<CliId>> {
     let parts: Vec<&str> = source.split(',').collect();
     let mut result = Vec::new();
@@ -202,7 +272,7 @@ fn parse_list_with_disambiguation(
             continue;
         }
 
-        let matches = id_map.parse_using_context(part, ctx)?;
+        let matches = parse_scoped(ctx, id_map, part, scope)?;
         if matches.is_empty() {
             return Err(IdResolutionError::new(format!(
                 "Item '{part}' in list not found. If you just performed a Git operation (squash, rebase, etc.), try running 'but status' to refresh the current state."

--- a/crates/but/src/id/parser.rs
+++ b/crates/but/src/id/parser.rs
@@ -2,7 +2,7 @@ use anyhow::Context as _;
 use bstr::BStr;
 use but_ctx::Context;
 
-use crate::{CliId, IdMap, utils::OutputChannel};
+use crate::{CliId, IdMap, id::SourceScope, utils::OutputChannel};
 
 #[derive(Debug)]
 pub(crate) struct IdResolutionError(String);
@@ -20,16 +20,6 @@ impl std::fmt::Display for IdResolutionError {
 }
 
 impl std::error::Error for IdResolutionError {}
-
-/// Which namespace source selectors resolve in.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum SourceScope {
-    /// Match commits, branches, stacks, and uncommitted files alike.
-    Any,
-    /// Match only uncommitted files and hunks, so commit and branch IDs
-    /// minted after a file ID was printed cannot shadow it.
-    UncommittedOnly,
-}
 
 fn parse_scoped(
     ctx: &mut Context,

--- a/crates/but/src/id/parser.rs
+++ b/crates/but/src/id/parser.rs
@@ -39,33 +39,44 @@ fn parse_scoped(
 ) -> anyhow::Result<Vec<CliId>> {
     match scope {
         SourceScope::Any => id_map.parse_using_context(part, ctx),
-        SourceScope::UncommittedOnly => {
-            let scoped = id_map.parse_uncommitted_using_context(part, ctx)?;
-            if !scoped.is_empty() {
-                return Ok(scoped);
-            }
-            // Nothing uncommitted matches directly. Container selectors the
-            // scoped parser does not model may still resolve to uncommitted
-            // files in the full namespace; anything else gets a targeted error.
-            let full = id_map.parse_using_context(part, ctx)?;
-            if !full.is_empty()
-                && full
-                    .iter()
-                    .all(|id| matches!(id, CliId::UncommittedHunkOrFile(_)))
-            {
-                return Ok(full);
-            }
-            if let Some(other) = full.first() {
-                return Err(IdResolutionError::new(format!(
-                    "'{}' is {} but must be an uncommitted file or hunk",
-                    part,
-                    other.kind_for_humans()
-                ))
-                .into());
-            }
-            Ok(vec![])
-        }
+        SourceScope::UncommittedOnly => resolve_uncommitted_part(ctx, id_map, part),
     }
+}
+
+/// Resolve one selector that must name uncommitted changes: the uncommitted
+/// namespace first, then a full-namespace fallback that keeps any uncommitted
+/// interpretations (container selectors the scoped parser does not model) and
+/// turns everything else into a targeted error naming what the selector is.
+///
+/// This is the single home of that policy — `but commit --changes`, amend,
+/// stage, unstage, and discard all resolve through it so they cannot diverge.
+pub(crate) fn resolve_uncommitted_part(
+    ctx: &mut Context,
+    id_map: &IdMap,
+    part: &str,
+) -> anyhow::Result<Vec<CliId>> {
+    let scoped = id_map.parse_uncommitted_using_context(part, ctx)?;
+    if !scoped.is_empty() {
+        return Ok(scoped);
+    }
+    let full = id_map.parse_using_context(part, ctx)?;
+    let uncommitted: Vec<CliId> = full
+        .iter()
+        .filter(|id| matches!(id, CliId::UncommittedHunkOrFile(_)))
+        .cloned()
+        .collect();
+    if !uncommitted.is_empty() {
+        return Ok(uncommitted);
+    }
+    if let Some(other) = full.first() {
+        return Err(IdResolutionError::new(format!(
+            "'{}' is {} but must be an uncommitted file or hunk",
+            part,
+            other.kind_for_humans()
+        ))
+        .into());
+    }
+    Ok(vec![])
 }
 
 pub(crate) fn parse_sources(
@@ -73,22 +84,41 @@ pub(crate) fn parse_sources(
     id_map: &IdMap,
     source: &str,
 ) -> anyhow::Result<Vec<CliId>> {
+    parse_sources_scoped(ctx, id_map, source, SourceScope::Any)
+}
+
+/// Like [parse_sources], but selectors resolve only against uncommitted files
+/// and hunks. For commands whose sources must be uncommitted (e.g. discard).
+pub(crate) fn parse_uncommitted_sources(
+    ctx: &mut Context,
+    id_map: &IdMap,
+    source: &str,
+) -> anyhow::Result<Vec<CliId>> {
+    parse_sources_scoped(ctx, id_map, source, SourceScope::UncommittedOnly)
+}
+
+fn parse_sources_scoped(
+    ctx: &mut Context,
+    id_map: &IdMap,
+    source: &str,
+    scope: SourceScope,
+) -> anyhow::Result<Vec<CliId>> {
     // Check if it's a list (contains ',')
     if source.contains(',') {
-        return parse_list(ctx, id_map, source);
+        return parse_list(ctx, id_map, source, scope);
     }
 
     // Check if it's a valid range (e.g., "g0-h2" where both sides are uncommitted files).
     // If the string contains '-' but isn't a valid range (e.g., a filename like "my-file.rs"
     // or a branch name like "feature-auth"), fall through to single-entity parsing.
     if source.contains('-')
-        && let Some(range_result) = try_parse_range(ctx, id_map, source)?
+        && let Some(range_result) = try_parse_range(ctx, id_map, source, scope)?
     {
         return Ok(range_result);
     }
 
     // Single source (including strings with dashes that aren't valid ranges)
-    let source_result = id_map.parse_using_context(source, ctx)?;
+    let source_result = parse_scoped(ctx, id_map, source, scope)?;
     if source_result.len() != 1 {
         if source_result.is_empty() {
             return Err(IdResolutionError::new(format!(
@@ -124,6 +154,7 @@ fn try_parse_range(
     ctx: &mut Context,
     id_map: &IdMap,
     source: &str,
+    scope: SourceScope,
 ) -> anyhow::Result<Option<Vec<CliId>>> {
     let parts: Vec<&str> = source.split('-').collect();
     if parts.len() != 2 {
@@ -131,11 +162,14 @@ fn try_parse_range(
     }
 
     // If either half fails to parse (e.g., single character "a" in "a-file.txt"),
-    // this isn't a range — fall through to single-entity parsing.
-    let Ok(start_matches) = id_map.parse_using_context(parts[0], ctx) else {
+    // this isn't a range — fall through to single-entity parsing. Endpoints
+    // honor the caller's scope: a range copied from `but diff` must keep
+    // resolving even when a later commit's change ID shadows an endpoint in
+    // the full namespace.
+    let Ok(start_matches) = parse_scoped(ctx, id_map, parts[0], scope) else {
         return Ok(None);
     };
-    let Ok(end_matches) = id_map.parse_using_context(parts[1], ctx) else {
+    let Ok(end_matches) = parse_scoped(ctx, id_map, parts[1], scope) else {
         return Ok(None);
     };
 
@@ -230,7 +264,7 @@ fn parse_sources_with_disambiguation_scoped(
     // If the string contains '-' but isn't a valid range (e.g., a filename like "my-file.rs"
     // or a branch name like "feature-auth"), fall through to single-entity parsing.
     if source.contains('-')
-        && let Some(range_result) = try_parse_range(ctx, id_map, source)?
+        && let Some(range_result) = try_parse_range(ctx, id_map, source, scope)?
     {
         return Ok(range_result);
     }
@@ -301,7 +335,12 @@ fn parse_list_with_disambiguation(
     Ok(result)
 }
 
-fn parse_list(ctx: &mut Context, id_map: &IdMap, source: &str) -> anyhow::Result<Vec<CliId>> {
+fn parse_list(
+    ctx: &mut Context,
+    id_map: &IdMap,
+    source: &str,
+    scope: SourceScope,
+) -> anyhow::Result<Vec<CliId>> {
     let parts: Vec<&str> = source.split(',').collect();
     let mut result = Vec::new();
 
@@ -313,7 +352,7 @@ fn parse_list(ctx: &mut Context, id_map: &IdMap, source: &str) -> anyhow::Result
             continue;
         }
 
-        let matches = id_map.parse_using_context(part, ctx)?;
+        let matches = parse_scoped(ctx, id_map, part, scope)?;
         if matches.len() != 1 {
             if matches.is_empty() {
                 return Err(IdResolutionError::new(format!(

--- a/crates/but/src/id/tests.rs
+++ b/crates/but/src/id/tests.rs
@@ -2598,6 +2598,73 @@ fn uncommitted_selector_is_not_shadowed_by_commit_change_id() -> anyhow::Result<
 }
 
 #[test]
+fn uncommitted_scope_resolves_a_file_literally_named_zz() -> anyhow::Result<()> {
+    let changed_paths_fn = |commit_id: gix::ObjectId,
+                            parent_id: Option<gix::ObjectId>|
+     -> anyhow::Result<Vec<but_core::TreeChange>> {
+        bail!("unexpected IDs {commit_id} {parent_id:?}");
+    };
+    let id_map = IdMap::new(
+        vec![stack([segment("not-important", [], None, [])])],
+        vec![hunk_assignment("zz", None)],
+        gix::hashtable::HashMap::default(),
+    )?;
+
+    // The full parser returns the filename match before considering the `zz`
+    // sentinel; the scoped parser must agree instead of reporting an
+    // ambiguity the full parser does not have.
+    let scoped = id_map.parse_uncommitted("zz", Box::new(changed_paths_fn))?;
+    match scoped.as_slice() {
+        [CliId::UncommittedHunkOrFile(uncommitted)] => {
+            assert_eq!(uncommitted.hunk_assignments.first().path_bytes, "zz");
+        }
+        other => panic!("expected exactly the file named zz, got {other:?}"),
+    }
+    Ok(())
+}
+
+#[test]
+fn uncommitted_scope_does_not_prefix_match_a_branch_short_id() -> anyhow::Result<()> {
+    let changed_paths_fn = |commit_id: gix::ObjectId,
+                            parent_id: Option<gix::ObjectId>|
+     -> anyhow::Result<Vec<but_core::TreeChange>> {
+        bail!("unexpected IDs {commit_id} {parent_id:?}");
+    };
+    // File "foo242" gets reverse-hex ID "kpo…"; a branch literally named "kp"
+    // takes short ID "kp", which the ID assigner deliberately allows to be a
+    // prefix of the file's ID (branches win in the full namespace).
+    let id_map = IdMap::new(
+        vec![stack([segment("kp", [id(1)], None, [])])],
+        vec![hunk_assignment("foo242", None)],
+        gix::hashtable::HashMap::default(),
+    )?;
+
+    let full = id_map.parse("kp", Box::new(changed_paths_fn))?;
+    assert!(
+        matches!(full.as_slice(), [CliId::Branch { .. }]),
+        "precondition: the full namespace resolves 'kp' to the branch: {full:?}"
+    );
+
+    // The scoped parser must NOT silently resolve the displayed branch ID to
+    // the file by hex-prefix accident — an empty result lets callers produce
+    // the targeted "is a branch" error via their full-namespace fallback.
+    let scoped = id_map.parse_uncommitted("kp", Box::new(changed_paths_fn))?;
+    assert_eq!(
+        scoped,
+        vec![],
+        "a displayed branch ID never resolves to a file in the uncommitted scope"
+    );
+
+    // A longer prefix that no branch owns still resolves the file.
+    let scoped = id_map.parse_uncommitted("kpo", Box::new(changed_paths_fn))?;
+    assert!(
+        matches!(scoped.as_slice(), [CliId::UncommittedHunkOrFile(_)]),
+        "file prefixes beyond the branch ID keep resolving: {scoped:?}"
+    );
+    Ok(())
+}
+
+#[test]
 fn change_ids_are_disambiguated_on_collision() {
     let id1 = id(1);
     let id2 = id(2);

--- a/crates/but/src/id/tests.rs
+++ b/crates/but/src/id/tests.rs
@@ -2526,6 +2526,78 @@ branches: [ no ]
 }
 
 #[test]
+fn uncommitted_selector_is_not_shadowed_by_commit_change_id() -> anyhow::Result<()> {
+    let changed_paths_fn = || {
+        Box::new(
+            |commit_id: gix::ObjectId,
+             parent_id: Option<gix::ObjectId>|
+             -> anyhow::Result<Vec<but_core::TreeChange>> {
+                bail!("unexpected IDs {commit_id} {parent_id:?}");
+            },
+        )
+    };
+
+    // Discover the ID the file gets while no commit competes with it — the ID
+    // an agent copies from `but diff` before committing.
+    let commitless = IdMap::new(
+        vec![stack([segment("not-important", [], None, [])])],
+        vec![hunk_assignment("README.md", None)],
+        gix::hashtable::HashMap::default(),
+    )?;
+    let file_id = commitless
+        .all_ids()
+        .into_iter()
+        .find_map(|cli_id| match cli_id {
+            CliId::UncommittedHunkOrFile(uncommitted) => Some(uncommitted.id.clone()),
+            _ => None,
+        })
+        .expect("one uncommitted file");
+
+    // A commit is created whose random change ID starts with that file ID.
+    let id1 = id(1);
+    let colliding_change_id = ChangeId::from(BString::from(format!(
+        "{file_id}{}",
+        "z".repeat(32 - file_id.len())
+    )));
+    let commit_id_to_change_id: gix::hashtable::HashMap<gix::ObjectId, ChangeId> =
+        [(id1, colliding_change_id)].into_iter().collect();
+    let id_map = IdMap::new(
+        vec![stack([segment("not-important", [id1], None, [])])],
+        vec![hunk_assignment("README.md", None)],
+        commit_id_to_change_id,
+    )?;
+
+    // In the full namespace the commit shadows the previously issued file ID.
+    let full = id_map.parse(&file_id, changed_paths_fn())?;
+    assert!(
+        matches!(full.as_slice(), [CliId::Commit { .. }]),
+        "the commit change ID shadows the file ID in the full namespace: {full:?}"
+    );
+
+    // Scoped to uncommitted files, the same selector still finds the file.
+    let scoped = id_map.parse_uncommitted(&file_id, changed_paths_fn())?;
+    match scoped.as_slice() {
+        [CliId::UncommittedHunkOrFile(uncommitted)] => {
+            assert_eq!(
+                uncommitted.hunk_assignments.first().path_bytes,
+                "README.md",
+                "the selector resolves to the file it was issued for"
+            );
+        }
+        other => panic!("expected the uncommitted file, got {other:?}"),
+    }
+
+    // Hunk selectors under the file keep working too.
+    let hunk = id_map.parse_uncommitted(&format!("{file_id}:q"), changed_paths_fn())?;
+    assert!(
+        matches!(hunk.as_slice(), [CliId::UncommittedHunkOrFile(_)]),
+        "hunk selector resolves in the scoped namespace: {hunk:?}"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn change_ids_are_disambiguated_on_collision() {
     let id1 = id(1);
     let id2 = id(2);

--- a/crates/but/tests/but/command/absorb.rs
+++ b/crates/but/tests/but/command/absorb.rs
@@ -15,6 +15,49 @@ fn find_uncommitted_cli_id(status: &serde_json::Value, path: &str) -> Option<Str
 }
 
 #[test]
+fn unresolvable_source_errors_instead_of_absorbing_everything() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+
+    env.setup_metadata_at_target(&["A", "B"], "origin/main");
+    commit_file_with_worktree_changes_as_two_hunks(&env, "A", "a.txt");
+
+    // A source that resolves to nothing must fail loudly. It used to be
+    // swallowed, silently degrading `absorb <id>` to absorb-everything.
+    env.but("absorb zq").assert().failure();
+
+    // The worktree change is untouched.
+    let status = util::status_json(&env).expect("status should be valid JSON");
+    assert!(
+        find_uncommitted_cli_id(&status, "a.txt").is_some(),
+        "nothing was absorbed by the failed command"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn ambiguous_source_errors_instead_of_absorbing_an_arbitrary_match() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+
+    env.setup_metadata_at_target(&["A", "B"], "origin/main");
+    commit_file_with_worktree_changes_as_two_hunks(&env, "A", "a.txt");
+    // "foo23" and "foo242" share the reverse-hex ID prefix "kp".
+    env.file("foo23", "data\n");
+    env.file("foo242", "data\n");
+
+    env.but("absorb kp").assert().failure();
+
+    // Nothing was absorbed by the ambiguous selector.
+    let status = util::status_json(&env).expect("status should be valid JSON");
+    assert!(
+        find_uncommitted_cli_id(&status, "a.txt").is_some(),
+        "the ambiguous command must not touch any commit"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn uncommitted_file() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
 
@@ -38,7 +81,7 @@ fn uncommitted_file() -> anyhow::Result<()> {
 ...
 "#]]);
 
-    env.but("absorb i0")
+    env.but("absorb")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
@@ -332,7 +375,7 @@ Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "mes
 
 "#]]);
 
-    env.but("absorb i0")
+    env.but("absorb")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
@@ -462,7 +505,7 @@ fn dry_run_shows_plan_without_changes() -> anyhow::Result<()> {
         .stdout;
 
     // Run absorb with dry-run flag
-    env.but("absorb i0 --dry-run")
+    env.but("absorb --dry-run")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
@@ -493,7 +536,7 @@ Dry run complete. No changes were made.
     let repo = env.open_repo();
     let ws_id = repo.rev_parse_single(b"gitbutler/workspace")?.detach();
     // Re-run dry-run and confirm workspace is still the same
-    env.but("absorb i0 --dry-run").assert().success();
+    env.but("absorb --dry-run").assert().success();
     let ws_id_after = repo.rev_parse_single(b"gitbutler/workspace")?.detach();
     assert_eq!(ws_id, ws_id_after, "dry-run must not touch workspace HEAD");
 
@@ -553,7 +596,7 @@ fn workspace_head_is_refreshed_after_absorb() -> anyhow::Result<()> {
     let repo = env.open_repo();
     let ws_before = repo.rev_parse_single(b"gitbutler/workspace")?.detach();
 
-    env.but("absorb i0").assert().success().stderr_eq(str![""]);
+    env.but("absorb").assert().success().stderr_eq(str![""]);
 
     // After absorb the workspace commit must have changed.
     let ws_after = repo.rev_parse_single(b"gitbutler/workspace")?.detach();

--- a/crates/but/tests/but/command/commit.rs
+++ b/crates/but/tests/but/command/commit.rs
@@ -1360,6 +1360,33 @@ Error: Invalid file ID(s):
 }
 
 #[test]
+fn commit_with_filename_shadowed_by_branch_of_same_name_succeeds() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
+    env.but("branch new notes.txt").assert().success();
+
+    // A dirty file sharing its name with a branch: in the full namespace the
+    // selector would be ambiguous, but `--changes` only takes uncommitted
+    // files, so the filename must keep working.
+    env.file("notes.txt", "content\n");
+
+    env.but("commit A -m 'notes' --changes notes.txt")
+        .assert()
+        .success();
+
+    let status = util::status_json(&env).expect("status should be valid JSON");
+    let remaining = status["uncommittedChanges"]
+        .as_array()
+        .map(Vec::len)
+        .unwrap_or_default();
+    assert_eq!(remaining, 0, "the file should be committed");
+    let messages = branch_commit_messages(&env, "A");
+    assert_eq!(messages[..1], ["notes"]);
+
+    Ok(())
+}
+
+#[test]
 fn commit_with_file_assigned_to_different_stack_fails() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
     env.setup_metadata(&["A", "B"]);

--- a/crates/but/tests/but/command/pull.rs
+++ b/crates/but/tests/but/command/pull.rs
@@ -556,7 +556,7 @@ Summary
       rou [conflict] bottom change
 
 To resolve conflicts:
-  1. Run `but resolve <commit>` on a conflicted commit listed above — oldest first (they are listed bottom-up)
+  1. Run `but resolve <commit>` on a conflicted commit listed above — oldest first (they are listed bottom-up). Worktree files show no conflict markers until this checks the commit out
   2. Edit files to resolve the conflicts
   3. Run `but resolve finish` to finalize the resolution
 
@@ -626,7 +626,7 @@ Summary
       trk [conflict] bottom change
 
 To resolve conflicts:
-  1. Run `but resolve <commit>` on a conflicted commit listed above — oldest first (they are listed bottom-up)
+  1. Run `but resolve <commit>` on a conflicted commit listed above — oldest first (they are listed bottom-up). Worktree files show no conflict markers until this checks the commit out
   2. Edit files to resolve the conflicts
   3. Run `but resolve finish` to finalize the resolution
 

--- a/crates/but/tests/but/command/rub.rs
+++ b/crates/but/tests/but/command/rub.rs
@@ -1189,7 +1189,7 @@ fn unstage_command_validation() -> anyhow::Result<()> {
         .assert()
         .failure()
         .stderr_eq(str![[r#"
-Failed to unstage. Cannot unstage f - it is a commit. Only uncommitted files and hunks can be unstaged.
+Failed to unstage. '1' is a commit but must be an uncommitted file or hunk
 
 "#]]);
 

--- a/crates/but/tests/but/command/skill.rs
+++ b/crates/but/tests/but/command/skill.rs
@@ -284,6 +284,41 @@ fn agent_skill_notice_reports_a_stale_local_skill_despite_a_current_global_copy(
 }
 
 #[test]
+fn skill_check_update_repairs_a_stale_local_skill() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
+
+    env.but("skill install --path .codex/skills/gitbutler")
+        .assert()
+        .success();
+    std::fs::write(
+        env.projects_root().join(".codex/skills/gitbutler/SKILL.md"),
+        "---\nname: but\nversion: old\n---\n",
+    )
+    .unwrap();
+
+    // The staleness notice tells agents to run exactly this command; it must
+    // converge instead of failing (it used to bail about a relative --path the
+    // agent never passed when the repository was discovered from a relative
+    // working directory).
+    env.but("skill check --update")
+        .env("AI_AGENT", "codex")
+        .assert()
+        .success();
+
+    // The local copy is current again, so the notice stops.
+    let output = env
+        .but("alias list")
+        .env("AI_AGENT", "codex")
+        .output()
+        .expect("alias list runs");
+    assert!(
+        !String::from_utf8_lossy(&output.stdout).contains("AGENT ACTION REQUIRED"),
+        "the suggested remediation must clear the notice"
+    );
+}
+
+#[test]
 fn agent_skill_notice_repairs_another_agents_stale_global_skill() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
     env.setup_metadata(&[]);

--- a/crates/but/tests/but/command/status.rs
+++ b/crates/but/tests/but/command/status.rs
@@ -1178,7 +1178,7 @@ This notice repeats until the skill is installed. If it still appears after inst
 ┴ 0dc3733 (common base) 2000-01-02 add M
 
 Hint: ◐ means rewritten locally vs upstream.
-Hint: the first token on each line is the ID to use in commands.
+Hint: commits are listed newest first. The first token on each line is the ID to use in commands.
 
 "#]]);
 
@@ -1196,7 +1196,7 @@ Hint: the first token on each line is the ID to use in commands.
 ┴ 0dc3733 (common base) 2000-01-02 add M
 
 Hint: ◐ means rewritten locally vs upstream.
-Hint: the first token on each line is the ID to use in commands.
+Hint: commits are listed newest first. The first token on each line is the ID to use in commands.
 
 "#]]);
 }


### PR DESCRIPTION
Improvements to how coding agents drive `but`, from an overnight tuning session against version-control-bench plus review passes on the result.

Selector resolution
- `--changes` (and amend/stage/unstage/discard sources) resolve in the uncommitted namespace, so a freshly minted commit change ID or branch ID can never shadow a file/hunk ID mid-chain. One shared fallback (`resolve_uncommitted_part`) covers container selectors and keeps targeted errors; range endpoints honor the scope; a selector equal to a displayed branch/stack ID errors instead of silently prefix-resolving to a file.
- `absorb` no longer swallows source-resolution errors (a bad ID used to silently degrade to absorb-everything); `unstage` reuses its validated parse instead of re-resolving the raw string.
- The scoped parser is folded into `parse_element` behind a `SourceScope` enum — one code path for both namespaces instead of a parallel twin.

Output at the point of misread (each from a transcript-verified agent misread)
- Pull's conflict block notes that worktree files show no markers until `but resolve` checks the commit out.
- The agent-facing status hint states that commits are listed newest first.
- `but config target` (read) says new remote commits arrive via `but pull`, not by repointing the target.
- `but skill check --update` now works on repo-local installs discovered from a relative working directory (its suggested-remediation loop used to dead-end with a misleading `--path` error).

Skill and policy
- SKILL.md slimmed 21.1KB/272 lines to 14.9KB/190 lines: deduped guidance, depth moved to point-of-use CLI output and references/, and it now fits the 240-line window Codex reads by default (the tail was previously invisible to it). Cuts ledger kept; every recipe and anti-pattern warning survives.
- The check-before-pull preflight is relaxed: recipes and the generated agent policy say run `but pull` directly (it refuses safely, reports conflicts, and undoes cleanly); `--check` remains as a dry-run preview and stays mandatory when other agents' branches are applied. A self-initiated update that hits conflicts stops to ask.

Verified with ~350 graded bench runs across the session (349 pass; the one failure was a display-direction misread that produced two of the fixes above), full suites and clippy green throughout. Claude token medians dropped 4-19% per scenario; command floors held or improved (S6: 8 → 7 when agents skip the preflight).