### PR TITLE
fix(cherry-pick): allow picking commits from outside the workspace

### DIFF
--- a/crates/but-api/src/commit/cherry_pick.rs
+++ b/crates/but-api/src/commit/cherry_pick.rs
@@ -15,9 +15,10 @@ use super::types::CommitCherryPickResult;
 
 /// Cherry-picks `source_commit_ids` to `side` of `relative_to`.
 ///
-/// Sources are deduplicated and ordered by parentage. When `dry_run` is
-/// enabled, the returned workspace previews the rewritten graph without
-/// materializing it.
+/// Sources may live anywhere in the repository, including outside the
+/// workspace. They are deduplicated and applied in the order given. When
+/// `dry_run` is enabled, the returned workspace previews the rewritten graph
+/// without materializing it.
 #[but_api(try_from = crate::commit::json::CommitCherryPickResult)]
 #[instrument(err(Debug))]
 pub fn commit_cherry_pick_only(

--- a/crates/but-api/tests/api/commit_cherry_pick.rs
+++ b/crates/but-api/tests/api/commit_cherry_pick.rs
@@ -148,3 +148,116 @@ fn cherry_pick_dry_run_does_not_persist_commits_or_move_the_reference() -> anyho
     }
     Ok(())
 }
+
+/// Add a branch holding `outside-one` and `outside-two` that the workspace traversal doesn't
+/// reach, the way the branches view offers commits from unapplied branches for cherry-picking.
+fn add_branch_outside_the_workspace(tmp: &std::path::Path) -> anyhow::Result<()> {
+    git_at_dir(tmp)
+        .args(["checkout", "-b", "unapplied", "refs/remotes/origin/main"])
+        .run();
+    for name in ["outside-one", "outside-two"] {
+        write_file(tmp, &format!("{name}.txt"), "outside\n")?;
+        git_at_dir(tmp).args(["add", "."]).run();
+        git_at_dir(tmp).args(["commit", "-m", name]).run();
+    }
+    git_at_dir(tmp).args(["checkout", "main"]).run();
+    Ok(())
+}
+
+#[test]
+fn cherry_pick_from_a_branch_outside_the_workspace() -> anyhow::Result<()> {
+    let (mut ctx, tmp) = context_with_cherry_pick_history()?;
+    add_branch_outside_the_workspace(tmp.path())?;
+
+    let (outside_commit, main_tip) = {
+        let repo = ctx.repo.get()?;
+        (
+            repo.rev_parse_single("refs/heads/unapplied")?.detach(),
+            repo.rev_parse_single("main")?.detach(),
+        )
+    };
+    let main_ref: gix::refs::FullName = "refs/heads/main".try_into()?;
+
+    let result = but_api::commit::cherry_pick::commit_cherry_pick(
+        &mut ctx,
+        vec![outside_commit],
+        RelativeTo::Reference(main_ref.clone()),
+        InsertSide::Below,
+        DryRun::No,
+    )?;
+
+    assert_eq!(result.new_commits.len(), 1);
+    let repo = ctx.repo.get()?;
+    assert_eq!(
+        repo.rev_parse_single(main_ref.as_ref())?.detach(),
+        result.new_commits[0],
+        "the copy becomes the new branch tip"
+    );
+    assert_eq!(
+        repo.find_commit(result.new_commits[0])?
+            .parent_ids()
+            .next()
+            .expect("the copy is stacked onto the previous tip")
+            .detach(),
+        main_tip
+    );
+    assert_ne!(
+        result.new_commits[0], outside_commit,
+        "the source is copied, not moved"
+    );
+    Ok(())
+}
+
+#[test]
+fn cherry_pick_multiple_commits_from_outside_the_workspace() -> anyhow::Result<()> {
+    let (mut ctx, tmp) = context_with_cherry_pick_history()?;
+    add_branch_outside_the_workspace(tmp.path())?;
+
+    let (outside_first, outside_second) = {
+        let repo = ctx.repo.get()?;
+        (
+            repo.rev_parse_single("refs/heads/unapplied~1")?.detach(),
+            repo.rev_parse_single("refs/heads/unapplied")?.detach(),
+        )
+    };
+    let main_ref: gix::refs::FullName = "refs/heads/main".try_into()?;
+
+    // This is what interactive `but pick` does: several commits off an unapplied branch, handed
+    // over oldest-first and applied in that order.
+    let result = but_api::commit::cherry_pick::commit_cherry_pick(
+        &mut ctx,
+        vec![outside_first, outside_second],
+        RelativeTo::Reference(main_ref.clone()),
+        InsertSide::Below,
+        DryRun::No,
+    )?;
+
+    assert_eq!(result.new_commits.len(), 2);
+    let repo = ctx.repo.get()?;
+    assert_eq!(
+        repo.rev_parse_single(main_ref.as_ref())?.detach(),
+        result.new_commits[1],
+        "the last source given ends up as the branch tip"
+    );
+    assert_eq!(
+        repo.find_commit(result.new_commits[1])?
+            .parent_ids()
+            .next()
+            .expect("the copies are stacked in the order given")
+            .detach(),
+        result.new_commits[0]
+    );
+    let titles = result
+        .new_commits
+        .iter()
+        .map(|id| -> anyhow::Result<String> {
+            Ok(repo.find_commit(*id)?.message()?.title.to_string())
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    assert_eq!(
+        titles,
+        ["outside-one\n", "outside-two\n"],
+        "the copies keep the order the sources were given in"
+    );
+    Ok(())
+}

--- a/crates/but-workspace/src/commit/cherry_pick.rs
+++ b/crates/but-workspace/src/commit/cherry_pick.rs
@@ -1,26 +1,36 @@
 //! Cherry-pick commits into a workspace graph.
 
+use std::collections::HashSet;
+
 use anyhow::bail;
 use but_core::{RefMetadata, commit::Headers};
 use but_rebase::commit::DateMode;
 use but_rebase::graph_rebase::{
-    Editor, Selector, Step, SuccessfulRebase, ToCommitSelector, ToSelector as _,
+    Editor, Selector, Step, SuccessfulRebase, ToSelector as _,
     mutate::{InsertSide, RelativeTo},
 };
 
 /// Cherry-pick commits above or below a commit, or below a reference, in the
 /// workspace graph.
 ///
-/// Sources are deduplicated and ordered parent-first. Child commits, and the
-/// target commit, if applicable, are rebased atop the cherry-picked commits.
+/// Sources are read from the object database, so they may live anywhere in the repository,
+/// including on branches that aren't part of the workspace. Duplicates are dropped, keeping the
+/// first occurrence, and the rest are applied in the order given rather than reordered, like
+/// `git cherry-pick`: the first source lands at `side` of `relative_to`, and each later one
+/// directly above the one before it.
+/// Child commits, and the target commit, if applicable, are rebased atop the cherry-picked commits.
 pub fn cherry_pick_commits<'ws, 'meta, M: RefMetadata>(
     mut editor: Editor<'ws, 'meta, M>,
-    source_commits: impl IntoIterator<Item: ToCommitSelector>,
+    source_commits: impl IntoIterator<Item = gix::ObjectId>,
     relative_to: RelativeTo,
     side: InsertSide,
 ) -> anyhow::Result<(SuccessfulRebase<'ws, 'meta, M>, Vec<Selector>)> {
-    let mut source_commits = source_commits.into_iter().peekable();
-    if source_commits.peek().is_none() {
+    let mut seen = HashSet::new();
+    let sources = source_commits
+        .into_iter()
+        .filter(|id| seen.insert(*id))
+        .collect::<Vec<_>>();
+    if sources.is_empty() {
         bail!("No commits were provided to cherry-pick")
     }
     if matches!(
@@ -31,13 +41,12 @@ pub fn cherry_pick_commits<'ws, 'meta, M: RefMetadata>(
     }
 
     let target = relative_to.to_selector(&editor)?;
-    let ordered_selectors = editor.order_commit_selectors_by_parentage(source_commits)?;
 
-    let mut inserted_selectors = Vec::with_capacity(ordered_selectors.len());
+    let mut inserted_selectors = Vec::with_capacity(sources.len());
     let mut previous_selector = None;
-    for source_selector in ordered_selectors {
+    for source in sources {
         // Give the copy its own change ID, retaining all other metadata.
-        let (_, mut template) = editor.find_selectable_commit(source_selector)?;
+        let mut template = editor.find_commit(source)?;
         let mut headers = Headers::try_from_commit(&template.inner).unwrap_or_default();
         headers.change_id = Headers::from_config(&editor.repo().config_snapshot()).change_id;
         headers.set_in_commit(&mut template.inner);

--- a/crates/but-workspace/tests/workspace/commit/cherry_pick.rs
+++ b/crates/but-workspace/tests/workspace/commit/cherry_pick.rs
@@ -138,7 +138,7 @@ fn insert_below_reference() -> anyhow::Result<()> {
 }
 
 #[test]
-fn parent_ordered() -> anyhow::Result<()> {
+fn sources_are_applied_in_the_order_given() -> anyhow::Result<()> {
     let (_tmp, graph, repo, mut meta, _description) =
         writable_scenario("ws-ref-ws-commit-single-stack-double-stack", |_| {})?;
     let mut workspace = graph.into_workspace()?;
@@ -164,7 +164,7 @@ fn parent_ordered() -> anyhow::Result<()> {
     let editor = Editor::create(&mut workspace, &mut meta, &repo)?;
     let (rebase, _) = but_workspace::commit::cherry_pick_commits(
         editor,
-        [c, b],
+        [b, c],
         RelativeTo::Reference(a_ref),
         InsertSide::Below,
     )?;


### PR DESCRIPTION
`commit_cherry_pick` resolved its sources through the rebase editor's step graph, which only holds commits the workspace traversal reaches. Picking a commit from an unapplied branch — what the branches view actually offers — failed with `Failed to find commit <id> in rebase editor`.

Sources are now plain commit ids read from the object database. `find_selectable_commit` only used the graph to turn a selector back into an id before reading the commit from the odb anyway, so nothing is lost: a source is copied into a brand new commit and never has to be part of the graph it is copied into.

Sources are deduplicated and applied in the order given.


fyi @samhh - made a small adjustment