### PR TITLE
Speed up Playwright CI

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -118,11 +118,15 @@ jobs:
           overwrite: true
           path: ./e2e-output/
 
-  playwright:
-    name: e2e-playwright
+  playwright_shards:
+    name: e2e-playwright (${{ matrix.shard }}/${{ strategy.job-total }})
     needs: changes
     if: ${{ needs.changes.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     permissions:
       contents: read
       packages: read
@@ -150,7 +154,7 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           shared-key: e2e-playwright-rust-binaries
-          save-if: ${{ github.ref == 'refs/heads/master' }}
+          save-if: ${{ github.ref == 'refs/heads/master' && matrix.shard == 1 }}
       - name: Preset Git Configuration and but location
         run: |
           echo "GIT_CONFIG_GLOBAL=$PWD/e2e/playwright/fixtures/.gitconfig" >> $GITHUB_ENV
@@ -165,7 +169,7 @@ jobs:
         with:
           path: |
             ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ steps.get_playwright_version.outputs.playwright-version }}
+          key: ${{ runner.os }}-playwright-e2e-webkit-${{ steps.get_playwright_version.outputs.playwright-version }}
       - name: Build Rust binaries, SvelteKit, and install Playwright
         env:
           PLAYWRIGHT_CACHE_HIT: ${{ steps.playwright-cache.outputs.cache-hit }}
@@ -176,7 +180,7 @@ jobs:
           pnpm_pid=$!
           pw_pid=""
           if [ "$PLAYWRIGHT_CACHE_HIT" != "true" ]; then
-            (apt-get update && cd e2e && pnpm exec playwright install chromium webkit) &
+            pnpm --dir e2e exec playwright install webkit &
             pw_pid=$!
           fi
           status=0
@@ -185,12 +189,29 @@ jobs:
           [ -n "$pw_pid" ] && { wait "$pw_pid" || status=1; }
           exit "$status"
       - name: Run Playwright tests
-        run: pnpm exec turbo run test:e2e:playwright
+        run: pnpm exec turbo run test:e2e:playwright -- --shard="${{ matrix.shard }}/${{ strategy.job-total }}"
         env:
           BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_SUITE_TOKEN_PLAYWRIGHT }}
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
-          name: playwright-report
+          name: playwright-report-${{ matrix.shard }}-of-${{ strategy.job-total }}
+          overwrite: true
           path: ./e2e/playwright/test-results-flat/
           retention-days: 30
+
+  playwright:
+    name: e2e-playwright
+    needs: [changes, playwright_shards]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Verify Playwright shards
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          SHOULD_RUN: ${{ needs.changes.outputs.should_run }}
+          SHARDS_RESULT: ${{ needs.playwright_shards.result }}
+        run: |
+          test "$CHANGES_RESULT" = "success" &&
+            { test "$SHOULD_RUN" != "true" || test "$SHARDS_RESULT" = "success"; }

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -189,9 +189,10 @@ jobs:
           [ -n "$pw_pid" ] && { wait "$pw_pid" || status=1; }
           exit "$status"
       - name: Run Playwright tests
-        run: pnpm exec turbo run test:e2e:playwright -- --shard="${{ matrix.shard }}/${{ strategy.job-total }}"
+        run: pnpm exec turbo run test:e2e:playwright -- --shard="$PLAYWRIGHT_SHARD"
         env:
           BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_SUITE_TOKEN_PLAYWRIGHT }}
+          PLAYWRIGHT_SHARD: ${{ matrix.shard }}/${{ strategy.job-total }}
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:

--- a/e2e/playwright/playwright.config.ts
+++ b/e2e/playwright/playwright.config.ts
@@ -45,40 +45,27 @@ export default defineConfig({
 		/* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
 		// I have no idea why, but with this disabled, some tests just always fail. I have no idea why.
 		trace: "retain-on-failure",
-		video: { mode: "retain-on-failure", size: { width: 1920, height: 1080 } },
+		video: { mode: "retain-on-failure", size: { width: 1280, height: 720 } },
 	},
 
 	/* Configure projects for major browsers */
-	projects: projects(),
+	projects: [
+		{
+			name: "webkit",
+			use: {
+				...devices["Desktop Safari"],
+				viewport: { width: 1920, height: 1080 },
+				deviceScaleFactor: 1,
+				headless: process.env.CI ? true : process.env.PLAYWRIGHT_UI !== "1",
+			},
+		},
+	],
 
 	/* Run your local dev server before starting the tests */
 	webServer: webServers(),
 
 	snapshotPathTemplate: "{testDir}/__snapshots__/{testFilePath}/{arg}{ext}",
 });
