### PR TITLE
Show icon-only outline tabs when the panel is narrow

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/Outline.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Outline.module.css
@@ -5,11 +5,19 @@
 }
 
 .top {
+	container-type: inline-size;
 	display: flex;
 	row-gap: 12px;
 	flex-direction: column;
 	padding-inline: var(--panel-padding-inline);
 	padding-block: var(--panel-padding-block);
+}
+
+/* When the panel is too narrow to fit the tab labels, show icons only. */
+@container (max-width: 320px) {
+	.tabLabel {
+		display: none;
+	}
 }
 
 .workspaceControls {

--- a/apps/lite/ui/src/routes/project/$id/workspace/Outline.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Outline.tsx
@@ -391,17 +391,25 @@ export const Outline: FC<{
 					value={[outlineTab]}
 					onValueChange={selectOutlineTab}
 				>
-					<Toggle render={<ToggleStyles />} value={"workspace" satisfies OutlineTab}>
+					<Toggle
+						render={<ToggleStyles />}
+						value={"workspace" satisfies OutlineTab}
+						aria-label="Workspace"
+					>
 						<Icon name="workbench" />
-						Workspace
+						<span className={styles.tabLabel}>Workspace</span>
 					</Toggle>
-					<Toggle render={<ToggleStyles />} value="upstream" disabled>
+					<Toggle render={<ToggleStyles />} value="upstream" disabled aria-label="Upstream">
 						<Icon name="inbox" />
-						Upstream
+						<span className={styles.tabLabel}>Upstream</span>
 					</Toggle>
-					<Toggle render={<ToggleStyles />} value={"branches" satisfies OutlineTab}>
+					<Toggle
+						render={<ToggleStyles />}
+						value={"branches" satisfies OutlineTab}
+						aria-label="Branches"
+					>
 						<Icon name="branch" />
-						Branches
+						<span className={styles.tabLabel}>Branches</span>
 					</Toggle>
 				</ToggleGroup>
 			</div>

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
@@ -502,7 +502,7 @@ const WorkspacePage: FC = () => {
 					<Panel
 						id={"outline-panel" satisfies PanelId}
 						className={styles.panel}
-						minSize={300}
+						minSize={240}
 						defaultSize={500}
 						groupResizeBehavior="preserve-pixel-size"
 					>


### PR DESCRIPTION
The outline tab labels (Workspace / Upstream / Branches) need ~310px, so at the old 300px panel minimum they clipped. The tab bar is now a container query: below 320px of panel content width the labels hide and only the icons remain, with aria-labels keeping the tabs accessible.

With icon-only tabs in place, the outline panel minimum width is lowered from 300px to 240px.