### PR TITLE
Fix GitHub native stack sync base updates and lost membership

### DIFF
--- a/crates/but-api/src/legacy/forge.rs
+++ b/crates/but-api/src/legacy/forge.rs
@@ -1107,10 +1107,13 @@ fn cache_review_target_updates(
 }
 
 /// Prepare native forge state before temporarily flattening review targets for a reordered push.
+///
+/// Returns the ordered memberships of any native GitHub stacks that had to be dissolved, so a
+/// failed push can restore them.
 pub(crate) async fn prepare_review_target_updates(
     ctx: ThreadSafeContext,
     reviews: Vec<but_forge::ForgeReviewTargetUpdate>,
-) -> Result<()> {
+) -> Result<Vec<Vec<i64>>> {
     let (
         storage,
         forge_repo_info,
@@ -1151,6 +1154,8 @@ pub(crate) async fn prepare_review_target_updates(
 /// The original remote targets changed while preparing a reviewed stack for push.
 pub(crate) struct ReviewTargetFlattening {
     original_targets: Vec<but_forge::ForgeReviewTargetUpdate>,
+    /// Ordered memberships of native GitHub stacks dissolved before flattening.
+    dissolved_stacks: Vec<Vec<i64>>,
 }
 
 /// Temporarily point a reordered reviewed stack at trunk before its refs are pushed.
@@ -1170,10 +1175,11 @@ pub(crate) async fn flatten_review_targets_before_push(
         .iter()
         .map(|(desired, _)| desired.clone())
         .collect::<Vec<_>>();
-    prepare_review_target_updates(ctx.clone(), desired).await?;
+    let dissolved_stacks = prepare_review_target_updates(ctx.clone(), desired).await?;
 
     let mut flattening = ReviewTargetFlattening {
         original_targets: Vec::new(),
+        dissolved_stacks,
     };
     for (review, current_target) in reviews {
         if !reviews_to_flatten.contains(&review.number) {
@@ -1241,14 +1247,41 @@ pub(crate) async fn restore_review_targets(
             ));
         }
     }
-    if errors.is_empty() {
-        Ok(())
-    } else {
+    if !errors.is_empty() {
+        if !flattening.dissolved_stacks.is_empty() {
+            errors.push(
+                "Native GitHub stack membership was not restored; the next successful push will \
+                 recreate it."
+                    .to_string(),
+            );
+        }
         anyhow::bail!(
             "Could not restore all review targets after the push failed:\n{}",
             errors.join("\n")
         )
     }
+    if flattening.dissolved_stacks.is_empty() {
+        return Ok(());
+    }
+
+    let (storage, forge_repo_info, preferred_forge_user) = {
+        let ctx = ctx.into_thread_local();
+        let project_meta = ctx.project_meta()?;
+        let repo = ctx.repo.get()?;
+        let (forge_repo_info, _) = base_and_push_repo_info(&project_meta, &repo)?;
+        (
+            but_forge_storage::Controller::from_path(but_path::app_data_dir()?),
+            forge_repo_info,
+            ctx.legacy_project.preferred_forge_user.clone(),
+        )
+    };
+    but_forge::restore_native_stacks(
+        &preferred_forge_user,
+        &forge_repo_info,
+        &flattening.dissolved_stacks,
+        &storage,
+    )
+    .await
 }
 
 fn review_target_flattening_plan(

--- a/crates/but-forge/src/lib.rs
+++ b/crates/but-forge/src/lib.rs
@@ -22,8 +22,8 @@ pub use review::{
     cache_review, check_forge_account_is_valid, compute_review_target_updates, create_forge_review,
     get_forge_review, get_review_base_repo_url, get_review_merge_status,
     get_review_template_functions, list_forge_reviews_for_branch, list_forge_reviews_with_cache,
-    merge_review, prepare_review_target_updates, set_review_auto_merge_state,
-    set_review_draftiness, sync_reviews, update_review,
+    merge_review, prepare_review_target_updates, restore_native_stacks,
+    set_review_auto_merge_state, set_review_draftiness, sync_reviews, update_review,
 };
 
 fn determine_forge_from_host(host: &str) -> Option<ForgeName> {

--- a/crates/but-forge/src/review.rs
+++ b/crates/but-forge/src/review.rs
@@ -1681,10 +1681,15 @@ pub enum GitHubStackingMode {
     Native,
 }
 
-/// Remove conflicting native GitHub stack membership before changing review target branches.
+/// Remove native GitHub stack membership before changing review target branches.
 ///
 /// The caller temporarily flattens reordered reviews onto trunk before pushing their refs. GitHub
-/// requires conflicting native stack membership to be removed before those target updates.
+/// refuses to change the base branch of any stacked pull request — even when membership and
+/// ordering stay the same — so every native stack containing these reviews is dissolved first.
+///
+/// Returns the ordered memberships of the dissolved stacks so a failed push can restore them via
+/// [`restore_native_stacks`]. After a successful push, regular synchronization re-registers the
+/// desired membership.
 pub async fn prepare_review_target_updates(
     preferred_forge_user: &Option<crate::ForgeUser>,
     forge_repo_info: &crate::forge::ForgeRepoInfo,
@@ -1692,7 +1697,7 @@ pub async fn prepare_review_target_updates(
     reviews: &[ForgeReviewUpdate],
     storage: &but_forge_storage::Controller,
     github_stacking_mode: GitHubStackingMode,
-) -> Result<()> {
+) -> Result<Vec<Vec<i64>>> {
     let crate::forge::ForgeRepoInfo {
         forge, owner, repo, ..
     } = forge_repo_info;
@@ -1700,12 +1705,12 @@ pub async fn prepare_review_target_updates(
         || github_stacking_mode != GitHubStackingMode::Native
         || reviews.is_empty()
     {
-        return Ok(());
+        return Ok(Vec::new());
     }
 
     let (_, head_repo) = github_head_owner_and_repo(forge_repo_info, forge_push_repo_info);
     if head_repo.is_some() {
-        return Ok(());
+        return Ok(Vec::new());
     }
 
     let preferred_account = preferred_forge_user.as_ref().and_then(|user| user.github());
@@ -1713,13 +1718,56 @@ pub async fn prepare_review_target_updates(
         .iter()
         .map(|review| review.number)
         .collect::<Vec<_>>();
-    let prepared =
-        but_github::stacks::prepare(preferred_account, owner, repo, &pr_numbers, storage).await?;
-    if let but_github::stacks::Availability::Supported(plan) = prepared {
-        but_github::stacks::unstack_conflicting(preferred_account, owner, repo, &plan, storage)
-            .await?;
+    let dissolved =
+        but_github::stacks::dissolve(preferred_account, owner, repo, &pr_numbers, storage).await?;
+    let but_github::stacks::Availability::Supported(stacks) = dissolved else {
+        return Ok(Vec::new());
+    };
+    // GitHub keeps closed pull requests as stack members but refuses to register a stack
+    // containing one, so they are dropped from the rollback snapshot. A stack needs two open
+    // members to be restorable at all.
+    Ok(stacks
+        .into_iter()
+        .filter_map(|stack| {
+            let open: Vec<i64> = stack
+                .pull_requests
+                .into_iter()
+                .filter(|review| !review.is_closed())
+                .map(|review| review.number)
+                .collect();
+            (open.len() >= 2).then_some(open)
+        })
+        .collect())
+}
+
+/// Re-register native stacks dissolved by [`prepare_review_target_updates`] after a failed push.
+///
+/// Call this only after the affected review target branches have been restored, so the recreated
+/// stacks match the bases GitHub sees.
+pub async fn restore_native_stacks(
+    preferred_forge_user: &Option<crate::ForgeUser>,
+    forge_repo_info: &crate::forge::ForgeRepoInfo,
+    stacks: &[Vec<i64>],
+    storage: &but_forge_storage::Controller,
+) -> Result<()> {
+    let crate::forge::ForgeRepoInfo { owner, repo, .. } = forge_repo_info;
+    let preferred_account = preferred_forge_user.as_ref().and_then(|user| user.github());
+    let mut errors = Vec::new();
+    for pull_requests in stacks {
+        if let Err(err) =
+            but_github::stacks::create(preferred_account, owner, repo, pull_requests, storage).await
+        {
+            errors.push(format!("{err:#}"));
+        }
     }
-    Ok(())
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        anyhow::bail!(
+            "Could not restore native GitHub stack membership after the push failed:\n{}",
+            errors.join("\n")
+        )
+    }
 }
 
 async fn github_review_bodies(
@@ -1760,10 +1808,11 @@ async fn sync_github_reviews_with_descriptions(
     owner: &str,
     repo: &str,
     reviews: &[ForgeReviewUpdate],
-    pr_numbers: &[i64],
     storage: &but_forge_storage::Controller,
     description_mode: ReviewStackingDescription,
+    update_bases: bool,
 ) -> Result<Vec<String>> {
+    let pr_numbers: Vec<i64> = reviews.iter().map(|review| review.number).collect();
     let (bodies, mut errors) =
         github_review_bodies(preferred_account, owner, repo, reviews, storage).await?;
     for (review, current_body) in reviews.iter().zip(bodies) {
@@ -1771,7 +1820,7 @@ async fn sync_github_reviews_with_descriptions(
             update_body_with_mode(
                 body.as_deref(),
                 review.number,
-                pr_numbers,
+                &pr_numbers,
                 "#",
                 description_mode,
             )
@@ -1782,7 +1831,11 @@ async fn sync_github_reviews_with_descriptions(
             pr_number: review.number,
             title: None,
             body: updated_body.as_deref(),
-            base: review.target_branch.as_deref(),
+            base: if update_bases {
+                review.target_branch.as_deref()
+            } else {
+                None
+            },
             state: None,
         };
         if let Err(err) = but_github::pr::update(preferred_account, params, storage).await {
@@ -1797,27 +1850,68 @@ async fn sync_github_native_reviews(
     owner: &str,
     repo: &str,
     reviews: &[ForgeReviewUpdate],
-    pr_numbers: &[i64],
     storage: &but_forge_storage::Controller,
     description_mode: ReviewStackingDescription,
 ) -> Result<but_github::stacks::Availability<Vec<String>>> {
+    let pr_numbers: Vec<i64> = reviews.iter().map(|review| review.number).collect();
     let prepared =
-        but_github::stacks::prepare(preferred_account, owner, repo, pr_numbers, storage).await?;
-    let but_github::stacks::Availability::Supported(plan) = prepared else {
+        but_github::stacks::prepare(preferred_account, owner, repo, &pr_numbers, storage).await?;
+    let but_github::stacks::Availability::Supported(mut prepared) = prepared else {
         return Ok(but_github::stacks::Availability::Unsupported);
     };
+
+    // A surviving stack pins every member's base except the bottom one, whose base is the
+    // stack's target branch. That base can still be stale — e.g. the workspace target changed
+    // while pre-push flattening was skipped for lack of cached current targets. Skipping it as
+    // locked would report success and mask the drift, so verify it and rebuild on mismatch.
+    if !prepared.locked.is_empty()
+        && let Some(bottom) = reviews.first()
+        && let Some(desired_target) = bottom.target_branch.as_deref()
+    {
+        let current = but_github::pr::get(
+            preferred_account,
+            owner,
+            repo,
+            bottom.number.try_into()?,
+            storage,
+        )
+        .await?;
+        if current.target_branch != desired_target {
+            but_github::stacks::dissolve(preferred_account, owner, repo, &pr_numbers, storage)
+                .await?;
+            prepared = but_github::stacks::PreparedPlan {
+                plan: but_github::stacks::ReconcilePlan::Create {
+                    desired: pr_numbers.clone(),
+                },
+                locked: Vec::new(),
+            };
+        }
+    }
+
     let (bodies, mut errors) =
         github_review_bodies(preferred_account, owner, repo, reviews, storage).await?;
 
     // Rebuilds have to dissolve the old native membership before GitHub will accept reordered
     // target branches. Legacy footers remain in place until the new native shape is durable.
-    but_github::stacks::unstack_conflicting(preferred_account, owner, repo, &plan, storage).await?;
+    but_github::stacks::unstack_conflicting(
+        preferred_account,
+        owner,
+        repo,
+        &prepared.plan,
+        storage,
+    )
+    .await?;
 
     let mut target_errors = Vec::new();
     for review in reviews {
         let Some(target_branch) = review.target_branch.as_deref() else {
             continue;
         };
+        // GitHub rejects base updates for current stack members, even when the base is
+        // unchanged. Surviving members keep the bases the stack already enforces.
+        if prepared.locked.contains(&review.number) {
+            continue;
+        }
         let params = but_github::UpdatePullRequestParams {
             owner,
             repo,
@@ -1832,13 +1926,15 @@ async fn sync_github_native_reviews(
         }
     }
     if !target_errors.is_empty() {
+        // Dissolved membership stays dissolved here; the next successful synchronization sees
+        // no registered stacks and recreates the desired one.
         anyhow::bail!(
             "Could not update all PR targets before native stack registration:\n{}",
             target_errors.join("\n")
         );
     }
 
-    but_github::stacks::finish(preferred_account, owner, repo, &plan, storage).await?;
+    but_github::stacks::finish(preferred_account, owner, repo, &prepared.plan, storage).await?;
 
     // GitHub now renders the native stack. Independently honor the configured GitButler
     // description mode and preserve user text.
@@ -1849,7 +1945,7 @@ async fn sync_github_native_reviews(
         let updated_body = update_body_with_mode(
             current_body.as_deref(),
             review.number,
-            pr_numbers,
+            &pr_numbers,
             "#",
             description_mode,
         );
@@ -1928,7 +2024,6 @@ pub async fn sync_reviews(
                     owner,
                     repo,
                     reviews,
-                    &pr_numbers,
                     storage,
                     description_mode,
                 )
@@ -1947,24 +2042,29 @@ pub async fn sync_reviews(
                                 owner,
                                 repo,
                                 reviews,
-                                &pr_numbers,
                                 storage,
                                 description_mode,
+                                true,
                             )
                             .await?,
                         );
                     }
                     Err(err) => {
                         errors.push(format!("GitHub native stack: {err}"));
+                        // Some reviews may still be native stack members, and GitHub rejects
+                        // base updates for members, so sync only descriptions. Because this
+                        // function returns an error, the caller does not cache the desired
+                        // targets, and the next synchronization still sees the drift and
+                        // reconciles bases and membership.
                         errors.extend(
                             sync_github_reviews_with_descriptions(
                                 preferred_account,
                                 owner,
                                 repo,
                                 reviews,
-                                &pr_numbers,
                                 storage,
                                 description_mode,
+                                false,
                             )
                             .await?,
                         );
@@ -1991,9 +2091,9 @@ pub async fn sync_reviews(
                         owner,
                         repo,
                         reviews,
-                        &pr_numbers,
                         storage,
                         description_mode,
+                        true,
                     )
                     .await?,
                 );

--- a/crates/but-github/src/client.rs
+++ b/crates/but-github/src/client.rs
@@ -465,7 +465,10 @@ impl GitHubClient {
         let response = self.client.patch(&url).json(&body).send().await?;
 
         if !response.status().is_success() {
-            bail!("Failed to update pull request: {}", response.status());
+            bail!(
+                "Failed to update pull request: {}",
+                response_error(response).await
+            );
         }
 
         let pr: GitHubPullRequest = response.json().await?;
@@ -1308,6 +1311,16 @@ struct CheckRunsQuery<'a> {
     per_page: usize,
     page: usize,
 }
+
+/// Render a failed response as `<status>: <body>` so GitHub's error message reaches the user.
+pub(crate) async fn response_error(response: reqwest::Response) -> String {
+    let status = response.status();
+    match response.text().await {
+        Ok(body) if !body.is_empty() => format!("{status}: {body}"),
+        _ => status.to_string(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/but-github/src/stacks.rs
+++ b/crates/but-github/src/stacks.rs
@@ -8,7 +8,7 @@ use std::collections::BTreeMap;
 use anyhow::{Context as _, Result, bail};
 use serde::{Deserialize, Serialize};
 
-use crate::client::GitHubClient;
+use crate::client::{GitHubClient, response_error};
 
 /// A GitHub native pull-request stack.
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
@@ -23,6 +23,16 @@ pub struct Stack {
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 pub struct StackPullRequest {
     pub number: i64,
+    /// `open` or `closed`. GitHub keeps closed pull requests as stack members but refuses to
+    /// register a new stack containing one.
+    #[serde(default)]
+    pub state: Option<String>,
+}
+
+impl StackPullRequest {
+    pub fn is_closed(&self) -> bool {
+        self.state.as_deref() == Some("closed")
+    }
 }
 
 /// Whether the repository exposes GitHub's native stacks preview.
@@ -30,6 +40,15 @@ pub struct StackPullRequest {
 pub enum Availability<T> {
     Unsupported,
     Supported(T),
+}
+
+/// A reconcile plan plus the pull requests whose native membership survives it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PreparedPlan {
+    pub plan: ReconcilePlan,
+    /// Desired PRs that remain stack members after [`unstack_conflicting`]. GitHub rejects
+    /// base-branch updates for them (HTTP 422), even when the requested base is unchanged.
+    pub locked: Vec<i64>,
 }
 
 /// The native-stack membership mutation needed to reach a desired reviewed stack.
@@ -75,32 +94,54 @@ pub async fn prepare(
     repo: &str,
     desired: &[i64],
     storage: &but_forge_storage::Controller,
-) -> Result<Availability<ReconcilePlan>> {
+) -> Result<Availability<PreparedPlan>> {
     let gh = GitHubClient::from_storage(storage, preferred_account)?;
     let Some(existing) = gh.existing_stacks(owner, repo, desired).await? else {
         return Ok(Availability::Unsupported);
     };
-    Ok(Availability::Supported(reconcile_plan(existing, desired)))
+    let plan = reconcile_plan(existing.clone(), desired);
+    let locked = locked_members(&existing, &plan);
+    Ok(Availability::Supported(PreparedPlan { plan, locked }))
 }
 
 /// Dissolve every native stack containing any of `pull_requests`.
+///
+/// Returns the dissolved stacks so callers can restore their membership if a
+/// follow-up operation fails.
 pub async fn dissolve(
     preferred_account: Option<&crate::GithubAccountIdentifier>,
     owner: &str,
     repo: &str,
     pull_requests: &[i64],
     storage: &but_forge_storage::Controller,
-) -> Result<Availability<()>> {
+) -> Result<Availability<Vec<Stack>>> {
     let gh = GitHubClient::from_storage(storage, preferred_account)?;
     let Some(existing) = gh.existing_stacks(owner, repo, pull_requests).await? else {
         return Ok(Availability::Unsupported);
     };
-    for stack in existing {
+    for stack in &existing {
         gh.unstack(owner, repo, stack.number)
             .await
             .with_context(|| format!("Failed to dissolve GitHub stack #{}", stack.number))?;
     }
-    Ok(Availability::Supported(()))
+    Ok(Availability::Supported(existing))
+}
+
+/// Register `pull_requests` (ordered bottom-to-top) as a native stack.
+///
+/// Used to restore membership removed by [`dissolve`] after a failed push. The PR bases must
+/// already form the stacked chain.
+pub async fn create(
+    preferred_account: Option<&crate::GithubAccountIdentifier>,
+    owner: &str,
+    repo: &str,
+    pull_requests: &[i64],
+    storage: &but_forge_storage::Controller,
+) -> Result<()> {
+    let gh = GitHubClient::from_storage(storage, preferred_account)?;
+    gh.create_stack(owner, repo, pull_requests)
+        .await
+        .context("Failed to create GitHub native stack")
 }
 
 impl GitHubClient {
@@ -172,6 +213,16 @@ pub async fn finish(
             .await
             .with_context(|| format!("Failed to extend GitHub stack #{stack_number}")),
     }
+}
+
+/// Members of stacks the plan leaves in place; their bases cannot be changed on GitHub.
+fn locked_members(existing: &[Stack], plan: &ReconcilePlan) -> Vec<i64> {
+    let unstacked = plan.stack_numbers_to_unstack();
+    existing
+        .iter()
+        .filter(|stack| !unstacked.contains(&stack.number))
+        .flat_map(|stack| stack.pull_requests.iter().map(|review| review.number))
+        .collect()
 }
 
 fn reconcile_plan(mut existing: Vec<Stack>, desired: &[i64]) -> ReconcilePlan {
@@ -308,14 +359,6 @@ impl GitHubClient {
     }
 }
 
-async fn response_error(response: reqwest::Response) -> String {
-    let status = response.status();
-    match response.text().await {
-        Ok(body) if !body.is_empty() => format!("{status}: {body}"),
-        _ => status.to_string(),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -325,7 +368,10 @@ mod tests {
             number,
             pull_requests: members
                 .iter()
-                .map(|number| StackPullRequest { number: *number })
+                .map(|number| StackPullRequest {
+                    number: *number,
+                    state: None,
+                })
                 .collect(),
         }
     }
@@ -384,6 +430,46 @@ mod tests {
                 stack_numbers: vec![7, 9],
                 desired: vec![1, 2, 3, 4]
             }
+        );
+    }
+
+    #[test]
+    fn surviving_members_stay_base_locked() {
+        // Noop keeps the whole stack registered, so every member's base stays locked.
+        let existing = vec![stack(7, &[1, 2, 3])];
+        let plan = reconcile_plan(existing.clone(), &[1, 2, 3]);
+        assert_eq!(
+            locked_members(&existing, &plan),
+            vec![1, 2, 3],
+            "an unchanged native stack keeps every base locked"
+        );
+
+        // Append keeps the existing prefix registered; only the new suffix may be retargeted.
+        let existing = vec![stack(7, &[1, 2])];
+        let plan = reconcile_plan(existing.clone(), &[1, 2, 3, 4]);
+        assert_eq!(
+            locked_members(&existing, &plan),
+            vec![1, 2],
+            "appending locks only the pre-existing members"
+        );
+    }
+
+    #[test]
+    fn dissolved_and_unregistered_members_are_not_locked() {
+        // Rebuild dissolves every conflicting stack first, freeing all bases.
+        let existing = vec![stack(7, &[1, 2, 3])];
+        let plan = reconcile_plan(existing.clone(), &[3, 2, 1]);
+        assert_eq!(
+            locked_members(&existing, &plan),
+            Vec::<i64>::new(),
+            "a rebuild dissolves membership before bases change"
+        );
+
+        // No registered stacks means nothing is locked, including singletons.
+        assert_eq!(
+            locked_members(&[], &reconcile_plan(Vec::new(), &[1])),
+            Vec::<i64>::new(),
+            "unregistered reviews have no base lock"
         );
     }
 

--- a/e2e/playwright/src/fakeGithub.ts
+++ b/e2e/playwright/src/fakeGithub.ts
@@ -113,6 +113,11 @@ export async function startFakeGitHubServer({
 	const githubStacks = new Map<number, FakeGitHubStack>();
 	const nativeStackMutationHistory: NativeStackMutation[] = [];
 	let nextStackNumber = 1;
+	function isStacked(reviewNumber: number) {
+		return [...githubStacks.values()].some((stack) =>
+			stack.pull_requests.some((review) => review.number === reviewNumber),
+		);
+	}
 
 	const sockets = new Set<Socket>();
 	const server = http.createServer((request, response) => {
@@ -155,6 +160,11 @@ export async function startFakeGitHubServer({
 				}
 				const current = reviews.get(number);
 				if (!current) return { status: "notFound" as const };
+				// GitHub rejects base updates for native stack members, even when the
+				// requested base equals the current one.
+				if (input.base !== undefined && isStacked(number)) {
+					return { status: "stackLocked" as const };
+				}
 				const updated = {
 					...current,
 					title: input.title ?? current.title,
@@ -175,6 +185,16 @@ export async function startFakeGitHubServer({
 				);
 			},
 			createStack(pullRequests) {
+				if (pullRequests.some(isStacked)) return "alreadyStacked";
+				// Real GitHub requires at least two members whose bases chain onto the
+				// previous member's head branch.
+				if (pullRequests.length < 2) return "invalid";
+				for (const [index, number] of pullRequests.entries()) {
+					const review = reviews.get(number);
+					if (!review) return "invalid";
+					const below = index > 0 ? reviews.get(pullRequests[index - 1]) : undefined;
+					if (below && review.base.ref !== below.head.ref) return "invalid";
+				}
 				const stack = nativeStackPayload(nextStackNumber++, pullRequests);
 				githubStacks.set(stack.number, stack);
 				nativeStackMutationHistory.push({
@@ -185,7 +205,8 @@ export async function startFakeGitHubServer({
 			},
 			addToStack(stackNumber, pullRequests) {
 				const current = githubStacks.get(stackNumber);
-				if (!current) return undefined;
+				if (!current) return "notFound";
+				if (pullRequests.some(isStacked)) return "alreadyStacked";
 				current.pull_requests.push(...pullRequests.map((number) => ({ number })));
 				nativeStackMutationHistory.push({
 					operation: "add",
@@ -274,10 +295,14 @@ async function handleRequest(
 		) =>
 			| { status: "updated"; review: FakeGitHubReview }
 			| { status: "notFound" }
-			| { status: "failed" };
+			| { status: "failed" }
+			| { status: "stackLocked" };
 		listStacks: (reviewNumber?: number) => FakeGitHubStack[] | undefined;
-		createStack: (pullRequests: number[]) => FakeGitHubStack;
-		addToStack: (stackNumber: number, pullRequests: number[]) => FakeGitHubStack | undefined;
+		createStack: (pullRequests: number[]) => FakeGitHubStack | "alreadyStacked" | "invalid";
+		addToStack: (
+			stackNumber: number,
+			pullRequests: number[],
+		) => FakeGitHubStack | "notFound" | "alreadyStacked";
 		unstack: (stackNumber: number) => boolean;
 	},
 ) {
@@ -322,6 +347,13 @@ async function handleRequest(
 		if (result.status === "failed") {
 			return json(response, { message: "Configured review update failure" }, 500);
 		}
+		if (result.status === "stackLocked") {
+			return json(
+				response,
+				{ message: "Cannot change the base branch because the pull request is part of a stack." },
+				422,
+			);
+		}
 		return result.status === "updated"
 			? json(response, result.review)
 			: json(response, { message: "Not Found" }, 404);
@@ -337,18 +369,40 @@ async function handleRequest(
 
 	if (request.method === "POST" && url.pathname === stacksPath) {
 		const input = JSON.parse(await readBody(request)) as { pull_requests: number[] };
-		return json(response, state.createStack(input.pull_requests), 201);
+		const stack = state.createStack(input.pull_requests);
+		if (stack === "alreadyStacked") {
+			return json(response, { message: "Pull request is already part of a stack." }, 422);
+		}
+		if (stack === "invalid") {
+			return json(
+				response,
+				{
+					message:
+						"Pull requests must form a stack, where each PR's base ref is the previous PR's head ref",
+				},
+				422,
+			);
+		}
+		return json(response, stack, 201);
 	}
 
 	if (request.method === "POST" && stackMutation?.operation === "add") {
 		const input = JSON.parse(await readBody(request)) as { pull_requests: number[] };
 		const stack = state.addToStack(stackMutation.stackNumber, input.pull_requests);
-		return stack ? json(response, stack) : json(response, { message: "Not Found" }, 404);
+		if (stack === "notFound") return json(response, { message: "Not Found" }, 404);
+		if (stack === "alreadyStacked") {
+			return json(response, { message: "Pull request is already part of a stack." }, 422);
+		}
+		return json(response, stack);
 	}
 	if (request.method === "POST" && stackMutation?.operation === "unstack") {
-		return state.unstack(stackMutation.stackNumber)
-			? json(response, {}, 200)
-			: json(response, { message: "Not Found" }, 404);
+		if (!state.unstack(stackMutation.stackNumber)) {
+			return json(response, { message: "Not Found" }, 404);
+		}
+		// Real GitHub answers a successful unstack with 204 and no body.
+		response.writeHead(204, { Connection: "close" });
+		response.end();
+		return;
 	}
 
 	const repositoryPath = `/${options.owner}/${options.repo}.git`;

--- a/e2e/playwright/tests/reviewStackingDescription.spec.ts
+++ b/e2e/playwright/tests/reviewStackingDescription.spec.ts
@@ -569,6 +569,170 @@ test("GitHub native stacks are rebuilt when a review is created in the middle", 
 	});
 });
 
+test("an unchanged GitHub native stack pushes without base updates and appends new tops", async ({
+	page,
+	gitbutler,
+	fakeGithub,
+}) => {
+	const server = await fakeGithub({
+		headRepoPath: gitbutler.pathInWorkdir("remote-project"),
+		isFork: false,
+		listed: false,
+		nativeStacks: true,
+	});
+	await gitbutler.runScript("project-with-stacks.sh", [server.repositoryUrl]);
+	await storeFakeGitHubEnterprisePat(page, server);
+	mirrorFakeCredentialForCli(gitbutler);
+	await applyUpstream(gitbutler, "branch1", "branch2", "branch3");
+	await mockForge(page, {
+		get_review_merge_status: mergeStatus(),
+		get_repo_info: repoInfo(),
+		list_ci_checks: [],
+	});
+	await openWorkspace(page);
+	await setGitHubStackingMode(page, gitbutler, "native");
+
+	const branchHeaders = page.getByTestId("branch-header");
+	await dragAndDropByLocator(
+		page,
+		branchHeaders.filter({ hasText: "branch2" }),
+		branchHeaders.filter({ hasText: "branch1" }),
+		{ force: true, position: { x: 120, y: -10 } },
+	);
+	await expect(stack(page)).toHaveCount(2);
+	await gitbutler.runScript("push-branch.sh", ["branch2"]);
+
+	await publishReview(page, "branch1", "Description for branch1");
+	server.setListed(true);
+	await publishReview(page, "branch2", "Description for branch2");
+	await expect(page.getByText("PR #43 created successfully")).toBeVisible();
+	await expect
+		.poll(() => server.getNativeStacks())
+		.toEqual([{ number: 1, pull_requests: [{ number: 42 }, { number: 43 }] }]);
+	await expectReviews(server, 2, (reviews) => {
+		expectBottomFooter(reviews[0], "Description for branch1", "part 1 of 2");
+		expectBottomFooter(reviews[1], "Description for branch2", "part 2 of 2");
+	});
+
+	// GitHub refuses base updates for native stack members, so an ordinary push of the
+	// unchanged stack must not send any.
+	writeFileSync(gitbutler.pathInWorkdir("local-clone/b_file"), "ordinary native push\n", {
+		flag: "a",
+	});
+	await gitbutler.runScript("commit-branch.sh", ["branch2", "branch2: ordinary native push"]);
+	const beforeOrdinaryPush = reviewHistoryLengths(server, [42, 43]);
+	const ordinaryPushPath = gitbutler.pathInWorkdir("ordinary-native-push.json");
+	await gitbutler.runScript("push-branch-json.sh", ["branch2", ordinaryPushPath]);
+	expect(readPushOutcome(ordinaryPushPath).reviewSync).toEqual({ status: "succeeded" });
+	expectNoBaseUpdates(server, beforeOrdinaryPush, [42, 43]);
+	await expect
+		.poll(() => server.getNativeStacks())
+		.toEqual([{ number: 1, pull_requests: [{ number: 42 }, { number: 43 }] }]);
+	await expect
+		.poll(() => server.getNativeStackMutationHistory())
+		.toEqual([{ operation: "create", pullRequests: [42, 43] }]);
+
+	// Appending a new top review must extend the existing native stack without touching the
+	// locked bases of the members below it.
+	await dragAndDropByLocator(
+		page,
+		branchHeaders.filter({ hasText: "branch3" }),
+		branchHeaders.filter({ hasText: "branch2" }),
+		{ force: true, position: { x: 120, y: -10 } },
+	);
+	await expect(stack(page)).toHaveCount(1);
+	const beforeAppend = reviewHistoryLengths(server, [42, 43]);
+	await publishReview(page, "branch3", "Description for branch3");
+	await expect(page.getByText("PR #44 created successfully")).toBeVisible();
+	await expect
+		.poll(() => server.getNativeStacks())
+		.toEqual([{ number: 1, pull_requests: [{ number: 42 }, { number: 43 }, { number: 44 }] }]);
+	expect(server.getNativeStackMutationHistory()).toEqual([
+		{ operation: "create", pullRequests: [42, 43] },
+		{ operation: "add", stackNumber: 1, pullRequests: [44] },
+	]);
+	expectNoBaseUpdates(server, beforeAppend, [42, 43]);
+	await expectReviews(server, 3, (reviews) => {
+		expect(reviews.map((review) => review.base.ref)).toEqual(["master", "branch1", "branch2"]);
+	});
+});
+
+test("a failed reordered push restores GitHub native stack membership", async ({
+	page,
+	gitbutler,
+	fakeGithub,
+}) => {
+	const server = await fakeGithub({
+		headRepoPath: gitbutler.pathInWorkdir("remote-project"),
+		isFork: false,
+		listed: false,
+		nativeStacks: true,
+	});
+	await gitbutler.runScript("project-with-stacks.sh", [server.repositoryUrl]);
+	await storeFakeGitHubEnterprisePat(page, server);
+	mirrorFakeCredentialForCli(gitbutler);
+	await applyUpstream(gitbutler, "branch1", "branch2", "branch3");
+	await mockForge(page, {
+		get_review_merge_status: mergeStatus(),
+		get_repo_info: repoInfo(),
+		list_ci_checks: [],
+	});
+	await openWorkspace(page);
+	await setGitHubStackingMode(page, gitbutler, "native");
+	const branchHeaders = page.getByTestId("branch-header");
+	for (const [branch, parent, remainingStacks] of [
+		["branch2", "branch1", 2],
+		["branch3", "branch2", 1],
+	] as const) {
+		await dragAndDropByLocator(
+			page,
+			branchHeaders.filter({ hasText: branch }),
+			branchHeaders.filter({ hasText: parent }),
+			{ force: true, position: { x: 120, y: -10 } },
+		);
+		await expect(stack(page)).toHaveCount(remainingStacks);
+	}
+	await gitbutler.runScript("push-branch.sh", ["branch3"]);
+
+	await publishReview(page, "branch1", "Description for branch1");
+	server.setListed(true);
+	await publishReview(page, "branch2", "Description for branch2");
+	await publishReview(page, "branch3", "Description for branch3");
+	await expect(page.getByText("PR #44 created successfully")).toBeVisible();
+	await expect
+		.poll(() => server.getNativeStacks())
+		.toEqual([{ number: 1, pull_requests: [{ number: 42 }, { number: 43 }, { number: 44 }] }]);
+
+	await dragAndDropByLocator(
+		page,
+		branchHeaders.filter({ hasText: "branch2" }),
+		branchHeaders.filter({ hasText: "branch3" }),
+		{ force: true, position: { x: 120, y: -10 } },
+	);
+	await expectBranchHeaderOrder(page, ["branch2", "branch3", "branch1"]);
+
+	const beforeFailedPush = reviewHistoryLengths(server, [42, 43, 44]);
+	server.setGitPushesFailing(true);
+	await expect(gitbutler.runScript("push-branch.sh", ["branch3"])).rejects.toThrow(
+		"Command failed with exit code",
+	);
+	// The failed push must restore both the flattened PR bases and the native stack
+	// membership that was dissolved to allow the base changes.
+	await expectReviewHistoryDeltas(server, beforeFailedPush, { 42: 0, 43: 2, 44: 2 });
+	await expectReviews(server, 3, (reviews) => {
+		expect(reviews.map((review) => review.base.ref)).toEqual(["master", "branch1", "branch2"]);
+	});
+	await expect
+		.poll(() => server.getNativeStacks())
+		.toEqual([{ number: 2, pull_requests: [{ number: 42 }, { number: 43 }, { number: 44 }] }]);
+	expect(server.getNativeStackMutationHistory()).toEqual([
+		{ operation: "create", pullRequests: [42, 43] },
+		{ operation: "add", stackNumber: 1, pullRequests: [44] },
+		{ operation: "unstack", stackNumber: 1 },
+		{ operation: "create", pullRequests: [42, 43, 44] },
+	]);
+});
+
 test("reordering reviewed refs updates every target after a partial push", async ({
 	page,
 	gitbutler,
@@ -1111,6 +1275,22 @@ function reviewHistoryLengths(server: FakeGitHubServer, reviews: number[]) {
 	return Object.fromEntries(
 		reviews.map((number) => [number, server.getReviewUpdateHistory(number).length]),
 	);
+}
+
+function expectNoBaseUpdates(
+	server: FakeGitHubServer,
+	before: Record<number, number>,
+	reviews: number[],
+) {
+	for (const number of reviews) {
+		const updates = server.getReviewUpdateHistory(number).slice(before[number] ?? 0);
+		for (const update of updates) {
+			expect(
+				update.base,
+				`review #${number} must not receive base updates while natively stacked`,
+			).toBeUndefined();
+		}
+	}
 }
 
 async function expectReviewHistoryDeltas(


### PR DESCRIPTION
GitHub rejects base-branch updates for any PR that is currently a member of a native stack (HTTP 422), even when the requested base is unchanged. The native sync path sent those updates for every review, which broke three flows:

- An ordinary push of an unchanged native stack emitted a review-sync warning for every member.
- Appending a new PR on top failed before the native `add` call, so the GitHub stack kept its old membership.
- After a failed reordered push, the pre-push flattening had already dissolved the native stack and only the PR bases were restored, permanently losing membership. A target-branch change with unchanged PR ordering also hit the 422 before the push even started.

Changes:

- `stacks::prepare` now reports which PRs remain stack members after reconciliation; the sync skips base updates for them (Noop patches nothing, Append patches only the new suffix). Their bases are enforced by the stack itself and cannot drift.
- The pre-push target flattening dissolves every native stack containing the affected reviews — it only runs when bases are about to change, regardless of whether PR ordering changed — and the dissolved memberships are carried in the rollback state. A failed push restores bases first, then recreates membership; if base restoration fails, membership is not recreated and the error says so.
- When native sync fails, the fallback now updates descriptions only instead of resending locked bases. The desired targets are not cached on that path, so the next synchronization still detects the drift and reconciles.
- PR update errors now include GitHub's response body, so a 422 shows the actual "part of a stack" message.

The fake GitHub server used in e2e tests now models the member base-lock (422 on any base update for a stacked PR, including no-op ones) and rejects re-stacking already-stacked PRs; regression tests cover the unchanged-stack push, append, and failed-reorder membership restore.

Known limitation: a crash between dissolve and restore strands membership until the next successful sync recreates it; GitHub offers no transactional API for this.