### PR TITLE
Fix logged-out UI flashing on account pages

### DIFF
--- a/apps/web/src/lib/components/HeaderAuthSection.svelte
+++ b/apps/web/src/lib/components/HeaderAuthSection.svelte
@@ -14,10 +14,13 @@
 
 	const userService = inject(USER_SERVICE);
 	const user = $derived(userService.user);
+	const userLoaded = $derived(userService.loaded);
 	const routes = inject(WEB_ROUTES_SERVICE);
 </script>
 
-{#if $user && !hideIfUserAuthenticated}
+{#if !$user && !$userLoaded}
+	<div class="auth-placeholder"></div>
+{:else if $user && !hideIfUserAuthenticated}
 	<UserAuthAvatar user={$user} />
 {:else if !$user}
 	<div class="login-signup-wrap">
@@ -27,6 +30,10 @@
 {/if}
 
 <style lang="postcss">
+	.auth-placeholder {
+		height: var(--size-button);
+	}
+
 	.login-signup-wrap {
 		display: flex;
 		align-items: center;

--- a/apps/web/src/lib/user/userService.ts
+++ b/apps/web/src/lib/user/userService.ts
@@ -30,6 +30,8 @@ export type LoadablePatchStacks = Loadable<Branch[]> & { ownerSlug: string };
 export const USER_SERVICE = new InjectionToken<UserService>("UserService");
 
 export class UserService {
+	readonly loaded: Writable<boolean> = writable(false);
+
 	user: Writable<User | undefined> = writable<User | undefined>(undefined, (set) => {
 		this.fetchUser()
 			.then((data) => {
@@ -38,6 +40,9 @@ export class UserService {
 			})
 			.catch((err) => {
 				this.error.set(err);
+			})
+			.finally(() => {
+				this.loaded.set(true);
 			});
 	});
 
@@ -61,6 +66,9 @@ export class UserService {
 					})
 					.catch((err) => {
 						this.error.set(err);
+					})
+					.finally(() => {
+						this.loaded.set(true);
 					});
 			} else if (!available) {
 				// If authentication is no longer available, clear the user

--- a/apps/web/src/routes/(app)/[ownerSlug]/[projectSlug]/reviews/+page.svelte
+++ b/apps/web/src/routes/(app)/[ownerSlug]/[projectSlug]/reviews/+page.svelte
@@ -17,10 +17,11 @@
 	const routes = inject(WEB_ROUTES_SERVICE);
 	const userService = inject(USER_SERVICE);
 	const user = userService.user;
+	const userLoaded = userService.loaded;
 
 	// If there is no user (user not logged in), redirect to home
 	$effect(() => {
-		if ($user === undefined) {
+		if ($user === undefined && $userLoaded) {
 			goto(routes.homePath());
 		}
 	});

--- a/apps/web/src/routes/(app)/[ownerSlug]/rules/+page.svelte
+++ b/apps/web/src/routes/(app)/[ownerSlug]/rules/+page.svelte
@@ -14,10 +14,11 @@
 	const routes = inject(WEB_ROUTES_SERVICE);
 	const userService = inject(USER_SERVICE);
 	const user = userService.user;
+	const userLoaded = userService.loaded;
 
 	// If there is no user (user not logged in), redirect to home
 	$effect(() => {
-		if ($user === undefined) {
+		if ($user === undefined && $userLoaded) {
 			goto(routes.homePath());
 		}
 	});

--- a/apps/web/src/routes/(app)/organizations/invite/[slug]/[code]/+page.svelte
+++ b/apps/web/src/routes/(app)/organizations/invite/[slug]/[code]/+page.svelte
@@ -14,6 +14,7 @@
 	const organizationService = inject(ORGANIZATION_SERVICE);
 
 	const user = $derived(userService.user);
+	const userLoaded = $derived(userService.loaded);
 
 	// Get the org slug and invite code from the route parameters
 	const inviteCode = $derived($page.params.code!);
@@ -100,7 +101,11 @@
 	<div class="invite-card">
 		<h1>Organization Invitation</h1>
 
-		{#if !isLoggedIn}
+		{#if !isLoggedIn && !$userLoaded}
+			<div class="loading-container">
+				<p>Checking your invitation...</p>
+			</div>
+		{:else if !isLoggedIn}
 			<p>You've been invited to join <strong>{slug}</strong>.</p>
 			<p>Please log in to continue.</p>
 			<Button onclick={goToLogin} style="pop">Log In</Button>

--- a/apps/web/src/routes/(app)/profile/+page.svelte
+++ b/apps/web/src/routes/(app)/profile/+page.svelte
@@ -29,6 +29,7 @@
 	);
 
 	const user = $derived(userService.user);
+	const userLoaded = $derived(userService.loaded);
 
 	const detectedOS = $derived.by(() => {
 		const os = getOS();
@@ -83,7 +84,9 @@
 	<title>GitButler | User</title>
 </svelte:head>
 
-{#if !$user?.id}
+{#if !$user?.id && !$userLoaded}
+	<div class="loading-user"></div>
+{:else if !$user?.id}
 	<div class="not-logged-in">
 		<h3 class="text-18 text-bold">It looks like you're not logged in</h3>
 		<p class="text-14 text-body clr-text-2">
@@ -274,6 +277,11 @@
 </Modal>
 
 <style lang="postcss">
+	.loading-user {
+		grid-column: full-start / full-end;
+		min-height: 100%;
+	}
+
 	.not-logged-in {
 		display: flex;
 		row-gap: 10px;


### PR DESCRIPTION
### The problem

Load or refresh the profile page while signed in and you get "It looks like you're not logged in" for a moment before the real page appears. Same idea in the header, where the Log in / Sign up buttons flash before your avatar shows up.

### Why it happens

Web auth is cookie based, so the client has no way of knowing synchronously whether you're signed in. `UserService.user` starts out as `undefined` and only fills in once `GET /api/user` comes back. That means `undefined` covers two very different states: "still fetching" and "logged out". Everything reading the store treats it as the second one on the first frame.

### What I found along the way

The rules page and the reviews page have a nastier version of this. Their redirect effect fires while the fetch is still in flight, so refreshing either page while signed in kicks you back to home. The organization invite page shows "Please log in to continue" for the same reason.

### The fix

`UserService` now exposes a `loaded` store that flips to true once the initial fetch settles, either way. Pages wait for it before rendering logged-out UI or redirecting.

One thing worth calling out: the conditions read `$user` before `$userLoaded` on purpose. Svelte only subscribes to a store when the expression reading it actually runs, so putting `$userLoaded` first would short circuit, leave `$user` unsubscribed, and the fetch would never start.

### Testing

`svelte-check` passes clean on 1791 files, eslint is clean on the touched files, and the existing web unit tests still pass. I haven't been able to confirm it in a live browser since that needs a real signed-in session cookie.

Files touched:

- `apps/web/src/lib/user/userService.ts`
- `apps/web/src/routes/(app)/profile/+page.svelte`
- `apps/web/src/lib/components/HeaderAuthSection.svelte`
- `apps/web/src/routes/(app)/organizations/invite/[slug]/[code]/+page.svelte`
- `apps/web/src/routes/(app)/[ownerSlug]/rules/+page.svelte`
- `apps/web/src/routes/(app)/[ownerSlug]/[projectSlug]/reviews/+page.svelte`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
