### PR TITLE
Write conflict markers when integrating upstream over conflicting uncommitted changes

### DIFF
--- a/crates/but-api/src/diff.rs
+++ b/crates/but-api/src/diff.rs
@@ -142,7 +142,9 @@ pub fn changes_in_worktree_with_perm(
 
     if !compute_deps_and_assignments {
         let repo = ctx.repo.get()?;
-        return Ok(but_core::diff::worktree_changes(&repo)?.into());
+        let changes: but_core::ui::WorktreeChanges =
+            but_core::diff::worktree_changes(&repo)?.into();
+        return Ok(changes.with_conflict_marker_paths(&repo).into());
     }
 
     let (repo, ws, mut db) = ctx.workspace_and_db_mut_with_perm(perm)?;
@@ -167,10 +169,11 @@ pub fn changes_in_worktree_with_perm(
     };
 
     trans.commit()?;
+    let changes = but_core::ui::WorktreeChanges::from(changes).with_conflict_marker_paths(&repo);
     drop((repo, ws, db));
 
     Ok(WorktreeChanges {
-        worktree_changes: changes.into(),
+        worktree_changes: changes,
         assignments,
         assignments_error: assignments_error.map(|err| serde_error::Error::new(&*err)),
         dependencies: dependencies.as_ref().ok().cloned(),

--- a/crates/but-api/src/workspace.rs
+++ b/crates/but-api/src/workspace.rs
@@ -587,7 +587,9 @@ pub fn workspace_integrate_upstream_only_with_perm(
             });
         }
 
-        let materialized = rebase.materialize()?;
+        // The dry-run preview reports conflicting uncommitted files via `worktree_conflicts`,
+        // so frontends warn (or refuse, like `but pull`) before this point is reached.
+        let materialized = rebase.materialize_with_worktree_conflict_markers()?;
         project_meta.persist_to_local_config(&repo)?;
 
         if let Some(ref_name) = materialized.workspace.ref_name()

--- a/crates/but-core/src/ui.rs
+++ b/crates/but-core/src/ui.rs
@@ -81,6 +81,17 @@ pub struct WorktreeChanges {
     pub changes: Vec<TreeChange>,
     /// Changes that were in the index that we can't handle. The user can see them and interact with them to clear them out before a commit can be made.
     pub ignored_changes: Vec<IgnoredWorktreeChange>,
+    /// Paths of `changes` whose current worktree content contains Git conflict markers,
+    /// e.g. after updating the workspace over conflicting uncommitted changes.
+    ///
+    /// These are ordinary committable changes - clients can display them as conflicted,
+    /// and editing the markers away clears the flag. Populated only in responses of the
+    /// worktree-changes API; empty in all other contexts.
+    #[cfg_attr(
+        feature = "export-schema",
+        schemars(schema_with = "but_schemars::bstring_lossy_vec")
+    )]
+    pub conflict_marker_paths: Vec<BStringForFrontend>,
 }
 
 impl WorktreeChanges {
@@ -90,6 +101,40 @@ impl WorktreeChanges {
         context_lines: u32,
     ) -> anyhow::Result<BString> {
         changes_to_unidiff(self.changes.clone(), repo, context_lines)
+    }
+
+    /// Fill [`Self::conflict_marker_paths`] by scanning the current worktree content of
+    /// `changes` for Git conflict markers.
+    ///
+    /// The scan is best-effort display metadata: unreadable, non-blob, or oversized files
+    /// are skipped rather than failing the whole listing.
+    pub fn with_conflict_marker_paths(mut self, repo: &gix::Repository) -> Self {
+        /// Larger files are assumed not to be hand-edited conflict resolutions.
+        const MAX_SCAN_SIZE: u64 = 8 * 1024 * 1024;
+        self.conflict_marker_paths = self
+            .changes
+            .iter()
+            .filter(|change| {
+                matches!(
+                    &change.status,
+                    TreeStatus::Addition { state, .. }
+                        | TreeStatus::Modification { state, .. }
+                        | TreeStatus::Rename { state, .. }
+                    if matches!(state.kind, EntryKind::Blob | EntryKind::BlobExecutable)
+                )
+            })
+            .filter(|change| {
+                let Some(path) = repo.workdir_path(&change.path_bytes) else {
+                    return false;
+                };
+                std::fs::symlink_metadata(&path)
+                    .is_ok_and(|md| md.is_file() && md.len() <= MAX_SCAN_SIZE)
+                    && std::fs::read(&path)
+                        .is_ok_and(|content| crate::worktree::contains_conflict_markers(&content))
+            })
+            .map(|change| change.path.clone())
+            .collect();
+        self
     }
 }
 
