### PR TITLE
fix: don't suggest `but update install` on Windows

### DIFF
--- a/crates/but/src/command/update.rs
+++ b/crates/but/src/command/update.rs
@@ -64,9 +64,15 @@ fn print_human_output(writer: &mut dyn std::fmt::Write, status: &CheckUpdateStat
             {
                 "Install it with your package manager"
             }
-            #[cfg(not(feature = "packaged-but-distribution"))]
+            // `but update install` only exists on Unix (see `args::update::Subcommands`), so only
+            // suggest it there. On other platforms (e.g. Windows) point at the download instead.
+            #[cfg(all(unix, not(feature = "packaged-but-distribution")))]
             {
                 "Install it with 'but update install'"
+            }
+            #[cfg(all(not(unix), not(feature = "packaged-but-distribution")))]
+            {
+                "Download it from https://gitbutler.com/downloads"
             }
         };
 


### PR DESCRIPTION
The `but update install` subcommand is compiled only on Unix (the installer has no Windows implementation), but the update-check message printed the "Install it with 'but update install'" hint on every non-packaged build. Windows users following it hit `error: unrecognized subcommand 'install'`.

Gate the hint to match where the subcommand actually exists and point other platforms at the download page instead.

Fixes #14894