### PR TITLE
refactor(but): re-implement `unapply` using new command structure

### DIFF
--- a/crates/but/src/args/atoms/cli_id.rs
+++ b/crates/but/src/args/atoms/cli_id.rs
@@ -1,3 +1,4 @@
+use but_core::ref_metadata::StackId;
 use nonempty::NonEmpty;
 use serde::Serialize;
 
@@ -93,7 +94,7 @@ impl CliIdArg {
                 ResolvedCliIdArg::CommittedFile(committed_file)
             }
             CliId::Uncommitted { .. } => ResolvedCliIdArg::Uncommitted,
-            CliId::Stack { .. } => ResolvedCliIdArg::Stack,
+            CliId::Stack { id, stack_id } => ResolvedCliIdArg::Stack { id, stack_id },
         }))
     }
 
@@ -415,7 +416,10 @@ pub enum ResolvedCliIdArg {
         id: String,
         hunks: NonEmpty<IdAndHunk>,
     },
-    Stack,
+    Stack {
+        id: String,
+        stack_id: StackId,
+    },
 }
 
 impl ResolvedCliIdArg {
@@ -431,6 +435,18 @@ impl ResolvedCliIdArg {
         Err(bad_input(format!("Expected a commit or a branch, got {kind}")).into())
     }
 
+    /// Convert this into a branch or stack.
+    pub fn into_branch_or_stack(self) -> CliResult<BranchOrStack> {
+        let kind = match self {
+            ResolvedCliIdArg::Branch(branch) => return Ok(BranchOrStack::Branch(branch)),
+            ResolvedCliIdArg::Stack { id, stack_id } => {
+                return Ok(BranchOrStack::Stack { id, stack_id });
+            }
+            other => other.kind_for_humans(),
+        };
+        Err(bad_input(format!("Expected a branch or a stack, got {kind}")).into())
+    }
+
     /// Returns a human-readable description of the entity type.
     pub fn kind_for_humans(&self) -> &'static str {
         match self {
@@ -440,7 +456,7 @@ impl ResolvedCliIdArg {
             ResolvedCliIdArg::Branch { .. } => "a branch",
             ResolvedCliIdArg::Commit { .. } => "a commit",
             ResolvedCliIdArg::Uncommitted => "uncommitted changes",
-            ResolvedCliIdArg::Stack => "a stack",
+            ResolvedCliIdArg::Stack { .. } => "a stack",
         }
     }
 
@@ -459,7 +475,10 @@ impl ResolvedCliIdArg {
                 ResolvedCliIdArgRef::PathPrefix { id, hunks }
             }
             ResolvedCliIdArg::Uncommitted => ResolvedCliIdArgRef::Uncommitted,
-            ResolvedCliIdArg::Stack => ResolvedCliIdArgRef::Stack,
+            ResolvedCliIdArg::Stack { id, stack_id } => ResolvedCliIdArgRef::Stack {
+                id,
+                stack_id: *stack_id,
+            },
         }
     }
 }
@@ -506,9 +525,17 @@ impl PartialEq<CliId> for ResolvedCliIdArg {
                     return lhs_id == rhs_id && lhs_hunks == rhs_hunks;
                 }
             }
-            ResolvedCliIdArg::Stack => {
-                // stacks are being phased out of the cli so ignore them for now
-                return false;
+            ResolvedCliIdArg::Stack {
+                stack_id: lhs,
+                id: _,
+            } => {
+                if let CliId::Stack {
+                    stack_id: rhs,
+                    id: _,
+                } = other
+                {
+                    return lhs == rhs;
+                }
             }
         }
         false
@@ -524,7 +551,7 @@ impl std::fmt::Display for ResolvedCliIdArg {
             ResolvedCliIdArg::PathPrefix { .. } => f.write_str("path"),
             ResolvedCliIdArg::CommittedFile(..) => f.write_str("committed file"),
             ResolvedCliIdArg::Uncommitted => f.write_str("uncommitted changes"),
-            ResolvedCliIdArg::Stack => f.write_str("stack"),
+            ResolvedCliIdArg::Stack { .. } => f.write_str("stack"),
         }
     }
 }
