### PR TITLE
Pass the branch a commit will land on into the AI prompt

### DIFF
--- a/apps/desktop/src/components/commit/CommitMessageEditor.svelte
+++ b/apps/desktop/src/components/commit/CommitMessageEditor.svelte
@@ -32,6 +32,8 @@
 		disabledAction?: boolean;
 		loading?: boolean;
 		existingCommitId?: string;
+		/** The branch this commit will land on, used for `%{branch_name}` in AI prompts. */
+		branchName?: string;
 		title: string;
 		floatingBoxHeader?: string;
 		description: string;
@@ -51,6 +53,7 @@
 		description,
 		floatingBoxHeader = "Create commit",
 		existingCommitId,
+		branchName,
 	}: Props = $props();
 
 	const uiState = inject(UI_STATE);
@@ -63,9 +66,6 @@
 	const diffService = inject(DIFF_SERVICE);
 	const uncommittedService = inject(UNCOMMITTED_SERVICE);
 	const stackService = inject(STACK_SERVICE);
-
-	const laneState = $derived(stackId ? uiState.lane(stackId) : undefined);
-	const stackSelection = $derived(laneState?.selection);
 
 	let composer = $state<ReturnType<typeof MessageEditor>>();
 	let titleInput = $state<HTMLTextAreaElement>();
@@ -120,7 +120,7 @@
 			let firstToken = true;
 
 			const output = await aiMacros.generateCommitMessage({
-				branchName: stackSelection?.current?.branchName,
+				branchName,
 				onToken: (t) => {
 					if (firstToken) {
 						beginGeneration();

--- a/apps/desktop/src/components/commit/CommitView.svelte
+++ b/apps/desktop/src/components/commit/CommitView.svelte
@@ -232,6 +232,7 @@
 					{stackId}
 					action={({ title, description }) => saveCommitMessage(title, description)}
 					actionLabel="Save changes"
+					{branchName}
 					onCancel={cancelEdit}
 					floatingBoxHeader="Reword commit"
 					loading={messageUpdateQuery.current.isLoading}

--- a/apps/desktop/src/components/commit/NewCommitView.svelte
+++ b/apps/desktop/src/components/commit/NewCommitView.svelte
@@ -44,6 +44,9 @@
 	const topBranchName = $derived(topBranchQuery?.response?.at(0)?.refName?.displayName);
 
 	const draftBranchName = $derived(uiState.global.draftBranchName.current);
+	// Same resolution `createCommit` uses below, so `%{branch_name}` in an AI prompt
+	// names the branch the commit will actually land on.
+	const promptBranchName = $derived(commitAction?.branchName || draftBranchName || topBranchName);
 	const canCommit = $derived(selectedLines.current.length > 0);
 
 	let input = $state<ReturnType<typeof CommitMessageEditor>>();
@@ -225,6 +228,7 @@
 		{projectId}
 		{stackId}
 		actionLabel="Create commit"
+		branchName={promptBranchName}
 		action={({ title, description }) => handleCommitCreation(title, description)}
 		onChange={({ title, description }) => handleMessageUpdate(title, description)}
 		onCancel={cancel}

--- a/apps/desktop/src/lib/ai/service.test.ts
+++ b/apps/desktop/src/lib/ai/service.test.ts
@@ -17,6 +17,7 @@ import {
 import {
 	AnthropicModelName,
 	ModelKind,
+	MessageRole,
 	OpenAIModelName,
 	type AIClient,
 	type Prompt,
@@ -390,6 +391,30 @@ describe("AIService", () => {
 			expect(
 				await aiService.summarizeCommit({ diffInput: exampleDiffs, useExtraConciseStyle: true }),
 			).toStrictEqual("one");
+		});
+
+		test("It substitutes %{branch_name} into a custom prompt", async () => {
+			const { aiService } = buildDefaultServices();
+
+			let capturedPrompt: Prompt | undefined;
+			const capturingClient: AIClient = {
+				defaultCommitTemplate: SHORT_DEFAULT_COMMIT_TEMPLATE,
+				defaultBranchTemplate: SHORT_DEFAULT_BRANCH_TEMPLATE,
+				defaultPRTemplate: SHORT_DEFAULT_PR_TEMPLATE,
+				async evaluate(prompt: Prompt): Promise<string> {
+					capturedPrompt = prompt;
+					return "a message";
+				},
+			};
+			vi.spyOn(aiService, "buildClient").mockReturnValue(Promise.resolve(capturingClient));
+
+			await aiService.summarizeCommit({
+				diffInput: exampleDiffs,
+				commitTemplate: [{ role: MessageRole.User, content: "on branch %{branch_name}" }],
+				branchName: "my-branch",
+			});
+
+			expect(capturedPrompt?.[0]?.content).toBe("on branch my-branch");
 		});
 	});
 


### PR DESCRIPTION
Fixes #9977

### Problem

`%{branch_name}` in a custom AI commit prompt is left as the literal placeholder.

The substitution itself is fine — `summarizeCommit` does `content.replaceAll("%{branch_name}", branchName)` ([the block you linked](https://github.com/gitbutlerapp/gitbutler/blob/f50b5a3fc407d831efeaa68eb07b36a4cc3d7fff/apps/desktop/src/lib/ai/service.ts#L374-L376)) — but it's guarded by `if (branchName)`, so when no name is supplied the placeholder is silently left alone rather than failing.

The name arrives `undefined`. `CommitMessageEditor` read it from `laneState.selection.current.branchName`, and the lane selection is `undefined` by default and never set in the plain commit flow (it's also cleared in a number of paths). So the editor had no name to substitute.

Only custom prompts are affected: `%{branch_name}` doesn't appear in any default template.

### Change

Rather than have the editor re-derive the branch, it now takes `branchName` as a prop, and each parent passes what it already resolves for the commit itself:

- **`NewCommitView`** — `commitAction?.branchName || draftBranchName || topBranchName`, the same expression `createCommit()` uses a few lines below
- **`CommitView`** — the `branchName` it already uses to save a reword

That matters for two cases a lookup inside the editor would get wrong: "Commit goes here" on a lower branch sets `commitAction.branchName` while the selection stays empty, and committing to a new stack has no `stackId` to look anything up from but does have `draftBranchName`. Reusing each parent's own resolution means the prompt can't name a different branch than the one the commit lands on.

Two now-unused derivations in the editor go away with it.

### Test

The added test injects a capturing client and asserts the prompt actually sent has `%{branch_name}` replaced when a name is supplied.

To be clear about what it does *not* do: it doesn't touch `service.ts`, passes identically without this change, and would not have caught this bug. It only guards the substitution arm. I added it because my first two guesses at the cause were that the `role !== MessageRole.User` skip dropped substitution in part of a custom prompt, and then that substitution was broken outright — both wrong, and the test is what ruled the second one out and pointed at the caller.

### Not verified in a running app

I haven't confirmed this end-to-end in the desktop app, so the unverified step is whether each parent's expression holds the expected branch at the moment Generate is pressed. Both are the expressions those components already use to create or save the commit, so I'd expect it to — but I'd rather say so than imply I checked.

A component-level test would mean mocking all eight of the editor's injected services, which seemed disproportionate to this change; happy to add one if you'd prefer.

### Verification

`pnpm lint` (prettier, eslint, oxlint, knip), `pnpm check` (svelte-check: 0 errors) and the desktop vitest suite are clean.
