### PR TITLE
Show the commit target in the collapsed commit row

### DIFF
--- a/apps/lite/ui/src/components/Tooltip.module.css
+++ b/apps/lite/ui/src/components/Tooltip.module.css
@@ -1,6 +1,7 @@
 .tooltip {
 	display: flex;
 	align-items: center;
+	max-width: 240px;
 	padding: 6px 8px;
 	gap: 7px;
 	border-radius: var(--radius-button);
@@ -9,6 +10,19 @@
 	color: var(--text-1);
 }
 
+/* Long content (branch or commit names) wraps instead of stretching the tooltip
+   past its max width, and breaks mid-word when a single token is wider than the
+   tooltip. */
+.content {
+	min-width: 0;
+	overflow-wrap: anywhere;
+}
+
 .withKbd {
 	padding-right: 6px;
+
+	/* The shortcut keeps its intrinsic width; only the text wraps. */
+	& > :not(.content) {
+		flex-shrink: 0;
+	}
 }

--- a/apps/lite/ui/src/components/Tooltip.tsx
+++ b/apps/lite/ui/src/components/Tooltip.tsx
@@ -14,7 +14,7 @@ export const TooltipPopup: FC<
 		{...props}
 		className={classes(props.className, "text-12", styles.tooltip, kbd != null && styles.withKbd)}
 	>
-		<span>{children}</span>
+		<span className={styles.content}>{children}</span>
 		{kbd != null && <Kbd hotkey={kbd} />}
 	</div>
 );

