### PR TITLE
branch delete: clean up no-commit paths to target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1702,6 +1702,7 @@ dependencies = [
  "but-core",
  "but-ctx",
  "but-db",
+ "but-graph",
  "but-oplog",
  "but-rebase",
  "but-testsupport",

--- a/crates/but-rebase/src/graph_rebase/workspace.rs
+++ b/crates/but-rebase/src/graph_rebase/workspace.rs
@@ -16,7 +16,7 @@ use but_core::{
     ui::{CommitState, PushStatus},
 };
 use but_graph::workspace::commit::is_managed_workspace_by_message;
-use gix::prelude::ObjectIdExt;
+use gix::{prelude::ObjectIdExt, refs::FullNameRef};
 use petgraph::{Direction, visit::EdgeRef as _};
 
 use crate::graph_rebase::{
@@ -270,10 +270,20 @@ impl<M: RefMetadata> Editor<'_, '_, M> {
     }
 
     /// The target commit's node, if a target is configured and present.
-    fn target_selector(&self) -> Option<Selector> {
+    pub fn target_selector(&self) -> Option<Selector> {
         let target = self.workspace.graph.project_meta.target_commit_id?;
         let selector = self.try_select_commit(target)?;
         self.history.normalize_selector(selector).ok()
+    }
+
+    /// The target ref.
+    pub fn target_ref(&self) -> Option<&FullNameRef> {
+        self.workspace
+            .graph
+            .project_meta
+            .target_ref
+            .as_ref()
+            .map(|r| r.as_ref())
     }
 
     /// Compute the per-reference status for every local-branch reference in the

--- a/crates/but-transaction/Cargo.toml
+++ b/crates/but-transaction/Cargo.toml
@@ -17,6 +17,7 @@ but-core.workspace = true
 but-workspace.workspace = true
 but-rebase.workspace = true
 but-db.workspace = true
+but-graph.workspace = true
 
 gix.workspace = true
 anyhow.workspace = true

--- a/crates/but-transaction/src/lib.rs
+++ b/crates/but-transaction/src/lib.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use anyhow::Context as _;
-use bstr::BStr;
+use bstr::{BStr, BString, ByteVec};
 use but_api::WorkspaceState;
 use but_core::{
     DiffSpec, DryRun, RefMetadata, commit::CommitIdentifiers, ref_metadata, sync::RepoExclusive,
@@ -13,7 +13,7 @@ use but_core::{
 use but_ctx::Context;
 use but_oplog::legacy::SnapshotDetails;
 use but_rebase::graph_rebase::{
-    Editor, Step, SuccessfulRebase,
+    Editor, LookupStep as _, Step, SuccessfulRebase,
     mutate::{InsertSide, RelativeTo},
 };
 use but_workspace::commit::{
@@ -339,8 +339,83 @@ where
 
     pub fn remove_reference(&mut self, ref_name: &FullNameRef) -> anyhow::Result<()> {
         self.rebase(|mut editor, _, _| {
-            let selector = editor.select_reference(ref_name)?;
-            editor.replace(selector, but_rebase::graph_rebase::Step::None)?;
+            let ref_selector = editor.select_reference(ref_name)?;
+
+            let must_disconnect_child = 'must_disconnect: {
+                let Some(target_selector) = editor.target_selector() else {
+                    break 'must_disconnect None;
+                };
+
+                // Only one child, which must be the workspace commit. The
+                // workspace commit must also have more than one parent (if
+                // not the workspace commit would end up with no parents, which
+                // is bad).
+                let child_selectors = editor.direct_children(ref_selector)?;
+                let [(child_selector, _)] = child_selectors[..] else {
+                    break 'must_disconnect None;
+                };
+                if !matches!(editor.lookup_step(child_selector)?, Step::Pick(..)) {
+                    break 'must_disconnect None;
+                }
+                let (_, child_commit) = editor.find_selectable_commit(child_selector)?;
+                if !but_graph::workspace::commit::is_managed_workspace_by_message(
+                    child_commit.message.as_ref(),
+                ) {
+                    break 'must_disconnect None;
+                }
+                if editor.direct_parents(child_selector)?.len() == 1 {
+                    break 'must_disconnect None;
+                }
+
+                // All ancestors up to the target commit must be Step::None or
+                // the local branch corresponding to the target ref.
+                let mut ancestor_selectors: Vec<_> = editor
+                    .direct_parents(ref_selector)?
+                    .into_iter()
+                    .map(|(selector, _)| selector)
+                    .collect();
+                let target_local_branch = editor.target_ref().map(|r| {
+                    let bstr = r.as_bstr();
+                    if let Some(shortname) = bstr.rsplit(|&c| c == b'/').next() {
+                        let mut target_ref = BString::new(b"refs/heads/".to_vec());
+                        target_ref.push_str(shortname);
+                        target_ref
+                    } else {
+                        bstr.to_owned()
+                    }
+                });
+                while let Some(ancestor_selector) = ancestor_selectors.pop() {
+                    if ancestor_selector == target_selector {
+                        // OK, do nothing
+                    } else {
+                        let step = editor.lookup_step(ancestor_selector)?;
+                        let mut ok_to_skip = matches!(step, Step::None);
+                        if !ok_to_skip
+                            && let Some(ref target_local_branch) = target_local_branch
+                            && matches!(step, Step::Reference { refname, .. }
+                                if refname.as_bstr() == target_local_branch)
+                        {
+                            ok_to_skip = true;
+                        }
+                        if ok_to_skip {
+                            ancestor_selectors.extend(
+                                editor
+                                    .direct_parents(ancestor_selector)?
+                                    .into_iter()
+                                    .map(|(selector, _)| selector),
+                            );
+                        } else {
+                            break 'must_disconnect None;
+                        }
+                    }
+                }
+                Some(child_selector)
+            };
+
+            editor.replace(ref_selector, but_rebase::graph_rebase::Step::None)?;
+            if let Some(must_disconnect_child) = must_disconnect_child {
+                editor.remove_edges(must_disconnect_child, ref_selector)?;
+            }
             let rebase = editor.rebase()?;
             Ok(((), MaterializeWithoutCheckout::Either, rebase))
         })?;

--- a/crates/but/src/command/legacy/discard.rs
+++ b/crates/but/src/command/legacy/discard.rs
@@ -454,11 +454,11 @@ pub fn run(
         |mut tx| {
             let outcome = match executable {
                 ExecutableDiscardOperation::Branches { branches, commits } => {
-                    for branch in &branches {
-                        tx.remove_reference(branch.as_ref())?;
-                    }
                     if !commits.is_empty() {
                         tx.discard_commits(commits.iter().map(|c| c.commit_id))?;
+                    }
+                    for branch in &branches {
+                        tx.remove_reference(branch.as_ref())?;
                     }
                     DiscardOutcome::Branches(branches)
                 }

--- a/crates/but/tests/but/command/branch/delete.rs
+++ b/crates/but/tests/but/command/branch/delete.rs
@@ -47,6 +47,16 @@ Discarded branch 'A'
 Hint: run `but help` for all commands
 
 "#]]);
+
+    snapbox::assert_data_eq!(
+        env.git_log(),
+        snapbox::str![[r#"
+* 082c0c2 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+* d3e2ba3 (B) add B
+* 0dc3733 (origin/main, origin/HEAD, main, gitbutler/target) add M
+
+"#]]
+    );
 }
 
 #[test]
@@ -83,6 +93,17 @@ Discarded branch 'A'
 Hint: run `but help` for all commands
 
 "#]]);
+
+    snapbox::assert_data_eq!(
+        env.git_log(),
+        snapbox::str![[r#"
+* c4a9f43 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+* ec33a86 (C) add C
+* 05d3df1 (B) add B
+* 0dc3733 (origin/main, origin/HEAD, main, gitbutler/target) add M
+
+"#]]
+    );
 }
 
 #[test]
@@ -119,6 +140,17 @@ Discarded branch 'B'
 Hint: run `but help` for all commands
 
 "#]]);
+
+    snapbox::assert_data_eq!(
+        env.git_log(),
+        snapbox::str![[r#"
+* ea6cfac (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+* 983f317 (C) add C
+* 9477ae7 (A) add A
+* 0dc3733 (origin/main, origin/HEAD, main, gitbutler/target) add M
+
+"#]]
+    );
 }
 
 #[test]
@@ -155,6 +187,17 @@ Discarded branch 'C'
 Hint: run `but help` for all commands
 
 "#]]);
+
+    snapbox::assert_data_eq!(
+        env.git_log(),
+        snapbox::str![[r#"
+* 5299ad0 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+* 582f37b (B) add B
+* 9477ae7 (A) add A
+* 0dc3733 (origin/main, origin/HEAD, main, gitbutler/target) add M
+
+"#]]
+    );
 }
 
 #[test]

--- a/crates/but/tests/but/command/clean.rs
+++ b/crates/but/tests/but/command/clean.rs
@@ -33,6 +33,18 @@ fn removes_empty_branch() {
 ✓ Deleted 1 empty branch(es)
 
 "#]]);
+
+    snapbox::assert_data_eq!(
+        env.git_log(),
+        snapbox::str![[r#"
+*   0e97f4a (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+|/  
+| * 9477ae7 (A) add A
+|/  
+* 0dc3733 (origin/main, origin/HEAD, main, gitbutler/target) add M
+
+"#]]
+    );
 }
 
 #[test]


### PR DESCRIPTION
Currently, when a branch is deleted, an edge between the workspace
commit and the target (or the local branch corresponding to the target
ref) remains. Ensure that we do not have that edge.