### PR TITLE
Make the minimap read like a document

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -130,7 +130,7 @@ import {
 	hunkOperandIdentityKey,
 } from "./diff-view.ts";
 import { DiffMinimap } from "./DiffMinimap.tsx";
-import { getMinimapFiles, measureWrapColumns } from "./diff-minimap.ts";
+import { getMinimapFiles, measureWrapColumns, type MinimapSelection } from "./diff-minimap.ts";
 
 export type DiffViewerHandle = CodeViewHandle<Annotation>;
 
@@ -949,6 +949,26 @@ const Diff: FC<{
 
 	const diffView = withAnnotations(diffViewSansAnno, annotationsByPath);
 
+	// The diff panel resolves this selection for the viewer; the ruler wants it in
+	// file line numbers, which is what the hunk's own range already holds.
+	const diffSelection = useAppSelector((state) =>
+		projectSlice.selectors.selectSelectionDiff(state, projectId, diffViewSansAnno.navigationIndex),
+	);
+	const minimapSelection = useMemo((): MinimapSelection | null => {
+		if (!diffSelection) return null;
+
+		const key = hunkOperandIdentityKey(diffSelection);
+		const selected = diffViewSansAnno.hunkByKey.get(key)?.selectedLines;
+		if (!selected) return null;
+
+		return {
+			itemId: selected.id,
+			side: selected.range.side ?? "additions",
+			start: selected.range.start,
+			end: selected.range.end,
+		};
+	}, [diffSelection, diffViewSansAnno]);
+
 	const activateFile = (selection: string) => {
 		onPassiveFileSelection(selection);
 
@@ -1200,7 +1220,13 @@ const Diff: FC<{
 							didScrollToViaFileRef={didScrollToViaFileRef}
 						/>
 
-						<DiffMinimap viewerRef={viewerRef} files={minimapFiles} diffStyle={diffStyle} />
+						<DiffMinimap
+							viewerRef={viewerRef}
+							files={minimapFiles}
+							diffStyle={diffStyle}
+							annotationsByPath={annotationsByPath}
+							selection={minimapSelection}
+						/>
 					</div>
 				</Panel>
 			</Group>

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -130,7 +130,7 @@ import {
 	hunkOperandIdentityKey,
 } from "./diff-view.ts";
 import { DiffMinimap } from "./DiffMinimap.tsx";
-import { getMinimapFiles } from "./diff-minimap.ts";
+import { getMinimapFiles, measureWrapColumns } from "./diff-minimap.ts";
 
 export type DiffViewerHandle = CodeViewHandle<Annotation>;
 
@@ -987,6 +987,11 @@ const Diff: FC<{
 
 	const diffContentsEl = useRef<HTMLElement | null>(null);
 	const [canUseSplitDiff, setCanUseSplitDiff] = useState<boolean | undefined>();
+	const [wrapColumns, setWrapColumns] = useState<number | null>(null);
+
+	// Wrapping stretches a long line over several rows, which the minimap has to
+	// model or its marks drift down the file it is mapping.
+	const wraps = (diffSettings?.diffOverflow ?? defaultSettings.diffOverflow) === "wrap";
 
 	// Split and unified lay hunks out differently, so the minimap has to model
 	// whichever style the viewer is actually rendering.
@@ -1012,8 +1017,9 @@ const Diff: FC<{
 					shownIndex < 0 ? treeChangeDiffs : treeChangeDiffs.slice(shownIndex, shownIndex + 1),
 				diffStyle,
 				tabSize,
+				wrapColumns,
 			}),
-		[shownIndex, fileParent, changes, treeChangeDiffs, diffStyle, tabSize],
+		[shownIndex, fileParent, changes, treeChangeDiffs, diffStyle, tabSize, wrapColumns],
 	);
 
 	useHotkeys([
@@ -1032,21 +1038,34 @@ const Diff: FC<{
 		},
 	]);
 
+	// Both of these are facts about the rendered pane rather than about the diff,
+	// so they are measured on the same resize rather than derived.
 	useLayoutEffect(() => {
 		const el = diffContentsEl.current;
 		if (!el) return;
 
-		const measureCanUseSplitDiff = () => el.getBoundingClientRect().width >= 700;
+		const measure = () => {
+			setCanUseSplitDiff(el.getBoundingClientRect().width >= 700);
 
-		setCanUseSplitDiff(measureCanUseSplitDiff());
+			if (!wraps) {
+				setWrapColumns(null);
+				return;
+			}
 
-		const resizeObserver = new ResizeObserver(() => {
-			setCanUseSplitDiff(measureCanUseSplitDiff());
-		});
+			// Held only once it can be read: a resize that lands between renders would
+			// otherwise drop the count and unwrap the whole model for a frame.
+			const viewer = viewerRef.current?.getInstance();
+			const columns = viewer ? measureWrapColumns(viewer) : null;
+			if (columns !== null) setWrapColumns(columns);
+		};
+
+		measure();
+
+		const resizeObserver = new ResizeObserver(measure);
 		resizeObserver.observe(el);
 
 		return () => resizeObserver.disconnect();
-	}, [diffContentsEl]);
+	}, [diffContentsEl, viewerRef, wraps, diffViewSansAnno]);
 
 	const layoutId = `project=${projectId}:details`;
 	const panelIds: Array<PanelId> = filesVisible ? ["files-panel", "diff-panel"] : ["diff-panel"];

--- a/apps/lite/ui/src/routes/project/$id/workspace/DiffMinimap.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DiffMinimap.module.css
@@ -27,6 +27,18 @@
 	initial-value: transparent;
 }
 
