### PR TITLE
Refresh CLI documentation

### DIFF
--- a/crates/but-clap/src/generator.rs
+++ b/crates/but-clap/src/generator.rs
@@ -227,10 +227,7 @@ fn generate_argument_doc(arg: &Arg) -> String {
 
     doc.push_str(&format!("* `<{arg_name}>` "));
 
-    // Add help text, preferring long_help
-    if let Some(long_help) = arg.get_long_help() {
-        doc.push_str(&format!("— {long_help}"));
-    } else if let Some(help) = arg.get_help() {
+    if let Some(help) = mdx_help(arg) {
         doc.push_str(&format!("— {help}"));
     }
 
@@ -272,10 +269,7 @@ fn generate_option_doc(opt: &Arg) -> String {
 
     doc.push_str(&format!("* {sig} "));
 
-    // Add help text, preferring long_help
-    if let Some(long_help) = opt.get_long_help() {
-        doc.push_str(&format!("— {long_help}"));
-    } else if let Some(help) = opt.get_help() {
+    if let Some(help) = mdx_help(opt) {
         doc.push_str(&format!("— {help}"));
     }
 
@@ -293,4 +287,12 @@ fn generate_option_doc(opt: &Arg) -> String {
 
     doc.push('\n');
     doc
+}
+
+fn mdx_help(arg: &Arg) -> Option<String> {
+    arg.get_long_help().or_else(|| arg.get_help()).map(|help| {
+        replace_rustdoc_hyperlinks(&help.to_string())
+            .replace('<', "&lt;")
+            .replace('>', "&gt;")
+    })
 }

--- a/crates/but-clap/src/main.rs
+++ b/crates/but-clap/src/main.rs
@@ -6,9 +6,13 @@ use but_clap::generator;
 fn main() -> Result<()> {
     use clap::CommandFactory;
 
-    // Create the cli-docs directory if it doesn't exist
     let docs_dir = Path::new("cli-docs");
-    fs::create_dir_all(docs_dir).context("Failed to create cli-docs directory")?;
+    let next_docs_dir = Path::new("cli-docs.next");
+    if next_docs_dir.exists() {
+        fs::remove_dir_all(next_docs_dir)
+            .context("Failed to remove stale cli-docs.next directory")?;
+    }
+    fs::create_dir_all(next_docs_dir).context("Failed to create cli-docs.next directory")?;
 
     // Get the main Args command
     let app = but::args::Args::command();
@@ -20,7 +24,7 @@ fn main() -> Result<()> {
         }
 
         let subcommand_name = subcommand.get_name();
-        let file_path = docs_dir.join(format!("but-{subcommand_name}.mdx"));
+        let file_path = next_docs_dir.join(format!("but-{subcommand_name}.mdx"));
 
         let mdx_content = generator::generate_command_mdx(subcommand);
         fs::write(&file_path, mdx_content).with_context(|| {
@@ -40,7 +44,7 @@ fn main() -> Result<()> {
             }
 
             let topic_name = topic_command.get_name();
-            let file_path = docs_dir.join(format!("but-help-{topic_name}.mdx"));
+            let file_path = next_docs_dir.join(format!("but-help-{topic_name}.mdx"));
             let mdx_content = generator::generate_topic_mdx(
                 topic_command,
                 &[help_command.get_name(), topic_command.get_name()],
@@ -50,6 +54,11 @@ fn main() -> Result<()> {
             println!("Generated: {file_path:?}");
         }
     }
+
+    if docs_dir.exists() {
+        fs::remove_dir_all(docs_dir).context("Failed to remove existing cli-docs directory")?;
+    }
+    fs::rename(next_docs_dir, docs_dir).context("Failed to install generated documentation")?;
 
     println!("\nDocumentation generation complete!");
     Ok(())

--- a/crates/but-clap/tests/mdx_generation.rs
+++ b/crates/but-clap/tests/mdx_generation.rs
@@ -168,6 +168,24 @@ fn test_simple_command_mdx_generation() {
 }
 
 #[test]
+fn test_escapes_mdx_angle_brackets_in_argument_help() {
+    let cmd = Command::new("move").arg(
+        Arg::new("sources")
+            .help("Place <SOURCES> above <TARGET>. See <https://example.com>.")
+            .required(true),
+    );
+    let mdx = but_clap::generator::generate_command_mdx(&cmd);
+
+    assert!(
+        mdx.contains(
+            "Place &lt;SOURCES&gt; above &lt;TARGET&gt;. See \
+             [https://example.com](https://example.com)."
+        ),
+        "argument help must escape placeholders without breaking Rustdoc autolinks"
+    );
+}
+
+#[test]
 fn test_command_with_subcommands_mdx_generation() {
     let cmd = create_command_with_subcommands();
     let mdx = but_clap::generator::generate_command_mdx(&cmd);

--- a/crates/but/src/args/alias.rs
+++ b/crates/but/src/args/alias.rs
@@ -20,7 +20,7 @@ pub enum Subcommands {
     /// ```text
     /// but alias add st status
     /// but alias add stv "status --verbose"
-    /// but alias add co "commit --only"
+    /// but alias add branches "branch list --all"
     /// ```
     Add {
         /// The name of the alias to create

--- a/crates/but/src/args/config.rs
+++ b/crates/but/src/args/config.rs
@@ -46,7 +46,7 @@ pub enum Subcommands {
     /// View and manage forge configuration.
     ///
     /// Shows configured forge accounts (GitHub, GitLab, Bitbucket) and authentication status.
-    /// Use subcommands to authenticate or forget accounts.
+    /// Use subcommands to manage accounts or native GitHub stacked pull requests.
     ///
     /// ## Examples
     ///
@@ -72,6 +72,13 @@ pub enum Subcommands {
     ///
     /// ```text
     /// but config forge forget username
+    /// ```
+    ///
+    /// View or configure native GitHub stacked pull requests:
+    ///
+    /// ```text
+    /// but config forge github-stacks
+    /// but config forge github-stacks enable
     /// ```
     Forge {
         #[clap(subcommand)]

--- a/crates/but/src/args/forge.rs
+++ b/crates/but/src/args/forge.rs
@@ -12,6 +12,11 @@ pub mod pr {
         /// Create a new review for a branch.
         /// If no branch is specified, you will be prompted to select one.
         /// If there is only one branch without a review, you will be asked to confirm.
+        ///
+        /// If the branch is part of a stack, GitButler pushes that branch and its ancestors
+        /// and creates missing reviews from the bottom upward. It also updates stack metadata
+        /// using native GitHub stacks when enabled and supported, or review descriptions
+        /// otherwise.
         New {
             /// The branch to create a review for.
             #[clap(value_name = "BRANCH")]

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -962,6 +962,12 @@ pub enum Subcommands {
     /// but pick feature-branch
     /// ```
     ///
+    /// If one or more cherry-picks conflict, GitButler keeps the commits in a
+    /// conflicted state instead of aborting the operation. Resolve all of them,
+    /// oldest first, with `but resolve --ai`; or find their IDs with `but status`
+    /// and resolve them individually with `but resolve <commit-id>`. Back out of
+    /// the pick operation with `but undo`.
+    ///
     #[cfg(feature = "legacy")]
     #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Pick {


### PR DESCRIPTION
Update CLI help for aliases, stacked reviews, forge configuration, and conflicted picks. Replace generated CLI docs as a complete set and escape Clap help text for MDX.