### PR TITLE
fix: revert breaking DB schema changes

### DIFF
--- a/crates/but-db/src/table/virtual_branches.rs
+++ b/crates/but-db/src/table/virtual_branches.rs
@@ -1,10 +1,9 @@
 use crate::{DbHandle, M, SchemaVersion, Transaction};
 
-pub(crate) const M: &[M<'static>] = &[
-    M::up(
-        20260219130000,
-        SchemaVersion::Zero,
-        "CREATE TABLE `vb_state`(
+pub(crate) const M: &[M<'static>] = &[M::up(
+    20260219130000,
+    SchemaVersion::Zero,
+    "CREATE TABLE `vb_state`(
 	`id` INTEGER PRIMARY KEY CHECK (`id` = 1),
 	`initialized` INTEGER NOT NULL DEFAULT 0,
 	`default_target_remote_name` TEXT,
@@ -61,21 +60,7 @@ CREATE INDEX `idx_vb_stacks_sort_order` ON `vb_stacks`(`sort_order`);
 CREATE INDEX `idx_vb_stacks_in_workspace` ON `vb_stacks`(`in_workspace`);
 CREATE INDEX `idx_vb_stack_heads_stack_id` ON `vb_stack_heads`(`stack_id`);
 ",
-    ),
-    M::up(
-        20260722120000,
-        // Older binaries still select these columns, so physically removing them crosses the
-        // forward-compatibility boundary even though the data has no remaining runtime consumer.
-        SchemaVersion::One,
-        "DROP TABLE `vb_branch_targets`;
-ALTER TABLE `vb_state` DROP COLUMN `default_target_remote_name`;
-ALTER TABLE `vb_state` DROP COLUMN `default_target_branch_name`;
-ALTER TABLE `vb_state` DROP COLUMN `default_target_remote_url`;
-ALTER TABLE `vb_state` DROP COLUMN `default_target_sha`;
-ALTER TABLE `vb_state` DROP COLUMN `default_target_push_remote_name`;
-",
-    ),
-];
+)];
 
 /// One-row state table for virtual branches metadata (`vb_state`).
 #[derive(Default, Debug, Clone, PartialEq, Eq)]

--- a/crates/but-db/tests/db/migration.rs
+++ b/crates/but-db/tests/db/migration.rs
@@ -527,6 +527,17 @@ CREATE TABLE `hunk_assignments`(
 	PRIMARY KEY(`path`, `hunk_header`)
 );
 
+-- table vb_branch_targets
+CREATE TABLE `vb_branch_targets`(
+	`stack_id` TEXT NOT NULL PRIMARY KEY,
+	`remote_name` TEXT NOT NULL,
+	`branch_name` TEXT NOT NULL,
+	`remote_url` TEXT NOT NULL,
+	`sha` TEXT NOT NULL,
+	`push_remote_name` TEXT,
+	FOREIGN KEY(`stack_id`) REFERENCES `vb_stacks`(`id`) ON DELETE CASCADE
+);
+
 -- table vb_stack_heads
 CREATE TABLE `vb_stack_heads`(
 	`stack_id` TEXT NOT NULL,
@@ -563,6 +574,11 @@ CREATE TABLE `vb_stacks`(
 CREATE TABLE `vb_state`(
 	`id` INTEGER PRIMARY KEY CHECK (`id` = 1),
 	`initialized` INTEGER NOT NULL DEFAULT 0,
+	`default_target_remote_name` TEXT,
+	`default_target_branch_name` TEXT,
+	`default_target_remote_url` TEXT,
+	`default_target_sha` TEXT,
+	`default_target_push_remote_name` TEXT,
 	`last_pushed_base_sha` TEXT,
 	`toml_last_seen_mtime_ns` INTEGER,
 	`toml_last_seen_sha256` TEXT
@@ -663,7 +679,6 @@ Text("20260626120100")
 Text("20260715120000")
 Text("20260715161258")
 Text("20260716175500")
-Text("20260722120000")
 
 Table: hunk_assignments
 hunk_header | path | path_bytes | stack_id | id | branch_ref
@@ -696,13 +711,16 @@ Table: ci_checks
 id | name | output_summary | output_text | output_title | started_at | status_type | status_conclusion | status_completed_at | head_sha | url | html_url | details_url | pull_requests | reference | last_sync_at | struct_version
 
 Table: vb_state
-id | initialized | last_pushed_base_sha | toml_last_seen_mtime_ns | toml_last_seen_sha256
+id | initialized | default_target_remote_name | default_target_branch_name | default_target_remote_url | default_target_sha | default_target_push_remote_name | last_pushed_base_sha | toml_last_seen_mtime_ns | toml_last_seen_sha256
 
 Table: vb_stacks
 id | source_refname | upstream_remote_name | upstream_branch_name | sort_order | in_workspace | legacy_name | legacy_notes | legacy_ownership | legacy_allow_rebasing | legacy_post_commits | legacy_tree_sha | legacy_head_sha | legacy_created_timestamp_ms | legacy_updated_timestamp_ms
 
 Table: vb_stack_heads
 stack_id | position | name | head_sha | pr_number | archived | review_id
+
+Table: vb_branch_targets
+stack_id | remote_name | branch_name | remote_url | sha | push_remote_name
 
 Table: branch_order
 branch_ref_name | parent_ref_name


### PR DESCRIPTION
These breaking schema changes do not seem strictly necessary at the moment, so we defer them until we have a better strategy for making the breaking change.