### PR TITLE
Keep hunk assignments while edit mode has the workspace's changes parked

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3940,6 +3940,7 @@ dependencies = [
  "but-core",
  "but-ctx",
  "but-graph",
+ "but-hunk-assignment",
  "but-meta",
  "but-oxidize",
  "but-rebase",

--- a/crates/but-hunk-assignment/src/lib.rs
+++ b/crates/but-hunk-assignment/src/lib.rs
@@ -482,6 +482,12 @@ pub fn assign(
 /// precise fallback and kept returning usable `assignments`, but the original
 /// error is preserved so callers can log or surface degraded accuracy. It is
 /// `None` when assignment reconciliation completed normally.
+///
+/// Reconciliation is skipped, and `assignments` is empty without anything being persisted,
+/// while the working tree does not hold the workspace's uncommitted changes. Edit mode parks
+/// them in a ref and checks them out until it ends, and reconciling against the working tree
+/// there would delete every assignment that covers them. The stored assignments are left as
+/// they are and come back on the next read once the workspace is checked out again.
 pub fn assignments_with_fallback(
     db: HunkAssignmentsHandleMut,
     repo: &gix::Repository,
@@ -494,6 +500,33 @@ pub fn assignments_with_fallback(
     Ok((hunk_assignments, None))
 }
 
+/// Return `true` if `repo`'s working tree still holds the workspace's uncommitted changes.
+///
+/// Edit mode checks those changes out of the working tree and parks them in a ref until it ends,
+/// pointing `HEAD` at a branch of its own that is no part of the workspace. Having a branch of
+/// the workspace checked out instead is not that situation: the changes are still there.
+fn worktree_holds_workspace_changes(
+    repo: &gix::Repository,
+    workspace: &but_graph::Workspace,
+) -> bool {
+    let Some(workspace_ref) = workspace.ref_name() else {
+        // Nothing names the workspace, so it is whatever happens to be checked out.
+        return true;
+    };
+    let head_ref = match repo.head_ref() {
+        Ok(Some(head_ref)) => head_ref,
+        // A detached `HEAD` is none of the modes that park the workspace's changes.
+        Ok(None) => return true,
+        // Without knowing what is checked out, keeping assignments that are no longer current
+        // is the cheaper mistake: they reconcile again on the next read, deletion is final.
+        Err(_) => return false,
+    };
+    head_ref.name() == workspace_ref
+        || workspace
+            .find_segment_and_stack_by_refname(head_ref.name())
+            .is_some()
+}
+
 fn reconcile_worktree_changes_with_worktree(
     db: HunkAssignmentsHandleMut,
     repo: &gix::Repository,
@@ -501,6 +534,12 @@ fn reconcile_worktree_changes_with_worktree(
     worktree_changes: Option<impl IntoIterator<Item = impl Into<but_core::TreeChange>>>,
     context_lines: u32,
 ) -> Result<Vec<HunkAssignment>> {
+    // Reconciling a working tree the workspace's changes were parked out of would delete every
+    // assignment covering them, so leave the stored assignments alone until they are back.
+    if !worktree_holds_workspace_changes(repo, workspace) {
+        return Ok(vec![]);
+    }
+
     let worktree_changes: Vec<but_core::TreeChange> = match worktree_changes {
         Some(wtc) => wtc.into_iter().map(Into::into).collect(),
         None => but_core::diff::worktree_changes(repo)?.changes,

--- a/crates/gitbutler-edit-mode/Cargo.toml
+++ b/crates/gitbutler-edit-mode/Cargo.toml
@@ -37,6 +37,7 @@ git-meta-lib.workspace = true
 
 [dev-dependencies]
 but-testsupport.workspace = true
+but-hunk-assignment.workspace = true
 but-meta = { workspace = true, features = ["legacy"] }
 snapbox.workspace = true
 

--- a/crates/gitbutler-edit-mode/tests/edit_mode.rs
+++ b/crates/gitbutler-edit-mode/tests/edit_mode.rs
@@ -116,6 +116,143 @@ fn assert_edit_mode_cleaned_up(ctx: &Context) -> Result<()> {
     Ok(())
 }
 
+/// The hunk assignments currently persisted for the workspace, as `(path, assigned)` pairs
+/// sorted by path.
+///
+/// Reading assignments reconciles them with the worktree, which is what the desktop app does
+/// on every refresh.
+fn assignments(ctx: &Context, perm: &but_ctx::access::RepoShared) -> Result<Vec<(String, bool)>> {
+    let context_lines = ctx.settings.context_lines;
+    let (repo, ws, mut db) = ctx.workspace_and_db_mut_with_perm(perm)?;
+    let (assignments, _) = but_hunk_assignment::assignments_with_fallback(
+        db.hunk_assignments_mut()?,
+        &repo,
+        &ws,
+        None::<Vec<but_core::TreeChange>>,
+        context_lines,
+    )?;
+    let mut out = assignments
+        .into_iter()
+        .map(|assignment| (assignment.path, assignment.stack_id.is_some()))
+        .collect::<Vec<_>>();
+    out.sort();
+    Ok(out)
+}
+
+/// Assign every uncommitted change to `stack_id`, like picking a lane for them in the UI.
+fn assign_everything_to(
+    ctx: &Context,
+    perm: &but_ctx::access::RepoShared,
+    stack_id: StackId,
+) -> Result<()> {
+    let context_lines = ctx.settings.context_lines;
+    let (repo, ws, mut db) = ctx.workspace_and_db_mut_with_perm(perm)?;
+    let (current, _) = but_hunk_assignment::assignments_with_fallback(
+        db.hunk_assignments_mut()?,
+        &repo,
+        &ws,
+        None::<Vec<but_core::TreeChange>>,
+        context_lines,
+    )?;
+    let requests = current
+        .into_iter()
+        .map(|assignment| but_hunk_assignment::HunkAssignmentRequest {
+            hunk_header: assignment.hunk_header,
+            path_bytes: assignment.path_bytes,
+            target: Some(but_hunk_assignment::HunkAssignmentTarget::Stack { stack_id }),
+        })
+        .collect();
+    but_hunk_assignment::assign(
+        db.hunk_assignments_mut()?,
+        &repo,
+        &ws,
+        requests,
+        context_lines,
+    )?;
+    Ok(())
+}
+
+/// Edit mode parks the uncommitted changes in a ref and checks them out of the worktree, so
+/// while it is active the worktree no longer contains the changes the assignments describe.
+/// Anything that recomputes assignments in that window - the file monitor does, on every
+/// worktree write, via `gitbutler-watcher` - must not persist that view over the real one.
+#[test]
+fn assignments_survive_edit_mode() -> Result<()> {
+    let (mut ctx, _tempdir) = command_ctx("conficted_entries_get_written_when_leaving_edit_mode")?;
+    let repo = ctx.repo.get()?;
+    let foobar = repo.head_commit()?.decode()?.parents().next().unwrap();
+    let worktree_dir = repo.workdir().unwrap().to_owned();
+    drop(repo);
+
+    // An uncommitted change that has nothing to do with the commit being edited.
+    std::fs::write(worktree_dir.join("assigned.txt"), "assigned to branchy\n")?;
+
+    let mut guard = ctx.exclusive_worktree_access();
+    let stack_id = {
+        let (_repo, ws, _db) = ctx.workspace_and_db_with_perm(guard.read_permission())?;
+        stack_id(&ws)?
+    };
+    assign_everything_to(&ctx, guard.read_permission(), stack_id)?;
+    assert_eq!(
+        assignments(&ctx, guard.read_permission())?,
+        [("assigned.txt".to_owned(), true)],
+        "the change starts out assigned to the stack"
+    );
+
+    enter_edit_mode(&mut ctx, foobar, stack_id, guard.write_permission())?;
+
+    // Editing the commit's content is what the report does while in edit mode. Entering it on
+    // an unconflicted commit checks that same commit out, so the working tree starts clean and
+    // the recompute below would otherwise take the empty-changes early return.
+    std::fs::write(worktree_dir.join("file"), "edited during edit mode\n")?;
+    // The file monitor recomputes assignments on every worktree write, ignoring failures.
+    let _ = assignments(&ctx, guard.read_permission());
+
+    save_and_return_to_workspace(&mut ctx, guard.write_permission())?;
+
+    assert_eq!(
+        assignments(&ctx, guard.read_permission())?,
+        [("assigned.txt".to_owned(), true)],
+        "leaving edit mode restores the change to the worktree with its branch still assigned"
+    );
+    Ok(())
+}
+
+/// Aborting throws the edit away rather than keeping it, but it restores the same parked
+/// changes, so their assignments have to survive that exit too.
+#[test]
+fn assignments_survive_aborting_edit_mode() -> Result<()> {
+    let (mut ctx, _tempdir) = command_ctx("conficted_entries_get_written_when_leaving_edit_mode")?;
+    let repo = ctx.repo.get()?;
+    let foobar = repo.head_commit()?.decode()?.parents().next().unwrap();
+    let worktree_dir = repo.workdir().unwrap().to_owned();
+    drop(repo);
+
+    std::fs::write(worktree_dir.join("assigned.txt"), "assigned to branchy\n")?;
+
+    let mut guard = ctx.exclusive_worktree_access();
+    let stack_id = {
+        let (_repo, ws, _db) = ctx.workspace_and_db_with_perm(guard.read_permission())?;
+        stack_id(&ws)?
+    };
+    assign_everything_to(&ctx, guard.read_permission(), stack_id)?;
+
+    enter_edit_mode(&mut ctx, foobar, stack_id, guard.write_permission())?;
+
+    std::fs::write(worktree_dir.join("file"), "edited during edit mode\n")?;
+    let _ = assignments(&ctx, guard.read_permission());
+
+    // Those edits are what makes the abort need forcing.
+    abort_and_return_to_workspace(&mut ctx, true, guard.write_permission())?;
+
+    assert_eq!(
+        assignments(&ctx, guard.read_permission())?,
+        [("assigned.txt".to_owned(), true)],
+        "aborting edit mode restores the change with its branch still assigned"
+    );
+    Ok(())
+}
+
 #[test]
 fn basic_leaving_edit_mode() -> Result<()> {
     let (mut ctx, _tempdir) = command_ctx("conficted_entries_get_written_when_leaving_edit_mode")?;


### PR DESCRIPTION
Fixes #10987

Entering edit mode parks the workspace's uncommitted changes in `refs/gitbutler/edit-uncommitted-changes` and checks them out of the working tree, so while it is active the working tree no longer holds the changes the assignments describe.

`assignments_with_fallback()` reconciles the stored assignments against the working tree and persists the result. Called in that window it sees the assigned hunks as gone, deletes their rows and writes that back, so leaving edit mode restores the files but not the branch they were assigned to.

`gitbutler-watcher` makes that call on every worktree write (`handler.rs:236`), discarding the result, which is what the report hits.

### Change

`reconcile_worktree_changes_with_worktree()` leaves the stored assignments alone when the working tree is not holding the workspace's changes:

```rust
head_ref.name() == workspace_ref
    || workspace
        .find_segment_and_stack_by_refname(head_ref.name())
        .is_some()
```

Guarding the reconciliation rather than the file monitor that triggers it also covers the other callers that reach the same persist through `assignments_with_fallback()` — `but_api::diff::changes_in_worktree_with_perm()`, `but-action`, and `but clean`. `assign()` reconciles and persists too, but it is the explicit "put this hunk on that branch" path rather than a background refresh, so it is left to do what it is asked.

Returning no assignments is a state the API already produces for a working tree that is not the workspace's: `changes_in_worktree` does the same for a linked worktree source, and for `compute_deps_and_assignments: false`.

### Why segment membership rather than `HEAD == workspace ref`

The simpler check is too broad. Having a branch of the workspace checked out also leaves `HEAD` different from the workspace ref, and assignments have to keep working there:

| checked out | part of the workspace | assignments |
| --- | --- | --- |
| `refs/heads/branchy`, a stack branch | yes | unchanged |
| `refs/heads/main`, outside it | yes, as its own workspace | unchanged |
| `refs/heads/gitbutler/edit` | no | left alone |

`segment_name_is_special()` keeps `refs/heads/gitbutler/*` from shaping stacks, so edit mode's branch can never name a workspace segment.

Asking the workspace projection rather than `gitbutler-operating-modes` keeps this out of `but-hunk-assignment`'s dependencies, and the projection being lossy only costs accuracy in one direction here: a `HEAD` the projection does not place in the workspace freezes the assignments for that read instead of deleting them, and the next read reconciles as usual.

### Tests

`assignments_survive_edit_mode` and `assignments_survive_aborting_edit_mode` follow the reported steps for both ways out of edit mode, driving `assignments_with_fallback()` the way the file monitor does. Both fail without the change, with the assignment coming back unassigned.

Entering edit mode on an unconflicted commit checks that same commit out, so the working tree starts clean and the existing empty-changes early return is what spares the assignments until something writes to the working tree — which is why the report's step 3 matters. A conflicted commit checks out a merged index over `.conflict-side-0` and is dirty on entry, so there the first refresh is enough.
