### PR TITLE
Draw the minimap at a fixed scale

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/DiffMinimap.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DiffMinimap.module.css
@@ -59,7 +59,12 @@
 	--minimap-selection: color-mix(in srgb, var(--fill-pop-bg) 16%, transparent);
 
 	position: relative;
+	/* Ends where the map does rather than stretching past it. At a fixed scale a
+	   short diff simply doesn't reach the foot of the pane, and ruler below the
+	   last line is ruler the lens can never travel to. */
+	align-self: start;
 	width: 56px;
+	height: var(--minimap-track-height, 100%);
 	/* Stronger than the panel's other hairlines: the marks run right to this
 	   edge, and a deletion-heavy diff puts near-identical pinks on both sides. */
 	border-left: 1px solid var(--border-2);
@@ -72,10 +77,19 @@
 	display: none;
 }
 
+/*
+ * Out of the flow, and sized outright. A canvas carries its bitmap as an
+ * intrinsic size and the bitmap is sized from the box it lands in, which is a
+ * loop this pane has been round before. Taking it out of the flow stops it
+ * sizing the ruler; the explicit height stops the ruler's own inset from
+ * leaving it `auto`, which for a replaced element means that bitmap again.
+ */
 .canvas {
 	display: block;
+	position: absolute;
 	width: 100%;
 	height: 100%;
+	inset: 0;
 }
 
 /*
@@ -124,7 +138,7 @@
 	display: flex;
 	z-index: 3;
 	position: absolute;
-	top: clamp(16px, var(--minimap-hint-top, 0%), calc(100% - 16px));
+	top: clamp(16px, var(--minimap-hint-top, 0px), calc(100% - 16px));
 	/* The ruler is the window's right edge, so the label opens inward. */
 	right: calc(100% + 8px);
 	align-items: center;

