### PR TITLE
fix: use squash matches during upstream integration

### DIFF
--- a/crates/but-core/src/changeset.rs
+++ b/crates/but-core/src/changeset.rs
@@ -92,8 +92,28 @@ impl<T: ChangesetCommit + ?Sized> ChangesetCommit for &T {
 
 /// Similarity matches between workspace commits and upstream commits, computed from commit IDs.
 pub struct SimilarityByCommitIds {
-    /// Upstream commit IDs keyed by the workspace commit ID that matched them.
+    /// Upstream commit IDs keyed by workspace commits proven integrated individually or by range.
     pub matches_by_workspace_commit: HashMap<gix::ObjectId, gix::ObjectId>,
+    upstream_lut: Identity,
+    time_used: Duration,
+}
+
+impl SimilarityByCommitIds {
+    /// Return the upstream commit whose changeset matches `base` to `tip`.
+    ///
+    /// Range matching is content-only: unlike individual commit matching, commit metadata and
+    /// change IDs cannot prove that a cumulative range was integrated.
+    pub fn matching_changeset(
+        &mut self,
+        repo: &gix::Repository,
+        base: gix::ObjectId,
+        tip: gix::ObjectId,
+    ) -> anyhow::Result<Option<gix::ObjectId>> {
+        Ok(
+            range_changeset_identifier(repo, Some(base), tip, &mut self.time_used)?
+                .and_then(|identifier| self.upstream_lut.get(&identifier).copied()),
+        )
+    }
 }
 
 /// Compute upstream similarity for the provided workspace commits.
@@ -137,6 +157,8 @@ pub fn compute_similarity_by_commit_ids(
 
     Ok(SimilarityByCommitIds {
         matches_by_workspace_commit,
+        upstream_lut,
+        time_used,
     })
 }
 
@@ -151,12 +173,23 @@ pub fn changeset_identifier<C: ChangesetCommit>(
     let Some(commit) = commit else {
         return Ok(None);
     };
+    range_changeset_identifier(repo, commit.first_parent_id(), commit.id(), elapsed)
+}
+
+/// Return the changeset identity for `base..tip` while sharing the expensive-computation budget
+/// in `elapsed` with other similarity checks.
+pub fn range_changeset_identifier(
+    repo: &gix::Repository,
+    base: Option<gix::ObjectId>,
+    tip: gix::ObjectId,
+    elapsed: &mut Duration,
+) -> anyhow::Result<Option<Identifier>> {
     if *elapsed > MAX_COMPUTE_WALLCLOCK_DURATION {
         return Ok(None);
     }
 
     let start = std::time::Instant::now();
-    let res = id_for_tree_diff(repo, commit.first_parent_id(), commit.id())?;
+    let res = id_for_tree_diff(repo, base, tip)?;
     *elapsed += start.elapsed();
 
     if *elapsed > MAX_COMPUTE_WALLCLOCK_DURATION {

--- a/crates/but-rebase/src/graph_rebase/workspace.rs
+++ b/crates/but-rebase/src/graph_rebase/workspace.rs
@@ -380,14 +380,6 @@ impl<M: RefMetadata> Editor<'_, '_, M> {
             upstream = from_target_ref.iter().copied().collect();
         }
         let upstream_ids = self.pick_ids(upstream.into_iter())?;
-        let workspace_ids = self.pick_ids(nodes.iter().copied())?;
-        let content = but_core::changeset::compute_similarity_by_commit_ids(
-            self.repo(),
-            &upstream_ids,
-            &workspace_ids,
-            true,
-        )?;
-
         let reference_names: HashMap<Selector, gix::refs::FullName> = nodes
             .iter()
             .filter_map(|node| match self.lookup_step(*node) {
@@ -397,14 +389,14 @@ impl<M: RefMetadata> Editor<'_, '_, M> {
             })
             .collect::<Result<_>>()?;
 
+        let content = self.workspace_content_matches(&upstream_ids, nodes, &from_target_ref)?;
+
         let is_commit_integrated = |selector: Selector| -> Result<bool> {
             if from_target_ref.contains(&selector) {
                 return Ok(true);
             }
             Ok(match self.lookup_step(selector)? {
-                Step::Pick(Pick { id, .. }) => {
-                    content.matches_by_workspace_commit.contains_key(&id)
-                }
+                Step::Pick(Pick { id, .. }) => content.contains_key(&id),
                 _ => false,
             })
         };
@@ -501,6 +493,107 @@ impl<M: RefMetadata> Editor<'_, '_, M> {
             commit_state,
             integrated_references,
         })
+    }
+
+    /// Match workspace commits to upstream by individual identity or cumulative stack content.
+    ///
+    /// Aggregate matches use the named, unique stack segments in the workspace projection backing
+    /// this editor. Call this before editing the graph, while that projection still describes it.
+    pub fn workspace_content_matches(
+        &self,
+        upstream_ids: &[gix::ObjectId],
+        nodes: &HashSet<Selector>,
+        excluded: &HashSet<Selector>,
+    ) -> Result<HashMap<gix::ObjectId, gix::ObjectId>> {
+        let workspace_ids = self.pick_ids(nodes.iter().copied())?;
+        let mut content = but_core::changeset::compute_similarity_by_commit_ids(
+            self.repo(),
+            upstream_ids,
+            &workspace_ids,
+            true,
+        )?;
+        let eligible = |segment: &but_graph::workspace::StackSegment| {
+            segment.commits_outside.is_none()
+                && segment.ref_name().and_then(|name| name.category())
+                    == Some(gix::refs::Category::LocalBranch)
+                && segment.commits.iter().all(|commit| {
+                    commit.parent_ids.len() == 1
+                        && self.try_select_commit(commit.id).is_some_and(|selector| {
+                            nodes.contains(&selector)
+                                && !excluded.contains(&selector)
+                                && matches!(
+                                    self.lookup_step(selector),
+                                    Ok(Step::Pick(Pick {
+                                        mutable: true,
+                                        preserved_parents: None,
+                                        ..
+                                    }))
+                                )
+                        })
+                })
+        };
+
+        for stack in &self.workspace.stacks {
+            let Some(stack_base) = stack.base() else {
+                continue;
+            };
+            let mut lower_segments_eligible = true;
+            for segment_idx in (0..stack.segments.len()).rev() {
+                let segment = &stack.segments[segment_idx];
+                let segment_eligible = eligible(segment);
+                let stack_range_eligible = segment_eligible && lower_segments_eligible;
+                lower_segments_eligible = stack_range_eligible;
+                let Some(segment_base) = segment.base else {
+                    continue;
+                };
+                if !segment_eligible
+                    || segment.commits.last().is_some_and(|commit| {
+                        content.matches_by_workspace_commit.contains_key(&commit.id)
+                    })
+                {
+                    continue;
+                }
+                let base_tree = if stack_base == segment_base {
+                    None
+                } else {
+                    Some(but_core::changeset::id_to_tree(self.repo(), segment_base)?.id)
+                };
+                for boundary in (0..segment.commits.len()).rev() {
+                    let commit_id = segment.commits[boundary].id;
+                    let local_match =
+                        content.matching_changeset(self.repo(), segment_base, commit_id)?;
+                    let stack_match = if local_match.is_none()
+                        && stack_range_eligible
+                        && let Some(base_tree) = base_tree
+                        && but_core::changeset::id_to_tree(self.repo(), commit_id)?.id != base_tree
+                    {
+                        content.matching_changeset(self.repo(), stack_base, commit_id)?
+                    } else {
+                        None
+                    };
+                    let Some(upstream_id) = local_match.or(stack_match) else {
+                        continue;
+                    };
+                    for commit in &segment.commits[boundary..] {
+                        content
+                            .matches_by_workspace_commit
+                            .insert(commit.id, upstream_id);
+                    }
+                    if stack_match.is_some() {
+                        for commit in stack.segments[segment_idx + 1..]
+                            .iter()
+                            .flat_map(|segment| &segment.commits)
+                        {
+                            content
+                                .matches_by_workspace_commit
+                                .insert(commit.id, upstream_id);
+                        }
+                    }
+                    break;
+                }
+            }
+        }
+        Ok(content.matches_by_workspace_commit)
     }
 
     /// The commit ids of the `Pick` steps among `selectors` (non-picks dropped).

--- a/crates/but-workspace/src/changeset.rs
+++ b/crates/but-workspace/src/changeset.rs
@@ -8,20 +8,16 @@ use std::borrow::Cow;
 
 use bstr::BStr;
 use but_core::changeset::{
-    ChangeIdMode, ChangesetCommit, Identifier, changeset_identifier, create_similarity_lut,
-    id_for_tree_diff, id_to_tree, lookup_similar,
+    ChangeIdMode, ChangesetCommit, changeset_identifier, create_similarity_lut, lookup_similar,
+    range_changeset_identifier,
 };
 use gix::prelude::ObjectIdExt;
 
 use crate::{
     RefInfo,
-    ref_info::{Commit, LocalCommit, LocalCommitRelation},
+    ref_info::{Commit, LocalCommitRelation},
     ui::PushStatus,
 };
-
-// The by-ids similarity entry point now lives in `but-core`; re-exported so existing
-// `crate::changeset::compute_similarity_by_commit_ids` callers stay unchanged.
-pub(crate) use but_core::changeset::compute_similarity_by_commit_ids;
 
 /// Lets the `but-core` changeset engine read `ref_info::Commit` directly, without
 /// copying it into an intermediate struct. The message is already conflict-stripped
@@ -51,8 +47,7 @@ impl RefInfo {
     /// * …and author and message (exact match) in stack commits…
     /// * …and (expensive) changeset-ids of
     ///     - stack commits
-    ///     - the squash-merge between all stack-tips (ST) and the target branch to simulate squash merges
-    ///       as they could have happened.
+    ///     - content-equivalent stack prefixes, to simulate squash merges.
     ///
     /// Matches from the first two cheap stages will speed up the expensive stage, as fewer commits or combinations
     /// are left to test.
@@ -166,49 +161,81 @@ impl RefInfo {
                 continue 'next_stack;
             }
 
-            // Another round from top to bottom where we take remote and local tips of non-integrated commits
-            // and test-squash-merge them (cleanly), to see if that changeset ID is contained in upstream.
-            // If so, the whole branch everything that follows is bluntly considered integrated, as it probably is
-            // most of the time.
-            let base_commit_id = stack.segments.last().and_then(|s| s.base);
-            let mut segments = stack.segments.iter_mut();
-            while let Some(segment) = segments.next() {
-                // Find the topmost commit that isn't already integrated and carries changes of its
-                // own; that is the integration boundary for the squash-merge trial. Commits above it
-                // are either already integrated or introduce no changes of their own, so the trial
-                // must not mark them: otherwise a no-change commit at the tip would be treated as
-                // merged - because it borrows the cumulative content of the commits below it - and
-                // its branch deleted.
-                let Some((boundary, boundary_tree_id)) =
-                    segment.commits.iter().enumerate().find_map(|(i, c)| {
-                        let carries_changes =
-                            !matches!(c.relation, LocalCommitRelation::Integrated(_))
-                                && commit_introduces_changes(repo, c);
-                        carries_changes.then_some((i, c.tree_id))
+            // Test prefixes from the base upwards, both within each named segment and across the
+            // linear stack. The segment-local identity must be non-empty even for a stack-wide
+            // match, so a live upper segment whose changes cancel out cannot borrow landed content
+            // from below.
+            let eligible = |segment: &crate::ref_info::Segment| {
+                segment.commits_outside.is_none()
+                    && segment
+                        .ref_info
+                        .as_ref()
+                        .and_then(|info| info.ref_name.category())
+                        == Some(gix::refs::Category::LocalBranch)
+                    && segment
+                        .commits
+                        .iter()
+                        .all(|commit| commit.parent_ids.len() == 1)
+            };
+            let stack_base = stack.segments.last().and_then(|segment| segment.base);
+            for segment_idx in (0..stack.segments.len()).rev() {
+                let (_, current_and_lower) = stack.segments.split_at_mut(segment_idx);
+                let Some((segment, lower_segments)) = current_and_lower.split_first_mut() else {
+                    continue;
+                };
+                let Some(base_commit_id) = segment.base else {
+                    continue;
+                };
+                if !eligible(segment)
+                    || segment.commits.last().is_some_and(|commit| {
+                        matches!(commit.relation, LocalCommitRelation::Integrated(_))
                     })
-                else {
+                {
                     continue;
-                };
-                let Some(changeset_id) = id_for_tree_diff(repo, base_commit_id, boundary_tree_id)?
-                else {
-                    continue;
-                };
-
-                let identity_of_tip_to_base = Identifier::ChangesetId(changeset_id);
-                let Some(squashed_commit_id) = upstream_lut.get(&identity_of_tip_to_base).cloned()
-                else {
-                    continue;
-                };
-
-                // Mark the boundary commit and everything below it (down to the base, across the
-                // lower segments) as integrated; leave the commits above the boundary untouched.
-                for (i, segment) in Some(segment).into_iter().chain(segments).enumerate() {
-                    let skip = if i == 0 { boundary } else { 0 };
-                    for commit in segment.commits.iter_mut().skip(skip) {
-                        commit.relation = LocalCommitRelation::Integrated(squashed_commit_id)
+                }
+                let stack_range_eligible = lower_segments.iter().all(&eligible);
+                let mut matched = None;
+                for (boundary, commit) in segment.commits.iter().enumerate().rev() {
+                    let Some(segment_id) = range_changeset_identifier(
+                        repo,
+                        Some(base_commit_id),
+                        commit.id,
+                        &mut time_used,
+                    )?
+                    else {
+                        continue;
+                    };
+                    let local_match = upstream_lut.get(&segment_id).copied();
+                    let stack_match = if local_match.is_none()
+                        && stack_base.is_some_and(|stack_base| stack_base != base_commit_id)
+                        && stack_range_eligible
+                    {
+                        range_changeset_identifier(repo, stack_base, commit.id, &mut time_used)?
+                            .and_then(|id| upstream_lut.get(&id).copied())
+                    } else {
+                        None
+                    };
+                    if let Some(squashed_commit_id) = local_match.or(stack_match) {
+                        matched = Some((boundary, squashed_commit_id, stack_match.is_some()));
+                        break;
                     }
                 }
-                break;
+
+                let Some((boundary, squashed_commit_id, crosses_segments)) = matched else {
+                    continue;
+                };
+
+                let (_, suffix) = segment.commits.split_at_mut(boundary);
+                for commit in suffix {
+                    commit.relation = LocalCommitRelation::Integrated(squashed_commit_id)
+                }
+                if crosses_segments {
+                    for segment in lower_segments {
+                        for commit in &mut segment.commits {
+                            commit.relation = LocalCommitRelation::Integrated(squashed_commit_id)
+                        }
+                    }
+                }
             }
         }
         self.compute_pushstatus(graph);
@@ -363,17 +390,4 @@ fn is_similarity_candidate(commit: &crate::ref_info::LocalCommit) -> bool {
         // if any of these is also integrated.
         LocalCommitRelation::LocalAndRemote(_)
     )
-}
-
-/// Whether `commit` introduces changes of its own, i.e. its tree differs from its first
-/// parent's tree. This only compares tree ids and skips the full diff that [`id_for_tree_diff`]
-/// computes, which matters when scanning many commits. On a lookup failure we assume the commit
-/// carries changes, so a genuinely merged branch is never spared from squash-merge detection.
-fn commit_introduces_changes(repo: &gix::Repository, commit: &LocalCommit) -> bool {
-    match commit.parent_ids.first() {
-        None => !commit.tree_id.is_empty_tree(),
-        Some(parent) => id_to_tree(repo, *parent)
-            .map(|parent_tree| parent_tree.id != commit.tree_id)
-            .unwrap_or(true),
-    }
 }

--- a/crates/but-workspace/src/upstream_integration.rs
+++ b/crates/but-workspace/src/upstream_integration.rs
@@ -15,7 +15,6 @@ use but_rebase::{
     },
 };
 
-use crate::changeset::compute_similarity_by_commit_ids;
 use crate::graph_manipulation::traverse_nodes;
 use crate::resolve_tracking_branch_ref_name;
 
@@ -616,15 +615,31 @@ fn collect_stacks<'ws, 'meta, M: RefMetadata>(
     for stack in &output_stacks {
         workspace_selectors.extend(stack.nodes.keys());
     }
-    let integration = compute_similarity_by_commit_ids(
-        editor.repo(),
+    let integration = editor.workspace_content_matches(
         &upstream_commits,
-        &commit_ids(editor, workspace_selectors)?,
-        true,
+        &workspace_selectors,
+        &from_target_ref,
     )?;
 
     for stack in &mut output_stacks {
-        let Stack { nodes, bottoms, .. } = stack;
+        let Stack {
+            nodes,
+            heads,
+            bottoms,
+            ..
+        } = stack;
+
+        for head in heads.iter().copied() {
+            for reference in editor.step_references(head)? {
+                if matches!(
+                    editor.lookup_step(reference)?,
+                    Step::Reference { refname, .. }
+                        if refname.category() == Some(gix::refs::Category::LocalBranch)
+                ) {
+                    nodes.entry(reference).or_insert_with(AnnotatedNode::new);
+                }
+            }
+        }
 
         for node in nodes.keys() {
             if editor
@@ -650,7 +665,7 @@ fn collect_stacks<'ws, 'meta, M: RefMetadata>(
             }
 
             if let Step::Pick(Pick { id, .. }) = step
-                && integration.matches_by_workspace_commit.contains_key(&id)
+                && integration.contains_key(&id)
             {
                 attrs.content_integrated = true;
             }

--- a/crates/but-workspace/tests/fixtures/scenario/squash-integrated-shared-bottom-with-live-heads.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/squash-integrated-shared-bottom-with-live-heads.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# Two live heads share a two-commit bottom branch that was squash-merged upstream.
+# The left head edits a bottom file; the right adds and reverts a file, leaving its
+# final tree equal to bottom. Both heads must remain local and conflict-free.
+git init
+commit M1
+git branch -M main
+setup_target_to_match_main
+
+git checkout -b bottom
+commit-file bottom-1.txt bottom-1
+commit-file bottom-2.txt bottom-2
+
+git checkout -b left
+commit-file bottom-2.txt left
+
+git checkout bottom
+git checkout -b right
+commit-file temporary.txt temporary
+git rm temporary.txt
+git commit -m "revert temporary"
+
+create_workspace_commit_once left right
+
+git checkout -b upstream-main main
+echo bottom-1 >bottom-1.txt
+echo bottom-2 >bottom-2.txt
+git add bottom-1.txt bottom-2.txt
+git commit -m "squash bottom"
+git update-ref refs/remotes/origin/main upstream-main
+
+git checkout gitbutler/workspace
+git branch -D upstream-main

--- a/crates/but-workspace/tests/workspace/graph.rs
+++ b/crates/but-workspace/tests/workspace/graph.rs
@@ -932,6 +932,40 @@ f5b02d3 A        state=integrated
     Ok(())
 }
 
+/// Aggregate CONTENT integration: neither local commit matches the upstream squash by itself,
+/// but their branch-owned prefix does. The detailed projection must agree with upstream
+/// integration and mark both commits and branch `A` integrated while leaving sibling `B` local.
+#[test]
+fn integration_status_marks_squash_integrated_branch() -> Result<()> {
+    let (_tmp, detailed) = detailed_writable(
+        "review-hint-squash-integrated-two-commit-stack-with-sibling",
+        "origin",
+        "main",
+        "main",
+        |meta| {
+            add_stack(meta, 1, "A", StackState::InWorkspace);
+            add_stack(meta, 2, "B", StackState::InWorkspace);
+        },
+    )?;
+    // The projection should classify the same branch-owned aggregate that upstream integration
+    // removes when updating this fixture.
+    snapbox::assert_data_eq!(
+        render_statuses(&detailed),
+        snapbox::str![[r#"
+# Stack 0
+refs/heads/A   push=Integrated                     combined=Integrated                     remote=-
+refs/heads/B   push=CompletelyUnpushed             combined=UnpushedCommitsRequiringForce  remote=-
+refs/heads/main push=UnpushedCommitsRequiringForce  combined=UnpushedCommitsRequiringForce  remote=refs/remotes/origin/main
+
+# Stack 0
+[..] add A2   state=integrated
+[..] add A1   state=integrated
+[..] add B1   state=local
+"#]]
+    );
+    Ok(())
+}
+
 /// Commit state via HISTORICAL integration: `A` and `B` are reachable from the
 /// target ref through the merge commit on `origin/master`.
 #[test]

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/exhaustive_with_squash_merges.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/exhaustive_with_squash_merges.rs
@@ -1,6 +1,8 @@
 //! A collection of tests that build on top of each other, like a progression of steps a user could take.
 use but_meta::VirtualBranchesTomlMetadata;
+use but_rebase::graph_rebase::mutate::RelativeTo;
 use but_testsupport::visualize_commit_graph_all;
+use but_workspace::{BottomUpdate, BottomUpdateKind, integrate_upstream};
 use snapbox::prelude::*;
 
 use crate::ref_info::{
@@ -1410,6 +1412,49 @@ Ok(
 
 "#]]
         .raw()
+    );
+
+    let project_meta = crate::ref_info::with_workspace_commit::utils::project_meta(&repo)?;
+    let graph = but_graph::Graph::from_head(
+        &repo,
+        &*meta,
+        project_meta.clone(),
+        but_graph::init::Options {
+            extra_target_commit_id: project_meta.target_commit_id,
+            ..but_graph::init::Options::limited()
+        },
+    )?;
+    let mut workspace = graph.into_workspace()?;
+    let outcome = integrate_upstream(
+        &mut workspace,
+        &mut *meta,
+        project_meta,
+        &repo,
+        vec![BottomUpdate {
+            kind: BottomUpdateKind::Rebase,
+            selector: RelativeTo::Commit(repo.rev_parse_single("local-bottom")?.detach()),
+        }],
+    )?;
+    let preview = outcome.rebase.overlayed_graph()?;
+    for name in ["refs/heads/local", "refs/heads/local-bottom"] {
+        let name: gix::refs::FullName = name.try_into()?;
+        assert!(
+            preview.segment_by_ref_name(name.as_ref()).is_none(),
+            "the squash-integrated segment {name} should leave the workspace"
+        );
+    }
+    for name in ["local", "local-bottom"] {
+        assert!(
+            preview
+                .segment_by_commit_id(repo.rev_parse_single(name)?.detach())
+                .is_err(),
+            "the squash-integrated commit {name} should not be replayed"
+        );
+    }
+    let s1: gix::refs::FullName = "refs/heads/S1".try_into()?;
+    assert!(
+        preview.segment_by_ref_name(s1.as_ref()).is_some(),
+        "the unrelated stack should remain"
     );
     Ok(())
 }

--- a/crates/but-workspace/tests/workspace/upstream_integration.rs
+++ b/crates/but-workspace/tests/workspace/upstream_integration.rs
@@ -14,6 +14,7 @@ use gix::prelude::ObjectIdExt;
 use gix::refs::transaction::PreviousValue;
 use snapbox::IntoData;
 
+use crate::ref_info::head_info;
 use crate::ref_info::with_workspace_commit::utils::{
     StackState, add_stack, add_stack_with_segments, named_writable_scenario_with_description,
 };
@@ -2964,12 +2965,10 @@ fn review_hint_integrates_squashed_two_commit_stack_in_managed_workspace() -> Re
 }
 
 #[test]
-fn review_hint_integrates_squashed_two_commit_direct_checkout_branch() -> Result<()> {
+fn content_integrates_squashed_two_commit_direct_checkout_without_review_hint() -> Result<()> {
     let (_tmp, repo, mut meta, _description) =
         named_writable_scenario_with_description("review-hint-squash-integrated-direct-checkout")?;
     let target_sha = repo.rev_parse_single("main")?.detach();
-    let review_head = repo.rev_parse_single("A")?.detach();
-
     let project_meta = target_project_meta("refs/remotes/origin/main", target_sha)?;
     let graph = but_graph::Graph::from_commit_traversal_tips(
         &repo,
@@ -3014,7 +3013,7 @@ fn review_hint_integrates_squashed_two_commit_direct_checkout_branch() -> Result
 
     let project_meta = workspace.graph.project_meta.clone();
 
-    let out = integrate_upstream_with_hints(
+    let out = integrate_upstream(
         &mut workspace,
         &mut meta,
         project_meta.clone(),
@@ -3022,10 +3021,6 @@ fn review_hint_integrates_squashed_two_commit_direct_checkout_branch() -> Result
         vec![BottomUpdate {
             kind: BottomUpdateKind::Rebase,
             selector: RelativeTo::Commit(repo.rev_parse_single("A^")?.detach()),
-        }],
-        &[ReviewIntegrationHint {
-            head_commit_at_merge: review_head,
-            source_branch: "A".into(),
         }],
     )?;
     out.rebase.materialize(Default::default())?;
@@ -3436,5 +3431,158 @@ fn remove_managed_workspace_ref(repo: &gix::Repository) -> Result<()> {
     if let Some(reference) = repo.try_find_reference(but_core::WORKSPACE_REF_NAME)? {
         reference.delete()?;
     }
+    Ok(())
+}
+
+#[test]
+fn content_integrates_shared_bottom_without_consuming_net_zero_live_head() -> Result<()> {
+    let (_tmp, repo, mut meta, _description) = named_writable_scenario_with_description(
+        "squash-integrated-shared-bottom-with-live-heads",
+    )?;
+    let target_sha = repo.rev_parse_single("main")?.detach();
+    assert_eq!(
+        repo.rev_parse_single("right^{tree}")?.detach(),
+        repo.rev_parse_single("bottom^{tree}")?.detach(),
+        "fixture must make the right head content-equal to bottom through an add and revert",
+    );
+
+    let project_meta = target_project_meta("refs/remotes/origin/main", target_sha)?;
+    add_stack_with_segments(&mut meta, 1, "left", StackState::InWorkspace, &["bottom"]);
+    add_stack_with_segments(&mut meta, 2, "right", StackState::InWorkspace, &["bottom"]);
+    let info = head_info(
+        &repo,
+        &meta,
+        but_workspace::ref_info::Options {
+            project_meta: project_meta.clone(),
+            expensive_commit_info: true,
+            ..Default::default()
+        },
+    )?;
+    let right = info
+        .stacks
+        .iter()
+        .flat_map(|stack| &stack.segments)
+        .find_map(|segment| {
+            (segment
+                .ref_info
+                .as_ref()
+                .is_some_and(|info| info.ref_name.as_bstr() == b"refs/heads/right".as_bstr()))
+            .then_some(&segment.commits)
+        })
+        .context("right segment should be present")?;
+    assert_eq!(right.len(), 2, "right should contain its add and revert");
+    assert!(
+        right.iter().all(|commit| matches!(
+            commit.relation,
+            but_workspace::ref_info::LocalCommitRelation::LocalOnly
+        )),
+        "RefInfo should keep the net-zero right segment local"
+    );
+    let graph = but_graph::Graph::from_head(
+        &repo,
+        &meta,
+        project_meta,
+        Options {
+            extra_target_commit_id: Some(target_sha),
+            ..Options::limited()
+        },
+    )?;
+    let mut workspace = graph.into_workspace()?;
+
+    integrate_and_materialize(
+        &mut workspace,
+        &mut meta,
+        &repo,
+        vec![BottomUpdate {
+            kind: BottomUpdateKind::Rebase,
+            selector: RelativeTo::Commit(repo.rev_parse_single("bottom^")?.detach()),
+        }],
+    )?;
+
+    assert!(
+        repo.try_find_reference("bottom")?.is_none(),
+        "shared content-equivalent bottom should leave both stacks",
+    );
+    assert_eq!(
+        repo.rev_parse_single("right~2")?.detach(),
+        repo.rev_parse_single("origin/main")?.detach(),
+        "right's add and revert commits should remain above the squash",
+    );
+    assert_eq!(
+        repo.rev_parse_single("left^")?.detach(),
+        repo.rev_parse_single("origin/main")?.detach(),
+        "left should be rebased directly onto the squash",
+    );
+    for name in ["left", "right"] {
+        let commit = repo.find_commit(repo.rev_parse_single(name)?.detach())?;
+        assert!(
+            !Commit::from_id(commit.id.attach(&repo))?.is_conflicted(),
+            "live head {name} should remain unconflicted",
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
+fn content_does_not_integrate_near_match_and_preserves_real_conflict() -> Result<()> {
+    let (_tmp, repo, mut meta, _description) = named_writable_scenario_with_description(
+        "review-hint-squash-integrated-two-commit-stack-with-sibling",
+    )?;
+    let target_sha = repo.rev_parse_single("main")?.detach();
+
+    git(&repo)
+        .args(["checkout", "--detach", "origin/main"])
+        .run();
+    std::fs::write(
+        repo.workdir()
+            .context("fixture repositories should have a worktree")?
+            .join("A2.txt"),
+        "different upstream content\n",
+    )?;
+    git(&repo).args(["add", "A2.txt"]).run();
+    git(&repo).args(["commit", "--amend", "--no-edit"]).run();
+    git(&repo)
+        .args(["update-ref", "refs/remotes/origin/main", "HEAD"])
+        .run();
+    git(&repo).args(["checkout", "gitbutler/workspace"]).run();
+
+    let project_meta = target_project_meta("refs/remotes/origin/main", target_sha)?;
+    add_stack(&mut meta, 1, "A", StackState::InWorkspace);
+    add_stack(&mut meta, 2, "B", StackState::InWorkspace);
+    let graph = but_graph::Graph::from_head(
+        &repo,
+        &meta,
+        project_meta,
+        Options {
+            extra_target_commit_id: Some(target_sha),
+            ..Options::limited()
+        },
+    )?;
+    let mut workspace = graph.into_workspace()?;
+
+    integrate_and_materialize(
+        &mut workspace,
+        &mut meta,
+        &repo,
+        vec![BottomUpdate {
+            kind: BottomUpdateKind::Rebase,
+            selector: RelativeTo::Commit(repo.rev_parse_single("A^")?.detach()),
+        }],
+    )?;
+
+    assert!(
+        repo.try_find_reference("A")?.is_some(),
+        "one differing blob must keep the local branch",
+    );
+    assert!(
+        Commit::from_id(repo.rev_parse_single("A")?)?.is_conflicted(),
+        "a genuine overlapping difference must still be reported as a conflict",
+    );
+    assert!(
+        repo.try_find_reference("B")?.is_some(),
+        "near-match handling must not affect the sibling",
+    );
+
     Ok(())
 }


### PR DESCRIPTION
## 🧢 Changes

- Use cumulative changeset matches during upstream integration.
- Remove local commits only when their combined content is present upstream.
- Keep unmatched branches and commits local.
- Add regression coverage for direct and managed workspaces, shared stack bases, multi-segment squashes, net-zero heads, and near matches.

## ☕️ Reasoning

`RefInfo` already detected squash-integrated commit ranges by comparing their combined content with upstream. The integration path did not use that result and checked only individual commits.

Consequently, GitButler could report a squashed range as integrated and then replay the same commits during integration, producing unnecessary conflicts or leaving stale branch state.

This change applies cumulative content matching to the integration path. Matching is attempted within named branch segments first. A squash spanning adjacent segments is accepted only when the complete range is eligible and exactly matches upstream. Unmatched or net-zero live segments remain local.

This prevents incorrect replay of squash-integrated commits. It does not repair workspaces already affected by an earlier integration.

## 🎫 Affected issues

Fixes #14298
Related to #15154