### PR TITLE
but: report newly conflicted commits in mutation output

### DIFF
--- a/crates/but/skill/AGENTS.md
+++ b/crates/but/skill/AGENTS.md
@@ -19,6 +19,9 @@ reference file there.
 - **Never document commands agents should not run:** subcommands and flags
   marked `hide = true` in `crates/but/src/args/` (the hidden flags on `push` are
   the usual trap), and the TUI/GUI surfaces.
+- **Never mention `--format json` or other output formats.** Agents read the
+  default agent output; format-specific notes (flags, streams, JSON shapes)
+  don't belong in skill files.
 - **When a command changes, re-derive its guidance** instead of syntax-swapping
   the prose; rationale written for the old implementation dies with it. The same
   facts are deliberately repeated across the four installed files — grep and

--- a/crates/but/skill/SKILL.md
+++ b/crates/but/skill/SKILL.md
@@ -158,7 +158,7 @@ If that `but move` fails, do NOT try `uncommit`, `squash`, or `undo` as a workar
 
 **NEVER use `git add`, `git commit`, `git checkout --theirs/--ours`, or any git write command during resolution.** Only `but resolve` commands plus direct file edits.
 
-1. Find conflicted commits: the `but pull` summary lists them oldest-first; otherwise `but status` marks them.
+1. Find conflicted commits: history-editing commands (`move`, `discard`, …) warn about newly conflicted commits in their output, and the `but pull` summary lists them oldest-first; otherwise `but status` marks them.
 2. `but resolve <commit-id>` — enters resolution mode and prints the conflict regions.
 3. **Edit the files** to remove every conflict marker — `<<<<<<<`, `|||||||` (the common-ancestor section), `=======` and `>>>>>>>` — and keep the correct content. Do NOT skip this; do NOT use `but amend` on conflicted commits.
 4. `but resolve finish` reports leftover markers, surviving uncommitted changes, every remaining conflicted commit, and the exact current `but resolve <id>` command. Add `--status-after` to the finish you expect to clear the last conflict only when the task needs the complete resulting workspace. When it says no conflicted commits remain, stop; do not run a verification status.

--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -306,7 +306,7 @@ All provided IDs must be the same kind, and committed files must come from the s
 
 ## Conflict Resolution
 
-When commits have conflicts (the `but pull` summary lists them; `but status` marks them as conflicted):
+When commits have conflicts (history-editing commands warn about newly conflicted commits in their output; the `but pull` summary lists them; `but status` marks them as conflicted):
 
 ### `but resolve <commit>`
 

