### PR TITLE
Add native GitHub stack sync

### DIFF
--- a/apps/desktop/src/components/projectSettings/ForgeForm.svelte
+++ b/apps/desktop/src/components/projectSettings/ForgeForm.svelte
@@ -29,6 +29,7 @@
 	import type {
 		BitbucketAccountIdentifier,
 		ForgeName,
+		GitHubStackingMode,
 		GithubAccountIdentifier,
 		GitlabAccountIdentifier,
 		ReviewStackingDescription,
@@ -56,6 +57,9 @@
 	const reviewStackingDescription = $derived(
 		(gitConfigQuery.response?.gitbutlerReviewStackingDescription ??
 			"bottom") as ReviewStackingDescription,
+	);
+	const githubStackingMode = $derived(
+		(gitConfigQuery.response?.gitbutlerGithubStackingMode ?? "disabled") as GitHubStackingMode,
 	);
 	const projectQuery = $derived(projectsService.getProject(projectId));
 	const project = $derived(projectQuery.response);
@@ -113,6 +117,10 @@
 
 	async function updateReviewStackingDescription(value: ReviewStackingDescription) {
 		await gitConfigService.setGbConfig(projectId, { gitbutlerReviewStackingDescription: value });
+	}
+
+	async function updateGitHubStackingMode(value: GitHubStackingMode) {
+		await gitConfigService.setGbConfig(projectId, { gitbutlerGithubStackingMode: value });
 	}
 </script>
 
@@ -188,6 +196,38 @@
 	</CardGroup.Item>
 
 	{#if forgeInfo?.name === "github"}
+		<CardGroup.Item>
+			{#snippet title()}
+				Native GitHub stacked pull requests
+			{/snippet}
+
+			{#snippet caption()}
+				Register this project’s reviewed stacks with GitHub’s private-preview stacks API. Higher
+				pull requests may merge the pull requests below them. Changes apply on the next push or pull
+				request creation. Fork-backed pull requests continue using description metadata.
+			{/snippet}
+
+			<div data-testid="github-stacking-mode-select">
+				<Select
+					value={githubStackingMode}
+					options={[
+						{ label: "Disabled", value: "disabled" },
+						{ label: "Native", value: "native" },
+					]}
+					wide
+					onselect={(value) => updateGitHubStackingMode(value as GitHubStackingMode)}
+				>
+					{#snippet itemSnippet({ item, highlighted })}
+						<div data-testid={`github-stacking-mode-option-${item.value}`}>
+							<SelectItem selected={item.value === githubStackingMode} {highlighted}>
+								{item.label}
+							</SelectItem>
+						</div>
+					{/snippet}
+				</Select>
+			</div>
+		</CardGroup.Item>
+
 		<ForgeAccountConfig
 			{projectId}
 			displayName="GitHub"

--- a/apps/desktop/src/lib/config/gitConfigService.ts
+++ b/apps/desktop/src/lib/config/gitConfigService.ts
@@ -52,6 +52,7 @@ export class GitConfigService {
 				signCommits: config.signCommits ?? null,
 				gitbutlerGerritMode: config.gitbutlerGerritMode ?? null,
 				gitbutlerReviewStackingDescription: config.gitbutlerReviewStackingDescription ?? null,
+				gitbutlerGithubStackingMode: config.gitbutlerGithubStackingMode ?? null,
 				gitbutlerForgeReviewTemplatePath: config.gitbutlerForgeReviewTemplatePath ?? null,
 				gitbutlerGitlabProjectId: config.gitbutlerGitlabProjectId ?? null,
 				gitbutlerGitlabUpstreamProjectId: config.gitbutlerGitlabUpstreamProjectId ?? null,

--- a/crates/but-api/src/legacy/config.rs
+++ b/crates/but-api/src/legacy/config.rs
@@ -1,7 +1,6 @@
 use anyhow::Result;
 use but_api_macros::but_api;
 use but_core::{RepositoryExt, settings::git::ui::GitConfigSettings};
-use but_ctx::ThreadSafeContext;
 use but_serde::bstring_lossy_opt;
 use gix::bstr::BString;
 use serde::Serialize;
@@ -16,24 +15,8 @@ pub fn get_gb_config(ctx: &but_ctx::Context) -> Result<GitConfigSettings> {
 
 #[but_api]
 #[instrument(err(Debug))]
-pub async fn set_gb_config(mut ctx: ThreadSafeContext, config: GitConfigSettings) -> Result<()> {
-    let sync_reviews = config.gitbutler_review_stacking_description.is_some()
-        || config.gitbutler_github_stacking_mode.is_some();
-    {
-        let ctx = ctx.clone().into_thread_local();
-        ctx.repo.get()?.set_git_settings(&config.into())?;
-    }
-    if sync_reviews
-        && let but_forge::ReviewSyncOutcome::Failed { message } =
-            crate::legacy::forge::sync_all_review_stacks({
-                ctx.repo = None;
-                ctx
-            })
-            .await
-    {
-        tracing::warn!(%message, "Could not synchronize reviews after updating stack settings");
-    }
-    Ok(())
+pub fn set_gb_config(ctx: &but_ctx::Context, config: GitConfigSettings) -> Result<()> {
+    ctx.repo.get()?.set_git_settings(&config.into())
 }
 
 #[but_api]

--- a/crates/but-api/src/legacy/config.rs
+++ b/crates/but-api/src/legacy/config.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use but_api_macros::but_api;
 use but_core::{RepositoryExt, settings::git::ui::GitConfigSettings};
+use but_ctx::ThreadSafeContext;
 use but_serde::bstring_lossy_opt;
 use gix::bstr::BString;
 use serde::Serialize;
@@ -15,8 +16,24 @@ pub fn get_gb_config(ctx: &but_ctx::Context) -> Result<GitConfigSettings> {
 
 #[but_api]
 #[instrument(err(Debug))]
-pub fn set_gb_config(ctx: &but_ctx::Context, config: GitConfigSettings) -> Result<()> {
-    ctx.repo.get()?.set_git_settings(&config.into())
+pub async fn set_gb_config(mut ctx: ThreadSafeContext, config: GitConfigSettings) -> Result<()> {
+    let sync_reviews = config.gitbutler_review_stacking_description.is_some()
+        || config.gitbutler_github_stacking_mode.is_some();
+    {
+        let ctx = ctx.clone().into_thread_local();
+        ctx.repo.get()?.set_git_settings(&config.into())?;
+    }
+    if sync_reviews
+        && let but_forge::ReviewSyncOutcome::Failed { message } =
+            crate::legacy::forge::sync_all_review_stacks({
+                ctx.repo = None;
+                ctx
+            })
+            .await
+    {
+        tracing::warn!(%message, "Could not synchronize reviews after updating stack settings");
+    }
+    Ok(())
 }
 
 #[but_api]

--- a/crates/but-api/src/legacy/forge.rs
+++ b/crates/but-api/src/legacy/forge.rs
@@ -562,6 +562,31 @@ mod tests {
     }
 
     #[test]
+    fn unknown_review_targets_do_not_need_pre_push_flattening() {
+        let reviews = [
+            (
+                but_forge::ForgeReviewTargetUpdate {
+                    number: 1,
+                    target_branch: "main".into(),
+                },
+                Some("main".into()),
+            ),
+            (
+                but_forge::ForgeReviewTargetUpdate {
+                    number: 2,
+                    target_branch: "bottom".into(),
+                },
+                None,
+            ),
+        ];
+
+        assert!(
+            review_target_flattening_plan(&reviews).is_none(),
+            "missing cache data must not cause remote mutations before a push"
+        );
+    }
+
+    #[test]
     fn review_remote_name_collision_gets_suffix() -> Result<()> {
         let tmp = tempfile::tempdir()?;
         git_at_dir(tmp.path()).args(["init"]).run();
@@ -982,6 +1007,7 @@ pub async fn update_review_footers(
     ctx: ThreadSafeContext,
     reviews: Vec<but_forge::ForgeReviewUpdate>,
 ) -> Result<()> {
+    let cache_ctx = ctx.clone();
     let (
         storage,
         forge_repo_info,
@@ -1032,7 +1058,42 @@ pub async fn update_review_footers(
         description_mode,
         github_stacking_mode,
     )
-    .await
+    .await?;
+
+    let ctx = cache_ctx.into_thread_local();
+    cache_review_target_updates(&ctx, &reviews)
+}
+
+fn cache_review_target_updates(
+    ctx: &Context,
+    updates: &[but_forge::ForgeReviewUpdate],
+) -> Result<()> {
+    let targets = updates
+        .iter()
+        .filter_map(|update| {
+            update
+                .target_branch
+                .as_ref()
+                .map(|target| (update.number, target))
+        })
+        .collect::<std::collections::HashMap<_, _>>();
+    if targets.is_empty() {
+        return Ok(());
+    }
+
+    let cached_reviews = {
+        let db = ctx.db.get_cache()?;
+        but_forge::list_cached_forge_reviews(&db)?
+    };
+    let mut db = ctx.db.get_cache_mut()?;
+    for mut review in cached_reviews {
+        let Some(target) = targets.get(&review.number) else {
+            continue;
+        };
+        review.target_branch = (*target).clone();
+        but_forge::cache_review(&mut db, &review)?;
+    }
+    Ok(())
 }
 
 /// Prepare native forge state before temporarily flattening review targets for a reordered push.
@@ -1077,6 +1138,11 @@ pub(crate) async fn prepare_review_target_updates(
     .await
 }
 
+/// The original remote targets changed while preparing a reviewed stack for push.
+pub(crate) struct ReviewTargetFlattening {
+    original_targets: Vec<but_forge::ForgeReviewTargetUpdate>,
+}
+
 /// Temporarily point a reordered reviewed stack at trunk before its refs are pushed.
 ///
 /// This prevents any stale stacked base from containing a rewritten review head while the remote
@@ -1085,9 +1151,9 @@ pub(crate) async fn prepare_review_target_updates(
 pub(crate) async fn flatten_review_targets_before_push(
     ctx: ThreadSafeContext,
     reviews: &[(but_forge::ForgeReviewTargetUpdate, Option<String>)],
-) -> Result<bool> {
+) -> Result<Option<ReviewTargetFlattening>> {
     let Some((trunk, reviews_to_flatten)) = review_target_flattening_plan(reviews) else {
-        return Ok(false);
+        return Ok(None);
     };
 
     let desired = reviews
@@ -1096,11 +1162,17 @@ pub(crate) async fn flatten_review_targets_before_push(
         .collect::<Vec<_>>();
     prepare_review_target_updates(ctx.clone(), desired).await?;
 
-    for (review, _) in reviews {
+    let mut flattening = ReviewTargetFlattening {
+        original_targets: Vec::new(),
+    };
+    for (review, current_target) in reviews {
         if !reviews_to_flatten.contains(&review.number) {
             continue;
         }
-        update_review(
+        let current_target = current_target
+            .as_ref()
+            .expect("the flattening plan requires every current target");
+        let update_result = update_review(
             ctx.clone(),
             review
                 .number
@@ -1111,20 +1183,70 @@ pub(crate) async fn flatten_review_targets_before_push(
             None,
             Some(trunk.clone()),
         )
-        .await
-        .with_context(|| {
-            format!(
+        .await;
+        if let Err(err) = update_result {
+            let err = err.context(format!(
                 "Failed to temporarily retarget review #{} before pushing reordered refs",
                 review.number
-            )
-        })?;
+            ));
+            if let Err(restore_err) = restore_review_targets(ctx, &flattening).await {
+                return Err(err.context(format!(
+                    "Additionally failed to restore already-retargeted reviews: {restore_err:#}"
+                )));
+            }
+            return Err(err);
+        }
+        flattening
+            .original_targets
+            .push(but_forge::ForgeReviewTargetUpdate {
+                number: review.number,
+                target_branch: current_target.clone(),
+            });
     }
-    Ok(true)
+    Ok(Some(flattening))
+}
+
+pub(crate) async fn restore_review_targets(
+    ctx: ThreadSafeContext,
+    flattening: &ReviewTargetFlattening,
+) -> Result<()> {
+    let mut errors = Vec::new();
+    for review in &flattening.original_targets {
+        if let Err(err) = update_review(
+            ctx.clone(),
+            review
+                .number
+                .try_into()
+                .context("Review number cannot be represented as usize")?,
+            None,
+            None,
+            None,
+            Some(review.target_branch.clone()),
+        )
+        .await
+        {
+            errors.push(format!(
+                "Failed to restore review #{} to `{}`: {err}",
+                review.number, review.target_branch
+            ));
+        }
+    }
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        anyhow::bail!(
+            "Could not restore all review targets after the push failed:\n{}",
+            errors.join("\n")
+        )
+    }
 }
 
 fn review_target_flattening_plan(
     reviews: &[(but_forge::ForgeReviewTargetUpdate, Option<String>)],
 ) -> Option<(String, std::collections::HashSet<i64>)> {
+    if reviews.iter().any(|(_, current)| current.is_none()) {
+        return None;
+    }
     let targets_changed = reviews
         .iter()
         .any(|(desired, current)| current.as_deref() != Some(desired.target_branch.as_str()));

--- a/crates/but-api/src/legacy/forge.rs
+++ b/crates/but-api/src/legacy/forge.rs
@@ -508,6 +508,60 @@ mod tests {
     }
 
     #[test]
+    fn unchanged_review_targets_do_not_need_pre_push_flattening() {
+        let reviews = [
+            (
+                but_forge::ForgeReviewTargetUpdate {
+                    number: 1,
+                    target_branch: "main".into(),
+                },
+                Some("main".into()),
+            ),
+            (
+                but_forge::ForgeReviewTargetUpdate {
+                    number: 2,
+                    target_branch: "bottom".into(),
+                },
+                Some("bottom".into()),
+            ),
+        ];
+
+        assert!(
+            review_target_flattening_plan(&reviews).is_none(),
+            "an ordinary push should not contact the forge before pushing"
+        );
+    }
+
+    #[test]
+    fn reordered_review_targets_are_temporarily_flattened_to_trunk() {
+        let reviews = [
+            (
+                but_forge::ForgeReviewTargetUpdate {
+                    number: 1,
+                    target_branch: "main".into(),
+                },
+                Some("old-bottom".into()),
+            ),
+            (
+                but_forge::ForgeReviewTargetUpdate {
+                    number: 2,
+                    target_branch: "new-bottom".into(),
+                },
+                Some("main".into()),
+            ),
+        ];
+
+        let (trunk, reviews_to_flatten) =
+            review_target_flattening_plan(&reviews).expect("the reviewed stack was reordered");
+        assert_eq!(trunk, "main");
+        assert_eq!(
+            reviews_to_flatten,
+            std::collections::HashSet::from([1]),
+            "only reviews not already targeting trunk need a preparatory update"
+        );
+    }
+
+    #[test]
     fn review_remote_name_collision_gets_suffix() -> Result<()> {
         let tmp = tempfile::tempdir()?;
         git_at_dir(tmp.path()).args(["init"]).run();
@@ -981,6 +1035,112 @@ pub async fn update_review_footers(
     .await
 }
 
+/// Prepare native forge state before temporarily flattening review targets for a reordered push.
+pub(crate) async fn prepare_review_target_updates(
+    ctx: ThreadSafeContext,
+    reviews: Vec<but_forge::ForgeReviewTargetUpdate>,
+) -> Result<()> {
+    let (
+        storage,
+        forge_repo_info,
+        forge_push_repo_info,
+        preferred_forge_user,
+        github_stacking_mode,
+    ) = {
+        let ctx = ctx.into_thread_local();
+        let project_meta = ctx.project_meta()?;
+        let repo = ctx.repo.get()?;
+        let (forge_repo_info, forge_push_repo_info) =
+            base_and_push_repo_info(&project_meta, &repo)?;
+        let github_stacking_mode = match repo.git_settings()?.gitbutler_github_stacking_mode {
+            Some(but_core::GitHubStackingMode::Native) => but_forge::GitHubStackingMode::Native,
+            Some(but_core::GitHubStackingMode::Disabled) => but_forge::GitHubStackingMode::Disabled,
+            None => but_forge::GitHubStackingMode::Unconfigured,
+        };
+        (
+            but_forge_storage::Controller::from_path(but_path::app_data_dir()?),
+            forge_repo_info,
+            forge_push_repo_info,
+            ctx.legacy_project.preferred_forge_user.clone(),
+            github_stacking_mode,
+        )
+    };
+    let reviews = reviews.into_iter().map(Into::into).collect::<Vec<_>>();
+    but_forge::prepare_review_target_updates(
+        &preferred_forge_user,
+        &forge_repo_info,
+        &forge_push_repo_info,
+        &reviews,
+        &storage,
+        github_stacking_mode,
+    )
+    .await
+}
+
+/// Temporarily point a reordered reviewed stack at trunk before its refs are pushed.
+///
+/// This prevents any stale stacked base from containing a rewritten review head while the remote
+/// refs transition to their new topology. The regular post-push synchronization restores the
+/// desired stacked targets.
+pub(crate) async fn flatten_review_targets_before_push(
+    ctx: ThreadSafeContext,
+    reviews: &[(but_forge::ForgeReviewTargetUpdate, Option<String>)],
+) -> Result<bool> {
+    let Some((trunk, reviews_to_flatten)) = review_target_flattening_plan(reviews) else {
+        return Ok(false);
+    };
+
+    let desired = reviews
+        .iter()
+        .map(|(desired, _)| desired.clone())
+        .collect::<Vec<_>>();
+    prepare_review_target_updates(ctx.clone(), desired).await?;
+
+    for (review, _) in reviews {
+        if !reviews_to_flatten.contains(&review.number) {
+            continue;
+        }
+        update_review(
+            ctx.clone(),
+            review
+                .number
+                .try_into()
+                .context("Review number cannot be represented as usize")?,
+            None,
+            None,
+            None,
+            Some(trunk.clone()),
+        )
+        .await
+        .with_context(|| {
+            format!(
+                "Failed to temporarily retarget review #{} before pushing reordered refs",
+                review.number
+            )
+        })?;
+    }
+    Ok(true)
+}
+
+fn review_target_flattening_plan(
+    reviews: &[(but_forge::ForgeReviewTargetUpdate, Option<String>)],
+) -> Option<(String, std::collections::HashSet<i64>)> {
+    let targets_changed = reviews
+        .iter()
+        .any(|(desired, current)| current.as_deref() != Some(desired.target_branch.as_str()));
+    if !targets_changed {
+        return None;
+    }
+
+    let trunk = reviews.first()?.0.target_branch.clone();
+    let reviews_to_flatten = reviews
+        .iter()
+        .filter(|(_, current)| current.as_deref() != Some(trunk.as_str()))
+        .map(|(review, _)| review.number)
+        .collect();
+    Some((trunk, reviews_to_flatten))
+}
+
 /// Synchronize every review in the workspace stack containing `branch`.
 ///
 /// The branch identifies the affected stack, but does not bound the reviews that are updated.
@@ -1224,6 +1384,52 @@ fn review_updates_for_branch(
     Ok(review_updates_for_stack(stack, &base_branch)
         .into_iter()
         .map(Into::into)
+        .collect())
+}
+
+pub(crate) fn review_target_updates_for_branch(
+    ctx: &Context,
+    branch: &gix::refs::FullNameRef,
+) -> Result<
+    Vec<(
+        gix::refs::FullName,
+        but_forge::ForgeReviewTargetUpdate,
+        Option<String>,
+    )>,
+> {
+    let info = crate::legacy::workspace::head_info(ctx)?;
+    let (stack, _) = stack_and_segment_for_branch(&info, branch)?;
+    if !stack
+        .segments
+        .iter()
+        .any(|segment| review_number(segment).is_some())
+    {
+        return Ok(Vec::new());
+    }
+    let base_branch = {
+        let guard = ctx.shared_worktree_access();
+        gitbutler_branch_actions::base::get_base_branch_data(ctx, guard.read_permission())?
+            .short_name
+    };
+    let updates = review_updates_for_stack(stack, &base_branch);
+    let db = ctx.db.get_cache()?;
+    let cached_targets = but_forge::list_cached_forge_reviews(&db)?
+        .into_iter()
+        .map(|review| (review.number, review.target_branch))
+        .collect::<std::collections::HashMap<_, _>>();
+    let reviewed_refs = stack.segments.iter().rev().filter_map(|segment| {
+        review_number(segment)?;
+        segment
+            .ref_info
+            .as_ref()
+            .map(|ref_info| ref_info.ref_name.clone())
+    });
+    Ok(reviewed_refs
+        .zip(updates)
+        .map(|(branch, update)| {
+            let current_target = cached_targets.get(&update.number).cloned();
+            (branch, update, current_target)
+        })
         .collect())
 }
 

--- a/crates/but-api/src/legacy/forge.rs
+++ b/crates/but-api/src/legacy/forge.rs
@@ -23,6 +23,25 @@ pub fn push_remote_url(project_meta: &ProjectMeta, repo: &gix::Repository) -> Re
     project_meta.push_remote_url(repo)
 }
 
+fn base_and_push_repo_info(
+    project_meta: &ProjectMeta,
+    repo: &gix::Repository,
+) -> Result<(but_forge::ForgeRepoInfo, Option<but_forge::ForgeRepoInfo>)> {
+    let base_remote_url = remote_url(project_meta, repo)?;
+    let push_remote_url = push_remote_url(project_meta, repo)?;
+    let forge_repo_info = but_forge::derive_forge_repo_info(&base_remote_url)
+        .context("No forge could be determined for this repository branch")?;
+    let forge_push_repo_info = if base_remote_url != push_remote_url {
+        Some(
+            but_forge::derive_forge_repo_info(&push_remote_url)
+                .context("Failed to derive forge information for the push repository")?,
+        )
+    } else {
+        None
+    };
+    Ok((forge_repo_info, forge_push_repo_info))
+}
+
 fn review_template_content(file: FileInfo) -> Result<String> {
     if file.size.is_none() {
         return Ok(String::new());
@@ -741,18 +760,8 @@ pub async fn publish_review_only(
         let ctx = ctx.into_thread_local();
         let project_meta = ctx.project_meta()?;
         let repo = ctx.repo.get()?;
-        let base_remote_url = remote_url(&project_meta, &repo)?;
-        let push_remote_url = push_remote_url(&project_meta, &repo)?;
-        let forge_repo_info = but_forge::derive_forge_repo_info(&base_remote_url)
-            .context("No forge could be determined for this repository branch")?;
-        let forge_push_repo_info = if base_remote_url != push_remote_url {
-            let info = but_forge::derive_forge_repo_info(&push_remote_url).context(
-                "Failed to derive forge repository information from the push remote URL.",
-            )?;
-            Some(info)
-        } else {
-            None
-        };
+        let (forge_repo_info, forge_push_repo_info) =
+            base_and_push_repo_info(&project_meta, &repo)?;
 
         (
             but_forge_storage::Controller::from_path(but_path::app_data_dir()?),
@@ -919,12 +928,21 @@ pub async fn update_review_footers(
     ctx: ThreadSafeContext,
     reviews: Vec<but_forge::ForgeReviewUpdate>,
 ) -> Result<()> {
-    let (storage, forge_repo_info, preferred_forge_user, description_mode) = {
+    let (
+        storage,
+        forge_repo_info,
+        forge_push_repo_info,
+        preferred_forge_user,
+        description_mode,
+        github_stacking_mode,
+    ) = {
         let ctx = ctx.into_thread_local();
         let project_meta = ctx.project_meta()?;
         let repo = ctx.repo.get()?;
-        let forge_repo_info = but_forge::derive_forge_repo_info(&remote_url(&project_meta, &repo)?);
-        let description_mode = match repo.git_settings()?.gitbutler_review_stacking_description {
+        let (forge_repo_info, forge_push_repo_info) =
+            base_and_push_repo_info(&project_meta, &repo)?;
+        let settings = repo.git_settings()?;
+        let description_mode = match settings.gitbutler_review_stacking_description {
             Some(but_core::ReviewStackingDescription::Top) => {
                 but_forge::ReviewStackingDescription::Top
             }
@@ -935,21 +953,30 @@ pub async fn update_review_footers(
                 but_forge::ReviewStackingDescription::Bottom
             }
         };
+        let github_stacking_mode = match settings.gitbutler_github_stacking_mode {
+            Some(but_core::GitHubStackingMode::Native) => but_forge::GitHubStackingMode::Native,
+            Some(but_core::GitHubStackingMode::Disabled) => but_forge::GitHubStackingMode::Disabled,
+            None => but_forge::GitHubStackingMode::Unconfigured,
+        };
 
         (
             but_forge_storage::Controller::from_path(but_path::app_data_dir()?),
             forge_repo_info,
+            forge_push_repo_info,
             ctx.legacy_project.preferred_forge_user.clone(),
             description_mode,
+            github_stacking_mode,
         )
     };
 
     but_forge::sync_reviews(
         &preferred_forge_user,
-        &forge_repo_info.context("No forge could be determined for this repository branch")?,
+        &forge_repo_info,
+        &forge_push_repo_info,
         &reviews,
         &storage,
         description_mode,
+        github_stacking_mode,
     )
     .await
 }
@@ -1052,6 +1079,46 @@ pub async fn sync_review_stack_after_review_creation(
     branch: gix::refs::FullName,
 ) -> but_forge::ReviewSyncOutcome {
     sync_review_stack_for_branch(ctx, branch).await
+}
+
+/// Synchronize every reviewed workspace stack.
+///
+/// This is used by explicit configuration changes because they are not coupled to a push or review
+/// creation event, but still need to migrate existing stack metadata immediately.
+pub async fn sync_all_review_stacks(ctx: ThreadSafeContext) -> but_forge::ReviewSyncOutcome {
+    let updates = {
+        let ctx = ctx.clone().into_thread_local();
+        review_updates_for_all_stacks(&ctx)
+    };
+    sync_review_update_groups(ctx, updates).await
+}
+
+fn review_updates_for_all_stacks(ctx: &Context) -> Result<Vec<Vec<but_forge::ForgeReviewUpdate>>> {
+    let info = crate::legacy::workspace::head_info(ctx)?;
+    if !info
+        .stacks
+        .iter()
+        .flat_map(|stack| &stack.segments)
+        .any(|segment| review_number(segment).is_some())
+    {
+        return Ok(Vec::new());
+    }
+    let base_branch = {
+        let guard = ctx.shared_worktree_access();
+        gitbutler_branch_actions::base::get_base_branch_data(ctx, guard.read_permission())?
+            .short_name
+    };
+    Ok(info
+        .stacks
+        .iter()
+        .map(|stack| {
+            review_updates_for_stack(stack, &base_branch)
+                .into_iter()
+                .map(Into::into)
+                .collect::<Vec<_>>()
+        })
+        .filter(|updates| !updates.is_empty())
+        .collect())
 }
 
 fn review_updates_after_push(

--- a/crates/but-api/src/legacy/forge.rs
+++ b/crates/but-api/src/legacy/forge.rs
@@ -1363,46 +1363,6 @@ pub async fn sync_review_stack_after_review_creation(
     sync_review_stack_for_branch(ctx, branch).await
 }
 
-/// Synchronize every reviewed workspace stack.
-///
-/// This is used by explicit configuration changes because they are not coupled to a push or review
-/// creation event, but still need to migrate existing stack metadata immediately.
-pub async fn sync_all_review_stacks(ctx: ThreadSafeContext) -> but_forge::ReviewSyncOutcome {
-    let updates = {
-        let ctx = ctx.clone().into_thread_local();
-        review_updates_for_all_stacks(&ctx)
-    };
-    sync_review_update_groups(ctx, updates).await
-}
-
-fn review_updates_for_all_stacks(ctx: &Context) -> Result<Vec<Vec<but_forge::ForgeReviewUpdate>>> {
-    let info = crate::legacy::workspace::head_info(ctx)?;
-    if !info
-        .stacks
-        .iter()
-        .flat_map(|stack| &stack.segments)
-        .any(|segment| review_number(segment).is_some())
-    {
-        return Ok(Vec::new());
-    }
-    let base_branch = {
-        let guard = ctx.shared_worktree_access();
-        gitbutler_branch_actions::base::get_base_branch_data(ctx, guard.read_permission())?
-            .short_name
-    };
-    Ok(info
-        .stacks
-        .iter()
-        .map(|stack| {
-            review_updates_for_stack(stack, &base_branch)
-                .into_iter()
-                .map(Into::into)
-                .collect::<Vec<_>>()
-        })
-        .filter(|updates| !updates.is_empty())
-        .collect())
-}
-
 fn review_updates_after_push(
     ctx: &Context,
     branch: &gix::refs::FullNameRef,

--- a/crates/but-api/src/legacy/workspace.rs
+++ b/crates/but-api/src/legacy/workspace.rs
@@ -464,9 +464,24 @@ pub async fn workspace_branch_and_ancestors_push(
         )
     })
     .await
-    .context("Push task failed")??;
+    .context("Push task failed")
+    .and_then(|result| result);
+    let result = match result {
+        Ok(result) => result,
+        Err(push_err) => {
+            if let Some(flattening) = &flattened_review_targets
+                && let Err(restore_err) =
+                    crate::legacy::forge::restore_review_targets(sync_ctx, flattening).await
+            {
+                return Err(push_err.context(format!(
+                    "Additionally failed to restore review targets: {restore_err:#}"
+                )));
+            }
+            return Err(push_err);
+        }
+    };
     let review_sync = if !push_needs_review_sync(&result) {
-        if flattened_review_targets {
+        if flattened_review_targets.is_some() {
             crate::legacy::forge::sync_review_stack_for_branch(sync_ctx, branch).await
         } else {
             but_forge::ReviewSyncOutcome::NotNeeded

--- a/crates/but-api/src/legacy/workspace.rs
+++ b/crates/but-api/src/legacy/workspace.rs
@@ -438,6 +438,17 @@ pub async fn workspace_branch_and_ancestors_push(
 ) -> Result<WorkspaceBranchAndAncestorsPushOutcome> {
     let branch: gix::refs::FullName = branch.try_into()?;
     let sync_ctx = ctx.clone();
+    let review_target_updates = {
+        let ctx = ctx.clone().into_thread_local();
+        crate::legacy::forge::review_target_updates_for_branch(&ctx, branch.as_ref())?
+    };
+    let review_targets = review_target_updates
+        .iter()
+        .map(|(_, desired, current)| (desired.clone(), current.clone()))
+        .collect::<Vec<_>>();
+    let flattened_review_targets =
+        crate::legacy::forge::flatten_review_targets_before_push(sync_ctx.clone(), &review_targets)
+            .await?;
     let push_branch = branch.clone();
     // This API also awaits forge synchronization, but the Git push remains synchronous and may
     // perform network I/O, hooks, and credential handling. Keep it off Tokio's async worker pool.
@@ -455,7 +466,11 @@ pub async fn workspace_branch_and_ancestors_push(
     .await
     .context("Push task failed")??;
     let review_sync = if !push_needs_review_sync(&result) {
-        but_forge::ReviewSyncOutcome::NotNeeded
+        if flattened_review_targets {
+            crate::legacy::forge::sync_review_stack_for_branch(sync_ctx, branch).await
+        } else {
+            but_forge::ReviewSyncOutcome::NotNeeded
+        }
     } else {
         crate::legacy::forge::sync_review_stacks_after_push(
             sync_ctx,

--- a/crates/but-core/src/lib.rs
+++ b/crates/but-core/src/lib.rs
@@ -98,7 +98,7 @@ pub mod cmd;
 /// Various settings
 pub mod settings;
 pub use settings::git::types::GitConfigSettings;
-pub use settings::git::ui::ReviewStackingDescription;
+pub use settings::git::ui::{GitHubStackingMode, ReviewStackingDescription};
 
 pub mod snapshot;
 

--- a/crates/but-core/src/settings.rs
+++ b/crates/but-core/src/settings.rs
@@ -11,6 +11,7 @@ pub mod git {
     const GITBUTLER_SIGN_COMMITS: &str = "gitbutler.signCommits";
     const GITBUTLER_GERRIT_MODE: &str = "gitbutler.gerritMode";
     const GITBUTLER_REVIEW_STACKING_DESCRIPTION: &str = "gitbutler.reviewStackingDescription";
+    const GITBUTLER_GITHUB_STACKING_MODE: &str = "gitbutler.githubStackingMode";
     const GITBUTLER_FORGE_TEMPLATE_PATH: &str = "gitbutler.forgeReviewTemplatePath";
     const GITBUTLER_GITLAB_PROJECT_ID: &str = "gitbutler.gitlabProjectId";
     const GITBUTLER_GITLAB_UPSTREAM_PROJECT_ID: &str = "gitbutler.gitlabUpstreamProjectId";
@@ -38,6 +39,19 @@ pub mod git {
         #[cfg(feature = "export-schema")]
         but_schemars::register_sdk_type!(ReviewStackingDescription);
 
+        /// Controls whether GitButler registers reviewed stacks with GitHub's native stacks API.
+        #[derive(Debug, PartialEq, Eq, Clone, Copy, serde::Serialize, serde::Deserialize)]
+        #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+        #[serde(rename_all = "lowercase")]
+        pub enum GitHubStackingMode {
+            /// Keep using ordinary pull requests and GitButler-managed description metadata.
+            Disabled,
+            /// Register same-repository GitHub pull requests as native GitHub stacks.
+            Native,
+        }
+        #[cfg(feature = "export-schema")]
+        but_schemars::register_sdk_type!(GitHubStackingMode);
+
         /// See [`GitConfigSettings`](crate::GitConfigSettings) for the docs.
         #[derive(Debug, PartialEq, Clone, Default, serde::Serialize, serde::Deserialize)]
         #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
@@ -48,6 +62,7 @@ pub mod git {
             pub gitbutler_sign_commits: Option<bool>,
             pub gitbutler_gerrit_mode: Option<bool>,
             pub gitbutler_review_stacking_description: Option<ReviewStackingDescription>,
+            pub gitbutler_github_stacking_mode: Option<GitHubStackingMode>,
             #[cfg_attr(feature = "export-schema", schemars(with = "Option<String>"))]
             pub gitbutler_forge_review_template_path: Option<BStringForFrontend>,
             pub gitbutler_gitlab_project_id: Option<String>,
@@ -70,6 +85,7 @@ pub mod git {
                     gitbutler_sign_commits,
                     gitbutler_gerrit_mode,
                     gitbutler_review_stacking_description,
+                    gitbutler_github_stacking_mode,
                     gitbutler_forge_review_template_path,
                     gitbutler_gitlab_project_id,
                     gitbutler_gitlab_upstream_project_id,
@@ -83,6 +99,7 @@ pub mod git {
                     gitbutler_sign_commits,
                     gitbutler_gerrit_mode,
                     gitbutler_review_stacking_description,
+                    gitbutler_github_stacking_mode,
                     gitbutler_forge_review_template_path: gitbutler_forge_review_template_path
                         .map(Into::into),
                     gitbutler_gitlab_project_id,
@@ -103,6 +120,7 @@ pub mod git {
                     gitbutler_sign_commits,
                     gitbutler_gerrit_mode,
                     gitbutler_review_stacking_description,
+                    gitbutler_github_stacking_mode,
                     gitbutler_forge_review_template_path,
                     gitbutler_gitlab_project_id,
                     gitbutler_gitlab_upstream_project_id,
@@ -116,6 +134,7 @@ pub mod git {
                     gitbutler_sign_commits,
                     gitbutler_gerrit_mode,
                     gitbutler_review_stacking_description,
+                    gitbutler_github_stacking_mode,
                     gitbutler_forge_review_template_path: gitbutler_forge_review_template_path
                         .map(Into::into),
                     gitbutler_gitlab_project_id,
@@ -132,7 +151,7 @@ pub mod git {
     pub(crate) mod types {
         use std::ffi::OsString;
 
-        pub use super::ui::ReviewStackingDescription;
+        pub use super::ui::{GitHubStackingMode, ReviewStackingDescription};
         use bstr::BString;
 
         /// Settings that are retrieved from Git and written into the repository-local configuration.
@@ -150,6 +169,8 @@ pub mod git {
             pub gitbutler_gerrit_mode: Option<bool>,
             /// Controls where GitButler puts stack information in review descriptions.
             pub gitbutler_review_stacking_description: Option<ReviewStackingDescription>,
+            /// Controls whether GitHub pull requests are registered with the native stacks API.
+            pub gitbutler_github_stacking_mode: Option<GitHubStackingMode>,
             /// The path to the review description template to be used for this repository.
             pub gitbutler_forge_review_template_path: Option<BString>,
             /// The project ID of the GitLab project this repository is associated with, if any.
@@ -168,7 +189,7 @@ pub mod git {
         }
     }
     use types::GitConfigSettings;
-    use ui::ReviewStackingDescription;
+    use ui::{GitHubStackingMode, ReviewStackingDescription};
 
     impl GitConfigSettings {
         /// Read all settings from the given snapshot.
@@ -192,6 +213,16 @@ pub mod git {
                         ReviewStackingDescription::Bottom
                     }
                 });
+            let gitbutler_github_stacking_mode = config
+                .string(GITBUTLER_GITHUB_STACKING_MODE)
+                .map(|value| match value.as_slice() {
+                    b"disabled" => GitHubStackingMode::Disabled,
+                    b"native" => GitHubStackingMode::Native,
+                    invalid => {
+                        tracing::warn!(value = ?invalid, "Invalid gitbutler.githubStackingMode; using disabled");
+                        GitHubStackingMode::Disabled
+                    }
+                });
             let gitbutler_forge_review_template_path = config.string(GITBUTLER_FORGE_TEMPLATE_PATH);
             let gitbutler_gitlab_project_id = config
                 .string(GITBUTLER_GITLAB_PROJECT_ID)
@@ -207,6 +238,7 @@ pub mod git {
                 gitbutler_sign_commits,
                 gitbutler_gerrit_mode,
                 gitbutler_review_stacking_description,
+                gitbutler_github_stacking_mode,
                 gitbutler_forge_review_template_path,
                 gitbutler_gitlab_project_id,
                 gitbutler_gitlab_upstream_project_id,
@@ -241,6 +273,15 @@ pub mod git {
                             ReviewStackingDescription::Bottom => "bottom",
                             ReviewStackingDescription::Top => "top",
                             ReviewStackingDescription::Disabled => "disabled",
+                        },
+                    )?;
+                };
+                if let Some(mode) = self.gitbutler_github_stacking_mode {
+                    config.set_raw_value(
+                        GITBUTLER_GITHUB_STACKING_MODE,
+                        match mode {
+                            GitHubStackingMode::Disabled => "disabled",
+                            GitHubStackingMode::Native => "native",
                         },
                     )?;
                 };

--- a/crates/but-core/tests/core/settings.rs
+++ b/crates/but-core/tests/core/settings.rs
@@ -1,7 +1,9 @@
 mod git {
     use std::io::Write;
 
-    use but_core::{GitConfigSettings, RepositoryExt, ReviewStackingDescription};
+    use but_core::{
+        GitConfigSettings, GitHubStackingMode, RepositoryExt, ReviewStackingDescription,
+    };
     use but_testsupport::gix_testtools;
 
     #[test]
@@ -25,6 +27,7 @@ mod git {
             gitbutler_sign_commits: Some(true),
             gitbutler_gerrit_mode: Some(false),
             gitbutler_review_stacking_description: None,
+            gitbutler_github_stacking_mode: None,
             gitbutler_forge_review_template_path: None,
             gitbutler_gitlab_project_id: None,
             gitbutler_gitlab_upstream_project_id: None,
@@ -86,6 +89,7 @@ mod git {
             gitbutler_sign_commits: Some(true),
             gitbutler_gerrit_mode: Some(false),
             gitbutler_review_stacking_description: None,
+            gitbutler_github_stacking_mode: None,
             gitbutler_forge_review_template_path: Some("template.md".into()),
             gitbutler_gitlab_project_id: Some("project-id".into()),
             gitbutler_gitlab_upstream_project_id: Some("upstream-project-id".into()),
@@ -99,6 +103,7 @@ mod git {
             gitbutler_sign_commits: Some(true),
             gitbutler_gerrit_mode: Some(false),
             gitbutler_review_stacking_description: None,
+            gitbutler_github_stacking_mode: None,
             gitbutler_forge_review_template_path: Some("".into()),
             gitbutler_gitlab_project_id: Some(String::new()),
             gitbutler_gitlab_upstream_project_id: Some(String::new()),
@@ -171,6 +176,27 @@ mod git {
                 repo.git_settings()?.gitbutler_review_stacking_description,
                 Some(value),
                 "the configured review stacking description should round-trip"
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn github_stacking_mode_round_trips() -> anyhow::Result<()> {
+        for value in [GitHubStackingMode::Disabled, GitHubStackingMode::Native] {
+            let tmp = gix_testtools::tempfile::TempDir::new()?;
+            gix::init(tmp.path())?;
+            let repo = gix::open_opts(tmp.path(), gix::open::Options::isolated())?;
+            repo.set_git_settings(&GitConfigSettings {
+                gitbutler_github_stacking_mode: Some(value),
+                ..Default::default()
+            })?;
+
+            let repo = but_testsupport::open_repo(repo.path())?;
+            assert_eq!(
+                repo.git_settings()?.gitbutler_github_stacking_mode,
+                Some(value),
+                "the configured GitHub stacking mode should round-trip"
             );
         }
         Ok(())

--- a/crates/but-forge/src/lib.rs
+++ b/crates/but-forge/src/lib.rs
@@ -16,10 +16,10 @@ pub use forge_info::{ForgeCapabilities, ForgeInfo, ForgeUnitInfo, compare_branch
 pub use repo::{RepoInfo, RepoPermissions, get_repo_info};
 pub use review::{
     CacheConfig, CreateForgeReviewParams, ForgeAccountValidity, ForgeReview, ForgeReviewFilter,
-    ForgeReviewTargetUpdate, ForgeReviewUpdate, PublishReviewOutcome, ReviewMergeMethod,
-    ReviewMergeStatus, ReviewStackingDescription, ReviewState, ReviewSyncOutcome,
-    ReviewTemplateFunctions, ReviewUpdatePayload, available_review_templates, cache_review,
-    check_forge_account_is_valid, compute_review_target_updates, create_forge_review,
+    ForgeReviewTargetUpdate, ForgeReviewUpdate, GitHubStackingMode, PublishReviewOutcome,
+    ReviewMergeMethod, ReviewMergeStatus, ReviewStackingDescription, ReviewState,
+    ReviewSyncOutcome, ReviewTemplateFunctions, ReviewUpdatePayload, available_review_templates,
+    cache_review, check_forge_account_is_valid, compute_review_target_updates, create_forge_review,
     get_forge_review, get_review_base_repo_url, get_review_merge_status,
     get_review_template_functions, list_forge_reviews_for_branch, list_forge_reviews_with_cache,
     merge_review, set_review_auto_merge_state, set_review_draftiness, sync_reviews, update_review,

--- a/crates/but-forge/src/lib.rs
+++ b/crates/but-forge/src/lib.rs
@@ -22,7 +22,8 @@ pub use review::{
     cache_review, check_forge_account_is_valid, compute_review_target_updates, create_forge_review,
     get_forge_review, get_review_base_repo_url, get_review_merge_status,
     get_review_template_functions, list_forge_reviews_for_branch, list_forge_reviews_with_cache,
-    merge_review, set_review_auto_merge_state, set_review_draftiness, sync_reviews, update_review,
+    merge_review, prepare_review_target_updates, set_review_auto_merge_state,
+    set_review_draftiness, sync_reviews, update_review,
 };
 
 fn determine_forge_from_host(host: &str) -> Option<ForgeName> {

--- a/crates/but-forge/src/review.rs
+++ b/crates/but-forge/src/review.rs
@@ -1681,6 +1681,47 @@ pub enum GitHubStackingMode {
     Native,
 }
 
+/// Remove conflicting native GitHub stack membership before changing review target branches.
+///
+/// The caller temporarily flattens reordered reviews onto trunk before pushing their refs. GitHub
+/// requires conflicting native stack membership to be removed before those target updates.
+pub async fn prepare_review_target_updates(
+    preferred_forge_user: &Option<crate::ForgeUser>,
+    forge_repo_info: &crate::forge::ForgeRepoInfo,
+    forge_push_repo_info: &Option<crate::forge::ForgeRepoInfo>,
+    reviews: &[ForgeReviewUpdate],
+    storage: &but_forge_storage::Controller,
+    github_stacking_mode: GitHubStackingMode,
+) -> Result<()> {
+    let crate::forge::ForgeRepoInfo {
+        forge, owner, repo, ..
+    } = forge_repo_info;
+    if *forge != ForgeName::GitHub
+        || github_stacking_mode != GitHubStackingMode::Native
+        || reviews.is_empty()
+    {
+        return Ok(());
+    }
+
+    let (_, head_repo) = github_head_owner_and_repo(forge_repo_info, forge_push_repo_info);
+    if head_repo.is_some() {
+        return Ok(());
+    }
+
+    let preferred_account = preferred_forge_user.as_ref().and_then(|user| user.github());
+    let pr_numbers = reviews
+        .iter()
+        .map(|review| review.number)
+        .collect::<Vec<_>>();
+    let prepared =
+        but_github::stacks::prepare(preferred_account, owner, repo, &pr_numbers, storage).await?;
+    if let but_github::stacks::Availability::Supported(plan) = prepared {
+        but_github::stacks::unstack_conflicting(preferred_account, owner, repo, &plan, storage)
+            .await?;
+    }
+    Ok(())
+}
+
 async fn github_review_bodies(
     preferred_account: Option<&but_github::GithubAccountIdentifier>,
     owner: &str,
@@ -1758,6 +1799,7 @@ async fn sync_github_native_reviews(
     reviews: &[ForgeReviewUpdate],
     pr_numbers: &[i64],
     storage: &but_forge_storage::Controller,
+    description_mode: ReviewStackingDescription,
 ) -> Result<but_github::stacks::Availability<Vec<String>>> {
     let prepared =
         but_github::stacks::prepare(preferred_account, owner, repo, pr_numbers, storage).await?;
@@ -1798,7 +1840,8 @@ async fn sync_github_native_reviews(
 
     but_github::stacks::finish(preferred_account, owner, repo, &plan, storage).await?;
 
-    // GitHub now renders the stack. Remove only GitButler's managed block and preserve user text.
+    // GitHub now renders the native stack. Independently honor the configured GitButler
+    // description mode and preserve user text.
     for (review, current_body) in reviews.iter().zip(bodies) {
         let Some(current_body) = current_body else {
             continue;
@@ -1808,7 +1851,7 @@ async fn sync_github_native_reviews(
             review.number,
             pr_numbers,
             "#",
-            ReviewStackingDescription::Disabled,
+            description_mode,
         );
         let params = but_github::UpdatePullRequestParams {
             owner,
@@ -1887,6 +1930,7 @@ pub async fn sync_reviews(
                     reviews,
                     &pr_numbers,
                     storage,
+                    description_mode,
                 )
                 .await
                 {

--- a/crates/but-forge/src/review.rs
+++ b/crates/but-forge/src/review.rs
@@ -1673,6 +1673,159 @@ pub enum ReviewStackingDescription {
     Disabled,
 }
 
+/// Controls whether same-repository GitHub reviews use GitHub's native stacks API.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GitHubStackingMode {
+    Unconfigured,
+    Disabled,
+    Native,
+}
+
+async fn github_review_bodies(
+    preferred_account: Option<&but_github::GithubAccountIdentifier>,
+    owner: &str,
+    repo: &str,
+    reviews: &[ForgeReviewUpdate],
+    storage: &but_forge_storage::Controller,
+) -> Result<(Vec<Option<Option<String>>>, Vec<String>)> {
+    let mut bodies = Vec::with_capacity(reviews.len());
+    let mut errors = Vec::new();
+    for review in reviews {
+        if review.update_description {
+            bodies.push(Some(review.body.clone()));
+            continue;
+        }
+        match but_github::pr::get(
+            preferred_account,
+            owner,
+            repo,
+            review.number.try_into()?,
+            storage,
+        )
+        .await
+        {
+            Ok(review) => bodies.push(Some(review.body)),
+            Err(err) => {
+                errors.push(format!("PR #{} description: {err}", review.number));
+                bodies.push(None);
+            }
+        }
+    }
+    Ok((bodies, errors))
+}
+
+async fn sync_github_reviews_with_descriptions(
+    preferred_account: Option<&but_github::GithubAccountIdentifier>,
+    owner: &str,
+    repo: &str,
+    reviews: &[ForgeReviewUpdate],
+    pr_numbers: &[i64],
+    storage: &but_forge_storage::Controller,
+    description_mode: ReviewStackingDescription,
+) -> Result<Vec<String>> {
+    let (bodies, mut errors) =
+        github_review_bodies(preferred_account, owner, repo, reviews, storage).await?;
+    for (review, current_body) in reviews.iter().zip(bodies) {
+        let updated_body = current_body.map(|body| {
+            update_body_with_mode(
+                body.as_deref(),
+                review.number,
+                pr_numbers,
+                "#",
+                description_mode,
+            )
+        });
+        let params = but_github::UpdatePullRequestParams {
+            owner,
+            repo,
+            pr_number: review.number,
+            title: None,
+            body: updated_body.as_deref(),
+            base: review.target_branch.as_deref(),
+            state: None,
+        };
+        if let Err(err) = but_github::pr::update(preferred_account, params, storage).await {
+            errors.push(format!("PR #{}: {err}", review.number));
+        }
+    }
+    Ok(errors)
+}
+
+async fn sync_github_native_reviews(
+    preferred_account: Option<&but_github::GithubAccountIdentifier>,
+    owner: &str,
+    repo: &str,
+    reviews: &[ForgeReviewUpdate],
+    pr_numbers: &[i64],
+    storage: &but_forge_storage::Controller,
+) -> Result<but_github::stacks::Availability<Vec<String>>> {
+    let prepared =
+        but_github::stacks::prepare(preferred_account, owner, repo, pr_numbers, storage).await?;
+    let but_github::stacks::Availability::Supported(plan) = prepared else {
+        return Ok(but_github::stacks::Availability::Unsupported);
+    };
+    let (bodies, mut errors) =
+        github_review_bodies(preferred_account, owner, repo, reviews, storage).await?;
+
+    // Rebuilds have to dissolve the old native membership before GitHub will accept reordered
+    // target branches. Legacy footers remain in place until the new native shape is durable.
+    but_github::stacks::unstack_conflicting(preferred_account, owner, repo, &plan, storage).await?;
+
+    let mut target_errors = Vec::new();
+    for review in reviews {
+        let Some(target_branch) = review.target_branch.as_deref() else {
+            continue;
+        };
+        let params = but_github::UpdatePullRequestParams {
+            owner,
+            repo,
+            pr_number: review.number,
+            title: None,
+            body: None,
+            base: Some(target_branch),
+            state: None,
+        };
+        if let Err(err) = but_github::pr::update(preferred_account, params, storage).await {
+            target_errors.push(format!("PR #{} target: {err}", review.number));
+        }
+    }
+    if !target_errors.is_empty() {
+        anyhow::bail!(
+            "Could not update all PR targets before native stack registration:\n{}",
+            target_errors.join("\n")
+        );
+    }
+
+    but_github::stacks::finish(preferred_account, owner, repo, &plan, storage).await?;
+
+    // GitHub now renders the stack. Remove only GitButler's managed block and preserve user text.
+    for (review, current_body) in reviews.iter().zip(bodies) {
+        let Some(current_body) = current_body else {
+            continue;
+        };
+        let updated_body = update_body_with_mode(
+            current_body.as_deref(),
+            review.number,
+            pr_numbers,
+            "#",
+            ReviewStackingDescription::Disabled,
+        );
+        let params = but_github::UpdatePullRequestParams {
+            owner,
+            repo,
+            pr_number: review.number,
+            title: None,
+            body: Some(&updated_body),
+            base: None,
+            state: None,
+        };
+        if let Err(err) = but_github::pr::update(preferred_account, params, storage).await {
+            errors.push(format!("PR #{} description: {err}", review.number));
+        }
+    }
+    Ok(but_github::stacks::Availability::Supported(errors))
+}
+
 #[cfg(feature = "export-schema")]
 but_schemars::register_sdk_type!(ForgeReviewUpdate);
 
@@ -1706,9 +1859,11 @@ impl From<ForgeReviewTargetUpdate> for ForgeReviewUpdate {
 pub async fn sync_reviews(
     preferred_forge_user: &Option<crate::ForgeUser>,
     forge_repo_info: &crate::forge::ForgeRepoInfo,
+    forge_push_repo_info: &Option<crate::forge::ForgeRepoInfo>,
     reviews: &[ForgeReviewUpdate],
     storage: &but_forge_storage::Controller,
     description_mode: ReviewStackingDescription,
+    github_stacking_mode: GitHubStackingMode,
 ) -> Result<()> {
     let crate::forge::ForgeRepoInfo {
         forge, owner, repo, ..
@@ -1720,52 +1875,84 @@ pub async fn sync_reviews(
         ForgeName::GitHub => {
             let preferred_account = preferred_forge_user.as_ref().and_then(|user| user.github());
             let pr_numbers: Vec<i64> = reviews.iter().map(|r| r.number).collect();
-
-            for review in reviews {
-                // Hydrate target-only callers so policy changes are still applied on the next
-                // stack sync. A failed read must not prevent the independent target update below.
-                let current_body = if !review.update_description {
-                    match but_github::pr::get(
+            let (_, head_repo) = github_head_owner_and_repo(forge_repo_info, forge_push_repo_info);
+            let use_native = github_stacking_mode == GitHubStackingMode::Native
+                && head_repo.is_none()
+                && !reviews.is_empty();
+            if use_native {
+                match sync_github_native_reviews(
+                    preferred_account,
+                    owner,
+                    repo,
+                    reviews,
+                    &pr_numbers,
+                    storage,
+                )
+                .await
+                {
+                    Ok(but_github::stacks::Availability::Supported(native_errors)) => {
+                        errors.extend(native_errors);
+                    }
+                    Ok(but_github::stacks::Availability::Unsupported) => {
+                        errors.push(
+                            "GitHub native stacks are not enabled for this repository".to_string(),
+                        );
+                        errors.extend(
+                            sync_github_reviews_with_descriptions(
+                                preferred_account,
+                                owner,
+                                repo,
+                                reviews,
+                                &pr_numbers,
+                                storage,
+                                description_mode,
+                            )
+                            .await?,
+                        );
+                    }
+                    Err(err) => {
+                        errors.push(format!("GitHub native stack: {err}"));
+                        errors.extend(
+                            sync_github_reviews_with_descriptions(
+                                preferred_account,
+                                owner,
+                                repo,
+                                reviews,
+                                &pr_numbers,
+                                storage,
+                                description_mode,
+                            )
+                            .await?,
+                        );
+                    }
+                }
+            } else {
+                if github_stacking_mode == GitHubStackingMode::Disabled
+                    && head_repo.is_none()
+                    && !reviews.is_empty()
+                    && let Err(err) = but_github::stacks::dissolve(
                         preferred_account,
                         owner,
                         repo,
-                        review.number.try_into()?,
+                        &pr_numbers,
                         storage,
                     )
                     .await
-                    {
-                        Ok(review) => Some(review.body),
-                        Err(err) => {
-                            errors.push(format!("PR #{} description: {err}", review.number));
-                            None
-                        }
-                    }
-                } else {
-                    Some(review.body.clone())
-                };
-                let updated_body = current_body.map(|body| {
-                    update_body_with_mode(
-                        body.as_deref(),
-                        review.number,
+                {
+                    errors.push(format!("GitHub native stack removal: {err}"));
+                }
+                errors.extend(
+                    sync_github_reviews_with_descriptions(
+                        preferred_account,
+                        owner,
+                        repo,
+                        reviews,
                         &pr_numbers,
-                        "#",
+                        storage,
                         description_mode,
                     )
-                });
-
-                let params = but_github::UpdatePullRequestParams {
-                    owner,
-                    repo,
-                    pr_number: review.number,
-                    title: None,
-                    body: updated_body.as_deref(),
-                    base: review.target_branch.as_deref(),
-                    state: None,
-                };
-
-                if let Err(err) = but_github::pr::update(preferred_account, params, storage).await {
-                    errors.push(format!("PR #{}: {err}", review.number));
-                }
+                    .await?,
+                );
             }
         }
         ForgeName::GitLab => {

--- a/crates/but-github/src/client.rs
+++ b/crates/but-github/src/client.rs
@@ -33,8 +33,8 @@ fn ensure_success(response: &reqwest::Response) -> Result<()> {
 }
 
 pub struct GitHubClient {
-    client: reqwest::Client,
-    base_url: String,
+    pub(crate) client: reqwest::Client,
+    pub(crate) base_url: String,
 }
 
 impl GitHubClient {

--- a/crates/but-github/src/lib.rs
+++ b/crates/but-github/src/lib.rs
@@ -9,6 +9,7 @@ pub mod checks;
 mod client;
 mod graphql;
 pub mod pr;
+pub mod stacks;
 pub use client::{
     AutoMergeEnableParams, AutoMergeState, CheckRun, CreatePullRequestParams, GitHubClient,
     GitHubPrLabel, GitHubRepoPermissions, GitHubRepository, GitHubUser, MergeMethod,

--- a/crates/but-github/src/stacks.rs
+++ b/crates/but-github/src/stacks.rs
@@ -1,0 +1,400 @@
+//! GitHub's native stacked-pull-requests REST API.
+//!
+//! Native stacks are enabled per repository. Their API models a stack as pull request numbers
+//! ordered from the review closest to the target branch to the review at the top.
+
+use std::collections::BTreeMap;
+
+use anyhow::{Context as _, Result, bail};
+use serde::{Deserialize, Serialize};
+
+use crate::client::GitHubClient;
+
+/// A GitHub native pull-request stack.
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct Stack {
+    /// The repository-scoped number used to address the stack.
+    pub number: i64,
+    /// Member pull requests ordered bottom-to-top.
+    pub pull_requests: Vec<StackPullRequest>,
+}
+
+/// A pull request belonging to a native stack.
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct StackPullRequest {
+    pub number: i64,
+}
+
+/// Whether the repository exposes GitHub's native stacks preview.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Availability<T> {
+    Unsupported,
+    Supported(T),
+}
+
+/// The native-stack membership mutation needed to reach a desired reviewed stack.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReconcilePlan {
+    Noop,
+    Create {
+        desired: Vec<i64>,
+    },
+    Append {
+        stack_number: i64,
+        pull_requests: Vec<i64>,
+    },
+    Rebuild {
+        stack_numbers: Vec<i64>,
+        desired: Vec<i64>,
+    },
+    Dissolve {
+        stack_numbers: Vec<i64>,
+    },
+}
+
+impl ReconcilePlan {
+    /// Native stack numbers that must be dissolved before PR targets are updated.
+    pub fn stack_numbers_to_unstack(&self) -> &[i64] {
+        match self {
+            ReconcilePlan::Rebuild { stack_numbers, .. }
+            | ReconcilePlan::Dissolve { stack_numbers } => stack_numbers,
+            ReconcilePlan::Noop | ReconcilePlan::Create { .. } | ReconcilePlan::Append { .. } => {
+                &[]
+            }
+        }
+    }
+}
+
+/// Inspect native membership for every desired PR and calculate the required mutation.
+///
+/// Looking up every member is necessary when GitButler combines reviews that currently belong to
+/// separate native stacks.
+pub async fn prepare(
+    preferred_account: Option<&crate::GithubAccountIdentifier>,
+    owner: &str,
+    repo: &str,
+    desired: &[i64],
+    storage: &but_forge_storage::Controller,
+) -> Result<Availability<ReconcilePlan>> {
+    let gh = GitHubClient::from_storage(storage, preferred_account)?;
+    let Some(existing) = gh.existing_stacks(owner, repo, desired).await? else {
+        return Ok(Availability::Unsupported);
+    };
+    Ok(Availability::Supported(reconcile_plan(existing, desired)))
+}
+
+/// Dissolve every native stack containing any of `pull_requests`.
+pub async fn dissolve(
+    preferred_account: Option<&crate::GithubAccountIdentifier>,
+    owner: &str,
+    repo: &str,
+    pull_requests: &[i64],
+    storage: &but_forge_storage::Controller,
+) -> Result<Availability<()>> {
+    let gh = GitHubClient::from_storage(storage, preferred_account)?;
+    let Some(existing) = gh.existing_stacks(owner, repo, pull_requests).await? else {
+        return Ok(Availability::Unsupported);
+    };
+    for stack in existing {
+        gh.unstack(owner, repo, stack.number)
+            .await
+            .with_context(|| format!("Failed to dissolve GitHub stack #{}", stack.number))?;
+    }
+    Ok(Availability::Supported(()))
+}
+
+impl GitHubClient {
+    async fn existing_stacks(
+        &self,
+        owner: &str,
+        repo: &str,
+        pull_requests: &[i64],
+    ) -> Result<Option<Vec<Stack>>> {
+        let mut existing = BTreeMap::new();
+        for review_number in pull_requests {
+            let Some(stacks) = self
+                .stacks_for_pull_request(owner, repo, *review_number)
+                .await
+                .with_context(|| {
+                    format!("Failed to inspect native stack membership for PR #{review_number}")
+                })?
+            else {
+                return Ok(None);
+            };
+            for stack in stacks {
+                existing.entry(stack.number).or_insert(stack);
+            }
+        }
+        Ok(Some(existing.into_values().collect()))
+    }
+}
+
+/// Dissolve native stacks that conflict with the desired stack shape.
+pub async fn unstack_conflicting(
+    preferred_account: Option<&crate::GithubAccountIdentifier>,
+    owner: &str,
+    repo: &str,
+    plan: &ReconcilePlan,
+    storage: &but_forge_storage::Controller,
+) -> Result<()> {
+    if plan.stack_numbers_to_unstack().is_empty() {
+        return Ok(());
+    }
+    let gh = GitHubClient::from_storage(storage, preferred_account)?;
+    for stack_number in plan.stack_numbers_to_unstack() {
+        gh.unstack(owner, repo, *stack_number)
+            .await
+            .with_context(|| format!("Failed to dissolve GitHub stack #{stack_number}"))?;
+    }
+    Ok(())
+}
+
+/// Apply the create or append portion of a prepared plan after PR targets are correct.
+pub async fn finish(
+    preferred_account: Option<&crate::GithubAccountIdentifier>,
+    owner: &str,
+    repo: &str,
+    plan: &ReconcilePlan,
+    storage: &but_forge_storage::Controller,
+) -> Result<()> {
+    let gh = GitHubClient::from_storage(storage, preferred_account)?;
+    match plan {
+        ReconcilePlan::Noop | ReconcilePlan::Dissolve { .. } => Ok(()),
+        ReconcilePlan::Create { desired } | ReconcilePlan::Rebuild { desired, .. } => gh
+            .create_stack(owner, repo, desired)
+            .await
+            .context("Failed to create GitHub native stack"),
+        ReconcilePlan::Append {
+            stack_number,
+            pull_requests,
+        } => gh
+            .add_to_stack(owner, repo, *stack_number, pull_requests)
+            .await
+            .with_context(|| format!("Failed to extend GitHub stack #{stack_number}")),
+    }
+}
+
+fn reconcile_plan(mut existing: Vec<Stack>, desired: &[i64]) -> ReconcilePlan {
+    existing.sort_by_key(|stack| stack.number);
+    let stack_numbers = existing
+        .iter()
+        .map(|stack| stack.number)
+        .collect::<Vec<_>>();
+    if desired.len() < 2 {
+        return if stack_numbers.is_empty() {
+            ReconcilePlan::Noop
+        } else {
+            ReconcilePlan::Dissolve { stack_numbers }
+        };
+    }
+    if existing.is_empty() {
+        return ReconcilePlan::Create {
+            desired: desired.to_vec(),
+        };
+    }
+    if existing.len() == 1 {
+        let stack = &existing[0];
+        let members = stack
+            .pull_requests
+            .iter()
+            .map(|review| review.number)
+            .collect::<Vec<_>>();
+        if members == desired {
+            return ReconcilePlan::Noop;
+        }
+        if desired.starts_with(&members) {
+            return ReconcilePlan::Append {
+                stack_number: stack.number,
+                pull_requests: desired[members.len()..].to_vec(),
+            };
+        }
+    }
+    ReconcilePlan::Rebuild {
+        stack_numbers,
+        desired: desired.to_vec(),
+    }
+}
+
+#[derive(Serialize)]
+struct StackMembersBody<'a> {
+    pull_requests: &'a [i64],
+}
+
+impl GitHubClient {
+    /// `Ok(None)` means the repository does not expose the native stacks endpoint.
+    async fn stacks_for_pull_request(
+        &self,
+        owner: &str,
+        repo: &str,
+        review_number: i64,
+    ) -> Result<Option<Vec<Stack>>> {
+        let response = self
+            .client
+            .get(format!("{}/repos/{owner}/{repo}/stacks", self.base_url))
+            .query(&[("pull_request", review_number)])
+            .send()
+            .await?;
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        if !response.status().is_success() {
+            bail!(
+                "Failed to list GitHub stacks: {}",
+                response_error(response).await
+            );
+        }
+        Ok(Some(response.json().await?))
+    }
+
+    async fn create_stack(&self, owner: &str, repo: &str, desired: &[i64]) -> Result<()> {
+        let response = self
+            .client
+            .post(format!("{}/repos/{owner}/{repo}/stacks", self.base_url))
+            .json(&StackMembersBody {
+                pull_requests: desired,
+            })
+            .send()
+            .await?;
+        if !response.status().is_success() {
+            bail!(
+                "Failed to create GitHub stack: {}",
+                response_error(response).await
+            );
+        }
+        Ok(())
+    }
+
+    async fn add_to_stack(
+        &self,
+        owner: &str,
+        repo: &str,
+        stack_number: i64,
+        pull_requests: &[i64],
+    ) -> Result<()> {
+        let response = self
+            .client
+            .post(format!(
+                "{}/repos/{owner}/{repo}/stacks/{stack_number}/add",
+                self.base_url
+            ))
+            .json(&StackMembersBody { pull_requests })
+            .send()
+            .await?;
+        if !response.status().is_success() {
+            bail!(
+                "Failed to add to GitHub stack: {}",
+                response_error(response).await
+            );
+        }
+        Ok(())
+    }
+
+    async fn unstack(&self, owner: &str, repo: &str, stack_number: i64) -> Result<()> {
+        let response = self
+            .client
+            .post(format!(
+                "{}/repos/{owner}/{repo}/stacks/{stack_number}/unstack",
+                self.base_url
+            ))
+            .send()
+            .await?;
+        if !response.status().is_success() {
+            bail!(
+                "Failed to unstack GitHub stack: {}",
+                response_error(response).await
+            );
+        }
+        Ok(())
+    }
+}
+
+async fn response_error(response: reqwest::Response) -> String {
+    let status = response.status();
+    match response.text().await {
+        Ok(body) if !body.is_empty() => format!("{status}: {body}"),
+        _ => status.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stack(number: i64, members: &[i64]) -> Stack {
+        Stack {
+            number,
+            pull_requests: members
+                .iter()
+                .map(|number| StackPullRequest { number: *number })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn plans_creation_for_an_unregistered_stack() {
+        assert_eq!(
+            reconcile_plan(Vec::new(), &[1, 2, 3]),
+            ReconcilePlan::Create {
+                desired: vec![1, 2, 3]
+            }
+        );
+    }
+
+    #[test]
+    fn exact_membership_is_a_noop() {
+        assert_eq!(
+            reconcile_plan(vec![stack(7, &[1, 2, 3])], &[1, 2, 3]),
+            ReconcilePlan::Noop
+        );
+    }
+
+    #[test]
+    fn only_a_top_suffix_can_be_appended() {
+        assert_eq!(
+            reconcile_plan(vec![stack(7, &[1, 2])], &[1, 2, 3, 4]),
+            ReconcilePlan::Append {
+                stack_number: 7,
+                pull_requests: vec![3, 4]
+            }
+        );
+    }
+
+    #[test]
+    fn insertion_removal_and_reorder_rebuild_the_stack() {
+        for (existing, desired) in [
+            (vec![stack(7, &[1, 3])], vec![1, 2, 3]),
+            (vec![stack(7, &[1, 2, 3])], vec![1, 3]),
+            (vec![stack(7, &[1, 2, 3])], vec![3, 2, 1]),
+        ] {
+            assert_eq!(
+                reconcile_plan(existing, &desired),
+                ReconcilePlan::Rebuild {
+                    stack_numbers: vec![7],
+                    desired
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn combining_native_stacks_dissolves_all_of_them() {
+        assert_eq!(
+            reconcile_plan(vec![stack(7, &[1, 2]), stack(9, &[3, 4])], &[1, 2, 3, 4]),
+            ReconcilePlan::Rebuild {
+                stack_numbers: vec![7, 9],
+                desired: vec![1, 2, 3, 4]
+            }
+        );
+    }
+
+    #[test]
+    fn singleton_reviews_are_not_native_stacks() {
+        assert_eq!(
+            reconcile_plan(vec![stack(7, &[1, 2])], &[1]),
+            ReconcilePlan::Dissolve {
+                stack_numbers: vec![7]
+            }
+        );
+        assert_eq!(reconcile_plan(Vec::new(), &[1]), ReconcilePlan::Noop);
+    }
+}

--- a/crates/but-server/src/lib.rs
+++ b/crates/but-server/src/lib.rs
@@ -801,7 +801,7 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
         )
         .route(
             "/set_gb_config",
-            but_post_async(legacy::config::set_gb_config_cmd),
+            but_post(legacy::config::set_gb_config_cmd),
         )
         .route(
             "/store_author_globally_if_unset",

--- a/crates/but-server/src/lib.rs
+++ b/crates/but-server/src/lib.rs
@@ -801,7 +801,7 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
         )
         .route(
             "/set_gb_config",
-            but_post(legacy::config::set_gb_config_cmd),
+            but_post_async(legacy::config::set_gb_config_cmd),
         )
         .route(
             "/store_author_globally_if_unset",

--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -410,6 +410,11 @@ Agents must use `--message (-m)`, `--file (-F)`, or `--default (-t)` to avoid ed
 
 Requires forge integration to be configured via `but config forge auth`.
 
+Use `but config forge github-stacks enable` inside a repository to let GitButler register and
+reconcile same-repository pull requests with GitHub's native stacked pull requests API. The setting
+is project-local and shared with Desktop. The repository must be enrolled in GitHub's private
+preview. Use `but config forge github-stacks disable` to return to GitButler description footers.
+
 ### `but land <branch>`
 
 Land a branch directly onto the target (e.g. `origin/master`), skipping a pull request. Fast-forwards

--- a/crates/but/src/args/config.rs
+++ b/crates/but/src/args/config.rs
@@ -566,4 +566,21 @@ pub enum ForgeSubcommand {
         /// If not provided, you'll be prompted to select which account(s) to forget.
         username: Option<String>,
     },
+
+    /// View or configure native GitHub stacked pull requests for this repository.
+    ///
+    /// This is an opt-in GitHub private-preview feature. The setting is stored in the
+    /// repository-local Git config and shared with the GitButler desktop application.
+    GithubStacks {
+        /// Enable or disable native GitHub stacked pull requests.
+        #[clap(value_enum)]
+        status: Option<GitHubStacksStatus>,
+    },
+}
+
+/// Values for the native GitHub stacks project setting.
+#[derive(Debug, Clone, Copy, clap::ValueEnum)]
+pub enum GitHubStacksStatus {
+    Enable,
+    Disable,
 }

--- a/crates/but/src/args/config.rs
+++ b/crates/but/src/args/config.rs
@@ -571,6 +571,7 @@ pub enum ForgeSubcommand {
     ///
     /// This is an opt-in GitHub private-preview feature. The setting is stored in the
     /// repository-local Git config and shared with the GitButler desktop application.
+    #[cfg(feature = "legacy")]
     GithubStacks {
         /// Enable or disable native GitHub stacked pull requests.
         #[clap(value_enum)]
@@ -579,6 +580,7 @@ pub enum ForgeSubcommand {
 }
 
 /// Values for the native GitHub stacks project setting.
+#[cfg(feature = "legacy")]
 #[derive(Debug, Clone, Copy, clap::ValueEnum)]
 pub enum GitHubStacksStatus {
     Enable,

--- a/crates/but/src/command/config.rs
+++ b/crates/but/src/command/config.rs
@@ -6,8 +6,10 @@
 use std::fmt::{Display, Write};
 
 use anyhow::{Context as _, Result};
+#[cfg(feature = "legacy")]
+use but_core::{GitConfigSettings, GitHubStackingMode};
 use but_core::{
-    GitConfigSettings, GitHubStackingMode, RepositoryExt,
+    RepositoryExt,
     git_config::{remove_config_value, set_config_value},
 };
 use but_ctx::Context;
@@ -28,10 +30,12 @@ use gix::bstr::ByteSlice as _;
 use serde::Serialize;
 
 use super::git_config::edit_git_config;
+#[cfg(feature = "legacy")]
+use crate::args::config::GitHubStacksStatus;
 use crate::{
     args::config::{
-        AiKeyOption, AiSubcommand, FeatureFlag, FeatureStatus, ForgeSubcommand, GitHubStacksStatus,
-        MetricsStatus, Subcommands, UiSubcommand, UserSubcommand,
+        AiKeyOption, AiSubcommand, FeatureFlag, FeatureStatus, ForgeSubcommand, MetricsStatus,
+        Subcommands, UiSubcommand, UserSubcommand,
     },
     theme::{self, Paint},
     tui,
@@ -100,6 +104,7 @@ pub async fn exec(
             push_remote,
         }) => target_config(ctx, out, branch, push_remote).await,
         Some(Subcommands::PushRemote { remote }) => push_remote_config(ctx, out, remote),
+        #[cfg(feature = "legacy")]
         Some(Subcommands::Forge {
             cmd: Some(ForgeSubcommand::GithubStacks { status }),
         }) => github_stacks_config(ctx, out, status).await,
@@ -670,6 +675,7 @@ pub(crate) async fn forge_config(
         Some(ForgeSubcommand::Auth) => forge_auth(out).await,
         Some(ForgeSubcommand::ListUsers) => forge_show_overview(out).await,
         Some(ForgeSubcommand::Forget { username }) => forge_forget(username, out).await,
+        #[cfg(feature = "legacy")]
         Some(ForgeSubcommand::GithubStacks { .. }) => {
             anyhow::bail!("GitHub stacks configuration requires a repository")
         }
@@ -677,6 +683,7 @@ pub(crate) async fn forge_config(
     }
 }
 
+#[cfg(feature = "legacy")]
 pub(crate) async fn github_stacks_config(
     ctx: &mut Context,
     out: &mut OutputChannel,

--- a/crates/but/src/command/config.rs
+++ b/crates/but/src/command/config.rs
@@ -694,6 +694,8 @@ pub(crate) async fn github_stacks_config(
                     gitbutler_github_stacking_mode: Some(mode),
                     ..Default::default()
                 })?;
+                drop(repo);
+                ctx.repo.take();
                 mode
             }
             None => repo

--- a/crates/but/src/command/config.rs
+++ b/crates/but/src/command/config.rs
@@ -6,7 +6,10 @@
 use std::fmt::{Display, Write};
 
 use anyhow::{Context as _, Result};
-use but_core::git_config::{remove_config_value, set_config_value};
+use but_core::{
+    GitConfigSettings, GitHubStackingMode, RepositoryExt,
+    git_config::{remove_config_value, set_config_value},
+};
 use but_ctx::Context;
 use but_llm::{
     AI_ANTHROPIC_KEY_OPTION_KEY, AI_ANTHROPIC_MODEL_NAME_KEY, AI_ANTHROPIC_SECRET_HANDLE,
@@ -27,8 +30,8 @@ use serde::Serialize;
 use super::git_config::edit_git_config;
 use crate::{
     args::config::{
-        AiKeyOption, AiSubcommand, FeatureFlag, FeatureStatus, ForgeSubcommand, MetricsStatus,
-        Subcommands, UiSubcommand, UserSubcommand,
+        AiKeyOption, AiSubcommand, FeatureFlag, FeatureStatus, ForgeSubcommand, GitHubStacksStatus,
+        MetricsStatus, Subcommands, UiSubcommand, UserSubcommand,
     },
     theme::{self, Paint},
     tui,
@@ -97,6 +100,9 @@ pub async fn exec(
             push_remote,
         }) => target_config(ctx, out, branch, push_remote).await,
         Some(Subcommands::PushRemote { remote }) => push_remote_config(ctx, out, remote),
+        Some(Subcommands::Forge {
+            cmd: Some(ForgeSubcommand::GithubStacks { status }),
+        }) => github_stacks_config(ctx, out, status).await,
         Some(Subcommands::Forge { cmd }) => forge_config(out, cmd).await,
         Some(Subcommands::Metrics { status }) => metrics_config(out, status).await,
         Some(Subcommands::Feature { flag, status }) => feature_config(out, flag, status),
@@ -664,8 +670,86 @@ pub(crate) async fn forge_config(
         Some(ForgeSubcommand::Auth) => forge_auth(out).await,
         Some(ForgeSubcommand::ListUsers) => forge_show_overview(out).await,
         Some(ForgeSubcommand::Forget { username }) => forge_forget(username, out).await,
+        Some(ForgeSubcommand::GithubStacks { .. }) => {
+            anyhow::bail!("GitHub stacks configuration requires a repository")
+        }
         None => forge_show_overview(out).await,
     }
+}
+
+pub(crate) async fn github_stacks_config(
+    ctx: &mut Context,
+    out: &mut OutputChannel,
+    status: Option<GitHubStacksStatus>,
+) -> Result<()> {
+    let configured = {
+        let repo = ctx.repo.get()?;
+        match status {
+            Some(status) => {
+                let mode = match status {
+                    GitHubStacksStatus::Enable => GitHubStackingMode::Native,
+                    GitHubStacksStatus::Disable => GitHubStackingMode::Disabled,
+                };
+                repo.set_git_settings(&GitConfigSettings {
+                    gitbutler_github_stacking_mode: Some(mode),
+                    ..Default::default()
+                })?;
+                mode
+            }
+            None => repo
+                .git_settings()?
+                .gitbutler_github_stacking_mode
+                .unwrap_or(GitHubStackingMode::Disabled),
+        }
+    };
+    let review_sync = if status.is_some() {
+        Some(but_api::legacy::forge::sync_all_review_stacks(ctx.to_sync()).await)
+    } else {
+        None
+    };
+    let enabled = configured == GitHubStackingMode::Native;
+    if let Some(out) = out.for_human() {
+        let t = theme::get();
+        let symbol = if status.is_some() {
+            &t.sym().success
+        } else {
+            &t.sym().dot
+        };
+        writeln!(
+            out,
+            "{} Native GitHub stacks are {} for this repository",
+            symbol,
+            if enabled {
+                t.success.paint("enabled")
+            } else {
+                t.hint.paint("disabled")
+            }
+        )?;
+        if enabled {
+            writeln!(
+                out,
+                "{}",
+                t.hint.paint(
+                    "The repository must be enrolled in GitHub's stacked pull requests preview."
+                )
+            )?;
+        }
+        if let Some(but_forge::ReviewSyncOutcome::Failed { message }) = &review_sync {
+            writeln!(
+                out,
+                "{} Setting updated, but stack synchronization failed: {message}",
+                t.sym().warning
+            )?;
+        }
+    } else if let Some(out) = out.for_shell() {
+        writeln!(out, "{}", if enabled { "enabled" } else { "disabled" })?;
+    } else if let Some(out) = out.for_json() {
+        out.write_value(serde_json::json!({
+            "mode": if enabled { "native" } else { "disabled" },
+            "reviewSync": review_sync,
+        }))?;
+    }
+    Ok(())
 }
 
 /// Show overview of forge configuration (same as list-users)

--- a/crates/but/src/command/config.rs
+++ b/crates/but/src/command/config.rs
@@ -107,7 +107,7 @@ pub async fn exec(
         #[cfg(feature = "legacy")]
         Some(Subcommands::Forge {
             cmd: Some(ForgeSubcommand::GithubStacks { status }),
-        }) => github_stacks_config(ctx, out, status).await,
+        }) => github_stacks_config(ctx, out, status),
         Some(Subcommands::Forge { cmd }) => forge_config(out, cmd).await,
         Some(Subcommands::Metrics { status }) => metrics_config(out, status).await,
         Some(Subcommands::Feature { flag, status }) => feature_config(out, flag, status),
@@ -684,7 +684,7 @@ pub(crate) async fn forge_config(
 }
 
 #[cfg(feature = "legacy")]
-pub(crate) async fn github_stacks_config(
+pub(crate) fn github_stacks_config(
     ctx: &mut Context,
     out: &mut OutputChannel,
     status: Option<GitHubStacksStatus>,
@@ -701,8 +701,6 @@ pub(crate) async fn github_stacks_config(
                     gitbutler_github_stacking_mode: Some(mode),
                     ..Default::default()
                 })?;
-                drop(repo);
-                ctx.repo.take();
                 mode
             }
             None => repo
@@ -710,11 +708,6 @@ pub(crate) async fn github_stacks_config(
                 .gitbutler_github_stacking_mode
                 .unwrap_or(GitHubStackingMode::Disabled),
         }
-    };
-    let review_sync = if status.is_some() {
-        Some(but_api::legacy::forge::sync_all_review_stacks(ctx.to_sync()).await)
-    } else {
-        None
     };
     let enabled = configured == GitHubStackingMode::Native;
     if let Some(out) = out.for_human() {
@@ -743,19 +736,11 @@ pub(crate) async fn github_stacks_config(
                 )
             )?;
         }
-        if let Some(but_forge::ReviewSyncOutcome::Failed { message }) = &review_sync {
-            writeln!(
-                out,
-                "{} Setting updated, but stack synchronization failed: {message}",
-                t.sym().warning
-            )?;
-        }
     } else if let Some(out) = out.for_shell() {
         writeln!(out, "{}", if enabled { "enabled" } else { "disabled" })?;
     } else if let Some(out) = out.for_json() {
         out.write_value(serde_json::json!({
             "mode": if enabled { "native" } else { "disabled" },
-            "reviewSync": review_sync,
         }))?;
     }
     Ok(())

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -539,6 +539,26 @@ async fn match_subcommand(
                         .emit_metrics(metrics_ctx)
                         .map_err(CliError::from)
                 }
+                Some(args::config::Subcommands::Forge {
+                    cmd: Some(args::config::ForgeSubcommand::GithubStacks { .. }),
+                }) => {
+                    // Repository-local setting; handled below after project setup.
+                    cfg_if! {
+                        if #[cfg(feature = "legacy")] {
+                            let mut ctx = setup::init_ctx(&args, InitCtxOptions {
+                                background_sync: BackgroundSync::Disabled,
+                                target_requirement: TargetRequirement::Optional,
+                                ..Default::default()
+                            }, out)?;
+                            command::config::exec(&mut ctx, out, cmd)
+                                .await
+                                .emit_metrics(metrics_ctx)
+                                .map_err(CliError::from)
+                        } else {
+                            unreachable!("repository-local config requires the legacy setup path")
+                        }
+                    }
+                }
                 Some(args::config::Subcommands::Forge { cmd: forge_cmd }) => {
                     command::config::forge_config(out, forge_cmd.clone())
                         .await

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -539,25 +539,24 @@ async fn match_subcommand(
                         .emit_metrics(metrics_ctx)
                         .map_err(CliError::from)
                 }
+                #[cfg(feature = "legacy")]
                 Some(args::config::Subcommands::Forge {
                     cmd: Some(args::config::ForgeSubcommand::GithubStacks { .. }),
                 }) => {
                     // Repository-local setting; handled below after project setup.
-                    cfg_if! {
-                        if #[cfg(feature = "legacy")] {
-                            let mut ctx = setup::init_ctx(&args, InitCtxOptions {
-                                background_sync: BackgroundSync::Disabled,
-                                target_requirement: TargetRequirement::Optional,
-                                ..Default::default()
-                            }, out)?;
-                            command::config::exec(&mut ctx, out, cmd)
-                                .await
-                                .emit_metrics(metrics_ctx)
-                                .map_err(CliError::from)
-                        } else {
-                            unreachable!("repository-local config requires the legacy setup path")
-                        }
-                    }
+                    let mut ctx = setup::init_ctx(
+                        &args,
+                        InitCtxOptions {
+                            background_sync: BackgroundSync::Disabled,
+                            target_requirement: TargetRequirement::Optional,
+                            ..Default::default()
+                        },
+                        out,
+                    )?;
+                    command::config::exec(&mut ctx, out, cmd)
+                        .await
+                        .emit_metrics(metrics_ctx)
+                        .map_err(CliError::from)
                 }
                 Some(args::config::Subcommands::Forge { cmd: forge_cmd }) => {
                     command::config::forge_config(out, forge_cmd.clone())

--- a/crates/but/tests/but/command/config.rs
+++ b/crates/but/tests/but/command/config.rs
@@ -28,10 +28,7 @@ The repository must be enrolled in GitHub's stacked pull requests preview.
         .success()
         .stdout_eq(str![[r#"
 {
-  "mode": "disabled",
-  "reviewSync": {
-    "status": "notNeeded"
-  }
+  "mode": "disabled"
 }
 
 "#]]);

--- a/crates/but/tests/but/command/config.rs
+++ b/crates/but/tests/but/command/config.rs
@@ -1,6 +1,58 @@
 use crate::utils::{CommandExt as _, Sandbox};
 use snapbox::str;
 
+#[test]
+fn github_stacks_configuration_is_repository_local() {
+    let env = Sandbox::open_with_default_settings("repo-with-remote-and-head");
+
+    env.but("config forge github-stacks enable")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+✓ Native GitHub stacks are enabled for this repository
+The repository must be enrolled in GitHub's stacked pull requests preview.
+
+"#]]);
+    assert_eq!(
+        env.invoke_git("config --local --get gitbutler.githubStackingMode"),
+        "native"
+    );
+    env.but("--format shell config forge github-stacks")
+        .assert()
+        .success()
+        .stdout_eq("enabled\n");
+    env.but("--format json config forge github-stacks disable")
+        .allow_json()
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+{
+  "mode": "disabled",
+  "reviewSync": {
+    "status": "notNeeded"
+  }
+}
+
+"#]]);
+    assert_eq!(
+        env.invoke_git("config --local --get gitbutler.githubStackingMode"),
+        "disabled"
+    );
+}
+
+#[test]
+fn github_stacks_configuration_requires_a_repository() {
+    Sandbox::empty()
+        .but("config forge github-stacks enable")
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
+Error: No git repository found at .
+Please run 'but setup' to initialize the project.
+
+"#]]);
+}
+
 #[cfg(feature = "legacy")]
 #[test]
 fn target_configures_distinct_push_remote_for_fork() {

--- a/crates/but/tests/but/command/config.rs
+++ b/crates/but/tests/but/command/config.rs
@@ -1,6 +1,7 @@
 use crate::utils::{CommandExt as _, Sandbox};
 use snapbox::str;
 
+#[cfg(feature = "legacy")]
 #[test]
 fn github_stacks_configuration_is_repository_local() {
     let env = Sandbox::open_with_default_settings("repo-with-remote-and-head");
@@ -40,6 +41,7 @@ The repository must be enrolled in GitHub's stacked pull requests preview.
     );
 }
 
+#[cfg(feature = "legacy")]
 #[test]
 fn github_stacks_configuration_requires_a_repository() {
     Sandbox::empty()

--- a/e2e/playwright/src/fakeGithub.ts
+++ b/e2e/playwright/src/fakeGithub.ts
@@ -17,6 +17,7 @@ export type FakeGitHubOptions = {
 	listed?: boolean;
 	failReviewUpdates?: boolean;
 	failGitPushes?: boolean;
+	nativeStacks?: boolean;
 };
 
 type ResolvedFakeGitHubOptions = {
@@ -39,6 +40,8 @@ export type FakeGitHubServer = {
 	getReviews: () => FakeGitHubReview[];
 	getReviewUpdateCount: () => number;
 	getReviewUpdateHistory: (number: number) => ReviewMutation[];
+	getNativeStacks: () => FakeGitHubStack[];
+	getNativeStackMutationHistory: () => NativeStackMutation[];
 	setReviewUpdatesFailing: (failing: boolean) => void;
 	setFailingReviewUpdates: (numbers: number[]) => void;
 	setGitPushesFailing: (failing: boolean) => void;
@@ -55,6 +58,16 @@ export type ReviewMutation = {
 	draft?: boolean;
 };
 
+export type FakeGitHubStack = {
+	number: number;
+	pull_requests: Array<{ number: number }>;
+};
+
+export type NativeStackMutation =
+	| { operation: "create"; pullRequests: number[] }
+	| { operation: "add"; stackNumber: number; pullRequests: number[] }
+	| { operation: "unstack"; stackNumber: number };
+
 export async function startFakeGitHubServer({
 	headRepoPath,
 	forkRepoPath,
@@ -69,6 +82,7 @@ export async function startFakeGitHubServer({
 	listed = true,
 	failReviewUpdates = false,
 	failGitPushes = false,
+	nativeStacks = false,
 }: FakeGitHubOptions): Promise<FakeGitHubServer> {
 	const reviewRepoPath = headRepoPath ?? forkRepoPath;
 	if (!reviewRepoPath) {
@@ -94,6 +108,9 @@ export async function startFakeGitHubServer({
 	let reviewUpdatesFailing = failReviewUpdates;
 	let failingReviewUpdates = new Set<number>();
 	let gitPushesFailing = failGitPushes;
+	const githubStacks = new Map<number, FakeGitHubStack>();
+	const nativeStackMutationHistory: NativeStackMutation[] = [];
+	let nextStackNumber = 1;
 
 	const sockets = new Set<Socket>();
 	const server = http.createServer((request, response) => {
@@ -147,6 +164,39 @@ export async function startFakeGitHubServer({
 				reviews.set(number, updated);
 				return { status: "updated" as const, review: updated };
 			},
+			listStacks(reviewNumber) {
+				if (!nativeStacks) return undefined;
+				return [...githubStacks.values()].filter(
+					(stack) =>
+						reviewNumber === undefined ||
+						stack.pull_requests.some((review) => review.number === reviewNumber),
+				);
+			},
+			createStack(pullRequests) {
+				const stack = nativeStackPayload(nextStackNumber++, pullRequests);
+				githubStacks.set(stack.number, stack);
+				nativeStackMutationHistory.push({
+					operation: "create",
+					pullRequests: [...pullRequests],
+				});
+				return stack;
+			},
+			addToStack(stackNumber, pullRequests) {
+				const current = githubStacks.get(stackNumber);
+				if (!current) return undefined;
+				current.pull_requests.push(...pullRequests.map((number) => ({ number })));
+				nativeStackMutationHistory.push({
+					operation: "add",
+					stackNumber,
+					pullRequests: [...pullRequests],
+				});
+				return current;
+			},
+			unstack(stackNumber) {
+				if (!githubStacks.delete(stackNumber)) return false;
+				nativeStackMutationHistory.push({ operation: "unstack", stackNumber });
+				return true;
+			},
 		}).catch((error: unknown) => {
 			response.writeHead(500, { "Content-Type": "application/json" });
 			response.end(JSON.stringify({ message: String(error) }));
@@ -184,6 +234,11 @@ export async function startFakeGitHubServer({
 		getReviewUpdateCount: () => reviewUpdateCount,
 		getReviewUpdateHistory: (number) =>
 			(reviewUpdateHistory.get(number) ?? []).map((update) => structuredClone(update)),
+		getNativeStacks: () =>
+			[...githubStacks.values()]
+				.sort((a, b) => a.number - b.number)
+				.map((stack) => structuredClone(stack)),
+		getNativeStackMutationHistory: () => structuredClone(nativeStackMutationHistory),
 		setReviewUpdatesFailing: (failing) => {
 			reviewUpdatesFailing = failing;
 		},
@@ -218,10 +273,15 @@ async function handleRequest(
 			| { status: "updated"; review: FakeGitHubReview }
 			| { status: "notFound" }
 			| { status: "failed" };
+		listStacks: (reviewNumber?: number) => FakeGitHubStack[] | undefined;
+		createStack: (pullRequests: number[]) => FakeGitHubStack;
+		addToStack: (stackNumber: number, pullRequests: number[]) => FakeGitHubStack | undefined;
+		unstack: (stackNumber: number) => boolean;
 	},
 ) {
 	const url = new URL(request.url ?? "/", "http://127.0.0.1");
 	const pullPath = `/api/v3/repos/${options.owner}/${options.repo}/pulls`;
+	const stacksPath = `/api/v3/repos/${options.owner}/${options.repo}/stacks`;
 
 	if (request.method === "GET" && url.pathname === "/api/v3/user") {
 		return json(response, {
@@ -257,6 +317,31 @@ async function handleRequest(
 		}
 		return result.status === "updated"
 			? json(response, result.review)
+			: json(response, { message: "Not Found" }, 404);
+	}
+
+	if (request.method === "GET" && url.pathname === stacksPath) {
+		const requestedReview = url.searchParams.get("pull_request");
+		const stacks = state.listStacks(requestedReview === null ? undefined : Number(requestedReview));
+		return stacks === undefined
+			? json(response, { message: "Not Found" }, 404)
+			: json(response, stacks);
+	}
+
+	if (request.method === "POST" && url.pathname === stacksPath) {
+		const input = JSON.parse(await readBody(request)) as { pull_requests: number[] };
+		return json(response, state.createStack(input.pull_requests), 201);
+	}
+
+	const stackMutation = nativeStackMutationFromPath(url.pathname, stacksPath);
+	if (request.method === "POST" && stackMutation?.operation === "add") {
+		const input = JSON.parse(await readBody(request)) as { pull_requests: number[] };
+		const stack = state.addToStack(stackMutation.stackNumber, input.pull_requests);
+		return stack ? json(response, stack) : json(response, { message: "Not Found" }, 404);
+	}
+	if (request.method === "POST" && stackMutation?.operation === "unstack") {
+		return state.unstack(stackMutation.stackNumber)
+			? json(response, {}, 200)
 			: json(response, { message: "Not Found" }, 404);
 	}
 
@@ -351,6 +436,29 @@ function reviewNumberFromPath(pathname: string, pullPath: string): number | unde
 	if (!pathname.startsWith(`${pullPath}/`)) return undefined;
 	const value = Number(pathname.slice(pullPath.length + 1));
 	return Number.isSafeInteger(value) ? value : undefined;
+}
+
+function nativeStackMutationFromPath(
+	pathname: string,
+	stacksPath: string,
+): { stackNumber: number; operation: "add" | "unstack" } | undefined {
+	const match = pathname.match(new RegExp(`^${escapeRegExp(stacksPath)}/(\\d+)/(add|unstack)$`));
+	if (!match) return undefined;
+	return {
+		stackNumber: Number(match[1]),
+		operation: match[2] as "add" | "unstack",
+	};
+}
+
+function nativeStackPayload(number: number, pullRequests: number[]): FakeGitHubStack {
+	return {
+		number,
+		pull_requests: pullRequests.map((reviewNumber) => ({ number: reviewNumber })),
+	};
+}
+
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function unqualifiedHeadRef(head: string): string {

--- a/e2e/playwright/src/fakeGithub.ts
+++ b/e2e/playwright/src/fakeGithub.ts
@@ -30,6 +30,7 @@ type ResolvedFakeGitHubOptions = {
 	reviewNumber: number;
 	title: string;
 	isFork: boolean;
+	nativeStacks: boolean;
 };
 
 export type FakeGitHubServer = {
@@ -99,6 +100,7 @@ export async function startFakeGitHubServer({
 		reviewNumber,
 		title,
 		isFork,
+		nativeStacks,
 	};
 	const reviews = new Map<number, FakeGitHubReview>([[reviewNumber, pullRequestPayload(options)]]);
 	let nextReviewNumber = reviewNumber;
@@ -282,6 +284,11 @@ async function handleRequest(
 	const url = new URL(request.url ?? "/", "http://127.0.0.1");
 	const pullPath = `/api/v3/repos/${options.owner}/${options.repo}/pulls`;
 	const stacksPath = `/api/v3/repos/${options.owner}/${options.repo}/stacks`;
+	const stackMutation = nativeStackMutationFromPath(url.pathname, stacksPath);
+
+	if (!options.nativeStacks && (url.pathname === stacksPath || stackMutation !== undefined)) {
+		return json(response, { message: "Not Found" }, 404);
+	}
 
 	if (request.method === "GET" && url.pathname === "/api/v3/user") {
 		return json(response, {
@@ -333,7 +340,6 @@ async function handleRequest(
 		return json(response, state.createStack(input.pull_requests), 201);
 	}
 
-	const stackMutation = nativeStackMutationFromPath(url.pathname, stacksPath);
 	if (request.method === "POST" && stackMutation?.operation === "add") {
 		const input = JSON.parse(await readBody(request)) as { pull_requests: number[] };
 		const stack = state.addToStack(stackMutation.stackNumber, input.pull_requests);

--- a/e2e/playwright/tests/reviewStackingDescription.spec.ts
+++ b/e2e/playwright/tests/reviewStackingDescription.spec.ts
@@ -627,7 +627,7 @@ test("reordering reviewed refs updates every target after a partial push", async
 
 	const beforePartialPush = reviewHistoryLengths(server, [42, 43, 44]);
 	await gitbutler.runScript("push-branch.sh", ["branch3"]);
-	await expectReviewHistoryDeltas(server, beforePartialPush, { 42: 1, 43: 1, 44: 1 });
+	await expectReviewHistoryDeltas(server, beforePartialPush, { 42: 1, 43: 2, 44: 2 });
 	await expectReviews(server, 3, (reviews) => {
 		expect(reviews.map((review) => review.base.ref)).toEqual(["master", "branch3", "branch1"]);
 		for (const review of reviews) {
@@ -893,6 +893,66 @@ test("a Git push failure does not start review synchronization", async ({
 			message: "review synchronization must not start after the Git push fails",
 		})
 		.toBe(beforeFailedPush);
+});
+
+test("a failed reordered push restores temporarily flattened review targets", async ({
+	page,
+	gitbutler,
+	fakeGithub,
+}) => {
+	const server = await fakeGithub({
+		headRepoPath: gitbutler.pathInWorkdir("remote-project"),
+		isFork: false,
+		listed: false,
+	});
+	await gitbutler.runScript("project-with-stacks.sh", [server.repositoryUrl]);
+	await storeFakeGitHubEnterprisePat(page, server);
+	mirrorFakeCredentialForCli(gitbutler);
+	await applyUpstream(gitbutler, "branch1", "branch2", "branch3");
+	await mockForge(page, {
+		get_review_merge_status: mergeStatus(),
+		get_repo_info: repoInfo(),
+		list_ci_checks: [],
+	});
+	await openWorkspace(page);
+	const branchHeaders = page.getByTestId("branch-header");
+	for (const [branch, parent, remainingStacks] of [
+		["branch2", "branch1", 2],
+		["branch3", "branch2", 1],
+	] as const) {
+		await dragAndDropByLocator(
+			page,
+			branchHeaders.filter({ hasText: branch }),
+			branchHeaders.filter({ hasText: parent }),
+			{ force: true, position: { x: 120, y: -10 } },
+		);
+		await expect(stack(page)).toHaveCount(remainingStacks);
+	}
+	await gitbutler.runScript("push-branch.sh", ["branch3"]);
+
+	await publishReview(page, "branch1", "Description for branch1");
+	server.setListed(true);
+	await publishReview(page, "branch2", "Description for branch2");
+	await publishReview(page, "branch3", "Description for branch3");
+	await expect(page.getByText("PR #44 created successfully")).toBeVisible();
+
+	await dragAndDropByLocator(
+		page,
+		branchHeaders.filter({ hasText: "branch2" }),
+		branchHeaders.filter({ hasText: "branch3" }),
+		{ force: true, position: { x: 120, y: -10 } },
+	);
+	await expectBranchHeaderOrder(page, ["branch2", "branch3", "branch1"]);
+
+	const beforeFailedPush = reviewHistoryLengths(server, [42, 43, 44]);
+	server.setGitPushesFailing(true);
+	await expect(gitbutler.runScript("push-branch.sh", ["branch3"])).rejects.toThrow(
+		"Command failed with exit code",
+	);
+	await expectReviewHistoryDeltas(server, beforeFailedPush, { 42: 0, 43: 2, 44: 2 });
+	await expectReviews(server, 3, (reviews) => {
+		expect(reviews.map((review) => review.base.ref)).toEqual(["master", "branch1", "branch2"]);
+	});
 });
 
 async function combineBranchesIntoStack(page: Page) {

--- a/e2e/playwright/tests/reviewStackingDescription.spec.ts
+++ b/e2e/playwright/tests/reviewStackingDescription.spec.ts
@@ -26,6 +26,34 @@ type PushOutcome = {
 		| { status: "failed"; message: string };
 };
 
+test("GitHub native stack endpoints are unavailable when unsupported", async ({
+	gitbutler,
+	fakeGithub,
+}) => {
+	const server = await fakeGithub({
+		headRepoPath: gitbutler.pathInWorkdir("remote-project"),
+		nativeStacks: false,
+	});
+	const stacksUrl = `${server.apiBaseUrl}/repos/acme/widgets/stacks`;
+	const requests = [
+		fetch(stacksUrl),
+		fetch(stacksUrl, {
+			method: "POST",
+			body: JSON.stringify({ pull_requests: [42] }),
+		}),
+		fetch(`${stacksUrl}/1/add`, {
+			method: "POST",
+			body: JSON.stringify({ pull_requests: [42] }),
+		}),
+		fetch(`${stacksUrl}/1/unstack`, { method: "POST" }),
+	];
+
+	for (const response of await Promise.all(requests)) {
+		expect(response.status).toBe(404);
+	}
+	expect(server.getNativeStackMutationHistory()).toEqual([]);
+});
+
 test("review stack descriptions follow the per-project policy", async ({
 	page,
 	gitbutler,

--- a/e2e/playwright/tests/reviewStackingDescription.spec.ts
+++ b/e2e/playwright/tests/reviewStackingDescription.spec.ts
@@ -479,10 +479,8 @@ test("GitHub native stacks are rebuilt when a review is created in the middle", 
 		.toEqual([{ number: 1, pull_requests: [{ number: 42 }, { number: 43 }] }]);
 	await expectReviews(server, 2, (reviews) => {
 		expect(reviews.map((review) => review.base.ref)).toEqual(["master", "branch1"]);
-		for (const review of reviews) {
-			expect(review.body).not.toContain(FOOTER_TOP);
-			expect(review.body).not.toContain(FOOTER_BOTTOM);
-		}
+		expectBottomFooter(reviews[0], "Description for branch1", "part 1 of 2");
+		expectBottomFooter(reviews[1], "Description for branch2", "part 2 of 2");
 	});
 
 	await dragAndDropByLocator(
@@ -514,10 +512,9 @@ test("GitHub native stacks are rebuilt when a review is created in the middle", 
 	]);
 	await expectReviews(server, 3, (reviews) => {
 		expect(reviews.map((review) => review.base.ref)).toEqual(["master", "branch3", "branch1"]);
-		for (const review of reviews) {
-			expect(review.body).not.toContain(FOOTER_TOP);
-			expect(review.body).not.toContain(FOOTER_BOTTOM);
-		}
+		expectBottomFooter(reviews[0], "Description for branch1", "part 1 of 3");
+		expectBottomFooter(reviews[1], "Description for branch2", "part 3 of 3");
+		expectBottomFooter(reviews[2], "Description for branch3", "part 2 of 3");
 	});
 
 	await setGitHubStackingMode(page, gitbutler, "disabled");

--- a/e2e/playwright/tests/reviewStackingDescription.spec.ts
+++ b/e2e/playwright/tests/reviewStackingDescription.spec.ts
@@ -330,7 +330,7 @@ test("local moves do not update reviews and partial pushes synchronize the compl
 	await gitbutler.runScript("push-branch.sh", ["branch2"]);
 	await expectReviewHistoryDeltas(server, beforeMiddlePush, {
 		42: 1,
-		43: 1,
+		43: 2,
 		44: 1,
 		45: 0,
 	});
@@ -479,6 +479,7 @@ test("GitHub native stacks are rebuilt when a review is created in the middle", 
 	});
 	await gitbutler.runScript("project-with-stacks.sh", [server.repositoryUrl]);
 	await storeFakeGitHubEnterprisePat(page, server);
+	mirrorFakeCredentialForCli(gitbutler);
 	await applyUpstream(gitbutler, "branch1", "branch2", "branch3");
 	await mockForge(page, {
 		get_review_merge_status: mergeStatus(),
@@ -702,7 +703,7 @@ test("removing a reviewed middle ref is reflected after pushing the remaining st
 
 	const beforeRemainingStackPush = reviewHistoryLengths(server, [42, 43, 44]);
 	await gitbutler.runScript("push-branch.sh", ["branch3"]);
-	await expectReviewHistoryDeltas(server, beforeRemainingStackPush, { 42: 1, 43: 1, 44: 1 });
+	await expectReviewHistoryDeltas(server, beforeRemainingStackPush, { 42: 1, 43: 1, 44: 2 });
 	await expectReviews(server, 3, (reviews) => {
 		const [reviewA, reviewB, reviewC] = reviews;
 		expect(reviewA?.base.ref).toBe("master");
@@ -776,7 +777,7 @@ test("moving a reviewed ref between reviewed stacks continues after one stack up
 	server.setFailingReviewUpdates([42]);
 	const beforePush = reviewHistoryLengths(server, [42, 43, 44, 45]);
 	await gitbutler.runScript("push-branch.sh", ["branch2"]);
-	await expectReviewHistoryDeltas(server, beforePush, { 42: 1, 43: 1, 44: 1, 45: 1 });
+	await expectReviewHistoryDeltas(server, beforePush, { 42: 1, 43: 2, 44: 1, 45: 2 });
 	await expectReviews(server, 4, (reviews) => {
 		const [reviewA, reviewB, reviewC, reviewD] = reviews;
 		expect(reviews.map((review) => review.base.ref)).toEqual([

--- a/e2e/playwright/tests/reviewStackingDescription.spec.ts
+++ b/e2e/playwright/tests/reviewStackingDescription.spec.ts
@@ -17,6 +17,7 @@ import type { FakeGitHubReview, FakeGitHubServer } from "../src/fakeGithub.ts";
 const FOOTER_TOP = "<!-- GitButler Footer Boundary Top -->";
 const FOOTER_BOTTOM = "<!-- GitButler Footer Boundary Bottom -->";
 const POLICY_KEY = "gitbutler.reviewStackingDescription";
+const GITHUB_STACKING_KEY = "gitbutler.githubStackingMode";
 
 type PushOutcome = {
 	reviewSync:
@@ -437,6 +438,111 @@ test("creating a review in the middle synchronizes the complete review stack", a
 	});
 });
 
+test("GitHub native stacks are rebuilt when a review is created in the middle", async ({
+	page,
+	gitbutler,
+	fakeGithub,
+}) => {
+	const server = await fakeGithub({
+		headRepoPath: gitbutler.pathInWorkdir("remote-project"),
+		isFork: false,
+		listed: false,
+		nativeStacks: true,
+	});
+	await gitbutler.runScript("project-with-stacks.sh", [server.repositoryUrl]);
+	await storeFakeGitHubEnterprisePat(page, server);
+	await applyUpstream(gitbutler, "branch1", "branch2", "branch3");
+	await mockForge(page, {
+		get_review_merge_status: mergeStatus(),
+		get_repo_info: repoInfo(),
+		list_ci_checks: [],
+	});
+	await openWorkspace(page);
+	await setGitHubStackingMode(page, gitbutler, "native");
+
+	const branchHeaders = page.getByTestId("branch-header");
+	await dragAndDropByLocator(
+		page,
+		branchHeaders.filter({ hasText: "branch2" }),
+		branchHeaders.filter({ hasText: "branch1" }),
+		{ force: true, position: { x: 120, y: -10 } },
+	);
+	await expect(stack(page)).toHaveCount(2);
+	await gitbutler.runScript("push-branch.sh", ["branch2"]);
+
+	await publishReview(page, "branch1", "Description for branch1");
+	server.setListed(true);
+	await publishReview(page, "branch2", "Description for branch2");
+	await expect(page.getByText("PR #43 created successfully")).toBeVisible();
+	await expect
+		.poll(() => server.getNativeStacks())
+		.toEqual([{ number: 1, pull_requests: [{ number: 42 }, { number: 43 }] }]);
+	await expectReviews(server, 2, (reviews) => {
+		expect(reviews.map((review) => review.base.ref)).toEqual(["master", "branch1"]);
+		for (const review of reviews) {
+			expect(review.body).not.toContain(FOOTER_TOP);
+			expect(review.body).not.toContain(FOOTER_BOTTOM);
+		}
+	});
+
+	await dragAndDropByLocator(
+		page,
+		branchHeaders.filter({ hasText: "branch3" }),
+		branchHeaders.filter({ hasText: "branch1" }),
+		{ force: true, position: { x: 120, y: 0 } },
+	);
+	await expect(stack(page)).toHaveCount(1);
+	await gitbutler.runScript("push-branch.sh", ["branch2"]);
+	expect(server.getNativeStackMutationHistory()).toEqual([
+		{ operation: "create", pullRequests: [42, 43] },
+	]);
+
+	await publishReview(page, "branch3", "Description for branch3");
+	await expect(page.getByText("PR #44 created successfully")).toBeVisible();
+	await expect
+		.poll(() => server.getNativeStacks())
+		.toEqual([
+			{
+				number: 2,
+				pull_requests: [{ number: 42 }, { number: 44 }, { number: 43 }],
+			},
+		]);
+	expect(server.getNativeStackMutationHistory()).toEqual([
+		{ operation: "create", pullRequests: [42, 43] },
+		{ operation: "unstack", stackNumber: 1 },
+		{ operation: "create", pullRequests: [42, 44, 43] },
+	]);
+	await expectReviews(server, 3, (reviews) => {
+		expect(reviews.map((review) => review.base.ref)).toEqual(["master", "branch3", "branch1"]);
+		for (const review of reviews) {
+			expect(review.body).not.toContain(FOOTER_TOP);
+			expect(review.body).not.toContain(FOOTER_BOTTOM);
+		}
+	});
+
+	await setGitHubStackingMode(page, gitbutler, "disabled");
+	writeFileSync(
+		gitbutler.pathInWorkdir("local-clone/b_file"),
+		"change after disabling native stacks\n",
+		{ flag: "a" },
+	);
+	await gitbutler.runScript("commit-branch.sh", ["branch2", "branch2: disable native stacks"]);
+	await gitbutler.runScript("push-branch.sh", ["branch2"]);
+	await expect.poll(() => server.getNativeStacks()).toEqual([]);
+	expect(server.getNativeStackMutationHistory()).toEqual([
+		{ operation: "create", pullRequests: [42, 43] },
+		{ operation: "unstack", stackNumber: 1 },
+		{ operation: "create", pullRequests: [42, 44, 43] },
+		{ operation: "unstack", stackNumber: 2 },
+	]);
+	await expectReviews(server, 3, (reviews) => {
+		for (const review of reviews) {
+			expect(review.body).toContain(FOOTER_TOP);
+			expect(review.body).toContain(FOOTER_BOTTOM);
+		}
+	});
+});
+
 test("reordering reviewed refs updates every target after a partial push", async ({
 	page,
 	gitbutler,
@@ -826,6 +932,23 @@ async function setDescriptionPolicy(page: Page, gitbutler: GitButler, policy: "t
 		.getByRole("button")
 		.click();
 	await assertGitConfigValue(POLICY_KEY, policy, gitbutler.pathInWorkdir("local-clone"));
+	await page.keyboard.press("Escape");
+	await expect(page.getByTestId("project-settings-modal")).toHaveCount(0);
+}
+
+async function setGitHubStackingMode(
+	page: Page,
+	gitbutler: GitButler,
+	mode: "disabled" | "native",
+) {
+	await clickByTestId(page, "chrome-sidebar-project-settings-button");
+	await waitForTestId(page, "project-settings-modal");
+	const select = page.getByTestId("github-stacking-mode-select");
+	await expect(select).toBeVisible();
+	await select.scrollIntoViewIfNeeded();
+	await select.click();
+	await page.getByTestId(`github-stacking-mode-option-${mode}`).getByRole("button").click();
+	await assertGitConfigValue(GITHUB_STACKING_KEY, mode, gitbutler.pathInWorkdir("local-clone"));
 	await page.keyboard.press("Escape");
 	await expect(page.getByTestId("project-settings-modal")).toHaveCount(0);
 }

--- a/packages/but-sdk/src/generated/graph/index.d.ts
+++ b/packages/but-sdk/src/generated/graph/index.d.ts
@@ -1797,6 +1797,7 @@ export type GitConfigSettings = {
   signCommits: boolean | null;
   gitbutlerGerritMode: boolean | null;
   gitbutlerReviewStackingDescription: ReviewStackingDescription | null;
+  gitbutlerGithubStackingMode: GitHubStackingMode | null;
   gitbutlerForgeReviewTemplatePath: string | null;
   gitbutlerGitlabProjectId: string | null;
   gitbutlerGitlabUpstreamProjectId: string | null;
@@ -1810,6 +1811,9 @@ export type GitHubOAuthAppSettings = {
   /** Client ID for the GitHub OAuth application. Set this to use custom (non-GitButler) OAuth application. */
   oauthClientId: string;
 };
+
+/** Controls whether GitButler registers reviewed stacks with GitHub's native stacks API. */
+export type GitHubStackingMode = "disabled" | "native";
 
 export type GithubAccountIdentifier = {
   type: "oAuthUsername";

--- a/packages/but-sdk/src/generated/linear/index.d.ts
+++ b/packages/but-sdk/src/generated/linear/index.d.ts
@@ -1797,6 +1797,7 @@ export type GitConfigSettings = {
   signCommits: boolean | null;
   gitbutlerGerritMode: boolean | null;
   gitbutlerReviewStackingDescription: ReviewStackingDescription | null;
+  gitbutlerGithubStackingMode: GitHubStackingMode | null;
   gitbutlerForgeReviewTemplatePath: string | null;
   gitbutlerGitlabProjectId: string | null;
   gitbutlerGitlabUpstreamProjectId: string | null;
@@ -1810,6 +1811,9 @@ export type GitHubOAuthAppSettings = {
   /** Client ID for the GitHub OAuth application. Set this to use custom (non-GitButler) OAuth application. */
   oauthClientId: string;
 };
+
+/** Controls whether GitButler registers reviewed stacks with GitHub's native stacks API. */
+export type GitHubStackingMode = "disabled" | "native";
 
 export type GithubAccountIdentifier = {
   type: "oAuthUsername";


### PR DESCRIPTION
## Why?

It'd be cool to support native GitHub stacks

## Summary

Adds opt-in support for GitHub's native stacked pull request API from the backend-owned review synchronization flow.

- Adds the repository-local `gitbutler.githubStackingMode = disabled | native` setting and SDK bindings.
- Adds GitHub native stack REST client support and reconciliation planning for create, append, rebuild, merge/split, and dissolve cases.
- Integrates native-stack reconciliation into review sync after pushes, PR creation.
- Adds Desktop and CLI controls plus fake GitHub/e2e coverage for native stack behavior.
