### PR TITLE
push: factor out the calculation of branches to push

### DIFF
--- a/crates/but-workspace/src/legacy/push.rs
+++ b/crates/but-workspace/src/legacy/push.rs
@@ -36,7 +36,7 @@ pub fn workspace_branch_and_ancestors_push(
     push_opts: Vec<but_gerrit::PushFlag>,
 ) -> Result<PushResult> {
     let graph = &ws.graph;
-    let mut to_push = IndexMap::new();
+    let to_push = branch_and_ancestor_segments(ref_info, branch);
 
     let remote_names = repo.remote_names();
     let target_ref_name = ws
@@ -56,27 +56,6 @@ pub fn workspace_branch_and_ancestors_push(
         branch_to_remote: vec![],
         branch_sha_updates: vec![],
     };
-
-    for stack in &ref_info.stacks {
-        let mut refname_found = false;
-        for segment in &stack.segments {
-            let Some(ref_name) = segment.ref_info.as_ref().map(|r| r.ref_name.as_ref()) else {
-                continue;
-            };
-
-            if ref_name.category() != Some(gix::refs::Category::LocalBranch) {
-                continue;
-            }
-
-            if ref_name == branch {
-                refname_found = true;
-            }
-
-            if refname_found {
-                to_push.insert(segment.id, segment);
-            }
-        }
-    }
 
     for (sidx, segment) in to_push.iter().rev() {
         // this will always be set
@@ -161,6 +140,39 @@ pub fn workspace_branch_and_ancestors_push(
     }
 
     Ok(result)
+}
+
+/// Return the selected local branch and its ancestors in top-to-base order.
+///
+/// This is the logical scope of a push operation. It includes ancestors that are already current
+/// on the remote, even though [`workspace_branch_and_ancestors_push()`] will skip transferring
+/// those refs.
+pub fn branch_and_ancestor_segments<'a>(
+    ref_info: &'a RefInfo,
+    branch: &gix::refs::FullNameRef,
+) -> IndexMap<but_graph::SegmentIndex, &'a Segment> {
+    let mut selected = IndexMap::new();
+    for stack in &ref_info.stacks {
+        let mut refname_found = false;
+        for segment in &stack.segments {
+            let Some(ref_name) = segment.ref_info.as_ref().map(|r| r.ref_name.as_ref()) else {
+                continue;
+            };
+
+            if ref_name.category() != Some(gix::refs::Category::LocalBranch) {
+                continue;
+            }
+
+            if ref_name == branch {
+                refname_found = true;
+            }
+
+            if refname_found {
+                selected.insert(segment.id, segment);
+            }
+        }
+    }
+    selected
 }
 
 struct GerritPushArgs {

--- a/crates/but-workspace/tests/fixtures/scenario/push.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/push.sh
@@ -12,6 +12,8 @@ git push --quiet -u origin main
 
 git checkout -b bottom main
 commit bottom
+git checkout -b middle
+commit middle
 git checkout -b top
 commit top
 
@@ -19,4 +21,3 @@ git checkout -b solo main
 commit solo
 
 create_workspace_commit_once top solo
-

--- a/crates/but-workspace/tests/workspace/push.rs
+++ b/crates/but-workspace/tests/workspace/push.rs
@@ -119,6 +119,38 @@ fn status(info: &RefInfo, branch: &str) -> but_workspace::ui::PushStatus {
         .push_status
 }
 
+fn logical_scope(info: &RefInfo, branch: &str) -> Vec<String> {
+    let branch = gix::refs::Category::LocalBranch
+        .to_full_name(branch)
+        .expect("valid fixture branch name");
+    but_workspace::legacy::push::branch_and_ancestor_segments(info, branch.as_ref())
+        .values()
+        .filter_map(|segment| {
+            segment
+                .ref_info
+                .as_ref()
+                .map(|ref_info| ref_info.ref_name.shorten().to_string())
+        })
+        .collect()
+}
+
+#[test]
+fn logical_push_scope_is_selected_branch_plus_ancestors() -> anyhow::Result<()> {
+    let (_tmp, repo, meta) = fixture("push")?;
+    let (info, _) = head_info(&repo, &meta)?;
+
+    assert_eq!(logical_scope(&info, "bottom"), ["bottom"]);
+    assert_eq!(logical_scope(&info, "middle"), ["middle", "bottom"]);
+    assert_eq!(logical_scope(&info, "top"), ["top", "middle", "bottom"]);
+    assert_eq!(
+        logical_scope(&info, "solo"),
+        ["solo"],
+        "an unrelated stack must not enter the selected scope"
+    );
+
+    Ok(())
+}
+
 #[test]
 fn pushing_bottom_of_stack_reports_only_bottom_as_pushed() -> anyhow::Result<()> {
     let (_tmp, repo, meta) = fixture("push")?;
@@ -148,6 +180,8 @@ fn pushing_top_of_stack_reports_top_as_pushed_after_bottom_is_current() -> anyho
 
     let bottom_result = push(&repo, &meta, r("refs/heads/bottom"), false, false, false)?;
     apply_remote_tracking_updates(&repo, &bottom_result)?;
+    let middle_result = push(&repo, &meta, r("refs/heads/middle"), false, false, false)?;
+    apply_remote_tracking_updates(&repo, &middle_result)?;
 
     let result = push(&repo, &meta, r("refs/heads/top"), false, false, false)?;
     assert_eq!(
@@ -157,12 +191,18 @@ fn pushing_top_of_stack_reports_top_as_pushed_after_bottom_is_current() -> anyho
             .map(|(branch, _)| branch.as_str())
             .collect::<Vec<_>>(),
         ["top"],
-        "once the bottom branch is current, pushing the top branch should report only the top"
+        "once the ancestors are current, pushing the top branch should report only the top"
     );
 
     apply_remote_tracking_updates(&repo, &result)?;
     let (info, _) = head_info(&repo, &meta)?;
+    assert_eq!(
+        logical_scope(&info, "top"),
+        ["top", "middle", "bottom"],
+        "already-current ancestors remain in the logical synchronization scope"
+    );
     assert_eq!(status(&info, "bottom"), NothingToPush);
+    assert_eq!(status(&info, "middle"), NothingToPush);
     assert_eq!(status(&info, "top"), NothingToPush);
 
     Ok(())


### PR DESCRIPTION
No functional changes

Factor out the calculation of which references should be pushed when e.g. we’re pushing a stacked branch.
Add tests for that as well.

--- 

### Why?
I'll need this later to be able to sync stacked reviews using the same slice of refs that we push.