--- a/crates/but/src/command/legacy/conflict_notice.rs
+++ b/crates/but/src/command/legacy/conflict_notice.rs
@@ -1,0 +1,187 @@
+//! Warn when a mutation command leaves commits newly conflicted.
+//!
+//! GitButler operations never stop on conflicts; rebased commits are recorded
+//! in a conflicted state instead. Commands that edit history capture a
+//! [`ConflictSnapshot`] before mutating and call [`report_newly_conflicted`]
+//! afterwards so the user learns about new conflicts directly from the command
+//! output instead of the next `but status`.
+
+use std::collections::HashSet;
+
+use but_core::ChangeId;
+use but_ctx::Context;
+use gix::prelude::ObjectIdExt as _;
+use itertools::Itertools as _;
+
+use crate::{
+    args::OutputFormat,
+    theme::{self, Paint},
+    utils::OutputChannel,
+};
+
+/// The conflicted workspace commits captured before a mutation ran.
+///
+/// Commits are identified by change-id, which survives rebases for commits
+/// carrying the change-id header. Commits without it fall back to an identity
+/// derived from their sha, so such a commit that stays conflicted across a
+/// rebase is re-reported as new; GitButler writes the header on every commit
+/// it creates, so this only affects commits from external sources.
+pub(crate) struct ConflictSnapshot {
+    /// `None` when the snapshot could not be taken; reporting is skipped then
+    /// so pre-existing conflicts aren't misreported as new ones.
+    change_ids: Option<HashSet<ChangeId>>,
+}
+
+/// Capture the conflicted workspace commits before a mutation. Best-effort;
+/// a failure disables reporting instead of failing the command.
+pub(crate) fn snapshot(ctx: &Context) -> ConflictSnapshot {
+    let commits = conflicted_workspace_commits(ctx);
+    // Enumeration cached a workspace projection taken under a shared guard.
+    // Drop it so the command that runs next re-projects under its own lock
+    // instead of operating on a potentially outdated view. Failure means a
+    // workspace borrow is still live, which no caller of this function does;
+    // disabling the report is all that can be done for it here, the stale
+    // cache entry itself cannot be removed.
+    let invalidated = ctx.invalidate_workspace_cache();
+    let change_ids = match (commits, invalidated) {
+        (Ok(commits), Ok(())) => Some(commits.into_iter().map(|commit| commit.change_id).collect()),
+        (Err(err), _) | (_, Err(err)) => {
+            tracing::warn!(
+                ?err,
+                "could not capture conflicted commits before the operation"
+            );
+            None
+        }
+    };
+    ConflictSnapshot { change_ids }
+}
+
+/// Warn about commits that are conflicted now but weren't in `before`.
+/// Best-effort; the mutation already succeeded, so errors are only logged.
+pub(crate) fn report_newly_conflicted(
+    ctx: &Context,
+    out: &mut OutputChannel,
+    before: ConflictSnapshot,
+) {
+    if let Err(err) = try_report_newly_conflicted(ctx, out, before) {
+        tracing::warn!(?err, "could not report newly conflicted commits");
+    }
+}
+
+fn try_report_newly_conflicted(
+    ctx: &Context,
+    out: &mut OutputChannel,
+    before: ConflictSnapshot,
+) -> anyhow::Result<()> {
+    let Some(before) = before.change_ids else {
+        return Ok(());
+    };
+    let newly: Vec<_> = conflicted_workspace_commits(ctx)?
+        .into_iter()
+        .filter(|commit| !before.contains(&commit.change_id))
+        .collect();
+    if newly.is_empty() {
+        return Ok(());
+    }
+
+    let t = theme::get();
+    if let Some(out) = out.for_human() {
+        let commits = match newly.len() {
+            1 => "a commit".to_string(),
+            n => format!("{n} commits"),
+        };
+        writeln!(out)?;
+        writeln!(
+            out,
+            "{}",
+            t.attention
+                .paint(format!("⚠ This operation left {commits} conflicted:"))
+        )?;
+        for commit in &newly {
+            writeln!(
+                out,
+                "  {} {} {}",
+                t.sym().dot.error(),
+                theme::Commit(commit.id, Some(commit.change_id.clone())),
+                commit.message
+            )?;
+        }
+        writeln!(
+            out,
+            "Resolve with {}, or back out with {}.",
+            t.command_suggestion.paint("but resolve"),
+            t.command_suggestion.paint("but undo")
+        )?;
+    } else if matches!(out.format(), OutputFormat::Shell | OutputFormat::Json) {
+        // Shell and JSON outputs are parsed, so the warning goes to stderr.
+        // `OutputFormat::None` promises no output at all and stays silent.
+        let ids = newly
+            .iter()
+            .map(|commit| commit.id.to_hex_with_len(7))
+            .join(", ");
+        eprintln!(
+            "warning: this operation left {} commit(s) conflicted: {ids}. Resolve with `but resolve`, or back out with `but undo`.",
+            newly.len()
+        );
+    }
+    Ok(())
+}
+
+struct ConflictedCommit {
+    id: gix::ObjectId,
+    change_id: ChangeId,
+    /// First line of the commit message, sanitized for terminal output.
+    message: String,
+}
+
+/// All conflicted commits currently in the workspace, oldest first within each
+/// stack so listings match the bottom-up resolution order. Each commit appears
+/// once overall: the traversal visits segments shared between stacks once per
+/// stack, so their commits are deduplicated by id.
+fn conflicted_workspace_commits(ctx: &Context) -> anyhow::Result<Vec<ConflictedCommit>> {
+    let guard = ctx.shared_worktree_access();
+    let (repo, ws, _db) = ctx.workspace_and_db_with_perm(guard.read_permission())?;
+
+    let mut seen = HashSet::new();
+    let mut conflicted = Vec::new();
+    for stack_commit in ws
+        .stacks
+        .iter()
+        .flat_map(|stack| &stack.segments)
+        .flat_map(|segment| &segment.commits)
+    {
+        if !seen.insert(stack_commit.id) {
+            continue;
+        }
+        let commit = but_core::Commit::from_id(stack_commit.id.attach(&repo))?;
+        if commit.is_conflicted() {
+            conflicted.push(ConflictedCommit {
+                id: stack_commit.id,
+                change_id: commit.change_id(),
+                message: message_excerpt(&commit),
+            });
+        }
+    }
+    // The traversal walks each stack newest first; resolution proceeds oldest
+    // first, so flip the order. Stacks are independent of each other, so the
+    // reversed stack order does not matter.
+    conflicted.reverse();
+    Ok(conflicted)
+}
+
+/// First line of the commit message, stripped of control characters as the
+/// message can come from untrusted upstreams, and shortened for display.
+fn message_excerpt(commit: &but_core::Commit<'_>) -> String {
+    use bstr::ByteSlice as _;
+    commit
+        .inner
+        .message
+        .lines()
+        .next()
+        .map(|line| line.to_str_lossy())
+        .unwrap_or_default()
+        .chars()
+        .filter(|c| !c.is_control())
+        .take(50)
+        .collect()
+}

