### PR TITLE
feat(tui): `--remember-selection` flag

### DIFF
--- a/crates/but/src/args/atoms/cli_id.rs
+++ b/crates/but/src/args/atoms/cli_id.rs
@@ -84,10 +84,12 @@ impl CliIdArg {
                 commit_id,
                 path,
                 id,
+                change_id,
             } => ResolvedCliIdArg::CommittedFile(CommittedFileId {
                 commit_id,
                 path,
                 id,
+                change_id,
             }),
             CliId::Uncommitted { .. } => ResolvedCliIdArg::Uncommitted,
             CliId::Stack { .. } => ResolvedCliIdArg::Stack,

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -993,6 +993,12 @@ pub enum Subcommands {
     #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     #[cfg(feature = "legacy")]
     Tui {
+        /// When the TUI quits save the selection and restore it when re-opening.
+        ///
+        /// If the saved selection cannot be restore the TUI launch normally as if
+        /// `--remember-selection` wasn't passed.
+        #[clap(long, default_value_t = false)]
+        remember_selection: bool,
         /// Show debug pane with selected-line metadata.
         ///
         /// Requires `tui-profiling` feature.

--- a/crates/but/src/command/commit/move.rs
+++ b/crates/but/src/command/commit/move.rs
@@ -391,6 +391,7 @@ mod tests {
             commit_id: gix::ObjectId::empty_tree(gix::hash::Kind::Sha1),
             path: BString::from(path),
             id: "cf".to_string(),
+            change_id: None,
         }
     }
 

--- a/crates/but/src/command/legacy/diff2.rs
+++ b/crates/but/src/command/legacy/diff2.rs
@@ -221,6 +221,7 @@ fn resolve(ctx: &Context, id_map: &IdMap, args: Platform) -> CliResult<DiffOpera
             commit_id,
             path,
             id,
+            change_id: _,
         }) => Ok(DiffOperation::CommittedFile {
             commit_id,
             path,

--- a/crates/but/src/command/legacy/move2.rs
+++ b/crates/but/src/command/legacy/move2.rs
@@ -614,6 +614,7 @@ fn resolve_sources(
                 commit_id,
                 path,
                 id: _,
+                change_id: _,
             }) => {
                 file_sources.push((commit_id, path));
             }

--- a/crates/but/src/command/legacy/rub/mod.rs
+++ b/crates/but/src/command/legacy/rub/mod.rs
@@ -2211,6 +2211,7 @@ mod tests {
             commit_id: gix::ObjectId::empty_tree(gix::hash::Kind::Sha1),
             path: BString::from("test.txt"),
             id: "cd".to_string(),
+            change_id: None,
         }
     }
 

--- a/crates/but/src/command/legacy/squash2.rs
+++ b/crates/but/src/command/legacy/squash2.rs
@@ -388,6 +388,7 @@ pub fn resolve<'a>(
                             commit_id,
                             path,
                             id: _,
