### PR TITLE
Agent experience: sharper CLI guidance and recovery hints

### DIFF
--- a/crates/but/skill/SKILL.md
+++ b/crates/but/skill/SKILL.md
@@ -67,7 +67,7 @@ The first token on each `but diff` / `but status` line is that line's ID — pas
 - Only one targeting flag (`-b` / `--above` / `--below`) per command. Targeting is **required** when more than one **stack** is applied; without it `but commit` fails with "Unclear where to commit. Found more than one stack". Several branches stacked together count as one stack — an untargeted commit then silently lands on the stack's top branch, so pass `-b` whenever the branch matters.
 - Always pass `-m "<msg>"` (or `--no-message`) to `but commit`, and to `but squash` whenever its sources are commits or branches — those compose a new message, and without a flag an editor opens and blocks. Squash sources that are uncommitted or committed files reuse the target's message and need no flag; squashing into `zz` rejects message flags outright.
 - Amend: `but amend -t <commit-or-branch> <file-or-hunk-id> <file-or-hunk-id>` — a branch target resolves to its newest commit
-- Uncommit: `but uncommit <commit-id>` (whole commit) or `but uncommit <commit-id>:<file-id>` (one committed file)
+- Uncommit: `but uncommit <commit-id>` (whole commit) or `but uncommit <commit-id>:<file-id>` (one committed file); multiple committed-file sources in one call must come from one commit
 - Insert empty commit: `but commit --empty -b <branch> -m "<msg>"`
 - Squash commits: `but squash <source-commit-id> [<source-commit-id>...] -t <target-commit-id> -m "<msg>"`
 - Squash a whole branch into one commit: `but squash <branch> -m "<msg>"` (no `-t`)

--- a/crates/but/skill/SKILL.md
+++ b/crates/but/skill/SKILL.md
@@ -78,7 +78,7 @@ The first token on each `but diff` / `but status` line is that line's ID — pas
 - Tear off a branch: `but move <branch> --unstack`
 - Discard: `but discard <id> [<id>...]` — accepts branches, commits, committed files, uncommitted files/hunks, or `zz` for all uncommitted changes
 - Push: `but push <branch-name>` — always specify the branch; bare `but push` pushes ALL branches when run non-interactively
-- Pull (update workspace from the target): `but pull` — the output reports the result
+- Pull (update workspace from the target): `but pull` — the output reports the result; `but pull --check` previews without updating when a preview is actually needed
 - Create PR: `but pr new <branch-id> [-m "Title..."] [-F pr_message.txt] [-t] [--draft]` — auto-pushes first; do not run `but push` before it
 
 ## Task Recipes
@@ -89,6 +89,10 @@ For "get latest from main", "update/sync this workspace", "rebase onto main", or
 
 1. `but pull` — one command; no preflight needed. Its output reports the resulting state, it refuses safely when uncommitted changes conflict, and `but undo` reverts it.
 2. If commits come back conflicted, resolve them oldest-first following the printed instructions: `but resolve <commit>`, edit the files, then `but resolve finish`. Its result gives the current ID of the next conflict. Add `--status-after` to the finish you expect to clear the last conflict only when the task needs the complete resulting workspace. When it says no conflicted commits remain, stop; do not run a verification status. Finishing a lower commit rebases the ones above it, so always work bottom-up.
+
+`but pull --check` answers "would this conflict?" without updating. Do not use it as a routine
+preflight; use it when the user asks for a preview, repository policy requires one, or other agents'
+branches may move.
 
 Rebasing applied branches onto the latest target IS `but pull` — never `move`, `config target`, `unapply`, or raw `git pull`/`git rebase`. The base shown in status is the last FETCHED state: when `git log` shows `main` (local or remote) ahead of it, that is exactly the update `but pull` fetches and applies — the target setting is not stale and repointing it is never the fix. Pull carries uncommitted changes along, and its output reports the resulting state. If it refuses because uncommitted changes conflict, park them: `but commit -b <branch> -m "wip" <ids>`, pull again, then `but uncommit` the parked commit (there is no stash; do not hand-revert files).
 

