### PR TITLE
Say "commits between" instead of "shared commits" in the upstream expander

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/UpstreamList.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/UpstreamList.tsx
@@ -204,7 +204,7 @@ const SegmentExpanderRow: FC<{
 					dispatch(projectSlice.actions.toggleUpstreamSegment({ projectId, segmentId }))
 				}
 			>
-				{expanded ? "hide commits" : `${count} shared ${count === 1 ? "commit" : "commits"}`}
+				{expanded ? "hide commits" : `${count} ${count === 1 ? "commit" : "commits"} between`}
 			</Button>
 		</div>
 	);


### PR DESCRIPTION
The collapsed segment expander in lite's Upstream tab labeled the folded target commits as "x shared commits". "x commits between" describes what they are: the commits between the two fork points.