### PR TITLE
Point to but reword for branch renames in but branch help

### DIFF
--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -83,6 +83,8 @@ but branch list --empty  # Include empty branches
 but branch list --review  # Fetch and display review information
 ```
 
+To rename an applied branch, use `but reword <branch> -m "new-name"` (unapplied branches cannot be renamed).
+
 ### `but branch new [name]`
 
 Create a new branch.
@@ -294,6 +296,7 @@ Reword commit message or rename branch.
 
 ```bash
 but reword <id> -m "new"          # Always pass -m; without it an editor opens and blocks
+but reword <branch> -m "new-name" # Rename a branch (applied branches only)
 but reword <id> --fix-formatting  # Format to 72-char wrapping
 ```
 

--- a/crates/but/src/args/branch.rs
+++ b/crates/but/src/args/branch.rs
@@ -16,6 +16,7 @@ pub enum IntegrationStrategy {
 }
 
 #[derive(Debug, clap::Parser)]
+#[clap(after_help = "To rename an applied branch, use `but reword <branch> -m <new-name>`.")]
 pub struct Platform {
     #[clap(subcommand)]
     pub cmd: Option<Subcommands>,

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -332,6 +332,8 @@ pub enum Subcommands {
     ///
     /// To apply or unapply branches, use `but apply` and `but unapply`.
     ///
+    /// To rename an applied branch, use `but reword <branch> -m <new-name>`.
+    ///
     #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Branch(branch::Platform),
 


### PR DESCRIPTION
Agents (and humans) failed to discover that `but reword` is how you rename a branch when looking at `but branch -h`.

- Add an `after_help` hint to `but branch` so the short `-h` help mentions `but reword <branch> -m <new-name>`
- Mention renaming in the long `--help` doc for the branch command
- Surface rename in the agent skill reference: a pointer in the Branching section and a rename example under `but reword`

Requested in Discord.