### PR TITLE
Persist only the checkbox selection of uncommitted changes

### DIFF
--- a/apps/desktop/src/lib/selection/uncommitted.ts
+++ b/apps/desktop/src/lib/selection/uncommitted.ts
@@ -30,6 +30,19 @@ type UncommittedState = {
 };
 
 /**
+ * The parts of this slice that must not survive a restart.
+ *
+ * Both are refetched from the worktree on startup, so a persisted copy is only ever the previous
+ * session's, rendered for the frames before the fresh query replaces it. `hunkSelection` is
+ * deliberately absent: the checkboxes are the state worth keeping, and `update()` rebuilds them
+ * against whatever assignments arrive.
+ */
+export const UNCOMMITTED_PERSIST_BLACKLIST = [
+	"treeChanges",
+	"hunkAssignments",
+] as const satisfies readonly (keyof UncommittedState)[];
+
+/**
  * State representing uncommitted changes.
  *
  * In this slice we manage a few related concepts, 1) tree changes, 2) hunk

--- a/apps/desktop/src/lib/selection/uncommittedService.svelte.ts
+++ b/apps/desktop/src/lib/selection/uncommittedService.svelte.ts
@@ -9,6 +9,7 @@ import {
 import { showToast } from "$lib/notifications/toasts";
 import { compositeKey, partialKey, type HunkSelection } from "$lib/selection/entityAdapters";
 import {
+	UNCOMMITTED_PERSIST_BLACKLIST,
 	uncommittedSelectors,
 	uncommittedSlice,
 	type CheckboxStatus,
@@ -59,7 +60,9 @@ export class UncommittedService {
 		private diffService: DiffService,
 	) {
 		this.dispatch = clientState.dispatch;
-		const getSlice = clientState.injectPersistedSlice(uncommittedSlice);
+		const getSlice = clientState.injectPersistedSlice(uncommittedSlice, [
+			...UNCOMMITTED_PERSIST_BLACKLIST,
+		]);
 
 		$effect(() => {
 			this.state = getSlice() ?? uncommittedSlice.getInitialState();

--- a/apps/desktop/src/lib/state/clientState.svelte.ts
+++ b/apps/desktop/src/lib/state/clientState.svelte.ts
@@ -1,4 +1,5 @@
 import { createBackendApi, type BackendApi } from "$lib/state/backendApi";
+import { persistConfigFor } from "$lib/state/persistConfig";
 import { uiStateSlice } from "$lib/state/uiState.svelte";
 import { InjectionToken } from "@gitbutler/core/context";
 import { mergeUnlisten } from "@gitbutler/ui/utils/mergeUnlisten";
@@ -65,11 +66,21 @@ export class ClientState {
 		});
 	}
 
-	injectPersistedSlice<S>(slice: Slice<S>): () => S | undefined {
+	/**
+	 * Persist `slice` across restarts, restoring it before the first render.
+	 *
+	 * `blacklist` names parts of the slice that should not survive. State that a query refetches
+	 * on startup belongs there: persisting it means the previous session's copy is rendered
+	 * first and replaced moments later, which reads as a flash of stale data.
+	 */
+	injectPersistedSlice<S extends object>(
+		slice: Slice<S>,
+		blacklist?: Extract<keyof S, string>[],
+	): () => S | undefined {
 		this.reducer.inject(
 			{
 				reducerPath: slice.reducerPath,
-				reducer: persistReducer({ key: slice.reducerPath, storage }, slice.reducer),
+				reducer: persistReducer(persistConfigFor(slice.reducerPath, blacklist), slice.reducer),
 			},
 			{ overrideExisting: false },
 		);

--- a/apps/desktop/src/lib/state/persistBlacklist.test.ts
+++ b/apps/desktop/src/lib/state/persistBlacklist.test.ts
@@ -1,0 +1,97 @@
+import {
+	UNCOMMITTED_PERSIST_BLACKLIST,
+	uncommittedActions,
+	uncommittedSlice,
+} from "$lib/selection/uncommitted";
+import { persistConfigFor } from "$lib/state/persistConfig";
+import { configureStore } from "@reduxjs/toolkit";
+import { persistReducer } from "redux-persist";
+import persistStore from "redux-persist/lib/persistStore";
+import { describe, expect, test } from "vitest";
+import type { Storage } from "redux-persist";
+
+/** Records what redux-persist writes, so tests can assert on the persisted shape itself. */
+function recordingStorage(seed?: Record<string, string>): Storage & {
+	written(): Record<string, string>;
+} {
+	const items: Record<string, string> = { ...seed };
+	return {
+		getItem: async (key: string) => items[key] ?? null,
+		setItem: async (key: string, value: string) => {
+			items[key] = value;
+		},
+		removeItem: async (key: string) => {
+			delete items[key];
+		},
+		written: () => items,
+	};
+}
+
+type UncommittedState = ReturnType<typeof uncommittedSlice.getInitialState>;
+
+const KEY = uncommittedSlice.reducerPath;
+const BLACKLIST = [...UNCOMMITTED_PERSIST_BLACKLIST];
+
+/** A change and its assignment, enough to populate every part of the slice. */
+const CHANGE = { path: "a.txt", status: { type: "Modification" } } as never;
+const ASSIGNMENT = {
+	id: "assignment-1",
+	path: "a.txt",
+	pathBytes: "a.txt",
+	stackId: null,
+	hunkHeader: null,
+	lineNumsAdded: null,
+	lineNumsRemoved: null,
+} as never;
+
+/**
+ * Run the real slice through a real persist cycle under the config the app uses, with only
+ * storage swapped out, and report what reached storage and what the store holds.
+ */
+async function persistCycle(seed?: Record<string, string>) {
+	const storage = recordingStorage(seed);
+	const store = configureStore({
+		reducer: persistReducer(
+			{ ...persistConfigFor<UncommittedState>(KEY, BLACKLIST), storage },
+			uncommittedSlice.reducer,
+		),
+		middleware: (getDefault) => getDefault({ serializableCheck: false }),
+	});
+	await new Promise<void>((resolve) => persistStore(store, undefined, () => resolve()));
+	// What the app would render on startup: rehydrated, but before the worktree query lands.
+	const rehydrated = store.getState();
+	store.dispatch(uncommittedActions.update({ assignments: [ASSIGNMENT], changes: [CHANGE] }));
+	// redux-persist writes on a timeout, so let the queued write run.
+	await new Promise((resolve) => setTimeout(resolve, 50));
+
+	const raw = storage.written()[`persist:${KEY}`];
+	return {
+		persisted: raw ? Object.keys(JSON.parse(raw)).filter((k) => k !== "_persist") : [],
+		rehydrated,
+	};
+}
+
+describe("uncommitted slice persistence", () => {
+	// Types already stop a name that is not part of the slice; this stops the opposite mistake.
+	test("the checkbox state is not blacklisted", () => {
+		expect(BLACKLIST).not.toContain("hunkSelection");
+	});
+
+	test("only the checkbox state is written", async () => {
+		const { persisted } = await persistCycle();
+		expect(persisted).toEqual(["hunkSelection"]);
+	});
+
+	// Anything an earlier build already wrote has to be dropped on the way in as well, or the
+	// first launch after upgrading rehydrates a stale file list and flashes it once more.
+	test("state left by an earlier build is not rehydrated", async () => {
+		const stale = JSON.stringify({
+			treeChanges: JSON.stringify({ ids: ["gone.txt"], entities: { "gone.txt": CHANGE } }),
+			hunkAssignments: JSON.stringify({ ids: [], entities: {} }),
+			hunkSelection: JSON.stringify({ ids: [], entities: {} }),
+			_persist: JSON.stringify({ version: -1, rehydrated: true }),
+		});
+		const { rehydrated } = await persistCycle({ [`persist:${KEY}`]: stale });
+		expect(rehydrated.treeChanges.ids).toEqual([]);
+	});
+});

--- a/apps/desktop/src/lib/state/persistConfig.ts
+++ b/apps/desktop/src/lib/state/persistConfig.ts
@@ -1,0 +1,31 @@
+import autoMergeLevel1 from "redux-persist/lib/stateReconciler/autoMergeLevel1";
+import storage from "redux-persist/lib/storage";
+import type { PersistConfig } from "redux-persist";
+
+/**
+ * Persist configuration for a slice, keeping the `blacklist`ed keys out of storage.
+ *
+ * `blacklist` on its own only stops those keys being written. Whatever an earlier build already
+ * wrote is still read back and merged on the next launch, so the reconciler drops them on the
+ * way in as well; without that, the first launch after upgrading still restores stale state.
+ */
+export function persistConfigFor<S extends object>(
+	key: string,
+	blacklist?: Extract<keyof S, string>[],
+): PersistConfig<S> {
+	if (!blacklist || blacklist.length === 0) {
+		return { key, storage };
+	}
+	return {
+		key,
+		storage,
+		blacklist,
+		stateReconciler: (inbound: S, original: S, reduced: S, config: PersistConfig<S>) => {
+			const kept = { ...inbound };
+			for (const name of blacklist) {
+				delete kept[name];
+			}
+			return autoMergeLevel1(kept, original, reduced, config);
+		},
+	};
+}


### PR DESCRIPTION
## 🧠 Changes

`uncommittedSlice` is now persisted with `treeChanges` and `hunkAssignments` blacklisted, leaving only `hunkSelection` — the checkbox state — to survive a restart.

The blacklist alone would not have been enough. redux-persist applies it when writing, but `getStoredState` reads back every key on disk and `autoMergeLevel1` merges all of them, so anything an earlier build had already written would still rehydrate once after upgrading. `persistConfigFor()` pairs the blacklist with a state reconciler that drops those keys on the way in as well.

## ☕️ Reasoning

`injectPersistedSlice()` persisted whole slices, and the uncommitted slice holds three things:

```
treeChanges      // the file list
hunkAssignments  // assignments
hunkSelection    // the checkbox state
```

The first two are refetched from the worktree on startup, so a persisted copy is only ever the previous session's, rendered for the frames before the fresh query replaces it. That is the flash in the report, and it fits the observation that deleting the cache directory makes it go away.

The blacklist lives next to the type it has to match, as `const satisfies readonly (keyof UncommittedState)[]`, so a name that drifts from the slice shape fails the type check rather than silently re-persisting a key.

Three tests in `persistBlacklist.test.ts` drive the real slice through a real persist cycle under the config the app builds, with only storage swapped for a recording adapter. Two of them fail if `persistConfigFor()` is reverted to returning `{ key, storage }`:

- *only the checkbox state is written* — all three keys reach storage
- *state left by an earlier build is not rehydrated* — `gone.txt` is still there after rehydrate

The third asserts `hunkSelection` is not blacklisted. That one is a guard against the opposite mistake rather than a regression test, and passes either way.

One consequence worth stating plainly: a partial line selection inside a hunk comes back as the whole hunk checked after a restart, because `updateLines()` no longer has the previous assignment to diff against. If the file also changed while the app was closed, the reconciled assignment keeps its id but covers different lines, so a restored selection can be wider than what was originally chosen. Whole-hunk and whole-file checkboxes restore exactly.

Keeping `hunkAssignments` persisted would avoid that, at the cost of still rehydrating state this issue calls out as not being checkbox selection. I went with the narrower persistence; happy to swap to blacklisting only `treeChanges` if you would rather keep line-level precision across restarts.

## 🎫 Affected issues

Fixes: #10892
