### PR TITLE
lite: outline section headers and shared Scroller component

### DIFF
--- a/apps/lite/ui/src/components/PickerDialog.module.css
+++ b/apps/lite/ui/src/components/PickerDialog.module.css
@@ -81,19 +81,13 @@
 }
 
 .listArea {
-	display: flex;
-	position: relative;
 	flex: 0 1 auto;
-	min-height: 0;
 	max-height: min(60dvh, 24rem);
 	overflow: hidden;
 }
 
 .listViewport {
 	box-sizing: border-box;
-	flex: 1 1 auto;
-	min-height: 0;
-	overscroll-behavior: contain;
 	scroll-padding-block: 0.25rem;
 
 	&:focus-visible {
@@ -182,35 +176,6 @@
 	color: var(--color-gray-600);
 	font-size: 0.925rem;
 	line-height: 1rem;
-}
-
-.scrollbar {
-	display: flex;
-	justify-content: center;
-	width: 1.5rem;
-	margin-right: -0.25rem;
-	padding-top: 0.5rem;
-	padding-bottom: 0.5rem;
-}
-
-.scrollbarThumb {
-	display: flex;
-	justify-content: center;
-	width: 100%;
-
-	&::before {
-		display: block;
-		width: 0.25rem;
-		height: 100%;
-		border-radius: 0.25rem;
-		background-color: var(--scale-gray-60);
-		content: "";
-		opacity: 0.8;
-	}
-
-	&:hover::before {
-		opacity: 1;
-	}
 }
 
 .footer {

--- a/apps/lite/ui/src/components/PickerDialog.tsx
+++ b/apps/lite/ui/src/components/PickerDialog.tsx
@@ -2,8 +2,9 @@
  * @file Based on https://base-ui.com/react/components/autocomplete#command-palette
  */
 
-import { Autocomplete, Dialog, ScrollArea } from "@base-ui/react";
+import { Autocomplete, Dialog } from "@base-ui/react";
 import { type ReactNode, useRef } from "react";
+import { Scroller } from "#ui/components/Scroller.tsx";
 import styles from "./PickerDialog.module.css";
 
 /** @public */
@@ -65,57 +66,52 @@ export const PickerDialog = <Item,>({
 							/>
 							<Dialog.Close className={styles.visuallyHiddenClose}>{closeLabel}</Dialog.Close>
 
-							<ScrollArea.Root className={styles.listArea}>
-								<ScrollArea.Viewport className={styles.listViewport}>
-									<ScrollArea.Content className={styles.listContent}>
-										<Autocomplete.Status>
-											{statusLabel !== undefined ? (
-												<div className={styles.empty}>{statusLabel}</div>
-											) : null}
-										</Autocomplete.Status>
-										<Autocomplete.Empty>
-											{statusLabel === undefined ? (
-												<div className={styles.empty}>{emptyLabel}</div>
-											) : null}
-										</Autocomplete.Empty>
+							<Scroller className={styles.listArea} viewportClassName={styles.listViewport}>
+								<div className={styles.listContent}>
+									<Autocomplete.Status>
+										{statusLabel !== undefined ? (
+											<div className={styles.empty}>{statusLabel}</div>
+										) : null}
+									</Autocomplete.Status>
+									<Autocomplete.Empty>
+										{statusLabel === undefined ? (
+											<div className={styles.empty}>{emptyLabel}</div>
+										) : null}
+									</Autocomplete.Empty>
 
-										<Autocomplete.List className={styles.list}>
-											{(group: PickerDialogGroup<Item>) => (
-												<Autocomplete.Group
-													key={group.value}
-													items={group.items}
-													className={styles.group}
-												>
-													<Autocomplete.GroupLabel className={styles.groupLabel}>
-														{group.value}
-													</Autocomplete.GroupLabel>
-													<Autocomplete.Collection>
-														{(item: Item) => {
-															const itemType = getItemType(item, group);
-															return (
-																<Autocomplete.Item
-																	key={getItemKey(item)}
-																	className={styles.item}
-																	value={item}
-																	onClick={() => onSelectItem(item)}
-																>
-																	<span className={styles.itemLabel}>{getItemLabel(item)}</span>
-																	{itemType !== undefined && (
-																		<span className={styles.itemType}>{itemType}</span>
-																	)}
-																</Autocomplete.Item>
-															);
-														}}
-													</Autocomplete.Collection>
-												</Autocomplete.Group>
-											)}
-										</Autocomplete.List>
-									</ScrollArea.Content>
-								</ScrollArea.Viewport>
-								<ScrollArea.Scrollbar className={styles.scrollbar}>
-									<ScrollArea.Thumb className={styles.scrollbarThumb} />
-								</ScrollArea.Scrollbar>
-							</ScrollArea.Root>
+									<Autocomplete.List className={styles.list}>
+										{(group: PickerDialogGroup<Item>) => (
+											<Autocomplete.Group
+												key={group.value}
+												items={group.items}
+												className={styles.group}
+											>
+												<Autocomplete.GroupLabel className={styles.groupLabel}>
+													{group.value}
+												</Autocomplete.GroupLabel>
+												<Autocomplete.Collection>
+													{(item: Item) => {
+														const itemType = getItemType(item, group);
+														return (
+															<Autocomplete.Item
+																key={getItemKey(item)}
+																className={styles.item}
+																value={item}
+																onClick={() => onSelectItem(item)}
+															>
+																<span className={styles.itemLabel}>{getItemLabel(item)}</span>
+																{itemType !== undefined && (
+																	<span className={styles.itemType}>{itemType}</span>
+																)}
+															</Autocomplete.Item>
+														);
+													}}
+												</Autocomplete.Collection>
+											</Autocomplete.Group>
+										)}
+									</Autocomplete.List>
+								</div>
+							</Scroller>
 
 							<div className={styles.footer}>
 								<div className={styles.footerLeft}>

--- a/apps/lite/ui/src/components/Scroller.tsx
+++ b/apps/lite/ui/src/components/Scroller.tsx
@@ -1,0 +1,37 @@
+import { classes } from "#ui/components/classes.ts";
+import { ScrollArea } from "@base-ui/react";
+import type { ComponentProps, FC } from "react";
+import styles from "./ui.module.css";
+
+/**
+ * A scroll container based on Base UI's ScrollArea with the standard overlay
+ * scrollbar. Unlike a native scrollbar, it doesn't reserve gutter space, so
+ * content and sticky separators can span the full viewport width.
+ *
+ * `className` applies to the root (use it for sizing within the parent
+ * layout), `viewportClassName` to the scroll viewport (use it for the
+ * content padding).
+ */
+export const Scroller: FC<
+	{
+		className?: string;
+		viewportClassName?: string;
+		/** Show a separator line at the top edge while scrolled down. */
+		withSeparator?: boolean;
+	} & Omit<ComponentProps<typeof ScrollArea.Root>, "className">
+> = ({ className, viewportClassName, withSeparator = false, children, ...props }) => (
+	<ScrollArea.Root {...props} className={classes(styles.scrollAreaRoot, className)}>
+		<ScrollArea.Viewport
+			className={classes(
+				styles.scrollAreaViewport,
+				withSeparator && styles.scrollerWithSeparator,
+				viewportClassName,
+			)}
+		>
+			{children}
+		</ScrollArea.Viewport>
+		<ScrollArea.Scrollbar className={styles.scrollAreaScrollbar}>
+			<ScrollArea.Thumb className={styles.scrollAreaThumb} />
+		</ScrollArea.Scrollbar>
+	</ScrollArea.Root>
+);

--- a/apps/lite/ui/src/components/ui.module.css
+++ b/apps/lite/ui/src/components/ui.module.css
@@ -53,6 +53,72 @@
 	}
 }
 
+/* Scrollbar/thumb styles for Base UI's ScrollArea (see Scroller.tsx). Unlike
+   .overlayScrollbar, the scrollbar is a true overlay: it doesn't reserve
+   gutter space, so sticky separators and content can span the full viewport
+   width. */
+.scrollAreaRoot {
+	display: flex;
+	position: relative;
+	min-height: 0;
+}
+
+.scrollAreaViewport {
+	flex: 1 1 auto;
+	min-width: 0;
+	overscroll-behavior: contain;
+}
+
+.scrollAreaScrollbar {
+	display: flex;
+	z-index: 1;
+	position: absolute;
+	inset-block: 0;
+	right: 0;
+	width: 10px;
+	padding-block: 3px;
+	opacity: 0;
+	pointer-events: none;
+	transition: opacity 120ms ease;
+
+	&[data-hovering],
+	&[data-scrolling] {
+		opacity: 1;
+		pointer-events: auto;
+	}
+}
+
+.scrollAreaThumb {
+	display: flex;
+	justify-content: center;
+	width: 100%;
+
+	/* The visible pill is painted on a pseudo-element so its border radius
+	   applies to the actual painted box, keeping the end caps circular as the
+	   thumb widens on hover. */
+	&::before {
+		display: block;
+		width: 4px;
+		height: 100%;
+		border-radius: 10px;
+		background-color: color-mix(in srgb, var(--text-1) 25%, transparent);
+		content: "";
+		transition:
+			width 120ms ease,
+			background-color 120ms ease;
+	}
+
+	/* Widen while scrolling or hovering; darken only on hover. */
+	.scrollAreaScrollbar:hover &::before,
+	.scrollAreaScrollbar[data-scrolling] &::before {
+		width: 6px;
+	}
+
+	.scrollAreaScrollbar:hover &::before {
+		background-color: color-mix(in srgb, var(--text-1) 40%, transparent);
+	}
+}
+
 .scrollerWithSeparator {
 	container-type: scroll-state;
 	overflow: auto;

--- a/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.module.css
@@ -17,18 +17,16 @@
 	flex-grow: 1;
 }
 
+.listArea {
+	flex-grow: 1;
+}
+
 .list {
 	display: flex;
 	row-gap: 8px;
-	flex-grow: 1;
 	flex-direction: column;
-
-	/* The scrollbar gutter takes up part of the inline end padding so the
-	   thumb visually overlays the panel margin. */
-	padding-inline: var(--panel-padding-inline)
-		calc(var(--panel-padding-inline) - var(--overlay-scrollbar-size));
+	padding-inline: var(--panel-padding-inline);
 	padding-block: var(--panel-padding-block);
-	overflow-y: auto;
 }
 
 /* The tree holds only stack groups, so the heading and empty-state message

--- a/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.tsx
@@ -1,5 +1,5 @@
 import rowStyles from "./Row.module.css";
-import uiStyles from "#ui/components/ui.module.css";
+import { Scroller } from "#ui/components/Scroller.tsx";
 import { useApply } from "#ui/api/mutations.ts";
 import { branchDetailsQueryOptions } from "#ui/api/queries.ts";
 import { encodeBytes } from "#ui/api/bytes.ts";
@@ -385,7 +385,7 @@ export const BranchesList: FC<
 				/>
 			</div>
 
-			<div className={classes(styles.list, uiStyles.overlayScrollbar)}>
+			<Scroller className={styles.listArea} viewportClassName={styles.list}>
 				<h4 id={headingId} className={classes("text-13", styles.heading)}>
 					Recent branches
 				</h4>
@@ -423,7 +423,7 @@ export const BranchesList: FC<
 						</div>
 					))}
 				</div>
-			</div>
+			</Scroller>
 		</div>
 	);
 };

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -1,4 +1,4 @@
-import uiStyles from "#ui/components/ui.module.css";
+import { Scroller } from "#ui/components/Scroller.tsx";
 import { SuspenseQuery } from "@suspensive/react-query";
 import {
 	useMergeReview,
@@ -1273,16 +1273,17 @@ const Diff: FC<{
 							minSize={180}
 							groupResizeBehavior="preserve-pixel-size"
 						>
-							<FilesTree
-								data-selection-scope={"files" satisfies SelectionScope}
-								className={classes(styles.diffFiles, uiStyles.scrollerWithSeparator)}
-								onFileSelection={selectFileAndNavigateDiff}
-								projectId={projectId}
-								items={filesItems}
-								selection={filesSelection}
-								navigationIndex={filesNavigationIndex}
-								fileParent={fileParent}
-							/>
+							<Scroller withSeparator viewportClassName={styles.diffFiles}>
+								<FilesTree
+									data-selection-scope={"files" satisfies SelectionScope}
+									onFileSelection={selectFileAndNavigateDiff}
+									projectId={projectId}
+									items={filesItems}
+									selection={filesSelection}
+									navigationIndex={filesNavigationIndex}
+									fileParent={fileParent}
+								/>
+							</Scroller>
 						</Panel>
 						<Separator className={styles.resizeHandle} />
 					</>

--- a/apps/lite/ui/src/routes/project/$id/workspace/Outline.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Outline.tsx
@@ -32,6 +32,8 @@ import type { BranchesOutline } from "#ui/routes/project/$id/workspace/useBranch
 import type { OutlineTab } from "#ui/projects/project.ts";
 import styles from "./Outline.module.css";
 import { TopLeftControls } from "#ui/routes/project/$id/workspace/TopLeftControls.tsx";
+import { RowToolbar } from "#ui/routes/project/$id/workspace/Row.tsx";
+import { getRowButtonClassName } from "#ui/routes/project/$id/workspace/Row-utils.ts";
 
 const ActivitySpinner: FC = () => {
 	const fetchingCount = useIsFetching();
@@ -300,28 +302,6 @@ export const Outline: FC<
 
 						<Tooltip.Root>
 							<Tooltip.Trigger
-								aria-label={workspaceHotkeys.createIndependentBranch.meta.name}
-								className={getButtonClassName({ iconOnly: true })}
-								onClick={createIndependentBranch}
-								// We pass `disabled` here because we want to disable the button, not
-								// the tooltip. Other props should be passed above.
-								render={<Button focusableWhenDisabled disabled={!canCreateIndependentBranch} />}
-							>
-								{isBranchCreatePending ? <Icon name="spinner" /> : <Icon name="plus" />}
-							</Tooltip.Trigger>
-							<Tooltip.Portal>
-								<Tooltip.Positioner sideOffset={4}>
-									<Tooltip.Popup
-										render={<TooltipPopup kbd={workspaceHotkeys.createIndependentBranch.hotkey} />}
-									>
-										{workspaceHotkeys.createIndependentBranch.meta.name}
-									</Tooltip.Popup>
-								</Tooltip.Positioner>
-							</Tooltip.Portal>
-						</Tooltip.Root>
-
-						<Tooltip.Root>
-							<Tooltip.Trigger
 								aria-label={workspaceHotkeys.applyBranch.meta.name}
 								className={getButtonClassName({ iconOnly: true })}
 								onClick={openApplyBranchPicker}
@@ -398,6 +378,33 @@ export const Outline: FC<
 					uncommittedFilesNavigationIndex={uncommittedFilesNavigationIndex}
 					absorptionTargetCommitIds={absorptionTargetCommitIds}
 					projectId={projectId}
+					stacksHeaderActions={
+						<RowToolbar forceVisible>
+							<Tooltip.Root>
+								<Tooltip.Trigger
+									aria-label={workspaceHotkeys.createIndependentBranch.meta.name}
+									className={getRowButtonClassName({ size: "regular", iconOnly: true })}
+									onClick={createIndependentBranch}
+									// We pass `disabled` here because we want to disable the button, not
+									// the tooltip. Other props should be passed above.
+									render={<Button focusableWhenDisabled disabled={!canCreateIndependentBranch} />}
+								>
+									{isBranchCreatePending ? <Icon name="spinner" /> : <Icon name="plus" />}
+								</Tooltip.Trigger>
+								<Tooltip.Portal>
+									<Tooltip.Positioner sideOffset={4}>
+										<Tooltip.Popup
+											render={
+												<TooltipPopup kbd={workspaceHotkeys.createIndependentBranch.hotkey} />
+											}
+										>
+											{workspaceHotkeys.createIndependentBranch.meta.name}
+										</Tooltip.Popup>
+									</Tooltip.Positioner>
+								</Tooltip.Portal>
+							</Tooltip.Root>
+						</RowToolbar>
+					}
 				/>
 			)}
 		</div>

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.module.css
@@ -42,13 +42,17 @@
 	min-height: 0;
 }
 
-.uncommittedChangesTree {
+.uncommittedChangesTreeArea {
 	flex-grow: 1;
+}
 
-	/* The scrollbar gutter takes up part of the inline end padding so the
-	   thumb visually overlays the panel margin. */
-	padding-inline: var(--panel-padding-inline)
-		calc(var(--panel-padding-inline) - var(--overlay-scrollbar-size));
+.uncommittedChangesTree {
+	padding-inline: var(--panel-padding-inline);
+
+	/* Stretch the scroll separator over the inline padding to full width. */
+	&::before {
+		margin-inline: calc(-1 * var(--panel-padding-inline));
+	}
 
 	/* Gradient ramp that fades out the scrolling items, shown only while there
 	   is more content to scroll to below. */
@@ -89,18 +93,22 @@
 
 .stacksScroller {
 	flex-grow: 1;
-	min-height: 0;
+}
 
-	/* The scrollbar gutter takes up part of the inline end padding so the
-	   thumb visually overlays the panel margin. */
-	padding-inline: var(--panel-padding-inline)
-		calc(var(--panel-padding-inline) - var(--overlay-scrollbar-size));
+.stacksViewport {
+	padding-inline: var(--panel-padding-inline);
+
+	/* Stretch the scroll separator over the inline padding to full width. */
+	&::before {
+		margin-inline: calc(-1 * var(--panel-padding-inline));
+	}
 }
 
 .stacks {
 	display: flex;
 	row-gap: 8px;
 	flex-direction: column;
+	padding-top: 1px; /* hack to avoid drop shadow crop */
 	padding-bottom: var(--panel-padding-block);
 }
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.module.css
@@ -78,19 +78,30 @@
 }
 
 .stacksPanel {
+	display: flex;
+	flex-direction: column;
 	background-color: var(--bg-2);
+}
+
+.stacksHeader {
+	flex-shrink: 0;
+}
+
+.stacksScroller {
+	flex-grow: 1;
+	min-height: 0;
+
+	/* The scrollbar gutter takes up part of the inline end padding so the
+	   thumb visually overlays the panel margin. */
+	padding-inline: var(--panel-padding-inline)
+		calc(var(--panel-padding-inline) - var(--overlay-scrollbar-size));
 }
 
 .stacks {
 	display: flex;
 	row-gap: 8px;
 	flex-direction: column;
-
-	/* The scrollbar gutter takes up part of the inline end padding so the
-	   thumb visually overlays the panel margin. */
-	padding-inline: var(--panel-padding-inline)
-		calc(var(--panel-padding-inline) - var(--overlay-scrollbar-size));
-	padding-block: var(--panel-padding-block);
+	padding-bottom: var(--panel-padding-block);
 }
 
 .segments {

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
@@ -38,10 +38,18 @@ import uiStyles from "#ui/components/ui.module.css";
 
 import { useQuery } from "@tanstack/react-query";
 import { Match } from "effect";
-import { type ComponentProps, createContext, type FC, Fragment, use, useRef } from "react";
+import {
+	type ComponentProps,
+	createContext,
+	type FC,
+	Fragment,
+	type ReactNode,
+	use,
+	useRef,
+} from "react";
 import { Group, Panel, Separator, useDefaultLayout } from "react-resizable-panels";
 import styles from "./OutlineTree.module.css";
-import { Row, RowLabel, RowLabelContainer } from "../Row.tsx";
+import { Row, RowLabel, RowLabelContainer, SectionHeaderRow } from "../Row.tsx";
 import { treeItemId } from "../Row-utils.ts";
 import { getOperation, type Placement, useDryRunOperation } from "#ui/operations/operation.ts";
 import { createDiffSpec } from "#ui/operations/diff-specs.ts";
@@ -644,12 +652,14 @@ export const OutlineTree: FC<
 		navigationIndex: NavigationIndex<Operand>;
 		uncommittedFilesNavigationIndex: NavigationIndex<string>;
 		absorptionTargetCommitIds: ReadonlySet<string>;
+		stacksHeaderActions?: ReactNode;
 	} & ComponentProps<"div">
 > = ({
 	projectId,
 	navigationIndex,
 	uncommittedFilesNavigationIndex,
 	absorptionTargetCommitIds,
+	stacksHeaderActions,
 	...props
 }) => {
 	const { data: headInfo } = useQuery(headInfoQueryOptions(projectId));
@@ -800,17 +810,27 @@ export const OutlineTree: FC<
 
 					<Separator className={styles.resizeHandle} />
 
-					<Panel
-						id={"stacks-panel" satisfies PanelId}
-						className={classes(styles.stacksPanel, uiStyles.overlayScrollbar)}
-						minSize={120}
-					>
-						<Stacks
-							projectId={projectId}
-							checkCommit={checkCommit}
-							onAmendCommit={amendCommit}
-							canAmendCommit={canAmendCommit}
+					<Panel id={"stacks-panel" satisfies PanelId} className={styles.stacksPanel} minSize={120}>
+						<SectionHeaderRow
+							label="Stacks and branches"
+							className={styles.stacksHeader}
+							actions={stacksHeaderActions}
 						/>
+
+						<div
+							className={classes(
+								styles.stacksScroller,
+								uiStyles.scrollerWithSeparator,
+								uiStyles.overlayScrollbar,
+							)}
+						>
+							<Stacks
+								projectId={projectId}
+								checkCommit={checkCommit}
+								onAmendCommit={amendCommit}
+								canAmendCommit={canAmendCommit}
+							/>
+						</div>
 					</Panel>
 				</Group>
 			</AbsorptionTargetCommitIdsContext>

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
@@ -26,6 +26,7 @@ import { useAppDispatch, useAppSelector, useAppStore } from "#ui/store.ts";
 import { classes } from "#ui/components/classes.ts";
 import { navigationIndexIncludes, type NavigationIndex } from "#ui/workspace/navigation-index.ts";
 import { mergeProps, Tooltip, useRender } from "@base-ui/react";
+import { Scroller } from "#ui/components/Scroller.tsx";
 import type {
 	BranchReference,
 	Segment,
@@ -34,7 +35,6 @@ import type {
 	WorktreeChanges,
 	WorkspaceState,
 } from "@gitbutler/but-sdk";
-import uiStyles from "#ui/components/ui.module.css";
 
 import { useQuery } from "@tanstack/react-query";
 import { Match } from "effect";
@@ -260,12 +260,10 @@ const UncommittedChanges: FC<{
 		<div className={styles.uncommittedChanges}>
 			<UncommittedChangesRow changes={worktreeChanges?.changes ?? []} projectId={projectId} />
 
-			<div
-				className={classes(
-					styles.uncommittedChangesTree,
-					uiStyles.scrollerWithSeparator,
-					uiStyles.overlayScrollbar,
-				)}
+			<Scroller
+				withSeparator
+				className={styles.uncommittedChangesTreeArea}
+				viewportClassName={styles.uncommittedChangesTree}
 			>
 				<FilesTree
 					data-selection-scope={"uncommitted-files" satisfies SelectionScope}
@@ -293,7 +291,7 @@ const UncommittedChanges: FC<{
 					}}
 					selection={fileSelection}
 				/>
-			</div>
+			</Scroller>
 
 			<CommitForm
 				projectId={projectId}
@@ -817,12 +815,10 @@ export const OutlineTree: FC<
 							actions={stacksHeaderActions}
 						/>
 
-						<div
-							className={classes(
-								styles.stacksScroller,
-								uiStyles.scrollerWithSeparator,
-								uiStyles.overlayScrollbar,
-							)}
+						<Scroller
+							withSeparator
+							className={styles.stacksScroller}
+							viewportClassName={styles.stacksViewport}
 						>
 							<Stacks
 								projectId={projectId}
@@ -830,7 +826,7 @@ export const OutlineTree: FC<
 								onAmendCommit={amendCommit}
 								canAmendCommit={canAmendCommit}
 							/>
-						</div>
+						</Scroller>
 					</Panel>
 				</Group>
 			</AbsorptionTargetCommitIdsContext>

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/UncommittedChangesRow.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/UncommittedChangesRow.module.css
@@ -1,9 +1,3 @@
-.container {
-	flex-shrink: 0;
-	padding-inline: calc(var(--panel-padding-inline) + 4px);
-	padding-block: calc(var(--panel-padding-block) - 4px);
-}
-
 .lineStats {
 	display: inline-flex;
 	align-items: center;

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/UncommittedChangesRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/UncommittedChangesRow.tsx
@@ -18,7 +18,7 @@ import type { AbsorptionTarget, TreeChange, UnifiedPatch } from "@gitbutler/but-
 import type { FC } from "react";
 import { getRowButtonClassName } from "../Row-utils.ts";
 import { Badge } from "#ui/components/Badge.tsx";
-import { Row, RowLabel, RowLabelContainer, RowToolbar } from "../Row.tsx";
+import { RowToolbar, SectionHeaderRow } from "../Row.tsx";
 import { useQueries } from "@tanstack/react-query";
 import { treeChangeDiffsQueryOptions } from "#ui/api/queries.ts";
 import styles from "./UncommittedChangesRow.module.css";
@@ -99,43 +99,42 @@ export const UncommittedChangesRow: FC<{
 	];
 
 	return (
-		<Row
-			className={styles.container}
+		<SectionHeaderRow
+			label="Uncommitted changes"
 			onContextMenu={(event) => {
 				void showNativeContextMenu(event, menuItems);
 			}}
-			interactive={false}
-		>
-			<RowLabelContainer>
-				<RowLabel heading>Uncommitted changes</RowLabel>
-
-				<Badge variant="fillGray">{changes.length}</Badge>
-
-				{(lineStats.linesAdded > 0 || lineStats.linesRemoved > 0) && (
-					<span className={classes("text-12", styles.lineStats)}>
-						{lineStats.linesAdded > 0 && (
-							<span className={styles.linesAdded}>+{lineStats.linesAdded}</span>
-						)}
-						{lineStats.linesRemoved > 0 && (
-							<span className={styles.linesRemoved}>-{lineStats.linesRemoved}</span>
-						)}
-					</span>
-				)}
-			</RowLabelContainer>
-
-			{isDefaultMode && (
-				<Toolbar.Root aria-label="Uncommitted changes actions" render={<RowToolbar forceVisible />}>
-					<Toolbar.Button
-						aria-label="Uncommitted changes menu"
-						onClick={(event) => {
-							void showNativeMenuFromTrigger(event.currentTarget, menuItems);
-						}}
-						className={getRowButtonClassName({ iconOnly: true })}
+			actions={
+				isDefaultMode && (
+					<Toolbar.Root
+						aria-label="Uncommitted changes actions"
+						render={<RowToolbar forceVisible />}
 					>
-						<Icon name="kebab" />
-					</Toolbar.Button>
-				</Toolbar.Root>
+						<Toolbar.Button
+							aria-label="Uncommitted changes menu"
+							onClick={(event) => {
+								void showNativeMenuFromTrigger(event.currentTarget, menuItems);
+							}}
+							className={getRowButtonClassName({ size: "regular", iconOnly: true })}
+						>
+							<Icon name="kebab" />
+						</Toolbar.Button>
+					</Toolbar.Root>
+				)
+			}
+		>
+			<Badge variant="fillGray">{changes.length}</Badge>
+
+			{(lineStats.linesAdded > 0 || lineStats.linesRemoved > 0) && (
+				<span className={classes("text-12", styles.lineStats)}>
+					{lineStats.linesAdded > 0 && (
+						<span className={styles.linesAdded}>+{lineStats.linesAdded}</span>
+					)}
+					{lineStats.linesRemoved > 0 && (
+						<span className={styles.linesRemoved}>-{lineStats.linesRemoved}</span>
+					)}
+				</span>
 			)}
-		</Row>
+		</SectionHeaderRow>
 	);
 };

--- a/apps/lite/ui/src/routes/project/$id/workspace/Row-utils.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Row-utils.ts
@@ -1,4 +1,4 @@
-import { type ButtonVariant, getButtonClassName } from "#ui/components/Button.tsx";
+import { type ButtonSize, type ButtonVariant, getButtonClassName } from "#ui/components/Button.tsx";
 import { classes } from "#ui/components/classes.ts";
 import { operandIdentityKey, type Operand } from "#ui/operands.ts";
 import { Match } from "effect";
@@ -9,15 +9,17 @@ export const treeItemId = (operand: Operand): string =>
 
 export const getRowButtonClassName = ({
 	variant = "ghost",
+	size = "small",
 	iconOnly = false,
 }: {
 	variant?: Extract<ButtonVariant, "ghost" | "outline">;
+	size?: ButtonSize;
 	iconOnly?: boolean;
 }) =>
 	classes(
 		getButtonClassName({
 			variant,
-			size: "small",
+			size,
 			iconOnly,
 			// On selection/focus change we change the button variant. This
 			// transition would clash with other selection/focus style changes

--- a/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
@@ -4,7 +4,6 @@
 	--single-line-row-label-padding-block: calc(
 		(var(--single-line-row-height) - var(--single-line-row-label-line-height)) / 2
 	);
-	--button-height: 20px;
 
 	display: flex;
 	column-gap: 8px;
@@ -14,6 +13,14 @@
 	&[inert] {
 		opacity: 0.5;
 	}
+}
+
+.sectionHeader {
+	flex-shrink: 0;
+	/* The label gets an extra inset to line up with row content inside the
+	   section, while action buttons on the right align with the panel edge. */
+	padding-inline: calc(var(--panel-padding-inline) + 4px) var(--panel-padding-inline);
+	padding-block: calc(var(--panel-padding-block) - 4px);
 }
 
 .containerInteractive {
@@ -65,7 +72,9 @@
 	&.toolbarForceVisible {
 		display: flex;
 		column-gap: 8px;
-		padding-block: calc((var(--single-line-row-height) - var(--button-height)) / 2);
+		align-items: center;
+		/* Center buttons of any height within the first row line. */
+		height: var(--single-line-row-height);
 	}
 
 	button:has([data-icon]) {

--- a/apps/lite/ui/src/routes/project/$id/workspace/Row.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Row.tsx
@@ -1,7 +1,14 @@
 import { classes } from "#ui/components/classes.ts";
 import { Checkbox } from "#ui/components/Checkbox.tsx";
 import { useMergedRefs } from "@base-ui/utils/useMergedRefs";
-import { type ComponentProps, type FC, type MouseEvent, useLayoutEffect, useRef } from "react";
+import {
+	type ComponentProps,
+	type FC,
+	type MouseEvent,
+	type ReactNode,
+	useLayoutEffect,
+	useRef,
+} from "react";
 import styles from "./Row.module.css";
 import { mergeProps, useRender } from "@base-ui/react";
 
@@ -102,6 +109,29 @@ export const RowLabel: FC<
 			),
 		}),
 	});
+
+/**
+ * A non-interactive row that acts as a section header (e.g. "Stacks", "Uncommitted changes").
+ *
+ * `children` are rendered inside the label container next to the heading (e.g. badges),
+ * while `actions` are rendered outside of it (e.g. a toolbar).
+ */
+export const SectionHeaderRow: FC<
+	{ label: ReactNode; actions?: ReactNode } & Omit<
+		ComponentProps<typeof Row>,
+		"interactive" | "onSelect" | "isSelected"
+	>
+> = ({ label, actions, children, ...props }) => (
+	<Row {...props} className={classes(props.className, styles.sectionHeader)} interactive={false}>
+		<RowLabelContainer>
+			<RowLabel heading>{label}</RowLabel>
+
+			{children}
+		</RowLabelContainer>
+
+		{actions}
+	</Row>
+);
 
 /** @public */
 export const RowBubbleGroup: FC<ComponentProps<"span">> = (props) => (


### PR DESCRIPTION
## What

Two related UI improvements to the lite outline:

### Section headers
- Adds a reusable `SectionHeaderRow` component (non-interactive row with heading, optional badges, and actions)
- New "Stacks and branches" header on the stacks panel, with the create-independent-branch button moved from the top outline toolbar into the header
- "Uncommitted changes" row refactored to use the same `SectionHeaderRow`

### Shared Scroller component
- New `Scroller` wrapper around Base UI's `ScrollArea` with a standard overlay scrollbar
- Unlike the previous native `overlayScrollbar` approach, it reserves no gutter space, so scroll separators and content span the full viewport width
- Thumb widens while scrolling or hovering, darkens only on hover; pill end caps stay circular at any width
- Migrated: outline stacks scroller, uncommitted changes tree, branches list, details files panel, and `PickerDialog`
- `overlayScrollbar` is kept for the commit-message textarea (a `textarea` can't be wrapped in a ScrollArea)

## Testing
- `pnpm -F @gitbutler/lite check` passes
- oxlint / oxfmt / prettier clean

---


https://github.com/user-attachments/assets/c9f9cf4a-07f4-467f-9baa-1644441d461c

