### PR TITLE
branch listing API review

### DIFF
--- a/crates/but-api-macros/src/lib.rs
+++ b/crates/but-api-macros/src/lib.rs
@@ -14,9 +14,11 @@ use syn::{FnArg, ItemFn, Pat, parse_macro_input};
 ///
 /// * `JSONReturnType`
 ///     - Use it like `but_api(JSONReturnType)` where `JSONReturnType::from(actual_return_type)` is implemented.
+///     - `Result<Vec<T>>` converts each `T` into `JSONReturnType`.
 ///     - Controls how the actual return value is converted for JSON serialization in `func_json` and `func_cmd`.
 /// * `try_from = JSONReturnType`
 ///     - Use it like `but_api(try_from = JSONReturnType)` where `JSONReturnType::try_from(actual_return_type)?` is implemented.
+///     - `Result<Vec<T>>` converts each `T` into `JSONReturnType`.
 ///     - Controls how the actual return value is fallibly converted for JSON serialization in `func_json` and `func_cmd`.
 ///
 /// # Parameter Attributes
@@ -81,7 +83,7 @@ pub fn but_api(attr: TokenStream, item: TokenStream) -> TokenStream {
     let input = &sig.inputs;
     let output = &sig.output;
 
-    let is_result_option = is_result_option(match output {
+    let result_container = result_container(match output {
         syn::ReturnType::Type(_, ty) => ty.as_ref(),
         syn::ReturnType::Default => panic!("function must return a type"),
     });
@@ -90,7 +92,7 @@ pub fn but_api(attr: TokenStream, item: TokenStream) -> TokenStream {
         Options::default()
     } else {
         match syn::parse::Parser::parse(
-            |input: syn::parse::ParseStream| parse_options(input, is_result_option),
+            |input: syn::parse::ParseStream| parse_options(input, result_container),
             attr,
         ) {
             Ok(opts) => opts,
@@ -184,34 +186,37 @@ pub fn but_api(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let (convert_to_json_result_type, json_ty) = if let Some(ResultConversion {
         mode,
-        is_result_option,
+        container,
         json_ty,
         json_ty_rval,
     }) = opts.result_conversion
     {
         let convert = match mode {
-            FromMode::From => {
-                if is_result_option {
-                    quote! {
-                        let result: Option<#json_ty> = result.map(Into::into);
-                    }
-                } else {
-                    quote! {
-                        let result: #json_ty = result.into();
-                    }
-                }
-            }
-            FromMode::TryFrom => {
-                if is_result_option {
-                    quote! {
-                        let result: Option<#json_ty> = result.map(TryInto::try_into).transpose()?;
-                    }
-                } else {
-                    quote! {
-                        let result: #json_ty = result.try_into()?;
-                    }
-                }
-            }
+            FromMode::From => match container {
+                ResultContainer::Value => quote! {
+                    let result: #json_ty = result.into();
+                },
+                ResultContainer::Option => quote! {
+                    let result: Option<#json_ty> = result.map(Into::into);
+                },
+                ResultContainer::Vec => quote! {
+                    let result: Vec<#json_ty> = result.into_iter().map(Into::into).collect();
+                },
+            },
+            FromMode::TryFrom => match container {
+                ResultContainer::Value => quote! {
+                    let result: #json_ty = result.try_into()?;
+                },
+                ResultContainer::Option => quote! {
+                    let result: Option<#json_ty> = result.map(TryInto::try_into).transpose()?;
+                },
+                ResultContainer::Vec => quote! {
+                    let result: Vec<#json_ty> = result
+                        .into_iter()
+                        .map(TryInto::try_into)
+                        .collect::<Result<_, _>>()?;
+                },
+            },
         };
         (convert, json_ty_rval)
     } else {
@@ -1078,15 +1083,18 @@ struct Options {
 struct ResultConversion {
     /// If the result type conversion is fallbile.
     mode: FromMode,
-    /// If the function returns `Result<Option<T>>>`
-    is_result_option: bool,
+    /// Container around the converted value in the function's `Result`.
+    container: ResultContainer,
     /// The type to convert *to* for json.
     json_ty: syn::Type,
-    /// The resulting JSON type after applying option wrapping.
+    /// The resulting JSON type after applying container wrapping.
     json_ty_rval: syn::Type,
 }
 
-fn parse_options(input: syn::parse::ParseStream, is_result_option: bool) -> syn::Result<Options> {
+fn parse_options(
+    input: syn::parse::ParseStream,
+    container: ResultContainer,
+) -> syn::Result<Options> {
     let mut napi = false;
     let mut conversion_path: Option<(FromMode, syn::Path)> = None;
 
@@ -1134,14 +1142,14 @@ fn parse_options(input: syn::parse::ParseStream, is_result_option: bool) -> syn:
             qself: None,
             path: p,
         });
-        let json_ty_rval = if is_result_option {
-            syn::parse_quote! { Option<#base_ty> }
-        } else {
-            base_ty.clone()
+        let json_ty_rval = match container {
+            ResultContainer::Value => base_ty.clone(),
+            ResultContainer::Option => syn::parse_quote! { Option<#base_ty> },
+            ResultContainer::Vec => syn::parse_quote! { Vec<#base_ty> },
         };
         ResultConversion {
             mode,
-            is_result_option,
+            container,
             json_ty: base_ty,
             json_ty_rval,
         }
@@ -1153,8 +1161,15 @@ fn parse_options(input: syn::parse::ParseStream, is_result_option: bool) -> syn:
     })
 }
 
-/// Detect `Result<Option<` type
-fn is_result_option(ty: &syn::Type) -> bool {
+#[derive(Clone, Copy)]
+enum ResultContainer {
+    Value,
+    Option,
+    Vec,
+}
+
+/// Detect the supported container directly inside `Result`.
+fn result_container(ty: &syn::Type) -> ResultContainer {
     if let syn::Type::Path(tp) = ty
         && let Some(seg) = tp.path.segments.last()
         && seg.ident == "Result"
@@ -1162,11 +1177,14 @@ fn is_result_option(ty: &syn::Type) -> bool {
         && let Some(syn::GenericArgument::Type(inner)) = args.args.first()
         && let syn::Type::Path(tp) = inner
         && let Some(first) = tp.path.segments.last()
-        && first.ident == "Option"
     {
-        true
+        match first.ident.to_string().as_str() {
+            "Option" => ResultContainer::Option,
+            "Vec" => ResultContainer::Vec,
+            _ => ResultContainer::Value,
+        }
     } else {
-        false
+        ResultContainer::Value
     }
 }
 

--- a/crates/but-api-macros/tests/tests/ui/pass/default_vec_conversion.rs
+++ b/crates/but-api-macros/tests/tests/ui/pass/default_vec_conversion.rs
@@ -1,0 +1,26 @@
+// Case: `Result<Vec<T>>` plus explicit `From` conversion.
+// Extend when: collection conversion rules or output typing for vectors changes.
+
+use but_api_macros::but_api;
+
+pub use but_api_macros_tests::{UiValue, UiValueTry, json, panic_capture};
+
+#[but_api(UiValue)]
+pub fn values() -> anyhow::Result<Vec<i32>> {
+    Ok(vec![1, 2])
+}
+
+#[but_api(try_from = UiValueTry)]
+pub fn checked_values() -> anyhow::Result<Vec<i32>> {
+    Ok(vec![1, 2])
+}
+
+fn main() {
+    let _: Result<Vec<UiValue>, _> = values_json();
+    let _: Result<Vec<UiValueTry>, _> = checked_values_json();
+    #[cfg(feature = "legacy")]
+    {
+        let _ = values_cmd(serde_json::json!({}));
+        let _ = checked_values_cmd(serde_json::json!({}));
+    }
+}

--- a/crates/but-api/src/branch.rs
+++ b/crates/but-api/src/branch.rs
@@ -71,6 +71,7 @@ pub struct BranchCheckoutResult {
 
 /// JSON transport types for branch APIs.
 pub mod json {
+    use bstr::ByteSlice;
     use but_workspace::{branch::apply::OutcomeStatus, ui::ref_info::BranchReference};
     use serde::{Deserialize, Serialize};
 
@@ -716,6 +717,46 @@ pub mod json {
     }
     #[cfg(feature = "export-schema")]
     but_schemars::register_sdk_type!(BranchReviewStatus);
+
+    impl From<super::ListedStack> for ListedStack {
+        fn from(value: super::ListedStack) -> Self {
+            Self {
+                status: value.status.into(),
+                branches: value.branches.into_iter().map(Into::into).collect(),
+                updated_at_ms: value.updated_at_ms,
+            }
+        }
+    }
+
+    impl From<super::ListedBranch> for ListedBranch {
+        fn from(value: super::ListedBranch) -> Self {
+            let super::ListedBranch { branch, review } = value;
+            let review_status = review.as_ref().map(|review| {
+                if review.is_merged() {
+                    BranchReviewStatus::Merged
+                } else if review.closed_at.is_some() {
+                    BranchReviewStatus::Closed
+                } else if review.draft {
+                    BranchReviewStatus::Draft
+                } else {
+                    BranchReviewStatus::Open
+                }
+            });
+            Self {
+                ref_name: branch.ref_name.into(),
+                display_name: branch.display_name.to_str_lossy().into_owned(),
+                tip: branch.tip.into(),
+                has_local: branch.has_local,
+                remote_refs: branch.remote_refs.into_iter().map(Into::into).collect(),
+                commit_count: branch.commit_count,
+                commits_ahead_of_target: branch.commits_ahead_of_target,
+                last_author: branch.last_author.map(Into::into),
+                updated_at_ms: branch.updated_at_ms,
+                review: review.as_ref().map(Into::into),
+                review_status,
+            }
+        }
+    }
 
     impl TryFrom<but_workspace::branch::InitialBranchIntegration> for InitialBranchIntegration {
         type Error = anyhow::Error;
@@ -1607,9 +1648,9 @@ pub fn branch_diff(ctx: &Context, branch: String) -> anyhow::Result<TreeChanges>
 /// workspace-related ones. Ahead-counts are relative to the
 /// project's configured target branch, which clients know from the project APIs.
 /// For the listing semantics, see [`but_branches::list()`].
-#[but_api(napi)]
+#[but_api(napi, json::ListedStack)]
 #[instrument(err(Debug))]
-pub fn branch_list(ctx: &Context) -> anyhow::Result<Vec<json::ListedStack>> {
+pub fn branch_list(ctx: &Context) -> anyhow::Result<Vec<ListedStack>> {
     let meta = ctx.meta()?;
     let project_meta = ctx.project_meta()?;
     let _guard = ctx.shared_worktree_access();
@@ -1630,50 +1671,40 @@ pub fn branch_list(ctx: &Context) -> anyhow::Result<Vec<json::ListedStack>> {
     Ok(listing
         .stacks
         .into_iter()
-        .map(|stack| json::ListedStack {
-            status: stack.status.into(),
+        .map(|stack| ListedStack {
+            status: stack.status,
             updated_at_ms: stack.updated_at_ms,
             branches: stack
                 .branches
                 .into_iter()
-                .map(|branch| listed_branch_json(branch, &mut reviews_by_head))
+                .map(|branch| {
+                    let review =
+                        reviews_by_head.remove(branch.display_name.to_str_lossy().as_ref());
+                    ListedBranch { branch, review }
+                })
                 .collect(),
         })
         .collect())
 }
 
-/// Convert one listed branch to its transport form, joining the cached review that
-/// belongs to it. Reviews are cached under the pushed short branch name.
-fn listed_branch_json(
-    branch: but_branches::ListedBranch,
-    reviews_by_head: &mut std::collections::HashMap<String, but_forge::ForgeReview>,
-) -> json::ListedBranch {
-    let display_name = branch.display_name.to_str_lossy().into_owned();
-    let review = reviews_by_head.remove(&display_name);
-    let review_status = review.as_ref().map(|review| {
-        if review.is_merged() {
-            json::BranchReviewStatus::Merged
-        } else if review.closed_at.is_some() {
-            json::BranchReviewStatus::Closed
-        } else if review.draft {
-            json::BranchReviewStatus::Draft
-        } else {
-            json::BranchReviewStatus::Open
-        }
-    });
-    json::ListedBranch {
-        ref_name: branch.ref_name.into(),
-        display_name,
-        tip: branch.tip.into(),
-        has_local: branch.has_local,
-        remote_refs: branch.remote_refs.into_iter().map(Into::into).collect(),
-        commit_count: branch.commit_count,
-        commits_ahead_of_target: branch.commits_ahead_of_target,
-        last_author: branch.last_author.map(Into::into),
-        updated_at_ms: branch.updated_at_ms,
-        review: review.as_ref().map(Into::into),
-        review_status,
-    }
+/// A listed stack enriched with cached forge review data.
+#[derive(Debug)]
+pub struct ListedStack {
+    /// How the stack relates to the workspace.
+    pub status: but_branches::ListedStackStatus,
+    /// The branches in the stack, from tip to base.
+    pub branches: Vec<ListedBranch>,
+    /// The committer timestamp of the newest branch tip.
+    pub updated_at_ms: Option<i64>,
+}
+
+/// A listed branch and its cached forge review, if present.
+#[derive(Debug)]
+pub struct ListedBranch {
+    /// The branch listing data.
+    pub branch: but_branches::ListedBranch,
+    /// The cached review associated with the branch.
+    pub review: Option<but_forge::ForgeReview>,
 }
 
 /// Get the initial upstream integration script for `branch`.

--- a/crates/but-api/tests/api/branch_list.rs
+++ b/crates/but-api/tests/api/branch_list.rs
@@ -1,7 +1,8 @@
 //! Tests for [`but_api::branch::branch_list()`].
 
-use but_api::branch::json::{BranchReviewStatus, ListedStackStatus};
+use but_branches::ListedStackStatus;
 use but_forge::ForgeReview;
+use gix::bstr::ByteSlice;
 
 use crate::support::{repo_with_feature_branch, set_project_target_to_feature};
 
@@ -52,7 +53,13 @@ fn groups_classifies_and_enriches_from_cache() -> anyhow::Result<()> {
                 stack
                     .branches
                     .iter()
-                    .map(|branch| branch.display_name.as_str())
+                    .map(|branch| {
+                        branch
+                            .branch
+                            .display_name
+                            .to_str()
+                            .expect("fixture branch names are valid UTF-8")
+                    })
                     .collect(),
             )
         })
@@ -65,9 +72,9 @@ fn groups_classifies_and_enriches_from_cache() -> anyhow::Result<()> {
     );
 
     let feature = &stacks[0].branches[0];
-    assert!(feature.has_local, "feature exists as a local branch");
+    assert!(feature.branch.has_local, "feature exists as a local branch");
     assert_eq!(
-        feature.commit_count,
+        feature.branch.commit_count,
         Some(0),
         "feature sits on the target commit and contributes nothing on top"
     );
@@ -86,8 +93,8 @@ fn groups_classifies_and_enriches_from_cache() -> anyhow::Result<()> {
         "the listing carries what it takes to display and open the review"
     );
     assert!(
-        matches!(feature.review_status, Some(BranchReviewStatus::Open)),
-        "the server-derived review status matches the open review"
+        !review.draft && review.closed_at.is_none() && !review.is_merged(),
+        "the cached review is open"
     );
 
     let main = &stacks[1].branches[0];
@@ -96,7 +103,7 @@ fn groups_classifies_and_enriches_from_cache() -> anyhow::Result<()> {
         "no cached review exists for the main branch"
     );
     assert_eq!(
-        main.commits_ahead_of_target,
+        main.branch.commits_ahead_of_target,
         Some(1),
         "main has one commit on top of the target"
     );

--- a/crates/but-branches/src/lib.rs
+++ b/crates/but-branches/src/lib.rs
@@ -240,7 +240,8 @@ pub fn list(
 /// A local or remote branch ref resolved to its tip.
 struct BranchRef {
     ref_name: FullName,
-    /// The remote this ref belongs to, if it is a remote-tracking ref.
+    /// The symbolic name of the remote this ref belongs to, if it is a remote-tracking ref,
+    /// as extracted from the ref itself.
     remote: Option<String>,
     /// The branch name without ref prefix or remote name.
     identity: BString,
@@ -594,14 +595,20 @@ fn listed_stack(status: ListedStackStatus, branches: Vec<ListedBranch>) -> Liste
 /// GitButler-internal branches that are never interesting to users.
 fn is_technical_branch(identity: &BString) -> bool {
     const TECHNICAL_IDENTITIES: &[&[u8]] = &[
-        b"gitbutler/edit",
-        b"gitbutler/workspace",
-        b"gitbutler/integration",
-        b"gitbutler/target",
-        b"gitbutler/oplog",
         b"HEAD",
+        b"gitbutler/edit",
+        b"gitbutler/integration",
+        b"gitbutler/oplog",
+        b"gitbutler/target",
+        b"gitbutler/workspace",
     ];
-    TECHNICAL_IDENTITIES.contains(&identity.as_bytes())
+    debug_assert!(
+        TECHNICAL_IDENTITIES.is_sorted(),
+        "binary search requires sorted technical identities"
+    );
+    TECHNICAL_IDENTITIES
+        .binary_search(&identity.as_bytes())
+        .is_ok()
         || identity.starts_with(b"gitbutler/rename-backup/")
 }
 

--- a/crates/but-debug/src/args.rs
+++ b/crates/but-debug/src/args.rs
@@ -56,6 +56,8 @@ pub struct ApiArgs {
 /// The `but-api` entry points exposed by `but-debug`.
 #[derive(Debug, clap::Subcommand)]
 pub enum ApiSubcommands {
+    /// List branches through `but_api::branch::branch_list`.
+    BranchList,
     /// Unapply a stack through `but_api::legacy::virtual_branches::unapply_stack`.
     #[command(name = "unapply-stack", visible_alias = "unapply")]
     UnapplyStack(ApiUnapplyStackArgs),

--- a/crates/but-debug/src/command/api.rs
+++ b/crates/but-debug/src/command/api.rs
@@ -16,8 +16,16 @@ pub(crate) fn run(
     err: &mut dyn io::Write,
 ) -> Result<()> {
     match &api_args.cmd {
+        ApiSubcommands::BranchList => branch_list(args, out),
         ApiSubcommands::UnapplyStack(unapply_args) => unapply_stack(args, unapply_args, out, err),
     }
+}
+
+fn branch_list(args: &Args, out: &mut dyn io::Write) -> Result<()> {
+    let ctx = discover_context(args)?;
+    let branches = but_api::branch::branch_list(&ctx)?;
+    writeln!(out, "{branches:#?}")?;
+    Ok(())
 }
 
 fn unapply_stack(

--- a/crates/but-graph/src/init/mod.rs
+++ b/crates/but-graph/src/init/mod.rs
@@ -821,6 +821,12 @@ impl Graph {
         )
     }
 
+    #[instrument(
+        name = "Graph::traverse_tips_with_overlay",
+        level = "trace",
+        skip_all,
+        err(Debug)
+    )]
     fn traverse_tips_with_overlay<T: RefMetadata>(
         repo: &OverlayRepo<'_>,
         tips: Vec<Tip>,


### PR DESCRIPTION
Some changes I made when taking a rough look at the target PR.

### Tasks

* [x] `but-debug api branch-list`
* [x] use macro for transformation

### Performance Notes

Not as optimal as I would have hoped. Turns out that with ~27k branches, there is a hotspot in the graph traversal, which would be expected to finish in about 1.5s at most for 650k commits with commit-graph cache.

<img width="913" height="334" alt="Screenshot 2026-07-24 at 09 23 09" src="https://github.com/user-attachments/assets/1e2e4a6e-58a2-4e7b-a65e-7416c92f8db4" />

While optimisations are possible, these are defered as the segmentation is going to be removed one way or another.


### Review notes

I found two correctness issues: direct read of `meta`, and the notion of `identity` which was incorrect in the previous implementation as well, but then again, nobody complained.

With that said, perfect doesn't have to be the enemy of the good, and I think it works well enough for now. It also has the benefit of supporting multiple remotes per ref (I think), whereas the graph would currently only keep a local tracking ref linked up to one remote tracking ref (but there could be multiple).