### PR TITLE
Add branch reference deletion to Lite

### DIFF
--- a/apps/lite/ui/src/hotkeys.ts
+++ b/apps/lite/ui/src/hotkeys.ts
@@ -143,6 +143,13 @@ export const workspaceHotkeys = {
 	},
 } satisfies Record<string, HotkeyWithMeta>;
 
+export const branchesHotkeys = {
+	deleteBranchRef: {
+		hotkey: globalThis.window.lite.platform === "darwin" ? "Mod+Backspace" : "Delete",
+		meta: { group: "Branch", name: "Delete branch reference" },
+	},
+} satisfies Record<string, HotkeyWithMeta>;
+
 export const outlineHotkeys = {
 	checkCommit: {
 		hotkey: "Space",

--- a/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.tsx
@@ -1,8 +1,8 @@
 import rowStyles from "./Row.module.css";
 import { Scroller } from "#ui/components/Scroller.tsx";
-import { useApply } from "#ui/api/mutations.ts";
+import { useApply, useBranchRemove } from "#ui/api/mutations.ts";
 import { branchDetailsQueryOptions } from "#ui/api/queries.ts";
-import { encodeBytes } from "#ui/api/bytes.ts";
+import { decodeBytes, encodeBytes } from "#ui/api/bytes.ts";
 import { assert } from "#ui/assert.ts";
 import {
 	branchDetailsParams,
@@ -16,8 +16,10 @@ import { classes } from "#ui/components/classes.ts";
 import { FieldControlStyles } from "#ui/components/Field.tsx";
 import { GraphSegment, type GraphSegmentStatus } from "#ui/components/GraphSegment.tsx";
 import { Icon } from "#ui/components/Icon.tsx";
+import { branchesHotkeys, toElectronAccelerator } from "#ui/hotkeys.ts";
 import {
 	nativeMenuItem,
+	nativeMenuSeparator,
 	showNativeContextMenu,
 	showNativeMenuFromTrigger,
 	type NativeMenuItem,
@@ -41,6 +43,7 @@ import type { Commit, ListedBranch } from "@gitbutler/but-sdk";
 import { Toolbar } from "@base-ui/react";
 import { useMergedRefs } from "@base-ui/utils/useMergedRefs";
 import { useQuery } from "@tanstack/react-query";
+import { useHotkey } from "@tanstack/react-hotkeys";
 import {
 	type ComponentProps,
 	type FC,
@@ -153,6 +156,7 @@ const BranchItem: FC<{ projectId: string; branch: ListedBranch }> = ({ projectId
 	const review = branch.review;
 
 	const { isPending: isApplyPending, mutate: apply } = useApply();
+	const { isPending: isBranchRemovePending, mutate: branchRemove } = useBranchRemove();
 
 	const toggleUnfolded = () => {
 		dispatch(projectSlice.actions.toggleBranchUnfolded({ projectId, branchRef }));
@@ -189,6 +193,13 @@ const BranchItem: FC<{ projectId: string; branch: ListedBranch }> = ({ projectId
 			label: "Apply to Workspace",
 			enabled: !isApplyPending,
 			onSelect: applyBranch,
+		}),
+		nativeMenuSeparator,
+		nativeMenuItem({
+			label: "Delete Branch Reference",
+			enabled: branch.hasLocal && !isBranchRemovePending,
+			accelerator: toElectronAccelerator(branchesHotkeys.deleteBranchRef.hotkey),
+			onSelect: () => branchRemove({ projectId, refName: encodeBytes(branchRef) }),
 		}),
 	];
 
@@ -337,6 +348,12 @@ export const BranchesList: FC<
 
 	const headingId = useId();
 	const hotkeysRef = useRef<HTMLDivElement>(null);
+	const { isPending: isBranchRemovePending, mutate: branchRemove } = useBranchRemove();
+	const selectedBranchIsLocal =
+		selection?._tag === "Branch" && decodeBytes(selection.branchRef).startsWith("refs/heads/");
+	const removeBranch = (branchRef: Array<number>) => {
+		branchRemove({ projectId, refName: branchRef });
+	};
 
 	useNavigationIndexHotkeys({
 		navigationIndex,
@@ -349,6 +366,18 @@ export const BranchesList: FC<
 		ref: hotkeysRef,
 		getKey: operandIdentityKey,
 	});
+
+	useHotkey(
+		branchesHotkeys.deleteBranchRef.hotkey,
+		() => {
+			if (selection?._tag === "Branch") removeBranch(selection.branchRef);
+		},
+		{
+			enabled: selectedBranchIsLocal && !isBranchRemovePending,
+			meta: branchesHotkeys.deleteBranchRef.meta,
+			target: hotkeysRef,
+		},
+	);
 
 	const showFilterMenu = (trigger: HTMLElement) => {
 		void showNativeMenuFromTrigger(

--- a/crates/but-api/src/branch.rs
+++ b/crates/but-api/src/branch.rs
@@ -1043,8 +1043,9 @@ pub fn branch_remove(
     branch_remove_with_perm(ctx, ref_name, guard.write_permission())
 }
 
-/// Remove the local branch `ref_name` under caller-held exclusive repository
-/// access and record an oplog snapshot on success.
+/// Remove the local branch `ref_name`, whether or not it is part of the current
+/// workspace projection, under caller-held exclusive repository access and
+/// record an oplog snapshot on success.
 ///
 /// See [`branch_remove()`] for the checked-out-reference behaviour and
 /// [`but_workspace::branch::remove_reference()`] for the lower-level deletion.
@@ -1053,6 +1054,19 @@ pub fn branch_remove_with_perm(
     ref_name: gix::refs::FullName,
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<BranchRemoveResult> {
+    if ref_name.category() != Some(gix::refs::Category::LocalBranch) {
+        bail!(
+            "Can only delete local branches under refs/heads, got '{}'",
+            ref_name.as_bstr()
+        );
+    }
+    if but_branches::is_technical_branch_name(ref_name.shorten()) {
+        bail!(
+            "Cannot delete GitButler technical branch '{}'",
+            ref_name.shorten()
+        );
+    }
+
     let maybe_oplog_entry = but_oplog::UnmaterializedOplogSnapshot::from_details_with_perm(
         ctx,
         SnapshotDetails::new(OperationKind::DeleteBranch)
@@ -1104,15 +1118,35 @@ pub fn branch_remove_with_perm(
         }
     };
 
-    let changed = if let Some(below) = move_head_to {
-        // Land `HEAD` on the reference underneath, then delete the now-detached
-        // tip and its metadata directly: after the checkout the tip sits above
-        // the entrypoint and is no longer part of the downward projection, so
-        // `remove_reference` would not find it there.
+    let moved_head = move_head_to.is_some();
+    if let Some(below) = move_head_to {
+        // Land `HEAD` on the reference underneath. The old tip now sits above
+        // the entrypoint and is no longer part of the downward projection.
         branch_checkout_with_perm(ctx, below, perm)?;
+    }
 
-        let mut meta = ctx.meta()?;
-        let (repo, mut ws, _db) = ctx.workspace_mut_and_db_with_perm(perm)?;
+    let mut meta = ctx.meta()?;
+    let (repo, mut ws, _db) = ctx.workspace_mut_and_db_with_perm(perm)?;
+    let new_ws = if moved_head {
+        None
+    } else {
+        but_workspace::branch::remove_reference(
+            ref_name.as_ref(),
+            &repo,
+            &ws,
+            &mut meta,
+            but_workspace::branch::remove_reference::Options {
+                avoid_anonymous_stacks: true,
+                keep_metadata: false,
+            },
+        )?
+    };
+    let changed = if let Some(new_ws) = new_ws {
+        *ws = new_ws;
+        true
+    } else {
+        // Standalone branches are intentionally absent from the workspace
+        // projection, as is a checked-out tip after moving HEAD below it.
         let deleted_ref = if let Some(reference) = repo.try_find_reference(ref_name.as_ref())? {
             let safe_delete = but_core::branch::SafeDelete::new(&repo)?;
             let out = safe_delete.delete_reference(&reference)?;
@@ -1136,25 +1170,10 @@ pub fn branch_remove_with_perm(
         } else {
             false
         }
-    } else {
-        let mut meta = ctx.meta()?;
-        let (repo, mut ws, _db) = ctx.workspace_mut_and_db_with_perm(perm)?;
-        let new_ws = but_workspace::branch::remove_reference(
-            ref_name.as_ref(),
-            &repo,
-            &ws,
-            &mut meta,
-            but_workspace::branch::remove_reference::Options {
-                avoid_anonymous_stacks: true,
-                keep_metadata: false,
-            },
-        )?;
-        let changed = new_ws.is_some();
-        if let Some(new_ws) = new_ws {
-            *ws = new_ws;
-        }
-        changed
     };
+    drop(ws);
+    drop(repo);
+    drop(meta);
 
     if changed && let Some(snapshot) = maybe_oplog_entry {
         snapshot.commit(ctx, perm).ok();

--- a/crates/but-api/tests/api/branch_remove.rs
+++ b/crates/but-api/tests/api/branch_remove.rs
@@ -2,8 +2,77 @@ use but_core::RefMetadata;
 
 use crate::support::{
     assert_workspace_ref, checkout_branch_in_linked_worktree, create_empty_branch_above,
-    repo_with_feature_branch,
+    repo_with_feature_branch, set_project_target_to_feature,
 };
+
+#[test]
+fn branch_remove_rejects_non_local_reference() -> anyhow::Result<()> {
+    let (repo, _tmp) = repo_with_feature_branch()?;
+    let mut ctx = but_ctx::Context::from_repo_for_testing(repo)?.with_memory_app_cache();
+    let remote = gix::refs::FullName::try_from("refs/remotes/origin/main")?;
+
+    let err = but_api::branch::branch_remove(&mut ctx, remote.clone())
+        .expect_err("remote-tracking references cannot be deleted as local branches");
+    assert!(
+        err.to_string().contains("local branches"),
+        "unexpected error: {err}"
+    );
+
+    let repo = ctx.repo.get()?;
+    assert!(
+        repo.try_find_reference(remote.as_ref())?.is_some(),
+        "the rejected remote-tracking reference remains"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn branch_remove_rejects_gitbutler_technical_reference() -> anyhow::Result<()> {
+    let (repo, _tmp) = repo_with_feature_branch()?;
+    let technical = gix::refs::FullName::try_from("refs/heads/gitbutler/target")?;
+    let head_id = repo.head_id()?.detach();
+    repo.reference(
+        technical.as_ref(),
+        head_id,
+        gix::refs::transaction::PreviousValue::MustNotExist,
+        "create technical branch for test",
+    )?;
+    let mut ctx = but_ctx::Context::from_repo_for_testing(repo)?.with_memory_app_cache();
+
+    let err = but_api::branch::branch_remove(&mut ctx, technical.clone())
+        .expect_err("GitButler technical references cannot be deleted as user branches");
+    assert!(
+        err.to_string().contains("technical branch"),
+        "unexpected error: {err}"
+    );
+
+    let repo = ctx.repo.get()?;
+    assert!(
+        repo.try_find_reference(technical.as_ref())?.is_some(),
+        "the rejected technical reference remains"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn branch_remove_deletes_standalone_branch() -> anyhow::Result<()> {
+    let (repo, _tmp) = repo_with_feature_branch()?;
+    set_project_target_to_feature(&repo)?;
+    let mut ctx = but_ctx::Context::from_repo_for_testing(repo)?.with_memory_app_cache();
+    let feature = gix::refs::FullName::try_from("refs/heads/feature")?;
+
+    but_api::branch::branch_remove(&mut ctx, feature.clone())?;
+
+    let repo = ctx.repo.get()?;
+    assert!(
+        repo.try_find_reference(feature.as_ref())?.is_none(),
+        "the standalone branch reference was removed"
+    );
+
+    Ok(())
+}
 
 #[test]
 fn branch_remove_deletes_middle_empty_branch_and_keeps_head() -> anyhow::Result<()> {

--- a/crates/but-branches/src/lib.rs
+++ b/crates/but-branches/src/lib.rs
@@ -10,7 +10,7 @@ mod walk;
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use bstr::{BString, ByteSlice};
+use bstr::{BStr, BString, ByteSlice};
 use but_core::{RefMetadata, WORKSPACE_REF_NAME};
 use but_graph::{Graph, SegmentIndex, Workspace};
 use gix::{
@@ -595,8 +595,9 @@ fn listed_stack(status: ListedStackStatus, branches: Vec<ListedBranch>) -> Liste
     }
 }
 
-/// GitButler-internal branches that are never interesting to users.
-fn is_technical_branch(identity: &BString) -> bool {
+/// Return `true` if `identity` is a GitButler-internal branch name that must not
+/// be shown or treated as a user branch.
+pub fn is_technical_branch_name(identity: &BStr) -> bool {
     const TECHNICAL_IDENTITIES: &[&[u8]] = &[
         b"HEAD",
         b"gitbutler/edit",
@@ -637,7 +638,7 @@ fn enumerate_branch_refs(
             }
             _ => continue,
         };
-        if is_technical_branch(&identity) {
+        if is_technical_branch_name(identity.as_bstr()) {
             continue;
         }
         let Ok(tip) = reference.into_fully_peeled_id() else {


### PR DESCRIPTION
Add a local branch deletion action to the Lite Branches tab, including the native keyboard shortcut. Extend the branch removal path to handle standalone references while keeping deletion restricted to local refs.