### PR TITLE
feat(ai): discover models from custom OpenAI endpoints

### DIFF
--- a/apps/desktop/src/components/settings/AiSettings.svelte
+++ b/apps/desktop/src/components/settings/AiSettings.svelte
@@ -3,6 +3,7 @@
 	import AiCredentialCheck from "$components/settings/AiCredentialCheck.svelte";
 	import AuthorizationBanner from "$components/settings/AuthorizationBanner.svelte";
 	import SettingsSection from "$components/shared/SettingsSection.svelte";
+	import { listOpenAIModels, OpenAIModelDiscoveryError } from "$lib/ai/openAIClient";
 	import { AISecretHandle, AI_SERVICE, GitAIConfigKey, KeyOption } from "$lib/ai/service";
 	import { OpenAIModelName, AnthropicModelName, ModelKind } from "$lib/ai/types";
 	import { GIT_CONFIG_SERVICE } from "$lib/config/gitConfigService";
@@ -10,6 +11,7 @@
 	import { USER_SERVICE } from "$lib/user/userService.svelte";
 	import { inject } from "@gitbutler/core/context";
 	import {
+		Button,
 		CardGroup,
 		Icon,
 		InfoMessage,
@@ -35,7 +37,16 @@
 	let anthropicKeyOption: KeyOption | undefined = $state();
 	let openAIKey: string | undefined = $state();
 	let openAICustomEndpoint: string | undefined = $state();
-	let openAIModelName: OpenAIModelName | undefined = $state();
+	let openAIModelName: string | undefined = $state();
+	let discoveredOpenAIModelOptions: { label: string; value: string }[] = $state([]);
+	let openAIModelDiscoveryState:
+		| "idle"
+		| "empty"
+		| "authentication"
+		| "unsupported"
+		| "invalid-response"
+		| "unavailable" = $state("idle");
+	let loadingOpenAIModels = $state(false);
 	let anthropicKey: string | undefined = $state();
 	let anthropicModelName: AnthropicModelName | undefined = $state();
 	let diffLengthLimit: number | undefined = $state();
@@ -110,6 +121,66 @@
 			value: OpenAIModelName.GPT54Nano,
 		},
 	];