+                            change_id: _,
                         } = committed_file;
 
                         if source != commit_id {

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -115,6 +115,7 @@ pub enum StatusRenderMode {
 
 #[derive(Debug, Default, Copy, Clone)]
 pub struct TuiLaunchOptions {
+    pub remember_selection: bool,
     pub debug: bool,
     pub quit_after: Option<u64>,
     pub headless: bool,

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -1690,6 +1690,7 @@ fn print_commit(
                         commit_id: commit.id,
                         path: inner.path.clone(),
                         id: short_id.to_owned(),
+                        change_id: change_id.map(|change_id| change_id.change_id.clone()),
                     };
 
                     let display_id = displayed_file_id(padded_file_id_prefix.as_deref(), short_id);

--- a/crates/but/src/command/legacy/status/tui/app/discard.rs
+++ b/crates/but/src/command/legacy/status/tui/app/discard.rs
@@ -188,6 +188,7 @@ impl App {
                     commit_id,
                     path,
                     id: _,
+                    change_id: _,
                 } => {
                     let commit_id = *commit_id;
                     let path = path.to_owned();

--- a/crates/but/src/command/legacy/status/tui/app/mark.rs
+++ b/crates/but/src/command/legacy/status/tui/app/mark.rs
@@ -201,6 +201,7 @@ impl<'a> MarksRef<'a> {
                     commit_id,
                     path,
                     id: _,
+                    change_id: _,
                 } = cli_id
                 else {
                     return false;
@@ -573,10 +574,12 @@ impl Markable {
                 commit_id,
                 path,
                 id,
+                change_id,
             }) => CliId::CommittedFile {
                 commit_id,
                 path,
                 id,
+                change_id,
             },
             Markable::Branch(BranchId { name, id, stack_id }) => {
                 CliId::Branch { name, id, stack_id }
@@ -655,12 +658,14 @@ impl<'a> MarkableRef<'a> {
                         commit_id,
                         path,
                         id,
+                        change_id,
                     } = cli_id
                     {
                         return Some(Self::CommittedFile(CommittedFileIdRef {
                             commit_id: *commit_id,
                             path: path.as_ref(),
                             id,
+                            change_id: change_id.as_ref(),
                         }));
                     }
                 }

--- a/crates/but/src/command/legacy/status/tui/app/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/app/mod.rs
@@ -19,7 +19,7 @@ use crate::{
         FilesStatusFlag, StatusFlags, StatusOutputLine, TuiLaunchOptions, TuiOutcome,
         TuiRunOptions,
         output::StatusOutputLineData,
-        tui::{copy_selection_picker::Clipboard, details::Details},
+        tui::{copy_selection_picker::Clipboard, details::Details, remember_selection},
     },
     theme::Theme,
     tui::TerminalGuard,
@@ -133,6 +133,7 @@ pub(super) fn changed_paths_affect_uncommitted_details<'a>(
 
 impl App {
     pub fn new(
+        ctx: &Context,
         status_lines: Vec<StatusOutputLine>,
         flags: StatusFlags,
         launch_options: TuiLaunchOptions,
@@ -145,6 +146,10 @@ impl App {
         let cursor = if let Some(object_id) = launch_options.select_commit {
             Cursor::select_commit(object_id, &status_lines)
                 .unwrap_or_else(|| Cursor::new(&status_lines))
+        } else if launch_options.remember_selection
+            && let Some(cursor) = remember_selection::restore_selection(ctx, &status_lines)
+        {
+            cursor
         } else {
             Cursor::new(&status_lines)
         };

--- a/crates/but/src/command/legacy/status/tui/app/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/app/mod.rs
@@ -1290,6 +1290,7 @@ impl App {
                 path,
                 id,
                 commit_id: _,
+                change_id: _,
             } => copy_selection_picker::committed_file_picker(
                 path.to_owned(),
                 id.to_owned(),

--- a/crates/but/src/command/legacy/status/tui/app/squash_mode.rs
+++ b/crates/but/src/command/legacy/status/tui/app/squash_mode.rs
@@ -377,11 +377,13 @@ impl App {
                 commit_id,
                 path,
                 id,
+                change_id,
             } => {
                 self.start_with_source(SquashSource::CommittedFile(CommittedFileId {
                     commit_id: *commit_id,
                     path: path.clone(),
                     id: id.clone(),
+                    change_id: change_id.clone(),
                 }));
             }
             CliId::PathPrefix { .. } | CliId::Stack { .. } => {}

--- a/crates/but/src/command/legacy/status/tui/cursor/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/cursor/mod.rs
@@ -711,16 +711,26 @@ pub(super) fn same_entity_for_reload(previous: &CliId, current: &CliId) -> bool 
             .eq(current.iter().map(|(_, assignment)| assignment)),
         (
             CliId::CommittedFile {
-                commit_id: previous_commit,
+                commit_id: previous_commit_id,
                 path: previous_path,
+                change_id: previous_change_id,
                 ..
             },
             CliId::CommittedFile {
-                commit_id: current_commit,
+                commit_id: current_commit_id,
                 path: current_path,
+                change_id: current_change_id,
                 ..
             },
-        ) => previous_commit == current_commit && previous_path == current_path,
+        ) => {
+            previous_path == current_path
+                && match (previous_change_id, current_change_id) {
+                    (Some(previous), Some(current)) => previous == current,
+                    (Some(_), None) | (None, Some(_)) | (None, None) => {
+                        previous_commit_id == current_commit_id
+                    }
+                }
+        }
         (CliId::Branch { name: previous, .. }, CliId::Branch { name: current, .. }) => {
             previous == current
         }

--- a/crates/but/src/command/legacy/status/tui/cursor/tests.rs
+++ b/crates/but/src/command/legacy/status/tui/cursor/tests.rs
@@ -62,6 +62,7 @@ fn committed_file_cli_id(hex: &str, path: &str, id: &str) -> Arc<CliId> {
         commit_id: commit_id(hex),
         path: path.into(),
         id: id.into(),
+        change_id: None,
     })
 }
 

--- a/crates/but/src/command/legacy/status/tui/details.rs
+++ b/crates/but/src/command/legacy/status/tui/details.rs
@@ -323,6 +323,7 @@ impl Details {
                 commit_id,
                 path,
                 id,
+                change_id: _,
             } => {
                 let commit = *commit_id;
                 let path = path.clone();

--- a/crates/but/src/command/legacy/status/tui/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/mod.rs
@@ -36,6 +36,7 @@ use crate::{
             help::HelpMessage,
             key_bind::{KeyBinds, fuzzy_picker_key_binds},
             mode::Mode,
+            remember_selection::save_selection_to_disk,
             toast::ToastKind,
         },
     },
@@ -65,6 +66,7 @@ mod message_on_drop;
 mod mode;
 mod operations;
 mod popup;
+mod remember_selection;
 mod render;
 mod toast;
 
@@ -93,6 +95,7 @@ pub fn render_tui(
 
     let head_sha = operations::head_sha(ctx)?;
     let mut app = App::new(
+        ctx,
         status_lines,
         flags,
         launch_options,
@@ -334,6 +337,10 @@ where
 
     if app.fps.update() {
         app.should_render = true;
+    }
+
+    if app.outcome.is_some() && app.launch_options.remember_selection {
+        _ = save_selection_to_disk(ctx, app);
     }
 
     Ok(())

--- a/crates/but/src/command/legacy/status/tui/remember_selection.rs
+++ b/crates/but/src/command/legacy/status/tui/remember_selection.rs
@@ -1,0 +1,93 @@
+use std::path::PathBuf;
+
+use but_ctx::Context;
+
+use crate::{
+    CliId,
+    command::legacy::status::{
+        StatusOutputLine,
+        tui::{app::App, cursor::Cursor},
+    },
+};
+
+pub fn restore_selection(ctx: &Context, lines: &[StatusOutputLine]) -> Option<Cursor> {
+    let cursor = (|| {
+        let Ok(selection) = load_saved_selection_from_disk(ctx) else {
+            return None;
+        };
+        let previous_selection = find_matching_line(&selection, lines)?;
+        let id = previous_selection.data.cli_id()?;
+        Cursor::restore(id, lines)
+    })();
+
+    if cursor.is_none() {
+        _ = remove_saved_selection_from_disk(ctx);
+    }
+
+    cursor
+}
+
+fn load_saved_selection_from_disk(ctx: &Context) -> std::io::Result<String> {
+    Ok(std::fs::read_to_string(path(ctx))?.to_owned())
+}
+
+fn remove_saved_selection_from_disk(ctx: &Context) -> std::io::Result<()> {
+    std::fs::remove_file(path(ctx))?;
+    Ok(())
+}
+
+pub fn save_selection_to_disk(ctx: &Context, app: &App) -> std::io::Result<()> {
+    let Some(selection) = app
+        .cursor
+        .selected_line(&app.status_lines)
+        .and_then(|s| s.data.cli_id())
+    else {
+        return Ok(());
+    };
+    let Some(id) = line_id(selection) else {
+        return Ok(());
+    };
+    std::fs::write(path(ctx), &*id)?;
+    Ok(())
+}
+
+fn find_matching_line<'a>(
+    selection: &str,
+    lines: &'a [StatusOutputLine],
+) -> Option<&'a StatusOutputLine> {
+    lines.iter().find(|line| {
+        line.data
+            .cli_id()
+            .and_then(|id| line_id(id))
+            .is_some_and(|id| id == selection)
+    })
+}
+
+fn path(ctx: &Context) -> PathBuf {
+    ctx.project_data_dir.join("tui-selection")
+}
+
+fn line_id(id: &CliId) -> Option<String> {
+    Some(match id {
+        CliId::UncommittedHunkOrFile(hunk) => format!("hunk:{}", hunk.hunk_assignments.head.path),
+        CliId::Branch { name, .. } => format!("branch:{name}"),
+        CliId::CommittedFile {
+            commit_id,
+            change_id,
+            ..
+        }
+        | CliId::Commit {
+            commit_id,
+            change_id,
+            ..
+        } => {
+            if let Some(change_id) = change_id {
+                format!("commit:{change_id}")
+            } else {
+                format!("commit:{commit_id}")
+            }
+        }
+        CliId::Uncommitted { id } => format!("uncommitted:{id}"),
+        CliId::PathPrefix { .. } | CliId::Stack { .. } => return None,
+    })
+}

--- a/crates/but/src/command/legacy/status/tui/tests/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/mod.rs
@@ -12,7 +12,7 @@ use crate::command::legacy::status::tui::tests::utils::{
     TestTuiOptions, test_tui, test_tui_with_options,
 };
 use crate::command::legacy::status::tui::{BackstackEntry, Message, ReloadCause};
-use crate::command::legacy::status::{TuiOutcome, TuiRunOptions};
+use crate::command::legacy::status::{TuiLaunchOptions, TuiOutcome, TuiRunOptions};
 
 mod branch_picker_tests;
 mod branch_tests;
@@ -1169,4 +1169,78 @@ fn maintains_selection_using_change_id() {
     // undo the reword, this shouldn't change the selection
     tui.input('u')
         .assert_current_line_eq(str!["┊●   1 (no commit message) (no changes)"]);
+}
+
+#[test]
+fn remember_selection() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
+
+    let launch_options = TuiLaunchOptions {
+        remember_selection: true,
+        ..Default::default()
+    };
+
+    let mut tui = test_tui_with_options(
+        env,
+        TestTuiOptions {
+            launch_options,
+            ..Default::default()
+        },
+    );
+
+    tui.input('j');
+    tui.input('j')
+        .assert_current_line_eq(str![["┊●   tpm add A"]]);
+    tui.input('q');
+
+    let env = tui.into_env();
+
+    let mut tui = test_tui_with_options(
+        env,
+        TestTuiOptions {
+            launch_options,
+            ..Default::default()
+        },
+    );
+
+    tui.reload()
+        .assert_current_line_eq(str![["┊●   tpm add A"]]);
+}
+
+#[test]
+fn remember_selection_with_file_name_conflicting_with_branch() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
+
+    env.file("A", "");
+
+    let launch_options = TuiLaunchOptions {
+        remember_selection: true,
+        ..Default::default()
+    };
+
+    let mut tui = test_tui_with_options(
+        env,
+        TestTuiOptions {
+            launch_options,
+            ..Default::default()
+        },
+    );
+
+    tui.input('j');
+    tui.input('j').assert_current_line_eq(str![["┊╭┄ g0 [A]"]]);
+    tui.input('q');
+
+    let env = tui.into_env();
+
+    let mut tui = test_tui_with_options(
+        env,
+        TestTuiOptions {
+            launch_options,
+            ..Default::default()
+        },
+    );
+
+    tui.reload().assert_current_line_eq(str![["┊╭┄ g0 [A]"]]);
 }

--- a/crates/but/src/command/legacy/status/tui/tests/utils.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/utils.rs
@@ -49,6 +49,7 @@ pub struct TestTuiOptions {
     pub height: u16,
     pub run_options: TuiRunOptions,
     pub show_file_browser: bool,
+    pub launch_options: TuiLaunchOptions,
 }
 
 impl Default for TestTuiOptions {
@@ -58,6 +59,7 @@ impl Default for TestTuiOptions {
             height: 20,
             run_options: Default::default(),
             show_file_browser: false,
+            launch_options: Default::default(),
         }
     }
 }
@@ -72,6 +74,7 @@ pub fn test_tui_with_options(env: Sandbox, options: TestTuiOptions) -> TestTui {
         height,
         run_options,
         show_file_browser,
+        launch_options,
     } = options;
 
     env.invoke_git("config user.name committer");
@@ -87,10 +90,6 @@ pub fn test_tui_with_options(env: Sandbox, options: TestTuiOptions) -> TestTui {
     let mut out = OutputChannel::new(OutputFormat::Human);
 
     let flags = StatusFlags::all_false();
-    let launch_options = TuiLaunchOptions {
-        debug: false,
-        ..Default::default()
-    };
 
     let mut guard = ctx.exclusive_worktree_access();
 
@@ -116,6 +115,7 @@ pub fn test_tui_with_options(env: Sandbox, options: TestTuiOptions) -> TestTui {
     let (clipboard, clipboard_text) = Clipboard::test();
 
     let app = App::new(
+        &ctx,
         lines,
         flags,
         launch_options,
@@ -222,6 +222,14 @@ impl TestTui {
         });
 
         TestTuiInputThenRenderResult(self)
+    }
+
+    pub fn into_env(mut self) -> Sandbox {
+        let env = self.env.take().expect(
+            "env already removed?! This shouldn't happen, only TestTui::recreate removes the env",
+        );
+        std::mem::forget(self);
+        env
     }
 
     #[track_caller]

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -394,6 +394,10 @@ impl<'a> Node<'a> for &'a WorkspaceCommitWithId {
                                 .unwrap_or(&self.short_id),
                             short_id
                         ),
+                        change_id: self
+                            .change_id
+                            .as_ref()
+                            .map(|change_id| change_id.change_id.clone()),
                     },
                 }));
             }
