### PR TITLE
fix(cli): avoid unnecessary editor opens when squashing commits

### DIFF
--- a/crates/but/src/command/legacy/squash2.rs
+++ b/crates/but/src/command/legacy/squash2.rs
@@ -1,5 +1,5 @@
 use anyhow::Context as _;
-use bstr::BString;
+use bstr::{BString, ByteSlice as _};
 use but_api::json::HexHash;
 use but_core::{DiffSpec, DryRun, RefMetadata, sync::RepoExclusive};
 use but_ctx::Context;
@@ -172,7 +172,7 @@ pub fn squash(
     let resolved_args = resolve_args(&repo, args, &id_map, &head_info)?;
     let resolved_args = resolved_args.as_ref();
 
-    let squash_op = resolve(resolved_args, &ws)?;
+    let squash_op = resolve(resolved_args, &ws, &repo)?;
 
     drop(repo);
     drop(ws);
@@ -313,6 +313,7 @@ pub enum ResolvedSquashArgsRef<'a> {
 pub fn resolve<'a>(
     args: ResolvedSquashArgsRef<'a>,
     ws: &Workspace,
+    repo: &gix::Repository,
 ) -> CliResult<SquashOperation<'a>> {
     let resolved_squash = match args {
         ResolvedSquashArgsRef::Normal { sources, target } => {
@@ -425,7 +426,7 @@ pub fn resolve<'a>(
         }
     };
 
-    let squash_op = match resolved_squash {
+    let mut squash_op = match resolved_squash {
         ResolvedSquash::Commits { target, sources } => match target {
             SquashTarget::Commit {
                 commit: target,
@@ -479,6 +480,8 @@ pub fn resolve<'a>(
         },
     };
 
+    fix_up_unnecessary_reword_via_editor(&mut squash_op, repo)?;
+
     Ok(squash_op)
 }
 
@@ -486,6 +489,95 @@ fn cannot_uncommit_uncommitted_changes_error() -> CliError {
     bad_input("Cannot uncommit uncommitted changes")
         .hint("When squashing uncommitted changes the --target must be a commit or a branch")
         .into()
+}
+
+/// Changes how the operation rewords the target to avoid unnecessarily opening the editor.
+///
+/// For example if none of the sources have a message then we should always pick the target
+/// message, and vice versa.
+///
+/// If no editor would have been opened then this function does nothing. So we still respect
+/// `--use-source-message` and `--use-target-message` flags.
+fn fix_up_unnecessary_reword_via_editor(
+    op: &mut SquashOperation,
+    repo: &gix::Repository,
+) -> anyhow::Result<()> {
+    fn obvious_final_message<I>(
+        commits: I,
+        repo: &gix::Repository,
+    ) -> anyhow::Result<Option<String>>
+    where
+        I: IntoIterator<Item = gix::ObjectId>,
+    {
+        let mut out = None;
+        let mut seen = Vec::new();
+        for commit in commits {
+            if seen.contains(&commit) {
+                continue;
+            } else {
+                seen.push(commit);
+            }
+
+            let commit = repo.find_commit(commit)?;
+            let msg = commit.message_raw()?;
+            if msg.is_empty() {
+                continue;
+            }
+            if out.is_some() {
+                return Ok(None);
+            }
+            if let Ok(msg) = msg.to_str() {
+                out = Some(msg.to_owned());
+            } else {
+                // make sure we don't remove non utf-8 messages
+                return Ok(None);
+            }
+        }
+        if let Some(out) = out {
+            Ok(Some(out))
+        } else {
+            // none of the commits have messages so just keep an empty message and dont open an
+            // editor
+            Ok(Some(String::new()))
+        }
+    }
+
+    if !op.will_open_editor() {
+        return Ok(());
+    }
+
+    match op {
+        SquashOperation::Commits(op) => {
+            let commits = op.sources.iter().copied().chain([op.target]);
+            if let Some(msg) = obvious_final_message(commits, repo)? {
+                op.reword = HowToRewordTarget::Reword(RewordCommitOperation::Message(msg));
+            }
+        }
+        SquashOperation::Branch(op) => {
+            let commits = op.sources.iter().copied().chain([op.target]);
+            if let Some(msg) = obvious_final_message(commits, repo)? {
+                op.reword = HowToRewordTarget::Reword(RewordCommitOperation::Message(msg));
+            }
+        }
+        SquashOperation::UncommittedHunks(op) => {
+            if let Some(msg) = obvious_final_message([op.target], repo)? {
+                op.reword = HowToRewordTargetNoSource::Reword(RewordCommitOperation::Message(msg));
+            }
+        }
+        SquashOperation::Uncommitted { target, reword, .. } => {
+            if let Some(msg) = obvious_final_message([*target], repo)? {
+                *reword = HowToRewordTargetNoSource::Reword(RewordCommitOperation::Message(msg));
+            }
+        }
+        SquashOperation::MoveCommittedFiles { target, reword, .. } => {
+            if let Some(msg) = obvious_final_message([*target], repo)? {
+                *reword = HowToRewordTargetNoSource::Reword(RewordCommitOperation::Message(msg));
+            }
+        }
+        SquashOperation::Uncommit(..) | SquashOperation::UncommitCommittedFiles(..) => {}
+    }
+
+    Ok(())
 }
 
 #[derive(Debug)]

--- a/crates/but/src/command/legacy/status/tui/app/squash_mode.rs
+++ b/crates/but/src/command/legacy/status/tui/app/squash_mode.rs
@@ -636,7 +636,7 @@ fn resolve_squash_operation<'a>(
         },
     };
 
