### PR TITLE
feat(transaction): support cherry-picking commits

### DIFF
--- a/crates/but-transaction/src/lib.rs
+++ b/crates/but-transaction/src/lib.rs
@@ -638,6 +638,41 @@ where
         })
     }
 
+    /// Cherry-pick commits into the transaction's workspace graph.
+    ///
+    /// Source and target commit IDs are automatically mapped through changes made earlier in the
+    /// transaction. The returned identifiers refer to the newly created commits and can be passed
+    /// to subsequent transaction operations.
+    pub fn cherry_pick_commits(
+        &mut self,
+        source_commit_ids: impl IntoIterator<Item = ObjectId>,
+        relative_to: RelativeTo,
+        side: InsertSide,
+    ) -> anyhow::Result<Vec<CommitIdentifiers>> {
+        self.rebase(|editor, commit_mappings, _| {
+            let source_commit_ids = source_commit_ids
+                .into_iter()
+                .map(|commit| commit_mappings.map(commit));
+            let relative_to = match relative_to {
+                RelativeTo::Commit(object_id) => RelativeTo::Commit(commit_mappings.map(object_id)),
+                RelativeTo::Reference(full_name) => RelativeTo::Reference(full_name),
+            };
+
+            let (rebase, inserted_selectors) = but_workspace::commit::cherry_pick_commits(
+                editor,
+                source_commit_ids,
+                relative_to,
+                side,
+            )?;
+            let new_commits = inserted_selectors
+                .into_iter()
+                .map(|selector| rebase.lookup_commit(selector))
+                .collect::<anyhow::Result<Vec<_>>>()?;
+
+            Ok((new_commits, rebase))
+        })
+    }
+
     pub fn move_commits(
         &mut self,
         subject_commit_ids: impl IntoIterator<Item = ObjectId>,

--- a/crates/but-transaction/src/tests.rs
+++ b/crates/but-transaction/src/tests.rs
@@ -369,6 +369,58 @@ fn create_reference_then_commit_below_anchor_keeps_commit_in_workspace() {
 }
 
 #[test]
+fn cherry_pick_then_reword_copied_commit() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
+
+    let [three, one] = find_commits(&env, ["1e25c58", "dbdbcea"]);
+
+    let repo = but_testsupport::open_repo(env.projects_root()).unwrap();
+    let mut ctx = Context::from_repo_for_testing(repo)
+        .map(Context::with_memory_app_cache)
+        .unwrap();
+
+    let mut meta = ctx.meta().unwrap();
+    let snapshot_details = SnapshotDetails::new(OperationKind::CherryPick);
+
+    let outcome = with_transaction(
+        &mut ctx,
+        &mut meta,
+        snapshot_details,
+        DryRun::No,
+        |mut tx| {
+            let copied =
+                tx.cherry_pick_commits([one], RelativeTo::Commit(three), InsertSide::Above)?;
+            let reworded = tx.reword_commit(copied[0].id, "copied commit".into())?;
+
+            Ok(DynamicOutcome::<_, ()>::Commit(reworded))
+        },
+    )
+    .unwrap();
+
+    let DynamicOutcome::Commit((reworded, _workspace)) = outcome else {
+        panic!("transaction should commit");
+    };
+    let branch = FullName::try_from("refs/heads/branch").unwrap();
+    assert_eq!(
+        Some(reworded.id),
+        ref_target(&env, branch.as_ref()),
+        "reworded cherry-picked commit should become the branch tip"
+    );
+    assert_ne!(reworded.id, one, "cherry-pick should create a new commit");
+    assert_eq!(
+        env.open_repo()
+            .find_commit(reworded.id)
+            .unwrap()
+            .message_raw()
+            .unwrap(),
+        "copied commit",
+        "returned identifier should refer to the reworded copy"
+    );
+    assert_num_snapshots(&ctx, 1);
+}
+
+#[test]
 fn move_commits_then_commit_relative_to_moved_commit() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
     env.setup_metadata(&["A"]);


### PR DESCRIPTION
I'm gonna re-write `but pick` which will require transaction support.