### PR TITLE
Add worktree support to the Editor

### DIFF
--- a/crates/but-ctx/src/worktrees.rs
+++ b/crates/but-ctx/src/worktrees.rs
@@ -36,6 +36,7 @@ impl Context {
             .worktree_tips
             .extend(self.active_worktrees()?.into_iter().map(|worktree| {
                 but_graph::init::WorktreeTip {
+                    name: worktree.name,
                     ref_name: worktree.ref_name,
                     id: worktree.head,
                 }

--- a/crates/but-ctx/tests/ctx/main.rs
+++ b/crates/but-ctx/tests/ctx/main.rs
@@ -751,6 +751,16 @@ fn workspace_from_head_seeds_active_worktree_tips() -> anyhow::Result<()> {
     }
     let mut ctx = Context::from_repo_for_testing(repo)?;
     ctx.settings.feature_flags.worktree_manipulation = true;
+    let options = ctx.graph_options(Default::default())?;
+    assert_eq!(
+        options
+            .worktree_tips
+            .iter()
+            .map(|tip| tip.name.to_string())
+            .collect::<Vec<_>>(),
+        ["wt-b"],
+        "graph options preserve the stable name of each active worktree"
+    );
     snapbox::assert_data_eq!(
         workspace_graph(&ctx)?,
         snapbox::str![[r#"

--- a/crates/but-graph/src/init/mod.rs
+++ b/crates/but-graph/src/init/mod.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use anyhow::{Context as _, bail, ensure};
-use bstr::ByteSlice;
+use bstr::{BString, ByteSlice};
 use but_core::{
     RefMetadata, WORKSPACE_REF_NAME, extract_remote_name_and_short_name,
     ref_metadata::{self, ProjectMeta},
@@ -502,6 +502,11 @@ pub struct Options {
 /// [`Options::worktree_tips`].
 #[derive(Debug, Clone)]
 pub struct WorktreeTip {
+    /// The stable worktree name, i.e. the directory name under `$GIT_COMMON_DIR/worktrees/`.
+    ///
+    /// Traversal does not consume it, but it travels with the graph for consumers
+    /// that need to identify the linked worktree.
+    pub name: BString,
     /// The branch the worktree has checked out, if its `HEAD` is symbolic.
     pub ref_name: Option<gix::refs::FullName>,
     /// The peeled `HEAD` commit at caller resolution time.

--- a/crates/but-graph/tests/graph/init/mod.rs
+++ b/crates/but-graph/tests/graph/init/mod.rs
@@ -1850,6 +1850,7 @@ fn worktree_tips_as_extra_traversal_heads() -> anyhow::Result<()> {
     let wt_head_id = repo.find_reference("wt-feature")?.peel_to_id()?.detach();
     let with_worktree_tip = |ref_name: Option<gix::refs::FullName>| but_graph::init::Options {
         worktree_tips: vec![but_graph::init::WorktreeTip {
+            name: "worktree-ahead-feature".into(),
             ref_name,
             id: wt_head_id,
         }],
@@ -1903,6 +1904,7 @@ fn worktree_tips_as_extra_traversal_heads() -> anyhow::Result<()> {
         but_core::ref_metadata::ProjectMeta::default(),
         but_graph::init::Options {
             worktree_tips: vec![but_graph::init::WorktreeTip {
+                name: "worktree-ahead-feature".into(),
                 ref_name: Some("refs/heads/wt-feature".try_into()?),
                 id: repo.head_id()?.detach(),
             }],
@@ -1927,10 +1929,12 @@ fn worktree_tips_as_extra_traversal_heads() -> anyhow::Result<()> {
     // the graph exactly as if no worktree tips were given.
     for tip in [
         but_graph::init::WorktreeTip {
+            name: "worktree-at-head".into(),
             ref_name: None,
             id: repo.head_id()?.detach(),
         },
         but_graph::init::WorktreeTip {
+            name: "worktree-with-missing-ref".into(),
             ref_name: Some("refs/heads/does-not-exist".try_into()?),
             id: wt_head_id,
         },

--- a/crates/but-graph/tests/graph/init/with_workspace.rs
+++ b/crates/but-graph/tests/graph/init/with_workspace.rs
@@ -8125,6 +8125,7 @@ fn worktree_tip_in_workspace_priority_mode() -> anyhow::Result<()> {
     // target, and remote computations undisturbed.
     let mut options = standard_options();
     options.worktree_tips = vec![but_graph::init::WorktreeTip {
+        name: "workspace-with-external-branch-feature".into(),
         ref_name: Some("refs/heads/wt-feature".try_into()?),
         id: repo.find_reference("wt-feature")?.peel_to_id()?.detach(),
     }];

--- a/crates/but-rebase/src/graph_rebase/commit.rs
+++ b/crates/but-rebase/src/graph_rebase/commit.rs
@@ -30,6 +30,7 @@ impl<M: RefMetadata> Editor<'_, '_, M> {
                 } => {
                     *merge_base_override = Some(tree_id);
                 }
+                super::Checkout::Worktree { .. } => {}
             }
         }
     }

--- a/crates/but-rebase/src/graph_rebase/creation.rs
+++ b/crates/but-rebase/src/graph_rebase/creation.rs
@@ -1,6 +1,6 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail};
 use but_core::{RefMetadata, commit::SignCommit};
 use but_graph::{Commit, SegmentIndex};
 use petgraph::{Direction, visit::EdgeRef as _};
@@ -61,11 +61,16 @@ impl<'ws, 'meta, M: RefMetadata> Editor<'ws, 'meta, M> {
         // TODO(CTO): Look into traversing "in workspace" segments that are not
         // reachable from the entrypoint TODO(CTO): Look into stopping at the
         // common base
+        let worktree_tips = workspace.graph.options.worktree_tips.clone();
         let entrypoint = workspace.graph.entrypoint()?;
 
         let mut mutable_entrypoints = vec![entrypoint.segment.id];
 
-        for ref_name in &options.extra_mutable_refs {
+        for ref_name in options
+            .extra_mutable_refs
+            .iter()
+            .chain(worktree_tips.iter().filter_map(|tip| tip.ref_name.as_ref()))
+        {
             let Some((segment, _)) = workspace
                 .graph
                 .segment_and_commit_by_ref_name(ref_name.as_ref())
@@ -99,6 +104,7 @@ impl<'ws, 'meta, M: RefMetadata> Editor<'ws, 'meta, M> {
         let mut commits: Vec<Commit> = vec![];
         let mut commit_to_idx = HashMap::<gix::ObjectId, SegmentIndex>::new();
         let mut commit_to_pick_ix = HashMap::<gix::ObjectId, StepGraphIndex>::new();
+        let mut reference_to_ix = HashMap::<gix::refs::FullName, StepGraphIndex>::new();
         let mut graph = StepGraph::new();
         let mut head_selectors = vec![];
         let mut references = vec![];
@@ -113,17 +119,23 @@ impl<'ws, 'meta, M: RefMetadata> Editor<'ws, 'meta, M> {
             let mutable = mutable_segments.contains(&sid);
             let mut nodes = vec![];
 
-            if let Some(reference) = segment.ref_name() {
-                let refname = reference.to_owned();
+            if let Some(ref_info) = &segment.ref_info {
+                let refname = ref_info.ref_name.clone();
                 // Only mutable references are tracked for potential deletion.
-                if mutable {
+                if mutable
+                    && ref_info
+                        .worktree
+                        .as_ref()
+                        .is_none_or(|worktree| worktree.owned_by_repo)
+                {
                     references.push(refname.clone());
                 }
                 let ix = graph.add_node(Step::Reference {
                     refname: refname.clone(),
                     mutable,
                 });
-                if Some(reference) == entrypoint.segment.ref_name() {
+                reference_to_ix.insert(refname.clone(), ix);
+                if Some(refname.as_ref()) == entrypoint.segment.ref_name() {
                     head_selectors.push(Selector {
                         id: ix,
                         revision: 0,
@@ -136,20 +148,21 @@ impl<'ws, 'meta, M: RefMetadata> Editor<'ws, 'meta, M> {
                 commits.push(commit.clone());
                 commit_to_idx.insert(commit.id, segment.id);
 
-                let refs = commit
-                    .refs
-                    .iter()
-                    .map(|r| r.ref_name.clone())
-                    .collect::<Vec<_>>();
-
-                for reference in refs {
-                    if mutable {
-                        references.push(reference.to_owned());
+                for ref_info in &commit.refs {
+                    let refname = ref_info.ref_name.clone();
+                    if mutable
+                        && ref_info
+                            .worktree
+                            .as_ref()
+                            .is_none_or(|worktree| worktree.owned_by_repo)
+                    {
+                        references.push(refname.clone());
                     }
                     let ix = graph.add_node(Step::Reference {
-                        refname: reference.clone(),
+                        refname: refname.clone(),
                         mutable,
                     });
+                    reference_to_ix.insert(refname, ix);
                     if let Some(previous_ix) = nodes.last() {
                         graph.add_edge(*previous_ix, ix, Edge { order: 0 });
                     }
@@ -304,18 +317,49 @@ impl<'ws, 'meta, M: RefMetadata> Editor<'ws, 'meta, M> {
             }
         }
 
+        let mut worktree_checkouts = BTreeMap::new();
+        for tip in worktree_tips {
+            let selector = match &tip.ref_name {
+                Some(ref_name) => *reference_to_ix.get(ref_name).with_context(|| {
+                    format!(
+                        "Visible worktree {} reference {ref_name} is missing from the editor",
+                        tip.name
+                    )
+                })?,
+                None => *commit_to_pick_ix.get(&tip.id).with_context(|| {
+                    format!(
+                        "Visible detached worktree {} HEAD {} is missing from the editor",
+                        tip.name, tip.id
+                    )
+                })?,
+            };
+            let name = tip.name.clone();
+            let checkout = Checkout::Worktree {
+                worktree_name: name.clone(),
+                selector: Selector {
+                    id: selector,
+                    revision: 0,
+                },
+                ref_name: tip.ref_name,
+                initial_head: tip.id,
+            };
+            if worktree_checkouts.insert(name.clone(), checkout).is_some() {
+                bail!("Visible worktree {name} was listed more than once");
+            }
+        }
+
+        let checkouts = worktree_checkouts
+            .into_values()
+            .chain(head_selectors.into_iter().map(|selector| Checkout::Head {
+                selector,
+                merge_base_override: None,
+            }))
+            .collect();
+
         Ok(Self {
             graph,
             initial_references: references,
-            // TODO(CTO): We need to eventually list all worktrees that we own
-            // here so we can `safe_checkout` them too.
-            checkouts: head_selectors
-                .into_iter()
-                .map(|selector| Checkout::Head {
-                    selector,
-                    merge_base_override: None,
-                })
-                .collect(),
+            checkouts,
             repo: repo.clone().with_object_memory(),
             history: RevisionHistory::new(),
             workspace,

--- a/crates/but-rebase/src/graph_rebase/materialize.rs
+++ b/crates/but-rebase/src/graph_rebase/materialize.rs
@@ -2,67 +2,172 @@
 use anyhow::{Context, Result, bail};
 use but_core::{
     ObjectStorageExt as _, RefMetadata,
-    worktree::{checkout::Options, safe_checkout_from_head},
+    worktree::{
+        checkout::{Options, PreparedCheckout},
+        prepare_safe_checkout_from_head,
+    },
 };
-use gix::refs::{
-    Target,
-    transaction::{Change, LogChange, PreviousValue, RefEdit, RefLog},
+use gix::{
+    bstr::{BString, ByteSlice as _},
+    refs::{
+        Target,
+        transaction::{Change, LogChange, PreviousValue, RefEdit, RefLog},
+    },
 };
 
-use crate::graph_rebase::{
-    Checkout, MaterializeOutcome, Pick, Step, SuccessfulRebase, util::collect_ordered_parents,
-};
+use crate::graph_rebase::{Checkout, MaterializeOutcome, SuccessfulRebase};
+
+struct LinkedCheckoutSpec {
+    name: BString,
+    initial_head: gix::ObjectId,
+    ref_name: Option<gix::refs::FullName>,
+    target: gix::ObjectId,
+}
+
+struct LinkedCheckoutRepo {
+    name: BString,
+    repo: gix::Repository,
+    target: gix::ObjectId,
+    detached: bool,
+}
+
+fn open_linked_checkout_repos(
+    repo: &gix::Repository,
+    specs: Vec<LinkedCheckoutSpec>,
+) -> Result<Vec<LinkedCheckoutRepo>> {
+    specs
+        .into_iter()
+        .map(|spec| {
+            let proxy = repo
+                .worktrees()?
+                .into_iter()
+                .find(|proxy| proxy.id() == spec.name.as_bstr())
+                .with_context(|| format!("Visible worktree {} no longer exists", spec.name))?;
+            let worktree_repo = proxy.into_repo()?;
+            let actual_ref = worktree_repo.head_name()?;
+            let actual_head = worktree_repo.head_id()?.detach();
+            if actual_ref.as_ref() != spec.ref_name.as_ref() || actual_head != spec.initial_head {
+                bail!(
+                    "Visible worktree {} changed since the editor was created: \
+                     expected {} at {}, got {} at {}",
+                    spec.name,
+                    spec.ref_name
+                        .as_ref()
+                        .map_or_else(|| "detached".into(), ToString::to_string),
+                    spec.initial_head,
+                    actual_ref
+                        .as_ref()
+                        .map_or_else(|| "detached".into(), ToString::to_string),
+                    actual_head
+                );
+            }
+            Ok(LinkedCheckoutRepo {
+                name: spec.name,
+                repo: worktree_repo,
+                target: spec.target,
+                detached: spec.ref_name.is_none(),
+            })
+        })
+        .collect()
+}
+
+fn prepare_linked_checkouts(repos: &[LinkedCheckoutRepo]) -> Result<Vec<PreparedCheckout<'_>>> {
+    repos
+        .iter()
+        .map(|checkout| {
+            prepare_safe_checkout_from_head(
+                checkout.target,
+                &checkout.repo,
+                Options {
+                    skip_head_update: !checkout.detached,
+                    merge_base_override: None,
+                    allow_conflicted_commit_checkout: false,
+                },
+            )
+            .with_context(|| format!("Cannot update linked worktree {}", checkout.name))
+        })
+        .collect()
+}
 
 impl<'ws, 'graph, M: RefMetadata> SuccessfulRebase<'ws, 'graph, M> {
-    /// Materializes a history rewrite
-    pub fn materialize(mut self) -> Result<MaterializeOutcome<'ws, 'graph, M>> {
-        let repo = self.repo.clone();
-        if let Some(memory) = self.repo.objects.take_object_memory() {
-            memory.persist(self.repo)?;
-        }
+    fn linked_checkout_specs(&self) -> Result<Vec<LinkedCheckoutSpec>> {
+        self.checkouts
+            .iter()
+            .filter_map(|checkout| {
+                let Checkout::Worktree {
+                    worktree_name,
+                    selector,
+                    ref_name,
+                    initial_head,
+                } = checkout
+                else {
+                    return None;
+                };
+                Some((worktree_name, selector, ref_name, initial_head))
+            })
+            .map(|(worktree_name, selector, expected_ref, initial_head)| {
+                let (target, actual_ref) = self.checkout_target(*selector)?.with_context(|| {
+                    format!("Visible worktree {worktree_name} HEAD was removed")
+                })?;
+                if actual_ref.as_ref() != expected_ref.as_ref() {
+                    bail!("Visible worktree {worktree_name} HEAD changed shape during the edit");
+                }
+                Ok(LinkedCheckoutSpec {
+                    name: worktree_name.clone(),
+                    initial_head: *initial_head,
+                    ref_name: expected_ref.clone(),
+                    target,
+                })
+            })
+            .collect()
+    }
 
-        let mut head_reference_update = None;
-        for checkout in self.checkouts {
-            match checkout {
+    fn head_checkout(
+        &self,
+    ) -> Result<(
+        gix::ObjectId,
+        Option<gix::refs::FullName>,
+        Option<gix::ObjectId>,
+    )> {
+        let (selector, merge_base_override) = self
+            .checkouts
+            .iter()
+            .find_map(|checkout| match checkout {
                 Checkout::Head {
                     selector,
                     merge_base_override,
-                } => {
-                    let selector = self.history.normalize_selector(selector)?;
-                    let step = self.graph[selector.id].clone();
+                } => Some((*selector, *merge_base_override)),
+                Checkout::Worktree { .. } => None,
+            })
+            .context("Editor has no HEAD checkout")?;
+        let (target, ref_name) = self
+            .checkout_target(selector)?
+            .context("Checkout selector is pointing to none")?;
+        Ok((target, ref_name, merge_base_override))
+    }
 
-                    let (new_head, new_head_refname) = match step {
-                        Step::None => bail!("Checkout selector is pointing to none"),
-                        Step::Pick(Pick { id, .. }) => (id, None),
-                        Step::Reference { refname, .. } => {
-                            let parents = collect_ordered_parents(&self.graph, selector.id);
-                            let parent_step_id =
-                                parents.first().context("No first parent to reference")?;
-                            let Step::Pick(Pick { id, .. }) = self.graph[*parent_step_id] else {
-                                bail!("collect_ordered_parents should always return a commit pick");
-                            };
-                            (id, Some(refname))
-                        }
-                    };
-                    head_reference_update = new_head_refname;
-
-                    // If the head has changed (which means it's in the
-                    // commit mapping), perform a safe checkout.
-                    safe_checkout_from_head(
-                        new_head,
-                        &repo,
-                        Options {
-                            skip_head_update: true,
-                            merge_base_override,
-                            allow_conflicted_commit_checkout: true,
-                        },
-                    )?;
-                }
-            }
+    /// Materializes a history rewrite.
+    pub fn materialize(mut self) -> Result<MaterializeOutcome<'ws, 'graph, M>> {
+        let repo = self.repo.clone();
+        if let Some(memory) = self.repo.objects.take_object_memory() {
+            memory.persist(&self.repo)?;
         }
 
+        let linked_repos = open_linked_checkout_repos(&repo, self.linked_checkout_specs()?)?;
+        let prepared_linked = prepare_linked_checkouts(&linked_repos)?;
+        let (new_head, new_head_refname, merge_base_override) = self.head_checkout()?;
+        let prepared_head = prepare_safe_checkout_from_head(
+            new_head,
+            &repo,
+            Options {
+                skip_head_update: true,
+                merge_base_override,
+                allow_conflicted_commit_checkout: true,
+            },
+        )?;
+
         let mut ref_edits = self.ref_edits.clone();
-        if let Some(refname) = head_reference_update
+        if let Some(refname) = new_head_refname
             && repo.head_name()?.as_ref() != Some(&refname)
         {
             let ref_short_name = refname.shorten().to_owned();
@@ -84,6 +189,13 @@ impl<'ws, 'graph, M: RefMetadata> SuccessfulRebase<'ws, 'graph, M> {
                 deref: false,
             });
         }
+        for (prepared, checkout) in prepared_linked.into_iter().zip(&linked_repos) {
+            prepared
+                .execute()
+                .with_context(|| format!("Failed to update linked worktree {}", checkout.name))?;
+        }
+        prepared_head.execute()?;
+
         repo.edit_references(ref_edits)?;
 
         let project_meta = self.workspace.graph.project_meta.clone();
@@ -98,25 +210,11 @@ impl<'ws, 'graph, M: RefMetadata> SuccessfulRebase<'ws, 'graph, M> {
         })
     }
 
-    /// Materializes a rebase without performing a checkout.
-    ///
-    /// For the vast majority of operations you want to use
-    /// [`Self::materialize`]. This is intended to be used in niche cases like
-    /// `uncommit`.
-    ///
-    /// This has means that we don't "cherry pick" the uncommitted changes from
-    /// the old head onto the new one.
-    ///
-    /// If I dropped a commit from the history,
-    /// [`Self::materialize_without_checkout`] will now see those changes in
-    /// your working directory.
-    ///
-    /// If I instead called [`Self::materialize`], the changes would instead be
-    /// gone from disk.
+    /// Materializes a rebase without checking out the editor's own worktree.
     pub fn materialize_without_checkout(mut self) -> Result<MaterializeOutcome<'ws, 'graph, M>> {
         let repo = self.repo.clone();
         if let Some(memory) = self.repo.objects.take_object_memory() {
-            memory.persist(self.repo)?;
+            memory.persist(&self.repo)?;
         }
 
         repo.edit_references(self.ref_edits.clone())?;

--- a/crates/but-rebase/src/graph_rebase/mod.rs
+++ b/crates/but-rebase/src/graph_rebase/mod.rs
@@ -254,6 +254,17 @@ pub(crate) enum Checkout {
         /// and don't reappear as uncommitted changes.
         merge_base_override: Option<gix::ObjectId>,
     },
+    /// A visible linked worktree whose `HEAD` should follow this edit.
+    Worktree {
+        /// The stable worktree name under `$GIT_COMMON_DIR/worktrees/`.
+        worktree_name: gix::bstr::BString,
+        /// The worktree's `HEAD` selector: a reference when attached, or a commit when detached.
+        selector: Selector,
+        /// The symbolic referent at editor creation, or `None` for a detached `HEAD`.
+        ref_name: Option<gix::refs::FullName>,
+        /// The peeled `HEAD` at editor creation, used to reject stale worktree state.
+        initial_head: gix::ObjectId,
+    },
 }
 
 /// Used to manipulate a set of picks.
@@ -311,6 +322,67 @@ impl<'ws, 'meta, M: RefMetadata> SuccessfulRebase<'ws, 'meta, M> {
     /// workspace preview computed from [`Self::overlayed_graph`].
     pub fn repo_and_meta_mut(&mut self) -> (&gix::Repository, &mut M) {
         (&self.repo, self.meta)
+    }
+
+    fn checkout_target(
+        &self,
+        selector: Selector,
+    ) -> Result<Option<(gix::ObjectId, Option<gix::refs::FullName>)>> {
+        let selector = self.history.normalize_selector(selector)?;
+        Ok(match &self.graph[selector.id] {
+            Step::None => None,
+            Step::Pick(Pick { id, .. }) => Some((*id, None)),
+            Step::Reference { refname, .. } => {
+                let parent = collect_ordered_parents(&self.graph, selector.id)
+                    .into_iter()
+                    .next()
+                    .context("No first parent to reference")?;
+                let Step::Pick(Pick { id, .. }) = self.graph[parent] else {
+                    bail!("collect_ordered_parents should always return a commit pick");
+                };
+                Some((id, Some(refname.clone())))
+            }
+        })
+    }
+
+    fn worktree_tips_after_rebase(&self) -> Result<Vec<but_graph::init::WorktreeTip>> {
+        self.checkouts
+            .iter()
+            .filter_map(|checkout| {
+                let Checkout::Worktree {
+                    worktree_name,
+                    selector,
+                    ref_name,
+                    ..
+                } = checkout
+                else {
+                    return None;
+                };
+                Some((worktree_name, selector, ref_name))
+            })
+            .map(|(worktree_name, selector, expected_ref)| {
+                let (id, actual_ref) = self
+                    .checkout_target(*selector)?
+                    .with_context(|| format!("Worktree {worktree_name} HEAD was removed"))?;
+                if actual_ref.as_ref() != expected_ref.as_ref() {
+                    bail!(
+                        "Worktree {worktree_name} HEAD changed shape during the edit: \
+                         expected {}, got {}",
+                        expected_ref
+                            .as_ref()
+                            .map_or_else(|| "detached".into(), ToString::to_string),
+                        actual_ref
+                            .as_ref()
+                            .map_or_else(|| "detached".into(), ToString::to_string)
+                    );
+                }
+                Ok(but_graph::init::WorktreeTip {
+                    name: worktree_name.clone(),
+                    ref_name: expected_ref.clone(),
+                    id,
+                })
+            })
+            .collect()
     }
 
     /// Return the commit targeted by `ref_name` in the post-rebase step graph.
@@ -374,26 +446,8 @@ impl<'ws, 'meta, M: RefMetadata> SuccessfulRebase<'ws, 'meta, M> {
             .checkouts
             .iter()
             .filter_map(|checkout| match checkout {
-                Checkout::Head { selector, .. } => {
-                    let selector = self.history.normalize_selector(*selector).ok()?;
-                    let step = &self.graph[selector.id];
-
-                    match step {
-                        Step::None => None,
-                        Step::Pick(Pick { id, .. }) => Some((*id, None)),
-                        Step::Reference { refname, .. } => {
-                            let parents = collect_ordered_parents(&self.graph, selector.id);
-
-                            if let Some(to_reference) = parents.first()
-                                && let Step::Pick(Pick { id, .. }) = self.graph[*to_reference]
-                            {
-                                Some((id, Some(refname.clone())))
-                            } else {
-                                None
-                            }
-                        }
-                    }
-                }
+                Checkout::Head { selector, .. } => self.checkout_target(*selector).ok().flatten(),
+                Checkout::Worktree { .. } => None,
             })
             .next()
         else {
@@ -411,9 +465,9 @@ impl<'ws, 'meta, M: RefMetadata> SuccessfulRebase<'ws, 'meta, M> {
         if let Some(branch_stack_order) = branch_stack_order {
             overlay = overlay.with_branch_stack_order_override(branch_stack_order.iter().cloned());
         }
-        self.workspace
-            .graph
-            .redo_traversal_with_overlay(&self.repo, self.meta, overlay)
+        let mut graph = self.workspace.graph.clone();
+        graph.options.worktree_tips = self.worktree_tips_after_rebase()?;
+        graph.redo_traversal_with_overlay(&self.repo, self.meta, overlay)
     }
 }
 

--- a/crates/but-rebase/src/graph_rebase/workspace.rs
+++ b/crates/but-rebase/src/graph_rebase/workspace.rs
@@ -259,14 +259,14 @@ impl<M: RefMetadata> Editor<'_, '_, M> {
 
     /// The entrypoint (`HEAD`) reference node, or `None` if HEAD isn't on a ref.
     fn head_index(&self) -> Option<StepGraphIndex> {
-        self.checkouts
-            .iter()
-            .find_map(|Checkout::Head { selector, .. }| {
-                self.history
-                    .normalize_selector(*selector)
-                    .ok()
-                    .map(|s| s.id)
-            })
+        self.checkouts.iter().find_map(|checkout| match checkout {
+            Checkout::Head { selector, .. } => self
+                .history
+                .normalize_selector(*selector)
+                .ok()
+                .map(|s| s.id),
+            Checkout::Worktree { .. } => None,
+        })
     }
 
     /// The target commit's node, if a target is configured and present.

--- a/crates/but-rebase/tests/fixtures/scenario/worktree-checkout-dirt.sh
+++ b/crates/but-rebase/tests/fixtures/scenario/worktree-checkout-dirt.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+git init
+
+printf 'base\n' >shared
+printf 'unchanged\n' >unrelated
+git add . && git commit -m "base"
+
+printf 'middle\n' >shared
+printf 'middle only\n' >middle-only
+git add . && git commit -m "middle"
+git branch middle
+
+printf 'main only\n' >main-only
+git add . && git commit -m "main"
+
+git worktree add wt middle
+git branch second middle
+git worktree add wt2 second

--- a/crates/but-rebase/tests/fixtures/scenario/worktree-checkout-heads.sh
+++ b/crates/but-rebase/tests/fixtures/scenario/worktree-checkout-heads.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+git init
+
+echo "base" >base && git add . && git commit -m "base"
+echo "a" >a && git add . && git commit -m "a"
+git branch middle
+echo "b" >b && git add . && git commit -m "b"
+
+git worktree add wt middle
+git worktree add --detach wt-detached middle

--- a/crates/but-rebase/tests/rebase/graph_rebase/materialize.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/materialize.rs
@@ -1,9 +1,13 @@
 //! Tests for `materialize` vs `materialize_without_checkout` behavior differences
-use anyhow::Result;
+use anyhow::{Context, Result};
 use but_graph::Graph;
-use but_rebase::graph_rebase::{Editor, Step};
+use but_rebase::graph_rebase::{
+    Editor, Step,
+    mutate::{SegmentDelimiter, SelectorSet},
+};
 use but_testsupport::{
-    StackState, graph_tree, visualize_commit_graph_all, visualize_disk_tree_skip_dot_git,
+    StackState, git_status, graph_tree, visualize_commit_graph_all,
+    visualize_disk_tree_skip_dot_git,
 };
 use snapbox::IntoData;
 
@@ -11,6 +15,76 @@ use crate::{
     graph_rebase::add_stack_with_segments,
     utils::{fixture_writable, standard_options, target_meta},
 };
+
+fn worktree_fixture(
+    name: &str,
+) -> Result<(
+    gix::Repository,
+    tempfile::TempDir,
+    std::mem::ManuallyDrop<but_meta::VirtualBranchesTomlMetadata>,
+)> {
+    let (repo, tmp) = but_testsupport::writable_scenario_slow(name);
+    let meta = but_meta::VirtualBranchesTomlMetadata::from_path(
+        repo.path()
+            .join(".git")
+            .join("should-never-be-written.toml"),
+    )?;
+    Ok((repo, tmp, std::mem::ManuallyDrop::new(meta)))
+}
+
+fn worktree_tip(repo: &gix::Repository, name: &str) -> Result<but_graph::init::WorktreeTip> {
+    let proxy = repo
+        .worktrees()?
+        .into_iter()
+        .find(|proxy| proxy.id() == name)
+        .with_context(|| format!("missing worktree {name}"))?;
+    let name = proxy.id().to_owned();
+    let worktree_repo = proxy.into_repo()?;
+    let mut head = worktree_repo.head()?;
+    let ref_name = head.referent_name().map(ToOwned::to_owned);
+    let id = head.peel_to_commit()?.id;
+    Ok(but_graph::init::WorktreeTip { name, ref_name, id })
+}
+
+fn options_with_worktrees(
+    repo: &gix::Repository,
+    names: &[&str],
+) -> Result<but_graph::init::Options> {
+    let mut options = standard_options();
+    options.worktree_tips = names
+        .iter()
+        .map(|name| worktree_tip(repo, name))
+        .collect::<Result<Vec<_>>>()?;
+    Ok(options)
+}
+
+fn repoint_reference(
+    editor: &mut Editor<'_, '_, impl but_core::RefMetadata>,
+    refname: &str,
+    target: gix::ObjectId,
+) -> Result<()> {
+    let reference = editor.select_reference(refname.try_into()?)?;
+    let target = editor.select_commit(target)?;
+    editor.disconnect_segment_from(
+        SegmentDelimiter {
+            child: reference,
+            parent: reference,
+        },
+        SelectorSet::All,
+        SelectorSet::All,
+        false,
+    )?;
+    editor.add_edge(reference, target, 0)
+}
+
+fn linked_repo(repo: &gix::Repository, name: &str) -> Result<gix::Repository> {
+    repo.worktrees()?
+        .into_iter()
+        .find(|proxy| proxy.id() == name)
+        .with_context(|| format!("missing worktree {name}"))?
+        .into_repo()
+        .map_err(Into::into)
+}
 
 #[test]
 fn materialize_removes_dropped_commit_changes_from_worktree() -> Result<()> {
@@ -439,5 +513,196 @@ fn materialize_does_not_delete_immutable_refs_removed_from_graph() -> Result<()>
         .raw()
     );
 
+    Ok(())
+}
+
+#[test]
+fn visible_attached_and_detached_worktrees_follow_a_rewritten_commit() -> Result<()> {
+    let (repo, _tmpdir, mut meta) = worktree_fixture("worktree-checkout-heads")?;
+    let old_middle = repo.rev_parse_single("middle")?.detach();
+    let attached_dir = repo.workdir().unwrap().join("wt");
+    let detached_dir = repo.workdir().unwrap().join("wt-detached");
+
+    let graph = Graph::from_head(
+        &repo,
+        &*meta,
+        Default::default(),
+        options_with_worktrees(&repo, &["wt", "wt-detached"])?,
+    )?
+    .validated()?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
+
+    let mut replacement = but_core::Commit::from_id(repo.rev_parse_single("middle")?)?;
+    let a = repo.rev_parse_single("middle:a")?.detach();
+    let mut tree = repo.edit_tree(replacement.tree)?;
+    tree.remove("a")?;
+    tree.upsert("a-renamed", gix::objs::tree::EntryKind::Blob, a)?;
+    replacement.tree = tree.write()?.detach();
+    replacement.message = "a rewritten".into();
+    let replacement = repo.write_object(replacement.inner)?.detach();
+    let old_middle_selector = editor.select_commit(old_middle)?;
+    editor.replace(old_middle_selector, Step::new_pick(replacement))?;
+    editor.rebase()?.materialize()?;
+
+    let new_middle = repo.rev_parse_single("middle")?.detach();
+    assert_ne!(new_middle, old_middle);
+
+    let attached = gix::open(&attached_dir)?;
+    assert_eq!(
+        std::fs::read_to_string(attached.git_dir().join("HEAD"))?,
+        "ref: refs/heads/middle\n"
+    );
+    assert_eq!(
+        attached.head_name()?,
+        Some("refs/heads/middle".try_into()?),
+        "the branch-backed worktree stays attached"
+    );
+    assert_eq!(attached.head_id()?.detach(), new_middle);
+    assert!(
+        !attached_dir.join("a").exists(),
+        "the attached worktree removes the rename source"
+    );
+    assert_eq!(
+        std::fs::read_to_string(attached_dir.join("a-renamed"))?,
+        "a\n",
+        "the attached worktree writes the rename target"
+    );
+    // The attached worktree's index and files match its rewritten branch.
+    snapbox::assert_data_eq!(git_status(&attached)?, snapbox::str![""]);
+
+    let detached = gix::open(&detached_dir)?;
+    assert_eq!(
+        detached.head_name()?,
+        None,
+        "the detached worktree stays detached"
+    );
+    assert_eq!(detached.head_id()?.detach(), new_middle);
+    assert_eq!(
+        std::fs::read_to_string(detached.git_dir().join("HEAD"))?,
+        format!("{new_middle}\n")
+    );
+    assert!(
+        !detached_dir.join("a").exists(),
+        "the detached worktree removes the rename source"
+    );
+    assert_eq!(
+        std::fs::read_to_string(detached_dir.join("a-renamed"))?,
+        "a\n",
+        "the detached worktree writes the rename target"
+    );
+    // The detached worktree's index and files match its rewritten HEAD.
+    snapbox::assert_data_eq!(git_status(&detached)?, snapbox::str![""]);
+    Ok(())
+}
+
+#[test]
+fn references_checked_out_in_linked_worktrees_are_not_deleted() -> Result<()> {
+    let (repo, _tmpdir, mut meta) = worktree_fixture("worktree-checkout-heads")?;
+    let middle = repo.rev_parse_single("middle")?.detach();
+    repo.reference(
+        "refs/heads/doomed",
+        middle,
+        gix::refs::transaction::PreviousValue::MustNotExist,
+        "test setup",
+    )?;
+
+    let graph =
+        Graph::from_head(&repo, &*meta, Default::default(), standard_options())?.validated()?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
+    for refname in ["refs/heads/middle", "refs/heads/doomed"] {
+        let selector = editor.select_reference(refname.try_into()?)?;
+        editor.replace(selector, Step::None)?;
+    }
+    editor.rebase()?.materialize()?;
+
+    assert!(
+        repo.try_find_reference("middle")?.is_some(),
+        "a checked-out branch must not be deleted, even when the worktree is not visible"
+    );
+    assert!(
+        repo.try_find_reference("doomed")?.is_none(),
+        "an otherwise-identical unchecked-out branch is deleted"
+    );
+    Ok(())
+}
+
+#[test]
+fn every_linked_worktree_is_prepared_before_reference_edits() -> Result<()> {
+    let (repo, _tmpdir, mut meta) = worktree_fixture("worktree-checkout-dirt")?;
+    let worktree_dir = repo.workdir().unwrap().join("wt");
+    let conflicting_dir = repo.workdir().unwrap().join("wt2");
+    std::fs::write(conflicting_dir.join("main-only"), "local collision\n")?;
+
+    let worktree = linked_repo(&repo, "wt")?;
+    let conflicting = linked_repo(&repo, "wt2")?;
+    let refs_before = visualize_commit_graph_all(&repo)?;
+    let middle_before = repo.rev_parse_single("middle")?.detach();
+    let second_before = repo.rev_parse_single("second")?.detach();
+    let worktree_head_before = std::fs::read(worktree.git_dir().join("HEAD"))?;
+    let conflicting_head_before = std::fs::read(conflicting.git_dir().join("HEAD"))?;
+    let worktree_index_before = std::fs::read(worktree.git_dir().join("index"))?;
+    let conflicting_index_before = std::fs::read(conflicting.git_dir().join("index"))?;
+    let worktree_shared_before = std::fs::read(worktree_dir.join("shared"))?;
+    let conflicting_main_before = std::fs::read(conflicting_dir.join("main-only"))?;
+
+    let graph = Graph::from_head(
+        &repo,
+        &*meta,
+        Default::default(),
+        options_with_worktrees(&repo, &["wt", "wt2"])?,
+    )?
+    .validated()?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
+    repoint_reference(
+        &mut editor,
+        "refs/heads/middle",
+        repo.rev_parse_single("main~2")?.detach(),
+    )?;
+    repoint_reference(
+        &mut editor,
+        "refs/heads/second",
+        repo.rev_parse_single("main")?.detach(),
+    )?;
+
+    let err = editor
+        .rebase()?
+        .materialize()
+        .expect_err("the second checkout must fail during preparation");
+    assert!(
+        format!("{err:#}").contains("Uncommitted files would be overwritten by checkout"),
+        "the checkout conflict is surfaced: {err:#}"
+    );
+
+    assert_eq!(visualize_commit_graph_all(&repo)?, refs_before);
+    assert_eq!(repo.rev_parse_single("middle")?.detach(), middle_before);
+    assert_eq!(repo.rev_parse_single("second")?.detach(), second_before);
+    assert_eq!(
+        std::fs::read(worktree.git_dir().join("HEAD"))?,
+        worktree_head_before
+    );
+    assert_eq!(
+        std::fs::read(conflicting.git_dir().join("HEAD"))?,
+        conflicting_head_before
+    );
+    assert_eq!(
+        std::fs::read(worktree.git_dir().join("index"))?,
+        worktree_index_before
+    );
+    assert_eq!(
+        std::fs::read(conflicting.git_dir().join("index"))?,
+        conflicting_index_before
+    );
+    assert_eq!(
+        std::fs::read(worktree_dir.join("shared"))?,
+        worktree_shared_before
+    );
+    assert!(worktree_dir.join("middle-only").exists());
+    assert_eq!(
+        std::fs::read(conflicting_dir.join("main-only"))?,
+        conflicting_main_before
+    );
     Ok(())
 }


### PR DESCRIPTION


<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #14963 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #14943
<!-- GitButler Footer Boundary Bottom -->