### PR TITLE
Lower the commit button label hide breakpoint

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.module.css
@@ -70,7 +70,7 @@
 }
 
 /* When the panel is too narrow to fit the commit button label, hide it. */
-@container (max-width: 300px) {
+@container (max-width: 280px) {
 	.commitButtonLabel {
 		display: none;
 	}


### PR DESCRIPTION
The commit button label now hides at 280px instead of 300px container width, keeping the label visible in slightly narrower panels.