### PR TITLE
Explain dependency-conflict commit failures and name the owning branch

### DIFF
--- a/crates/but/skill/SKILL.md
+++ b/crates/but/skill/SKILL.md
@@ -94,7 +94,7 @@ Rebasing applied branches onto the latest target IS `but pull` — never `move`,
 1. `but diff` — shows file and hunk IDs for uncommitted changes. Do not run plain `but status` first.
 2. Use file IDs when whole files belong in the commit; use hunk IDs (`<file-id>:<hunk-id>`) when only part of a file belongs. Omit IDs you don't want committed.
 3. New branch: `but commit <branch> -c -m "<msg>" --changes <id1>,<id2>` (no prior `but branch new` needed). Existing branch: omit `-c`.
-4. **Check the returned status** for remaining uncommitted changes. If a file you committed still shows as uncommitted, it may be dependency-locked — see "Stacked dependency / commit-lock recovery".
+4. **Check the returned status** for remaining uncommitted changes. If a file you committed still shows as uncommitted, it may be dependency-locked — see "Dependency conflict with another branch".
 
 Edge case: if wanted and unwanted edits are in the same diff hunk, GitButler cannot split that hunk by ID. Only when the task requires keeping part of that hunk uncommitted, temporarily edit the working tree to isolate the wanted lines, commit with `--changes`, then restore the leftover lines so they remain uncommitted.
 
