### PR TITLE
Symlink nested CLAUDE.md to AGENTS.md

### DIFF
--- a/apps/lite/CLAUDE.md
+++ b/apps/lite/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/CLAUDE.md
+++ b/crates/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/but/CLAUDE.md
+++ b/crates/but/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
Claude Code's instruction discovery only matches the basenames `CLAUDE.md` and
`CLAUDE.local.md` — `AGENTS.md` is never auto-loaded, at any level. That meant
`crates/AGENTS.md`, `crates/but/AGENTS.md` and `apps/lite/AGENTS.md` were not
injected when work touched those directories; they reached an agent only if it
noticed the pointer in the root instructions and read them by hand.

This adds a `CLAUDE.md -> AGENTS.md` symlink next to each nested `AGENTS.md`,
mirroring what the repo root already does. `AGENTS.md` stays the single source
of truth, and tools with native nested `AGENTS.md` support are unaffected.

The root `CLAUDE.md` symlink is not part of this — it's currently a local,
untracked file in my checkout.