### PR TITLE
feat(desktop): show open-in-folder icon on hovered project when ⌘ is held

### DIFF
--- a/apps/desktop/src/components/views/AppHeader.svelte
+++ b/apps/desktop/src/components/views/AppHeader.svelte
@@ -105,6 +105,32 @@
 
 	let newProjectLoading = $state(false);
 	let projectSelectorOpen = $state(false);
+	let metaKeyHeld = $state(false);
+
+	// Only listen while the dropdown is open, so items can hint that ⌘-click opens a new window.
+	$effect(() => {
+		if (!projectSelectorOpen) {
+			metaKeyHeld = false;
+			return;
+		}
+
+		function updateMetaKey(e: KeyboardEvent) {
+			metaKeyHeld = e.metaKey;
+		}
+		function clearMetaKey() {
+			metaKeyHeld = false;
+		}
+
+		window.addEventListener("keydown", updateMetaKey);
+		window.addEventListener("keyup", updateMetaKey);
+		window.addEventListener("blur", clearMetaKey);
+
+		return () => {
+			window.removeEventListener("keydown", updateMetaKey);
+			window.removeEventListener("keyup", updateMetaKey);
+			window.removeEventListener("blur", clearMetaKey);
+		};
+	});
 
 	const isOnWorkspacePage = $derived(!!isWorkspacePath());
 
