### PR TITLE
but: accept retired commit syntax with a teaching hint

### DIFF
--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -15,7 +15,7 @@ use nonempty::NonEmpty;
 use serde::Serialize;
 
 use crate::{
-    CliId, CliResult, CliResultExt, IdMap,
+    CliError, CliId, CliResult, CliResultExt, IdMap,
     args::{
         atoms::{BranchArg, BranchOrCommit, CliIdArg, Purpose},
         commit::Platform,
@@ -172,7 +172,13 @@ fn resolve(
     let (guard, commit_selection) = if !changes.is_empty() {
         let changes = changes
             .into_iter()
-            .map(|change| change.resolve_uncommitted(&*ctx.repo.get()?, id_map))
+            .map(|change| {
+                let repo = ctx.repo.get()?;
+                match change.try_resolve_uncommitted(&repo, id_map)? {
+                    Some(resolved) => Ok(resolved),
+                    None => Err(unresolved_change_error(&change, &repo, id_map)),
+                }
+            })
             .collect::<CliResult<Vec<Vec<UncommittedHunkOrFile>>>>()?;
         let changes = changes.into_iter().flatten().collect();
         let Some(changes) = NonEmpty::from_vec(changes) else {
@@ -226,6 +232,28 @@ fn resolve(
     let reword_op = RewordCommitOperation::resolve(no_message, message);
 
     Ok((guard, commit_op, commit_selection, reword_op))
+}
+
+/// The retired syntax put the target branch in positional position
+/// (`but commit <branch> -m "message"`), which the modern grammar reads as a
+/// change. When a change fails to resolve but names an applied branch,
+/// suggest `-b` targeting instead of the generic missing-target hint.
+fn unresolved_change_error(change: &CliIdArg, repo: &gix::Repository, id_map: &IdMap) -> CliError {
+    let names_branch = change
+        .parse(repo, id_map)
+        .ok()
+        .into_iter()
+        .flatten()
+        .any(|id| matches!(id, CliId::Branch(..)));
+    let err = bad_input(format!("Could not find uncommitted change: '{change}'"));
+    if names_branch {
+        err.hint(format!(
+            "'{change}' is a branch. To commit onto it, run `but commit -b {change} -m \"message\" [<change>...]`"
+        ))
+        .into()
+    } else {
+        err.hint(CliIdArg::TARGET_MISSING_HINT).into()
+    }
 }
 
 pub fn run(

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -55,6 +55,7 @@ pub use utils::binary_path::is_executed_as_but;
 mod alias;
 /// A place for all command implementations.
 pub(crate) mod command;
+mod retired_syntax;
 pub mod theme;
 mod tui;
 
@@ -75,7 +76,36 @@ fn early_help_format(_args: &[OsString], agent_detected: bool) -> OutputFormat {
 
 fn parse_args_and_output_format(args: Vec<OsString>, agent_detected: bool) -> (Args, OutputFormat) {
     let command = Args::command();
-    let matches = command.get_matches_from(args);
+    let matches = match command.try_get_matches_from(&args) {
+        Ok(matches) => matches,
+        Err(err) => {
+            // Fall back to translating retired syntax (the pre-revamp
+            // `but commit <branch> -c --changes <id>,<id>` form) before giving
+            // up. Help and version requests also arrive as `Err`; translation
+            // rejects them, so they exit through `err.exit()` below.
+            use retired_syntax::Translation;
+            let retry = match retired_syntax::translate_commit(&args) {
+                Translation::Translated(translated) => {
+                    Args::command().try_get_matches_from(translated).ok()
+                }
+                Translation::Refused => None,
+                Translation::NotRetired => err.exit(),
+            };
+            match retry {
+                Some(matches) => {
+                    retired_syntax::mark_used();
+                    matches
+                }
+                // Retired syntax we cannot safely translate (e.g.
+                // `--no-hooks`): teach the new form, then report the
+                // original error.
+                None => {
+                    print_err_infallible(retired_syntax::hint(agent_detected));
+                    err.exit()
+                }
+            }
+        }
+    };
     let args = Args::from_arg_matches(&matches).unwrap_or_else(|err| err.exit());
 
     let output_format = if args.format.json {
@@ -264,6 +294,10 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
         Some(cmd) => match_subcommand(cmd, args, app_settings, out).await,
     };
 
+    if retired_syntax::was_used() {
+        print_err_infallible(retired_syntax::hint(agent_detected));
+    }
+
     match result {
         Err(CliError::Internal(err)) => Err(err),
         Err(CliError::BadInput(bad_input)) => print_and_exit_non_zero(bad_input),
@@ -422,6 +456,11 @@ async fn match_subcommand(
         && let Some(metrics_ctx) = metrics_ctx.as_mut()
     {
         metrics_ctx.push_extra_prop("agentSkillHintShown", true);
+    }
+    if retired_syntax::was_used()
+        && let Some(metrics_ctx) = metrics_ctx.as_mut()
+    {
+        metrics_ctx.push_extra_prop("retiredCommitSyntax", true);
     }
 
     match cmd {

--- a/crates/but/src/retired_syntax.rs
+++ b/crates/but/src/retired_syntax.rs
@@ -1,0 +1,496 @@
+//! Temporary translation of retired `but commit` syntax into the modern form.
+//!
+//! Before the July 2026 command revamp, `but commit` was invoked as
+//! `but commit <branch> -c -m "message" --changes <id>,<id>`. That form is
+//! widespread in LLM training data, so agents keep producing it. Instead of a
+//! hard parse error, the retired form is rewritten into the modern
+//! `but commit -b <branch> -m "message" <change>...` equivalent, the command
+//! runs normally, and a hint teaching the new syntax is printed at the end.
+//!
+//! The retired grammar is redeclared below as a clap struct, so command lines
+//! are tokenized exactly as the pre-revamp binary did (short-flag bundles,
+//! `=`-attached values, comma-separated `--changes`). Translation then maps
+//! typed fields to modern argv. It only runs as a fallback after the modern
+//! parser has rejected the command line, so current syntax is never affected.
+//! Translation is refused (surfacing the hint followed by the original parse
+//! error) for retired flags with no modern equivalent, and whenever the
+//! rewrite could widen the commit's scope beyond what was asked, such as an
+//! empty `--changes` value.
+//!
+//! One deliberate deviation from the retired parser: the modern `--branch`
+//! flag creates the branch when it does not exist, while the retired
+//! positional required an existing branch unless `-c` was given. A retired
+//! invocation naming a nonexistent branch without `-c` therefore creates it
+//! instead of erroring; completing the requested commit is preferred over
+//! faithfully reproducing the old error.
+//!
+//! Delete this module and its call sites in `lib.rs` once the
+//! `retiredCommitSyntax` command prop shows the old syntax has aged out of
+//! common use.
+
+use std::ffi::OsString;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use crate::theme::Paint as _;
+
+static USED: AtomicBool = AtomicBool::new(false);
+
+/// Record that a retired command line was translated and executed.
+pub(crate) fn mark_used() {
+    USED.store(true, Ordering::Relaxed);
+}
+
+/// Whether the current invocation used retired syntax.
+pub(crate) fn was_used() -> bool {
+    USED.load(Ordering::Relaxed)
+}
+
+/// The hint teaching the modern syntax, printed to stderr.
+pub(crate) fn hint(agent: bool) -> String {
+    let t = crate::theme::get();
+    let mut text = format!(
+        "\n{} this invocation used retired `but commit` syntax. The modern form is:\n\n    \
+         but commit -b <branch> -m \"message\" <change>...\n\n\
+         See `but commit --help` for details.\n",
+        t.attention.paint("note:"),
+    );
+    if agent {
+        text.push_str(
+            "Run `but skill install` (or `but skill check --update`) to load current command docs.\n",
+        );
+    }
+    text
+}
+
+/// The outcome of attempting to translate a command line.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum Translation {
+    /// No retired-only token was found; this is not a retired invocation.
+    NotRetired,
+    /// Retired syntax was identified, but translating it safely is not
+    /// possible (e.g. it could widen the commit's scope). The original parse
+    /// error should stand, prefixed with the teaching hint.
+    Refused,
+    /// The modern equivalent command line.
+    Translated(Vec<OsString>),
+}
+
+/// The retired `but commit` argument grammar. Only `message`, `branch`,
+/// `create`, `all` and `changes` have modern equivalents; the other flags are
+/// declared so that invocations using them are recognized as retired syntax
+/// and refused with the teaching hint.
+#[derive(Debug, clap::Parser)]
+struct RetiredCommit {
+    #[clap(short, long)]
+    message: Option<String>,
+    #[clap(long, value_name = "FILE")]
+    message_file: Option<std::path::PathBuf>,
+    /// The branch to commit onto; the retired grammar's only positional.
+    branch: Option<String>,
+    #[clap(short, long)]
+    create: bool,
+    #[clap(long)]
+    before: Option<String>,
+    #[clap(long)]
+    after: Option<String>,
+    /// Documented in the retired grammar as a no-op compatibility flag for
+    /// `git commit -a`; committing everything is the modern default too.
+    #[clap(short, long)]
+    all: bool,
+    #[clap(short = 'n', long, alias = "no-verify")]
+    no_hooks: bool,
+    #[clap(short = 'i', long, require_equals = true)]
+    ai: Option<Option<String>>,
+    #[clap(short = 'p', long, value_delimiter = ',')]
+    changes: Vec<String>,
+    #[clap(long)]
+    diff: bool,
+    #[clap(long)]
+    no_diff: bool,
+    /// Global option in both grammars; may legally follow the subcommand.
+    #[clap(long)]
+    json: bool,
+    /// Global option in both grammars; may legally follow the subcommand.
+    #[clap(long)]
+    status_after: bool,
+}
+
+/// Rewrite a retired `but commit` command line into the modern equivalent.
+///
+/// Returns [`Translation::NotRetired`] unless the tail after the `commit`
+/// subcommand parses under the retired grammar and contains at least one
+/// retired-only token.
+pub(crate) fn translate_commit(args: &[OsString]) -> Translation {
+    let Some(commit_ix) = find_commit_subcommand(args) else {
+        return Translation::NotRetired;
+    };
+    let (prefix, tail) = args.split_at(commit_ix + 1);
+    let parse = std::iter::once(OsString::from("but commit")).chain(tail.iter().cloned());
+    let Ok(retired) = <RetiredCommit as clap::Parser>::try_parse_from(parse) else {
+        // Not even the retired parser accepts this; the modern error stands.
+        return Translation::NotRetired;
+    };
+    let RetiredCommit {
+        message,
+        message_file,
+        branch,
+        create,
+        before,
+        after,
+        all,
+        no_hooks,
+        ai,
+        changes,
+        diff,
+        no_diff,
+        json,
+        status_after,
+    } = retired;
+
+    let unsupported = message_file.is_some()
+        || before.is_some()
+        || after.is_some()
+        || no_hooks
+        || ai.is_some()
+        || diff
+        || no_diff;
+    let changes_given = !changes.is_empty();
+    if !(create || all || changes_given || unsupported) {
+        return Translation::NotRetired;
+    }
+
+    // Refuse change lists the retired binary would not have committed as-is:
+    // it rejected empty components (`--changes one,`) during ID resolution,
+    // so dropping them here could silently commit less than was asked (or,
+    // for a fully empty list, everything uncommitted). Hyphen-leading
+    // components would be re-parsed as flags when re-emitted as positionals.
+    let unsafe_changes = changes
+        .iter()
+        .any(|change| change.is_empty() || change.starts_with('-'));
+    if unsupported || unsafe_changes {
+        return Translation::Refused;
+    }
+
+    let mut translated = prefix.to_vec();
+    if let Some(message) = message {
+        // The `=`-attached form also binds hyphen-leading messages.
+        translated.push(format!("--message={message}").into());
+    }
+    if json {
+        translated.push("--json".into());
+    }
+    if status_after {
+        translated.push("--status-after".into());
+    }
+    if let Some(branch) = &branch {
+        // The `=`-attached form binds unambiguously to the optional-value flag.
+        translated.push(format!("--branch={branch}").into());
+    }
+    translated.extend(changes.into_iter().map(OsString::from));
+    if branch.is_none() && create {
+        // Retired `-c` without a branch name created a generated-name branch;
+        // a bare trailing `--branch` does the same in the modern grammar.
+        translated.push("--branch".into());
+    }
+    Translation::Translated(translated)
+}
+
+/// Find the index of the `commit` subcommand token, skipping root options.
+fn find_commit_subcommand(args: &[OsString]) -> Option<usize> {
+    let mut ix = 1;
+    while ix < args.len() {
+        let token = &args[ix];
+        // Root options that consume a separate value token.
+        if token == "-C" || token == "--current-dir" || token == "--log-file" {
+            ix += 2;
+            continue;
+        }
+        if token.as_encoded_bytes().starts_with(b"-") {
+            ix += 1;
+            continue;
+        }
+        return (token == "commit").then_some(ix);
+    }
+    None
+}
+
+#[cfg(all(test, feature = "legacy"))]
+mod tests {
+    use clap::Parser as _;
+
+    use super::{Translation, hint, translate_commit};
+    use crate::args::{Args, Subcommands, commit::Platform};
+
+    fn translate(args: &[&str]) -> Translation {
+        let args: Vec<_> = std::iter::once("but")
+            .chain(args.iter().copied())
+            .map(Into::into)
+            .collect();
+        translate_commit(&args)
+    }
+
+    fn translated(args: &[&str]) -> Vec<String> {
+        match translate(args) {
+            Translation::Translated(translated) => translated
+                .into_iter()
+                .map(|arg| arg.into_string().expect("translated args are UTF-8"))
+                .collect(),
+            outcome => panic!("expected a translation, got {outcome:?}"),
+        }
+    }
+
+    /// Translate and parse with the real CLI parser, proving the rewritten
+    /// command line is accepted and lands in the expected fields.
+    fn translate_and_parse(args: &[&str]) -> Platform {
+        let args = Args::try_parse_from(translated(args)).expect("translated args parse");
+        match args.cmd.expect("a subcommand") {
+            Subcommands::Commit(platform) => platform,
+            cmd => panic!("expected commit command, got {cmd:?}"),
+        }
+    }
+
+    fn change_names(changes: Vec<crate::args::atoms::CliIdArg>) -> Vec<String> {
+        changes.into_iter().map(|change| change.0).collect()
+    }
+
+    #[test]
+    fn full_retired_form() {
+        let platform = translate_and_parse(&[
+            "commit",
+            "my-branch",
+            "-c",
+            "-m",
+            "msg",
+            "--changes",
+            "ab,cd",
+        ]);
+        let branch = platform.branch.expect("branch flag set").expect("named");
+        assert_eq!(branch.0, "my-branch");
+        assert_eq!(platform.message, Some(vec!["msg".to_owned()]));
+        assert_eq!(change_names(platform.changes), ["ab", "cd"]);
+    }
+
+    #[test]
+    fn changes_only_without_branch() {
+        let platform = translate_and_parse(&["commit", "--changes=ab", "-m", "msg"]);
+        assert!(platform.branch.is_none(), "no branch flag without -c");
+        assert_eq!(change_names(platform.changes), ["ab"]);
+    }
+
+    #[test]
+    fn create_without_branch_name_requests_generated_branch() {
+        let platform = translate_and_parse(&["commit", "-c", "-m", "msg"]);
+        assert!(
+            matches!(platform.branch, Some(None)),
+            "bare -c maps to a generated-name branch"
+        );
+    }
+
+    #[test]
+    fn all_flag_is_dropped() {
+        let platform = translate_and_parse(&["commit", "my-branch", "-a", "-m", "msg"]);
+        let branch = platform.branch.expect("branch flag set").expect("named");
+        assert_eq!(branch.0, "my-branch");
+        assert!(platform.changes.is_empty());
+    }
+
+    #[test]
+    fn short_changes_flag_with_attached_value() {
+        let platform = translate_and_parse(&["commit", "my-branch", "-c", "-pab,cd", "-m", "msg"]);
+        assert_eq!(change_names(platform.changes), ["ab", "cd"]);
+    }
+
+    #[test]
+    fn bundled_short_flags() {
+        // The `git commit -am`-style habit the retired parser accepted.
+        let platform = translate_and_parse(&["commit", "-am", "msg"]);
+        assert_eq!(platform.message, Some(vec!["msg".to_owned()]));
+        assert!(platform.branch.is_none());
+
+        let platform = translate_and_parse(&["commit", "my-branch", "-cm", "msg"]);
+        let branch = platform.branch.expect("branch flag set").expect("named");
+        assert_eq!(branch.0, "my-branch");
+        assert_eq!(platform.message, Some(vec!["msg".to_owned()]));
+
+        let platform = translate_and_parse(&["commit", "-cpab,cd", "-m", "msg"]);
+        assert!(
+            matches!(platform.branch, Some(None)),
+            "bundled -c without a branch name maps to a generated-name branch"
+        );
+        assert_eq!(change_names(platform.changes), ["ab", "cd"]);
+
+        let platform = translate_and_parse(&["commit", "-camsg-text"]);
+        assert_eq!(platform.message, Some(vec!["sg-text".to_owned()]));
+    }
+
+    #[test]
+    fn unknown_flags_reject_translation() {
+        assert_eq!(
+            translate(&["commit", "-ax", "-m", "msg"]),
+            Translation::NotRetired
+        );
+        assert_eq!(
+            translate(&["commit", "-cb", "-m", "msg"]),
+            Translation::NotRetired
+        );
+    }
+
+    #[test]
+    fn empty_changes_components_refuse_translation() {
+        // The retired binary rejected empty components during ID resolution;
+        // dropping them could silently commit less (or, for a fully empty
+        // list, everything uncommitted), so refuse to translate.
+        for retired in [
+            &["commit", "b", "-c", "-m", "msg", "--changes", ""][..],
+            &["commit", "b", "-c", "-m", "msg", "--changes="],
+            &["commit", "b", "-c", "-m", "msg", "--changes", ",,"],
+            &["commit", "b", "-c", "-m", "msg", "--changes", "one,"],
+            &["commit", "b", "-c", "-m", "msg", "--changes", "one,,two"],
+        ] {
+            assert_eq!(translate(retired), Translation::Refused, "{retired:?}");
+        }
+    }
+
+    #[test]
+    fn flag_looking_changes_values_do_not_translate() {
+        // A `--changes` value that looks like a flag must never be re-emitted
+        // as a positional (clap would re-parse it as a flag and commit
+        // everything). Attached forms are refused; a missing value fails the
+        // retired parse outright, like the retired binary did.
+        assert_eq!(
+            translate(&["commit", "b", "-c", "-m", "msg", "--changes=-x"]),
+            Translation::Refused
+        );
+        for retired in [
+            &["commit", "b", "-c", "-m", "msg", "--changes", "--json"][..],
+            &["commit", "b", "-cp", "--json", "-m", "msg"],
+            &["commit", "b", "-c", "-m", "msg", "--changes"],
+        ] {
+            assert_eq!(translate(retired), Translation::NotRetired, "{retired:?}");
+        }
+    }
+
+    #[test]
+    fn global_flags_after_subcommand_are_preserved() {
+        assert_eq!(
+            translated(&[
+                "commit",
+                "b",
+                "-c",
+                "-m",
+                "msg",
+                "--changes",
+                "ab",
+                "--json"
+            ]),
+            [
+                "but",
+                "commit",
+                "--message=msg",
+                "--json",
+                "--branch=b",
+                "ab"
+            ]
+        );
+    }
+
+    #[test]
+    fn trailing_positionals_reject_translation() {
+        // The retired grammar had a single positional; anything after `--` was
+        // a second one and errored.
+        assert_eq!(
+            translate(&[
+                "commit",
+                "b",
+                "-c",
+                "-m",
+                "msg",
+                "--changes",
+                "ab",
+                "--",
+                "two.txt"
+            ]),
+            Translation::NotRetired
+        );
+    }
+
+    #[test]
+    fn message_value_is_not_mistaken_for_branch() {
+        let platform = translate_and_parse(&[
+            "commit",
+            "-c",
+            "-m",
+            "looks-like-a-branch",
+            "--changes",
+            "ab",
+        ]);
+        assert!(
+            matches!(platform.branch, Some(None)),
+            "the -m value must not become the branch"
+        );
+        assert_eq!(change_names(platform.changes), ["ab"]);
+    }
+
+    #[test]
+    fn root_options_are_preserved() {
+        assert_eq!(
+            translated(&["-C", "/repo", "commit", "my-branch", "-c", "-m", "msg"]),
+            [
+                "but",
+                "-C",
+                "/repo",
+                "commit",
+                "--message=msg",
+                "--branch=my-branch"
+            ]
+        );
+    }
+
+    #[test]
+    fn modern_syntax_is_not_translated() {
+        assert_eq!(
+            translate(&["commit", "ab", "cd", "-b", "my-branch", "-m", "msg"]),
+            Translation::NotRetired
+        );
+        assert_eq!(
+            translate(&["commit", "--no-message"]),
+            Translation::NotRetired
+        );
+    }
+
+    #[test]
+    fn other_subcommands_are_not_translated() {
+        assert_eq!(
+            translate(&["amend", "-c", "--changes", "ab"]),
+            Translation::NotRetired
+        );
+        assert_eq!(translate(&["branch", "new", "-c"]), Translation::NotRetired);
+    }
+
+    #[test]
+    fn retired_flags_without_modern_equivalent_are_refused() {
+        for retired in [
+            &["commit", "my-branch", "-c", "--no-hooks", "-m", "msg"][..],
+            &["commit", "my-branch", "-c", "-m", "msg", "--before", "ab"],
+            &["commit", "my-branch", "--changes", "ab", "--ai"],
+            &["commit", "my-branch", "--changes", "ab", "-i=prompt"],
+            &["commit", "my-branch", "-c", "--diff"],
+        ] {
+            assert_eq!(translate(retired), Translation::Refused, "{retired:?}");
+        }
+    }
+
+    #[test]
+    fn hyphen_leading_message_still_binds() {
+        // The retired parser accepted `--message=-hello`; the attached form
+        // keeps binding it through translation.
+        let platform = translate_and_parse(&["commit", "b", "-c", "--message=-hello"]);
+        assert_eq!(platform.message, Some(vec!["-hello".to_owned()]));
+    }
+
+    #[test]
+    fn skill_pointer_only_shown_to_agents() {
+        assert!(hint(true).contains("but skill install"));
+        assert!(!hint(false).contains("but skill install"));
+    }
+}

--- a/crates/but/tests/but/command/commit.rs
+++ b/crates/but/tests/but/command/commit.rs
@@ -1316,11 +1316,23 @@ fn committing_something_that_isnt_a_cli_id() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
     env.setup_metadata(&["A"]);
 
+    // The retired grammar's positional branch: teach `-b` targeting.
     env.but("commit --no-message A")
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
 Error: Could not find uncommitted change: 'A'
+
+Hint: 'A' is a branch. To commit onto it, run `but commit -b A -m "message" [<change>...]`
+
+"#]]);
+
+    // Anything that names no branch keeps the generic hint.
+    env.but("commit --no-message notexist")
+        .assert()
+        .failure()
+        .stderr_eq(snapbox::str![[r#"
+Error: Could not find uncommitted change: 'notexist'
 
 Hint: Run `but status` for applicable targets.
 

--- a/crates/but/tests/but/command/commit.rs
+++ b/crates/but/tests/but/command/commit.rs
@@ -2130,3 +2130,141 @@ Hint: Most likely you want `but pull`, which updates the workspace and removes l
 
 "#]]);
 }
+
+#[test]
+fn retired_syntax_is_translated_and_hinted() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
+
+    env.file("one", "one content");
+    env.file("two", "two content");
+    env.file("three", "three content");
+
+    // The pre-revamp syntax: positional branch, `-c` to create it, and
+    // `--changes` with a comma-separated list.
+    env.but("commit my-branch -c -m 'add one and two' --changes one,two")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Created commit f6b81a9 on new branch 'my-branch'
+
+"#]])
+        .stderr_eq(snapbox::str![[r#"
+
+note: this invocation used retired `but commit` syntax. The modern form is:
+
+    but commit -b <branch> -m "message" <change>...
+
+See `but commit --help` for details.
+
+"#]]);
+
+    // Only the selected changes were committed; `three` stays uncommitted.
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄ zz [uncommitted]
+┊   or A three
+┊
+┊╭┄ my [my-branch]
+┊●   1 add one and two
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but diff` to see uncommitted changes and `but commit -b <branch> -m "message" <id>` to commit them
+
+"#]]);
+}
+
+#[test]
+fn retired_syntax_with_unsafe_changes_value_refuses_and_hints() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
+
+    env.file("one", "one content");
+
+    // An empty `--changes` value must not silently become "commit
+    // everything"; translation is refused, and the hint precedes the original
+    // parse error.
+    env.but("commit my-branch -c -m 'add nothing' --changes ''")
+        .assert()
+        .failure()
+        .stderr_eq(snapbox::str![[r#"
+
+note: this invocation used retired `but commit` syntax. The modern form is:
+
+    but commit -b <branch> -m "message" <change>...
+
+See `but commit --help` for details.
+error: unexpected argument '-c' found
+
+  tip: to pass '-c' as a value, use '-- -c'
+
+Usage: but commit [OPTIONS] [CHANGES]...
+
+For more information, try '--help'.
+
+"#]]);
+
+    // A missing `--changes` value fails even the retired grammar, exactly as
+    // the retired binary did; the original error surfaces with no hint.
+    env.but("commit my-branch -c -m 'add nothing' --changes --json")
+        .assert()
+        .failure()
+        .stderr_eq(snapbox::str![[r#"
+error: unexpected argument '-c' found
+
+  tip: to pass '-c' as a value, use '-- -c'
+
+Usage: but commit [OPTIONS] [CHANGES]...
+
+For more information, try '--help'.
+
+"#]]);
+
+    // Nothing was committed by either refused invocation.
+    env.but("status")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄ zz [uncommitted]
+┊   kl A one
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but branch new` to create a new branch to work on
+
+"#]]);
+}
+
+#[test]
+fn retired_syntax_without_modern_equivalent_hints_and_fails() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
+
+    env.file("one", "one content");
+
+    // `--no-hooks` has no modern equivalent, so the command still fails with
+    // the original error — but the hint teaches the new syntax first.
+    env.but("commit my-branch -c -m 'add one' --no-hooks --changes one")
+        .assert()
+        .failure()
+        .stderr_eq(snapbox::str![[r#"
+
+note: this invocation used retired `but commit` syntax. The modern form is:
+
+    but commit -b <branch> -m "message" <change>...
+
+See `but commit --help` for details.
+error: unexpected argument '-c' found
+
+  tip: to pass '-c' as a value, use '-- -c'
+
+Usage: but commit [OPTIONS] [CHANGES]...
+
+For more information, try '--help'.
+
+"#]]);
+}


### PR DESCRIPTION
The pre-revamp `but commit <branch> -c -m "message" --changes <id>,<id>` syntax is widespread in LLM training data, so agents keep producing it and hitting hard parse errors.

When the modern parser rejects a `commit` invocation, we now retry it through a translation layer: the retired grammar is redeclared as a clap struct (so tokenization — short-flag bundles, `=`-forms, comma-separated values — matches the old binary exactly), and its typed fields are mapped to the modern argv. The command then runs normally and a stderr note teaches the modern form, pointing agents at `but skill install`.

Design decisions:

- The fallback only runs on command lines that fail to parse today, so modern syntax is provably unaffected.
- Retired forms we cannot translate safely are refused with the hint followed by the original error, never silently altered. In particular, anything that would widen the commit's scope (e.g. an empty `--changes` value becoming "commit everything") is refused.
- Retired flags with no modern equivalent (`--no-hooks`, `--before`/`--after`, `--ai`, ...) are recognized and refused with the hint rather than passed through.
- One deliberate deviation, documented in the module: a nonexistent branch without `-c` is created rather than reproducing the old "branch not found" error.

A second commit handles the marker-less form `but commit <branch> -m "message"`, which parses cleanly in the modern grammar as a change positional and only fails at resolve time: when a change fails to resolve but names an applied branch, the error now suggests the concrete `but commit -b <branch> ...` invocation instead of the generic hint. This hint is permanent and survives the eventual deletion of the translation module, which is self-contained for that purpose.