### PR TITLE
Refuse branch creation anchored at a segment shared by multiple stacks

### DIFF
--- a/crates/but-workspace/src/branch/create_reference.rs
+++ b/crates/but-workspace/src/branch/create_reference.rs
@@ -307,6 +307,13 @@ pub(super) mod function {
             }) => {
                 let mut validate_id = true;
                 let indexes = workspace.try_find_owner_indexes_by_commit_id(commit_id)?;
+                let (stack_idx, seg_idx, _cidx) = indexes;
+                bail_if_anchor_in_multiple_stacks(
+                    workspace,
+                    (stack_idx, seg_idx),
+                    Some(commit_id),
+                    || format!("Commit {commit_id}"),
+                )?;
                 let ref_target_id =
                     position.resolve_commit(workspace.lookup_commit(indexes).into(), ws_base)?;
                 let id_out_of_workspace = Some(ref_target_id) == ws_base;
@@ -319,7 +326,6 @@ pub(super) mod function {
                     .filter(|_| !id_out_of_workspace)
                     .map(|_| instruction_by_named_anchor_for_commit(workspace, commit_id))
                     .or_else(|| {
-                        let (stack_idx, _seg_idx, _cidx) = indexes;
                         workspace.stacks[stack_idx]
                             .id
                             .map(Instruction::DependentInStack)
@@ -334,6 +340,12 @@ pub(super) mod function {
                 let ref_target_id = if workspace.has_metadata() {
                     let (stack_idx, seg_idx) =
                         workspace.try_find_segment_owner_indexes_by_refname(ref_name.as_ref())?;
+                    bail_if_anchor_in_multiple_stacks(
+                        workspace,
+                        (stack_idx, seg_idx),
+                        None,
+                        || format!("Branch '{}'", ref_name.shorten()),
+                    )?;
                     let segment = &workspace.stacks[stack_idx].segments[seg_idx];
 
                     let id = workspace
@@ -386,6 +398,12 @@ pub(super) mod function {
                 if workspace.has_metadata() {
                     let (stack_idx, seg_idx) =
                         workspace.try_find_segment_owner_indexes_by_refname(anchor_ref.as_ref())?;
+                    bail_if_anchor_in_multiple_stacks(
+                        workspace,
+                        (stack_idx, seg_idx),
+                        None,
+                        || format!("Branch '{}'", anchor_ref.shorten()),
+                    )?;
                     let segment = &workspace.stacks[stack_idx].segments[seg_idx];
                     let ref_target_id = workspace
                         .tip_commit_by_segment_id(segment.id)
@@ -757,6 +775,47 @@ pub(super) mod function {
         Ok(())
     }
 
+    /// Fail with a precondition error if the anchor at `(stack_idx, seg_idx)` is projected
+    /// into more than one stack of `ws`, describing the anchor with `anchor_display`.
+    ///
+    /// This happens when multiple applied stacks contain the same underlying branch.
+    /// Workspace metadata can only place a branch in a single stack, so a new reference
+    /// relative to a shared anchor has no unambiguous location. Proceeding anyway would
+    /// re-project the shared segment based on whichever stack claims it first, visibly
+    /// replacing the anchor branch in all stacks that share it.
+    ///
+    /// A projected stack segment can aggregate multiple graph segments, and an unnamed
+    /// shared commit is aggregated into a differently-named segment per stack. Ownership
+    /// is thus decided by `anchor_commit` where one is known, and by segment identity
+    /// only for by-name anchors, whose segment is never aggregated into another one.
+    fn bail_if_anchor_in_multiple_stacks(
+        ws: &but_graph::Workspace,
+        (stack_idx, seg_idx): (usize, usize),
+        anchor_commit: Option<gix::ObjectId>,
+        anchor_display: impl FnOnce() -> String,
+    ) -> anyhow::Result<()> {
+        let anchor_segment_id = ws.stacks[stack_idx].segments[seg_idx].id;
+        let num_owning_stacks = ws
+            .stacks
+            .iter()
+            .filter(|stack| {
+                stack.segments.iter().any(|segment| match anchor_commit {
+                    Some(id) => segment.commits.iter().any(|c| c.id == id),
+                    None => segment.id == anchor_segment_id,
+                })
+            })
+            .count();
+        if num_owning_stacks > 1 {
+            bail_precondition!(
+                "{} is part of {num_owning_stacks} applied stacks. \
+                 Creating a branch relative to it is ambiguous - unapply the other stacks \
+                 that contain it and try again",
+                anchor_display()
+            );
+        }
+        Ok(())
+    }
+
     /// Create the instruction that would be needed to insert the new ref-name into workspace data
     /// so that it represents the `position` of `anchor_id`.
     /// `position` indicates where, in relation to `anchor_id`, the ref name should be inserted.
@@ -774,6 +833,14 @@ pub(super) mod function {
                     ws.ref_name_display()
                 )
             })?;
+        // The commit-anchor arms guard before calling this function; this covers the
+        // remaining caller, the anchor-less arm for a pre-existing reference.
+        bail_if_anchor_in_multiple_stacks(
+            ws,
+            (anchor_stack_idx, anchor_seg_idx),
+            Some(anchor_id),
+            || format!("Commit {anchor_id}"),
+        )?;
 
         let stack = &ws.stacks[anchor_stack_idx];
         // Find first non-empty segment in this stack upward and downward.

--- a/crates/but-workspace/tests/fixtures/scenario/two-stacks-shared-branch.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/two-stacks-shared-branch.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+git init
+echo "Two applied stacks, bar-one and bar-two, that share the underlying branch 'foo'" >.git/description
+
+git commit --allow-empty -m "M1"
+
+# The shared branch both stacks are built on.
+git checkout -b foo
+git commit --allow-empty -m "F1"
+
+git checkout -b bar-one foo
+git commit --allow-empty -m "B1"
+
+git checkout -b bar-two foo
+git commit --allow-empty -m "B2"
+
+remote_tracking_caught_up main
+add_main_remote_setup
+
+# Create workspace commit merging both stack tips.
+id=$(git commit-tree HEAD^{tree} -p bar-one -p bar-two -m "GitButler Workspace Commit")
+git checkout -b gitbutler/workspace
+git reset --hard $id

--- a/crates/but-workspace/tests/workspace/branch/create_reference.rs
+++ b/crates/but-workspace/tests/workspace/branch/create_reference.rs
@@ -46,6 +46,7 @@ mod with_workspace {
         ref_info::with_workspace_commit::utils::{
             StackState, add_stack_with_segments, named_read_only_in_memory_scenario,
             named_writable_scenario, named_writable_scenario_with_description,
+            named_writable_scenario_with_description_and_graph,
         },
         utils::{r, rc},
     };
@@ -1271,6 +1272,157 @@ Single commit, target, no ws commit, but ws-reference
 
 "#]]
         );
+        Ok(())
+    }
+
+    /// Two applied stacks share the underlying branch `foo`. Anchoring a new branch at `foo`
+    /// (by segment, commit, or reference) has no unambiguous stack to place it in, and used to
+    /// silently replace `foo` in the projection of both stacks. It must refuse instead.
+    #[test]
+    fn no_anchor_on_branch_shared_by_multiple_stacks() -> anyhow::Result<()> {
+        let (_tmp, graph, repo, mut meta, _desc) =
+            named_writable_scenario_with_description_and_graph(
+                "two-stacks-shared-branch",
+                |meta| {
+                    add_stack_with_segments(meta, 0, "bar-one", StackState::InWorkspace, &["foo"]);
+                    add_stack_with_segments(meta, 1, "bar-two", StackState::InWorkspace, &["foo"]);
+                },
+            )?;
+        snapbox::assert_data_eq!(
+            visualize_commit_graph_all(&repo)?,
+            snapbox::str![[r#"
+*   f8a0ddc (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+|\  
+| * 5f347cd (bar-two) B2
+* | 2fd178b (bar-one) B1
+|/  
+* d03b217 (foo) F1
+* 3183e43 (origin/main, main) M1
+
+"#]]
+            .raw()
+        );
+
+        // The `foo` segment is projected into both stacks.
+        let ws = graph.into_workspace()?;
+        snapbox::assert_data_eq!(
+            graph_workspace(&ws).to_string(),
+            snapbox::str![[r#"
+📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+├── ≡📙:3:bar-one on 3183e43 {0}
+│   ├── 📙:3:bar-one
+│   │   └── ·2fd178b (🏘️)
+│   └── 📙:4:foo
+│       └── ·d03b217 (🏘️)
+└── ≡📙:5:bar-two on 3183e43 {1}
+    ├── 📙:5:bar-two
+    │   └── ·5f347cd (🏘️)
+    └── 📙:4:foo
+        └── ·d03b217 (🏘️)
+
+"#]]
+        );
+
+        let foo_id = id_by_rev(&repo, ":/F1").detach();
+        let anchors_and_expected_subjects = [
+            (
+                Anchor::at_segment(r("refs/heads/foo"), Above),
+                "Branch 'foo'".to_string(),
+            ),
+            (
+                Anchor::at_segment(r("refs/heads/foo"), Below),
+                "Branch 'foo'".to_string(),
+            ),
+            (Anchor::at_id(foo_id, Above), format!("Commit {foo_id}")),
+            // `Below` the only commit of `foo` resolves to the workspace base and would
+            // otherwise fall back to placement in whichever stack owns the segment first.
+            (Anchor::at_id(foo_id, Below), format!("Commit {foo_id}")),
+            (
+                Anchor::at_reference(r("refs/heads/foo"), Above),
+                "Branch 'foo'".to_string(),
+            ),
+        ];
+        for (anchor, expected_subject) in anchors_and_expected_subjects {
+            let err = but_workspace::branch::create_reference(
+                r("refs/heads/mybranch"),
+                anchor,
+                &repo,
+                &ws,
+                &mut meta,
+                stack_id_for_name,
+                None,
+            )
+            .unwrap_err();
+            assert_eq!(
+                err.to_string(),
+                format!(
+                    "{expected_subject} is part of 2 applied stacks. Creating a branch \
+                     relative to it is ambiguous - unapply the other stacks that contain \
+                     it and try again"
+                )
+            );
+        }
+        // Nothing was created or altered.
+        assert!(repo.try_find_reference("mybranch")?.is_none());
+        Ok(())
+    }
+
+    /// Like [`no_anchor_on_branch_shared_by_multiple_stacks`], but the shared commit is
+    /// unnamed and thus aggregated into the differently-named segment of each stack.
+    /// Sharing must still be detected through the commit itself, not segment identity.
+    #[test]
+    fn no_anchor_on_unnamed_commit_shared_by_multiple_stacks() -> anyhow::Result<()> {
+        let (_tmp, graph, repo, mut meta, _desc) =
+            named_writable_scenario_with_description_and_graph(
+                "workspace-shared-commit",
+                |meta| {
+                    add_stack_with_segments(meta, 0, "stack-x", StackState::InWorkspace, &[]);
+                    add_stack_with_segments(meta, 1, "stack-y", StackState::InWorkspace, &[]);
+                },
+            )?;
+        // The shared commit `S` is owned by both stacks, without a segment of its own.
+        let ws = graph.into_workspace()?;
+        snapbox::assert_data_eq!(
+            graph_workspace(&ws).to_string(),
+            snapbox::str![[r#"
+📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 965998b
+├── ≡📙:3:stack-x on 965998b {0}
+│   └── 📙:3:stack-x
+│       ├── ·9f0269c (🏘️)
+│       └── ·d2bff94 (🏘️)
+└── ≡📙:4:stack-y on 965998b {1}
+    └── 📙:4:stack-y
+        ├── ·e6d5410 (🏘️)
+        └── ·d2bff94 (🏘️)
+
+"#]]
+        );
+
+        let shared_id = id_by_rev(&repo, ":/S").detach();
+        for anchor in [
+            Anchor::at_id(shared_id, Above),
+            Anchor::at_id(shared_id, Below),
+        ] {
+            let err = but_workspace::branch::create_reference(
+                r("refs/heads/mybranch"),
+                anchor,
+                &repo,
+                &ws,
+                &mut meta,
+                stack_id_for_name,
+                None,
+            )
+            .unwrap_err();
+            assert_eq!(
+                err.to_string(),
+                format!(
+                    "Commit {shared_id} is part of 2 applied stacks. Creating a branch \
+                     relative to it is ambiguous - unapply the other stacks that contain \
+                     it and try again"
+                )
+            );
+        }
+        assert!(repo.try_find_reference("mybranch")?.is_none());
         Ok(())
     }
 


### PR DESCRIPTION
Mitigates [GB-1294](https://linear.app/gitbutler/issue/GB-1294/creating-new-branch-renames-existing-branch): with two applied stacks that share an underlying branch (e.g. `feature-bar-1` and `feature-bar-2` both stacked on `feature-foo`), running `but branch new X -a feature-foo` appeared to *rename* `feature-foo` to `X` in both stacks. The git refs were never touched - the workspace re-projection replaced the shared segment based on whichever stack claimed it first, and the vb-toml reconciliation then persisted the wrong projection by dropping the anchor branch as a duplicate head, making the "rename" permanent.

There is no unambiguous place for such a branch: workspace metadata can only place a branch in one stack, while the anchor segment belongs to several. Instead of corrupting metadata, `create_reference` now fails with a precondition error suggesting to unapply the other stacks first. This covers segment, commit, and reference anchors, and thereby CLI, GUI, and SDK flows alike.

This is a mitigation, not the full fix - inserting a branch into just one of the sharing stacks needs per-stack edge routing in the projection, or the upcoming stacks model where a branch belongs to exactly one stack. Once that lands, the guard can be deleted and the new test flipped to assert successful creation.

Reproduction test case: #13912. Related: [GB-1569](https://linear.app/gitbutler/issue/GB-1569/creating-new-branch-modifies-existing-branch-and-creates-new-branch-in).