### PR TITLE
Change sign up label to sign in

### DIFF
--- a/apps/web/src/routes/(app)/login/+page.svelte
+++ b/apps/web/src/routes/(app)/login/+page.svelte
@@ -166,7 +166,7 @@
 
 		<Button style="pop" disabled={!isFormValid} onclick={handleSubmit}>Log in</Button>
 
-		<OAuthButtons mode="signup" />
+		<OAuthButtons mode="signin" />
 	</div>
 
 	{#snippet footer()}


### PR DESCRIPTION
## 🧢 Changes
Correct the sign up label to sign in
## ☕️ Reasoning
On the login page, it's currently showing "Or sign up with" instead of "Or sign in with" since sign-in is supported for both social logins
<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:
