### PR TITLE
revert code from PR #15096

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -756,8 +756,7 @@ const DiffContents: FC<{
 				__devOnlyValidateItemHeights: false,
 				onPostRender: handleHunkPostRender,
 				itemMetrics: {
-					diffHeaderHeight: 37,
-					paddingTop: 1,
+					diffHeaderHeight: 38,
 					paddingBottom: 9,
 				},
 				unsafeCSS: `


### PR DESCRIPTION
I revert it since in this [PR](https://github.com/gitbutlerapp/gitbutler/pull/15096) important part was removed:

```
&:first-child {
	border-top: none;
}

```

the goal was to remove double border.

<img width="919" height="246" alt="5D3B76F1-6B89-4B05-8CC5-B32261F06420" src="https://github.com/user-attachments/assets/5aa487b5-ae1a-478b-b283-fddf9881859c" />

I'll address in the next PR
