### PR TITLE
Handle single-branch mode branch creation in the API

### DIFF
--- a/crates/but-api/src/legacy/stack.rs
+++ b/crates/but-api/src/legacy/stack.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use anyhow::{Context as _, Result, anyhow};
+use anyhow::{Context as _, Result, anyhow, bail};
 use but_api_macros::but_api;
 use but_core::{DryRun, branch, ref_metadata::StackId, sync::RepoExclusive};
 use but_ctx::Context;
@@ -68,6 +68,10 @@ pub fn create_reference(
 /// translates the legacy anchor payload into the `but_workspace` representation,
 /// and updates the workspace state in place without acquiring its own repository lock.
 ///
+/// In single-branch mode the request is fulfilled through
+/// `create_reference_single_branch_with_perm()` instead, which re-anchors it for the
+/// ad-hoc workspace.
+///
 /// Returns the stack id owning the created or attached reference when one exists, together with
 /// the full refname that was created.
 ///
@@ -120,6 +124,12 @@ pub fn create_reference_with_perm(
         })
         .transpose()?;
 
+    if ctx.settings.feature_flags.single_branch
+        && gitbutler_operating_modes::in_outside_workspace_mode(ctx, perm.read_permission())?
+    {
+        return create_reference_single_branch_with_perm(ctx, new_ref, anchor, perm);
+    }
+
     let mut meta = ctx.meta()?;
     let (repo, mut ws, _db) = ctx.workspace_mut_and_db_with_perm(perm)?;
 
@@ -151,6 +161,72 @@ pub fn create_reference_with_perm(
 
     *ws = new_ws.into_owned();
     Ok((stack_id, new_ref))
+}
+
+/// Fulfill a [`create_reference_with_perm()`] request in single-branch mode by delegating to
+/// [`crate::branch::branch_create_with_perm()`], which owns the ad-hoc placement rules and the
+/// checkout of a branch created above the checked-out branch.
+///
+/// An unanchored request becomes placement above the checked-out `HEAD` branch, and segment
+/// anchors above a branch are applied as reference placement - in an ad-hoc workspace both name
+/// a local branch on the same commit. Placement below a segment would have to split the
+/// segment's commits, which reference placement cannot express, so it is refused rather than
+/// silently remapped. Ad-hoc workspaces have no stack ids, so none is returned.
+fn create_reference_single_branch_with_perm(
+    ctx: &mut Context,
+    new_ref: gix::refs::FullName,
+    anchor: Option<but_workspace::branch::create_reference::Anchor<'_>>,
+    perm: &mut RepoExclusive,
+) -> Result<(Option<StackId>, gix::refs::FullName)> {
+    use but_rebase::graph_rebase::mutate::InsertSide;
+    use but_workspace::branch::create_reference::{Anchor, Position};
+
+    use crate::commit::json::RelativeTo;
+
+    let to_side = |position: Position| match position {
+        Position::Above => InsertSide::Above,
+        Position::Below => InsertSide::Below,
+    };
+    let (relative_to, side) = match anchor {
+        None => {
+            let head_name = ctx
+                .repo
+                .get()?
+                .head()?
+                .referent_name()
+                .filter(|name| name.category() == Some(Category::LocalBranch))
+                .context("single-branch branch creation requires HEAD to be a local branch")?
+                .to_owned();
+            (RelativeTo::Reference(head_name), InsertSide::Above)
+        }
+        Some(Anchor::AtCommit {
+            commit_id,
+            position,
+        }) => (RelativeTo::Commit(commit_id), to_side(position)),
+        Some(Anchor::AtSegment {
+            ref_name,
+            position: Position::Below,
+        }) => {
+            bail!(
+                "Cannot create '{new}' below segment '{anchor}' in single-branch mode",
+                new = new_ref.shorten(),
+                anchor = ref_name.shorten()
+            );
+        }
+        Some(
+            Anchor::AtSegment { ref_name, position } | Anchor::AtReference { ref_name, position },
+        ) => (
+            RelativeTo::Reference(ref_name.into_owned()),
+            to_side(position),
+        ),
+    };
+    let created = crate::branch::branch_create_with_perm(
+        ctx,
+        Some(new_ref),
+        crate::branch::json::BranchCreatePlacement::Dependent { relative_to, side },
+        perm,
+    )?;
+    Ok((None, created.new_ref))
 }
 
 /// Create a dependent branch named by `request.name` in the stack identified by

--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -95,6 +95,8 @@ but branch new feature -a <anchor>  # Stacked branch (dependent work)
 
 Use parallel branches for independent tasks. Use stacked branches when work depends on another branch.
 
