### PR TITLE
Make CLI mutation output concise by default

### DIFF
--- a/crates/but/skill/SKILL.md
+++ b/crates/but/skill/SKILL.md
@@ -36,7 +36,7 @@ but diff
 but commit -b <branch> -m "<msg>" <id> <id>
 ```
 
-`but commit -b <branch> ...` creates the branch when it does not exist and prints the resulting workspace state. Do not run a separate `but branch new`, status command, or verification diff unless the returned output lacks information you need.
+`but commit -b <branch> ...` creates the branch when it does not exist and prints the created commit. Do not run a separate `but branch new`, status command, or verification diff unless the task needs workspace information that the result does not provide.
 
 ## IDs
 
@@ -48,12 +48,12 @@ The first token on each `but diff` / `but status` line is that line's ID — pas
 - Commit IDs are stable change IDs that survive history edits (`amend`, `squash`, `move`, `uncommit`, `reword`). Commits without a change ID (e.g. upstream-only) lead with a sha prefix instead, and `#N`-suffixed refs disambiguate duplicates — both go stale after history edits, and a stale sha can silently resolve to the wrong commit. The `(sha …)` on verbose commit lines is informational — do not pass it to commands.
 - File/hunk IDs copied from one diff read generally remain usable across chained commits; branch IDs are stable. If an ID stops resolving, re-read `but status`/`but diff` and retry.
 
-**Chaining:** you may chain mutations with `&&` off one inspection read. Chained `but commit` calls stack in the order written — the first is oldest, each later one goes on top. History edits may run in sequence when every commit ref involved is a change-ID ref; run them one at a time when a ref is sha-based or `#N`-suffixed, or when the next command needs IDs the previous one prints (e.g. recommitting after `but uncommit`). Chaining `but uncommit <id> && but diff` is safe because bare `diff` needs no ID from the uncommit output. Take follow-up refs from the returned workspace state.
+**Chaining:** mutation output is concise by default, so you may chain mutations with `&&` off one inspection read. Add `--status-after` only when the next step needs workspace IDs or details that the mutation result does not provide. Chained `but commit` calls stack in the order written — the first is oldest, each later one goes on top. History edits may run in sequence when every commit ref involved is a change-ID ref; run them one at a time with `--status-after` when a ref is sha-based or `#N`-suffixed, or when the next command needs freshly issued IDs. Chaining `but uncommit <id> && but diff` is safe because bare `diff` needs no ID from the uncommit output.
 
 ## Non-Negotiable Rules
 
 1. Use `but` for all write operations. Never run `git add`, `git commit`, `git push`, `git checkout`, `git merge`, `git rebase`, `git stash`, or `git cherry-pick`. If the user says a `git` write command, translate it to `but` and run that. Exceptions: `git add -- <path>` to mark a conflicted uncommitted file resolved (see "Conflicts in uncommitted files"), and a worktree-local Git commit when `but commit` reports that linked worktrees are unsupported. Never run `but setup` from a linked worktree.
-2. After a mutation, read the workspace state it returned — it replaces a follow-up status command. Re-run `but status`/`but diff` only if that output lacks the ID you need or files changed since.
+2. Mutation commands print their result without appending workspace status. Add `--status-after` only when the next step needs resulting workspace IDs or details; otherwise trust the mutation result and do not run a verification status/diff.
 3. Never commit or push to a branch marked `(merged upstream)`; run `but pull` to remove it, or create/use another branch for new work.
 4. In non-interactive CLI workflows, do not narrate progress between routine commands. Execute the needed `but` commands and give a concise final summary.
 5. Prefer this skill and `references/reference.md` over exploratory help calls. Use `<command> --help` when required syntax is missing or a command fails; use top-level help only when you genuinely need to discover an undocumented command.
@@ -62,7 +62,7 @@ The first token on each `but diff` / `but status` line is that line's ID — pas
 
 - Commit: `but commit -b <branch> -m "<msg>" <id> <id>` — `-b <branch>` creates the branch if it does not exist
 - Commit everything uncommitted: `but commit -b <branch> -m "<msg>"` (omit the IDs)
-- Several commits from one diff: chain `but commit` calls with `&&` (commits stack oldest-first in the order written)
+- Several commits from one diff: chain `but commit` calls with `&&` (commits stack oldest-first)
 - Commit at a specific history position: `--above <commit-or-branch>` or `--below <commit-or-branch>` instead of `-b`
 - Only one targeting flag (`-b` / `--above` / `--below`) per command. Targeting is **required** when more than one **stack** is applied; without it `but commit` fails with "Unclear where to commit. Found more than one stack". Several branches stacked together count as one stack — an untargeted commit then silently lands on the stack's top branch, so pass `-b` whenever the branch matters.
 - Always pass `-m "<msg>"` (or `--no-message`) to `but commit`, and to `but squash` whenever its sources are commits or branches — those compose a new message, and without a flag an editor opens and blocks. Squash sources that are uncommitted or committed files reuse the target's message and need no flag; squashing into `zz` rejects message flags outright.
@@ -88,7 +88,7 @@ The first token on each `but diff` / `but status` line is that line's ID — pas
 For "get latest from main", "update/sync this workspace", "rebase onto main", or "pull main":
 
 1. `but pull` — one command; no preflight needed. Its output reports the resulting state, it refuses safely when uncommitted changes conflict, and `but undo` reverts it.
