### PR TITLE
Clean up retired but commit syntax in installed agent rules

### DIFF
--- a/crates/but/src/command/agent/cleanup.rs
+++ b/crates/but/src/command/agent/cleanup.rs
@@ -1,0 +1,343 @@
+//! Best-effort cleanup of retired command syntax inside the managed policy
+//! block that `but agent setup` wrote before the syntax changed.
+//!
+//! The wizard's answers are not persisted, so the full block cannot be
+//! re-rendered for existing installs. Instead, the exact machine-written
+//! bullet that taught the retired syntax is swapped for its current wording,
+//! and only inside the managed markers.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context as _, Result};
+
+use super::{
+    files::{find_line_anchored, managed_block_spans},
+    plan::{AgentTarget, join_components},
+    policy,
+};
+use crate::{theme, utils::detect_agent};
+
+/// The commit fast-path bullet as `but agent setup` wrote it before the
+/// `but commit` arguments changed. The replacement is derived from the
+/// wizard's current wording, so the two can never drift apart.
+const RETIRED_FAST_PATH_BULLET: &str = "- For commit just/only/specific changes on a new branch (selected-change requests), use the two-command fast path from the GitButler skill: `but diff`, then `but commit <branch> -c -m \"message\" --changes <id>,<id>`.";
+
+/// The wizard's current wording for the same rule, prefixed the way
+/// `write_bullets` renders it.
+fn current_bullet() -> String {
+    format!("- {}", policy::FAST_PATH_BULLET)
+}
+
+/// Rewrite the retired commit bullet in every global instruction file
+/// `but agent setup` could have written, and return an agent-facing notice
+/// when something changed. Returns `None` when no agent is driving or nothing
+/// needed rewriting.
+///
+/// Infallible by construction: per-file errors are logged and skipped inside
+/// `cleanup_files`, and a panic anywhere in the sweep is caught here, so this
+/// maintenance pass can never take down the command that triggered it.
+pub(crate) fn retired_policy_syntax_notice() -> Option<String> {
+    detect_agent::detect()?;
+    std::panic::catch_unwind(|| {
+        let changed = cleanup_files(&candidate_files());
+        (!changed.is_empty()).then(|| notice(&changed))
+    })
+    .unwrap_or_else(|_| {
+        tracing::debug!("retired policy syntax cleanup panicked");
+        None
+    })
+}
+
+/// The per-agent global instruction files under `$HOME` the setup wizard
+/// writes. Deliberately NOT the repo-local `AGENTS.md`/`CLAUDE.md` files: those
+/// are usually git-tracked, and this sweep runs right before the invoked
+/// command, so dirtying them here could sweep the edit into an unrelated
+/// `but commit` or block a clean `but pull`. Stale repo files still get fixed
+/// by re-running `but agent setup` in that repository.
+fn candidate_files() -> Vec<PathBuf> {
+    let Some(home) = but_path::home_dir() else {
+        return Vec::new();
+    };
+    AgentTarget::ALL
+        .into_iter()
+        .filter_map(|agent| agent.global_instruction_components())
+        .map(|components| join_components(&home, components))
+        .collect()
+}
+
+/// Instruction files are kilobytes; anything larger is not a file the setup
+/// wizard wrote, so leave it alone rather than rewriting something unexpected.
+const MAX_INSTRUCTION_FILE_BYTES: u64 = 1024 * 1024;
+
+fn cleanup_files(paths: &[PathBuf]) -> Vec<PathBuf> {
+    let mut changed = Vec::new();
+    for path in paths {
+        match cleanup_file(path) {
+            Ok(true) => changed.push(path.clone()),
+            Ok(false) => {}
+            Err(err) => {
+                tracing::debug!(?err, ?path, "failed to rewrite retired policy syntax");
+            }
+        }
+    }
+    changed
+}
+
+fn cleanup_file(path: &Path) -> Result<bool> {
+    // `metadata` follows symlinks, so size, type, and permissions describe the
+    // real file even for a dotfile-managed link.
+    let metadata = match std::fs::metadata(path) {
+        Ok(metadata) => metadata,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(err) => return Err(err.into()),
+    };
+    if !metadata.is_file() || metadata.len() > MAX_INSTRUCTION_FILE_BYTES {
+        return Ok(false);
+    }
+    // Non-UTF-8 content errors here, so binary or otherwise unexpected files
+    // are skipped instead of being rewritten lossily.
+    let content = std::fs::read_to_string(path)?;
+    let Some(updated) = replace_retired_bullet(&content) else {
+        return Ok(false);
+    };
+    // Only now, on the rare rewrite path, resolve symlinks so the write below
+    // edits the link's target; renaming over the path directly would swap the
+    // symlink itself for a regular file.
+    replace_file_contents(&path.canonicalize()?, &content, &updated, &metadata)?;
+    Ok(true)
+}
+
+/// Write via a temp file in the same directory and rename it over `path`, so
+/// a crash or full disk never leaves a truncated instruction file behind. The
+/// rewrite is idempotent, so two concurrent `but` invocations converge on the
+/// same corrected content.
+fn replace_file_contents(
+    path: &Path,
+    read_content: &str,
+    new_content: &str,
+    original: &std::fs::Metadata,
+) -> Result<()> {
+    use std::io::Write as _;
+    let dir = path
+        .parent()
+        .with_context(|| format!("No parent directory for {}", path.display()))?;
+    let mut temp = tempfile::NamedTempFile::new_in(dir)?;
+    temp.write_all(new_content.as_bytes())?;
+    // Temp files default to owner-only permissions; keep the original mode.
+    temp.as_file().set_permissions(original.permissions())?;
+    temp.as_file().sync_all()?;
+    // The rename below replaces the whole file, so an edit that landed after
+    // our read would be silently thrown away with it. Back off if the content
+    // moved under us — a later command re-runs the sweep on the fresh content.
+    if std::fs::read_to_string(path)? != read_content {
+        anyhow::bail!(
+            "{} changed while preparing the rewrite; leaving it alone",
+            path.display()
+        );
+    }
+    temp.persist(path)
+        .with_context(|| format!("Failed to replace {}", path.display()))?;
+    Ok(())
+}
+
+/// Replace every line-anchored occurrence of the retired bullet that sits
+/// inside a managed block. Returns `None` when nothing needs rewriting.
+fn replace_retired_bullet(content: &str) -> Option<String> {
+    // The cheap check first: on the steady-state clean file this skips the
+    // marker scan and allocation entirely.
+    if !content.contains(RETIRED_FAST_PATH_BULLET) {
+        return None;
+    }
+    // A malformed block (unmatched marker) is not ours to interpret: skip.
+    let spans = managed_block_spans(content).ok()?;
+    let current = current_bullet();
+    let mut updated = String::with_capacity(content.len());
+    let mut copied = 0;
+    let mut pos = 0;
+    while let Some(idx) = find_line_anchored(content, RETIRED_FAST_PATH_BULLET, pos) {
+        pos = idx + RETIRED_FAST_PATH_BULLET.len();
+        if !spans.iter().any(|span| span.contains(&idx)) {
+            continue;
+        }
+        updated.push_str(&content[copied..idx]);
+        updated.push_str(&current);
+        copied = pos;
+    }
+    (copied > 0).then(|| {
+        updated.push_str(&content[copied..]);
+        updated
+    })
+}
+
+/// The agent that triggered the cleanup loaded the stale rules at session
+/// start, so the notice restates the current syntax instead of only pointing
+/// at the rewritten files.
+fn notice(changed: &[PathBuf]) -> String {
+    let t = theme::get();
+    let paths = changed
+        .iter()
+        .map(|path| path.display().to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        "{} Retired `but commit` syntax was removed from your GitButler workflow rules ({paths}).\n\
+         The rule is now: {}\n\
+         Follow the updated syntax; the rules text loaded into your context is outdated.",
+        t.sym().success,
+        policy::FAST_PATH_BULLET,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        super::{MANAGED_BLOCK_END, MANAGED_BLOCK_START},
+        *,
+    };
+
+    fn managed(body: &str) -> String {
+        format!("# Rules\n\n{MANAGED_BLOCK_START}\n{body}\n{MANAGED_BLOCK_END}\n")
+    }
+
+    #[test]
+    fn rewrites_retired_bullet_inside_managed_block() {
+        let content = managed(&format!("## Version control\n\n{RETIRED_FAST_PATH_BULLET}"));
+        let updated = replace_retired_bullet(&content).unwrap();
+        assert_eq!(
+            updated,
+            managed(&format!("## Version control\n\n{}", current_bullet())),
+            "only the bullet changes; the rest of the file is byte-identical"
+        );
+    }
+
+    #[test]
+    fn leaves_retired_bullet_outside_managed_block_alone() {
+        let content = format!("# Notes\n\n{RETIRED_FAST_PATH_BULLET}\n");
+        assert!(
+            replace_retired_bullet(&content).is_none(),
+            "user-authored text outside the markers is not ours to edit"
+        );
+    }
+
+    #[test]
+    fn leaves_current_bullet_alone() {
+        let content = managed(&current_bullet());
+        assert!(replace_retired_bullet(&content).is_none());
+    }
+
+    #[test]
+    fn preserves_crlf_line_endings() {
+        let content = managed(RETIRED_FAST_PATH_BULLET).replace('\n', "\r\n");
+        let updated = replace_retired_bullet(&content).unwrap();
+        assert_eq!(
+            updated,
+            managed(&current_bullet()).replace('\n', "\r\n"),
+            "the bullet itself has no line ending, so CRLF endings survive"
+        );
+    }
+
+    #[test]
+    fn cleanup_files_rewrites_and_reports_only_changed_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let stale = dir.path().join("stale.md");
+        let current = dir.path().join("current.md");
+        let missing = dir.path().join("missing.md");
+        std::fs::write(&stale, managed(RETIRED_FAST_PATH_BULLET)).unwrap();
+        std::fs::write(&current, managed(&current_bullet())).unwrap();
+
+        let changed = cleanup_files(&[stale.clone(), current.clone(), missing]);
+
+        assert_eq!(changed, vec![stale.clone()]);
+        assert_eq!(
+            std::fs::read_to_string(&stale).unwrap(),
+            managed(&current_bullet())
+        );
+    }
+
+    #[test]
+    fn skips_oversized_and_binary_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let oversized = dir.path().join("oversized.md");
+        let mut content = managed(RETIRED_FAST_PATH_BULLET);
+        content.push_str(&"x".repeat(MAX_INSTRUCTION_FILE_BYTES as usize));
+        std::fs::write(&oversized, &content).unwrap();
+        let binary = dir.path().join("binary.md");
+        let mut bytes = managed(RETIRED_FAST_PATH_BULLET).into_bytes();
+        bytes.push(0xff);
+        std::fs::write(&binary, &bytes).unwrap();
+
+        let changed = cleanup_files(&[oversized.clone(), binary.clone()]);
+
+        assert_eq!(
+            changed,
+            Vec::<PathBuf>::new(),
+            "files the wizard cannot have written stay untouched"
+        );
+        assert_eq!(std::fs::read_to_string(&oversized).unwrap(), content);
+        assert_eq!(std::fs::read(&binary).unwrap(), bytes);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rewrites_symlink_target_and_keeps_the_link() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("dotfiles-repo.md");
+        let link = dir.path().join("rules.md");
+        std::fs::write(&target, managed(RETIRED_FAST_PATH_BULLET)).unwrap();
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        let changed = cleanup_files(std::slice::from_ref(&link));
+
+        assert_eq!(changed, vec![link.clone()]);
+        assert!(
+            std::fs::symlink_metadata(&link).unwrap().is_symlink(),
+            "a dotfile-managed rules file must stay a symlink"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&target).unwrap(),
+            managed(&current_bullet())
+        );
+    }
+
+    #[test]
+    fn backs_off_when_the_file_changed_after_the_read() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rules.md");
+        let concurrent_edit = format!(
+            "{}\nA line saved by an editor.\n",
+            managed(&current_bullet())
+        );
+        std::fs::write(&path, &concurrent_edit).unwrap();
+        let metadata = std::fs::metadata(&path).unwrap();
+
+        let stale_read = managed(RETIRED_FAST_PATH_BULLET);
+        let result =
+            replace_file_contents(&path, &stale_read, &managed(&current_bullet()), &metadata);
+
+        assert!(result.is_err(), "a rewrite from a stale read must back off");
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            concurrent_edit,
+            "the concurrent edit must survive untouched"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn preserves_file_permissions() {
+        use std::os::unix::fs::PermissionsExt as _;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rules.md");
+        std::fs::write(&path, managed(RETIRED_FAST_PATH_BULLET)).unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        let changed = cleanup_files(std::slice::from_ref(&path));
+
+        assert_eq!(changed, vec![path.clone()]);
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o644,
+            "the rewrite must not tighten the file to the temp file's owner-only mode"
+        );
+    }
+}