--- a/apps/lite/ui/src/routes/project/$id/workspace/DiffMinimap.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DiffMinimap.tsx
@@ -13,10 +13,12 @@ import {
 import type { Annotation } from "./diff-view.ts";
 import {
 	getMinimapGeometry,
+	getMinimapLayout,
 	getMinimapOverlays,
-	getMinimapViewport,
+	getMinimapScrollable,
 	type MinimapFile,
 	type MinimapGeometry,
+	type MinimapLayout,
 	type MinimapSelection,
 	scrollMinimapTo,
 } from "./diff-minimap.ts";
@@ -24,16 +26,12 @@ import { type MinimapBadge, paintMinimap } from "./diff-minimap-canvas.ts";
 import styles from "./DiffMinimap.module.css";
 
 /**
- * Height the lens keeps however little of the diff the window holds, so it stays
- * a thing you can take hold of rather than a hairline.
+ * Room the ruler has to work in, which is the pane's rather than its own: it
+ * ends with the map, and a map scaled against that height would be reasoning in
+ * a circle.
  */
-const MARKER_MIN_HEIGHT = 14;
-
-const markerHeight = (share: number, track: number): number =>
-	Math.min(Math.max(share * track, MARKER_MIN_HEIGHT), track);
-
-/** Track left for the lens to move down, once it has taken its own height out. */
-const travel = (track: number, marker: number): number => Math.max(track - marker, 0);
+const availableTrack = (ruler: HTMLElement): number =>
+	ruler.parentElement?.getBoundingClientRect().height ?? 0;
 
 /**
  * A scroll ruler for the diff: every added and removed run drawn where it
@@ -55,10 +53,16 @@ export const DiffMinimap: FC<{
 	const rulerRef = useRef<HTMLDivElement>(null);
 	const canvasRef = useRef<HTMLCanvasElement>(null);
 	const markerRef = useRef<HTMLDivElement>(null);
-	/** Where the pointer took hold of the lens, in pixels from its top. */
-	const grabRef = useRef(0);
+	/**
+	 * The lens as it was when the pointer took hold: where on it the grab landed,
+	 * and the mapping to invert. Frozen for the length of the drag because
+	 * CodeView's content height is an estimate that firms up as it renders, and a
+	 * mapping recomputed under the pointer slides the diff while you hold it.
+	 */
+	const grabRef = useRef<{ offset: number; layout: MinimapLayout } | null>(null);
 	const dataRef = useRef({ files, diffStyle, annotationsByPath, selection });
 	const geometryRef = useRef<MinimapGeometry | null>(null);
+	const layoutRef = useRef<MinimapLayout | null>(null);
 	const resyncRef = useRef<(() => void) | null>(null);
 	const [navigable, setNavigable] = useState(false);
 	const [hovered, setHovered] = useState<string | null>(null);
@@ -72,8 +76,9 @@ export const DiffMinimap: FC<{
 		let frame: number | null = null;
 		let forced = false;
 		let lastScrollHeight: number | null = null;
+		let lastOffset: number | null = null;
 
-		const draw = (): void => {
+		const draw = (layout: MinimapLayout): void => {
 			const { files, diffStyle, annotationsByPath, selection } = dataRef.current;
 			const geometry = getMinimapGeometry(
 				viewer,
@@ -85,40 +90,45 @@ export const DiffMinimap: FC<{
 			if (!geometry) return;
 
 			const overlays = getMinimapOverlays({ files, geometry, annotationsByPath, selection });
-			setBadges(paintMinimap(canvas, { files, geometry, diffStyle, overlays }));
+			setBadges(paintMinimap(canvas, { files, geometry, layout, diffStyle, overlays }));
 		};
 
 		const sync = (force: boolean): void => {
-			// Item heights start out estimated and firm up as virtualization renders
-			// them, which moves every file below. Total height moves with them, so it
-			// doubles as a cheap "the layout shifted" check on the scroll path.
-			const scrollHeight = viewer.getScrollHeight();
-			if (force || scrollHeight !== lastScrollHeight) {
-				lastScrollHeight = scrollHeight;
-				draw();
-			}
-
 			const ruler = rulerRef.current;
 			if (!ruler) return;
 
-			// The ruler is collapsed until the first draw finds something to map, and
-			// a lens measured against no track at all would be written away to
-			// nothing. The draw that gives it a height also resizes the canvas, which
-			// brings us straight back here.
-			//
 			// Measured to the sub-pixel, as the drag is: a track rounded here and not
-			// there puts the two a fraction of a percent apart, which on a diff long
-			// enough to floor the lens is thousands of lines.
-			const track = ruler.getBoundingClientRect().height;
+			// there puts the two a fraction of a percent apart, which at this scale is
+			// a good many lines. Zero while the ruler is collapsed, which it is until
+			// a draw finds something to map — so the draw has to come first, or it
+			// waits on the height that only it can bring about.
+			const track = availableTrack(ruler);
+			const layout = getMinimapLayout(viewer, track);
+
+			// The ruler stops where the map does, so its own height can't be what the
+			// map was scaled against — that would be a box sized from what it holds
+			// and holding what it was sized for.
+			ruler.style.setProperty("--minimap-track-height", `${Math.min(track, layout.mapHeight)}px`);
+
+			// Item heights start out estimated and firm up as virtualization renders
+			// them, which moves every file below. Total height moves with them, so it
+			// doubles as a cheap "the layout shifted" check on the scroll path. A map
+			// too tall for the ruler also winds under the lens as the diff scrolls,
+			// and that is a different picture every time it moves.
+			const scrollHeight = viewer.getScrollHeight();
+			if (force || scrollHeight !== lastScrollHeight || layout.offset !== lastOffset) {
+				lastScrollHeight = scrollHeight;
+				lastOffset = layout.offset;
+				draw(layout);
+			}
+
+			// The canvas the draw just sized is what gives the ruler its height, so
+			// the pass that opens it measures nothing and the resize brings us back.
 			if (track === 0) return;
 
-			const viewport = getMinimapViewport(viewer);
-			const marker = markerHeight(viewport.height, track);
-			ruler.style.setProperty(
-				"--minimap-marker-top",
-				`${viewport.progress * travel(track, marker)}px`,
-			);
-			ruler.style.setProperty("--minimap-marker-height", `${marker}px`);
+			layoutRef.current = layout;
+			ruler.style.setProperty("--minimap-marker-top", `${layout.lensTop}px`);
+			ruler.style.setProperty("--minimap-marker-height", `${layout.lensHeight}px`);
 		};
 
 		// A forced pass has to outlive being folded into a pending scroll one,
@@ -157,12 +167,29 @@ export const DiffMinimap: FC<{
 		const scheme = globalThis.matchMedia("(prefers-color-scheme: dark)");
 		scheme.addEventListener("change", redraw);
 
+		// The bitmap is sized from the device pixel ratio, which changes with no
+		// change to the ruler's own box when the window is dragged onto a display
+		// that scales differently — so nothing else here would notice. The query
+		// only asks about the ratio it was built from, so re-arm on every change.
+		let pixels: MediaQueryList | null = null;
+		const watchPixels = (): void => {
+			pixels?.removeEventListener("change", onPixels);
+			pixels = globalThis.matchMedia(`(resolution: ${globalThis.devicePixelRatio}dppx)`);
+			pixels.addEventListener("change", onPixels);
+		};
+		const onPixels = (): void => {
+			watchPixels();
+			redraw();
+		};
+		watchPixels();
+
 		return () => {
 			resyncRef.current = null;
 			if (frame !== null) cancelAnimationFrame(frame);
 			unsubscribe();
 			resizeObserver.disconnect();
 			scheme.removeEventListener("change", redraw);
+			pixels?.removeEventListener("change", onPixels);
 		};
 	}, [viewerRef]);
 
@@ -181,39 +208,57 @@ export const DiffMinimap: FC<{
 		resyncRef.current?.();
 	});
 
-	const fractionAt = (event: PointerEvent<HTMLDivElement>): number | null => {
-		const { height, top } = event.currentTarget.getBoundingClientRect();
-		if (height === 0) return null;
+	/** Where the pointer sits on the ruler, in pixels from its top. */
+	const rulerOffset = (event: PointerEvent<HTMLDivElement>): number =>
+		event.clientY - event.currentTarget.getBoundingClientRect().top;
 
-		// A captured pointer travels outside the ruler, and this is a fraction of
-		// it — so keep it one rather than leaving every caller to cope.
-		return Math.min(Math.max((event.clientY - top) / height, 0), 1);
+	/** Bring a place in the content into the middle of the window, and say where that left it. */
+	const jumpTo = (content: number): number => {
+		const viewer = viewerRef.current?.getInstance();
+		if (!viewer) return 0;
+
+		const middle = content - viewer.getHeight() / 2;
+		const landing = Math.min(Math.max(middle, 0), getMinimapScrollable(viewer));
+		scrollMinimapTo(viewer, landing);
+
+		return landing;
 	};
 
 	// Placing the lens rather than pointing at content: the pointer carries it by
-	// the spot it was taken hold of, over the track its own height leaves.
+	// the spot it was taken hold of, over the room the lens has to move.
 	const dragTo = (event: PointerEvent<HTMLDivElement>): void => {
 		const viewer = viewerRef.current?.getInstance();
-		const { height: track, top: trackTop } = event.currentTarget.getBoundingClientRect();
-		if (!viewer || track === 0) return;
+		const grab = grabRef.current;
+		if (!viewer || !grab) return;
 
-		const room = travel(track, markerHeight(getMinimapViewport(viewer).height, track));
-		const top = event.clientY - trackTop - grabRef.current;
+		const top = rulerOffset(event) - grab.offset;
+		const reach = grab.layout.travel === 0 ? 0 : top / grab.layout.travel;
+		const progress = Math.min(Math.max(reach, 0), 1);
 
-		scrollMinimapTo(viewer, room === 0 ? 0 : Math.min(Math.max(top / room, 0), 1));
+		// The estimate the mapping was frozen against firms up as the drag scrolls
+		// through it, and the far end is the one place that shows: stopping short of
+		// a diff that grew under you reads as the lens failing to reach the bottom.
+		// So the last of the travel goes wherever the end is now.
+		const scrollable = progress === 1 ? getMinimapScrollable(viewer) : grab.layout.scrollable;
+
+		scrollMinimapTo(viewer, progress * scrollable);
 	};
 
 	// The label's position is written straight to the DOM, so following the
 	// pointer costs no renders; only naming a different file does.
-	const describe = (fraction: number): void => {
+	const describe = (event: PointerEvent<HTMLDivElement>): void => {
 		const geometry = geometryRef.current;
+		const layout = layoutRef.current;
 		const ruler = rulerRef.current;
-		if (!geometry || !ruler) return;
+		if (!geometry || !layout || !ruler) return;
 
-		ruler.style.setProperty("--minimap-hint-top", `${fraction * 100}%`);
+		const y = rulerOffset(event);
+		ruler.style.setProperty("--minimap-hint-top", `${y}px`);
 
-		const offset = fraction * geometry.contentHeight;
-		const index = geometry.blocks.findLastIndex((block) => block.top <= offset);
+		// Back through the drawing: the ruler shows the map from `offset` down, at
+		// a fixed scale, so this is the content the pointer is actually over.
+		const content = (y + layout.offset) / layout.scale;
+		const index = geometry.blocks.findLastIndex((block) => block.top <= content);
 		const path = dataRef.current.files[index]?.path ?? null;
 		if (path !== hovered) setHovered(path);
 	};
@@ -232,28 +277,41 @@ export const DiffMinimap: FC<{
 				event.preventDefault();
 
 				const viewer = viewerRef.current?.getInstance();
-				if (!viewer) return;
-
-				// Taking hold of the lens keeps the point you grabbed, the way a
-				// scrollbar does; pressing the track jumps its middle there and drags on
-				// from the middle. Its own rect is the hit test, so the minimum height
-				// it can shrink to doesn't have to be repeated here.
-				const marker = markerRef.current?.getBoundingClientRect();
-				const held = marker && event.clientY >= marker.top && event.clientY <= marker.bottom;
-				grabRef.current = held
-					? event.clientY - marker.top
-					: (marker?.height ?? MARKER_MIN_HEIGHT) / 2;
+				const layout = layoutRef.current;
+				if (!viewer || !layout) return;
 
 				event.currentTarget.setPointerCapture(event.pointerId);
-				// Taking hold shouldn't move anything; pressing the track jumps.
-				if (!held) dragTo(event);
+
+				// Taking hold of the lens keeps the point you grabbed, the way a
+				// scrollbar does, and moves nothing until you do. Its own rect is the hit
+				// test, so the minimum height it can shrink to doesn't have to be
+				// repeated here.
+				const marker = markerRef.current?.getBoundingClientRect();
+				if (marker && event.clientY >= marker.top && event.clientY <= marker.bottom) {
+					grabRef.current = { offset: event.clientY - marker.top, layout };
+					return;
+				}
+
+				// Pressing the track is pointing at the code drawn there, not at a share
+				// of the whole diff: the map is a picture at a fixed scale, so read the
+				// position back out of it the way the hint does and bring it into the
+				// middle of the window.
+				const landing = jumpTo((rulerOffset(event) + layout.offset) / layout.scale);
+
+				// The map may have wound on under the pointer, taking the lens with it,
+				// so the drag carries on from where the lens has landed. Worked out from
+				// the landing rather than read back off the viewer, which goes on
+				// reporting the old position for a frame yet — long enough for the first
+				// move to teleport by the difference.
+				const landed = getMinimapLayout(viewer, availableTrack(event.currentTarget), landing);
+				grabRef.current = { offset: rulerOffset(event) - landed.lensTop, layout: landed };
 			}}
 			onPointerMove={(event) => {
-				const fraction = fractionAt(event);
-				if (fraction === null) return;
-
-				describe(fraction);
+				describe(event);
 				if (event.currentTarget.hasPointerCapture(event.pointerId)) dragTo(event);
+			}}
+			onPointerUp={() => {
+				grabRef.current = null;
 			}}
 			onPointerLeave={() => setHovered(null)}
 		>

--- a/apps/lite/ui/src/routes/project/$id/workspace/diff-minimap-canvas.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/diff-minimap-canvas.ts
@@ -3,6 +3,7 @@ import {
 	getMinimapScale,
 	type MinimapFile,
 	type MinimapGeometry,
+	type MinimapLayout,
 	type MinimapOverlays,
 	type MinimapSide,
 } from "./diff-minimap.ts";
@@ -52,11 +53,13 @@ const resolveLanes = ({
 	geometry,
 	rows,
 	scale,
+	offset,
 }: {
 	files: Array<MinimapFile>;
 	geometry: MinimapGeometry;
 	rows: number;
 	scale: number;
+	offset: number;
 }): Record<MinimapSide, Lane> => {
 	const lane = (): Lane => ({
 		widths: new Float32Array(rows),
@@ -73,14 +76,22 @@ const resolveLanes = ({
 		// Straight off the file's own marks: a scaled copy of every one of them,
 		// on every paint, is a lot of garbage for two multiplications.
 		const correction = getMinimapScale(file, block) * scale;
-		const origin = block.top * scale;
+		const origin = block.top * scale - offset;
+
+		// A wound-on map leaves most of the diff off either end of the ruler, and
+		// the whole point of drawing at a fixed scale is that there can be a great
+		// deal of it. Whole files first, then runs within the file that survives.
+		if (origin > rows || origin + block.height * scale < 0) continue;
 
 		for (const mark of file.marks) {
 			const lane = lanes[mark.side];
+			const markTop = origin + mark.top * correction;
+			if (markTop > rows) break;
+			if (markTop + mark.height * correction < 0) continue;
 			// One rendered row, which is also each line's height unless wrapping gave
 			// some of them more than one.
 			const rowHeight = (mark.height * correction) / mark.rowCount;
-			let y = origin + mark.top * correction;
+			let y = markTop;
 
 			for (const [line, width] of mark.widths.entries()) {
 				const lineHeight = (mark.rows?.[line] ?? 1) * rowHeight;
@@ -117,30 +128,33 @@ const resolveLanes = ({
 };
 
 /**
- * One rule per file, snapped to a whole pixel. Where two would collide the
- * taller section keeps the slot, so a sliver can't take it from the file after
- * it. The first file gets none — the ruler's top edge is already where it
- * starts, and the toolbar above draws its own border there.
+ * One rule per file boundary that falls on the ruler, snapped to a whole pixel.
+ * Where two would collide the taller section keeps the slot, so a sliver can't
+ * take it from the file after it.
+ *
+ * A boundary off either end draws nothing, which is also why the first file
+ * needs no special case: at rest its top sits on the ruler's own top edge,
+ * where the toolbar above already draws a border.
  */
 const resolveRules = ({
 	geometry,
 	scale,
+	offset,
 	limit,
 }: {
 	geometry: MinimapGeometry;
 	scale: number;
+	offset: number;
 	limit: number;
 }): Array<{ index: number; y: number; height: number }> => {
 	const rules: Array<{ index: number; y: number; height: number }> = [];
 
 	for (const [index, block] of geometry.blocks.entries()) {
-		if (index === 0) continue;
+		const y = Math.round(block.top * scale - offset);
+		if (y <= 0) continue;
+		if (y > limit) break;
 
-		const rule = {
-			index,
-			y: Math.min(Math.round(block.top * scale), limit),
-			height: block.height * scale,
-		};
+		const rule = { index, y, height: block.height * scale };
 		const previous = rules.at(-1);
 
 		if (previous && rule.y - previous.y < RULE_MIN_GAP) {
@@ -154,6 +168,28 @@ const resolveRules = ({
 };
 
 /**
+ * The file the top of the ruler falls inside, so it can be badged there the way
+ * the files below are badged against their rules. Only worth an icon if enough
+ * of it is left on the ruler to hang one on.
+ */
+const resolveOpening = ({
+	geometry,
+	scale,
+	offset,
+}: {
+	geometry: MinimapGeometry;
+	scale: number;
+	offset: number;
+}): Array<MinimapBadge> => {
+	const index = geometry.blocks.findLastIndex((block) => block.top * scale - offset <= 0);
+	const block = geometry.blocks[index];
+	if (!block) return [];
+
+	const remaining = (block.top + block.height) * scale - offset;
+	return remaining >= ICON_MIN_SECTION ? [{ index, top: 0 }] : [];
+};
+
+/**
  * Paint the ruler, and report which files have room for a type icon. Badges are
  * only offered for files that kept a rule, so one always sits the same distance
  * under the line opening its section rather than measuring to one further up.
@@ -163,11 +199,13 @@ export const paintMinimap = (
 	{
 		files,
 		geometry,
+		layout,
 		diffStyle,
 		overlays,
 	}: {
 		files: Array<MinimapFile>;
 		geometry: MinimapGeometry;
+		layout: MinimapLayout;
 		diffStyle: GUISettings["diffStyle"];
 		overlays: MinimapOverlays;
 	},
@@ -200,9 +238,15 @@ export const paintMinimap = (
 	const laneWidth = Math.max(split ? (width - LANE_SPLIT) / 2 : width, 1);
 	// One device pixel, in the CSS units the context is scaled to.
 	const thinnest = 1 / ratio;
-	const scale = height / geometry.contentHeight;
+	const { scale, offset } = layout;
 	const rows = deviceHeight;
-	const lanes = resolveLanes({ files, geometry, rows, scale: scale * ratio });
+	const lanes = resolveLanes({
+		files,
+		geometry,
+		rows,
+		scale: scale * ratio,
+		offset: offset * ratio,
+	});
 
 	for (let row = 0; row < rows; row++) {
 		const removed = lanes.deletions.coverage[row] ?? 0;
@@ -250,7 +294,7 @@ export const paintMinimap = (
 		context.fillStyle = fills.selection;
 		context.fillRect(
 			0,
-			overlays.band.top * scale,
+			overlays.band.top * scale - offset,
 			width,
 			Math.max(overlays.band.height * scale, thinnest),
 		);
@@ -265,23 +309,28 @@ export const paintMinimap = (
 
 	// Drawn last and opaque, so a rule reads over the marks it crosses rather
 	// than tinting with them.
-	const rules = resolveRules({ geometry, scale, limit: height - thinnest });
+	const rules = resolveRules({ geometry, scale, offset, limit: height - thinnest });
 	context.fillStyle = palette.getPropertyValue("--minimap-file-rule");
 	for (const rule of rules) context.fillRect(0, rule.y, width, thinnest);
 
 	// Pinned to the right edge, opposite the file badges, so a commented line is
-	// findable without covering the marks it belongs to.
+	// findable without covering the marks it belongs to. Nudged inside the ends
+	// rather than clamped to them, so one just off the wound-on map stays off it.
 	context.fillStyle = fills.pin;
 	for (const pin of overlays.pins) {
-		const top = Math.min(Math.max(pin * scale - PIN_HEIGHT / 2, 0), height - PIN_HEIGHT);
-		context.fillRect(width - PIN_WIDTH, top, PIN_WIDTH, PIN_HEIGHT);
+		const top = pin * scale - offset - PIN_HEIGHT / 2;
+		if (top < -PIN_HEIGHT || top > height) continue;
+
+		context.fillRect(
+			width - PIN_WIDTH,
+			Math.min(Math.max(top, 0), height - PIN_HEIGHT),
+			PIN_WIDTH,
+			PIN_HEIGHT,
+		);
 	}
 
-	const first = geometry.blocks[0];
-	const opening = first && first.height * scale >= ICON_MIN_SECTION ? [{ index: 0, top: 0 }] : [];
-
 	return [
-		...opening,
+		...resolveOpening({ geometry, scale, offset }),
 		...rules
 			.filter((rule) => rule.height >= ICON_MIN_SECTION)
 			.map(({ index, y }) => ({ index, top: y })),

--- a/apps/lite/ui/src/routes/project/$id/workspace/diff-minimap.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/diff-minimap.ts
@@ -493,38 +493,107 @@ export const getMinimapOverlays = ({
 };
 
 /**
- * The visible window: how much of the content it covers, and how far through
- * the scrollable range it sits.
+ * Ruler pixels a diff row is drawn tall, whatever the diff's length.
  *
- * Progress rather than a top, because the lens is held to a minimum height and
- * one wider than the window it stands for travels a track shortened by the
- * difference — the arithmetic every scrollbar does. Where the lens is its true
- * size the two agree exactly, so only a diff long enough to floor it moves.
+ * Fixed rather than fitted: a map squeezed to the ruler tells you less the more
+ * there is to tell, until a long diff is sub-pixel slivers under a lens too
+ * small to take hold of. At a fixed scale the picture keeps its meaning and a
+ * map with nowhere to go scrolls instead, the way the editor's does.
  */
-export const getMinimapViewport = (
-	viewer: CodeView<Annotation>,
-): { height: number; progress: number } => {
-	const total = contentHeight(viewer);
-	if (total <= 0) return { height: 1, progress: 0 };
+const MAP_ROW_HEIGHT = 1;
 
-	const scrollable = scrollableHeight(viewer);
-	const progress = scrollable <= 0 ? 0 : viewer.getScrollTop() / scrollable;
+/**
+ * Ruler-fulls of map to wind through before rows begin sharing pixels. A map
+ * that scrolls for ever is as hard to place yourself in as one squeezed to
+ * nothing, so past this the rows are averaged down instead of the map growing
+ * — which the painter already does well, it being how a line thinner than a
+ * pixel has always been drawn.
+ */
+const MAX_MAP_TRACKS = 4;
 
-	return { height: viewer.getHeight() / total, progress: Math.min(Math.max(progress, 0), 1) };
+/**
+ * Ruler pixels per scroll-content pixel: a row to the pixel until the map would
+ * outrun the winding above, and thereafter whatever keeps it to that.
+ */
+const mapScale = (total: number, track: number): number => {
+	const fixed = MAP_ROW_HEIGHT / ROW_HEIGHT;
+	if (total <= 0 || track <= 0) return fixed;
+
+	return Math.min(fixed, (track * MAX_MAP_TRACKS) / total);
+};
+
+/**
+ * Height the lens keeps however little of the diff the window holds. At a fixed
+ * scale it is the window's own height scaled down, so it only binds on a pane
+ * too short to draw one — but the travel below is measured against whatever it
+ * ends up being, so a floored lens still ends where the scrolling does.
+ */
+const LENS_MIN_HEIGHT = 14;
+
+/**
+ * Where the map and its lens sit, in ruler pixels.
+ *
+ * The lens travels the track its own height leaves — the arithmetic every
+ * scrollbar does — and the map is then slid so the code under the lens is the
+ * code in the window. Both reach their ends together: at the foot of the
+ * scroll the lens is at the foot of the track and the map at its own last
+ * pixel.
+ */
+export type MinimapLayout = {
+	/** Ruler pixels per content pixel. */
+	scale: number;
+	/** The whole map, which the track may not have room for. */
+	mapHeight: number;
+	/** How far the map is wound on under the lens; zero while it all fits. */
+	offset: number;
+	lensTop: number;
+	lensHeight: number;
+	/** Room the lens has to move, which the drag inverts. */
+	travel: number;
+	/** How far the diff can scroll: everything below the window it doesn't fill. */
+	scrollable: number;
 };
 
 /** How far the diff can scroll: everything below the window it doesn't fill. */
-const scrollableHeight = (viewer: CodeView<Annotation>): number =>
+export const getMinimapScrollable = (viewer: CodeView<Annotation>): number =>
 	Math.max(contentHeight(viewer) - viewer.getHeight(), 0);
 
-/** Scroll `progress` of the way through the range, 0 being the top and 1 the end. */
-export const scrollMinimapTo = (viewer: CodeView<Annotation>, progress: number): void => {
+export const getMinimapLayout = (
+	viewer: CodeView<Annotation>,
+	track: number,
+	/** Where the diff will be, for a caller that has just asked it to move and
+	 * cannot wait to be told: CodeView reports the old position for a frame yet. */
+	scrollTop: number = viewer.getScrollTop(),
+): MinimapLayout => {
+	const total = contentHeight(viewer);
+	const window = viewer.getHeight();
+	const scale = mapScale(total, track);
+	const mapHeight = total * scale;
+	const lensHeight = Math.min(Math.max(window * scale, LENS_MIN_HEIGHT), track);
+
+	const scrollable = getMinimapScrollable(viewer);
+	const progress = scrollable <= 0 ? 0 : Math.min(Math.max(scrollTop / scrollable, 0), 1);
+
+	// A map with room to spare keeps the lens over its own place on it; one
+	// taller than the track keeps the lens on the track and winds the map under.
+	const scrolls = mapHeight > track;
+	const travel = Math.max((scrolls ? track : mapHeight) - lensHeight, 0);
+	const lensTop = progress * travel;
+	const offset = scrolls
+		? Math.min(Math.max(scrollTop * scale - lensTop, 0), mapHeight - track)
+		: 0;
+
+	return { scale, mapHeight, offset, lensTop, lensHeight, travel, scrollable };
+};
+
+/** Scroll so the window's top sits at `position` in the content. */
+export const scrollMinimapTo = (viewer: CodeView<Annotation>, position: number): void => {
 	viewer.scrollTo({
 		type: "position",
 		// CodeView lifts a position target by the sticky header, so the row you
 		// asked for isn't left under it. The minimap is placing the viewport rather
 		// than a row, so add it back or every drag sits a header too high.
-		position: progress * scrollableHeight(viewer) + codeViewItemMetrics.diffHeaderHeight,
+		position: position + codeViewItemMetrics.diffHeaderHeight,
 		behavior: "instant",
 	});
 };


### PR DESCRIPTION
Follow-on from #15251, which fixed the minimap's zoom faults. This changes what
it draws.

The map was squeezed to fit the ruler, which says less the more there is to say:
a branch-sized diff came out as sub-pixel slivers under a lens too small to take
hold of. It is now drawn a pixel to the diff row and winds under the lens once it
outgrows the ruler, with rows averaged down past four ruler-fulls so it cannot
wind for ever. The ruler ends where its map does.

Where lines share a pixel, the row carries coverage per pixel rather than an
average width — solid as far as every line reaches, fading towards the longest.
A single width is a statistic standing in for a distribution, and max, min and
mean are each wrong in their own way.

Scrolling the diff draws the map along after it; pressing the ruler goes to the
code drawn there and leaves the map where it is; dragging moves the diff at the
map's own scale; and a wheel over the ruler winds the map alone. Showing the
ruler at all is now a setting under Appearance, defaulting to on, rather than a
guess at whether the diff is twice the window tall.
