### PR TITLE
Add CLI feature flag configuration

### DIFF
--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -516,12 +516,15 @@ View and manage GitButler configuration.
 
 ```bash
 but config
-but config user               # Also: forge, target, metrics, ui, ai
+but config user               # Also: forge, target, metrics, feature, ui, ai
 but config ai openai          # Also: anthropic, ollama, lmstudio, openrouter
 but config target             # Show the current target branch
 but config target origin/main # Set the fetch target
 but config push-remote         # Show the current push remote
 but config push-remote origin  # Set the push remote without changing the target
+but config feature                         # List configurable feature flags
+but config feature single-branch           # Show a feature flag's value
+but config feature single-branch enable    # Also: disable
 ```
 
 ### `but update check`

--- a/crates/but/src/args/config.rs
+++ b/crates/but/src/args/config.rs
@@ -165,6 +165,33 @@ pub enum Subcommands {
         status: Option<MetricsStatus>,
     },
 
+    /// View and configure feature flags.
+    ///
+    /// Without arguments, displays all feature flags that can be changed through the CLI.
+    /// Specify a flag to view its current value, or add `enable` or `disable` to update it.
+    ///
+    /// ## Examples
+    ///
+    /// View all feature flags:
+    ///
+    /// ```text
+    /// but config feature
+    /// ```
+    ///
+    /// Enable single-branch mode:
+    ///
+    /// ```text
+    /// but config feature single-branch enable
+    /// ```
+    Feature {
+        /// Feature flag to view or update.
+        #[clap(value_enum)]
+        flag: Option<FeatureFlag>,
+        /// Whether the feature flag is enabled.
+        #[clap(value_enum, requires = "flag")]
+        status: Option<FeatureStatus>,
+    },
+
     /// View and configure UI preferences.
     ///
     /// Without arguments, displays current UI settings.
@@ -434,6 +461,37 @@ impl UiConfigKey {
 pub enum MetricsStatus {
     Enable,
     Disable,
+}
+
+/// Feature flags that can be managed through `but config feature`.
+#[derive(Debug, Clone, Copy, clap::ValueEnum)]
+pub enum FeatureFlag {
+    /// Use the V3 unapply compatibility mode.
+    UnapplyV3Pgm,
+    /// Enable single-branch mode.
+    SingleBranch,
+}
+
+impl FeatureFlag {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            FeatureFlag::UnapplyV3Pgm => "unapply-v3-pgm",
+            FeatureFlag::SingleBranch => "single-branch",
+        }
+    }
+}
+
+/// Values for a feature flag.
+#[derive(Debug, Clone, Copy, clap::ValueEnum)]
+pub enum FeatureStatus {
+    Enable,
+    Disable,
+}
+
+impl FeatureStatus {
+    pub fn enabled(self) -> bool {
+        matches!(self, FeatureStatus::Enable)
+    }
 }
 
 impl MetricsStatus {

--- a/crates/but/src/args/config.rs
+++ b/crates/but/src/args/config.rs
@@ -479,6 +479,13 @@ impl FeatureFlag {
             FeatureFlag::SingleBranch => "single-branch",
         }
     }
+
+    pub fn as_json_key(self) -> &'static str {
+        match self {
+            FeatureFlag::UnapplyV3Pgm => "unapply_v3_pgm",
+            FeatureFlag::SingleBranch => "single_branch",
+        }
+    }
 }
 
 /// Values for a feature flag.

--- a/crates/but/src/args/tests.rs
+++ b/crates/but/src/args/tests.rs
@@ -510,6 +510,64 @@ mod config_target {
     }
 }
 
+mod config_feature {
+    use clap::Parser;
+
+    use crate::args::{
+        Args, Subcommands,
+        config::{
+            FeatureFlag, FeatureStatus, Platform as ConfigPlatform, Subcommands as ConfigCmd,
+        },
+    };
+
+    #[test]
+    fn parses_feature_list() {
+        let args = Args::try_parse_from(["but", "config", "feature"]).expect("parse feature list");
+
+        assert!(matches!(
+            args.cmd,
+            Some(Subcommands::Config(ConfigPlatform {
+                cmd: Some(ConfigCmd::Feature {
+                    flag: None,
+                    status: None,
+                }),
+            }))
+        ));
+    }
+
+    #[test]
+    fn parses_feature_update() {
+        let args = Args::try_parse_from(["but", "config", "feature", "single-branch", "enable"])
+            .expect("parse feature update");
+
+        assert!(matches!(
+            args.cmd,
+            Some(Subcommands::Config(ConfigPlatform {
+                cmd: Some(ConfigCmd::Feature {
+                    flag: Some(FeatureFlag::SingleBranch),
+                    status: Some(FeatureStatus::Enable),
+                }),
+            }))
+        ));
+    }
+
+    #[test]
+    fn rejects_feature_status_without_flag() {
+        let err = Args::try_parse_from(["but", "config", "feature", "enable"])
+            .expect_err("feature status without flag is invalid");
+
+        assert_eq!(err.kind(), clap::error::ErrorKind::InvalidValue);
+    }
+
+    #[test]
+    fn does_not_expose_irc() {
+        let err = Args::try_parse_from(["but", "config", "feature", "irc"])
+            .expect_err("IRC feature flag is intentionally hidden");
+
+        assert_eq!(err.kind(), clap::error::ErrorKind::InvalidValue);
+    }
+}
+
 #[test]
 fn output_format_agent_is_text_without_human_ui() {
     let format = OutputFormat::Agent;

--- a/crates/but/src/args/tests.rs
+++ b/crates/but/src/args/tests.rs
@@ -566,6 +566,12 @@ mod config_feature {
 
         assert_eq!(err.kind(), clap::error::ErrorKind::InvalidValue);
     }
+
+    #[test]
+    fn json_keys_use_snake_case() {
+        assert_eq!(FeatureFlag::UnapplyV3Pgm.as_json_key(), "unapply_v3_pgm");
+        assert_eq!(FeatureFlag::SingleBranch.as_json_key(), "single_branch");
+    }
 }
 
 #[test]

