### PR TITLE
Fix `but resolve` finish with sibling stack renames

### DIFF
--- a/crates/but-rebase/src/graph_rebase/cherry_pick.rs
+++ b/crates/but-rebase/src/graph_rebase/cherry_pick.rs
@@ -445,7 +445,7 @@ fn find_real_tree<'repo>(
     })
 }
 
-fn commit_from_unconflicted_tree<'repo>(
+pub(crate) fn commit_from_unconflicted_tree<'repo>(
     parents: &[gix::ObjectId],
     to_rebase: but_core::Commit<'repo>,
     resolved_tree_id: gix::Id<'repo>,

--- a/crates/but-rebase/src/graph_rebase/mod.rs
+++ b/crates/but-rebase/src/graph_rebase/mod.rs
@@ -27,6 +27,7 @@ pub mod mutate;
 pub mod ordering;
 pub(crate) mod util;
 pub mod workspace;
+mod workspace_commit;
 pub use workspace::{GraphWorkspace, Subgraph};
 
 /// Utilities for testing

--- a/crates/but-rebase/src/graph_rebase/rebase.rs
+++ b/crates/but-rebase/src/graph_rebase/rebase.rs
@@ -14,6 +14,7 @@ use crate::graph_rebase::{
     Editor, Pick, Step, StepGraph, StepGraphIndex, SuccessfulRebase,
     cherry_pick::{CherryPickOutcome, cherry_pick},
     util::collect_ordered_parents,
+    workspace_commit,
 };
 
 impl<'ws, 'graph, M: RefMetadata> Editor<'ws, 'graph, M> {
@@ -67,6 +68,18 @@ impl<'ws, 'graph, M: RefMetadata> Editor<'ws, 'graph, M> {
                         pick.tree_merge_mode,
                         pick.sign_commit,
                     )?;
+                    let outcome = match outcome {
+                        failure @ CherryPickOutcome::FailedToMergeBases { .. } => {
+                            workspace_commit::replay_single_parent_delta(
+                                &self.repo,
+                                pick.id,
+                                &ontos,
+                                pick.sign_commit,
+                            )?
+                            .unwrap_or(failure)
+                        }
+                        outcome => outcome,
+                    };
 
                     if matches!(outcome, CherryPickOutcome::ConflictedCommit(_))
                         && !pick.conflictable

--- a/crates/but-rebase/src/graph_rebase/workspace_commit.rs
+++ b/crates/but-rebase/src/graph_rebase/workspace_commit.rs
@@ -1,0 +1,135 @@
+//! Workspace-commit replay during graph rebases.
+
+use anyhow::Result;
+use but_core::{RepositoryExt, commit::SignCommit};
+use gix::prelude::ObjectIdExt;
+
+use super::cherry_pick::{CherryPickOutcome, commit_from_unconflicted_tree};
+
+/// Replay the sole rewritten parent's delta onto a managed workspace commit's
+/// recorded tree.
+///
+/// A managed workspace tree already records how its independent parents were
+/// merged. Re-merging those parents from scratch can therefore conflict even
+/// when changing one parent is applicable. This fallback preserves the
+/// recorded merge and only applies the one parent rewrite we can align
+/// unambiguously. If that requires rename detection, only exact renames from
+/// the recorded workspace side are considered; a deletion in the rewritten
+/// parent makes that distinction ambiguous. More general workspace
+/// reconstruction belongs at a higher layer with stack metadata.
+pub(crate) fn replay_single_parent_delta(
+    repo: &gix::Repository,
+    target_id: gix::ObjectId,
+    ontos: &[gix::ObjectId],
+    sign_commit: SignCommit,
+) -> Result<Option<CherryPickOutcome>> {
+    let target = but_core::Commit::from_id(target_id.attach(repo))?;
+    if !but_graph::workspace::commit::is_managed_workspace_by_message(target.inner.message.as_ref())
+        || target.is_conflicted()
+        || target.parents.len() != ontos.len()
+    {
+        return Ok(None);
+    }
+
+    let mut changed = target
+        .parents
+        .iter()
+        .zip(ontos)
+        .filter(|(old, new)| old != new);
+    let Some((old, new)) = changed.next() else {
+        return Ok(None);
+    };
+    if changed.next().is_some() {
+        return Ok(None);
+    }
+
+    let base = but_core::Commit::from_id(old.attach(repo))?
+        .tree_id_or_auto_resolution()?
+        .detach();
+    let theirs = but_core::Commit::from_id(new.attach(repo))?
+        .tree_id_or_auto_resolution()?
+        .detach();
+    let ours = target.tree_id_or_auto_resolution()?.detach();
+
+    let (options, conflict_kind) = repo.merge_options_no_rewrites_fail_fast()?;
+    let mut merge = repo.merge_trees(base, ours, theirs, repo.default_merge_labels(), options)?;
+    if merge.has_unresolved_conflicts(conflict_kind) {
+        if parent_delta_has_deletions(repo, base, theirs)? {
+            return Ok(None);
+        }
+        let (options, conflict_kind) = repo.merge_options_fail_fast()?;
+        let options = options.with_rewrites(Some(gix::diff::Rewrites {
+            percentage: None,
+            ..Default::default()
+        }));
+        merge = repo.merge_trees(base, ours, theirs, repo.default_merge_labels(), options)?;
+        if merge.has_unresolved_conflicts(conflict_kind) {
+            return Ok(None);
+        }
+    }
+    let tree = merge.tree.write()?.detach();
+    Ok(Some(CherryPickOutcome::Commit(
+        commit_from_unconflicted_tree(ontos, target, tree.attach(repo), sign_commit)?.detach(),
+    )))
+}
+
+fn parent_delta_has_deletions(
+    repo: &gix::Repository,
+    base: gix::ObjectId,
+    theirs: gix::ObjectId,
+) -> Result<bool> {
+    let base = repo.find_tree(base)?;
+    let theirs = repo.find_tree(theirs)?;
+    let changes = repo.diff_tree_to_tree(
+        Some(&base),
+        Some(&theirs),
+        Some(gix::diff::Options::default()),
+    )?;
+    Ok(changes.into_iter().any(|change| {
+        matches!(
+            change,
+            gix::diff::tree_with_rewrites::Change::Deletion { .. }
+        )
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use but_core::commit::SignCommit;
+
+    use super::replay_single_parent_delta;
+
+    #[test]
+    fn rejects_rename_inference() -> anyhow::Result<()> {
+        let repo = but_testsupport::read_only_in_memory_scenario("cherry-pick-rename-detection")?;
+        let workspace = repo.rev_parse_single("workspace-before")?.detach();
+        let stack1 = repo.rev_parse_single("stack-1")?.detach();
+        let stack2_after = repo.rev_parse_single("stack-2-after")?.detach();
+
+        let outcome =
+            replay_single_parent_delta(&repo, workspace, &[stack1, stack2_after], SignCommit::No)?;
+
+        assert!(
+            outcome.is_none(),
+            "an exact delete/add must not absorb a sibling modification"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_more_than_one_rewritten_parent() -> anyhow::Result<()> {
+        let repo = but_testsupport::read_only_in_memory_scenario("cherry-pick-rename-detection")?;
+        let workspace = repo.rev_parse_single("workspace-before")?.detach();
+        let base = repo.rev_parse_single("base")?.detach();
+        let stack2_after = repo.rev_parse_single("stack-2-after")?.detach();
+
+        let outcome =
+            replay_single_parent_delta(&repo, workspace, &[base, stack2_after], SignCommit::No)?;
+
+        assert!(
+            outcome.is_none(),
+            "multiple parent rewrites require workspace-level reconstruction"
+        );
+        Ok(())
+    }
+}

--- a/crates/but-rebase/tests/fixtures/scenario/cherry-pick-rename-detection.sh
+++ b/crates/but-rebase/tests/fixtures/scenario/cherry-pick-rename-detection.sh
@@ -8,19 +8,17 @@
 #   stack-1: modifies file-b.txt (leaves file-a.txt unchanged)
 #   stack-2-after: deletes file-a.txt AND file-b.txt, adds file-combined.txt
 #
-# file-combined.txt has content similar to file-b.txt, which would cause gix's
-# rename detection to match file-b → file-combined as a rename. With rename
-# detection enabled, this hides the delete-vs-modify conflict on file-b.txt
-# and silently drops file-a.txt's deletion.
+# file-combined.txt has the same content as file-b.txt, which causes exact
+# rename detection to match file-b → file-combined. That hides the
+# delete-vs-modify conflict on file-b.txt and moves stack-1's modification to
+# an unrelated path.
 
 set -eu -o pipefail
 
 git init
 
-# Base commit with two files
-# file-b has content that is very similar to what file-combined will have,
-# so rename detection may heuristically match file-b → file-combined as a rename.
-# file-a is different content, so it should just be a clean delete.
+# Base commit with two files. file-b's content will be reused byte-for-byte by
+# stack-2-after, while file-a is an unrelated clean deletion.
 cat > file-a.txt << 'CONTENT'
 This is file A with unique content.
 It has nothing in common with the combined file.
@@ -55,19 +53,12 @@ git checkout -b stack-2-before
 git reset --hard base
 echo "unrelated" > other-file.txt && git add . && git commit -m "stack-2-before: unrelated change"
 
-# stack-2-after: deletes both files and creates combined file
-# file-combined has content very similar to file-b (rename detection target)
+# stack-2-after: deletes both files and independently creates another path with
+# file-b's exact content.
 git checkout -b stack-2-after
 git reset --hard base
+cp file-b.txt file-combined.txt
 rm file-a.txt file-b.txt
-cat > file-combined.txt << 'CONTENT'
-This is the test runner configuration.
-It sets up the playwright test environment.
-Line 3 of the config.
-Line 4 of the config.
-Line 5 of the config.
-Additional combined content from both files.
-CONTENT
 git add . && git commit -m "stack-2-after: combine files"
 
 # Create the workspace commit: merge of stack-1 and stack-2-before

--- a/crates/but-rebase/tests/rebase/graph_rebase/cherry_pick.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/cherry_pick.rs
@@ -1143,7 +1143,7 @@ fn workspace_merge_surfaces_delete_vs_modify_conflict() -> Result<()> {
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
         snapbox::str![[r#"
-* 8ef051f (stack-2-after) stack-2-after: combine files
+* 756b796 (stack-2-after) stack-2-after: combine files
 | *   978e614 (HEAD -> workspace-before) GitButler Workspace Commit
 | |\  
 | | * b8f64ac (stack-2-before) stack-2-before: unrelated change

--- a/crates/but/tests/but/command/resolve.rs
+++ b/crates/but/tests/but/command/resolve.rs
@@ -120,6 +120,58 @@ Resolve the next commit with but resolve [..].
 }
 
 #[test]
+fn resolve_finish_succeeds_next_to_sibling_stack_with_rename() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings(
+        "upstream-conflicted-with-sibling-rename",
+    );
+    env.setup_metadata_at_target(&["A", "B"], "refs/heads/base");
+    env.invoke_git("remote set-url origin .");
+    env.but("pull").assert().success();
+
+    let status = super::util::status_json(&env);
+    let branch = super::util::find_branch(&status, "A");
+    let conflicted_commit = branch["commits"]
+        .as_array()
+        .context("branch commits should be an array")
+        .unwrap()
+        .iter()
+        .find(|commit| commit["conflicted"].as_bool() == Some(true))
+        .and_then(|commit| commit["cliId"].as_str())
+        .context("should find the conflicted commit on A")
+        .unwrap();
+
+    env.but(format!("resolve {conflicted_commit}"))
+        .assert()
+        .success();
+
+    // Resolve the conflict, and also touch the file that stack B renamed.
+    // Merging the rewritten A tip with B's tip then only works with rename
+    // detection, which the workspace-commit rebase must fall back to.
+    env.file("file.txt", "resolved content\n");
+    env.file(
+        "shared.txt",
+        "line 1\nline 2 - fixed during resolution\nline 3\nline 4\nline 5\n",
+    );
+    env.invoke_git("add file.txt shared.txt");
+
+    env.but("resolve finish").assert().success();
+
+    assert_eq!(
+        env.read_file("renamed.txt").unwrap(),
+        "line 1\nline 2 - fixed during resolution\nline 3\nline 4\nline 5\n",
+        "the resolved edit should follow the sibling stack's rename"
+    );
+    assert!(
+        !env.projects_root().join("shared.txt").exists(),
+        "the renamed source path should stay absent"
+    );
+
+    let status = super::util::status_json(&env);
+    super::util::find_branch(&status, "A");
+    super::util::find_branch(&status, "B");
+}
+
+#[test]
 fn resolve_finish_json_deduplicates_shared_conflicts() {
     let env = Sandbox::init_scenario_with_target_and_default_settings(
         "pull-conflicts-in-both-branches-of-stack",

--- a/crates/but/tests/fixtures/scenario/upstream-conflicted-with-sibling-rename.sh
+++ b/crates/but/tests/fixtures/scenario/upstream-conflicted-with-sibling-rename.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# Two independent stacks on a shared base, with upstream advanced so that
+# pulling conflicts stack A's commit.
+# Stack A changes `file.txt`, which upstream also changes.
+# Stack B renames `shared.txt` to `renamed.txt` without touching its content.
+# Resolving A's conflicted commit while also modifying `shared.txt` makes the
+# rewritten A tip and B's tip merge only when rename detection is enabled.
+git-init-frozen
+
+echo base > file.txt
+cat > shared.txt << 'CONTENT'
+line 1
+line 2
+line 3
+line 4
+line 5
+CONTENT
+git add file.txt shared.txt
+git commit -m "base"
+git update-ref refs/heads/base HEAD
+
+git checkout -b A
+echo change-on-A > file.txt
+git add file.txt
+git commit -m "A-change"
+
+git checkout -b B main
+git mv shared.txt renamed.txt
+git commit -m "B-rename-shared"
+
+git checkout main
+echo change-on-main > file.txt
+git add file.txt
+git commit -m "main-change"
+setup_target_to_match_main
+
+git checkout A
+create_workspace_commit_once A B


### PR DESCRIPTION
Fixes #15112

Users can hit this when multiple stacks are applied, a commit on one stack conflicts with upstream, and another applied stack renames a file. If the user resolves the conflicted commit while changing the file at its original path, `but resolve finish` rebuilds the managed workspace commit and may fail with `Failed to merge bases while cherry picking`. The resolution is complete, but the user is left unable to exit edit mode and restore the workspace.

The failure came from re-merging the independent workspace parents from scratch. The sibling rename and the resolved modification look like a delete/modify conflict there, even though the existing workspace commit already records a valid combination of those stacks.

When that parent merge fails, rebuild the managed workspace commit by replaying its sole changed parent onto the recorded workspace tree. The replay first avoids rename detection, then retries with exact renames only so the resolved edit follows a real sibling rename without allowing fuzzy matches between unrelated stack content. Genuine conflicts and changes to multiple parents keep the existing failure behavior.