### PR TITLE
Fix integration of empty checked-out branches

### DIFF
--- a/crates/but-api/src/workspace.rs
+++ b/crates/but-api/src/workspace.rs
@@ -408,11 +408,19 @@ fn review_integration_hints_from_reviews(
                     .iter()
                     .any(|sha| incoming_commit_ids.contains(sha))
         })
-        .filter_map(|review| gix::ObjectId::from_hex(review.sha.as_bytes()).ok())
-        .filter(|head_commit_at_merge| seen.insert(*head_commit_at_merge))
-        .map(|head_commit_at_merge| ReviewIntegrationHint {
-            head_commit_at_merge,
+        .filter_map(|review| {
+            Some((
+                gix::ObjectId::from_hex(review.sha.as_bytes()).ok()?,
+                review.source_branch,
+            ))
         })
+        .filter(|hint| seen.insert(hint.clone()))
+        .map(
+            |(head_commit_at_merge, source_branch)| ReviewIntegrationHint {
+                head_commit_at_merge,
+                source_branch,
+            },
+        )
         .collect()
 }
 
@@ -851,6 +859,10 @@ mod tests {
             hints[0].head_commit_at_merge.to_hex().to_string(),
             "1234567890abcdef1234567890abcdef12345678",
             "the hint should use the review head SHA reported by the forge"
+        );
+        assert_eq!(
+            hints[0].source_branch, "feature",
+            "the hint should retain the review's source-branch association"
         );
     }
 

--- a/crates/but-workspace/src/upstream_integration.rs
+++ b/crates/but-workspace/src/upstream_integration.rs
@@ -3,6 +3,7 @@
 use std::collections::{HashMap, HashSet};
 
 use anyhow::{Context, Result, bail};
+use bstr::ByteSlice;
 
 use but_core::{RefMetadata, branch::unique_canned_refname, ref_metadata::ProjectMeta};
 use but_graph::workspace::commit::is_managed_workspace_by_message;
