### PR TITLE
CLI: refuse mutating merged-upstream history

### DIFF
--- a/crates/but-api/src/legacy/absorb.rs
+++ b/crates/but-api/src/legacy/absorb.rs
@@ -538,6 +538,7 @@ fn prepare_commit_absorptions(
 /// Get the commit summary message
 fn get_commit_summary(repo: &gix::Repository, commit_id: gix::ObjectId) -> anyhow::Result<String> {
     let commit = repo.find_commit(commit_id)?;
-    let message = commit.message()?.title.to_string();
+    // The title still carries the trailing newline of single-paragraph messages.
+    let message = commit.message()?.title.trim_end().as_bstr().to_string();
     Ok(message)
 }

--- a/crates/but/skill/SKILL.md
+++ b/crates/but/skill/SKILL.md
@@ -54,7 +54,7 @@ The first token on each `but diff` / `but status` line is that line's ID — pas
 
 1. Use `but` for all write operations. Never run `git add`, `git commit`, `git push`, `git checkout`, `git merge`, `git rebase`, `git stash`, or `git cherry-pick`. If the user says a `git` write command, translate it to `but` and run that. Exceptions: `git add -- <path>` to mark a conflicted uncommitted file resolved (see "Conflicts in uncommitted files"), and a worktree-local Git commit when `but commit` reports that linked worktrees are unsupported. Never run `but setup` from a linked worktree.
 2. Mutation commands print their result without appending workspace status. Add `--status-after` only when the next step needs resulting workspace IDs or details; otherwise trust the mutation result and do not run a verification status/diff.
-3. Never commit or push to a branch marked `(merged upstream)`; run `but pull` to remove it, or create/use another branch for new work.
+3. Branches marked `(merged upstream)` have landed; run `but pull` to remove them, or start new work on another branch. `push` and mutations (`commit`, `amend`, `squash`, `uncommit`, `reword`, `move`) refuse landed branches and commits, `absorb` skips them with a notice, and `commit` skips them when picking a default target.
 4. In non-interactive CLI workflows, do not narrate progress between routine commands. Execute the needed `but` commands and give a concise final summary.
 5. Prefer this skill and `references/reference.md` over exploratory help calls. Use `<command> --help` when required syntax is missing or a command fails; use top-level help only when you genuinely need to discover an undocumented command.
 

--- a/crates/but/src/args/amend.rs
+++ b/crates/but/src/args/amend.rs
@@ -2,7 +2,7 @@
 
 #![deny(missing_docs)]
 
-use crate::args::atoms::CliIdArg;
+use crate::args::atoms::{AllowMergedArg, CliIdArg};
 
 /// Amend uncommitted changes into a commit or branch.
 ///
@@ -23,4 +23,8 @@ pub struct Platform {
     /// One or more uncommitted files or hunks to amend.
     #[clap(required = true)]
     pub sources: Vec<CliIdArg>,
+
+    #[clap(flatten)]
+    #[allow(missing_docs)]
+    pub allow_merged: AllowMergedArg,
 }

--- a/crates/but/src/args/atoms/mod.rs
+++ b/crates/but/src/args/atoms/mod.rs
@@ -14,3 +14,14 @@ pub use commit_arg::*;
 
 mod cli_id;
 pub use cli_id::*;
+
+/// Escape hatch for the merged-upstream guard, shared by mutation commands.
+#[derive(Debug, Clone, Copy, Default, clap::Args)]
+pub struct AllowMergedArg {
+    /// Allow targeting branches and commits that are already merged upstream.
+    ///
+    /// By default, mutations refuse to touch history that has landed in the
+    /// target branch, since the results tend to conflict on the next `but pull`.
+    #[clap(long)]
+    pub allow_merged: bool,
+}

--- a/crates/but/src/args/commit.rs
+++ b/crates/but/src/args/commit.rs
@@ -2,7 +2,7 @@
 
 #![deny(missing_docs)]
 
-use crate::args::atoms::CliIdArg;
+use crate::args::atoms::{AllowMergedArg, CliIdArg};
 
 /// Create a commit.
 ///
@@ -88,4 +88,8 @@ pub struct Platform {
     /// A change can either be a file or a hunk.
     #[clap(group = "changes_to_commit")]
     pub changes: Vec<CliIdArg>,
+
+    #[clap(flatten)]
+    #[allow(missing_docs)]
+    pub allow_merged: AllowMergedArg,
 }

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -548,6 +548,8 @@ pub enum Subcommands {
         /// Show the absorption plan without making any changes.
         #[clap(long = "dry-run")]
         dry_run: bool,
+        #[clap(flatten)]
+        allow_merged: atoms::AllowMergedArg,
     },
 
     /// Edit the commit message of the specified commit.
@@ -586,6 +588,8 @@ pub enum Subcommands {
         /// Never show the diff inside the editor.
         #[clap(long = "no-diff", default_value_t, conflicts_with_all = &["diff", "fix_formatting"])]
         no_diff: bool,
+        #[clap(flatten)]
+        allow_merged: atoms::AllowMergedArg,
     },
 
     #[cfg(feature = "legacy")]

--- a/crates/but/src/args/move.rs
+++ b/crates/but/src/args/move.rs
@@ -1,4 +1,4 @@
-use crate::args::atoms::CliIdArg;
+use crate::args::atoms::{AllowMergedArg, CliIdArg};
 
 /// Move commits and changes around.
 ///
@@ -92,4 +92,8 @@ pub struct Platform {
     /// an error.
     #[clap(required = true)]
     pub sources: Vec<CliIdArg>,
+
+    #[clap(flatten)]
+    #[allow(missing_docs)]
+    pub allow_merged: AllowMergedArg,
 }

--- a/crates/but/src/args/push.rs
+++ b/crates/but/src/args/push.rs
@@ -43,4 +43,7 @@ pub struct Command {
     /// Show what would be pushed without actually pushing
     #[clap(long, short = 'd')]
     pub dry_run: bool,
+
+    #[clap(flatten)]
+    pub allow_merged: crate::args::atoms::AllowMergedArg,
 }

--- a/crates/but/src/args/squash.rs
+++ b/crates/but/src/args/squash.rs
@@ -2,7 +2,7 @@
 
 #![deny(missing_docs)]
 
-use crate::args::atoms::CliIdArg;
+use crate::args::atoms::{AllowMergedArg, CliIdArg};
 
 /// Squash commits, branches, or changes.
 ///
@@ -88,4 +88,8 @@ pub struct Platform {
     /// commits, branches, uncommitted files, `zz`, or committed files.
     #[clap(required = true)]
     pub sources: Vec<CliIdArg>,
+
+    #[clap(flatten)]
+    #[allow(missing_docs)]
+    pub allow_merged: AllowMergedArg,
 }

--- a/crates/but/src/args/tests.rs
+++ b/crates/but/src/args/tests.rs
@@ -671,6 +671,7 @@ mod push {
                 topic_from_branch: false,
                 private: false,
                 dry_run: false,
+                allow_merged: Default::default(),
             };
 
             let result = get_gerrit_flags(&args, "test-branch", false);
@@ -692,6 +693,7 @@ mod push {
                 topic_from_branch: false,
                 private: false,
                 dry_run: false,
+                allow_merged: Default::default(),
             };
 
             let result = get_gerrit_flags(&args, "test-branch", false);
@@ -718,6 +720,7 @@ mod push {
                 topic_from_branch: false,
                 private: false,
                 dry_run: false,
+                allow_merged: Default::default(),
             };
 
             let result = get_gerrit_flags(&args, "test-branch", true);
@@ -741,6 +744,7 @@ mod push {
                 topic_from_branch: false,
                 private: false,
                 dry_run: false,
+                allow_merged: Default::default(),
             };
 
             let result = get_gerrit_flags(&args, "test-branch", true);
@@ -764,6 +768,7 @@ mod push {
                 topic_from_branch: false,
                 private: false,
                 dry_run: false,
+                allow_merged: Default::default(),
             };
 
             let result = get_gerrit_flags(&args, "test-branch", true);
@@ -798,6 +803,7 @@ mod push {
                 topic_from_branch: false,
                 private: false,
                 dry_run: false,
+                allow_merged: Default::default(),
             };
 
             let result = get_gerrit_flags(&args, "test-branch", true);
@@ -829,6 +835,7 @@ mod push {
                 topic_from_branch: true,
                 private: false,
                 dry_run: false,
+                allow_merged: Default::default(),
             };
 
             let result = get_gerrit_flags(&args, "my-branch-name", true);
@@ -860,6 +867,7 @@ mod push {
                 topic_from_branch: false,
                 private: true,
                 dry_run: false,
+                allow_merged: Default::default(),
             };
 
             let result = get_gerrit_flags(&args, "test-branch", true);
@@ -888,6 +896,7 @@ mod push {
                 topic_from_branch: false,
                 private: true,
                 dry_run: false,
+                allow_merged: Default::default(),
             };
 
             let result = get_gerrit_flags(&args, "test-branch", true);
@@ -934,6 +943,7 @@ mod push {
                 topic_from_branch: false,
                 private: false,
                 dry_run: false,
+                allow_merged: Default::default(),
             };
 
             let result = get_gerrit_flags(&args, "test-branch", true);
@@ -960,6 +970,7 @@ mod push {
                 topic_from_branch: false,
                 private: false,
                 dry_run: false,
+                allow_merged: Default::default(),
             };
 
             let result = get_gerrit_flags(&args, "test-branch", true);

--- a/crates/but/src/args/tests/amend.rs
+++ b/crates/but/src/args/tests/amend.rs
@@ -16,7 +16,11 @@ fn parse_amend(args: &[&str]) -> Platform {
 
 #[test]
 fn parses_sources_followed_by_long_target() {
-    let Platform { target, sources } = parse_amend(&["amend", "a1", "b2", "c3", "--target", "d4"]);
+    let Platform {
+        target,
+        sources,
+        allow_merged: _,
+    } = parse_amend(&["amend", "a1", "b2", "c3", "--target", "d4"]);
 
     assert_eq!(target.0, "d4");
     assert_eq!(
@@ -30,7 +34,11 @@ fn parses_sources_followed_by_long_target() {
 
 #[test]
 fn parses_sources_followed_by_short_target() {
-    let Platform { target, sources } = parse_amend(&["amend", "a1", "b2", "-t", "d4"]);
+    let Platform {
+        target,
+        sources,
+        allow_merged: _,
+    } = parse_amend(&["amend", "a1", "b2", "-t", "d4"]);
 
     assert_eq!(target.0, "d4");
     assert_eq!(

--- a/crates/but/src/args/uncommit.rs
+++ b/crates/but/src/args/uncommit.rs
@@ -2,7 +2,7 @@
 
 #![deny(missing_docs)]
 
-use crate::args::atoms::CliIdArg;
+use crate::args::atoms::{AllowMergedArg, CliIdArg};
 
 /// Uncommit changes from commits or committed files to the uncommitted area.
 ///
@@ -16,4 +16,8 @@ pub struct Platform {
     /// `<commit-id>:<file-id>`.
     #[clap(required = true)]
     pub sources: Vec<CliIdArg>,
+
+    #[clap(flatten)]
+    #[allow(missing_docs)]
+    pub allow_merged: AllowMergedArg,
 }

--- a/crates/but/src/command/legacy/absorb.rs
+++ b/crates/but/src/command/legacy/absorb.rs
@@ -15,7 +15,7 @@ use itertools::Itertools;
 use crate::{
     CliId, IdMap,
     id::{UncommittedHunkOrFile, parser::parse_sources},
-    utils::OutputChannel,
+    utils::{OutputChannel, merged_upstream::MergedUpstream},
 };
 
 /// Amends changes into the appropriate commits where they belong.
@@ -36,6 +36,7 @@ pub(crate) fn handle(
     out: &mut OutputChannel,
     source: Option<&str>,
     dry_run: bool,
+    allow_merged: crate::args::atoms::AllowMergedArg,
 ) -> anyhow::Result<()> {
     let mut guard = ctx.exclusive_worktree_access();
     let id_map = IdMap::new_from_context(ctx, None, guard.read_permission())?;
@@ -100,6 +101,16 @@ pub(crate) fn handle(
     let absorption_plan =
         but_api::legacy::absorb::absorption_plan_with_perm(ctx, target, guard.write_permission())?;
 
+    // Absorbing into a landed commit entangles the new change with an entire
+    // already-merged commit, which conflicts on the next `but pull`. Drop such
+    // plan entries and tell the user, instead of silently amending them.
+    let merged = MergedUpstream::from_ctx(ctx, allow_merged)?;
+    let Some((absorption_plan, skipped_merged)) =
+        drop_landed_absorptions(absorption_plan, &merged, out)?
+    else {
+        return Ok(());
+    };
+
     // Display the plan (in JSON mode for non-dry-run, collect without writing — we'll
     // combine it with the result in absorb_assignments to avoid a double-write that
     // would overwrite the plan in the JSON buffer).
@@ -127,6 +138,7 @@ pub(crate) fn handle(
         guard.write_permission(),
         out,
         plan_json,
+        skipped_merged,
     )?;
 
     Ok(())
@@ -139,6 +151,7 @@ fn absorb_assignments(
     perm: &mut RepoExclusive,
     out: &mut OutputChannel,
     plan_json: Option<JsonAbsorbOutput>,
+    skipped_merged: Vec<String>,
 ) -> anyhow::Result<()> {
     let total_rejected = but_api::legacy::absorb::absorb_with_perm(ctx, absorption_plan, perm)?;
     // Refresh the workspace commit so `gitbutler/workspace` HEAD stays in sync
@@ -173,6 +186,10 @@ fn absorb_assignments(
         });
         if let Some(plan) = plan_json {
             combined["plan"] = serde_json::to_value(plan).unwrap_or(serde_json::Value::Null);
+        }
+        if !skipped_merged.is_empty() {
+            combined["skippedMergedUpstream"] =
+                serde_json::to_value(skipped_merged).unwrap_or(serde_json::Value::Null);
         }
         out.write_value(combined)?;
     }
@@ -315,4 +332,71 @@ fn display_absorption_plan(
     // When write_json is false (non-dry-run), return the plan so the caller can
     // combine it with the operation result in a single write_value call.
     Ok(if write_json { None } else { Some(plan_output) })
+}
+
+/// Drop plan entries that target commits already merged upstream, reporting
+/// each skip. Returns the remaining plan and the skipped commit ids for the
+/// final JSON output, or `None` when nothing is left to absorb — the outcome
+/// has then been fully reported and the caller should stop before
+/// snapshotting.
+#[allow(clippy::type_complexity)]
+fn drop_landed_absorptions(
+    plan: Vec<CommitAbsorption>,
+    merged: &MergedUpstream,
+    out: &mut OutputChannel,
+) -> anyhow::Result<Option<(Vec<CommitAbsorption>, Vec<String>)>> {
+    let (skipped, plan): (Vec<_>, Vec<_>) = plan
+        .into_iter()
+        .partition(|absorption| merged.contains_commit(absorption.commit_id));
+    let skipped_ids = || {
+        skipped
+            .iter()
+            .map(|absorption| absorption.commit_id.to_string())
+            .collect::<Vec<_>>()
+    };
+    if skipped.is_empty() {
+        return Ok(Some((plan, Vec::new())));
+    }
+
+    if let Some(out) = out.for_human() {
+        let t = theme::get();
+        for absorption in &skipped {
+            writeln!(
+                out,
+                "{}: not absorbing into {} {}: commit is merged upstream",
+                t.attention.paint("Skipped"),
+                theme::Commit(absorption.commit_id, None),
+                absorption.commit_summary,
+            )?;
+        }
+        writeln!(
+            out,
+            "{}: most likely you want `but pull`, which removes landed work; in rare cases pass --allow-merged to absorb anyway",
+            t.info.paint("Hint")
+        )?;
+    } else {
+        // JSON output is parsed, so the warning goes to stderr.
+        let ids = skipped
+            .iter()
+            .map(|absorption| absorption.commit_id.to_hex_with_len(7).to_string())
+            .join(", ");
+        eprintln!(
+            "warning: skipped absorbing into {} merged-upstream commit(s): {ids}. Run `but pull` to update the workspace, or pass --allow-merged to absorb anyway.",
+            skipped.len()
+        );
+    }
+
+    if !plan.is_empty() {
+        return Ok(Some((plan, skipped_ids())));
+    }
+
+    if let Some(out) = out.for_human() {
+        writeln!(out, "Nothing left to absorb")?;
+    } else if let Some(out) = out.for_json() {
+        out.write_value(serde_json::json!({
+            "ok": false,
+            "skippedMergedUpstream": skipped_ids(),
+        }))?;
+    }
+    Ok(None)
 }

--- a/crates/but/src/command/legacy/amend.rs
+++ b/crates/but/src/command/legacy/amend.rs
@@ -12,7 +12,7 @@ use crate::{
     command::legacy::squash::{
         self, HowToRewordTarget, ResolveTargetError, ResolvedSquashArgsRef, SquashOperation,
     },
-    utils::IntermediateChannel,
+    utils::{IntermediateChannel, merged_upstream::MergedUpstream},
 };
 
 pub fn amend(
@@ -24,17 +24,11 @@ pub fn amend(
     let mut meta = ctx.meta()?;
     let id_map = IdMap::new_from_context(ctx, None, guard.read_permission())?;
 
+    let head_info = but_api::legacy::workspace::head_info(ctx)?;
+    let merged = MergedUpstream::new(&*ctx.repo.get()?, &head_info, args.allow_merged);
+
     let (repo, ws, _) = ctx.workspace_and_db_with_perm(guard.read_permission())?;
-    let head_info = but_workspace::head_info(
-        &repo,
-        &meta,
-        but_workspace::ref_info::Options {
-            project_meta: ctx.project_meta()?,
-            expensive_commit_info: false,
-            ..Default::default()
-        },
-    )?;
-    let operation = resolve(args, &ws, &repo, &id_map, &head_info)?;
+    let operation = resolve(args, &ws, &repo, &id_map, &head_info, &merged)?;
     drop(repo);
     drop(ws);
 
@@ -52,8 +46,13 @@ fn resolve(
     repo: &gix::Repository,
     id_map: &IdMap,
     head_info: &RefInfo,
+    merged: &MergedUpstream,
 ) -> CliResult<SquashOperation<'static>> {
-    let Platform { target, sources } = args;
+    let Platform {
+        target,
+        sources,
+        allow_merged: _,
+    } = args;
 
     let mut resolved_sources = Vec::new();
     for source in sources {
@@ -104,5 +103,5 @@ fn resolve(
     };
 
     let args = ResolvedSquashArgsRef::Normal { sources, target };
-    Ok(squash::resolve(args, ws, repo)?.into_fully_owned())
+    Ok(squash::resolve(args, ws, repo, merged)?.into_fully_owned())
 }

--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -29,7 +29,7 @@ use crate::{
     theme::{self, Theme},
     utils::{
         CliOutput, CliOutputHuman, IntermediateChannel, WriteWithUtils,
-        diff_specs::DiffSpecBuilder, targeting::Side,
+        diff_specs::DiffSpecBuilder, merged_upstream::MergedUpstream, targeting::Side,
     },
 };
 
@@ -150,7 +150,10 @@ fn resolve(
         below,
         interactive,
         changes,
+        allow_merged,
     } = args;
+
+    let merged = MergedUpstream::new(&*ctx.repo.get()?, head_info, allow_merged);
 
     let target_ish = match (branch, above, below) {
         (Some(Some(branch)), None, None) => CommitOperationTargetIsh::Branch(branch),
@@ -217,7 +220,7 @@ fn resolve(
 
     let commit_op = {
         let (repo, ws, _db) = ctx.workspace_and_db_with_perm(guard.read_permission())?;
-        route_commit_operation(&repo, &ws, head_info, out, id_map, target_ish)?
+        route_commit_operation(&repo, &ws, head_info, out, id_map, target_ish, &merged)?
     };
 
     let reword_op = RewordCommitOperation::resolve(no_message, message);
@@ -311,15 +314,16 @@ fn route_commit_operation(
     out: &mut IntermediateChannel<'_>,
     id_map: &IdMap,
     target: CommitOperationTargetIsh,
+    merged: &MergedUpstream,
 ) -> CliResult<CommitOperation> {
     match target {
         CommitOperationTargetIsh::Above(cli_id) => {
             let side = Side::Above;
-            route_commit_above_or_below(repo, id_map, cli_id, side)
+            route_commit_above_or_below(repo, id_map, cli_id, side, merged)
         }
         CommitOperationTargetIsh::Below(cli_id) => {
             let side = Side::Below;
-            route_commit_above_or_below(repo, id_map, cli_id, side)
+            route_commit_above_or_below(repo, id_map, cli_id, side, merged)
         }
         CommitOperationTargetIsh::Branch(cli_id) => {
             if let Some(branch) = cli_id.try_resolve_branch(repo, id_map)? {
@@ -327,6 +331,7 @@ fn route_commit_operation(
                 let ref_info = segment.ref_info.with_context(|| {
                     format!("BUG: Segment resolved from branch name {branch} has no ref info")
                 })?;
+                merged.ensure_branch_not_merged(ref_info.ref_name.as_ref())?;
 
                 let target = CommitRelativeToTarget::BranchTip {
                     name: ref_info.ref_name,
@@ -348,71 +353,86 @@ fn route_commit_operation(
         CommitOperationTargetIsh::UnstackedCannedBranch => Ok(CommitOperation::CommitToNewBranch(
             CommitToNewBranchOperation { branch_name: None },
         )),
-        CommitOperationTargetIsh::Default => match &head_info.stacks[..] {
-            [] => Ok(CommitOperation::CommitToNewBranch(
-                CommitToNewBranchOperation { branch_name: None },
-            )),
-            [stack] => {
-                let ref_info = stack
-                    .segments
-                    .first()
-                    .and_then(|segment| segment.ref_info.as_ref())
-                    .context("Head stack has no ref")?;
-                Ok(CommitOperation::CommitAt(CommitAtOperation {
-                    target: CommitRelativeToTarget::BranchTip {
-                        name: ref_info.ref_name.clone(),
-                    },
-                }))
-            }
-            stacks => {
-                let stack_heads = stacks
-                    .iter()
-                    .filter_map(|stack| stack.segments.first())
-                    .filter_map(|segment| segment.ref_info.as_ref())
-                    .map(|ref_info| (ref_info.ref_name.shorten(), &ref_info.ref_name))
-                    .collect::<Vec<_>>();
+        CommitOperationTargetIsh::Default => {
+            // Branches that have landed upstream are not sensible default targets;
+            // skip them so new work goes to a live branch or a fresh one.
+            let stacks = head_info
+                .stacks
+                .iter()
+                .filter(|stack| {
+                    !stack
+                        .segments
+                        .first()
+                        .is_some_and(|segment| merged.contains_segment(segment))
+                })
+                .collect::<Vec<_>>();
 
-                let Some(stack_heads) = NonEmpty::from_vec(stack_heads) else {
-                    return Err(anyhow::anyhow!(
-                        "BUG: found multiple stacks but none of them have heads"
-                    )
-                    .into());
-                };
+            match &stacks[..] {
+                [] => Ok(CommitOperation::CommitToNewBranch(
+                    CommitToNewBranchOperation { branch_name: None },
+                )),
+                [stack] => {
+                    let ref_info = stack
+                        .segments
+                        .first()
+                        .and_then(|segment| segment.ref_info.as_ref())
+                        .context("Head stack has no ref")?;
+                    Ok(CommitOperation::CommitAt(CommitAtOperation {
+                        target: CommitRelativeToTarget::BranchTip {
+                            name: ref_info.ref_name.clone(),
+                        },
+                    }))
+                }
+                stacks => {
+                    let stack_heads = stacks
+                        .iter()
+                        .filter_map(|stack| stack.segments.first())
+                        .filter_map(|segment| segment.ref_info.as_ref())
+                        .map(|ref_info| (ref_info.ref_name.shorten(), &ref_info.ref_name))
+                        .collect::<Vec<_>>();
 
-                let Some(mut input) = out.prepare_for_terminal_input() else {
-                    return Err(
-                        bad_input("Unclear where to commit. Found more than one stack")
-                            .hint("You can specify where to commit with `--branch [<BRANCH>]`")
-                            .into(),
-                    );
-                };
+                    let Some(stack_heads) = NonEmpty::from_vec(stack_heads) else {
+                        return Err(anyhow::anyhow!(
+                            "BUG: found multiple stacks but none of them have heads"
+                        )
+                        .into());
+                    };
 
-                let mut stack_heads =
-                    stack_heads.map(|(name, branch)| (name, PickerItem::StackHead(branch)));
-                stack_heads.push(("Create new stack".into(), PickerItem::NewStack));
+                    let Some(mut input) = out.prepare_for_terminal_input() else {
+                        return Err(bad_input(
+                            "Unclear where to commit. Found more than one stack",
+                        )
+                        .hint("You can specify where to commit with `--branch [<BRANCH>]`")
+                        .into());
+                    };
 
-                let Some(selection) = input.prompt_select(
-                    "Multiple stacks found. Choose one to commit to",
-                    &stack_heads,
-                )?
-                else {
-                    return Err(bad_input("No stack picked").into());
-                };
+                    let mut stack_heads =
+                        stack_heads.map(|(name, branch)| (name, PickerItem::StackHead(branch)));
+                    stack_heads.push(("Create new stack".into(), PickerItem::NewStack));
 
-                match selection {
-                    PickerItem::StackHead(full_name) => {
-                        Ok(CommitOperation::CommitAt(CommitAtOperation {
-                            target: CommitRelativeToTarget::BranchTip {
-                                name: (*full_name).clone(),
-                            },
-                        }))
+                    let Some(selection) = input.prompt_select(
+                        "Multiple stacks found. Choose one to commit to",
+                        &stack_heads,
+                    )?
+                    else {
+                        return Err(bad_input("No stack picked").into());
+                    };
+
+                    match selection {
+                        PickerItem::StackHead(full_name) => {
+                            Ok(CommitOperation::CommitAt(CommitAtOperation {
+                                target: CommitRelativeToTarget::BranchTip {
+                                    name: (*full_name).clone(),
+                                },
+                            }))
+                        }
+                        PickerItem::NewStack => Ok(CommitOperation::CommitToNewBranch(
+                            CommitToNewBranchOperation { branch_name: None },
+                        )),
                     }
-                    PickerItem::NewStack => Ok(CommitOperation::CommitToNewBranch(
-                        CommitToNewBranchOperation { branch_name: None },
-                    )),
                 }
             }
-        },
+        }
     }
 }
 
@@ -426,6 +446,7 @@ fn route_commit_above_or_below(
     id_map: &IdMap,
     cli_id: CliIdArg,
     side: Side,
+    merged: &MergedUpstream,
 ) -> CliResult<CommitOperation> {
     let target = match cli_id
         .resolve_in_workspace(repo, id_map, Purpose::Target, None)
@@ -435,11 +456,15 @@ fn route_commit_above_or_below(
         .into_branch_or_commit()
         .hint("Run `but status` to show applicable targets")?
     {
-        BranchOrCommit::Commit(commit_id) => CommitRelativeToTarget::Commit { commit_id, side },
-        BranchOrCommit::Branch(arg) => CommitRelativeToTarget::BranchBucket {
-            name: arg.resolve_local_branch_name()?,
-            side,
-        },
+        BranchOrCommit::Commit(commit_id) => {
+            merged.ensure_commit_not_merged(commit_id)?;
+            CommitRelativeToTarget::Commit { commit_id, side }
+        }
+        BranchOrCommit::Branch(arg) => {
+            let name = arg.resolve_local_branch_name()?;
+            merged.ensure_branch_not_merged(name.as_ref())?;
+            CommitRelativeToTarget::BranchBucket { name, side }
+        }
     };
     Ok(CommitOperation::CommitAt(CommitAtOperation { target }))
 }

--- a/crates/but/src/command/legacy/move.rs
+++ b/crates/but/src/command/legacy/move.rs
@@ -22,7 +22,7 @@ use crate::{
     theme::{self, Theme},
     utils::{
         CliOutputHuman, IntermediateChannel, WriteWithUtils, diff_specs::DiffSpecBuilder,
-        targeting::Side,
+        merged_upstream::MergedUpstream, targeting::Side,
     },
 };
 
@@ -131,9 +131,54 @@ pub fn r#move(
     let mut meta = ctx.meta()?;
     let id_map = IdMap::new_from_context(ctx, None, guard.read_permission())?;
 
+    let allow_merged = args.allow_merged;
     let move_op = resolve(ctx, guard.write_permission(), args, &id_map)?;
+    ensure_not_touching_merged_upstream(&move_op, &MergedUpstream::from_ctx(ctx, allow_merged)?)?;
 
     Ok(run(ctx, &mut meta, guard.write_permission(), move_op)?)
+}
+
+/// Reject moves whose committed sources or targets have already landed in the
+/// target branch. Purely structural branch moves ([`MoveOperation::StackBranch`]
+/// and [`MoveOperation::UnstackBranch`]) stay allowed: they re-anchor commits
+/// without changing their content, so upstream-integration detection still
+/// recognizes them.
+fn ensure_not_touching_merged_upstream(
+    op: &MoveOperation,
+    merged: &MergedUpstream,
+) -> CliResult<()> {
+    let (source_commits, target) = match op {
+        MoveOperation::CommitsRelativeTo(MoveCommitsRelativeToOperation { sources, target }) => {
+            (sources.iter().copied().collect::<Vec<_>>(), Some(target))
+        }
+        MoveOperation::CommitsToNewBranch(MoveCommitsToNewBranchOperation { sources, .. }) => {
+            (sources.iter().copied().collect(), None)
+        }
+        MoveOperation::ChangesRelativeTo(MoveChangesRelativeToOperation {
+            source_commit_id,
+            target,
+            ..
+        }) => (vec![*source_commit_id], Some(target)),
+        MoveOperation::ChangesToNewBranch(MoveChangesToNewBranchOperation {
+            source_commit_id,
+            ..
+        }) => (vec![*source_commit_id], None),
+        MoveOperation::StackBranch(_) | MoveOperation::UnstackBranch(_) => return Ok(()),
+    };
+
+    for commit_id in source_commits {
+        merged.ensure_commit_not_merged(commit_id)?;
+    }
+    match target {
+        Some(MoveTarget::Commit { commit_id, .. }) => {
+            merged.ensure_commit_not_merged(*commit_id)?
+        }
+        Some(MoveTarget::BranchTip { name } | MoveTarget::BranchBucket { name, .. }) => {
+            merged.ensure_branch_not_merged(name.as_ref())?
+        }
+        None => {}
+    }
+    Ok(())
 }
 
 #[derive(Clone)]
@@ -373,6 +418,8 @@ fn resolve(
         sources,
         branch,
         unstack,
+        // Consumed by the caller when building the `MergedUpstream` guard.
+        allow_merged: _,
     } = args;
 
     let context_lines = ctx.settings.context_lines;

--- a/crates/but/src/command/legacy/push.rs
+++ b/crates/but/src/command/legacy/push.rs
@@ -7,11 +7,13 @@ use gitbutler_git::PushResult;
 use serde::Serialize;
 
 use crate::{
-    CliId, IdMap,
+    CliId, CliResultExt as _, IdMap,
     args::{push, push::Command},
     command::legacy::workspace_target,
     theme::{self, Paint},
-    utils::{OutputChannel, shorten_hex_object_id, shorten_object_id},
+    utils::{
+        OutputChannel, merged_upstream::MergedUpstream, shorten_hex_object_id, shorten_object_id,
+    },
 };
 
 /// Represents the result of branch selection when no branch is specified
@@ -73,6 +75,27 @@ pub async fn handle(
     } else {
         handle_no_branch_specified(ctx, out)?
     };
+
+    // Pushing a branch that already landed in the target recreates or rewrites
+    // remote state for work that is finished. The lower push layer silently
+    // skips branches with an integrated push status, but that misses branches
+    // that never had a remote; refuse explicitly-selected merged branches here.
+    {
+        let selected_branches = match &branch_selection {
+            BranchSelection::Single(name) => std::slice::from_ref(name),
+            BranchSelection::Multiple(names) => names.as_slice(),
+            BranchSelection::All | BranchSelection::None => &[],
+        };
+        if !selected_branches.is_empty() {
+            let merged = MergedUpstream::from_ctx(ctx, args.allow_merged)?;
+            for name in selected_branches {
+                let full_name = gix::refs::FullName::try_from(format!("refs/heads/{name}"))?;
+                merged
+                    .ensure_branch_not_merged(full_name.as_ref())
+                    .into_internal_error()?;
+            }
+        }
+    }
 
     // Handle branch selection
     match branch_selection {

--- a/crates/but/src/command/legacy/reword.rs
+++ b/crates/but/src/command/legacy/reword.rs
@@ -13,7 +13,7 @@ use crate::{
     CliResult, IdMap,
     args::atoms::{BranchArg, BranchOrCommit, CliIdArg, Purpose},
     bad_input, tui,
-    utils::{OutputChannel, get_change_id_for_commit},
+    utils::{OutputChannel, get_change_id_for_commit, merged_upstream::MergedUpstream},
 };
 
 pub(crate) fn reword_target(
@@ -23,6 +23,7 @@ pub(crate) fn reword_target(
     message: Option<&str>,
     format: bool,
     show_diff_in_editor: ShowDiffInEditor,
+    allow_merged: crate::args::atoms::AllowMergedArg,
 ) -> CliResult<()> {
     // Formats without an interactive editor must provide the new message up front.
     if message.is_none() && !format && !out.format().allows_human_ui() {
@@ -57,6 +58,9 @@ pub(crate) fn reword_target(
             edit_branch_name(ctx, &name, out, message, guard.write_permission())?;
         }
         BranchOrCommit::Commit(commit) => {
+            // Rewording a landed commit is lost work: the rewritten commit is
+            // dropped again on the next `but pull`.
+            MergedUpstream::from_ctx(ctx, allow_merged)?.ensure_commit_not_merged(commit)?;
             edit_commit_message_by_id_and_reword_commit(
                 ctx,
                 commit,

--- a/crates/but/src/command/legacy/squash.rs
+++ b/crates/but/src/command/legacy/squash.rs
@@ -26,7 +26,8 @@ use crate::{
     id::{CommittedFileId, UNCOMMITTED, UncommittedHunkOrFile},
     theme::{self, Theme},
     utils::{
-        CliOutput, CliOutputHuman, IntermediateChannel, WriteWithUtils, diff_specs::DiffSpecBuilder,
+        CliOutput, CliOutputHuman, IntermediateChannel, WriteWithUtils,
+        diff_specs::DiffSpecBuilder, merged_upstream::MergedUpstream,
     },
 };
 
@@ -150,21 +151,14 @@ pub fn squash(
     let mut guard = ctx.exclusive_worktree_access();
     let mut meta = ctx.meta()?;
     let id_map = IdMap::new_from_context(ctx, None, guard.read_permission())?;
-    let (repo, ws, _) = ctx.workspace_and_db_with_perm(guard.read_permission())?;
-    let head_info = but_workspace::head_info(
-        &repo,
-        &meta,
-        but_workspace::ref_info::Options {
-            project_meta: ctx.project_meta()?,
-            expensive_commit_info: false,
-            ..Default::default()
-        },
-    )?;
+    let head_info = but_api::legacy::workspace::head_info(ctx)?;
+    let merged = MergedUpstream::new(&*ctx.repo.get()?, &head_info, args.allow_merged);
 
+    let (repo, ws, _) = ctx.workspace_and_db_with_perm(guard.read_permission())?;
     let resolved_args = resolve_args(&repo, args, &id_map, &head_info)?;
     let resolved_args = resolved_args.as_ref();
 
-    let squash_op = resolve(resolved_args, &ws, &repo)?;
+    let squash_op = resolve(resolved_args, &ws, &repo, &merged)?;
 
     drop(repo);
     drop(ws);
@@ -185,6 +179,8 @@ fn resolve_args(
         no_message,
         use_target_message,
         use_source_message,
+        // Consumed by the caller when building the `MergedUpstream` guard.
+        allow_merged: _,
     } = args;
 
     let reword = resolve_reword(message, no_message, use_target_message, use_source_message);
@@ -306,6 +302,7 @@ pub fn resolve<'a>(
     args: ResolvedSquashArgsRef<'a>,
     ws: &Workspace,
     repo: &gix::Repository,
+    merged: &MergedUpstream,
 ) -> CliResult<SquashOperation<'a>> {
     let resolved_squash = match args {
         ResolvedSquashArgsRef::Normal { sources, target } => {
@@ -473,9 +470,57 @@ pub fn resolve<'a>(
         },
     };
 
+    ensure_not_touching_merged_upstream(&squash_op, merged)?;
+
     fix_up_unnecessary_reword_via_editor(&mut squash_op, repo)?;
 
     Ok(squash_op)
+}
+
+/// Reject operations whose sources or target have already landed in the
+/// target branch. This covers every entrypoint into the squash machinery:
+/// `squash`, `amend`, `uncommit`, and the status TUI.
+fn ensure_not_touching_merged_upstream(
+    op: &SquashOperation<'_>,
+    merged: &MergedUpstream,
+) -> CliResult<()> {
+    match op {
+        SquashOperation::Commits(SquashCommitsOperation {
+            sources, target, ..
+        }) => {
+            merged.ensure_commit_not_merged(*target)?;
+            for source in sources {
+                merged.ensure_commit_not_merged(*source)?;
+            }
+        }
+        SquashOperation::Branch(SquashBranchOperation {
+            sources, target, ..
+        }) => {
+            merged.ensure_commit_not_merged(*target)?;
+            for source in sources {
+                merged.ensure_commit_not_merged(*source)?;
+            }
+        }
+        SquashOperation::UncommittedHunks(AmendUncommittedHunks { target, .. })
+        | SquashOperation::Uncommitted { target, .. } => {
+            merged.ensure_commit_not_merged(*target)?;
+        }
+        SquashOperation::MoveCommittedFiles { target, source, .. } => {
+            merged.ensure_commit_not_merged(*target)?;
+            merged.ensure_commit_not_merged(*source)?;
+        }
+        SquashOperation::Uncommit(UncommitOperation { sources }) => {
+            for source in sources {
+                merged.ensure_commit_not_merged(*source)?;
+            }
+        }
+        SquashOperation::UncommitCommittedFiles(UncommitCommittedFilesOperation {
+            source, ..
+        }) => {
+            merged.ensure_commit_not_merged(*source)?;
+        }
+    }
+    Ok(())
 }
 
 fn cannot_uncommit_uncommitted_changes_error() -> CliError {

--- a/crates/but/src/command/legacy/status/tui/app/squash_mode.rs
+++ b/crates/but/src/command/legacy/status/tui/app/squash_mode.rs
@@ -9,7 +9,7 @@ use ratatui::{prelude::Backend, text::Span};
 
 use crate::{
     CliId, CliResultExt,
-    args::atoms::{BranchArg, ResolvedCliIdArgRef},
+    args::atoms::{AllowMergedArg, BranchArg, ResolvedCliIdArgRef},
     command::legacy::{
         reword2::RewordCommitOperation,
         squash::{
@@ -29,6 +29,7 @@ use crate::{
     },
     id::{BranchId, CommitId, CommittedFileId, UncommittedHunkOrFile},
     tui::TerminalGuard,
+    utils::merged_upstream::MergedUpstream,
 };
 
 use super::mark::{Marks, MarksRef};
@@ -439,10 +440,13 @@ impl App {
         };
 
         let mut guard = ctx.exclusive_worktree_access();
+        let head_info = but_api::legacy::workspace::head_info(ctx)?;
+        let merged = MergedUpstream::new(&*ctx.repo.get()?, &head_info, AllowMergedArg::default());
         let (repo, ws, _) = ctx.workspace_and_db_with_perm(guard.read_permission())?;
         let mut meta = ctx.meta()?;
 
-        let Some(squash_op) = resolve_squash_operation(source, target, *reword, &repo, &ws, &meta)?
+        let Some(squash_op) =
+            resolve_squash_operation(source, target, *reword, &repo, &ws, &head_info, &merged)?
         else {
             return Ok(());
         };
@@ -491,7 +495,8 @@ fn resolve_squash_operation<'a>(
     reword: SquashReword,
     repo: &gix::Repository,
     ws: &Workspace,
-    meta: &impl but_core::RefMetadata,
+    head_info: &but_workspace::RefInfo,
+    merged: &MergedUpstream,
 ) -> anyhow::Result<Option<SquashOperation<'a>>> {
     let Some(op) = source.route(target) else {
         return Ok(None);
@@ -513,7 +518,7 @@ fn resolve_squash_operation<'a>(
         SquashRoute::UncommittedToBranch { target } => {
             let source = Vec::from([ResolvedCliIdArgRef::Uncommitted]);
             let target = ResolvedCliIdArgRef::Branch(target);
-            resolve_squash_operation_with_branch(source, target, reword, repo, ws, meta)?
+            resolve_squash_operation_with_branch(source, target, reword, head_info)?
         }
         SquashRoute::UncommittedHunkToCommit { sources, target } => ResolvedSquashArgsRef::Normal {
             sources: sources
@@ -541,7 +546,7 @@ fn resolve_squash_operation<'a>(
                 .map(ResolvedCliIdArgRef::UncommittedHunkOrFile)
                 .collect();
             let target = ResolvedCliIdArgRef::Branch(target);
-            resolve_squash_operation_with_branch(source, target, reword, repo, ws, meta)?
+            resolve_squash_operation_with_branch(source, target, reword, head_info)?
         }
         SquashRoute::CommitToCommit { sources, target } => ResolvedSquashArgsRef::Normal {
             sources: sources
@@ -561,7 +566,7 @@ fn resolve_squash_operation<'a>(
                 .map(|branch| ResolvedCliIdArgRef::Branch(&branch.name))
                 .collect();
             let target = ResolvedCliIdArgRef::Commit(target, None);
-            resolve_squash_operation_with_branch(sources, target, reword, repo, ws, meta)?
+            resolve_squash_operation_with_branch(sources, target, reword, head_info)?
         }
         SquashRoute::BranchToBranch { sources, target } => {
             let sources = sources
@@ -569,7 +574,7 @@ fn resolve_squash_operation<'a>(
                 .map(|branch| ResolvedCliIdArgRef::Branch(&branch.name))
                 .collect();
             let target = ResolvedCliIdArgRef::Branch(target);
-            resolve_squash_operation_with_branch(sources, target, reword, repo, ws, meta)?
+            resolve_squash_operation_with_branch(sources, target, reword, head_info)?
         }
         SquashRoute::CommitToBranch { sources, target } => {
             let sources = sources
@@ -579,7 +584,7 @@ fn resolve_squash_operation<'a>(
                 })
                 .collect();
             let target = ResolvedCliIdArgRef::Branch(target);
-            resolve_squash_operation_with_branch(sources, target, reword, repo, ws, meta)?
+            resolve_squash_operation_with_branch(sources, target, reword, head_info)?
         }
         SquashRoute::CommittedFileToBranch { sources, target } => {
             let sources = sources
@@ -587,7 +592,7 @@ fn resolve_squash_operation<'a>(
                 .map(ResolvedCliIdArgRef::CommittedFile)
                 .collect();
             let target = ResolvedCliIdArgRef::Branch(target);
-            resolve_squash_operation_with_branch(sources, target, reword, repo, ws, meta)?
+            resolve_squash_operation_with_branch(sources, target, reword, head_info)?
         }
         SquashRoute::BranchToSelf { source } => {
             ResolvedSquashArgsRef::SingleBranchSourceAndTarget {
@@ -613,7 +618,7 @@ fn resolve_squash_operation<'a>(
         },
     };
 
-    let op = squash::resolve(resolved_args, ws, repo).into_internal_error()?;
+    let op = squash::resolve(resolved_args, ws, repo, merged).into_internal_error()?;
 
     Ok(Some(op))
 }
@@ -622,21 +627,9 @@ fn resolve_squash_operation_with_branch<'a>(
     sources: Vec<ResolvedCliIdArgRef<'a>>,
     target: ResolvedCliIdArgRef<'_>,
     reword: HowToRewordTarget,
-    repo: &gix::Repository,
-    ws: &Workspace,
-    meta: &impl but_core::RefMetadata,
+    head_info: &but_workspace::RefInfo,
 ) -> anyhow::Result<ResolvedSquashArgsRef<'a>> {
-    let head_info = but_workspace::head_info(
-        repo,
-        meta,
-        but_workspace::ref_info::Options {
-            project_meta: ws.graph.project_meta.clone(),
-            expensive_commit_info: false,
-            ..Default::default()
-        },
-    )?;
-
-    let target = resolve_target(target, reword, &head_info).map_err(|err| match err {
+    let target = resolve_target(target, reword, head_info).map_err(|err| match err {
         squash::ResolveTargetError::Other(err) => err,
         other => {
             anyhow::anyhow!("BUG: failed to compute squash target: {other:?}")

--- a/crates/but/src/command/legacy/uncommit.rs
+++ b/crates/but/src/command/legacy/uncommit.rs
@@ -15,7 +15,10 @@ use crate::{
     },
     command::legacy::squash::{self, ResolvedSquashArgsRef, SquashOperation, SquashTarget},
     theme::Theme,
-    utils::{CliOutput, CliOutputHuman, IntermediateChannel, WriteWithUtils},
+    utils::{
+        CliOutput, CliOutputHuman, IntermediateChannel, WriteWithUtils,
+        merged_upstream::MergedUpstream,
+    },
 };
 
 pub fn uncommit(
@@ -27,8 +30,10 @@ pub fn uncommit(
     let mut meta = ctx.meta()?;
     let id_map = IdMap::new_from_context(ctx, None, guard.read_permission())?;
 
+    let merged = MergedUpstream::from_ctx(ctx, args.allow_merged)?;
+
     let (repo, ws, _) = ctx.workspace_and_db_with_perm(guard.read_permission())?;
-    let op = resolve(args, &ws, &repo, &id_map)?;
+    let op = resolve(args, &ws, &repo, &id_map, &merged)?;
     drop(repo);
     drop(ws);
 
@@ -40,8 +45,12 @@ fn resolve(
     ws: &Workspace,
     repo: &gix::Repository,
     id_map: &IdMap,
+    merged: &MergedUpstream,
 ) -> CliResult<SquashOperation<'static>> {
-    let Platform { sources } = args;
+    let Platform {
+        sources,
+        allow_merged: _,
+    } = args;
 
     let sources = sources
         .into_iter()
@@ -59,5 +68,5 @@ fn resolve(
         target: SquashTarget::Uncommitted,
     };
 
-    Ok(squash::resolve(squash_args, ws, repo)?.into_fully_owned())
+    Ok(squash::resolve(squash_args, ws, repo, merged)?.into_fully_owned())
 }

--- a/crates/but/src/error.rs
+++ b/crates/but/src/error.rs
@@ -64,11 +64,12 @@ pub(crate) fn bad_input<S: AsRef<str>>(message: S) -> BadInput {
     BadInput::new(message)
 }
 
+// The `Error: ` prefix is added by the consumer: `print_and_exit_non_zero`
+// for directly printed errors, and anyhow's termination handler for errors
+// converted via `into_internal`. Embedding it here would double it up.
 impl Display for BadInput {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let t = theme::get();
-
-        write!(f, "{}", t.error.paint("Error: "))?;
 
         match (&self.arg_name, &self.arg_value) {
             (Some(name), Some(value)) => {

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -377,7 +377,7 @@ fn print_err_infallible<T: std::fmt::Display>(err: T) {
 }
 
 fn print_and_exit_non_zero<T: std::fmt::Display>(err: T) -> ! {
-    print_err_infallible(err);
+    print_err_infallible(format!("{}{err}", theme::get().error.paint("Error: ")));
     std::process::exit(1)
 }
 
@@ -1103,6 +1103,7 @@ async fn match_subcommand(
             format,
             diff,
             no_diff,
+            allow_merged,
         } => {
             let status_after = args.status_after;
             let mut ctx = setup::init_ctx(
@@ -1123,6 +1124,7 @@ async fn match_subcommand(
                 // clap's `conflicts_with` should prevent this being `None` but better safe than
                 // sorry
                 ShowDiffInEditor::from_args(diff, no_diff).unwrap_or(ShowDiffInEditor::Unspecified),
+                allow_merged,
             )
             .emit_metrics(metrics_ctx);
             run_status_after_if_ok(status_after, &result, &mut ctx, out);
@@ -1175,7 +1177,11 @@ async fn match_subcommand(
                 .map_err(CliError::from)
         }
         #[cfg(feature = "legacy")]
-        Subcommands::Absorb { source, dry_run } => {
+        Subcommands::Absorb {
+            source,
+            dry_run,
+            allow_merged,
+        } => {
             let status_after = args.status_after;
             let mut ctx = setup::init_ctx(
                 &args,
@@ -1187,8 +1193,14 @@ async fn match_subcommand(
             )?;
             out.begin_status_after(status_after);
             let conflicts_before = command::legacy::conflict_notice::snapshot(&ctx);
-            let result = command::legacy::absorb::handle(&mut ctx, out, source.as_deref(), dry_run)
-                .emit_metrics(metrics_ctx);
+            let result = command::legacy::absorb::handle(
+                &mut ctx,
+                out,
+                source.as_deref(),
+                dry_run,
+                allow_merged,
+            )
+            .emit_metrics(metrics_ctx);
             if result.is_ok() {
                 command::legacy::conflict_notice::report_newly_conflicted(
                     &ctx,

--- a/crates/but/src/utils/merged_upstream.rs
+++ b/crates/but/src/utils/merged_upstream.rs
@@ -1,0 +1,190 @@
+//! A shared guard against mutating history that has already landed in the
+//! target branch.
+//!
+//! Commands that rewrite commits or add work to branches build a
+//! [`MergedUpstream`] once and validate their targets against it. Amending,
+//! squashing into, or uncommitting a landed commit produces content that
+//! upstream-integration detection no longer recognizes, so the duplicated
+//! work resurfaces as conflicts on the next `but pull`.
+
+use but_workspace::{
+    RefInfo,
+    ref_info::{LocalCommitRelation, Segment},
+    ui::PushStatus,
+};
+use gix::refs::{FullName, FullNameRef};
+
+use crate::{CliResult, args::atoms::AllowMergedArg, bad_input};
+
+/// The shared hint for refused operations: pulling is almost always the right
+/// fix, the escape hatch is for the rare deliberate case.
+const PULL_FIRST_HINT: &str = "Most likely you want `but pull`, which updates the workspace and removes landed work. \
+     In rare cases `--allow-merged` can bypass this check";
+
+/// The branches and commits of the workspace that have already landed in the
+/// target branch. Mirrors the strongest signals behind the `(merged upstream)`
+/// marker in `but status`, using only data present on [`RefInfo`] segments.
+pub struct MergedUpstream {
+    integrated_commits: gix::hashtable::HashSet<gix::ObjectId>,
+    merged_branches: std::collections::BTreeSet<FullName>,
+}
+
+impl MergedUpstream {
+    /// Build the guard from the canonical workspace view, the same
+    /// [`but_api::legacy::workspace::head_info`] that `but commit` and the GUI
+    /// use. When `--allow-merged` was passed, the guard is permissive and
+    /// every check passes; the workspace query is skipped entirely.
+    ///
+    /// Acquires no worktree guard, so this is safe to call while one is held.
+    pub fn from_ctx(ctx: &but_ctx::Context, allow_merged: AllowMergedArg) -> anyhow::Result<Self> {
+        if allow_merged.allow_merged {
+            return Ok(Self::permissive());
+        }
+        let head_info = but_api::legacy::workspace::head_info(ctx)?;
+        Ok(Self::new(&*ctx.repo.get()?, &head_info, allow_merged))
+    }
+
+    /// Collect merged branches and integrated commits from `head_info`, for
+    /// callers that already computed it. When `--allow-merged` was passed, the
+    /// guard is permissive and every check passes.
+    ///
+    /// `repo` is only read to classify empty branches, whose merged state
+    /// cannot be derived from `head_info` alone.
+    pub fn new(repo: &gix::Repository, head_info: &RefInfo, allow_merged: AllowMergedArg) -> Self {
+        let mut this = Self::permissive();
+        if allow_merged.allow_merged {
+            return this;
+        }
+        for segment in head_info.stacks.iter().flat_map(|stack| &stack.segments) {
+            if segment_is_merged_upstream(segment)
+                && let Some(ref_info) = &segment.ref_info
+            {
+                this.merged_branches.insert(ref_info.ref_name.clone());
+            }
+            for commit in &segment.commits {
+                if matches!(commit.relation, LocalCommitRelation::Integrated(_)) {
+                    this.integrated_commits.insert(commit.id);
+                }
+            }
+        }
+        this.collect_merged_empty_branches(repo, head_info);
+        this
+    }
+
+    /// Empty segments have no commits to classify, so detect landed ones the
+    /// way `but status` does: their remote tip is reachable from the target
+    /// tip. Only the bottom-most segment of each stack is considered — it
+    /// rests on the workspace base, where ancestry is meaningful. Best-effort:
+    /// lookup failures leave the branch unguarded rather than erroring.
+    fn collect_merged_empty_branches(&mut self, repo: &gix::Repository, head_info: &RefInfo) {
+        fn peel(repo: &gix::Repository, name: &FullNameRef) -> Option<gix::ObjectId> {
+            repo.try_find_reference(name)
+                .ok()
+                .flatten()
+                .and_then(|mut reference| reference.peel_to_id().ok())
+                .map(|id| id.detach())
+        }
+
+        let target_ref_name = head_info
+            .target_ref
+            .as_ref()
+            .map(|target| target.ref_name.as_ref());
+        let Some(target_tip) = target_ref_name.and_then(|name| peel(repo, name)) else {
+            return;
+        };
+        let stored_target_base = head_info
+            .target_commit
+            .as_ref()
+            .map(|target| target.commit_id);
+
+        for stack in &head_info.stacks {
+            let Some(segment) = stack
+                .segments
+                .last()
+                .filter(|segment| segment.commits.is_empty())
+            else {
+                continue;
+            };
+            let (Some(ref_info), Some(remote_ref_name)) =
+                (&segment.ref_info, segment.remote_tracking_ref_name.as_ref())
+            else {
+                continue;
+            };
+            if Some(remote_ref_name.as_ref()) == target_ref_name {
+                continue;
+            }
+            let Some(remote_tip) = peel(repo, remote_ref_name.as_ref()) else {
+                continue;
+            };
+            // A fresh empty branch pushed while sitting at the (possibly stale)
+            // base is trivially an ancestor of the target without having landed.
+            if stored_target_base == Some(remote_tip) && remote_tip != target_tip {
+                continue;
+            }
+            if repo
+                .merge_base(remote_tip, target_tip)
+                .is_ok_and(|merge_base| merge_base.detach() == remote_tip)
+            {
+                self.merged_branches.insert(ref_info.ref_name.clone());
+            }
+        }
+    }
+
+    fn permissive() -> Self {
+        Self {
+            integrated_commits: Default::default(),
+            merged_branches: Default::default(),
+        }
+    }
+
+    /// Whether `commit_id` has landed in the target branch.
+    pub fn contains_commit(&self, commit_id: gix::ObjectId) -> bool {
+        self.integrated_commits.contains(&commit_id)
+    }
+
+    /// Whether the branch at the head of this segment has landed in the target branch.
+    pub fn contains_segment(&self, segment: &Segment) -> bool {
+        segment
+            .ref_info
+            .as_ref()
+            .is_some_and(|ref_info| self.merged_branches.contains(&ref_info.ref_name))
+    }
+
+    /// Reject `commit_id` as a mutation source or target if it has landed.
+    pub fn ensure_commit_not_merged(&self, commit_id: gix::ObjectId) -> CliResult<()> {
+        if self.contains_commit(commit_id) {
+            return Err(bad_input(format!(
+                "Commit {} is merged upstream",
+                commit_id.to_hex_with_len(7)
+            ))
+            .hint(PULL_FIRST_HINT)
+            .into());
+        }
+        Ok(())
+    }
+
+    /// Reject the branch `name` as a mutation or push target if it has landed.
+    pub fn ensure_branch_not_merged(&self, name: &FullNameRef) -> CliResult<()> {
+        if self.merged_branches.contains(name) {
+            return Err(
+                bad_input(format!("Branch '{}' is merged upstream", name.shorten()))
+                    .hint(PULL_FIRST_HINT)
+                    .into(),
+            );
+        }
+        Ok(())
+    }
+}
+
+/// Whether the branch at the tip of this segment has already landed in the
+/// target branch, using the same signals as the `(merged upstream)` marker in
+/// `but status`. The push-status check looks redundant with the commit
+/// relation today, but keeps the guard aligned should its derivation grow
+/// more inputs.
+fn segment_is_merged_upstream(segment: &Segment) -> bool {
+    matches!(segment.push_status, PushStatus::Integrated)
+        || segment
+            .commits
+            .first()
+            .is_some_and(|commit| matches!(commit.relation, LocalCommitRelation::Integrated(_)))
+}

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -868,6 +868,7 @@ mod tests {
                 below: None,
                 unstack: false,
                 sources: Vec::from([CliIdArg("ci".to_owned())]),
+                allow_merged: Default::default(),
             }),
             "move",
         );
@@ -888,6 +889,7 @@ mod tests {
                 Subcommands::Amend(crate::args::amend::Platform {
                     target: CliIdArg("c1".into()),
                     sources: vec![CliIdArg("a1".into())],
+                    allow_merged: Default::default(),
                 }),
                 "amend",
             );
@@ -904,6 +906,7 @@ mod tests {
                 below: None,
                 unstack: false,
                 sources: Vec::from([CliIdArg("ci".to_owned())]),
+                allow_merged: Default::default(),
             });
             let props = moved.to_metrics_extra_props();
             assert_eq!(

--- a/crates/but/src/utils/mod.rs
+++ b/crates/but/src/utils/mod.rs
@@ -25,6 +25,8 @@ pub mod time;
 
 pub(crate) mod binary_path;
 pub(crate) mod diff_specs;
+#[cfg(feature = "legacy")]
+pub(crate) mod merged_upstream;
 pub(crate) mod targeting;
 
 pub mod diff_rendering;

--- a/crates/but/tests/but/command/absorb.rs
+++ b/crates/but/tests/but/command/absorb.rs
@@ -600,3 +600,102 @@ fn workspace_head_is_refreshed_after_absorb() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn absorb_skips_merged_upstream_commits() {
+    let env =
+        Sandbox::init_scenario_with_target_and_default_settings("upstream-integrated-with-updates");
+    env.setup_metadata_at_target(&["A", "B"], "refs/heads/base");
+
+    // This change depends on branch A's commit, whose content already landed
+    // on origin/main; absorb must not amend it.
+    env.file("file-a.txt", "change-A-modified\n");
+
+    env.but("absorb")
+        .env("NO_BG_TASKS", "1")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Skipped: not absorbing into 756ee31 A-change: commit is merged upstream
+Hint: most likely you want `but pull`, which removes landed work; in rare cases pass --allow-merged to absorb anyway
+Nothing left to absorb
+
+"#]]);
+}
+
+#[test]
+fn absorb_json_reports_skipped_merged_upstream_commits_on_stderr() {
+    let env =
+        Sandbox::init_scenario_with_target_and_default_settings("upstream-integrated-with-updates");
+    env.setup_metadata_at_target(&["A", "B"], "refs/heads/base");
+    env.file("file-a.txt", "change-A-modified\n");
+
+    env.but("--json absorb")
+        .allow_json()
+        .env("NO_BG_TASKS", "1")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+{
+  "ok": false,
+  "skippedMergedUpstream": [
+    "756ee31783c2adf1542abe10ea254866d1464983"
+  ]
+}
+
+"#]])
+        .stderr_eq(str![[r#"
+warning: skipped absorbing into 1 merged-upstream commit(s): 756ee31. Run `but pull` to update the workspace, or pass --allow-merged to absorb anyway.
+
+"#]]);
+}
+
+#[test]
+fn absorb_json_reports_partially_skipped_merged_upstream_commits() {
+    let env =
+        Sandbox::init_scenario_with_target_and_default_settings("upstream-integrated-with-updates");
+    env.setup_metadata_at_target(&["A", "B"], "refs/heads/base");
+    // file-a.txt depends on branch A's landed commit (skipped); file-b.txt on
+    // branch B's live commit (absorbed).
+    env.file("file-a.txt", "change-A-modified\n");
+    env.file("file-b.txt", "change-B-modified\n");
+
+    env.but("--json absorb")
+        .allow_json()
+        .env("NO_BG_TASKS", "1")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+{
+  "ok": true,
+  "rejected": 0,
+  "plan": {
+    "total_files": 1,
+    "commits": [
+      {
+        "commit_id": "536958e9343fce0fa27fd4d51f88317cca5ff78f",
+        "commit_summary": "B-change",
+        "reason": "hunk_dependency",
+        "reason_description": "files locked to commit due to hunk range overlap",
+        "files": [
+          {
+            "path": "file-b.txt",
+            "hunks": [
+              "@1,1 +1,1"
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "skippedMergedUpstream": [
+    "756ee31783c2adf1542abe10ea254866d1464983"
+  ]
+}
+
+"#]])
+        .stderr_eq(str![[r#"
+warning: skipped absorbing into 1 merged-upstream commit(s): 756ee31. Run `but pull` to update the workspace, or pass --allow-merged to absorb anyway.
+
+"#]]);
+}

--- a/crates/but/tests/but/command/amend.rs
+++ b/crates/but/tests/but/command/amend.rs
@@ -124,3 +124,74 @@ Amended [..] to create [..]
 
     Ok(())
 }
+
+#[test]
+fn amend_rejects_merged_upstream_commit() {
+    let env =
+        Sandbox::init_scenario_with_target_and_default_settings("upstream-integrated-with-updates");
+    env.setup_metadata_at_target(&["A", "B"], "refs/heads/base");
+    env.file("file.txt", "Some text");
+
+    let status = status_json(&env).unwrap();
+    let source = status["uncommittedChanges"][0]["cliId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // `nyq` is branch A's commit, whose content already landed on origin/main.
+    env.but(format!("amend -t nyq {source}"))
+        .env("NO_BG_TASKS", "1")
+        .assert()
+        .failure()
+        .stdout_eq(str![])
+        .stderr_eq(str![[r#"
+Error: Commit 756ee31 is merged upstream
+
+Hint: Most likely you want `but pull`, which updates the workspace and removes landed work. In rare cases `--allow-merged` can bypass this check
+
+"#]]);
+
+    // The escape hatch permits amending landed commits regardless.
+    env.but(format!("amend -t nyq {source} --allow-merged"))
+        .env("NO_BG_TASKS", "1")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+Amended 756ee31 to create f18cbfd
+
+"#]]);
+}
+
+#[test]
+fn amend_rejects_landed_commit_in_partially_integrated_stack() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings(
+        "pull-partially-integrated-multi-branch-stack",
+    );
+    env.setup_single_stack_metadata_at_target(&["A", "C"], "refs/heads/base")
+        .unwrap();
+    env.file("file.txt", "Some text");
+
+    let status = status_json(&env).unwrap();
+    let source = status["uncommittedChanges"][0]["cliId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let landed_bottom = branch_commit_cli_ids(&status, "C")
+        .pop()
+        .expect("branch C has a commit");
+
+    // Branch C at the bottom of the stack has landed while A on top is live;
+    // the landed commit alone must be refused.
+    env.but(format!("amend -t {landed_bottom} {source}"))
+        .env("NO_BG_TASKS", "1")
+        .assert()
+        .failure()
+        .stdout_eq(str![])
+        .stderr_eq(str![[r#"
+Error: Commit e5378e0 is merged upstream
+
+Hint: Most likely you want `but pull`, which updates the workspace and removes landed work. In rare cases `--allow-merged` can bypass this check
+
+"#]]);
+}

--- a/crates/but/tests/but/command/commit.rs
+++ b/crates/but/tests/but/command/commit.rs
@@ -1962,3 +1962,171 @@ Hint: run `but help` for all commands
 
 "#]]);
 }
+
+#[test]
+fn branch_flag_rejects_merged_upstream_branch() {
+    let env =
+        Sandbox::init_scenario_with_target_and_default_settings("upstream-integrated-with-updates");
+    env.setup_metadata_at_target(&["A", "B"], "refs/heads/base");
+    env.file("file.txt", "Some text");
+
+    env.but("commit --no-message --branch A")
+        .env("NO_BG_TASKS", "1")
+        .assert()
+        .failure()
+        .stdout_eq(snapbox::str![])
+        .stderr_eq(snapbox::str![[r#"
+Error: Branch 'A' is merged upstream
+
+Hint: Most likely you want `but pull`, which updates the workspace and removes landed work. In rare cases `--allow-merged` can bypass this check
+
+"#]]);
+}
+
+#[test]
+fn default_target_skips_merged_upstream_branch() {
+    let env =
+        Sandbox::init_scenario_with_target_and_default_settings("upstream-integrated-with-updates");
+    env.setup_metadata_at_target(&["A", "B"], "refs/heads/base");
+    env.file("file.txt", "Some text");
+
+    // A has landed upstream, so the commit goes to B without prompting.
+    env.but("commit --no-message")
+        .env("NO_BG_TASKS", "1")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Created commit e4531e0 on branch 'B'
+
+"#]]);
+}
+
+#[test]
+fn default_target_creates_new_branch_when_all_branches_merged_upstream() {
+    let env =
+        Sandbox::init_scenario_with_target_and_default_settings("upstream-integrated-single-stack");
+    env.setup_metadata_at_target(&["A"], "refs/heads/base");
+    env.file("file.txt", "Some text");
+
+    // The only branch has landed upstream, so the commit starts a new branch.
+    env.but("commit --no-message")
+        .env("NO_BG_TASKS", "1")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Created commit b9049c6 on new branch 'a-branch-1'
+
+"#]]);
+}
+
+#[test]
+fn above_below_reject_merged_upstream_targets() {
+    let env =
+        Sandbox::init_scenario_with_target_and_default_settings("upstream-integrated-with-updates");
+    env.setup_metadata_at_target(&["A", "B"], "refs/heads/base");
+    env.file("file.txt", "Some text");
+
+    // `nyq` is branch A's commit, whose content already landed on origin/main.
+    env.but("commit --no-message --below nyq")
+        .env("NO_BG_TASKS", "1")
+        .assert()
+        .failure()
+        .stdout_eq(snapbox::str![])
+        .stderr_eq(snapbox::str![[r#"
+Error: Commit 756ee31 is merged upstream
+
+Hint: Most likely you want `but pull`, which updates the workspace and removes landed work. In rare cases `--allow-merged` can bypass this check
+
+"#]]);
+
+    env.but("commit --no-message --above A")
+        .env("NO_BG_TASKS", "1")
+        .assert()
+        .failure()
+        .stdout_eq(snapbox::str![])
+        .stderr_eq(snapbox::str![[r#"
+Error: Branch 'A' is merged upstream
+
+Hint: Most likely you want `but pull`, which updates the workspace and removes landed work. In rare cases `--allow-merged` can bypass this check
+
+"#]]);
+}
+
+#[test]
+fn branch_flag_with_allow_merged_permits_merged_upstream_branch() {
+    let env =
+        Sandbox::init_scenario_with_target_and_default_settings("upstream-integrated-with-updates");
+    env.setup_metadata_at_target(&["A", "B"], "refs/heads/base");
+    env.file("file.txt", "Some text");
+
+    env.but("commit --no-message --branch A --allow-merged")
+        .env("NO_BG_TASKS", "1")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+Created commit db11aaa on branch 'A'
+
+"#]]);
+}
+
+#[test]
+fn partially_integrated_stack_guards_only_the_landed_commit() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings(
+        "pull-partially-integrated-multi-branch-stack",
+    );
+    env.setup_single_stack_metadata_at_target(&["A", "C"], "refs/heads/base")
+        .unwrap();
+    env.file("file.txt", "Some text");
+
+    // Branch C at the bottom has landed; branch A on top is live. Committing
+    // to the live tip must still work.
+    env.but("commit --no-message --branch A")
+        .env("NO_BG_TASKS", "1")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+Created commit aff34b9 on branch 'A'
+
+"#]]);
+
+    // The landed bottom branch stays refused.
+    env.but("commit --no-message --branch C")
+        .env("NO_BG_TASKS", "1")
+        .assert()
+        .failure()
+        .stdout_eq(snapbox::str![])
+        .stderr_eq(snapbox::str![[r#"
+Error: Branch 'C' is merged upstream
+
+Hint: Most likely you want `but pull`, which updates the workspace and removes landed work. In rare cases `--allow-merged` can bypass this check
+
+"#]]);
+}
+
+#[test]
+fn branch_flag_rejects_empty_merged_upstream_branch() {
+    let env =
+        Sandbox::init_scenario_with_target_and_default_settings("upstream-merged-empty-branch");
+
+    env.but("apply origin/document-but-pr-skill")
+        .env("NO_BG_TASKS", "1")
+        .assert()
+        .success();
+    env.file("file.txt", "Some text");
+
+    // The applied branch has no local commits, but its remote tip has been
+    // merged into the target; status marks it `(merged upstream)`.
+    env.but("commit --no-message --branch document-but-pr-skill")
+        .env("NO_BG_TASKS", "1")
+        .assert()
+        .failure()
+        .stdout_eq(snapbox::str![])
+        .stderr_eq(snapbox::str![[r#"
+Error: Branch 'document-but-pr-skill' is merged upstream
+
+Hint: Most likely you want `but pull`, which updates the workspace and removes landed work. In rare cases `--allow-merged` can bypass this check
+
+"#]]);
+}

--- a/crates/but/tests/but/command/move.rs
+++ b/crates/but/tests/but/command/move.rs
@@ -2649,3 +2649,36 @@ Moved [..] above commit [..]
 
     Ok(())
 }
+
+#[test]
+fn move_rejects_merged_upstream_commits() {
+    let env =
+        Sandbox::init_scenario_with_target_and_default_settings("upstream-integrated-with-updates");
+    env.setup_metadata_at_target(&["A", "B"], "refs/heads/base");
+
+    // `nyq` is branch A's landed commit, `kyl` is branch B's live commit.
+    // Landed history is rejected both as move source and as target branch.
+    env.but("move nyq --branch B")
+        .env("NO_BG_TASKS", "1")
+        .assert()
+        .failure()
+        .stdout_eq(snapbox::str![])
+        .stderr_eq(snapbox::str![[r#"
+Error: Commit 756ee31 is merged upstream
+
+Hint: Most likely you want `but pull`, which updates the workspace and removes landed work. In rare cases `--allow-merged` can bypass this check
+
+"#]]);
+
+    env.but("move kyl --branch A")
+        .env("NO_BG_TASKS", "1")
+        .assert()
+        .failure()
+        .stdout_eq(snapbox::str![])
+        .stderr_eq(snapbox::str![[r#"
+Error: Branch 'A' is merged upstream
+
+Hint: Most likely you want `but pull`, which updates the workspace and removes landed work. In rare cases `--allow-merged` can bypass this check
+
+"#]]);
+}

--- a/crates/but/tests/but/command/pull.rs
+++ b/crates/but/tests/but/command/pull.rs
@@ -1,11 +1,3 @@
-use std::ops::DerefMut;
-
-use but_core::{
-    RefMetadata, WORKSPACE_REF_NAME,
-    ref_metadata::{
-        ProjectMeta, StackId, WorkspaceCommitRelation, WorkspaceStack, WorkspaceStackBranch,
-    },
-};
 use snapbox::str;
 
 use crate::utils::{CommandExt, Sandbox};
@@ -88,7 +80,7 @@ fn pull_prunes_integrated_branch_from_partial_stack() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings(
         "pull-partially-integrated-multi-branch-stack",
     );
-    setup_single_stack_metadata_at_target(&env, &["A", "C"], "refs/heads/base")?;
+    env.setup_single_stack_metadata_at_target(&["A", "C"], "refs/heads/base")?;
 
     env.but("status").assert().success().stdout_eq(str![[r#"
 ╭┄ zz [uncommitted] (no changes)
@@ -146,7 +138,7 @@ fn pull_keeps_empty_branch_above_merged_branch() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings(
         "upstream-merged-branch-below-empty-branch",
     );
-    setup_single_stack_metadata_at_target(&env, &["top", "bottom"], "refs/heads/main")?;
+    env.setup_single_stack_metadata_at_target(&["top", "bottom"], "refs/heads/main")?;
     env.invoke_git("remote set-url origin .");
 
     env.but("pull").assert().success();
@@ -173,7 +165,7 @@ fn pull_check_uses_workspace_dry_run_for_partial_stack() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings(
         "pull-partially-integrated-multi-branch-stack",
     );
-    setup_single_stack_metadata_at_target(&env, &["A", "C"], "refs/heads/base")?;
+    env.setup_single_stack_metadata_at_target(&["A", "C"], "refs/heads/base")?;
 
     env.but("status").assert().success().stdout_eq(str![[r#"
 ╭┄ zz [uncommitted] (no changes)
@@ -523,7 +515,7 @@ fn pull_reports_conflict_in_lower_branch_of_stack() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings(
         "pull-conflict-in-lower-branch-of-stack",
     );
-    setup_single_stack_metadata_at_target(&env, &["A", "B"], "main")?;
+    env.setup_single_stack_metadata_at_target(&["A", "B"], "main")?;
 
     env.but("status").assert().success().stdout_eq(str![[r#"
 ╭┄ zz [uncommitted] (no changes)
@@ -591,7 +583,7 @@ fn pull_reports_conflicts_in_multiple_branches_of_stack() -> anyhow::Result<()> 
     let env = Sandbox::init_scenario_with_target_and_default_settings(
         "pull-conflicts-in-both-branches-of-stack",
     );
-    setup_single_stack_metadata_at_target(&env, &["A", "B"], "main")?;
+    env.setup_single_stack_metadata_at_target(&["A", "B"], "main")?;
 
     env.but("status").assert().success().stdout_eq(str![[r#"
 ╭┄ zz [uncommitted] (no changes)
@@ -711,33 +703,6 @@ To update anyway, park them on a temporary commit first:
     Ok(())
 }
 
-fn setup_single_stack_metadata_at_target(
-    env: &Sandbox,
-    branch_names: &[&str],
-    target_spec: &str,
-) -> anyhow::Result<()> {
-    let mut meta = env.meta();
-    let mut ws = meta.workspace(r(WORKSPACE_REF_NAME))?;
-    let repo = env.open_repo();
-    let ws_data = ws.deref_mut();
-    ws_data.stacks = vec![WorkspaceStack {
-        id: StackId::from_number_for_testing(0),
-        branches: branch_names
-            .iter()
-            .map(|branch_name| WorkspaceStackBranch {
-                ref_name: r(&format!("refs/heads/{branch_name}")).to_owned(),
-                archived: false,
-            })
-            .collect(),
-        workspacecommit_relation: WorkspaceCommitRelation::Merged,
-    }];
-    let mut project_meta = ProjectMeta::resolve(&repo)?;
-    project_meta.target_commit_id = Some(repo.rev_parse_single(target_spec)?.detach());
-    meta.set_workspace(&ws)?;
-    project_meta.persist(&repo)?;
-    Ok(())
-}
-
 fn git_ref_exists(env: &Sandbox, ref_name: &str) -> anyhow::Result<bool> {
     Ok(env.open_repo().try_find_reference(ref_name)?.is_some())
 }
@@ -756,10 +721,6 @@ fn rev_parse_all(env: &Sandbox, spec: &str) -> anyhow::Result<Vec<String>> {
         .lines()
         .map(str::to_owned)
         .collect())
-}
-
-fn r(name: &str) -> &gix::refs::FullNameRef {
-    name.try_into().expect("statically known valid ref-name")
 }
 
 fn status_stack_count(env: &Sandbox) -> anyhow::Result<usize> {

--- a/crates/but/tests/but/command/push.rs
+++ b/crates/but/tests/but/command/push.rs
@@ -147,3 +147,25 @@ Please resolve conflicts before pushing using 'but resolve <commit>'.
 
     Ok(())
 }
+
+#[test]
+fn push_rejects_merged_upstream_branch() {
+    let env =
+        Sandbox::init_scenario_with_target_and_default_settings("upstream-integrated-with-updates");
+    env.setup_metadata_at_target(&["A", "B"], "refs/heads/base");
+
+    // Branch A's content already landed on origin/main; pushing it would
+    // publish finished work to a branch nobody needs anymore.
+    env.but("push A")
+        .env("NO_BG_TASKS", "1")
+        .assert()
+        .failure()
+        .stdout_eq(snapbox::str![])
+        .stderr_eq(snapbox::str![[r#"
+Error: Branch 'A' is merged upstream
+
+Hint: Most likely you want `but pull`, which updates the workspace and removes landed work. In rare cases `--allow-merged` can bypass this check
+
+
+"#]]);
+}

--- a/crates/but/tests/but/command/reword.rs
+++ b/crates/but/tests/but/command/reword.rs
@@ -282,3 +282,23 @@ fn reword_commit_json_can_request_status_after() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn reword_rejects_merged_upstream_commit() {
+    let env =
+        Sandbox::init_scenario_with_target_and_default_settings("upstream-integrated-with-updates");
+    env.setup_metadata_at_target(&["A", "B"], "refs/heads/base");
+
+    // `nyq` is branch A's commit, whose content already landed on origin/main.
+    env.but("reword nyq -m 'new message'")
+        .env("NO_BG_TASKS", "1")
+        .assert()
+        .failure()
+        .stdout_eq(str![])
+        .stderr_eq(str![[r#"
+Error: Commit 756ee31 is merged upstream
+
+Hint: Most likely you want `but pull`, which updates the workspace and removes landed work. In rare cases `--allow-merged` can bypass this check
+
+"#]]);
+}

--- a/crates/but/tests/but/command/squash.rs
+++ b/crates/but/tests/but/command/squash.rs
@@ -2504,3 +2504,36 @@ Hint: run `but help` for all commands
 
 "#]]);
 }
+
+#[test]
+fn squash_rejects_merged_upstream_commits() {
+    let env =
+        Sandbox::init_scenario_with_target_and_default_settings("upstream-integrated-with-updates");
+    env.setup_metadata_at_target(&["A", "B"], "refs/heads/base");
+
+    // `nyq` is branch A's landed commit, `kyl` is branch B's live commit.
+    // Landed commits are rejected both as source and as target.
+    env.but("squash nyq --target kyl --use-target-message")
+        .env("NO_BG_TASKS", "1")
+        .assert()
+        .failure()
+        .stdout_eq(str![])
+        .stderr_eq(str![[r#"
+Error: Commit 756ee31 is merged upstream
+
+Hint: Most likely you want `but pull`, which updates the workspace and removes landed work. In rare cases `--allow-merged` can bypass this check
+
+"#]]);
+
+    env.but("squash kyl --target nyq --use-target-message")
+        .env("NO_BG_TASKS", "1")
+        .assert()
+        .failure()
+        .stdout_eq(str![])
+        .stderr_eq(str![[r#"
+Error: Commit 756ee31 is merged upstream
+
+Hint: Most likely you want `but pull`, which updates the workspace and removes landed work. In rare cases `--allow-merged` can bypass this check
+
+"#]]);
+}

--- a/crates/but/tests/but/command/uncommit.rs
+++ b/crates/but/tests/but/command/uncommit.rs
@@ -208,3 +208,23 @@ fn uncommit_command_on_commit() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn uncommit_rejects_merged_upstream_commit() {
+    let env =
+        Sandbox::init_scenario_with_target_and_default_settings("upstream-integrated-with-updates");
+    env.setup_metadata_at_target(&["A", "B"], "refs/heads/base");
+
+    // `nyq` is branch A's commit, whose content already landed on origin/main.
+    env.but("uncommit nyq")
+        .env("NO_BG_TASKS", "1")
+        .assert()
+        .failure()
+        .stdout_eq(snapbox::str![])
+        .stderr_eq(snapbox::str![[r#"
+Error: Commit 756ee31 is merged upstream
+
+Hint: Most likely you want `but pull`, which updates the workspace and removes landed work. In rare cases `--allow-merged` can bypass this check
+
+"#]]);
+}

--- a/crates/but/tests/but/utils.rs
+++ b/crates/but/tests/but/utils.rs
@@ -111,6 +111,46 @@ impl Sandbox {
         self.inner.set_target_sha(target_spec);
         stack_ids
     }
+
+    /// Create metadata for a single stack holding all of `branch_names`
+    /// (topmost first), then pin the workspace target to `target_spec`.
+    pub fn setup_single_stack_metadata_at_target(
+        &self,
+        branch_names: &[&str],
+        target_spec: &str,
+    ) -> anyhow::Result<()> {
+        use but_core::{
+            RefMetadata, WORKSPACE_REF_NAME,
+            ref_metadata::{
+                ProjectMeta, StackId, WorkspaceCommitRelation, WorkspaceStack, WorkspaceStackBranch,
+            },
+        };
+
+        fn r(name: &str) -> &gix::refs::FullNameRef {
+            name.try_into().expect("statically known valid ref-name")
+        }
+
+        let mut meta = self.meta();
+        let mut ws = meta.workspace(r(WORKSPACE_REF_NAME))?;
+        let repo = self.open_repo();
+        let ws_data = ws.deref_mut();
+        ws_data.stacks = vec![WorkspaceStack {
+            id: StackId::from_number_for_testing(0),
+            branches: branch_names
+                .iter()
+                .map(|branch_name| WorkspaceStackBranch {
+                    ref_name: r(&format!("refs/heads/{branch_name}")).to_owned(),
+                    archived: false,
+                })
+                .collect(),
+            workspacecommit_relation: WorkspaceCommitRelation::Merged,
+        }];
+        let mut project_meta = ProjectMeta::resolve(&repo)?;
+        project_meta.target_commit_id = Some(repo.rev_parse_single(target_spec)?.detach());
+        meta.set_workspace(&ws)?;
+        project_meta.persist(&repo)?;
+        Ok(())
+    }
 }
 
 /// Invocations

--- a/crates/but/tests/fixtures/scenario/upstream-integrated-single-stack.sh
+++ b/crates/but/tests/fixtures/scenario/upstream-integrated-single-stack.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+git-init-frozen
+
+echo base > file.txt
+git add file.txt
+git commit -m "base"
+git update-ref refs/heads/base HEAD
+
+git checkout -b A
+
+echo change-A > file-a.txt
+git add file-a.txt
+git commit -m "A-change"
+A_COMMIT=$(git rev-parse HEAD)
+
+git checkout main
+git cherry-pick "$A_COMMIT"
+echo main-advance > file-main.txt
+git add file-main.txt
+git commit -m "main-advance"
+setup_target_to_match_main
+
+git checkout A
+create_workspace_commit_once A


### PR DESCRIPTION
Mutations now refuse branches and commits that have already landed in the target branch: `commit` (`--branch`/`--above`/`--below` and default-target selection), `amend`, `squash`, `uncommit`, `reword`, `move`, `push`, and the status TUI's squash mode all validate against a shared `MergedUpstream` guard built from the canonical `but-api` workspace view. `absorb` instead skips landed plan entries with a notice (stderr warning and `skippedMergedUpstream` in JSON mode).

Rewriting landed history entangles new work with already-merged commits — integration detection no longer recognizes the result, so it resurfaces as duplicate work and conflicts on the next `but pull`. Committing or pushing to a merged branch publishes work that is already finished.

Decisions:
- Every refusal points at `but pull` first; `--allow-merged` (a shared clap atom) is the escape hatch for the rare deliberate case and also skips the integration computation.
- The squash family funnels through one validation at the end of `squash::resolve`, so `squash`/`amend`/`uncommit`/TUI cannot bypass the guard by construction.
- Purely structural moves (stack/unstack branch) stay allowed: they re-anchor commits without changing content.
- `but push` refuses explicitly-selected merged branches; bare `but push` keeps the lower layer's existing silent skip.
- The `Error: ` prefix moved out of `BadInput`'s Display into the error sinks — it double-printed whenever a `BadInput` was stringified into anyhow, which push's refusal would have hit.