### PR TITLE
discard commit: allow workdir-target conflicts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3831,7 +3831,7 @@ dependencies = [
 [[package]]
 name = "git2"
 version = "0.21.0"
-source = "git+https://github.com/gitbutlerapp/git2-rs?rev=efce108bf14cb1708cfc4c80f2ddf3244a2635ff#efce108bf14cb1708cfc4c80f2ddf3244a2635ff"
+source = "git+https://github.com/gitbutlerapp/git2-rs?rev=a87a7bb3f6843504339fe7434ee0732a3e968f3e#a87a7bb3f6843504339fe7434ee0732a3e968f3e"
 dependencies = [
  "bitflags 2.13.0",
  "libc",
@@ -6281,7 +6281,7 @@ dependencies = [
 [[package]]
 name = "libgit2-sys"
 version = "0.18.5+1.9.4"
-source = "git+https://github.com/gitbutlerapp/git2-rs?rev=efce108bf14cb1708cfc4c80f2ddf3244a2635ff#efce108bf14cb1708cfc4c80f2ddf3244a2635ff"
+source = "git+https://github.com/gitbutlerapp/git2-rs?rev=a87a7bb3f6843504339fe7434ee0732a3e968f3e#a87a7bb3f6843504339fe7434ee0732a3e968f3e"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -318,7 +318,7 @@ sapling-renderdag = "0.1.0"
 # Keep workspace crates that use the `gix 0.86` line on the same git revision.
 # This was relevant to force `git-meta` to use our version.
 gix = { git = "https://github.com/GitoxideLabs/gitoxide", rev = "83e074c1e2d070059febaaab1022058948855101" }
-git2 = { git = "https://github.com/gitbutlerapp/git2-rs", rev = "efce108bf14cb1708cfc4c80f2ddf3244a2635ff" }
+git2 = { git = "https://github.com/gitbutlerapp/git2-rs", rev = "a87a7bb3f6843504339fe7434ee0732a3e968f3e" }
 
 [workspace.lints.clippy]
 # Note that `all` doesn't include everything, so extra lints should be added here.

--- a/apps/desktop/src/lib/upstream/branchIntegrationView.test.ts
+++ b/apps/desktop/src/lib/upstream/branchIntegrationView.test.ts
@@ -251,6 +251,7 @@ describe("branchIntegrationView", () => {
 				isManagedCommit: true,
 				isEntrypoint: true,
 			},
+			checkoutConflictOccurred: false,
 		};
 
 		expect(buildNextStateGraphRows({ workspace, branchRef: BRANCH_REF })).toEqual([

--- a/crates/but-api/src/commit/discard_commit.rs
+++ b/crates/but-api/src/commit/discard_commit.rs
@@ -1,4 +1,4 @@
-use crate::WorkspaceState;
+use crate::{WorkspaceState, workspace_state::WorkspaceStateFromSuccessfulRebaseOptions};
 use but_api_macros::but_api;
 use but_core::{DiffSpec, DryRun, sync::RepoExclusive};
 use but_oplog::legacy::{OperationKind, SnapshotDetails, Trailer};
@@ -43,7 +43,10 @@ pub fn commit_discard_only_with_perm(
 
     let rebase = but_workspace::commit::discard_commits(editor, [subject_commit_id])?;
 
-    let workspace = WorkspaceState::from_successful_rebase_with_db(rebase, &repo, dry_run, &db)?;
+    let workspace = WorkspaceStateFromSuccessfulRebaseOptions::new(rebase, &repo, dry_run)
+        .with_db(&db)?
+        .allow_uncommitted_changes_to_conflict_with_new_head(true)
+        .generate()?;
 
     Ok(CommitDiscardResult {
         discarded_commit: subject_commit_id,

--- a/crates/but-api/src/json.rs
+++ b/crates/but-api/src/json.rs
@@ -176,6 +176,9 @@ pub struct WorkspaceState {
     /// rendered graph projection.
     #[cfg(feature = "graph-workspace")]
     pub graph_workspace: but_workspace::ui::workspace::DetailedGraphWorkspace,
+    /// True if a checkout occurred, and a conflict occurred during that
+    /// checkout.
+    pub checkout_conflict_occurred: bool,
 }
 
 #[cfg(feature = "export-schema")]
@@ -195,6 +198,7 @@ impl TryFrom<crate::WorkspaceState> for WorkspaceState {
             head_info: value.head_info.try_into()?,
             #[cfg(feature = "graph-workspace")]
             graph_workspace: value.graph_workspace,
+            checkout_conflict_occurred: value.checkout_conflict_occurred,
         })
     }
 }

--- a/crates/but-api/src/lib.rs
+++ b/crates/but-api/src/lib.rs
@@ -72,7 +72,8 @@ pub mod panic_capture;
 #[cfg(feature = "export-schema")]
 pub mod watcher;
 
-mod workspace_state;
+/// Functions for workspace state.
+pub mod workspace_state;
 
 /// Represents the workspace for the frontend
 ///
@@ -92,4 +93,7 @@ pub struct WorkspaceState {
     /// for more detail.
     #[cfg(feature = "graph-workspace")]
     pub graph_workspace: but_workspace::ui::workspace::DetailedGraphWorkspace,
+    /// True if a checkout occurred, and a conflict occurred during that
+    /// checkout.
+    pub checkout_conflict_occurred: bool,
 }

--- a/crates/but-api/src/workspace_state.rs
+++ b/crates/but-api/src/workspace_state.rs
@@ -2,7 +2,7 @@ use super::WorkspaceState;
 use std::collections::{BTreeMap, HashMap};
 
 use but_core::{DryRun, RefMetadata};
-use but_rebase::graph_rebase::SuccessfulRebase;
+use but_rebase::graph_rebase::{SuccessfulRebase, materialize::MaterializeOptions};
 
 /// Build a `{ pushed short name -> PR number }` lookup from the forge review
 /// cache, for resolving branch PR associations at projection time.
@@ -102,6 +102,7 @@ impl WorkspaceState {
         repo: &gix::Repository,
         replaced_commits: BTreeMap<gix::ObjectId, gix::ObjectId>,
         prs_by_head: &HashMap<String, usize>,
+        checkout_conflict_occurred: bool,
     ) -> anyhow::Result<WorkspaceState> {
         #[cfg(not(feature = "graph-workspace"))]
         {
@@ -125,6 +126,7 @@ impl WorkspaceState {
             Ok(WorkspaceState {
                 replaced_commits,
                 head_info,
+                checkout_conflict_occurred,
             })
         }
         #[cfg(feature = "graph-workspace")]
@@ -139,6 +141,7 @@ impl WorkspaceState {
             Ok(WorkspaceState {
                 replaced_commits,
                 graph_workspace: graph_workspace.into(),
+                checkout_conflict_occurred,
             })
         }
     }
@@ -154,8 +157,16 @@ impl WorkspaceState {
         meta: &mut M,
         repo: &gix::Repository,
         replaced_commits: BTreeMap<gix::ObjectId, gix::ObjectId>,
+        checkout_conflict_occurred: bool,
     ) -> anyhow::Result<WorkspaceState> {
-        Self::from_workspace(workspace, meta, repo, replaced_commits, &HashMap::new())
+        Self::from_workspace(
+            workspace,
+            meta,
+            repo,
+            replaced_commits,
+            &HashMap::new(),
+            checkout_conflict_occurred,
+        )
     }
 
     /// Build a [`WorkspaceState`] from an already-prepared overlayed graph.
@@ -171,7 +182,7 @@ impl WorkspaceState {
         db: &but_db::DbHandle,
     ) -> anyhow::Result<WorkspaceState> {
         let prs_by_head = forge_prs_by_head(db)?;
-        Self::from_workspace(workspace, meta, repo, replaced_commits, &prs_by_head)
+        Self::from_workspace(workspace, meta, repo, replaced_commits, &prs_by_head, false)
     }
 
     /// Build a preview [`WorkspaceState`] from a successful rebase without materializing it.
@@ -189,7 +200,7 @@ impl WorkspaceState {
     ) -> anyhow::Result<WorkspaceState> {
         let workspace = rebase.overlayed_graph()?.into_workspace()?;
         let (repo, meta) = rebase.repo_and_meta_mut();
-        Self::from_workspace(&workspace, meta, repo, replaced_commits, prs_by_head)
+        Self::from_workspace(&workspace, meta, repo, replaced_commits, prs_by_head, false)
     }
 
     /// Build a preview [`WorkspaceState`] from a successful rebase without materializing it.
@@ -206,36 +217,6 @@ impl WorkspaceState {
         Self::from_rebase_preview(rebase, replaced_commits, &prs_by_head)
     }
 
-    /// Build a [`WorkspaceState`] from a successful rebase, materializing it when needed.
-    ///
-    /// Use this as the default entry point when an operation ends with a [`SuccessfulRebase`] and
-    /// the API should return the resulting workspace state. When `dry_run` is `true`, this
-    /// delegates to [`WorkspaceState::from_rebase_preview`] so the caller sees the projected state
-    /// without changing the repository. Otherwise it materializes the rebase, then reports the
-    /// workspace state together with the final commit-replacement mappings returned by the
-    /// materialized history.
-    fn from_successful_rebase<M: RefMetadata>(
-        rebase: SuccessfulRebase<'_, '_, M>,
-        repo: &gix::Repository,
-        dry_run: DryRun,
-        prs_by_head: &HashMap<String, usize>,
-    ) -> anyhow::Result<WorkspaceState> {
-        if dry_run.into() {
-            let mut rebase = rebase;
-            let replaced_commits = rebase.history.commit_mappings();
-            return Self::from_rebase_preview(&mut rebase, replaced_commits, prs_by_head);
-        }
-
-        let materialized = rebase.materialize(Default::default())?;
-        Self::from_workspace(
-            materialized.workspace,
-            materialized.meta,
-            repo,
-            materialized.history.commit_mappings(),
-            prs_by_head,
-        )
-    }
-
     /// Build a [`WorkspaceState`] from a successful rebase without PR associations.
     ///
     /// Prefer `WorkspaceState::from_successful_rebase_with_db` for API
@@ -247,7 +228,9 @@ impl WorkspaceState {
         repo: &gix::Repository,
         dry_run: DryRun,
     ) -> anyhow::Result<WorkspaceState> {
-        Self::from_successful_rebase(rebase, repo, dry_run, &HashMap::new())
+        WorkspaceStateFromSuccessfulRebaseOptions::new(rebase, repo, dry_run)
+            .without_pr_associations()
+            .generate()
     }
 
     /// Build a [`WorkspaceState`] from a successful rebase, materializing it when needed.
@@ -261,7 +244,102 @@ impl WorkspaceState {
         dry_run: DryRun,
         db: &but_db::DbHandle,
     ) -> anyhow::Result<WorkspaceState> {
-        let prs_by_head = forge_prs_by_head(db)?;
-        Self::from_successful_rebase(rebase, repo, dry_run, &prs_by_head)
+        WorkspaceStateFromSuccessfulRebaseOptions::new(rebase, repo, dry_run)
+            .with_db(db)?
+            .generate()
+    }
+}
+
+/// Options to build a [WorkspaceState] from a successful rebase.
+pub struct WorkspaceStateFromSuccessfulRebaseOptions<'ws, 'meta, 'repo, M: RefMetadata> {
+    rebase: SuccessfulRebase<'ws, 'meta, M>,
+    repo: &'repo gix::Repository,
+    dry_run: DryRun,
+    allow_uncommitted_changes_to_conflict_with_new_head: bool,
+    prs_by_head: Option<HashMap<String, usize>>,
+}
+
+impl<'ws, 'meta, 'repo, M: RefMetadata>
+    WorkspaceStateFromSuccessfulRebaseOptions<'ws, 'meta, 'repo, M>
+{
+    /// Creates a new set of options.
+    pub fn new(
+        rebase: SuccessfulRebase<'ws, 'meta, M>,
+        repo: &'repo gix::Repository,
+        dry_run: DryRun,
+    ) -> Self {
+        Self {
+            rebase,
+            repo,
+            dry_run,
+            allow_uncommitted_changes_to_conflict_with_new_head: false,
+            prs_by_head: None,
+        }
+    }
+
+    /// Generate with the PRs from the given db.
+    pub fn with_db(self, db: &but_db::DbHandle) -> anyhow::Result<Self> {
+        let prs_by_head = Some(forge_prs_by_head(db)?);
+        Ok(Self {
+            prs_by_head,
+            ..self
+        })
+    }
+
+    /// Generate without any PRs.
+    pub fn without_pr_associations(self) -> Self {
+        Self {
+            prs_by_head: Some(HashMap::new()),
+            ..self
+        }
+    }
+
+    /// When checking out, allow uncommitted changes to conflict.
+    pub fn allow_uncommitted_changes_to_conflict_with_new_head(
+        self,
+        allow_uncommitted_changes_to_conflict_with_new_head: bool,
+    ) -> Self {
+        Self {
+            allow_uncommitted_changes_to_conflict_with_new_head,
+            ..self
+        }
+    }
+
+    /// Generates the [WorkspaceState]. [Self::with_db] or
+    /// [Self::without_pr_associations] must have been previously called.
+    pub fn generate(self) -> anyhow::Result<WorkspaceState> {
+        let Self {
+            rebase,
+            repo,
+            dry_run,
+            allow_uncommitted_changes_to_conflict_with_new_head,
+            prs_by_head,
+        } = self;
+        let Some(prs_by_head) = prs_by_head else {
+            anyhow::bail!("BUG: must call with_db() or without_pr_associations()");
+        };
+
+        if dry_run.into() {
+            let mut rebase = rebase;
+            let replaced_commits = rebase.history.commit_mappings();
+            return WorkspaceState::from_rebase_preview(
+                &mut rebase,
+                replaced_commits,
+                &prs_by_head,
+            );
+        }
+
+        let materialized = rebase.materialize(MaterializeOptions {
+            allow_uncommitted_changes_to_conflict_with_new_head,
+            ..Default::default()
+        })?;
+        WorkspaceState::from_workspace(
+            materialized.workspace,
+            materialized.meta,
+            repo,
+            materialized.history.commit_mappings(),
+            &prs_by_head,
+            materialized.checkout_conflict_occurred,
+        )
     }
 }

--- a/crates/but-core/src/worktree/checkout/function.rs
+++ b/crates/but-core/src/worktree/checkout/function.rs
@@ -1,7 +1,12 @@
 use anyhow::bail;
+use bstr::BStr;
 use but_error::bail_precondition;
 use but_oxidize::{ObjectIdExt, OidExt as _};
-use gix::{merge::tree::TreatAsUnresolved, prelude::ObjectIdExt as _, refs::Target};
+use gix::{
+    merge::{plumbing::tree::ConflictIndexEntry, tree::TreatAsUnresolved},
+    prelude::ObjectIdExt as _,
+    refs::Target,
+};
 use tracing::instrument;
 
 use crate::{RepositoryExt, update_head_reference};
@@ -31,6 +36,7 @@ pub fn safe_checkout_from_head(
         skip_head_update,
         merge_base_override,
         allow_conflicted_commit_checkout,
+        allow_uncommitted_changes_to_conflict_with_new_head,
     }: Options,
 ) -> anyhow::Result<Outcome> {
     let new_object = new_head_id.attach(repo).object()?;
@@ -65,6 +71,7 @@ pub fn safe_checkout_from_head(
     let new_tree = git2_repo
         .find_object(new_head_id.to_git2(), None)?
         .peel_to_tree()?;
+    let mut conflict_occurred = false;
     if old_tree.id() != new_tree.id() {
         // Reopen to ensure that there is no "object memory" (i.e. all object
         // writes actually happen on disk).
@@ -83,28 +90,80 @@ pub fn safe_checkout_from_head(
             Default::default(),
             repo.tree_merge_options()?.with_rewrites(None),
         )?;
+        let checkout_target_base_id = outcome.tree.write()?.detach();
+
+        let checkout_target_base = git2_repo.find_tree(checkout_target_base_id.to_git2())?;
+        let mut checkout_target = git2::Index::new()?;
+        checkout_target.read_tree(&checkout_target_base)?;
+
         let unresolved = TreatAsUnresolved::git();
         if outcome.has_unresolved_conflicts(unresolved) {
-            let mut paths = outcome
-                .conflicts
-                .iter()
-                .filter(|c| c.is_unresolved(unresolved))
-                .map(|c| format!("{:?}", c.ours.location()))
-                .collect::<Vec<_>>();
-            paths.sort();
-            paths.dedup();
-            bail_precondition!(
-                "Uncommitted files would be overwritten by checkout: {}",
-                paths.join(", ")
-            );
+            conflict_occurred = true;
+            if allow_uncommitted_changes_to_conflict_with_new_head {
+                for conflict in outcome.conflicts.iter() {
+                    if !conflict.is_unresolved(unresolved) {
+                        continue;
+                    }
+                    let [base, ours, theirs] = conflict.entries();
+                    if base.is_some_and(|c| c.mode.is_tree())
+                        || ours.is_some_and(|c| c.mode.is_tree())
+                        || theirs.is_some_and(|c| c.mode.is_tree())
+                    {
+                        bail_precondition!(
+                            "Cannot checkout file-directory conflict: {}",
+                            conflict.ours.location()
+                        );
+                    }
+                    fn to_git2_index_entry(
+                        entry: &ConflictIndexEntry,
+                        path: &BStr,
+                    ) -> git2::IndexEntry {
+                        git2::IndexEntry {
+                            ctime: git2::IndexTime::new(0, 0),
+                            mtime: git2::IndexTime::new(0, 0),
+                            dev: 0,
+                            ino: 0,
+                            mode: entry.mode.value() as u32,
+                            uid: 0,
+                            gid: 0,
+                            file_size: 0,
+                            id: entry.id.to_git2(),
+                            flags: 0,
+                            flags_extended: 0,
+                            path: path.to_vec(),
+                        }
+                    }
+                    let base_index_entry =
+                        base.map(|c| to_git2_index_entry(&c, conflict.ours.location()));
+                    let ours_index_entry =
+                        ours.map(|c| to_git2_index_entry(&c, conflict.ours.location()));
+                    let theirs_index_entry =
+                        theirs.map(|c| to_git2_index_entry(&c, conflict.ours.location()));
+                    checkout_target.conflict_add(
+                        base_index_entry.as_ref(),
+                        ours_index_entry.as_ref(),
+                        theirs_index_entry.as_ref(),
+                    )?;
+                }
+            } else {
+                let mut paths = outcome
+                    .conflicts
+                    .iter()
+                    .filter(|c| c.is_unresolved(unresolved))
+                    .map(|c| format!("{:?}", c.ours.location()))
+                    .collect::<Vec<_>>();
+                paths.sort();
+                paths.dedup();
+                bail_precondition!(
+                    "Uncommitted files would be overwritten by checkout: {}",
+                    paths.join(", ")
+                );
+            }
         }
-        let checkout_target_id = outcome.tree.write()?.detach();
 
         let mut checkout_opts = git2::build::CheckoutBuilder::new();
         checkout_opts.baseline(&wd_tree);
-        let checkout_target =
-            git2_repo.find_object(checkout_target_id.to_git2(), Some(git2::ObjectType::Tree))?;
-        git2_repo.checkout_tree(&checkout_target, Some(&mut checkout_opts))?;
+        git2_repo.checkout_index(Some(&mut checkout_target), Some(&mut checkout_opts))?;
     }
 
     let mut head_update = None;
@@ -128,5 +187,8 @@ pub fn safe_checkout_from_head(
         }
     }
 
-    Ok(Outcome { head_update })
+    Ok(Outcome {
+        head_update,
+        conflict_occurred,
+    })
 }

--- a/crates/but-core/src/worktree/checkout/mod.rs
+++ b/crates/but-core/src/worktree/checkout/mod.rs
@@ -18,6 +18,11 @@ pub struct Options {
     /// conflict workflow instead. Rebase materialization may opt in when it
     /// intentionally created the conflicted commit it is about to materialize.
     pub allow_conflicted_commit_checkout: bool,
+    /// Normally, the 3-way merge between the merge base override, the working
+    /// directory, and the new HEAD must not result in a conflict. If this field
+    /// is true, such a conflict is allowed; all stages in all conflicts will be
+    /// written to the index.
+    pub allow_uncommitted_changes_to_conflict_with_new_head: bool,
 }
 
 /// The successful outcome of [super::safe_checkout_from_head()] operation.
@@ -25,6 +30,9 @@ pub struct Options {
 pub struct Outcome {
     /// If `new_head_id` was a commit, these are the ref-edits returned after performing the transaction.
     pub head_update: Option<Vec<gix::refs::transaction::RefEdit>>,
+    /// True if a conflict occurred during checkout. This is always false if
+    /// [Options::allow_uncommitted_changes_to_conflict_with_new_head] is false.
+    pub conflict_occurred: bool,
 }
 
 pub(crate) mod function;

--- a/crates/but-core/src/worktree/checkout/utils.rs
+++ b/crates/but-core/src/worktree/checkout/utils.rs
@@ -2,7 +2,7 @@ use crate::worktree::checkout::Outcome;
 
 impl std::fmt::Debug for Outcome {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let Outcome { head_update } = self;
+        let Outcome { head_update, .. } = self;
         f.debug_struct("Outcome")
             .field(
                 "head_update",

--- a/crates/but-rebase/src/graph_rebase/materialize.rs
+++ b/crates/but-rebase/src/graph_rebase/materialize.rs
@@ -126,6 +126,14 @@ pub struct MaterializeOptions {
     /// rewrite, so what they had checked out surfaces as uncommitted changes there -
     /// exactly like the editor's own worktree.
     pub without_checkout: bool,
+    /// When checking out our own worktree, allow uncommitted changes to
+    /// conflict with what's checked out. If such a conflict happens, it will be
+    /// reported in the returned [MaterializeOutcome].
+    ///
+    /// (In linked worktrees, conflicts are still unallowed.)
+    ///
+    /// Has no effect if [Self::without_checkout] is false.
+    pub allow_uncommitted_changes_to_conflict_with_new_head: bool,
 }
 
 impl<'ws, 'graph, M: RefMetadata> SuccessfulRebase<'ws, 'graph, M> {
@@ -207,7 +215,7 @@ impl<'ws, 'graph, M: RefMetadata> SuccessfulRebase<'ws, 'graph, M> {
         let specs = self.linked_checkout_specs()?;
         let detached_head_edits = detached_worktree_head_edits(&specs)?;
 
-        let head = if !materialize_options.without_checkout {
+        let (head, checkout_conflict_occurred) = if !materialize_options.without_checkout {
             let linked_repos = open_linked_checkout_repos(&repo, specs)?;
             for linked_repo in linked_repos {
                 safe_checkout_from_head(
@@ -217,25 +225,31 @@ impl<'ws, 'graph, M: RefMetadata> SuccessfulRebase<'ws, 'graph, M> {
                         skip_head_update: true,
                         merge_base_override: linked_repo.merge_base_override,
                         allow_conflicted_commit_checkout: false,
+                        allow_uncommitted_changes_to_conflict_with_new_head: false,
                     },
                 )?;
             }
 
             let head = self.head_checkout()?;
-            if let Some(head) = &head {
-                safe_checkout_from_head(
+            let checkout_conflict_occurred = if let Some(head) = &head {
+                let outcome = safe_checkout_from_head(
                     head.target,
                     &repo,
                     Options {
                         skip_head_update: true,
                         merge_base_override: head.merge_base_override,
                         allow_conflicted_commit_checkout: true,
+                        allow_uncommitted_changes_to_conflict_with_new_head: materialize_options
+                            .allow_uncommitted_changes_to_conflict_with_new_head,
                     },
                 )?;
-            }
-            head
+                outcome.conflict_occurred
+            } else {
+                false
+            };
+            (head, checkout_conflict_occurred)
         } else {
-            None
+            (None, false)
         };
 
         let mut ref_edits = self.ref_edits.clone();
@@ -276,6 +290,7 @@ impl<'ws, 'graph, M: RefMetadata> SuccessfulRebase<'ws, 'graph, M> {
             history: self.history,
             workspace: self.workspace,
             meta: self.meta,
+            checkout_conflict_occurred,
         })
     }
 
@@ -284,6 +299,7 @@ impl<'ws, 'graph, M: RefMetadata> SuccessfulRebase<'ws, 'graph, M> {
     pub fn materialize_without_checkout(self) -> Result<MaterializeOutcome<'ws, 'graph, M>> {
         self.materialize(MaterializeOptions {
             without_checkout: true,
+            ..Default::default()
         })
     }
 }

--- a/crates/but-rebase/src/graph_rebase/mod.rs
+++ b/crates/but-rebase/src/graph_rebase/mod.rs
@@ -474,6 +474,10 @@ pub struct MaterializeOutcome<'ws, 'meta, M: RefMetadata> {
     pub workspace: &'ws mut but_graph::Workspace,
     /// A reference to the metadata that the editor was created for.
     pub meta: &'meta mut M,
+    /// True if a conflict occurred during checkout. This is always false if
+    /// `allow_uncommitted_changes_to_conflict_with_new_head` in the options
+    /// struct passed to the materialize call is false.
+    pub checkout_conflict_occurred: bool,
 }
 
 /// Provides lookup for different steps that a selector might point to.

--- a/crates/but-transaction/src/lib.rs
+++ b/crates/but-transaction/src/lib.rs
@@ -5,7 +5,7 @@ use std::{
 
 use anyhow::Context as _;
 use bstr::BStr;
-use but_api::WorkspaceState;
+use but_api::{WorkspaceState, workspace_state::WorkspaceStateFromSuccessfulRebaseOptions};
 use but_core::{
     DiffSpec, DryRun, RefMetadata, commit::CommitIdentifiers, ref_metadata, sync::RepoExclusive,
     tree::create_tree::RejectionReason,
@@ -14,6 +14,7 @@ use but_ctx::Context;
 use but_oplog::legacy::SnapshotDetails;
 use but_rebase::graph_rebase::{
     Editor, Step, SuccessfulRebase,
+    materialize::MaterializeOptions,
     mutate::{InsertSide, RelativeTo},
 };
 use but_workspace::commit::{
@@ -85,7 +86,30 @@ where
 {
     let mut guard = ctx.exclusive_worktree_access();
     let perm = guard.write_permission();
-    with_transaction_with_perm(ctx, meta, perm, snapshot_details, dry_run, f)
+    with_transaction_with_perm(
+        ctx,
+        meta,
+        perm,
+        snapshot_details,
+        WithTransactionOptions {
+            dry_run,
+            ..Default::default()
+        },
+        f,
+    )
+}
+
+pub struct WithTransactionOptions {
+    pub dry_run: DryRun,
+    pub allow_uncommitted_changes_to_conflict_with_new_head: bool,
+}
+impl Default for WithTransactionOptions {
+    fn default() -> Self {
+        Self {
+            dry_run: DryRun::No,
+            allow_uncommitted_changes_to_conflict_with_new_head: false,
+        }
+    }
 }
 
 /// Like [`with_transaction`] but allows the caller to provide the lock.
@@ -94,7 +118,10 @@ pub fn with_transaction_with_perm<M, F, T>(
     meta: &mut M,
     perm: &mut RepoExclusive,
     snapshot_details: SnapshotDetails,
-    dry_run: DryRun,
+    WithTransactionOptions {
+        dry_run,
+        allow_uncommitted_changes_to_conflict_with_new_head,
+    }: WithTransactionOptions,
     f: F,
 ) -> anyhow::Result<T::Outcome>
 where
@@ -166,6 +193,7 @@ where
             pending_created_independent_refs,
             dry_run,
             materialize_without_checkout.unwrap_or(false),
+            allow_uncommitted_changes_to_conflict_with_new_head,
         );
 
         let outcome = match outcome {
@@ -1124,6 +1152,7 @@ pub trait TransactionOutcome: sealed::Sealed {
         pending_created_independent_refs: Vec<PendingCreatedIndependentRef>,
         dry_run: DryRun,
         materialize_without_checkout: bool,
+        allow_uncommitted_changes_to_conflict_with_new_head: bool,
     ) -> anyhow::Result<Self::Outcome>;
 }
 
@@ -1145,6 +1174,7 @@ impl TransactionOutcome for () {
         pending_created_independent_refs: Vec<PendingCreatedIndependentRef>,
         dry_run: DryRun,
         materialize_without_checkout: bool,
+        allow_uncommitted_changes_to_conflict_with_new_head: bool,
     ) -> anyhow::Result<Self::Outcome> {
         let ws = workspace_state_from_rebase(
             rebase,
@@ -1154,6 +1184,7 @@ impl TransactionOutcome for () {
             pending_created_independent_refs,
             dry_run,
             materialize_without_checkout,
+            allow_uncommitted_changes_to_conflict_with_new_head,
         )?;
         if dry_run == DryRun::No {
             db_tx.commit()?;
@@ -1184,6 +1215,7 @@ impl<T> TransactionOutcome for Rollback<T> {
         _pending_created_independent_refs: Vec<PendingCreatedIndependentRef>,
         _dry_run: DryRun,
         _materialize_without_checkout: bool,
+        _allow_uncommitted_changes_to_conflict_with_new_head: bool,
     ) -> anyhow::Result<Self::Outcome> {
         Ok(self.0)
     }
@@ -1211,6 +1243,7 @@ impl<T> TransactionOutcome for Commit<T> {
         pending_created_independent_refs: Vec<PendingCreatedIndependentRef>,
         dry_run: DryRun,
         materialize_without_checkout: bool,
+        allow_uncommitted_changes_to_conflict_with_new_head: bool,
     ) -> anyhow::Result<Self::Outcome> {
         let workspace = workspace_state_from_rebase(
             rebase,
@@ -1220,6 +1253,7 @@ impl<T> TransactionOutcome for Commit<T> {
             pending_created_independent_refs,
             dry_run,
             materialize_without_checkout,
+            allow_uncommitted_changes_to_conflict_with_new_head,
         )?;
         if dry_run == DryRun::No {
             db_tx.commit()?;
@@ -1253,6 +1287,7 @@ impl<T, K> TransactionOutcome for DynamicOutcome<T, K> {
         pending_created_independent_refs: Vec<PendingCreatedIndependentRef>,
         dry_run: DryRun,
         materialize_without_checkout: bool,
+        allow_uncommitted_changes_to_conflict_with_new_head: bool,
     ) -> anyhow::Result<Self::Outcome> {
         match self {
             DynamicOutcome::Commit(value) => {
@@ -1264,6 +1299,7 @@ impl<T, K> TransactionOutcome for DynamicOutcome<T, K> {
                     pending_created_independent_refs,
                     dry_run,
                     materialize_without_checkout,
+                    allow_uncommitted_changes_to_conflict_with_new_head,
                 )?;
                 if dry_run == DryRun::No {
                     db_tx.commit()?;
@@ -1275,6 +1311,7 @@ impl<T, K> TransactionOutcome for DynamicOutcome<T, K> {
     }
 }
 
+#[expect(clippy::too_many_arguments)]
 fn workspace_state_from_rebase<M: RefMetadata>(
     rebase: SuccessfulRebase<'_, '_, M>,
     repo: &gix::Repository,
@@ -1283,18 +1320,21 @@ fn workspace_state_from_rebase<M: RefMetadata>(
     pending_created_independent_refs: Vec<PendingCreatedIndependentRef>,
     dry_run: DryRun,
     materialize_without_checkout: bool,
+    allow_uncommitted_changes_to_conflict_with_new_head: bool,
 ) -> anyhow::Result<WorkspaceState> {
     if dry_run.into() {
-        return WorkspaceState::from_successful_rebase_without_pr_associations(
-            rebase, repo, dry_run,
-        );
+        return WorkspaceStateFromSuccessfulRebaseOptions::new(rebase, repo, dry_run)
+            .without_pr_associations()
+            .allow_uncommitted_changes_to_conflict_with_new_head(
+                allow_uncommitted_changes_to_conflict_with_new_head,
+            )
+            .generate();
     }
 
-    let materialized = if materialize_without_checkout {
-        rebase.materialize_without_checkout()?
-    } else {
-        rebase.materialize(Default::default())?
-    };
+    let materialized = rebase.materialize(MaterializeOptions {
+        without_checkout: materialize_without_checkout,
+        allow_uncommitted_changes_to_conflict_with_new_head,
+    })?;
     for branch in pending_created_independent_refs {
         if materialized
             .workspace
@@ -1338,6 +1378,7 @@ fn workspace_state_from_rebase<M: RefMetadata>(
         materialized.meta,
         repo,
         materialized.history.commit_mappings(),
+        materialized.checkout_conflict_occurred,
     )
 }
 

--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -1,7 +1,7 @@
 use anyhow::Context as _;
 use but_api::json::{ChangeIdString, HexHash};
 use but_core::{
-    DiffSpec, DryRun, RefMetadata,
+    DiffSpec, RefMetadata,
     ref_metadata::StackId,
     sync::{RepoExclusive, RepoExclusiveGuard},
 };
@@ -297,7 +297,7 @@ pub fn run(
         meta,
         perm,
         snapshot_details,
-        DryRun::No,
+        Default::default(),
         |mut tx| {
             let (
                 IntermediateCommitCreateResult {

--- a/crates/but/src/command/legacy/discard.rs
+++ b/crates/but/src/command/legacy/discard.rs
@@ -5,9 +5,9 @@ use std::collections::BTreeMap;
 use anyhow::{Context as _, bail};
 use bstr::{BString, ByteSlice as _};
 use but_api::json::{ChangeIdString, HexHash};
-use but_core::{DiffSpec, DryRun, RefMetadata, sync::RepoExclusive};
+use but_core::{DiffSpec, RefMetadata, sync::RepoExclusive};
 use but_ctx::Context;
-use but_transaction::Commit;
+use but_transaction::{Commit, WithTransactionOptions};
 use gitbutler_oplog::entry::{OperationKind, SnapshotDetails};
 use gix::{ObjectId, refs::FullName};
 use itertools::Itertools;
@@ -124,6 +124,7 @@ pub enum DiscardOutcome {
         commits: NonEmpty<CommitId>,
         /// Rewritten surviving commits, used by callers to retain their selection.
         replaced_commits: BTreeMap<ObjectId, ObjectId>,
+        checkout_conflict_occurred: bool,
     },
     CommittedFiles {
         source: CommitId,
@@ -153,13 +154,20 @@ impl CliOutputHuman for DiscardOutcome {
             }
             DiscardOutcome::Commits {
                 commits,
-                replaced_commits: _,
+                checkout_conflict_occurred,
+                ..
             } => {
                 if commits.len() == 1 {
                     writeln!(out, "Discarded commit {}", theme::Commit(commits.head))?;
                 } else {
                     let commits = commits.iter().map(theme::Commit).join(", ");
                     writeln!(out, "Discarded commits {commits}")?;
+                }
+                if checkout_conflict_occurred {
+                    writeln!(
+                        out,
+                        "A conflict occurred during checkout. Run `but status` for more information."
+                    )?;
                 }
             }
             DiscardOutcome::CommittedFiles {
@@ -221,10 +229,7 @@ impl CliOutput for DiscardOutcome {
                     .map(|branch| branch.shorten().to_string())
                     .collect(),
             },
-            DiscardOutcome::Commits {
-                commits,
-                replaced_commits: _,
-            } => Output::Commits {
+            DiscardOutcome::Commits { commits, .. } => Output::Commits {
                 commits: commits.into_iter().map(Into::into).collect(),
             },
             DiscardOutcome::CommittedFiles {
@@ -447,7 +452,10 @@ pub fn run(
         meta,
         perm,
         SnapshotDetails::new(OperationKind::Discard),
-        DryRun::No,
+        WithTransactionOptions {
+            allow_uncommitted_changes_to_conflict_with_new_head: true,
+            ..Default::default()
+        },
         |mut tx| {
             let outcome = match executable {
                 ExecutableDiscardOperation::Branches { branches, commits } => {
@@ -464,6 +472,7 @@ pub fn run(
                     DiscardOutcome::Commits {
                         commits,
                         replaced_commits: BTreeMap::new(),
+                        checkout_conflict_occurred: false,
                     }
                 }
                 ExecutableDiscardOperation::CommittedFiles {
@@ -500,10 +509,13 @@ pub fn run(
     )?;
 
     if let DiscardOutcome::Commits {
-        replaced_commits, ..
+        replaced_commits,
+        checkout_conflict_occurred,
+        ..
     } = &mut outcome
     {
         *replaced_commits = workspace.replaced_commits;
+        *checkout_conflict_occurred = workspace.checkout_conflict_occurred;
     }
 
     Ok(outcome)

--- a/crates/but/src/command/legacy/move.rs
+++ b/crates/but/src/command/legacy/move.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use bstr::ByteSlice;
 use but_api::json::{ChangeIdString, HexHash};
-use but_core::{DiffSpec, DryRun, RefMetadata, ref_metadata::StackId, sync::RepoExclusive};
+use but_core::{DiffSpec, RefMetadata, ref_metadata::StackId, sync::RepoExclusive};
 use but_ctx::Context;
 use but_rebase::graph_rebase::mutate::RelativeTo;
 use but_transaction::Transaction;
@@ -876,7 +876,7 @@ pub fn run(
         meta,
         perm,
         snapshot_details,
-        DryRun::No,
+        Default::default(),
         |mut tx| {
             let outcome = match move_op {
                 MoveOperation::CommitsRelativeTo(op) => {

--- a/crates/but/src/command/legacy/pick.rs
+++ b/crates/but/src/command/legacy/pick.rs
@@ -1,6 +1,6 @@
 use but_api::json::{ChangeIdString, HexHash};
 use but_core::{
-    DryRun, RefMetadata,
+    RefMetadata,
     ref_metadata::StackId,
     sync::{RepoExclusive, RepoShared},
 };
@@ -249,7 +249,7 @@ pub fn run(
         meta,
         perm,
         snapshot_details,
-        DryRun::No,
+        Default::default(),
         |mut tx| {
             let (new_commits, branch_name_target) = match commit_op {
                 CommitOperation::CommitToNewBranch(CommitToNewBranchOperation { branch_name }) => {

--- a/crates/but/src/command/legacy/reword2.rs
+++ b/crates/but/src/command/legacy/reword2.rs
@@ -3,7 +3,7 @@ use but_api::{
     diff::ComputeLineStats,
     json::{ChangeIdString, HexHash},
 };
-use but_core::{DryRun, RefMetadata, diff::CommitDetails, sync::RepoExclusive};
+use but_core::{RefMetadata, diff::CommitDetails, sync::RepoExclusive};
 use but_ctx::Context;
 use but_error::Code;
 use but_transaction::Transaction;
@@ -473,7 +473,7 @@ fn reword_commit(
         meta,
         perm,
         snapshot_details,
-        DryRun::No,
+        Default::default(),
         |mut tx| {
             let new_commit =
                 tx.reword_commit(target.commit_id, BString::from(new_message).as_ref())?;

--- a/crates/but/src/command/legacy/squash.rs
+++ b/crates/but/src/command/legacy/squash.rs
@@ -1283,7 +1283,7 @@ pub fn run(
                 meta,
                 perm,
                 snapshot_details,
-                DryRun::No,
+                Default::default(),
                 |mut tx| {
                     let new_commit = match op.clone() {
                         TransactionCompatibleOperation::Commits(op) => op.execute(&mut tx)?,
@@ -1362,7 +1362,7 @@ pub fn run(
                 meta,
                 perm,
                 snapshot_details,
-                DryRun::No,
+                Default::default(),
                 |mut tx| {
                     match &op {
                         UncommitOperation::Commits { sources } => {

--- a/crates/but/src/command/legacy/status/tui/app/discard.rs
+++ b/crates/but/src/command/legacy/status/tui/app/discard.rs
@@ -127,6 +127,8 @@ impl App {
                             let DiscardOutcome::Commits {
                                 commits: _,
                                 replaced_commits,
+                                // TODO report checkout conflict if it has occurred
+                                checkout_conflict_occurred: _,
                             } = run_discard(ctx, DiscardOperation::Commits(NonEmpty::new(commit)))?
                             else {
                                 anyhow::bail!("BUG: commit discard returned an unexpected outcome")
@@ -294,6 +296,8 @@ impl App {
                     DiscardOutcome::Commits {
                         commits: _,
                         replaced_commits,
+                        // TODO report checkout conflict if it has occurred
+                        checkout_conflict_occurred: _,
                     } => map_selected_commits(select_after_reload, |commit_id| {
                         replaced_commits
                             .get(&commit_id)

--- a/crates/but/tests/but/command/discard.rs
+++ b/crates/but/tests/but/command/discard.rs
@@ -361,6 +361,135 @@ Hint: run `but help` for all commands
 }
 
 #[test]
+fn discard_resulting_in_workdir_ud_conflict() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
+
+    env.file("commit.txt", "text\n");
+    env.but("commit -b A -m 'discardable commit'")
+        .assert()
+        .success();
+    let commit_id = env.invoke_git("rev-parse refs/heads/A");
+
+    env.file("commit.txt", "would conflict if commit above was deleted\n");
+
+    env.but(format!("discard {commit_id}"))
+        .assert()
+        .success()
+        .stderr_eq("")
+        .stdout_eq(snapbox::str![[r#"
+Discarded commit 1
+A conflict occurred during checkout. Run `but status` for more information.
+
+"#]]);
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄ zz [uncommitted]
+┊    commit.txt {conflicted}
+┊
+┊╭┄ g0 [A]
+┊●   tpm add A
+┊│     tpm:t A A
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+⚠ Uncommitted file conflicts: choose the desired file state, then run `git add -- <path>`.
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    snapbox::assert_data_eq!(
+        env.git_status(),
+        snapbox::str![[r#"
+UD commit.txt
+
+"#]]
+    );
+
+    snapbox::assert_data_eq!(
+        std::fs::read_to_string(env.projects_root().join("commit.txt")).unwrap(),
+        snapbox::str![[r#"
+would conflict if commit above was deleted
+
+"#]]
+    );
+}
+
+#[test]
+fn discard_resulting_in_workdir_uu_conflict() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
+
+    env.file("commit.txt", "first\n");
+    env.but("commit -b A -m 'commit'").assert().success();
+
+    env.file("commit.txt", "second\n");
+    env.but("commit -b A -m 'discardable commit'")
+        .assert()
+        .success();
+    let commit_id = env.invoke_git("rev-parse refs/heads/A");
+
+    env.file("commit.txt", "would conflict if commit above was deleted\n");
+
+    env.but(format!("discard {commit_id}"))
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Discarded commit 1
+A conflict occurred during checkout. Run `but status` for more information.
+
+"#]]);
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄ zz [uncommitted]
+┊    commit.txt {conflicted}
+┊
+┊╭┄ g0 [A]
+┊●   1 commit
+┊│     1:t A commit.txt
+┊●   tpm add A
+┊│     tpm:t A A
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+⚠ Uncommitted file conflicts: choose the desired file state, then run `git add -- <path>`.
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    snapbox::assert_data_eq!(
+        env.git_status(),
+        snapbox::str![[r#"
+UU commit.txt
+
+"#]]
+    );
+
+    // The output depends on whether merge.conflictstyle=diff3 is configured in
+    // gitconfig, so add a wildcard to support both types of output.
+    snapbox::assert_data_eq!(
+        std::fs::read_to_string(env.projects_root().join("commit.txt")).unwrap(),
+        snapbox::str![[r#"
+<<<<<<< ours
+would conflict if commit above was deleted
+...
+=======
+first
+>>>>>>> theirs
+
+"#]]
+    );
+}
+
+#[test]
 fn discard_multiple_commits_outputs_human() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
     env.setup_metadata(&["A"]);

--- a/crates/but/tests/but/command/undo.rs
+++ b/crates/but/tests/but/command/undo.rs
@@ -135,6 +135,44 @@ fn can_undo_but_discard_rename() {
 }
 
 #[test]
+fn can_undo_but_discard_commit() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
+
+    let commit_id = env
+        .open_repo()
+        .rev_parse_single("HEAD^{/add second}")
+        .unwrap()
+        .detach();
+
+    run_mutate_undo_roundtrip_test(&env, |env| {
+        env.but(format!("discard {}", commit_id.to_hex()))
+            .assert()
+            .success();
+    });
+}
+
+#[test]
+fn can_undo_but_discard_commit_that_caused_conflict() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
+
+    env.file("second", "update second");
+
+    let commit_id = env
+        .open_repo()
+        .rev_parse_single("HEAD^{/add second}")
+        .unwrap()
+        .detach();
+
+    run_mutate_undo_roundtrip_test(&env, |env| {
+        env.but(format!("discard {}", commit_id.to_hex()))
+            .assert()
+            .success();
+    });
+}
+
+#[test]
 fn can_undo_unapply() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
     env.setup_metadata(&["A"]);

--- a/packages/but-sdk/src/generated/graph/index.d.ts
+++ b/packages/but-sdk/src/generated/graph/index.d.ts
@@ -3298,6 +3298,11 @@ export type WorkspaceState = {
    * rendered graph projection.
    */
   graphWorkspace: DetailedGraphWorkspace;
+  /**
+   * True if a checkout occurred, and a conflict occurred during that
+   * checkout.
+   */
+  checkoutConflictOccurred: boolean;
 };
 
 /** Same as `but_core::ui::WorktreeChanges`, but with the addition of hunk assignments. */

--- a/packages/but-sdk/src/generated/linear/index.d.ts
+++ b/packages/but-sdk/src/generated/linear/index.d.ts
@@ -3295,6 +3295,11 @@ export type WorkspaceState = {
   replacedCommits: Record<string, string>;
   /** The post-operation workspace view presented to the frontend. */
   headInfo: RefInfo;
+  /**
+   * True if a checkout occurred, and a conflict occurred during that
+   * checkout.
+   */
+  checkoutConflictOccurred: boolean;
 };
 
 /** Same as `but_core::ui::WorktreeChanges`, but with the addition of hunk assignments. */


### PR DESCRIPTION
It's more complicated than I was hoping - there were some things that need to be plumbed, and the plumbing was longer than expected.

If this is too big for reviewers, I could look into doing some refactorings first to make the actual change simpler. I already did some refactoring PRs, but perhaps not enough.

---

The sides of the conflicts will be written to the index.

An earlier version of this commit reverted some of the changes in
https://github.com/gitbutlerapp/gitbutler/commit/9547b84b99f2adb10700e1dfcc80a91944d2456e (revive `but worktree` subcommands, 2026-06-11) (which
changed some tests because at that time, GitButler didn't support
checkout causing workdir-target conflicts) but this commit no longer
does so as allowing workdir-target conflicts is no longer on for all
commands by default, but must be configured individually (I did it
this way because there is no generic way to report to the user that a
conflict has occurred).

This currently only works when discarding commits (not other things).
