### PR TITLE
Lite: outline tree scroll gradient fix and shorter uncommitted label

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.module.css
@@ -47,7 +47,14 @@
 }
 
 .uncommittedChangesTree {
+	--scroll-gradient-height: 14px;
+	--scroll-gradient-overlap: 4px;
+
 	padding-inline: var(--panel-padding-inline);
+	/* The sticky gradient below takes up flow space at the end of the content.
+	   Account for it when scrolling rows into view (e.g. arrow-key navigation),
+	   so the last row can reach the true bottom and the gradient fades out. */
+	scroll-padding-block-end: calc(var(--scroll-gradient-height) - var(--scroll-gradient-overlap));
 
 	/* Stretch the scroll separator over the inline padding to full width. */
 	&::before {
@@ -61,8 +68,8 @@
 		z-index: 1;
 		position: sticky;
 		bottom: 0;
-		height: 20px;
-		margin-block-start: -8px;
+		height: var(--scroll-gradient-height);
+		margin-block-start: calc(-1 * var(--scroll-gradient-overlap));
 		background: linear-gradient(to top, var(--bg-1) 20%, transparent);
 		content: "";
 		opacity: 0;

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/UncommittedChangesRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/UncommittedChangesRow.tsx
@@ -100,7 +100,7 @@ export const UncommittedChangesRow: FC<{
 
 	return (
 		<SectionHeaderRow
-			label="Uncommitted changes"
+			label="Uncommitted"
 			onContextMenu={(event) => {
 				void showNativeContextMenu(event, menuItems);
 			}}


### PR DESCRIPTION
Two small tweaks to the lite outline tree:

- **Fix scroll padding for the sticky bottom gradient** — introduce CSS variables for the gradient height/overlap and set `scroll-padding-block-end` on the uncommitted changes tree, so arrow-key navigation can scroll the last row past the sticky gradient to the true bottom (where the gradient fades out).
- **Shorten the section label** from "Uncommitted changes" to "Uncommitted".

## Screenshots

Before:

https://github.com/user-attachments/assets/46c87f8d-3c3a-4dea-a075-09d47ca4680c


After:

https://github.com/user-attachments/assets/4660b067-90aa-4262-b6af-5fcb92a2e665