--- a/crates/but/src/command/legacy/mod.rs
+++ b/crates/but/src/command/legacy/mod.rs
@@ -11,6 +11,7 @@ pub mod branch;
 pub mod clean;
 pub mod commit;
 pub mod commit_message_prep;
+pub(crate) mod conflict_notice;
 pub mod diff;
 #[cfg(feature = "legacy")]
 pub mod diff2;

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -1024,6 +1024,7 @@ async fn match_subcommand(
             )?;
             out.begin_status_after(status_after);
 
+            let conflicts_before = command::legacy::conflict_notice::snapshot(&ctx);
             let outcome = command::legacy::commit::commit(
                 &mut ctx,
                 IntermediateChannel::new(out),
@@ -1031,6 +1032,7 @@ async fn match_subcommand(
             )
             .emit_metrics(metrics_ctx)?;
             out.print_cli_output(outcome)?;
+            command::legacy::conflict_notice::report_newly_conflicted(&ctx, out, conflicts_before);
             run_status_after_if_requested(status_after, &mut ctx, out);
             Ok(())
         }
@@ -1049,6 +1051,7 @@ async fn match_subcommand(
             )?;
             out.begin_status_after(status_after);
 
+            let conflicts_before = command::legacy::conflict_notice::snapshot(&ctx);
             let outcome = command::legacy::squash::squash(
                 &mut ctx,
                 IntermediateChannel::new(out),
@@ -1056,6 +1059,7 @@ async fn match_subcommand(
             )
             .emit_metrics(metrics_ctx)?;
             out.print_cli_output(outcome)?;
+            command::legacy::conflict_notice::report_newly_conflicted(&ctx, out, conflicts_before);
             run_status_after_if_requested(status_after, &mut ctx, out);
             Ok(())
         }
@@ -1074,10 +1078,12 @@ async fn match_subcommand(
             )?;
             out.begin_status_after(status_after);
 
+            let conflicts_before = command::legacy::conflict_notice::snapshot(&ctx);
             let outcome =
                 command::legacy::r#move::r#move(&mut ctx, IntermediateChannel::new(out), move_args)
                     .emit_metrics(metrics_ctx)?;
             out.print_cli_output_human(outcome)?;
+            command::legacy::conflict_notice::report_newly_conflicted(&ctx, out, conflicts_before);
             run_status_after_if_requested(status_after, &mut ctx, out);
             Ok(())
         }
@@ -1198,8 +1204,16 @@ async fn match_subcommand(
                 out,
             )?;
             out.begin_status_after(status_after);
+            let conflicts_before = command::legacy::conflict_notice::snapshot(&ctx);
             let result = command::legacy::absorb::handle(&mut ctx, out, source.as_deref(), dry_run)
                 .emit_metrics(metrics_ctx);
+            if result.is_ok() {
+                command::legacy::conflict_notice::report_newly_conflicted(
+                    &ctx,
+                    out,
+                    conflicts_before,
+                );
+            }
             run_status_after_if_ok(status_after, &result, &mut ctx, out);
             result.map_err(CliError::from)
         }
