### PR TITLE
Style tweaks in lite workspace details view

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
@@ -11,7 +11,7 @@
 
 .headerWrap {
 	display: flex;
-	row-gap: 12px;
+	row-gap: 8px;
 	flex-direction: column;
 	padding-inline: var(--panel-padding-inline);
 	padding-block-start: var(--panel-padding-block);

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
@@ -192,6 +192,11 @@
 		--diffs-selection-number-fg: var(--text-1);
 		border-top: 1px solid var(--border-3);
 		border-bottom: 1px solid var(--border-3);
+
+		/* Hide the first diff's top border so it doesn't double up with the container above. */
+		&:first-child {
+			border-top-color: var(--bg-1);
+		}
 	}
 
 	[data-selection-focus-styles="true"] [data-selection-scope="diff"]:focus-within & {

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -1026,7 +1026,7 @@ const Diff: FC<{
 						<Panel
 							id={"files-panel" satisfies PanelId}
 							className={styles.panel}
-							defaultSize={250}
+							defaultSize={320}
 							minSize={180}
 							groupResizeBehavior="preserve-pixel-size"
 						>

--- a/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
@@ -19,8 +19,8 @@
 	flex-shrink: 0;
 	/* The label gets an extra inset to line up with row content inside the
 	   section, while action buttons on the right align with the panel edge. */
-	padding-inline: calc(var(--panel-padding-inline) + 4px) var(--panel-padding-inline);
-	padding-block: calc(var(--panel-padding-block) - 4px);
+	padding-inline: calc(var(--panel-padding-inline) + 4px) calc(var(--panel-padding-inline) + 4px);
+	padding-block: calc(var(--panel-padding-block) - 2px);
 }
 
 .containerInteractive {


### PR DESCRIPTION
## 🧢 Changes

Small visual tweaks in the lite workspace details view:

- Align section paddings in `Row.module.css` — even inline inset on both sides, and a smaller block padding reduction.
- Tighten `.headerWrap` row gap from 12px to 8px.
- Hide the first diff container's top border so it doesn't double up with the border of the container above it.
- Widen the files panel default size from 250px to 320px.

## ☕️ Reasoning

Purely cosmetic polish — sections were visually misaligned, the header block felt loose, the first diff showed a doubled 2px border, and the default files panel was too narrow for typical paths.