### PR TITLE
Allow switching base branch with applied stacks

### DIFF
--- a/apps/desktop/src/components/forge/BaseBranchSwitch.svelte
+++ b/apps/desktop/src/components/forge/BaseBranchSwitch.svelte
@@ -1,9 +1,21 @@
 <script lang="ts">
 	import { BASE_BRANCH_SERVICE } from "$lib/baseBranch/baseBranchService.svelte";
+	import { parseError } from "$lib/error/parser";
+	import { showError } from "$lib/error/showError";
 	import { SETTINGS_SERVICE } from "$lib/settings/appSettings";
+	import { getStackName, handleApplyOutcome } from "$lib/stacks/stack";
 	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
 	import { inject } from "@gitbutler/core/context";
-	import { Button, CardGroup, InfoMessage, Select, SelectItem } from "@gitbutler/ui";
+	import {
+		AsyncButton,
+		Button,
+		CardGroup,
+		InfoMessage,
+		Modal,
+		Select,
+		SelectItem,
+	} from "@gitbutler/ui";
+	import type { Stack } from "$lib/stacks/stack";
 
 	const { projectId }: { projectId: string } = $props();
 
@@ -20,8 +32,11 @@
 	let selectedRemote = $derived(baseBranch?.pushRemoteName);
 
 	const stacksQuery = $derived(stackService.stacks(projectId));
-	const stackCount = $derived(stacksQuery.response?.length);
-	const targetChangeDisabled = $derived(!!(stackCount && stackCount > 0));
+	const stacks = $derived(stacksQuery.response ?? []);
+	const stackCount = $derived(stacks.length);
+
+	let confirmModal = $state<Modal>();
+	let reapplying = $state(false);
 
 	function uniqueRemotes(remoteBranches: { name: string }[]): { name: string }[] {
 		return Array.from(new Set(remoteBranches.map((b) => b.name.split("/")[0])))
@@ -32,7 +47,7 @@
 	}
 
 	const switching = $derived(
-		targetBranchSwitch.current.isLoading || targetRefSwitch.current.isLoading,
+		targetBranchSwitch.current.isLoading || targetRefSwitch.current.isLoading || reapplying,
 	);
 	// With the singleBranch feature flag, only the target metadata is rewritten
 	// and no branch is checked out, so avoid claiming a branch switch.
@@ -49,8 +64,70 @@
 		}
 	}
 
