### PR TITLE
Open the diff context menu anywhere in a hunk

### DIFF
--- a/apps/lite/ui/src/hunk.test.ts
+++ b/apps/lite/ui/src/hunk.test.ts
@@ -1,0 +1,91 @@
+import { contiguousSelectionByLine, wholeHunkSelectionByLine } from "#ui/hunk.ts";
+import { processFile } from "@pierre/diffs";
+import { describe, expect, it } from "vitest";
+
+// Two hunks, the first holding two changed runs with context between them. The second starts at a
+// different line on either side, so a lookup that took the wrong side would miss it.
+const PATCH = [
+	"diff --git a/file.ts b/file.ts",
+	"--- a/file.ts",
+	"+++ b/file.ts",
+	"@@ -1,8 +1,9 @@",
+	" one",
+	"-two",
+	"+TWO",
+	" three",
+	" four",
+	"-five",
+	"+FIVE",
+	"+FIVE AND A HALF",
+	" six",
+	" seven",
+	" eight",
+	"@@ -20,5 +21,5 @@",
+	" twenty",
+	"-twentyone",
+	"+TWENTYONE",
+	" twentytwo",
+	" twentythree",
+	" twentyfour",
+	"",
+].join("\n");
+
+const hunks = (() => {
+	const parsed = processFile(PATCH, { cacheKey: "hunk.test" });
+	if (!parsed) throw new Error("Failed to parse patch");
+	return parsed.hunks;
+})();
+
+describe("wholeHunkSelectionByLine", () => {
+	it("takes every changed run of the hunk holding a context line", () => {
+		// " six", the context line between the second changed run and the end of the first hunk.
+		expect(wholeHunkSelectionByLine({ hunks, line: 6, side: "deletions" })).toEqual({
+			hunkHeader: { oldStart: 1, oldLines: 8, newStart: 1, newLines: 9 },
+			lineGroups: [
+				{ side: "deletions", start: 2, lines: 1 },
+				{ side: "additions", start: 2, lines: 1 },
+				{ side: "deletions", start: 5, lines: 1 },
+				{ side: "additions", start: 5, lines: 2 },
+			],
+		});
+	});
+
+	it("takes the same hunk from either side of a split diff", () => {
+		// The same context line, numbered by the addition column instead.
+		expect(wholeHunkSelectionByLine({ hunks, line: 7, side: "additions" })).toEqual(
+			wholeHunkSelectionByLine({ hunks, line: 6, side: "deletions" }),
+		);
+	});
+
+	it("numbers the line by the given side", () => {
+		// Line 20 is the second hunk's first line on the deletion side only; the two sides drifted
+		// apart by the line the first hunk added.
+		expect(wholeHunkSelectionByLine({ hunks, line: 20, side: "deletions" })?.hunkHeader).toEqual({
+			oldStart: 20,
+			oldLines: 5,
+			newStart: 21,
+			newLines: 5,
+		});
+		expect(wholeHunkSelectionByLine({ hunks, line: 20, side: "additions" })).toBeNull();
+	});
+
+	it("has no hunk for a line between them", () => {
+		expect(wholeHunkSelectionByLine({ hunks, line: 15, side: "deletions" })).toBeNull();
+	});
+
+	it("takes more than the changed line under it does", () => {
+		expect(contiguousSelectionByLine({ hunks, line: 2, side: "deletions" })).toEqual({
+			hunkHeader: { oldStart: 1, oldLines: 8, newStart: 1, newLines: 9 },
+			lineGroups: [
+				{ side: "deletions", start: 2, lines: 1 },
+				{ side: "additions", start: 2, lines: 1 },
+			],
+		});
+	});
+
+	// Why the two live side by side: a context line names a hunk but no changed run in it.
+	it("answers where the changed-run lookup cannot", () => {
+		expect(contiguousSelectionByLine({ hunks, line: 6, side: "deletions" })).toBeNull();
+		expect(wholeHunkSelectionByLine({ hunks, line: 6, side: "deletions" })).not.toBeNull();
+	});
+});

--- a/apps/lite/ui/src/hunk.ts
+++ b/apps/lite/ui/src/hunk.ts
@@ -140,25 +140,51 @@ export const firstContiguousSelectionFromHunk = (hunk: Hunk): HunkLineSelection 
 	return null;
 };
 
