### PR TITLE
but land: fetch only the target's remote

### DIFF
--- a/crates/but-api/src/land/mod.rs
+++ b/crates/but-api/src/land/mod.rs
@@ -19,8 +19,10 @@
 //! ([`crate::workspace::workspace_integrate_upstream_with_perm`]). This module orchestrates them.
 //!
 //! Unlike the modern single-mutation endpoints, `branch_land` cannot hold one exclusive permission
-//! throughout: it interleaves `fetch_from_remotes` (which re-acquires shared access) with the
-//! retry loop, so it acquires and releases worktree access per step, like the legacy public APIs.
+//! throughout: it interleaves fetching the target remote with the retry loop, so it acquires and
+//! releases worktree access per step, like the legacy public APIs. Only the target's fetch remote
+//! is fetched — landing needs a fresh target tracking ref and nothing else, and an unreachable
+//! unrelated remote must not block the land.
 //! The reconcile step owns its own permission and oplog snapshot. The target move itself is not
 //! captured by the oplog (see the CLI's undo caveats), matching the prior CLI behavior.
 
@@ -33,6 +35,7 @@ use std::path::Path;
 use anyhow::bail;
 use but_api_macros::but_api;
 use but_ctx::Context;
+use gitbutler_git::GitContextExt as _;
 use gix::prelude::ObjectIdExt;
 use tracing::instrument;
 
@@ -223,7 +226,9 @@ pub fn branch_land(
     // the user did not opt into, and never publish conflicted commits onto the target.
     validate_branch_landing(ctx, &branch, &target_display, whole_stack)?;
 
-    crate::legacy::virtual_branches::fetch_from_remotes(ctx, Some("land".to_string()))?;
+    // Fetch only the target's remote: landing needs a fresh target tracking ref and nothing else,
+    // and an unreachable unrelated remote must not block the land.
+    fetch_target_remote(ctx, &fetch_remote_name)?;
 
     // Land the branch, retrying when the target moves underneath us (optimistic concurrency).
     let mut landed: Option<BranchLandKind> = None;
@@ -278,7 +283,7 @@ pub fn branch_land(
             Err(err)
                 if deliver::is_retryable_concurrency_error(&err) && attempt < MAX_PUSH_ATTEMPTS =>
             {
-                crate::legacy::virtual_branches::fetch_from_remotes(ctx, Some("land".to_string()))?;
+                fetch_target_remote(ctx, &fetch_remote_name)?;
             }
             Err(err) if deliver::is_retryable_concurrency_error(&err) => {
                 return Err(err.context(format!(
@@ -303,7 +308,7 @@ pub fn branch_land(
     if let BranchLandKind::Updated { new_target_oid, .. } = &landed
         && !update_target_locally
     {
-        crate::legacy::virtual_branches::fetch_from_remotes(ctx, Some("land".to_string()))?;
+        fetch_target_remote(ctx, &fetch_remote_name)?;
 
         // A concurrent push may have moved the tip *past* our commit, which still counts as the
         // target having advanced to include what we landed — so test reachability, not equality.
@@ -398,6 +403,29 @@ fn validate_branch_landing(
         );
     }
     Ok(())
+}
+
+/// Fetch the target's fetch remote and record the outcome on the project, mirroring the
+/// bookkeeping `fetch_from_remotes` performs so `last_fetched` and auto-fetch scheduling stay
+/// accurate for targeted fetches too.
+fn fetch_target_remote(ctx: &Context, remote: &str) -> anyhow::Result<()> {
+    use anyhow::Context as _;
+
+    let result = ctx.fetch(remote, Some("land".to_string()));
+    let timestamp = std::time::SystemTime::now();
+    let project_data_last_fetched = match &result {
+        Ok(()) => gitbutler_project::FetchResult::Fetched { timestamp },
+        Err(err) => gitbutler_project::FetchResult::Error {
+            timestamp,
+            error: err.to_string(),
+        },
+    };
+    gitbutler_project::update(gitbutler_project::UpdateRequest {
+        project_data_last_fetched: Some(project_data_last_fetched),
+        ..gitbutler_project::UpdateRequest::default_with_id(ctx.legacy_project.id.clone())
+    })
+    .context("failed to update project with last fetched timestamp")?;
+    result
 }
 
 /// What landing `branch` would publish beyond the branch's own segment, for callers that must

--- a/crates/but/tests/but/command/land.rs
+++ b/crates/but/tests/but/command/land.rs
@@ -246,6 +246,32 @@ fn land_no_ff_creates_signed_merge_commit() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// An unreachable remote that is not the target's must not block landing: `but land` fetches only
+/// the target's fetch remote, so a dead unrelated remote (old fork, deleted mirror) is ignored.
+#[test]
+fn land_ignores_unreachable_unrelated_remote() -> anyhow::Result<()> {
+    let env = Sandbox::open_with_default_settings("merge-gb-local-two-branches");
+    env.but("setup").assert().success();
+    env.invoke_git("remote add broken /nonexistent/path/broken.git");
+
+    env.but("branch new first-branch").assert().success();
+    env.file("file1.txt", "content1");
+    env.but("commit -b first-branch -m 'first commit on branch A'")
+        .assert()
+        .success();
+    let branch_tip = env.invoke_git("rev-parse first-branch");
+
+    env.but("land first-branch --yes").assert().success();
+
+    assert_eq!(
+        env.invoke_git("rev-parse gb-local/main"),
+        branch_tip,
+        "the land must succeed and advance the target despite the unreachable unrelated remote"
+    );
+
+    Ok(())
+}
+
 /// Landing a non-bottom segment of a stack would silently publish the lower segments' commits, so
 /// it must be refused before anything is mutated, naming the lower segment.
 #[test]


### PR DESCRIPTION
`but land` called `fetch_from_remotes`, which fetches every configured remote and fails if any of them errors — so an unreachable unrelated remote (old fork, deleted mirror) blocked landing entirely, even with a healthy target remote.

Landing only needs a fresh target tracking ref, so all three fetch call sites (pre-land, target-moved retry, post-land reconcile) now fetch just the target's fetch remote. `but pull` and `but push --dry-run` share the all-remotes helper and will be addressed separately.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #15081
- <kbd>&nbsp;2&nbsp;</kbd> #15079 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #15078
<!-- GitButler Footer Boundary Bottom -->