### PR TITLE
chore: symlink .claude/skills to .agents/skills

### DIFF
--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/.gitignore
+++ b/.gitignore
@@ -75,7 +75,9 @@ storybook-static
 /.agents/*
 !/.agents/skills/
 !/.agents/skills/**
-/.claude/
+/.claude/*
+# Symlink to /.agents/skills so Claude Code discovers the repo's skills.
+!/.claude/skills
 
 # Auto-generated design tokens
 packages/ui/src/styles/tokens.css


### PR DESCRIPTION
The repo keeps its agent skills in `.agents/skills`, but Claude Code only discovers project skills under `.claude/skills` — so `cli-commands`, `lite-render-perf` and `tui-tests` were never loaded.
