### PR TITLE
feat(but): re-implement `but branch new` using new command flags and structure

### DIFF
--- a/crates/but-transaction/src/lib.rs
+++ b/crates/but-transaction/src/lib.rs
@@ -504,16 +504,34 @@ where
             }
             anchor => (anchor, None),
         };
+        let repo = self.repo().clone();
+        let branch_stack_orders = self
+            .inner
+            .pending_metadata_updates
+            .iter()
+            .filter_map(|update| match update {
+                PendingMetadataUpdate::Workspace(_) | PendingMetadataUpdate::Branch(_) => None,
+                PendingMetadataUpdate::BranchStackOrder(branches) => Some(branches.clone()),
+            })
+            .collect();
+        let rebase = self
+            .inner
+            .rebase
+            .as_mut()
+            .expect("rebase is always Some(_)");
+        let (_, persisted_meta) = rebase.repo_and_meta_mut();
         let mut meta = RecordingMetadata {
+            persisted_meta,
             workspace_name: workspace.ref_name().map(ToOwned::to_owned),
             workspace: workspace.metadata.clone(),
+            branch_stack_orders,
             updates: Vec::new(),
         };
 
         but_workspace::branch::create_reference(
             ref_name,
             anchor.clone(),
-            self.repo(),
+            &repo,
             &workspace,
             &mut meta,
             new_stack_id,
@@ -975,12 +993,14 @@ struct PendingCreatedIndependentRef {
 enum PendingMetadataUpdate {
     Workspace(RecordingMetadataHandle<ref_metadata::Workspace>),
     Branch(RecordingMetadataHandle<ref_metadata::Branch>),
+    BranchStackOrder(Vec<FullName>),
 }
 
-#[derive(Default)]
-struct RecordingMetadata {
+struct RecordingMetadata<'meta, M: RefMetadata> {
+    persisted_meta: &'meta M,
     workspace_name: Option<FullName>,
     workspace: Option<ref_metadata::Workspace>,
+    branch_stack_orders: Vec<Vec<FullName>>,
     updates: Vec<PendingMetadataUpdate>,
 }
 
@@ -1017,7 +1037,7 @@ impl<T> ref_metadata::ValueInfo for RecordingMetadataHandle<T> {
     }
 }
 
-impl RefMetadata for RecordingMetadata {
+impl<M: RefMetadata> RefMetadata for RecordingMetadata<'_, M> {
     type Handle<T> = RecordingMetadataHandle<T>;
 
     fn iter(&self) -> impl Iterator<Item = anyhow::Result<(FullName, Box<dyn std::any::Any>)>> {
@@ -1070,6 +1090,34 @@ impl RefMetadata for RecordingMetadata {
                 is_default: value.is_default,
             }));
         Ok(())
+    }
+
+    fn branch_stack_order(&self, ref_name: &FullNameRef) -> anyhow::Result<Option<Vec<FullName>>> {
+        let pending_order = self
+            .updates
+            .iter()
+            .rev()
+            .filter_map(|update| match update {
+                PendingMetadataUpdate::Workspace(_) | PendingMetadataUpdate::Branch(_) => None,
+                PendingMetadataUpdate::BranchStackOrder(branches) => Some(branches),
+            })
+            .chain(self.branch_stack_orders.iter().rev())
+            .find(|branches| branches.iter().any(|branch| branch.as_ref() == ref_name));
+
+        match pending_order {
+            Some(branches) => Ok(Some(branches.clone())),
+            None => self.persisted_meta.branch_stack_order(ref_name),
+        }
+    }
+
+    fn set_branch_stack_order(&mut self, branches: &[FullName]) -> anyhow::Result<()> {
+        self.updates
+            .push(PendingMetadataUpdate::BranchStackOrder(branches.to_vec()));
+        Ok(())
+    }
+
+    fn can_persist_branch_stack_order(&self) -> bool {
+        self.persisted_meta.can_persist_branch_stack_order()
     }
 
     fn remove(&mut self, _ref_name: &FullNameRef) -> anyhow::Result<bool> {
@@ -1326,6 +1374,9 @@ fn workspace_state_from_rebase<M: RefMetadata>(
                 let mut handle = materialized.meta.branch(branch.as_ref())?;
                 *handle = branch.value;
                 materialized.meta.set_branch(&handle)?;
+            }
+            PendingMetadataUpdate::BranchStackOrder(branches) => {
+                materialized.meta.set_branch_stack_order(&branches)?;
             }
         }
     }

--- a/crates/but-transaction/src/tests.rs
+++ b/crates/but-transaction/src/tests.rs
@@ -1,5 +1,5 @@
 use but_api::WorkspaceState;
-use but_core::{DiffSpec, DryRun};
+use but_core::{DiffSpec, DryRun, RefMetadata};
 use but_ctx::Context;
 use but_oplog::legacy::{OperationKind, SnapshotDetails};
 use but_rebase::graph_rebase::mutate::{InsertSide, RelativeTo};
@@ -185,6 +185,98 @@ fn create_reference_without_creating_commits() {
         "created reference should be persisted even if no commits are created"
     );
     assert_num_snapshots(&ctx, 1);
+}
+
+#[test]
+fn create_reference_records_branch_stack_order_in_single_branch_mode() {
+    let env = Sandbox::open_scenario_with_target_and_default_settings("one-stack");
+    env.invoke_git("checkout main");
+
+    let repo = but_testsupport::open_repo(env.projects_root()).unwrap();
+    let mut ctx = Context::from_repo_for_testing(repo)
+        .map(Context::with_memory_app_cache)
+        .unwrap();
+    let mut meta = ctx.meta().unwrap();
+    let snapshot_details = SnapshotDetails::new(OperationKind::CreateBranch);
+    let main = FullName::try_from("refs/heads/main").unwrap();
+    let new_branch = FullName::try_from("refs/heads/new-branch").unwrap();
+    let main_target = ref_target(&env, main.as_ref()).unwrap();
+
+    let _workspace: WorkspaceState = with_transaction(
+        &mut ctx,
+        &mut meta,
+        snapshot_details,
+        DryRun::No,
+        |mut tx| {
+            tx.create_reference(
+                new_branch.as_ref(),
+                Anchor::at_reference(main.as_ref(), Position::Above),
+                |_| but_core::ref_metadata::StackId::generate(),
+                None,
+            )?;
+
+            Ok(())
+        },
+    )
+    .unwrap();
+
+    assert_eq!(
+        Some(main_target),
+        ref_target(&env, new_branch.as_ref()),
+        "single-branch transaction should persist the created reference"
+    );
+    assert_eq!(
+        meta.branch_stack_order(main.as_ref()).unwrap(),
+        Some(vec![new_branch, main]),
+        "single-branch transaction should persist the recorded branch order"
+    );
+    assert_num_snapshots(&ctx, 1);
+}
+
+#[test]
+fn create_reference_rolls_back_branch_stack_order_in_single_branch_mode() {
+    let env = Sandbox::open_scenario_with_target_and_default_settings("one-stack");
+    env.invoke_git("checkout main");
+
+    let repo = but_testsupport::open_repo(env.projects_root()).unwrap();
+    let mut ctx = Context::from_repo_for_testing(repo)
+        .map(Context::with_memory_app_cache)
+        .unwrap();
+    let mut meta = ctx.meta().unwrap();
+    let snapshot_details = SnapshotDetails::new(OperationKind::CreateBranch);
+    let main = FullName::try_from("refs/heads/main").unwrap();
+    let new_branch = FullName::try_from("refs/heads/rolled-back").unwrap();
+
+    let outcome = with_transaction(
+        &mut ctx,
+        &mut meta,
+        snapshot_details,
+        DryRun::No,
+        |mut tx| {
+            tx.create_reference(
+                new_branch.as_ref(),
+                Anchor::at_reference(main.as_ref(), Position::Above),
+                |_| but_core::ref_metadata::StackId::generate(),
+                None,
+            )?;
+
+            Ok(tx.rollback("rolled back"))
+        },
+    )
+    .unwrap();
+
+    assert_eq!(outcome, "rolled back");
+    assert_eq!(
+        ref_target(&env, new_branch.as_ref()),
+        None,
+        "rolled-back single-branch transaction should remove the created reference"
+    );
+    assert_eq!(
+        meta.branch_stack_order(main.as_ref()).unwrap(),
+        None,
+        "rolled-back single-branch transaction should not persist branch order"
+    );
+    assert_num_snapshots(&ctx, 0);
 }
 
 #[test]

