### PR TITLE
Report what the forge said when a merge is refused

### DIFF
--- a/crates/but-github/src/client.rs
+++ b/crates/but-github/src/client.rs
@@ -503,7 +503,10 @@ impl GitHubClient {
         let response = self.client.put(&url).json(&body).send().await?;
 
         if !response.status().is_success() {
-            bail!("Failed to merge pull request: {}", response.status());
+            bail!(
+                "Failed to merge pull request: {}",
+                response_error(response).await
+            );
         }
 
         Ok(())
@@ -1312,13 +1315,43 @@ struct CheckRunsQuery<'a> {
     page: usize,
 }
 
-/// Render a failed response as `<status>: <body>` so GitHub's error message reaches the user.
+/// Render a failed response as `<status>: <detail>` so GitHub's error message reaches the user.
 pub(crate) async fn response_error(response: reqwest::Response) -> String {
     let status = response.status();
     match response.text().await {
-        Ok(body) if !body.is_empty() => format!("{status}: {body}"),
+        Ok(body) if !body.is_empty() => format!("{status}: {}", error_message(&body)),
         _ => status.to_string(),
     }
+}
+
+/// Return the `message` of a GitHub error body, or `body` itself when that would lose something.
+///
+/// Failures come back as a JSON object whose `message` is the sentence worth showing, alongside
+/// fields like `documentation_url` that only add noise to a toast. A rejected merge is the case
+/// this exists for: the status alone says nothing a user can act on.
+///
+/// `errors` is the exception. It carries the per-field detail that makes a validation failure
+/// diagnosable, of which `message` is only the headline, so such a body is passed through whole.
+fn error_message(body: &str) -> String {
+    // Only an object can be an error body; deserializing straight into a struct would also accept
+    // a JSON array and quietly adopt its first element as the message.
+    let Ok(serde_json::Value::Object(fields)) = serde_json::from_str(body) else {
+        return body.to_owned();
+    };
+
+    let has_details = fields
+        .get("errors")
+        .and_then(serde_json::Value::as_array)
+        .is_some_and(|errors| !errors.is_empty());
+    if has_details {
+        return body.to_owned();
+    }
+
+    fields
+        .get("message")
+        .and_then(serde_json::Value::as_str)
+        .filter(|message| !message.trim().is_empty())
+        .map_or_else(|| body.to_owned(), ToOwned::to_owned)
 }
 
 #[cfg(test)]
@@ -1330,6 +1363,67 @@ mod tests {
     fn graphql_endpoint_for_github_cloud() {
         let endpoint = graphql_endpoint_from_base_url("https://api.github.com");
         assert_eq!(endpoint, "https://api.github.com/graphql");
+    }
+
+    /// A refused merge reaches the user as GitHub's sentence rather than a bare status.
+    #[test]
+    fn error_message_is_what_github_said() {
+        let body = json!({
+            "message": "Rebase merges are not allowed on this repository.",
+            "documentation_url": "https://docs.github.com/rest/pulls/pulls#merge-a-pull-request",
+            "status": "405"
+        })
+        .to_string();
+
+        assert_eq!(
+            error_message(&body),
+            "Rebase merges are not allowed on this repository."
+        );
+    }
+
+    /// `message` is only the headline of a validation failure, so the detail has to survive.
+    #[test]
+    fn error_message_keeps_a_body_that_carries_errors() {
+        let body = json!({
+            "message": "Validation Failed",
+            "errors": [{ "resource": "PullRequest", "field": "base", "code": "invalid" }]
+        })
+        .to_string();
+
+        assert_eq!(error_message(&body), body);
+    }
+
+    #[test]
+    fn error_message_collapses_when_errors_is_empty() {
+        let body = json!({ "message": "Not Found", "errors": [] }).to_string();
+        assert_eq!(error_message(&body), "Not Found");
+    }
+
+    /// A struct would accept a sequence here and adopt its first element as the message.
+    #[test]
+    fn error_message_keeps_a_json_array() {
+        let body = json!(["boom"]).to_string();
+        assert_eq!(error_message(&body), body);
+    }
+
+    #[test]
+    fn error_message_keeps_a_body_that_is_not_json() {
+        assert_eq!(
+            error_message("<html>502 Bad Gateway</html>"),
+            "<html>502 Bad Gateway</html>"
+        );
+    }
+
+    #[test]
+    fn error_message_keeps_json_without_a_message() {
+        let body = json!({ "documentation_url": "https://docs.github.com" }).to_string();
+        assert_eq!(error_message(&body), body);
+    }
+
+    #[test]
+    fn error_message_keeps_the_body_when_the_message_is_blank() {
+        let body = json!({ "message": "   " }).to_string();
+        assert_eq!(error_message(&body), body);
     }
 
     #[test]

--- a/crates/but-gitlab/src/client.rs
+++ b/crates/but-gitlab/src/client.rs
@@ -413,7 +413,9 @@ impl GitLabClient {
         let response = self.client.put(&url).json(&body).send().await?;
 
         if !response.status().is_success() {
-            bail!("Failed to merge merge request: {}", response.status());
+            let status = response.status();
+            let error_text = response.text().await.unwrap_or_default();
+            bail!("Failed to merge merge request: {status} - {error_text}");
         }
 
         Ok(())


### PR DESCRIPTION
## 🧠 Changes

`merge_pull_request` now reports what GitHub said, not just the status it said it with, by using `response_error()` — the helper the rest of the client already reaches for, including `update_pull_request` ten lines above it.

`response_error()` in turn surfaces GitHub's `message` rather than the whole JSON object, so a toast reads `405 Method Not Allowed: <sentence>` instead of that sentence buried between `documentation_url` and `status`. Bodies carrying `errors` are passed through whole, since that array is the part of a validation failure worth reading and `message` is only its headline.

GitLab's `merge_merge_request` had the same gap, in a file that already spells `{status} - {error_text}` at five other sites. One line.

## ☕️ Reasoning

Merging with a method the repository has disabled fails today with nothing to act on. #8403 describes it as two problems stacked: the picker offers all three methods because nothing fetches `allow_merge_commit` / `allow_squash_merge` / `allow_rebase_merge`, and the rejection that follows is reduced to a status code. This is the second one. The first is UI work tracked separately in #8654, and greying options out is easier to judge once the failure is legible.

The change is small because the intent was already there: `response_error()`'s own doc comment says "so GitHub's error message reaches the user", four sites in `stacks.rs` use it, and #15212 is adding seven more. `merge_pull_request` was the one that missed it.

Three things this deliberately does not do:

- `response_error()` itself stays uncovered. Reaching it needs a real `reqwest::Response`, and there is no mock-HTTP anywhere in the workspace; extracting a one-line `format!` purely to test it seemed worse than the gap. What it delegates to is tested, fallbacks included.
- The five remaining `response.status()` sites in `client.rs` are untouched, keeping this a bug fix rather than a sweep. Happy to convert them in one go if you would prefer that.
- Error text now reaches the telemetry `showError` sends. Preferring `message` narrows what that carries compared with raw bodies, which is part of why `errors` is a carve-out rather than the general rule.

I have not reproduced a 405 against a repository with the method disabled, so the exact wording GitHub uses is taken from the issue rather than something I have seen. Nothing in the change depends on it.

## 🎫 Affected issues

Addresses: #8403
