### PR TITLE
Remove but absorb from the agent skill

### DIFF
--- a/crates/but/skill/references/concepts.md
+++ b/crates/but/skill/references/concepts.md
@@ -164,7 +164,7 @@ The uncommitted change **depends on** C1 (because it calls `foo()`).
 **Implications:**
 
 1. Can't commit this change to a stack that doesn't contain C1
-2. `but absorb` will automatically amend it into C1 (or a commit after C1)
+2. When amending it into history, it belongs in C1 (or a commit after C1)
 3. If you try to move the change, GitButler prevents invalid operations
 
 ### Why This Matters

--- a/crates/but/skill/references/examples.md
+++ b/crates/but/skill/references/examples.md
@@ -70,9 +70,9 @@ but pr new bv -t
 
 **Result:** Two PRs where user-profile targets add-authentication, with GitButler stack information in the PR descriptions.
 
-## Example 3: Using Absorb Instead of New Commits
+## Example 3: Amending Fixes Into Existing Commits
 
-**Scenario:** Made a small typo fix that should be part of the last commit, not a new commit.
+**Scenario:** Made a small typo fix that should be part of an existing commit, not a new commit.
 
 ```bash
 # 1. Check current commits and uncommitted changes
@@ -86,25 +86,14 @@ but status -fv
 # Uncommitted:
 #   a1: fix-typo.js
 
-# 2. Preview what absorb would do (recommended first step)
-but absorb a1 --dry-run    # Shows where a1 would be absorbed
+# 2. Decide which commit the fix belongs to
+# (the typo is in code introduced by nn, so it belongs in nn)
 
-# 3. Absorb the specific file into appropriate commit
-but absorb a1    # Absorb just this file + get updated status
-
-# GitButler analyzes the change and amends it into nn
-# (because the typo is in code from nn)
+# 3. Amend the file into that commit
+but amend nn --changes a1    # Amend just this file + get updated status
 ```
 
-**Targeted vs blanket absorb:**
-
-```bash
-but absorb a1    # Absorb specific file (recommended)
-but absorb bu    # Absorb all changes assigned to branch bu
-but absorb       # Absorb ALL uncommitted changes (use with caution)
-```
-
-**Why absorb?** Keeps history clean. Small fixes belong in the commits they fix, not as separate "fix typo" commits.
+**Why amend?** Keeps history clean. Small fixes belong in the commits they fix, not as separate "fix typo" commits. You know what you changed and why — pick the target commit yourself.
 
 ## Example 4: Reorganizing Commit History
 
@@ -260,7 +249,7 @@ but commit bu -m "Style dashboard components" --changes <file-ids>
 
 # 7. Make small fix
 # (fix typo in widget)
-but absorb a1    # Absorb specific file into appropriate commit
+but amend <commit-id> --changes a1    # Amend fix into the commit it belongs to
 
 # 8. Clean up if needed
 but squash bu    # Combine all commits (optional)
@@ -366,7 +355,7 @@ but commit bu -m "Identify auth bug source" --changes <file-ids>
 # (make more changes)
 but commit bu -m "Fix token expiration handling" --changes <file-ids>
 # (small fix to existing code)
-but absorb a1              # Absorb specific fix into appropriate commit
+but amend <commit-id> --changes a1  # Amend fix into the commit it belongs to
 
 # Mid-day: Start urgent fix on different branch
 but branch new hotfix-login  # Parallel branch for urgent work
@@ -384,9 +373,7 @@ but pr new bu      # Push and create PR
 
 # After PR review: Make requested changes
 # (make changes based on feedback)
-but absorb <file-id>    # Absorb specific changes into commits
-# Or absorb all changes for this branch:
-but absorb bu          # Absorb all changes assigned to bu
+but amend <commit-id> --changes <file-id>  # Amend each fix into the commit it belongs to
 but push fix-auth-bug   # Push updated history
 ```
 
@@ -446,7 +433,6 @@ but status -fv    # File-centric view for quick overview
 ### Preview Before Doing
 
 ```bash
-but absorb <file-id> --dry-run  # See where specific file would be absorbed
 but push my-feature --dry-run   # See what would be pushed
 ```
 

--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -6,7 +6,7 @@ Agent-focused reference for useful `but` commands.
 
 - [Inspection](#inspection-understanding-state) - `status`, `show`, `diff`
 - [Branching](#branching) - `branch new`, `apply`, `unapply`, `branch delete`, `pick`
-- [Committing](#committing) - `commit`, `absorb`
+- [Committing](#committing) - `commit`
 - [Editing History](#editing-history) - `rub`, `squash`, `amend`, `move`, `uncommit`, `reword`, `discard`
 - [Conflict Resolution](#conflict-resolution) - `resolve`
 - [Remote Operations](#remote-operations) - `push`, `pull`, `pr`, `land`
@@ -198,26 +198,6 @@ Edge case: if wanted and unwanted edits are in the same hunk, GitButler cannot s
 
 If only one branch is applied, you can omit the branch ID.
 
-### `but absorb [source]`
-
-Automatically amend uncommitted changes into existing commits.
-
-```bash
-but absorb <file-id>          # Absorb specific file (recommended)
-but absorb <branch-id>        # Absorb all changes assigned to this branch
-but absorb                    # Absorb ALL uncommitted changes (use with caution)
-but absorb --dry-run          # Preview without making changes
-but absorb <file-id> --dry-run  # Preview specific file absorption
-```
-
-**Recommendation:** Prefer targeted absorb (`but absorb <file-id>`) over absorbing everything. Running `but absorb` without arguments absorbs ALL uncommitted changes across all branches, which may not be what you want.
-
-Logic:
-
-- Changes amended into topmost commit of their branch
-- Changes depending on specific commit amended into that commit
-- Uses smart matching to find appropriate commits
-
 ## Editing History
 
 ### `but rub <source> <dest>`
@@ -266,9 +246,7 @@ Amend one or more files/hunks into a specific commit. Use when you know exactly 
 but amend <commit-id> --changes <file-id>,<hunk-id>
 ```
 
-**When to use `amend` vs `absorb`:**
-- `but amend` - You know the target commit; explicit control
-- `but absorb` - Let GitButler auto-detect the target; smart matching based on dependencies
+Decide the target commit yourself: check `but status -fv`, find the commit the change logically belongs to, then amend into it.
 
 Convenience wrapper around `rub` for amending uncommitted files or hunks into a known commit.
 


### PR DESCRIPTION
Absorb is a human convenience; agents already know what they changed and why, so they should pick the target commit themselves and amend into it with `but amend`. This removes the absorb command section and rewrites the examples to model explicit amending instead.