### PR TITLE
Polish the lite diff minimap

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
@@ -147,6 +147,18 @@
 	   nothing to map. */
 	grid-template-columns: minmax(0, 1fr) auto;
 
+	/* The ruler ends where its map does, so its own edge can't be the column's:
+	   a map shorter than the pane would leave the rest of the gutter unruled and
+	   the code running into it. Placed into the ruler's cell, which is the full
+	   row whatever the ruler does with it, and behind it — the two borders land
+	   on the same pixel. */
+	&:has([data-minimap-navigable="true"])::before {
+		grid-area: 1 / 2;
+		border-left: 1px solid var(--border-2);
+		background-color: var(--bg-1);
+		content: "";
+	}
+
 	/* Drop the native scrollbar only while the minimap is showing, so a diff too
 	   short to map keeps one. */
 	&:has([data-minimap-navigable="true"]) .diffContents {

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
@@ -151,10 +151,8 @@
 		/* The ruler's edge, drawn from the code's side of it. The ruler ends where
 		   its map does — at a fixed scale a short diff doesn't reach the foot of the
 		   pane — while this column always fills the row, so the line runs unbroken
-		   from here. Stronger than the panel's other hairlines: the marks run right
-		   up to it, and a deletion-heavy diff puts near-identical pinks on both
-		   sides. */
-		border-right: 1px solid var(--border-2);
+		   from here. */
+		border-right: 1px solid var(--border-section);
 		/* Drop the native scrollbar only while the minimap is showing, so a diff too
 		   short to map keeps one. */
 		scrollbar-width: none;

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
@@ -147,21 +147,16 @@
 	   nothing to map. */
 	grid-template-columns: minmax(0, 1fr) auto;
 
-	/* The ruler ends where its map does, so its own edge can't be the column's:
-	   a map shorter than the pane would leave the rest of the gutter unruled and
-	   the code running into it. Placed into the ruler's cell, which is the full
-	   row whatever the ruler does with it, and behind it — the two borders land
-	   on the same pixel. */
-	&:has([data-minimap-navigable="true"])::before {
-		grid-area: 1 / 2;
-		border-left: 1px solid var(--border-2);
-		background-color: var(--bg-1);
-		content: "";
-	}
-
-	/* Drop the native scrollbar only while the minimap is showing, so a diff too
-	   short to map keeps one. */
 	&:has([data-minimap-navigable="true"]) .diffContents {
+		/* The ruler's edge, drawn from the code's side of it. The ruler ends where
+		   its map does — at a fixed scale a short diff doesn't reach the foot of the
+		   pane — while this column always fills the row, so the line runs unbroken
+		   from here. Stronger than the panel's other hairlines: the marks run right
+		   up to it, and a deletion-heavy diff puts near-identical pinks on both
+		   sides. */
+		border-right: 1px solid var(--border-2);
+		/* Drop the native scrollbar only while the minimap is showing, so a diff too
+		   short to map keeps one. */
 		scrollbar-width: none;
 
 		&::-webkit-scrollbar {

--- a/apps/lite/ui/src/routes/project/$id/workspace/DiffMinimap.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DiffMinimap.module.css
@@ -115,20 +115,22 @@
  * top left while the rest of them stay visible past it.
  */
 .badge {
+	display: flex;
 	z-index: 1;
 	position: absolute;
 	left: 0;
-	place-items: start;
-	width: 22px;
-	height: 22px;
+	align-items: center;
+	justify-content: center;
+	width: 16px;
+	height: 16px;
 	/* Clear the rule itself, so it runs unbroken behind the badge. */
 	margin-top: 1px;
-	background: linear-gradient(to bottom right, var(--bg-1) 50%, transparent 50%);
+	background: var(--bg-1);
 	cursor: pointer;
 
 	& > svg {
-		width: 14px;
-		height: 14px;
+		width: 12px;
+		height: 12px;
 	}
 }
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/DiffMinimap.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DiffMinimap.module.css
@@ -59,8 +59,12 @@
 	/* Behind the marks it covers rather than over them, so a selected hunk still
 	   reads as added or removed. */
 	--minimap-selection: color-mix(in srgb, var(--fill-pop-bg) 16%, transparent);
-
 	position: relative;
+
+	/* Placed rather than left to the flow: the pane draws the column's edge into
+	   this same cell, and auto-placement won't share a cell with something put
+	   there by hand. */
+	grid-area: 1 / 2;
 	/* Ends where the map does rather than stretching past it. At a fixed scale a
 	   short diff simply doesn't reach the foot of the pane, and ruler below the
 	   last line is ruler the lens can never travel to. */

--- a/apps/lite/ui/src/routes/project/$id/workspace/DiffMinimap.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DiffMinimap.module.css
@@ -61,20 +61,12 @@
 	--minimap-selection: color-mix(in srgb, var(--fill-pop-bg) 16%, transparent);
 	position: relative;
 
-	/* Placed rather than left to the flow: the pane draws the column's edge into
-	   this same cell, and auto-placement won't share a cell with something put
-	   there by hand. */
-	grid-area: 1 / 2;
 	/* Ends where the map does rather than stretching past it. At a fixed scale a
 	   short diff simply doesn't reach the foot of the pane, and ruler below the
 	   last line is ruler the lens can never travel to. */
 	align-self: start;
 	width: 56px;
 	height: var(--minimap-track-height, 100%);
-	/* Stronger than the panel's other hairlines: the marks run right to this
-	   edge, and a deletion-heavy diff puts near-identical pinks on both sides. */
-	border-left: 1px solid var(--border-2);
-	background-color: var(--bg-1);
 	cursor: default;
 }
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/DiffMinimap.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DiffMinimap.module.css
@@ -142,7 +142,9 @@
 	/* The ruler is the window's right edge, so the label opens inward. */
 	right: calc(100% + 8px);
 	align-items: center;
-	max-width: 420px;
+	/* Enough for a name and the end of the path it sits under. A label that runs
+	   most of the way across the diff covers the code it is naming. */
+	max-width: 280px;
 	padding: 6px 8px;
 	gap: 6px;
 	translate: 0 -50%;
@@ -161,12 +163,22 @@
 	height: 14px;
 }
 
+/* The name is what the pointer is asking about, so it doesn't give way at all
+   while the path still has something to give. Only a name that fills the label
+   on its own is cut, and then by the label's own width rather than by sharing. */
 .hintName {
+	flex: none;
+	max-width: 100%;
 	overflow: hidden;
 	text-overflow: ellipsis;
 }
 
+/* All of the shrinking, down to nothing if that is what the name needs. Read
+   from the right, so what survives of a long path is the part that tells the
+   file apart from its neighbours rather than the root it shares with them. */
 .hintDirectory {
+	flex: 0 1 auto;
+	min-width: 0;
 	overflow: hidden;
 	color: var(--text-2);
 	direction: rtl;

--- a/apps/lite/ui/src/routes/project/$id/workspace/DiffMinimap.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DiffMinimap.tsx
@@ -19,10 +19,12 @@ import {
 	type MinimapFile,
 	type MinimapGeometry,
 	type MinimapLayout,
+	type MinimapOverlays,
 	type MinimapSelection,
+	sameMinimapGeometry,
 	scrollMinimapTo,
 } from "./diff-minimap.ts";
-import { type MinimapBadge, paintMinimap } from "./diff-minimap-canvas.ts";
+import { forgetMinimapPalette, type MinimapBadge, paintMinimap } from "./diff-minimap-canvas.ts";
 import styles from "./DiffMinimap.module.css";
 
 /**
@@ -83,24 +85,54 @@ export const DiffMinimap: FC<{
 		const canvas = canvasRef.current;
 		if (!viewer || !canvas) return;
 
+		// The cached tokens are only invalidated by the scheme listener below, which
+		// no instance is holding while none is mounted.
+		forgetMinimapPalette();
+
 		let frame: number | null = null;
 		let forced = false;
 		let lastScrollHeight: number | null = null;
 		let lastOffset: number | null = null;
 		let lastScrollTop: number | null = null;
 
+		/**
+		 * What the ruler was last told, so a frame that would repeat itself doesn't
+		 * dirty style for nothing — the paint reads layout back, and a write between
+		 * the two makes that read a synchronous one.
+		 */
+		const written = new Map<string, string>();
+		const write = (ruler: HTMLElement, name: string, value: string): void => {
+			if (written.get(name) === value) return;
+
+			written.set(name, value);
+			ruler.style.setProperty(name, value);
+		};
+
+		// Overlays are in content pixels, so winding the map past them changes
+		// nothing about where they are. They cost a pass over every annotation of
+		// every file, which is not a thing to redo on a scroll.
+		let lastData = dataRef.current;
+		let lastGeometry: MinimapGeometry | null = null;
+		let lastOverlays: MinimapOverlays | null = null;
+
 		const draw = (layout: MinimapLayout): void => {
-			const { files, diffStyle, annotationsByPath, selection } = dataRef.current;
-			const geometry = getMinimapGeometry(
-				viewer,
-				files.map((file) => file.itemId),
-			);
+			const data = dataRef.current;
+			const { files, diffStyle, annotationsByPath, selection } = data;
+			const geometry = getMinimapGeometry(viewer, files);
 
 			geometryRef.current = geometry;
 			setNavigable(geometry !== null);
 			if (!geometry) return;
 
-			const overlays = getMinimapOverlays({ files, geometry, annotationsByPath, selection });
+			const overlays =
+				lastOverlays !== null && lastData === data && sameMinimapGeometry(lastGeometry, geometry)
+					? lastOverlays
+					: getMinimapOverlays({ files, geometry, annotationsByPath, selection });
+
+			lastData = data;
+			lastGeometry = geometry;
+			lastOverlays = overlays;
+
 			setBadges(paintMinimap(canvas, { files, geometry, layout, diffStyle, overlays }));
 		};
 
@@ -127,7 +159,7 @@ export const DiffMinimap: FC<{
 			// The ruler stops where the map does, so its own height can't be what the
 			// map was scaled against — that would be a box sized from what it holds
 			// and holding what it was sized for.
-			ruler.style.setProperty("--minimap-track-height", `${Math.min(track, layout.mapHeight)}px`);
+			write(ruler, "--minimap-track-height", `${Math.min(track, layout.mapHeight)}px`);
 
 			// Item heights start out estimated and firm up as virtualization renders
 			// them, which moves every file below. Total height moves with them, so it
@@ -146,8 +178,8 @@ export const DiffMinimap: FC<{
 			if (track === 0) return;
 
 			layoutRef.current = layout;
-			ruler.style.setProperty("--minimap-marker-top", `${layout.lensTop}px`);
-			ruler.style.setProperty("--minimap-marker-height", `${layout.lensHeight}px`);
+			write(ruler, "--minimap-marker-top", `${layout.lensTop}px`);
+			write(ruler, "--minimap-marker-height", `${layout.lensHeight}px`);
 		};
 
 		// A forced pass has to outlive being folded into a pending scroll one,
@@ -197,10 +229,14 @@ export const DiffMinimap: FC<{
 		};
 		ruler?.addEventListener("wheel", onWheel, { passive: false });
 
-		// Canvas colours are sampled, not live CSS, so they need repainting when
-		// the tokens behind them resolve differently.
+		// Canvas colours are sampled, not live CSS, so they need reading again and
+		// repainting when the tokens behind them resolve differently.
 		const scheme = globalThis.matchMedia("(prefers-color-scheme: dark)");
-		scheme.addEventListener("change", redraw);
+		const onScheme = (): void => {
+			forgetMinimapPalette();
+			redraw();
+		};
+		scheme.addEventListener("change", onScheme);
 
 		// The bitmap is sized from the device pixel ratio, which changes with no
 		// change to the ruler's own box when the window is dragged onto a display
@@ -223,7 +259,7 @@ export const DiffMinimap: FC<{
 			if (frame !== null) cancelAnimationFrame(frame);
 			unsubscribe();
 			resizeObserver.disconnect();
-			scheme.removeEventListener("change", redraw);
+			scheme.removeEventListener("change", onScheme);
 			pixels?.removeEventListener("change", onPixels);
 			ruler?.removeEventListener("wheel", onWheel);
 		};

--- a/apps/lite/ui/src/routes/project/$id/workspace/diff-minimap-canvas.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/diff-minimap-canvas.ts
@@ -269,6 +269,44 @@ const resolveColour = (colour: string): [number, number, number] => {
 };
 
 /**
+ * The tokens the ruler is drawn in. Reading them costs a style recalc, and the
+ * ruler writes its own inline properties just before every paint — so the recalc
+ * is never one the browser has already done. They only move with the colour
+ * scheme, which is a thing the ruler is told about.
+ */
+type MinimapPalette = {
+	context: [number, number, number];
+	deletions: [number, number, number];
+	additions: [number, number, number];
+	pin: string;
+	selection: string;
+	rule: string;
+};
+
+let palette: MinimapPalette | null = null;
+
+/** Drop the cached tokens, for a caller that knows they now resolve differently. */
+export const forgetMinimapPalette = (): void => {
+	palette = null;
+};
+
+const readPalette = (canvas: HTMLCanvasElement): MinimapPalette => {
+	if (palette) return palette;
+
+	const style = getComputedStyle(canvas);
+	palette = {
+		context: resolveColour(style.getPropertyValue("--minimap-context")),
+		deletions: resolveColour(style.getPropertyValue("--minimap-deletions")),
+		additions: resolveColour(style.getPropertyValue("--minimap-additions")),
+		pin: style.getPropertyValue("--minimap-pin"),
+		selection: style.getPropertyValue("--minimap-selection"),
+		rule: style.getPropertyValue("--minimap-file-rule"),
+	};
+
+	return palette;
+};
+
+/**
  * Paint the ruler, and report which files have room for a type icon. Badges are
  * only offered for files that kept a rule, so one always sits the same distance
  * under the line opening its section rather than measuring to one further up.
@@ -304,15 +342,7 @@ export const paintMinimap = (
 	context.setTransform(ratio, 0, 0, ratio, 0, 0);
 	context.clearRect(0, 0, width, height);
 
-	const palette = getComputedStyle(canvas);
-	const fills = {
-		context: palette.getPropertyValue("--minimap-context"),
-		deletions: palette.getPropertyValue("--minimap-deletions"),
-		additions: palette.getPropertyValue("--minimap-additions"),
-		pin: palette.getPropertyValue("--minimap-pin"),
-		selection: palette.getPropertyValue("--minimap-selection"),
-	};
-
+	const fills = readPalette(canvas);
 	const split = diffStyle === "split";
 	// One device pixel, in the CSS units the context is scaled to.
 	const thinnest = 1 / ratio;
@@ -413,15 +443,10 @@ export const paintMinimap = (
 
 		const right = columns + channel;
 		// Unchanged code is the same on both sides, so split shows it in both columns.
-		paintLane(surface.image.data, lanes.context, 0, resolveColour(fills.context));
-		if (split) paintLane(surface.image.data, lanes.context, right, resolveColour(fills.context));
-		paintLane(surface.image.data, lanes.deletions, 0, resolveColour(fills.deletions));
-		paintLane(
-			surface.image.data,
-			lanes.additions,
-			split ? right : 0,
-			resolveColour(fills.additions),
-		);
+		paintLane(surface.image.data, lanes.context, 0, fills.context);
+		if (split) paintLane(surface.image.data, lanes.context, right, fills.context);
+		paintLane(surface.image.data, lanes.deletions, 0, fills.deletions);
+		paintLane(surface.image.data, lanes.additions, split ? right : 0, fills.additions);
 
 		marks.putImageData(surface.image, 0, 0);
 		// Drawn rather than written, so the band beneath shows through the gaps.
@@ -431,7 +456,7 @@ export const paintMinimap = (
 	// Drawn last and opaque, so a rule reads over the marks it crosses rather
 	// than tinting with them.
 	const rules = resolveRules({ geometry, scale, offset, limit: height - thinnest });
-	context.fillStyle = palette.getPropertyValue("--minimap-file-rule");
+	context.fillStyle = fills.rule;
 	for (const rule of rules) context.fillRect(0, rule.y, width, thinnest);
 
 	// Pinned to the right edge, opposite the file badges, so a commented line is

--- a/apps/lite/ui/src/routes/project/$id/workspace/diff-minimap-canvas.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/diff-minimap-canvas.ts
@@ -290,22 +290,6 @@ export const forgetMinimapPalette = (): void => {
 	palette = null;
 };
 
-const readPalette = (canvas: HTMLCanvasElement): MinimapPalette => {
-	if (palette) return palette;
-
-	const style = getComputedStyle(canvas);
-	palette = {
-		context: resolveColour(style.getPropertyValue("--minimap-context")),
-		deletions: resolveColour(style.getPropertyValue("--minimap-deletions")),
-		additions: resolveColour(style.getPropertyValue("--minimap-additions")),
-		pin: style.getPropertyValue("--minimap-pin"),
-		selection: style.getPropertyValue("--minimap-selection"),
-		rule: style.getPropertyValue("--minimap-file-rule"),
-	};
-
-	return palette;
-};
-
 /**
  * Paint the ruler, and report which files have room for a type icon. Badges are
  * only offered for files that kept a rule, so one always sits the same distance
@@ -342,7 +326,15 @@ export const paintMinimap = (
 	context.setTransform(ratio, 0, 0, ratio, 0, 0);
 	context.clearRect(0, 0, width, height);
 
-	const fills = readPalette(canvas);
+	const palette = getComputedStyle(canvas);
+	const fills = {
+		context: palette.getPropertyValue("--minimap-context"),
+		deletions: palette.getPropertyValue("--minimap-deletions"),
+		additions: palette.getPropertyValue("--minimap-additions"),
+		pin: palette.getPropertyValue("--minimap-pin"),
+		selection: palette.getPropertyValue("--minimap-selection"),
+	};
+
 	const split = diffStyle === "split";
 	// One device pixel, in the CSS units the context is scaled to.
 	const thinnest = 1 / ratio;
@@ -443,10 +435,15 @@ export const paintMinimap = (
 
 		const right = columns + channel;
 		// Unchanged code is the same on both sides, so split shows it in both columns.
-		paintLane(surface.image.data, lanes.context, 0, fills.context);
-		if (split) paintLane(surface.image.data, lanes.context, right, fills.context);
-		paintLane(surface.image.data, lanes.deletions, 0, fills.deletions);
-		paintLane(surface.image.data, lanes.additions, split ? right : 0, fills.additions);
+		paintLane(surface.image.data, lanes.context, 0, resolveColour(fills.context));
+		if (split) paintLane(surface.image.data, lanes.context, right, resolveColour(fills.context));
+		paintLane(surface.image.data, lanes.deletions, 0, resolveColour(fills.deletions));
+		paintLane(
+			surface.image.data,
+			lanes.additions,
+			split ? right : 0,
+			resolveColour(fills.additions),
+		);
 
 		marks.putImageData(surface.image, 0, 0);
 		// Drawn rather than written, so the band beneath shows through the gaps.
@@ -456,7 +453,7 @@ export const paintMinimap = (
 	// Drawn last and opaque, so a rule reads over the marks it crosses rather
 	// than tinting with them.
 	const rules = resolveRules({ geometry, scale, offset, limit: height - thinnest });
-	context.fillStyle = fills.rule;
+	context.fillStyle = palette.getPropertyValue("--minimap-file-rule");
 	for (const rule of rules) context.fillRect(0, rule.y, width, thinnest);
 
 	// Pinned to the right edge, opposite the file badges, so a commented line is

--- a/apps/lite/ui/src/routes/project/$id/workspace/diff-minimap-canvas.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/diff-minimap-canvas.ts
@@ -290,6 +290,21 @@ export const forgetMinimapPalette = (): void => {
 	palette = null;
 };
 
+const readMinimapPalette = (canvas: HTMLCanvasElement): MinimapPalette => {
+	if (palette) return palette;
+
+	const tokens = getComputedStyle(canvas);
+	palette = {
+		context: resolveColour(tokens.getPropertyValue("--minimap-context")),
+		deletions: resolveColour(tokens.getPropertyValue("--minimap-deletions")),
+		additions: resolveColour(tokens.getPropertyValue("--minimap-additions")),
+		pin: tokens.getPropertyValue("--minimap-pin"),
+		selection: tokens.getPropertyValue("--minimap-selection"),
+		rule: tokens.getPropertyValue("--minimap-file-rule"),
+	};
+	return palette;
+};
+
 /**
  * Paint the ruler, and report which files have room for a type icon. Badges are
  * only offered for files that kept a rule, so one always sits the same distance
@@ -326,14 +341,7 @@ export const paintMinimap = (
 	context.setTransform(ratio, 0, 0, ratio, 0, 0);
 	context.clearRect(0, 0, width, height);
 
-	const palette = getComputedStyle(canvas);
-	const fills = {
-		context: palette.getPropertyValue("--minimap-context"),
-		deletions: palette.getPropertyValue("--minimap-deletions"),
-		additions: palette.getPropertyValue("--minimap-additions"),
-		pin: palette.getPropertyValue("--minimap-pin"),
-		selection: palette.getPropertyValue("--minimap-selection"),
-	};
+	const fills = readMinimapPalette(canvas);
 
 	const split = diffStyle === "split";
 	// One device pixel, in the CSS units the context is scaled to.
@@ -435,15 +443,10 @@ export const paintMinimap = (
 
 		const right = columns + channel;
 		// Unchanged code is the same on both sides, so split shows it in both columns.
-		paintLane(surface.image.data, lanes.context, 0, resolveColour(fills.context));
-		if (split) paintLane(surface.image.data, lanes.context, right, resolveColour(fills.context));
-		paintLane(surface.image.data, lanes.deletions, 0, resolveColour(fills.deletions));
-		paintLane(
-			surface.image.data,
-			lanes.additions,
-			split ? right : 0,
-			resolveColour(fills.additions),
-		);
+		paintLane(surface.image.data, lanes.context, 0, fills.context);
+		if (split) paintLane(surface.image.data, lanes.context, right, fills.context);
+		paintLane(surface.image.data, lanes.deletions, 0, fills.deletions);
+		paintLane(surface.image.data, lanes.additions, split ? right : 0, fills.additions);
 
 		marks.putImageData(surface.image, 0, 0);
 		// Drawn rather than written, so the band beneath shows through the gaps.
@@ -453,7 +456,7 @@ export const paintMinimap = (
 	// Drawn last and opaque, so a rule reads over the marks it crosses rather
 	// than tinting with them.
 	const rules = resolveRules({ geometry, scale, offset, limit: height - thinnest });
-	context.fillStyle = palette.getPropertyValue("--minimap-file-rule");
+	context.fillStyle = fills.rule;
 	for (const rule of rules) context.fillRect(0, rule.y, width, thinnest);
 
 	// Pinned to the right edge, opposite the file badges, so a commented line is

--- a/apps/lite/ui/src/routes/project/$id/workspace/diff-minimap.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/diff-minimap.ts
@@ -349,19 +349,24 @@ export const getMinimapFiles = ({
  */
 export const getMinimapGeometry = (
 	viewer: CodeView<Annotation>,
-	itemIds: Array<string>,
+	files: Array<MinimapFile>,
 ): MinimapGeometry | null => {
 	const total = contentHeight(viewer);
-	if (itemIds.length === 0) return null;
+	const first = files[0];
+	if (first === undefined) return null;
 
 	const blocks: Array<{ top: number; height: number }> = [];
 
-	for (const [index, itemId] of itemIds.entries()) {
-		const top = viewer.getTopForItem(itemId);
+	// Each file's own top is the one the file before it measured to, so ask once
+	// per file rather than once per boundary — this runs on every paint, and a
+	// wound map repaints per frame.
+	let top = viewer.getTopForItem(first.itemId);
+
+	for (let index = 0; index < files.length; index++) {
 		// CodeView can hold a stale item list for a frame after the diff changes.
 		if (top === undefined) return null;
 
-		const nextId = itemIds[index + 1];
+		const nextId = files[index + 1]?.itemId;
 		const nextTop = nextId === undefined ? undefined : viewer.getTopForItem(nextId);
 		if (nextId !== undefined && nextTop === undefined) return null;
 
@@ -369,9 +374,29 @@ export const getMinimapGeometry = (
 			nextTop === undefined ? total - codeViewLayout.paddingBottom : nextTop - codeViewLayout.gap;
 
 		blocks.push({ top, height: Math.max(bottom - top, 0) });
+		top = nextTop;
 	}
 
 	return { contentHeight: total, blocks };
+};
+
+/**
+ * Whether two readings describe the same layout. Cheap next to what a caller
+ * would otherwise redo on every frame: the blocks only move while CodeView's
+ * estimated item heights are still firming up, and stand still after that.
+ */
+export const sameMinimapGeometry = (
+	left: MinimapGeometry | null,
+	right: MinimapGeometry | null,
+): boolean => {
+	if (left === null || right === null) return left === right;
+	if (left.contentHeight !== right.contentHeight) return false;
+	if (left.blocks.length !== right.blocks.length) return false;
+
+	return left.blocks.every((block, index) => {
+		const other = right.blocks[index];
+		return other !== undefined && block.top === other.top && block.height === other.height;
+	});
 };
 
 /**


### PR DESCRIPTION
A few refinements to the diff minimap in the lite workspace:

- Draw the minimap's column edge behind the ruler
- Draw the minimap's edge from the code column
- Keep the minimap's per-frame work off style and layout
- Settle the minimap's edge and file badges
- Keep the minimap's hover label to its name