### PR TITLE
lite: dedicated conflict indicators for commits and files

### DIFF
--- a/apps/lite/ui/src/components/ConflictIcon.stories.tsx
+++ b/apps/lite/ui/src/components/ConflictIcon.stories.tsx
@@ -18,9 +18,18 @@ const meta = preview.meta({
 	},
 });
 
-export const Default = meta.story({});
+export const Default = meta.story({
+	args: {
+		variant: "conflict",
+		size: 16,
+	},
+});
 
 export const AllVariants = meta.story({
+	args: {
+		variant: "conflict",
+		size: 16,
+	},
 	render: (args) => (
 		<div style={{ display: "flex", gap: 16, alignItems: "center" }}>
 			{(["conflict", "plus", "minus"] as const).map((variant) => (

--- a/apps/lite/ui/src/components/ConflictIcon.stories.tsx
+++ b/apps/lite/ui/src/components/ConflictIcon.stories.tsx
@@ -1,0 +1,37 @@
+import preview from "#storybook/preview";
+import { ConflictIcon } from "./ConflictIcon.tsx";
+
+const meta = preview.meta({
+	component: ConflictIcon,
+	argTypes: {
+		variant: {
+			control: "select",
+			options: ["conflict", "plus", "minus"],
+		},
+		size: {
+			control: { type: "range", min: 8, max: 128, step: 4 },
+		},
+	},
+	args: {
+		variant: "conflict",
+		size: 16,
+	},
+});
+
+export const Default = meta.story({});
+
+export const AllVariants = meta.story({
+	render: (args) => (
+		<div style={{ display: "flex", gap: 16, alignItems: "center" }}>
+			{(["conflict", "plus", "minus"] as const).map((variant) => (
+				<div
+					key={variant}
+					style={{ display: "flex", flexDirection: "column", gap: 8, alignItems: "center" }}
+				>
+					<ConflictIcon variant={variant} size={args.size} />
+					<span style={{ fontSize: 11, opacity: 0.5 }}>{variant}</span>
+				</div>
+			))}
+		</div>
+	),
+});

--- a/apps/lite/ui/src/components/ConflictIcon.tsx
+++ b/apps/lite/ui/src/components/ConflictIcon.tsx
@@ -1,0 +1,63 @@
+import type { ComponentProps, FC } from "react";
+
+type Props = {
+	variant: "conflict" | "plus" | "minus";
+	size?: number;
+} & Omit<ComponentProps<"svg">, "width" | "height">;
+
+export const ConflictIcon: FC<Props> = ({ variant, size = 16, ...props }) => {
+	if (variant === "conflict") {
+		return (
+			<svg
+				width={size}
+				height={size}
+				viewBox="0 0 16 16"
+				fill="none"
+				xmlns="http://www.w3.org/2000/svg"
+				{...props}
+			>
+				<path
+					d="M6.20252 2.82467C6.95455 1.40909 8.98295 1.40909 9.73498 2.82467L14.3765 11.5617C15.0842 12.8938 14.1187 14.5 12.6103 14.5H3.32721C1.8188 14.5 0.853298 12.8938 1.56098 11.5617L6.20252 2.82467Z"
+					fill="var(--fill-danger-bg)"
+				/>
+				<path
+					d="M7.96875 8.9375L7.96875 5.9375M7.96875 11.9375L7.96875 10.4375"
+					stroke="white"
+					strokeWidth="1.5"
+				/>
+			</svg>
+		);
+	}
+
+	return (
+		<svg
+			width={(size * 20) / 16}
+			height={size}
+			viewBox="0 0 20 16"
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
+			{...props}
+		>
+			<path
+				opacity="0.8"
+				d="M3.97745 4.07735C4.58318 2.86634 6.11122 2.65062 7.04581 3.42989C6.84356 4.08413 6.73526 4.77954 6.73526 5.50021C6.73537 8.58304 8.72915 11.1982 11.497 12.132C11.7228 13.3157 10.8237 14.5002 9.53018 14.5002H2.00186C0.515306 14.4999 -0.451071 12.9354 0.213776 11.6057L3.97745 4.07735Z"
+				fill="var(--text-2)"
+			/>
+			<circle
+				cx="13.7349"
+				cy="5.5"
+				r="5.5"
+				fill={variant === "plus" ? "var(--fill-danger-bg)" : "var(--fill-safe-bg)"}
+			/>
+			{variant === "plus" ? (
+				<path
+					d="M13.7271 8.55545V2.44434M10.6792 5.49225L16.7903 5.49225"
+					stroke="white"
+					strokeWidth="1.5"
+				/>
+			) : (
+				<path d="M10.6792 5.49219H16.7903" stroke="white" strokeWidth="1.5" />
+			)}
+		</svg>
+	);
+};

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
@@ -284,3 +284,8 @@
 	gap: 8px;
 	color: var(--text-3);
 }
+
+.commitConflictIcon {
+	flex-shrink: 0;
+	margin-right: 2px;
+}

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
@@ -285,7 +285,6 @@
 	color: var(--text-3);
 }
 
-.commitConflictIcon {
+.commitConflictBadge {
 	flex-shrink: 0;
-	margin-right: 2px;
 }

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -39,8 +39,8 @@ import {
 } from "#ui/operands.ts";
 import { projectSlice } from "#ui/projects/state.ts";
 import { interfaceSlice } from "#ui/interface/state.ts";
+import { Badge } from "#ui/components/Badge.tsx";
 import { getButtonClassName } from "#ui/components/Button.tsx";
-import { ConflictIcon } from "#ui/components/ConflictIcon.tsx";
 import { Icon } from "#ui/components/Icon.tsx";
 import { TooltipPopup } from "#ui/components/Tooltip.tsx";
 import { ToggleGroupStyles, ToggleStyles } from "#ui/components/ToggleGroup.tsx";
@@ -728,8 +728,11 @@ const Title: FC<{
 									{commitTitle(commitDetails.commit.message) ?? "(no message)"}
 								</span>
 								{commitDetails.commit.hasConflicts && (
-									<ConflictIcon variant="conflict" className={styles.commitConflictIcon} />
+									<Badge variant="danger" className={styles.commitConflictBadge}>
+										Conflicted
+									</Badge>
 								)}
+
 								{commitBody(commitDetails.commit.message) !== undefined && (
 									<Tooltip.Root>
 										<Tooltip.Trigger

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -40,6 +40,7 @@ import {
 import { projectSlice } from "#ui/projects/state.ts";
 import { interfaceSlice } from "#ui/interface/state.ts";
 import { getButtonClassName } from "#ui/components/Button.tsx";
+import { ConflictIcon } from "#ui/components/ConflictIcon.tsx";
 import { Icon } from "#ui/components/Icon.tsx";
 import { TooltipPopup } from "#ui/components/Tooltip.tsx";
 import { ToggleGroupStyles, ToggleStyles } from "#ui/components/ToggleGroup.tsx";
@@ -726,7 +727,9 @@ const Title: FC<{
 								<span className={styles.titleContent}>
 									{commitTitle(commitDetails.commit.message) ?? "(no message)"}
 								</span>
-								{commitDetails.commit.hasConflicts && " ⚠️"}
+								{commitDetails.commit.hasConflicts && (
+									<ConflictIcon variant="conflict" className={styles.commitConflictIcon} />
+								)}
 								{commitBody(commitDetails.commit.message) !== undefined && (
 									<Tooltip.Root>
 										<Tooltip.Trigger

--- a/apps/lite/ui/src/routes/project/$id/workspace/FileRow.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/FileRow.module.css
@@ -52,3 +52,8 @@
 		display: none;
 	}
 }
+
+.conflictIcon {
+	flex-shrink: 0;
+	margin-right: 2px;
+}

--- a/apps/lite/ui/src/routes/project/$id/workspace/FileRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/FileRow.tsx
@@ -1,3 +1,4 @@
+import { ConflictIcon } from "#ui/components/ConflictIcon.tsx";
 import { FileIcon } from "#ui/components/FileIcon.tsx";
 import rowStyles from "./Row.module.css";
 import { showNativeContextMenu, showNativeMenuFromTrigger } from "#ui/native-menu.ts";
@@ -102,7 +103,13 @@ export const FileRow: FC<
 				</div>
 
 				<RowLabelContainer>
-					{item._tag === "Conflict" && "⚠️"}
+					{item._tag === "Conflict" && (
+						<ConflictIcon
+							variant="conflict"
+							className={styles.conflictIcon}
+							aria-label="Conflicted"
+						/>
+					)}
 					<RowLabel singleLine>
 						{fileName}
 						{directoryPath !== null && (

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/CommitRow.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/CommitRow.module.css
@@ -20,3 +20,8 @@
 		display: none;
 	}
 }
+
+.conflictIcon {
+	flex-shrink: 0;
+	margin-right: 2px;
+}

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/CommitRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/CommitRow.tsx
@@ -9,6 +9,7 @@ import {
 } from "#ui/api/mutations.ts";
 import { forgeInfoOptions, headInfoQueryOptions } from "#ui/api/queries.ts";
 import { classes } from "#ui/components/classes.ts";
+import { ConflictIcon } from "#ui/components/ConflictIcon.tsx";
 import { GraphSegment } from "#ui/components/GraphSegment.tsx";
 import { Icon } from "#ui/components/Icon.tsx";
 import { TooltipPopup } from "#ui/components/Tooltip.tsx";
@@ -375,13 +376,19 @@ export const CommitRow: FC<
 				/>
 			) : (
 				<RowLabelContainer>
+					{hasConflicts && (
+						<ConflictIcon
+							variant="conflict"
+							className={styles.conflictIcon}
+							aria-label="Conflicted"
+						/>
+					)}
 					<RowLabel singleLine>
 						{title === undefined ? (
 							<span className={rowStyles.fadedText}>(no message)</span>
 						) : (
 							title
 						)}
-						{hasConflicts && " ⚠️"}
 					</RowLabel>
 				</RowLabelContainer>
 			)}


### PR DESCRIPTION
### What

Replaces the ad-hoc ⚠️ emoji conflict markers in the Lite app with a purpose-built `ConflictIcon` component, and adds a labeled "Conflicted" badge to the commit details header.

[Figma component](https://www.figma.com/design/EBuHQGUcCaSw4Ln5uVpWkn/Lite?node-id=2885-26630&t=1B6ExDpjNjpVWNEN-1)

- New `ConflictIcon` component (`conflict` / `plus` / `minus` variants) with Storybook stories
- Commit rows (outline tree): emoji → `ConflictIcon`
- File rows: emoji → `ConflictIcon`
- Commit details title: labeled `Badge variant="danger"` reading **Conflicted**

### Why (UX)

The ⚠️ emoji rendered inconsistently across platforms, couldn't follow theme colors.

- **Unified conflict icons** — all conflict indicators (commit rows, file rows) now use the same `ConflictIcon` component instead of scattered emoji, so the visual language is consistent across the app and platforms.
- **Ready for dry runs** — the component ships with two extra variants, `plus` and `minus`, to indicate when an operation *will introduce* or *will resolve* a conflict.
- **Label in the details title** — the header shows a worded "Conflicted" label rather than repeating the bare glyph: it's the one place with room for text, and a third identical icon would add noise without new information.

### Screenshots

<img width="286" height="277" alt="image" src="https://github.com/user-attachments/assets/997c53a4-bd5c-4b35-80e6-3a6ffaf744c8" />


<img width="1192" height="825" alt="Screenshot 2026-07-24 at 23 45 06" src="https://github.com/user-attachments/assets/bb01d299-4d99-4900-a4b6-5dd287e7680e" />
