### PR TITLE
rebase: add options parameter to `materialize()`

### DIFF
--- a/crates/but-action/src/reword.rs
+++ b/crates/but-action/src/reword.rs
@@ -45,7 +45,7 @@ pub fn commit(
     let (rebase, edited_commit_selector) =
         but_workspace::commit::reword(editor, input.commit_id, message.as_bytes().as_bstr())?;
     let new_commit_id = rebase.lookup_pick(edited_commit_selector)?;
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
 
     Ok((new_commit_id, message))
 }

--- a/crates/but-action/src/simple.rs
+++ b/crates/but-action/src/simple.rs
@@ -137,7 +137,7 @@ pub(crate) fn handle_changes(
             .map(|selector| outcome.rebase.lookup_pick(selector))
             .transpose()?
         {
-            outcome.rebase.materialize()?;
+            outcome.rebase.materialize(Default::default())?;
             updated_branches.push(crate::UpdatedBranch {
                 stack_id,
                 branch_name: stack_branch_name,

--- a/crates/but-api/src/branch.rs
+++ b/crates/but-api/src/branch.rs
@@ -2001,7 +2001,7 @@ fn branch_workspace_from_rebase<M: but_core::RefMetadata>(
         );
     }
 
-    let materialized = rebase.materialize()?;
+    let materialized = rebase.materialize(Default::default())?;
     if let Some(order) = branch_stack_order {
         materialized.meta.set_branch_stack_order(order)?;
         let project_meta = materialized.workspace.graph.project_meta.clone();

--- a/crates/but-api/src/legacy/virtual_branches.rs
+++ b/crates/but-api/src/legacy/virtual_branches.rs
@@ -675,7 +675,7 @@ fn commit_assigned_diffspec(
         );
     }
     if outcome.commit_selector.is_some() {
-        outcome.rebase.materialize()?;
+        outcome.rebase.materialize(Default::default())?;
         drop((repo, ws));
         ctx.reload_repo_and_invalidate_workspace(perm)?;
     }

--- a/crates/but-api/src/legacy/workspace.rs
+++ b/crates/but-api/src/legacy/workspace.rs
@@ -361,7 +361,7 @@ pub fn stash_into_branch(
             .map(|selector| rebase.lookup_pick(selector))
             .transpose()?;
         let rebase_output = if let Some(new_commit) = new_commit {
-            let materialized = rebase.materialize()?;
+            let materialized = rebase.materialize(Default::default())?;
             let commit_mapping: Vec<_> = materialized
                 .history
                 .commit_mappings()

--- a/crates/but-api/src/workspace.rs
+++ b/crates/but-api/src/workspace.rs
@@ -575,7 +575,7 @@ pub fn workspace_integrate_upstream_only_with_perm(
             });
         }
 
-        let materialized = rebase.materialize()?;
+        let materialized = rebase.materialize(Default::default())?;
         project_meta.persist(&repo)?;
 
         if let Some(ref_name) = materialized.workspace.ref_name()

--- a/crates/but-api/src/workspace_state.rs
+++ b/crates/but-api/src/workspace_state.rs
@@ -226,7 +226,7 @@ impl WorkspaceState {
             return Self::from_rebase_preview(&mut rebase, replaced_commits, prs_by_head);
         }
 
-        let materialized = rebase.materialize()?;
+        let materialized = rebase.materialize(Default::default())?;
         Self::from_workspace(
             materialized.workspace,
             materialized.meta,

--- a/crates/but-rebase/src/graph_rebase/materialize.rs
+++ b/crates/but-rebase/src/graph_rebase/materialize.rs
@@ -117,6 +117,17 @@ fn open_linked_checkout_repos(
         .collect()
 }
 
+/// Options for [SuccessfulRebase::materialize].
+#[derive(Default)]
+pub struct MaterializeOptions {
+    /// Materializes a rebase without checking out the editor's own worktree.
+    ///
+    /// Linked worktrees aren't checked out either, but their `HEAD`s still follow the
+    /// rewrite, so what they had checked out surfaces as uncommitted changes there -
+    /// exactly like the editor's own worktree.
+    pub without_checkout: bool,
+}
+
 impl<'ws, 'graph, M: RefMetadata> SuccessfulRebase<'ws, 'graph, M> {
     /// The linked worktrees this edit has to move, with where the rewrite put each
     /// one, validated against the shape recorded at editor creation.
@@ -184,7 +195,10 @@ impl<'ws, 'graph, M: RefMetadata> SuccessfulRebase<'ws, 'graph, M> {
     }
 
     /// Materializes a history rewrite.
-    pub fn materialize(mut self) -> Result<MaterializeOutcome<'ws, 'graph, M>> {
+    pub fn materialize(
+        mut self,
+        materialize_options: MaterializeOptions,
+    ) -> Result<MaterializeOutcome<'ws, 'graph, M>> {
         let repo = self.repo.clone();
         if let Some(memory) = self.repo.objects.take_object_memory() {
             memory.persist(&self.repo)?;
@@ -192,35 +206,43 @@ impl<'ws, 'graph, M: RefMetadata> SuccessfulRebase<'ws, 'graph, M> {
 
         let specs = self.linked_checkout_specs()?;
         let detached_head_edits = detached_worktree_head_edits(&specs)?;
-        let linked_repos = open_linked_checkout_repos(&repo, specs)?;
-        for linked_repo in linked_repos {
-            safe_checkout_from_head(
-                linked_repo.target,
-                &linked_repo.repo,
-                Options {
-                    skip_head_update: true,
-                    merge_base_override: linked_repo.merge_base_override,
-                    allow_conflicted_commit_checkout: false,
-                },
-            )?;
-        }
 
-        let head = self.head_checkout()?;
-        if let Some(head) = &head {
-            safe_checkout_from_head(
-                head.target,
-                &repo,
-                Options {
-                    skip_head_update: true,
-                    merge_base_override: head.merge_base_override,
-                    allow_conflicted_commit_checkout: true,
-                },
-            )?;
-        }
+        let head = if !materialize_options.without_checkout {
+            let linked_repos = open_linked_checkout_repos(&repo, specs)?;
+            for linked_repo in linked_repos {
+                safe_checkout_from_head(
+                    linked_repo.target,
+                    &linked_repo.repo,
+                    Options {
+                        skip_head_update: true,
+                        merge_base_override: linked_repo.merge_base_override,
+                        allow_conflicted_commit_checkout: false,
+                    },
+                )?;
+            }
+
+            let head = self.head_checkout()?;
+            if let Some(head) = &head {
+                safe_checkout_from_head(
+                    head.target,
+                    &repo,
+                    Options {
+                        skip_head_update: true,
+                        merge_base_override: head.merge_base_override,
+                        allow_conflicted_commit_checkout: true,
+                    },
+                )?;
+            }
+            head
+        } else {
+            None
+        };
 
         let mut ref_edits = self.ref_edits.clone();
         ref_edits.extend(detached_head_edits);
-        if let Some(refname) = head.and_then(|head| head.ref_name)
+
+        if !materialize_options.without_checkout
+            && let Some(refname) = head.and_then(|head| head.ref_name)
             && repo.head_name()?.as_ref() != Some(&refname)
         {
             let ref_short_name = refname.shorten().to_owned();
@@ -257,32 +279,11 @@ impl<'ws, 'graph, M: RefMetadata> SuccessfulRebase<'ws, 'graph, M> {
         })
     }
 
-    /// Materializes a rebase without checking out the editor's own worktree.
-    ///
-    /// Linked worktrees aren't checked out either, but their `HEAD`s still follow the
-    /// rewrite, so what they had checked out surfaces as uncommitted changes there -
-    /// exactly like the editor's own worktree.
-    pub fn materialize_without_checkout(mut self) -> Result<MaterializeOutcome<'ws, 'graph, M>> {
-        let repo = self.repo.clone();
-        if let Some(memory) = self.repo.objects.take_object_memory() {
-            memory.persist(&self.repo)?;
-        }
-
-        let mut ref_edits = self.ref_edits.clone();
-        ref_edits.extend(detached_worktree_head_edits(
-            &self.linked_checkout_specs()?,
-        )?);
-        repo.edit_references(ref_edits)?;
-
-        let project_meta = self.workspace.graph.project_meta.clone();
-        self.workspace
-            .refresh_from_head(&repo, &*self.meta, project_meta)?;
-
-        Ok(MaterializeOutcome {
-            graph: self.graph,
-            history: self.history,
-            workspace: self.workspace,
-            meta: self.meta,
+    /// Convenience for [Self::materialize] with
+    /// [MaterializeOptions::without_checkout] set.
+    pub fn materialize_without_checkout(self) -> Result<MaterializeOutcome<'ws, 'graph, M>> {
+        self.materialize(MaterializeOptions {
+            without_checkout: true,
         })
     }
 }

--- a/crates/but-rebase/tests/rebase/graph_rebase/conflictable_restriction.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/conflictable_restriction.rs
@@ -56,7 +56,7 @@ fn by_default_conflicts_are_allowed() -> Result<()> {
 
 "#]]
     );
-    let outcome = outcome.materialize()?;
+    let outcome = outcome.materialize(Default::default())?;
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
     // We expect to see conflicted headers
@@ -205,7 +205,7 @@ fn if_a_commit_has_been_configured_not_to_conflict_and_doesnt_end_up_conflicted_
 
 "#]]
     );
-    let outcome = outcome.materialize()?;
+    let outcome = outcome.materialize(Default::default())?;
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
     // The rebase is successful because `c` remained unconflicted

--- a/crates/but-rebase/tests/rebase/graph_rebase/disconnect.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/disconnect.rs
@@ -67,7 +67,7 @@ fn disconnect_and_remove_middle_commit_in_linear_history() -> Result<()> {
 
 "#]]
     );
-    let outcome = outcome.materialize()?;
+    let outcome = outcome.materialize(Default::default())?;
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
     snapbox::assert_data_eq!(
@@ -145,7 +145,7 @@ fn disconnect_and_remove_two_middle_commits_in_linear_history() -> Result<()> {
 
 "#]]
     );
-    let outcome = outcome.materialize()?;
+    let outcome = outcome.materialize(Default::default())?;
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
     snapbox::assert_data_eq!(
@@ -227,7 +227,7 @@ fn disconnect_and_remove_commit_in_merge_history_rewires_children() -> Result<()
 
 "#]]
     );
-    let outcome = outcome.materialize()?;
+    let outcome = outcome.materialize(Default::default())?;
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
     let a_now = repo.rev_parse_single("A")?.detach();
@@ -328,7 +328,7 @@ fn disconnect_and_remove_merge_with_two_parents_and_two_children() -> Result<()>
 
 "#]]
     );
-    let outcome = outcome.materialize()?;
+    let outcome = outcome.materialize(Default::default())?;
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
     let p1 = repo.rev_parse_single("P1")?.detach();
@@ -473,7 +473,7 @@ fn disconnect_and_remove_merge_with_two_parents_and_two_children_from_one_side()
 
 "#]]
     );
-    let outcome = outcome.materialize()?;
+    let outcome = outcome.materialize(Default::default())?;
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
     let p1 = repo.rev_parse_single("P1")?.detach();
@@ -608,7 +608,7 @@ fn disconnect_remove_merge_with_two_parents_and_two_children_children_only() -> 
 
 "#]]
     );
-    let outcome = outcome.materialize()?;
+    let outcome = outcome.materialize(Default::default())?;
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
     let p1 = repo.rev_parse_single("P1")?.detach();
@@ -761,7 +761,7 @@ fn disconnect_fails_when_parents_to_disconnect_is_none() -> Result<()> {
 
 "#]]
     );
-    let outcome = outcome.materialize()?;
+    let outcome = outcome.materialize(Default::default())?;
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
     let after = visualize_commit_graph_all(&repo)?;
@@ -843,7 +843,7 @@ fn disconnect_fails_fast_if_parent_to_disconnect_is_not_direct_parent() -> Resul
 
 "#]]
     );
-    let outcome = outcome.materialize()?;
+    let outcome = outcome.materialize(Default::default())?;
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
     let after = visualize_commit_graph_all(&repo)?;
@@ -925,7 +925,7 @@ fn disconnect_fails_fast_if_child_to_disconnect_is_not_direct_child() -> Result<
 
 "#]]
     );
-    let outcome = outcome.materialize()?;
+    let outcome = outcome.materialize(Default::default())?;
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
     let after = visualize_commit_graph_all(&repo)?;

--- a/crates/but-rebase/tests/rebase/graph_rebase/insert.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/insert.rs
@@ -75,7 +75,7 @@ fn insert_below_merge_commit() -> Result<()> {
 
 "#]]
     );
-    let outcome = outcome.materialize()?;
+    let outcome = outcome.materialize(Default::default())?;
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
     snapbox::assert_data_eq!(
@@ -181,7 +181,7 @@ fn insert_below_merge_commit_excluded_mappings() -> Result<()> {
 
 "#]]
     );
-    let outcome = outcome.materialize()?;
+    let outcome = outcome.materialize(Default::default())?;
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
     snapbox::assert_data_eq!(
@@ -282,7 +282,7 @@ fn insert_above_commit_with_two_children() -> Result<()> {
 
 "#]]
     );
-    let outcome = outcome.materialize()?;
+    let outcome = outcome.materialize(Default::default())?;
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
     snapbox::assert_data_eq!(

--- a/crates/but-rebase/tests/rebase/graph_rebase/insert_segment.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/insert_segment.rs
@@ -99,7 +99,7 @@ fn insert_single_node_segment_above() -> Result<()> {
 
 "#]]
     );
-    let outcome = outcome.materialize()?;
+    let outcome = outcome.materialize(Default::default())?;
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
     snapbox::assert_data_eq!(
@@ -199,7 +199,7 @@ fn insert_single_node_segment_below() -> Result<()> {
 
 "#]]
     );
-    let outcome = outcome.materialize()?;
+    let outcome = outcome.materialize(Default::default())?;
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
     snapbox::assert_data_eq!(
@@ -303,7 +303,7 @@ fn insert_multi_node_segment_above() -> Result<()> {
 
 "#]]
     );
-    let outcome = outcome.materialize()?;
+    let outcome = outcome.materialize(Default::default())?;
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
     snapbox::assert_data_eq!(
@@ -406,7 +406,7 @@ fn insert_multi_node_segment_below() -> Result<()> {
 
 "#]]
     );
-    let outcome = outcome.materialize()?;
+    let outcome = outcome.materialize(Default::default())?;
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
     snapbox::assert_data_eq!(
@@ -518,7 +518,7 @@ fn insert_single_node_segment_above_with_explicit_children() -> Result<()> {
 
 "#]]
     );
-    let outcome = outcome.materialize()?;
+    let outcome = outcome.materialize(Default::default())?;
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
     snapbox::assert_data_eq!(
@@ -636,7 +636,7 @@ fn insert_single_node_segment_below_with_explicit_parents() -> Result<()> {
 
 "#]]
     );
-    let outcome = outcome.materialize()?;
+    let outcome = outcome.materialize(Default::default())?;
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
     assert_eq!(
         parent_subjects(&repo, "B")?,
@@ -713,7 +713,7 @@ fn insert_single_node_segment_below_can_append_reparented_parent() -> Result<()>
         mutate::ParentReparentingOrder::Append,
     )?;
 
-    editor.rebase()?.materialize()?;
+    editor.rebase()?.materialize(Default::default())?;
     assert_eq!(
         parent_subjects(&repo, "B")?,
         [

--- a/crates/but-rebase/tests/rebase/graph_rebase/materialize.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/materialize.rs
@@ -116,7 +116,7 @@ fn materialize_removes_dropped_commit_changes_from_worktree() -> Result<()> {
 
 "#]]
     );
-    let outcome = outcome.materialize()?;
+    let outcome = outcome.materialize(Default::default())?;
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
     // After materialize, file 'c' should be GONE from worktree
@@ -245,7 +245,7 @@ fn both_methods_update_references_identically() -> Result<()> {
 
         let outcome = editor.rebase()?;
         let overlayed = graph_tree(&outcome.overlayed_graph()?).to_string();
-        let outcome = outcome.materialize()?;
+        let outcome = outcome.materialize(Default::default())?;
         assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
         (
@@ -339,7 +339,7 @@ fn materialize_repoints_head_when_checkout_reference_is_replaced() -> Result<()>
         "overlay preview should not repoint HEAD before materialization"
     );
 
-    let outcome = outcome.materialize()?;
+    let outcome = outcome.materialize(Default::default())?;
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
     assert_eq!(
         repo.head_name()?,
@@ -428,7 +428,7 @@ fn materialize_keeps_immutable_refs_unchanged_while_updating_local_refs() -> Res
     editor.replace(stack_tip_sel, Step::None)?;
 
     let outcome = editor.rebase()?;
-    outcome.materialize()?;
+    outcome.materialize(Default::default())?;
 
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
@@ -469,7 +469,7 @@ fn materialize_does_not_delete_immutable_refs_removed_from_graph() -> Result<()>
     editor.replace(main_sel, Step::None)?;
 
     let outcome = editor.rebase()?;
-    outcome.materialize()?;
+    outcome.materialize(Default::default())?;
 
     assert_eq!(repo.rev_parse_single("main")?.detach(), main_before);
 
@@ -521,7 +521,7 @@ fn visible_attached_and_detached_worktrees_follow_a_rewritten_commit() -> Result
     let replacement = repo.write_object(replacement.inner)?.detach();
     let old_middle_selector = editor.select_commit(old_middle)?;
     editor.replace(old_middle_selector, Step::new_pick(replacement))?;
-    editor.rebase()?.materialize()?;
+    editor.rebase()?.materialize(Default::default())?;
 
     let new_middle = repo.rev_parse_single("middle")?.detach();
     assert_ne!(new_middle, old_middle);
@@ -593,7 +593,7 @@ fn references_checked_out_in_linked_worktrees_are_not_deleted() -> Result<()> {
         let selector = editor.select_reference(refname.try_into()?)?;
         editor.replace(selector, Step::None)?;
     }
-    editor.rebase()?.materialize()?;
+    editor.rebase()?.materialize(Default::default())?;
 
     assert!(
         repo.try_find_reference("middle")?.is_some(),
@@ -637,7 +637,7 @@ fn changes_consumed_from_a_linked_worktree_cancel_during_its_checkout() -> Resul
     let middle_selector = editor.select_commit(middle)?;
     editor.replace(middle_selector, Step::new_pick(amended))?;
     editor.set_worktree_merge_base_override(gix::bstr::BStr::new("wt"), consumed_tree)?;
-    editor.rebase()?.materialize()?;
+    editor.rebase()?.materialize(Default::default())?;
 
     assert_eq!(repo.rev_parse_single("middle")?.detach(), amended);
     assert_eq!(

--- a/crates/but-rebase/tests/rebase/graph_rebase/rebase_identities.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/rebase_identities.rs
@@ -49,7 +49,7 @@ fn four_commits() -> Result<()> {
 
 "#]]
     );
-    let outcome = outcome.materialize()?;
+    let outcome = outcome.materialize(Default::default())?;
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
     assert_eq!(visualize_commit_graph_all(&repo)?, before);
@@ -119,7 +119,7 @@ fn four_commits_with_short_traversal() -> Result<()> {
 
 "#]]
     );
-    let outcome = outcome.materialize()?;
+    let outcome = outcome.materialize(Default::default())?;
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
     assert_eq!(visualize_commit_graph_all(&repo)?, before);
@@ -184,7 +184,7 @@ fn merge_in_the_middle() -> Result<()> {
 
 "#]]
     );
-    let outcome = outcome.materialize()?;
+    let outcome = outcome.materialize(Default::default())?;
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
     assert_eq!(visualize_commit_graph_all(&repo)?, before);
@@ -257,7 +257,7 @@ fn three_branches_merged() -> Result<()> {
 
 "#]]
     );
-    let outcome = outcome.materialize()?;
+    let outcome = outcome.materialize(Default::default())?;
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
     assert_eq!(visualize_commit_graph_all(&repo)?, before);

--- a/crates/but-rebase/tests/rebase/graph_rebase/replace.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/replace.rs
@@ -76,7 +76,7 @@ fn reword_a_commit() -> Result<()> {
 
 "#]]
     );
-    let outcome = outcome.materialize()?;
+    let outcome = outcome.materialize(Default::default())?;
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
     assert_eq!(head_tree, repo.head_tree()?.id);
@@ -198,7 +198,7 @@ f766d1f
 
 "#]]
     );
-    let outcome = outcome.materialize()?;
+    let outcome = outcome.materialize(Default::default())?;
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
     snapbox::assert_data_eq!(

--- a/crates/but-rebase/tests/rebase/graph_rebase/sha256.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/sha256.rs
@@ -77,7 +77,7 @@ Sha256
 
 "#]]
     );
-    let outcome = outcome.materialize()?;
+    let outcome = outcome.materialize(Default::default())?;
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
     snapbox::assert_data_eq!(
@@ -175,7 +175,7 @@ Sha256
 
 "#]]
     );
-    let outcome = outcome.materialize()?;
+    let outcome = outcome.materialize(Default::default())?;
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
     snapbox::assert_data_eq!(
@@ -283,7 +283,7 @@ Sha256
 
 "#]]
     );
-    let outcome = outcome.materialize()?;
+    let outcome = outcome.materialize(Default::default())?;
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
     snapbox::assert_data_eq!(

--- a/crates/but-rebase/tests/rebase/graph_rebase/signing_preferences.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/signing_preferences.rs
@@ -58,7 +58,7 @@ fn commits_maintain_state_if_not_cherry_picked() -> Result<()> {
 
 "#]]
     );
-    let outcome = outcome.materialize()?;
+    let outcome = outcome.materialize(Default::default())?;
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
     assert_eq!(visualize_commit_graph_all(&repo)?, before);
@@ -111,7 +111,7 @@ fn commits_are_signed_by_default() -> Result<()> {
 
 "#]]
     );
-    let outcome = outcome.materialize()?;
+    let outcome = outcome.materialize(Default::default())?;
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
     snapbox::assert_data_eq!(
@@ -208,7 +208,7 @@ fn when_cherry_picking_dont_resign_if_not_set() -> Result<()> {
 
 "#]]
     );
-    let outcome = outcome.materialize()?;
+    let outcome = outcome.materialize(Default::default())?;
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
     snapbox::assert_data_eq!(
@@ -285,7 +285,7 @@ fn force_picked_commit_with_sign_yes_is_signed_when_otherwise_unchanged() -> Res
     editor.replace(top_commit_sel, Step::Pick(pick))?;
 
     let outcome = editor.rebase()?;
-    let materialize_outcome = outcome.materialize()?;
+    let materialize_outcome = outcome.materialize(Default::default())?;
 
     let after = visualize_commit_graph_all(&repo)?;
     snapbox::assert_data_eq!(
@@ -370,7 +370,7 @@ fn force_picked_ancestor_does_not_sign_descendants_picked_with_sign_commit_no() 
     editor.replace(mid_sel, Step::Pick(pick))?;
 
     let outcome = editor.rebase()?;
-    let materialize_outcome = outcome.materialize()?;
+    let materialize_outcome = outcome.materialize(Default::default())?;
 
     let after = visualize_commit_graph_all(&repo)?;
     snapbox::assert_data_eq!(
@@ -471,7 +471,7 @@ fn force_picked_ancestor_triggers_cascading_signatures_on_descendants_picked_wit
     editor.replace(mid_sel, Step::Pick(pick))?;
 
     let outcome = editor.rebase()?;
-    let materialize_outcome = outcome.materialize()?;
+    let materialize_outcome = outcome.materialize(Default::default())?;
 
     let after = visualize_commit_graph_all(&repo)?;
     snapbox::assert_data_eq!(
@@ -567,7 +567,7 @@ fn commit_picked_with_sign_if_enabled_is_not_signed_when_signing_config_is_disab
     editor.replace(mid_sel, Step::None)?;
 
     let outcome = editor.rebase()?;
-    let materialize_outcome = outcome.materialize()?;
+    let materialize_outcome = outcome.materialize(Default::default())?;
 
     let after = visualize_commit_graph_all(&repo)?;
     snapbox::assert_data_eq!(
@@ -650,7 +650,7 @@ fn parentless_commit_force_picked_with_sign_yes_is_signed() -> Result<()> {
     editor.replace(base_sel, Step::Pick(pick))?;
 
     let outcome = editor.rebase()?;
-    let materialize_outcome = outcome.materialize()?;
+    let materialize_outcome = outcome.materialize(Default::default())?;
 
     let commit_mappings = materialize_outcome.history.commit_mappings();
     let new_base_commit_id = commit_mappings

--- a/crates/but-rebase/tests/rebase/graph_rebase/workspace_commit_behaviour.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/workspace_commit_behaviour.rs
@@ -75,7 +75,7 @@ fn workspace_remains_unchanged_with_no_operations() -> Result<()> {
         "Workspace step should match workspace pick defaults after first rebase"
     );
 
-    let mat_outcome = outcome.materialize()?;
+    let mat_outcome = outcome.materialize(Default::default())?;
     assert_eq!(
         overlayed,
         graph_tree(&mat_outcome.workspace.graph).to_string()
@@ -140,7 +140,7 @@ fn workspace_commit_is_not_signed_after_cherry_pick() -> Result<()> {
 
 "#]]
     );
-    let outcome = outcome.materialize()?;
+    let outcome = outcome.materialize(Default::default())?;
     assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
     snapbox::assert_data_eq!(
@@ -261,7 +261,7 @@ fn ad_hoc_workspace_keeps_regular_defaults() -> Result<()> {
         "Step should match regular pick defaults after rebase"
     );
 
-    let mat_outcome = outcome.materialize()?;
+    let mat_outcome = outcome.materialize(Default::default())?;
     assert_eq!(
         overlayed,
         graph_tree(&mat_outcome.workspace.graph).to_string()
@@ -409,7 +409,7 @@ fn workspace_commit_with_deleted_branch_ref_rebases_successfully() -> Result<()>
     // The rebase should succeed even though the workspace commit has a
     // parent that no longer has a corresponding Reference node.
     let outcome = editor.rebase()?;
-    let _materialized = outcome.materialize()?;
+    let _materialized = outcome.materialize(Default::default())?;
 
     Ok(())
 }

--- a/crates/but-transaction/src/lib.rs
+++ b/crates/but-transaction/src/lib.rs
@@ -1293,7 +1293,7 @@ fn workspace_state_from_rebase<M: RefMetadata>(
     let materialized = if materialize_without_checkout {
         rebase.materialize_without_checkout()?
     } else {
-        rebase.materialize()?
+        rebase.materialize(Default::default())?
     };
     for branch in pending_created_independent_refs {
         if materialized

--- a/crates/but-workspace/src/commit/move_changes.rs
+++ b/crates/but-workspace/src/commit/move_changes.rs
@@ -37,7 +37,7 @@ pub struct MoveChangesOutcome<'ws, 'meta, M: RefMetadata> {
 ///
 /// Returns the rebase outcome along with selectors pointing to both the
 /// modified source and destination commits. The caller should call
-/// `outcome.rebase.materialize()` to persist the changes.
+/// `outcome.rebase.materialize(Default::default())` to persist the changes.
 pub fn move_changes_between_commits<'ws, 'meta, M: RefMetadata>(
     mut editor: Editor<'ws, 'meta, M>,
     source_commit: impl ToCommitSelector,

--- a/crates/but-workspace/tests/workspace/branch/integrate_branch_upstream.rs
+++ b/crates/but-workspace/tests/workspace/branch/integrate_branch_upstream.rs
@@ -1167,7 +1167,7 @@ fn integrate_branch_with_merge_step_does_not_require_preceding_commit() -> Resul
 
     let rebase =
         integrate_branch_with_steps(r("refs/heads/A"), integration, &mut ws, &mut meta, &repo)?;
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
 
     snapbox::assert_data_eq!(
         normalized_graph_snapshot(&repo)?,
@@ -1251,7 +1251,7 @@ fn integrate_upstream_commits_into_local() -> Result<()> {
 
     let rebase =
         integrate_branch_with_steps(r("refs/heads/A"), integration, &mut ws, &mut meta, &repo)?;
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
 
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
@@ -1325,7 +1325,7 @@ fn integrate_upstream_commits_into_local_with_merge_step() -> Result<()> {
 
     let rebase =
         integrate_branch_with_steps(r("refs/heads/A"), integration, &mut ws, &mut meta, &repo)?;
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
 
     snapbox::assert_data_eq!(
         normalized_graph_snapshot(&repo)?,
@@ -1423,7 +1423,7 @@ fn integrate_upstream_commits_into_local_with_all_locals_then_merge_second_remot
 
     let rebase =
         integrate_branch_with_steps(r("refs/heads/A"), integration, &mut ws, &mut meta, &repo)?;
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
 
     snapbox::assert_data_eq!(
         normalized_graph_snapshot(&repo)?,
@@ -1498,7 +1498,7 @@ fn integrate_upstream_commits_into_local_with_two_merges_in_sequence() -> Result
 
     let rebase =
         integrate_branch_with_steps(r("refs/heads/A"), integration, &mut ws, &mut meta, &repo)?;
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
 
     snapbox::assert_data_eq!(
         normalized_graph_snapshot(&repo)?,
@@ -1607,7 +1607,7 @@ fn integrate_upstream_commits_into_local_with_remote_on_top() -> Result<()> {
 
     let rebase =
         integrate_branch_with_steps(r("refs/heads/A"), integration, &mut ws, &mut meta, &repo)?;
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
 
     snapbox::assert_data_eq!(
         normalized_graph_snapshot(&repo)?,
@@ -1684,7 +1684,7 @@ fn integrate_upstream_commits_into_local_with_remote_interlaced() -> Result<()> 
 
     let rebase =
         integrate_branch_with_steps(r("refs/heads/A"), integration, &mut ws, &mut meta, &repo)?;
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
 
     snapbox::assert_data_eq!(
         normalized_graph_snapshot(&repo)?,
@@ -1752,7 +1752,7 @@ fn integrate_upstream_commits_into_local_with_remote_one_local_one_remote() -> R
 
     let rebase =
         integrate_branch_with_steps(r("refs/heads/A"), integration, &mut ws, &mut meta, &repo)?;
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
 
     snapbox::assert_data_eq!(
         normalized_graph_snapshot(&repo)?,
@@ -1822,7 +1822,7 @@ fn integrate_upstream_commits_into_local_with_remote_one_local_one_remote_and_ex
 
     let rebase =
         integrate_branch_with_steps(r("refs/heads/A"), integration, &mut ws, &mut meta, &repo)?;
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
 
     snapbox::assert_data_eq!(
         normalized_graph_snapshot(&repo)?,
@@ -1892,7 +1892,7 @@ fn integrate_upstream_commits_into_local_with_only_remote_commits() -> Result<()
 
     let rebase =
         integrate_branch_with_steps(r("refs/heads/A"), integration, &mut ws, &mut meta, &repo)?;
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
 
     snapbox::assert_data_eq!(
         normalized_graph_snapshot(&repo)?,
@@ -1975,7 +1975,7 @@ pick remote-commit
         &mut meta,
         &repo,
     )?;
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
 
     snapbox::assert_data_eq!(
         labeled_graph_snapshot(&repo, &labels)?,
@@ -2046,7 +2046,7 @@ pick remote-commit
         &mut meta,
         &repo,
     )?;
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
 
     snapbox::assert_data_eq!(
         labeled_graph_snapshot(&repo, &labels)?,
@@ -2137,7 +2137,7 @@ pick local-commit-3
         &mut meta,
         &repo,
     )?;
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
 
     snapbox::assert_data_eq!(
         labeled_graph_snapshot(&repo, &labels)?,
@@ -2206,7 +2206,7 @@ pick local-tip
         &mut meta,
         &repo,
     )?;
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
 
     snapbox::assert_data_eq!(
         labeled_graph_snapshot(&repo, &labels)?,
@@ -2264,7 +2264,7 @@ fn integrate_upstream_commits_into_local_with_squashed_local_commits() -> Result
 
     let rebase =
         integrate_branch_with_steps(r("refs/heads/A"), integration, &mut ws, &mut meta, &repo)?;
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
 
     snapbox::assert_data_eq!(
         normalized_graph_snapshot(&repo)?,
@@ -2324,7 +2324,7 @@ fn integrate_upstream_commits_into_local_with_squashed_remote_commits() -> Resul
 
     let rebase =
         integrate_branch_with_steps(r("refs/heads/A"), integration, &mut ws, &mut meta, &repo)?;
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
 
     snapbox::assert_data_eq!(
         normalized_graph_snapshot(&repo)?,
@@ -2385,7 +2385,7 @@ fn integrate_upstream_commits_into_local_with_squashed_remote_into_local_commits
 
     let rebase =
         integrate_branch_with_steps(r("refs/heads/A"), integration, &mut ws, &mut meta, &repo)?;
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
 
     snapbox::assert_data_eq!(
         normalized_graph_snapshot(&repo)?,
@@ -2445,7 +2445,7 @@ fn integrate_upstream_commits_into_local_with_squashed_remote_into_local_conflic
 
     let rebase =
         integrate_branch_with_steps(r("refs/heads/A"), integration, &mut ws, &mut meta, &repo)?;
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
 
     snapbox::assert_data_eq!(
         normalized_graph_snapshot(&repo)?,
@@ -2537,7 +2537,7 @@ fn integrate_upstream_commits_into_local_with_merge_remote_into_local_conflicts(
 
     let rebase =
         integrate_branch_with_steps(r("refs/heads/A"), integration, &mut ws, &mut meta, &repo)?;
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
 
     snapbox::assert_data_eq!(
         normalized_graph_snapshot(&repo)?,
@@ -2692,7 +2692,7 @@ fn integrate_upstream_precomputes_squash_before_later_step_graph_rewiring() -> R
 
     let rebase =
         integrate_branch_with_steps(r("refs/heads/A"), integration, &mut ws, &mut meta, &repo)?;
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
 
     let mut current_commit_id = repo.rev_parse_single("A")?.detach();
     let squashed_commit_id = loop {
@@ -2980,7 +2980,7 @@ fn apply_initial_steps_example_2_also_applies_integrated_local_commits() -> Resu
         &repo,
     )?;
 
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
     let c_prime = repo.rev_parse_single("A")?.detach();
     let d_prime = repo.rev_parse_single("A~1")?.detach();
     assert_ne!(

--- a/crates/but-workspace/tests/workspace/branch/move_branch.rs
+++ b/crates/but-workspace/tests/workspace/branch/move_branch.rs
@@ -63,7 +63,7 @@ fn move_top_branch_to_top_of_another_stack() -> anyhow::Result<()> {
     )?;
 
     // Materialize the operation
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
     set_workspace_metadata(&mut meta, &ws, ws_meta)?;
     let project_meta = ws.graph.project_meta.clone();
     ws.refresh_from_head(&repo, &meta, project_meta)?;
@@ -189,7 +189,7 @@ fn move_bottom_branch_to_top_of_another_stack() -> anyhow::Result<()> {
     )?;
 
     // Materialize the operation
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
     set_workspace_metadata(&mut meta, &ws, ws_meta)?;
     let project_meta = ws.graph.project_meta.clone();
     ws.refresh_from_head(&repo, &meta, project_meta)?;
@@ -281,7 +281,7 @@ fn move_single_branch_to_top_of_another_stack() -> anyhow::Result<()> {
     )?;
 
     // Materialize the operation
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
     set_workspace_metadata(&mut meta, &ws, ws_meta)?;
     let project_meta = ws.graph.project_meta.clone();
     ws.refresh_from_head(&repo, &meta, project_meta)?;
@@ -369,7 +369,7 @@ fn reorder_branch_in_stack() -> anyhow::Result<()> {
     )?;
 
     // Materialize the operation
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
     set_workspace_metadata(&mut meta, &ws, ws_meta)?;
     let project_meta = ws.graph.project_meta.clone();
     ws.refresh_from_head(&repo, &meta, project_meta)?;
@@ -461,7 +461,7 @@ fn insert_branch_in_the_middle_of_a_stack() -> anyhow::Result<()> {
     )?;
 
     // Materialize the operation
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
     set_workspace_metadata(&mut meta, &ws, ws_meta)?;
     let project_meta = ws.graph.project_meta.clone();
     ws.refresh_from_head(&repo, &meta, project_meta)?;
@@ -541,7 +541,7 @@ fn move_empty_branch() -> anyhow::Result<()> {
     )?;
 
     // Materialize the operation
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
     set_workspace_metadata(&mut meta, &ws, ws_meta)?;
     let project_meta = ws.graph.project_meta.clone();
     ws.refresh_from_head(&repo, &meta, project_meta)?;
@@ -615,7 +615,7 @@ fn move_branch_on_top_of_empty_branch() -> anyhow::Result<()> {
     )?;
 
     // Materialize the operation
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
     set_workspace_metadata(&mut meta, &ws, ws_meta)?;
     let project_meta = ws.graph.project_meta.clone();
     ws.refresh_from_head(&repo, &meta, project_meta)?;
@@ -689,7 +689,7 @@ fn move_empty_branch_on_top_of_empty_branch_in_same_stack() -> anyhow::Result<()
         "refs/heads/B".try_into()?,
     )?;
 
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
     set_workspace_metadata(&mut meta, &ws, ws_meta)?;
     let project_meta = ws.graph.project_meta.clone();
     ws.refresh_from_head(&repo, &meta, project_meta)?;
@@ -755,7 +755,7 @@ fn move_empty_branch_on_top_of_empty_branch_across_stacks() -> anyhow::Result<()
         "refs/heads/B".try_into()?,
     )?;
 
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
     set_workspace_metadata(&mut meta, &ws, ws_meta)?;
     let project_meta = ws.graph.project_meta.clone();
     ws.refresh_from_head(&repo, &meta, project_meta)?;
@@ -839,7 +839,7 @@ fn non_empty_move_updates_metadata_and_keeps_display_order_aligned() -> anyhow::
         .map(|ws_meta| workspace_metadata_stack_order(ws_meta, StackKind::Applied))
         .unwrap_or_default();
 
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
     set_workspace_metadata(&mut meta, &ws, ws_meta)?;
 
     // before refreshing `ws` the pure-virtual change isn't visible (should be fixed once meta is in db!)
@@ -951,7 +951,7 @@ fn empty_move_keeps_display_order_aligned_with_metadata() -> anyhow::Result<()> 
         .map(|ws_meta| workspace_metadata_stack_order(ws_meta, StackKind::AppliedAndUnapplied))
         .unwrap_or_default();
 
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
     set_workspace_metadata(&mut meta, &ws, ws_meta)?;
     let project_meta = ws.graph.project_meta.clone();
     ws.refresh_from_head(&repo, &meta, project_meta)?;
@@ -1038,7 +1038,7 @@ fn move_branch_when_base_segment_has_no_ref_name() -> anyhow::Result<()> {
         "refs/heads/A".try_into()?,
     )?;
 
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
     set_workspace_metadata(&mut meta, &ws, ws_meta)?;
     let project_meta = ws.graph.project_meta.clone();
     ws.refresh_from_head(&repo, &meta, project_meta)?;
@@ -1125,7 +1125,7 @@ fn move_empty_branch_onto_non_empty_branch_with_advanced_target() -> anyhow::Res
         "refs/heads/A".try_into()?,
     )?;
 
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
     set_workspace_metadata(&mut meta, &ws, ws_meta)?;
     let project_meta = ws.graph.project_meta.clone();
     ws.refresh_from_head(&repo, &meta, project_meta)?;
@@ -1207,7 +1207,7 @@ fn move_non_empty_branch_onto_empty_branch_with_advanced_target() -> anyhow::Res
         "refs/heads/B".try_into()?,
     )?;
 
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
     set_workspace_metadata(&mut meta, &ws, ws_meta)?;
     let project_meta = ws.graph.project_meta.clone();
     ws.refresh_from_head(&repo, &meta, project_meta)?;
@@ -1364,7 +1364,7 @@ mod single_branch_mode {
             ws_meta.is_none(),
             "ad-hoc reorder lives in branch_order, not workspace metadata"
         );
-        rebase.materialize()?;
+        rebase.materialize(Default::default())?;
         persist_order(meta, &branch_stack_order)?;
         if let Some(new_tip) = new_tip {
             invoke_bash(&format!("git checkout {}\n", new_tip.shorten()), repo);
@@ -1491,7 +1491,7 @@ mod single_branch_mode {
             branch_stack_order,
             ..
         } = but_workspace::branch::move_branch(editor, r("refs/heads/empty-bottom"), main_ref)?;
-        rebase.materialize()?;
+        rebase.materialize(Default::default())?;
 
         // The subject is reported as the new tip so the caller can check it out.
         assert_eq!(
@@ -1530,7 +1530,7 @@ mod single_branch_mode {
             r("refs/heads/empty-bottom"),
             r("refs/heads/empty-top"),
         )?;
-        rebase.materialize()?;
+        rebase.materialize(Default::default())?;
 
         assert_eq!(
             new_tip, None,
@@ -1596,7 +1596,7 @@ mod single_branch_mode {
             ws_meta.is_none(),
             "ad-hoc reorder lives in branch_order, not workspace metadata"
         );
-        rebase.materialize()?;
+        rebase.materialize(Default::default())?;
         // A real (non-dry-run) caller persists the returned order.
         persist_order(&mut meta, &branch_stack_order)?;
 
@@ -1872,7 +1872,7 @@ mod single_branch_mode {
             r("refs/heads/empty-top"),
             r("refs/heads/base"),
         )?;
-        rebase.materialize()?;
+        rebase.materialize(Default::default())?;
 
         assert_eq!(new_tip, None, "base isn't the checked-out tip");
         // `empty-top` is placed directly above `base`; the rest of the order is preserved.
@@ -1967,7 +1967,7 @@ mod single_branch_mode {
             r("refs/heads/empty-bottom"),
             r("refs/heads/empty-top"),
         )?;
-        rebase.materialize()?;
+        rebase.materialize(Default::default())?;
 
         // A reorder is computed and returned...
         assert!(branch_stack_order.is_some());

--- a/crates/but-workspace/tests/workspace/branch/tear_off_branch.rs
+++ b/crates/but-workspace/tests/workspace/branch/tear_off_branch.rs
@@ -60,7 +60,7 @@ fn tear_off_top_most_branch() -> anyhow::Result<()> {
     )?;
 
     // Materialize the operation
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
     set_workspace_metadata(&mut meta, &ws, ws_meta)?;
     let project_meta = ws.graph.project_meta.clone();
     ws.refresh_from_head(&repo, &meta, project_meta)?;
@@ -154,7 +154,7 @@ fn tear_off_bottom_most_branch() -> anyhow::Result<()> {
     )?;
 
     // Materialize the operation
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
     set_workspace_metadata(&mut meta, &ws, ws_meta)?;
     let project_meta = ws.graph.project_meta.clone();
     ws.refresh_from_head(&repo, &meta, project_meta)?;
@@ -248,7 +248,7 @@ fn tear_off_only_branch_in_stack() -> anyhow::Result<()> {
     )?;
 
     // Materialize the operation
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
     set_workspace_metadata(&mut meta, &ws, ws_meta)?;
     let project_meta = ws.graph.project_meta.clone();
     ws.refresh_from_head(&repo, &meta, project_meta)?;
@@ -330,7 +330,7 @@ fn tear_off_from_single_stack_in_ws_top() -> anyhow::Result<()> {
     )?;
 
     // Materialize the operation
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
     set_workspace_metadata(&mut meta, &ws, ws_meta)?;
     let project_meta = ws.graph.project_meta.clone();
     ws.refresh_from_head(&repo, &meta, project_meta)?;
@@ -409,7 +409,7 @@ fn tear_off_from_single_stack_in_ws_bottom() -> anyhow::Result<()> {
     )?;
 
     // Materialize the operation
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
     set_workspace_metadata(&mut meta, &ws, ws_meta)?;
     let project_meta = ws.graph.project_meta.clone();
     ws.refresh_from_head(&repo, &meta, project_meta)?;
@@ -488,7 +488,7 @@ fn tear_off_empty_branch() -> anyhow::Result<()> {
     )?;
 
     // Materialize the operation
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
     set_workspace_metadata(&mut meta, &ws, ws_meta)?;
     let project_meta = ws.graph.project_meta.clone();
     ws.refresh_from_head(&repo, &meta, project_meta)?;
@@ -565,7 +565,7 @@ fn tear_off_non_empty_branch() -> anyhow::Result<()> {
     )?;
 
     // Materialize the operation
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
     set_workspace_metadata(&mut meta, &ws, ws_meta)?;
     let project_meta = ws.graph.project_meta.clone();
     ws.refresh_from_head(&repo, &meta, project_meta)?;

--- a/crates/but-workspace/tests/workspace/commit/cherry_pick.rs
+++ b/crates/but-workspace/tests/workspace/commit/cherry_pick.rs
@@ -35,7 +35,7 @@ fn insert_below_commit() -> anyhow::Result<()> {
         InsertSide::Below,
     )?
     .0
-    .materialize()?;
+    .materialize(Default::default())?;
 
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
@@ -79,7 +79,7 @@ fn insert_above_commit() -> anyhow::Result<()> {
         InsertSide::Above,
     )?
     .0
-    .materialize()?;
+    .materialize(Default::default())?;
 
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
@@ -121,7 +121,7 @@ fn insert_below_reference() -> anyhow::Result<()> {
         InsertSide::Below,
     )?
     .0
-    .materialize()?;
+    .materialize(Default::default())?;
 
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
@@ -168,7 +168,7 @@ fn sources_are_applied_in_the_order_given() -> anyhow::Result<()> {
         RelativeTo::Reference(a_ref),
         InsertSide::Below,
     )?;
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
 
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
@@ -226,7 +226,7 @@ fn sources_are_deduped() -> anyhow::Result<()> {
         1,
         "duplicate B should produce only one copy"
     );
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
 
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
@@ -263,7 +263,7 @@ fn copies_get_new_change_ids() -> anyhow::Result<()> {
         InsertSide::Below,
     )?;
     let copy = rebase.lookup_pick(inserted_selectors[0])?;
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
 
     assert_ne!(
         Commit::from_id(source.attach(&repo))?.change_id(),
@@ -290,7 +290,7 @@ fn copies_commit_contents() -> anyhow::Result<()> {
         InsertSide::Below,
     )?;
     let copy = rebase.lookup_pick(inserted_selectors[0])?;
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
 
     assert_eq!(
         repo.find_commit(copy)?.message_raw()?,
@@ -331,7 +331,7 @@ fn rebased_children_keep_contents() -> anyhow::Result<()> {
         InsertSide::Below,
     )?
     .0
-    .materialize()?;
+    .materialize(Default::default())?;
 
     let rebased_target = repo.rev_parse_single("A")?.detach();
     assert_eq!(

--- a/crates/but-workspace/tests/workspace/commit/commit_amend.rs
+++ b/crates/but-workspace/tests/workspace/commit/commit_amend.rs
@@ -60,7 +60,7 @@ fn amend_commit_smoke_test() -> Result<()> {
 
     assert!(outcome.rejected_specs.is_empty());
     let selector = outcome.commit_selector.expect("selector exists");
-    let materialized = outcome.rebase.materialize()?;
+    let materialized = outcome.rebase.materialize(Default::default())?;
     let rewritten_id = materialized.lookup_pick(selector)?;
 
     let rewritten_commit = repo.find_commit(rewritten_id)?;
@@ -116,7 +116,7 @@ fn amend_into_earlier_commit_leaves_no_uncommitted_changes() -> Result<()> {
 
     assert!(outcome.rejected_specs.is_empty());
     let _selector = outcome.commit_selector.expect("amend selector exists");
-    let _materialized = outcome.rebase.materialize()?;
+    let _materialized = outcome.rebase.materialize(Default::default())?;
 
     // No uncommitted changes should remain: the change was amended into
     // "save 1", so it must not persist as an uncommitted worktree change.
@@ -186,7 +186,7 @@ fn amend_with_two_stacks_preserves_uncommitted_deletions() -> Result<()> {
     let outcome = commit_amend(editor, a_commit_id, a_file_specs, 0, ChangeSource::Head)?;
 
     assert!(outcome.rejected_specs.is_empty());
-    let _materialized = outcome.rebase.materialize()?;
+    let _materialized = outcome.rebase.materialize(Default::default())?;
 
     // After amend: a-file.txt should no longer be modified (it was amended)
     // but b-file.txt should STILL be deleted (uncommitted deletion preserved)
@@ -314,7 +314,7 @@ mod from_worktree {
             outcome.rejected_specs
         );
         let selector = outcome.commit_selector.expect("a commit was amended");
-        let materialized = outcome.rebase.materialize()?;
+        let materialized = outcome.rebase.materialize(Default::default())?;
         let new_id = materialized.lookup_pick(selector)?;
 
         assert_eq!(
@@ -379,7 +379,7 @@ mod from_worktree {
             },
         )?;
         let selector = outcome.commit_selector.expect("a commit was amended");
-        let materialized = outcome.rebase.materialize()?;
+        let materialized = outcome.rebase.materialize(Default::default())?;
         let new_id = materialized.lookup_pick(selector)?;
 
         assert_eq!(
@@ -453,7 +453,7 @@ mod from_worktree {
             "{:?}",
             outcome.rejected_specs
         );
-        outcome.rebase.materialize()?;
+        outcome.rebase.materialize(Default::default())?;
 
         snapbox::assert_data_eq!(
             git_status_at_dir(repo.workdir().unwrap())?,
@@ -576,7 +576,7 @@ mod from_worktree {
             outcome.rejected_specs
         );
         let selector = outcome.commit_selector.expect("a commit was created");
-        let materialized = outcome.rebase.materialize()?;
+        let materialized = outcome.rebase.materialize(Default::default())?;
         let new_id = materialized.lookup_pick(selector)?;
 
         assert_eq!(

--- a/crates/but-workspace/tests/workspace/commit/commit_create.rs
+++ b/crates/but-workspace/tests/workspace/commit/commit_create.rs
@@ -43,7 +43,7 @@ fn commit_above_commit() -> Result<()> {
     let selector = outcome
         .commit_selector
         .expect("a selector for the new commit");
-    let materialized = outcome.rebase.materialize()?;
+    let materialized = outcome.rebase.materialize(Default::default())?;
     let new_commit_id = materialized.lookup_pick(selector)?;
 
     let new_commit = repo.find_commit(new_commit_id)?;
@@ -91,7 +91,7 @@ fn commit_below_commit() -> Result<()> {
     let selector = outcome
         .commit_selector
         .expect("a selector for the new commit");
-    let materialized = outcome.rebase.materialize()?;
+    let materialized = outcome.rebase.materialize(Default::default())?;
     let new_commit_id = materialized.lookup_pick(selector)?;
 
     let new_commit = repo.find_commit(new_commit_id)?;
@@ -133,7 +133,7 @@ fn commit_above_reference() -> Result<()> {
     let selector = outcome
         .commit_selector
         .expect("a selector for the new commit");
-    let materialized = outcome.rebase.materialize()?;
+    let materialized = outcome.rebase.materialize(Default::default())?;
     let new_commit_id = materialized.lookup_pick(selector)?;
 
     let new_commit = repo.find_commit(new_commit_id)?;
@@ -186,7 +186,7 @@ fn commit_below_merge_commit_uses_first_parent() -> Result<()> {
     let selector = outcome
         .commit_selector
         .expect("a selector for the new commit");
-    let materialized = outcome.rebase.materialize()?;
+    let materialized = outcome.rebase.materialize(Default::default())?;
     let new_commit_id = materialized.lookup_pick(selector)?;
 
     let new_commit = repo.find_commit(new_commit_id)?;

--- a/crates/but-workspace/tests/workspace/commit/discard_commit.rs
+++ b/crates/but-workspace/tests/workspace/commit/discard_commit.rs
@@ -31,7 +31,7 @@ fn discard_middle_commit_in_non_managed_workspace() -> Result<()> {
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     let outcome = discard_commits(editor, [two.detach()])?;
 
-    outcome.materialize()?;
+    outcome.materialize(Default::default())?;
 
     let tip_of_two = repo.rev_parse_single("two")?;
     assert_eq!(tip_of_two, one, "The tip of two should now point to one");
@@ -119,7 +119,7 @@ fn discard_tip_commit_in_workspace_stack() -> Result<()> {
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     let outcome = discard_commits(editor, [c.detach()])?;
 
-    let outcome = outcome.materialize()?;
+    let outcome = outcome.materialize(Default::default())?;
     snapbox::assert_data_eq!(
         graph_workspace(outcome.workspace).to_string(),
         snapbox::str![[r#"
@@ -204,7 +204,7 @@ fn discard_bottom_commit_in_workspace_stack() -> Result<()> {
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     let outcome = discard_commits(editor, [b.detach()])?;
 
-    let outcome = outcome.materialize()?;
+    let outcome = outcome.materialize(Default::default())?;
     snapbox::assert_data_eq!(
         graph_workspace(outcome.workspace).to_string(),
         snapbox::str![[r#"
@@ -272,7 +272,7 @@ fn can_discard_conflicted_commit() -> Result<()> {
     let editor = Editor::create(&mut ws, &mut meta, &repo)?;
     let outcome = discard_commits(editor, [conflicted.detach()])?;
 
-    outcome.materialize()?;
+    outcome.materialize(Default::default())?;
 
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
@@ -310,7 +310,7 @@ fn discard_multiple_commits_in_single_rebase() -> Result<()> {
     // Discard both two and three in a single operation.
     let outcome = discard_commits(editor, [two.into(), three.into()])?;
 
-    outcome.materialize()?;
+    outcome.materialize(Default::default())?;
 
     let tip_of_two = repo.rev_parse_single("two")?;
     assert_eq!(tip_of_two, one, "two should now point to one");
@@ -382,7 +382,7 @@ fn discard_both_commits_in_workspace_stack() -> Result<()> {
     // Discard both B and C in one rebase.
     let outcome = discard_commits(editor, [b.into(), c.into()])?;
 
-    outcome.materialize()?;
+    outcome.materialize(Default::default())?;
 
     let tip_of_b = repo.rev_parse_single("B")?;
     assert_eq!(tip_of_b, main, "B should now point to main");

--- a/crates/but-workspace/tests/workspace/commit/insert_blank_commit.rs
+++ b/crates/but-workspace/tests/workspace/commit/insert_blank_commit.rs
@@ -33,7 +33,7 @@ fn insert_below_commit() -> Result<()> {
         RelativeToRef::Commit(id.detach()),
     )?
     .0
-    .materialize()?;
+    .materialize(Default::default())?;
 
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
@@ -78,7 +78,7 @@ fn insert_above_commit() -> Result<()> {
         RelativeToRef::Commit(id.detach()),
     )?
     .0
-    .materialize()?;
+    .materialize(Default::default())?;
 
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
@@ -121,7 +121,7 @@ fn insert_below_reference() -> Result<()> {
         RelativeToRef::Reference(reference.name()),
     )?
     .0
-    .materialize()?;
+    .materialize(Default::default())?;
 
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
@@ -164,7 +164,7 @@ fn insert_above_reference() -> Result<()> {
         RelativeToRef::Reference(reference.name()),
     )?
     .0
-    .materialize()?;
+    .materialize(Default::default())?;
 
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,

--- a/crates/but-workspace/tests/workspace/commit/move_changes.rs
+++ b/crates/but-workspace/tests/workspace/commit/move_changes.rs
@@ -43,7 +43,7 @@ fn move_changes_same_commit_is_noop() -> Result<()> {
         move_changes_between_commits(editor, commit_id, commit_id, Vec::<DiffSpec>::new(), 0)?;
 
     // Materialize should succeed
-    outcome.rebase.materialize()?;
+    outcome.rebase.materialize(Default::default())?;
 
     // Graph should be unchanged
     snapbox::assert_data_eq!(
@@ -113,7 +113,7 @@ aac5238
         0,
     )?;
 
-    let materialized = outcome.rebase.materialize()?;
+    let materialized = outcome.rebase.materialize(Default::default())?;
     snapbox::assert_data_eq!(
         materialized.history.commit_mappings().to_debug(),
         snapbox::str![[r#"
@@ -201,7 +201,7 @@ fn move_file_from_parent_to_head() -> Result<()> {
         0,
     )?;
 
-    let materialized = outcome.rebase.materialize()?;
+    let materialized = outcome.rebase.materialize(Default::default())?;
     snapbox::assert_data_eq!(
         materialized.history.commit_mappings().to_debug(),
         snapbox::str![[r#"
@@ -287,7 +287,7 @@ fn move_file_between_non_adjacent_commits() -> Result<()> {
         0,
     )?;
 
-    let materialized = outcome.rebase.materialize()?;
+    let materialized = outcome.rebase.materialize(Default::default())?;
     snapbox::assert_data_eq!(
         materialized.history.commit_mappings().to_debug(),
         snapbox::str![[r#"

--- a/crates/but-workspace/tests/workspace/commit/move_commit.rs
+++ b/crates/but-workspace/tests/workspace/commit/move_commit.rs
@@ -77,7 +77,7 @@ fn move_top_commit_to_top_of_another_stack() -> anyhow::Result<()> {
     )?;
 
     // Materialize the operation
-    let materialization = rebase.materialize()?;
+    let materialization = rebase.materialize(Default::default())?;
     let commit_mapping = materialization.history.commit_mappings();
     let project_meta = ws.graph.project_meta.clone();
     ws.refresh_from_head(&repo, &meta, project_meta)?;
@@ -187,7 +187,7 @@ fn move_bottom_commit_to_top_of_another_stack() -> anyhow::Result<()> {
     )?;
 
     // Materialize the operation
-    let materialization = rebase.materialize()?;
+    let materialization = rebase.materialize(Default::default())?;
     let commit_mapping = materialization.history.commit_mappings();
     let project_meta = ws.graph.project_meta.clone();
     ws.refresh_from_head(&repo, &meta, project_meta)?;
@@ -299,7 +299,7 @@ fn move_top_commit_to_bottom_of_another_stack() -> anyhow::Result<()> {
     )?;
 
     // Materialize the operation
-    let materialization = rebase.materialize()?;
+    let materialization = rebase.materialize(Default::default())?;
     let commit_mapping = materialization.history.commit_mappings();
     let project_meta = ws.graph.project_meta.clone();
     ws.refresh_from_head(&repo, &meta, project_meta)?;
@@ -409,7 +409,7 @@ fn move_bottom_commit_to_bottom_of_another_stack() -> anyhow::Result<()> {
     )?;
 
     // Materialize the operation
-    let materialization = rebase.materialize()?;
+    let materialization = rebase.materialize(Default::default())?;
     let commit_mapping = materialization.history.commit_mappings();
     let project_meta = ws.graph.project_meta.clone();
     ws.refresh_from_head(&repo, &meta, project_meta)?;
@@ -520,7 +520,7 @@ fn move_single_commit_to_the_top_of_another_branch() -> anyhow::Result<()> {
     )?;
 
     // Materialize the operation
-    let materialization = rebase.materialize()?;
+    let materialization = rebase.materialize(Default::default())?;
     let commit_mapping = materialization.history.commit_mappings();
     let project_meta = ws.graph.project_meta.clone();
     ws.refresh_from_head(&repo, &meta, project_meta)?;
@@ -624,7 +624,7 @@ fn move_single_commit_to_the_bottom_of_another_branch() -> anyhow::Result<()> {
     )?;
 
     // Materialize the operation
-    let materialization = rebase.materialize()?;
+    let materialization = rebase.materialize(Default::default())?;
     let commit_mapping = materialization.history.commit_mappings();
     let project_meta = ws.graph.project_meta.clone();
     ws.refresh_from_head(&repo, &meta, project_meta)?;
@@ -726,7 +726,7 @@ fn move_commit_to_empty_branch() -> anyhow::Result<()> {
     )?;
 
     // Materialize the operation
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
     let project_meta = ws.graph.project_meta.clone();
     ws.refresh_from_head(&repo, &meta, project_meta)?;
 
@@ -809,7 +809,7 @@ fn move_commit_in_non_managed_workspace() -> anyhow::Result<()> {
     )?;
 
     // Materialize the operation
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
     let project_meta = ws.graph.project_meta.clone();
     ws.refresh_from_head(&repo, &meta, project_meta)?;
 
@@ -903,7 +903,7 @@ fn reorder_merge_commit_above_keeps_child_commits_visible() -> anyhow::Result<()
         InsertSide::Above,
     )?;
 
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
     let project_meta = ws.graph.project_meta.clone();
     ws.refresh_from_head(&repo, &meta, project_meta)?;
 
@@ -987,7 +987,7 @@ fn reorder_merge_commit_below_keeps_child_commits_visible() -> anyhow::Result<()
         InsertSide::Below,
     )?;
 
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
     let project_meta = ws.graph.project_meta.clone();
     ws.refresh_from_head(&repo, &meta, project_meta)?;
 
@@ -1064,7 +1064,7 @@ fn reorder_commit_in_non_managed_workspace() -> anyhow::Result<()> {
     )?;
 
     // Materialize the operation
-    let materialization = rebase.materialize()?;
+    let materialization = rebase.materialize(Default::default())?;
     let commit_mappings = materialization.history.commit_mappings();
     let project_meta = ws.graph.project_meta.clone();
     ws.refresh_from_head(&repo, &meta, project_meta)?;
@@ -1161,7 +1161,7 @@ fn move_mixed_main_and_worktree_commits_to_another_worktree() -> anyhow::Result<
         RelativeTo::Reference("refs/heads/other".try_into()?),
         InsertSide::Below,
     )?
-    .materialize()?;
+    .materialize(Default::default())?;
 
     // Both moved commits land on `other` and `main` falls back onto `stack-base`. The
     // placeholder left where `feat`'s commit sat keeps `feat` directly above `other`, so

--- a/crates/but-workspace/tests/workspace/commit/reword.rs
+++ b/crates/but-workspace/tests/workspace/commit/reword.rs
@@ -25,7 +25,7 @@ fn reword_head_commit() -> Result<()> {
     let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
     reword(editor, id.detach(), b"New name".into())?
         .0
-        .materialize()?;
+        .materialize(Default::default())?;
 
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
@@ -62,7 +62,7 @@ fn reword_middle_commit() -> Result<()> {
     let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
     reword(editor, id.detach(), b"New name".into())?
         .0
-        .materialize()?;
+        .materialize(Default::default())?;
 
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
@@ -101,7 +101,7 @@ fn reword_base_commit() -> Result<()> {
     let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
     reword(editor, id.detach(), b"New name".into())?
         .0
-        .materialize()?;
+        .materialize(Default::default())?;
 
     // We end up with two divergent histories here. This is to be expected if we
     // rewrite the very bottom commit in a repository.

--- a/crates/but-workspace/tests/workspace/commit/squash_commits.rs
+++ b/crates/but-workspace/tests/workspace/commit/squash_commits.rs
@@ -38,7 +38,7 @@ fn squash_top_commit_into_parent() -> Result<()> {
         squash_commits::MessageCombinationStrategy::KeepBoth,
     )?;
 
-    let materialized = outcome.rebase.materialize()?;
+    let materialized = outcome.rebase.materialize(Default::default())?;
     let squashed_id = materialized.lookup_pick(outcome.commit_selector)?;
 
     let squashed_commit = repo.find_commit(squashed_id)?;
@@ -105,7 +105,7 @@ fn squash_top_commit_into_parent_keeping_target_message() -> Result<()> {
         squash_commits::MessageCombinationStrategy::KeepTarget,
     )?;
 
-    let materialized = outcome.rebase.materialize()?;
+    let materialized = outcome.rebase.materialize(Default::default())?;
     let squashed_id = materialized.lookup_pick(outcome.commit_selector)?;
 
     let squashed_commit = repo.find_commit(squashed_id)?;
@@ -145,7 +145,7 @@ fn squash_top_commit_into_parent_keeping_subject_message() -> Result<()> {
         squash_commits::MessageCombinationStrategy::KeepSubject,
     )?;
 
-    let materialized = outcome.rebase.materialize()?;
+    let materialized = outcome.rebase.materialize(Default::default())?;
     let squashed_id = materialized.lookup_pick(outcome.commit_selector)?;
 
     let squashed_commit = repo.find_commit(squashed_id)?;
@@ -187,7 +187,7 @@ fn squash_reorders_when_subject_is_not_on_top() -> Result<()> {
         squash_commits::MessageCombinationStrategy::KeepBoth,
     )?;
 
-    let materialized = outcome.rebase.materialize()?;
+    let materialized = outcome.rebase.materialize(Default::default())?;
     let squashed_id = materialized.lookup_pick(outcome.commit_selector)?;
 
     let squashed_commit = repo.find_commit(squashed_id)?;
@@ -233,7 +233,7 @@ fn squash_deduplicates_duplicate_subjects() -> Result<()> {
         squash_commits::MessageCombinationStrategy::KeepBoth,
     )?;
 
-    let materialized = outcome.rebase.materialize()?;
+    let materialized = outcome.rebase.materialize(Default::default())?;
     let squashed_id = materialized.lookup_pick(outcome.commit_selector)?;
     let squashed_commit = repo.find_commit(squashed_id)?;
 
@@ -346,7 +346,7 @@ fn squash_down_keeps_topmost_tree_for_shared_file_lineage() -> Result<()> {
         squash_commits::MessageCombinationStrategy::KeepBoth,
     )?;
 
-    let materialized = outcome.rebase.materialize()?;
+    let materialized = outcome.rebase.materialize(Default::default())?;
     let squashed_id = materialized.lookup_pick(outcome.commit_selector)?;
 
     let spec = format!("{squashed_id}:shared.txt");
@@ -392,7 +392,7 @@ fn squash_move_subject_below_target_for_shared_file_lineage() -> Result<()> {
         squash_commits::MessageCombinationStrategy::KeepBoth,
     )?;
 
-    let materialized = outcome.rebase.materialize()?;
+    let materialized = outcome.rebase.materialize(Default::default())?;
     let squashed_id = materialized.lookup_pick(outcome.commit_selector)?;
 
     let spec = format!("{squashed_id}:shared.txt");
@@ -511,7 +511,7 @@ fn squash_across_stacks_subject_into_target() -> Result<()> {
         squash_commits::MessageCombinationStrategy::KeepBoth,
     )?;
 
-    let materialized = outcome.rebase.materialize()?;
+    let materialized = outcome.rebase.materialize(Default::default())?;
     let squashed_id = materialized.lookup_pick(outcome.commit_selector)?;
 
     let squashed_commit = repo.find_commit(squashed_id)?;
@@ -597,7 +597,7 @@ fn squash_across_stacks_target_into_subject() -> Result<()> {
         squash_commits::MessageCombinationStrategy::KeepBoth,
     )?;
 
-    let materialized = outcome.rebase.materialize()?;
+    let materialized = outcome.rebase.materialize(Default::default())?;
     let squashed_id = materialized.lookup_pick(outcome.commit_selector)?;
 
     let squashed_commit = repo.find_commit(squashed_id)?;
@@ -668,7 +668,7 @@ fn squash_cross_stack_commit_does_not_pull_in_ancestor_tree_state() -> Result<()
         squash_commits::MessageCombinationStrategy::KeepBoth,
     )?;
 
-    let materialized = outcome.rebase.materialize()?;
+    let materialized = outcome.rebase.materialize(Default::default())?;
     let squashed_id = materialized.lookup_pick(outcome.commit_selector)?;
 
     let file_a = repo
@@ -742,7 +742,7 @@ fn squash_cross_stack_commit_with_deeper_stacks_does_not_pull_in_ancestor_tree_s
         squash_commits::MessageCombinationStrategy::KeepBoth,
     )?;
 
-    let materialized = outcome.rebase.materialize()?;
+    let materialized = outcome.rebase.materialize(Default::default())?;
     let squashed_id = materialized.lookup_pick(outcome.commit_selector)?;
 
     let normalized = visualize_commit_graph_all(&repo)?.replace("  \n", "\n");
@@ -921,7 +921,7 @@ fn squash_all_c_commits_into_second_commit_of_b_keeps_new_file_content() -> Resu
         squash_commits::MessageCombinationStrategy::KeepBoth,
     )?;
 
-    let materialized = outcome.rebase.materialize()?;
+    let materialized = outcome.rebase.materialize(Default::default())?;
     let squashed_id = materialized.lookup_pick(outcome.commit_selector)?;
 
     let new_file_blob = repo

--- a/crates/but-workspace/tests/workspace/commit/uncommit_changes.rs
+++ b/crates/but-workspace/tests/workspace/commit/uncommit_changes.rs
@@ -141,7 +141,7 @@ e0495e9
     let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
     let outcome = uncommit_changes(editor, three_id, vec![diff_spec_for_file("three.txt")], 0)?;
 
-    let materialized = outcome.rebase.materialize()?;
+    let materialized = outcome.rebase.materialize(Default::default())?;
     let new_commit_id = materialized.lookup_pick(outcome.commit_selector)?;
 
     // Graph structure should be maintained (commit hash will change)
@@ -205,7 +205,7 @@ aac5238
     let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
     let outcome = uncommit_changes(editor, two_id, vec![diff_spec_for_file("two.txt")], 0)?;
 
-    let materialized = outcome.rebase.materialize()?;
+    let materialized = outcome.rebase.materialize(Default::default())?;
     let new_commit_id = materialized.lookup_pick(outcome.commit_selector)?;
 
     // Graph structure should be maintained
@@ -283,7 +283,7 @@ fn uncommit_file_from_root_commit() -> Result<()> {
     let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
     let outcome = uncommit_changes(editor, one_id, vec![diff_spec_for_file("one.txt")], 0)?;
 
-    let materialized = outcome.rebase.materialize()?;
+    let materialized = outcome.rebase.materialize(Default::default())?;
     let new_commit_id = materialized.lookup_pick(outcome.commit_selector)?;
 
     // Graph structure should be maintained
@@ -362,7 +362,7 @@ fn uncommit_empty_changes_is_noop() -> Result<()> {
     let editor = Editor::create(&mut ws, &mut _meta, &repo)?;
     let outcome = uncommit_changes(editor, three_id, Vec::<DiffSpec>::new(), 0)?;
 
-    outcome.rebase.materialize()?;
+    outcome.rebase.materialize(Default::default())?;
 
     // Graph should be unchanged
     snapbox::assert_data_eq!(

--- a/crates/but-workspace/tests/workspace/upstream_integration.rs
+++ b/crates/but-workspace/tests/workspace/upstream_integration.rs
@@ -82,7 +82,7 @@ fn diamond_partially_historically_integrated_rebase() -> Result<()> {
         }],
     )?;
 
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
 
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
@@ -169,7 +169,7 @@ fn diamond_partially_historically_integrated_merge() -> Result<()> {
         }],
     )?;
 
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
 
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
@@ -269,7 +269,7 @@ fn diamond_partially_content_integrated_rebase() -> Result<()> {
         }],
     )?;
 
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
 
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
@@ -346,7 +346,7 @@ fn diamond_partially_content_integrated_merge() -> Result<()> {
         }],
     )?;
 
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
 
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
@@ -438,7 +438,7 @@ fn integrated_bottom_branch_no_workspace_rebase() -> Result<()> {
         }],
     )?;
 
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
 
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
@@ -504,7 +504,7 @@ fn integrated_bottom_branch_does_not_delete_local_main_or_master() -> Result<()>
             selector: RelativeTo::Commit(integrated_bottom_commit),
         }],
     )?;
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
 
     assert!(
         repo.try_find_reference("B")?.is_none(),
@@ -587,7 +587,7 @@ fn integrated_bottom_branch_no_workspace_merge() -> Result<()> {
         }],
     )?;
 
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
 
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
@@ -668,7 +668,7 @@ fn merge_upstream_with_conflicting_target_materializes_conflicted_merge_commit()
         }],
     )?;
 
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
 
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
@@ -1007,7 +1007,7 @@ fn non_bottom_update_selector_does_not_prune_fully_integrated_stack() -> Result<
         1,
         "non-bottom update selectors should not mark integrated stacks as selected for pruning"
     );
-    out.rebase.materialize()?;
+    out.rebase.materialize(Default::default())?;
 
     assert!(
         repo.try_find_reference("A")?.is_some(),
@@ -1175,7 +1175,7 @@ fn fully_integrated_direct_checkout_creates_unique_canned_branch_at_target_tip()
     );
     drop(preview);
 
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
 
     assert!(
         repo.try_find_reference("A")?.is_none(),
@@ -1262,7 +1262,7 @@ fn fully_integrated_direct_checkout_creates_canned_branch_at_merge_target_tip() 
     );
     drop(preview);
 
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
 
     assert!(
         repo.try_find_reference("A")?.is_none(),
@@ -2078,7 +2078,7 @@ fn empty_branch_with_integrated_remote_tip_is_removed() -> Result<()> {
         ws_meta.stacks.is_empty(),
         "workspace metadata should no longer expose the integrated empty branch"
     );
-    out.rebase.materialize()?;
+    out.rebase.materialize(Default::default())?;
     let graph = but_graph::Graph::from_head(&repo, &meta, project_meta, Options::limited())?;
     let workspace = graph.into_workspace()?;
     snapbox::assert_data_eq!(
@@ -2283,7 +2283,7 @@ fn empty_branch_above_integrated_branch_is_preserved() -> Result<()> {
         vec!["top"],
         "workspace metadata should retain only the unmerged empty top branch"
     );
-    out.rebase.materialize()?;
+    out.rebase.materialize(Default::default())?;
     let graph = but_graph::Graph::from_head(&repo, &meta, project_meta, Options::limited())?;
     let workspace = graph.into_workspace()?;
     snapbox::assert_data_eq!(
@@ -2442,7 +2442,7 @@ fn review_hint_fully_integrates_direct_checkout_branch() -> Result<()> {
             head_commit_at_merge: review_head,
         }],
     )?;
-    out.rebase.materialize()?;
+    out.rebase.materialize(Default::default())?;
 
     assert!(
         repo.try_find_reference("A")?.is_none(),
@@ -2526,7 +2526,7 @@ fn review_hint_integrates_squashed_two_commit_stack_in_managed_workspace() -> Re
             head_commit_at_merge: review_head,
         }],
     )?;
-    out.rebase.materialize()?;
+    out.rebase.materialize(Default::default())?;
 
     let graph = but_graph::Graph::from_head(&repo, &meta, project_meta, Options::limited())?;
     let workspace = graph.into_workspace()?;
@@ -2633,7 +2633,7 @@ fn review_hint_integrates_squashed_two_commit_direct_checkout_branch() -> Result
             head_commit_at_merge: review_head,
         }],
     )?;
-    out.rebase.materialize()?;
+    out.rebase.materialize(Default::default())?;
     let graph = but_graph::Graph::from_head(&repo, &meta, project_meta, Options::limited())?;
     let workspace = graph.into_workspace()?;
     snapbox::assert_data_eq!(
@@ -2829,7 +2829,7 @@ fn review_hint_integrates_squashed_prefix_and_keeps_extra_commit_in_direct_check
             head_commit_at_merge: review_head,
         }],
     )?;
-    rebase.materialize()?;
+    rebase.materialize(Default::default())?;
 
     let graph = but_graph::Graph::from_commit_traversal_tips(
         &repo,
@@ -2919,7 +2919,7 @@ fn review_hint_integrates_prefix_but_keeps_extra_local_commit() -> Result<()> {
             head_commit_at_merge: review_head,
         }],
     )?;
-    out.rebase.materialize()?;
+    out.rebase.materialize(Default::default())?;
 
     assert!(
         repo.try_find_reference("A")?.is_some(),
@@ -2953,7 +2953,7 @@ fn integrate_and_materialize<M: RefMetadata>(
         ws_meta,
         project_meta,
     } = integrate_upstream(workspace, meta, current_project_meta, repo, updates)?;
-    let materialized = rebase.materialize()?;
+    let materialized = rebase.materialize(Default::default())?;
     if let Some(ref_name) = materialized.workspace.ref_name()
         && let Some(ws_meta) = ws_meta
     {
@@ -2995,7 +2995,7 @@ fn integrate_with_hints_and_materialize<M: RefMetadata>(
         updates,
         review_hints,
     )?;
-    let materialized = rebase.materialize()?;
+    let materialized = rebase.materialize(Default::default())?;
     if let Some(ref_name) = materialized.workspace.ref_name()
         && let Some(ws_meta) = ws_meta
     {

--- a/crates/but-worktrees/src/integrate.rs
+++ b/crates/but-worktrees/src/integrate.rs
@@ -87,7 +87,7 @@ pub fn worktree_integrate<M: RefMetadata>(
     // checkout. Uncommitted changes that would conflict abort the operation
     // before any ref is touched.
     rebase
-        .materialize()
+        .materialize(Default::default())
         .context("Failed to integrate worktree into the workspace")?;
 
     git_worktree_remove(repo.common_dir(), id, true)?;

--- a/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/mod.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/mod.rs
@@ -361,7 +361,7 @@ pub fn create_commit(
         )
         .and_then(|outcome| {
             let selector = outcome.commit_selector;
-            let materialized = outcome.rebase.materialize()?;
+            let materialized = outcome.rebase.materialize(Default::default())?;
             selector
                 .map(|selector| materialized.lookup_pick(selector))
                 .transpose()


### PR DESCRIPTION
The changes touch many files, but besides the change to `crates/but-rebase/src/graph_rebase/materialize.rs`, the changes are trivial, so hopefully this is easy to review.

---

In the future, it will need another parameter that controls how conflicts during checkouts are reported. Therefore, perform a preliminary refactor to add an options struct parameter.
