### PR TITLE
Add root `--skill` flag printing the bundled skill text

### DIFF
--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -44,6 +44,9 @@ pub struct Args {
     /// Use when the next step needs IDs or details from the resulting workspace.
     #[clap(long, global = true)]
     pub status_after: bool,
+    /// Print the bundled agent skill text (SKILL.md) to stdout and exit.
+    #[clap(long)]
+    pub skill: bool,
     /// Subcommand to run (`but <COMMAND>`).
     ///
     /// On UNIX, if `<COMMAND>` is not built in and `but-<COMMAND>` exists on the PATH, that program
@@ -905,6 +908,12 @@ pub enum Subcommands {
     ///
     /// ```text
     /// but skill install --global
+    /// ```
+    ///
+    /// Print the base skill text (SKILL.md) to stdout:
+    ///
+    /// ```text
+    /// but --skill
     /// ```
     #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Skill(skill::Platform),

--- a/crates/but/src/command/skill/mod.rs
+++ b/crates/but/src/command/skill/mod.rs
@@ -977,6 +977,12 @@ fn prepare_skill_content(version: &str) -> Result<String> {
     Ok(inject_version(skill_content, version))
 }
 
+/// The bundled base skill text (SKILL.md) with the CLI version injected,
+/// as printed by `but --skill`.
+pub fn base_skill_text() -> Result<String> {
+    prepare_skill_content(option_env!("VERSION").unwrap_or("dev"))
+}
+
 /// Write the bundled skill files into `install_path`, creating the directory
 /// structure as needed and injecting the CLI version into SKILL.md. Returns the
 /// version that was written.

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -289,6 +289,13 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
     }
 
     let (mut args, output_format) = parse_args_and_output_format(args, agent_detected);
+
+    // Like `--version`, `--skill` prints and exits without dispatching a subcommand.
+    if args.skill {
+        print!("{}", command::skill::base_skill_text()?);
+        return Ok(());
+    }
+
     let _tracing_appender_worker_guard = if args.trace > 0 {
         trace::init(args.trace, args.log_file.as_deref())?
     } else {

--- a/crates/but/tests/but/command/skill.rs
+++ b/crates/but/tests/but/command/skill.rs
@@ -15,6 +15,45 @@ fn path_ends_with_gitbutler_agents_dir(path: &str) -> bool {
 }
 
 #[test]
+fn skill_flag_prints_base_skill_text_to_stdout() {
+    let env = Sandbox::empty();
+
+    let version_stdout = env
+        .but("--version")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let version = std::str::from_utf8(&version_stdout)
+        .unwrap()
+        .trim()
+        .strip_prefix("but ")
+        .expect("`but --version` output starts with the binary name")
+        .to_string();
+
+    let stdout = env
+        .but("--skill")
+        .assert()
+        .success()
+        .stderr_eq(str![[]])
+        .get_output()
+        .stdout
+        .clone();
+
+    let expected = include_str!("../../../skill/SKILL.md").replacen(
+        "version: 0.0.0",
+        &format!("version: {version}"),
+        1,
+    );
+    assert_eq!(
+        std::str::from_utf8(&stdout).unwrap(),
+        expected,
+        "`but --skill` prints the bundled SKILL.md with the CLI version injected"
+    );
+}
+
+#[test]
 fn skill_check_local_outside_repo_fails() {
     let env = Sandbox::empty();
 


### PR DESCRIPTION
`but --skill` writes the bundled base skill text (`SKILL.md`) to stdout and exits, so agents can load the GitButler skill into context directly (e.g. `but --skill >> prompt.md`) without installing skill files first.

## What changed

- New root-only `--skill` flag on `Args`. It short-circuits right after argument parsing, like `--version`: `but --skill` prints the skill even if a subcommand follows, and `but status --skill` is rejected since the flag is not global.
- The output reuses the installer's `prepare_skill_content` path via a new `command::skill::base_skill_text()`, so the CLI version is injected into the frontmatter exactly as `but skill install` writes it, and the embedded file is UTF-8 validated.
- Output is raw stdout — no pager, truncation, or output-channel formatting — so it pipes cleanly.
- `but skill --help` long help now cross-references `but --skill` for discoverability.

## Decisions

- Only `SKILL.md` is printed, not the `references/` files; the flag targets bootstrap/context-loading, where the base skill is the entry point.
- The bundled skill docs themselves don't mention the flag: an agent that already has the skill installed has no use for printing it.

## Testing

Integration test asserts `but --skill` output equals the embedded `SKILL.md` with the version swapped in, deriving the expected version from `but --version` so it holds for both `dev` and release builds.