@@ -1218,6 +1232,7 @@ async fn match_subcommand(
             )?;
             out.begin_status_after(status_after);
 
+            let conflicts_before = command::legacy::conflict_notice::snapshot(&ctx);
             let outcome = command::legacy::discard::discard(
                 &mut ctx,
                 IntermediateChannel::new(out),
@@ -1225,6 +1240,7 @@ async fn match_subcommand(
             )
             .emit_metrics(metrics_ctx)?;
             out.print_cli_output(outcome)?;
+            command::legacy::conflict_notice::report_newly_conflicted(&ctx, out, conflicts_before);
             run_status_after_if_requested(status_after, &mut ctx, out);
             Ok(())
         }
@@ -1438,6 +1454,7 @@ async fn match_subcommand(
             )?;
             out.begin_status_after(status_after);
 
+            let conflicts_before = command::legacy::conflict_notice::snapshot(&ctx);
             let outcome = command::legacy::uncommit::uncommit(
                 &mut ctx,
                 IntermediateChannel::new(out),
@@ -1445,6 +1462,7 @@ async fn match_subcommand(
             )
             .emit_metrics(metrics_ctx)?;
             out.print_cli_output(outcome)?;
+            command::legacy::conflict_notice::report_newly_conflicted(&ctx, out, conflicts_before);
             run_status_after_if_requested(status_after, &mut ctx, out);
             Ok(())
         }
@@ -1463,20 +1481,30 @@ async fn match_subcommand(
             )?;
             out.begin_status_after(status_after);
 
+            let conflicts_before = command::legacy::conflict_notice::snapshot(&ctx);
             let outcome =
                 command::legacy::amend::amend(&mut ctx, IntermediateChannel::new(out), amend_args)
                     .emit_metrics(metrics_ctx)?;
             out.print_cli_output(outcome)?;
+            command::legacy::conflict_notice::report_newly_conflicted(&ctx, out, conflicts_before);
             run_status_after_if_requested(status_after, &mut ctx, out);
             Ok(())
         }
         #[cfg(feature = "legacy")]
         Subcommands::Land { branch, yes, no_ff } => {
             let mut ctx = setup::init_ctx(&args, InitCtxOptions::default(), out)?;
-            command::legacy::land::handle(&mut ctx, out, &branch, yes, no_ff)
+            let conflicts_before = command::legacy::conflict_notice::snapshot(&ctx);
+            let result = command::legacy::land::handle(&mut ctx, out, &branch, yes, no_ff)
                 .context("Failed to land branch.")
-                .emit_metrics(metrics_ctx)
-                .show_root_cause_error_then_exit_without_destructors(output)
+                .emit_metrics(metrics_ctx);
+            if result.is_ok() {
+                command::legacy::conflict_notice::report_newly_conflicted(
+                    &ctx,
+                    out,
+                    conflicts_before,
+                );
+            }
+            result.show_root_cause_error_then_exit_without_destructors(output)
         }
         #[cfg(feature = "legacy")]
         Subcommands::Pick {
@@ -1491,10 +1519,19 @@ async fn match_subcommand(
                 },
                 out,
             )?;
-            command::legacy::pick::handle(&mut ctx, out, &source, target_branch.as_deref())
-                .context("Failed to pick commit.")
-                .emit_metrics(metrics_ctx)
-                .show_root_cause_error_then_exit_without_destructors(output)
+            let conflicts_before = command::legacy::conflict_notice::snapshot(&ctx);
+            let result =
+                command::legacy::pick::handle(&mut ctx, out, &source, target_branch.as_deref())
+                    .context("Failed to pick commit.")
+                    .emit_metrics(metrics_ctx);
+            if result.is_ok() {
+                command::legacy::conflict_notice::report_newly_conflicted(
+                    &ctx,
+                    out,
+                    conflicts_before,
+                );
+            }
+            result.show_root_cause_error_then_exit_without_destructors(output)
         }
         #[cfg(feature = "legacy")]
         Subcommands::Unapply { identifier } => {

--- a/crates/but/tests/but/command/discard.rs
+++ b/crates/but/tests/but/command/discard.rs
@@ -776,3 +776,36 @@ lw:e hunks.txt│
         "the undiscarded last hunk should remain"
     );
 }
