### PR TITLE
Diff annotations w/ prompt copying

### DIFF
--- a/apps/lite/ui/src/annotation.ts
+++ b/apps/lite/ui/src/annotation.ts
@@ -1,0 +1,103 @@
+import { decodeBytes } from "#ui/api/bytes.ts";
+import type { FileParent } from "#ui/operands.ts";
+import type { AnnotationSide } from "@pierre/diffs";
+import { queryOptions, useMutation } from "@tanstack/react-query";
+import * as idb from "idb-keyval";
+
+/** Local-only annotation intended for sending to an agent, hence no draft/published status. */
+export type LocalAnnotation = {
+	id: string;
+	lineNumber: number;
+	side: AnnotationSide;
+	body: string;
+};
+
+export type LocalAnnotationsByPath = Map<string, Array<LocalAnnotation>>;
+
+export const createLocalAnnotation = (
+	lineNumber: number,
+	side: AnnotationSide,
+): LocalAnnotation => ({
+	id: crypto.randomUUID(),
+	lineNumber,
+	side,
+	body: "",
+});
+
+const localAnnotationsKey = ({
+	projectId,
+	fileParentKey,
+}: {
+	projectId: string;
+	fileParentKey: string;
+}) => `local_annotations:v1:${projectId}:${fileParentKey}`;
+
+export const localAnnotationsQueryOptions = ({
+	projectId,
+	fileParentKey,
+}: {
+	projectId: string;
+	fileParentKey: string;
+}) =>
+	queryOptions({
+		queryKey: ["localAnnotations", projectId, fileParentKey],
+		queryFn: async () =>
+			(await idb.get<LocalAnnotationsByPath>(localAnnotationsKey({ projectId, fileParentKey }))) ??
+			new Map(),
+	});
+
+export const usePersistLocalAnnotations = () =>
+	useMutation({
+		mutationFn: ({
+			projectId,
+			fileParentKey,
+			annotations,
+		}: {
+			projectId: string;
+			fileParentKey: string;
+			annotations: LocalAnnotationsByPath;
+		}) => {
+			const key = localAnnotationsKey({ projectId, fileParentKey });
+			return annotations.size === 0 ? idb.del(key) : idb.set(key, annotations);
+		},
+		onSuccess: (_data, input, _result, ctx) => {
+			ctx.client.setQueryData(
+				localAnnotationsQueryOptions({
+					projectId: input.projectId,
+					fileParentKey: input.fileParentKey,
+				}).queryKey,
+				input.annotations,
+			);
+		},
+	});
+
+const localAnnotationRevision = (fileParent: FileParent): string => {
+	switch (fileParent._tag) {
+		case "UncommittedChanges":
+			return "working copy";
+		case "Branch":
+			return decodeBytes(fileParent.branchRef);
+		case "Commit":
+			return fileParent.commitId;
+	}
+};
+
+export const feedbackPrompt = (
+	allFeedback: Array<{
+		annotation: LocalAnnotation;
+		fileParent: FileParent;
+		path: string;
+	}>,
+): string => `# Feedback
+
+${allFeedback
+	.map(
+		(
+			feedback,
+			idx,
+		) => `${idx + 1}. ${feedback.path}:${feedback.annotation.lineNumber} (${feedback.annotation.side}) in ${localAnnotationRevision(feedback.fileParent)}
+
+${feedback.annotation.body}
+`,
+	)
+	.join("\n")}`;

