### PR TITLE
feat(transaction): return change ids from transaction outcomes

### DIFF
--- a/crates/but-core/src/commit/mod.rs
+++ b/crates/but-core/src/commit/mod.rs
@@ -864,3 +864,12 @@ pub fn write_conflicted_tree(
         .context("failed to write conflicted tree")
         .map(|tree_id| tree_id.detach())
 }
+
+/// A commit with change id.
+#[derive(Debug, Clone)]
+pub struct CommitIdentifiers {
+    /// The commit sha.
+    pub id: gix::ObjectId,
+    /// The change id.
+    pub change_id: ChangeId,
+}

--- a/crates/but-rebase/src/graph_rebase/mod.rs
+++ b/crates/but-rebase/src/graph_rebase/mod.rs
@@ -10,6 +10,7 @@ pub mod traverse;
 use std::collections::{BTreeMap, HashMap};
 
 use anyhow::{Context, Result, bail};
+use but_core::commit::CommitIdentifiers;
 use but_core::{RefMetadata, commit::SignCommit};
 use but_graph::init::Overlay;
 pub use creation::GraphEditorOptions;
@@ -444,6 +445,22 @@ impl<'ws, 'meta, M: RefMetadata> SuccessfulRebase<'ws, 'meta, M> {
         let mut graph = self.workspace.graph.clone();
         graph.options.worktree_tips = self.worktree_tips_after_rebase()?;
         graph.redo_traversal_with_overlay(&self.repo, self.meta, overlay)
+    }
+
+    /// Resolve `selector` to the identifiers of its commit pick including the change id.
+    pub fn lookup_commit(&self, selector: Selector) -> Result<CommitIdentifiers> {
+        let id = self.lookup_pick(selector)?;
+        let commit = self.repo.find_commit(id)?;
+        let commit = commit.decode()?;
+
+        let change_id =
+            but_core::commit::Headers::try_from_commit_headers(|| commit.extra_headers())
+                .unwrap_or_default()
+                .ensure_change_id(id)
+                .change_id
+                .expect("change ID is ensured");
+
+        Ok(CommitIdentifiers { id, change_id })
     }
 }
 

--- a/crates/but-transaction/src/lib.rs
+++ b/crates/but-transaction/src/lib.rs
@@ -7,13 +7,13 @@ use anyhow::Context as _;
 use bstr::BStr;
 use but_api::WorkspaceState;
 use but_core::{
-    DiffSpec, DryRun, RefMetadata, ref_metadata, sync::RepoExclusive,
+    DiffSpec, DryRun, RefMetadata, commit::CommitIdentifiers, ref_metadata, sync::RepoExclusive,
     tree::create_tree::RejectionReason,
 };
 use but_ctx::Context;
 use but_oplog::legacy::SnapshotDetails;
 use but_rebase::graph_rebase::{
-    Editor, LookupStep as _, Step, SuccessfulRebase,
+    Editor, Step, SuccessfulRebase,
     mutate::{InsertSide, RelativeTo},
 };
 use but_workspace::commit::{
@@ -238,7 +238,7 @@ where
         subjects: impl IntoIterator<Item = ObjectId>,
         target: ObjectId,
         how_to_combine_messages: MessageCombinationStrategy,
-    ) -> anyhow::Result<ObjectId> {
+    ) -> anyhow::Result<CommitIdentifiers> {
         self.rebase(|editor, commit_mappings, _| {
             let SquashCommitsOutcome {
                 rebase,
@@ -252,16 +252,20 @@ where
                 commit_mappings.map(target),
                 how_to_combine_messages,
             )?;
-            let new_commit = rebase.lookup_pick(commit_selector)?;
+            let new_commit = rebase.lookup_commit(commit_selector)?;
             Ok((new_commit, rebase))
         })
     }
 
-    pub fn reword_commit(&mut self, commit: ObjectId, message: &BStr) -> anyhow::Result<ObjectId> {
+    pub fn reword_commit(
+        &mut self,
+        commit: ObjectId,
+        message: &BStr,
+    ) -> anyhow::Result<CommitIdentifiers> {
         self.rebase(|editor, commit_mappings, _| {
             let (rebase, edited_commit_selector) =
                 but_workspace::commit::reword(editor, commit_mappings.map(commit), message)?;
-            let new_commit = rebase.lookup_pick(edited_commit_selector)?;
+            let new_commit = rebase.lookup_commit(edited_commit_selector)?;
             Ok((new_commit, rebase))
         })
     }
@@ -285,7 +289,7 @@ where
         &mut self,
         source: gix::ObjectId,
         changes: Vec<DiffSpec>,
-    ) -> anyhow::Result<ObjectId> {
+    ) -> anyhow::Result<CommitIdentifiers> {
         let context_lines = self.inner.context_lines;
         self.rebase(|editor, commit_mappings, _| {
             let but_workspace::commit::UncommitChangesOutcome {
@@ -298,7 +302,7 @@ where
                 context_lines,
             )?;
 
-            let new_commit = rebase.lookup_pick(commit_selector)?;
+            let new_commit = rebase.lookup_commit(commit_selector)?;
             Ok((new_commit, rebase))
         })
     }
