### PR TITLE
but-db: document that schema-version bumps are reserved for planned breaks

### DIFF
--- a/crates/AGENTS.md
+++ b/crates/AGENTS.md
@@ -88,6 +88,13 @@ vendored, or fixture data unless the task is specifically about that code.
   consumers need classification, use existing `but_error::Code` patterns; do
   not make consumers match error strings.
 
+## Database Migrations (`but-db`)
+
+- Keep migrations forward-compatible: stay on the current `SchemaVersion` and
+  leave columns or tables that new code stopped using in place. Bumping the
+  version locks every older binary out of the database; reserve it for planned,
+  coordinated breaks, never routine cleanup.
+
 ## Version Control
 
 - Assume the worktree may contain other agents' changes. Do not overwrite, clean

--- a/crates/but-db/src/cache/mod.rs
+++ b/crates/but-db/src/cache/mod.rs
@@ -22,6 +22,9 @@ pub use table::{
 
 /// Just like [`crate::SchemaVersion`], but for project caches. Note that caches can always be created though
 /// as they are generated in memory in the worst case, particularly on migration failure.
+///
+/// The same rule applies: stay on the current version and leave stale columns or tables
+/// in place — bump only for a planned, coordinated break, never routine cleanup.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum SchemaVersion {
     /// The current forward-compatible schema line.

--- a/crates/but-db/src/lib.rs
+++ b/crates/but-db/src/lib.rs
@@ -161,6 +161,10 @@ pub struct M<'a> {
 /// The numeric migration id remains the source of truth for ordering. This enum exists so
 /// each migration must state whether it crosses into a new forward-incompatible database
 /// shape or remains readable by older client binaries.
+///
+/// Bumping the version locks every older binary out of the database, so it is reserved
+/// for planned, coordinated breaks. Leaving no-longer-used columns or tables in place is
+/// harmless and always preferred over a bump for routine cleanup.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum SchemaVersion {
     /// The current forward-compatible schema line.

--- a/crates/but-db/src/migration.rs
+++ b/crates/but-db/src/migration.rs
@@ -175,6 +175,9 @@ impl<'a> M<'a> {
     /// Create a new migration with `created_at_for_sorting` in a format like `20250529110746`,
     /// a documented forward-compatibility `schema_version`, and the `up_sql` which is Sqlite
     /// compatible SQL to create or update tables.
+    ///
+    /// Prefer [`SchemaVersion::Zero`]: a higher version locks older binaries out of the
+    /// database. Leave stale columns or tables in place rather than bumping for cleanup.
     pub const fn up(
         created_at_for_sorting: u64,
         schema_version: SchemaVersion,

--- a/crates/but-db/src/table/mod.rs
+++ b/crates/but-db/src/table/mod.rs
@@ -13,6 +13,9 @@ pub(crate) mod virtual_branches;
 pub(crate) mod worktree_meta;
 
 /// Move migrations that relate to tables that don't have their module anymore here.
+///
+/// Removing a feature does not justify a schema-version bump: keep these at
+/// [`SchemaVersion::Zero`] and leave tables that older binaries still read in place.
 pub(crate) const M_FULLY_REMOVED: &[M<'static>] = &[
     M::up(
         20251013092749,


### PR DESCRIPTION
Bumping `SchemaVersion` locks every older binary out of the database, so the established policy (settled after #14948) is to leave stale columns and tables in place rather than bump for cleanup.

This captures that policy where migration authors will actually see it: on both `SchemaVersion` enums, on `M::up`, on the removed-tables list, and as a short rule in `crates/AGENTS.md` — to prevent accidental bumps during routine cleanup. Comments are deliberately brief; a planned, coordinated break remains legitimate when genuinely needed.