### PR TITLE
feat(but/lite): add ability to define custom callable programs

### DIFF
--- a/crates/but-api/src/open/mod.rs
+++ b/crates/but-api/src/open/mod.rs
@@ -8,7 +8,10 @@ use tracing::instrument;
 use url::Url;
 
 use crate::open::{
-    program::{Editor, PROGRAMS, ProgramSpec, UserDefinedProgramSpec, open_in_program_unchecked},
+    program::{
+        Editor, PROGRAMS, ProgramSpec, USER_DEFINED_PROGRAMS_FILENAME, UserDefinedProgramSpec,
+        open_in_program_unchecked,
+    },
     spawn::spawn_and_reap,
 };
 
@@ -635,15 +638,7 @@ pub fn show_in_finder(path: String) -> Result<()> {
 #[but_api(napi)]
 #[instrument(err(Debug))]
 pub fn list_editors() -> anyhow::Result<Vec<Editor>> {
-    let user_defined_programs = match list_user_defined_program_specs() {
-        Ok(programs) => programs,
-        Err(err) => {
-            tracing::warn!(?err, "Failed to fetch user defined programs");
-            vec![]
-        }
-    };
-
-    Ok(user_defined_programs
+    Ok(list_user_defined_program_specs()
         .iter()
         .chain(PROGRAMS.iter())
         .filter(|p| p.is_gui_editor())
@@ -657,24 +652,40 @@ pub fn list_builtin_program_specs() -> &'static [ProgramSpec] {
 }
 
 /// List all user-defined programs.
-pub fn list_user_defined_program_specs() -> anyhow::Result<Vec<ProgramSpec>> {
-    let Ok(config_dir) = but_path::app_config_dir() else {
-        return Ok(vec![]);
+///
+/// This function never fails, it only logs errors as warnings if something goes wrong.
+pub fn list_user_defined_program_specs() -> Vec<ProgramSpec> {
+    let Ok(user_defined_programs_file) =
+        but_path::app_config_dir().map(|dir| dir.join(USER_DEFINED_PROGRAMS_FILENAME))
+    else {
+        return vec![];
     };
 
-    let user_defined_programs_file = config_dir.join("programs.json");
+    let content = match std::fs::read_to_string(&user_defined_programs_file) {
+        Ok(content) => content,
+        Err(err) => {
+            tracing::debug!(
+                ?err,
+                ?user_defined_programs_file,
+                "Failed to read from user-defined programs file"
+            );
+            return vec![];
+        }
+    };
 
-    if !user_defined_programs_file.is_file() {
-        return Ok(vec![]);
-    }
+    let user_defined_program_specs: Vec<UserDefinedProgramSpec> =
+        match serde_json::from_str(&content) {
+            Ok(specs) => specs,
+            Err(err) => {
+                tracing::warn!(?err, "Failed to decode user-defined programs file");
+                vec![]
+            }
+        };
 
-    let content = std::fs::read_to_string(user_defined_programs_file)?;
-    let user_defined_program_specs: Vec<UserDefinedProgramSpec> = serde_json::from_str(&content)?;
-
-    Ok(user_defined_program_specs
+    user_defined_program_specs
         .into_iter()
         .map(Into::into)
-        .collect())
+        .collect()
 }
 
 /// Open `path` within the given project's workdir using the editor specified by `editor_id`.
@@ -707,7 +718,6 @@ pub fn open_in_editor(
     }
 
     if let Some(editor) = list_user_defined_program_specs()
-        .unwrap_or_default()
         .iter()
         .chain(PROGRAMS.iter())
         .find(|editor| editor.id == editor_id)

--- a/crates/but-api/src/open/mod.rs
+++ b/crates/but-api/src/open/mod.rs
@@ -8,7 +8,7 @@ use tracing::instrument;
 use url::Url;
 
 use crate::open::{
-    program::{Editor, PROGRAMS, ProgramSpec, open_in_program_unchecked},
+    program::{Editor, PROGRAMS, ProgramSpec, UserDefinedProgramSpec, open_in_program_unchecked},
     spawn::spawn_and_reap,
 };
 
@@ -642,9 +642,30 @@ pub fn list_editors() -> anyhow::Result<Vec<Editor>> {
         .collect())
 }
 
-/// List all supported programs.
-pub fn list_program_specs() -> &'static [ProgramSpec] {
+/// List all built-in supported programs.
+pub fn list_builtin_program_specs() -> &'static [ProgramSpec] {
     PROGRAMS.as_slice()
+}
+
+/// List all user-defined programs.
+pub fn list_user_defined_program_specs() -> anyhow::Result<Vec<ProgramSpec>> {
+    let Ok(config_dir) = but_path::app_config_dir() else {
+        return Ok(vec![]);
+    };
+
+    let user_defined_programs_file = config_dir.join("programs.json");
+
+    if !user_defined_programs_file.is_file() {
+        return Ok(vec![]);
+    }
+
+    let content = std::fs::read_to_string(user_defined_programs_file)?;
+    let user_defined_program_specs: Vec<UserDefinedProgramSpec> = serde_json::from_str(&content)?;
+
+    Ok(user_defined_program_specs
+        .into_iter()
+        .map(Into::into)
+        .collect())
 }
 
 /// Open `path` within the given project's workdir using the editor specified by `editor_id`.

--- a/crates/but-api/src/open/mod.rs
+++ b/crates/but-api/src/open/mod.rs
@@ -635,9 +635,18 @@ pub fn show_in_finder(path: String) -> Result<()> {
 #[but_api(napi)]
 #[instrument(err(Debug))]
 pub fn list_editors() -> anyhow::Result<Vec<Editor>> {
-    Ok(PROGRAMS
+    let user_defined_programs = match list_user_defined_program_specs() {
+        Ok(programs) => programs,
+        Err(err) => {
+            tracing::warn!(?err, "Failed to fetch user defined programs");
+            vec![]
+        }
+    };
+
+    Ok(user_defined_programs
         .iter()
-        .filter(|program| program.is_gui_editor())
+        .chain(PROGRAMS.iter())
+        .filter(|p| p.is_gui_editor())
         .map(Into::into)
         .collect())
 }
@@ -697,7 +706,11 @@ pub fn open_in_editor(
         bail_precondition!("{path:?} is inside repository .git directory at {git_dir_path:?}");
     }
 
-    if let Some(editor) = PROGRAMS.iter().find(|editor| editor.id == editor_id)
+    if let Some(editor) = list_user_defined_program_specs()
+        .unwrap_or_default()
+        .iter()
+        .chain(PROGRAMS.iter())
+        .find(|editor| editor.id == editor_id)
         && editor.is_gui_editor()
     {
         open_in_program_unchecked(editor, &resolved_path, line_nr)

--- a/crates/but-api/src/open/program.rs
+++ b/crates/but-api/src/open/program.rs
@@ -112,7 +112,7 @@ impl From<UserDefinedShellExecutable> for ExecutableProgram {
     fn from(value: UserDefinedShellExecutable) -> Self {
         ExecutableProgram::ShellExecutable(ShellExecutable {
             name_or_path: value.name_or_path,
-            requires_tty: value.requires_tty,
+            requires_tty: value.requires_terminal,
         })
     }
 }
@@ -554,11 +554,11 @@ pub struct UserDefinedProgramSpec {
 pub struct UserDefinedShellExecutable {
     /// Name of the executable on the PATH, or a qualified path to it.
     pub name_or_path: String,
-    /// Whether the program requires an attached TTY or not.
+    /// Whether the program requires an attached terminal or not.
     ///
     /// If this is true, it means that this program cannot be launched reliably from a GUI client,
     /// and also needs the TUI to suspend in order for the editor to take over the terminal.
-    pub requires_tty: bool,
+    pub requires_terminal: bool,
 }
 
 /// Program category.

--- a/crates/but-api/src/open/program.rs
+++ b/crates/but-api/src/open/program.rs
@@ -189,7 +189,7 @@ struct CustomCliArgumentSupplier {
     /// * [`FILEPATH_PLACEHOLDER`] is substituted for the filepath
     ///
     /// TODO should not assume utf8 for args
-    open_args: Vec<String>,
+    open_args: Option<Vec<String>>,
     /// Arguments to pass to the executable when invoked to open at a specific line.
     ///
     /// Recognized placeholders:
@@ -198,12 +198,16 @@ struct CustomCliArgumentSupplier {
     /// * [`LINE_NUMBER_PLACEHOLDER`] is substituted for the line number
     ///
     /// TODO should not assume utf8 for args
-    open_at_line_args: Vec<String>,
+    open_at_line_args: Option<Vec<String>>,
 }
 
 impl CustomCliArgumentSupplier {
     fn open_at_line<'a>(&self, cmd: &'a mut Command, path: &Path, line_nr: i32) -> &'a mut Command {
-        for arg in &self.open_at_line_args {
+        let Some(open_at_line_args) = &self.open_at_line_args else {
+            return self.open(cmd, path);
+        };
+
+        for arg in open_at_line_args {
             // TODO should not assume utf8 for path
             cmd.arg(
                 arg.replace(FILEPATH_PLACEHOLDER, &path.to_string_lossy())
@@ -214,7 +218,12 @@ impl CustomCliArgumentSupplier {
     }
 
     fn open<'a>(&self, cmd: &'a mut Command, path: &Path) -> &'a mut Command {
-        for arg in &self.open_args {
+        let Some(open_args) = &self.open_args else {
+            cmd.arg(path);
+            return cmd;
+        };
+
+        for arg in open_args {
             // TODO should not assume utf8 for path
             cmd.arg(arg.replace(FILEPATH_PLACEHOLDER, &path.to_string_lossy()));
         }
@@ -326,11 +335,11 @@ pub(crate) static PROGRAMS: LazyLock<Vec<ProgramSpec>> = LazyLock::new(|| {
             id: "echo".into(),
             name: "echo".into(),
             cli_arg_supplier: CliArgumentSupplier::Custom(CustomCliArgumentSupplier {
-                open_at_line_args: vec![
+                open_at_line_args: Some(vec![
                     "filepath='{{filepath}}'".into(),
                     "line_number='{{line_number}}'".into(),
-                ],
-                open_args: vec!["filepath='{{filepath}}'".into()],
+                ]),
+                open_args: Some(vec!["filepath='{{filepath}}'".into()]),
             }),
             executable: ExecutableProgram::ShellExecutable(ShellExecutable {
                 name_or_path: "echo".into(),
@@ -354,18 +363,18 @@ pub(crate) static PROGRAMS: LazyLock<Vec<ProgramSpec>> = LazyLock::new(|| {
             id: "nvim-remote".into(),
             name: "Neovim Remote".into(),
             cli_arg_supplier: CliArgumentSupplier::Custom(CustomCliArgumentSupplier {
-                open_at_line_args: vec![
+                open_at_line_args: Some(vec![
                     "--server".into(),
                     "/tmp/nvim-server.pipe".into(),
                     "--remote-expr".into(),
                     "execute('edit +{{line_number}} ' . fnameescape('{{filepath}}'))".into(),
-                ],
-                open_args: vec![
+                ]),
+                open_args: Some(vec![
                     "--server".into(),
                     "/tmp/nvim-server.pipe".into(),
                     "--remote-expr".into(),
                     "execute('edit ' . fnameescape('{{filepath}}'))".into(),
-                ],
+                ]),
             }),
             executable: ExecutableProgram::ShellExecutable(ShellExecutable {
                 name_or_path: "nvim".into(),
@@ -524,14 +533,14 @@ pub struct UserDefinedProgramSpec {
     /// Recognized placeholders:
     ///
     /// * [`FILEPATH_PLACEHOLDER`] is substituted for the filepath
-    pub open_args: Vec<String>,
+    pub open_args: Option<Vec<String>>,
     /// Arguments to pass to the executable when invoked to open at a specific line.
     ///
     /// Recognized placeholders:
     ///
     /// * [`FILEPATH_PLACEHOLDER`] is substituted for the filepath
     /// * [`LINE_NUMBER_PLACEHOLDER`] is substituted for the line number
-    pub open_at_line_args: Vec<String>,
+    pub open_at_line_args: Option<Vec<String>>,
 }
 
 /// A user defined executable.

--- a/crates/but-api/src/open/program.rs
+++ b/crates/but-api/src/open/program.rs
@@ -74,8 +74,8 @@ impl ProgramSpec {
 impl From<UserDefinedProgramSpec> for ProgramSpec {
     fn from(value: UserDefinedProgramSpec) -> Self {
         ProgramSpec {
-            id: value.id,
-            name: value.display_name,
+            id: value.id.unwrap_or_else(|| value.name.clone()),
+            name: value.name,
             cli_arg_supplier: CliArgumentSupplier::Custom(CustomCliArgumentSupplier {
                 open_args: value.open_args,
                 open_at_line_args: value.open_at_line_args,
@@ -524,9 +524,11 @@ fn open_in_macos_application(
 #[serde(rename_all = "camelCase")]
 pub struct UserDefinedProgramSpec {
     /// Identifier used to refer to the program.
-    pub id: String,
+    ///
+    /// If left empty, the ID is derived from [`Self::name`] instead.
+    pub id: Option<String>,
     /// The display name of the program.
-    pub display_name: String,
+    pub name: String,
     /// The exuctable to invoke to start the program.
     pub executable: UserDefinedShellExecutable,
     /// The kind of the program.

--- a/crates/but-api/src/open/program.rs
+++ b/crates/but-api/src/open/program.rs
@@ -15,8 +15,11 @@ use serde::{Deserialize, Serialize};
 /// Name of the user-defined programs file
 pub const USER_DEFINED_PROGRAMS_FILENAME: &str = "programs.json";
 
-const FILEPATH_PLACEHOLDER: &str = "{{filepath}}";
-const LINE_NUMBER_PLACEHOLDER: &str = "{{line_number}}";
+/// Placeholder used for filepath interpolation.
+pub const FILEPATH_PLACEHOLDER: &str = "{{filepath}}";
+
+/// Placeholder used for line number.
+pub const LINE_NUMBER_PLACEHOLDER: &str = "{{line_number}}";
 
 /// Program category to classify an openable program.
 #[derive(Clone, Debug, PartialEq)]

--- a/crates/but-api/src/open/program.rs
+++ b/crates/but-api/src/open/program.rs
@@ -12,6 +12,9 @@ use crate::open::spawn::spawn_and_reap;
 
 use serde::{Deserialize, Serialize};
 
+/// Name of the user-defined programs file
+pub const USER_DEFINED_PROGRAMS_FILENAME: &str = "programs.json";
+
 const FILEPATH_PLACEHOLDER: &str = "{{filepath}}";
 const LINE_NUMBER_PLACEHOLDER: &str = "{{line_number}}";
 

--- a/crates/but-api/src/open/program.rs
+++ b/crates/but-api/src/open/program.rs
@@ -27,6 +27,7 @@ pub enum ProgramCategory {
     FileManager,
     /// Anything that doesn't fit within other types and is not worthwhile to add a new type for.
     Other,
+    #[cfg(debug_assertions)]
     /// Purely for testing, should not be included in production builds.
     Test,
 }
@@ -334,6 +335,7 @@ pub(crate) static PROGRAMS: LazyLock<Vec<ProgramSpec>> = LazyLock::new(|| {
             }),
             category: ProgramCategory::Editor,
         },
+        #[cfg(debug_assertions)]
         ProgramSpec {
             id: "echo".into(),
             name: "echo".into(),

--- a/crates/but-api/src/open/program.rs
+++ b/crates/but-api/src/open/program.rs
@@ -10,25 +10,36 @@ use std::path::PathBuf;
 
 use crate::open::spawn::spawn_and_reap;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 const FILEPATH_PLACEHOLDER: &str = "{{filepath}}";
 const LINE_NUMBER_PLACEHOLDER: &str = "{{line_number}}";
 
-/// Program type to classify an openable program.
-#[derive(Clone, PartialEq)]
-pub enum ProgramType {
+/// Program category to classify an openable program.
+#[derive(Clone, Debug, PartialEq)]
+pub enum ProgramCategory {
     /// A text editor/IDE.
     Editor,
+    /// A file manager such as Finder, Explorer or Thunar.
+    FileManager,
     /// Anything that doesn't fit within other types and is not worthwhile to add a new type for.
     Other,
-    /// Purely for testing, should never be exposed outside of this module. This is only here until
-    /// we have the capability to define custom programs through config.
+    /// Purely for testing, should not be included in production builds.
     Test,
 }
 
+impl From<UserDefinedProgramCategory> for ProgramCategory {
+    fn from(value: UserDefinedProgramCategory) -> Self {
+        match value {
+            UserDefinedProgramCategory::Editor => ProgramCategory::Editor,
+            UserDefinedProgramCategory::FileManager => ProgramCategory::FileManager,
+            UserDefinedProgramCategory::Other => ProgramCategory::Other,
+        }
+    }
+}
+
 /// Supported program to open a file or directory in.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct ProgramSpec {
     /// Identifier used to refer to the program.
     pub id: String,
@@ -38,8 +49,8 @@ pub struct ProgramSpec {
     cli_arg_supplier: CliArgumentSupplier,
     /// The exuctable to invoke to start the program.
     pub executable: ExecutableProgram,
-    /// The kind of the program.
-    pub kind: ProgramType,
+    /// The category of the program.
+    pub category: ProgramCategory,
 }
 
 impl ProgramSpec {
@@ -53,12 +64,27 @@ impl ProgramSpec {
             ExecutableProgram::MacosApplication(_) => false,
         };
 
-        !requires_terminal && self.kind == ProgramType::Editor
+        !requires_terminal && self.category == ProgramCategory::Editor
+    }
+}
+
+impl From<UserDefinedProgramSpec> for ProgramSpec {
+    fn from(value: UserDefinedProgramSpec) -> Self {
+        ProgramSpec {
+            id: value.id,
+            name: value.display_name,
+            cli_arg_supplier: CliArgumentSupplier::Custom(CustomCliArgumentSupplier {
+                open_args: value.open_args,
+                open_at_line_args: value.open_at_line_args,
+            }),
+            executable: value.executable.into(),
+            category: value.category.into(),
+        }
     }
 }
 
 /// A named executable that can be invoked from a shell.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct ShellExecutable {
     /// Name of the executable on the PATH, or a qualified path to it.
     pub name_or_path: String,
@@ -70,13 +96,22 @@ pub struct ShellExecutable {
 }
 
 /// The executable to invoke for a program.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum ExecutableProgram {
     /// A program that can be executed from a shell.
     ShellExecutable(ShellExecutable),
     /// A macOS application installed s.t. it has a bundle identifier.
     #[cfg(target_os = "macos")]
     MacosApplication(MacosApplication),
+}
+
+impl From<UserDefinedShellExecutable> for ExecutableProgram {
+    fn from(value: UserDefinedShellExecutable) -> Self {
+        ExecutableProgram::ShellExecutable(ShellExecutable {
+            name_or_path: value.name_or_path,
+            requires_tty: value.requires_tty,
+        })
+    }
 }
 
 /// Supported editor configuration for API clients.
@@ -100,7 +135,7 @@ impl From<&ProgramSpec> for Editor {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 enum CliArgumentSupplier {
     VSCodeLike,
     Zed,
@@ -145,7 +180,7 @@ impl CliArgumentSupplier {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 struct CustomCliArgumentSupplier {
     /// Arguments to pass to the executable when invoked to open a file.
     ///
@@ -197,7 +232,7 @@ pub(crate) static PROGRAMS: LazyLock<Vec<ProgramSpec>> = LazyLock::new(|| {
                 name_or_path: "nvim".into(),
                 requires_tty: true,
             }),
-            kind: ProgramType::Editor,
+            category: ProgramCategory::Editor,
         },
         ProgramSpec {
             id: "cursor".into(),
@@ -217,7 +252,7 @@ pub(crate) static PROGRAMS: LazyLock<Vec<ProgramSpec>> = LazyLock::new(|| {
                 bundle_identifier: "com.todesktop.230313mzl4w4u92".into(),
                 cli_wrapper_path: Some("Contents/Resources/app/bin/cursor".into()),
             }),
-            kind: ProgramType::Editor,
+            category: ProgramCategory::Editor,
         },
         ProgramSpec {
             id: "sublime".into(),
@@ -236,7 +271,7 @@ pub(crate) static PROGRAMS: LazyLock<Vec<ProgramSpec>> = LazyLock::new(|| {
                 bundle_identifier: "com.sublimetext.4".into(),
                 cli_wrapper_path: Some("Contents/SharedSupport/bin/subl".into()),
             }),
-            kind: ProgramType::Editor,
+            category: ProgramCategory::Editor,
         },
         ProgramSpec {
             id: "vscode".into(),
@@ -255,7 +290,7 @@ pub(crate) static PROGRAMS: LazyLock<Vec<ProgramSpec>> = LazyLock::new(|| {
                 bundle_identifier: "com.microsoft.VSCode".into(),
                 cli_wrapper_path: Some("Contents/Resources/app/bin/code".into()),
             }),
-            kind: ProgramType::Editor,
+            category: ProgramCategory::Editor,
         },
         #[cfg(target_os = "macos")]
         ProgramSpec {
@@ -266,7 +301,7 @@ pub(crate) static PROGRAMS: LazyLock<Vec<ProgramSpec>> = LazyLock::new(|| {
                 bundle_identifier: "com.apple.dt.Xcode".into(),
                 cli_wrapper_path: Some("Contents/Developer/usr/bin/xed".into()),
             }),
-            kind: ProgramType::Editor,
+            category: ProgramCategory::Editor,
         },
         ProgramSpec {
             id: "zed".into(),
@@ -285,9 +320,8 @@ pub(crate) static PROGRAMS: LazyLock<Vec<ProgramSpec>> = LazyLock::new(|| {
                 bundle_identifier: "dev.zed.Zed".into(),
                 cli_wrapper_path: Some("Contents/MacOS/cli".into()),
             }),
-            kind: ProgramType::Editor,
+            category: ProgramCategory::Editor,
         },
-        #[cfg(any(target_os = "linux", target_os = "macos"))]
         ProgramSpec {
             id: "echo".into(),
             name: "echo".into(),
@@ -302,7 +336,7 @@ pub(crate) static PROGRAMS: LazyLock<Vec<ProgramSpec>> = LazyLock::new(|| {
                 name_or_path: "echo".into(),
                 requires_tty: true,
             }),
-            kind: ProgramType::Test,
+            category: ProgramCategory::Test,
         },
         #[cfg(target_os = "linux")]
         ProgramSpec {
@@ -313,7 +347,7 @@ pub(crate) static PROGRAMS: LazyLock<Vec<ProgramSpec>> = LazyLock::new(|| {
                 name_or_path: "thunar".into(),
                 requires_tty: false,
             }),
-            kind: ProgramType::Other,
+            category: ProgramCategory::FileManager,
         },
         #[cfg(unix)]
         ProgramSpec {
@@ -337,7 +371,7 @@ pub(crate) static PROGRAMS: LazyLock<Vec<ProgramSpec>> = LazyLock::new(|| {
                 name_or_path: "nvim".into(),
                 requires_tty: false,
             }),
-            kind: ProgramType::Editor,
+            category: ProgramCategory::Editor,
         },
     ])
 });
@@ -395,7 +429,7 @@ fn open_in_shell_executable(
 
 /// A canonically installed macOS application with a bundle ID and an optional CLI wrapper.
 #[cfg(target_os = "macos")]
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct MacosApplication {
     /// macOS bundle identifier for the application.
     pub bundle_identifier: String,
@@ -471,4 +505,56 @@ fn open_in_macos_application(
     }
 
     Ok(())
+}
+
+/// A serializable form of [`ProgramSpec`] for user defined programs.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UserDefinedProgramSpec {
+    /// Identifier used to refer to the program.
+    pub id: String,
+    /// The display name of the program.
+    pub display_name: String,
+    /// The exuctable to invoke to start the program.
+    pub executable: UserDefinedShellExecutable,
+    /// The kind of the program.
+    pub category: UserDefinedProgramCategory,
+    /// Arguments to pass to the executable when invoked to open a file.
+    ///
+    /// Recognized placeholders:
+    ///
+    /// * [`FILEPATH_PLACEHOLDER`] is substituted for the filepath
+    pub open_args: Vec<String>,
+    /// Arguments to pass to the executable when invoked to open at a specific line.
+    ///
+    /// Recognized placeholders:
+    ///
+    /// * [`FILEPATH_PLACEHOLDER`] is substituted for the filepath
+    /// * [`LINE_NUMBER_PLACEHOLDER`] is substituted for the line number
+    pub open_at_line_args: Vec<String>,
+}
+
+/// A user defined executable.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UserDefinedShellExecutable {
+    /// Name of the executable on the PATH, or a qualified path to it.
+    pub name_or_path: String,
+    /// Whether the program requires an attached TTY or not.
+    ///
+    /// If this is true, it means that this program cannot be launched reliably from a GUI client,
+    /// and also needs the TUI to suspend in order for the editor to take over the terminal.
+    pub requires_tty: bool,
+}
+
+/// Program category.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum UserDefinedProgramCategory {
+    /// A text editor/IDE.
+    Editor,
+    /// A file manager.
+    FileManager,
+    /// Anything else.
+    Other,
 }

--- a/crates/but/src/command/open.rs
+++ b/crates/but/src/command/open.rs
@@ -4,7 +4,6 @@ use but_api::open::{
 use but_ctx::Context;
 use but_hunk_assignment::HunkAssignment;
 use gix::utils::AsBStr;
-use itertools::Itertools;
 
 use crate::{
     CliError, CliResult, IdMap,

--- a/crates/but/src/command/open.rs
+++ b/crates/but/src/command/open.rs
@@ -52,31 +52,22 @@ pub(crate) fn open(
 
     let builtin_program_specs = list_builtin_program_specs();
     let user_defined_program_specs = list_user_defined_program_specs();
-    let all_program_specs: Vec<_> = user_defined_program_specs
+    let mut all_program_specs = user_defined_program_specs
         .iter()
-        .chain(builtin_program_specs)
-        .collect();
+        .chain(builtin_program_specs);
 
     let program = match program_id {
         Some(program_id) => all_program_specs
-            .iter()
             .find(|ps| ps.id == program_id)
             .ok_or_else(|| {
-                let all_programs = all_program_specs
-                    .iter()
-                    .map(|ps| format!("id='{}', name='{}'", ps.id, ps.name))
-                    .join("\n");
-
                 CliError::from(
-                    bad_input(format!(
-                        "No such program found. Available programs: \n\n{all_programs}"
-                    ))
-                    .arg_name("--program-id")
-                    .arg_value(program_id),
+                    bad_input("No such program found")
+                        .arg_name("--program-id")
+                        .arg_value(program_id),
                 )
             })?,
-        None => builtin_program_specs
-            .first()
+        None => all_program_specs
+            .next()
             .expect("BUG: The internal list of programs should not be empty"),
     };
 

--- a/crates/but/src/command/open.rs
+++ b/crates/but/src/command/open.rs
@@ -75,7 +75,7 @@ pub(crate) fn open(
                     .arg_value(program_id),
                 )
             })?,
-        None => list_builtin_program_specs()
+        None => builtin_program_specs
             .first()
             .expect("BUG: The internal list of programs should not be empty"),
     };

--- a/crates/but/src/command/open.rs
+++ b/crates/but/src/command/open.rs
@@ -51,7 +51,7 @@ pub(crate) fn open(
         };
 
     let builtin_program_specs = list_builtin_program_specs();
-    let user_defined_program_specs = list_user_defined_program_specs()?;
+    let user_defined_program_specs = list_user_defined_program_specs();
     let all_program_specs: Vec<_> = user_defined_program_specs
         .iter()
         .chain(builtin_program_specs)

--- a/crates/but/src/command/open.rs
+++ b/crates/but/src/command/open.rs
@@ -1,6 +1,5 @@
 use but_api::open::{
-    list_program_specs,
-    program::open_in_program_unchecked,
+    list_builtin_program_specs, list_user_defined_program_specs, program::open_in_program_unchecked,
 };
 use but_ctx::Context;
 use but_hunk_assignment::HunkAssignment;
@@ -51,20 +50,32 @@ pub(crate) fn open(
             }
         };
 
+    let builtin_program_specs = list_builtin_program_specs();
+    let user_defined_program_specs = list_user_defined_program_specs()?;
+    let all_program_specs: Vec<_> = user_defined_program_specs
+        .iter()
+        .chain(builtin_program_specs)
+        .collect();
+
     let program = match program_id {
-        Some(program_id) => list_program_specs()
+        Some(program_id) => all_program_specs
             .iter()
             .find(|ps| ps.id == program_id)
             .ok_or_else(|| {
-                let all_programs = list_program_specs().iter().map(|ps| format!("id='{}', name='{}'", ps.id, ps.name)).join("\n");
+                let all_programs = all_program_specs
+                    .iter()
+                    .map(|ps| format!("id='{}', name='{}'", ps.id, ps.name))
+                    .join("\n");
 
                 CliError::from(
-                    bad_input(format!("No such program found. Available programs: \n\n{all_programs}"))
-                        .arg_name("--program-id")
-                        .arg_value(program_id),
+                    bad_input(format!(
+                        "No such program found. Available programs: \n\n{all_programs}"
+                    ))
+                    .arg_name("--program-id")
+                    .arg_value(program_id),
                 )
             })?,
-        None => list_program_specs()
+        None => list_builtin_program_specs()
             .first()
             .expect("BUG: The internal list of programs should not be empty"),
     };

--- a/crates/but/src/command/open.rs
+++ b/crates/but/src/command/open.rs
@@ -1,10 +1,14 @@
-use but_api::open::{list_program_specs, program::open_in_program_unchecked};
+use but_api::open::{
+    list_program_specs,
+    program::open_in_program_unchecked,
+};
 use but_ctx::Context;
 use but_hunk_assignment::HunkAssignment;
 use gix::utils::AsBStr;
+use itertools::Itertools;
 
 use crate::{
-    CliResult, IdMap,
+    CliError, CliResult, IdMap,
     args::atoms::{CliIdArg, Purpose, ResolvedCliIdArg},
     bad_input,
 };
@@ -47,20 +51,22 @@ pub(crate) fn open(
             }
         };
 
-    let program = if let Some(program_id) = program_id {
-        match list_program_specs().iter().find(|ps| ps.id == program_id) {
-            Some(program) => program,
-            None => {
-                return Err(bad_input("No such program")
-                    .arg_name("--program-id")
-                    .arg_value(program_id)
-                    .into());
-            }
-        }
-    } else {
-        list_program_specs()
+    let program = match program_id {
+        Some(program_id) => list_program_specs()
+            .iter()
+            .find(|ps| ps.id == program_id)
+            .ok_or_else(|| {
+                let all_programs = list_program_specs().iter().map(|ps| format!("id='{}', name='{}'", ps.id, ps.name)).join("\n");
+
+                CliError::from(
+                    bad_input(format!("No such program found. Available programs: \n\n{all_programs}"))
+                        .arg_name("--program-id")
+                        .arg_value(program_id),
+                )
+            })?,
+        None => list_program_specs()
             .first()
-            .expect("The list of programs cannot be empty")
+            .expect("BUG: The internal list of programs should not be empty"),
     };
 
     open_in_program_unchecked(program, &path, line_nr)?;

--- a/crates/but/tests/but/command/open.rs
+++ b/crates/but/tests/but/command/open.rs
@@ -260,16 +260,7 @@ fn cannot_open_with_unknown_program() {
         .stderr_eq(snapbox::str![[r#"
 Error: Bad input 'nosuchprogram' for '--program-id'
 
-No such program found. Available programs: 
-
-id='nvim', name='Neovim'
-id='cursor', name='Cursor'
-id='sublime', name='Sublime Text'
-id='vscode', name='VS Code'
-id='zed', name='Zed'
-id='echo', name='echo'
-id='thunar', name='Thunar'
-id='nvim-remote', name='Neovim Remote'
+No such program found
 
 "#]]);
 }
@@ -521,16 +512,7 @@ fn ignores_malformed_user_defined_programs_file() {
         .stderr_eq(snapbox::str![[r#"
 Error: Bad input 'test-program' for '--program-id'
 
-No such program found. Available programs: 
-
-id='nvim', name='Neovim'
-id='cursor', name='Cursor'
-id='sublime', name='Sublime Text'
-id='vscode', name='VS Code'
-id='zed', name='Zed'
-id='echo', name='echo'
-id='thunar', name='Thunar'
-id='nvim-remote', name='Neovim Remote'
+No such program found
 
 "#]]);
 

--- a/crates/but/tests/but/command/open.rs
+++ b/crates/but/tests/but/command/open.rs
@@ -290,7 +290,7 @@ fn user_defined_program_shell_executable_handles_shell_metacharacters() {
         r#"[
    {
      "id": "test-program",
-     "displayName": "Test Program",
+     "name": "Test Program",
      "executable": {
        "nameOrPath": "echo",
        "requiresTty": true
@@ -373,7 +373,7 @@ fn user_defined_program_defaults_to_default_open_args() {
         r#"[
    {
      "id": "test-program-no-args",
-     "displayName": "Test Program No Args",
+     "name": "Test Program No Args",
      "executable": {
        "nameOrPath": "echo",
        "requiresTty": true
@@ -382,7 +382,7 @@ fn user_defined_program_defaults_to_default_open_args() {
    },
    {
      "id": "test-program-only-open-args",
-     "displayName": "Test Program Only Open Args",
+     "name": "Test Program Only Open Args",
      "executable": {
        "nameOrPath": "echo",
        "requiresTty": true
@@ -394,7 +394,7 @@ fn user_defined_program_defaults_to_default_open_args() {
    },
    {
      "id": "test-program-only-open-at-args",
-     "displayName": "Test Program Only Open At Args",
+     "name": "Test Program Only Open At Args",
      "executable": {
        "nameOrPath": "echo",
        "requiresTty": true
@@ -508,7 +508,7 @@ fn ignores_malformed_user_defined_programs_file() {
         r#"[
    {
      "id": "test-program",
-     "displayName": "Test Program",
+     "name": "Test Program",
      "executable": {
        "nameOrPath": "echo",
    "#,
@@ -531,6 +531,58 @@ id='zed', name='Zed'
 id='echo', name='echo'
 id='thunar', name='Thunar'
 id='nvim-remote', name='Neovim Remote'
+
+"#]]);
+
+    // Can still successfully use built-ins
+    env.but("_open file.txt -p echo")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+filepath='/[..]/file.txt'
+
+"#]]);
+}
+
+#[test]
+fn user_defined_program_derives_id_from_name_if_id_is_omitted() {
+    let env = setup_multi_hunk_uncommitted_changes("file.txt");
+
+    let programs_json = env
+        .app_data_dir()
+        .join("gitbutler")
+        .join(USER_DEFINED_PROGRAMS_FILENAME);
+
+    std::fs::write(
+        programs_json,
+        r#"[
+   {
+     "name": "Test Program",
+     "executable": {
+       "nameOrPath": "echo",
+       "requiresTty": true
+     },
+     "category": "other",
+     "openArgs": [
+       "Test Program - Open File:",
+       "filepath='{{filepath}}'"
+     ],
+     "openAtLineArgs": [
+       "Test Program - Open File At Line:",
+       "line_number='{{line_number}}'",
+       "filepath='{{filepath}}'"
+     ]
+   }
+]
+   "#,
+    )
+    .unwrap();
+
+    env.but("_open file.txt -p 'Test Program'")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Test Program - Open File: filepath='/tmp/.tmpbzRQkQ/file.txt'
 
 "#]]);
 

--- a/crates/but/tests/but/command/open.rs
+++ b/crates/but/tests/but/command/open.rs
@@ -161,12 +161,12 @@ filepath='/[..]/file-with-mixed.txt' line_number='2'
 #[test]
 fn open_uncommitted_hunk_in_file_that_contains_spaces_and_shell_metacharacters() {
     let env = setup_multi_hunk_uncommitted_changes(
-        "file with some $meta; cat A > new-file.txt; spaces/in it.txt",
+        "file with some $meta; cat A > new-file.txt; spaces in it.txt",
     );
 
     env.but("status").assert().success().stdout_eq(snapbox::str![[r#"
 ╭┄ zz [uncommitted]
-┊   pr M file with some $meta; cat A > new-file.txt; spaces/in it.txt
+┊   pv M file with some $meta; cat A > new-file.txt; spaces in it.txt
 ┊
 ┊╭┄ br [a-branch-1]
 ┊●   1 Add file
@@ -178,11 +178,11 @@ Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "mes
 
 "#]]);
 
-    env.but("_open pr:4 -p echo")
+    env.but("_open pv:4 -p echo")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-filepath='/[..]/file with some $meta; cat A > new-file.txt; spaces/in it.txt' line_number='11'
+filepath='/tmp/.tmpI7AHQU/file with some $meta; cat A > new-file.txt; spaces in it.txt' line_number='11'
 
 "#]]);
 }
@@ -252,7 +252,10 @@ Error: Expected uncommitted file or hunk, got a committed file
 #[test]
 fn cannot_open_with_unknown_program() {
     let env = setup_multi_hunk_uncommitted_changes("file.txt");
-    env.but("_open file.txt -p nosuchprogram").assert().failure().stderr_eq(snapbox::str![[r#"
+    env.but("_open file.txt -p nosuchprogram")
+        .assert()
+        .failure()
+        .stderr_eq(snapbox::str![[r#"
 Error: Bad input 'nosuchprogram' for '--program-id'
 
 No such program found. Available programs: 
@@ -265,6 +268,86 @@ id='zed', name='Zed'
 id='echo', name='echo'
 id='thunar', name='Thunar'
 id='nvim-remote', name='Neovim Remote'
+
+"#]]);
+}
+
+#[test]
+fn user_defined_program_shell_executable_handles_shell_metacharacters() {
+    let env = setup_multi_hunk_uncommitted_changes(
+        "file with some $meta; cat A > new-file.txt; spaces in it.txt",
+    );
+
+    let programs_json = env.app_data_dir().join("gitbutler").join("programs.json");
+
+    std::fs::write(
+        programs_json,
+        r#"[
+   {
+     "id": "test-program",
+     "displayName": "Test Program",
+     "executable": {
+       "nameOrPath": "echo",
+       "requiresTty": true
+     },
+     "category": "other",
+     "openArgs": [
+       "Test Program - Open File:",
+       "filepath='{{filepath}}'"
+     ],
+     "openAtLineArgs": [
+       "Test Program - Open File At Line:",
+       "line_number='{{line_number}}'",
+       "filepath='{{filepath}}'"
+     ]
+   }
+]"#,
+    )
+    .unwrap();
+
+    env.but("status -f").assert().success().stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted]
+┊   pv M file with some $meta; cat A > new-file.txt; spaces in it.txt
+┊
+┊╭┄br [a-branch-1]
+┊●   1 Add file
+┊│     1:p A file with some $meta; cat A > new-file.txt; spaces in it.txt
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "message" --changes <id>` to commit them
+
+"#]]);
+
+    env.but("_open pv -p test-program").assert().success().stdout_eq(snapbox::str![[r#"
+Test Program - Open File: filepath='/tmp/.tmphACMwH/file with some $meta; cat A > new-file.txt; spaces in it.txt'
+
+"#]]);
+
+    env.but("diff")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+─────────────────────────────────────────────────────────────────╮
+pv:7 file with some $meta; cat A > new-file.txt; spaces in it.txt│
+─────────────────────────────────────────────────────────────────╯
+     1│+new first
+   1 2│ this
+   2 3│ is
+   3 4│ some
+─────────────────────────────────────────────────────────────────╮
+pv:4 file with some $meta; cat A > new-file.txt; spaces in it.txt│
+─────────────────────────────────────────────────────────────────╯
+    7  8│ with
+    8  9│ added
+    9 10│ lines
+      11│+new last
+
+"#]]);
+
+    env.but("_open pv:4 -p test-program ").assert().success().stdout_eq(snapbox::str![[r#"
+Test Program - Open File At Line: line_number='11' filepath='/tmp/.tmphACMwH/file with some $meta; cat A > new-file.txt; spaces in it.txt'
 
 "#]]);
 }

--- a/crates/but/tests/but/command/open.rs
+++ b/crates/but/tests/but/command/open.rs
@@ -293,7 +293,7 @@ fn user_defined_program_shell_executable_handles_shell_metacharacters() {
      "name": "Test Program",
      "executable": {
        "nameOrPath": "echo",
-       "requiresTty": true
+       "requiresTerminal": true
      },
      "category": "other",
      "openArgs": [
@@ -376,7 +376,7 @@ fn user_defined_program_defaults_to_default_open_args() {
      "name": "Test Program No Args",
      "executable": {
        "nameOrPath": "echo",
-       "requiresTty": true
+       "requiresTerminal": true
      },
      "category": "other"
    },
@@ -385,7 +385,7 @@ fn user_defined_program_defaults_to_default_open_args() {
      "name": "Test Program Only Open Args",
      "executable": {
        "nameOrPath": "echo",
-       "requiresTty": true
+       "requiresTerminal": true
      },
      "category": "other",
      "openArgs": [
@@ -397,7 +397,7 @@ fn user_defined_program_defaults_to_default_open_args() {
      "name": "Test Program Only Open At Args",
      "executable": {
        "nameOrPath": "echo",
-       "requiresTty": true
+       "requiresTerminal": true
      },
      "category": "other",
      "openAtLineArgs": [
@@ -560,7 +560,7 @@ fn user_defined_program_derives_id_from_name_if_id_is_omitted() {
      "name": "Test Program",
      "executable": {
        "nameOrPath": "echo",
-       "requiresTty": true
+       "requiresTerminal": true
      },
      "category": "other",
      "openArgs": [

--- a/crates/but/tests/but/command/open.rs
+++ b/crates/but/tests/but/command/open.rs
@@ -321,7 +321,7 @@ Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "mes
 "#]]);
 
     env.but("_open pv -p test-program").assert().success().stdout_eq(snapbox::str![[r#"
-Test Program - Open File: filepath='/tmp/.tmphACMwH/file with some $meta; cat A > new-file.txt; spaces in it.txt'
+Test Program - Open File: filepath='/[..]/file with some $meta; cat A > new-file.txt; spaces in it.txt'
 
 "#]]);
 
@@ -347,7 +347,141 @@ pv:4 file with some $meta; cat A > new-file.txt; spaces in it.txt│
 "#]]);
 
     env.but("_open pv:4 -p test-program ").assert().success().stdout_eq(snapbox::str![[r#"
-Test Program - Open File At Line: line_number='11' filepath='/tmp/.tmphACMwH/file with some $meta; cat A > new-file.txt; spaces in it.txt'
+Test Program - Open File At Line: line_number='11' filepath='/[..]/file with some $meta; cat A > new-file.txt; spaces in it.txt'
+
+"#]]);
+}
+
+/// For most programs, you get something usable by just defining the executable and passing the file
+/// as the first argument.
+#[test]
+fn user_defined_program_defaults_to_default_open_args() {
+    let env = setup_multi_hunk_uncommitted_changes("file.txt");
+
+    let programs_json = env.app_data_dir().join("gitbutler").join("programs.json");
+
+    std::fs::write(
+        programs_json,
+        r#"[
+   {
+     "id": "test-program-no-args",
+     "displayName": "Test Program No Args",
+     "executable": {
+       "nameOrPath": "echo",
+       "requiresTty": true
+     },
+     "category": "other"
+   },
+   {
+     "id": "test-program-only-open-args",
+     "displayName": "Test Program Only Open Args",
+     "executable": {
+       "nameOrPath": "echo",
+       "requiresTty": true
+     },
+     "category": "other",
+     "openArgs": [
+       "filepath='{{filepath}}'"
+     ]
+   },
+   {
+     "id": "test-program-only-open-at-args",
+     "displayName": "Test Program Only Open At Args",
+     "executable": {
+       "nameOrPath": "echo",
+       "requiresTty": true
+     },
+     "category": "other",
+     "openAtLineArgs": [
+       "line_number='{{line_number}}'",
+       "filepath='{{filepath}}'"
+     ]
+   }
+]"#,
+    )
+    .unwrap();
+
+    env.but("status -f").assert().success().stdout_eq(snapbox::str![[r#"
+╭┄zz [uncommitted]
+┊   uv M file.txt
+┊
+┊╭┄br [a-branch-1]
+┊●   1 Add file
+┊│     1:u A file.txt
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "message" --changes <id>` to commit them
+
+"#]]);
+
+    env.but("diff")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+─────────────╮
+uv:7 file.txt│
+─────────────╯
+     1│+new first
+   1 2│ this
+   2 3│ is
+   3 4│ some
+─────────────╮
+uv:4 file.txt│
+─────────────╯
+    7  8│ with
+    8  9│ added
+    9 10│ lines
+      11│+new last
+
+"#]]);
+
+    // No-args program, should always only get the filepath passed by the default CLI arg supplier
+    env.but("_open uv -p test-program-no-args")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+/[..]/file.txt
+
+"#]]);
+    env.but("_open uv:4 -p test-program-no-args")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+/[..]/file.txt
+
+"#]]);
+
+    // Open args defined, should get the custom open args both for open and open at line
+    env.but("_open uv -p test-program-only-open-args")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+filepath='/[..]/file.txt'
+
+"#]]);
+    env.but("_open uv:4 -p test-program-only-open-args")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+filepath='/[..]/file.txt'
+
+"#]]);
+
+    // Open at line args defined, should get default open and custom open at line
+    env.but("_open uv -p test-program-only-open-at-args")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+/[..]/file.txt
+
+"#]]);
+    env.but("_open uv:4 -p test-program-only-open-at-args")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+line_number='11' filepath='/[..]/file.txt'
 
 "#]]);
 }

--- a/crates/but/tests/but/command/open.rs
+++ b/crates/but/tests/but/command/open.rs
@@ -1,3 +1,5 @@
+use but_api::open::program::USER_DEFINED_PROGRAMS_FILENAME;
+
 use crate::utils::Sandbox;
 
 fn setup_multi_hunk_uncommitted_changes(path: &str) -> Sandbox {
@@ -182,7 +184,7 @@ Hint: run `but diff` to see uncommitted changes and `but commit <branch> -m "mes
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-filepath='/tmp/.tmpI7AHQU/file with some $meta; cat A > new-file.txt; spaces in it.txt' line_number='11'
+filepath='/[..]/file with some $meta; cat A > new-file.txt; spaces in it.txt' line_number='11'
 
 "#]]);
 }
@@ -278,7 +280,10 @@ fn user_defined_program_shell_executable_handles_shell_metacharacters() {
         "file with some $meta; cat A > new-file.txt; spaces in it.txt",
     );
 
-    let programs_json = env.app_data_dir().join("gitbutler").join("programs.json");
+    let programs_json = env
+        .app_data_dir()
+        .join("gitbutler")
+        .join(USER_DEFINED_PROGRAMS_FILENAME);
 
     std::fs::write(
         programs_json,
@@ -358,7 +363,10 @@ Test Program - Open File At Line: line_number='11' filepath='/[..]/file with som
 fn user_defined_program_defaults_to_default_open_args() {
     let env = setup_multi_hunk_uncommitted_changes("file.txt");
 
-    let programs_json = env.app_data_dir().join("gitbutler").join("programs.json");
+    let programs_json = env
+        .app_data_dir()
+        .join("gitbutler")
+        .join(USER_DEFINED_PROGRAMS_FILENAME);
 
     std::fs::write(
         programs_json,
@@ -482,6 +490,56 @@ filepath='/[..]/file.txt'
         .success()
         .stdout_eq(snapbox::str![[r#"
 line_number='11' filepath='/[..]/file.txt'
+
+"#]]);
+}
+
+#[test]
+fn ignores_malformed_user_defined_programs_file() {
+    let env = setup_multi_hunk_uncommitted_changes("file.txt");
+
+    let programs_json = env
+        .app_data_dir()
+        .join("gitbutler")
+        .join(USER_DEFINED_PROGRAMS_FILENAME);
+
+    std::fs::write(
+        programs_json,
+        r#"[
+   {
+     "id": "test-program",
+     "displayName": "Test Program",
+     "executable": {
+       "nameOrPath": "echo",
+   "#,
+    )
+    .unwrap();
+
+    env.but("_open file.txt -p test-program")
+        .assert()
+        .failure()
+        .stderr_eq(snapbox::str![[r#"
+Error: Bad input 'test-program' for '--program-id'
+
+No such program found. Available programs: 
+
+id='nvim', name='Neovim'
+id='cursor', name='Cursor'
+id='sublime', name='Sublime Text'
+id='vscode', name='VS Code'
+id='zed', name='Zed'
+id='echo', name='echo'
+id='thunar', name='Thunar'
+id='nvim-remote', name='Neovim Remote'
+
+"#]]);
+
+    // Can still successfully use built-ins
+    env.but("_open file.txt -p echo")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+filepath='/[..]/file.txt'
 
 "#]]);
 }

--- a/crates/but/tests/but/command/open.rs
+++ b/crates/but/tests/but/command/open.rs
@@ -582,7 +582,7 @@ fn user_defined_program_derives_id_from_name_if_id_is_omitted() {
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Test Program - Open File: filepath='/tmp/.tmpbzRQkQ/file.txt'
+Test Program - Open File: filepath='/[..]/file.txt'
 
 "#]]);
 

--- a/crates/but/tests/but/command/open.rs
+++ b/crates/but/tests/but/command/open.rs
@@ -311,10 +311,10 @@ fn user_defined_program_shell_executable_handles_shell_metacharacters() {
     .unwrap();
 
     env.but("status -f").assert().success().stdout_eq(snapbox::str![[r#"
-╭┄zz [uncommitted]
+╭┄ zz [uncommitted]
 ┊   pv M file with some $meta; cat A > new-file.txt; spaces in it.txt
 ┊
-┊╭┄br [a-branch-1]
+┊╭┄ br [a-branch-1]
 ┊●   1 Add file
 ┊│     1:p A file with some $meta; cat A > new-file.txt; spaces in it.txt
 ├╯
@@ -410,10 +410,10 @@ fn user_defined_program_defaults_to_default_open_args() {
     .unwrap();
 
     env.but("status -f").assert().success().stdout_eq(snapbox::str![[r#"
-╭┄zz [uncommitted]
+╭┄ zz [uncommitted]
 ┊   uv M file.txt
 ┊
-┊╭┄br [a-branch-1]
+┊╭┄ br [a-branch-1]
 ┊●   1 Add file
 ┊│     1:u A file.txt
 ├╯

--- a/crates/but/tests/but/command/open.rs
+++ b/crates/but/tests/but/command/open.rs
@@ -23,7 +23,6 @@ Created new independent branch 'a-branch-1'
 #[test]
 fn open_uncommitted_file_with_() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
-    env.setup_metadata(&["A"]);
 
     env.file("new-file.txt", "content");
 
@@ -206,6 +205,7 @@ Hint: Run `but status` for applicable targets.
 #[test]
 fn cannot_open_committed_changes() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.but("status -f")
         .assert()
@@ -245,6 +245,26 @@ Error: Expected uncommitted file or hunk, got a commit
         .failure()
         .stderr_eq(snapbox::str![[r#"
 Error: Expected uncommitted file or hunk, got a committed file
+
+"#]]);
+}
+
+#[test]
+fn cannot_open_with_unknown_program() {
+    let env = setup_multi_hunk_uncommitted_changes("file.txt");
+    env.but("_open file.txt -p nosuchprogram").assert().failure().stderr_eq(snapbox::str![[r#"
+Error: Bad input 'nosuchprogram' for '--program-id'
+
+No such program found. Available programs: 
+
+id='nvim', name='Neovim'
+id='cursor', name='Cursor'
+id='sublime', name='Sublime Text'
+id='vscode', name='VS Code'
+id='zed', name='Zed'
+id='echo', name='echo'
+id='thunar', name='Thunar'
+id='nvim-remote', name='Neovim Remote'
 
 "#]]);
 }


### PR DESCRIPTION
## 🧢 Changes
This adds in the ability to define custom programs in a separate `programs.json` file. For the moment, I want that file separate as it's _meant_ to be tampered with and potentially wrecked by the user, and I don't think our existing `settings.json` is. If we find a smooth way to define this file through `but` and/or Lite, then we can inline it into `settings.json`.

The tests for `but _open` have a bunch of examples of what this file can look like, but here are some more illustrations.

A **minimal definition** that is mostly servicable looks like this.

```json
[
   {
     "name": "Test Program",
     "executable": {
       "nameOrPath": "/path/to/some/program",
       "requiresTerminal": false
     },
     "category": "editor"
   }
]
```

This is rendered in Lite alongside other editors as `Test Program`, and can be invoked from `but _open` with `_but open -p 'Test Program'`. When opening a file at `<filepath>` with this program, it will be invoked as `/path/to/some/program <filepath>`.

> If opening a hunk, the line number is simply dropped.

For less awkward `but` invocation, you can add an ID.

```json
[
   {
     "id": "test-program",
     "name": "Test Program",
     "executable": {
       "nameOrPath": "/path/to/some/program",
       "requiresTerminal": false
     },
     "category": "editor"
   }
]
```

This can now be invoked with `_but open -p test-program`. Usage from Lite is unchanged.

If the default `<nameOrPath> <filepath>` invocation does not work, a custom argument list can be specified in `openArgs`:

```json
[
   {
     "id": "test-program",
     "name": "Test Program",
     "executable": {
       "nameOrPath": "/path/to/some/program",
       "requiresTerminal": false
     },
     "category": "editor",
     "openArgs": [
       "--filepath",
       "{{filepath}}"
     ]
   }
]
```

> Note that the arguments is an _array_. Every item in the array is passed as an individual argument. This is to allow us to not invoke the program via a shell, which is security risk due to the renderer in Lite being able to call it with an arbitrary value for filepath (and in the future, probably more things).

This will invoke the command as `/path/to/some/program --filepath {{filepath}}` for all invocations, and line number is _still_ dropped.

To make use of the line number when opening a hunk, a custom argument list can be specified in `openAtLineArgs`.

```json
[
   {
     "id": "test-program",
     "name": "Test Program",
     "executable": {
       "nameOrPath": "/path/to/some/program",
       "requiresTerminal": false
     },
     "category": "editor",
     "openAtLineArgs": [
       "--filepath",
       "{{filepath}}",
       "--line-number",
       "{{line_number}}"
     ]
   }
]
```

> Note: If `openArgs` are defined but `openAtLineArgs` are not, then `openArgs` are used for opening at line, except that the line number is dropped.

> Note: If `openAtLineArgs` are defined but `openArgs` are not, then opening a file (without line number) uses the default invocation of `<program> <filepath>`. It's not generally safe to use the `openAtLineArgs` and just not pass the line number, as that is likely to leave a weird `{{line_number}}` placeholder somewhere.

# Some remaining issues

* A user-defined program can currently shadow built-in programs as the IDs are not checked for uniqueness. This is somewhat intentional, but it can get really confusing if you've selected a built-in and then happen to have defined a custom one that has the same ID. Then the custom one will actually be invoked.
* By the same mechanism as above, if you define multiple custom programs with the same ID, the "first one wins"
* Support for macOS bundle ID instead of path to/name of executable isn't in yet
* No user-friendly way of defining the programs yet, it's all hand-wrangling JSON.

# Some more complete examples

**Neovim remote**
```json
[
   {
     "id": "nvim-remote",
     "name": "Neovim Remote Custom",
     "executable": {
       "nameOrPath": "nvim",
       "requiresTty": false
     },
     "category": "editor",
     "openArgs": [
       "--server",
       "/tmp/nvim-server.pipe",
       "--remote",
       "execute('edit ' . fnameescape('{{filepath}}'))"
     ],
     "openAtLineArgs": [
       "--server",
       "/tmp/nvim-server.pipe",
       "--remote-expr",
       "execute('edit +{{line_number}} ' . fnameescape('{{filepath}}'))"
     ]
   }
]
```

**Safari**
```json
[
   {
     "name": "Safari",
     "executable": {
       "nameOrPath": "/Applications/Safari.app/Contents/MacOS/Safari",
       "requiresTty": false
     },
     "category": "other"
   }
]
```
