### PR TITLE
Snappy annotations

### DIFF
--- a/apps/lite/ui/src/annotation.ts
+++ b/apps/lite/ui/src/annotation.ts
@@ -3,7 +3,7 @@ import type {
 	CommentCreateParams,
 	CommentUpdateParams,
 } from "#electron/ipc.ts";
-import type { QueryKey } from "#ui/api/queries.ts";
+import { commentsQueryOptions } from "#ui/api/queries.ts";
 import { decodeBytes } from "#ui/api/bytes.ts";
 import { errorMessageForToast } from "#ui/errors.ts";
 import type { FileParent } from "#ui/operands.ts";
@@ -64,10 +64,34 @@ export const useCommentCreate = () => {
 	const toastManager = Toast.useToastManager();
 
 	return useMutation({
-		mutationFn: (params: CommentCreateParams) => window.lite.commentCreate(params),
+		mutationFn: (params: CommentCreateParams & { comment: { id: string } }) =>
+			window.lite.commentCreate(params),
+		onMutate: async (input, ctx) => {
+			await ctx.client.cancelQueries({ queryKey: commentsQueryOptions(input.projectId).queryKey });
+
+			const prev = ctx.client.getQueryData(commentsQueryOptions(input.projectId).queryKey);
+
+			const now = Date.now();
+			const appended: DiffComment = {
+				...input.comment,
+				lineContent: "",
+				createdAtMs: now,
+				updatedAtMs: now,
+				context: null,
+			};
+
+			ctx.client.setQueryData(
+				commentsQueryOptions(input.projectId).queryKey,
+				(comments) => comments?.concat(appended) ?? [appended],
+			);
+
+			return prev;
+		},
 		onSettled: (_comment, _err, input, _result, ctx) =>
-			ctx.client.invalidateQueries({ queryKey: ["comments" satisfies QueryKey, input.projectId] }),
-		onError: (error) => {
+			ctx.client.invalidateQueries({ queryKey: commentsQueryOptions(input.projectId).queryKey }),
+		onError: (error, input, prev, ctx) => {
+			if (prev) ctx.client.setQueryData(commentsQueryOptions(input.projectId).queryKey, prev);
+
 			// oxlint-disable-next-line no-console
 			console.error(error);
 
@@ -87,7 +111,7 @@ export const useCommentUpdate = () => {
 	return useMutation({
 		mutationFn: (params: CommentUpdateParams) => window.lite.commentUpdate(params),
 		onSettled: (_comment, _err, input, _result, ctx) =>
-			ctx.client.invalidateQueries({ queryKey: ["comments" satisfies QueryKey, input.projectId] }),
+			ctx.client.invalidateQueries({ queryKey: commentsQueryOptions(input.projectId).queryKey }),
 		onError: (error) => {
 			// oxlint-disable-next-line no-console
 			console.error(error);
@@ -107,9 +131,22 @@ export const useCommentArchive = () => {
 
 	return useMutation({
 		mutationFn: (params: CommentArchiveParams) => window.lite.commentArchive(params),
+		onMutate: async (input, ctx) => {
+			await ctx.client.cancelQueries({ queryKey: commentsQueryOptions(input.projectId).queryKey });
+
+			const prev = ctx.client.getQueryData(commentsQueryOptions(input.projectId).queryKey);
+
+			ctx.client.setQueryData(commentsQueryOptions(input.projectId).queryKey, (comments) =>
+				comments?.filter((comment) => comment.id !== input.id),
+			);
+
+			return prev;
+		},
 		onSettled: (_comment, _err, input, _result, ctx) =>
-			ctx.client.invalidateQueries({ queryKey: ["comments" satisfies QueryKey, input.projectId] }),
-		onError: (error) => {
+			ctx.client.invalidateQueries({ queryKey: commentsQueryOptions(input.projectId).queryKey }),
+		onError: (error, input, prev, ctx) => {
+			if (prev) ctx.client.setQueryData(commentsQueryOptions(input.projectId).queryKey, prev);
+
 			// oxlint-disable-next-line no-console
 			console.error(error);
 

--- a/apps/lite/ui/src/annotation.ts
+++ b/apps/lite/ui/src/annotation.ts
@@ -10,7 +10,7 @@ import type { FileParent } from "#ui/operands.ts";
 import { Toast } from "@base-ui/react";
 import type { DiffComment, DiffSide } from "@gitbutler/but-sdk";
 import type { AnnotationSide } from "@pierre/diffs";
-import { type QueryClient, useMutation } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 
 /**
  * A backend comment anchored to a diff line, shaped for the diff view. Comments are read by
@@ -26,22 +26,6 @@ export type LocalAnnotation = {
 
 export type LocalAnnotationsByPath = Map<string, Array<LocalAnnotation>>;
 
-/**
- * The backend anchor scope of a file parent: `null` for the uncommitted worktree diff, the
- * commit's change id for a commit diff, and `undefined` when comments are not supported
- * (branch diffs have no stable anchor scope).
- */
-export const commentScopeChangeId = (fileParent: FileParent): string | null | undefined => {
-	switch (fileParent._tag) {
-		case "UncommittedChanges":
-			return null;
-		case "Commit":
-			return fileParent.changeId;
-		case "Branch":
-			return undefined;
-	}
-};
-
 export const annotationSideToDiffSide = (side: AnnotationSide): DiffSide =>
 	side === "deletions" ? "old" : "new";
 
@@ -51,11 +35,17 @@ const diffSideToAnnotationSide = (side: DiffSide): AnnotationSide =>
 /** Group the comments belonging to the given scope by path, shaped for the diff view. */
 export const annotationsByPathForScope = (
 	comments: Array<DiffComment>,
-	commitChangeId: string | null,
+	fileParent: FileParent,
 ): LocalAnnotationsByPath => {
 	const byPath: LocalAnnotationsByPath = new Map();
+
+	// We don't currently support annotations on branches.
+	if (fileParent._tag === "Branch") return byPath;
+
+	const commitChangeId = fileParent._tag === "Commit" ? fileParent.changeId : null;
 	for (const comment of comments) {
 		if (comment.commitChangeId !== commitChangeId) continue;
+
 		const annotations = byPath.get(comment.path) ?? [];
 		annotations.push({
 			id: comment.id,
@@ -66,50 +56,70 @@ export const annotationsByPathForScope = (
 		});
 		byPath.set(comment.path, annotations);
 	}
+
 	return byPath;
 };
 
-const invalidateComments = (client: QueryClient, projectId: string) =>
-	void client.invalidateQueries({ queryKey: ["comments" satisfies QueryKey, projectId] });
-
-const useCommentErrorToast = (title: string) => {
-	const toastManager = Toast.useToastManager();
-	return (error: unknown) => {
-		// oxlint-disable-next-line no-console
-		console.error(error);
-		toastManager.add({
-			type: "error",
-			title,
-			description: errorMessageForToast(error),
-			priority: "high",
-		});
-	};
-};
-
 export const useCommentCreate = () => {
-	const onError = useCommentErrorToast("Failed to create comment");
+	const toastManager = Toast.useToastManager();
+
 	return useMutation({
 		mutationFn: (params: CommentCreateParams) => window.lite.commentCreate(params),
-		onSuccess: (_comment, input, _result, ctx) => invalidateComments(ctx.client, input.projectId),
-		onError,
+		onSettled: (_comment, _err, input, _result, ctx) =>
+			ctx.client.invalidateQueries({ queryKey: ["comments" satisfies QueryKey, input.projectId] }),
+		onError: (error) => {
+			// oxlint-disable-next-line no-console
+			console.error(error);
+
+			toastManager.add({
+				type: "error",
+				title: "Failed to create comment",
+				description: errorMessageForToast(error),
+				priority: "high",
+			});
+		},
 	});
 };
 
 export const useCommentUpdate = () => {
-	const onError = useCommentErrorToast("Failed to save comment");
+	const toastManager = Toast.useToastManager();
+
 	return useMutation({
 		mutationFn: (params: CommentUpdateParams) => window.lite.commentUpdate(params),
-		onSuccess: (_data, input, _result, ctx) => invalidateComments(ctx.client, input.projectId),
-		onError,
+		onSettled: (_comment, _err, input, _result, ctx) =>
+			ctx.client.invalidateQueries({ queryKey: ["comments" satisfies QueryKey, input.projectId] }),
+		onError: (error) => {
+			// oxlint-disable-next-line no-console
+			console.error(error);
+
+			toastManager.add({
+				type: "error",
+				title: "Failed to update comment",
+				description: errorMessageForToast(error),
+				priority: "high",
+			});
+		},
 	});
 };
 
 export const useCommentArchive = () => {
-	const onError = useCommentErrorToast("Failed to archive comment");
+	const toastManager = Toast.useToastManager();
+
 	return useMutation({
 		mutationFn: (params: CommentArchiveParams) => window.lite.commentArchive(params),
-		onSuccess: (_archived, input, _result, ctx) => invalidateComments(ctx.client, input.projectId),
-		onError,
+		onSettled: (_comment, _err, input, _result, ctx) =>
+			ctx.client.invalidateQueries({ queryKey: ["comments" satisfies QueryKey, input.projectId] }),
+		onError: (error) => {
+			// oxlint-disable-next-line no-console
+			console.error(error);
+
+			toastManager.add({
+				type: "error",
+				title: "Failed to archive comment",
+				description: errorMessageForToast(error),
+				priority: "high",
+			});
+		},
 	});
 };
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -658,23 +658,20 @@ const DiffContents: FC<{
 					const file = fileByItemId.get(item.id);
 					if (!file) return;
 
-					createComment(
-						{
-							projectId,
-							comment: {
-								path: file.operand.path,
-								commitChangeId: fileParent._tag === "Commit" ? fileParent.changeId : null,
-								side: annotationSideToDiffSide(line.side),
-								lineNumber: line.lineNumber,
-								payload: "",
-							},
+					const id = crypto.randomUUID();
+					newFocusableAnnotationIdRef.current = id;
+
+					createComment({
+						projectId,
+						comment: {
+							id,
+							path: file.operand.path,
+							commitChangeId: fileParent._tag === "Commit" ? fileParent.changeId : null,
+							side: annotationSideToDiffSide(line.side),
+							lineNumber: line.lineNumber,
+							payload: "",
 						},
-						{
-							onSuccess: (comment) => {
-								newFocusableAnnotationIdRef.current = comment.id;
-							},
-						},
-					);
+					});
 				};
 
 				return (

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -1084,11 +1084,21 @@ const Diff: FC<{
 				: annotationsByPathForScope(comments, scopeChangeId),
 	});
 
-	const diffViewSansAnno = getDiffView({
-		fileParent,
-		changes,
-		treeChangeDiffs,
-	});
+	const diffViewSansAnno = useMemo(
+		() =>
+			getDiffView({
+				fileParent,
+				changes,
+				treeChangeDiffs,
+			}),
+		[
+			fileParent,
+			changes,
+			// oxlint-disable-next-line @tanstack/query/no-unstable-deps -- False positive?: https://github.com/TanStack/query/issues/9718
+			treeChangeDiffs,
+		],
+	);
+
 	const diffView = withAnnotations(diffViewSansAnno, annotationsByPath);
 
 	const selectFileAndNavigateDiff = (selection: string) => {

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -136,7 +136,6 @@ import { AnnotationCard } from "#ui/routes/project/$id/workspace/AnnotationCard.
 import {
 	annotationSideToDiffSide,
 	annotationsByPathForScope,
-	commentScopeChangeId,
 	type LocalAnnotationsByPath,
 	useCommentCreate,
 } from "#ui/annotation.ts";
@@ -370,8 +369,6 @@ const DiffContents: FC<{
 	selectionScopeRef: RefObject<HTMLDivElement | null>;
 	onViewerFileSelection: (path: string) => void;
 	fileParent: FileParent;
-	/** See [commentScopeChangeId]; `undefined` disables annotating. */
-	scopeChangeId: string | null | undefined;
 	projectId: string;
 	diffView: DiffView;
 	annotationsByPath: LocalAnnotationsByPath;
@@ -385,7 +382,6 @@ const DiffContents: FC<{
 	selectionScopeRef,
 	onViewerFileSelection,
 	fileParent,
-	scopeChangeId,
 	projectId,
 	diffView: { items, navigationIndex, hunkByKey, fileByHunkKey, fileByItemId },
 	annotationsByPath,
@@ -650,52 +646,51 @@ const DiffContents: FC<{
 					/>
 				);
 			}}
-			renderGutterUtility={
-				scopeChangeId === undefined
-					? undefined
-					: (getHoveredLine, item) => {
-							const handleClick = () => {
-								const badlyTypedLine = getHoveredLine();
-								if (!badlyTypedLine || !("side" in badlyTypedLine)) return;
-								const line = badlyTypedLine as GetHoveredLineResult<"diff">;
+			renderGutterUtility={(getHoveredLine, item) => {
+				// We don't currently support annotations on branches.
+				if (fileParent._tag === "Branch") return;
 
-								const file = fileByItemId.get(item.id);
-								if (!file) return;
+				const handleClick = () => {
+					const badlyTypedLine = getHoveredLine();
+					if (!badlyTypedLine || !("side" in badlyTypedLine)) return;
+					const line = badlyTypedLine as GetHoveredLineResult<"diff">;
 
-								createComment(
-									{
-										projectId,
-										comment: {
-											path: file.operand.path,
-											commitChangeId: scopeChangeId,
-											side: annotationSideToDiffSide(line.side),
-											lineNumber: line.lineNumber,
-											payload: "",
-										},
-									},
-									{
-										onSuccess: (comment) => {
-											newFocusableAnnotationIdRef.current = comment.id;
-										},
-									},
-								);
-							};
+					const file = fileByItemId.get(item.id);
+					if (!file) return;
 
-							return (
-								<button
-									type="button"
-									onClick={handleClick}
-									aria-label="Annotate"
-									className={classes(
-										getButtonClassName({ variant: "pop", size: "small", iconOnly: true }),
-										styles.annotate,
-									)}
-								>
-									<Icon name="plus" />
-								</button>
-							);
-						}
-			}
+					createComment(
+						{
+							projectId,
+							comment: {
+								path: file.operand.path,
+								commitChangeId: fileParent._tag === "Commit" ? fileParent.changeId : null,
+								side: annotationSideToDiffSide(line.side),
+								lineNumber: line.lineNumber,
+								payload: "",
+							},
+						},
+						{
+							onSuccess: (comment) => {
+								newFocusableAnnotationIdRef.current = comment.id;
+							},
+						},
+					);
+				};
+
+				return (
+					<button
+						type="button"
+						onClick={handleClick}
+						aria-label="Annotate"
+						className={classes(
+							getButtonClassName({ variant: "pop", size: "small", iconOnly: true }),
+							styles.annotate,
+						)}
+					>
+						<Icon name="plus" />
+					</button>
+				);
+			}}
 			renderAnnotation={(anno, item) => {
 				if (!("side" in anno)) throw new Error("Only diff items may be rendered");
 
@@ -1072,16 +1067,10 @@ const Diff: FC<{
 		queries: changes.map((change) => treeChangeDiffsQueryOptions({ projectId, change })),
 		combine: (results) => results.map((result) => result.data),
 	});
-	// A primitive so the select closure below is memoised on it (see lite-render-perf).
-	const scopeChangeId = commentScopeChangeId(fileParent);
-	// Not a suspense query: comments are a garnish on the diff, so a failing listing must
-	// degrade to "no annotations" rather than take down the whole details pane.
+
 	const { data: annotationsByPath = EMPTY_ANNOTATIONS_BY_PATH } = useQuery({
 		...commentsQueryOptions(projectId),
-		select: (comments) =>
-			scopeChangeId === undefined
-				? EMPTY_ANNOTATIONS_BY_PATH
-				: annotationsByPathForScope(comments, scopeChangeId),
+		select: (comments) => annotationsByPathForScope(comments, fileParent),
 	});
 
 	const diffViewSansAnno = useMemo(
@@ -1262,7 +1251,6 @@ const Diff: FC<{
 							localAnnotationFormId={localAnnotationFormId}
 							onViewerFileSelection={onFileSelection}
 							fileParent={fileParent}
-							scopeChangeId={scopeChangeId}
 							projectId={projectId}
 							diffView={diffView}
 							annotationsByPath={annotationsByPath}

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -137,7 +137,6 @@ import {
 	annotationSideToDiffSide,
 	annotationsByPathForScope,
 	commentScopeChangeId,
-	type LocalAnnotation as PersistedLocalAnnotation,
 	type LocalAnnotationsByPath,
 	useCommentCreate,
 } from "#ui/annotation.ts";
@@ -199,7 +198,6 @@ const mkCodeViewItem = (
 	id: string,
 	change: TreeChange,
 	hunks: Array<DiffHunk>,
-	annotations: Array<PersistedLocalAnnotation>,
 ): CodeViewDiffItem<Annotation> => {
 	const combinedFilePatch = synthesizeFilePatch(change, hunks);
 	const version = hash(combinedFilePatch);
@@ -213,25 +211,11 @@ const mkCodeViewItem = (
 	if (!fileDiff) throw new Error("Failed to parse any files in patch");
 	if (restFiles.length > 0) throw new Error("Parsed more than one file in patch");
 
-	const itemAnnotations: Array<DiffLineAnnotation<Annotation>> = annotations.map(
-		({ id, lineNumber, side }) => ({
-			lineNumber,
-			side,
-			metadata: { _tag: "local", id },
-		}),
-	);
-
 	return {
 		type: "diff",
 		id,
-		// Annotations move when their backend anchor drifts, so the version must cover their
-		// positions and identities, not just their count.
-		version: combineHashes(
-			version,
-			hash(itemAnnotations.map((a) => `${a.metadata.id}:${a.side}:${a.lineNumber}`).join()),
-		),
+		version,
 		fileDiff,
-		annotations: itemAnnotations,
 	};
 };
 
@@ -239,7 +223,6 @@ type DiffViewDeps = {
 	fileParent: FileParent;
 	changes: Array<TreeChange>;
 	treeChangeDiffs: Array<UnifiedPatch | null>;
-	annotationsByPath: LocalAnnotationsByPath;
 };
 
 type DiffViewFile = {
@@ -265,12 +248,7 @@ type DiffView = {
 };
 
 /** Build relationships between our SDK data and Pierre's view. */
-const getDiffView = ({
-	fileParent,
-	changes,
-	treeChangeDiffs,
-	annotationsByPath,
-}: DiffViewDeps): DiffView => {
+const getDiffView = ({ fileParent, changes, treeChangeDiffs }: DiffViewDeps): DiffView => {
 	const navigationIndex: NavigationIndex<HunkOperand> = {
 		items: [],
 		indexByKey: new Map(),
@@ -285,7 +263,6 @@ const getDiffView = ({
 
 	for (const [ci, change] of changes.entries()) {
 		const mdiff = treeChangeDiffs[ci];
-		const annotations = annotationsByPath.get(change.path) ?? [];
 
 		const file: FileOperand = {
 			parent: fileParent,
@@ -295,7 +272,6 @@ const getDiffView = ({
 			weakFileIdentityKey(file),
 			change,
 			mdiff && "subject" in mdiff && "hunks" in mdiff.subject ? mdiff.subject.hunks : [],
-			annotations,
 		);
 
 		items.push(item);
@@ -351,6 +327,43 @@ const getDiffView = ({
 		navigationIndex,
 	};
 };
+
+const withAnnotations = (
+	diffView: DiffView,
+	annotationsByPath: LocalAnnotationsByPath,
+): DiffView => ({
+	...diffView,
+	items: diffView.items.map((item) => {
+		const file = diffView.fileByItemId.get(item.id);
+		if (!file) throw new Error("Diff view file not found by ID");
+
+		const persistedAnnotations = annotationsByPath.get(file.operand.path);
+		if (!persistedAnnotations || persistedAnnotations.length === 0) return item;
+
+		const annotations: Array<DiffLineAnnotation<Annotation>> = persistedAnnotations.map(
+			({ id, lineNumber, side }) => ({
+				lineNumber,
+				side,
+				metadata: { _tag: "local", id },
+			}),
+		);
+
+		// Annotations move when their backend anchor drifts, so the version must cover their
+		// positions and identities, not just their count.
+		const annoHash = hash(
+			annotations.map((a) => `${a.metadata.id}:${a.side}:${a.lineNumber}`).join(),
+		);
+
+		const version = item.version;
+		if (version === undefined) throw new Error("Diff view item missing base version");
+
+		return {
+			...item,
+			version: combineHashes(version, annoHash),
+			annotations,
+		};
+	}),
+});
 
 const DiffContents: FC<{
 	localAnnotationFormId: string;
@@ -1071,12 +1084,12 @@ const Diff: FC<{
 				: annotationsByPathForScope(comments, scopeChangeId),
 	});
 
-	const diffView = getDiffView({
+	const diffViewSansAnno = getDiffView({
 		fileParent,
 		changes,
 		treeChangeDiffs,
-		annotationsByPath,
 	});
+	const diffView = withAnnotations(diffViewSansAnno, annotationsByPath);
 
 	const selectFileAndNavigateDiff = (selection: string) => {
 		onFileSelection(selection);

--- a/crates/but-comments/src/lib.rs
+++ b/crates/but-comments/src/lib.rs
@@ -93,6 +93,8 @@ but_schemars::register_sdk_type!(DiffComment);
 #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct NewComment {
+    /// An optional client-supplied ID. An ID will be generated if this is absent.
+    pub id: Option<String>,
     /// The worktree-relative path of the file to anchor the comment to.
     pub path: String,
     /// `None` to anchor to the uncommitted worktree diff, or the change-id of a workspace commit
@@ -159,7 +161,9 @@ pub fn create_comment(
         .map(|line| line.content.clone());
 
     let stored = StoredComment {
-        id: uuid::Uuid::new_v4().to_string(),
+        id: comment
+            .id
+            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string()),
         path: comment.path,
         commit_change_id: comment.commit_change_id,
         side: comment.side,

--- a/crates/but/src/command/comment.rs
+++ b/crates/but/src/command/comment.rs
@@ -339,6 +339,7 @@ pub fn run(
             let comment = comments::comment_create_with_perm(
                 ctx,
                 NewComment {
+                    id: None,
                     path,
                     commit_change_id,
                     side,

--- a/packages/but-sdk/src/generated/graph/index.d.ts
+++ b/packages/but-sdk/src/generated/graph/index.d.ts
@@ -2400,6 +2400,8 @@ export type MoveChangesResult = {
 
 /** Everything needed to create a new comment. See [`DiffComment`] for the field semantics. */
 export type NewComment = {
+  /** An optional client-supplied ID. An ID will be generated if this is absent. */
+  id: string | null;
   /** The worktree-relative path of the file to anchor the comment to. */
   path: string;
   /**

--- a/packages/but-sdk/src/generated/linear/index.d.ts
+++ b/packages/but-sdk/src/generated/linear/index.d.ts
@@ -2400,6 +2400,8 @@ export type MoveChangesResult = {
 
 /** Everything needed to create a new comment. See [`DiffComment`] for the field semantics. */
 export type NewComment = {
+  /** An optional client-supplied ID. An ID will be generated if this is absent. */
+  id: string | null;
   /** The worktree-relative path of the file to anchor the comment to. */
   path: string;
   /**


### PR DESCRIPTION
Feels snappy like the non-SDK version used to.

For review: I tweaked the comment API in d21767d to accept a client-supplied ID in order to enable optimistic creation.