--- a/crates/but/src/command/agent/files.rs
+++ b/crates/but/src/command/agent/files.rs
@@ -58,6 +58,31 @@ fn inside_fenced_block(haystack: &str, idx: usize) -> bool {
     open
 }
 
+/// Byte spans of each managed block, from the first byte of the start marker
+/// to just past the last byte of the end marker (both markers lie inside the
+/// end-exclusive `Range`). Pairs every line-anchored start with the first
+/// line-anchored end after it. Errors when a start marker has no matching end,
+/// so callers refuse to touch a malformed block.
+pub(super) fn managed_block_spans(existing: &str) -> Result<Vec<std::ops::Range<usize>>> {
+    let mut spans = Vec::new();
+    let mut pos = 0;
+    while let Some(start) = find_line_anchored(existing, MANAGED_BLOCK_START, pos) {
+        let Some(end) = find_line_anchored(
+            existing,
+            MANAGED_BLOCK_END,
+            start + MANAGED_BLOCK_START.len(),
+        ) else {
+            anyhow::bail!(
+                "Found a GitButler managed block start marker without a matching end marker. Refusing to edit a partial managed block."
+            );
+        };
+        let span_end = end + MANAGED_BLOCK_END.len();
+        spans.push(start..span_end);
+        pos = span_end;
+    }
+    Ok(spans)
+}
+
 /// Rewrite `block` to use CRLF line endings when `existing` already does, so a
 /// replaced or appended block does not introduce mixed line endings.
 fn match_line_endings(existing: &str, block: &str) -> String {
@@ -88,29 +113,18 @@ pub(super) fn upsert_managed_block(existing: &str, block: &str) -> Result<String
         (Some(_), Some(_)) => {}
     }
 