@@ -105,6 +150,7 @@ impl From<crate::WorktreeChanges> for WorktreeChanges {
         WorktreeChanges {
             changes: changes.into_iter().map(Into::into).collect(),
             ignored_changes,
+            conflict_marker_paths: Vec::new(),
         }
     }
 }

--- a/crates/but-core/src/worktree/checkout/function.rs
+++ b/crates/but-core/src/worktree/checkout/function.rs
@@ -17,11 +17,14 @@ use super::{Options, Outcome, utils::merge_worktree_changes_into_destination_or_
 /// `new_head_id^{tree}`.
 ///
 /// If `new_head_id` is a *commit*, we will also set `HEAD` (or the ref it points to if symbolic) to the `new_head_id`.
-/// We will also update the `.git/index` to match the `new_head_id^{tree}`.
+/// We will also update the `.git/index` to match the checked-out tree. Note that this is usually
+/// `new_head_id^{tree}`, but when uncommitted worktree changes are preserved across the checkout
+/// it is a synthesized variant of that tree which carries them.
 /// GitButler-conflicted commits are rejected by default before any worktree, index, or ref update.
 ///
 /// We will always handle changes in the worktree safely to avoid loss of uncommitted information. This also means that deletions
-/// never cause us to conflict. Conflicted files that would be checked out will cause an error.
+/// never cause us to conflict. Conflicted files that would be checked out will cause an error,
+/// unless [`Options::allow_worktree_conflicts`] is set to keep them with conflict markers instead.
 ///
 /// #### Note: No rename tracking
 ///
@@ -36,6 +39,7 @@ pub fn safe_checkout_from_head(
         skip_head_update,
         merge_base_override,
         allow_conflicted_commit_checkout,
+        allow_worktree_conflicts,
     }: Options,
 ) -> anyhow::Result<Outcome> {
     let current_head_id = repo.head_tree_id_or_empty()?.detach();
@@ -67,6 +71,7 @@ pub fn safe_checkout_from_head(
         destination_tree.id,
         &mut opts,
         merge_base_override,
+        allow_worktree_conflicts,
     )?
     .map(|(snapshot_id, new_destination_id)| {
         if let Some(id) = new_destination_id {

--- a/crates/but-core/src/worktree/checkout/mod.rs
+++ b/crates/but-core/src/worktree/checkout/mod.rs
@@ -18,6 +18,12 @@ pub struct Options {
     /// conflict workflow instead. Rebase materialization may opt in when it
     /// intentionally created the conflicted commit it is about to materialize.
     pub allow_conflicted_commit_checkout: bool,
+    /// If `true`, proceed when uncommitted worktree changes conflict with the checkout
+    /// destination, writing Git-style conflict markers into the affected files.
+    ///
+    /// The markers become part of the uncommitted changes, without conflict entries in the index.
+    /// By default such a checkout is refused so no conflict markers ever appear on disk.
+    pub allow_worktree_conflicts: bool,
 }
 
 /// The successful outcome of [super::safe_checkout_from_head()] operation.

--- a/crates/but-core/src/worktree/checkout/utils.rs
+++ b/crates/but-core/src/worktree/checkout/utils.rs
@@ -53,6 +53,9 @@ use crate::{TreeStatus, ext::ObjectStorageExt, snapshot, worktree::checkout::Out
 ///   to checkout the whole destination tree.
 ///
 ///   Normal added or modified checkout paths are still added by the caller.
+/// * `allow_worktree_conflicts` - If `true`, do not refuse when preserved worktree changes conflict
+///   with `destination_tree_id`. The conflicting files are kept with Git-style conflict markers,
+///   as part of the replacement destination tree.
 pub fn merge_worktree_changes_into_destination_or_keep_snapshot(
     files_to_checkout: &[(ChangeKind, BString)],
     repo: &gix::Repository,
@@ -60,6 +63,7 @@ pub fn merge_worktree_changes_into_destination_or_keep_snapshot(
     destination_tree_id: gix::ObjectId,
     checkout_opts: &mut git2::build::CheckoutBuilder,
     merge_base_override: Option<gix::ObjectId>,
+    allow_worktree_conflicts: bool,
 ) -> anyhow::Result<Option<(gix::ObjectId, Option<gix::ObjectId>)>> {
     if files_to_checkout.is_empty() {
         return Ok(None);
@@ -235,39 +239,56 @@ pub fn merge_worktree_changes_into_destination_or_keep_snapshot(
                         merge_base_override,
                     },
                 )?;
-                let new_destination_id =
-                    if let Some(mut worktree_cherry_pick) = resolve.worktree_cherry_pick {
-                        // re-apply snapshot of just what we need and see if they apply cleanly.
-                        let unresolved = TreatAsUnresolved::git();
-                        if worktree_cherry_pick.has_unresolved_conflicts(unresolved) {
-                            let mut paths = worktree_cherry_pick
-                                .conflicts
-                                .iter()
-                                .filter(|c| c.is_unresolved(unresolved))
-                                .map(|c| format!("{:?}", c.ours.location()))
-                                .collect::<Vec<_>>();
-                            paths.sort();
-                            paths.dedup();
-                            bail_precondition!(
-                                "Uncommitted files would be overwritten by checkout: {}",
-                                paths.join(", ")
-                            );
-                        }
+                let new_destination_id = if let Some(mut worktree_cherry_pick) =
+                    resolve.worktree_cherry_pick
+                {
+                    // re-apply snapshot of just what we need and see if they apply cleanly.
+                    let unresolved = TreatAsUnresolved::git();
+                    let mut paths = worktree_cherry_pick
+                        .conflicts
+                        .iter()
+                        .filter(|c| c.is_unresolved(unresolved))
+                        .filter(|c| !allow_worktree_conflicts || !merged_with_conflict_markers(c))
+                        .map(|c| format!("{:?}", c.ours.location()))
+                        .collect::<Vec<_>>();
+                    if !paths.is_empty() {
+                        paths.sort();
+                        paths.dedup();
+                        bail_precondition!(
+                            "Uncommitted files would be overwritten by checkout: {}",
+                            paths.join(", ")
+                        );
+                    }
 
-                        let res = Some(worktree_cherry_pick.tree.write()?.detach());
-                        if let Some(memory) = repo_in_memory.objects.take_object_memory() {
-                            memory.persist(repo_in_memory)?;
-                        }
-                        res
-                    } else {
-                        None
-                    };
+                    let res = Some(worktree_cherry_pick.tree.write()?.detach());
+                    if let Some(memory) = repo_in_memory.objects.take_object_memory() {
+                        memory.persist(repo_in_memory)?;
+                    }
+                    res
+                } else {
+                    None
+                };
                 return Ok(Some((out.snapshot_tree, new_destination_id)));
                 // TODO: deal with index, but to do that it needs to be merged with destination tree!
             }
         }
     }
     Ok(None)
+}
+
+/// `true` if the unresolved `conflict` was merged into the tree as a newly written blob
+/// containing Git-style conflict markers, so checking out that tree keeps both sides visible.
+///
+/// Binary, oversized, deleted, or renamed files cannot be represented that way: their merge
+/// picks one side's blob instead, so checking that out would silently drop the other side.
+fn merged_with_conflict_markers(conflict: &gix::merge::tree::Conflict) -> bool {
+    let Some(merge) = conflict.content_merge() else {
+        return false;
+    };
+    let (ours, theirs) = conflict.changes_in_resolution();
+    matches!(merge.resolution, gix::merge::blob::Resolution::Conflict)
+        && merge.merged_blob_id.as_ref() != ours.entry_mode_and_id().1
+        && merge.merged_blob_id.as_ref() != theirs.entry_mode_and_id().1
 }
 
 #[derive(Default)]

--- a/crates/but-core/src/worktree/mod.rs
+++ b/crates/but-core/src/worktree/mod.rs
@@ -7,6 +7,33 @@ use bstr::BStr;
 pub use checkout::function::safe_checkout_from_head;
 use gix::filter::plumbing::pipeline::convert::ToGitOutcome;
 
+/// `true` if `content` contains a complete set of Git conflict markers: a `<<<<<<<` line,
+/// later followed by a `=======` line, later followed by a `>>>>>>>` line.
+///
+/// Content containing NUL bytes is considered binary and never reported as marked.
+pub fn contains_conflict_markers(content: &[u8]) -> bool {
+    fn is_marker_line(line: &[u8], marker: &[u8; 7]) -> bool {
+        line.strip_prefix(marker)
+            .is_some_and(|rest| rest.is_empty() || matches!(rest[0], b' ' | b'\r'))
+    }
+    if content.contains(&0) {
+        return false;
+    }
+    let mut after_ours = false;
+    let mut after_separator = false;
+    for line in content.split(|byte| *byte == b'\n') {
+        if is_marker_line(line, b"<<<<<<<") {
+            after_ours = true;
+            after_separator = false;
+        } else if after_ours && is_marker_line(line, b"=======") {
+            after_separator = true;
+        } else if after_separator && is_marker_line(line, b">>>>>>>") {
+            return true;
+        }
+    }
+    false
+}
+
 /// Read a worktree file into `buf` after converting it to what Git *would* store.
 /// Useful if `buf` should be turned into a blob.
 /// `md` is used to know how to read the entry, and we assume that it was pre-filtered

--- a/crates/but-core/tests/core/diff/ui.rs
+++ b/crates/but-core/tests/core/diff/ui.rs
@@ -366,7 +366,8 @@ fn worktree_changes() -> anyhow::Result<()> {
       "path": "removed-in-index-changed-in-worktree",
       "status": "TreeIndex"
     }
-  ]
+  ],
+  "conflictMarkerPaths": []
 }
 "#]]
     );

