### PR TITLE
Prefer the index when it and the worktree disagree about a removed file

### DIFF
--- a/crates/but-core/src/diff/worktree.rs
+++ b/crates/but-core/src/diff/worktree.rs
@@ -638,18 +638,17 @@ fn merge_changes(
             return Ok(single(index_wt));
         }
         (
-            TreeStatus::Deletion { previous_state, .. },
+            TreeStatus::Deletion { .. },
             TreeStatus::Addition {
-                is_untracked: true,
-                state,
+                is_untracked: true, ..
             },
         ) => {
-            index_wt.status = TreeStatus::Modification {
-                previous_state: *previous_state,
-                state: *state,
-                flags: None,
-            };
-            index_wt
+            // The index says the path isn't tracked anymore, so what remains on disk is
+            // an untracked file rather than a modification of the one that was removed.
+            // Merging the two into a modification instead makes them cancel out whenever
+            // the file still matches `HEAD`, which is what makes `git rm --cached` look
+            // like it did nothing and silently re-tracks the file on the next commit.
+            return Ok(single(tree_index));
         }
         (
             TreeStatus::Modification { previous_state, .. },

--- a/crates/but-core/tests/core/diff/ui.rs
+++ b/crates/but-core/tests/core/diff/ui.rs
@@ -285,17 +285,12 @@ fn worktree_changes() -> anyhow::Result<()> {
         101
       ],
       "status": {
-        "type": "Modification",
+        "type": "Deletion",
         "subject": {
           "previousState": {
             "id": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
             "kind": "Blob"
-          },
-          "state": {
-            "id": "0000000000000000000000000000000000000000",
-            "kind": "Blob"
-          },
-          "flags": null
+          }
         }
       }
     },
