### PR TITLE
style: update linked commit highlight

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
@@ -35,8 +35,25 @@
 }
 
 .containerHighlighted {
-	background-color: #63cdc7;
+	background-color: color-mix(var(--fill-pop-bg) 20%, transparent);
 	color: var(--text-1);
+
+	@media (prefers-reduced-motion: no-preference) {
+		animation: wiggle 0.35s ease-in-out infinite;
+	}
+}
+
+@keyframes wiggle {
+	0%,
+	100% {
+		translate: 0;
+	}
+	25% {
+		translate: -1px;
+	}
+	75% {
+		translate: 1px;
+	}
 }
 
 .toolbar {


### PR DESCRIPTION
Adjusted the highlight, it was a bit too intense and clashing with the background. I've softened the color and added a subtle animation instead.

Before:


https://github.com/user-attachments/assets/13ff22ea-1290-43b6-be7f-73b48156eb15



After:


https://github.com/user-attachments/assets/cb380dc4-a1be-43fb-88eb-4cb98a24005e


