### PR TITLE
Update the Upstream tab design 

### DIFF
--- a/apps/lite/ui/src/api/queries.ts
+++ b/apps/lite/ui/src/api/queries.ts
@@ -11,12 +11,7 @@ import type {
 import { aggregateCIChecks } from "#ui/ci.ts";
 import { clampAutoFetch, defaultSettings } from "#ui/settings.ts";
 import type { ForgeReview } from "@gitbutler/but-sdk";
-import {
-	infiniteQueryOptions,
-	queryOptions,
-	skipToken,
-	type QueryClient,
-} from "@tanstack/react-query";
+import { queryOptions, type QueryClient } from "@tanstack/react-query";
 import * as ms from "ms";
 
 export type QueryKey =
@@ -48,8 +43,7 @@ export type QueryKey =
 	| "guiSettings"
 	| "workspaceFetch"
 	| "workspaceFetchStatus"
-	| "workspaceTargetCommits"
-	| "workspaceTargetCommitsOlder";
+	| "workspaceTargetCommits";
 
 export const branchDetailsQueryOptions = ({ projectId, ...params }: BranchDetailsParams) =>
 	queryOptions({
@@ -145,30 +139,6 @@ export const refreshIntegratedReviews = async (
 		}),
 	);
 };
-
-const olderTargetCommitsPageSize = 25;
-
-/**
- * Pages of target history older than the workspace's fork point, continued
- * below `from` with a commit-id cursor. A `null` cursor means the base
- * listing has not arrived yet, so there is nothing to continue from.
- */
-export const olderTargetCommitsInfiniteQueryOptions = (projectId: string, from: string | null) =>
-	infiniteQueryOptions({
-		queryKey: ["workspaceTargetCommitsOlder" satisfies QueryKey, projectId, from],
-		queryFn:
-			from === null
-				? skipToken
-				: ({ pageParam }) =>
-						window.lite.workspaceTargetCommits({
-							projectId,
-							from: pageParam,
-							limit: olderTargetCommitsPageSize,
-						}),
-		initialPageParam: from ?? "",
-		getNextPageParam: (lastPage) =>
-			lastPage.hasMore ? (lastPage.commits.at(-1)?.commit.id ?? undefined) : undefined,
-	});
 
 export const workspaceFetchStatusQueryOptions = (projectId: string) =>
 	queryOptions({

--- a/apps/lite/ui/src/components/GraphSegment.module.css
+++ b/apps/lite/ui/src/components/GraphSegment.module.css
@@ -16,6 +16,10 @@
 		--commit-status-color: var(--commit-integrated);
 	}
 
+	&[data-status="Upstream"] {
+		--commit-status-color: var(--commit-upstream);
+	}
+
 	&[data-status="Diverged"] {
 		--commit-status-color: var(--commit-local);
 	}

--- a/apps/lite/ui/src/components/GraphSegment.tsx
+++ b/apps/lite/ui/src/components/GraphSegment.tsx
@@ -58,7 +58,12 @@ const stretchableGlyphs = new Set<GraphSegmentGlyph>([
 	"joinBoth",
 ]);
 
-export type GraphSegmentStatus = "Diverged" | CommitState["type"];
+/**
+ * `Upstream` has no counterpart in {@link CommitState}: it describes the target
+ * branch's own line — commits that are on the target and not in the workspace
+ * at all, rather than commits of ours in some state against it.
+ */
+export type GraphSegmentStatus = "Diverged" | "Upstream" | CommitState["type"];
 
 interface GraphSegmentProps extends ComponentProps<"div"> {
 	glyph: GraphSegmentGlyph;

--- a/apps/lite/ui/src/projects/project.ts
+++ b/apps/lite/ui/src/projects/project.ts
@@ -167,9 +167,6 @@ export const projectReducers = {
 	toggleUpstreamSegment: (state: ProjectState, { segmentId }: { segmentId: string }) => {
 		upstreamReducers.toggleSegment(state.upstream, { segmentId });
 	},
-	toggleUpstreamIncoming: (state: ProjectState) => {
-		upstreamReducers.toggleIncoming(state.upstream);
-	},
 	selectFiles: (state: ProjectState, { selection }: { selection: string | null }) => {
 		const workspaceState = state.workspace;
 		if (workspaceState.selection.files === selection) return;

--- a/apps/lite/ui/src/projects/upstream.ts
+++ b/apps/lite/ui/src/projects/upstream.ts
@@ -9,21 +9,14 @@ export type UpstreamState = {
 	selection: Operand | null;
 	/**
 	 * Expanded shared-history segments, keyed by the segment's newest commit
-	 * id. Expanding reveals the target commits between fork points, or — for
-	 * the segment below the deepest fork point — pages of older target history.
+	 * id. Expanding reveals the target commits between two fork points.
 	 */
 	expandedSegments: Record<string, true>;
-	/**
-	 * Whether the incoming commits are folded away. Unlike the shared-history
-	 * segments they show by default, so their toggle is stored inverted.
-	 */
-	incomingHidden: boolean;
 };
 
 const initialState = (): UpstreamState => ({
 	selection: null,
 	expandedSegments: {},
-	incomingHidden: false,
 });
 
 const upstreamSlice = createSlice({
@@ -44,15 +37,11 @@ const upstreamSlice = createSlice({
 			if (state.expandedSegments[segmentId]) delete state.expandedSegments[segmentId];
 			else state.expandedSegments[segmentId] = true;
 		},
-		toggleIncoming: (state) => {
-			state.incomingHidden = !state.incomingHidden;
-		},
 	},
 	selectors: {
 		/** The selection as stored, without resolving it against a navigation index. */
 		selectPrimaryUpstreamSelection: (state) => state.selection,
 		selectExpandedUpstreamSegments: (state) => state.expandedSegments,
-		selectUpstreamIncomingHidden: (state) => state.incomingHidden,
 		selectSelectionUpstream: (state, navigationIndex: NavigationIndex<Operand>) =>
 			resolveNavigationIndexSelection(navigationIndex, state.selection, operandIdentityKey),
 	},
@@ -66,9 +55,6 @@ export const upstreamReducers = {
 	},
 	toggleSegment: (state: UpstreamState, payload: { segmentId: string }) => {
 		upstreamSlice.caseReducers.toggleSegment(state, upstreamSlice.actions.toggleSegment(payload));
-	},
-	toggleIncoming: (state: UpstreamState) => {
-		upstreamSlice.caseReducers.toggleIncoming(state);
 	},
 };
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/StackCard.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/StackCard.module.css
@@ -49,9 +49,17 @@
 	padding-block-end: var(--stack-card-body-inset-block-end, 6px);
 }
 
-/* Carries the rail on from one branch to the next. The last one has no branch
-   to reach, so it is clipped to a stub that runs past the final row and
-   supplies the card's floor — which is what the body's inset opts out of. */
+/* Carries the rail on from one branch to the next. It only has to bridge the
+   gap, so it is clipped shorter than a regular row. */
+.railConnector {
+	height: 14px;
+	min-height: auto;
+	overflow: hidden;
+}
+
+/* The last one has no branch to reach, so it is clipped to a stub that runs
+   past the final row and supplies the card's floor — which is what the body's
+   inset opts out of. */
 .railConnector:last-child {
 	height: 8px;
 	min-height: auto;

--- a/apps/lite/ui/src/routes/project/$id/workspace/UpstreamList.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/UpstreamList.module.css
@@ -37,7 +37,7 @@
 	   as a glyph's own box, and anything outside one reads as a break in the
 	   rail. It is added as drawn rail instead; see `.expanderGlyph` and
 	   `.railStub`. */
-	--expander-glyph-air: 8px;
+	--expander-glyph-air: 4px;
 
 	display: flex;
 	flex-direction: column;

--- a/apps/lite/ui/src/routes/project/$id/workspace/UpstreamList.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/UpstreamList.module.css
@@ -17,19 +17,34 @@
 	padding-block: var(--panel-padding-block);
 }
 
-.heading {
-	display: flex;
-	column-gap: 6px;
-	align-items: center;
-	color: var(--text-2);
+/* The heading names the tree for screen readers; the target's own row heads
+   the card visually, so a second visible heading would only repeat it. */
+.srOnly {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	overflow: hidden;
+	white-space: nowrap;
+	clip-path: inset(50%);
 }
 
-/* The tree holds only the commit group, so the heading and empty-state message
-   above it stay out of the ARIA tree. */
-.tree {
+/* The target history and the workspace's branches are two regions of one
+   graph, so they share a single card and are divided rather than boxed apart. */
+.card {
+	/* The one knob for how much room a shared-history run gets: above its
+	   toggle, and below the last commit it reveals. Padding cannot supply that
+	   room — the graph line is drawn by the glyphs, so it only reaches as far
+	   as a glyph's own box, and anything outside one reads as a break in the
+	   rail. It is added as drawn rail instead; see `.expanderGlyph` and
+	   `.railStub`. */
+	--expander-glyph-air: 8px;
+
 	display: flex;
-	row-gap: 8px;
 	flex-direction: column;
+	padding: 6px;
+	border-radius: var(--radius-card);
+	background-color: var(--bg-1);
+	box-shadow: var(--shadow-card);
 
 	&:focus {
 		/* The focus state is displayed on the item row instead. */
@@ -37,13 +52,36 @@
 	}
 }
 
-.card {
+/* Spans the card's full width, so it reads as a division of the card rather
+   than of the rows inset within it. The rail tail above supplies its own gap,
+   so the divider only insets below. */
+.divider {
+	margin-inline: -6px;
+	margin-block: 0 6px;
+	border-block-start: 1px dashed var(--border-3);
+}
+
+/* Carries a rail past the last row of its region: the glyph is clipped to a
+   stub so only the top of its vertical line shows, and the negative inset lets
+   it run out through the card's own padding to the floor. */
+.railTail {
 	display: flex;
-	flex-direction: column;
-	padding: 6px;
-	border-radius: var(--radius-card);
-	background-color: var(--bg-1);
-	box-shadow: var(--shadow-card);
+	height: 14px;
+	margin-block-end: -6px;
+	padding-inline: 8px;
+	overflow: hidden;
+}
+
+/* The target's stub ends at the divider instead, which supplies the gap below
+   it. */
+.railTailBridge {
+	margin-block-end: 0;
+}
+
+.message {
+	padding-inline: 8px;
+	padding-block: 2px;
+	color: var(--text-2);
 }
 
 .label {
@@ -67,46 +105,69 @@
 	gap: 4px;
 }
 
-/* Target history flows bare on the panel background; the inset keeps its
-   rows aligned with the contents of the branch cards. */
-.commitRun {
-	display: flex;
-	flex-direction: column;
-	padding-inline: 6px;
-}
-
+/* Sits on the rail like a row, so the graph line runs through it rather than
+   breaking around the control. */
 .expanderRow {
-	padding-inline-start: 12px;
-	padding-block: 2px;
-	border: none;
-	background: none;
-	color: inherit;
-	text-align: start;
-	cursor: pointer;
-
-	&:hover {
-		color: var(--text-1);
-	}
-
-	&:disabled {
-		cursor: default;
-	}
-}
-
-.statePill {
-	flex-shrink: 0;
-	align-self: center;
-	white-space: nowrap;
-}
-
-.footer {
 	display: flex;
-	row-gap: 8px;
-	flex-direction: column;
-	padding-inline: var(--panel-padding-inline);
-	padding-block: var(--panel-padding-block);
+	column-gap: 8px;
+	padding-inline: 8px;
 }
 
-.footerText {
-	color: var(--text-2);
+/* Stacks the glyph over a stub of rail. That stub is the only way to add space
+   *below* the glyph: a segment has a single stretch band, and the reversed
+   column above has already spent it. */
+.expanderRail {
+	display: flex;
+	flex-direction: column;
+}
+
+/* Closes an expanded run, so the space under its last commit answers the space
+   above its toggle. Aligned like a row so its rail lands on the same line. */
+.runTail {
+	display: flex;
+	padding-inline: 8px;
+}
+
+/* Reversing the column puts the plain stretch band above the glyph, where it
+   goes on drawing the rail through the space it opens.
+
+   The 32px is where the group glyph centres its rings rather than a chosen
+   number: they sit at 3–17 of its 26px canvas, which leaves 9px of tail below
+   them, so the band above has to come out to the same 9px. Growing past that
+   is what the tail stub is for. Doubled selector because this has to beat
+   GraphSegment's own `flex-direction`, equally specific and otherwise decided
+   by import order. */
+.expanderGlyph.expanderGlyph {
+	flex-direction: column-reverse;
+	height: calc(32px + var(--expander-glyph-air));
+}
+
+/* A clipped length of plain rail, used wherever the graph has to keep drawing
+   through space no glyph covers. */
+.railStub {
+	height: var(--expander-glyph-air);
+	overflow: hidden;
+}
+
+/* Sized by the button itself; this only keeps it from stretching. */
+.expanderButton {
+	align-self: center;
+}
+
+/* Hangs off the target rail below the incoming commits, so the prose and the
+   button read as acting on them. */
+.updateBlock {
+	display: flex;
+	column-gap: 8px;
+	padding-inline: 8px;
+}
+
+.updateBlockBody {
+	display: flex;
+	row-gap: 12px;
+	flex-grow: 1;
+	flex-direction: column;
+	min-width: 0;
+	padding-block-start: 12px;
+	padding-block-end: 6px;
 }

--- a/apps/lite/ui/src/routes/project/$id/workspace/UpstreamList.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/UpstreamList.tsx
@@ -52,7 +52,9 @@ const useIsSelected = (projectId: string, operand: Operand): boolean =>
  * the commit rows hang off.
  */
 const TargetHeadRow: FC<{ label: string }> = ({ label }) => (
-	<Row interactive={false}>
+	// Presentational within the tree: only the commit rows are `treeitem`s, so
+	// everything else the card draws is excluded from the tree's children.
+	<Row role="none" interactive={false}>
 		<GraphSegment glyph="forkRight" status="Upstream" />
 		<RowLabelContainer>
 			<RowLabel heading singleLine title={label}>
@@ -144,7 +146,7 @@ const UpstreamBranchRow: FC<{ item: UpstreamBranchItem; glyph: GraphSegmentGlyph
 	item,
 	glyph,
 }) => (
-	<Row interactive={false}>
+	<Row role="none" interactive={false}>
 		<GraphSegment glyph={glyph} status={item.integrated ? "Integrated" : "LocalOnly"} />
 		<div className={styles.label}>
 			<RowLabelContainer>
@@ -178,7 +180,7 @@ const SegmentExpanderRow: FC<{
 	const dispatch = useAppDispatch();
 
 	return (
-		<div className={styles.expanderRow}>
+		<div role="none" className={styles.expanderRow}>
 			<div className={styles.expanderRail}>
 				{/* The stacked rings stand in for the commits while they are folded
 				    away; once they are on screen the rail just runs past the toggle. */}
@@ -223,7 +225,7 @@ const UpdateBlock: FC<{
 	const messageClassName = classes("text-12", "text-body", rowStyles.fadedText);
 
 	return (
-		<div className={styles.updateBlock}>
+		<div role="none" className={styles.updateBlock}>
 			<GraphSegment glyph="parent" status="Upstream" />
 			<div className={styles.updateBlockBody}>
 				{incomingCount > 0 ? (
@@ -292,7 +294,7 @@ const listItem = (
 		case "branch":
 			return (
 				<UpstreamBranchRow
-					key={item.name}
+					key={`${item.stackKey}/${item.name}`}
 					item={item}
 					glyph={isFirstBranch ? "forkRight" : "joinRight"}
 				/>
@@ -401,15 +403,19 @@ export const UpstreamList: FC<
 					{targetLabel !== null && <TargetHeadRow label={targetLabel} />}
 
 					{isError && (
-						<p className={classes("text-13", styles.message)}>Unable to load incoming commits.</p>
+						<p role="none" className={classes("text-13", styles.message)}>
+							Unable to load incoming commits.
+						</p>
 					)}
 
 					{!isError && isPending && items.length === 0 && (
-						<p className={classes("text-13", styles.message)}>Loading incoming commits…</p>
+						<p role="none" className={classes("text-13", styles.message)}>
+							Loading incoming commits…
+						</p>
 					)}
 
 					{!isError && !isPending && targetLabel === null && (
-						<p className={classes("text-13", styles.message)}>
+						<p role="none" className={classes("text-13", styles.message)}>
 							No target branch is configured for this project.
 						</p>
 					)}

--- a/apps/lite/ui/src/routes/project/$id/workspace/UpstreamList.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/UpstreamList.tsx
@@ -137,19 +137,30 @@ const TargetCommitRow: FC<{ projectId: string; item: UpstreamCommitItem }> = ({
  * A workspace branch positioned against the target line. It carries its name
  * and nothing else — the rows exist to show where the workspace's branches
  * fork from the target, and everything actionable about a branch lives on the
- * workspace tab.
+ * workspace tab — except for having landed, which the rail's colour and a
+ * second line both report.
  */
 const UpstreamBranchRow: FC<{ item: UpstreamBranchItem; glyph: GraphSegmentGlyph }> = ({
 	item,
 	glyph,
 }) => (
 	<Row interactive={false}>
-		<GraphSegment glyph={glyph} status="LocalOnly" />
-		<RowLabelContainer>
-			<RowLabel heading singleLine title={item.name}>
-				{item.name}
-			</RowLabel>
-		</RowLabelContainer>
+		<GraphSegment glyph={glyph} status={item.integrated ? "Integrated" : "LocalOnly"} />
+		<div className={styles.label}>
+			<RowLabelContainer>
+				<RowLabel heading singleLine title={item.name}>
+					{item.name}
+				</RowLabel>
+			</RowLabelContainer>
+
+			{/* The rail's colour is easy to miss on a branch that has landed, so
+			    the state is spelled out on the second line as well. */}
+			{item.integrated && (
+				<RowLabelFooter className={classes("text-13", styles.labelMeta)}>
+					<span className={classes(rowStyles.fadedText, styles.labelMetaItem)}>integrated</span>
+				</RowLabelFooter>
+			)}
+		</div>
 	</Row>
 );
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/UpstreamList.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/UpstreamList.tsx
@@ -1,14 +1,15 @@
 import rowStyles from "./Row.module.css";
 import { Scroller } from "#ui/components/Scroller.tsx";
-import { forgeInfoOptions } from "#ui/api/queries.ts";
 import { commitTitle } from "#ui/commit.ts";
-import { Badge } from "#ui/components/Badge.tsx";
 import { getButtonClassName } from "#ui/components/Button.tsx";
 import { classes } from "#ui/components/classes.ts";
-import { GraphSegment } from "#ui/components/GraphSegment.tsx";
+import {
+	GraphSegment,
+	type GraphSegmentGlyph,
+	type GraphSegmentStatus,
+} from "#ui/components/GraphSegment.tsx";
 import { Icon } from "#ui/components/Icon.tsx";
-import { branchOperand, commitOperand, operandIdentityKey, type Operand } from "#ui/operands.ts";
-import { prForgeUrl } from "#ui/pr.ts";
+import { commitOperand, operandIdentityKey, type Operand } from "#ui/operands.ts";
 import { projectSlice } from "#ui/projects/state.ts";
 import {
 	useAutofocusSelectionScope,
@@ -17,8 +18,8 @@ import {
 } from "#ui/selection-scopes.ts";
 import { useAppDispatch, useAppSelector } from "#ui/store.ts";
 import { RelativeTime } from "#ui/components/RelativeTime.tsx";
+import { Button } from "@base-ui/react";
 import { useMergedRefs } from "@base-ui/utils/useMergedRefs";
-import { useQuery } from "@tanstack/react-query";
 import {
 	type ComponentProps,
 	type FC,
@@ -34,18 +35,32 @@ import {
 	treeItemId,
 	useIsSelected as useIsSelectedInList,
 } from "./Row-utils.ts";
-import {
-	INCOMING_SEGMENT_ID,
-	useOlderTargetCommits,
-	type UpstreamBranchItem,
-	type UpstreamCommitItem,
-	type UpstreamListItem,
-	type UpstreamOutline,
+import type {
+	UpstreamBranchItem,
+	UpstreamCommitItem,
+	UpstreamListItem,
+	UpstreamOutline,
 } from "./useUpstreamOutline.ts";
 import styles from "./UpstreamList.module.css";
 
 const useIsSelected = (projectId: string, operand: Operand): boolean =>
 	useIsSelectedInList(projectId, operand, projectSlice.selectors.selectPrimaryUpstreamSelection);
+
+/**
+ * The target branch the incoming commits below it belong to. It heads the card
+ * the way a stack's own name heads a stack card, and starts the target rail
+ * the commit rows hang off.
+ */
+const TargetHeadRow: FC<{ label: string }> = ({ label }) => (
+	<Row interactive={false}>
+		<GraphSegment glyph="forkRight" status="Upstream" />
+		<RowLabelContainer>
+			<RowLabel heading singleLine title={label}>
+				{label}
+			</RowLabel>
+		</RowLabelContainer>
+	</Row>
+);
 
 const TargetCommitRow: FC<{ projectId: string; item: UpstreamCommitItem }> = ({
 	projectId,
@@ -77,10 +92,13 @@ const TargetCommitRow: FC<{ projectId: string; item: UpstreamCommitItem }> = ({
 				dispatch(projectSlice.actions.selectUpstream({ projectId, selection: operand }))
 			}
 		>
-			<GraphSegment glyph="commit" status={inWorkspace ? "Integrated" : "LocalAndRemote"} />
+			<GraphSegment glyph="commit" status={inWorkspace ? "Integrated" : "Upstream"} />
 			<div className={styles.label}>
 				<RowLabelContainer>
-					<RowLabel singleLine className={inWorkspace ? rowStyles.fadedText : undefined}>
+					{/* Commits the workspace already has are not dimmed: the row is
+					    selectable like any other, and the rail's colour already
+					    says which side of the boundary the commit is on. */}
+					<RowLabel singleLine>
 						{title === undefined ? (
 							<span className={rowStyles.fadedText}>(no message)</span>
 						) : (
@@ -116,200 +134,171 @@ const TargetCommitRow: FC<{ projectId: string; item: UpstreamCommitItem }> = ({
 };
 
 /**
- * A workspace branch positioned against the target line, with the same row
- * anatomy as the workspace tab's branch rows: bold name, meta footer, and PR
- * link. Branch rows deliberately stay off the commit line — the state pill
- * alone carries their relation to the upstream.
+ * A workspace branch positioned against the target line. It carries its name
+ * and nothing else — the rows exist to show where the workspace's branches
+ * fork from the target, and everything actionable about a branch lives on the
+ * workspace tab.
  */
-const UpstreamBranchRow: FC<{ projectId: string; item: UpstreamBranchItem }> = ({
-	projectId,
+const UpstreamBranchRow: FC<{ item: UpstreamBranchItem; glyph: GraphSegmentGlyph }> = ({
 	item,
-}) => {
-	const dispatch = useAppDispatch();
-	const operand = branchOperand({ branchRef: item.refBytes });
-	const isSelected = useIsSelected(projectId, operand);
-
-	const { data: forgeInfo } = useQuery(forgeInfoOptions(projectId));
-	const mforgeUrl =
-		item.prNumber !== null ? forgeInfo && prForgeUrl(item.prNumber, forgeInfo) : null;
-
-	const openPRInBrowser = async (evt: MouseEvent<HTMLAnchorElement>): Promise<void> => {
-		evt.preventDefault();
-
-		if (mforgeUrl != null) await window.lite.openInWebBrowser(mforgeUrl);
-	};
-
-	return (
-		<Row
-			id={treeItemId(operand)}
-			role="treeitem"
-			aria-label={item.name}
-			aria-selected={isSelected}
-			isSelected={isSelected}
-			onSelect={() =>
-				dispatch(projectSlice.actions.selectUpstream({ projectId, selection: operand }))
-			}
-		>
-			<GraphSegment glyph="space" status="LocalOnly" />
-			<div className={styles.label}>
-				<RowLabelContainer>
-					<RowLabel heading singleLine title={item.name}>
-						{item.name}
-					</RowLabel>
-				</RowLabelContainer>
-				{/* Always rendered so integrated and unintegrated rows share the
-				    same height regardless of what the footer carries. */}
-				<RowLabelFooter className={classes("text-13", styles.labelMeta)}>
-					{item.commitCount > 0 && (
-						<span className={classes(rowStyles.fadedText, styles.labelMetaItem)}>
-							<Icon name="commit" />
-							{item.commitCount}
-						</span>
-					)}
-
-					{mforgeUrl != null && (
-						<a
-							href={mforgeUrl}
-							onClick={(evt) => void openPRInBrowser(evt)}
-							className={classes(rowStyles.fadedText, styles.labelMetaItem)}
-						>
-							<Icon name="pr" size={14} />
-							PR
-						</a>
-					)}
-				</RowLabelFooter>
-			</div>
-			{item.integrated ? (
-				<Badge
-					variant="integrated"
-					className={styles.statePill}
-					title="Merged into the target branch; updating the workspace cleans it up."
-				>
-					Integrated
-				</Badge>
-			) : (
-				<Badge
-					variant="lightGray"
-					className={styles.statePill}
-					title="Branching off here; not part of the target branch yet."
-				>
-					In workspace
-				</Badge>
-			)}
-		</Row>
-	);
-};
-
-type CommitRunItem = Exclude<UpstreamListItem, UpstreamBranchItem>;
-
-type ItemGroup =
-	/** Adjacent segments of one stack share a card, like on the workspace tab. */
-	| { branches: Array<UpstreamBranchItem>; rows?: undefined }
-	| { branches?: undefined; rows: Array<CommitRunItem> };
+	glyph,
+}) => (
+	<Row interactive={false}>
+		<GraphSegment glyph={glyph} status="LocalOnly" />
+		<RowLabelContainer>
+			<RowLabel heading singleLine title={item.name}>
+				{item.name}
+			</RowLabel>
+		</RowLabelContainer>
+	</Row>
+);
 
 /**
- * Split the flat listing into stack cards and the bare commit runs flowing
- * between them, so the workspace's branches read as their own objects rather
- * than part of the target history.
+ * A toggle for the shared history between two fork points: target commits the
+ * workspace already has, whose count measures how much older one stack's base
+ * is than the one above it.
  */
-const groupItems = (items: Array<UpstreamListItem>): Array<ItemGroup> => {
-	const groups: Array<ItemGroup> = [];
-	for (const item of items) {
-		const last = groups.at(-1);
-		if (item.type === "branch") {
-			if (last?.branches !== undefined && last.branches[0]?.stackKey === item.stackKey)
-				last.branches.push(item);
-			else groups.push({ branches: [item] });
-			continue;
-		}
-		if (last?.rows !== undefined) last.rows.push(item);
-		else groups.push({ rows: [item] });
-	}
-	return groups;
-};
-
-const groupKey = (rows: Array<CommitRunItem>): string => {
-	const first = rows[0];
-	if (first === undefined) return "empty";
-	switch (first.type) {
-		case "commit":
-			return first.commit.id;
-		case "expander":
-			return `expander-${first.segmentId}`;
-		case "more":
-			return "more";
-		default:
-			return first satisfies never;
-	}
-};
-
 const SegmentExpanderRow: FC<{
 	projectId: string;
 	segmentId: string;
-	count: number | null;
+	count: number;
 	expanded: boolean;
 }> = ({ projectId, segmentId, count, expanded }) => {
 	const dispatch = useAppDispatch();
-	const incoming = segmentId === INCOMING_SEGMENT_ID;
 
 	return (
-		<button
-			type="button"
-			// The tree's active-descendant navigation skips expanders, but as
-			// direct children of the tree they still need the treeitem role for
-			// the structure to stay valid.
-			role="treeitem"
-			aria-expanded={expanded}
-			className={classes("text-13", rowStyles.fadedText, styles.expanderRow)}
-			title={
-				incoming
-					? "The commits an update would bring into the workspace."
-					: count !== null
-						? "Shared target commits between these fork points."
-						: "Target history below this fork point."
-			}
-			onClick={() =>
-				dispatch(
-					incoming
-						? projectSlice.actions.toggleUpstreamIncoming({ projectId })
-						: projectSlice.actions.toggleUpstreamSegment({ projectId, segmentId }),
-				)
-			}
-		>
-			⋮{" "}
-			{expanded
-				? "hide"
-				: count !== null
-					? `${count} ${count === 1 ? "commit" : "commits"}`
-					: "older commits…"}
-		</button>
+		<div className={styles.expanderRow}>
+			<div className={styles.expanderRail}>
+				{/* The stacked rings stand in for the commits while they are folded
+				    away; once they are on screen the rail just runs past the toggle. */}
+				<GraphSegment
+					className={styles.expanderGlyph}
+					glyph={expanded ? "parent" : "group"}
+					status="LocalOnly"
+				/>
+				<GraphSegment className={styles.railStub} glyph="parent" status="LocalOnly" />
+			</div>
+			<Button
+				aria-expanded={expanded}
+				className={classes(
+					// Filled while the run it reveals is on screen, so the toggle
+					// reads as pressed rather than as another thing to click.
+					getButtonClassName({ variant: expanded ? "gray" : "outline", size: "small" }),
+					styles.expanderButton,
+				)}
+				title="Target commits your workspace already has, between these two fork points."
+				onClick={() =>
+					dispatch(projectSlice.actions.toggleUpstreamSegment({ projectId, segmentId }))
+				}
+			>
+				{expanded ? "hide commits" : `${count} shared ${count === 1 ? "commit" : "commits"}`}
+			</Button>
+		</div>
 	);
 };
 
-const OlderCommitsMoreRow: FC<{ projectId: string }> = ({ projectId }) => {
-	// Shares the pages the outline hook merges into the list; this instance
-	// only drives fetching. Only rendered while the older segment is expanded.
-	const { fetchNextPage, isFetching, isError } = useOlderTargetCommits(projectId, true);
+/**
+ * The prose and the button that act on the whole target section, drawn inside
+ * the card against the target rail so they read as belonging to the commits
+ * above them rather than to the panel.
+ */
+const UpdateBlock: FC<{
+	incomingCount: number;
+	hasIntegrated: boolean;
+	canUpdate: boolean;
+	isUpdatePending: boolean;
+	onUpdateWorkspace: () => void;
+}> = ({ incomingCount, hasIntegrated, canUpdate, isUpdatePending, onUpdateWorkspace }) => {
+	const messageClassName = classes("text-12", "text-body", rowStyles.fadedText);
 
 	return (
-		<button
-			type="button"
-			// Same as the segment expanders: a treeitem in structure, though
-			// active-descendant navigation skips it.
-			role="treeitem"
-			className={classes("text-13", rowStyles.fadedText, styles.expanderRow)}
-			disabled={isFetching}
-			onClick={() => void fetchNextPage()}
-		>
-			{isFetching ? (
-				<Icon name="spinner" />
-			) : isError ? (
-				"⋮ couldn't load older commits — retry"
-			) : (
-				"⋮ show more…"
-			)}
-		</button>
+		<div className={styles.updateBlock}>
+			<GraphSegment glyph="parent" status="Upstream" />
+			<div className={styles.updateBlockBody}>
+				{incomingCount > 0 ? (
+					<p className={messageClassName}>
+						Your workspace is {incomingCount} {incomingCount === 1 ? "commit" : "commits"} behind
+						the upstream.
+						<br />
+						Rebase to update all stacks at once.
+					</p>
+				) : hasIntegrated ? (
+					<p className={messageClassName}>
+						Integrated branches can be cleaned up by updating the workspace.
+					</p>
+				) : (
+					<p className={messageClassName}>Your workspace is up to date.</p>
+				)}
+				<button
+					type="button"
+					className={getButtonClassName({ variant: "gray" })}
+					disabled={!canUpdate}
+					onClick={onUpdateWorkspace}
+				>
+					{isUpdatePending
+						? "Updating…"
+						: incomingCount > 0
+							? "Rebase all stacks"
+							: "Update workspace"}
+				</button>
+			</div>
+		</div>
 	);
+};
+
+/**
+ * A clipped stub carrying a rail past the last row of its region, so the graph
+ * runs out into the space below rather than stopping dead at the content edge.
+ * The target's stub bridges the divider; the workspace's supplies the card's
+ * floor.
+ */
+const RailTail: FC<{ status: GraphSegmentStatus; bridge?: boolean }> = ({ status, bridge }) => (
+	<div aria-hidden className={classes(styles.railTail, bridge && styles.railTailBridge)}>
+		<GraphSegment glyph="parent" status={status} />
+	</div>
+);
+
+/**
+ * The air closing an expanded shared-history run, answering the space its
+ * toggle gets above it so the run reads as one block rather than as commits
+ * crowding the branch below.
+ */
+const RunTail: FC = () => (
+	<div aria-hidden className={styles.runTail}>
+		<GraphSegment className={styles.railStub} glyph="parent" status="LocalOnly" />
+	</div>
+);
+
+const listItem = (
+	projectId: string,
+	item: UpstreamListItem,
+	/** The first branch row opens the workspace rail; the rest join it. */
+	isFirstBranch: boolean,
+) => {
+	switch (item.type) {
+		case "commit":
+			return <TargetCommitRow key={item.commit.id} projectId={projectId} item={item} />;
+		case "branch":
+			return (
+				<UpstreamBranchRow
+					key={item.name}
+					item={item}
+					glyph={isFirstBranch ? "forkRight" : "joinRight"}
+				/>
+			);
+		case "expander":
+			return (
+				<SegmentExpanderRow
+					key={`expander-${item.segmentId}`}
+					projectId={projectId}
+					segmentId={item.segmentId}
+					count={item.count}
+					expanded={item.expanded}
+				/>
+			);
+		default:
+			return item satisfies never;
+	}
 };
 
 export const UpstreamList: FC<
@@ -331,8 +320,16 @@ export const UpstreamList: FC<
 	const dispatch = useAppDispatch();
 	// Derived once in WorkspacePage and passed down, so the rendered list and the
 	// navigation index that resolves selection are the same object.
-	const { items, targetLabel, incomingCount, hasIntegrated, navigationIndex, isPending, isError } =
-		outline;
+	const {
+		items,
+		incomingItemCount,
+		targetLabel,
+		incomingCount,
+		hasIntegrated,
+		navigationIndex,
+		isPending,
+		isError,
+	} = outline;
 
 	const selection = useAppSelector((state) =>
 		projectSlice.selectors.selectSelectionUpstream(state, projectId, navigationIndex),
@@ -364,111 +361,83 @@ export const UpstreamList: FC<
 	const hasIncoming = incomingCount > 0;
 	const canUpdate = canUpdateWorkspace && (hasIncoming || hasIntegrated);
 
+	const targetItems = items.slice(0, incomingItemCount);
+	const workspaceItems = items.slice(incomingItemCount);
+	const firstBranch = workspaceItems.find((item) => item.type === "branch");
+
 	return (
 		<div {...restProps} className={classes(restProps.className, styles.container)}>
 			<Scroller className={styles.listArea} viewportClassName={styles.list}>
-				<h4 id={headingId} className={classes("text-13", styles.heading)}>
-					<span>
-						Incoming changes
-						{targetLabel !== null && (
-							<span className={rowStyles.fadedText}> from {targetLabel}</span>
-						)}
-					</span>
-					{hasIncoming && <Badge variant="fillGray">{incomingCount}</Badge>}
+				<h4 id={headingId} className={styles.srOnly}>
+					Incoming changes{targetLabel !== null && <> from {targetLabel}</>}
 				</h4>
 
-				{isError && (
-					<p className={classes("text-13", styles.heading)}>Unable to load incoming commits.</p>
-				)}
-
-				{!isError && isPending && items.length === 0 && (
-					<p className={classes("text-13", styles.heading)}>Loading incoming commits…</p>
-				)}
-
-				{!isError && !isPending && targetLabel === null && (
-					<p className={classes("text-13", styles.heading)}>
-						No target branch is configured for this project.
-					</p>
-				)}
-
-				{!isError && !isPending && targetLabel !== null && !hasIncoming && (
-					<p className={classes("text-13", styles.heading)}>Your workspace is up to date.</p>
-				)}
-
+				{/* The whole outline is one card: the target and the workspace's
+				    branches are two regions of a single graph, divided rather than
+				    boxed apart. */}
 				<div
 					tabIndex={0}
 					role="tree"
 					aria-labelledby={headingId}
 					aria-activedescendant={selection ? treeItemId(selection) : undefined}
 					data-selection-scope={"outline" satisfies SelectionScope}
-					className={styles.tree}
+					className={styles.card}
 					onFocus={() =>
 						dispatch(projectSlice.actions.setDetailsSelectionScope({ projectId, scope: "outline" }))
 					}
 					ref={useMergedRefs(hotkeysRef, useAutofocusSelectionScope())}
 				>
-					{groupItems(items).map((group) =>
-						group.branches !== undefined ? (
-							// The card surface matches the workspace tab's stack cards: the
-							// workspace's own stacks are carded objects, target history
-							// flows bare around them.
-							// oxlint-disable-next-line jsx-a11y/prefer-tag-over-role -- A stack is an ARIA group of tree items.
-							<div key={group.branches[0]?.name ?? "stack"} role="group" className={styles.card}>
-								{group.branches.map((branch) => (
-									<UpstreamBranchRow key={branch.name} projectId={projectId} item={branch} />
-								))}
-							</div>
-						) : (
-							// oxlint-disable-next-line jsx-a11y/prefer-tag-over-role -- A commit run is an ARIA group of tree items.
-							<div key={groupKey(group.rows)} role="group" className={styles.commitRun}>
-								{group.rows.map((item) =>
-									item.type === "commit" ? (
-										<TargetCommitRow key={item.commit.id} projectId={projectId} item={item} />
-									) : item.type === "expander" ? (
-										<SegmentExpanderRow
-											key={`expander-${item.segmentId}`}
-											projectId={projectId}
-											segmentId={item.segmentId}
-											count={item.count}
-											expanded={item.expanded}
-										/>
-									) : (
-										<OlderCommitsMoreRow key="more" projectId={projectId} />
-									),
-								)}
-							</div>
-						),
+					{targetLabel !== null && <TargetHeadRow label={targetLabel} />}
+
+					{isError && (
+						<p className={classes("text-13", styles.message)}>Unable to load incoming commits.</p>
 					)}
+
+					{!isError && isPending && items.length === 0 && (
+						<p className={classes("text-13", styles.message)}>Loading incoming commits…</p>
+					)}
+
+					{!isError && !isPending && targetLabel === null && (
+						<p className={classes("text-13", styles.message)}>
+							No target branch is configured for this project.
+						</p>
+					)}
+
+					{targetItems.map((item) => listItem(projectId, item, false))}
+
+					{!isError && !isPending && targetLabel !== null && (
+						<UpdateBlock
+							incomingCount={incomingCount}
+							hasIntegrated={hasIntegrated}
+							canUpdate={canUpdate}
+							isUpdatePending={isUpdatePending}
+							onUpdateWorkspace={onUpdateWorkspace}
+						/>
+					)}
+
+					{targetLabel !== null && <RailTail status="Upstream" bridge />}
+
+					{workspaceItems.length > 0 && <div role="none" className={styles.divider} />}
+
+					{workspaceItems.flatMap((item, index) => {
+						const row = listItem(projectId, item, item === firstBranch);
+						// Commits only appear here as the body of an expanded run, so
+						// the last one before anything else is where a run closes.
+						const next = workspaceItems[index + 1];
+						return item.type === "commit" && next !== undefined && next.type !== "commit"
+							? [row, <RunTail key={`${item.commit.id}-tail`} />]
+							: [row];
+					})}
+
+					{workspaceItems.length > 0 && <RailTail status="LocalOnly" />}
 				</div>
+
 				{outline.truncated && (
-					<p className={classes("text-13", rowStyles.fadedText, styles.heading)}>
+					<p className={classes("text-13", rowStyles.fadedText, styles.message)}>
 						Only the most recent target history is shown.
 					</p>
 				)}
 			</Scroller>
-
-			<footer className={styles.footer}>
-				{hasIncoming ? (
-					<p className={classes("text-13", styles.footerText)}>
-						Your workspace is {incomingCount} {incomingCount === 1 ? "commit" : "commits"} behind
-						the upstream. Update to rebase all stacks at once.
-					</p>
-				) : (
-					hasIntegrated && (
-						<p className={classes("text-13", styles.footerText)}>
-							Integrated branches can be cleaned up by updating the workspace.
-						</p>
-					)
-				)}
-				<button
-					type="button"
-					className={getButtonClassName({ variant: "pop" })}
-					disabled={!canUpdate}
-					onClick={onUpdateWorkspace}
-				>
-					{isUpdatePending ? "Updating…" : "Update workspace"}
-				</button>
-			</footer>
 		</div>
 	);
 };

--- a/apps/lite/ui/src/routes/project/$id/workspace/useUpstreamOutline.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/useUpstreamOutline.ts
@@ -1,27 +1,10 @@
-import {
-	headInfoQueryOptions,
-	olderTargetCommitsInfiniteQueryOptions,
-	workspaceTargetCommitsQueryOptions,
-} from "#ui/api/queries.ts";
-import { branchOperand, commitOperand, operandIdentityKey, type Operand } from "#ui/operands.ts";
+import { headInfoQueryOptions, workspaceTargetCommitsQueryOptions } from "#ui/api/queries.ts";
+import { commitOperand, operandIdentityKey, type Operand } from "#ui/operands.ts";
 import { projectSlice } from "#ui/projects/state.ts";
 import { useAppSelector } from "#ui/store.ts";
 import { buildIndexByKey, type NavigationIndex } from "#ui/workspace/navigation-index.ts";
 import type { RefInfo, TargetCommit } from "@gitbutler/but-sdk";
-import { useInfiniteQuery, useQueries, useQuery } from "@tanstack/react-query";
-
-/**
- * The expansion key of the shared-history segment below the deepest fork
- * point, whose contents page through older target history.
- */
-const OLDER_SEGMENT_ID = "older";
-
-/**
- * The expansion key of the incoming-commits run. Unlike the shared-history
- * segments it shows by default, and hiding it keeps the integrated branch
- * rows attached to it visible.
- */
-export const INCOMING_SEGMENT_ID = "incoming";
+import { useQueries } from "@tanstack/react-query";
 
 // Stable empties for the inactive-tab result, so consumers' identities do not
 // churn while the tab is hidden.
@@ -56,9 +39,8 @@ export type UpstreamCommitItem = TargetCommit & { type: "commit" };
 export type UpstreamBranchItem = {
 	type: "branch";
 	name: string;
-	refBytes: Array<number>;
+	/** Matched against a landed review to place the branch; never displayed. */
 	prNumber: number | null;
-	commitCount: number;
 	integrated: boolean;
 	/**
 	 * Identifies the stack the branch belongs to, so adjacent segments of one
@@ -71,16 +53,20 @@ export type UpstreamListItem =
 	| UpstreamCommitItem
 	| UpstreamBranchItem
 	/**
-	 * A toggle revealing a shared-history segment: the target commits between
-	 * two fork points (`count` known), or — below the deepest fork point —
-	 * older target history paged on demand (`count` null).
+	 * A toggle revealing the shared history between two fork points: target
+	 * commits the workspace already has, whose count measures how much older
+	 * one stack's base is than the one above it.
 	 */
-	| { type: "expander"; segmentId: string; count: number | null; expanded: boolean }
-	/** Fetches the next page of older target history. */
-	| { type: "more" };
+	| { type: "expander"; segmentId: string; count: number; expanded: boolean };
 
 export type UpstreamOutline = {
 	items: Array<UpstreamListItem>;
+	/**
+	 * How many leading items are incoming commits. The list draws its divider
+	 * here, so everything after it is the workspace's own branches and the
+	 * shared history between them.
+	 */
+	incomingItemCount: number;
 	/** The target's display label, like `origin/main`, or `null` without a target. */
 	targetLabel: string | null;
 	/**
@@ -122,9 +108,7 @@ const workspaceStackBranches = (headInfo: RefInfo | undefined): Array<WorkspaceS
 							{
 								type: "branch",
 								name: segment.refName.displayName,
-								refBytes: segment.refName.fullNameBytes,
 								prNumber: segment.metadata?.review.pullRequest ?? null,
-								commitCount: segment.commits.length,
 								integrated: segment.pushStatus === "integrated",
 								stackKey,
 							},
@@ -153,14 +137,17 @@ const workspaceStackBranches = (headInfo: RefInfo | undefined): Array<WorkspaceS
  * below the boundary, the previous workspace update would have removed it —
  * so it sits at the bottom of that range, right above the boundary. Fork
  * points missing from the (possibly clipped) list trail at the end.
+ *
+ * Returns the boundary along with the items: the walk crosses it exactly once,
+ * and it cannot be recovered from the items afterwards, because an integrated
+ * branch attached to the last incoming commit and one parked at the boundary
+ * land in the same place.
  */
 const buildItems = (
 	commits: Array<UpstreamCommitItem>,
 	stacks: Array<WorkspaceStackBranches>,
 	expanded: Record<string, true>,
-	incoming: { count: number; hidden: boolean },
-	older: { available: boolean; commits: Array<UpstreamCommitItem>; showMore: boolean },
-): Array<UpstreamListItem> => {
+): { items: Array<UpstreamListItem>; incomingItemCount: number } => {
 	const stubsByBase = new Map<string, Array<UpstreamBranchItem>>();
 	const strandedStubs: Array<UpstreamBranchItem> = [];
 	for (const stack of stacks) {
@@ -194,21 +181,12 @@ const buildItems = (
 	const unmatchedIntegrated = () => allIntegrated.filter((branch) => !matched.has(branch));
 
 	const items: Array<UpstreamListItem> = [];
-	// The incoming commits are always the prefix of the walk, so their
-	// expander leads the list. Hiding them keeps the integrated branch rows
-	// they landed visible below.
-	if (incoming.count > 0) {
-		items.push({
-			type: "expander",
-			segmentId: INCOMING_SEGMENT_ID,
-			count: incoming.count,
-			expanded: !incoming.hidden,
-		});
-	}
 
 	// Commits already in the workspace are not shown outright — the tab is
-	// about what's upstream — but each run of them between fork points becomes
-	// an expandable shared-history segment.
+	// about what's upstream — but each run of them *between* fork points
+	// becomes an expandable shared-history segment. The run trailing the
+	// deepest fork point has no fork point below it to measure against, so it
+	// is dropped rather than flushed: target history simply continues there.
 	let gap: Array<UpstreamCommitItem> = [];
 	const flushGap = () => {
 		const first = gap[0];
@@ -221,6 +199,9 @@ const buildItems = (
 	};
 
 	let boundarySeen = false;
+	// Everything pushed before the walk crosses into the workspace is the
+	// target section, integrated branches attached to those commits included.
+	let incomingItemCount = 0;
 	for (const commit of commits) {
 		const attachedStubs = stubsByBase.get(commit.commit.id);
 		if (attachedStubs !== undefined) stubsByBase.delete(commit.commit.id);
@@ -228,59 +209,26 @@ const buildItems = (
 
 		if (commit.inWorkspace && !boundarySeen) {
 			boundarySeen = true;
+			incomingItemCount = items.length;
 			items.push(...unmatchedIntegrated());
 		}
 		if (attachedStubs !== undefined || landed !== undefined) flushGap();
 		if (attachedStubs !== undefined) items.push(...attachedStubs);
-		if (!commit.inWorkspace) {
-			if (!incoming.hidden) items.push(commit);
-		} else {
-			gap.push(commit);
-		}
+		if (commit.inWorkspace) gap.push(commit);
+		else items.push(commit);
 		if (landed !== undefined) items.push(...landed);
 	}
+	// Without a boundary commit in the list the walk never left the target, so
+	// everything listed so far belongs to it.
+	if (!boundarySeen) incomingItemCount = items.length;
+
 	for (const stranded of stubsByBase.values()) items.push(...stranded);
 	items.push(...strandedStubs);
 	// Without a boundary commit in the list there is no anchor; keep the
 	// integrated branches visible at the end instead of dropping them.
 	if (!boundarySeen) items.push(...unmatchedIntegrated());
 
-	// The trailing shared history below the deepest fork point continues into
-	// older target commits, paged on demand through the same expander.
-	if (commits.length > 0 && older.available) {
-		const olderExpanded = expanded[OLDER_SEGMENT_ID] === true;
-		items.push({
-			type: "expander",
-			segmentId: OLDER_SEGMENT_ID,
-			count: null,
-			expanded: olderExpanded,
-		});
-		if (olderExpanded) {
-			items.push(...gap);
-			items.push(...older.commits);
-			if (older.showMore) items.push({ type: "more" });
-		}
-	}
-
-	return items;
-};
-
-/**
- * The pages of target history older than the deepest fork point, continued
- * below the last commit of the base listing with a commit-id cursor. Shared
- * by the outline (which merges the pages into the items) and the show-more
- * row (which drives fetching) so the two cannot disagree about the query.
- */
-export const useOlderTargetCommits = (projectId: string, enabled: boolean) => {
-	const { data: olderFrom = null } = useQuery({
-		...workspaceTargetCommitsQueryOptions(projectId),
-		enabled,
-		select: (page) => (page.hasMore ? null : (page.commits.at(-1)?.commit.id ?? null)),
-	});
-	return useInfiniteQuery({
-		...olderTargetCommitsInfiniteQueryOptions(projectId, olderFrom),
-		enabled,
-	});
+	return { items, incomingItemCount };
 };
 
 /**
@@ -297,20 +245,11 @@ export const useUpstreamOutline = (projectId: string): UpstreamOutline => {
 	const expandedSegments = useAppSelector((state) =>
 		projectSlice.selectors.selectExpandedUpstreamSegments(state, projectId),
 	);
-	const incomingHidden = useAppSelector((state) =>
-		projectSlice.selectors.selectUpstreamIncomingHidden(state, projectId),
-	);
-
-	const olderExpanded = expandedSegments[OLDER_SEGMENT_ID] === true;
-	const olderQuery = useOlderTargetCommits(projectId, active && olderExpanded);
-	const olderPages = olderQuery.data;
-	const olderShowMore = olderExpanded && (olderPages === undefined || olderQuery.hasNextPage);
-
 	// The whole derivation lives in `combine` so its result keeps a stable
 	// identity: react-query caches it on the query results and the `combine`
 	// reference — which itself only changes when a captured input like the
-	// expansion map or a fetched page does — so the items and navigation index
-	// are not rebuilt on unrelated renders.
+	// expansion map does — so the items and navigation index are not rebuilt
+	// on unrelated renders.
 	return useQueries({
 		queries: [
 			{ ...workspaceTargetCommitsQueryOptions(projectId), enabled: active },
@@ -337,6 +276,7 @@ export const useUpstreamOutline = (projectId: string): UpstreamOutline => {
 			if (!active) {
 				return {
 					items: noItems,
+					incomingItemCount: 0,
 					targetLabel,
 					incomingCount,
 					hasIntegrated: false,
@@ -349,17 +289,7 @@ export const useUpstreamOutline = (projectId: string): UpstreamOutline => {
 
 			const stacks = workspaceStackBranches(headInfo);
 			const commits = targetCommits.map(asItem);
-			const items = buildItems(
-				commits,
-				stacks,
-				expandedSegments,
-				{ count: incomingCount, hidden: incomingHidden },
-				{
-					available: targetPage?.hasMore === false,
-					commits: olderPages?.pages.flatMap((page) => page.commits).map(asItem) ?? [],
-					showMore: olderShowMore,
-				},
-			);
+			const { items, incomingItemCount } = buildItems(commits, stacks, expandedSegments);
 
 			const navigationItems = items.flatMap((item): Array<Operand> => {
 				switch (item.type) {
@@ -372,10 +302,10 @@ export const useUpstreamOutline = (projectId: string): UpstreamOutline => {
 								changeId: item.commit.changeId ?? item.commit.id,
 							}),
 						];
+					// Branch rows carry only their name and are not selectable, so
+					// they stay out of the navigation index.
 					case "branch":
-						return [branchOperand({ branchRef: item.refBytes })];
 					case "expander":
-					case "more":
 						return [];
 					default:
 						return item satisfies never;
@@ -384,6 +314,7 @@ export const useUpstreamOutline = (projectId: string): UpstreamOutline => {
 
 			return {
 				items,
+				incomingItemCount,
 				targetLabel,
 				incomingCount,
 				hasIntegrated: stacks.some((stack) => stack.integrated.length > 0),


### PR DESCRIPTION
Before:
<img width="434" height="888" alt="Screenshot 2026-08-09 at 15 20 34" src="https://github.com/user-attachments/assets/98b6e9ea-bd72-40b9-8a58-56fae9685650" />

After:
<img width="451" height="903" alt="Screenshot 2026-08-09 at 15 21 14" src="https://github.com/user-attachments/assets/8e311132-5a8e-4188-bdc9-4511b543323d" />

---

### Note:
It's not final design just polishing up @krlvi first implementation. 

---

### Changes

Reworks the Upstream tab in the lite app:

- Redesign the Upstream tab layout and rows.
- Make the gap between branches in a stack smaller.
- Mark integrated branches on the rail and spell out "integrated" on a second line, since the rail colour alone is easy to miss.
- Tighten the expander glyph air from 8px to 4px.