### PR TITLE
but: show example invocations when a command line is rejected

### DIFF
--- a/.agents/skills/cli-commands/SKILL.md
+++ b/.agents/skills/cli-commands/SKILL.md
@@ -62,6 +62,12 @@ documentation from `Platform`.
 
 Use `#[clap(group = "...")]` to create mutually exclusive groups of arguments.
 
+Commands with tricky grammar can define a `pub(crate) const ERROR_EXAMPLES`
+next to `Platform` and register it in `args::error_examples`; the block is
+appended after clap parse errors. At most 4 lines, each a
+`but <cmd> ...   # what it does` invocation that works as written (e.g.
+include `-m` where omitting it would open an editor).
+
 ## Handling the command
 
 Add match arm to `crates/but/src/lib.rs` to handle the command:

--- a/crates/but/AGENTS.md
+++ b/crates/but/AGENTS.md
@@ -9,6 +9,9 @@ changes, also read `crates/WORKSPACE_MODEL.md`.
 ## Command structure and I/O
 
 - Use the `cli-commands` skill for guidance on how to write new CLI commands.
+- Some commands define `ERROR_EXAMPLES` in `crates/but/src/args/` that are
+  shown on parse errors; keep them accurate when changing a command's
+  arguments or behavior.
 
 ## Worktree Guards And Deadlocks
 

--- a/crates/but/src/args/amend.rs
+++ b/crates/but/src/args/amend.rs
@@ -29,3 +29,11 @@ pub struct Platform {
     #[allow(missing_docs)]
     pub allow_merged: AllowMergedArg,
 }
+
+/// Example invocations appended to a `but amend` parse error.
+pub(crate) const ERROR_EXAMPLES: &str = "\
+Examples:
+  but amend -t <commit> <file-or-hunk>...   # amend selected uncommitted changes
+  but amend -t <commit>                     # amend all uncommitted changes
+  but amend -t <branch>                     # amend into the tip of a branch
+";

--- a/crates/but/src/args/commit.rs
+++ b/crates/but/src/args/commit.rs
@@ -93,3 +93,11 @@ pub struct Platform {
     #[allow(missing_docs)]
     pub allow_merged: AllowMergedArg,
 }
+
+/// Example invocations appended to a `but commit` parse error.
+pub(crate) const ERROR_EXAMPLES: &str = "\
+Examples:
+  but commit -b <branch> -m \"message\"                    # commit onto a branch (created if needed)
+  but commit -b <branch> -m \"message\" <file-or-hunk>...  # commit only the given changes
+  but commit -m \"message\"                                # commit when only one stack is applied
+";

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -1311,5 +1311,49 @@ pub mod worktree {
 
 pub mod branch;
 
+/// Find the subcommand token and its index in raw argv, skipping root options.
+pub(crate) fn find_subcommand(args: &[std::ffi::OsString]) -> Option<(usize, &std::ffi::OsString)> {
+    let mut ix = 1;
+    while ix < args.len() {
+        let token = &args[ix].as_encoded_bytes();
+        // Root options that consume a separate value token. `-C` is the only
+        // value-taking short option, so a short cluster ending in it (e.g.
+        // `-tC`) consumes the next token too; with an attached value
+        // (`-C.`, `-tC.`) the cluster ends in the value instead.
+        let cluster_ending_in_c =
+            token.starts_with(b"-") && !token.starts_with(b"--") && token.ends_with(b"C");
+        if cluster_ending_in_c || *token == b"--current-dir" || *token == b"--log-file" {
+            ix += 2;
+            continue;
+        }
+        if token.starts_with(b"-") {
+            ix += 1;
+            continue;
+        }
+        return Some((ix, &args[ix]));
+    }
+    None
+}
+
+/// Example invocations appended to a subcommand's parse error, for the
+/// commands whose grammar most often trips people up.
+pub(crate) fn error_examples(subcommand: &str) -> Option<&'static str> {
+    #[cfg(feature = "legacy")]
+    {
+        Some(match subcommand {
+            "commit" => commit::ERROR_EXAMPLES,
+            "amend" => amend::ERROR_EXAMPLES,
+            "move" => r#move::ERROR_EXAMPLES,
+            "squash" => squash::ERROR_EXAMPLES,
+            _ => return None,
+        })
+    }
+    #[cfg(not(feature = "legacy"))]
+    {
+        let _ = subcommand;
+        None
+    }
+}
+
 #[cfg(test)]
 mod tests;

