### PR TITLE
Outline tree row and checkbox polish

### DIFF
--- a/apps/lite/ui/src/components/Checkbox.module.css
+++ b/apps/lite/ui/src/components/Checkbox.module.css
@@ -8,7 +8,9 @@
 	inline-size: 14px;
 	block-size: 14px;
 	border-radius: var(--radius-xs);
-	background-color: var(--bg-1);
+	/* Left undeclared so a consumer can set --checkbox-bg from the row or the
+	   checkbox itself without a same-specificity fight over the default. */
+	background-color: var(--checkbox-bg, var(--bg-1));
 	box-shadow: inset 0 0 0 var(--border-width) var(--border-2);
 	color: var(--text-2);
 	transition:
@@ -44,19 +46,34 @@
 
 	&:disabled,
 	&[data-disabled] {
-		color: var(--text-2);
 		cursor: not-allowed;
 
 		&:not([data-checked]) {
-			background-color: color-mix(in srgb, var(--border-2) var(--disabled-opacity), var(--bg-1));
+			background-color: color-mix(
+				in srgb,
+				var(--border-2) var(--disabled-opacity),
+				var(--checkbox-bg, var(--bg-1))
+			);
 			box-shadow: inset 0 0 0 var(--border-width)
-				color-mix(in srgb, var(--border-2) var(--disabled-opacity), var(--bg-1));
+				color-mix(in srgb, var(--border-2) var(--disabled-opacity), var(--checkbox-bg, var(--bg-1)));
 		}
 
 		&[data-checked] {
-			background-color: color-mix(in srgb, var(--fill-pop-bg) var(--disabled-opacity), var(--bg-1));
+			background-color: color-mix(
+				in srgb,
+				var(--fill-pop-bg) var(--disabled-opacity),
+				var(--checkbox-bg, var(--bg-1))
+			);
 			box-shadow: inset 0 0 0 var(--border-width)
-				color-mix(in srgb, var(--fill-pop-bg) var(--disabled-opacity), var(--bg-1));
+				color-mix(
+					in srgb,
+					var(--fill-pop-bg) var(--disabled-opacity),
+					var(--checkbox-bg, var(--bg-1))
+				);
+
+			& .checkboxIndicator {
+				opacity: var(--disabled-opacity);
+			}
 		}
 	}
 }

