### PR TITLE
Add authoring rules for the bundled `but` skill

### DIFF
--- a/crates/but/skill/AGENTS.md
+++ b/crates/but/skill/AGENTS.md
@@ -1,0 +1,30 @@
+# Editing the bundled `but` skill
+
+`SKILL.md` and `references/` are installed verbatim into users' agents — a wrong
+line here misdirects every agent in every user repo. Only the files in
+`SKILL_FILES` in `crates/but/src/command/skill/mod.rs` ship, so register any new
+reference file there.
+
+- **Never document anything that can block on a TTY.** An editor or interactive
+  picker hangs an agent forever. Give the non-interactive form (`-m`,
+  `--no-message`, `-F`, `-t`, `--yes`), and where the blocking variant is one
+  omitted argument away — bare `but push` — name it and warn against it rather
+  than staying silent.
+- **Never document what you have not observed.** Help text and doc comments
+  state intent and drift from behavior, so build the CLI and run the command
+  against a scratch repo — setting `E2E_TEST_APP_DATA_DIR` to a temp dir keeps
+  it off your real GitButler data. Sample output in examples is a claim too.
+  Warnings need the same evidence: if you cannot reproduce the failure one
+  prevents, cut it.
+- **Never document commands agents should not run:** subcommands and flags
+  marked `hide = true` in `crates/but/src/args/` (the hidden flags on `push` are
+  the usual trap), and the TUI/GUI surfaces.
+- **When a command changes, re-derive its guidance** instead of syntax-swapping
+  the prose; rationale written for the old implementation dies with it. The same
+  facts are deliberately repeated across the four installed files — grep and
+  update every occurrence.
+- **Leave `version: 0.0.0` alone.** `inject_version` string-replaces that exact
+  text at install time, so "fixing" it silently breaks skill versioning.
+- **Keep the frontmatter `description` under 1024 characters.** Past that, Codex
+  drops it outright and Claude Code truncates it — the skill loses its trigger
+  text with no error either way.

--- a/crates/but/skill/CLAUDE.md
+++ b/crates/but/skill/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/but/skill/README.md
+++ b/crates/but/skill/README.md
@@ -47,6 +47,7 @@ The skill directory contains both distributable skill files and development docu
 ```text
 crates/but/skill/
 ├── SKILL.md                   ← Skill entry point (INSTALLED)
+├── AGENTS.md                  ← Rules for editing these files (NOT installed)
 ├── README.md                  ← This file - development docs (NOT installed)
 └── references/                ← Additional skill documentation (INSTALLED)
     ├── reference.md           - Command reference
@@ -61,6 +62,7 @@ The `but skill install` command only copies the distributable files to the user'
 
 **What stays in the repository:**
 Development documentation remains in the source tree and is not installed:
+- `AGENTS.md` - Rules for anyone editing the skill files (symlinked as `CLAUDE.md`)
 - `README.md` - This file (development and maintenance docs)
 
 ## When This Skill Is Invoked
@@ -93,7 +95,7 @@ The YAML `description` field contains all triggering information so Claude knows
 
 ### Lean Entry Point
 
-SKILL.md is kept under 150 lines as a "table of contents" that points to detailed materials.
+SKILL.md acts as a "table of contents" that points to detailed materials.
 
 ### Domain Separation
 
@@ -128,10 +130,6 @@ Uses directive language ("do this") rather than passive ("this might happen").
 - New workflow patterns
 - Common user questions
 - Real-world scenarios
-
-### Line Count Guideline
-
-Keep SKILL.md at or under 250 lines. Split content into reference files if approaching the limit.
 
 ## Testing the Skill
 

--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -12,7 +12,7 @@ Agent-focused reference for useful `but` commands.
 - [Remote Operations](#remote-operations) - `push`, `pull`, `pr`, `land`
 - [Workspace Maintenance](#workspace-maintenance) - `clean`
 - [History & Undo](#history--undo) - `undo`, `oplog`
-- [Setup & Configuration](#setup--configuration) - `setup`, `teardown`, `config`, `update`, `skill`, `gui`
+- [Setup & Configuration](#setup--configuration) - `setup`, `teardown`, `config`, `update`, `skill`
 - [Selected Options](#selected-options)
 
 ## Inspection (Understanding State)
@@ -539,17 +539,6 @@ Manage installed GitButler skill files.
 but skill check
 but skill check --update
 but skill install --detect
-```
-
-### `but gui [path]`
-
-Open the GitButler desktop app for a project directory.
-
-```bash
-but gui                     # Open the current directory in the app
-but gui ../other-repo       # Open a specific project directory
-but gui --new-window        # Open the current project in a new app window
-but gui -n ../other-repo    # Short flag for opening another project in a new window
 ```
 
 ## Selected Options


### PR DESCRIPTION
The skill files in `crates/but/skill/` are compiled into the binary and installed verbatim into users' agents, so a wrong line there propagates widely. The recent correctness pass (#15009) found the breakage was all of one kind and all avoidable: syntax that rotted silently when the CLI changed underneath it, a claim transcribed from help text that was itself wrong, steering carried over from a command that no longer existed, and an example whose sample output contradicted the flag it used.

This adds a short `AGENTS.md` (with the usual `CLAUDE.md` symlink) recording the rules that prevent that class:

- never document anything that can block on a TTY, and where the blocking variant is one omitted argument away, name it rather than staying silent
- never document what you have not observed — help text states intent and drifts from behavior
- never document commands agents should not run
- when a command changes, re-derive its guidance instead of syntax-swapping the prose
- leave `version: 0.0.0` alone

It also records the two traps that are invisible from the skill files themselves: only the files in the `include_bytes!` list ship, and `version: 0.0.0` is a literal that `inject_version` replaces at install time.

The second commit is the rules' first application — `but gui` is gone from the reference, since opening the desktop app is not something an agent should do on the user's behalf.

The one size limit worth stating is the 1024-char `description` cap, because exceeding it fails silently — Codex drops the field outright, Claude Code truncates it, and the skill loses its trigger text with no error. The `SKILL.md` line-count guideline is deliberately excluded: it is 192 of a recommended 500, nothing enforces it, and an unenforced number in a rules file is a comment cosplaying as a constraint.