@@ -703,17 +698,9 @@ fn worktree_changes_unified_diffs_json_example() -> anyhow::Result<()> {
   {
     "type": "Patch",
     "subject": {
-      "hunks": [
-        {
-          "oldStart": 1,
-          "oldLines": 0,
-          "newStart": 1,
-          "newLines": 1,
-          "diff": "@@ -1,0 +1,1 @@\n+worktree-change\n"
-        }
-      ],
+      "hunks": [],
       "isResultOfBinaryToTextConversion": false,
-      "linesAdded": 1,
+      "linesAdded": 0,
       "linesRemoved": 0
     }
   },

--- a/crates/but-core/tests/core/diff/worktree_changes.rs
+++ b/crates/but-core/tests/core/diff/worktree_changes.rs
@@ -1738,16 +1738,11 @@ WorktreeChanges {
     changes: [
         TreeChange {
             path: "file",
-            status: Modification {
+            status: Deletion {
                 previous_state: ChangeState {
                     id: Sha1(e79c5e8f964493290a409888d5413a737e8e5dd5),
                     kind: Blob,
                 },
-                state: ChangeState {
-                    id: Sha1(0000000000000000000000000000000000000000),
-                    kind: Blob,
-                },
-                flags: None,
             },
         },
     ],
@@ -1768,9 +1763,8 @@ WorktreeChanges {
     snapbox::assert_data_eq!(
         hunks[0].diff.to_string(),
         snapbox::str![[r#"
-@@ -1,1 +1,2 @@
- initial
-+wt-changed
+@@ -1,1 +1,0 @@
+-initial
 
 "#]]
     );
@@ -1780,11 +1774,21 @@ WorktreeChanges {
         diff::worktree_changes(&repo)?.to_debug(),
         snapbox::str![[r#"
 WorktreeChanges {
-    changes: [],
+    changes: [
+        TreeChange {
+            path: "file",
+            status: Deletion {
+                previous_state: ChangeState {
+                    id: Sha1(e79c5e8f964493290a409888d5413a737e8e5dd5),
+                    kind: Blob,
+                },
+            },
+        },
+    ],
     ignored_changes: [
         IgnoredWorktreeChange {
             path: "file",
-            status: TreeIndexWorktreeChangeIneffective,
+            status: TreeIndex,
         },
     ],
 }

--- a/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/mod.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/mod.rs
@@ -175,6 +175,15 @@ impl TestRepo {
             },
         )
         .unwrap();
+        // A real `git commit` leaves `.git/index` matching the new commit. Without
+        // this the index keeps looking like the paths were never tracked, which shows
+        // up as staged deletions the moment the index isn't ignored.
+        let mut index = repo
+            .index_from_tree(&gix::prelude::ObjectIdExt::attach(tree_id, &repo))
+            .expect("index can be built from the committed tree");
+        index
+            .write(Default::default())
+            .expect("index can be written");
         update_current_head(&repo, commit_id, "commit");
         commit_id
     }


### PR DESCRIPTION
Draft, for the discussion in #10722. @Byron — pinging you as asked.

Fixes #10722

### Problem

`git rm --cached <file>` leaves the path deleted in the index but still on disk. `merge_changes` combines the tree→index deletion with the index→worktree untracked addition into a `Modification`, which then reaches the no-op check at the end of the function (`current == previous` → `[None, None]`). Since `git rm --cached` doesn't touch the file, the two hashes match, the change is dropped as `TreeIndexWorktreeChangeIneffective`, and committing re-tracks the file.

### Change

That arm now prefers the index and returns its deletion, rather than merging the two sides into a modification that can cancel itself out.

The clearest evidence is an existing fixture: `modified-in-index-and-worktree-del-add-noop` is exactly the reported shape — path removed from the index, content on disk still matching `HEAD` — and its expectation moves from

```
changes: [],
ignored_changes: [ file → TreeIndexWorktreeChangeIneffective ]
```

to

```
changes: [ file → Deletion ],
ignored_changes: [ file → TreeIndex ]
```

### Adjusted expectations

Per your suggestion, four snapshots move:

- `diff::worktree_changes::modified_in_index_and_worktree_del_add` — `Modification` (whose `state` was the null hash) becomes `Deletion`, and its unified diff becomes a removal
- the `-noop` case above
- `diff::ui::worktree_changes` and `diff::ui::worktree_changes_unified_diffs_json_example` — the same change at the UI layer. The empty `hunks: []` there is expected: that file's `previousState` is the empty blob, so deleting it has no lines to show.

### The test-harness change

Five tests in `gitbutler-branch-actions` (`set_base_branch::go_back_to_workspace::*`) failed at first, and the cause turned out not to be this change directly.

`set_base_branch` reads `worktree_changes` (`base.rs:225`) and auto-creates a stack when the result isn't empty (`:226-262`). The test helper `commit_all` commits a tree built with `create_wd_tree` and never writes `.git/index`, so afterwards the index looks as though those paths were never tracked — the same shape as this bug, manufactured by the harness. Once the index is no longer ignored, that residue surfaces and a stack gets created.

Making `commit_all` leave `.git/index` matching the commit, as a real `git commit` does, turns all five green without touching product code. Baseline for the record: the five pass on master, fail with only the `but-core` change, and pass again with the harness fix.

Worth noting separately: `safe_checkout_from_head`'s docs say `.git/index` is updated, but the default path doesn't write it (`but-core/src/worktree/checkout/function.rs:15` vs the body). That may be worth a look on its own.

### Two things I'd like your call on

1. **Should the untracked side still be reported?** This returns only the index's deletion, so a file with different content on disk becomes invisible. `git status` shows both a staged deletion and an untracked file, and `merge_changes` already has a two-entry return shape that could express that. Preferring the index alone is the smaller change, but it does move away from "changes produce a tree equal to the current worktree".

2. **The reported case involves an ignored file.** The report is about a `__pycache__/*.pyc`, and ignored files aren't emitted by the dirwalk (`set_emit_ignored(None)`), so none of the snapshots here cover that variant. I didn't want to imply this is proven end-to-end for the exact scenario reported.

Also: the inverse you described — added to the index, removed from disk — is one arm along and costs one further test expectation on top of this. Left out to keep this focused; happy to fold it in.

### Verification

`cargo test --workspace` (excluding `gitbutler-tauri` and `but-api-macros-tests`, as CI does) is green at 3608 passing, along with `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --check --all`.
