### PR TITLE
but: allow workdir-target conflicts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3834,7 +3834,7 @@ dependencies = [
 [[package]]
 name = "git2"
 version = "0.21.0"
-source = "git+https://github.com/gitbutlerapp/git2-rs?rev=efce108bf14cb1708cfc4c80f2ddf3244a2635ff#efce108bf14cb1708cfc4c80f2ddf3244a2635ff"
+source = "git+https://github.com/gitbutlerapp/git2-rs?rev=a87a7bb3f6843504339fe7434ee0732a3e968f3e#a87a7bb3f6843504339fe7434ee0732a3e968f3e"
 dependencies = [
  "bitflags 2.13.0",
  "libc",
@@ -6286,7 +6286,7 @@ dependencies = [
 [[package]]
 name = "libgit2-sys"
 version = "0.18.5+1.9.4"
-source = "git+https://github.com/gitbutlerapp/git2-rs?rev=efce108bf14cb1708cfc4c80f2ddf3244a2635ff#efce108bf14cb1708cfc4c80f2ddf3244a2635ff"
+source = "git+https://github.com/gitbutlerapp/git2-rs?rev=a87a7bb3f6843504339fe7434ee0732a3e968f3e#a87a7bb3f6843504339fe7434ee0732a3e968f3e"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -318,7 +318,7 @@ sapling-renderdag = "0.1.0"
 # Keep workspace crates that use the `gix 0.86` line on the same git revision.
 # This was relevant to force `git-meta` to use our version.
 gix = { git = "https://github.com/GitoxideLabs/gitoxide", rev = "83e074c1e2d070059febaaab1022058948855101" }
-git2 = { git = "https://github.com/gitbutlerapp/git2-rs", rev = "efce108bf14cb1708cfc4c80f2ddf3244a2635ff" }
+git2 = { git = "https://github.com/gitbutlerapp/git2-rs", rev = "a87a7bb3f6843504339fe7434ee0732a3e968f3e" }
 
 [workspace.lints.clippy]
 # Note that `all` doesn't include everything, so extra lints should be added here.

--- a/apps/desktop/src/lib/upstream/branchIntegrationView.test.ts
+++ b/apps/desktop/src/lib/upstream/branchIntegrationView.test.ts
@@ -251,6 +251,7 @@ describe("branchIntegrationView", () => {
 				isManagedCommit: true,
 				isEntrypoint: true,
 			},
+			checkoutConflictOccurred: false,
 		};
 
 		expect(buildNextStateGraphRows({ workspace, branchRef: BRANCH_REF })).toEqual([

--- a/crates/but-api/src/json.rs
+++ b/crates/but-api/src/json.rs
@@ -176,6 +176,9 @@ pub struct WorkspaceState {
     /// rendered graph projection.
     #[cfg(feature = "graph-workspace")]
     pub graph_workspace: but_workspace::ui::workspace::DetailedGraphWorkspace,
+    /// True if a checkout occurred, and a conflict occurred during that
+    /// checkout.
+    pub checkout_conflict_occurred: bool,
 }
 
 #[cfg(feature = "export-schema")]
@@ -195,6 +198,7 @@ impl TryFrom<crate::WorkspaceState> for WorkspaceState {
             head_info: value.head_info.try_into()?,
             #[cfg(feature = "graph-workspace")]
             graph_workspace: value.graph_workspace,
+            checkout_conflict_occurred: value.checkout_conflict_occurred,
         })
     }
 }

--- a/crates/but-api/src/lib.rs
+++ b/crates/but-api/src/lib.rs
@@ -72,7 +72,8 @@ pub mod panic_capture;
 #[cfg(feature = "export-schema")]
 pub mod watcher;
 
-mod workspace_state;
+/// Functions for workspace state.
+pub mod workspace_state;
 
 /// Represents the workspace for the frontend
 ///
@@ -92,4 +93,7 @@ pub struct WorkspaceState {
     /// for more detail.
     #[cfg(feature = "graph-workspace")]
     pub graph_workspace: but_workspace::ui::workspace::DetailedGraphWorkspace,
+    /// True if a checkout occurred, and a conflict occurred during that
+    /// checkout.
+    pub checkout_conflict_occurred: bool,
 }

--- a/crates/but-api/src/workspace.rs
+++ b/crates/but-api/src/workspace.rs
@@ -595,13 +595,14 @@ pub fn workspace_integrate_upstream_only_with_perm(
             materialized.meta.set_workspace(&md)?;
         }
 
-        let workspace_state = WorkspaceState::from_workspace_with_db(
+        let mut workspace_state = WorkspaceState::from_workspace_with_db(
             materialized.workspace,
             materialized.meta,
             &repo,
             materialized.history.commit_mappings(),
             &db,
         )?;
+        workspace_state.checkout_conflict_occurred = materialized.checkout_conflict_occurred;
         (workspace_state, worktree_conflicts)
     };
     ctx.invalidate_workspace_cache()?;

--- a/crates/but-api/src/workspace_state.rs
+++ b/crates/but-api/src/workspace_state.rs
@@ -102,6 +102,7 @@ impl WorkspaceState {
         repo: &gix::Repository,
         replaced_commits: BTreeMap<gix::ObjectId, gix::ObjectId>,
         prs_by_head: &HashMap<String, usize>,
+        checkout_conflict_occurred: bool,
     ) -> anyhow::Result<WorkspaceState> {
         #[cfg(not(feature = "graph-workspace"))]
         {
@@ -125,6 +126,7 @@ impl WorkspaceState {
             Ok(WorkspaceState {
                 replaced_commits,
                 head_info,
+                checkout_conflict_occurred,
             })
         }
         #[cfg(feature = "graph-workspace")]
@@ -139,6 +141,7 @@ impl WorkspaceState {
             Ok(WorkspaceState {
                 replaced_commits,
                 graph_workspace: graph_workspace.into(),
+                checkout_conflict_occurred,
             })
         }
     }
@@ -154,8 +157,16 @@ impl WorkspaceState {
         meta: &mut M,
         repo: &gix::Repository,
         replaced_commits: BTreeMap<gix::ObjectId, gix::ObjectId>,
+        checkout_conflict_occurred: bool,
     ) -> anyhow::Result<WorkspaceState> {
-        Self::from_workspace(workspace, meta, repo, replaced_commits, &HashMap::new())
+        Self::from_workspace(
+            workspace,
+            meta,
+            repo,
+            replaced_commits,
+            &HashMap::new(),
+            checkout_conflict_occurred,
+        )
     }
 
     /// Build a [`WorkspaceState`] from an already-prepared overlayed graph.
@@ -171,7 +182,7 @@ impl WorkspaceState {
         db: &but_db::DbHandle,
     ) -> anyhow::Result<WorkspaceState> {
         let prs_by_head = forge_prs_by_head(db)?;
-        Self::from_workspace(workspace, meta, repo, replaced_commits, &prs_by_head)
+        Self::from_workspace(workspace, meta, repo, replaced_commits, &prs_by_head, false)
     }
 
     /// Build a preview [`WorkspaceState`] from a successful rebase without materializing it.
@@ -189,7 +200,7 @@ impl WorkspaceState {
     ) -> anyhow::Result<WorkspaceState> {
         let workspace = rebase.overlayed_graph()?.into_workspace()?;
         let (repo, meta) = rebase.repo_and_meta_mut();
-        Self::from_workspace(&workspace, meta, repo, replaced_commits, prs_by_head)
+        Self::from_workspace(&workspace, meta, repo, replaced_commits, prs_by_head, false)
     }
 
     /// Build a preview [`WorkspaceState`] from a successful rebase without materializing it.
@@ -233,6 +244,7 @@ impl WorkspaceState {
             repo,
             materialized.history.commit_mappings(),
             prs_by_head,
+            materialized.checkout_conflict_occurred,
         )
     }
 

--- a/crates/but-core/src/worktree/checkout/function.rs
+++ b/crates/but-core/src/worktree/checkout/function.rs
@@ -1,7 +1,12 @@
 use anyhow::bail;
+use bstr::BStr;
 use but_error::bail_precondition;
 use but_oxidize::{ObjectIdExt, OidExt as _};
-use gix::{merge::tree::TreatAsUnresolved, prelude::ObjectIdExt as _, refs::Target};
+use gix::{
+    merge::{plumbing::tree::ConflictIndexEntry, tree::TreatAsUnresolved},
+    prelude::ObjectIdExt as _,
+    refs::Target,
+};
 use tracing::instrument;
 
 use crate::{RepositoryExt, update_head_reference};
@@ -31,6 +36,7 @@ pub fn safe_checkout_from_head(
         skip_head_update,
         merge_base_override,
         allow_conflicted_commit_checkout,
+        allow_uncommitted_changes_to_conflict_with_new_head,
     }: Options,
 ) -> anyhow::Result<Outcome> {
     let new_object = new_head_id.attach(repo).object()?;
@@ -65,6 +71,7 @@ pub fn safe_checkout_from_head(
     let new_tree = git2_repo
         .find_object(new_head_id.to_git2(), None)?
         .peel_to_tree()?;
+    let mut conflict_occurred = false;
     if old_tree.id() != new_tree.id() {
         // Reopen to ensure that there is no "object memory" (i.e. all object
         // writes actually happen on disk).
@@ -83,28 +90,80 @@ pub fn safe_checkout_from_head(
             Default::default(),
             repo.tree_merge_options()?.with_rewrites(None),
         )?;
+        let checkout_target_base_id = outcome.tree.write()?.detach();
+
+        let checkout_target_base = git2_repo.find_tree(checkout_target_base_id.to_git2())?;
+        let mut checkout_target = git2::Index::new()?;
+        checkout_target.read_tree(&checkout_target_base)?;
+
         let unresolved = TreatAsUnresolved::git();
         if outcome.has_unresolved_conflicts(unresolved) {
-            let mut paths = outcome
-                .conflicts
-                .iter()
-                .filter(|c| c.is_unresolved(unresolved))
-                .map(|c| format!("{:?}", c.ours.location()))
-                .collect::<Vec<_>>();
-            paths.sort();
-            paths.dedup();
-            bail_precondition!(
-                "Uncommitted files would be overwritten by checkout: {}",
-                paths.join(", ")
-            );
+            conflict_occurred = true;
+            if allow_uncommitted_changes_to_conflict_with_new_head {
+                for conflict in outcome.conflicts.iter() {
+                    if !conflict.is_unresolved(unresolved) {
+                        continue;
+                    }
+                    let [base, ours, theirs] = conflict.entries();
+                    if base.is_some_and(|c| c.mode.is_tree())
+                        || ours.is_some_and(|c| c.mode.is_tree())
+                        || theirs.is_some_and(|c| c.mode.is_tree())
+                    {
+                        bail_precondition!(
+                            "Cannot checkout file-directory conflict: {}",
+                            conflict.ours.location()
+                        );
+                    }
+                    fn to_git2_index_entry(
+                        entry: &ConflictIndexEntry,
+                        path: &BStr,
+                    ) -> git2::IndexEntry {
+                        git2::IndexEntry {
+                            ctime: git2::IndexTime::new(0, 0),
+                            mtime: git2::IndexTime::new(0, 0),
+                            dev: 0,
+                            ino: 0,
+                            mode: entry.mode.value() as u32,
+                            uid: 0,
+                            gid: 0,
+                            file_size: 0,
+                            id: entry.id.to_git2(),
+                            flags: 0,
+                            flags_extended: 0,
+                            path: path.to_vec(),
+                        }
+                    }
+                    let base_index_entry =
+                        base.map(|c| to_git2_index_entry(&c, conflict.ours.location()));
+                    let ours_index_entry =
+                        ours.map(|c| to_git2_index_entry(&c, conflict.ours.location()));
+                    let theirs_index_entry =
+                        theirs.map(|c| to_git2_index_entry(&c, conflict.ours.location()));
+                    checkout_target.conflict_add(
+                        base_index_entry.as_ref(),
+                        ours_index_entry.as_ref(),
+                        theirs_index_entry.as_ref(),
+                    )?;
+                }
+            } else {
+                let mut paths = outcome
+                    .conflicts
+                    .iter()
+                    .filter(|c| c.is_unresolved(unresolved))
+                    .map(|c| format!("{:?}", c.ours.location()))
+                    .collect::<Vec<_>>();
+                paths.sort();
+                paths.dedup();
+                bail_precondition!(
+                    "Uncommitted files would be overwritten by checkout: {}",
+                    paths.join(", ")
+                );
+            }
         }
-        let checkout_target_id = outcome.tree.write()?.detach();
 
         let mut checkout_opts = git2::build::CheckoutBuilder::new();
         checkout_opts.baseline(&wd_tree);
-        let checkout_target =
-            git2_repo.find_object(checkout_target_id.to_git2(), Some(git2::ObjectType::Tree))?;
-        git2_repo.checkout_tree(&checkout_target, Some(&mut checkout_opts))?;
+        git2_repo.checkout_index(Some(&mut checkout_target), Some(&mut checkout_opts))?;
     }
 
     let mut head_update = None;
@@ -128,5 +187,8 @@ pub fn safe_checkout_from_head(
         }
     }
 
-    Ok(Outcome { head_update })
+    Ok(Outcome {
+        head_update,
+        conflict_occurred,
+    })
 }

--- a/crates/but-core/src/worktree/checkout/mod.rs
+++ b/crates/but-core/src/worktree/checkout/mod.rs
@@ -18,6 +18,11 @@ pub struct Options {
     /// conflict workflow instead. Rebase materialization may opt in when it
     /// intentionally created the conflicted commit it is about to materialize.
     pub allow_conflicted_commit_checkout: bool,
+    /// Normally, the 3-way merge between the merge base override, the working
+    /// directory, and the new HEAD must not result in a conflict. If this field
+    /// is true, such a conflict is allowed; all stages in all conflicts will be
+    /// written to the index.
+    pub allow_uncommitted_changes_to_conflict_with_new_head: bool,
 }
 
 /// The successful outcome of [super::safe_checkout_from_head()] operation.
@@ -25,6 +30,9 @@ pub struct Options {
 pub struct Outcome {
     /// If `new_head_id` was a commit, these are the ref-edits returned after performing the transaction.
     pub head_update: Option<Vec<gix::refs::transaction::RefEdit>>,
+    /// True if a conflict occurred during checkout. This is always false if
+    /// [Options::allow_uncommitted_changes_to_conflict_with_new_head] is false.
+    pub conflict_occurred: bool,
 }
 
 pub(crate) mod function;

--- a/crates/but-core/src/worktree/checkout/utils.rs
+++ b/crates/but-core/src/worktree/checkout/utils.rs
@@ -2,7 +2,7 @@ use crate::worktree::checkout::Outcome;
 
 impl std::fmt::Debug for Outcome {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let Outcome { head_update } = self;
+        let Outcome { head_update, .. } = self;
         f.debug_struct("Outcome")
             .field(
                 "head_update",

--- a/crates/but-rebase/src/graph_rebase/materialize.rs
+++ b/crates/but-rebase/src/graph_rebase/materialize.rs
@@ -207,7 +207,7 @@ impl<'ws, 'graph, M: RefMetadata> SuccessfulRebase<'ws, 'graph, M> {
         let specs = self.linked_checkout_specs()?;
         let detached_head_edits = detached_worktree_head_edits(&specs)?;
 
-        let head = if !materialize_options.without_checkout {
+        let (head, checkout_conflict_occurred) = if !materialize_options.without_checkout {
             let linked_repos = open_linked_checkout_repos(&repo, specs)?;
             for linked_repo in linked_repos {
                 safe_checkout_from_head(
@@ -217,25 +217,32 @@ impl<'ws, 'graph, M: RefMetadata> SuccessfulRebase<'ws, 'graph, M> {
                         skip_head_update: true,
                         merge_base_override: linked_repo.merge_base_override,
                         allow_conflicted_commit_checkout: false,
+                        // Don't allow for linked worktrees.
+                        allow_uncommitted_changes_to_conflict_with_new_head: false,
                     },
                 )?;
             }
 
             let head = self.head_checkout()?;
-            if let Some(head) = &head {
-                safe_checkout_from_head(
+            let checkout_conflict_occurred = if let Some(head) = &head {
+                let outcome = safe_checkout_from_head(
                     head.target,
                     &repo,
                     Options {
                         skip_head_update: true,
                         merge_base_override: head.merge_base_override,
                         allow_conflicted_commit_checkout: true,
+                        // Allow for our worktree.
+                        allow_uncommitted_changes_to_conflict_with_new_head: true,
                     },
                 )?;
-            }
-            head
+                outcome.conflict_occurred
+            } else {
+                false
+            };
+            (head, checkout_conflict_occurred)
         } else {
-            None
+            (None, false)
         };
 
         let mut ref_edits = self.ref_edits.clone();
@@ -276,6 +283,7 @@ impl<'ws, 'graph, M: RefMetadata> SuccessfulRebase<'ws, 'graph, M> {
             history: self.history,
             workspace: self.workspace,
             meta: self.meta,
+            checkout_conflict_occurred,
         })
     }
 

--- a/crates/but-rebase/src/graph_rebase/mod.rs
+++ b/crates/but-rebase/src/graph_rebase/mod.rs
@@ -474,6 +474,10 @@ pub struct MaterializeOutcome<'ws, 'meta, M: RefMetadata> {
     pub workspace: &'ws mut but_graph::Workspace,
     /// A reference to the metadata that the editor was created for.
     pub meta: &'meta mut M,
+    /// True if a conflict occurred during checkout. This is always false if
+    /// `allow_uncommitted_changes_to_conflict_with_new_head` in the options
+    /// struct passed to the materialize call is false.
+    pub checkout_conflict_occurred: bool,
 }
 
 /// Provides lookup for different steps that a selector might point to.

--- a/crates/but-transaction/src/lib.rs
+++ b/crates/but-transaction/src/lib.rs
@@ -1389,6 +1389,7 @@ fn workspace_state_from_rebase<M: RefMetadata>(
         materialized.meta,
         repo,
         materialized.history.commit_mappings(),
+        materialized.checkout_conflict_occurred,
     )
 }
 

--- a/crates/but-worktrees/tests/worktree/various.rs
+++ b/crates/but-worktrees/tests/worktree/various.rs
@@ -214,34 +214,26 @@ fn causes_workdir_conflicts_simple() -> anyhow::Result<()> {
         "In this case, we're putting a new commit on the top of the stack - the thing that should conflict is the working directory"
     );
 
-    let feature_b_tip_before = ctx
-        .repo
-        .get()?
-        .find_reference(feature_b_name.as_ref())?
-        .id()
-        .detach();
-    let err = integrate(
+    integrate(
         &ctx,
         guard.write_permission(),
         &b.created.id,
         feature_b_name.as_ref(),
     )
-    .expect_err("integration aborts instead of clobbering uncommitted changes");
-    assert!(
-        format!("{err:#}").contains("Failed to integrate worktree"),
-        "unexpected error: {err:#}"
-    );
+    .expect("it works");
 
     let foo = std::fs::read_to_string(main_worktree_dir.join("foo.txt"))?;
-    snapbox::assert_data_eq!(foo.into_bytes(), snapbox::Data::binary(b"qux\n"));
-    assert_eq!(
-        ctx.repo
-            .get()?
-            .find_reference(feature_b_name.as_ref())?
-            .id()
-            .detach(),
-        feature_b_tip_before,
-        "an aborted integration must not move any refs"
+    snapbox::assert_data_eq!(
+        foo,
+        snapbox::str![[r#"
+<<<<<<< ours
+qux
+...
+=======
+foo
+>>>>>>> theirs
+
+"#]]
     );
 
     Ok(())
@@ -299,10 +291,21 @@ fn causes_workdir_conflicts_complex() -> anyhow::Result<()> {
         &a.created.id,
         feature_a_name.as_ref(),
     )
-    .expect_err("integration aborts instead of clobbering uncommitted changes");
+    .expect("it works");
 
     let foo = std::fs::read_to_string(main_worktree_dir.join("foo.txt"))?;
-    snapbox::assert_data_eq!(foo.into_bytes(), snapbox::Data::binary(b"qux\n"));
+    snapbox::assert_data_eq!(
+        foo,
+        snapbox::str![[r#"
+<<<<<<< ours
+qux
+...
+=======
+foo
+>>>>>>> theirs
+
+"#]]
+    );
 
     Ok(())
 }

--- a/crates/but/src/command/legacy/conflict_notice.rs
+++ b/crates/but/src/command/legacy/conflict_notice.rs
@@ -62,6 +62,33 @@ pub(crate) fn snapshot(ctx: &Context) -> ConflictSnapshot {
     ConflictSnapshot { change_ids }
 }
 
+/// Warn about checkout conflict.
+pub(crate) fn report_checkout_conflict(out: &mut OutputChannel) {
+    if let Err(err) = try_report_checkout_conflict(out) {
+        tracing::warn!(?err, "could not report checkout_conflict");
+    }
+}
+
+fn try_report_checkout_conflict(out: &mut OutputChannel) -> anyhow::Result<()> {
+    let t = theme::get();
+    if let Some(out) = out.for_human() {
+        writeln!(out)?;
+        writeln!(
+            out,
+            "{}",
+            t.attention.paint(
+                "⚠ A conflict occurred during checkout. Run `but status` for more information."
+            )
+        )?;
+    } else if matches!(out.format(), OutputFormat::Json) {
+        // JSON outputs are parsed, so the warning goes to stderr.
+        eprintln!(
+            "warning: A conflict occurred during checkout. Run `but status` for more information.",
+        );
+    }
+    Ok(())
+}
+
 /// Warn about commits that are conflicted now but weren't in `before`.
 /// Best-effort; the mutation already succeeded, so errors are only logged.
 pub(crate) fn report_newly_conflicted(

--- a/crates/but/src/command/legacy/pull/mod.rs
+++ b/crates/but/src/command/legacy/pull/mod.rs
@@ -2,8 +2,7 @@ mod json;
 
 use std::fmt::Write;
 
-use anyhow::bail;
-use bstr::ByteSlice;
+use but_api::WorkspaceState;
 use but_core::{DryRun, RepositoryExt};
 use but_ctx::Context;
 use json::{BaseBranchInfo, BranchStatusInfo, PullCheckOutput, UpstreamCommit, UpstreamInfo};
@@ -77,9 +76,10 @@ pub async fn handle(
     ctx: &mut Context,
     out: &mut OutputChannel,
     check_only: bool,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<Option<WorkspaceState>> {
     if check_only {
-        handle_check(ctx, out).await
+        handle_check(ctx, out).await?;
+        Ok(None)
     } else {
         handle_pull(ctx, out).await
     }
@@ -230,7 +230,10 @@ async fn handle_check(ctx: &Context, out: &mut OutputChannel) -> anyhow::Result<
     Ok(())
 }
 
-async fn handle_pull(ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Result<()> {
+async fn handle_pull(
+    ctx: &mut Context,
+    out: &mut OutputChannel,
+) -> anyhow::Result<Option<WorkspaceState>> {
     let t = theme::get();
     let mut pull_result = PullResult {
         status: String::new(),
@@ -337,13 +340,13 @@ async fn handle_pull(ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Resu
         if let Some(out) = out.for_json() {
             out.write_value(&pull_result)?;
         }
-        return Ok(());
+        return Ok(None);
     }
 
     // Step 2: Dry-run integration and derive statuses from the preview, like the desktop app.
     let upstream::IntegrationPreview {
         current: current_head_info,
-        outcome: preview,
+        outcome: _preview,
         statuses,
     } = upstream::dry_run_integration(ctx)?;
 
@@ -355,52 +358,10 @@ async fn handle_pull(ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Resu
         if let Some(out) = out.for_json() {
             out.write_value(&pull_result)?;
         }
-        return Ok(());
+        return Ok(None);
     }
 
-    let statuses_to_apply = if !preview.worktree_conflicts.is_empty() {
-        pull_result.status = "worktree_conflicts".to_string();
-        if let Some(out) = out.for_human() {
-            writeln!(
-                out,
-                "\n{}",
-                t.error.paint(
-                    "There are uncommitted changes in the worktree that conflict with the updates:"
-                )
-            )?;
-            for path in &preview.worktree_conflicts {
-                writeln!(out, "  {}", t.attention.paint(path.to_str_lossy()))?;
-            }
-            writeln!(
-                out,
-                "{}",
-                t.important
-                    .paint("To update anyway, park them on a temporary commit first:")
-            )?;
-            writeln!(
-                out,
-                "  1. Run {} with the files listed above ({} shows their IDs)",
-                t.command_suggestion
-                    .paint("`but commit -b <branch> -m \"wip\" <file-id...>`"),
-                t.command_suggestion.paint("`but diff`")
-            )?;
-            writeln!(
-                out,
-                "  2. Run {} again; the parked commit may come back conflicted, ready for {}",
-                t.command_suggestion.paint("`but pull`"),
-                t.command_suggestion.paint("`but resolve`")
-            )?;
-            writeln!(
-                out,
-                "  3. Run {} afterwards to make those changes uncommitted again",
-                t.command_suggestion.paint("`but uncommit <commit>`")
-            )?;
-        }
-        if let Some(out) = out.for_json() {
-            out.write_value(&pull_result)?;
-        }
-        bail!("nothing was updated; uncommitted changes conflict with the incoming updates");
-    } else {
+    let statuses_to_apply = {
         pull_result.status = "updating".to_string();
 
         let mut branches_to_update = 0;
@@ -652,6 +613,7 @@ async fn handle_pull(ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Resu
                 if let Some(out) = out.for_json() {
                     out.write_value(&pull_result)?;
                 }
+                return Ok(Some(outcome.workspace_state));
             }
             Err(e) => {
                 pull_result.status = "error".to_string();
@@ -667,7 +629,7 @@ async fn handle_pull(ctx: &mut Context, out: &mut OutputChannel) -> anyhow::Resu
         }
     }
 
-    Ok(())
+    Ok(None)
 }
 
 fn check_branch_statuses(statuses: &[PullBranchStatusInfo]) -> Vec<BranchStatusInfo> {

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -1049,12 +1049,9 @@ async fn match_subcommand(
             None
         }
         #[cfg(feature = "legacy")]
-        Subcommands::Pull { check } => {
-            command::legacy::pull::handle(&mut ctx, out, check)
-                .await
-                .emit_metrics(metrics_ctx)?;
-            None
-        }
+        Subcommands::Pull { check } => command::legacy::pull::handle(&mut ctx, out, check)
+            .await
+            .emit_metrics(metrics_ctx)?,
         #[cfg(feature = "legacy")]
         Subcommands::Fetch => {
             use std::fmt::Write;
@@ -1068,8 +1065,7 @@ async fn match_subcommand(
             )?;
             command::legacy::pull::handle(&mut ctx, out, true)
                 .await
-                .emit_metrics(metrics_ctx)?;
-            None
+                .emit_metrics(metrics_ctx)?
         }
         #[cfg(feature = "legacy")]
         Subcommands::Clean {

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -865,7 +865,7 @@ async fn match_subcommand(
     // If `Some`, and if result is `Ok`, this is passed to
     // `run_status_after_if_requested()`.
     let mut status_after_data: Option<bool> = None;
-    let _ws: Option<WorkspaceState> = match cmd {
+    let ws: Option<WorkspaceState> = match cmd {
         Subcommands::Metrics { .. }
         | Subcommands::Gui { .. }
         | Subcommands::Completions { .. }
@@ -1674,6 +1674,12 @@ async fn match_subcommand(
         }
     };
 
+    #[cfg(feature = "legacy")]
+    if let Some(ws) = ws
+        && ws.checkout_conflict_occurred
+    {
+        command::legacy::conflict_notice::report_checkout_conflict(out);
+    }
     #[cfg(feature = "legacy")]
     if let Some(conflicts_before) = newly_conflicted_data {
         command::legacy::conflict_notice::report_newly_conflicted(&ctx, out, conflicts_before);

--- a/crates/but/tests/but/command/discard.rs
+++ b/crates/but/tests/but/command/discard.rs
@@ -361,6 +361,137 @@ Hint: run `but help` for all commands
 }
 
 #[test]
+fn discard_resulting_in_workdir_ud_conflict() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
+
+    env.file("commit.txt", "text\n");
+    env.but("commit -b A -m 'discardable commit'")
+        .assert()
+        .success();
+    let commit_id = env.invoke_git("rev-parse refs/heads/A");
+
+    env.file("commit.txt", "would conflict if commit above was deleted\n");
+
+    env.but(format!("discard {commit_id}"))
+        .assert()
+        .success()
+        .stderr_eq("")
+        .stdout_eq(snapbox::str![[r#"
+Discarded commit 1
+
+⚠ A conflict occurred during checkout. Run `but status` for more information.
+
+"#]]);
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄ zz [uncommitted]
+┊    commit.txt {conflicted}
+┊
+┊╭┄ g0 [A]
+┊●   tpm add A
+┊│     tpm:t A A
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+⚠ Uncommitted file conflicts: choose the desired file state, then run `git add -- <path>`.
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    snapbox::assert_data_eq!(
+        env.git_status(),
+        snapbox::str![[r#"
+UD commit.txt
+
+"#]]
+    );
+
+    snapbox::assert_data_eq!(
+        std::fs::read_to_string(env.projects_root().join("commit.txt")).unwrap(),
+        snapbox::str![[r#"
+would conflict if commit above was deleted
+
+"#]]
+    );
+}
+
+#[test]
+fn discard_resulting_in_workdir_uu_conflict() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
+
+    env.file("commit.txt", "first\n");
+    env.but("commit -b A -m 'commit'").assert().success();
+
+    env.file("commit.txt", "second\n");
+    env.but("commit -b A -m 'discardable commit'")
+        .assert()
+        .success();
+    let commit_id = env.invoke_git("rev-parse refs/heads/A");
+
+    env.file("commit.txt", "would conflict if commit above was deleted\n");
+
+    env.but(format!("discard {commit_id}"))
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Discarded commit 1
+
+⚠ A conflict occurred during checkout. Run `but status` for more information.
+
+"#]]);
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄ zz [uncommitted]
+┊    commit.txt {conflicted}
+┊
+┊╭┄ g0 [A]
+┊●   1 commit
+┊│     1:t A commit.txt
+┊●   tpm add A
+┊│     tpm:t A A
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+⚠ Uncommitted file conflicts: choose the desired file state, then run `git add -- <path>`.
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    snapbox::assert_data_eq!(
+        env.git_status(),
+        snapbox::str![[r#"
+UU commit.txt
+
+"#]]
+    );
+
+    // The output depends on whether merge.conflictstyle=diff3 is configured in
+    // gitconfig, so add a wildcard to support both types of output.
+    snapbox::assert_data_eq!(
+        std::fs::read_to_string(env.projects_root().join("commit.txt")).unwrap(),
+        snapbox::str![[r#"
+<<<<<<< ours
+would conflict if commit above was deleted
+...
+=======
+first
+>>>>>>> theirs
+
+"#]]
+    );
+}
+
+#[test]
 fn discard_multiple_commits_outputs_human() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
     env.setup_metadata(&["A"]);

--- a/crates/but/tests/but/command/pull.rs
+++ b/crates/but/tests/but/command/pull.rs
@@ -674,17 +674,38 @@ fn pull_reports_worktree_conflict_paths() {
     // to `shared.txt` on the resulting workspace head.
     env.file("shared.txt", "dirty local\nmore local work\n");
 
-    env.but("pull").assert().failure().stdout_eq(str![[r#"
+    env.but("pull").assert().success().stdout_eq(str![[r#"
 
 Found 1 upstream commits on origin/main
    [..] upstream change
 
-There are uncommitted changes in the worktree that conflict with the updates:
-  shared.txt
-To update anyway, park them on a temporary commit first:
-  1. Run `but commit -b <branch> -m "wip" <file-id...>` with the files listed above (`but diff` shows their IDs)
-  2. Run `but pull` again; the parked commit may come back conflicted, ready for `but resolve`
-  3. Run `but uncommit <commit>` afterwards to make those changes uncommitted again
+Updating 1 active branches...
+
+Rebase successful
+
+Summary
+────────
+  A - rebased
+
+To undo this operation:
+  Run `but undo`
+
+⚠ A conflict occurred during checkout. Run `but status` for more information.
+
+"#]]);
+
+    env.but("status").assert().success().stdout_eq(str![[r#"
+╭┄ zz [uncommitted]
+┊    shared.txt {conflicted}
+┊
+┊╭┄ g0 [A]
+┊◐   zyx add A
+├╯
+┊
+┴ 7f73771 (common base) 2000-01-02 upstream change
+⚠ Uncommitted file conflicts: choose the desired file state, then run `git add -- <path>`.
+
+Hint: run `but help` for all commands
 
 "#]]);
 }

--- a/crates/but/tests/but/command/undo.rs
+++ b/crates/but/tests/but/command/undo.rs
@@ -136,6 +136,44 @@ fn can_undo_but_discard_rename() {
 }
 
 #[test]
+fn can_undo_but_discard_commit() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
+
+    let commit_id = env
+        .open_repo()
+        .rev_parse_single("HEAD^{/add second}")
+        .unwrap()
+        .detach();
+
+    run_mutate_undo_roundtrip_test(&env, |env| {
+        env.but(format!("discard {}", commit_id.to_hex()))
+            .assert()
+            .success();
+    });
+}
+
+#[test]
+fn can_undo_but_discard_commit_that_caused_conflict() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
+
+    env.file("second", "update second");
+
+    let commit_id = env
+        .open_repo()
+        .rev_parse_single("HEAD^{/add second}")
+        .unwrap()
+        .detach();
+
+    run_mutate_undo_roundtrip_test(&env, |env| {
+        env.but(format!("discard {}", commit_id.to_hex()))
+            .assert()
+            .success();
+    });
+}
+
+#[test]
 fn can_undo_unapply() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
     env.setup_metadata(&["A"]);

--- a/packages/but-sdk/src/generated/graph/index.d.ts
+++ b/packages/but-sdk/src/generated/graph/index.d.ts
@@ -3851,6 +3851,11 @@ export type WorkspaceState = {
    * rendered graph projection.
    */
   graphWorkspace: DetailedGraphWorkspace;
+  /**
+   * True if a checkout occurred, and a conflict occurred during that
+   * checkout.
+   */
+  checkoutConflictOccurred: boolean;
 };
 
 /** Same as `but_core::ui::WorktreeChanges`, but with the addition of hunk assignments. */

--- a/packages/but-sdk/src/generated/linear/index.d.ts
+++ b/packages/but-sdk/src/generated/linear/index.d.ts
@@ -3848,6 +3848,11 @@ export type WorkspaceState = {
   replacedCommits: Record<string, string>;
   /** The post-operation workspace view presented to the frontend. */
   headInfo: RefInfo;
+  /**
+   * True if a checkout occurred, and a conflict occurred during that
+   * checkout.
+   */
+  checkoutConflictOccurred: boolean;
 };
 
 /** Same as `but_core::ui::WorktreeChanges`, but with the addition of hunk assignments. */


### PR DESCRIPTION
The sides of the conflicts will be written to the index.

Some of the changes in 9547b84b99 (revive `but worktree` subcommands, 2026-06-11) (which changed some tests because at that time, GitButler didn't support checkout causing workdir-target conflicts) have also been reverted, since we support workdir-target conflicts now.