@@ -38,13 +39,15 @@ pub struct BottomUpdate {
 
 /// A merged-review-derived integration anchor.
 ///
-/// The commit points to the review head that was merged upstream. When that
-/// commit is still present in a local stack, everything reachable beneath it is
-/// considered integrated for workspace upstream integration purposes.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+/// The commit points to the review head that was merged upstream. When that commit is still
+/// present in a local stack, everything reachable beneath it is considered integrated. The source
+/// branch associates the review with a reference-only empty stack.
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ReviewIntegrationHint {
     /// The merged review head commit that should act as an integration anchor.
     pub head_commit_at_merge: gix::ObjectId,
+    /// The forge source branch associated with the merged review.
+    pub source_branch: String,
 }
 
 /// The outcome of integrating upstream
@@ -205,6 +208,26 @@ pub fn integrate_upstream_with_hints<'ws, 'meta, M: RefMetadata>(
         .map(|update| Ok((update.selector.to_selector(&editor)?, update.kind)))
         .collect::<Result<Vec<_>, anyhow::Error>>()?;
 
+    // Empty projected branches are selected by reference rather than by commit. Include the
+    // checked-out reference in the collected graph only for that API shape, leaving ordinary
+    // non-empty direct checkouts on the existing commit-based path.
+    let direct_checkout_update_ref_selector =
+        direct_checkout_head_ref_name
+            .as_ref()
+            .and_then(|head_ref_name| {
+                updates
+                    .iter()
+                    .zip(&updates_with_selectors)
+                    .find_map(|(update, (selector, _))| match &update.selector {
+                        RelativeTo::Reference(ref_name)
+                            if ref_name.as_ref() == head_ref_name.as_ref() =>
+                        {
+                            Some(*selector)
+                        }
+                        _ => None,
+                    })
+            });
+
     let target_ref_selector = target_ref.ref_name.to_selector(&editor)?;
     let target_sha_selector = target_sha.to_selector(&editor)?;
     let target_ref_commit_selector = target_ref_commit.detach().to_selector(&editor)?;
@@ -216,6 +239,7 @@ pub fn integrate_upstream_with_hints<'ws, 'meta, M: RefMetadata>(
     let mut stacks = collect_stacks(
         head_commit,
         head_is_workspace_commit,
+        direct_checkout_update_ref_selector,
         &editor,
         from_target_sha,
         from_target_ref,
@@ -449,7 +473,31 @@ pub fn integrate_upstream_with_hints<'ws, 'meta, M: RefMetadata>(
                 // We could add back multiple, but it's likely unintentional
                 // that there were two parents in the first place.
                 if let Some(removed) = removed.iter().min() {
-                    editor.add_edge(child, target_ref_selector, *removed)?;
+                    let target_selector = match editor.lookup_step(child)? {
+                        Step::Reference { refname, .. }
+                            if !head_is_workspace_commit
+                                && direct_checkout_head_ref_name.as_ref().is_some_and(
+                                    |head_ref| head_ref.as_ref() == refname.as_ref(),
+                                ) =>
+                        {
+                            // A direct local ref cannot be parented through the target reference
+                            // node when both refs already participate in the same reachable graph.
+                            // Anchor it at the immutable target-tip pick instead.
+                            editor.disconnect_segment_from(
+                                SegmentDelimiter {
+                                    child,
+                                    parent: child,
+                                },
+                                SelectorSet::All,
+                                SelectorSet::All,
+                                false,
+                            )?;
+                            preserve_pick_parents(&mut editor, target_ref_commit_selector)?;
+                            target_ref_commit_selector
+                        }
+                        _ => target_ref_selector,
+                    };
+                    editor.add_edge(child, target_selector, *removed)?;
                 }
             }
         }
@@ -468,6 +516,7 @@ pub fn integrate_upstream_with_hints<'ws, 'meta, M: RefMetadata>(
 fn collect_stacks<'ws, 'meta, M: RefMetadata>(
     head_commit: gix::Commit<'_>,
     head_is_workspace_commit: bool,
+    direct_checkout_update_ref_selector: Option<Selector>,
     editor: &Editor<'ws, 'meta, M>,
     from_target_sha: HashSet<Selector>,
     from_target_ref: HashSet<Selector>,
@@ -488,7 +537,10 @@ fn collect_stacks<'ws, 'meta, M: RefMetadata>(
             })
             .collect()
     } else {
-        let c = editor.select_commit(head_commit.id)?;
+        let c = match direct_checkout_update_ref_selector {
+            Some(selector) => selector,
+            None => editor.select_commit(head_commit.id)?,
+        };
         vec![Stack {
             to_merge: false,
             nodes: HashMap::from([(c, AnnotatedNode::new())]),
@@ -561,13 +613,19 @@ fn collect_stacks<'ws, 'meta, M: RefMetadata>(
         }
 
         for (node, attrs) in nodes.iter_mut() {
-            if from_target_ref.contains(node) {
+            let step = editor.lookup_step(*node)?;
+            let is_local_reference = matches!(
+                &step,
+                Step::Reference { refname, .. }
+                    if refname.category() == Some(gix::refs::Category::LocalBranch)
+            );
+            if from_target_ref.contains(node)
+                && !(!head_is_workspace_commit && is_local_reference && stack.heads.contains(node))
+            {
                 attrs.historically_integrated = true;
             }
 
-            let node = editor.lookup_step(*node)?;
-
-            if let Step::Pick(Pick { id, .. }) = node
+            if let Step::Pick(Pick { id, .. }) = step
                 && integration.matches_by_workspace_commit.contains_key(&id)
             {
                 attrs.content_integrated = true;
@@ -648,6 +706,21 @@ fn collect_stacks<'ws, 'meta, M: RefMetadata>(
                 // the segment is integrated so local work ahead of its tracking
                 // branch is not discarded.
                 node.reference_integrated = all_integrated.then_some(r_name.clone());
+            } else if !head_is_workspace_commit
+                && stack.heads.contains(r_sel)
+                && r_name.category() == Some(gix::refs::Category::LocalBranch)
+            {
+                // A local ref pointing to target-reachable history is not by itself evidence that
+                // the branch was integrated. For an empty local segment, require branch-specific
+                // evidence from its configured remote-tracking ref or its associated merged
+                // review.
+                let review_integrated =
+                    configured_tracking_branch_short_name(editor.repo(), r_name.as_ref())
+                        .is_some_and(|pushed_branch| {
+                            review_hints_match_pushed_branch(review_hints, &pushed_branch)
+                        });
+                node.reference_integrated =
+                    (remote_tip_integrated || review_integrated).then_some(r_name.clone());
             } else {
                 node.reference_integrated =
                     (node.is_integrated() || remote_tip_integrated).then_some(r_name.clone());
@@ -656,6 +729,45 @@ fn collect_stacks<'ws, 'meta, M: RefMetadata>(
     }
 
     Ok(output_stacks)
+}
+
+/// Return the configured remote/pushed branch name without requiring its tracking ref to exist.
+/// Forge hosts commonly delete merged source branches, while the local branch configuration stays.
+fn configured_tracking_branch_short_name(
+    repo: &gix::Repository,
+    ref_name: &gix::refs::FullNameRef,
+) -> Option<String> {
+    let remote_ref_name = repo
+        .branch_remote_tracking_ref_name(ref_name, gix::remote::Direction::Fetch)
+        .transpose()
+        .ok()
+        .flatten()?;
+    let (_, short_name) = but_core::extract_remote_name_and_short_name(
+        remote_ref_name.as_ref(),
+        &repo.remote_names(),
+    )?;
+    short_name.to_str().ok().map(ToOwned::to_owned)
+}
+
+/// Match the forge's source branch against the branch that was actually pushed. A uniquely
+/// matching `owner:branch` fork head is accepted, while ambiguous fork heads remain conservative.
+fn review_hints_match_pushed_branch(
+    review_hints: &[ReviewIntegrationHint],
+    pushed_branch: &str,
+) -> bool {
+    if review_hints
+        .iter()
+        .any(|hint| hint.source_branch == pushed_branch)
+    {
+        return true;
+    }
+
+    let mut fork_matches = review_hints.iter().filter(|hint| {
+        hint.source_branch
+            .rsplit_once(':')
+            .is_some_and(|(_, branch)| branch == pushed_branch)
+    });
+    fork_matches.next().is_some() && fork_matches.next().is_none()
 }
 
 /// Return `true` if an empty local branch can be treated as integrated because

--- a/crates/but-workspace/src/upstream_integration.rs
+++ b/crates/but-workspace/src/upstream_integration.rs
@@ -525,6 +525,7 @@ fn collect_stacks<'ws, 'meta, M: RefMetadata>(
     target_ref_commit: gix::ObjectId,
     review_hints: &[ReviewIntegrationHint],
 ) -> Result<Vec<Stack>> {
+    let direct_checkout_head_commit_id = head_commit.id;
     let mut stacks = if head_is_workspace_commit {
         editor
             .direct_parents(head_commit.id)?
@@ -717,7 +718,11 @@ fn collect_stacks<'ws, 'meta, M: RefMetadata>(
                 let review_integrated =
                     configured_tracking_branch_short_name(editor.repo(), r_name.as_ref())
                         .is_some_and(|pushed_branch| {
-                            review_hints_match_pushed_branch(review_hints, &pushed_branch)
+                            review_hints_match_pushed_branch(
+                                review_hints,
+                                &pushed_branch,
+                                direct_checkout_head_commit_id,
+                            )
                         });
                 node.reference_integrated =
                     (remote_tip_integrated || review_integrated).then_some(r_name.clone());
@@ -749,23 +754,26 @@ fn configured_tracking_branch_short_name(
     short_name.to_str().ok().map(ToOwned::to_owned)
 }
 
-/// Match the forge's source branch against the branch that was actually pushed. A uniquely
+/// Match the forge's source branch and review head against the checked-out branch. A uniquely
 /// matching `owner:branch` fork head is accepted, while ambiguous fork heads remain conservative.
 fn review_hints_match_pushed_branch(
     review_hints: &[ReviewIntegrationHint],
     pushed_branch: &str,
+    branch_tip: gix::ObjectId,
 ) -> bool {
     if review_hints
         .iter()
-        .any(|hint| hint.source_branch == pushed_branch)
+        .any(|hint| hint.source_branch == pushed_branch && hint.head_commit_at_merge == branch_tip)
     {
         return true;
     }
 
     let mut fork_matches = review_hints.iter().filter(|hint| {
-        hint.source_branch
-            .rsplit_once(':')
-            .is_some_and(|(_, branch)| branch == pushed_branch)
+        hint.head_commit_at_merge == branch_tip
+            && hint
+                .source_branch
+                .rsplit_once(':')
+                .is_some_and(|(_, branch)| branch == pushed_branch)
     });
     fork_matches.next().is_some() && fork_matches.next().is_none()
 }

--- a/crates/but-workspace/tests/fixtures/scenario/empty-integrated-branch-direct-checkout.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/empty-integrated-branch-direct-checkout.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+# The checked-out topic branch has no commits outside the stored target. Its
+# tracking tip is reachable from the target, which is the evidence that the
+# otherwise-empty branch is integrated.
+git init
+commit-file base.txt base
+
+git checkout -b topic
+commit-file topic.txt topic
+setup_remote_tracking topic
+git config branch.topic.remote origin
+git config branch.topic.merge refs/heads/topic
+
+git checkout main
+git merge --no-ff -m "merge topic" topic
+setup_target_to_match_main
+
+git checkout -b advanced-target
+git commit --allow-empty -m "upstream commit"
+git update-ref refs/remotes/origin/main advanced-target
+
+git checkout topic
+git branch -D advanced-target

--- a/crates/but-workspace/tests/workspace/upstream_integration.rs
+++ b/crates/but-workspace/tests/workspace/upstream_integration.rs
@@ -1478,6 +1478,66 @@ fn empty_direct_checkout_with_merged_review_for_pushed_branch_is_replaced() -> R
 }
 
 #[test]
+fn empty_direct_checkout_ignores_same_named_review_for_different_head() -> Result<()> {
+    let (_tmp, mut repo, mut meta, _description) =
+        named_writable_scenario_with_description("empty-integrated-branch-direct-checkout")?;
+    remove_managed_workspace_ref(&repo)?;
+    repo.config_snapshot_mut()
+        .set_raw_value("branch.topic.merge", "refs/heads/pushed-topic")?;
+    git(&repo)
+        .args(["update-ref", "-d", "refs/remotes/origin/topic"])
+        .run();
+    let target_sha = repo.rev_parse_single("main")?.detach();
+    let target_tip = repo.rev_parse_single("origin/main")?.detach();
+    let topic_tip = repo.rev_parse_single("topic")?.detach();
+    assert_ne!(
+        topic_tip, target_tip,
+        "the colliding review head must differ from the checked-out branch tip"
+    );
+
+    let project_meta = target_project_meta("refs/remotes/origin/main", target_sha)?;
+    let graph = but_graph::Graph::from_head(
+        &repo,
+        &meta,
+        project_meta.clone(),
+        Options {
+            extra_target_commit_id: Some(target_sha),
+            ..Options::limited()
+        },
+    )?;
+    let mut workspace = graph.into_workspace()?;
+    let project_meta = workspace.graph.project_meta.clone();
+    let out = integrate_upstream_with_hints(
+        &mut workspace,
+        &mut meta,
+        project_meta,
+        &repo,
+        vec![BottomUpdate {
+            kind: BottomUpdateKind::Rebase,
+            selector: RelativeTo::Reference(gix::refs::FullName::try_from("refs/heads/topic")?),
+        }],
+        &[ReviewIntegrationHint {
+            head_commit_at_merge: target_tip,
+            source_branch: "pushed-topic".into(),
+        }],
+    )?;
+    out.rebase.materialize(Default::default())?;
+
+    assert_eq!(
+        repo.find_reference("topic")?.id(),
+        target_tip,
+        "a same-named review for another head must not delete the local branch"
+    );
+    assert_eq!(
+        repo.head_name()?,
+        Some(gix::refs::FullName::try_from("refs/heads/topic")?),
+        "the preserved branch should remain checked out"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn fully_integrated_direct_checkout_creates_canned_branch_at_merge_target_tip() -> Result<()> {
     let (_tmp, mut repo, mut meta, _description) = named_writable_scenario_with_description(
         "fully-integrated-single-branch-target-advanced-through-merge",

--- a/crates/but-workspace/tests/workspace/upstream_integration.rs
+++ b/crates/but-workspace/tests/workspace/upstream_integration.rs
@@ -1300,6 +1300,184 @@ fn fully_integrated_direct_checkout_creates_unique_canned_branch_at_target_tip()
 }
 
 #[test]
+fn empty_integrated_direct_checkout_is_replaced() -> Result<()> {
+    let (_tmp, mut repo, mut meta, _description) =
+        named_writable_scenario_with_description("empty-integrated-branch-direct-checkout")?;
+    force_prefixless_canned_branch_name(&mut repo)?;
+    remove_managed_workspace_ref(&repo)?;
+    let target_sha = repo.rev_parse_single("main")?.detach();
+    let target_tip = repo.rev_parse_single("origin/main")?.detach();
+    let topic_tip = repo.rev_parse_single("topic")?.detach();
+    let remote_topic_tip = repo.rev_parse_single("origin/topic")?.detach();
+
+    assert_eq!(
+        topic_tip, remote_topic_tip,
+        "the empty local branch should be classified through its tracking tip"
+    );
+    assert_eq!(
+        repo.merge_base(remote_topic_tip, target_tip)?.detach(),
+        remote_topic_tip,
+        "the tracking tip should be reachable from the target"
+    );
+
+    let project_meta = target_project_meta("refs/remotes/origin/main", target_sha)?;
+    let graph = but_graph::Graph::from_head(
+        &repo,
+        &meta,
+        project_meta.clone(),
+        Options {
+            extra_target_commit_id: Some(target_sha),
+            ..Options::limited()
+        },
+    )?;
+    let mut workspace = graph.into_workspace()?;
+    assert!(
+        workspace
+            .stacks
+            .first()
+            .and_then(|stack| stack.segments.first())
+            .is_some_and(|segment| segment.commits.is_empty()),
+        "the checked-out branch should be empty in the workspace projection"
+    );
+
+    let project_meta = workspace.graph.project_meta.clone();
+    let but_workspace::IntegrateUpstreamOutcome { rebase, .. } = integrate_upstream(
+        &mut workspace,
+        &mut meta,
+        project_meta,
+        &repo,
+        vec![BottomUpdate {
+            kind: BottomUpdateKind::Rebase,
+            selector: RelativeTo::Reference(gix::refs::FullName::try_from("refs/heads/topic")?),
+        }],
+    )?;
+    rebase.materialize(Default::default())?;
+
+    assert!(
+        repo.try_find_reference("topic")?.is_none(),
+        "an empty checked-out branch should be removed when its tracking tip is integrated"
+    );
+    assert_eq!(
+        repo.head_id()?.detach(),
+        target_tip,
+        "replacement checkout should land at the latest target tip"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn local_only_empty_direct_checkout_is_preserved() -> Result<()> {
+    let (_tmp, mut repo, mut meta, _description) =
+        named_writable_scenario_with_description("empty-integrated-branch-direct-checkout")?;
+    remove_managed_workspace_ref(&repo)?;
+    repo.config_snapshot_mut()
+        .set_raw_value("branch.topic.merge", "refs/heads/pushed-topic")?;
+    git(&repo)
+        .args(["update-ref", "-d", "refs/remotes/origin/topic"])
+        .run();
+    let target_sha = repo.rev_parse_single("main")?.detach();
+    let target_tip = repo.rev_parse_single("origin/main")?.detach();
+
+    let project_meta = target_project_meta("refs/remotes/origin/main", target_sha)?;
+    let graph = but_graph::Graph::from_head(
+        &repo,
+        &meta,
+        project_meta.clone(),
+        Options {
+            extra_target_commit_id: Some(target_sha),
+            ..Options::limited()
+        },
+    )?;
+    let mut workspace = graph.into_workspace()?;
+    let project_meta = workspace.graph.project_meta.clone();
+    let but_workspace::IntegrateUpstreamOutcome { rebase, .. } = integrate_upstream_with_hints(
+        &mut workspace,
+        &mut meta,
+        project_meta,
+        &repo,
+        vec![BottomUpdate {
+            kind: BottomUpdateKind::Rebase,
+            selector: RelativeTo::Reference(gix::refs::FullName::try_from("refs/heads/topic")?),
+        }],
+        &[ReviewIntegrationHint {
+            head_commit_at_merge: repo.rev_parse_single("topic")?.detach(),
+            source_branch: "topic".into(),
+        }],
+    )?;
+    rebase.materialize(Default::default())?;
+
+    assert_eq!(
+        repo.find_reference("topic")?.id(),
+        target_tip,
+        "an empty local-only branch should ignore a review matching only its local name"
+    );
+    assert_eq!(
+        repo.head_name()?,
+        Some(gix::refs::FullName::try_from("refs/heads/topic")?),
+        "the preserved local-only branch should remain checked out"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn empty_direct_checkout_with_merged_review_for_pushed_branch_is_replaced() -> Result<()> {
+    let (_tmp, mut repo, mut meta, _description) =
+        named_writable_scenario_with_description("empty-integrated-branch-direct-checkout")?;
+    force_prefixless_canned_branch_name(&mut repo)?;
+    remove_managed_workspace_ref(&repo)?;
+    repo.config_snapshot_mut()
+        .set_raw_value("branch.topic.merge", "refs/heads/pushed-topic")?;
+    git(&repo)
+        .args(["update-ref", "-d", "refs/remotes/origin/topic"])
+        .run();
+    let target_sha = repo.rev_parse_single("main")?.detach();
+    let target_tip = repo.rev_parse_single("origin/main")?.detach();
+    let review_head = repo.rev_parse_single("topic")?.detach();
+
+    let project_meta = target_project_meta("refs/remotes/origin/main", target_sha)?;
+    let graph = but_graph::Graph::from_head(
+        &repo,
+        &meta,
+        project_meta.clone(),
+        Options {
+            extra_target_commit_id: Some(target_sha),
+            ..Options::limited()
+        },
+    )?;
+    let mut workspace = graph.into_workspace()?;
+    let project_meta = workspace.graph.project_meta.clone();
+    let out = integrate_upstream_with_hints(
+        &mut workspace,
+        &mut meta,
+        project_meta,
+        &repo,
+        vec![BottomUpdate {
+            kind: BottomUpdateKind::Rebase,
+            selector: RelativeTo::Reference(gix::refs::FullName::try_from("refs/heads/topic")?),
+        }],
+        &[ReviewIntegrationHint {
+            head_commit_at_merge: review_head,
+            source_branch: "pushed-topic".into(),
+        }],
+    )?;
+    out.rebase.materialize(Default::default())?;
+
+    assert!(
+        repo.try_find_reference("topic")?.is_none(),
+        "an empty checked-out branch should be removed when its associated review is merged"
+    );
+    assert_eq!(
+        repo.head_id()?.detach(),
+        target_tip,
+        "replacement checkout should land at the latest target tip"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn fully_integrated_direct_checkout_creates_canned_branch_at_merge_target_tip() -> Result<()> {
     let (_tmp, mut repo, mut meta, _description) = named_writable_scenario_with_description(
         "fully-integrated-single-branch-target-advanced-through-merge",
@@ -2539,6 +2717,7 @@ fn review_hint_fully_integrates_direct_checkout_branch() -> Result<()> {
         }],
         &[ReviewIntegrationHint {
             head_commit_at_merge: review_head,
+            source_branch: "A".into(),
         }],
     )?;
     out.rebase.materialize(Default::default())?;
@@ -2623,6 +2802,7 @@ fn review_hint_integrates_squashed_two_commit_stack_in_managed_workspace() -> Re
         }],
         &[ReviewIntegrationHint {
             head_commit_at_merge: review_head,
+            source_branch: "A".into(),
         }],
     )?;
     out.rebase.materialize(Default::default())?;
@@ -2730,6 +2910,7 @@ fn review_hint_integrates_squashed_two_commit_direct_checkout_branch() -> Result
         }],
         &[ReviewIntegrationHint {
             head_commit_at_merge: review_head,
+            source_branch: "A".into(),
         }],
     )?;
     out.rebase.materialize(Default::default())?;
@@ -2826,6 +3007,7 @@ fn review_hint_integrates_squashed_prefix_and_keeps_extra_commit_in_managed_work
         }],
         &[ReviewIntegrationHint {
             head_commit_at_merge: review_head,
+            source_branch: "A".into(),
         }],
     )?;
 
@@ -2926,6 +3108,7 @@ fn review_hint_integrates_squashed_prefix_and_keeps_extra_commit_in_direct_check
         }],
         &[ReviewIntegrationHint {
             head_commit_at_merge: review_head,
+            source_branch: "A".into(),
         }],
     )?;
     rebase.materialize(Default::default())?;
@@ -3016,6 +3199,7 @@ fn review_hint_integrates_prefix_but_keeps_extra_local_commit() -> Result<()> {
         }],
         &[ReviewIntegrationHint {
             head_commit_at_merge: review_head,
+            source_branch: "A".into(),
         }],
     )?;
     out.rebase.materialize(Default::default())?;

--- a/e2e/playwright/scripts/project-in-single-branch-upstream-integration.sh
+++ b/e2e/playwright/scripts/project-in-single-branch-upstream-integration.sh
@@ -53,6 +53,23 @@ case "$scenario" in
     ;;
   rebase)
     ;;
+  empty-integrated)
+    git checkout -b empty-integrated-branch
+    echo "empty integrated branch" > empty_integrated_branch.txt
+    git add empty_integrated_branch.txt
+    git commit -m "empty-integrated: branch commit"
+    git checkout master
+    git merge --no-ff -m "empty-integrated: merge branch" empty-integrated-branch
+    ;;
+  local-only-empty)
+    git checkout -b local-only-empty-source
+    echo "local only empty branch" > local_only_empty_branch.txt
+    git add local_only_empty_branch.txt
+    git commit -m "local-only-empty: branch commit"
+    git checkout master
+    git merge --no-ff -m "local-only-empty: merge branch" local-only-empty-source
+    git branch -D local-only-empty-source
+    ;;
   *)
     echo "Unknown scenario: $scenario" >&2
     exit 1
@@ -94,6 +111,15 @@ case "$scenario" in
   rebase)
     "$BUT" apply rebased-single-branch
     git checkout rebased-single-branch
+    ;;
+  empty-integrated)
+    "$BUT" apply empty-integrated-branch
+    git checkout empty-integrated-branch
+    ;;
+  local-only-empty)
+    git branch local-only-empty-branch master^2
+    "$BUT" apply local-only-empty-branch
+    git checkout local-only-empty-branch
     ;;
 esac
 popd

