### PR TITLE
refactor(tui): use _move2

### DIFF
--- a/crates/but/src/command/legacy/mod.rs
+++ b/crates/but/src/command/legacy/mod.rs
@@ -19,7 +19,6 @@ pub mod discard;
 pub mod forge;
 pub mod land;
 pub mod mcp;
-#[cfg(all(feature = "legacy", feature = "but-2"))]
 pub mod move2;
 pub mod oplog;
 pub mod pick;

--- a/crates/but/src/command/legacy/move2.rs
+++ b/crates/but/src/command/legacy/move2.rs
@@ -28,6 +28,7 @@ use crate::{
 pub enum MoveOutcome {
     Commits {
         sources: NonEmpty<gix::ObjectId>,
+        moved_commits: NonEmpty<gix::ObjectId>,
         target: Option<MoveTarget>,
         new_branch_name: Option<FullName>,
     },
@@ -52,6 +53,7 @@ impl CliOutputHuman for MoveOutcome {
         match self {
             Self::Commits {
                 sources,
+                moved_commits: _,
                 target,
                 new_branch_name,
             } => {
@@ -110,6 +112,7 @@ impl CliOutputHuman for MoveOutcome {
     }
 }
 
+#[cfg_attr(not(feature = "but-2"), expect(dead_code))]
 pub fn r#move(
     ctx: &mut Context,
     _out: IntermediateChannel<'_>,
@@ -121,11 +124,11 @@ pub fn r#move(
 
     let move_op = resolve(ctx, guard.write_permission(), args, &id_map)?;
 
-    run(ctx, &mut meta, guard.write_permission(), move_op)
+    Ok(run(ctx, &mut meta, guard.write_permission(), move_op)?)
 }
 
 #[derive(Clone)]
-enum MoveOperation {
+pub enum MoveOperation {
     CommitsRelativeTo(MoveCommitsRelativeToOperation),
     CommitsToNewBranch(MoveCommitsToNewBranchOperation),
     ChangesRelativeTo(MoveChangesRelativeToOperation),
@@ -135,9 +138,9 @@ enum MoveOperation {
 }
 
 #[derive(Clone)]
-struct MoveCommitsRelativeToOperation {
-    sources: NonEmpty<gix::ObjectId>,
-    target: MoveTarget,
+pub struct MoveCommitsRelativeToOperation {
+    pub sources: NonEmpty<gix::ObjectId>,
+    pub target: MoveTarget,
 }
 
 impl MoveCommitsRelativeToOperation {
@@ -175,9 +178,9 @@ impl MoveCommitsRelativeToOperation {
 }
 
 #[derive(Clone)]
-struct MoveCommitsToNewBranchOperation {
-    sources: NonEmpty<gix::ObjectId>,
-    branch_name: Option<FullName>,
+pub struct MoveCommitsToNewBranchOperation {
+    pub sources: NonEmpty<gix::ObjectId>,
+    pub branch_name: Option<FullName>,
 }
 
 impl MoveCommitsToNewBranchOperation {
@@ -203,10 +206,10 @@ impl MoveCommitsToNewBranchOperation {
 }
 
 #[derive(Clone)]
-struct MoveChangesRelativeToOperation {
-    source_commit_id: gix::ObjectId,
-    changes: NonEmpty<DiffSpec>,
-    target: MoveTarget,
+pub struct MoveChangesRelativeToOperation {
+    pub source_commit_id: gix::ObjectId,
+    pub changes: NonEmpty<DiffSpec>,
+    pub target: MoveTarget,
 }
 
 impl MoveChangesRelativeToOperation {
@@ -253,10 +256,10 @@ impl MoveChangesRelativeToOperation {
 }
 
 #[derive(Clone)]
-struct MoveChangesToNewBranchOperation {
-    source_commit_id: gix::ObjectId,
-    changes: NonEmpty<DiffSpec>,
-    branch_name: Option<FullName>,
+pub struct MoveChangesToNewBranchOperation {
+    pub source_commit_id: gix::ObjectId,
+    pub changes: NonEmpty<DiffSpec>,
+    pub branch_name: Option<FullName>,
 }
 
 impl MoveChangesToNewBranchOperation {
@@ -294,9 +297,9 @@ impl MoveChangesToNewBranchOperation {
 }
 
 #[derive(Clone)]
-struct StackBranchOnOperation {
-    source_branch: FullName,
-    target_branch: FullName,
+pub struct StackBranchOnOperation {
+    pub source_branch: FullName,
+    pub target_branch: FullName,
 }
 
 impl StackBranchOnOperation {
@@ -306,8 +309,8 @@ impl StackBranchOnOperation {
 }
 
 #[derive(Clone)]
-struct UnstackBranchOperation {
-    source_branch: FullName,
+pub struct UnstackBranchOperation {
+    pub source_branch: FullName,
 }
 
 impl UnstackBranchOperation {
@@ -678,12 +681,12 @@ fn resolve_sources(
     }
 }
 
-fn run(
+pub fn run(
     ctx: &mut Context,
     meta: &mut impl RefMetadata,
     perm: &mut RepoExclusive,
     move_op: MoveOperation,
-) -> CliResult<MoveOutcome> {
+) -> anyhow::Result<MoveOutcome> {
     let snapshot_details = match &move_op {
         MoveOperation::CommitsRelativeTo(_) | MoveOperation::CommitsToNewBranch(_) => {
             SnapshotDetails::new(OperationKind::MoveCommit)
@@ -702,16 +705,33 @@ fn run(
         DryRun::No,
         |mut tx| {
             let outcome = match move_op {
-                MoveOperation::CommitsRelativeTo(op) => MoveOutcome::Commits {
-                    sources: op.sources.clone(),
-                    target: Some(op.target.clone()),
-                    new_branch_name: op.execute(&mut tx)?,
-                },
-                MoveOperation::CommitsToNewBranch(op) => MoveOutcome::Commits {
-                    sources: op.sources.clone(),
-                    target: None,
-                    new_branch_name: Some(op.execute(&mut tx)?),
-                },
+                MoveOperation::CommitsRelativeTo(op) => {
+                    let sources = op.sources.clone();
+                    let target = op.target.clone();
+                    let new_branch_name = op.execute(&mut tx)?;
+                    let moved_commits = sources
+                        .clone()
+                        .map(|source| tx.get_mapped_commit(source).unwrap_or(source));
+                    MoveOutcome::Commits {
+                        sources,
+                        moved_commits,
+                        target: Some(target),
+                        new_branch_name,
+                    }
+                }
+                MoveOperation::CommitsToNewBranch(op) => {
+                    let sources = op.sources.clone();
+                    let new_branch_name = op.execute(&mut tx)?;
+                    let moved_commits = sources
+                        .clone()
+                        .map(|source| tx.get_mapped_commit(source).unwrap_or(source));
+                    MoveOutcome::Commits {
+                        sources,
+                        moved_commits,
+                        target: None,
+                        new_branch_name: Some(new_branch_name),
+                    }
+                }
                 MoveOperation::ChangesRelativeTo(op) => {
                     let target = op.target.clone();
                     let num_changes = op.changes.len();

--- a/crates/but/src/command/legacy/status/tui/app/move_mode.rs
+++ b/crates/but/src/command/legacy/status/tui/app/move_mode.rs
@@ -3,23 +3,31 @@ use std::sync::Arc;
 use but_core::ref_metadata::StackId;
 use but_ctx::Context;
 use but_rebase::graph_rebase::mutate::InsertSide;
+use gix::refs::Category;
 use nonempty::NonEmpty;
 use ratatui::prelude::Span;
 
 use crate::{
     CliId,
-    command::legacy::status::{
-        output::StatusOutputLineData,
-        tui::{
-            App, Message, Mode, ReloadCause, SelectAfterReload,
-            app::mark::MarkedCommit,
-            operations,
-            render::{
-                ModeRender, RenderSingleLineSpans, render_move_operation_target_marker, source_span,
+    command::legacy::{
+        move2::{
+            self, MoveCommitsRelativeToOperation, MoveOperation,
+            MoveOutcome as MoveOperationOutcome, StackBranchOnOperation, UnstackBranchOperation,
+        },
+        status::{
+            output::StatusOutputLineData,
+            tui::{
+                App, Message, Mode, ReloadCause, SelectAfterReload,
+                app::mark::MarkedCommit,
+                render::{
+                    ModeRender, RenderSingleLineSpans, render_move_operation_target_marker,
+                    source_span,
+                },
             },
         },
     },
     id::ShortId,
+    utils::targeting,
 };
 
 #[derive(Debug, Clone)]
@@ -302,88 +310,41 @@ impl App {
             }
         };
 
-        let selection_after_reload = match &**source {
-            MoveSource::Commit {
-                commit_id: source_commit_id,
-                ..
-            } => {
-                let commit_move_result = match target {
-                    MoveTarget::Branch { name } => operations::move_commit_to_branch(
-                        ctx,
-                        Vec::from([*source_commit_id]),
-                        name,
-                    )?,
-                    MoveTarget::Commit {
-                        commit_id: target_commit_id,
-                    } => operations::move_commit_to_commit(
-                        ctx,
-                        Vec::from([*source_commit_id]),
-                        target_commit_id,
-                        *insert_side,
-                    )?,
-                    MoveTarget::MergeBase => return Ok(()),
-                };
-
-                commit_move_result
-                    .workspace
-                    .replaced_commits
-                    .get(source_commit_id)
-                    .copied()
-                    .map(SelectAfterReload::Commit)
+        let move_op = match &**source {
+            MoveSource::Commit { commit_id, .. } => {
+                MoveOperation::CommitsRelativeTo(MoveCommitsRelativeToOperation {
+                    sources: NonEmpty::new(*commit_id),
+                    target: move_target(target, *insert_side)?,
+                })
             }
             MoveSource::Marks(commits) => {
-                let sources = commits
-                    .iter()
-                    .map(|commit| commit.commit_id)
-                    .collect::<Vec<_>>();
-
-                let commit_move_result = match target {
-                    MoveTarget::Branch { name } => {
-                        operations::move_commit_to_branch(ctx, sources.clone(), name)?
-                    }
-                    MoveTarget::Commit {
-                        commit_id: target_commit_id,
-                    } => operations::move_commit_to_commit(
-                        ctx,
-                        sources.clone(),
-                        target_commit_id,
-                        *insert_side,
-                    )?,
-                    MoveTarget::MergeBase => return Ok(()),
-                };
-
-                sources
-                    .iter()
-                    .find_map(|source| {
-                        commit_move_result
-                            .workspace
-                            .replaced_commits
-                            .get(source)
-                            .copied()
-                    })
-                    .map(SelectAfterReload::Commit)
+                MoveOperation::CommitsRelativeTo(MoveCommitsRelativeToOperation {
+                    sources: commits.clone().map(|commit| commit.commit_id),
+                    target: move_target(target, *insert_side)?,
+                })
             }
             MoveSource::Branch {
                 name: source_branch_name,
                 ..
-            } => match target {
-                MoveTarget::Branch {
-                    name: target_branch_name,
-                } => {
-                    operations::move_branch_onto_branch(
-                        ctx,
-                        source_branch_name,
-                        target_branch_name,
-                    )?;
-                    Some(SelectAfterReload::Branch(source_branch_name.to_owned()))
+            } => {
+                let source_branch =
+                    Category::LocalBranch.to_full_name(source_branch_name.as_str())?;
+                match target {
+                    MoveTarget::Branch {
+                        name: target_branch_name,
+                    } => MoveOperation::StackBranch(StackBranchOnOperation {
+                        source_branch,
+                        target_branch: Category::LocalBranch.to_full_name(target_branch_name)?,
+                    }),
+                    MoveTarget::MergeBase => {
+                        MoveOperation::UnstackBranch(UnstackBranchOperation { source_branch })
+                    }
+                    MoveTarget::Commit { .. } => return Ok(()),
                 }
-                MoveTarget::MergeBase => {
-                    operations::tear_off_branch(ctx, source_branch_name)?;
-                    Some(SelectAfterReload::Branch(source_branch_name.to_owned()))
-                }
-                MoveTarget::Commit { .. } => return Ok(()),
-            },
+            }
         };
+
+        let selection_after_reload = move_with(ctx, move_op)?;
 
         messages.extend([
             Message::EnterNormalModeAfterConfirmingOperation,
@@ -392,4 +353,42 @@ impl App {
 
         Ok(())
     }
+}
+
+fn move_target(
+    target: MoveTarget<'_>,
+    insert_side: InsertSide,
+) -> anyhow::Result<move2::MoveTarget> {
+    Ok(match target {
+        MoveTarget::Branch { name } => move2::MoveTarget::BranchTip {
+            name: Category::LocalBranch.to_full_name(name)?,
+        },
+        MoveTarget::Commit { commit_id } => move2::MoveTarget::Commit {
+            commit_id,
+            side: targeting::Side::from(insert_side),
+        },
+        MoveTarget::MergeBase => anyhow::bail!("commits cannot be moved to the merge base"),
+    })
+}
+
+fn move_with(
+    ctx: &mut Context,
+    move_op: MoveOperation,
+) -> anyhow::Result<Option<SelectAfterReload>> {
+    let mut guard = ctx.exclusive_worktree_access();
+    let mut meta = ctx.meta()?;
+    let outcome = move2::run(ctx, &mut meta, guard.write_permission(), move_op)?;
+
+    Ok(match outcome {
+        MoveOperationOutcome::Commits { moved_commits, .. } => {
+            Some(SelectAfterReload::Commit(moved_commits.head))
+        }
+        MoveOperationOutcome::Changes { new_commit_id, .. } => {
+            Some(SelectAfterReload::Commit(new_commit_id))
+        }
+        MoveOperationOutcome::StackBranch { source_branch, .. }
+        | MoveOperationOutcome::UnstackBranch { source_branch } => Some(SelectAfterReload::Branch(
+            source_branch.shorten().to_string(),
+        )),
+    })
 }

--- a/crates/but/src/command/legacy/status/tui/operations.rs
+++ b/crates/but/src/command/legacy/status/tui/operations.rs
@@ -174,67 +174,6 @@ pub fn reword_commit_legacy(
         .map(Some)
 }
 
-pub fn move_commit_to_branch(
-    ctx: &mut Context,
-    subject_commit_ids: Vec<gix::ObjectId>,
-    branch_name: &str,
-) -> anyhow::Result<but_api::commit::types::CommitMoveResult> {
-    let repo = ctx.repo.get()?;
-    let target_branch_name = repo
-        .find_reference(branch_name)
-        .context("failed to find reference")?
-        .name()
-        .to_owned();
-    drop(repo);
-    but_api::commit::move_commit::commit_move(
-        ctx,
-        subject_commit_ids,
-        RelativeTo::Reference(target_branch_name),
-        InsertSide::Below,
-        DryRun::No,
-    )
-    .context("failed to move commit")
-}
-
-pub fn move_commit_to_commit(
-    ctx: &mut Context,
-    subject_commit_ids: Vec<gix::ObjectId>,
-    target_commit_id: gix::ObjectId,
-    insert_side: InsertSide,
-) -> anyhow::Result<but_api::commit::types::CommitMoveResult> {
-    but_api::commit::move_commit::commit_move(
-        ctx,
-        subject_commit_ids,
-        RelativeTo::Commit(target_commit_id),
-        insert_side,
-        DryRun::No,
-    )
-    .context("failed to move commit")
-}
-
-pub fn move_branch_onto_branch(
-    ctx: &mut Context,
-    source_branch_name: &str,
-    target_branch_name: &str,
-) -> anyhow::Result<()> {
-    let repo = ctx.repo.get()?;
-    let source_ref = repo.find_reference(source_branch_name)?.name().to_owned();
-    let target_ref = repo.find_reference(target_branch_name)?.name().to_owned();
-    drop(repo);
-    but_api::branch::move_branch(ctx, source_ref.as_ref(), target_ref.as_ref(), DryRun::No)
-        .context("failed to move branch")?;
-    Ok(())
-}
-
-pub fn tear_off_branch(ctx: &mut Context, source_branch_name: &str) -> anyhow::Result<()> {
-    let repo = ctx.repo.get()?;
-    let source_ref = repo.find_reference(source_branch_name)?.name().to_owned();
-    drop(repo);
-    but_api::branch::tear_off_branch(ctx, source_ref.as_ref(), DryRun::No)
-        .context("failed to unstack branch")?;
-    Ok(())
-}
-
 pub fn create_branch_anchored_legacy(
     ctx: &mut Context,
     short_name: String,


### PR DESCRIPTION
Changes the TUI to use _move2 for moving commits instead of its own adhoc impl.