### PR TITLE
fetch_from_remotes: tolerate failures of unrelated remotes

### DIFF
--- a/crates/but-api/src/legacy/virtual_branches.rs
+++ b/crates/but-api/src/legacy/virtual_branches.rs
@@ -702,6 +702,11 @@ pub fn get_branch_listing_details(
     Ok(branches)
 }
 
+/// Fetch from every configured remote, tolerating failures of remotes the workspace does not
+/// depend on: the call fails only when the target branch's own fetch remote failed (or when no
+/// target is configured to judge by). An unreachable unrelated remote (an old fork, a deleted
+/// mirror) must not block operations that only need the target refreshed, like `pull` or a
+/// dry-run push. Every remote's error is still recorded on the project's fetch status.
 #[but_api]
 #[instrument(err(Debug))]
 pub fn fetch_from_remotes(ctx: &Context, action: Option<String>) -> Result<BaseBranch> {
@@ -712,13 +717,20 @@ pub fn fetch_from_remotes(ctx: &Context, action: Option<String>) -> Result<BaseB
             .map(|name| name.to_str().map(str::to_owned))
             .collect::<std::result::Result<Vec<_>, _>>()?
     };
+    let target_fetch_remote: Option<String> = {
+        let guard = ctx.shared_worktree_access();
+        gitbutler_branch_actions::base::get_base_branch_data(ctx, guard.read_permission())
+            .ok()
+            .map(|base| base.remote_name)
+            .filter(|name| !name.is_empty())
+    };
     let askpass = Some(action.unwrap_or_else(|| "unknown".to_string()));
-    let fetch_errors: Vec<_> = remotes
+    let fetch_errors: Vec<(String, String)> = remotes
         .iter()
         .filter_map(|remote| {
             ctx.fetch(remote, askpass.clone())
                 .err()
-                .map(|err| err.to_string())
+                .map(|err| (remote.clone(), err.to_string()))
         })
         .collect();
 
@@ -728,7 +740,11 @@ pub fn fetch_from_remotes(ctx: &Context, action: Option<String>) -> Result<BaseB
     } else {
         FetchResult::Error {
             timestamp,
-            error: fetch_errors.join("\n"),
+            error: fetch_errors
+                .iter()
+                .map(|(remote, error)| format!("{remote}: {error}"))
+                .collect::<Vec<_>>()
+                .join("\n"),
         }
     };
     let project_meta = ctx.project_meta()?;
@@ -750,7 +766,19 @@ pub fn fetch_from_remotes(ctx: &Context, action: Option<String>) -> Result<BaseB
     .context("failed to update project with last fetched timestamp")?;
 
     if let FetchResult::Error { error, .. } = project_data_last_fetched {
-        return Err(anyhow!(error));
+        // The target counts as failed when its fetch errored — and also when it isn't among the
+        // configured remotes at all (stale target metadata), since it was then never fetched and
+        // cannot vouch for anything.
+        let target_failed = match &target_fetch_remote {
+            Some(target) => {
+                !remotes.iter().any(|remote| remote == target)
+                    || fetch_errors.iter().any(|(remote, _)| remote == target)
+            }
+            None => true,
+        };
+        if target_failed {
+            return Err(anyhow!(error));
+        }
     }
 
     let guard = ctx.shared_worktree_access();

--- a/crates/but/tests/but/command/pull.rs
+++ b/crates/but/tests/but/command/pull.rs
@@ -2,6 +2,20 @@ use snapbox::str;
 
 use crate::utils::{CommandExt, Sandbox};
 
+/// An unreachable remote that is not the target's must not block pulling: `fetch_from_remotes`
+/// only fails when the target's own fetch remote failed, so a dead unrelated remote (old fork,
+/// deleted mirror) is tolerated.
+#[test]
+fn pull_ignores_unreachable_unrelated_remote() -> anyhow::Result<()> {
+    let env = Sandbox::open_with_default_settings("merge-gb-local-two-branches");
+    env.but("setup").assert().success();
+    env.invoke_git("remote add broken /nonexistent/path/broken.git");
+
+    env.but("pull").assert().success();
+
+    Ok(())
+}
+
 #[test]
 fn pull_prunes_integrated_stack_and_keeps_remaining_stack_parent() -> anyhow::Result<()> {
     let env = Sandbox::init_scenario_with_target_and_default_settings(

--- a/crates/but/tests/but/command/push.rs
+++ b/crates/but/tests/but/command/push.rs
@@ -39,6 +39,18 @@ fn configure_other_tracking_remote(env: &Sandbox) -> std::path::PathBuf {
     other
 }
 
+/// An unreachable remote that is not the target's must not block a dry-run push:
+/// `fetch_from_remotes` only fails when the target's own fetch remote failed.
+#[test]
+fn push_dry_run_ignores_unreachable_unrelated_remote() -> anyhow::Result<()> {
+    let env = repo_with_unpushed_branch()?;
+    env.invoke_git("remote add broken /nonexistent/path/broken.git");
+
+    env.but("push --dry-run branchB").assert().success();
+
+    Ok(())
+}
+
 #[test]
 fn push_dry_run_json_reports_remote_and_remote_ref() -> anyhow::Result<()> {
     let env = repo_with_unpushed_branch()?;


### PR DESCRIPTION
The shared fetch helper fetched every configured remote and failed when any of them errored — so a dead unrelated remote (old fork, deleted mirror) blocked `but pull` and `but push --dry-run` entirely, even with a healthy target remote. (Same failure mode as the `but land` fix below in this stack.)

It now fails only when the target branch's own fetch remote failed, or when no target is configured to judge by. Every remote's error is still recorded on the project's fetch status, now prefixed with the remote name so multi-remote failures are attributable.

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #15081 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #15079
- <kbd>&nbsp;1&nbsp;</kbd> #15078
<!-- GitButler Footer Boundary Bottom -->