### PR TITLE
Get safe_checkout ready for worktree support

### DIFF
--- a/crates/but-core/src/worktree/checkout/function.rs
+++ b/crates/but-core/src/worktree/checkout/function.rs
@@ -11,7 +11,10 @@ use tracing::instrument;
 
 use crate::update_head_reference;
 
-use super::{Options, Outcome, utils::merge_worktree_changes_into_destination_or_keep_snapshot};
+use super::{
+    Options, Outcome, PreparedCheckout,
+    utils::merge_worktree_changes_into_destination_or_keep_snapshot,
+};
 
 /// Perform all file operations necessary to turn the *worktree* of `repo` into
 /// `new_head_id^{tree}`.
@@ -28,8 +31,20 @@ use super::{Options, Outcome, utils::merge_worktree_changes_into_destination_or_
 /// To keep it simpler, we don't do rename tracking, so deletions and additions are always treated separately.
 /// If this changes, then the source sid of a rename could also cause conflicts, maybe? It's a bit unclear what it would mean
 /// in practice, but I guess that we bring deleted files back instead of conflicting.
-#[instrument(skip(repo), err(Debug))]
 pub fn safe_checkout_from_head(
+    new_head_id: gix::ObjectId,
+    repo: &gix::Repository,
+    options: Options,
+) -> anyhow::Result<Outcome> {
+    prepare_safe_checkout_from_head(new_head_id, repo, options)?.execute()
+}
+
+/// Resolve checkout conflicts without changing the worktree, index, or refs.
+///
+/// The returned operation retains the repository's current `HEAD` tree so it can still be executed
+/// after a shared reference transaction moves a linked worktree's symbolic `HEAD`.
+#[instrument(skip(repo), err(Debug))]
+pub fn prepare_safe_checkout_from_head(
     new_head_id: gix::ObjectId,
     repo: &gix::Repository,
     Options {
@@ -37,7 +52,7 @@ pub fn safe_checkout_from_head(
         merge_base_override,
         allow_conflicted_commit_checkout,
     }: Options,
-) -> anyhow::Result<Outcome> {
+) -> anyhow::Result<PreparedCheckout<'_>> {
     let current_head_id = repo.head_tree_id_or_empty()?.detach();
     let source_tree = current_head_id.attach(repo).object()?.peel_to_tree()?;
     let new_object = new_head_id.attach(repo).object()?;
@@ -75,118 +90,152 @@ pub fn safe_checkout_from_head(
         snapshot_id
     });
 
-    let num_deleted_files = changed_files
-        .iter()
-        .filter(|(kind, _)| matches!(kind, ChangeKind::Deletion))
-        .count();
-    // Finally, perform the actual checkout
-    // TODO(gix): use unconditional `gix` checkout implementation as pre-cursor to the real deal (not needed here).
-    //            All it has to do is to be able to apply the target changes to any working tree, while using filters,
-    //            and while doing it symlink-safe.
-    if !changed_files.is_empty() {
-        let git2_repo = git2::Repository::open(repo.git_dir())?;
-        let destination_tree = git2_repo
-            .find_tree(destination_tree.id.to_git2())?
-            .into_object();
-        let mut dirs_we_tried_to_delete = BTreeSet::new();
-        for (kind, path_to_alter) in &changed_files {
-            if matches!(kind, ChangeKind::Deletion) {
-                // By now we can assume that the destination tree contains all files that should be
-                // in the worktree, along with the worktree changes we will touch.
-                // Thus, it's safe to delete the files that should be deleted, before possibly recreating them.
-                let path_to_delete = repo
-                    .workdir_path(path_to_alter)
-                    .context("non-bare repository")?;
-                if let Err(err) = std::fs::remove_file(&path_to_delete) {
-                    if err.kind() == std::io::ErrorKind::NotFound
-                        || err.kind() == std::io::ErrorKind::PermissionDenied
-                        || err.kind() == std::io::ErrorKind::NotADirectory
-                        || err.kind() == std::io::ErrorKind::IsADirectory
-                    {
-                        // If this file is a directory (i.e. IsADirectory is
-                        // the error kind), it would be reasonable to delete the
-                        // entire directory, because we are checking out a tree
-                        // that contains the directory anyway. But this triggers
-                        // a bug in libgit2 in which a `git_diff_delta` with
-                        // status `GIT_DELTA_TYPECHANGE` (correct, since its
-                        // type changes from blob to tree) and null OID (I don't
-                        // know the internals of libgit2 well enough to judge
-                        // this, but this seems reasonable, since at that point
-                        // of time, the tree OID cannot be known) is
-                        // created; then, if the workdir contains no entries
-                        // corresponding to that path, libgit2 erroneously
-                        // attempts to read from that null OID. So, don't
-                        // do anything if the file to be deleted is actually
-                        // a directory.
-                        continue;
-                    };
-                    return Err(err.into());
-                } else {
-                    let workdir = repo.workdir().context("non-bare repository")?;
-                    for dir_to_delete in path_to_delete.ancestors().skip(1) {
-                        let Ok(relative_to_workdir) = dir_to_delete.strip_prefix(workdir) else {
-                            break;
+    Ok(PreparedCheckout {
+        repo,
+        new_head_id,
+        new_commit_parent_count: new_object
+            .kind
+            .is_commit()
+            .then(|| new_object.into_commit().parent_ids().count()),
+        destination_tree_id: destination_tree.id,
+        changed_files,
+        checkout_options: opts,
+        skip_head_update,
+    })
+}
+
+impl PreparedCheckout<'_> {
+    /// Apply the checkout prepared against the repository's earlier `HEAD`.
+    #[instrument(skip(self), err(Debug))]
+    pub fn execute(self) -> anyhow::Result<Outcome> {
+        let PreparedCheckout {
+            repo,
+            new_head_id,
+            new_commit_parent_count,
+            destination_tree_id,
+            changed_files,
+            mut checkout_options,
+            skip_head_update,
+        } = self;
+        let num_deleted_files = changed_files
+            .iter()
+            .filter(|(kind, _)| matches!(kind, ChangeKind::Deletion))
+            .count();
+
+        // Finally, perform the actual checkout
+        // TODO(gix): use unconditional `gix` checkout implementation as pre-cursor to the real deal (not needed here).
+        //            All it has to do is to be able to apply the target changes to any working tree, while using filters,
+        //            and while doing it symlink-safe.
+        if !changed_files.is_empty() {
+            let git2_repo = git2::Repository::open(repo.git_dir())?;
+            let destination_tree = git2_repo
+                .find_tree(destination_tree_id.to_git2())?
+                .into_object();
+            let mut dirs_we_tried_to_delete = BTreeSet::new();
+            for (kind, path_to_alter) in &changed_files {
+                if matches!(kind, ChangeKind::Deletion) {
+                    // By now we can assume that the destination tree contains all files that should be
+                    // in the worktree, along with the worktree changes we will touch.
+                    // Thus, it's safe to delete the files that should be deleted, before possibly recreating them.
+                    let path_to_delete = repo
+                        .workdir_path(path_to_alter)
+                        .context("non-bare repository")?;
+                    if let Err(err) = std::fs::remove_file(&path_to_delete) {
+                        if err.kind() == std::io::ErrorKind::NotFound
+                            || err.kind() == std::io::ErrorKind::PermissionDenied
+                            || err.kind() == std::io::ErrorKind::NotADirectory
+                            || err.kind() == std::io::ErrorKind::IsADirectory
+                        {
+                            // If this file is a directory (i.e. IsADirectory is
+                            // the error kind), it would be reasonable to delete the
+                            // entire directory, because we are checking out a tree
+                            // that contains the directory anyway. But this triggers
+                            // a bug in libgit2 in which a `git_diff_delta` with
+                            // status `GIT_DELTA_TYPECHANGE` (correct, since its
+                            // type changes from blob to tree) and null OID (I don't
+                            // know the internals of libgit2 well enough to judge
+                            // this, but this seems reasonable, since at that point
+                            // of time, the tree OID cannot be known) is
+                            // created; then, if the workdir contains no entries
+                            // corresponding to that path, libgit2 erroneously
+                            // attempts to read from that null OID. So, don't
+                            // do anything if the file to be deleted is actually
+                            // a directory.
+                            continue;
                         };
-                        if relative_to_workdir.as_os_str().is_empty() {
-                            break;
-                        }
-                        if !dirs_we_tried_to_delete.insert(dir_to_delete.to_owned()) {
-                            break;
-                        }
-                        if let Err(err) = std::fs::remove_dir(dir_to_delete) {
-                            if err.kind() == std::io::ErrorKind::DirectoryNotEmpty {
+                        return Err(err.into());
+                    } else {
+                        let workdir = repo.workdir().context("non-bare repository")?;
+                        for dir_to_delete in path_to_delete.ancestors().skip(1) {
+                            let Ok(relative_to_workdir) = dir_to_delete.strip_prefix(workdir)
+                            else {
                                 break;
-                            } else {
-                                return Err(err.into());
+                            };
+                            if relative_to_workdir.as_os_str().is_empty() {
+                                break;
+                            }
+                            if !dirs_we_tried_to_delete.insert(dir_to_delete.to_owned()) {
+                                break;
+                            }
+                            if let Err(err) = std::fs::remove_dir(dir_to_delete) {
+                                if err.kind() == std::io::ErrorKind::DirectoryNotEmpty {
+                                    break;
+                                } else {
+                                    return Err(err.into());
+                                }
                             }
                         }
                     }
-                }
-            } else {
-                opts.path(path_to_alter.as_bytes());
-            }
-        }
-
-        git2_repo.checkout_tree(
-            &destination_tree,
-            Some(opts.force().disable_pathspec_match(true)),
-        )?;
-
-        if num_deleted_files > 0
-            && let Ok(mut index) = repo.index().map(|index| index.into_owned_or_cloned())
-        {
-            for (kind, path_to_alter) in &changed_files {
-                if matches!(kind, ChangeKind::Deletion)
-                    && let Some(entry) = index
-                        .entry_mut_by_path_and_stage(path_to_alter.as_bstr(), Stage::Unconflicted)
-                {
-                    entry.flags |= gix::index::entry::Flags::REMOVE;
+                } else {
+                    checkout_options.path(path_to_alter.as_bytes());
                 }
             }
-            index.write(Default::default())?;
-        }
-    }
 
-    let mut head_update = None;
-    if new_object.kind.is_commit() && !skip_head_update {
-        let needs_update = repo
-            .head()?
-            .id()
-            .is_none_or(|actual_head_id| actual_head_id != new_head_id);
-        if needs_update {
-            // We play it loose here, as we assume a repository lock so we won't interfere with ourselves.
-            // Git itself enforces no lock either, so we rely on basic locking ref-locking here. Good enough.
-            let edits = update_head_reference(
-                repo,
-                Target::Object(new_head_id),
-                true,
-                "safe checkout",
-                "GitButler".into(),
-                new_object.into_commit().parent_ids().count(),
+            git2_repo.checkout_tree(
+                &destination_tree,
+                Some(checkout_options.force().disable_pathspec_match(true)),
             )?;
-            head_update = Some(edits);
-        }
-    }
 
-    Ok(Outcome { head_update })
+            if num_deleted_files > 0
+                && let Ok(mut index) = repo.index().map(|index| index.into_owned_or_cloned())
+            {
+                for (kind, path_to_alter) in &changed_files {
+                    if matches!(kind, ChangeKind::Deletion)
+                        && let Some(entry) = index.entry_mut_by_path_and_stage(
+                            path_to_alter.as_bstr(),
+                            Stage::Unconflicted,
+                        )
+                    {
+                        entry.flags |= gix::index::entry::Flags::REMOVE;
+                    }
+                }
+                index.write(Default::default())?;
+            }
+        }
+
+        let mut head_update = None;
+        if let Some(parent_count) = new_commit_parent_count
+            && !skip_head_update
+        {
+            let needs_update = repo
+                .head()?
+                .id()
+                .is_none_or(|actual_head_id| actual_head_id != new_head_id);
+            if needs_update {
+                // We play it loose here, as we assume a repository lock so we won't interfere with ourselves.
+                // Git itself enforces no lock either, so we rely on basic locking ref-locking here. Good enough.
+                let edits = update_head_reference(
+                    repo,
+                    Target::Object(new_head_id),
+                    true,
+                    "safe checkout",
+                    "GitButler".into(),
+                    parent_count,
+                )?;
+                head_update = Some(edits);
+            }
+        }
+
+        Ok(Outcome { head_update })
+    }
 }

--- a/crates/but-core/src/worktree/checkout/mod.rs
+++ b/crates/but-core/src/worktree/checkout/mod.rs
@@ -1,3 +1,18 @@
+/// A checkout whose conflicts were resolved against the repository state at preparation time.
+///
+/// Ref updates may happen between preparation and [`Self::execute()`], but callers must keep the
+/// worktree and index unchanged.
+#[must_use = "a prepared checkout does not update the worktree until it is executed"]
+pub struct PreparedCheckout<'repo> {
+    repo: &'repo gix::Repository,
+    new_head_id: gix::ObjectId,
+    new_commit_parent_count: Option<usize>,
+    destination_tree_id: gix::ObjectId,
+    changed_files: Vec<(gix::diff::rewrites::tracker::ChangeKind, gix::bstr::BString)>,
+    checkout_options: git2::build::CheckoutBuilder<'static>,
+    skip_head_update: bool,
+}
+
 /// Options for use in [super::safe_checkout_from_head()].
 #[derive(Default, Debug, Clone)]
 pub struct Options {

--- a/crates/but-core/src/worktree/mod.rs
+++ b/crates/but-core/src/worktree/mod.rs
@@ -4,7 +4,7 @@ pub mod checkout;
 use std::{io::Read, path::Path};
 
 use bstr::BStr;
-pub use checkout::function::safe_checkout_from_head;
+pub use checkout::function::{prepare_safe_checkout_from_head, safe_checkout_from_head};
 use gix::filter::plumbing::pipeline::convert::ToGitOutcome;
 
 /// Read a worktree file into `buf` after converting it to what Git *would* store.

--- a/crates/but-core/tests/core/worktree/checkout.rs
+++ b/crates/but-core/tests/core/worktree/checkout.rs
@@ -1,14 +1,364 @@
 use bstr::ByteSlice;
-use but_core::worktree::{checkout, safe_checkout_from_head};
+use but_core::worktree::{checkout, prepare_safe_checkout_from_head, safe_checkout_from_head};
 use but_testsupport::{
     CommandExt, git_at_dir, git_status, open_repo, read_only_in_memory_scenario,
     visualize_commit_graph_all, visualize_disk_tree_skip_dot_git, visualize_index,
-    writable_scenario, writable_scenario_slow,
+    visualize_index_with_content, writable_scenario, writable_scenario_slow,
 };
 use gix::object::tree::EntryKind;
 use snapbox::prelude::*;
 
 use crate::worktree::utils::build_commit;
+
+struct LinkedWorktreeTestContext {
+    main: gix::Repository,
+    linked_a: gix::Repository,
+    linked_b: gix::Repository,
+    _tmp: but_testsupport::gix_testtools::tempfile::TempDir,
+}
+
+fn linked_worktree_test_context() -> anyhow::Result<LinkedWorktreeTestContext> {
+    let root = but_testsupport::gix_testtools::tempfile::TempDir::new()?;
+    let main_path = root.path().join("main");
+    let linked_a_path = root.path().join("linked-a");
+    let linked_b_path = root.path().join("linked-b");
+    gix::init(&main_path)?;
+    let main_repo = open_repo(&main_path)?;
+
+    let old_blob = main_repo.write_blob(b"old\n")?;
+    let unrelated_blob = main_repo.write_blob(b"base\n")?;
+    let mut tree = main_repo.empty_tree().edit()?;
+    tree.upsert("tracked.txt", EntryKind::Blob, old_blob)?;
+    tree.upsert("unrelated.txt", EntryKind::Blob, unrelated_blob)?;
+    let initial = main_repo.new_commit("initial", tree.write()?.detach(), None::<gix::ObjectId>)?;
+    let initial_id = initial.id;
+    drop(initial);
+    safe_checkout_from_head(initial_id, &main_repo, Default::default())?;
+
+    git_at_dir(&main_path)
+        .args(["worktree", "add", "-b", "linked-a"])
+        .arg(&linked_a_path)
+        .run();
+    git_at_dir(&main_path)
+        .args(["worktree", "add", "-b", "linked-b"])
+        .arg(&linked_b_path)
+        .run();
+    let linked_a_repo = open_repo(&linked_a_path)?;
+    let linked_b_repo = open_repo(&linked_b_path)?;
+    Ok(LinkedWorktreeTestContext {
+        main: main_repo,
+        linked_a: linked_a_repo,
+        linked_b: linked_b_repo,
+        _tmp: root,
+    })
+}
+
+fn visualize_linked_worktree(repo: &gix::Repository) -> anyhow::Result<String> {
+    let workdir = repo.workdir().expect("non-bare repository");
+    let tracked = std::fs::read_to_string(workdir.join("tracked.txt"))?;
+    let unrelated = std::fs::read_to_string(workdir.join("unrelated.txt"))?;
+    Ok(format!(
+        "HEAD\n{}INDEX\n{}WORKTREE\n{}FILES\ntracked.txt: {tracked:?}\nunrelated.txt: {unrelated:?}\nSTATUS\n{}",
+        std::fs::read_to_string(repo.git_dir().join("HEAD"))?,
+        visualize_index_with_content(repo, &**repo.index()?),
+        visualize_disk_tree_skip_dot_git(workdir)?,
+        git_status(repo)?
+    ))
+}
+
+#[test]
+fn prepared_checkouts_use_the_old_linked_worktree_heads_after_their_refs_move() -> anyhow::Result<()>
+{
+    let ctx = linked_worktree_test_context()?;
+    let target_blob = ctx.main.write_blob(b"new\n")?;
+    let target = build_commit(
+        &ctx.main,
+        |tree| {
+            tree.upsert("tracked.txt", EntryKind::Blob, target_blob)?;
+            Ok(())
+        },
+        "update tracked file",
+    )?;
+    std::fs::write(
+        ctx.linked_a
+            .workdir_path("unrelated.txt")
+            .expect("non-bare repository"),
+        "dirty\n",
+    )?;
+
+    let prepared_a = prepare_safe_checkout_from_head(
+        target.id,
+        &ctx.linked_a,
+        checkout::Options {
+            skip_head_update: true,
+            ..Default::default()
+        },
+    )?;
+    let prepared_b = prepare_safe_checkout_from_head(
+        target.id,
+        &ctx.linked_b,
+        checkout::Options {
+            skip_head_update: true,
+            ..Default::default()
+        },
+    )?;
+    git_at_dir(ctx.main.workdir().expect("non-bare repository"))
+        .args(["update-ref", "refs/heads/linked-a", &target.id.to_string()])
+        .run();
+    git_at_dir(ctx.main.workdir().expect("non-bare repository"))
+        .args(["update-ref", "refs/heads/linked-b", &target.id.to_string()])
+        .run();
+
+    let graph = visualize_commit_graph_all(&ctx.main)?;
+    // Both shared branch refs have moved to the target commit.
+    snapbox::assert_data_eq!(
+        graph.as_str(),
+        snapbox::str![[r#"
+* c2aefa0 (linked-b, linked-a) update tracked file
+* 5e6f558 (HEAD -> main) initial
+
+"#]]
+    );
+    // Linked A still has its old index and unrelated worktree change.
+    snapbox::assert_data_eq!(
+        visualize_linked_worktree(&ctx.linked_a)?,
+        snapbox::str![[r#"
+HEAD
+ref: refs/heads/linked-a
+INDEX
+100644:3367afd tracked.txt "old\n"
+100644:df967b9 unrelated.txt "base\n"
+WORKTREE
+.
+├── .git:100644
+├── tracked.txt:100644
+└── unrelated.txt:100644
+FILES
+tracked.txt: "old\n"
+unrelated.txt: "dirty\n"
+STATUS
+M  tracked.txt
+ M unrelated.txt
+
+"#]]
+        .raw()
+    );
+    // Linked B still has its old index and clean worktree.
+    snapbox::assert_data_eq!(
+        visualize_linked_worktree(&ctx.linked_b)?,
+        snapbox::str![[r#"
+HEAD
+ref: refs/heads/linked-b
+INDEX
+100644:3367afd tracked.txt "old\n"
+100644:df967b9 unrelated.txt "base\n"
+WORKTREE
+.
+├── .git:100644
+├── tracked.txt:100644
+└── unrelated.txt:100644
+FILES
+tracked.txt: "old\n"
+unrelated.txt: "base\n"
+STATUS
+M  tracked.txt
+
+"#]]
+        .raw()
+    );
+
+    let outcome_a = prepared_a.execute()?;
+    let outcome_b = prepared_b.execute()?;
+
+    // Executing A updates one file without updating HEAD.
+    snapbox::assert_data_eq!(
+        outcome_a.to_debug(),
+        snapbox::str![[r#"
+Outcome {
+    head_update: "None",
+}
+
+"#]]
+    );
+    // Executing B updates one file without updating HEAD.
+    snapbox::assert_data_eq!(
+        outcome_b.to_debug(),
+        snapbox::str![[r#"
+Outcome {
+    head_update: "None",
+}
+
+"#]]
+    );
+
+    // Execution does not move the shared refs again.
+    snapbox::assert_data_eq!(visualize_commit_graph_all(&ctx.main)?, graph.raw());
+    // Linked A now has the target content while preserving its unrelated dirt.
+    snapbox::assert_data_eq!(
+        visualize_linked_worktree(&ctx.linked_a)?,
+        snapbox::str![[r#"
+HEAD
+ref: refs/heads/linked-a
+INDEX
+100644:3e75765 tracked.txt "new\n"
+100644:df967b9 unrelated.txt "base\n"
+WORKTREE
+.
+├── .git:100644
+├── tracked.txt:100644
+└── unrelated.txt:100644
+FILES
+tracked.txt: "new\n"
+unrelated.txt: "dirty\n"
+STATUS
+ M unrelated.txt
+
+"#]]
+        .raw()
+    );
+    // Linked B now has the target content and remains clean.
+    snapbox::assert_data_eq!(
+        visualize_linked_worktree(&ctx.linked_b)?,
+        snapbox::str![[r#"
+HEAD
+ref: refs/heads/linked-b
+INDEX
+100644:3e75765 tracked.txt "new\n"
+100644:df967b9 unrelated.txt "base\n"
+WORKTREE
+.
+├── .git:100644
+├── tracked.txt:100644
+└── unrelated.txt:100644
+FILES
+tracked.txt: "new\n"
+unrelated.txt: "base\n"
+STATUS
+
+"#]]
+        .raw()
+    );
+    Ok(())
+}
+
+#[test]
+fn conflicting_linked_worktree_checkout_fails_during_preparation_without_mutation()
+-> anyhow::Result<()> {
+    let ctx = linked_worktree_test_context()?;
+    let target_blob = ctx.main.write_blob(b"target\n")?;
+    let target = build_commit(
+        &ctx.main,
+        |tree| {
+            tree.upsert("tracked.txt", EntryKind::Blob, target_blob)?;
+            Ok(())
+        },
+        "conflicting target",
+    )?;
+    let conflicting_tracked_path = ctx
+        .linked_b
+        .workdir_path("tracked.txt")
+        .expect("non-bare repository");
+    std::fs::write(&conflicting_tracked_path, "local\n")?;
+
+    let graph_before = visualize_commit_graph_all(&ctx.main)?;
+    // All refs still point to the initial commit.
+    snapbox::assert_data_eq!(
+        graph_before.as_str(),
+        snapbox::str![[r#"
+* 5e6f558 (HEAD -> main, linked-b, linked-a) initial
+
+"#]]
+    );
+    let linked_a_before = visualize_linked_worktree(&ctx.linked_a)?;
+    // Linked A starts clean.
+    snapbox::assert_data_eq!(
+        linked_a_before.as_str(),
+        snapbox::str![[r#"
+HEAD
+ref: refs/heads/linked-a
+INDEX
+100644:3367afd tracked.txt "old\n"
+100644:df967b9 unrelated.txt "base\n"
+WORKTREE
+.
+├── .git:100644
+├── tracked.txt:100644
+└── unrelated.txt:100644
+FILES
+tracked.txt: "old\n"
+unrelated.txt: "base\n"
+STATUS
+
+"#]]
+        .raw()
+    );
+    let linked_b_before = visualize_linked_worktree(&ctx.linked_b)?;
+    // Linked B starts with the conflicting local edit.
+    snapbox::assert_data_eq!(
+        linked_b_before.as_str(),
+        snapbox::str![[r#"
+HEAD
+ref: refs/heads/linked-b
+INDEX
+100644:3367afd tracked.txt "old\n"
+100644:df967b9 unrelated.txt "base\n"
+WORKTREE
+.
+├── .git:100644
+├── tracked.txt:100644
+└── unrelated.txt:100644
+FILES
+tracked.txt: "local\n"
+unrelated.txt: "base\n"
+STATUS
+ M tracked.txt
+
+"#]]
+        .raw()
+    );
+
+    let prepared = prepare_safe_checkout_from_head(
+        target.id,
+        &ctx.linked_a,
+        checkout::Options {
+            skip_head_update: true,
+            ..Default::default()
+        },
+    )?;
+    let err = match prepare_safe_checkout_from_head(
+        target.id,
+        &ctx.linked_b,
+        checkout::Options {
+            skip_head_update: true,
+            ..Default::default()
+        },
+    ) {
+        Ok(_) => panic!("conflicting worktree changes must fail during preparation"),
+        Err(err) => err,
+    };
+
+    // The conflicting edit is rejected during preparation.
+    snapbox::assert_data_eq!(
+        err.to_string(),
+        snapbox::str![[r#"
+Uncommitted files would be overwritten by checkout: "tracked.txt"
+"#]]
+    );
+    // Failed preparation does not move any refs.
+    snapbox::assert_data_eq!(visualize_commit_graph_all(&ctx.main)?, graph_before.raw());
+    // Prepared but unexecuted A remains unchanged.
+    snapbox::assert_data_eq!(
+        visualize_linked_worktree(&ctx.linked_a)?,
+        linked_a_before.raw()
+    );
+    // Failed preparation leaves B unchanged.
+    snapbox::assert_data_eq!(
+        visualize_linked_worktree(&ctx.linked_b)?,
+        linked_b_before.raw()
+    );
+    drop(prepared);
+    Ok(())
+}
 
 #[test]
 fn update_unborn_head() -> anyhow::Result<()> {


### PR DESCRIPTION
This commit adds in tests to ensure that safe checkouts work on worktrees, and
adds the option to speculatively see if a checkout will succeed.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #14963
- <kbd>&nbsp;1&nbsp;</kbd> #14943 👈 
<!-- GitButler Footer Boundary Bottom -->