### PR TITLE
feat(but): add support for opening many files

### DIFF
--- a/crates/but-api/src/open/mod.rs
+++ b/crates/but-api/src/open/mod.rs
@@ -9,8 +9,8 @@ use url::Url;
 
 use crate::open::{
     program::{
-        Editor, PROGRAMS, ProgramSpec, USER_DEFINED_PROGRAMS_FILENAME, UserDefinedProgramSpec,
-        open_in_program_unchecked,
+        Editor, OpenSpec, PROGRAMS, ProgramSpec, USER_DEFINED_PROGRAMS_FILENAME,
+        UserDefinedProgramSpec, open_in_program_unchecked,
     },
     spawn::spawn_and_reap,
 };
@@ -723,7 +723,11 @@ pub fn open_in_editor(
         .find(|editor| editor.id == editor_id)
         && editor.is_gui_editor()
     {
-        open_in_program_unchecked(editor, &resolved_path, line_nr)
+        let open_spec = match line_nr {
+            Some(line_nr) => OpenSpec::FileAtLine(resolved_path, line_nr),
+            None => OpenSpec::File(resolved_path),
+        };
+        open_in_program_unchecked(editor, open_spec)
     } else {
         bail_precondition!("editor_id '{editor_id}' is not a GUI-compatible editor");
     }

--- a/crates/but-api/src/open/program.rs
+++ b/crates/but-api/src/open/program.rs
@@ -1,12 +1,9 @@
 use std::{
     ffi::OsString,
-    path::Path,
+    path::{Path, PathBuf},
     process::{Command, Stdio},
     sync::LazyLock,
 };
-
-#[cfg(target_os = "macos")]
-use std::path::PathBuf;
 
 use crate::open::spawn::spawn_and_reap;
 
@@ -183,14 +180,8 @@ enum CliArgumentSupplier {
 }
 
 impl CliArgumentSupplier {
-    /// Add argument(s) to `cmd` to open the file on the specific line, or error if it's not
-    /// supported.
-    fn open_at_line<'a>(
-        &self,
-        cmd: &'a mut Command,
-        path: &Path,
-        line_nr: u32,
-    ) -> anyhow::Result<&'a mut Command> {
+    /// Add argument(s) to `cmd` to open the file on the specific line.
+    fn open_at_line<'a>(&self, cmd: &'a mut Command, path: &Path, line_nr: u32) -> &'a mut Command {
         match self {
             Self::VSCodeLike => cmd.arg("--goto").arg(self.path_with_line_nr(path, line_nr)),
             Self::Zed => cmd.arg(self.path_with_line_nr(path, line_nr)),
@@ -198,11 +189,33 @@ impl CliArgumentSupplier {
             #[cfg(all(target_os = "macos", not(debug_assertions)))]
             Self::Xcode => cmd.arg("--line").arg(line_nr.to_string()).arg(path),
             Self::Neovim => cmd.arg(format!("+{line_nr}")).arg(path),
-            Self::Custom(open_at_line) => open_at_line.open_at_line(cmd, path, line_nr),
+            Self::Custom(custom) => custom.open_at_line(cmd, path, line_nr),
             Self::Default => cmd.arg(path),
         };
 
-        Ok(cmd)
+        cmd
+    }
+
+    /// Add argument(s) to `cmd` to open the file.
+    fn open<'a>(&self, cmd: &'a mut Command, path: &Path) -> &'a mut Command {
+        match self {
+            Self::Custom(custom) => custom.open(cmd, path),
+            _ => cmd.arg(path),
+        };
+        cmd
+    }
+
+    /// Add argument(s) to `cmd` to open all files.
+    fn open_many<'a, P: AsRef<Path>>(&self, cmd: &'a mut Command, paths: &[P]) -> &'a mut Command {
+        match self {
+            Self::Custom(custom) => custom.open_many(cmd, paths),
+            _ => {
+                for path in paths {
+                    cmd.arg(path.as_ref());
+                }
+                cmd
+            }
+        }
     }
 
     fn path_with_line_nr(&self, path: &Path, line_nr: u32) -> OsString {
@@ -260,6 +273,24 @@ impl CustomCliArgumentSupplier {
             // TODO should not assume utf8 for path
             cmd.arg(arg.replace(FILEPATH_PLACEHOLDER, &path.to_string_lossy()));
         }
+        cmd
+    }
+
+    fn open_many<'a, P: AsRef<Path>>(&self, cmd: &'a mut Command, paths: &[P]) -> &'a mut Command {
+        let Some(open_args) = &self.open_args else {
+            return CliArgumentSupplier::Default.open_many(cmd, paths);
+        };
+
+        for arg in open_args {
+            if arg.contains(FILEPATH_PLACEHOLDER) {
+                for path in paths {
+                    cmd.arg(arg.replace(FILEPATH_PLACEHOLDER, &path.as_ref().to_string_lossy()));
+                }
+            } else {
+                cmd.arg(arg);
+            }
+        }
+
         cmd
     }
 }
