### PR TITLE
fix(sdk): make build:sdk notice Rust changes

### DIFF
--- a/packages/but-sdk/turbo.json
+++ b/packages/but-sdk/turbo.json
@@ -3,7 +3,19 @@
 	"extends": ["//"],
 	"tasks": {
 		"build": {
+			"inputs": [
+				"$TURBO_DEFAULT$",
+				"!src/generated/**",
+				"$TURBO_ROOT$/crates/**/*.rs",
+				"$TURBO_ROOT$/crates/**/Cargo.toml",
+				"$TURBO_ROOT$/Cargo.toml",
+				"$TURBO_ROOT$/Cargo.lock",
+				"$TURBO_ROOT$/rust-toolchain.toml"
+			],
 			"outputs": ["src/generated/**"]
+		},
+		"package": {
+			"inputs": ["$TURBO_DEFAULT$", "!src/generated/**"]
 		}
 	}
 }


### PR DESCRIPTION
`pnpm build:sdk` could silently skip regenerating the SDK, leaving stale bindings on disk.

`packages/but-sdk/turbo.json` declared `outputs` but no `inputs`, so turbo hashed only files inside `packages/but-sdk`. The SDK is generated from `crates/**` — `cargo run -p but-ts` and `napi build --manifest-path ../../crates/but-napi/Cargo.toml` — so Rust API changes never invalidated the cache. Since `crates/CLAUDE.md` tells contributors to run `pnpm build:sdk` after changing Rust APIs exposed through the SDK, the documented workflow could commit a stale SDK with no visible failure.

**The fix**

- `inputs` now covers the Rust sources and Cargo manifests the build depends on, reaching outside the package with turbo's `$TURBO_ROOT$` microsyntax.
- `!src/generated/**` takes the build's own output back out of its key, which was costing a second full build after every change. It is needed on `package` too: that task has no script here, but `build` depends on it and folds in its hash, which included all 9 generated files.

**Verified** — `--dry=json` shows the `build` key going from 16 files, all inside the package, to 1091 including 1015 `.rs`, with no generated files in either task key. End to end, adding one `#[but_api(napi)]` endpoint moves the hash and forces a real 1m7s rebuild (122 → 123 endpoints), the next run is `FULL TURBO` in ~1s, and reverting the endpoint restores the exact earlier hash.

`packages/but-sdk` is the only package whose scripts call `cargo` or `napi`, so nothing else needs this.
