### PR TITLE
fix(but-db): don't drop vb_state target columns or bump schema version

### DIFF
--- a/crates/but-db/src/table/virtual_branches.rs
+++ b/crates/but-db/src/table/virtual_branches.rs
@@ -62,18 +62,14 @@ CREATE INDEX `idx_vb_stacks_in_workspace` ON `vb_stacks`(`in_workspace`);
 CREATE INDEX `idx_vb_stack_heads_stack_id` ON `vb_stack_heads`(`stack_id`);
 ",
     ),
+    // No-op slot. This used to DROP vb_branch_targets and vb_state's default_target_* columns
+    // with a SchemaVersion::One bump, locking out older binaries that still select them.
+    // Per the M_FULLY_REMOVED convention, dead columns stay in place instead. The slot itself
+    // stays because some dev databases already recorded this migration id.
     M::up(
         20260722120000,
-        // Older binaries still select these columns, so physically removing them crosses the
-        // forward-compatibility boundary even though the data has no remaining runtime consumer.
-        SchemaVersion::One,
-        "DROP TABLE `vb_branch_targets`;
-ALTER TABLE `vb_state` DROP COLUMN `default_target_remote_name`;
-ALTER TABLE `vb_state` DROP COLUMN `default_target_branch_name`;
-ALTER TABLE `vb_state` DROP COLUMN `default_target_remote_url`;
-ALTER TABLE `vb_state` DROP COLUMN `default_target_sha`;
-ALTER TABLE `vb_state` DROP COLUMN `default_target_push_remote_name`;
-",
+        SchemaVersion::Zero,
+        "-- no-op; see comment above.",
     ),
 ];
 

--- a/crates/but-db/tests/db/migration.rs
+++ b/crates/but-db/tests/db/migration.rs
@@ -527,6 +527,17 @@ CREATE TABLE `hunk_assignments`(
 	PRIMARY KEY(`path`, `hunk_header`)
 );
 
+-- table vb_branch_targets
+CREATE TABLE `vb_branch_targets`(
+	`stack_id` TEXT NOT NULL PRIMARY KEY,
+	`remote_name` TEXT NOT NULL,
+	`branch_name` TEXT NOT NULL,
+	`remote_url` TEXT NOT NULL,
+	`sha` TEXT NOT NULL,
+	`push_remote_name` TEXT,
+	FOREIGN KEY(`stack_id`) REFERENCES `vb_stacks`(`id`) ON DELETE CASCADE
+);
+
 -- table vb_stack_heads
 CREATE TABLE `vb_stack_heads`(
 	`stack_id` TEXT NOT NULL,
@@ -563,6 +574,11 @@ CREATE TABLE `vb_stacks`(
 CREATE TABLE `vb_state`(
 	`id` INTEGER PRIMARY KEY CHECK (`id` = 1),
 	`initialized` INTEGER NOT NULL DEFAULT 0,
+	`default_target_remote_name` TEXT,
+	`default_target_branch_name` TEXT,
+	`default_target_remote_url` TEXT,
+	`default_target_sha` TEXT,
+	`default_target_push_remote_name` TEXT,
 	`last_pushed_base_sha` TEXT,
 	`toml_last_seen_mtime_ns` INTEGER,
 	`toml_last_seen_sha256` TEXT
@@ -696,13 +712,16 @@ Table: ci_checks
 id | name | output_summary | output_text | output_title | started_at | status_type | status_conclusion | status_completed_at | head_sha | url | html_url | details_url | pull_requests | reference | last_sync_at | struct_version
 
 Table: vb_state
-id | initialized | last_pushed_base_sha | toml_last_seen_mtime_ns | toml_last_seen_sha256
+id | initialized | default_target_remote_name | default_target_branch_name | default_target_remote_url | default_target_sha | default_target_push_remote_name | last_pushed_base_sha | toml_last_seen_mtime_ns | toml_last_seen_sha256
 
 Table: vb_stacks
 id | source_refname | upstream_remote_name | upstream_branch_name | sort_order | in_workspace | legacy_name | legacy_notes | legacy_ownership | legacy_allow_rebasing | legacy_post_commits | legacy_tree_sha | legacy_head_sha | legacy_created_timestamp_ms | legacy_updated_timestamp_ms
 
 Table: vb_stack_heads
 stack_id | position | name | head_sha | pr_number | archived | review_id
+
+Table: vb_branch_targets
+stack_id | remote_name | branch_name | remote_url | sha | push_remote_name
 
 Table: branch_order
 branch_ref_name | parent_ref_name


### PR DESCRIPTION
The `20260722120000` migration dropped `vb_branch_targets` and the `default_target_*` columns of `vb_state` and tagged it `SchemaVersion::One`. That bump writes `PRAGMA user_version = 1`, so every older binary refuses to open the database — breaking dev/nightly clients.

Nothing in current code reads those columns, so there is no need to drop them. Following the same convention used for `workspace_rules` and `workflows`, leave them in place (unused) and stay on `SchemaVersion::Zero` — no bump, no lockout. The migration slot is kept as an inert no-op rather than deleted, so a later migration can't collide with the id in dev databases that already recorded it.

Note for reviewers: devs who already ran the destructive `master` have a `user_version=1` database with the columns dropped. A fixed binary can't retroactively un-bump it — forward-compat is a one-way ratchet — so those local databases need a one-time reset. The project cache DB (`removed_change_ids`) carries the same `SchemaVersion::One` pattern and is left for a separate look.