### PR TITLE
Keep the minimap honest at non-default zoom

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
@@ -148,6 +148,11 @@
 
 .diffContentsContainer {
 	display: grid;
+	/* Bound the row to the pane. Left to size itself, it takes the height of the
+	   ruler's canvas — which has no height of its own but its bitmap's, which the
+	   painter sizes from this row. At a fractional device pixel ratio the rounding
+	   in that loop doesn't cancel and the pane grows a little on every frame. */
+	grid-template-rows: minmax(0, 1fr);
 	/* Code, then the minimap ruler — which collapses the column when it has
 	   nothing to map. */
 	grid-template-columns: minmax(0, 1fr) auto;

--- a/apps/lite/ui/src/routes/project/$id/workspace/DiffMinimap.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DiffMinimap.module.css
@@ -58,12 +58,6 @@
 	   reads as added or removed. */
 	--minimap-selection: color-mix(in srgb, var(--fill-pop-bg) 16%, transparent);
 
-	--minimap-view-min: 14px;
-	/* Clamped here rather than in the geometry, which works in fractions and has
-	   no idea how tall the ruler ended up. */
-	--minimap-view-top: min(var(--minimap-marker-top, 0%), calc(100% - var(--minimap-view-min)));
-	--minimap-view-height: max(var(--minimap-marker-height, 0%), var(--minimap-view-min));
-
 	position: relative;
 	width: 56px;
 	/* Stronger than the panel's other hairlines: the marks run right to this
@@ -93,8 +87,10 @@
 	z-index: 2;
 	position: absolute;
 	inset-inline: 0;
-	top: var(--minimap-view-top);
-	height: var(--minimap-view-height);
+	/* Written in pixels by the ruler, which is the only place that knows how tall
+	   the track ended up — and so how much of it a lens at its floor takes. */
+	top: var(--minimap-marker-top, 0px);
+	height: var(--minimap-marker-height, 0px);
 	border-radius: 2px;
 	background-color: color-mix(in srgb, var(--fill-gray-bg) 16%, transparent);
 	pointer-events: none;

--- a/apps/lite/ui/src/routes/project/$id/workspace/DiffMinimap.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DiffMinimap.tsx
@@ -24,6 +24,18 @@ import { type MinimapBadge, paintMinimap } from "./diff-minimap-canvas.ts";
 import styles from "./DiffMinimap.module.css";
 
 /**
+ * Height the lens keeps however little of the diff the window holds, so it stays
+ * a thing you can take hold of rather than a hairline.
+ */
+const MARKER_MIN_HEIGHT = 14;
+
+const markerHeight = (share: number, track: number): number =>
+	Math.min(Math.max(share * track, MARKER_MIN_HEIGHT), track);
+
+/** Track left for the lens to move down, once it has taken its own height out. */
+const travel = (track: number, marker: number): number => Math.max(track - marker, 0);
+
+/**
  * A scroll ruler for the diff: every added and removed run drawn where it
  * actually sits in the scroll extent, as wide as its lines are long, with a
  * rule between files.
@@ -43,7 +55,7 @@ export const DiffMinimap: FC<{
 	const rulerRef = useRef<HTMLDivElement>(null);
 	const canvasRef = useRef<HTMLCanvasElement>(null);
 	const markerRef = useRef<HTMLDivElement>(null);
-	/** Where the pointer took hold of the thumb, as a fraction of the content. */
+	/** Where the pointer took hold of the lens, in pixels from its top. */
 	const grabRef = useRef(0);
 	const dataRef = useRef({ files, diffStyle, annotationsByPath, selection });
 	const geometryRef = useRef<MinimapGeometry | null>(null);
@@ -89,9 +101,24 @@ export const DiffMinimap: FC<{
 			const ruler = rulerRef.current;
 			if (!ruler) return;
 
+			// The ruler is collapsed until the first draw finds something to map, and
+			// a lens measured against no track at all would be written away to
+			// nothing. The draw that gives it a height also resizes the canvas, which
+			// brings us straight back here.
+			//
+			// Measured to the sub-pixel, as the drag is: a track rounded here and not
+			// there puts the two a fraction of a percent apart, which on a diff long
+			// enough to floor the lens is thousands of lines.
+			const track = ruler.getBoundingClientRect().height;
+			if (track === 0) return;
+
 			const viewport = getMinimapViewport(viewer);
-			ruler.style.setProperty("--minimap-marker-top", `${viewport.top * 100}%`);
-			ruler.style.setProperty("--minimap-marker-height", `${viewport.height * 100}%`);
+			const marker = markerHeight(viewport.height, track);
+			ruler.style.setProperty(
+				"--minimap-marker-top",
+				`${viewport.progress * travel(track, marker)}px`,
+			);
+			ruler.style.setProperty("--minimap-marker-height", `${marker}px`);
 		};
 
 		// A forced pass has to outlive being folded into a pending scroll one,
@@ -163,9 +190,17 @@ export const DiffMinimap: FC<{
 		return Math.min(Math.max((event.clientY - top) / height, 0), 1);
 	};
 
-	const dragTo = (fraction: number): void => {
+	// Placing the lens rather than pointing at content: the pointer carries it by
+	// the spot it was taken hold of, over the track its own height leaves.
+	const dragTo = (event: PointerEvent<HTMLDivElement>): void => {
 		const viewer = viewerRef.current?.getInstance();
-		if (viewer) scrollMinimapTo(viewer, fraction - grabRef.current);
+		const { height: track, top: trackTop } = event.currentTarget.getBoundingClientRect();
+		if (!viewer || track === 0) return;
+
+		const room = travel(track, markerHeight(getMinimapViewport(viewer).height, track));
+		const top = event.clientY - trackTop - grabRef.current;
+
+		scrollMinimapTo(viewer, room === 0 ? 0 : Math.min(Math.max(top / room, 0), 1));
 	};
 
 	// The label's position is written straight to the DOM, so following the
@@ -197,8 +232,7 @@ export const DiffMinimap: FC<{
 				event.preventDefault();
 
 				const viewer = viewerRef.current?.getInstance();
-				const fraction = fractionAt(event);
-				if (!viewer || fraction === null) return;
+				if (!viewer) return;
 
 				// Taking hold of the lens keeps the point you grabbed, the way a
 				// scrollbar does; pressing the track jumps its middle there and drags on
@@ -206,19 +240,20 @@ export const DiffMinimap: FC<{
 				// it can shrink to doesn't have to be repeated here.
 				const marker = markerRef.current?.getBoundingClientRect();
 				const held = marker && event.clientY >= marker.top && event.clientY <= marker.bottom;
-				const viewport = getMinimapViewport(viewer);
-				grabRef.current = held ? fraction - viewport.top : viewport.height / 2;
+				grabRef.current = held
+					? event.clientY - marker.top
+					: (marker?.height ?? MARKER_MIN_HEIGHT) / 2;
 
 				event.currentTarget.setPointerCapture(event.pointerId);
 				// Taking hold shouldn't move anything; pressing the track jumps.
-				if (!held) dragTo(fraction);
+				if (!held) dragTo(event);
 			}}
 			onPointerMove={(event) => {
 				const fraction = fractionAt(event);
 				if (fraction === null) return;
 
 				describe(fraction);
-				if (event.currentTarget.hasPointerCapture(event.pointerId)) dragTo(fraction);
+				if (event.currentTarget.hasPointerCapture(event.pointerId)) dragTo(event);
 			}}
 			onPointerLeave={() => setHovered(null)}
 		>

--- a/apps/lite/ui/src/routes/project/$id/workspace/diff-minimap.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/diff-minimap.ts
@@ -492,24 +492,39 @@ export const getMinimapOverlays = ({
 	return { pins, band };
 };
 
-/** The visible window, as fractions of the content. */
+/**
+ * The visible window: how much of the content it covers, and how far through
+ * the scrollable range it sits.
+ *
+ * Progress rather than a top, because the lens is held to a minimum height and
+ * one wider than the window it stands for travels a track shortened by the
+ * difference — the arithmetic every scrollbar does. Where the lens is its true
+ * size the two agree exactly, so only a diff long enough to floor it moves.
+ */
 export const getMinimapViewport = (
 	viewer: CodeView<Annotation>,
-): { top: number; height: number } => {
+): { height: number; progress: number } => {
 	const total = contentHeight(viewer);
-	if (total <= 0) return { top: 0, height: 1 };
+	if (total <= 0) return { height: 1, progress: 0 };
 
-	return { top: viewer.getScrollTop() / total, height: viewer.getHeight() / total };
+	const scrollable = scrollableHeight(viewer);
+	const progress = scrollable <= 0 ? 0 : viewer.getScrollTop() / scrollable;
+
+	return { height: viewer.getHeight() / total, progress: Math.min(Math.max(progress, 0), 1) };
 };
 
-/** Scroll so the top of the viewport sits at `fraction` of the content. */
-export const scrollMinimapTo = (viewer: CodeView<Annotation>, fraction: number): void => {
+/** How far the diff can scroll: everything below the window it doesn't fill. */
+const scrollableHeight = (viewer: CodeView<Annotation>): number =>
+	Math.max(contentHeight(viewer) - viewer.getHeight(), 0);
+
+/** Scroll `progress` of the way through the range, 0 being the top and 1 the end. */
+export const scrollMinimapTo = (viewer: CodeView<Annotation>, progress: number): void => {
 	viewer.scrollTo({
 		type: "position",
 		// CodeView lifts a position target by the sticky header, so the row you
 		// asked for isn't left under it. The minimap is placing the viewport rather
 		// than a row, so add it back or every drag sits a header too high.
-		position: fraction * contentHeight(viewer) + codeViewItemMetrics.diffHeaderHeight,
+		position: progress * scrollableHeight(viewer) + codeViewItemMetrics.diffHeaderHeight,
 		behavior: "instant",
 	});
 };


### PR DESCRIPTION
Two minimap bugs that only show up at non-default zoom.

The diff pane took its height from the minimap canvas, and the painter sized that
canvas from the pane. At the fractional device pixel ratios ⌘+/⌘− produce, the
rounding in that loop doesn't cancel, so the pane grew every frame until the diff
and the ruler hung below the window. Bounding the grid row cuts the loop.

The lens has a 14px minimum height but was positioned as a fraction of the whole
track, so on a long enough diff it parked at the bottom of the track while
dragging carried on scrolling. It now travels the track its own height leaves,
which is identical to the old maths whenever the lens is its true size.
