### PR TITLE
Cosmetic UI fixes

### DIFF
--- a/apps/lite/package.json
+++ b/apps/lite/package.json
@@ -126,7 +126,7 @@
 		"@base-ui/react": "^1.6.0",
 		"@base-ui/utils": "^0.3.1",
 		"@gitbutler/but-sdk": "workspace:*",
-		"@gitbutler/design-core": "3.10.8",
+		"@gitbutler/design-core": "3.11.2",
 		"@pierre/diffs": "^1.2.12",
 		"@pierre/theming": "^0.0.2",
 		"@reduxjs/toolkit": "catalog:redux",

--- a/apps/lite/ui/src/components/Button.module.css
+++ b/apps/lite/ui/src/components/Button.module.css
@@ -106,7 +106,7 @@
 }
 
 :where(.outline) {
-	--button-border: 1px solid color-mix(in srgb, var(--fill-gray-bg) 30%, transparent);
+	--button-border: 1px solid color-mix(in srgb, var(--fill-gray-bg) 26%, transparent);
 	--button-bg: transparent;
 	--button-fg: color-mix(in srgb, var(--text-1) 90%, transparent);
 	--button-hover-fg: var(--text-1);
@@ -114,7 +114,7 @@
 }
 
 :where(.outline-inverted) {
-	--button-border: 1px solid color-mix(in srgb, var(--fill-gray-fg) 30%, transparent);
+	--button-border: 1px solid color-mix(in srgb, var(--fill-gray-fg) 26%, transparent);
 	--button-bg: transparent;
 	--button-fg: color-mix(in srgb, var(--text-1-invert) 90%, transparent);
 	--button-hover-fg: var(--text-1-invert);

--- a/apps/lite/ui/src/components/PickerDialog.module.css
+++ b/apps/lite/ui/src/components/PickerDialog.module.css
@@ -183,7 +183,7 @@
 	align-items: center;
 	justify-content: space-between;
 	padding: 0.625rem 0.75rem;
-	border-top: 1px solid var(--border-3);
+	border-top: 1px solid var(--border-section);
 	border-radius: 0 0 1rem 1rem;
 	background-color: var(--bg-2);
 	color: var(--text-2);

--- a/apps/lite/ui/src/components/ResizeHandle.module.css
+++ b/apps/lite/ui/src/components/ResizeHandle.module.css
@@ -1,0 +1,17 @@
+.resizeHandle {
+	background-color: var(--border-section);
+
+	/* A horizontal group (side-by-side panels) reports a vertical separator. */
+	&[aria-orientation="vertical"] {
+		width: 1px;
+	}
+
+	&[aria-orientation="horizontal"] {
+		height: 1px;
+	}
+
+	&[data-separator="hover"],
+	&[data-separator="active"] {
+		background-color: var(--border-1);
+	}
+}

--- a/apps/lite/ui/src/components/ResizeHandle.tsx
+++ b/apps/lite/ui/src/components/ResizeHandle.tsx
@@ -1,0 +1,13 @@
+import { classes } from "#ui/components/classes.ts";
+import type { FC } from "react";
+import { Separator, type SeparatorProps } from "react-resizable-panels";
+import styles from "./ResizeHandle.module.css";
+
+/**
+ * The hairline divider between resizable panels. It picks its own axis from
+ * the separator's `aria-orientation`, so the same handle works in both
+ * horizontal and vertical `Group`s.
+ */
+export const ResizeHandle: FC<SeparatorProps> = (p) => (
+	<Separator {...p} className={classes(styles.resizeHandle, p.className)} />
+);

--- a/apps/lite/ui/src/components/ui.module.css
+++ b/apps/lite/ui/src/components/ui.module.css
@@ -129,7 +129,7 @@
 		position: sticky;
 		top: 0;
 		margin-top: -1px;
-		border-top: 1px solid var(--border-3);
+		border-top: 1px solid var(--border-section);
 		content: "";
 		opacity: 0;
 		transition: opacity 50ms ease;

--- a/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.module.css
@@ -11,7 +11,7 @@
 	align-items: center;
 	padding-inline: var(--panel-padding-inline);
 	padding-block: 10px;
-	border-bottom: 1px solid var(--border-3);
+	border-bottom: 1px solid var(--border-section);
 	background-color: var(--bg-1);
 }
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/ChangeStats.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/ChangeStats.module.css
@@ -1,6 +1,9 @@
 .container {
 	display: inline-flex;
 	column-gap: 6px;
+	/* The stats are short and fixed-width: when the header runs out of room the
+	   heading next to them truncates instead. */
+	flex-shrink: 0;
 	align-items: center;
 }
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
@@ -66,7 +66,7 @@
 	/* With a separate header above (commit/branch views), use tighter padding. */
 	padding: 10px;
 	gap: 12px;