@@ -542,7 +569,10 @@ pub enum ResolvedCliIdArgRef<'a> {
         hunks: &'a NonEmpty<IdAndHunk>,
     },
     Uncommitted,
-    Stack,
+    Stack {
+        id: &'a str,
+        stack_id: StackId,
+    },
 }
 
 /// Most commands need cli ids that point to either branches or commits.
@@ -561,4 +591,11 @@ impl std::fmt::Display for BranchOrCommit {
             BranchOrCommit::Branch(inner) => inner.fmt(f),
         }
     }
+}
+
+#[derive(Debug, Clone)]
+#[expect(missing_docs)]
+pub enum BranchOrStack {
+    Branch(BranchArg),
+    Stack { id: String, stack_id: StackId },
 }

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -469,10 +469,7 @@ pub enum Subcommands {
     ///
     #[cfg(feature = "legacy")]
     #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
-    Unapply {
-        /// CLI ID or name of the branch/stack to unapply
-        identifier: String,
-    },
+    Unapply(unapply::Platform),
 
     /// Apply a branch to the workspace.
     ///
@@ -1145,6 +1142,8 @@ pub mod skill;
 pub mod squash;
 #[cfg(feature = "legacy")]
 pub mod tui;
+#[cfg(feature = "legacy")]
+pub mod unapply;
 #[cfg(feature = "legacy")]
 pub mod uncommit;
 pub mod update;

--- a/crates/but/src/args/unapply.rs
+++ b/crates/but/src/args/unapply.rs
@@ -1,0 +1,16 @@
+//! Arguments for `unapply`.
+
+#![deny(missing_docs)]
+
+use crate::args::atoms::CliIdArg;
+
+/// Unapply a branch or stack.
+///
+/// For more details about CLI IDs, see `but help cli-ids`.
+#[derive(Debug, clap::Parser)]
+#[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
+pub struct Platform {
+    /// The branch or stack to unapply.
+    #[clap(value_name = "BRANCH_OR_STACK")]
+    pub target: CliIdArg,
+}

--- a/crates/but/src/command/legacy/diff2.rs
+++ b/crates/but/src/command/legacy/diff2.rs
@@ -441,7 +441,7 @@ fn resolve(ctx: &Context, id_map: &IdMap, args: Platform) -> CliResult<DiffOpera
             path,
         }),
         ResolvedCliIdArg::PathPrefix { id, hunks } => Ok(DiffOperation::PathPrefix { id, hunks }),
-        ResolvedCliIdArg::Stack => {
+        ResolvedCliIdArg::Stack { .. } => {
             Err(bad_input("viewing diffs for stack assignments is not supported").into())
         }
     }

--- a/crates/but/src/command/legacy/discard.rs
+++ b/crates/but/src/command/legacy/discard.rs
@@ -291,7 +291,7 @@ fn resolve(repo: &gix::Repository, id_map: &IdMap, args: Platform) -> CliResult<
             ResolvedCliIdArg::PathPrefix { id: _, hunks } => {
                 uncommitted_change_sources.push(UncommittedDiscardSource::PathPrefix(hunks))
             }
