### PR TITLE
Prevent invalid branch integration graphs

### DIFF
--- a/apps/desktop/src/components/branch/BranchIntegrationModal.svelte
+++ b/apps/desktop/src/components/branch/BranchIntegrationModal.svelte
@@ -24,7 +24,7 @@
 		Badge,
 		chipToasts,
 	} from "@gitbutler/ui";
-	import type { BranchIntegrationStrategy } from "@gitbutler/but-sdk";
+	import type { BranchIntegrationStrategy, InitialBranchIntegration } from "@gitbutler/but-sdk";
 	import type { IconName } from "@gitbutler/ui";
 
 	type Props = {
@@ -85,10 +85,10 @@
 	let previewRows = $state<IntegrationGraphRow[] | null>(null);
 	let previewError = $state<string | null>(null);
 	let applying = $state(false);
-	let initializedForOpen = $state(false);
 	let showAllStrategies = $state(false);
 	let showIntegratedLocalCommits = $state(false);
 	let templateSelectionVersion = 0;
+	let initializedFrom: InitialBranchIntegration | undefined;
 
 	const visibleTemplates = $derived(
 		showAllStrategies
@@ -210,9 +210,10 @@
 	$effect(() => {
 		const modalOpen = modalRef?.imports.open ?? false;
 		if (!modalOpen) {
+			initializedFrom = undefined;
 			selectedTemplate = DEFAULT_TEMPLATE;
 			templateSelectionVersion++;
-			initializedForOpen = false;
+			stepDrafts = [];
 			showAllStrategies = false;
 			showIntegratedLocalCommits = false;
 			previewRows = null;
@@ -223,14 +224,15 @@
 	$effect(() => {
 		const modalOpen = modalRef?.imports.open ?? false;
 		const initial = initialBranchIntegration.response;
-		if (!modalOpen || !initial || initializedForOpen) return;
+		if (!modalOpen || !initial || initial === initializedFrom) return;
+		initializedFrom = initial;
 
 		const nextStepDrafts = buildIntegrationStepDrafts(initial.integration);
-		const version = templateSelectionVersion;
+		const version = ++templateSelectionVersion;
+		selectedTemplate = DEFAULT_TEMPLATE;
 		stepDrafts = nextStepDrafts;
 		previewRows = null;
 		previewError = null;
-		initializedForOpen = true;
 		if (nextStepDrafts.length > 0) {
 			void previewIntegrationWithSteps(
 				initial.integration.mergeBase,

--- a/apps/desktop/src/lib/stacks/stackEndpoints.test.ts
+++ b/apps/desktop/src/lib/stacks/stackEndpoints.test.ts
@@ -1,5 +1,11 @@
 import { buildStackEndpoints } from "$lib/stacks/stackEndpoints";
-import { invalidatesItem, invalidatesList, invalidatesType, ReduxTag } from "$lib/state/tags";
+import {
+	invalidatesItem,
+	invalidatesList,
+	invalidatesType,
+	providesList,
+	ReduxTag,
+} from "$lib/state/tags";
 import { describe, expect, test } from "vitest";
 import type { BackendEndpointBuilder } from "$lib/state/backendApi";
 
@@ -11,6 +17,30 @@ function createEndpointBuilder(): BackendEndpointBuilder {
 }
 
 describe("buildStackEndpoints", () => {
+	test("refreshes integration plans after pushing a stack", () => {
+		const endpoints = buildStackEndpoints(createEndpointBuilder());
+		const invalidatesTags = endpoints.pushWorkspaceBranchAndAncestors.invalidatesTags;
+		const args = {
+			projectId: "project-1",
+			stackId: "stack-1",
+			withForce: false,
+			skipForcePushProtection: false,
+			branch: "feature",
+			runHooks: true,
+			pushOpts: [],
+		};
+
+		if (typeof invalidatesTags !== "function") {
+			throw new Error("Expected pushWorkspaceBranchAndAncestors.invalidatesTags to be callable");
+		}
+
+		expect(invalidatesTags(undefined, undefined, args, undefined)).toEqual([
+			invalidatesItem(ReduxTag.StackDetails, "stack-1"),
+			invalidatesList(ReduxTag.StackDetails),
+			invalidatesList(ReduxTag.BranchListing),
+		]);
+	});
+
 	test("maps uncommit to commit_uncommit with the new request shape", () => {
 		const endpoints = buildStackEndpoints(createEndpointBuilder());
 		const query = endpoints.uncommit.query;
@@ -145,16 +175,6 @@ describe("buildStackEndpoints", () => {
 		]);
 	});
 
-	test("invalidates integration state after creating commits", () => {
-		const endpoints = buildStackEndpoints(createEndpointBuilder());
-
-		expect(endpoints.commitCreate.invalidatesTags).toEqual([
-			invalidatesList(ReduxTag.WorktreeChanges),
-			invalidatesList(ReduxTag.IntegrationSteps),
-			invalidatesList(ReduxTag.HeadSha),
-		]);
-	});
-
 	test("uses move_branch with normalized refs and dryRun disabled", () => {
 		const endpoints = buildStackEndpoints(createEndpointBuilder());
 		const query = endpoints.moveBranch.query;
@@ -219,6 +239,10 @@ describe("buildStackEndpoints", () => {
 		expect(endpoints.getInitialBranchIntegration.extraOptions).toEqual({
 			command: "get_initial_branch_integration",
 		});
+		expect(endpoints.getInitialBranchIntegration.providesTags).toEqual([
+			providesList(ReduxTag.HeadSha),
+			providesList(ReduxTag.StackDetails),
+		]);
 		expect(query).toBeDefined();
 		expect(
 			query?.({
@@ -272,7 +296,6 @@ describe("buildStackEndpoints", () => {
 			invalidatesList(ReduxTag.Stacks),
 			invalidatesList(ReduxTag.StackDetails),
 			invalidatesList(ReduxTag.BranchListing),
-			invalidatesItem(ReduxTag.IntegrationSteps, "refs/heads/feature"),
 		]);
 	});
 

--- a/apps/desktop/src/lib/stacks/stackEndpoints.ts
+++ b/apps/desktop/src/lib/stacks/stackEndpoints.ts
@@ -335,6 +335,7 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 			}),
 			invalidatesTags: (_result, _error, args) => [
 				invalidatesItem(ReduxTag.StackDetails, args.stackId),
+				invalidatesList(ReduxTag.StackDetails),
 				invalidatesList(ReduxTag.BranchListing),
 			],
 		}),
@@ -357,7 +358,6 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 			transformResponse: normalizeCreateCommitOutcome,
 			invalidatesTags: [
 				invalidatesList(ReduxTag.WorktreeChanges),
-				invalidatesList(ReduxTag.IntegrationSteps),
 				invalidatesList(ReduxTag.HeadSha),
 			],
 		}),
@@ -821,8 +821,7 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 				branch: branchRef,
 				strategy,
 			}),
-			providesTags: (_result, _error, { branchRef }) =>
-				providesItem(ReduxTag.IntegrationSteps, branchRef),
+			providesTags: [providesList(ReduxTag.HeadSha), providesList(ReduxTag.StackDetails)],
 		}),
 		applyBranchIntegration: build.mutation<
 			IntegrateBranchResult,
@@ -852,7 +851,6 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 							invalidatesList(ReduxTag.Stacks),
 							invalidatesList(ReduxTag.StackDetails),
 							invalidatesList(ReduxTag.BranchListing),
-							invalidatesItem(ReduxTag.IntegrationSteps, args.branchRef),
 						],
 		}),
 		branchApply: build.mutation<ApplyOutcome, { projectId: string; existingBranch: string }>({

--- a/apps/desktop/src/lib/state/tags.ts
+++ b/apps/desktop/src/lib/state/tags.ts
@@ -31,7 +31,6 @@ export enum ReduxTag {
 	InitalEditListing = "InitialEditListing",
 	EditChangesSinceInitial = "EditChangesSinceInitial",
 	AuthorInfo = "AuthorInfo",
-	IntegrationSteps = "IntegrationSteps",
 	GitConfigProperty = "GitConfigProperty",
 	GitButlerConfig = "GitButlerConfig",
 	IrcConnectionState = "IrcConnectionState",

--- a/crates/but-rebase/src/graph_rebase/mutate.rs
+++ b/crates/but-rebase/src/graph_rebase/mutate.rs
@@ -4,7 +4,7 @@ use std::collections::HashSet;
 
 use anyhow::{Context as _, Result, anyhow, bail};
 use but_core::RefMetadata;
-use petgraph::{Direction, visit::EdgeRef};
+use petgraph::{Direction, algo::has_path_connecting, visit::EdgeRef};
 use serde::{Deserialize, Serialize};
 
 use crate::graph_rebase::{
@@ -831,25 +831,8 @@ impl<M: RefMetadata> Editor<'_, '_, M> {
         let child = self.history.normalize_selector(child.to_selector(self)?)?;
         let parent = self.history.normalize_selector(parent.to_selector(self)?)?;
 
-        if cfg!(debug_assertions) {
-            let mut seen = HashSet::from([parent.id]);
-            let mut tips = vec![parent.id];
-
-            while let Some(tip) = tips.pop() {
-                for parent in self
-                    .graph
-                    .edges_directed(tip, Direction::Outgoing)
-                    .map(|e| e.target())
-                {
-                    if seen.insert(parent) {
-                        tips.push(parent);
-                    }
-                }
-            }
-
-            if seen.contains(&child.id) {
-                bail!("BUG: Add edge introduces a cycle");
-            }
+        if has_path_connecting(&self.graph, parent.id, child.id, None) {
+            bail!("BUG: Add edge introduces a cycle");
         }
 
         if self

--- a/crates/but-rebase/src/graph_rebase/rebase.rs
+++ b/crates/but-rebase/src/graph_rebase/rebase.rs
@@ -1,9 +1,6 @@
 //! Perform the actual rebase operations
 
-use std::{
-    collections::{HashMap, HashSet, VecDeque},
-    fmt::Write as _,
-};
+use std::{collections::HashMap, fmt::Write as _};
 
 use anyhow::{Context, Result, bail};
 use but_core::RefMetadata;
@@ -11,7 +8,7 @@ use gix::refs::{
     Target,
     transaction::{Change, LogChange, PreviousValue, RefEdit},
 };
-use petgraph::{Direction, visit::EdgeRef};
+use petgraph::{algo::toposort, visit::EdgeRef};
 
 use crate::graph_rebase::{
     Editor, Pick, Step, StepGraph, StepGraphIndex, SuccessfulRebase,
@@ -22,21 +19,8 @@ use crate::graph_rebase::{
 impl<'ws, 'graph, M: RefMetadata> Editor<'ws, 'graph, M> {
     /// Perform the rebase
     pub fn rebase(self) -> Result<SuccessfulRebase<'ws, 'graph, M>> {
-        // First we want to get a list of nodes that can be reached by
-        // traversing downwards from the heads that we care about.
-        // Usually there would be just one "head" which is an index to access
-        // the reference step for `gitbutler/workspace`, but there could be
-        // multiple.
-
         let mut ref_edits = vec![];
-        // Every external (a node with no children) seeds the traversal so the
-        // output graph keeps every commit - immutable picks are copied verbatim
-        // rather than cherry-picked.
-        let rebase_heads = self
-            .graph
-            .externals(Direction::Incoming)
-            .collect::<Vec<_>>();
-        let steps_to_pick = order_steps_picking(&self.graph, &rebase_heads);
+        let steps_to_pick = order_steps_picking(&self.graph)?;
 
         // A 1 to 1 mapping between the incoming graph and the output graph
         let mut graph_mapping: HashMap<StepGraphIndex, StepGraphIndex> = HashMap::new();
@@ -239,59 +223,15 @@ impl<'ws, 'graph, M: RefMetadata> Editor<'ws, 'graph, M> {
     }
 }
 
-/// Creates a list of step indicies ordered in the dependency order.
-///
-/// We do this by first doing a breadth-first traversal down from the heads
-/// (which would usually be the `gitbutler/workspace` reference step) in order
-/// to determine which steps are reachable, and what the bottom most steps are.
-///
-/// Then, we do a second traversal up from those bottom most
-/// steps.
-///
-/// This second traversal ensures that all the parents of any given node have
-/// been seen, before traversing it.
-fn order_steps_picking(graph: &StepGraph, heads: &[StepGraphIndex]) -> VecDeque<StepGraphIndex> {
-    let mut heads = heads.to_vec();
-    let mut seen = heads.iter().cloned().collect::<HashSet<StepGraphIndex>>();
-    // Reachable nodes with no outgoing nodes.
-    let mut bases = VecDeque::new();
-
-    while let Some(head) = heads.pop() {
-        let edges = graph.edges_directed(head, petgraph::Direction::Outgoing);
-
-        if edges.clone().count() == 0 {
-            bases.push_back(head);
-            continue;
-        }
-
-        for edge in edges {
-            let t = edge.target();
-            if seen.insert(t) {
-                heads.push(t);
-            }
-        }
-    }
-
-    // Now we want to create a vector that contains all the steps in
-    // dependency order.
-    let mut ordered = bases.clone();
-    let mut retraversed = bases.iter().cloned().collect::<HashSet<_>>();
-
-    while let Some(base) = bases.pop_front() {
-        for edge in graph.edges_directed(base, petgraph::Direction::Incoming) {
-            // We only want to queue nodes for traversing that have had all of their parents traversed.
-            let s = edge.source();
-            let mut outgoing_edges = graph.edges_directed(s, petgraph::Direction::Outgoing);
-            let all_parents_seen = outgoing_edges.clone().count() == 0
-                || outgoing_edges.all(|e| retraversed.contains(&e.target()));
-            if all_parents_seen && seen.contains(&s) && retraversed.insert(s) {
-                bases.push_back(s);
-                ordered.push_back(s);
-            };
-        }
-    }
-
-    ordered
+/// Return every graph step in parent-before-child dependency order.
+fn order_steps_picking(graph: &StepGraph) -> Result<Vec<StepGraphIndex>> {
+    let mut ordered = match toposort(graph, None) {
+        Ok(ordered) => ordered,
+        Err(_) => bail!("BUG: Rebase editor graph contains a cycle"),
+    };
+    // Editor edges point from child to parent, opposite Petgraph's topological order.
+    ordered.reverse();
+    Ok(ordered)
 }
 
 fn format_base_merge_error(
@@ -375,12 +315,23 @@ mod test {
 "#]]
             );
 
-            let ordered_from_a = order_steps_picking(&graph, &[a]);
+            let ordered_from_a = order_steps_picking(&graph)?;
             assert_eq!(&ordered_from_a, &[c, b, a]);
-            let ordered_from_b = order_steps_picking(&graph, &[b]);
-            assert_eq!(&ordered_from_b, &[c, b]);
-            let ordered_from_c = order_steps_picking(&graph, &[c]);
-            assert_eq!(&ordered_from_c, &[c]);
+
+            Ok(())
+        }
+
+        #[test]
+        fn incomplete_order_from_a_cycle_is_rejected() -> Result<()> {
+            let mut graph = StepGraph::new();
+            let commit = graph.add_node(Step::new_pick(gix::ObjectId::from_str(
+                "1000000000000000000000000000000000000000",
+            )?));
+            graph.add_edge(commit, commit, Edge { order: 0 });
+
+            let err = order_steps_picking(&graph)
+                .expect_err("a cyclic graph must not produce a partial rebase mapping");
+            assert_eq!(err.to_string(), "BUG: Rebase editor graph contains a cycle");
 
             Ok(())
         }
@@ -449,8 +400,33 @@ mod test {
 "#]]
             );
 
-            let ordered_from_a = order_steps_picking(&graph, &[f, h]);
-            assert_eq!(&ordered_from_a, &[e, d, h, c, g, f]);
+            let ordered_from_a = order_steps_picking(&graph)?;
+            assert_eq!(
+                ordered_from_a.len(),
+                graph.node_count(),
+                "topological ordering must include every graph component"
+            );
+            let position = |node| {
+                ordered_from_a
+                    .iter()
+                    .position(|candidate| *candidate == node)
+                    .expect("every graph node is present")
+            };
+            for (child, parent) in [
+                (a, b),
+                (b, c),
+                (c, d),
+                (d, e),
+                (f, g),
+                (g, c),
+                (h, d),
+                (i, j),
+            ] {
+                assert!(
+                    position(parent) < position(child),
+                    "every parent must be ordered before its child"
+                );
+            }
 
             Ok(())
         }
@@ -494,7 +470,7 @@ mod test {
 "#]]
             );
 
-            let ordered_from_a = order_steps_picking(&graph, &[a]);
+            let ordered_from_a = order_steps_picking(&graph)?;
             assert_eq!(&ordered_from_a, &[c, b, e, d, a]);
 
             Ok(())
@@ -539,7 +515,7 @@ mod test {
 "#]]
             );
 
-            let ordered_from_a = order_steps_picking(&graph, &[a]);
+            let ordered_from_a = order_steps_picking(&graph)?;
             assert_eq!(&ordered_from_a, &[c, b, e, d, a]);
 
             Ok(())

--- a/crates/but-rebase/tests/rebase/graph_rebase/edge.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/edge.rs
@@ -89,7 +89,6 @@ fn adding_an_existing_edge_causes_an_error() -> Result<()> {
 }
 
 #[test]
-#[cfg(debug_assertions)]
 fn adding_an_edge_that_introduces_a_cycle_causes_an_error() -> Result<()> {
     let (repo, mut meta) = fixture("four-commits")?;
 

--- a/crates/but-workspace/src/branch/integrate_branch_upstream/mod.rs
+++ b/crates/but-workspace/src/branch/integrate_branch_upstream/mod.rs
@@ -5,6 +5,7 @@ use std::{
 
 use anyhow::{Result, bail};
 use but_core::{RefMetadata, commit::Headers};
+use but_error::bail_precondition;
 use but_rebase::graph_rebase::{
     Editor, LookupStep, SuccessfulRebase, ToSelector,
     mutate::{SegmentDelimiter, SelectorSet},
@@ -17,7 +18,7 @@ use crate::{
     },
     divergence::{
         BranchMergeBaseCommits, classify_selectors_against_target_ref, commit_ids_from_selectors,
-        get_commits_until_merge_base,
+        find_local_commit_until_merge_base, get_commits_until_merge_base,
     },
 };
 use crate::{graph_manipulation::determine_parent_selector, resolve_tracking_branch_ref_name};
@@ -128,12 +129,23 @@ pub fn integrate_branch_with_steps<'ws, 'meta, M: RefMetadata>(
     let prepared_steps = prepare_integration_steps_for_editor(&editor, &integration.steps)?;
 
     let delimiter_child = editor.select_reference(ref_name)?;
-    let delimiter_parent =
-        if let Some(first_local_not_integrated_commit) = integration.first_local_not_integrated {
-            editor.select_commit(first_local_not_integrated_commit)?
-        } else {
-            editor.select_reference(ref_name)?
-        };
+    let delimiter_parent = match integration.first_local_not_integrated {
+        Some(commit_id) => {
+            let selector = find_local_commit_until_merge_base(
+                ref_name,
+                commit_id,
+                integration.merge_base,
+                &editor,
+            )?;
+            let Some(selector) = selector else {
+                bail_precondition!(
+                    "Integration plan is stale: the first local commit {commit_id} is no longer reachable from the selected branch. Refresh the integration plan and try again"
+                );
+            };
+            selector
+        }
+        None => delimiter_child,
+    };
     // Segment, from local-ref to the parent-most non-integrated local commit.
     // This represents the bounds of the commit chain we're about to manipulate and rebuild.
     let segment_delimiter = SegmentDelimiter {

--- a/crates/but-workspace/src/branch/integrate_branch_upstream/plan.rs
+++ b/crates/but-workspace/src/branch/integrate_branch_upstream/plan.rs
@@ -8,6 +8,7 @@ use but_core::{
     ChangeId, RefMetadata, RepositoryExt,
     commit::{add_conflict_markers, write_conflicted_tree},
 };
+use but_error::bail_precondition;
 use but_rebase::{
     commit::DateMode,
     graph_rebase::{
@@ -213,22 +214,36 @@ pub(super) fn prepare_integration_steps_for_editor<M: RefMetadata>(
     editor: &Editor<'_, '_, M>,
     steps: &[InteractiveIntegrationStep],
 ) -> Result<Vec<PreparedIntegrationStep>> {
-    steps
-        .iter()
-        .map(|step| match step {
-            InteractiveIntegrationStep::Pick { commit_id } => Ok(PreparedIntegrationStep::Pick {
+    let mut prepared = Vec::with_capacity(steps.len());
+    let mut commit_ids = HashSet::new();
+
+    for step in steps {
+        let step = match step {
+            InteractiveIntegrationStep::Pick { commit_id } => PreparedIntegrationStep::Pick {
                 commit_id: *commit_id,
-            }),
-            InteractiveIntegrationStep::Merge { commit_id } => Ok(PreparedIntegrationStep::Merge {
+            },
+            InteractiveIntegrationStep::Merge { commit_id } => PreparedIntegrationStep::Merge {
                 commit_id: *commit_id,
-            }),
+            },
             InteractiveIntegrationStep::Squash { commits, message } => {
-                Ok(PreparedIntegrationStep::Pick {
+                PreparedIntegrationStep::Pick {
                     commit_id: prepare_squash_step_for_editor(editor, commits, message.as_deref())?,
-                })
+                }
             }
-        })
-        .collect()
+        };
+        let commit_id = match &step {
+            PreparedIntegrationStep::Pick { commit_id }
+            | PreparedIntegrationStep::Merge { commit_id } => *commit_id,
+        };
+        if !commit_ids.insert(commit_id) {
+            bail_precondition!(
+                "Integration plan is invalid: prepared commit {commit_id} appears more than once"
+            );
+        }
+        prepared.push(step);
+    }
+
+    Ok(prepared)
 }
 
 /// Precompute the squash payload from the current editor/repository state,

--- a/crates/but-workspace/src/divergence.rs
+++ b/crates/but-workspace/src/divergence.rs
@@ -105,6 +105,31 @@ pub(crate) fn commit_ids_from_selectors<M: RefMetadata>(
         .collect()
 }
 
+/// Find `commit_id` on the effective local first-parent path above `merge_base`.
+///
+/// The effective tip includes workspace commits above the local branch ref, while
+/// bounding the walk at the plan's merge base keeps commits from other stacks out.
+pub(crate) fn find_local_commit_until_merge_base<M: RefMetadata>(
+    ref_name: &gix::refs::FullNameRef,
+    commit_id: gix::ObjectId,
+    merge_base: gix::ObjectId,
+    editor: &Editor<'_, '_, M>,
+) -> Result<Option<Selector>> {
+    let local_tip = tip_for_ref(editor, ref_name, editor.repo())?;
+    let mut path = first_parent_path_until(editor, local_tip, |selector| {
+        editor.lookup_pick(*selector).ok() == Some(merge_base)
+    })?;
+    let Some(path_end) = path.pop() else {
+        return Ok(None);
+    };
+    if editor.lookup_pick(path_end).ok() != Some(merge_base) {
+        return Ok(None);
+    }
+    Ok(path
+        .into_iter()
+        .find(|selector| editor.lookup_pick(*selector).ok() == Some(commit_id)))
+}
+
 /// Classify candidate selectors by whether the target branch reaches them.
 ///
 /// `editor` provides the graph traversal and pick lookup operations used during

--- a/crates/but-workspace/tests/workspace/branch/integrate_branch_upstream.rs
+++ b/crates/but-workspace/tests/workspace/branch/integrate_branch_upstream.rs
@@ -4,6 +4,7 @@ use std::vec;
 use anyhow::{Result, bail};
 use bstr::ByteSlice;
 use but_core::{ChangeId, Commit, RefMetadata, commit::Headers};
+use but_error::{AnyhowContextExt, Code};
 use but_graph::init::Options;
 use but_testsupport::gix_testtools::tempfile::TempDir;
 use but_testsupport::{InMemoryRefMetadata, visualize_commit_graph_all, visualize_tree};
@@ -968,6 +969,167 @@ fn integrate_branch_with_steps_empty_errors_early() -> Result<()> {
         err.to_string()
             .contains("Integration steps cannot be empty"),
         "unexpected error: {err:#}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn integrate_branch_with_steps_rejects_duplicate_prepared_commit() -> Result<()> {
+    let (_tmp, graph, repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "remote-diverged-with-workspace",
+            |meta| {
+                add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+            },
+        )?;
+    let mut ws = graph.into_workspace()?;
+    let remote_commit = repo.rev_parse_single("origin/A~1")?.detach();
+    let merge_base = repo.rev_parse_single("A~2")?.detach();
+    let integration = InteractiveIntegration {
+        merge_base,
+        first_local_not_integrated: None,
+        steps: vec![
+            InteractiveIntegrationStep::Pick {
+                commit_id: remote_commit,
+            },
+            InteractiveIntegrationStep::Pick {
+                commit_id: remote_commit,
+            },
+        ],
+    };
+
+    let err =
+        integrate_branch_with_steps(r("refs/heads/A"), integration, &mut ws, &mut meta, &repo)
+            .expect_err("a repeated commit would alias one editor node and create a self-cycle");
+    assert_eq!(
+        err.custom_context().map(|context| context.code),
+        Some(Code::PreconditionFailed),
+        "a malformed integration plan is a recoverable caller precondition"
+    );
+    assert!(
+        err.to_string().contains("prepared commit")
+            && err.to_string().contains("appears more than once"),
+        "the error should explain which plan invariant failed: {err:#}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn integrate_branch_with_steps_classifies_a_stale_first_local_commit() -> Result<()> {
+    let (_tmp, graph, repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "remote-diverged-with-workspace",
+            |meta| {
+                add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+            },
+        )?;
+    let mut ws = graph.into_workspace()?;
+    let local_commit = repo.rev_parse_single("A~1")?.detach();
+    let remote_commit = repo.rev_parse_single("origin/A~1")?.detach();
+    let merge_base = repo.rev_parse_single("A~2")?.detach();
+    let mut stale_commit = repo.find_commit(local_commit)?.decode()?.to_owned()?;
+    stale_commit.message = "unreachable stale integration commit".into();
+    let stale_commit = repo.write_object(stale_commit)?.detach();
+    let integration = InteractiveIntegration {
+        merge_base,
+        first_local_not_integrated: Some(stale_commit),
+        steps: vec![InteractiveIntegrationStep::Pick {
+            commit_id: remote_commit,
+        }],
+    };
+
+    let err =
+        integrate_branch_with_steps(r("refs/heads/A"), integration, &mut ws, &mut meta, &repo)
+            .expect_err("an integration plan must be refreshed after its boundary commit changes");
+    assert_eq!(
+        err.custom_context().map(|context| context.code),
+        Some(Code::PreconditionFailed),
+        "a stale cross-operation plan is a recoverable caller precondition"
+    );
+    assert!(
+        err.to_string().contains("Integration plan is stale")
+            && err.to_string().contains(&stale_commit.to_string()),
+        "the error should identify the stale commit and recovery: {err:#}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn integrate_branch_with_steps_accepts_a_duplicate_merge_base_pick_off_path() -> Result<()> {
+    let (_tmp, graph, repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "remote-diverged-with-workspace",
+            |meta| {
+                add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+            },
+        )?;
+    let mut ws = graph.into_workspace()?;
+    let local_commit = repo.rev_parse_single("A~1")?.detach();
+    let remote_commit = repo.rev_parse_single("origin/A~1")?.detach();
+    let merge_base = repo.rev_parse_single("A~2")?.detach();
+    let duplicate_merge_base = ws
+        .graph
+        .segment_by_commit_id(merge_base)?
+        .commit_by_id(merge_base)
+        .expect("the merge-base segment contains the merge-base commit")
+        .clone();
+    let remote_segment = ws
+        .graph
+        .segment_by_ref_name(r("refs/remotes/origin/A"))
+        .expect("the fixture has the tracked remote branch")
+        .id;
+    ws.graph[remote_segment].commits.push(duplicate_merge_base);
+
+    let integration = InteractiveIntegration {
+        merge_base,
+        first_local_not_integrated: Some(local_commit),
+        steps: vec![InteractiveIntegrationStep::Pick {
+            commit_id: remote_commit,
+        }],
+    };
+
+    integrate_branch_with_steps(r("refs/heads/A"), integration, &mut ws, &mut meta, &repo)?;
+
+    Ok(())
+}
+
+#[test]
+fn integrate_branch_with_steps_rejects_a_boundary_from_another_branch() -> Result<()> {
+    let (_tmp, graph, repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "ws-ref-ws-commit-single-stack-double-stack",
+            |meta| {
+                add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+                add_stack_with_segments(meta, 2, "C", StackState::InWorkspace, &["B"]);
+            },
+        )?;
+    let mut ws = graph.into_workspace()?;
+    let boundary_on_b = repo.rev_parse_single("B")?.detach();
+    let integration = InteractiveIntegration {
+        merge_base: repo.rev_parse_single("main")?.detach(),
+        first_local_not_integrated: Some(boundary_on_b),
+        steps: vec![InteractiveIntegrationStep::Pick {
+            commit_id: repo.rev_parse_single("C")?.detach(),
+        }],
+    };
+
+    let err =
+        integrate_branch_with_steps(r("refs/heads/A"), integration, &mut ws, &mut meta, &repo)
+            .expect_err("a boundary on another branch must not delimit the selected branch");
+    assert_eq!(
+        err.custom_context().map(|context| context.code),
+        Some(Code::PreconditionFailed),
+        "a moved integration boundary is a recoverable caller precondition"
+    );
+    assert!(
+        err.to_string().contains("Integration plan is stale")
+            && err
+                .to_string()
+                .contains("no longer reachable from the selected branch"),
+        "the error should explain that the boundary moved to another branch: {err:#}"
     );
 
     Ok(())


### PR DESCRIPTION
Branch integration could accept cyclic editor graphs in release builds and then produce incomplete selector mappings during materialization or preview. Integration plans could also retain a boundary commit after that commit was removed from the branch graph.

This makes cycle validation unconditional, orders the complete editor graph topologically, rejects duplicate prepared steps, reports stale boundaries as refreshable preconditions, and derives integration-plan freshness from canonical workspace state.

Why this surfaced in 0.21.1: #14691 redesigned the integration modal around a default integration query plus separately fetched strategy previews. It preserved the previous preview while a new plan loaded and stopped blocking Apply for every in-flight integration mutation. That made stale or mixed-generation plans easier to submit, exposing pre-existing cache and graph-invariant bugs rather than introducing them.

Relevant history: #13521 deliberately limited editor cycle validation to debug builds under the assumption that callers could not create cycles. #14088 introduced the integration-plan cache without tying its freshness to every workspace mutation that can change the plan.