### PR TITLE
Fix tab indentation in TUI diffs

### DIFF
--- a/crates/but/src/command/legacy/status/tui/tests/details_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/details_tests.rs
@@ -289,6 +289,30 @@ fn details_diff_svg_shows_plus_and_minus_backgrounds() {
 }
 
 #[test]
+fn details_view_renders_tab_indented_file() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
+
+    env.file(
+        "tab-indented.svelte",
+        "\t<CardGroup.Item>\n\t\t{#snippet title()}\n\t\t\tWorktree manipulation\n\t\t{/snippet}\n\t</CardGroup.Item>\n",
+    );
+
+    let mut tui = test_tui_with_options(
+        env,
+        TestTuiOptions {
+            width: 100,
+            height: 14,
+            ..Default::default()
+        },
+    );
+
+    tui.input('d').assert_rendered_term_svg_eq(file![
+        "snapshots/details_view_renders_tab_indented_file_001.svg"
+    ]);
+}
+
+#[test]
 fn toggling_details_off_and_on_resets_scroll_position() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
     env.setup_metadata(&["A"]);

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/details_view_renders_tab_indented_file_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/details_view_renders_tab_indented_file_001.svg
@@ -1,0 +1,120 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="272" viewBox="0 0 820 272">
+  <rect x="0" y="0" width="820" height="272" fill="#000000" />
+  <rect x="10" y="10" width="400" height="18" fill="#45475A" />
+  <rect x="418" y="154" width="392" height="18" fill="#004100" />
+  <rect x="418" y="172" width="392" height="18" fill="#004100" />
+  <rect x="418" y="190" width="392" height="18" fill="#004100" />
+  <rect x="418" y="208" width="392" height="18" fill="#004100" />
+  <rect x="418" y="226" width="392" height="18" fill="#004100" />
+  <rect x="10" y="244" width="80" height="18" fill="#555555" />
+  <g font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">
+    <text x="10 18" y="24" style="fill:#FFFFFF;font-weight:bold;">╭┄</text>
+    <text x="34 42" y="24" style="fill:#0000AA;font-weight:bold;">zz</text>
+    <text x="58" y="24" style="fill:#FFFFFF;font-weight:bold;">[</text>
+    <text x="66 74 82 90 98 106 114 122 130 138 146" y="24" style="fill:#00AAAA;font-weight:bold;">uncommitted</text>
+    <text x="154" y="24" style="fill:#FFFFFF;font-weight:bold;">]</text>
+    <text x="410" y="24" style="fill:#555555;">│</text>
+    <text x="418" y="24" style="fill:#CCCCCC;">1</text>
+    <text x="434 442 450 458" y="24" style="fill:#CCCCCC;">file</text>
+    <text x="474 482 490 498 506 514 522 530" y="24" style="fill:#CCCCCC;">changed,</text>
+    <text x="546 554" y="24" style="fill:#00AA00;">+5</text>
+    <text x="570 578" y="24" style="fill:#AA0000;">-0</text>
+    <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
+    <text x="42 50" y="42" style="fill:#0000AA;font-weight:bold;">yk</text>
+    <text x="66" y="42" style="fill:#CCCCCC;">A</text>
+    <text x="82 90 98 106 114 122 130 138 146 154 162 170 178 186 194 202 210 218 226" y="42" style="fill:#00AA00;">tab-indented.svelte</text>
+    <text x="410" y="42" style="fill:#555555;">│</text>
+    <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
+    <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530 538 546 554 562 570 578 586 594 602 610 618 626" y="60" style="fill:#555555;">│──────────────────────────╮</text>
+    <text x="10 18 26" y="78" style="fill:#CCCCCC;">┊╭┄</text>
+    <text x="42 50" y="78" style="fill:#0000AA;font-weight:bold;">g0</text>
+    <text x="66" y="78" style="fill:#CCCCCC;">[</text>
+    <text x="74" y="78" style="fill:#00AA00;">A</text>
+    <text x="82" y="78" style="fill:#CCCCCC;">]</text>
+    <text x="410" y="78" style="fill:#555555;">│</text>
+    <text x="426 434 442 450" y="78" style="fill:#0000AA;">yk:9</text>
+    <text x="466 474 482 490 498 506 514 522 530 538 546 554 562 570 578 586 594 602 610" y="78" style="fill:#CCCCCC;">tab-indented.svelte</text>
+    <text x="626" y="78" style="fill:#555555;">│</text>
+    <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
+    <text x="50" y="96" style="fill:#AA00AA;">t</text>
+    <text x="58 66" y="96" style="fill:#CCCCCC;opacity:0.75;">pm</text>
+    <text x="82 90 98" y="96" style="fill:#CCCCCC;">add</text>
+    <text x="114" y="96" style="fill:#CCCCCC;">A</text>
+    <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530 538 546 554 562 570 578 586 594 602 610 618 626" y="96" style="fill:#555555;">│──────────────────────────╯</text>
+    <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
+    <text x="410" y="114" style="fill:#555555;">│</text>
+    <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
+    <text x="410" y="132" style="fill:#555555;">│</text>
+    <text x="418 426" y="132" style="fill:#CCCCCC;opacity:0.75;">@@</text>
+    <text x="442 450 458 466" y="132" style="fill:#CCCCCC;opacity:0.75;">-1,0</text>
+    <text x="482 490 498 506" y="132" style="fill:#CCCCCC;opacity:0.75;">+1,5</text>
+    <text x="522 530" y="132" style="fill:#CCCCCC;opacity:0.75;">@@</text>
+    <text x="10" y="150" style="fill:#CCCCCC;">┴</text>
+    <text x="26 34 42 50 58 66 74" y="150" style="fill:#CCCCCC;opacity:0.75;">0dc3733</text>
+    <text x="90 98 106 114 122 130 138" y="150" style="fill:#CCCCCC;">(common</text>
+    <text x="154 162 170 178 186" y="150" style="fill:#CCCCCC;">base)</text>
+    <text x="202 210 218 226 234 242 250 258 266 274" y="150" style="fill:#CCCCCC;opacity:0.75;">2000-01-02</text>
+    <text x="290 298 306" y="150" style="fill:#CCCCCC;">add</text>
+    <text x="322" y="150" style="fill:#CCCCCC;">M</text>
+    <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530" y="150" style="fill:#555555;">│───────────────</text>
+    <text x="410" y="168" style="fill:#555555;">│</text>
+    <text x="434" y="168" style="fill:#555555;">┊</text>
+    <text x="450" y="168" style="fill:#00AA00;">1</text>
+    <text x="466" y="168" style="fill:#555555;">│</text>
+    <text x="482" y="168" style="fill:#CCCCCC;">+</text>
+    <text x="522 530 538 546 554 562 570 578 586 594 602 610 618 626 634 642" y="168" style="fill:#CDD6F4;">&lt;CardGroup.Item&gt;</text>
+    <text x="410" y="186" style="fill:#555555;">│</text>
+    <text x="434" y="186" style="fill:#555555;">┊</text>
+    <text x="450" y="186" style="fill:#00AA00;">2</text>
+    <text x="466" y="186" style="fill:#555555;">│</text>
+    <text x="482" y="186" style="fill:#CCCCCC;">+</text>
+    <text x="554 562 570 578 586 594 602 610 618" y="186" style="fill:#CDD6F4;">{#snippet</text>
+    <text x="634 642 650 658 666 674 682 690" y="186" style="fill:#CDD6F4;">title()}</text>
+    <text x="410" y="204" style="fill:#555555;">│</text>
+    <text x="434" y="204" style="fill:#555555;">┊</text>
+    <text x="450" y="204" style="fill:#00AA00;">3</text>
+    <text x="466" y="204" style="fill:#555555;">│</text>
+    <text x="482" y="204" style="fill:#CCCCCC;">+</text>
+    <text x="586 594 602 610 618 626 634 642" y="204" style="fill:#CDD6F4;">Worktree</text>
+    <text x="658 666 674 682 690 698 706 714 722 730 738 746" y="204" style="fill:#CDD6F4;">manipulation</text>
+    <text x="410" y="222" style="fill:#555555;">│</text>
+    <text x="434" y="222" style="fill:#555555;">┊</text>
+    <text x="450" y="222" style="fill:#00AA00;">4</text>
+    <text x="466" y="222" style="fill:#555555;">│</text>
+    <text x="482" y="222" style="fill:#CCCCCC;">+</text>
+    <text x="554 562 570 578 586 594 602 610 618 626" y="222" style="fill:#CDD6F4;">{/snippet}</text>
+    <text x="410" y="240" style="fill:#555555;">│</text>
+    <text x="434" y="240" style="fill:#555555;">┊</text>
+    <text x="450" y="240" style="fill:#00AA00;">5</text>
+    <text x="466" y="240" style="fill:#555555;">│</text>
+    <text x="482" y="240" style="fill:#CCCCCC;">+</text>
+    <text x="522 530 538 546 554 562 570 578 586 594 602 610 618 626 634 642 650" y="240" style="fill:#CDD6F4;">&lt;/CardGroup.Item&gt;</text>
+    <text x="26 34 42 50 58 66" y="258" style="fill:#FFFFFF;">normal</text>
+    <text x="98 106 114" y="258" style="fill:#0000AA;">↑/k</text>
+    <text x="130 138" y="258" style="fill:#CCCCCC;opacity:0.75;">up</text>
+    <text x="154" y="258" style="fill:#CCCCCC;opacity:0.75;">•</text>
+    <text x="170 178 186" y="258" style="fill:#0000AA;">↓/j</text>
+    <text x="202 210 218 226" y="258" style="fill:#CCCCCC;opacity:0.75;">down</text>
+    <text x="242" y="258" style="fill:#CCCCCC;opacity:0.75;">•</text>
+    <text x="258" y="258" style="fill:#0000AA;">r</text>
+    <text x="274 282 290 298 306 314" y="258" style="fill:#CCCCCC;opacity:0.75;">squash</text>
+    <text x="330" y="258" style="fill:#CCCCCC;opacity:0.75;">•</text>
+    <text x="346" y="258" style="fill:#0000AA;">c</text>
+    <text x="362 370 378 386 394 402" y="258" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="418" y="258" style="fill:#CCCCCC;opacity:0.75;">•</text>
+    <text x="434" y="258" style="fill:#0000AA;">m</text>
+    <text x="450 458 466 474" y="258" style="fill:#CCCCCC;opacity:0.75;">move</text>
+    <text x="490" y="258" style="fill:#CCCCCC;opacity:0.75;">•</text>
+    <text x="506" y="258" style="fill:#0000AA;">b</text>
+    <text x="522 530 538 546 554 562" y="258" style="fill:#CCCCCC;opacity:0.75;">branch</text>
+    <text x="578" y="258" style="fill:#CCCCCC;opacity:0.75;">•</text>
+    <text x="594" y="258" style="fill:#0000AA;">s</text>
+    <text x="610 618 626 634 642" y="258" style="fill:#CCCCCC;opacity:0.75;">stack</text>
+    <text x="658" y="258" style="fill:#CCCCCC;opacity:0.75;">•</text>
+    <text x="674" y="258" style="fill:#0000AA;">?</text>
+    <text x="690 698 706 714" y="258" style="fill:#CCCCCC;opacity:0.75;">help</text>
+    <text x="730" y="258" style="fill:#CCCCCC;opacity:0.75;">•</text>
+    <text x="746" y="258" style="fill:#0000AA;">q</text>
+    <text x="762 770 778 786" y="258" style="fill:#CCCCCC;opacity:0.75;">quit</text>
+  </g>
+</svg>

