### PR TITLE
Fix worktree wipe after `but land`: reparent workspace off the stale target

### DIFF
--- a/crates/but-workspace/src/upstream_integration.rs
+++ b/crates/but-workspace/src/upstream_integration.rs
@@ -279,6 +279,7 @@ pub fn integrate_upstream_with_hints<'ws, 'meta, M: RefMetadata>(
         .transpose()?;
     let mut fully_integrated_workspace_parents = HashSet::new();
     let mut direct_checkout_replacement_ref: Option<(Selector, gix::refs::FullName)> = None;
+    let mut selected_stack_nodes = HashSet::new();
     for stack in &stacks {
         let is_selected = stack.nodes.values().any(|attrs| attrs.to_rebase)
             || stack.to_merge
@@ -292,6 +293,7 @@ pub fn integrate_upstream_with_hints<'ws, 'meta, M: RefMetadata>(
         if !is_selected {
             continue;
         }
+        selected_stack_nodes.extend(stack.nodes.keys().copied());
 
         if is_fully_integrated {
             // If we're not in the managed workspace, we haven't determined a
@@ -351,12 +353,17 @@ pub fn integrate_upstream_with_hints<'ws, 'meta, M: RefMetadata>(
         let direct_parents = editor.direct_parents(workspace_commit_selector)?;
         match direct_parents.as_slice() {
             [(parent_selector, parent_order)]
-                if fully_integrated_workspace_parents.is_empty()
+                if !selected_stack_nodes.contains(parent_selector)
                     && selector_commit_id(&editor, *parent_selector)? == Some(target_sha)
                     && target_sha != target_ref_commit.detach() =>
             {
-                // Only parent is the old target sha, and that's not the latest tip of the target ref.
-                // We need to reparent it onto the latest target ref.
+                // Only parent is the old target sha, and that's not the latest tip of the target
+                // ref. This is a workspace with no stacks, or an unnamed empty lane at the base
+                // left behind after disconnecting fully integrated stacks — but never a selected
+                // stack (a selected empty branch is rebased onto the target instead, and the
+                // workspace commit must keep following it). We need to reparent it onto the
+                // latest target ref; leaving it would materialize the stale target's tree over
+                // the worktree.
                 editor.remove_edges(workspace_commit_selector, *parent_selector)?;
                 editor.add_edge(
                     workspace_commit_selector,

--- a/crates/but-workspace/tests/fixtures/scenario/fully-integrated-branch-with-empty-sibling-at-stale-target.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/fully-integrated-branch-with-empty-sibling-at-stale-target.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# Like fully-integrated-branch-with-stale-target-parent, but the second lane is
+# a named empty branch B at the old target commit M instead of a bare edge to it.
+# Stack A is fully integrated (the target ref advanced to contain it), while B
+# must survive the integration: it rebases onto the advanced target and the
+# workspace commit keeps following it.
+git init
+commit-file M.txt M
+setup_target_to_match_main
+
+git branch B
+
+git checkout -b A
+commit-file A.txt A
+git update-ref refs/remotes/origin/main A
+
+# `git merge` refuses to create a merge commit with an ancestor, so build the
+# two-parent workspace commit (stack tip + empty branch at the old target)
+# directly.
+tick
+git checkout -b gitbutler/workspace
+git update-ref refs/heads/gitbutler/workspace \
+  "$(git commit-tree "A^{tree}" -p A -p B -m "GitButler Workspace Commit")"

--- a/crates/but-workspace/tests/fixtures/scenario/fully-integrated-branch-with-stale-target-parent.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/fully-integrated-branch-with-stale-target-parent.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# A stack A sits on the old target commit M, and the workspace commit merges
+# both A and the old target directly (an unnamed empty lane at the base). The
+# target ref has advanced to contain A, exactly like right after `but land`
+# fast-forwarded it. Integrating must reparent the workspace commit onto the
+# advanced target instead of leaving it on the stale base.
+git init
+commit-file M.txt M
+setup_target_to_match_main
+
+git checkout -b A
+commit-file A.txt A
+git update-ref refs/remotes/origin/main A
+
+# `git merge` refuses to create a merge commit with an ancestor, so build the
+# two-parent workspace commit (stack tip + stale target) directly.
+tick
+git checkout -b gitbutler/workspace
+git update-ref refs/heads/gitbutler/workspace \
+  "$(git commit-tree "A^{tree}" -p A -p main -m "GitButler Workspace Commit")"

--- a/crates/but-workspace/tests/workspace/upstream_integration.rs
+++ b/crates/but-workspace/tests/workspace/upstream_integration.rs
@@ -1014,6 +1014,61 @@ fn fully_integrated_single_branch_with_stale_target_parent_reparents_workspace_c
 }
 
 #[test]
+fn fully_integrated_branch_with_selected_empty_sibling_keeps_following_it() -> Result<()> {
+    let (_tmp, repo, mut meta, _description) = named_writable_scenario_with_description(
+        "fully-integrated-branch-with-empty-sibling-at-stale-target",
+    )?;
+    let target_sha = repo.rev_parse_single("main")?.detach();
+
+    let project_meta = target_project_meta("refs/remotes/origin/main", target_sha)?;
+    add_stack(&mut meta, 1, "A", StackState::InWorkspace);
+    add_stack(&mut meta, 2, "B", StackState::InWorkspace);
+    let graph = but_graph::Graph::from_head(
+        &repo,
+        &meta,
+        project_meta.clone(),
+        Options {
+            extra_target_commit_id: Some(target_sha),
+            ..Options::limited()
+        },
+    )?;
+    let mut workspace = graph.into_workspace()?;
+
+    integrate_and_materialize(
+        &mut workspace,
+        &mut meta,
+        &repo,
+        vec![
+            BottomUpdate {
+                kind: BottomUpdateKind::Rebase,
+                selector: RelativeTo::Commit(repo.rev_parse_single("A")?.detach()),
+            },
+            BottomUpdate {
+                kind: BottomUpdateKind::Rebase,
+                selector: RelativeTo::Reference(gix::refs::FullName::try_from("refs/heads/B")?),
+            },
+        ],
+    )?;
+
+    // Same shape as the stale-target-parent test, except the second lane is a named empty
+    // branch B, selected for update like every named stack is by real callers. The reparent
+    // must leave the workspace commit following B — B has its own rebase onto the target —
+    // rather than treating B's edge as a stale base and stealing the workspace commit from it.
+    assert_eq!(
+        repo.rev_parse_single("B")?.detach(),
+        repo.rev_parse_single("origin/main")?.detach(),
+        "the selected empty branch survives and rebases onto the advanced target tip"
+    );
+    assert_eq!(
+        workspace_parent_ids(&repo)?,
+        vec![repo.rev_parse_single("origin/main")?.detach()],
+        "workspace commit keeps following the empty branch to the target tip"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn non_bottom_update_selector_does_not_prune_fully_integrated_stack() -> Result<()> {
     let (_tmp, repo, mut meta, _description) =
         named_writable_scenario_with_description("fully-integrated-single-branch-target-advanced")?;

--- a/crates/but-workspace/tests/workspace/upstream_integration.rs
+++ b/crates/but-workspace/tests/workspace/upstream_integration.rs
@@ -970,6 +970,50 @@ fn fully_integrated_single_branch_reparents_workspace_commit_to_advanced_target(
 }
 
 #[test]
+fn fully_integrated_single_branch_with_stale_target_parent_reparents_workspace_commit() -> Result<()>
+{
+    let (_tmp, repo, mut meta, _description) = named_writable_scenario_with_description(
+        "fully-integrated-branch-with-stale-target-parent",
+    )?;
+    let target_sha = repo.rev_parse_single("main")?.detach();
+
+    let project_meta = target_project_meta("refs/remotes/origin/main", target_sha)?;
+    add_stack(&mut meta, 1, "A", StackState::InWorkspace);
+    let graph = but_graph::Graph::from_head(
+        &repo,
+        &meta,
+        project_meta.clone(),
+        Options {
+            extra_target_commit_id: Some(target_sha),
+            ..Options::limited()
+        },
+    )?;
+    let mut workspace = graph.into_workspace()?;
+
+    integrate_and_materialize(
+        &mut workspace,
+        &mut meta,
+        &repo,
+        vec![BottomUpdate {
+            kind: BottomUpdateKind::Rebase,
+            selector: RelativeTo::Commit(repo.rev_parse_single("A")?.detach()),
+        }],
+    )?;
+
+    // This is the `but land` reconcile shape: the workspace commit merges the landed stack and
+    // the stale target directly (an unnamed empty lane at the base). Removing the integrated
+    // stack must not leave the workspace commit parented on the stale base — that would
+    // materialize the old target's tree over the worktree.
+    assert_eq!(
+        workspace_parent_ids(&repo)?,
+        vec![repo.rev_parse_single("origin/main")?.detach()],
+        "workspace commit moves off the stale target parent onto the advanced target tip"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn non_bottom_update_selector_does_not_prune_fully_integrated_stack() -> Result<()> {
     let (_tmp, repo, mut meta, _description) =
         named_writable_scenario_with_description("fully-integrated-single-branch-target-advanced")?;


### PR DESCRIPTION
**Problem:** After `but land`, the reconcile (`integrate_upstream`) removes the integrated stack from the workspace commit but leaves it parented on the *old* target sha when an unnamed base lane remains — the reparenting `match` has arms for "empty workspace" and "orphaned workspace", and this combined case falls through. Materializing then checks out the stale target's tree, deleting every tracked file (with an empty initial commit, the entire worktree). `but pull` runs the same code, so the wipe repeats after `but undo`.

**Fix:** Reparent the workspace commit onto the advanced target whenever its sole remaining parent resolves to the stale target sha and no selected stack owns that parent. The selection check (instead of just dropping the old guard) keeps a named empty branch alive: it has its own rebase update, and the workspace commit must keep following it.

Includes a fixture + regression test that fails on the old guard. Full write-up with state diagrams: https://claude.ai/code/artifact/e319204b-1f5b-4632-b448-5ccb6f9210f9