### PR TITLE
perf(but-core): make ChangeId cheap to clone

### DIFF
--- a/crates/but-core/src/change_id.rs
+++ b/crates/but-core/src/change_id.rs
@@ -1,6 +1,6 @@
 //! A type representing ChangeIDs in commit headers.
 
-use std::{fmt, ops::Deref};
+use std::{fmt, ops::Deref, sync::Arc};
 
 use bstr::{BStr, BString};
 use rand::Rng;
@@ -18,14 +18,15 @@ const CHANGE_ID_REVERSE_BYTE_LEN: usize = CHANGE_ID_REVERSE_HEX_LEN / 2;
 /// header, but is usually a reverse hex string or a uuid.
 ///
 /// For all intents and purposes, this type acts like a [`BString`].
-#[derive(Clone, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct ChangeId(BString);
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ChangeId(Arc<[u8]>);
 
 /// Lifecycle
 impl ChangeId {
     /// Creates a ChangeId from a number for testing purposes.
     pub fn from_number_for_testing(value: u128) -> Self {
-        ChangeId(value.to_string().into())
+        let bstr = BString::from(value.to_string());
+        ChangeId(Vec::<u8>::from(bstr).into())
     }
 
     /// Creates a random length 32 reverse hex ChangeId (SHA-1).
@@ -48,12 +49,21 @@ impl ChangeId {
 
         Self(out.into())
     }
+
+    fn from_bstring(bstr: BString) -> Self {
+        ChangeId(Vec::<u8>::from(bstr).into())
+    }
 }
 
 impl ChangeId {
     /// Return the raw bytes backing this `ChangeId`.
     pub fn as_bytes(&self) -> &[u8] {
         self.0.as_ref()
+    }
+
+    /// Return the `BStr` backing this `ChangeId`.
+    pub fn as_bstr(&self) -> &BStr {
+        BStr::new(&*self.0)
     }
 
     /// Try to return the compact bytes represented by this reverse-hex `ChangeId`,
@@ -83,8 +93,10 @@ impl ChangeId {
 /// Use with care and only if you know what you are doing.
 impl ChangeId {
     /// Prefixes this instance with the given `prefix` bytes.
-    pub fn prefix_with(&mut self, prefix: impl IntoIterator<Item = u8>) {
-        self.0.splice(0..0, prefix);
+    pub fn prefixed_with(self, prefix: impl IntoIterator<Item = u8>) -> Self {
+        let mut bstr = BString::from(&*self.0);
+        bstr.splice(0..0, prefix);
+        Self::from_bstring(bstr)
     }
 }
 
@@ -111,22 +123,22 @@ fn reverse_hex_char_to_nibble(byte: u8) -> Option<u8> {
 }
 
 impl Deref for ChangeId {
-    type Target = BString;
+    type Target = BStr;
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        self.as_bstr()
     }
 }
 
 impl fmt::Debug for ChangeId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
+        self.as_bstr().fmt(f)
     }
 }
 
 impl fmt::Display for ChangeId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
+        self.as_bstr().fmt(f)
     }
 }
 
@@ -135,7 +147,7 @@ impl<'de> Deserialize<'de> for ChangeId {
     where
         D: Deserializer<'de>,
     {
-        BString::deserialize(deserializer).map(ChangeId)
+        BString::deserialize(deserializer).map(ChangeId::from_bstring)
     }
 }
 
@@ -144,19 +156,19 @@ impl Serialize for ChangeId {
     where
         S: Serializer,
     {
-        self.0.serialize(serializer)
+        self.as_bstr().serialize(serializer)
     }
 }
 
 impl From<&BStr> for ChangeId {
     fn from(value: &BStr) -> Self {
-        Self(value.to_owned())
+        Self::from_bstring(value.to_owned())
     }
 }
 
 impl From<BString> for ChangeId {
     fn from(value: BString) -> Self {
-        Self(value)
+        Self::from_bstring(value)
     }
 }
 

--- a/crates/but-core/src/commit/mod.rs
+++ b/crates/but-core/src/commit/mod.rs
@@ -193,7 +193,7 @@ impl From<&Headers> for Vec<(BString, BString)> {
         )];
 
         if let Some(change_id) = &hdr.change_id {
-            out.push((HEADERS_NEW_CHANGE_ID_FIELD.into(), (**change_id).clone()));
+            out.push((HEADERS_NEW_CHANGE_ID_FIELD.into(), (**change_id).to_owned()));
         }
 
         if let Some(conflicted) = hdr.conflicted {

--- a/crates/but-core/tests/core/change_id.rs
+++ b/crates/but-core/tests/core/change_id.rs
@@ -38,7 +38,7 @@ mod decode_reverse_hex_bytes {
     #[test]
     fn decode_reverse_hex_bytes_rejects_non_reverse_hex_characters() {
         let mut change_id = ChangeId::from_bytes(&[0xaa; 16]);
-        change_id.prefix_with(b"not-reverse-hex-".iter().copied());
+        change_id = change_id.prefixed_with(b"not-reverse-hex-".iter().copied());
 
         assert_eq!(change_id.decode_reverse_hex_bytes(), None);
     }

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -123,7 +123,7 @@ fn create_reverse_hex_id(path_bytes: &[u8]) -> anyhow::Result<ChangeId> {
     let object_id = hasher.try_finalize()?;
     let mut change_id = ChangeId::from_bytes(object_id.as_bytes());
     if path_bytes.iter().all(|c| b'k' <= *c && *c <= b'z') {
-        change_id.prefix_with(path_bytes.iter().copied());
+        change_id = change_id.prefixed_with(path_bytes.iter().copied());
     }
     Ok(change_id)
 }


### PR DESCRIPTION
With how much the CLI is using change ids now I think making them cheap to clone is a nice easy perf win. This changes it to store `Arc<[u8]>` internally while still exposing the `BString` like interface.