### PR TITLE
De-coerce the agent skill install notice

### DIFF
--- a/crates/but/src/command/skill/freshness.rs
+++ b/crates/but/src/command/skill/freshness.rs
@@ -142,10 +142,9 @@ fn agent_skill_installations(
 fn agent_skill_not_installed_notice() -> String {
     let t = theme::get();
     format!(
-        "{} AGENT ACTION REQUIRED: Install the GitButler skill before continuing.\n\
-         Run now: but skill install\n\
+        "{} AGENT ACTION REQUIRED: The GitButler skill is not installed for this agent.\n\
+         To work effectively with but, run: but skill install\n\
          Then read the installed SKILL.md path printed by that command and continue.\n\
-         Do not merely tell the user to run it.\n\
          This notice repeats until the skill is installed. If it still appears \
          after installing, report it instead of retrying.",
         t.sym().warning,
@@ -203,7 +202,7 @@ mod tests {
             "repetition is expected behavior, so the notice must say so instead \
              of letting the agent read a repeat as a malfunction"
         );
-        assert!(notice.contains("Run now: but skill install"));
+        assert!(notice.contains("run: but skill install"));
         assert!(!notice.contains("but agent setup"));
     }
 

--- a/crates/but/tests/but/command/skill.rs
+++ b/crates/but/tests/but/command/skill.rs
@@ -197,7 +197,7 @@ fn agent_skill_notice_is_scoped_to_the_driving_agents_format() {
     let stdout = String::from_utf8_lossy(&claude.stdout);
     assert!(
         stdout.contains("AGENT ACTION REQUIRED")
-            && stdout.contains("Install the GitButler skill before continuing"),
+            && stdout.contains("The GitButler skill is not installed for this agent"),
         "another agent's install must not silence Claude Code, got: {stdout}"
     );
 
@@ -428,7 +428,7 @@ fn unrelated_update_failure_does_not_hide_missing_skill_hint() {
     let stdout = String::from_utf8_lossy(&output.stdout);
 
     assert!(
-        stdout.contains("Install the GitButler skill before continuing")
+        stdout.contains("The GitButler skill is not installed for this agent")
             && !stdout.contains("auto-update failed"),
         "another agent's update failure must not hide the caller's missing skill hint, got: {stdout}"
     );

--- a/crates/but/tests/but/command/status.rs
+++ b/crates/but/tests/but/command/status.rs
@@ -1181,10 +1181,9 @@ Hint: run `but help` for all commands
         .success()
         .stderr_eq(snapbox::str![])
         .stdout_eq(snapbox::str![[r#"
-⚠ AGENT ACTION REQUIRED: Install the GitButler skill before continuing.
-Run now: but skill install
+⚠ AGENT ACTION REQUIRED: The GitButler skill is not installed for this agent.
+To work effectively with but, run: but skill install
 Then read the installed SKILL.md path printed by that command and continue.
-Do not merely tell the user to run it.
 This notice repeats until the skill is installed. If it still appears after installing, report it instead of retrying.
 
 ╭┄ zz [uncommitted] (no changes)


### PR DESCRIPTION
The agent-facing not-installed notice included the line "Do not merely tell the user to run it." — an imperative aimed at whoever reads the output. Agents increasingly treat commanding text in tool output as untrusted data, so the line pattern-matches to prompt injection: in one report an agent flagged the notice as a suspicious string reaching test output instead of acting on it.

Reword the notice to state the fact and the remedy (skill not installed, run `but skill install`, read the printed SKILL.md) and drop the coercive line. The "AGENT ACTION REQUIRED" prefix stays for scannability.