### PR TITLE
feat(cli): re-implement `but pick` using new command structure

### DIFF
--- a/crates/but-api/tests/api/commit_cherry_pick.rs
+++ b/crates/but-api/tests/api/commit_cherry_pick.rs
@@ -222,8 +222,6 @@ fn cherry_pick_multiple_commits_from_outside_the_workspace() -> anyhow::Result<(
     };
     let main_ref: gix::refs::FullName = "refs/heads/main".try_into()?;
 
-    // This is what interactive `but pick` does: several commits off an unapplied branch, handed
-    // over oldest-first and applied in that order.
     let result = but_api::commit::cherry_pick::commit_cherry_pick(
         &mut ctx,
         vec![outside_first, outside_second],

--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -138,18 +138,18 @@ but branch show <id> --check  # Check if branch merges cleanly into upstream
 but branch show <id> -r       # Fetch and display review information
 ```
 
-### `but pick <source> [target]`
+### `but pick [SOURCES]...`
 
 Cherry-pick commits from unapplied branches into applied branches.
 
 ```bash
-but pick <commit-sha> <branch>       # Pick specific commit into branch
-but pick <cli-id> <branch>           # Pick using CLI ID (e.g., "nn")
+but pick <commit-sha> --branch <branch>       # Pick specific commit into branch
+but pick <cli-id> --branch <branch>           # Pick using CLI ID (e.g., "nn")
 ```
 
-Name both the source commit and the target branch. Passing a branch as the source opens an
-interactive commit picker, and omitting the target prompts for one when several branches exist —
-both block. The source can be a commit SHA (full or short) or a CLI ID from `but status`.
+Name both the source commit and the target branch. Omitting the target prompts
+for one when several branches exist. The source can be a commit SHA (full or
+short) or a CLI ID from `but status`.
 
 ## Committing
 

--- a/crates/but/src/args/atoms/commit_arg.rs
+++ b/crates/but/src/args/atoms/commit_arg.rs
@@ -25,7 +25,12 @@ impl CommitArg {
             return Err(bad_input(format!("'{self}' is not a valid commit")).into());
         };
         match repo.objects.lookup_prefix(prefix, None)? {
-            Some(Ok(commit)) => Ok(commit),
+            Some(Ok(commit)) => {
+                if repo.find_commit(commit).is_err() {
+                    return Err(bad_input(format!("'{self}' is not a commit")).into());
+                }
+                Ok(commit)
+            }
             Some(Err(_)) => Err(bad_input(format!(
                 "Commit prefix '{self}' is ambiguous, matches multiple commits"
             ))

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -875,56 +875,9 @@ pub enum Subcommands {
     #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Config(config::Platform),
 
-    /// Cherry-pick a commit from an unapplied branch into an applied virtual branch.
-    ///
-    /// This command allows you to pick individual commits from unapplied branches
-    /// and apply them to your current workspace branches.
-    ///
-    /// The source can be:
-    /// - A commit SHA (full or short)
-    /// - A CLI ID (e.g., "c5" from `but status`)
-    /// - An unapplied branch name (shows interactive commit selection)
-    ///
-    /// If no target branch is specified:
-    /// - In interactive mode: prompts you to select a target branch
-    /// - If only one branch exists: automatically uses that branch
-    /// - In non-interactive mode: fails with an error
-    ///
-    /// ## Examples
-    ///
-    /// Pick a specific commit into a branch:
-    ///
-    /// ```text
-    /// but pick abc1234 my-feature
-    /// ```
-    ///
-    /// Pick using a CLI ID:
-    ///
-    /// ```text
-    /// but pick c5 my-feature
-    /// ```
-    ///
-    /// Interactively select commits from an unapplied branch:
-    ///
-    /// ```text
-    /// but pick feature-branch
-    /// ```
-    ///
-    /// If one or more cherry-picks conflict, GitButler keeps the commits in a
-    /// conflicted state instead of aborting the operation. Resolve all of them,
-    /// oldest first, with `but resolve --ai`; or find their IDs with `but status`
-    /// and resolve them individually with `but resolve <commit-id>`. Back out of
-    /// the pick operation with `but undo`.
-    ///
     #[cfg(feature = "legacy")]
     #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
-    Pick {
-        /// The commit SHA, CLI ID, or unapplied branch name to cherry-pick from
-        source: String,
-        /// The target virtual branch to apply the commit(s) to
-        #[clap(value_name = "TARGET_BRANCH")]
-        target_branch: Option<String>,
-    },
+    Pick(pick::Platform),
 
     /// Switch to a local branch, workspace branch ID, or the GitButler workspace.
     ///
@@ -1178,6 +1131,8 @@ pub mod discard;
 pub mod mcp;
 #[cfg(feature = "legacy")]
 pub mod r#move;
+#[cfg(feature = "legacy")]
+pub mod pick;
 pub mod skill;
 #[cfg(feature = "legacy")]
 pub mod squash;

--- a/crates/but/src/args/pick.rs
+++ b/crates/but/src/args/pick.rs
@@ -1,0 +1,68 @@
+//! Arguments for `pick`.
+
+#![deny(missing_docs)]
+
+use crate::args::atoms::{AllowMergedArg, CliIdArg};
+
+/// Cherry-pick commits into an applied branch.
+///
+/// Each source commit is copied to the target location as a new commit.
+///
+/// If there are no branches applied, a new branch is created for the picked commits. If there is
+/// only one stack of branches applied, the commits are placed at the tip of that stack. Otherwise,
+/// the targeting flags `--above`, `--below`, and `--branch` control where the commits are placed.
+/// Only one targeting flag can be provided at a time.
+///
+/// For more details about CLI IDs, see `but help cli-ids`.
+#[derive(Debug, clap::Parser)]
+#[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
+pub struct Platform {
+    /// Place the picked commits on the branch `BRANCH`.
+    ///
+    /// If `BRANCH` does not exist, it is created as an unstacked branch.
+    ///
+    /// If `BRANCH` is omitted, an unstacked branch with a generated name is created.
+    ///
+    /// Attempting to pick onto a branch that exists but is not applied is an error.
+    #[clap(short, long, value_name = "BRANCH", group = "targeting")]
+    pub branch: Option<Option<CliIdArg>>,
+
+    /// Place the picked commits above `BRANCH_OR_COMMIT`.
+    ///
+    /// If `BRANCH_OR_COMMIT` is a commit, the picked commits are placed on the same branch as the
+    /// targeted commit.
+    ///
+    /// If `BRANCH_OR_COMMIT` is a branch, the picked commits are placed on a new branch above the
+    /// targeted branch.
+    #[clap(
+        short = 'A',
+        long,
+        value_name = "BRANCH_OR_COMMIT",
+        group = "targeting"
+    )]
+    pub above: Option<CliIdArg>,
+
+    /// Place the picked commits below `BRANCH_OR_COMMIT`.
+    ///
+    /// If `BRANCH_OR_COMMIT` is a commit, the picked commits are placed on the same branch as the
+    /// targeted commit.
+    ///
+    /// If `BRANCH_OR_COMMIT` is a branch, the picked commits are placed on a new branch below the
+    /// targeted branch. Branches are treated as buckets, meaning that "below a branch" is treated
+    /// as below the oldest ancestor on that branch.
+    #[clap(
+        short = 'B',
+        long,
+        value_name = "BRANCH_OR_COMMIT",
+        group = "targeting"
+    )]
+    pub below: Option<CliIdArg>,
+
+    /// The sources to cherry-pick.
+    #[clap(group = "changes_to_commit", required = true)]
+    pub sources: Vec<CliIdArg>,
+
+    #[clap(flatten)]
+    #[allow(missing_docs)]
+    pub allow_merged: AllowMergedArg,
+}

