### PR TITLE
Derive watcher invalidations from the query-key union

### DIFF
--- a/apps/lite/ui/src/api/queries.ts
+++ b/apps/lite/ui/src/api/queries.ts
@@ -5,7 +5,11 @@ import type { ForgeReview } from "@gitbutler/but-sdk";
 import { queryOptions, type QueryClient } from "@tanstack/react-query";
 import * as ms from "ms";
 
-export type QueryKey =
+/**
+ * Keyed `[key, projectId, ...]`. The fixed position is what lets `handleWatcher`
+ * invalidate a whole query root holding nothing but a project id.
+ */
+export type ProjectQueryKey =
 	| "branchDetails"
 	| "branchDiff"
 	| "branchList"
@@ -26,20 +30,25 @@ export type QueryKey =
 	| "reviewMergeStatus"
 	| "reviewerCandidates"
 	| "reviews"
-	| "editors"
-	| "terminals"
-	| "forgeAccounts"
-	| "userProfile"
 	| "gbConfig"
-	| "projects"
 	| "signingSettings"
 	| "treeChangeDiffs"
 	| "absorptionPlan"
 	| "dryRun"
-	| "guiSettings"
 	| "workspaceFetch"
 	| "workspaceFetchStatus"
 	| "workspaceTargetCommits";
