### PR TITLE
Remove unused Claude settings update plumbing

### DIFF
--- a/crates/but-api/src/legacy/settings.rs
+++ b/crates/but-api/src/legacy/settings.rs
@@ -2,10 +2,7 @@
 use anyhow::Result;
 use but_settings::{
     AppSettingsWithDiskSync,
-    api::{
-        ClaudeUpdate, FeatureFlagsUpdate, FetchUpdate, IrcUpdate, ReviewsUpdate, TelemetryUpdate,
-        UiUpdate,
-    },
+    api::{FeatureFlagsUpdate, FetchUpdate, IrcUpdate, ReviewsUpdate, TelemetryUpdate, UiUpdate},
 };
 use serde::Deserialize;
 
@@ -59,19 +56,6 @@ pub fn update_feature_flags(
     params: UpdateFeatureFlagsParams,
 ) -> Result<()> {
     app_settings_sync.update_feature_flags(params.update)
-}
-
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct UpdateClaudeParams {
-    pub update: ClaudeUpdate,
-}
-
-pub fn update_claude(
-    app_settings_sync: &AppSettingsWithDiskSync,
-    params: UpdateClaudeParams,
-) -> Result<()> {
-    app_settings_sync.update_claude(params.update)
 }
 
 #[derive(Deserialize)]

--- a/crates/but-settings/src/api.rs
+++ b/crates/but-settings/src/api.rs
@@ -22,18 +22,6 @@ pub struct FeatureFlagsUpdate {
     pub worktree_manipulation: Option<bool>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
-/// Update request for [`crate::app_settings::Claude`].
-pub struct ClaudeUpdate {
-    pub executable: Option<String>,
-    pub notify_on_completion: Option<bool>,
-    pub notify_on_permission_request: Option<bool>,
-    pub dangerously_allow_all_permissions: Option<bool>,
-    pub auto_commit_after_completion: Option<bool>,
-    pub use_configured_model: Option<bool>,
-}
-
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 /// Update request for [`crate::app_settings::Reviews`].
@@ -133,29 +121,6 @@ impl AppSettingsWithDiskSync {
         }
         if let Some(worktree_manipulation) = worktree_manipulation {
             settings.feature_flags.worktree_manipulation = worktree_manipulation;
-        }
-        settings.save()
-    }
-
-    pub fn update_claude(&self, update: ClaudeUpdate) -> Result<()> {
-        let mut settings = self.get_mut_enforce_save()?;
-        if let Some(executable) = update.executable {
-            settings.claude.executable = executable;
-        }
-        if let Some(notify_on_completion) = update.notify_on_completion {
-            settings.claude.notify_on_completion = notify_on_completion;
-        }
-        if let Some(notify_on_permission_request) = update.notify_on_permission_request {
-            settings.claude.notify_on_permission_request = notify_on_permission_request;
-        }
-        if let Some(dangerously_allow_all_permissions) = update.dangerously_allow_all_permissions {
-            settings.claude.dangerously_allow_all_permissions = dangerously_allow_all_permissions;
-        }
-        if let Some(auto_commit_after_completion) = update.auto_commit_after_completion {
-            settings.claude.auto_commit_after_completion = auto_commit_after_completion;
-        }
-        if let Some(use_configured_model) = update.use_configured_model {
-            settings.claude.use_configured_model = use_configured_model;
         }
         settings.save()
     }


### PR DESCRIPTION
No frontend ever exposed an update_claude command: the but-api legacy wrapper, the ClaudeUpdate struct, and AppSettingsWithDiskSync::update_claude were all dead code. The Claude settings section itself remains readable via get_app_settings.