### PR TITLE
Fold with z and navigate panes with arrows in Lite

### DIFF
--- a/apps/lite/ui/src/components/Tooltip.tsx
+++ b/apps/lite/ui/src/components/Tooltip.tsx
@@ -1,20 +1,36 @@
 import { classes } from "#ui/components/classes.ts";
 import styles from "./Tooltip.module.css";
 import { Kbd } from "#ui/components/Kbd.tsx";
+import { isFocusWithinSelectionScope, type SelectionScope } from "#ui/selection-scopes.ts";
 import type { HotkeySequence } from "@tanstack/react-hotkeys";
-import type { ComponentProps, FC } from "react";
+import { useState, type ComponentProps, type FC } from "react";
 
 export const TooltipPopup: FC<
 	ComponentProps<"div"> & {
 		/** Optional keyboard shortcut displayed alongside the content. */
 		kbd?: string | HotkeySequence;
+		/**
+		 * The selection scope the shortcut is bound to. When given, the shortcut
+		 * only shows while that scope owns focus — a scoped hotkey does nothing
+		 * from anywhere else, so advertising it there would mislead. Checked once
+		 * as the popup mounts (it opens on hover, which doesn't move focus), so no
+		 * subscription re-renders rows on pane switches.
+		 */
+		kbdScope?: SelectionScope;
 	}
-> = ({ children, kbd, ...props }) => (
-	<div
-		{...props}
-		className={classes(props.className, "text-12", styles.tooltip, kbd != null && styles.withKbd)}
-	>
-		<span className={styles.content}>{children}</span>
-		{kbd != null && <Kbd hotkey={kbd} />}
-	</div>
-);
+> = ({ children, kbd, kbdScope, ...props }) => {
+	const [kbdApplies] = useState(
+		() => kbdScope === undefined || isFocusWithinSelectionScope(kbdScope),
+	);
+	const showKbd = kbd != null && kbdApplies;
+
+	return (
+		<div
+			{...props}
+			className={classes(props.className, "text-12", styles.tooltip, showKbd && styles.withKbd)}
+		>
+			<span className={styles.content}>{children}</span>
+			{showKbd && <Kbd hotkey={kbd} />}
+		</div>
+	);
+};