--- a/crates/but/src/args/atoms/cli_id.rs
+++ b/crates/but/src/args/atoms/cli_id.rs
@@ -1,6 +1,5 @@
 use but_core::ref_metadata::StackId;
 use nonempty::NonEmpty;
-use serde::Serialize;
 
 use crate::{
     CliError, CliId, CliResult, IdMap,
@@ -11,8 +10,7 @@ use crate::{
 };
 
 /// An argument atom for cli ids that can match multiple things like branches, commits, files, etc.
-#[derive(Debug, Clone, Serialize)]
-#[serde(transparent)]
+#[derive(Debug, Clone)]
 pub struct CliIdArg(pub String);
 
 impl std::str::FromStr for CliIdArg {

--- a/crates/but/src/args/branch.rs
+++ b/crates/but/src/args/branch.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "legacy")]
-use crate::args::atoms::{BranchArg, CliIdArg};
+use crate::args::atoms::{AllowMergedArg, BranchArg, CliIdArg};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum, Default)]
 pub enum IntegrationStrategy {
@@ -23,24 +23,9 @@ pub struct Platform {
 
 #[derive(Debug, clap::Subcommand)]
 pub enum Subcommands {
-    /// Creates a new branch in the workspace
-    ///
-    /// If no branch name is provided, a new parallel branch with a generated
-    /// name will be created.
-    ///
-    /// You can also specify an anchor point using the `--anchor` option,
-    /// which can be either a commit ID or an existing branch name to create
-    /// the new branch from. This allows you to create stacked branches.
-    ///
     #[cfg(feature = "legacy")]
     #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
-    New {
-        /// Name of the new branch
-        branch_name: Option<BranchArg>,
-        /// Anchor point - either a commit ID or branch name to create the new branch from
-        #[clap(long, short = 'a')]
-        anchor: Option<CliIdArg>,
-    },
+    New(NewPlatform),
 
     /// Delete branchs from the workspace
     ///
@@ -161,4 +146,60 @@ pub enum Subcommands {
         #[clap(long, short = 'i')]
         interactive: bool,
     },
+}
+
+/// Create a new branch.
+///
+/// Use `--above` or `--below` to created stacked branches. Omitting these create a new unstacked
+/// branch.
+///
+/// For more details about CLI IDs, see `but help cli-ids`.
+#[cfg(feature = "legacy")]
+#[derive(Debug, clap::Parser)]
+#[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
+pub struct NewPlatform {
+    /// Place the branch above `BRANCH_OR_COMMIT`, which must be an applied branch or commit.
+    ///
+    /// If `BRANCH_OR_COMMIT` is a commit, the new branch is created above the commit.
+    ///
+    /// If `BRANCH_OR_COMMIT` is a branch, the new branch is created above the targeted branch.
+    #[clap(
+        short = 'A',
+        long,
+        value_name = "BRANCH_OR_COMMIT",
+        group = "targeting"
+    )]
+    pub above: Option<CliIdArg>,
+
+    /// Deprecated flag that will be removed in a future release. Use `--above` instead.
+    #[clap(
+        short,
+        long,
+        value_name = "BRANCH_OR_COMMIT",
+        group = "targeting",
+        hide = true
+    )]
+    pub anchor: Option<CliIdArg>,
+
+    /// Place the branch below `BRANCH_OR_COMMIT`, which must be an applied branch or commit.
+    ///
+    /// If `BRANCH_OR_COMMIT` is a commit, the new branch is created below the commit.
+    ///
+    /// If `BRANCH_OR_COMMIT` is a branch, the new branch is created below the targeted branch.
+    #[clap(
+        short = 'B',
+        long,
+        value_name = "BRANCH_OR_COMMIT",
+        group = "targeting"
+    )]
+    pub below: Option<CliIdArg>,
+
+    /// Name of the new branch.
+    ///
+    /// If omitted the new branch will get a generated name.
+    pub name: Option<BranchArg>,
+
+    #[clap(flatten)]
+    #[allow(missing_docs)]
+    pub allow_merged: AllowMergedArg,
 }

--- a/crates/but/src/command/legacy/branch/json.rs
+++ b/crates/but/src/command/legacy/branch/json.rs
@@ -1,14 +1,5 @@
 use serde::Serialize;
 
-use crate::args::atoms::CliIdArg;
-
-#[derive(Debug, Serialize)]
-pub struct BranchNewOutput {
-    pub branch: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub anchor: Option<CliIdArg>,
-}
-
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BranchListOutput {

--- a/crates/but/src/command/legacy/branch/mod.rs
+++ b/crates/but/src/command/legacy/branch/mod.rs
@@ -1,16 +1,16 @@
 use anyhow::Context as _;
-use but_api::json::HexHash;
 use but_ctx::Context;
 use itertools::Itertools;
 use nonempty::NonEmpty;
 
 use crate::{
     CliResult, IdMap,
-    args::atoms::{BranchArg, BranchOrCommit, CliIdArg, Purpose, ResolvedCliIdArg},
+    args::atoms::CliIdArg,
     command::legacy::discard::{self, DiscardOutcome},
-    theme::{self, Paint},
     utils::{IntermediateChannel, OutputChannel},
 };
+
+pub mod new;
 
 mod json;
 mod list;
@@ -45,103 +45,6 @@ pub fn delete(
         guard.write_permission(),
         discard::DiscardOperation::Branches(branches),
     )?)
