### PR TITLE
refactor: prune the gitbutler-branch-actions surface

### DIFF
--- a/crates/but-api/src/legacy/forge.rs
+++ b/crates/but-api/src/legacy/forge.rs
@@ -19,6 +19,16 @@ pub fn remote_url(project_meta: &ProjectMeta, repo: &gix::Repository) -> Result<
     project_meta.remote_url_with_fallback(repo)
 }
 
+/// The name of the target branch within its remote, like `main` for `refs/remotes/origin/main`.
+///
+/// Errors if no target is set, or if its remote cannot be determined.
+pub fn target_short_name(project_meta: &ProjectMeta, repo: &gix::Repository) -> Result<String> {
+    let target_ref = project_meta.target_ref_or_err()?;
+    but_core::extract_remote_name_and_short_name(target_ref.as_ref(), &repo.remote_names())
+        .map(|(_remote_name, short_name)| short_name.to_string())
+        .with_context(|| format!("failed to determine remote for branch {target_ref}"))
+}
+
 pub fn push_remote_url(project_meta: &ProjectMeta, repo: &gix::Repository) -> Result<String> {
     project_meta.push_remote_url(repo)
 }
@@ -1436,11 +1446,7 @@ fn review_updates_after_push(
         }
     }
 
-    let base_branch = {
-        let guard = ctx.shared_worktree_access();
-        gitbutler_branch_actions::base::get_base_branch_data(ctx, guard.read_permission())?
-            .short_name
-    };
+    let base_branch = target_short_name(&ctx.project_meta()?, &*ctx.repo.get()?)?;
     Ok(affected_stack_indices
         .into_iter()
         .map(|index| {
@@ -1456,11 +1462,7 @@ fn review_updates_for_branch(
     ctx: &Context,
     branch: &gix::refs::FullNameRef,
 ) -> Result<Vec<but_forge::ForgeReviewUpdate>> {
-    let base_branch = {
-        let guard = ctx.shared_worktree_access();
-        gitbutler_branch_actions::base::get_base_branch_data(ctx, guard.read_permission())?
-            .short_name
-    };
+    let base_branch = target_short_name(&ctx.project_meta()?, &*ctx.repo.get()?)?;
     let info = crate::legacy::workspace::head_info(ctx)?;
     let (stack, _) = stack_and_segment_for_branch(&info, branch)?;
     Ok(review_updates_for_stack(stack, &base_branch)
@@ -1488,11 +1490,7 @@ pub(crate) fn review_target_updates_for_branch(
     {
         return Ok(Vec::new());
     }
-    let base_branch = {
-        let guard = ctx.shared_worktree_access();
-        gitbutler_branch_actions::base::get_base_branch_data(ctx, guard.read_permission())?
-            .short_name
-    };
+    let base_branch = target_short_name(&ctx.project_meta()?, &*ctx.repo.get()?)?;
     let updates = review_updates_for_stack(stack, &base_branch);
     let db = ctx.db.get_cache()?;
     let cached_targets = but_forge::list_cached_forge_reviews(&db)?
@@ -1543,11 +1541,6 @@ fn review_updates_for_stack(
 }
 
 fn review_creation_target(ctx: &Context, branch: &gix::refs::FullNameRef) -> Result<String> {
-    let base_branch = {
-        let guard = ctx.shared_worktree_access();
-        gitbutler_branch_actions::base::get_base_branch_data(ctx, guard.read_permission())?
-            .short_name
-    };
     let info = crate::legacy::workspace::head_info(ctx)?;
     let (stack, selected_index) = stack_and_segment_for_branch(&info, branch)?;
     let repo = ctx.repo.get()?;
@@ -1575,10 +1568,10 @@ fn review_creation_target(ctx: &Context, branch: &gix::refs::FullNameRef) -> Res
         }
     }
 
-    Ok(reviewed_ancestors
-        .pop()
-        .map(|head| head.branch_name)
-        .unwrap_or(base_branch))
+    match reviewed_ancestors.pop() {
+        Some(nearest_reviewed_ancestor) => Ok(nearest_reviewed_ancestor.branch_name),
+        None => target_short_name(&ctx.project_meta()?, &repo),
+    }
 }
 
 #[derive(Debug)]

--- a/crates/but-api/src/legacy/repo.rs
+++ b/crates/but-api/src/legacy/repo.rs
@@ -5,10 +5,9 @@ use but_api_macros::but_api;
 use but_askpass as askpass;
 use but_core::DiffSpec;
 use but_ctx::Context;
-use gitbutler_branch_actions::hooks;
 use gitbutler_repo::{
     FileInfo, RepoCommands,
-    hooks::{HookResult, MessageHookResult},
+    hooks::{self, HookResult, MessageHookResult},
 };
 use tracing::instrument;
 

--- a/crates/but/src/command/legacy/forge/review.rs
+++ b/crates/but/src/command/legacy/forge/review.rs
@@ -360,11 +360,10 @@ pub async fn create_review(
 /// Make sure that the account that is about to be used in this repository's forge is correctly authenticated.
 async fn ensure_forge_authentication(ctx: &mut Context) -> Result<(), anyhow::Error> {
     let (storage, forge_repo_info, preferred_forge_user) = {
-        let base_branch = gitbutler_branch_actions::base::get_base_branch_data(
-            ctx,
-            ctx.shared_worktree_access().read_permission(),
-        )?;
-        let forge_repo_info = but_forge::derive_forge_repo_info(&base_branch.remote_url);
+        let remote_url = ctx
+            .project_meta()?
+            .remote_url_with_fallback(&*ctx.repo.get()?)?;
+        let forge_repo_info = but_forge::derive_forge_repo_info(&remote_url);
         (
             but_forge_storage::Controller::from_path(but_path::app_data_dir()?),
             forge_repo_info,
@@ -539,12 +538,12 @@ fn prompt_for_branch_selection(
     applied_stacks: &[HeadInfoStack],
     out: &mut OutputChannel,
 ) -> anyhow::Result<Vec<String>> {
-    let base_branch = gitbutler_branch_actions::base::get_base_branch_data(
-        ctx,
-        ctx.shared_worktree_access().read_permission(),
-    )?;
-    let base_branch_id = base_branch.current_sha;
+    let project_meta = ctx.project_meta()?;
     let repo = &*ctx.repo.get()?;
+    let base_branch_id = repo
+        .find_reference(project_meta.target_ref_or_err()?)?
+        .id()
+        .detach();
 
     let mut branch_options = Vec::new();
     for stack_entry in applied_stacks {
@@ -614,10 +613,8 @@ async fn publish_reviews_for_branch_and_dependents(
     out: &mut OutputChannel,
 ) -> Result<PublishReviewsOutcome, anyhow::Error> {
     let t = theme::get();
-    let base_branch = {
-        let guard = ctx.shared_worktree_access();
-        gitbutler_branch_actions::base::get_base_branch_data(ctx, guard.read_permission())?
-    };
+    let base_branch_short_name =
+        but_api::legacy::forge::target_short_name(&ctx.project_meta()?, &*ctx.repo.get()?)?;
     let all_branches_up_to_subject = stack_entry
         .branches
         .iter()
@@ -659,7 +656,7 @@ async fn publish_reviews_for_branch_and_dependents(
 
     let mut newly_published = Vec::new();
     let mut already_existing = Vec::new();
-    let mut current_target_branch = base_branch.short_name.as_str();
+    let mut current_target_branch = base_branch_short_name.as_str();
     for branch in stack_entry.branches.iter().rev() {
         if let Some(out) = out.for_human() {
             let draftiness = if draft { "draft " } else { "" };

--- a/crates/gitbutler-branch-actions/src/hooks.rs
+++ b/crates/gitbutler-branch-actions/src/hooks.rs
@@ -1,9 +1,0 @@
-use but_ctx::Context;
-use gitbutler_repo::hooks::{self, HookResult};
-
-pub fn pre_commit_with_tree(
-    ctx: &Context,
-    tree_id: gix::ObjectId,
-) -> Result<HookResult, anyhow::Error> {
-    hooks::pre_commit_with_tree(ctx, tree_id)
-}

--- a/crates/gitbutler-branch-actions/src/lib.rs
+++ b/crates/gitbutler-branch-actions/src/lib.rs
@@ -41,5 +41,4 @@ pub use branch::{
     list_branches,
 };
 
-pub mod hooks;
 pub mod stack;

--- a/crates/gitbutler-branch-actions/src/stack.rs
+++ b/crates/gitbutler-branch-actions/src/stack.rs
@@ -4,19 +4,9 @@ use but_ctx::Context;
 use gitbutler_operating_modes::ensure_open_workspace_mode;
 use gitbutler_oplog::SnapshotExt;
 use gitbutler_reference::normalize_branch_name;
-use gitbutler_stack::Stack;
 use serde::{Deserialize, Serialize};
 
 use crate::{VirtualBranchesExt, actions::Verify};
-
-/// Return the legacy stack identified by `stack_id`.
-///
-/// This keeps legacy virtual-branches access encapsulated within
-/// `gitbutler-branch-actions` for callers that still operate on
-/// `gitbutler_stack::Stack`.
-pub fn get_stack(ctx: &Context, stack_id: StackId) -> Result<Stack> {
-    ctx.virtual_branches().get_stack(stack_id)
-}
 
 /// Request to create a new series in a stack
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]


### PR DESCRIPTION
Two independent steps toward removing production usage of `gitbutler-branch-actions`, following #15005.

**Delete two exports without callers.** The `hooks` module was a pass-through to `gitbutler_repo::hooks`; its only caller already imported that module for its types and already called `gitbutler_repo::hooks::post_commit` directly a few lines below. `stack::get_stack` had no callers at all.

**Stop building `BaseBranch` to read one field.** Seven call sites called `get_base_branch_data`, which projects the whole workspace, walks every upstream commit and 20 recent ones, and peels each to check conflict state — then discarded all of it except a short name, a remote URL, or the target ref tip. The remote URL and the target tip need no new code. The short name gets a `target_short_name` helper next to the existing `remote_url` and `push_remote_url` helpers in the forge module, built on `but_core::extract_remote_name_and_short_name`, which resolves the remote exactly as the `BaseBranch` path did. These sites also no longer take a shared worktree lock, which they only held to satisfy `get_base_branch_data`'s permission argument.

While there, `review_creation_target` no longer computes the target name eagerly at the top of the function: it is only the fallback when a stack has no reviewed ancestor, so it moved into that branch and reuses the existing repository handle. That removes a redundant borrow and stops a broken target configuration from failing review creation whose base is a sibling branch.

Behavior is unchanged. `get_base_branch_data` keeps the four callers that genuinely need the full DTO.

`crates/but/src/command/config.rs` and `crates/but/src/command/legacy/land/mod.rs` reach the same function through the `but-api` wrapper and are candidates for the same treatment later.