### PR TITLE
Add a folder tree mode to lite's file lists

### DIFF
--- a/apps/lite/electron/src/settings.ts
+++ b/apps/lite/electron/src/settings.ts
@@ -23,6 +23,7 @@ const guiSettingsV1 = type({
 	"diffStyle?": '"unified" | "split"',
 	"diffTabSize?": "number",
 	"editorId?": "string",
+	"fileDisplayMode?": "'list' | 'tree'",
 	"lineDiffType?": "'word-alt' | 'word' | 'char' | 'none'",
 	"pathFirst?": "boolean",
 	"terminalId?": "string",

--- a/apps/lite/ui/src/components/Checkbox.module.css
+++ b/apps/lite/ui/src/components/Checkbox.module.css
@@ -15,7 +15,7 @@
 	box-shadow: inset 0 0 0 var(--border-width) var(--border-2);
 	color: var(--text-2);
 
-	&:not([data-checked], :disabled, [data-disabled]) {
+	&:not([data-checked], [data-indeterminate], :disabled, [data-disabled]) {
 		&:hover {
 			box-shadow: inset 0 0 0 var(--border-width) var(--border-1);
 
@@ -25,7 +25,9 @@
 		}
 	}
 
-	&[data-checked] {
+	/* Indeterminate reads as filled like a checked box: it stands for a folder
+	   with some of its files checked, so it belongs on the checked side. */
+	&:is([data-checked], [data-indeterminate]) {
 		background-color: var(--fill-pop-bg);
 		box-shadow: inset 0 0 0 var(--border-width) var(--fill-pop-bg);
 		color: var(--fill-pop-fg);
@@ -46,7 +48,7 @@
 	&[data-disabled] {
 		cursor: not-allowed;
 
-		&:not([data-checked]) {
+		&:not([data-checked], [data-indeterminate]) {
 			background-color: color-mix(
 				in srgb,
 				var(--border-2) var(--disabled-opacity),
@@ -56,7 +58,7 @@
 				color-mix(in srgb, var(--border-2) var(--disabled-opacity), var(--resolved-bg));
 		}
 
-		&[data-checked] {
+		&:is([data-checked], [data-indeterminate]) {
 			background-color: color-mix(
 				in srgb,
 				var(--fill-pop-bg) var(--disabled-opacity),
@@ -80,4 +82,9 @@
 	transition:
 		opacity 0.08s ease,
 		transform 0.08s ease;
+}
+
+.checkbox:not([data-indeterminate]) .checkboxDash,
+.checkbox[data-indeterminate] .checkboxTick {
+	display: none;
 }

--- a/apps/lite/ui/src/components/Checkbox.tsx
+++ b/apps/lite/ui/src/components/Checkbox.tsx
@@ -11,12 +11,31 @@ export const Checkbox: FC<Omit<ComponentProps<typeof BaseCheckbox.Root>, "childr
 		}
 	>
 		<BaseCheckbox.Indicator keepMounted className={styles.checkboxIndicator}>
-			<svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true">
+			{/* Both glyphs are always drawn and CSS shows one, so a checkbox that
+			    changes state doesn't remount its indicator mid-transition. */}
+			<svg
+				className={styles.checkboxTick}
+				width="10"
+				height="10"
+				viewBox="0 0 10 10"
+				fill="none"
+				aria-hidden="true"
+			>
 				<path
 					d="M9 2.5L4.92139 6.74855C4.52783 7.15851 3.87217 7.15851 3.47861 6.74856L1 4.16667"
 					stroke="currentColor"
 					strokeWidth="1.5"
 				/>
+			</svg>
+			<svg
+				className={styles.checkboxDash}
+				width="10"
+				height="10"
+				viewBox="0 0 10 10"
+				fill="none"
+				aria-hidden="true"
+			>
+				<path d="M1.5 5H8.5" stroke="currentColor" strokeWidth="1.5" />
 			</svg>
 		</BaseCheckbox.Indicator>
 	</BaseCheckbox.Root>

--- a/apps/lite/ui/src/projects/project.ts
+++ b/apps/lite/ui/src/projects/project.ts
@@ -88,6 +88,16 @@ type WorkspaceState = {
 	 */
 	uncommittedFilesFilter: string | null;
 	filesFilter: string | null;
+	/**
+	 * Directories whose contents the tree view hides, keyed by directory path.
+	 *
+	 * Collapsed rather than expanded, as with {@link WorkspaceState.foldedSegments}:
+	 * a tree opens showing everything, so it is the hiding that is worth recording.
+	 * One set per list, as with the filters — the two lists hold different files
+	 * and each is somewhere the user is looking separately.
+	 */
+	uncommittedFilesCollapsedDirectories: Record<string, true>;
+	filesCollapsedDirectories: Record<string, true>;
 };
 
 const createInitialSelectionState = (): SelectionState => ({
@@ -107,6 +117,8 @@ const createInitialWorkspaceState = (): WorkspaceState => ({
 	selection: createInitialSelectionState(),
 	uncommittedFilesFilter: null,
 	filesFilter: null,
+	uncommittedFilesCollapsedDirectories: {},
+	filesCollapsedDirectories: {},
 });
 
 export type OutlineTab = "workspace" | "upstream" | "branches";
@@ -485,6 +497,16 @@ export const projectReducers = {
 
 		workspaceState.filesFilter = filter;
 	},
+	toggleUncommittedFilesDirectoryCollapsed: (state: ProjectState, { path }: { path: string }) => {
+		const collapsed = state.workspace.uncommittedFilesCollapsedDirectories;
+		if (collapsed[path]) delete collapsed[path];
+		else collapsed[path] = true;
+	},
+	toggleFilesDirectoryCollapsed: (state: ProjectState, { path }: { path: string }) => {
+		const collapsed = state.workspace.filesCollapsedDirectories;
+		if (collapsed[path]) delete collapsed[path];
+		else collapsed[path] = true;
+	},
 	setBranchSearch: (state: ProjectState, { search }: { search: string }) => {
 		branchesReducers.setSearch(state.branches, { search });
 	},
@@ -579,6 +601,10 @@ export const projectSelectors = {
 	selectDetailsSelectionScope: (state: ProjectState) => state.workspace.detailsSelectionScope,
 	selectUncommittedFilesFilter: (state: ProjectState) => state.workspace.uncommittedFilesFilter,
 	selectFilesFilter: (state: ProjectState) => state.workspace.filesFilter,
+	selectUncommittedFilesCollapsedDirectories: (state: ProjectState) =>
+		state.workspace.uncommittedFilesCollapsedDirectories,
+	selectFilesCollapsedDirectories: (state: ProjectState) =>
+		state.workspace.filesCollapsedDirectories,
 	selectSelectionUncommittedFiles: (
 		state: ProjectState,
 		navigationIndex: NavigationIndex<string>,

--- a/apps/lite/ui/src/routes/project/$id/workspace/ChangesHeaderRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/ChangesHeaderRow.tsx
@@ -21,6 +21,7 @@ import { ChangeStats } from "./ChangeStats.tsx";
 import type { LineStats } from "./lineStats.ts";
 import { getRowButtonClassName } from "./Row-utils.ts";
 import { RowToolbar, SectionHeaderRow } from "./Row.tsx";
+import { FileDisplayModeToggle } from "./FileDisplayModeToggle.tsx";
 
 export const ChangesHeaderRow: FC<{
 	projectId: string;
@@ -103,13 +104,17 @@ export const ChangesHeaderRow: FC<{
 			actions={
 				<Toolbar.Root aria-label="Changes actions" render={<RowToolbar forceVisible />}>
 					{changes.length > 0 && (
-						<Toolbar.Button
-							aria-label="Filter files"
-							onClick={onOpenFilter}
-							className={getRowButtonClassName({ size: "regular", iconOnly: true })}
-						>
-							<Icon name="search" />
-						</Toolbar.Button>
+						<>
+							<FileDisplayModeToggle />
+
+							<Toolbar.Button
+								aria-label="Filter files"
+								onClick={onOpenFilter}
+								className={getRowButtonClassName({ size: "regular", iconOnly: true })}
+							>
+								<Icon name="search" />
+							</Toolbar.Button>
+						</>
 					)}
 
 					<Toolbar.Button

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -1194,7 +1194,6 @@ const Diff: FC<{
 										onRowSelection={activateRow}
 										projectId={projectId}
 										rows={filesRows}
-										mode={fileDisplayMode}
 										collapsedDirectories={filesCollapsedDirectories}
 										onToggleDirectoryCollapsed={(path) =>
 											dispatch(

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -92,10 +92,17 @@ import {
 	pathMatchesFilter,
 	type FileRowItem,
 } from "./file-row.ts";
+import {
+	buildFileTreeRows,
+	fileTreeNavigationIndex,
+	selectedFilePath,
+	type FileDisplayMode,
+	type FileTreeRow,
+} from "./file-tree.ts";
+import { useFileDisplayMode } from "./useFileDisplayMode.ts";
 import { FileFilterRow } from "./FileFilterRow.tsx";
 import { useFileFilter } from "./useFileFilter.ts";
 import { contiguousSelectionByLine, wholeHunkSelectionByLine } from "#ui/hunk.ts";
-import { buildIndexByKey, type NavigationIndex } from "#ui/workspace/navigation-index.ts";
 import { showNativeContextMenu, showNativeMenuFromTrigger } from "#ui/native-menu.ts";
 import { useFileMenuItems } from "#ui/routes/project/$id/workspace/useFileMenuItems.ts";
 import { useMergedRefs } from "@base-ui/utils/useMergedRefs";
@@ -848,6 +855,31 @@ const DiffStyleToggleGroup: FC<
 	);
 };
 
+/**
+ * Kept whole and out of the component so the compiler can memoise the layout on
+ * its inputs; derived in render, the rows — and the navigation index built from
+ * them — take a fresh identity every time anything else about the pane changes.
+ *
+ * The filter narrows the file list only; the diff itself keeps every file, so
+ * the list stays a way of reaching a file rather than a way of hiding one.
+ */
+const buildFilesRows = ({
+	filesItems,
+	filter,
+	mode,
+	collapsedDirectories,
+}: {
+	filesItems: Array<FileRowItem>;
+	filter: string | null;
+	mode: FileDisplayMode;
+	collapsedDirectories: Record<string, true>;
+}): Array<FileTreeRow<FileRowItem>> =>
+	buildFileTreeRows({
+		items: filesItems.filter((item) => pathMatchesFilter(item.path, filter)),
+		mode,
+		collapsedDirectories,
+	});
+
 const Diff: FC<{
 	changes: Array<TreeChange>;
 	filesVisible: boolean;
@@ -893,14 +925,24 @@ const Diff: FC<{
 	const filesFilter = useAppSelector((state) =>
 		projectSlice.selectors.selectFilesFilter(state, projectId),
 	);
-	// The filter narrows the file list only; the diff itself keeps every file, so
-	// the list stays a way of reaching a file rather than a way of hiding one.
-	const filteredFilesItems = filesItems.filter((item) => pathMatchesFilter(item.path, filesFilter));
-	const files = filteredFilesItems.map((item) => item.path);
-	const filesNavigationIndex: NavigationIndex<string> = {
-		items: files,
-		indexByKey: buildIndexByKey(files, (path) => path),
-	};
+	const fileDisplayMode = useFileDisplayMode();
+	const filesCollapsedDirectories = useAppSelector((state) =>
+		projectSlice.selectors.selectFilesCollapsedDirectories(state, projectId),
+	);
+	// As with `fileParent` below, the compiler leaves this derivation outside its
+	// memo blocks here, and the rows carry the identity the file list and its
+	// navigation index are keyed on — so it is memoised by hand.
+	const filesRows = useMemo(
+		() =>
+			buildFilesRows({
+				filesItems,
+				filter: filesFilter,
+				mode: fileDisplayMode,
+				collapsedDirectories: filesCollapsedDirectories,
+			}),
+		[filesItems, filesFilter, fileDisplayMode, filesCollapsedDirectories],
+	);
+	const filesNavigationIndex = useMemo(() => fileTreeNavigationIndex(filesRows), [filesRows]);
 	const filesSelection = useAppSelector((state) =>
 		projectSlice.selectors.selectSelectionFiles(state, projectId, filesNavigationIndex),
 	);
@@ -935,7 +977,10 @@ const Diff: FC<{
 		select: (comments) => annotationsByPathForScope(comments, fileParent),
 	});
 
-	const activeFilePath = selection._tag === "File" ? selection.path : filesSelection;
+	// A directory row stands for the first file below it, so the diff has
+	// something to show while the cursor rests on a folder.
+	const activeFilePath =
+		selection._tag === "File" ? selection.path : selectedFilePath(filesRows, filesSelection);
 
 	// Keyed on the file's index, not its path: scrolling moves the selection, so
 	// keying on path reparsed every file per boundary crossed. `null` is
@@ -980,10 +1025,11 @@ const Diff: FC<{
 		};
 	}, [diffSelection, diffViewSansAnno]);
 
-	const activateFile = (selection: string) => {
+	const activateRow = (selection: string) => {
 		onPassiveFileSelection(selection);
 
-		const file = diffViewSansAnno.fileByPath.get(selection);
+		const path = selectedFilePath(filesRows, selection);
+		const file = path === null ? undefined : diffViewSansAnno.fileByPath.get(path);
 		if (!file) return;
 
 		onActiveFileSelection(file.item.id, file.hunks[0]?.operand ?? null);
@@ -997,8 +1043,8 @@ const Diff: FC<{
 		inputId: "files-filter-input",
 		scope: "files",
 		selection: filesSelection,
-		firstPath: filteredFilesItems[0]?.path,
-		onEnterList: activateFile,
+		firstPath: filesRows[0]?.path,
+		onEnterList: activateRow,
 		panelRef: filesPanelRef,
 		listRef: filesTreeRef,
 		enabled: filesVisible && changes.length > 0,
@@ -1145,9 +1191,16 @@ const Diff: FC<{
 								>
 									<FilesTree
 										data-selection-scope={"files" satisfies SelectionScope}
-										onFileSelection={activateFile}
+										onRowSelection={activateRow}
 										projectId={projectId}
-										items={filteredFilesItems}
+										rows={filesRows}
+										mode={fileDisplayMode}
+										collapsedDirectories={filesCollapsedDirectories}
+										onToggleDirectoryCollapsed={(path) =>
+											dispatch(
+												projectSlice.actions.toggleFilesDirectoryCollapsed({ projectId, path }),
+											)
+										}
 										selection={filesSelection}
 										navigationIndex={filesNavigationIndex}
 										fileParent={fileParent}

--- a/apps/lite/ui/src/routes/project/$id/workspace/DirectoryRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DirectoryRow.tsx
@@ -1,0 +1,79 @@
+import { Icon } from "#ui/components/Icon.tsx";
+import { classes } from "#ui/components/classes.ts";
+import { projectSlice } from "#ui/projects/state.ts";
+import { useAppSelector } from "#ui/store.ts";
+import type { ComponentProps, FC } from "react";
+import styles from "./FilesTree.module.css";
+import rowStyles from "./Row.module.css";
+import { Row, RowCheckbox, RowLabel, RowLabelContainer } from "./Row.tsx";
+
+/** Whether every file below a directory is checked, some of them, or none. */
+export type DirectoryCheckedState = "checked" | "indeterminate" | "unchecked";
+
+export const DirectoryRow: FC<
+	{
+		projectId: string;
+		path: string;
+		/** The trailing path segments this row stands for, e.g. `src/lib`. */
+		name: string;
+		fileCount: number;
+		isCollapsed: boolean;
+		canCheck: boolean;
+		checkedState: DirectoryCheckedState;
+		checkDirectory: (evt: { path: string; checked: boolean }) => void;
+	} & ComponentProps<typeof Row>
+> = ({
+	projectId,
+	path,
+	name,
+	fileCount,
+	isCollapsed,
+	canCheck,
+	checkedState,
+	checkDirectory,
+	...restProps
+}) => {
+	const isDefaultMode = useAppSelector(
+		(state) => projectSlice.selectors.selectOutlineModeState(state, projectId)._tag === "Default",
+	);
+
+	return (
+		<Row
+			{...restProps}
+			isChecked={checkedState === "checked"}
+			className={classes(restProps.className, styles.row)}
+		>
+			{/* The chevron reports the state the row's own click toggles, so it is a
+			    mark rather than a control — the checkbox is what takes clicks here. */}
+			<div className={styles.leading}>
+				<Icon
+					size={14}
+					className={styles.leadingMark}
+					name={isCollapsed ? "chevron-right" : "chevron-down"}
+				/>
+				<RowCheckbox
+					disabled={!isDefaultMode || !canCheck}
+					aria-label={`Check directory ${path}`}
+					checked={checkedState === "checked"}
+					indeterminate={checkedState === "indeterminate"}
+					className={styles.leadingCheckbox}
+					nativeButton
+					onCheckedChange={(checked) => {
+						checkDirectory({ path, checked });
+					}}
+				/>
+			</div>
+
+			<RowLabelContainer>
+				<RowLabel singleLine>{name}</RowLabel>
+			</RowLabelContainer>
+
+			{/* Collapsed, the count is the only sign of what the row is holding. */}
+			{isCollapsed && (
+				<span className={classes(styles.fileCount, rowStyles.fadedText, "text-13")}>
+					{fileCount}
+				</span>
+			)}
+		</Row>
+	);
+};

--- a/apps/lite/ui/src/routes/project/$id/workspace/FileDisplayModeToggle.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/FileDisplayModeToggle.tsx
@@ -1,0 +1,27 @@
+import { useSaveGUISettings } from "#ui/api/mutations.ts";
+import { Icon } from "#ui/components/Icon.tsx";
+import { Toolbar } from "@base-ui/react";
+import type { FC } from "react";
+import { getRowButtonClassName } from "./Row-utils.ts";
+import { useFileDisplayMode } from "./useFileDisplayMode.ts";
+
+/**
+ * Switches every file list between flat and folder-shaped. It shows the mode it
+ * would switch to rather than the one in force — the list below it is already
+ * saying which that is.
+ */
+export const FileDisplayModeToggle: FC = () => {
+	const mode = useFileDisplayMode();
+	const { mutate: saveGUISettings } = useSaveGUISettings();
+	const nextMode = mode === "tree" ? "list" : "tree";
+
+	return (
+		<Toolbar.Button
+			aria-label={nextMode === "tree" ? "Show as tree" : "Show as list"}
+			onClick={() => saveGUISettings({ fileDisplayMode: nextMode })}
+			className={getRowButtonClassName({ size: "regular", iconOnly: true })}
+		>
+			<Icon name={nextMode === "tree" ? "folder-tree" : "list"} />
+		</Toolbar.Button>
+	);
+};

--- a/apps/lite/ui/src/routes/project/$id/workspace/FileRow.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/FileRow.module.css
@@ -33,32 +33,6 @@
 	}
 }
 
-.iconWithCheckbox {
-	display: grid;
-
-	& > * {
-		grid-area: 1 / 1;
-	}
-}
-
-.icon {
-	align-self: center;
-}
-
-.checkbox {
-	opacity: 0;
-
-	&[data-checked],
-	.row:hover &,
-	&:focus {
-		opacity: 1;
-	}
-
-	&[data-disabled] {
-		display: none;
-	}
-}
-
 .conflictIcon {
 	flex-shrink: 0;
 	margin-right: 2px;

--- a/apps/lite/ui/src/routes/project/$id/workspace/FileRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/FileRow.tsx
@@ -12,6 +12,7 @@ import { Toolbar, Tooltip } from "@base-ui/react";
 import { Match } from "effect";
 import type { ComponentProps, FC } from "react";
 import styles from "./FileRow.module.css";
+import treeStyles from "./FilesTree.module.css";
 import { Row, RowCheckbox, RowLabel, RowLabelContainer, RowToolbar } from "./Row.tsx";
 import { getRowButtonClassName } from "./Row-utils.ts";
 import { DependencyIndicator } from "#ui/routes/project/$id/workspace/DependencyIndicator.tsx";
@@ -28,8 +29,11 @@ export const FileRow: FC<
 		canCheck: boolean;
 		isChecked: boolean;
 		checkFile: (evt: { path: string; shiftKey: boolean }) => void;
-		/** Lead with the directory instead of the file name. Resolved by the list, not here. */
-		pathFirst: boolean;
+		/**
+		 * Where the directory goes: leading the file name, trailing it, or nowhere
+		 * — the tree already says which directory this is. Resolved by the list.
+		 */
+		pathDisplay: "lead" | "trail" | "hidden";
 	} & Omit<ComponentProps<typeof Row>, "projectId">
 > = ({
 	item,
@@ -39,7 +43,7 @@ export const FileRow: FC<
 	canCheck,
 	isChecked,
 	checkFile,
-	pathFirst,
+	pathDisplay,
 	id,
 	...restProps
 }) => {
@@ -70,15 +74,15 @@ export const FileRow: FC<
 					<Row
 						{...restProps}
 						isChecked={isChecked}
-						className={classes(restProps.className, styles.row)}
+						className={classes(restProps.className, treeStyles.row)}
 						onContextMenu={(event) => {
 							void showNativeContextMenu(event, menuItems);
 						}}
 					/>
 				}
 			>
-				<div className={styles.iconWithCheckbox}>
-					<FileIcon fileName={fileName} className={styles.icon} />
+				<div className={treeStyles.leading}>
+					<FileIcon fileName={fileName} className={treeStyles.leadingMark} />
 					<Tooltip.Root
 						// This gets in the way when the user tries to move their hover to a
 						// sibling row.
@@ -88,7 +92,7 @@ export const FileRow: FC<
 							disabled={!isDefaultMode || !canCheck}
 							aria-label={`Check file ${relativePath}`}
 							checked={isChecked}
-							className={styles.checkbox}
+							className={treeStyles.leadingCheckbox}
 							nativeButton
 							render={<Tooltip.Trigger />}
 							onCheckedChange={(_checked, { event }) => {
@@ -117,13 +121,13 @@ export const FileRow: FC<
 						/>
 					)}
 					<RowLabel singleLine>
-						{directoryPath !== null && pathFirst && (
+						{directoryPath !== null && pathDisplay === "lead" && (
 							<span className={classes(styles.pathLead, rowStyles.fadedText)}>
 								{directoryPath}/
 							</span>
 						)}
 						{fileName}
-						{directoryPath !== null && !pathFirst && (
+						{directoryPath !== null && pathDisplay === "trail" && (
 							<span className={classes(styles.pathInit, rowStyles.fadedText)}>{directoryPath}</span>
 						)}
 					</RowLabel>

--- a/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.module.css
@@ -7,3 +7,47 @@
 		outline: none;
 	}
 }
+
+/* Shared by both row kinds, which is why it lives with the tree rather than
+   with either of them: it anchors the hover rules below, and carries the
+   indent that puts a row under its directory. List mode leaves depth at 0. */
+.row.row {
+	padding-inline-start: calc(8px + var(--file-tree-depth, 0) * 12px);
+}
+
+/* The mark and the checkbox share one cell: the mark says what the row is, and
+   gives way to the checkbox once the row is worth acting on. */
+.leading {
+	display: grid;
+
+	& > * {
+		grid-area: 1 / 1;
+	}
+}
+
+.leadingMark {
+	align-self: center;
+	color: var(--text-3);
+}
+
+.fileCount {
+	flex-shrink: 0;
+	align-self: center;
+	font-variant-numeric: tabular-nums;
+}
+
+/* Opaque, so a checked box covers the mark it shares a cell with. */
+.leadingCheckbox {
+	opacity: 0;
+
+	&[data-checked],
+	&[data-indeterminate],
+	.row:hover &,
+	&:focus {
+		opacity: 1;
+	}
+
+	&[data-disabled] {
+		display: none;
+	}
+}

--- a/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.tsx
@@ -30,7 +30,8 @@ import { useMergedRefs } from "@base-ui/utils/useMergedRefs";
 import { FileRow } from "./FileRow.tsx";
 import { DirectoryRow, type DirectoryCheckedState } from "./DirectoryRow.tsx";
 import type { FileRowItem } from "./file-row.ts";
-import { parentDirectoryRow, type FileDisplayMode, type FileTreeRow } from "./file-tree.ts";
+import { parentDirectoryRow, type FileTreeRow } from "./file-tree.ts";
+import { useFileDisplayMode } from "./useFileDisplayMode.ts";
 import { checkedRange, navigationIndexRange } from "#ui/checking.ts";
 import {
 	useCommitUncommitChanges,
@@ -39,8 +40,6 @@ import {
 } from "#ui/api/mutations.ts";
 import { createDiffSpec } from "#ui/operations/diff-specs.ts";
 import type { TreeChange } from "@gitbutler/but-sdk";
-
-type Rows = Array<FileTreeRow<FileRowItem>>;
 
 const useFilesTreeHotkeys = ({
 	checkRow,
@@ -51,6 +50,7 @@ const useFilesTreeHotkeys = ({
 	fileParent,
 	rows,
 	selection,
+	selectedRow,
 	selectedChange,
 	toggleDirectoryCollapsed,
 	collapsedDirectories,
@@ -61,8 +61,9 @@ const useFilesTreeHotkeys = ({
 	projectId: string;
 	ref: React.RefObject<HTMLElement | null>;
 	fileParent: FileParent;
-	rows: Rows;
+	rows: Array<FileTreeRow<FileRowItem>>;
 	selection: string | null;
+	selectedRow: FileTreeRow<FileRowItem> | undefined;
 	selectedChange: TreeChange | null;
 	toggleDirectoryCollapsed: (path: string) => void;
 	collapsedDirectories: Record<string, true>;
@@ -87,10 +88,11 @@ const useFilesTreeHotkeys = ({
 	const selectedUncommittedChange =
 		fileParent._tag === "UncommittedChanges" ? selectedChange : null;
 
-	const selectedRowIndex =
-		selection === null ? -1 : rows.findIndex((row) => row.path === selection);
-	const selectedRow = selectedRowIndex === -1 ? undefined : rows[selectedRowIndex];
 	const selectedDirectory = selectedRow?._tag === "Directory" ? selectedRow : null;
+
+	// Only the two moves below want a position rather than a row, and only once a
+	// key is pressed — so the scan for it stays off the render path.
+	const rowIndex = (path: string): number => rows.findIndex((row) => row.path === path);
 
 	const absorbSelectedFile = () => {
 		if (selectedUncommittedChange === null) return;
@@ -152,7 +154,7 @@ const useFilesTreeHotkeys = ({
 			return;
 		}
 
-		const child = rows[selectedRowIndex + 1];
+		const child = rows[rowIndex(selectedDirectory.path) + 1];
 		if (child !== undefined && child.depth > selectedDirectory.depth) onRowSelection(child.path);
 	};
 
@@ -163,7 +165,9 @@ const useFilesTreeHotkeys = ({
 			return;
 		}
 
-		const parent = parentDirectoryRow(rows, selectedRowIndex);
+		if (selectedRow === undefined) return;
+
+		const parent = parentDirectoryRow(rows, rowIndex(selectedRow.path));
 		if (parent !== null) onRowSelection(parent.path);
 	};
 
@@ -310,8 +314,7 @@ const useFilesTreeHotkeys = ({
 export const FilesTree: FC<
 	{
 		projectId: string;
-		rows: Rows;
-		mode: FileDisplayMode;
+		rows: Array<FileTreeRow<FileRowItem>>;
 		collapsedDirectories: Record<string, true>;
 		onToggleDirectoryCollapsed: (path: string) => void;
 		selection: string | null;
@@ -322,7 +325,6 @@ export const FilesTree: FC<
 	} & ComponentProps<"div">
 > = ({
 	rows,
-	mode,
 	collapsedDirectories,
 	onToggleDirectoryCollapsed,
 	selection,
@@ -345,6 +347,7 @@ export const FilesTree: FC<
 		...guiSettingsQueryOptions,
 		select: (cfg) => cfg.pathFirst ?? defaultSettings.pathFirst,
 	});
+	const mode = useFileDisplayMode();
 	const canCheck = useAppSelector((state) =>
 		projectSlice.selectors.selectCanCheckFiles(state, projectId, fileParent),
 	);
@@ -358,7 +361,8 @@ export const FilesTree: FC<
 
 	const fileCheckRangeAnchor = useRef<string>(null);
 	const fileCheckRangeEnd = useRef<string>(null);
-	const selectedRow = selection === null ? undefined : rows.find((row) => row.path === selection);
+	const rowByPath = new Map(rows.map((row) => [row.path, row]));
+	const selectedRow = selection === null ? undefined : rowByPath.get(selection);
 	const selectedItem = selectedRow?._tag === "File" ? selectedRow.item : undefined;
 	const selectedChange = selectedItem?._tag === "Change" ? selectedItem.change : null;
 
@@ -376,14 +380,12 @@ export const FilesTree: FC<
 		return checkedCount === filePaths.length ? "checked" : "indeterminate";
 	};
 
-	const directoryPaths = new Set(rows.flatMap((row) => (row._tag === "Directory" ? row.path : [])));
-
 	const rangeResolver = navigationIndexRange<string, string>({
 		navigationIndex,
 		getKey: (path) => path,
 		// Range-checking runs over files; a directory caught in the middle of a
 		// range is passed over rather than checked as a path of its own.
-		filterMap: (path) => (directoryPaths.has(path) ? null : path),
+		filterMap: (path) => (rowByPath.get(path)?._tag === "Directory" ? null : path),
 	});
 	const getCheckedRange = checkedRange(rangeResolver);
 
@@ -443,7 +445,7 @@ export const FilesTree: FC<
 	};
 
 	const checkDirectory = ({ path, checked }: { path: string; checked: boolean }): void => {
-		const row = rows.find((row) => row.path === path);
+		const row = rowByPath.get(path);
 		if (row?._tag !== "Directory") return;
 
 		// A directory stands for a set rather than a point, so it can't anchor a
@@ -461,7 +463,7 @@ export const FilesTree: FC<
 
 	/** Space and the row checkboxes both land here, whichever kind of row it is. */
 	const checkRow = ({ path, shiftKey }: { path: string; shiftKey: boolean }): void => {
-		const row = rows.find((row) => row.path === path);
+		const row = rowByPath.get(path);
 		if (row?._tag === "Directory") {
 			checkDirectory({ path, checked: directoryCheckedState(row.filePaths) !== "checked" });
 			return;
@@ -479,6 +481,7 @@ export const FilesTree: FC<
 		fileParent,
 		rows,
 		selection,
+		selectedRow,
 		selectedChange,
 		toggleDirectoryCollapsed: onToggleDirectoryCollapsed,
 		collapsedDirectories,
@@ -609,8 +612,6 @@ const TreeItem: FC<
 			"aria-selected": isSelected,
 			"aria-expanded": isExpanded,
 			"aria-level": row.depth + 1,
-			"aria-posinset": row.positionInLevel,
-			"aria-setsize": row.levelSize,
 			style: depthStyle(row.depth),
 		}),
 	});

--- a/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.tsx
@@ -18,7 +18,7 @@ import { useAppDispatch, useAppSelector, useAppStore } from "#ui/store.ts";
 import { classes } from "#ui/components/classes.ts";
 import { mergeProps, useRender } from "@base-ui/react";
 import { useQuery } from "@tanstack/react-query";
-import { type ComponentProps, type FC, useRef } from "react";
+import { type ComponentProps, type CSSProperties, type FC, useRef } from "react";
 import styles from "./FilesTree.module.css";
 import { Row, RowLabel, RowLabelContainer } from "./Row.tsx";
 import { OperationSourceC } from "#ui/routes/project/$id/workspace/OperationSourceC.tsx";
@@ -28,7 +28,9 @@ import { changesFileHotkeys } from "#ui/hotkeys.ts";
 import { useHotkeys } from "@tanstack/react-hotkeys";
 import { useMergedRefs } from "@base-ui/utils/useMergedRefs";
 import { FileRow } from "./FileRow.tsx";
+import { DirectoryRow, type DirectoryCheckedState } from "./DirectoryRow.tsx";
 import type { FileRowItem } from "./file-row.ts";
+import { parentDirectoryRow, type FileDisplayMode, type FileTreeRow } from "./file-tree.ts";
 import { checkedRange, navigationIndexRange } from "#ui/checking.ts";
 import {
 	useCommitUncommitChanges,
@@ -38,24 +40,32 @@ import {
 import { createDiffSpec } from "#ui/operations/diff-specs.ts";
 import type { TreeChange } from "@gitbutler/but-sdk";
 
+type Rows = Array<FileTreeRow<FileRowItem>>;
+
 const useFilesTreeHotkeys = ({
-	checkFile,
+	checkRow,
 	navigationIndex,
-	onFileSelection,
+	onRowSelection,
 	projectId,
 	ref,
 	fileParent,
+	rows,
 	selection,
 	selectedChange,
+	toggleDirectoryCollapsed,
+	collapsedDirectories,
 }: {
-	checkFile: (evt: { path: string; shiftKey: boolean }) => void;
+	checkRow: (evt: { path: string; shiftKey: boolean }) => void;
 	navigationIndex: NavigationIndex<string>;
-	onFileSelection: (selection: string) => void;
+	onRowSelection: (selection: string) => void;
 	projectId: string;
 	ref: React.RefObject<HTMLElement | null>;
 	fileParent: FileParent;
+	rows: Rows;
 	selection: string | null;
 	selectedChange: TreeChange | null;
+	toggleDirectoryCollapsed: (path: string) => void;
+	collapsedDirectories: Record<string, true>;
 }) => {
 	const isDefaultMode = useAppSelector(
 		(state) => projectSlice.selectors.selectOutlineModeState(state, projectId)._tag === "Default",
@@ -76,6 +86,11 @@ const useFilesTreeHotkeys = ({
 	const selectedChangesFile = fileParent._tag === "UncommittedChanges" ? selection : null;
 	const selectedUncommittedChange =
 		fileParent._tag === "UncommittedChanges" ? selectedChange : null;
+
+	const selectedRowIndex =
+		selection === null ? -1 : rows.findIndex((row) => row.path === selection);
+	const selectedRow = selectedRowIndex === -1 ? undefined : rows[selectedRowIndex];
+	const selectedDirectory = selectedRow?._tag === "Directory" ? selectedRow : null;
 
 	const absorbSelectedFile = () => {
 		if (selectedUncommittedChange === null) return;
@@ -99,14 +114,14 @@ const useFilesTreeHotkeys = ({
 		focusSelectionScope("outline");
 	};
 
-	const toggleSelectedFileChecked = (event: KeyboardEvent) => {
+	const toggleSelectedRowChecked = (event: KeyboardEvent) => {
 		if (selection === null) return;
 		// Leave activation of a directly focused checkbox to the checkbox itself.
 		if (event.target !== ref.current) return;
 
 		event.preventDefault();
 		event.stopPropagation();
-		checkFile({ path: selection, shiftKey: event.shiftKey });
+		checkRow({ path: selection, shiftKey: event.shiftKey });
 	};
 
 	const discardSelectedFile = () => {
@@ -128,6 +143,30 @@ const useFilesTreeHotkeys = ({
 		});
 	};
 
+	/** Open a collapsed directory, else step into it. A file has nowhere to go. */
+	const expandSelectedRow = () => {
+		if (selectedDirectory === null) return;
+
+		if (collapsedDirectories[selectedDirectory.path] === true) {
+			toggleDirectoryCollapsed(selectedDirectory.path);
+			return;
+		}
+
+		const child = rows[selectedRowIndex + 1];
+		if (child !== undefined && child.depth > selectedDirectory.depth) onRowSelection(child.path);
+	};
+
+	/** Close an open directory, else step out to the one this row sits in. */
+	const collapseSelectedRow = () => {
+		if (selectedDirectory !== null && collapsedDirectories[selectedDirectory.path] !== true) {
+			toggleDirectoryCollapsed(selectedDirectory.path);
+			return;
+		}
+
+		const parent = parentDirectoryRow(rows, selectedRowIndex);
+		if (parent !== null) onRowSelection(parent.path);
+	};
+
 	const canDiscardSelectedFile = selectedChange !== null && canDiscard;
 
 	const canCheckTheseFiles = useAppSelector((state) =>
@@ -147,7 +186,7 @@ const useFilesTreeHotkeys = ({
 		},
 		{
 			hotkey: changesFileHotkeys.checkFile.hotkey,
-			callback: toggleSelectedFileChecked,
+			callback: toggleSelectedRowChecked,
 			options: {
 				conflictBehavior: "allow",
 				enabled: selection !== null && isDefaultMode && canCheckTheseFiles,
@@ -169,7 +208,7 @@ const useFilesTreeHotkeys = ({
 		},
 		{
 			hotkey: "Shift+Space",
-			callback: toggleSelectedFileChecked,
+			callback: toggleSelectedRowChecked,
 			options: {
 				conflictBehavior: "allow",
 				enabled: selection !== null && isDefaultMode && canCheckTheseFiles,
@@ -211,13 +250,49 @@ const useFilesTreeHotkeys = ({
 				meta: changesFileHotkeys.uncommit.meta,
 			},
 		},
+		{
+			hotkey: "ArrowRight",
+			callback: expandSelectedRow,
+			options: {
+				conflictBehavior: "allow",
+				enabled: selectedDirectory !== null,
+				target: ref,
+			},
+		},
+		{
+			hotkey: "L",
+			callback: expandSelectedRow,
+			options: {
+				conflictBehavior: "allow",
+				enabled: selectedDirectory !== null,
+				target: ref,
+			},
+		},
+		{
+			hotkey: "ArrowLeft",
+			callback: collapseSelectedRow,
+			options: {
+				conflictBehavior: "allow",
+				enabled: selectedRow !== undefined,
+				target: ref,
+			},
+		},
+		{
+			hotkey: "H",
+			callback: collapseSelectedRow,
+			options: {
+				conflictBehavior: "allow",
+				enabled: selectedRow !== undefined,
+				target: ref,
+			},
+		},
 	]);
 
 	useNavigationIndexHotkeys({
 		navigationIndex,
 		projectId,
 		group: "File",
-		select: onFileSelection,
+		select: onRowSelection,
 		selection,
 		ref,
 		getKey: (path) => path,
@@ -235,17 +310,23 @@ const useFilesTreeHotkeys = ({
 export const FilesTree: FC<
 	{
 		projectId: string;
-		items: Array<FileRowItem>;
+		rows: Rows;
+		mode: FileDisplayMode;
+		collapsedDirectories: Record<string, true>;
+		onToggleDirectoryCollapsed: (path: string) => void;
 		selection: string | null;
-		onFileSelection: (selection: string) => void;
+		onRowSelection: (selection: string) => void;
 		navigationIndex: NavigationIndex<string>;
 		fileParent: FileParent;
 		emptyLabel?: string;
 	} & ComponentProps<"div">
 > = ({
-	items,
+	rows,
+	mode,
+	collapsedDirectories,
+	onToggleDirectoryCollapsed,
 	selection,
-	onFileSelection,
+	onRowSelection,
 	projectId,
 	navigationIndex,
 	fileParent,
@@ -277,29 +358,77 @@ export const FilesTree: FC<
 
 	const fileCheckRangeAnchor = useRef<string>(null);
 	const fileCheckRangeEnd = useRef<string>(null);
-	const selectedItem =
-		selection === null ? undefined : items.find((item) => item.path === selection);
+	const selectedRow = selection === null ? undefined : rows.find((row) => row.path === selection);
+	const selectedItem = selectedRow?._tag === "File" ? selectedRow.item : undefined;
 	const selectedChange = selectedItem?._tag === "Change" ? selectedItem.change : null;
+
+	// The tree already names the directory a row sits under, so repeating it on
+	// the row itself would say it twice.
+	const pathDisplay =
+		mode === "tree" ? "hidden" : (pathFirst ?? defaultSettings.pathFirst) ? "lead" : "trail";
+
+	const isFileChecked = (path: string): boolean =>
+		checkedOperandKeys.has(operandIdentityKey(fileOperand({ parent: fileParent, path })));
+
+	const directoryCheckedState = (filePaths: Array<string>): DirectoryCheckedState => {
+		const checkedCount = filePaths.filter((path) => isFileChecked(path)).length;
+		if (checkedCount === 0) return "unchecked";
+		return checkedCount === filePaths.length ? "checked" : "indeterminate";
+	};
+
+	const directoryPaths = new Set(rows.flatMap((row) => (row._tag === "Directory" ? row.path : [])));
 
 	const rangeResolver = navigationIndexRange<string, string>({
 		navigationIndex,
 		getKey: (path) => path,
-		filterMap: (path) => path,
+		// Range-checking runs over files; a directory caught in the middle of a
+		// range is passed over rather than checked as a path of its own.
+		filterMap: (path) => (directoryPaths.has(path) ? null : path),
 	});
 	const getCheckedRange = checkedRange(rangeResolver);
 
-	const checkFile = ({ path, shiftKey }: { path: string; shiftKey: boolean }): void => {
+	const checkedFilePaths = (): Set<string> => {
 		const checkedOperands = projectSlice.selectors.selectCheckedOperands(
 			store.getState(),
 			projectId,
 		);
-		const checkedFilePaths = new Set(
+		return new Set(
 			checkedOperands.flatMap((operand) =>
 				operand._tag === "File" && operandEquals(operand.parent, fileParent) ? operand.path : [],
 			),
 		);
+	};
+
+	const applyCheckedFiles = ({
+		previous,
+		next,
+	}: {
+		previous: Set<string>;
+		next: Set<string>;
+	}): void => {
+		const operands = (paths: Set<string>) =>
+			Array.from(paths, (path) => fileOperand({ parent: fileParent, path }));
+
+		dispatch(
+			projectSlice.actions.checkOperands({
+				projectId,
+				operands: operands(next.difference(previous)),
+				checked: true,
+			}),
+		);
+		dispatch(
+			projectSlice.actions.checkOperands({
+				projectId,
+				operands: operands(previous.difference(next)),
+				checked: false,
+			}),
+		);
+	};
+
+	const checkFile = ({ path, shiftKey }: { path: string; shiftKey: boolean }): void => {
+		const previous = checkedFilePaths();
 		const nextFileRange = getCheckedRange({
-			checked: checkedFilePaths,
+			checked: previous,
 			rangeAnchor: fileCheckRangeAnchor.current,
 			rangeEnd: fileCheckRangeEnd.current,
 		})({
@@ -310,33 +439,49 @@ export const FilesTree: FC<
 		fileCheckRangeAnchor.current = nextFileRange.rangeAnchor;
 		fileCheckRangeEnd.current = nextFileRange.rangeEnd;
 
-		const checkedFiles = nextFileRange.checked.difference(checkedFilePaths);
-		const uncheckedFiles = checkedFilePaths.difference(nextFileRange.checked);
-		dispatch(
-			projectSlice.actions.checkOperands({
-				projectId,
-				operands: Array.from(checkedFiles, (path) => fileOperand({ parent: fileParent, path })),
-				checked: true,
-			}),
-		);
-		dispatch(
-			projectSlice.actions.checkOperands({
-				projectId,
-				operands: Array.from(uncheckedFiles, (path) => fileOperand({ parent: fileParent, path })),
-				checked: false,
-			}),
-		);
+		applyCheckedFiles({ previous, next: nextFileRange.checked });
+	};
+
+	const checkDirectory = ({ path, checked }: { path: string; checked: boolean }): void => {
+		const row = rows.find((row) => row.path === path);
+		if (row?._tag !== "Directory") return;
+
+		// A directory stands for a set rather than a point, so it can't anchor a
+		// range the way a file does.
+		fileCheckRangeAnchor.current = null;
+		fileCheckRangeEnd.current = null;
+
+		const previous = checkedFilePaths();
+		const subject = new Set(row.filePaths);
+		applyCheckedFiles({
+			previous,
+			next: checked ? previous.union(subject) : previous.difference(subject),
+		});
+	};
+
+	/** Space and the row checkboxes both land here, whichever kind of row it is. */
+	const checkRow = ({ path, shiftKey }: { path: string; shiftKey: boolean }): void => {
+		const row = rows.find((row) => row.path === path);
+		if (row?._tag === "Directory") {
+			checkDirectory({ path, checked: directoryCheckedState(row.filePaths) !== "checked" });
+			return;
+		}
+
+		checkFile({ path, shiftKey });
 	};
 
 	useFilesTreeHotkeys({
-		checkFile,
+		checkRow,
 		navigationIndex,
-		onFileSelection,
+		onRowSelection,
 		projectId,
 		ref,
 		fileParent,
+		rows,
 		selection,
 		selectedChange,
+		toggleDirectoryCollapsed: onToggleDirectoryCollapsed,
+		collapsedDirectories,
 	});
 
 	return (
@@ -348,7 +493,7 @@ export const FilesTree: FC<
 			className={classes(props.className, styles.tree)}
 			ref={useMergedRefs(refProp, ref)}
 		>
-			{items.length === 0 ? (
+			{rows.length === 0 ? (
 				<Row interactive={false}>
 					<RowLabelContainer>
 						<RowLabel className={rowStyles.fadedText}>{emptyLabel}</RowLabel>
@@ -357,18 +502,53 @@ export const FilesTree: FC<
 			) : (
 				// oxlint-disable-next-line jsx-a11y/prefer-tag-over-role -- Tree items need ARIA group semantics.
 				<div role="group">
-					{items.map((item) => {
-						const operand = fileOperand({ parent: fileParent, path: item.path });
+					{rows.map((row) => {
+						const isSelected = selection !== null && selection === row.path;
+
+						if (row._tag === "Directory") {
+							const isCollapsed = collapsedDirectories[row.path] === true;
+
+							return (
+								<TreeItem
+									key={row.path}
+									row={row}
+									isSelected={isSelected}
+									isExpanded={!isCollapsed}
+									aria-label={`Directory ${row.path}`}
+									render={
+										<DirectoryRow
+											projectId={projectId}
+											path={row.path}
+											name={row.name}
+											fileCount={row.filePaths.length}
+											isCollapsed={isCollapsed}
+											isSelected={isSelected}
+											canCheck={canCheck}
+											checkedState={directoryCheckedState(row.filePaths)}
+											checkDirectory={checkDirectory}
+											onSelect={() => {
+												onRowSelection(row.path);
+												onToggleDirectoryCollapsed(row.path);
+											}}
+										/>
+									}
+								/>
+							);
+						}
+
+						const item = row.item;
+						const operand = fileOperand({ parent: fileParent, path: row.path });
+
 						return (
 							<TreeItem
-								key={item.path}
-								isSelected={selection !== null && selection === item.path}
+								key={row.path}
+								row={row}
+								isSelected={isSelected}
 								aria-label={
 									item._tag === "Change"
 										? `${item.change.status.type} ${item.change.path}`
 										: `Conflict ${item.path}`
 								}
-								path={item.path}
 								render={
 									<OperationSourceC
 										projectId={projectId}
@@ -377,11 +557,11 @@ export const FilesTree: FC<
 										render={
 											<FileRow
 												item={item}
-												pathFirst={pathFirst ?? defaultSettings.pathFirst}
-												inert={!navigationIndexIncludes(navigationIndex, item.path, (path) => path)}
-												isSelected={selection !== null && selection === item.path}
+												pathDisplay={pathDisplay}
+												inert={!navigationIndexIncludes(navigationIndex, row.path, (path) => path)}
+												isSelected={isSelected}
 												isChecked={checkedOperandKeys.has(operandIdentityKey(operand))}
-												onSelect={() => onFileSelection(item.path)}
+												onSelect={() => onRowSelection(row.path)}
 												canCheck={canCheck}
 												checkFile={checkFile}
 												projectId={projectId}
@@ -405,18 +585,32 @@ export const FilesTree: FC<
 
 const treeItemId = (path: string): string => `files-treeitem-${encodeURIComponent(path)}`;
 
+// Spread so the object type widens to allow the custom property, as `Icon` does.
+const depthStyle = (depth: number): CSSProperties => ({ "--file-tree-depth": depth });
+
+/**
+ * One row of the flattened tree. Depth is reported rather than nested, which is
+ * what `aria-level` and its siblings are for: a screen reader still hears the
+ * shape a `role="group"` per directory would have given it.
+ */
 const TreeItem: FC<
 	{
-		path: string;
+		row: FileTreeRow<FileRowItem>;
 		isSelected: boolean;
+		isExpanded?: boolean;
 	} & useRender.ComponentProps<"div">
-> = ({ path, isSelected, render, ...props }) =>
+> = ({ row, isSelected, isExpanded, render, ...props }) =>
 	useRender({
 		render,
 		defaultTagName: "div",
 		props: mergeProps<"div">(props, {
-			id: treeItemId(path),
+			id: treeItemId(row.path),
 			role: "treeitem",
 			"aria-selected": isSelected,
+			"aria-expanded": isExpanded,
+			"aria-level": row.depth + 1,
+			"aria-posinset": row.positionInLevel,
+			"aria-setsize": row.levelSize,
+			style: depthStyle(row.depth),
 		}),
 	});

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
@@ -352,7 +352,6 @@ const UncommittedChanges: FC<{
 					}
 					fileParent={uncommittedChangesFileParent}
 					rows={fileRows}
-					mode={fileDisplayMode}
 					collapsedDirectories={collapsedDirectories}
 					onToggleDirectoryCollapsed={(path) =>
 						dispatch(

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
@@ -67,7 +67,9 @@ import { useOutlineTreeHotkeys } from "./hotkeys.ts";
 import { UncommittedChangesRow } from "./UncommittedChangesRow.tsx";
 import { FileFilterRow } from "../FileFilterRow.tsx";
 import { useFileFilter } from "../useFileFilter.ts";
-import { getChangesFileRowItems, pathMatchesFilter } from "../file-row.ts";
+import { getChangesFileRowItems, pathMatchesFilter, type FileRowItem } from "../file-row.ts";
+import { buildFileTreeRows, type FileDisplayMode, type FileTreeRow } from "../file-tree.ts";
+import { useFileDisplayMode } from "../useFileDisplayMode.ts";
 import {
 	canRemoveBranchReference,
 	downstackPushStatusesFromSegments,
@@ -237,6 +239,30 @@ const OperandC: FC<
 	});
 };
 
+/**
+ * Laid out from the same source and settings as the navigation index the page
+ * builds, so the rows and the keys that move between them stay in step. Kept
+ * out of the component so the compiler memoises it on those inputs.
+ */
+const buildUncommittedFileRows = ({
+	worktreeChanges,
+	filter,
+	mode,
+	collapsedDirectories,
+}: {
+	worktreeChanges: WorktreeChanges | undefined;
+	filter: string | null;
+	mode: FileDisplayMode;
+	collapsedDirectories: Record<string, true>;
+}): Array<FileTreeRow<FileRowItem>> =>
+	buildFileTreeRows({
+		items: (worktreeChanges ? getChangesFileRowItems(worktreeChanges) : []).filter((item) =>
+			pathMatchesFilter(item.path, filter),
+		),
+		mode,
+		collapsedDirectories,
+	});
+
 const UncommittedChanges: FC<{
 	navigationIndex: NavigationIndex<string>;
 	commitTarget: CommitTargetComboboxItem | null;
@@ -261,9 +287,16 @@ const UncommittedChanges: FC<{
 	const filter = useAppSelector((state) =>
 		projectSlice.selectors.selectUncommittedFilesFilter(state, projectId),
 	);
-	const fileRowItems = (worktreeChanges ? getChangesFileRowItems(worktreeChanges) : []).filter(
-		(item) => pathMatchesFilter(item.path, filter),
+	const fileDisplayMode = useFileDisplayMode();
+	const collapsedDirectories = useAppSelector((state) =>
+		projectSlice.selectors.selectUncommittedFilesCollapsedDirectories(state, projectId),
 	);
+	const fileRows = buildUncommittedFileRows({
+		worktreeChanges,
+		filter,
+		mode: fileDisplayMode,
+		collapsedDirectories,
+	});
 
 	const fileSelection = useAppSelector((state) =>
 		projectSlice.selectors.selectSelectionUncommittedFiles(state, projectId, navigationIndex),
@@ -278,7 +311,7 @@ const UncommittedChanges: FC<{
 		inputId: "uncommitted-files-filter-input",
 		scope: "uncommitted-files",
 		selection: fileSelection,
-		firstPath: fileRowItems[0]?.path,
+		firstPath: fileRows[0]?.path,
 		onEnterList: onActiveFileSelection,
 		panelRef,
 		listRef: fileListRef,
@@ -318,9 +351,16 @@ const UncommittedChanges: FC<{
 							: "Nothing to commit"
 					}
 					fileParent={uncommittedChangesFileParent}
-					items={fileRowItems}
+					rows={fileRows}
+					mode={fileDisplayMode}
+					collapsedDirectories={collapsedDirectories}
+					onToggleDirectoryCollapsed={(path) =>
+						dispatch(
+							projectSlice.actions.toggleUncommittedFilesDirectoryCollapsed({ projectId, path }),
+						)
+					}
 					navigationIndex={navigationIndex}
-					onFileSelection={onActiveFileSelection}
+					onRowSelection={onActiveFileSelection}
 					projectId={projectId}
 					ref={useMergedRefs(fileListRef, useAutofocusSelectionScope())}
 					selection={fileSelection}

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/UncommittedChangesRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/UncommittedChangesRow.tsx
@@ -19,6 +19,7 @@ import type { FC } from "react";
 import { getRowButtonClassName } from "../Row-utils.ts";
 import { ChangeStats } from "../ChangeStats.tsx";
 import { RowToolbar, SectionHeaderRow } from "../Row.tsx";
+import { FileDisplayModeToggle } from "../FileDisplayModeToggle.tsx";
 import { useQueries } from "@tanstack/react-query";
 import { treeChangeDiffsQueryOptions } from "#ui/api/queries.ts";
 
@@ -96,13 +97,17 @@ export const UncommittedChangesRow: FC<{
 						render={<RowToolbar forceVisible />}
 					>
 						{changes.length > 0 && (
-							<Toolbar.Button
-								aria-label="Filter files"
-								onClick={onOpenFilter}
-								className={getRowButtonClassName({ size: "regular", iconOnly: true })}
-							>
-								<Icon name="search" />
-							</Toolbar.Button>
+							<>
+								<FileDisplayModeToggle />
+
+								<Toolbar.Button
+									aria-label="Filter files"
+									onClick={onOpenFilter}
+									className={getRowButtonClassName({ size: "regular", iconOnly: true })}
+								>
+									<Icon name="search" />
+								</Toolbar.Button>
+							</>
 						)}
 
 						<Toolbar.Button

--- a/apps/lite/ui/src/routes/project/$id/workspace/Settings/Appearance.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Settings/Appearance.tsx
@@ -95,10 +95,32 @@ export const Appearance: FC = () => {
 			</Section>
 
 			<Section heading="Files">
+				<Row label="Layout" labelId="file-display-mode" hint="Also on each file list's header.">
+					<ToggleGroup
+						aria-labelledby="file-display-mode"
+						value={[settings.fileDisplayMode ?? defaultSettings.fileDisplayMode]}
+						onValueChange={([fileDisplayMode]) => {
+							if (fileDisplayMode !== undefined) {
+								saveGUISettings({
+									fileDisplayMode: fileDisplayMode as GUISettings["fileDisplayMode"],
+								});
+							}
+						}}
+						render={<ToggleGroupStyles />}
+					>
+						<Toggle render={<ToggleStyles />} value="list">
+							List
+						</Toggle>
+						<Toggle render={<ToggleStyles />} value="tree">
+							Tree
+						</Toggle>
+					</ToggleGroup>
+				</Row>
+
 				<Row
 					label="File path first"
 					labelId="path-first"
-					hint="Lead each row with the directory rather than the file name."
+					hint="Lead each row with the directory rather than the file name. The tree names the directory once, on its own row, so this applies to the list."
 				>
 					<Switch
 						aria-labelledby="path-first"

--- a/apps/lite/ui/src/routes/project/$id/workspace/Settings/Appearance.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Settings/Appearance.tsx
@@ -95,32 +95,10 @@ export const Appearance: FC = () => {
 			</Section>
 
 			<Section heading="Files">
-				<Row label="Layout" labelId="file-display-mode" hint="Also on each file list's header.">
-					<ToggleGroup
-						aria-labelledby="file-display-mode"
-						value={[settings.fileDisplayMode ?? defaultSettings.fileDisplayMode]}
-						onValueChange={([fileDisplayMode]) => {
-							if (fileDisplayMode !== undefined) {
-								saveGUISettings({
-									fileDisplayMode: fileDisplayMode as GUISettings["fileDisplayMode"],
-								});
-							}
-						}}
-						render={<ToggleGroupStyles />}
-					>
-						<Toggle render={<ToggleStyles />} value="list">
-							List
-						</Toggle>
-						<Toggle render={<ToggleStyles />} value="tree">
-							Tree
-						</Toggle>
-					</ToggleGroup>
-				</Row>
-
 				<Row
 					label="File path first"
 					labelId="path-first"
-					hint="Lead each row with the directory rather than the file name. The tree names the directory once, on its own row, so this applies to the list."
+					hint="Lead each row with the directory rather than the file name. The tree gives the directory a row of its own, so this is for the list."
 				>
 					<Switch
 						aria-labelledby="path-first"

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
@@ -21,7 +21,7 @@ import { PickerDialog } from "#ui/components/PickerDialog.tsx";
 import { globalHotkeys, workspaceHotkeys } from "#ui/hotkeys.ts";
 import { writeLastOpenedProject } from "#ui/project.ts";
 import { useAppDispatch, useAppSelector } from "#ui/store.ts";
-import type { ProjectForFrontend, RefInfo, WorktreeChanges } from "@gitbutler/but-sdk";
+import type { ProjectForFrontend, RefInfo, TreeChange, WorktreeChanges } from "@gitbutler/but-sdk";
 import { useHotkey, useHotkeys, type UseHotkeyDefinition } from "@tanstack/react-hotkeys";
 import {
 	QueryErrorResetBoundary,
@@ -48,6 +48,14 @@ import {
 import { Details, type DiffViewerHandle } from "./Details.tsx";
 import { getDiffFileNavigation } from "./diff-view.ts";
 import { pathMatchesFilter } from "./file-row.ts";
+import {
+	buildFileTreeRows,
+	fileTreeNavigationIndex,
+	selectedFilePath,
+	type FileDisplayMode,
+	type FileTreeRow,
+} from "./file-tree.ts";
+import { useFileDisplayMode } from "./useFileDisplayMode.ts";
 import styles from "./WorkspacePage.module.css";
 import { useActiveElement } from "#ui/focus.ts";
 import { ApplyBranchPicker } from "./ApplyBranchPicker.tsx";
@@ -232,19 +240,23 @@ const hasAnyOperation = (sources: Array<Operand>, target: Operand) => {
 	return !!operations.into || !!operations.above || !!operations.below;
 };
 
-const buildUncommittedFilesNavigationIndex = ({
+const buildUncommittedFileRows = ({
 	worktreeChanges,
 	filter,
+	mode,
+	collapsedDirectories,
 }: {
 	worktreeChanges: WorktreeChanges | undefined;
 	filter: string | null;
-}): NavigationIndex<string> => {
-	const items =
-		worktreeChanges?.changes.flatMap((change) =>
-			pathMatchesFilter(change.path, filter) ? change.path : [],
-		) ?? [];
-	return { items, indexByKey: buildIndexByKey(items, (path) => path) };
-};
+	mode: FileDisplayMode;
+	collapsedDirectories: Record<string, true>;
+}): Array<FileTreeRow<TreeChange>> =>
+	buildFileTreeRows({
+		items:
+			worktreeChanges?.changes.filter((change) => pathMatchesFilter(change.path, filter)) ?? [],
+		mode,
+		collapsedDirectories,
+	});
 
 const buildOutlineNavigationIndex = ({
 	headInfo,
@@ -519,10 +531,19 @@ const WorkspacePage: FC = () => {
 	const uncommittedFilesFilter = useAppSelector((state) =>
 		projectSlice.selectors.selectUncommittedFilesFilter(state, projectId),
 	);
-	const uncommittedFilesNavigationIndex = buildUncommittedFilesNavigationIndex({
+	const uncommittedFilesDisplayMode = useFileDisplayMode();
+	const uncommittedFilesCollapsedDirectories = useAppSelector((state) =>
+		projectSlice.selectors.selectUncommittedFilesCollapsedDirectories(state, projectId),
+	);
+	const uncommittedFileRows = buildUncommittedFileRows({
 		worktreeChanges,
 		filter: uncommittedFilesFilter,
+		mode: uncommittedFilesDisplayMode,
+		collapsedDirectories: uncommittedFilesCollapsedDirectories,
 	});
+	// Directories take the cursor as files do, so the index follows the layout the
+	// list renders — and a collapsed directory takes its files out of it too.
+	const uncommittedFilesNavigationIndex = fileTreeNavigationIndex(uncommittedFileRows);
 	const uncommittedTreeChangeDiffs = useQueries({
 		queries:
 			worktreeChanges?.changes.map((change) =>
@@ -536,9 +557,12 @@ const WorkspacePage: FC = () => {
 	});
 
 	const onActiveUncommittedFileSelection = (selection: string) => {
+		// A directory row stands for the first file below it, so activating a
+		// folder still gives the details pane somewhere to go.
+		const path = selectedFilePath(uncommittedFileRows, selection);
 		// Indexed against the worktree changes rather than the navigation index,
 		// which the file filter can narrow out from under them.
-		const index = worktreeChanges?.changes.findIndex((change) => change.path === selection) ?? -1;
+		const index = worktreeChanges?.changes.findIndex((change) => change.path === path) ?? -1;
 		const change = index === -1 ? undefined : worktreeChanges?.changes[index];
 		const treeChangeDiff = index === -1 ? undefined : uncommittedTreeChangeDiffs?.[index];
 		const navigation =

--- a/apps/lite/ui/src/routes/project/$id/workspace/file-tree.test.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/file-tree.test.ts
@@ -79,18 +79,6 @@ describe("buildFileTreeRows", () => {
 			filePaths: ["src/ui/row.ts", "src/app.ts"],
 		});
 	});
-
-	test("counts siblings per level for assistive technology", () => {
-		const rows = tree(["src/app.ts", "docs/guide.md", "readme.md"]);
-
-		expect(rows.map((row) => `${row.positionInLevel}/${row.levelSize}`)).toEqual([
-			"1/3",
-			"1/1",
-			"2/3",
-			"1/1",
-			"3/3",
-		]);
-	});
 });
 
 describe("selectedFilePath", () => {

--- a/apps/lite/ui/src/routes/project/$id/workspace/file-tree.test.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/file-tree.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from "vitest";
+import {
+	buildFileTreeRows,
+	parentDirectoryRow,
+	selectedFilePath,
+	type FileTreeRow,
+} from "./file-tree.ts";
+
+const items = (...paths: Array<string>) => paths.map((path) => ({ path }));
+
+const layout = (rows: Array<FileTreeRow<{ path: string }>>): Array<string> =>
+	rows.map(
+		(row) => `${"  ".repeat(row.depth)}${row._tag === "Directory" ? `${row.name}/` : row.path}`,
+	);
+
+const tree = (paths: Array<string>, collapsedDirectories: Record<string, true> = {}) =>
+	buildFileTreeRows({ items: items(...paths), mode: "tree", collapsedDirectories });
+
+describe("buildFileTreeRows", () => {
+	test("list mode keeps the given order, whole paths, one level", () => {
+		const rows = buildFileTreeRows({
+			items: items("src/b.ts", "a.ts", "src/lib/c.ts"),
+			mode: "list",
+			collapsedDirectories: { src: true },
+		});
+
+		expect(layout(rows)).toEqual(["src/b.ts", "a.ts", "src/lib/c.ts"]);
+	});
+
+	test("groups files under their directories, directories first", () => {
+		const rows = tree(["readme.md", "src/app.ts", "src/ui/row.ts", "docs/guide.md"]);
+
+		expect(layout(rows)).toEqual([
+			"docs/",
+			"  docs/guide.md",
+			"src/",
+			"  ui/",
+			"    src/ui/row.ts",
+			"  src/app.ts",
+			"readme.md",
+		]);
+	});
+
+	test("folds a chain of sole-child directories into one row", () => {
+		const rows = tree(["src/lib/files/row.ts", "src/lib/files/tree.ts"]);
+
+		expect(layout(rows)).toEqual([
+			"src/lib/files/",
+			"  src/lib/files/row.ts",
+			"  src/lib/files/tree.ts",
+		]);
+		expect(rows[0]?.path).toBe("src/lib/files");
+	});
+
+	test("stops folding where a directory holds files of its own", () => {
+		const rows = tree(["src/lib/row.ts", "src/app.ts"]);
+
+		expect(layout(rows)).toEqual(["src/", "  lib/", "    src/lib/row.ts", "  src/app.ts"]);
+	});
+
+	test("sorts names naturally, case only breaking ties", () => {
+		const rows = tree(["v9.ts", "v10.ts", "Beta.ts", "alpha.ts"]);
+
+		expect(layout(rows)).toEqual(["alpha.ts", "Beta.ts", "v9.ts", "v10.ts"]);
+	});
+
+	test("a collapsed directory hides its rows but keeps its own", () => {
+		const rows = tree(["src/ui/row.ts", "src/app.ts", "readme.md"], { src: true });
+
+		expect(layout(rows)).toEqual(["src/", "readme.md"]);
+	});
+
+	test("a directory row carries every file below it, expansion order", () => {
+		const rows = tree(["src/ui/row.ts", "src/app.ts"], { src: true });
+
+		expect(rows[0]).toMatchObject({
+			_tag: "Directory",
+			path: "src",
+			filePaths: ["src/ui/row.ts", "src/app.ts"],
+		});
+	});
+
+	test("counts siblings per level for assistive technology", () => {
+		const rows = tree(["src/app.ts", "docs/guide.md", "readme.md"]);
+
+		expect(rows.map((row) => `${row.positionInLevel}/${row.levelSize}`)).toEqual([
+			"1/3",
+			"1/1",
+			"2/3",
+			"1/1",
+			"3/3",
+		]);
+	});
+});
+
+describe("selectedFilePath", () => {
+	const rows = tree(["src/ui/row.ts", "src/app.ts"], { src: true });
+
+	test("resolves a directory to the first file below it", () => {
+		expect(selectedFilePath(rows, "src")).toBe("src/ui/row.ts");
+	});
+
+	test("passes a file, an unknown path, and no selection through", () => {
+		expect(selectedFilePath(tree(["a.ts"]), "a.ts")).toBe("a.ts");
+		expect(selectedFilePath(rows, "filtered-out.ts")).toBe("filtered-out.ts");
+		expect(selectedFilePath(rows, null)).toBeNull();
+	});
+});
+
+describe("parentDirectoryRow", () => {
+	const rows = tree(["src/ui/row.ts", "src/app.ts", "readme.md"]);
+
+	test("finds the directory a row sits in, skipping deeper rows", () => {
+		expect(parentDirectoryRow(rows, layout(rows).indexOf("  src/app.ts"))).toMatchObject({
+			path: "src",
+		});
+	});
+
+	test("is null at the top level", () => {
+		expect(parentDirectoryRow(rows, 0)).toBeNull();
+		expect(parentDirectoryRow(rows, rows.length - 1)).toBeNull();
+	});
+});

--- a/apps/lite/ui/src/routes/project/$id/workspace/file-tree.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/file-tree.ts
@@ -1,0 +1,222 @@
+/**
+ * @file Folder-shaped layout for the file lists.
+ *
+ * Rows come out flat and in render order, one array for both display modes:
+ * the list is the tree with every path kept whole at depth zero. Flat keeps
+ * rendering a single `map`, and lets the navigation index stay a list of paths
+ * — a directory path and a file path can never collide, so one string still
+ * identifies any row.
+ */
+
+import { buildIndexByKey, type NavigationIndex } from "#ui/workspace/navigation-index.ts";
+
+export type FileDisplayMode = "list" | "tree";
+
+export type FileTreeRow<T> = {
+	path: string;
+	/** Indent depth, counted from zero. Every list-mode row sits at zero. */
+	depth: number;
+	/** Position among the rows sharing this parent, 1-based, for `aria-posinset`. */
+	positionInLevel: number;
+	/** How many rows share this parent, for `aria-setsize`. */
+	levelSize: number;
+} & (
+	| {
+			_tag: "Directory";
+			/** The last path segment, or several joined when a sole-child chain was folded in. */
+			name: string;
+			/** Every file below this directory, in the order expanding it would reveal them. */
+			filePaths: Array<string>;
+	  }
+	| { _tag: "File"; item: T }
+);
+
+type Directory<T> = {
+	directories: Map<string, Directory<T>>;
+	items: Array<T>;
+};
+
+const emptyDirectory = <T>(): Directory<T> => ({ directories: new Map(), items: [] });
+
+// Matches the desktop app's file sorting: digits compare as numbers so `v10`
+// follows `v9`, and case only breaks ties.
+const compareNames = (a: string, b: string): number =>
+	a.localeCompare(b, "en", { numeric: true, caseFirst: "lower", sensitivity: "base" });
+
+const fileName = (path: string): string => path.slice(path.lastIndexOf("/") + 1);
+
+const insert = <T extends { path: string }>(root: Directory<T>, item: T): void => {
+	const segments = item.path.split("/");
+	let directory = root;
+
+	for (const segment of segments.slice(0, -1)) {
+		let child = directory.directories.get(segment);
+		if (child === undefined) {
+			child = emptyDirectory();
+			directory.directories.set(segment, child);
+		}
+		directory = child;
+	}
+
+	directory.items.push(item);
+};
+
+type NamedDirectory<T> = { name: string; directory: Directory<T> };
+
+/** The one directory a directory holds, when that is all it holds. */
+const soleChild = <T>(directory: Directory<T>): NamedDirectory<T> | null => {
+	if (directory.items.length > 0 || directory.directories.size !== 1) return null;
+
+	const [entry] = directory.directories;
+	return entry === undefined ? null : { name: entry[0], directory: entry[1] };
+};
+
+/**
+ * Fold a chain of directories that each hold nothing but the next one into a
+ * single row, so `src` › `lib` › `files` arrives as `src/lib/files` rather than
+ * three rows deep with nothing to choose between them.
+ */
+const foldSoleChildren = <T>(name: string, directory: Directory<T>): NamedDirectory<T> => {
+	let folded: NamedDirectory<T> = { name, directory };
+
+	for (let child = soleChild(directory); child !== null; child = soleChild(child.directory))
+		folded = { name: `${folded.name}/${child.name}`, directory: child.directory };
+
+	return folded;
+};
+
+const sortedDirectories = <T>(directory: Directory<T>): Array<NamedDirectory<T>> =>
+	[...directory.directories]
+		.map(([name, child]) => foldSoleChildren(name, child))
+		.sort((a, b) => compareNames(a.name, b.name));
+
+const sortedItems = <T extends { path: string }>(directory: Directory<T>): Array<T> =>
+	[...directory.items].sort((a, b) => compareNames(fileName(a.path), fileName(b.path)));
+
+const directoryFilePaths = <T extends { path: string }>(directory: Directory<T>): Array<string> => [
+	...sortedDirectories(directory).flatMap(({ directory: child }) => directoryFilePaths(child)),
+	...sortedItems(directory).map((item) => item.path),
+];
+
+const collectRows = <T extends { path: string }>({
+	directory,
+	prefix,
+	depth,
+	collapsedDirectories,
+	rows,
+}: {
+	directory: Directory<T>;
+	prefix: string;
+	depth: number;
+	collapsedDirectories: Record<string, true>;
+	rows: Array<FileTreeRow<T>>;
+}): void => {
+	const directories = sortedDirectories(directory);
+	const items = sortedItems(directory);
+	const levelSize = directories.length + items.length;
+
+	for (const [index, { name, directory: child }] of directories.entries()) {
+		const path = prefix === "" ? name : `${prefix}/${name}`;
+
+		rows.push({
+			_tag: "Directory",
+			path,
+			name,
+			depth,
+			positionInLevel: index + 1,
+			levelSize,
+			filePaths: directoryFilePaths(child),
+		});
+
+		if (collapsedDirectories[path] !== true) {
+			collectRows({
+				directory: child,
+				prefix: path,
+				depth: depth + 1,
+				collapsedDirectories,
+				rows,
+			});
+		}
+	}
+
+	for (const [index, item] of items.entries()) {
+		rows.push({
+			_tag: "File",
+			path: item.path,
+			item,
+			depth,
+			positionInLevel: directories.length + index + 1,
+			levelSize,
+		});
+	}
+};
+
+export const buildFileTreeRows = <T extends { path: string }>({
+	items,
+	mode,
+	collapsedDirectories,
+}: {
+	items: Array<T>;
+	mode: FileDisplayMode;
+	collapsedDirectories: Record<string, true>;
+}): Array<FileTreeRow<T>> => {
+	if (mode === "list") {
+		return items.map((item, index) => ({
+			_tag: "File",
+			path: item.path,
+			item,
+			depth: 0,
+			positionInLevel: index + 1,
+			levelSize: items.length,
+		}));
+	}
+
+	const root = emptyDirectory<T>();
+	for (const item of items) insert(root, item);
+
+	const rows: Array<FileTreeRow<T>> = [];
+	collectRows({ directory: root, prefix: "", depth: 0, collapsedDirectories, rows });
+	return rows;
+};
+
+export const fileTreeNavigationIndex = <T>(
+	rows: Array<FileTreeRow<T>>,
+): NavigationIndex<string> => {
+	const items = rows.map((row) => row.path);
+	return { items, indexByKey: buildIndexByKey(items, (path) => path) };
+};
+
+/**
+ * The file a selected row stands for: itself, or — for a directory — the first
+ * file beneath it, so the diff has something to show while the cursor rests on
+ * a folder. A path the rows don't hold is passed through, since the caller's
+ * own list may reach further than the filtered rows do.
+ */
+export const selectedFilePath = <T>(
+	rows: Array<FileTreeRow<T>>,
+	selection: string | null,
+): string | null => {
+	if (selection === null) return null;
+
+	const row = rows.find((row) => row.path === selection);
+	if (row === undefined) return selection;
+
+	return row._tag === "File" ? row.path : (row.filePaths[0] ?? null);
+};
+
+/** The directory row a row sits in, or `null` at the top level. */
+export const parentDirectoryRow = <T>(
+	rows: Array<FileTreeRow<T>>,
+	index: number,
+): Extract<FileTreeRow<T>, { _tag: "Directory" }> | null => {
+	const row = rows[index];
+	if (row === undefined || row.depth === 0) return null;
+
+	for (let candidateIndex = index - 1; candidateIndex >= 0; candidateIndex--) {
+		const candidate = rows[candidateIndex];
+		if (candidate !== undefined && candidate.depth === row.depth - 1)
+			return candidate._tag === "Directory" ? candidate : null;
+	}
+
+	return null;
+};

--- a/apps/lite/ui/src/routes/project/$id/workspace/file-tree.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/file-tree.ts
@@ -16,10 +16,6 @@ export type FileTreeRow<T> = {
 	path: string;
 	/** Indent depth, counted from zero. Every list-mode row sits at zero. */
 	depth: number;
-	/** Position among the rows sharing this parent, 1-based, for `aria-posinset`. */
-	positionInLevel: number;
-	/** How many rows share this parent, for `aria-setsize`. */
-	levelSize: number;
 } & (
 	| {
 			_tag: "Directory";
@@ -79,7 +75,7 @@ const soleChild = <T>(directory: Directory<T>): NamedDirectory<T> | null => {
 const foldSoleChildren = <T>(name: string, directory: Directory<T>): NamedDirectory<T> => {
 	let folded: NamedDirectory<T> = { name, directory };
 
-	for (let child = soleChild(directory); child !== null; child = soleChild(child.directory))
+	for (let child = soleChild(folded.directory); child !== null; child = soleChild(folded.directory))
 		folded = { name: `${folded.name}/${child.name}`, directory: child.directory };
 
 	return folded;
@@ -93,62 +89,45 @@ const sortedDirectories = <T>(directory: Directory<T>): Array<NamedDirectory<T>>
 const sortedItems = <T extends { path: string }>(directory: Directory<T>): Array<T> =>
 	[...directory.items].sort((a, b) => compareNames(fileName(a.path), fileName(b.path)));
 
-const directoryFilePaths = <T extends { path: string }>(directory: Directory<T>): Array<string> => [
-	...sortedDirectories(directory).flatMap(({ directory: child }) => directoryFilePaths(child)),
-	...sortedItems(directory).map((item) => item.path),
-];
+/** One directory's worth of rows, and every file path below it. */
+type Collected<T> = { rows: Array<FileTreeRow<T>>; filePaths: Array<string> };
 
 const collectRows = <T extends { path: string }>({
 	directory,
 	prefix,
 	depth,
 	collapsedDirectories,
-	rows,
 }: {
 	directory: Directory<T>;
 	prefix: string;
 	depth: number;
 	collapsedDirectories: Record<string, true>;
-	rows: Array<FileTreeRow<T>>;
-}): void => {
-	const directories = sortedDirectories(directory);
-	const items = sortedItems(directory);
-	const levelSize = directories.length + items.length;
+}): Collected<T> => {
+	const rows: Array<FileTreeRow<T>> = [];
+	const filePaths: Array<string> = [];
 
-	for (const [index, { name, directory: child }] of directories.entries()) {
+	for (const { name, directory: child } of sortedDirectories(directory)) {
 		const path = prefix === "" ? name : `${prefix}/${name}`;
-
-		rows.push({
-			_tag: "Directory",
-			path,
-			name,
-			depth,
-			positionInLevel: index + 1,
-			levelSize,
-			filePaths: directoryFilePaths(child),
+		// Walked whether or not it is collapsed: collapsing keeps a directory's rows
+		// out of the list, but it still answers for its files at its own checkbox.
+		const below = collectRows({
+			directory: child,
+			prefix: path,
+			depth: depth + 1,
+			collapsedDirectories,
 		});
 
-		if (collapsedDirectories[path] !== true) {
-			collectRows({
-				directory: child,
-				prefix: path,
-				depth: depth + 1,
-				collapsedDirectories,
-				rows,
-			});
-		}
+		rows.push({ _tag: "Directory", path, name, depth, filePaths: below.filePaths });
+		if (collapsedDirectories[path] !== true) rows.push(...below.rows);
+		filePaths.push(...below.filePaths);
 	}
 
-	for (const [index, item] of items.entries()) {
-		rows.push({
-			_tag: "File",
-			path: item.path,
-			item,
-			depth,
-			positionInLevel: directories.length + index + 1,
-			levelSize,
-		});
+	for (const item of sortedItems(directory)) {
+		rows.push({ _tag: "File", path: item.path, item, depth });
+		filePaths.push(item.path);
 	}
+
+	return { rows, filePaths };
 };
 
 export const buildFileTreeRows = <T extends { path: string }>({
@@ -160,23 +139,13 @@ export const buildFileTreeRows = <T extends { path: string }>({
 	mode: FileDisplayMode;
 	collapsedDirectories: Record<string, true>;
 }): Array<FileTreeRow<T>> => {
-	if (mode === "list") {
-		return items.map((item, index) => ({
-			_tag: "File",
-			path: item.path,
-			item,
-			depth: 0,
-			positionInLevel: index + 1,
-			levelSize: items.length,
-		}));
-	}
+	if (mode === "list")
+		return items.map((item) => ({ _tag: "File", path: item.path, item, depth: 0 }));
 
 	const root = emptyDirectory<T>();
 	for (const item of items) insert(root, item);
 
-	const rows: Array<FileTreeRow<T>> = [];
-	collectRows({ directory: root, prefix: "", depth: 0, collapsedDirectories, rows });
-	return rows;
+	return collectRows({ directory: root, prefix: "", depth: 0, collapsedDirectories }).rows;
 };
 
 export const fileTreeNavigationIndex = <T>(

--- a/apps/lite/ui/src/routes/project/$id/workspace/useFileDisplayMode.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/useFileDisplayMode.ts
@@ -1,0 +1,17 @@
+import { guiSettingsQueryOptions } from "#ui/api/queries.ts";
+import { defaultSettings } from "#ui/settings.ts";
+import { useQuery } from "@tanstack/react-query";
+import type { FileDisplayMode } from "./file-tree.ts";
+
+/**
+ * Whether the file lists show a flat list or a folder tree. One stored setting
+ * for every list, so a mode switched in one place is the mode everywhere.
+ */
+export const useFileDisplayMode = (): FileDisplayMode => {
+	const { data } = useQuery({
+		...guiSettingsQueryOptions,
+		select: (cfg) => cfg.fileDisplayMode ?? defaultSettings.fileDisplayMode,
+	});
+
+	return data ?? defaultSettings.fileDisplayMode;
+};

--- a/apps/lite/ui/src/settings.ts
+++ b/apps/lite/ui/src/settings.ts
@@ -12,6 +12,8 @@ export const defaultSettings = {
 	diffOverflow: "scroll",
 	diffStyle: "split",
 	diffTabSize: 4,
+	// Lite has always shown a flat list; the tree is the mode you opt into.
+	fileDisplayMode: "list",
 	// Pierre's own default, named here so the setting has somewhere to fall back to.
 	lineDiffType: "word-alt",
 	// Lite has always led with the file name; desktop leads with the path.


### PR DESCRIPTION
Adds a folder tree as an alternative to lite's flat file list, in both places files are listed — the details pane and the outline's uncommitted panel. Switch it with the button in either list's header. The flat list stays the default.

## How it works

`file-tree.ts` turns the changed files into a **flat** list of rows, each knowing how deep it sits. Rendering therefore stays one `map`, and a row is still identified by its path — a folder path and a file path can never be the same string, so folders join the existing keyboard navigation without changing how a selection is stored. The flat list is the same function with every path left whole at depth 0.

Folders take the cursor like files (`←`/`→` close and open them), a folder's checkbox checks every file beneath it, and closed folders are remembered per project and per list.

## Files

| | |
| --- | --- |
| `file-tree.ts` | **new** — builds the rows; parent and first-file lookups |
| `DirectoryRow.tsx` | **new** — the folder row: chevron, checkbox, count |
| `FileDisplayModeToggle.tsx`, `useFileDisplayMode.ts` | **new** — the header button, and reading the choice it stores |
| `FilesTree.tsx`, `FileRow.tsx` | folder rows, collapse/expand keys, folder checking |
| `Details.tsx`, `OutlineTree.tsx`, `WorkspacePage.tsx` | build the rows for the two lists |
| `project.ts`, `settings.ts`, `electron/settings.ts` | remembers which folders are closed, and which layout you picked |
| `Checkbox.tsx` + css | dash mark for a partly checked folder |

## Tests

11 unit tests in `file-tree.test.ts` — grouping, joining, sorting, closing, and the lookups. Also driven by hand in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
