### PR TITLE
Render diffs for uncommitted files faster

### DIFF
--- a/crates/but/src/args/atoms/cli_id.rs
+++ b/crates/but/src/args/atoms/cli_id.rs
@@ -5,7 +5,7 @@ use crate::{
     CliError, CliId, CliResult, IdMap,
     args::atoms::BranchArg,
     bad_input,
-    id::{CommitId, CommitIdRef, CommittedFileId, UncommittedHunkOrFile},
+    id::{CommitId, CommitIdRef, CommittedFileId, IdAndHunk, UncommittedHunkOrFile, WorktreeHunk},
     theme,
 };
 
@@ -88,11 +88,16 @@ impl CliIdArg {
             CliId::UncommittedHunkOrFile(uncommitted) => {
                 ResolvedCliIdArg::UncommittedHunkOrFile(Box::new(uncommitted))
             }
-            CliId::PathPrefix { .. } => ResolvedCliIdArg::PathPrefix,
-            CliId::CommittedFile {
-                committed_file,
-                id: _,
-            } => ResolvedCliIdArg::CommittedFile(committed_file),
+            CliId::PathPrefix {
+                id,
+                hunk_assignments,
+            } => ResolvedCliIdArg::PathPrefix {
+                id,
+                hunks: hunk_assignments,
+            },
+            CliId::CommittedFile { committed_file, .. } => {
+                ResolvedCliIdArg::CommittedFile(committed_file)
+            }
             CliId::Uncommitted { .. } => ResolvedCliIdArg::Uncommitted,
             CliId::Stack { .. } => ResolvedCliIdArg::Stack,
         }))
