### PR TITLE
Support ad-hoc commits on new branches

### DIFF
--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use anyhow::Context as _;
 use but_api::{
     WorkspaceState,
@@ -9,6 +11,7 @@ use but_core::{
     sync::{RepoExclusive, RepoExclusiveGuard},
 };
 use but_ctx::Context;
+use but_graph::workspace::WorkspaceKind;
 use but_rebase::graph_rebase::mutate::{InsertSide, RelativeTo};
 use but_transaction::{IntermediateCommitCreateResult, Transaction};
 use but_workspace::{RefInfo, branch::create_reference::Anchor, commit::ChangeSource};
@@ -272,6 +275,7 @@ pub fn run(
     commit_selection: CommitSelection,
     reword_op: CommitMessageSource,
 ) -> anyhow::Result<(CommitOutcome, WorkspaceState)> {
+    let checkout_after_create = commit_op.checkout_after_create();
     let changes = {
         let context_lines = ctx.settings.context_lines;
         let (repo, ..) = ctx.workspace_and_db_mut_with_perm(perm.read_permission())?;
@@ -323,6 +327,10 @@ pub fn run(
         },
     )
     .map_err(|err| rejection::explain_after_rollback(ctx, perm, "commit", rejection_target, err))?;
+
+    if checkout_after_create && let Some(BranchNameTarget::New(branch_name)) = &branch_name {
+        but_api::branch::branch_checkout_with_perm(ctx, branch_name.clone(), perm)?;
+    }
 
     Ok((
         CommitOutcome {
@@ -381,6 +389,7 @@ pub fn route_commit_operation(
     target: CommitOperationTargetIsh,
     merged: &MergedUpstream,
 ) -> Result<CommitOperation, RouteCommitOperationError> {
+    let stack_on_head = matches!(ws.kind, WorkspaceKind::AdHoc);
     match target {
         CommitOperationTargetIsh::Above(cli_id) => {
             let side = Side::Above;
@@ -415,12 +424,16 @@ pub fn route_commit_operation(
                 Ok(CommitOperation::CommitToNewBranch(
                     CommitToNewBranchOperation {
                         branch_name: Some(branch_name),
+                        stack_on_head,
                     },
                 ))
             }
         }
         CommitOperationTargetIsh::UnstackedCannedBranch => Ok(CommitOperation::CommitToNewBranch(
-            CommitToNewBranchOperation { branch_name: None },
+            CommitToNewBranchOperation {
+                branch_name: None,
+                stack_on_head,
+            },
         )),
         CommitOperationTargetIsh::Default => {
             // Branches that have landed upstream are not sensible default targets;
@@ -438,7 +451,10 @@ pub fn route_commit_operation(
 
             match &stacks[..] {
                 [] => Ok(CommitOperation::CommitToNewBranch(
-                    CommitToNewBranchOperation { branch_name: None },
+                    CommitToNewBranchOperation {
+                        branch_name: None,
+                        stack_on_head,
+                    },
                 )),
                 [stack] => {
                     let ref_info = stack
@@ -494,7 +510,10 @@ pub fn route_commit_operation(
                             }))
                         }
                         PickerItem::NewStack => Ok(CommitOperation::CommitToNewBranch(
-                            CommitToNewBranchOperation { branch_name: None },
+                            CommitToNewBranchOperation {
+                                branch_name: None,
+                                stack_on_head,
+                            },
                         )),
                     }
                 }
@@ -573,6 +592,16 @@ pub enum CommitOperation {
 }
 
 impl CommitOperation {
+    pub(crate) fn checkout_after_create(&self) -> bool {
+        matches!(
+            self,
+            CommitOperation::CommitToNewBranch(CommitToNewBranchOperation {
+                stack_on_head: true,
+                ..
+            })
+        )
+    }
+
     /// What the operation targets, for explaining rejected changes after a
     /// rollback.
     fn rejection_target(&self) -> rejection::Target {
@@ -608,6 +637,7 @@ impl CommitOperation {
 
 pub struct CommitToNewBranchOperation {
     pub branch_name: Option<FullName>,
+    pub stack_on_head: bool,
 }
 
 impl CommitToNewBranchOperation {
@@ -616,15 +646,7 @@ impl CommitToNewBranchOperation {
         tx: &mut Transaction<'_, '_, impl RefMetadata>,
         changes: Vec<DiffSpec>,
     ) -> anyhow::Result<(IntermediateCommitCreateResult, Option<BranchNameTarget>)> {
-        let Self { branch_name } = self;
-
-        let branch_name = if let Some(branch_name) = branch_name {
-            branch_name
-        } else {
-            but_core::branch::unique_canned_refname(tx.repo())?
-        };
-
-        tx.create_reference(branch_name.as_ref(), None, |_| StackId::generate(), Some(0))?;
+        let branch_name = self.create_reference(tx)?;
 
         let commit_create_result = tx.create_commit(
             RelativeTo::Reference(branch_name.clone()),
@@ -638,6 +660,46 @@ impl CommitToNewBranchOperation {
             commit_create_result,
             Some(BranchNameTarget::New(branch_name)),
         ))
+    }
+
+    pub(crate) fn create_reference(
+        self,
+        tx: &mut Transaction<'_, '_, impl RefMetadata>,
+    ) -> anyhow::Result<FullName> {
+        let Self {
+            branch_name,
+            stack_on_head,
+        } = self;
+
+        let branch_name = if let Some(branch_name) = branch_name {
+            branch_name
+        } else {
+            but_core::branch::unique_canned_refname(tx.repo())?
+        };
+
+        let anchor = stack_on_head
+            .then(|| -> anyhow::Result<_> {
+                let head_name = tx
+                    .repo()
+                    .head()?
+                    .referent_name()
+                    .filter(|name| name.category() == Some(gix::refs::Category::LocalBranch))
+                    .context("single-branch commit requires HEAD to be a local branch")?
+                    .to_owned();
+                Ok(Anchor::AtReference {
+                    ref_name: Cow::Owned(head_name),
+                    position: but_workspace::branch::create_reference::Position::Above,
+                })
+            })
+            .transpose()?;
+        tx.create_reference(
+            branch_name.as_ref(),
+            anchor,
+            |_| StackId::generate(),
+            Some(0),
+        )?;
+
+        Ok(branch_name)
     }
 }
 

--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -124,6 +124,9 @@ pub fn commit(
     let guard = ctx.exclusive_worktree_access();
     let mut meta = ctx.meta()?;
     let id_map = IdMap::new_from_context(ctx, guard.read_permission())?;
+    let operating_mode =
+        but_api::legacy::modes::operating_mode_with_perm(ctx, guard.read_permission())?
+            .operating_mode;
 
     let (mut guard, commit_op, commit_selection, reword_op) = {
         let head_info = but_api::legacy::workspace::head_info(ctx)?;
@@ -134,6 +137,7 @@ pub fn commit(
         &mut meta,
         guard.write_permission(),
         commit_op,
+        should_stack_on_head(&operating_mode),
         commit_selection,
         reword_op,
     )?)
@@ -224,31 +228,20 @@ fn resolve(
     };
 
     let commit_op = {
-        let operating_mode =
-            but_api::legacy::modes::operating_mode_with_perm(ctx, guard.read_permission())?
-                .operating_mode;
         let (repo, ws, _db) = ctx.workspace_and_db_with_perm(guard.read_permission())?;
-        route_commit_operation(
-            &repo,
-            &ws,
-            &operating_mode,
-            head_info,
-            out,
-            id_map,
-            target_ish,
-            &merged,
-        )
-        .map_err(|err| match err {
-            RouteCommitOperationError::NoStackToCommitTo => {
-                bad_input("Found no stack that could be committed to").into()
-            }
-            RouteCommitOperationError::UnclearTargetCantPrompt => {
-                bad_input("Unclear where to commit. Found more than one stack")
-                    .hint("You can specify where to commit with `--branch [<BRANCH>]`")
-                    .into()
-            }
-            RouteCommitOperationError::Other(cli_error) => cli_error,
-        })?
+        route_commit_operation(&repo, &ws, head_info, out, id_map, target_ish, &merged).map_err(
+            |err| match err {
+                RouteCommitOperationError::NoStackToCommitTo => {
+                    bad_input("Found no stack that could be committed to").into()
+                }
+                RouteCommitOperationError::UnclearTargetCantPrompt => {
+                    bad_input("Unclear where to commit. Found more than one stack")
+                        .hint("You can specify where to commit with `--branch [<BRANCH>]`")
+                        .into()
+                }
+                RouteCommitOperationError::Other(cli_error) => cli_error,
+            },
+        )?
     };
 
     let reword_op = CommitMessageSource::from_args(no_message, message)?;
@@ -283,10 +276,12 @@ pub fn run(
     meta: &mut impl RefMetadata,
     perm: &mut RepoExclusive,
     commit_op: CommitOperation,
+    stack_on_head: bool,
     commit_selection: CommitSelection,
     reword_op: CommitMessageSource,
 ) -> anyhow::Result<(CommitOutcome, WorkspaceState)> {
-    let checkout_after_create = commit_op.checkout_after_create();
+    let checkout_after_create =
+        stack_on_head && matches!(commit_op, CommitOperation::CommitToNewBranch(_));
     let changes = {
         let context_lines = ctx.settings.context_lines;
         let (repo, ..) = ctx.workspace_and_db_mut_with_perm(perm.read_permission())?;
@@ -323,7 +318,7 @@ pub fn run(
                     rejected_specs,
                 },
                 branch_name,
-            ) = commit_op.execute(&mut tx, changes)?;
+            ) = commit_op.execute(&mut tx, changes, stack_on_head)?;
 
             if !rejected_specs.is_empty() {
                 return Err(rejection::RejectedChanges(rejected_specs).into());
@@ -391,18 +386,15 @@ impl CommitOperationTargetIsh {
     }
 }
 
-#[expect(clippy::too_many_arguments)]
 pub fn route_commit_operation(
     repo: &gix::Repository,
     ws: &but_graph::Workspace,
-    operating_mode: &OperatingMode,
     head_info: &RefInfo,
     out: &mut IntermediateChannel<'_>,
     id_map: &IdMap,
     target: CommitOperationTargetIsh,
     merged: &MergedUpstream,
 ) -> Result<CommitOperation, RouteCommitOperationError> {
-    let stack_on_head = should_stack_on_head(operating_mode);
     match target {
         CommitOperationTargetIsh::Above(cli_id) => {
             let side = Side::Above;
@@ -437,16 +429,12 @@ pub fn route_commit_operation(
                 Ok(CommitOperation::CommitToNewBranch(
                     CommitToNewBranchOperation {
                         branch_name: Some(branch_name),
-                        stack_on_head,
                     },
                 ))
             }
         }
         CommitOperationTargetIsh::UnstackedCannedBranch => Ok(CommitOperation::CommitToNewBranch(
-            CommitToNewBranchOperation {
-                branch_name: None,
-                stack_on_head,
-            },
+            CommitToNewBranchOperation { branch_name: None },
         )),
         CommitOperationTargetIsh::Default => {
             // Branches that have landed upstream are not sensible default targets;
@@ -464,10 +452,7 @@ pub fn route_commit_operation(
 
             match &stacks[..] {
                 [] => Ok(CommitOperation::CommitToNewBranch(
-                    CommitToNewBranchOperation {
-                        branch_name: None,
-                        stack_on_head,
-                    },
+                    CommitToNewBranchOperation { branch_name: None },
                 )),
                 [stack] => {
                     let ref_info = stack
@@ -523,10 +508,7 @@ pub fn route_commit_operation(
                             }))
                         }
                         PickerItem::NewStack => Ok(CommitOperation::CommitToNewBranch(
-                            CommitToNewBranchOperation {
-                                branch_name: None,
-                                stack_on_head,
-                            },
+                            CommitToNewBranchOperation { branch_name: None },
                         )),
                     }
                 }
@@ -612,16 +594,6 @@ pub enum CommitOperation {
 }
 
 impl CommitOperation {
-    pub(crate) fn checkout_after_create(&self) -> bool {
-        matches!(
-            self,
-            CommitOperation::CommitToNewBranch(CommitToNewBranchOperation {
-                stack_on_head: true,
-                ..
-            })
-        )
-    }
-
     /// What the operation targets, for explaining rejected changes after a
     /// rollback.
     fn rejection_target(&self) -> rejection::Target {
@@ -647,9 +619,10 @@ impl CommitOperation {
         self,
         tx: &mut Transaction<'_, '_, impl RefMetadata>,
         changes: Vec<DiffSpec>,
+        stack_on_head: bool,
     ) -> anyhow::Result<(IntermediateCommitCreateResult, Option<BranchNameTarget>)> {
         match self {
-            CommitOperation::CommitToNewBranch(op) => op.execute(tx, changes),
+            CommitOperation::CommitToNewBranch(op) => op.execute(tx, changes, stack_on_head),
             CommitOperation::CommitAt(op) => op.execute(tx, changes),
         }
     }
@@ -657,7 +630,6 @@ impl CommitOperation {
 
 pub struct CommitToNewBranchOperation {
     pub branch_name: Option<FullName>,
-    pub stack_on_head: bool,
 }
 
 impl CommitToNewBranchOperation {
@@ -665,8 +637,9 @@ impl CommitToNewBranchOperation {
         self,
         tx: &mut Transaction<'_, '_, impl RefMetadata>,
         changes: Vec<DiffSpec>,
+        stack_on_head: bool,
     ) -> anyhow::Result<(IntermediateCommitCreateResult, Option<BranchNameTarget>)> {
-        let branch_name = self.create_reference(tx)?;
+        let branch_name = self.create_reference(tx, stack_on_head)?;
 
         let commit_create_result = tx.create_commit(
             RelativeTo::Reference(branch_name.clone()),
@@ -685,11 +658,9 @@ impl CommitToNewBranchOperation {
     pub(crate) fn create_reference(
         self,
         tx: &mut Transaction<'_, '_, impl RefMetadata>,
+        stack_on_head: bool,
     ) -> anyhow::Result<FullName> {
-        let Self {
-            branch_name,
-            stack_on_head,
-        } = self;
+        let Self { branch_name } = self;
 
         let branch_name = if let Some(branch_name) = branch_name {
             branch_name

--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -11,10 +11,10 @@ use but_core::{
     sync::{RepoExclusive, RepoExclusiveGuard},
 };
 use but_ctx::Context;
-use but_graph::workspace::WorkspaceKind;
 use but_rebase::graph_rebase::mutate::{InsertSide, RelativeTo};
 use but_transaction::{IntermediateCommitCreateResult, Transaction};
 use but_workspace::{RefInfo, branch::create_reference::Anchor, commit::ChangeSource};
+use gitbutler_operating_modes::OperatingMode;
 use gitbutler_oplog::entry::{OperationKind, SnapshotDetails};
 use gix::refs::FullName;
 use nonempty::NonEmpty;
@@ -224,20 +224,31 @@ fn resolve(
     };
 
     let commit_op = {
+        let operating_mode =
+            but_api::legacy::modes::operating_mode_with_perm(ctx, guard.read_permission())?
+                .operating_mode;
         let (repo, ws, _db) = ctx.workspace_and_db_with_perm(guard.read_permission())?;
-        route_commit_operation(&repo, &ws, head_info, out, id_map, target_ish, &merged).map_err(
-            |err| match err {
-                RouteCommitOperationError::NoStackToCommitTo => {
-                    bad_input("Found no stack that could be committed to").into()
-                }
-                RouteCommitOperationError::UnclearTargetCantPrompt => {
-                    bad_input("Unclear where to commit. Found more than one stack")
-                        .hint("You can specify where to commit with `--branch [<BRANCH>]`")
-                        .into()
-                }
-                RouteCommitOperationError::Other(cli_error) => cli_error,
-            },
-        )?
+        route_commit_operation(
+            &repo,
+            &ws,
+            &operating_mode,
+            head_info,
+            out,
+            id_map,
+            target_ish,
+            &merged,
+        )
+        .map_err(|err| match err {
+            RouteCommitOperationError::NoStackToCommitTo => {
+                bad_input("Found no stack that could be committed to").into()
+            }
+            RouteCommitOperationError::UnclearTargetCantPrompt => {
+                bad_input("Unclear where to commit. Found more than one stack")
+                    .hint("You can specify where to commit with `--branch [<BRANCH>]`")
+                    .into()
+            }
+            RouteCommitOperationError::Other(cli_error) => cli_error,
+        })?
     };
 
     let reword_op = CommitMessageSource::from_args(no_message, message)?;
@@ -380,16 +391,18 @@ impl CommitOperationTargetIsh {
     }
 }
 
+#[expect(clippy::too_many_arguments)]
 pub fn route_commit_operation(
     repo: &gix::Repository,
     ws: &but_graph::Workspace,
+    operating_mode: &OperatingMode,
     head_info: &RefInfo,
     out: &mut IntermediateChannel<'_>,
     id_map: &IdMap,
     target: CommitOperationTargetIsh,
     merged: &MergedUpstream,
 ) -> Result<CommitOperation, RouteCommitOperationError> {
-    let stack_on_head = matches!(ws.kind, WorkspaceKind::AdHoc);
+    let stack_on_head = should_stack_on_head(operating_mode);
     match target {
         CommitOperationTargetIsh::Above(cli_id) => {
             let side = Side::Above;
@@ -520,6 +533,13 @@ pub fn route_commit_operation(
             }
         }
     }
+}
+
+pub(crate) fn should_stack_on_head(operating_mode: &OperatingMode) -> bool {
+    matches!(
+        operating_mode,
+        OperatingMode::OutsideWorkspace(metadata) if metadata.branch_name.is_some()
+    )
 }
 
 #[derive(Debug)]

--- a/crates/but/src/command/legacy/pick.rs
+++ b/crates/but/src/command/legacy/pick.rs
@@ -203,20 +203,30 @@ fn resolve(
     let target_ish = CommitOperationTargetIsh::resolve(branch, above, below)?;
 
     let commit_op = {
+        let operating_mode =
+            but_api::legacy::modes::operating_mode_with_perm(ctx, perm)?.operating_mode;
         let (repo, ws, _db) = ctx.workspace_and_db_with_perm(perm)?;
-        route_commit_operation(&repo, &ws, head_info, out, id_map, target_ish, &merged).map_err(
-            |err| match err {
-                RouteCommitOperationError::NoStackToCommitTo => {
-                    bad_input("Found no stack that could be picked to").into()
-                }
-                RouteCommitOperationError::UnclearTargetCantPrompt => {
-                    bad_input("Unclear where to pick to. Found more than one stack")
-                        .hint("You can specify where to pick to with `--branch [<BRANCH>]`")
-                        .into()
-                }
-                RouteCommitOperationError::Other(cli_error) => cli_error,
-            },
-        )?
+        route_commit_operation(
+            &repo,
+            &ws,
+            &operating_mode,
+            head_info,
+            out,
+            id_map,
+            target_ish,
+            &merged,
+        )
+        .map_err(|err| match err {
+            RouteCommitOperationError::NoStackToCommitTo => {
+                bad_input("Found no stack that could be picked to").into()
+            }
+            RouteCommitOperationError::UnclearTargetCantPrompt => {
+                bad_input("Unclear where to pick to. Found more than one stack")
+                    .hint("You can specify where to pick to with `--branch [<BRANCH>]`")
+                    .into()
+            }
+            RouteCommitOperationError::Other(cli_error) => cli_error,
+        })?
     };
 
     Ok(PickOperation {

--- a/crates/but/src/command/legacy/pick.rs
+++ b/crates/but/src/command/legacy/pick.rs
@@ -4,6 +4,7 @@ use but_api::{
 };
 use but_core::{
     DryRun, RefMetadata,
+    ref_metadata::StackId,
     sync::{RepoExclusive, RepoShared},
 };
 use but_ctx::Context;
@@ -22,8 +23,8 @@ use crate::{
     },
     bad_input,
     command::legacy::commit::{
-        BranchNameTarget, CommitOperation, CommitOperationTargetIsh, RouteCommitOperationError,
-        route_commit_operation,
+        BranchNameTarget, CommitOperation, CommitOperationTargetIsh, CommitToNewBranchOperation,
+        RouteCommitOperationError, route_commit_operation,
     },
     id::CommitId,
     theme::{self, Theme},
@@ -203,30 +204,20 @@ fn resolve(
     let target_ish = CommitOperationTargetIsh::resolve(branch, above, below)?;
 
     let commit_op = {
-        let operating_mode =
-            but_api::legacy::modes::operating_mode_with_perm(ctx, perm)?.operating_mode;
         let (repo, ws, _db) = ctx.workspace_and_db_with_perm(perm)?;
-        route_commit_operation(
-            &repo,
-            &ws,
-            &operating_mode,
-            head_info,
-            out,
-            id_map,
-            target_ish,
-            &merged,
-        )
-        .map_err(|err| match err {
-            RouteCommitOperationError::NoStackToCommitTo => {
-                bad_input("Found no stack that could be picked to").into()
-            }
-            RouteCommitOperationError::UnclearTargetCantPrompt => {
-                bad_input("Unclear where to pick to. Found more than one stack")
-                    .hint("You can specify where to pick to with `--branch [<BRANCH>]`")
-                    .into()
-            }
-            RouteCommitOperationError::Other(cli_error) => cli_error,
-        })?
+        route_commit_operation(&repo, &ws, head_info, out, id_map, target_ish, &merged).map_err(
+            |err| match err {
+                RouteCommitOperationError::NoStackToCommitTo => {
+                    bad_input("Found no stack that could be picked to").into()
+                }
+                RouteCommitOperationError::UnclearTargetCantPrompt => {
+                    bad_input("Unclear where to pick to. Found more than one stack")
+                        .hint("You can specify where to pick to with `--branch [<BRANCH>]`")
+                        .into()
+                }
+                RouteCommitOperationError::Other(cli_error) => cli_error,
+            },
+        )?
     };
 
     Ok(PickOperation {
@@ -253,7 +244,6 @@ pub fn run(
         commit_op,
         order_commits_by_parentage,
     } = pick_op;
-    let checkout_after_create = commit_op.checkout_after_create();
 
     let snapshot_details =
         SnapshotDetails::new(OperationKind::CherryPick).with_count(sources.len());
@@ -265,8 +255,19 @@ pub fn run(
         DryRun::No,
         |mut tx| {
             let (new_commits, branch_name_target) = match commit_op {
-                CommitOperation::CommitToNewBranch(operation) => {
-                    let branch_name = operation.create_reference(&mut tx)?;
+                CommitOperation::CommitToNewBranch(CommitToNewBranchOperation { branch_name }) => {
+                    let branch_name = if let Some(branch_name) = branch_name {
+                        branch_name
+                    } else {
+                        but_core::branch::unique_canned_refname(tx.repo())?
+                    };
+
+                    tx.create_reference(
+                        branch_name.as_ref(),
+                        None,
+                        |_| StackId::generate(),
+                        Some(0),
+                    )?;
 
                     let new_commits = tx.cherry_pick_commits(
                         sources.iter().copied(),
@@ -293,10 +294,6 @@ pub fn run(
             Ok(but_transaction::Commit((new_commits, branch_name_target)))
         },
     )?;
-
-    if checkout_after_create && let Some(BranchNameTarget::New(branch_name)) = &branch_name_target {
-        but_api::branch::branch_checkout_with_perm(ctx, branch_name.clone(), perm)?;
-    }
 
     let new_commits = new_commits.into_iter().map(Into::into).collect();
 

--- a/crates/but/src/command/legacy/pick.rs
+++ b/crates/but/src/command/legacy/pick.rs
@@ -4,7 +4,6 @@ use but_api::{
 };
 use but_core::{
     DryRun, RefMetadata,
-    ref_metadata::StackId,
     sync::{RepoExclusive, RepoShared},
 };
 use but_ctx::Context;
@@ -23,8 +22,8 @@ use crate::{
     },
     bad_input,
     command::legacy::commit::{
-        BranchNameTarget, CommitOperation, CommitOperationTargetIsh, CommitToNewBranchOperation,
-        RouteCommitOperationError, route_commit_operation,
+        BranchNameTarget, CommitOperation, CommitOperationTargetIsh, RouteCommitOperationError,
+        route_commit_operation,
     },
     id::CommitId,
     theme::{self, Theme},
@@ -244,6 +243,7 @@ pub fn run(
         commit_op,
         order_commits_by_parentage,
     } = pick_op;
+    let checkout_after_create = commit_op.checkout_after_create();
 
     let snapshot_details =
         SnapshotDetails::new(OperationKind::CherryPick).with_count(sources.len());
@@ -255,19 +255,8 @@ pub fn run(
         DryRun::No,
         |mut tx| {
             let (new_commits, branch_name_target) = match commit_op {
-                CommitOperation::CommitToNewBranch(CommitToNewBranchOperation { branch_name }) => {
-                    let branch_name = if let Some(branch_name) = branch_name {
-                        branch_name
-                    } else {
-                        but_core::branch::unique_canned_refname(tx.repo())?
-                    };
-
-                    tx.create_reference(
-                        branch_name.as_ref(),
-                        None,
-                        |_| StackId::generate(),
-                        Some(0),
-                    )?;
+                CommitOperation::CommitToNewBranch(operation) => {
+                    let branch_name = operation.create_reference(&mut tx)?;
 
                     let new_commits = tx.cherry_pick_commits(
                         sources.iter().copied(),
@@ -294,6 +283,10 @@ pub fn run(
             Ok(but_transaction::Commit((new_commits, branch_name_target)))
         },
     )?;
+
+    if checkout_after_create && let Some(BranchNameTarget::New(branch_name)) = &branch_name_target {
+        but_api::branch::branch_checkout_with_perm(ctx, branch_name.clone(), perm)?;
+    }
 
     let new_commits = new_commits.into_iter().map(Into::into).collect();
 

--- a/crates/but/src/command/legacy/status/tui/app/commit_mode.rs
+++ b/crates/but/src/command/legacy/status/tui/app/commit_mode.rs
@@ -386,7 +386,7 @@ impl App {
             CliId::UncommittedHunkOrFile(..) | CliId::Uncommitted { .. } => {
                 commit::CommitOperation::CommitToNewBranch(commit::CommitToNewBranchOperation {
                     branch_name: None,
-                    stack_on_head: false,
+                    stack_on_head: commit::should_stack_on_head(&self.operating_mode),
                 })
             }
             CliId::Branch(branch) => commit::CommitOperation::CommitAt(commit::CommitAtOperation {

--- a/crates/but/src/command/legacy/status/tui/app/commit_mode.rs
+++ b/crates/but/src/command/legacy/status/tui/app/commit_mode.rs
@@ -355,7 +355,7 @@ impl App {
         };
         let commit_op = commit::CommitOperation::CommitAt(commit::CommitAtOperation { target });
 
-        commit_with(ctx, terminal_guard, messages, mode, commit_op)?;
+        commit_with(ctx, terminal_guard, messages, mode, commit_op, false)?;
 
         Ok(())
     }
@@ -386,7 +386,6 @@ impl App {
             CliId::UncommittedHunkOrFile(..) | CliId::Uncommitted { .. } => {
                 commit::CommitOperation::CommitToNewBranch(commit::CommitToNewBranchOperation {
                     branch_name: None,
-                    stack_on_head: commit::should_stack_on_head(&self.operating_mode),
                 })
             }
             CliId::Branch(branch) => commit::CommitOperation::CommitAt(commit::CommitAtOperation {
@@ -402,7 +401,14 @@ impl App {
             | CliId::Stack { .. } => return Ok(()),
         };
 
-        commit_with(ctx, terminal_guard, messages, mode, commit_op)?;
+        commit_with(
+            ctx,
+            terminal_guard,
+            messages,
+            mode,
+            commit_op,
+            commit::should_stack_on_head(&self.operating_mode),
+        )?;
 
         Ok(())
     }
@@ -456,6 +462,7 @@ fn commit_with<T>(
     messages: &mut Vec<Message>,
     mode: &CommitMode,
     commit_op: commit::CommitOperation,
+    stack_on_head: bool,
 ) -> anyhow::Result<()>
 where
     T: TerminalGuard,
@@ -509,6 +516,7 @@ where
         &mut meta,
         guard.write_permission(),
         commit_op,
+        stack_on_head,
         commit_selection,
         reword_op,
     )?;

--- a/crates/but/src/command/legacy/status/tui/app/commit_mode.rs
+++ b/crates/but/src/command/legacy/status/tui/app/commit_mode.rs
@@ -386,6 +386,7 @@ impl App {
             CliId::UncommittedHunkOrFile(..) | CliId::Uncommitted { .. } => {
                 commit::CommitOperation::CommitToNewBranch(commit::CommitToNewBranchOperation {
                     branch_name: None,
+                    stack_on_head: false,
                 })
             }
             CliId::Branch(branch) => commit::CommitOperation::CommitAt(commit::CommitAtOperation {

--- a/crates/but/src/command/legacy/status/tui/app/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/app/mod.rs
@@ -1442,6 +1442,7 @@ impl App {
                             name: Category::LocalBranch.to_full_name(&*branch.name)?,
                         },
                     }),
+                    false,
                     CommitSelection::Nothing,
                     CommitMessageSource::Empty,
                 )?;
@@ -1469,6 +1470,7 @@ impl App {
                             side: Side::Above,
                         },
                     }),
+                    false,
                     CommitSelection::Nothing,
                     CommitMessageSource::Empty,
                 )?;

--- a/crates/but/src/command/legacy/status/tui/tests/commit_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/commit_tests.rs
@@ -164,6 +164,43 @@ fn commit_from_unstaged_changes_to_new_branch_creates_branch_and_commit() {
 }
 
 #[test]
+fn commit_from_unstaged_changes_to_new_branch_checks_out_branch_in_single_branch_mode() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
+    env.invoke_git("checkout A");
+
+    env.file(
+        "editor.sh",
+        format!("printf '{TEST_EDITOR_MESSAGE}\\n' > \"$1\"\n"),
+    );
+    let editor_path = env.projects_root().join("editor.sh");
+    let editor_command = format!("sh {}", editor_path.display());
+
+    let mut tui = test_status_tui(env);
+
+    tui.env().file("test.txt", "content");
+    tui.reload();
+    tui.input('c');
+
+    with_var("GIT_EDITOR", Some(editor_command), || {
+        tui.input('b').assert_rendered_term_svg_eq(file![
+            "snapshots/commit_from_unstaged_changes_to_new_branch_checks_out_branch_in_single_branch_mode_final.svg"
+        ]);
+    });
+
+    assert_eq!(
+        tui.env().invoke_git("symbolic-ref --short HEAD"),
+        "c-branch-1",
+        "creating a branch from the TUI should check it out in single-branch mode"
+    );
+    assert_eq!(
+        tui.env().invoke_git("log -1 --format=%s"),
+        TEST_EDITOR_MESSAGE,
+        "the checked-out branch should contain the TUI commit"
+    );
+}
+
+#[test]
 fn commit_from_unstaged_changes_with_multiple_hunks_in_same_file_commits_all_changes() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
     env.setup_metadata(&["A"]);

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_from_unstaged_changes_to_new_branch_checks_out_branch_in_single_branch_mode_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_from_unstaged_changes_to_new_branch_checks_out_branch_in_single_branch_mode_final.svg
@@ -1,0 +1,73 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="380" viewBox="0 0 820 380">
+  <rect x="0" y="0" width="820" height="380" fill="#000000" />
+  <rect x="10" y="64" width="800" height="18" fill="#45475A" />
+  <rect x="10" y="352" width="80" height="18" fill="#555555" />
+  <g font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">
+    <text x="10 18" y="24" style="fill:#CCCCCC;">╭┄</text>
+    <text x="34 42" y="24" style="fill:#0000AA;font-weight:bold;">zz</text>
+    <text x="58" y="24" style="fill:#CCCCCC;">[</text>
+    <text x="66 74 82 90 98 106 114 122 130 138 146" y="24" style="fill:#00AAAA;">uncommitted</text>
+    <text x="154" y="24" style="fill:#CCCCCC;">]</text>
+    <text x="170 178 186" y="24" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="202 210 218 226 234 242 250 258" y="24" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
+    <text x="10 18 26" y="60" style="fill:#CCCCCC;">┊╭┄</text>
+    <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;">br</text>
+    <text x="66" y="60" style="fill:#CCCCCC;">[</text>
+    <text x="74 82 90 98 106 114 122 130 138 146" y="60" style="fill:#00AA00;">c-branch-1</text>
+    <text x="154" y="60" style="fill:#CCCCCC;">]</text>
+    <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
+    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
+    <text x="66 74 82 90 98 106" y="78" style="fill:#FFFFFF;font-weight:bold;">commit</text>
+    <text x="122 130 138 146" y="78" style="fill:#FFFFFF;font-weight:bold;">from</text>
+    <text x="162 170 178" y="78" style="fill:#FFFFFF;font-weight:bold;">tui</text>
+    <text x="194 202 210 218" y="78" style="fill:#FFFFFF;font-weight:bold;">test</text>
+    <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
+    <text x="10 18 26" y="114" style="fill:#CCCCCC;">┊├┄</text>
+    <text x="42 50" y="114" style="fill:#0000AA;font-weight:bold;">g0</text>
+    <text x="66" y="114" style="fill:#CCCCCC;">[</text>
+    <text x="74" y="114" style="fill:#00AA00;">A</text>
+    <text x="82" y="114" style="fill:#CCCCCC;">]</text>
+    <text x="10 18" y="132" style="fill:#CCCCCC;">┊●</text>
+    <text x="50" y="132" style="fill:#AA00AA;">t</text>
+    <text x="58 66" y="132" style="fill:#CCCCCC;opacity:0.75;">pm</text>
+    <text x="82 90 98" y="132" style="fill:#CCCCCC;">add</text>
+    <text x="114" y="132" style="fill:#CCCCCC;">A</text>
+    <text x="10 18" y="150" style="fill:#CCCCCC;">├╯</text>
+    <text x="10" y="168" style="fill:#CCCCCC;">┊</text>
+    <text x="10" y="186" style="fill:#CCCCCC;">┴</text>
+    <text x="26 34 42 50 58 66 74" y="186" style="fill:#CCCCCC;opacity:0.75;">0dc3733</text>
+    <text x="90 98 106 114 122 130 138" y="186" style="fill:#CCCCCC;">(common</text>
+    <text x="154 162 170 178 186" y="186" style="fill:#CCCCCC;">base)</text>
+    <text x="202 210 218 226 234 242 250 258 266 274" y="186" style="fill:#CCCCCC;opacity:0.75;">2000-01-02</text>
+    <text x="290 298 306" y="186" style="fill:#CCCCCC;">add</text>
+    <text x="322" y="186" style="fill:#CCCCCC;">M</text>
+    <text x="26 34 42 50 58 66" y="366" style="fill:#FFFFFF;">normal</text>
+    <text x="98 106 114" y="366" style="fill:#0000AA;">↑/k</text>
+    <text x="130 138" y="366" style="fill:#CCCCCC;opacity:0.75;">up</text>
+    <text x="154" y="366" style="fill:#CCCCCC;opacity:0.75;">•</text>
+    <text x="170 178 186" y="366" style="fill:#0000AA;">↓/j</text>
+    <text x="202 210 218 226" y="366" style="fill:#CCCCCC;opacity:0.75;">down</text>
+    <text x="242" y="366" style="fill:#CCCCCC;opacity:0.75;">•</text>
+    <text x="258" y="366" style="fill:#0000AA;">c</text>
+    <text x="274 282 290 298 306 314" y="366" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="330" y="366" style="fill:#CCCCCC;opacity:0.75;">•</text>
+    <text x="346" y="366" style="fill:#0000AA;">r</text>
+    <text x="362 370 378 386 394 402" y="366" style="fill:#CCCCCC;opacity:0.75;">squash</text>
+    <text x="418" y="366" style="fill:#CCCCCC;opacity:0.75;">•</text>
+    <text x="434" y="366" style="fill:#0000AA;">m</text>
+    <text x="450 458 466 474" y="366" style="fill:#CCCCCC;opacity:0.75;">move</text>
+    <text x="490" y="366" style="fill:#CCCCCC;opacity:0.75;">•</text>
+    <text x="506" y="366" style="fill:#0000AA;">b</text>
+    <text x="522 530 538 546 554 562" y="366" style="fill:#CCCCCC;opacity:0.75;">branch</text>
+    <text x="578" y="366" style="fill:#CCCCCC;opacity:0.75;">•</text>
+    <text x="594" y="366" style="fill:#0000AA;">s</text>
+    <text x="610 618 626 634 642" y="366" style="fill:#CCCCCC;opacity:0.75;">stack</text>
+    <text x="658" y="366" style="fill:#CCCCCC;opacity:0.75;">•</text>
+    <text x="674" y="366" style="fill:#0000AA;">?</text>
+    <text x="690 698 706 714" y="366" style="fill:#CCCCCC;opacity:0.75;">help</text>
+    <text x="730" y="366" style="fill:#CCCCCC;opacity:0.75;">•</text>
+    <text x="746" y="366" style="fill:#0000AA;">q</text>
+    <text x="762 770 778 786" y="366" style="fill:#CCCCCC;opacity:0.75;">quit</text>
+  </g>
+</svg>

--- a/crates/but/tests/but/command/commit.rs
+++ b/crates/but/tests/but/command/commit.rs
@@ -1,4 +1,105 @@
-use crate::utils::Sandbox;
+use super::util::{find_branch, status_json_with_files};
+use crate::utils::{CommandExt as _, Sandbox};
+
+#[test]
+fn commits_a_dirty_file_on_a_new_branch_in_single_branch_mode() {
+    let env = Sandbox::open_with_default_settings("one-fork");
+    env.but("config feature single-branch enable")
+        .assert()
+        .success();
+    env.file("ad-hoc.txt", "content\n");
+
+    env.but("status --files")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+╭┄ zz [uncommitted]
+┊   xt A ad-hoc.txt
+┊
+┊╭┄ ma [main]
+┊●   nmy M (no changes)
+├╯
+┊
+┴ e31e6ca (common base) 2000-01-02 add init
+
+Hint: run `but diff` to see uncommitted changes and `but commit -b <branch> -m "message" <id>` to commit them
+
+"#]]);
+
+    let diff = env
+        .but("--json diff")
+        .allow_json()
+        .output()
+        .expect("diff should succeed");
+    let diff: serde_json::Value =
+        serde_json::from_slice(&diff.stdout).expect("diff output should be JSON");
+    let changes = diff["changes"]
+        .as_array()
+        .expect("diff.changes should be an array");
+    assert_eq!(changes.len(), 1, "the dirty file should be the only change");
+    assert_eq!(changes[0]["path"], "ad-hoc.txt");
+    let change_id = changes[0]["id"]
+        .as_str()
+        .expect("the dirty file should have a CLI ID");
+
+    env.but(format!(
+        "commit -b feature -m 'add ad-hoc file' {change_id}"
+    ))
+    .assert()
+    .success()
+    .stderr_eq(snapbox::str![])
+    .stdout_eq(snapbox::str![[r#"
+Created commit 1 on new branch 'feature'
+
+"#]]);
+
+    env.but("status --files")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ at [feature]
+┊●   1 add ad-hoc file
+┊│     1:x A ad-hoc.txt
+┊│
+┊├┄ ma [main]
+┊●   nmy M (no changes)
+┊●   ply add init
+┊│     ply:k A init
+├╯
+┊
+┴ e31e6ca (common base) 2000-01-02 add init
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    let status = status_json_with_files(&env);
+    assert_eq!(
+        status["uncommittedChanges"].as_array().map(Vec::len),
+        Some(0),
+        "the committed file should no longer be dirty"
+    );
+    let branch = find_branch(&status, "feature");
+    assert_eq!(branch["commits"].as_array().map(Vec::len), Some(1));
+    assert_eq!(branch["commits"][0]["changes"][0]["filePath"], "ad-hoc.txt");
+    assert_eq!(
+        env.invoke_git("symbolic-ref --short HEAD"),
+        "feature",
+        "creating the branch should check it out in single-branch mode"
+    );
+    assert_eq!(env.invoke_git("show feature:ad-hoc.txt"), "content");
+    assert!(
+        env.open_repo()
+            .try_find_reference(but_core::WORKSPACE_REF_NAME)
+            .unwrap()
+            .is_none(),
+        "the commit journey must remain outside managed workspace mode"
+    );
+}
 
 #[test]
 fn no_message_nothing_to_commit() {

--- a/crates/but/tests/but/command/commit.rs
+++ b/crates/but/tests/but/command/commit.rs
@@ -102,6 +102,41 @@ Hint: run `but help` for all commands
 }
 
 #[test]
+fn commits_on_top_of_a_checked_out_managed_workspace_branch() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
+    env.but("config feature single-branch enable")
+        .assert()
+        .success();
+    env.invoke_git("checkout A");
+    env.file("outside-workspace.txt", "content\n");
+
+    env.but("commit -b feature -m 'commit outside workspace'")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+Created commit 1 on new branch 'feature'
+
+"#]]);
+
+    assert_eq!(
+        env.invoke_git("symbolic-ref --short HEAD"),
+        "feature",
+        "the new branch should be checked out"
+    );
+    assert_eq!(
+        env.invoke_git("rev-parse feature^"),
+        env.invoke_git("rev-parse A"),
+        "the new branch should be based on the previously checked-out branch"
+    );
+    assert_eq!(
+        env.invoke_git("show feature:outside-workspace.txt"),
+        "content"
+    );
+}
+
+#[test]
 fn no_message_nothing_to_commit() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
     env.setup_metadata(&["A"]);

--- a/crates/but/tests/but/command/status.rs
+++ b/crates/but/tests/but/command/status.rs
@@ -3,6 +3,61 @@ use crate::utils::{CommandExt as _, Sandbox};
 use snapbox::IntoData;
 
 #[test]
+fn single_branch_mode_lazily_initializes_an_unregistered_repository() {
+    let env = Sandbox::open_with_default_settings("one-fork");
+    env.but("config feature single-branch enable")
+        .assert()
+        .success();
+
+    let status = status_json(&env);
+    let project_meta = env.project_meta();
+    assert_eq!(
+        project_meta.target_ref.as_ref().map(ToString::to_string),
+        Some("refs/remotes/origin/main".into()),
+        "the inferred target should be persisted"
+    );
+    assert_eq!(
+        project_meta.target_commit_id.map(|id| id.to_string()),
+        Some(env.invoke_git("merge-base HEAD origin/main")),
+        "the inferred merge base should be persisted"
+    );
+    assert_eq!(
+        env.invoke_git("symbolic-ref --short HEAD"),
+        "main",
+        "lazy initialization must not change the checked-out branch"
+    );
+    assert!(
+        env.open_repo()
+            .try_find_reference(but_core::WORKSPACE_REF_NAME)
+            .unwrap()
+            .is_none(),
+        "lazy initialization must not create a managed workspace"
+    );
+
+    assert_eq!(
+        status_json(&env),
+        status,
+        "reopening the lazily initialized repository should be idempotent"
+    );
+    assert_eq!(
+        env.project_meta(),
+        project_meta,
+        "reopening the repository should preserve its target metadata"
+    );
+
+    let projects_file = env.app_data_dir().join("com.gitbutler.app/projects.json");
+    let projects: serde_json::Value = std::fs::read_to_string(projects_file)
+        .unwrap()
+        .parse()
+        .unwrap();
+    assert_eq!(
+        projects.as_array().map(Vec::len),
+        Some(1),
+        "the repository should be registered exactly once"
+    );
+}
+
+#[test]
 fn worktrees() {
     let env = Sandbox::init_scenario_with_target_and_default_settings_slow("two-worktrees");
     snapbox::assert_data_eq!(


### PR DESCRIPTION
## Summary
- add CLI coverage for lazy single-branch initialization
- add an end-to-end dirty file → diff → commit → status journey
- align CLI and TUI commit-to-new-branch behavior outside the managed workspace

## Root cause
`but commit -b <new-branch>` created an independent workspace branch even when `HEAD` was a normal local branch. Its target commit could already belong to the checked-out branch, so branch creation was rejected.

Commit execution now checks `OperatingMode`: when a named local branch is checked out outside `gitbutler/workspace`, the new branch is anchored above that ref and checked out. Managed-workspace behavior is unchanged. `pick` behavior is intentionally out of scope.

## Validation
- `cargo test -p but`
- `cargo fmt --all`
- `cargo check -p but --all-targets`
- `cargo clippy -p but --all-targets -- -D warnings`