-            ResolvedCliIdArg::Stack => {
+            ResolvedCliIdArg::Stack { .. } => {
                 return Err(bad_input("Stacks cannot be discarded")
                     .arg_name("<CHANGES>")
                     .arg_value(value)

--- a/crates/but/src/command/legacy/pick.rs
+++ b/crates/but/src/command/legacy/pick.rs
@@ -181,7 +181,7 @@ fn resolve(
                         | ResolvedCliIdArg::CommittedFile(..)
                         | ResolvedCliIdArg::Uncommitted
                         | ResolvedCliIdArg::PathPrefix { .. }
-                        | ResolvedCliIdArg::Stack => Err(bad_input(format!(
+                        | ResolvedCliIdArg::Stack { .. } => Err(bad_input(format!(
                             "Only commits can be cherry-picked. {} is {}",
                             source,
                             resolved.kind_for_humans()

--- a/crates/but/src/command/legacy/squash.rs
+++ b/crates/but/src/command/legacy/squash.rs
@@ -850,7 +850,7 @@ pub fn resolve_target(
         ResolvedCliIdArgRef::UncommittedHunkOrFile(..)
         | ResolvedCliIdArgRef::CommittedFile { .. }
         | ResolvedCliIdArgRef::PathPrefix { .. }
-        | ResolvedCliIdArgRef::Stack => Err(ResolveTargetError::InvalidTarget),
+        | ResolvedCliIdArgRef::Stack { .. } => Err(ResolveTargetError::InvalidTarget),
     }
 }
 
@@ -1055,7 +1055,7 @@ impl<'a> Squashable<'a> {
                     UncommittedSquashSource::PathPrefix(Cow::Borrowed(hunks)),
                 ));
             }
-            ResolvedCliIdArgRef::Stack => "a stack",
+            ResolvedCliIdArgRef::Stack { .. } => "a stack",
         };
         Err(bad_input(format!(
             "Expected a commit, a branch, or an uncommitted change, got {kind}"

--- a/crates/but/src/command/legacy/status/tui/app/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/app/mod.rs
@@ -336,7 +336,7 @@ impl App {
             | ResolvedCliIdArg::CommittedFile(..)
             | ResolvedCliIdArg::Uncommitted
             | ResolvedCliIdArg::PathPrefix { .. }
-            | ResolvedCliIdArg::Stack => None,
+            | ResolvedCliIdArg::Stack { .. } => None,
         });
         let initial_committed_file = matches!(
             initial_target.as_ref(),

--- a/crates/but/src/command/legacy/status/tui/app/stack_mode.rs
+++ b/crates/but/src/command/legacy/status/tui/app/stack_mode.rs
@@ -11,21 +11,25 @@ use ratatui::prelude::{Line, Span, Style, Text};
 
 use crate::{
     CliId,
-    command::legacy::status::{
-        FilesStatusFlag, StatusOutputLine,
-        output::StatusOutputLineData,
-        tui::{
-            App, Cursor, FuzzyPicker, Message, Modal, Mode, ReloadCause, SelectAfterReload,
-            ToastKind,
-            app::NormalMode,
-            cursor::is_selectable_in_mode,
-            fuzzy_picker::{Col, FuzzyPickerItem, SearchableToken},
-            fuzzy_picker_key_binds,
-            render::{
-                ModeRender, RenderSingleLineSpans, SpanExt,
-                render_move_stack_operation_target_marker, source_span, stack_operation_display,
+    command::legacy::{
+        status::{
+            FilesStatusFlag, StatusOutputLine,
+            output::StatusOutputLineData,
+            tui::{
+                App, Cursor, FuzzyPicker, Message, Modal, Mode, ReloadCause, SelectAfterReload,
+                ToastKind,
+                app::NormalMode,
+                cursor::is_selectable_in_mode,
+                fuzzy_picker::{Col, FuzzyPickerItem, SearchableToken},
+                fuzzy_picker_key_binds,
+                render::{
+                    ModeRender, RenderSingleLineSpans, SpanExt,
+                    render_move_stack_operation_target_marker, source_span,
+                    stack_operation_display,
+                },
             },
         },
+        unapply::{self, UnapplyOperation},
     },
     id::{BranchId, CommitId, CommittedFileId},
     resolve_legacy_top_level_apply_branch_name,
@@ -475,7 +479,16 @@ impl App {
             .map(SelectAfterReload::Branch)
             .unwrap_or(SelectAfterReload::Uncommitted);
 
-        but_api::legacy::virtual_branches::unapply_stack(ctx, stack_id)?;
+        {
+            let mut guard = ctx.exclusive_worktree_access();
+            let head_info = but_api::legacy::workspace::head_info(ctx)?;
+            unapply::run(
+                ctx,
+                guard.write_permission(),
+                &head_info,
+                UnapplyOperation { stack_id },
+            )?;
+        }
 
         messages.extend([
             Message::EnterNormalModeAfterConfirmingOperation,

--- a/crates/but/src/command/legacy/status/tui/cursor/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/cursor/mod.rs
@@ -96,7 +96,7 @@ impl Cursor {
                     .hint(hint)
                     .into());
             }
-            ResolvedCliIdArg::Stack => {
+            ResolvedCliIdArg::Stack { .. } => {
                 return Err(bad_input("Selecting stacks is not supported")
                     .hint(hint)
                     .into());
@@ -122,7 +122,7 @@ impl Cursor {
                 | ResolvedCliIdArg::CommittedFile(..)
                 | ResolvedCliIdArg::Uncommitted
                 | ResolvedCliIdArg::PathPrefix { .. }
-                | ResolvedCliIdArg::Stack => target == **cli_id,
+                | ResolvedCliIdArg::Stack { .. } => target == **cli_id,
             })
         }) else {
             return Ok(None);

--- a/crates/but/src/command/legacy/unapply.rs
+++ b/crates/but/src/command/legacy/unapply.rs
@@ -1,134 +1,162 @@
 //! Implementation of the `but unapply` command.
 
-use anyhow::{Context as _, bail};
-use but_core::ref_metadata::StackId;
+use anyhow::Context as _;
+use but_core::{ref_metadata::StackId, sync::RepoExclusive};
+use but_ctx::Context;
+use but_workspace::RefInfo;
+use gix::refs::FullName;
+use itertools::Itertools as _;
+use serde::Serialize;
 
-use crate::{CliId, IdMap, legacy::workspace::HeadInfoStack, utils::OutputChannel};
+use crate::{
+    CliResult, IdMap,
+    args::{
+        atoms::{BranchOrStack, CliIdArg, Priority, Purpose},
+        unapply::Platform,
+    },
+    bad_input,
+    theme::{self, Theme},
+    utils::{CliOutput, CliOutputHuman, IntermediateChannel, WriteWithUtils},
+};
 
-/// Handle the unapply command.
-///
-/// The identifier can be:
-/// - A CLI ID pointing to a stack
-/// - A CLI ID pointing to a branch
-/// - A branch name
-///
-/// If a branch is specified, the entire stack containing that branch will be unapplied.
-pub fn handle(
-    ctx: &mut but_ctx::Context,
-    out: &mut OutputChannel,
-    identifier: &str,
-) -> anyhow::Result<()> {
-    let mut guard = ctx.exclusive_worktree_access();
-    // Fetch stacks once at the start
-    let stacks = crate::legacy::workspace::applied_stacks(ctx)?;
-
-    let id_map = IdMap::new_from_context(ctx, guard.read_permission())?;
-    let parsed_ids = id_map.parse_using_context(identifier, ctx)?;
-
-    // Try to find the stack to unapply
-    let (stack_id, branches) = if parsed_ids.is_empty() {
-        // No CLI ID match, try to find by branch name directly
-        find_stack_by_branch_name(&stacks, identifier)?
-    } else if parsed_ids.len() == 1 {
-        match &parsed_ids[0] {
-            CliId::Stack { stack_id, .. } => {
-                // Direct stack ID - get the branches for display
-                get_stack_branches(&stacks, *stack_id, identifier)?
-            }
-            CliId::Branch(branch) => {
-                // Branch ID - use the associated stack
-                if let Some(stack_id) = branch.stack_id {
-                    get_stack_branches(&stacks, stack_id, &branch.name)?
-                } else {
-                    bail!("Branch '{}' does not have an associated stack", branch.name);
-                }
-            }
-            CliId::Commit { .. } => {
-                bail!("Cannot unapply a commit. Please specify a branch or stack identifier.");
-            }
-            CliId::UncommittedHunkOrFile(_)
-            | CliId::CommittedFile { .. }
-            | CliId::PathPrefix { .. } => {
-                bail!("Cannot unapply a file. Please specify a branch or stack identifier.");
-            }
-            CliId::Uncommitted { .. } => {
-                bail!(
-                    "Cannot unapply the uncommitted area. Please specify a branch or stack identifier."
-                );
-            }
-        }
-    } else {
-        bail!(
-            "Ambiguous identifier '{}', matches {} items. Please be more specific.",
-            identifier,
-            parsed_ids.len()
-        );
-    };
-
-    unapply_stack(ctx, stack_id, &branches, out, guard.write_permission())
+pub struct UnapplyOutcome {
+    pub branches_in_stack: Vec<FullName>,
 }
 
-/// Get branches for a stack by ID, validating the stack exists.
-fn get_stack_branches(
-    stacks: &[HeadInfoStack],
-    stack_id: StackId,
-    identifier: &str,
-) -> anyhow::Result<(StackId, Vec<String>)> {
-    let stack = stacks
-        .iter()
-        .find(|s| s.id == Some(stack_id))
-        .with_context(|| format!("Stack for '{identifier}' not found in workspace"))?;
+impl CliOutputHuman for UnapplyOutcome {
+    fn on_human(
+        self,
+        out: &mut dyn WriteWithUtils,
+        _agent: bool,
+        _theme: &'static Theme,
+    ) -> anyhow::Result<()> {
+        let Self { branches_in_stack } = self;
 
-    let branches: Vec<String> = stack.branch_names().map(ToOwned::to_owned).collect();
+        let branches_in_stack = branches_in_stack.iter().map(theme::Branch).join(", ");
 
-    if branches.is_empty() {
-        bail!("Stack for '{identifier}' has no branches");
-    }
-
-    Ok((stack_id, branches))
-}
-
-/// Find a stack by branch name and return the stack ID and branches.
-fn find_stack_by_branch_name(
-    stacks: &[HeadInfoStack],
-    branch_name: &str,
-) -> anyhow::Result<(StackId, Vec<String>)> {
-    for stack_entry in stacks {
-        if stack_entry.contains_branch(branch_name)
-            && let Some(sid) = stack_entry.id
-        {
-            let branches: Vec<String> = stack_entry.branch_names().map(ToOwned::to_owned).collect();
-            return Ok((sid, branches));
-        }
-    }
-
-    bail!("Branch '{branch_name}' not found in any applied stack");
-}
-
-fn unapply_stack(
-    ctx: &mut but_ctx::Context,
-    sid: StackId,
-    branches: &[String],
-    out: &mut OutputChannel,
-    perm: &mut but_core::sync::RepoExclusive,
-) -> anyhow::Result<()> {
-    let branches_display = branches.join(", ");
-
-    but_api::legacy::virtual_branches::unapply_stack_with_perm(ctx, sid, perm)?;
-
-    if let Some(out) = out.for_human() {
         writeln!(
             out,
-            "Unapplied stack with branches '{branches_display}' from workspace"
+            "Unapplied stack with {branches_in_stack} from workspace"
         )?;
-    }
 
-    if let Some(out) = out.for_json() {
-        out.write_value(serde_json::json!({
-            "unapplied": true,
-            "branches": branches
-        }))?;
+        Ok(())
     }
+}
 
-    Ok(())
+impl CliOutput for UnapplyOutcome {
+    fn on_json(self) -> impl Serialize {
+        #[derive(Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Output {
+            branches: Vec<String>,
+        }
+
+        let Self { branches_in_stack } = self;
+
+        let branches = branches_in_stack
+            .iter()
+            .map(|branch| branch.shorten().to_string())
+            .collect();
+
+        Output { branches }
+    }
+}
+
+pub fn unapply(
+    ctx: &mut Context,
+    _out: IntermediateChannel<'_>,
+    args: Platform,
+) -> CliResult<UnapplyOutcome> {
+    let mut guard = ctx.exclusive_worktree_access();
+    let id_map = IdMap::new_from_context(ctx, guard.read_permission())?;
+    let head_info = but_api::legacy::workspace::head_info(ctx)?;
+
+    let operation = {
+        let repo = ctx.repo.get()?;
+        resolve(args, &id_map, &repo, &head_info)?
+    };
+
+    Ok(run(ctx, guard.write_permission(), &head_info, operation)?)
+}
+
+fn resolve(
+    args: Platform,
+    id_map: &IdMap,
+    repo: &gix::Repository,
+    head_info: &RefInfo,
+) -> CliResult<UnapplyOperation> {
+    let Platform { target } = args;
+
+    let stack = match target
+        .resolve_in_workspace(repo, id_map, Purpose::Source, Some(Priority::Branch))?
+        .into_branch_or_stack()?
+    {
+        BranchOrStack::Branch(branch_arg) => {
+            let branch = branch_arg.resolve_local_branch_name()?;
+
+            let stack = head_info.stacks.iter().find(|stack| {
+                stack.segments.iter().any(|segment| {
+                    segment
+                        .ref_info
+                        .as_ref()
+                        .is_some_and(|ref_info| ref_info.ref_name == branch)
+                })
+            });
+
+            let Some(stack) = stack else {
+                return Err(bad_input(format!("Branch {} not found", branch.shorten()))
+                    .hint(CliIdArg::TARGET_MISSING_HINT)
+                    .into());
+            };
+
+            stack
+        }
+        BranchOrStack::Stack { stack_id, id } => {
+            let stack = head_info
+                .stacks
+                .iter()
+                .find(|stack| stack.id.is_some_and(|id| id == stack_id));
+
+            let Some(stack) = stack else {
+                return Err(bad_input(format!("Stack {id} not found"))
+                    .hint(CliIdArg::TARGET_MISSING_HINT)
+                    .into());
+            };
+
+            stack
+        }
+    };
+
+    let stack_id = stack.id.context("BUG: stack has no id")?;
+
+    Ok(UnapplyOperation { stack_id })
+}
+
+pub fn run(
+    ctx: &mut Context,
+    perm: &mut RepoExclusive,
+    head_info: &RefInfo,
+    operation: UnapplyOperation,
+) -> anyhow::Result<UnapplyOutcome> {
+    let UnapplyOperation { stack_id } = operation;
+
+    let stack = head_info
+        .stacks
+        .iter()
+        .find(|stack| stack.id.is_some_and(|id| id == stack_id))
+        .context("BUG: stack not found")?;
+
+    let branches_in_stack = stack
+        .segments
+        .iter()
+        .filter_map(|segment| Some(segment.ref_info.as_ref()?.ref_name.clone()))
+        .collect::<Vec<_>>();
+
+    but_api::legacy::virtual_branches::unapply_stack_with_perm(ctx, stack_id, perm)?;
+
+    Ok(UnapplyOutcome { branches_in_stack })
+}
+
+pub struct UnapplyOperation {
+    pub stack_id: StackId,
 }

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -1696,7 +1696,10 @@ async fn match_subcommand(
             Ok(())
         }
         #[cfg(feature = "legacy")]
-        Subcommands::Unapply { identifier } => {
+        Subcommands::Unapply(unapply_args) => {
+            use crate::utils::IntermediateChannel;
+
+            let status_after = args.status_after;
             let mut ctx = setup::init_ctx(
                 &args,
                 InitCtxOptions {
@@ -1705,10 +1708,17 @@ async fn match_subcommand(
                 },
                 out,
             )?;
-            command::legacy::unapply::handle(&mut ctx, out, &identifier)
-                .context("Failed to unapply branch.")
-                .emit_metrics(metrics_ctx)
-                .show_root_cause_error_then_exit_without_destructors(output)
+            out.begin_status_after(status_after);
+
+            let outcome = command::legacy::unapply::unapply(
+                &mut ctx,
+                IntermediateChannel::new(out),
+                unapply_args,
+            )
+            .emit_metrics(metrics_ctx)?;
+            out.print_cli_output(outcome)?;
+            run_status_after_if_requested(status_after, &mut ctx, out);
+            Ok(())
         }
         #[cfg(feature = "legacy")]
         Subcommands::Apply { branch_name } => {

--- a/crates/but/tests/but/command/branch/show.rs
+++ b/crates/but/tests/but/command/branch/show.rs
@@ -67,7 +67,7 @@ tpm add A
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Unapplied stack with branches 'A' from workspace
+Unapplied stack with 'A' from workspace
 
 "#]]);
 

--- a/crates/but/tests/but/command/branch/unapply.rs
+++ b/crates/but/tests/but/command/branch/unapply.rs
@@ -50,7 +50,7 @@ fn single_branch() {
         .success()
         .stderr_eq(str![])
         .stdout_eq(str![[r#"
-Unapplied stack with branches 'feature-branch' from workspace
+Unapplied stack with 'feature-branch' from workspace
 
 "#]]);
 
@@ -129,7 +129,9 @@ fn unapply_idempotent() {
         .assert()
         .failure()
         .stderr_eq(str![[r#"
-Failed to unapply branch. Branch 'feature-branch' not found in any applied stack
+Error: Could not find source: 'feature-branch'
+
+Hint: Run `but status` for applicable targets.
 
 "#]])
         .stdout_eq(str![]);
@@ -144,7 +146,9 @@ fn unapply_nonexistent_branch() {
         .assert()
         .failure()
         .stderr_eq(str![[r#"
-Failed to unapply branch. Branch 'nonexistent-branch' not found in any applied stack
+Error: Could not find source: 'nonexistent-branch'
+
+Hint: Run `but status` for applicable targets.
 
 "#]])
         .stdout_eq(str![]);
@@ -175,7 +179,9 @@ fn unapply_branch_not_in_workspace() {
         .assert()
         .failure()
         .stderr_eq(str![[r#"
-Failed to unapply branch. Branch 'feature-branch' not found in any applied stack
+Error: Could not find source: 'feature-branch'
+
+Hint: Run `but status` for applicable targets.
 
 "#]])
         .stdout_eq(str![]);
@@ -229,7 +235,7 @@ fn unapply_remote_tracking_branch() {
         .success()
         .stderr_eq(str![])
         .stdout_eq(str![[r#"
-Unapplied stack with branches 'remote-feature' from workspace
+Unapplied stack with 'remote-feature' from workspace
 
 "#]]);
 
@@ -330,7 +336,7 @@ fn unapply_using_cli_branch_id() {
         .success()
         .stderr_eq(str![])
         .stdout_eq(str![[r#"
-Unapplied stack with branches 'feature-branch' from workspace
+Unapplied stack with 'feature-branch' from workspace
 
 "#]]);
 
@@ -394,7 +400,7 @@ fn unapply_using_cli_stack_id() {
         .success()
         .stderr_eq(str![])
         .stdout_eq(str![[r#"
-Unapplied stack with branches 'feature-branch' from workspace
+Unapplied stack with 'feature-branch' from workspace
 
 "#]]);
 }
@@ -423,7 +429,6 @@ fn unapply_json_output_validation() {
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
 
     // Validate JSON structure
-    assert_eq!(json["unapplied"], serde_json::json!(true));
     let branches = json["branches"]
         .as_array()
         .expect("branches should be an array");

--- a/crates/but/tests/but/command/undo.rs
+++ b/crates/but/tests/but/command/undo.rs
@@ -143,7 +143,10 @@ fn can_undo_unapply() {
         env.but("unapply A")
             .assert()
             .success()
-            .stdout_eq("Unapplied stack with branches 'A' from workspace\n")
+            .stdout_eq(snapbox::str![[r#"
+Unapplied stack with 'A' from workspace
+
+"#]])
             .stderr_eq("");
     });
 }


### PR DESCRIPTION
No behavioral changes. Just moving it to the new architecture.