### PR TITLE
Align commit checkbox behavior with files and tint checked rows

### DIFF
--- a/apps/lite/ui/src/projects/project.ts
+++ b/apps/lite/ui/src/projects/project.ts
@@ -572,11 +572,6 @@ const selectCheckedOperandCount = createSelector(
 	(checkedOperands) => checkedOperands.length,
 );
 
-const selectHasCheckedOperands = createSelector(
-	selectCheckedOperands,
-	(checkedOperands) => checkedOperands.length > 0,
-);
-
 export const projectSelectors = {
 	selectFilesVisible: (state: ProjectState) => state.filesVisible,
 	selectOutlineTab: (state: ProjectState) => state.outlineTab,
@@ -640,7 +635,6 @@ export const projectSelectors = {
 	selectCheckedCommitIds,
 	selectCheckedUncommittedFilePaths,
 	selectCheckedOperandCount,
-	selectHasCheckedOperands,
 	// Checking has been defined in a flexible way to support heterogeneous items, however in the UI
 	// we currently only allow a single context of checked items at a time, hence these selectors.
 	selectCheckedOperandsContext: (state: ProjectState): CheckableOperand["_tag"] | null =>

--- a/apps/lite/ui/src/routes/project/$id/workspace/ChangesHeaderRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/ChangesHeaderRow.tsx
@@ -102,13 +102,15 @@ export const ChangesHeaderRow: FC<{
 			}}
 			actions={
 				<Toolbar.Root aria-label="Changes actions" render={<RowToolbar forceVisible />}>
-					<Toolbar.Button
-						aria-label="Filter files"
-						onClick={onOpenFilter}
-						className={getRowButtonClassName({ size: "regular", iconOnly: true })}
-					>
-						<Icon name="search" />
-					</Toolbar.Button>
+					{changes.length > 0 && (
+						<Toolbar.Button
+							aria-label="Filter files"
+							onClick={onOpenFilter}
+							className={getRowButtonClassName({ size: "regular", iconOnly: true })}
+						>
+							<Icon name="search" />
+						</Toolbar.Button>
+					)}
 
 					<Toolbar.Button
 						aria-label="Changes menu"

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -988,7 +988,7 @@ const Diff: FC<{
 		onEnterList: activateFile,
 		panelRef: filesPanelRef,
 		listRef: filesTreeRef,
-		enabled: filesVisible,
+		enabled: filesVisible && changes.length > 0,
 	});
 
 	const { data: diffSettings } = useQuery({

--- a/apps/lite/ui/src/routes/project/$id/workspace/FileRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/FileRow.tsx
@@ -66,6 +66,7 @@ export const FileRow: FC<
 				render={
 					<Row
 						{...restProps}
+						isChecked={isChecked}
 						className={classes(restProps.className, styles.row)}
 						onContextMenu={(event) => {
 							void showNativeContextMenu(event, menuItems);

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/CommitRow.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/CommitRow.module.css
@@ -10,13 +10,13 @@
 	justify-self: center;
 	opacity: 0;
 
-	:global([data-has-checked-operands]) &,
+	&[data-checked],
 	.row:hover &,
 	&:focus {
 		opacity: 1;
 	}
 
-	:global([role="tree"]:not([data-has-checked-operands])) &[data-disabled] {
+	&[data-disabled]:not([data-checked]) {
 		display: none;
 	}
 }

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/CommitRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/CommitRow.tsx
@@ -341,6 +341,7 @@ export const CommitRow: FC<
 			{...restProps}
 			projectId={projectId}
 			operand={operand}
+			isChecked={isChecked}
 			isHighlighted={isHighlighted}
 			onContextMenu={(event) => {
 				void showNativeContextMenu(event, menuItems);

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
@@ -282,6 +282,7 @@ const UncommittedChanges: FC<{
 		onEnterList: onActiveFileSelection,
 		panelRef,
 		listRef: fileListRef,
+		enabled: (worktreeChanges?.changes.length ?? 0) > 0,
 	});
 
 	return (
@@ -723,9 +724,6 @@ export const OutlineTree: FC<
 		items: commitTargetComboboxItems,
 		outlineSelection,
 	});
-	const hasCheckedOperands = useAppSelector((state) =>
-		projectSlice.selectors.selectHasCheckedOperands(state, projectId),
-	);
 	const store = useAppStore();
 	const dispatch = useAppDispatch();
 	const { isPending: isCommitAmendPending, mutate: commitAmend } = useCommitAmend();
@@ -815,7 +813,6 @@ export const OutlineTree: FC<
 					{...props}
 					id={layoutId}
 					orientation="vertical"
-					data-has-checked-operands={hasCheckedOperands || undefined}
 					className={classes(props.className, styles.tree)}
 					defaultLayout={outlineLayout.defaultLayout}
 					onLayoutChanged={outlineLayout.onLayoutChanged}

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/UncommittedChangesRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/UncommittedChangesRow.tsx
@@ -95,13 +95,15 @@ export const UncommittedChangesRow: FC<{
 						aria-label="Uncommitted changes actions"
 						render={<RowToolbar forceVisible />}
 					>
-						<Toolbar.Button
-							aria-label="Filter files"
-							onClick={onOpenFilter}
-							className={getRowButtonClassName({ size: "regular", iconOnly: true })}
-						>
-							<Icon name="search" />
-						</Toolbar.Button>
+						{changes.length > 0 && (
+							<Toolbar.Button
+								aria-label="Filter files"
+								onClick={onOpenFilter}
+								className={getRowButtonClassName({ size: "regular", iconOnly: true })}
+							>
+								<Icon name="search" />
+							</Toolbar.Button>
+						)}
 
 						<Toolbar.Button
 							aria-label="Uncommitted changes menu"

--- a/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
@@ -59,6 +59,14 @@
 		border-start-start-radius: 0;
 		border-start-end-radius: 0;
 	}
+
+	/* Selected but unfocused, this row would otherwise take the gray selection
+	   tint and punch a hole in a run of checked rows — so it stays in the pop
+	   family, one step deeper than its neighbours. The focused selection below
+	   still wins: it outranks this on specificity or on source order. */
+	&.containerSelected {
+		background-color: color-mix(var(--fill-pop-bg) 30%, transparent);
+	}
 }
 
 .containerSelected {

--- a/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
@@ -38,6 +38,29 @@
 	}
 }
 
+/* Placed before .containerSelected so selection wins on a row that is both. */
+.containerChecked {
+	background-color: color-mix(var(--fill-pop-bg) 15%, transparent);
+
+	/* Deepens by the same amount an unchecked row picks up from
+	   --opacity-bg-hover, so hover reads the same everywhere. */
+	&:where(.containerInteractive:hover) {
+		background-color: color-mix(var(--fill-pop-bg) 20%, transparent);
+	}
+
+	/* A run of checked rows reads as one block: the corners where two of them
+	   meet are squared off so the tints join without a notch. */
+	&:has(+ .containerChecked) {
+		border-end-start-radius: 0;
+		border-end-end-radius: 0;
+	}
+
+	.containerChecked + & {
+		border-start-start-radius: 0;
+		border-start-end-radius: 0;
+	}
+}
+
 .containerSelected {
 	background-color: color-mix(var(--fill-gray-bg) var(--opacity-bg-selected-blur), transparent);
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/Row.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Row.tsx
@@ -25,9 +25,24 @@ export const Row: FC<
 		onSelect?: () => void;
 		/** @default false */
 		isHighlighted?: boolean;
+		/**
+		 * Whether the row's checkbox is checked. The row needs this on the
+		 * container — rather than reading it off the checkbox with `:has()` — so
+		 * that a row can also style itself against a *neighbouring* row's checked
+		 * state, which would otherwise require nesting `:has()` inside `:has()`.
+		 */
+		isChecked?: boolean;
 		interactive?: boolean;
 	} & Omit<ComponentProps<"div">, "onSelect">
-> = ({ isSelected, onSelect, isHighlighted, interactive = true, ref: refProp, ...props }) => {
+> = ({
+	isSelected,
+	onSelect,
+	isHighlighted,
+	isChecked,
+	interactive = true,
+	ref: refProp,
+	...props
+}) => {
 	const rowRef = useRef<HTMLDivElement | null>(null);
 	const mergedRef = useMergedRefs(rowRef, refProp);
 
@@ -48,6 +63,7 @@ export const Row: FC<
 			className={classes(
 				props.className,
 				styles.container,
+				isChecked && styles.containerChecked,
 				isSelected && styles.containerSelected,
 				isHighlighted && styles.containerHighlighted,
 				interactive && styles.containerInteractive,


### PR DESCRIPTION


https://github.com/user-attachments/assets/82e7e3d1-ebbf-48b8-988e-02941d755cab



Lite workspace checkbox/selection polish:

- Commit checkboxes now follow the same visibility rules as file checkboxes, instead of their own ad-hoc logic.
- Checked rows get a background tint in both the outline tree and the file tree, so a checked row is readable at a glance.
- Checked rows keep their selection tint when the pane loses focus, rather than dropping to the unfocused style.

TODO:

- Handle "blur but selected" states differently, the current one doesn't look good — too blend.
<img width="406" height="315" alt="Screenshot 2026-08-05 at 23 55 38" src="https://github.com/user-attachments/assets/b8911ad2-e044-4c61-8739-3b19e9e97c22" />
