### PR TITLE
Repair missing default target after virtual_branches.toml reset

### DIFF
--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -484,6 +484,10 @@ experimental single-branch feature is enabled, normal CLI use does not require t
 repository is registered and its target is inferred lazily without checking out
 `gitbutler/workspace` or installing setup hooks.
 
+Rerunning `but setup` on an already-configured project also repairs a missing default target — for
+example if `virtual_branches.toml` was reset while the target survived in Git config — so it is the
+recovery path when target configuration looks broken.
+
 ### `but teardown`
 
 Exit GitButler mode and return to normal git workflow.

--- a/crates/but/src/command/legacy/setup.rs
+++ b/crates/but/src/command/legacy/setup.rs
@@ -265,6 +265,20 @@ pub(crate) fn repo(
         )),
     }?;
 
+    // A ported project can keep its target in Git config while the legacy `virtual_branches.toml`
+    // / database store is empty — for example after that store was reset. The check below would
+    // then see a target and report "already set up", but the workspace needs the legacy default
+    // target to work. Repair it from the workspace first so setup isn't a dead end.
+    if gitbutler_branch_actions::base::bootstrap_default_target_if_missing(&*ctx)?
+        && let Some(out) = out.for_human()
+    {
+        writeln!(
+            out,
+            "  {}",
+            t.success.paint("✓ Repaired missing target metadata")
+        )?;
+    }
+
     // Check if target branch is set
     let target = but_api::legacy::virtual_branches::get_base_branch_data(ctx, perm)?;
 

--- a/crates/gitbutler-branch-actions/src/base.rs
+++ b/crates/gitbutler-branch-actions/src/base.rs
@@ -2,7 +2,7 @@ use std::time;
 
 use anyhow::{Context as _, Result, anyhow};
 use but_core::{
-    WORKSPACE_REF_NAME,
+    RefMetadata, WORKSPACE_REF_NAME,
     git_config::{edit_repo_config, ensure_config_value},
     sync::RepoShared,
 };
@@ -105,17 +105,30 @@ pub fn bootstrap_default_target_if_missing(ctx: &Context) -> Result<bool> {
         return Ok(false);
     }
 
