### PR TITLE
Offer agent skill setup at the end of installation

### DIFF
--- a/crates/but-installer/src/lib.rs
+++ b/crates/but-installer/src/lib.rs
@@ -71,7 +71,38 @@ pub fn run_installation_with_version(
 /// changes on installation failure.
 pub fn run_installation() -> Result<()> {
     let config = InstallerConfig::new()?;
-    run_installation_impl(config, ui::is_connected_to_terminal())
+    let interactive = ui::is_connected_to_terminal();
+    let but_path = but_binary_path(&config.home_dir);
+    run_installation_impl(config, interactive)?;
+    if supports_agent_setup(&but_path) {
+        if interactive {
+            ui::println_empty();
+            offer_agent_skill_setup(&but_path);
+        } else {
+            info("To install the GitButler skill for your coding agent, run: but agent setup");
+        }
+    }
+    Ok(())
+}
+
+/// Returns true if the installed `but` has the built-in `agent setup` command.
+///
+/// Detected by `but --help` listing an `agent` subcommand. Do not probe by
+/// running `but agent ...` itself: pinned older versions lack the command and
+/// some of them would dispatch it to an unrelated `but-agent` executable on
+/// PATH, whereas `--help` is built in on every version.
+fn supports_agent_setup(but_path: &std::path::Path) -> bool {
+    std::process::Command::new(but_path)
+        .arg("--help")
+        .stdin(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .output()
+        .is_ok_and(|out| {
+            out.status.success()
+                && String::from_utf8_lossy(&out.stdout)
+                    .lines()
+                    .any(|line| line.trim_start().starts_with("agent "))
+        })
 }
 
 fn run_installation_impl(config: InstallerConfig, interactive: bool) -> Result<()> {
@@ -153,4 +184,33 @@ fn run_installation_impl(config: InstallerConfig, interactive: bool) -> Result<(
     }
 
     Ok(())
+}
+
+/// Offers to run `but agent setup` after a successful interactive installation.
+///
+/// Best-effort: the installation has already succeeded at this point, so
+/// declining, cancelling the wizard, or any failure never fails the install.
+fn offer_agent_skill_setup(but_path: &std::path::Path) {
+    if !ui::prompt_for_confirmation_default_yes(
+        "Install the GitButler skill for your coding agent (Claude Code, Codex, ...)?",
+    ) {
+        info("You can install it later with: but agent setup");
+        return;
+    }
+
+    // The setup wizard requires a terminal on stdin. Under `curl | sh` this
+    // process inherits curl's pipe as stdin, so connect the child directly to
+    // the controlling terminal instead.
+    let child_stdin = std::fs::File::open("/dev/tty")
+        .map(std::process::Stdio::from)
+        .unwrap_or_else(|_| std::process::Stdio::inherit());
+
+    let status = std::process::Command::new(but_path)
+        .args(["agent", "setup"])
+        .stdin(child_stdin)
+        .status();
+
+    if !status.map(|s| s.success()).unwrap_or(false) {
+        info("Agent setup did not complete. You can run it again with: but agent setup");
+    }
 }

--- a/crates/but-installer/src/ui.rs
+++ b/crates/but-installer/src/ui.rs
@@ -88,20 +88,44 @@ pub fn println_empty() {
 /// a pipe (e.g., during `curl | sh` installation). Falls back to stdin if
 /// `/dev/tty` is not available.
 pub fn prompt_for_confirmation(prompt: &str) -> bool {
+    confirm(prompt, false)
+}
+
+/// Prompts a user for a [Y/n] style confirmation where yes is the default.
+///
+/// Returns true if the user enters "y", "yes", or just presses Enter; false
+/// otherwise. EOF (no terminal user to answer) declines.
+///
+/// Reads from `/dev/tty` when available so that prompts work even when stdin is
+/// a pipe (e.g., during `curl | sh` installation). Falls back to stdin if
+/// `/dev/tty` is not available.
+pub fn prompt_for_confirmation_default_yes(prompt: &str) -> bool {
+    confirm(prompt, true)
+}
+
+fn confirm(prompt: &str, default_yes: bool) -> bool {
     print(prompt);
-    print(" [y/N] ");
+    print(if default_yes { " [Y/n] " } else { " [y/N] " });
 
     let mut response = String::new();
-    if let Some(tty) = open_tty() {
-        io::BufReader::new(tty)
-            .read_line(&mut response)
-            .unwrap_or_default();
+    let read = if let Some(tty) = open_tty() {
+        io::BufReader::new(tty).read_line(&mut response)
     } else {
-        stdin().read_line(&mut response).unwrap_or_default();
+        stdin().read_line(&mut response)
+    };
+    // A zero-byte read means EOF: there is no user who can answer, so never
+    // assume consent — only an actual empty line accepts the default.
+    if !matches!(read, Ok(n) if n > 0) {
+        println_empty();
+        return false;
     }
-    response = response.trim().to_lowercase();
+    let response = response.trim().to_lowercase();
 
-    response == "yes" || response == "y"
+    if response.is_empty() {
+        default_yes
+    } else {
+        response == "yes" || response == "y"
+    }
 }
 
 /// Checks if there is a terminal to run interactive prompts on.


### PR DESCRIPTION
At the end of a successful interactive install (`curl | sh` or running the installer directly in a terminal), offer to run `but agent setup` with yes as the default:

```
Install the GitButler skill for your coding agent (Claude Code, Codex, ...)? [Y/n]
```

Headless installs (CI, no tty) print a hint to run `but agent setup` later instead of prompting.

Key decisions:
- The wizard is launched with stdin connected to `/dev/tty`, since under `curl | sh` the installer inherits curl's pipe as stdin and `but agent setup` requires a terminal on stdin.
- The offer (and the headless hint) are gated on probing `but agent setup --print` for the managed-block marker in its output. Pinned older versions lack the subcommand and would dispatch `agent` to an unrelated `but-agent` executable on PATH, so the exit code alone proves nothing.
- EOF at the prompt declines instead of accepting the default, so a dead pty can never launch the wizard (which would hang on an EOF'd terminal).
- Everything after the success banner is best-effort: declining, cancelling the wizard, or a failing setup never fails the installation. `but update` calls `run_installation_with_version(_, false)` and is unaffected — the shared install path is untouched.

The installer binary ships to releases.gitbutler.com on merge to master, independent of app releases.