### PR TITLE
Show the pull request a branch already has

### DIFF
--- a/apps/lite/ui/src/operands.ts
+++ b/apps/lite/ui/src/operands.ts
@@ -3,6 +3,10 @@ import type { HunkLineSelection } from "#ui/hunk.ts";
 
 export type Operand =
 	| { _tag: "UncommittedChanges" }
+	/**
+	 * Applied to the workspace: no operation can act on an unapplied branch, and
+	 * `operandLabel` asserts the ref resolves to a segment.
+	 */
 	| ({ _tag: "Branch" } & BranchOperand)
 	| ({ _tag: "Commit" } & CommitOperand)
 	| ({ _tag: "File" } & FileOperand)
@@ -37,7 +41,9 @@ export const uncommittedChangesOperand: Operand = {
 	_tag: "UncommittedChanges",
 };
 
-export const branchOperand = ({ branchRef }: BranchOperand): Operand => ({
+export const branchOperand = ({
+	branchRef,
+}: BranchOperand): Extract<Operand, { _tag: "Branch" }> => ({
 	_tag: "Branch",
 	branchRef,
 });

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -15,18 +15,23 @@ import {
 	treeChangeDiffsQueryOptions,
 } from "#ui/api/queries.ts";
 import { decodeBytes } from "#ui/api/bytes.ts";
+import type { ForgeReview } from "@gitbutler/but-sdk";
 import { branchDetailsParams } from "#ui/branch.ts";
 import { commitBody, commitTitle, shortCommitId } from "#ui/commit.ts";
 import {
 	branchFileParent,
 	branchIdentityKey,
+	type BranchOperand,
+	branchOperand,
 	commitFileParent,
+	commitOperand,
 	type FileOperand,
 	fileOperand,
 	hunkOperand,
 	type FileParent,
 	type HunkOperand,
 	type Operand,
+	uncommittedChangesFileParent,
 	weakCommitIdentityKey,
 } from "#ui/operands.ts";
 import type { BranchTab } from "#ui/projects/project.ts";
@@ -142,6 +147,7 @@ import {
 } from "./diff-view.ts";
 import { DiffMinimap } from "./DiffMinimap.tsx";
 import { getMinimapFiles, measureWrapColumns, type MinimapSelection } from "./diff-minimap.ts";
+import type { DetailsSelection } from "./details-selection.ts";
 
 export type DiffViewerHandle = CodeViewHandle<Annotation>;
 
@@ -1570,18 +1576,15 @@ const CommitDetails: FC<{
 	);
 };
 
-const BranchDetails: FC<{
-	selection: Extract<Operand, { _tag: "Branch" }>;
-	onActiveFileSelection: (itemId: string, firstHunk: HunkOperand | null) => void;
-	viewerRef: RefObject<DiffViewerHandle | null>;
-	didScrollToViaFileRef: RefObject<boolean>;
-}> = ({ selection, onActiveFileSelection, viewerRef, didScrollToViaFileRef }) => {
+/** A branch's own changes, whatever the branch's standing. */
+const BranchDiff: FC<BranchDetailsProps> = ({
+	branch,
+	onActiveFileSelection,
+	viewerRef,
+	didScrollToViaFileRef,
+}) => {
 	const { id: projectId } = useParams({ from: "/project/$id/workspace" });
-	const { data: forgeInfo } = useQuery(forgeInfoOptions(projectId));
-	const { data: headInfo } = useQuery(headInfoQueryOptions(projectId));
-	const headInfoIndex = headInfo ? getHeadInfoIndex(headInfo) : null;
 	const dispatch = useAppDispatch();
-	const detailsFullWindow = useAppSelector(interfaceSlice.selectors.selectDetailsFullWindow);
 	const filesVisibleState = useAppSelector((state) =>
 		projectSlice.selectors.selectFilesVisible(state, projectId),
 	);
@@ -1589,7 +1592,238 @@ const BranchDetails: FC<{
 		projectSlice.selectors.selectCanShowFiles(state, projectId),
 	);
 	const filesVisible = canShowFiles && filesVisibleState;
-	const branchRef = decodeBytes(selection.branchRef);
+
+	const selectFile = (selection: string) => {
+		dispatch(projectSlice.actions.selectFiles({ projectId, selection }));
+	};
+
+	return (
+		<SuspenseQuery
+			{...branchDiffQueryOptions({ projectId, branch: decodeBytes(branch.branchRef) })}
+		>
+			{({ data: branchDiff }) => (
+				<Diff
+					changes={branchDiff.changes}
+					filesVisible={filesVisible}
+					filesItems={branchDiff.changes.map((change) =>
+						changeFileRowItem({
+							change,
+							path: change.path,
+							dependencyCommitIds: [],
+						}),
+					)}
+					onPassiveFileSelection={selectFile}
+					selection={branchOperand(branch)}
+					projectId={projectId}
+					onActiveFileSelection={onActiveFileSelection}
+					viewerRef={viewerRef}
+					didScrollToViaFileRef={didScrollToViaFileRef}
+				/>
+			)}
+		</SuspenseQuery>
+	);
+};
+
+const BranchTitleRow: FC<{ branchName: string }> = ({ branchName }) => {
+	const detailsFullWindow = useAppSelector(interfaceSlice.selectors.selectDetailsFullWindow);
+
+	return (
+		<div className={styles.titleRow}>
+			{detailsFullWindow && <TopLeftControls />}
+
+			<div className={styles.title}>
+				<Icon name="branch" />
+				<h3 className={classes("text-15", "text-semibold")}>{branchName}</h3>
+			</div>
+		</div>
+	);
+};
+
+/** The Diff / Pull Request toggle, for a branch with both to show. */
+const BranchTabToggle: FC<{ branchTab: BranchTab; setBranchTab: (tab: BranchTab) => void }> = ({
+	branchTab,
+	setBranchTab,
+}) => (
+	<ToggleGroup
+		render={<ToggleGroupStyles />}
+		value={[branchTab]}
+		onValueChange={(value: Array<BranchTab>) => {
+			const head = value[0];
+			if (head === undefined) return;
+			setBranchTab(head);
+		}}
+		aria-label="Branch tab"
+	>
+		<Toggle render={<ToggleStyles />} value={"diff" satisfies BranchTab}>
+			Diff
+		</Toggle>
+		<Toggle render={<ToggleStyles />} value={"pr" satisfies BranchTab}>
+			Pull Request
+		</Toggle>
+	</ToggleGroup>
+);
+
+/** `[` and `]` step between a branch's tabs; with two of them, either key toggles. */
+const useBranchTabHotkeys = ({
+	branchTab,
+	setBranchTab,
+	target,
+	enabled = true,
+}: {
+	branchTab: BranchTab;
+	setBranchTab: (tab: BranchTab) => void;
+	target: RefObject<HTMLElement | null>;
+	enabled?: boolean;
+}) => {
+	const toggle = () => {
+		switch (branchTab) {
+			case "diff": {
+				setBranchTab("pr");
+				break;
+			}
+			case "pr": {
+				setBranchTab("diff");
+				break;
+			}
+			default:
+				branchTab satisfies never;
+		}
+	};
+
+	useHotkeys(
+		(["[", "]"] as const).map((hotkey) => ({
+			hotkey,
+			callback: toggle,
+			options: { conflictBehavior: "allow" as const, enabled, target },
+		})),
+	);
+};
+
+/**
+ * An existing review: its description, the conversation and the side panel.
+ * Editing is the applied branch's affordance — the branches tab shows a review,
+ * it does not work on one.
+ */
+const ReviewView: FC<{
+	projectId: string;
+	sourceBranch: string;
+	review: ForgeReview;
+	editing?: { active: boolean; onDone: () => void };
+}> = ({ projectId, sourceBranch, review, editing }) => {
+	const { data: forgeInfo } = useQuery(forgeInfoOptions(projectId));
+
+	return (
+		<div className={styles.prLayout}>
+			<div className={styles.prMain}>
+				<PullRequestDescription
+					key={review.number}
+					body={review.body}
+					projectId={projectId}
+					reviewId={review.number}
+					sourceBranch={sourceBranch}
+					title={review.title}
+					canSubmit={editing !== undefined}
+					editing={editing?.active ?? false}
+					onDoneEditing={() => editing?.onDone()}
+				/>
+
+				{forgeInfo?.capabilities.reviewComments !== false && (
+					<PullRequestComments projectId={projectId} review={review} />
+				)}
+			</div>
+
+			<PullRequestPanel projectId={projectId} review={review} />
+		</div>
+	);
+};
+
+type BranchDetailsProps = {
+	branch: BranchOperand;
+	onActiveFileSelection: (itemId: string, firstHunk: HunkOperand | null) => void;
+	viewerRef: RefObject<DiffViewerHandle | null>;
+	didScrollToViaFileRef: RefObject<boolean>;
+};
+
+/**
+ * A branch the workspace does not hold, as the branches tab lists them: its
+ * changes, and its review when one already exists. Opening a review is not
+ * offered — the base comes from a branch's position in a workspace stack, which
+ * this branch has not got, so `publish_review` refuses it.
+ */
+const UnappliedBranchDetails: FC<BranchDetailsProps> = ({
+	branch,
+	onActiveFileSelection,
+	viewerRef,
+	didScrollToViaFileRef,
+}) => {
+	const { id: projectId } = useParams({ from: "/project/$id/workspace" });
+	const dispatch = useAppDispatch();
+	const branchName = branchDetailsParams(decodeBytes(branch.branchRef)).branchName;
+	const { data: forgeInfo } = useQuery(forgeInfoOptions(projectId));
+	// Same query key as the applied branch's, so the two share one listing
+	// rather than polling the forge twice. Reviews are keyed by branch name,
+	// which says nothing about whether the branch is applied.
+	const { data: review } = useQuery({
+		...listReviewsQueryOptions({ projectId, cacheConfig: "noCache" }),
+		enabled: forgeInfo?.capabilities.prService === true,
+		select: (reviews) => reviews.find((review) => review.sourceBranch === branchName) ?? null,
+	});
+
+	const branchTab = useAppSelector((state) =>
+		projectSlice.selectors.selectBranchTab(state, projectId, branchName),
+	);
+	const setBranchTab = (tab: BranchTab) => {
+		dispatch(projectSlice.actions.setSelectedBranchTab({ projectId, branchName, tab }));
+	};
+
+	const ref = useRef<HTMLDivElement>(null);
+	// The review is the only second tab on offer here, so the toggle and the keys
+	// that drive it both wait for one to exist.
+	useBranchTabHotkeys({ branchTab, setBranchTab, target: ref, enabled: !!review });
+
+	return (
+		<div className={styles.container} ref={ref}>
+			<div className={styles.headerWrap}>
+				<BranchTitleRow branchName={branchName} />
+
+				{review && (
+					<div className={classes(styles.tabsRow, branchTab === "pr" && styles.tabsRowPrCap)}>
+						<BranchTabToggle branchTab={branchTab} setBranchTab={setBranchTab} />
+					</div>
+				)}
+			</div>
+
+			<Suspense fallback={<div className={classes(styles.loadingTab, "text-13")}>Loading…</div>}>
+				{review && branchTab === "pr" ? (
+					<div className={styles.prTab}>
+						<ReviewView projectId={projectId} sourceBranch={branchName} review={review} />
+					</div>
+				) : (
+					<BranchDiff
+						branch={branch}
+						onActiveFileSelection={onActiveFileSelection}
+						viewerRef={viewerRef}
+						didScrollToViaFileRef={didScrollToViaFileRef}
+					/>
+				)}
+			</Suspense>
+		</div>
+	);
+};
+
+/** A branch applied to the workspace: its changes, and the review of them. */
+const AppliedBranchDetails: FC<BranchDetailsProps> = ({
+	branch,
+	onActiveFileSelection,
+	viewerRef,
+	didScrollToViaFileRef,
+}) => {
+	const { id: projectId } = useParams({ from: "/project/$id/workspace" });
+	const { data: forgeInfo } = useQuery(forgeInfoOptions(projectId));
+	const { data: headInfo } = useQuery(headInfoQueryOptions(projectId));
+	const headInfoIndex = headInfo ? getHeadInfoIndex(headInfo) : null;
+	const dispatch = useAppDispatch();
+	const branchRef = decodeBytes(branch.branchRef);
 	const branchName = branchDetailsParams(branchRef).branchName;
 	const branchTab = useAppSelector((state) =>
 		projectSlice.selectors.selectBranchTab(state, projectId, branchName),
@@ -1609,59 +1843,11 @@ const BranchDetails: FC<{
 	};
 
 	const ref = useRef<HTMLDivElement>(null);
-
-	useHotkeys([
-		{
-			hotkey: "[",
-			callback: () => {
-				switch (branchTab) {
-					case "diff": {
-						setBranchTab("pr");
-						break;
-					}
-					case "pr": {
-						setBranchTab("diff");
-						break;
-					}
-					default:
-						branchTab satisfies never;
-				}
-			},
-			options: {
-				conflictBehavior: "allow",
-				target: ref,
-			},
-		},
-		{
-			hotkey: "]",
-			callback: () => {
-				switch (branchTab) {
-					case "diff": {
-						setBranchTab("pr");
-						break;
-					}
-					case "pr": {
-						setBranchTab("diff");
-						break;
-					}
-					default:
-						branchTab satisfies never;
-				}
-			},
-			options: {
-				conflictBehavior: "allow",
-				target: ref,
-			},
-		},
-	]);
-
-	const selectFile = (selection: string) => {
-		dispatch(projectSlice.actions.selectFiles({ projectId, selection }));
-	};
+	useBranchTabHotkeys({ branchTab, setBranchTab, target: ref });
 
 	// Use push status of segment, not branch details; something about remote
 	// tracking refs.
-	const branchCtx = headInfoIndex?.branchContextByRefBytes(selection.branchRef);
+	const branchCtx = headInfoIndex?.branchContextByRefBytes(branch.branchRef);
 	const parentSegment = branchCtx?.stack.segments[branchCtx.segmentIndex + 1];
 	const targetBranch =
 		!parentSegment || parentSegment.pushStatus === "integrated"
@@ -1673,33 +1859,10 @@ const BranchDetails: FC<{
 	return (
 		<div className={styles.container} ref={ref}>
 			<div className={styles.headerWrap}>
-				<div className={styles.titleRow}>
-					{detailsFullWindow && <TopLeftControls />}
-
-					<div className={styles.title}>
-						<Icon name="branch" />
-						<h3 className={classes("text-15", "text-semibold")}>{branchName}</h3>
-					</div>
-				</div>
+				<BranchTitleRow branchName={branchName} />
 
 				<div className={classes(styles.tabsRow, branchTab === "pr" && styles.tabsRowPrCap)}>
-					<ToggleGroup
-						render={<ToggleGroupStyles />}
-						value={[branchTab]}
-						onValueChange={(value: Array<BranchTab>) => {
-							const head = value[0];
-							if (head === undefined) return;
-							setBranchTab(head);
-						}}
-						aria-label="Branch tab"
-					>
-						<Toggle render={<ToggleStyles />} value={"diff" satisfies BranchTab}>
-							Diff
-						</Toggle>
-						<Toggle render={<ToggleStyles />} value={"pr" satisfies BranchTab}>
-							Pull Request
-						</Toggle>
-					</ToggleGroup>
+					<BranchTabToggle branchTab={branchTab} setBranchTab={setBranchTab} />
 
 					{branchTab === "pr" && !!forgeInfo?.capabilities.prService && (
 						<Suspense>
@@ -1768,54 +1931,24 @@ const BranchDetails: FC<{
 											canSubmit
 										/>
 									) : (
-										<div className={styles.prLayout}>
-											<div className={styles.prMain}>
-												<PullRequestDescription
-													key={review.number}
-													body={review.body}
-													projectId={projectId}
-													reviewId={review.number}
-													sourceBranch={branchName}
-													title={review.title}
-													canSubmit
-													editing={prEditing}
-													onDoneEditing={() => setPrEditing(false)}
-												/>
-
-												{forgeInfo.capabilities.reviewComments !== false && (
-													<PullRequestComments projectId={projectId} review={review} />
-												)}
-											</div>
-
-											<PullRequestPanel projectId={projectId} review={review} />
-										</div>
+										<ReviewView
+											projectId={projectId}
+											sourceBranch={branchName}
+											review={review}
+											editing={{ active: prEditing, onDone: () => setPrEditing(false) }}
+										/>
 									);
 								}}
 							</SuspenseQuery>
 						)}
 					</div>
 				) : (
-					<SuspenseQuery {...branchDiffQueryOptions({ projectId, branch: branchRef })}>
-						{({ data: branchDiff }) => (
-							<Diff
-								changes={branchDiff.changes}
-								filesVisible={filesVisible}
-								filesItems={branchDiff.changes.map((change) =>
-									changeFileRowItem({
-										change,
-										path: change.path,
-										dependencyCommitIds: [],
-									}),
-								)}
-								onPassiveFileSelection={selectFile}
-								selection={selection}
-								projectId={projectId}
-								onActiveFileSelection={onActiveFileSelection}
-								viewerRef={viewerRef}
-								didScrollToViaFileRef={didScrollToViaFileRef}
-							/>
-						)}
-					</SuspenseQuery>
+					<BranchDiff
+						branch={branch}
+						onActiveFileSelection={onActiveFileSelection}
+						viewerRef={viewerRef}
+						didScrollToViaFileRef={didScrollToViaFileRef}
+					/>
 				)}
 			</Suspense>
 		</div>
@@ -1844,13 +1977,11 @@ const FileDetailsSkeleton: FC = () => {
 };
 
 const FileDetails: FC<{
-	selection: Extract<Operand, { _tag: "File" }> & {
-		parent: Extract<FileParent, { _tag: "UncommittedChanges" }>;
-	};
+	path: string;
 	onActiveFileSelection: (itemId: string, firstHunk: HunkOperand | null) => void;
 	viewerRef: RefObject<DiffViewerHandle | null>;
 	didScrollToViaFileRef: RefObject<boolean>;
-}> = ({ selection, onActiveFileSelection, viewerRef, didScrollToViaFileRef }) => {
+}> = ({ path, onActiveFileSelection, viewerRef, didScrollToViaFileRef }) => {
 	const { id: projectId } = useParams({ from: "/project/$id/workspace" });
 	const dispatch = useAppDispatch();
 	const detailsFullWindow = useAppSelector(interfaceSlice.selectors.selectDetailsFullWindow);
@@ -1888,7 +2019,7 @@ const FileDetails: FC<{
 					filesVisible={filesVisible}
 					filesItems={filesItems}
 					onPassiveFileSelection={selectFile}
-					selection={selection}
+					selection={fileOperand({ parent: uncommittedChangesFileParent, path })}
 					projectId={projectId}
 					onActiveFileSelection={onActiveFileSelection}
 					viewerRef={viewerRef}
@@ -1905,46 +2036,37 @@ const FileDetails: FC<{
 };
 
 export const Details: FC<{
-	selection: Operand | null;
+	selection: DetailsSelection | null;
 	onActiveFileSelection: (itemId: string, firstHunk: HunkOperand | null) => void;
 	viewerRef: RefObject<DiffViewerHandle | null>;
 	didScrollToViaFileRef: RefObject<boolean>;
 }> = ({ selection, onActiveFileSelection, viewerRef, didScrollToViaFileRef }) => {
 	if (!selection) return;
 
+	const viewProps = { onActiveFileSelection, viewerRef, didScrollToViaFileRef };
+
 	return Match.value(selection).pipe(
-		Match.tags({
+		Match.tagsExhaustive({
 			Commit: (commit) => (
 				<Suspense fallback={<CommitDetailsSkeleton />}>
 					<CommitDetails
 						key={weakCommitIdentityKey(commit)}
-						selection={commit}
-						onActiveFileSelection={onActiveFileSelection}
-						viewerRef={viewerRef}
-						didScrollToViaFileRef={didScrollToViaFileRef}
+						selection={commitOperand(commit)}
+						{...viewProps}
 					/>
 				</Suspense>
 			),
-			Branch: (branch) => (
-				<BranchDetails
-					key={branchIdentityKey(branch)}
-					selection={branch}
-					onActiveFileSelection={onActiveFileSelection}
-					viewerRef={viewerRef}
-					didScrollToViaFileRef={didScrollToViaFileRef}
-				/>
+			AppliedBranch: (branch) => (
+				<AppliedBranchDetails key={branchIdentityKey(branch)} branch={branch} {...viewProps} />
+			),
+			UnappliedBranch: (branch) => (
+				<UnappliedBranchDetails key={branchIdentityKey(branch)} branch={branch} {...viewProps} />
+			),
+			UncommittedFile: ({ path }) => (
+				<Suspense fallback={<FileDetailsSkeleton />}>
+					<FileDetails path={path} {...viewProps} />
+				</Suspense>
 			),
 		}),
-		Match.when({ _tag: "File", parent: { _tag: "UncommittedChanges" } }, (file) => (
-			<Suspense fallback={<FileDetailsSkeleton />}>
-				<FileDetails
-					selection={file}
-					onActiveFileSelection={onActiveFileSelection}
-					viewerRef={viewerRef}
-					didScrollToViaFileRef={didScrollToViaFileRef}
-				/>
-			</Suspense>
-		)),
-		Match.orElseAbsurd,
 	);
 };

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
@@ -32,12 +32,11 @@ import {
 } from "@tanstack/react-query";
 import { useNavigate, useParams } from "@tanstack/react-router";
 import { Match } from "effect";
-import { type FC, Activity, useDeferredValue, useRef } from "react";
+import { type FC, Activity, useDeferredValue, useMemo, useRef } from "react";
 import { Group, Panel, useDefaultLayout } from "react-resizable-panels";
 import {
 	branchOperand,
 	commitOperand,
-	fileOperand,
 	operandContains,
 	operandEquals,
 	operandIdentityKey,
@@ -70,6 +69,11 @@ import { WorkspacePageErrorBoundary } from "./WorkspacePageErrorBoundary.tsx";
 import { Settings } from "./Settings/Settings.tsx";
 import { useBranchesOutline } from "./useBranchesOutline.ts";
 import { useUpstreamOutline } from "./useUpstreamOutline.ts";
+import {
+	appliedSelection,
+	unappliedSelection,
+	uncommittedFileSelection,
+} from "./details-selection.ts";
 import type { OutlineMode } from "#ui/outline/mode.ts";
 import { useStateReconciler as useReconcileState } from "#ui/reconcile.ts";
 import { defaultSettings } from "#ui/settings.ts";
@@ -608,22 +612,36 @@ const WorkspacePage: FC = () => {
 	const detailsSelectionScope = useAppSelector((state) =>
 		projectSlice.selectors.selectDetailsSelectionScope(state, projectId),
 	);
-	const detailsSelection = Match.value(detailsSelectionScope).pipe(
-		Match.when("outline", () =>
-			Match.value(outlineTab).pipe(
-				Match.when("workspace", () => outlineSelection),
-				Match.when("upstream", () => upstreamSelection),
-				Match.when("branches", () => branchesSelection),
+	// Memoised because `useDeferredValue` compares by identity and React Compiler
+	// will not memoise calls to imported helpers, so a freshly built selection
+	// every render would defer every render.
+	const detailsSelection = useMemo(
+		() =>
+			Match.value(detailsSelectionScope).pipe(
+				Match.when("outline", () =>
+					Match.value(outlineTab).pipe(
+						Match.when("workspace", () => appliedSelection(outlineSelection)),
+						Match.when("upstream", () => appliedSelection(upstreamSelection)),
+						Match.when("branches", () => unappliedSelection(branchesSelection)),
+						Match.exhaustive,
+					),
+				),
+				Match.when("uncommitted-files", () =>
+					uncommittedFilesSelection === null
+						? null
+						: uncommittedFileSelection(uncommittedFilesSelection),
+				),
+				Match.when(null, () => null),
 				Match.exhaustive,
 			),
-		),
-		Match.when("uncommitted-files", () =>
-			uncommittedFilesSelection === null
-				? null
-				: fileOperand({ parent: uncommittedChangesFileParent, path: uncommittedFilesSelection }),
-		),
-		Match.when(null, () => null),
-		Match.exhaustive,
+		[
+			branchesSelection,
+			detailsSelectionScope,
+			outlineSelection,
+			outlineTab,
+			uncommittedFilesSelection,
+			upstreamSelection,
+		],
 	);
 
 	const deferredDetailsSelection = useDeferredValue(detailsSelection);

--- a/apps/lite/ui/src/routes/project/$id/workspace/details-selection.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/details-selection.ts
@@ -1,0 +1,55 @@
+import { Match } from "effect";
+import type { BranchOperand, CommitOperand, Operand } from "#ui/operands.ts";
+
+/**
+ * What the details pane is showing.
+ *
+ * The outline tabs select from one operand vocabulary, but they are not
+ * looking at the same things: a branch applied to the workspace has a position
+ * — a base to diff against, a push status, a pull request — that an unapplied
+ * one does not. Naming the two apart is what keeps the pane from having to
+ * work out which tab it was reached from.
+ */
+export type DetailsSelection =
+	| ({ _tag: "AppliedBranch" } & BranchOperand)
+	| ({ _tag: "UnappliedBranch" } & BranchOperand)
+	| ({ _tag: "Commit" } & CommitOperand)
+	| { _tag: "UncommittedFile"; path: string };
+
+export const uncommittedFileSelection = (path: string): DetailsSelection => ({
+	_tag: "UncommittedFile",
+	path,
+});
+
+const commitSelection = ({ commitId, changeId }: CommitOperand): DetailsSelection => ({
+	_tag: "Commit",
+	commitId,
+	changeId,
+});
+
+/**
+ * An operand from a tab showing what the workspace holds. Operands with no
+ * details view of their own resolve to nothing.
+ */
+export const appliedSelection = (operand: Operand | null): DetailsSelection | null =>
+	operand === null
+		? null
+		: Match.value(operand).pipe(
+				Match.tags({
+					Branch: ({ branchRef }): DetailsSelection => ({ _tag: "AppliedBranch", branchRef }),
+					Commit: commitSelection,
+				}),
+				Match.orElse(() => null),
+			);
+
+/** An operand from the branches tab, which lists what the workspace does not hold. */
+export const unappliedSelection = (operand: Operand | null): DetailsSelection | null =>
+	operand === null
+		? null
+		: Match.value(operand).pipe(
+				Match.tags({
+					Branch: ({ branchRef }): DetailsSelection => ({ _tag: "UnappliedBranch", branchRef }),
+					Commit: commitSelection,
+				}),
+				Match.orElse(() => null),
+			);


### PR DESCRIPTION
Selecting a branch in the branches explorer showed a **Diff / Pull Request** toggle whose form could not work: `publish_review` derives the base from the branch's position in a workspace stack, and an unapplied branch has none.

The pane dispatched on the *operand* — what is selected, not what it is — and both outline tabs mint a `Branch`. It now takes a `DetailsSelection`:

```
AppliedBranch | UnappliedBranch | Commit | UncommittedFile
```

`WorkspacePage` already resolves selection per tab, so it names what it resolved. Applied and unapplied are the words the rest of the app uses — `unappliedStacks` is what fills the branches tab, and `ListedBranch` was already taken by the SDK type those stacks are made of.

## What the branches tab shows now

| | header | body |
|---|---|---|
| branch has a pull request | Diff / Pull Request toggle | diff, or the full review |
| branch has none | title only | diff |

A review is keyed by branch name, so the description, conversation, checks, reviewers and labels were already reachable — nothing new was needed to read them. The toggle appears only alongside a review, so it is never a half-dead control. Opening a review is still not offered here; apply the branch and use the workspace, where the base exists.

`AppliedBranchDetails` and `UnappliedBranchDetails` share `BranchTabToggle`, `useBranchTabHotkeys`, `BranchDiff`, `BranchTitleRow` and `ReviewView`. Editing the description stays the applied view's affordance; the review's own controls work in both.

`Operand` keeps its shape. It is the argument type of `getOperations`, and an unapplied branch is precisely what operations cannot act on — so the distinction belongs where the two tabs converge, not in a dozen exhaustive matches that could not act on it. Its `Branch` case is now commented to say it means an *applied* branch, which it already did: `operandLabel` asserts the ref resolves to a segment.

## Verification

Driven against the running dev app over CDP: an unapplied branch with a PR shows both tabs and the full review (description, checks, reviewers, labels, activity); one without shows title and diff only; an applied branch is unchanged and its pull-request tab still loads.

Checked against the committed tree in a scratch worktree, not the working copy: typecheck, `oxlint` over the whole repo, `prettier`, `knip:prod`, `knip:non-prod` and the lite unit tests (77/77) all clean.