--- a/crates/but/src/args/move.rs
+++ b/crates/but/src/args/move.rs
@@ -97,3 +97,12 @@ pub struct Platform {
     #[allow(missing_docs)]
     pub allow_merged: AllowMergedArg,
 }
+
+/// Example invocations appended to a `but move` parse error.
+pub(crate) const ERROR_EXAMPLES: &str = "\
+Examples:
+  but move <child-branch> --above <parent-branch>   # stack a branch on top of another
+  but move <commit> --below <other-commit>          # reorder commits
+  but move <commit> --branch <branch>               # move a commit onto a branch
+  but move <branch> --unstack                       # tear a branch off its stack
+";

--- a/crates/but/src/args/squash.rs
+++ b/crates/but/src/args/squash.rs
@@ -95,3 +95,12 @@ pub struct Platform {
     #[allow(missing_docs)]
     pub allow_merged: AllowMergedArg,
 }
+
+/// Example invocations appended to a `but squash` parse error.
+pub(crate) const ERROR_EXAMPLES: &str = "\
+Examples:
+  but squash <commit>... -t <other-commit> -m \"message\"   # squash commits into another commit
+  but squash <branch> -m \"message\"                # squash a branch into a single commit
+  but squash <file> -t <commit>                    # move an uncommitted file into a commit
+  but squash <commit>:<file> -t <other-commit>     # move a committed file to another commit
+";

--- a/crates/but/src/args/tests.rs
+++ b/crates/but/src/args/tests.rs
@@ -5,6 +5,29 @@ mod amend;
 #[cfg(feature = "legacy")]
 mod reword;
 
+mod find_subcommand {
+    fn found(args: &[&str]) -> Option<String> {
+        let args: Vec<std::ffi::OsString> = args.iter().map(Into::into).collect();
+        crate::args::find_subcommand(&args).map(|(_, name)| name.to_string_lossy().into_owned())
+    }
+
+    #[test]
+    fn skips_root_options_including_short_clusters() {
+        assert_eq!(found(&["but", "move", "ab"]).as_deref(), Some("move"));
+        assert_eq!(found(&["but", "-C", ".", "move"]).as_deref(), Some("move"));
+        // Clap accepts `-C`'s value clustered behind other shorts or attached.
+        assert_eq!(found(&["but", "-tC", ".", "move"]).as_deref(), Some("move"));
+        assert_eq!(
+            found(&["but", "-ttC", ".", "move"]).as_deref(),
+            Some("move")
+        );
+        assert_eq!(found(&["but", "-tC.", "move"]).as_deref(), Some("move"));
+        assert_eq!(found(&["but", "-C.", "move"]).as_deref(), Some("move"));
+        assert_eq!(found(&["but", "-t", "move"]).as_deref(), Some("move"));
+        assert_eq!(found(&["but", "-t"]), None);
+    }
+}
+
 mod config_ai {
     use clap::Parser;
 

--- a/crates/but/src/command/legacy/move.rs
+++ b/crates/but/src/command/legacy/move.rs
@@ -28,6 +28,11 @@ use crate::{
     },
 };
 
