### PR TITLE
but: teach modern syntax when retired command forms are used

### DIFF
--- a/crates/but/src/command/legacy/squash.rs
+++ b/crates/but/src/command/legacy/squash.rs
@@ -227,9 +227,28 @@ fn resolve_args(
                 let branch = source.resolve_branch_in_workspace(repo, id_map)?;
                 Ok(ResolvedSquashArgs::SingleBranchSourceAndTarget { branch, reword })
             }
-            _ => Err(
-                bad_input("When --target isn't used the source must be exactly one branch").into(),
-            ),
+            _ => {
+                let mut err =
+                    bad_input("When --target isn't used the source must be exactly one branch");
+                // The retired `but squash <id>...` form squashed everything
+                // into the last ID; suggest the flagged equivalent when the
+                // sources can be re-emitted verbatim without being re-parsed
+                // as flags.
+                if let Some((last, rest)) = sources.split_last()
+                    && !rest.is_empty()
+                    && sources
+                        .iter()
+                        .all(|source| crate::retired_syntax::plain(&source.0))
+                {
+                    let rest: Vec<&str> = rest.iter().map(|source| source.0.as_str()).collect();
+                    err = err.hint(format!(
+                        "To squash into the last source, use `but squash {} -t {}`",
+                        rest.join(" "),
+                        last.0
+                    ));
+                }
+                Err(err.into())
+            }
         }
     }
 }

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -89,7 +89,20 @@ fn parse_args_and_output_format(args: Vec<OsString>, agent_detected: bool) -> (A
                     Args::command().try_get_matches_from(translated).ok()
                 }
                 Translation::Refused => None,