@@ -602,7 +606,7 @@ where
             )?;
 
             let new_commit = commit_selector
-                .map(|commit_selector| rebase.lookup_pick(commit_selector))
+                .map(|commit_selector| rebase.lookup_commit(commit_selector))
                 .transpose()?;
 
             Ok((
@@ -619,7 +623,7 @@ where
         &mut self,
         relative_to: RelativeTo,
         side: InsertSide,
-    ) -> anyhow::Result<gix::ObjectId> {
+    ) -> anyhow::Result<CommitIdentifiers> {
         self.rebase(|editor, commit_mappings, _| {
             let relative_to = match relative_to {
                 RelativeTo::Commit(object_id) => RelativeTo::Commit(commit_mappings.map(object_id)),
@@ -628,7 +632,7 @@ where
 
             let (rebase, blank_commit_selector) =
                 but_workspace::commit::insert_blank_commit(editor, side, relative_to)?;
-            let new_commit = rebase.lookup_pick(blank_commit_selector)?;
+            let new_commit = rebase.lookup_commit(blank_commit_selector)?;
 
             Ok((new_commit, rebase))
         })
@@ -676,7 +680,7 @@ where
             )?;
 
             let new_commit = commit_selector
-                .map(|commit_selector| rebase.lookup_pick(commit_selector))
+                .map(|commit_selector| rebase.lookup_commit(commit_selector))
                 .transpose()?;
 
             Ok((
@@ -694,7 +698,7 @@ where
         source: ObjectId,
         target: ObjectId,
         changes: Vec<but_core::DiffSpec>,
-    ) -> anyhow::Result<ObjectId> {
+    ) -> anyhow::Result<CommitIdentifiers> {
         let context_lines = self.context_lines();
         self.rebase(|editor, commit_mappings, _| {
             let source = commit_mappings.map(source);
@@ -713,7 +717,7 @@ where
             )?;
 
             let new_commit = rebase
-                .lookup_pick(destination_selector)
+                .lookup_commit(destination_selector)
                 .context("failed to find rebased commit")?;
 
             Ok((new_commit, rebase))
@@ -1201,7 +1205,7 @@ fn workspace_state_from_rebase<M: RefMetadata>(
 /// in-memory.
 pub struct IntermediateCommitCreateResult {
     /// If the commit was successfully created. This should only be none if all the DiffSpecs were rejected.
-    pub new_commit: Option<gix::ObjectId>,
+    pub new_commit: Option<CommitIdentifiers>,
     /// Any specs that failed to be committed.
     pub rejected_specs: Vec<(RejectionReason, DiffSpec)>,
 }

--- a/crates/but-transaction/src/tests.rs
+++ b/crates/but-transaction/src/tests.rs
@@ -75,11 +75,11 @@ fn squashing_three_commits() {
                 MessageCombinationStrategy::KeepBoth,
             )?;
             let new_one = tx.squash_commits(
-                Vec::from([new_two]),
+                Vec::from([new_two.id]),
                 one,
                 MessageCombinationStrategy::KeepBoth,
             )?;
-            tx.reword_commit(new_one, "squashed".into())?;
+            tx.reword_commit(new_one.id, "squashed".into())?;
 
             Ok(())
         },
@@ -338,12 +338,12 @@ fn create_reference_then_commit_below_anchor_keeps_commit_in_workspace() {
         panic!("transaction should commit");
     };
 
-    assert_eq!(Some(new_commit), ref_target(&env, refname.as_ref()));
+    assert_eq!(Some(new_commit.id), ref_target(&env, refname.as_ref()));
 
     let repo = env.open_repo();
     let mut branch_commit = ref_target(&env, branch.as_ref()).unwrap();
     let mut commits_above_new_branch = 0;
-    while branch_commit != new_commit {
+    while branch_commit != new_commit.id {
         commits_above_new_branch += 1;
         let commit = repo.find_commit(branch_commit).unwrap();
         let commit = commit.decode().unwrap();
@@ -353,7 +353,7 @@ fn create_reference_then_commit_below_anchor_keeps_commit_in_workspace() {
         3, commits_above_new_branch,
         "new lower branch commit should be below oldest commit in anchored segment"
     );
-    let lower_branch_tip = repo.find_commit(new_commit).unwrap();
+    let lower_branch_tip = repo.find_commit(new_commit.id).unwrap();
     let lower_branch_tip = lower_branch_tip.decode().unwrap();
     assert_eq!(
         Some(base),
@@ -402,7 +402,7 @@ fn move_commits_then_commit_relative_to_moved_commit() {
     };
 
     assert_eq!(
-        Some(new_commit),
+        Some(new_commit.id),
         ref_target(
             &env,
             FullName::try_from("refs/heads/branch").unwrap().as_ref()
@@ -506,7 +506,7 @@ fn create_reference_then_commit_relative_to_it() {
         panic!("transaction should commit");
     };
     assert_eq!(
-        Some(new_commit),
+        Some(new_commit.id),
         ref_target(&env, refname.as_ref()),
         "created reference should point to the commit inserted relative to it"
     );
@@ -701,7 +701,7 @@ fn discard_changes_from_commit() {
 
     let repo = env.open_repo();
     let new_two_tree_id = repo
-        .find_commit(new_two)
+        .find_commit(new_two.id)
         .unwrap()
         .tree_id()
         .unwrap()

--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -275,7 +275,7 @@ pub fn run(
             let new_commit =
                 new_commit.context("BUG: rejected_specs is empty yet nothing was committed")?;
 
-            let reworded_commit = reword_op.execute(new_commit, &mut tx)?;
+            let reworded_commit = reword_op.execute(new_commit.id, &mut tx)?;
 
             Ok(but_transaction::Commit((reworded_commit, branch_name)))
         },

--- a/crates/but/src/command/legacy/discard.rs
+++ b/crates/but/src/command/legacy/discard.rs
@@ -443,7 +443,7 @@ pub fn run(
                     DiscardOutcome::CommittedFiles {
                         source,
                         paths,
-                        new_commit,
+                        new_commit: new_commit.id,
                     }
                 }
                 ExecutableDiscardOperation::Uncommitted { paths, changes } => {

--- a/crates/but/src/command/legacy/move.rs
+++ b/crates/but/src/command/legacy/move.rs
@@ -257,10 +257,13 @@ impl MoveChangesRelativeToOperation {
         };
 
         let empty_commit_id = tx.insert_blank_commit(relative_to, side)?;
-        let new_commit_id =
-            tx.move_committed_changes_between(source_commit_id, empty_commit_id, changes.into())?;
+        let new_commit_id = tx.move_committed_changes_between(
+            source_commit_id,
+            empty_commit_id.id,
+            changes.into(),
+        )?;
 
-        Ok((new_commit_id, new_branch_name))
+        Ok((new_commit_id.id, new_branch_name))
     }
 }
 
@@ -299,9 +302,12 @@ impl MoveChangesToNewBranchOperation {
             RelativeTo::Reference(new_branch_name.clone()),
             Side::Below.into(),
         )?;
-        let new_commit_id =
-            tx.move_committed_changes_between(source_commit_id, empty_commit_id, changes.into())?;
-        Ok((new_commit_id, new_branch_name))
+        let new_commit_id = tx.move_committed_changes_between(
+            source_commit_id,
+            empty_commit_id.id,
+            changes.into(),
+        )?;
+        Ok((new_commit_id.id, new_branch_name))
     }
 }
 

--- a/crates/but/src/command/legacy/reword2.rs
+++ b/crates/but/src/command/legacy/reword2.rs
@@ -79,6 +79,6 @@ impl RewordCommitOperation {
 
         let reworded_commit = tx.reword_commit(new_commit, BString::from(message).as_ref())?;
 
-        Ok(reworded_commit)
+        Ok(reworded_commit.id)
     }
 }

--- a/crates/but/src/command/legacy/squash.rs
+++ b/crates/but/src/command/legacy/squash.rs
@@ -1342,7 +1342,7 @@ impl SquashCommitsOperation {
             reword,
         } = self;
         let new_commit = tx.squash_commits(sources, target, reword.how_to_combine_messages())?;
-        reword.execute(new_commit, tx)
+        reword.execute(new_commit.id, tx)
     }
 }
 
@@ -1373,7 +1373,7 @@ impl SquashBranchOperation {
         }
 
         let new_commit = tx.squash_commits(sources, target, reword.how_to_combine_messages())?;
-        reword.execute(new_commit, tx)
+        reword.execute(new_commit.id, tx)
     }
 }
 
@@ -1405,7 +1405,7 @@ impl AmendUncommittedDiffSpecsOperation {
         let new_commit =
             new_commit.context("BUG: rejected_specs is empty yet nothing was committed")?;
 
-        reword.execute(new_commit, tx)
+        reword.execute(new_commit.id, tx)
     }
 }
 
@@ -1430,7 +1430,7 @@ impl MoveCommittedFilesOperation {
         } = self;
 
         let new_commit = tx.move_committed_changes_between(source, target, changes)?;
-        reword.execute(new_commit, tx)
+        reword.execute(new_commit.id, tx)
     }
 }
 


### PR DESCRIPTION
We're working towards making change ids more first class in the CLI which includes operations such as `but commit` printing change ids instead of commit ids.

This updates `but-transaction` to return a `CommitIdentifiers` type that has both the commit and change id. This type is obtained through a new `SuccessfulRebase::lookup_commit` method.