### PR TITLE
Correct three claims in `commit`, `squash` and `discard` help

### DIFF
--- a/crates/but/src/args/commit.rs
+++ b/crates/but/src/args/commit.rs
@@ -11,8 +11,8 @@ use crate::args::atoms::CliIdArg;
 /// arguments.
 ///
 /// If there are no branches applied, a new branch is created for the commit. If there is only one
-/// branch applied, the commit is placed at the tip of that branch. Otherwise, the targeting flags
-/// `--above`, `--below` and `--branch` must be used to control where the commit is placed. Note
+/// stack of branches applied, the commit is placed at the tip of that stack. Otherwise, the
+/// targeting flags `--above`, `--below` and `--branch` control where the commit is placed. Note
 /// that only one of the targeting flags can be provided at a time.
 ///
 /// The commit is expected to have a commit message unless `--no-message` is provided. If neither of

--- a/crates/but/src/args/discard.rs
+++ b/crates/but/src/args/discard.rs
@@ -11,6 +11,8 @@ use crate::args::atoms::CliIdArg;
 ///
 /// All provided changes must be the same kind. Committed files must come from the same commit.
 ///
+/// The entire operation is recorded as a single oplog entry, so it can be undone with `but undo`.
+///
 /// For more details about CLI IDs, see `but help cli-ids`.
 #[derive(Debug, clap::Parser)]
 #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]

--- a/crates/but/src/args/squash.rs
+++ b/crates/but/src/args/squash.rs
@@ -15,8 +15,8 @@ use crate::args::atoms::CliIdArg;
 /// - Uncommit commits
 /// - Uncommit changes in commits
 ///
-/// If no message-related flag is passed an editor will be opened where the new message can be
-/// composed.
+/// If no message-related flag is passed when squashing commits or branches, an editor may be
+/// opened where the new message can be composed; other squashes keep the target's message.
 ///
 /// For more details about CLI IDs, see `but help cli-ids`.
 #[derive(Debug, clap::Parser)]


### PR DESCRIPTION
A pass over the `--help` text of the commands that changed in the switcheroo turned up two statements that are wrong rather than merely imprecise, plus one omission worth a line. Everything else was left alone.

**`but commit`** said the targeting flags are needed once more than one *branch* is applied. The gate is stacks. Several branches stacked together take an untargeted commit at the stack tip — the case stacking users are in constantly — and the old wording put them in the "otherwise" arm, telling them a targeting flag was mandatory and leaving where the commit lands undefined. The runtime error already says "Found more than one stack", so the help now agrees with it. Net zero words.

**`but squash`** said an editor opens whenever no message-related flag is passed. That only holds when the sources are commits or branches. Uncommitted, `zz` and committed-file sources reuse the target's message and never open an editor (`fix_up_unnecessary_reword_via_editor`), and squashing into `zz` rejects message flags outright. The old wording invited callers either to pass `-m` where it is rejected, or to fear a hang that cannot happen — and amending uncommitted changes is the most common squash there is.

**`but discard`** is the most destructive command in the CLI and said nothing about recoverability, while `but clean` documents exactly this. Discarding uncommitted content is where a git-trained reader reasonably assumes the work is gone for good, so the fact that one `but undo` restores the whole batch is the most decision-relevant thing its help can say. The sentence is copied verbatim from `clean`, so no new vocabulary enters the help corpus.

Two further changes were considered and rejected. `absorb`'s "staged to a lane (branch)" is stale now that the CLI has no stage command, but "staged" appears several times across the help corpus including `but status`, so fixing absorb alone would make the vocabulary less consistent, not more — that belongs in its own sweep. And `commit`'s "must be used" slightly overstates the multi-stack case, since an interactive terminal offers a picker; non-tty callers, who are the ones relying on this prose, do get the error.