@@ -414,24 +445,30 @@ pub(crate) static PROGRAMS: LazyLock<Vec<ProgramSpec>> = LazyLock::new(|| {
     ])
 });
 
+/// Specification to open.
+pub enum OpenSpec {
+    /// A single file.
+    File(PathBuf),
+    /// Multiple files.
+    Files(Vec<PathBuf>),
+    /// A single file at a specific line.
+    FileAtLine(PathBuf, u32),
+}
+
 /// Low-level API to open a `path` with a specified `program`.
 ///
 /// # WARNING
 /// It is up to the caller to assure that the `path` is safe to open and that the `program` is safe
 /// to use. Therefore, this should never be exposed to an untrusted context, such as the GUI
 /// renderer.
-pub fn open_in_program_unchecked(
-    program: &ProgramSpec,
-    path: &Path,
-    line_nr: Option<u32>,
-) -> anyhow::Result<()> {
+pub fn open_in_program_unchecked(program: &ProgramSpec, open_spec: OpenSpec) -> anyhow::Result<()> {
     match &program.executable {
         ExecutableProgram::PathExecutable(path_executable) => {
-            open_in_path_executable(path_executable, &program.cli_arg_supplier, path, line_nr)
+            open_in_path_executable(path_executable, &program.cli_arg_supplier, open_spec)
         }
         #[cfg(target_os = "macos")]
         ExecutableProgram::MacosApplication(macos_application) => {
-            open_in_macos_application(macos_application, &program.cli_arg_supplier, path, line_nr)
+            open_in_macos_application(macos_application, &program.cli_arg_supplier, open_spec)
         }
     }
 }
@@ -439,17 +476,16 @@ pub fn open_in_program_unchecked(
 fn open_in_path_executable(
     path_executable: &PathExecutable,
     cli_arg_supplier: &CliArgumentSupplier,
-    path: &Path,
-    line_nr: Option<u32>,
+    open_spec: OpenSpec,
 ) -> anyhow::Result<()> {
     let mut cmd = Command::new(&path_executable.name_or_path);
 
-    if let Some(line_nr) = line_nr {
-        cli_arg_supplier.open_at_line(&mut cmd, path, line_nr)?
-    } else if let CliArgumentSupplier::Custom(custom_cli_arg_supplier) = cli_arg_supplier {
-        custom_cli_arg_supplier.open(&mut cmd, path)
-    } else {
-        cmd.arg(path)
+    match open_spec {
+        OpenSpec::File(path) => cli_arg_supplier.open(&mut cmd, &path),
+        OpenSpec::Files(paths) => cli_arg_supplier.open_many(&mut cmd, &paths),
+        OpenSpec::FileAtLine(path, line_nr) => {
+            cli_arg_supplier.open_at_line(&mut cmd, &path, line_nr)
+        }
     };
 
     if path_executable.requires_tty {
@@ -459,7 +495,11 @@ fn open_in_path_executable(
             .status()?;
     } else {
         cmd.stdout(Stdio::null()).stderr(Stdio::null());
-        spawn_and_reap(cmd, &path_executable.name_or_path, &path.to_string_lossy())?;
+        spawn_and_reap(
+            cmd,
+            &path_executable.name_or_path,
+            &path_executable.name_or_path,
+        )?;
     }
 
     Ok(())
@@ -515,30 +555,42 @@ impl MacosApplication {
 fn open_in_macos_application(
     app: &MacosApplication,
     cli_arg_supplier: &CliArgumentSupplier,
-    path: &Path,
-    line_nr: Option<u32>,
+    open_spec: OpenSpec,
 ) -> anyhow::Result<()> {
-    if let (Some(line_nr), Ok(cli_abspath)) = (line_nr, app.resolve_cli_wrapper_abspath()) {
-        let mut cmd = Command::new(cli_abspath);
-        cli_arg_supplier.open_at_line(&mut cmd, path, line_nr)?;
-        cmd.stdout(Stdio::null()).stderr(Stdio::null());
-        spawn_and_reap(cmd, &app.bundle_identifier, &path.to_string_lossy())?;
-    } else {
-        let mut cmd = Command::new("/usr/bin/open");
-        let status = cmd
-            .arg("-b")
-            .arg(&app.bundle_identifier)
-            .arg(path)
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()?;
+    match open_spec {
+        OpenSpec::FileAtLine(path, line_nr) => match app.resolve_cli_wrapper_abspath() {
+            Ok(cli_abspath) => {
+                let mut cmd = Command::new(cli_abspath);
+                cli_arg_supplier.open_at_line(&mut cmd, &path, line_nr);
+                cmd.stdout(Stdio::null()).stderr(Stdio::null());
+                spawn_and_reap(cmd, &app.bundle_identifier, &path.to_string_lossy())
+            }
+            Err(_) => open_macos_application_via_open(app, &[path]),
+        },
+        OpenSpec::File(path) => open_macos_application_via_open(app, &[path]),
+        OpenSpec::Files(paths) => open_macos_application_via_open(app, &paths),
+    }
+}
 
-        if !status.success() {
-            anyhow::bail!(
-                "failed to open {path:?} with app bundle identifier '{}'",
-                app.bundle_identifier
-            );
-        }
+#[cfg(target_os = "macos")]
+fn open_macos_application_via_open(
+    app: &MacosApplication,
+    paths: &[PathBuf],
+) -> anyhow::Result<()> {
+    let mut cmd = Command::new("/usr/bin/open");
+    cmd.arg("-b").arg(&app.bundle_identifier);
+
+    for path in paths {
+        cmd.arg(path);
+    }
+
+    let status = cmd.stdout(Stdio::null()).stderr(Stdio::null()).status()?;
+
+    if !status.success() {
+        anyhow::bail!(
+            "failed to open {paths:?} with app bundle identifier '{}'",
+            app.bundle_identifier
+        );
     }
 
     Ok(())

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -946,8 +946,9 @@ pub enum Subcommands {
     #[clap(hide = true, name = "_open")]
     #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     _Open {
-        /// The thing to open.
-        id: CliIdArg,
+        /// One or more uncommitted files or hunks to open.
+        #[clap(num_args = 1..)]
+        sources: Vec<CliIdArg>,
         /// The program to use for opening.
         #[clap(long, short = 'p')]
         program_id: Option<String>,

--- a/crates/but/src/command/legacy/status/tui/app/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/app/mod.rs
@@ -417,7 +417,7 @@ impl App {
             }
             Message::PickProgramThenOpen => self.handle_pick_program_then_open(ctx)?,
             Message::OpenInProgram(program, to_open) => {
-                self.handle_open_in_program(&program, &to_open, terminal_guard, messages)?;
+                self.handle_open_in_program(&program, to_open, terminal_guard, messages)?;
             }
             Message::ShowToast { kind, text } => {
                 self.toasts.insert(kind, text);
@@ -1389,7 +1389,7 @@ impl App {
     fn handle_open_in_program<T>(
         &mut self,
         program: &ProgramSpec,
-        to_open: &Openable,
+        to_open: Openable,
         terminal_guard: &mut T,
         messages: &mut Vec<Message>,
     ) -> anyhow::Result<()>

--- a/crates/but/src/command/open.rs
+++ b/crates/but/src/command/open.rs
@@ -85,21 +85,24 @@ impl Openable {
     }
 }
 
-pub(crate) fn open(ctx: &Context, cli_id: CliIdArg, program_id: Option<String>) -> CliResult<()> {
+pub(crate) fn open(
+    ctx: &Context,
+    sources: Vec<CliIdArg>,
+    program_id: Option<String>,
+) -> CliResult<()> {
     let guard = ctx.shared_worktree_access();
     let id_map = IdMap::new_from_context(ctx, None, guard.read_permission())?;
     let (repo, _ws, _db) = ctx.workspace_and_db_with_perm(guard.read_permission())?;
 
-    let to_open = match cli_id.resolve_in_workspace(&repo, &id_map, Purpose::Uncommitted, None)? {
-        ResolvedCliIdArg::UncommittedHunkOrFile(uncommitted) => {
-            Openable::try_from_uncommitted(&repo, &uncommitted)?
-        }
-        resolved_id => {
-            return Err(bad_input(format!(
-                "Expected uncommitted file or hunk, got {}",
-                resolved_id.kind_for_humans()
-            ))
-            .into());
+    let to_open = match sources.as_slice() {
+        [] => return Err(bad_input("At least one source is required").into()),
+        [source] => resolve_source(&repo, &id_map, source)?,
+        sources => {
+            let paths = sources
+                .iter()
+                .map(|source| resolve_file_source(&repo, &id_map, source))
+                .collect::<CliResult<Vec<_>>>()?;
+            Openable::Files(paths)
         }
     };
 
@@ -127,6 +130,53 @@ pub(crate) fn open(ctx: &Context, cli_id: CliIdArg, program_id: Option<String>) 
     run(program, to_open)?;
 
     Ok(())
+}
+
+fn resolve_source(
+    repo: &gix::Repository,
+    id_map: &IdMap,
+    source: &CliIdArg,
+) -> CliResult<Openable> {
+    match source.resolve_in_workspace(repo, id_map, Purpose::Uncommitted, None)? {
+        ResolvedCliIdArg::UncommittedHunkOrFile(uncommitted) => {
+            Ok(Openable::try_from_uncommitted(repo, &uncommitted)?)
+        }
+        resolved_id => Err(unexpected_source_kind(resolved_id)),
+    }
+}
+
+fn resolve_file_source(
+    repo: &gix::Repository,
+    id_map: &IdMap,
+    source: &CliIdArg,
+) -> CliResult<PathBuf> {
+    match source.resolve_in_workspace(repo, id_map, Purpose::Uncommitted, None)? {
+        ResolvedCliIdArg::UncommittedHunkOrFile(uncommitted) => {
+            if !uncommitted.is_entire_file {
+                return Err(bad_input(format!(
+                    "Only entire files can be opened when multiple sources are provided; \
+                     '{source}' is a hunk"
+                ))
+                .into());
+            }
+
+            match Openable::try_from_uncommitted(repo, &uncommitted)? {
+                Openable::File(path) => Ok(path),
+                Openable::Hunk(_) | Openable::Files(_) => {
+                    unreachable!("entire-file source must resolve to one file")
+                }
+            }
+        }
+        resolved_id => Err(unexpected_source_kind(resolved_id)),
+    }
+}
+
+fn unexpected_source_kind(resolved_id: ResolvedCliIdArg) -> CliError {
+    bad_input(format!(
+        "Expected uncommitted file or hunk, got {}",
+        resolved_id.kind_for_humans()
+    ))
+    .into()
 }
 
 pub(crate) fn run(program: &ProgramSpec, to_open: Openable) -> anyhow::Result<()> {

--- a/crates/but/src/command/open.rs
+++ b/crates/but/src/command/open.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use bstr::BStr;
 use but_api::open::{
     list_builtin_program_specs, list_user_defined_program_specs,
-    program::{ProgramSpec, open_in_program_unchecked},
+    program::{OpenSpec, ProgramSpec, open_in_program_unchecked},
 };
 use but_ctx::Context;
 use gix::utils::AsBStr;
@@ -32,6 +32,7 @@ pub(crate) struct Hunk {
 #[derive(Debug)]
 pub(crate) enum Openable {
     File(PathBuf),
+    Files(Vec<PathBuf>),
     Hunk(Hunk),
 }
 
@@ -123,18 +124,22 @@ pub(crate) fn open(ctx: &Context, cli_id: CliIdArg, program_id: Option<String>) 
             .expect("BUG: The internal list of programs should not be empty"),
     };
 
-    run(program, &to_open)?;
+    run(program, to_open)?;
 
     Ok(())
 }
 
-pub(crate) fn run(program: &ProgramSpec, to_open: &Openable) -> anyhow::Result<()> {
-    let (path, line_number) = match to_open {
-        Openable::Hunk(hunk) => (&hunk.path, Some(compute_line_number_to_open_at(hunk))),
-        Openable::File(path) => (path, None),
+pub(crate) fn run(program: &ProgramSpec, to_open: Openable) -> anyhow::Result<()> {
+    let open_spec = match to_open {
+        Openable::Hunk(hunk) => {
+            let line_number = compute_line_number_to_open_at(&hunk);
+            OpenSpec::FileAtLine(hunk.path, line_number)
+        }
+        Openable::File(path) => OpenSpec::File(path),
+        Openable::Files(paths) => OpenSpec::Files(paths),
     };
 
-    open_in_program_unchecked(program, path, line_number)
+    open_in_program_unchecked(program, open_spec)
 }
 
 /// Compute the line to place the cursor at, going through a priority order of additions ->

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -473,7 +473,10 @@ async fn match_subcommand(
                 .emit_metrics(metrics_ctx)
                 .map_err(CliError::from)
         }
-        Subcommands::_Open { id, program_id } => {
+        Subcommands::_Open {
+            sources,
+            program_id,
+        } => {
             let ctx = setup::init_ctx(
                 &args,
                 InitCtxOptions {
@@ -482,7 +485,7 @@ async fn match_subcommand(
                 },
                 out,
             )?;
-            command::open::open(&ctx, id, program_id).emit_metrics(metrics_ctx)
+            command::open::open(&ctx, sources, program_id).emit_metrics(metrics_ctx)
         }
         Subcommands::Completions { shell } => command::completions::generate_completions(shell)
             .emit_metrics(metrics_ctx)

--- a/crates/but/tests/but/command/open.rs
+++ b/crates/but/tests/but/command/open.rs
@@ -51,6 +51,22 @@ filepath='/[..]/new-file.txt'
 }
 
 #[test]
+fn open_multiple_uncommitted_files() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+
+    env.file("first.txt", "first");
+    env.file("second.txt", "second");
+
+    env.but("_open first.txt second.txt -p echo")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+filepath='/[..]/first.txt' filepath='/[..]/second.txt'
+
+"#]]);
+}
+
+#[test]
 fn open_uncommitted_hunk() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
     env.setup_metadata(&["A"]);
@@ -156,6 +172,19 @@ filepath='/[..]/file-with-deletions.txt' line_number='7'
         .success()
         .stdout_eq(snapbox::str![[r#"
 filepath='/[..]/file-with-mixed.txt' line_number='2'
+
+"#]]);
+}
+
+#[test]
+fn cannot_open_hunk_with_multiple_sources() {
+    let env = setup_multi_hunk_uncommitted_changes("file.txt");
+
+    env.but("_open file.txt uv:4 -p echo")
+        .assert()
+        .failure()
+        .stderr_eq(snapbox::str![[r#"
+Error: Only entire files can be opened when multiple sources are provided; 'uv:4' is a hunk
 
 "#]]);
 }


### PR DESCRIPTION
This is a stab at adding multi-file open support to the "open in program" APIs.

It's pretty simple.

* For built-in path executables, it just piles on the paths as arguments at the end
* For native macOS applications, it also just piles on the arguments at the end (which is supported by `open`)
* For user-defined commands, any arg containing the `{{filepath}}` placeholder is repeated once per path, with the placeholder swapped out for said path

This mostly just works. Many, maybe even most, CLI programs that can open a single file can open multiple by just passing more paths. So for the most part this simple approach should work.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #14959
- <kbd>&nbsp;1&nbsp;</kbd> #14950 👈 
<!-- GitButler Footer Boundary Bottom -->