### PR TITLE
Finish the minimap: coverage, motion and a setting

### DIFF
--- a/apps/lite/electron/src/settings.ts
+++ b/apps/lite/electron/src/settings.ts
@@ -25,6 +25,7 @@ const guiSettingsV1 = type({
 	"editorId?": "string",
 	"fileDisplayMode?": "'list' | 'tree'",
 	"lineDiffType?": "'word-alt' | 'word' | 'char' | 'none'",
+	"minimap?": "boolean",
 	"pathFirst?": "boolean",
 	"terminalId?": "string",
 	"syntaxHighlighting?": {

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -1059,6 +1059,7 @@ const Diff: FC<{
 			diffOverflow: cfg.diffOverflow,
 			diffStyle: cfg.diffStyle,
 			diffTabSize: cfg.diffTabSize,
+			minimap: cfg.minimap,
 		}),
 	});
 
@@ -1087,18 +1088,32 @@ const Diff: FC<{
 		? -1
 		: changes.findIndex((change) => change.path === activeFilePath);
 
+	const minimapShown = diffSettings?.minimap ?? defaultSettings.minimap;
+	// Modelling the map reads every line of the diff, so a ruler nobody asked for
+	// shouldn't be parsed for either.
 	const minimapFiles = useMemo(
 		() =>
-			getMinimapFiles({
-				fileParent,
-				changes: shownIndex < 0 ? changes : changes.slice(shownIndex, shownIndex + 1),
-				treeChangeDiffs:
-					shownIndex < 0 ? treeChangeDiffs : treeChangeDiffs.slice(shownIndex, shownIndex + 1),
-				diffStyle,
-				tabSize,
-				wrapColumns,
-			}),
-		[shownIndex, fileParent, changes, treeChangeDiffs, diffStyle, tabSize, wrapColumns],
+			minimapShown
+				? getMinimapFiles({
+						fileParent,
+						changes: shownIndex < 0 ? changes : changes.slice(shownIndex, shownIndex + 1),
+						treeChangeDiffs:
+							shownIndex < 0 ? treeChangeDiffs : treeChangeDiffs.slice(shownIndex, shownIndex + 1),
+						diffStyle,
+						tabSize,
+						wrapColumns,
+					})
+				: [],
+		[
+			minimapShown,
+			shownIndex,
+			fileParent,
+			changes,
+			treeChangeDiffs,
+			diffStyle,
+			tabSize,
+			wrapColumns,
+		],
 	);
 
 	useHotkeys([
@@ -1287,13 +1302,15 @@ const Diff: FC<{
 							didScrollToViaFileRef={didScrollToViaFileRef}
 						/>
 
-						<DiffMinimap
-							viewerRef={viewerRef}
-							files={minimapFiles}
-							diffStyle={diffStyle}
-							annotationsByPath={annotationsByPath}
-							selection={minimapSelection}
-						/>
+						{minimapShown && (
+							<DiffMinimap
+								viewerRef={viewerRef}
+								files={minimapFiles}
+								diffStyle={diffStyle}
+								annotationsByPath={annotationsByPath}
+								selection={minimapSelection}
+							/>
+						)}
 					</div>
 				</Panel>
 			</Group>

--- a/apps/lite/ui/src/routes/project/$id/workspace/DiffMinimap.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DiffMinimap.module.css
@@ -41,7 +41,9 @@
 
 .minimap {
 	/* Mixed towards the background the way the diff tints its own changed rows,
-	   just further, since a mark can be a single pixel tall. */
+	   just further, since a mark can be a single pixel tall. This is the colour
+	   at full coverage — a pixel every line reaches — and coverage fades from
+	   here as fewer of them do. */
 	--minimap-additions: color-mix(in lab, var(--bg-1) 62%, var(--fill-safe-bg));
 	--minimap-deletions: color-mix(in lab, var(--bg-1) 62%, var(--fill-danger-bg));
 	/* Recessive enough to read as the page the changes are written on, not as a

--- a/apps/lite/ui/src/routes/project/$id/workspace/DiffMinimap.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DiffMinimap.tsx
@@ -54,15 +54,25 @@ export const DiffMinimap: FC<{
 	const canvasRef = useRef<HTMLCanvasElement>(null);
 	const markerRef = useRef<HTMLDivElement>(null);
 	/**
-	 * The lens as it was when the pointer took hold: where on it the grab landed,
-	 * and the mapping to invert. Frozen for the length of the drag because
-	 * CodeView's content height is an estimate that firms up as it renders, and a
-	 * mapping recomputed under the pointer slides the diff while you hold it.
+	 * Where the pointer took hold and what the diff was showing at the time. The
+	 * drag is a delta from here at the map's own scale — a pixel down the ruler is
+	 * a pixel of map — so it carries on winding once the lens has run out of
+	 * ruler, and CodeView's content height firming up mid-drag can't slide the
+	 * diff under the pointer.
 	 */
-	const grabRef = useRef<{ offset: number; layout: MinimapLayout } | null>(null);
+	const grabRef = useRef<{
+		y: number;
+		scrollTop: number;
+		scale: number;
+		scrollable: number;
+	} | null>(null);
 	const dataRef = useRef({ files, diffStyle, annotationsByPath, selection });
 	const geometryRef = useRef<MinimapGeometry | null>(null);
 	const layoutRef = useRef<MinimapLayout | null>(null);
+	/** Where the map is wound to, which it keeps until the lens runs out of ruler. */
+	const offsetRef = useRef(0);
+	/** Wound by hand, and so allowed to show a part of the diff the window is not on. */
+	const freeRef = useRef(false);
 	const resyncRef = useRef<(() => void) | null>(null);
 	const [navigable, setNavigable] = useState(false);
 	const [hovered, setHovered] = useState<string | null>(null);
@@ -77,6 +87,7 @@ export const DiffMinimap: FC<{
 		let forced = false;
 		let lastScrollHeight: number | null = null;
 		let lastOffset: number | null = null;
+		let lastScrollTop: number | null = null;
 
 		const draw = (layout: MinimapLayout): void => {
 			const { files, diffStyle, annotationsByPath, selection } = dataRef.current;
@@ -97,13 +108,21 @@ export const DiffMinimap: FC<{
 			const ruler = rulerRef.current;
 			if (!ruler) return;
 
-			// Measured to the sub-pixel, as the drag is: a track rounded here and not
-			// there puts the two a fraction of a percent apart, which at this scale is
-			// a good many lines. Zero while the ruler is collapsed, which it is until
-			// a draw finds something to map — so the draw has to come first, or it
-			// waits on the height that only it can bring about.
+			// Sub-pixel: rounded here and not in the drag, the two would sit a fraction
+			// of a percent apart, which at this scale is a good many lines.
 			const track = availableTrack(ruler);
-			const layout = getMinimapLayout(viewer, track);
+
+			// A pointer on the ruler is pointing at the map, so it holds still and the
+			// lens moves instead; a map wound by hand keeps where it was put until the
+			// diff moves again.
+			const scrollTop = viewer.getScrollTop();
+			const scrolled = lastScrollTop !== null && scrollTop !== lastScrollTop;
+			lastScrollTop = scrollTop;
+			if (scrolled) freeRef.current = false;
+
+			const moved = scrolled && !grabRef.current ? "draws" : freeRef.current ? "free" : "holds";
+			const layout = getMinimapLayout(viewer, track, scrollTop, offsetRef.current, moved);
+			offsetRef.current = layout.offset;
 
 			// The ruler stops where the map does, so its own height can't be what the
 			// map was scaled against — that would be a box sized from what it holds
@@ -122,8 +141,8 @@ export const DiffMinimap: FC<{
 				draw(layout);
 			}
 
-			// The canvas the draw just sized is what gives the ruler its height, so
-			// the pass that opens it measures nothing and the resize brings us back.
+			// Nothing to place a lens along yet; the resize that gives the pane a
+			// height brings us back.
 			if (track === 0) return;
 
 			layoutRef.current = layout;
@@ -162,6 +181,22 @@ export const DiffMinimap: FC<{
 			if (root.firstElementChild) resizeObserver.observe(root.firstElementChild);
 		}
 
+		// Winds the map rather than the diff. Bound natively rather than through
+		// React, which listens passively and so could not keep the wheel from
+		// reaching whatever is behind it.
+		const ruler = rulerRef.current;
+		const onWheel = (event: WheelEvent): void => {
+			const layout = layoutRef.current;
+			const limit = ruler && layout ? layout.mapHeight - availableTrack(ruler) : 0;
+			if (!layout || limit <= 0) return;
+
+			event.preventDefault();
+			freeRef.current = true;
+			offsetRef.current = Math.min(Math.max(offsetRef.current + event.deltaY, 0), limit);
+			redraw();
+		};
+		ruler?.addEventListener("wheel", onWheel, { passive: false });
+
 		// Canvas colours are sampled, not live CSS, so they need repainting when
 		// the tokens behind them resolve differently.
 		const scheme = globalThis.matchMedia("(prefers-color-scheme: dark)");
@@ -190,6 +225,7 @@ export const DiffMinimap: FC<{
 			resizeObserver.disconnect();
 			scheme.removeEventListener("change", redraw);
 			pixels?.removeEventListener("change", onPixels);
+			ruler?.removeEventListener("wheel", onWheel);
 		};
 	}, [viewerRef]);
 
@@ -229,19 +265,15 @@ export const DiffMinimap: FC<{
 	const dragTo = (event: PointerEvent<HTMLDivElement>): void => {
 		const viewer = viewerRef.current?.getInstance();
 		const grab = grabRef.current;
-		if (!viewer || !grab) return;
+		if (!viewer || !grab || grab.scale === 0) return;
 
-		const top = rulerOffset(event) - grab.offset;
-		const reach = grab.layout.travel === 0 ? 0 : top / grab.layout.travel;
-		const progress = Math.min(Math.max(reach, 0), 1);
+		const moved = (rulerOffset(event) - grab.y) / grab.scale;
+		// The end can grow as the drag scrolls into parts the viewer has only
+		// estimated, so ask again rather than stopping short of a diff that got
+		// longer under you.
+		const scrollable = Math.max(grab.scrollable, getMinimapScrollable(viewer));
 
-		// The estimate the mapping was frozen against firms up as the drag scrolls
-		// through it, and the far end is the one place that shows: stopping short of
-		// a diff that grew under you reads as the lens failing to reach the bottom.
-		// So the last of the travel goes wherever the end is now.
-		const scrollable = progress === 1 ? getMinimapScrollable(viewer) : grab.layout.scrollable;
-
-		scrollMinimapTo(viewer, progress * scrollable);
+		scrollMinimapTo(viewer, Math.min(Math.max(grab.scrollTop + moved, 0), scrollable));
 	};
 
 	// The label's position is written straight to the DOM, so following the
@@ -286,9 +318,18 @@ export const DiffMinimap: FC<{
 				// scrollbar does, and moves nothing until you do. Its own rect is the hit
 				// test, so the minimum height it can shrink to doesn't have to be
 				// repeated here.
+				const hold = (scrollTop: number): void => {
+					grabRef.current = {
+						y: rulerOffset(event),
+						scrollTop,
+						scale: layout.scale,
+						scrollable: layout.scrollable,
+					};
+				};
+
 				const marker = markerRef.current?.getBoundingClientRect();
 				if (marker && event.clientY >= marker.top && event.clientY <= marker.bottom) {
-					grabRef.current = { offset: event.clientY - marker.top, layout };
+					hold(viewer.getScrollTop());
 					return;
 				}
 
@@ -296,15 +337,10 @@ export const DiffMinimap: FC<{
 				// of the whole diff: the map is a picture at a fixed scale, so read the
 				// position back out of it the way the hint does and bring it into the
 				// middle of the window.
-				const landing = jumpTo((rulerOffset(event) + layout.offset) / layout.scale);
-
-				// The map may have wound on under the pointer, taking the lens with it,
-				// so the drag carries on from where the lens has landed. Worked out from
-				// the landing rather than read back off the viewer, which goes on
-				// reporting the old position for a frame yet — long enough for the first
-				// move to teleport by the difference.
-				const landed = getMinimapLayout(viewer, availableTrack(event.currentTarget), landing);
-				grabRef.current = { offset: rulerOffset(event) - landed.lensTop, layout: landed };
+				// Worked out from where the jump lands rather than read back off the
+				// viewer, which goes on reporting the old position for a frame yet —
+				// long enough for the first move of a drag to teleport by the difference.
+				hold(jumpTo((rulerOffset(event) + layout.offset) / layout.scale));
 			}}
 			onPointerMove={(event) => {
 				describe(event);

--- a/apps/lite/ui/src/routes/project/$id/workspace/Settings/Appearance.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Settings/Appearance.tsx
@@ -109,6 +109,18 @@ export const Appearance: FC = () => {
 			</Section>
 
 			<Section heading="Diff">
+				<Row
+					label="Minimap"
+					labelId="minimap"
+					hint="A map of the diff down the right-hand edge, standing in for the scrollbar."
+				>
+					<Switch
+						aria-labelledby="minimap"
+						checked={settings.minimap ?? defaultSettings.minimap}
+						onCheckedChange={(minimap) => saveGUISettings({ minimap })}
+					/>
+				</Row>
+
 				<Row label="Diff files" labelId="unidiff">
 					<ToggleGroup
 						aria-labelledby="unidiff"

--- a/apps/lite/ui/src/routes/project/$id/workspace/diff-minimap-canvas.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/diff-minimap-canvas.ts
@@ -22,17 +22,47 @@ const PIN_HEIGHT = 3;
 const ICON_MIN_SECTION = 24;
 
 /**
- * Per device pixel: line widths and indents summed against how much of the
- * pixel each line covers, so dividing one by the other gives the average. Held
- * as sums rather than averages because they are accumulated a line at a time.
+ * Room a badge takes below where it hangs, its own height and the margin
+ * clearing the rule. One offered past the end of the ruler would still be
+ * placed there, and an absolute box hanging out of the ruler makes an ancestor
+ * scrollable — so a wheel over the map would scroll the pane instead.
+ */
+const ICON_HEIGHT = 23;
+
+/**
+ * Coverage per pixel, rather than an average width per pixel row.
+ *
+ * Where a row holds one line the two say the same thing. Where it holds many,
+ * an average is a single number standing in for a distribution — and every
+ * such number is wrong in its own way: the widest squares the run off, the
+ * narrowest cuts it short, the mean lands where no line actually ends. Coverage
+ * keeps all of them: the row is solid as far as every line reaches and thins
+ * out towards the longest, and that fade is the shape of the code.
+ *
+ * Held as a difference array — coverage added where a line starts and taken
+ * away where it ends — so a line costs two writes however long it is, and one
+ * running sum along the row turns them back into coverage per pixel.
  */
 type Lane = {
-	widths: Float32Array;
-	indents: Float32Array;
-	/** Everything that landed here, blank lines included. */
+	/** Two entries per line, on a row of its own: `stride` wide, `columns` used. */
+	edges: Float32Array;
+	/** Everything that landed on the row, which the running sums divide by. */
 	coverage: Float32Array;
-	/** Only the lines with something on them, which is what the sums average by. */
-	content: Float32Array;
+};
+
+/** Kept between paints: these run to megabytes, and a winding map repaints per frame. */
+const held = new Map<string, Float32Array>();
+
+const scratch = (key: string, length: number): Float32Array => {
+	const kept = held.get(key);
+	if (kept?.length === length) {
+		kept.fill(0);
+		return kept;
+	}
+
+	const made = new Float32Array(length);
+	held.set(key, made);
+	return made;
 };
 
 /** A file section with room for its type icon, and where that icon goes. */
@@ -52,22 +82,29 @@ const resolveLanes = ({
 	files,
 	geometry,
 	rows,
+	columns,
 	scale,
 	offset,
 }: {
 	files: Array<MinimapFile>;
 	geometry: MinimapGeometry;
 	rows: number;
+	columns: number;
 	scale: number;
 	offset: number;
 }): Record<MinimapSide, Lane> => {
-	const lane = (): Lane => ({
-		widths: new Float32Array(rows),
-		indents: new Float32Array(rows),
-		coverage: new Float32Array(rows),
-		content: new Float32Array(rows),
+	// One past the last column, so a line reaching the far edge has somewhere to
+	// be taken away again.
+	const stride = columns + 1;
+	const lane = (name: MinimapSide): Lane => ({
+		edges: scratch(`${name}.edges`, rows * stride),
+		coverage: scratch(`${name}.coverage`, rows),
 	});
-	const lanes = { context: lane(), deletions: lane(), additions: lane() };
+	const lanes = {
+		context: lane("context"),
+		deletions: lane("deletions"),
+		additions: lane("additions"),
+	};
 
 	for (const [index, file] of files.entries()) {
 		const block = geometry.blocks[index];
@@ -104,20 +141,21 @@ const resolveLanes = ({
 				const last = Math.min(tall ? Math.ceil(y + lineHeight) - 1 : first, rows - 1);
 
 				const indent = mark.indents[line] ?? 0;
-				// A line with nothing but whitespace on it marks its pixel, but averaging
-				// its zero length in would drag the shape of the lines around it down.
-				const blank = width === indent;
+
+				// Leading whitespace is left uncovered, so indentation reads as the gap
+				// before a line's code. Every line marks at least the one pixel, however
+				// little of the lane it fills.
+				const start = Math.min(Math.round((indent * columns) / 255), columns - 1);
+				const end = Math.min(Math.max(Math.round((width * columns) / 255), start + 1), columns);
 
 				for (let row = first; row <= last; row++) {
 					// A sub-pixel line was pinned to one row, so all of it counts there.
 					const covered = tall ? Math.min(y + lineHeight, row + 1) - Math.max(y, row) : lineHeight;
+					const base = row * stride;
 
 					lane.coverage[row] = (lane.coverage[row] ?? 0) + covered;
-					if (blank) continue;
-
-					lane.content[row] = (lane.content[row] ?? 0) + covered;
-					lane.widths[row] = (lane.widths[row] ?? 0) + width * covered;
-					lane.indents[row] = (lane.indents[row] ?? 0) + indent * covered;
+					lane.edges[base + start] = (lane.edges[base + start] ?? 0) + covered;
+					lane.edges[base + end] = (lane.edges[base + end] ?? 0) - covered;
 				}
 				y += lineHeight;
 			}
@@ -190,6 +228,47 @@ const resolveOpening = ({
 };
 
 /**
+ * Marks are composited through a surface of their own so the selection band
+ * keeps showing between the lines it covers: writing pixels straight onto the
+ * ruler would put them over it rather than on top of it.
+ */
+const surface: { canvas: HTMLCanvasElement | null; image: ImageData | null } = {
+	canvas: null,
+	image: null,
+};
+
+/**
+ * Canvas takes a colour as CSS writes it, but pixels have to be numbers — and
+ * these arrive as whatever `color-mix` resolved to. Painting one and reading it
+ * back is the only reader of modern colour syntax we have to hand.
+ */
+const swatch: { canvas: HTMLCanvasElement | null; read: Map<string, [number, number, number]> } = {
+	canvas: null,
+	read: new Map(),
+};
+
+const resolveColour = (colour: string): [number, number, number] => {
+	const known = swatch.read.get(colour);
+	if (known) return known;
+
+	swatch.canvas ??= document.createElement("canvas");
+	swatch.canvas.width = 1;
+	swatch.canvas.height = 1;
+
+	const context = swatch.canvas.getContext("2d", { willReadFrequently: true });
+	if (!context) return [0, 0, 0];
+
+	context.clearRect(0, 0, 1, 1);
+	context.fillStyle = colour;
+	context.fillRect(0, 0, 1, 1);
+
+	const [red = 0, green = 0, blue = 0] = context.getImageData(0, 0, 1, 1).data;
+	const resolved: [number, number, number] = [red, green, blue];
+	swatch.read.set(colour, resolved);
+	return resolved;
+};
+
+/**
  * Paint the ruler, and report which files have room for a type icon. Badges are
  * only offered for files that kept a rule, so one always sits the same distance
  * under the line opening its section rather than measuring to one further up.
@@ -235,15 +314,18 @@ export const paintMinimap = (
 	};
 
 	const split = diffStyle === "split";
-	const laneWidth = Math.max(split ? (width - LANE_SPLIT) / 2 : width, 1);
 	// One device pixel, in the CSS units the context is scaled to.
 	const thinnest = 1 / ratio;
 	const { scale, offset } = layout;
 	const rows = deviceHeight;
+	const channel = Math.round(LANE_SPLIT * ratio);
+	const columns = Math.max(split ? Math.floor((deviceWidth - channel) / 2) : deviceWidth, 1);
+	const stride = columns + 1;
 	const lanes = resolveLanes({
 		files,
 		geometry,
 		rows,
+		columns,
 		scale: scale * ratio,
 		offset: offset * ratio,
 	});
@@ -266,25 +348,42 @@ export const paintMinimap = (
 		losing.coverage[row] = 0;
 	}
 
-	// Leading whitespace is left unpainted, so indentation reads as the gap
-	// before a line's code. Every line grows from its own lane's left edge, the
-	// way the text does in the column it stands for.
-	const drawLane = (lane: Lane, origin: number, fill: string): void => {
-		context.fillStyle = fill;
-
+	/**
+	 * Dividing the running sum by the row's own coverage gives the share of its
+	 * lines reaching each pixel: a row of one line is solid to its end, a row of
+	 * many fades out across the lengths they run to.
+	 */
+	const paintLane = (
+		data: Uint8ClampedArray,
+		lane: Lane,
+		origin: number,
+		[red, green, blue]: [number, number, number],
+	): void => {
 		for (let row = 0; row < rows; row++) {
-			if ((lane.coverage[row] ?? 0) === 0) continue;
+			const covered = lane.coverage[row] ?? 0;
+			if (covered === 0) continue;
 
-			// Nothing but blank lines here: the pixel still gets the single-pixel
-			// minimum below, so the change stays countable rather than vanishing.
-			const content = lane.content[row] ?? 0;
-			const width = content === 0 ? 0 : (lane.widths[row] ?? 0) / content;
-			const indent = content === 0 ? 0 : (lane.indents[row] ?? 0) / content;
+			const base = row * stride;
+			let running = 0;
 
-			const outer = Math.max((laneWidth * width) / 255, thinnest);
-			const inner = Math.min((laneWidth * indent) / 255, outer - thinnest);
+			for (let column = 0; column < columns; column++) {
+				running += lane.edges[base + column] ?? 0;
+				if (running <= 0) continue;
 
-			context.fillRect(origin + inner, row / ratio, outer - inner, thinnest);
+				const alpha = Math.min(running / covered, 1);
+				const at = (row * deviceWidth + origin + column) * 4;
+
+				// Over whatever a lane before it left, so the two columns of a split
+				// diff and the context under them compose rather than overwrite.
+				const beneath = ((data[at + 3] ?? 0) / 255) * (1 - alpha);
+				const total = alpha + beneath;
+				if (total <= 0) continue;
+
+				data[at] = (red * alpha + (data[at] ?? 0) * beneath) / total;
+				data[at + 1] = (green * alpha + (data[at + 1] ?? 0) * beneath) / total;
+				data[at + 2] = (blue * alpha + (data[at + 2] ?? 0) * beneath) / total;
+				data[at + 3] = total * 255;
+			}
 		}
 	};
 
@@ -300,12 +399,34 @@ export const paintMinimap = (
 		);
 	}
 
-	const right = laneWidth + LANE_SPLIT;
-	// Unchanged code is the same on both sides, so split shows it in both columns.
-	drawLane(lanes.context, 0, fills.context);
-	if (split) drawLane(lanes.context, right, fills.context);
-	drawLane(lanes.deletions, 0, fills.deletions);
-	drawLane(lanes.additions, split ? right : 0, fills.additions);
+	surface.canvas ??= document.createElement("canvas");
+	if (surface.canvas.width !== deviceWidth || surface.canvas.height !== deviceHeight) {
+		surface.canvas.width = deviceWidth;
+		surface.canvas.height = deviceHeight;
+		surface.image = null;
+	}
+
+	const marks = surface.canvas.getContext("2d");
+	if (marks) {
+		surface.image ??= marks.createImageData(deviceWidth, deviceHeight);
+		surface.image.data.fill(0);
+
+		const right = columns + channel;
+		// Unchanged code is the same on both sides, so split shows it in both columns.
+		paintLane(surface.image.data, lanes.context, 0, resolveColour(fills.context));
+		if (split) paintLane(surface.image.data, lanes.context, right, resolveColour(fills.context));
+		paintLane(surface.image.data, lanes.deletions, 0, resolveColour(fills.deletions));
+		paintLane(
+			surface.image.data,
+			lanes.additions,
+			split ? right : 0,
+			resolveColour(fills.additions),
+		);
+
+		marks.putImageData(surface.image, 0, 0);
+		// Drawn rather than written, so the band beneath shows through the gaps.
+		context.drawImage(surface.canvas, 0, 0, width, height);
+	}
 
 	// Drawn last and opaque, so a rule reads over the marks it crosses rather
 	// than tinting with them.
@@ -332,7 +453,7 @@ export const paintMinimap = (
 	return [
 		...resolveOpening({ geometry, scale, offset }),
 		...rules
-			.filter((rule) => rule.height >= ICON_MIN_SECTION)
+			.filter((rule) => rule.height >= ICON_MIN_SECTION && rule.y + ICON_HEIGHT <= height)
 			.map(({ index, y }) => ({ index, top: y })),
 	];
 };

--- a/apps/lite/ui/src/routes/project/$id/workspace/diff-minimap.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/diff-minimap.ts
@@ -28,15 +28,15 @@ const SEPARATOR_BETWEEN = 48;
  */
 const MAX_CHANGED_LINES = 250_000;
 
-/**
- * How many viewports tall the diff has to be before the map earns its space.
- * Just over one, and the marker covers most of the ruler and says nothing the
- * scrollbar wouldn't.
- */
-const MIN_VIEWPORTS = 2;
-
 /** Line width at which a mark fills its lane. */
 const REFERENCE_COLUMNS = 100;
+
+/**
+ * Width a line with nothing on it is drawn. It still happened, and a run of
+ * them is the shape of the code around them — but at a pixel to the row a
+ * hairline is easy to lose between its neighbours, so give it a character.
+ */
+const BLANK_COLUMNS = 1;
 
 /**
  * Context is the unchanged code a hunk carries with it. Drawn under the two
@@ -138,10 +138,13 @@ const runMetrics = (
 	for (const [index, line] of lines.entries()) {
 		const { indent, columns } = lineColumns(line, tabSize);
 
-		widths[index] = share(columns);
-		// Never wider than the line it sits in, which also leaves a line that is
-		// nothing but whitespace with the two equal — how a blank one is spotted.
-		indents[index] = Math.min(share(indent), widths[index]);
+		// Nothing but whitespace, if anything at all: drawn from the margin rather
+		// than at an indent it has no code to fill.
+		const blank = columns === indent;
+
+		widths[index] = blank ? share(BLANK_COLUMNS) : share(columns);
+		// Never wider than the line it sits in.
+		indents[index] = blank ? 0 : Math.min(share(indent), widths[index]);
 
 		// The viewer breaks on word boundaries where it can, so a line can take one
 		// row more than its length demands. Under-counting leaves the rest of the
@@ -349,7 +352,7 @@ export const getMinimapGeometry = (
 	itemIds: Array<string>,
 ): MinimapGeometry | null => {
 	const total = contentHeight(viewer);
-	if (itemIds.length === 0 || total < viewer.getHeight() * MIN_VIEWPORTS) return null;
+	if (itemIds.length === 0) return null;
 
 	const blocks: Array<{ top: number; height: number }> = [];
 
@@ -531,14 +534,13 @@ const mapScale = (total: number, track: number): number => {
 const LENS_MIN_HEIGHT = 14;
 
 /**
- * Where the map and its lens sit, in ruler pixels.
- *
- * The lens travels the track its own height leaves — the arithmetic every
- * scrollbar does — and the map is then slid so the code under the lens is the
- * code in the window. Both reach their ends together: at the foot of the
- * scroll the lens is at the foot of the track and the map at its own last
- * pixel.
+ * How much of the way the map closes on the diff each time it is drawn along.
+ * Enough to keep up with a scroll and settle quickly after one, gentle enough
+ * that it reads as the map moving rather than being redrawn somewhere else.
  */
+const FOLLOW_RATE = 0.25;
+
+/** Where the map and its lens sit, in ruler pixels. */
 export type MinimapLayout = {
 	/** Ruler pixels per content pixel. */
 	scale: number;
@@ -548,9 +550,6 @@ export type MinimapLayout = {
 	offset: number;
 	lensTop: number;
 	lensHeight: number;
-	/** Room the lens has to move, which the drag inverts. */
-	travel: number;
-	/** How far the diff can scroll: everything below the window it doesn't fill. */
 	scrollable: number;
 };
 
@@ -558,12 +557,29 @@ export type MinimapLayout = {
 export const getMinimapScrollable = (viewer: CodeView<Annotation>): number =>
 	Math.max(contentHeight(viewer) - viewer.getHeight(), 0);
 
+/**
+ * Scrolling the diff draws the map along with it, a little at a time, towards
+ * where the diff has got to overall: a map taller than the ruler is only
+ * legible as such if you can watch it move. Everything else leaves the map
+ * where it is and moves the lens instead, so what you are pointing at stays
+ * under the pointer. Either way the lens is kept on the ruler, which is what
+ * makes the map wind when there is nowhere else for it to go.
+ */
 export const getMinimapLayout = (
 	viewer: CodeView<Annotation>,
 	track: number,
 	/** Where the diff will be, for a caller that has just asked it to move and
 	 * cannot wait to be told: CodeView reports the old position for a frame yet. */
 	scrollTop: number = viewer.getScrollTop(),
+	/** Where the map was left, which it keeps for as long as the lens allows. */
+	previousOffset = 0,
+	/**
+	 * What moved. Scrolling the diff *draws* the map along after it; a pointer on
+	 * the ruler *holds* it where it is and moves the lens instead; and winding the
+	 * map by hand sets it *free*, the one case where the window is allowed off the
+	 * part of the map being shown.
+	 */
+	moved: "draws" | "holds" | "free" = "holds",
 ): MinimapLayout => {
 	const total = contentHeight(viewer);
 	const window = viewer.getHeight();
@@ -571,19 +587,38 @@ export const getMinimapLayout = (
 	const mapHeight = total * scale;
 	const lensHeight = Math.min(Math.max(window * scale, LENS_MIN_HEIGHT), track);
 
-	const scrollable = getMinimapScrollable(viewer);
-	const progress = scrollable <= 0 ? 0 : Math.min(Math.max(scrollTop / scrollable, 0), 1);
-
 	// A map with room to spare keeps the lens over its own place on it; one
 	// taller than the track keeps the lens on the track and winds the map under.
 	const scrolls = mapHeight > track;
 	const travel = Math.max((scrolls ? track : mapHeight) - lensHeight, 0);
-	const lensTop = progress * travel;
-	const offset = scrolls
-		? Math.min(Math.max(scrollTop * scale - lensTop, 0), mapHeight - track)
-		: 0;
+	const scrollable = getMinimapScrollable(viewer);
 
-	return { scale, mapHeight, offset, lensTop, lensHeight, travel, scrollable };
+	// Where the top of the window falls on the map, wound or not.
+	const onMap = scrollTop * scale;
+	const limit = Math.max(mapHeight - track, 0);
+
+	// Following the diff, the map makes for the place its own scroll has reached
+	// — part of the way each time, so it is drawn along rather than jumping to
+	// keep up, and so a map left somewhere by hand finds its way back.
+	const sought =
+		moved === "draws" && scrollable > 0
+			? previousOffset + ((scrollTop / scrollable) * limit - previousOffset) * FOLLOW_RATE
+			: previousOffset;
+
+	// The least the map has to move for the lens to still be on the ruler — and
+	// no more than that, so it stays where it was left — then held within the
+	// map's own ends.
+	const wound = moved === "free" ? sought : Math.min(Math.max(sought, onMap - travel), onMap);
+	const offset = scrolls ? Math.min(Math.max(wound, 0), limit) : 0;
+
+	return {
+		scale,
+		mapHeight,
+		offset,
+		lensTop: Math.min(Math.max(onMap - offset, 0), travel),
+		lensHeight,
+		scrollable,
+	};
 };
 
 /** Scroll so the window's top sits at `position` in the content. */

--- a/apps/lite/ui/src/settings.ts
+++ b/apps/lite/ui/src/settings.ts
@@ -16,6 +16,7 @@ export const defaultSettings = {
 	fileDisplayMode: "list",
 	// Pierre's own default, named here so the setting has somewhere to fall back to.
 	lineDiffType: "word-alt",
+	minimap: true,
 	// Lite has always led with the file name; desktop leads with the path.
 	pathFirst: false,
 	terminalId: "",


### PR DESCRIPTION
This was written alongside #15255 and left out of it in error. That branch was
squashed into one commit, but the squash never reached the remote — the push
reported success without moving the ref, and the check I made afterwards
couldn't tell the difference, since the pre-squash head carried the same commit
title. #15255 therefore merged its first commit alone, and the five that
followed stayed local. They all belong with that work.

**Coverage instead of an average width.** Where lines share a pixel, the row now
carries coverage per pixel: solid as far as every line reaches, fading towards
the longest. A single width is a statistic standing in for a distribution, and
max, min and mean are each wrong in their own way. A line with nothing on it is
drawn a character wide from the margin rather than left out of the reckoning.

**Motion.** Scrolling the diff draws the map along after it, a little at a time,
so a map taller than the ruler can be seen to be one. A pointer on the ruler
holds it still and moves the lens instead, so what you press stays under the
pointer. A wheel over the ruler winds the map alone without moving the diff.

**A setting.** Showing the ruler is now a setting under Appearance, defaulting to
on, rather than a guess at whether the diff is twice the window tall. Turned off,
nothing is drawn and nothing is parsed — modelling the map reads every line.

**A fix.** A file is only badged where its icon fits above the end of the ruler.
One hanging past it left the ruler overflowing its own box, which made the pane
scrollable, so a wheel over the map scrolled the whole section instead of the
diff.