### PR TITLE
Remove `Serialize` and `Deserialize` impls from `ChangeId`

### DIFF
--- a/crates/but-core/src/change_id.rs
+++ b/crates/but-core/src/change_id.rs
@@ -4,7 +4,6 @@ use std::{fmt, ops::Deref, sync::Arc};
 
 use bstr::{BStr, BString};
 use rand::Rng;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// How long a reverse hex change id should be if stored in actual reverse hex
 /// ASCII characters, ranging from `z` to `k`. In accordance with the standard
@@ -139,24 +138,6 @@ impl fmt::Debug for ChangeId {
 impl fmt::Display for ChangeId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.as_bstr().fmt(f)
-    }
-}
-
-impl<'de> Deserialize<'de> for ChangeId {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        BString::deserialize(deserializer).map(ChangeId::from_bstring)
-    }
-}
-
-impl Serialize for ChangeId {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        self.as_bstr().serialize(serializer)
     }
 }
 


### PR DESCRIPTION
`Serialize` and `Deserialize` for `ChangeId` would serialize the raw bytes. So
if you had a change id like "ymospk..." it would get serialized as
`[121,109,111,115,...]`. I think this is surprising and a footgun because
when the CLI produces JSON we'd always want the stringified change ids since
thats what you pass into other commands.

We could just change the impls to do that but since we also ingest change ids
from other VCSs I guess that might be dangerous. So I propose we just remove
the impls entirely. They weren't actually used anyway.

In #15042 I'm gonna add a newtype that serializes change ids as strings but
doesn't support deserialization, since serialization will use
`.to_str_lossy()`.