### PR TITLE
refactor: delete dead code from the legacy gitbutler-* crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4140,7 +4140,6 @@ dependencies = [
  "but-db",
  "but-error",
  "but-meta",
- "but-rebase",
  "but-testsupport",
  "ctor 0.6.3",
  "filetime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4075,7 +4075,6 @@ dependencies = [
  "but-path",
  "but-project-handle",
  "but-schemars",
- "but-serde",
  "but-testsupport",
  "but-utils",
  "gix",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4050,7 +4050,6 @@ dependencies = [
  "but-serde",
  "but-testsupport",
  "but-utils",
- "gitbutler-branch",
  "gitbutler-cherry-pick",
  "gitbutler-repo",
  "gix",

--- a/crates/gitbutler-branch-actions/src/integration.rs
+++ b/crates/gitbutler-branch-actions/src/integration.rs
@@ -48,10 +48,6 @@ fn write_workspace_file(head_target: gix::ObjectId, path: PathBuf) -> Result<()>
 }
 
 /// Update `gitbutler/workspace` using the current virtual branch state from `ctx`.
-///
-/// Prefer this helper unless the caller is already carrying a `VirtualBranchesHandle` through a
-/// stack/target mutation flow. In those cases use [`update_workspace_commit_with_vb_state()`] so
-/// the dependency on that handle stays explicit at the call-site.
 pub fn update_workspace_commit(
     ctx: &Context,
     checkout_new_worktree: bool,
@@ -70,7 +66,7 @@ pub fn update_workspace_commit(
 /// handle is already part of the operation itself, such as branch creation, base-branch changes,
 /// or rebases that update stack metadata before refreshing the workspace commit.
 #[instrument(level = "debug", skip(vb_state, ctx), err(Debug))]
-pub fn update_workspace_commit_with_vb_state(
+pub(crate) fn update_workspace_commit_with_vb_state(
     vb_state: &VirtualBranchesHandle,
     ctx: &Context,
     checkout_new_worktree: bool,

--- a/crates/gitbutler-branch-actions/src/lib.rs
+++ b/crates/gitbutler-branch-actions/src/lib.rs
@@ -15,10 +15,7 @@ pub mod base;
 pub use base::BaseBranch;
 
 mod integration;
-pub use integration::{
-    GITBUTLER_WORKSPACE_COMMIT_TITLE, update_workspace_commit,
-    update_workspace_commit_with_vb_state,
-};
+pub use integration::{GITBUTLER_WORKSPACE_COMMIT_TITLE, update_workspace_commit};
 
 mod remote;
 

--- a/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/mod.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/mod.rs
@@ -12,7 +12,10 @@ use but_testsupport::{
     open_repo,
 };
 use gitbutler_branch_actions::GITBUTLER_WORKSPACE_COMMIT_TITLE;
-use gitbutler_oplog::{OplogExt, SnapshotExt};
+use gitbutler_oplog::{
+    OplogExt,
+    entry::{OperationKind, SnapshotDetails, Trailer},
+};
 use gitbutler_reference::{LocalRefname, Refname};
 use gitbutler_repo::{SignaturePurpose, commit_without_signature_gix, signature_gix};
 use gix::refs::transaction::PreviousValue;
@@ -364,13 +367,15 @@ pub fn create_commit(
         })
     };
     let _ = snapshot_tree.and_then(|snapshot_tree| {
-        ctx.snapshot_commit_creation(
-            snapshot_tree,
-            outcome.as_ref().err(),
-            message.to_owned(),
-            None,
-            guard.write_permission(),
-        )
+        let details = SnapshotDetails::new(OperationKind::CreateCommit).with_trailers(
+            [Trailer::Message(message.to_owned())].into_iter().chain(
+                outcome
+                    .as_ref()
+                    .err()
+                    .map(|e| Trailer::Error(e.to_string())),
+            ),
+        );
+        ctx.commit_snapshot(snapshot_tree, details, guard.write_permission())
     });
     let new_commit = outcome?.ok_or(anyhow::anyhow!("No new commit created"))?;
     ctx.reload_repo_and_invalidate_workspace(guard.write_permission())?;

--- a/crates/gitbutler-commit/src/commit_ext.rs
+++ b/crates/gitbutler-commit/src/commit_ext.rs
@@ -6,7 +6,6 @@ use but_core::{ChangeId, commit::Headers};
 /// For now, it collects useful methods from `gitbutler-core::git::Commit`
 pub trait CommitExt {
     fn change_id(&self) -> Option<ChangeId>;
-    fn is_signed(&self) -> bool;
     fn is_conflicted(&self) -> bool;
 }
 
@@ -19,11 +18,6 @@ impl CommitExt for gix::Commit<'_> {
     fn change_id(&self) -> Option<ChangeId> {
         let commit = self.decode().ok()?;
         Headers::try_from_commit_headers(|| commit.extra_headers())?.change_id
-    }
-
-    fn is_signed(&self) -> bool {
-        self.decode()
-            .is_ok_and(|decoded| decoded.extra_headers().pgp_signature().is_some())
     }
 
     fn is_conflicted(&self) -> bool {

--- a/crates/gitbutler-git/src/refspec.rs
+++ b/crates/gitbutler-git/src/refspec.rs
@@ -20,27 +20,6 @@ pub struct RefSpec {
 }
 
 impl RefSpec {
-    /// Sets the `update_non_fastforward` flag
-    #[inline]
-    pub fn with_update_non_fastforward(mut self, update_non_fastforward: bool) -> Self {
-        self.update_non_fastforward = update_non_fastforward;
-        self
-    }
-
-    /// Sets the `source` refspec
-    #[inline]
-    pub fn with_source(mut self, source: Option<String>) -> Self {
-        self.source = source;
-        self
-    }
-
-    /// Sets the `destination` refspec
-    #[inline]
-    pub fn with_destination(mut self, destination: Option<String>) -> Self {
-        self.destination = destination;
-        self
-    }
-
     /// Parses a refspec from a string.
     pub fn parse<S: AsRef<str>>(refspec: S) -> Result<Self, Error> {
         let s = refspec.as_ref();

--- a/crates/gitbutler-operating-modes/src/lib.rs
+++ b/crates/gitbutler-operating-modes/src/lib.rs
@@ -230,11 +230,3 @@ pub fn in_outside_workspace_mode(ctx: &Context, perm: &RepoShared) -> Result<boo
         OperatingMode::OutsideWorkspace(_)
     ))
 }
-
-pub fn ensure_outside_workspace_mode(ctx: &Context, perm: &RepoShared) -> Result<()> {
-    if in_outside_workspace_mode(ctx, perm)? {
-        Ok(())
-    } else {
-        bail!("Expected to be in outside workspace mode")
-    }
-}

--- a/crates/gitbutler-operating-modes/tests/operating_modes.rs
+++ b/crates/gitbutler-operating-modes/tests/operating_modes.rs
@@ -162,7 +162,7 @@ mod operating_modes {
     }
 
     mod outside_workspace_mode {
-        use gitbutler_operating_modes::{ensure_outside_workspace_mode, in_outside_workspace_mode};
+        use gitbutler_operating_modes::in_outside_workspace_mode;
 
         use crate::{create_and_checkout_branch, create_edit_mode_metadata, new_case};
 
@@ -204,40 +204,6 @@ mod operating_modes {
             let in_outside_worskpace =
                 in_outside_workspace_mode(ctx, guard.read_permission()).unwrap();
             assert!(!in_outside_worskpace);
-        }
-
-        #[test]
-        fn assure_outside_workspace_mode_ok_when_on_other_branches() {
-            let case = new_case();
-            let ctx = &case.ctx;
-
-            create_and_checkout_branch(ctx, "testeroni");
-
-            let guard = ctx.shared_worktree_access();
-            assert!(ensure_outside_workspace_mode(ctx, guard.read_permission()).is_ok());
-        }
-
-        #[test]
-        fn assure_outside_workspace_mode_err_when_on_gitbutler_edit() {
-            let case = new_case();
-            let ctx = &case.ctx;
-
-            create_and_checkout_branch(ctx, "gitbutler/edit");
-            create_edit_mode_metadata(ctx);
-
-            let guard = ctx.shared_worktree_access();
-            assert!(ensure_outside_workspace_mode(ctx, guard.read_permission()).is_err());
-        }
-
-        #[test]
-        fn assure_outside_workspace_mode_err_when_on_gitbutler_workspace() {
-            let case = new_case();
-            let ctx = &case.ctx;
-
-            create_and_checkout_branch(ctx, "gitbutler/workspace");
-
-            let guard = ctx.shared_worktree_access();
-            assert!(ensure_outside_workspace_mode(ctx, guard.read_permission()).is_err());
         }
     }
 

--- a/crates/gitbutler-oplog/Cargo.toml
+++ b/crates/gitbutler-oplog/Cargo.toml
@@ -20,7 +20,6 @@ but-utils.workspace = true
 but-ctx = { workspace = true }
 but-schemars = { workspace = true, optional = true }
 
-gitbutler-branch.workspace = true
 gitbutler-repo.workspace = true
 gitbutler-cherry-pick.workspace = true
 

--- a/crates/gitbutler-oplog/src/oplog.rs
+++ b/crates/gitbutler-oplog/src/oplog.rs
@@ -134,7 +134,6 @@ impl TryFrom<SnapshotProjectMeta> for ProjectMeta {
 /// └── worktree/…
 /// ```
 pub trait OplogExt {
-    fn snapshot_workspace_tree(&self, sha: gix::ObjectId) -> Result<gix::ObjectId>;
     /// Prepares a snapshot of the current state of the working directory as well as GitButler data.
     /// Returns a tree hash of the snapshot. The snapshot is not discoverable until it is committed with [`commit_snapshot`](Self::commit_snapshot())
     /// If there are files that are untracked and larger than `SNAPSHOT_FILE_LIMIT_BYTES`, they are excluded from snapshot creation and restoring.
@@ -336,15 +335,6 @@ impl OplogExt for Context {
         };
 
         tree_changes(&repo, Some(before_tree_id), after_tree_id)
-    }
-
-    fn snapshot_workspace_tree(&self, sha: gix::ObjectId) -> Result<gix::ObjectId> {
-        let repo = self.repo.get()?;
-        let tree = repo.find_commit(sha)?.tree()?;
-        let workspace = tree
-            .find_entry("worktree")
-            .context("Failed to find workspace tree in snapshot")?;
-        Ok(workspace.object_id())
     }
 
     /// Gets the sha of the last snapshot commit if present.

--- a/crates/gitbutler-oplog/src/snapshot.rs
+++ b/crates/gitbutler-oplog/src/snapshot.rs
@@ -7,15 +7,6 @@ use crate::{
 };
 
 pub trait SnapshotExt {
-    fn snapshot_commit_creation(
-        &self,
-        snapshot_tree: gix::ObjectId,
-        error: Option<&anyhow::Error>,
-        commit_message: String,
-        sha: Option<gix::ObjectId>,
-        perm: &mut RepoExclusive,
-    ) -> anyhow::Result<()>;
-
     fn snapshot_stash_into_branch(
         &self,
         branch_name: String,
@@ -49,24 +40,6 @@ pub trait SnapshotExt {
 
 /// Snapshot functionality
 impl SnapshotExt for but_ctx::Context {
-    fn snapshot_commit_creation(
-        &self,
-        snapshot_tree: gix::ObjectId,
-        error: Option<&anyhow::Error>,
-        commit_message: String,
-        sha: Option<gix::ObjectId>,
-        perm: &mut RepoExclusive,
-    ) -> anyhow::Result<()> {
-        let details = SnapshotDetails::new(OperationKind::CreateCommit).with_trailers(
-            [Trailer::Message(commit_message)]
-                .into_iter()
-                .chain(sha.map(Trailer::Sha))
-                .chain(error_trailer(error)),
-        );
-        self.commit_snapshot(snapshot_tree, details, perm)?;
-        Ok(())
-    }
-
     fn snapshot_stash_into_branch(
         &self,
         branch_name: String,
@@ -121,8 +94,4 @@ impl SnapshotExt for but_ctx::Context {
         self.create_snapshot(details, perm)?;
         Ok(())
     }
-}
-
-fn error_trailer(error: Option<&anyhow::Error>) -> Option<Trailer> {
-    error.map(|e| Trailer::Error(e.to_string()))
 }

--- a/crates/gitbutler-oplog/src/snapshot.rs
+++ b/crates/gitbutler-oplog/src/snapshot.rs
@@ -1,6 +1,4 @@
-use anyhow::Result;
 use but_ctx::access::RepoExclusive;
-use gitbutler_branch::BranchUpdateRequest;
 
 use super::entry::Trailer;
 use crate::{
@@ -8,25 +6,7 @@ use crate::{
     oplog::OplogExt,
 };
 
-/// The name of a reference i.e. `refs/heads/master`
-pub type ReferenceName = String;
-
 pub trait SnapshotExt {
-    fn snapshot_branch_unapplied(
-        &self,
-        snapshot_tree: gix::ObjectId,
-        result: Result<&ReferenceName, &anyhow::Error>,
-        perm: &mut RepoExclusive,
-    ) -> anyhow::Result<()>;
-
-    fn snapshot_commit_undo(
-        &self,
-        snapshot_tree: gix::ObjectId,
-        result: Result<&(), &anyhow::Error>,
-        commit_sha: gix::ObjectId,
-        perm: &mut RepoExclusive,
-    ) -> anyhow::Result<()>;
-
     fn snapshot_commit_creation(
         &self,
         snapshot_tree: gix::ObjectId,
@@ -45,21 +25,6 @@ pub trait SnapshotExt {
     fn snapshot_branch_creation(
         &self,
         branch_name: String,
-        perm: &mut RepoExclusive,
-    ) -> anyhow::Result<()>;
-
-    fn snapshot_branch_deletion(
-        &self,
-        branch_name: String,
-        perm: &mut RepoExclusive,
-    ) -> anyhow::Result<()>;
-
-    fn snapshot_branch_update(
-        &self,
-        snapshot_tree: gix::ObjectId,
-        old_order: usize,
-        update: &BranchUpdateRequest,
-        error: Option<&anyhow::Error>,
         perm: &mut RepoExclusive,
     ) -> anyhow::Result<()>;
 
@@ -84,37 +49,6 @@ pub trait SnapshotExt {
 
 /// Snapshot functionality
 impl SnapshotExt for but_ctx::Context {
-    fn snapshot_branch_unapplied(
-        &self,
-        snapshot_tree: gix::ObjectId,
-        result: Result<&ReferenceName, &anyhow::Error>,
-        perm: &mut RepoExclusive,
-    ) -> anyhow::Result<()> {
-        let result = result.map(|s| s.to_owned());
-        let details =
-            SnapshotDetails::new(OperationKind::UnapplyBranch).with_trailers(match result {
-                Ok(name) => [Trailer::Name(name)],
-                Err(err) => [Trailer::Error(err.to_string())],
-            });
-        self.commit_snapshot(snapshot_tree, details, perm)?;
-        Ok(())
-    }
-
-    fn snapshot_commit_undo(
-        &self,
-        snapshot_tree: gix::ObjectId,
-        result: Result<&(), &anyhow::Error>,
-        commit_sha: gix::ObjectId,
-        perm: &mut RepoExclusive,
-    ) -> anyhow::Result<()> {
-        let details = SnapshotDetails::new(OperationKind::UndoCommit).with_trailers(match result {
-            Ok(_) => [Trailer::Sha(commit_sha)],
-            Err(err) => [Trailer::Error(err.to_string())],
-        });
-        self.commit_snapshot(snapshot_tree, details, perm)?;
-        Ok(())
-    }
-
     fn snapshot_commit_creation(
         &self,
         snapshot_tree: gix::ObjectId,
@@ -152,38 +86,6 @@ impl SnapshotExt for but_ctx::Context {
         let details = SnapshotDetails::new(OperationKind::CreateBranch)
             .with_trailers([Trailer::Name(branch_name)]);
         self.create_snapshot(details, perm)?;
-        Ok(())
-    }
-
-    fn snapshot_branch_deletion(
-        &self,
-        branch_name: String,
-        perm: &mut RepoExclusive,
-    ) -> anyhow::Result<()> {
-        let details = SnapshotDetails::new(OperationKind::DeleteBranch)
-            .with_trailers([Trailer::Name(branch_name)]);
-        self.create_snapshot(details, perm)?;
-        Ok(())
-    }
-
-    fn snapshot_branch_update(
-        &self,
-        snapshot_tree: gix::ObjectId,
-        old_order: usize,
-        update: &BranchUpdateRequest,
-        error: Option<&anyhow::Error>,
-        perm: &mut RepoExclusive,
-    ) -> anyhow::Result<()> {
-        let details = if let Some(order) = update.order {
-            SnapshotDetails::new(OperationKind::ReorderBranches).with_trailers(
-                [Trailer::Before(old_order), Trailer::After(order)]
-                    .into_iter()
-                    .chain(error_trailer(error)),
-            )
-        } else {
-            SnapshotDetails::new(OperationKind::GenericBranchUpdate)
-        };
-        self.commit_snapshot(snapshot_tree, details, perm)?;
         Ok(())
     }
 

--- a/crates/gitbutler-project/Cargo.toml
+++ b/crates/gitbutler-project/Cargo.toml
@@ -15,7 +15,6 @@ doctest = false
 [dependencies]
 but-error.workspace = true
 but-path.workspace = true
-but-serde = { workspace = true, features = ["legacy"] }
 but-core.workspace = true
 but-utils = { workspace = true, features = ["legacy"] }
 but-forge.workspace = true

--- a/crates/gitbutler-project/src/lib.rs
+++ b/crates/gitbutler-project/src/lib.rs
@@ -46,15 +46,6 @@ pub fn update(project: UpdateRequest) -> anyhow::Result<Project> {
     controller.update(project)
 }
 
-/// Testing purpose only.
-pub fn update_with_path<P: AsRef<Path>>(
-    app_data_dir: P,
-    project: UpdateRequest,
-) -> anyhow::Result<Project> {
-    let controller = Controller::from_path(app_data_dir.as_ref());
-    controller.update(project)
-}
-
 pub fn add<P: AsRef<Path>>(path: P) -> anyhow::Result<AddProjectOutcome> {
     add_at_app_data_dir(but_path::app_data_dir()?, path)
 }
@@ -91,17 +82,6 @@ pub fn add_at_app_data_dir(
 /// NOTE: call [`Project::migrated()`] if the instance should be used for actual functionality.
 pub fn dangerously_list_projects_without_migration() -> anyhow::Result<Vec<Project>> {
     let controller = Controller::from_path(but_path::app_data_dir()?);
-    controller.list()
-}
-
-/// Testing purpose only.
-///
-/// Like [`dangerously_list_projects_without_migration()`], but allows setting
-/// the `app_data_dir` explicitly for isolated tests and diagnostics.
-pub fn dangerously_list_projects_without_migration_with_path(
-    app_data_dir: impl AsRef<Path>,
-) -> anyhow::Result<Vec<Project>> {
-    let controller = Controller::from_path(app_data_dir.as_ref());
     controller.list()
 }
 

--- a/crates/gitbutler-project/src/lib.rs
+++ b/crates/gitbutler-project/src/lib.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 pub use but_project_handle::{ProjectHandle, ProjectHandleOrLegacyProjectId};
 use controller::Controller;
 use project::ApiProject;
-pub use project::{AddProjectOutcome, CodePushState, FetchResult, Project};
+pub use project::{AddProjectOutcome, FetchResult, Project};
 pub use storage::UpdateRequest;
 
 /// The maximum size of files to automatically start tracking, i.e. untracked files we pick up for tree-creation.

--- a/crates/gitbutler-project/src/project.rs
+++ b/crates/gitbutler-project/src/project.rs
@@ -54,18 +54,6 @@ impl FetchResult {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, Copy, Clone)]
-#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-pub struct CodePushState {
-    #[serde(with = "but_serde::object_id")]
-    #[cfg_attr(
-        feature = "export-schema",
-        schemars(schema_with = "but_schemars::object_id")
-    )]
-    pub id: gix::ObjectId,
-    pub timestamp: time::SystemTime,
-}
-
 /// Not registered for the frontend types because it is consumed flattened
 #[derive(Debug, Deserialize, Serialize, Clone)]
 #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
@@ -117,9 +105,6 @@ pub struct Project {
     pub gitbutler_data_last_fetch: Option<FetchResult>,
     #[serde(default)]
     #[cfg_attr(feature = "export-schema", schemars(skip))]
-    pub gitbutler_code_push_state: Option<CodePushState>,
-    #[serde(default)]
-    #[cfg_attr(feature = "export-schema", schemars(skip))]
     pub project_data_last_fetch: Option<FetchResult>,
     #[serde(default)]
     pub omit_certificate_check: Option<bool>,
@@ -148,7 +133,6 @@ impl Project {
             husky_hooks_enabled: false,
             api: None,
             gitbutler_data_last_fetch: None,
-            gitbutler_code_push_state: None,
             project_data_last_fetch: None,
             omit_certificate_check: None,
             snapshot_lines_threshold: None,
@@ -383,51 +367,5 @@ impl AddProjectOutcome {
                 Err(anyhow::anyhow!("not a git repository: {msg}"))
             }
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::time::{Duration, UNIX_EPOCH};
-
-    use serde_json::json;
-
-    use super::CodePushState;
-
-    #[test]
-    fn code_push_state_json_roundtrip() {
-        let state = CodePushState {
-            id: "0123456789abcdef0123456789abcdef01234567"
-                .parse()
-                .expect("valid object id"),
-            timestamp: UNIX_EPOCH + Duration::from_secs(123),
-        };
-
-        let value = serde_json::to_value(state).expect("serializes");
-
-        assert_eq!(
-            value,
-            json!({
-                "id": "0123456789abcdef0123456789abcdef01234567",
-                "timestamp": {
-                    "secs_since_epoch": 123,
-                    "nanos_since_epoch": 0
-                }
-            })
-        );
-
-        let state: CodePushState = serde_json::from_value(value).expect("deserializes");
-
-        assert_eq!(
-            state.id.to_string(),
-            "0123456789abcdef0123456789abcdef01234567"
-        );
-        assert_eq!(
-            state
-                .timestamp
-                .duration_since(UNIX_EPOCH)
-                .expect("after epoch"),
-            Duration::from_secs(123)
-        );
     }
 }

--- a/crates/gitbutler-project/src/project.rs
+++ b/crates/gitbutler-project/src/project.rs
@@ -173,23 +173,8 @@ impl Project {
 }
 
 /// Testing
-// TODO: remove once the remaining legacy testsupport constructor isn't needed anymore, and `gitbutler-repo`
+// TODO: remove once `gitbutler-repo` doesn't need this constructor anymore.
 impl Project {
-    /// A special constructor needed as `worktree_dir` isn't accessible anymore.
-    pub fn new_for_but_testsupport(title: String, worktree_dir: PathBuf) -> Self {
-        let project_id = ProjectHandleOrLegacyProjectId::ProjectHandle(
-            ProjectHandle::from_path(&worktree_dir)
-                .expect("testsupport projects require a valid path for ProjectHandle"),
-        );
-        Project {
-            title,
-            worktree_dir,
-            ..Project::default_with_id(project_id)
-        }
-        .migrated()
-        .unwrap()
-    }
-
     /// A special constructor needed as `worktree_dir` isn't accessible anymore.
     pub fn new_for_gitbutler_repo(worktree_dir: PathBuf) -> Self {
         let project_id = ProjectHandleOrLegacyProjectId::ProjectHandle(

--- a/crates/gitbutler-project/src/storage.rs
+++ b/crates/gitbutler-project/src/storage.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use anyhow::{Context as _, Result};
 use serde::Deserialize;
 
-use crate::{ApiProject, CodePushState, FetchResult, Project, ProjectHandleOrLegacyProjectId};
+use crate::{ApiProject, FetchResult, Project, ProjectHandleOrLegacyProjectId};
 
 const PROJECTS_FILE: &str = "projects.json";
 
@@ -26,7 +26,6 @@ pub struct UpdateRequest {
     pub ok_with_force_push: Option<bool>,
     pub force_push_protection: Option<bool>,
     pub husky_hooks_enabled: Option<bool>,
-    pub gitbutler_code_push_state: Option<CodePushState>,
     pub project_data_last_fetched: Option<FetchResult>,
     pub omit_certificate_check: Option<bool>,
     pub use_diff_context: Option<bool>,
@@ -52,7 +51,6 @@ impl UpdateRequest {
             ok_with_force_push: None,
             force_push_protection: None,
             husky_hooks_enabled: None,
-            gitbutler_code_push_state: None,
             project_data_last_fetched: None,
             omit_certificate_check: None,
             use_diff_context: None,
@@ -77,7 +75,6 @@ impl From<Project> for UpdateRequest {
             husky_hooks_enabled,
             api,
             gitbutler_data_last_fetch,
-            gitbutler_code_push_state,
             project_data_last_fetch,
             omit_certificate_check,
             snapshot_lines_threshold,
@@ -97,7 +94,6 @@ impl From<Project> for UpdateRequest {
             ok_with_force_push: Some(ok_with_force_push.into()),
             force_push_protection: Some(force_push_protection),
             husky_hooks_enabled: Some(husky_hooks_enabled),
-            gitbutler_code_push_state,
             project_data_last_fetched: project_data_last_fetch,
             omit_certificate_check,
             use_diff_context: None,
@@ -168,7 +164,6 @@ impl Storage {
             ok_with_force_push,
             force_push_protection,
             husky_hooks_enabled,
-            gitbutler_code_push_state,
             project_data_last_fetched,
             omit_certificate_check,
             use_diff_context: _, /* seemingly not used for a while */
@@ -226,10 +221,6 @@ impl Storage {
 
         if let Some(project_data_last_fetched) = project_data_last_fetched.as_ref() {
             project.project_data_last_fetch = Some(project_data_last_fetched.clone());
-        }
-
-        if let Some(state) = gitbutler_code_push_state {
-            project.gitbutler_code_push_state = Some(state);
         }
 
         if let Some(ok_with_force_push) = ok_with_force_push {

--- a/crates/gitbutler-reference/src/refname/error.rs
+++ b/crates/gitbutler-reference/src/refname/error.rs
@@ -2,8 +2,6 @@
 pub enum Error {
     #[error("branch name is invalid: {0}")]
     InvalidName(String),
-    #[error("reference is not a tag: {0}")]
-    NotTag(String),
     #[error("branch is not local: {0}")]
     NotLocal(String),
     #[error("branch is not remote: {0}")]

--- a/crates/gitbutler-reference/src/refname/mod.rs
+++ b/crates/gitbutler-reference/src/refname/mod.rs
@@ -65,15 +65,6 @@ impl Refname {
         }
     }
 
-    pub fn simple_name(&self) -> String {
-        match self {
-            Refname::Virtual(virtual_refname) => virtual_refname.branch().to_string(),
-            Refname::Local(local) => local.branch().to_string(),
-            Refname::Remote(remote) => remote.fullname(),
-            Refname::Other(raw) => raw.to_string(),
-        }
-    }
-
     pub fn remote(&self) -> Option<&str> {
         match self {
             Self::Remote(remote) => Some(remote.remote()),

--- a/crates/gitbutler-reference/src/refname/remote.rs
+++ b/crates/gitbutler-reference/src/refname/remote.rs
@@ -37,10 +37,6 @@ impl Refname {
     pub fn remote(&self) -> &str {
         &self.remote
     }
-
-    pub fn fullname(&self) -> String {
-        format!("{}/{}", &self.remote, &self.branch)
-    }
 }
 
 impl fmt::Display for Refname {

--- a/crates/gitbutler-stack/Cargo.toml
+++ b/crates/gitbutler-stack/Cargo.toml
@@ -11,7 +11,6 @@ doctest = false
 
 [dependencies]
 but-core.workspace = true
-but-rebase.workspace = true
 but-meta.workspace = true
 but-error.workspace = true
 but-ctx.workspace = true

--- a/crates/gitbutler-stack/src/stack.rs
+++ b/crates/gitbutler-stack/src/stack.rs
@@ -1,14 +1,10 @@
-use std::{
-    collections::{HashMap, HashSet},
-    path::Path,
-};
+use std::path::Path;
 
 use anyhow::{Context as _, Result, anyhow, bail};
 pub(crate) use but_core::ref_metadata::StackId;
 use but_ctx::Context;
 use but_error::bail_precondition;
 use but_meta::virtual_branches_legacy_types;
-use but_rebase::ReferenceSpec;
 use gitbutler_reference::{Refname, RemoteRefname, VirtualRefname, normalize_branch_name};
 use gix::validate::reference::name_partial;
 use itertools::Itertools;
@@ -339,50 +335,6 @@ impl Stack {
     /// Ordered from oldest to newest (most recent)
     pub fn branches(&self) -> Vec<StackBranch> {
         self.heads.clone()
-    }
-
-    /// Sets the stack heads to the provided commits.
-    /// This is useful multiple heads are updated and the intermediate states are not valid while the final state is.
-    fn set_all_heads(
-        &mut self,
-        gix_repo: &gix::Repository,
-        project_data_dir: &Path,
-        new_heads: HashMap<String, gix::ObjectId>,
-    ) -> Result<()> {
-        let mut state = branch_state_from_project_data_dir(project_data_dir);
-
-        // same heads, just different commits
-        if self
-            .heads
-            .iter()
-            .filter(|h| !h.archived)
-            .map(|h| h.name())
-            .collect::<HashSet<_>>()
-            != new_heads.keys().collect::<HashSet<_>>()
-        {
-            return Err(anyhow!("The new head names do not match the current heads"));
-        }
-        for head in &mut self.heads {
-            if let Some(commit) = new_heads.get(head.name()) {
-                head.set_head(*commit, gix_repo)?;
-            }
-        }
-        state.set_stack(self.clone())?;
-        Ok(())
-    }
-
-    /// Sets the stack heads according to the output from the rebase of a `but-rebase` rebase operation
-    pub fn set_heads_from_rebase_output(
-        &mut self,
-        ctx: &Context,
-        references: Vec<ReferenceSpec>,
-    ) -> anyhow::Result<()> {
-        let mut new_heads: HashMap<String, gix::ObjectId> = HashMap::new();
-        for spec in &references {
-            new_heads.insert(spec.reference.to_string(), spec.commit_id);
-        }
-
-        self.set_all_heads(&*ctx.repo.get()?, &ctx.project_data_dir(), new_heads)
     }
 }
 

--- a/crates/gitbutler-user/src/api.rs
+++ b/crates/gitbutler-user/src/api.rs
@@ -80,7 +80,7 @@ pub struct LoginToken {
 ///
 /// The returned [`LoginToken::url`] should be opened in the user's browser.
 /// After the user authenticates, they receive a token that can be validated
-/// with [`validate_token_owner`].
+/// with [`fetch_user_by_token`].
 pub fn fetch_login_token() -> Result<LoginToken> {
     let api_url = default_api_url();
     run_async(async move {
@@ -236,35 +236,6 @@ pub fn update_user_profile(params: UpdateUserParams) -> Result<serde_json::Value
             .await
             .context("Failed to parse profile update response")
     })
-}
-
-/// Check whether a token belongs to a specific user.
-///
-/// This is a convenience wrapper around [`fetch_user_by_token`] used by
-/// the remote-access auth middleware to verify that the authenticated user
-/// matches the local machine owner.
-///
-/// Returns `Ok(false)` for authentication failures (401/403) so that
-/// callers can distinguish "not the owner" from actual errors. Other HTTP
-/// errors (e.g. 429 rate-limit, 5xx) and network failures produce `Err`.
-pub fn validate_token_owner(token: &str, expected_user_id: u64) -> Result<bool> {
-    let user = match fetch_user_by_token(token) {
-        Ok(user) => user,
-        Err(e) => match e.downcast_ref::<ApiHttpError>() {
-            Some(http_err)
-                if http_err.status == StatusCode::UNAUTHORIZED
-                    || http_err.status == StatusCode::FORBIDDEN =>
-            {
-                return Ok(false);
-            }
-            _ => return Err(e),
-        },
-    };
-    let id = user
-        .get("id")
-        .and_then(|v| v.as_u64())
-        .context("whoami response missing 'id' field")?;
-    Ok(id == expected_user_id)
 }
 
 /// Execute an async future on a dedicated thread with its own Tokio runtime.

--- a/crates/gitbutler-user/src/controller.rs
+++ b/crates/gitbutler-user/src/controller.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use anyhow::{Context as _, Result};
-use but_secret::{Sensitive, secret};
+use but_secret::secret;
 
 use super::{User, storage::Storage};
 
@@ -39,25 +39,6 @@ impl Controller {
             self.storage.set(user).context("failed to set user")
         } else {
             Ok(())
-        }
-    }
-
-    /// This will remove GitHub-related secrets from the stored user, if any.
-    /// Returns the access token that was removed, if any.
-    pub(crate) fn forget_github_login_for_user(&self) -> Result<Option<Sensitive<String>>> {
-        if let Some(mut user) = self.get_user()? {
-            let namespace = secret::Namespace::BuildKind;
-            let access_token = secret::retrieve(User::GITHUB_ACCESS_TOKEN_HANDLE, namespace)?;
-            // Take the token before passing to set_user, so it is not lost
-            user.github_access_token.borrow_mut().take();
-            user.github_username = None;
-            // Remove the secret from the secret store
-            secret::delete(User::GITHUB_ACCESS_TOKEN_HANDLE, namespace).ok();
-            // Persist the user without the token
-            self.set_user(&user)?;
-            Ok(access_token)
-        } else {
-            Ok(None)
         }
     }
 

--- a/crates/gitbutler-user/src/lib.rs
+++ b/crates/gitbutler-user/src/lib.rs
@@ -23,13 +23,6 @@ pub fn set_user(user: &User) -> anyhow::Result<()> {
     controller.set_user(user)
 }
 
-/// Remove the GitHub login information from the stored user,
-/// returning the removed GitHub access token, if any.
-pub fn forget_github_login_for_user() -> anyhow::Result<Option<but_secret::Sensitive<String>>> {
-    let controller = Controller::from_path(but_path::app_data_dir()?);
-    controller.forget_github_login_for_user()
-}
-
 /// Testing purpose only.
 pub fn set_user_with_path<P: AsRef<std::path::Path>>(
     data_dir: P,

--- a/crates/gitbutler-workspace/src/branch_trees.rs
+++ b/crates/gitbutler-workspace/src/branch_trees.rs
@@ -65,27 +65,6 @@ impl WorkspaceState {
             base: base_tree_id,
         })
     }
-
-    pub fn create_from_heads(
-        ctx: &Context,
-        _perm: &RepoShared,
-        heads: &[gix::ObjectId],
-    ) -> Result<Self> {
-        let repo = &*ctx.repo.get()?;
-        let target_base_oid = legacy_target_base_oid(ctx)?;
-        Self::create_from_heads_and_target(repo, heads, target_base_oid)
-    }
-}
-
-/// Update the uncommitted changes from one snapshot of the workspace and rebase
-/// them on top of the new snapshot.
-pub fn update_uncommitted_changes(
-    ctx: &Context,
-    old: WorkspaceState,
-    new: WorkspaceState,
-    perm: &mut RepoExclusive,
-) -> Result<()> {
-    update_uncommitted_changes_with_tree(ctx, old, new, None, None, perm)
 }
 
 /// Pass `None` for `old_uncommitted_changes` to transition the worktree via safe checkout;
@@ -202,15 +181,4 @@ pub fn merge_workspace(
     }
 
     Ok(output)
-}
-
-pub fn move_tree_has_conflicts(
-    ctx: &Context,
-    tree: gix::ObjectId,
-    old_workspace: gix::ObjectId,
-    new_workspace: gix::ObjectId,
-) -> Result<bool> {
-    #[expect(deprecated, reason = "tree merge/index materialization boundary")]
-    let repo = &*ctx.git2_repo.get()?;
-    Ok(move_tree(repo, tree, old_workspace, new_workspace)?.has_conflicts())
 }

--- a/crates/gitbutler-workspace/src/lib.rs
+++ b/crates/gitbutler-workspace/src/lib.rs
@@ -1,28 +1,8 @@
 pub mod branch_trees;
 
 use anyhow::Result;
-use but_ctx::{Context, access::RepoShared};
+use but_ctx::Context;
 use but_meta::VirtualBranchesTomlMetadata;
-
-/// Returns the oid of the base of the workspace
-/// TODO: Ensure that this is the bottom most common ancestor of all the stacks
-pub fn workspace_base(ctx: &Context, _perm: &RepoShared) -> Result<gix::ObjectId> {
-    let repo = ctx.clone_repo_for_merging()?;
-    let meta = ctx.legacy_meta()?;
-    let target_base_oid = ctx.project_meta()?.target_commit_id_or_err()?;
-    let stack_heads = legacy_workspace_stack_heads_from_meta(&meta, &repo, target_base_oid)?;
-    workspace_base_from_heads_and_target(&repo, &stack_heads, target_base_oid)
-}
-
-pub fn workspace_base_from_heads(
-    ctx: &Context,
-    _perm: &RepoShared,
-    heads: &[gix::ObjectId],
-) -> Result<gix::ObjectId> {
-    let repo = ctx.clone_repo_for_merging()?;
-    let target_base_oid = ctx.project_meta()?.target_commit_id_or_err()?;
-    workspace_base_from_heads_and_target(&repo, heads, target_base_oid)
-}
 
 pub(crate) fn legacy_workspace_stack_heads(
     ctx: &Context,
@@ -60,18 +40,4 @@ fn legacy_workspace_stack_heads_from_meta(
 
 pub(crate) fn legacy_target_base_oid(ctx: &Context) -> Result<gix::ObjectId> {
     ctx.project_meta()?.target_commit_id_or_err()
-}
-
-pub(crate) fn workspace_base_from_heads_and_target(
-    repo: &gix::Repository,
-    heads: &[gix::ObjectId],
-    target_base_oid: gix::ObjectId,
-) -> Result<gix::ObjectId> {
-    let merge_base_id = repo
-        .merge_base_octopus([heads, &[target_base_oid]].concat())?
-        .object()?
-        .id()
-        .detach();
-
-    Ok(merge_base_id)
 }


### PR DESCRIPTION
Deletes code in the `gitbutler-*` crates that has no production callers, as a step toward being able to remove those crates entirely. ~440 lines across nine independently reviewable commits.

## What went

| Crate | Removed |
|---|---|
| `gitbutler-workspace` | `workspace_base`, `workspace_base_from_heads`, `WorkspaceState::create_from_heads`, `update_uncommitted_changes`, `move_tree_has_conflicts` |
| `gitbutler-user` | `forget_github_login_for_user`, `api::validate_token_owner` |
| `gitbutler-project` | `update_with_path`, `dangerously_list_projects_without_migration_with_path`, `Project::new_for_but_testsupport`, `CodePushState` |
| `gitbutler-git` | `RefSpec`'s three builder methods |
| `gitbutler-reference` | `Refname::simple_name`, `RemoteRefname::fullname`, `Error::NotTag` |
| `gitbutler-stack` | `set_heads_from_rebase_output` → cascaded into `set_all_heads` |
| `gitbutler-operating-modes` | `ensure_outside_workspace_mode` and its three tests |
| `gitbutler-oplog` | four `SnapshotExt` methods, `OplogExt::snapshot_workspace_tree`, `ReferenceName` |
| `gitbutler-commit` | `CommitExt::is_signed` |

Two dependency edges fell out: `gitbutler-oplog` no longer depends on `gitbutler-branch`, and `gitbutler-stack` no longer depends on `but-rebase`.

## Two decisions worth a look

**`CodePushState`** is the only change with an effect beyond the code. It was a persisted field in `projects.json`, threaded through `UpdateRequest`, that nothing has set or read since the GitButler Code push feature was retired. `Project` has no `deny_unknown_fields`, so existing files still deserialize — the key is ignored on read and dropped on the next write. Nothing in the SDK or either frontend references it. Happy to drop this commit if you'd rather keep the field.

**Code kept alive only by its own tests** was treated as dead. `ensure_outside_workspace_mode` had no callers and its three tests duplicated the `in_outside_workspace_mode` tests beside them. `SnapshotExt::snapshot_commit_creation` survived only for a test helper, which now builds the same `SnapshotDetails` inline — the oplog history assertions that depend on it still pass unchanged.

Test-injection seams with real coverage behind them were kept: the `*_with_path` functions in `gitbutler-user` and `gitbutler-project` are how the storage and secret-migration paths get tested.

## Not included

- **`gitbutler-tauri` IRC commands** — around thirty with no frontend caller, mirrored in `but-server`. Removing them is a product call on an experimental feature rather than dead-code cleanup.
- **Over-exposed but live items** (`ReflogCommits`, `set_reference_to_oplog`, `Pipe`/`FileStat`, `HookInstallationResult`, `compute_short_name`, and others) are used internally and merely wider than needed. Narrowing visibility shrinks the surface but isn't deletion; worth a separate pass.