### PR TITLE
Handle missing Bitbucket CI refs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1089,6 +1089,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tokio",
  "tracing",
  "urlencoding",
 ]

--- a/apps/desktop/src/components/settings/BitbucketIntegration.svelte
+++ b/apps/desktop/src/components/settings/BitbucketIntegration.svelte
@@ -117,7 +117,8 @@
 					{/snippet}
 
 					{#snippet caption()}
-						Requires an API token with read/write access to repositories and pull requests.
+						Requires read:user:bitbucket, read:repository:bitbucket, read:pullrequest:bitbucket, and
+						write:pullrequest:bitbucket.
 						<br />
 						<Link href="https://id.atlassian.com/manage-profile/security/api-tokens"
 							>Create one on id.atlassian.com</Link

--- a/crates/but-bitbucket/Cargo.toml
+++ b/crates/but-bitbucket/Cargo.toml
@@ -33,6 +33,7 @@ but-schemars = { workspace = true, optional = true }
 [dev-dependencies]
 reqwest = { workspace = true, features = ["blocking"] }
 serde_json.workspace = true
+tokio = { workspace = true, features = ["macros", "rt"] }
 
 [lints]
 workspace = true

--- a/crates/but-bitbucket/src/client.rs
+++ b/crates/but-bitbucket/src/client.rs
@@ -433,71 +433,113 @@ impl BitbucketClient {
 
     /// List commit build statuses for a git reference.
     ///
-    /// Bitbucket's statuses endpoint is keyed by commit hash, so a branch name is
-    /// first resolved to its head commit; anything else is treated as a commit
-    /// revspec directly.
+    /// `None` means the repository is accessible but the reference does not
+    /// resolve. Bitbucket's statuses endpoint accepts branch names and commit
+    /// hashes directly, so a separate branch lookup is unnecessary.
     pub async fn list_checks_for_ref(
         &self,
         workspace: &str,
         repo_slug: &str,
         reference: &str,
-    ) -> Result<Vec<BitbucketBuildStatus>> {
-        let commit = self
-            .resolve_commit_hash(workspace, repo_slug, reference)
-            .await?;
+    ) -> Result<Option<Vec<BitbucketBuildStatus>>> {
         let url = format!(
             "{}/repositories/{}/{}/commit/{}/statuses?pagelen=100",
             self.base_url,
             urlencoding::encode(workspace),
             urlencoding::encode(repo_slug),
-            urlencoding::encode(&commit),
-        );
-        let statuses: Vec<BitbucketApiBuildStatus> = self.get_paginated(url).await?;
-        Ok(statuses
-            .into_iter()
-            .map(|s| BitbucketBuildStatus::from_api(s, &commit))
-            .collect())
-    }
-
-    /// Resolve a branch name to its head commit hash, falling back to treating
-    /// `reference` as a commit revspec when it isn't a branch.
-    async fn resolve_commit_hash(
-        &self,
-        workspace: &str,
-        repo_slug: &str,
-        reference: &str,
-    ) -> Result<String> {
-        if is_full_commit_hash(reference) {
-            return Ok(reference.to_string());
-        }
-        let url = format!(
-            "{}/repositories/{}/{}/refs/branches/{}",
-            self.base_url,
-            urlencoding::encode(workspace),
-            urlencoding::encode(repo_slug),
-            encode_branch_path(reference),
+            urlencoding::encode(reference),
         );
         let response = self.client.get(&url).send().await?;
         let status = response.status();
-        if status.is_success() {
-            #[derive(Deserialize)]
-            struct Branch {
-                target: Target,
-            }
-            #[derive(Deserialize)]
-            struct Target {
-                hash: String,
-            }
-            let branch: Branch = response.json().await?;
-            return Ok(branch.target.hash);
-        }
-        // 404 means it isn't a branch — treat the reference as a commit revspec.
-        // Any other status (auth failure, server error) is a real error to surface
-        // rather than silently returning empty checks.
         if status == reqwest::StatusCode::NOT_FOUND {
-            return Ok(reference.to_string());
+            let repository_status = self.repository_status(workspace, repo_slug).await?;
+            if repository_status.is_success() {
+                return Ok(None);
+            }
+            if matches!(
+                repository_status,
+                reqwest::StatusCode::UNAUTHORIZED
+                    | reqwest::StatusCode::FORBIDDEN
+                    | reqwest::StatusCode::NOT_FOUND
+            ) {
+                return Err(self
+                    .classify_repository_access_error(repository_status, workspace, repo_slug)
+                    .await);
+            }
+            return Err(anyhow::Error::new(HttpStatusError {
+                status: repository_status,
+            })
+            .context("Failed to verify Bitbucket repository access"));
         }
-        Err(HttpStatusError { status }.into())
+        if matches!(
+            status,
+            reqwest::StatusCode::UNAUTHORIZED | reqwest::StatusCode::FORBIDDEN
+        ) {
+            return Err(self
+                .classify_repository_access_error(status, workspace, repo_slug)
+                .await);
+        }
+        if !status.is_success() {
+            bail!("Bitbucket request failed: {status}");
+        }
+
+        let page: Paginated<BitbucketApiBuildStatus> = response.json().await?;
+        let mut statuses = page.values;
+        if let Some(next) = page.next {
+            statuses.extend(self.get_paginated(next).await?);
+        }
+        Ok(Some(
+            statuses
+                .into_iter()
+                .map(BitbucketBuildStatus::from_api)
+                .collect(),
+        ))
+    }
+
+    async fn repository_status(
+        &self,
+        workspace: &str,
+        repo_slug: &str,
+    ) -> Result<reqwest::StatusCode> {
+        let url = format!(
+            "{}/repositories/{}/{}",
+            self.base_url,
+            urlencoding::encode(workspace),
+            urlencoding::encode(repo_slug),
+        );
+        let response = self.client.get(&url).send().await?;
+        Ok(response.status())
+    }
+
+    /// Turn an ambiguous repository API failure into an actionable error.
+    ///
+    /// Repository endpoints can hide both inaccessible repositories and missing
+    /// scopes behind 404/401. `/user` only separates invalid credentials; a
+    /// valid token still cannot distinguish repository access from missing scope.
+    async fn classify_repository_access_error(
+        &self,
+        status: reqwest::StatusCode,
+        workspace: &str,
+        repo_slug: &str,
+    ) -> anyhow::Error {
+        if let Err(err) = self.get_authenticated().await {
+            if let Some(http_err) = err.downcast_ref::<HttpStatusError>() {
+                return match http_err.status {
+                    reqwest::StatusCode::UNAUTHORIZED => {
+                        err.context("Bitbucket credentials are invalid or expired")
+                    }
+                    reqwest::StatusCode::FORBIDDEN => err.context(
+                        "Bitbucket API token is missing required scope `read:user:bitbucket`",
+                    ),
+                    _ => err.context("Failed to verify Bitbucket credentials"),
+                };
+            }
+            return err.context("Failed to verify Bitbucket credentials");
+        }
+
+        anyhow::Error::new(HttpStatusError { status }).context(format!(
+            "Bitbucket repository '{workspace}/{repo_slug}' is inaccessible to this token, or the token is missing required scope `read:repository:bitbucket`"
+        ))
     }
 }
 
@@ -524,23 +566,6 @@ pub(crate) fn resolve_account(
     };
 
     Ok(account.to_owned())
-}
-
-/// Whether `reference` is a full 40-character SHA-1 commit hash, in which case it
-/// can be used against the statuses endpoint directly without a branch lookup.
-fn is_full_commit_hash(reference: &str) -> bool {
-    reference.len() == 40 && reference.bytes().all(|b| b.is_ascii_hexdigit())
-}
-
-/// Percent-encode a git ref for use as the `refs/branches/{name}` path, encoding
-/// each path segment individually so `/` stays a literal separator (encoding the
-/// whole ref would turn `feature/x` into `feature%2Fx`, which Bitbucket 404s).
-fn encode_branch_path(reference: &str) -> String {
-    reference
-        .split('/')
-        .map(|segment| urlencoding::encode(segment).into_owned())
-        .collect::<Vec<_>>()
-        .join("/")
 }
 
 /// Escape a value for embedding inside a double-quoted Bitbucket query-language
