### PR TITLE
Remove untuned MCP guidance from but skill

### DIFF
--- a/crates/but/skill/SKILL.md
+++ b/crates/but/skill/SKILL.md
@@ -146,7 +146,7 @@ To make one existing branch depend on another: `but move <child-branch> --above 
 
 ### Create or manage pull requests
 
-`but pr new <branch-id>` pushes the branch and creates the PR in one step — no prior `but push`. Provide `-F pr_message.txt`, `-t`, or `-m` with real newlines (zsh/bash: `-m $'Title\n\nBody'`) so no editor opens. If forge auth is missing, run `but config forge auth`. When the GitButler MCP server exposes `gitbutler_review_card`, call it with every review number returned by `but pr new` so the created PRs/MRs are shown to the user; pass the active repository path when it is known, and omit it only when the MCP client is known to supply that repository as a filesystem root. The rendered card refreshes review and CI state itself while monitoring is active.
+`but pr new <branch-id>` pushes the branch and creates the PR in one step — no prior `but push`. Provide `-F pr_message.txt`, `-t`, or `-m` with real newlines (zsh/bash: `-m $'Title\n\nBody'`) so no editor opens. If forge auth is missing, run `but config forge auth`.
 
 For stacked branches `but pr` is mandatory (it sets PR bases and stack metadata; `gh pr create` breaks that). To publish a whole stack: `but pr new <top-branch-id> -t`. Manage with `but pr auto-merge|set-draft|set-ready <selector>`. See `references/reference.md` for details.
 

--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -12,7 +12,7 @@ Agent-focused reference for useful `but` commands.
 - [Remote Operations](#remote-operations) - `push`, `pull`, `pr`, `land`
 - [Workspace Maintenance](#workspace-maintenance) - `clean`
 - [History & Undo](#history--undo) - `undo`, `oplog`
-- [Setup & Configuration](#setup--configuration) - `setup`, `teardown`, `config`, `update`, `skill`, `gui`, `mcp`
+- [Setup & Configuration](#setup--configuration) - `setup`, `teardown`, `config`, `update`, `skill`
 - [Selected Options](#selected-options)
 
 ## Inspection (Understanding State)
@@ -413,8 +413,6 @@ but pr set-ready <selector>   # Mark review as ready
 Use `--no-hooks` to bypass pre-push hooks when needed.
 Review creation remains successful if the follow-up stack synchronization fails, and reports that
 partial success as a warning.
-
-If the GitButler MCP server exposes `gitbutler_review_card`, call it after a successful `but pr new` with every number from the command's `published` reviews. Omit `repository` when the MCP client supplied the current repository as a filesystem root; otherwise pass the repository path. The card displays each PR/MR, offers a ready-for-review action for drafts, and refreshes review and CI state while its monitoring conditions remain active.
 
 Selectors for `auto-merge`, `set-draft`, and `set-ready` can be branch names, branch IDs, stack IDs, or numeric review IDs, comma-separated.
 


### PR DESCRIPTION
Removes the MCP review-card guidance from the bundled but skill for now. It has not yet been tested or tuned as agent steering, so keeping it out avoids prescribing behavior before it is ready.

The MCP implementation itself is unchanged.