-2. If commits come back conflicted, resolve them oldest-first following the printed instructions: `but resolve <commit>`, edit the files, `but resolve finish`. Finishing a lower commit rebases the ones above it, so always work bottom-up.
+2. If commits come back conflicted, resolve them oldest-first following the printed instructions: `but resolve <commit>`, edit the files, then `but resolve finish`. Its result gives the current ID of the next conflict. Add `--status-after` to the finish you expect to clear the last conflict only when the task needs the complete resulting workspace. When it says no conflicted commits remain, stop; do not run a verification status. Finishing a lower commit rebases the ones above it, so always work bottom-up.
 
 Rebasing applied branches onto the latest target IS `but pull` — never `move`, `config target`, `unapply`, or raw `git pull`/`git rebase`. The base shown in status is the last FETCHED state: when `git log` shows `main` (local or remote) ahead of it, that is exactly the update `but pull` fetches and applies — the target setting is not stale and repointing it is never the fix. Pull carries uncommitted changes along, and its output reports the resulting state. If it refuses because uncommitted changes conflict, park them: `but commit -b <branch> -m "wip" <ids>`, pull again, then `but uncommit` the parked commit (there is no stash; do not hand-revert files).
 
@@ -97,14 +97,14 @@ Rebasing applied branches onto the latest target IS `but pull` — never `move`,
 1. `but diff` — shows file and hunk IDs for uncommitted changes. Do not run plain `but status` first.
 2. Use file IDs when whole files belong in the commit; use hunk IDs (`<file-id>:<hunk-id>`) when only part of a file belongs. Omit IDs you don't want committed.
 3. `but commit -b <branch> -m "<msg>" <id1> <id2>` — the branch is created if it does not exist, so no prior `but branch new` is needed.
-4. **Check the returned status** for remaining uncommitted changes.
+4. When the task requires knowing which changes remain, add `--status-after`; otherwise the created-commit result is sufficient.
 
 Edge case: if wanted and unwanted edits are in the same diff hunk, GitButler cannot split that hunk by ID. Only when the task requires keeping part of that hunk uncommitted, temporarily edit the working tree to isolate the wanted lines, commit those IDs, then restore the leftover lines so they remain uncommitted.
 
 ### Amend into existing commit
 
 1. `but status -fv` (or `but show <branch-id>`) — locate file/hunk IDs and target commit IDs.
-2. `but amend -t <commit-id> <id> <id>` — one command per target commit. For several target commits, chain the amends with `&&` when every target is a change-ID ref; otherwise run them one at a time with fresh refs from each returned status.
+2. `but amend -t <commit-id> <id> <id>` — one command per target commit. For several target commits, chain the amends with `&&` when every target is a change-ID ref; otherwise run them one at a time with `--status-after` to get fresh refs.
 
 ### Split an existing commit
 
@@ -115,7 +115,7 @@ Use this when an existing commit should be replaced by selected smaller commits.
 3. Pick replacement contents from that dirty diff, not from the old committed diff.
 4. Determine the requested chronological order from the user's wording, then create the replacement commits oldest-first by chaining `but commit` calls. Do not reverse that order to match `but status`, which displays commits newest-first. `-b <branch>` puts each new commit at the TOP of that branch — if the split commit had commits above it, the replacements now sit above those preserved commits.
 5. **If commits from that branch must stay ABOVE the replacements, put the preserved block back on top instead of fighting anchors.** Do not anchor with `--above <top>`/`--below <top>` (sha/`#N` anchors go stale as each insert rewrites history). Move the block together so its internal order stays intact: append `&& but move <preserved-id> [<preserved-id>...] -b <branch>` to the commit chain. Change-ID refs from step 1 stay valid; wait for fresh output first if any preserved ref is sha-based or `#N`-suffixed.
-6. Leave unwanted changes uncommitted. Remember the returned state lists commits newest first: replacements created oldest-first therefore appear in reverse request order under the preserved commits — that is correct; do not reorder them. Stop when the history matches.
+6. Leave unwanted changes uncommitted. Replacements created oldest-first appear newest-first in status — that is correct; do not reorder them. Add `--status-after` to the final mutation when you need to inspect the resulting order.
 
 ### Reorder commits
 
@@ -123,7 +123,7 @@ Use this when an existing commit should be replaced by selected smaller commits.
 
 1. `but status` once to get commit IDs (use `-fv` only if you also need file details).
 2. `but move <source> --below <target-commit>` places source immediately below target in `but status` (older in oldest-to-newest history). `--above` places it immediately above (newer). `but move <source> -b <branch>` moves it to branch top/newest.
-3. For an adjacent block, run ONE move, anchored either way: `but move <block-id> <block-id> --below <following-commit-id>` or `but move <block-id> <block-id> --above <preceding-commit-id>`. Pick an anchor outside the block; source order does not matter and the block keeps its internal order. After a successful block move, stop if the returned status shows the requested order; do not move the anchor or block members again.
+3. For an adjacent block, run ONE move, anchored either way: `but move <block-id> <block-id> --below <following-commit-id>` or `but move <block-id> <block-id> --above <preceding-commit-id>`. Pick an anchor outside the block; source order does not matter and the block keeps its internal order. Add `--status-after` when you need to inspect the resulting order; do not move the anchor or block members again.
 4. For other reorders, make the smallest set of moves.
 
 ### Squash commits
@@ -132,7 +132,7 @@ Use this when an existing commit should be replaced by selected smaller commits.
 2. Name the sources positionally and the result/target commit with `-t`: `but squash <source> [<source>...] -t <target> -m "<new message>"`.
 3. To collapse an entire branch into one commit, pass just the branch and no `-t`: `but squash <branch> -m "<new message>"`.
 4. Multiple independent groups may run in sequence off one status read (targets keep their change-ID refs); prefer newer/top groups first. Take fresh refs only when a ref is sha-based or `#N`-suffixed.
-5. Stop when the returned status shows the requested history; do not re-verify with extra status calls.
+5. Add `--status-after` to the final squash when you need to inspect the resulting history; do not re-verify with a separate status.
 
 ### Stack existing branches
 
