### PR TITLE
Refresh branch cards after external checkout

### DIFF
--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -205,6 +205,10 @@
 			backend.listen(`project://${projectId}/hunk-assignment-update`, () => {
 				stackService.invalidateStacksAndDetails();
 			}),
+			// A symbolic HEAD change can switch branches without changing the commit SHA.
+			backend.listen(`project://${projectId}/git/head`, () => {
+				stackService.invalidateStacksAndDetails();
+			}),
 			backend.listen(`project://${projectId}/worktree_changes`, () => {
 				clientState.dispatch(
 					clientState.backendApi.util.invalidateTags([invalidatesList(ReduxTag.Diff)]),

--- a/e2e/playwright/scripts/project-with-remote-branches__checkout-new-branch-at-target.sh
+++ b/e2e/playwright/scripts/project-with-remote-branches__checkout-new-branch-at-target.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+echo "GIT CONFIG $GIT_CONFIG_GLOBAL"
+echo "DATA DIR $E2E_TEST_APP_DATA_DIR"
+echo "BUT $BUT"
+echo "PROJECT NAME: $1"
+echo "BRANCH NAME: $2"
+
+pushd "$1"
+  git checkout -b "$2" "$(git rev-parse refs/remotes/origin/master)"
+popd

--- a/e2e/playwright/tests/singleBranch/mode.spec.ts
+++ b/e2e/playwright/tests/singleBranch/mode.spec.ts
@@ -1,9 +1,10 @@
 import {
+	branchHeader,
 	expectCurrentBranchChip,
 	openSingleBranchWorkspace,
 	SINGLE_BRANCH_NAME,
 } from "./helpers.ts";
-import { assertBranch, assertCommitSubjects } from "../../src/branch.ts";
+import { assertBranch, assertCommitSubjects, branchTip } from "../../src/branch.ts";
 import { openWorkspace } from "../../src/setup.ts";
 import { test } from "../../src/test.ts";
 import { getByTestId, waitForTestId, waitForTestIdToNotExist } from "../../src/util.ts";
@@ -78,5 +79,31 @@ test.describe("single-branch mode enabled", () => {
 			["single-branch: add file", "single-branch: second commit", "single-branch: first commit"],
 			localClone,
 		);
+	});
+
+	test("shows a new externally checked-out branch at the target commit", async ({
+		page,
+		gitbutler,
+	}) => {
+		await gitbutler.runScript("project-with-remote-branches.sh");
+		const localClone = gitbutler.pathInWorkdir("local-clone");
+		await gitbutler.runScript("project-with-remote-branches__checkout-master.sh", ["local-clone"]);
+		await assertBranch("master", localClone);
+		expect(branchTip("master", localClone)).toBe(branchTip("origin/master", localClone));
+
+		await openSingleBranchWorkspace(page);
+		await expect(branchHeader(page, "master")).toBeVisible();
+
+		const branchName = "external-branch-at-target";
+		await gitbutler.runScript("project-with-remote-branches__checkout-new-branch-at-target.sh", [
+			"local-clone",
+			branchName,
+		]);
+
+		await assertBranch(branchName, localClone);
+		expect(branchTip(branchName, localClone)).toBe(branchTip("origin/master", localClone));
+		await expectCurrentBranchChip(page, branchName);
+		await expect(branchHeader(page, branchName)).toBeVisible();
+		await expect(branchHeader(page, "master")).toHaveCount(0);
 	});
 });


### PR DESCRIPTION
## Summary

- invalidate cached workspace stacks when symbolic `HEAD` changes
- cover externally creating and checking out a branch at the target commit
- verify the stale branch card is replaced without reloading the application

## Root cause

The current-branch header listens to symbolic `HEAD` changes, while the workspace stack cache was invalidated only when the HEAD commit SHA changed. Switching between two branches at the same target commit updated the header but left the previous `head_info` projection cached.
