### PR TITLE
More Lite navigation hotkeys

### DIFF
--- a/apps/lite/ui/src/hotkeys.ts
+++ b/apps/lite/ui/src/hotkeys.ts
@@ -117,15 +117,6 @@ export const workspaceHotkeys = {
 			name: "Update workspace (rebases all stacks)",
 		},
 	},
-	focusDetails: {
-		hotkey: "0",
-	},
-	focusUncommittedFiles: {
-		hotkey: "1",
-	},
-	focusOutline: {
-		hotkey: "2",
-	},
 	focusHorizontalSelectionScopeLeft: {
 		hotkey: "Mod+Alt+ArrowLeft",
 	},

--- a/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.tsx
@@ -30,11 +30,16 @@ import {
 	type Operand,
 } from "#ui/operands.ts";
 import { projectSlice } from "#ui/projects/state.ts";
-import { useNavigationIndexHotkeys, type SelectionScope } from "#ui/selection-scopes.ts";
+import {
+	autofocusSelectionScope,
+	useNavigationIndexHotkeys,
+	type SelectionScope,
+} from "#ui/selection-scopes.ts";
 import { useAppDispatch, useAppSelector } from "#ui/store.ts";
 import { formatRelativeTime } from "#ui/time.ts";
 import type { Commit, ListedBranch } from "@gitbutler/but-sdk";
 import { Toolbar } from "@base-ui/react";