@@ -202,8 +207,11 @@ impl CliIdArg {
                 hunk_assignments
                     .into_iter()
                     .map(|(id, assignment)| UncommittedHunkOrFile {
-                        id,
-                        hunk_assignments: NonEmpty::new(assignment),
+                        id: id.clone(),
+                        hunk_assignments: NonEmpty::new(IdAndHunk {
+                            id,
+                            hunk: assignment,
+                        }),
                         // In a world without staging, all these hunk assignments should be turned
                         // into "entire file" assignments for every file under the given PathPrefix.
                         // However, currently, already assigned changes are not resolved by
@@ -415,9 +423,10 @@ pub enum ResolvedCliIdArg {
     UncommittedHunkOrFile(Box<UncommittedHunkOrFile>),
     CommittedFile(CommittedFileId),
     Uncommitted,
-    // These have no data because we don't have any commands that use them. So just add data if you
-    // have a use case
-    PathPrefix,
+    PathPrefix {
+        id: String,
+        hunks: NonEmpty<(String, WorktreeHunk)>,
+    },
     Stack,
 }
 
@@ -438,7 +447,7 @@ impl ResolvedCliIdArg {
     pub fn kind_for_humans(&self) -> &'static str {
         match self {
             ResolvedCliIdArg::UncommittedHunkOrFile { .. } => "an uncommitted file or hunk",
-            ResolvedCliIdArg::PathPrefix => "a path prefix",
+            ResolvedCliIdArg::PathPrefix { .. } => "a path prefix",
             ResolvedCliIdArg::CommittedFile { .. } => "a committed file",
             ResolvedCliIdArg::Branch { .. } => "a branch",
             ResolvedCliIdArg::Commit { .. } => "a commit",
@@ -458,7 +467,9 @@ impl ResolvedCliIdArg {
             ResolvedCliIdArg::CommittedFile(committed_file) => {
                 ResolvedCliIdArgRef::CommittedFile(committed_file)
             }
-            ResolvedCliIdArg::PathPrefix => ResolvedCliIdArgRef::PathPrefix,
+            ResolvedCliIdArg::PathPrefix { id, hunks } => {
+                ResolvedCliIdArgRef::PathPrefix { id, hunks }
+            }
             ResolvedCliIdArg::Uncommitted => ResolvedCliIdArgRef::Uncommitted,
             ResolvedCliIdArg::Stack => ResolvedCliIdArgRef::Stack,
         }
@@ -471,8 +482,8 @@ impl std::fmt::Display for ResolvedCliIdArg {
             ResolvedCliIdArg::Commit(commit) => theme::Commit(commit.as_ref()).fmt(f),
             ResolvedCliIdArg::Branch(inner) => inner.fmt(f),
             ResolvedCliIdArg::UncommittedHunkOrFile(..) => f.write_str("uncommitted file or hunk"),
-            ResolvedCliIdArg::PathPrefix => f.write_str("path"),
-            ResolvedCliIdArg::CommittedFile { .. } => f.write_str("committed file"),
+            ResolvedCliIdArg::PathPrefix { .. } => f.write_str("path"),
+            ResolvedCliIdArg::CommittedFile(..) => f.write_str("committed file"),
             ResolvedCliIdArg::Uncommitted => f.write_str("uncommitted changes"),
             ResolvedCliIdArg::Stack => f.write_str("stack"),
         }
@@ -487,9 +498,10 @@ pub enum ResolvedCliIdArgRef<'a> {
     Branch(&'a str),
     UncommittedHunkOrFile(&'a UncommittedHunkOrFile),
     CommittedFile(&'a CommittedFileId),
-    // These have no data because we don't have any commands that use them. So just add data if you
-    // have a use case
-    PathPrefix,
+    PathPrefix {
+        id: &'a str,
+        hunks: &'a NonEmpty<(String, WorktreeHunk)>,
+    },
     Uncommitted,
     Stack,
 }

--- a/crates/but/src/args/atoms/cli_id.rs
+++ b/crates/but/src/args/atoms/cli_id.rs
@@ -5,7 +5,7 @@ use crate::{
     CliError, CliId, CliResult, IdMap,
     args::atoms::BranchArg,
     bad_input,
-    id::{CommitId, CommitIdRef, CommittedFileId, IdAndHunk, UncommittedHunkOrFile, WorktreeHunk},
+    id::{CommitId, CommitIdRef, CommittedFileId, IdAndHunk, UncommittedHunkOrFile},
     theme,
 };
 
@@ -206,12 +206,9 @@ impl CliIdArg {
             } => Ok(Some(
                 hunk_assignments
                     .into_iter()
-                    .map(|(id, assignment)| UncommittedHunkOrFile {
-                        id: id.clone(),
-                        hunk_assignments: NonEmpty::new(IdAndHunk {
-                            id,
-                            hunk: assignment,
-                        }),
+                    .map(|id_and_hunk| UncommittedHunkOrFile {
+                        id: id_and_hunk.id.clone(),
+                        hunk_assignments: NonEmpty::new(id_and_hunk),
                         // In a world without staging, all these hunk assignments should be turned
                         // into "entire file" assignments for every file under the given PathPrefix.
                         // However, currently, already assigned changes are not resolved by
@@ -425,7 +422,7 @@ pub enum ResolvedCliIdArg {
     Uncommitted,
     PathPrefix {
         id: String,
-        hunks: NonEmpty<(String, WorktreeHunk)>,
+        hunks: NonEmpty<IdAndHunk>,
     },
     Stack,
 }
@@ -500,7 +497,7 @@ pub enum ResolvedCliIdArgRef<'a> {
     CommittedFile(&'a CommittedFileId),
     PathPrefix {
         id: &'a str,
-        hunks: &'a NonEmpty<(String, WorktreeHunk)>,
+        hunks: &'a NonEmpty<IdAndHunk>,
     },
     Uncommitted,
     Stack,

--- a/crates/but/src/command/expand.rs
+++ b/crates/but/src/command/expand.rs
@@ -141,15 +141,21 @@ fn resources_from_cli_id(cli_id: CliId) -> Vec<Resource> {
         }],
         CliId::UncommittedHunkOrFile(uncommitted) if uncommitted.is_entire_file => {
             vec![Resource::UncommittedFile {
-                path: uncommitted.hunk_assignments.first().path_bytes.to_string(),
+                path: uncommitted
+                    .hunk_assignments
+                    .first()
+                    .hunk
+                    .path_bytes
+                    .to_string(),
             }]
         }
         CliId::UncommittedHunkOrFile(uncommitted) => uncommitted
             .hunk_assignments
             .into_iter()
             .map(|assignment| Resource::UncommittedHunk {
-                path: assignment.path_bytes.to_string(),
+                path: assignment.hunk.path_bytes.to_string(),
                 hunk_header: assignment
+                    .hunk
                     .hunk_header
                     .map(format_hunk_header)
                     .unwrap_or_else(|| "<no hunk header>".to_string()),

--- a/crates/but/src/command/legacy/absorb.rs
+++ b/crates/but/src/command/legacy/absorb.rs
@@ -80,7 +80,7 @@ pub(crate) fn handle(
                 // Absorb this particular file
                 AbsorptionTarget::HunkAssignments {
                     assignments: hunk_assignments
-                        .map(|hunk| hunk.into_hunk_assignment_ignoring_stack_assignments())
+                        .map(|hunk| hunk.hunk.into_hunk_assignment_ignoring_stack_assignments())
                         .into(),
                 }
             }

--- a/crates/but/src/command/legacy/diff/show.rs
+++ b/crates/but/src/command/legacy/diff/show.rs
@@ -34,9 +34,9 @@ pub(crate) fn worktree(
                 Some(Filter::UncommittedArea) => true,
                 Some(Filter::Uncommitted(id)) => {
                     if id.is_entire_file {
-                        a.path_bytes == id.hunk_assignments.first().path_bytes
+                        a.path_bytes == id.hunk_assignments.first().hunk.path_bytes
                     } else {
-                        a.eq(id.hunk_assignments.first())
+                        a.eq(&id.hunk_assignments.first().hunk)
                     }
                 }
             }

--- a/crates/but/src/command/legacy/diff/show.rs
+++ b/crates/but/src/command/legacy/diff/show.rs
@@ -9,7 +9,7 @@ use super::{
 };
 use crate::{
     IdMap,
-    id::{UncommittedHunkOrFile, WorktreeHunk},
+    id::{IdAndHunk, UncommittedHunkOrFile, WorktreeHunk},
     utils::OutputChannel,
 };
 
@@ -47,12 +47,12 @@ pub(crate) fn worktree(
 }
 
 pub(crate) fn hunk_assignments<'a>(
-    hunk_assignments: impl IntoIterator<Item = &'a (String, WorktreeHunk)>,
+    hunk_assignments: impl IntoIterator<Item = &'a IdAndHunk>,
     out: &mut OutputChannel,
 ) -> anyhow::Result<()> {
     let short_id_assignment_pairs: Vec<(&str, &WorktreeHunk)> = hunk_assignments
         .into_iter()
-        .map(|(short_id, hunk_assignment)| (short_id.as_str(), hunk_assignment))
+        .map(|id_and_hunk| (id_and_hunk.id.as_str(), &id_and_hunk.hunk))
         .collect();
     print_short_id_assignment_pairs(short_id_assignment_pairs, out)
 }

--- a/crates/but/src/command/legacy/diff2.rs
+++ b/crates/but/src/command/legacy/diff2.rs
@@ -82,7 +82,6 @@ impl CliOutputHuman for DiffOutcome<'_> {
             DiffOperation::UncommittedHunkOrFile { hunk } => {
                 diff_rendering::render_uncommitted_hunk(
                     *hunk,
-                    ctx,
                     theme,
                     &mut id_gen,
                     options,

--- a/crates/but/src/command/legacy/diff2.rs
+++ b/crates/but/src/command/legacy/diff2.rs
@@ -1,6 +1,7 @@
 use bstr::BString;
 use but_ctx::Context;
 use gix::refs::FullName;
+use nonempty::NonEmpty;
 use serde::Serialize;
 
 use crate::{
@@ -10,7 +11,7 @@ use crate::{
         diff2::Platform,
     },
     bad_input,
-    id::{CommitId, CommittedFileId, UncommittedHunkOrFile},
+    id::{CommitId, CommittedFileId, UncommittedHunkOrFile, WorktreeHunk},
     theme::{Paint as _, Theme},
     utils::{
         CliOutput, CliOutputHuman, IntermediateChannel, WriteWithUtils,
@@ -98,6 +99,9 @@ impl CliOutputHuman for DiffOutcome<'_> {
                     options,
                     &mut writer,
                 )?;
+            }
+            DiffOperation::PathPrefix { .. } => {
+                anyhow::bail!("Diffing paths is not supported")
             }
         }
 
@@ -222,12 +226,9 @@ fn resolve(ctx: &Context, id_map: &IdMap, args: Platform) -> CliResult<DiffOpera
             },
             path,
         }),
+        ResolvedCliIdArg::PathPrefix { id, hunks } => Ok(DiffOperation::PathPrefix { id, hunks }),
         ResolvedCliIdArg::Stack => {
             Err(bad_input("viewing diffs for stack assignments is not supported").into())
-        }
-        ResolvedCliIdArg::PathPrefix => {
-            // TODO(david)
-            Err(anyhow::anyhow!("path prefix targets are not yet implemented").into())
         }
     }
 }
@@ -239,8 +240,22 @@ fn run(ctx: &mut Context, op: DiffOperation) -> anyhow::Result<DiffOutcome<'_>> 
 #[derive(Debug)]
 enum DiffOperation {
     Uncommitted,
-    Commit { commit: CommitId },
-    Branch { branch: FullName },
-    UncommittedHunkOrFile { hunk: Box<UncommittedHunkOrFile> },
-    CommittedFile { commit: CommitId, path: BString },
+    Commit {
+        commit: CommitId,
+    },
+    Branch {
+        branch: FullName,
+    },
+    UncommittedHunkOrFile {
+        hunk: Box<UncommittedHunkOrFile>,
+    },
+    CommittedFile {
+        commit: CommitId,
+        path: BString,
+    },
+    #[expect(dead_code)]
+    PathPrefix {
+        id: String,
+        hunks: NonEmpty<(String, WorktreeHunk)>,
+    },
 }

--- a/crates/but/src/command/legacy/diff2.rs
+++ b/crates/but/src/command/legacy/diff2.rs
@@ -11,7 +11,7 @@ use crate::{
         diff2::Platform,
     },
     bad_input,
-    id::{CommitId, CommittedFileId, UncommittedHunkOrFile, WorktreeHunk},
+    id::{CommitId, CommittedFileId, IdAndHunk, UncommittedHunkOrFile},
     theme::{Paint as _, Theme},
     utils::{
         CliOutput, CliOutputHuman, IntermediateChannel, WriteWithUtils,
@@ -99,8 +99,16 @@ impl CliOutputHuman for DiffOutcome<'_> {
                     &mut writer,
                 )?;
             }
-            DiffOperation::PathPrefix { .. } => {
-                anyhow::bail!("Diffing paths is not supported")
+            DiffOperation::PathPrefix { id, hunks } => {
+                diff_rendering::render_path_prefix(
+                    &id,
+                    hunks,
+                    ctx,
+                    theme,
+                    &mut id_gen,
+                    options,
+                    &mut writer,
+                )?;
             }
         }
 
@@ -252,9 +260,8 @@ enum DiffOperation {
         commit: CommitId,
         path: BString,
     },
-    #[expect(dead_code)]
     PathPrefix {
         id: String,
-        hunks: NonEmpty<(String, WorktreeHunk)>,
+        hunks: NonEmpty<IdAndHunk>,
     },
 }

--- a/crates/but/src/command/legacy/discard.rs
+++ b/crates/but/src/command/legacy/discard.rs
@@ -270,7 +270,7 @@ fn resolve(repo: &gix::Repository, id_map: &IdMap, args: Platform) -> CliResult<
             }
             ResolvedCliIdArg::UncommittedHunkOrFile(change) => hunk_sources.push(*change),
             ResolvedCliIdArg::Uncommitted => uncommitted_sources.push(()),
-            ResolvedCliIdArg::PathPrefix => {
+            ResolvedCliIdArg::PathPrefix { .. } => {
                 return Err(bad_input("Path prefixes cannot be discarded")
                     .arg_name("<CHANGES>")
                     .arg_value(value)

--- a/crates/but/src/command/legacy/squash.rs
+++ b/crates/but/src/command/legacy/squash.rs
@@ -809,7 +809,7 @@ pub fn resolve_target(
         }
         ResolvedCliIdArgRef::UncommittedHunkOrFile(..)
         | ResolvedCliIdArgRef::CommittedFile { .. }
-        | ResolvedCliIdArgRef::PathPrefix
+        | ResolvedCliIdArgRef::PathPrefix { .. }
         | ResolvedCliIdArgRef::Stack => Err(ResolveTargetError::InvalidTarget),
     }
 }
@@ -1001,7 +1001,7 @@ impl<'a> Squashable<'a> {
             ResolvedCliIdArgRef::CommittedFile(file) => {
                 return Ok(Self::CommittedFile(file.clone()));
             }
-            ResolvedCliIdArgRef::PathPrefix => "a path",
+            ResolvedCliIdArgRef::PathPrefix { .. } => "a path",
             ResolvedCliIdArgRef::Stack => "a stack",
         };
         Err(bad_input(format!(

--- a/crates/but/src/command/legacy/status/assignment.rs
+++ b/crates/but/src/command/legacy/status/assignment.rs
@@ -38,7 +38,7 @@ impl FileAssignment {
             };
             for hunk_assignment in uncommitted_file.hunk_assignments() {
                 assignments.push(CLIHunkAssignment {
-                    inner: hunk_assignment.clone(),
+                    inner: hunk_assignment.1.clone(),
                     cli_id: uncommitted_file.short_id.clone(),
                 });
             }

--- a/crates/but/src/command/legacy/status/tui/app/mark.rs
+++ b/crates/but/src/command/legacy/status/tui/app/mark.rs
@@ -18,7 +18,7 @@ use crate::{
     },
     id::{
         BranchId, BranchIdRef, CommitId, CommitIdRef, CommittedFileId, CommittedFileIdRef,
-        UncommittedHunkOrFile, WorktreeHunk,
+        IdAndHunk, UncommittedHunkOrFile,
     },
 };
 
@@ -789,7 +789,7 @@ fn handle_mark_cli_id(commit: &CliId, mode: &mut Mode) -> anyhow::Result<bool> {
 fn synthetic_hunk(
     base_id: &str,
     idx: usize,
-    hunk_assignments: NonEmpty<WorktreeHunk>,
+    hunk_assignments: NonEmpty<IdAndHunk>,
     is_entire_file: bool,
 ) -> UncommittedHunkOrFile {
     UncommittedHunkOrFile {
@@ -802,7 +802,7 @@ fn synthetic_hunk(
 pub fn synthetic_parent_hunk(
     base_id: &str,
     idx: usize,
-    hunk_assignments: NonEmpty<WorktreeHunk>,
+    hunk_assignments: NonEmpty<IdAndHunk>,
 ) -> UncommittedHunkOrFile {
     synthetic_hunk(base_id, idx, hunk_assignments, true)
 }
@@ -810,7 +810,7 @@ pub fn synthetic_parent_hunk(
 pub fn synthetic_child_hunk(
     base_id: &str,
     idx: usize,
-    hunk_assignments: NonEmpty<WorktreeHunk>,
+    hunk_assignments: NonEmpty<IdAndHunk>,
 ) -> UncommittedHunkOrFile {
     synthetic_hunk(base_id, idx, hunk_assignments, false)
 }

--- a/crates/but/src/command/legacy/status/tui/app/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/app/mod.rs
@@ -1047,6 +1047,7 @@ impl App {
                                 changed_paths.iter().any(|changed_path| {
                                     hunk.hunk_assignments
                                         .head
+                                        .hunk
                                         .path_bytes
                                         .to_path()
                                         .is_ok_and(|path| path == changed_path)
@@ -1094,7 +1095,7 @@ impl App {
                                     | StatusOutputLineData::NoAssignmentsUnstaged => None,
                                 })
                                 .flat_map(|assignments| assignments.iter())
-                                .map(|assignment| assignment.path_bytes.as_ref());
+                                .map(|assignment| assignment.hunk.path_bytes.as_ref());
                             let current_uncommitted_paths = changes
                                 .worktree_changes
                                 .changes
@@ -1463,7 +1464,7 @@ impl App {
                 id: _,
             } => path.to_str_lossy(),
             CliId::UncommittedHunkOrFile(uncommitted) => {
-                Cow::Borrowed(&*uncommitted.hunk_assignments.first().path)
+                Cow::Borrowed(&*uncommitted.hunk_assignments.first().hunk.path)
             }
             CliId::PathPrefix { .. } | CliId::Uncommitted { .. } | CliId::Stack { .. } => {
                 return Ok(());
@@ -1561,7 +1562,7 @@ impl App {
                 ctx,
                 std::iter::once(head)
                     .chain(tail)
-                    .map(|hunk| hunk.hunk_assignments.head.path_bytes.as_bstr()),
+                    .map(|hunk| hunk.hunk_assignments.head.hunk.path_bytes.as_bstr()),
             ),
             mark::MarksRef::CommittedFiles { head, tail } => openable_from_paths(
                 ctx,

--- a/crates/but/src/command/legacy/status/tui/copy_selection_picker.rs
+++ b/crates/but/src/command/legacy/status/tui/copy_selection_picker.rs
@@ -51,7 +51,7 @@ pub fn uncommitted_hunk_picker(
     hunk: UncommittedHunkOrFile,
     theme: &'static Theme,
 ) -> FuzzyPicker<CopySelectionItem> {
-    let path = hunk.hunk_assignments.head.path.clone();
+    let path = hunk.hunk_assignments.head.hunk.path.clone();
     picker(
         NonEmpty::from_slice(&[
             CopySelectionItem::ShortId(hunk.id.clone()),
@@ -293,9 +293,9 @@ fn uncommitted_hunk_matches_selection(
     let selected_hunk = uncommitted.hunk_assignments.first();
 
     if uncommitted.is_entire_file {
-        hunk_assignment.path_bytes == selected_hunk.path_bytes
+        hunk_assignment.path_bytes == selected_hunk.hunk.path_bytes
     } else {
-        hunk_assignment == selected_hunk
+        hunk_assignment == &selected_hunk.hunk
     }
 }
 

--- a/crates/but/src/command/legacy/status/tui/cursor/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/cursor/mod.rs
@@ -343,7 +343,7 @@ impl Cursor {
                 line.data.cli_id().map(|id| &**id)
             {
                 let assignment = uncommitted.hunk_assignments.first();
-                &**assignment.path_bytes == path
+                &**assignment.hunk.path_bytes == path
             } else {
                 false
             }
@@ -706,7 +706,7 @@ pub(super) fn same_entity_for_reload(previous: &CliId, current: &CliId) -> bool 
             if previous.is_entire_file {
                 let previous = previous.hunk_assignments.first();
                 let current = current.hunk_assignments.first();
-                previous.path_bytes == current.path_bytes
+                previous.hunk.path_bytes == current.hunk.path_bytes
             } else {
                 previous == current
             }

--- a/crates/but/src/command/legacy/status/tui/cursor/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/cursor/mod.rs
@@ -722,8 +722,8 @@ pub(super) fn same_entity_for_reload(previous: &CliId, current: &CliId) -> bool 
             },
         ) => previous
             .iter()
-            .map(|(_, assignment)| assignment)
-            .eq(current.iter().map(|(_, assignment)| assignment)),
+            .map(|id_and_hunk| &id_and_hunk.hunk)
+            .eq(current.iter().map(|id_and_hunk| &id_and_hunk.hunk)),
         (
             CliId::CommittedFile {
                 committed_file:

--- a/crates/but/src/command/legacy/status/tui/cursor/tests.rs
+++ b/crates/but/src/command/legacy/status/tui/cursor/tests.rs
@@ -21,7 +21,7 @@ use crate::{
             },
         },
     },
-    id::{BranchId, CommitId, CommittedFileId, UncommittedHunkOrFile, WorktreeHunk},
+    id::{BranchId, CommitId, CommittedFileId, IdAndHunk, UncommittedHunkOrFile, WorktreeHunk},
 };
 
 fn line(data: StatusOutputLineData) -> StatusOutputLine {
@@ -117,7 +117,10 @@ fn uncommitted_cli_id(path: &str, id: &str) -> Arc<CliId> {
 fn uncommitted_cli_id_with_old_start(path: &str, id: &str, old_start: u32) -> Arc<CliId> {
     Arc::new(CliId::UncommittedHunkOrFile(UncommittedHunkOrFile {
         id: id.to_owned(),
-        hunk_assignments: NonEmpty::new(hunk_assignment(path, old_start)),
+        hunk_assignments: NonEmpty::new(IdAndHunk {
+            id: id.to_owned(),
+            hunk: hunk_assignment(path, old_start),
+        }),
         is_entire_file: true,
     }))
 }

--- a/crates/but/src/command/legacy/status/tui/details.rs
+++ b/crates/but/src/command/legacy/status/tui/details.rs
@@ -1255,7 +1255,7 @@ impl Details {
             if let CliId::UncommittedHunkOrFile(hunk) = &*section_cli_id {
                 (
                     Span::raw(section_cli_id.to_short_string()).style(self.theme.cli_id),
-                    Span::raw(hunk.hunk_assignments.head.path.clone()),
+                    Span::raw(hunk.hunk_assignments.head.hunk.path.clone()),
                     DiscardOperation::Uncommitted(UncommittedSelection::Changes(Box::new(
                         NonEmpty::new(hunk.clone()),
                     ))),
@@ -1444,8 +1444,8 @@ impl Details {
                 };
                 // the detail view can contain hunks from multiple files, for example if viewing
                 // the uncommitted area, so only check hunks from the marked file
-                if section_hunk.hunk_assignments.head.path_bytes
-                    != hunk.hunk_assignments.head.path_bytes
+                if section_hunk.hunk_assignments.head.hunk.path_bytes
+                    != hunk.hunk_assignments.head.hunk.path_bytes
                 {
                     return None;
                 }

--- a/crates/but/src/command/legacy/status/tui/details.rs
+++ b/crates/but/src/command/legacy/status/tui/details.rs
@@ -316,10 +316,9 @@ impl Details {
                     ctx,
                     None,
                     selection_did_change,
-                    move |ctx, theme, id_gen, line_writer, options| {
+                    move |_ctx, theme, id_gen, line_writer, options| {
                         diff_rendering::render_uncommitted_hunk(
                             uncommitted,
-                            ctx,
                             theme,
                             id_gen,
                             options,

--- a/crates/but/src/command/legacy/status/tui/remember_selection.rs
+++ b/crates/but/src/command/legacy/status/tui/remember_selection.rs
@@ -70,7 +70,9 @@ fn path(ctx: &Context) -> PathBuf {
 
 fn line_id(id: &CliId) -> Option<String> {
     Some(match id {
-        CliId::UncommittedHunkOrFile(hunk) => format!("hunk:{}", hunk.hunk_assignments.head.path),
+        CliId::UncommittedHunkOrFile(hunk) => {
+            format!("hunk:{}", hunk.hunk_assignments.head.hunk.path)
+        }
         CliId::Branch(branch) => format!("branch:{}", branch.name),
         CliId::CommittedFile {
             committed_file:

--- a/crates/but/src/command/legacy/status/tui/tests/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/mod.rs
@@ -930,7 +930,7 @@ fn pick_changes_mode() {
         .map(|hunk| {
             (
                 hunk.id,
-                hunk.hunk_assignments.head.path,
+                hunk.hunk_assignments.head.hunk.path,
                 hunk.is_entire_file,
             )
         })
@@ -1021,7 +1021,7 @@ fn stays_in_pick_change_mode_after_full_screen_details() {
         .map(|hunk| {
             (
                 hunk.id,
-                hunk.hunk_assignments.head.path,
+                hunk.hunk_assignments.head.hunk.path,
                 hunk.is_entire_file,
             )
         })

--- a/crates/but/src/command/open.rs
+++ b/crates/but/src/command/open.rs
@@ -46,7 +46,7 @@ impl Openable {
         repo: &gix::Repository,
         uncommitted: &UncommittedHunkOrFile,
     ) -> anyhow::Result<Self> {
-        let hunk = uncommitted.hunk_assignments.first();
+        let hunk = &uncommitted.hunk_assignments.first().hunk;
 
         let path = repo
             .workdir_path(hunk.path_bytes.as_bstr())

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -995,14 +995,17 @@ impl IdMap {
     }
 
     fn parse_uncommitted_path_prefix<'a>(&'a self, element: &str) -> Vec<Box<dyn Node<'a> + 'a>> {
-        let mut hunk_assignments = Vec::<(String, WorktreeHunk)>::new();
+        let mut hunk_assignments = Vec::new();
         for (short_id, uncommitted_hunk) in self.uncommitted_hunks.iter() {
             let hunk_assignment = &uncommitted_hunk.hunk_assignment;
             if hunk_assignment.path_bytes.starts_with(element.as_bytes()) {
-                hunk_assignments.push((short_id.to_owned(), hunk_assignment.to_owned()));
+                hunk_assignments.push(IdAndHunk {
+                    id: short_id.to_owned(),
+                    hunk: hunk_assignment.to_owned(),
+                });
             }
         }
-        hunk_assignments.sort_by(|a, b| a.1.path_bytes.cmp(&b.1.path_bytes));
+        hunk_assignments.sort_by(|a, b| a.hunk.path_bytes.cmp(&b.hunk.path_bytes));
         let Some(hunk_assignments) = NonEmpty::from_vec(hunk_assignments) else {
             return vec![];
         };
@@ -1525,7 +1528,7 @@ pub enum CliId {
         /// The ID as given by the user
         id: ShortId,
         /// The hunk assignments with their associated short IDs
-        hunk_assignments: NonEmpty<(ShortId, WorktreeHunk)>,
+        hunk_assignments: NonEmpty<IdAndHunk>,
     },
     /// A file that exists in a commit.
     CommittedFile {

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -540,7 +540,7 @@ impl<'a> Node<'a> for &'a StackWithId {
             // TODO once the set of allowed CLI IDs is determined and the
             // access patterns of `uncommitted_files` are known, change its data
             // structure to be more efficient than the current linear search.
-            if hunk_assignment.path_bytes == element.as_bytes() {
+            if hunk_assignment.1.path_bytes == element.as_bytes() {
                 return Ok(vec![Box::new(uncommitted_file)]);
             }
         }
@@ -987,7 +987,7 @@ impl IdMap {
             // TODO once the set of allowed CLI IDs is determined and the
             // access patterns of `uncommitted_files` are known, change its data
             // structure to be more efficient than the current linear search.
-            if hunk_assignment.path_bytes == element.as_bytes() {
+            if hunk_assignment.1.path_bytes == element.as_bytes() {
                 matches.push(Box::new(uncommitted_file));
             }
         }
@@ -1446,13 +1446,29 @@ fn cli_ids_refer_to_same_entity(lhs: &CliId, rhs: &CliId) -> bool {
     }
 }
 
+/// A worktree hunk paired with its fully qualified short CLI ID.
+#[derive(Debug, Clone)]
+pub struct IdAndHunk {
+    /// The full CLI selector, including both the file and hunk IDs.
+    pub id: ShortId,
+    /// The worktree hunk identified by `id`.
+    pub hunk: WorktreeHunk,
+}
+
+impl PartialEq for IdAndHunk {
+    fn eq(&self, other: &Self) -> bool {
+        let Self { id: _, hunk } = self;
+        hunk == &other.hunk
+    }
+}
+
 /// An uncommitted file or hunk in the worktree.
 #[derive(Debug, Clone)]
 pub struct UncommittedHunkOrFile {
     /// The short CLI ID for this file (typically 2 characters)
     pub id: ShortId,
     /// The hunk assignments
-    pub hunk_assignments: NonEmpty<WorktreeHunk>,
+    pub hunk_assignments: NonEmpty<IdAndHunk>,
     /// `true` if self represents all hunks in a stack-assignment or file pair.
     /// Note that this file may have hunks with other stack assignments.
     pub is_entire_file: bool,
@@ -1488,7 +1504,7 @@ impl UncommittedHunkOrFile {
         let assignment = "the uncommitted area";
         format!(
             "{hunk_cardinality} in {} in {assignment}",
-            self.hunk_assignments.first().path_bytes,
+            self.hunk_assignments.first().hunk.path_bytes,
         )
     }
 }
@@ -1632,7 +1648,7 @@ pub struct UncommittedFile {
 impl UncommittedFile {
     /// The path of the uncommitted file.
     pub fn path(&self) -> &BStr {
-        self.hunk_assignments().first().path_bytes.as_ref()
+        self.hunk_assignments().first().1.path_bytes.as_ref()
     }
 
     /// Turn this instance into a [CliId].
@@ -1640,17 +1656,20 @@ impl UncommittedFile {
         CliId::UncommittedHunkOrFile(UncommittedHunkOrFile {
             hunk_assignments: self
                 .hunk_assignments()
-                .map(|hunk_assignment| hunk_assignment.to_owned()),
+                .map(|(hunk_id, hunk_assignment)| IdAndHunk {
+                    id: format!("{}:{hunk_id}", self.short_id),
+                    hunk: hunk_assignment.to_owned(),
+                }),
             id: self.short_id.clone(),
             is_entire_file: true,
         })
     }
 
-    /// Hunk assignments.
-    pub fn hunk_assignments(&self) -> NonEmpty<&WorktreeHunk> {
+    /// Hunk assignments paired with hunk IDs that are not qualified by the file ID.
+    pub fn hunk_assignments(&self) -> NonEmpty<(String, &WorktreeHunk)> {
         self.short_id_hunk_assignments
             .as_ref()
-            .map(|(_, hunk_assignment)| hunk_assignment)
+            .map(|(short_id, hunk_assignment)| (short_id.short_id(), hunk_assignment))
     }
 }
 
@@ -1665,9 +1684,13 @@ impl<'a> Node<'a> for &'a UncommittedFile {
             Some(maybe_index) if let Ok(index) = usize::from_str(maybe_index) => {
                 if let Some((hunk_id, hunk_assignment)) = self.short_id_hunk_assignments.get(index)
                 {
+                    let id = format!("{}:{}", self.short_id, hunk_id.short_id());
                     let cli_id = CliId::UncommittedHunkOrFile(UncommittedHunkOrFile {
-                        id: format!("{}:{}", self.short_id, hunk_id.short_id()),
-                        hunk_assignments: NonEmpty::new(hunk_assignment.to_owned()),
+                        id: id.clone(),
+                        hunk_assignments: NonEmpty::new(IdAndHunk {
+                            id,
+                            hunk: hunk_assignment.to_owned(),
+                        }),
                         is_entire_file: false,
                     });
                     Ok(vec![Box::new(Leaf { cli_id })])
@@ -1681,9 +1704,13 @@ impl<'a> Node<'a> for &'a UncommittedFile {
                     .iter()
                     .filter(|(hunk_id, _)| hunk_id.matches_prefix(element))
                     .map(|(hunk_id, hunk_assignment)| {
+                        let id = format!("{}:{}", self.short_id, hunk_id.short_id());
                         let cli_id = CliId::UncommittedHunkOrFile(UncommittedHunkOrFile {
-                            id: format!("{}:{}", self.short_id, hunk_id.short_id()),
-                            hunk_assignments: NonEmpty::new(hunk_assignment.to_owned()),
+                            id: id.clone(),
+                            hunk_assignments: NonEmpty::new(IdAndHunk {
+                                id: id.clone(),
+                                hunk: hunk_assignment.to_owned(),
+                            }),
                             is_entire_file: false,
                         });
                         Box::new(Leaf { cli_id }) as Box<dyn Node<'a> + 'a>
@@ -1699,13 +1726,7 @@ impl<'a> Node<'a> for &'a UncommittedFile {
         _short_id: &str,
         _id_map: &IdMap,
     ) -> anyhow::Result<Option<CliId>> {
-        Ok(Some(CliId::UncommittedHunkOrFile(UncommittedHunkOrFile {
-            id: self.short_id.clone(),
-            hunk_assignments: self
-                .hunk_assignments()
-                .map(|hunk_assignment| hunk_assignment.to_owned()),
-            is_entire_file: true,
-        })))
+        Ok(Some((*self).to_id()))
     }
 }
 
@@ -1733,7 +1754,10 @@ impl<'a> Node<'a> for &'a UncommittedHunk {
     ) -> anyhow::Result<Option<CliId>> {
         Ok(Some(CliId::UncommittedHunkOrFile(UncommittedHunkOrFile {
             id: short_id.to_owned(),
-            hunk_assignments: NonEmpty::new(self.hunk_assignment.clone()),
+            hunk_assignments: NonEmpty::new(IdAndHunk {
+                id: short_id.to_owned(),
+                hunk: self.hunk_assignment.clone(),
+            }),
             is_entire_file: false,
         })))
     }

--- a/crates/but/src/id/tests.rs
+++ b/crates/but/src/id/tests.rs
@@ -1290,9 +1290,9 @@ fn uncommitted_path() -> anyhow::Result<()> {
     PathPrefix {
         id: "prefix/",
         hunk_assignments: NonEmpty {
-            head: (
-                "yz:q",
-                WorktreeHunk {
+            head: IdAndHunk {
+                id: "yz:q",
+                hunk: WorktreeHunk {
                     id: None,
                     hunk_header: None,
                     path: "",
@@ -1301,11 +1301,11 @@ fn uncommitted_path() -> anyhow::Result<()> {
                     line_nums_removed: None,
                     diff: None,
                 },
-            ),
+            },
             tail: [
-                (
-                    "uo:q",
-                    WorktreeHunk {
+                IdAndHunk {
+                    id: "uo:q",
+                    hunk: WorktreeHunk {
                         id: None,
                         hunk_header: None,
                         path: "",
@@ -1314,7 +1314,7 @@ fn uncommitted_path() -> anyhow::Result<()> {
                         line_nums_removed: None,
                         diff: None,
                     },
-                ),
+                },
             ],
         },
     },

--- a/crates/but/src/id/tests.rs
+++ b/crates/but/src/id/tests.rs
@@ -464,14 +464,17 @@ stacks: [ j0 ]
         UncommittedHunkOrFile {
             id: "kv",
             hunk_assignments: NonEmpty {
-                head: WorktreeHunk {
-                    id: None,
-                    hunk_header: None,
-                    path: "",
-                    path_bytes: "uncommitted2.txt",
-                    line_nums_added: None,
-                    line_nums_removed: None,
-                    diff: None,
+                head: IdAndHunk {
+                    id: "kv:q",
+                    hunk: WorktreeHunk {
+                        id: None,
+                        hunk_header: None,
+                        path: "",
+                        path_bytes: "uncommitted2.txt",
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: None,
+                    },
                 },
                 tail: [],
             },
@@ -482,14 +485,17 @@ stacks: [ j0 ]
         UncommittedHunkOrFile {
             id: "kv:q",
             hunk_assignments: NonEmpty {
-                head: WorktreeHunk {
-                    id: None,
-                    hunk_header: None,
-                    path: "",
-                    path_bytes: "uncommitted2.txt",
-                    line_nums_added: None,
-                    line_nums_removed: None,
-                    diff: None,
+                head: IdAndHunk {
+                    id: "kv:q",
+                    hunk: WorktreeHunk {
+                        id: None,
+                        hunk_header: None,
+                        path: "",
+                        path_bytes: "uncommitted2.txt",
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: None,
+                    },
                 },
                 tail: [],
             },
@@ -500,28 +506,34 @@ stacks: [ j0 ]
         UncommittedHunkOrFile {
             id: "ro",
             hunk_assignments: NonEmpty {
-                head: WorktreeHunk {
-                    id: None,
-                    hunk_header: Some(
-                        HunkHeader("-1,2", "+1,2"),
-                    ),
-                    path: "",
-                    path_bytes: "uncommitted1.txt",
-                    line_nums_added: None,
-                    line_nums_removed: None,
-                    diff: None,
-                },
-                tail: [
-                    WorktreeHunk {
+                head: IdAndHunk {
+                    id: "ro:q#0-2",
+                    hunk: WorktreeHunk {
                         id: None,
                         hunk_header: Some(
-                            HunkHeader("-3,2", "+3,2"),
+                            HunkHeader("-1,2", "+1,2"),
                         ),
                         path: "",
                         path_bytes: "uncommitted1.txt",
                         line_nums_added: None,
                         line_nums_removed: None,
                         diff: None,
+                    },
+                },
+                tail: [
+                    IdAndHunk {
+                        id: "ro:q#1-2",
+                        hunk: WorktreeHunk {
+                            id: None,
+                            hunk_header: Some(
+                                HunkHeader("-3,2", "+3,2"),
+                            ),
+                            path: "",
+                            path_bytes: "uncommitted1.txt",
+                            line_nums_added: None,
+                            line_nums_removed: None,
+                            diff: None,
+                        },
                     },
                 ],
             },
@@ -532,16 +544,19 @@ stacks: [ j0 ]
         UncommittedHunkOrFile {
             id: "ro:q#0-2",
             hunk_assignments: NonEmpty {
-                head: WorktreeHunk {
-                    id: None,
-                    hunk_header: Some(
-                        HunkHeader("-1,2", "+1,2"),
-                    ),
-                    path: "",
-                    path_bytes: "uncommitted1.txt",
-                    line_nums_added: None,
-                    line_nums_removed: None,
-                    diff: None,
+                head: IdAndHunk {
+                    id: "ro:q#0-2",
+                    hunk: WorktreeHunk {
+                        id: None,
+                        hunk_header: Some(
+                            HunkHeader("-1,2", "+1,2"),
+                        ),
+                        path: "",
+                        path_bytes: "uncommitted1.txt",
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: None,
+                    },
                 },
                 tail: [],
             },
@@ -552,16 +567,19 @@ stacks: [ j0 ]
         UncommittedHunkOrFile {
             id: "ro:q#1-2",
             hunk_assignments: NonEmpty {
-                head: WorktreeHunk {
-                    id: None,
-                    hunk_header: Some(
-                        HunkHeader("-3,2", "+3,2"),
-                    ),
-                    path: "",
-                    path_bytes: "uncommitted1.txt",
-                    line_nums_added: None,
-                    line_nums_removed: None,
-                    diff: None,
+                head: IdAndHunk {
+                    id: "ro:q#1-2",
+                    hunk: WorktreeHunk {
+                        id: None,
+                        hunk_header: Some(
+                            HunkHeader("-3,2", "+3,2"),
+                        ),
+                        path: "",
+                        path_bytes: "uncommitted1.txt",
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: None,
+                    },
                 },
                 tail: [],
             },
@@ -573,6 +591,49 @@ stacks: [ j0 ]
 "#]]
     );
 
+    Ok(())
+}
+
+#[test]
+fn uncommitted_file_to_id_qualifies_hunk_ids() -> anyhow::Result<()> {
+    let hunk_assignments = vec![
+        HunkAssignment {
+            hunk_header: Some(hunk_header("-1,2", "+1,2")),
+            ..hunk_assignment("uncommitted.txt", None)
+        },
+        HunkAssignment {
+            hunk_header: Some(hunk_header("-3,2", "+3,2")),
+            ..hunk_assignment("uncommitted.txt", None)
+        },
+    ];
+    let id_map = IdMap::new(
+        Vec::new(),
+        hunk_assignments,
+        gix::hashtable::HashMap::default(),
+    )?;
+    let uncommitted_file = id_map
+        .uncommitted_files
+        .values()
+        .next()
+        .expect("the map contains the uncommitted file");
+    let expected_ids = uncommitted_file
+        .hunk_assignments()
+        .iter()
+        .map(|(hunk_id, _)| format!("{}:{hunk_id}", uncommitted_file.short_id))
+        .collect::<Vec<_>>();
+    let CliId::UncommittedHunkOrFile(uncommitted) = uncommitted_file.to_id() else {
+        panic!("an uncommitted file converts to an uncommitted CLI ID");
+    };
+    let actual_ids = uncommitted
+        .hunk_assignments
+        .iter()
+        .map(|assignment| assignment.id.clone())
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        actual_ids, expected_ids,
+        "nested hunk IDs include their file ID"
+    );
     Ok(())
 }
 
@@ -652,14 +713,17 @@ uncommitted_hunks: [ ln:q ]
         UncommittedHunkOrFile {
             id: "ln",
             hunk_assignments: NonEmpty {
-                head: WorktreeHunk {
-                    id: None,
-                    hunk_header: None,
-                    path: "",
-                    path_bytes: "uncommitted.txt",
-                    line_nums_added: None,
-                    line_nums_removed: None,
-                    diff: None,
+                head: IdAndHunk {
+                    id: "ln:q",
+                    hunk: WorktreeHunk {
+                        id: None,
+                        hunk_header: None,
+                        path: "",
+                        path_bytes: "uncommitted.txt",
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: None,
+                    },
                 },
                 tail: [],
             },
@@ -730,14 +794,17 @@ fn uncommitted_files_disambiguate_between_themselves() -> anyhow::Result<()> {
         UncommittedHunkOrFile {
             id: "kpo",
             hunk_assignments: NonEmpty {
-                head: WorktreeHunk {
-                    id: None,
-                    hunk_header: None,
-                    path: "",
-                    path_bytes: "foo242",
-                    line_nums_added: None,
-                    line_nums_removed: None,
-                    diff: None,
+                head: IdAndHunk {
+                    id: "kpo:q",
+                    hunk: WorktreeHunk {
+                        id: None,
+                        hunk_header: None,
+                        path: "",
+                        path_bytes: "foo242",
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: None,
+                    },
                 },
                 tail: [],
             },
@@ -748,14 +815,17 @@ fn uncommitted_files_disambiguate_between_themselves() -> anyhow::Result<()> {
         UncommittedHunkOrFile {
             id: "kpr",
             hunk_assignments: NonEmpty {
-                head: WorktreeHunk {
-                    id: None,
-                    hunk_header: None,
-                    path: "",
-                    path_bytes: "foo23",
-                    line_nums_added: None,
-                    line_nums_removed: None,
-                    diff: None,
+                head: IdAndHunk {
+                    id: "kpr:q",
+                    hunk: WorktreeHunk {
+                        id: None,
+                        hunk_header: None,
+                        path: "",
+                        path_bytes: "foo23",
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: None,
+                    },
                 },
                 tail: [],
             },
@@ -775,14 +845,17 @@ fn uncommitted_files_disambiguate_between_themselves() -> anyhow::Result<()> {
         UncommittedHunkOrFile {
             id: "kpo",
             hunk_assignments: NonEmpty {
-                head: WorktreeHunk {
-                    id: None,
-                    hunk_header: None,
-                    path: "",
-                    path_bytes: "foo242",
-                    line_nums_added: None,
-                    line_nums_removed: None,
-                    diff: None,
+                head: IdAndHunk {
+                    id: "kpo:q",
+                    hunk: WorktreeHunk {
+                        id: None,
+                        hunk_header: None,
+                        path: "",
+                        path_bytes: "foo242",
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: None,
+                    },
                 },
                 tail: [],
             },
@@ -801,14 +874,17 @@ fn uncommitted_files_disambiguate_between_themselves() -> anyhow::Result<()> {
         UncommittedHunkOrFile {
             id: "kpr",
             hunk_assignments: NonEmpty {
-                head: WorktreeHunk {
-                    id: None,
-                    hunk_header: None,
-                    path: "",
-                    path_bytes: "foo23",
-                    line_nums_added: None,
-                    line_nums_removed: None,
-                    diff: None,
+                head: IdAndHunk {
+                    id: "kpr:q",
+                    hunk: WorktreeHunk {
+                        id: None,
+                        hunk_header: None,
+                        path: "",
+                        path_bytes: "foo23",
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: None,
+                    },
                 },
                 tail: [],
             },
@@ -889,14 +965,17 @@ fn uncommitted_files_disambiguate_with_branch() -> anyhow::Result<()> {
         UncommittedHunkOrFile {
             id: "qsy",
             hunk_assignments: NonEmpty {
-                head: WorktreeHunk {
-                    id: None,
-                    hunk_header: None,
-                    path: "",
-                    path_bytes: "file",
-                    line_nums_added: None,
-                    line_nums_removed: None,
-                    diff: None,
+                head: IdAndHunk {
+                    id: "qsy:q",
+                    hunk: WorktreeHunk {
+                        id: None,
+                        hunk_header: None,
+                        path: "",
+                        path_bytes: "file",
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: None,
+                    },
                 },
                 tail: [],
             },
@@ -935,14 +1014,17 @@ fn longer_id_is_ok() -> anyhow::Result<()> {
         UncommittedHunkOrFile {
             id: "kp",
             hunk_assignments: NonEmpty {
-                head: WorktreeHunk {
-                    id: None,
-                    hunk_header: None,
-                    path: "",
-                    path_bytes: "foo23",
-                    line_nums_added: None,
-                    line_nums_removed: None,
-                    diff: None,
+                head: IdAndHunk {
+                    id: "kp:q",
+                    hunk: WorktreeHunk {
+                        id: None,
+                        hunk_header: None,
+                        path: "",
+                        path_bytes: "foo23",
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: None,
+                    },
                 },
                 tail: [],
             },
@@ -981,14 +1063,17 @@ fn reverse_hex_filename_is_its_own_id() -> anyhow::Result<()> {
         UncommittedHunkOrFile {
             id: "kl",
             hunk_assignments: NonEmpty {
-                head: WorktreeHunk {
-                    id: None,
-                    hunk_header: None,
-                    path: "",
-                    path_bytes: "klmxyz",
-                    line_nums_added: None,
-                    line_nums_removed: None,
-                    diff: None,
+                head: IdAndHunk {
+                    id: "kl:q",
+                    hunk: WorktreeHunk {
+                        id: None,
+                        hunk_header: None,
+                        path: "",
+                        path_bytes: "klmxyz",
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: None,
+                    },
                 },
                 tail: [],
             },
@@ -1036,14 +1121,17 @@ fn branch_and_file_by_name() -> anyhow::Result<()> {
         UncommittedHunkOrFile {
             id: "zo",
             hunk_assignments: NonEmpty {
-                head: WorktreeHunk {
-                    id: None,
-                    hunk_header: None,
-                    path: "",
-                    path_bytes: "foo",
-                    line_nums_added: None,
-                    line_nums_removed: None,
-                    diff: None,
+                head: IdAndHunk {
+                    id: "zo:q",
+                    hunk: WorktreeHunk {
+                        id: None,
+                        hunk_header: None,
+                        path: "",
+                        path_bytes: "foo",
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: None,
+                    },
                 },
                 tail: [],
             },
@@ -1086,14 +1174,17 @@ fn colon_uncommitted_filename() -> anyhow::Result<()> {
         UncommittedHunkOrFile {
             id: "nv",
             hunk_assignments: NonEmpty {
-                head: WorktreeHunk {
-                    id: None,
-                    hunk_header: None,
-                    path: "",
-                    path_bytes: "assigned",
-                    line_nums_added: None,
-                    line_nums_removed: None,
-                    diff: None,
+                head: IdAndHunk {
+                    id: "nv:q",
+                    hunk: WorktreeHunk {
+                        id: None,
+                        hunk_header: None,
+                        path: "",
+                        path_bytes: "assigned",
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: None,
+                    },
                 },
                 tail: [],
             },
@@ -1116,14 +1207,17 @@ fn colon_uncommitted_filename() -> anyhow::Result<()> {
         UncommittedHunkOrFile {
             id: "nv",
             hunk_assignments: NonEmpty {
-                head: WorktreeHunk {
-                    id: None,
-                    hunk_header: None,
-                    path: "",
-                    path_bytes: "assigned",
-                    line_nums_added: None,
-                    line_nums_removed: None,
-                    diff: None,
+                head: IdAndHunk {
+                    id: "nv:q",
+                    hunk: WorktreeHunk {
+                        id: None,
+                        hunk_header: None,
+                        path: "",
+                        path_bytes: "assigned",
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: None,
+                    },
                 },
                 tail: [],
             },
@@ -1146,14 +1240,17 @@ fn colon_uncommitted_filename() -> anyhow::Result<()> {
         UncommittedHunkOrFile {
             id: "pv",
             hunk_assignments: NonEmpty {
-                head: WorktreeHunk {
-                    id: None,
-                    hunk_header: None,
-                    path: "",
-                    path_bytes: "uncommitted",
-                    line_nums_added: None,
-                    line_nums_removed: None,
-                    diff: None,
+                head: IdAndHunk {
+                    id: "pv:q",
+                    hunk: WorktreeHunk {
+                        id: None,
+                        hunk_header: None,
+                        path: "",
+                        path_bytes: "uncommitted",
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: None,
+                    },
                 },
                 tail: [],
             },
@@ -1375,14 +1472,17 @@ fn short_uncommitted_files_are_properly_reverse_hexed() -> anyhow::Result<()> {
         UncommittedHunkOrFile {
             id: "ky",
             hunk_assignments: NonEmpty {
-                head: WorktreeHunk {
-                    id: None,
-                    hunk_header: None,
-                    path: "",
-                    path_bytes: "k",
-                    line_nums_added: None,
-                    line_nums_removed: None,
-                    diff: None,
+                head: IdAndHunk {
+                    id: "ky:q",
+                    hunk: WorktreeHunk {
+                        id: None,
+                        hunk_header: None,
+                        path: "",
+                        path_bytes: "k",
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: None,
+                    },
                 },
                 tail: [],
             },
@@ -1402,14 +1502,17 @@ fn short_uncommitted_files_are_properly_reverse_hexed() -> anyhow::Result<()> {
         UncommittedHunkOrFile {
             id: "klx",
             hunk_assignments: NonEmpty {
-                head: WorktreeHunk {
-                    id: None,
-                    hunk_header: None,
-                    path: "",
-                    path_bytes: "kl",
-                    line_nums_added: None,
-                    line_nums_removed: None,
-                    diff: None,
+                head: IdAndHunk {
+                    id: "klx:q",
+                    hunk: WorktreeHunk {
+                        id: None,
+                        hunk_header: None,
+                        path: "",
+                        path_bytes: "kl",
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: None,
+                    },
                 },
                 tail: [],
             },
@@ -1429,14 +1532,17 @@ fn short_uncommitted_files_are_properly_reverse_hexed() -> anyhow::Result<()> {
         UncommittedHunkOrFile {
             id: "klml",
             hunk_assignments: NonEmpty {
-                head: WorktreeHunk {
-                    id: None,
-                    hunk_header: None,
-                    path: "",
-                    path_bytes: "klm",
-                    line_nums_added: None,
-                    line_nums_removed: None,
-                    diff: None,
+                head: IdAndHunk {
+                    id: "klml:q",
+                    hunk: WorktreeHunk {
+                        id: None,
+                        hunk_header: None,
+                        path: "",
+                        path_bytes: "klm",
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: None,
+                    },
                 },
                 tail: [],
             },
@@ -1484,16 +1590,19 @@ fn uncommitted_hunks_by_numeric_index() -> anyhow::Result<()> {
         UncommittedHunkOrFile {
             id: "ro:q#0-2",
             hunk_assignments: NonEmpty {
-                head: WorktreeHunk {
-                    id: None,
-                    hunk_header: Some(
-                        HunkHeader("-1,2", "+1,2"),
-                    ),
-                    path: "",
-                    path_bytes: "uncommitted1.txt",
-                    line_nums_added: None,
-                    line_nums_removed: None,
-                    diff: None,
+                head: IdAndHunk {
+                    id: "ro:q#0-2",
+                    hunk: WorktreeHunk {
+                        id: None,
+                        hunk_header: Some(
+                            HunkHeader("-1,2", "+1,2"),
+                        ),
+                        path: "",
+                        path_bytes: "uncommitted1.txt",
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: None,
+                    },
                 },
                 tail: [],
             },
@@ -1515,16 +1624,19 @@ fn uncommitted_hunks_by_numeric_index() -> anyhow::Result<()> {
         UncommittedHunkOrFile {
             id: "ro:q#0-2",
             hunk_assignments: NonEmpty {
-                head: WorktreeHunk {
-                    id: None,
-                    hunk_header: Some(
-                        HunkHeader("-1,2", "+1,2"),
-                    ),
-                    path: "",
-                    path_bytes: "uncommitted1.txt",
-                    line_nums_added: None,
-                    line_nums_removed: None,
-                    diff: None,
+                head: IdAndHunk {
+                    id: "ro:q#0-2",
+                    hunk: WorktreeHunk {
+                        id: None,
+                        hunk_header: Some(
+                            HunkHeader("-1,2", "+1,2"),
+                        ),
+                        path: "",
+                        path_bytes: "uncommitted1.txt",
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: None,
+                    },
                 },
                 tail: [],
             },
@@ -1546,16 +1658,19 @@ fn uncommitted_hunks_by_numeric_index() -> anyhow::Result<()> {
         UncommittedHunkOrFile {
             id: "ro:q#0-2",
             hunk_assignments: NonEmpty {
-                head: WorktreeHunk {
-                    id: None,
-                    hunk_header: Some(
-                        HunkHeader("-1,2", "+1,2"),
-                    ),
-                    path: "",
-                    path_bytes: "uncommitted1.txt",
-                    line_nums_added: None,
-                    line_nums_removed: None,
-                    diff: None,
+                head: IdAndHunk {
+                    id: "ro:q#0-2",
+                    hunk: WorktreeHunk {
+                        id: None,
+                        hunk_header: Some(
+                            HunkHeader("-1,2", "+1,2"),
+                        ),
+                        path: "",
+                        path_bytes: "uncommitted1.txt",
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: None,
+                    },
                 },
                 tail: [],
             },
@@ -1624,18 +1739,21 @@ fn uncommitted_hunks_by_id() -> anyhow::Result<()> {
         UncommittedHunkOrFile {
             id: "ro:3",
             hunk_assignments: NonEmpty {
-                head: WorktreeHunk {
-                    id: None,
-                    hunk_header: Some(
-                        HunkHeader("-1,6", "+1,7"),
-                    ),
-                    path: "",
-                    path_bytes: "uncommitted1.txt",
-                    line_nums_added: None,
-                    line_nums_removed: None,
-                    diff: Some(
-                        "@@ -1,6 +1,7 @@\n 1\n 2\n 3\n+hello\n 4\n 5\n 6\n",
-                    ),
+                head: IdAndHunk {
+                    id: "ro:3",
+                    hunk: WorktreeHunk {
+                        id: None,
+                        hunk_header: Some(
+                            HunkHeader("-1,6", "+1,7"),
+                        ),
+                        path: "",
+                        path_bytes: "uncommitted1.txt",
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: Some(
+                            "@@ -1,6 +1,7 @@\n 1\n 2\n 3\n+hello\n 4\n 5\n 6\n",
+                        ),
+                    },
                 },
                 tail: [],
             },
@@ -1656,18 +1774,21 @@ fn uncommitted_hunks_by_id() -> anyhow::Result<()> {
         UncommittedHunkOrFile {
             id: "ro:f",
             hunk_assignments: NonEmpty {
-                head: WorktreeHunk {
-                    id: None,
-                    hunk_header: Some(
-                        HunkHeader("-23,6", "+24,7"),
-                    ),
-                    path: "",
-                    path_bytes: "uncommitted1.txt",
-                    line_nums_added: None,
-                    line_nums_removed: None,
-                    diff: Some(
-                        "@@ -23,6 +24,7 @@\n 1\n 2\n 3\n+there\n 4\n 5\n 6\n",
-                    ),
+                head: IdAndHunk {
+                    id: "ro:f",
+                    hunk: WorktreeHunk {
+                        id: None,
+                        hunk_header: Some(
+                            HunkHeader("-23,6", "+24,7"),
+                        ),
+                        path: "",
+                        path_bytes: "uncommitted1.txt",
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: Some(
+                            "@@ -23,6 +24,7 @@\n 1\n 2\n 3\n+there\n 4\n 5\n 6\n",
+                        ),
+                    },
                 },
                 tail: [],
             },
@@ -1688,18 +1809,21 @@ fn uncommitted_hunks_by_id() -> anyhow::Result<()> {
         UncommittedHunkOrFile {
             id: "ro:1",
             hunk_assignments: NonEmpty {
-                head: WorktreeHunk {
-                    id: None,
-                    hunk_header: Some(
-                        HunkHeader("-60,6", "+62,7"),
-                    ),
-                    path: "",
-                    path_bytes: "uncommitted1.txt",
-                    line_nums_added: None,
-                    line_nums_removed: None,
-                    diff: Some(
-                        "@@ -60,6 +62,7 @@\n 46\n 47\n 48\n+hello\n 49\n 50\n 51\n",
-                    ),
+                head: IdAndHunk {
+                    id: "ro:1",
+                    hunk: WorktreeHunk {
+                        id: None,
+                        hunk_header: Some(
+                            HunkHeader("-60,6", "+62,7"),
+                        ),
+                        path: "",
+                        path_bytes: "uncommitted1.txt",
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: Some(
+                            "@@ -60,6 +62,7 @@\n 46\n 47\n 48\n+hello\n 49\n 50\n 51\n",
+                        ),
+                    },
                 },
                 tail: [],
             },
@@ -1723,14 +1847,17 @@ fn uncommitted_hunks_by_id() -> anyhow::Result<()> {
         UncommittedHunkOrFile {
             id: "wp:q",
             hunk_assignments: NonEmpty {
-                head: WorktreeHunk {
-                    id: None,
-                    hunk_header: None,
-                    path: "",
-                    path_bytes: "hunk_without_diff.txt",
-                    line_nums_added: None,
-                    line_nums_removed: None,
-                    diff: None,
+                head: IdAndHunk {
+                    id: "wp:q",
+                    hunk: WorktreeHunk {
+                        id: None,
+                        hunk_header: None,
+                        path: "",
+                        path_bytes: "hunk_without_diff.txt",
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: None,
+                    },
                 },
                 tail: [],
             },
@@ -1789,18 +1916,21 @@ fn uncommitted_hunks_by_id_increase_id_length_as_necessary() -> anyhow::Result<(
         UncommittedHunkOrFile {
             id: "ro:78",
             hunk_assignments: NonEmpty {
-                head: WorktreeHunk {
-                    id: None,
-                    hunk_header: Some(
-                        HunkHeader("-1,6", "+1,7"),
-                    ),
-                    path: "",
-                    path_bytes: "uncommitted1.txt",
-                    line_nums_added: None,
-                    line_nums_removed: None,
-                    diff: Some(
-                        "@@ -1,6 +1,7 @@\n 1\n 2\n 3\n+hellooooo\n 4\n 5\n 6\n",
-                    ),
+                head: IdAndHunk {
+                    id: "ro:78",
+                    hunk: WorktreeHunk {
+                        id: None,
+                        hunk_header: Some(
+                            HunkHeader("-1,6", "+1,7"),
+                        ),
+                        path: "",
+                        path_bytes: "uncommitted1.txt",
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: Some(
+                            "@@ -1,6 +1,7 @@\n 1\n 2\n 3\n+hellooooo\n 4\n 5\n 6\n",
+                        ),
+                    },
                 },
                 tail: [],
             },
@@ -1823,18 +1953,21 @@ fn uncommitted_hunks_by_id_increase_id_length_as_necessary() -> anyhow::Result<(
         UncommittedHunkOrFile {
             id: "ro:79",
             hunk_assignments: NonEmpty {
-                head: WorktreeHunk {
-                    id: None,
-                    hunk_header: Some(
-                        HunkHeader("-23,6", "+24,7"),
-                    ),
-                    path: "",
-                    path_bytes: "uncommitted1.txt",
-                    line_nums_added: None,
-                    line_nums_removed: None,
-                    diff: Some(
-                        "@@ -23,6 +24,7 @@\n 1\n 2\n 3\n+hellooo\n 4\n 5\n 6\n",
-                    ),
+                head: IdAndHunk {
+                    id: "ro:79",
+                    hunk: WorktreeHunk {
+                        id: None,
+                        hunk_header: Some(
+                            HunkHeader("-23,6", "+24,7"),
+                        ),
+                        path: "",
+                        path_bytes: "uncommitted1.txt",
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: Some(
+                            "@@ -23,6 +24,7 @@\n 1\n 2\n 3\n+hellooo\n 4\n 5\n 6\n",
+                        ),
+                    },
                 },
                 tail: [],
             },
@@ -1892,18 +2025,21 @@ fn uncommitted_hunks_overspecifying_id_prefix() -> anyhow::Result<()> {
         UncommittedHunkOrFile {
             id: "ro:7",
             hunk_assignments: NonEmpty {
-                head: WorktreeHunk {
-                    id: None,
-                    hunk_header: Some(
-                        HunkHeader("-1,6", "+1,7"),
-                    ),
-                    path: "",
-                    path_bytes: "uncommitted1.txt",
-                    line_nums_added: None,
-                    line_nums_removed: None,
-                    diff: Some(
-                        "@@ -1,6 +1,7 @@\n 1\n 2\n 3\n+hellooooo\n 4\n 5\n 6\n",
-                    ),
+                head: IdAndHunk {
+                    id: "ro:7",
+                    hunk: WorktreeHunk {
+                        id: None,
+                        hunk_header: Some(
+                            HunkHeader("-1,6", "+1,7"),
+                        ),
+                        path: "",
+                        path_bytes: "uncommitted1.txt",
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: Some(
+                            "@@ -1,6 +1,7 @@\n 1\n 2\n 3\n+hellooooo\n 4\n 5\n 6\n",
+                        ),
+                    },
                 },
                 tail: [],
             },
@@ -1967,18 +2103,21 @@ fn uncommitted_hunks_overspecifying_id_prefix_with_collision_disambiguation() ->
         UncommittedHunkOrFile {
             id: "ro:3#0-2",
             hunk_assignments: NonEmpty {
-                head: WorktreeHunk {
-                    id: None,
-                    hunk_header: Some(
-                        HunkHeader("-1,6", "+1,7"),
-                    ),
-                    path: "",
-                    path_bytes: "uncommitted1.txt",
-                    line_nums_added: None,
-                    line_nums_removed: None,
-                    diff: Some(
-                        "@@ -1,6 +1,7 @@\n 1\n 2\n 3\n+hello\n 4\n 5\n 6\n",
-                    ),
+                head: IdAndHunk {
+                    id: "ro:3#0-2",
+                    hunk: WorktreeHunk {
+                        id: None,
+                        hunk_header: Some(
+                            HunkHeader("-1,6", "+1,7"),
+                        ),
+                        path: "",
+                        path_bytes: "uncommitted1.txt",
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: Some(
+                            "@@ -1,6 +1,7 @@\n 1\n 2\n 3\n+hello\n 4\n 5\n 6\n",
+                        ),
+                    },
                 },
                 tail: [],
             },
@@ -2046,18 +2185,21 @@ fn underspecifying_hunk_ids() -> anyhow::Result<()> {
         UncommittedHunkOrFile {
             id: "ro:78#0-2",
             hunk_assignments: NonEmpty {
-                head: WorktreeHunk {
-                    id: None,
-                    hunk_header: Some(
-                        HunkHeader("-1,6", "+1,7"),
-                    ),
-                    path: "",
-                    path_bytes: "uncommitted1.txt",
-                    line_nums_added: None,
-                    line_nums_removed: None,
-                    diff: Some(
-                        "@@ -1,6 +1,7 @@\n 1\n 2\n 3\n+hellooooo\n 4\n 5\n 6\n",
-                    ),
+                head: IdAndHunk {
+                    id: "ro:78#0-2",
+                    hunk: WorktreeHunk {
+                        id: None,
+                        hunk_header: Some(
+                            HunkHeader("-1,6", "+1,7"),
+                        ),
+                        path: "",
+                        path_bytes: "uncommitted1.txt",
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: Some(
+                            "@@ -1,6 +1,7 @@\n 1\n 2\n 3\n+hellooooo\n 4\n 5\n 6\n",
+                        ),
+                    },
                 },
                 tail: [],
             },
@@ -2068,18 +2210,21 @@ fn underspecifying_hunk_ids() -> anyhow::Result<()> {
         UncommittedHunkOrFile {
             id: "ro:79",
             hunk_assignments: NonEmpty {
-                head: WorktreeHunk {
-                    id: None,
-                    hunk_header: Some(
-                        HunkHeader("-23,6", "+24,7"),
-                    ),
-                    path: "",
-                    path_bytes: "uncommitted1.txt",
-                    line_nums_added: None,
-                    line_nums_removed: None,
-                    diff: Some(
-                        "@@ -23,6 +24,7 @@\n 1\n 2\n 3\n+hellooo\n 4\n 5\n 6\n",
-                    ),
+                head: IdAndHunk {
+                    id: "ro:79",
+                    hunk: WorktreeHunk {
+                        id: None,
+                        hunk_header: Some(
+                            HunkHeader("-23,6", "+24,7"),
+                        ),
+                        path: "",
+                        path_bytes: "uncommitted1.txt",
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: Some(
+                            "@@ -23,6 +24,7 @@\n 1\n 2\n 3\n+hellooo\n 4\n 5\n 6\n",
+                        ),
+                    },
                 },
                 tail: [],
             },
@@ -2090,18 +2235,21 @@ fn underspecifying_hunk_ids() -> anyhow::Result<()> {
         UncommittedHunkOrFile {
             id: "ro:78#1-2",
             hunk_assignments: NonEmpty {
-                head: WorktreeHunk {
-                    id: None,
-                    hunk_header: Some(
-                        HunkHeader("-33,6", "+35,7"),
-                    ),
-                    path: "",
-                    path_bytes: "uncommitted1.txt",
-                    line_nums_added: None,
-                    line_nums_removed: None,
-                    diff: Some(
-                        "@@ -33,6 +35,7 @@\n 1\n 2\n 3\n+hellooooo\n 4\n 5\n 6\n",
-                    ),
+                head: IdAndHunk {
+                    id: "ro:78#1-2",
+                    hunk: WorktreeHunk {
+                        id: None,
+                        hunk_header: Some(
+                            HunkHeader("-33,6", "+35,7"),
+                        ),
+                        path: "",
+                        path_bytes: "uncommitted1.txt",
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: Some(
+                            "@@ -33,6 +35,7 @@\n 1\n 2\n 3\n+hellooooo\n 4\n 5\n 6\n",
+                        ),
+                    },
                 },
                 tail: [],
             },
@@ -2125,18 +2273,21 @@ fn underspecifying_hunk_ids() -> anyhow::Result<()> {
         UncommittedHunkOrFile {
             id: "ro:78#0-2",
             hunk_assignments: NonEmpty {
-                head: WorktreeHunk {
-                    id: None,
-                    hunk_header: Some(
-                        HunkHeader("-1,6", "+1,7"),
-                    ),
-                    path: "",
-                    path_bytes: "uncommitted1.txt",
-                    line_nums_added: None,
-                    line_nums_removed: None,
-                    diff: Some(
-                        "@@ -1,6 +1,7 @@\n 1\n 2\n 3\n+hellooooo\n 4\n 5\n 6\n",
-                    ),
+                head: IdAndHunk {
+                    id: "ro:78#0-2",
+                    hunk: WorktreeHunk {
+                        id: None,
+                        hunk_header: Some(
+                            HunkHeader("-1,6", "+1,7"),
+                        ),
+                        path: "",
+                        path_bytes: "uncommitted1.txt",
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: Some(
+                            "@@ -1,6 +1,7 @@\n 1\n 2\n 3\n+hellooooo\n 4\n 5\n 6\n",
+                        ),
+                    },
                 },
                 tail: [],
             },
@@ -2217,18 +2368,21 @@ fn uncommitted_hunks_by_id_collision_handling() -> anyhow::Result<()> {
         UncommittedHunkOrFile {
             id: "ro:3#0-2",
             hunk_assignments: NonEmpty {
-                head: WorktreeHunk {
-                    id: None,
-                    hunk_header: Some(
-                        HunkHeader("-1,6", "+1,7"),
-                    ),
-                    path: "",
-                    path_bytes: "uncommitted1.txt",
-                    line_nums_added: None,
-                    line_nums_removed: None,
-                    diff: Some(
-                        "@@ -1,6 +1,7 @@\n 1\n 2\n 3\n+hello\n 4\n 5\n 6\n",
-                    ),
+                head: IdAndHunk {
+                    id: "ro:3#0-2",
+                    hunk: WorktreeHunk {
+                        id: None,
+                        hunk_header: Some(
+                            HunkHeader("-1,6", "+1,7"),
+                        ),
+                        path: "",
+                        path_bytes: "uncommitted1.txt",
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: Some(
+                            "@@ -1,6 +1,7 @@\n 1\n 2\n 3\n+hello\n 4\n 5\n 6\n",
+                        ),
+                    },
                 },
                 tail: [],
             },
@@ -2251,18 +2405,21 @@ fn uncommitted_hunks_by_id_collision_handling() -> anyhow::Result<()> {
         UncommittedHunkOrFile {
             id: "ro:3#1-2",
             hunk_assignments: NonEmpty {
-                head: WorktreeHunk {
-                    id: None,
-                    hunk_header: Some(
-                        HunkHeader("-23,6", "+24,7"),
-                    ),
-                    path: "",
-                    path_bytes: "uncommitted1.txt",
-                    line_nums_added: None,
-                    line_nums_removed: None,
-                    diff: Some(
-                        "@@ -23,6 +24,7 @@\n 1\n 2\n 3\n+hello\n 4\n 5\n 6\n",
-                    ),
+                head: IdAndHunk {
+                    id: "ro:3#1-2",
+                    hunk: WorktreeHunk {
+                        id: None,
+                        hunk_header: Some(
+                            HunkHeader("-23,6", "+24,7"),
+                        ),
+                        path: "",
+                        path_bytes: "uncommitted1.txt",
+                        line_nums_added: None,
+                        line_nums_removed: None,
+                        diff: Some(
+                            "@@ -23,6 +24,7 @@\n 1\n 2\n 3\n+hello\n 4\n 5\n 6\n",
+                        ),
+                    },
                 },
                 tail: [],
             },
@@ -2554,7 +2711,7 @@ fn uncommitted_selector_is_not_shadowed_by_commit_change_id() -> anyhow::Result<
     match scoped.as_slice() {
         [CliId::UncommittedHunkOrFile(uncommitted)] => {
             assert_eq!(
-                uncommitted.hunk_assignments.first().path_bytes,
+                uncommitted.hunk_assignments.first().hunk.path_bytes,
                 "README.md",
                 "the selector resolves to the file it was issued for"
             );
@@ -2576,7 +2733,10 @@ fn uncommitted_selector_is_not_shadowed_by_commit_change_id() -> anyhow::Result<
         .expect("selector resolution succeeds")
         .expect("the issued hunk selector still resolves");
     assert_eq!(resolved.len(), 1, "exactly one hunk resolves");
-    assert_eq!(resolved[0].hunk_assignments.first().path_bytes, "README.md");
+    assert_eq!(
+        resolved[0].hunk_assignments.first().hunk.path_bytes,
+        "README.md"
+    );
 
     let resolved = CliIdArg(format!("{file_id}:q"))
         .resolve_in_workspace(
@@ -2616,7 +2776,7 @@ fn uncommitted_scope_resolves_a_file_literally_named_zz() -> anyhow::Result<()> 
     let scoped = id_map.parse_uncommitted("zz", Box::new(changed_paths_fn))?;
     match scoped.as_slice() {
         [CliId::UncommittedHunkOrFile(uncommitted)] => {
-            assert_eq!(uncommitted.hunk_assignments.first().path_bytes, "zz");
+            assert_eq!(uncommitted.hunk_assignments.first().hunk.path_bytes, "zz");
         }
         other => panic!("expected exactly the file named zz, got {other:?}"),
     }

--- a/crates/but/src/tui/diff_viewer.rs
+++ b/crates/but/src/tui/diff_viewer.rs
@@ -11,7 +11,7 @@ use ratatui::{
 };
 
 use crate::{
-    id::{UncommittedHunkOrFile, WorktreeHunk},
+    id::{IdAndHunk, UncommittedHunkOrFile, WorktreeHunk},
     theme,
     tui::TerminalGuard as _,
 };
@@ -77,11 +77,14 @@ impl DiffFileEntry {
     }
 
     pub fn from_hunk_assignments<'a>(
-        hunk_assignments: impl IntoIterator<Item = &'a (String, WorktreeHunk)>,
+        hunk_assignments: impl IntoIterator<Item = &'a IdAndHunk>,
     ) -> Vec<DiffFileEntry> {
         let mut by_path: BTreeMap<String, Vec<&WorktreeHunk>> = BTreeMap::new();
-        for (_, a) in hunk_assignments {
-            by_path.entry(a.path.clone()).or_default().push(a);
+        for id_and_hunk in hunk_assignments {
+            by_path
+                .entry(id_and_hunk.hunk.path.clone())
+                .or_default()
+                .push(&id_and_hunk.hunk);
         }
 
         Self::from_hunk_assignments_by_path(by_path)

--- a/crates/but/src/tui/diff_viewer.rs
+++ b/crates/but/src/tui/diff_viewer.rs
@@ -62,9 +62,9 @@ impl DiffFileEntry {
                 Some(WorktreeFilter::UncommittedArea) => true,
                 Some(WorktreeFilter::Uncommitted(id)) => {
                     if id.is_entire_file {
-                        a.path_bytes == id.hunk_assignments.first().path_bytes
+                        a.path_bytes == id.hunk_assignments.first().hunk.path_bytes
                     } else {
-                        a.eq(id.hunk_assignments.first())
+                        a.eq(&id.hunk_assignments.first().hunk)
                     }
                 }
             };

--- a/crates/but/src/utils/diff_rendering.rs
+++ b/crates/but/src/utils/diff_rendering.rs
@@ -588,7 +588,9 @@ pub fn render_uncommitted(
 
     if !options.skip_line_stats {
         let line_stats = render_line_stats(compute_line_stats_from_uncommitted_hunks(
-            &uncommitted_hunks,
+            uncommitted_hunks
+                .iter()
+                .map(|(_, _, hunk)| &hunk.hunk_assignment),
         ));
         out.write_selectable_text(id_gen.new_id("line_stats"), None, line_stats)?;
         out.write_section_separator()?;
@@ -620,7 +622,6 @@ pub fn render_uncommitted(
 
 pub fn render_uncommitted_hunk(
     hunk: UncommittedHunkOrFile,
-    ctx: &mut Context,
     theme: &'static Theme,
     id_gen: &mut IdGen<'_>,
     options: Options,
@@ -628,36 +629,47 @@ pub fn render_uncommitted_hunk(
 ) -> anyhow::Result<()> {
     let mut id_gen = id_gen.scoped("hunk");
     let mut id_gen = id_gen.scoped(&hunk.id);
-
-    let wt_changes = but_api::diff::changes_in_worktree(ctx, true)?;
-    let id_map = IdMap::legacy_new_from_context(ctx, Some(wt_changes.assignments))?;
-    let uncommitted_hunks = filter_uncommitted_hunks(ctx, &id_map, |hunk_assignment| {
-        uncommitted_hunk_matches_selection(hunk_assignment, &hunk)
-    })?;
+    let mut hunks = hunk.hunk_assignments.into_iter().collect::<Vec<_>>();
+    hunks.sort_by(|a, b| {
+        (
+            &a.hunk.path_bytes,
+            a.hunk.hunk_header.as_ref().map(|header| header.old_start),
+            &a.id,
+        )
+            .cmp(&(
+                &b.hunk.path_bytes,
+                b.hunk.hunk_header.as_ref().map(|header| header.old_start),
+                &b.id,
+            ))
+    });
 
     if !options.skip_line_stats {
         let line_stats = render_line_stats(compute_line_stats_from_uncommitted_hunks(
-            &uncommitted_hunks,
+            hunks.iter().map(|hunk| &hunk.hunk),
         ));
         out.write_selectable_text(id_gen.new_id("line_stats"), None, line_stats)?;
         out.write_section_separator()?;
     }
 
-    for (pos, (raw_id, cli_id, UncommittedHunk { hunk_assignment })) in
-        uncommitted_hunks.into_iter().with_position()
-    {
+    for (pos, id_and_hunk) in hunks.into_iter().with_position() {
+        let raw_id = &id_and_hunk.id;
         let id = id_gen.new_id(raw_id);
+        let cli_id = Arc::new(CliId::UncommittedHunkOrFile(UncommittedHunkOrFile {
+            id: raw_id.clone(),
+            hunk_assignments: nonempty::NonEmpty::new(id_and_hunk.clone()),
+            is_entire_file: false,
+        }));
 
         render_hunk_path_header(
             id,
             Some(Arc::clone(&cli_id)),
-            hunk_assignment.path_bytes.as_ref(),
+            id_and_hunk.hunk.path_bytes.as_ref(),
             Some(ShortIdOrTreeStatus::ShortId(raw_id)),
             out,
             theme,
         )?;
 
-        render_hunk_assignment(id, Some(Arc::clone(&cli_id)), hunk_assignment, theme, out)?;
+        render_hunk_assignment(id, Some(Arc::clone(&cli_id)), &id_and_hunk.hunk, theme, out)?;
 
         if pos.needs_padding_below() {
             out.write_section_separator()?;
@@ -1073,19 +1085,18 @@ fn render_unified_patch(
     Ok(())
 }
 
-fn compute_line_stats_from_uncommitted_hunks(
-    uncommitted_hunks: &[(&str, Arc<CliId>, &UncommittedHunk)],
+fn compute_line_stats_from_uncommitted_hunks<'a>(
+    uncommitted_hunks: impl IntoIterator<Item = &'a WorktreeHunk>,
 ) -> LineStats {
     let mut line_stats = LineStats::default();
     let mut unique_paths = HashSet::new();
-    for (_, _, hunk) in uncommitted_hunks {
-        let hunk_assignment = &hunk.hunk_assignment;
-        unique_paths.insert(&hunk_assignment.path_bytes);
-        line_stats.lines_added += hunk_assignment
+    for hunk in uncommitted_hunks {
+        unique_paths.insert(&hunk.path_bytes);
+        line_stats.lines_added += hunk
             .line_nums_added
             .as_ref()
             .map_or(0, |lines| lines.len() as u64);
-        line_stats.lines_removed += hunk_assignment
+        line_stats.lines_removed += hunk
             .line_nums_removed
             .as_ref()
             .map_or(0, |lines| lines.len() as u64);
@@ -1143,20 +1154,6 @@ where
     });
 
     Ok(uncommitted_hunks)
-}
-
-/// Returns true if `hunk_assignment` is part of the selected uncommitted entity.
-fn uncommitted_hunk_matches_selection(
-    hunk_assignment: &WorktreeHunk,
-    hunk: &UncommittedHunkOrFile,
-) -> bool {
-    let selected_hunk = &hunk.hunk_assignments.first().hunk;
-
-    if hunk.is_entire_file {
-        hunk_assignment.path_bytes == selected_hunk.path_bytes
-    } else {
-        hunk_assignment == selected_hunk
-    }
 }
 
 trait PositionExt {
@@ -1218,9 +1215,117 @@ pub fn load_syntax_set() -> SyntaxSet {
 
 #[cfg(test)]
 mod tests {
+    use bstr::BString;
+    use nonempty::NonEmpty;
     use ratatui::text::Span;
 
-    use super::{expand_tabs_for_display, format_with_dot_thousands};
+    use super::{
+        DetailsLine, DiffLineWriter, IdGen, Options, compute_line_stats_from_uncommitted_hunks,
+        expand_tabs_for_display, format_with_dot_thousands, render_uncommitted_hunk,
+    };
+    use crate::{
+        CliId,
+        id::{IdAndHunk, UncommittedHunkOrFile, WorktreeHunk},
+        utils::string_interning::Strings,
+    };
+
+    #[derive(Default)]
+    struct CollectingWriter {
+        lines: Vec<DetailsLine>,
+    }
+
+    impl DiffLineWriter for CollectingWriter {
+        fn write(&mut self, line: DetailsLine) -> anyhow::Result<()> {
+            self.lines.push(line);
+            Ok(())
+        }
+    }
+
+    fn id_and_hunk(id: &str, path: &str) -> IdAndHunk {
+        IdAndHunk {
+            id: id.to_owned(),
+            hunk: WorktreeHunk {
+                id: None,
+                hunk_header: None,
+                path: path.to_owned(),
+                path_bytes: BString::from(path),
+                line_nums_added: None,
+                line_nums_removed: None,
+                diff: None,
+            },
+        }
+    }
+
+    #[test]
+    fn renders_the_hunks_stored_in_the_selection() -> anyhow::Result<()> {
+        let selection = UncommittedHunkOrFile {
+            id: "fi".to_owned(),
+            hunk_assignments: NonEmpty {
+                head: id_and_hunk("fi:b", "file.txt"),
+                tail: vec![id_and_hunk("fi:a", "file.txt")],
+            },
+            is_entire_file: true,
+        };
+        let mut id_gen = IdGen::new(Strings::default());
+        let mut writer = CollectingWriter::default();
+
+        render_uncommitted_hunk(
+            selection,
+            crate::theme::get(),
+            &mut id_gen,
+            Options {
+                skip_commit_header: true,
+                skip_line_stats: true,
+            },
+            &mut writer,
+        )?;
+
+        let rendered_ids = writer
+            .lines
+            .iter()
+            .filter_map(|line| match line {
+                DetailsLine::HunkHeader {
+                    cli_id: Some(cli_id),
+                    ..
+                } => match &**cli_id {
+                    CliId::UncommittedHunkOrFile(hunk) => Some(hunk.id.as_str()),
+                    CliId::PathPrefix { .. }
+                    | CliId::CommittedFile { .. }
+                    | CliId::Branch(..)
+                    | CliId::Commit { .. }
+                    | CliId::Uncommitted { .. }
+                    | CliId::Stack { .. } => None,
+                },
+                DetailsLine::Text { .. }
+                | DetailsLine::TextToWrap { .. }
+                | DetailsLine::Code(..)
+                | DetailsLine::SectionSeparator
+                | DetailsLine::HunkHeader { cli_id: None, .. } => None,
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            rendered_ids,
+            ["fi:a", "fi:b"],
+            "the renderer uses every supplied hunk and preserves deterministic ordering"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn computes_stats_from_the_supplied_hunks() {
+        let mut first = id_and_hunk("fi:a", "first.txt").hunk;
+        first.line_nums_added = Some(vec![1, 2]);
+        first.line_nums_removed = Some(vec![3]);
+        let mut second = id_and_hunk("se:a", "second.txt").hunk;
+        second.line_nums_added = Some(vec![1]);
+
+        let stats = compute_line_stats_from_uncommitted_hunks([&first, &second]);
+
+        assert_eq!(stats.files_changed, 2, "both supplied paths are counted");
+        assert_eq!(stats.lines_added, 3, "all supplied additions are counted");
+        assert_eq!(stats.lines_removed, 1, "all supplied removals are counted");
+    }
 
     #[test]
     fn expands_tabs_to_four_column_stops_across_spans() {

--- a/crates/but/src/utils/diff_rendering.rs
+++ b/crates/but/src/utils/diff_rendering.rs
@@ -1150,7 +1150,7 @@ fn uncommitted_hunk_matches_selection(
     hunk_assignment: &WorktreeHunk,
     hunk: &UncommittedHunkOrFile,
 ) -> bool {
-    let selected_hunk = hunk.hunk_assignments.first();
+    let selected_hunk = &hunk.hunk_assignments.first().hunk;
 
     if hunk.is_entire_file {
         hunk_assignment.path_bytes == selected_hunk.path_bytes

--- a/crates/but/src/utils/diff_rendering.rs
+++ b/crates/but/src/utils/diff_rendering.rs
@@ -17,6 +17,7 @@ use but_core::{
 use but_ctx::Context;
 use gix::{ObjectId, actor::Signature};
 use itertools::{Itertools, Position};
+use nonempty::NonEmpty;
 use ratatui::{
     style::{Color, Stylize as _},
     text::{Line, Span},
@@ -29,7 +30,7 @@ use unicode_width::UnicodeWidthStr as _;
 
 use crate::{
     CliId, IdMap,
-    id::{UncommittedHunk, UncommittedHunkOrFile, WorktreeHunk},
+    id::{IdAndHunk, UncommittedHunk, UncommittedHunkOrFile, WorktreeHunk},
     theme::Theme,
     utils::string_interning::{SharedStrings, Strings},
 };
@@ -629,7 +630,42 @@ pub fn render_uncommitted_hunk(
 ) -> anyhow::Result<()> {
     let mut id_gen = id_gen.scoped("hunk");
     let mut id_gen = id_gen.scoped(&hunk.id);
-    let mut hunks = hunk.hunk_assignments.into_iter().collect::<Vec<_>>();
+    render_id_and_hunks(
+        hunk.hunk_assignments.into_iter().collect(),
+        theme,
+        &mut id_gen,
+        options,
+        out,
+    )
+}
+
+pub fn render_path_prefix(
+    id: &str,
+    hunks: NonEmpty<IdAndHunk>,
+    _ctx: &mut Context,
+    theme: &'static Theme,
+    id_gen: &mut IdGen<'_>,
+    options: Options,
+    out: &mut dyn DiffLineWriter,
+) -> anyhow::Result<()> {
+    let mut id_gen = id_gen.scoped("path_prefix");
+    let mut id_gen = id_gen.scoped(id);
+    render_id_and_hunks(
+        hunks.into_iter().collect(),
+        theme,
+        &mut id_gen,
+        options,
+        out,
+    )
+}
+
+fn render_id_and_hunks(
+    mut hunks: Vec<IdAndHunk>,
+    theme: &'static Theme,
+    id_gen: &mut IdGen<'_>,
+    options: Options,
+    out: &mut dyn DiffLineWriter,
+) -> anyhow::Result<()> {
     hunks.sort_by(|a, b| {
         (
             &a.hunk.path_bytes,
@@ -656,7 +692,7 @@ pub fn render_uncommitted_hunk(
         let id = id_gen.new_id(raw_id);
         let cli_id = Arc::new(CliId::UncommittedHunkOrFile(UncommittedHunkOrFile {
             id: raw_id.clone(),
-            hunk_assignments: nonempty::NonEmpty::new(id_and_hunk.clone()),
+            hunk_assignments: NonEmpty::new(id_and_hunk.clone()),
             is_entire_file: false,
         }));
 

--- a/crates/but/src/utils/diff_specs.rs
+++ b/crates/but/src/utils/diff_specs.rs
@@ -76,7 +76,7 @@ impl<'a> DiffSpecBuilder<'a> {
         uncommitted: &UncommittedHunkOrFile,
     ) -> anyhow::Result<()> {
         let assignments = uncommitted.hunk_assignments.iter().cloned();
-        self.push_hunk_assignments(assignments)
+        self.push_hunk_assignments(assignments.map(|hunk| hunk.hunk))
     }
 
     pub fn push_changes_from_path_prefix(

--- a/crates/but/src/utils/diff_specs.rs
+++ b/crates/but/src/utils/diff_specs.rs
@@ -4,7 +4,7 @@ use but_core::{DiffSpec, HunkHeader};
 
 use crate::{
     CliId,
-    id::{CommitId, CommittedFileId, ShortId, UncommittedHunkOrFile, WorktreeHunk},
+    id::{CommitId, CommittedFileId, IdAndHunk, UncommittedHunkOrFile, WorktreeHunk},
 };
 
 #[derive(Debug)]
@@ -81,12 +81,12 @@ impl<'a> DiffSpecBuilder<'a> {
 
     pub fn push_changes_from_path_prefix(
         &mut self,
-        hunk_assignments: &nonempty::NonEmpty<(ShortId, WorktreeHunk)>,
+        hunk_assignments: &nonempty::NonEmpty<IdAndHunk>,
     ) -> anyhow::Result<()> {
         self.push_hunk_assignments(
             hunk_assignments
                 .iter()
-                .map(|(_id, assignment)| assignment.clone()),
+                .map(|id_and_hunk| id_and_hunk.hunk.clone()),
         )
     }
 

--- a/crates/but/tests/but/command/diff2.rs
+++ b/crates/but/tests/but/command/diff2.rs
@@ -41,3 +41,35 @@ puts "\nA distant door unlocks."
         .success()
         .stdout_eq(snapbox::file!["snapshots/diff2/uncommitted.stdout"].raw());
 }
+
+#[test]
+fn path_prefix() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
+
+    env.file("a/b/c.txt", "content of c");
+    env.file("a/b/d.txt", "content of d");
+    env.file("a/b.txt", "content of b");
+
+    env.but("_diff2 a/b/")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+────────────────╮
+ up:2 a/b/c.txt │
+────────────────╯
+ 
+@@ -1,0 +1,1 @@
+───────────────
+  ┊ 1 │ +content of c
+
+────────────────╮
+ oz:8 a/b/d.txt │
+────────────────╯
+ 
+@@ -1,0 +1,1 @@
+───────────────
+  ┊ 1 │ +content of d
+
+"#]]);
+}


### PR DESCRIPTION
The cli id carries the hunk so we don't need to re-fetch it.