### PR TITLE
Commit box update

### DIFF
--- a/apps/lite/ui/src/components/Kbd.module.css
+++ b/apps/lite/ui/src/components/Kbd.module.css
@@ -25,3 +25,16 @@
 	font-family: inherit;
 	white-space: nowrap;
 }
+
+.button .key {
+	padding: 0;
+	background-color: transparent;
+	box-shadow: none;
+	color: currentColor;
+	font-size: inherit;
+	opacity: 0.4;
+}
+
+.button {
+	gap: 0;
+}

--- a/apps/lite/ui/src/components/Kbd.tsx
+++ b/apps/lite/ui/src/components/Kbd.tsx
@@ -7,6 +7,7 @@ import type { FC } from "react";
 type Props = {
 	// We can't use the `Hotkey` type because it causes type errors in Storybook. 🤷‍♂️
 	hotkey: string | HotkeySequence;
+	variant?: "button";
 };
 
 const formatKeys = (hotkey: string | HotkeySequence): string =>
@@ -14,8 +15,8 @@ const formatKeys = (hotkey: string | HotkeySequence): string =>
 		? formatForDisplaySorted(hotkey)
 		: hotkey.map(formatForDisplaySorted).join(" ");
 
-export const Kbd: FC<Props> = ({ hotkey }) => (
-	<span className={classes(styles.keys, "text-semibold")}>
+export const Kbd: FC<Props> = ({ hotkey, variant }) => (
+	<span className={classes(styles.keys, variant === "button" && styles.button, "text-semibold")}>
 		{formatKeys(hotkey)
 			.split(" ")
 			.map((key, index) => (

--- a/apps/lite/ui/src/components/ui.module.css
+++ b/apps/lite/ui/src/components/ui.module.css
@@ -66,7 +66,7 @@
 		border-top: 1px solid var(--border-3);
 		content: "";
 		opacity: 0;
-		transition: opacity 120ms ease;
+		transition: opacity 50ms ease;
 
 		@container scroll-state(scrollable: top) {
 			opacity: 1;

--- a/apps/lite/ui/src/draft.ts
+++ b/apps/lite/ui/src/draft.ts
@@ -1,0 +1,21 @@
+import { queryOptions, useMutation } from "@tanstack/react-query";
+import * as idb from "idb-keyval";
+
+const draftCommitMessageKey = (projectId: string): string => `commit_message_draft:v1:${projectId}`;
+
+export const draftCommitMessageQueryOptions = (projectId: string) =>
+	queryOptions({
+		queryKey: ["commitMessageDraft", projectId],
+		queryFn: async () => (await idb.get<string>(draftCommitMessageKey(projectId))) ?? "",
+	});
+
+export const usePersistDraftCommitMessage = () =>
+	useMutation({
+		mutationFn: ({ projectId, message }: { projectId: string; message: string }) =>
+			idb.set(draftCommitMessageKey(projectId), message),
+		onSuccess: (_data, input, _res, ctx) =>
+			ctx.client.setQueryData(
+				draftCommitMessageQueryOptions(input.projectId).queryKey,
+				input.message,
+			),
+	});

--- a/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.module.css
@@ -1,3 +1,7 @@
+.startCommitButton {
+	flex-shrink: 0;
+}
+
 .form {
 	display: flex;
 	row-gap: 10px;
@@ -37,8 +41,13 @@
 
 .footer {
 	display: flex;
-	column-gap: 4px;
+	column-gap: 6px;
 	justify-content: space-between;
+}
+
+.commitActions {
+	display: flex;
+	column-gap: 4px;
 }
 
 .dropdownButton {

--- a/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.module.css
@@ -2,6 +2,11 @@
 	flex-shrink: 0;
 }
 
+.startCommitButtonExiting {
+	animation: commit-button-exit 80ms ease forwards;
+	pointer-events: none;
+}
+
 .form {
 	display: flex;
 	row-gap: 10px;
@@ -11,6 +16,7 @@
 	outline: 1px solid var(--border-2);
 	outline-offset: -1px;
 	background: var(--bg-1);
+	animation: commit-form-enter 100ms ease-out;
 
 	&:not(:has(.textarea[disabled])) {
 		&:hover {
@@ -19,6 +25,31 @@
 		&:focus-within {
 			outline: var(--focus-ring);
 		}
+	}
+}
+
+@keyframes commit-button-exit {
+	to {
+		opacity: 0.1;
+		transform: translateY(4px) ;
+	}
+}
+
+@keyframes commit-form-enter {
+	from {
+		opacity: 0.3;
+		transform: translateY(4px);
+	}
+}
+
+
+@media (prefers-reduced-motion: reduce) {
+	.form,
+	.footer {
+		animation: none;
+	}
+	.startCommitButtonExiting {
+		animation-duration: 0.01ms;
 	}
 }
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.module.css
@@ -2,11 +2,6 @@
 	flex-shrink: 0;
 }
 
-.startCommitButtonExiting {
-	animation: commit-button-exit 80ms ease forwards;
-	pointer-events: none;
-}
-
 .form {
 	display: flex;
 	row-gap: 10px;
@@ -16,7 +11,6 @@
 	outline: 1px solid var(--border-2);
 	outline-offset: -1px;
 	background: var(--bg-1);
-	animation: commit-form-enter 100ms ease-out;
 
 	&:not(:has(.textarea[disabled])) {
 		&:hover {
@@ -25,31 +19,6 @@
 		&:focus-within {
 			outline: var(--focus-ring);
 		}
-	}
-}
-
-@keyframes commit-button-exit {
-	to {
-		opacity: 0.1;
-		transform: translateY(4px) ;
-	}
-}
-
-@keyframes commit-form-enter {
-	from {
-		opacity: 0.3;
-		transform: translateY(4px);
-	}
-}
-
-
-@media (prefers-reduced-motion: reduce) {
-	.form,
-	.footer {
-		animation: none;
-	}
-	.startCommitButtonExiting {
-		animation-duration: 0.01ms;
 	}
 }
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
@@ -277,7 +277,7 @@ export const CommitForm: FC<{
 				readOnly={isCommitOrAmendPending}
 				placeholder={commitTextareaLabel}
 				defaultValue={draftMessage ?? ""}
-				className={classes("text-13", "text-body", styles.textarea)}
+				className={classes("text-13", "text-body", styles.textarea, uiStyles.overlayScrollbar)}
 			/>
 
 			<div className={styles.footer}>

--- a/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
@@ -84,17 +84,19 @@ export const CommitForm: FC<{
 		select: getHeadInfoIndex,
 	});
 	const isCommitOrAmendPending = isCommitCreatePending || isCommitAmendPending;
+
+	const [open, setOpen] = useState(false);
+	const [isExpanded, setIsExpanded] = useState(false);
+
 	const canCommitOrAmendBase = isDefaultMode && commitTarget !== null && !isCommitOrAmendPending;
-	const canCommit = canCommitOrAmendBase;
+	const canCommit = canCommitOrAmendBase && isExpanded;
 	const canAmend =
 		canCommitOrAmendBase &&
+		isExpanded &&
 		worktreeChanges &&
 		worktreeChanges.changes.length > 0 &&
 		headInfoIndex &&
 		resolveRelativeTo({ headInfoIndex, relativeTo: commitTarget.relativeTo }) !== null;
-
-	const [open, setOpen] = useState(false);
-	const [isExpanded, setIsExpanded] = useState(false);
 
 	const selectBranch = (option: CommitTargetComboboxItem | null) => {
 		if (option)
@@ -295,7 +297,9 @@ export const CommitForm: FC<{
 								setIsExpanded(false);
 								setOpen(false);
 							}}
-							render={<Button focusableWhenDisabled disabled={isCommitOrAmendPending} />}
+							render={
+								<Button focusableWhenDisabled disabled={isCommitOrAmendPending} type="button" />
+							}
 						>
 							Cancel
 						</Tooltip.Trigger>

--- a/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
@@ -191,12 +191,8 @@ export const CommitForm: FC<{
 			const form = formRef.current;
 			if (!form || !form.contains(document.activeElement)) return;
 
-			const isTextareaFocused = document.activeElement === commitTextareaRef.current;
-			const keepExpanded = isTextareaFocused && (commitTextareaRef.current?.value ?? "") !== "";
-			if (!keepExpanded) {
-				setIsExpanded(false);
-				setOpen(false);
-			}
+			setIsExpanded(false);
+			setOpen(false);
 			focusSelectionScope("uncommitted-files");
 		},
 		{

--- a/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
@@ -191,7 +191,10 @@ export const CommitForm: FC<{
 
 			const isTextareaFocused = document.activeElement === commitTextareaRef.current;
 			const keepExpanded = isTextareaFocused && (commitTextareaRef.current?.value ?? "") !== "";
-			if (!keepExpanded) setIsExpanded(false);
+			if (!keepExpanded) {
+				setIsExpanded(false);
+				setOpen(false);
+			}
 			focusSelectionScope("uncommitted-files");
 		},
 		{
@@ -288,7 +291,10 @@ export const CommitForm: FC<{
 					<Tooltip.Root>
 						<Tooltip.Trigger
 							className={getButtonClassName({ variant: "outline" })}
-							onClick={() => setIsExpanded(false)}
+							onClick={() => {
+								setIsExpanded(false);
+								setOpen(false);
+							}}
 							render={<Button focusableWhenDisabled disabled={isCommitOrAmendPending} />}
 						>
 							Cancel

--- a/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
@@ -254,9 +254,11 @@ export const CommitForm: FC<{
 		<form
 			ref={formRef}
 			onSubmit={submit}
-			onBlur={() =>
-				persistDraftMessage({ projectId, message: commitTextareaRef.current?.value ?? "" })
-			}
+			onBlur={(e) => {
+				const next = e.relatedTarget;
+				if (next instanceof Node && e.currentTarget.contains(next)) return;
+				persistDraftMessage({ projectId, message: commitTextareaRef.current?.value ?? "" });
+			}}
 			className={classes(styles.form, className)}
 		>
 			<textarea

--- a/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
@@ -7,6 +7,7 @@ import { classes } from "#ui/components/classes.ts";
 import { Icon } from "#ui/components/Icon.tsx";
 import { Kbd } from "#ui/components/Kbd.tsx";
 import { TooltipPopup } from "#ui/components/Tooltip.tsx";
+import { draftCommitMessageQueryOptions, usePersistDraftCommitMessage } from "#ui/draft.ts";
 import { changesHotkeys, outlineHotkeys, toElectronAccelerator } from "#ui/hotkeys.ts";
 import { nativeMenuItem, showNativeMenuFromTrigger, type NativeMenuItem } from "#ui/native-menu.ts";
 import { operandEquals, operandIdentityKey, type Operand } from "#ui/operands.ts";
@@ -16,8 +17,7 @@ import { useAppDispatch, useAppSelector } from "#ui/store.ts";
 import { Button, Combobox, Tooltip } from "@base-ui/react";
 import type { RelativeTo } from "@gitbutler/but-sdk";
 import { useHotkey, useHotkeys } from "@tanstack/react-hotkeys";
-import { queryOptions, useMutation, useQuery } from "@tanstack/react-query";
-import * as idb from "idb-keyval";
+import { useQuery } from "@tanstack/react-query";
 import { type FC, type SubmitEventHandler, useRef, useState } from "react";
 import styles from "./CommitForm.module.css";
 
@@ -26,25 +26,6 @@ export type CommitTargetComboboxItem = {
 	operand: Extract<Operand, { _tag: "Branch" | "Commit" }>;
 	relativeTo: RelativeTo;
 };
-
-const draftCommitMessageKey = (projectId: string): string => `commit_message_draft:v1:${projectId}`;
-
-const draftCommitMessageQueryOptions = (projectId: string) =>
-	queryOptions({
-		queryKey: ["commitMessageDraft", projectId],
-		queryFn: async () => (await idb.get<string>(draftCommitMessageKey(projectId))) ?? "",
-	});
-
-const usePersistDraftCommitMessage = () =>
-	useMutation({
-		mutationFn: ({ projectId, message }: { projectId: string; message: string }) =>
-			idb.set(draftCommitMessageKey(projectId), message),
-		onSuccess: (_data, input, _res, ctx) =>
-			ctx.client.setQueryData(
-				draftCommitMessageQueryOptions(input.projectId).queryKey,
-				input.message,
-			),
-	});
 
 const CommitTargetComboboxPopup: FC = () => (
 	<Combobox.Popup className={classes(uiStyles.popup, "text-13", styles.targetPopup)}>

--- a/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
@@ -5,13 +5,9 @@ import { getHeadInfoIndex, resolveRelativeTo } from "#ui/api/ref-info.ts";
 import { getButtonClassName } from "#ui/components/Button.tsx";
 import { classes } from "#ui/components/classes.ts";
 import { Icon } from "#ui/components/Icon.tsx";
+import { Kbd } from "#ui/components/Kbd.tsx";
 import { TooltipPopup } from "#ui/components/Tooltip.tsx";
-import {
-	changesHotkeys,
-	formatForDisplaySorted,
-	outlineHotkeys,
-	toElectronAccelerator,
-} from "#ui/hotkeys.ts";
+import { changesHotkeys, outlineHotkeys, toElectronAccelerator } from "#ui/hotkeys.ts";
 import { nativeMenuItem, showNativeMenuFromTrigger, type NativeMenuItem } from "#ui/native-menu.ts";
 import { operandEquals, operandIdentityKey, type Operand } from "#ui/operands.ts";
 import { projectSlice } from "#ui/projects/state.ts";
@@ -204,34 +200,24 @@ export const CommitForm: FC<{
 		},
 	);
 
-	const commitTextareaLabel = `Compose commit message ${formatForDisplaySorted(
-		outlineHotkeys.composeCommitMessage.hotkey,
-	)}`;
+	const commitTextareaLabel = "Compose commit message";
 
 	if (!isExpanded) {
 		return (
-			<Tooltip.Root>
-				<Tooltip.Trigger
-					className={classes(
-						getButtonClassName({ variant: "pop" }),
-						styles.startCommitButton,
-						className,
-					)}
-					onClick={() => setIsExpanded(true)}
-					render={<Button focusableWhenDisabled disabled={!isDefaultMode} />}
-				>
-					Start commit
-				</Tooltip.Trigger>
-				<Tooltip.Portal>
-					<Tooltip.Positioner sideOffset={4}>
-						<Tooltip.Popup
-							render={<TooltipPopup kbd={outlineHotkeys.composeCommitMessage.hotkey} />}
-						>
-							Compose commit message
-						</Tooltip.Popup>
-					</Tooltip.Positioner>
-				</Tooltip.Portal>
-			</Tooltip.Root>
+			<Button
+				className={classes(
+					getButtonClassName({ variant: "pop" }),
+					styles.startCommitButton,
+					className,
+				)}
+				id={startCommitButtonId}
+				onClick={() => setIsExpanded(true)}
+				focusableWhenDisabled
+				disabled={!isDefaultMode}
+			>
+				Start commit
+				<Kbd hotkey={outlineHotkeys.composeCommitMessage.hotkey} variant="button" />
+			</Button>
 		);
 	}
 
@@ -315,23 +301,15 @@ export const CommitForm: FC<{
 					</Tooltip.Root>
 
 					<div className={styles.dropdownButton}>
-						<Tooltip.Root>
-							<Tooltip.Trigger
-								className={getButtonClassName({ variant: "pop" })}
-								// We pass `disabled` here because we want to disable the button, not
-								// the tooltip. Other props should be passed above.
-								render={<Button focusableWhenDisabled type="submit" disabled={!canCommit} />}
-							>
-								Commit
-							</Tooltip.Trigger>
-							<Tooltip.Portal>
-								<Tooltip.Positioner sideOffset={4}>
-									<Tooltip.Popup render={<TooltipPopup kbd={changesHotkeys.commit.hotkey} />}>
-										{changesHotkeys.commit.meta.name}
-									</Tooltip.Popup>
-								</Tooltip.Positioner>
-							</Tooltip.Portal>
-						</Tooltip.Root>
+						<Button
+							className={getButtonClassName({ variant: "pop" })}
+							focusableWhenDisabled
+							type="submit"
+							disabled={!canCommit}
+						>
+							Commit
+							<Kbd hotkey={changesHotkeys.commit.hotkey} variant="button" />
+						</Button>
 						<div aria-hidden className={styles.dropdownButtonSeparator} />
 						<Button
 							focusableWhenDisabled

--- a/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
@@ -96,10 +96,9 @@ export const CommitForm: FC<{
 	const [isExpanded, setIsExpanded] = useState(false);
 
 	const canCommitOrAmendBase = isDefaultMode && commitTarget !== null && !isCommitOrAmendPending;
-	const canCommit = canCommitOrAmendBase && isExpanded;
+	const canCommit = canCommitOrAmendBase;
 	const canAmend =
 		canCommitOrAmendBase &&
-		isExpanded &&
 		worktreeChanges &&
 		worktreeChanges.changes.length > 0 &&
 		headInfoIndex &&
@@ -116,15 +115,16 @@ export const CommitForm: FC<{
 
 		commitCreate(
 			{
-				message: commitTextareaRef.current?.value ?? "",
+				message: commitTextareaRef.current?.value ?? draftMessage ?? "",
 				relativeTo: commitTarget.relativeTo,
 			},
 			{
 				onSuccess: (response) => {
-					if (response.newCommit !== null && commitTextareaRef.current) {
-						commitTextareaRef.current.value = "";
-						persistDraftMessage({ projectId, message: "" });
-					}
+					if (response.newCommit === null) return;
+
+					if (commitTextareaRef.current) commitTextareaRef.current.value = "";
+
+					persistDraftMessage({ projectId, message: "" });
 				},
 			},
 		);

--- a/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
@@ -265,7 +265,11 @@ export const CommitForm: FC<{
 				// oxlint-disable-next-line jsx_a11y/no-autofocus
 				autoFocus
 				id={commitMessageInputId}
-				ref={commitTextareaRef}
+				ref={(el) => {
+					commitTextareaRef.current = el;
+					// Place the caret at the end of the restored draft message.
+					el?.setSelectionRange(el.value.length, el.value.length);
+				}}
 				aria-label={commitTextareaLabel}
 				disabled={!isDefaultMode}
 				readOnly={isCommitOrAmendPending}

--- a/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
@@ -333,6 +333,7 @@ export const CommitForm: FC<{
 								});
 								setIsExpanded(false);
 								setOpen(false);
+								focusSelectionScope("uncommitted-files");
 							}}
 							render={
 								<Button focusableWhenDisabled disabled={isCommitOrAmendPending} type="button" />

--- a/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
@@ -27,12 +27,6 @@ export type CommitTargetComboboxItem = {
 	relativeTo: RelativeTo;
 };
 
-// oxlint-disable-next-line react/only-export-components -- TODO: move
-export const commitMessageInputId = "commit-message-input";
-
-// oxlint-disable-next-line react/only-export-components -- TODO: move
-export const startCommitButtonId = "start-commit-button";
-
 const draftCommitMessageKey = (projectId: string): string => `commit_message_draft:v1:${projectId}`;
 
 const draftCommitMessageQueryOptions = (projectId: string) =>
@@ -80,8 +74,17 @@ export const CommitForm: FC<{
 	projectId: string;
 	commitTarget: CommitTargetComboboxItem | null;
 	targetComboboxItems: Array<CommitTargetComboboxItem>;
+	startCommitButtonId: string;
+	commitMessageInputId: string;
 	className?: string;
-}> = ({ projectId, commitTarget, targetComboboxItems, className }) => {
+}> = ({
+	projectId,
+	commitTarget,
+	targetComboboxItems,
+	startCommitButtonId,
+	commitMessageInputId,
+	className,
+}) => {
 	const dispatch = useAppDispatch();
 	const { isPending: isCommitCreatePending, mutate: commitCreate } = useCommitCreate({
 		projectId,

--- a/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
@@ -99,7 +99,6 @@ export const CommitForm: FC<{
 
 	const [open, setOpen] = useState(false);
 	const [isExpanded, setIsExpanded] = useState(false);
-	const [isButtonExiting, setIsButtonExiting] = useState(false);
 
 	const selectBranch = (option: CommitTargetComboboxItem | null) => {
 		if (option)
@@ -216,16 +215,9 @@ export const CommitForm: FC<{
 					className={classes(
 						getButtonClassName({ variant: "pop" }),
 						styles.startCommitButton,
-						isButtonExiting && styles.startCommitButtonExiting,
 						className,
 					)}
-					onClick={() => setIsButtonExiting(true)}
-					onAnimationEnd={() => {
-						if (!isButtonExiting) return;
-
-						setIsButtonExiting(false);
-						setIsExpanded(true);
-					}}
+					onClick={() => setIsExpanded(true)}
 					render={<Button focusableWhenDisabled disabled={!isDefaultMode} />}
 				>
 					Start commit

--- a/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
@@ -77,6 +77,7 @@ export const CommitForm: FC<{
 	const { data: worktreeChanges } = useQuery(changesInWorktreeQueryOptions(projectId));
 
 	const commitTextareaRef = useRef<HTMLTextAreaElement | null>(null);
+	const formRef = useRef<HTMLFormElement | null>(null);
 
 	const isDefaultMode = useAppSelector(
 		(state) => projectSlice.selectors.selectOutlineModeState(state, projectId)._tag === "Default",
@@ -98,6 +99,7 @@ export const CommitForm: FC<{
 
 	const [open, setOpen] = useState(false);
 	const [isExpanded, setIsExpanded] = useState(false);
+	const [isButtonExiting, setIsButtonExiting] = useState(false);
 
 	const selectBranch = (option: CommitTargetComboboxItem | null) => {
 		if (option)
@@ -183,15 +185,23 @@ export const CommitForm: FC<{
 		},
 	]);
 
+	// Note we deliberately don't scope this hotkey with `target` refs. The form
+	// is conditionally rendered, so the refs are `null` on mount, and the hook
+	// would never register the listener.
 	useHotkey(
 		"Escape",
 		() => {
-			if ((commitTextareaRef.current?.value ?? "") === "") setIsExpanded(false);
+			const form = formRef.current;
+			if (!form || !form.contains(document.activeElement)) return;
+
+			const isTextareaFocused = document.activeElement === commitTextareaRef.current;
+			const keepExpanded = isTextareaFocused && (commitTextareaRef.current?.value ?? "") !== "";
+			if (!keepExpanded) setIsExpanded(false);
 			focusSelectionScope("uncommitted-files");
 		},
 		{
-			target: commitTextareaRef,
 			conflictBehavior: "allow",
+			enabled: isExpanded,
 		},
 	);
 
@@ -201,23 +211,40 @@ export const CommitForm: FC<{
 
 	if (!isExpanded) {
 		return (
-			<Button
-				id={startCommitButtonId}
-				disabled={!isDefaultMode}
-				className={classes(
-					getButtonClassName({ variant: "pop" }),
-					styles.startCommitButton,
-					className,
-				)}
-				onClick={() => setIsExpanded(true)}
-			>
-				Start commit
-			</Button>
+			<Tooltip.Root>
+				<Tooltip.Trigger
+					className={classes(
+						getButtonClassName({ variant: "pop" }),
+						styles.startCommitButton,
+						isButtonExiting && styles.startCommitButtonExiting,
+						className,
+					)}
+					onClick={() => setIsButtonExiting(true)}
+					onAnimationEnd={() => {
+						if (!isButtonExiting) return;
+
+						setIsButtonExiting(false);
+						setIsExpanded(true);
+					}}
+					render={<Button focusableWhenDisabled disabled={!isDefaultMode} />}
+				>
+					Start commit
+				</Tooltip.Trigger>
+				<Tooltip.Portal>
+					<Tooltip.Positioner sideOffset={4}>
+						<Tooltip.Popup
+							render={<TooltipPopup kbd={outlineHotkeys.composeCommitMessage.hotkey} />}
+						>
+							Compose commit message
+						</Tooltip.Popup>
+					</Tooltip.Positioner>
+				</Tooltip.Portal>
+			</Tooltip.Root>
 		);
 	}
 
 	return (
-		<form onSubmit={submit} className={classes(styles.form, className)}>
+		<form ref={formRef} onSubmit={submit} className={classes(styles.form, className)}>
 			<textarea
 				// The form is only rendered expanded after interacting with the
 				// "Start commit" trigger, so focusing the input is expected.
@@ -280,14 +307,20 @@ export const CommitForm: FC<{
 				</Combobox.Root>
 
 				<div className={styles.commitActions}>
-					<Button
-						focusableWhenDisabled
-						disabled={isCommitOrAmendPending}
-						className={getButtonClassName({ variant: "outline" })}
-						onClick={() => setIsExpanded(false)}
-					>
-						Cancel
-					</Button>
+					<Tooltip.Root>
+						<Tooltip.Trigger
+							className={getButtonClassName({ variant: "outline" })}
+							onClick={() => setIsExpanded(false)}
+							render={<Button focusableWhenDisabled disabled={isCommitOrAmendPending} />}
+						>
+							Cancel
+						</Tooltip.Trigger>
+						<Tooltip.Portal>
+							<Tooltip.Positioner sideOffset={4}>
+								<Tooltip.Popup render={<TooltipPopup kbd="Escape" />}>Cancel</Tooltip.Popup>
+							</Tooltip.Positioner>
+						</Tooltip.Portal>
+					</Tooltip.Root>
 
 					<div className={styles.dropdownButton}>
 						<Tooltip.Root>

--- a/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
@@ -16,7 +16,8 @@ import { useAppDispatch, useAppSelector } from "#ui/store.ts";
 import { Button, Combobox, Tooltip } from "@base-ui/react";
 import type { RelativeTo } from "@gitbutler/but-sdk";
 import { useHotkey, useHotkeys } from "@tanstack/react-hotkeys";
-import { useQuery } from "@tanstack/react-query";
+import { queryOptions, useMutation, useQuery } from "@tanstack/react-query";
+import * as idb from "idb-keyval";
 import { type FC, type SubmitEventHandler, useRef, useState } from "react";
 import styles from "./CommitForm.module.css";
 
@@ -31,6 +32,25 @@ export const commitMessageInputId = "commit-message-input";
 
 // oxlint-disable-next-line react/only-export-components -- TODO: move
 export const startCommitButtonId = "start-commit-button";
+
+const draftCommitMessageKey = (projectId: string): string => `commit_message_draft:v1:${projectId}`;
+
+const draftCommitMessageQueryOptions = (projectId: string) =>
+	queryOptions({
+		queryKey: ["commitMessageDraft", projectId],
+		queryFn: async () => (await idb.get<string>(draftCommitMessageKey(projectId))) ?? "",
+	});
+
+const usePersistDraftCommitMessage = () =>
+	useMutation({
+		mutationFn: ({ projectId, message }: { projectId: string; message: string }) =>
+			idb.set(draftCommitMessageKey(projectId), message),
+		onSuccess: (_data, input, _res, ctx) =>
+			ctx.client.setQueryData(
+				draftCommitMessageQueryOptions(input.projectId).queryKey,
+				input.message,
+			),
+	});
 
 const CommitTargetComboboxPopup: FC = () => (
 	<Combobox.Popup className={classes(uiStyles.popup, "text-13", styles.targetPopup)}>
@@ -75,6 +95,9 @@ export const CommitForm: FC<{
 	const commitTextareaRef = useRef<HTMLTextAreaElement | null>(null);
 	const formRef = useRef<HTMLFormElement | null>(null);
 
+	const { data: draftMessage } = useQuery(draftCommitMessageQueryOptions(projectId));
+	const { mutate: persistDraftMessage } = usePersistDraftCommitMessage();
+
 	const isDefaultMode = useAppSelector(
 		(state) => projectSlice.selectors.selectOutlineModeState(state, projectId)._tag === "Default",
 	);
@@ -114,8 +137,10 @@ export const CommitForm: FC<{
 			},
 			{
 				onSuccess: (response) => {
-					if (response.newCommit !== null && commitTextareaRef.current)
+					if (response.newCommit !== null && commitTextareaRef.current) {
 						commitTextareaRef.current.value = "";
+						persistDraftMessage({ projectId, message: "" });
+					}
 				},
 			},
 		);
@@ -191,6 +216,8 @@ export const CommitForm: FC<{
 			const form = formRef.current;
 			if (!form || !form.contains(document.activeElement)) return;
 
+			// Persist the draft before the textarea unmounts.
+			persistDraftMessage({ projectId, message: commitTextareaRef.current?.value ?? "" });
 			setIsExpanded(false);
 			setOpen(false);
 			focusSelectionScope("uncommitted-files");
@@ -223,7 +250,15 @@ export const CommitForm: FC<{
 	}
 
 	return (
-		<form ref={formRef} onSubmit={submit} className={classes(styles.form, className)}>
+		// oxlint-disable-next-line jsx-a11y/no-noninteractive-element-interactions -- Used for persistence, not UI per se.
+		<form
+			ref={formRef}
+			onSubmit={submit}
+			onBlur={() =>
+				persistDraftMessage({ projectId, message: commitTextareaRef.current?.value ?? "" })
+			}
+			className={classes(styles.form, className)}
+		>
 			<textarea
 				// The form is only rendered expanded after interacting with the
 				// "Start commit" trigger, so focusing the input is expected.
@@ -235,6 +270,7 @@ export const CommitForm: FC<{
 				disabled={!isDefaultMode}
 				readOnly={isCommitOrAmendPending}
 				placeholder={commitTextareaLabel}
+				defaultValue={draftMessage ?? ""}
 				className={classes("text-13", "text-body", styles.textarea)}
 			/>
 
@@ -290,6 +326,11 @@ export const CommitForm: FC<{
 						<Tooltip.Trigger
 							className={getButtonClassName({ variant: "outline" })}
 							onClick={() => {
+								// Persist the draft before the textarea unmounts.
+								persistDraftMessage({
+									projectId,
+									message: commitTextareaRef.current?.value ?? "",
+								});
 								setIsExpanded(false);
 								setOpen(false);
 							}}

--- a/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
@@ -33,6 +33,9 @@ export type CommitTargetComboboxItem = {
 // oxlint-disable-next-line react/only-export-components -- TODO: move
 export const commitMessageInputId = "commit-message-input";
 
+// oxlint-disable-next-line react/only-export-components -- TODO: move
+export const startCommitButtonId = "start-commit-button";
+
 const CommitTargetComboboxPopup: FC = () => (
 	<Combobox.Popup className={classes(uiStyles.popup, "text-13", styles.targetPopup)}>
 		<Combobox.Input
@@ -94,6 +97,7 @@ export const CommitForm: FC<{
 		resolveRelativeTo({ headInfoIndex, relativeTo: commitTarget.relativeTo }) !== null;
 
 	const [open, setOpen] = useState(false);
+	const [isExpanded, setIsExpanded] = useState(false);
 
 	const selectBranch = (option: CommitTargetComboboxItem | null) => {
 		if (option)
@@ -179,18 +183,46 @@ export const CommitForm: FC<{
 		},
 	]);
 
-	useHotkey("Escape", () => focusSelectionScope("uncommitted-files"), {
-		target: commitTextareaRef,
-		conflictBehavior: "allow",
-	});
+	useHotkey(
+		"Escape",
+		() => {
+			if ((commitTextareaRef.current?.value ?? "") === "") setIsExpanded(false);
+			focusSelectionScope("uncommitted-files");
+		},
+		{
+			target: commitTextareaRef,
+			conflictBehavior: "allow",
+		},
+	);
 
 	const commitTextareaLabel = `Compose commit message ${formatForDisplaySorted(
 		outlineHotkeys.composeCommitMessage.hotkey,
 	)}`;
 
+	if (!isExpanded) {
+		return (
+			<Button
+				id={startCommitButtonId}
+				disabled={!isDefaultMode}
+				className={classes(
+					getButtonClassName({ variant: "pop" }),
+					styles.startCommitButton,
+					className,
+				)}
+				onClick={() => setIsExpanded(true)}
+			>
+				Start commit
+			</Button>
+		);
+	}
+
 	return (
 		<form onSubmit={submit} className={classes(styles.form, className)}>
 			<textarea
+				// The form is only rendered expanded after interacting with the
+				// "Start commit" trigger, so focusing the input is expected.
+				// oxlint-disable-next-line jsx_a11y/no-autofocus
+				autoFocus
 				id={commitMessageInputId}
 				ref={commitTextareaRef}
 				aria-label={commitTextareaLabel}
@@ -247,36 +279,47 @@ export const CommitForm: FC<{
 					</Combobox.Portal>
 				</Combobox.Root>
 
-				<div className={styles.dropdownButton}>
-					<Tooltip.Root>
-						<Tooltip.Trigger
-							className={getButtonClassName({ variant: "pop" })}
-							// We pass `disabled` here because we want to disable the button, not
-							// the tooltip. Other props should be passed above.
-							render={<Button focusableWhenDisabled type="submit" disabled={!canCommit} />}
-						>
-							Commit
-						</Tooltip.Trigger>
-						<Tooltip.Portal>
-							<Tooltip.Positioner sideOffset={4}>
-								<Tooltip.Popup render={<TooltipPopup kbd={changesHotkeys.commit.hotkey} />}>
-									{changesHotkeys.commit.meta.name}
-								</Tooltip.Popup>
-							</Tooltip.Positioner>
-						</Tooltip.Portal>
-					</Tooltip.Root>
-					<div aria-hidden className={styles.dropdownButtonSeparator} />
+				<div className={styles.commitActions}>
 					<Button
 						focusableWhenDisabled
-						disabled={!(canAmend || canCommit)}
-						aria-label="Commit options"
-						className={getButtonClassName({ variant: "pop", iconOnly: true })}
-						onClick={(event) => {
-							void showNativeMenuFromTrigger(event.currentTarget, commitMenuItems);
-						}}
+						disabled={isCommitOrAmendPending}
+						className={getButtonClassName({ variant: "outline" })}
+						onClick={() => setIsExpanded(false)}
 					>
-						<Icon name="chevron-down" />
+						Cancel
 					</Button>
+
+					<div className={styles.dropdownButton}>
+						<Tooltip.Root>
+							<Tooltip.Trigger
+								className={getButtonClassName({ variant: "pop" })}
+								// We pass `disabled` here because we want to disable the button, not
+								// the tooltip. Other props should be passed above.
+								render={<Button focusableWhenDisabled type="submit" disabled={!canCommit} />}
+							>
+								Commit
+							</Tooltip.Trigger>
+							<Tooltip.Portal>
+								<Tooltip.Positioner sideOffset={4}>
+									<Tooltip.Popup render={<TooltipPopup kbd={changesHotkeys.commit.hotkey} />}>
+										{changesHotkeys.commit.meta.name}
+									</Tooltip.Popup>
+								</Tooltip.Positioner>
+							</Tooltip.Portal>
+						</Tooltip.Root>
+						<div aria-hidden className={styles.dropdownButtonSeparator} />
+						<Button
+							focusableWhenDisabled
+							disabled={!(canAmend || canCommit)}
+							aria-label="Commit options"
+							className={getButtonClassName({ variant: "pop", iconOnly: true })}
+							onClick={(event) => {
+								void showNativeMenuFromTrigger(event.currentTarget, commitMenuItems);
+							}}
+						>
+							<Icon name="chevron-down" />
+						</Button>
+					</div>
 				</div>
 			</div>
 		</form>

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
@@ -280,6 +280,8 @@ const UncommittedChanges: FC<{
 				projectId={projectId}
 				commitTarget={commitTarget}
 				targetComboboxItems={targetComboboxItems}
+				startCommitButtonId={startCommitButtonId}
+				commitMessageInputId={commitMessageInputId}
 				className={styles.commitForm}
 			/>
 		</div>
@@ -522,6 +524,17 @@ const StackC: FC<{
 	);
 };
 
+const startCommitButtonId = "start-commit-button";
+const commitMessageInputId = "commit-message-input";
+
+const focusCommitMessageInput = () => {
+	const input = document.getElementById(commitMessageInputId);
+	if (input) input.focus();
+	// The commit form may be collapsed; clicking the trigger expands it and
+	// focuses the message input.
+	else document.getElementById(startCommitButtonId)?.click();
+};
+
 const Stacks: FC<{
 	projectId: string;
 	checkCommit: (evt: { commitId: string; shiftKey: boolean }) => void;
@@ -571,6 +584,7 @@ const Stacks: FC<{
 		projectId,
 		ref: hotkeysRef,
 		checkCommit,
+		focusCommitMessageInput,
 	});
 
 	return (

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/hotkeys.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/hotkeys.ts
@@ -31,7 +31,7 @@ import { type UseHotkeyDefinition, useHotkeys } from "@tanstack/react-hotkeys";
 import { useQuery } from "@tanstack/react-query";
 import { Match } from "effect";
 import type { RefObject } from "react";
-import { commitMessageInputId } from "../CommitForm.tsx";
+import { commitMessageInputId, startCommitButtonId } from "../CommitForm.tsx";
 import { selectAfterDiscardedCommit } from "./selectAfterDiscardedCommit.ts";
 import { downstackPushStatusDisabled, downstackPushStatusFromSegments } from "#ui/segment.ts";
 
@@ -59,7 +59,11 @@ const pushContextForSegment = ({
 };
 
 const focusCommitMessageInput = () => {
-	document.getElementById(commitMessageInputId)?.focus();
+	const input = document.getElementById(commitMessageInputId);
+	if (input) input.focus();
+	// The commit form may be collapsed; clicking the trigger expands it and
+	// focuses the message input.
+	else document.getElementById(startCommitButtonId)?.click();
 };
 
 export const useOutlineTreeHotkeys = ({

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/hotkeys.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/hotkeys.ts
@@ -31,7 +31,6 @@ import { type UseHotkeyDefinition, useHotkeys } from "@tanstack/react-hotkeys";
 import { useQuery } from "@tanstack/react-query";
 import { Match } from "effect";
 import type { RefObject } from "react";
-import { commitMessageInputId, startCommitButtonId } from "../CommitForm.tsx";
 import { selectAfterDiscardedCommit } from "./selectAfterDiscardedCommit.ts";
 import { downstackPushStatusDisabled, downstackPushStatusFromSegments } from "#ui/segment.ts";
 
@@ -58,24 +57,18 @@ const pushContextForSegment = ({
 	};
 };
 
-const focusCommitMessageInput = () => {
-	const input = document.getElementById(commitMessageInputId);
-	if (input) input.focus();
-	// The commit form may be collapsed; clicking the trigger expands it and
-	// focuses the message input.
-	else document.getElementById(startCommitButtonId)?.click();
-};
-
 export const useOutlineTreeHotkeys = ({
 	navigationIndex,
 	projectId,
 	ref,
 	checkCommit,
+	focusCommitMessageInput,
 }: {
 	navigationIndex: NavigationIndex<Operand>;
 	projectId: string;
 	ref: RefObject<HTMLElement | null>;
 	checkCommit: (evt: { commitId: string; shiftKey: boolean }) => void;
+	focusCommitMessageInput: () => void;
 }) => {
 	const { data: headInfoIndex } = useQuery({
 		...headInfoQueryOptions(projectId),
@@ -400,9 +393,7 @@ export const useOutlineTreeHotkeys = ({
 		},
 		{
 			hotkey: outlineHotkeys.composeCommitMessage.hotkey,
-			callback: () => {
-				focusCommitMessageInput();
-			},
+			callback: focusCommitMessageInput,
 			options: {
 				conflictBehavior: "allow",
 			},


### PR DESCRIPTION
## Commit box update

Redesigns the commit form in the Lite app to support a collapsed/expanded state, improving the UX for starting a commit.

### Changes

**Collapsed "Start commit" entry point**

* The commit form now renders as a collapsed "Start commit" button when the form is not in use
* Clicking the trigger expands the full form with a message textarea, commit target selector, and Cancel/Commit actions
* Escape and Cancel both collapse the form and reset the commit-target combobox state
* `canCommit`/`canAmend` are gated on the expanded state so the commit hotkey can't fire while collapsed

**Draft message persistence**

* The commit message draft is persisted in IndexedDB (`idb-keyval`), scoped per project, following the same pattern as draft PRs
* The draft is saved on form blur, Cancel, and Escape, restored when the form re-expands, and cleared after a successful commit
* The caret is placed at the end of the restored draft message

**Hotkey integration**

* The existing commit message focus hotkey now also works when the form is collapsed — it clicks the "Start commit" trigger to expand and focus the input automatically
* Hotkey hints are displayed inline in the Cancel and Commit buttons using a new `Kbd` variant

`Kbd` **component update**

* Added a `variant="button"` prop to `Kbd` for rendering keyboard shortcuts inline inside buttons without background/shadow styling

**Minor CSS tweaks**

* Reduced the scroll-indicator fade transition from `120ms` to `50ms` for snappier feel
* Updated footer `column-gap` from `4px` to `6px`
* Added `.commitActions` flex container for the footer action buttons

### Demo

https://github.com/user-attachments/assets/e4316eaa-5b0c-482c-886a-faa730486004