@@ -873,11 +898,7 @@ pub struct BitbucketBuildStatus {
 }
 
 impl BitbucketBuildStatus {
-    fn from_api(status: BitbucketApiBuildStatus, fallback_commit: &str) -> Self {
-        let commit_hash = status
-            .commit
-            .and_then(|c| c.hash)
-            .unwrap_or_else(|| fallback_commit.to_owned());
+    fn from_api(status: BitbucketApiBuildStatus) -> Self {
         // Bitbucket requires `key`; `name` is optional, so fall back to it.
         let name = status.name.unwrap_or_else(|| status.key.clone());
         BitbucketBuildStatus {
@@ -886,7 +907,7 @@ impl BitbucketBuildStatus {
             description: status.description,
             state: status.state,
             url: status.url,
-            commit_hash,
+            commit_hash: status.commit.hash,
             created_on: status.created_on,
             updated_on: status.updated_on,
         }
@@ -903,12 +924,16 @@ struct BitbucketApiBuildStatus {
     state: String,
     #[serde(default)]
     url: Option<String>,
-    #[serde(default)]
-    commit: Option<BitbucketCommitRef>,
+    commit: BitbucketBuildStatusCommit,
     #[serde(default)]
     created_on: Option<String>,
     #[serde(default)]
     updated_on: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct BitbucketBuildStatusCommit {
+    hash: String,
 }
 
 pub struct CreatePullRequestParams<'a> {
@@ -1031,6 +1056,9 @@ struct BranchBody<'a> {
 struct RepositoryBody<'a> {
     full_name: &'a str,
 }
+
+#[cfg(test)]
+mod checks_tests;
 
 #[cfg(test)]
 mod tests {
@@ -1227,35 +1255,6 @@ mod tests {
         assert!(pr.is_open());
         assert_eq!(pr.merged_at(), None);
         assert_eq!(pr.closed_at(), None);
-    }
-
-    #[test]
-    fn encode_branch_path_keeps_slashes_literal() {
-        assert_eq!(encode_branch_path("feature/login"), "feature/login");
-        assert_eq!(encode_branch_path("main"), "main");
-        // Per-segment encoding still escapes characters within a segment.
-        assert_eq!(encode_branch_path("feat/a b"), "feat/a%20b");
-        assert_eq!(encode_branch_path("a/b/c"), "a/b/c");
-    }
-
-    #[test]
-    fn is_full_commit_hash_only_matches_40_char_hex() {
-        assert!(is_full_commit_hash(
-            "0123456789abcdef0123456789abcdef01234567"
-        ));
-        assert!(is_full_commit_hash(
-            "0123456789ABCDEF0123456789ABCDEF01234567"
-        ));
-        // A branch name, a short hash, and an over-long string are all rejected.
-        assert!(!is_full_commit_hash("main"));
-        assert!(!is_full_commit_hash("0123456"));
-        assert!(!is_full_commit_hash(
-            "0123456789abcdef0123456789abcdef012345678"
-        ));
-        // 40 chars but not all hex.
-        assert!(!is_full_commit_hash(
-            "feature/0123456789abcdef0123456789abcdef"
-        ));
     }
 
     #[test]

--- a/crates/but-bitbucket/src/client/checks_tests.rs
+++ b/crates/but-bitbucket/src/client/checks_tests.rs
@@ -1,0 +1,333 @@
+use super::*;
+use std::io::{ErrorKind, Read as _, Write as _};
+use std::net::TcpListener;
+use std::time::{Duration, Instant};
+
+struct MockResponse {
+    path: &'static str,
+    status: reqwest::StatusCode,
+    body: &'static str,
+}
+
+fn mock_client(responses: Vec<MockResponse>) -> (BitbucketClient, std::thread::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    listener.set_nonblocking(true).unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = std::thread::spawn(move || {
+        for expected in responses {
+            let deadline = Instant::now() + Duration::from_secs(2);
+            let mut stream = loop {
+                match listener.accept() {
+                    Ok((stream, _)) => break stream,
+                    Err(err)
+                        if err.kind() == ErrorKind::WouldBlock && Instant::now() < deadline =>
+                    {
+                        std::thread::sleep(Duration::from_millis(5));
+                    }
+                    Err(err) => panic!("expected request to {}: {err}", expected.path),
+                }
+            };
+            stream.set_nonblocking(false).unwrap();
+
+            let mut request = Vec::new();
+            let mut chunk = [0; 1024];
+            while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+                let read = stream.read(&mut chunk).unwrap();
+                assert_ne!(read, 0, "request should include complete HTTP headers");
+                request.extend_from_slice(&chunk[..read]);
+            }
+            let request = String::from_utf8(request).unwrap();
+            let mut request_line = request.lines().next().unwrap().split_whitespace();
+            assert_eq!(
+                request_line.next(),
+                Some("GET"),
+                "checks client uses GET requests"
+            );
+            assert_eq!(
+                request_line.next(),
+                Some(expected.path),
+                "checks client requests the expected endpoint"
+            );
+
+            let reason = expected.status.canonical_reason().unwrap_or("Unknown");
+            write!(
+                stream,
+                "HTTP/1.1 {} {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                expected.status.as_u16(),
+                reason,
+                expected.body.len(),
+                expected.body
+            )
+            .unwrap();
+        }
+    });
+    let mut client =
+        BitbucketClient::new("user@example.com", &Sensitive("test-token".to_string())).unwrap();
+    client.base_url = format!("http://{addr}");
+    (client, server)
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn lists_checks_directly_for_a_branch() {
+    let (client, server) = mock_client(vec![MockResponse {
+        path: "/repositories/workspace/repo/commit/feature/statuses?pagelen=100",
+        status: reqwest::StatusCode::OK,
+        body: r#"{"values":[{"key":"build","state":"SUCCESSFUL","commit":{"hash":"0123456789abcdef0123456789abcdef01234567"}}]}"#,
+    }]);
+
+    let checks = client
+        .list_checks_for_ref("workspace", "repo", "feature")
+        .await
+        .expect("resolved branch should list checks")
+        .expect("resolved branch should be authoritative");
+    assert_eq!(checks.len(), 1, "the returned build status is preserved");
+    assert_eq!(
+        checks[0].commit_hash, "0123456789abcdef0123456789abcdef01234567",
+        "the resolved commit hash comes from the status response"
+    );
+    server.join().unwrap();
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn slash_branch_is_encoded_for_the_statuses_endpoint() {
+    let (client, server) = mock_client(vec![MockResponse {
+        path: "/repositories/workspace/repo/commit/feature%2Flogin/statuses?pagelen=100",
+        status: reqwest::StatusCode::OK,
+        body: r#"{"values":[]}"#,
+    }]);
+
+    let checks = client
+        .list_checks_for_ref("workspace", "repo", "feature/login")
+        .await
+        .expect("a slash branch should resolve through the statuses endpoint")
+        .expect("a slash branch with no statuses is authoritative");
+    assert!(
+        checks.is_empty(),
+        "a slash branch without statuses has no checks"
+    );
+    server.join().unwrap();
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn empty_statuses_are_authoritative() {
+    let (client, server) = mock_client(vec![MockResponse {
+        path: "/repositories/workspace/repo/commit/feature/statuses?pagelen=100",
+        status: reqwest::StatusCode::OK,
+        body: r#"{"values":[]}"#,
+    }]);
+
+    let checks = client
+        .list_checks_for_ref("workspace", "repo", "feature")
+        .await
+        .expect("an existing ref without statuses should succeed")
+        .expect("an existing ref without statuses is authoritative");
+    assert!(
+        checks.is_empty(),
+        "an existing ref without statuses has no checks"
+    );
+    server.join().unwrap();
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn status_without_a_commit_hash_is_rejected() {
+    let (client, server) = mock_client(vec![MockResponse {
+        path: "/repositories/workspace/repo/commit/feature/statuses?pagelen=100",
+        status: reqwest::StatusCode::OK,
+        body: r#"{"values":[{"key":"build","state":"SUCCESSFUL"}]}"#,
+    }]);
+
+    let err = client
+        .list_checks_for_ref("workspace", "repo", "feature")
+        .await
+        .expect_err("a status without its resolved commit hash is malformed");
+    assert!(
+        format!("{err:#}").contains("missing field `commit`"),
+        "a malformed status must not use the branch name as a commit hash: {err:#}"
+    );
+    server.join().unwrap();
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn missing_ref_is_unresolved_when_the_repository_is_accessible() {
+    let (client, server) = mock_client(vec![
+        MockResponse {
+            path: "/repositories/workspace/repo/commit/deleted-branch/statuses?pagelen=100",
+            status: reqwest::StatusCode::NOT_FOUND,
+            body: "{}",
+        },
+        MockResponse {
+            path: "/repositories/workspace/repo",
+            status: reqwest::StatusCode::OK,
+            body: "{}",
+        },
+    ]);
+
+    let checks = client
+        .list_checks_for_ref("workspace", "repo", "deleted-branch")
+        .await
+        .expect("an accessible repository with a missing ref is not an API failure");
+    assert!(
+        checks.is_none(),
+        "a missing ref must not replace authoritative cached checks"
+    );
+    server.join().unwrap();
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn inaccessible_repository_is_not_misclassified_as_a_missing_ref() {
+    let (client, server) = mock_client(vec![
+        MockResponse {
+            path: "/repositories/workspace/repo/commit/feature/statuses?pagelen=100",
+            status: reqwest::StatusCode::NOT_FOUND,
+            body: "{}",
+        },
+        MockResponse {
+            path: "/repositories/workspace/repo",
+            status: reqwest::StatusCode::NOT_FOUND,
+            body: "{}",
+        },
+        MockResponse {
+            path: "/user",
+            status: reqwest::StatusCode::OK,
+            body: "{}",
+        },
+    ]);
+
+    let err = client
+        .list_checks_for_ref("workspace", "repo", "feature")
+        .await
+        .expect_err("an inaccessible repository should remain an error");
+    assert!(
+        err.to_string().contains("inaccessible to this token"),
+        "repository access errors should be actionable: {err:#}"
+    );
+    server.join().unwrap();
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn repository_probe_server_error_is_not_misclassified_as_an_access_failure() {
+    let (client, server) = mock_client(vec![
+        MockResponse {
+            path: "/repositories/workspace/repo/commit/feature/statuses?pagelen=100",
+            status: reqwest::StatusCode::NOT_FOUND,
+            body: "{}",
+        },
+        MockResponse {
+            path: "/repositories/workspace/repo",
+            status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+            body: "{}",
+        },
+    ]);
+
+    let err = client
+        .list_checks_for_ref("workspace", "repo", "feature")
+        .await
+        .expect_err("a repository probe server failure should remain an error");
+    assert!(
+        format!("{err:#}").contains("HTTP 500 Internal Server Error"),
+        "the repository probe preserves its server status: {err:#}"
+    );
+    assert!(
+        !err.to_string().contains("missing required scope"),
+        "a server failure must not be presented as a scope problem: {err:#}"
+    );
+    server.join().unwrap();
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn repository_scope_failure_is_distinct_from_a_missing_ref() {
+    let (client, server) = mock_client(vec![
+        MockResponse {
+            path: "/repositories/workspace/repo/commit/feature/statuses?pagelen=100",
+            status: reqwest::StatusCode::FORBIDDEN,
+            body: "{}",
+        },
+        MockResponse {
+            path: "/user",
+            status: reqwest::StatusCode::OK,
+            body: "{}",
+        },
+    ]);
+
+    let err = client
+        .list_checks_for_ref("workspace", "repo", "feature")
+        .await
+        .expect_err("repository scope failure should remain an error");
+    assert!(
+        err.to_string().contains("read:repository:bitbucket"),
+        "scope errors should name the required scope: {err:#}"
+    );
+    server.join().unwrap();
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn invalid_credentials_are_distinct_from_repository_access() {
+    let (client, server) = mock_client(vec![
+        MockResponse {
+            path: "/repositories/workspace/repo/commit/feature/statuses?pagelen=100",
+            status: reqwest::StatusCode::UNAUTHORIZED,
+            body: "{}",
+        },
+        MockResponse {
+            path: "/user",
+            status: reqwest::StatusCode::UNAUTHORIZED,
+            body: "{}",
+        },
+    ]);
+
+    let err = client
+        .list_checks_for_ref("workspace", "repo", "feature")
+        .await
+        .expect_err("invalid credentials should remain an error");
+    assert!(
+        err.to_string().contains("invalid or expired"),
+        "credential errors should not be presented as access failures: {err:#}"
+    );
+    server.join().unwrap();
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn user_scope_failure_is_distinct_from_invalid_credentials() {
+    let (client, server) = mock_client(vec![
+        MockResponse {
+            path: "/repositories/workspace/repo/commit/feature/statuses?pagelen=100",
+            status: reqwest::StatusCode::FORBIDDEN,
+            body: "{}",
+        },
+        MockResponse {
+            path: "/user",
+            status: reqwest::StatusCode::FORBIDDEN,
+            body: "{}",
+        },
+    ]);
+
+    let err = client
+        .list_checks_for_ref("workspace", "repo", "feature")
+        .await
+        .expect_err("missing user scope should remain an error");
+    assert!(
+        err.to_string().contains("read:user:bitbucket"),
+        "user scope errors should name the required scope: {err:#}"
+    );
+    server.join().unwrap();
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn unrelated_status_errors_are_preserved() {
+    let (client, server) = mock_client(vec![MockResponse {
+        path: "/repositories/workspace/repo/commit/feature/statuses?pagelen=100",
+        status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+        body: "{}",
+    }]);
+
+    let err = client
+        .list_checks_for_ref("workspace", "repo", "feature")
+        .await
+        .expect_err("server failures should remain errors");
+    assert_eq!(
+        err.to_string(),
+        "Bitbucket request failed: 500 Internal Server Error",
+        "unrelated status failures keep their original error"
+    );
+    server.join().unwrap();
+}

--- a/crates/but-forge/src/ci.rs
+++ b/crates/but-forge/src/ci.rs
@@ -44,8 +44,8 @@ pub fn ci_checks_for_ref_with_cache(
 ///
 /// A resolvable ref returns an authoritative list — even an empty one, which
 /// replaces the cache (e.g. after a force-push to a commit that has no CI). An
-/// unresolvable ref (`None`, e.g. a transient GitHub 422 before a pushed ref
-/// propagates) is surfaced as "no checks" for display but must not overwrite the
+/// unresolvable ref (`None`, e.g. a transient GitHub 422 or a deleted Bitbucket
+/// branch) is surfaced as "no checks" for display but must not overwrite the
 /// previously-good checks that cache-only readers such as `but status` rely on,
 /// since it can be transient.
 fn fetch_and_refresh_cache(
@@ -63,8 +63,8 @@ fn fetch_and_refresh_cache(
 ///
 /// `Some(checks)` is authoritative and refreshes the cache — even an empty vec,
 /// which clears it (e.g. after a force-push to a commit that has no CI). `None`
-/// means the ref did not resolve (a transient GitHub 422); it is surfaced as "no
-/// checks" for display but deliberately leaves the cache untouched, since a
+/// means the ref did not resolve; it is surfaced as "no checks" for display but
+/// deliberately leaves the cache untouched, since a
 /// cache-only reader such as `but status` must not lose previously-good checks
 /// to a momentary blip.
 fn refresh_cache_with_fetched(
@@ -81,8 +81,7 @@ fn refresh_cache_with_fetched(
     }
 }
 
-/// Fetch checks from the forge. `None` means the ref did not resolve (only
-/// GitHub distinguishes this today); every other forge returns `Some`.
+/// Fetch checks from the forge. `None` means the ref did not resolve.
 fn ci_checks_for_ref(
     preferred_forge_user: Option<crate::ForgeUser>,
     forge_repo_info: &crate::forge::ForgeRepoInfo,
@@ -180,7 +179,7 @@ fn ci_checks_for_ref(
             .join()
             .map_err(|e| anyhow::anyhow!("Failed to join thread: {e:?}"))??;
 
-            Ok(Some(
+            Ok(statuses.map(|statuses| {
                 statuses
                     .into_iter()
                     .map(|status| {
@@ -188,8 +187,8 @@ fn ci_checks_for_ref(
                         ci_check.reference = reference_for_checks.to_string();
                         ci_check
                     })
-                    .collect(),
-            ))
+                    .collect()
+            }))
         }
         _ => Err(anyhow::anyhow!(
             "Listing ci checks for forge {forge:?} is not implemented yet."
@@ -552,8 +551,8 @@ mod tests {
         let (_tmp, mut db) = test_db();
         refresh_cache_with_fetched(&mut db, REFERENCE, Some(vec![cache_check(1)]));
 
-        // An unresolvable ref (a transient GitHub 422) shows "no checks" for
-        // display but must not wipe the previously-good cache.
+        // An unresolvable ref shows "no checks" for display but must not wipe
+        // the previously-good cache.
         let displayed = refresh_cache_with_fetched(&mut db, REFERENCE, None);
 
         assert!(displayed.is_empty(), "an unresolvable ref shows no checks");


### PR DESCRIPTION
Treat unresolved Bitbucket refs as unavailable checks while preserving cached results. Keep repository, credential, and scope failures visible, and document the required token scopes.