### PR TITLE
Lite: hide the macOS traffic light spacer in full-screen

### DIFF
--- a/apps/lite/electron/src/ipc.ts
+++ b/apps/lite/electron/src/ipc.ts
@@ -459,6 +459,8 @@ export interface LiteElectronApi {
 	getReview: (params: GetReviewParams) => Promise<ForgeReview>;
 	getUndoTargetSnapshot: (projectId: string) => Promise<Snapshot | null>;
 	headInfo: (projectId: string) => Promise<RefInfo>;
+	isFullScreen: () => Promise<boolean>;
+	onFullScreenChange: (callback: (fullScreen: boolean) => void) => () => void;
 	listBranches: (
 		projectId: string,
 		filter: BranchListingFilter | null,
@@ -547,6 +549,8 @@ export const liteIpcChannels = {
 	getReview: "workspace:get-review",
 	getUndoTargetSnapshot: "workspace:get-undo-target-snapshot",
 	headInfo: "workspace:head-info",
+	isFullScreen: "lite:is-full-screen",
+	fullScreenChange: "lite:full-screen-change",
 	listBranches: "workspace:list-branches",
 	listAvailableReviewTemplates: "workspace:list-available-review-templates",
 	listCiChecks: "workspace:list-ci-checks",

--- a/apps/lite/electron/src/main.ts
+++ b/apps/lite/electron/src/main.ts
@@ -538,6 +538,9 @@ const registerIpcHandlers = (): void => {
 		getUndoTargetSnapshot(projectId),
 	);
 	senderValidatingHandle(liteIpcChannels.headInfo, (_e, projectId: string) => headInfo(projectId));
+	senderValidatingHandle(liteIpcChannels.isFullScreen, (event) =>
+		Promise.resolve(BrowserWindow.fromWebContents(event.sender)?.isFullScreen() ?? false),
+	);
 	senderValidatingHandle(
 		liteIpcChannels.listBranches,
 		(_e, projectId: string, filter: BranchListingFilter | null) => listBranches(projectId, filter),
@@ -763,6 +766,12 @@ const createMainWindow = async (): Promise<void> => {
 			preload: path.join(currentDirPath, "preload.cjs"),
 		},
 	});
+
+	const notifyFullScreenChange = () => {
+		mainWindow.webContents.send(liteIpcChannels.fullScreenChange, mainWindow.isFullScreen());
+	};
+	mainWindow.on("enter-full-screen", notifyFullScreenChange);
+	mainWindow.on("leave-full-screen", notifyFullScreenChange);
 
 	const devServerUrl = process.env.VITE_DEV_SERVER_URL;
 	if (devServerUrl !== undefined) {

--- a/apps/lite/electron/src/preload.cts
+++ b/apps/lite/electron/src/preload.cts
@@ -146,6 +146,14 @@ const api: LiteElectronApi = {
 	getUndoTargetSnapshot: (params) =>
 		ipcRenderer.invoke("workspace:get-undo-target-snapshot", params) as Promise<Snapshot | null>,
 	headInfo: (projectId) => ipcRenderer.invoke("workspace:head-info", projectId) as Promise<RefInfo>,
+	isFullScreen: () => ipcRenderer.invoke("lite:is-full-screen") as Promise<boolean>,
+	onFullScreenChange: (callback) => {
+		const listener = (_event: Electron.IpcRendererEvent, fullScreen: boolean) => {
+			callback(fullScreen);
+		};
+		ipcRenderer.on("lite:full-screen-change", listener);
+		return () => ipcRenderer.removeListener("lite:full-screen-change", listener);
+	},
 	listBranches: (projectId, filter) =>
 		ipcRenderer.invoke("workspace:list-branches", projectId, filter) as Promise<
 			Array<BranchListing>

--- a/apps/lite/ui/src/routes/project/$id/workspace/TopLeftControls.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/TopLeftControls.tsx
@@ -5,7 +5,7 @@ import { interfaceSlice } from "#ui/interface/state.ts";
 import { useAppDispatch, useAppSelector } from "#ui/store.ts";
 import { workspaceHotkeys } from "#ui/hotkeys.ts";
 import { Tooltip } from "@base-ui/react";
-import type { FC } from "react";
+import { useEffect, useState, type FC } from "react";
 import styles from "./TopLeftControls.module.css";
 
 const FullWindowButton: FC = () => {
@@ -41,9 +41,33 @@ const FullWindowButton: FC = () => {
 
 const isMac = window.lite.platform === "darwin";
 
+/**
+ * Leaves room for the traffic lights, which are hidden in full-screen.
+ *
+ * Only mounted on macOS, so the full-screen subscription is set up there alone.
+ */
+const MacSpacer: FC = () => {
+	const [fullScreen, setFullScreen] = useState(false);
+
+	useEffect(() => {
+		let notified = false;
+		const unsubscribe = window.lite.onFullScreenChange((value) => {
+			notified = true;
+			setFullScreen(value);
+		});
+		// An event received while the query is in flight is more recent than its result.
+		void window.lite.isFullScreen().then((value) => {
+			if (!notified) setFullScreen(value);
+		});
+		return unsubscribe;
+	}, []);
+
+	return fullScreen ? null : <div className={styles.macSpacer} />;
+};
+
 export const TopLeftControls: FC = () => (
 	<div className={styles.container}>
-		{isMac && <div className={styles.macSpacer} />}
+		{isMac && <MacSpacer />}
 		<FullWindowButton />
 	</div>
 );


### PR DESCRIPTION
Before:

<img width="611" height="358" alt="Scherm­afbeelding 2026-07-22 om 00 07 42" src="https://github.com/user-attachments/assets/ac32d1dd-2287-41b5-a593-2a806ee41108" />

After:

https://github.com/user-attachments/assets/8fb0237a-bd0c-4769-b14e-6998bc5cf2a9