--- a/crates/but/src/utils/diff_rendering.rs
+++ b/crates/but/src/utils/diff_rendering.rs
@@ -311,17 +311,59 @@ fn syntax_highlight(
     highlight_lines: &mut HighlightLines<'_>,
     syntax_set: &SyntaxSet,
 ) -> Vec<Span<'static>> {
-    let Ok(ranges) = highlight_lines.highlight_line(code, syntax_set) else {
-        return Vec::from([Span::raw(code.to_owned())]);
+    let mut visual_column = 0;
+    match highlight_lines.highlight_line(code, syntax_set) {
+        Ok(ranges) => ranges
+            .iter()
+            .map(|(style, text)| {
+                let color = Color::Rgb(style.foreground.r, style.foreground.g, style.foreground.b);
+                let span = Span::raw(text.to_string()).fg(color);
+                expand_tabs_for_display(span, &mut visual_column)
+            })
+            .collect(),
+        Err(_) => Vec::from([expand_tabs_for_display(
+            Span::raw(code.to_owned()),
+            &mut visual_column,
+        )]),
+    }
+}
+
+fn expand_tabs_for_display(mut span: Span<'static>, visual_column: &mut usize) -> Span<'static> {
+    const TAB_WIDTH: usize = 4;
+
+    if !span.content.contains('\t') {
+        *visual_column += span.content.width();
+        return span;
+    }
+
+    let expanded = {
+        let content = span.content.as_ref();
+        let mut expanded = String::with_capacity(content.len());
+        let mut segment_start = 0;
+
+        for (index, character) in content.char_indices() {
+            if character != '\t' {
+                continue;
+            }
+
+            let segment = &content[segment_start..index];
+            expanded.push_str(segment);
+            *visual_column += segment.width();
+
+            let spaces = TAB_WIDTH - *visual_column % TAB_WIDTH;
+            expanded.extend(repeat_n(' ', spaces));
+            *visual_column += spaces;
+            segment_start = index + character.len_utf8();
+        }
+
+        let remaining = &content[segment_start..];
+        expanded.push_str(remaining);
+        *visual_column += remaining.width();
+        expanded
     };
 
-    ranges
-        .iter()
-        .map(|(style, text)| {
-            let color = Color::Rgb(style.foreground.r, style.foreground.g, style.foreground.b);
-            Span::raw(text.to_string()).fg(color)
-        })
-        .collect::<Vec<_>>()
+    span.content = expanded.into();
+    span
 }
 
 pub fn num_digits(n: u32) -> u32 {
@@ -1176,7 +1218,29 @@ pub fn load_syntax_set() -> SyntaxSet {
 
 #[cfg(test)]
 mod tests {
-    use super::format_with_dot_thousands;
+    use ratatui::text::Span;
+
+    use super::{expand_tabs_for_display, format_with_dot_thousands};
+
+    #[test]
+    fn expands_tabs_to_four_column_stops_across_spans() {
+        let mut visual_column = 0;
+        let contents = [
+            Span::raw("\troot "),
+            Span::raw("a\tb"),
+            Span::raw("\t\tdeep"),
+        ]
+        .into_iter()
+        .map(|span| expand_tabs_for_display(span, &mut visual_column))
+        .map(|span| span.content.into_owned())
+        .collect::<Vec<_>>();
+
+        assert_eq!(
+            contents,
+            ["    root ", "a  b", "       deep"],
+            "tabs advance to the next four-column stop across syntax spans"
+        );
+    }
 
     #[test]
     fn formats_numbers_with_dot_thousands_separators() {


### PR DESCRIPTION
Expand hard tabs to four-column display stops while preserving raw diff text.