-                Translation::NotRetired => err.exit(),
+                Translation::NotRetired => {
+                    // The other revamped commands are never translated, but a
+                    // rejected line that looks like their retired syntax gets
+                    // a teaching hint before the error. Help and version
+                    // requests also arrive as `Err` and must pass untouched.
+                    if err.use_stderr()
+                        && let Some((command, hint)) =
+                            retired_syntax::parse_failure_hint(&args, agent_detected)
+                    {
+                        print_err_infallible(hint);
+                        utils::metrics::emit_retired_syntax_hint(command);
+                    }
+                    err.exit()
+                }
             };
             match retry {
                 Some(matches) => {
@@ -101,6 +114,7 @@ fn parse_args_and_output_format(args: Vec<OsString>, agent_detected: bool) -> (A
                 // original error.
                 None => {
                     print_err_infallible(retired_syntax::hint(agent_detected));
+                    utils::metrics::emit_retired_syntax_hint(args::metrics::CommandName::Commit);
                     err.exit()
                 }
             }
@@ -302,6 +316,12 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
         Err(CliError::Internal(err)) => Err(err),
         Err(CliError::BadInput(bad_input)) => print_and_exit_non_zero(bad_input),
         Err(CliError::ExternalCommandNotFound(command_name)) => {
+            // Commands removed by the revamp (`rub`) land here as unknown
+            // external subcommands; teach their replacements before the error.
+            if let Some(hint) = retired_syntax::removed_command_hint(&command_name, agent_detected)
+            {
+                print_err_infallible(hint);
+            }
             // We reparse without external subcommands allowed, which _should_ result in a proper
             // clap error, including suggestions for "near matches". This gives richer error
             // information than the plain ExternalCommandNotFound error.

--- a/crates/but/src/retired_syntax.rs
+++ b/crates/but/src/retired_syntax.rs
@@ -1,17 +1,24 @@
-//! Temporary translation of retired `but commit` syntax into the modern form.
+//! Temporary handling of syntax retired by the July 2026 command revamp.
 //!
-//! Before the July 2026 command revamp, `but commit` was invoked as
-//! `but commit <branch> -c -m "message" --changes <id>,<id>`. That form is
-//! widespread in LLM training data, so agents keep producing it. Instead of a
-//! hard parse error, the retired form is rewritten into the modern
-//! `but commit -b <branch> -m "message" <change>...` equivalent, the command
-//! runs normally, and a hint teaching the new syntax is printed at the end.
+//! The revamp changed `commit`, `squash`, `move`, `amend`, `uncommit` and
+//! `discard`, and removed `rub`. The retired forms are widespread in LLM
+//! training data, so agents keep producing them. Two mitigations live here:
 //!
-//! The retired grammar is redeclared below as a clap struct, so command lines
-//! are tokenized exactly as the pre-revamp binary did (short-flag bundles,
-//! `=`-attached values, comma-separated `--changes`). Translation then maps
-//! typed fields to modern argv. It only runs as a fallback after the modern
-//! parser has rejected the command line, so current syntax is never affected.
+//! - `but commit <branch> -c -m "message" --changes <id>,<id>` is rewritten
+//!   into the modern `but commit -b <branch> -m "message" <change>...`
+//!   equivalent, the command runs normally, and a hint teaching the new
+//!   syntax is printed at the end.
+//! - For the other revamped commands, a rejected command line that looks like
+//!   retired syntax gets a teaching hint before the parse error — with the
+//!   concrete modern equivalent whenever it can be derived mechanically.
+//!   Nothing is translated or executed for these.
+//!
+//! The retired grammars are redeclared below as clap structs, so command
+//! lines are tokenized exactly as the pre-revamp binary did (short-flag
+//! bundles, `=`-attached values, comma-separated `--changes`). For `commit`,
+//! translation then maps typed fields to modern argv. Everything only runs as
+//! a fallback after the modern parser has rejected the command line, so
+//! current syntax is never affected.
 //! Translation is refused (surfacing the hint followed by the original parse
 //! error) for retired flags with no modern equivalent, and whenever the
 //! rewrite could widen the commit's scope beyond what was asked, such as an
@@ -25,13 +32,17 @@
 //! faithfully reproducing the old error.
 //!
 //! Delete this module and its call sites in `lib.rs` once the
-//! `retiredCommitSyntax` command prop shows the old syntax has aged out of
-//! common use.
+//! `retiredCommitSyntax` and `retiredSyntaxHint` command props show the old
+//! syntax has aged out of common use. (`rub` attempts are visible without a
+//! dedicated prop, as external-command events with `externalSubcommand:
+//! "rub"`.) The resolve-time suggestions — commit's `-b` hint and squash's
+//! `-t` hint — are permanent teaching improvements outside this module and
+//! are not part of these criteria.
 
 use std::ffi::OsString;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use crate::theme::Paint as _;
+use crate::{args::metrics::CommandName, theme::Paint as _};
 
 static USED: AtomicBool = AtomicBool::new(false);
 
@@ -47,13 +58,34 @@ pub(crate) fn was_used() -> bool {
 
 /// The hint teaching the modern syntax, printed to stderr.
 pub(crate) fn hint(agent: bool) -> String {
-    let t = crate::theme::get();
-    let mut text = format!(
-        "\n{} this invocation used retired `but commit` syntax. The modern form is:\n\n    \
+    note(
+        "this invocation used retired `but commit` syntax. The modern form is:\n\n    \
          but commit -b <branch> -m \"message\" <change>...\n\n\
-         See `but commit --help` for details.\n",
-        t.attention.paint("note:"),
-    );
+         See `but commit --help` for details.",
+        agent,
+    )
+}
+
+/// The hint for an invocation of a command removed by the revamp, which
+/// surfaces as an unknown external subcommand rather than a parse failure.
+pub(crate) fn removed_command_hint(command_name: &std::ffi::OsStr, agent: bool) -> Option<String> {
+    (command_name == "rub").then(|| {
+        note(
+            "`but rub` was retired. Squashing sources into a target is now:\n\n    \
+             but squash <source>... -t <target>\n\n\
+             Moving sources is `but move <source>...` with a placement flag \
+             (`--below`/`--above` a commit, `--branch <branch>`).\n\
+             See `but squash --help` and `but move --help` for details.",
+            agent,
+        )
+    })
+}
+
+/// A stderr note in the shared teaching-hint format, with a pointer to the
+/// bundled skill docs when an agent is driving the CLI.
+fn note(body: &str, agent: bool) -> String {
+    let t = crate::theme::get();
+    let mut text = format!("\n{} {body}\n", t.attention.paint("note:"));
     if agent {
         text.push_str(
             "Run `but skill install` (or `but skill check --update`) to load current command docs.\n",
@@ -73,6 +105,16 @@ pub(crate) enum Translation {
     Refused,
     /// The modern equivalent command line.
     Translated(Vec<OsString>),
+}
+
+/// Global options valid in both grammars; they may legally follow the
+/// subcommand, so every retired grammar must accept them.
+#[derive(Debug, clap::Args)]
+struct RetiredGlobals {
+    #[clap(long)]
+    json: bool,
+    #[clap(long)]
+    status_after: bool,
 }
 
 /// The retired `but commit` argument grammar. Only `message`, `branch`,
@@ -107,12 +149,8 @@ struct RetiredCommit {
     diff: bool,
     #[clap(long)]
     no_diff: bool,
-    /// Global option in both grammars; may legally follow the subcommand.
-    #[clap(long)]
-    json: bool,
-    /// Global option in both grammars; may legally follow the subcommand.
-    #[clap(long)]
-    status_after: bool,
+    #[clap(flatten)]
+    globals: RetiredGlobals,
 }
 
 /// Rewrite a retired `but commit` command line into the modern equivalent.
@@ -121,9 +159,12 @@ struct RetiredCommit {
 /// subcommand parses under the retired grammar and contains at least one
 /// retired-only token.
 pub(crate) fn translate_commit(args: &[OsString]) -> Translation {
-    let Some(commit_ix) = find_commit_subcommand(args) else {
+    let Some((commit_ix, subcommand)) = find_subcommand(args) else {
         return Translation::NotRetired;
     };
+    if subcommand != "commit" {
+        return Translation::NotRetired;
+    }
     let (prefix, tail) = args.split_at(commit_ix + 1);
     let parse = std::iter::once(OsString::from("but commit")).chain(tail.iter().cloned());
     let Ok(retired) = <RetiredCommit as clap::Parser>::try_parse_from(parse) else {
@@ -143,8 +184,7 @@ pub(crate) fn translate_commit(args: &[OsString]) -> Translation {
         changes,
         diff,
         no_diff,
-        json,
-        status_after,
+        globals: RetiredGlobals { json, status_after },
     } = retired;
 
     let unsupported = message_file.is_some()
@@ -195,8 +235,8 @@ pub(crate) fn translate_commit(args: &[OsString]) -> Translation {
     Translation::Translated(translated)
 }
 
-/// Find the index of the `commit` subcommand token, skipping root options.
-fn find_commit_subcommand(args: &[OsString]) -> Option<usize> {
+/// Find the subcommand token and its index, skipping root options.
+fn find_subcommand(args: &[OsString]) -> Option<(usize, &OsString)> {
     let mut ix = 1;
     while ix < args.len() {
         let token = &args[ix];
@@ -209,9 +249,220 @@ fn find_commit_subcommand(args: &[OsString]) -> Option<usize> {
             ix += 1;
             continue;
         }
-        return (token == "commit").then_some(ix);
+        return Some((ix, token));
     }
     None
+}
+
+/// A teaching hint for a command line the modern parser rejected, when the
+/// failure looks like retired syntax for one of the revamped subcommands.
+/// Returns the command's metrics name alongside the hint so the caller can
+/// record that retired syntax is still being produced.
+///
+/// Unlike [`translate_commit`], nothing is executed on the caller's behalf:
+/// the hint names the concrete modern equivalent when it can be derived
+/// mechanically, and otherwise just points at the command's help.
+pub(crate) fn parse_failure_hint(args: &[OsString], agent: bool) -> Option<(CommandName, String)> {
+    let (ix, subcommand) = find_subcommand(args)?;
+    let tail = &args[ix + 1..];
+    let (command, hint) = match subcommand.to_str()? {
+        "amend" => (CommandName::Amend, amend_hint(tail, agent)),
+        "move" => (CommandName::Move, move_hint(tail, agent)),
+        "squash" => (CommandName::Squash, squash_hint(tail, agent)),
+        "uncommit" => (CommandName::Uncommit, uncommit_hint(tail, agent)),
+        _ => return None,
+    };
+    Some((command, hint?))
+}
+
+/// Hint body naming the concrete modern equivalent of a retired invocation.
+fn equivalent_body(cmd: &str, modern: &str) -> String {
+    format!(
+        "this invocation used retired `but {cmd}` syntax. The modern equivalent is:\n\n    \
+         {modern}\n\n\
+         See `but {cmd} --help` for details."
+    )
+}
+
+/// Hint body for retired syntax where no concrete rewrite can be derived.
+fn changed_body(cmd: &str) -> String {
+    format!("`but {cmd}` syntax has changed. See `but {cmd} --help` for the current form.")
+}
+
+/// Whether the tail contains one of the given retired-only flags, in bare or
+/// attached-value form. This is what separates retired syntax from a modern
+/// invocation that merely failed to parse; hints must never fire for the
+/// latter.
+fn has_retired_flag(tail: &[OsString], flags: &[&str]) -> bool {
+    tail.iter().filter_map(|token| token.to_str()).any(|token| {
+        flags.iter().any(|flag| match token.strip_prefix(flag) {
+            // Long flags attach a value with `=`; short flags attach it
+            // directly.
+            Some(rest) => rest.is_empty() || !flag.starts_with("--") || rest.starts_with('='),
+            None => false,
+        })
+    })
+}
+
+/// Whether a captured value can be re-emitted verbatim inside a suggested
+/// command line: nothing flag-like, empty, or containing characters that
+/// would change shell tokenization when the suggestion is copy-pasted.
+/// Anything else falls back to a hint without a concrete rewrite.
+pub(crate) fn plain(value: &str) -> bool {
+    !value.is_empty()
+        && !value.starts_with('-')
+        && value
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | '/' | '#'))
+}
+
+/// Parse a subcommand tail under a retired grammar, for deriving suggestions.
+fn parse_retired<P: clap::Parser>(tail: &[OsString]) -> Option<P> {
+    let parse = std::iter::once(OsString::from("but")).chain(tail.iter().cloned());
+    P::try_parse_from(parse).ok()
+}
+
+/// The retired `but amend` grammar: `but amend <commit> --changes <id>,<id>`.
+#[derive(Debug, clap::Parser)]
+struct RetiredAmend {
+    /// The commit to amend into.
+    commit: Option<String>,
+    #[clap(long = "changes", short = 'p', value_delimiter = ',')]
+    changes: Vec<String>,
+    #[clap(flatten)]
+    globals: RetiredGlobals,
+}
+
+/// Retired amend failures: the `--changes` flag is the only marker. Bare
+/// positionals are left to the plain parse error — `but amend <a> <b>` is
+/// just as likely a modern invocation missing `--target`, and a retired
+/// reading would reverse it.
+fn amend_hint(tail: &[OsString], agent: bool) -> Option<String> {
+    if !has_retired_flag(tail, &["--changes", "-p"]) {
+        return None;
+    }
+    let modern = parse_retired::<RetiredAmend>(tail).and_then(|retired| {
+        let commit = retired.commit?;
+        (plain(&commit) && !retired.changes.is_empty() && retired.changes.iter().all(|c| plain(c)))
+            .then(|| format!("but amend -t {commit} {}", retired.changes.join(" ")))
+    });
+    Some(match modern {
+        Some(modern) => note(&equivalent_body("amend", &modern), agent),
+        None => note(&changed_body("amend"), agent),
+    })
+}
+
+/// The retired `but move` grammar: `but move <source> <target> [--after]`,
+/// with comma-separated multi-commit sources and `zz` as the unstack target.
+#[derive(Debug, clap::Parser)]
+struct RetiredMove {
+    source: Option<String>,
+    target: Option<String>,
+    #[clap(short = 'a', long)]
+    after: bool,
+    #[clap(flatten)]
+    globals: RetiredGlobals,
+}
+
+/// Retired move failures: the two-positional `but move <source> <target>`
+/// form (the modern grammar requires a placement flag), or the retired
+/// `--after` flag.
+fn move_hint(tail: &[OsString], agent: bool) -> Option<String> {
+    let body = parse_retired::<RetiredMove>(tail).and_then(|retired| {
+        let (Some(source), Some(target)) = (retired.source, retired.target) else {
+            return None;
+        };
+        let sources: Vec<&str> = source.split(',').collect();
+        if !plain(&target) || sources.iter().any(|source| !plain(source)) {
+            return None;
+        }
+        let sources = sources.join(" ");
+        if target == "zz" {
+            // A `zz` target tore a branch off its stack.
+            return (!retired.after)
+                .then(|| equivalent_body("move", &format!("but move {sources} --unstack")));
+        }
+        if retired.after {
+            // `--after` only applied to commit targets, where it meant above.
+            return Some(equivalent_body(
+                "move",
+                &format!("but move {sources} --above {target}"),
+            ));
+        }
+        // The target's kind is unknown without resolving it, and the modern
+        // placement differs: the retired default put sources before (below) a
+        // commit target, but placed them on top of a branch target.
+        Some(equivalent_body(
+            "move",
+            &format!(
+                "but move {sources} --below {target}     if {target} is a commit\n    \
+                 but move {sources} --branch {target}    if {target} is a branch\n    \
+                 but move {sources} --above {target}     to stack a branch onto branch {target}"
+            ),
+        ))
+    });
+    match body {
+        Some(body) => Some(note(&body, agent)),
+        None => {
+            has_retired_flag(tail, &["--after", "-a"]).then(|| note(&changed_body("move"), agent))
+        }
+    }
+}
+
+/// Retired squash failures: only the retired-only flags, since the retired
+/// positional forms parse under the modern grammar and are hinted at resolve
+/// time instead.
+fn squash_hint(tail: &[OsString], agent: bool) -> Option<String> {
+    if has_retired_flag(tail, &["--drop-message", "-d"]) {
+        return Some(note(
+            "the retired `--drop-message` flag is now `--use-target-message` (`-u`). \
+             See `but squash --help` for details.",
+            agent,
+        ));
+    }
+    has_retired_flag(tail, &["--ai", "-i"]).then(|| note(&changed_body("squash"), agent))
+}
+
+/// The retired `but uncommit` grammar, for extracting the single source when
+/// suggesting `but discard`.
+#[derive(Debug, clap::Parser)]
+struct RetiredUncommit {
+    source: Option<String>,
+    #[clap(long, short = 'd')]
+    discard: bool,
+    #[clap(long)]
+    diff: bool,
+    #[clap(flatten)]
+    globals: RetiredGlobals,
+}
+
+/// The modern `but uncommit <source>...` keeps the retired shape, so only the
+/// retired-only flags get a hint; other failures return `None`.
+fn uncommit_hint(tail: &[OsString], agent: bool) -> Option<String> {
+    if has_retired_flag(tail, &["--discard", "-d"]) {
+        let modern = parse_retired::<RetiredUncommit>(tail)
+            .and_then(|retired| retired.source)
+            .filter(|source| plain(source))
+            .map_or_else(
+                || "but discard <source>...".to_owned(),
+                |source| format!("but discard {source}"),
+            );
+        return Some(note(
+            &format!(
+                "the retired `but uncommit --discard` is now its own command:\n\n    \
+                 {modern}\n\n\
+                 See `but discard --help` for details."
+            ),
+            agent,
+        ));
+    }
+    has_retired_flag(tail, &["--diff"]).then(|| {
+        note(
+            "the retired `--diff` flag was removed; run `but diff` after uncommitting \
+             to see the result.",
+            agent,
+        )
+    })
 }
 
 #[cfg(all(test, feature = "legacy"))]
@@ -221,12 +472,15 @@ mod tests {
     use super::{Translation, hint, translate_commit};
     use crate::args::{Args, Subcommands, commit::Platform};
 
-    fn translate(args: &[&str]) -> Translation {
-        let args: Vec<_> = std::iter::once("but")
+    fn argv(args: &[&str]) -> Vec<std::ffi::OsString> {
+        std::iter::once("but")
             .chain(args.iter().copied())
             .map(Into::into)
-            .collect();
-        translate_commit(&args)
+            .collect()
+    }
+
+    fn translate(args: &[&str]) -> Translation {
+        translate_commit(&argv(args))
     }
 
     fn translated(args: &[&str]) -> Vec<String> {
@@ -492,5 +746,154 @@ mod tests {
     fn skill_pointer_only_shown_to_agents() {
         assert!(hint(true).contains("but skill install"));
         assert!(!hint(false).contains("but skill install"));
+        let retired_amend = failure_hint(&["amend", "j4", "--changes", "ab"], true);
+        assert!(retired_amend.expect("a hint").contains("but skill install"));
+    }
+
+    fn failure_hint(args: &[&str], agent: bool) -> Option<String> {
+        super::parse_failure_hint(&argv(args), agent).map(|(_, hint)| hint)
+    }
+
+    /// The concrete modern equivalent suggested for a retired command line.
+    #[track_caller]
+    fn suggested(args: &[&str]) -> String {
+        let hint = failure_hint(args, false).expect("a hint");
+        let (_, tail) = hint
+            .split_once("    but ")
+            .unwrap_or_else(|| panic!("no suggested command line in {hint:?}"));
+        let (modern, _) = tail.split_once('\n').expect("suggestion ends the line");
+        format!("but {modern}")
+    }
+
+    #[track_caller]
+    fn assert_generic(args: &[&str], cmd: &str) {
+        let hint = failure_hint(args, false).expect("a hint");
+        assert!(
+            hint.contains(&format!("`but {cmd}` syntax has changed")),
+            "expected the generic changed-syntax hint, got {hint:?}"
+        );
+    }
+
+    #[test]
+    fn retired_amend_changes_form_suggests_the_target_flag() {
+        assert_eq!(
+            suggested(&["amend", "j4", "--changes", "ab,cd"]),
+            "but amend -t j4 ab cd"
+        );
+        assert_eq!(suggested(&["amend", "j4", "-pab"]), "but amend -t j4 ab");
+    }
+
+    #[test]
+    fn amend_changes_flag_without_rewrite_gets_the_generic_hint() {
+        // Values that would be re-parsed as flags are never re-emitted, but
+        // `--changes` itself is a retired-only marker.
+        assert_generic(&["amend", "j4", "--changes=-x"], "amend");
+        assert_generic(&["amend", "j4", "--changes=one,"], "amend");
+        // Values that would change shell tokenization if the suggestion is
+        // copy-pasted are never re-emitted either.
+        assert_generic(&["amend", "j4", "--changes", "a;echo"], "amend");
+        assert_generic(&["amend", "j4;echo", "--changes", "ab"], "amend");
+    }
+
+    #[test]
+    fn modern_amend_mistakes_get_no_hint() {
+        // A single positional without --changes was an error in the retired
+        // grammar too; a hint would misdiagnose a modern mistake.
+        assert_eq!(failure_hint(&["amend", "j4"], false), None);
+        assert_eq!(failure_hint(&["amend", "--bogus"], false), None);
+        // Bare positionals are as likely a modern invocation missing
+        // `--target` as the retired hidden two-positional form; a retired
+        // reading would reverse source and target.
+        assert_eq!(failure_hint(&["amend", "ab", "j4"], false), None);
+        assert_eq!(failure_hint(&["amend", "ab", "cd", "ef"], false), None);
+    }
+
+    #[test]
+    fn retired_move_forms_suggest_placement_flags() {
+        // The retired default placement depended on the target's kind, which
+        // cannot be resolved at parse time, so both readings are offered.
+        let hint = failure_hint(&["move", "ab", "cd"], false).expect("a hint");
+        assert!(hint.contains("but move ab --below cd"), "got {hint:?}");
+        assert!(hint.contains("but move ab --branch cd"), "got {hint:?}");
+        // Comma-separated multi-commit sources become positionals.
+        let hint = failure_hint(&["move", "ab,cd", "ef"], false).expect("a hint");
+        assert!(hint.contains("but move ab cd --below ef"), "got {hint:?}");
+        // `--after` only applied to commit targets, and the `zz` target tore
+        // a branch off; both map to a single modern equivalent.
+        assert_eq!(
+            suggested(&["move", "ab", "cd", "--after"]),
+            "but move ab --above cd"
+        );
+        assert_eq!(suggested(&["move", "ab", "zz"]), "but move ab --unstack");
+    }
+
+    #[test]
+    fn retired_move_flag_without_rewrite_gets_the_generic_hint() {
+        // `--after` never applied to the unstack target, so there is no
+        // equivalent to suggest — but the flag itself is a retired-only
+        // marker.
+        assert_generic(&["move", "ab", "zz", "--after"], "move");
+    }
+
+    #[test]
+    fn modern_move_mistakes_get_no_hint() {
+        assert_eq!(failure_hint(&["move", "ab"], false), None);
+        assert_eq!(failure_hint(&["move", "ab,", "cd"], false), None);
+        assert_eq!(failure_hint(&["move", "-b"], false), None);
+        // Modern long flags must not be mistaken for the retired short `-a`.
+        assert_eq!(
+            failure_hint(&["move", "--below", "x", "--above", "y"], false),
+            None
+        );
+    }
+
+    #[test]
+    fn retired_squash_flags_get_hints_and_other_failures_none() {
+        let hint = failure_hint(&["squash", "ab", "cd", "-d"], false).expect("a hint");
+        assert!(hint.contains("--use-target-message"), "got {hint:?}");
+        assert_generic(&["squash", "ab", "--ai"], "squash");
+        assert_generic(&["squash", "ab", "--ai=summary"], "squash");
+        // Modern mistakes are left to the plain parse error.
+        assert_eq!(failure_hint(&["squash"], false), None);
+        assert_eq!(failure_hint(&["squash", "--bogus"], false), None);
+    }
+
+    #[test]
+    fn retired_uncommit_flags_get_hints_and_other_failures_none() {
+        let hint = failure_hint(&["uncommit", "--discard", "ab"], false).expect("a hint");
+        assert!(hint.contains("but discard ab"), "got {hint:?}");
+        let hint = failure_hint(&["uncommit", "-d"], false).expect("a hint");
+        assert!(hint.contains("but discard <source>..."), "got {hint:?}");
+        let hint = failure_hint(&["uncommit", "--discard=true", "ab"], false).expect("a hint");
+        assert!(hint.contains("but discard"), "got {hint:?}");
+        let hint = failure_hint(&["uncommit", "--diff", "ab"], false).expect("a hint");
+        assert!(hint.contains("but diff"), "got {hint:?}");
+        // The modern grammar kept the retired shape, so any other failure is
+        // not retired syntax.
+        assert_eq!(failure_hint(&["uncommit", "--bogus", "ab"], false), None);
+    }
+
+    #[test]
+    fn other_subcommands_get_no_failure_hint() {
+        assert_eq!(failure_hint(&["branch", "--bogus"], false), None);
+        assert_eq!(failure_hint(&["discard"], false), None);
+    }
+
+    #[test]
+    fn failure_hints_skip_root_options() {
+        assert_eq!(
+            suggested(&["-C", "/repo", "move", "ab", "cd", "--after"]),
+            "but move ab --above cd"
+        );
+    }
+
+    #[test]
+    fn rub_hint_teaches_squash_and_move() {
+        let hint = super::removed_command_hint(std::ffi::OsStr::new("rub"), false)
+            .expect("rub was removed by the revamp");
+        assert!(hint.contains("but squash <source>... -t <target>"));
+        assert!(hint.contains("placement flag"));
+        let other = super::removed_command_hint(std::ffi::OsStr::new("frobnicate"), false);
+        assert_eq!(other, None, "only removed commands get a hint");
     }
 }

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -681,6 +681,25 @@ impl<T> ResultMetricsExt<T, CliError> for Result<T, CliError> {
     }
 }
 
+/// Emit an event for a command line that never ran because the parser
+/// rejected it and a retired-syntax teaching hint was shown.
+///
+/// The event carries a `retiredSyntaxHint` prop, so remaining pre-revamp
+/// usage can be tracked to decide when the hints in `retired_syntax` can be
+/// removed. Root options like `-C` are not parsed on the failure paths that
+/// call this, so the event reports the process working directory.
+pub(crate) fn emit_retired_syntax_hint(command: CommandName) {
+    let Ok(settings) = crate::app_settings() else {
+        return;
+    };
+    if !settings.telemetry.app_metrics_enabled {
+        return;
+    }
+    let mut props = Props::new();
+    props.insert("retiredSyntaxHint", true);
+    emit_metrics(command, &props, Path::new("."));
+}
+
 fn emit_metrics(command: CommandName, props: &Props, current_dir: &Path) {
     let Some(v) = command.to_possible_value() else {
         tracing::warn!("BUG: didn't get string value for {command:?}");

--- a/crates/but/tests/but/command/amend.rs
+++ b/crates/but/tests/but/command/amend.rs
@@ -200,3 +200,43 @@ Hint: Most likely you want `but pull`, which updates the workspace and removes l
 
 "#]]);
 }
+
+#[test]
+fn retired_syntax_gets_a_teaching_hint() {
+    let env = Sandbox::empty();
+
+    // The pre-revamp `but amend <commit> --changes <id>,<id>` form: the hint
+    // suggests the concrete modern equivalent before the parse error.
+    env.but("amend j4 --changes ab,cd")
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
+
+note: this invocation used retired `but amend` syntax. The modern equivalent is:
+
+    but amend -t j4 ab cd
+
+See `but amend --help` for details.
+error: unexpected argument '--changes' found
+
+  tip: to pass '--changes' as a value, use '-- --changes'
+
+Usage: but amend --target <COMMIT_OR_BRANCH> <SOURCES>...
+
+For more information, try '--help'.
+
+"#]]);
+}
+
+#[test]
+fn retired_flag_with_help_passes_through_without_hint() {
+    let env = Sandbox::empty();
+
+    // Help requests arrive as clap parse errors too; when clap decides to
+    // show help despite the retired `--changes` marker being present, no
+    // retired-syntax note may precede it.
+    env.but("amend --help --changes ab")
+        .assert()
+        .success()
+        .stderr_eq(str![""]);
+}

--- a/crates/but/tests/but/command/external.rs
+++ b/crates/but/tests/but/command/external.rs
@@ -153,3 +153,24 @@ For more information, try '--help'.
 
 "#]]);
 }
+
+#[test]
+fn removed_rub_command_teaches_its_replacements() {
+    let env = Sandbox::empty();
+
+    env.but("rub ab cd").assert().failure().stderr_eq(str![[r#"
+
+note: `but rub` was retired. Squashing sources into a target is now:
+
+    but squash <source>... -t <target>
+
+Moving sources is `but move <source>...` with a placement flag (`--below`/`--above` a commit, `--branch <branch>`).
+See `but squash --help` and `but move --help` for details.
+error: unrecognized subcommand 'rub'
+
+Usage: but [OPTIONS] [COMMAND]
+
+For more information, try '--help'.
+
+"#]]);
+}

--- a/crates/but/tests/but/command/move.rs
+++ b/crates/but/tests/but/command/move.rs
@@ -2682,3 +2682,31 @@ Hint: Most likely you want `but pull`, which updates the workspace and removes l
 
 "#]]);
 }
+
+#[test]
+fn retired_syntax_gets_a_teaching_hint() {
+    let env = Sandbox::empty();
+
+    // The pre-revamp `but move <source> <target>` form placed the source
+    // below the target; the hint suggests the flagged modern equivalent.
+    env.but("move ab cd")
+        .assert()
+        .failure()
+        .stderr_eq(snapbox::str![[r#"
+
+note: this invocation used retired `but move` syntax. The modern equivalent is:
+
+    but move ab --below cd     if cd is a commit
+    but move ab --branch cd    if cd is a branch
+    but move ab --above cd     to stack a branch onto branch cd
+
+See `but move --help` for details.
+error: the following required arguments were not provided:
+  <--above <BRANCH_OR_COMMIT>|--below <BRANCH_OR_COMMIT>|--branch [<BRANCH>]|--unstack>
+
+Usage: but move <--above <BRANCH_OR_COMMIT>|--below <BRANCH_OR_COMMIT>|--branch [<BRANCH>]|--unstack> <SOURCES>...
+
+For more information, try '--help'.
+
+"#]]);
+}

--- a/crates/but/tests/but/command/squash.rs
+++ b/crates/but/tests/but/command/squash.rs
@@ -686,6 +686,8 @@ fn cannot_squash_multiple_commits_without_target() {
         .stderr_eq(snapbox::str![[r#"
 Error: When --target isn't used the source must be exactly one branch
 
+Hint: To squash into the last source, use `but squash 1#0 -t 1#2`
+
 "#]]);
 }
 
@@ -702,6 +704,8 @@ fn cannot_squash_multiple_branches_without_target() {
         .failure()
         .stderr_eq(snapbox::str![[r#"
 Error: When --target isn't used the source must be exactly one branch
+
+Hint: To squash into the last source, use `but squash a-branch-1 -t second-branch`
 
 "#]]);
 }

--- a/crates/but/tests/but/command/uncommit.rs
+++ b/crates/but/tests/but/command/uncommit.rs
@@ -259,3 +259,28 @@ Hint: Most likely you want `but pull`, which updates the workspace and removes l
 
 "#]]);
 }
+
+#[test]
+fn retired_discard_flag_points_at_the_discard_command() {
+    let env = Sandbox::empty();
+
+    env.but("uncommit --discard ab")
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
+
+note: the retired `but uncommit --discard` is now its own command:
+
+    but discard ab
+
+See `but discard --help` for details.
+error: unexpected argument '--discard' found
+
+  tip: to pass '--discard' as a value, use '-- --discard'
+
+Usage: but uncommit [OPTIONS] <SOURCES>...
+
+For more information, try '--help'.
+
+"#]]);
+}


### PR DESCRIPTION
#15033 gave `but commit` a translation fallback for its retired syntax. The other revamped commands — `amend`, `move`, `squash`, `uncommit`, and the removed `rub` — still fail with raw clap errors that teach nothing, so agents producing pre-revamp syntax dead-end.

Rejected command lines that carry a retired-only marker now get a teaching hint ahead of the parse error, with the concrete modern equivalent whenever it can be derived mechanically:

- `but amend <commit> --changes ab,cd` suggests `but amend -t <commit> ab cd`
- `but move <src> <target> --after` suggests `--above`; a `zz` target suggests `--unstack`
- `but move <src> <target>` lists the readings per target kind — the retired default placed sources below a commit target but on top of a branch target, so a single rewrite would mis-teach one of them
- `but uncommit --discard <id>` points at `but discard <id>`; retired squash flags map to their modern spellings
- `but rub` (an unknown subcommand today) explains the squash/move split

Nothing is translated or executed for these; commit remains the only translated command. Hints fire only on retired-only markers, never for a modern invocation that merely failed to parse, and help/version requests pass through untouched. Multi-source `squash` without `--target` additionally suggests the flagged equivalent of the retired into-last form at resolve time.

Hinted invocations emit a `retiredSyntaxHint` command prop so remaining pre-revamp usage can be observed to decide when this handling (all contained in `retired_syntax.rs` plus two seams in `lib.rs`) can be deleted; `rub` attempts were already visible via `externalSubcommand`.