--- a/crates/but-core/tests/core/worktree/checkout.rs
+++ b/crates/but-core/tests/core/worktree/checkout.rs
@@ -462,33 +462,7 @@ RM file-to-be-renamed-in-index -> file-renamed-in-index
         .raw()
     );
 
-    // In the target tree, make a surgical edit (one changed line) so the changes should still apply cleany
-    let new_commit = build_commit(
-        &repo,
-        |tree| {
-            let blob_id = repo.write_blob(
-                b"5
-6
-7
-8
-9
-10
-11
-12
-13
-14
-15
-16
-this will cause a conflict
-17
-18
-",
-            )?;
-            tree.upsert("file", EntryKind::Blob, blob_id)?;
-            Ok(())
-        },
-        "edited 'file' (add single line)",
-    )?;
+    let new_commit = commit_conflicting_with_worktree_edit_of_file(&repo)?;
 
     let err = safe_checkout_from_head(new_commit.id, &repo, Default::default()).unwrap_err();
     assert_eq!(
@@ -534,6 +508,128 @@ RM file-to-be-renamed-in-index -> file-renamed-in-index
 ?? file-renamed
 
 "#]]
+    );
+
+    Ok(())
+}
+
+/// In the `mixed-hunk-modifications` scenario, commit an edit to `file` that conflicts
+/// with the uncommitted worktree changes to the same lines.
+fn commit_conflicting_with_worktree_edit_of_file(
+    repo: &gix::Repository,
+) -> anyhow::Result<gix::Commit<'_>> {
+    build_commit(
+        repo,
+        |tree| {
+            let blob_id = repo.write_blob(
+                b"5
+6
+7
+8
+9
+10
+11
+12
+13
+14
+15
+16
+this will cause a conflict
+17
+18
+",
+            )?;
+            tree.upsert("file", EntryKind::Blob, blob_id)?;
+            Ok(())
+        },
+        "edited 'file' (add single line)",
+    )
+}
+
+#[test]
+fn worktree_conflicts_are_kept_with_conflict_markers_when_allowed() -> anyhow::Result<()> {
+    let (repo, _tmp) = writable_scenario("mixed-hunk-modifications");
+    let file_path = repo.workdir_path("file").unwrap();
+
+    let new_commit = commit_conflicting_with_worktree_edit_of_file(&repo)?;
+
+    safe_checkout_from_head(
+        new_commit.id,
+        &repo,
+        checkout::Options {
+            allow_worktree_conflicts: true,
+            ..Default::default()
+        },
+    )?;
+
+    // The conflicting uncommitted changes are kept, with conflict markers.
+    let actual = std::fs::read_to_string(&file_path)?;
+    snapbox::assert_data_eq!(
+        actual.to_debug(),
+        snapbox::str![[r#"
+"1\n2\n3\n4\n5\n6-7\n8\n9\nten\neleven\n12\n20\n21\n22\n15\n16\n<<<<<<< ours\nthis will cause a conflict\n17\n18\n=======\n>>>>>>> theirs\n"
+
+"#]].raw()
+    );
+    snapbox::assert_data_eq!(
+        visualize_commit_graph_all(&repo)?,
+        snapbox::str![[r#"
+* 439723b (HEAD -> main) edited 'file' (add single line)
+* 647cc94 init
+
+"#]]
+    );
+    snapbox::assert_data_eq!(
+        git_status(&repo)?,
+        snapbox::str![[r#"
+M  file
+M  file-in-index
+RM file-to-be-renamed-in-index -> file-renamed-in-index
+ D file-to-be-renamed
+?? file-renamed
+
+"#]]
+    );
+
+    Ok(())
+}
+
+#[test]
+fn binary_worktree_conflicts_are_still_refused_when_markers_are_allowed() -> anyhow::Result<()> {
+    let (repo, _tmp) = writable_scenario("mixed-hunk-modifications");
+    let file_path = repo.workdir_path("file").unwrap();
+    let worktree_content_before = std::fs::read(&file_path)?;
+
+    // The destination turns `file` into binary content, so the conflict with the
+    // uncommitted text edits cannot be represented with conflict markers - the merge
+    // would pick the destination blob and silently drop the uncommitted version.
+    let new_commit = build_commit(
+        &repo,
+        |tree| {
+            let blob_id = repo.write_blob(b"\x00\x01\x02binary")?;
+            tree.upsert("file", EntryKind::Blob, blob_id)?;
+            Ok(())
+        },
+        "turn 'file' into binary content",
+    )?;
+
+    let err = safe_checkout_from_head(
+        new_commit.id,
+        &repo,
+        checkout::Options {
+            allow_worktree_conflicts: true,
+            ..Default::default()
+        },
+    )
+    .unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "Uncommitted files would be overwritten by checkout: \"file\"",
+    );
+    assert_eq!(
+        std::fs::read(&file_path)?,
+        worktree_content_before,
+        "the uncommitted content is untouched"
     );
 
     Ok(())

--- a/crates/but-core/tests/core/worktree/conflict_markers.rs
+++ b/crates/but-core/tests/core/worktree/conflict_markers.rs
@@ -1,0 +1,69 @@
+use but_core::worktree::contains_conflict_markers;
+use but_testsupport::writable_scenario;
+
+#[test]
+fn detects_a_complete_marker_sequence() {
+    let marked = b"1\n<<<<<<< ours\ntheir line\n=======\nour line\n>>>>>>> theirs\n2\n";
+    assert!(contains_conflict_markers(marked));
+
+    let crlf = b"<<<<<<< ours\r\na\r\n=======\r\nb\r\n>>>>>>> theirs\r\n";
+    assert!(contains_conflict_markers(crlf));
+
+    let diff3 = b"<<<<<<< ours\na\n||||||| base\nc\n=======\nb\n>>>>>>> theirs\n";
+    assert!(contains_conflict_markers(diff3));
+
+    let unlabelled = b"<<<<<<<\na\n=======\nb\n>>>>>>>\n";
+    assert!(contains_conflict_markers(unlabelled));
+}
+
+#[test]
+fn incomplete_or_lookalike_sequences_are_not_detected() {
+    assert!(!contains_conflict_markers(b""));
+    assert!(!contains_conflict_markers(b"plain content\n"));
+    // A separator line alone, like in setext markdown headers or tables.
+    assert!(!contains_conflict_markers(b"header\n=======\ncontent\n"));
+    // Start marker without the rest.
+    assert!(!contains_conflict_markers(b"<<<<<<< ours\ncontent\n"));
+    // Out of order.
+    assert!(!contains_conflict_markers(
+        b">>>>>>> theirs\n=======\n<<<<<<< ours\n"
+    ));
+    // Markers must start the line and be exactly 7 characters wide.
+    assert!(!contains_conflict_markers(
+        b" <<<<<<< ours\n=======\n>>>>>>> theirs\n"
+    ));
+    assert!(!contains_conflict_markers(
+        b"<<<<<<<< ours\n=======\n>>>>>>>> theirs\n"
+    ));
+    // Binary content is never considered marked.
+    assert!(!contains_conflict_markers(
+        b"\x00<<<<<<< ours\n=======\n>>>>>>> theirs\n"
+    ));
+}
+
+#[test]
+fn worktree_changes_flag_files_with_conflict_markers() -> anyhow::Result<()> {
+    let (repo, _tmp) = writable_scenario("mixed-hunk-modifications");
+
+    std::fs::write(
+        repo.workdir_path("file").unwrap(),
+        "1\n<<<<<<< ours\nupdated\n=======\noriginal\n>>>>>>> theirs\n",
+    )?;
+
+    let changes: but_core::ui::WorktreeChanges = but_core::diff::worktree_changes(&repo)?.into();
+    assert_eq!(
+        changes.conflict_marker_paths,
+        Vec::<but_serde::BStringForFrontend>::new(),
+        "the plain conversion does not scan for markers"
+    );
+
+    let changes = changes.with_conflict_marker_paths(&repo);
+    assert_eq!(
+        changes.conflict_marker_paths,
+        vec![but_serde::BStringForFrontend::from("file")],
+        "only the file with a complete marker sequence is flagged, \
+         other dirty files stay unflagged"
+    );
+
+    Ok(())
+}

--- a/crates/but-core/tests/core/worktree/mod.rs
+++ b/crates/but-core/tests/core/worktree/mod.rs
@@ -1,4 +1,5 @@
 mod checkout;
+mod conflict_markers;
 
 mod utils {
     /// Using the `repo` `HEAD` commit, build a new commit based on its tree with `edit` and `message`, and return the new commit.

--- a/crates/but-hunk-assignment/src/lib.rs
+++ b/crates/but-hunk-assignment/src/lib.rs
@@ -343,13 +343,6 @@ impl From<but_core::ui::WorktreeChanges> for WorktreeChanges {
     }
 }
 
-impl From<but_core::WorktreeChanges> for WorktreeChanges {
-    fn from(worktree_changes: but_core::WorktreeChanges) -> Self {
-        let ui_changes: but_core::ui::WorktreeChanges = worktree_changes.into();
-        ui_changes.into()
-    }
-}
-
 impl HunkAssignmentRequest {
     pub fn matches_assignment(&self, assignment: &HunkAssignment) -> bool {
         self.path_bytes == assignment.path_bytes && self.hunk_header == assignment.hunk_header

--- a/crates/but-rebase/src/graph_rebase/materialize.rs
+++ b/crates/but-rebase/src/graph_rebase/materialize.rs
@@ -15,7 +15,26 @@ use crate::graph_rebase::{
 
 impl<'ws, 'graph, M: RefMetadata> SuccessfulRebase<'ws, 'graph, M> {
     /// Materializes a history rewrite
-    pub fn materialize(mut self) -> Result<MaterializeOutcome<'ws, 'graph, M>> {
+    pub fn materialize(self) -> Result<MaterializeOutcome<'ws, 'graph, M>> {
+        self.materialize_impl(false)
+    }
+
+    /// Like [`Self::materialize`], but if uncommitted worktree changes conflict with the
+    /// new workspace head, keep them with Git-style conflict markers instead of refusing
+    /// the checkout.
+    ///
+    /// Only use this when the caller has surfaced the conflicting paths to the user first,
+    /// like the upstream integration preview does.
+    pub fn materialize_with_worktree_conflict_markers(
+        self,
+    ) -> Result<MaterializeOutcome<'ws, 'graph, M>> {
+        self.materialize_impl(true)
+    }
+
+    fn materialize_impl(
+        mut self,
+        allow_worktree_conflicts: bool,
+    ) -> Result<MaterializeOutcome<'ws, 'graph, M>> {
         let repo = self.repo.clone();
         if let Some(memory) = self.repo.objects.take_object_memory() {
             memory.persist(self.repo)?;
@@ -55,6 +74,7 @@ impl<'ws, 'graph, M: RefMetadata> SuccessfulRebase<'ws, 'graph, M> {
                             skip_head_update: true,
                             merge_base_override,
                             allow_conflicted_commit_checkout: true,
+                            allow_worktree_conflicts,
                         },
                     )?;
                 }

--- a/crates/but-schemars/src/lib.rs
+++ b/crates/but-schemars/src/lib.rs
@@ -110,6 +110,19 @@ pub fn object_id_vec(generate: &mut schemars::SchemaGenerator) -> schemars::Sche
     generate.subschema_for::<Vec<String>>()
 }
 
+/// Use on `Vec<BStringForFrontend>` fields, which serialize as lossy strings.
+///
+/// ```rust,ignore
+/// #[derive(serde::Serialize, schemars::JsonSchema)]
+/// struct Example {
+///     #[schemars(schema_with = "but_schemars::bstring_lossy_vec")]
+///     paths: Vec<but_serde::BStringForFrontend>,
+/// }
+/// ```
+pub fn bstring_lossy_vec(generate: &mut schemars::SchemaGenerator) -> schemars::Schema {
+    generate.subschema_for::<Vec<String>>()
+}
+
 /// Use on `gix::refs::FullName` fields serialized with
 /// `but_serde::fullname_lossy`.
 ///

--- a/crates/but/src/command/legacy/status/json.rs
+++ b/crates/but/src/command/legacy/status/json.rs
@@ -34,6 +34,10 @@ pub(crate) struct WorkspaceStatus {
     /// Uncommitted files with unresolved merge conflicts in the index; not committable until resolved.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     conflicted_files: Vec<String>,
+    /// Uncommitted files whose content contains Git conflict markers; committable, but the
+    /// markers should be edited away first.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    files_with_conflict_markers: Vec<String>,
     /// The stacks that are applied in the current workspace
     stacks: Vec<Stack>,
     /// The most recent common merge base between all applied stacks and the target upstream branch
@@ -55,24 +59,6 @@ pub(crate) struct UpstreamState {
     /// List of upstream commits (only populated when requested with --upstream flag)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub upstream_commits: Option<Vec<Commit>>,
-}
-
-impl WorkspaceStatus {
-    pub fn new(
-        uncommitted_changes: Vec<FileChange>,
-        conflicted_files: Vec<String>,
-        stacks: Vec<Stack>,
-        merge_base: Commit,
-        upstream_state: UpstreamState,
-    ) -> Self {
-        Self {
-            uncommitted_changes,
-            conflicted_files,
-            stacks,
-            merge_base,
-            upstream_state,
-        }
-    }
 }
 
 /// Represents a stack of branches applied in the current workspace
@@ -714,11 +700,16 @@ pub(super) fn build_workspace_status_json(
         }
     };
 
-    Ok(WorkspaceStatus::new(
-        json_uncommitted_changes,
-        status_ctx.conflicted_paths.clone(),
-        json_stacks,
-        merge_base_commit,
-        upstream_state_json,
-    ))
+    Ok(WorkspaceStatus {
+        uncommitted_changes: json_uncommitted_changes,
+        conflicted_files: status_ctx.conflicted_paths.clone(),
+        files_with_conflict_markers: status_ctx
+            .conflict_marker_paths
+            .iter()
+            .map(|path| path.to_string())
+            .collect(),
+        stacks: json_stacks,
+        merge_base: merge_base_commit,
+        upstream_state: upstream_state_json,
+    })
 }

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -189,6 +189,9 @@ struct StatusContext<'a> {
     worktree_changes: Vec<ui::TreeChange>,
     /// Uncommitted files with unresolved merge conflicts in the index; not committable until resolved.
     conflicted_paths: Vec<String>,
+    /// Uncommitted files whose content contains Git conflict markers; committable, but the
+    /// markers should be edited away first.
+    conflict_marker_paths: Vec<but_serde::BStringForFrontend>,
     common_merge_base_data: CommonMergeBase,
     target_tip_id: gix::ObjectId,
     upstream_state: Option<UpstreamState>,
@@ -417,6 +420,10 @@ fn build_status_context<'a>(
         .map(|change| change.path.to_string())
         .collect();
     conflicted_paths.sort();
+    let conflict_marker_paths = worktree_changes
+        .worktree_changes
+        .conflict_marker_paths
+        .clone();
 
     let id_map = IdMap::new(
         stacks,
@@ -555,6 +562,7 @@ fn build_status_context<'a>(
         stack_details,
         worktree_changes: worktree_changes.worktree_changes.changes,
         conflicted_paths,
+        conflict_marker_paths,
         common_merge_base_data,
         target_tip_id,
         upstream_state,
@@ -636,14 +644,19 @@ fn print_conflicted_files_warning(
     status_ctx: &StatusContext<'_>,
     output: &mut StatusOutput<'_>,
 ) -> anyhow::Result<()> {
-    if status_ctx.conflicted_paths.is_empty() {
-        return Ok(());
-    }
     let t = crate::theme::get();
-    output.warning(Vec::from([Span::styled(
-        "⚠ Uncommitted file conflicts: choose the desired file state, then run `git add -- <path>`.",
-        t.attention,
-    )]))?;
+    if !status_ctx.conflicted_paths.is_empty() {
+        output.warning(Vec::from([Span::styled(
+            "⚠ Uncommitted file conflicts: choose the desired file state, then run `git add -- <path>`.",
+            t.attention,
+        )]))?;
+    }
+    if !status_ctx.conflict_marker_paths.is_empty() {
+        output.warning(Vec::from([Span::styled(
+            "⚠ Files marked {conflict markers} contain conflict markers: edit the files to resolve, then commit.",
+            t.attention,
+        )]))?;
+    }
     Ok(())
 }
 
@@ -1164,6 +1177,16 @@ fn print_assignments(
 
         let status = state.as_ref().map(status_letter_ui).unwrap_or_default();
 
+        let mut path_spans = Vec::from([path]);
+        if status_ctx
+            .conflict_marker_paths
+            .iter()
+            .any(|marked| **marked == fa.path)
+        {
+            path_spans.push(Span::raw(" "));
+            path_spans.push(Span::styled("{conflict markers}", t.error));
+        }
+
         let first_assignment = &fa.assignments[0];
         let cli_id = &first_assignment.cli_id;
         let id_padding = " ".repeat(max_id_width.saturating_sub(cli_id.len()) + 1);
@@ -1182,7 +1205,7 @@ fn print_assignments(
                 Span::raw(id_padding),
             ]),
             status: Vec::from([Span::raw(status.to_string()), Span::raw(" ")]),
-            path: Vec::from([path]),
+            path: path_spans,
         };
 
         if unstaged {

--- a/packages/but-sdk/src/generated/graph/index.d.ts
+++ b/packages/but-sdk/src/generated/graph/index.d.ts
@@ -2922,6 +2922,15 @@ export type WorktreeChanges = {
   changes: Array<TreeChange>;
   /** Changes that were in the index that we can't handle. The user can see them and interact with them to clear them out before a commit can be made. */
   ignoredChanges: Array<IgnoredWorktreeChange>;
+  /**
+   * Paths of `changes` whose current worktree content contains Git conflict markers,
+   * e.g. after updating the workspace over conflicting uncommitted changes.
+   *
+   * These are ordinary committable changes - clients can display them as conflicted,
+   * and editing the markers away clears the flag. Populated only in responses of the
+   * worktree-changes API; empty in all other contexts.
+   */
+  conflictMarkerPaths: Array<string>;
   assignments: Array<HunkAssignment>;
   assignmentsError: SerdeError | null;
   dependencies: HunkDependencies | null;

--- a/packages/but-sdk/src/generated/linear/index.d.ts
+++ b/packages/but-sdk/src/generated/linear/index.d.ts
@@ -2919,6 +2919,15 @@ export type WorktreeChanges = {
   changes: Array<TreeChange>;
   /** Changes that were in the index that we can't handle. The user can see them and interact with them to clear them out before a commit can be made. */
   ignoredChanges: Array<IgnoredWorktreeChange>;
+  /**
+   * Paths of `changes` whose current worktree content contains Git conflict markers,
+   * e.g. after updating the workspace over conflicting uncommitted changes.
+   *
+   * These are ordinary committable changes - clients can display them as conflicted,
+   * and editing the markers away clears the flag. Populated only in responses of the
+   * worktree-changes API; empty in all other contexts.
+   */
+  conflictMarkerPaths: Array<string>;
   assignments: Array<HunkAssignment>;
   assignmentsError: SerdeError | null;
   dependencies: HunkDependencies | null;


### PR DESCRIPTION
Updating the workspace with uncommitted changes that conflict with the incoming updates always failed at checkout time with 'Uncommitted files would be overwritten' — even though the GUI's update modal explicitly tells the user they can proceed and conflict markers will be added to their uncommitted work.

The safe checkout already computes the merged tree containing the marker blobs, then discards it and refuses. This adds an `allow_worktree_conflicts` checkout option that keeps that tree instead, so conflicting files stay on disk as uncommitted changes with Git-style conflict markers (no index conflict entries).

Upstream integration opts in via `materialize_with_worktree_conflict_markers()`, which is justified because its dry-run preview surfaces the conflicting paths to frontends first: the GUI warns before the user proceeds, and `but pull` still refuses at its own preview layer with the parked-commit recipe, so CLI behavior is unchanged. All other checkout and materialize callers keep the refusal default.

---

Update: instead of writing conflict entries into `.git/index` (see review discussion), the worktree-changes API now scans dirty files for a complete conflict-marker sequence and reports them as `conflictMarkerPaths`, so clients can display them as conflicted. The index stays clean, the files remain ordinary committable changes, and editing the markers away clears the flag on its own. `but status` marks such files with `{conflict markers}` and lists them as `filesWithConflictMarkers` in JSON output; GUI display can hook into the same field.