-    // Pair each start marker with the first end marker after it. Replace the
-    // first block with the fresh one and drop any extra blocks (e.g. left over
-    // from an earlier buggy run), so the file converges to exactly one block.
+    // Replace the first block with the fresh one and drop any extra blocks
+    // (e.g. left over from an earlier buggy run), so the file converges to
+    // exactly one block.
     let mut spans = Vec::new();
-    let mut pos = 0;
-    while let Some(start) = find_line_anchored(existing, MANAGED_BLOCK_START, pos) {
-        let Some(end) = find_line_anchored(
-            existing,
-            MANAGED_BLOCK_END,
-            start + MANAGED_BLOCK_START.len(),
-        ) else {
-            anyhow::bail!(
-                "Found a GitButler managed block start marker without a matching end marker. Refusing to edit a partial managed block."
-            );
-        };
-        let mut block_end = end + MANAGED_BLOCK_END.len();
+    for span in managed_block_spans(existing)? {
+        let mut block_end = span.end;
         if existing[block_end..].starts_with("\r\n") {
             block_end += 2;
         } else if existing[block_end..].starts_with('\n') {
             block_end += 1;
         }
-        spans.push((start, block_end));
-        pos = block_end;
+        spans.push((span.start, block_end));
     }
 
     let block = match_line_endings(existing, block);

--- a/crates/but/src/command/agent/mod.rs
+++ b/crates/but/src/command/agent/mod.rs
@@ -13,11 +13,14 @@ use crate::{
     utils::{InputOutputChannel, OutputChannel, PromptLine, detect_agent},
 };
 
+mod cleanup;
 mod files;
 mod plan;
 mod policy;
 #[cfg(test)]
 mod tests;
+
+pub(crate) use cleanup::retired_policy_syntax_notice;
 
 use files::upsert_managed_block_file;
 use plan::{AgentTarget, Plan};

--- a/crates/but/src/command/agent/plan.rs
+++ b/crates/but/src/command/agent/plan.rs
@@ -342,7 +342,7 @@ pub(super) fn collect_instruction_writes(
     ))
 }
 
