### PR TITLE
Allow landing a whole stack with `but land --whole-stack` and from the GUI

### DIFF
--- a/apps/desktop/src/components/branch/LandBranchModal.svelte
+++ b/apps/desktop/src/components/branch/LandBranchModal.svelte
@@ -15,22 +15,40 @@
 
 	let modalEl = $state<ReturnType<typeof Modal>>();
 	let branchName = $state<string>();
+	let wholeStack = $state(false);
+	let lowerBranches = $state<string[]>([]);
 
 	const targetLabel = $derived(targetBranchName ?? "the target branch");
+	const landedLabel = $derived(
+		wholeStack ? `"${branchName}" and the branches below it` : `"${branchName}"`,
+	);
+	const lowerListLabel = $derived(lowerBranches.length > 0 ? ` (${lowerBranches.join(", ")})` : "");
 
-	export function show(branch: string) {
+	/**
+	 * Passing `stack` lands the whole stack. The intent is carried by the argument itself, not by
+	 * `lowerBranches` being non-empty — segments below can be unnamed (deleted branch refs) and
+	 * still land.
+	 */
+	export function show(branch: string, stack?: { lowerBranches: string[] }) {
 		branchName = branch;
+		wholeStack = stack !== undefined;
+		lowerBranches = stack?.lowerBranches ?? [];
 		modalEl?.show();
 	}
 
 	async function land(): Promise<boolean> {
 		if (!branchName) return false;
 		try {
-			const result = await stackService.landBranch({ projectId, branch: branchName, noFf: false });
+			const result = await stackService.landBranch({
+				projectId,
+				branch: branchName,
+				noFf: false,
+				wholeStack,
+			});
 			if (result.landed.type === "alreadyIntegrated") {
-				chipToasts.success(`"${branchName}" is already integrated into ${targetLabel}`);
+				chipToasts.success(`${landedLabel} is already integrated into ${targetLabel}`);
 			} else {
-				chipToasts.success(`Landed "${branchName}" into ${targetLabel}`);
+				chipToasts.success(`Landed ${landedLabel} into ${targetLabel}`);
 			}
 			if (result.reconcileSkipped) {
 				chipToasts.warning("Other branches were left un-reconciled. Run `but pull` to finish.");
@@ -43,9 +61,14 @@
 	}
 </script>
 
-<Modal bind:this={modalEl} width="small" title="Land branch">
+<Modal bind:this={modalEl} width="small" title={wholeStack ? "Land stack" : "Land branch"}>
 	<p>
-		This lands <strong>{branchName}</strong> directly onto {targetLabel}. It cannot be undone.
+		{#if wholeStack}
+			This lands <strong>{branchName}</strong> and everything below it in its stack{lowerListLabel}
+			directly onto {targetLabel}. It cannot be undone.
+		{:else}
+			This lands <strong>{branchName}</strong> directly onto {targetLabel}. It cannot be undone.
+		{/if}
 	</p>
 	{#snippet controls(close)}
 		<Button kind="outline" type="reset" onclick={close}>Cancel</Button>

--- a/apps/desktop/src/components/views/BranchList.svelte
+++ b/apps/desktop/src/components/views/BranchList.svelte
@@ -218,22 +218,34 @@
 			{/if}
 
 			{#if $landDirectly}
-				{#if lastBranch && !isNewBranch && branchName}
+				{#if (lastBranch || firstBranch) && !isNewBranch && branchName}
+					{@const wholeStack = !lastBranch}
+					{@const lowerBranches = wholeStack
+						? segments
+								.slice(i + 1)
+								.map((s) => s.refName?.displayName)
+								.filter((name): name is string => !!name)
+						: []}
+					{@const blockedByConflicts = wholeStack
+						? segments.slice(i).some((s) => s.commits.some((c) => c.hasConflicts))
+						: isConflicted}
 					<Button
 						size="tag"
 						kind="outline"
 						shrinkable
 						onclick={(e) => {
 							e.stopPropagation();
-							landBranchModal?.show(branchName);
+							landBranchModal?.show(branchName, wholeStack ? { lowerBranches } : undefined);
 						}}
-						disabled={!!controller.exclusiveAction || isConflicted}
-						tooltip={isConflicted
+						disabled={!!controller.exclusiveAction || blockedByConflicts}
+						tooltip={blockedByConflicts
 							? "Resolve conflicts before landing"
-							: "Land directly into the target branch"}
+							: wholeStack
+								? "Land the whole stack directly into the target branch"
+								: "Land directly into the target branch"}
 						icon="branch-merge"
 					>
-						Land
+						{wholeStack ? "Land stack" : "Land"}
 					</Button>
 				{/if}
 			{:else if canPublishPR && !isNewBranch && branchName}

--- a/apps/desktop/src/lib/stacks/stackEndpoints.test.ts
+++ b/apps/desktop/src/lib/stacks/stackEndpoints.test.ts
@@ -440,11 +440,13 @@ describe("buildStackEndpoints", () => {
 				projectId: "project-1",
 				branch: "feature",
 				noFf: false,
+				wholeStack: true,
 			}),
 		).toEqual({
 			projectId: "project-1",
 			branch: "feature",
 			noFf: false,
+			wholeStack: true,
 		});
 
 		// The base-branch query provides a type-level tag, so it must be invalidated

--- a/apps/desktop/src/lib/stacks/stackEndpoints.ts
+++ b/apps/desktop/src/lib/stacks/stackEndpoints.ts
@@ -819,7 +819,7 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 		}),
 		landBranch: build.mutation<
 			BranchLandResult,
-			{ projectId: string; branch: string; noFf: boolean }
+			{ projectId: string; branch: string; noFf: boolean; wholeStack: boolean }
 		>({
 			extraOptions: {
 				command: "branch_land",

--- a/crates/but-api/src/land/mod.rs
+++ b/crates/but-api/src/land/mod.rs
@@ -151,8 +151,10 @@ pub mod json {
 /// Land `branch` directly onto the configured target ref.
 ///
 /// `branch` is the short name of the branch to land (its `refs/heads/<branch>` ref). The branch
-/// must be the bottom segment of its stack and free of conflicted commits, and the workspace must
-/// be a managed GitButler workspace with a configured, non-triangular target remote.
+/// must be the bottom segment of its stack — or, with `whole_stack`, the top segment, which
+/// publishes every segment below it as well — and the landed segments must be free of conflicted
+/// commits. The workspace must be a managed GitButler workspace with a configured, non-triangular
+/// target remote.
 ///
 /// This fetches the target, lands the branch (fast-forward or signed merge commit, retrying when
 /// the target moves underneath us), then reconciles the remaining applied branches onto the moved
@@ -164,6 +166,7 @@ pub fn branch_land(
     ctx: &mut Context,
     branch: String,
     no_ff: bool,
+    whole_stack: bool,
 ) -> anyhow::Result<BranchLandResult> {
     let base_branch = {
         let mut guard = ctx.exclusive_worktree_access();
@@ -217,8 +220,8 @@ pub fn branch_land(
     };
 
     // Safety guards a non-CLI caller must not be able to bypass: never publish lower stack segments
-    // the user did not name, and never publish conflicted commits onto the target.
-    validate_branch_landing(ctx, &branch, &target_display)?;
+    // the user did not opt into, and never publish conflicted commits onto the target.
+    validate_branch_landing(ctx, &branch, &target_display, whole_stack)?;
 
     crate::legacy::virtual_branches::fetch_from_remotes(ctx, Some("land".to_string()))?;
 
@@ -333,14 +336,115 @@ pub fn branch_land(
     })
 }
 
-/// Refuse landing a non-bottom stack segment (it would publish the lower segments the user did not
-/// name) or a branch with conflicted commits (the same guard `but push` applies before sending
-/// commits to a remote). Both are computed from the graph workspace, not stack projections.
+/// Refuse landing a non-bottom stack segment unless `whole_stack` opts into publishing the lower
+/// segments — and even then only for the top segment, so `--whole-stack` always means "the entire
+/// stack lands", never a partial land that strands the segments above. Also refuse conflicted
+/// commits in any segment that would be published (the same guard `but push` applies before
+/// sending commits to a remote). All computed from the graph workspace, not stack projections.
 fn validate_branch_landing(
     ctx: &mut Context,
     branch: &str,
     target_display: &str,
+    whole_stack: bool,
 ) -> anyhow::Result<()> {
+    let Some(scan) = scan_stack(ctx, branch)? else {
+        return Ok(());
+    };
+
+    if whole_stack && scan.has_upper {
+        // Judge "top of the stack" by position, not by names: a segment whose branch ref was
+        // deleted still holds commits that "land the entire stack" would have to include.
+        if let Some(top) = scan.upper_segments.first() {
+            bail!(
+                "Refusing to land `{branch}` with --whole-stack: it is not the top of its stack. \
+                 --whole-stack lands the entire stack; name its top segment `{top}` instead.",
+            );
+        }
+        bail!(
+            "Refusing to land `{branch}` with --whole-stack: it is not the top of its stack — \
+             unnamed segment(s) with commits sit above it (their branch refs no longer exist), so \
+             landing `{branch}` would not land the entire stack.",
+        );
+    }
+    // Key off the commits below, not the segment names: segments whose branch ref was deleted are
+    // unnamed but their commits would be published all the same.
+    let publishes_below = scan.commits_below > 0 || !scan.lower_segments.is_empty();
+    if publishes_below && !whole_stack {
+        if scan.lower_segments.is_empty() {
+            bail!(
+                "Refusing to land `{branch}`: {} commit(s) on unnamed segment(s) below it would \
+                 also be published to {target_display}. Pass --whole-stack to land `{branch}` \
+                 together with everything below it.",
+                scan.commits_below,
+            );
+        }
+        bail!(
+            "Refusing to land `{branch}`: it is stacked on top of {} other segment(s) ({}) \
+             whose commits would also be published to {target_display}. Land the bottom segment \
+             `{}`, or pass --whole-stack to land `{branch}` together with everything below it.",
+            scan.lower_segments.len(),
+            scan.lower_segments.join(", "),
+            scan.lower_segments.last().expect("non-empty checked above"),
+        );
+    }
+
+    if !scan.conflicted.is_empty() {
+        bail!(
+            "Cannot land `{branch}`: it would publish {} conflicted commit{} ({}). \
+             Resolve them first with `but resolve <commit>`.",
+            scan.conflicted.len(),
+            if scan.conflicted.len() == 1 { "" } else { "s" },
+            scan.conflicted.join(", "),
+        );
+    }
+    Ok(())
+}
+
+/// What landing `branch` would publish beyond the branch's own segment, for callers that must
+/// describe a whole-stack land before invoking [`branch_land`]. Empty when `branch` is the bottom
+/// of its stack or not an applied branch.
+#[derive(Debug, Clone, Default)]
+pub struct LowerStack {
+    /// Named segments below `branch`, top to bottom.
+    pub segments: Vec<String>,
+    /// Commits on unnamed segments below `branch` (their branch refs no longer exist) — published
+    /// all the same, so confirmations must disclose them even without a name to show.
+    pub unnamed_commits: usize,
+}
+
+/// The [`LowerStack`] landing `branch` would publish along with it.
+pub fn lower_stack(ctx: &mut Context, branch: &str) -> anyhow::Result<LowerStack> {
+    Ok(scan_stack(ctx, branch)?
+        .map(|scan| LowerStack {
+            segments: scan.lower_segments,
+            unnamed_commits: scan.unnamed_below_commits,
+        })
+        .unwrap_or_default())
+}
+
+/// `branch`'s position in its stack as the landing guards see it.
+struct StackScan {
+    /// Named segments above `branch`, top of the stack first. Non-empty means landing `branch`
+    /// would leave these stranded above a moved target.
+    upper_segments: Vec<String>,
+    /// Whether any segment sits above `branch` in its stack, named or not.
+    has_upper: bool,
+    /// Named segments below `branch`, top to bottom. Non-empty means landing `branch` also
+    /// publishes their commits.
+    lower_segments: Vec<String>,
+    /// Commits in all segments below `branch`, named or not — everything its tip would publish
+    /// beyond its own segment.
+    commits_below: usize,
+    /// The subset of `commits_below` sitting on unnamed segments, for confirmations to disclose.
+    unnamed_below_commits: usize,
+    /// Short hashes of conflicted commits in `branch`'s segment and every segment below it — every
+    /// commit the branch's tip would publish.
+    conflicted: Vec<String>,
+}
+
+/// Locate `branch` in the graph workspace, or `None` when no applied stack has a segment by that
+/// name.
+fn scan_stack(ctx: &mut Context, branch: &str) -> anyhow::Result<Option<StackScan>> {
     let guard = ctx.exclusive_worktree_access();
     let (repo, ws, _db) = ctx.workspace_and_db_with_perm(guard.read_permission())?;
     let head_info = but_workspace::graph_to_ref_info(
@@ -354,6 +458,8 @@ fn validate_branch_landing(
         },
     )?;
 
+    // Segments are ordered top of the stack first, so everything after `pos` is published along
+    // with the branch's tip and everything before it sits on top of the branch.
     for stack in &head_info.stacks {
         let Some(pos) = stack
             .segments
@@ -362,42 +468,34 @@ fn validate_branch_landing(
         else {
             continue;
         };
-
-        // Segments below the named one (oldest last) carry commits the branch's tip would also
-        // publish. Naming a non-bottom segment is refused so lower segments aren't landed silently.
-        let lower_segments: Vec<String> = stack.segments[pos + 1..]
-            .iter()
-            .filter_map(segment_short_name)
-            .collect();
-        if !lower_segments.is_empty() {
-            bail!(
-                "Refusing to land `{branch}`: it is stacked on top of {} other segment(s) ({}) \
-                 whose commits would also be published to {target_display}. Land the bottom segment \
-                 `{}` (or the whole stack) instead.",
-                lower_segments.len(),
-                lower_segments.join(", "),
-                lower_segments.last().expect("non-empty checked above"),
-            );
-        }
-
-        let conflicted: Vec<String> = stack.segments[pos]
-            .commits
-            .iter()
-            .filter(|c| c.has_conflicts)
-            .map(|c| c.id.attach(&repo).shorten_or_id().to_string())
-            .collect();
-        if !conflicted.is_empty() {
-            bail!(
-                "Cannot land `{branch}`: it contains {} conflicted commit{} ({}). \
-                 Resolve them first with `but resolve <commit>`.",
-                conflicted.len(),
-                if conflicted.len() == 1 { "" } else { "s" },
-                conflicted.join(", "),
-            );
-        }
-        return Ok(());
+        return Ok(Some(StackScan {
+            upper_segments: stack.segments[..pos]
+                .iter()
+                .filter_map(segment_short_name)
+                .collect(),
+            has_upper: pos > 0,
+            lower_segments: stack.segments[pos + 1..]
+                .iter()
+                .filter_map(segment_short_name)
+                .collect(),
+            commits_below: stack.segments[pos + 1..]
+                .iter()
+                .map(|s| s.commits.len())
+                .sum(),
+            unnamed_below_commits: stack.segments[pos + 1..]
+                .iter()
+                .filter(|s| segment_short_name(s).is_none())
+                .map(|s| s.commits.len())
+                .sum(),
+            conflicted: stack.segments[pos..]
+                .iter()
+                .flat_map(|s| &s.commits)
+                .filter(|c| c.has_conflicts)
+                .map(|c| c.id.attach(&repo).shorten_or_id().to_string())
+                .collect(),
+        }));
     }
-    Ok(())
+    Ok(None)
 }
 
 /// The short local-branch name of a segment, or `None` if the segment isn't a named local branch.

--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -434,11 +434,14 @@ when possible, otherwise makes a signed merge commit; for a `gb-local` target it
 locally. Then reconciles the remaining branches like `but pull`.
 
 ```bash
-but land <branch-id> --yes            # Land onto the target (--yes required non-interactively)
-but land <branch-id> --no-ff --yes    # Force a merge commit instead of fast-forwarding
+but land <branch-id> --yes                  # Land onto the target (--yes required non-interactively)
+but land <branch-id> --no-ff --yes          # Force a merge commit instead of fast-forwarding
+but land <top-branch> --whole-stack --yes   # Land an entire stack by naming its top segment
 ```
 
 Direct target updates are hard to reverse, so confirmation is required (agents must pass `--yes`).
+A branch stacked on other segments is refused (its tip would also publish them); `--whole-stack`
+is the explicit opt-in, and only the stack's top segment can be named with it.
 
 ## Workspace Maintenance
 

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -346,6 +346,9 @@ pub enum Subcommands {
     /// use `but push` and open a PR (`but pr new`) instead — `but land` deliberately bypasses that
     /// process. On a real remote, a branch protected against direct pushes will reject the land.
     ///
+    /// Landing a segment with other segments below it is refused unless `--whole-stack` is
+    /// passed with the stack's top segment, which lands the entire stack.
+    ///
     /// ## Examples
     ///
     /// Land a branch by its CLI ID:
@@ -359,6 +362,12 @@ pub enum Subcommands {
     /// ```text
     /// but land my-feature-branch --no-ff
     /// ```
+    ///
+    /// Land an entire stack by naming its top segment:
+    ///
+    /// ```text
+    /// but land top-branch --whole-stack
+    /// ```
     #[cfg(feature = "legacy")]
     #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Land {
@@ -370,6 +379,10 @@ pub enum Subcommands {
         /// Always create a merge commit, even when the branch can be fast-forwarded.
         #[clap(long)]
         no_ff: bool,
+        /// Land the entire stack: BRANCH must be the top segment, and the segments below it are
+        /// published to the target along with it.
+        #[clap(long)]
+        whole_stack: bool,
     },
 
     #[cfg(feature = "legacy")]

--- a/crates/but/src/command/legacy/land/messaging.rs
+++ b/crates/but/src/command/legacy/land/messaging.rs
@@ -162,26 +162,50 @@ fn print_undo_caveat(
     Ok(())
 }
 
-/// Confirm a direct target update. The PR-attached warning is always printed; `--yes` only skips
-/// the interactive prompt, never the warning.
+/// Confirm a direct target update. For a whole-stack land, `lower` describes everything else that
+/// will be published — named segments and commits on unnamed segments alike — so the user confirms
+/// the full set. The PR-attached warning is always printed; `--yes` only skips the interactive
+/// prompt, never the warning.
 pub(super) fn confirm_direct_target_update(
     out: &mut OutputChannel,
     branch_name: &str,
-    pr_number: Option<usize>,
+    lower: &but_api::land::LowerStack,
+    attached_prs: &[(String, usize)],
     target_display: &str,
     yes: bool,
 ) -> anyhow::Result<()> {
+    let mut extras = Vec::new();
+    if !lower.segments.is_empty() {
+        extras.push(format!(
+            "the {} segment(s) below it ({})",
+            lower.segments.len(),
+            lower.segments.join(", "),
+        ));
+    }
+    if lower.unnamed_commits > 0 {
+        extras.push(format!(
+            "{} commit(s) on unnamed segments below it",
+            lower.unnamed_commits,
+        ));
+    }
+    let subject = if extras.is_empty() {
+        branch_name.to_string()
+    } else {
+        format!("{branch_name} — together with {} —", extras.join(" and "))
+    };
     let action = format!(
-        "This lands {branch_name} directly onto {target_display} without a pull request — \
+        "This lands {subject} directly onto {target_display} without a pull request — \
          skipping any code review, CI checks, or branch protections your team may rely on."
     );
-    let warning = if let Some(pr_number) = pr_number {
-        format!(
-            "Branch {branch_name} has PR #{pr_number} attached. {action} The pull request will be \
-             left open and its remote branch orphaned."
-        )
-    } else {
+    let warning = if attached_prs.is_empty() {
         action
+    } else {
+        let prs = attached_prs
+            .iter()
+            .map(|(name, pr)| format!("{name} (PR #{pr})"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("{action} This orphans open pull request(s): {prs}.")
     };
 
     if let Some(out) = out.for_human() {
@@ -198,23 +222,51 @@ pub(super) fn confirm_direct_target_update(
         );
     };
 
-    if inout.confirm(
-        format!("Land {branch_name} directly onto {target_display}?"),
-        ConfirmDefault::No,
-    )? == Confirm::No
-    {
+    let question = if extras.is_empty() {
+        format!("Land {branch_name} directly onto {target_display}?")
+    } else {
+        format!("Land {branch_name} and everything below it directly onto {target_display}?")
+    };
+    if inout.confirm(question, ConfirmDefault::No)? == Confirm::No {
         bail!("Land cancelled");
     }
 
     Ok(())
 }
 
-/// The open pull-request number attached to `branch_name`, if any, read from its stack.
-pub(super) fn branch_pr_number(ctx: &Context, branch_name: &str) -> anyhow::Result<Option<usize>> {
-    let pr_number = but_api::legacy::virtual_branches::list_branches(ctx, None)?
-        .into_iter()
-        .find(|branch| branch.name.to_string() == branch_name)
-        .and_then(|branch| branch.stack)
-        .and_then(|stack| stack.pull_requests.get(branch_name).copied());
-    Ok(pr_number)
+/// The open pull-request numbers attached to `branch_name` or any of `lower_segments`. Whole-stack
+/// landing orphans every one of them, so all are surfaced.
+///
+/// Only applied workspace segments can land, so this reads the forge review associations that
+/// `head_info` projects onto the workspace segments (`segment.metadata.review.pull_request` is
+/// overwritten from the forge review cache there, not stored state) instead of computing the
+/// repository-wide branch listing.
+pub(super) fn attached_pr_numbers(
+    ctx: &Context,
+    branch_name: &str,
+    lower_segments: &[String],
+) -> anyhow::Result<Vec<(String, usize)>> {
+    let info = but_api::legacy::workspace::head_info(ctx)?;
+    // A segment shared between stacks is listed once per stack; dedup so the warning doesn't
+    // repeat it.
+    let mut seen = std::collections::HashSet::new();
+    Ok(info
+        .stacks
+        .iter()
+        .flat_map(|stack| &stack.segments)
+        .filter_map(|segment| {
+            let ref_name = &segment.ref_info.as_ref()?.ref_name;
+            if ref_name.category() != Some(gix::refs::Category::LocalBranch) {
+                return None;
+            }
+            let name = ref_name.shorten();
+            let name = std::str::from_utf8(name.as_ref()).ok()?;
+            if name != branch_name && !lower_segments.iter().any(|lower| lower == name) {
+                return None;
+            }
+            let pr = segment.metadata.as_ref()?.review.pull_request?;
+            Some((name.to_string(), pr))
+        })
+        .filter(|(name, _)| seen.insert(name.clone()))
+        .collect())
 }

--- a/crates/but/src/command/legacy/land/mod.rs
+++ b/crates/but/src/command/legacy/land/mod.rs
@@ -21,6 +21,7 @@ pub fn handle(
     branch_id: &str,
     yes: bool,
     no_ff: bool,
+    whole_stack: bool,
 ) -> anyhow::Result<()> {
     // Resolve the branch identifier and read the target configuration. The managed-workspace guard
     // runs here for a friendly message before the prompt; the API enforces it again, along with the
@@ -68,15 +69,31 @@ pub fn handle(
     };
     let target_display = format!("{push_remote_name}/{target_branch_name}");
 
-    let pr_number = messaging::branch_pr_number(ctx, &branch_name)?;
-    messaging::confirm_direct_target_update(out, &branch_name, pr_number, &target_display, yes)?;
+    // With --whole-stack the confirmation must disclose everything that will be published, not
+    // just the branch the user typed — including commits on segments that no longer have a name.
+    // The API re-derives and enforces this; what's gathered here is display.
+    let lower = if whole_stack {
+        but_api::land::lower_stack(ctx, &branch_name)?
+    } else {
+        but_api::land::LowerStack::default()
+    };
+
+    let attached_prs = messaging::attached_pr_numbers(ctx, &branch_name, &lower.segments)?;
+    messaging::confirm_direct_target_update(
+        out,
+        &branch_name,
+        &lower,
+        &attached_prs,
+        &target_display,
+        yes,
+    )?;
 
     {
         let mut progress = out.progress_channel();
         writeln!(progress, "Landing {branch_name} onto {target_display}...")?;
     }
 
-    let result = but_api::land::branch_land(ctx, branch_name.clone(), no_ff)?;
+    let result = but_api::land::branch_land(ctx, branch_name.clone(), no_ff, whole_stack)?;
 
     messaging::report_land_result(
         out,

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -1557,12 +1557,18 @@ async fn match_subcommand(
             Ok(())
         }
         #[cfg(feature = "legacy")]
-        Subcommands::Land { branch, yes, no_ff } => {
+        Subcommands::Land {
+            branch,
+            yes,
+            no_ff,
+            whole_stack,
+        } => {
             let mut ctx = setup::init_ctx(&args, InitCtxOptions::default(), out)?;
             let conflicts_before = command::legacy::conflict_notice::snapshot(&ctx);
-            let result = command::legacy::land::handle(&mut ctx, out, &branch, yes, no_ff)
-                .context("Failed to land branch.")
-                .emit_metrics(metrics_ctx);
+            let result =
+                command::legacy::land::handle(&mut ctx, out, &branch, yes, no_ff, whole_stack)
+                    .context("Failed to land branch.")
+                    .emit_metrics(metrics_ctx);
             if result.is_ok() {
                 command::legacy::conflict_notice::report_newly_conflicted(
                     &ctx,

--- a/crates/but/tests/but/command/land.rs
+++ b/crates/but/tests/but/command/land.rs
@@ -285,6 +285,147 @@ fn land_refuses_non_bottom_stack_segment() -> anyhow::Result<()> {
         stderr.contains("bottom-seg"),
         "the refusal must name the lower segment that would be carried along; got:\n{stderr}"
     );
+    assert!(
+        stderr.contains("--whole-stack"),
+        "the refusal must advertise the explicit whole-stack opt-in; got:\n{stderr}"
+    );
+    assert_eq!(
+        target_before,
+        env.invoke_git("rev-parse gb-local/main"),
+        "a refused land must not move the target"
+    );
+
+    Ok(())
+}
+
+/// `--whole-stack` is the explicit opt-in: naming the top segment lands the entire stack, and the
+/// pre-flight warning names the lower segments being published so `--yes` runs stay honest.
+#[test]
+fn land_whole_stack_lands_top_segment() -> anyhow::Result<()> {
+    let env = Sandbox::open_with_default_settings("merge-gb-local-two-branches");
+    env.but("setup").assert().success();
+
+    env.but("branch new bottom-seg").assert().success();
+    env.file("bottom.txt", "bottom");
+    env.but("commit -b bottom-seg -m 'bottom commit'")
+        .assert()
+        .success();
+    env.but("branch new top-seg --anchor bottom-seg")
+        .assert()
+        .success();
+    env.file("top.txt", "top");
+    env.but("commit -b top-seg -m 'top commit'")
+        .assert()
+        .success();
+    let top_tip = env.invoke_git("rev-parse top-seg");
+
+    let output = env
+        .but("land top-seg --whole-stack --yes")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let stdout = String::from_utf8_lossy(&output);
+    assert!(
+        stdout.contains("bottom-seg"),
+        "the warning must name the lower segment being published along; got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("Landed top-seg onto gb-local/main"),
+        "the land should report success; got:\n{stdout}"
+    );
+
+    assert_eq!(
+        env.invoke_git("rev-parse gb-local/main"),
+        top_tip,
+        "the target should advance to the top segment's tip, publishing the whole stack"
+    );
+    assert_eq!(
+        env.invoke_git("rev-parse main"),
+        top_tip,
+        "the self-remote land should move the local target too"
+    );
+    assert_eq!(
+        status_json(&env)?["stacks"].as_array().unwrap().len(),
+        0,
+        "both landed segments should be removed from the workspace"
+    );
+
+    Ok(())
+}
+
+/// The conflicted-commit guard must cover every segment a whole-stack land would publish: a
+/// conflicted commit in a LOWER segment refuses `--whole-stack` on a clean top segment.
+#[test]
+fn land_whole_stack_refuses_conflicted_lower_segment() -> anyhow::Result<()> {
+    let env = super::util::sandbox_with_conflicted_commit();
+
+    // Stack a clean segment on top of branch A, which carries the conflicted commit.
+    env.but("branch new top-seg --anchor A").assert().success();
+    env.file("top.txt", "top");
+    env.but("commit -b top-seg -m 'clean top commit'")
+        .assert()
+        .success();
+
+    let output = env
+        .but("land top-seg --whole-stack --yes")
+        .assert()
+        .failure()
+        .get_output()
+        .stderr
+        .clone();
+    let stderr = String::from_utf8_lossy(&output);
+    assert!(
+        stderr.contains("conflicted commit"),
+        "a conflicted commit below the named segment must refuse the whole-stack land; got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("but resolve"),
+        "the refusal must point at the resolution command; got:\n{stderr}"
+    );
+
+    Ok(())
+}
+
+/// `--whole-stack` always means "the entire stack lands": naming anything but the top segment is
+/// refused, pointing at the actual top, so a partial land can't strand the segments above.
+#[test]
+fn land_whole_stack_refuses_non_top_segment() -> anyhow::Result<()> {
+    let env = Sandbox::open_with_default_settings("merge-gb-local-two-branches");
+    env.but("setup").assert().success();
+
+    env.but("branch new bottom-seg").assert().success();
+    env.file("bottom.txt", "bottom");
+    env.but("commit -b bottom-seg -m 'bottom commit'")
+        .assert()
+        .success();
+    env.but("branch new top-seg --anchor bottom-seg")
+        .assert()
+        .success();
+    env.file("top.txt", "top");
+    env.but("commit -b top-seg -m 'top commit'")
+        .assert()
+        .success();
+
+    let target_before = env.invoke_git("rev-parse gb-local/main");
+
+    let output = env
+        .but("land bottom-seg --whole-stack --yes")
+        .assert()
+        .failure()
+        .get_output()
+        .stderr
+        .clone();
+    let stderr = String::from_utf8_lossy(&output);
+    assert!(
+        stderr.contains("not the top of its stack"),
+        "--whole-stack on a non-top segment must be refused; got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("top-seg"),
+        "the refusal must point at the actual top segment to name; got:\n{stderr}"
+    );
     assert_eq!(
         target_before,
         env.invoke_git("rev-parse gb-local/main"),

--- a/packages/but-sdk/src/generated/graph/index.d.ts
+++ b/packages/but-sdk/src/generated/graph/index.d.ts
@@ -94,15 +94,17 @@ export declare function branchDiff(projectId: string, branch: string): Promise<T
  * Land `branch` directly onto the configured target ref.
  *
  * `branch` is the short name of the branch to land (its `refs/heads/<branch>` ref). The branch
- * must be the bottom segment of its stack and free of conflicted commits, and the workspace must
- * be a managed GitButler workspace with a configured, non-triangular target remote.
+ * must be the bottom segment of its stack — or, with `whole_stack`, the top segment, which
+ * publishes every segment below it as well — and the landed segments must be free of conflicted
+ * commits. The workspace must be a managed GitButler workspace with a configured, non-triangular
+ * target remote.
  *
  * This fetches the target, lands the branch (fast-forward or signed merge commit, retrying when
  * the target moves underneath us), then reconciles the remaining applied branches onto the moved
  * target. The remote push is not undoable; see [`BranchLandResult::reconcile_skipped`] and the
  * workspace state for what to report.
  */
-export declare function branchLand(projectId: string, branch: string, noFf: boolean): Promise<BranchLandResult>
+export declare function branchLand(projectId: string, branch: string, noFf: boolean, wholeStack: boolean): Promise<BranchLandResult>
 
 /**
  * Lists all local and remote branches of the project, grouped into stacks where

--- a/packages/but-sdk/src/generated/linear/index.d.ts
+++ b/packages/but-sdk/src/generated/linear/index.d.ts
@@ -94,15 +94,17 @@ export declare function branchDiff(projectId: string, branch: string): Promise<T
  * Land `branch` directly onto the configured target ref.
  *
  * `branch` is the short name of the branch to land (its `refs/heads/<branch>` ref). The branch
- * must be the bottom segment of its stack and free of conflicted commits, and the workspace must
- * be a managed GitButler workspace with a configured, non-triangular target remote.
+ * must be the bottom segment of its stack — or, with `whole_stack`, the top segment, which
+ * publishes every segment below it as well — and the landed segments must be free of conflicted
+ * commits. The workspace must be a managed GitButler workspace with a configured, non-triangular
+ * target remote.
  *
  * This fetches the target, lands the branch (fast-forward or signed merge commit, retrying when
  * the target moves underneath us), then reconciles the remaining applied branches onto the moved
  * target. The remote push is not undoable; see [`BranchLandResult::reconcile_skipped`] and the
  * workspace state for what to report.
  */
-export declare function branchLand(projectId: string, branch: string, noFf: boolean): Promise<BranchLandResult>
+export declare function branchLand(projectId: string, branch: string, noFf: boolean, wholeStack: boolean): Promise<BranchLandResult>
 
 /**
  * Lists all local and remote branches of the project, grouped into stacks where


### PR DESCRIPTION
`but land` refuses to land a branch stacked on other segments, since its tip would also publish their commits. This adds the explicit opt-in: naming the stack's top segment with `--whole-stack` (or the new 'Land stack' button on the top branch in the desktop) lands the entire stack.

- Naming any segment other than the top is refused, pointing at the actual top — a whole-stack land can never strand segments above a moved target.
- The refusal guard now keys off the commits below the named segment, not just named segments, so lower segments whose branch ref was deleted are covered too.
- The conflicted-commit guard sweeps every segment that would be published, not only the named one.
- The CLI confirmation and the desktop modal list the extra segments being published; the CLI also names every attached PR that would be orphaned.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #15081
- <kbd>&nbsp;2&nbsp;</kbd> #15079
- <kbd>&nbsp;1&nbsp;</kbd> #15078 👈 
<!-- GitButler Footer Boundary Bottom -->