--- a/e2e/playwright/tests/singleBranch/upstreamIntegration.spec.ts
+++ b/e2e/playwright/tests/singleBranch/upstreamIntegration.spec.ts
@@ -13,6 +13,8 @@ import { expect, type Page } from "@playwright/test";
 import { execFileSync } from "node:child_process";
 
 const FULLY_INTEGRATED_BRANCH = "fully-integrated-branch";
+const EMPTY_INTEGRATED_BRANCH = "empty-integrated-branch";
+const LOCAL_ONLY_EMPTY_BRANCH = "local-only-empty-branch";
 const PARTIAL_STACK_BASE = "partial-stack-base";
 const PARTIAL_STACK_TOP = "partial-stack-top";
 const REBASED_SINGLE_BRANCH = "rebased-single-branch";
@@ -69,6 +71,15 @@ async function expectLocalBranchNotToExist(pathToRepo: string, branchName: strin
 			intervals: [100, 200, 500, 1000],
 		})
 		.toBe(false);
+}
+
+async function expectBranchTipToBeOriginMaster(pathToRepo: string, branchName: string) {
+	await expect
+		.poll(() => git(pathToRepo, ["rev-parse", branchName]), {
+			message: `Expected ${branchName} to point to origin/master`,
+			intervals: [100, 200, 500, 1000],
+		})
+		.toBe(git(pathToRepo, ["rev-parse", TARGET_REMOTE_BRANCH]));
 }
 
 async function replacementBranchAtTarget(pathToRepo: string): Promise<string> {
@@ -140,6 +151,55 @@ test("creates a new branch on top of the advanced target after branch is fully i
 	expect(git(localClone, ["rev-parse", replacementBranch])).toBe(
 		git(localClone, ["rev-parse", TARGET_REMOTE_BRANCH]),
 	);
+	await assertCleanWorktree(localClone);
+	await expectNoErrorToast(page);
+});
+
+test("replaces an empty checked-out branch when its tracking tip is integrated", async ({
+	page,
+	gitbutler,
+}) => {
+	await gitbutler.runScript("project-in-single-branch-upstream-integration.sh", [
+		"empty-integrated",
+	]);
+	await openSingleBranchWorkspace(page);
+
+	const localClone = gitbutler.pathInWorkdir("local-clone");
+	await assertBranch(EMPTY_INTEGRATED_BRANCH, localClone);
+	await expectCurrentBranchChip(page, EMPTY_INTEGRATED_BRANCH);
+	await expect(commitRow(page, "empty-integrated: branch commit")).toHaveCount(0);
+
+	await gitbutler.runScript("project-with-remote-branches__add-commit-to-base.sh");
+	await syncAndIntegrateWorkspace(page);
+
+	await expectLocalBranchNotToExist(localClone, EMPTY_INTEGRATED_BRANCH);
+	const replacementBranch = await replacementBranchAtTarget(localClone);
+	await expectCurrentBranchChip(page, replacementBranch);
+	await expectBranchTipToBeOriginMaster(localClone, replacementBranch);
+	await assertCleanWorktree(localClone);
+	await expectNoErrorToast(page);
+});
+
+test("preserves an empty local-only checked-out branch while advancing it", async ({
+	page,
+	gitbutler,
+}) => {
+	await gitbutler.runScript("project-in-single-branch-upstream-integration.sh", [
+		"local-only-empty",
+	]);
+	await openSingleBranchWorkspace(page);
+
+	const localClone = gitbutler.pathInWorkdir("local-clone");
+	await assertBranch(LOCAL_ONLY_EMPTY_BRANCH, localClone);
+	await expectCurrentBranchChip(page, LOCAL_ONLY_EMPTY_BRANCH);
+	await expect(commitRow(page, "local-only-empty: branch commit")).toHaveCount(0);
+
+	await gitbutler.runScript("project-with-remote-branches__add-commit-to-base.sh");
+	await syncAndIntegrateWorkspace(page);
+
+	await assertBranch(LOCAL_ONLY_EMPTY_BRANCH, localClone);
+	await expectCurrentBranchChip(page, LOCAL_ONLY_EMPTY_BRANCH);
+	await expectBranchTipToBeOriginMaster(localClone, LOCAL_ONLY_EMPTY_BRANCH);
 	await assertCleanWorktree(localClone);
 	await expectNoErrorToast(page);
 });


### PR DESCRIPTION
## Summary

Fix upstream integration for directly checked-out branches whose commits are already contained in the target, leaving an empty projected branch.

- select the checked-out reference when the projected branch has no commits
- remove empty branches only when their remote tracking tip is integrated or a merged review matches the configured pushed branch
- preserve and advance empty local-only branches
- keep missing/deleted remote tracking refs conservative
- add focused Rust and Playwright regression coverage

## Root cause

Direct checkout integration selected stacks by commit. Once all branch commits were already reachable from the target, the workspace projection contained only the branch reference, so the requested branch could not be selected and integrated correctly.

Review-derived evidence also needed to retain the forge source branch so an empty branch is associated with the branch that was actually pushed, rather than relying on its local name.

## Scope

This intentionally does not change merge-commit projection or broaden selector handling beyond the directly checked-out empty-reference case.