+
+/** Keyed without a project id, so no project event can invalidate them. */
+type GlobalQueryKey =
+	| "editors"
+	| "terminals"
+	| "forgeAccounts"
+	| "userProfile"
+	| "projects"
+	| "guiSettings";
+
+export type QueryKey = ProjectQueryKey | GlobalQueryKey;
 
 export const branchDetailsQueryOptions = ({ projectId, ...params }: PayloadFor<"branchDetails">) =>
 	queryOptions({

--- a/apps/lite/ui/src/watcher.ts
+++ b/apps/lite/ui/src/watcher.ts
@@ -1,73 +1,86 @@
-import { refreshIntegratedReviews, type QueryKey } from "#ui/api/queries.ts";
+import { refreshIntegratedReviews, type ProjectQueryKey } from "#ui/api/queries.ts";
 import type { WatcherEvent } from "@gitbutler/but-sdk";
 import type { QueryClient } from "@tanstack/react-query";
+
+type WatcherEventType = WatcherEvent["payload"]["type"];
+
+/**
+ * A `Record`, not a `Partial`: a new project query has to declare what refreshes
+ * it, or this stops compiling.
+ */
+const refreshedBy: Record<ProjectQueryKey, ReadonlyArray<WatcherEventType>> = {
+	absorptionPlan: ["gitActivity", "workspaceActivity", "worktreeChanges"],
+	// A fetch changes no local commit, but it moves remote-tracking refs.
+	branchDetails: ["gitFetch", "gitActivity", "workspaceActivity"],
+	branchDiff: ["gitFetch", "gitActivity", "workspaceActivity"],
+	branchList: ["gitFetch", "gitActivity", "workspaceActivity"],
+	// Pushed below rather than invalidated: `worktreeChanges` carries the data.
+	changesInWorktree: ["gitActivity", "workspaceActivity"],
+	ciChecks: [],
+	commentReactions: [],
+	comments: ["gitActivity", "workspaceActivity", "worktreeChanges"],
+	commitDetailsWithLineStats: ["gitActivity", "workspaceActivity"],
+	currentForgeLogin: [],
+	dryRun: ["gitActivity", "workspaceActivity", "worktreeChanges"],
+	forgeInfo: [],
+	gbConfig: [],
+	headInfo: ["gitActivity", "workspaceActivity"],
+	repoLabels: [],
+	review: ["gitFetch"],
+	reviewComments: [],
+	reviewMergeStatus: [],
+	reviewReactions: [],
+	reviewSubmissions: [],
+	reviewTimelineEvents: [],
+	reviewerCandidates: [],
+	reviews: ["gitFetch"],
+	signingSettings: [],
+	treeChangeDiffs: ["gitActivity", "workspaceActivity", "worktreeChanges"],
+	workspaceFetch: [],
+	workspaceFetchStatus: ["gitFetch"],
+	// `gitFetch` refreshes this too, but only once reviews land — see below.
+	workspaceTargetCommits: ["gitActivity", "workspaceActivity"],
+};
+
+/** Inverted once, so an event costs a lookup rather than a walk of every query. */
+const staleAfter = new Map<WatcherEventType, Array<ProjectQueryKey>>();
+for (const [key, events] of Object.entries(refreshedBy) as Array<
+	[ProjectQueryKey, ReadonlyArray<WatcherEventType>]
+>) {
+	for (const event of events) {
+		const keys = staleAfter.get(event);
+		if (keys) keys.push(key);
+		else staleAfter.set(event, [key]);
+	}
+}
 
 export const handleWatcher = (
 	event: WatcherEvent,
 	projectId: string,
 	client: QueryClient,
 ): void => {
-	switch (event.payload.type) {
-		case "gitFetch":
-			void client.invalidateQueries({
-				queryKey: ["workspaceFetchStatus" satisfies QueryKey, projectId],
-			});
-			void client.invalidateQueries({ queryKey: ["reviews" satisfies QueryKey, projectId] });
-			void client.invalidateQueries({ queryKey: ["review" satisfies QueryKey, projectId] });
-			// A fetch moves remote-tracking refs, so the branch listing goes stale,
-			// and it can advance a remote branch whose commits or diff are already
-			// cached (unfolded or selected in the Branches tab). This case does not
-			// fall through to the gitActivity invalidations below.
-			void client.invalidateQueries({ queryKey: ["branchList" satisfies QueryKey, projectId] });
-			void client.invalidateQueries({ queryKey: ["branchDetails" satisfies QueryKey, projectId] });
-			void client.invalidateQueries({ queryKey: ["branchDiff" satisfies QueryKey, projectId] });
-			// The target-commit annotations read the backend's review cache, so
-			// refresh newly integrated reviews first and re-read the listing once
-			// they land. The refresh failing (offline, rate-limited) degrades to
-			// unannotated commits and is retried on the next fetch.
-			void refreshIntegratedReviews(client, projectId)
-				.catch(() => undefined)
-				.finally(() => {
-					void client.invalidateQueries({
-						queryKey: ["workspaceTargetCommits" satisfies QueryKey, projectId],
-					});
+	const { payload } = event;
+
+	if (payload.type === "worktreeChanges") {
+		client.setQueryData(
+			["changesInWorktree" satisfies ProjectQueryKey, projectId],
+			() => payload.subject.changes,
+		);
+	}
+
+	for (const key of staleAfter.get(payload.type) ?? [])
+		void client.invalidateQueries({ queryKey: [key, projectId] });
+
+	// The annotations read the backend's review cache, so integrated reviews have
+	// to land before the listing is re-read. A failed refresh degrades to
+	// unannotated commits until the next fetch.
+	if (payload.type === "gitFetch") {
+		void refreshIntegratedReviews(client, projectId)
+			.catch(() => undefined)
+			.finally(() => {
+				void client.invalidateQueries({
+					queryKey: ["workspaceTargetCommits" satisfies ProjectQueryKey, projectId],
 				});
-			break;
-		case "gitActivity":
-		case "workspaceActivity": {
-			void client.invalidateQueries({ queryKey: ["absorptionPlan" satisfies QueryKey, projectId] });
-			void client.invalidateQueries({ queryKey: ["branchDetails" satisfies QueryKey, projectId] });
-			void client.invalidateQueries({ queryKey: ["branchList" satisfies QueryKey, projectId] });
-			void client.invalidateQueries({ queryKey: ["branchDiff" satisfies QueryKey, projectId] });
-			void client.invalidateQueries({
-				queryKey: ["changesInWorktree" satisfies QueryKey, projectId],
 			});
-			void client.invalidateQueries({ queryKey: ["comments" satisfies QueryKey, projectId] });
-			void client.invalidateQueries({
-				queryKey: ["commitDetailsWithLineStats" satisfies QueryKey, projectId],
-			});
-			void client.invalidateQueries({ queryKey: ["dryRun" satisfies QueryKey, projectId] });
-			void client.invalidateQueries({ queryKey: ["headInfo" satisfies QueryKey, projectId] });
-			void client.invalidateQueries({
-				queryKey: ["treeChangeDiffs" satisfies QueryKey, projectId],
-			});
-			void client.invalidateQueries({
-				queryKey: ["workspaceTargetCommits" satisfies QueryKey, projectId],
-			});
-			break;
-		}
-		case "worktreeChanges":
-			const workspaceChanges = event.payload.subject.changes;
-			client.setQueryData(
-				["changesInWorktree" satisfies QueryKey, projectId],
-				() => workspaceChanges,
-			);
-			void client.invalidateQueries({ queryKey: ["absorptionPlan" satisfies QueryKey, projectId] });
-			void client.invalidateQueries({ queryKey: ["comments" satisfies QueryKey, projectId] });
-			void client.invalidateQueries({ queryKey: ["dryRun" satisfies QueryKey, projectId] });
-			void client.invalidateQueries({
-				queryKey: ["treeChangeDiffs" satisfies QueryKey, projectId],
-			});
-			break;
 	}
 };


### PR DESCRIPTION
## The problem

`handleWatcher` restated its invalidation lists per event type by hand. A new
query key that nobody remembered to add there silently never refreshed, and
nothing caught it — the queries use `staleTime: Infinity`, so the stale data
stays until the route remounts.

## The change

Invert the lists: instead of each event naming the queries it refreshes, each
query declares the events that make it stale, in a `Record` exhaustive over the
project query keys. Forget to classify a new query and it stops compiling.

That only works if `[key, projectId]` is a fact rather than an assumption, so
`QueryKey` splits into `ProjectQueryKey | GlobalQueryKey`. Six keys carry no
project id (`terminals`, `userProfile`, `forgeAccounts`, `projects`, `editors`,
`guiSettings`); classifying one of those by mistake would build a key that
matches nothing — the same silent failure, moved. Now it is a type error.

Authoring shape and runtime shape then come apart. The table is key-major
because that is the direction the compiler can check for completeness, while
dispatch wants the opposite, so it is inverted once at module load into a
`Map<WatcherEventType, ProjectQueryKey[]>`. An event costs one lookup and
touches only the queries that went stale, rather than a walk of all 29 rows.

Two behaviours stay explicit code rather than table rows, both commented at the
corresponding entry: `worktreeChanges` pushes the changes it already carries
instead of invalidating, and `gitFetch` re-reads target commits only once
integrated reviews have landed.

## Verification

No behaviour change, checked mechanically rather than by eye: a temporary
harness ran the previous implementation and this one side by side against a
recording `QueryClient` for all five event types and asserted identical
invalidations and pushes. The compile gate was confirmed by probe — an
unclassified key, an unknown key, and a misspelled event name each fail
typecheck.

One gap left open on purpose: a *new watcher event type* added to the SDK still
compiles and refreshes nothing. Closing that needs an exhaustive switch on the
event side, which re-introduces the switch this removes — worth doing only if
events start changing often.
