### PR TITLE
checkout: stop tracking file statistics

### DIFF
--- a/crates/but-core/src/worktree/checkout/function.rs
+++ b/crates/but-core/src/worktree/checkout/function.rs
@@ -188,9 +188,5 @@ pub fn safe_checkout_from_head(
         }
     }
 
-    Ok(Outcome {
-        head_update,
-        num_deleted_files,
-        num_added_or_updated_files: changed_files.len() - num_deleted_files,
-    })
+    Ok(Outcome { head_update })
 }

--- a/crates/but-core/src/worktree/checkout/mod.rs
+++ b/crates/but-core/src/worktree/checkout/mod.rs
@@ -25,12 +25,6 @@ pub struct Options {
 pub struct Outcome {
     /// If `new_head_id` was a commit, these are the ref-edits returned after performing the transaction.
     pub head_update: Option<Vec<gix::refs::transaction::RefEdit>>,
-    /// The number of files that were deleted turn the current worktree into the desired one.
-    /// Note that this only counts files, not directories.
-    pub num_deleted_files: usize,
-    /// The number of files that were added or modified turn the current worktree into the desired one.
-    /// Note that this only counts files, not directories.
-    pub num_added_or_updated_files: usize,
 }
 
 pub(crate) mod function;

--- a/crates/but-core/src/worktree/checkout/utils.rs
+++ b/crates/but-core/src/worktree/checkout/utils.rs
@@ -329,14 +329,8 @@ impl gix::diff::tree::Visit for Delegate {
 
 impl std::fmt::Debug for Outcome {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let Outcome {
-            head_update,
-            num_deleted_files,
-            num_added_or_updated_files,
-        } = self;
+        let Outcome { head_update } = self;
         f.debug_struct("Outcome")
-            .field("num_deleted_files", num_deleted_files)
-            .field("num_added_or_updated_files", num_added_or_updated_files)
             .field(
                 "head_update",
                 &match head_update {

--- a/crates/but-core/tests/core/worktree/checkout.rs
+++ b/crates/but-core/tests/core/worktree/checkout.rs
@@ -24,8 +24,6 @@ fn update_unborn_head() -> anyhow::Result<()> {
         out.to_debug(),
         snapbox::str![[r#"
 Outcome {
-    num_deleted_files: 0,
-    num_added_or_updated_files: 0,
     head_update: "Update refs/heads/main to Some(Object(Sha1(31ec8eacfba4051fd673e4fe23c775e87896a463)))",
 }
 
@@ -82,8 +80,6 @@ fn no_op_trees_never_touch_worktree() -> anyhow::Result<()> {
         out.to_debug(),
         snapbox::str![[r#"
 Outcome {
-    num_deleted_files: 0,
-    num_added_or_updated_files: 0,
     head_update: "None",
 }
 
@@ -187,8 +183,6 @@ fn pure_deletion_checkout_does_not_restore_unrelated_worktree_deletions() -> any
         out.to_debug(),
         snapbox::str![[r#"
 Outcome {
-    num_deleted_files: 1,
-    num_added_or_updated_files: 0,
     head_update: "Update refs/heads/main to Some(Object(Sha1(5eedd314adfb480212989a303c7651717062a9b2)))",
 }
 
@@ -248,8 +242,6 @@ fn pure_deletion_checkout_keeps_non_intersecting_worktree_deletion() -> anyhow::
         "delete a.txt",
     )?;
     let out = safe_checkout_from_head(new_commit.id, &repo, Default::default())?;
-    assert_eq!(out.num_deleted_files, 1);
-    assert_eq!(out.num_added_or_updated_files, 0);
     assert!(out.head_update.is_some());
 
     assert!(!repo.workdir_path("a.txt").unwrap().exists());
@@ -313,9 +305,7 @@ fn pure_deletion_checkout_keeps_empty_worktree_root() -> anyhow::Result<()> {
         },
         "delete only file",
     )?;
-    let out = safe_checkout_from_head(new_commit.id, &repo, Default::default())?;
-    assert_eq!(out.num_deleted_files, 1);
-    assert_eq!(out.num_added_or_updated_files, 0);
+    safe_checkout_from_head(new_commit.id, &repo, Default::default())?;
     assert!(
         worktree.is_dir(),
         "safe checkout must not delete the worktree root while cleaning up empty parents"
@@ -380,8 +370,6 @@ D  to-be-deleted-in-index
         out.to_debug(),
         snapbox::str![[r#"
 Outcome {
-    num_deleted_files: 1,
-    num_added_or_updated_files: 1,
     head_update: "Update refs/heads/main to Some(Object(Sha1(24f802a1250d2f84e1f49094e3b8bb1e5c0d29ad)))",
 }
 
@@ -655,8 +643,6 @@ eleven
         out.to_debug(),
         snapbox::str![[r#"
 Outcome {
-    num_deleted_files: 0,
-    num_added_or_updated_files: 1,
     head_update: "Update refs/heads/main to Some(Object(Sha1(89b113aeae66a3cb1116bb23a195422edbd6af27)))",
 }
 
@@ -741,8 +727,6 @@ fn worktree_snapshot_of_legacy_crlf_blob_merges_cleanly_with_independent_target_
         out.to_debug(),
         snapbox::str![[r#"
 Outcome {
-    num_deleted_files: 0,
-    num_added_or_updated_files: 1,
     head_update: "Update refs/heads/main to Some(Object(Sha1(a530b145a2513ba5b2a4418bbb74920d3967f8fb)))",
 }
 
@@ -812,8 +796,6 @@ fn checkout_handles_directory_and_file_replacements() -> anyhow::Result<()> {
         out.to_debug(),
         snapbox::str![[r#"
 Outcome {
-    num_deleted_files: 1,
-    num_added_or_updated_files: 3,
     head_update: "Update refs/heads/merge to Some(Object(Sha1(df178e3012ac0862407185ae7dd8d634a6cde677)))",
 }
 
@@ -859,8 +841,6 @@ Outcome {
         out.to_debug(),
         snapbox::str![[r#"
 Outcome {
-    num_deleted_files: 3,
-    num_added_or_updated_files: 1,
     head_update: "Update refs/heads/merge to Some(Object(Sha1(94cc54fa25411ad51e319a9895d031d8da97b7ab)))",
 }
 
@@ -939,8 +919,6 @@ fn unrelated_additions_do_not_affect_worktree_changes() -> anyhow::Result<()> {
         out.to_debug(),
         snapbox::str![[r#"
 Outcome {
-    num_deleted_files: 0,
-    num_added_or_updated_files: 1,
     head_update: "Update refs/heads/main to Some(Object(Sha1(7add6cadcf636e5b3a6c15c75e82abbec97d6eef)))",
 }
 


### PR DESCRIPTION
This is used only for tests, which already assert correctness in other ways. This change is in preparation for migrating to using libgit2 to delete files (instead of doing it ourselves) in order to simplify the code and fix some bugs, and it seems that libgit2 produces wrong statistics when a file is replaced with a directory.