@@ -142,15 +142,11 @@ To make one existing branch depend on another: `but move <child-branch> <parent-
 
 For stacked branches `but pr` is mandatory (it sets PR bases and stack metadata; `gh pr create` breaks that). To publish a whole stack: `but pr new <top-branch-id> -t`. Manage with `but pr auto-merge|set-draft|set-ready <selector>`. See `references/reference.md` for details.
 
-### Stacked dependency / commit-lock recovery
+### Dependency conflict with another branch
 
-A **dependency lock**: a file was originally committed on branch A, and you're committing changes to it on branch B. Symptom: `but commit` succeeds but the file still shows as uncommitted in the returned status.
+Changes that build on another branch's commits cannot land on an independent branch. `but commit` either creates the commit but reports the change as "could not be applied", or refuses outright — both name the branch the changes depend on and print the exact recovery command.
 
-Recovery: stack your branch on the dependency branch, then commit:
-
-1. `but status -fv` — identify which branch's commits own the file.
-2. `but move <your-branch-name> <dependency-branch-name>` (full branch **names**).
-3. Commit the file: `but commit <branch> -m "<msg>" --changes <id>`.
+Recovery: run the printed `but move <your-branch> <dependency-branch>` (full branch **names**) to stack the branches, then commit again with the same `--changes` IDs.
 
 If that `but move` fails, do NOT try `uncommit`, `squash`, or `undo` as a workaround — re-run `but status -fv` to confirm both branches exist and are applied, then retry with exact branch names.
 

--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -657,15 +657,43 @@ pub(crate) fn commit(
         commit_message
     };
 
-    let outcome = commit_create(
+    let outcome = match commit_create(
         ctx,
         relative_to,
         insert_side,
-        diff_specs,
+        diff_specs.clone(),
         final_commit_message,
         DryRun::No,
         guard.write_permission(),
-    )?;
+    ) {
+        Ok(outcome) => outcome,
+        Err(err) => {
+            // When the workspace re-merge trips over changes that build on
+            // another branch's commits (adjacent insertions evade hunk-level
+            // lock detection), name the branch and the stacking recovery
+            // instead of surfacing cherry-pick internals. Any other failure
+            // passes through untouched — the marker strings are but-rebase's
+            // two re-merge conflict errors.
+            let remerge_conflict = err.chain().any(|cause| {
+                let cause = cause.to_string();
+                cause.contains("Failed to merge bases while cherry picking")
+                    || cause.contains("merge could not be repeated without conflicts")
+            });
+            let explained = remerge_conflict
+                .then(|| ctx.workspace_and_db_with_perm(guard.read_permission()).ok())
+                .flatten()
+                .and_then(|(repo, ws, _db)| {
+                    rejection::commit_failure_error(&repo, &ws, &diff_specs, &target_branch.name)
+                });
+            return Err(match explained {
+                Some(explained) => {
+                    tracing::debug!(?err, "commit failed; reporting dependency conflict instead");
+                    explained.into()
+                }
+                None => err.into(),
+            });
+        }
+    };
 
     let rejected = if outcome.rejected_specs.is_empty() {
         Vec::new()
@@ -679,7 +707,12 @@ pub(crate) fn commit(
         // projection (or a rejected hunk could resolve to it). This relies on
         // `commit_create` not invalidating the cached workspace.
         let (repo, ws, _db) = ctx.workspace_and_db_with_perm(guard.read_permission())?;
-        rejection::explain_rejections(&repo, &ws, &outcome.rejected_specs)
+        rejection::explain_rejections(
+            &repo,
+            &ws,
+            &outcome.rejected_specs,
+            Some(&target_branch.name),
+        )
     };
 
     if let Some(out) = out.for_human() {

--- a/crates/but/src/command/legacy/rub/amend.rs
+++ b/crates/but/src/command/legacy/rub/amend.rs
@@ -30,7 +30,8 @@ pub(crate) fn uncommitted_to_commit_with_perm(
         (builder.into_diff_specs(), target_branch)
     };
 
-    let (new_commit, rejected) = amend_diff_specs(ctx, diff_specs, oid, perm)?;
+    let (new_commit, rejected) =
+        amend_diff_specs(ctx, diff_specs, oid, target_branch.as_deref(), perm)?;
     update_workspace_commit(ctx, false)?;
     if let Some(out) = out.for_human() {
         let new_commit = theme::new_commit_ref_with_perm(ctx, perm.read_permission(), new_commit)?;
@@ -50,6 +51,7 @@ fn amend_diff_specs(
     ctx: &mut Context,
     diff_specs: Vec<DiffSpec>,
     oid: ObjectId,
+    target_branch: Option<&str>,
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<(Option<ObjectId>, Vec<rejection::RejectedChange>)> {
     let mut meta = ctx.meta()?;
@@ -74,6 +76,6 @@ fn amend_diff_specs(
 
     // `materialize()` released the workspace borrow, so we can now look up why
     // the rejected changes were locked and to which branch each one depends on.
-    let rejected = rejection::explain_rejections(&repo, &ws, &rejected_specs);
+    let rejected = rejection::explain_rejections(&repo, &ws, &rejected_specs, target_branch);
     Ok((new_commit, rejected))
 }

--- a/crates/but/src/utils/rejection.rs
+++ b/crates/but/src/utils/rejection.rs
@@ -36,6 +36,11 @@ pub struct RejectedChange {
     /// Empty when the rejection was not caused by a dependency, or when the
     /// dependency could not be pinpointed to a specific hunk.
     pub dependencies: Vec<HunkDependency>,
+    /// When a dependency rejection cannot be pinpointed to a hunk (adjacent
+    /// insertions, for example, do not intersect as ranges), the branches
+    /// whose workspace commits also touch this path — the likely dependency.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub suspected_branches: Vec<String>,
 }
 
 /// A hunk that depends on one or more commits in the workspace.
@@ -73,6 +78,7 @@ pub fn explain_rejections(
     repo: &gix::Repository,
     ws: &Workspace,
     rejected_specs: &[(RejectionReason, DiffSpec)],
+    target_branch: Option<&str>,
 ) -> Vec<RejectedChange> {
     let needs_dependencies = rejected_specs
         .iter()
@@ -102,10 +108,21 @@ pub fn explain_rejections(
                 }
                 _ => Vec::new(),
             };
+            // The branch being committed to never explains its own rejection,
+            // so it is excluded from the suspects.
+            let suspected_branches = if dependencies.is_empty() && is_dependency_reason(*reason) {
+                branches_touching_path(repo, ws, spec.path.as_bstr())
+                    .into_iter()
+                    .filter(|branch| Some(branch.as_str()) != target_branch)
+                    .collect()
+            } else {
+                Vec::new()
+            };
             RejectedChange {
                 path: spec.path.clone(),
                 reason: *reason,
                 dependencies,
+                suspected_branches,
             }
         })
         .collect()
@@ -138,10 +155,34 @@ pub fn write_rejection_report<W: std::fmt::Write + ?Sized>(
         rejected.len(),
         noun,
     )?;
+    write_rejection_body(out, rejected, target_branch)
+}
+
+/// The per-change lines and the stacking suggestion shared by the
+/// partial-rejection report and the hard commit-failure error.
+fn write_rejection_body<W: std::fmt::Write + ?Sized>(
+    out: &mut W,
+    rejected: &[RejectedChange],
+    target_branch: Option<&str>,
+) -> std::fmt::Result {
+    let t = theme::get();
     for change in rejected {
         writeln!(out, "  {}", change.path.to_str_lossy())?;
         if change.dependencies.is_empty() {
-            writeln!(out, "    {}", reason_summary(change.reason))?;
+            if change.suspected_branches.is_empty() {
+                writeln!(out, "    {}", reason_summary(change.reason))?;
+            } else {
+                let branches = change
+                    .suspected_branches
+                    .iter()
+                    .map(|branch| t.local_branch.paint(branch).to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                writeln!(
+                    out,
+                    "    conflicts with commits on {branches} (edits touch the same file)",
+                )?;
+            }
             continue;
         }
         for dependency in &change.dependencies {
@@ -168,7 +209,7 @@ pub fn write_rejection_report<W: std::fmt::Write + ?Sized>(
         writeln!(out)?;
         writeln!(
             out,
-            "{} you can stack {} on top of {} to apply these changes:",
+            "{} to apply these changes, stack {} on top of {} and commit them again — commits already on the branch move with it:",
             t.hint.paint("Hint:"),
             t.local_branch.paint(target),
             t.local_branch.paint(dependency),
@@ -219,21 +260,31 @@ fn is_dependency_reason(reason: RejectionReason) -> bool {
 /// resolve it), a dependency couldn't be resolved to a branch, or dependencies
 /// span more than one branch.
 fn sole_dependency_branch(rejected: &[RejectedChange]) -> Option<&str> {
-    let mut branch = None;
+    let mut branch: Option<&str> = None;
     for change in rejected {
-        // Every rejected change must be dependency-locked; otherwise a single
-        // stack command wouldn't apply all of them.
-        if change.dependencies.is_empty() {
+        // Every rejected change must point at a dependency; otherwise a single
+        // stack command wouldn't apply all of them. When no hunk-level lock
+        // exists, the path-level suspects stand in.
+        if change.dependencies.is_empty() && change.suspected_branches.is_empty() {
             return None;
         }
-        for dependency in &change.dependencies {
-            for commit in &dependency.commits {
-                let name = commit.branch.as_deref()?;
-                match branch {
-                    None => branch = Some(name),
-                    Some(existing) if existing != name => return None,
-                    _ => {}
-                }
+        let names = change
+            .dependencies
+            .iter()
+            .flat_map(|dependency| &dependency.commits)
+            .map(|commit| commit.branch.as_deref())
+            .chain(
+                change
+                    .suspected_branches
+                    .iter()
+                    .map(|name| Some(name.as_str())),
+            );
+        for name in names {
+            let name = name?;
+            match branch {
+                None => branch = Some(name),
+                Some(existing) if existing != name => return None,
+                _ => {}
             }
         }
     }
@@ -318,6 +369,66 @@ pub fn branch_of_commit(
         }
     }
     None
+}
+
+/// The short names of all branches whose workspace commits touch `path` —
+/// the dependency suspects when hunk-level locks cannot pinpoint one. Callers
+/// filter out the branch being committed to. Only runs on failure paths, so
+/// the per-commit tree diffs are acceptable.
+fn branches_touching_path(
+    repo: &gix::Repository,
+    ws: &Workspace,
+    path: &bstr::BStr,
+) -> Vec<String> {
+    let mut branches = Vec::new();
+    for stack in &ws.stacks {
+        for segment in &stack.segments {
+            let touches = segment.commits.iter().any(|commit| {
+                but_core::diff::tree_changes(repo, commit.parent_ids.first().copied(), commit.id)
+                    .map(|changes| changes.iter().any(|change| change.path == path))
+                    .unwrap_or(false)
+            });
+            if touches && let Some(ref_name) = segment.ref_name() {
+                let name = ref_name.shorten().to_string();
+                if !branches.contains(&name) {
+                    branches.push(name);
+                }
+            }
+        }
+    }
+    branches
+}
+
+/// A targeted error for a commit that failed outright (not just rejected
+/// specs): when the attempted changes conflict with commits on another
+/// workspace branch, name that branch and the stacking recovery instead of
+/// letting internal cherry-pick errors surface. Returns `None` when no other
+/// branch can be blamed, so the caller keeps the original error.
+pub fn commit_failure_error(
+    repo: &gix::Repository,
+    ws: &Workspace,
+    specs: &[DiffSpec],
+    target_branch: &str,
+) -> Option<anyhow::Error> {
+    // Every attempted change is treated as a dependency-shaped rejection and
+    // runs through the standard explanation pipeline: hunk-level locks first,
+    // path-level suspects otherwise.
+    let assumed: Vec<(RejectionReason, DiffSpec)> = specs
+        .iter()
+        .map(|spec| (RejectionReason::WorkspaceMergeConflict, spec.clone()))
+        .collect();
+    let rejected = explain_rejections(repo, ws, &assumed, Some(target_branch));
+    if rejected
+        .iter()
+        .all(|change| change.dependencies.is_empty() && change.suspected_branches.is_empty())
+    {
+        return None;
+    }
+    let mut message = format!(
+        "Cannot commit to '{target_branch}': the selected changes conflict with commits on another branch.\n"
+    );
+    write_rejection_body(&mut message, &rejected, Some(target_branch)).ok()?;
+    Some(anyhow::anyhow!(message.trim_end().to_string()))
 }
 
 /// Whether two hunks touch the same lines on the new (worktree) side, which is

--- a/crates/but/tests/but/command/amend.rs
+++ b/crates/but/tests/but/command/amend.rs
@@ -55,7 +55,7 @@ Note: 1 change could not be applied:
   first
     line 1 depends on foo ([..])
 
-Hint: you can stack bar on top of foo to apply these changes:
+Hint: to apply these changes, stack bar on top of foo and commit them again — commits already on the branch move with it:
   but move bar foo
 
 "#]]);

--- a/crates/but/tests/but/command/commit.rs
+++ b/crates/but/tests/but/command/commit.rs
@@ -115,7 +115,7 @@ Note: 1 change could not be applied:
   first
     line 1 depends on foo ([..])
 
-Hint: you can stack bar on top of foo to apply these changes:
+Hint: to apply these changes, stack bar on top of foo and commit them again — commits already on the branch move with it:
   but move bar foo
 
 "#]]);
@@ -1357,6 +1357,49 @@ Error: Invalid file ID(s):
   'A' is a branch but must be an uncommitted file or hunk
 
 "#]]);
+}
+
+#[test]
+fn commit_of_adjacent_insertion_to_independent_branch_names_the_dependency() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
+
+    // The base owns file `M`. Branch A INSERTS a line…
+    env.file("M", "line one\nline two\nline three\n");
+    env.but("commit A -m 'baseline M' --changes M")
+        .assert()
+        .success();
+    env.file("M", "line one\ninserted by A\nline two\nline three\n");
+    env.but("commit A -m 'insert a line' --changes M")
+        .assert()
+        .success();
+
+    // …and the worktree inserts another line right next to it. Pure adjacent
+    // insertions do not intersect as hunk ranges, so no dependency lock is
+    // detected — but the two insertions still conflict when the workspace
+    // re-merges, so the change is rejected. The rejection report must name
+    // the conflicting branch and the stacking recovery, not just a vague
+    // reason.
+    env.file(
+        "M",
+        "line one\ninserted by A\ninserted in worktree\nline two\nline three\n",
+    );
+    env.but("commit api -c -m 'insert another line' --changes M")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Created new independent branch 'api'
+✓ Created commit 1#0 on branch api
+Note: 1 change could not be applied:
+  M
+    conflicts with commits on A (edits touch the same file)
+
+Hint: to apply these changes, stack api on top of A and commit them again — commits already on the branch move with it:
+  but move api A
+
+"#]]);
+
+    Ok(())
 }
 
 #[test]


### PR DESCRIPTION
When a commit is rejected (or hard-fails during workspace re-merge) because the selected changes depend on commits on another branch, the CLI previously either printed a vague no-lock rejection or surfaced a raw cherry-pick error with no recovery path.

Now both failure shapes name the branch that owns the conflicting commits and print the exact recovery: stack your branch on top of the dependency branch with `but move`, then commit again.

- `explain_rejections` attributes lock-less rejections by scanning per-commit tree changes for the touched paths (excluding the target branch, so it never blames itself).
- The hard re-merge failure on `but commit` is intercepted and rewritten through the same attribution pipeline instead of leaking a cherry-pick error.
- The skill recipe covers both shapes and warns against undo/uncommit detours.

Root cause of the previously undetected shape: adjacent pure insertions don't intersect as hunk ranges, so lock detection misses them and the re-merge fails downstream.