### PR TITLE
Auto-detect native GitHub stacks by default

### DIFF
--- a/apps/desktop/src/components/projectSettings/ForgeForm.svelte
+++ b/apps/desktop/src/components/projectSettings/ForgeForm.svelte
@@ -59,7 +59,7 @@
 			"bottom") as ReviewStackingDescription,
 	);
 	const githubStackingMode = $derived(
-		(gitConfigQuery.response?.gitbutlerGithubStackingMode ?? "disabled") as GitHubStackingMode,
+		(gitConfigQuery.response?.gitbutlerGithubStackingMode ?? "auto") as GitHubStackingMode,
 	);
 	const projectQuery = $derived(projectsService.getProject(projectId));
 	const project = $derived(projectQuery.response);
@@ -203,14 +203,17 @@
 
 			{#snippet caption()}
 				Register this project’s reviewed stacks with GitHub’s private-preview stacks API. Higher
-				pull requests may merge the pull requests below them. Changes apply on the next push or pull
-				request creation. Fork-backed pull requests continue using description metadata.
+				pull requests may merge the pull requests below them. Auto falls back to description
+				metadata when the repository is not enrolled in the preview, while Native reports an error.
+				Changes apply on the next push or pull request creation. Fork-backed pull requests always
+				use description metadata.
 			{/snippet}
 
 			<div data-testid="github-stacking-mode-select">
 				<Select
 					value={githubStackingMode}
 					options={[
+						{ label: "Auto", value: "auto" },
 						{ label: "Disabled", value: "disabled" },
 						{ label: "Native", value: "native" },
 					]}

--- a/crates/but-api/src/legacy/forge.rs
+++ b/crates/but-api/src/legacy/forge.rs
@@ -1046,7 +1046,7 @@ pub async fn update_review_footers(
         let github_stacking_mode = match settings.gitbutler_github_stacking_mode {
             Some(but_core::GitHubStackingMode::Native) => but_forge::GitHubStackingMode::Native,
             Some(but_core::GitHubStackingMode::Disabled) => but_forge::GitHubStackingMode::Disabled,
-            None => but_forge::GitHubStackingMode::Unconfigured,
+            Some(but_core::GitHubStackingMode::Auto) | None => but_forge::GitHubStackingMode::Auto,
         };
 
         (
@@ -1129,7 +1129,7 @@ pub(crate) async fn prepare_review_target_updates(
         let github_stacking_mode = match repo.git_settings()?.gitbutler_github_stacking_mode {
             Some(but_core::GitHubStackingMode::Native) => but_forge::GitHubStackingMode::Native,
             Some(but_core::GitHubStackingMode::Disabled) => but_forge::GitHubStackingMode::Disabled,
-            None => but_forge::GitHubStackingMode::Unconfigured,
+            Some(but_core::GitHubStackingMode::Auto) | None => but_forge::GitHubStackingMode::Auto,
         };
         (
             but_forge_storage::Controller::from_path(but_path::app_data_dir()?),

--- a/crates/but-core/src/settings.rs
+++ b/crates/but-core/src/settings.rs
@@ -44,6 +44,8 @@ pub mod git {
         #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
         #[serde(rename_all = "lowercase")]
         pub enum GitHubStackingMode {
+            /// Use native stacks when available, description metadata otherwise.
+            Auto,
             /// Keep using ordinary pull requests and GitButler-managed description metadata.
             Disabled,
             /// Register same-repository GitHub pull requests as native GitHub stacks.
@@ -216,11 +218,12 @@ pub mod git {
             let gitbutler_github_stacking_mode = config
                 .string(GITBUTLER_GITHUB_STACKING_MODE)
                 .map(|value| match value.as_slice() {
+                    b"auto" => GitHubStackingMode::Auto,
                     b"disabled" => GitHubStackingMode::Disabled,
                     b"native" => GitHubStackingMode::Native,
                     invalid => {
-                        tracing::warn!(value = ?invalid, "Invalid gitbutler.githubStackingMode; using disabled");
-                        GitHubStackingMode::Disabled
+                        tracing::warn!(value = ?invalid, "Invalid gitbutler.githubStackingMode; using auto");
+                        GitHubStackingMode::Auto
                     }
                 });
             let gitbutler_forge_review_template_path = config.string(GITBUTLER_FORGE_TEMPLATE_PATH);
@@ -280,6 +283,7 @@ pub mod git {
                     config.set_raw_value(
                         GITBUTLER_GITHUB_STACKING_MODE,
                         match mode {
+                            GitHubStackingMode::Auto => "auto",
                             GitHubStackingMode::Disabled => "disabled",
                             GitHubStackingMode::Native => "native",
                         },

--- a/crates/but-core/tests/core/settings.rs
+++ b/crates/but-core/tests/core/settings.rs
@@ -183,7 +183,11 @@ mod git {
 
     #[test]
     fn github_stacking_mode_round_trips() -> anyhow::Result<()> {
-        for value in [GitHubStackingMode::Disabled, GitHubStackingMode::Native] {
+        for value in [
+            GitHubStackingMode::Auto,
+            GitHubStackingMode::Disabled,
+            GitHubStackingMode::Native,
+        ] {
             let tmp = gix_testtools::tempfile::TempDir::new()?;
             gix::init(tmp.path())?;
             let repo = gix::open_opts(tmp.path(), gix::open::Options::isolated())?;

--- a/crates/but-forge/src/review.rs
+++ b/crates/but-forge/src/review.rs
@@ -1676,7 +1676,8 @@ pub enum ReviewStackingDescription {
 /// Controls whether same-repository GitHub reviews use GitHub's native stacks API.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GitHubStackingMode {
-    Unconfigured,
+    /// Use native stacks when the repository supports them, description metadata otherwise.
+    Auto,
     Disabled,
     Native,
 }
@@ -1702,7 +1703,7 @@ pub async fn prepare_review_target_updates(
         forge, owner, repo, ..
     } = forge_repo_info;
     if *forge != ForgeName::GitHub
-        || github_stacking_mode != GitHubStackingMode::Native
+        || github_stacking_mode == GitHubStackingMode::Disabled
         || reviews.is_empty()
     {
         return Ok(Vec::new());
@@ -2015,7 +2016,7 @@ pub async fn sync_reviews(
             let preferred_account = preferred_forge_user.as_ref().and_then(|user| user.github());
             let pr_numbers: Vec<i64> = reviews.iter().map(|r| r.number).collect();
             let (_, head_repo) = github_head_owner_and_repo(forge_repo_info, forge_push_repo_info);
-            let use_native = github_stacking_mode == GitHubStackingMode::Native
+            let use_native = github_stacking_mode != GitHubStackingMode::Disabled
                 && head_repo.is_none()
                 && !reviews.is_empty();
             if use_native {
@@ -2033,9 +2034,13 @@ pub async fn sync_reviews(
                         errors.extend(native_errors);
                     }
                     Ok(but_github::stacks::Availability::Unsupported) => {
-                        errors.push(
-                            "GitHub native stacks are not enabled for this repository".to_string(),
-                        );
+                        // Under `Auto` an unenrolled repository is the expected case, not an error.
+                        if github_stacking_mode == GitHubStackingMode::Native {
+                            errors.push(
+                                "GitHub native stacks are not enabled for this repository"
+                                    .to_string(),
+                            );
+                        }
                         errors.extend(
                             sync_github_reviews_with_descriptions(
                                 preferred_account,

--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -422,10 +422,10 @@ Agents must use `--message (-m)`, `--file (-F)`, or `--default (-t)` to avoid ed
 
 Requires forge integration to be configured via `but config forge auth`.
 
-Use `but config forge github-stacks enable` inside a repository to let GitButler register and
-reconcile same-repository pull requests with GitHub's native stacked pull requests API. The setting
-is project-local and shared with Desktop. The repository must be enrolled in GitHub's private
-preview. Use `but config forge github-stacks disable` to return to GitButler description footers.
+Same-repository pull requests are automatically registered with GitHub's native stacked pull
+requests API when the repository is enrolled in GitHub's private preview; otherwise GitButler uses
+description footers. `but config forge github-stacks disable` opts out. The setting is
+project-local and shared with Desktop.
 
 ### `but land <branch>`
 

--- a/crates/but/src/args/config.rs
+++ b/crates/but/src/args/config.rs
@@ -573,7 +573,7 @@ pub enum ForgeSubcommand {
     /// repository-local Git config and shared with the GitButler desktop application.
     #[cfg(feature = "legacy")]
     GithubStacks {
-        /// Enable or disable native GitHub stacked pull requests.
+        /// Enable, disable, or auto-detect native GitHub stacked pull requests.
         #[clap(value_enum)]
         status: Option<GitHubStacksStatus>,
     },
@@ -583,6 +583,8 @@ pub enum ForgeSubcommand {
 #[cfg(feature = "legacy")]
 #[derive(Debug, Clone, Copy, clap::ValueEnum)]
 pub enum GitHubStacksStatus {
+    /// Use native stacks when the repository supports them (the default).
+    Auto,
     Enable,
     Disable,
 }

--- a/crates/but/src/command/config.rs
+++ b/crates/but/src/command/config.rs
@@ -683,6 +683,7 @@ pub(crate) fn github_stacks_config(
         match status {
             Some(status) => {
                 let mode = match status {
+                    GitHubStacksStatus::Auto => GitHubStackingMode::Auto,
                     GitHubStacksStatus::Enable => GitHubStackingMode::Native,
                     GitHubStacksStatus::Disable => GitHubStackingMode::Disabled,
                 };
@@ -695,10 +696,9 @@ pub(crate) fn github_stacks_config(
             None => repo
                 .git_settings()?
                 .gitbutler_github_stacking_mode
-                .unwrap_or(GitHubStackingMode::Disabled),
+                .unwrap_or(GitHubStackingMode::Auto),
         }
     };
-    let enabled = configured == GitHubStackingMode::Native;
     if let Some(out) = out.for_human() {
         let t = theme::get();
         let symbol = if status.is_some() {
@@ -710,25 +710,31 @@ pub(crate) fn github_stacks_config(
             out,
             "{} Native GitHub stacks are {} for this repository",
             symbol,
-            if enabled {
-                t.success.paint("enabled")
-            } else {
-                t.hint.paint("disabled")
+            match configured {
+                GitHubStackingMode::Auto => t.success.paint("automatic"),
+                GitHubStackingMode::Native => t.success.paint("enabled"),
+                GitHubStackingMode::Disabled => t.hint.paint("disabled"),
             }
         )?;
-        if enabled {
-            writeln!(
+        match configured {
+            GitHubStackingMode::Auto => writeln!(
+                out,
+                "{}",
+                t.hint.paint(
+                    "They are used when the repository is enrolled in GitHub's stacked pull requests preview."
+                )
+            )?,
+            GitHubStackingMode::Native => writeln!(
                 out,
                 "{}",
                 t.hint.paint(
                     "The repository must be enrolled in GitHub's stacked pull requests preview."
                 )
-            )?;
+            )?,
+            GitHubStackingMode::Disabled => {}
         }
     } else if let Some(out) = out.for_json() {
-        out.write_value(serde_json::json!({
-            "mode": if enabled { "native" } else { "disabled" },
-        }))?;
+        out.write_value(serde_json::json!({ "mode": configured }))?;
     }
     Ok(())
 }

--- a/crates/but/tests/but/command/config.rs
+++ b/crates/but/tests/but/command/config.rs
@@ -6,6 +6,15 @@ use snapbox::str;
 fn github_stacks_configuration_is_repository_local() {
     let env = Sandbox::open_with_default_settings("repo-with-remote-and-head");
 
+    env.but("--json config forge github-stacks")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+{
+  "mode": "auto"
+}
+
+"#]]);
     env.but("config forge github-stacks enable")
         .assert()
         .success()
@@ -40,6 +49,19 @@ The repository must be enrolled in GitHub's stacked pull requests preview.
     assert_eq!(
         env.invoke_git("config --local --get gitbutler.githubStackingMode"),
         "disabled"
+    );
+    env.but("config forge github-stacks auto")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+✓ Native GitHub stacks are automatic for this repository
+They are used when the repository is enrolled in GitHub's stacked pull requests preview.
+
+"#]]);
+    assert_eq!(
+        env.invoke_git("config --local --get gitbutler.githubStackingMode"),
+        "auto",
+        "selecting auto should persist it in repository-local git config"
     );
 }
 

--- a/packages/but-sdk/src/generated/graph/index.d.ts
+++ b/packages/but-sdk/src/generated/graph/index.d.ts
@@ -1903,7 +1903,7 @@ export type GitHubOAuthAppSettings = {
 };
 
 /** Controls whether GitButler registers reviewed stacks with GitHub's native stacks API. */
-export type GitHubStackingMode = "disabled" | "native";
+export type GitHubStackingMode = "auto" | "disabled" | "native";
 
 export type GithubAccountIdentifier = {
   type: "oAuthUsername";

--- a/packages/but-sdk/src/generated/linear/index.d.ts
+++ b/packages/but-sdk/src/generated/linear/index.d.ts
@@ -1903,7 +1903,7 @@ export type GitHubOAuthAppSettings = {
 };
 
 /** Controls whether GitButler registers reviewed stacks with GitHub's native stacks API. */
-export type GitHubStackingMode = "disabled" | "native";
+export type GitHubStackingMode = "auto" | "disabled" | "native";
 
 export type GithubAccountIdentifier = {
   type: "oAuthUsername";


### PR DESCRIPTION
Adds an `auto` value to `gitbutler.githubStackingMode` and makes it the default when unset. Auto behaves like native mode but treats an unenrolled repository as the expected case: the existing stacks-endpoint probe decides, and review sync falls back to description footers silently instead of reporting an error. Explicit `native` keeps the error, since there it signals a misconfiguration.

Surfaces updated: `but config forge github-stacks` accepts `auto` and reports it as the default, the desktop setting gets an Auto option as default, and the bundled skill docs now describe the automatic behavior with `disable` as the opt-out.

Note: repositories already enrolled in GitHub's stacked pull requests preview switch from description footers to native stacks on their next push.