@@ -161,7 +161,7 @@ If that `but move` fails, do NOT try `uncommit`, `squash`, or `undo` as a workar
 1. Find conflicted commits: the `but pull` summary lists them oldest-first; otherwise `but status` marks them.
 2. `but resolve <commit-id>` — enters resolution mode and prints the conflict regions.
 3. **Edit the files** to remove every conflict marker — `<<<<<<<`, `|||||||` (the common-ancestor section), `=======` and `>>>>>>>` — and keep the correct content. Do NOT skip this; do NOT use `but amend` on conflicted commits.
-4. `but resolve finish` — reports leftover markers, surviving uncommitted changes, every remaining conflicted commit with the exact next `but resolve <id>` command, and the resulting workspace state. When it says no conflicted commits remain, stop; do not run a follow-up status.
+4. `but resolve finish` reports leftover markers, surviving uncommitted changes, every remaining conflicted commit, and the exact current `but resolve <id>` command. Add `--status-after` to the finish you expect to clear the last conflict only when the task needs the complete resulting workspace. When it says no conflicted commits remain, stop; do not run a verification status.
 5. Repeat for remaining conflicted commits, oldest first — finishing a lower commit rebases the ones above it.
 
 ### Conflicts in uncommitted files

--- a/crates/but/skill/SKILL.md
+++ b/crates/but/skill/SKILL.md
@@ -78,7 +78,7 @@ The first token on each `but diff` / `but status` line is that line's ID — pas
 - Tear off a branch: `but move <branch> --unstack`
 - Discard: `but discard <id> [<id>...]` — accepts branches, commits, committed files, uncommitted files/hunks, or `zz` for all uncommitted changes
 - Push: `but push <branch-name>` — always specify the branch; bare `but push` pushes ALL branches when run non-interactively
-- Pull (update workspace from the target): `but pull` — the output reports the result; `--check` is only a dry-run preview
+- Pull (update workspace from the target): `but pull` — the output reports the result
 - Create PR: `but pr new <branch-id> [-m "Title..."] [-F pr_message.txt] [-t] [--draft]` — auto-pushes first; do not run `but push` before it
 
 ## Task Recipes
@@ -89,8 +89,6 @@ For "get latest from main", "update/sync this workspace", "rebase onto main", or
 
 1. `but pull` — one command; no preflight needed. Its output reports the resulting state, it refuses safely when uncommitted changes conflict, and `but undo` reverts it.
 2. If commits come back conflicted, resolve them oldest-first following the printed instructions: `but resolve <commit>`, edit the files, `but resolve finish`. Finishing a lower commit rebases the ones above it, so always work bottom-up.
-
-`but pull --check` answers "would this conflict?" without updating. For a straightforward update, run `but pull` directly; use `--check` first when the user or repository policy requires a preview.
 
 Rebasing applied branches onto the latest target IS `but pull` — never `move`, `config target`, `unapply`, or raw `git pull`/`git rebase`. The base shown in status is the last FETCHED state: when `git log` shows `main` (local or remote) ahead of it, that is exactly the update `but pull` fetches and applies — the target setting is not stale and repointing it is never the fix. Pull carries uncommitted changes along, and its output reports the resulting state. If it refuses because uncommitted changes conflict, park them: `but commit -b <branch> -m "wip" <ids>`, pull again, then `but uncommit` the parked commit (there is no stash; do not hand-revert files).
 

--- a/crates/but/skill/references/concepts.md
+++ b/crates/but/skill/references/concepts.md
@@ -58,7 +58,7 @@ Stacks:     m0, n0          (auto-generated, 2–3 chars)
 
 **Reading status output:** the first token on each line is that line's ID. Verbose commit lines append an informational `(sha …)` after the timestamp — it changes on every amend; do not pass it to commands.
 
-**Stability:** File/hunk IDs copied from the current output generally remain usable across ordinary commits, so you can reference several in a row, including across chained `but commit` calls. If an ID stops resolving, re-read the diff and continue. Commit IDs are change-ID prefixes when the commit has a change ID and sha prefixes otherwise. Change-ID refs survive history edits (`amend`, `squash`, `move`, `uncommit`, `reword`); sha refs and `#N`-suffixed refs do not — a stale sha can silently resolve to the wrong commit. History edits may run in sequence off one status read when every ref involved is a change-ID ref; otherwise run them one at a time and take the next ref from the returned workspace state.
+**Stability:** File/hunk IDs copied from the current output generally remain usable across ordinary commits, so you can reference several in a row, including across chained `but commit` calls. If an ID stops resolving, re-read the diff and continue. Commit IDs are change-ID prefixes when the commit has a change ID and sha prefixes otherwise. Change-ID refs survive history edits (`amend`, `squash`, `move`, `uncommit`, `reword`); sha refs and `#N`-suffixed refs do not — a stale sha can silently resolve to the wrong commit. History edits may run in sequence off one status read when every ref involved is a change-ID ref; otherwise run them one at a time with `--status-after` to get the next ref.
 
 **Usage:** Pass these IDs as arguments to commands:
 

--- a/crates/but/skill/references/examples.md
+++ b/crates/but/skill/references/examples.md
@@ -29,7 +29,7 @@ but commit -b <api-branch-id> -m "Add user details endpoint" <api-file-id>
 but commit -b <ui-branch-id> -m "Update button hover styles" <ui-file-id>
 
 # Follow-up fix that belongs in a commit you just made? Amend it in.
-# Each mutation returns updated workspace state — take any new IDs you need from it.
+# Add --status-after only when the next step needs resulting workspace IDs or details.
 # but amend -t <api-commit-id> <api-fix-file-id> <api-fix-hunk-id>
 
 # 6. Create pull requests (auto-pushes the branches)