+import { useMergedRefs } from "@base-ui/utils/useMergedRefs";
 import { useQuery } from "@tanstack/react-query";
 import {
 	type ComponentProps,
@@ -412,7 +417,9 @@ export const BranchesList: FC<
 					onFocus={() =>
 						dispatch(projectSlice.actions.setDetailsSelectionScope({ projectId, scope: "outline" }))
 					}
-					ref={hotkeysRef}
+					ref={useMergedRefs(hotkeysRef, (el) => {
+						if (el) autofocusSelectionScope(el);
+					})}
 				>
 					{stacks.map((stack) => (
 						// oxlint-disable-next-line jsx-a11y/prefer-tag-over-role -- A stack is an ARIA group of tree items.

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -93,7 +93,11 @@ import { Group, Panel, Separator, useDefaultLayout } from "react-resizable-panel
 import styles from "./Details.module.css";
 import { diffHotkeys, pullRequestHotkeys, workspaceHotkeys } from "#ui/hotkeys.ts";
 import { useHotkey, useHotkeys } from "@tanstack/react-hotkeys";
-import { type SelectionScope, useNavigationIndexHotkeys } from "#ui/selection-scopes.ts";
+import {
+	autofocusSelectionScope,
+	type SelectionScope,
+	useNavigationIndexHotkeys,
+} from "#ui/selection-scopes.ts";
 import { FilesTree } from "#ui/routes/project/$id/workspace/FilesTree.tsx";
 import { TopLeftControls } from "#ui/routes/project/$id/workspace/TopLeftControls.tsx";
 import {
@@ -1227,7 +1231,9 @@ const Diff: FC<{
 						// oxlint-disable-next-line jsx_a11y/no-noninteractive-tabindex -- Revisit this when we add hunk/line selection.
 						tabIndex={0}
 						className={styles.diffContentsContainer}
-						ref={useMergedRefs(selectionScopeRef, diffContentsEl)}
+						ref={useMergedRefs(selectionScopeRef, diffContentsEl, (el) => {
+							if (el) autofocusSelectionScope(el);
+						})}
 					>
 						<DiffContents
 							localAnnotationFormId={localAnnotationFormId}
@@ -1344,6 +1350,9 @@ const PullRequestForm: FC<{
 					render={<FieldControlStyles />}
 					className="text-15 text-semibold"
 					data-selection-scope={"pr" satisfies SelectionScope}
+					ref={(el) => {
+						if (el) autofocusSelectionScope(el);
+					}}
 					name="title"
 					onChange={(evt) => setLocalDocument({ ...localDocument, title: evt.currentTarget.value })}
 					placeholder="Title"
@@ -1726,6 +1735,53 @@ const BranchDetails: FC<{
 	const filesVisible = canShowFiles && filesVisibleState;
 	const [branchTab, setBranchTab] = useState<BranchTab>("diff");
 
+	const ref = useRef<HTMLDivElement>(null);
+
+	useHotkeys([
+		{
+			hotkey: "[",
+			callback: () => {
+				switch (branchTab) {
+					case "diff": {
+						setBranchTab("pr");
+						break;
+					}
+					case "pr": {
+						setBranchTab("diff");
+						break;
+					}
+					default:
+						branchTab satisfies never;
+				}
+			},
+			options: {
+				conflictBehavior: "allow",
+				target: ref,
+			},
+		},
+		{
+			hotkey: "]",
+			callback: () => {
+				switch (branchTab) {
+					case "diff": {
+						setBranchTab("pr");
+						break;
+					}
+					case "pr": {
+						setBranchTab("diff");
+						break;
+					}
+					default:
+						branchTab satisfies never;
+				}
+			},
+			options: {
+				conflictBehavior: "allow",
+				target: ref,
+			},
+		},
+	]);
+
 	const selectFile = (selection: string) => {
 		dispatch(projectSlice.actions.selectFiles({ projectId, selection }));
 	};
@@ -1744,7 +1800,7 @@ const BranchDetails: FC<{
 	const branchName = branchDetailsParams(decodeBytes(selection.branchRef)).branchName;
 
 	return (
-		<div className={styles.container}>
+		<div className={styles.container} ref={ref}>
 			<div className={styles.headerWrap}>
 				<div className={styles.titleRow}>
 					{detailsFullWindow && <TopLeftControls />}

--- a/apps/lite/ui/src/routes/project/$id/workspace/Outline.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Outline.tsx
@@ -24,7 +24,7 @@ import type { BottomUpdate, ProjectForFrontend } from "@gitbutler/but-sdk";
 import { useIsFetching, useIsMutating, useQuery } from "@tanstack/react-query";
 import { useHotkeys } from "@tanstack/react-hotkeys";
 import { Match } from "effect";
-import { type ComponentProps, type FC, useRef, useState } from "react";
+import { type FC, useRef, useState } from "react";
 import { ToggleGroupStyles, ToggleStyles } from "#ui/components/ToggleGroup.tsx";
 import { OutlineTree } from "#ui/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx";
 import { BranchesList } from "#ui/routes/project/$id/workspace/BranchesList.tsx";
@@ -89,23 +89,20 @@ const FetchFromRemotesButton: FC<{
 	);
 };
 
-export const Outline: FC<
-	{
-		absorptionTargetCommitIds: ReadonlySet<string>;
-		branchesOutline: BranchesOutline;
-		navigationIndex: NavigationIndex<Operand>;
-		uncommittedFilesNavigationIndex: NavigationIndex<string>;
-		project: ProjectForFrontend;
-		projectId: string;
-	} & ComponentProps<"div">
-> = ({
+export const Outline: FC<{
+	absorptionTargetCommitIds: ReadonlySet<string>;
+	branchesOutline: BranchesOutline;
+	navigationIndex: NavigationIndex<Operand>;
+	uncommittedFilesNavigationIndex: NavigationIndex<string>;
+	project: ProjectForFrontend;
+	projectId: string;
+}> = ({
 	absorptionTargetCommitIds,
 	branchesOutline,
 	navigationIndex,
 	uncommittedFilesNavigationIndex,
 	project,
 	projectId,
-	...restProps
 }) => {
 	const dispatch = useAppDispatch();
 	const toastManager = Toast.useToastManager();
@@ -288,7 +285,7 @@ export const Outline: FC<
 	]);
 
 	return (
-		<div {...restProps} className={classes(restProps.className, styles.container)} ref={ref}>
+		<div className={styles.container} ref={ref}>
 			<div className={styles.top}>
 				<header className={styles.workspaceControls}>
 					<TopLeftControls />

--- a/apps/lite/ui/src/routes/project/$id/workspace/Outline.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Outline.tsx
@@ -24,7 +24,7 @@ import type { BottomUpdate, ProjectForFrontend } from "@gitbutler/but-sdk";
 import { useIsFetching, useIsMutating, useQuery } from "@tanstack/react-query";
 import { useHotkeys } from "@tanstack/react-hotkeys";
 import { Match } from "effect";
-import { type ComponentProps, type FC, useState } from "react";
+import { type ComponentProps, type FC, useRef, useState } from "react";
 import { ToggleGroupStyles, ToggleStyles } from "#ui/components/ToggleGroup.tsx";
 import { OutlineTree } from "#ui/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx";
 import { BranchesList } from "#ui/routes/project/$id/workspace/BranchesList.tsx";
@@ -204,6 +204,8 @@ export const Outline: FC<
 
 	const canOpenSettings = isDefaultMode;
 
+	const ref = useRef<HTMLDivElement>(null);
+
 	useHotkeys([
 		{
 			hotkey: workspaceHotkeys.applyBranch.hotkey,
@@ -241,10 +243,52 @@ export const Outline: FC<
 				meta: workspaceHotkeys.updateWorkspace.meta,
 			},
 		},
+		{
+			hotkey: "[",
+			callback: () => {
+				switch (outlineTab) {
+					case "workspace": {
+						dispatch(projectSlice.actions.setOutlineTab({ projectId, tab: "branches" }));
+						break;
+					}
+					case "branches": {
+						dispatch(projectSlice.actions.setOutlineTab({ projectId, tab: "workspace" }));
+						break;
+					}
+					default:
+						outlineTab satisfies never;
+				}
+			},
+			options: {
+				conflictBehavior: "allow",
+				target: ref,
+			},
+		},
+		{
+			hotkey: "]",
+			callback: () => {
+				switch (outlineTab) {
+					case "workspace": {
+						dispatch(projectSlice.actions.setOutlineTab({ projectId, tab: "branches" }));
+						break;
+					}
+					case "branches": {
+						dispatch(projectSlice.actions.setOutlineTab({ projectId, tab: "workspace" }));
+						break;
+					}
+					default:
+						outlineTab satisfies never;
+				}
+			},
+			options: {
+				conflictBehavior: "allow",
+				target: ref,
+			},
+		},
 	]);
 
 	return (
-		<div {...restProps} className={classes(restProps.className, styles.container)}>
+		<div {...restProps} className={classes(restProps.className, styles.container)} ref={ref}>
 			<div className={styles.top}>
 				<header className={styles.workspaceControls}>
 					<TopLeftControls />

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
@@ -69,7 +69,7 @@ import {
 } from "#ui/segment.ts";
 import { checkedRange, navigationIndexRange } from "#ui/checking.ts";
 import { TooltipPopup } from "#ui/components/Tooltip.tsx";
-import type { SelectionScope } from "#ui/selection-scopes.ts";
+import { autofocusSelectionScope, type SelectionScope } from "#ui/selection-scopes.ts";
 import { FilesTree } from "#ui/routes/project/$id/workspace/FilesTree.tsx";
 import {
 	CommitForm,
@@ -284,10 +284,7 @@ const UncommittedChanges: FC<{
 					}
 					projectId={projectId}
 					ref={(el) => {
-						// Don't steal focus if this component is mounted later on.
-						if (document.activeElement !== document.body) return;
-
-						el?.focus({ focusVisible: false });
+						if (el) autofocusSelectionScope(el);
 					}}
 					selection={fileSelection}
 				/>

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
@@ -19,7 +19,7 @@ import { globalHotkeys, workspaceHotkeys } from "#ui/hotkeys.ts";
 import { writeLastOpenedProject } from "#ui/project.ts";
 import { useAppDispatch, useAppSelector } from "#ui/store.ts";
 import type { ProjectForFrontend, RefInfo, WorktreeChanges } from "@gitbutler/but-sdk";
-import { useHotkey, useHotkeys } from "@tanstack/react-hotkeys";
+import { useHotkey, useHotkeys, type UseHotkeyDefinition } from "@tanstack/react-hotkeys";
 import {
 	QueryErrorResetBoundary,
 	useQueries,
@@ -81,6 +81,9 @@ const useWorkspaceHotkeys = (projectId: string) => {
 		projectSlice.selectors.selectDetailsSelectionScope(state, projectId),
 	);
 	const filesVisible = canShowFiles && filesVisibleState;
+	const outlineTab = useAppSelector((state) =>
+		projectSlice.selectors.selectOutlineTab(state, projectId),
+	);
 
 	const { isPending: isRestoreSnapshotPending, mutate: restoreSnapshot } = useRestoreSnapshot({
 		projectId,
@@ -133,20 +136,35 @@ const useWorkspaceHotkeys = (projectId: string) => {
 			hotkey: "0",
 			callback: () => focusSelectionScope("details"),
 		},
-		{
-			hotkey: "1",
-			callback: () => focusSelectionScope("uncommitted-files"),
-			options: {
-				enabled: outlineVisible,
-			},
-		},
-		{
-			hotkey: "2",
-			callback: () => focusSelectionScope("outline"),
-			options: {
-				enabled: outlineVisible,
-			},
-		},
+		...Match.value(outlineTab).pipe(
+			Match.withReturnType<Array<UseHotkeyDefinition>>(),
+			Match.when("workspace", () => [
+				{
+					hotkey: "1",
+					callback: () => focusSelectionScope("uncommitted-files"),
+					options: {
+						enabled: outlineVisible,
+					},
+				},
+				{
+					hotkey: "2",
+					callback: () => focusSelectionScope("outline"),
+					options: {
+						enabled: outlineVisible,
+					},
+				},
+			]),
+			Match.when("branches", () => [
+				{
+					hotkey: "1",
+					callback: () => focusSelectionScope("outline"),
+					options: {
+						enabled: outlineVisible,
+					},
+				},
+			]),
+			Match.exhaustive,
+		),
 		{
 			hotkey: workspaceHotkeys.focusHorizontalSelectionScopeLeft.hotkey,
 			callback: () => {

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
@@ -130,18 +130,18 @@ const useWorkspaceHotkeys = (projectId: string) => {
 			},
 		},
 		{
-			hotkey: workspaceHotkeys.focusDetails.hotkey,
+			hotkey: "0",
 			callback: () => focusSelectionScope("details"),
 		},
 		{
-			hotkey: workspaceHotkeys.focusUncommittedFiles.hotkey,
+			hotkey: "1",
 			callback: () => focusSelectionScope("uncommitted-files"),
 			options: {
 				enabled: outlineVisible,
 			},
 		},
 		{
-			hotkey: workspaceHotkeys.focusOutline.hotkey,
+			hotkey: "2",
 			callback: () => focusSelectionScope("outline"),
 			options: {
 				enabled: outlineVisible,

--- a/apps/lite/ui/src/selection-scopes.ts
+++ b/apps/lite/ui/src/selection-scopes.ts
@@ -16,7 +16,7 @@ const allSelectionScopes: Set<string> = new Set([
 	"pr",
 ] satisfies Array<SelectionScope>);
 
-// Supports arbitarily nested scopes. Must share that ancestral relationship in the DOM. Tries from
+// Supports arbitrarily nested scopes. Must share that ancestral relationship in the DOM. Tries from
 // left to right.
 const selectionScopeChildren: Partial<Record<SelectionScope, Set<SelectionScope>>> = {
 	details: new Set(["diff", "pr", "files"]),

--- a/apps/lite/ui/src/selection-scopes.ts
+++ b/apps/lite/ui/src/selection-scopes.ts
@@ -98,6 +98,13 @@ export const focusVerticalSelectionScope = (offset: -1 | 1) => {
 	if (nextSelectionScope !== undefined) focusSelectionScope(nextSelectionScope);
 };
 
+export const autofocusSelectionScope = (el: HTMLElement) => {
+	// Don't steal focus if this component is mounted later on.
+	if (document.activeElement !== document.body) return;
+
+	el.focus({ focusVisible: false });
+};
+
 export const useNavigationIndexHotkeys = <T>({
 	navigationIndex,
 	projectId,


### PR DESCRIPTION
Adds `[`/`]`, and tweaks the branches tab's one left pane target to use `1` instead of `2`.