### PR TITLE
Fix 'terminal setting is reset after application restart'

### DIFF
--- a/apps/desktop/src/lib/state/uiState.svelte.test.ts
+++ b/apps/desktop/src/lib/state/uiState.svelte.test.ts
@@ -1,0 +1,39 @@
+import { UiState, uiStateSlice, type TerminalSettings } from "$lib/state/uiState.svelte";
+import { configureStore } from "@reduxjs/toolkit";
+import { describe, expect, test } from "vitest";
+import type { AppDispatch } from "$lib/state/clientState.svelte";
+
+const WARP: TerminalSettings = { identifier: "warp", displayName: "Warp", platform: "macos" };
+
+describe("UiState", () => {
+	test("set() with a $state proxy stores plain, serializable data", () => {
+		const store = configureStore({ reducer: { uiState: uiStateSlice.reducer } });
+
+		const cleanup = $effect.root(() => {
+			const uiState = new UiState(
+				{
+					get current() {
+						return store.getState().uiState;
+					},
+				},
+				store.dispatch as AppDispatch,
+			);
+
+			// Mirrors GeneralSettings.svelte: terminalOptions is a $state array,
+			// so the selected option is a deeply-reactive proxy.
+			const terminalOptions = $state([{ ...WARP }]);
+			const selected = terminalOptions.find((o) => o.identifier === "warp")!;
+
+			uiState.global.defaultTerminal.set(selected);
+		});
+		cleanup();
+
+		// The dispatch must survive Immer's auto-freeze (Object.freeze on a
+		// $state proxy throws state_descriptors_fixed)...
+		const entities = store.getState().uiState.entities;
+		expect(entities["defaultTerminal"]?.value).toEqual(WARP);
+
+		// ...and redux-persist must be able to JSON-serialize what was stored.
+		expect(JSON.parse(JSON.stringify(entities)).defaultTerminal.value).toEqual(WARP);
+	});
+});

--- a/apps/desktop/src/lib/state/uiState.svelte.ts
+++ b/apps/desktop/src/lib/state/uiState.svelte.ts
@@ -303,7 +303,9 @@ export class UiState {
 	}
 
 	private update(id: string, value: UiStateValue) {
-		this.dispatch(upsertOne({ id, value }));
+		// Values may be $state proxies (e.g. picked from a $state array), which
+		// Immer's auto-freeze cannot handle — snapshot to plain data first.
+		this.dispatch(upsertOne({ id, value: $state.snapshot(value) as UiStateValue }));
 	}
 
 	/**


### PR DESCRIPTION
## 🧢 Changes

Convert values to plain data with `$state.snapshot()` in `UiState.update()` before storing it in Redux.
Added a regression test.

## ☕️ Reasoning

The terminal picker passes a Svelte `$state` proxy into the Redux store. Immer's auto-freeze can't handle proxies and throws, so the dispatch silently fails and the setting is never persisted – it only lives in memory until the app closes.

## 🎫 Affected issues

Fixes: #14802

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