-	border-bottom: 1px solid var(--border-3);
+	border-bottom: 1px solid var(--border-section);
 
 	/* No files panel to the left, so align with the panel padding. */
 	&.filesHidden {
@@ -87,7 +87,7 @@
 }
 
 .panels {
-	border-top: 1px solid var(--border-3);
+	border-top: 1px solid var(--border-section);
 
 	/* No header above in the lone layout; the border would shift content down 1px. */
 	.containerLone & {
@@ -167,8 +167,8 @@
 
 	diffs-container {
 		--diffs-selection-number-fg: var(--text-1);
-		border-top: 1px solid var(--border-3);
-		border-bottom: 1px solid var(--border-3);
+		border-top: 1px solid var(--border-section);
+		border-bottom: 1px solid var(--border-section);
 
 		/* Hide the first diff's top border so it doesn't double up with the container above. */
 		&:first-child {

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
@@ -102,16 +102,6 @@
 	grid-template-columns: minmax(0, 1fr);
 }
 
-.resizeHandle {
-	width: 1px;
-	background-color: var(--border-3);
-
-	&[data-separator="hover"],
-	&[data-separator="active"] {
-		background-color: var(--border-2);
-	}
-}
-
 .loadingTab {
 	padding-inline: var(--panel-padding-inline);
 	padding-block-end: var(--panel-padding-block);

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -1,3 +1,4 @@
+import { ResizeHandle } from "#ui/components/ResizeHandle.tsx";
 import { Scroller } from "#ui/components/Scroller.tsx";
 import { SuspenseQuery } from "@suspensive/react-query";
 import { useOpenInProgram, useSaveGUISettings } from "#ui/api/mutations.ts";
@@ -71,7 +72,7 @@ import {
 	useRef,
 	useState,
 } from "react";
-import { Group, Panel, Separator, useDefaultLayout } from "react-resizable-panels";
+import { Group, Panel, useDefaultLayout } from "react-resizable-panels";
 import styles from "./Details.module.css";
 import { diffHotkeys, workspaceHotkeys } from "#ui/hotkeys.ts";
 import { useHotkeys } from "@tanstack/react-hotkeys";
@@ -1161,7 +1162,7 @@ const Diff: FC<{
 								</Scroller>
 							</div>
 						</Panel>
-						<Separator className={styles.resizeHandle} />
+						<ResizeHandle />
 					</>
 				)}
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -1124,7 +1124,7 @@ const Diff: FC<{
 							id={"files-panel" satisfies PanelId}
 							className={styles.panel}
 							defaultSize={320}
-							minSize={180}
+							minSize={220}
 							groupResizeBehavior="preserve-pixel-size"
 						>
 							<div className={styles.filesPanelContent} ref={filesPanelRef}>

--- a/apps/lite/ui/src/routes/project/$id/workspace/FileFilterRow.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/FileFilterRow.module.css
@@ -1,4 +1,5 @@
 .filterRow {
+	column-gap: 4px;
 	align-items: center;
 }
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/Outline.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Outline.module.css
@@ -67,5 +67,5 @@
 }
 
 .outlineTree {
-	border-top: 1px solid var(--border-3);
+	border-top: 1px solid var(--border-section);
 }

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.module.css
@@ -5,16 +5,6 @@
 	}
 }
 
-.resizeHandle {
-	height: 1px;
-	background-color: var(--border-3);
-
-	&[data-separator="hover"],
-	&[data-separator="active"] {
-		background-color: var(--border-2);
-	}
-}
-
 .uncommittedChangesOuterPanel {
 	/* Stretch/shrink single child element to fit this element. */
 	display: grid;

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
@@ -28,6 +28,7 @@ import { classes } from "#ui/components/classes.ts";
 import { navigationIndexIncludes, type NavigationIndex } from "#ui/workspace/navigation-index.ts";
 import { mergeProps, Tooltip, useRender } from "@base-ui/react";
 import { useMergedRefs } from "@base-ui/utils/useMergedRefs";
+import { ResizeHandle } from "#ui/components/ResizeHandle.tsx";
 import { Scroller } from "#ui/components/Scroller.tsx";
 import type {
 	BranchReference,
@@ -49,7 +50,7 @@ import {
 	use,
 	useRef,
 } from "react";
-import { Group, Panel, Separator, useDefaultLayout } from "react-resizable-panels";
+import { Group, Panel, useDefaultLayout } from "react-resizable-panels";
 import styles from "./OutlineTree.module.css";
 import { Row, RowLabel, RowLabelContainer, SectionHeaderRow } from "../Row.tsx";
 import { StackCard } from "../StackCard.tsx";
@@ -851,7 +852,7 @@ export const OutlineTree: FC<
 						/>
 					</Panel>
 
-					<Separator className={styles.resizeHandle} />
+					<ResizeHandle />
 
 					<Panel id={"stacks-panel" satisfies PanelId} className={styles.stacksPanel} minSize={120}>
 						<SectionHeaderRow

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestComments.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestComments.module.css
@@ -123,7 +123,7 @@
 	margin-block-start: 4px;
 	padding-block-start: 8px;
 	gap: 8px;
-	border-top: 1px solid var(--border-3);
+	border-top: 1px solid var(--border-section);
 }
 
 .replyButton {

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.module.css
@@ -15,7 +15,7 @@
 	padding: 10px 12px;
 
 	& + & {
-		border-top: 1px solid var(--border-3);
+		border-top: 1px solid var(--border-section);
 	}
 }
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/Row.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Row.tsx
@@ -188,7 +188,9 @@ export const SectionHeaderRow: FC<
 > = ({ label, actions, children, ...props }) => (
 	<Row {...props} className={classes(props.className, styles.sectionHeader)} interactive={false}>
 		<RowLabelContainer>
-			<RowLabel heading>{label}</RowLabel>
+			<RowLabel heading singleLine>
+				{label}
+			</RowLabel>
 
 			{children}
 		</RowLabelContainer>

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.module.css
@@ -36,13 +36,3 @@
 	grid-template-rows: minmax(0, 1fr);
 	grid-template-columns: minmax(0, 1fr);
 }
-
-.resizeHandle {
-	width: 1px;
-	background-color: var(--border-3);
-
-	&[data-separator="hover"],
-	&[data-separator="active"] {
-		background-color: var(--border-2);
-	}
-}

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
@@ -18,6 +18,7 @@ import {
 import { projectSlice } from "#ui/projects/state.ts";
 import { interfaceSlice } from "#ui/interface/state.ts";
 import { PickerDialog } from "#ui/components/PickerDialog.tsx";
+import { ResizeHandle } from "#ui/components/ResizeHandle.tsx";
 import { globalHotkeys, workspaceHotkeys } from "#ui/hotkeys.ts";
 import { writeLastOpenedProject } from "#ui/project.ts";
 import { useAppDispatch, useAppSelector } from "#ui/store.ts";
@@ -32,7 +33,7 @@ import {
 import { useNavigate, useParams } from "@tanstack/react-router";
 import { Match } from "effect";
 import { type FC, Activity, useDeferredValue, useRef } from "react";
-import { Group, Panel, Separator, useDefaultLayout } from "react-resizable-panels";
+import { Group, Panel, useDefaultLayout } from "react-resizable-panels";
 import {
 	branchOperand,
 	commitOperand,
@@ -653,7 +654,7 @@ const WorkspacePage: FC = () => {
 							onActiveFileSelection={onActiveUncommittedFileSelection}
 						/>
 					</Panel>
-					<Separator className={styles.resizeHandle} />
+					<ResizeHandle />
 				</Activity>
 
 				<Panel

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -414,8 +414,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/but-sdk
       '@gitbutler/design-core':
-        specifier: 3.10.8
-        version: 3.10.8
+        specifier: 3.11.2
+        version: 3.11.2
       '@pierre/diffs':
         specifier: ^1.2.12
         version: 1.2.12(@shikijs/themes@4.3.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -2036,8 +2036,8 @@ packages:
   '@gitbutler/design-core@2.2.2':
     resolution: {integrity: sha512-oPPnYjwsKxwoTY6wK/fT9ylwhSIBgQxCOGJzYefbM8WFr2OuJePH9MnDnZ3K9UQlb94p+NR7m/QCFzhbDVRwxw==}
 
-  '@gitbutler/design-core@3.10.8':
-    resolution: {integrity: sha512-kbVuEvXwTFOe8K3TtJAotyGpEEIQI2R9m19plmkkGelSVd4Wv5XJQaqlIxjChCzKWta8wT2W2pwU5hl7KSfIIA==}
+  '@gitbutler/design-core@3.11.2':
+    resolution: {integrity: sha512-R4DYPQ6lerTYZgBKqDVQbsaK27SsbGbylD4DPI83Zwlbcx29H6yka7vXAjlq6c5qRfWYpfhP/53I3FBrxCTVZQ==}
 
   '@gitbutler/design-core@3.9.1':
     resolution: {integrity: sha512-kLkZ1+pqeqpBntBOSV53kYVCmY/ZFemjxsWc78GTGLgn1Op8p7bWCNxCUSU822MKLJrzmjUg99MpqdHpXGcNAQ==}
@@ -11293,7 +11293,7 @@ snapshots:
 
   '@gitbutler/design-core@2.2.2': {}
 
-  '@gitbutler/design-core@3.10.8': {}
+  '@gitbutler/design-core@3.11.2': {}
 
   '@gitbutler/design-core@3.9.1': {}
 


### PR DESCRIPTION
A few small visual cleanups in the lite UI:

- Replace the section border variable with a semantic one
- Update button outline
- Bump design tokens and add new vars
- ResizeHandle: unify the three duplicate panel separators
- FilterRow: fix gap between elements