### PR TITLE
Lite scope hotkeys

### DIFF
--- a/apps/lite/ui/src/hotkeys.ts
+++ b/apps/lite/ui/src/hotkeys.ts
@@ -117,6 +117,15 @@ export const workspaceHotkeys = {
 			name: "Update workspace (rebases all stacks)",
 		},
 	},
+	focusDetails: {
+		hotkey: "0",
+	},
+	focusUncommittedFiles: {
+		hotkey: "1",
+	},
+	focusOutline: {
+		hotkey: "2",
+	},
 	focusHorizontalSelectionScopeLeft: {
 		hotkey: "Mod+Alt+ArrowLeft",
 	},

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
@@ -153,7 +153,7 @@
 		--diffs-selection-number-fg: var(--text-1);
 	}
 
-	[data-selection-focus-styles="true"] [data-selection-scope]:focus-within & {
+	[data-selection-focus-styles="true"] [data-selection-scope="diff"]:focus-within & {
 		--diffs-bg-selection-number-override: var(--fill-gray-bg);
 
 		diffs-container {

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -1409,6 +1409,7 @@ const PullRequestForm: FC<{
 				<Field.Control
 					render={<FieldControlStyles />}
 					className="text-15 text-semibold"
+					data-selection-scope={"pr" satisfies SelectionScope}
 					name="title"
 					onChange={(evt) => setLocalDocument({ ...localDocument, title: evt.currentTarget.value })}
 					placeholder="Title"

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
@@ -28,7 +28,7 @@ import {
 } from "@tanstack/react-query";
 import { useNavigate, useParams } from "@tanstack/react-router";
 import { Match } from "effect";
-import { type FC, Activity, useDeferredValue } from "react";
+import { type FC, type RefObject, Activity, useDeferredValue, useRef } from "react";
 import { Group, Panel, Separator, useDefaultLayout } from "react-resizable-panels";
 import {
 	branchOperand,
@@ -61,7 +61,10 @@ import { useStateReconciler as useReconcileState } from "#ui/reconcile.ts";
 // stored in local storage.
 type PanelId = "outline-panel" | "details-panel";
 
-const useWorkspaceHotkeys = (projectId: string) => {
+const useWorkspaceHotkeys = (
+	projectId: string,
+	detailsPanelRef: RefObject<HTMLDivElement | null>,
+) => {
 	const dispatch = useAppDispatch();
 	const detailsFullWindow = useAppSelector(interfaceSlice.selectors.selectDetailsFullWindow);
 	const dialog = useAppSelector(interfaceSlice.selectors.selectDialogState);
@@ -127,6 +130,27 @@ const useWorkspaceHotkeys = (projectId: string) => {
 				conflictBehavior: "allow",
 				enabled: canShowFiles,
 				meta: workspaceHotkeys.toggleFiles.meta,
+			},
+		},
+		{
+			hotkey: workspaceHotkeys.focusDetails.hotkey,
+			callback: () => {
+				const focusedDiff = focusSelectionScope("diff");
+				if (!focusedDiff) detailsPanelRef.current?.focus({ focusVisible: false });
+			},
+		},
+		{
+			hotkey: workspaceHotkeys.focusUncommittedFiles.hotkey,
+			callback: () => focusSelectionScope("uncommitted-files"),
+			options: {
+				enabled: outlineVisible,
+			},
+		},
+		{
+			hotkey: workspaceHotkeys.focusOutline.hotkey,
+			callback: () => focusSelectionScope("outline"),
+			options: {
+				enabled: outlineVisible,
 			},
 		},
 		{
@@ -294,8 +318,9 @@ const WorkspacePage: FC = () => {
 	const outlineMode = useAppSelector((state) =>
 		projectSlice.selectors.selectOutlineModeState(state, projectId),
 	);
+	const detailsPanelRef = useRef<HTMLDivElement>(null);
 
-	useWorkspaceHotkeys(projectId);
+	useWorkspaceHotkeys(projectId, detailsPanelRef);
 
 	const selectBranch = (branch: BranchOperand) => {
 		dispatch(
@@ -482,7 +507,12 @@ const WorkspacePage: FC = () => {
 					<Separator className={styles.resizeHandle} />
 				</Activity>
 
-				<Panel id={"details-panel" satisfies PanelId} className={styles.panel}>
+				<Panel
+					id={"details-panel" satisfies PanelId}
+					className={styles.panel}
+					elementRef={detailsPanelRef}
+					tabIndex={-1}
+				>
 					<Details selection={deferredDetailsSelection} />
 				</Panel>
 			</Group>

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
@@ -28,7 +28,7 @@ import {
 } from "@tanstack/react-query";
 import { useNavigate, useParams } from "@tanstack/react-router";
 import { Match } from "effect";
-import { type FC, type RefObject, Activity, useDeferredValue, useRef } from "react";
+import { type FC, Activity, useDeferredValue } from "react";
 import { Group, Panel, Separator, useDefaultLayout } from "react-resizable-panels";
 import {
 	branchOperand,
@@ -61,10 +61,7 @@ import { useStateReconciler as useReconcileState } from "#ui/reconcile.ts";
 // stored in local storage.
 type PanelId = "outline-panel" | "details-panel";
 
-const useWorkspaceHotkeys = (
-	projectId: string,
-	detailsPanelRef: RefObject<HTMLDivElement | null>,
-) => {
+const useWorkspaceHotkeys = (projectId: string) => {
 	const dispatch = useAppDispatch();
 	const detailsFullWindow = useAppSelector(interfaceSlice.selectors.selectDetailsFullWindow);
 	const dialog = useAppSelector(interfaceSlice.selectors.selectDialogState);
@@ -134,10 +131,7 @@ const useWorkspaceHotkeys = (
 		},
 		{
 			hotkey: workspaceHotkeys.focusDetails.hotkey,
-			callback: () => {
-				const focusedDiff = focusSelectionScope("diff");
-				if (!focusedDiff) detailsPanelRef.current?.focus({ focusVisible: false });
-			},
+			callback: () => focusSelectionScope("details"),
 		},
 		{
 			hotkey: workspaceHotkeys.focusUncommittedFiles.hotkey,
@@ -318,9 +312,8 @@ const WorkspacePage: FC = () => {
 	const outlineMode = useAppSelector((state) =>
 		projectSlice.selectors.selectOutlineModeState(state, projectId),
 	);
-	const detailsPanelRef = useRef<HTMLDivElement>(null);
 
-	useWorkspaceHotkeys(projectId, detailsPanelRef);
+	useWorkspaceHotkeys(projectId);
 
 	const selectBranch = (branch: BranchOperand) => {
 		dispatch(
@@ -510,8 +503,7 @@ const WorkspacePage: FC = () => {
 				<Panel
 					id={"details-panel" satisfies PanelId}
 					className={styles.panel}
-					elementRef={detailsPanelRef}
-					tabIndex={-1}
+					data-selection-scope={"details" satisfies SelectionScope}
 				>
 					<Details selection={deferredDetailsSelection} />
 				</Panel>

--- a/apps/lite/ui/src/selection-scopes.ts
+++ b/apps/lite/ui/src/selection-scopes.ts
@@ -7,10 +7,14 @@ import { getAdjacent, type NavigationIndex } from "#ui/workspace/navigation-inde
 import { useHotkeySequences, useHotkeys } from "@tanstack/react-hotkeys";
 
 export type SelectionScope = "uncommitted-files" | "outline" | "files" | "diff";
-const allSelectionScopes: Array<SelectionScope> = ["uncommitted-files", "outline", "files", "diff"];
+const allSelectionScopes: Set<string> = new Set([
+	"uncommitted-files",
+	"outline",
+	"files",
+	"diff",
+] satisfies Array<SelectionScope>);
 
-const isSelectionScope = (id: string): id is SelectionScope =>
-	allSelectionScopes.includes(id as SelectionScope);
+const isSelectionScope = (id: string): id is SelectionScope => allSelectionScopes.has(id);
 
 export const getFocusedSelectionScope = (activeElement: Element | null): SelectionScope | null => {
 	const selectionScope = activeElement?.matches("[data-selection-scope]")

--- a/apps/lite/ui/src/selection-scopes.ts
+++ b/apps/lite/ui/src/selection-scopes.ts
@@ -24,10 +24,11 @@ export const getFocusedSelectionScope = (activeElement: Element | null): Selecti
 	return isSelectionScope(selectionScope) ? selectionScope : null;
 };
 
-export const focusSelectionScope = (selectionScope: SelectionScope) => {
-	document
-		.querySelector<HTMLElement>(`[data-selection-scope="${selectionScope}"]`)
-		?.focus({ focusVisible: false });
+export const focusSelectionScope = (selectionScope: SelectionScope): boolean => {
+	const el = document.querySelector<HTMLElement>(`[data-selection-scope="${selectionScope}"]`);
+
+	if (el) el.focus({ focusVisible: false });
+	return !!el;
 };
 
 export const focusHorizontalSelectionScope = ({

--- a/apps/lite/ui/src/selection-scopes.ts
+++ b/apps/lite/ui/src/selection-scopes.ts
@@ -6,13 +6,21 @@ import { useAppDispatch } from "#ui/store.ts";
 import { getAdjacent, type NavigationIndex } from "#ui/workspace/navigation-index.ts";
 import { useHotkeySequences, useHotkeys } from "@tanstack/react-hotkeys";
 
-export type SelectionScope = "uncommitted-files" | "outline" | "files" | "diff";
+export type SelectionScope = "details" | "uncommitted-files" | "outline" | "files" | "diff" | "pr";
 const allSelectionScopes: Set<string> = new Set([
+	"details",
 	"uncommitted-files",
 	"outline",
 	"files",
 	"diff",
+	"pr",
 ] satisfies Array<SelectionScope>);
+
+// Supports arbitarily nested scopes. Must share that ancestral relationship in the DOM. Tries from
+// left to right.
+const selectionScopeChildren: Partial<Record<SelectionScope, Set<SelectionScope>>> = {
+	details: new Set(["diff", "pr", "files"]),
+};
 
 const isSelectionScope = (id: string): id is SelectionScope => allSelectionScopes.has(id);
 
@@ -24,11 +32,23 @@ export const getFocusedSelectionScope = (activeElement: Element | null): Selecti
 	return isSelectionScope(selectionScope) ? selectionScope : null;
 };
 
-export const focusSelectionScope = (selectionScope: SelectionScope): boolean => {
-	const el = document.querySelector<HTMLElement>(`[data-selection-scope="${selectionScope}"]`);
+const findFocusTarget = (parent: ParentNode, scope: SelectionScope): HTMLElement | null => {
+	const root = parent.querySelector<HTMLElement>(`[data-selection-scope="${scope}"]`);
+	if (!root) return null;
 
-	if (el) el.focus({ focusVisible: false });
-	return !!el;
+	const children = selectionScopeChildren[scope];
+	if (children) {
+		for (const childScope of children) {
+			const target = findFocusTarget(root, childScope);
+			if (target) return target;
+		}
+	}
+
+	return root;
+};
+
+export const focusSelectionScope = (scope: SelectionScope) => {
+	findFocusTarget(document, scope)?.focus({ focusVisible: false });
 };
 
 export const focusHorizontalSelectionScope = ({


### PR DESCRIPTION
0/1/2. The branches tab currently uses 2 for consistency and simplicity but re: UX it should arguably use 1. This also raises some questions around these hotkeys given, to me, the natural focus target of the PR tab is an input.