@@ -451,11 +451,13 @@ but commit -b my-branch -m "Add parser" qs:5 qs:2 \
 The commits stack in the order you write them, so `Add parser` ends up below (older
 than) `Add tests`. Chain these commit commands when each references uncommitted IDs
 (plus the stable branch ID). If an ID stops resolving, re-read the diff and continue.
+Mutation output is concise by default. Add `--status-after` only when the next
+step needs workspace IDs or details that the mutation result does not provide.
 History edits — `amend`, `squash`, `move`, `uncommit`, `reword` — may also run in
 sequence off one status read when every commit ref involved is a change-ID ref;
 those stay stable across the edits. Run them one at a time when a ref is sha-based
-or `#N`-suffixed, or when the next command needs IDs the previous one prints, and
-take follow-up refs from the returned workspace state.
+or `#N`-suffixed, or when the next command needs freshly issued IDs, and add
+`--status-after` to get them.
 
 
 ### Auto-completion

--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -182,9 +182,9 @@ but commit --empty -b <branch> -m "message"  # Insert an empty commit
 - **Hunk IDs** (`<file-id>:<hunk-id>`) from `but diff`: commits individual hunks
 - IDs are space-separated (`<id> <id>`). Commas are not separators — `a1,b2` is parsed as a single ID and fails to resolve.
 
-**Placing commits:** Use `--above <target>` or `--below <target>` when the new commit should be inserted at a specific position in existing history. Change-ID refs of existing commits remain valid after an insertion; sha and `#N`-suffixed refs may go stale — use refs from the returned status output for subsequent history edits.
+**Placing commits:** Use `--above <target>` or `--below <target>` when the new commit should be inserted at a specific position in existing history. Change-ID refs of existing commits remain valid after an insertion; sha and `#N`-suffixed refs may go stale — add `--status-after` when subsequent history edits need fresh refs.
 
-**Several commits from one diff:** Chain `but commit` calls with `&&` to split a broad uncommitted change into several semantic commits: `but commit -b <branch> -m "msg1" a1 b2 && but commit -b <branch> -m "msg2" c3 d4`. The commits stack in the order you write them — the first `but commit` is the oldest of the new commits and each later one goes on top (newest). File/hunk IDs copied from the original output generally remain usable across commits; if an ID stops resolving, re-read the diff and continue. History edits (`amend`, `squash`, `move`, `uncommit`, `reword`) may run in sequence off one status read when every commit ref involved is a change-ID ref; run them one at a time when a ref is sha-based or `#N`-suffixed, or when the next command needs IDs the previous one prints, and take follow-up refs from the returned workspace state. Bare `but diff` needs no ID from the preceding command, so `but uncommit <id> && but diff` is safe. If commits from that branch must stay *above* the new ones, see "Split an existing commit" in SKILL.md: commit the replacements, then move the preserved block together with `but move <preserved-id> [<preserved-id>...] -b <branch>` so its internal order stays intact.
+**Several commits from one diff:** Chain `but commit` calls with `&&` to split a broad uncommitted change into several semantic commits: `but commit -b <branch> -m "msg1" a1 b2 && but commit -b <branch> -m "msg2" c3 d4`. Mutation output is concise by default. Add `--status-after` only when the next step needs workspace IDs or details that the mutation result does not provide. The commits stack in the order you write them — the first `but commit` is the oldest of the new commits and each later one goes on top (newest). File/hunk IDs copied from the original output generally remain usable across commits; if an ID stops resolving, re-read the diff and continue. History edits (`amend`, `squash`, `move`, `uncommit`, `reword`) may run in sequence off one status read when every commit ref involved is a change-ID ref; run them one at a time with `--status-after` when a ref is sha-based or `#N`-suffixed, or when the next command needs freshly issued IDs. Bare `but diff` needs no ID from the preceding command, so `but uncommit <id> && but diff` is safe. If commits from that branch must stay *above* the new ones, see "Split an existing commit" in SKILL.md: commit the replacements, then move the preserved block together with `but move <preserved-id> [<preserved-id>...] -b <branch>` so its internal order stays intact.
 
 Example: `but commit -b my-branch -m "Fix bug" ab cd` commits files/hunks `ab` and `cd`.
 
@@ -232,7 +232,7 @@ None of the message flags may be used when the target is `zz`.
 
 For multiple independent squash groups, prefer newer/top groups first; change-ID refs from
 one status read stay valid across squashes (the target keeps its ref), so the
-groups may run in sequence — take fresh refs from the returned status only
+groups may run in sequence — use `--status-after` to get fresh refs only
 when a ref is sha-based or `#N`-suffixed.
 
 ### `but amend -t <commit-or-branch> <SOURCES>...`
@@ -277,8 +277,8 @@ but uncommit <commit-id>                 # Uncommit an entire commit
 but uncommit <commit-id>:<file-id>       # Uncommit one file from its commit
 ```
 
-The returned status lists the resulting uncommitted file IDs. When you also need hunk IDs to
-recommit selectively, use `but uncommit <id> && but diff` in one shell call.
+When you need file and hunk IDs to recommit selectively, use
+`but uncommit <id> && but diff` in one shell call.
 
 ### `but reword <id>`
 
@@ -330,7 +330,13 @@ Finalize conflict resolution.
 
 ```bash
 but resolve finish