--- a/crates/but/src/command/config.rs
+++ b/crates/but/src/command/config.rs
@@ -442,7 +442,7 @@ pub(crate) fn feature_config(
         }
     } else if let Some(out) = out.for_shell() {
         for (flag, enabled) in flags {
-            writeln!(out, "{}={enabled}", flag.as_str())?;
+            writeln!(out, "{}={enabled}", flag.as_json_key())?;
         }
     } else if let Some(out) = out.for_json() {
         out.write_value(serde_json::json!({

--- a/crates/but/src/command/config.rs
+++ b/crates/but/src/command/config.rs
@@ -16,7 +16,10 @@ use but_llm::{
     AI_OPENROUTER_MODEL_NAME_KEY, AI_OPENROUTER_SECRET_HANDLE, LLMProviderKind,
 };
 use but_secret::{Sensitive, secret};
-use but_settings::{AppSettingsWithDiskSync, api::TelemetryUpdate};
+use but_settings::{
+    AppSettingsWithDiskSync,
+    api::{FeatureFlagsUpdate, TelemetryUpdate},
+};
 use cfg_if::cfg_if;
 use gix::bstr::ByteSlice as _;
 use serde::Serialize;
@@ -24,8 +27,8 @@ use serde::Serialize;
 use super::git_config::edit_git_config;
 use crate::{
     args::config::{
-        AiKeyOption, AiSubcommand, ForgeSubcommand, MetricsStatus, Subcommands, UiSubcommand,
-        UserSubcommand,
+        AiKeyOption, AiSubcommand, FeatureFlag, FeatureStatus, ForgeSubcommand, MetricsStatus,
+        Subcommands, UiSubcommand, UserSubcommand,
     },
     theme::{self, Paint},
     tui,
@@ -96,6 +99,7 @@ pub async fn exec(
         Some(Subcommands::PushRemote { remote }) => push_remote_config(ctx, out, remote),
         Some(Subcommands::Forge { cmd }) => forge_config(out, cmd).await,
         Some(Subcommands::Metrics { status }) => metrics_config(out, status).await,
+        Some(Subcommands::Feature { flag, status }) => feature_config(out, flag, status),
         Some(Subcommands::Ai { local, global, cmd }) => {
             ai_config_with_repo(ctx, out, cmd, local, global)
         }
@@ -246,6 +250,11 @@ async fn show_overview(ctx: &mut Context, out: &mut OutputChannel) -> Result<()>
         )?;
         writeln!(
             out,
+            "  {} - Feature flags",
+            t.command_suggestion.paint("but config feature")
+        )?;
+        writeln!(
+            out,
             "  {}      - AI provider settings",
             t.command_suggestion.paint("but config ai")
         )?;
@@ -351,6 +360,131 @@ pub(crate) async fn metrics_config(
         }
     }
 
+    Ok(())
+}
+
+/// Handle feature flag configuration without requiring a repository context.
+pub(crate) fn feature_config(
+    out: &mut OutputChannel,
+    flag: Option<FeatureFlag>,
+    status: Option<FeatureStatus>,
+) -> Result<()> {
+    let t = theme::get();
+    let app_settings_sync = load_app_settings_sync()?;
+
+    if let Some(status) = status {
+        let flag = flag.context("A feature flag is required when setting its status")?;
+        let enabled = status.enabled();
+        app_settings_sync.update_feature_flags(feature_flag_update(flag, enabled))?;
+
+        if let Some(out) = out.for_human() {
+            writeln!(
+                out,
+                "{} Feature flag {} is now {}",
+                t.sym().success,
+                t.config_value.paint(flag.as_str()),
+                if enabled {
+                    t.success.paint("enabled")
+                } else {
+                    t.error.paint("disabled")
+                }
+            )?;
+        } else {
+            write_feature_flag_value(out, flag, enabled)?;
+        }
+        return Ok(());
+    }
+
+    let settings = app_settings_sync.get()?;
+    if let Some(flag) = flag {
+        let enabled = feature_flag_value(&settings.feature_flags, flag);
+        if let Some(out) = out.for_human() {
+            writeln!(
+                out,
+                "{}: {}",
+                t.config_value.paint(flag.as_str()),
+                if enabled {
+                    t.success.paint("enabled")
+                } else {
+                    t.hint.paint("disabled")
+                }
+            )?;
+        } else {
+            write_feature_flag_value(out, flag, enabled)?;
+        }
+        return Ok(());
+    }
+
+    let flags = [
+        (
+            FeatureFlag::UnapplyV3Pgm,
+            settings.feature_flags.unapply_v3_pgm,
+        ),
+        (
+            FeatureFlag::SingleBranch,
+            settings.feature_flags.single_branch,
+        ),
+    ];
+    if let Some(out) = out.for_human() {
+        writeln!(out, "\n{}:", t.important.paint("Feature Flags"))?;
+        writeln!(out)?;
+        for (flag, enabled) in flags {
+            writeln!(
+                out,
+                "  {}: {}",
+                t.config_value.paint(flag.as_str()),
+                if enabled {
+                    t.success.paint("enabled")
+                } else {
+                    t.hint.paint("disabled")
+                }
+            )?;
+        }
+    } else if let Some(out) = out.for_shell() {
+        for (flag, enabled) in flags {
+            writeln!(out, "{}={enabled}", flag.as_str())?;
+        }
+    } else if let Some(out) = out.for_json() {
+        out.write_value(serde_json::json!({
+            "unapply_v3_pgm": settings.feature_flags.unapply_v3_pgm,
+            "single_branch": settings.feature_flags.single_branch,
+        }))?;
+    }
+
+    Ok(())
+}
+
+fn feature_flag_value(flags: &but_settings::app_settings::FeatureFlags, flag: FeatureFlag) -> bool {
+    match flag {
+        FeatureFlag::UnapplyV3Pgm => flags.unapply_v3_pgm,
+        FeatureFlag::SingleBranch => flags.single_branch,
+    }
+}
+
+fn feature_flag_update(flag: FeatureFlag, enabled: bool) -> FeatureFlagsUpdate {
+    let mut update = FeatureFlagsUpdate {
+        unapply_v3_pgm: None,
+        single_branch: None,
+        irc: None,
+        worktree_manipulation: None,
+    };
+    match flag {
+        FeatureFlag::UnapplyV3Pgm => update.unapply_v3_pgm = Some(enabled),
+        FeatureFlag::SingleBranch => update.single_branch = Some(enabled),
+    }
+    update
+}
+
+fn write_feature_flag_value(
+    out: &mut OutputChannel,
+    flag: FeatureFlag,
+    enabled: bool,
+) -> Result<()> {
+    if let Some(out) = out.for_shell() {
+        writeln!(out, "{enabled}")?;
+    } else if let Some(out) = out.for_json() {
+        out.write_value(serde_json::json!({ flag.as_str(): enabled }))?;
+    }
     Ok(())
 }
 

--- a/crates/but/src/command/config.rs
+++ b/crates/but/src/command/config.rs
@@ -483,7 +483,7 @@ fn write_feature_flag_value(
     if let Some(out) = out.for_shell() {
         writeln!(out, "{enabled}")?;
     } else if let Some(out) = out.for_json() {
-        out.write_value(serde_json::json!({ flag.as_str(): enabled }))?;
+        out.write_value(serde_json::json!({ flag.as_json_key(): enabled }))?;
     }
     Ok(())
 }

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -529,6 +529,11 @@ async fn match_subcommand(
                         .emit_metrics(metrics_ctx)
                         .map_err(CliError::from)
                 }
+                Some(args::config::Subcommands::Feature { flag, status }) => {
+                    command::config::feature_config(out, *flag, *status)
+                        .emit_metrics(metrics_ctx)
+                        .map_err(CliError::from)
+                }
                 Some(args::config::Subcommands::Forge { cmd: forge_cmd }) => {
                     command::config::forge_config(out, forge_cmd.clone())
                         .await

--- a/crates/but/tests/but/command/config.rs
+++ b/crates/but/tests/but/command/config.rs
@@ -79,6 +79,36 @@ origin
 }
 
 #[test]
+fn feature_config_shell_output_uses_valid_identifiers() {
+    let env = Sandbox::empty();
+
+    env.but("--format shell config feature")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+unapply_v3_pgm=false
+single_branch=true
+
+"#]]);
+}
+
+#[test]
+fn feature_config_json_output_uses_stable_key() {
+    let env = Sandbox::empty();
+
+    env.but("--format json config feature single-branch")
+        .allow_json()
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+{
+  "single_branch": true
+}
+
+"#]]);
+}
+
+#[test]
 fn ai_openai_defaults_to_global_config() {
     let env = Sandbox::empty();
     env.invoke_bash("git init repo");


### PR DESCRIPTION
## Why?

Would be cool to not have to enable features in the GUI. This will also enable trying single-branch mode from the CLI.

## Summary

- add `but config feature` for listing and inspecting configurable feature flags
- support enabling and disabling `single-branch` and `unapply-v3-pgm` outside repositories
- support human, shell, and JSON output formats
- keep the IRC feature flag hidden from the CLI
