### PR TITLE
Stop documenting assignment of changes to a lane

### DIFF
--- a/crates/but/skill/SKILL.md
+++ b/crates/but/skill/SKILL.md
@@ -36,7 +36,7 @@ but diff
 but commit -b <branch> -m "<msg>" <id> <id>
 ```
 
-`but commit -b <branch> ...` creates the branch when it does not exist and prints the resulting workspace state. Do not run a separate `but branch new`, staging command, status command, or verification diff unless the returned output lacks information you need.
+`but commit -b <branch> ...` creates the branch when it does not exist and prints the resulting workspace state. Do not run a separate `but branch new`, status command, or verification diff unless the returned output lacks information you need.
 
 ## IDs
 

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -180,8 +180,8 @@ impl HelpTopic {
 pub enum Subcommands {
     /// Overview of the project workspace state.
     ///
-    /// This shows unstaged files, files staged to stacks, all applied
-    /// branches (stacked or parallel), commits on each of those branches,
+    /// This shows uncommitted files, all applied branches (stacked or
+    /// parallel), commits on each of those branches,
     /// upstream commits that are unintegrated, commit status (pushed or local),
     /// and base branch information.
     ///
@@ -524,14 +524,13 @@ pub enum Subcommands {
     /// The semantic for finding "the appropriate commit" is as follows:
     ///
     /// - If a change has a dependency to a particular commit, it will be amended into that particular commit
-    /// - If a change is staged to a particular lane (branch), it will be amended into a commit there
-    /// - If there are no commits in this branch, a new commit is created
-    /// - Changes are amended into the topmost commit of the leftmost (first) lane (branch)
+    /// - If a change is assigned to a branch in the GitButler app, it will be amended into a commit there
+    /// - If there are no commits on that branch, a new commit is created there
+    /// - Changes are amended into the topmost commit of the leftmost (first) branch
     ///
-    /// Optionally an identifier to an Uncommitted File or a Branch (stack) may be provided.
+    /// Optionally an identifier to an Uncommitted File may be provided.
     ///
     /// - If an Uncommitted File id is provided, absorb will be performed for just that file
-    /// - If a Branch (stack) id is provided, absorb will be performed for all changes staged to that stack
     /// - If no source is provided, absorb is performed for all uncommitted changes
     ///
     /// If `--dry-run` is specified, no changes will be made; instead, the absorption plan
@@ -541,7 +540,6 @@ pub enum Subcommands {
     #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Absorb {
         /// If the Source is an uncommitted change - the change will be absorbed.
-        /// If the Source is a stack - anything staged to the stack will be absorbed accordingly.
         /// If not provided, everything that is uncommitted will be absorbed.
         source: Option<String>,
         /// Show the absorption plan without making any changes.
@@ -777,8 +775,9 @@ pub enum Subcommands {
 
     /// Remove empty branches from the workspace.
     ///
-    /// A branch is considered empty if it has no local commits, no assigned
-    /// changes, and (by default) no upstream-only commits.
+    /// A branch is considered empty if it has no local commits and (by default)
+    /// no upstream-only commits. Stacks with uncommitted changes assigned to them
+    /// in the GitButler app are skipped entirely.
     ///
     /// The entire operation is recorded as a single oplog entry, so it can
     /// be undone with `but undo`.

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -1118,12 +1118,12 @@ fn print_assignments(
     if let Some(stack) = stack
         && (!unstaged && !assignments.is_empty())
     {
-        let staged_changes_cli_id = status_ctx
+        let assigned_changes_cli_id = status_ctx
             .id_map
             .resolve_stack(stack)
             .cloned()
             .with_context(|| {
-                format!("Could not resolve stack CLI id for staged changes. stack_id={stack:?}")
+                format!("Could not resolve stack CLI id for assigned changes. stack_id={stack:?}")
             })?;
 
         output.staged_changes(
@@ -1134,8 +1134,8 @@ fn print_assignments(
                 Span::styled(
                     branch_name
                         .as_ref()
-                        .map(|name| format!("staged to {name}"))
-                        .unwrap_or_else(|| "staged to ".to_string()),
+                        .map(|name| format!("assigned to {name}"))
+                        .unwrap_or_else(|| "assigned".to_string()),
                     t.info,
                 ),
                 Span::raw("]"),
@@ -1149,7 +1149,7 @@ fn print_assignments(
                     .flatten(),
             )
             .collect(),
-            staged_changes_cli_id,
+            assigned_changes_cli_id,
         )?;
     }
 


### PR DESCRIPTION
The CLI can no longer assign changes to a branch. Nothing under `crates/but/src` creates an assignment — there is no `set_assignment`/`HunkAssignmentRequest` call anywhere, and the TUI only reads them — so help text describing "changes staged to a lane" describes the desktop app rather than this tool.

Removed rather than reworded, since renaming "staged" to "assigned" would have kept a concept the CLI does not have:

- **`but status`** no longer claims to show "files staged to stacks".
- **`but absorb`** loses the branch/stack source form. That form's only meaning was "absorb whatever is assigned to this branch", which a CLI user cannot bring about. The command still accepts a branch id and still works for anyone whose repo has assignments from the desktop app; it is simply no longer documented as a CLI concept.
- **`but clean`** and **`but absorb`** keep the places where behaviour genuinely depends on assignments, now attributed to where they come from. `find_empty_branches` skips any stack with assigned worktree changes, and `absorb` routes an assigned change to its stack ahead of the leftmost-branch fallback — so dropping those would have made the help describe behaviour the commands do not have. Both now say "in the GitButler app", which keeps the point of this PR (the CLI cannot assign) without leaving the docs wrong.
- The bundled skill's commit fast path told agents not to run "a staging command" — steering against something that does not exist.

One thing kept: `but status` still surfaces assignments when a repo has them, and that line now reads "assigned to <branch>" instead of "staged to <branch>". The output reflects real workspace state, so suppressing it would misrepresent the repo; "assigned" at least matches the wording the desktop app uses for the same thing.
