### PR TITLE
Fix redundant diff rerenders

### DIFF
--- a/apps/lite/AGENTS.md
+++ b/apps/lite/AGENTS.md
@@ -19,7 +19,7 @@ $ pnpm -F @gitbutler/lite check
 
 # Components
 
-Memoization utilities such as `useMemo`, `useCallback`, and `React.memo` are redundant as we use React Compiler.
+Memoization utilities such as `useMemo`, `useCallback`, and `React.memo` are usually redundant as we use React Compiler, however may be necessary in hot paths where the compiler fails to understand that a computation is pure and therefore safe to memoise.
 
 The compiler does not prevent re-render regressions: it silently skips memoizing calls to imported functions, and context still re-renders every consumer. Before writing code that derives values during render, adds a context, subscribes to the store, or renders lists of rows — or when the UI is slow or re-renders too much — use the `lite-render-perf` skill (`.agents/skills/lite-render-perf/SKILL.md`).
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -80,6 +80,7 @@ import {
 	Suspense,
 	useId,
 	useLayoutEffect,
+	useMemo,
 	useRef,
 	useState,
 } from "react";
@@ -1040,21 +1041,31 @@ const Diff: FC<{
 		projectSlice.selectors.selectSelectionFiles(state, projectId, filesNavigationIndex),
 	);
 
-	const changesetKey = Match.value(outlineSelection).pipe(
-		Match.tags({
-			Branch: ({ branchRef }) => decodeBytes(branchRef),
-			File: ({ path }) => path,
-			Commit: ({ commitId }) => commitId,
-		}),
-		Match.orElseAbsurd,
+	// At time of writing React Compiler cannot statically analyse that these are pure derivations of
+	// the outline selection, even with the helpers inlined, hence manual memoisation.
+	const changesetKey = useMemo(
+		() =>
+			Match.value(outlineSelection).pipe(
+				Match.tags({
+					Branch: ({ branchRef }) => decodeBytes(branchRef),
+					File: ({ path }) => path,
+					Commit: ({ commitId }) => commitId,
+				}),
+				Match.orElseAbsurd,
+			),
+		[outlineSelection],
 	);
-	const fileParent = Match.value(outlineSelection).pipe(
-		Match.tags({
-			Branch: ({ branchRef }) => branchFileParent({ branchRef }),
-			File: ({ parent }) => parent,
-			Commit: ({ commitId }) => commitFileParent({ commitId }),
-		}),
-		Match.orElseAbsurd,
+	const fileParent = useMemo(
+		() =>
+			Match.value(outlineSelection).pipe(
+				Match.tags({
+					Branch: ({ branchRef }) => branchFileParent({ branchRef }),
+					File: ({ parent }) => parent,
+					Commit: ({ commitId }) => commitFileParent({ commitId }),
+				}),
+				Match.orElseAbsurd,
+			),
+		[outlineSelection],
 	);
 
 	const treeChangeDiffs = useSuspenseQueries({


### PR DESCRIPTION
Supersedes #14976 (cc @krlvi). It was always plausible that we'd need to perform manual memoisation in some select hot paths.