### PR TITLE
Preserve empty branches during upstream integration

### DIFF
--- a/crates/but-workspace/src/upstream_integration.rs
+++ b/crates/but-workspace/src/upstream_integration.rs
@@ -208,10 +208,32 @@ pub fn integrate_upstream_with_hints<'ws, 'meta, M: RefMetadata>(
         .map(|update| Ok((update.selector.to_selector(&editor)?, update.kind)))
         .collect::<Result<Vec<_>, anyhow::Error>>()?;
 
-    // Empty projected branches are selected by reference rather than by commit. Include the
-    // checked-out reference in the collected graph only for that API shape, leaving ordinary
-    // non-empty direct checkouts on the existing commit-based path.
-    let direct_checkout_update_ref_selector =
+    let direct_checkout_head_ref_selector = direct_checkout_head_ref_name
+        .as_ref()
+        .map(|head_ref_name| head_ref_name.to_selector(&editor))
+        .transpose()?;
+    let mut direct_checkout_head_shares_tip_with_local_ref = false;
+    if let Some(head_ref_selector) = direct_checkout_head_ref_selector {
+        for selector in editor.step_references(head_commit_id)? {
+            if selector != head_ref_selector
+                && matches!(
+                    editor.lookup_step(selector)?,
+                    Step::Reference { refname, .. }
+                        if refname.category() == Some(gix::refs::Category::LocalBranch)
+                )
+            {
+                direct_checkout_head_shares_tip_with_local_ref = true;
+                break;
+            }
+        }
+    }
+
+    // Select an empty checked-out branch by reference so same-tip local refs retain their distinct
+    // identities. A direct reference update has the same requirement; ordinary non-empty direct
+    // checkouts stay on the existing commit-based path.
+    let direct_checkout_ref_selector = if direct_checkout_head_shares_tip_with_local_ref {
+        direct_checkout_head_ref_selector
+    } else {
         direct_checkout_head_ref_name
             .as_ref()
             .and_then(|head_ref_name| {
@@ -226,7 +248,8 @@ pub fn integrate_upstream_with_hints<'ws, 'meta, M: RefMetadata>(
                         }
                         _ => None,
                     })
-            });
+            })
+    };
 
     let target_ref_selector = target_ref.ref_name.to_selector(&editor)?;
     let target_sha_selector = target_sha.to_selector(&editor)?;
