### PR TITLE
Align workspace sidebar header with Figma design

### DIFF
--- a/apps/lite/ui/src/components/Button.module.css
+++ b/apps/lite/ui/src/components/Button.module.css
@@ -1,7 +1,13 @@
 .button {
 	display: inline-flex;
+
+	/* The size classes below only provide defaults for these, at zero
+	   specificity, so consumers can override them from their own class. */
+	column-gap: var(--button-gap);
 	align-items: center;
 	justify-content: center;
+	height: var(--button-height);
+	padding-inline: var(--button-padding-inline);
 	border: var(--button-border);
 	border-radius: var(--radius-button);
 	background-color: var(--button-bg);
@@ -47,27 +53,31 @@
 	}
 }
 
-.small {
-	column-gap: 4px;
-	height: 20px;
-	padding-inline: 6px;
+:where(.iconOnly) {
+	width: var(--button-width);
+}
+
+:where(.small) {
+	--button-gap: 4px;
+	--button-height: 20px;
+	--button-padding-inline: 6px;
 	--icon-size: 14px;
 
 	&:where(.iconOnly) {
-		width: 22px;
-		padding-inline: 3px;
+		--button-width: 22px;
+		--button-padding-inline: 3px;
 	}
 }
 
-.regular {
-	column-gap: 6px;
-	height: 28px;
-	padding-inline: 8px;
+:where(.regular) {
+	--button-gap: 6px;
+	--button-height: 28px;
+	--button-padding-inline: 8px;
 	--icon-size: 16px;
 
 	&:where(.iconOnly) {
-		width: 28px;
-		padding-inline: 8px;
+		--button-width: 28px;
+		--button-padding-inline: 8px;
 	}
 }
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.module.css
@@ -10,7 +10,7 @@
 	column-gap: 8px;
 	align-items: center;
 	padding-inline: var(--panel-padding-inline);
-	padding-block: var(--panel-padding-block);
+	padding-block: 10px;
 	border-bottom: 1px solid var(--border-3);
 	background-color: var(--bg-1);
 }

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
@@ -11,7 +11,7 @@
 
 .headerWrap {
 	display: flex;
-	row-gap: 8px;
+	row-gap: 10px;
 	flex-direction: column;
 	padding-inline: var(--panel-padding-inline) 10px;
 	padding-block-start: var(--panel-padding-block);

--- a/apps/lite/ui/src/routes/project/$id/workspace/Outline.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Outline.module.css
@@ -37,7 +37,7 @@
 	display: flex;
 	align-items: center;
 	margin-inline-start: auto;
-	gap: 4px;
+	gap: 2px;
 }
 
 .workspaceName {

--- a/apps/lite/ui/src/routes/project/$id/workspace/Outline.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Outline.module.css
@@ -7,7 +7,7 @@
 .top {
 	container-type: inline-size;
 	display: flex;
-	row-gap: 12px;
+	row-gap: 10px;
 	flex-direction: column;
 	padding-inline: var(--panel-padding-inline);
 	padding-block: var(--panel-padding-block);
@@ -42,17 +42,15 @@
 
 .workspaceName {
 	display: flex;
-	column-gap: 4px;
+	column-gap: 6px;
 	align-items: center;
 	min-width: 0;
+}
 
-	.workspaceNameChevron {
-		color: var(--text-2);
-	}
-
-	&:hover .workspaceNameChevron {
-		color: var(--text-1);
-	}
+/* The folder mark is not square, so opt out of the button's icon sizing. */
+.workspaceNameFolder.workspaceNameFolder {
+	width: 17px;
+	height: 14px;
 }
 
 .workspaceNameLabel {

--- a/apps/lite/ui/src/routes/project/$id/workspace/Outline.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Outline.module.css
@@ -20,6 +20,13 @@
 	}
 }
 
+/* Too narrow for the project name, keep only the folder mark. */
+@container (max-width: 275px) {
+	.workspaceNameLabel {
+		display: none;
+	}
+}
+
 .workspaceControls {
 	display: flex;
 	column-gap: 12px;
@@ -41,8 +48,9 @@
 }
 
 .workspaceName {
+	--button-gap: 6px;
+	--button-padding-inline: 10px;
 	display: flex;
-	column-gap: 6px;
 	align-items: center;
 	min-width: 0;
 }

--- a/apps/lite/ui/src/routes/project/$id/workspace/Outline.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Outline.tsx
@@ -335,50 +335,6 @@ export const Outline: FC<{
 
 						<Tooltip.Root>
 							<Tooltip.Trigger
-								aria-label={workspaceHotkeys.updateWorkspace.meta.name}
-								className={getButtonClassName({ iconOnly: true })}
-								onClick={updateWorkspace}
-								// We pass `disabled` here because we want to disable the button, not
-								// the tooltip. Other props should be passed above.
-								render={<Button focusableWhenDisabled disabled={!canUpdateWorkspace} />}
-							>
-								<Icon name="arrow-line-down" />
-							</Tooltip.Trigger>
-							<Tooltip.Portal>
-								<Tooltip.Positioner sideOffset={4}>
-									<Tooltip.Popup
-										render={<TooltipPopup kbd={workspaceHotkeys.updateWorkspace.hotkey} />}
-									>
-										{workspaceHotkeys.updateWorkspace.meta.name}
-									</Tooltip.Popup>
-								</Tooltip.Positioner>
-							</Tooltip.Portal>
-						</Tooltip.Root>
-
-						<Tooltip.Root>
-							<Tooltip.Trigger
-								aria-label={workspaceHotkeys.applyBranch.meta.name}
-								className={getButtonClassName({ iconOnly: true })}
-								onClick={openApplyBranchPicker}
-								// We pass `disabled` here because we want to disable the button, not
-								// the tooltip. Other props should be passed above.
-								render={<Button focusableWhenDisabled disabled={!canApplyBranch} />}
-							>
-								<Icon name="branch" />
-							</Tooltip.Trigger>
-							<Tooltip.Portal>
-								<Tooltip.Positioner sideOffset={4}>
-									<Tooltip.Popup
-										render={<TooltipPopup kbd={workspaceHotkeys.applyBranch.hotkey} />}
-									>
-										{workspaceHotkeys.applyBranch.meta.name}
-									</Tooltip.Popup>
-								</Tooltip.Positioner>
-							</Tooltip.Portal>
-						</Tooltip.Root>
-
-						<Tooltip.Root>
-							<Tooltip.Trigger
 								aria-label={workspaceHotkeys.settings.meta.name}
 								className={getButtonClassName({ iconOnly: true })}
 								onClick={openSettings}

--- a/apps/lite/ui/src/routes/project/$id/workspace/Outline.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Outline.tsx
@@ -40,7 +40,10 @@ import { TopLeftControls } from "#ui/routes/project/$id/workspace/TopLeftControl
 import { RowToolbar } from "#ui/routes/project/$id/workspace/Row.tsx";
 import { getRowButtonClassName } from "#ui/routes/project/$id/workspace/Row-utils.ts";
 
-const ActivitySpinner: FC = () => {
+const ActivitySpinner: FC<{
+	/** Suppressed while the fetch button shows its own spinner, to avoid two spinners at once. */
+	suppressed: boolean;
+}> = (p) => {
 	const fetchingCount = useIsFetching();
 	const mutatingCount = useIsMutating();
 
@@ -54,7 +57,7 @@ const ActivitySpinner: FC = () => {
 		Match.orElse(() => null),
 	);
 
-	return status !== null && <Icon name="spinner" aria-label={status} />;
+	return !p.suppressed && status !== null && <Icon name="spinner" aria-label={status} />;
 };
 
 const FetchFromRemotesButton: FC<{
@@ -328,7 +331,7 @@ export const Outline: FC<{
 								</Tooltip.Positioner>
 							</Tooltip.Portal>
 						</Tooltip.Root>
-						<ActivitySpinner />
+						<ActivitySpinner suppressed={isWorkspaceFetchFromRemotesPending} />
 					</div>
 
 					<div className={styles.workspaceControlsActions}>

--- a/apps/lite/ui/src/routes/project/$id/workspace/Outline.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Outline.tsx
@@ -29,6 +29,7 @@ import { ToggleGroupStyles, ToggleStyles } from "#ui/components/ToggleGroup.tsx"
 import { OutlineTree } from "#ui/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx";
 import { BranchesList } from "#ui/routes/project/$id/workspace/BranchesList.tsx";
 import type { BranchesOutline } from "#ui/routes/project/$id/workspace/useBranchesOutline.ts";
+import { ProjectFolderIcon } from "#ui/routes/project/$id/workspace/ProjectFolderIcon.tsx";
 import { UpstreamList } from "#ui/routes/project/$id/workspace/UpstreamList.tsx";
 import type { UpstreamOutline } from "#ui/routes/project/$id/workspace/useUpstreamOutline.ts";
 import { assert } from "#ui/assert.ts";
@@ -308,11 +309,16 @@ export const Outline: FC<{
 						<Tooltip.Root>
 							<Tooltip.Trigger
 								aria-label={globalHotkeys.selectProject.meta.name}
-								className={classes("text-15", "text-bold", styles.workspaceName)}
+								className={classes(
+									getButtonClassName({ variant: "ghost" }),
+									"text-15",
+									"text-bold",
+									styles.workspaceName,
+								)}
 								onClick={openProjectPicker}
 							>
+								<ProjectFolderIcon className={styles.workspaceNameFolder} />
 								<span className={styles.workspaceNameLabel}>{project.title}</span>
-								<Icon name="chevron-down" className={styles.workspaceNameChevron} />
 							</Tooltip.Trigger>
 							<Tooltip.Portal>
 								<Tooltip.Positioner sideOffset={4}>

--- a/apps/lite/ui/src/routes/project/$id/workspace/Outline.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Outline.tsx
@@ -72,7 +72,7 @@ const FetchFromRemotesButton: FC<{
 		>
 			<Tooltip.Trigger
 				aria-label={workspaceHotkeys.fetchFromRemotes.meta.name}
-				className={getButtonClassName({ iconOnly: true })}
+				className={getButtonClassName({ iconOnly: true, variant: "ghost" })}
 				onClick={p.onFetch}
 				// We pass `disabled` here because we want to disable the button, not
 				// the tooltip.
@@ -336,7 +336,7 @@ export const Outline: FC<{
 						<Tooltip.Root>
 							<Tooltip.Trigger
 								aria-label={workspaceHotkeys.settings.meta.name}
-								className={getButtonClassName({ iconOnly: true })}
+								className={getButtonClassName({ iconOnly: true, variant: "ghost" })}
 								onClick={openSettings}
 								// We pass `disabled` here because we want to disable the button, not
 								// the tooltip. Other props should be passed above.

--- a/apps/lite/ui/src/routes/project/$id/workspace/Outline.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Outline.tsx
@@ -311,7 +311,7 @@ export const Outline: FC<{
 					<div className={styles.workspaceControlsLeft}>
 						<Tooltip.Root>
 							<Tooltip.Trigger
-								aria-label={globalHotkeys.selectProject.meta.name}
+								aria-label={`${globalHotkeys.selectProject.meta.name} (current: ${project.title})`}
 								className={classes(
 									getButtonClassName({ variant: "ghost" }),
 									"text-15",

--- a/apps/lite/ui/src/routes/project/$id/workspace/ProjectFolderIcon.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/ProjectFolderIcon.tsx
@@ -1,0 +1,24 @@
+import type { ComponentProps, FC } from "react";
+
+/** Colored folder mark shown next to the project name in the workspace header. */
+export const ProjectFolderIcon: FC<ComponentProps<"svg">> = (p) => (
+	<svg {...p} width="17" height="14" viewBox="0 0 17 14" fill="none" aria-hidden>
+		<path
+			d="M16.6629 13.2545H0V0H5.82617L7.57402 3.35636H16.6629V13.2545Z"
+			fill="url(#projectFolderIconGradient)"
+		/>
+		<defs>
+			<linearGradient
+				id="projectFolderIconGradient"
+				x1="7.57403"
+				y1="0"
+				x2="7.57403"
+				y2="11.7397"
+				gradientUnits="userSpaceOnUse"
+			>
+				<stop stopColor="#BCE1E2" />
+				<stop offset="1" stopColor="#7BC6C7" />
+			</linearGradient>
+		</defs>
+	</svg>
+);

--- a/apps/lite/ui/src/routes/project/$id/workspace/ProjectFolderIcon.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/ProjectFolderIcon.tsx
@@ -1,24 +1,28 @@
-import type { ComponentProps, FC } from "react";
+import { useId, type ComponentProps, type FC } from "react";
 
 /** Colored folder mark shown next to the project name in the workspace header. */
-export const ProjectFolderIcon: FC<ComponentProps<"svg">> = (p) => (
-	<svg {...p} width="17" height="14" viewBox="0 0 17 14" fill="none" aria-hidden>
-		<path
-			d="M16.6629 13.2545H0V0H5.82617L7.57402 3.35636H16.6629V13.2545Z"
-			fill="url(#projectFolderIconGradient)"
-		/>
-		<defs>
-			<linearGradient
-				id="projectFolderIconGradient"
-				x1="7.57403"
-				y1="0"
-				x2="7.57403"
-				y2="11.7397"
-				gradientUnits="userSpaceOnUse"
-			>
-				<stop stopColor="#BCE1E2" />
-				<stop offset="1" stopColor="#7BC6C7" />
-			</linearGradient>
-		</defs>
-	</svg>
-);
+export const ProjectFolderIcon: FC<ComponentProps<"svg">> = (p) => {
+	const gradientId = useId();
+
+	return (
+		<svg width="17" height="14" {...p} viewBox="0 0 17 14" fill="none" aria-hidden>
+			<path
+				d="M16.6629 13.2545H0V0H5.82617L7.57402 3.35636H16.6629V13.2545Z"
+				fill={`url(#${gradientId})`}
+			/>
+			<defs>
+				<linearGradient
+					id={gradientId}
+					x1="7.57403"
+					y1="0"
+					x2="7.57403"
+					y2="11.7397"
+					gradientUnits="userSpaceOnUse"
+				>
+					<stop stopColor="#BCE1E2" />
+					<stop offset="1" stopColor="#7BC6C7" />
+				</linearGradient>
+			</defs>
+		</svg>
+	);
+};


### PR DESCRIPTION
Now that the "Upstream" work has landed, the workspace sidebar header can match the Figma design.

### Changes

- **Project name button**: replaced the trailing chevron with a folder mark (`ProjectFolderIcon`) and styled the trigger as a ghost button. Below a 275px container width the label is hidden and only the folder mark remains.
- **Removed the "Update workspace" and "Apply branch" icon buttons** from the header — these are covered in the "Upstream" and "Branches" tabs now.
- **Ghost variant** for the remaining header icon buttons (fetch, settings).
- **Button sizing via CSS vars**: `.small` / `.regular` now set `--button-gap`, `--button-height`, `--button-padding-inline` (and `--button-width` for icon-only) at zero specificity via `:where()`, so consumers can override sizing from their own class instead of fighting specificity. Used by the project-name button and the non-square folder mark.
- Minor spacing tweaks in the outline header (row gap 12px → 10px, action gap 4px → 2px).

<img width="425" height="139" alt="image" src="https://github.com/user-attachments/assets/ff560651-4324-4774-8ae2-8312ad665176" />
