### PR TITLE
Match commit header height to the branch header

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
@@ -351,6 +351,9 @@
 	display: flex;
 	flex-wrap: wrap;
 	align-items: center;
+	/* Match the branch header's tabs row (regular button height) so both
+	   header variants end at the same line. */
+	min-height: 28px;
 	gap: 8px;
 	color: var(--text-3);
 }


### PR DESCRIPTION
The commit preview header ended ~10px higher than the branch preview header: both stack a 28px title row over a second row, but the branch view's second row is the 28px Diff/Pull Request toggle while the commit view's author-meta row was only ~18px tall, so the header separator lines drifted between the two views. Give the meta row a 28px min-height so both header variants end at the same line.