### PR TITLE
Repair rather than derive stale state

### DIFF
--- a/apps/lite/ui/src/api/ref-info.ts
+++ b/apps/lite/ui/src/api/ref-info.ts
@@ -19,7 +19,10 @@ type CommitIndex = {
 export type HeadInfoIndex = {
 	stackContextById: (stackId: string) => StackIndex | undefined;
 	branchContextByRefBytes: (ref: Array<number>) => (StackIndex & SegmentIndex) | undefined;
-	commitContextById: (commitId: string) => (StackIndex & SegmentIndex & CommitIndex) | undefined;
+	/** Prefer lookups by commit ID which is globally unique. */
+	commitContextById: (
+		commitOrChangeId: string,
+	) => (StackIndex & SegmentIndex & CommitIndex) | undefined;
 };
 
 const headInfoIndexCache = new WeakMap<RefInfo, HeadInfoIndex>();
@@ -45,22 +48,25 @@ const buildHeadInfoIndex = (headInfo: RefInfo): HeadInfoIndex => {
 			}
 
 			for (const [commitIndex, commit] of segment.commits.entries()) {
-				commitContextById.set(commit.id, {
+				const ctx = {
 					stack,
 					stackIndex,
 					segment,
 					segmentIndex,
 					commit,
 					commitIndex,
-				});
+				};
+				commitContextById.set(commit.id, ctx);
+				// Change IDs aren't globally unique, in which case this is last write wins.
+				commitContextById.set(commit.changeId, ctx);
 			}
 		}
 	}
 
 	return {
-		stackContextById: (id: string) => stackContextById.get(id),
+		stackContextById: (stackId: string) => stackContextById.get(stackId),
 		branchContextByRefBytes: (ref: Array<number>) => branchContextByRef.get(branchRefKey(ref)),
-		commitContextById: (id: string) => commitContextById.get(id),
+		commitContextById: (commitOrChangeId: string) => commitContextById.get(commitOrChangeId),
 	};
 };
 