@@ -1494,6 +1498,8 @@ pub enum CliId {
         path: BString,
         /// The short CLI ID for this file (typically 2 characters)
         id: ShortId,
+        /// The stable change ID from the commit headers, if present.
+        change_id: Option<but_core::ChangeId>,
     },
     /// A branch.
     Branch {
@@ -1736,6 +1742,7 @@ pub struct CommittedFileId {
     pub commit_id: gix::ObjectId,
     pub path: BString,
     pub id: ShortId,
+    pub change_id: Option<ChangeId>,
 }
 
 impl CommittedFileId {
@@ -1744,6 +1751,7 @@ impl CommittedFileId {
             commit_id: self.commit_id,
             path: self.path.as_ref(),
             id: &self.id,
+            change_id: self.change_id.as_ref(),
         }
     }
 }
@@ -1759,6 +1767,7 @@ pub struct CommittedFileIdRef<'a> {
     pub commit_id: gix::ObjectId,
     pub path: &'a BStr,
     pub id: &'a str,
+    pub change_id: Option<&'a ChangeId>,
 }
 
 impl CommittedFileIdRef<'_> {
@@ -1767,6 +1776,7 @@ impl CommittedFileIdRef<'_> {
             commit_id: self.commit_id,
             path: self.path.to_owned(),
             id: self.id.to_owned(),
