### PR TITLE
but push: exit non-zero when the batch push fails

### DIFF
--- a/crates/but/skill/SKILL.md
+++ b/crates/but/skill/SKILL.md
@@ -78,7 +78,7 @@ The first token on each `but diff` / `but status` line is that line's ID — pas
 - Stack branches: `but move <branch> --above <target-branch>` (**branch names or branch CLI IDs**)
 - Tear off a branch: `but move <branch> --unstack`
 - Discard: `but discard <id> [<id>...]` — accepts branches, commits, committed files, uncommitted files/hunks, or `zz` for all uncommitted changes
-- Push: `but push <top-branch>` — pushes the selected branch and its ancestors; to update a stack, select its top branch once and never loop. Bare `but push` pushes all unpushed work when run non-interactively — one push per stack (its topmost unpushed branch, ancestors included), so output has one entry per stack, not per branch
+- Push: `but push <top-branch>` — pushes the selected branch and its ancestors; to update a stack, select its top branch once and never loop. Bare `but push` pushes all unpushed work when run non-interactively — one push per stack (its topmost unpushed branch, ancestors included), so output has one entry per stack, not per branch. It exits non-zero if any stack failed; stacks that already pushed stay pushed, and rerunning after fixing the failure is safe (up-to-date stacks are skipped)
 - Pull (update workspace from the target): `but pull` — the output reports the result; `but pull --check` previews without updating when a preview is actually needed
 - Create PR: `but pr new <branch-id> [-m "Title..."] [-F pr_message.txt] [-t] [--draft]` — auto-pushes first; do not run `but push` before it
 

--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -366,7 +366,7 @@ but resolve cancel --force
 
 ### `but push <branch>`
 
-Push a selected branch and its ancestors to the remote. To update a whole stack, select its top branch once; never loop over the branches. Always specify which branch to push: without one, `but push` prompts for a selection in interactive terminals (one entry per stack, folding in stack ancestors) and otherwise pushes all unpushed work — one push per stack via its topmost unpushed branch, so output has one entry per stack, not per branch. Accepts a full branch name or a branch CLI ID — prefer the name; it stays valid across mutations.
+Push a selected branch and its ancestors to the remote. To update a whole stack, select its top branch once; never loop over the branches. Always specify which branch to push: without one, `but push` prompts for a selection in interactive terminals (one entry per stack, folding in stack ancestors) and otherwise pushes all unpushed work — one push per stack via its topmost unpushed branch, so output has one entry per stack, not per branch. A batch push exits non-zero if any stack failed; stacks that already pushed stay pushed, and rerunning after fixing the failure is safe since up-to-date stacks are skipped. Accepts a full branch name or a branch CLI ID — prefer the name; it stays valid across mutations.
 
 ```bash
 but push <branch-name>             # Push the selected branch and its ancestors

--- a/crates/but/src/command/legacy/push.rs
+++ b/crates/but/src/command/legacy/push.rs
@@ -669,13 +669,15 @@ async fn push_single_branch_impl(
     .await
 }
 
-/// Returns `true` if at least one branch was pushed successfully.
+/// Errors if any attempted branch failed to push, so the process exits
+/// non-zero; per-branch failures are still printed and reported via JSON
+/// first. An up-to-date workspace with nothing to push is not an error.
 async fn push_all_branches(
     ctx: &mut Context,
     args: &Command,
     gerrit_mode: bool,
     out: &mut OutputChannel,
-) -> anyhow::Result<bool> {
+) -> anyhow::Result<()> {
     let t = theme::get();
     let mut progress = out.progress_channel();
     let branches_to_push = get_push_candidates(ctx)?;
@@ -697,7 +699,7 @@ async fn push_all_branches(
                 t.hint.paint("No branches have unpushed commits.")
             )?;
         }
-        return Ok(false);
+        return Ok(());
     }
 
     writeln!(progress)?;
@@ -831,7 +833,17 @@ async fn push_all_branches(
         }
     }
 
-    Ok(!pushed_results.is_empty())
+    if !failed_branches.is_empty() {
+        let attempted = failed_branches.len() + pushed_results.len();
+        anyhow::bail!(
+            "failed to push {} of {} branch{}",
+            failed_branches.len(),
+            attempted,
+            if attempted == 1 { "" } else { "es" }
+        );
+    }
+
+    Ok(())
 }
 
 fn handle_no_branch_specified(

--- a/crates/but/tests/but/command/push.rs
+++ b/crates/but/tests/but/command/push.rs
@@ -153,6 +153,28 @@ Please resolve conflicts before pushing using 'but resolve <commit>'.
 }
 
 #[test]
+fn push_all_exits_nonzero_when_push_fails() {
+    let env = repo_with_unpushed_branch();
+
+    // Reject every push via a pre-push hook, then push without a branch
+    // argument: the non-interactive push-all path must surface the failure
+    // in the exit code, not just in the printed summary.
+    env.invoke_bash(
+        "mkdir -p .githooks \
+         && printf '#!/bin/sh\\necho PRE-PUSH DENY; exit 1\\n' > .githooks/pre-push \
+         && chmod +x .githooks/pre-push \
+         && git config core.hooksPath .githooks",
+    );
+
+    // Counts are wildcarded: the claim is the non-zero exit on failure, not
+    // how many candidates this fixture happens to produce.
+    env.but("push").assert().failure().stderr_eq(str![[r#"
+Error: failed to push [..] of [..] branches
+
+"#]]);
+}
+
+#[test]
 fn push_refuses_conflicted_commits_on_ancestors() {
     let env = sandbox_with_conflicted_commit();
 


### PR DESCRIPTION
Bare `but push` (the non-interactive default for scripts and agents) collected per-branch failures into the printed summary and JSON, then returned success — so `but push && next-step` recorded green for work that never left the machine. `but push <branch>` already exited 1 for the same failure.

`push_all_branches` now bails with `failed to push N of M branches` after printing the existing per-branch detail, covering hook rejections, unreachable remotes, and partial failures alike. Nothing-to-push remains exit 0. Regression test drives the no-argument form against a denying pre-push hook.

Fixes #15215