### PR TITLE
Spill arrow navigation across the pane boundary

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.tsx
@@ -49,6 +49,7 @@ const useFilesTreeHotkeys = ({
 	checkRow,
 	navigationIndex,
 	onRowSelection,
+	onEdgeSpill,
 	projectId,
 	ref,
 	fileParent,
@@ -61,6 +62,7 @@ const useFilesTreeHotkeys = ({
 	checkRow: (evt: { path: string; shiftKey: boolean }) => void;
 	navigationIndex: NavigationIndex<string>;
 	onRowSelection: (selection: string) => void;
+	onEdgeSpill?: (offset: -1 | 1) => void;
 	projectId: string;
 	ref: React.RefObject<HTMLElement | null>;
 	fileParent: FileParent;
@@ -268,6 +270,7 @@ const useFilesTreeHotkeys = ({
 		select: onRowSelection,
 		selection,
 		ref,
+		onEdgeSpill,
 		getKey: (path) => path,
 		operationSourcesForItem: (path) => {
 			const operand = fileOperand({ parent: fileParent, path });
@@ -288,6 +291,8 @@ export const FilesTree: FC<
 		onToggleDirectoryCollapsed: (path: string) => void;
 		selection: string | null;
 		onRowSelection: (selection: string) => void;
+		/** See {@link useNavigationIndexHotkeys}'s option of the same name. */
+		onEdgeSpill?: (offset: -1 | 1) => void;
 		navigationIndex: NavigationIndex<string>;
 		fileParent: FileParent;
 		/** The scope this tree's hotkeys are bound to; also stamped on the tree element. */
@@ -300,6 +305,7 @@ export const FilesTree: FC<
 	onToggleDirectoryCollapsed,
 	selection,
 	onRowSelection,
+	onEdgeSpill,
 	projectId,
 	navigationIndex,
 	fileParent,
@@ -448,6 +454,7 @@ export const FilesTree: FC<
 		checkRow,
 		navigationIndex,
 		onRowSelection,
+		onEdgeSpill,
 		projectId,
 		ref,
 		fileParent,

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
@@ -78,7 +78,11 @@ import {
 } from "#ui/segment.ts";
 import { checkedRange, navigationIndexRange } from "#ui/checking.ts";
 import { TooltipPopup } from "#ui/components/Tooltip.tsx";
-import { useAutofocusSelectionScope, type SelectionScope } from "#ui/selection-scopes.ts";
+import {
+	focusSelectionScope,
+	useAutofocusSelectionScope,
+	type SelectionScope,
+} from "#ui/selection-scopes.ts";
 import { FilesTree } from "#ui/routes/project/$id/workspace/FilesTree.tsx";
 import {
 	CommitForm,
@@ -272,6 +276,7 @@ const UncommittedChanges: FC<{
 	onAmendCommit: (commitId: string) => void;
 	canAmendCommit: boolean;
 	onActiveFileSelection: (selection: string) => void;
+	onEdgeSpill: (offset: -1 | 1) => void;
 	worktreeChanges: WorktreeChanges | undefined;
 }> = ({
 	navigationIndex,
@@ -281,6 +286,7 @@ const UncommittedChanges: FC<{
 	onAmendCommit,
 	canAmendCommit,
 	onActiveFileSelection,
+	onEdgeSpill,
 	worktreeChanges,
 }) => {
 	const dispatch = useAppDispatch();
@@ -361,6 +367,7 @@ const UncommittedChanges: FC<{
 					}
 					navigationIndex={navigationIndex}
 					onRowSelection={onActiveFileSelection}
+					onEdgeSpill={onEdgeSpill}
 					projectId={projectId}
 					ref={useMergedRefs(fileListRef, useAutofocusSelectionScope())}
 					selection={fileSelection}
@@ -653,7 +660,8 @@ const Stacks: FC<{
 	checkCommit: (evt: { commitId: string; shiftKey: boolean }) => void;
 	onAmendCommit: (commitId: string) => void;
 	canAmendCommit: boolean;
-}> = ({ projectId, checkCommit, onAmendCommit, canAmendCommit }) => {
+	onEdgeSpill: (offset: -1 | 1) => void;
+}> = ({ projectId, checkCommit, onAmendCommit, canAmendCommit, onEdgeSpill }) => {
 	const navigationIndex = assert(use(NavigationIndexContext));
 	const dispatch = useAppDispatch();
 	const { data: headInfo } = useQuery(headInfoQueryOptions(projectId));
@@ -700,6 +708,7 @@ const Stacks: FC<{
 		ref: hotkeysRef,
 		checkCommit,
 		focusCommitMessageInput,
+		onEdgeSpill,
 	});
 
 	return (
@@ -846,6 +855,25 @@ export const OutlineTree: FC<
 		panelIds: ["uncommitted-changes-panel", "stacks-panel"] satisfies Array<PanelId>,
 	});
 
+	// The two panes stack vertically, so arrow navigation continues across
+	// their boundary: entering a pane selects its item nearest to the border,
+	// while the pane being left keeps its selection. An empty neighbor keeps
+	// focus where it is. Mod+Alt+arrow pane toggling stays selection-neutral.
+	const spillIntoStacks = (offset: -1 | 1) => {
+		if (offset !== 1) return;
+		const item = navigationIndex.items.at(0);
+		if (item === undefined) return;
+		dispatch(projectSlice.actions.selectOutline({ projectId, selection: item }));
+		focusSelectionScope("outline");
+	};
+	const spillIntoUncommittedChanges = (offset: -1 | 1) => {
+		if (offset !== -1) return;
+		const path = uncommittedFilesNavigationIndex.items.at(-1);
+		if (path === undefined) return;
+		onActiveFileSelection(path);
+		focusSelectionScope("uncommitted-files");
+	};
+
 	return (
 		<NavigationIndexContext value={navigationIndex}>
 			<AbsorptionTargetCommitIdsContext value={absorptionTargetCommitIds}>
@@ -883,6 +911,7 @@ export const OutlineTree: FC<
 											onAmendCommit={amendCommit}
 											canAmendCommit={canAmendCommit}
 											onActiveFileSelection={onActiveFileSelection}
+											onEdgeSpill={spillIntoStacks}
 											worktreeChanges={worktreeChanges}
 										/>
 									}
@@ -910,6 +939,7 @@ export const OutlineTree: FC<
 								checkCommit={checkCommit}
 								onAmendCommit={amendCommit}
 								canAmendCommit={canAmendCommit}
+								onEdgeSpill={spillIntoUncommittedChanges}
 							/>
 						</Scroller>
 					</Panel>

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/hotkeys.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/hotkeys.ts
@@ -69,12 +69,14 @@ export const useOutlineTreeHotkeys = ({
 	ref,
 	checkCommit,
 	focusCommitMessageInput,
+	onEdgeSpill,
 }: {
 	navigationIndex: NavigationIndex<Operand>;
 	projectId: string;
 	ref: RefObject<HTMLElement | null>;
 	checkCommit: (evt: { commitId: string; shiftKey: boolean }) => void;
 	focusCommitMessageInput: () => void;
+	onEdgeSpill?: (offset: -1 | 1) => void;
 }) => {
 	const { data: headInfoIndex } = useQuery({
 		...headInfoQueryOptions(projectId),
@@ -418,6 +420,7 @@ export const useOutlineTreeHotkeys = ({
 		select: (newItem) =>
 			dispatch(projectSlice.actions.selectOutline({ projectId, selection: newItem })),
 		selection,
+		onEdgeSpill,
 		getKey: operandIdentityKey,
 		operationSourcesForItem: (operand) => {
 			const checkedOperands = projectSlice.selectors.selectCheckedOperands(

--- a/apps/lite/ui/src/selection-scopes.ts
+++ b/apps/lite/ui/src/selection-scopes.ts
@@ -162,6 +162,7 @@ export const useNavigationIndexHotkeys = <T>({
 	ref,
 	selectSectionPredicate,
 	operationSourcesForItem,
+	onEdgeSpill,
 	getKey,
 }: {
 	navigationIndex: NavigationIndex<T>;
@@ -173,6 +174,12 @@ export const useNavigationIndexHotkeys = <T>({
 	selectSectionPredicate?: (item: T) => boolean;
 	/** When omitted, the selection operation hotkeys (move, cut) are not registered. */
 	operationSourcesForItem?: (item: T) => Array<Operand>;
+	/**
+	 * Called with the direction when arrow navigation hits the pane's edge (or
+	 * the pane is empty). Wired by whichever component stacks this pane against
+	 * a neighbor, so crossing the boundary can enter the adjacent pane.
+	 */
+	onEdgeSpill?: (offset: -1 | 1) => void;
 	getKey: (item: T) => string;
 }) => {
 	const dispatch = useAppDispatch();
@@ -182,7 +189,10 @@ export const useNavigationIndexHotkeys = <T>({
 			selection === null
 				? navigationIndex.items.at(offset === 1 ? 0 : -1)
 				: getAdjacent({ navigationIndex, selection, offset, getKey });
-		if (newItem === null || newItem === undefined) return;
+		if (newItem === null || newItem === undefined) {
+			onEdgeSpill?.(offset);
+			return;
+		}
 		select(newItem);
 	};
 


### PR DESCRIPTION
In the lite workspace view, bare arrow/J/K navigation now continues across the border between the uncommitted files pane and the outline: at a pane's edge, focus moves into the vertically adjacent pane and selects its nearest item — the first when arriving from above, the last when arriving from below. This makes the two panes feel like one continuous list under the arrow keys.

Deliberate behaviors:
- The pane being left keeps its selection.
- If the adjacent pane has nothing to select, focus stays put rather than parking in an empty pane.
- Mod+Alt+arrow pane toggling is untouched and still preserves both panes' selections, so toggle-style switching coexists with the continuous navigation.
- In the future there will be more ways to go to a panel

Implementation: the shared navigation hook only reports the edge via a new optional `onEdgeSpill` callback. `OutlineTree`, the component that stacks the two panes and already owns both navigation indexes and select paths, wires the two directions (select the neighbor's edge item, then focus it). Panes that nothing wires — the diff and files panes, and the branches/upstream tabs — keep their edges inert. Earlier registry-based designs were dropped in review for this parent-wired shape, which needs no module state and no effect lifecycle.