### PR TITLE
Stop reparsing every file when scrolling a diff

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -937,17 +937,26 @@ const Diff: FC<{
 
 	const activeFilePath = selection._tag === "File" ? selection.path : filesSelection;
 
-	const diffViewSansAnno = useMemo(() => {
-		const selectedFileIdx = changes.findIndex((change) => change.path === activeFilePath);
+	// Keyed on the file's index, not its path: scrolling moves the selection, so
+	// keying on path reparsed every file per boundary crossed. `null` is
+	// render-all, distinct from the -1 of a path matching no file.
+	const shownFileIndex = renderAllFiles
+		? null
+		: changes.findIndex((change) => change.path === activeFilePath);
 
-		return getDiffView({
-			fileParent,
-			changes: renderAllFiles ? changes : changes.slice(selectedFileIdx, selectedFileIdx + 1),
-			treeChangeDiffs: renderAllFiles
-				? treeChangeDiffs
-				: treeChangeDiffs.slice(selectedFileIdx, selectedFileIdx + 1),
-		});
-	}, [fileParent, renderAllFiles, activeFilePath, changes, treeChangeDiffs]);
+	const diffViewSansAnno = useMemo(
+		() =>
+			getDiffView({
+				fileParent,
+				changes:
+					shownFileIndex === null ? changes : changes.slice(shownFileIndex, shownFileIndex + 1),
+				treeChangeDiffs:
+					shownFileIndex === null
+						? treeChangeDiffs
+						: treeChangeDiffs.slice(shownFileIndex, shownFileIndex + 1),
+			}),
+		[fileParent, shownFileIndex, changes, treeChangeDiffs],
+	);
 
 	const diffView = withAnnotations(diffViewSansAnno, annotationsByPath);
 


### PR DESCRIPTION
Long branch diffs stuttered while scrolling.

The viewer selects the file at the viewport top as you scroll, and the diff's
memo listed that path as a dependency — so every file boundary crossed
reparsed every file in the diff. Now keyed on the shown file's index, which is
null in render-all mode and so doesn't change while scrolling. The minimap
already did this.

Same scroll on a 356-file diff: p90 frame 133ms -> 23ms, 28 long tasks
(82-281ms) -> 0, React commit time 3.5s -> 240ms.