### PR TITLE
Handle narrow sidebar

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.module.css
@@ -51,8 +51,8 @@
 	column-gap: 4px;
 }
 
-/* When the panel is too narrow to fit the tab labels, show icons only. */
-@container (max-width: 320px) {
+/* When the panel is too narrow to fit the commit button label, hide it. */
+@container (max-width: 300px) {
 	.commitButtonLabel {
 		display: none;
 	}

--- a/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.module.css
@@ -3,6 +3,7 @@
 }
 
 .form {
+	container-type: inline-size;
 	display: flex;
 	row-gap: 10px;
 	flex-direction: column;
@@ -48,6 +49,13 @@
 .commitActions {
 	display: flex;
 	column-gap: 4px;
+}
+
+/* When the panel is too narrow to fit the tab labels, show icons only. */
+@container (max-width: 320px) {
+	.commitButtonLabel {
+		display: none;
+	}
 }
 
 .dropdownButton {

--- a/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
@@ -80,6 +80,7 @@ export const CommitForm: FC<{
 
 	const commitTextareaRef = useRef<HTMLTextAreaElement | null>(null);
 	const formRef = useRef<HTMLFormElement | null>(null);
+	const commitButtonLabelRef = useRef<HTMLSpanElement | null>(null);
 
 	const { data: draftMessage } = useQuery(draftCommitMessageQueryOptions(projectId));
 	const { mutate: persistDraftMessage } = usePersistDraftCommitMessage();
@@ -97,6 +98,7 @@ export const CommitForm: FC<{
 
 	const [open, setOpen] = useState(false);
 	const [isExpanded, setIsExpanded] = useState(false);
+	const [commitTooltipOpen, setCommitTooltipOpen] = useState(false);
 
 	const canCommitOrAmendBase = isDefaultMode && commitTarget !== null && !isCommitOrAmendPending;
 	const canCommit = canCommitOrAmendBase;
@@ -354,15 +356,32 @@ export const CommitForm: FC<{
 					</Tooltip.Root>
 
 					<div className={styles.dropdownButton}>
-						<Button
-							className={getButtonClassName({ variant: "pop" })}
-							focusableWhenDisabled
-							type="submit"
-							disabled={!canCommit}
+						<Tooltip.Root
+							open={commitTooltipOpen}
+							onOpenChange={(nextOpen) => {
+								// Only show the tooltip when the container query hides the label.
+								const label = commitButtonLabelRef.current;
+								const labelHidden = label !== null && getComputedStyle(label).display === "none";
+								setCommitTooltipOpen(nextOpen && labelHidden);
+							}}
 						>
-							Commit
-							<Kbd hotkey={changesHotkeys.commit.hotkey} variant="button" />
-						</Button>
+							<Tooltip.Trigger
+								className={getButtonClassName({ variant: "pop" })}
+								render={<Button focusableWhenDisabled type="submit" disabled={!canCommit} />}
+							>
+								<span ref={commitButtonLabelRef} className={styles.commitButtonLabel}>
+									Commit
+								</span>
+								<Kbd hotkey={changesHotkeys.commit.hotkey} variant="button" />
+							</Tooltip.Trigger>
+							<Tooltip.Portal>
+								<Tooltip.Positioner sideOffset={4}>
+									<Tooltip.Popup render={<TooltipPopup kbd={changesHotkeys.commit.hotkey} />}>
+										Commit
+									</Tooltip.Popup>
+								</Tooltip.Positioner>
+							</Tooltip.Portal>
+						</Tooltip.Root>
 						<div aria-hidden className={styles.dropdownButtonSeparator} />
 						<Button
 							focusableWhenDisabled

--- a/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
@@ -20,7 +20,7 @@ import type { InsertSide, RelativeTo, WorktreeChanges } from "@gitbutler/but-sdk
 import { useHotkey, useHotkeys } from "@tanstack/react-hotkeys";
 import { useIsMutating, useQuery } from "@tanstack/react-query";
 import { Match } from "effect";
-import { type FC, type SubmitEventHandler, useRef, useState } from "react";
+import { type FC, type SubmitEventHandler, useEffect, useRef, useState } from "react";
 import styles from "./CommitForm.module.css";
 
 export type CommitTargetComboboxItem = {
@@ -99,6 +99,22 @@ export const CommitForm: FC<{
 	const [open, setOpen] = useState(false);
 	const [isExpanded, setIsExpanded] = useState(false);
 	const [commitTooltipOpen, setCommitTooltipOpen] = useState(false);
+	const [commitLabelHidden, setCommitLabelHidden] = useState(false);
+
+	// Track whether the container query hides the label, including while resizing.
+	useEffect(() => {
+		const form = formRef.current;
+		const label = commitButtonLabelRef.current;
+		if (form === null || label === null) return;
+
+		const update = () => {
+			setCommitLabelHidden(getComputedStyle(label).display === "none");
+		};
+		update();
+		const observer = new ResizeObserver(update);
+		observer.observe(form);
+		return () => observer.disconnect();
+	}, []);
 
 	const canCommitOrAmendBase = isDefaultMode && commitTarget !== null && !isCommitOrAmendPending;
 	const canCommit = canCommitOrAmendBase;
@@ -357,15 +373,12 @@ export const CommitForm: FC<{
 
 					<div className={styles.dropdownButton}>
 						<Tooltip.Root
-							open={commitTooltipOpen}
-							onOpenChange={(nextOpen) => {
-								// Only show the tooltip when the container query hides the label.
-								const label = commitButtonLabelRef.current;
-								const labelHidden = label !== null && getComputedStyle(label).display === "none";
-								setCommitTooltipOpen(nextOpen && labelHidden);
-							}}
+							// Only show the tooltip when the container query hides the label.
+							open={commitTooltipOpen && commitLabelHidden}
+							onOpenChange={setCommitTooltipOpen}
 						>
 							<Tooltip.Trigger
+								aria-label="Commit"
 								className={getButtonClassName({ variant: "pop" })}
 								render={<Button focusableWhenDisabled type="submit" disabled={!canCommit} />}
 							>

--- a/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
@@ -107,11 +107,10 @@ export const CommitForm: FC<{
 		const label = commitButtonLabelRef.current;
 		if (form === null || label === null) return;
 
-		const update = () => {
+		// ResizeObserver fires once on observe, providing the initial value.
+		const observer = new ResizeObserver(() => {
 			setCommitLabelHidden(getComputedStyle(label).display === "none");
-		};
-		update();
-		const observer = new ResizeObserver(update);
+		});
 		observer.observe(form);
 		return () => observer.disconnect();
 	}, []);

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/BranchRow.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/BranchRow.module.css
@@ -2,6 +2,7 @@
 	display: flex;
 	flex-grow: 1;
 	flex-direction: column;
+	overflow: hidden;
 }
 
 .labelMeta {
@@ -12,8 +13,21 @@
 
 .labelMetaItem {
 	display: flex;
+	flex-shrink: 0;
 	align-items: center;
 	/* Match small button height to prevent layout shift when buttons appear/disappear. */
 	height: 20px;
 	gap: 4px;
+}
+
+/* Item that yields space to its siblings by truncating its text. */
+.labelMetaItemShrinkable {
+	flex-shrink: 1;
+	min-width: 0;
+}
+
+.labelMetaItemText {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/BranchRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/BranchRow.tsx
@@ -395,15 +395,23 @@ export const BranchRow: FC<
 					</RowLabelContainer>
 
 					<RowLabelFooter className={classes("text-13", styles.labelMeta)}>
-						<span className={classes(rowStyles.fadedText, styles.labelMetaItem)}>
-							{Match.value(pushStatus).pipe(
-								Match.when("nothingToPush", () => "Nothing to push"),
-								Match.when("unpushedCommits", () => "Some unpushed"),
-								Match.when("completelyUnpushed", () => "Unpushed branch"),
-								Match.when("unpushedCommitsRequiringForce", () => "Some unpushed"),
-								Match.when("integrated", () => "Integrated"),
-								Match.exhaustive,
+						<span
+							className={classes(
+								rowStyles.fadedText,
+								styles.labelMetaItem,
+								styles.labelMetaItemShrinkable,
 							)}
+						>
+							<span className={styles.labelMetaItemText}>
+								{Match.value(pushStatus).pipe(
+									Match.when("nothingToPush", () => "Nothing to push"),
+									Match.when("unpushedCommits", () => "Some unpushed"),
+									Match.when("completelyUnpushed", () => "Unpushed branch"),
+									Match.when("unpushedCommitsRequiringForce", () => "Some unpushed"),
+									Match.when("integrated", () => "Integrated"),
+									Match.exhaustive,
+								)}
+							</span>
 						</span>
 
 						{mforgeUrl != null && (

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
@@ -569,8 +569,8 @@ const WorkspacePage: FC = () => {
 					<Panel
 						id={"outline-panel" satisfies PanelId}
 						className={styles.panel}
-						minSize={240}
-						defaultSize={500}
+						minSize={260}
+						defaultSize={420}
 						groupResizeBehavior="preserve-pixel-size"
 					>
 						<Outline


### PR DESCRIPTION
### Summary

The workspace sidebar (outline panel) broke down at narrow widths: the commit button overflowed, and branch row meta items (status text, PR link, Push button) collided instead of adapting. This PR makes the sidebar degrade gracefully when resized down.

### Changes

**Commit button adapts to narrow panels**
- The commit form is now a CSS container; below 300px the "Commit" label is hidden, leaving the icon/kbd only.
- When the label is hidden, a tooltip shows "Commit" (with the hotkey) on hover — the tooltip is suppressed while the label is visible.

**Branch row push status truncates with ellipsis**
- Status text ("Nothing to push", "Some unpushed", …) now truncates with an ellipsis instead of overflowing into the PR link and Push button.
- Meta items no longer shrink (`flex-shrink: 0`); only the status text yields space via a dedicated shrinkable item, so buttons and links keep their full size.

**Outline panel sizing**
- Min width raised from 240px → 260px, default width lowered from 500px → 420px.

### Testing

- `pnpm isgood` passes; typecheck clean.
- Manually resized the sidebar to min width and verified: label hides at the breakpoint, tooltip appears only then, and branch rows truncate without overlap.

### Screenshots


https://github.com/user-attachments/assets/612f71ef-1213-41b8-8a1b-69ec90779813



### What's left

<img width="621" height="215" alt="Screenshot 2026-07-31 at 00-02-37" src="https://github.com/user-attachments/assets/323d41b5-c638-4a76-8ef4-d34eb9565180" />

I hold off on this bug. Once Kiril unlocks the 'Upstream' tab, we can properly update the header design. Should be soon.