+	function errorMessage(error: unknown): string {
+		return parseError(error).message;
+	}
+
+	/**
+	 * Changing the target while branches are applied fails, since the workspace
+	 * commit is rebuilt against the currently applied stacks. So we unapply
+	 * everything first, switch, then reapply — collecting any failures along
+	 * the way instead of aborting, so the user sees the full picture at the end.
+	 */
+	async function switchTargetWithReapply(branch: string, pushRemote?: string) {
+		const stacksToReapply = stacks.filter((stack): stack is Stack & { id: string } => !!stack.id);
+		const errors: string[] = [];
+
+		for (const stack of stacksToReapply) {
+			try {
+				await stackService.unapply({ projectId, stackId: stack.id });
+			} catch (error) {
+				errors.push(`Failed to unapply "${getStackName(stack)}": ${errorMessage(error)}`);
+			}
+		}
+
+		try {
+			await switchTarget(branch, pushRemote);
+		} catch (error) {
+			errors.push(`Failed to change the target branch: ${errorMessage(error)}`);
+		}
+
+		reapplying = true;
+		try {
+			for (const stack of stacksToReapply) {
+				const branchName = stack.segments.at(0)?.refName?.displayName;
+				if (!branchName) {
+					errors.push(
+						`Could not reapply "${getStackName(stack)}": its top branch has no name to reapply by.`,
+					);
+					continue;
+				}
+				try {
+					const outcome = await stackService.branchApply({
+						projectId,
+						existingBranch: `refs/heads/${branchName}`,
+					});
+					handleApplyOutcome(outcome);
+				} catch (error) {
+					errors.push(`Failed to reapply "${branchName}": ${errorMessage(error)}`);
+				}
+			}
+		} finally {
+			reapplying = false;
+		}
+
+		if (errors.length > 0) {
+			showError("Some steps failed while switching the base branch", errors.join("\n"));
+		}
+	}
+
 	async function onSetBaseBranchClick() {
 		if (!selectedBranch) return;
+
+		if (stackCount > 0) {
+			confirmModal?.show();
+			return;
+		}
 
 		if (selectedRemote) {
 			await switchTarget(selectedBranch, selectedRemote);
@@ -88,7 +165,6 @@
 					onselect={(value) => {
 						selectedBranch = value;
 					}}
-					disabled={targetChangeDisabled}
 					label="Current target branch"
 					searchable
 				>
@@ -107,7 +183,6 @@
 						onselect={(value) => {
 							selectedRemote = value;
 						}}
-						disabled={targetChangeDisabled}
 						label="Create branches on remote"
 					>
 						{#snippet itemSnippet({ item, highlighted })}
@@ -118,26 +193,16 @@
 					</Select>
 				{/if}
 
-				{#if targetChangeDisabled}
-					<InfoMessage filled outlined={false} icon="info">
-						{#snippet content()}
-							You have {stackCount === 1 ? "1 active branch" : `${stackCount} active branches`} in your
-							workspace. Please clear the workspace before switching the base branch.
-						{/snippet}
-					</InfoMessage>
-				{:else}
-					<Button
-						kind="outline"
-						onclick={onSetBaseBranchClick}
-						id="set-base-branch"
-						loading={switching}
-						disabled={(selectedBranch === baseBranch?.branchName &&
-							selectedRemote === baseBranch?.pushRemoteName) ||
-							targetChangeDisabled}
-					>
-						{switching ? switchingLabel : "Update configuration"}
-					</Button>
-				{/if}
+				<Button
+					kind="outline"
+					onclick={onSetBaseBranchClick}
+					id="set-base-branch"
+					loading={switching}
+					disabled={selectedBranch === baseBranch?.branchName &&
+						selectedRemote === baseBranch?.pushRemoteName}
+				>
+					{switching ? switchingLabel : "Update configuration"}
+				</Button>
 			</CardGroup.Item>
 		</CardGroup>
 	{/if}
@@ -148,3 +213,30 @@
 		{/snippet}
 	</InfoMessage>
 {/if}
+
+<Modal bind:this={confirmModal} width="small" type="warning" title="Change target branch">
+	<p class="text-13 text-body">
+		You have {stackCount === 1 ? "1 active branch" : `${stackCount} active branches`} applied in
+		your workspace. To switch the target branch, GitButler will unapply all of them, change the
+		target, and then reapply them.
+	</p>
+	<p class="text-13 text-body">
+		If reapplying a branch fails (for example due to conflicts with the new target), it is left
+		unapplied. Any errors encountered along the way are shown once the operation completes.
+	</p>
+
+	{#snippet controls(close)}
+		<Button kind="outline" onclick={close}>Cancel</Button>
+		<AsyncButton
+			style="warning"
+			type="submit"
+			action={async () => {
+				if (!selectedBranch) return;
+				await switchTargetWithReapply(selectedBranch, selectedRemote);
+				close();
+			}}
+		>
+			Continue
+		</AsyncButton>
+	{/snippet}
+</Modal>


### PR DESCRIPTION
## Summary
- The "Update configuration" control for switching a project's base/target branch was disabled outright whenever any stack was applied, since changing the target while branches are applied could fail.
- Now the control stays enabled; if stacks are applied, clicking it opens a confirmation dialog explaining that GitButler will unapply all applied stacks, switch the target, and reapply them.
- On confirm, each step (unapply, switch target, reapply) runs even if a previous stack's step failed, and any errors encountered are collected and shown together once the whole operation completes.

## Test plan
- [ ] With one or more stacks applied, open Project Settings > the base branch section, pick a different target branch, and confirm the dialog appears.
- [ ] Confirm: verify stacks are unapplied, target is updated, and stacks are reapplied afterward.
- [ ] Force a failure (e.g. a stack that conflicts with the new target) and verify the resulting error is surfaced via toast after the operation finishes, without blocking the other stacks.
- [ ] With no stacks applied, verify the button still switches the target directly without showing the confirmation dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)