-}
-
-pub fn new(
-    ctx: &mut but_ctx::Context,
-    out: &mut OutputChannel,
-    branch_name_arg: Option<BranchArg>,
-    anchor_arg: Option<CliIdArg>,
-) -> CliResult<()> {
-    let mut guard = ctx.exclusive_worktree_access();
-
-    let branch_name = if let Some(branch_name_arg) = branch_name_arg {
-        let (repo, ws, _db) = ctx.workspace_and_db_with_perm(guard.read_permission())?;
-        branch_name_arg
-            .resolve_for_creation(&repo, &ws)?
-            .shorten()
-            .to_string()
-    } else {
-        but_api::legacy::workspace::canned_branch_name(ctx)?
-    };
-
-    let id_map = IdMap::new_from_context(ctx, guard.read_permission())?;
-
-    let resolved_anchor = {
-        let repo = ctx.repo.get()?;
-        anchor_arg
-            .clone()
-            .map(|anchor| anchor.resolve_in_workspace(&repo, &id_map, Purpose::Anchor, None))
-            .transpose()?
-    };
-
-    let anchor = resolved_anchor
-        .clone()
-        .map(|anchor| -> CliResult<_> {
-            match anchor.into_branch_or_commit()? {
-                BranchOrCommit::Commit(commit) => {
-                    Ok(but_api::legacy::stack::create_reference::Anchor::AtCommit {
-                        commit_id: HexHash(commit.commit_id),
-                        position: but_workspace::branch::create_reference::Position::Above,
-                    })
-                }
-                BranchOrCommit::Branch(BranchArg(name)) => Ok(
-                    but_api::legacy::stack::create_reference::Anchor::AtSegment {
-                        short_name: name.clone(),
-                        position: but_workspace::branch::create_reference::Position::Above,
-                    },
-                ),
-            }
-        })
-        .transpose()?;
-
-    but_api::legacy::stack::create_reference_with_perm(
-        ctx,
-        but_api::legacy::stack::create_reference::Request {
-            new_name: branch_name.clone(),
-            anchor,
-        },
-        guard.write_permission(),
-    )?;
-
-    write_new_branch_output(out, &branch_name, resolved_anchor.as_ref(), anchor_arg)?;
-
-    Ok(())
-}
-
-fn write_new_branch_output(
-    out: &mut OutputChannel,
-    branch_name: &str,
-    resolved_anchor: Option<&ResolvedCliIdArg>,
-    anchor_arg: Option<CliIdArg>,
-) -> CliResult<()> {
-    let t = theme::get();
-    if let Some(out) = out.for_human() {
-        if let Some(resolved_anchor) = resolved_anchor {
-            writeln!(
-                out,
-                "{} Created branch {} stacked on {}",
-                t.sym().success,
-                t.local_branch.paint(branch_name),
-                t.hint.paint(format!("{resolved_anchor}")),
-            )?;
-        } else {
-            writeln!(
-                out,
-                "{} Created branch {}",
-                t.sym().success,
-                t.local_branch.paint(branch_name),
-            )?;
-        }
-    } else if let Some(out) = out.for_json() {
-        let value = json::BranchNewOutput {
-            branch: branch_name.to_owned(),
-            anchor: anchor_arg,
-        };
-        out.write_value(value)?;
-    }
-
-    Ok(())
 }
 
 pub fn show_branches(

--- a/crates/but/src/command/legacy/branch/new.rs
+++ b/crates/but/src/command/legacy/branch/new.rs
@@ -1,0 +1,320 @@
+use std::borrow::Cow;
+
+use anyhow::Context as _;
+use but_core::{
+    DryRun, RefMetadata,
+    ref_metadata::StackId,
+    sync::{RepoExclusive, RepoShared},
+};
+use but_ctx::Context;
+use but_workspace::{
+    RefInfo,
+    branch::create_reference::{Anchor, Position},
+};
+use gitbutler_oplog::entry::{OperationKind, SnapshotDetails};
+use gix::refs::FullName;
+use serde::Serialize;
+
+use crate::{
+    CliResult, IdMap,
+    args::{
+        atoms::{BranchOrCommit, CliIdArg, Priority, Purpose},
+        branch::NewPlatform,
+    },
+    id::CommitId,
+    print_deprecation_warning,
+    theme::{self, Theme},
+    utils::{
+        CliOutput, CliOutputHuman, IntermediateChannel, WriteWithUtils,
+        merged_upstream::MergedUpstream, targeting::Side,
+    },
+};
+
+pub fn new(
+    ctx: &mut Context,
+    _out: IntermediateChannel<'_>,
+    args: NewPlatform,
+) -> CliResult<NewOutcome> {
+    let mut guard = ctx.exclusive_worktree_access();
+    let mut meta = ctx.meta()?;
+    let id_map = IdMap::new_from_context(ctx, guard.read_permission())?;
+
+    let operation = {
+        let head_info = but_api::legacy::workspace::head_info(ctx)?;
+        resolve(ctx, guard.read_permission(), args, &head_info, &id_map)?
+    };
+
+    Ok(run(ctx, &mut meta, guard.write_permission(), operation)?)
+}
+
+fn resolve(
+    ctx: &mut Context,
+    perm: &RepoShared,
+    args: NewPlatform,
+    head_info: &RefInfo,
+    id_map: &IdMap,
+) -> CliResult<NewOperation> {
+    let NewPlatform {
+        above,
+        below,
+        anchor,
+        name,
+        allow_merged,
+    } = args;
+
+    let merged = MergedUpstream::new(&*ctx.repo.get()?, head_info, allow_merged);
+
+    let (repo, ws, _db) = ctx.workspace_and_db_with_perm(perm)?;
+
+    let name = name
+        .map(|name| name.resolve_for_creation(&repo, &ws))
+        .transpose()?;
+
+    let above = match (above, anchor) {
+        (None, None) => None,
+        (None, Some(anchor)) => {
+            print_deprecation_warning(
+                "`--anchor/-a` is deprecated and will be removed in a future release. Use `--above/-A` instead",
+            );
+            Some(anchor)
+        }
+        (Some(above), None) => Some(above),
+        (Some(_), Some(_)) => {
+            unreachable!("--anchor and --above are mutually exclusive in the clap args")
+        }
+    };
+
+    match (above, below) {
+        (None, None) => Ok(NewOperation::NewUnstackedBranch { name }),
+        (None, Some(target_below)) => {
+            let target = resolve_above_below_target(&repo, id_map, target_below)?;
+
+            match &target {
+                NewStackedBranchTarget::Commit(commit) => {
+                    merged.ensure_commit_not_merged(commit.commit_id)?;
+                }
+                NewStackedBranchTarget::Branch(target) => {
+                    merged.ensure_branch_not_merged(target.as_ref())?;
+                }
+            }
+
+            Ok(NewOperation::NewStackedBranch {
+                name,
+                target,
+                side: Side::Below,
+            })
+        }
+        (Some(target_above), None) => {
+            let target = resolve_above_below_target(&repo, id_map, target_above)?;
+            Ok(NewOperation::NewStackedBranch {
+                name,
+                target,
+                side: Side::Above,
+            })
+        }
+        (Some(_), Some(_)) => {
+            unreachable!("--above and --below are mutually exclusive in the clap args")
+        }
+    }
+}
+
+fn resolve_above_below_target(
+    repo: &gix::Repository,
+    id_map: &IdMap,
+    target: CliIdArg,
+) -> CliResult<NewStackedBranchTarget> {
+    let target = target
+        .resolve_in_workspace(
+            repo,
+            id_map,
+            Purpose::Target,
+            Some(Priority::BranchAndCommit),
+        )?
+        .into_branch_or_commit()?;
+
+    Ok(match target {
+        BranchOrCommit::Commit(commit) => NewStackedBranchTarget::Commit(commit),
+        BranchOrCommit::Branch(branch_arg) => {
+            NewStackedBranchTarget::Branch(branch_arg.resolve_local_branch_name()?)
+        }
+    })
+}
+
+pub enum NewOperation {
+    NewUnstackedBranch {
+        name: Option<FullName>,
+    },
+    NewStackedBranch {
+        name: Option<FullName>,
+        target: NewStackedBranchTarget,
+        side: Side,
+    },
+}
+
+pub enum NewStackedBranchTarget {
+    Commit(CommitId),
+    Branch(FullName),
+}
+
+pub fn run(
+    ctx: &mut Context,
+    meta: &mut impl RefMetadata,
+    perm: &mut RepoExclusive,
+    operation: NewOperation,
+) -> anyhow::Result<NewOutcome> {
+    let in_single_branch_mode = ctx.settings.feature_flags.single_branch
+        && gitbutler_operating_modes::in_outside_workspace_mode(ctx, perm.read_permission())?;
+    let mut checkout_after_create = false;
+
+    let snapshot_details = SnapshotDetails::new(OperationKind::CreateBranch);
+    let (name, _ws) = but_transaction::with_transaction_with_perm(
+        ctx,
+        meta,
+        perm,
+        snapshot_details,
+        DryRun::No,
+        |mut tx| {
+            let new_ref = match &operation {
+                NewOperation::NewStackedBranch { name, .. }
+                | NewOperation::NewUnstackedBranch { name } => {
+                    if let Some(name) = name {
+                        name.clone()
+                    } else {
+                        but_core::branch::unique_canned_refname(tx.repo())?
+                    }
+                }
+            };
+
+            let anchor = match &operation {
+                NewOperation::NewUnstackedBranch { name: _ } => None,
+                NewOperation::NewStackedBranch {
+                    name: _,
+                    target,
+                    side,
+                } => Some(match target {
+                    NewStackedBranchTarget::Commit(commit_target) => Anchor::AtCommit {
+                        commit_id: commit_target.commit_id,
+                        position: (*side).into(),
+                    },
+                    NewStackedBranchTarget::Branch(branch_target) => {
+                        Anchor::at_segment(branch_target.as_ref(), (*side).into())
+                    }
+                }),
+            };
+
+            let anchor = if let Some(anchor) = anchor {
+                match anchor {
+                    Anchor::AtSegment { position, ref_name }
+                        if matches!(position, Position::Above) && in_single_branch_mode =>
+                    {
+                        let head_name = head_name(tx.repo())?;
+                        if &*ref_name == head_name.as_ref() {
+                            Some(single_branch_mode_anchor(
+                                head_name,
+                                &mut checkout_after_create,
+                            )?)
+                        } else {
+                            Some(Anchor::AtReference { ref_name, position })
+                        }
+                    }
+                    _ => Some(anchor),
+                }
+            } else if in_single_branch_mode {
+                let head_name = head_name(tx.repo())?;
+                Some(single_branch_mode_anchor(
+                    head_name,
+                    &mut checkout_after_create,
+                )?)
+            } else {
+                None
+            };
+
+            tx.create_reference(new_ref.as_ref(), anchor, |_| StackId::generate(), Some(0))?;
+
+            Ok(but_transaction::Commit(new_ref))
+        },
+    )?;
+
+    if checkout_after_create {
+        but_api::branch::branch_checkout_with_perm(ctx, name.clone(), perm)?;
+    }
+
+    let target = match operation {
+        NewOperation::NewUnstackedBranch { .. } => None,
+        NewOperation::NewStackedBranch { target, side, .. } => Some((target, side)),
+    };
+
+    Ok(NewOutcome { name, target })
+}
+
+fn head_name(repo: &gix::Repository) -> anyhow::Result<FullName> {
+    Ok(repo
+        .head()?
+        .referent_name()
+        .filter(|name| name.category() == Some(gix::refs::Category::LocalBranch))
+        .context("single-branch branch creation requires HEAD to be a local branch")?
+        .to_owned())
+}
+
+fn single_branch_mode_anchor(
+    head_name: FullName,
+    checkout_after_create: &mut bool,
+) -> anyhow::Result<Anchor<'static>> {
+    *checkout_after_create = true;
+
+    Ok(Anchor::AtReference {
+        ref_name: Cow::Owned(head_name),
+        position: Side::Above.into(),
+    })
+}
+
+#[must_use]
+pub struct NewOutcome {
+    pub name: FullName,
+    pub target: Option<(NewStackedBranchTarget, Side)>,
+}
+
+impl CliOutputHuman for NewOutcome {
+    fn on_human(
+        self,
+        out: &mut dyn WriteWithUtils,
+        _agent: bool,
+        _theme: &Theme,
+    ) -> anyhow::Result<()> {
+        let Self { name, target } = self;
+
+        write!(out, "Created branch {}", theme::Branch(name))?;
+
+        if let Some((target, side)) = target {
+            write!(out, " {side} ")?;
+            match target {
+                NewStackedBranchTarget::Commit(commit_target) => {
+                    write!(out, "commit {}", theme::Commit(commit_target))?;
+                }
+                NewStackedBranchTarget::Branch(branch_target) => {
+                    write!(out, "branch {}", theme::Branch(branch_target))?;
+                }
+            }
+        }
+
+        writeln!(out)?;
+
+        Ok(())
+    }
+}
+
+impl CliOutput for NewOutcome {
+    fn on_json(self) -> impl serde::Serialize {
+        #[derive(Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Output {
+            branch: String,
+        }
+
+        let Self { name, target: _ } = self;
+
+        Output {
+            branch: name.shorten().to_string(),
+        }
+    }
+}