--- a/crates/but/src/command/help.rs
+++ b/crates/but/src/command/help.rs
@@ -380,7 +380,7 @@ Branching and Committing:
   unapply      Unapply a branch from the workspace
   apply        Apply a branch to the workspace
   clean        Remove empty branches from the workspace
-  pick         Cherry-pick a commit from an unapplied branch into an applied v…
+  pick         Cherry-pick commits into an applied branch
 
 Editing Commits:
   squash       Squash commits, branches, or changes
@@ -445,7 +445,7 @@ Environment variables:
 
         assert!(
             output.contains(
-                "Cherry-pick a commit from an unapplied branch into an applied virtual branch"
+                "Uncommit changes from commits or committed files to the uncommitted area"
             ),
             "agent help should keep the full command description"
         );

--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -25,6 +25,7 @@ use crate::{
         reword2::RewordCommitOperation,
         status::{Selectable, TuiOutcome, TuiRunOptions, tui_with_options},
     },
+    error::BadInput,
     id::{CommitId, UncommittedHunkOrFile},
     theme::{self, Theme},
     utils::{
@@ -41,6 +42,7 @@ pub struct CommitOutcome {
 
 /// `--json` should only include newly created things. So if the branch already existed it
 /// wont be included in the JSON output.
+#[derive(Debug)]
 pub enum BranchNameTarget {
     Existing(FullName),
     New(FullName),
@@ -158,19 +160,7 @@ fn resolve(
 
     let merged = MergedUpstream::new(&*ctx.repo.get()?, head_info, allow_merged);
 
-    let target_ish = match (branch, above, below) {
-        (Some(Some(branch)), None, None) => CommitOperationTargetIsh::Branch(branch),
-        (Some(None), None, None) => CommitOperationTargetIsh::UnstackedCannedBranch,
-        (None, Some(cli_id), None) => CommitOperationTargetIsh::Above(cli_id),
-        (None, None, Some(cli_id)) => CommitOperationTargetIsh::Below(cli_id),
-        (None, None, None) => CommitOperationTargetIsh::Default,
-        _ => {
-            return Err(anyhow::anyhow!(
-                "BUG: Should not be able to supply more than one of above, below or branch"
-            )
-            .into());
-        }
-    };
+    let target_ish = CommitOperationTargetIsh::resolve(branch, above, below)?;
 
     let (guard, commit_selection) = if !changes.is_empty() {
         let changes = changes
@@ -229,7 +219,19 @@ fn resolve(
 
     let commit_op = {
         let (repo, ws, _db) = ctx.workspace_and_db_with_perm(guard.read_permission())?;
-        route_commit_operation(&repo, &ws, head_info, out, id_map, target_ish, &merged)?
+        route_commit_operation(&repo, &ws, head_info, out, id_map, target_ish, &merged).map_err(
+            |err| match err {
+                RouteCommitOperationError::NoStackToCommitTo => {
+                    bad_input("Found no stack that could be committed to").into()
+                }
+                RouteCommitOperationError::UnclearTargetCantPrompt => {
+                    bad_input("Unclear where to commit. Found more than one stack")
+                        .hint("You can specify where to commit with `--branch [<BRANCH>]`")
+                        .into()
+                }
+                RouteCommitOperationError::Other(cli_error) => cli_error,
+            },
+        )?
     };
 
     let reword_op = RewordCommitOperation::resolve(no_message, message);
@@ -326,7 +328,7 @@ pub fn run(
 }
 
 /// Targeting modes for committing.
-enum CommitOperationTargetIsh {
+pub enum CommitOperationTargetIsh {
     /// Target the branch if it exists, or create it at the newest base if it does not.
     Branch(CliIdArg),
     /// Target newest base with a new canned branch name.
@@ -342,7 +344,29 @@ enum CommitOperationTargetIsh {
     Default,
 }
 
-fn route_commit_operation(
+impl CommitOperationTargetIsh {
+    pub fn resolve(
+        branch: Option<Option<CliIdArg>>,
+        above: Option<CliIdArg>,
+        below: Option<CliIdArg>,
+    ) -> CliResult<Self> {
+        Ok(match (branch, above, below) {
+            (Some(Some(branch)), None, None) => CommitOperationTargetIsh::Branch(branch),
+            (Some(None), None, None) => CommitOperationTargetIsh::UnstackedCannedBranch,
+            (None, Some(cli_id), None) => CommitOperationTargetIsh::Above(cli_id),
+            (None, None, Some(cli_id)) => CommitOperationTargetIsh::Below(cli_id),
+            (None, None, None) => CommitOperationTargetIsh::Default,
+            _ => {
+                return Err(anyhow::anyhow!(
+                    "BUG: Should not be able to supply more than one of above, below or branch"
+                )
+                .into());
+            }
+        })
+    }
+}
+
+pub fn route_commit_operation(
     repo: &gix::Repository,
     ws: &but_graph::Workspace,
     head_info: &RefInfo,
@@ -350,15 +374,19 @@ fn route_commit_operation(
     id_map: &IdMap,
     target: CommitOperationTargetIsh,
     merged: &MergedUpstream,
-) -> CliResult<CommitOperation> {
+) -> Result<CommitOperation, RouteCommitOperationError> {
     match target {
         CommitOperationTargetIsh::Above(cli_id) => {
             let side = Side::Above;
-            route_commit_above_or_below(repo, id_map, cli_id, side, merged)
+            Ok(route_commit_above_or_below(
+                repo, id_map, cli_id, side, merged,
+            )?)
         }
         CommitOperationTargetIsh::Below(cli_id) => {
             let side = Side::Below;
-            route_commit_above_or_below(repo, id_map, cli_id, side, merged)
+            Ok(route_commit_above_or_below(
+                repo, id_map, cli_id, side, merged,
+            )?)
         }
         CommitOperationTargetIsh::Branch(cli_id) => {
             if let Some(branch) = cli_id.try_resolve_branch(repo, id_map)? {
@@ -432,15 +460,11 @@ fn route_commit_operation(
                         .collect::<Vec<_>>();
 
                     let Some(stack_heads) = NonEmpty::from_vec(stack_heads) else {
-                        return Err(bad_input("Found not stack that could be committed to").into());
+                        return Err(RouteCommitOperationError::NoStackToCommitTo);
                     };
 
                     let Some(mut input) = out.prepare_for_terminal_input() else {
-                        return Err(bad_input(
-                            "Unclear where to commit. Found more than one stack",
-                        )
-                        .hint("You can specify where to commit with `--branch [<BRANCH>]`")
-                        .into());
+                        return Err(RouteCommitOperationError::UnclearTargetCantPrompt);
                     };
 
                     let mut stack_heads =
@@ -470,6 +494,31 @@ fn route_commit_operation(
                 }
             }
         }
+    }
+}
+
+#[derive(Debug)]
+pub enum RouteCommitOperationError {
+    NoStackToCommitTo,
+    UnclearTargetCantPrompt,
+    Other(CliError),
+}
+
+impl From<anyhow::Error> for RouteCommitOperationError {
+    fn from(err: anyhow::Error) -> Self {
+        Self::Other(err.into())
+    }
+}
+
+impl From<CliError> for RouteCommitOperationError {
+    fn from(value: CliError) -> Self {
+        Self::Other(value)
+    }
+}
+
+impl From<BadInput> for RouteCommitOperationError {
+    fn from(value: BadInput) -> Self {
+        Self::Other(value.into())
     }
 }
 
@@ -595,13 +644,25 @@ impl CommitAtOperation {
         tx: &mut Transaction<'_, '_, impl RefMetadata>,
         changes: Vec<DiffSpec>,
     ) -> anyhow::Result<(IntermediateCommitCreateResult, Option<BranchNameTarget>)> {
-        let (relative_to, side, branch_name_target) = match self.target {
+        let (relative_to, side, branch_name_target) = self.create_target(tx)?;
+
+        let commit_create_result =
+            tx.create_commit(relative_to.clone(), side, changes, String::new())?;
+
+        Ok((commit_create_result, branch_name_target))
+    }
+
+    pub fn create_target(
+        &self,
+        tx: &mut Transaction<'_, '_, impl RefMetadata>,
+    ) -> anyhow::Result<(RelativeTo, InsertSide, Option<BranchNameTarget>)> {
+        Ok(match &self.target {
             CommitRelativeToTarget::Commit { commit, side } => {
-                (RelativeTo::Commit(commit.commit_id), side.into(), None)
+                (RelativeTo::Commit(commit.commit_id), (*side).into(), None)
             }
             CommitRelativeToTarget::BranchBucket { name, side } => {
                 let new_branch_name = but_core::branch::unique_canned_refname(tx.repo())?;
-                let anchor = Anchor::at_segment(name.as_ref(), side.into());
+                let anchor = Anchor::at_segment(name.as_ref(), (*side).into());
                 tx.create_reference(
                     new_branch_name.as_ref(),
                     Some(anchor),
@@ -618,14 +679,9 @@ impl CommitAtOperation {
             CommitRelativeToTarget::BranchTip { name } => (
                 RelativeTo::Reference(name.clone()),
                 InsertSide::Below,
-                Some(BranchNameTarget::Existing(name)),
+                Some(BranchNameTarget::Existing(name.clone())),
             ),
-        };
-
-        let commit_create_result =
-            tx.create_commit(relative_to.clone(), side, changes, String::new())?;
-
-        Ok((commit_create_result, branch_name_target))
+        })
     }
 }
 

--- a/crates/but/src/command/legacy/move.rs
+++ b/crates/but/src/command/legacy/move.rs
@@ -58,7 +58,6 @@ impl CliOutputHuman for MoveOutcome {
         _agent: bool,
         _theme: &Theme,
     ) -> anyhow::Result<()> {
-        // GB-1771 missing change ID here
         match self {
             Self::Commits {
                 sources,

--- a/crates/but/src/command/legacy/pick.rs
+++ b/crates/but/src/command/legacy/pick.rs
@@ -1,377 +1,288 @@
-//! Cherry-pick commits from unapplied branches into applied virtual branches.
-
-use crate::legacy::workspace::HeadInfoStack;
-use crate::theme::{self, Paint};
-use anyhow::{Context as _, Result, bail};
-use but_api::legacy::virtual_branches;
-use but_core::{DryRun, RepositoryExt, ref_metadata::StackId, sync::RepoShared};
+use but_api::json::{ChangeIdString, HexHash};
+use but_core::{
+    DryRun, RefMetadata,
+    ref_metadata::StackId,
+    sync::{RepoExclusive, RepoShared},
+};
 use but_ctx::Context;
 use but_rebase::graph_rebase::mutate::{InsertSide, RelativeTo};
-use gitbutler_branch_actions::BranchListingFilter;
-use gix::{revision::walk::Sorting, traverse::commit::simple::CommitTimeOrder};
+use but_workspace::RefInfo;
+use gitbutler_oplog::entry::{OperationKind, SnapshotDetails};
+use gix::ObjectId;
+use itertools::Itertools as _;
+use serde::Serialize;
 
 use crate::{
-    CliId, IdMap,
-    command::legacy::workspace_target,
+    CliResult, IdMap,
+    args::{
+        atoms::{CommitArg, Priority, Purpose, ResolvedCliIdArg},
+        pick::Platform,
+    },
+    bad_input,
+    command::legacy::commit::{
+        BranchNameTarget, CommitOperation, CommitOperationTargetIsh, CommitToNewBranchOperation,
+        RouteCommitOperationError, route_commit_operation,
+    },
     id::CommitId,
-    utils::{OutputChannel, WriteWithUtils, shorten_object_id},
+    theme::{self, Theme},
+    utils::{
+        CliOutput, CliOutputHuman, IntermediateChannel, WriteWithUtils,
+        merged_upstream::MergedUpstream,
+    },
 };
 
-/// Handle the `but pick` command.
-///
-/// Cherry-picks one or more commits from an unapplied branch into an applied virtual branch.
-pub fn handle(
-    ctx: &mut Context,
-    out: &mut OutputChannel,
-    source: &str,
-    target_branch: Option<&str>,
-) -> Result<()> {
-    let mut guard = ctx.exclusive_worktree_access();
-    let id_map = IdMap::new_from_context(ctx, None, guard.read_permission())?;
+#[derive(Debug)]
+pub struct PickOutcome {
+    sources: Vec<ObjectId>,
+    new_commits: Vec<CommitId>,
+    branch_name: Option<BranchNameTarget>,
+}
 
-    // Get applied stacks first - we'll need them for target resolution
-    let stacks = crate::legacy::workspace::applied_stacks(ctx).context("Failed to list stacks")?;
+impl CliOutputHuman for PickOutcome {
+    fn on_human(
+        self,
+        out: &mut dyn WriteWithUtils,
+        _agent: bool,
+        _theme: &Theme,
+    ) -> anyhow::Result<()> {
+        let Self {
+            sources,
+            new_commits,
+            branch_name,
+        } = self;
 
-    if stacks.is_empty() {
-        bail!(
-            "No applied stacks in workspace. Apply a branch first with 'but apply <branch-name>'."
-        );
-    }
+        let sources = sources
+            .into_iter()
+            .map(|commit| CommitId {
+                commit_id: commit,
+                change_id: None,
+            })
+            .map(theme::Commit)
+            .join(", ");
+        let new_commits = new_commits.into_iter().map(theme::Commit).join(", ");
 
-    // Resolve the target before the source so an interactive run prompts for the branch first.
-    let target = resolve_target_stack(ctx, out, &id_map, &stacks, target_branch)?;
-
-    // Resolve the source to commit(s) (may involve interactive multi-selection for branches)
-    let commit_oids = resolve_source_commits(ctx, guard.read_permission(), out, &id_map, source)?;
-
-    // All picks land on the target branch in one rebase, which also records the oplog snapshot.
-    but_api::commit::cherry_pick::commit_cherry_pick_with_perm(
-        ctx,
-        commit_oids.clone(),
-        RelativeTo::Reference(target.reference.clone()),
-        InsertSide::Below,
-        DryRun::No,
-        guard.write_permission(),
-    )
-    .context("Failed to cherry-pick commit")?;
-
-    // Output results
-    let t = theme::get();
-    let repo = ctx.repo.get()?.clone().for_commit_shortening();
-    for commit_oid in &commit_oids {
-        let commit_short = shorten_object_id(&repo, *commit_oid);
-        if let Some(out) = out.for_human() {
-            writeln!(
+        match branch_name {
+            Some(BranchNameTarget::New(branch_name)) => writeln!(
                 out,
-                "{} {} {} {}",
-                t.success.paint("Picked commit"),
-                t.commit_id.paint(&commit_short),
-                t.success.paint("into branch"),
-                t.local_branch.paint(&target.name)
-            )?;
+                "Picked {} onto new branch {} to create {}",
+                sources,
+                theme::Branch(branch_name),
+                new_commits,
+            )?,
+            Some(BranchNameTarget::Existing(branch_name)) => writeln!(
+                out,
+                "Picked {} onto branch {} to create {}",
+                sources,
+                theme::Branch(branch_name),
+                new_commits,
+            )?,
+            None => writeln!(out, "Picked {sources} to create {new_commits}")?,
         }
-    }
 
-    if let Some(out) = out.for_json() {
-        let picked = |commit_oid: &gix::ObjectId| {
-            serde_json::json!({
-                "picked_commit": commit_oid.to_string(),
-                "target_branch": target.name,
-                "target_stack_id": target.stack_id.to_string(),
-            })
-        };
-        if let [only] = commit_oids.as_slice() {
-            out.write_value(picked(only))?;
-        } else {
-            out.write_value(serde_json::json!({
-                "picked_commits": commit_oids.iter().map(picked).collect::<Vec<_>>(),
-            }))?;
-        }
+        Ok(())
     }
-
-    Ok(())
 }
 
-/// Resolve the source argument to one or more commit OIDs.
-///
-/// Tries in order:
-/// 1. Unapplied branch name (shows interactive commit selection if available)
-/// 2. CLI ID (e.g., "c5")
-/// 3. Full or partial commit SHA (via rev_parse)
-fn resolve_source_commits(
-    ctx: &Context,
-    perm: &RepoShared,
-    out: &mut OutputChannel,
-    id_map: &IdMap,
-    source: &str,
-) -> Result<Vec<gix::ObjectId>> {
-    // Try as an unapplied branch name first (case-insensitive)
-    // This takes priority so branch names trigger interactive commit selection
-    let branches = virtual_branches::list_branches(
+impl CliOutput for PickOutcome {
+    fn on_json(self) -> impl serde::Serialize {
+        #[derive(Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct PickedCommit {
+            source_commit_id: HexHash,
+            new_commit_id: HexHash,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            new_change_id: Option<ChangeIdString>,
+        }
+
+        #[derive(Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Output {
+            commits: Vec<PickedCommit>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            branch: Option<String>,
+        }
+
+        let Self {
+            sources,
+            new_commits,
+            branch_name,
+        } = self;
+
+        Output {
+            commits: sources
+                .into_iter()
+                .zip(new_commits)
+                .map(|(source, new)| PickedCommit {
+                    source_commit_id: source.into(),
+                    new_commit_id: new.commit_id.into(),
+                    new_change_id: new.change_id.map(Into::into),
+                })
+                .collect(),
+            branch: match branch_name {
+                Some(BranchNameTarget::New(branch_name)) => Some(branch_name.shorten().to_string()),
+                Some(BranchNameTarget::Existing(_)) | None => None,
+            },
+        }
+    }
+}
+
+pub fn pick(
+    ctx: &mut Context,
+    mut out: IntermediateChannel<'_>,
+    args: Platform,
+) -> CliResult<PickOutcome> {
+    let mut guard = ctx.exclusive_worktree_access();
+    let mut meta = ctx.meta()?;
+    let id_map = IdMap::new_from_context(ctx, None, guard.read_permission())?;
+    let head_info = but_api::legacy::workspace::head_info(ctx)?;
+
+    let pick_op = resolve(
         ctx,
-        Some(BranchListingFilter {
-            applied: Some(false),
-            local: None,
-        }),
-    )
-    .context("Failed to list branches")?;
+        &head_info,
+        &mut out,
+        guard.read_permission(),
+        &id_map,
+        args,
+    )?;
 
-    let source_lower = source.to_lowercase();
-    if let Some(branch) = branches
-        .iter()
-        .find(|b| b.name.to_string() == source || b.name.to_string().to_lowercase() == source_lower)
-    {
-        let branch_name = branch.name.to_string();
-        return select_commits_from_branch(ctx, perm, out, branch.head, &branch_name);
-    }
-
-    // Try using IdMap for CLI IDs
-    let cli_ids = id_map.parse_using_context(source, ctx)?;
-
-    for cli_id in &cli_ids {
-        if let CliId::Commit {
-            commit: CommitId { commit_id, .. },
-            id: _,
-        } = cli_id
-        {
-            return Ok(vec![*commit_id]);
-        }
-    }
-
-    // Fall back to git revision (handles full SHA, short SHA, refs)
-    {
-        let repo = ctx.repo.get()?;
-        if let Ok(oid) = repo.rev_parse_single(source) {
-            let object_id: gix::ObjectId = oid.detach();
-            if repo.find_commit(object_id).is_ok() {
-                return Ok(vec![object_id]);
-            }
-        }
-    }
-
-    bail!(
-        "Source '{source}' is not a valid commit ID, CLI ID, or unapplied branch name.\n\
-Run 'but status' to see available CLI IDs, or 'but branch list' to see branches."
-    );
+    Ok(run(ctx, &mut meta, guard.write_permission(), pick_op)?)
 }
 
-/// Select one or more commits from a branch, either interactively or using the head.
-fn select_commits_from_branch(
+fn resolve(
     ctx: &Context,
+    head_info: &RefInfo,
+    out: &mut IntermediateChannel<'_>,
     perm: &RepoShared,
-    out: &mut OutputChannel,
-    branch_head: gix::ObjectId,
-    branch_name: &str,
-) -> Result<Vec<gix::ObjectId>> {
-    use gix::prelude::ObjectIdExt as _;
-
-    let repo = ctx.repo.get()?;
-
-    // Find merge base
-    let (merge_base, _) =
-        workspace_target::merge_base_with_target_with_perm(ctx, perm, branch_head)?;
-
-    // Non-interactive mode: use the branch head directly (most recent commit)
-    if !out.can_prompt() {
-        // Verify branch_head is not the merge base itself (i.e., there are commits to pick)
-        if branch_head == merge_base {
-            bail!("No commits found on branch '{branch_name}' that aren't already in target.");
-        }
-        return Ok(vec![branch_head]);
-    }
-
-    // Interactive mode: walk commits from branch head to merge base
-    let traversal = branch_head
-        .attach(&repo)
-        .ancestors()
-        .sorting(Sorting::ByCommitTime(CommitTimeOrder::NewestFirst))
-        .with_hidden(Some(merge_base))
-        .all()?;
-
-    // Collect commit OIDs and then decode them for message display
-    let commit_oids: Vec<gix::ObjectId> = traversal
-        .filter_map(Result::ok)
-        .map(|info| info.id)
-        .take(50) // Limit to reasonable number
-        .collect();
-
-    // Keep OID paired with each commit summary so indices stay aligned after filtering.
-    let commits: Vec<_> = commit_oids
-        .iter()
-        .filter_map(|oid| {
-            repo.find_commit(*oid).ok().and_then(|commit| {
-                let commit = commit.decode().ok()?;
-                (*oid, super::commit_summary(&commit)).into()
-            })
-        })
-        .collect();
-
-    if commits.is_empty() {
-        bail!("No commits found on branch '{branch_name}' that aren't already in target.");
-    }
-
-    // If only one commit, use it directly
-    if commits.len() == 1 {
-        return Ok(vec![commits[0].0]);
-    }
-
-    // Interactive multi-selection
-    let options = commits
-        .iter()
-        .enumerate()
-        .map(|(i, (oid, message))| {
-            let short_id = shorten_object_id(&repo, *oid);
-            let display = out.truncate_if_unpaged(message, 60);
-            (format!("[{}] {} {}", i + 1, short_id, display), i)
-        })
-        .collect::<Vec<_>>();
-    let options = nonempty::NonEmpty::from_vec(options).context("No commits available")?;
-    let mut input = out
-        .prepare_for_terminal_input()
-        .context("Human input required - run this in a terminal")?;
-
-    let selections = input
-        .prompt_multi_select(format!("Pick commits from '{branch_name}'"), &options)?
-        .ok_or_else(|| anyhow::anyhow!("Selection aborted"))?;
-
-    if selections.is_empty() {
-        bail!("No commits selected.");
-    }
-
-    // Return in oldest-first order so they are applied chronologically
-    let mut selected_indices_sorted = selections.into_iter().copied().collect::<Vec<_>>();
-    selected_indices_sorted.sort_unstable();
-    selected_indices_sorted.reverse();
-
-    Ok(selected_indices_sorted
-        .into_iter()
-        .map(|i| commits[i].0)
-        .collect())
-}
-
-/// The branch that picked commits land on.
-#[derive(Clone)]
-struct PickTarget {
-    stack_id: StackId,
-    /// The branch tip the picks are placed below, i.e. on top of.
-    reference: gix::refs::FullName,
-    /// The branch name as shown to the user.
-    name: String,
-}
-
-/// Resolve the target stack based on user input.
-fn resolve_target_stack(
-    ctx: &Context,
-    out: &mut OutputChannel,
     id_map: &IdMap,
-    stacks: &[HeadInfoStack],
-    target_branch: Option<&str>,
-) -> Result<PickTarget> {
-    // If target is specified, find matching stack (by CLI ID or name)
-    if let Some(target) = target_branch {
-        return find_stack_by_target(ctx, id_map, stacks, target);
-    }
+    args: Platform,
+) -> CliResult<PickOperation> {
+    let Platform {
+        branch,
+        above,
+        below,
+        sources,
+        allow_merged,
+    } = args;
 
-    // If only one stack, use it automatically
-    if stacks.len() == 1 {
-        return pick_target(&stacks[0]);
-    }
+    let merged = MergedUpstream::new(&*ctx.repo.get()?, head_info, allow_merged);
 
-    // Multiple stacks and no target specified - need interactive selection
-    if !out.can_prompt() {
-        bail!(
-            "Multiple stacks in workspace. Specify target branch explicitly.\n\
-Available stacks: {}",
-            format_stack_names(stacks)
-        );
-    }
-
-    let mut input = out
-        .prepare_for_terminal_input()
-        .context("Human input required - run this in a terminal")?;
-    select_target_interactively(&mut input, stacks)
-}
-
-/// Find a stack by CLI ID or branch name (case-insensitive).
-fn find_stack_by_target(
-    ctx: &Context,
-    id_map: &IdMap,
-    stacks: &[HeadInfoStack],
-    target: &str,
-) -> Result<PickTarget> {
-    // Try parsing as CLI ID first
-    if let Ok(cli_ids) = id_map.parse_using_context(target, ctx) {
-        for cli_id in &cli_ids {
-            if let CliId::Branch(branch) = cli_id
-                && let Some(stack_id) = branch.stack_id
-            {
-                // Verify the stack is in our list of applied stacks. Picks land on the stack's
-                // top branch even when the ID names one further down, as they always have.
-                if let Some(stack) = stacks.iter().find(|stack| stack.id == Some(stack_id)) {
-                    return pick_target(stack);
+    let sources = {
+        let repo = ctx.repo.get()?;
+        sources
+            .into_iter()
+            .map(|source| {
+                if let Some(resolved) =
+                    source.try_resolve(&repo, id_map, Purpose::Source, Some(Priority::Commit))?
+                {
+                    match resolved {
+                        ResolvedCliIdArg::Commit(commit_id) => Ok(commit_id.commit_id),
+                        ResolvedCliIdArg::Branch(..)
+                        | ResolvedCliIdArg::UncommittedHunkOrFile(..)
+                        | ResolvedCliIdArg::CommittedFile(..)
+                        | ResolvedCliIdArg::Uncommitted
+                        | ResolvedCliIdArg::PathPrefix { .. }
+                        | ResolvedCliIdArg::Stack => Err(bad_input(format!(
+                            "Only commits can be cherry-picked. {} is {}",
+                            source,
+                            resolved.kind_for_humans()
+                        ))
+                        .into()),
+                    }
+                } else {
+                    CommitArg(source.0).resolve(&repo)
                 }
-            }
-        }
-    }
+            })
+            .collect::<CliResult<Vec<_>>>()?
+            .into_iter()
+            .unique()
+            .collect()
+    };
 
-    // Fall back to name-based matching (case-insensitive)
-    let target_lower = target.to_lowercase();
-    for stack in stacks {
-        for branch in &stack.branches {
-            if branch.name == target || branch.name.to_lowercase() == target_lower {
-                return pick_target(stack);
-            }
-        }
-    }
+    let target_ish = CommitOperationTargetIsh::resolve(branch, above, below)?;
 
-    bail!(
-        "Target branch '{}' not found among applied stacks.\n\
-Available stacks: {}",
-        target,
-        format_stack_names(stacks)
-    );
+    let commit_op = {
+        let (repo, ws, _db) = ctx.workspace_and_db_with_perm(perm)?;
+        route_commit_operation(&repo, &ws, head_info, out, id_map, target_ish, &merged).map_err(
+            |err| match err {
+                RouteCommitOperationError::NoStackToCommitTo => {
+                    bad_input("Found no stack that could be picked to").into()
+                }
+                RouteCommitOperationError::UnclearTargetCantPrompt => {
+                    bad_input("Unclear where to pick to. Found more than one stack")
+                        .hint("You can specify where to pick to with `--branch [<BRANCH>]`")
+                        .into()
+                }
+                RouteCommitOperationError::Other(cli_error) => cli_error,
+            },
+        )?
+    };
+
+    Ok(PickOperation { sources, commit_op })
 }
 
-/// Extract the pick target from a stack entry.
-fn pick_target(stack: &HeadInfoStack) -> Result<PickTarget> {
-    let stack_id = stack.id.context("Stack has no ID")?;
-    let top_branch = stack
-        .branches
-        .first()
-        .context("Stack has no branches to pick into")?;
-    Ok(PickTarget {
-        stack_id,
-        reference: top_branch.reference.clone(),
-        name: top_branch.name.clone(),
+struct PickOperation {
+    sources: Vec<ObjectId>,
+    commit_op: CommitOperation,
+}
+
+fn run(
+    ctx: &mut Context,
+    meta: &mut impl RefMetadata,
+    perm: &mut RepoExclusive,
+    pick_op: PickOperation,
+) -> anyhow::Result<PickOutcome> {
+    let PickOperation { sources, commit_op } = pick_op;
+
+    let snapshot_details =
+        SnapshotDetails::new(OperationKind::CherryPick).with_count(sources.len());
+    let ((new_commits, branch_name_target), _ws) = but_transaction::with_transaction_with_perm(
+        ctx,
+        meta,
+        perm,
+        snapshot_details,
+        DryRun::No,
+        |mut tx| {
+            let (new_commits, branch_name_target) = match commit_op {
+                CommitOperation::CommitToNewBranch(CommitToNewBranchOperation { branch_name }) => {
+                    let branch_name = if let Some(branch_name) = branch_name {
+                        branch_name
+                    } else {
+                        but_core::branch::unique_canned_refname(tx.repo())?
+                    };
+
+                    tx.create_reference(
+                        branch_name.as_ref(),
+                        None,
+                        |_| StackId::generate(),
+                        Some(0),
+                    )?;
+
+                    let new_commits = tx.cherry_pick_commits(
+                        sources.iter().copied(),
+                        RelativeTo::Reference(branch_name.clone()),
+                        InsertSide::Below,
+                    )?;
+
+                    (new_commits, Some(BranchNameTarget::New(branch_name)))
+                }
+                CommitOperation::CommitAt(op) => {
+                    let (relative_to, side, branch_name_target) = op.create_target(&mut tx)?;
+                    let new_commits =
+                        tx.cherry_pick_commits(sources.iter().copied(), relative_to, side)?;
+
+                    (new_commits, branch_name_target)
+                }
+            };
+
+            Ok(but_transaction::Commit((new_commits, branch_name_target)))
+        },
+    )?;
+
+    let new_commits = new_commits.into_iter().map(Into::into).collect();
+
+    Ok(PickOutcome {
+        sources,
+        new_commits,
+        branch_name: branch_name_target,
     })
-}
-
-/// Format stack names for display in error messages.
-fn format_stack_names(stacks: &[HeadInfoStack]) -> String {
-    stacks
-        .iter()
-        .filter_map(|stack| stack.top_branch_name().map(ToOwned::to_owned))
-        .collect::<Vec<_>>()
-        .join(", ")
-}
-
-/// Interactive selection of target stack.
-fn select_target_interactively(
-    input: &mut crate::utils::InputOutputChannel<'_>,
-    stacks: &[HeadInfoStack],
-) -> Result<PickTarget> {
-    let options = stacks
-        .iter()
-        .filter_map(|stack| {
-            let target = pick_target(stack).ok()?;
-            Some((target.name.clone(), target))
-        })
-        .collect::<Vec<_>>();
-    let options =
-        nonempty::NonEmpty::from_vec(options).context("No branches available for selection")?;
-
-    input
-        .prompt_select("Select target branch", &options)?
-        .cloned()
-        .ok_or_else(|| anyhow::anyhow!("Selection aborted"))
 }

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -1631,10 +1631,10 @@ async fn match_subcommand(
             result.show_root_cause_error_then_exit_without_destructors(output)
         }
         #[cfg(feature = "legacy")]
-        Subcommands::Pick {
-            source,
-            target_branch,
-        } => {
+        Subcommands::Pick(pick_args) => {
+            use crate::utils::IntermediateChannel;
+
+            let status_after = args.status_after;
             let mut ctx = setup::init_ctx(
                 &args,
                 InitCtxOptions {
@@ -1643,19 +1643,16 @@ async fn match_subcommand(
                 },
                 out,
             )?;
+            out.begin_status_after(status_after);
+
             let conflicts_before = command::legacy::conflict_notice::snapshot(&ctx);
-            let result =
-                command::legacy::pick::handle(&mut ctx, out, &source, target_branch.as_deref())
-                    .context("Failed to pick commit.")
-                    .emit_metrics(metrics_ctx);
-            if result.is_ok() {
-                command::legacy::conflict_notice::report_newly_conflicted(
-                    &ctx,
-                    out,
-                    conflicts_before,
-                );
-            }
-            result.show_root_cause_error_then_exit_without_destructors(output)
+            let outcome =
+                command::legacy::pick::pick(&mut ctx, IntermediateChannel::new(out), pick_args)
+                    .emit_metrics(metrics_ctx)?;
+            out.print_cli_output(outcome)?;
+            command::legacy::conflict_notice::report_newly_conflicted(&ctx, out, conflicts_before);
+            run_status_after_if_requested(status_after, &mut ctx, out);
+            Ok(())
         }
         #[cfg(feature = "legacy")]
         Subcommands::Unapply { identifier } => {

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -226,7 +226,7 @@ impl Subcommands {
             #[cfg(feature = "legacy")]
             Subcommands::Land { .. } => Land,
             #[cfg(feature = "legacy")]
-            Subcommands::Pick { .. } => Pick,
+            Subcommands::Pick(..) => Pick,
             Subcommands::Skill(skill::Platform { cmd }) => match cmd {
                 skill::Subcommands::Install { .. } => SkillInstall,
                 skill::Subcommands::Check { .. } => SkillCheck,

--- a/crates/but/tests/but/command/pick.rs
+++ b/crates/but/tests/but/command/pick.rs
@@ -1,175 +1,292 @@
 use snapbox::str;
 
-use crate::utils::{CommandExt, Sandbox};
-
-/// Get commit SHA from a git reference
-fn get_commit_sha(env: &Sandbox, git_ref: &str) -> String {
-    env.invoke_git(&format!("rev-parse {git_ref}"))
-}
-
-/// Check if a branch contains a commit with the given message substring
-fn branch_has_commit_message(env: &Sandbox, branch_name: &str, message_contains: &str) -> bool {
-    let result = env.but("status --json").assert().success();
-    let stdout = String::from_utf8_lossy(&result.get_output().stdout);
-    let status: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
-
-    status["stacks"]
-        .as_array()
-        .unwrap()
-        .iter()
-        .flat_map(|stack| stack["branches"].as_array().unwrap())
-        .filter(|branch| branch["name"] == branch_name)
-        .flat_map(|branch| branch["commits"].as_array().unwrap())
-        .any(|commit| {
-            commit["message"]
-                .as_str()
-                .map(|m| m.contains(message_contains))
-                .unwrap_or(false)
-        })
-}
-
-// === Success cases ===
+use crate::utils::{CommandExt as _, Sandbox};
 
 #[test]
-fn pick_by_full_sha() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("pick-from-unapplied");
-    env.setup_metadata(&["applied-branch"]);
+fn pick_commit_to_existing_branch_outputs_json() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
-    let sha = get_commit_sha(&env, "refs/gitbutler/pickable-first");
-    env.but(format!("pick {sha} applied-branch"))
-        .assert()
-        .success();
+    env.but("unapply B").assert().success();
 
-    assert!(branch_has_commit_message(
-        &env,
-        "applied-branch",
-        "first pickable commit"
-    ));
-}
-
-#[test]
-fn pick_by_short_sha() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("pick-from-unapplied");
-    env.setup_metadata(&["applied-branch"]);
-
-    let short_sha = &get_commit_sha(&env, "refs/gitbutler/pickable-first")[..7];
-    env.but(format!("pick {short_sha} applied-branch"))
-        .assert()
-        .success();
-
-    assert!(branch_has_commit_message(
-        &env,
-        "applied-branch",
-        "first pickable commit"
-    ));
-}
-
-#[test]
-fn pick_by_branch_name() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("pick-from-unapplied");
-    env.setup_metadata(&["applied-branch"]);
-
-    // When picking by branch name in non-interactive mode, picks the head commit
-    env.but("pick unapplied-branch applied-branch")
-        .assert()
-        .success();
-
-    assert!(branch_has_commit_message(
-        &env,
-        "applied-branch",
-        "second pickable commit"
-    ));
-}
-
-#[test]
-fn pick_auto_selects_single_stack() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("pick-from-unapplied");
-    env.setup_metadata(&["applied-branch"]);
-
-    let sha = get_commit_sha(&env, "refs/gitbutler/pickable-first");
-
-    // No target specified - should auto-select the only stack
-    let result = env.but(format!("pick {sha}")).assert().success();
-    let stdout = String::from_utf8_lossy(&result.get_output().stdout);
-
-    assert!(stdout.contains("into branch applied-branch"));
-}
-
-#[test]
-fn pick_target_is_case_insensitive() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("pick-from-unapplied");
-    env.setup_metadata(&["applied-branch"]);
-
-    let sha = get_commit_sha(&env, "refs/gitbutler/pickable-first");
-    env.but(format!("pick {sha} APPLIED-BRANCH"))
-        .assert()
-        .success();
-}
-
-#[test]
-fn pick_json_output() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("pick-from-unapplied");
-    let stack_ids = env.setup_metadata(&["applied-branch"]);
-
-    let sha = get_commit_sha(&env, "refs/gitbutler/pickable-first");
-    let result = env
-        .but(format!("--json pick {sha} applied-branch"))
+    env.but("--json pick d3e2ba3")
         .allow_json()
-        .output()
-        .unwrap();
-
-    assert!(result.status.success());
-    let stdout = String::from_utf8_lossy(&result.stdout);
-    let json: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
-
-    assert_eq!(json["picked_commit"], sha);
-    assert_eq!(json["target_branch"], "applied-branch");
-    assert_eq!(json["target_stack_id"], stack_ids[0].to_string());
-}
-
-// === Error cases ===
-
-#[test]
-fn pick_without_applied_stacks_points_to_public_apply_command() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
-    env.setup_metadata(&[]);
-
-    env.but("pick unapplied-branch")
         .assert()
-        .failure()
-        .stderr_eq(str![[r#"
-Failed to pick commit. No applied stacks in workspace. Apply a branch first with 'but apply <branch-name>'.
+        .success()
+        .stdout_eq(str![[r#"
+{
+  "commits": [
+    {
+      "sourceCommitId": "d3e2ba36c529fbdce8de90593e22aceae21f9b17",
+      "newCommitId": "b40d58bcb23bf959c85cef47249d7d263a2e9b0c",
+      "newChangeId": "1"
+    }
+  ]
+}
 
 "#]]);
 }
 
 #[test]
-fn pick_invalid_source_fails() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("pick-from-unapplied");
-    env.setup_metadata(&["applied-branch"]);
+fn pick_rejects_non_commit_object() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
+    let tree = env.invoke_git("rev-parse 9477ae7^{tree}");
 
-    env.but("pick nonexistent-thing applied-branch")
+    env.but(format!("pick {tree} --branch new-branch"))
         .assert()
         .failure()
         .stderr_eq(str![[r#"
-Failed to pick commit. Source 'nonexistent-thing' is not a valid commit ID, CLI ID, or unapplied branch name.
-Run 'but status' to see available CLI IDs, or 'but branch list' to see branches.
+Error: '[..]' is not a commit
 
 "#]]);
 }
 
 #[test]
-fn pick_invalid_target_fails() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("pick-from-unapplied");
-    env.setup_metadata(&["applied-branch"]);
+fn pick_duplicate_sources_outputs_each_commit_once() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
 
-    let sha = get_commit_sha(&env, "refs/gitbutler/pickable-first");
-    env.but(format!("pick {sha} nonexistent-branch"))
+    env.but("--json pick 9477ae7 9477ae7 d3e2ba3 --branch new-branch")
+        .allow_json()
         .assert()
-        .failure()
-        .stderr_eq(str![[r#"
-Failed to pick commit. Target branch 'nonexistent-branch' not found among applied stacks.
-Available stacks: applied-branch
+        .success()
+        .stdout_eq(str![[r#"
+{
+  "commits": [
+    {
+      "sourceCommitId": "9477ae721ab521d9d0174f70e804ce3ff9f6fb56",
+      "newCommitId": "f033235315bbeb928633d5cad1926d91bf2b9dfb",
+      "newChangeId": "1"
+    },
+    {
+      "sourceCommitId": "d3e2ba36c529fbdce8de90593e22aceae21f9b17",
+      "newCommitId": "10d0f0680d5ef69031deb2e94ba05e934d59b7c0",
+      "newChangeId": "1"
+    }
+  ],
+  "branch": "new-branch"
+}
+
+"#]]);
+}
+
+#[test]
+fn pick_commit_to_new_branch_outputs_json() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A", "B"]);
+
+    env.but("unapply A").assert().success();
+
+    env.but("--json pick 9477ae7 --branch new-branch")
+        .allow_json()
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+{
+  "commits": [
+    {
+      "sourceCommitId": "9477ae721ab521d9d0174f70e804ce3ff9f6fb56",
+      "newCommitId": "f033235315bbeb928633d5cad1926d91bf2b9dfb",
+      "newChangeId": "1"
+    }
+  ],
+  "branch": "new-branch"
+}
+
+"#]]);
+}
+
+#[test]
+fn pick_commit_to_default_branch() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
+
+    env.but("unapply B").assert().success();
+
+    env.but("pick d3e2ba3")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Picked d3e2ba3 onto branch 'A' to create 1
+
+"#]]);
+
+    env.but("status -v").assert().success().stdout_eq(str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ g0 [A]
+┊● 1 author 2000-01-01 00:00:00 +0000 (sha b40d58b)
+┊│     add B 
+┊● tpm author 2000-01-01 00:00:00 +0000 (sha 9477ae7)
+┊│     add A 
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn pick_commit_to_new_branch() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A", "B"]);
+
+    env.but("unapply A").assert().success();
+
+    env.but("pick 9477ae7 -b new-branch")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Picked 9477ae7 onto new branch 'new-branch' to create 1
+
+"#]]);
+
+    env.but("status -v").assert().success().stdout_eq(str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ ne [new-branch]
+┊● 1 author 2000-01-01 00:00:00 +0000 (sha f033235)
+┊│     add A 
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn pick_commit_above_commit() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
+
+    env.but("unapply B").assert().success();
+
+    env.but("pick d3e2ba3 --above 9477ae7")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Picked d3e2ba3 to create 1
+
+"#]]);
+
+    env.but("status -v").assert().success().stdout_eq(str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ g0 [A]
+┊● 1 author 2000-01-01 00:00:00 +0000 (sha b40d58b)
+┊│     add B 
+┊● tpm author 2000-01-01 00:00:00 +0000 (sha 9477ae7)
+┊│     add A 
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn pick_commit_below_commit() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
+
+    env.but("unapply B").assert().success();
+
+    env.but("pick d3e2ba3 --below 9477ae7")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Picked d3e2ba3 to create 1
+
+"#]]);
+
+    env.but("status -v").assert().success().stdout_eq(str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ g0 [A]
+┊● tpm author 2000-01-01 00:00:00 +0000 (sha c341b3d)
+┊│     add A 
+┊● 1 author 2000-01-01 00:00:00 +0000 (sha 2174f2b)
+┊│     add B 
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn pick_commit_above_branch() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
+
+    env.but("unapply B").assert().success();
+
+    env.but("pick d3e2ba3 --above A")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Picked d3e2ba3 onto new branch 'a-branch-1' to create 1
+
+"#]]);
+
+    env.but("status -v").assert().success().stdout_eq(str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ br [a-branch-1]
+┊● 1 author 2000-01-01 00:00:00 +0000 (sha b40d58b)
+┊│     add B 
+┊│
+┊├┄ g0 [A]
+┊● tpm author 2000-01-01 00:00:00 +0000 (sha 9477ae7)
+┊│     add A 
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn pick_commit_below_branch() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
+
+    env.but("unapply B").assert().success();
+
+    env.but("pick d3e2ba3 --below A")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Picked d3e2ba3 onto new branch 'a-branch-1' to create 1
+
+"#]]);
+
+    env.but("status -v").assert().success().stdout_eq(str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ g0 [A]
+┊● tpm author 2000-01-01 00:00:00 +0000 (sha c341b3d)
+┊│     add A 
+┊│
+┊├┄ br [a-branch-1]
+┊● 1 author 2000-01-01 00:00:00 +0000 (sha 2174f2b)
+┊│     add B 
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
 
 "#]]);
 }


### PR DESCRIPTION
This re-implements `but pick` using the new command structure and arguments similar to `but commit`:

```sh
# infer which branch to pick to (create new, choose single, or prompt)
but pick <commit>

# pick commit to existing branch (or create my-branch)
but pick <commit> -b my-branch

# pick commit to a new branch above/below my-branch
but pick <commit> --above/--below my-branch

# pick commit above another commit
but pick <commit> --above/--below <other commit>
```