--- a/crates/but/skill/SKILL.md
+++ b/crates/but/skill/SKILL.md
@@ -184,7 +184,7 @@ If that `but move` fails, do NOT try `uncommit`, `squash`, or `undo` as a workar
 | `git rebase --onto` | `but move <branch> --above <new-base>` |
 | `git checkout -- <file>` / `git restore` | `but discard <id>` |
 | `git cherry-pick` | `but pick` |
-| `gh pr create` | `but pr new <branch-id>` |
+| `gh pr create` | `but pr new <branch-id> -m "Title..."` |
 
 ## Notes
 

--- a/crates/but/skill/references/concepts.md
+++ b/crates/but/skill/references/concepts.md
@@ -151,7 +151,8 @@ which `amend` does not accept.
 The other editing commands are narrower entry points on the same model:
 
 - `but amend -t <commit> <changes>` — amend uncommitted files/hunks into a known commit
-- `but uncommit <commits-or-committed-files>` — move committed work back to uncommitted
+- `but uncommit <commits-or-committed-files>` — move committed work back to uncommitted; committed
+  files in one call must come from one commit
 - `but move <sources> --above|--below|--branch|--unstack` — relocate commits, committed files, or a
   branch; this is the command with position control
 - `but discard <changes>` — drop work instead of relocating it

--- a/crates/but/skill/references/examples.md
+++ b/crates/but/skill/references/examples.md
@@ -32,9 +32,9 @@ but commit -b <ui-branch-id> -m "Update button hover styles" <ui-file-id>
 # Add --status-after only when the next step needs resulting workspace IDs or details.
 # but amend -t <api-commit-id> <api-fix-file-id> <api-fix-hunk-id>
 
-# 6. Create pull requests (auto-pushes the branches)
-but pr new <api-branch-id>
-but pr new <ui-branch-id>
+# 6. Create pull requests (auto-pushes the branches; -m sets the PR title so no editor opens)
+but pr new <api-branch-id> -m "Add user details endpoint"
+but pr new <ui-branch-id> -m "Update button hover styles"
 ```
 
 **Why parallel branches?** The API endpoint and UI styling are independent - neither depends on the other. They can be reviewed and merged separately.
@@ -255,7 +255,7 @@ but amend -t <commit-id> a1    # Amend fix into the commit it belongs to
 but squash bu -m "Add user dashboard"    # Combine all commits (optional)
 
 # 9. Create pull request (auto-pushes the branch)
-but pr new bu
+but pr new bu -m "Add user dashboard"
 
 # Output:
 # Created PR #123: https://github.com/org/repo/pull/123
@@ -288,7 +288,7 @@ but unapply bw
 but commit -b bu -m "Complete feature-a" <file-ids>
 
 # 4. Create PR for feature-a (auto-pushes)
-but pr new bu
+but pr new bu -m "Complete feature-a"
 
 # 5. Reapply other branches
 but apply feature-b
@@ -361,7 +361,7 @@ but amend -t <commit-id> a1  # Amend fix into the commit it belongs to
 but branch new hotfix-login  # Parallel branch for urgent work
 # (make fix)
 but commit -b bv -m "Fix login redirect loop" <file-ids>
-but pr new bv      # Push and create PR immediately
+but pr new bv -m "Fix login redirect loop"    # Push and create PR immediately
 
 # Back to original work
 # (continue working on bu, auth bug fix)
@@ -369,7 +369,7 @@ but commit -b bu -m "Add tests for token handling" <file-ids>
 
 # End of day: Clean up and create PR
 but squash bu -m "Fix auth bug"    # Combine into clean history
-but pr new bu      # Push and create PR
+but pr new bu -m "Fix auth bug"    # Push and create PR
 
 # After PR review: Make requested changes
 # (make changes based on feedback)

--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -277,6 +277,9 @@ but uncommit <commit-id>                 # Uncommit an entire commit
 but uncommit <commit-id>:<file-id>       # Uncommit one file from its commit
 ```
 
+Multiple whole commits may be passed together. Multiple committed-file sources must all come from
+the same commit; uncommit files from different commits in separate commands.
+
 When you need file and hunk IDs to recommit selectively, use
 `but uncommit <id> && but diff` in one shell call.
 

