### PR TITLE
Stop sending forge access tokens to the frontend

### DIFF
--- a/apps/desktop/src/lib/forge/bitbucket/bitbucketUserService.svelte.ts
+++ b/apps/desktop/src/lib/forge/bitbucket/bitbucketUserService.svelte.ts
@@ -4,7 +4,7 @@ import type { BackendApi } from "$lib/state/backendApi";
 import type { ReactiveQuery } from "$lib/state/butlerModule";
 import type {
 	BitbucketAccountIdentifier,
-	BitbucketAuthStatusResponseSensitive,
+	BitbucketAuthStatusResponse,
 	BitbucketAuthenticatedUserSensitive,
 } from "@gitbutler/but-sdk";
 
@@ -146,7 +146,7 @@ function injectBackendEndpoints(api: BackendApi) {
 				invalidatesTags: [providesList(ReduxTag.BitbucketUserList)],
 			}),
 			storeBitbucketApiToken: build.mutation<
-				BitbucketAuthStatusResponseSensitive,
+				BitbucketAuthStatusResponse,
 				{ email: string; accessToken: string }
 			>({
 				extraOptions: {

--- a/apps/desktop/src/lib/forge/github/githubUserService.svelte.ts
+++ b/apps/desktop/src/lib/forge/github/githubUserService.svelte.ts
@@ -4,7 +4,7 @@ import type { BackendApi } from "$lib/state/backendApi";
 import type { ReactiveQuery } from "$lib/state/butlerModule";
 import type {
 	GithubAccountIdentifier,
-	GithubAuthStatusResponseSensitive,
+	GithubAuthStatusResponse,
 	GithubAuthenticatedUserSensitive,
 } from "@gitbutler/but-sdk";
 
@@ -169,7 +169,7 @@ function injectBackendEndpoints(api: BackendApi) {
 				},
 				query: () => ({}),
 			}),
-			checkAuthStatus: build.mutation<GithubAuthStatusResponseSensitive, { deviceCode: string }>({
+			checkAuthStatus: build.mutation<GithubAuthStatusResponse, { deviceCode: string }>({
 				extraOptions: {
 					command: "check_github_auth_status",
 					actionName: "Check GitHub Auth Status",
@@ -204,7 +204,7 @@ function injectBackendEndpoints(api: BackendApi) {
 				query: () => ({}),
 				invalidatesTags: [providesList(ReduxTag.GitHubUserList)],
 			}),
-			storeGitHubPat: build.mutation<GithubAuthStatusResponseSensitive, { accessToken: string }>({
+			storeGitHubPat: build.mutation<GithubAuthStatusResponse, { accessToken: string }>({
 				extraOptions: {
 					command: "store_github_pat",
 					actionName: "Store GitHub PAT",
@@ -213,7 +213,7 @@ function injectBackendEndpoints(api: BackendApi) {
 				invalidatesTags: [providesList(ReduxTag.GitHubUserList)],
 			}),
 			storeGithuibEnterprisePat: build.mutation<
-				GithubAuthStatusResponseSensitive,
+				GithubAuthStatusResponse,
 				{ host: string; accessToken: string }
 			>({
 				extraOptions: {

--- a/apps/desktop/src/lib/forge/github/hooks.svelte.ts
+++ b/apps/desktop/src/lib/forge/github/hooks.svelte.ts
@@ -6,7 +6,7 @@ import { PROJECTS_SERVICE } from "$lib/project/projectsService";
 import { inject } from "@gitbutler/core/context";
 import { reactive } from "@gitbutler/shared/reactiveUtils.svelte";
 import type { ForgeUserQuery } from "$lib/forge/interface/types";
-import type { Code, GithubAccountIdentifier } from "@gitbutler/but-sdk";
+import type { GithubAccountIdentifier } from "@gitbutler/but-sdk";
 import type { Reactive } from "@gitbutler/shared/storeUtils";
 
 type GitHubPreferences = {
@@ -51,42 +51,6 @@ export function usePreferredGitHubUsername(projectId: Reactive<string>): GitHubP
 	return {
 		preferredGitHubAccount: reactive(() => preferredUser),
 		githubAccounts: reactive(() => githubAccounts),
-	};
-}
-
-type GitHubAccess = {
-	host: Reactive<string | undefined>;
-	accessToken: Reactive<string | undefined>;
-	isLoading: Reactive<boolean>;
-	error: Reactive<{ code?: Code; message: string } | undefined>;
-	isError: Reactive<boolean>;
-};
-
-/**
- * Return the GitHub access token for the given project ID, based on the preferred GitHub username.
- */
-export function useGitHubAccessToken(projectId: Reactive<string>): GitHubAccess {
-	const githubUserService = inject(GITHUB_USER_SERVICE);
-	const { preferredGitHubAccount } = usePreferredGitHubUsername(projectId);
-	const ghUserResponse = $derived.by(() => {
-		if (preferredGitHubAccount.current === undefined) return undefined;
-		return githubUserService.authenticatedUser(preferredGitHubAccount.current);
-	});
-	const aceessToken = $derived(ghUserResponse?.response?.accessToken);
-	const host = $derived.by(() => {
-		if (preferredGitHubAccount.current?.type === "enterprise") {
-			return preferredGitHubAccount.current.info.host;
-		}
-		return undefined;
-	});
-	return {
-		host: reactive(() => host),
-		accessToken: reactive(() => aceessToken),
-		isLoading: reactive(() => ghUserResponse?.result.isLoading ?? false),
-		error: reactive(
-			() => ghUserResponse?.result.error as { code?: Code; message: string } | undefined,
-		),
-		isError: reactive(() => ghUserResponse?.result.isError ?? false),
 	};
 }
 

--- a/apps/desktop/src/lib/forge/gitlab/gitlabUserService.svelte.ts
+++ b/apps/desktop/src/lib/forge/gitlab/gitlabUserService.svelte.ts
@@ -5,7 +5,7 @@ import type { BackendApi } from "$lib/state/backendApi";
 import type { ReactiveQuery } from "$lib/state/butlerModule";
 import type {
 	GitlabAccountIdentifier,
-	GitlabAuthStatusResponseSensitive,
+	GitlabAuthStatusResponse,
 	GitlabAuthenticatedUserSensitive,
 } from "@gitbutler/but-sdk";
 
@@ -184,7 +184,7 @@ function injectBackendEndpoints(api: BackendApi) {
 				query: () => ({}),
 				invalidatesTags: [providesList(ReduxTag.GitLabUserList)],
 			}),
-			storeGitLabPat: build.mutation<GitlabAuthStatusResponseSensitive, { accessToken: string }>({
+			storeGitLabPat: build.mutation<GitlabAuthStatusResponse, { accessToken: string }>({
 				extraOptions: {
 					command: "store_gitlab_pat",
 					actionName: "Store GitLab PAT",
@@ -193,7 +193,7 @@ function injectBackendEndpoints(api: BackendApi) {
 				invalidatesTags: [providesList(ReduxTag.GitLabUserList)],
 			}),
 			storeGitLabEnterprisePat: build.mutation<
-				GitlabAuthStatusResponseSensitive,
+				GitlabAuthStatusResponse,
 				{ host: string; accessToken: string }
 			>({
 				extraOptions: {

--- a/crates/but-api/src/bitbucket.rs
+++ b/crates/but-api/src/bitbucket.rs
@@ -17,9 +17,9 @@ use tracing::instrument;
 ///
 /// # Returns
 ///
-/// * `Ok(AuthStatusResponse)` - Token is valid, contains user details
+/// * `Ok(_)` - The token is valid and stored
 /// * `Err(_)` - If the token is invalid or storage fails
-#[but_api(napi, json::BitbucketAuthStatusResponseSensitive)]
+#[but_api(napi, json::BitbucketAuthStatusResponse)]
 #[instrument(err(Debug))]
 pub async fn store_bitbucket_api_token(
     email: String,

--- a/crates/but-api/src/github.rs
+++ b/crates/but-api/src/github.rs
@@ -34,11 +34,11 @@ pub async fn init_github_device_oauth() -> Result<Verification> {
 ///
 /// # Returns
 ///
-/// * `Ok(AuthStatusResponse)` - User is authenticated, contains access token and user details
+/// * `Ok(_)` - The user completed the flow; the account and its token are stored
 /// * `Err(_)` - If the authorization is pending, denied, or the request fails
 ///
 /// For lower-level implementation details, see [`but_github::check_github_auth_status()`].
-#[but_api(napi, json::GithubAuthStatusResponseSensitive)]
+#[but_api(napi, json::GithubAuthStatusResponse)]
 #[instrument(err(Debug))]
 pub async fn check_github_auth_status(device_code: String) -> Result<AuthStatusResponse> {
     let storage = but_forge_storage::Controller::from_path(but_path::app_data_dir()?);
@@ -56,9 +56,9 @@ pub async fn check_github_auth_status(device_code: String) -> Result<AuthStatusR
 ///
 /// # Returns
 ///
-/// * `Ok(AuthStatusResponse)` - Token is valid, contains user details
+/// * `Ok(_)` - The token is valid and stored
 /// * `Err(_)` - If the token is invalid or storage fails
-#[but_api(napi, json::GithubAuthStatusResponseSensitive)]
+#[but_api(napi, json::GithubAuthStatusResponse)]
 #[instrument(err(Debug))]
 pub async fn store_github_pat(access_token: Sensitive<String>) -> Result<AuthStatusResponse> {
     let storage = but_forge_storage::Controller::from_path(but_path::app_data_dir()?);
@@ -77,9 +77,9 @@ pub async fn store_github_pat(access_token: Sensitive<String>) -> Result<AuthSta
 ///
 /// # Returns
 ///
-/// * `Ok(AuthStatusResponse)` - Token is valid, contains user details and host
+/// * `Ok(_)` - The token is valid and stored
 /// * `Err(_)` - If the token is invalid, host is unreachable, or storage fails
-#[but_api(json::GithubAuthStatusResponseSensitive)]
+#[but_api(json::GithubAuthStatusResponse)]
 #[instrument(err(Debug))]
 pub async fn store_github_enterprise_pat(
     access_token: Sensitive<String>,

--- a/crates/but-api/src/gitlab.rs
+++ b/crates/but-api/src/gitlab.rs
@@ -15,9 +15,9 @@ use tracing::instrument;
 ///
 /// # Returns
 ///
-/// * `Ok(AuthStatusResponse)` - Token is valid, contains user details
+/// * `Ok(_)` - The token is valid and stored
 /// * `Err(_)` - If the token is invalid or storage fails
-#[but_api(napi, json::GitlabAuthStatusResponseSensitive)]
+#[but_api(napi, json::GitlabAuthStatusResponse)]
 #[instrument(err(Debug))]
 pub async fn store_gitlab_pat(access_token: Sensitive<String>) -> Result<AuthStatusResponse> {
     let storage = but_forge_storage::Controller::from_path(but_path::app_data_dir()?);
@@ -36,9 +36,9 @@ pub async fn store_gitlab_pat(access_token: Sensitive<String>) -> Result<AuthSta
 ///
 /// # Returns
 ///
-/// * `Ok(AuthStatusResponse)` - Token is valid, contains user details and host
+/// * `Ok(_)` - The token is valid and stored
 /// * `Err(_)` - If the token is invalid, host is unreachable, or storage fails
-#[but_api(json::GitlabAuthStatusResponseSensitive)]
+#[but_api(json::GitlabAuthStatusResponse)]
 #[instrument(err(Debug))]
 pub async fn store_gitlab_selfhosted_pat(
     access_token: Sensitive<String>,

--- a/crates/but-bitbucket/src/lib.rs
+++ b/crates/but-bitbucket/src/lib.rs
@@ -226,32 +226,29 @@ pub mod json {
 
     use crate::{AuthStatusResponse, AuthenticatedUser};
 
-    /// Serializable version of [`AuthStatusResponse`] with exposed access token.
+    /// Serializable version of [`AuthStatusResponse`], without the access token.
+    ///
+    /// The credential is stored by the backend as part of the call, so the caller is told
+    /// who authenticated and nothing more. Field names are camelCase for JSON.
     #[derive(Debug, Serialize)]
     #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
     #[serde(rename_all = "camelCase")]
-    pub struct BitbucketAuthStatusResponseSensitive {
-        /// The Bitbucket access token as a plain string (sensitive data).
-        pub access_token: String,
-        /// The Bitbucket username.
+    pub struct BitbucketAuthStatusResponse {
         pub username: String,
-        /// The user's display name, if available.
         pub name: Option<String>,
-        /// The Atlassian account email used for authentication.
         pub email: Option<String>,
     }
 
-    impl From<AuthStatusResponse> for BitbucketAuthStatusResponseSensitive {
+    impl From<AuthStatusResponse> for BitbucketAuthStatusResponse {
         fn from(
             AuthStatusResponse {
-                access_token,
                 username,
                 name,
                 email,
+                ..
             }: AuthStatusResponse,
         ) -> Self {
-            BitbucketAuthStatusResponseSensitive {
-                access_token: access_token.0,
+            BitbucketAuthStatusResponse {
                 username,
                 name,
                 email,
@@ -260,7 +257,7 @@ pub mod json {
     }
 
     #[cfg(feature = "export-schema")]
-    but_schemars::register_sdk_type!(BitbucketAuthStatusResponseSensitive);
+    but_schemars::register_sdk_type!(BitbucketAuthStatusResponse);
 
     /// Serializable version of [`AuthenticatedUser`] with exposed access token.
     #[derive(Debug, Serialize)]

--- a/crates/but-github/src/lib.rs
+++ b/crates/but-github/src/lib.rs
@@ -367,38 +367,32 @@ pub mod json {
 
     use crate::{AuthStatusResponse, AuthenticatedUser};
 
-    /// Serializable version of [`AuthStatusResponse`] with exposed access token.
+    /// Serializable version of [`AuthStatusResponse`], without the access token.
     ///
-    /// This struct is used for API responses where the access token needs to be
-    /// sent as a plain string. Field names are converted to camelCase for JSON.
+    /// The credential is stored by the backend as part of the call, so the caller is told
+    /// who authenticated and nothing more. Field names are camelCase for JSON.
     #[derive(Debug, Serialize)]
     #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
     #[serde(rename_all = "camelCase")]
-    pub struct GithubAuthStatusResponseSensitive {
-        /// The GitHub access token as a plain string (sensitive data).
-        pub access_token: String,
-        /// The GitHub username/login.
+    pub struct GithubAuthStatusResponse {
         pub login: String,
-        /// The user's display name, if available.
         pub name: Option<String>,
-        /// The user's email address, if available.
         pub email: Option<String>,
-        /// The GitHub Enterprise host, if this is an enterprise account.
+        /// The enterprise or self-hosted host, when there is one.
         pub host: Option<String>,
     }
 
-    impl From<AuthStatusResponse> for GithubAuthStatusResponseSensitive {
+    impl From<AuthStatusResponse> for GithubAuthStatusResponse {
         fn from(
             AuthStatusResponse {
-                access_token,
                 login,
                 name,
                 email,
                 host,
+                ..
             }: AuthStatusResponse,
         ) -> Self {
-            GithubAuthStatusResponseSensitive {
-                access_token: access_token.0,
+            GithubAuthStatusResponse {
                 login,
                 name,
                 email,
@@ -408,7 +402,7 @@ pub mod json {
     }
 
     #[cfg(feature = "export-schema")]
-    but_schemars::register_sdk_type!(GithubAuthStatusResponseSensitive);
+    but_schemars::register_sdk_type!(GithubAuthStatusResponse);
 
     /// Serializable version of [`AuthenticatedUser`] with exposed access token.
     ///

--- a/crates/but-gitlab/src/lib.rs
+++ b/crates/but-gitlab/src/lib.rs
@@ -244,38 +244,32 @@ pub mod json {
 
     use crate::{AuthStatusResponse, AuthenticatedUser};
 
-    /// Serializable version of [`AuthStatusResponse`] with exposed access token.
+    /// Serializable version of [`AuthStatusResponse`], without the access token.
     ///
-    /// This struct is used for API responses where the access token needs to be
-    /// sent as a plain string. Field names are converted to camelCase for JSON.
+    /// The credential is stored by the backend as part of the call, so the caller is told
+    /// who authenticated and nothing more. Field names are camelCase for JSON.
     #[derive(Debug, Serialize)]
     #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
     #[serde(rename_all = "camelCase")]
-    pub struct GitlabAuthStatusResponseSensitive {
-        /// The GitLab access token as a plain string (sensitive data).
-        pub access_token: String,
-        /// The GitLab username.
+    pub struct GitlabAuthStatusResponse {
         pub username: String,
-        /// The user's display name, if available.
         pub name: Option<String>,
-        /// The user's email address, if available.
         pub email: Option<String>,
-        /// The self-hosted GitLab host, if this is a self-hosted instance.
+        /// The enterprise or self-hosted host, when there is one.
         pub host: Option<String>,
     }
 
-    impl From<AuthStatusResponse> for GitlabAuthStatusResponseSensitive {
+    impl From<AuthStatusResponse> for GitlabAuthStatusResponse {
         fn from(
             AuthStatusResponse {
-                access_token,
                 username,
                 name,
                 email,
                 host,
+                ..
             }: AuthStatusResponse,
         ) -> Self {
-            GitlabAuthStatusResponseSensitive {
-                access_token: access_token.0,
+            GitlabAuthStatusResponse {
                 username,
                 name,
                 email,
@@ -285,7 +279,7 @@ pub mod json {
     }
 
     #[cfg(feature = "export-schema")]
-    but_schemars::register_sdk_type!(GitlabAuthStatusResponseSensitive);
+    but_schemars::register_sdk_type!(GitlabAuthStatusResponse);
 
     /// Serializable version of [`AuthenticatedUser`] with exposed access token.
     ///

--- a/packages/but-sdk/src/generated/graph/index.d.ts
+++ b/packages/but-sdk/src/generated/graph/index.d.ts
@@ -200,12 +200,12 @@ export declare function changesInWorktreeWithPerm(projectId: string, changesSour
  *
  * # Returns
  *
- * * `Ok(AuthStatusResponse)` - User is authenticated, contains access token and user details
+ * * `Ok(_)` - The user completed the flow; the account and its token are stored
  * * `Err(_)` - If the authorization is pending, denied, or the request fails
  *
  * For lower-level implementation details, see [`but_github::check_github_auth_status()`].
  */
-export declare function checkGithubAuthStatus(deviceCode: string): Promise<GithubAuthStatusResponseSensitive>
+export declare function checkGithubAuthStatus(deviceCode: string): Promise<GithubAuthStatusResponse>
 
 export declare function checkSigningSettings(projectId: string): Promise<boolean>
 
@@ -905,10 +905,10 @@ export declare function setTargetRefAndInitProject(projectId: string, targetRef:
  *
  * # Returns
  *
- * * `Ok(AuthStatusResponse)` - Token is valid, contains user details
+ * * `Ok(_)` - The token is valid and stored
  * * `Err(_)` - If the token is invalid or storage fails
  */
-export declare function storeBitbucketApiToken(email: string, accessToken: string): Promise<BitbucketAuthStatusResponseSensitive>
+export declare function storeBitbucketApiToken(email: string, accessToken: string): Promise<BitbucketAuthStatusResponse>
 
 /**
  * Stores a GitHub Personal Access Token (PAT) for github.com.
@@ -922,10 +922,10 @@ export declare function storeBitbucketApiToken(email: string, accessToken: strin
  *
  * # Returns
  *
- * * `Ok(AuthStatusResponse)` - Token is valid, contains user details
+ * * `Ok(_)` - The token is valid and stored
  * * `Err(_)` - If the token is invalid or storage fails
  */
-export declare function storeGithubPat(accessToken: string): Promise<GithubAuthStatusResponseSensitive>
+export declare function storeGithubPat(accessToken: string): Promise<GithubAuthStatusResponse>
 
 /**
  * Stores a GitLab Personal Access Token (PAT) for gitlab.com.
@@ -939,10 +939,10 @@ export declare function storeGithubPat(accessToken: string): Promise<GithubAuthS
  *
  * # Returns
  *
- * * `Ok(AuthStatusResponse)` - Token is valid, contains user details
+ * * `Ok(_)` - The token is valid and stored
  * * `Err(_)` - If the token is invalid or storage fails
  */
-export declare function storeGitlabPat(accessToken: string): Promise<GitlabAuthStatusResponseSensitive>
+export declare function storeGitlabPat(accessToken: string): Promise<GitlabAuthStatusResponse>
 
 /**
  * Tears off a branch using the behavior described by [`tear_off_branch_with_perm()`].
@@ -1360,15 +1360,15 @@ export type BitbucketAccountIdentifier = {
   };
 };
 
-/** Serializable version of [`AuthStatusResponse`] with exposed access token. */
-export type BitbucketAuthStatusResponseSensitive = {
-  /** The Bitbucket access token as a plain string (sensitive data). */
-  accessToken: string;
-  /** The Bitbucket username. */
+/**
+ * Serializable version of [`AuthStatusResponse`], without the access token.
+ *
+ * The credential is stored by the backend as part of the call, so the caller is told
+ * who authenticated and nothing more. Field names are camelCase for JSON.
+ */
+export type BitbucketAuthStatusResponse = {
   username: string;
-  /** The user's display name, if available. */
   name: string | null;
-  /** The Atlassian account email used for authentication. */
   email: string | null;
 };
 
@@ -2423,21 +2423,16 @@ export type GithubAccountIdentifier = {
 };
 
 /**
- * Serializable version of [`AuthStatusResponse`] with exposed access token.
+ * Serializable version of [`AuthStatusResponse`], without the access token.
  *
- * This struct is used for API responses where the access token needs to be
- * sent as a plain string. Field names are converted to camelCase for JSON.
+ * The credential is stored by the backend as part of the call, so the caller is told
+ * who authenticated and nothing more. Field names are camelCase for JSON.
  */
-export type GithubAuthStatusResponseSensitive = {
-  /** The GitHub access token as a plain string (sensitive data). */
-  accessToken: string;
-  /** The GitHub username/login. */
+export type GithubAuthStatusResponse = {
   login: string;
-  /** The user's display name, if available. */
   name: string | null;
-  /** The user's email address, if available. */
   email: string | null;
-  /** The GitHub Enterprise host, if this is an enterprise account. */
+  /** The enterprise or self-hosted host, when there is one. */
   host: string | null;
 };
 
@@ -2474,21 +2469,16 @@ export type GitlabAccountIdentifier = {
 };
 
 /**
- * Serializable version of [`AuthStatusResponse`] with exposed access token.
+ * Serializable version of [`AuthStatusResponse`], without the access token.
  *
- * This struct is used for API responses where the access token needs to be
- * sent as a plain string. Field names are converted to camelCase for JSON.
+ * The credential is stored by the backend as part of the call, so the caller is told
+ * who authenticated and nothing more. Field names are camelCase for JSON.
  */
-export type GitlabAuthStatusResponseSensitive = {
-  /** The GitLab access token as a plain string (sensitive data). */
-  accessToken: string;
-  /** The GitLab username. */
+export type GitlabAuthStatusResponse = {
   username: string;
-  /** The user's display name, if available. */
   name: string | null;
-  /** The user's email address, if available. */
   email: string | null;
-  /** The self-hosted GitLab host, if this is a self-hosted instance. */
+  /** The enterprise or self-hosted host, when there is one. */
   host: string | null;
 };
 

--- a/packages/but-sdk/src/generated/linear/index.d.ts
+++ b/packages/but-sdk/src/generated/linear/index.d.ts
@@ -200,12 +200,12 @@ export declare function changesInWorktreeWithPerm(projectId: string, changesSour
  *
  * # Returns
  *
- * * `Ok(AuthStatusResponse)` - User is authenticated, contains access token and user details
+ * * `Ok(_)` - The user completed the flow; the account and its token are stored
  * * `Err(_)` - If the authorization is pending, denied, or the request fails
  *
  * For lower-level implementation details, see [`but_github::check_github_auth_status()`].
  */
-export declare function checkGithubAuthStatus(deviceCode: string): Promise<GithubAuthStatusResponseSensitive>
+export declare function checkGithubAuthStatus(deviceCode: string): Promise<GithubAuthStatusResponse>
 
 export declare function checkSigningSettings(projectId: string): Promise<boolean>
 
@@ -905,10 +905,10 @@ export declare function setTargetRefAndInitProject(projectId: string, targetRef:
  *
  * # Returns
  *
- * * `Ok(AuthStatusResponse)` - Token is valid, contains user details
+ * * `Ok(_)` - The token is valid and stored
  * * `Err(_)` - If the token is invalid or storage fails
  */
-export declare function storeBitbucketApiToken(email: string, accessToken: string): Promise<BitbucketAuthStatusResponseSensitive>
+export declare function storeBitbucketApiToken(email: string, accessToken: string): Promise<BitbucketAuthStatusResponse>
 
 /**
  * Stores a GitHub Personal Access Token (PAT) for github.com.
@@ -922,10 +922,10 @@ export declare function storeBitbucketApiToken(email: string, accessToken: strin
  *
  * # Returns
  *
- * * `Ok(AuthStatusResponse)` - Token is valid, contains user details
+ * * `Ok(_)` - The token is valid and stored
  * * `Err(_)` - If the token is invalid or storage fails
  */
-export declare function storeGithubPat(accessToken: string): Promise<GithubAuthStatusResponseSensitive>
+export declare function storeGithubPat(accessToken: string): Promise<GithubAuthStatusResponse>
 
 /**
  * Stores a GitLab Personal Access Token (PAT) for gitlab.com.
@@ -939,10 +939,10 @@ export declare function storeGithubPat(accessToken: string): Promise<GithubAuthS
  *
  * # Returns
  *
- * * `Ok(AuthStatusResponse)` - Token is valid, contains user details
+ * * `Ok(_)` - The token is valid and stored
  * * `Err(_)` - If the token is invalid or storage fails
  */
-export declare function storeGitlabPat(accessToken: string): Promise<GitlabAuthStatusResponseSensitive>
+export declare function storeGitlabPat(accessToken: string): Promise<GitlabAuthStatusResponse>
 
 /**
  * Tears off a branch using the behavior described by [`tear_off_branch_with_perm()`].
@@ -1360,15 +1360,15 @@ export type BitbucketAccountIdentifier = {
   };
 };
 
-/** Serializable version of [`AuthStatusResponse`] with exposed access token. */
-export type BitbucketAuthStatusResponseSensitive = {
-  /** The Bitbucket access token as a plain string (sensitive data). */
-  accessToken: string;
-  /** The Bitbucket username. */
+/**
+ * Serializable version of [`AuthStatusResponse`], without the access token.
+ *
+ * The credential is stored by the backend as part of the call, so the caller is told
+ * who authenticated and nothing more. Field names are camelCase for JSON.
+ */
+export type BitbucketAuthStatusResponse = {
   username: string;
-  /** The user's display name, if available. */
   name: string | null;
-  /** The Atlassian account email used for authentication. */
   email: string | null;
 };
 
@@ -2423,21 +2423,16 @@ export type GithubAccountIdentifier = {
 };
 
 /**
- * Serializable version of [`AuthStatusResponse`] with exposed access token.
+ * Serializable version of [`AuthStatusResponse`], without the access token.
  *
- * This struct is used for API responses where the access token needs to be
- * sent as a plain string. Field names are converted to camelCase for JSON.
+ * The credential is stored by the backend as part of the call, so the caller is told
+ * who authenticated and nothing more. Field names are camelCase for JSON.
  */
-export type GithubAuthStatusResponseSensitive = {
-  /** The GitHub access token as a plain string (sensitive data). */
-  accessToken: string;
-  /** The GitHub username/login. */
+export type GithubAuthStatusResponse = {
   login: string;
-  /** The user's display name, if available. */
   name: string | null;
-  /** The user's email address, if available. */
   email: string | null;
-  /** The GitHub Enterprise host, if this is an enterprise account. */
+  /** The enterprise or self-hosted host, when there is one. */
   host: string | null;
 };
 
@@ -2474,21 +2469,16 @@ export type GitlabAccountIdentifier = {
 };
 
 /**
- * Serializable version of [`AuthStatusResponse`] with exposed access token.
+ * Serializable version of [`AuthStatusResponse`], without the access token.
  *
- * This struct is used for API responses where the access token needs to be
- * sent as a plain string. Field names are converted to camelCase for JSON.
+ * The credential is stored by the backend as part of the call, so the caller is told
+ * who authenticated and nothing more. Field names are camelCase for JSON.
  */
-export type GitlabAuthStatusResponseSensitive = {
-  /** The GitLab access token as a plain string (sensitive data). */
-  accessToken: string;
-  /** The GitLab username. */
+export type GitlabAuthStatusResponse = {
   username: string;
-  /** The user's display name, if available. */
   name: string | null;
-  /** The user's email address, if available. */
   email: string | null;
-  /** The self-hosted GitLab host, if this is a self-hosted instance. */
+  /** The enterprise or self-hosted host, when there is one. */
   host: string | null;
 };
 


### PR DESCRIPTION
The six forge auth endpoints answered with a `*Sensitive` DTO carrying the access token as a plain string, so a credential crossed into every frontend that called them.

None of them wanted it. Desktop types those mutations with the response and discards it, using the result only for a loading flag; lite discards it too. The `but` CLI does read the response, but only for the login it prints back — never the token. And the token desktop genuinely uses comes from `get_gh_user`, a different endpoint returning a different type, untouched here.

So the DTO loses its token rather than the endpoints losing their return: Rust callers still get `AuthStatusResponse`, while the wire type is now a plain `*AuthStatusResponse` with `login`, `name`, `email` and `host`. The frontends keep the part they display and stop receiving the part they never read.

Also drops `useGitHubAccessToken`, a desktop hook that read a token and had no callers.

Verified against master plus this commit: `cargo check`/`clippy --workspace --all-targets`, `cargo doc -D warnings`, byte-identical SDK regeneration, `svelte-check` (2647 files) and lite's typecheck.

Follow-up to #15242.
