### PR TITLE
Retry transient Git config locks

### DIFF
--- a/crates/but-core/src/git_config.rs
+++ b/crates/but-core/src/git_config.rs
@@ -37,7 +37,7 @@ pub fn open_config_for_editing(
     std::fs::create_dir_all(path.parent().context("git config path has no parent")?)?;
     let lock = gix::lock::File::acquire_to_update_resource(
         &path,
-        gix::lock::acquire::Fail::Immediately,
+        gix::lock::acquire::Fail::AfterDurationWithBackoff(std::time::Duration::from_secs(1)),
         None,
     )?;
     if !path.exists() {

--- a/crates/but-core/src/ref_metadata.rs
+++ b/crates/but-core/src/ref_metadata.rs
@@ -460,31 +460,54 @@ impl ProjectMeta {
     pub fn persist(&self, repo: &gix::Repository) -> anyhow::Result<()> {
         let project_meta = repair_target_metadata_for_migration(self, repo);
         let changed = git_config::edit_repo_config(repo, gix::config::Source::Local, |config| {
-            set_or_remove(
-                config,
-                PROJECT_TARGET_REF,
-                project_meta.target_ref.as_ref().map(ToString::to_string),
-            )?;
-            set_or_remove(
-                config,
-                PROJECT_TARGET_COMMIT_ID,
-                project_meta
-                    .target_commit_id
-                    .filter(|id| !id.is_null())
-                    .map(|id| id.to_string()),
-            )?;
-            set_or_remove(
-                config,
-                PROJECT_PUSH_REMOTE,
-                project_meta.push_remote.as_deref(),
-            )?;
-            git_config::set_config_value(config, PROJECT_PORTED_META, "true")?;
-            Ok(())
+            project_meta.write_to_config(config)
         })?;
-        if changed && let Ok(storage_path) = but_project_handle::gitbutler_storage_path(repo) {
-            but_project_handle::write_refresh_sentinel(&storage_path.join("virtual_branches.toml"));
-        }
+        notify_legacy_storage(repo, changed);
         Ok(())
+    }
+
+    /// Port project metadata, loading the legacy fallback only if Git config has no metadata.
+    pub fn port_if_needed(
+        repo: &gix::Repository,
+        legacy_fallback: impl FnOnce() -> anyhow::Result<Self>,
+    ) -> anyhow::Result<()> {
+        let changed = git_config::edit_repo_config(repo, gix::config::Source::Local, |config| {
+            if matches!(config.boolean(PROJECT_PORTED_META), Ok(Some(true))) {
+                return Ok(());
+            }
+            let configured = Self::try_from_config(config)?;
+            let project_meta = if configured == Self::default() {
+                legacy_fallback()?
+            } else {
+                configured
+            };
+            repair_target_metadata_for_migration(&project_meta, repo).write_to_config(config)
+        })?;
+        notify_legacy_storage(repo, changed);
+        Ok(())
+    }
+
+    fn write_to_config(&self, config: &mut gix::config::File) -> anyhow::Result<()> {
+        set_or_remove(
+            config,
+            PROJECT_TARGET_REF,
+            self.target_ref.as_ref().map(ToString::to_string),
+        )?;
+        set_or_remove(
+            config,
+            PROJECT_TARGET_COMMIT_ID,
+            self.target_commit_id
+                .filter(|id| !id.is_null())
+                .map(|id| id.to_string()),
+        )?;
+        set_or_remove(config, PROJECT_PUSH_REMOTE, self.push_remote.as_deref())?;
+        git_config::set_config_value(config, PROJECT_PORTED_META, "true")
+    }
+}
+
+fn notify_legacy_storage(repo: &gix::Repository, changed: bool) {
+    if changed && let Ok(storage_path) = but_project_handle::gitbutler_storage_path(repo) {
+        but_project_handle::write_refresh_sentinel(&storage_path.join("virtual_branches.toml"));
     }
 }
 

--- a/crates/but-ctx/src/lib.rs
+++ b/crates/but-ctx/src/lib.rs
@@ -521,16 +521,12 @@ impl Context {
     /// Use `repo` instead of the default repository that would be opened on first query.
     pub fn with_repo(mut self, repo: gix::Repository) -> anyhow::Result<Self> {
         if !ProjectMeta::is_ported_repo(&repo)? {
-            let configured = ProjectMeta::resolve(&repo)?;
-            let project_meta = if configured == ProjectMeta::default() {
-                but_meta::legacy_storage::read_legacy_project_meta(
+            ProjectMeta::port_if_needed(&repo, || {
+                Ok(but_meta::legacy_storage::read_legacy_project_meta(
                     &self.project_data_dir.join("virtual_branches.toml"),
                 )?
-                .unwrap_or_default()
-            } else {
-                configured
-            };
-            project_meta.persist(&repo)?;
+                .unwrap_or_default())
+            })?;
         }
         self.repo.assign(repo);
         Ok(self)

--- a/crates/but-ctx/tests/ctx/main.rs
+++ b/crates/but-ctx/tests/ctx/main.rs
@@ -1,4 +1,8 @@
-use std::fs;
+use std::{
+    fs,
+    sync::{Arc, Barrier},
+    thread,
+};
 
 use but_core::ref_metadata::ProjectMeta;
 use but_ctx::{Context, ProjectHandle};
@@ -279,11 +283,48 @@ fn context_creation_ports_legacy_toml_before_cleanup() -> anyhow::Result<()> {
 }
 
 #[test]
+fn concurrent_context_creation_ports_legacy_toml() -> anyhow::Result<()> {
+    let (_tmp, repo, target_commit_id) = run_fixture("project-meta-toml")?;
+    let gitdir = repo.git_dir().to_owned();
+    let barrier = Arc::new(Barrier::new(9));
+    let repos = (0..8)
+        .map(|_| open_repo(&gitdir))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let threads = repos
+        .into_iter()
+        .map(|repo| {
+            let barrier = barrier.clone();
+            thread::spawn(move || -> anyhow::Result<()> {
+                barrier.wait();
+                Context::from_repo_for_testing(repo)?;
+                Ok(())
+            })
+        })
+        .collect::<Vec<_>>();
+    barrier.wait();
+
+    for thread in threads {
+        thread.join().expect("context creation does not panic")?;
+    }
+    assert_eq!(
+        ProjectMeta::resolve(&repo)?,
+        project_meta(target_commit_id, "refs/remotes/origin/main", "fork")?,
+        "legacy project metadata is ported"
+    );
+    Ok(())
+}
+
+#[test]
 fn context_creation_preserves_unmarked_project_config() -> anyhow::Result<()> {
     let (_tmp, repo, _target_commit_id) = run_fixture("project-meta-ported")?;
     but_core::git_config::edit_repo_config(&repo, gix::config::Source::Local, |config| {
         but_core::git_config::remove_config_value(config, "gitbutler.project.portedMeta")
     })?;
+    fs::write(
+        repo.git_dir().join("gitbutler/virtual_branches.toml"),
+        "invalid legacy metadata",
+    )?;
 
     let ctx = Context::from_repo_for_testing(repo)?;
     snapbox::assert_data_eq!(


### PR DESCRIPTION
## Summary

- Retry Git config lock acquisition for up to one second.
- Cover concurrent context creation during legacy project metadata migration.

## Why

Project startup creates several contexts concurrently. On the first open after an upgrade, those contexts can all try to migrate legacy project metadata into `.git/config`. The lock previously failed immediately, so every request except the winner could surface an error even though the winning write completed almost instantly.

A short backoff lets these brief writes serialize while still failing promptly for a genuinely stuck lock.