### PR TITLE
Truncate branch name in outline row when not editing

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/BranchRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/BranchRow.tsx
@@ -391,7 +391,9 @@ export const BranchRow: FC<
 			) : (
 				<div className={styles.label}>
 					<RowLabelContainer>
-						<RowLabel heading>{optimisticBranchDisplayName}</RowLabel>
+						<RowLabel heading singleLine>
+							{optimisticBranchDisplayName}
+						</RowLabel>
 					</RowLabelContainer>
 
 					<RowLabelFooter className={classes("text-13", styles.labelMeta)}>


### PR DESCRIPTION
## What

Long branch names in the "Stacks and branches" outline previously wrapped onto
multiple lines, making rows jumpy on hover because of the kebab menu.

---

### Before:


https://github.com/user-attachments/assets/7a0d69bf-c8a0-4491-b9fa-9be770ec128d



### After:

https://github.com/user-attachments/assets/e2d5221e-d744-448b-9d1a-2c7d9835fc34


---


Theres is still an issue with the meta because the kebab affect both rows - the label and the meta rows, but it's a different fix
