### PR TITLE
Fix uncommit leaving files staged in the index

### DIFF
--- a/crates/but-rebase/src/graph_rebase/materialize.rs
+++ b/crates/but-rebase/src/graph_rebase/materialize.rs
@@ -6,6 +6,7 @@ use but_core::{
 };
 use gix::{
     bstr::{BString, ByteSlice as _},
+    prelude::ObjectIdExt as _,
     refs::{
         Target,
         transaction::{Change, LogChange, PreviousValue, RefEdit, RefLog},
@@ -274,6 +275,13 @@ impl<'ws, 'graph, M: RefMetadata> SuccessfulRebase<'ws, 'graph, M> {
         )?);
         repo.edit_references(ref_edits)?;
 
+        // Skipping the checkout leaves the worktree alone on purpose, but `HEAD` still
+        // moved. The index has to follow it, or its entries keep pointing at blobs from
+        // the commits that were just rewritten, and Git reports those paths as staged
+        // even though the worktree matches `HEAD`. These are `git reset --mixed`
+        // semantics: move the ref and reset the index, but keep the worktree.
+        reset_index_to_head(&repo)?;
+
         let project_meta = self.workspace.graph.project_meta.clone();
         self.workspace
             .refresh_from_head(&repo, &*self.meta, project_meta)?;
@@ -285,4 +293,26 @@ impl<'ws, 'graph, M: RefMetadata> SuccessfulRebase<'ws, 'graph, M> {
             meta: self.meta,
         })
     }
+}
+
+/// Reset `.git/index` to `HEAD^{tree}`, leaving the working tree untouched.
+///
+/// GitButler tracks the worktree rather than the staging area, so the index is only
+/// ever a cache of `HEAD`. Letting it drift makes Git report paths as staged that the
+/// user never staged, and nothing in the normal flow clears that residue.
+fn reset_index_to_head(repo: &gix::Repository) -> Result<()> {
+    let tree_id = match repo.head_id() {
+        // A rewrite can leave `HEAD` on a conflicted commit, whose own tree holds the
+        // conflict sidecars rather than a checkout-able state, so resolve it the same
+        // way anything reading such a commit does.
+        Ok(head_id) => but_core::Commit::from_id(head_id)?
+            .tree_id_or_auto_resolution()?
+            .detach(),
+        // An unborn `HEAD` has no tree, and the empty tree yields the empty index
+        // that matches it.
+        Err(_) => gix::ObjectId::empty_tree(repo.object_hash()),
+    };
+    let mut index = repo.index_from_tree(&tree_id.attach(repo))?;
+    index.write(Default::default())?;
+    Ok(())
 }

--- a/crates/but-rebase/tests/rebase/graph_rebase/materialize.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/materialize.rs
@@ -229,6 +229,37 @@ fn materialize_without_checkout_preserves_dropped_commit_changes_in_worktree() -
 }
 
 #[test]
+fn materialize_without_checkout_resets_the_index_to_the_new_head() -> Result<()> {
+    // Uncommitting rewrites refs while deliberately keeping the worktree, so the index
+    // has to follow `HEAD`. Otherwise its entries still point at the blobs of the commit
+    // that was just dropped, and Git reports those paths as staged even though the user
+    // never staged them - and nothing in the normal flow clears that residue.
+    let (repo, _tmpdir, mut meta) = fixture_writable("four-commits")?;
+
+    let graph =
+        Graph::from_head(&repo, &*meta, Default::default(), standard_options())?.validated()?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo)?;
+
+    // Drop the 'c' commit, which is what uncommitting it amounts to.
+    let c = repo.rev_parse_single("HEAD")?;
+    let c_sel = editor.select_commit(c.detach())?;
+    editor.replace(c_sel, Step::None)?;
+    editor.rebase()?.materialize_without_checkout()?;
+
+    // 'c' stays in the worktree, but as an untracked file rather than a staged addition.
+    snapbox::assert_data_eq!(
+        git_status(&repo)?,
+        snapbox::str![[r#"
+?? c
+
+"#]]
+    );
+
+    Ok(())
+}
+
+#[test]
 fn both_methods_update_references_identically() -> Result<()> {
     // Test with materialize
     let (ref_after_materialize, overlayed_materialize) = {


### PR DESCRIPTION
Fixes #14876

### Problem

Committing a file and then uncommitting it leaves that file **staged** in `.git/index`, with an index blob that differs from `HEAD`. GitButler otherwise tracks the worktree rather than the staging area, so nothing in the normal flow clears the residue.

`materialize_without_checkout()` skips the worktree on purpose, so the uncommitted changes stay put, but it only edits refs. The index is never updated, so its entries keep pointing at blobs from the commits that were just rewritten.

### Fix

Reset the index to `HEAD^{tree}` after the ref edits: `git reset --mixed` semantics, moving the ref and resetting the index while keeping the worktree.

Doing this inside `materialize_without_checkout()` covers all three uncommit entry points at once (`commit_uncommit`, `commit_uncommit_changes` and `commit_uncommit_changes_from_commits`). `gitbutler-edit-mode` already did this resync by hand after its own call to the same function, which is now redundant, but I left it alone rather than make an unrelated change here.

A conflicted `HEAD` is resolved through `tree_id_or_auto_resolution()`, since such a commit's own tree holds the conflict sidecars rather than a checkout-able state.

### Notes

- **Scope is uncommit.** The discard path goes through `materialize()`, which checks out and therefore already updates the index, so the entry that was reported as surviving a discard looks like residue inherited from the earlier uncommit. Happy to add a defensive resync there too if you'd prefer it.
- **The reset is not path-scoped.** Resetting the whole index matches the expectation in the issue, that the index ends up consistent with `HEAD` in line with the index-free model, and matches what edit-mode already does. A path-scoped variant is possible if preserving entries staged outside GitButler matters more.
- **No claim about the conflict warnings.** This addresses the index residue only. Whether the false-positive "incoming changes will conflict" warning follows from the stale entry is unconfirmed and may well be a separate issue.

### Test

`materialize_without_checkout_resets_the_index_to_the_new_head` drops the `HEAD` commit, which is what uncommitting it amounts to, and asserts `git status` reports the file as untracked rather than staged. Against the previous implementation it fails with `A  c`, the file staged by the uncommit itself.

The test sits at the `but-rebase` layer rather than at `commit_uncommit*`, since the single fix point covers both surfaces.