+
+#[test]
+fn discard_that_conflicts_warns_on_stderr_in_json_mode() -> anyhow::Result<()> {
+    let env =
+        Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-dependent-commits");
+    env.setup_metadata(&["A"]);
+
+    let status = util::status_json(&env)?;
+    let bottom = util::branch_commit_cli_ids(&status, "A")
+        .pop()
+        .expect("branch A has commits");
+
+    // Discarding the bottom commit rebases its dependent on top of the base,
+    // which conflicts. JSON output stays parseable, so the warning goes to
+    // stderr.
+    env.but(format!("--format json discard {bottom}"))
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+{
+  "commits": [
+    "[..]"
+  ]
+}
+
+"#]])
+        .stderr_eq(snapbox::str![[r#"
+warning: this operation left 1 commit(s) conflicted: [..]. Resolve with `but resolve`, or back out with `but undo`.
+
+"#]]);
+
+    Ok(())
+}

--- a/crates/but/tests/but/command/move.rs
+++ b/crates/but/tests/but/command/move.rs
@@ -2605,3 +2605,47 @@ fn move_multiple_commits_to_branch_tip_preserves_order() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn move_that_conflicts_warns_about_newly_conflicted_commits() -> anyhow::Result<()> {
+    let env =
+        Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-dependent-commits");
+    env.setup_metadata(&["A"]);
+
+    let status = status_json(&env)?;
+    let commits = branch_commit_cli_ids(&status, "A");
+    let (top, bottom) = (&commits[0], &commits[1]);
+
+    // Swapping two commits that edit the same line leaves the rebased commit
+    // conflicted; the command output must say so.
+    env.but(format!("move {bottom} --above {top}"))
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Moved [..] above commit [..]
+
+⚠ This operation left a commit conflicted:
+  ● [..] [conflict] set two
+Resolve with but resolve, or back out with but undo.
+
+"#]]);
+
+    Ok(())
+}
+
+#[test]
+fn move_without_conflicts_prints_no_conflict_warning() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
+
+    // The commits touch different files, so the swap rebases cleanly.
+    env.but("move zll --above ywx")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Moved [..] above commit [..]
+
+"#]]);
+
+    Ok(())
+}

--- a/crates/but/tests/fixtures/scenario/one-stack-two-dependent-commits.sh
+++ b/crates/but/tests/fixtures/scenario/one-stack-two-dependent-commits.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+### Description
+# One stack with two commits that edit the same line of the same file, so
+# reordering or discarding them produces conflicted commits.
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+git-init-frozen
+
+echo base >file.txt
+git add file.txt
+git commit -m "base"
+setup_target_to_match_main
+
+git checkout -b A
+echo one >file.txt
+git add file.txt
+git commit -m "set one"
+echo two >file.txt
+git add file.txt
+git commit -m "set two"
+
+create_workspace_commit_once A


### PR DESCRIPTION
GitButler operations never stop on conflicts — rebases record commits in a conflicted state instead. History-editing commands (`move`, `commit`, `squash`, `amend`, `uncommit`, `discard`, `absorb`, `pick`, `land`) could silently leave commits conflicted; users only found out from the next `but status`.

Now each of these commands warns when it leaves commits newly conflicted:

```
Moved e4a0cd4 above commit 6fa8e1a

⚠ This operation left a commit conflicted:
  ● uzu [conflict] set two
Resolve with but resolve, or back out with but undo.
```

How it works:

- A shared helper snapshots the workspace's conflicted commits before the mutation and diffs against the state afterwards, so only *new* conflicts are reported — pre-existing ones stay quiet. Identity is keyed on change-ids, which survive rebases.
- Enumeration iterates only workspace commits from the graph projection (no full-ancestry walks), and the snapshot invalidates the workspace cache afterwards so commands still project under their own lock.
- In `--format json`/`shell` mode the warning goes to stderr, keeping stdout parseable.
- Reporting is best-effort: any failure is logged and never fails the mutation.

`pull` and `resolve` already report conflicts themselves and are untouched; `reword` cannot create conflicts. The bundled agent skill was updated to mention the new warnings.