+but resolve finish --status-after  # When clearing the last conflict and its workspace is needed
 ```
+
+The concise result reports leftover markers, surviving uncommitted changes, every remaining
+conflicted commit, and the exact current `but resolve <id>` command. Add `--status-after` to the
+finish you expect to clear the last conflict only when the task needs the complete resulting
+workspace. When it says no conflicted commits remain, stop; do not run a verification status.
 
 ### `but resolve cancel`
 
@@ -345,7 +351,7 @@ but resolve cancel --force
 
 1. `but resolve <commit-id>` — enter resolution mode using the commit ID from the `but pull` summary (or `but status`); the conflict regions are printed with line numbers
 2. Edit the conflicted files — remove every marker (`<<<<<<<`, `|||||||`, `=======`, `>>>>>>>`; conflicts are diff3-style, so the `|||||||` common-ancestor section is present too) and keep the correct content (`but resolve status` re-lists what remains when several files are conflicted)
-3. `but resolve finish` — finalize and return to normal mode; the output reports leftover markers, surviving uncommitted changes, every remaining conflicted commit with the exact next `but resolve <id>` command, and the resulting workspace state. When it says no conflicted commits remain, do not run a follow-up status
+3. Finalize with `but resolve finish`; add `--status-after` to the finish you expect to clear the last conflict only when the task needs the complete resulting workspace. When it says no conflicted commits remain, stop; do not run a verification status
 4. If multiple commits are conflicted, repeat steps 1-3 for each one, oldest commit first — finishing a lower commit rebases the ones above it
 
 **Important:** Never use `git add`, `git commit`, or other git write commands during conflict resolution. Only use `but resolve` commands and edit files directly.

--- a/crates/but/src/args/atoms/cli_id.rs
+++ b/crates/but/src/args/atoms/cli_id.rs
@@ -66,7 +66,19 @@ impl CliIdArg {
         purpose: Purpose,
         priority: Option<Priority>,
     ) -> CliResult<Option<ResolvedCliIdArg>> {
-        let Some(id) = try_resolve_cli_id(self, repo, id_map, purpose, priority)? else {
+        let id = if matches!(purpose, Purpose::Uncommitted) {
+            debug_assert!(
+                priority.is_none(),
+                "uncommitted-only resolution does not accept cross-kind priority"
+            );
+            match self.try_resolve_uncommitted_id(repo, id_map)? {
+                Some(id) => Some(id),
+                None => try_resolve_cli_id(self, repo, id_map, purpose, priority)?,
+            }
+        } else {
+            try_resolve_cli_id(self, repo, id_map, purpose, priority)?
+        };
+        let Some(id) = id else {
             return Ok(None);
         };
         Ok(Some(match id {
@@ -175,17 +187,10 @@ impl CliIdArg {
         repo: &gix::Repository,
         id_map: &IdMap,
     ) -> CliResult<Option<Vec<UncommittedHunkOrFile>>> {
-        let Some(id) = try_resolve_cli_id(
-            self,
-            repo,
-            id_map,
-            Purpose::Uncommitted,
-            Some(Priority::Uncommitted),
-        )?
-        else {
+        let Some(target) = self.try_resolve_uncommitted_id(repo, id_map)? else {
             return Ok(None);
         };
-        match id {
+        match target {
             CliId::UncommittedHunkOrFile(uncommitted) => Ok(Some(vec![uncommitted])),
             CliId::PathPrefix {
                 id: _,
@@ -207,6 +212,40 @@ impl CliIdArg {
             )),
             _ => Ok(None),
         }
+    }
+
+    fn try_resolve_uncommitted_id(
+        &self,
+        repo: &gix::Repository,
+        id_map: &IdMap,
+    ) -> CliResult<Option<CliId>> {
+        let mut target_ids = id_map
+            .parse_uncommitted_using_repo(&self.0, repo)?
+            .into_iter()
+            .peekable();
+        let Some(target) = target_ids.next() else {
+            return Ok(None);
+        };
+        let target = if target_ids.peek().is_none() {
+            target
+        } else {
+            let mut uncommitted = std::iter::once(target)
+                .chain(target_ids)
+                .filter(|id| matches!(id, CliId::UncommittedHunkOrFile(_)))
+                .collect::<Vec<_>>();
+            match uncommitted.len() {
+                0 => return Ok(None),
+                1 => uncommitted.pop().expect("exactly one item"),
+                _ => {
+                    return Err(bad_input(format!(
+                        "Ambiguous uncommitted change '{self}', matches multiple items"
+                    ))
+                    .hint("Use a longer ID to disambiguate")
+                    .into());
+                }
+            }
+        };
+        Ok(Some(target))
     }
 
     /// TODO
@@ -346,7 +385,8 @@ pub enum Purpose {
     Target,
     #[expect(missing_docs)]
     Source,
-    #[expect(missing_docs)]
+    /// Prefer uncommitted file and hunk IDs, then preserve any other matching kind so callers can
+    /// report a targeted wrong-kind error. Cross-kind priority is not supported for this purpose.
     Uncommitted,
 }
 

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -38,14 +38,11 @@ pub struct Args {
     pub current_dir: PathBuf,
     #[clap(flatten)]
     pub format: OutputFormatArg,
-    /// Whether mutation commands should append workspace status.
-    #[clap(skip)]
+    /// Append workspace status when supported by a mutation command.
+    ///
+    /// Use when the next step needs IDs or details from the resulting workspace.
+    #[clap(long, global = true)]
     pub status_after: bool,
-    // Keep accepting the removed flag so agents with older skills do not start
-    // erroring after the `but` CLI is updated. It is intentionally ignored;
-    // agent detection controls the current status-after behavior.
-    #[clap(long = "status-after", global = true, hide = true)]
-    pub legacy_status_after: bool,
     /// Subcommand to run (`but <COMMAND>`).
     ///
     /// On UNIX, if `<COMMAND>` is not built in and `but-<COMMAND>` exists on the PATH, that program

--- a/crates/but/src/args/tests.rs
+++ b/crates/but/src/args/tests.rs
@@ -431,26 +431,30 @@ fn diff_help_explains_single_target() {
 }
 
 #[test]
-fn status_after_is_hidden_noop_compatibility_flag() {
-    use clap::Parser;
+fn status_after_is_global_and_shown_in_help() {
+    use clap::{CommandFactory, Parser};
 
-    let args = Args::try_parse_from(["but", "branch", "--format", "json", "--status-after"])
-        .expect("parse legacy status-after flag");
-
-    assert!(matches!(dbg!(args.format.format), OutputFormat::Json));
-    assert!(args.legacy_status_after);
-    assert!(!args.status_after);
-}
-
-#[test]
-fn status_after_is_not_shown_in_help() {
-    use clap::CommandFactory;
+    let before = Args::try_parse_from(["but", "--status-after", "branch"])
+        .expect("parse status-after before command");
+    let after = Args::try_parse_from(["but", "branch", "--status-after"])
+        .expect("parse status-after after command");
+    assert!(
+        before.status_after,
+        "a global status-after flag must parse before a built-in command"
+    );
+    assert!(
+        after.status_after,
+        "a global status-after flag must parse after a built-in command"
+    );
 
     let help = Args::command().render_long_help().to_string();
-
     assert!(
-        !help.contains("--status-after"),
-        "compatibility-only flag should stay hidden from help"
+        help.contains("--status-after"),
+        "status opt-in should be discoverable in help"
+    );
+    assert!(
+        help.contains("next step needs IDs or details"),
+        "help should explain when status is useful"
     );
 }
 

--- a/crates/but/src/command/agent/policy.rs
+++ b/crates/but/src/command/agent/policy.rs
@@ -150,7 +150,7 @@ pub(super) fn render_managed_policy_block(answers: &WizardAnswers) -> String {
             "For commit just/only/specific changes on a new branch (selected-change requests), use the two-command fast path from the GitButler skill: `but diff`, then `but commit -b <branch> -m \"message\" <id> <id>`.",
             "For that fast path, after the commit succeeds, stop and summarize; do not run separate branch, staging, status, or diff commands unless the commit output is missing information you need.",
             "Use the installed GitButler skill for command recipes and syntax before guessing flags, using `--help`, or translating Git habits directly.",