--- a/apps/lite/ui/src/projects/project.ts
+++ b/apps/lite/ui/src/projects/project.ts
@@ -1,4 +1,3 @@
-import type { HeadInfoIndex } from "#ui/api/ref-info.ts";
 import {
 	branchOperand,
 	commitOperand,
@@ -341,13 +340,7 @@ export const projectReducers = {
 
 const selectCheckedCommits = createSelector(
 	(state: ProjectState) => state.workspace.checkedCommitIds,
-	(_state: ProjectState, headInfoIndex: HeadInfoIndex) => headInfoIndex,
-	(checkedCommitIds, headInfoIndex) =>
-		new Set(
-			Object.keys(checkedCommitIds).filter(
-				(commitId) => headInfoIndex.commitContextById(commitId) !== undefined,
-			),
-		),
+	(checkedCommitIdsRec) => new Set(Object.keys(checkedCommitIdsRec)),
 );
 
 const selectCheckedCommitOperands = createSelector(selectCheckedCommits, (checkedCommitIds) =>
@@ -404,8 +397,6 @@ export const projectSelectors = {
 		state.workspace.checkedCommitIds[commitId] === true,
 	selectCheckedCommits,
 	selectCheckedCommitOperands,
-	selectCheckedCommitCount: (state: ProjectState, headInfoIndex: HeadInfoIndex) =>
-		selectCheckedCommits(state, headInfoIndex).size,
-	selectHasCheckedCommits: (state: ProjectState, headInfoIndex: HeadInfoIndex) =>
-		selectCheckedCommits(state, headInfoIndex).size > 0,
+	selectCheckedCommitCount: (state: ProjectState) => selectCheckedCommits(state).size,
+	selectHasCheckedCommits: (state: ProjectState) => selectCheckedCommits(state).size > 0,
 };

--- a/apps/lite/ui/src/projects/project.ts
+++ b/apps/lite/ui/src/projects/project.ts
@@ -373,6 +373,7 @@ export const projectSelectors = {
 		);
 		return selection !== null && operandEquals(selection, operand);
 	},
+	selectPrimaryOutlineSelection: (state: ProjectState) => state.workspace.selection.outline,
 	selectSelectionOutline: (state: ProjectState, navigationIndex: NavigationIndex<Operand>) =>
 		resolveNavigationIndexSelection(
 			navigationIndex,

--- a/apps/lite/ui/src/projects/state.ts
+++ b/apps/lite/ui/src/projects/state.ts
@@ -71,6 +71,7 @@ export const projectSlice = createSlice({
 		selectDetailsSelectionScope: fromProject(projectSelectors.selectDetailsSelectionScope),
 		selectSelectionUncommittedFiles: fromProject(projectSelectors.selectSelectionUncommittedFiles),
 		selectIsSelectedOutline: fromProject(projectSelectors.selectIsSelectedOutline),
+		selectPrimaryOutlineSelection: fromProject(projectSelectors.selectPrimaryOutlineSelection),
 		selectSelectionOutline: fromProject(projectSelectors.selectSelectionOutline),
 		selectSelectionFiles: fromProject(projectSelectors.selectSelectionFiles),
 		selectSelectionDiff: fromProject(projectSelectors.selectSelectionDiff),

--- a/apps/lite/ui/src/reconcile.ts
+++ b/apps/lite/ui/src/reconcile.ts
@@ -1,0 +1,45 @@
+import { useQuery } from "@tanstack/react-query";
+import { headInfoQueryOptions } from "./api/queries.ts";
+import { useParams } from "@tanstack/react-router";
+import { getHeadInfoIndex, type HeadInfoIndex } from "./api/ref-info.ts";
+import { useEffectEvent, useLayoutEffect } from "react";
+import { useAppDispatch, useAppSelector } from "./store.ts";
+import { projectSlice } from "./projects/state.ts";
+
+/**
+ * Reconcile state between Redux and React Query. This hook should be called very high up in the
+ * tree so that synchronous dispatches in layout effects don't waste too much work. This hook
+ * remains subscribed to any queries that are relevant to the current state.
+ */
+export const useStateReconciler = (): void => {
+	const { id: projectId } = useParams({ from: "/project/$id/workspace" });
+
+	const { data: headInfoIndex } = useQuery({
+		...headInfoQueryOptions(projectId),
+		select: getHeadInfoIndex,
+	});
+
+	const dispatch = useAppDispatch();
+	const checkedCommitIds = useAppSelector((state) =>
+		projectSlice.selectors.selectCheckedCommits(state, projectId),
+	);
+
+	const reconcileCheckedCommits = useEffectEvent((headInfoIndex: HeadInfoIndex) => {
+		const invalidated = checkedCommitIds
+			.values()
+			.filter((commitId) => !headInfoIndex.commitContextById(commitId))
+			.toArray();
+
+		if (invalidated.length > 0) {
+			dispatch(
+				projectSlice.actions.checkCommits({ projectId, commitIds: invalidated, checked: false }),
+			);
+		}
+	});
+
+	useLayoutEffect(() => {
+		if (!headInfoIndex) return;
+
+		reconcileCheckedCommits(headInfoIndex);
+	}, [headInfoIndex]);
+};

--- a/apps/lite/ui/src/reconcile.ts
+++ b/apps/lite/ui/src/reconcile.ts
@@ -1,10 +1,16 @@
+/**
+ * @file Known rewritten commit IDs and branch names are handled separately before reaching this
+ * module.
+ */
+
 import { useQuery } from "@tanstack/react-query";
 import { headInfoQueryOptions } from "./api/queries.ts";
 import { useParams } from "@tanstack/react-router";
 import { getHeadInfoIndex, type HeadInfoIndex } from "./api/ref-info.ts";
-import { useEffectEvent, useLayoutEffect } from "react";
+import { useEffectEvent, useLayoutEffect, useRef } from "react";
 import { useAppDispatch, useAppSelector } from "./store.ts";
 import { projectSlice } from "./projects/state.ts";
+import { commitOperand } from "./operands.ts";
 
 /**
  * Reconcile state between Redux and React Query. This hook should be called very high up in the
@@ -18,12 +24,39 @@ export const useStateReconciler = (): void => {
 		...headInfoQueryOptions(projectId),
 		select: getHeadInfoIndex,
 	});
+	const prevHeadInfoIndexRef = useRef<HeadInfoIndex>(null);
 
 	const dispatch = useAppDispatch();
+
+	const outlineSelection = useAppSelector((state) =>
+		projectSlice.selectors.selectPrimaryOutlineSelection(state, projectId),
+	);
+	const reconcileSelectedCommit = useEffectEvent(
+		(headInfoIndex: HeadInfoIndex, prevHeadInfoIndex: HeadInfoIndex | null) => {
+			if (outlineSelection?._tag !== "Commit") return;
+
+			const curr = headInfoIndex.commitContextById(outlineSelection.commitId);
+			if (curr) return;
+
+			const prev = prevHeadInfoIndex?.commitContextById(outlineSelection.commitId);
+			// Change IDs are not necessarily globally unique, but typically will be. In any case this is
+			// a best-effort fallback.
+			const commitId = prev
+				? headInfoIndex.commitContextById(prev.commit.changeId)?.commit.id
+				: null;
+
+			dispatch(
+				projectSlice.actions.selectOutline({
+					projectId,
+					selection: commitId != null ? commitOperand({ commitId }) : null,
+				}),
+			);
+		},
+	);
+
 	const checkedCommitIds = useAppSelector((state) =>
 		projectSlice.selectors.selectCheckedCommits(state, projectId),
 	);
-
 	const reconcileCheckedCommits = useEffectEvent((headInfoIndex: HeadInfoIndex) => {
 		const invalidated = checkedCommitIds
 			.values()
@@ -41,5 +74,8 @@ export const useStateReconciler = (): void => {
 		if (!headInfoIndex) return;
 
 		reconcileCheckedCommits(headInfoIndex);
+		reconcileSelectedCommit(headInfoIndex, prevHeadInfoIndexRef.current);
+
+		prevHeadInfoIndexRef.current = headInfoIndex;
 	}, [headInfoIndex]);
 };

--- a/apps/lite/ui/src/routes/project/$id/workspace/FileRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/FileRow.tsx
@@ -1,4 +1,3 @@
-import type { HeadInfoIndex } from "#ui/api/ref-info.ts";
 import { FileIcon } from "#ui/components/FileIcon.tsx";
 import rowStyles from "./Row.module.css";
 import { showNativeContextMenu, showNativeMenuFromTrigger } from "#ui/native-menu.ts";
@@ -24,9 +23,8 @@ export const FileRow: FC<
 		projectId: string;
 		fileParent: FileParent;
 		branchNameByCommitId: (commitId: string) => string | undefined;
-		headInfoIndex: HeadInfoIndex | undefined;
 	} & Omit<ComponentProps<typeof Row>, "projectId">
-> = ({ item, projectId, fileParent, branchNameByCommitId, headInfoIndex, id, ...restProps }) => {
+> = ({ item, projectId, fileParent, branchNameByCommitId, id, ...restProps }) => {
 	const relativePath = item._tag === "Change" ? item.change.path : item.path;
 
 	const isDefaultMode = useAppSelector(
@@ -40,9 +38,7 @@ export const FileRow: FC<
 	});
 
 	const hasCheckedCommits = useAppSelector((state) =>
-		headInfoIndex
-			? projectSlice.selectors.selectHasCheckedCommits(state, projectId, headInfoIndex)
-			: false,
+		projectSlice.selectors.selectHasCheckedCommits(state, projectId),
 	);
 
 	const lastSepIdx = relativePath.lastIndexOf("/");

--- a/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.tsx
@@ -194,7 +194,6 @@ export const FilesTree: FC<
 									render={
 										<FileRow
 											item={item}
-											headInfoIndex={headInfoIndex}
 											inert={!navigationIndexIncludes(navigationIndex, item.path, (path) => path)}
 											isSelected={selection !== null && selection === item.path}
 											onSelect={() => onFileSelection(item.path)}

--- a/apps/lite/ui/src/routes/project/$id/workspace/OperationControls.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OperationControls.tsx
@@ -357,9 +357,7 @@ export const OperationControls: FC<{ outlineNavigationIndex: NavigationIndex<Ope
 		select: getHeadInfoIndex,
 	});
 	const checkedCommitCount = useAppSelector((state) =>
-		headInfoIndex
-			? projectSlice.selectors.selectCheckedCommitCount(state, projectId, headInfoIndex)
-			: 0,
+		projectSlice.selectors.selectCheckedCommitCount(state, projectId),
 	);
 
 	return Match.value(outlineMode).pipe(

--- a/apps/lite/ui/src/routes/project/$id/workspace/OperationSourceC.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OperationSourceC.tsx
@@ -39,7 +39,7 @@ export const OperationSourceC: FC<
 	);
 	// We don't necessarily wrap in an array here in order to preserve reference identity.
 	const dragSource = useAppSelector((state) => {
-		if (source._tag !== "Commit" || !headInfoIndex) return source;
+		if (source._tag !== "Commit") return source;
 
 		const isCheckedCommit = projectSlice.selectors.selectCommitChecked(
 			state,
@@ -51,7 +51,6 @@ export const OperationSourceC: FC<
 		const checkedCommitOperands = projectSlice.selectors.selectCheckedCommitOperands(
 			state,
 			projectId,
-			headInfoIndex,
 		);
 		return checkedCommitOperands.length > 0 ? checkedCommitOperands : source;
 	});

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
@@ -624,9 +624,7 @@ export const OutlineTree: FC<
 		outlineSelection,
 	});
 	const hasCheckedCommits = useAppSelector((state) =>
-		headInfoIndex
-			? projectSlice.selectors.selectHasCheckedCommits(state, projectId, headInfoIndex)
-			: false,
+		projectSlice.selectors.selectHasCheckedCommits(state, projectId),
 	);
 	const store = useAppStore();
 	const dispatch = useAppDispatch();
@@ -642,12 +640,9 @@ export const OutlineTree: FC<
 	const getCheckedRange = checkedRange(rangeResolver);
 
 	const checkCommit = ({ commitId, shiftKey }: { commitId: string; shiftKey: boolean }): void => {
-		if (!headInfoIndex) return;
-
 		const checkedCommitIds = projectSlice.selectors.selectCheckedCommits(
 			store.getState(),
 			projectId,
-			headInfoIndex,
 		);
 		const nextCommitRange = getCheckedRange({
 			checked: checkedCommitIds,

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/hotkeys.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/hotkeys.ts
@@ -373,12 +373,9 @@ export const useOutlineTreeHotkeys = ({
 		selection,
 		getKey: operandIdentityKey,
 		operationSourcesForItem: (operand) => {
-			if (!headInfoIndex) return [operand];
-
 			const checkedCommits = projectSlice.selectors.selectCheckedCommitOperands(
 				store.getState(),
 				projectId,
-				headInfoIndex,
 			);
 			return checkedCommits.length > 0 ? checkedCommits : [operand];
 		},

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
@@ -54,6 +54,7 @@ import { OperationControls } from "#ui/routes/project/$id/workspace/OperationCon
 import { WorkspacePageErrorBoundary } from "./WorkspacePageErrorBoundary.tsx";
 import { Settings } from "./Settings.tsx";
 import type { OutlineMode } from "#ui/outline/mode.ts";
+import { useStateReconciler as useReconcileState } from "#ui/reconcile.ts";
 
 // This must be unique as to not collide with other IDs, and stable because it's
 // stored in local storage.
@@ -279,6 +280,8 @@ const ProjectPicker: FC<ProjectPickerProps> = (p) => {
 };
 
 const WorkspacePage: FC = () => {
+	useReconcileState();
+
 	const dispatch = useAppDispatch();
 
 	const { id: projectId } = useParams({ from: "/project/$id/workspace" });


### PR DESCRIPTION
Prep for checked files in a roundabout way, see commits. Substantially improves commit selection stability (e.g. undo), towards GB-1723. Arguably simplifies the mental model, but does not fully embrace this new approach yet. We don't currently bother correlating commits except in selections, though we could; there are probably some abstractions waiting for us here somewhere.