+/// Guidance shown whenever a branch source is combined with a target it does
+/// not support.
+const BRANCH_SOURCE_HINT: &str =
+    "Branches can be moved with `--above <branch>` to stack or `--unstack` to unstack";
+
 pub enum MoveOutcome {
     Commits {
         sources: NonEmpty<CommitId>,
@@ -531,7 +536,9 @@ fn resolve(
         (Some(Some(branch)), None, None, false) => {
             match (branch.try_resolve_branch(&repo, id_map)?, resolved_sources) {
                 (_, ResolvedSources::Branch(_)) => {
-                    Err(bad_input("Cannot combine `--branch` with a branch source").into())
+                    Err(bad_input("Cannot combine `--branch` with a branch source")
+                        .hint(BRANCH_SOURCE_HINT)
+                        .into())
                 }
                 (
                     Some(branch),
@@ -671,7 +678,7 @@ fn create_move_above_or_below_op(
                 return Err(bad_input("Invalid target for branch source")
                     .arg_name(format!("--{side}"))
                     .arg_value(unresolved_target.to_string())
-                    .hint("Branches can only be moved with `--above <branch>` to stack or `--unstack` to unstack")
+                    .hint(BRANCH_SOURCE_HINT)
                     .into());
             };
 

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -90,18 +90,38 @@ fn parse_args_and_output_format(args: Vec<OsString>, agent_detected: bool) -> (A
                 }
                 Translation::Refused => None,
                 Translation::NotRetired => {
+                    // Help and version requests also arrive as `Err`; they
+                    // print to stdout and must pass through untouched.
+                    if !err.use_stderr() {
+                        err.exit()
+                    }
                     // The other revamped commands are never translated, but a
                     // rejected line that looks like their retired syntax gets
-                    // a teaching hint before the error. Help and version
-                    // requests also arrive as `Err` and must pass untouched.
-                    if err.use_stderr()
-                        && let Some((command, hint)) =
-                            retired_syntax::parse_failure_hint(&args, agent_detected)
-                    {
+                    // a teaching hint before the error.
+                    let retired_hint = retired_syntax::parse_failure_hint(&args, agent_detected);
+                    if let Some((command, hint)) = &retired_hint {
                         print_err_infallible(hint);
-                        utils::metrics::emit_retired_syntax_hint(command);
+                        utils::metrics::emit_retired_syntax_hint(*command);
                     }
-                    err.exit()
+                    let _ = err.print();
+                    // For the commands with the trickiest grammar, follow the
+                    // error with example invocations — unless the hint above
+                    // already named a concrete rewrite. The usage-line check
+                    // keeps root-level errors (e.g. a bad root flag before the
+                    // subcommand) from getting examples for a grammar that
+                    // never rejected anything.
+                    let concrete_rewrite = retired_hint
+                        .as_ref()
+                        .is_some_and(|(_, hint)| retired_syntax::hint_is_concrete(hint));
+                    if !concrete_rewrite
+                        && let Some(examples) = args::find_subcommand(&args)
+                            .and_then(|(_, name)| name.to_str())
+                            .filter(|name| err.to_string().contains(&format!("but {name}")))
+                            .and_then(args::error_examples)
+                    {
+                        print_err_infallible(format!("\n{examples}"));
+                    }
+                    std::process::exit(err.exit_code())
                 }
             };
             match retry {

--- a/crates/but/src/retired_syntax.rs
+++ b/crates/but/src/retired_syntax.rs
@@ -42,7 +42,10 @@
 use std::ffi::OsString;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use crate::{args::metrics::CommandName, theme::Paint as _};
+use crate::{
+    args::{find_subcommand, metrics::CommandName},
+    theme::Paint as _,
+};
 
 static USED: AtomicBool = AtomicBool::new(false);
 
@@ -235,25 +238,6 @@ pub(crate) fn translate_commit(args: &[OsString]) -> Translation {
     Translation::Translated(translated)
 }
 
-/// Find the subcommand token and its index, skipping root options.
-fn find_subcommand(args: &[OsString]) -> Option<(usize, &OsString)> {
-    let mut ix = 1;
-    while ix < args.len() {
-        let token = &args[ix];
-        // Root options that consume a separate value token.
-        if token == "-C" || token == "--current-dir" || token == "--log-file" {
-            ix += 2;
-            continue;
-        }
-        if token.as_encoded_bytes().starts_with(b"-") {
-            ix += 1;
-            continue;
-        }
-        return Some((ix, token));
-    }
-    None
-}
-
 /// A teaching hint for a command line the modern parser rejected, when the
 /// failure looks like retired syntax for one of the revamped subcommands.
 /// Returns the command's metrics name alongside the hint so the caller can
@@ -273,6 +257,13 @@ pub(crate) fn parse_failure_hint(args: &[OsString], agent: bool) -> Option<(Comm
         _ => return None,
     };
     Some((command, hint?))
+}
+
+/// Whether a failure hint embeds a concrete modern command line (the
+/// indented `but ...` block produced by [`equivalent_body`]), as opposed to a
+/// generic "syntax has changed" pointer.
+pub(crate) fn hint_is_concrete(hint: &str) -> bool {
+    hint.contains("\n    but ")
 }
 
 /// Hint body naming the concrete modern equivalent of a retired invocation.

--- a/crates/but/tests/but/command/amend.rs
+++ b/crates/but/tests/but/command/amend.rs
@@ -279,6 +279,47 @@ For more information, try '--help'.
 }
 
 #[test]
+fn parse_error_appends_examples() {
+    let env = Sandbox::empty();
+
+    // A rejected amend command line must end with the registered example
+    // invocations, after clap's own error and usage output.
+    env.but("amend").assert().failure().stderr_eq(str![[r#"
+error: the following required arguments were not provided:
+  --target <COMMIT_OR_BRANCH>
+
+Usage: but amend --target <COMMIT_OR_BRANCH> [SOURCES]...
+
+For more information, try '--help'.
+
+Examples:
+  but amend -t <commit> <file-or-hunk>...   # amend selected uncommitted changes
+  but amend -t <commit>                     # amend all uncommitted changes
+  but amend -t <branch>                     # amend into the tip of a branch
+
+"#]]);
+}
+
+#[test]
+fn root_level_parse_error_gets_no_examples() {
+    let env = Sandbox::empty();
+
+    // The bad flag belongs to the root grammar; appending `amend` examples
+    // would misattribute the failure to the amend grammar.
+    env.but("--nope amend")
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
+error: unexpected argument '--nope' found
+
+Usage: but [OPTIONS] [COMMAND]
+
+For more information, try '--help'.
+
+"#]]);
+}
+
+#[test]
 fn retired_flag_with_help_passes_through_without_hint() {
     let env = Sandbox::empty();
 

--- a/crates/but/tests/but/command/commit.rs
+++ b/crates/but/tests/but/command/commit.rs
@@ -1000,6 +1000,11 @@ Usage: but commit --above <BRANCH_OR_COMMIT> [CHANGES]...
 
 For more information, try '--help'.
 
+Examples:
+  but commit -b <branch> -m "message"                    # commit onto a branch (created if needed)
+  but commit -b <branch> -m "message" <file-or-hunk>...  # commit only the given changes
+  but commit -m "message"                                # commit when only one stack is applied
+
 "#]]);
 }
 
@@ -1018,6 +1023,11 @@ Usage: but commit --above <BRANCH_OR_COMMIT> [CHANGES]...
 
 For more information, try '--help'.
 
+Examples:
+  but commit -b <branch> -m "message"                    # commit onto a branch (created if needed)
+  but commit -b <branch> -m "message" <file-or-hunk>...  # commit only the given changes
+  but commit -m "message"                                # commit when only one stack is applied
+
 "#]]);
 }
 
@@ -1035,6 +1045,11 @@ error: the argument '--below <BRANCH_OR_COMMIT>' cannot be used with '--branch [
 Usage: but commit --below <BRANCH_OR_COMMIT> [CHANGES]...
 
 For more information, try '--help'.
+
+Examples:
+  but commit -b <branch> -m "message"                    # commit onto a branch (created if needed)
+  but commit -b <branch> -m "message" <file-or-hunk>...  # commit only the given changes
+  but commit -m "message"                                # commit when only one stack is applied
 
 "#]]);
 }
@@ -2270,6 +2285,11 @@ error: unexpected argument '-c' found
 Usage: but commit [OPTIONS] [CHANGES]...
 
 For more information, try '--help'.
+
+Examples:
+  but commit -b <branch> -m "message"                    # commit onto a branch (created if needed)
+  but commit -b <branch> -m "message" <file-or-hunk>...  # commit only the given changes
+  but commit -m "message"                                # commit when only one stack is applied
 
 "#]]);
 

--- a/crates/but/tests/but/command/move.rs
+++ b/crates/but/tests/but/command/move.rs
@@ -2288,7 +2288,7 @@ Error: Bad input 'B' for '--below'
 
 Invalid target for branch source
 
-Hint: Branches can only be moved with `--above <branch>` to stack or `--unstack` to unstack
+Hint: Branches can be moved with `--above <branch>` to stack or `--unstack` to unstack
 
 "#]]);
 }
@@ -2327,6 +2327,8 @@ Hint: run `but help` for all commands
         .failure()
         .stderr_eq(snapbox::str![[r#"
 Error: Cannot combine `--branch` with a branch source
+
+Hint: Branches can be moved with `--above <branch>` to stack or `--unstack` to unstack
 
 "#]]);
 }
@@ -2461,6 +2463,12 @@ Usage: but move <--above <BRANCH_OR_COMMIT>|--below <BRANCH_OR_COMMIT>|--branch 
 
 For more information, try '--help'.
 
+Examples:
+  but move <child-branch> --above <parent-branch>   # stack a branch on top of another
+  but move <commit> --below <other-commit>          # reorder commits
+  but move <commit> --branch <branch>               # move a commit onto a branch
+  but move <branch> --unstack                       # tear a branch off its stack
+
 "#]]);
 }
 
@@ -2480,6 +2488,12 @@ Usage: but move <--above <BRANCH_OR_COMMIT>|--below <BRANCH_OR_COMMIT>|--branch 
 
 For more information, try '--help'.
 
+Examples:
+  but move <child-branch> --above <parent-branch>   # stack a branch on top of another
+  but move <commit> --below <other-commit>          # reorder commits
+  but move <commit> --branch <branch>               # move a commit onto a branch
+  but move <branch> --unstack                       # tear a branch off its stack
+
 "#]]);
 }
 
@@ -2498,6 +2512,12 @@ error: the following required arguments were not provided:
 Usage: but move <--above <BRANCH_OR_COMMIT>|--below <BRANCH_OR_COMMIT>|--branch [<BRANCH>]|--unstack> <SOURCES>...
 
 For more information, try '--help'.
+
+Examples:
+  but move <child-branch> --above <parent-branch>   # stack a branch on top of another
+  but move <commit> --below <other-commit>          # reorder commits
+  but move <commit> --branch <branch>               # move a commit onto a branch
+  but move <branch> --unstack                       # tear a branch off its stack
 
 "#]]);
 }

--- a/crates/but/tests/but/command/squash.rs
+++ b/crates/but/tests/but/command/squash.rs
@@ -642,6 +642,12 @@ Usage: but squash <SOURCES>...
 
 For more information, try '--help'.
 
+Examples:
+  but squash <commit>... -t <other-commit> -m "message"   # squash commits into another commit
+  but squash <branch> -m "message"                # squash a branch into a single commit
+  but squash <file> -t <commit>                    # move an uncommitted file into a commit
+  but squash <commit>:<file> -t <other-commit>     # move a committed file to another commit
+
 "#]]);
 }
 


### PR DESCRIPTION
The generated usage line has proven hard to act on for the revamped commands — a confused `but move pe -t sw` gets an error and an abstract usage string, but no path to the answer. Parse failures for `commit`, `amend`, `move` and `squash` now end with a short block of example invocations:

```
❯ but move pe -t sw
error: unexpected argument '-t' found

  tip: to pass '-t' as a value, use '-- -t'

Usage: but move [OPTIONS] <--above <BRANCH_OR_COMMIT>|--below <BRANCH_OR_COMMIT>|--branch [<BRANCH>]|--unstack> <SOURCES>...

For more information, try '--help'.

Examples:
  but move <child-branch> --above <parent-branch>   # stack a branch on top of another
  but move <commit> --below <other-commit>          # reorder commits
  but move <commit> --branch <branch>               # move a commit onto a branch
  but move <branch> --unstack                       # tear a branch off its stack
```

Each command's examples live next to its clap grammar in `args/<cmd>.rs`, so they are easy to keep accurate as the grammar changes. Two deliberate exclusions keep the output focused: when a retired-syntax hint already names a concrete rewrite the examples are skipped (one teaching block per error), and root-level errors — a bad flag before the subcommand — never get subcommand examples.

The resolve-time "Cannot combine `--branch` with a branch source" error now carries the existing stack/unstack hint, so branch stacking is discoverable at the exact point where people have been getting stuck.
