### PR TITLE
Add a diff minimap

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
@@ -148,6 +148,19 @@
 
 .diffContentsContainer {
 	display: grid;
+	/* Code, then the minimap ruler — which collapses the column when it has
+	   nothing to map. */
+	grid-template-columns: minmax(0, 1fr) auto;
+
+	/* Drop the native scrollbar only while the minimap is showing, so a diff too
+	   short to map keeps one. */
+	&:has([data-minimap-navigable="true"]) .diffContents {
+		scrollbar-width: none;
+
+		&::-webkit-scrollbar {
+			display: none;
+		}
+	}
 }
 
 .diffContents {

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -123,10 +123,14 @@ import {
 import { FileIcon } from "#ui/components/FileIcon.tsx";
 import {
 	type Annotation,
+	codeViewItemMetrics,
+	codeViewLayout,
 	type DiffView,
 	getDiffView,
 	hunkOperandIdentityKey,
 } from "./diff-view.ts";
+import { DiffMinimap } from "./DiffMinimap.tsx";
+import { getMinimapFiles } from "./diff-minimap.ts";
 
 export type DiffViewerHandle = CodeViewHandle<Annotation>;
 
@@ -591,22 +595,14 @@ const DiffContents: FC<{
 				onLineLeave: ({ numberElement }) => {
 					numberElement.querySelector(':scope > slot[name="gutter-utility-slot"]')?.remove();
 				},
-				layout: {
-					paddingTop: 0,
-					// Match --panel-padding-block.
-					paddingBottom: 12,
-					gap: 10,
-				},
+				layout: codeViewLayout,
 				// This appears to validate before our custom header has been slotted, in which case - if
 				// our metrics are correct - we should see deltas in multiples of our custom header height
 				// as defined in the metrics. We'll see an additional set of logs if there are other issues
 				// with our metrics.
 				__devOnlyValidateItemHeights: false,
 				onPostRender: handleHunkPostRender,
-				itemMetrics: {
-					diffHeaderHeight: 38,
-					paddingBottom: 9,
-				},
+				itemMetrics: codeViewItemMetrics,
 				unsafeCSS: `
           :host {
             background-color: transparent;
@@ -938,9 +934,10 @@ const Diff: FC<{
 		select: (comments) => annotationsByPathForScope(comments, fileParent),
 	});
 
+	const activeFilePath = selection._tag === "File" ? selection.path : filesSelection;
+
 	const diffViewSansAnno = useMemo(() => {
-		const selectedFile = selection._tag === "File" ? selection.path : filesSelection;
-		const selectedFileIdx = changes.findIndex((change) => change.path === selectedFile);
+		const selectedFileIdx = changes.findIndex((change) => change.path === activeFilePath);
 
 		return getDiffView({
 			fileParent,
@@ -949,7 +946,7 @@ const Diff: FC<{
 				? treeChangeDiffs
 				: treeChangeDiffs.slice(selectedFileIdx, selectedFileIdx + 1),
 		});
-	}, [fileParent, renderAllFiles, selection, filesSelection, changes, treeChangeDiffs]);
+	}, [fileParent, renderAllFiles, activeFilePath, changes, treeChangeDiffs]);
 
 	const diffView = withAnnotations(diffViewSansAnno, annotationsByPath);
 
@@ -983,6 +980,7 @@ const Diff: FC<{
 			diffBackground: cfg.diffBackground,
 			diffOverflow: cfg.diffOverflow,
 			diffStyle: cfg.diffStyle,
+			diffTabSize: cfg.diffTabSize,
 		}),
 	});
 
@@ -990,6 +988,34 @@ const Diff: FC<{
 
 	const diffContentsEl = useRef<HTMLElement | null>(null);
 	const [canUseSplitDiff, setCanUseSplitDiff] = useState<boolean | undefined>();
+
+	// Split and unified lay hunks out differently, so the minimap has to model
+	// whichever style the viewer is actually rendering.
+	const diffStyle = canUseSplitDiff
+		? (diffSettings?.diffStyle ?? diffDefaults.diffStyle)
+		: "unified";
+
+	const tabSize = diffSettings?.diffTabSize ?? defaultSettings.diffTabSize;
+
+	// The minimap maps whatever the viewer holds — every file, or the one file
+	// shown at a time. Keyed on that file's index rather than its path so the
+	// map doesn't rebuild as scrolling moves the selection through the list.
+	const shownIndex = renderAllFiles
+		? -1
+		: changes.findIndex((change) => change.path === activeFilePath);
+
+	const minimapFiles = useMemo(
+		() =>
+			getMinimapFiles({
+				fileParent,
+				changes: shownIndex < 0 ? changes : changes.slice(shownIndex, shownIndex + 1),
+				treeChangeDiffs:
+					shownIndex < 0 ? treeChangeDiffs : treeChangeDiffs.slice(shownIndex, shownIndex + 1),
+				diffStyle,
+				tabSize,
+			}),
+		[shownIndex, fileParent, changes, treeChangeDiffs, diffStyle, tabSize],
+	);
 
 	useHotkeys([
 		{
@@ -1150,11 +1176,13 @@ const Diff: FC<{
 							annotationsByPath={annotationsByPath}
 							diffBackgrounds={diffSettings?.diffBackground}
 							diffOverflow={diffSettings?.diffOverflow}
-							diffStyle={canUseSplitDiff ? diffSettings?.diffStyle : "unified"}
+							diffStyle={diffStyle}
 							selectionScopeRef={selectionScopeRef}
 							viewerRef={viewerRef}
 							didScrollToViaFileRef={didScrollToViaFileRef}
 						/>
+
+						<DiffMinimap viewerRef={viewerRef} files={minimapFiles} diffStyle={diffStyle} />
 					</div>
 				</Panel>
 			</Group>

--- a/apps/lite/ui/src/routes/project/$id/workspace/DiffMinimap.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DiffMinimap.module.css
@@ -1,0 +1,136 @@
+/*
+ * Registered so the computed value is a resolved colour rather than the
+ * unevaluated light-dark() token — the canvas samples these and cannot
+ * evaluate CSS itself.
+ */
+@property --minimap-additions {
+	syntax: "<color>";
+	inherits: true;
+	initial-value: transparent;
+}
+
+@property --minimap-deletions {
+	syntax: "<color>";
+	inherits: true;
+	initial-value: transparent;
+}
+
+@property --minimap-file-rule {
+	syntax: "<color>";
+	inherits: true;
+	initial-value: transparent;
+}
+
+.minimap {
+	/* Mixed towards the background the way the diff tints its own changed rows,
+	   just further, since a mark can be a single pixel tall. */
+	--minimap-additions: color-mix(in lab, var(--bg-1) 62%, var(--fill-safe-bg));
+	--minimap-deletions: color-mix(in lab, var(--bg-1) 62%, var(--fill-danger-bg));
+	/* Mixed into the background rather than towards transparent, so a rule covers
+	   the marks it crosses instead of tinting with them. */
+	--minimap-file-rule: color-mix(in srgb, var(--fill-gray-bg) 14%, var(--bg-1));
+
+	--minimap-view-min: 14px;
+	/* Clamped here rather than in the geometry, which works in fractions and has
+	   no idea how tall the ruler ended up. */
+	--minimap-view-top: min(var(--minimap-marker-top, 0%), calc(100% - var(--minimap-view-min)));
+	--minimap-view-height: max(var(--minimap-marker-height, 0%), var(--minimap-view-min));
+
+	position: relative;
+	width: 56px;
+	/* Stronger than the panel's other hairlines: the marks run right to this
+	   edge, and a deletion-heavy diff puts near-identical pinks on both sides. */
+	border-left: 1px solid var(--border-2);
+	background-color: var(--bg-1);
+	cursor: default;
+}
+
+/* Nothing worth mapping: no files, or the diff is barely taller than the pane. */
+.minimap[data-minimap-navigable="false"] {
+	display: none;
+}
+
+.canvas {
+	display: block;
+	width: 100%;
+	height: 100%;
+}
+
+/*
+ * A lens over the marks showing what the viewport covers. A flat fill with no
+ * edge, kept light enough to read as an overlay rather than shading them — and
+ * above the badges, since a file's icon is part of what it covers.
+ */
+.marker {
+	z-index: 2;
+	position: absolute;
+	inset-inline: 0;
+	top: var(--minimap-view-top);
+	height: var(--minimap-view-height);
+	border-radius: 2px;
+	background-color: color-mix(in srgb, var(--fill-gray-bg) 16%, transparent);
+	pointer-events: none;
+}
+
+/*
+ * Tucked into the corner its file opens from, against the rule above it. The
+ * backdrop is opaque only across that corner — a hard stop at the halfway point
+ * makes the boundary a clean diagonal — so the icon reads over the marks at its
+ * top left while the rest of them stay visible past it.
+ */
+.badge {
+	z-index: 1;
+	position: absolute;
+	left: 0;
+	place-items: start;
+	width: 22px;
+	height: 22px;
+	/* Clear the rule itself, so it runs unbroken behind the badge. */
+	margin-top: 1px;
+	background: linear-gradient(to bottom right, var(--bg-1) 50%, transparent 50%);
+	pointer-events: none;
+
+	& > svg {
+		width: 14px;
+		height: 14px;
+	}
+}
+
+.hint {
+	display: flex;
+	z-index: 3;
+	position: absolute;
+	top: clamp(16px, var(--minimap-hint-top, 0%), calc(100% - 16px));
+	/* The ruler is the window's right edge, so the label opens inward. */
+	right: calc(100% + 8px);
+	align-items: center;
+	max-width: 420px;
+	padding: 6px 8px;
+	gap: 6px;
+	translate: 0 -50%;
+	border-radius: var(--radius-button);
+	background-color: var(--bg-1);
+	box-shadow: var(--shadow-tooltip);
+	color: var(--text-1);
+	font-size: 12px;
+	white-space: nowrap;
+	pointer-events: none;
+}
+
+.hintIcon {
+	flex: none;
+	width: 14px;
+	height: 14px;
+}
+
+.hintName {
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.hintDirectory {
+	overflow: hidden;
+	color: var(--text-2);
+	direction: rtl;
+	text-overflow: ellipsis;
+}

--- a/apps/lite/ui/src/routes/project/$id/workspace/DiffMinimap.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DiffMinimap.tsx
@@ -1,0 +1,248 @@
+import { FileIcon } from "#ui/components/FileIcon.tsx";
+import type { GUISettings } from "#electron/settings.ts";
+import type { CodeViewHandle } from "@pierre/diffs/react";
+import {
+	type FC,
+	type PointerEvent,
+	type RefObject,
+	useLayoutEffect,
+	useRef,
+	useState,
+} from "react";
+import type { Annotation } from "./diff-view.ts";
+import {
+	getMinimapGeometry,
+	getMinimapViewport,
+	type MinimapFile,
+	type MinimapGeometry,
+	scrollMinimapTo,
+} from "./diff-minimap.ts";
+import { type MinimapBadge, paintMinimap } from "./diff-minimap-canvas.ts";
+import styles from "./DiffMinimap.module.css";
+
+/**
+ * A scroll ruler for the diff: every added and removed run drawn where it
+ * actually sits in the scroll extent, as wide as its lines are long, with a
+ * rule between files.
+ *
+ * Painted to a canvas from CodeView's live layout rather than rendered from
+ * React state, so the file list stays off the scroll path — which matters
+ * because the diff panel already re-renders on scroll, as the file under the
+ * viewport top drives the selection — and a dense diff costs no DOM.
+ */
+export const DiffMinimap: FC<{
+	viewerRef: RefObject<CodeViewHandle<Annotation> | null>;
+	files: Array<MinimapFile>;
+	diffStyle: GUISettings["diffStyle"];
+}> = ({ viewerRef, files, diffStyle }) => {
+	const rulerRef = useRef<HTMLDivElement>(null);
+	const canvasRef = useRef<HTMLCanvasElement>(null);
+	const markerRef = useRef<HTMLDivElement>(null);
+	/** Where the pointer took hold of the thumb, as a fraction of the content. */
+	const grabRef = useRef(0);
+	const dataRef = useRef({ files, diffStyle });
+	const geometryRef = useRef<MinimapGeometry | null>(null);
+	const resyncRef = useRef<(() => void) | null>(null);
+	const [navigable, setNavigable] = useState(false);
+	const [hovered, setHovered] = useState<string | null>(null);
+	const [badges, setBadges] = useState<Array<MinimapBadge>>([]);
+
+	useLayoutEffect(() => {
+		const viewer = viewerRef.current?.getInstance();
+		const canvas = canvasRef.current;
+		if (!viewer || !canvas) return;
+
+		let frame: number | null = null;
+		let forced = false;
+		let lastScrollHeight: number | null = null;
+
+		const draw = (): void => {
+			const { files, diffStyle } = dataRef.current;
+			const geometry = getMinimapGeometry(
+				viewer,
+				files.map((file) => file.itemId),
+			);
+
+			geometryRef.current = geometry;
+			setNavigable(geometry !== null);
+			if (!geometry) return;
+
+			setBadges(paintMinimap(canvas, { files, geometry, diffStyle }));
+		};
+
+		const sync = (force: boolean): void => {
+			// Item heights start out estimated and firm up as virtualization renders
+			// them, which moves every file below. Total height moves with them, so it
+			// doubles as a cheap "the layout shifted" check on the scroll path.
+			const scrollHeight = viewer.getScrollHeight();
+			if (force || scrollHeight !== lastScrollHeight) {
+				lastScrollHeight = scrollHeight;
+				draw();
+			}
+
+			const ruler = rulerRef.current;
+			if (!ruler) return;
+
+			const viewport = getMinimapViewport(viewer);
+			ruler.style.setProperty("--minimap-marker-top", `${viewport.top * 100}%`);
+			ruler.style.setProperty("--minimap-marker-height", `${viewport.height * 100}%`);
+		};
+
+		// A forced pass has to outlive being folded into a pending scroll one,
+		// which would otherwise drop the repaint it was asked for.
+		const schedule = (force: boolean) => () => {
+			forced ||= force;
+			if (frame !== null) return;
+
+			frame = requestAnimationFrame(() => {
+				frame = null;
+				const repaint = forced;
+				forced = false;
+				sync(repaint);
+			});
+		};
+
+		const redraw = schedule(true);
+		resyncRef.current = redraw;
+		sync(true);
+
+		const unsubscribe = viewer.subscribeToScroll(schedule(false));
+
+		const resizeObserver = new ResizeObserver(redraw);
+		resizeObserver.observe(canvas);
+		const root = viewer.getContainerElement();
+		if (root) {
+			resizeObserver.observe(root);
+			// CodeView sizes this scaffold to the full content height, so watching it
+			// catches folds, annotations and settling measurements — none of which
+			// emit a scroll event.
+			if (root.firstElementChild) resizeObserver.observe(root.firstElementChild);
+		}
+
+		// Canvas colours are sampled, not live CSS, so they need repainting when
+		// the tokens behind them resolve differently.
+		const scheme = globalThis.matchMedia("(prefers-color-scheme: dark)");
+		scheme.addEventListener("change", redraw);
+
+		return () => {
+			resyncRef.current = null;
+			if (frame !== null) cancelAnimationFrame(frame);
+			unsubscribe();
+			resizeObserver.disconnect();
+			scheme.removeEventListener("change", redraw);
+		};
+	}, [viewerRef]);
+
+	// Republish what the paint loop reads, since it owns its data outside React.
+	// Guarded so renders driven by hover don't repaint the canvas.
+	useLayoutEffect(() => {
+		const previous = dataRef.current;
+		if (previous.files === files && previous.diffStyle === diffStyle) return;
+
+		dataRef.current = { files, diffStyle };
+		resyncRef.current?.();
+	});
+
+	const fractionAt = (event: PointerEvent<HTMLDivElement>): number | null => {
+		const { height, top } = event.currentTarget.getBoundingClientRect();
+		if (height === 0) return null;
+
+		// A captured pointer travels outside the ruler, and this is a fraction of
+		// it — so keep it one rather than leaving every caller to cope.
+		return Math.min(Math.max((event.clientY - top) / height, 0), 1);
+	};
+
+	const dragTo = (fraction: number): void => {
+		const viewer = viewerRef.current?.getInstance();
+		if (viewer) scrollMinimapTo(viewer, fraction - grabRef.current);
+	};
+
+	// The label's position is written straight to the DOM, so following the
+	// pointer costs no renders; only naming a different file does.
+	const describe = (fraction: number): void => {
+		const geometry = geometryRef.current;
+		const ruler = rulerRef.current;
+		if (!geometry || !ruler) return;
+
+		ruler.style.setProperty("--minimap-hint-top", `${fraction * 100}%`);
+
+		const offset = fraction * geometry.contentHeight;
+		const index = geometry.blocks.findLastIndex((block) => block.top <= offset);
+		const path = dataRef.current.files[index]?.path ?? null;
+		if (path !== hovered) setHovered(path);
+	};
+
+	return (
+		<div
+			ref={rulerRef}
+			// The files tree and the diff hotkeys are the accessible route through the
+			// same content; this is a pointer shortcut over it.
+			aria-hidden
+			className={styles.minimap}
+			// Read by the diff panel's CSS to drop the native scrollbar only while
+			// this is standing in for it.
+			data-minimap-navigable={navigable}
+			onPointerDown={(event) => {
+				event.preventDefault();
+
+				const viewer = viewerRef.current?.getInstance();
+				const fraction = fractionAt(event);
+				if (!viewer || fraction === null) return;
+
+				// Taking hold of the lens keeps the point you grabbed, the way a
+				// scrollbar does; pressing the track jumps its middle there and drags on
+				// from the middle. Its own rect is the hit test, so the minimum height
+				// it can shrink to doesn't have to be repeated here.
+				const marker = markerRef.current?.getBoundingClientRect();
+				const held = marker && event.clientY >= marker.top && event.clientY <= marker.bottom;
+				const viewport = getMinimapViewport(viewer);
+				grabRef.current = held ? fraction - viewport.top : viewport.height / 2;
+
+				event.currentTarget.setPointerCapture(event.pointerId);
+				// Taking hold shouldn't move anything; pressing the track jumps.
+				if (!held) dragTo(fraction);
+			}}
+			onPointerMove={(event) => {
+				const fraction = fractionAt(event);
+				if (fraction === null) return;
+
+				describe(fraction);
+				if (event.currentTarget.hasPointerCapture(event.pointerId)) dragTo(fraction);
+			}}
+			onPointerLeave={() => setHovered(null)}
+		>
+			<canvas ref={canvasRef} className={styles.canvas} />
+			<div ref={markerRef} className={styles.marker} />
+
+			{badges.map(({ index, top }) => {
+				const path = files[index]?.path;
+
+				return (
+					path !== undefined && (
+						<FileIcon
+							key={path}
+							fileName={path}
+							className={styles.badge}
+							style={{ top: `${top}px` }}
+						/>
+					)
+				);
+			})}
+
+			{hovered !== null && <MinimapHint path={hovered} />}
+		</div>
+	);
+};
+
+const MinimapHint: FC<{ path: string }> = ({ path }) => {
+	const separator = path.lastIndexOf("/");
+	const name = separator === -1 ? path : path.slice(separator + 1);
+
+	return (
+		<div className={styles.hint}>
+			<FileIcon fileName={name} className={styles.hintIcon} />
+			<span className={styles.hintName}>{name}</span>
+			{separator !== -1 && <span className={styles.hintDirectory}>{path.slice(0, separator)}</span>}
+		</div>
+	);
+};

--- a/apps/lite/ui/src/routes/project/$id/workspace/diff-minimap-canvas.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/diff-minimap-canvas.ts
@@ -1,0 +1,244 @@
+import type { GUISettings } from "#electron/settings.ts";
+import { getMinimapScale, type MinimapFile, type MinimapGeometry } from "./diff-minimap.ts";
+
+/** The channel between the two lanes in side-by-side. */
+const LANE_SPLIT = 1;
+
+/** Vertical room a file rule needs before the next one is drawn. */
+const RULE_MIN_GAP = 6;
+
+/** Height a file's section needs before it is badged with its type icon. */
+const ICON_MIN_SECTION = 24;
+
+type Side = "additions" | "deletions";
+
+/**
+ * Per device pixel: line widths and indents summed against how much of the
+ * pixel each line covers, so dividing one by the other gives the average. Held
+ * as sums rather than averages because they are accumulated a line at a time.
+ */
+type Lane = {
+	widths: Float32Array;
+	indents: Float32Array;
+	/** Everything that landed here, blank lines included. */
+	coverage: Float32Array;
+	/** Only the lines with something on them, which is what the sums average by. */
+	content: Float32Array;
+};
+
+/** A file section with room for its type icon, and where that icon goes. */
+export type MinimapBadge = {
+	index: number;
+	top: number;
+};
+
+/**
+ * Resolve every changed line down to one value per device pixel, each line
+ * weighted by how much of the pixel it covers — the same box filter an image
+ * uses when it is scaled down. Averaging rather than taking the widest keeps a
+ * lone long line from squaring off a whole run. Nothing is drawn twice, so a
+ * dense diff can't paint itself taller than the ruler.
+ */
+const resolveLanes = ({
+	files,
+	geometry,
+	rows,
+	scale,
+}: {
+	files: Array<MinimapFile>;
+	geometry: MinimapGeometry;
+	rows: number;
+	scale: number;
+}): Record<Side, Lane> => {
+	const lane = (): Lane => ({
+		widths: new Float32Array(rows),
+		indents: new Float32Array(rows),
+		coverage: new Float32Array(rows),
+		content: new Float32Array(rows),
+	});
+	const lanes = { deletions: lane(), additions: lane() };
+
+	for (const [index, file] of files.entries()) {
+		const block = geometry.blocks[index];
+		if (!block) continue;
+
+		// Straight off the file's own marks: a scaled copy of every one of them,
+		// on every paint, is a lot of garbage for two multiplications.
+		const correction = getMinimapScale(file, block) * scale;
+		const origin = block.top * scale;
+
+		for (const mark of file.marks) {
+			const lane = lanes[mark.side];
+			const lineHeight = (mark.height * correction) / mark.widths.length;
+			let y = origin + mark.top * correction;
+
+			for (const [line, width] of mark.widths.entries()) {
+				// A line owns the pixels it covers, and one thinner than a pixel owns
+				// only the one its middle lands in — otherwise a removal and the
+				// addition under it would both claim the boundary between them.
+				const tall = lineHeight >= 1;
+				const first = Math.max(Math.floor(tall ? y : y + lineHeight / 2), 0);
+				const last = Math.min(tall ? Math.ceil(y + lineHeight) - 1 : first, rows - 1);
+
+				const indent = mark.indents[line] ?? 0;
+				// A line with nothing but whitespace on it marks its pixel, but averaging
+				// its zero length in would drag the shape of the lines around it down.
+				const blank = width === indent;
+
+				for (let row = first; row <= last; row++) {
+					// A sub-pixel line was pinned to one row, so all of it counts there.
+					const covered = tall ? Math.min(y + lineHeight, row + 1) - Math.max(y, row) : lineHeight;
+
+					lane.coverage[row] = (lane.coverage[row] ?? 0) + covered;
+					if (blank) continue;
+
+					lane.content[row] = (lane.content[row] ?? 0) + covered;
+					lane.widths[row] = (lane.widths[row] ?? 0) + width * covered;
+					lane.indents[row] = (lane.indents[row] ?? 0) + indent * covered;
+				}
+				y += lineHeight;
+			}
+		}
+	}
+
+	return lanes;
+};
+
+/**
+ * One rule per file, snapped to a whole pixel. Where two would collide the
+ * taller section keeps the slot, so a sliver can't take it from the file after
+ * it. The first file gets none — the ruler's top edge is already where it
+ * starts, and the toolbar above draws its own border there.
+ */
+const resolveRules = ({
+	geometry,
+	scale,
+	limit,
+}: {
+	geometry: MinimapGeometry;
+	scale: number;
+	limit: number;
+}): Array<{ index: number; y: number; height: number }> => {
+	const rules: Array<{ index: number; y: number; height: number }> = [];
+
+	for (const [index, block] of geometry.blocks.entries()) {
+		if (index === 0) continue;
+
+		const rule = {
+			index,
+			y: Math.min(Math.round(block.top * scale), limit),
+			height: block.height * scale,
+		};
+		const previous = rules.at(-1);
+
+		if (previous && rule.y - previous.y < RULE_MIN_GAP) {
+			if (rule.height > previous.height) rules[rules.length - 1] = rule;
+			continue;
+		}
+		rules.push(rule);
+	}
+
+	return rules;
+};
+
+/**
+ * Paint the ruler, and report which files have room for a type icon. Badges are
+ * only offered for files that kept a rule, so one always sits the same distance
+ * under the line opening its section rather than measuring to one further up.
+ */
+export const paintMinimap = (
+	canvas: HTMLCanvasElement,
+	{
+		files,
+		geometry,
+		diffStyle,
+	}: {
+		files: Array<MinimapFile>;
+		geometry: MinimapGeometry;
+		diffStyle: GUISettings["diffStyle"];
+	},
+): Array<MinimapBadge> => {
+	const { width, height } = canvas.getBoundingClientRect();
+	const context = canvas.getContext("2d");
+	if (!context || width === 0 || height === 0) return [];
+
+	const ratio = globalThis.devicePixelRatio > 0 ? globalThis.devicePixelRatio : 1;
+	const deviceWidth = Math.round(width * ratio);
+	const deviceHeight = Math.round(height * ratio);
+	if (canvas.width !== deviceWidth || canvas.height !== deviceHeight) {
+		canvas.width = deviceWidth;
+		canvas.height = deviceHeight;
+	}
+
+	context.setTransform(ratio, 0, 0, ratio, 0, 0);
+	context.clearRect(0, 0, width, height);
+
+	const palette = getComputedStyle(canvas);
+	const fills = {
+		deletions: palette.getPropertyValue("--minimap-deletions"),
+		additions: palette.getPropertyValue("--minimap-additions"),
+	};
+
+	const split = diffStyle === "split";
+	const laneWidth = Math.max(split ? (width - LANE_SPLIT) / 2 : width, 1);
+	// One device pixel, in the CSS units the context is scaled to.
+	const thinnest = 1 / ratio;
+	const scale = height / geometry.contentHeight;
+	const rows = deviceHeight;
+	const lanes = resolveLanes({ files, geometry, rows, scale: scale * ratio });
+
+	// Unified stacks both sides in one lane, so past a line per pixel a removal
+	// and an addition can land on the same one. Give it to whichever fills more
+	// of it, rather than letting the second side painted cover part of the first
+	// and read as a line that changes colour.
+	if (!split) {
+		for (let row = 0; row < rows; row++) {
+			const removed = lanes.deletions.coverage[row] ?? 0;
+			const added = lanes.additions.coverage[row] ?? 0;
+			if (removed === 0 || added === 0) continue;
+
+			// Ties go to removals, which come first within a change.
+			const losing = added > removed ? lanes.deletions : lanes.additions;
+			losing.coverage[row] = 0;
+		}
+	}
+
+	// Leading whitespace is left unpainted, so indentation reads as the gap
+	// before a line's code. Every line grows from its own lane's left edge, the
+	// way the text does in the column it stands for.
+	for (const [side, lane] of Object.entries(lanes) as Array<[Side, Lane]>) {
+		const origin = split && side === "additions" ? laneWidth + LANE_SPLIT : 0;
+		context.fillStyle = fills[side];
+
+		for (let row = 0; row < rows; row++) {
+			if ((lane.coverage[row] ?? 0) === 0) continue;
+
+			// Nothing but blank lines here: the pixel still gets the single-pixel
+			// minimum below, so the change stays countable rather than vanishing.
+			const content = lane.content[row] ?? 0;
+			const width = content === 0 ? 0 : (lane.widths[row] ?? 0) / content;
+			const indent = content === 0 ? 0 : (lane.indents[row] ?? 0) / content;
+
+			const outer = Math.max((laneWidth * width) / 255, thinnest);
+			const inner = Math.min((laneWidth * indent) / 255, outer - thinnest);
+
+			context.fillRect(origin + inner, row / ratio, outer - inner, thinnest);
+		}
+	}
+
+	// Drawn last and opaque, so a rule reads over the marks it crosses rather
+	// than tinting with them.
+	const rules = resolveRules({ geometry, scale, limit: height - thinnest });
+	context.fillStyle = palette.getPropertyValue("--minimap-file-rule");
+	for (const rule of rules) context.fillRect(0, rule.y, width, thinnest);
+
+	const first = geometry.blocks[0];
+	const opening = first && first.height * scale >= ICON_MIN_SECTION ? [{ index: 0, top: 0 }] : [];
+
+	return [
+		...opening,
+		...rules
+			.filter((rule) => rule.height >= ICON_MIN_SECTION)
+			.map(({ index, y }) => ({ index, top: y })),
+	];
+};

--- a/apps/lite/ui/src/routes/project/$id/workspace/diff-minimap.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/diff-minimap.ts
@@ -1,0 +1,270 @@
+import { weakFileIdentityKey, type FileParent } from "#ui/operands.ts";
+import type { GUISettings } from "#electron/settings.ts";
+import type { TreeChange, UnifiedPatch } from "@gitbutler/but-sdk";
+import type { CodeView } from "@pierre/diffs";
+import {
+	type Annotation,
+	codeViewItemMetrics,
+	codeViewLayout,
+	parseChangeDiff,
+} from "./diff-view.ts";
+
+/**
+ * The diff viewer's own row height and separator-bar costs, measured against
+ * its exact `getLinePosition`. Unlike the layout and metrics we hand CodeView,
+ * these are the library's — hence the correction in `getMinimapScale`. The
+ * leading bar sits directly under the file header and so has spacing one side.
+ */
+const ROW_HEIGHT = 20;
+const SEPARATOR_LEADING = 40;
+const SEPARATOR_BETWEEN = 48;
+
+/**
+ * Changed lines the map will model before it gives up and lets the native
+ * scrollbar take over. The work here is linear in those lines, and past this a
+ * ruler costs more to build than it can usefully show. Counted off the patch,
+ * so a runaway change set is turned away without parsing any of it.
+ */
+const MAX_CHANGED_LINES = 250_000;
+
+/**
+ * How many viewports tall the diff has to be before the map earns its space.
+ * Just over one, and the marker covers most of the ruler and says nothing the
+ * scrollbar wouldn't.
+ */
+const MIN_VIEWPORTS = 2;
+
+/** Line width at which a mark fills its lane. */
+const REFERENCE_COLUMNS = 100;
+
+/**
+ * A run of added or removed lines, in pixels from the top of its file.
+ *
+ * Widths are per line rather than averaged, so the ruler can resolve individual
+ * lines wherever it has the pixels for them, and each carries its leading
+ * whitespace separately so indentation can be drawn back from the code.
+ * Both are shares of a full lane, in 255ths.
+ */
+type MinimapMark = {
+	top: number;
+	height: number;
+	side: "additions" | "deletions";
+	widths: Uint8Array;
+	indents: Uint8Array;
+};
+
+export type MinimapFile = {
+	itemId: string;
+	path: string;
+	/** Modelled height of the whole file block, used to correct the marks. */
+	contentHeight: number;
+	marks: Array<MinimapMark>;
+};
+
+/** Scroll-content pixels, the space every position here is measured in. */
+export type MinimapGeometry = {
+	contentHeight: number;
+	blocks: Array<{ top: number; height: number }>;
+};
+
+/** CodeView reports scroll height without the layout's outer padding; tops include it. */
+const contentHeight = (viewer: CodeView<Annotation>): number =>
+	codeViewLayout.paddingTop + viewer.getScrollHeight() + codeViewLayout.paddingBottom;
+
+/**
+ * Rendered width of a line in columns, and the leading whitespace within it.
+ * Only the indent is expanded to tab stops — tabs inside a line are rare enough
+ * not to justify scanning every character of every line in the diff.
+ */
+const lineColumns = (line: string, tabSize: number): { indent: number; columns: number } => {
+	let end = line.length;
+	while (end > 0 && (line[end - 1] === "\n" || line[end - 1] === "\r")) end--;
+
+	let indent = 0;
+	let index = 0;
+	while (index < end && (line[index] === "\t" || line[index] === " ")) {
+		indent += line[index] === "\t" ? tabSize - (indent % tabSize) : 1;
+		index++;
+	}
+
+	return { indent, columns: indent + (end - index) };
+};
+
+const share = (columns: number): number =>
+	Math.round(Math.min(columns / REFERENCE_COLUMNS, 1) * 255);
+
+const runMetrics = (
+	lines: Array<string>,
+	tabSize: number,
+): { widths: Uint8Array; indents: Uint8Array } => {
+	const widths = new Uint8Array(lines.length);
+	const indents = new Uint8Array(lines.length);
+
+	for (const [index, line] of lines.entries()) {
+		const { indent, columns } = lineColumns(line, tabSize);
+
+		widths[index] = share(columns);
+		// Never wider than the line it sits in, which also leaves a line that is
+		// nothing but whitespace with the two equal — how a blank one is spotted.
+		indents[index] = Math.min(share(indent), widths[index]);
+	}
+
+	return { widths, indents };
+};
+
+/**
+ * Where each file's changes sit inside its own block.
+ *
+ * Only hunks are rendered — the lines between them are collapsed behind a
+ * separator bar — so a change's offset is a sum of whole rows and bars rather
+ * than a share of the file's line count.
+ *
+ * Item IDs are derived the same way as in `getDiffView` rather than read back
+ * off it, so the minimap doesn't inherit that view's selection-driven churn.
+ */
+export const getMinimapFiles = ({
+	fileParent,
+	changes,
+	treeChangeDiffs,
+	diffStyle,
+	tabSize,
+}: {
+	fileParent: FileParent;
+	changes: Array<TreeChange>;
+	treeChangeDiffs: Array<UnifiedPatch | null>;
+	diffStyle: GUISettings["diffStyle"];
+	tabSize: number;
+}): Array<MinimapFile> => {
+	const changedLines = treeChangeDiffs.reduce(
+		(total, diff) =>
+			total + (diff?.type === "Patch" ? diff.subject.linesAdded + diff.subject.linesRemoved : 0),
+		0,
+	);
+	if (changedLines > MAX_CHANGED_LINES) return [];
+
+	const split = diffStyle === "split";
+
+	return changes.map((change, changeIndex) => {
+		const { fileDiff } = parseChangeDiff(change, treeChangeDiffs[changeIndex] ?? null);
+		const marks: Array<MinimapMark> = [];
+		let top = codeViewItemMetrics.diffHeaderHeight;
+
+		for (const [hunkIndex, hunk] of fileDiff.hunks.entries()) {
+			if (hunk.collapsedBefore > 0) top += hunkIndex === 0 ? SEPARATOR_LEADING : SEPARATOR_BETWEEN;
+
+			let row = 0;
+			for (const part of hunk.hunkContent) {
+				if (part.type === "context") {
+					row += part.lines;
+					continue;
+				}
+
+				if (part.deletions > 0) {
+					marks.push({
+						top: top + row * ROW_HEIGHT,
+						height: part.deletions * ROW_HEIGHT,
+						side: "deletions",
+						...runMetrics(
+							fileDiff.deletionLines.slice(
+								part.deletionLineIndex,
+								part.deletionLineIndex + part.deletions,
+							),
+							tabSize,
+						),
+					});
+				}
+				if (part.additions > 0) {
+					marks.push({
+						// Split puts both sides on the same rows; unified stacks the
+						// removals above the additions.
+						top: top + (split ? row : row + part.deletions) * ROW_HEIGHT,
+						height: part.additions * ROW_HEIGHT,
+						side: "additions",
+						...runMetrics(
+							fileDiff.additionLines.slice(
+								part.additionLineIndex,
+								part.additionLineIndex + part.additions,
+							),
+							tabSize,
+						),
+					});
+				}
+
+				row += split ? Math.max(part.deletions, part.additions) : part.deletions + part.additions;
+			}
+
+			top += (split ? hunk.splitLineCount : hunk.unifiedLineCount) * ROW_HEIGHT;
+		}
+
+		return {
+			itemId: weakFileIdentityKey({ parent: fileParent, path: change.path }),
+			path: change.path,
+			contentHeight: top + codeViewItemMetrics.paddingBottom,
+			marks,
+		};
+	});
+};
+
+/**
+ * File positions, or null when the diff is too short to be worth mapping.
+ *
+ * Tops are exact rather than sampled: CodeView lays out every item, including
+ * ones virtualization hasn't rendered. Heights are the distance to the next
+ * file less the inter-item gap, since CodeView exposes no per-item height.
+ */
+export const getMinimapGeometry = (
+	viewer: CodeView<Annotation>,
+	itemIds: Array<string>,
+): MinimapGeometry | null => {
+	const total = contentHeight(viewer);
+	if (itemIds.length === 0 || total < viewer.getHeight() * MIN_VIEWPORTS) return null;
+
+	const blocks: Array<{ top: number; height: number }> = [];
+
+	for (const [index, itemId] of itemIds.entries()) {
+		const top = viewer.getTopForItem(itemId);
+		// CodeView can hold a stale item list for a frame after the diff changes.
+		if (top === undefined) return null;
+
+		const nextId = itemIds[index + 1];
+		const nextTop = nextId === undefined ? undefined : viewer.getTopForItem(nextId);
+		if (nextId !== undefined && nextTop === undefined) return null;
+
+		const bottom =
+			nextTop === undefined ? total - codeViewLayout.paddingBottom : nextTop - codeViewLayout.gap;
+
+		blocks.push({ top, height: Math.max(bottom - top, 0) });
+	}
+
+	return { contentHeight: total, blocks };
+};
+
+/**
+ * How far a file's modelled height is from the one CodeView actually laid out.
+ * Scaling its marks by this squashes them along with the file when wrapped
+ * lines — or a library change to a row or bar — make the model too tall.
+ */
+export const getMinimapScale = (file: MinimapFile, block: { height: number }): number =>
+	file.contentHeight <= 0 ? 0 : block.height / file.contentHeight;
+
+/** The visible window, as fractions of the content. */
+export const getMinimapViewport = (
+	viewer: CodeView<Annotation>,
+): { top: number; height: number } => {
+	const total = contentHeight(viewer);
+	if (total <= 0) return { top: 0, height: 1 };
+
+	return { top: viewer.getScrollTop() / total, height: viewer.getHeight() / total };
+};
+
+/** Scroll so the top of the viewport sits at `fraction` of the content. */
+export const scrollMinimapTo = (viewer: CodeView<Annotation>, fraction: number): void => {
+	viewer.scrollTo({
+		type: "position",
+		// CodeView lifts a position target by the sticky header, so the row you
+		// asked for isn't left under it. The minimap is placing the viewport rather
+		// than a row, so add it back or every drag sits a header too high.
+		position: fraction * contentHeight(viewer) + codeViewItemMetrics.diffHeaderHeight,
+		behavior: "instant",
+	});
+};

--- a/apps/lite/ui/src/routes/project/$id/workspace/diff-view.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/diff-view.ts
@@ -15,9 +15,31 @@ import {
 } from "#ui/operands.ts";
 import type { NavigationIndex } from "#ui/workspace/navigation-index.ts";
 import type { TreeChange, UnifiedPatch } from "@gitbutler/but-sdk";
-import { processFile, type CodeViewDiffItem, type CodeViewLineSelection } from "@pierre/diffs";
+import {
+	processFile,
+	type CodeViewDiffItem,
+	type CodeViewLayout,
+	type CodeViewLineSelection,
+	type VirtualFileMetrics,
+} from "@pierre/diffs";
 
 export type Annotation = { _tag: "local"; id: string };
+
+/**
+ * Layout and metrics handed to CodeView. Shared because the minimap models item
+ * positions from the same numbers, and would drift silently if they diverged.
+ */
+export const codeViewLayout: CodeViewLayout = {
+	paddingTop: 0,
+	// Match --panel-padding-block.
+	paddingBottom: 12,
+	gap: 10,
+};
+
+export const codeViewItemMetrics = {
+	diffHeaderHeight: 38,
+	paddingBottom: 9,
+} satisfies Partial<VirtualFileMetrics>;
 
 type DiffViewDeps = {
 	fileParent: FileParent;
@@ -58,6 +80,21 @@ const parseFileDiff = (
 	if (!parsed) throw new Error("Failed to parse patch");
 
 	return parsed;
+};
+
+/**
+ * Parse a change into CodeView's diff shape. Shared with the minimap, which
+ * needs the same hunk layout — going through here keeps both on one parse
+ * cache entry instead of paying for the patch twice.
+ */
+export const parseChangeDiff = (
+	change: TreeChange,
+	patch: UnifiedPatch | null,
+): { version: number; fileDiff: CodeViewDiffItem<Annotation>["fileDiff"] } => {
+	const combined = synthesizeFilePatch(change, patch?.type === "Patch" ? patch.subject.hunks : []);
+	const version = hash(combined);
+
+	return { version, fileDiff: parseFileDiff(combined, String(version)) };
 };
 
 type DiffFileNavigation = {
@@ -125,16 +162,12 @@ export const getDiffView = ({ fileParent, changes, treeChangeDiffs }: DiffViewDe
 			path: change.path,
 		};
 
-		const combinedFilePatch = synthesizeFilePatch(
-			change,
-			mdiff?.type === "Patch" ? mdiff.subject.hunks : [],
-		);
-		const version = hash(combinedFilePatch);
+		const { version, fileDiff } = parseChangeDiff(change, mdiff ?? null);
 		const item: CodeViewDiffItem<Annotation> = {
 			type: "diff",
 			id: weakFileIdentityKey(file),
 			version,
-			fileDiff: parseFileDiff(combinedFilePatch, String(version)),
+			fileDiff,
 		};
 
 		items.push(item);


### PR DESCRIPTION
A ruler down the right side of the diff panel that shows the whole change at
once, so you can see where you are and jump around without scrolling blind.

<img width="711" height="706" alt="image" src="https://github.com/user-attachments/assets/0e4f1d62-785d-4b4f-8093-c4dc03beff6d" />

## What you see

- Every added and removed run, drawn where it actually is in the diff
- Marks as wide as the lines are long, with indentation left blank, so you get
  a rough sense of the shape of the code
- A thin line between files, plus a file type icon where there is room
- Two columns in side-by-side mode, one in unified — same as the diff
- A lens over the part that is currently on screen

## What you can do

- Grab the lens and drag it, the way you would a scrollbar
- Or press anywhere on the track to jump there
- Hover to see which file you are over

## When it shows up

- Only once the diff is at least two screens tall. Below that the lens covers
  most of the ruler and says nothing the scrollbar would not, so the normal
  scrollbar stays instead
- Works the same whether you show all files at once or one at a time
- Very large change sets are turned away rather than mapped, counted off the
  patch so nothing is parsed to find out

## How it works

- Positions come from the diff viewer's own layout, so files it has not
  rendered yet are still placed correctly. The within-file model was checked
  against the viewer's own exact line positions and matched on every file, hunk
  and mark measured
- It is painted on a canvas, so a few hundred files cost nothing in DOM, and
  scrolling only moves the lens
- Once there is less than a pixel per line it averages them, each weighted by
  how much of the pixel it covers, the way an image is scaled down

## Known limits

- With line wrapping on, marks shift a little as you scroll, because the viewer
  only estimates line heights until it renders them. Wrapping off, which is the
  default, is exact