-fn join_components(base: &Path, components: &[&str]) -> PathBuf {
+pub(super) fn join_components(base: &Path, components: &[&str]) -> PathBuf {
     components
         .iter()
         .fold(base.to_path_buf(), |path, component| path.join(component))

--- a/crates/but/src/command/agent/policy.rs
+++ b/crates/but/src/command/agent/policy.rs
@@ -131,6 +131,12 @@ impl WizardAnswers {
     }
 }
 
+/// The selected-change commit fast-path rule. Named so `super::cleanup` can
+/// rewrite the retired wording in already-installed policy blocks to exactly
+/// this text. Rewording it strands old installs on the previous wording unless
+/// the cleanup learns that wording as another retired variant.
+pub(super) const FAST_PATH_BULLET: &str = "For commit just/only/specific changes on a new branch (selected-change requests), use the two-command fast path from the GitButler skill: `but diff`, then `but commit -b <branch> -m \"message\" <id> <id>`.";
+
 /// Render the GitButler steering as a managed block. Mirrors the published
 /// guidance: an always-on `## Version control` baseline (see the docs "Getting
 /// started" page) followed by one `###` section per selected preference (see
@@ -147,7 +153,7 @@ pub(super) fn render_managed_policy_block(answers: &WizardAnswers) -> String {
         &[
             "Use GitButler (`but`) for version-control inspection and write operations, including status, diffs, branching, committing, pushing, and history edits.",
             "Assume multiple agents may be working in this repository. Do not move, amend, squash, discard, commit, push, or otherwise modify another agent's work unless the user asks.",
-            "For commit just/only/specific changes on a new branch (selected-change requests), use the two-command fast path from the GitButler skill: `but diff`, then `but commit -b <branch> -m \"message\" <id> <id>`.",
+            FAST_PATH_BULLET,
             "For that fast path, after the commit succeeds, stop and summarize; do not run separate branch, staging, status, or diff commands unless the commit output is missing information you need.",
             "Use the installed GitButler skill for command recipes and syntax before guessing flags, using `--help`, or translating Git habits directly.",
             "Mutation commands report their result without appending workspace status. Add `--status-after` only when the next step needs resulting workspace IDs or details; otherwise do not rerun status or diff to verify success.",

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -451,8 +451,9 @@ async fn match_subcommand(
     };
 
     let is_expand = matches!(&cmd, Subcommands::_Expand { .. });
-    let show_agent_skill_notice = out.format().is_human_text()
-        && !out.can_prompt()
+    // A non-interactive invocation of a regular command: the situation where an
+    // agent-facing maintenance notice is worth printing.
+    let notice_worthy_command = !out.can_prompt()
         && !is_expand
         && !matches!(
             &cmd,
@@ -463,6 +464,7 @@ async fn match_subcommand(
                 | Subcommands::Completions { .. }
                 | Subcommands::Metrics { .. }
         );
+    let show_agent_skill_notice = out.format().is_human_text() && notice_worthy_command;
     let agent_skill_notice = show_agent_skill_notice
         .then(|| command::skill::agent_skill_notice(&args.current_dir))
         .flatten();
@@ -472,11 +474,30 @@ async fn match_subcommand(
         writeln!(human, "{}", notice.text()).ok();
         writeln!(human).ok();
     }
+    // Unlike the skill notice, the policy cleanup also runs for JSON-driven
+    // agents; its notice goes to stderr there so the JSON contract on stdout
+    // stays intact.
+    let retired_policy_notice = notice_worthy_command
+        .then(command::agent::retired_policy_syntax_notice)
+        .flatten();
+    if let Some(notice) = retired_policy_notice.as_ref() {
+        if let Some(human) = out.for_human() {
+            writeln!(human, "{notice}").ok();
+            writeln!(human).ok();
+        } else if out.is_json() {
+            print_err_infallible(format!("{notice}\n"));
+        }
+    }
     let mut metrics_ctx = cmd.to_metrics_context(&app_settings, &args.current_dir);
     if agent_skill_notice.is_some_and(|notice| notice.is_hint())
         && let Some(metrics_ctx) = metrics_ctx.as_mut()
     {
         metrics_ctx.push_extra_prop("agentSkillHintShown", true);
+    }
+    if retired_policy_notice.is_some()
+        && let Some(metrics_ctx) = metrics_ctx.as_mut()
+    {
+        metrics_ctx.push_extra_prop("retiredPolicySyntaxCleaned", true);
     }
     if retired_syntax::was_used()
         && let Some(metrics_ctx) = metrics_ctx.as_mut()


### PR DESCRIPTION
`but agent setup` used to write a workflow bullet teaching a since-retired `but commit` syntax into agent instruction files. The skill auto-updates on CLI upgrades, but the written policy text had no update path, so that stale rule would sit in users' rules files forever.

This adds a best-effort sweep that runs before agent-driven commands: it checks the per-agent global instruction files under `$HOME` and, when the exact retired bullet appears inside the `gitbutler-agent-setup` managed markers, rewrites it to the wizard's current wording and prints a notice restating the new rule (the agent's in-context copy is stale at that point).

Safety properties, since this silently edits user files:

- Only the exact machine-written line inside the managed markers can change; everything else is byte-identical by construction.
- Atomic writes (temp file + rename, permissions preserved, fsynced); symlinks are resolved so dotfile-managed rules keep their link.
- Skips anything unexpected: non-UTF-8, >1 MiB, non-regular files, malformed marker pairs. Never creates files or directories.
- Infallible: per-file errors are logged and skipped, the whole sweep is wrapped in catch_unwind, and it cannot alter a command's output or exit code. JSON invocations get the notice on stderr so the stdout contract stays intact.
- Repo-local AGENTS.md/CLAUDE.md are deliberately excluded — they are usually git-tracked, and a pre-command rewrite could get swept into an unrelated commit. Those heal by re-running `but agent setup`.
- Interactive human sessions never trigger the sweep; it is gated on a detected agent driving a non-interactive invocation.

The replacement text is derived from the policy renderer's bullet constant, so the two cannot drift. The managed-block span scan moved into a shared helper in files.rs that the setup wizard's upsert path now also uses.

Each file is rewritten at most once ever; steady state is a handful of short reads ending at a cheap contains check.