### PR TITLE
Skip description footers on GitHub native stacks

### DIFF
--- a/apps/desktop/src/components/projectSettings/ForgeForm.svelte
+++ b/apps/desktop/src/components/projectSettings/ForgeForm.svelte
@@ -170,7 +170,8 @@
 
 		{#snippet caption()}
 			Choose where GitButler-managed stack information appears. Changes apply on the next review
-			sync. The default is Bottom.
+			sync. The default is Bottom. Does not apply to native GitHub stacked pull requests, where
+			GitHub shows the stack on its own.
 		{/snippet}
 
 		<div data-testid="review-stacking-description-select">

--- a/crates/but-forge/src/review.rs
+++ b/crates/but-forge/src/review.rs
@@ -1852,7 +1852,6 @@ async fn sync_github_native_reviews(
     repo: &str,
     reviews: &[ForgeReviewUpdate],
     storage: &but_forge_storage::Controller,
-    description_mode: ReviewStackingDescription,
 ) -> Result<but_github::stacks::Availability<Vec<String>>> {
     let pr_numbers: Vec<i64> = reviews.iter().map(|review| review.number).collect();
     let prepared =
@@ -1937,8 +1936,10 @@ async fn sync_github_native_reviews(
 
     but_github::stacks::finish(preferred_account, owner, repo, &prepared.plan, storage).await?;
 
-    // GitHub now renders the native stack. Independently honor the configured GitButler
-    // description mode and preserve user text.
+    // GitHub now renders the native stack, so GitButler's description footer is redundant.
+    // Strip any existing footers regardless of the configured description mode, which only
+    // applies to footer-based stacking. User text is preserved, and reviews whose body would
+    // not change are skipped entirely — unless the caller supplied a new description to push.
     for (review, current_body) in reviews.iter().zip(bodies) {
         let Some(current_body) = current_body else {
             continue;
@@ -1948,8 +1949,11 @@ async fn sync_github_native_reviews(
             review.number,
             &pr_numbers,
             "#",
-            description_mode,
+            ReviewStackingDescription::Disabled,
         );
+        if !review.update_description && current_body.as_deref().unwrap_or("") == updated_body {
+            continue;
+        }
         let params = but_github::UpdatePullRequestParams {
             owner,
             repo,
@@ -2020,15 +2024,8 @@ pub async fn sync_reviews(
                 && head_repo.is_none()
                 && !reviews.is_empty();
             if use_native {
-                match sync_github_native_reviews(
-                    preferred_account,
-                    owner,
-                    repo,
-                    reviews,
-                    storage,
-                    description_mode,
-                )
-                .await
+                match sync_github_native_reviews(preferred_account, owner, repo, reviews, storage)
+                    .await
                 {
                     Ok(but_github::stacks::Availability::Supported(native_errors)) => {
                         errors.extend(native_errors);

--- a/e2e/playwright/tests/reviewStackingDescription.spec.ts
+++ b/e2e/playwright/tests/reviewStackingDescription.spec.ts
@@ -508,8 +508,7 @@ test("GitHub native stacks are rebuilt when a review is created in the middle", 
 		.toEqual([{ number: 1, pull_requests: [{ number: 42 }, { number: 43 }] }]);
 	await expectReviews(server, 2, (reviews) => {
 		expect(reviews.map((review) => review.base.ref)).toEqual(["master", "branch1"]);
-		expectBottomFooter(reviews[0], "Description for branch1", "part 1 of 2");
-		expectBottomFooter(reviews[1], "Description for branch2", "part 2 of 2");
+		expectPlainDescriptions(reviews);
 	});
 
 	await dragAndDropByLocator(
@@ -541,9 +540,7 @@ test("GitHub native stacks are rebuilt when a review is created in the middle", 
 	]);
 	await expectReviews(server, 3, (reviews) => {
 		expect(reviews.map((review) => review.base.ref)).toEqual(["master", "branch3", "branch1"]);
-		expectBottomFooter(reviews[0], "Description for branch1", "part 1 of 3");
-		expectBottomFooter(reviews[1], "Description for branch2", "part 3 of 3");
-		expectBottomFooter(reviews[2], "Description for branch3", "part 2 of 3");
+		expectPlainDescriptions(reviews);
 	});
 
 	await setGitHubStackingMode(page, gitbutler, "disabled");
@@ -610,8 +607,7 @@ test("an unchanged GitHub native stack pushes without base updates and appends n
 		.poll(() => server.getNativeStacks())
 		.toEqual([{ number: 1, pull_requests: [{ number: 42 }, { number: 43 }] }]);
 	await expectReviews(server, 2, (reviews) => {
-		expectBottomFooter(reviews[0], "Description for branch1", "part 1 of 2");
-		expectBottomFooter(reviews[1], "Description for branch2", "part 2 of 2");
+		expectPlainDescriptions(reviews);
 	});
 
 	// GitHub refuses base updates for native stack members, so an ordinary push of the
@@ -1235,6 +1231,13 @@ async function expectReviews(
 			},
 		)
 		.toBe("ok");
+}
+
+// On native GitHub stacks no footer is written; bodies stay exactly as authored.
+function expectPlainDescriptions(reviews: FakeGitHubReview[]) {
+	for (const [index, review] of reviews.entries()) {
+		expect(review.body).toBe(`Description for branch${index + 1}`);
+	}
 }
 
 function expectBottomFooter(review: FakeGitHubReview, description: string, part: string) {


### PR DESCRIPTION
GitHub renders native stacks itself, so the GitButler-managed footer is redundant there. The native sync path now ignores the stack-description setting: it strips any leftover footers (e.g. after a repo transitions from footer-based to native stacking) and otherwise leaves PR bodies untouched, skipping the API call when nothing changed — unless the caller explicitly supplied a new description to push.

The setting keeps working for footer-based stacking (GitLab, and GitHub repos without native stacks), and its settings copy now says it does not apply to native GitHub stacked pull requests.