### PR TITLE
Stabilise diff on commit rewrite

### DIFF
--- a/apps/lite/electron/src/ipc.ts
+++ b/apps/lite/electron/src/ipc.ts
@@ -3,12 +3,12 @@ import type {
 	ApplyOutcome,
 	BranchCheckoutResult,
 	BranchIntegrationStrategy,
-	BranchReference,
 	BranchCreatePlacement,
 	BranchCreateResult,
 	BranchDetails,
 	BranchListing,
 	BranchListingFilter,
+	BranchRenameResult,
 	BottomUpdate,
 	CacheConfig,
 	CiCheck,
@@ -362,10 +362,9 @@ export interface WorkspaceFetchFromRemotesParams {
 	action: string | null;
 }
 
-export interface UpdateBranchNameParams {
+export interface BranchRenameParams {
 	projectId: string;
-	stackId: string;
-	branchName: string;
+	refName: FullNameBytes;
 	newName: string;
 }
 
@@ -382,8 +381,6 @@ export interface UpdateReviewFootersParams {
 	projectId: string;
 	reviews: Array<ForgeReviewUpdate>;
 }
-
-export type UpdateBranchNameResult = BranchReference;
 
 export interface WatcherSubscribeParams {
 	projectId: string;
@@ -484,7 +481,7 @@ export interface LiteElectronApi {
 	openInProgram: (params: OpenInProgramParams) => Promise<void>;
 	pathJoin: (...paths: Array<string>) => Promise<string>;
 	publishReview: (params: PublishReviewParams) => Promise<PublishReviewOutcome>;
-	updateBranchName: (params: UpdateBranchNameParams) => Promise<UpdateBranchNameResult>;
+	branchRename: (params: BranchRenameParams) => Promise<BranchRenameResult>;
 	updateReview: (params: UpdateReviewParams) => Promise<void>;
 	tearOffBranch: (params: TearOffBranchParams) => Promise<MoveBranchResult>;
 	peelRestoreSnapshot: (params: PeelRestoreSnapshotParams) => Promise<Snapshot | null>;
@@ -573,7 +570,7 @@ export const liteIpcChannels = {
 	openInWebBrowser: "workspace:open-in-web-browser",
 	pathJoin: "lite:path-join",
 	publishReview: "workspace:publish-review",
-	updateBranchName: "workspace:update-branch-name",
+	branchRename: "workspace:branch-rename",
 	updateReview: "workspace:update-review",
 	tearOffBranch: "workspace:tear-off-branch",
 	peelRestoreSnapshot: "workspace:peel-restore-snapshot",

--- a/apps/lite/electron/src/ipc.ts
+++ b/apps/lite/electron/src/ipc.ts
@@ -6,8 +6,6 @@ import type {
 	BranchCreatePlacement,
 	BranchCreateResult,
 	BranchDetails,
-	BranchListing,
-	BranchListingFilter,
 	BranchRemoveResult,
 	BranchRenameResult,
 	BottomUpdate,
@@ -235,11 +233,6 @@ export interface CommitUncommitChangesParams {
 	dryRun: boolean;
 }
 
-export interface ListBranchesParams {
-	projectId: string;
-	filter: BranchListingFilter | null;
-}
-
 export interface ListReviewsForBranchParams {
 	projectId: string;
 	branch: string;
@@ -464,10 +457,6 @@ export interface LiteElectronApi {
 	headInfo: (projectId: string) => Promise<RefInfo>;
 	isFullScreen: () => Promise<boolean>;
 	onFullScreenChange: (callback: (fullScreen: boolean) => void) => () => void;
-	listBranches: (
-		projectId: string,
-		filter: BranchListingFilter | null,
-	) => Promise<Array<BranchListing>>;
 	listAvailableReviewTemplates: (projectId: string) => Promise<Array<string>>;
 	listCiChecks: (params: ListCiChecksParams) => Promise<Array<CiCheck>>;
 	listEditors: () => Promise<Array<Editor>>;
@@ -556,7 +545,6 @@ export const liteIpcChannels = {
 	headInfo: "workspace:head-info",
 	isFullScreen: "lite:is-full-screen",
 	fullScreenChange: "lite:full-screen-change",
-	listBranches: "workspace:list-branches",
 	listAvailableReviewTemplates: "workspace:list-available-review-templates",
 	listCiChecks: "workspace:list-ci-checks",
 	listEditors: "workspace:list-editors",

--- a/apps/lite/electron/src/ipc.ts
+++ b/apps/lite/electron/src/ipc.ts
@@ -8,6 +8,7 @@ import type {
 	BranchDetails,
 	BranchListing,
 	BranchListingFilter,
+	BranchRemoveResult,
 	BranchRenameResult,
 	BottomUpdate,
 	CacheConfig,
@@ -300,10 +301,9 @@ export interface WorkspaceBranchAndAncestorsPushParams {
 	pushOpts: Array<PushFlag>;
 }
 
-export interface RemoveBranchParams {
+export interface BranchRemoveParams {
 	projectId: string;
-	stackId: string;
-	branchName: string;
+	refName: FullNameBytes;
 }
 
 export interface RestoreSnapshotWithKindParams {
@@ -488,7 +488,7 @@ export interface LiteElectronApi {
 	workspaceBranchAndAncestorsPush: (
 		params: WorkspaceBranchAndAncestorsPushParams,
 	) => Promise<PushResult>;
-	removeBranch: (params: RemoveBranchParams) => Promise<void>;
+	branchRemove: (params: BranchRemoveParams) => Promise<BranchRemoveResult>;
 	restoreSnapshotWithKind: (params: RestoreSnapshotWithKindParams) => Promise<void>;
 	reviewTemplate: (projectId: string) => Promise<ReviewTemplateInfo | null>;
 	setReviewAutoMerge: (params: SetReviewAutoMergeParams) => Promise<void>;
@@ -575,7 +575,7 @@ export const liteIpcChannels = {
 	tearOffBranch: "workspace:tear-off-branch",
 	peelRestoreSnapshot: "workspace:peel-restore-snapshot",
 	workspaceBranchAndAncestorsPush: "workspace:push-stack",
-	removeBranch: "workspace:remove-branch",
+	branchRemove: "workspace:branch-remove",
 	restoreSnapshotWithKind: "workspace:restore-snapshot-with-kind",
 	reviewTemplate: "workspace:review-template",
 	setReviewAutoMerge: "workspace:set-review-auto-merge",

--- a/apps/lite/electron/src/main.ts
+++ b/apps/lite/electron/src/main.ts
@@ -95,7 +95,6 @@ import {
 	getReviewBaseRepoUrl,
 	getReviewMergeStatus,
 	listAvailableReviewTemplates,
-	listBranches,
 	listCiChecks,
 	listEditors,
 	listPrograms,
@@ -111,7 +110,6 @@ import {
 	unapplyStack,
 	updateReview,
 	workspaceBranchAndAncestorsPush,
-	type BranchListingFilter,
 	commitUncommit,
 	reviewTemplate,
 	restoreSnapshotWithKind,
@@ -547,10 +545,6 @@ const registerIpcHandlers = (): void => {
 	senderValidatingHandle(liteIpcChannels.headInfo, (_e, projectId: string) => headInfo(projectId));
 	senderValidatingHandle(liteIpcChannels.isFullScreen, (event) =>
 		Promise.resolve(BrowserWindow.fromWebContents(event.sender)?.isFullScreen() ?? false),
-	);
-	senderValidatingHandle(
-		liteIpcChannels.listBranches,
-		(_e, projectId: string, filter: BranchListingFilter | null) => listBranches(projectId, filter),
 	);
 	senderValidatingHandle(liteIpcChannels.listAvailableReviewTemplates, (_e, projectId: string) =>
 		listAvailableReviewTemplates(projectId),

--- a/apps/lite/electron/src/main.ts
+++ b/apps/lite/electron/src/main.ts
@@ -35,7 +35,7 @@ import {
 	type OpenInProgramParams,
 	type PublishReviewParams,
 	type WorkspaceBranchAndAncestorsPushParams,
-	type RemoveBranchParams,
+	type BranchRemoveParams,
 	type TearOffBranchParams,
 	type TreeChangeDiffParams,
 	type BranchRenameParams,
@@ -70,6 +70,7 @@ import {
 	branchDetails,
 	branchDiff,
 	branchList,
+	branchRemove,
 	branchRename,
 	changesInWorktree,
 	commitAmend,
@@ -105,7 +106,6 @@ import {
 	moveBranch,
 	openInProgram,
 	publishReview,
-	removeBranch,
 	tearOffBranch,
 	treeChangeDiffs,
 	unapplyStack,
@@ -652,9 +652,8 @@ const registerIpcHandlers = (): void => {
 			),
 	);
 	senderValidatingHandle(
-		liteIpcChannels.removeBranch,
-		(_e, { projectId, stackId, branchName }: RemoveBranchParams) =>
-			removeBranch(projectId, stackId, branchName),
+		liteIpcChannels.branchRemove,
+		(_e, { projectId, refName }: BranchRemoveParams) => branchRemove(projectId, refName),
 	);
 	senderValidatingHandle(
 		liteIpcChannels.restoreSnapshotWithKind,

--- a/apps/lite/electron/src/main.ts
+++ b/apps/lite/electron/src/main.ts
@@ -38,7 +38,7 @@ import {
 	type RemoveBranchParams,
 	type TearOffBranchParams,
 	type TreeChangeDiffParams,
-	type UpdateBranchNameParams,
+	type BranchRenameParams,
 	type UpdateReviewParams,
 	type ApplyParams,
 	type AskpassSubmitPromptResponseParams,
@@ -70,6 +70,7 @@ import {
 	branchDetails,
 	branchDiff,
 	branchList,
+	branchRename,
 	changesInWorktree,
 	commitAmend,
 	commitCreate,
@@ -108,7 +109,6 @@ import {
 	tearOffBranch,
 	treeChangeDiffs,
 	unapplyStack,
-	updateBranchName,
 	updateReview,
 	workspaceBranchAndAncestorsPush,
 	type BranchListingFilter,
@@ -611,9 +611,9 @@ const registerIpcHandlers = (): void => {
 		(_e, { projectId, params }: PublishReviewParams) => publishReview(projectId, params),
 	);
 	senderValidatingHandle(
-		liteIpcChannels.updateBranchName,
-		(_e, { projectId, stackId, branchName, newName }: UpdateBranchNameParams) =>
-			updateBranchName(projectId, stackId, branchName, newName),
+		liteIpcChannels.branchRename,
+		(_e, { projectId, refName, newName }: BranchRenameParams) =>
+			branchRename(projectId, refName, newName),
 	);
 	senderValidatingHandle(
 		liteIpcChannels.updateReview,

--- a/apps/lite/electron/src/preload.cts
+++ b/apps/lite/electron/src/preload.cts
@@ -42,6 +42,7 @@ import type {
 	RepoInfo,
 	ReviewMergeStatus,
 	ReviewTemplateInfo,
+	BranchRemoveResult,
 	BranchRenameResult,
 } from "@gitbutler/but-sdk";
 import type { GUISettings } from "./settings";
@@ -198,7 +199,8 @@ const api: LiteElectronApi = {
 		ipcRenderer.invoke("workspace:peel-restore-snapshot", params) as Promise<Snapshot | null>,
 	workspaceBranchAndAncestorsPush: (params) =>
 		ipcRenderer.invoke("workspace:push-stack", params) as Promise<PushResult>,
-	removeBranch: (params) => ipcRenderer.invoke("workspace:remove-branch", params) as Promise<void>,
+	branchRemove: (params) =>
+		ipcRenderer.invoke("workspace:branch-remove", params) as Promise<BranchRemoveResult>,
 	restoreSnapshotWithKind: (params) =>
 		ipcRenderer.invoke("workspace:restore-snapshot-with-kind", params) as Promise<void>,
 	reviewTemplate: (projectId) =>

--- a/apps/lite/electron/src/preload.cts
+++ b/apps/lite/electron/src/preload.cts
@@ -1,5 +1,5 @@
 import { contextBridge, ipcRenderer } from "electron";
-import type { LiteElectronApi, UpdateBranchNameResult, WatcherSubscribeResult } from "./ipc";
+import type { LiteElectronApi, WatcherSubscribeResult } from "./ipc";
 import type {
 	CommitAbsorption,
 	ApplyOutcome,
@@ -42,6 +42,7 @@ import type {
 	RepoInfo,
 	ReviewMergeStatus,
 	ReviewTemplateInfo,
+	BranchRenameResult,
 } from "@gitbutler/but-sdk";
 import type { GUISettings } from "./settings";
 
@@ -188,8 +189,8 @@ const api: LiteElectronApi = {
 		ipcRenderer.invoke("lite:path-join", path, ...paths) as Promise<string>,
 	publishReview: (params) =>
 		ipcRenderer.invoke("workspace:publish-review", params) as Promise<PublishReviewOutcome>,
-	updateBranchName: (params) =>
-		ipcRenderer.invoke("workspace:update-branch-name", params) as Promise<UpdateBranchNameResult>,
+	branchRename: (params) =>
+		ipcRenderer.invoke("workspace:branch-rename", params) as Promise<BranchRenameResult>,
 	updateReview: (params) => ipcRenderer.invoke("workspace:update-review", params) as Promise<void>,
 	tearOffBranch: (params) =>
 		ipcRenderer.invoke("workspace:tear-off-branch", params) as Promise<MoveBranchResult>,

--- a/apps/lite/electron/src/preload.cts
+++ b/apps/lite/electron/src/preload.cts
@@ -6,7 +6,6 @@ import type {
 	BranchCheckoutResult,
 	BranchCreateResult,
 	BranchDetails,
-	BranchListing,
 	CommitDetails,
 	DiffSpec,
 	Editor,
@@ -161,10 +160,6 @@ const api: LiteElectronApi = {
 		ipcRenderer.on("lite:full-screen-change", listener);
 		return () => ipcRenderer.removeListener("lite:full-screen-change", listener);
 	},
-	listBranches: (projectId, filter) =>
-		ipcRenderer.invoke("workspace:list-branches", projectId, filter) as Promise<
-			Array<BranchListing>
-		>,
 	listAvailableReviewTemplates: (projectId) =>
 		ipcRenderer.invoke("workspace:list-available-review-templates", projectId) as Promise<
 			Array<string>

--- a/apps/lite/ui/src/api/bytes.ts
+++ b/apps/lite/ui/src/api/bytes.ts
@@ -3,7 +3,3 @@ export const decodeBytes = (b: Array<number>): string =>
 	new TextDecoder().decode(Uint8Array.from(b));
 
 export const encodeBytes = (s: string): Array<number> => Array.from(new TextEncoder().encode(s));
-
-export const bytesEqual = (left: Array<number>, right: Array<number>): boolean =>
-	left === right ||
-	(left.length === right.length && left.every((value, index) => value === right[index]));

--- a/apps/lite/ui/src/api/mutations.ts
+++ b/apps/lite/ui/src/api/mutations.ts
@@ -412,7 +412,7 @@ export const useCommitCreate = ({ projectId }: { projectId: string }) => {
 
 			if (input.relativeTo.type === "commit" && response.newCommit !== null) {
 				const headInfoIndex = getHeadInfoIndex(response.workspace.headInfo);
-				const newCommitCtx = headInfoIndex.commitContextById(response.newCommit);
+				const newCommitCtx = headInfoIndex.commitContextByCommitId(response.newCommit);
 
 				if (newCommitCtx) {
 					dispatch(
@@ -529,7 +529,7 @@ export const useCommitInsertBlank = () => {
 			syncCoreCaches(mutation.client, dispatch, input.projectId, response);
 
 			const headInfoIndex = getHeadInfoIndex(response.workspace.headInfo);
-			const newCommitCtx = headInfoIndex.commitContextById(response.newCommit);
+			const newCommitCtx = headInfoIndex.commitContextByCommitId(response.newCommit);
 
 			if (newCommitCtx) {
 				dispatch(

--- a/apps/lite/ui/src/api/mutations.ts
+++ b/apps/lite/ui/src/api/mutations.ts
@@ -696,11 +696,15 @@ export const useWorkspaceIntegrateUpstream = () => {
 	});
 };
 
-export const useRemoveBranch = () => {
+export const useBranchRemove = () => {
+	const dispatch = useAppDispatch();
 	const toastManager = Toast.useToastManager();
 
 	return useMutation({
-		mutationFn: window.lite.removeBranch,
+		mutationFn: window.lite.branchRemove,
+		onSuccess: (response, input, _context, mutation) => {
+			syncCoreCaches(mutation.client, dispatch, input.projectId, response);
+		},
 		onError: (error) => {
 			// oxlint-disable-next-line no-console
 			console.error(error);

--- a/apps/lite/ui/src/api/mutations.ts
+++ b/apps/lite/ui/src/api/mutations.ts
@@ -1,5 +1,5 @@
 import { decodeBytes, encodeBytes } from "#ui/api/bytes.ts";
-import { renameBranchInHeadInfo } from "#ui/api/ref-info.ts";
+import { getHeadInfoIndex, renameBranchInHeadInfo } from "#ui/api/ref-info.ts";
 import {
 	changesInWorktreeQueryOptions,
 	getReviewMergeStatusQueryOptions,
@@ -411,12 +411,20 @@ export const useCommitCreate = ({ projectId }: { projectId: string }) => {
 			syncCoreCaches(mutation.client, dispatch, projectId, response);
 
 			if (input.relativeTo.type === "commit" && response.newCommit !== null) {
-				dispatch(
-					projectSlice.actions.selectOutline({
-						projectId,
-						selection: commitOperand({ commitId: response.newCommit }),
-					}),
-				);
+				const headInfoIndex = getHeadInfoIndex(response.workspace.headInfo);
+				const newCommitCtx = headInfoIndex.commitContextById(response.newCommit);
+
+				if (newCommitCtx) {
+					dispatch(
+						projectSlice.actions.selectOutline({
+							projectId,
+							selection: commitOperand({
+								commitId: response.newCommit,
+								changeId: newCommitCtx.commit.changeId,
+							}),
+						}),
+					);
+				}
 			}
 
 			if (response.rejectedChanges.length > 0) {
@@ -520,12 +528,20 @@ export const useCommitInsertBlank = () => {
 		onSuccess: async (response, input, _context, mutation) => {
 			syncCoreCaches(mutation.client, dispatch, input.projectId, response);
 
-			dispatch(
-				projectSlice.actions.selectOutline({
-					projectId: input.projectId,
-					selection: commitOperand({ commitId: response.newCommit }),
-				}),
-			);
+			const headInfoIndex = getHeadInfoIndex(response.workspace.headInfo);
+			const newCommitCtx = headInfoIndex.commitContextById(response.newCommit);
+
+			if (newCommitCtx) {
+				dispatch(
+					projectSlice.actions.selectOutline({
+						projectId: input.projectId,
+						selection: commitOperand({
+							commitId: response.newCommit,
+							changeId: newCommitCtx.commit.changeId,
+						}),
+					}),
+				);
+			}
 		},
 		onError: (error) => {
 			// oxlint-disable-next-line no-console

--- a/apps/lite/ui/src/api/mutations.ts
+++ b/apps/lite/ui/src/api/mutations.ts
@@ -1,5 +1,5 @@
 import { decodeBytes, encodeBytes } from "#ui/api/bytes.ts";
-import { getHeadInfoIndex, renameBranchInHeadInfo } from "#ui/api/ref-info.ts";
+import { getHeadInfoIndex } from "#ui/api/ref-info.ts";
 import {
 	changesInWorktreeQueryOptions,
 	getReviewMergeStatusQueryOptions,
@@ -15,7 +15,7 @@ import {
 	discardChangesToastOptions,
 	rejectedChangesToastOptions,
 } from "#ui/operations/toastOptions.tsx";
-import { commitOperand, type BranchOperand } from "#ui/operands.ts";
+import { commitOperand } from "#ui/operands.ts";
 import { projectSlice } from "#ui/projects/state.ts";
 import { type AppDispatch, useAppDispatch } from "#ui/store.ts";
 import { formatRelativeTime } from "#ui/time.ts";
@@ -814,54 +814,37 @@ export const useUnapplyStack = () => {
 	});
 };
 
-export const useUpdateBranchName = ({
-	projectId,
-	branchRef,
-	oldBranch,
-}: {
-	projectId: string;
-	branchRef: Array<number>;
-	oldBranch: BranchOperand;
-}) => {
+export const useBranchRename = () => {
 	const dispatch = useAppDispatch();
 	const toastManager = Toast.useToastManager();
 
 	return useMutation({
-		mutationFn: window.lite.updateBranchName,
-		onSuccess: async (newRef, _input, _context, mutation) => {
-			const newBranch: BranchOperand = {
-				branchRef: newRef.fullNameBytes,
-			};
-
-			mutation.client.setQueryData(headInfoQueryOptions(projectId).queryKey, (headInfo) => {
-				if (!headInfo) return headInfo;
-
-				return renameBranchInHeadInfo({
-					headInfo,
-					branchRef,
-					newName: newRef.displayName,
-					newBranchRef: newRef.fullNameBytes,
-				});
-			});
+		mutationFn: window.lite.branchRename,
+		onSuccess: async (response, input, _context, mutation) => {
+			syncCoreCaches(mutation.client, dispatch, input.projectId, response);
 
 			dispatch(
 				projectSlice.actions.updateRewrittenBranchReferences({
-					projectId,
-					oldBranch,
-					newBranch,
+					projectId: input.projectId,
+					oldBranch: {
+						branchRef: input.refName,
+					},
+					newBranch: {
+						branchRef: response.newRef.fullNameBytes,
+					},
 				}),
 			);
 
 			await moveDraftPR({
 				queryClient: mutation.client,
-				projectId,
+				projectId: input.projectId,
 				oldBranch:
 					// https://linear.app/gitbutler/issue/GB-1226/unify-branch-identifiers
-					decodeBytes(oldBranch.branchRef).replace(/^refs\/heads\//, ""),
-				newBranch: newRef.displayName,
+					decodeBytes(input.refName).replace(/^refs\/heads\//, ""),
+				newBranch: response.newRef.displayName,
 			});
 
-			dispatch(projectSlice.actions.exitMode({ projectId }));
+			dispatch(projectSlice.actions.exitMode({ projectId: input.projectId }));
 		},
 		onError: (error) => {
 			// oxlint-disable-next-line no-console

--- a/apps/lite/ui/src/api/queries.ts
+++ b/apps/lite/ui/src/api/queries.ts
@@ -4,7 +4,6 @@ import type {
 	BranchDiffParams,
 	CommitDetailsWithLineStatsParams,
 	GetReviewParams,
-	ListBranchesParams,
 	ListCiChecksParams,
 	ListReviewsParams,
 	TreeChangeDiffParams,
@@ -27,7 +26,6 @@ export type QueryKey =
 	| "review"
 	| "reviewMergeStatus"
 	| "reviews"
-	| "branches"
 	| "editors"
 	| "projects"
 	| "treeChangeDiffs"
@@ -144,12 +142,6 @@ export const listReviewsQueryOptions = ({ projectId, ...params }: ListReviewsPar
 			};
 		},
 		staleTime: 60_000,
-	});
-
-export const listBranchesQueryOptions = ({ projectId, ...params }: ListBranchesParams) =>
-	queryOptions({
-		queryKey: ["branches" satisfies QueryKey, projectId, params],
-		queryFn: () => window.lite.listBranches(projectId, params.filter),
 	});
 
 export const listProjectsQueryOptions = queryOptions({

--- a/apps/lite/ui/src/api/ref-info.ts
+++ b/apps/lite/ui/src/api/ref-info.ts
@@ -17,7 +17,6 @@ type CommitIndex = {
 };
 
 export type HeadInfoIndex = {
-	stackContextById: (stackId: string) => StackIndex | undefined;
 	branchContextByRefBytes: (ref: Array<number>) => (StackIndex & SegmentIndex) | undefined;
 	commitContextByCommitId: (
 		commitId: string,
@@ -32,7 +31,6 @@ export type HeadInfoIndex = {
 const headInfoIndexCache = new WeakMap<RefInfo, HeadInfoIndex>();
 
 const buildHeadInfoIndex = (headInfo: RefInfo): HeadInfoIndex => {
-	const stackContextById = new Map<string, StackIndex>();
 	const branchContextByRef = new Map<string, StackIndex & SegmentIndex>();
 	const commitContextByCommitId = new Map<string, StackIndex & SegmentIndex & CommitIndex>();
 	const commitContextsByChangeId = new Map<
@@ -43,8 +41,6 @@ const buildHeadInfoIndex = (headInfo: RefInfo): HeadInfoIndex => {
 	const branchRefKey = (ref: Array<number>): string => ref.join(",");
 
 	for (const [stackIndex, stack] of headInfo.stacks.entries()) {
-		if (stack.id !== null) stackContextById.set(stack.id, { stack, stackIndex });
-
 		for (const [segmentIndex, segment] of stack.segments.entries()) {
 			if (segment.refName) {
 				branchContextByRef.set(branchRefKey(segment.refName.fullNameBytes), {
@@ -74,7 +70,6 @@ const buildHeadInfoIndex = (headInfo: RefInfo): HeadInfoIndex => {
 	}
 
 	return {
-		stackContextById: (stackId: string) => stackContextById.get(stackId),
 		branchContextByRefBytes: (ref: Array<number>) => branchContextByRef.get(branchRefKey(ref)),
 		commitContextByCommitId: (commitId: string) => commitContextByCommitId.get(commitId),
 		commitContextsByChangeId: (changeId: string) => commitContextsByChangeId.get(changeId),

--- a/apps/lite/ui/src/api/ref-info.ts
+++ b/apps/lite/ui/src/api/ref-info.ts
@@ -1,4 +1,4 @@
-import { encodeBytes, bytesEqual } from "#ui/api/bytes.ts";
+import { encodeBytes } from "#ui/api/bytes.ts";
 import type { Commit, RefInfo, RelativeTo, Segment, Stack } from "@gitbutler/but-sdk";
 
 type StackIndex = {
@@ -84,35 +84,6 @@ export const getHeadInfoIndex = (headInfo: RefInfo): HeadInfoIndex => {
 	headInfoIndexCache.set(headInfo, index);
 	return index;
 };
-
-export const renameBranchInHeadInfo = ({
-	headInfo,
-	branchRef,
-	newName,
-	newBranchRef,
-}: {
-	headInfo: RefInfo;
-	branchRef: Array<number>;
-	newName: string;
-	newBranchRef: Array<number>;
-}): RefInfo => ({
-	...headInfo,
-	stacks: headInfo.stacks.map((stack) => ({
-		...stack,
-		segments: stack.segments.map((segment) => {
-			if (!segment.refName || !bytesEqual(segment.refName.fullNameBytes, branchRef)) return segment;
-
-			return {
-				...segment,
-				refName: {
-					...segment.refName,
-					displayName: newName,
-					fullNameBytes: newBranchRef,
-				},
-			};
-		}),
-	})),
-});
 
 export const resolveRelativeTo = ({
 	headInfoIndex,

--- a/apps/lite/ui/src/api/ref-info.ts
+++ b/apps/lite/ui/src/api/ref-info.ts
@@ -19,10 +19,14 @@ type CommitIndex = {
 export type HeadInfoIndex = {
 	stackContextById: (stackId: string) => StackIndex | undefined;
 	branchContextByRefBytes: (ref: Array<number>) => (StackIndex & SegmentIndex) | undefined;
-	/** Prefer lookups by commit ID which is globally unique. */
-	commitContextById: (
-		commitOrChangeId: string,
+	commitContextByCommitId: (
+		commitId: string,
 	) => (StackIndex & SegmentIndex & CommitIndex) | undefined;
+	commitContextsByChangeId: (
+		changeId: string,
+	) =>
+		| [StackIndex & SegmentIndex & CommitIndex, ...Array<StackIndex & SegmentIndex & CommitIndex>]
+		| undefined;
 };
 
 const headInfoIndexCache = new WeakMap<RefInfo, HeadInfoIndex>();
@@ -30,7 +34,11 @@ const headInfoIndexCache = new WeakMap<RefInfo, HeadInfoIndex>();
 const buildHeadInfoIndex = (headInfo: RefInfo): HeadInfoIndex => {
 	const stackContextById = new Map<string, StackIndex>();
 	const branchContextByRef = new Map<string, StackIndex & SegmentIndex>();
-	const commitContextById = new Map<string, StackIndex & SegmentIndex & CommitIndex>();
+	const commitContextByCommitId = new Map<string, StackIndex & SegmentIndex & CommitIndex>();
+	const commitContextsByChangeId = new Map<
+		string,
+		[StackIndex & SegmentIndex & CommitIndex, ...Array<StackIndex & SegmentIndex & CommitIndex>]
+	>();
 
 	const branchRefKey = (ref: Array<number>): string => ref.join(",");
 
@@ -56,9 +64,11 @@ const buildHeadInfoIndex = (headInfo: RefInfo): HeadInfoIndex => {
 					commit,
 					commitIndex,
 				};
-				commitContextById.set(commit.id, ctx);
-				// Change IDs aren't globally unique, in which case this is last write wins.
-				commitContextById.set(commit.changeId, ctx);
+				commitContextByCommitId.set(commit.id, ctx);
+
+				const prev = commitContextsByChangeId.get(commit.changeId);
+				if (prev) prev.push(ctx);
+				else commitContextsByChangeId.set(commit.changeId, [ctx]);
 			}
 		}
 	}
@@ -66,7 +76,8 @@ const buildHeadInfoIndex = (headInfo: RefInfo): HeadInfoIndex => {
 	return {
 		stackContextById: (stackId: string) => stackContextById.get(stackId),
 		branchContextByRefBytes: (ref: Array<number>) => branchContextByRef.get(branchRefKey(ref)),
-		commitContextById: (commitOrChangeId: string) => commitContextById.get(commitOrChangeId),
+		commitContextByCommitId: (commitId: string) => commitContextByCommitId.get(commitId),
+		commitContextsByChangeId: (changeId: string) => commitContextsByChangeId.get(changeId),
 	};
 };
 

--- a/apps/lite/ui/src/operands.ts
+++ b/apps/lite/ui/src/operands.ts
@@ -97,7 +97,8 @@ const uncommittedChangesIdentityKey = "uncommitted_changes";
 
 const stackIdentityKey = (operand: StackOperand) => `stack:${operand.stackId}`;
 
-const branchIdentityKey = (operand: BranchOperand) => `branch:${operand.branchRef.join(",")}`;
+export const branchIdentityKey = (operand: BranchOperand) =>
+	`branch:${operand.branchRef.join(",")}`;
 
 export const commitIdentityKey = (operand: Pick<CommitOperand, "commitId">) =>
 	`commit:${operand.commitId}`;
@@ -116,7 +117,7 @@ const fileParentIdentityKey = (fp: FileParent): string => {
 	}
 };
 
-const fileIdentityKey = (operand: FileOperand) =>
+export const fileIdentityKey = (operand: FileOperand) =>
 	`file:${operand.path} <- ${fileParentIdentityKey(operand.parent)}`;
 
 const hunkIdentityKey = (operand: HunkOperand) =>

--- a/apps/lite/ui/src/operands.ts
+++ b/apps/lite/ui/src/operands.ts
@@ -19,8 +19,13 @@ export type BranchOperand = {
 	branchRef: Array<number>;
 };
 
+/**
+ * The commit operand holds two forms of identity, the commit ID and the change ID, corresponding to
+ * strong and weak identity respectively. Use one or the other as needed.
+ */
 export type CommitOperand = {
 	commitId: string;
+	changeId: string;
 };
 
 export type FileOperand = {
@@ -49,9 +54,11 @@ export const branchOperand = ({ branchRef }: BranchOperand): Operand => ({
 
 export const commitOperand = ({
 	commitId,
+	changeId,
 }: CommitOperand): Extract<Operand, { _tag: "Commit" }> => ({
 	_tag: "Commit",
 	commitId,
+	changeId,
 });
 
 export const fileOperand = ({ parent, path }: FileOperand): Extract<Operand, { _tag: "File" }> => ({
@@ -80,10 +87,14 @@ export const branchFileParent = ({ branchRef }: BranchOperand): FileParent => ({
 	branchRef,
 });
 
-export const commitFileParent = ({ commitId }: CommitOperand): FileParent => ({
+export const commitFileParent = ({ commitId, changeId }: CommitOperand): FileParent => ({
 	_tag: "Commit",
 	commitId,
+	changeId,
 });
+
+export const commitIdentityKey = (operand: Pick<CommitOperand, "commitId">) =>
+	JSON.stringify(["Commit", operand.commitId]);
 
 export const operandIdentityKey = (operand: Operand): string =>
 	Match.value(operand).pipe(
@@ -92,7 +103,7 @@ export const operandIdentityKey = (operand: Operand): string =>
 			File: (x) => JSON.stringify(["File", x.parent, x.path]),
 			Stack: (x) => JSON.stringify(["Stack", x.stackId]),
 			Branch: (x) => JSON.stringify(["Branch", x.branchRef]),
-			Commit: (x) => JSON.stringify(["Commit", x.commitId]),
+			Commit: (x) => commitIdentityKey(x),
 			Hunk: (x) =>
 				JSON.stringify([
 					"Hunk",

--- a/apps/lite/ui/src/operands.ts
+++ b/apps/lite/ui/src/operands.ts
@@ -93,27 +93,51 @@ export const commitFileParent = ({ commitId, changeId }: CommitOperand): FilePar
 	changeId,
 });
 
-export const commitIdentityKey = (operand: Pick<CommitOperand, "commitId">) =>
-	JSON.stringify(["Commit", operand.commitId]);
+const uncommittedChangesIdentityKey = "uncommitted_changes";
 
-export const operandIdentityKey = (operand: Operand): string =>
-	Match.value(operand).pipe(
-		Match.tagsExhaustive({
-			UncommittedChanges: () => JSON.stringify(["UncommittedChanges"]),
-			File: (x) => JSON.stringify(["File", x.parent, x.path]),
-			Stack: (x) => JSON.stringify(["Stack", x.stackId]),
-			Branch: (x) => JSON.stringify(["Branch", x.branchRef]),
-			Commit: (x) => commitIdentityKey(x),
-			Hunk: (x) =>
-				JSON.stringify([
-					"Hunk",
-					x.parent,
-					x.hunkHeader,
-					x.lineGroups,
-					x.isResultOfBinaryToTextConversion,
-				]),
-		}),
-	);
+const stackIdentityKey = (operand: StackOperand) => `stack:${operand.stackId}`;
+
+const branchIdentityKey = (operand: BranchOperand) => `branch:${operand.branchRef.join(",")}`;
+
+export const commitIdentityKey = (operand: Pick<CommitOperand, "commitId">) =>
+	`commit:${operand.commitId}`;
+
+export const weakCommitIdentityKey = (operand: Pick<CommitOperand, "changeId">) =>
+	`commit:${operand.changeId}`;
+
+const fileParentIdentityKey = (fp: FileParent): string => {
+	switch (fp._tag) {
+		case "UncommittedChanges":
+			return uncommittedChangesIdentityKey;
+		case "Branch":
+			return branchIdentityKey(fp);
+		case "Commit":
+			return commitIdentityKey(fp);
+	}
+};
+
+const fileIdentityKey = (operand: FileOperand) =>
+	`file:${operand.path} <- ${fileParentIdentityKey(operand.parent)}`;
+
+const hunkIdentityKey = (operand: HunkOperand) =>
+	`hunk:${JSON.stringify(operand.hunkHeader)}:${JSON.stringify(operand.lineGroups)}:${operand.isResultOfBinaryToTextConversion} <- ${fileIdentityKey(operand.parent)}`;
+
+export const operandIdentityKey = (operand: Operand): string => {
+	switch (operand._tag) {
+		case "UncommittedChanges":
+			return uncommittedChangesIdentityKey;
+		case "File":
+			return fileIdentityKey(operand);
+		case "Stack":
+			return stackIdentityKey(operand);
+		case "Branch":
+			return branchIdentityKey(operand);
+		case "Commit":
+			return commitIdentityKey(operand);
+		case "Hunk":
+			return hunkIdentityKey(operand);
+	}
+};
 
 export const operandEquals = (a: Operand, b: Operand): boolean =>
 	operandIdentityKey(a) === operandIdentityKey(b);

--- a/apps/lite/ui/src/operands.ts
+++ b/apps/lite/ui/src/operands.ts
@@ -3,17 +3,12 @@ import type { HunkLineSelection } from "#ui/hunk.ts";
 
 export type Operand =
 	| { _tag: "UncommittedChanges" }
-	| ({ _tag: "Stack" } & StackOperand)
 	| ({ _tag: "Branch" } & BranchOperand)
 	| ({ _tag: "Commit" } & CommitOperand)
 	| ({ _tag: "File" } & FileOperand)
 	| ({ _tag: "Hunk" } & HunkOperand);
 
 export type FileParent = Extract<Operand, { _tag: "UncommittedChanges" | "Branch" | "Commit" }>;
-
-export type StackOperand = {
-	stackId: string;
-};
 
 export type BranchOperand = {
 	branchRef: Array<number>;
@@ -41,11 +36,6 @@ export type HunkOperand = HunkLineSelection & {
 export const uncommittedChangesOperand: Operand = {
 	_tag: "UncommittedChanges",
 };
-
-export const stackOperand = ({ stackId }: StackOperand): Operand => ({
-	_tag: "Stack",
-	stackId,
-});
 
 export const branchOperand = ({ branchRef }: BranchOperand): Operand => ({
 	_tag: "Branch",
@@ -95,8 +85,6 @@ export const commitFileParent = ({ commitId, changeId }: CommitOperand): FilePar
 
 const uncommittedChangesIdentityKey = "uncommitted_changes";
 
-const stackIdentityKey = (operand: StackOperand) => `stack:${operand.stackId}`;
-
 export const branchIdentityKey = (operand: BranchOperand) =>
 	`branch:${operand.branchRef.join(",")}`;
 
@@ -129,8 +117,6 @@ export const operandIdentityKey = (operand: Operand): string => {
 			return uncommittedChangesIdentityKey;
 		case "File":
 			return fileIdentityKey(operand);
-		case "Stack":
-			return stackIdentityKey(operand);
 		case "Branch":
 			return branchIdentityKey(operand);
 		case "Commit":

--- a/apps/lite/ui/src/projects/branches.ts
+++ b/apps/lite/ui/src/projects/branches.ts
@@ -61,7 +61,8 @@ const branchesSlice = createSlice({
 			if (state.selection?._tag !== "Commit") return;
 
 			const newId = replacedCommits[state.selection.commitId];
-			if (newId !== undefined) state.selection = commitOperand({ commitId: newId });
+			if (newId !== undefined)
+				state.selection = commitOperand({ commitId: newId, changeId: state.selection.changeId });
 		},
 		toggleUnfolded: (state, { payload: { branchRef } }: PayloadAction<{ branchRef: string }>) => {
 			if (state.unfolded[branchRef]) delete state.unfolded[branchRef];

--- a/apps/lite/ui/src/projects/project.ts
+++ b/apps/lite/ui/src/projects/project.ts
@@ -338,8 +338,12 @@ export const projectReducers = {
 		const selection = workspaceState.selection.outline;
 		if (selection?._tag === "Commit") {
 			const newId = replacedCommits[selection.commitId];
-			if (newId !== undefined)
-				workspaceState.selection.outline = commitOperand({ commitId: newId });
+			if (newId !== undefined) {
+				workspaceState.selection.outline = commitOperand({
+					commitId: newId,
+					changeId: selection.changeId,
+				});
+			}
 		}
 
 		branchesReducers.updateRewrittenCommitReferences(state.branches, { replacedCommits });
@@ -348,12 +352,13 @@ export const projectReducers = {
 			let newOperand: CheckableOperand | null = null;
 			if (operand._tag === "Commit") {
 				const newId = replacedCommits[operand.commitId];
-				if (newId !== undefined) newOperand = commitOperand({ commitId: newId });
+				if (newId !== undefined)
+					newOperand = commitOperand({ commitId: newId, changeId: operand.changeId });
 			} else if (operand.parent._tag === "Commit") {
 				const newId = replacedCommits[operand.parent.commitId];
 				if (newId !== undefined) {
 					newOperand = fileOperand({
-						parent: commitFileParent({ commitId: newId }),
+						parent: commitFileParent({ commitId: newId, changeId: operand.parent.changeId }),
 						path: operand.path,
 					});
 				}
@@ -366,8 +371,11 @@ export const projectReducers = {
 
 		if (workspaceState.mode._tag === "RewordCommit") {
 			const newId = replacedCommits[workspaceState.mode.operand.commitId];
-			if (newId !== undefined)
-				workspaceState.mode = rewordCommitOutlineMode({ operand: { commitId: newId } });
+			if (newId !== undefined) {
+				workspaceState.mode = rewordCommitOutlineMode({
+					operand: { commitId: newId, changeId: workspaceState.mode.operand.changeId },
+				});
+			}
 		}
 	},
 	toggleFiles: (state: ProjectState) => {

--- a/apps/lite/ui/src/reconcile.ts
+++ b/apps/lite/ui/src/reconcile.ts
@@ -34,12 +34,12 @@ export const useStateReconciler = (): void => {
 	const reconcileSelectedCommit = useEffectEvent((headInfoIndex: HeadInfoIndex) => {
 		if (outlineSelection?._tag !== "Commit") return;
 
-		const curr = headInfoIndex.commitContextById(outlineSelection.commitId);
+		const curr = headInfoIndex.commitContextByCommitId(outlineSelection.commitId);
 		if (curr) return;
 
-		// Change IDs are not necessarily globally unique, but typically will be. In any case this is
-		// a best-effort fallback.
-		const commit = headInfoIndex.commitContextById(outlineSelection.changeId)?.commit;
+		// Change IDs are not necessarily globally unique, but typically will be. In any case this
+		// is a best-effort fallback.
+		const commit = headInfoIndex.commitContextsByChangeId(outlineSelection.changeId)?.[0].commit;
 
 		dispatch(
 			projectSlice.actions.selectOutline({
@@ -58,7 +58,7 @@ export const useStateReconciler = (): void => {
 	const checkedCommits = checkedOperands.filter((operand) => operand._tag === "Commit");
 	const reconcileCheckedCommits = useEffectEvent((headInfoIndex: HeadInfoIndex) => {
 		const invalidated = checkedCommits.filter(
-			(commit) => !headInfoIndex.commitContextById(commit.commitId),
+			(commit) => !headInfoIndex.commitContextByCommitId(commit.commitId),
 		);
 
 		if (invalidated.length > 0) {
@@ -92,7 +92,7 @@ export const useStateReconciler = (): void => {
 		(headInfoIndex: HeadInfoIndex, checkedCommitFilesByCommitId: Map<string, Set<string>>) => {
 			const invalidated = checkedCommitFiles.filter(
 				(file) =>
-					!headInfoIndex.commitContextById(file.parent.commitId) ||
+					!headInfoIndex.commitContextByCommitId(file.parent.commitId) ||
 					checkedCommitFilesByCommitId.get(file.parent.commitId)?.has(file.path) === false,
 			);
 

--- a/apps/lite/ui/src/reconcile.ts
+++ b/apps/lite/ui/src/reconcile.ts
@@ -12,7 +12,7 @@ import {
 } from "./api/queries.ts";
 import { useParams } from "@tanstack/react-router";
 import { getHeadInfoIndex, type HeadInfoIndex } from "./api/ref-info.ts";
-import { useEffectEvent, useLayoutEffect, useRef } from "react";
+import { useEffectEvent, useLayoutEffect } from "react";
 import { useAppDispatch, useAppSelector } from "./store.ts";
 import { projectSlice } from "./projects/state.ts";
 import { commitOperand } from "./operands.ts";
@@ -31,28 +31,25 @@ export const useStateReconciler = (): void => {
 	const outlineSelection = useAppSelector((state) =>
 		projectSlice.selectors.selectPrimaryOutlineSelection(state, projectId),
 	);
-	const reconcileSelectedCommit = useEffectEvent(
-		(headInfoIndex: HeadInfoIndex, prevHeadInfoIndex: HeadInfoIndex | null) => {
-			if (outlineSelection?._tag !== "Commit") return;
+	const reconcileSelectedCommit = useEffectEvent((headInfoIndex: HeadInfoIndex) => {
+		if (outlineSelection?._tag !== "Commit") return;
 
-			const curr = headInfoIndex.commitContextById(outlineSelection.commitId);
-			if (curr) return;
+		const curr = headInfoIndex.commitContextById(outlineSelection.commitId);
+		if (curr) return;
 
-			const prev = prevHeadInfoIndex?.commitContextById(outlineSelection.commitId);
-			// Change IDs are not necessarily globally unique, but typically will be. In any case this is
-			// a best-effort fallback.
-			const commitId = prev
-				? headInfoIndex.commitContextById(prev.commit.changeId)?.commit.id
-				: null;
+		// Change IDs are not necessarily globally unique, but typically will be. In any case this is
+		// a best-effort fallback.
+		const commit = headInfoIndex.commitContextById(outlineSelection.changeId)?.commit;
 
-			dispatch(
-				projectSlice.actions.selectOutline({
-					projectId,
-					selection: commitId != null ? commitOperand({ commitId }) : null,
-				}),
-			);
-		},
-	);
+		dispatch(
+			projectSlice.actions.selectOutline({
+				projectId,
+				selection: commit
+					? commitOperand({ commitId: commit.id, changeId: commit.changeId })
+					: null,
+			}),
+		);
+	});
 
 	const checkedOperands = useAppSelector((state) =>
 		projectSlice.selectors.selectCheckedOperands(state, projectId),
@@ -131,14 +128,11 @@ export const useStateReconciler = (): void => {
 		...headInfoQueryOptions(projectId),
 		select: getHeadInfoIndex,
 	});
-	const prevHeadInfoIndexRef = useRef<HeadInfoIndex>(null);
 	useLayoutEffect(() => {
 		if (!headInfoIndex) return;
 
-		reconcileSelectedCommit(headInfoIndex, prevHeadInfoIndexRef.current);
+		reconcileSelectedCommit(headInfoIndex);
 		reconcileCheckedCommits(headInfoIndex);
-
-		prevHeadInfoIndexRef.current = headInfoIndex;
 	}, [headInfoIndex]);
 
 	const { data: worktreeChangePaths } = useQuery({

--- a/apps/lite/ui/src/routes/project/$id/workspace/ApplyBranchPicker.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/ApplyBranchPicker.tsx
@@ -1,10 +1,8 @@
-import { encodeBytes } from "#ui/api/bytes.ts";
 import { useApply } from "#ui/api/mutations.ts";
-import { getHeadInfoIndex } from "#ui/api/ref-info.ts";
-import { headInfoQueryOptions, listBranchesQueryOptions } from "#ui/api/queries.ts";
+import { branchListQueryOptions } from "#ui/api/queries.ts";
 import { PickerDialog, type PickerDialogGroup } from "#ui/components/PickerDialog.tsx";
 import { formatRelativeTime } from "#ui/time.ts";
-import type { BranchListing } from "@gitbutler/but-sdk";
+import type { ListedBranch, ListedStack } from "@gitbutler/but-sdk";
 import { useQuery } from "@tanstack/react-query";
 import { type FC, useState } from "react";
 
@@ -12,7 +10,7 @@ type ApplyBranchPickerOption = {
 	branchRef: string;
 	label: string;
 	type: string;
-	updatedAt: number;
+	updatedAt: number | null;
 };
 
 type Props = {
@@ -21,26 +19,32 @@ type Props = {
 	projectId: string;
 };
 
-const branchListingToApplyBranchPickerOptions = (
-	branch: BranchListing,
+const listedBranchToApplyBranchPickerOptions = (
+	branch: ListedBranch,
 ): Array<ApplyBranchPickerOption> => {
 	if (branch.hasLocal) {
 		return [
 			{
-				branchRef: `refs/heads/${branch.name}`,
-				label: branch.name,
+				branchRef: branch.refName.full,
+				label: branch.displayName,
 				type: "Local",
-				updatedAt: branch.updatedAt,
+				updatedAt: branch.updatedAtMs,
 			},
 		];
 	}
 
-	return branch.remotes.map((remote) => ({
-		branchRef: `refs/remotes/${remote}/${branch.name}`,
-		label: branch.name,
-		type: remote,
-		updatedAt: branch.updatedAt,
-	}));
+	return branch.remoteRefs.flatMap(({ full }) => {
+		const type = /^refs\/remotes\/([^/]+)\//.exec(full)?.[1];
+
+		return type !== undefined
+			? {
+					branchRef: full,
+					label: branch.displayName,
+					type,
+					updatedAt: branch.updatedAtMs,
+				}
+			: [];
+	});
 };
 
 const groupApplyBranchPickerOptions = (
@@ -51,7 +55,8 @@ const groupApplyBranchPickerOptions = (
 		([value, items]): PickerDialogGroup<ApplyBranchPickerOption> => ({
 			value,
 			items: items.toSorted((a, b) => {
-				if (value === "Local" && a.updatedAt !== b.updatedAt) return b.updatedAt - a.updatedAt;
+				if (value === "Local" && a.updatedAt !== b.updatedAt)
+					return (b.updatedAt ?? 0) - (a.updatedAt ?? 0);
 				return a.label.localeCompare(b.label);
 			}),
 		}),
@@ -61,32 +66,32 @@ const groupApplyBranchPickerOptions = (
 		return a.value.localeCompare(b.value);
 	});
 
+const listedStacksToApplyBranchPickerGroups = (
+	stacks: Array<ListedStack>,
+): Array<PickerDialogGroup<ApplyBranchPickerOption>> =>
+	groupApplyBranchPickerOptions(
+		stacks.flatMap(({ status, branches }) =>
+			status === "unapplied" || status === "standalone"
+				? branches.flatMap(listedBranchToApplyBranchPickerOptions)
+				: [],
+		),
+	);
+
 export const ApplyBranchPicker: FC<Props> = ({ open, onOpenChange, projectId }) => {
-	const { data: headInfoIndex } = useQuery({
-		...headInfoQueryOptions(projectId),
-		select: getHeadInfoIndex,
-	});
 	const {
-		data: items = [],
+		data: groups,
 		isError,
 		isPending,
 	} = useQuery({
-		...listBranchesQueryOptions({ projectId, filter: null }),
-		select: (branches) =>
-			branches
-				.flatMap(branchListingToApplyBranchPickerOptions)
-				// Filter out branches that are applied in the *current* workspace.
-				.filter((option) => !headInfoIndex?.branchContextByRefBytes(encodeBytes(option.branchRef))),
+		...branchListQueryOptions(projectId),
+		select: listedStacksToApplyBranchPickerGroups,
 	});
 	const [now] = useState(() => Date.now());
 	const { mutate: apply } = useApply();
-	const statusLabel =
-		items.length === 0
-			? isPending
-				? "Loading branches…"
-				: isError
-					? "Unable to load branches."
-					: undefined
+	const statusLabel = isPending
+		? "Loading branches…"
+		: isError
+			? "Unable to load branches."
 			: undefined;
 
 	const selectBranch = (option: ApplyBranchPickerOption) => {
@@ -101,9 +106,9 @@ export const ApplyBranchPicker: FC<Props> = ({ open, onOpenChange, projectId }) 
 			emptyLabel="No available branches found."
 			getItemKey={(x) => x.branchRef}
 			getItemLabel={(x) => x.label}
-			getItemType={(x) => formatRelativeTime(x.updatedAt, now)}
+			getItemType={(x) => (x.updatedAt === null ? undefined : formatRelativeTime(x.updatedAt, now))}
 			itemToStringValue={(x) => x.label}
-			items={groupApplyBranchPickerOptions(items)}
+			items={groups ?? []}
 			open={open}
 			onOpenChange={onOpenChange}
 			onSelectItem={selectBranch}

--- a/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.tsx
@@ -88,7 +88,7 @@ const InertRow: FC<{ branch: ListedBranch; label: string }> = ({ branch, label }
 
 const CommitItem: FC<{ projectId: string; commit: Commit }> = ({ projectId, commit }) => {
 	const dispatch = useAppDispatch();
-	const operand = commitOperand({ commitId: commit.id });
+	const operand = commitOperand({ commitId: commit.id, changeId: commit.changeId });
 	const isSelected = useIsSelected(projectId, operand);
 	const title = commitTitle(commit.message);
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -1067,7 +1067,7 @@ const Diff: FC<{
 				Match.tags({
 					Branch: ({ branchRef }) => branchFileParent({ branchRef }),
 					File: ({ parent }) => parent,
-					Commit: ({ commitId }) => commitFileParent({ commitId }),
+					Commit: ({ commitId, changeId }) => commitFileParent({ commitId, changeId }),
 				}),
 				Match.orElseAbsurd,
 			),

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -1053,9 +1053,9 @@ const Diff: FC<{
 		() =>
 			Match.value(outlineSelection).pipe(
 				Match.tags({
-					Branch: ({ branchRef }) => decodeBytes(branchRef),
-					File: ({ path }) => path,
-					Commit: ({ commitId }) => commitId,
+					Branch: ({ branchRef }) => `branch:${decodeBytes(branchRef)}`,
+					File: ({ path }) => `file:${path}`,
+					Commit: ({ commitId }) => `commit:${commitId}`,
 				}),
 				Match.orElseAbsurd,
 			),

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -36,6 +36,9 @@ import {
 	type FileParent,
 	type HunkOperand,
 	type Operand,
+	branchIdentityKey,
+	fileIdentityKey,
+	weakCommitIdentityKey,
 } from "#ui/operands.ts";
 import { projectSlice } from "#ui/projects/state.ts";
 import { interfaceSlice } from "#ui/interface/state.ts";
@@ -1053,9 +1056,9 @@ const Diff: FC<{
 		() =>
 			Match.value(outlineSelection).pipe(
 				Match.tags({
-					Branch: ({ branchRef }) => `branch:${decodeBytes(branchRef)}`,
-					File: ({ path }) => `file:${path}`,
-					Commit: ({ changeId }) => `commit:${changeId}`,
+					Branch: (x) => branchIdentityKey(x),
+					File: (x) => fileIdentityKey(x),
+					Commit: (x) => weakCommitIdentityKey(x),
 				}),
 				Match.orElseAbsurd,
 			),

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -1055,7 +1055,7 @@ const Diff: FC<{
 				Match.tags({
 					Branch: ({ branchRef }) => `branch:${decodeBytes(branchRef)}`,
 					File: ({ path }) => `file:${path}`,
-					Commit: ({ commitId }) => `commit:${commitId}`,
+					Commit: ({ changeId }) => `commit:${changeId}`,
 				}),
 				Match.orElseAbsurd,
 			),

--- a/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.tsx
@@ -309,8 +309,9 @@ export const FilesTree: FC<
 												checkFile={checkFile}
 												projectId={projectId}
 												fileParent={fileParent}
-												branchNameByCommitId={(cid) =>
-													headInfoIndex?.commitContextById(cid)?.segment.refName?.displayName
+												branchNameByCommitId={(commitId) =>
+													headInfoIndex?.commitContextByCommitId(commitId)?.segment.refName
+														?.displayName
 												}
 											/>
 										}

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/BranchRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/BranchRow.tsx
@@ -4,7 +4,7 @@ import {
 	useCommitInsertBlank,
 	useRemoveBranch,
 	useTearOffBranch,
-	useUpdateBranchName,
+	useBranchRename,
 	useWorkspaceBranchAndAncestorsPush,
 } from "#ui/api/mutations.ts";
 import {
@@ -160,11 +160,7 @@ export const BranchRow: FC<
 	);
 	const [isRenamePending, startRenameTransition] = useTransition();
 
-	const { mutateAsync: updateBranchName } = useUpdateBranchName({
-		projectId,
-		branchRef: refName.fullNameBytes,
-		oldBranch: branchOperandV,
-	});
+	const { mutateAsync: branchRename } = useBranchRename();
 
 	const startEditing = () => {
 		dispatch(projectSlice.actions.startRenameBranch({ projectId, branch: branchOperandV }));
@@ -195,10 +191,9 @@ export const BranchRow: FC<
 		startRenameTransition(async () => {
 			setOptimisticBranchDisplayName(trimmed);
 			try {
-				await updateBranchName({
+				await branchRename({
 					projectId,
-					stackId,
-					branchName: refName.displayName,
+					refName: refName.fullNameBytes,
 					newName: trimmed,
 				});
 			} catch (error) {

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/BranchRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/BranchRow.tsx
@@ -1,8 +1,8 @@
 import rowStyles from "../Row.module.css";
 import {
 	useBranchCreate,
+	useBranchRemove,
 	useCommitInsertBlank,
-	useRemoveBranch,
 	useTearOffBranch,
 	useBranchRename,
 	useWorkspaceBranchAndAncestorsPush,
@@ -98,7 +98,6 @@ export const BranchRow: FC<
 	{
 		projectId: string;
 		refName: BranchReference;
-		stackId: string;
 		canTearOffBranch: boolean;
 		canRemoveBranch: boolean;
 		downstackPushStatus: DownstackPushStatus;
@@ -110,7 +109,6 @@ export const BranchRow: FC<
 > = ({
 	projectId,
 	refName,
-	stackId,
 	canTearOffBranch,
 	canRemoveBranch,
 	downstackPushStatus,
@@ -180,7 +178,7 @@ export const BranchRow: FC<
 	} = useWorkspaceBranchAndAncestorsPush();
 	const { mutate: commitInsertBlank } = useCommitInsertBlank();
 	const { isPending: isTearOffBranchPending, mutate: tearOffBranch } = useTearOffBranch();
-	const { mutate: removeBranch } = useRemoveBranch();
+	const { mutate: branchRemove } = useBranchRemove();
 	const { mutate: branchCreate } = useBranchCreate();
 
 	const pushesMultipleBranches = downstackPushStatus.downstackBranches > 1;
@@ -359,10 +357,9 @@ export const BranchRow: FC<
 			label: "Delete Branch Reference",
 			enabled: canRemoveBranch,
 			onSelect: () =>
-				removeBranch({
+				branchRemove({
 					projectId,
-					stackId,
-					branchName: decodeBytes(refName.fullNameBytes),
+					refName: refName.fullNameBytes,
 				}),
 		}),
 	];

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/CommitRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/CommitRow.tsx
@@ -54,6 +54,7 @@ export const CommitRow: FC<
 	const mforgeUrl = forgeInfo && commitForgeUrl(commit, forgeInfo);
 	const commitOperandV: CommitOperand = {
 		commitId: commit.id,
+		changeId: commit.changeId,
 	};
 	const operand = commitOperand(commitOperandV);
 
@@ -152,12 +153,17 @@ export const CommitRow: FC<
 			},
 			{
 				onSuccess: (response) => {
-					const newId =
-						selectionAfterDiscard?._tag === "Commit"
-							? response.workspace.replacedCommits[selectionAfterDiscard.commitId]
-							: undefined;
-					const latestSelectionAfterDiscard =
-						newId === undefined ? selectionAfterDiscard : commitOperand({ commitId: newId });
+					let latestSelectionAfterDiscard = selectionAfterDiscard;
+
+					rewrite: if (selectionAfterDiscard?._tag === "Commit") {
+						const newId = response.workspace.replacedCommits[selectionAfterDiscard.commitId];
+						if (newId === undefined) break rewrite;
+
+						latestSelectionAfterDiscard = commitOperand({
+							commitId: newId,
+							changeId: selectionAfterDiscard.changeId,
+						});
+					}
 
 					dispatch(
 						projectSlice.actions.selectOutline({

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
@@ -397,7 +397,7 @@ const SegmentContent: FC<{
 				const dryRunCommitId = dryRunWorkspace?.replacedCommits[commit.id];
 				const dryRunCommit =
 					dryRunCommitId !== undefined
-						? (dryRunHeadInfoIndex?.commitContextById(dryRunCommitId)?.commit ?? null)
+						? (dryRunHeadInfoIndex?.commitContextByCommitId(dryRunCommitId)?.commit ?? null)
 						: null;
 				return (
 					<TreeItem
@@ -678,7 +678,7 @@ export const OutlineTree: FC<
 			projectSlice.actions.checkOperands({
 				projectId,
 				operands: Array.from(checkedCommits).flatMap((commitId) => {
-					const ctx = headInfoIndex?.commitContextById(commitId);
+					const ctx = headInfoIndex?.commitContextByCommitId(commitId);
 					return ctx ? commitOperand({ commitId, changeId: ctx.commit.changeId }) : [];
 				}),
 				checked: true,
@@ -688,7 +688,7 @@ export const OutlineTree: FC<
 			projectSlice.actions.checkOperands({
 				projectId,
 				operands: Array.from(uncheckedCommits).flatMap((commitId) => {
-					const ctx = headInfoIndex?.commitContextById(commitId);
+					const ctx = headInfoIndex?.commitContextByCommitId(commitId);
 					return ctx ? commitOperand({ commitId, changeId: ctx.commit.changeId }) : [];
 				}),
 				checked: false,

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
@@ -8,7 +8,6 @@ import {
 	uncommittedChangesFileParent,
 	commitOperand,
 	operandIdentityKey,
-	stackOperand,
 	type Operand,
 	operandEquals,
 	commitIdentityKey,
@@ -429,27 +428,16 @@ const StackC: FC<{
 	stack: Stack;
 	checkCommit: (evt: { commitId: string; shiftKey: boolean }) => void;
 }> = ({ projectId, stack, checkCommit }) => {
-	// From Caleb:
-	// > There shouldn't be a way within GitButler to end up with a stack without a
-	//   StackId. Users can disrupt our matching against our metadata by playing
-	//   with references, but we currently also try to patch it up at certain points
-	//   so it probably isn't too common.
-	// For now we'll treat this as non-nullable until we identify cases where it
-	// could genuinely be null (assuming backend correctness).
-	// [tag:stack-id-required]
-	const operand = stackOperand({ stackId: assert(stack.id) });
 	const canTearOffBranch = stack.segments.length > 1;
 	const downstackPushStatuses = downstackPushStatusesFromSegments(stack.segments);
 	const navigationIndex = assert(use(NavigationIndexContext));
 
 	return (
-		<TreeItem
-			projectId={projectId}
-			operand={operand}
+		<div
+			// oxlint-disable-next-line jsx-a11y/prefer-tag-over-role -- This is a group of treeitems.
+			role="group"
 			aria-label="Stack"
-			aria-expanded
 			className={classes(styles.section, styles.stack)}
-			render={<OperandC projectId={projectId} operand={operand} outline="outside" />}
 		>
 			<StackRow projectId={projectId} stack={stack} />
 
@@ -517,7 +505,7 @@ const StackC: FC<{
 					);
 				})}
 			</div>
-		</TreeItem>
+		</div>
 	);
 };
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
@@ -11,6 +11,7 @@ import {
 	stackOperand,
 	type Operand,
 	operandEquals,
+	commitIdentityKey,
 } from "#ui/operands.ts";
 import { projectSlice } from "#ui/projects/state.ts";
 import { getTransferTarget } from "#ui/outline/mode.ts";
@@ -392,7 +393,7 @@ const SegmentContent: FC<{
 	return (
 		<div>
 			{segment.commits.map((commit) => {
-				const operand = commitOperand({ commitId: commit.id });
+				const operand = commitOperand({ commitId: commit.id, changeId: commit.changeId });
 				const dryRunCommitId = dryRunWorkspace?.replacedCommits[commit.id];
 				const dryRunCommit =
 					dryRunCommitId !== undefined
@@ -498,7 +499,10 @@ const StackC: FC<{
 										navigationIndex,
 										segment.commits.length === 0
 											? branchOperand({ branchRef: assert(segment.refName).fullNameBytes })
-											: commitOperand({ commitId: assert(segment.commits.at(-1)).id }),
+											: commitOperand({
+													commitId: assert(segment.commits.at(-1)).id,
+													changeId: assert(segment.commits.at(-1)).changeId,
+												}),
 										operandIdentityKey,
 									)
 								}
@@ -646,7 +650,7 @@ export const OutlineTree: FC<
 
 	const rangeResolver = navigationIndexRange<Operand, string>({
 		navigationIndex,
-		getKey: (commitId) => operandIdentityKey(commitOperand({ commitId })),
+		getKey: (commitId) => commitIdentityKey({ commitId }),
 		filterMap: (item) => (item._tag === "Commit" ? item.commitId : null),
 	});
 	const getCheckedRange = checkedRange(rangeResolver);
@@ -673,14 +677,20 @@ export const OutlineTree: FC<
 		dispatch(
 			projectSlice.actions.checkOperands({
 				projectId,
-				operands: Array.from(checkedCommits, (commitId) => commitOperand({ commitId })),
+				operands: Array.from(checkedCommits).flatMap((commitId) => {
+					const ctx = headInfoIndex?.commitContextById(commitId);
+					return ctx ? commitOperand({ commitId, changeId: ctx.commit.changeId }) : [];
+				}),
 				checked: true,
 			}),
 		);
 		dispatch(
 			projectSlice.actions.checkOperands({
 				projectId,
-				operands: Array.from(uncheckedCommits, (commitId) => commitOperand({ commitId })),
+				operands: Array.from(uncheckedCommits).flatMap((commitId) => {
+					const ctx = headInfoIndex?.commitContextById(commitId);
+					return ctx ? commitOperand({ commitId, changeId: ctx.commit.changeId }) : [];
+				}),
 				checked: false,
 			}),
 		);

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
@@ -305,7 +305,6 @@ const BranchSegment: FC<{
 	projectId: string;
 	segment: Segment;
 	refName: BranchReference;
-	stackId: string;
 	canTearOffBranch: boolean;
 	canRemoveBranch: boolean;
 	downstackPushStatus: DownstackPushStatus;
@@ -315,7 +314,6 @@ const BranchSegment: FC<{
 	projectId,
 	segment,
 	refName,
-	stackId,
 	canTearOffBranch,
 	canRemoveBranch,
 	downstackPushStatus,
@@ -335,7 +333,6 @@ const BranchSegment: FC<{
 			<BranchRow
 				projectId={projectId}
 				refName={refName}
-				stackId={stackId}
 				canTearOffBranch={canTearOffBranch}
 				canRemoveBranch={canRemoveBranch}
 				downstackPushStatus={downstackPushStatus}
@@ -440,8 +437,7 @@ const StackC: FC<{
 	// For now we'll treat this as non-nullable until we identify cases where it
 	// could genuinely be null (assuming backend correctness).
 	// [tag:stack-id-required]
-	const stackId = assert(stack.id);
-	const operand = stackOperand({ stackId });
+	const operand = stackOperand({ stackId: assert(stack.id) });
 	const canTearOffBranch = stack.segments.length > 1;
 	const downstackPushStatuses = downstackPushStatusesFromSegments(stack.segments);
 	const navigationIndex = assert(use(NavigationIndexContext));
@@ -476,7 +472,6 @@ const StackC: FC<{
 										projectId={projectId}
 										segment={segment}
 										refName={segment.refName}
-										stackId={stackId}
 										canTearOffBranch={canTearOffBranch}
 										canRemoveBranch={canRemoveBranchReference(stack, index)}
 										downstackPushStatus={downstackPushStatus}

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/StackRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/StackRow.tsx
@@ -18,7 +18,6 @@ import type { BottomUpdate, Stack } from "@gitbutler/but-sdk";
 import type { ComponentProps, FC } from "react";
 import { getRowButtonClassName } from "../Row-utils.ts";
 import { Row, RowToolbar } from "../Row.tsx";
-import { assert } from "#ui/assert.ts";
 import styles from "./StackRow.module.css";
 
 export const StackRow: FC<
@@ -37,8 +36,10 @@ export const StackRow: FC<
 
 	const { isPending: isUnapplyStackPending, mutate: unapplyStack } = useUnapplyStack();
 	const unapply = () => {
-		// [ref:stack-id-required]
-		unapplyStack({ projectId, stackId: assert(stack.id) });
+		// In the future we should have an unapply API that doesn't require an ID.
+		if (stack.id === null) throw new Error("Require stack ID in order to unapply");
+
+		unapplyStack({ projectId, stackId: stack.id });
 	};
 
 	const { mutate: workspaceIntegrateUpstream } = useWorkspaceIntegrateUpstream();

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/commitTargetComboboxItems.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/commitTargetComboboxItems.ts
@@ -15,7 +15,7 @@ export const buildCommitTargetComboboxItems = ({
 }): Array<CommitTargetComboboxItem> => {
 	const commitTarget =
 		outlineSelection?._tag === "Commit"
-			? headInfoIndex?.commitContextById(outlineSelection.commitId)?.commit
+			? headInfoIndex?.commitContextByCommitId(outlineSelection.commitId)?.commit
 			: null;
 
 	return [

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/commitTargetComboboxItems.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/commitTargetComboboxItems.ts
@@ -23,7 +23,7 @@ export const buildCommitTargetComboboxItems = ({
 			? ([
 					{
 						label: commitTitle(commitTarget.message) ?? "(no message)",
-						operand: { _tag: "Commit", commitId: commitTarget.id },
+						operand: { _tag: "Commit", commitId: commitTarget.id, changeId: commitTarget.changeId },
 						relativeTo: { type: "commit", subject: commitTarget.id },
 					},
 				] satisfies Array<CommitTargetComboboxItem>)

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/hotkeys.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/hotkeys.ts
@@ -85,7 +85,6 @@ export const useOutlineTreeHotkeys = ({
 
 	const selectionStack = Match.value(selection).pipe(
 		Match.tags({
-			Stack: (stack) => headInfoIndex?.stackContextById(stack.stackId)?.stack,
 			Branch: (branch) => headInfoIndex?.branchContextByRefBytes(branch.branchRef)?.stack,
 			Commit: (commit) => headInfoIndex?.commitContextByCommitId(commit.commitId)?.stack,
 		}),

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/hotkeys.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/hotkeys.ts
@@ -102,7 +102,7 @@ export const useOutlineTreeHotkeys = ({
 					projectSlice.selectors.selectOperandChecked(
 						state,
 						projectId,
-						commitOperand({ commitId: commit.id }),
+						commitOperand({ commitId: commit.id, changeId: commit.changeId }),
 					),
 				)
 			: false,
@@ -225,7 +225,7 @@ export const useOutlineTreeHotkeys = ({
 			projectSlice.actions.checkOperands({
 				projectId,
 				operands: selectedBranchSegment.commits.map((commit) =>
-					commitOperand({ commitId: commit.id }),
+					commitOperand({ commitId: commit.id, changeId: commit.changeId }),
 				),
 				checked: !selectedBranchCommitsChecked,
 			}),
@@ -268,7 +268,7 @@ export const useOutlineTreeHotkeys = ({
 
 		const selectionAfterDiscard = selectAfterDiscardedCommit({
 			navigationIndex,
-			commit: { commitId: selection.commitId },
+			commit: { commitId: selection.commitId, changeId: selection.changeId },
 			headInfoIndex,
 		});
 
@@ -280,12 +280,17 @@ export const useOutlineTreeHotkeys = ({
 			},
 			{
 				onSuccess: (response) => {
-					const newId =
-						selectionAfterDiscard?._tag === "Commit"
-							? response.workspace.replacedCommits[selectionAfterDiscard.commitId]
-							: undefined;
-					const latestSelectionAfterDiscard =
-						newId === undefined ? selectionAfterDiscard : commitOperand({ commitId: newId });
+					let latestSelectionAfterDiscard = selectionAfterDiscard;
+
+					rewrite: if (selectionAfterDiscard?._tag === "Commit") {
+						const newId = response.workspace.replacedCommits[selectionAfterDiscard.commitId];
+						if (newId === undefined) break rewrite;
+
+						latestSelectionAfterDiscard = commitOperand({
+							commitId: newId,
+							changeId: selectionAfterDiscard.changeId,
+						});
+					}
 
 					dispatch(
 						projectSlice.actions.selectOutline({

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/hotkeys.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/hotkeys.ts
@@ -87,7 +87,7 @@ export const useOutlineTreeHotkeys = ({
 		Match.tags({
 			Stack: (stack) => headInfoIndex?.stackContextById(stack.stackId)?.stack,
 			Branch: (branch) => headInfoIndex?.branchContextByRefBytes(branch.branchRef)?.stack,
-			Commit: (commit) => headInfoIndex?.commitContextById(commit.commitId)?.stack,
+			Commit: (commit) => headInfoIndex?.commitContextByCommitId(commit.commitId)?.stack,
 		}),
 		Match.orElse(() => undefined),
 	);
@@ -109,7 +109,7 @@ export const useOutlineTreeHotkeys = ({
 	);
 	const selectedCommit =
 		selection?._tag === "Commit"
-			? (headInfoIndex?.commitContextById(selection.commitId) ?? null)?.commit
+			? (headInfoIndex?.commitContextByCommitId(selection.commitId) ?? null)?.commit
 			: null;
 	const selectedCommitForgeUrl =
 		selectedCommit && forgeInfo ? commitForgeUrl(selectedCommit, forgeInfo) : null;
@@ -307,7 +307,7 @@ export const useOutlineTreeHotkeys = ({
 		selection?._tag === "Branch"
 			? headInfoIndex?.branchContextByRefBytes(selection.branchRef)?.segmentIndex
 			: selection?._tag === "Commit"
-				? headInfoIndex?.commitContextById(selection.commitId)?.segmentIndex
+				? headInfoIndex?.commitContextByCommitId(selection.commitId)?.segmentIndex
 				: undefined;
 
 	const selectedPushContext =

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/selectAfterDiscardedCommit.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/selectAfterDiscardedCommit.ts
@@ -26,7 +26,7 @@ export const selectAfterDiscardedCommit = ({
 	const prevCommit = navigationIndex.items[commitIndex - 1];
 	if (prevCommit?._tag === "Commit") return prevCommit;
 
-	const commitCtx = headInfoIndex?.commitContextById(commit.commitId);
+	const commitCtx = headInfoIndex?.commitContextByCommitId(commit.commitId);
 	if (!commitCtx?.segment.refName) return null;
 
 	const branchIdx = navigationIndex.indexByKey.get(

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
@@ -206,7 +206,9 @@ const buildOutlineNavigationIndex = ({
 						...(segment.refName
 							? [branchOperand({ branchRef: segment.refName.fullNameBytes })]
 							: []),
-						...segment.commits.map((commit) => commitOperand({ commitId: commit.id })),
+						...segment.commits.map((commit) =>
+							commitOperand({ commitId: commit.id, changeId: commit.changeId }),
+						),
 					],
 				),
 			) ?? [];

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
@@ -40,6 +40,7 @@ import {
 	type BranchOperand,
 	type Operand,
 	uncommittedChangesFileParent,
+	weakCommitIdentityKey,
 } from "#ui/operands.ts";
 import { Details } from "./Details.tsx";
 import styles from "./WorkspacePage.module.css";
@@ -484,7 +485,13 @@ const WorkspacePage: FC = () => {
 
 				<Panel id={"details-panel" satisfies PanelId} className={styles.panel}>
 					<Details
-						key={deferredDetailsSelection ? operandIdentityKey(deferredDetailsSelection) : null}
+						key={
+							deferredDetailsSelection
+								? deferredDetailsSelection._tag === "Commit"
+									? weakCommitIdentityKey(deferredDetailsSelection)
+									: operandIdentityKey(deferredDetailsSelection)
+								: null
+						}
 						outlineSelection={deferredDetailsSelection}
 					/>
 				</Panel>

--- a/apps/lite/ui/src/routes/project/$id/workspace/operandLabel.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/operandLabel.ts
@@ -20,7 +20,7 @@ export const operandLabel = ({
 			File: ({ path }) => path,
 			UncommittedChanges: () => "Uncommitted changes",
 			Commit: ({ commitId }) => {
-				const commit = headInfoIndex.commitContextById(commitId)?.commit;
+				const commit = headInfoIndex.commitContextByCommitId(commitId)?.commit;
 				return commit
 					? `${commitTitle(commit.message) ?? "(no message)"}${commit.hasConflicts ? " ⚠️" : ""}`
 					: shortCommitId(commitId);

--- a/apps/lite/ui/src/routes/project/$id/workspace/operandLabel.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/operandLabel.ts
@@ -25,7 +25,6 @@ export const operandLabel = ({
 					? `${commitTitle(commit.message) ?? "(no message)"}${commit.hasConflicts ? " ⚠️" : ""}`
 					: shortCommitId(commitId);
 			},
-			Stack: () => "Stack",
 			Hunk: ({ lineGroups }) => {
 				const count = lineGroups.reduce((sum, group) => sum + group.lines, 0);
 				return `${count} changed line${count !== 1 ? "s" : ""}`;

--- a/apps/lite/ui/src/routes/project/$id/workspace/useBranchesOutline.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/useBranchesOutline.ts
@@ -57,15 +57,17 @@ export const useBranchesOutline = (projectId: string): BranchesOutline => {
 	);
 
 	const unfoldedBranchRefs = active ? Object.keys(unfoldedBranches) : [];
-	const commitIdsByRef = useQueries({
+	const commitsByRef = useQueries({
 		queries: unfoldedBranchRefs.map((refName) =>
 			branchDetailsQueryOptions({ projectId, ...branchDetailsParams(refName) }),
 		),
 		combine: (results) =>
-			new Map<string, Array<string>>(
+			new Map(
 				unfoldedBranchRefs.map((refName, index) => [
 					refName,
-					results[index]?.data?.commits.map((commit) => commit.id) ?? [],
+					results[index]?.data?.commits.map((commit) =>
+						commitOperand({ commitId: commit.id, changeId: commit.changeId }),
+					) ?? [],
 				]),
 			),
 	});
@@ -94,9 +96,7 @@ export const useBranchesOutline = (projectId: string): BranchesOutline => {
 						// its own cannot be unfolded, and an unfolded one shows only the
 						// commits it contributes itself.
 						...(unfoldedBranches[branch.refName.full] && !branchIsEmpty(branch)
-							? branchOwnCommits(branch, commitIdsByRef.get(branch.refName.full) ?? []).map(
-									(commitId) => commitOperand({ commitId }),
-								)
+							? branchOwnCommits(branch, commitsByRef.get(branch.refName.full) ?? [])
 							: []),
 					],
 				),

--- a/apps/lite/ui/src/watcher.ts
+++ b/apps/lite/ui/src/watcher.ts
@@ -13,11 +13,10 @@ export const handleWatcher = (
 				queryKey: ["workspaceFetchStatus" satisfies QueryKey, projectId],
 			});
 			void client.invalidateQueries({ queryKey: ["reviews" satisfies QueryKey, projectId] });
-			// A fetch moves remote-tracking refs, so both branch listings go stale,
+			// A fetch moves remote-tracking refs, so the branch listing goes stale,
 			// and it can advance a remote branch whose commits or diff are already
 			// cached (unfolded or selected in the Branches tab). This case does not
 			// fall through to the gitActivity invalidations below.
-			void client.invalidateQueries({ queryKey: ["branches" satisfies QueryKey, projectId] });
 			void client.invalidateQueries({ queryKey: ["branchList" satisfies QueryKey, projectId] });
 			void client.invalidateQueries({ queryKey: ["branchDetails" satisfies QueryKey, projectId] });
 			void client.invalidateQueries({ queryKey: ["branchDiff" satisfies QueryKey, projectId] });
@@ -25,7 +24,6 @@ export const handleWatcher = (
 		case "gitActivity":
 		case "workspaceActivity": {
 			void client.invalidateQueries({ queryKey: ["absorptionPlan" satisfies QueryKey, projectId] });
-			void client.invalidateQueries({ queryKey: ["branches" satisfies QueryKey, projectId] });
 			void client.invalidateQueries({ queryKey: ["branchDetails" satisfies QueryKey, projectId] });
 			void client.invalidateQueries({ queryKey: ["branchList" satisfies QueryKey, projectId] });
 			void client.invalidateQueries({ queryKey: ["branchDiff" satisfies QueryKey, projectId] });


### PR DESCRIPTION
For example on reword or amend, the diff would previously rerender (by two keys), losing scroll position and other state.

Various misc also included.