### PR TITLE
Allow branch details outside workspace

### DIFF
--- a/crates/but-workspace/src/branch_details.rs
+++ b/crates/but-workspace/src/branch_details.rs
@@ -7,11 +7,7 @@ use gix::{
 };
 use itertools::Itertools;
 
-use crate::{
-    ref_info::workspace_data_of_default_workspace_branch,
-    ui,
-    ui::{CommitState, PushStatus, UpstreamCommit},
-};
+use crate::ui::{self, CommitState, PushStatus, UpstreamCommit};
 
 /// Returns information about the current state of a branch identified by its `name`.
 /// This branch is assumed to not be in the workspace, but it will still be assumed to want to integrate with the workspace target
@@ -33,10 +29,6 @@ pub fn branch_details(
     meta: &impl RefMetadata,
     project_meta: &ProjectMeta,
 ) -> anyhow::Result<ui::BranchDetails> {
-    workspace_data_of_default_workspace_branch(meta)?.context(
-        "TODO: cannot run in non-workspace mode yet.\
-        It would need a way to deal with limiting the commit traversal",
-    )?;
     let integration_branch_name = project_meta
         .target_ref
         .clone()

--- a/crates/but-workspace/tests/workspace/branch_details.rs
+++ b/crates/but-workspace/tests/workspace/branch_details.rs
@@ -1,3 +1,36 @@
+mod without_workspace {
+    use but_core::ref_metadata::ProjectMeta;
+    use but_testsupport::InMemoryRefMetadata;
+
+    use crate::utils::read_only_in_memory_scenario_named;
+
+    #[test]
+    fn uses_the_project_target_as_the_traversal_boundary() -> anyhow::Result<()> {
+        let repo =
+            read_only_in_memory_scenario_named("with-remotes-no-workspace", "nothing-to-push")?;
+        let meta = InMemoryRefMetadata::default();
+        let project_meta = ProjectMeta {
+            target_ref: Some("refs/remotes/origin/main".try_into()?),
+            ..Default::default()
+        };
+
+        let details =
+            but_workspace::branch_details(&repo, "refs/heads/A".try_into()?, &meta, &project_meta)?;
+        let target_id = repo.rev_parse_single("refs/remotes/origin/main")?.detach();
+
+        assert_eq!(
+            details.base_commit, target_id,
+            "the configured project target bounds branch traversal"
+        );
+        assert_eq!(
+            details.commits.len(),
+            2,
+            "only commits above the configured project target are returned"
+        );
+        Ok(())
+    }
+}
+
 /// All tests have a workspace present.
 mod with_workspace {
     use snapbox::prelude::*;


### PR DESCRIPTION
Remove the obsolete workspace metadata guard now that traversal is bounded by the configured project target. Add coverage for repositories without workspace metadata.