+            change_id: self.change_id.cloned(),
         }
     }
 }
@@ -1777,6 +1787,7 @@ impl PartialEq for CommittedFileIdRef<'_> {
             commit_id,
             path,
             id: _,
+            change_id: _,
         } = self;
         *commit_id == other.commit_id && path == &other.path
     }

--- a/crates/but/src/id/tests.rs
+++ b/crates/but/src/id/tests.rs
@@ -676,6 +676,7 @@ uncommitted_hunks: [ ln:q ]
         commit_id: Sha1(0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a),
         path: "committed.txt",
         id: "0:z",
+        change_id: None,
     },
 ]
 
@@ -1326,6 +1327,9 @@ fn committed_file_can_be_referenced_by_either_change_id_or_commit_id() {
         commit_id: Sha1(0101010101010101010101010101010101010101),
         path: "file.txt",
         id: "s:u",
+        change_id: Some(
+            "swstzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
+        ),
     },
 ]
 
@@ -1342,6 +1346,9 @@ fn committed_file_can_be_referenced_by_either_change_id_or_commit_id() {
         commit_id: Sha1(0101010101010101010101010101010101010101),
         path: "file.txt",
         id: "s:u",
+        change_id: Some(
+            "swstzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
+        ),
     },
 ]
 

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -885,6 +885,7 @@ async fn match_subcommand(
         }
         #[cfg(feature = "legacy")]
         Subcommands::Tui {
+            remember_selection,
             #[cfg(feature = "tui-profiling")]
             debug,
             #[cfg(feature = "tui-profiling")]
@@ -917,6 +918,7 @@ async fn match_subcommand(
             )?;
             #[cfg(feature = "tui-profiling")]
             let _options = TuiLaunchOptions {
+                remember_selection,
                 debug,
                 quit_after,
                 headless,
@@ -925,7 +927,10 @@ async fn match_subcommand(
                 select_commit,
             };
             #[cfg(not(feature = "tui-profiling"))]
-            let _options = TuiLaunchOptions::default();
+            let _options = TuiLaunchOptions {
+                remember_selection,
+                ..Default::default()
+            };
             command::legacy::status::worktree(
                 &mut ctx,
                 out,

--- a/crates/but/src/utils/diff_specs.rs
+++ b/crates/but/src/utils/diff_specs.rs
@@ -59,6 +59,7 @@ impl<'a> DiffSpecBuilder<'a> {
                 commit_id,
                 path,
                 id: _,
+                change_id: _,
             } => self.push_changes_from_committed_file(*commit_id, path.as_ref()),
             CliId::Branch { name, id, stack_id } => {
                 self.push_changes_from_branch(name, id, *stack_id)


### PR DESCRIPTION
So when the tui re-opens it restores the previous selection. Saves to `.git/gitbutler/tui-selection`.