### PR TITLE
refactor: drop the legacy set_target_push_remote

### DIFF
--- a/crates/but-api/src/legacy/virtual_branches.rs
+++ b/crates/but-api/src/legacy/virtual_branches.rs
@@ -246,7 +246,11 @@ pub fn set_base_branch_with_perm(
 
     // if they also sent a different push remote, set that too
     if let Some(push_remote) = push_remote {
-        gitbutler_branch_actions::set_target_push_remote(ctx, &push_remote)?;
+        {
+            let repo = ctx.repo.get()?;
+            but_workspace::init::set_push_remote(&repo, push_remote)?;
+        }
+        ctx.invalidate_workspace_cache()?;
     }
     {
         crate::legacy::meta::reconcile_in_workspace_state_of_vb_toml(ctx, perm).ok();

--- a/crates/gitbutler-branch-actions/src/actions.rs
+++ b/crates/gitbutler-branch-actions/src/actions.rs
@@ -17,10 +17,6 @@ pub fn set_base_branch(
     base::set_base_branch(ctx, perm.read_permission(), target_branch)
 }
 
-pub fn set_target_push_remote(ctx: &mut Context, push_remote: &str) -> Result<()> {
-    base::set_target_push_remote(ctx, push_remote)
-}
-
 pub(crate) trait Verify {
     fn verify(&self, perm: &mut RepoExclusive) -> Result<()>;
 }

--- a/crates/gitbutler-branch-actions/src/base.rs
+++ b/crates/gitbutler-branch-actions/src/base.rs
@@ -270,24 +270,6 @@ pub(crate) fn set_base_branch(
     get_base_branch_data(ctx, perm)
 }
 
-pub(crate) fn set_target_push_remote(ctx: &mut Context, push_remote_name: &str) -> Result<()> {
-    ctx.repo
-        .get()?
-        .find_remote(push_remote_name)
-        .context(format!("failed to find remote {push_remote_name}"))?;
-
-    let mut project_meta = ctx.project_meta()?;
-    project_meta
-        .target_ref
-        .as_ref()
-        .context(Code::DefaultTargetNotFound)
-        .context("there is no default target")?;
-    project_meta.push_remote = Some(push_remote_name.to_owned());
-    ctx.set_project_meta(project_meta)?;
-
-    Ok(())
-}
-
 fn set_exclude_decoration(ctx: &Context) -> Result<()> {
     let repo = ctx.repo.get()?;
     edit_repo_config(&repo, gix::config::Source::Local, |config| {

--- a/crates/gitbutler-branch-actions/src/lib.rs
+++ b/crates/gitbutler-branch-actions/src/lib.rs
@@ -6,7 +6,7 @@
 
 mod actions;
 // This is our API
-pub use actions::{set_base_branch, set_target_push_remote};
+pub use actions::set_base_branch;
 
 mod branch_manager;
 pub use branch_manager::BranchManagerExt;


### PR DESCRIPTION
One step toward removing production usage of `gitbutler-branch-actions`.

`set_target_push_remote` had a single production caller — `set_base_branch_with_perm` in `but-api` — and an exact modern equivalent already existed in `but_workspace::init::set_push_remote`. The caller now uses it directly, matching how `but_api::workspace::set_push_remote` does it, and the legacy function plus its `base.rs` body are deleted.

The legacy path invalidated the workspace cache implicitly via `ctx.set_project_meta`. The modern function persists straight to the repo, so that invalidation is now explicit at the call site.

Behavior is unchanged: both validate the remote exists and require a target before persisting. The migration repair the modern function runs first is a no-op here because `set_base_branch` writes fresh target metadata two lines up.

That leaves `set_base_branch` as the only export of the crate's `actions` module. Its three remaining callers (the API wrapper here, `switch_back_to_workspace`, and `but-action`'s `prepare_handle_changes`) are all workspace-mode concepts with no modern counterpart — they clear out when single-branch mode becomes the default.