--- a/apps/lite/ui/src/hotkeys.ts
+++ b/apps/lite/ui/src/hotkeys.ts
@@ -118,10 +118,12 @@ export const workspaceHotkeys = {
 		},
 	},
 	focusHorizontalSelectionScopeLeft: {
-		hotkey: "Mod+Alt+ArrowLeft",
+		hotkey: "ArrowLeft",
+		meta: { group: "Workspace", name: "Focus pane to the left" },
 	},
 	focusHorizontalSelectionScopeRight: {
-		hotkey: "Mod+Alt+ArrowRight",
+		hotkey: "ArrowRight",
+		meta: { group: "Workspace", name: "Focus pane to the right" },
 	},
 	focusVerticalSelectionScopeUp: {
 		hotkey: "Mod+Alt+ArrowUp",

--- a/apps/lite/ui/src/hotkeys.ts
+++ b/apps/lite/ui/src/hotkeys.ts
@@ -228,6 +228,10 @@ export const outlineHotkeys = {
 		hotkey: "T",
 		meta: { group: "Workspace", name: "Jump to branch" },
 	},
+	toggleFoldBranch: {
+		hotkey: "Z",
+		meta: { group: "Branch", name: "Fold/unfold commits" },
+	},
 	uncommitCommit: {
 		hotkey: "Mod+Alt+Backspace",
 		meta: { group: "Commit", name: "Uncommit" },
@@ -268,6 +272,10 @@ export const changesFileHotkeys = {
 	openInEditor: {
 		hotkey: "E",
 		meta: { group: "File", name: "Open in editor" },
+	},
+	toggleFoldDirectory: {
+		hotkey: "Z",
+		meta: { group: "File", name: "Fold/unfold directory" },
 	},
 	uncommit: {
 		hotkey: "Mod+Alt+Backspace",
@@ -312,13 +320,9 @@ export const operationHotkeys = {
 } satisfies Record<string, HotkeyWithMeta>;
 
 export const diffHotkeys = {
-	foldFile: {
-		hotkey: "Mod+Alt+[",
-		meta: { group: "Diff", name: "Fold" },
-	},
-	unfoldFile: {
-		hotkey: "Mod+Alt+]",
-		meta: { group: "Diff", name: "Unfold" },
+	toggleFoldFile: {
+		hotkey: "Z",
+		meta: { group: "Diff", name: "Fold/unfold file" },
 	},
 	toggleDiffStyle: {
 		hotkey: "Mod+B",

--- a/apps/lite/ui/src/projects/project.ts
+++ b/apps/lite/ui/src/projects/project.ts
@@ -646,6 +646,8 @@ export const projectSelectors = {
 			state.workspace.selection.diff,
 			hunkOperandIdentityKey,
 		),
+	/** The diff selection as stored, without resolving it against a navigation index. */
+	selectStoredDiffSelection: (state: ProjectState) => state.workspace.selection.diff,
 	selectOutlineModeState: (state: ProjectState) => state.workspace.mode,
 	selectFoldedSegments: (state: ProjectState) => state.workspace.foldedSegments,
 	selectSegmentFolded: (state: ProjectState, branchRef: string) =>

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
@@ -282,6 +282,28 @@
 	}
 }
 
+/* A folded file's header stands in for its hidden, selected hunks. A plain
+   accent bar marks it for now; positioned absolutely so the layout is
+   untouched. */
+.fileHeaderSelected {
+	position: relative;
+
+	&::before {
+		position: absolute;
+		width: 3px;
+		inset: 4px auto 4px 0;
+		border-radius: 0 2px 2px 0;
+		/* The row-selection fill, dimmed like row selections in a blurred
+		   panel; full strength while the diff pane owns focus. */
+		background-color: color-mix(var(--fill-gray-bg) var(--opacity-bg-selected-blur), transparent);
+		content: "";
+	}
+
+	[data-selection-focus-styles="true"] [data-selection-scope="diff"]:focus-within &::before {
+		background-color: var(--fill-gray-bg);
+	}
+}
+
 .fileHeaderActions {
 	display: flex;
 }

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -45,7 +45,7 @@ import {
 	PullRequestForm,
 	PullRequestPrimaryAction,
 } from "#ui/routes/project/$id/workspace/PullRequestTab.tsx";
-import { useAppDispatch, useAppSelector } from "#ui/store.ts";
+import { useAppDispatch, useAppSelector, useAppStore } from "#ui/store.ts";
 import { classes } from "#ui/components/classes.ts";
 import { Toggle, ToggleGroup, Toolbar, Tooltip } from "@base-ui/react";
 import type { CommitDetails, TreeChange } from "@gitbutler/but-sdk";
@@ -138,6 +138,7 @@ import {
 	type DiffView,
 	getDiffView,
 	hunkOperandIdentityKey,
+	withoutFoldedHunks,
 } from "./diff-view.ts";
 import { DiffMinimap } from "./DiffMinimap.tsx";
 import { getMinimapFiles, measureWrapColumns, type MinimapSelection } from "./diff-minimap.ts";
@@ -249,6 +250,7 @@ const DiffContents: FC<{
 	didScrollToViaFileRef,
 }) => {
 	const [collapsedItems, setCollapsedItems] = useState<Set<string>>(new Set());
+	const visibleNavigationIndex = withoutFoldedHunks(navigationIndex, hunkByKey, collapsedItems);
 	const newFocusableAnnotationIdRef = useRef<string | null>(null);
 	const dispatch = useAppDispatch();
 	const { mutate: createComment } = useCommentCreate();
@@ -267,15 +269,26 @@ const DiffContents: FC<{
 	});
 	const { mutate: openInProgram } = useOpenInProgram();
 	const hunkMenuItems = useHunkMenuItems({ projectId });
+	const store = useAppStore();
 
 	const diffSelection = useAppSelector((state) =>
-		projectSlice.selectors.selectSelectionDiff(state, projectId, navigationIndex),
+		projectSlice.selectors.selectSelectionDiff(state, projectId, visibleNavigationIndex),
+	);
+	const hasStoredDiffSelection = useAppSelector(
+		(state) => projectSlice.selectors.selectStoredDiffSelection(state, projectId) !== null,
 	);
 	const diffSelectionHunk =
 		diffSelection !== null ? hunkByKey.get(hunkOperandIdentityKey(diffSelection)) : null;
 	const selectedRange = diffSelection
 		? (hunkByKey.get(hunkOperandIdentityKey(diffSelection))?.selectedLines ?? null)
 		: null;
+	// A primitive, null while the selection sits on a visible hunk, so the item
+	// list and header closures below only pick up new identities when a folded
+	// file gains or loses the selection — not on every j/k move.
+	const selectedFoldedFileId =
+		diffSelectionHunk != null && collapsedItems.has(diffSelectionHunk.file.item.id)
+			? diffSelectionHunk.file.item.id
+			: null;
 
 	useLayoutEffect(() => {
 		if (!diffSelectionHunk) return;
@@ -304,7 +317,7 @@ const DiffContents: FC<{
 	};
 
 	useNavigationIndexHotkeys({
-		navigationIndex,
+		navigationIndex: visibleNavigationIndex,
 		projectId,
 		group: "Diff",
 		select: selectDiff,
@@ -320,25 +333,22 @@ const DiffContents: FC<{
 
 	useHotkeys([
 		{
-			hotkey: diffHotkeys.foldFile.hotkey,
-			callback: () =>
-				!!diffSelectionHunk && handleSetCollapsed(diffSelectionHunk.file.item.id)(true),
-			options: {
-				enabled: !!diffSelectionHunk && !collapsedItems.has(diffSelectionHunk.file.item.id),
-				conflictBehavior: "allow",
-				target: selectionScopeRef,
-				meta: diffHotkeys.foldFile.meta,
+			hotkey: diffHotkeys.toggleFoldFile.hotkey,
+			callback: () => {
+				if (!diffSelectionHunk) return;
+
+				handleSetCollapsed(diffSelectionHunk.file.item.id)(
+					!collapsedItems.has(diffSelectionHunk.file.item.id),
+				);
 			},
-		},
-		{
-			hotkey: diffHotkeys.unfoldFile.hotkey,
-			callback: () =>
-				!!diffSelectionHunk && handleSetCollapsed(diffSelectionHunk.file.item.id)(false),
 			options: {
-				enabled: !!diffSelectionHunk && collapsedItems.has(diffSelectionHunk.file.item.id),
+				// A stored selection, not the resolver's first-hunk fallback: after
+				// scrolling with nothing selected, folding the fallback would fold a
+				// file far off-screen. j/k (which stores a selection) is the way in.
+				enabled: hasStoredDiffSelection && !!diffSelectionHunk,
 				conflictBehavior: "allow",
 				target: selectionScopeRef,
-				meta: diffHotkeys.unfoldFile.meta,
+				meta: diffHotkeys.toggleFoldFile.meta,
 			},
 		},
 		{
@@ -472,16 +482,49 @@ const DiffContents: FC<{
 		else s.delete(itemId);
 
 		setCollapsedItems(s);
+
+		if (!collapsed) return;
+
+		// Folding hides the selected hunk's lines; hand the selection to the
+		// file's first hunk, which stands in for the folded file, and keep the
+		// header in view. The stored selection is read off the store rather than
+		// captured, so this callback's identity does not churn with j/k moves.
+		const stored = projectSlice.selectors.selectStoredDiffSelection(store.getState(), projectId);
+		const storedFile = stored && hunkByKey.get(hunkOperandIdentityKey(stored))?.file;
+		if (storedFile?.item.id !== itemId) return;
+
+		dispatch(
+			projectSlice.actions.selectDiff({
+				projectId,
+				selection: assert(storedFile.hunks[0]).operand,
+			}),
+		);
+		viewerRef.current?.scrollTo({ type: "item", id: itemId, align: "nearest" });
 	};
 
 	// We must change the version for updates to the collapsed property to be respected. The versions
-	// should be as stable as possible, collapsed or not, for performance.
-	const enhanceCollapsed = <T,>(item: CodeViewDiffItem<T>): CodeViewDiffItem<T> => ({
+	// should be as stable as possible, collapsed or not, for performance. The selected flag is
+	// hashed in so the header re-renders when the selection enters or leaves a folded file.
+	const enhanceCollapsed = <T,>(
+		item: CodeViewDiffItem<T>,
+		selected: boolean,
+	): CodeViewDiffItem<T> => ({
 		...item,
 		collapsed: true,
 		// We always use versions.
-		version: combineHashes(assert(item.version), 1),
+		version: combineHashes(assert(item.version), selected ? 2 : 1),
 	});
+
+	// Hoisted from the JSX so the rebuild runs when folds or the folded
+	// selection change, not on every render of this component.
+	const displayItems =
+		collapsedItems.size === 0
+			? items
+			: items.map((item) =>
+					collapsedItems.has(item.id)
+						? enhanceCollapsed(item, item.id === selectedFoldedFileId)
+						: item,
+				);
 
 	return items.length === 0 ? (
 		<p className="text-13">No changes.</p>
@@ -504,6 +547,7 @@ const DiffContents: FC<{
 						change={file.change}
 						hasDiff={item.fileDiff.hunks.length !== 0}
 						collapsed={item.collapsed ?? false}
+						selected={item.id === selectedFoldedFileId}
 						setCollapsed={handleSetCollapsed(item.id)}
 					/>
 				);
@@ -575,11 +619,7 @@ const DiffContents: FC<{
 			}}
 			onScroll={selectFileAtViewportTop}
 			className={styles.diffContents}
-			items={
-				collapsedItems.size === 0
-					? items
-					: items.map((item) => (collapsedItems.has(item.id) ? enhanceCollapsed(item) : item))
-			}
+			items={displayItems}
 			selectedLines={selectedRange}
 			onSelectedLinesChange={handleLinesSelected}
 			options={{
@@ -653,6 +693,8 @@ type DiffFileHeaderProps = {
 	change: TreeChange;
 	hasDiff: boolean;
 	collapsed: boolean;
+	/** Whether the folded file's stand-in hunk holds the diff selection. */
+	selected: boolean;
 	setCollapsed: (collapsed: boolean) => void;
 };
 
@@ -668,8 +710,7 @@ const DiffFileHeader: FC<DiffFileHeaderProps> = (p) => {
 	const directoryPath = lastSepIdx !== -1 ? p.change.path.slice(0, lastSepIdx) : null;
 	const fileName = lastSepIdx !== -1 ? p.change.path.slice(lastSepIdx + 1) : p.change.path;
 
-	const collapseHotkey = p.collapsed ? diffHotkeys.unfoldFile : diffHotkeys.foldFile;
-	const collapseLabel = collapseHotkey.meta.name;
+	const collapseLabel = p.collapsed ? "Unfold" : "Fold";
 
 	return (
 		<OperationSourceC projectId={p.projectId} source={fileOperand(p.operand)} outline="inside">
@@ -677,7 +718,11 @@ const DiffFileHeader: FC<DiffFileHeaderProps> = (p) => {
 				onContextMenu={(event) => {
 					void showNativeContextMenu(event, menuItems);
 				}}
-				className={classes(styles.fileHeader, (p.collapsed || !p.hasDiff) && styles.lone)}
+				className={classes(
+					styles.fileHeader,
+					(p.collapsed || !p.hasDiff) && styles.lone,
+					p.selected && styles.fileHeaderSelected,
+				)}
 			>
 				<Tooltip.Root>
 					<Tooltip.Trigger
@@ -690,7 +735,9 @@ const DiffFileHeader: FC<DiffFileHeaderProps> = (p) => {
 					</Tooltip.Trigger>
 					<Tooltip.Portal>
 						<Tooltip.Positioner sideOffset={4}>
-							<Tooltip.Popup render={<TooltipPopup kbd={collapseHotkey.hotkey} />}>
+							<Tooltip.Popup
+								render={<TooltipPopup kbd={diffHotkeys.toggleFoldFile.hotkey} kbdScope="diff" />}
+							>
 								{collapseLabel}
 							</Tooltip.Popup>
 						</Tooltip.Positioner>
@@ -1212,7 +1259,7 @@ const Diff: FC<{
 									viewportClassName={styles.diffFiles}
 								>
 									<FilesTree
-										data-selection-scope={"files" satisfies SelectionScope}
+										selectionScope="files"
 										onRowSelection={activateRow}
 										projectId={projectId}
 										rows={filesRows}

--- a/apps/lite/ui/src/routes/project/$id/workspace/DirectoryRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DirectoryRow.tsx
@@ -1,7 +1,11 @@
 import { FolderIcon } from "#ui/components/FolderIcon.tsx";
 import { classes } from "#ui/components/classes.ts";
+import { TooltipPopup } from "#ui/components/Tooltip.tsx";
+import { changesFileHotkeys } from "#ui/hotkeys.ts";
 import { projectSlice } from "#ui/projects/state.ts";
+import type { SelectionScope } from "#ui/selection-scopes.ts";
 import { useAppSelector } from "#ui/store.ts";
+import { Tooltip } from "@base-ui/react";
 import type { ComponentProps, FC } from "react";
 import styles from "./FilesTree.module.css";
 import rowStyles from "./Row.module.css";
@@ -24,6 +28,7 @@ export const DirectoryRow: FC<
 		canCheck: boolean;
 		checkedState: DirectoryCheckedState;
 		checkDirectory: (evt: { path: string; checked: boolean }) => void;
+		selectionScope: SelectionScope;
 	} & ComponentProps<typeof Row>
 > = ({
 	projectId,
@@ -36,6 +41,7 @@ export const DirectoryRow: FC<
 	canCheck,
 	checkedState,
 	checkDirectory,
+	selectionScope,
 	...restProps
 }) => {
 	const isDefaultMode = useAppSelector(
@@ -49,11 +55,27 @@ export const DirectoryRow: FC<
 			className={classes(restProps.className, styles.row)}
 		>
 			<TreeSteps depth={depth}>
-				<TreeStepsToggle
-					isCollapsed={isCollapsed}
-					aria-label={`${isCollapsed ? "Expand" : "Collapse"} directory ${path}`}
-					onClick={onToggleCollapsed}
-				/>
+				<Tooltip.Root disableHoverablePopup>
+					<Tooltip.Trigger
+						aria-label={`${isCollapsed ? "Expand" : "Collapse"} directory ${path}`}
+						onClick={onToggleCollapsed}
+						render={<TreeStepsToggle isCollapsed={isCollapsed} />}
+					/>
+					<Tooltip.Portal>
+						<Tooltip.Positioner sideOffset={4}>
+							<Tooltip.Popup
+								render={
+									<TooltipPopup
+										kbd={changesFileHotkeys.toggleFoldDirectory.hotkey}
+										kbdScope={selectionScope}
+									/>
+								}
+							>
+								{isCollapsed ? "Expand directory" : "Collapse directory"}
+							</Tooltip.Popup>
+						</Tooltip.Positioner>
+					</Tooltip.Portal>
+				</Tooltip.Root>
 			</TreeSteps>
 
 			{/* The folder stands where a file's type icon stands, and gives way to the

--- a/apps/lite/ui/src/routes/project/$id/workspace/FileRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/FileRow.tsx
@@ -4,6 +4,7 @@ import rowStyles from "./Row.module.css";
 import { showNativeContextMenu, showNativeMenuFromTrigger } from "#ui/native-menu.ts";
 import type { FileParent } from "#ui/operands.ts";
 import { projectSlice } from "#ui/projects/state.ts";
+import type { SelectionScope } from "#ui/selection-scopes.ts";
 import { useAppSelector } from "#ui/store.ts";
 import { Icon } from "#ui/components/Icon.tsx";
 import { classes } from "#ui/components/classes.ts";
@@ -37,6 +38,7 @@ export const FileRow: FC<
 		 * — the tree already says which directory this is. Resolved by the list.
 		 */
 		pathDisplay: "lead" | "trail" | "hidden";
+		selectionScope: SelectionScope;
 	} & Omit<ComponentProps<typeof Row>, "projectId">
 > = ({
 	item,
@@ -48,6 +50,7 @@ export const FileRow: FC<
 	checkFile,
 	depth,
 	pathDisplay,
+	selectionScope,
 	id,
 	...restProps
 }) => {
@@ -110,7 +113,14 @@ export const FileRow: FC<
 						/>
 						<Tooltip.Portal>
 							<Tooltip.Positioner sideOffset={4}>
-								<Tooltip.Popup render={<TooltipPopup kbd={changesFileHotkeys.checkFile.hotkey} />}>
+								<Tooltip.Popup
+									render={
+										<TooltipPopup
+											kbd={changesFileHotkeys.checkFile.hotkey}
+											kbdScope={selectionScope}
+										/>
+									}
+								>
 									{changesFileHotkeys.checkFile.meta.name}
 								</Tooltip.Popup>
 							</Tooltip.Positioner>

--- a/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.tsx
@@ -22,7 +22,11 @@ import { type ComponentProps, type FC, useRef } from "react";
 import styles from "./FilesTree.module.css";
 import { Row, RowLabel, RowLabelContainer } from "./Row.tsx";
 import { OperationSourceC } from "#ui/routes/project/$id/workspace/OperationSourceC.tsx";
-import { focusSelectionScope, useNavigationIndexHotkeys } from "#ui/selection-scopes.ts";
+import {
+	focusSelectionScope,
+	useNavigationIndexHotkeys,
+	type SelectionScope,
+} from "#ui/selection-scopes.ts";
 import { navigationIndexIncludes, type NavigationIndex } from "#ui/workspace/navigation-index.ts";
 import { changesFileHotkeys } from "#ui/hotkeys.ts";
 import { useHotkeys } from "@tanstack/react-hotkeys";
@@ -53,7 +57,6 @@ const useFilesTreeHotkeys = ({
 	selectedRow,
 	selectedChange,
 	toggleDirectoryCollapsed,
-	collapsedDirectories,
 }: {
 	checkRow: (evt: { path: string; shiftKey: boolean }) => void;
 	navigationIndex: NavigationIndex<string>;
@@ -66,11 +69,11 @@ const useFilesTreeHotkeys = ({
 	selectedRow: FileTreeRow<FileRowItem> | undefined;
 	selectedChange: TreeChange | null;
 	toggleDirectoryCollapsed: (path: string) => void;
-	collapsedDirectories: Record<string, true>;
 }) => {
 	const isDefaultMode = useAppSelector(
 		(state) => projectSlice.selectors.selectOutlineModeState(state, projectId)._tag === "Default",
 	);
+	const mode = useFileDisplayMode();
 	const { data: editors } = useQuery(listEditorsQueryOptions);
 	const { data: preferredEditor } = useQuery({
 		...guiSettingsQueryOptions,
@@ -87,12 +90,6 @@ const useFilesTreeHotkeys = ({
 	const selectedChangesFile = fileParent._tag === "UncommittedChanges" ? selection : null;
 	const selectedUncommittedChange =
 		fileParent._tag === "UncommittedChanges" ? selectedChange : null;
-
-	const selectedDirectory = selectedRow?._tag === "Directory" ? selectedRow : null;
-
-	// Only the two moves below want a position rather than a row, and only once a
-	// key is pressed — so the scan for it stays off the render path.
-	const rowIndex = (path: string): number => rows.findIndex((row) => row.path === path);
 
 	const absorbSelectedFile = () => {
 		if (selectedUncommittedChange === null) return;
@@ -145,30 +142,26 @@ const useFilesTreeHotkeys = ({
 		});
 	};
 
-	/** Open a collapsed directory, else step into it. A file has nowhere to go. */
-	const expandSelectedRow = () => {
-		if (selectedDirectory === null) return;
-
-		if (collapsedDirectories[selectedDirectory.path] === true) {
-			toggleDirectoryCollapsed(selectedDirectory.path);
-			return;
-		}
-
-		const child = rows[rowIndex(selectedDirectory.path) + 1];
-		if (child !== undefined && child.depth > selectedDirectory.depth) onRowSelection(child.path);
-	};
-
-	/** Close an open directory, else step out to the one this row sits in. */
-	const collapseSelectedRow = () => {
-		if (selectedDirectory !== null && collapsedDirectories[selectedDirectory.path] !== true) {
-			toggleDirectoryCollapsed(selectedDirectory.path);
-			return;
-		}
-
+	/**
+	 * A directory row folds or unfolds itself; a file row folds the directory it
+	 * sits in, handing it the selection so the selection stays visible. A file at
+	 * the tree root has nothing to fold.
+	 */
+	const toggleFoldSelectedRow = () => {
 		if (selectedRow === undefined) return;
 
-		const parent = parentDirectoryRow(rows, rowIndex(selectedRow.path));
-		if (parent !== null) onRowSelection(parent.path);
+		if (selectedRow._tag === "Directory") {
+			toggleDirectoryCollapsed(selectedRow.path);
+			return;
+		}
+
+		const parent = parentDirectoryRow(
+			rows,
+			rows.findIndex((row) => row.path === selectedRow.path),
+		);
+		if (parent === null) return;
+		onRowSelection(parent.path);
+		toggleDirectoryCollapsed(parent.path);
 	};
 
 	const canDiscardSelectedFile = selectedChange !== null && canDiscard;
@@ -255,39 +248,15 @@ const useFilesTreeHotkeys = ({
 			},
 		},
 		{
-			hotkey: "ArrowRight",
-			callback: expandSelectedRow,
+			hotkey: changesFileHotkeys.toggleFoldDirectory.hotkey,
+			callback: toggleFoldSelectedRow,
 			options: {
 				conflictBehavior: "allow",
-				enabled: selectedDirectory !== null,
+				// Folding is a view operation, so it stays available in every outline
+				// mode. Flat list mode has no directory rows, nothing to fold.
+				enabled: mode === "tree" && selectedRow !== undefined,
 				target: ref,
-			},
-		},
-		{
-			hotkey: "L",
-			callback: expandSelectedRow,
-			options: {
-				conflictBehavior: "allow",
-				enabled: selectedDirectory !== null,
-				target: ref,
-			},
-		},
-		{
-			hotkey: "ArrowLeft",
-			callback: collapseSelectedRow,
-			options: {
-				conflictBehavior: "allow",
-				enabled: selectedRow !== undefined,
-				target: ref,
-			},
-		},
-		{
-			hotkey: "H",
-			callback: collapseSelectedRow,
-			options: {
-				conflictBehavior: "allow",
-				enabled: selectedRow !== undefined,
-				target: ref,
+				meta: changesFileHotkeys.toggleFoldDirectory.meta,
 			},
 		},
 	]);
@@ -321,6 +290,8 @@ export const FilesTree: FC<
 		onRowSelection: (selection: string) => void;
 		navigationIndex: NavigationIndex<string>;
 		fileParent: FileParent;
+		/** The scope this tree's hotkeys are bound to; also stamped on the tree element. */
+		selectionScope: SelectionScope;
 		emptyLabel?: string;
 	} & ComponentProps<"div">
 > = ({
@@ -332,6 +303,7 @@ export const FilesTree: FC<
 	projectId,
 	navigationIndex,
 	fileParent,
+	selectionScope,
 	emptyLabel = "No changes.",
 	ref: refProp,
 	...props
@@ -484,12 +456,12 @@ export const FilesTree: FC<
 		selectedRow,
 		selectedChange,
 		toggleDirectoryCollapsed: onToggleDirectoryCollapsed,
-		collapsedDirectories,
 	});
 
 	return (
 		<div
 			{...props}
+			data-selection-scope={selectionScope}
 			tabIndex={0}
 			role="tree"
 			aria-activedescendant={selection !== null ? treeItemId(selection) : undefined}
@@ -526,11 +498,24 @@ export const FilesTree: FC<
 											fileCount={row.filePaths.length}
 											depth={row.depth}
 											isCollapsed={isCollapsed}
-											onToggleCollapsed={() => onToggleDirectoryCollapsed(row.path)}
+											onToggleCollapsed={() => {
+												// Collapsing over the selection hides it, and it would
+												// fall back to the first row: hand it to the directory
+												// row, as the z hotkey does. Other toggles leave the
+												// selection (and the details pane it drives) alone.
+												if (
+													!isCollapsed &&
+													selection !== null &&
+													(selection === row.path || selection.startsWith(`${row.path}/`))
+												)
+													onRowSelection(row.path);
+												onToggleDirectoryCollapsed(row.path);
+											}}
 											isSelected={isSelected}
 											canCheck={canCheck}
 											checkedState={directoryCheckedState(row.filePaths)}
 											checkDirectory={checkDirectory}
+											selectionScope={selectionScope}
 											onSelect={() => onRowSelection(row.path)}
 										/>
 									}
@@ -569,6 +554,7 @@ export const FilesTree: FC<
 												checkFile={checkFile}
 												projectId={projectId}
 												fileParent={fileParent}
+												selectionScope={selectionScope}
 												branchNameByCommitId={(commitId) =>
 													headInfoIndex?.commitContextByCommitId(commitId)?.segment.refName
 														?.displayName

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/BranchRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/BranchRow.tsx
@@ -9,6 +9,7 @@ import {
 } from "#ui/api/mutations.ts";
 import {
 	forgeInfoOptions,
+	headInfoQueryOptions,
 	listCIChecksQueryOptions,
 	listReviewsQueryOptions,
 } from "#ui/api/queries.ts";
@@ -34,7 +35,8 @@ import {
 import { branchOperand, operandEquals, type BranchOperand } from "#ui/operands.ts";
 import { projectSlice } from "#ui/projects/state.ts";
 import { focusSelectionScope } from "#ui/selection-scopes.ts";
-import { useAppDispatch, useAppSelector } from "#ui/store.ts";
+import { getHeadInfoIndex } from "#ui/api/ref-info.ts";
+import { useAppDispatch, useAppSelector, useAppStore } from "#ui/store.ts";
 import { prForgeUrl } from "#ui/pr.ts";
 import { Badge, type BadgeVariant } from "#ui/components/Badge.tsx";
 import {
@@ -46,6 +48,7 @@ import {
 	RowToolbar,
 } from "../Row.tsx";
 import { getRowButtonClassName } from "../Row-utils.ts";
+import { toggleFoldedSegment } from "./fold.ts";
 import { InlineEditor } from "./InlineEditor.tsx";
 import { insertBlankCommitMenuItem } from "./insertBlankCommitMenuItem.ts";
 import { ItemRow } from "./ItemRow.tsx";
@@ -127,6 +130,10 @@ export const BranchRow: FC<
 	...restProps
 }) => {
 	const { data: forgeInfo } = useQuery(forgeInfoOptions(projectId));
+	const { data: headInfoIndex } = useQuery({
+		...headInfoQueryOptions(projectId),
+		select: getHeadInfoIndex,
+	});
 	const { data: reviews } = useQuery({
 		...listReviewsQueryOptions({ projectId, cacheConfig: "noCache" }),
 		enabled: !!forgeInfo?.capabilities.prService,
@@ -146,6 +153,7 @@ export const BranchRow: FC<
 		pullRequest !== null ? forgeInfo && ciChecksSummaryUrl(pullRequest, forgeInfo) : null;
 
 	const dispatch = useAppDispatch();
+	const store = useAppStore();
 	const branchOperandV: BranchOperand = {
 		branchRef: refName.fullNameBytes,
 	};
@@ -315,7 +323,39 @@ export const BranchRow: FC<
 			? "Force Push Branch"
 			: "Push Branch";
 
+	const foldLabel = isFolded ? "Unfold commits" : "Fold commits";
+	const toggleFolded = () => {
+		// Hand the selection over only when folding would hide it — the selected
+		// commit sits in this segment. Unrelated selections (and the details pane
+		// they drive) stay put.
+		const stored = projectSlice.selectors.selectPrimaryOutlineSelection(
+			store.getState(),
+			projectId,
+		);
+		const storedSegmentRef =
+			stored?._tag === "Commit"
+				? headInfoIndex?.commitContextByCommitId(stored.commitId)?.segment.refName
+				: undefined;
+		const foldHidesSelection =
+			!isFolded &&
+			storedSegmentRef != null &&
+			decodeBytes(storedSegmentRef.fullNameBytes) === branchRef;
+
+		toggleFoldedSegment(dispatch, {
+			projectId,
+			branchRefBytes: refName.fullNameBytes,
+			select: foldHidesSelection,
+		});
+	};
+
 	const menuItems: Array<NativeMenuItem> = [
+		nativeMenuItem({
+			label: isFolded ? "Unfold Commits" : "Fold Commits",
+			enabled: commitCount > 0,
+			accelerator: toElectronAccelerator(outlineHotkeys.toggleFoldBranch.hotkey),
+			onSelect: toggleFolded,
+		}),
+		nativeMenuSeparator,
 		nativeMenuItem({
 			label: pushMenuLabel,
 			enabled: !workspaceBranchAndAncestorsPushDisabled,
@@ -389,19 +429,37 @@ export const BranchRow: FC<
 			}}
 		>
 			{commitCount > 0 ? (
-				<RowFoldToggle
-					folded={isFolded}
-					aria-label={isFolded ? "Unfold commits" : "Fold commits"}
-					onClick={() =>
-						dispatch(projectSlice.actions.toggleSegmentFolded({ projectId, branchRef }))
-					}
-					glyph={
-						// The glyph describes where the branch sits in the stack, so it
-						// does not change with fold state.
-						<GraphSegment glyph={isTopSegment ? "forkRight" : "joinRight"} status={graphStatus} />
-					}
-					foldedIndicator={<GraphSegment glyph="group" status={graphStatus} />}
-				/>
+				<Tooltip.Root>
+					<Tooltip.Trigger
+						aria-label={foldLabel}
+						onClick={toggleFolded}
+						render={
+							<RowFoldToggle
+								folded={isFolded}
+								glyph={
+									// The glyph describes where the branch sits in the stack, so it
+									// does not change with fold state.
+									<GraphSegment
+										glyph={isTopSegment ? "forkRight" : "joinRight"}
+										status={graphStatus}
+									/>
+								}
+								foldedIndicator={<GraphSegment glyph="group" status={graphStatus} />}
+							/>
+						}
+					/>
+					<Tooltip.Portal>
+						<Tooltip.Positioner sideOffset={4}>
+							<Tooltip.Popup
+								render={
+									<TooltipPopup kbd={outlineHotkeys.toggleFoldBranch.hotkey} kbdScope="outline" />
+								}
+							>
+								{foldLabel}
+							</Tooltip.Popup>
+						</Tooltip.Positioner>
+					</Tooltip.Portal>
+				</Tooltip.Root>
 			) : (
 				<GraphSegment glyph={isTopSegment ? "forkRight" : "joinRight"} status={graphStatus} />
 			)}
@@ -524,6 +582,7 @@ export const BranchRow: FC<
 													render={
 														<TooltipPopup
 															kbd={outlineHotkeys.workspaceBranchAndAncestorsPush.hotkey}
+															kbdScope="outline"
 														/>
 													}
 												>

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/CommitRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/CommitRow.tsx
@@ -374,7 +374,9 @@ export const CommitRow: FC<
 					/>
 					<Tooltip.Portal>
 						<Tooltip.Positioner sideOffset={4}>
-							<Tooltip.Popup render={<TooltipPopup kbd={outlineHotkeys.checkCommit.hotkey} />}>
+							<Tooltip.Popup
+								render={<TooltipPopup kbd={outlineHotkeys.checkCommit.hotkey} kbdScope="outline" />}
+							>
 								{outlineHotkeys.checkCommit.meta.name}
 							</Tooltip.Popup>
 						</Tooltip.Positioner>

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
@@ -337,7 +337,7 @@ const UncommittedChanges: FC<{
 				viewportClassName={styles.uncommittedChangesTree}
 			>
 				<FilesTree
-					data-selection-scope={"uncommitted-files" satisfies SelectionScope}
+					selectionScope="uncommitted-files"
 					onFocus={() =>
 						dispatch(
 							projectSlice.actions.setDetailsSelectionScope({

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/fold.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/fold.ts
@@ -1,0 +1,37 @@
+import { decodeBytes } from "#ui/api/bytes.ts";
+import { branchOperand } from "#ui/operands.ts";
+import { projectSlice } from "#ui/projects/state.ts";
+import type { AppDispatch } from "#ui/store.ts";
+
+/**
+ * Fold or unfold a branch segment. Every fold surface (chevron click, context
+ * menu, z hotkey) goes through here so the policy cannot diverge.
+ *
+ * With `select`, the branch row also takes the outline selection. Callers pass
+ * it when the fold hides the selected commit (it would otherwise fall out of
+ * the navigation index, making selection jump to the top of the outline);
+ * unfolds and folds of unrelated segments leave the selection alone.
+ */
+export const toggleFoldedSegment = (
+	dispatch: AppDispatch,
+	{
+		projectId,
+		branchRefBytes,
+		select,
+	}: { projectId: string; branchRefBytes: Array<number>; select: boolean },
+) => {
+	if (select) {
+		dispatch(
+			projectSlice.actions.selectOutline({
+				projectId,
+				selection: branchOperand({ branchRef: branchRefBytes }),
+			}),
+		);
+	}
+	dispatch(
+		projectSlice.actions.toggleSegmentFolded({
+			projectId,
+			branchRef: decodeBytes(branchRefBytes),
+		}),
+	);
+};

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/hotkeys.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/hotkeys.ts
@@ -32,6 +32,7 @@ import { type UseHotkeyDefinition, useHotkeys } from "@tanstack/react-hotkeys";
 import { useQuery } from "@tanstack/react-query";
 import { Match } from "effect";
 import type { RefObject } from "react";
+import { toggleFoldedSegment } from "./fold.ts";
 import { selectAfterDiscardedCommit } from "./selectAfterDiscardedCommit.ts";
 import {
 	canRemoveBranchReference,
@@ -88,17 +89,23 @@ export const useOutlineTreeHotkeys = ({
 		(state) => projectSlice.selectors.selectOutlineModeState(state, projectId)._tag === "Default",
 	);
 
-	const selectionStack = Match.value(selection).pipe(
+	const selectionContext = Match.value(selection).pipe(
 		Match.tags({
-			Branch: (branch) => headInfoIndex?.branchContextByRefBytes(branch.branchRef)?.stack,
-			Commit: (commit) => headInfoIndex?.commitContextByCommitId(commit.commitId)?.stack,
+			Branch: (branch) => headInfoIndex?.branchContextByRefBytes(branch.branchRef),
+			Commit: (commit) => headInfoIndex?.commitContextByCommitId(commit.commitId),
 		}),
 		Match.orElse(() => undefined),
 	);
+	const selectionStack = selectionContext?.stack;
 	const selectedBranchSegment =
-		selection?._tag === "Branch"
-			? headInfoIndex?.branchContextByRefBytes(selection.branchRef)?.segment
-			: undefined;
+		selection?._tag === "Branch" ? selectionContext?.segment : undefined;
+	// Only a segment with a branch reference and commits to hide can be folded.
+	const foldableSegmentRef =
+		selectionContext !== undefined &&
+		selectionContext.segment.refName !== null &&
+		selectionContext.segment.commits.length > 0
+			? selectionContext.segment.refName
+			: null;
 
 	const selectedCommit =
 		selection?._tag === "Commit"
@@ -307,6 +314,19 @@ export const useOutlineTreeHotkeys = ({
 		});
 	};
 
+	const toggleFoldSelected = () => {
+		if (foldableSegmentRef === null) return;
+
+		toggleFoldedSegment(dispatch, {
+			projectId,
+			branchRefBytes: foldableSegmentRef.fullNameBytes,
+			// A selected commit implies the segment is unfolded, so this is the
+			// folding case and the selection needs the hand-off; a selected branch
+			// row keeps its selection either way.
+			select: selection?._tag === "Commit",
+		});
+	};
+
 	const uncommitSelectedCommit = () => {
 		if (!selection || selection._tag !== "Commit") return;
 
@@ -318,12 +338,7 @@ export const useOutlineTreeHotkeys = ({
 		});
 	};
 
-	const selectedSegmentIndex =
-		selection?._tag === "Branch"
-			? headInfoIndex?.branchContextByRefBytes(selection.branchRef)?.segmentIndex
-			: selection?._tag === "Commit"
-				? headInfoIndex?.commitContextByCommitId(selection.commitId)?.segmentIndex
-				: undefined;
+	const selectedSegmentIndex = selectionContext?.segmentIndex;
 
 	const selectedPushContext =
 		selectionStack && selectedSegmentIndex !== undefined
@@ -547,6 +562,16 @@ export const useOutlineTreeHotkeys = ({
 				enabled: defaultOutlineHotkeysEnabled && isSelectedCommit && !isCommitUncommitPending,
 				target: ref,
 				meta: outlineHotkeys.uncommitCommit.meta,
+			},
+		},
+		{
+			hotkey: outlineHotkeys.toggleFoldBranch.hotkey,
+			callback: toggleFoldSelected,
+			options: {
+				conflictBehavior: "allow",
+				enabled: defaultOutlineHotkeysEnabled && foldableSegmentRef !== null,
+				target: ref,
+				meta: outlineHotkeys.toggleFoldBranch.meta,
 			},
 		},
 		{

--- a/apps/lite/ui/src/routes/project/$id/workspace/TreeSteps.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/TreeSteps.tsx
@@ -35,7 +35,7 @@ export const TreeStepsToggle: FC<{ isCollapsed: boolean } & ComponentProps<"butt
 	<button
 		type="button"
 		// The tree moves with the arrow keys rather than Tab, and the same fold is
-		// on ArrowLeft/ArrowRight, so this stays out of the tab order.
+		// on the z hotkey, so this stays out of the tab order.
 		tabIndex={-1}
 		{...props}
 		aria-expanded={!isCollapsed}

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
@@ -106,6 +106,22 @@ const useWorkspaceHotkeys = (projectId: string) => {
 		projectId,
 	});
 
+	// Shared by the arrow keys and their h/l aliases so the pairs cannot diverge.
+	const focusPane = (offset: -1 | 1) => {
+		focusHorizontalSelectionScope({
+			filesVisible,
+			offset,
+			outlineSelectionScope,
+			outlineVisible,
+		});
+	};
+	const focusPaneLeft = () => {
+		focusPane(-1);
+	};
+	const focusPaneRight = () => {
+		focusPane(1);
+	};
+
 	useHotkeys([
 		{
 			hotkey: globalHotkeys.redo.hotkey,
@@ -193,28 +209,30 @@ const useWorkspaceHotkeys = (projectId: string) => {
 		),
 		{
 			hotkey: workspaceHotkeys.focusHorizontalSelectionScopeLeft.hotkey,
-			callback: () => {
-				focusHorizontalSelectionScope({
-					filesVisible,
-					offset: -1,
-					outlineSelectionScope,
-					outlineVisible,
-				});
+			callback: focusPaneLeft,
+			options: {
+				conflictBehavior: "allow",
+				meta: workspaceHotkeys.focusHorizontalSelectionScopeLeft.meta,
 			},
+		},
+		{
+			hotkey: "H",
+			callback: focusPaneLeft,
 			options: {
 				conflictBehavior: "allow",
 			},
 		},
 		{
 			hotkey: workspaceHotkeys.focusHorizontalSelectionScopeRight.hotkey,
-			callback: () => {
-				focusHorizontalSelectionScope({
-					filesVisible,
-					offset: 1,
-					outlineSelectionScope,
-					outlineVisible,
-				});
+			callback: focusPaneRight,
+			options: {
+				conflictBehavior: "allow",
+				meta: workspaceHotkeys.focusHorizontalSelectionScopeRight.meta,
 			},
+		},
+		{
+			hotkey: "L",
+			callback: focusPaneRight,
 			options: {
 				conflictBehavior: "allow",
 			},

--- a/apps/lite/ui/src/routes/project/$id/workspace/diff-view.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/diff-view.ts
@@ -1,3 +1,4 @@
+import { assert } from "#ui/assert.ts";
 import { hash } from "#ui/hash.ts";
 import {
 	contiguousSelectionsFromHunk,
@@ -13,7 +14,7 @@ import {
 	type HunkOperand,
 	weakFileIdentityKey,
 } from "#ui/operands.ts";
-import type { NavigationIndex } from "#ui/workspace/navigation-index.ts";
+import { buildIndexByKey, type NavigationIndex } from "#ui/workspace/navigation-index.ts";
 import type { TreeChange, UnifiedPatch } from "@gitbutler/but-sdk";
 import {
 	processFile,
@@ -221,4 +222,29 @@ export const getDiffView = ({ fileParent, changes, treeChangeDiffs }: DiffViewDe
 		hunkByKey,
 		navigationIndex,
 	};
+};
+
+/**
+ * The navigation index with folded files' hunks removed — except each folded
+ * file's first hunk, which stands in for the file the way a folded branch
+ * keeps its branch row. j/k then stop once per folded file instead of walking
+ * its hidden hunks, and z can unfold from the keyboard.
+ */
+export const withoutFoldedHunks = (
+	navigationIndex: NavigationIndex<HunkOperand>,
+	hunkByKey: DiffView["hunkByKey"],
+	collapsedItems: Set<string>,
+): NavigationIndex<HunkOperand> => {
+	if (collapsedItems.size === 0) return navigationIndex;
+
+	const items = navigationIndex.items.filter((hunk) => {
+		const key = hunkOperandIdentityKey(hunk);
+		const file = hunkByKey.get(key)?.file;
+		return (
+			file === undefined ||
+			!collapsedItems.has(file.item.id) ||
+			hunkOperandIdentityKey(assert(file.hunks[0]).operand) === key
+		);
+	});
+	return { items, indexByKey: buildIndexByKey(items, hunkOperandIdentityKey) };
 };

--- a/apps/lite/ui/src/selection-scopes.ts
+++ b/apps/lite/ui/src/selection-scopes.ts
@@ -26,11 +26,34 @@ const selectionScopeChildren: Partial<Record<SelectionScope, Set<SelectionScope>
 const isSelectionScope = (id: string): id is SelectionScope => allSelectionScopes.has(id);
 
 export const getFocusedSelectionScope = (activeElement: Element | null): SelectionScope | null => {
-	const selectionScope = activeElement?.matches("[data-selection-scope]")
-		? activeElement.getAttribute("data-selection-scope")
-		: undefined;
+	// closest() so focus on a control inside a pane (a row button, the diff
+	// scroller) still reports that pane's scope.
+	const selectionScope = activeElement
+		?.closest("[data-selection-scope]")
+		?.getAttribute("data-selection-scope");
 	if (selectionScope == undefined) return null;
 	return isSelectionScope(selectionScope) ? selectionScope : null;
+};
+
+/** Whether keyboard focus currently sits inside the given selection scope. */
+export const isFocusWithinSelectionScope = (scope: SelectionScope): boolean =>
+	document.activeElement?.closest(`[data-selection-scope="${scope}"]`) != null;
+
+/**
+ * Whether bare-arrow pane navigation may act for the current focus. Widgets
+ * with their own arrow keys keep them: anything outside every pane (dialogs,
+ * toasts), toolbars (which rove with arrows wherever they live), and the
+ * details header chrome — focus that resolves to the "details" scope itself
+ * rather than one of its child panes. Body counts as navigable so the keys
+ * can enter a pane when nothing holds focus.
+ */
+const paneNavigationAllowed = (): boolean => {
+	const activeElement = document.activeElement;
+	if (activeElement === null || activeElement === document.body) return true;
+	if (activeElement.closest('[role="toolbar"]') !== null) return false;
+
+	const scope = getFocusedSelectionScope(activeElement);
+	return scope !== null && scope !== "details";
 };
 
 const findFocusTarget = (parent: ParentNode, scope: SelectionScope): HTMLElement | null => {
@@ -63,31 +86,41 @@ export const focusHorizontalSelectionScope = ({
 	outlineSelectionScope: Extract<SelectionScope, "uncommitted-files" | "outline"> | null;
 	outlineVisible: boolean;
 }) => {
+	if (!paneNavigationAllowed()) return;
+
 	const currentSelectionScope = getFocusedSelectionScope(document.activeElement);
 	const currentOutlineSelectionScope =
 		currentSelectionScope === "uncommitted-files" || currentSelectionScope === "outline"
 			? currentSelectionScope
 			: outlineSelectionScope;
 
+	// "details" resolves to whichever of its child scopes is mounted (diff or
+	// pr tab), so the rightmost slot works on both tabs.
 	const orderedSelectionScopes: Array<SelectionScope> = [
 		...(outlineVisible ? [currentOutlineSelectionScope ?? "outline"] : []),
 		...(filesVisible ? (["files"] satisfies Array<SelectionScope>) : []),
-		"diff",
+		"details",
 	];
+	const positionScope =
+		currentSelectionScope === "diff" || currentSelectionScope === "pr"
+			? "details"
+			: currentSelectionScope;
 
-	if (currentSelectionScope === null || !orderedSelectionScopes.includes(currentSelectionScope)) {
+	if (positionScope === null || !orderedSelectionScopes.includes(positionScope)) {
 		const nextSelectionScope: SelectionScope | undefined =
 			offset === 1 ? orderedSelectionScopes.at(0) : orderedSelectionScopes.at(-1);
 
 		if (nextSelectionScope !== undefined) focusSelectionScope(nextSelectionScope);
 	} else {
-		const nextIndex = orderedSelectionScopes.indexOf(currentSelectionScope) + offset;
+		const nextIndex = orderedSelectionScopes.indexOf(positionScope) + offset;
 		const nextSelectionScope = nextIndex < 0 ? undefined : orderedSelectionScopes.at(nextIndex);
 		if (nextSelectionScope !== undefined) focusSelectionScope(nextSelectionScope);
 	}
 };
 
 export const focusVerticalSelectionScope = (offset: -1 | 1) => {
+	if (!paneNavigationAllowed()) return;
+
 	const currentSelectionScope = getFocusedSelectionScope(document.activeElement);
 	const orderedSelectionScopes: Array<SelectionScope> = ["uncommitted-files", "outline"];
 	const currentIndex =


### PR DESCRIPTION
Folding and pane navigation for Lite, built around single-key spatial control:

- **`z` folds the thing you're on, everywhere**: the selected branch in the outline, the selected directory in the file trees, and the selected file's diff in the preview (replacing the `⌘⌥[` / `⌘⌥]` pair). Fold chevrons teach the shortcut in a hover tooltip, and the branch context menu carries the action too.
- **Plain `←`/`→` (and `h`/`l`) move focus between panes**, replacing `⌘⌥←`/`⌘⌥→`. The keys are free because the file tree's fold moved to `z`. Bare arrows only navigate when focus is inside a pane — dialogs, toasts, and toolbars keep their arrow keys — and the rightmost slot resolves to whichever details tab is mounted (diff or PR).
- **Folding never strands the selection**: when a fold would hide the selected row, the selection moves to the folded row (branch header, directory row, or the diff file's first hunk, which stays in the navigation index as a stand-in). Unfolding and unrelated folds leave the selection — and the details pane it drives — alone. A folded diff file's header shows a slim selection bar (placeholder styling, absolute-positioned; dims when the pane is blurred like other selections).
- **Tooltip shortcut chips are now honest**: scoped-hotkey chips (fold, check, push) render only while the pane that owns the hotkey has focus, since the key does nothing from elsewhere. `FilesTree` takes its selection scope as a typed prop instead of a magic data attribute.

One deliberate delta from the recent tree-view redesign (#15260): the directory chevron selects the directory when collapsing over the current selection — without it, the hidden selection falls back to the first row and the details pane jumps. All other chevron clicks leave selection untouched.

Known follow-ups, intentionally out of scope: the Branches tab's fold toggle has no `z` binding yet (separate reducer), stack-level fold-all doesn't hand off selection (pre-existing), and wide diffs lose native horizontal arrow scrolling to pane navigation (accepted tradeoff).