-
-function projects() {
-	const projects = [];
-	if (process.env.CI) {
-		projects.push({
-			name: "webkit",
-			use: { ...devices["Desktop Safari"], viewport: { width: 1920, height: 1080 } },
-		});
-		return projects;
-	}
-
-	projects.push({
-		name: "webkit",
-		use: {
-			...devices["Desktop Safari"],
-			viewport: { width: 1920, height: 1080 },
-			deviceScaleFactor: 1,
-			headless: process.env.PLAYWRIGHT_UI === "1" ? false : true,
-		},
-	});
-
-	return projects;
-}
 
 /**
  * Command to start the frontend server.

--- a/e2e/playwright/scripts/project-with-commit-hooks.sh
+++ b/e2e/playwright/scripts/project-with-commit-hooks.sh
@@ -69,10 +69,12 @@ HOOK_EOF
 # This hook checks if a marker file exists to trigger failure
 
 if [ -f "FAIL_POST_COMMIT" ]; then
+  touch POST_COMMIT_FAILED
   echo "Error: Post-commit hook failed due to FAIL_POST_COMMIT marker"
   exit 1
 fi
 
+touch POST_COMMIT_SUCCEEDED
 exit 0
 HOOK_EOF
 

--- a/e2e/playwright/src/setup.ts
+++ b/e2e/playwright/src/setup.ts
@@ -217,18 +217,17 @@ function createButServerProcess(rootDir: string, serverEnv: Record<string, strin
 	return child;
 }
 
-async function waitForServer(port: string, host = "localhost", maxAttempts = 500) {
+async function waitForServer(port: string, host = "localhost", timeoutMs = 30_000) {
 	const parsed = parseInt(port, 10);
+	const deadline = Date.now() + timeoutMs;
 
-	for (let i = 0; i < maxAttempts; i++) {
+	while (Date.now() < deadline) {
 		if (await checkPort(parsed, host)) {
 			log(`✅ Server is ready on ${host}:${port}`, colors.green);
 			return true;
 		}
 
-		if (i < maxAttempts - 1) {
-			await new Promise((resolve) => setTimeout(resolve, 1000));
-		}
+		await new Promise((resolve) => setTimeout(resolve, 100));
 	}
 
 	return false;

--- a/e2e/playwright/tests/branches.spec.ts
+++ b/e2e/playwright/tests/branches.spec.ts
@@ -113,8 +113,6 @@ test("should be able to apply a remote branch", async ({ page, gitbutler }) => {
 });
 
 test.describe("GitHub review apply", () => {
-	test.describe.configure({ mode: "serial" });
-
 	test("should apply a GitHub fork PR by creating the fork remote in the backend", async ({
 		page,
 		gitbutler,

--- a/e2e/playwright/tests/commitHooks.spec.ts
+++ b/e2e/playwright/tests/commitHooks.spec.ts
@@ -2,8 +2,7 @@ import { getButlerPort, type GitButler } from "../src/setup.ts";
 import { test } from "../src/test.ts";
 import { clickByTestId, commitRow, fillByTestId, getByTestId, waitForTestId } from "../src/util.ts";
 import { expect, type Page } from "@playwright/test";
-
-test.describe.configure({ mode: "serial" });
+import { existsSync } from "node:fs";
 
 /**
  * Bring up the hook-equipped project, enable hooks for the project, and reload
@@ -115,9 +114,9 @@ test("post-commit hook success", async ({ page, gitbutler }) => {
 	const row = commitRow(page).first();
 	await expect(row).toBeVisible();
 	await expect(row).toContainText("Testing post-commit hook");
-
-	// Post-commit hook runs in the background.
-	await page.waitForTimeout(1500);
+	await expect
+		.poll(() => existsSync(gitbutler.pathInWorkdir("local-with-hooks/POST_COMMIT_SUCCEEDED")))
+		.toBe(true);
 });
 
 test("post-commit hook failure does not block commit", async ({ page, gitbutler }) => {
@@ -132,6 +131,7 @@ test("post-commit hook failure does not block commit", async ({ page, gitbutler 
 	const row = commitRow(page).first();
 	await expect(row).toBeVisible();
 	await expect(row).toContainText("Trigger post-commit failure");
-
-	await page.waitForTimeout(1500);
+	await expect
+		.poll(() => existsSync(gitbutler.pathInWorkdir("local-with-hooks/POST_COMMIT_FAILED")))
+		.toBe(true);
 });


### PR DESCRIPTION
Shard the growing E2E suite across four jobs while preserving the required check name through an aggregate gate.

Also cut avoidable browser overhead, parallelize isolated test groups, and replace fixed hook sleeps with explicit completion markers.