### PR TITLE
Keep the lens inside the ruler on a short diff

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/diff-minimap.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/diff-minimap.ts
@@ -569,7 +569,14 @@ export const getMinimapLayout = (
 	const window = viewer.getHeight();
 	const scale = mapScale(total, track);
 	const mapHeight = total * scale;
-	const lensHeight = Math.min(Math.max(window * scale, LENS_MIN_HEIGHT), track);
+	// Against the ruler, which ends where the map does, rather than against the
+	// pane: a diff shorter than the window maps to less than a window's worth of
+	// ruler, and a lens taller than the ruler it sits in would hang out of the
+	// box and set the pane scrolling.
+	const lensHeight = Math.min(
+		Math.max(window * scale, LENS_MIN_HEIGHT),
+		Math.min(track, mapHeight),
+	);
 
 	const scrollable = getMinimapScrollable(viewer);
 	const progress = scrollable <= 0 ? 0 : Math.min(Math.max(scrollTop / scrollable, 0), 1);


### PR DESCRIPTION
Raised by Copilot on #15265, and correct.

The lens was clamped against the pane's height rather than the ruler's. The ruler
ends where the map does, so a diff shorter than the window maps to less than a
window's worth of ruler — and the lens then came out taller than the box holding
it. An absolutely positioned box hanging out of the ruler is exactly what made
the pane scrollable in the badge case on #15265, so a wheel over the map would
scroll the whole section instead of the diff.

Measured across the cases: a diff shorter than the window overhung by 20px, one
at half the window by 30px; a diff that fills the ruler and one taller than it
are unchanged.

Only reachable since showing the ruler became a setting — the old "twice the
window tall" guess had kept short diffs off the minimap entirely.