-            "After a successful GitButler write command, use the workspace state it returns. Rerun status or diff only when that output lacks information you need or files changed since.",
+            "Mutation commands report their result without appending workspace status. Add `--status-after` only when the next step needs resulting workspace IDs or details; otherwise do not rerun status or diff to verify success.",
             "Use a dedicated GitButler branch for each agent session, unless the user asks for a different branch structure. Commit only changes that belong to that session.",
             "Do not push or open pull requests unless the user asks.",
             "Keep commit messages and pull request descriptions succinct: explain what changed, why it changed, and any important decision.",

--- a/crates/but/src/command/agent/tests.rs
+++ b/crates/but/src/command/agent/tests.rs
@@ -35,6 +35,10 @@ fn generated_default_policy_includes_baseline_and_default_preferences() {
     assert!(policy.contains("For commit just/only/specific changes on a new branch"));
     assert!(policy.contains("For that fast path, after the commit succeeds, stop and summarize"));
     assert!(policy.contains("Use the installed GitButler skill for command recipes and syntax"));
+    assert!(
+        policy.contains("Mutation commands report their result without appending workspace status")
+    );
+    assert!(policy.contains("Add `--status-after` only when the next step needs"));
     assert!(policy.contains("amend an unpublished local commit"));
     assert!(policy.contains("Use GitButler to move the relevant changes"));
     assert!(policy.contains("If one file contains unrelated changes"));

--- a/crates/but/src/id/tests.rs
+++ b/crates/but/src/id/tests.rs
@@ -8,6 +8,7 @@ use snapbox::{assert_data_eq, prelude::*};
 
 use crate::{
     CliId, IdMap,
+    args::atoms::CliIdArg,
     id::{BranchId, CommitId, id_usage::UintId},
 };
 
@@ -2570,6 +2571,31 @@ fn uncommitted_selector_is_not_shadowed_by_commit_change_id() -> anyhow::Result<
         "hunk selector resolves in the scoped namespace: {hunk:?}"
     );
 
+    let tmp = tempfile::TempDir::new()?;
+    let repo = gix::init(tmp.path())?;
+    let resolved = CliIdArg(format!("{file_id}:q"))
+        .try_resolve_uncommitted(&repo, &id_map)
+        .expect("selector resolution succeeds")
+        .expect("the issued hunk selector still resolves");
+    assert_eq!(resolved.len(), 1, "exactly one hunk resolves");
+    assert_eq!(resolved[0].hunk_assignments.first().path_bytes, "README.md");
+
+    let resolved = CliIdArg(format!("{file_id}:q"))
+        .resolve_in_workspace(
+            &repo,
+            &id_map,
+            crate::args::atoms::Purpose::Uncommitted,
+            None,
+        )
+        .expect("a command requiring an uncommitted selector resolves the issued hunk");
+    assert!(
+        matches!(
+            resolved,
+            crate::args::atoms::ResolvedCliIdArg::UncommittedHunkOrFile(_)
+        ),
+        "the shared uncommitted-purpose resolver keeps the issued hunk"
+    );
+
     Ok(())
 }
 
@@ -2636,6 +2662,22 @@ fn uncommitted_scope_does_not_prefix_match_a_branch_short_id() -> anyhow::Result
     assert!(
         matches!(scoped.as_slice(), [CliId::UncommittedHunkOrFile(_)]),
         "file prefixes beyond the branch ID keep resolving: {scoped:?}"
+    );
+
+    let tmp = tempfile::TempDir::new()?;
+    let repo = gix::init(tmp.path())?;
+    let resolved = CliIdArg("kp".to_owned())
+        .resolve_in_workspace(
+            &repo,
+            &id_map,
+            crate::args::atoms::Purpose::Uncommitted,
+            None,
+        )
+        .expect("the full lookup should preserve a non-uncommitted match");
+    assert!(
+        matches!(resolved, crate::args::atoms::ResolvedCliIdArg::Branch(_)),
+        "when the uncommitted-only lookup deliberately yields nothing, the full lookup \
+         preserves the branch kind for the caller's targeted error: {resolved:?}"
     );
     Ok(())
 }

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -105,10 +105,7 @@ fn parse_args(args: Vec<OsString>, agent_detected: bool) -> Args {
         command = command.mut_arg("format", |arg| arg.default_value("agent"));
     }
     let matches = command.get_matches_from(args);