--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -397,9 +397,8 @@ Do not use raw `git pull` or `git rebase`.
 Create and manage pull requests.
 
 ```bash
-but pr new <branch-id>        # Push branch and create PR (recommended)
+but pr new <branch-id> -m "Title..."        # Push branch and create PR (recommended); first message line is title, rest is description
 but pr new <branch-id> -F pr_message.txt    # Use file: first line is title, rest is description
-but pr new <branch-id> -m "Title..."        # Inline message: first line is title, rest is description
 but pr new <branch-id> -t     # Use default content (commit message), skip prompts
 but pr new <branch-id> --draft  # Create as draft
 but pr new <branch-id> --no-hooks  # Bypass pre-push hooks (--no-verify also works)

--- a/crates/but/src/command/legacy/forge/review.rs
+++ b/crates/but/src/command/legacy/forge/review.rs
@@ -16,6 +16,8 @@ use crate::{
     utils::{Confirm, ConfirmDefault, OutputChannel},
 };
 
+const RETRY_REVIEW_ACTION: &str = "If you still need this action after the review state changes, retry the same command; it fetches the latest review data.";
+
 /// Automatically merge the review once all prerequisites are met.
 pub async fn enable_auto_merge(
     ctx: &mut Context,
@@ -102,7 +104,7 @@ pub async fn enable_auto_merge(
             };
             writeln!(
                 out,
-                "Skipped {review_count} {review_word} because of reasons.\nOnce those reasons have been addressed, run `but fetch` to refetch the data and try again."
+                "Skipped {review_count} {review_word} because of reasons.\n{RETRY_REVIEW_ACTION}"
             )?;
         }
     }
@@ -222,7 +224,7 @@ pub async fn set_draftiness(
             };
             writeln!(
                 out,
-                "Skipped {skipped_reviews} {review_word} because review state is incompatible with this action.\nOnce those reasons have been addressed, run `but fetch` to refetch the data and try again."
+                "Skipped {skipped_reviews} {review_word} because review state is incompatible with this action.\n{RETRY_REVIEW_ACTION}"
             )?;
         }
     }
@@ -1284,6 +1286,13 @@ fn extract_valid_ids(selector: &str) -> Vec<usize> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn skipped_review_recovery_retries_the_fresh_action_without_fetch_alias() {
+        assert!(RETRY_REVIEW_ACTION.contains("retry the same command"));
+        assert!(RETRY_REVIEW_ACTION.contains("fetches the latest review data"));
+        assert!(!RETRY_REVIEW_ACTION.contains("but fetch"));
+    }
 
     fn review_message() -> ForgeReviewMessage {
         ForgeReviewMessage {

--- a/crates/but/src/command/legacy/forge/review.rs
+++ b/crates/but/src/command/legacy/forge/review.rs
@@ -86,30 +86,45 @@ pub async fn enable_auto_merge(
     }
 
     if let Some(out) = out.for_human() {
-        let actual_reviews_modified = review_count - skipped_reviews;
-        if actual_reviews_modified > 0 {
-            let review_word = if actual_reviews_modified == 1 {
-                "review"
-            } else {
-                "reviews"
-            };
-            writeln!(out, "Auto-merge {action} for {review_count} {review_word}")?;
-        }
-
-        if skipped_reviews > 0 {
-            let review_word = if skipped_reviews == 1 {
-                "review"
-            } else {
-                "reviews"
-            };
-            writeln!(
-                out,
-                "Skipped {review_count} {review_word} because of reasons.\n{RETRY_REVIEW_ACTION}"
-            )?;
+        for line in auto_merge_summary_lines(action, review_count, skipped_reviews) {
+            writeln!(out, "{line}")?;
         }
     }
 
     Ok(())
+}
+
+fn auto_merge_summary_lines(
+    action: &str,
+    review_count: usize,
+    skipped_reviews: usize,
+) -> Vec<String> {
+    let mut lines = Vec::new();
+    let actual_reviews_modified = review_count - skipped_reviews;
+
+    if actual_reviews_modified > 0 {
+        let review_word = if actual_reviews_modified == 1 {
+            "review"
+        } else {
+            "reviews"
+        };
+        lines.push(format!(
+            "Auto-merge {action} for {actual_reviews_modified} {review_word}"
+        ));
+    }
+
+    if skipped_reviews > 0 {
+        let review_word = if skipped_reviews == 1 {
+            "review"
+        } else {
+            "reviews"
+        };
+        lines.push(format!(
+            "Skipped {skipped_reviews} {review_word} because of reasons.\n{RETRY_REVIEW_ACTION}"
+        ));
+    }
+
+    lines
 }
 
 /// Set the draftiness of or or multiple reviews.
@@ -1292,6 +1307,27 @@ mod tests {
         assert!(RETRY_REVIEW_ACTION.contains("retry the same command"));
         assert!(RETRY_REVIEW_ACTION.contains("fetches the latest review data"));
         assert!(!RETRY_REVIEW_ACTION.contains("but fetch"));
+    }
+
+    #[test]
+    fn auto_merge_summary_reports_mixed_result_counts() {
+        assert_eq!(
+            auto_merge_summary_lines("enabled", 2, 1),
+            vec![
+                "Auto-merge enabled for 1 review".to_string(),
+                format!("Skipped 1 review because of reasons.\n{RETRY_REVIEW_ACTION}"),
+            ]
+        );
+    }
+
+    #[test]
+    fn auto_merge_summary_reports_all_skipped() {
+        assert_eq!(
+            auto_merge_summary_lines("disabled", 2, 2),
+            [format!(
+                "Skipped 2 reviews because of reasons.\n{RETRY_REVIEW_ACTION}"
+            )]
+        );
     }
 
     fn review_message() -> ForgeReviewMessage {

--- a/crates/but/src/command/legacy/pick.rs
+++ b/crates/but/src/command/legacy/pick.rs
@@ -33,7 +33,9 @@ pub fn handle(
     let stacks = crate::legacy::workspace::applied_stacks(ctx).context("Failed to list stacks")?;
 
     if stacks.is_empty() {
-        bail!("No applied stacks in workspace. Apply a branch first with 'but branch apply'.");
+        bail!(
+            "No applied stacks in workspace. Apply a branch first with 'but apply <branch-name>'."
+        );
     }
 
     // Resolve the target before the source so an interactive run prompts for the branch first.

--- a/crates/but/src/command/legacy/pull/mod.rs
+++ b/crates/but/src/command/legacy/pull/mod.rs
@@ -614,11 +614,26 @@ async fn handle_pull(ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Resu
                     if has_conflicts {
                         writeln!(out)?;
                         writeln!(out, "{}", t.important.paint("To resolve conflicts:"))?;
-                        writeln!(
-                            out,
-                            "  1. Run {} on a conflicted commit listed above — oldest first (they are listed bottom-up). Worktree files show no conflict markers until this checks the commit out",
-                            t.command_suggestion.paint("`but resolve <commit>`")
-                        )?;
+                        if let Some(next_commit) = conflicted_rebases
+                            .iter()
+                            .find_map(|branch| conflicted_commits.get(branch)?.first())
+                        {
+                            writeln!(
+                                out,
+                                "  1. Start with: {}. Worktree files show no conflict markers until this checks the commit out",
+                                t.command_suggestion.paint(format!(
+                                    "`but resolve {}`",
+                                    next_commit.commit_short_id
+                                ))
+                            )?;
+                        } else {
+                            writeln!(
+                                out,
+                                "  1. Run {} to inspect the conflicted commits, then {}. Worktree files show no conflict markers until resolve checks the commit out",
+                                t.command_suggestion.paint("`but status`"),
+                                t.command_suggestion.paint("`but resolve <commit>`")
+                            )?;
+                        }
                         writeln!(out, "  2. Edit files to resolve the conflicts")?;
                         writeln!(
                             out,

--- a/crates/but/tests/but/command/pick.rs
+++ b/crates/but/tests/but/command/pick.rs
@@ -130,6 +130,20 @@ fn pick_json_output() -> anyhow::Result<()> {
 // === Error cases ===
 
 #[test]
+fn pick_without_applied_stacks_points_to_public_apply_command() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
+
+    env.but("pick unapplied-branch")
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
+Failed to pick commit. No applied stacks in workspace. Apply a branch first with 'but apply <branch-name>'.
+
+"#]]);
+}
+
+#[test]
 fn pick_invalid_source_fails() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("pick-from-unapplied");
     env.setup_metadata(&["applied-branch"]);

--- a/crates/but/tests/but/command/pull.rs
+++ b/crates/but/tests/but/command/pull.rs
@@ -550,7 +550,7 @@ Summary
       rou [conflict] bottom change
 
 To resolve conflicts:
-  1. Run `but resolve <commit>` on a conflicted commit listed above — oldest first (they are listed bottom-up). Worktree files show no conflict markers until this checks the commit out
+  1. Start with: `but resolve rou`. Worktree files show no conflict markers until this checks the commit out
   2. Edit files to resolve the conflicts
   3. Run `but resolve finish` to finalize the resolution
 
@@ -620,7 +620,7 @@ Summary
       trk [conflict] bottom change
 
 To resolve conflicts:
-  1. Run `but resolve <commit>` on a conflicted commit listed above — oldest first (they are listed bottom-up). Worktree files show no conflict markers until this checks the commit out
+  1. Start with: `but resolve trk`. Worktree files show no conflict markers until this checks the commit out
   2. Edit files to resolve the conflicts
   3. Run `but resolve finish` to finalize the resolution
 

--- a/crates/but/tests/but/command/resolve.rs
+++ b/crates/but/tests/but/command/resolve.rs
@@ -200,6 +200,109 @@ fn agent_resolve_finish_json_includes_result_and_status() -> anyhow::Result<()> 
 }
 
 #[test]
+fn agent_resolve_finish_json_status_tracks_rebased_conflict_queue() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings(
+        "pull-conflicts-in-both-branches-of-stack",
+    );
+    env.setup_metadata_at_target(&["A"], "main");
+    env.but("pull").assert().success();
+
+    let status = super::util::status_json(&env)?;
+    let branch = super::util::find_branch(&status, "A")?;
+    let commits = branch["commits"]
+        .as_array()
+        .context("branch commits should be an array")?;
+    let conflicted_top_commit = commits
+        .iter()
+        .find(|commit| {
+            commit["conflicted"].as_bool() == Some(true)
+                && commit["message"].as_str() == Some("top change")
+        })
+        .context("should find the conflicted top commit")?;
+    let top_commit_id_before = conflicted_top_commit["commitId"]
+        .as_str()
+        .context("top commit should have a full commit ID")?
+        .to_owned();
+    let conflicted_bottom_commit = status["stacks"]
+        .as_array()
+        .context("status stacks should be an array")?
+        .iter()
+        .flat_map(|stack| stack["branches"].as_array().into_iter().flatten())
+        .flat_map(|branch| branch["commits"].as_array().into_iter().flatten())
+        .find(|commit| {
+            commit["conflicted"].as_bool() == Some(true)
+                && commit["message"].as_str() == Some("bottom change")
+        })
+        .and_then(|commit| commit["cliId"].as_str())
+        .context("should find the conflicted bottom commit")?
+        .to_owned();
+
+    env.but(format!("resolve {conflicted_bottom_commit}"))
+        .assert()
+        .success();
+    env.file("bottom.txt", "resolved bottom\n");
+    env.invoke_git("add bottom.txt");
+
+    let mut command = super::util::but_std_cmd(&env, "--json resolve finish --status-after");
+    command.env("AI_AGENT", "codex");
+    let output = command.output()?;
+    assert!(output.status.success(), "resolve finish should succeed");
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout)?;
+
+    let queue = json["result"]["resolution_queue"]
+        .as_array()
+        .context("resolution_queue should be an array")?;
+    assert_eq!(
+        queue.len(),
+        1,
+        "only the rebased top conflict should remain"
+    );
+    let queued_top = &queue[0];
+    assert!(
+        queued_top["commit_message"]
+            .as_str()
+            .is_some_and(|message| message.ends_with("top change")),
+        "the queue should identify the remaining top conflict"
+    );
+    assert_ne!(
+        queued_top["commit_id"].as_str(),
+        Some(top_commit_id_before.as_str()),
+        "finishing the bottom conflict should rebase the top commit"
+    );
+    assert_eq!(
+        json["result"]["total_remaining_conflicted_commits"], 1,
+        "the result should count the remaining top conflict once"
+    );
+
+    let status_branch = super::util::find_branch(&json["status"], "A")?;
+    let status_top = status_branch["commits"]
+        .as_array()
+        .context("status branch commits should be an array")?
+        .iter()
+        .find(|commit| {
+            commit["message"]
+                .as_str()
+                .is_some_and(|message| message.ends_with("top change"))
+        })
+        .context("status should contain the rebased top commit")?;
+    assert_eq!(
+        status_top["conflicted"].as_bool(),
+        Some(true),
+        "the rebased top commit should remain conflicted"
+    );
+    assert_eq!(
+        status_top["commitId"], queued_top["commit_id"],
+        "status and the result queue should expose the same fresh commit ID"
+    );
+    assert_eq!(
+        status_top["cliId"], queued_top["commit_short_id"],
+        "status and the result queue should expose the same actionable selector"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn resolve_cancel_works_in_edit_mode() -> anyhow::Result<()> {
     let env = enter_edit_mode_with_conflicted_commit()?;
 

--- a/crates/but/tests/but/command/uncommit.rs
+++ b/crates/but/tests/but/command/uncommit.rs
@@ -1,10 +1,7 @@
-//! Integration tests for `but uncommit` with multiple committed-file sources.
+//! Integration tests for `but uncommit` with multiple sources.
 //!
-//! These exercise the multi-source uncommit path, where several committed files
-//! (potentially from different commits and branches, in any order) are handed to
-//! the backend in a single batched operation. Each test asserts the `but status`
-//! tree and the file contents of the affected commits, both before and after the
-//! uncommit.
+//! Whole-commit sources may span commits, but committed-file sources in one
+//! invocation must belong to the same commit.
 
 use snapbox::str;
 
@@ -155,6 +152,40 @@ Hint: run `but diff` to see uncommitted changes and `but commit -b <branch> -m "
     assert_eq!(commit_file_content(&env, "A:c2.txt"), None);
     assert_eq!(worktree_file_content(&env, "c1.txt"), "c1 content\n");
     assert_eq!(worktree_file_content(&env, "c2.txt"), "c2 content\n");
