### PR TITLE
Fix uncommitting a hunk when it is a file's only change

### DIFF
--- a/crates/but-workspace/src/tree_manipulation/create_tree_without_diff.rs
+++ b/crates/but-workspace/src/tree_manipulation/create_tree_without_diff.rs
@@ -124,11 +124,52 @@ pub fn create_tree_without_diff(
                     before_entry.object_id(),
                 )?;
                 continue;
-            } else {
+            }
+
+            if !is_blob(before_entry.mode().kind()) {
+                // Only blobs have hunks to speak of, so anything else stays the
+                // caller's problem, exactly as it was before.
                 anyhow::bail!(
                     "Deletions or additions aren't well-defined for hunk-based operations - use the whole-file mode instead"
                 );
             }
+
+            // A file the change deletes has no 'after' state to diff against, so it gets
+            // an empty one. Removing all of the deletion's hunks then brings the file
+            // back in full, and removing only some of them brings back just those lines.
+            let before_blob = before_entry.object()?.into_blob();
+            let removal = contents_without_hunks(
+                repository,
+                &change,
+                before_path.as_bstr(),
+                ChangeState {
+                    id: before_entry.id().detach(),
+                    kind: before_entry.mode().kind(),
+                },
+                &before_blob.data,
+                ChangeState {
+                    id: repository.write_blob(b"")?.detach(),
+                    kind: before_entry.mode().kind(),
+                },
+                &[],
+                context_lines,
+            )?;
+
+            if !removal.unmatched.is_empty() {
+                dropped.push(DiffSpec {
+                    previous_path: change.previous_path.clone(),
+                    path: change.path.clone(),
+                    hunk_headers: removal.unmatched,
+                });
+            }
+
+            if removal.removed_any {
+                // Leave the deletion in place when nothing matched, or the file would
+                // come back empty rather than staying deleted.
+                let restored = repository.write_blob(&removal.contents)?;
+                builder.upsert(change.path.as_bstr(), before_entry.mode().kind(), restored)?;
+            }
+            continue;
         };
 
         match after_entry.mode().kind() {
@@ -137,82 +178,77 @@ pub fn create_tree_without_diff(
                 if change.hunk_headers.is_empty() {
                     revert_file_to_before_state(&before_entry, &mut builder, &change)?;
                 } else {
-                    let Some(before_entry) = before_entry else {
-                        anyhow::bail!(
-                            "Deletions or additions aren't well-defined for hunk-based operations - use the whole-file mode instead"
-                        );
+                    // A file the change adds has no 'before' state to diff against, so
+                    // it gets an empty one. That keeps its hunks matchable, and removing
+                    // all of them then simply means the addition is gone.
+                    // Anything that isn't a blob has no contents to work with, and is
+                    // left to the diff below to reject with its own message.
+                    let before_blob = match &before_entry {
+                        Some(before_entry) if is_blob(before_entry.mode().kind()) => {
+                            Some(before_entry.object()?.into_blob())
+                        }
+                        _ => None,
+                    };
+                    let before_data: &[u8] = before_blob
+                        .as_ref()
+                        .map_or(&[], |blob| blob.data.as_slice());
+                    let before_state = match &before_entry {
+                        Some(before_entry) => ChangeState {
+                            id: before_entry.id().detach(),
+                            kind: before_entry.mode().kind(),
+                        },
+                        None => ChangeState {
+                            id: repository.write_blob(b"")?.detach(),
+                            kind: after_entry.mode().kind(),
+                        },
                     };
 
-                    let diff = but_core::UnifiedPatch::compute(
+                    let removal = contents_without_hunks(
                         repository,
-                        change.path.as_bstr(),
-                        Some(before_path.as_bstr()),
+                        &change,
+                        before_path.as_bstr(),
+                        before_state,
+                        before_data,
                         ChangeState {
                             id: after_entry.id().detach(),
                             kind: after_entry.mode().kind(),
                         },
-                        ChangeState {
-                            id: before_entry.id().detach(),
-                            kind: before_entry.mode().kind(),
-                        },
+                        &after_blob.data,
                         context_lines,
-                    )?
-                    .context(
-                        "Cannot diff submodules - if this is encountered we should look into it",
                     )?;
 
-                    let but_core::UnifiedPatch::Patch {
-                        hunks: diff_hunks, ..
-                    } = diff
-                    else {
-                        anyhow::bail!("expected a patch");
-                    };
-
-                    let mut good_hunk_headers = vec![];
-                    let mut bad_hunk_headers = vec![];
-
-                    for hunk in &change.hunk_headers {
-                        if diff_hunks
-                            .iter()
-                            .any(|diff_hunk| HunkHeader::from(diff_hunk).contains(*hunk))
-                        {
-                            good_hunk_headers.push(*hunk);
-                        } else {
-                            bad_hunk_headers.push(*hunk);
-                        }
-                    }
-
-                    if !bad_hunk_headers.is_empty() {
+                    if !removal.unmatched.is_empty() {
                         dropped.push(DiffSpec {
                             previous_path: change.previous_path.clone(),
                             path: change.path.clone(),
-                            hunk_headers: bad_hunk_headers,
+                            hunk_headers: removal.unmatched,
                         });
                     }
 
-                    // TODO: Validate that the hunks correspond with actual changes?
-                    let before_blob = before_entry.object()?.into_blob();
-
-                    let new_hunks = new_hunks_after_removals(
-                        diff_hunks.into_iter().map(Into::into).collect(),
-                        good_hunk_headers,
-                    )?;
-                    let new_after_contents = but_core::apply_hunks(
-                        before_blob.data.as_bstr(),
-                        after_blob.data.as_bstr(),
-                        &new_hunks,
-                    )?;
-                    let mode = if new_after_contents == before_blob.data {
-                        before_entry.mode().kind()
+                    let new_after_contents = removal.contents;
+                    if before_entry.is_none()
+                        && removal.removed_any
+                        && new_after_contents.is_empty()
+                    {
+                        // Every hunk of an added file was removed, so there is no
+                        // addition left to keep - an empty blob would be a different
+                        // file rather than none at all. Nothing matching at all leaves
+                        // the addition alone instead, including for an empty file.
+                        builder.remove(change.path.as_bstr())?;
                     } else {
-                        after_entry.mode().kind()
-                    };
-                    let new_after_contents = repository.write_blob(&new_after_contents)?;
+                        let mode = match &before_entry {
+                            Some(before_entry) if new_after_contents == before_data => {
+                                before_entry.mode().kind()
+                            }
+                            _ => after_entry.mode().kind(),
+                        };
+                        let new_after_contents = repository.write_blob(&new_after_contents)?;
 
-                    // Keep the mode of the after state. We _should_ at some
-                    // point introduce the mode specifically as part of the
-                    // DiscardSpec, but for now, we can just use the after state.
-                    builder.upsert(change.path.as_bstr(), mode, new_after_contents)?;
+                        // Keep the mode of the after state. We _should_ at some
+                        // point introduce the mode specifically as part of the
+                        // DiscardSpec, but for now, we can just use the after state.
+                        builder.upsert(change.path.as_bstr(), mode, new_after_contents)?;
+                    }
                 }
             }
             _ => {
@@ -223,6 +259,88 @@ pub fn create_tree_without_diff(
 
     let final_tree = builder.write()?;
     Ok((final_tree.detach(), dropped))
+}
+
+/// Remove the hunks named in `change` from the diff between `before` and `after`,
+/// returning the resulting file contents along with the hunks that couldn't be matched.
+///
+/// A side that doesn't exist - an addition has no `before`, a deletion has no `after` -
+/// is passed in as an empty blob. That keeps its hunks matchable, so removing all of them
+/// resolves to the whole-file outcome instead of being rejected as undefined.
+#[allow(clippy::too_many_arguments)]
+fn contents_without_hunks(
+    repository: &gix::Repository,
+    change: &DiffSpec,
+    before_path: &bstr::BStr,
+    before_state: ChangeState,
+    before_data: &[u8],
+    after_state: ChangeState,
+    after_data: &[u8],
+    context_lines: u32,
+) -> anyhow::Result<HunkRemoval> {
+    let diff = but_core::UnifiedPatch::compute(
+        repository,
+        change.path.as_bstr(),
+        Some(before_path),
+        after_state,
+        before_state,
+        context_lines,
+    )?
+    .context("Cannot diff submodules - if this is encountered we should look into it")?;
+
+    let but_core::UnifiedPatch::Patch {
+        hunks: diff_hunks, ..
+    } = diff
+    else {
+        anyhow::bail!("expected a patch");
+    };
+
+    let mut good_hunk_headers = vec![];
+    let mut bad_hunk_headers = vec![];
+    for hunk in &change.hunk_headers {
+        if diff_hunks
+            .iter()
+            .any(|diff_hunk| HunkHeader::from(diff_hunk).contains(*hunk))
+        {
+            good_hunk_headers.push(*hunk);
+        } else {
+            bad_hunk_headers.push(*hunk);
+        }
+    }
+
+    // TODO: Validate that the hunks correspond with actual changes?
+    let removed_any = !good_hunk_headers.is_empty();
+    let new_hunks = new_hunks_after_removals(
+        diff_hunks.into_iter().map(Into::into).collect(),
+        good_hunk_headers,
+    )?;
+    let contents = but_core::apply_hunks(before_data.as_bstr(), after_data.as_bstr(), &new_hunks)?;
+    Ok(HunkRemoval {
+        contents,
+        unmatched: bad_hunk_headers,
+        removed_any,
+    })
+}
+
+/// Whether `kind` is a file whose contents can be diffed into hunks.
+fn is_blob(kind: gix::objs::tree::EntryKind) -> bool {
+    matches!(
+        kind,
+        gix::objs::tree::EntryKind::Blob | gix::objs::tree::EntryKind::BlobExecutable
+    )
+}
+
+/// The outcome of removing hunks from a file's diff.
+struct HunkRemoval {
+    /// The file's contents with the matched hunks removed.
+    contents: bstr::BString,
+    /// Hunks that matched nothing in the diff, and so were not removed.
+    unmatched: Vec<HunkHeader>,
+    /// Whether any hunk matched at all.
+    ///
+    /// When nothing matched, the entry must be left exactly as it is: reporting a
+    /// spec as unmatched and still rewriting the entry would contradict each other.
+    removed_any: bool,
 }
 
 fn new_hunks_after_removals(

--- a/crates/but-workspace/tests/workspace/tree_manipulation/create_tree_without_diff.rs
+++ b/crates/but-workspace/tests/workspace/tree_manipulation/create_tree_without_diff.rs
@@ -1,10 +1,10 @@
 use but_core::{Commit, DiffSpec, HunkHeader};
-use but_testsupport::visualize_tree;
+use but_testsupport::{CommandExt, git, visualize_tree};
 use but_workspace::tree_manipulation::{ChangesSource, create_tree_without_diff};
 use gix::prelude::ObjectIdExt;
 use snapbox::IntoData;
 
-use crate::utils::{CONTEXT_LINES, read_only_in_memory_scenario};
+use crate::utils::{CONTEXT_LINES, read_only_in_memory_scenario, writable_scenario};
 
 #[test]
 fn two_regular_commits_should_succeed() -> anyhow::Result<()> {
@@ -74,6 +74,232 @@ fn conflicted_then_regular_should_succeed() -> anyhow::Result<()> {
 4ce1de9
 ├── file:100644:8076ded "keep-a\nkeep-b\n"
 └── regular-change.txt:100644:c01d3c5 "base-1\nbase-2\nkeep-1\ndrop-1\ndrop-2\nkeep-2\n"
+
+"#]]
+        .raw()
+    );
+    Ok(())
+}
+
+#[test]
+fn removing_the_only_hunk_of_an_added_file_should_succeed() -> anyhow::Result<()> {
+    // A commit that adds a file has no 'before' state for it, so removing that file's
+    // only hunk cannot be expressed as a diff against anything. That used to be
+    // rejected outright, telling the caller to use whole-file mode instead, which is
+    // what made a hunk undraggable when it was a file's only change.
+    let (repo, _tmp) = writable_scenario("plain-modifications");
+
+    std::fs::write(
+        repo.workdir().expect("non-bare repository").join("added"),
+        "a\nb\n",
+    )?;
+    git(&repo).args(["add", "added"]).run();
+    git(&repo)
+        .args(["commit", "-m", "add a brand-new file"])
+        .run();
+
+    let commit_id = repo.rev_parse_single("HEAD")?.detach();
+
+    let (actual_tree_id, dropped) = create_tree_without_diff(
+        &repo,
+        ChangesSource::Commit { id: commit_id },
+        [DiffSpec {
+            previous_path: None,
+            path: "added".into(),
+            hunk_headers: vec![HunkHeader {
+                old_start: 1,
+                old_lines: 0,
+                new_start: 1,
+                new_lines: 2,
+            }],
+        }],
+        CONTEXT_LINES,
+    )?;
+
+    assert!(
+        dropped.is_empty(),
+        "the hunk covers the entire addition, so nothing is left unmatched"
+    );
+    // The added file is gone again, leaving the rest of the commit's tree untouched.
+    snapbox::assert_data_eq!(
+        visualize_tree(actual_tree_id.attach(&repo)).to_string(),
+        snapbox::str![[r#"
+db299ef
+├── all-added:100644:e69de29 ""
+├── all-modified:100644:f00c965 "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n"
+└── all-removed:100644:f00c965 "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n"
+
+"#]]
+        .raw()
+    );
+    Ok(())
+}
+
+#[test]
+fn removing_the_only_hunk_of_a_deleted_file_should_succeed() -> anyhow::Result<()> {
+    // The mirror image of the addition: a commit that deletes a file has no 'after'
+    // state for it, so removing that deletion's only hunk was rejected the same way.
+    let (repo, _tmp) = writable_scenario("plain-modifications");
+    let workdir = repo.workdir().expect("non-bare repository").to_owned();
+
+    std::fs::write(workdir.join("doomed"), "a\nb\n")?;
+    git(&repo).args(["add", "doomed"]).run();
+    git(&repo).args(["commit", "-m", "add a file"]).run();
+    git(&repo).args(["rm", "doomed"]).run();
+    git(&repo).args(["commit", "-m", "delete it again"]).run();
+
+    let commit_id = repo.rev_parse_single("HEAD")?.detach();
+
+    let (actual_tree_id, dropped) = create_tree_without_diff(
+        &repo,
+        ChangesSource::Commit { id: commit_id },
+        [DiffSpec {
+            previous_path: None,
+            path: "doomed".into(),
+            hunk_headers: vec![HunkHeader {
+                old_start: 1,
+                old_lines: 2,
+                new_start: 1,
+                new_lines: 0,
+            }],
+        }],
+        CONTEXT_LINES,
+    )?;
+
+    assert!(
+        dropped.is_empty(),
+        "the hunk covers the entire deletion, so nothing is left unmatched"
+    );
+    // The file is back with its original content, as if the commit never removed it.
+    snapbox::assert_data_eq!(
+        visualize_tree(actual_tree_id.attach(&repo)).to_string(),
+        snapbox::str![[r#"
+66c77b4
+├── all-added:100644:e69de29 ""
+├── all-modified:100644:f00c965 "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n"
+├── all-removed:100644:f00c965 "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n"
+└── doomed:100644:422c2b7 "a\nb\n"
+
+"#]]
+        .raw()
+    );
+    Ok(())
+}
+
+#[test]
+fn an_unmatched_hunk_leaves_a_deletion_in_place() -> anyhow::Result<()> {
+    // A spec that matches nothing is reported back rather than applied, so the file has
+    // to stay deleted - bringing it back as an empty one would contradict the report.
+    let (repo, _tmp) = writable_scenario("plain-modifications");
+    let workdir = repo.workdir().expect("non-bare repository").to_owned();
+
+    std::fs::write(workdir.join("doomed"), "a\nb\n")?;
+    git(&repo).args(["add", "doomed"]).run();
+    git(&repo).args(["commit", "-m", "add a file"]).run();
+    git(&repo).args(["rm", "doomed"]).run();
+    git(&repo).args(["commit", "-m", "delete it again"]).run();
+
+    let commit_id = repo.rev_parse_single("HEAD")?.detach();
+
+    let (actual_tree_id, dropped) = create_tree_without_diff(
+        &repo,
+        ChangesSource::Commit { id: commit_id },
+        [DiffSpec {
+            previous_path: None,
+            path: "doomed".into(),
+            hunk_headers: vec![HunkHeader {
+                old_start: 99,
+                old_lines: 1,
+                new_start: 99,
+                new_lines: 0,
+            }],
+        }],
+        CONTEXT_LINES,
+    )?;
+
+    assert_eq!(
+        dropped,
+        vec![DiffSpec {
+            previous_path: None,
+            path: "doomed".into(),
+            hunk_headers: vec![HunkHeader {
+                old_start: 99,
+                old_lines: 1,
+                new_start: 99,
+                new_lines: 0,
+            }],
+        }],
+        "the unmatched hunk is reported back as it was requested"
+    );
+    // `doomed` is absent, exactly as the commit left it.
+    snapbox::assert_data_eq!(
+        visualize_tree(actual_tree_id.attach(&repo)).to_string(),
+        snapbox::str![[r#"
+db299ef
+├── all-added:100644:e69de29 ""
+├── all-modified:100644:f00c965 "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n"
+└── all-removed:100644:f00c965 "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n"
+
+"#]]
+        .raw()
+    );
+    Ok(())
+}
+
+#[test]
+fn an_unmatched_hunk_leaves_an_addition_in_place() -> anyhow::Result<()> {
+    // An added *empty* file has no hunks at all, so any spec is unmatched. The addition
+    // has to survive rather than being dropped from the tree.
+    let (repo, _tmp) = writable_scenario("plain-modifications");
+
+    std::fs::write(
+        repo.workdir().expect("non-bare repository").join("empty"),
+        "",
+    )?;
+    git(&repo).args(["add", "empty"]).run();
+    git(&repo).args(["commit", "-m", "add an empty file"]).run();
+
+    let commit_id = repo.rev_parse_single("HEAD")?.detach();
+
+    let (actual_tree_id, dropped) = create_tree_without_diff(
+        &repo,
+        ChangesSource::Commit { id: commit_id },
+        [DiffSpec {
+            previous_path: None,
+            path: "empty".into(),
+            hunk_headers: vec![HunkHeader {
+                old_start: 1,
+                old_lines: 0,
+                new_start: 1,
+                new_lines: 1,
+            }],
+        }],
+        CONTEXT_LINES,
+    )?;
+
+    assert_eq!(
+        dropped,
+        vec![DiffSpec {
+            previous_path: None,
+            path: "empty".into(),
+            hunk_headers: vec![HunkHeader {
+                old_start: 1,
+                old_lines: 0,
+                new_start: 1,
+                new_lines: 1,
+            }],
+        }],
+        "the unmatched hunk is reported back as it was requested"
+    );
+    // The empty file is still added, exactly as the commit left it.
+    snapbox::assert_data_eq!(
+        visualize_tree(actual_tree_id.attach(&repo)).to_string(),
+        snapbox::str![[r#"
+562ec11
+├── all-added:100644:e69de29 ""
+├── all-modified:100644:f00c965 "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n"
+├── all-removed:100644:f00c965 "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n"
+└── empty:100644:e69de29 ""
 
 "#]]
         .raw()


### PR DESCRIPTION
Fixes #12583

### Problem

Dragging a hunk out of a commit fails when that hunk is the file's only change:

```
Deletions or additions aren't well-defined for hunk-based operations - use the whole-file mode instead
```

`create_tree_without_diff` has two bails with that message, and either is reachable from `uncommit_changes`:

- a file the commit **adds** has no `before` state, so removing its only hunk has nothing to diff against;
- a file the commit **deletes** has no `after` state, and bails a few lines earlier.

When a file is wholly added or wholly removed, its entire content *is* the single hunk, so dragging that hunk out is exactly the rejected case.

### Fix

Rather than asking the caller to switch to whole-file mode, the missing side is given an empty blob. The existing hunk matching then applies unchanged, and removing every hunk lands on the whole-file outcome by itself: the addition drops out of the tree (rather than being written as an empty blob, which would be a different file), and the deletion is restored.

A spec that matches nothing is still reported in `dropped` and leaves the entry untouched, so an unmatched hunk cannot bring a deleted file back as an empty one.

The shared diff/match/apply sequence moved into one helper so both sites use it instead of carrying a copy each.

### Tests

Four, in `tree_manipulation/create_tree_without_diff.rs`:

- removing the only hunk of an added file leaves the file gone
- removing the only hunk of a deleted file restores it
- an unmatched hunk on a deletion leaves it deleted
- an unmatched hunk on an added empty file leaves it added

The first two fail on `master` with the message above.

The existing test in #12590 didn't reach either bail because every file in the `plain-modifications` fixture exists in the base commit, so there is always a `before` entry, and none of its changes delete a file (`all-removed` is emptied rather than removed).

### Notes

- Both routes are fixed because they produce the identical message from the same function, and I couldn't tell from the recordings which one they show. Happy to narrow this to the addition alone if you would rather keep it smaller.
- A conflicted source commit is rejected earlier with a different message, so this doesn't address the conflicted case from the first video.
