### PR TITLE
don't shrink elements

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/FileRow.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/FileRow.module.css
@@ -3,6 +3,7 @@
 }
 
 .statusBadge {
+	flex-shrink: 0;
 	align-self: center;
 	width: 12px;
 	font-weight: 700;


### PR DESCRIPTION
smo fix to align icons if there are long truncated file names.

<img width="799" height="231" alt="Screenshot 2026-07-31 at 11-59-54" src="https://github.com/user-attachments/assets/ab9d3f0a-0d96-4fa3-aa1f-c55ebc7757f3" />