-    let op = squash2::resolve(resolved_args, ws).into_internal_error()?;
+    let op = squash2::resolve(resolved_args, ws, repo).into_internal_error()?;
 
     Ok(Some(op))
 }

--- a/crates/but/tests/but/command/squash2.rs
+++ b/crates/but/tests/but/command/squash2.rs
@@ -2245,3 +2245,162 @@ Hint: run `but help` for all commands
 
 "#]]);
 }
+
+#[test]
+fn doesnt_open_editor_if_no_sources_have_message() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
+
+    env.file(".git/editor.sh", "false");
+    let editor_path = env.projects_root().join(".git/editor.sh");
+    let editor_command = format!("sh {}", editor_path.display());
+
+    env.but("_commit2 --empty --no-message").assert().success();
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   1 (no commit message) (no changes)
+┊●   tpm add A
+┊│     tpm:t A A
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("_squash2 1 -t tpm")
+        .env("GIT_EDITOR", editor_command)
+        .assert()
+        .success();
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   tpm add A
+┊│     tpm:t A A
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn doesnt_open_editor_if_no_target_has_message() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
+
+    env.file(".git/editor.sh", "false");
+    let editor_path = env.projects_root().join(".git/editor.sh");
+    let editor_command = format!("sh {}", editor_path.display());
+
+    env.but("_commit2 --empty --no-message").assert().success();
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   1 (no commit message) (no changes)
+┊●   tpm add A
+┊│     tpm:t A A
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("_squash2 tpm -t 1")
+        .env("GIT_EDITOR", editor_command)
+        .assert()
+        .success();
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   1 add A
+┊│     1:t A A
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn doesnt_open_editor_if_both_source_and_target_doesnt_have_a_message() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
+
+    env.file(".git/editor.sh", "false");
+    let editor_path = env.projects_root().join(".git/editor.sh");
+    let editor_command = format!("sh {}", editor_path.display());
+
+    env.but("_commit2 --empty --no-message").assert().success();
+    env.but("_commit2 --empty --no-message").assert().success();
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   1#0 (no commit message) (no changes)
+┊●   1#1 (no commit message) (no changes)
+┊●   tpm add A
+┊│     tpm:t A A
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("_squash2 1#0 -t 1#1")
+        .env("GIT_EDITOR", editor_command)
+        .assert()
+        .success();
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted] (no changes)
+┊
+┊╭┄g0 [A]
+┊●   1 (no commit message) (no changes)
+┊●   tpm add A
+┊│     tpm:t A A
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+}


### PR DESCRIPTION
If the list of sources + target contains exactly one commit with a message then just pick that message instead of opening an editor.