### PR TITLE
remove myself from codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,13 +1,13 @@
 /CODEOWNERS @krlvi @schacon
-/.github @krlvi @schacon @Byron @Caleb-T-Owens @estib-vega @mtsgrd @slarse
-/crates/but-core @krlvi @Byron @Caleb-T-Owens @estib-vega @jonathantanmy2
-/crates/but-ctx @krlvi @Byron @Caleb-T-Owens @estib-vega @jonathantanmy2
-/crates/but-db @krlvi @Byron @Caleb-T-Owens @estib-vega @jonathantanmy2
-/crates/but-fs @krlvi @Byron @Caleb-T-Owens @estib-vega @jonathantanmy2
-/crates/but-graph @krlvi @Byron @Caleb-T-Owens @estib-vega @jonathantanmy2
-/crates/but-rebase @krlvi @Byron @Caleb-T-Owens @estib-vega @jonathantanmy2
-/crates/but-meta @krlvi @Byron @Caleb-T-Owens @estib-vega @jonathantanmy2
-/crates/but-secret @krlvi @Byron @Caleb-T-Owens @estib-vega @jonathantanmy2
-/crates/but-update @krlvi @Byron @Caleb-T-Owens @estib-vega @jonathantanmy2
-/crates/but-workspace @krlvi @Byron @Caleb-T-Owens @estib-vega @jonathantanmy2
-/crates/gitbutler-edit-mode @krlvi @Byron @Caleb-T-Owens @estib-vega @jonathantanmy2
+/.github @krlvi @schacon @Caleb-T-Owens @estib-vega @mtsgrd @slarse
+/crates/but-core @krlvi @Caleb-T-Owens @estib-vega @jonathantanmy2
+/crates/but-ctx @krlvi @Caleb-T-Owens @estib-vega @jonathantanmy2
+/crates/but-db @krlvi @Caleb-T-Owens @estib-vega @jonathantanmy2
+/crates/but-fs @krlvi @Caleb-T-Owens @estib-vega @jonathantanmy2
+/crates/but-graph @krlvi @Caleb-T-Owens @estib-vega @jonathantanmy2
+/crates/but-rebase @krlvi @Caleb-T-Owens @estib-vega @jonathantanmy2
+/crates/but-meta @krlvi @Caleb-T-Owens @estib-vega @jonathantanmy2
+/crates/but-secret @krlvi @Caleb-T-Owens @estib-vega @jonathantanmy2
+/crates/but-update @krlvi @Caleb-T-Owens @estib-vega @jonathantanmy2
+/crates/but-workspace @krlvi @Caleb-T-Owens @estib-vega @jonathantanmy2
+/crates/gitbutler-edit-mode @krlvi @Caleb-T-Owens @estib-vega @jonathantanmy2


### PR DESCRIPTION
This is to reduce notifications which aren't relevant to me. Personal pings have been the way to get in touch for a while, and this change makes it official.