+	const hasCustomOpenAIEndpoint = $derived(Boolean(openAICustomEndpoint?.trim()));
+	const openAIModelDiscoveryMessage = $derived(
+		{
+			idle: undefined,
+			empty: "No models were returned. Enter a model ID manually.",
+			authentication: "Authentication failed. Check the API key or enter a model ID manually.",
+			unsupported: "This endpoint does not support model discovery. Enter a model ID manually.",
+			"invalid-response": "The endpoint returned an invalid model list. Enter a model ID manually.",
+			unavailable: "Models could not be loaded. Enter a model ID manually.",
+		}[openAIModelDiscoveryState],
+	);
+
+	function clearOpenAIModelDiscovery() {
+		discoveredOpenAIModelOptions = [];
+		openAIModelDiscoveryState = "idle";
+	}
+
+	function handleOpenAIEndpointInput(endpoint: string) {
+		clearOpenAIModelDiscovery();
+		if (
+			!endpoint.trim() &&
+			!Object.values(OpenAIModelName).includes(openAIModelName as OpenAIModelName)
+		) {
+			openAIModelName = OpenAIModelName.GPT54Nano;
+		}
+	}
+
+	async function discoverOpenAIModels() {
+		const openAIKeyValue = openAIKey?.trim();
+		const openAIEndpointValue = openAICustomEndpoint?.trim();
+		if (!openAIKeyValue || !openAIEndpointValue || loadingOpenAIModels) return;
+
+		loadingOpenAIModels = true;
+		clearOpenAIModelDiscovery();
+		try {
+			const modelIds = await listOpenAIModels(openAIKeyValue, openAIEndpointValue);
+			if (
+				openAIKeyValue !== openAIKey?.trim() ||
+				openAIEndpointValue !== openAICustomEndpoint?.trim()
+			) {
+				return;
+			}
+
+			discoveredOpenAIModelOptions = modelIds.map((modelId) => ({
+				label: modelId,
+				value: modelId,
+			}));
+			openAIModelDiscoveryState = modelIds.length > 0 ? "idle" : "empty";
+		} catch (error) {
+			if (
+				openAIKeyValue === openAIKey?.trim() &&
+				openAIEndpointValue === openAICustomEndpoint?.trim()
+			) {
+				openAIModelDiscoveryState =
+					error instanceof OpenAIModelDiscoveryError ? error.kind : "unavailable";
+			}
+		} finally {
+			loadingOpenAIModels = false;
+		}
+	}
 
 	const anthropicModelOptions = [
 		{
@@ -235,31 +306,79 @@
 						label="API key"
 						type="password"
 						bind:value={openAIKey}
+						oninput={clearOpenAIModelDiscovery}
 						required
 						placeholder="sk-..."
 					/>
 
-					<Select
-						value={openAIModelName}
-						options={openAIModelOptions}
-						label="Model version"
-						wide
-						onselect={(value) => {
-							openAIModelName = value as OpenAIModelName;
-						}}
-					>
-						{#snippet itemSnippet({ item, highlighted })}
-							<SelectItem selected={item.value === openAIModelName} {highlighted}>
-								{item.label}
-							</SelectItem>
-						{/snippet}
-					</Select>
-
 					<Textbox
 						label="Custom endpoint"
 						bind:value={openAICustomEndpoint}
+						oninput={handleOpenAIEndpointInput}
 						placeholder="https://api.openai.com/v1"
 					/>
+
+					{#if hasCustomOpenAIEndpoint}
+						<Textbox
+							label="Model ID"
+							bind:value={openAIModelName}
+							required
+							placeholder="model-id"
+						/>
+
+						<Button
+							kind="outline"
+							icon="refresh"
+							align="flex-end"
+							loading={loadingOpenAIModels}
+							disabled={!openAIKey?.trim()}
+							onclick={discoverOpenAIModels}
+						>
+							Load available models
+						</Button>
+
+						{#if discoveredOpenAIModelOptions.length > 0}
+							<Select
+								value={openAIModelName}
+								options={discoveredOpenAIModelOptions}
+								label="Available models"
+								placeholder="Select a discovered model..."
+								searchable
+								wide
+								onselect={(value) => {
+									openAIModelName = value;
+								}}
+							>
+								{#snippet itemSnippet({ item, highlighted })}
+									<SelectItem selected={item.value === openAIModelName} {highlighted}>
+										{item.label}
+									</SelectItem>
+								{/snippet}
+							</Select>
+						{:else if openAIModelDiscoveryMessage}
+							<InfoMessage style="warning" filled outlined={false}>
+								{#snippet content()}
+									{openAIModelDiscoveryMessage}
+								{/snippet}
+							</InfoMessage>
+						{/if}
+					{:else}
+						<Select
+							value={openAIModelName}
+							options={openAIModelOptions}
+							label="Model version"
+							wide
+							onselect={(value) => {
+								openAIModelName = value;
+							}}
+						>
+							{#snippet itemSnippet({ item, highlighted })}
+								<SelectItem selected={item.value === openAIModelName} {highlighted}>
+									{item.label}
+								</SelectItem>
+							{/snippet}
+						</Select>
+					{/if}
 				{/if}
 			</CardGroup.Item>
 		{/if}

--- a/apps/desktop/src/lib/ai/openAIClient.test.ts
+++ b/apps/desktop/src/lib/ai/openAIClient.test.ts
@@ -1,0 +1,86 @@
+import { listOpenAIModels } from "$lib/ai/openAIClient";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+describe("listOpenAIModels", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	test("requests and returns the models exposed by a custom endpoint", async () => {
+		const fetchMock = vi.fn().mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					object: "list",
+					data: [
+						{ id: "z-model", object: "model", created: 0, owned_by: "test" },
+						{ id: "a-model", object: "model", created: 0, owned_by: "test" },
+						{ id: "z-model", object: "model", created: 0, owned_by: "test" },
+					],
+				}),
+				{ headers: { "content-type": "application/json" } },
+			),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(
+			listOpenAIModels("test-api-key", "https://models.example.test/v1"),
+		).resolves.toEqual(["a-model", "z-model"]);
+
+		expect(fetchMock).toHaveBeenCalledOnce();
+		const [input, init] = fetchMock.mock.calls[0] as [RequestInfo | URL, RequestInit | undefined];
+		const requestUrl =
+			typeof input === "string" ? input : "url" in input ? input.url : input.toString();
+		const headers = new Headers(init?.headers);
+		expect(init?.method?.toUpperCase()).toBe("GET");
+		expect(requestUrl).toBe("https://models.example.test/v1/models");
+		expect(headers.get("authorization")).toBe("Bearer test-api-key");
+	});
+
+	test("classifies authentication failures without exposing the response body", async () => {
+		const fetchMock = vi.fn().mockResolvedValue(
+			new Response(JSON.stringify({ error: { message: "sensitive upstream detail" } }), {
+				status: 401,
+				headers: { "content-type": "application/json" },
+			}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(
+			listOpenAIModels("test-api-key", "https://models.example.test/v1"),
+		).rejects.toMatchObject({
+			kind: "authentication",
+			message: "Model discovery failed: authentication",
+		});
+	});
+
+	test("classifies an unsupported models endpoint", async () => {
+		const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 404 }));
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(
+			listOpenAIModels("test-api-key", "https://models.example.test/v1"),
+		).rejects.toMatchObject({ kind: "unsupported" });
+	});
+
+	test("classifies an unavailable endpoint", async () => {
+		const fetchMock = vi.fn().mockRejectedValue(new TypeError("fetch failed"));
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(
+			listOpenAIModels("test-api-key", "https://models.example.test/v1"),
+		).rejects.toMatchObject({ kind: "unavailable" });
+	});
+
+	test("classifies a malformed model list", async () => {
+		const fetchMock = vi.fn().mockResolvedValue(
+			new Response(JSON.stringify({ object: "list", data: [{ object: "model" }] }), {
+				headers: { "content-type": "application/json" },
+			}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(
+			listOpenAIModels("test-api-key", "https://models.example.test/v1"),
+		).rejects.toMatchObject({ kind: "invalid-response" });
+	});
+});

--- a/apps/desktop/src/lib/ai/openAIClient.ts
+++ b/apps/desktop/src/lib/ai/openAIClient.ts
@@ -4,15 +4,82 @@ import {
 	SHORT_DEFAULT_PR_TEMPLATE,
 } from "$lib/ai/prompts";
 import OpenAI from "openai";
-import type {
-	OpenAIModelName,
-	OpenRouterModelName,
-	Prompt,
-	AIClient,
-	AIEvalOptions,
-} from "$lib/ai/types";
+import type { Prompt, AIClient, AIEvalOptions } from "$lib/ai/types";
 
 const DEFAULT_MAX_TOKENS = 1024;
+
+export type OpenAIModelDiscoveryErrorKind =
+	| "authentication"
+	| "unsupported"
+	| "invalid-response"
+	| "unavailable";
+
+export class OpenAIModelDiscoveryError extends Error {
+	constructor(readonly kind: OpenAIModelDiscoveryErrorKind) {
+		super(`Model discovery failed: ${kind}`);
+		this.name = "OpenAIModelDiscoveryError";
+	}
+}
+
+function createOpenAIClient(openAIKey: string, baseURL: string | undefined) {
+	return new OpenAI({ apiKey: openAIKey, dangerouslyAllowBrowser: true, baseURL });
+}
+
+function parseOpenAIModelIds(response: unknown): string[] {
+	if (!response || typeof response !== "object") {
+		throw new OpenAIModelDiscoveryError("invalid-response");
+	}
+
+	const { data } = response as { data?: unknown };
+	if (!Array.isArray(data)) {
+		throw new OpenAIModelDiscoveryError("invalid-response");
+	}
+
+	const modelIds = data.map((model) => {
+		if (!model || typeof model !== "object") {
+			throw new OpenAIModelDiscoveryError("invalid-response");
+		}
+
+		const { id } = model as { id?: unknown };
+		if (typeof id !== "string" || !id.trim()) {
+			throw new OpenAIModelDiscoveryError("invalid-response");
+		}
+
+		return id.trim();
+	});
+
+	return [...new Set(modelIds)].sort((a, b) => a.localeCompare(b));
+}
+
+function classifyOpenAIModelDiscoveryError(error: unknown): OpenAIModelDiscoveryError {
+	if (error instanceof OpenAIModelDiscoveryError) return error;
+
+	const status =
+		error && typeof error === "object" && "status" in error && typeof error.status === "number"
+			? error.status
+			: undefined;
+	if (status === 401 || status === 403) {
+		return new OpenAIModelDiscoveryError("authentication");
+	}
+	if (status === 404 || status === 405 || status === 501) {
+		return new OpenAIModelDiscoveryError("unsupported");
+	}
+	return new OpenAIModelDiscoveryError("unavailable");
+}
+
+export async function listOpenAIModels(openAIKey: string, baseURL: string): Promise<string[]> {
+	if (!openAIKey.trim() || !baseURL.trim()) {
+		throw new OpenAIModelDiscoveryError("unavailable");
+	}
+
+	const client = createOpenAIClient(openAIKey.trim(), baseURL.trim());
+	try {
+		const response: unknown = await client.models.list();
+		return parseOpenAIModelIds(response);
+	} catch (error) {
+		throw classifyOpenAIModelDiscoveryError(error);
+	}
+}
 
 export class OpenAIClient implements AIClient {
 	defaultCommitTemplate = SHORT_DEFAULT_COMMIT_TEMPLATE;
@@ -21,16 +88,12 @@ export class OpenAIClient implements AIClient {
 
 	private client: OpenAI;
 	private openAIKey: string;
-	private modelName: OpenAIModelName | OpenRouterModelName;
+	private modelName: string;
 
-	constructor(
-		openAIKey: string,
-		modelName: OpenAIModelName | OpenRouterModelName,
-		baseURL: string | undefined,
-	) {
+	constructor(openAIKey: string, modelName: string, baseURL: string | undefined) {
 		this.openAIKey = openAIKey;
 		this.modelName = modelName;
-		this.client = new OpenAI({ apiKey: openAIKey, dangerouslyAllowBrowser: true, baseURL });
+		this.client = createOpenAIClient(openAIKey, baseURL);
 	}
 
 	async evaluate(prompt: Prompt, options?: AIEvalOptions): Promise<string> {

--- a/apps/desktop/src/lib/ai/service.test.ts
+++ b/apps/desktop/src/lib/ai/service.test.ts
@@ -296,10 +296,39 @@ describe("AIService", () => {
 			expect(await aiService.getOpenAIModelName()).toBe(OpenAIModelName.GPT54);
 		});
 
-		test("When a legacy/unknown model is stored, it falls back to the default", async () => {
+		test("When a custom model is stored, it returns the stored value", async () => {
 			const gitConfig = new DummyGitConfigService({
 				...defaultGitConfig,
-				[GitAIConfigKey.OpenAIModelName]: "gpt-4-turbo",
+				[GitAIConfigKey.OpenAIModelName]: "self-hosted-model",
+				[GitAIConfigKey.OpenAICustomEndpoint]: "https://models.example.test/v1",
+			});
+			const secretsService = new DummySecretsService();
+			const tokenMemoryService = new TokenMemoryService();
+			const fetchMock = vi.fn();
+			const cloud = new HttpClient(fetchMock, "https://www.example.com", tokenMemoryService.token);
+			const aiService = new AIService(gitConfig, secretsService, cloud, tokenMemoryService);
+
+			expect(await aiService.getOpenAIModelName()).toBe("self-hosted-model");
+		});
+
+		test("When a custom model is stored without a custom endpoint, it falls back to the default", async () => {
+			const gitConfig = new DummyGitConfigService({
+				...defaultGitConfig,
+				[GitAIConfigKey.OpenAIModelName]: "self-hosted-model",
+			});
+			const secretsService = new DummySecretsService();
+			const tokenMemoryService = new TokenMemoryService();
+			const fetchMock = vi.fn();
+			const cloud = new HttpClient(fetchMock, "https://www.example.com", tokenMemoryService.token);
+			const aiService = new AIService(gitConfig, secretsService, cloud, tokenMemoryService);
+
+			expect(await aiService.getOpenAIModelName()).toBe(OpenAIModelName.GPT54Nano);
+		});
+
+		test("When a blank model is stored, it falls back to the default", async () => {
+			const gitConfig = new DummyGitConfigService({
+				...defaultGitConfig,
+				[GitAIConfigKey.OpenAIModelName]: "   ",
 			});
 			const secretsService = new DummySecretsService();
 			const tokenMemoryService = new TokenMemoryService();

--- a/apps/desktop/src/lib/ai/service.ts
+++ b/apps/desktop/src/lib/ai/service.ts
@@ -162,8 +162,12 @@ export class AIService {
 			GitAIConfigKey.OpenAIModelName,
 			defaultModel,
 		);
-		if (Object.values(OpenAIModelName).includes(storedValue as OpenAIModelName)) {
-			return storedValue as OpenAIModelName;
+		const modelName = storedValue.trim();
+		if (!modelName) return defaultModel;
+
+		if ((await this.getOpenAICustomEndpoint())?.trim()) return modelName;
+		if (Object.values(OpenAIModelName).includes(modelName as OpenAIModelName)) {
+			return modelName;
 		}
 		return defaultModel;
 	}


### PR DESCRIPTION
## Changes

- Allow arbitrary model IDs when an OpenAI custom endpoint is configured.
- Add an explicit authenticated model discovery action backed by the endpoint models API.
- Keep manual model entry available when discovery is unsupported, unavailable, unauthorized, empty, or malformed.
- Categorize discovery failures without exposing endpoint URLs, credentials, or response bodies.
- Add regression coverage for authenticated discovery, failure categories, malformed data, and manual fallback.

## Reasoning

OpenAI-compatible endpoints can expose model IDs that are not part of GitButler preset options. Loading the configured endpoint model list makes those models discoverable while preserving manual configuration for implementations that do not support model discovery.

## Validation

- pnpm --filter @gitbutler/desktop test
- pnpm --filter @gitbutler/desktop check
- pnpm exec eslint apps/desktop/src/components/settings/AiSettings.svelte apps/desktop/src/lib/ai/openAIClient.ts apps/desktop/src/lib/ai/openAIClient.test.ts apps/desktop/src/lib/ai/service.ts apps/desktop/src/lib/ai/service.test.ts
- pnpm exec prettier --check apps/desktop/src/components/settings/AiSettings.svelte apps/desktop/src/lib/ai/openAIClient.ts apps/desktop/src/lib/ai/openAIClient.test.ts apps/desktop/src/lib/ai/service.ts apps/desktop/src/lib/ai/service.test.ts
- pnpm build:desktop

## Affected issues

Fixes #13352