-    let mut args = Args::from_arg_matches(&matches).unwrap_or_else(|err| err.exit());
-
-    args.status_after = agent_detected;
-    args
+    Args::from_arg_matches(&matches).unwrap_or_else(|err| err.exit())
 }
 
 static APP_SETTINGS: std::sync::OnceLock<AppSettings> = std::sync::OnceLock::new();
@@ -437,7 +434,6 @@ async fn match_subcommand(
         writeln!(human, "{}", notice.text()).ok();
         writeln!(human).ok();
     }
-
     let mut metrics_ctx = cmd.to_metrics_context(&app_settings, &args.current_dir);
     if agent_skill_notice.is_some_and(|notice| notice.is_hint())
         && let Some(metrics_ctx) = metrics_ctx.as_mut()
@@ -1120,6 +1116,7 @@ async fn match_subcommand(
             diff,
             no_diff,
         } => {
+            let status_after = args.status_after;
             let mut ctx = setup::init_ctx(
                 &args,
                 InitCtxOptions {
@@ -1128,7 +1125,8 @@ async fn match_subcommand(
                 },
                 out,
             )?;
-            command::legacy::reword::reword_target(
+            out.begin_status_after(status_after);
+            let result = command::legacy::reword::reword_target(
                 &mut ctx,
                 out,
                 target,
@@ -1138,7 +1136,9 @@ async fn match_subcommand(
                 // sorry
                 ShowDiffInEditor::from_args(diff, no_diff).unwrap_or(ShowDiffInEditor::Unspecified),
             )
-            .emit_metrics(metrics_ctx)
+            .emit_metrics(metrics_ctx);
+            run_status_after_if_ok(status_after, &result, &mut ctx, out);
+            result
         }
         #[cfg(feature = "legacy")]
         Subcommands::Oplog(args::oplog::Platform { cmd }) => {
@@ -1650,6 +1650,11 @@ fn run_status_after_if_requested(
     out: &mut OutputChannel,
 ) {
     if !status_after {
+        if out.is_json()
+            && let Some(notice) = command::skill::agent_skill_update_notice()
+        {
+            eprintln!("{notice}");
+        }
         return;
     }
     let mutation_json = out.take_json_buffer();
@@ -1666,14 +1671,14 @@ fn run_status_after_if_ok<T, E>(
 ) {
 }
 
-/// Run workspace status output after an agent mutation command completes.
+/// Run workspace status output after a mutation command when explicitly requested.
 ///
 /// In human mode, prints a blank line then full status.
 /// In JSON mode, combines the mutation's buffered JSON with status JSON into
 /// `{"result": <mutation_output>, "status": <workspace_status>}`.
 /// For JSON commands, reconciles stale skill installations and includes an
 /// update announcement or failure notice under `agent_skill_notice`.
-/// This function only runs when the CLI caller was detected as an agent.
+/// The global `--status-after` flag controls whether this function runs.
 ///
 /// Status errors are handled gracefully: in JSON mode the mutation result is
 /// always emitted (with a `"status_error"` field on failure); in human mode
@@ -1794,6 +1799,31 @@ mod tests {
         });
 
         assert!(matches!(format, OutputFormat::Json));
+    }
+
+    #[test]
+    #[cfg(feature = "legacy")]
+    fn detected_agent_omits_status_after_mutation_by_default() {
+        let args = parse_args(os_args(&["but", "commit", "--no-message"]), true);
+
+        assert!(
+            !args.status_after,
+            "detected agents must not request mutation status implicitly"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "legacy")]
+    fn detected_agent_can_request_status_after_mutation() {
+        let args = parse_args(
+            os_args(&["but", "commit", "--status-after", "--no-message"]),
+            true,
+        );
+
+        assert!(
+            args.status_after,
+            "detected agents must retain an explicit mutation status request"
+        );
     }
 
     #[test]

--- a/crates/but/tests/but/command/agent.rs
+++ b/crates/but/tests/but/command/agent.rs
@@ -29,6 +29,14 @@ fn assert_default_policy(policy: &str) {
         "policy should point agents to the installed skill for command details, got: {policy}"
     );
     assert!(
+        policy.contains("Mutation commands report their result without appending workspace status"),
+        "policy should explain concise mutation output, got: {policy}"
+    );
+    assert!(
+        policy.contains("Add `--status-after` only when the next step needs"),
+        "policy should explain situational status opt-in, got: {policy}"
+    );
+    assert!(
         policy.contains("amend an unpublished local commit"),
         "policy should include default fold-fixes preference, got: {policy}"
     );

--- a/crates/but/tests/but/command/commit.rs
+++ b/crates/but/tests/but/command/commit.rs
@@ -59,6 +59,63 @@ Hint: run `but help` for all commands
 }
 
 #[test]
+fn agent_mutation_omits_status_unless_requested() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
+    env.file("file.txt", "Some text");
+
+    let result = env
+        .but("commit --no-message")
+        .env("AI_AGENT", "codex")
+        .assert()
+        .success();
+    let stdout = String::from_utf8_lossy(&result.get_output().stdout);
+
+    assert!(stdout.contains("Created commit"));
+    assert!(
+        !stdout.contains("╭┄ zz"),
+        "agent mutations must omit workspace status by default"
+    );
+    assert!(
+        !stdout.contains("commits are listed newest first"),
+        "agent mutations must omit status hints by default"
+    );
+
+    env.file("other.txt", "Other text");
+    let result = env
+        .but("commit --no-message --status-after")
+        .env("AI_AGENT", "codex")
+        .assert()
+        .success();
+    let stdout = String::from_utf8_lossy(&result.get_output().stdout);
+
+    assert!(stdout.contains("Created commit"));
+    assert!(
+        stdout.contains("╭┄ zz"),
+        "explicit status opt-in must append workspace status"
+    );
+}
+
+#[test]
+fn human_mutation_can_request_status_after() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
+    env.file("file.txt", "Some text");
+
+    let result = env
+        .but("commit --no-message --status-after")
+        .assert()
+        .success();
+    let stdout = String::from_utf8_lossy(&result.get_output().stdout);
+
+    assert!(stdout.contains("Created commit"));
+    assert!(
+        stdout.contains("╭┄ zz"),
+        "human callers should be able to opt into workspace status"
+    );
+}
+
+#[test]
 fn no_args_single_head_no_message_shell_output() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
     env.setup_metadata(&["A"]);