+
+    Ok(())
+}
+
+#[test]
+fn uncommit_rejects_files_from_different_commits() -> anyhow::Result<()> {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
+
+    env.file("c1.txt", "c1 content\n");
+    env.but("commit -b A -m 'add c1'").assert().success();
+    env.file("c2.txt", "c2 content\n");
+    env.but("commit -b A -m 'add c2'").assert().success();
+
+    let before = status_json(&env)?;
+    let c2_id =
+        committed_file_id_in_commit(&before, "A", 0, "c2.txt").expect("c2.txt committed-file id");
+    let c1_id =
+        committed_file_id_in_commit(&before, "A", 1, "c1.txt").expect("c1.txt committed-file id");
+
+    env.but(format!("uncommit {c1_id} {c2_id}"))
+        .assert()
+        .failure()
+        .stdout_eq(str![])
+        .stderr_eq(str![[r#"
+Error: All committed files must come from the same commit. Found files from [..] and [..]
+
+"#]]);
+
+    let after = status_json(&env)?;
+    assert!(committed_file_id_in_commit(&after, "A", 0, "c2.txt").is_some());
+    assert!(committed_file_id_in_commit(&after, "A", 1, "c1.txt").is_some());
+    assert!(!uncommitted_contains_file(&after, "c1.txt"));
+    assert!(!uncommitted_contains_file(&after, "c2.txt"));
 
     Ok(())
 }


### PR DESCRIPTION
Improvements to `but` CLI output and the bundled skill, from an optimization run against the version-control bench (overfitting-prone changes were reviewed out; what remains is verified against real behavior):

- Auto-merge summaries now report the actual number of modified reviews instead of the total batch size when some reviews are skipped.
- PR state actions (auto-merge, set-draft, set-ready) recover with "retry the same command" instead of suggesting `but fetch`, which never refreshed review data.
- `but pick` failure recovery points to `but apply <branch-name>`; the previously suggested `but branch apply` does not exist.
- `but pull` conflict output prints the concrete next command (`but resolve <id>`) for the oldest conflicted commit.
- Skill docs now state that committed-file uncommit sources must come from a single commit, and document the separate-invocations workaround.
- Skill docs frame `but pull --check` as a conditional preview, not a routine preflight step.
- All `but pr new` examples pass `-m` with a real title so no example can open an editor and hang an agent.
- New regression test covering resolve-status composition across a rebase.