@@ -239,7 +262,7 @@ pub fn integrate_upstream_with_hints<'ws, 'meta, M: RefMetadata>(
     let mut stacks = collect_stacks(
         head_commit,
         head_is_workspace_commit,
-        direct_checkout_update_ref_selector,
+        direct_checkout_ref_selector,
         &editor,
         from_target_sha,
         from_target_ref,
@@ -516,7 +539,7 @@ pub fn integrate_upstream_with_hints<'ws, 'meta, M: RefMetadata>(
 fn collect_stacks<'ws, 'meta, M: RefMetadata>(
     head_commit: gix::Commit<'_>,
     head_is_workspace_commit: bool,
-    direct_checkout_update_ref_selector: Option<Selector>,
+    direct_checkout_ref_selector: Option<Selector>,
     editor: &Editor<'ws, 'meta, M>,
     from_target_sha: HashSet<Selector>,
     from_target_ref: HashSet<Selector>,
@@ -538,7 +561,7 @@ fn collect_stacks<'ws, 'meta, M: RefMetadata>(
             })
             .collect()
     } else {
-        let c = match direct_checkout_update_ref_selector {
+        let c = match direct_checkout_ref_selector {
             Some(selector) => selector,
             None => editor.select_commit(head_commit.id)?,
         };

--- a/crates/but-workspace/tests/fixtures/scenario/merged-branch-below-empty-branch-direct-checkout.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/merged-branch-below-empty-branch-direct-checkout.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+git init
+
+commit-file base
+
+git checkout -b bottom
+commit-file bottom
+setup_remote_tracking bottom
+
+git checkout -b top
+
+git checkout main
+git merge --no-ff -m "merge bottom" bottom
+setup_target_to_match_main
+
+git checkout top

--- a/crates/but-workspace/tests/workspace/upstream_integration.rs
+++ b/crates/but-workspace/tests/workspace/upstream_integration.rs
@@ -2651,6 +2651,61 @@ fn empty_branch_above_integrated_branch_is_preserved() -> Result<()> {
 }
 
 #[test]
+fn integrated_bottom_under_empty_direct_checkout_is_removed_and_top_is_preserved() -> Result<()> {
+    let (_tmp, repo, mut meta, _description) = named_writable_scenario_with_description(
+        "merged-branch-below-empty-branch-direct-checkout",
+    )?;
+    let target_sha = repo.rev_parse_single("main^")?.detach();
+    let target_tip = repo.rev_parse_single("origin/main")?.detach();
+    let bottom_tip = repo.rev_parse_single("bottom")?.detach();
+    let top_tip = repo.rev_parse_single("top")?.detach();
+    assert_eq!(
+        top_tip, bottom_tip,
+        "the checked-out top branch should initially be empty above bottom"
+    );
+
+    let project_meta = target_project_meta("refs/remotes/origin/main", target_sha)?;
+    let graph = but_graph::Graph::from_head(
+        &repo,
+        &meta,
+        project_meta.clone(),
+        Options {
+            extra_target_commit_id: Some(target_tip),
+            ..Options::limited()
+        },
+    )?;
+    let mut workspace = graph.into_workspace()?;
+    let out = integrate_upstream(
+        &mut workspace,
+        &mut meta,
+        project_meta,
+        &repo,
+        vec![BottomUpdate {
+            kind: BottomUpdateKind::Rebase,
+            selector: RelativeTo::Commit(bottom_tip),
+        }],
+    )?;
+    out.rebase.materialize(Default::default())?;
+
+    assert!(
+        repo.try_find_reference("bottom")?.is_none(),
+        "the integrated bottom branch should be deleted"
+    );
+    assert_eq!(
+        repo.find_reference("top")?.id(),
+        target_tip,
+        "the empty top branch should advance to the target tip"
+    );
+    assert_eq!(
+        repo.head_name()?,
+        Some(gix::refs::FullName::try_from("refs/heads/top")?),
+        "the empty top branch should remain checked out"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn orphan_reparent_same_target_tip_keeps_single_parent() -> Result<()> {
     let (_tmp, repo, mut meta, _description) =
         named_writable_scenario_with_description("fully-integrated-single-branch")?;

--- a/e2e/playwright/tests/singleBranch/upstreamIntegration.spec.ts
+++ b/e2e/playwright/tests/singleBranch/upstreamIntegration.spec.ts
@@ -1,4 +1,8 @@
-import { expectCurrentBranchChip, openSingleBranchWorkspace } from "./helpers.ts";
+import {
+	createDependentBranch,
+	expectCurrentBranchChip,
+	openSingleBranchWorkspace,
+} from "./helpers.ts";
 import { assertBranch, assertCleanWorktree, assertCommitSubjects } from "../../src/branch.ts";
 import { test } from "../../src/test.ts";
 import {
@@ -14,6 +18,8 @@ import { execFileSync } from "node:child_process";
 
 const FULLY_INTEGRATED_BRANCH = "fully-integrated-branch";
 const EMPTY_INTEGRATED_BRANCH = "empty-integrated-branch";
+const EMPTY_TOP_BRANCH = "empty-top-branch";
+const INTEGRATED_BRANCH_UNDER_EMPTY_TOP = "integrated-branch-under-empty-top";
 const LOCAL_ONLY_EMPTY_BRANCH = "local-only-empty-branch";
 const PARTIAL_STACK_BASE = "partial-stack-base";
 const PARTIAL_STACK_TOP = "partial-stack-top";
@@ -200,6 +206,45 @@ test("preserves an empty local-only checked-out branch while advancing it", asyn
 	await assertBranch(LOCAL_ONLY_EMPTY_BRANCH, localClone);
 	await expectCurrentBranchChip(page, LOCAL_ONLY_EMPTY_BRANCH);
 	await expectBranchTipToBeOriginMaster(localClone, LOCAL_ONLY_EMPTY_BRANCH);
+	await assertCleanWorktree(localClone);
+	await expectNoErrorToast(page);
+});
+
+test("keeps an empty top branch checked out when its bottom branch is integrated", async ({
+	page,
+	gitbutler,
+}) => {
+	await gitbutler.runScript("project-in-single-branch-upstream-integration.sh", [
+		"empty-top-over-integrated",
+	]);
+	await openSingleBranchWorkspace(page);
+
+	const localClone = gitbutler.pathInWorkdir("local-clone");
+	await assertBranch(INTEGRATED_BRANCH_UNDER_EMPTY_TOP, localClone);
+	await expectCurrentBranchChip(page, INTEGRATED_BRANCH_UNDER_EMPTY_TOP);
+	await expect(commitRow(page, "integrated-under-empty-top: second commit")).toBeVisible();
+
+	await createDependentBranch(page, EMPTY_TOP_BRANCH);
+	await assertBranch(EMPTY_TOP_BRANCH, localClone);
+	await expectCurrentBranchChip(page, EMPTY_TOP_BRANCH);
+	await expect(getByTestId(page, "branch-card")).toHaveCount(2);
+	expect(git(localClone, ["rev-parse", EMPTY_TOP_BRANCH])).toBe(
+		git(localClone, ["rev-parse", INTEGRATED_BRANCH_UNDER_EMPTY_TOP]),
+	);
+
+	await gitbutler.runScript("merge-upstream-branch-to-base.sh", [
+		INTEGRATED_BRANCH_UNDER_EMPTY_TOP,
+	]);
+	await syncAndIntegrateWorkspace(page);
+
+	await expectLocalBranchNotToExist(localClone, INTEGRATED_BRANCH_UNDER_EMPTY_TOP);
+	await assertBranch(EMPTY_TOP_BRANCH, localClone);
+	await expectCurrentBranchChip(page, EMPTY_TOP_BRANCH);
+	await expect(getByTestId(page, "branch-card")).toHaveCount(1);
+	await expect(getByTestId(page, "branch-card")).toContainText(EMPTY_TOP_BRANCH);
+	await expectBranchTipToBeOriginMaster(localClone, EMPTY_TOP_BRANCH);
+	await expect(commitRow(page, "integrated-under-empty-top: first commit")).toHaveCount(0);
+	await expect(commitRow(page, "integrated-under-empty-top: second commit")).toHaveCount(0);
 	await assertCleanWorktree(localClone);
 	await expectNoErrorToast(page);
 });


### PR DESCRIPTION
## Summary

- preserve an empty checked-out top branch when its integrated bottom branch is removed
- retain distinct branch identities when multiple local branches share the direct-checkout tip
- add Rust fixture/regression coverage and a single-branch end-to-end regression

## Root cause

Direct-checkout stack collection started from the checked-out commit. When the empty top branch and its bottom branch pointed to the same commit, that commit-based selection collapsed both local refs into one identity. Upstream integration then treated the whole stack as integrated and replaced the checked-out branch.

The collection now starts from the checked-out branch reference when its tip is shared with another local branch. This preserves the empty top branch identity while allowing the selected integrated bottom branch to be deleted and the top branch to advance to the target tip.
