### PR TITLE
Handle incompatible forge review cache rows

### DIFF
--- a/crates/but-api/src/workspace.rs
+++ b/crates/but-api/src/workspace.rs
@@ -443,12 +443,7 @@ fn forge_review_integration_hints(
         return Ok(vec![]);
     }
 
-    let associated_reviews = db
-        .forge_reviews()
-        .list_all()?
-        .into_iter()
-        .map(but_forge::ForgeReview::try_from)
-        .collect::<anyhow::Result<Vec<_>>>()?;
+    let associated_reviews = but_forge::list_cached_forge_reviews(db)?;
 
     Ok(review_integration_hints_from_reviews(
         &target_branch_name,

--- a/crates/but-api/tests/api/forge_pr_association.rs
+++ b/crates/but-api/tests/api/forge_pr_association.rs
@@ -94,6 +94,29 @@ fn optimistic_cache_insert_is_visible_on_the_next_projection() -> anyhow::Result
     Ok(())
 }
 
+#[test]
+fn incompatible_cache_rows_do_not_break_head_info() -> anyhow::Result<()> {
+    let (mut ctx, _tmp) = context_with_remote_branch()?;
+    let branch: gix::refs::FullName = format!("refs/heads/{BRANCH}").try_into()?;
+    but_api::branch::apply_only(&mut ctx, branch.as_ref())?;
+
+    for version in [1, 2] {
+        let mut row: but_db::ForgeReview = review(PR_NUMBER).try_into()?;
+        row.struct_version = version;
+        ctx.db
+            .get_cache_mut()?
+            .forge_reviews_mut()?
+            .set_all(vec![row])?;
+
+        assert_eq!(
+            projected_pr(&ctx)?,
+            None,
+            "an incompatible persisted review should behave like a cache miss"
+        );
+    }
+    Ok(())
+}
+
 fn context_with_remote_branch() -> anyhow::Result<(
     but_ctx::Context,
     but_testsupport::gix_testtools::tempfile::TempDir,

--- a/crates/but-db/src/table/forge_reviews.rs
+++ b/crates/but-db/src/table/forge_reviews.rs
@@ -179,16 +179,18 @@ impl ForgeReviewsHandleMut<'_> {
     ///
     /// The list is the source of truth for which reviews are currently *open*,
     /// with two deliberate exceptions that keep the cache useful — and
-    /// non-flickery — between syncs. The three steps run in a single savepoint,
+    /// non-flickery — between syncs. The four steps run in a single savepoint,
     /// so a partial reconcile is never observable.
     ///
-    /// 1. **Upsert everything listed.** Each listed review is inserted or
+    /// 1. **Delete rows with another `struct_version`.** Their missing fields
+    ///    cannot be reconstructed from persisted data.
+    /// 2. **Upsert everything listed.** Each listed review is inserted or
     ///    refreshed, which also bumps its `last_sync_at`.
-    /// 2. **Delete open reviews the forge no longer lists — but only stale ones**
+    /// 3. **Delete open reviews the forge no longer lists — but only stale ones**
     ///    (see [`delete_open_reviews_absent_from_list`]). A freshly-written
     ///    optimistic insert is spared via `absent_open_cutoff` so it doesn't
     ///    flicker off before the forge's eventually-consistent list catches up.
-    /// 3. **Prune old merged reviews** past `merged_cutoff` (see
+    /// 4. **Prune old merged reviews** past `merged_cutoff` (see
     ///    [`prune_merged_before`]). Closed (non-merged) reviews are always kept,
     ///    so direct lookups such as upstream-integration hints keep working.
     ///
@@ -197,9 +199,14 @@ impl ForgeReviewsHandleMut<'_> {
     pub fn reconcile_listed(
         self,
         reviews: Vec<ForgeReview>,
+        struct_version: i32,
         merged_cutoff: chrono::NaiveDateTime,
         absent_open_cutoff: chrono::NaiveDateTime,
     ) -> rusqlite::Result<()> {
+        self.sp.execute(
+            "DELETE FROM forge_reviews WHERE struct_version != ?1",
+            [struct_version],
+        )?;
         let listed_numbers = reviews
             .iter()
             .map(|review| review.number)

--- a/crates/but-db/tests/db/table/forge_review.rs
+++ b/crates/but-db/tests/db/table/forge_review.rs
@@ -245,7 +245,7 @@ fn reconcile_listed_prunes_stale_rows() -> anyhow::Result<()> {
     // All rows were synced at t=1_000_000, well before `cutoff`, so none fall
     // inside the optimistic-insert grace window here.
     db.forge_reviews_mut()?
-        .reconcile_listed(vec![listed_open.clone()], cutoff, cutoff)?;
+        .reconcile_listed(vec![listed_open.clone()], 2, cutoff, cutoff)?;
 
     let reviews = db.forge_reviews().list_all()?;
     assert_eq!(
@@ -286,7 +286,7 @@ fn reconcile_listed_spares_recent_optimistic_inserts() -> anyhow::Result<()> {
         .unwrap()
         .naive_utc();
     db.forge_reviews_mut()?
-        .reconcile_listed(vec![], cutoff, cutoff)?;
+        .reconcile_listed(vec![], 2, cutoff, cutoff)?;
 
     let reviews = db.forge_reviews().list_all()?;
     assert_eq!(
@@ -323,7 +323,7 @@ fn reconcile_listed_spares_recent_optimistic_inserts_with_non_empty_list() -> an
         .unwrap()
         .naive_utc();
     db.forge_reviews_mut()?
-        .reconcile_listed(vec![listed.clone()], cutoff, cutoff)?;
+        .reconcile_listed(vec![listed.clone()], 2, cutoff, cutoff)?;
 
     let reviews = db.forge_reviews().list_all()?;
     assert_eq!(

--- a/crates/but-forge/src/association.rs
+++ b/crates/but-forge/src/association.rs
@@ -26,7 +26,7 @@ pub fn review_for_head_ref(
     db: &but_db::DbHandle,
     head_ref_short: &str,
 ) -> anyhow::Result<Option<ForgeReview>> {
-    let reviews = crate::db::reviews_from_cache(db)?;
+    let reviews = crate::list_cached_forge_reviews(db)?;
     Ok(best_match(&reviews, head_ref_short).cloned())
 }
 
@@ -51,7 +51,7 @@ pub fn pr_numbers_by_head(db: &but_db::DbHandle) -> anyhow::Result<HashMap<Strin
 /// When several cached reviews share a `source_branch`, `preference` decides
 /// which one the key maps to.
 pub fn reviews_by_head(db: &but_db::DbHandle) -> anyhow::Result<HashMap<String, ForgeReview>> {
-    let reviews = crate::db::reviews_from_cache(db)?;
+    let reviews = crate::list_cached_forge_reviews(db)?;
     let mut map: HashMap<String, ForgeReview> = HashMap::new();
     for review in reviews {
         let replace = map

--- a/crates/but-forge/src/db.rs
+++ b/crates/but-forge/src/db.rs
@@ -90,13 +90,48 @@ impl TryFrom<but_db::ForgeReview> for ForgeReview {
     }
 }
 
-pub(crate) fn reviews_from_cache(db: &but_db::DbHandle) -> anyhow::Result<Vec<ForgeReview>> {
+pub(crate) struct CachedReviews {
+    reviews: Vec<ForgeReview>,
+    saw_incompatible: bool,
+}
+
+impl CachedReviews {
+    pub(crate) fn fresh_rows(
+        self,
+        max_age_seconds: u64,
+        now: chrono::NaiveDateTime,
+    ) -> Option<Vec<ForgeReview>> {
+        if self.saw_incompatible {
+            return None;
+        }
+        let last_sync_at = self.reviews.first()?.last_sync_at;
+        let age_seconds = (now - last_sync_at).num_seconds();
+        (age_seconds >= 0 && age_seconds as u64 <= max_age_seconds).then_some(self.reviews)
+    }
+}
+
+pub(crate) fn reviews_from_cache(db: &but_db::DbHandle) -> anyhow::Result<CachedReviews> {
     let db_reviews = db.forge_reviews().list_all()?;
-    let reviews: Vec<ForgeReview> = db_reviews
+    let expected_version = ForgeReview::struct_version();
+    let saw_incompatible = db_reviews
+        .iter()
+        .any(|review| review.struct_version != expected_version);
+    let reviews = db_reviews
         .into_iter()
-        .map(|r| r.try_into())
-        .collect::<anyhow::Result<Vec<ForgeReview>>>()?;
-    Ok(reviews)
+        .filter(|review| review.struct_version == expected_version)
+        .map(ForgeReview::try_from)
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    Ok(CachedReviews {
+        reviews,
+        saw_incompatible,
+    })
+}
+
+/// Lists compatible persisted reviews without performing network I/O.
+///
+/// Rows written with another [`ForgeReview::struct_version`] are cache misses.
+pub fn list_cached_forge_reviews(db: &but_db::DbHandle) -> anyhow::Result<Vec<ForgeReview>> {
+    Ok(reviews_from_cache(db)?.reviews)
 }
 
 /// Refreshes the cached review rows returned by a forge listing.
@@ -105,7 +140,8 @@ pub(crate) fn reviews_from_cache(db: &but_db::DbHandle) -> anyhow::Result<Vec<Fo
 /// fetched reviews, such as recently merged PRs used by upstream integration,
 /// are not deleted by an open-review list response. Cached open reviews that no
 /// longer appear in the listed response are deleted, while retained merged
-/// reviews are pruned after 15 days.
+/// reviews are pruned after 15 days. Rows written with another persisted-model
+/// version are deleted because their missing fields cannot be reconstructed.
 pub(crate) fn cache_reviews(
     db: &mut but_db::DbHandle,
     reviews: &[ForgeReview],
@@ -118,7 +154,12 @@ pub(crate) fn cache_reviews(
         .map(|review| review.clone().try_into())
         .collect::<anyhow::Result<Vec<_>>>()?;
     db.forge_reviews_mut()?
-        .reconcile_listed(db_reviews, merged_cutoff, absent_open_cutoff)
+        .reconcile_listed(
+            db_reviews,
+            ForgeReview::struct_version(),
+            merged_cutoff,
+            absent_open_cutoff,
+        )
         .map_err(anyhow::Error::from)?;
     Ok(())
 }
@@ -270,4 +311,175 @@ pub(crate) fn cache_ci_checks(
     db.ci_checks_mut()?
         .set_for_reference(reference, db_checks)
         .map_err(Into::into)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{cache_reviews, list_cached_forge_reviews, reviews_from_cache};
+    use crate::ForgeReview;
+
+    fn review(
+        number: i64,
+        source_branch: &str,
+        last_sync_at: chrono::NaiveDateTime,
+    ) -> ForgeReview {
+        ForgeReview {
+            html_url: String::new(),
+            number,
+            title: String::new(),
+            body: None,
+            author: None,
+            labels: Vec::new(),
+            draft: false,
+            source_branch: source_branch.to_string(),
+            target_branch: "main".to_string(),
+            sha: String::new(),
+            integration_commit_shas: Vec::new(),
+            created_at: None,
+            modified_at: None,
+            merged_at: None,
+            closed_at: None,
+            repository_ssh_url: None,
+            repository_https_url: None,
+            repo_owner: None,
+            head_repo_is_fork: false,
+            reviewers: Vec::new(),
+            unit_symbol: "#".to_string(),
+            last_sync_at,
+        }
+    }
+
+    fn test_db() -> (tempfile::TempDir, but_db::DbHandle) {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = but_db::DbHandle::new_in_directory(tmp.path()).unwrap();
+        (tmp, db)
+    }
+
+    fn stored_review(
+        number: i64,
+        source_branch: &str,
+        struct_version: i32,
+        last_sync_at: chrono::NaiveDateTime,
+    ) -> but_db::ForgeReview {
+        let mut row: but_db::ForgeReview = review(number, source_branch, last_sync_at)
+            .try_into()
+            .unwrap();
+        row.struct_version = struct_version;
+        row
+    }
+
+    #[test]
+    fn mixed_versions_are_filtered_and_force_a_refetch() {
+        let (_tmp, mut db) = test_db();
+        let now = chrono::Local::now().naive_local();
+        db.forge_reviews_mut()
+            .unwrap()
+            .set_all(vec![
+                stored_review(1, "stale-v1", 1, now),
+                stored_review(2, "stale-v2", 2, now),
+                stored_review(3, "current", ForgeReview::struct_version(), now),
+            ])
+            .unwrap();
+
+        let compatible = list_cached_forge_reviews(&db).unwrap();
+        assert_eq!(
+            compatible
+                .iter()
+                .map(|review| review.number)
+                .collect::<Vec<_>>(),
+            vec![3],
+            "cache-only readers should skip incompatible rows"
+        );
+        assert!(
+            reviews_from_cache(&db)
+                .unwrap()
+                .fresh_rows(60, now)
+                .is_none(),
+            "fallback readers should refetch rather than reuse a partial cache"
+        );
+    }
+
+    #[test]
+    fn compatible_fresh_rows_are_reused() {
+        let (_tmp, mut db) = test_db();
+        let now = chrono::Local::now().naive_local();
+        db.forge_reviews_mut()
+            .unwrap()
+            .set_all(vec![stored_review(
+                3,
+                "current",
+                ForgeReview::struct_version(),
+                now,
+            )])
+            .unwrap();
+
+        let cached = reviews_from_cache(&db)
+            .unwrap()
+            .fresh_rows(60, now)
+            .expect("a compatible fresh cache should be reused");
+        assert_eq!(cached[0].number, 3, "the cached review should be returned");
+    }
+
+    #[test]
+    fn compatible_stale_rows_force_a_refetch() {
+        let (_tmp, mut db) = test_db();
+        let now = chrono::Local::now().naive_local();
+        db.forge_reviews_mut()
+            .unwrap()
+            .set_all(vec![stored_review(
+                3,
+                "current",
+                ForgeReview::struct_version(),
+                now - chrono::Duration::seconds(61),
+            )])
+            .unwrap();
+
+        assert!(
+            reviews_from_cache(&db)
+                .unwrap()
+                .fresh_rows(60, now)
+                .is_none(),
+            "a compatible cache older than the maximum age should be refetched"
+        );
+    }
+
+    #[test]
+    fn refreshing_the_cache_deletes_incompatible_rows() {
+        let (_tmp, mut db) = test_db();
+        let now = chrono::Local::now().naive_local();
+        db.forge_reviews_mut()
+            .unwrap()
+            .set_all(vec![
+                stored_review(1, "stale-v1", 1, now),
+                stored_review(2, "stale-v2", 2, now),
+            ])
+            .unwrap();
+
+        cache_reviews(&mut db, &[review(3, "current", now)]).unwrap();
+
+        let rows = db.forge_reviews().list_all().unwrap();
+        assert_eq!(rows.len(), 1, "refresh should discard stale cache entries");
+        assert_eq!(
+            rows[0].struct_version,
+            ForgeReview::struct_version(),
+            "refreshed cache only contains the current persisted model"
+        );
+    }
+
+    #[test]
+    fn current_version_corruption_is_an_error() {
+        let (_tmp, mut db) = test_db();
+        let now = chrono::Local::now().naive_local();
+        let mut corrupt: but_db::ForgeReview = review(1, "corrupt", now).try_into().unwrap();
+        corrupt.labels = "not-json".to_string();
+        db.forge_reviews_mut()
+            .unwrap()
+            .set_all(vec![corrupt])
+            .unwrap();
+
+        assert!(
+            list_cached_forge_reviews(&db).is_err(),
+            "current-version corruption must not be treated as a cache miss"
+        );
+    }
 }

--- a/crates/but-forge/src/lib.rs
+++ b/crates/but-forge/src/lib.rs
@@ -6,6 +6,7 @@ pub use crate::forge::{ForgeName, ForgeRepoInfo, ForgeUser, deserialize_preferre
 mod association;
 mod ci;
 mod db;
+pub use db::list_cached_forge_reviews;
 mod forge_info;
 mod repo;
 mod review;

--- a/crates/but-forge/src/review.rs
+++ b/crates/but-forge/src/review.rs
@@ -516,14 +516,13 @@ pub fn list_forge_reviews_with_cache(
 ) -> Result<Vec<ForgeReview>> {
     let cache_config = cache_config.unwrap_or_default();
     let reviews = match cache_config {
-        CacheConfig::CacheOnly => crate::db::reviews_from_cache(db)?,
+        CacheConfig::CacheOnly => crate::list_cached_forge_reviews(db)?,
         CacheConfig::CacheWithFallback { max_age_seconds } => {
             let cached = crate::db::reviews_from_cache(db)?;
-            if let Some(last_sync) = cached.first().map(|r| r.last_sync_at) {
-                let age = chrono::Local::now().naive_local() - last_sync;
-                if !cached.is_empty() && age.num_seconds() as u64 <= max_age_seconds {
-                    return Ok(cached);
-                }
+            if let Some(reviews) =
+                cached.fresh_rows(max_age_seconds, chrono::Local::now().naive_local())
+            {
+                return Ok(reviews);
             }
             let reviews = list_forge_reviews(preferred_forge_user, forge_repo_info, storage)?;
             crate::db::cache_reviews(db, &reviews).ok();


### PR DESCRIPTION
ForgeReview cache rows persisted by older releases can have incompatible struct versions. Workspace and head projections were decoding every stored row, so stale cache data became a hard error and could prevent pull-request associations from being derived.

Treat version-mismatched rows as cache misses for cache-only projections, force fallback readers to refresh partial caches, and atomically discard incompatible rows after a successful refresh. Current-version corruption remains an error.

Fixes #14898