### PR TITLE
fix(squash): keep the source's changes when squashing into a newer commit

### DIFF
--- a/crates/but-workspace/src/commit/squash_commits.rs
+++ b/crates/but-workspace/src/commit/squash_commits.rs
@@ -208,6 +208,12 @@ pub fn squash_commits<'ws, 'meta, M: RefMetadata, S: ToCommitSelector, T: ToComm
         editor.replace(selector, Step::None)?;
     }
 
+    // Removing a subject that sits below the target rewrites every commit above it, including
+    // the target. Rebase before building the squashed commit so it is created on top of the
+    // rebased parents. Otherwise the squashed commit would be replayed as a diff against its
+    // old parent, and the subject's changes would disappear along with the subject commit.
+    let editor = editor.rebase()?.into_editor();
+
     let (editor, new_target_selector) = construct_new_squashed_commit(
         editor,
         squashed_tree,

--- a/crates/but/tests/but/command/squash.rs
+++ b/crates/but/tests/but/command/squash.rs
@@ -203,6 +203,72 @@ Hint: run `but help` for all commands
 }
 
 #[test]
+fn squash_between_oldest_and_newest_commit() {
+    let env = one_branch_three_commits();
+
+    // Squashing the oldest commit into the newest one has to carry `one` into the target,
+    // even though removing the source rewrites the commits in between.
+    env.but("squash 1#2 --target 1#0 --message 'squashed'")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Squashed ea345ba into f55169f to create 7e2f6f7
+
+"#]]);
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ br [a-branch-1]
+┊●   1#0 squashed
+┊│     1#0:k A one
+┊│     1#0:o A three
+┊●   1#1 add two
+┊│     1#1:t A two
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("undo").assert().success();
+
+    // The same squash in the other direction ends up with the same files per commit.
+    env.but("squash 1#0 --target 1#2 --message 'squashed'")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Squashed f55169f into ea345ba to create 734e151
+
+"#]]);
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ br [a-branch-1]
+┊●   1#0 add two
+┊│     1#0:t A two
+┊●   1#1 squashed
+┊│     1#1:k A one
+┊│     1#1:o A three
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
 fn use_target_message() {
     let env = one_branch_three_commits();
 


### PR DESCRIPTION
`but squash <older-commit> -t <newer-commit>` silently discarded the source commit's changes and reported success. The opposite direction worked.

## Cause

The squashed commit was built in the same editor pass that removed the source commits, so it was written with the target's *pre-rebase* parents and then replayed as a diff against them. When the source sits below the target, removing it rewrites every commit in between — but the squashed commit's diff was still computed against a parent that still contained the source's changes, so those changes vanished along with the source commit.

Downward squashes were unaffected: removing a commit above the target does not change the target's parent.

## Fix

Rebase once after removing the sources, before constructing the squashed commit — the same two-phase shape `move_changes_between_commits` already uses. The squashed commit is then built on the rebased parents, so its diff carries the source's changes. Its parents equal the ones it is picked onto, so the cherry-pick short-circuits to identity and the tree lands verbatim.

Also improves the conflicting-lineage case: an intermediate commit that depended on the source now becomes a properly marked conflicted commit, instead of the squashed commit ending up with a tree of nothing but conflict metadata and the file deleted from the worktree.

## Test

`squash_between_oldest_and_newest_commit` asserts the resulting file set per commit in both directions — the printed summary looked correct even while the changes were being dropped.