+In single-branch mode (no managed workspace), `but branch new` stacks the new branch above the checked-out branch (or the `-a` anchor). When the new branch lands above the checked-out branch — always the case without an anchor — it is checked out and `HEAD` moves to it.
+
 For "commit these selected changes on a new branch", prefer `but commit -b <branch> -m "message" <ids>` instead of a separate `but branch new` or preflight `but status -fv` — `-b` creates the branch when it does not exist.
 
 ### `but apply <branch-name>`

--- a/crates/but/src/command/legacy/branch/mod.rs
+++ b/crates/but/src/command/legacy/branch/mod.rs
@@ -75,32 +75,6 @@ pub fn new(
             .transpose()?
     };
 
-    if resolved_anchor.is_none()
-        && ctx.settings.feature_flags.single_branch
-        && gitbutler_operating_modes::in_outside_workspace_mode(ctx, guard.read_permission())?
-    {
-        let head_name = ctx
-            .repo
-            .get()?
-            .head()?
-            .referent_name()
-            .filter(|name| name.category() == Some(gix::refs::Category::LocalBranch))
-            .context("single-branch branch creation requires HEAD to be a local branch")?
-            .to_owned();
-        let new_ref: gix::refs::FullName = format!("refs/heads/{branch_name}").try_into()?;
-        but_api::branch::branch_create_with_perm(
-            ctx,
-            Some(new_ref),
-            but_api::branch::json::BranchCreatePlacement::Dependent {
-                relative_to: but_api::commit::json::RelativeTo::Reference(head_name),
-                side: but_rebase::graph_rebase::mutate::InsertSide::Above,
-            },
-            guard.write_permission(),
-        )?;
-        write_new_branch_output(out, &branch_name, None, anchor_arg)?;
-        return Ok(());
-    }
-
     let anchor = resolved_anchor
         .clone()
         .map(|anchor| -> CliResult<_> {

--- a/crates/but/tests/but/command/branch/new.rs
+++ b/crates/but/tests/but/command/branch/new.rs
@@ -232,6 +232,79 @@ fn single_branch_outputs_created_branch_for_all_formats() {
 }
 
 #[test]
+fn single_branch_stacks_new_branches_above_head_and_checks_them_out() {
+    let env = Sandbox::open_with_default_settings("one-fork");
+
+    env.but("branch new first").assert().success();
+    env.but("branch new second").assert().success();
+
+    let repo = env.open_repo();
+    assert_eq!(
+        repo.head_name().unwrap().unwrap().as_bstr(),
+        "refs/heads/second",
+        "each single-branch creation checks out the newly created branch"
+    );
+
+    env.but("status").assert().success().stdout_eq(str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ se [second] (no commits)
+┊│
+┊├┄ fi [first] (no commits)
+┊│
+┊├┄ ma [main]
+┊●   nmy M (no changes)
+┊●   ply add init
+├╯
+┊
+┴ e31e6ca (common base) 2000-01-02 add init
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn single_branch_stacks_anchored_branch_on_named_branch() {
+    let env = Sandbox::open_with_default_settings("one-fork");
+
+    env.but("branch new first").assert().success();
+    env.but("branch new --anchor first stacked")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+✓ Created branch stacked stacked on first
+
+"#]]);
+
+    let repo = env.open_repo();
+    assert_eq!(
+        repo.head_name().unwrap().unwrap().as_bstr(),
+        "refs/heads/stacked",
+        "creating above the checked-out anchor checks out the new branch"
+    );
+
+    env.but("status").assert().success().stdout_eq(str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ st [stacked] (no commits)
+┊│
+┊├┄ fi [first] (no commits)
+┊│
+┊├┄ ma [main]
+┊●   nmy M (no changes)
+┊●   ply add init
+├╯
+┊
+┴ e31e6ca (common base) 2000-01-02 add init
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
 fn handles_path_prefix_collision() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
     env.setup_metadata(&["A"]);


### PR DESCRIPTION
In single-branch mode, branch creation needs `Anchor::AtReference` placement plus a checkout of the new reference — `Anchor::AtSegment` placement does not work there ([GB-1823](https://linear.app/gitbutler/issue/GB-1823/test-if-cli-commands-that-create-branches-work-single-branch-mode)). Previously only `but branch new` handled this, via a special case in the CLI, and only for unanchored requests.

This moves the mode handling behind the API boundary: `but_api::legacy::stack::create_reference` now detects single-branch mode and delegates to `branch_create_with_perm`, which owns the ad-hoc placement rules and the checkout-after-create behavior. Unanchored requests are placed above the checked-out branch; segment anchors are applied as reference placement. Placement below a segment is refused with a clear error rather than silently remapped, since reference placement cannot express splitting a segment's commits.

As a result the CLI special case is gone, and anchored `but branch new --anchor` plus the status TUI's branch creation now work in single-branch mode too.

Deliberately out of scope (the remainder of GB-1823): `but commit -b`, `but pick`, and `but move` create branches through `but-transaction`, which does not yet support ad-hoc workspaces — fixing that needs branch-order support in the transaction's metadata recording.