### PR TITLE
Fetch after merging a pull request in lite

### DIFF
--- a/apps/desktop/src/lib/forge/shared/progressivePolling.ts
+++ b/apps/desktop/src/lib/forge/shared/progressivePolling.ts
@@ -1,26 +1,3 @@
-import { sleep } from "$lib/utils/sleep";
-
-const MAX_ATTEMPTS = 2;
-const INITIAL_DELAY = 2000; // 2 seconds
-
-/**
- * Call a function that returns a promise and check its result repeatedly.
- *
- * Repeatedly calls `promiseFn` until `shouldStop` returns true or max attempts reached.
- * Uses exponential backoff for delays.
- */
-export async function eventualConsistencyCheck<T>(
-	promiseFn: () => Promise<T>,
-	shouldStop: (r: T) => boolean,
-): Promise<T> {
-	let result: T = await promiseFn();
-	for (let attempts = 0; !shouldStop(result) && attempts < MAX_ATTEMPTS; attempts++) {
-		await sleep(INITIAL_DELAY * Math.pow(2, attempts));
-		result = await promiseFn();
-	}
-	return result;
-}
-
 const POLLING_INTERVAL_INITIAL = 5 * 1000;
 const POLLING_INTERVAL_SHORT = 30 * 1000;
 const POLLING_INTERVAL_MEDIUM = 5 * 60 * 1000;

--- a/apps/lite/ui/src/api/mutations.ts
+++ b/apps/lite/ui/src/api/mutations.ts
@@ -12,6 +12,7 @@ import {
 	listCommentReactionsQueryOptions,
 	listReviewCommentsQueryOptions,
 	listReviewReactionsQueryOptions,
+	workspaceFetchQueryOptions,
 	type QueryKey,
 } from "#ui/api/queries.ts";
 import { shortCommitId } from "#ui/commit.ts";
@@ -786,6 +787,16 @@ export const useMergeReview = () => {
 					queryKey: ["ciChecks" satisfies QueryKey, input.projectId],
 				}),
 			]);
+
+			await mutation.client
+				.fetchQuery({ ...workspaceFetchQueryOptions(input.projectId), staleTime: 0 })
+				.then(() =>
+					mutation.client.fetchQuery({
+						...headInfoQueryOptions(input.projectId),
+						staleTime: 0,
+					}),
+				)
+				.catch(() => undefined);
 		},
 		onError: (error) => {
 			// oxlint-disable-next-line no-console


### PR DESCRIPTION
Merging a pull request only refreshed forge caches, so the branch kept
looking un-integrated until the next auto-fetch or a manual sync. Fetch
and re-read head info once the merge succeeds.

Both calls pass staleTime: 0. The query client defaults to Infinity,
which makes a plain fetchQuery resolve from the cache without fetching at
all. Head info is re-read here rather than left to the gitFetch watcher,
so noticing the merge does not hang on watcher delivery.

Also drop the unused eventualConsistencyCheck from desktop. The merge
path there fetches immediately with no delay, and the helper had no call
sites.