--- a/apps/lite/ui/src/components/Annotation.module.css
+++ b/apps/lite/ui/src/components/Annotation.module.css
@@ -1,0 +1,35 @@
+.wrapper {
+	display: flex;
+	flex-direction: column;
+	max-width: 100ch;
+	margin: 12px;
+	padding: 18px;
+	gap: 12px;
+	border-radius: var(--radius-card);
+	border-top-left-radius: 0;
+	background: var(--bg-1);
+}
+
+.header {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.author {
+	font-weight: bold;
+}
+
+.date {
+	translate: 0 1px;
+	color: var(--text-2);
+}
+
+.body {
+	line-height: 21px;
+}
+
+.actions {
+	display: flex;
+	gap: 12px;
+}

--- a/apps/lite/ui/src/components/Annotation.tsx
+++ b/apps/lite/ui/src/components/Annotation.tsx
@@ -1,18 +1,21 @@
 import { classes } from "#ui/components/classes.ts";
 import { formatRelativeTime } from "#ui/time.ts";
-import type { FC, ReactNode } from "react";
+import type { FC, ReactNode, Ref } from "react";
 import styles from "./Annotation.module.css";
 import { FieldTextareaStyles } from "./Field.tsx";
 
 type Props = {
 	author: string;
 	defaultBody: string;
+	formId: string;
+	name: string;
 	onBlur?: (body: string) => void;
+	textareaRef?: Ref<HTMLTextAreaElement>;
 	updatedAt?: number;
 	actions?: ReactNode;
 };
 
-export const Annotation: FC<Props> = (p) => (
+export const Annotation: FC<Props> = ({ textareaRef, ...p }) => (
 	<div className={styles.wrapper}>
 		<header className={styles.header}>
 			<h5 className={classes(styles.author, "text-13")}>{p.author}</h5>
@@ -29,13 +32,14 @@ export const Annotation: FC<Props> = (p) => (
 		<FieldTextareaStyles
 			className={classes(styles.body, "text-13")}
 			defaultValue={p.defaultBody}
+			form={p.formId}
+			name={p.name}
+			ref={textareaRef}
 			rows={3}
 			onBlur={(event) => {
 				const body = event.currentTarget.value;
 				if (body !== p.defaultBody) p.onBlur?.(body);
 			}}
-			// oxlint-disable-next-line jsx-a11y/no-autofocus -- Focus shifts in response to user action.
-			autoFocus
 		/>
 
 		<div className={styles.actions}>{p.actions}</div>

--- a/apps/lite/ui/src/components/Annotation.tsx
+++ b/apps/lite/ui/src/components/Annotation.tsx
@@ -1,0 +1,43 @@
+import { classes } from "#ui/components/classes.ts";
+import { formatRelativeTime } from "#ui/time.ts";
+import type { FC, ReactNode } from "react";
+import styles from "./Annotation.module.css";
+import { FieldTextareaStyles } from "./Field.tsx";
+
+type Props = {
+	author: string;
+	defaultBody: string;
+	onBlur?: (body: string) => void;
+	updatedAt?: number;
+	actions?: ReactNode;
+};
+
+export const Annotation: FC<Props> = (p) => (
+	<div className={styles.wrapper}>
+		<header className={styles.header}>
+			<h5 className={classes(styles.author, "text-13")}>{p.author}</h5>
+			{p.updatedAt !== undefined && (
+				<time
+					dateTime={new Date(p.updatedAt).toISOString()}
+					className={classes(styles.date, "text-12")}
+				>
+					{formatRelativeTime(p.updatedAt)}
+				</time>
+			)}
+		</header>
+
+		<FieldTextareaStyles
+			className={classes(styles.body, "text-13")}
+			defaultValue={p.defaultBody}
+			rows={3}
+			onBlur={(event) => {
+				const body = event.currentTarget.value;
+				if (body !== p.defaultBody) p.onBlur?.(body);
+			}}
+			// oxlint-disable-next-line jsx-a11y/no-autofocus -- Focus shifts in response to user action.
+			autoFocus
+		/>
+
+		<div className={styles.actions}>{p.actions}</div>
+	</div>
+);

--- a/apps/lite/ui/src/operands.ts
+++ b/apps/lite/ui/src/operands.ts
@@ -104,7 +104,7 @@ const fileParentIdentityKey = (fp: FileParent): string => {
 	}
 };
 
-const weakFileParentIdentityKey = (fp: FileParent): string => {
+export const weakFileParentIdentityKey = (fp: FileParent): string => {
 	switch (fp._tag) {
 		case "UncommittedChanges":
 			return uncommittedChangesIdentityKey;

--- a/apps/lite/ui/src/operands.ts
+++ b/apps/lite/ui/src/operands.ts
@@ -85,8 +85,7 @@ export const commitFileParent = ({ commitId, changeId }: CommitOperand): FilePar
 
 const uncommittedChangesIdentityKey = "uncommitted_changes";
 
-export const branchIdentityKey = (operand: BranchOperand) =>
-	`branch:${operand.branchRef.join(",")}`;
+const branchIdentityKey = (operand: BranchOperand) => `branch:${operand.branchRef.join(",")}`;
 
 export const commitIdentityKey = (operand: Pick<CommitOperand, "commitId">) =>
 	`commit:${operand.commitId}`;
@@ -105,8 +104,22 @@ const fileParentIdentityKey = (fp: FileParent): string => {
 	}
 };
 
-export const fileIdentityKey = (operand: FileOperand) =>
+const weakFileParentIdentityKey = (fp: FileParent): string => {
+	switch (fp._tag) {
+		case "UncommittedChanges":
+			return uncommittedChangesIdentityKey;
+		case "Branch":
+			return branchIdentityKey(fp);
+		case "Commit":
+			return weakCommitIdentityKey(fp);
+	}
+};
+
+const fileIdentityKey = (operand: FileOperand) =>
 	`file:${operand.path} <- ${fileParentIdentityKey(operand.parent)}`;
+
+export const weakFileIdentityKey = (operand: FileOperand) =>
+	`file:${operand.path} <- ${weakFileParentIdentityKey(operand.parent)}`;
 
 const hunkIdentityKey = (operand: HunkOperand) =>
 	`hunk:${JSON.stringify(operand.hunkHeader)}:${JSON.stringify(operand.lineGroups)}:${operand.isResultOfBinaryToTextConversion} <- ${fileIdentityKey(operand.parent)}`;

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
@@ -162,6 +162,12 @@
 	}
 }
 
+.annotate {
+	z-index: 1;
+	position: relative;
+	translate: calc(50% + 1px) 0;
+}
+
 .avatar {
 	width: 16px;
 	height: 16px;

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -37,6 +37,7 @@ import {
 	type HunkOperand,
 	type Operand,
 	weakFileIdentityKey,
+	weakFileParentIdentityKey,
 } from "#ui/operands.ts";
 import { projectSlice } from "#ui/projects/state.ts";
 import { interfaceSlice } from "#ui/interface/state.ts";
@@ -68,6 +69,8 @@ import {
 	type CodeView as CodeViewClass,
 	type CodeViewLineSelection,
 	parsePatchFiles,
+	type GetHoveredLineResult,
+	type DiffLineAnnotation,
 } from "@pierre/diffs";
 import { CodeView, type CodeViewHandle } from "@pierre/diffs/react";
 import { useQuery, useSuspenseQueries, useSuspenseQuery } from "@tanstack/react-query";
@@ -125,6 +128,17 @@ import {
 import { useDiffHunkDrag } from "./diff-hunk-drag.ts";
 import type { DiffLineTarget } from "./diff-line-target.ts";
 import { useHunkMenuItems } from "./useHunkMenuItems.ts";
+import { Annotation } from "#ui/components/Annotation.tsx";
+import {
+	createLocalAnnotation,
+	feedbackPrompt,
+	localAnnotationsQueryOptions,
+	type LocalAnnotation as PersistedLocalAnnotation,
+	type LocalAnnotationsByPath,
+	usePersistLocalAnnotations,
+} from "#ui/annotation.ts";
+
+type Annotation = { _tag: "local"; id: string };
 
 type BranchTab = "diff" | "pr";
 
@@ -188,7 +202,8 @@ const mkCodeViewItem = (
 	id: string,
 	change: TreeChange,
 	hunks: Array<DiffHunk>,
-): CodeViewDiffItem => {
+	annotations: Array<PersistedLocalAnnotation>,
+): CodeViewDiffItem<Annotation> => {
 	const combinedFilePatch = synthesizeFilePatch(change, hunks);
 	const version = hash(combinedFilePatch);
 	const parsed = parsePatchFiles(combinedFilePatch, String(version));
@@ -201,11 +216,20 @@ const mkCodeViewItem = (
 	if (!fileDiff) throw new Error("Failed to parse any files in patch");
 	if (restFiles.length > 0) throw new Error("Parsed more than one file in patch");
 
+	const itemAnnotations: Array<DiffLineAnnotation<Annotation>> = annotations.map(
+		({ id, lineNumber, side }) => ({
+			lineNumber,
+			side,
+			metadata: { _tag: "local", id },
+		}),
+	);
+
 	return {
 		type: "diff",
 		id,
-		version,
+		version: combineHashes(version, itemAnnotations.length),
 		fileDiff,
+		annotations: itemAnnotations,
 	};
 };
 
@@ -213,11 +237,12 @@ type DiffViewDeps = {
 	fileParent: FileParent;
 	changes: Array<TreeChange>;
 	treeChangeDiffs: Array<UnifiedPatch | null>;
+	annotationsByPath: LocalAnnotationsByPath;
 };
 
 type DiffViewFile = {
 	operand: FileOperand;
-	item: CodeViewDiffItem;
+	item: CodeViewDiffItem<Annotation>;
 	change: TreeChange;
 	patch: UnifiedPatch | null;
 	hunks: Array<DiffViewHunk>;
@@ -230,7 +255,7 @@ type DiffViewHunk = {
 
 type DiffView = {
 	navigationIndex: NavigationIndex<HunkOperand>;
-	items: Array<CodeViewDiffItem>;
+	items: Array<CodeViewDiffItem<Annotation>>;
 	fileByItemId: Map<string, DiffViewFile>;
 	fileByPath: Map<string, DiffViewFile>;
 	fileByHunkKey: Map<string, DiffViewFile>;
@@ -238,13 +263,18 @@ type DiffView = {
 };
 
 /** Build relationships between our SDK data and Pierre's view. */
-const getDiffView = ({ fileParent, changes, treeChangeDiffs }: DiffViewDeps): DiffView => {
+const getDiffView = ({
+	fileParent,
+	changes,
+	treeChangeDiffs,
+	annotationsByPath,
+}: DiffViewDeps): DiffView => {
 	const navigationIndex: NavigationIndex<HunkOperand> = {
 		items: [],
 		indexByKey: new Map(),
 	};
 
-	const items: Array<CodeViewDiffItem> = [];
+	const items: Array<CodeViewDiffItem<Annotation>> = [];
 
 	const fileByItemId = new Map<string, DiffViewFile>();
 	const fileByPath = new Map<string, DiffViewFile>();
@@ -253,6 +283,7 @@ const getDiffView = ({ fileParent, changes, treeChangeDiffs }: DiffViewDeps): Di
 
 	for (const [ci, change] of changes.entries()) {
 		const mdiff = treeChangeDiffs[ci];
+		const annotations = annotationsByPath.get(change.path) ?? [];
 
 		const file: FileOperand = {
 			parent: fileParent,
@@ -262,6 +293,7 @@ const getDiffView = ({ fileParent, changes, treeChangeDiffs }: DiffViewDeps): Di
 			weakFileIdentityKey(file),
 			change,
 			mdiff && "subject" in mdiff && "hunks" in mdiff.subject ? mdiff.subject.hunks : [],
+			annotations,
 		);
 
 		items.push(item);
@@ -319,22 +351,26 @@ const getDiffView = ({ fileParent, changes, treeChangeDiffs }: DiffViewDeps): Di
 };
 
 const DiffContents: FC<{
+	localAnnotationFormId: string;
 	selectionScopeRef: RefObject<HTMLDivElement | null>;
 	onViewerFileSelection: (path: string) => void;
 	fileParent: FileParent;
 	projectId: string;
 	diffView: DiffView;
+	annotationsByPath: LocalAnnotationsByPath;
 	diffBackgrounds?: GUISettings["diffBackground"];
 	diffOverflow?: GUISettings["diffOverflow"];
 	diffStyle?: GUISettings["diffStyle"];
-	viewerRef: RefObject<CodeViewHandle<undefined> | null>;
+	viewerRef: RefObject<CodeViewHandle<Annotation> | null>;
 	didScrollToViaFileRef: RefObject<boolean>;
 }> = ({
+	localAnnotationFormId,
 	selectionScopeRef,
 	onViewerFileSelection,
 	fileParent,
 	projectId,
 	diffView: { items, navigationIndex, hunkByKey, fileByHunkKey, fileByItemId },
+	annotationsByPath,
 	diffBackgrounds,
 	diffOverflow,
 	diffStyle,
@@ -342,7 +378,24 @@ const DiffContents: FC<{
 	didScrollToViaFileRef,
 }) => {
 	const [collapsedItems, setCollapsedItems] = useState<Set<string>>(new Set());
+	const newFocusableAnnotationIdRef = useRef<string | null>(null);
 	const dispatch = useAppDispatch();
+	const { mutate: persistLocalAnnotations } = usePersistLocalAnnotations();
+
+	const persistFileAnnotations = (
+		path: string,
+		fileAnnotations: Array<PersistedLocalAnnotation>,
+	) => {
+		const updated = new Map(annotationsByPath);
+		if (fileAnnotations.length === 0) updated.delete(path);
+		else updated.set(path, fileAnnotations);
+
+		persistLocalAnnotations({
+			projectId,
+			fileParentKey: weakFileParentIdentityKey(fileParent),
+			annotations: updated,
+		});
+	};
 	const { data: editors } = useQuery(listEditorsQueryOptions);
 	const { data: preferredEditor } = useQuery({
 		...guiSettingsQueryOptions,
@@ -446,7 +499,7 @@ const DiffContents: FC<{
 		},
 	]);
 
-	const selectFileAtViewportTop = (scrollTop: number, viewer: CodeViewClass<undefined>): void => {
+	const selectFileAtViewportTop = (scrollTop: number, viewer: CodeViewClass<Annotation>): void => {
 		if (didScrollToViaFileRef.current) {
 			didScrollToViaFileRef.current = false;
 			return;
@@ -546,7 +599,7 @@ const DiffContents: FC<{
 		onContextMenu: handleLineContextMenu,
 	});
 
-	const handleHunkPostRender = useDiffHunkDrag({
+	const handleHunkPostRender = useDiffHunkDrag<Annotation>({
 		projectId,
 		getHunkOperand: getHunkOperandAtLine,
 	});
@@ -594,6 +647,143 @@ const DiffContents: FC<{
 					/>
 				);
 			}}
+			renderGutterUtility={(getHoveredLine, item) => {
+				const handleClick = () => {
+					const badlyTypedLine = getHoveredLine();
+					if (!badlyTypedLine || !("side" in badlyTypedLine)) return;
+					const line = badlyTypedLine as GetHoveredLineResult<"diff">;
+
+					const file = fileByItemId.get(item.id);
+					if (!file) return;
+
+					const annotation = createLocalAnnotation(line.lineNumber, line.side);
+					newFocusableAnnotationIdRef.current = annotation.id;
+					persistFileAnnotations(file.operand.path, [
+						...(annotationsByPath.get(file.operand.path) ?? []),
+						annotation,
+					]);
+				};
+
+				return (
+					<button
+						type="button"
+						onClick={handleClick}
+						aria-label="Annotate"
+						className={classes(
+							getButtonClassName({ variant: "pop", size: "small", iconOnly: true }),
+							styles.annotate,
+						)}
+					>
+						<Icon name="plus" />
+					</button>
+				);
+			}}
+			renderAnnotation={(anno, item) => {
+				if (!("side" in anno)) throw new Error("Only diff items may be rendered");
+
+				const file = fileByItemId.get(item.id);
+				if (!file) return null;
+
+				const annotations = annotationsByPath.get(file.operand.path) ?? [];
+				const idx = annotations.findIndex(({ id }) => id === anno.metadata.id);
+				const annotation = annotations[idx];
+				if (!annotation) return null;
+
+				return (
+					<Annotation
+						author="You"
+						defaultBody={annotation.body}
+						formId={localAnnotationFormId}
+						name={annotation.id}
+						textareaRef={(textarea) => {
+							if (textarea && newFocusableAnnotationIdRef.current === annotation.id) {
+								newFocusableAnnotationIdRef.current = null;
+								textarea.focus();
+							}
+						}}
+						// Pierre gracefully blurs focused annotations before virtualizing their item,
+						// permitting uncontrolled input state to be persisted.
+						onBlur={(body) =>
+							persistFileAnnotations(
+								file.operand.path,
+								annotations.with(idx, { ...annotation, body }),
+							)
+						}
+						actions={
+							<>
+								<button
+									type="button"
+									className={getButtonClassName({ variant: "ghost" })}
+									onClick={() => {
+										persistFileAnnotations(file.operand.path, annotations.toSpliced(idx, 1));
+										selectionScopeRef.current?.focus({ focusVisible: false });
+									}}
+								>
+									Delete
+								</button>
+
+								<button
+									type="button"
+									form={localAnnotationFormId}
+									className={getButtonClassName({ variant: "ghost" })}
+									onClick={(evt) => {
+										const form = evt.currentTarget.form;
+										if (!form) throw new Error("Missing owning form");
+
+										const body = new FormData(form).get(annotation.id);
+										if (typeof body !== "string") throw new Error("Missing or invalid body");
+
+										void window.lite.clipboardWriteText(
+											feedbackPrompt([
+												{
+													annotation: { ...annotation, body },
+													fileParent,
+													path: file.operand.path,
+												},
+											]),
+										);
+									}}
+								>
+									Copy as prompt
+								</button>
+
+								<button
+									type="button"
+									form={localAnnotationFormId}
+									className={getButtonClassName({ variant: "ghost" })}
+									onClick={(evt) => {
+										const form = evt.currentTarget.form;
+										if (!form) throw new Error("Missing owning form");
+
+										const formData = new FormData(form);
+										const feedback = annotationsByPath
+											.entries()
+											.flatMap(([path, annotations]) =>
+												annotations.map((annotation) => {
+													// Use any live mounted bodies, falling back to persisted.
+													const formBody = formData.get(annotation.id);
+													return {
+														annotation: {
+															...annotation,
+															body: typeof formBody === "string" ? formBody : annotation.body,
+														},
+														fileParent,
+														path,
+													};
+												}),
+											)
+											.toArray();
+
+										void window.lite.clipboardWriteText(feedbackPrompt(feedback));
+									}}
+								>
+									Copy all as prompt
+								</button>
+							</>
+						}
+					/>
+				);
+			}}
 			onScroll={selectFileAtViewportTop}
 			className={styles.diffContents}
 			items={
@@ -610,6 +800,17 @@ const DiffContents: FC<{
 				themeType: theme ?? defaultSettings.theme,
 				stickyHeaders: true,
 				enableLineSelection: true,
+				// Manually wire these up instead of using renderGutterUtility to separate annotations from
+				// selections.
+				onLineEnter: ({ numberElement }) => {
+					const slot = document.createElement("slot");
+					slot.name = "gutter-utility-slot";
+					slot.setAttribute("data-gutter-utility-slot", "");
+					numberElement.appendChild(slot);
+				},
+				onLineLeave: ({ numberElement }) => {
+					numberElement.querySelector(':scope > slot[name="gutter-utility-slot"]')?.remove();
+				},
 				layout: {
 					paddingTop: 0,
 					// Match --panel-padding-block.
@@ -1018,8 +1219,9 @@ const Diff: FC<{
 	outlineSelection: Operand;
 	projectId: string;
 }> = ({ changes, filesVisible, filesItems, onFileSelection, outlineSelection, projectId }) => {
+	const localAnnotationFormId = useId();
 	const selectionScopeRef = useRef<HTMLDivElement>(null);
-	const viewerRef = useRef<CodeViewHandle<undefined>>(null);
+	const viewerRef = useRef<CodeViewHandle<Annotation>>(null);
 
 	// On file selection we select the first hunk/block in that file and scroll to it, which triggers
 	// CodeView's scroll handler, which in turn updates file selection again (as per usual scrolling
@@ -1063,11 +1265,18 @@ const Diff: FC<{
 		queries: changes.map((change) => treeChangeDiffsQueryOptions({ projectId, change })),
 		combine: (results) => results.map((result) => result.data),
 	});
+	const { data: annotationsByPath } = useSuspenseQuery(
+		localAnnotationsQueryOptions({
+			projectId,
+			fileParentKey: weakFileParentIdentityKey(fileParent),
+		}),
+	);
 
 	const diffView = getDiffView({
 		fileParent,
 		changes,
 		treeChangeDiffs,
+		annotationsByPath,
 	});
 
 	const selectFileAndNavigateDiff = (selection: string) => {
@@ -1145,6 +1354,8 @@ const Diff: FC<{
 
 	return (
 		<div className={styles.diffTab}>
+			<form id={localAnnotationFormId} hidden />
+
 			<div className={styles.actions}>
 				{canShowFiles && <FilesToggle className={getButtonClassName({})}>Toggle files</FilesToggle>}
 
@@ -1223,10 +1434,12 @@ const Diff: FC<{
 						ref={useMergedRefs(selectionScopeRef, diffContentsEl)}
 					>
 						<DiffContents
+							localAnnotationFormId={localAnnotationFormId}
 							onViewerFileSelection={onFileSelection}
 							fileParent={fileParent}
 							projectId={projectId}
 							diffView={diffView}
+							annotationsByPath={annotationsByPath}
 							diffBackgrounds={diffSettings?.diffBackground}
 							diffOverflow={diffSettings?.diffOverflow}
 							diffStyle={canUseSplitDiff ? diffSettings?.diffStyle : "unified"}

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -562,7 +562,7 @@ const DiffContents: FC<{
 
 	// We must change the version for updates to the collapsed property to be respected. The versions
 	// should be as stable as possible, collapsed or not, for performance.
-	const enhanceCollapsed = (item: CodeViewDiffItem): CodeViewDiffItem => ({
+	const enhanceCollapsed = <T,>(item: CodeViewDiffItem<T>): CodeViewDiffItem<T> => ({
 		...item,
 		collapsed: true,
 		// We always use versions.
@@ -667,7 +667,7 @@ const DiffContents: FC<{
 
 type DiffFileHeaderProps = {
 	projectId: string;
-	item: CodeViewDiffItem;
+	item: CodeViewDiffItem<unknown>;
 	operand: FileOperand;
 	change: TreeChange;
 	hasDiff: boolean;

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -193,12 +193,19 @@ const mkCodeViewItem = (
 	const version = hash(combinedFilePatch);
 	const parsed = parsePatchFiles(combinedFilePatch, String(version));
 
+	const [patch, ...restPatches] = parsed;
+	if (!patch) throw new Error("Failed to parse any patches");
+	if (restPatches.length > 0) throw new Error("Parsed more than one patch");
+
+	const [fileDiff, ...restFiles] = patch.files;
+	if (!fileDiff) throw new Error("Failed to parse any files in patch");
+	if (restFiles.length > 0) throw new Error("Parsed more than one file in patch");
+
 	return {
 		type: "diff",
 		id,
 		version,
-		// There should always be exactly one result given our one parsed hunk.
-		fileDiff: assert(assert(parsed[0]).files[0]),
+		fileDiff,
 	};
 };
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -36,9 +36,7 @@ import {
 	type FileParent,
 	type HunkOperand,
 	type Operand,
-	branchIdentityKey,
-	fileIdentityKey,
-	weakCommitIdentityKey,
+	weakFileIdentityKey,
 } from "#ui/operands.ts";
 import { projectSlice } from "#ui/projects/state.ts";
 import { interfaceSlice } from "#ui/interface/state.ts";
@@ -140,12 +138,6 @@ const diffDefaults = {
 	diffStyle: "split",
 } satisfies Partial<GUISettings>;
 
-const codeViewItemId = ({ changesetKey, path }: { changesetKey: string; path: string }): string =>
-	`${changesetKey}:${path}`;
-
-const codeViewItemIdPath = ({ changesetKey, id }: { changesetKey: string; id: string }): string =>
-	id.slice(changesetKey.length + 1);
-
 const hunkOperandIdentityKey = (operand: HunkOperand): string =>
 	operandIdentityKey(hunkOperand(operand));
 
@@ -193,8 +185,8 @@ const getBranchFileRowItems = ({ branchDiff }: { branchDiff: TreeChanges }): Arr
 	);
 
 const mkCodeViewItem = (
+	id: string,
 	change: TreeChange,
-	changesetKey: string,
 	hunks: Array<DiffHunk>,
 ): CodeViewDiffItem => {
 	const combinedFilePatch = synthesizeFilePatch(change, hunks);
@@ -203,7 +195,7 @@ const mkCodeViewItem = (
 
 	return {
 		type: "diff",
-		id: codeViewItemId({ changesetKey, path: change.path }),
+		id,
 		version,
 		// There should always be exactly one result given our one parsed hunk.
 		fileDiff: assert(assert(parsed[0]).files[0]),
@@ -214,7 +206,6 @@ type DiffViewDeps = {
 	fileParent: FileParent;
 	changes: Array<TreeChange>;
 	treeChangeDiffs: Array<UnifiedPatch | null>;
-	changesetKey: string;
 };
 
 type DiffViewFile = {
@@ -240,12 +231,7 @@ type DiffView = {
 };
 
 /** Build relationships between our SDK data and Pierre's view. */
-const getDiffView = ({
-	fileParent,
-	changes,
-	treeChangeDiffs,
-	changesetKey,
-}: DiffViewDeps): DiffView => {
+const getDiffView = ({ fileParent, changes, treeChangeDiffs }: DiffViewDeps): DiffView => {
 	const navigationIndex: NavigationIndex<HunkOperand> = {
 		items: [],
 		indexByKey: new Map(),
@@ -261,18 +247,18 @@ const getDiffView = ({
 	for (const [ci, change] of changes.entries()) {
 		const mdiff = treeChangeDiffs[ci];
 
+		const file: FileOperand = {
+			parent: fileParent,
+			path: change.path,
+		};
 		const item = mkCodeViewItem(
+			weakFileIdentityKey(file),
 			change,
-			changesetKey,
 			mdiff && "subject" in mdiff && "hunks" in mdiff.subject ? mdiff.subject.hunks : [],
 		);
 
 		items.push(item);
 
-		const file: FileOperand = {
-			parent: fileParent,
-			path: change.path,
-		};
 		const diffViewFile: DiffViewFile = {
 			operand: file,
 			item,
@@ -327,9 +313,8 @@ const getDiffView = ({
 
 const DiffContents: FC<{
 	selectionScopeRef: RefObject<HTMLDivElement | null>;
-	onViewerFileSelection: (selection: string) => void;
+	onViewerFileSelection: (path: string) => void;
 	fileParent: FileParent;
-	changesetKey: string;
 	projectId: string;
 	diffView: DiffView;
 	diffBackgrounds?: GUISettings["diffBackground"];
@@ -341,7 +326,6 @@ const DiffContents: FC<{
 	selectionScopeRef,
 	onViewerFileSelection,
 	fileParent,
-	changesetKey,
 	projectId,
 	diffView: { items, navigationIndex, hunkByKey, fileByHunkKey, fileByItemId },
 	diffBackgrounds,
@@ -469,7 +453,10 @@ const DiffContents: FC<{
 		// This can happen on very fast scroll.
 		if (activeItem === undefined) return;
 
-		onViewerFileSelection(codeViewItemIdPath({ changesetKey, id: activeItem.id }));
+		const file = fileByItemId.get(activeItem.id);
+		if (!file) return;
+
+		onViewerFileSelection(file.operand.path);
 	};
 
 	// We currently only support selecting contiguous blocks.
@@ -1052,18 +1039,6 @@ const Diff: FC<{
 
 	// At time of writing React Compiler cannot statically analyse that these are pure derivations of
 	// the outline selection, even with the helpers inlined, hence manual memoisation.
-	const changesetKey = useMemo(
-		() =>
-			Match.value(outlineSelection).pipe(
-				Match.tags({
-					Branch: (x) => branchIdentityKey(x),
-					File: (x) => fileIdentityKey(x),
-					Commit: (x) => weakCommitIdentityKey(x),
-				}),
-				Match.orElseAbsurd,
-			),
-		[outlineSelection],
-	);
 	const fileParent = useMemo(
 		() =>
 			Match.value(outlineSelection).pipe(
@@ -1086,23 +1061,25 @@ const Diff: FC<{
 		fileParent,
 		changes,
 		treeChangeDiffs,
-		changesetKey,
 	});
 
 	const selectFileAndNavigateDiff = (selection: string) => {
 		onFileSelection(selection);
 
+		const file = diffView.fileByPath.get(selection);
+		if (!file) return;
+
 		dispatch(
 			projectSlice.actions.selectDiff({
 				projectId,
-				selection: diffView.fileByPath.get(selection)?.hunks[0]?.operand ?? null,
+				selection: file.hunks[0]?.operand ?? null,
 			}),
 		);
 
 		didScrollToViaFileRef.current = true;
 		viewerRef.current?.scrollTo({
 			type: "item",
-			id: codeViewItemId({ changesetKey, path: selection }),
+			id: file.item.id,
 		});
 	};
 
@@ -1241,7 +1218,6 @@ const Diff: FC<{
 						<DiffContents
 							onViewerFileSelection={onFileSelection}
 							fileParent={fileParent}
-							changesetKey={changesetKey}
 							projectId={projectId}
 							diffView={diffView}
 							diffBackgrounds={diffSettings?.diffBackground}

--- a/apps/lite/ui/src/routes/project/$id/workspace/diff-hunk-drag.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/diff-hunk-drag.ts
@@ -24,7 +24,7 @@ const HUNK_LINE_SELECTOR =
 	'[data-column-number][data-line-type="change-addition"], [data-column-number][data-line-type="change-deletion"]';
 const HUNK_DRAG_HANDLE_ATTRIBUTE = "data-hunk-drag-handle";
 
-type OnPostRender = NonNullable<CodeViewOptions<undefined>["onPostRender"]>;
+type OnPostRender<T> = NonNullable<CodeViewOptions<T>["onPostRender"]>;
 
 type Registration = {
 	itemId: string;
@@ -70,13 +70,13 @@ const cleanHunkDragHandles = (host: HTMLElement): void => {
 	}
 };
 
-export const useDiffHunkDrag = ({
+export const useDiffHunkDrag = <T>({
 	projectId,
 	getHunkOperand,
 }: {
 	projectId: string;
 	getHunkOperand: (target: DiffLineTarget) => HunkOperand | null;
-}): OnPostRender => {
+}): OnPostRender<T> => {
 	const store = useAppStore();
 	const queryClient = useQueryClient();
 
@@ -97,7 +97,7 @@ export const useDiffHunkDrag = ({
 	configRef.current = config;
 	const registrationsRef = useRef<Map<HTMLElement, Registration>>(new Map());
 
-	const onPostRenderRef = useRef<OnPostRender>(null);
+	const onPostRenderRef = useRef<OnPostRender<T>>(null);
 	onPostRenderRef.current ??= (host, _instance, phase, context): void => {
 		const registrations = registrationsRef.current;
 		const existing = registrations.get(host);

--- a/apps/lite/ui/src/routes/project/$id/workspace/diff-line-context-menu.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/diff-line-context-menu.ts
@@ -6,9 +6,9 @@ export type DiffLineContextMenuTarget = {
 	event: MouseEvent;
 } & DiffLineTarget;
 
-const contextMenuTarget = (
+const contextMenuTarget = <T>(
 	event: MouseEvent,
-	viewerRef: RefObject<CodeViewHandle<undefined> | null>,
+	viewerRef: RefObject<CodeViewHandle<T> | null>,
 ): DiffLineContextMenuTarget | null => {
 	// Pierre renders every diff item into its own open shadow root. Context-menu events are
 	// composed, so inspecting their path lets us delegate from the stable CodeView container
@@ -30,11 +30,11 @@ const contextMenuTarget = (
 	return target ? { event, ...target } : null;
 };
 
-export const useDiffLineContextMenu = ({
+export const useDiffLineContextMenu = <T>({
 	viewerRef,
 	onContextMenu,
 }: {
-	viewerRef: RefObject<CodeViewHandle<undefined> | null>;
+	viewerRef: RefObject<CodeViewHandle<T> | null>;
 	onContextMenu: (target: DiffLineContextMenuTarget) => void;
 }): void => {
 	const handleContextMenu = useEffectEvent((event: MouseEvent) => {


### PR DESCRIPTION
This is a _super early experimental_ version of something I wondered about over the weekend. I'd like to ship early and see how it feels before spending any longer on it. If this doesn't work out then on the plus side it's given me some exposure to how Pierre handles annotations.

In a nutshell, instead of hopping between your agent and GitButler and having to manually describe where your feedback relates to, you can type your targeted feedback in GitButler instead and copy a prompt with all of that information captured.

<img width="867" height="418" alt="Screenshot 2026-07-27 at 17 03 31" src="https://github.com/user-attachments/assets/53d764f4-120a-4633-8929-1ba8239c4eec" />


Here's how the prompts currently look:

```md
# Feedback

1. apps/lite/ui/src/annotation.ts:15 (additions) in refs/heads/localannos

Here is my first piece of feedback.

2. apps/lite/ui/src/routes/project/$id/workspace/Details.tsx:217 (additions) in refs/heads/localannos

Here is my second piece of feedback.

I sure am waffling on.
```

