### PR TITLE
Fix CI E2E filter

### DIFF
--- a/.github/workflows/check-e2e-changes.yml
+++ b/.github/workflows/check-e2e-changes.yml
@@ -24,6 +24,7 @@ jobs:
         if: ${{ github.event_name != 'workflow_dispatch' }}
         id: filter
         with:
+          predicate-quantifier: every
           filters: |
             e2e:
               - '**'


### PR DESCRIPTION
I noticed the (very slow!) E2E tests run in all my PRs despite only touching files under `apps/lite`, and I can see the same behaviour in Rusty PRs. This PR fixes the filter introduced in #13391.

The action we use defaults to [`predicate-quantifier: 'some'`](https://github.com/dorny/paths-filter#outputs) in which case, regardless of the exclusions, all files will match due to `**`:

> if **any** changed file matches **at least one** of the filter's rules

By setting the quantifier to `'every'` I believe we instead get the desired behaviour, respecting the exclusions:

> if **any** changed file matches **all** of the filter's rules