### PR TITLE
Don't stamp a stack footer onto single-PR stacks

### DIFF
--- a/apps/desktop/src/lib/forge/shared/prFooter.test.ts
+++ b/apps/desktop/src/lib/forge/shared/prFooter.test.ts
@@ -1,4 +1,9 @@
-import { generateFooter } from "$lib/forge/shared/prFooter";
+import {
+	generateFooter,
+	STACKING_FOOTER_BOUNDARY_BOTTOM,
+	STACKING_FOOTER_BOUNDARY_TOP,
+	updateBody,
+} from "$lib/forge/shared/prFooter";
 import { describe, expect, test } from "vitest";
 
 // The desktop receives stack segments child -> parent, i.e. [top, ..., base]
@@ -33,5 +38,38 @@ describe("generateFooter", () => {
 
 		expect(lines.find((l) => l.includes("#102"))).toContain("👈");
 		expect(lines.find((l) => l.includes("#101"))).not.toContain("👈");
+	});
+});
+
+describe("updateBody", () => {
+	test("adds no footer when the stack has a single PR", () => {
+		expect(updateBody("My description", 123, [123], "#")).toBe("My description");
+	});
+
+	test("removes an existing footer when the stack shrinks to a single PR", () => {
+		const body = `My description\n\n${generateFooter(123, [124, 123], "#")}`;
+		expect(body).toContain("in a stack");
+		expect(updateBody(body, 123, [123], "#")).toBe("My description");
+	});
+
+	test("preserves content after the footer when removing it", () => {
+		const body = `Head\n\n${STACKING_FOOTER_BOUNDARY_TOP}\nfooter\n${STACKING_FOOTER_BOUNDARY_BOTTOM}\n\nTail`;
+		expect(updateBody(body, 123, [123], "#")).toBe("Head\n\nTail");
+	});
+
+	test("adds a footer when the stack has multiple PRs", () => {
+		const result = updateBody("My description", 123, [124, 123], "#");
+		expect(result).toContain("My description");
+		expect(result).toContain("part 1 of 2 in a stack");
+	});
+
+	test("leaves a footer-less body untouched instead of rewriting it", () => {
+		const body = "\nMy description with trailing space \n";
+		expect(updateBody(body, 123, [123], "#")).toBe(body);
+	});
+
+	test("does not drop content when only the top boundary is present", () => {
+		const body = `Intro\n\n${STACKING_FOOTER_BOUNDARY_TOP}\ndangling text`;
+		expect(updateBody(body, 123, [123], "#")).toBe(body);
 	});
 });

--- a/apps/desktop/src/lib/forge/shared/prFooter.ts
+++ b/apps/desktop/src/lib/forge/shared/prFooter.ts
@@ -121,32 +121,42 @@ export async function unstackPRs(
 
 /**
  * Replaces or inserts a new footer into an existing body of text.
+ *
+ * If there is only one PR in the stack there is no stack to advertise, so we add
+ * no footer and strip any existing one - mirroring the single-PR guard in
+ * `update_body` in `but-forge`. A body without a footer is returned untouched so
+ * we don't needlessly rewrite PRs (including ones not opened through GitButler).
  */
-function updateBody(
+export function updateBody(
 	body: string | undefined,
 	prNumber: number,
 	allPrNumbers: number[],
 	symbol: string,
 ) {
-	const head = (body?.split(STACKING_FOOTER_BOUNDARY_TOP).at(0) || "").trim();
-	const tail = (body?.split(STACKING_FOOTER_BOUNDARY_BOTTOM).at(1) || "").trim();
-	const footer = generateFooter(prNumber, allPrNumbers, symbol);
-	const description = head + "\n\n" + footer + "\n\n" + tail;
-	return description;
+	if (allPrNumbers.length <= 1) {
+		return clearFooter(body) ?? "";
+	}
+	return composeBody(body, generateFooter(prNumber, allPrNumbers, symbol));
 }
 
 /**
  * Remove the footer from an existing body of text.
  */
 function clearFooter(body: string | undefined) {
-	if (!body) return body;
-	if (!body.includes(STACKING_FOOTER_BOUNDARY_TOP)) return body;
+	if (!body?.includes(STACKING_FOOTER_BOUNDARY_TOP)) return body;
 	if (!body.includes(STACKING_FOOTER_BOUNDARY_BOTTOM)) return body;
+	return composeBody(body);
+}
 
+/**
+ * Rebuild a PR body from its parts: the text before any existing footer, an
+ * optional new footer, and the text after any existing footer. Omitting the
+ * footer removes it.
+ */
+function composeBody(body: string | undefined, footer?: string): string {
 	const head = (body?.split(STACKING_FOOTER_BOUNDARY_TOP).at(0) || "").trim();
 	const tail = (body?.split(STACKING_FOOTER_BOUNDARY_BOTTOM).at(1) || "").trim();
-	const description = head + "\n\n" + tail;
-	return description;
+	return [head, footer, tail].filter(Boolean).join("\n\n");
 }
 
 /**


### PR DESCRIPTION
## What this resolves

GitButler was appending `This is **part 1 of 1 in a stack** made with GitButler` to PR descriptions — including PRs the user never opened through GitButler. Reported in Discord: a user with the GitHub integration on saw the footer show up on a PR they'd created manually.

The exact situation that triggers it: a stack that has **2+ branches but only one open PR**. On a branch reorder (drag), the frontend rebuilds every PR body in that stack via `updateStackPrs` → `updateBody`. The guard in `updateStackPrs` checks the number of *branches* (`branchDetails.length <= 1`), not the number of *PRs*, so it proceeds; `allPrNumbers` then filters down to a single number, and the frontend `updateBody` — unlike its Rust counterpart `but_forge::update_body` — had no single-PR guard, so it generated a footer anyway: "part 1 of 1". Because `updateStackPrs` writes to any PR it can associate to a branch, this also rewrites PRs GitButler didn't create.

## Why it's showing up now

The frontend `updateBody` has always lacked the guard, but casual users couldn't easily reach the drag path that calls it. That changed with #14669 (*Support reordering empty branches in single-branch mode*) and #14713 (*Allow single-branch stack reordering*), which enabled branch-reorder drags in single-branch mode. In single-branch mode every branch shares one stack, so "2+ branches, one PR" is the normal state rather than an edge case — turning a latent bug into a common one.

## Fix

Mirror the single-PR guard from `but_forge::update_body` in the frontend: with one PR, add no footer and strip any existing one. The body head/footer/tail recomposition is unified into a single `composeBody` helper so `updateBody` and `clearFooter` can't drift on whitespace edge cases. Adds unit tests covering the single-PR, footer-removal, and multi-PR cases.

Follow-up (not in this PR): the whole frontend footer path duplicates `but_forge::sync_reviews`; the drag handlers should route through the Rust implementation so the two copies can't diverge again.