@@ -75,7 +132,26 @@ fn no_args_single_head_no_message_shell_output() {
 }
 
 #[test]
-fn no_args_single_head_no_message_json_output() {
+fn agent_commit_json_uses_native_result_without_status_by_default() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
+
+    env.file("file.txt", "Some text");
+
+    env.but("commit --no-message --format json")
+        .env("AI_AGENT", "codex")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+{
+  "commit": "7bbfdca68284535242b93595db5f6a5bc885a124"
+}
+
+"#]]);
+}
+
+#[test]
+fn non_agent_commit_json_uses_native_result() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
     env.setup_metadata(&["A"]);
 

--- a/crates/but/tests/but/command/resolve.rs
+++ b/crates/but/tests/but/command/resolve.rs
@@ -182,7 +182,7 @@ fn agent_resolve_finish_json_includes_result_and_status() -> anyhow::Result<()> 
     env.file("file.txt", "resolved content\n");
     env.invoke_git("add file.txt");
 
-    let mut command = super::util::but_std_cmd(&env, "--format json resolve finish");
+    let mut command = super::util::but_std_cmd(&env, "--format json resolve finish --status-after");
     command.env("AI_AGENT", "codex");
     let output = command.output()?;
     assert!(output.status.success(), "resolve finish should succeed");

--- a/crates/but/tests/but/command/reword.rs
+++ b/crates/but/tests/but/command/reword.rs
@@ -259,3 +259,26 @@ fn reword_commit_with_json_flag() {
 "#]]
     );
 }
+
+#[test]
+fn reword_commit_json_can_request_status_after() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
+
+    let output = env
+        .but("reword tpm -m 'Updated commit message' --format json --status-after")
+        .assert()
+        .success();
+    let json: serde_json::Value = serde_json::from_slice(&output.get_output().stdout)?;
+
+    assert!(
+        json["result"]["new_commit_id"].is_string(),
+        "status output must retain the reword result"
+    );
+    assert!(
+        json["status"]["stacks"].is_array(),
+        "status-after must include the workspace with fresh commit IDs"
+    );
+
+    Ok(())
+}

--- a/crates/but/tests/but/command/skill.rs
+++ b/crates/but/tests/but/command/skill.rs
@@ -117,7 +117,7 @@ fn agent_skill_notice_gating() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
     env.setup_metadata(&[]);
 
-    // Only human-text output can carry the notice; JSON output skips the check.
+    // JSON stdout remains machine-readable. Skill upkeep is silent when nothing needs attention.
     let json_run = env
         .but("--format json alias list")
         .env("AI_AGENT", "codex")
@@ -352,6 +352,53 @@ fn agent_skill_notice_repairs_another_agents_stale_global_skill() {
         expected,
         "the detected agent should refresh other agents' global GitButler skill installations"
     );
+}
+
+#[test]
+#[cfg(feature = "legacy")]
+fn json_agent_command_repairs_stale_global_skill_without_wrapping_stdout() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
+    env.but("skill install")
+        .env("AI_AGENT", "codex")
+        .assert()
+        .success();
+    env.but("skill install")
+        .env("AI_AGENT", "claude-code")
+        .assert()
+        .success();
+
+    let claude_skill_path = env.home_dir().join(".claude/skills/gitbutler/SKILL.md");
+    let expected = std::fs::read_to_string(&claude_skill_path)?;
+    std::fs::write(&claude_skill_path, "---\nname: but\nversion: old\n---\n")?;
+    env.file("file.txt", "Some text");
+
+    let output = env
+        .but("commit --no-message --format json")
+        .env("AI_AGENT", "codex")
+        .allow_json()
+        .output()?;
+    assert!(
+        output.status.success(),
+        "the JSON mutation used to verify skill repair must succeed"
+    );
+    let stdout: serde_json::Value = serde_json::from_slice(&output.stdout)?;
+    assert!(
+        stdout.get("commit").is_some() && stdout.get("status").is_none(),
+        "the default JSON mutation result should remain native and omit status: {stdout}"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("was out of date and was updated"),
+        "JSON commands should report skill upkeep on stderr without wrapping stdout, got: {stderr}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&claude_skill_path)?,
+        expected,
+        "a JSON agent command should still refresh other agents' global skill installations"
+    );
+    Ok(())
 }
 
 #[test]


### PR DESCRIPTION
Default supported mutations to concise results with explicit `--status-after`, keep issued selectors stable across partial commits, and keep optional pull previews out of the fast path. Preserve native JSON results while maintaining skill reconciliation.