--- a/apps/lite/ui/src/components/Checkbox.module.css
+++ b/apps/lite/ui/src/components/Checkbox.module.css
@@ -1,6 +1,9 @@
 .checkbox {
 	--border-width: 1px;
 	--disabled-opacity: 50%;
+	/* Left undeclared so a consumer can set --checkbox-bg from the row or the
+	   checkbox itself without a same-specificity fight over the default. */
+	--resolved-bg: var(--checkbox-bg, var(--bg-1));
 
 	display: flex;
 	align-items: center;
@@ -8,9 +11,7 @@
 	inline-size: 14px;
 	block-size: 14px;
 	border-radius: var(--radius-xs);
-	/* Left undeclared so a consumer can set --checkbox-bg from the row or the
-	   checkbox itself without a same-specificity fight over the default. */
-	background-color: var(--checkbox-bg, var(--bg-1));
+	background-color: var(--resolved-bg);
 	box-shadow: inset 0 0 0 var(--border-width) var(--border-2);
 	color: var(--text-2);
 
@@ -49,24 +50,20 @@
 			background-color: color-mix(
 				in srgb,
 				var(--border-2) var(--disabled-opacity),
-				var(--checkbox-bg, var(--bg-1))
+				var(--resolved-bg)
 			);
 			box-shadow: inset 0 0 0 var(--border-width)
-				color-mix(in srgb, var(--border-2) var(--disabled-opacity), var(--checkbox-bg, var(--bg-1)));
+				color-mix(in srgb, var(--border-2) var(--disabled-opacity), var(--resolved-bg));
 		}
 
 		&[data-checked] {
 			background-color: color-mix(
 				in srgb,
 				var(--fill-pop-bg) var(--disabled-opacity),
-				var(--checkbox-bg, var(--bg-1))
+				var(--resolved-bg)
 			);
 			box-shadow: inset 0 0 0 var(--border-width)
-				color-mix(
-					in srgb,
-					var(--fill-pop-bg) var(--disabled-opacity),
-					var(--checkbox-bg, var(--bg-1))
-				);
+				color-mix(in srgb, var(--fill-pop-bg) var(--disabled-opacity), var(--resolved-bg));
 
 			& .checkboxIndicator {
 				opacity: var(--disabled-opacity);

--- a/apps/lite/ui/src/components/Checkbox.module.css
+++ b/apps/lite/ui/src/components/Checkbox.module.css
@@ -13,9 +13,6 @@
 	background-color: var(--checkbox-bg, var(--bg-1));
 	box-shadow: inset 0 0 0 var(--border-width) var(--border-2);
 	color: var(--text-2);
-	transition:
-		background-color 0.08s ease,
-		box-shadow 0.08s ease;
 
 	&:not([data-checked], :disabled, [data-disabled]) {
 		&:hover {

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/CommitRow.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/CommitRow.module.css
@@ -19,6 +19,15 @@
 	&[data-disabled]:not([data-checked]) {
 		display: none;
 	}
+
+	/* While the row carries an inline editor it is a text field, not a list
+	   item: the only things it can answer are save and cancel. The checkbox
+	   steps aside for the duration rather than sitting there disabled — it
+	   shares its grid cell with the graph glyph, which shows through in its
+	   place, so nothing moves. */
+	.row:has(:is(textarea, input):focus) & {
+		display: none;
+	}
 }
 
 .conflictIcon {

--- a/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
@@ -38,8 +38,8 @@
 	}
 }
 
-/* Placed before .containerSelected so the focused selection's fill wins on a
-   row that is both. */
+/* Placed before .containerSelected so selection wins on a row that is both:
+   selection reads the same everywhere, checked or not. */
 .containerChecked {
 	background-color: color-mix(var(--fill-pop-bg) 15%, transparent);
 
@@ -63,28 +63,10 @@
 }
 
 .containerSelected {
-	/* Unfocused, the tint alone is faint enough to blend into an already tinted
-	   or busy background, so the row carries a hairline as well. Drawn as an
-	   inset outline: it costs no layout, and it follows whatever corners the row
-	   ends up with — including the squared ones inside a run of checked rows. */
-	outline: 1px solid color-mix(var(--fill-gray-bg) 25%, transparent);
-	outline-offset: -1px;
-
-	/* A checked row already carries a tint of its own, so selection leaves its
-	   background alone and speaks through the outline — which joins the pop
-	   family so it doesn't drop a gray line into a run of checked rows. */
-	&:not(.containerChecked) {
-		background-color: var(--list-item-hover-bg);
-	}
-
-	&.containerChecked {
-		outline-color: color-mix(var(--fill-pop-bg) 80%, transparent);
-	}
+	background-color: color-mix(var(--fill-gray-bg) var(--opacity-bg-selected-blur), transparent);
 
 	&:has(:is(textarea, input):focus),
 	[data-selection-focus-styles="true"] [data-selection-scope]:focus & {
-		/* The focused fill is solid — it carries the state on its own. */
-		outline-color: transparent;
 		background-color: var(--fill-gray-bg);
 		color: var(--fill-gray-fg);
 	}

--- a/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
@@ -74,14 +74,7 @@
 	   background alone and speaks through the outline — which joins the pop
 	   family so it doesn't drop a gray line into a run of checked rows. */
 	&:not(.containerChecked) {
-		/* Half the usual blurred-selection tint, since the outline now carries
-		   most of the state and the fill only has to hint at it. Derived from the
-		   selection token rather than the hover one it currently matches, so the
-		   two can be tuned apart. */
-		background-color: color-mix(
-			var(--fill-gray-bg) calc(var(--opacity-bg-selected-blur) / 2),
-			transparent
-		);
+		background-color: var(--list-item-hover-bg);
 	}
 
 	&.containerChecked {

--- a/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
@@ -206,6 +206,14 @@
 .rowCheckbox {
 	--checkbox-height: 14px;
 	margin-block-start: calc((var(--single-line-row-height) - var(--checkbox-height)) / 2);
+
+	/* On the focused selection's solid fill, an unchecked box painted in --bg-1
+	   reads as a light chip punched out of the row. It takes the fill instead, so
+	   only its border marks it out. */
+	[data-selection-focus-styles="true"] [data-selection-scope]:focus .containerSelected &,
+	.containerSelected:has(:is(textarea, input):focus) & {
+		--checkbox-bg: var(--fill-gray-bg);
+	}
 }
 
 .labelContainer {


### PR DESCRIPTION
Mostly cosmetic updates! Not final-final yet, just want to see how it feels.

- Hide the commit checkbox while its inline editor is open
- Revert outline blur-selected state
- Remove transition from the main container for faster switching
- Let rows tint the checkbox background, and fade the disabled tick