### PR TITLE
land: delete the landed branch's remote copy after a successful land

### DIFF
--- a/crates/but-api/src/land/deliver.rs
+++ b/crates/but-api/src/land/deliver.rs
@@ -94,15 +94,35 @@ pub(super) fn push_to_target(
 ) -> anyhow::Result<()> {
     let push_remote_tracking_ref = format!("refs/remotes/{push_remote_name}/{target_branch_name}");
     let refspec = format!("{new_target_oid}:refs/heads/{target_branch_name}");
-    // Enable the askpass broker (`Some(None)`: no stack context) so authenticated remotes get
-    // credentials when called from desktop/SDK, where the broker is installed. The CLI disables
-    // askpass (`but_askpass::disable()` in main.rs), so there it falls back to git's own
-    // non-interactive credential helpers.
-    ctx.push(
+    push_refspec(
+        ctx,
         new_target_oid,
         push_remote_tracking_ref,
+        refspec,
         false,
-        false,
+    )
+}
+
+/// Land's push convention for one explicit refspec: no push options, and forceless unless
+/// `with_lease` asks for `--force-with-lease` against our remote-tracking ref (a compare-and-swap:
+/// the push is rejected when the remote no longer matches what we last fetched).
+/// `remote_tracking_ref` only names the remote to push to, and `head` is unused when an explicit
+/// refspec is given. Enables the askpass broker (`Some(None)`: no stack context) so authenticated
+/// remotes get credentials when called from desktop/SDK, where the broker is installed. The CLI
+/// disables askpass (`but_askpass::disable()` in main.rs), so there it falls back to git's own
+/// non-interactive credential helpers.
+fn push_refspec(
+    ctx: &Context,
+    head: gix::ObjectId,
+    remote_tracking_ref: String,
+    refspec: String,
+    with_lease: bool,
+) -> anyhow::Result<()> {
+    ctx.push(
+        head,
+        remote_tracking_ref,
+        with_lease,
+        with_lease,
         Some(refspec),
         Some(None),
         vec![],
@@ -117,4 +137,97 @@ pub(super) fn is_retryable_concurrency_error(err: &anyhow::Error) -> bool {
         err.downcast_ref::<but_error::Code>(),
         Some(but_error::Code::GitNonFastForward)
     )
+}
+
+/// Best-effort cleanup after a successful land: delete each landed branch's copy on the push
+/// remote — the direct-push counterpart of the forge's "delete branch after merge". A stale pushed
+/// copy is not just clutter: a branch later created with the same name is auto-associated with the
+/// leftover remote-tracking ref and classified as merged upstream, refusing commits.
+///
+/// Only branches whose remote tip is contained in `target_tip` are deleted, so remote commits that
+/// did not land are never discarded. Failures only warn — the land itself already succeeded.
+/// Returns the short names of the branches whose remote copy was deleted.
+pub(super) fn delete_landed_remote_branches(
+    ctx: &Context,
+    landed_branches: &[String],
+    push_remote_name: &str,
+    target_tip: gix::ObjectId,
+    local_delivery: bool,
+) -> Vec<String> {
+    let mut deleted = Vec::new();
+    for name in landed_branches {
+        match delete_landed_remote_branch(ctx, name, push_remote_name, target_tip, local_delivery) {
+            Ok(true) => deleted.push(name.clone()),
+            Ok(false) => {}
+            Err(err) => {
+                tracing::warn!(?err, branch = %name, "failed to delete the landed branch's remote copy");
+            }
+        }
+    }
+    deleted
+}
+
+/// Delete one landed branch's remote copy, returning whether it existed, was contained in the
+/// landed target, and was deleted. On the self-remote path the "remote branch" is the local branch
+/// itself (the reconcile removes it), so only the remote-tracking ref is deleted.
+fn delete_landed_remote_branch(
+    ctx: &Context,
+    branch_name: &str,
+    push_remote_name: &str,
+    target_tip: gix::ObjectId,
+    local_delivery: bool,
+) -> anyhow::Result<bool> {
+    let (tracking_ref_name, remote_branch_name) = {
+        let repo = ctx.repo.get()?;
+        let local_ref: gix::refs::FullName = format!("refs/heads/{branch_name}").try_into()?;
+        // Resolve the same association the merged-upstream classification uses — the configured
+        // upstream when set, otherwise a unique name match — rather than assuming
+        // `<push remote>/<short name>`. A branch with no remote copy resolves to an error.
+        let Ok(tracking_ref) =
+            but_core::branch::resolve_tracking_branch_ref_name(local_ref.as_ref(), &repo)
+        else {
+            return Ok(false);
+        };
+        let Some((remote_name, remote_branch_name)) = but_core::extract_remote_name_and_short_name(
+            tracking_ref.as_ref(),
+            &repo.remote_names(),
+        ) else {
+            return Ok(false);
+        };
+        // Only the push remote is in scope; never push deletions to another remote. And only a
+        // same-named remote branch counts as the landed branch's copy: a differently named
+        // configured upstream is a fork point, not a copy — `git checkout -b topic origin/main`
+        // makes `topic` track `origin/main`, and deleting that would delete the target itself.
+        if remote_name != push_remote_name || remote_branch_name != branch_name {
+            return Ok(false);
+        }
+        let tracking_ref_name = tracking_ref.as_ref().as_bstr().to_string();
+        let Some(remote_tip) = super::peel_ref(&repo, &tracking_ref_name)? else {
+            return Ok(false);
+        };
+        if !super::target_ref_contains(&repo, remote_tip, target_tip)? {
+            return Ok(false);
+        }
+        (tracking_ref_name, remote_branch_name)
+    };
+    if !local_delivery {
+        // Leased: the delete is rejected if the remote branch moved since our fetch, so commits
+        // pushed there mid-land are never discarded on the strength of a stale containment check.
+        push_refspec(
+            ctx,
+            target_tip,
+            tracking_ref_name.clone(),
+            format!(":refs/heads/{remote_branch_name}"),
+            true,
+        )?;
+    }
+    // Best-effort: the remote copy is gone either way, so a failed tracking-ref delete must not
+    // make the deletion go unreported.
+    let repo = ctx.repo.get()?;
+    if let Ok(Some(reference)) = repo.try_find_reference(&tracking_ref_name)
+        && let Err(err) = reference.delete()
+    {
+        tracing::warn!(?err, branch = %branch_name, "failed to delete the local remote-tracking ref");
+    }
+    Ok(true)
 }

--- a/crates/but-api/src/land/mod.rs
+++ b/crates/but-api/src/land/mod.rs
@@ -64,6 +64,9 @@ pub enum BranchLandKind {
 pub struct BranchLandResult {
     /// What landing did to the target.
     pub landed: BranchLandKind,
+    /// The landed branches whose copy on the push remote was deleted after the land (only copies
+    /// fully contained in the landed target are deleted).
+    pub deleted_remote_branches: Vec<String>,
     /// Whether delivery moved local refs (a `gb-local` self-remote) rather than pushing to a remote.
     pub local_delivery: bool,
     /// Set when the remaining branches were not reconciled onto the moved target — either the
@@ -126,6 +129,8 @@ pub mod json {
     pub struct BranchLandResult {
         /// What landing did to the target.
         pub landed: BranchLandKind,
+        /// The landed branches whose copy on the push remote was deleted after the land.
+        pub deleted_remote_branches: Vec<String>,
         /// Whether delivery moved local refs rather than pushing to a remote.
         pub local_delivery: bool,
         /// Whether the remaining branches were left un-reconciled (run `but pull` to finish).
@@ -143,6 +148,7 @@ pub mod json {
         fn try_from(value: super::BranchLandResult) -> Result<Self, Self::Error> {
             Ok(Self {
                 landed: value.landed.into(),
+                deleted_remote_branches: value.deleted_remote_branches,
                 local_delivery: value.local_delivery,
                 reconcile_skipped: value.reconcile_skipped,
                 workspace: value.workspace.try_into()?,
@@ -223,8 +229,14 @@ pub fn branch_land(
     };
 
     // Safety guards a non-CLI caller must not be able to bypass: never publish lower stack segments
-    // the user did not opt into, and never publish conflicted commits onto the target.
-    validate_branch_landing(ctx, &branch, &target_display, whole_stack)?;
+    // the user did not opt into, and never publish conflicted commits onto the target. The names
+    // being landed are captured before anything mutates: their remote copies are deleted after a
+    // successful land.
+    let lower_segments = validate_branch_landing(ctx, &branch, &target_display, whole_stack)?;
+    let mut landed_branch_names = vec![branch.clone()];
+    landed_branch_names.extend(lower_segments);
+    // Landing the target branch's own name must never delete the target on the remote.
+    landed_branch_names.retain(|name| *name != target_branch_name);
 
     // Fetch only the target's remote: landing needs a fresh target tracking ref and nothing else,
     // and an unreachable unrelated remote must not block the land.
@@ -322,6 +334,7 @@ pub fn branch_land(
         if !advanced {
             return Ok(BranchLandResult {
                 landed,
+                deleted_remote_branches: Vec::new(),
                 local_delivery: update_target_locally,
                 reconcile_skipped: true,
                 workspace: current_workspace_state(ctx)?,
@@ -333,8 +346,41 @@ pub fn branch_land(
     ctx.invalidate_workspace_cache()?;
 
     let reconciled = reconcile::reconcile_after_land(ctx)?;
+
+    // The direct-push counterpart of the forge's "delete branch after merge": drop the landed
+    // branches' remote copies now that the target contains them. Leaving them behind is what makes
+    // a later same-named branch show up as merged upstream and refuse commits. This must run after
+    // the reconcile — integration detection reads the remote-tracking refs as evidence — and is
+    // skipped when the reconcile was, so the still-applied branches keep that evidence for the
+    // later `but pull`.
+    let deleted_remote_branches = if reconciled.blocked_by_worktree {
+        Vec::new()
+    } else {
+        let target_tip = {
+            let repo = ctx.repo.get()?;
+            peel_target_tip(&repo, &fetch_remote_name, &target_branch_name)?
+        };
+        target_tip
+            .map(|tip| {
+                deliver::delete_landed_remote_branches(
+                    ctx,
+                    &landed_branch_names,
+                    &push_remote_name,
+                    tip,
+                    update_target_locally,
+                )
+            })
+            .unwrap_or_default()
+    };
+    if !deleted_remote_branches.is_empty() {
+        // The deletions changed refs after the reconcile's workspace read; drop the cached view so
+        // later reads in this process don't serve the deleted remote-tracking refs.
+        ctx.invalidate_workspace_cache()?;
+    }
+
     Ok(BranchLandResult {
         landed,
+        deleted_remote_branches,
         local_delivery: update_target_locally,
         reconcile_skipped: reconciled.blocked_by_worktree,
         workspace: reconciled.workspace,
@@ -346,14 +392,16 @@ pub fn branch_land(
 /// stack lands", never a partial land that strands the segments above. Also refuse conflicted
 /// commits in any segment that would be published (the same guard `but push` applies before
 /// sending commits to a remote). All computed from the graph workspace, not stack projections.
+/// Returns the named lower segments that land together with `branch` — non-empty only for a
+/// validated `--whole-stack` land.
 fn validate_branch_landing(
     ctx: &mut Context,
     branch: &str,
     target_display: &str,
     whole_stack: bool,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<Vec<String>> {
     let Some(scan) = scan_stack(ctx, branch)? else {
-        return Ok(());
+        return Ok(Vec::new());
     };
 
     if whole_stack && scan.has_upper {
@@ -402,7 +450,7 @@ fn validate_branch_landing(
             scan.conflicted.join(", "),
         );
     }
-    Ok(())
+    Ok(scan.lower_segments)
 }
 
 /// Fetch the target's fetch remote and record the outcome on the project, mirroring the

--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -438,7 +438,9 @@ project-local and shared with Desktop.
 
 Land a branch directly onto the target (e.g. `origin/master`), skipping a pull request. Fast-forwards
 when possible, otherwise makes a signed merge commit; for a `gb-local` target it moves the refs
-locally. Then reconciles the remaining branches like `but pull`.
+locally. Then reconciles the remaining branches like `but pull`, and deletes each landed branch's
+copy on the push remote (only when fully contained in the landed target), reported as
+`Deleted <remote>/<branch> (landed)`.
 
 ```bash
 but land <branch-id> --yes                  # Land onto the target (--yes required non-interactively)

--- a/crates/but/src/command/legacy/land/messaging.rs
+++ b/crates/but/src/command/legacy/land/messaging.rs
@@ -37,6 +37,14 @@ pub(super) fn report_land_result(
             t.success
         };
         writeln!(out, "\n{}", style.paint(headline))?;
+        for name in &result.deleted_remote_branches {
+            writeln!(
+                out,
+                "{}",
+                t.hint
+                    .paint(format!("Deleted {push_remote_name}/{name} (landed)"))
+            )?;
+        }
     }
 
     if result.reconcile_skipped {
@@ -205,7 +213,10 @@ pub(super) fn confirm_direct_target_update(
             .map(|(name, pr)| format!("{name} (PR #{pr})"))
             .collect::<Vec<_>>()
             .join(", ");
-        format!("{action} This orphans open pull request(s): {prs}.")
+        format!(
+            "{action} This closes open pull request(s) {prs}: their remote branches are deleted \
+             after landing."
+        )
     };
 
     if let Some(out) = out.for_human() {
@@ -234,8 +245,9 @@ pub(super) fn confirm_direct_target_update(
     Ok(())
 }
 
-/// The open pull-request numbers attached to `branch_name` or any of `lower_segments`. Whole-stack
-/// landing orphans every one of them, so all are surfaced.
+/// The open pull-request numbers attached to `branch_name` or any of `lower_segments`. Landing
+/// deletes each landed branch's remote copy, which closes the attached reviews on the forge, so
+/// all are surfaced.
 ///
 /// Only applied workspace segments can land, so this reads the forge review associations that
 /// `head_info` projects onto the workspace segments (`segment.metadata.review.pull_request` is

--- a/crates/but/tests/but/command/land.rs
+++ b/crates/but/tests/but/command/land.rs
@@ -553,6 +553,147 @@ fn land_without_yes_refuses_non_interactively() {
     );
 }
 
+/// Landing a previously pushed branch deletes its copy on the remote and the local tracking ref —
+/// the direct-push counterpart of the forge's "delete branch after merge". Leaving it behind makes
+/// a later branch with the same name show up as merged upstream and refuse commits.
+#[test]
+fn land_deletes_remote_copy_of_landed_branch() {
+    let (env, remote) = sandbox_with_bare_origin();
+
+    env.file("file1.txt", "content1");
+    env.but("commit -b first-branch -m 'first commit'")
+        .assert()
+        .success();
+    env.but("push first-branch").assert().success();
+    assert_eq!(
+        env.invoke_git("rev-parse origin/first-branch"),
+        env.invoke_git("rev-parse first-branch"),
+        "the branch must be on the remote before landing for this test to mean anything"
+    );
+
+    let output = env
+        .but("land first-branch --yes")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let stdout = String::from_utf8_lossy(&output);
+    assert!(
+        stdout.contains("Deleted origin/first-branch"),
+        "land should report the remote copy cleanup; got:\n{stdout}"
+    );
+
+    let remote_refs = env.invoke_git(&format!("--git-dir={} show-ref", remote.display()));
+    assert!(
+        !remote_refs.contains("refs/heads/first-branch"),
+        "the landed branch's copy on the remote must be deleted; got:\n{remote_refs}"
+    );
+    let local_refs = env.invoke_git("show-ref");
+    assert!(
+        !local_refs.contains("refs/remotes/origin/first-branch"),
+        "the stale remote-tracking ref must be deleted too; got:\n{local_refs}"
+    );
+}
+
+/// A remote copy holding commits that did not land must be left alone: the containment guard only
+/// deletes remote branches whose tip is reachable from the landed target.
+#[test]
+fn land_keeps_remote_branch_with_unlanded_commits() {
+    let (env, remote) = sandbox_with_bare_origin();
+
+    env.file("file1.txt", "content1");
+    env.but("commit -b first-branch -m 'first commit'")
+        .assert()
+        .success();
+    env.file("file2.txt", "content2");
+    env.but("commit -b second-branch -m 'second commit'")
+        .assert()
+        .success();
+
+    // Point the remote's first-branch at a commit that will NOT land (second-branch's tip).
+    let unlanded = env.invoke_git("rev-parse second-branch");
+    env.invoke_git(&format!("push origin {unlanded}:refs/heads/first-branch"));
+    env.invoke_git("fetch origin");
+
+    let output = env
+        .but("land first-branch --yes")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let stdout = String::from_utf8_lossy(&output);
+    assert!(
+        stdout.contains("Landed first-branch onto origin/main"),
+        "the land itself must succeed and report, or the negative check below proves nothing; got:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("Deleted origin/first-branch"),
+        "a remote copy with unlanded commits must not be reported deleted; got:\n{stdout}"
+    );
+
+    let remote_refs = env.invoke_git(&format!("--git-dir={} show-ref", remote.display()));
+    assert!(
+        remote_refs.contains("refs/heads/first-branch"),
+        "a remote copy with unlanded commits must survive the land; got:\n{remote_refs}"
+    );
+}
+
+/// A branch whose configured upstream is the target itself — the `git checkout -b topic
+/// origin/main` shape — must never have that upstream deleted as its "remote copy": the upstream
+/// is a fork point, not a copy, and deleting it would delete the target branch on the remote.
+#[test]
+fn land_never_deletes_a_differently_named_upstream() {
+    let (env, remote) = sandbox_with_bare_origin();
+
+    env.file("file1.txt", "content1");
+    env.but("commit -b topic -m 'topic commit'")
+        .assert()
+        .success();
+    env.invoke_git("branch --set-upstream-to=origin/main topic");
+
+    let output = env
+        .but("land topic --yes")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let stdout = String::from_utf8_lossy(&output);
+    assert!(
+        stdout.contains("Landed topic onto origin/main"),
+        "the land itself must succeed; got:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("Deleted origin/main"),
+        "the target must never be reported as a deleted branch copy; got:\n{stdout}"
+    );
+
+    let remote_refs = env.invoke_git(&format!("--git-dir={} show-ref", remote.display()));
+    assert!(
+        remote_refs.contains("refs/heads/main"),
+        "the target branch must survive on the remote; got:\n{remote_refs}"
+    );
+}
+
+/// A sandbox whose `origin` is a real bare repository holding `main`, with the workspace set up —
+/// the shape the remote-copy cleanup tests need to observe deletions on the remote side.
+fn sandbox_with_bare_origin() -> (Sandbox, std::path::PathBuf) {
+    let env = Sandbox::open_with_default_settings("repo-with-remote-and-head");
+    let remote = env.projects_root().with_extension("origin.git");
+    env.invoke_git(&format!("init --bare {}", remote.display()));
+    env.invoke_git(&format!(
+        "--git-dir={} symbolic-ref HEAD refs/heads/main",
+        remote.display()
+    ));
+    env.invoke_git(&format!("remote set-url origin {}", remote.display()));
+    env.invoke_git("push origin main:main");
+    env.invoke_git("fetch origin");
+    env.but("setup").assert().success();
+    (env, remote)
+}
+
 fn status_json(env: &Sandbox) -> serde_json::Value {
     let stdout = env
         .but("status --json")

--- a/crates/gitbutler-git/src/repository.rs
+++ b/crates/gitbutler-git/src/repository.rs
@@ -526,6 +526,7 @@ where
 {
     let mut args = vec!["push", "--quiet", "--no-verify"];
 
+    let is_deletion = refspec.source.is_none();
     let refspec = refspec.to_string();
 
     args.push(remote);
@@ -534,7 +535,12 @@ where
     if force {
         if force_push_protection {
             args.push("--force-with-lease");
-            args.push("--force-if-includes");
+            // `--force-if-includes` verifies the remote tip was integrated into the local branch
+            // being pushed; a deletion has no local side, so the check can never pass there and
+            // the lease alone provides the compare-and-swap against our remote-tracking ref.
+            if !is_deletion {
+                args.push("--force-if-includes");
+            }
         } else {
             args.push("--force");
         }

--- a/packages/but-sdk/src/generated/graph/index.d.ts
+++ b/packages/but-sdk/src/generated/graph/index.d.ts
@@ -1206,6 +1206,8 @@ export type BranchLandKind = {
 export type BranchLandResult = {
   /** What landing did to the target. */
   landed: BranchLandKind;
+  /** The landed branches whose copy on the push remote was deleted after the land. */
+  deletedRemoteBranches: Array<string>;
   /** Whether delivery moved local refs rather than pushing to a remote. */
   localDelivery: boolean;
   /** Whether the remaining branches were left un-reconciled (run `but pull` to finish). */

--- a/packages/but-sdk/src/generated/linear/index.d.ts
+++ b/packages/but-sdk/src/generated/linear/index.d.ts
@@ -1206,6 +1206,8 @@ export type BranchLandKind = {
 export type BranchLandResult = {
   /** What landing did to the target. */
   landed: BranchLandKind;
+  /** The landed branches whose copy on the push remote was deleted after the land. */
+  deletedRemoteBranches: Array<string>;
   /** Whether delivery moved local refs rather than pushing to a remote. */
   localDelivery: boolean;
   /** Whether the remaining branches were left un-reconciled (run `but pull` to finish). */


### PR DESCRIPTION
**Problem:** `but land` deletes the local branch but leaves `origin/<branch>` behind forever. A branch later created with the same name is auto-associated with that stale remote-tracking ref and classified as `(merged upstream)`, refusing commits — the "empty sc-branch-1 (merged upstream) for no reason" loop: create → bricked → `but pull` deletes it as integrated → recreate → bricked again, until the remote copy is deleted by hand.

**Fix:** after a successful land + reconcile, delete each landed branch's copy on the push remote and its local remote-tracking ref — the direct-push counterpart of the forge's "delete branch after merge".

Decisions:
- The remote copy is resolved through the branch's actual tracking association (`resolve_tracking_branch_ref_name`: configured upstream first, unique name match otherwise) — the same association the merged-upstream classification uses — never by assuming `<push remote>/<local name>`. Deletions are only pushed to the push remote.
- Containment guard: a remote copy is only deleted when its tip is an ancestor of the landed target, so remote commits that did not land are never discarded.
- Best-effort: failures warn and never fail the land (the land already succeeded).
- The cleanup runs after the reconcile — integration detection reads the remote-tracking refs as evidence, so deleting earlier keeps the landed branch applied. It is skipped when the reconcile was, so a later `but pull` keeps that evidence.
- `--whole-stack` cleans up every landed segment.

The CLI reports each cleanup (`Deleted origin/<branch> (landed)`), the pre-land confirmation now says attached PRs will be closed (their branch is deleted), and `BranchLandResult` carries `deleted_remote_branches`.

Follow-up worth considering: the deeper home for the tracking-ref half is the shared integration in `but-workspace` (which already deletes integrated local refs) — that would give `but pull` the same cleanup for free and shrink the land-side code to the remote push alone.