### PR TITLE
Fix agent setup wizard hanging when launched from the installer

### DIFF
--- a/crates/but-installer/src/lib.rs
+++ b/crates/but-installer/src/lib.rs
@@ -199,11 +199,19 @@ fn offer_agent_skill_setup(but_path: &std::path::Path) {
     }
 
     // The setup wizard requires a terminal on stdin. Under `curl | sh` this
-    // process inherits curl's pipe as stdin, so connect the child directly to
-    // the controlling terminal instead.
-    let child_stdin = std::fs::File::open("/dev/tty")
-        .map(std::process::Stdio::from)
-        .unwrap_or_else(|_| std::process::Stdio::inherit());
+    // process inherits curl's pipe as stdin, so give the child a duplicate of
+    // our stdout instead — in interactive mode that is the terminal device,
+    // opened read-write by the terminal emulator. Deliberately not an opened
+    // `/dev/tty`: on macOS, kqueue cannot poll that alias device, and the
+    // wizard's event loop would hang before reading a single key.
+    let child_stdin = {
+        use std::os::fd::AsFd;
+        std::io::stdout()
+            .as_fd()
+            .try_clone_to_owned()
+            .map(std::process::Stdio::from)
+            .unwrap_or_else(|_| std::process::Stdio::inherit())
+    };
 
     let status = std::process::Command::new(but_path)
         .args(["agent", "setup"])


### PR DESCRIPTION
Follow-up to #15100. Accepting the new post-install offer left the `but agent setup` wizard frozen after its step header: no list, no key handling, Ctrl-C dead.

Root cause: the installer passed an opened `/dev/tty` as the wizard's stdin. On macOS, kqueue cannot poll the `/dev/tty` alias device (only concrete `/dev/ttysNNN` slaves), so crossterm's mio-based event loop never saw the terminal's cursor-position reply — ratatui's inline viewport setup blocked forever before the first draw, and with raw mode already enabled Ctrl-C arrived as an unread key byte instead of a signal.

Fix: hand the child a duplicate of the installer's stdout. In interactive mode stdout is the terminal device itself, opened read-write by the terminal emulator, which kqueue polls fine.

Verified end-to-end with an expect harness (pty answering cursor-position queries): the old fd shape reproduces the exact hang with a stack sample pinning it in `compute_inline_size → get_cursor_position`; the new shape runs the real installer with a sandbox `HOME` through download, install, the offer prompt, and a fully interactive wizard.