@@ -194,7 +220,11 @@
 				{/snippet}
 
 				{#snippet itemSnippet({ item, highlighted })}
-					<SelectItem selected={item.value === projectId} {highlighted}>
+					<SelectItem
+						selected={item.value === projectId}
+						{highlighted}
+						hoverIcon={metaKeyHeld ? "open-in-folder" : undefined}
+					>
 						{item.label}
 					</SelectItem>
 				{/snippet}
@@ -233,6 +263,11 @@
 						Clone repository
 					</SelectItem>
 				</OptionsGroup>
+
+				<div class="text-11 new-window-hint">
+					<Icon name="open-in-folder" color="var(--text-3)" size={14} />
+					<span>Hold ⌘ to open in a new window</span>
+				</div>
 			</Select>
 			{#if singleBranchMode}
 				<Tooltip text="Current branch">
@@ -363,6 +398,16 @@
 		display: flex;
 		align-items: center;
 		gap: 8px;
+	}
+
+	.new-window-hint {
+		display: flex;
+		align-items: center;
+		padding-block: 10px;
+		padding-inline: 12px;
+		gap: 8px;
+		background-color: var(--bg-2);
+		color: var(--text-2);
 	}
 
 	/** Mac padding added here to not affect header flex-box sizing, only applied when using custom title bar. */

--- a/apps/desktop/src/components/views/AppHeader.svelte
+++ b/apps/desktop/src/components/views/AppHeader.svelte
@@ -105,30 +105,42 @@
 
 	let newProjectLoading = $state(false);
 	let projectSelectorOpen = $state(false);
-	let metaKeyHeld = $state(false);
+	let newWindowModifierHeld = $state(false);
 
-	// Only listen while the dropdown is open, so items can hint that ⌘-click opens a new window.
+	const isMac = $derived(backend.platformName === "macos");
+	// ⌘-click is the new-window gesture on macOS; elsewhere that role belongs to Ctrl.
+	const newWindowModifierLabel = $derived(isMac ? "⌘" : "Ctrl");
+
+	function hasNewWindowModifier(e: KeyboardEvent | MouseEvent) {
+		return isMac ? e.metaKey : e.ctrlKey;
+	}
+
+	// Only listen while the dropdown is open, so rows can hint that the modifier opens a new window.
 	$effect(() => {
 		if (!projectSelectorOpen) {
-			metaKeyHeld = false;
+			newWindowModifierHeld = false;
 			return;
 		}
 
-		function updateMetaKey(e: KeyboardEvent) {
-			metaKeyHeld = e.metaKey;
+		function update(e: KeyboardEvent | MouseEvent) {
+			newWindowModifierHeld = hasNewWindowModifier(e);
 		}
-		function clearMetaKey() {
-			metaKeyHeld = false;
+		function clear() {
+			newWindowModifierHeld = false;
 		}
 
-		window.addEventListener("keydown", updateMetaKey);
-		window.addEventListener("keyup", updateMetaKey);
-		window.addEventListener("blur", clearMetaKey);
+		window.addEventListener("keydown", update);
+		window.addEventListener("keyup", update);
+		// Mouse events carry the modifier state too, so a modifier already held when the
+		// dropdown opened is picked up as soon as the pointer moves over the list.
+		window.addEventListener("mousemove", update);
+		window.addEventListener("blur", clear);
 
 		return () => {
-			window.removeEventListener("keydown", updateMetaKey);
-			window.removeEventListener("keyup", updateMetaKey);
-			window.removeEventListener("blur", clearMetaKey);
+			window.removeEventListener("keydown", update);
+			window.removeEventListener("keyup", update);
+			window.removeEventListener("mousemove", update);
+			window.removeEventListener("blur", clear);
 		};
 	});
 
@@ -152,7 +164,7 @@
 
 <div
 	class="chrome-header"
-	class:mac={backend.platformName === "macos"}
+	class:mac={isMac}
 	data-tauri-drag-region={useCustomTitleBar}
 	class:single-branch={singleBranchMode}
 	use:focusable
@@ -190,7 +202,7 @@
 				loading={newProjectLoading}
 				disabled={newProjectLoading}
 				onselect={(value: string, modifiers?) => {
-					if (modifiers?.meta) {
+					if (isMac ? modifiers?.meta : modifiers?.ctrl) {
 						projectsService.openProjectInNewWindow(value);
 					} else {
 						goto(projectPath(value));
@@ -223,7 +235,7 @@
 					<SelectItem
 						selected={item.value === projectId}
 						{highlighted}
-						hoverIcon={metaKeyHeld ? "open-in-folder" : undefined}
+						hoverIcon={newWindowModifierHeld ? "open-in-folder" : undefined}
 					>
 						{item.label}
 					</SelectItem>
@@ -266,7 +278,7 @@
 
 				<div class="text-11 new-window-hint">
 					<Icon name="open-in-folder" color="var(--text-3)" size={14} />
-					<span>Hold ⌘ to open in a new window</span>
+					<span>Hold {newWindowModifierLabel} to open in a new window</span>
 				</div>
 			</Select>
 			{#if singleBranchMode}
@@ -403,8 +415,8 @@
 	.new-window-hint {
 		display: flex;
 		align-items: center;
-		padding-block: 10px;
 		padding-inline: 12px;
+		padding-block: 10px;
 		gap: 8px;
 		background-color: var(--bg-2);
 		color: var(--text-2);

--- a/packages/ui/src/lib/components/select/SelectItem.svelte
+++ b/packages/ui/src/lib/components/select/SelectItem.svelte
@@ -6,6 +6,8 @@
 
 	interface Props {
 		icon?: IconName;
+		/** Replaces the trailing icon while the item is hovered or highlighted. */
+		hoverIcon?: IconName;
 		iconSnippet?: Snippet;
 		selected?: boolean;
 		disabled?: boolean;
@@ -19,6 +21,7 @@
 
 	const {
 		icon = undefined,
+		hoverIcon = undefined,
 		iconSnippet,
 		selected = false,
 		disabled = false,
@@ -52,12 +55,21 @@
 	<div class="label text-13">
 		{@render children?.()}
 	</div>
-	{#if icon || selected}
-		<div class="icon">
-			{#if icon}
-				<Icon name={loading ? "spinner" : icon} />
-			{:else}
-				<Icon name="tick" />
+	{#if icon || selected || hoverIcon}
+		<div class="icon" class:has-hover-icon={!!hoverIcon}>
+			{#if icon || selected}
+				<span class="icon__base">
+					{#if icon}
+						<Icon name={loading ? "spinner" : icon} />
+					{:else}
+						<Icon name="tick" />
+					{/if}
+				</span>
+			{/if}
+			{#if hoverIcon}
+				<span class="icon__hover">
+					<Icon name={hoverIcon} />
+				</span>
 			{/if}
 		</div>
 	{/if}
@@ -68,6 +80,9 @@
 		display: flex;
 		align-items: center;
 		width: 100%;
+		/* Icons are 16px but a text-13 line box is 15.6px, so rows with and without an
+		   icon would otherwise differ in height. Pin it: 16px icon + 8px padding twice. */
+		min-height: 32px;
 		padding: 8px;
 		gap: 10px;
 		border-radius: var(--radius-m);
@@ -81,8 +96,7 @@
 		&:disabled {
 			opacity: 0.4;
 		}
-		& .icon,
-		.custom-icon {
+		& .custom-icon {
 			display: flex;
 			flex-shrink: 0;
 			color: var(--text-2);
@@ -107,5 +121,37 @@
 
 	.highlighted:not(.selected) {
 		background-color: var(--hover-bg-1);
+	}
+
+	/**
+	 * The hover icon takes over the trailing slot while the item is hovered or highlighted.
+	 * Both icons are stacked in the same grid cell so swapping them never changes the
+	 * slot's width — otherwise the label would shift on hover.
+	 */
+	.icon {
+		display: grid;
+		flex-shrink: 0;
+		place-items: center;
+		color: var(--text-2);
+
+		& .icon__base,
+		& .icon__hover {
+			display: flex;
+			grid-area: 1 / 1;
+		}
+		& .icon__hover {
+			opacity: 0;
+		}
+	}
+
+	/* Only swap when there is something to swap to, so a plain tick survives hover. */
+	.select-button:hover:enabled,
+	.select-button.highlighted:enabled {
+		& .icon.has-hover-icon .icon__base {
+			opacity: 0;
+		}
+		& .icon.has-hover-icon .icon__hover {
+			opacity: 1;
+		}
 	}
 </style>


### PR DESCRIPTION


https://github.com/user-attachments/assets/4563fe85-faa6-46f3-b3ff-4d75188f3f21



The project selector opens a project in a new window on ⌘-click, but nothing signalled that.

### Changes

- `SelectItem` gains an optional `hoverIcon` prop. When set, it takes over the trailing icon slot while the row is hovered or keyboard-highlighted.
- `AppHeader` tracks the meta key with window `keydown`/`keyup` listeners attached only while the project dropdown is open, cleared on `blur` so ⌘-tabbing away does not leave it stuck. Project rows pass `hoverIcon` while ⌘ is down.
- A hint row at the bottom

### Layout details

Two bits of care so the list does not twitch under the cursor:

- Both icons occupy the same grid cell and cross-fade with `opacity` rather than toggling `display`, so swapping them never changes the slot width and the label does not shift.
- `.select-button` gets `min-height: 32px`. A 16px icon is marginally taller than a 13px × 120% = 15.6px line box, so rows with and without an icon used to differ by a fraction of a pixel — visible as a jump when the icon appears on ⌘ press.

The swap is scoped to rows that actually have a `hoverIcon`, so the selected row keeps its tick on hover when ⌘ is not held.

### Testing

`svelte-check` on `@gitbutler/ui` passes. Not yet verified visually in the running app.