### PR TITLE
feat(but/tui): add ability to override builtin programs and set extensions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1017,6 +1017,7 @@ dependencies = [
  "itertools",
  "napi",
  "napi-derive",
+ "nonempty",
  "objc2-app-kit",
  "objc2-foundation",
  "open",

--- a/crates/but-api/Cargo.toml
+++ b/crates/but-api/Cargo.toml
@@ -147,6 +147,7 @@ gix = { workspace = true, features = ["worktree-mutation"] }
 open.workspace = true
 url.workspace = true
 which = "8.0.2"
+nonempty.workspace = true
 but-schemars.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/crates/but-api/src/open/mod.rs
+++ b/crates/but-api/src/open/mod.rs
@@ -659,10 +659,10 @@ fn list_user_defined_program_specs() -> Vec<ProgramSpec> {
     let content = match std::fs::read_to_string(&user_defined_programs_file) {
         Ok(content) => content,
         Err(err) => {
-            tracing::warn!(
+            tracing::info!(
                 ?err,
                 ?user_defined_programs_file,
-                "Failed to read from user-defined programs file"
+                "Failed to read from user-defined programs file, probably does not exist"
             );
             return vec![];
         }

--- a/crates/but-api/src/open/mod.rs
+++ b/crates/but-api/src/open/mod.rs
@@ -646,15 +646,10 @@ pub fn list_editors() -> anyhow::Result<Vec<Editor>> {
         .collect())
 }
 
-/// List all built-in supported programs.
-pub fn list_builtin_program_specs() -> &'static [ProgramSpec] {
-    PROGRAMS.as_slice()
-}
-
 /// List all user-defined programs.
 ///
 /// This function never fails, it only logs errors as warnings if something goes wrong.
-pub fn list_user_defined_program_specs() -> Vec<ProgramSpec> {
+fn list_user_defined_program_specs() -> Vec<ProgramSpec> {
     let Ok(user_defined_programs_file) =
         but_path::app_config_dir().map(|dir| dir.join(USER_DEFINED_PROGRAMS_FILENAME))
     else {
@@ -664,7 +659,7 @@ pub fn list_user_defined_program_specs() -> Vec<ProgramSpec> {
     let content = match std::fs::read_to_string(&user_defined_programs_file) {
         Ok(content) => content,
         Err(err) => {
-            tracing::debug!(
+            tracing::warn!(
                 ?err,
                 ?user_defined_programs_file,
                 "Failed to read from user-defined programs file"
@@ -684,8 +679,30 @@ pub fn list_user_defined_program_specs() -> Vec<ProgramSpec> {
 
     user_defined_program_specs
         .into_iter()
-        .map(Into::into)
+        .filter_map(|spec| match spec.try_into_program_spec() {
+            Ok(spec) => Some(spec),
+            Err(err) => {
+                tracing::warn!(?err, "Failed to decode user defined program specification");
+                None
+            }
+        })
         .collect()
+}
+
+/// List all program specifications.
+pub fn list_program_specs() -> Vec<ProgramSpec> {
+    let mut specs = list_user_defined_program_specs();
+
+    for builtin in PROGRAMS.iter() {
+        if !specs
+            .iter()
+            .any(|user_defined| user_defined.id == builtin.id)
+        {
+            specs.push(builtin.clone());
+        }
+    }
+
+    specs
 }
 
 /// Open `path` within the given project's workdir using the editor specified by `editor_id`.

--- a/crates/but-api/src/open/mod.rs
+++ b/crates/but-api/src/open/mod.rs
@@ -1,12 +1,14 @@
 //! In place of commands.rs
-use std::env;
+use std::{env, ffi::OsStr};
 
 use anyhow::{Context as _, Result, bail};
 use but_api_macros::but_api;
 use but_error::bail_precondition;
+use std::path::Path;
 use tracing::instrument;
 use url::Url;
 
+use crate::open::program::FILE_EXTENSION_WILDCARD;
 use crate::open::{
     program::{
         Editor, OpenSpec, PROGRAMS, ProgramSpec, USER_DEFINED_PROGRAMS_FILENAME,
@@ -509,8 +511,6 @@ pub fn open_in_terminal(terminal_id: String, path: String) -> Result<()> {
             cmd
         }
 
-        use std::path::Path;
-
         // Validate path exists and canonicalize it to proper Windows format
         let path_buf = Path::new(&path);
         if !path_buf.exists() {
@@ -703,6 +703,37 @@ pub fn list_program_specs() -> Vec<ProgramSpec> {
     }
 
     specs
+}
+
+/// List all programs that are suitable to use to open the file based on the file extension, or all
+/// programs if no specific ones are found.
+pub fn list_program_specs_for_file(path: &Path) -> Vec<ProgramSpec> {
+    let all_specs = list_program_specs();
+
+    let Some(ext) = path.extension().and_then(OsStr::to_str) else {
+        return all_specs;
+    };
+
+    let mut exact_extension_matches = vec![];
+    let mut wildcard_extension_matches = vec![];
+
+    for spec in &all_specs {
+        if let Some(extensions) = &spec.extensions {
+            if extensions.iter().any(|v| v == ext) {
+                exact_extension_matches.push(spec.clone());
+            } else if extensions.iter().any(|v| v == FILE_EXTENSION_WILDCARD) {
+                wildcard_extension_matches.push(spec.clone());
+            }
+        }
+    }
+
+    if !exact_extension_matches.is_empty() {
+        exact_extension_matches
+    } else if !wildcard_extension_matches.is_empty() {
+        wildcard_extension_matches
+    } else {
+        all_specs
+    }
 }
 
 /// Open `path` within the given project's workdir using the editor specified by `editor_id`.

--- a/crates/but-api/src/open/mod.rs
+++ b/crates/but-api/src/open/mod.rs
@@ -638,9 +638,8 @@ pub fn show_in_finder(path: String) -> Result<()> {
 #[but_api(napi)]
 #[instrument(err(Debug))]
 pub fn list_editors() -> anyhow::Result<Vec<Editor>> {
-    Ok(list_user_defined_program_specs()
+    Ok(list_program_specs()
         .iter()
-        .chain(PROGRAMS.iter())
         .filter(|p| p.is_gui_editor())
         .map(Into::into)
         .collect())

--- a/crates/but-api/src/open/mod.rs
+++ b/crates/but-api/src/open/mod.rs
@@ -709,17 +709,16 @@ pub fn list_program_specs() -> Vec<ProgramSpec> {
 /// programs if no specific ones are found.
 pub fn list_program_specs_for_file(path: &Path) -> Vec<ProgramSpec> {
     let all_specs = list_program_specs();
-
-    let Some(ext) = path.extension().and_then(OsStr::to_str) else {
-        return all_specs;
-    };
+    let ext = path.extension().and_then(OsStr::to_str);
 
     let mut exact_extension_matches = vec![];
     let mut wildcard_extension_matches = vec![];
 
     for spec in &all_specs {
         if let Some(extensions) = &spec.extensions {
-            if extensions.iter().any(|v| v == ext) {
+            if let Some(ext) = ext
+                && extensions.iter().any(|v| v == ext)
+            {
                 exact_extension_matches.push(spec.clone());
             } else if extensions.iter().any(|v| v == FILE_EXTENSION_WILDCARD) {
                 wildcard_extension_matches.push(spec.clone());

--- a/crates/but-api/src/open/program.rs
+++ b/crates/but-api/src/open/program.rs
@@ -7,6 +7,7 @@ use std::{
 
 use crate::open::spawn::spawn_and_reap;
 
+use nonempty::NonEmpty;
 use serde::{Deserialize, Serialize};
 
 /// Name of the user-defined programs file
@@ -197,7 +198,7 @@ impl CliArgumentSupplier {
     }
 
     /// Add argument(s) to `cmd` to open all files.
-    fn open_many<'a, P: AsRef<Path>>(&self, cmd: &'a mut Command, paths: &[P]) -> &'a mut Command {
+    fn open_many<'a, P: AsRef<Path>>(&self, cmd: &'a mut Command, paths: &NonEmpty<P>) -> &'a mut Command {
         match self {
             Self::Custom(custom) => custom.open_many(cmd, paths),
             _ => {
@@ -267,7 +268,7 @@ impl CustomCliArgumentSupplier {
         cmd
     }
 
-    fn open_many<'a, P: AsRef<Path>>(&self, cmd: &'a mut Command, paths: &[P]) -> &'a mut Command {
+    fn open_many<'a, P: AsRef<Path>>(&self, cmd: &'a mut Command, paths: &NonEmpty<P>) -> &'a mut Command {
         let Some(open_args) = &self.open_args else {
             return CliArgumentSupplier::Default.open_many(cmd, paths);
         };
@@ -450,7 +451,7 @@ pub enum OpenSpec {
     /// A single file.
     File(PathBuf),
     /// Multiple files.
-    Files(Vec<PathBuf>),
+    Files(NonEmpty<PathBuf>),
     /// A single file at a specific line.
     FileAtLine(PathBuf, u32),
 }

--- a/crates/but-api/src/open/program.rs
+++ b/crates/but-api/src/open/program.rs
@@ -198,7 +198,11 @@ impl CliArgumentSupplier {
     }
 
     /// Add argument(s) to `cmd` to open all files.
-    fn open_many<'a, P: AsRef<Path>>(&self, cmd: &'a mut Command, paths: &NonEmpty<P>) -> &'a mut Command {
+    fn open_many<'a, P: AsRef<Path>>(
+        &self,
+        cmd: &'a mut Command,
+        paths: &NonEmpty<P>,
+    ) -> &'a mut Command {
         match self {
             Self::Custom(custom) => custom.open_many(cmd, paths),
             _ => {
@@ -268,7 +272,11 @@ impl CustomCliArgumentSupplier {
         cmd
     }
 
-    fn open_many<'a, P: AsRef<Path>>(&self, cmd: &'a mut Command, paths: &NonEmpty<P>) -> &'a mut Command {
+    fn open_many<'a, P: AsRef<Path>>(
+        &self,
+        cmd: &'a mut Command,
+        paths: &NonEmpty<P>,
+    ) -> &'a mut Command {
         let Some(open_args) = &self.open_args else {
             return CliArgumentSupplier::Default.open_many(cmd, paths);
         };

--- a/crates/but-api/src/open/program.rs
+++ b/crates/but-api/src/open/program.rs
@@ -19,8 +19,9 @@ pub const FILEPATH_PLACEHOLDER: &str = "{{filepath}}";
 pub const LINE_NUMBER_PLACEHOLDER: &str = "{{line_number}}";
 
 /// Program category to classify an openable program.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Default)]
 pub enum ProgramCategory {
+    #[default]
     /// A text editor/IDE.
     Editor,
     /// A file manager such as Finder, Explorer or Thunar.
@@ -69,21 +70,6 @@ impl ProgramSpec {
             ExecutableProgram::PathExecutable(PathExecutable { requires_tty, .. }) => *requires_tty,
             #[cfg(target_os = "macos")]
             ExecutableProgram::MacosApplication(_) => false,
-        }
-    }
-}
-
-impl From<UserDefinedProgramSpec> for ProgramSpec {
-    fn from(value: UserDefinedProgramSpec) -> Self {
-        ProgramSpec {
-            id: value.id.unwrap_or_else(|| value.name.clone()),
-            name: value.name,
-            cli_arg_supplier: CliArgumentSupplier::Custom(CustomCliArgumentSupplier {
-                open_args: value.open_args,
-                open_at_line_args: value.open_at_line_args,
-            }),
-            executable: value.executable.into(),
-            category: value.category.into(),
         }
     }
 }
@@ -605,11 +591,11 @@ pub struct UserDefinedProgramSpec {
     /// If left empty, the ID is derived from [`Self::name`] instead.
     pub id: Option<String>,
     /// The display name of the program.
-    pub name: String,
+    pub name: Option<String>,
     /// The exuctable to invoke to start the program.
-    pub executable: UserDefinedExecutableProgram,
+    pub executable: Option<UserDefinedExecutableProgram>,
     /// The kind of the program.
-    pub category: UserDefinedProgramCategory,
+    pub category: Option<UserDefinedProgramCategory>,
     /// Arguments to pass to the executable when invoked to open a file.
     ///
     /// Recognized placeholders:
@@ -623,6 +609,59 @@ pub struct UserDefinedProgramSpec {
     /// * [`FILEPATH_PLACEHOLDER`] is substituted for the filepath
     /// * [`LINE_NUMBER_PLACEHOLDER`] is substituted for the line number
     pub open_at_line_args: Option<Vec<String>>,
+}
+
+impl UserDefinedProgramSpec {
+    /// Try to transform this specification into a valid [`ProgramSpec`].
+    pub fn try_into_program_spec(self) -> anyhow::Result<ProgramSpec> {
+        let (name, id) = match (self.name, self.id) {
+            (Some(name), Some(id)) => (name, id),
+            (Some(name), None) => (name.clone(), name),
+            (None, Some(id)) => (id.clone(), id),
+            (None, None) => anyhow::bail!("id or name must be specified"),
+        };
+
+        if let Some(builtin) = PROGRAMS.iter().find(|p| p.id == id) {
+            // This is an override for a builtin - merge!
+            let cli_arg_supplier = if self.open_args.is_some() || self.open_at_line_args.is_some() {
+                CliArgumentSupplier::Custom(CustomCliArgumentSupplier {
+                    open_args: self.open_args,
+                    open_at_line_args: self.open_at_line_args,
+                })
+            } else {
+                builtin.cli_arg_supplier.clone()
+            };
+
+            Ok(ProgramSpec {
+                id,
+                name,
+                executable: self
+                    .executable
+                    .map(Into::into)
+                    .unwrap_or_else(|| builtin.executable.clone()),
+                category: self
+                    .category
+                    .map(Into::into)
+                    .unwrap_or_else(|| builtin.category.clone()),
+                cli_arg_supplier,
+            })
+        } else {
+            let Some(executable) = self.executable else {
+                anyhow::bail!("executable must be specified for non built-ins")
+            };
+
+            Ok(ProgramSpec {
+                id,
+                name,
+                executable: executable.into(),
+                category: self.category.map(Into::into).unwrap_or_default(),
+                cli_arg_supplier: CliArgumentSupplier::Custom(CustomCliArgumentSupplier {
+                    open_args: self.open_args,
+                    open_at_line_args: self.open_at_line_args,
+                }),
+            })
+        }
+    }
 }
 
 /// The executable to invoke for a program.
@@ -672,10 +711,11 @@ pub struct UserDefinedMacosApplication {
     pub cli_wrapper_path: Option<String>,
 }
 
-#[cfg(all(test, target_os = "macos"))]
+#[cfg(test)]
 mod tests {
     use super::*;
 
+    #[cfg(target_os = "macos")]
     #[test]
     fn user_defined_macos_application_deserializes_into_program_spec() {
         let spec: UserDefinedProgramSpec = serde_json::from_str(
@@ -691,7 +731,7 @@ mod tests {
         )
         .expect("macOS application should deserialize");
 
-        let spec: ProgramSpec = spec.into();
+        let spec: ProgramSpec = spec.try_into_program_spec().unwrap();
         assert_eq!(
             spec,
             ProgramSpec {
@@ -709,5 +749,56 @@ mod tests {
             },
             "JSON should convert to expected internal program specification"
         );
+    }
+
+    #[test]
+    fn user_defined_override_for_builtin_executable_merges_with_builtin() {
+        let echo_override_spec: UserDefinedProgramSpec = serde_json::from_str(
+            r#"{
+                "id": "echo",
+                "executable": {
+                    "type": "pathExecutable",
+                    "nameOrPath": "/overridden/path",
+                    "requiresTerminal": false
+                }
+            }"#,
+        )
+        .expect("must deserialize");
+
+        let builtin_echo = PROGRAMS.iter().find(|p| p.id == "echo").unwrap();
+
+        let spec: ProgramSpec = echo_override_spec.try_into_program_spec().unwrap();
+        assert_eq!(
+            spec,
+            ProgramSpec {
+                executable: ExecutableProgram::PathExecutable(PathExecutable {
+                    name_or_path: "/overridden/path".into(),
+                    requires_tty: false
+                }),
+                ..builtin_echo.clone()
+            }
+        )
+    }
+
+    #[test]
+    fn user_defined_override_for_builtin_category_merges_with_builtin() {
+        let echo_override_spec: UserDefinedProgramSpec = serde_json::from_str(
+            r#"{
+                "id": "echo",
+                "category": "fileManager"
+            }"#,
+        )
+        .expect("must deserialize");
+
+        let builtin_echo = PROGRAMS.iter().find(|p| p.id == "echo").unwrap();
+
+        let spec: ProgramSpec = echo_override_spec.try_into_program_spec().unwrap();
+        assert_eq!(
+            spec,
+            ProgramSpec {
+                category: ProgramCategory::FileManager,
+                ..builtin_echo.clone()
+            }
+        )
     }
 }

--- a/crates/but-api/src/open/program.rs
+++ b/crates/but-api/src/open/program.rs
@@ -639,13 +639,6 @@ pub struct UserDefinedProgramSpec {
 impl UserDefinedProgramSpec {
     /// Try to transform this specification into a valid [`ProgramSpec`].
     pub fn try_into_program_spec(self) -> anyhow::Result<ProgramSpec> {
-        let (name, id) = match (self.name, self.id) {
-            (Some(name), Some(id)) => (name, id),
-            (Some(name), None) => (name.clone(), name),
-            (None, Some(id)) => (id.clone(), id),
-            (None, None) => anyhow::bail!("id or name must be specified"),
-        };
-
         let extensions = self.extensions.map(|extensions| {
             extensions
                 .into_iter()
@@ -653,7 +646,9 @@ impl UserDefinedProgramSpec {
                 .collect()
         });
 
-        if let Some(builtin) = PROGRAMS.iter().find(|p| p.id == id) {
+        if let Some(id) = &self.id
+            && let Some(builtin) = PROGRAMS.iter().find(|p| &p.id == id)
+        {
             // This is an override for a builtin - merge!
             let cli_arg_supplier = if self.open_args.is_some() || self.open_at_line_args.is_some() {
                 CliArgumentSupplier::Custom(CustomCliArgumentSupplier {
@@ -665,8 +660,8 @@ impl UserDefinedProgramSpec {
             };
 
             Ok(ProgramSpec {
-                id,
-                name,
+                id: id.clone(),
+                name: self.name.unwrap_or_else(|| builtin.name.clone()),
                 executable: self
                     .executable
                     .map(Into::into)
@@ -679,6 +674,13 @@ impl UserDefinedProgramSpec {
                 extensions,
             })
         } else {
+            let (name, id) = match (self.name, self.id) {
+                (Some(name), Some(id)) => (name, id),
+                (Some(name), None) => (name.clone(), name),
+                (None, Some(id)) => (id.clone(), id),
+                (None, None) => anyhow::bail!("id or name must be specified"),
+            };
+
             let Some(executable) = self.executable else {
                 anyhow::bail!("executable must be specified for non built-ins")
             };
@@ -788,9 +790,9 @@ mod tests {
 
     #[test]
     fn user_defined_override_for_builtin_executable_merges_with_builtin() {
-        let echo_override_spec: UserDefinedProgramSpec = serde_json::from_str(
+        let vscode_override_spec: UserDefinedProgramSpec = serde_json::from_str(
             r#"{
-                "id": "echo",
+                "id": "vscode",
                 "executable": {
                     "type": "pathExecutable",
                     "nameOrPath": "/overridden/path",
@@ -800,9 +802,9 @@ mod tests {
         )
         .expect("must deserialize");
 
-        let builtin_echo = PROGRAMS.iter().find(|p| p.id == "echo").unwrap();
+        let builtin_vscode = PROGRAMS.iter().find(|p| p.id == "vscode").unwrap();
 
-        let spec: ProgramSpec = echo_override_spec.try_into_program_spec().unwrap();
+        let spec: ProgramSpec = vscode_override_spec.try_into_program_spec().unwrap();
         assert_eq!(
             spec,
             ProgramSpec {
@@ -810,73 +812,73 @@ mod tests {
                     name_or_path: "/overridden/path".into(),
                     requires_tty: false
                 }),
-                ..builtin_echo.clone()
+                ..builtin_vscode.clone()
             }
         )
     }
 
     #[test]
     fn user_defined_override_for_builtin_category_merges_with_builtin() {
-        let echo_override_spec: UserDefinedProgramSpec = serde_json::from_str(
+        let vscode_override_spec: UserDefinedProgramSpec = serde_json::from_str(
             r#"{
-                "id": "echo",
+                "id": "vscode",
                 "category": "fileManager"
             }"#,
         )
         .expect("must deserialize");
 
-        let builtin_echo = PROGRAMS.iter().find(|p| p.id == "echo").unwrap();
+        let builtin_vscode = PROGRAMS.iter().find(|p| p.id == "vscode").unwrap();
 
-        let spec: ProgramSpec = echo_override_spec.try_into_program_spec().unwrap();
+        let spec: ProgramSpec = vscode_override_spec.try_into_program_spec().unwrap();
         assert_eq!(
             spec,
             ProgramSpec {
                 category: ProgramCategory::FileManager,
-                ..builtin_echo.clone()
+                ..builtin_vscode.clone()
             }
         )
     }
 
     #[test]
     fn user_defined_override_for_builtin_extensions_merges_with_builtin() {
-        let echo_override_spec: UserDefinedProgramSpec = serde_json::from_str(
+        let vscode_override_spec: UserDefinedProgramSpec = serde_json::from_str(
             r#"{
-                "id": "echo",
+                "id": "vscode",
                 "extensions": ["txt"]
             }"#,
         )
         .expect("must deserialize");
 
-        let builtin_echo = PROGRAMS.iter().find(|p| p.id == "echo").unwrap();
+        let builtin_vscode = PROGRAMS.iter().find(|p| p.id == "vscode").unwrap();
 
-        let spec: ProgramSpec = echo_override_spec.try_into_program_spec().unwrap();
+        let spec: ProgramSpec = vscode_override_spec.try_into_program_spec().unwrap();
         assert_eq!(
             spec,
             ProgramSpec {
                 extensions: Some(vec!["txt".into()]),
-                ..builtin_echo.clone()
+                ..builtin_vscode.clone()
             }
         )
     }
 
     #[test]
     fn user_defined_override_for_builtin_extensions_strips_periods_from_extensions() {
-        let echo_override_spec: UserDefinedProgramSpec = serde_json::from_str(
+        let vscode_override_spec: UserDefinedProgramSpec = serde_json::from_str(
             r#"{
-                "id": "echo",
+                "id": "vscode",
                 "extensions": [".txt"]
             }"#,
         )
         .expect("must deserialize");
 
-        let builtin_echo = PROGRAMS.iter().find(|p| p.id == "echo").unwrap();
+        let builtin_vscode = PROGRAMS.iter().find(|p| p.id == "vscode").unwrap();
 
-        let spec: ProgramSpec = echo_override_spec.try_into_program_spec().unwrap();
+        let spec: ProgramSpec = vscode_override_spec.try_into_program_spec().unwrap();
         assert_eq!(
             spec,
             ProgramSpec {
                 extensions: Some(vec!["txt".into()]),
-                ..builtin_echo.clone()
+                ..builtin_vscode.clone()
             }
         )
     }

--- a/crates/but-api/src/open/program.rs
+++ b/crates/but-api/src/open/program.rs
@@ -18,6 +18,9 @@ pub const FILEPATH_PLACEHOLDER: &str = "{{filepath}}";
 /// Placeholder used for line number.
 pub const LINE_NUMBER_PLACEHOLDER: &str = "{{line_number}}";
 
+/// Wildcard used to match any file extension (even the empty one)
+pub const FILE_EXTENSION_WILDCARD: &str = "*";
+
 /// Program category to classify an openable program.
 #[derive(Clone, Debug, PartialEq, Default)]
 pub enum ProgramCategory {
@@ -56,6 +59,8 @@ pub struct ProgramSpec {
     pub executable: ExecutableProgram,
     /// The category of the program.
     pub category: ProgramCategory,
+    /// Associated program extensions.
+    pub extensions: Option<Vec<String>>,
 }
 
 impl ProgramSpec {
@@ -297,6 +302,7 @@ pub(crate) static PROGRAMS: LazyLock<Vec<ProgramSpec>> = LazyLock::new(|| {
                 requires_tty: true,
             }),
             category: ProgramCategory::Editor,
+            extensions: None,
         },
         ProgramSpec {
             id: "cursor".into(),
@@ -317,6 +323,7 @@ pub(crate) static PROGRAMS: LazyLock<Vec<ProgramSpec>> = LazyLock::new(|| {
                 cli_wrapper_path: Some("Contents/Resources/app/bin/cursor".into()),
             }),
             category: ProgramCategory::Editor,
+            extensions: None,
         },
         ProgramSpec {
             id: "sublime".into(),
@@ -336,6 +343,7 @@ pub(crate) static PROGRAMS: LazyLock<Vec<ProgramSpec>> = LazyLock::new(|| {
                 cli_wrapper_path: Some("Contents/SharedSupport/bin/subl".into()),
             }),
             category: ProgramCategory::Editor,
+            extensions: None,
         },
         ProgramSpec {
             id: "vscode".into(),
@@ -355,6 +363,7 @@ pub(crate) static PROGRAMS: LazyLock<Vec<ProgramSpec>> = LazyLock::new(|| {
                 cli_wrapper_path: Some("Contents/Resources/app/bin/code".into()),
             }),
             category: ProgramCategory::Editor,
+            extensions: None,
         },
         #[cfg(all(target_os = "macos", not(debug_assertions)))]
         ProgramSpec {
@@ -366,6 +375,7 @@ pub(crate) static PROGRAMS: LazyLock<Vec<ProgramSpec>> = LazyLock::new(|| {
                 cli_wrapper_path: Some("Contents/Developer/usr/bin/xed".into()),
             }),
             category: ProgramCategory::Editor,
+            extensions: None,
         },
         ProgramSpec {
             id: "zed".into(),
@@ -385,6 +395,7 @@ pub(crate) static PROGRAMS: LazyLock<Vec<ProgramSpec>> = LazyLock::new(|| {
                 cli_wrapper_path: Some("Contents/MacOS/cli".into()),
             }),
             category: ProgramCategory::Editor,
+            extensions: None,
         },
         #[cfg(debug_assertions)]
         ProgramSpec {
@@ -402,6 +413,7 @@ pub(crate) static PROGRAMS: LazyLock<Vec<ProgramSpec>> = LazyLock::new(|| {
                 requires_tty: true,
             }),
             category: ProgramCategory::Test,
+            extensions: None,
         },
         #[cfg(debug_assertions)]
         ProgramSpec {
@@ -416,6 +428,7 @@ pub(crate) static PROGRAMS: LazyLock<Vec<ProgramSpec>> = LazyLock::new(|| {
                 requires_tty: true,
             }),
             category: ProgramCategory::Test,
+            extensions: None,
         },
         #[cfg(all(target_os = "linux", not(debug_assertions)))]
         ProgramSpec {
@@ -427,6 +440,7 @@ pub(crate) static PROGRAMS: LazyLock<Vec<ProgramSpec>> = LazyLock::new(|| {
                 requires_tty: false,
             }),
             category: ProgramCategory::FileManager,
+            extensions: None,
         },
     ])
 });
@@ -609,6 +623,8 @@ pub struct UserDefinedProgramSpec {
     /// * [`FILEPATH_PLACEHOLDER`] is substituted for the filepath
     /// * [`LINE_NUMBER_PLACEHOLDER`] is substituted for the line number
     pub open_at_line_args: Option<Vec<String>>,
+    /// File extensions to associate with this program.
+    pub extensions: Option<Vec<String>>,
 }
 
 impl UserDefinedProgramSpec {
@@ -620,6 +636,13 @@ impl UserDefinedProgramSpec {
             (None, Some(id)) => (id.clone(), id),
             (None, None) => anyhow::bail!("id or name must be specified"),
         };
+
+        let extensions = self.extensions.map(|extensions| {
+            extensions
+                .into_iter()
+                .map(|ext| ext.strip_prefix('.').unwrap_or(&ext).to_owned())
+                .collect()
+        });
 
         if let Some(builtin) = PROGRAMS.iter().find(|p| p.id == id) {
             // This is an override for a builtin - merge!
@@ -644,6 +667,7 @@ impl UserDefinedProgramSpec {
                     .map(Into::into)
                     .unwrap_or_else(|| builtin.category.clone()),
                 cli_arg_supplier,
+                extensions,
             })
         } else {
             let Some(executable) = self.executable else {
@@ -659,6 +683,7 @@ impl UserDefinedProgramSpec {
                     open_args: self.open_args,
                     open_at_line_args: self.open_at_line_args,
                 }),
+                extensions,
             })
         }
     }
@@ -746,6 +771,7 @@ mod tests {
                     cli_wrapper_path: Some("Contents/Resources/app/bin/code".into()),
                 }),
                 category: ProgramCategory::Editor,
+                extensions: None,
             },
             "JSON should convert to expected internal program specification"
         );
@@ -797,6 +823,50 @@ mod tests {
             spec,
             ProgramSpec {
                 category: ProgramCategory::FileManager,
+                ..builtin_echo.clone()
+            }
+        )
+    }
+
+    #[test]
+    fn user_defined_override_for_builtin_extensions_merges_with_builtin() {
+        let echo_override_spec: UserDefinedProgramSpec = serde_json::from_str(
+            r#"{
+                "id": "echo",
+                "extensions": ["txt"]
+            }"#,
+        )
+        .expect("must deserialize");
+
+        let builtin_echo = PROGRAMS.iter().find(|p| p.id == "echo").unwrap();
+
+        let spec: ProgramSpec = echo_override_spec.try_into_program_spec().unwrap();
+        assert_eq!(
+            spec,
+            ProgramSpec {
+                extensions: Some(vec!["txt".into()]),
+                ..builtin_echo.clone()
+            }
+        )
+    }
+
+    #[test]
+    fn user_defined_override_for_builtin_extensions_strips_periods_from_extensions() {
+        let echo_override_spec: UserDefinedProgramSpec = serde_json::from_str(
+            r#"{
+                "id": "echo",
+                "extensions": [".txt"]
+            }"#,
+        )
+        .expect("must deserialize");
+
+        let builtin_echo = PROGRAMS.iter().find(|p| p.id == "echo").unwrap();
+
+        let spec: ProgramSpec = echo_override_spec.try_into_program_spec().unwrap();
+        assert_eq!(
+            spec,
+            ProgramSpec {
+                extensions: Some(vec!["txt".into()]),
                 ..builtin_echo.clone()
             }
         )

--- a/crates/but/src/command/legacy/status/tui/app/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/app/mod.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use bstr::{BStr, ByteSlice};
-use but_api::open::{list_program_specs, program::ProgramSpec};
+use but_api::open::program::ProgramSpec;
 use but_ctx::Context;
 use crossterm::event::Event;
 use gitbutler_operating_modes::OperatingMode;
@@ -413,7 +413,7 @@ impl App {
             Message::CopyToClipboard(text) => {
                 self.clipboard.set_text(text)?;
             }
-            Message::PickProgramThenOpen => self.handle_pick_program_then_open(ctx)?,
+            Message::PickProgramThenOpen => self.handle_pick_program_then_open(ctx, messages)?,
             Message::OpenInProgram(program, to_open) => {
                 self.handle_open_in_program(&program, to_open, terminal_guard, messages)?;
             }
@@ -1330,7 +1330,11 @@ impl App {
         Ok(())
     }
 
-    fn handle_pick_program_then_open(&mut self, ctx: &Context) -> anyhow::Result<()> {
+    fn handle_pick_program_then_open(
+        &mut self,
+        ctx: &Context,
+        messages: &mut Vec<Message>,
+    ) -> anyhow::Result<()> {
         let selection = if matches!(&*self.mode, Mode::Details(..)) {
             self.details.selected_section_cli_id()
         } else {
@@ -1355,12 +1359,17 @@ impl App {
             }
         };
 
-        let mut program_specs = list_program_specs().into_iter();
-        let mut items = NonEmpty::new(
-            program_specs
-                .next()
-                .expect("BUG: Program specs cannot be empty"),
-        );
+        let mut program_specs = open::list_program_specs_for_openable(&to_open).into_iter();
+        let first_program = program_specs
+            .next()
+            .expect("BUG: Program specs cannot be empty");
+        let Some(second_program) = program_specs.next() else {
+            messages.push(Message::OpenInProgram(first_program, to_open));
+            return Ok(());
+        };
+
+        let mut items = NonEmpty::new(first_program);
+        items.push(second_program);
         items.extend(program_specs);
 
         self.modal = Some(Modal::ProgramPicker {

--- a/crates/but/src/command/legacy/status/tui/app/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/app/mod.rs
@@ -6,9 +6,7 @@ use std::{
 };
 
 use bstr::{BStr, ByteSlice};
-use but_api::open::{
-    list_builtin_program_specs, list_user_defined_program_specs, program::ProgramSpec,
-};
+use but_api::open::{list_program_specs, program::ProgramSpec};
 use but_ctx::Context;
 use crossterm::event::Event;
 use gitbutler_operating_modes::OperatingMode;
@@ -1357,19 +1355,13 @@ impl App {
             }
         };
 
-        let builtin_program_specs = list_builtin_program_specs();
-        let user_defined_program_specs = list_user_defined_program_specs();
-        let mut all_program_specs = user_defined_program_specs
-            .iter()
-            .chain(builtin_program_specs)
-            .cloned();
-
+        let mut program_specs = list_program_specs().into_iter();
         let mut items = NonEmpty::new(
-            all_program_specs
+            program_specs
                 .next()
                 .expect("BUG: Program specs cannot be empty"),
         );
-        items.extend(all_program_specs);
+        items.extend(program_specs);
 
         self.modal = Some(Modal::ProgramPicker {
             picker: Box::new(FuzzyPicker::new(

--- a/crates/but/src/command/legacy/status/tui/tests/open_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/open_tests.rs
@@ -1,3 +1,4 @@
+use but_api::open::program::USER_DEFINED_PROGRAMS_FILENAME;
 use but_testsupport::Sandbox;
 use crossterm::event::{KeyCode, KeyModifiers};
 use snapbox::{file, str};
@@ -36,6 +37,85 @@ fn open_uncommitted_file_in_program() {
     tui.input("g");
     tui.input([KeyCode::Down, KeyCode::Down])
         .assert_current_line_eq(str!["┊   wv A open-me.txt.touch"]);
+}
+
+#[test]
+fn open_uncommitted_file_in_program_chooses_program_by_extension_automatically_if_unambiguous() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
+
+    env.file("open-me.txt", "I have new content");
+
+    let mut tui = test_tui(env);
+    tui.input('g');
+    tui.input(KeyCode::Down)
+        .assert_current_line_eq(str!["┊   ps A open-me.txt"]);
+
+    let app_data_dir = tui.env().projects_root();
+    let config_dir = app_data_dir.join("gitbutler");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    std::fs::write(
+        config_dir.join(USER_DEFINED_PROGRAMS_FILENAME),
+        r#"[
+  {
+    "id": "touch",
+    "extensions": ["txt"]
+  }
+]"#,
+    )
+    .unwrap();
+
+    let app_data_dir = app_data_dir.display().to_string();
+    with_var("E2E_TEST_APP_DATA_DIR", Some(app_data_dir), || {
+        tui.input('o').assert_rendered_term_svg_eq(file![
+            "snapshots/open_uncommitted_file_in_program_chooses_program_by_extension_automatically_if_unambiguous_001.svg"
+        ]);
+        tui.reload().assert_rendered_term_svg_eq(file![
+            "snapshots/open_uncommitted_file_in_program_chooses_program_by_extension_automatically_if_unambiguous_002.svg"
+        ]);
+    });
+
+    tui.input("g");
+    tui.input([KeyCode::Down, KeyCode::Down])
+        .assert_current_line_eq(str!["┊   ps A open-me.txt"]);
+}
+
+#[test]
+fn open_uncommitted_file_in_program_shows_only_programs_that_match_extension() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
+
+    env.file("open-me.txt", "I have new content");
+
+    let mut tui = test_tui(env);
+    tui.input('g');
+    tui.input(KeyCode::Down)
+        .assert_current_line_eq(str!["┊   ps A open-me.txt"]);
+
+    let app_data_dir = tui.env().projects_root();
+    let config_dir = app_data_dir.join("gitbutler");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    std::fs::write(
+        config_dir.join(USER_DEFINED_PROGRAMS_FILENAME),
+        r#"[
+  {
+    "id": "touch",
+    "extensions": ["txt"]
+  },
+  {
+    "id": "echo",
+    "extensions": ["txt"]
+  }
+]"#,
+    )
+    .unwrap();
+
+    let app_data_dir = app_data_dir.display().to_string();
+    with_var("E2E_TEST_APP_DATA_DIR", Some(app_data_dir), || {
+        tui.input('o').assert_rendered_term_svg_eq(file![
+            "snapshots/open_uncommitted_file_in_program_shows_only_programs_that_match_extension.svg"
+        ]);
+    });
 }
 
 #[test]

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/open_uncommitted_file_in_program_chooses_program_by_extension_automatically_if_unambiguous_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/open_uncommitted_file_in_program_chooses_program_by_extension_automatically_if_unambiguous_001.svg
@@ -1,0 +1,63 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="380" viewBox="0 0 820 380">
+  <rect x="0" y="0" width="820" height="380" fill="#000000" />
+  <rect x="10" y="28" width="800" height="18" fill="#45475A" />
+  <rect x="10" y="352" width="80" height="18" fill="#555555" />
+  <g font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">
+    <text x="10 18" y="24" style="fill:#CCCCCC;">╭┄</text>
+    <text x="34 42" y="24" style="fill:#0000AA;font-weight:bold;">zz</text>
+    <text x="58" y="24" style="fill:#CCCCCC;">[</text>
+    <text x="66 74 82 90 98 106 114 122 130 138 146" y="24" style="fill:#00AAAA;">uncommitted</text>
+    <text x="154" y="24" style="fill:#CCCCCC;">]</text>
+    <text x="10" y="42" style="fill:#FFFFFF;font-weight:bold;">┊</text>
+    <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">ps</text>
+    <text x="66" y="42" style="fill:#FFFFFF;font-weight:bold;">A</text>
+    <text x="82 90 98 106 114 122 130 138 146 154 162" y="42" style="fill:#00AA00;font-weight:bold;">open-me.txt</text>
+    <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
+    <text x="10 18 26" y="78" style="fill:#CCCCCC;">┊╭┄</text>
+    <text x="42 50" y="78" style="fill:#0000AA;font-weight:bold;">g0</text>
+    <text x="66" y="78" style="fill:#CCCCCC;">[</text>
+    <text x="74" y="78" style="fill:#00AA00;">A</text>
+    <text x="82" y="78" style="fill:#CCCCCC;">]</text>
+    <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
+    <text x="50" y="96" style="fill:#AA00AA;">t</text>
+    <text x="58 66" y="96" style="fill:#CCCCCC;opacity:0.75;">pm</text>
+    <text x="82 90 98" y="96" style="fill:#CCCCCC;">add</text>
+    <text x="114" y="96" style="fill:#CCCCCC;">A</text>
+    <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
+    <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
+    <text x="10" y="150" style="fill:#CCCCCC;">┴</text>
+    <text x="26 34 42 50 58 66 74" y="150" style="fill:#CCCCCC;opacity:0.75;">0dc3733</text>
+    <text x="90 98 106 114 122 130 138" y="150" style="fill:#CCCCCC;">(common</text>
+    <text x="154 162 170 178 186" y="150" style="fill:#CCCCCC;">base)</text>
+    <text x="202 210 218 226 234 242 250 258 266 274" y="150" style="fill:#CCCCCC;opacity:0.75;">2000-01-02</text>
+    <text x="290 298 306" y="150" style="fill:#CCCCCC;">add</text>
+    <text x="322" y="150" style="fill:#CCCCCC;">M</text>
+    <text x="26 34 42 50 58 66" y="366" style="fill:#FFFFFF;">normal</text>
+    <text x="98 106 114" y="366" style="fill:#0000AA;">↑/k</text>
+    <text x="130 138" y="366" style="fill:#CCCCCC;opacity:0.75;">up</text>
+    <text x="154" y="366" style="fill:#CCCCCC;opacity:0.75;">•</text>
+    <text x="170 178 186" y="366" style="fill:#0000AA;">↓/j</text>
+    <text x="202 210 218 226" y="366" style="fill:#CCCCCC;opacity:0.75;">down</text>
+    <text x="242" y="366" style="fill:#CCCCCC;opacity:0.75;">•</text>
+    <text x="258" y="366" style="fill:#0000AA;">r</text>
+    <text x="274 282 290 298 306 314" y="366" style="fill:#CCCCCC;opacity:0.75;">squash</text>
+    <text x="330" y="366" style="fill:#CCCCCC;opacity:0.75;">•</text>
+    <text x="346" y="366" style="fill:#0000AA;">c</text>
+    <text x="362 370 378 386 394 402" y="366" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="418" y="366" style="fill:#CCCCCC;opacity:0.75;">•</text>
+    <text x="434" y="366" style="fill:#0000AA;">m</text>
+    <text x="450 458 466 474" y="366" style="fill:#CCCCCC;opacity:0.75;">move</text>
+    <text x="490" y="366" style="fill:#CCCCCC;opacity:0.75;">•</text>
+    <text x="506" y="366" style="fill:#0000AA;">b</text>
+    <text x="522 530 538 546 554 562" y="366" style="fill:#CCCCCC;opacity:0.75;">branch</text>
+    <text x="578" y="366" style="fill:#CCCCCC;opacity:0.75;">•</text>
+    <text x="594" y="366" style="fill:#0000AA;">s</text>
+    <text x="610 618 626 634 642" y="366" style="fill:#CCCCCC;opacity:0.75;">stack</text>
+    <text x="658" y="366" style="fill:#CCCCCC;opacity:0.75;">•</text>
+    <text x="674" y="366" style="fill:#0000AA;">?</text>
+    <text x="690 698 706 714" y="366" style="fill:#CCCCCC;opacity:0.75;">help</text>
+    <text x="730" y="366" style="fill:#CCCCCC;opacity:0.75;">•</text>
+    <text x="746" y="366" style="fill:#0000AA;">q</text>
+    <text x="762 770 778 786" y="366" style="fill:#CCCCCC;opacity:0.75;">quit</text>
+  </g>
+</svg>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/open_uncommitted_file_in_program_chooses_program_by_extension_automatically_if_unambiguous_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/open_uncommitted_file_in_program_chooses_program_by_extension_automatically_if_unambiguous_002.svg
@@ -1,0 +1,71 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="380" viewBox="0 0 820 380">
+  <rect x="0" y="0" width="820" height="380" fill="#000000" />
+  <rect x="10" y="46" width="800" height="18" fill="#45475A" />
+  <rect x="10" y="352" width="80" height="18" fill="#555555" />
+  <g font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">
+    <text x="10 18" y="24" style="fill:#CCCCCC;">╭┄</text>
+    <text x="34 42" y="24" style="fill:#0000AA;font-weight:bold;">zz</text>
+    <text x="58" y="24" style="fill:#CCCCCC;">[</text>
+    <text x="66 74 82 90 98 106 114 122 130 138 146" y="24" style="fill:#00AAAA;">uncommitted</text>
+    <text x="154" y="24" style="fill:#CCCCCC;">]</text>
+    <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
+    <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">xy</text>
+    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
+    <text x="82 90 98 106 114 122 130 138 146 154 162 170 178 186 194 202 210 218 226 234 242 250 258" y="42" style="fill:#00AA00;">gitbutler/programs.json</text>
+    <text x="10" y="60" style="fill:#FFFFFF;font-weight:bold;">┊</text>
+    <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;">ps</text>
+    <text x="66" y="60" style="fill:#FFFFFF;font-weight:bold;">A</text>
+    <text x="82 90 98 106 114 122 130 138 146 154 162" y="60" style="fill:#00AA00;font-weight:bold;">open-me.txt</text>
+    <text x="10" y="78" style="fill:#CCCCCC;">┊</text>
+    <text x="42 50" y="78" style="fill:#0000AA;font-weight:bold;">wv</text>
+    <text x="66" y="78" style="fill:#CCCCCC;">A</text>
+    <text x="82 90 98 106 114 122 130 138 146 154 162 170 178 186 194 202 210" y="78" style="fill:#00AA00;">open-me.txt.touch</text>
+    <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
+    <text x="10 18 26" y="114" style="fill:#CCCCCC;">┊╭┄</text>
+    <text x="42 50" y="114" style="fill:#0000AA;font-weight:bold;">g0</text>
+    <text x="66" y="114" style="fill:#CCCCCC;">[</text>
+    <text x="74" y="114" style="fill:#00AA00;">A</text>
+    <text x="82" y="114" style="fill:#CCCCCC;">]</text>
+    <text x="10 18" y="132" style="fill:#CCCCCC;">┊●</text>
+    <text x="50" y="132" style="fill:#AA00AA;">t</text>
+    <text x="58 66" y="132" style="fill:#CCCCCC;opacity:0.75;">pm</text>
+    <text x="82 90 98" y="132" style="fill:#CCCCCC;">add</text>
+    <text x="114" y="132" style="fill:#CCCCCC;">A</text>
+    <text x="10 18" y="150" style="fill:#CCCCCC;">├╯</text>
+    <text x="10" y="168" style="fill:#CCCCCC;">┊</text>
+    <text x="10" y="186" style="fill:#CCCCCC;">┴</text>
+    <text x="26 34 42 50 58 66 74" y="186" style="fill:#CCCCCC;opacity:0.75;">0dc3733</text>
+    <text x="90 98 106 114 122 130 138" y="186" style="fill:#CCCCCC;">(common</text>
+    <text x="154 162 170 178 186" y="186" style="fill:#CCCCCC;">base)</text>
+    <text x="202 210 218 226 234 242 250 258 266 274" y="186" style="fill:#CCCCCC;opacity:0.75;">2000-01-02</text>
+    <text x="290 298 306" y="186" style="fill:#CCCCCC;">add</text>
+    <text x="322" y="186" style="fill:#CCCCCC;">M</text>
+    <text x="26 34 42 50 58 66" y="366" style="fill:#FFFFFF;">normal</text>
+    <text x="98 106 114" y="366" style="fill:#0000AA;">↑/k</text>
+    <text x="130 138" y="366" style="fill:#CCCCCC;opacity:0.75;">up</text>
+    <text x="154" y="366" style="fill:#CCCCCC;opacity:0.75;">•</text>
+    <text x="170 178 186" y="366" style="fill:#0000AA;">↓/j</text>
+    <text x="202 210 218 226" y="366" style="fill:#CCCCCC;opacity:0.75;">down</text>
+    <text x="242" y="366" style="fill:#CCCCCC;opacity:0.75;">•</text>
+    <text x="258" y="366" style="fill:#0000AA;">r</text>
+    <text x="274 282 290 298 306 314" y="366" style="fill:#CCCCCC;opacity:0.75;">squash</text>
+    <text x="330" y="366" style="fill:#CCCCCC;opacity:0.75;">•</text>
+    <text x="346" y="366" style="fill:#0000AA;">c</text>
+    <text x="362 370 378 386 394 402" y="366" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="418" y="366" style="fill:#CCCCCC;opacity:0.75;">•</text>
+    <text x="434" y="366" style="fill:#0000AA;">m</text>
+    <text x="450 458 466 474" y="366" style="fill:#CCCCCC;opacity:0.75;">move</text>
+    <text x="490" y="366" style="fill:#CCCCCC;opacity:0.75;">•</text>
+    <text x="506" y="366" style="fill:#0000AA;">b</text>
+    <text x="522 530 538 546 554 562" y="366" style="fill:#CCCCCC;opacity:0.75;">branch</text>
+    <text x="578" y="366" style="fill:#CCCCCC;opacity:0.75;">•</text>
+    <text x="594" y="366" style="fill:#0000AA;">s</text>
+    <text x="610 618 626 634 642" y="366" style="fill:#CCCCCC;opacity:0.75;">stack</text>
+    <text x="658" y="366" style="fill:#CCCCCC;opacity:0.75;">•</text>
+    <text x="674" y="366" style="fill:#0000AA;">?</text>
+    <text x="690 698 706 714" y="366" style="fill:#CCCCCC;opacity:0.75;">help</text>
+    <text x="730" y="366" style="fill:#CCCCCC;opacity:0.75;">•</text>
+    <text x="746" y="366" style="fill:#0000AA;">q</text>
+    <text x="762 770 778 786" y="366" style="fill:#CCCCCC;opacity:0.75;">quit</text>
+  </g>
+</svg>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/open_uncommitted_file_in_program_shows_only_programs_that_match_extension.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/open_uncommitted_file_in_program_shows_only_programs_that_match_extension.svg
@@ -1,0 +1,80 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="380" viewBox="0 0 820 380">
+  <rect x="0" y="0" width="820" height="380" fill="#000000" />
+  <rect x="10" y="28" width="144" height="18" fill="#45475A" />
+  <rect x="674" y="28" width="136" height="18" fill="#45475A" />
+  <rect x="162" y="46" width="504" height="18" fill="#45475A" />
+  <rect x="10" y="352" width="80" height="18" fill="#555555" />
+  <g font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">
+    <text x="10 18" y="24" style="fill:#CCCCCC;">╭┄</text>
+    <text x="34 42" y="24" style="fill:#0000AA;font-weight:bold;">zz</text>
+    <text x="58" y="24" style="fill:#CCCCCC;">[</text>
+    <text x="66 74 82 90 98 106 114 122 130 138 146" y="24" style="fill:#00AAAA;">uncommitted</text>
+    <text x="154 162 170 178 186 194 202 210 218 226 234 242 250 258 266 274 282 290 298 306 314 322 330 338 346 354 362 370 378 386 394 402 410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530 538 546 554 562 570 578 586 594 602 610 618 626 634 642 650 658 666" y="24" style="fill:#555555;">╭───────────────────────────────────────────────────────────────╮</text>
+    <text x="10" y="42" style="fill:#FFFFFF;font-weight:bold;">┊</text>
+    <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">ps</text>
+    <text x="66" y="42" style="fill:#FFFFFF;font-weight:bold;">A</text>
+    <text x="82 90 98 106 114 122 130 138 146" y="42" style="fill:#00AA00;font-weight:bold;">open-me.t</text>
+    <text x="154" y="42" style="fill:#555555;">│</text>
+    <text x="162" y="42" style="fill:#CCCCCC;">&gt;</text>
+    <text x="666" y="42" style="fill:#555555;">│</text>
+    <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
+    <text x="154" y="60" style="fill:#555555;">│</text>
+    <text x="162 170 178 186 194" y="60" style="fill:#FFFFFF;font-weight:bold;">touch</text>
+    <text x="218 226 234 242 250" y="60" style="fill:#00AAAA;font-weight:bold;">touch</text>
+    <text x="666" y="60" style="fill:#555555;">│</text>
+    <text x="10 18 26" y="78" style="fill:#CCCCCC;">┊╭┄</text>
+    <text x="42 50" y="78" style="fill:#0000AA;font-weight:bold;">g0</text>
+    <text x="66" y="78" style="fill:#CCCCCC;">[</text>
+    <text x="74" y="78" style="fill:#00AA00;">A</text>
+    <text x="82" y="78" style="fill:#CCCCCC;">]</text>
+    <text x="154" y="78" style="fill:#555555;">│</text>
+    <text x="162 170 178 186" y="78" style="fill:#CCCCCC;">echo</text>
+    <text x="218 226 234 242" y="78" style="fill:#00AAAA;">echo</text>
+    <text x="666" y="78" style="fill:#555555;">│</text>
+    <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
+    <text x="50" y="96" style="fill:#AA00AA;">t</text>
+    <text x="58 66" y="96" style="fill:#CCCCCC;opacity:0.75;">pm</text>
+    <text x="82 90 98" y="96" style="fill:#CCCCCC;">add</text>
+    <text x="114" y="96" style="fill:#CCCCCC;">A</text>
+    <text x="154" y="96" style="fill:#555555;">│</text>
+    <text x="666" y="96" style="fill:#555555;">│</text>
+    <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
+    <text x="154" y="114" style="fill:#555555;">│</text>
+    <text x="666" y="114" style="fill:#555555;">│</text>
+    <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
+    <text x="154" y="132" style="fill:#555555;">│</text>
+    <text x="666" y="132" style="fill:#555555;">│</text>
+    <text x="10" y="150" style="fill:#CCCCCC;">┴</text>
+    <text x="26 34 42 50 58 66 74" y="150" style="fill:#CCCCCC;opacity:0.75;">0dc3733</text>
+    <text x="90 98 106 114 122 130 138" y="150" style="fill:#CCCCCC;">(common</text>
+    <text x="154" y="150" style="fill:#555555;">│</text>
+    <text x="666" y="150" style="fill:#555555;">│</text>
+    <text x="154" y="168" style="fill:#555555;">│</text>
+    <text x="666" y="168" style="fill:#555555;">│</text>
+    <text x="154" y="186" style="fill:#555555;">│</text>
+    <text x="666" y="186" style="fill:#555555;">│</text>
+    <text x="154" y="204" style="fill:#555555;">│</text>
+    <text x="666" y="204" style="fill:#555555;">│</text>
+    <text x="154" y="222" style="fill:#555555;">│</text>
+    <text x="666" y="222" style="fill:#555555;">│</text>
+    <text x="154" y="240" style="fill:#555555;">│</text>
+    <text x="666" y="240" style="fill:#555555;">│</text>
+    <text x="154" y="258" style="fill:#555555;">│</text>
+    <text x="666" y="258" style="fill:#555555;">│</text>
+    <text x="154" y="276" style="fill:#555555;">│</text>
+    <text x="666" y="276" style="fill:#555555;">│</text>
+    <text x="154" y="294" style="fill:#555555;">│</text>
+    <text x="666" y="294" style="fill:#555555;">│</text>
+    <text x="154" y="312" style="fill:#555555;">│</text>
+    <text x="666" y="312" style="fill:#555555;">│</text>
+    <text x="154" y="330" style="fill:#555555;">│</text>
+    <text x="666" y="330" style="fill:#555555;">│</text>
+    <text x="154" y="348" style="fill:#555555;">│</text>
+    <text x="666" y="348" style="fill:#555555;">│</text>
+    <text x="26 34 42 50 58 66" y="366" style="fill:#FFFFFF;">normal</text>
+    <text x="98" y="366" style="fill:#0000AA;">↑</text>
+    <text x="114 122" y="366" style="fill:#CCCCCC;opacity:0.75;">up</text>
+    <text x="138" y="366" style="fill:#CCCCCC;opacity:0.75;">•</text>
+    <text x="154 162 170 178 186 194 202 210 218 226 234 242 250 258 266 274 282 290 298 306 314 322 330 338 346 354 362 370 378 386 394 402 410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530 538 546 554 562 570 578 586 594 602 610 618 626 634 642 650 658 666" y="366" style="fill:#555555;">╰───────────────────────────────────────────────────────────────╯</text>
+  </g>
+</svg>

--- a/crates/but/src/command/open.rs
+++ b/crates/but/src/command/open.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use bstr::BStr;
 use but_api::open::{
-    list_program_specs_for_file,
+    list_program_specs, list_program_specs_for_file,
     program::{OpenSpec, ProgramSpec, open_in_program_unchecked},
 };
 use but_ctx::Context;
@@ -107,30 +107,34 @@ pub(crate) fn open(
         }
     };
 
-    let program_specs = list_program_specs_for_openable(&to_open);
     let program = match program_id {
-        Some(program_id) => program_specs
-            .iter()
-            .find(|ps| ps.id == program_id)
-            .ok_or_else(|| {
-                CliError::from(
-                    bad_input("No such program found")
-                        .arg_name("--program-id")
-                        .arg_value(program_id),
-                )
-            })?,
+        Some(program_id) => {
+            let program_specs = list_program_specs();
+            program_specs
+                .into_iter()
+                .find(|ps| ps.id == program_id)
+                .ok_or_else(|| {
+                    CliError::from(
+                        bad_input("No such program found")
+                            .arg_name("--program-id")
+                            .arg_value(program_id),
+                    )
+                })?
+        }
         None => {
-            if program_specs.len() == 1 {
-                &program_specs[0]
-            } else {
-                return Err(bad_input("Could not automatically choose program")
-                    .hint("Specify a program with `--program-id`")
-                    .into());
+            let program_specs = list_program_specs_for_openable(&to_open);
+            match TryInto::<[ProgramSpec; 1]>::try_into(program_specs) {
+                Ok([program_spec]) => program_spec,
+                _ => {
+                    return Err(bad_input("Could not automatically choose program")
+                        .hint("Specify a program with `--program-id`")
+                        .into());
+                }
             }
         }
     };
 
-    run(program, to_open)?;
+    run(&program, to_open)?;
 
     Ok(())
 }

--- a/crates/but/src/command/open.rs
+++ b/crates/but/src/command/open.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use bstr::BStr;
 use but_api::open::{
-    list_builtin_program_specs, list_user_defined_program_specs,
+    list_program_specs,
     program::{OpenSpec, ProgramSpec, open_in_program_unchecked},
 };
 use but_ctx::Context;
@@ -106,14 +106,10 @@ pub(crate) fn open(
         }
     };
 
-    let builtin_program_specs = list_builtin_program_specs();
-    let user_defined_program_specs = list_user_defined_program_specs();
-    let mut all_program_specs = user_defined_program_specs
-        .iter()
-        .chain(builtin_program_specs);
-
+    let program_specs = list_program_specs();
     let program = match program_id {
-        Some(program_id) => all_program_specs
+        Some(program_id) => program_specs
+            .iter()
             .find(|ps| ps.id == program_id)
             .ok_or_else(|| {
                 CliError::from(
@@ -122,9 +118,9 @@ pub(crate) fn open(
                         .arg_value(program_id),
                 )
             })?,
-        None => all_program_specs
-            .next()
-            .expect("BUG: The internal list of programs should not be empty"),
+        None => program_specs
+            .first()
+            .expect("BUG: The program list cannot be empty"),
     };
 
     run(program, to_open)?;

--- a/crates/but/src/command/open.rs
+++ b/crates/but/src/command/open.rs
@@ -1,8 +1,8 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use bstr::BStr;
 use but_api::open::{
-    list_program_specs,
+    list_program_specs_for_file,
     program::{OpenSpec, ProgramSpec, open_in_program_unchecked},
 };
 use but_ctx::Context;
@@ -106,7 +106,7 @@ pub(crate) fn open(
         }
     };
 
-    let program_specs = list_program_specs();
+    let program_specs = list_program_specs_for_openable(&to_open);
     let program = match program_id {
         Some(program_id) => program_specs
             .iter()
@@ -126,6 +126,16 @@ pub(crate) fn open(
     run(program, to_open)?;
 
     Ok(())
+}
+
+pub(crate) fn list_program_specs_for_openable(openable: &Openable) -> Vec<ProgramSpec> {
+    let path: &Path = match openable {
+        Openable::File(path) => path,
+        Openable::Files(paths) => paths.first().unwrap(),
+        Openable::Hunk(hunk) => &hunk.path,
+    };
+
+    list_program_specs_for_file(path)
 }
 
 fn resolve_source(

--- a/crates/but/src/command/open.rs
+++ b/crates/but/src/command/open.rs
@@ -7,6 +7,7 @@ use but_api::open::{
 };
 use but_ctx::Context;
 use gix::utils::AsBStr;
+use nonempty::NonEmpty;
 
 use crate::{
     CliError, CliResult, IdMap,
@@ -32,7 +33,7 @@ pub(crate) struct Hunk {
 #[derive(Debug)]
 pub(crate) enum Openable {
     File(PathBuf),
-    Files(Vec<PathBuf>),
+    Files(NonEmpty<PathBuf>),
     Hunk(Hunk),
 }
 
@@ -97,11 +98,11 @@ pub(crate) fn open(
     let to_open = match sources.as_slice() {
         [] => return Err(bad_input("At least one source is required").into()),
         [source] => resolve_source(&repo, &id_map, source)?,
-        sources => {
-            let paths = sources
-                .iter()
-                .map(|source| resolve_file_source(&repo, &id_map, source))
-                .collect::<CliResult<Vec<_>>>()?;
+        [first_source, tail @ ..] => {
+            let mut paths = NonEmpty::new(resolve_file_source(&repo, &id_map, first_source)?);
+            for source in tail {
+                paths.push(resolve_file_source(&repo, &id_map, source)?);
+            }
             Openable::Files(paths)
         }
     };
@@ -118,9 +119,15 @@ pub(crate) fn open(
                         .arg_value(program_id),
                 )
             })?,
-        None => program_specs
-            .first()
-            .expect("BUG: The program list cannot be empty"),
+        None => {
+            if program_specs.len() == 1 {
+                &program_specs[0]
+            } else {
+                return Err(bad_input("Could not automatically choose program")
+                    .hint("Specify a program with `--program-id`")
+                    .into());
+            }
+        }
     };
 
     run(program, to_open)?;
@@ -131,7 +138,7 @@ pub(crate) fn open(
 pub(crate) fn list_program_specs_for_openable(openable: &Openable) -> Vec<ProgramSpec> {
     let path: &Path = match openable {
         Openable::File(path) => path,
-        Openable::Files(paths) => paths.first().unwrap(),
+        Openable::Files(paths) => paths.first(),
         Openable::Hunk(hunk) => &hunk.path,
     };
 

--- a/crates/but/tests/but/command/open.rs
+++ b/crates/but/tests/but/command/open.rs
@@ -692,7 +692,7 @@ fn user_defined_programs_list_can_set_extension_list_for_builtins() {
        "requiresTerminal": true
      },
      "openArgs": [
-       "WRONG ROGRAM"
+       "WRONG PROGRAM"
      ]
    },
    {
@@ -708,6 +708,7 @@ fn user_defined_programs_list_can_set_extension_list_for_builtins() {
     )
     .unwrap();
 
+    // should find echo
     env.but("_open file.txt")
         .assert()
         .success()
@@ -731,6 +732,7 @@ Hint: run `but branch new` to create a new branch to work on
 
 "#]]);
 
+    // should find touch by wildcard
     env.but("_open file.md")
         .assert()
         .success()
@@ -752,6 +754,7 @@ Hint: run `but branch new` to create a new branch to work on
 
 "#]]);
 
+    // should find touch by wildcard
     env.but("_open Dockerfile")
         .assert()
         .success()
@@ -771,6 +774,24 @@ Hint: run `but branch new` to create a new branch to work on
 ┴ 0dc3733 (common base) 2000-01-02 add M
 
 Hint: run `but branch new` to create a new branch to work on
+
+"#]]);
+
+    // should still be able to explicitly select a different handler
+    env.but("_open Dockerfile -p echo")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+filepath='/[..]/Dockerfile'
+
+"#]]);
+
+    // should select echo as it's handler for the first file
+    env.but("_open file.txt file.md Dockerfile")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+filepath='/[..]/file.txt' filepath='/[..]/file.md' filepath='/[..]/Dockerfile'
 
 "#]]);
 }

--- a/crates/but/tests/but/command/open.rs
+++ b/crates/but/tests/but/command/open.rs
@@ -674,7 +674,7 @@ CUSTOM OVERRIDE='/[..]/file.txt'
 
 #[test]
 fn user_defined_programs_list_can_set_extension_list_for_builtins() {
-    let env = setup_multi_file_uncommitted_changes(&["file.txt", "file.md"]);
+    let env = setup_multi_file_uncommitted_changes(&["file.txt", "file.md", "Dockerfile"]);
 
     let programs_json = env
         .app_data_dir()
@@ -721,6 +721,7 @@ filepath='/[..]/file.txt'
         .success()
         .stdout_eq(snapbox::str![[r#"
 ╭┄ zz [uncommitted]
+┊   tt A Dockerfile
 ┊   zn A file.md
 ┊   uv A file.txt
 ┊
@@ -740,6 +741,29 @@ Hint: run `but branch new` to create a new branch to work on
         .success()
         .stdout_eq(snapbox::str![[r#"
 ╭┄ zz [uncommitted]
+┊   tt A Dockerfile
+┊   zn A file.md
+┊   ul A file.md.touch
+┊   uv A file.txt
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but branch new` to create a new branch to work on
+
+"#]]);
+
+    env.but("_open Dockerfile")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#""#]]);
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄ zz [uncommitted]
+┊   tt A Dockerfile
+┊   mu A Dockerfile.touch
 ┊   zn A file.md
 ┊   ul A file.md.touch
 ┊   uv A file.txt

--- a/crates/but/tests/but/command/open.rs
+++ b/crates/but/tests/but/command/open.rs
@@ -4,7 +4,7 @@ use crate::utils::Sandbox;
 
 fn setup_multi_hunk_uncommitted_changes(path: &str) -> Sandbox {
     let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
-    env.setup_metadata(&["A"]);
+    env.setup_metadata(&[]);
 
     let original_content = "this\nis\nsome\ncontent\nto\ndiff\nwith\nadded\nlines\n";
     env.file(path, original_content);
@@ -609,6 +609,38 @@ Test Program - Open File: filepath='/[..]/file.txt'
         .success()
         .stdout_eq(snapbox::str![[r#"
 filepath='/[..]/file.txt'
+
+"#]]);
+}
+
+#[test]
+fn user_defined_programs_can_override_builtins() {
+    let env = setup_multi_hunk_uncommitted_changes("file.txt");
+
+    let programs_json = env
+        .app_data_dir()
+        .join("gitbutler")
+        .join(USER_DEFINED_PROGRAMS_FILENAME);
+
+    std::fs::write(
+        programs_json,
+        r#"[
+   {
+     "id": "echo",
+     "openArgs": [
+       "CUSTOM OVERRIDE='{{filepath}}'"
+     ]
+   }
+]
+   "#,
+    )
+    .unwrap();
+
+    env.but("_open file.txt -p echo")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+CUSTOM OVERRIDE='/[..]/file.txt'
 
 "#]]);
 }

--- a/crates/but/tests/but/command/open.rs
+++ b/crates/but/tests/but/command/open.rs
@@ -34,7 +34,23 @@ fn setup_multi_file_uncommitted_changes(paths: &[&str]) -> Sandbox {
 }
 
 #[test]
-fn open_uncommitted_file_with_() {
+fn open_with_ambiguous_program() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.file("new-file.txt", "content");
+
+    env.but("_open new-file.txt")
+        .assert()
+        .failure()
+        .stderr_eq(snapbox::str![[r#"
+Error: Could not automatically choose program
+
+Hint: Specify a program with `--program-id`
+
+"#]]);
+}
+
+#[test]
+fn open_uncommitted_file_with() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
 
     env.file("new-file.txt", "content");

--- a/crates/but/tests/but/command/open.rs
+++ b/crates/but/tests/but/command/open.rs
@@ -22,6 +22,17 @@ Created new independent branch 'a-branch-1'
     env
 }
 
+fn setup_multi_file_uncommitted_changes(paths: &[&str]) -> Sandbox {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
+
+    for path in paths {
+        env.file(path, "content");
+    }
+
+    env
+}
+
 #[test]
 fn open_uncommitted_file_with_() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
@@ -641,6 +652,85 @@ fn user_defined_programs_can_override_builtins() {
         .success()
         .stdout_eq(snapbox::str![[r#"
 CUSTOM OVERRIDE='/[..]/file.txt'
+
+"#]]);
+}
+
+#[test]
+fn user_defined_programs_list_can_set_extension_list_for_builtins() {
+    let env = setup_multi_file_uncommitted_changes(&["file.txt", "file.md"]);
+
+    let programs_json = env
+        .app_data_dir()
+        .join("gitbutler")
+        .join(USER_DEFINED_PROGRAMS_FILENAME);
+
+    std::fs::write(
+        programs_json,
+        r#"[
+   {
+     "name": "Sentinel to make sure we don't just pick the first definition",
+     "executable": {
+       "type": "pathExecutable",
+       "nameOrPath": "echo",
+       "requiresTerminal": true
+     },
+     "openArgs": [
+       "WRONG ROGRAM"
+     ]
+   },
+   {
+     "id": "echo",
+     "extensions": ["txt"]
+   },
+   {
+     "id": "touch",
+     "extensions": ["*"]
+   }
+]
+   "#,
+    )
+    .unwrap();
+
+    env.but("_open file.txt")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+filepath='/[..]/file.txt'
+
+"#]]);
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄ zz [uncommitted]
+┊   zn A file.md
+┊   uv A file.txt
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but branch new` to create a new branch to work on
+
+"#]]);
+
+    env.but("_open file.md")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#""#]]);
+
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄ zz [uncommitted]
+┊   zn A file.md
+┊   ul A file.md.touch
+┊   uv A file.txt
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but branch new` to create a new branch to work on
 
 "#]]);
 }


### PR DESCRIPTION
This allows `programs.json` to override built-in programs by specifying the same ID, and also allows the setting of extensions on programs to make them handlers for that extension. If you open a file with an extension listed by only a single program, we can then immediately open the file with that program without prompting the user.

Simultaneously, this PR also makes pretty much everything in the program specs optional, and we try our darndest to infer reasonable defaults.

**Extension priority is as follows:**

1. Programs with exact match on extension.
2. Programs with wildcard extension (`*`)

If we get exact matches on extension, **wildcard matches are not shown**. Wildcard matches are only used as fallbacks right now, which might be a bit confusing, but I found it to be the most practical as otherwise having any wildcard will make every other extension mapping ambiguous.

### Example `programs.json` files that utilize the new override features.

**Set VS Code as default handler for all files, except svg which has a more specific override in Safari**
```json
[
   {
     "id": "vscode",
     "extensions": ["*"]
   },
   {
     "name": "Safari",
     "executable": {
       "type": "macosApplication",
       "bundleId": "com.apple.safari"
     },
     "extensions": ["svg"]
   }
]
```

**Override zed executable**
```json
[
  {
    "id": "zed",
    "executable": {
      "type": "pathExecutable",
      "nameOrPath": "/usr/bin/zeditor",
      "requiresTerminal": false
    }
  }
]
```

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #14959 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #14950
<!-- GitButler Footer Boundary Bottom -->