### PR TITLE
Keep the details preview when toggling the outline

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.tsx
@@ -31,7 +31,7 @@ import {
 import { branchOperand, commitOperand, operandIdentityKey, type Operand } from "#ui/operands.ts";
 import { projectSlice } from "#ui/projects/state.ts";
 import {
-	autofocusSelectionScope,
+	useAutofocusSelectionScope,
 	useNavigationIndexHotkeys,
 	type SelectionScope,
 } from "#ui/selection-scopes.ts";
@@ -534,9 +534,7 @@ export const BranchesList: FC<
 					onFocus={() =>
 						dispatch(projectSlice.actions.setDetailsSelectionScope({ projectId, scope: "outline" }))
 					}
-					ref={useMergedRefs(hotkeysRef, (el) => {
-						if (el) autofocusSelectionScope(el);
-					})}
+					ref={useMergedRefs(hotkeysRef, useAutofocusSelectionScope())}
 				>
 					{stacks.map((stack) => (
 						<StackCard

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -87,8 +87,8 @@ import styles from "./Details.module.css";
 import { diffHotkeys, pullRequestHotkeys, workspaceHotkeys } from "#ui/hotkeys.ts";
 import { useHotkey, useHotkeys } from "@tanstack/react-hotkeys";
 import {
-	autofocusSelectionScope,
 	type SelectionScope,
+	useAutofocusSelectionScope,
 	useNavigationIndexHotkeys,
 } from "#ui/selection-scopes.ts";
 import { ChangeStats } from "#ui/routes/project/$id/workspace/ChangeStats.tsx";
@@ -1117,9 +1117,7 @@ const Diff: FC<{
 						// oxlint-disable-next-line jsx_a11y/no-noninteractive-tabindex -- Revisit this when we add hunk/line selection.
 						tabIndex={0}
 						className={styles.diffContentsContainer}
-						ref={useMergedRefs(selectionScopeRef, diffContentsEl, (el) => {
-							if (el) autofocusSelectionScope(el);
-						})}
+						ref={useMergedRefs(selectionScopeRef, diffContentsEl, useAutofocusSelectionScope())}
 					>
 						<DiffContents
 							localAnnotationFormId={localAnnotationFormId}
@@ -1254,9 +1252,7 @@ const PullRequestForm: FC<{
 					render={<FieldControlStyles />}
 					className="text-15 text-semibold"
 					data-selection-scope={"pr" satisfies SelectionScope}
-					ref={(el) => {
-						if (el) autofocusSelectionScope(el);
-					}}
+					ref={useAutofocusSelectionScope()}
 					name="title"
 					onChange={(evt) => setLocalDocument({ ...localDocument, title: evt.currentTarget.value })}
 					placeholder="Title"

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
@@ -72,7 +72,7 @@ import {
 } from "#ui/segment.ts";
 import { checkedRange, navigationIndexRange } from "#ui/checking.ts";
 import { TooltipPopup } from "#ui/components/Tooltip.tsx";
-import { autofocusSelectionScope, type SelectionScope } from "#ui/selection-scopes.ts";
+import { useAutofocusSelectionScope, type SelectionScope } from "#ui/selection-scopes.ts";
 import { FilesTree } from "#ui/routes/project/$id/workspace/FilesTree.tsx";
 import {
 	CommitForm,
@@ -286,9 +286,7 @@ const UncommittedChanges: FC<{
 					navigationIndex={navigationIndex}
 					onFileSelection={onActiveFileSelection}
 					projectId={projectId}
-					ref={(el) => {
-						if (el) autofocusSelectionScope(el);
-					}}
+					ref={useAutofocusSelectionScope()}
 					selection={fileSelection}
 				/>
 			</Scroller>

--- a/apps/lite/ui/src/routes/project/$id/workspace/TopLeftControls.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/TopLeftControls.tsx
@@ -2,15 +2,32 @@ import { getButtonClassName } from "#ui/components/Button.tsx";
 import { Icon } from "#ui/components/Icon.tsx";
 import { TooltipPopup } from "#ui/components/Tooltip.tsx";
 import { interfaceSlice } from "#ui/interface/state.ts";
+import { projectSlice } from "#ui/projects/state.ts";
+import { focusSelectionScope } from "#ui/selection-scopes.ts";
 import { useAppDispatch, useAppSelector } from "#ui/store.ts";
 import { workspaceHotkeys } from "#ui/hotkeys.ts";
 import { Tooltip } from "@base-ui/react";
+import { useParams } from "@tanstack/react-router";
 import { useEffect, useState, type FC } from "react";
 import styles from "./TopLeftControls.module.css";
 
 const FullWindowButton: FC = () => {
 	const dispatch = useAppDispatch();
+	const { id: projectId } = useParams({ from: "/project/$id/workspace" });
 	const fullWindow = useAppSelector(interfaceSlice.selectors.selectDetailsFullWindow);
+	const detailsSelectionScope = useAppSelector((state) =>
+		projectSlice.selectors.selectDetailsSelectionScope(state, projectId),
+	);
+
+	const toggle = () => {
+		dispatch(interfaceSlice.actions.setDetailsFullWindow({ fullWindow: !fullWindow }));
+
+		// Toggling swaps this button for the copy in the other pane, so the click leaves focus on
+		// the body. Hand it to the pane the outline is folding out of, or back into.
+		requestAnimationFrame(() =>
+			focusSelectionScope(fullWindow ? (detailsSelectionScope ?? "outline") : "diff"),
+		);
+	};
 
 	return (
 		<Tooltip.Root>
@@ -20,9 +37,7 @@ const FullWindowButton: FC = () => {
 						type="button"
 						className={getButtonClassName({ iconOnly: true, variant: "ghost" })}
 						aria-label={workspaceHotkeys.toggleOutline.meta.name}
-						onClick={() =>
-							dispatch(interfaceSlice.actions.setDetailsFullWindow({ fullWindow: !fullWindow }))
-						}
+						onClick={toggle}
 					>
 						{fullWindow ? <Icon name="sidebar-narrow" /> : <Icon name="sidebar" />}
 					</button>

--- a/apps/lite/ui/src/routes/project/$id/workspace/TopLeftControls.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/TopLeftControls.tsx
@@ -4,7 +4,7 @@ import { TooltipPopup } from "#ui/components/Tooltip.tsx";
 import { interfaceSlice } from "#ui/interface/state.ts";
 import { projectSlice } from "#ui/projects/state.ts";
 import { focusSelectionScope } from "#ui/selection-scopes.ts";
-import { useAppDispatch, useAppSelector } from "#ui/store.ts";
+import { useAppDispatch, useAppSelector, useAppStore } from "#ui/store.ts";
 import { workspaceHotkeys } from "#ui/hotkeys.ts";
 import { Tooltip } from "@base-ui/react";
 import { useParams } from "@tanstack/react-router";
@@ -13,17 +13,19 @@ import styles from "./TopLeftControls.module.css";
 
 const FullWindowButton: FC = () => {
 	const dispatch = useAppDispatch();
+	const store = useAppStore();
 	const { id: projectId } = useParams({ from: "/project/$id/workspace" });
 	const fullWindow = useAppSelector(interfaceSlice.selectors.selectDetailsFullWindow);
-	const detailsSelectionScope = useAppSelector((state) =>
-		projectSlice.selectors.selectDetailsSelectionScope(state, projectId),
-	);
 
 	const toggle = () => {
 		dispatch(interfaceSlice.actions.setDetailsFullWindow({ fullWindow: !fullWindow }));
 
 		// Toggling swaps this button for the copy in the other pane, so the click leaves focus on
 		// the body. Hand it to the pane the outline is folding out of, or back into.
+		const detailsSelectionScope = projectSlice.selectors.selectDetailsSelectionScope(
+			store.getState(),
+			projectId,
+		);
 		requestAnimationFrame(() =>
 			focusSelectionScope(fullWindow ? (detailsSelectionScope ?? "outline") : "diff"),
 		);

--- a/apps/lite/ui/src/routes/project/$id/workspace/UpstreamList.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/UpstreamList.tsx
@@ -11,7 +11,7 @@ import { branchOperand, commitOperand, operandIdentityKey, type Operand } from "
 import { prForgeUrl } from "#ui/pr.ts";
 import { projectSlice } from "#ui/projects/state.ts";
 import {
-	autofocusSelectionScope,
+	useAutofocusSelectionScope,
 	useNavigationIndexHotkeys,
 	type SelectionScope,
 } from "#ui/selection-scopes.ts";
@@ -410,9 +410,7 @@ export const UpstreamList: FC<
 					onFocus={() =>
 						dispatch(projectSlice.actions.setDetailsSelectionScope({ projectId, scope: "outline" }))
 					}
-					ref={useMergedRefs(hotkeysRef, (el) => {
-						if (el) autofocusSelectionScope(el);
-					})}
+					ref={useMergedRefs(hotkeysRef, useAutofocusSelectionScope())}
 				>
 					{groupItems(items).map((group) =>
 						group.branches !== undefined ? (

--- a/apps/lite/ui/src/selection-scopes.ts
+++ b/apps/lite/ui/src/selection-scopes.ts
@@ -5,6 +5,7 @@ import { projectSlice } from "#ui/projects/state.ts";
 import { useAppDispatch } from "#ui/store.ts";
 import { getAdjacent, type NavigationIndex } from "#ui/workspace/navigation-index.ts";
 import { useHotkeySequences, useHotkeys } from "@tanstack/react-hotkeys";
+import { useRef } from "react";
 
 export type SelectionScope = "details" | "uncommitted-files" | "outline" | "files" | "diff" | "pr";
 const allSelectionScopes: Set<string> = new Set([
@@ -98,11 +99,25 @@ export const focusVerticalSelectionScope = (offset: -1 | 1) => {
 	if (nextSelectionScope !== undefined) focusSelectionScope(nextSelectionScope);
 };
 
-export const autofocusSelectionScope = (el: HTMLElement) => {
-	// Don't steal focus if this component is mounted later on.
-	if (document.activeElement !== document.body) return;
+/**
+ * Returns a ref callback that focuses the scope when its element first attaches.
+ *
+ * Only the first attachment gets a chance to autofocus: `Activity` detaches and re-attaches refs
+ * as it hides and reveals a subtree, and focusing on a reveal would switch the details pane away
+ * from whatever the user had selected before hiding it.
+ */
+export const useAutofocusSelectionScope = () => {
+	const attached = useRef(false);
 
-	el.focus({ focusVisible: false });
+	return (el: HTMLElement | null) => {
+		if (el === null || attached.current) return;
+		attached.current = true;
+
+		// Don't steal focus if this component is mounted later on.
+		if (document.activeElement !== document.body) return;
+
+		el.focus({ focusVisible: false });
+	};
 };
 
 export const useNavigationIndexHotkeys = <T>({


### PR DESCRIPTION
## Problem

Select a branch or a commit in the outline, hide the left sidebar, then show it again — the details pane silently switches to Uncommitted changes.


https://github.com/user-attachments/assets/c79d6e4d-7733-4b45-baba-4d4737d29541



## Cause

The details pane renders whatever the *details selection scope* points at, and that scope is set by focus: the uncommitted files tree dispatches `setDetailsSelectionScope({ scope: "uncommitted-files" })` from its `onFocus`.

The outline panel is wrapped in `<Activity mode={detailsFullWindow ? "hidden" : "visible"}>`, and `Activity` detaches refs when it hides a subtree and re-attaches them on reveal. So the files tree's mount-time autofocus ref callback ran again on every reveal. Its only guard was "don't steal focus unless `document.activeElement` is `<body>`" — and clicking the toggle button leaves focus exactly there, because the button lives in the pane that just unmounted (there is one copy in the outline header and one in the details header).

The keyboard shortcut never showed this: that path parks focus on the diff, so the guard held.

## Fix

- `autofocusSelectionScope` becomes `useAutofocusSelectionScope()`, a ref callback that only gets one shot, at the element's first attach. Real remounts still autofocus (new instance, re-armed); `Activity` reveals no longer do. Applied at all four call sites.
- That alone strands focus on `<body>` after a toggle, leaving keyboard nav dead until the next click, so the toggle button now hands focus to the diff when it folds the outline away and back to the current outline scope when it folds it out — matching what the hotkey path already did.

## Testing

Driven against the dev app over CDP:

| step | sidebar | focus | preview |
|---|---|---|---|
| commit selected | shown | outline | large commit |
| sidebar hidden | hidden | diff | large commit |
| sidebar shown again | shown | outline | large commit |

Same for an uncommitted-file selection (focus returns to `uncommitted-files`, preview holds), and a fresh page load still autofocuses the uncommitted files tree as before. `pnpm -F @gitbutler/lite check`, oxlint, oxfmt, prettier and knip are clean.