### PR TITLE
docs(lite): add state-modeling guidance to AGENTS.md

### DIFF
--- a/apps/lite/AGENTS.md
+++ b/apps/lite/AGENTS.md
@@ -35,6 +35,16 @@ export const MyComponent: FC<Props> = (p) => {
 };
 ```
 
+# State
+
+Share machinery, not state: when a new surface (a tab, pane, or mode) has its
+own selection or lifecycle, give it its own sub-state with its own
+reducers/selectors (see `ui/src/projects/branches.ts`), even when it reuses the
+same operand/navigation machinery. Don't multiplex an existing state container
+behind mode conditionals — the tell is an `if (tab === ...)` guard, or a
+comment explaining a special case, in code that shouldn't know that mode
+exists.
+
 # Concluding your work
 
 Once the work is functionally complete, lint and format it with Oxlint, Oxfmt,


### PR DESCRIPTION
Codifies the lesson from the branches-tab cleanup in #14992: when a new surface (tab, pane, or mode) has its own selection or lifecycle, it gets its own sub-state with its own reducers/selectors — share the operand/navigation machinery, not the state container. The tell that state is misfactored: a mode conditional, or a comment explaining a special case, in code that shouldn't know that mode exists.

@samhh i tried to capture the the cleanup you did in 14992 in the agents md - feel free to tweak if I misunderstood the preferred style