--- a/crates/but/src/command/legacy/status/tui/app/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/app/mod.rs
@@ -20,6 +20,10 @@ use crate::{
     args::atoms::ResolvedCliIdArg,
     command::{
         legacy::{
+            branch::{
+                self,
+                new::{NewOperation, NewStackedBranchTarget},
+            },
             commit::{
                 self, CommitAtOperation, CommitOperation, CommitRelativeToTarget, CommitSelection,
             },
@@ -1508,12 +1512,39 @@ impl App {
                 let CliId::Branch(branch) = &**cli_id else {
                     return Ok(());
                 };
-                operations::create_branch_anchored_legacy(ctx, branch.name.to_owned())?
+
+                let mut guard = ctx.exclusive_worktree_access();
+                let mut meta = ctx.meta()?;
+
+                let outcome = branch::new::run(
+                    ctx,
+                    &mut meta,
+                    guard.write_permission(),
+                    NewOperation::NewStackedBranch {
+                        name: None,
+                        target: NewStackedBranchTarget::Branch(
+                            Category::LocalBranch.to_full_name(&*branch.name)?,
+                        ),
+                        side: Side::Above,
+                    },
+                )?;
+
+                outcome.name.shorten().to_string()
             }
             StatusOutputLineData::UncommittedChanges { .. }
             | StatusOutputLineData::MergeBase
             | StatusOutputLineData::UncommittedFile { .. } => {
-                operations::create_branch_legacy(ctx)?
+                let mut guard = ctx.exclusive_worktree_access();
+                let mut meta = ctx.meta()?;
+
+                let outcome = branch::new::run(
+                    ctx,
+                    &mut meta,
+                    guard.write_permission(),
+                    NewOperation::NewUnstackedBranch { name: None },
+                )?;
+
+                outcome.name.shorten().to_string()
             }
             StatusOutputLineData::UpdateNotice
             | StatusOutputLineData::Connector

--- a/crates/but/src/command/legacy/status/tui/operations.rs
+++ b/crates/but/src/command/legacy/status/tui/operations.rs
@@ -79,35 +79,6 @@ pub fn commit_message_has_multiple_lines_legacy(message: &str) -> bool {
     legacy::commit_message_prep::commit_message_has_multiple_lines(message)
 }
 
-pub fn create_branch_anchored_legacy(
-    ctx: &mut Context,
-    short_name: String,
-) -> anyhow::Result<String> {
-    let new_name = but_api::legacy::workspace::canned_branch_name(ctx)
-        .context("failed to generate branch name")?;
-    let anchor = but_api::legacy::stack::create_reference::Anchor::AtSegment {
-        short_name,
-        position: but_workspace::branch::create_reference::Position::Above,
-    };
-    let req = but_api::legacy::stack::create_reference::Request {
-        new_name: new_name.clone(),
-        anchor: Some(anchor),
-    };
-    but_api::legacy::stack::create_reference(ctx, req).context("failed to create branch")?;
-    Ok(new_name)
-}
-
-pub fn create_branch_legacy(ctx: &mut Context) -> anyhow::Result<String> {
-    let new_name = but_api::legacy::workspace::canned_branch_name(ctx)
-        .context("failed to generate branch name")?;
-    let req = but_api::legacy::stack::create_reference::Request {
-        new_name: new_name.clone(),
-        anchor: None,
-    };
-    but_api::legacy::stack::create_reference(ctx, req).context("failed to create branch")?;
-    Ok(new_name)
-}
-
 pub fn commit_is_empty(ctx: &mut Context, commit_id: gix::ObjectId) -> anyhow::Result<bool> {
     let repo = ctx.repo.get()?;
     let commit = but_core::Commit::from_id(commit_id.attach(&repo))?;

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/moving_multiple_commits_005.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/moving_multiple_commits_005.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="820" height="380" viewBox="0 0 820 380">
   <rect x="0" y="0" width="820" height="380" fill="#000000" />
-  <rect x="10" y="82" width="800" height="18" fill="#45475A" />
+  <rect x="10" y="64" width="800" height="18" fill="#45475A" />
   <rect x="10" y="352" width="80" height="18" fill="#555555" />
   <g font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">
     <text x="10 18" y="24" style="fill:#CCCCCC;">╭┄</text>
@@ -16,16 +16,16 @@
     <text x="66" y="60" style="fill:#CCCCCC;">[</text>
     <text x="74 82 90 98 106 114 122 130 138 146" y="60" style="fill:#00AA00;">c-branch-1</text>
     <text x="154" y="60" style="fill:#CCCCCC;">]</text>
-    <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#AA00AA;">l</text>
-    <text x="58 66" y="78" style="fill:#CCCCCC;opacity:0.75;">rm</text>
-    <text x="82 90 98" y="78" style="fill:#CCCCCC;">add</text>
-    <text x="114" y="78" style="fill:#CCCCCC;">B</text>
-    <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="96" style="fill:#AA00AA;font-weight:bold;">t</text>
-    <text x="58 66" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">pm</text>
-    <text x="82 90 98" y="96" style="fill:#FFFFFF;font-weight:bold;">add</text>
-    <text x="114" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
+    <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
+    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">t</text>
+    <text x="58 66" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">pm</text>
+    <text x="82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;">add</text>
+    <text x="114" y="78" style="fill:#FFFFFF;font-weight:bold;">A</text>
+    <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
+    <text x="50" y="96" style="fill:#AA00AA;">l</text>
+    <text x="58 66" y="96" style="fill:#CCCCCC;opacity:0.75;">rm</text>
+    <text x="82 90 98" y="96" style="fill:#CCCCCC;">add</text>
+    <text x="114" y="96" style="fill:#CCCCCC;">B</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="150" style="fill:#CCCCCC;">┊╭┄</text>

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -819,10 +819,10 @@ async fn match_subcommand(
                 .emit_metrics(metrics_ctx)
             }
             #[cfg(feature = "legacy")]
-            Some(branch::Subcommands::New {
-                branch_name,
-                anchor,
-            }) => {
+            Some(branch::Subcommands::New(new_args)) => {
+                use crate::utils::IntermediateChannel;
+
+                let status_after = args.status_after;
                 let mut ctx = setup::init_ctx(
                     &args,
                     InitCtxOptions {
@@ -831,8 +831,23 @@ async fn match_subcommand(
                     },
                     out,
                 )?;
-                command::legacy::branch::new(&mut ctx, out, branch_name, anchor)
-                    .emit_metrics(metrics_ctx)
+                out.begin_status_after(status_after);
+
+                let conflicts_before = command::legacy::conflict_notice::snapshot(&ctx);
+                let outcome = command::legacy::branch::new::new(
+                    &mut ctx,
+                    IntermediateChannel::new(out),
+                    new_args,
+                )
+                .emit_metrics(metrics_ctx)?;
+                out.print_cli_output(outcome)?;
+                command::legacy::conflict_notice::report_newly_conflicted(
+                    &ctx,
+                    out,
+                    conflicts_before,
+                );
+                run_status_after_if_requested(status_after, &mut ctx, out);
+                Ok(())
             }
             #[cfg(feature = "legacy")]
             Some(branch::Subcommands::Delete { branches }) => {

--- a/crates/but/tests/but/command/branch/new.rs
+++ b/crates/but/tests/but/command/branch/new.rs
@@ -22,16 +22,16 @@ fn outputs_branch_name() {
         .success()
         .stderr_eq(str![])
         .stdout_eq(str![[r#"
-✓ Created branch my-feature
+Created branch 'my-feature'
 
 "#]]);
 
-    env.but("branch new --anchor tpm my-anchored-feature")
+    env.but("branch new --above tpm my-anchored-feature")
         .assert()
         .success()
         .stderr_eq(str![])
         .stdout_eq(str![[r#"
-✓ Created branch my-anchored-feature stacked on [..]
+Created branch 'my-anchored-feature' above commit tpm
 
 "#]]);
 }
@@ -42,11 +42,11 @@ fn rejects_anchor_outside_workspace() {
     env.setup_metadata(&["A"]);
     env.but("unapply A").assert().success();
 
-    env.but("branch new --anchor A new-branch")
+    env.but("branch new --above A new-branch")
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
-Error: Could not find anchor: 'A'
+Error: Could not find target: 'A'
 
 Hint: Run `but status` for applicable targets.
 
@@ -135,122 +135,85 @@ Error: A branch named 'A' exists but is not applied
 #[test]
 fn with_json_output() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
-    snapbox::assert_data_eq!(
-        env.git_log(),
-        snapbox::str![[r#"
-* edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-* 9477ae7 (A) add A
-* 0dc3733 (origin/main, origin/HEAD, main) add M
-
-"#]]
-    );
-
     env.setup_metadata(&["A"]);
 
-    // Test JSON output without anchor
-    env.but("--json branch new my-feature")
+    env.but("--json branch new middle")
         .allow_json()
         .assert()
         .success()
         .stderr_eq(str![])
         .stdout_eq(str![[r#"
 {
-  "branch": "my-feature"
+  "branch": "middle"
 }
 
 "#]]);
 
-    // Test JSON output with anchor
-    env.but("branch new --json --anchor tpm my-anchored-feature")
+    env.but("branch new --json bottom --below middle")
         .allow_json()
         .assert()
         .success()
         .stderr_eq(str![])
         .stdout_eq(str![[r#"
 {
-  "branch": "my-anchored-feature",
-  "anchor": "tpm"
+  "branch": "bottom"
 }
 
 "#]]);
 
-    // TODO: on error
-    // On error, we indicate this both by exit code and by json output to stdout
-    // so tools would be able to detect it that way.
+    env.but("branch new --json top --above middle")
+        .allow_json()
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+{
+  "branch": "top"
+}
+
+"#]]);
 }
 
 #[test]
-fn single_branch_outputs_created_branch_for_all_formats() {
+fn create_new_branch_in_single_branch_mode() {
     let env = Sandbox::open_with_default_settings("one-fork");
 
-    env.but("branch new human-feature")
+    env.but("status")
         .assert()
         .success()
         .stderr_eq(str![])
         .stdout_eq(str![[r#"
-✓ Created branch human-feature
-
-"#]]);
-
-    env.but("branch new shell-feature")
-        .assert()
-        .success()
-        .stderr_eq(str![])
-        .stdout_eq(str![[r#"
-✓ Created branch shell-feature
-
-"#]]);
-
-    env.but("--json branch new json-feature")
-        .allow_json()
-        .assert()
-        .success()
-        .stderr_eq(str![])
-        .stdout_eq(str![[r#"
-{
-  "branch": "json-feature"
-}
-
-"#]]);
-
-    let repo = env.open_repo();
-    for branch_name in ["human-feature", "shell-feature", "json-feature"] {
-        let reference_name = format!("refs/heads/{branch_name}");
-        assert!(
-            repo.try_find_reference(reference_name.as_str())
-                .unwrap()
-                .is_some(),
-            "single-branch creation writes the branch reference"
-        );
-    }
-    assert!(
-        repo.try_find_reference(but_core::WORKSPACE_REF_NAME)
-            .unwrap()
-            .is_none(),
-        "single-branch creation does not create a managed workspace reference"
-    );
-}
-
-#[test]
-fn single_branch_stacks_new_branches_above_head_and_checks_them_out() {
-    let env = Sandbox::open_with_default_settings("one-fork");
-
-    env.but("branch new first").assert().success();
-    env.but("branch new second").assert().success();
-
-    let repo = env.open_repo();
-    assert_eq!(
-        repo.head_name().unwrap().unwrap().as_bstr(),
-        "refs/heads/second",
-        "each single-branch creation checks out the newly created branch"
-    );
-
-    env.but("status").assert().success().stdout_eq(str![[r#"
 ╭┄ zz [uncommitted] (no changes)
 ┊
-┊╭┄ se [second] (no commits)
-┊│
-┊├┄ fi [first] (no commits)
+┊╭┄ ma [main]
+┊●   nmy M (no changes)
+├╯
+┊
+┴ e31e6ca (common base) 2000-01-02 add init
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("branch new middle")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+Created branch 'middle'
+
+"#]]);
+
+    // NOTE: the fact that `┊●   ply add init` suddenly shows up appears to be a bug in but-graph.
+    // At least according to gpt-5.6-sol
+    env.but("status")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ mi [middle] (no commits)
 ┊│
 ┊├┄ ma [main]
 ┊●   nmy M (no changes)
@@ -262,35 +225,287 @@ fn single_branch_stacks_new_branches_above_head_and_checks_them_out() {
 Hint: run `but help` for all commands
 
 "#]]);
-}
 
-#[test]
-fn single_branch_stacks_anchored_branch_on_named_branch() {
-    let env = Sandbox::open_with_default_settings("one-fork");
-
-    env.but("branch new first").assert().success();
-    env.but("branch new --anchor first stacked")
+    env.but("branch new bottom --below middle")
         .assert()
         .success()
         .stderr_eq(str![])
         .stdout_eq(str![[r#"
-✓ Created branch stacked stacked on first
+Created branch 'bottom' below branch 'middle'
+
+"#]]);
+
+    env.but("status")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ mi [middle] (no commits)
+┊│
+┊├┄ bo [bottom] (no commits)
+┊│
+┊├┄ ma [main]
+┊●   nmy M (no changes)
+┊●   ply add init
+├╯
+┊
+┴ e31e6ca (common base) 2000-01-02 add init
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("branch new top --above middle")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+Created branch 'top' above branch 'middle'
+
+"#]]);
+
+    env.but("status")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ to [top] (no commits)
+┊│
+┊├┄ mi [middle] (no commits)
+┊│
+┊├┄ bo [bottom] (no commits)
+┊│
+┊├┄ ma [main]
+┊●   nmy M (no changes)
+┊●   ply add init
+├╯
+┊
+┴ e31e6ca (common base) 2000-01-02 add init
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("branch new between-middle-and-top --above middle")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+Created branch 'between-middle-and-top' above branch 'middle'
+
+"#]]);
+
+    env.but("status")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ to [top] (no commits)
+┊│
+┊├┄ et [between-middle-and-top] (no commits)
+┊│
+┊├┄ mi [middle] (no commits)
+┊│
+┊├┄ bo [bottom] (no commits)
+┊│
+┊├┄ ma [main]
+┊●   nmy M (no changes)
+┊●   ply add init
+├╯
+┊
+┴ e31e6ca (common base) 2000-01-02 add init
+
+Hint: run `but help` for all commands
 
 "#]]);
 
     let repo = env.open_repo();
-    assert_eq!(
-        repo.head_name().unwrap().unwrap().as_bstr(),
-        "refs/heads/stacked",
-        "creating above the checked-out anchor checks out the new branch"
-    );
 
-    env.but("status").assert().success().stdout_eq(str![[r#"
+    // ensure the branches exist for real
+    for branch_name in ["top", "between-middle-and-top", "middle", "bottom"] {
+        let reference_name = format!("refs/heads/{branch_name}");
+        assert!(
+            repo.try_find_reference(reference_name.as_str())
+                .unwrap()
+                .is_some(),
+            "single-branch creation writes the branch reference"
+        );
+    }
+
+    // ensure we didn't create the workspace ref
+    assert!(
+        repo.try_find_reference(but_core::WORKSPACE_REF_NAME)
+            .unwrap()
+            .is_none(),
+        "single-branch creation does not create a managed workspace reference"
+    );
+}
+
+#[test]
+fn create_new_branches_with_commits_in_single_branch_mode() {
+    let env = Sandbox::open_with_default_settings("one-fork");
+
+    env.but("status")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
 ╭┄ zz [uncommitted] (no changes)
 ┊
-┊╭┄ st [stacked] (no commits)
+┊╭┄ ma [main]
+┊●   nmy M (no changes)
+├╯
+┊
+┴ e31e6ca (common base) 2000-01-02 add init
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("branch new middle")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Created branch 'middle'
+
+"#]]);
+
+    env.but("commit --empty -b middle -m 'on middle'")
+        .assert()
+        .success();
+
+    env.but("status")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ mi [middle]
+┊●   1 on middle (no changes)
 ┊│
-┊├┄ fi [first] (no commits)
+┊├┄ ma [main]
+┊●   nmy M (no changes)
+┊●   ply add init
+├╯
+┊
+┴ e31e6ca (common base) 2000-01-02 add init
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("branch new top --above middle")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Created branch 'top' above branch 'middle'
+
+"#]]);
+
+    env.but("commit --empty -b top -m 'on top'")
+        .assert()
+        .success();
+
+    env.but("status")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ to [top]
+┊●   1#0 on top (no changes)
+┊│
+┊├┄ mi [middle]
+┊●   1#1 on middle (no changes)
+┊│
+┊├┄ ma [main]
+┊●   nmy M (no changes)
+┊●   ply add init
+├╯
+┊
+┴ e31e6ca (common base) 2000-01-02 add init
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("branch new bottom --below middle")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Created branch 'bottom' below branch 'middle'
+
+"#]]);
+
+    env.but("commit --empty -b bottom -m 'on bottom'")
+        .assert()
+        .success();
+
+    env.but("status")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ to [top]
+┊●   1#0 on top (no changes)
+┊│
+┊├┄ mi [middle]
+┊●   1#1 on middle (no changes)
+┊│
+┊├┄ bo [bottom]
+┊●   1#2 on bottom (no changes)
+┊│
+┊├┄ ma [main]
+┊●   nmy M (no changes)
+┊●   ply add init
+├╯
+┊
+┴ e31e6ca (common base) 2000-01-02 add init
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("branch new between-middle-and-top --above middle")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Created branch 'between-middle-and-top' above branch 'middle'
+
+"#]]);
+
+    env.but("commit --empty -b between-middle-and-top -m 'on between-middle-and-top'")
+        .assert()
+        .success();
+
+    env.but("status")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ to [top]
+┊●   1#0 on top (no changes)
+┊│
+┊├┄ et [between-middle-and-top]
+┊●   1#1 on between-middle-and-top (no changes)
+┊│
+┊├┄ mi [middle]
+┊●   1#2 on middle (no changes)
+┊│
+┊├┄ bo [bottom]
+┊●   1#3 on bottom (no changes)
 ┊│
 ┊├┄ ma [main]
 ┊●   nmy M (no changes)
@@ -324,12 +539,15 @@ fn creates_new_branches_on_top() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
     env.setup_metadata(&[]);
 
-    env.but("branch new one").assert().success();
+    env.but("branch new").assert().success().stdout_eq(str![[r#"
+Created branch 'a-branch-1'
+
+"#]]);
 
     env.but("status").assert().success().stdout_eq(str![[r#"
 ╭┄ zz [uncommitted] (no changes)
 ┊
-┊╭┄ on [one] (no commits)
+┊╭┄ br [a-branch-1] (no commits)
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -338,15 +556,538 @@ Hint: run `but help` for all commands
 
 "#]]);
 
-    env.but("branch new two").assert().success();
+    env.but("branch new one")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Created branch 'one'
+
+"#]]);
 
     env.but("status").assert().success().stdout_eq(str![[r#"
 ╭┄ zz [uncommitted] (no changes)
 ┊
-┊╭┄ tw [two] (no commits)
+┊╭┄ on [one] (no commits)
 ├╯
 ┊
-┊╭┄ on [one] (no commits)
+┊╭┄ br [a-branch-1] (no commits)
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn create_branch_above_empty_branch() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
+
+    env.but("branch new bottom").assert().success();
+
+    env.but("status").assert().success().stdout_eq(str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ bo [bottom] (no commits)
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("branch new top --above bottom")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Created branch 'top' above branch 'bottom'
+
+"#]]);
+
+    env.but("status").assert().success().stdout_eq(str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ to [top] (no commits)
+┊│
+┊├┄ bo [bottom] (no commits)
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("branch new middle --above bottom")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Created branch 'middle' above branch 'bottom'
+
+"#]]);
+
+    env.but("status").assert().success().stdout_eq(str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ to [top] (no commits)
+┊│
+┊├┄ mi [middle] (no commits)
+┊│
+┊├┄ bo [bottom] (no commits)
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn create_branch_above_non_empty_branch() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
+
+    env.but("commit -b bottom --no-message").assert().success();
+
+    env.but("status").assert().success().stdout_eq(str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ bo [bottom]
+┊●   1 (no commit message) (no changes)
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("branch new top --above bottom")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Created branch 'top' above branch 'bottom'
+
+"#]]);
+
+    env.but("status").assert().success().stdout_eq(str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ to [top] (no commits)
+┊│
+┊├┄ bo [bottom]
+┊●   1 (no commit message) (no changes)
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn create_branch_below_empty_branch() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
+
+    env.but("branch new top").assert().success();
+
+    env.but("status").assert().success().stdout_eq(str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ to [top] (no commits)
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("branch new bottom --below top")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Created branch 'bottom' below branch 'top'
+
+"#]]);
+
+    env.but("status").assert().success().stdout_eq(str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ to [top] (no commits)
+┊│
+┊├┄ bo [bottom] (no commits)
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("branch new middle --below top")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Created branch 'middle' below branch 'top'
+
+"#]]);
+
+    env.but("status").assert().success().stdout_eq(str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ to [top] (no commits)
+┊│
+┊├┄ mi [middle] (no commits)
+┊│
+┊├┄ bo [bottom] (no commits)
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn create_branch_below_non_empty_branch() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
+
+    env.but("commit -b top --no-message").assert().success();
+
+    env.but("status").assert().success().stdout_eq(str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ to [top]
+┊●   1 (no commit message) (no changes)
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("branch new bottom --below top")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Created branch 'bottom' below branch 'top'
+
+"#]]);
+
+    env.but("status").assert().success().stdout_eq(str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ to [top]
+┊●   1 (no commit message) (no changes)
+┊│
+┊├┄ bo [bottom] (no commits)
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn create_branch_above_commit() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
+
+    env.but("commit -b my-branch -m bottom").assert().success();
+    env.but("commit -b my-branch -m middle").assert().success();
+    env.but("commit -b my-branch -m top").assert().success();
+
+    env.but("status").assert().success().stdout_eq(str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ my [my-branch]
+┊●   1#0 top (no changes)
+┊●   1#1 middle (no changes)
+┊●   1#2 bottom (no changes)
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("branch new --above 1#1")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Created branch 'a-branch-1' above commit 1
+
+"#]]);
+
+    env.but("status").assert().success().stdout_eq(str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ my [my-branch]
+┊●   1#0 top (no changes)
+┊│
+┊├┄ br [a-branch-1]
+┊●   1#1 middle (no changes)
+┊●   1#2 bottom (no changes)
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("branch new --above 1#0")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Created branch 'a-branch-2' above commit 1
+
+"#]]);
+
+    env.but("status").assert().success().stdout_eq(str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ my [my-branch] (no commits)
+┊│
+┊├┄ br [a-branch-2]
+┊●   1#0 top (no changes)
+┊│
+┊├┄ ra [a-branch-1]
+┊●   1#1 middle (no changes)
+┊●   1#2 bottom (no changes)
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn create_branch_below_commit() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
+
+    env.but("commit -b my-branch -m bottom").assert().success();
+    env.but("commit -b my-branch -m middle").assert().success();
+    env.but("commit -b my-branch -m top").assert().success();
+
+    env.but("status").assert().success().stdout_eq(str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ my [my-branch]
+┊●   1#0 top (no changes)
+┊●   1#1 middle (no changes)
+┊●   1#2 bottom (no changes)
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("branch new --below 1#1")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Created branch 'a-branch-1' below commit 1
+
+"#]]);
+
+    env.but("status").assert().success().stdout_eq(str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ my [my-branch]
+┊●   1#0 top (no changes)
+┊●   1#1 middle (no changes)
+┊│
+┊├┄ br [a-branch-1]
+┊●   1#2 bottom (no changes)
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("branch new --below 1#2")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Created branch 'a-branch-2' below commit 1
+
+"#]]);
+
+    env.but("status").assert().success().stdout_eq(str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ my [my-branch]
+┊●   1#0 top (no changes)
+┊●   1#1 middle (no changes)
+┊│
+┊├┄ br [a-branch-1]
+┊●   1#2 bottom (no changes)
+┊│
+┊├┄ ra [a-branch-2] (no commits)
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn can_create_new_branches_above_merged_branches_but_not_below() {
+    let env =
+        Sandbox::init_scenario_with_target_and_default_settings("upstream-merged-empty-branch");
+
+    env.but("apply origin/document-but-pr-skill")
+        .env("NO_BG_TASKS", "1")
+        .assert()
+        .success();
+
+    env.but("status")
+        .env("NO_BG_TASKS", "1")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ do [document-but-pr-skill] (merged upstream) (no commits)
+├╯
+┊
+┊● 55165db (upstream: origin/main) 1 new commit
+├╯ 55165db (common base) 2000-01-02 merge document-but-pr-skill
+
+Hint: origin/main moved ahead; run `but pull` to update the workspace
+Hint: branches marked `(merged upstream)` have landed; run `but pull` to remove them, or start new work on another branch
+
+"#]]);
+
+    env.but("branch new --above do")
+        .env("NO_BG_TASKS", "1")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Created branch 'a-branch-1' above branch 'document-but-pr-skill'
+
+"#]]);
+
+    env.but("status")
+        .env("NO_BG_TASKS", "1")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ br [a-branch-1] (no commits)
+┊│
+┊├┄ do [document-but-pr-skill] (merged upstream) (no commits)
+├╯
+┊
+┊● 55165db (upstream: origin/main) 1 new commit
+├╯ 55165db (common base) 2000-01-02 merge document-but-pr-skill
+
+Hint: origin/main moved ahead; run `but pull` to update the workspace
+Hint: branches marked `(merged upstream)` have landed; run `but pull` to remove them, or start new work on another branch
+
+"#]]);
+
+    env.but("branch new --below do")
+        .env("NO_BG_TASKS", "1")
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
+Error: Branch 'document-but-pr-skill' is merged upstream
+
+Hint: Most likely you want `but pull`, which updates the workspace and removes landed work. In rare cases `--allow-merged` can bypass this check
+
+"#]]);
+}
+
+#[test]
+fn cannot_create_branches_below_branches_merged_upstream() {
+    let env =
+        Sandbox::init_scenario_with_target_and_default_settings("upstream-integrated-single-stack");
+    env.setup_metadata_at_target(&["A"], "refs/heads/base");
+
+    env.but("status")
+        .env("NO_BG_TASKS", "1")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ g0 [A] (merged upstream)
+┊●   nyq A-change
+├╯
+┊
+┊● 9354ac4 (upstream: origin/main) 1 new commit
+├╯ efc9211 (common base) 2000-01-02 base
+
+Hint: origin/main moved ahead; run `but pull` to update the workspace
+Hint: branches marked `(merged upstream)` have landed; run `but pull` to remove them, or start new work on another branch
+
+"#]]);
+
+    env.but("branch new --below nyq")
+        .env("NO_BG_TASKS", "1")
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
+Error: Commit 756ee31 is merged upstream
+
+Hint: Most likely you want `but pull`, which updates the workspace and removes landed work. In rare cases `--allow-merged` can bypass this check
+
+"#]]);
+}
+
+#[test]
+fn create_branch_using_old_anchor_flag() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
+
+    env.but("status").assert().success().stdout_eq(str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but branch new` to create a new branch to work on
+
+"#]]);
+
+    env.but("branch new bottom").assert().success();
+    env.but("branch new middle --anchor bottom")
+        .assert()
+        .success();
+    env.but("branch new top -a middle").assert().success();
+
+    env.but("status").assert().success().stdout_eq(str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ to [top] (no commits)
+┊│
+┊├┄ mi [middle] (no commits)
+┊│
+┊├┄ bo [bottom] (no commits)
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M


### PR DESCRIPTION
Now callable as

- `but branch new`
- `but branch new foo`
- `but branch new foo --above/--below bar` where `bar` can be both a commit or a branch

The old `--anchor/-a` flags still work but are hidden and deprecated. They're an alias for `--above`.