### PR TITLE
Handle forge info before target initialization

### DIFF
--- a/crates/but-api/src/legacy/forge.rs
+++ b/crates/but-api/src/legacy/forge.rs
@@ -44,21 +44,23 @@ pub fn pr_templates(ctx: &but_ctx::Context, forge: ForgeName) -> Result<Vec<Stri
 /// Get the forge provider name.
 ///
 /// This is determined by the forge the base branch is pointing to.
+/// Returns no value when the project has no target yet or its target forge is unknown.
 #[but_api(napi)]
 #[instrument(err(Debug))]
 pub fn forge_provider(ctx: &Context) -> Result<Option<ForgeName>> {
-    let project_meta = ctx.project_meta()?;
-    let repo = ctx.repo.get()?;
-    let forge_repo_info = but_forge::derive_forge_repo_info(&remote_url(&project_meta, &repo)?);
-    Ok(forge_repo_info.map(|info| info.forge))
+    Ok(forge_info(ctx)?.map(|info| info.name))
 }
 
 /// Per-project forge display + URL config. Lets the renderer build
 /// commit/PR URLs and pick labels without branching on forge name.
+/// Returns no value when the project has no target yet or its target forge is unknown.
 #[but_api(napi)]
 #[instrument(err(Debug))]
 pub fn forge_info(ctx: &Context) -> Result<Option<but_forge::ForgeInfo>> {
     let project_meta = ctx.project_meta()?;
+    if project_meta.target_ref.is_none() {
+        return Ok(None);
+    }
     let repo = ctx.repo.get()?;
     Ok(but_forge::forge_info(&remote_url(&project_meta, &repo)?))
 }

--- a/crates/but-api/tests/api/forge_info.rs
+++ b/crates/but-api/tests/api/forge_info.rs
@@ -1,0 +1,55 @@
+use anyhow::Result;
+use but_api::legacy::forge::{forge_info, forge_provider};
+use but_forge::ForgeName;
+use but_testsupport::{CommandExt, git_at_dir, open_repo};
+
+#[test]
+fn forge_state_follows_target_initialization() -> Result<()> {
+    let (repo, tmp) = crate::support::repo_with_feature_branch()?;
+    drop(repo);
+    git_at_dir(tmp.path())
+        .args(["branch", "-D", "feature"])
+        .run();
+    git_at_dir(tmp.path())
+        .args([
+            "config",
+            "remote.origin.url",
+            "git@gitlab.example.com:acme/widgets.git",
+        ])
+        .run();
+    git_at_dir(tmp.path())
+        .args([
+            "config",
+            "remote.fork.url",
+            "https://github.com/acme/widgets.git",
+        ])
+        .run();
+
+    let mut ctx =
+        but_ctx::Context::from_repo_for_testing(open_repo(tmp.path())?)?.with_memory_app_cache();
+    assert!(
+        forge_info(&ctx)?.is_none(),
+        "configured remotes are ambiguous until the single-branch project has a target"
+    );
+    assert!(
+        forge_provider(&ctx)?.is_none(),
+        "the provider follows the same targetless state"
+    );
+
+    let target_ref = gix::refs::FullName::try_from("refs/remotes/origin/main")?;
+    but_api::workspace::set_target_ref_and_init_project(&mut ctx, target_ref.as_ref(), None)?;
+    assert_eq!(
+        forge_provider(&ctx)?,
+        Some(ForgeName::GitLab),
+        "the target remote determines the forge"
+    );
+
+    let existing_ctx =
+        but_ctx::Context::from_repo_for_testing(open_repo(tmp.path())?)?.with_memory_app_cache();
+    assert_eq!(
+        forge_info(&existing_ctx)?.map(|info| info.name),
+        Some(ForgeName::GitLab),
+        "persisted target metadata remains available after reopening the project"
+    );
+    Ok(())
+}

--- a/crates/but-api/tests/api/main.rs
+++ b/crates/but-api/tests/api/main.rs
@@ -4,6 +4,8 @@ mod branch_create;
 mod branch_move;
 mod branch_remove;
 mod branch_rename;
+#[cfg(feature = "legacy")]
+mod forge_info;
 #[cfg(all(feature = "legacy", not(feature = "graph-workspace")))]
 mod forge_pr_association;
 mod resolve_ai;

--- a/packages/but-sdk/src/generated/graph/index.d.ts
+++ b/packages/but-sdk/src/generated/graph/index.d.ts
@@ -325,6 +325,7 @@ export declare function forgeCompareBranchUrl(projectId: string, base: string, b
 /**
  * Per-project forge display + URL config. Lets the renderer build
  * commit/PR URLs and pick labels without branching on forge name.
+ * Returns no value when the project has no target yet or its target forge is unknown.
  */
 export declare function forgeInfo(projectId: string): Promise<ForgeInfo | null>
 
@@ -332,6 +333,7 @@ export declare function forgeInfo(projectId: string): Promise<ForgeInfo | null>
  * Get the forge provider name.
  *
  * This is determined by the forge the base branch is pointing to.
+ * Returns no value when the project has no target yet or its target forge is unknown.
  */
 export declare function forgeProvider(projectId: string): Promise<ForgeName | null>
 

--- a/packages/but-sdk/src/generated/linear/index.d.ts
+++ b/packages/but-sdk/src/generated/linear/index.d.ts
@@ -325,6 +325,7 @@ export declare function forgeCompareBranchUrl(projectId: string, base: string, b
 /**
  * Per-project forge display + URL config. Lets the renderer build
  * commit/PR URLs and pick labels without branching on forge name.
+ * Returns no value when the project has no target yet or its target forge is unknown.
  */
 export declare function forgeInfo(projectId: string): Promise<ForgeInfo | null>
 
@@ -332,6 +333,7 @@ export declare function forgeInfo(projectId: string): Promise<ForgeInfo | null>
  * Get the forge provider name.
  *
  * This is determined by the forge the base branch is pointing to.
+ * Returns no value when the project has no target yet or its target forge is unknown.
  */
 export declare function forgeProvider(projectId: string): Promise<ForgeName | null>
 


### PR DESCRIPTION
New single-branch projects can request forge metadata before a target ref has been selected. Remote URL resolution currently treats that normal initialization state as an error because it requires target metadata.

Return no forge until target initialization, keep the provider derived from the canonical forge info endpoint, and cover the lifecycle through target selection and reopening persisted project metadata, including self-hosted remotes.