### PR TITLE
fix(lite): discard every checked file, not just one

### DIFF
--- a/apps/lite/ui/src/api/mutations.ts
+++ b/apps/lite/ui/src/api/mutations.ts
@@ -14,24 +14,28 @@ import {
 } from "#ui/api/queries.ts";
 import { shortCommitId } from "#ui/commit.ts";
 import { errorMessageForToast } from "#ui/errors.ts";
+import { createDiffSpec, resolveDiffSpecs } from "#ui/operations/diff-specs.ts";
 import {
 	discardChangesToastOptions,
 	rejectedChangesToastOptions,
 } from "#ui/operations/toastOptions.tsx";
-import { commitOperand } from "#ui/operands.ts";
+import { commitOperand, filesUnder, type FileParent } from "#ui/operands.ts";
 import { projectSlice } from "#ui/projects/state.ts";
-import { type AppDispatch, useAppDispatch } from "#ui/store.ts";
+import { type AppDispatch, useAppDispatch, useAppStore } from "#ui/store.ts";
 import { formatRelativeTime } from "#ui/time.ts";
 import { Toast } from "@base-ui/react";
+import { Match } from "effect";
 import type {
 	CommitAbsorption,
+	DiffSpec,
 	ForgeReview,
 	ForgeReviewComment,
 	ForgeReviewReaction,
 	ForgeReviewUser,
 	Snapshot,
+	TreeChange,
 } from "@gitbutler/but-sdk";
-import { type QueryClient, useMutation } from "@tanstack/react-query";
+import { type QueryClient, useMutation, useQueryClient } from "@tanstack/react-query";
 import type { GUISettings } from "#electron/settings.ts";
 import { moveDraftPR } from "#ui/pr.ts";
 
@@ -1013,6 +1017,87 @@ export const useDiscardWorktreeChanges = () => {
 			});
 		},
 	});