-export const contiguousSelectionByLine = ({
-	hunks,
-	line,
-	side,
-}: {
+/** A line as the diff view names it: a number, read on one side of the change. */
+type LineQuery = {
 	hunks: Array<Hunk>;
 	line: number;
 	side: SelectionSide;
-}): HunkLineSelection | null => {
-	for (const hunk of hunks) {
-		for (const sel of contiguousSelectionsFromHunk(hunk)) {
-			const containsChangedLine = sel.lineGroups.some(
-				(group) => group.side === side && line >= group.start && line < group.start + group.lines,
-			);
-			if (containsChangedLine) return sel;
-		}
-	}
+};
 
-	return null;
+/** The hunk covering the line on that side. Hunks never overlap, so at most one does. */
+const hunkByLine = ({ hunks, line, side }: LineQuery): Hunk | null =>
+	hunks.find((hunk) => {
+		const start = side === "deletions" ? hunk.deletionStart : hunk.additionStart;
+		const lines = side === "deletions" ? hunk.deletionCount : hunk.additionCount;
+		return line >= start && line < start + lines;
+	}) ?? null;
+
+/** The changed group under the line, or nothing when the line is context. */
+export const contiguousSelectionByLine = (query: LineQuery): HunkLineSelection | null => {
+	const hunk = hunkByLine(query);
+	if (!hunk) return null;
+
+	const { line, side } = query;
+	return (
+		contiguousSelectionsFromHunk(hunk).find((sel) =>
+			sel.lineGroups.some(
+				(group) => group.side === side && line >= group.start && line < group.start + group.lines,
+			),
+		) ?? null
+	);
+};
+
+/**
+ * Every changed group in the hunk holding the line. Context lines belong to no group of their own,
+ * so a click on one takes the hunk whole.
+ */
+export const wholeHunkSelectionByLine = (query: LineQuery): HunkLineSelection | null => {
+	const hunk = hunkByLine(query);
+	if (!hunk) return null;
+
+	const lineGroups = contiguousSelectionsFromHunk(hunk).flatMap((sel) => sel.lineGroups);
+	if (lineGroups.length === 0) return null;
+
+	return {
+		hunkHeader: hunkHeaderFromHunk(hunk),
+		lineGroups,
+	};
 };
 
 export const diffSpecHunkHeadersForLineSelection = (

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -94,7 +94,7 @@ import {
 } from "./file-row.ts";
 import { FileFilterRow } from "./FileFilterRow.tsx";
 import { useFileFilter } from "./useFileFilter.ts";
-import { contiguousSelectionByLine } from "#ui/hunk.ts";
+import { contiguousSelectionByLine, wholeHunkSelectionByLine } from "#ui/hunk.ts";
 import { buildIndexByKey, type NavigationIndex } from "#ui/workspace/navigation-index.ts";
 import { showNativeContextMenu, showNativeMenuFromTrigger } from "#ui/native-menu.ts";
 import { useFileMenuItems } from "#ui/routes/project/$id/workspace/useFileMenuItems.ts";
@@ -413,15 +413,14 @@ const DiffContents: FC<{
 		itemId,
 		lineNumber,
 		side,
+		lineType,
 	}: DiffLineTarget): HunkOperand | null => {
 		const file = fileByItemId.get(itemId);
 		if (file?.patch?.type !== "Patch") return null;
 
-		const selection = contiguousSelectionByLine({
-			hunks: file.item.fileDiff.hunks,
-			line: lineNumber,
-			side,
-		});
+		const query = { hunks: file.item.fileDiff.hunks, line: lineNumber, side };
+		const selection =
+			lineType === "context" ? wholeHunkSelectionByLine(query) : contiguousSelectionByLine(query);
 		if (!selection) return null;
 
 		return {

--- a/apps/lite/ui/src/routes/project/$id/workspace/diff-line-context-menu.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/diff-line-context-menu.ts
@@ -1,6 +1,10 @@
 import type { CodeViewHandle } from "@pierre/diffs/react";
 import { useEffectEvent, useLayoutEffect, type RefObject } from "react";
-import { diffLineTargetFromElement, type DiffLineTarget } from "./diff-line-target.ts";
+import {
+	diffLineTargetFromElement,
+	LINE_NUMBER_ATTRIBUTES,
+	type DiffLineTarget,
+} from "./diff-line-target.ts";
 
 export type DiffLineContextMenuTarget = {
 	event: MouseEvent;
@@ -14,11 +18,14 @@ const contextMenuTarget = <T>(
 	// composed, so inspecting their path lets us delegate from the stable CodeView container
 	// instead of observing renders or attaching listeners to every line number.
 	const path = event.composedPath();
-	const lineNumberElement = path.find(
+	// A row is a gutter cell and the code beside it, each numbering the line in its own way. The
+	// menu belongs to the whole row, so take whichever half was clicked.
+	const lineElement = path.find(
 		(target): target is HTMLElement =>
-			target instanceof HTMLElement && target.hasAttribute("data-column-number"),
+			target instanceof HTMLElement &&
+			LINE_NUMBER_ATTRIBUTES.some((attribute) => target.hasAttribute(attribute)),
 	);
-	if (!lineNumberElement) return null;
+	if (!lineElement) return null;
 
 	const item = viewerRef.current
 		?.getInstance()
@@ -26,7 +33,7 @@ const contextMenuTarget = <T>(
 		.find(({ element }) => path.includes(element));
 	if (item?.type !== "diff") return null;
 
-	const target = diffLineTargetFromElement({ element: lineNumberElement, itemId: item.id });
+	const target = diffLineTargetFromElement({ element: lineElement, itemId: item.id });
 	return target ? { event, ...target } : null;
 };
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/diff-line-target.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/diff-line-target.ts
@@ -4,14 +4,29 @@ export type DiffLineTarget = {
 	itemId: string;
 	lineNumber: number;
 	side: SelectionSide;
+	/** Context lines belong to no one changed run of the hunk. */
+	lineType: "change" | "context";
 };
 
-const selectionSideFromLineNumber = (element: HTMLElement): SelectionSide | null => {
+/** The attributes naming a line, on the gutter cell and on the code respectively. */
+export const LINE_NUMBER_ATTRIBUTES = ["data-column-number", "data-line"];
+
+/** What the row says about itself, before the line it names is read. */
+type DiffLine = Pick<DiffLineTarget, "side" | "lineType">;
+
+const diffLineFromElement = (element: HTMLElement): DiffLine | null => {
 	switch (element.getAttribute("data-line-type")) {
 		case "change-addition":
-			return "additions";
+			return { side: "additions", lineType: "change" };
 		case "change-deletion":
-			return "deletions";
+			return { side: "deletions", lineType: "change" };
+		case "context":
+			// Context has no side of its own, so it is numbered by the column holding it: the deletions
+			// one in a split diff, the additions one otherwise.
+			return {
+				side: element.closest("[data-deletions]") ? "deletions" : "additions",
+				lineType: "context",
+			};
 		default:
 			return null;
 	}
@@ -24,15 +39,18 @@ export const diffLineTargetFromElement = ({
 	element: HTMLElement;
 	itemId: string;
 }): DiffLineTarget | null => {
-	const side = selectionSideFromLineNumber(element);
-	if (side === null) return null;
+	const line = diffLineFromElement(element);
+	if (!line) return null;
 
-	const lineNumber = Number.parseInt(element.getAttribute("data-column-number") ?? "", 10);
+	const [number] = LINE_NUMBER_ATTRIBUTES.flatMap(
+		(attribute) => element.getAttribute(attribute) ?? [],
+	);
+	const lineNumber = Number.parseInt(number ?? "", 10);
 	if (!Number.isFinite(lineNumber)) return null;
 
 	return {
 		itemId,
 		lineNumber,
-		side,
+		...line,
 	};
 };


### PR DESCRIPTION
Right-clicking a diff only opened the menu on the gutter of a changed line. Two gaps closed:

- **Either half of the row.** The gutter numbers a line with `data-column-number`, the code beside it with `data-line`; the handler now takes whichever was clicked. Hunk dragging still resolves through `data-hunk-drag-handle`, which stays gutter-only so it doesn't fight text selection.
- **Context lines.** They carry no side of their own, so they take the side of the column holding them — deletions in a split diff, additions otherwise, the way Pierre reads them. A context line belongs to no single changed run, so it targets the whole hunk: every changed run between the separators. Changed lines still target just their own run.

The whole-hunk operand is a list of per-run headers — the same shape `apps/desktop`'s `diffToHunkHeaders` sends for a fully selected hunk — so discard, uncommit and commit needed no new handling.

Both lookups now locate the hunk through one `hunkByLine`, and differ only in scope.

### Checks

`apps/lite/ui/src/hunk.test.ts` covers the scope rules against a real patch parsed by Pierre: a context line yields every run of a two-run hunk, both sides of a split diff agree, and a lookup with the wrong side misses the hunk the sides have drifted apart on.

Verified in the running app by recording what the menu would contain instead of displaying it: all four surfaces (changed/context × gutter/code) open it, and on a hunk with two runs, "Cut Hunk" from a context line reports 4 changed lines where the changed line above it reports 1.