--- a/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.module.css
@@ -1,5 +1,23 @@
+.startCommitRow {
+	display: flex;
+	column-gap: 4px;
+}
+
+.startCommitSplit {
+	flex: 1;
+	min-width: 0;
+}
+
 .startCommitButton {
+	flex: 1;
+	min-width: 0;
+}
+
+.collapsedTargetTrigger {
+	display: flex;
 	flex-shrink: 0;
+	align-items: center;
+	padding-inline: 6px;
 }
 
 .form {
@@ -97,6 +115,30 @@
 	&:not([data-disabled])[aria-expanded="true"] {
 		background-color: color-mix(in srgb, var(--fill-gray-bg) var(--opacity-bg-hover), transparent);
 	}
+}
+
+/* "Target:" keeps its width; only the name after it is allowed to shrink. */
+.tooltipTarget {
+	display: flex;
+	column-gap: 4px;
+	min-width: 0;
+}
+
+.tooltipTargetLabel {
+	flex-shrink: 0;
+	color: color-mix(in srgb, var(--text-1) 60%, transparent);
+}
+
+/* A branch name or commit subject is an identifier, so it stays on one
+   ellipsised line rather than wrapping the tooltip across several. */
+.tooltipTargetName {
+	/* `display: block` gives the span a width to ellipsise against — as an inline
+	   box it would just overflow the tooltip. */
+	display: block;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 .targetTriggerLabel {

--- a/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
@@ -20,7 +20,14 @@ import type { InsertSide, RelativeTo, WorktreeChanges } from "@gitbutler/but-sdk
 import { useHotkey, useHotkeys } from "@tanstack/react-hotkeys";
 import { useIsMutating, useQuery } from "@tanstack/react-query";
 import { Match } from "effect";
-import { type FC, type RefCallback, type SubmitEventHandler, useRef, useState } from "react";
+import {
+	type FC,
+	type ReactNode,
+	type RefCallback,
+	type SubmitEventHandler,
+	useRef,
+	useState,
+} from "react";
 import styles from "./CommitForm.module.css";
 
 export type CommitTargetComboboxItem = {
@@ -51,6 +58,42 @@ const CommitTargetComboboxPopup: FC = () => (
 			)}
 		</Combobox.List>
 	</Combobox.Popup>
+);
+
+/**
+ * Wires up the commit target combobox. The trigger is passed as children so the
+ * same picker can be rendered both in the expanded form's footer and next to
+ * the collapsed "Start commit" button.
+ */
+const CommitTargetCombobox: FC<{
+	items: Array<CommitTargetComboboxItem>;
+	value: CommitTargetComboboxItem | null;
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	onValueChange: (item: CommitTargetComboboxItem | null) => void;
+	disabled: boolean;
+	children: ReactNode;
+}> = ({ items, value, open, onOpenChange, onValueChange, disabled, children }) => (
+	<Combobox.Root<CommitTargetComboboxItem>
+		items={items}
+		open={open}
+		onOpenChange={onOpenChange}
+		// Note `undefined` means uncontrolled.
+		value={value}
+		onValueChange={onValueChange}
+		itemToStringLabel={(x) => x.label}
+		itemToStringValue={(x) => operandIdentityKey(x.operand)}
+		isItemEqualToValue={(a, b) => operandEquals(a.operand, b.operand)}
+		autoHighlight
+		disabled={disabled}
+	>
+		{children}
+		<Combobox.Portal>
+			<Combobox.Positioner align="start" sideOffset={4}>
+				<CommitTargetComboboxPopup />
+			</Combobox.Positioner>
+		</Combobox.Portal>
+	</Combobox.Root>
 );
 
 export const CommitForm: FC<{
@@ -251,20 +294,77 @@ export const CommitForm: FC<{
 
 	if (!isExpanded) {
 		return (
-			<Button
-				className={classes(
-					getButtonClassName({ variant: "pop" }),
-					styles.startCommitButton,
-					className,
-				)}
-				id={startCommitButtonId}
-				onClick={() => setIsExpanded(true)}
-				focusableWhenDisabled
-				disabled={!isDefaultMode}
-			>
-				Start commit
-				<Kbd hotkey={outlineHotkeys.composeCommitMessage.hotkey} variant="button" />
-			</Button>
+			<div className={classes(styles.startCommitRow, className)}>
+				<CommitTargetCombobox
+					items={targetComboboxItems}
+					value={commitTarget ?? null}
+					open={open}
+					onOpenChange={setOpen}
+					onValueChange={selectBranch}
+					disabled={!isDefaultMode || isCommitOrAmendPending}
+				>
+					<Tooltip.Root>
+						<Combobox.Trigger
+							className={classes(
+								getButtonClassName({ variant: "outline" }),
+								styles.collapsedTargetTrigger,
+							)}
+							aria-label="Select commit target"
+							render={<Button focusableWhenDisabled render={<Tooltip.Trigger />} />}
+						>
+							<Icon name="bullseye" size={14} />
+							<Icon
+								name={commitTarget?.operand._tag === "Commit" ? "commit" : "branch"}
+								size={14}
+							/>
+						</Combobox.Trigger>
+						<Tooltip.Portal>
+							<Tooltip.Positioner sideOffset={4}>
+								<Tooltip.Popup
+									render={<TooltipPopup kbd={changesHotkeys.selectCommitTarget.hotkey} />}
+								>
+									{commitTarget ? (
+										<span className={styles.tooltipTarget}>
+											<span className={styles.tooltipTargetLabel}>Target:</span>
+											<span className={styles.tooltipTargetName}>{commitTarget.label}</span>
+										</span>
+									) : (
+										"Select commit target"
+									)}
+								</Tooltip.Popup>
+							</Tooltip.Positioner>
+						</Tooltip.Portal>
+					</Tooltip.Root>
+				</CommitTargetCombobox>
+
+				{/* Amend ignores the message, so its affordance belongs here rather than
+				    behind the message composer. Mirrors the hotkeys, which are registered
+				    regardless of whether the form is expanded. */}
+				<div className={classes(styles.dropdownButton, styles.startCommitSplit)}>
+					<Button
+						className={classes(getButtonClassName({ variant: "pop" }), styles.startCommitButton)}
+						id={startCommitButtonId}
+						onClick={() => setIsExpanded(true)}
+						focusableWhenDisabled
+						disabled={!isDefaultMode}
+					>
+						Start commit
+						<Kbd hotkey={outlineHotkeys.composeCommitMessage.hotkey} variant="button" />
+					</Button>
+					<div aria-hidden className={styles.dropdownButtonSeparator} />
+					<Button
+						focusableWhenDisabled
+						disabled={!(canAmend || canCommit)}
+						aria-label="Commit options"
+						className={getButtonClassName({ variant: "pop", iconOnly: true })}
+						onClick={(event) => {
+							void showNativeMenuFromTrigger(event.currentTarget, commitMenuItems);
+						}}
+					>
+						<Icon name="chevron-down" />
+					</Button>
+				</div>
+			</div>
 		);
 	}
 
@@ -300,25 +400,18 @@ export const CommitForm: FC<{
 			/>
 
 			<div className={styles.footer}>
-				<Combobox.Root<CommitTargetComboboxItem>
+				<CommitTargetCombobox
 					items={targetComboboxItems}
+					value={commitTarget ?? null}
 					open={open}
 					onOpenChange={setOpen}
-					// Note `undefined` means uncontrolled.
-					value={commitTarget ?? null}
 					onValueChange={selectBranch}
-					itemToStringLabel={(x) => x.label}
-					itemToStringValue={(x) => operandIdentityKey(x.operand)}
-					isItemEqualToValue={(a, b) => operandEquals(a.operand, b.operand)}
-					autoHighlight
 					disabled={!isDefaultMode || isCommitOrAmendPending}
 				>
 					<Tooltip.Root>
 						<Combobox.Trigger
 							className={classes("text-13 text-semibold", styles.targetTrigger)}
 							aria-label="Select commit target"
-							// We pass `disabled` here because we want to disable the button, not
-							// the tooltip. Other props should be passed above.
 							render={<Button focusableWhenDisabled render={<Tooltip.Trigger />} />}
 						>
 							<Icon
@@ -339,12 +432,7 @@ export const CommitForm: FC<{
 							</Tooltip.Positioner>
 						</Tooltip.Portal>
 					</Tooltip.Root>
-					<Combobox.Portal>
-						<Combobox.Positioner align="start" sideOffset={4}>
-							<CommitTargetComboboxPopup />
-						</Combobox.Positioner>
-					</Combobox.Portal>
-				</Combobox.Root>
+				</CommitTargetCombobox>
 
 				<div className={styles.commitActions}>
 					<Tooltip.Root>
@@ -373,40 +461,26 @@ export const CommitForm: FC<{
 						</Tooltip.Portal>
 					</Tooltip.Root>
 
-					<div className={styles.dropdownButton}>
-						{/* The tooltip is redundant while the label is visible. */}
-						<Tooltip.Root disabled={!commitLabelHidden}>
-							<Tooltip.Trigger
-								aria-label="Commit"
-								className={getButtonClassName({ variant: "pop" })}
-								render={<Button focusableWhenDisabled type="submit" disabled={!canCommit} />}
-							>
-								<span ref={observeCommitLabel} className={styles.commitButtonLabel}>
-									Commit
-								</span>
-								<Kbd hotkey={changesHotkeys.commit.hotkey} variant="button" />
-							</Tooltip.Trigger>
-							<Tooltip.Portal>
-								<Tooltip.Positioner sideOffset={4}>
-									<Tooltip.Popup render={<TooltipPopup kbd={changesHotkeys.commit.hotkey} />}>
-										Commit
-									</Tooltip.Popup>
-								</Tooltip.Positioner>
-							</Tooltip.Portal>
-						</Tooltip.Root>
-						<div aria-hidden className={styles.dropdownButtonSeparator} />
-						<Button
-							focusableWhenDisabled
-							disabled={!(canAmend || canCommit)}
-							aria-label="Commit options"
-							className={getButtonClassName({ variant: "pop", iconOnly: true })}
-							onClick={(event) => {
-								void showNativeMenuFromTrigger(event.currentTarget, commitMenuItems);
-							}}
+					{/* The tooltip is redundant while the label is visible. */}
+					<Tooltip.Root disabled={!commitLabelHidden}>
+						<Tooltip.Trigger
+							aria-label="Commit"
+							className={getButtonClassName({ variant: "pop" })}
+							render={<Button focusableWhenDisabled type="submit" disabled={!canCommit} />}
 						>
-							<Icon name="chevron-down" />
-						</Button>
-					</div>
+							<span ref={observeCommitLabel} className={styles.commitButtonLabel}>
+								Commit
+							</span>
+							<Kbd hotkey={changesHotkeys.commit.hotkey} variant="button" />
+						</Tooltip.Trigger>
+						<Tooltip.Portal>
+							<Tooltip.Positioner sideOffset={4}>
+								<Tooltip.Popup render={<TooltipPopup kbd={changesHotkeys.commit.hotkey} />}>
+									Commit
+								</Tooltip.Popup>
+							</Tooltip.Positioner>
+						</Tooltip.Portal>
+					</Tooltip.Root>
 				</div>
 			</div>
 		</form>


### PR DESCRIPTION


https://github.com/user-attachments/assets/e807ca91-0153-4706-ae1e-5dc1c3b857c2



The collapsed "Start commit" row now carries the commit target picker and the
commit-options dropdown, so both are reachable without composing a message
first. The target's tooltip names the current selection.

## UX decisions

- **Collapsed row mirrors the expanded footer.** Expanding should change what you
  can write, not what you can do.
- **Amend sits behind the chevron.** It ignores the message, so it isn't a variant
  of "Start commit" — it belongs in the menu, next to "Commit", with the shortcuts
  that were already registered either way.
- **The target trigger is icon-only, with the name in its tooltip.** Labels range
  from a branch name to a full commit subject; in the trigger they'd squeeze the
  primary button and make the row's width jump.
- **The tooltip reads `Target: <name>`, on one clipped line.** A bare commit
  subject reads as an unexplained sentence, and wrapping an identifier across
  three lines looks like an error message.
- **Prose tooltips still wrap**, now under a 240px cap so they can't stretch across
  the pane.