+};
+
+/** Discards a file's changes, whichever of the two discards its parent calls for. */
+export const useDiscardFileChanges = ({
+	projectId,
+	fileParent,
+}: {
+	projectId: string;
+	fileParent: FileParent;
+}) => {
+	const store = useAppStore();
+	const queryClient = useQueryClient();
+	const toastManager = Toast.useToastManager();
+	const { isPending: isCommitDiscardChangesPending, mutate: commitDiscardChanges } =
+		useCommitDiscardChanges();
+	const { isPending: isDiscardWorktreeChangesPending, mutate: discardWorktreeChanges } =
+		useDiscardWorktreeChanges();
+
+	const canDiscard = Match.value(fileParent).pipe(
+		Match.tagsExhaustive({
+			Commit: () => !isCommitDiscardChangesPending,
+			UncommittedChanges: () => !isDiscardWorktreeChangesPending,
+			// We currently don't support any operations on branch files.
+			Branch: () => false,
+		}),
+	);
+
+	const runDiscard = (changes: Array<DiffSpec>): void =>
+		Match.value(fileParent).pipe(
+			Match.tagsExhaustive({
+				Commit: ({ commitId }) => {
+					commitDiscardChanges({ projectId, commitId, changes, dryRun: false });
+				},
+				UncommittedChanges: () => {
+					discardWorktreeChanges({ projectId, worktreeChanges: changes });
+				},
+				Branch: () => {},
+			}),
+		);
+
+	/**
+	 * Discard `change`, extended to the checked files when `extendToCheckedFiles` — a row's menu
+	 * passes its own checked state, as dragging does; a list hotkey passes true, as cut and move do.
+	 */
+	const discard = async ({
+		change,
+		extendToCheckedFiles,
+	}: {
+		change: TreeChange;
+		extendToCheckedFiles: boolean;
+	}): Promise<void> => {
+		// A checked set belonging to another list says nothing about this file, so the subject then
+		// stands alone, as it does when nothing is checked at all.
+		const checkedFiles = extendToCheckedFiles
+			? filesUnder(
+					projectSlice.selectors.selectCheckedOperands(store.getState(), projectId),
+					fileParent,
+				)
+			: [];
+		if (checkedFiles.length === 0) return runDiscard([createDiffSpec(change, [])]);
+
+		// Checked files carry only paths, so their changes have to be looked up.
+		try {
+			const changes = await resolveDiffSpecs({ projectId, queryClient, sources: checkedFiles });
+			// One of them gone stale fails resolution for the whole set — the reconciler is about to
+			// uncheck it — and discarding the subject instead is not what was asked for.
+			if (changes) runDiscard(changes);
+		} catch (error) {
+			// oxlint-disable-next-line no-console
+			console.error(error);
+
+			toastManager.add({
+				type: "error",
+				title: "Failed to discard changes",
+				description: errorMessageForToast(error),
+				priority: "high",
+			});
+		}
+	};
+
+	return { canDiscard, discard };
 };
 
 export const useCommitInsertBlank = () => {

--- a/apps/lite/ui/src/operands.test.ts
+++ b/apps/lite/ui/src/operands.test.ts
@@ -1,0 +1,62 @@
+import {
+	commitFileParent,
+	commitOperand,
+	fileOperand,
+	filesUnder,
+	uncommittedChangesFileParent,
+} from "./operands.ts";
+import { describe, expect, it } from "vitest";
+
+describe("filesUnder", () => {
+	const commit = commitFileParent({ commitId: "a1", changeId: "change-a1" });
+	const otherCommit = commitFileParent({ commitId: "b2", changeId: "change-b2" });
+
+	it("keeps files sharing the given parent", () => {
+		const files = [
+			fileOperand({ parent: commit, path: "one.ts" }),
+			fileOperand({ parent: commit, path: "two.ts" }),
+		];
+
+		expect(filesUnder(files, commit)).toEqual(files);
+	});
+
+	it("drops a set holding a file of another commit", () => {
+		expect(
+			filesUnder(
+				[
+					fileOperand({ parent: commit, path: "one.ts" }),
+					fileOperand({ parent: otherCommit, path: "two.ts" }),
+				],
+				commit,
+			),
+		).toEqual([]);
+	});
+
+	it("drops a set holding an uncommitted file", () => {
+		expect(
+			filesUnder(
+				[
+					fileOperand({ parent: commit, path: "one.ts" }),
+					fileOperand({ parent: uncommittedChangesFileParent, path: "two.ts" }),
+				],
+				commit,
+			),
+		).toEqual([]);
+	});
+
+	it("drops a set holding a commit", () => {
+		expect(
+			filesUnder(
+				[
+					fileOperand({ parent: uncommittedChangesFileParent, path: "one.ts" }),
+					commitOperand({ commitId: "a1", changeId: "change-a1" }),
+				],
+				uncommittedChangesFileParent,
+			),
+		).toEqual([]);
+	});
+
+	it("has nothing to keep when nothing is checked", () => {
+		expect(filesUnder([], uncommittedChangesFileParent)).toEqual([]);
+	});
+});

--- a/apps/lite/ui/src/operands.ts
+++ b/apps/lite/ui/src/operands.ts
@@ -154,6 +154,16 @@ export const operandFileParent = (operand: Operand): FileParent | null =>
 		Match.orElse(() => null),
 	);
 