-    if ctx.project_meta()?.target_ref.is_some() {
+    // Only heal when the legacy store this function repairs — `virtual_branches.toml` and the
+    // branch-order database — has no target. A ported repository also keeps its target in Git
+    // config, and reading that here made the repo look configured while the TOML/DB was empty, so
+    // this recovery never ran and setting the target branch afterwards deadlocked. Probe with a
+    // handle that doesn't reconcile the store back on drop, unlike `ctx.legacy_meta()`.
+    let legacy_meta = but_meta::VirtualBranchesTomlMetadata::from_path_read_only(
+        ctx.project_data_dir().join("virtual_branches.toml"),
+    )?;
+    if legacy_meta
+        .workspace(WORKSPACE_REF_NAME.try_into()?)?
+        .project_meta()
+        .target_ref
+        .is_some()
+    {
         return Ok(false);
     }
 
-    let target = match inferred_default_target(&repo) {
+    let target = match target_to_recover(ctx, &repo) {
         Ok(Some(target)) => target,
         Ok(None) => return Ok(false),
         Err(err) => {
             tracing::debug!(
                 error = ?err,
-                "failed to infer default target; leaving default target uninitialized"
+                "could not determine a default target to recover; leaving it uninitialized"
             );
             return Ok(false);
         }
@@ -123,6 +136,31 @@ pub fn bootstrap_default_target_if_missing(ctx: &Context) -> Result<bool> {
     ctx.set_default_target(target)?;
     set_exclude_decoration(ctx)?;
     Ok(true)
+}
+
+/// The target to restore into the legacy store: the one that survived in project metadata (Git
+/// config, for ported repos) when it still resolves, otherwise one inferred from the remote.
+///
+/// Preferring the survivor keeps a custom target from being silently replaced by an inferred
+/// default; inference is the fallback for when nothing survives (for example a never-ported repo).
+fn target_to_recover(ctx: &Context, repo: &gix::Repository) -> Result<Option<Target>> {
+    let project_meta = ctx.project_meta()?;
+    if let Some(target_ref) = project_meta.target_ref
+        && let Some(mut target) = target_from_ref(repo, target_ref.as_ref())?
+    {
+        // Keep the base commit and push remote that survived in Git config; the ref only fills in
+        // what config doesn't carry. Recomputing the base from the ref tip would advance the
+        // workspace's frame of reference (see `Target.sha`), and re-deriving the remote would drop
+        // a configured fork push remote.
+        if let Some(sha) = project_meta.target_commit_id {
+            target.sha = sha;
+        }
+        if let Some(push_remote) = project_meta.push_remote {
+            target.push_remote_name = Some(push_remote);
+        }
+        return Ok(Some(target));
+    }
+    inferred_default_target(repo)
 }
 
 #[instrument(skip(ctx, perm), err(Debug))]
@@ -409,10 +447,28 @@ fn inferred_default_target(repo: &gix::Repository) -> Result<Option<Target>> {
     let Some(target_ref) = but_workspace::init::infer_default_target_ref(repo)? else {
         return Ok(None);
     };
+    target_from_ref(repo, target_ref.as_ref())
+}
+
+/// Build a legacy [`Target`] from an existing remote-tracking `target_ref`, resolving its remote,
+/// URL and current commit. Returns `None` when `target_ref` isn't a remote branch or no longer
+/// resolves to a commit, so callers can fall back to inference.
+fn target_from_ref(
+    repo: &gix::Repository,
+    target_ref: &gix::refs::FullNameRef,
+) -> Result<Option<Target>> {
     let remote_names = repo.remote_names();
-    let (remote_name, _) =
-        but_core::extract_remote_name_and_short_name(target_ref.as_ref(), &remote_names)
-            .with_context(|| format!("failed to determine remote for branch '{target_ref}'"))?;
+    let Some((remote_name, _)) =
+        but_core::extract_remote_name_and_short_name(target_ref, &remote_names)
+    else {
+        return Ok(None);
+    };
+    let Some(mut reference) = repo.try_find_reference(target_ref)? else {
+        return Ok(None);
+    };
+    let Ok(sha) = reference.peel_to_commit().map(|commit| commit.id) else {
+        return Ok(None);
+    };
     let remote_url = repo
         .find_remote(remote_name.as_str())
         .ok()
@@ -423,13 +479,8 @@ fn inferred_default_target(repo: &gix::Repository) -> Result<Option<Target>> {
         })
         .map(|url| url.to_bstring().to_string())
         .unwrap_or_default();
-    let sha = repo
-        .find_reference(target_ref.as_ref())?
-        .peel_to_commit()
-        .with_context(|| format!("inferred target '{target_ref}' did not point to a commit"))?
-        .id;
     Ok(Some(Target {
-        branch: target_ref.to_string().parse()?,
+        branch: target_ref.as_bstr().to_string().parse()?,
         remote_url,
         sha,
         push_remote_name: Some(remote_name),

--- a/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/init.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/init.rs
@@ -297,3 +297,121 @@ fn bootstrap_missing_target_preserves_existing_workspace_ref() -> anyhow::Result
     assert_eq!(stacks[0].1.derived_name, expected_stack_name);
     Ok(())
 }
+
+/// Regression: the legacy target metadata is gone but Git config still carries the ported target
+/// (as happens when the `virtual_branches.toml` / DB store is reset while `.git/config` survives).
+/// Recovery must still run — keying the "already configured?" check off Git config used to skip it
+/// and left target setup deadlocked. It must also restore the *surviving* target, not a re-inferred
+/// default, or a custom target gets silently rewritten.
+#[test]
+fn bootstrap_missing_target_recovers_surviving_git_config_target() -> anyhow::Result<()> {
+    let test = &mut Test::default();
+    let Test {
+        repo,
+        project_id,
+        ctx,
+        ..
+    } = test;
+
+    repo.checkout(&"refs/heads/some-feature".parse().unwrap());
+    fs::write(repo.path().join("file.txt"), "content")?;
+    repo.commit_all("commit on feature");
+    // A second remote-tracking branch, so the surviving Git-config target can differ from the branch
+    // inference would pick (origin/master).
+    repo.simulate_push_branch(&"refs/heads/some-feature".parse().unwrap());
+
+    let mut guard = ctx.exclusive_worktree_access();
+    gitbutler_branch_actions::set_base_branch(
+        ctx,
+        &"refs/remotes/origin/master".parse().unwrap(),
+        guard.write_permission(),
+    )?;
+    drop(guard);
+
+    // The base commit recorded in Git config; recovery must preserve it rather than re-peel the ref
+    // tip (which would advance the workspace's frame of reference).
+    let recorded_target_commit = ctx
+        .project_meta()?
+        .target_commit_id
+        .expect("set_base_branch records a target commit");
+
+    let repo = ctx.repo.get()?;
+    let original_workspace_ref_target = repo
+        .try_find_reference("refs/heads/gitbutler/workspace")?
+        .expect("workspace ref should exist")
+        .peel_to_id()?
+        .detach();
+
+    // Empty the legacy store (fresh storage location) while Git config keeps a custom target that
+    // inference wouldn't pick. Only `targetRef` is rewritten; the recorded `targetCommitId` stays at
+    // the base captured above — an ancestor of `some-feature`, i.e. a base that lags the ref tip as
+    // it would after a fetch — so recovery must preserve it rather than re-peel `some-feature`'s tip.
+    edit_config(Some(&repo), gix::config::Source::Local, |config| {
+        set_config_value(
+            config,
+            but_project_handle::storage_path_config_key(),
+            "gitbutler-alt",
+        )?;
+        set_config_value(
+            config,
+            "gitbutler.project.targetRef",
+            "refs/remotes/origin/some-feature",
+        )?;
+        Ok(())
+    })?;
+    drop(repo);
+
+    let mut reopened: Context =
+        but_testsupport::isolated_app_data_dir(|| project_id.clone().try_into())?;
+    // Precondition: legacy store has no target, but Git config resolves the custom one.
+    assert!(
+        but_meta::legacy_storage::read_synced_virtual_branches(
+            &reopened.project_data_dir().join("virtual_branches.toml")
+        )?
+        .default_target
+        .is_none()
+    );
+    assert_eq!(
+        reopened
+            .project_meta()?
+            .target_ref
+            .map(|r| r.to_string())
+            .as_deref(),
+        Some("refs/remotes/origin/some-feature")
+    );
+
+    let mut guard = reopened.exclusive_worktree_access();
+    assert!(
+        gitbutler_branch_actions::base::bootstrap_default_target_if_missing(&reopened)?,
+        "recovery must run even though Git config still has the target"
+    );
+    let meta = reopened.legacy_meta_mut(guard.write_permission())?;
+    let repo = reopened.repo.get()?;
+    meta.write_reconciled(&repo)?;
+    drop(repo);
+    drop(guard);
+
+    // Healed from the surviving Git-config target, not re-inferred to origin/master.
+    let restored = but_meta::legacy_storage::read_synced_virtual_branches(
+        &reopened.project_data_dir().join("virtual_branches.toml"),
+    )?
+    .default_target
+    .expect("default target restored");
+    assert_eq!(restored.branch.remote(), "origin");
+    assert_eq!(restored.branch.branch(), "some-feature");
+    // Preserved the surviving base commit rather than re-peeling the ref tip.
+    assert_eq!(restored.sha, recorded_target_commit);
+
+    let workspace_ref_target_after_activation = reopened
+        .repo
+        .get()?
+        .try_find_reference("refs/heads/gitbutler/workspace")?
+        .expect("workspace ref should still exist")
+        .peel_to_id()?
+        .detach();
+    assert_eq!(
+        workspace_ref_target_after_activation,
+        original_workspace_ref_target
+    );
+    Ok(())
+}


### PR DESCRIPTION
The default target is stored in two places that nothing reconciles: Git config (`gitbutler.project.targetRef`) and the repo-local `virtual_branches.toml` / DB store. When the toml/DB store is reset but `.git/config` survives, they disagree — and `but setup` trusts Git config, sees a target, and reports "already set up", skipping the repair the workspace actually needs. Neither `but setup` nor `but config target` can then restore the target: a deadlock.

- `bootstrap_default_target_if_missing` now checks the store it repairs (toml/DB), not Git config, and restores the target that survived in Git config — falling back to inference — so a custom target isn't silently replaced. The probe uses a read-only handle so it can't rewrite the store as a side effect.
- `but setup` runs that recovery before its "already set up" check, so CLI-only users self-heal.

Fixes #14918.