+@property --minimap-pin {
+	syntax: "<color>";
+	inherits: true;
+	initial-value: transparent;
+}
+
+@property --minimap-selection {
+	syntax: "<color>";
+	inherits: true;
+	initial-value: transparent;
+}
+
 .minimap {
 	/* Mixed towards the background the way the diff tints its own changed rows,
 	   just further, since a mark can be a single pixel tall. */
@@ -39,6 +51,12 @@
 	   the marks it crosses instead of tinting with them. Stronger than the context
 	   it now runs through, which is grey in the same way. */
 	--minimap-file-rule: color-mix(in srgb, var(--fill-gray-bg) 26%, var(--bg-1));
+	/* The one saturated thing on the ruler, since a comment is the only mark here
+	   that someone put there deliberately. */
+	--minimap-pin: var(--fill-pop-bg);
+	/* Behind the marks it covers rather than over them, so a selected hunk still
+	   reads as added or removed. */
+	--minimap-selection: color-mix(in srgb, var(--fill-pop-bg) 16%, transparent);
 
 	--minimap-view-min: 14px;
 	/* Clamped here rather than in the geometry, which works in fractions and has

--- a/apps/lite/ui/src/routes/project/$id/workspace/DiffMinimap.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DiffMinimap.module.css
@@ -116,7 +116,7 @@
 	/* Clear the rule itself, so it runs unbroken behind the badge. */
 	margin-top: 1px;
 	background: linear-gradient(to bottom right, var(--bg-1) 50%, transparent 50%);
-	pointer-events: none;
+	cursor: pointer;
 
 	& > svg {
 		width: 14px;

--- a/apps/lite/ui/src/routes/project/$id/workspace/DiffMinimap.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DiffMinimap.module.css
@@ -15,6 +15,12 @@
 	initial-value: transparent;
 }
 
+@property --minimap-context {
+	syntax: "<color>";
+	inherits: true;
+	initial-value: transparent;
+}
+
 @property --minimap-file-rule {
 	syntax: "<color>";
 	inherits: true;
@@ -26,9 +32,13 @@
 	   just further, since a mark can be a single pixel tall. */
 	--minimap-additions: color-mix(in lab, var(--bg-1) 62%, var(--fill-safe-bg));
 	--minimap-deletions: color-mix(in lab, var(--bg-1) 62%, var(--fill-danger-bg));
+	/* Recessive enough to read as the page the changes are written on, not as a
+	   third kind of change. */
+	--minimap-context: color-mix(in lab, var(--bg-1) 88%, var(--fill-gray-bg));
 	/* Mixed into the background rather than towards transparent, so a rule covers
-	   the marks it crosses instead of tinting with them. */
-	--minimap-file-rule: color-mix(in srgb, var(--fill-gray-bg) 14%, var(--bg-1));
+	   the marks it crosses instead of tinting with them. Stronger than the context
+	   it now runs through, which is grey in the same way. */
+	--minimap-file-rule: color-mix(in srgb, var(--fill-gray-bg) 26%, var(--bg-1));
 
 	--minimap-view-min: 14px;
 	/* Clamped here rather than in the geometry, which works in fractions and has

--- a/apps/lite/ui/src/routes/project/$id/workspace/DiffMinimap.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DiffMinimap.tsx
@@ -226,15 +226,28 @@ export const DiffMinimap: FC<{
 			<div ref={markerRef} className={styles.marker} />
 
 			{badges.map(({ index, top }) => {
-				const path = files[index]?.path;
+				const file = files[index];
 
 				return (
-					path !== undefined && (
+					file !== undefined && (
 						<FileIcon
-							key={path}
-							fileName={path}
+							key={file.path}
+							fileName={file.path}
 							className={styles.badge}
 							style={{ top: `${top}px` }}
+							// Pressing the track puts the point you pressed in the middle of
+							// the viewport; a badge is a file rather than a position, so it
+							// opens that file at the top instead. Kept off the ruler's own
+							// handler so it doesn't also start a drag.
+							onPointerDown={(event) => {
+								event.stopPropagation();
+								viewerRef.current?.getInstance()?.scrollTo({
+									type: "item",
+									id: file.itemId,
+									align: "start",
+									behavior: "instant",
+								});
+							}}
 						/>
 					)
 				);

--- a/apps/lite/ui/src/routes/project/$id/workspace/DiffMinimap.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DiffMinimap.tsx
@@ -1,3 +1,4 @@
+import type { LocalAnnotationsByPath } from "#ui/annotation.ts";
 import { FileIcon } from "#ui/components/FileIcon.tsx";
 import type { GUISettings } from "#electron/settings.ts";
 import type { CodeViewHandle } from "@pierre/diffs/react";
@@ -12,9 +13,11 @@ import {
 import type { Annotation } from "./diff-view.ts";
 import {
 	getMinimapGeometry,
+	getMinimapOverlays,
 	getMinimapViewport,
 	type MinimapFile,
 	type MinimapGeometry,
+	type MinimapSelection,
 	scrollMinimapTo,
 } from "./diff-minimap.ts";
 import { type MinimapBadge, paintMinimap } from "./diff-minimap-canvas.ts";
@@ -34,13 +37,15 @@ export const DiffMinimap: FC<{
 	viewerRef: RefObject<CodeViewHandle<Annotation> | null>;
 	files: Array<MinimapFile>;
 	diffStyle: GUISettings["diffStyle"];
-}> = ({ viewerRef, files, diffStyle }) => {
+	annotationsByPath: LocalAnnotationsByPath;
+	selection: MinimapSelection | null;
+}> = ({ viewerRef, files, diffStyle, annotationsByPath, selection }) => {
 	const rulerRef = useRef<HTMLDivElement>(null);
 	const canvasRef = useRef<HTMLCanvasElement>(null);
 	const markerRef = useRef<HTMLDivElement>(null);
 	/** Where the pointer took hold of the thumb, as a fraction of the content. */
 	const grabRef = useRef(0);
-	const dataRef = useRef({ files, diffStyle });
+	const dataRef = useRef({ files, diffStyle, annotationsByPath, selection });
 	const geometryRef = useRef<MinimapGeometry | null>(null);
 	const resyncRef = useRef<(() => void) | null>(null);
 	const [navigable, setNavigable] = useState(false);
@@ -57,7 +62,7 @@ export const DiffMinimap: FC<{
 		let lastScrollHeight: number | null = null;
 
 		const draw = (): void => {
-			const { files, diffStyle } = dataRef.current;
+			const { files, diffStyle, annotationsByPath, selection } = dataRef.current;
 			const geometry = getMinimapGeometry(
 				viewer,
 				files.map((file) => file.itemId),
@@ -67,7 +72,8 @@ export const DiffMinimap: FC<{
 			setNavigable(geometry !== null);
 			if (!geometry) return;
 
-			setBadges(paintMinimap(canvas, { files, geometry, diffStyle }));
+			const overlays = getMinimapOverlays({ files, geometry, annotationsByPath, selection });
+			setBadges(paintMinimap(canvas, { files, geometry, diffStyle, overlays }));
 		};
 
 		const sync = (force: boolean): void => {
@@ -137,9 +143,14 @@ export const DiffMinimap: FC<{
 	// Guarded so renders driven by hover don't repaint the canvas.
 	useLayoutEffect(() => {
 		const previous = dataRef.current;
-		if (previous.files === files && previous.diffStyle === diffStyle) return;
+		const changed =
+			previous.files !== files ||
+			previous.diffStyle !== diffStyle ||
+			previous.annotationsByPath !== annotationsByPath ||
+			previous.selection !== selection;
+		if (!changed) return;
 
-		dataRef.current = { files, diffStyle };
+		dataRef.current = { files, diffStyle, annotationsByPath, selection };
 		resyncRef.current?.();
 	});
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/diff-minimap-canvas.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/diff-minimap-canvas.ts
@@ -1,5 +1,10 @@
 import type { GUISettings } from "#electron/settings.ts";
-import { getMinimapScale, type MinimapFile, type MinimapGeometry } from "./diff-minimap.ts";
+import {
+	getMinimapScale,
+	type MinimapFile,
+	type MinimapGeometry,
+	type MinimapSide,
+} from "./diff-minimap.ts";
 
 /** The channel between the two lanes in side-by-side. */
 const LANE_SPLIT = 1;
@@ -9,8 +14,6 @@ const RULE_MIN_GAP = 6;
 
 /** Height a file's section needs before it is badged with its type icon. */
 const ICON_MIN_SECTION = 24;
-
-type Side = "additions" | "deletions";
 
 /**
  * Per device pixel: line widths and indents summed against how much of the
@@ -49,14 +52,14 @@ const resolveLanes = ({
 	geometry: MinimapGeometry;
 	rows: number;
 	scale: number;
-}): Record<Side, Lane> => {
+}): Record<MinimapSide, Lane> => {
 	const lane = (): Lane => ({
 		widths: new Float32Array(rows),
 		indents: new Float32Array(rows),
 		coverage: new Float32Array(rows),
 		content: new Float32Array(rows),
 	});
-	const lanes = { deletions: lane(), additions: lane() };
+	const lanes = { context: lane(), deletions: lane(), additions: lane() };
 
 	for (const [index, file] of files.entries()) {
 		const block = geometry.blocks[index];
@@ -179,6 +182,7 @@ export const paintMinimap = (
 
 	const palette = getComputedStyle(canvas);
 	const fills = {
+		context: palette.getPropertyValue("--minimap-context"),
 		deletions: palette.getPropertyValue("--minimap-deletions"),
 		additions: palette.getPropertyValue("--minimap-additions"),
 	};
@@ -191,28 +195,29 @@ export const paintMinimap = (
 	const rows = deviceHeight;
 	const lanes = resolveLanes({ files, geometry, rows, scale: scale * ratio });
 
-	// Unified stacks both sides in one lane, so past a line per pixel a removal
-	// and an addition can land on the same one. Give it to whichever fills more
-	// of it, rather than letting the second side painted cover part of the first
-	// and read as a line that changes colour.
-	if (!split) {
-		for (let row = 0; row < rows; row++) {
-			const removed = lanes.deletions.coverage[row] ?? 0;
-			const added = lanes.additions.coverage[row] ?? 0;
-			if (removed === 0 || added === 0) continue;
+	for (let row = 0; row < rows; row++) {
+		const removed = lanes.deletions.coverage[row] ?? 0;
+		const added = lanes.additions.coverage[row] ?? 0;
 
-			// Ties go to removals, which come first within a change.
-			const losing = added > removed ? lanes.deletions : lanes.additions;
-			losing.coverage[row] = 0;
-		}
+		// A row carrying a change is described by that change, not by whatever
+		// unchanged code shares the pixel with it.
+		if (removed > 0 || added > 0) lanes.context.coverage[row] = 0;
+
+		// Unified stacks both sides in one lane, so past a line per pixel a removal
+		// and an addition can land on the same one. Give it to whichever fills more
+		// of it, rather than letting the second side painted cover part of the first
+		// and read as a line that changes colour. Ties go to removals, which come
+		// first within a change.
+		if (split || removed === 0 || added === 0) continue;
+		const losing = added > removed ? lanes.deletions : lanes.additions;
+		losing.coverage[row] = 0;
 	}
 
 	// Leading whitespace is left unpainted, so indentation reads as the gap
 	// before a line's code. Every line grows from its own lane's left edge, the
 	// way the text does in the column it stands for.
-	for (const [side, lane] of Object.entries(lanes) as Array<[Side, Lane]>) {
-		const origin = split && side === "additions" ? laneWidth + LANE_SPLIT : 0;
-		context.fillStyle = fills[side];
+	const drawLane = (lane: Lane, origin: number, fill: string): void => {
+		context.fillStyle = fill;
 
 		for (let row = 0; row < rows; row++) {
 			if ((lane.coverage[row] ?? 0) === 0) continue;
@@ -228,7 +233,14 @@ export const paintMinimap = (
 
 			context.fillRect(origin + inner, row / ratio, outer - inner, thinnest);
 		}
-	}
+	};
+
+	const right = laneWidth + LANE_SPLIT;
+	// Unchanged code is the same on both sides, so split shows it in both columns.
+	drawLane(lanes.context, 0, fills.context);
+	if (split) drawLane(lanes.context, right, fills.context);
+	drawLane(lanes.deletions, 0, fills.deletions);
+	drawLane(lanes.additions, split ? right : 0, fills.additions);
 
 	// Drawn last and opaque, so a rule reads over the marks it crosses rather
 	// than tinting with them.

--- a/apps/lite/ui/src/routes/project/$id/workspace/diff-minimap-canvas.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/diff-minimap-canvas.ts
@@ -69,10 +69,14 @@ const resolveLanes = ({
 
 		for (const mark of file.marks) {
 			const lane = lanes[mark.side];
-			const lineHeight = (mark.height * correction) / mark.widths.length;
+			// One rendered row, which is also each line's height unless wrapping gave
+			// some of them more than one.
+			const rowHeight = (mark.height * correction) / mark.rowCount;
 			let y = origin + mark.top * correction;
 
 			for (const [line, width] of mark.widths.entries()) {
+				const lineHeight = (mark.rows?.[line] ?? 1) * rowHeight;
+
 				// A line owns the pixels it covers, and one thinner than a pixel owns
 				// only the one its middle lands in — otherwise a removal and the
 				// addition under it would both claim the boundary between them.

--- a/apps/lite/ui/src/routes/project/$id/workspace/diff-minimap-canvas.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/diff-minimap-canvas.ts
@@ -3,6 +3,7 @@ import {
 	getMinimapScale,
 	type MinimapFile,
 	type MinimapGeometry,
+	type MinimapOverlays,
 	type MinimapSide,
 } from "./diff-minimap.ts";
 
@@ -11,6 +12,10 @@ const LANE_SPLIT = 1;
 
 /** Vertical room a file rule needs before the next one is drawn. */
 const RULE_MIN_GAP = 6;
+
+/** How far a comment pin reaches in from the ruler's right edge. */
+const PIN_WIDTH = 5;
+const PIN_HEIGHT = 3;
 
 /** Height a file's section needs before it is badged with its type icon. */
 const ICON_MIN_SECTION = 24;
@@ -159,10 +164,12 @@ export const paintMinimap = (
 		files,
 		geometry,
 		diffStyle,
+		overlays,
 	}: {
 		files: Array<MinimapFile>;
 		geometry: MinimapGeometry;
 		diffStyle: GUISettings["diffStyle"];
+		overlays: MinimapOverlays;
 	},
 ): Array<MinimapBadge> => {
 	const { width, height } = canvas.getBoundingClientRect();
@@ -185,6 +192,8 @@ export const paintMinimap = (
 		context: palette.getPropertyValue("--minimap-context"),
 		deletions: palette.getPropertyValue("--minimap-deletions"),
 		additions: palette.getPropertyValue("--minimap-additions"),
+		pin: palette.getPropertyValue("--minimap-pin"),
+		selection: palette.getPropertyValue("--minimap-selection"),
 	};
 
 	const split = diffStyle === "split";
@@ -235,6 +244,18 @@ export const paintMinimap = (
 		}
 	};
 
+	// Laid down before the marks so a selected hunk still reads as added or
+	// removed, with the wash showing through the gaps between its lines.
+	if (overlays.band) {
+		context.fillStyle = fills.selection;
+		context.fillRect(
+			0,
+			overlays.band.top * scale,
+			width,
+			Math.max(overlays.band.height * scale, thinnest),
+		);
+	}
+
 	const right = laneWidth + LANE_SPLIT;
 	// Unchanged code is the same on both sides, so split shows it in both columns.
 	drawLane(lanes.context, 0, fills.context);
@@ -247,6 +268,14 @@ export const paintMinimap = (
 	const rules = resolveRules({ geometry, scale, limit: height - thinnest });
 	context.fillStyle = palette.getPropertyValue("--minimap-file-rule");
 	for (const rule of rules) context.fillRect(0, rule.y, width, thinnest);
+
+	// Pinned to the right edge, opposite the file badges, so a commented line is
+	// findable without covering the marks it belongs to.
+	context.fillStyle = fills.pin;
+	for (const pin of overlays.pins) {
+		const top = Math.min(Math.max(pin * scale - PIN_HEIGHT / 2, 0), height - PIN_HEIGHT);
+		context.fillRect(width - PIN_WIDTH, top, PIN_WIDTH, PIN_HEIGHT);
+	}
 
 	const first = geometry.blocks[0];
 	const opening = first && first.height * scale >= ICON_MIN_SECTION ? [{ index: 0, top: 0 }] : [];

--- a/apps/lite/ui/src/routes/project/$id/workspace/diff-minimap.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/diff-minimap.ts
@@ -38,7 +38,14 @@ const MIN_VIEWPORTS = 2;
 const REFERENCE_COLUMNS = 100;
 
 /**
- * A run of added or removed lines, in pixels from the top of its file.
+ * Context is the unchanged code a hunk carries with it. Drawn under the two
+ * change lanes so a file reads as code with changes in it, rather than as marks
+ * floating in an empty column.
+ */
+export type MinimapSide = "additions" | "deletions" | "context";
+
+/**
+ * A run of lines from one side, in pixels from the top of its file.
  *
  * Widths are per line rather than averaged, so the ruler can resolve individual
  * lines wherever it has the pixels for them, and each carries its leading
@@ -48,7 +55,7 @@ const REFERENCE_COLUMNS = 100;
 type MinimapMark = {
 	top: number;
 	height: number;
-	side: "additions" | "deletions";
+	side: MinimapSide;
 	widths: Uint8Array;
 	indents: Uint8Array;
 	/** Rendered rows per line, or null when nothing here wraps and each takes one. */
@@ -194,7 +201,7 @@ export const getMinimapFiles = ({
 		for (const [hunkIndex, hunk] of fileDiff.hunks.entries()) {
 			if (hunk.collapsedBefore > 0) top += hunkIndex === 0 ? SEPARATOR_LEADING : SEPARATOR_BETWEEN;
 
-			const mark = (side: MinimapMark["side"], offset: number, metrics: RunMetrics): void => {
+			const mark = (side: MinimapSide, offset: number, metrics: RunMetrics): void => {
 				marks.push({
 					top: top + offset * ROW_HEIGHT,
 					height: metrics.rowCount * ROW_HEIGHT,
@@ -211,16 +218,21 @@ export const getMinimapFiles = ({
 
 			for (const part of hunk.hunkContent) {
 				if (part.type === "context") {
-					// Unchanged lines wrap too, so their rows have to be counted even
-					// though nothing is drawn for them.
-					row += runMetrics(
-						fileDiff.additionLines.slice(
-							part.additionLineIndex,
-							part.additionLineIndex + part.lines,
-						),
-						tabSize,
-						wrapColumns,
-					).rowCount;
+					if (part.lines > 0) {
+						// Unchanged, so the two sides hold the same text and either reads it.
+						const context = runMetrics(
+							fileDiff.additionLines.slice(
+								part.additionLineIndex,
+								part.additionLineIndex + part.lines,
+							),
+							tabSize,
+							wrapColumns,
+						);
+
+						mark("context", row, context);
+						row += context.rowCount;
+					}
+
 					unwrapped += part.lines;
 					continue;
 				}

--- a/apps/lite/ui/src/routes/project/$id/workspace/diff-minimap.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/diff-minimap.ts
@@ -51,7 +51,13 @@ type MinimapMark = {
 	side: "additions" | "deletions";
 	widths: Uint8Array;
 	indents: Uint8Array;
+	/** Rendered rows per line, or null when nothing here wraps and each takes one. */
+	rows: Uint16Array | null;
+	/** Rows the run spans — its line count unless wrapping stretched it. */
+	rowCount: number;
 };
+
+type RunMetrics = Omit<MinimapMark, "top" | "height" | "side">;
 
 export type MinimapFile = {
 	itemId: string;
@@ -96,9 +102,12 @@ const share = (columns: number): number =>
 const runMetrics = (
 	lines: Array<string>,
 	tabSize: number,
-): { widths: Uint8Array; indents: Uint8Array } => {
+	wrapColumns: number | null,
+): RunMetrics => {
 	const widths = new Uint8Array(lines.length);
 	const indents = new Uint8Array(lines.length);
+	const rows = wrapColumns === null ? null : new Uint16Array(lines.length);
+	let rowCount = 0;
 
 	for (const [index, line] of lines.entries()) {
 		const { indent, columns } = lineColumns(line, tabSize);
@@ -107,9 +116,39 @@ const runMetrics = (
 		// Never wider than the line it sits in, which also leaves a line that is
 		// nothing but whitespace with the two equal — how a blank one is spotted.
 		indents[index] = Math.min(share(indent), widths[index]);
+
+		// The viewer breaks on word boundaries where it can, so a line can take one
+		// row more than its length demands. Under-counting leaves the rest to the
+		// file's own correction to absorb; guessing high would push marks past it.
+		const lineRows = wrapColumns === null ? 1 : Math.max(Math.ceil(columns / wrapColumns), 1);
+		if (rows) rows[index] = lineRows;
+		rowCount += lineRows;
 	}
 
-	return { widths, indents };
+	return { widths, indents, rows, rowCount };
+};
+
+const sumRows = (rows: Uint16Array): number => rows.reduce((total, count) => total + count, 0);
+
+/**
+ * Split lays each removal beside its addition, so the two share a row and the
+ * taller wrap sets its height. Left alone, each side would count only its own
+ * rows and the shorter one would drift up the file.
+ */
+const pairSplitRows = (deletions: RunMetrics, additions: RunMetrics): void => {
+	if (!deletions.rows || !additions.rows) return;
+
+	const removed = deletions.rows.length;
+	const added = additions.rows.length;
+	const paired = new Uint16Array(Math.max(removed, added));
+
+	for (let index = 0; index < paired.length; index++)
+		paired[index] = Math.max(deletions.rows[index] ?? 1, additions.rows[index] ?? 1);
+
+	deletions.rows = paired.subarray(0, removed);
+	additions.rows = paired.subarray(0, added);
+	deletions.rowCount = sumRows(deletions.rows);
+	additions.rowCount = sumRows(additions.rows);
 };
 
 /**
@@ -128,12 +167,15 @@ export const getMinimapFiles = ({
 	treeChangeDiffs,
 	diffStyle,
 	tabSize,
+	wrapColumns,
 }: {
 	fileParent: FileParent;
 	changes: Array<TreeChange>;
 	treeChangeDiffs: Array<UnifiedPatch | null>;
 	diffStyle: GUISettings["diffStyle"];
 	tabSize: number;
+	/** Columns a line gets before it wraps, or null when the viewer scrolls instead. */
+	wrapColumns: number | null;
 }): Array<MinimapFile> => {
 	const changedLines = treeChangeDiffs.reduce(
 		(total, diff) =>
@@ -152,48 +194,77 @@ export const getMinimapFiles = ({
 		for (const [hunkIndex, hunk] of fileDiff.hunks.entries()) {
 			if (hunk.collapsedBefore > 0) top += hunkIndex === 0 ? SEPARATOR_LEADING : SEPARATOR_BETWEEN;
 
+			const mark = (side: MinimapMark["side"], offset: number, metrics: RunMetrics): void => {
+				marks.push({
+					top: top + offset * ROW_HEIGHT,
+					height: metrics.rowCount * ROW_HEIGHT,
+					side,
+					...metrics,
+				});
+			};
+
+			// Rendered rows, and the same walk as if nothing wrapped. Only their
+			// difference is taken from this walk — the hunk's own total comes from the
+			// viewer, so a part shape we don't recognise can't shift the file.
 			let row = 0;
+			let unwrapped = 0;
+
 			for (const part of hunk.hunkContent) {
 				if (part.type === "context") {
-					row += part.lines;
+					// Unchanged lines wrap too, so their rows have to be counted even
+					// though nothing is drawn for them.
+					row += runMetrics(
+						fileDiff.additionLines.slice(
+							part.additionLineIndex,
+							part.additionLineIndex + part.lines,
+						),
+						tabSize,
+						wrapColumns,
+					).rowCount;
+					unwrapped += part.lines;
 					continue;
 				}
 
-				if (part.deletions > 0) {
-					marks.push({
-						top: top + row * ROW_HEIGHT,
-						height: part.deletions * ROW_HEIGHT,
-						side: "deletions",
-						...runMetrics(
-							fileDiff.deletionLines.slice(
-								part.deletionLineIndex,
-								part.deletionLineIndex + part.deletions,
-							),
-							tabSize,
-						),
-					});
-				}
-				if (part.additions > 0) {
-					marks.push({
-						// Split puts both sides on the same rows; unified stacks the
-						// removals above the additions.
-						top: top + (split ? row : row + part.deletions) * ROW_HEIGHT,
-						height: part.additions * ROW_HEIGHT,
-						side: "additions",
-						...runMetrics(
-							fileDiff.additionLines.slice(
-								part.additionLineIndex,
-								part.additionLineIndex + part.additions,
-							),
-							tabSize,
-						),
-					});
-				}
+				const deletions =
+					part.deletions > 0
+						? runMetrics(
+								fileDiff.deletionLines.slice(
+									part.deletionLineIndex,
+									part.deletionLineIndex + part.deletions,
+								),
+								tabSize,
+								wrapColumns,
+							)
+						: null;
+				const additions =
+					part.additions > 0
+						? runMetrics(
+								fileDiff.additionLines.slice(
+									part.additionLineIndex,
+									part.additionLineIndex + part.additions,
+								),
+								tabSize,
+								wrapColumns,
+							)
+						: null;
 
-				row += split ? Math.max(part.deletions, part.additions) : part.deletions + part.additions;
+				if (split && deletions && additions) pairSplitRows(deletions, additions);
+
+				if (deletions) mark("deletions", row, deletions);
+				// Split puts both sides on the same rows; unified stacks the removals
+				// above the additions.
+				if (additions) mark("additions", split ? row : row + (deletions?.rowCount ?? 0), additions);
+
+				row += split
+					? Math.max(deletions?.rowCount ?? 0, additions?.rowCount ?? 0)
+					: (deletions?.rowCount ?? 0) + (additions?.rowCount ?? 0);
+				unwrapped += split
+					? Math.max(part.deletions, part.additions)
+					: part.deletions + part.additions;
 			}
 
-			top += (split ? hunk.splitLineCount : hunk.unifiedLineCount) * ROW_HEIGHT;
+			const lines = split ? hunk.splitLineCount : hunk.unifiedLineCount;
+			top += (lines + (row - unwrapped)) * ROW_HEIGHT;
 		}
 
 		return {
@@ -237,6 +308,34 @@ export const getMinimapGeometry = (
 	}
 
 	return { contentHeight: total, blocks };
+};
+
+/**
+ * Columns a code line gets before the viewer wraps it, read off a rendered one,
+ * or null while nothing is rendered yet. The gutter grows with a file's line
+ * numbers, so this is the measured file's width and a digit or two out on the
+ * rest — worth far less than the wrapping it lets us model at all.
+ *
+ * The font is monospace, so one character's advance scales to any line length.
+ */
+export const measureWrapColumns = (viewer: CodeView<Annotation>): number | null => {
+	const host = viewer.getContainerElement()?.querySelector("diffs-container");
+	const line = host?.shadowRoot?.querySelector("[data-content] > [data-line]");
+	if (!line) return null;
+
+	const style = getComputedStyle(line);
+	const width =
+		line.clientWidth - Number.parseFloat(style.paddingLeft) - Number.parseFloat(style.paddingRight);
+	if (!(width > 0)) return null;
+
+	const context = document.createElement("canvas").getContext("2d");
+	if (!context) return null;
+
+	context.font = `${style.fontWeight} ${style.fontSize} ${style.fontFamily}`;
+	const sample = "0".repeat(50);
+	const advance = context.measureText(sample).width / sample.length;
+
+	return advance > 0 ? Math.max(Math.floor(width / advance), 1) : null;
 };
 
 /**

--- a/apps/lite/ui/src/routes/project/$id/workspace/diff-minimap.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/diff-minimap.ts
@@ -1,3 +1,4 @@
+import type { LocalAnnotationsByPath } from "#ui/annotation.ts";
 import { weakFileIdentityKey, type FileParent } from "#ui/operands.ts";
 import type { GUISettings } from "#electron/settings.ts";
 import type { TreeChange, UnifiedPatch } from "@gitbutler/but-sdk";
@@ -66,12 +67,30 @@ type MinimapMark = {
 
 type RunMetrics = Omit<MinimapMark, "top" | "height" | "side">;
 
+/** The two sides a file line can be numbered on. Context lines are on both. */
+type ChangeSide = Exclude<MinimapSide, "context">;
+
+/**
+ * A run of consecutive file lines and the pixels it occupies, which is what
+ * turns a comment's line number — or a selected range — into a ruler position.
+ * Interpolating within the run is exact until wrapping makes lines uneven, and
+ * a line or so out is below what the ruler can draw anyway.
+ */
+type MinimapAnchor = {
+	side: ChangeSide;
+	start: number;
+	lines: number;
+	top: number;
+	height: number;
+};
+
 export type MinimapFile = {
 	itemId: string;
 	path: string;
 	/** Modelled height of the whole file block, used to correct the marks. */
 	contentHeight: number;
 	marks: Array<MinimapMark>;
+	anchors: Array<MinimapAnchor>;
 };
 
 /** Scroll-content pixels, the space every position here is measured in. */
@@ -125,7 +144,7 @@ const runMetrics = (
 		indents[index] = Math.min(share(indent), widths[index]);
 
 		// The viewer breaks on word boundaries where it can, so a line can take one
-		// row more than its length demands. Under-counting leaves the rest to the
+		// row more than its length demands. Under-counting leaves the rest of the
 		// file's own correction to absorb; guessing high would push marks past it.
 		const lineRows = wrapColumns === null ? 1 : Math.max(Math.ceil(columns / wrapColumns), 1);
 		if (rows) rows[index] = lineRows;
@@ -196,18 +215,31 @@ export const getMinimapFiles = ({
 	return changes.map((change, changeIndex) => {
 		const { fileDiff } = parseChangeDiff(change, treeChangeDiffs[changeIndex] ?? null);
 		const marks: Array<MinimapMark> = [];
+		const anchors: Array<MinimapAnchor> = [];
 		let top = codeViewItemMetrics.diffHeaderHeight;
 
 		for (const [hunkIndex, hunk] of fileDiff.hunks.entries()) {
 			if (hunk.collapsedBefore > 0) top += hunkIndex === 0 ? SEPARATOR_LEADING : SEPARATOR_BETWEEN;
 
-			const mark = (side: MinimapSide, offset: number, metrics: RunMetrics): void => {
-				marks.push({
+			type Placement = { top: number; height: number };
+
+			const mark = (side: MinimapSide, offset: number, metrics: RunMetrics): Placement => {
+				const placement = {
 					top: top + offset * ROW_HEIGHT,
 					height: metrics.rowCount * ROW_HEIGHT,
-					side,
-					...metrics,
-				});
+				};
+
+				marks.push({ ...placement, side, ...metrics });
+				return placement;
+			};
+
+			const anchor = (
+				side: ChangeSide,
+				start: number,
+				lines: number,
+				placement: Placement,
+			): void => {
+				if (lines > 0) anchors.push({ side, start, lines, ...placement });
 			};
 
 			// Rendered rows, and the same walk as if nothing wrapped. Only their
@@ -215,6 +247,10 @@ export const getMinimapFiles = ({
 			// viewer, so a part shape we don't recognise can't shift the file.
 			let row = 0;
 			let unwrapped = 0;
+			// The hunk header numbers its first line on each side; every part after
+			// that carries the count on from there.
+			let additionLine = hunk.additionStart;
+			let deletionLine = hunk.deletionStart;
 
 			for (const part of hunk.hunkContent) {
 				if (part.type === "context") {
@@ -229,10 +265,14 @@ export const getMinimapFiles = ({
 							wrapColumns,
 						);
 
-						mark("context", row, context);
+						const placement = mark("context", row, context);
+						anchor("additions", additionLine, part.lines, placement);
+						anchor("deletions", deletionLine, part.lines, placement);
 						row += context.rowCount;
 					}
 
+					additionLine += part.lines;
+					deletionLine += part.lines;
 					unwrapped += part.lines;
 					continue;
 				}
@@ -262,10 +302,18 @@ export const getMinimapFiles = ({
 
 				if (split && deletions && additions) pairSplitRows(deletions, additions);
 
-				if (deletions) mark("deletions", row, deletions);
-				// Split puts both sides on the same rows; unified stacks the removals
-				// above the additions.
-				if (additions) mark("additions", split ? row : row + (deletions?.rowCount ?? 0), additions);
+				if (deletions)
+					anchor("deletions", deletionLine, part.deletions, mark("deletions", row, deletions));
+
+				if (additions) {
+					// Split puts both sides on the same rows; unified stacks the removals
+					// above the additions.
+					const offset = split ? row : row + (deletions?.rowCount ?? 0);
+					anchor("additions", additionLine, part.additions, mark("additions", offset, additions));
+				}
+
+				additionLine += part.additions;
+				deletionLine += part.deletions;
 
 				row += split
 					? Math.max(deletions?.rowCount ?? 0, additions?.rowCount ?? 0)
@@ -284,6 +332,7 @@ export const getMinimapFiles = ({
 			path: change.path,
 			contentHeight: top + codeViewItemMetrics.paddingBottom,
 			marks,
+			anchors,
 		};
 	});
 };
@@ -357,6 +406,79 @@ export const measureWrapColumns = (viewer: CodeView<Annotation>): number | null 
  */
 export const getMinimapScale = (file: MinimapFile, block: { height: number }): number =>
 	file.contentHeight <= 0 ? 0 : block.height / file.contentHeight;
+
+/** Where a file line sits inside its own block, or null if no hunk renders it. */
+const lineTop = (file: MinimapFile, side: ChangeSide, line: number): number | null => {
+	for (const anchor of file.anchors) {
+		if (anchor.side !== side) continue;
+		if (line < anchor.start || line >= anchor.start + anchor.lines) continue;
+
+		return anchor.top + ((line - anchor.start) / anchor.lines) * anchor.height;
+	}
+
+	return null;
+};
+
+/** The range the diff currently has selected, in file line numbers. */
+export type MinimapSelection = { itemId: string; side: ChangeSide; start: number; end: number };
+
+export type MinimapOverlays = {
+	/** Comment positions, in scroll-content pixels. */
+	pins: Array<number>;
+	band: { top: number; height: number } | null;
+};
+
+/**
+ * Comment pins and the selected range, in the same scroll-content pixels as the
+ * geometry — resolved here rather than in the painter, which knows about ink
+ * and not about which line a comment hangs off.
+ */
+export const getMinimapOverlays = ({
+	files,
+	geometry,
+	annotationsByPath,
+	selection,
+}: {
+	files: Array<MinimapFile>;
+	geometry: MinimapGeometry;
+	annotationsByPath: LocalAnnotationsByPath;
+	selection: MinimapSelection | null;
+}): MinimapOverlays => {
+	const pins: Array<number> = [];
+	let band: { top: number; height: number } | null = null;
+
+	for (const [index, file] of files.entries()) {
+		const block = geometry.blocks[index];
+		if (!block) continue;
+
+		const scale = getMinimapScale(file, block);
+		const place = (side: ChangeSide, line: number): number | null => {
+			const local = lineTop(file, side, line);
+			return local === null ? null : block.top + local * scale;
+		};
+
+		for (const annotation of annotationsByPath.get(file.path) ?? []) {
+			const top = place(annotation.side, annotation.lineNumber);
+			if (top !== null) pins.push(top);
+		}
+
+		if (selection?.itemId !== file.itemId) continue;
+
+		// A hunk that only removes lines carries no addition to number the range
+		// against, and the other way round, so fall through to whichever side has it.
+		const other = selection.side === "additions" ? "deletions" : "additions";
+		const locate = (line: number): number | null =>
+			place(selection.side, line) ?? place(other, line);
+
+		const start = locate(selection.start);
+		// The band should stop where the line after the range starts; a selection
+		// running to the end of a hunk has no such line to ask for.
+		const end = locate(selection.end + 1) ?? locate(selection.end);
+		if (start !== null) band = { top: start, height: Math.max((end ?? start) - start, 0) };
+	}
+
+	return { pins, band };
+};
 
 /** The visible window, as fractions of the content. */
 export const getMinimapViewport = (

--- a/apps/lite/ui/src/routes/project/$id/workspace/diff-minimap.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/diff-minimap.ts
@@ -372,6 +372,15 @@ export const getMinimapGeometry = (
 };
 
 /**
+ * One scratch context for measuring text. A fresh canvas per call costs many
+ * times the measurement itself and leaves a backing store behind, which matters
+ * because the measuring runs on every resize.
+ */
+let textContext: CanvasRenderingContext2D | null = null;
+const measuringContext = (): CanvasRenderingContext2D | null =>
+	(textContext ??= document.createElement("canvas").getContext("2d"));
+
+/**
  * Columns a code line gets before the viewer wraps it, read off a rendered one,
  * or null while nothing is rendered yet. The gutter grows with a file's line
  * numbers, so this is the measured file's width and a digit or two out on the
@@ -389,9 +398,12 @@ export const measureWrapColumns = (viewer: CodeView<Annotation>): number | null 
 		line.clientWidth - Number.parseFloat(style.paddingLeft) - Number.parseFloat(style.paddingRight);
 	if (!(width > 0)) return null;
 
-	const context = document.createElement("canvas").getContext("2d");
+	const context = measuringContext();
 	if (!context) return null;
 
+	// Built from the longhands rather than taken from `style.font`, which computes
+	// to an empty string here — and empty leaves the context on its own default
+	// font, quietly measuring something else entirely.
 	context.font = `${style.fontWeight} ${style.fontSize} ${style.fontFamily}`;
 	const sample = "0".repeat(50);
 	const advance = context.measureText(sample).width / sample.length;


### PR DESCRIPTION
The minimap only drew changed lines, so a file was a few marks floating in an
empty column. Now it draws the unchanged code around them too, and reads like
code with changes in it.

Four commits:

- **Model wrapped lines.** Every line counted as one 20px row. That's wrong when
  wrapping is on, and marks drifted down the file they were mapping.
- **Paint the unchanged code** in faint grey, using the same line-length and
  indent shapes. Changes win any pixel they land on.
- **Show comments and the selected range.** A pin on the right edge for a
  comment, a wash behind the marks for the selected hunk.
- **Open a file from its badge.** Pressing the track centres the viewport where
  you pressed; pressing a badge opens that file at the top.