+/**
+ * The operands if they are all files under `fileParent`, none otherwise. Checking is confined to
+ * one parent at a time, so a set that isn't wholly ours belongs to another list, and its paths
+ * would resolve against the wrong parent.
+ */
+export const filesUnder = (operands: Array<Operand>, fileParent: FileParent): Array<Operand> =>
+	operands.every((operand) => operand._tag === "File" && operandEquals(operand.parent, fileParent))
+		? operands
+		: [];
+
 export const operandContains = (a: Operand, b: Operand) => {
 	const bFileParent = operandFileParent(b);
 	return bFileParent && operandEquals(a, bFileParent);

--- a/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.tsx
@@ -30,9 +30,8 @@ import { FileRow } from "./FileRow.tsx";
 import type { FileRowItem } from "./file-row.ts";
 import { checkedRange, navigationIndexRange } from "#ui/checking.ts";
 import {
-	useCommitDiscardChanges,
 	useCommitUncommitChanges,
-	useDiscardWorktreeChanges,
+	useDiscardFileChanges,
 	useOpenInProgram,
 } from "#ui/api/mutations.ts";
 import { createDiffSpec } from "#ui/operations/diff-specs.ts";
@@ -66,12 +65,9 @@ const useFilesTreeHotkeys = ({
 		select: (cfg) => editors?.find((editor) => editor.id === cfg.editorId),
 	});
 	const { mutate: openInProgram } = useOpenInProgram();
-	const { isPending: isCommitDiscardChangesPending, mutate: commitDiscardChanges } =
-		useCommitDiscardChanges();
 	const { isPending: isCommitUncommitChangesPending, mutate: commitUncommitChanges } =
 		useCommitUncommitChanges();
-	const { isPending: isDiscardWorktreeChangesPending, mutate: discardWorktreeChanges } =
-		useDiscardWorktreeChanges();
+	const { canDiscard, discard } = useDiscardFileChanges({ projectId, fileParent });
 
 	const store = useAppStore();
 	const dispatch = useAppDispatch();
@@ -115,17 +111,8 @@ const useFilesTreeHotkeys = ({
 	const discardSelectedFile = () => {
 		if (selectedChange === null) return;
 
-		const changes = [createDiffSpec(selectedChange, [])];
-		if (fileParent._tag === "Commit") {
-			commitDiscardChanges({
-				projectId,
-				commitId: fileParent.commitId,
-				changes,
-				dryRun: false,
-			});
-		} else if (fileParent._tag === "UncommittedChanges") {
-			discardWorktreeChanges({ projectId, worktreeChanges: changes });
-		}
+		// As with the other list-wide hotkeys, checked files are the subject when there are any.
+		void discard({ change: selectedChange, extendToCheckedFiles: true });
 	};
 
 	const uncommitSelectedFile = () => {
@@ -140,10 +127,7 @@ const useFilesTreeHotkeys = ({
 		});
 	};
 
-	const canDiscardSelectedFile =
-		selectedChange !== null &&
-		((fileParent._tag === "Commit" && !isCommitDiscardChangesPending) ||
-			(fileParent._tag === "UncommittedChanges" && !isDiscardWorktreeChangesPending));
+	const canDiscardSelectedFile = selectedChange !== null && canDiscard;
 
 	const canCheckTheseFiles = useAppSelector((state) =>
 		projectSlice.selectors.selectCanCheckFiles(state, projectId, fileParent),

--- a/apps/lite/ui/src/routes/project/$id/workspace/useFileMenuItems.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/useFileMenuItems.ts
@@ -1,7 +1,6 @@
 import {
-	useCommitDiscardChanges,
 	useCommitUncommitChanges,
-	useDiscardWorktreeChanges,
+	useDiscardFileChanges,
 	useOpenInProgram,
 } from "#ui/api/mutations.ts";
 import {
@@ -18,7 +17,7 @@ import { type NativeMenuItem, nativeMenuItem, nativeMenuItemsFromGroups } from "
 import { fileOperand, type FileOperand } from "#ui/operands.ts";
 import { createDiffSpec } from "#ui/operations/diff-specs.ts";
 import { projectSlice } from "#ui/projects/state.ts";
-import { useAppDispatch } from "#ui/store.ts";
+import { useAppDispatch, useAppSelector } from "#ui/store.ts";
 import { focusSelectionScope } from "#ui/selection-scopes.ts";
 import type { TreeChange } from "@gitbutler/but-sdk";
 import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
@@ -48,10 +47,22 @@ export const useFileMenuItems = ({
 
 	const { isPending: isCommitUncommitChangesPending, mutate: commitUncommitChanges } =
 		useCommitUncommitChanges();
-	const { isPending: isCommitDiscardChangesPending, mutate: commitDiscardChanges } =
-		useCommitDiscardChanges();
-	const { isPending: isDiscardWorktreeChangesPending, mutate: discardWorktreeChanges } =
-		useDiscardWorktreeChanges();
+	const { canDiscard, discard } = useDiscardFileChanges({
+		projectId,
+		fileParent: operand.parent,
+	});
+	// A file's actions apply to the checked set when the file is part of it, as dragging it does.
+	const isChecked = useAppSelector((state) =>
+		projectSlice.selectors.selectOperandChecked(state, projectId, fileOperand(operand)),
+	);
+	// Gated on the set being wholly ours, as the discard is, so the label can't overstate it.
+	const discardFileCount = useAppSelector((state) =>
+		isChecked && projectSlice.selectors.selectCanCheckFiles(state, projectId, operand.parent)
+			? projectSlice.selectors.selectCheckedOperandCount(state, projectId)
+			: 1,
+	);
+	const discardLabel =
+		discardFileCount > 1 ? `Discard Changes in ${discardFileCount} Files` : "Discard Changes";
 	const { isPending: isOpenInProgramPending, mutate: openInProgram } = useOpenInProgram();
 	const cutFile = () => {
 		dispatch(
@@ -135,13 +146,6 @@ export const useFileMenuItems = ({
 								changes: [createDiffSpec(change, [])],
 								dryRun: false,
 							});
-						const discard = () =>
-							commitDiscardChanges({
-								projectId,
-								commitId: operand.parent.commitId,
-								changes: [createDiffSpec(change, [])],
-								dryRun: false,
-							});
 
 						return [
 							[
@@ -152,10 +156,10 @@ export const useFileMenuItems = ({
 									onSelect: uncommit,
 								}),
 								nativeMenuItem({
-									label: "Discard Changes",
-									enabled: !isCommitDiscardChangesPending,
+									label: discardLabel,
+									enabled: canDiscard,
 									accelerator: toElectronAccelerator(changesFileHotkeys.discard.hotkey),
-									onSelect: discard,
+									onSelect: () => discard({ change, extendToCheckedFiles: isChecked }),
 								}),
 							],
 						];
@@ -177,11 +181,6 @@ export const useFileMenuItems = ({
 							);
 							focusSelectionScope("outline");
 						};
-						const discard = () =>
-							discardWorktreeChanges({
-								projectId,
-								worktreeChanges: [createDiffSpec(change, [])],
-							});
 
 						return [
 							[
@@ -191,10 +190,10 @@ export const useFileMenuItems = ({
 									onSelect: absorb,
 								}),
 								nativeMenuItem({
-									label: "Discard Changes",
-									enabled: !isDiscardWorktreeChangesPending,
+									label: discardLabel,
+									enabled: canDiscard,
 									accelerator: toElectronAccelerator(changesFileHotkeys.discard.hotkey),
-									onSelect: discard,
+									onSelect: () => discard({ change, extendToCheckedFiles: isChecked }),
 								}),
 							],
 						];


### PR DESCRIPTION
With several files checked, discard only ever removed one of them. Both entry
points — a file row's context menu and the `Mod+Backspace` hotkey — built a
single `DiffSpec` from the subject file and never looked at the checked set,
even though `discardWorktreeChanges` and `commitDiscardChanges` both take a
list (the header's "Discard All Changes" already passes every change).

A shared `useDiscardFileChanges` now backs both paths. It resolves the checked
files' changes through the existing `resolveDiffSpecs` and issues one discard
for them all. Who counts as the subject follows the conventions already in the
app:

- **Context menu** extends to the checked set only when the clicked row is
  itself checked — the rule `OperationSourceC` uses for dragging. Right-clicking
  an unchecked file never touches the others.
- **Hotkey** follows the checked set whenever there is one — the rule
  `operationSourcesForItem` uses for cut and move, and what the "3 files
  selected" banner implies. Checkbox clicks don't move the selection, so keying
  off the focused row alone would still have looked broken.

A checked set belonging to another list (a different commit's files) is
rejected wholesale by `filesUnder` rather than resolved against the wrong
parent, and the menu names the count when it will take more than one file.

## Verification

- New unit tests for the parent guard; `pnpm -F @gitbutler/lite check` clean.
- Resolution checked against a running dev app: three checked file operands
  resolve to three diff specs with matching paths, and a stale path fails the
  set, which the hook treats as "do nothing" rather than discarding just the
  subject.