### PR TITLE
Fix the upstream graph's rail ends

### DIFF
--- a/apps/lite/package.json
+++ b/apps/lite/package.json
@@ -126,7 +126,7 @@
 		"@base-ui/react": "^1.6.0",
 		"@base-ui/utils": "^0.3.1",
 		"@gitbutler/but-sdk": "workspace:*",
-		"@gitbutler/design-core": "3.11.2",
+		"@gitbutler/design-core": "3.11.4",
 		"@pierre/diffs": "^1.3.5",
 		"@pierre/theming": "^1.0.1",
 		"@reduxjs/toolkit": "catalog:redux",

--- a/apps/lite/ui/src/components/GraphSegment.tsx
+++ b/apps/lite/ui/src/components/GraphSegment.tsx
@@ -5,6 +5,11 @@ import type { CommitState } from "@gitbutler/but-sdk";
 
 const glyphPaths = {
 	parent: "M8 0V28",
+	/* The parent line with its overhead dropped, for a row that starts a rail
+	   rather than continuing one. It begins where the group glyph's rings do, so
+	   a fold toggle heading a rail starts its line in the same place whether the
+	   run it holds is folded away or on screen. */
+	parentHead: "M8 3V28",
 	horizontal: "M-9.53674e-07 14L16 14",
 	space: "",
 	// Forks
@@ -32,20 +37,37 @@ const commitGlyph = (
 	</>
 );
 
+const groupRingsPath =
+	"M11.0862 8.1524C11.3502 7.6602 11.5 7.0976 11.5 6.5C11.5 4.567 9.933 3 8 3C6.067 3 4.5 4.567 4.5 6.5C4.5 7.0976 4.64977 7.6602 4.91382 8.1524M5 11.8038C4.68259 11.277 4.5 10.6598 4.5 10C4.5 8.067 6.067 6.5 8 6.5C9.933 6.5 11.5 8.067 11.5 10C11.5 10.6598 11.3174 11.277 11 11.8038M11.5 13.5C11.5 15.433 9.933 17 8 17C6.067 17 4.5 15.433 4.5 13.5C4.5 11.567 6.067 10 8 10C9.933 10 11.5 11.567 11.5 13.5Z";
+
 const groupGlyph = (
 	<>
 		<path opacity="0.4" d="M8 0V2.78571M8 17.0038V26" stroke="currentColor" strokeWidth="1.5" />
-		<path
-			d="M11.0862 8.1524C11.3502 7.6602 11.5 7.0976 11.5 6.5C11.5 4.567 9.933 3 8 3C6.067 3 4.5 4.567 4.5 6.5C4.5 7.0976 4.64977 7.6602 4.91382 8.1524M5 11.8038C4.68259 11.277 4.5 10.6598 4.5 10C4.5 8.067 6.067 6.5 8 6.5C9.933 6.5 11.5 8.067 11.5 10C11.5 10.6598 11.3174 11.277 11 11.8038M11.5 13.5C11.5 15.433 9.933 17 8 17C6.067 17 4.5 15.433 4.5 13.5C4.5 11.567 6.067 10 8 10C9.933 10 11.5 11.567 11.5 13.5Z"
-			stroke="currentColor"
-			strokeWidth="1.5"
-		/>
+		<path d={groupRingsPath} stroke="currentColor" strokeWidth="1.5" />
+	</>
+);
+
+/** The rings without the tail above them, for a row that starts a rail. */
+const groupHeadGlyph = (
+	<>
+		<path opacity="0.4" d="M8 17.0038V26" stroke="currentColor" strokeWidth="1.5" />
+		<path d={groupRingsPath} stroke="currentColor" strokeWidth="1.5" />
 	</>
 );
 
 /** @public */
-export type GraphSegmentGlyph = keyof typeof glyphPaths | "commit" | "group";
+export type GraphSegmentGlyph = keyof typeof glyphPaths | "commit" | "group" | "groupHead";
 
+/** Both are drawn on the group glyph's shorter canvas. */
+const isGroupGlyph = (glyph: GraphSegmentGlyph): boolean =>
+	glyph === "group" || glyph === "groupHead";
+
+/**
+ * Glyphs whose rail carries on past the drawing, so a taller row goes on
+ * drawing it. The head glyphs are left out: what they start is the rail below
+ * them, and the band would draw over the very space they exist to leave empty
+ * in a column that stacks upwards.
+ */
 const stretchableGlyphs = new Set<GraphSegmentGlyph>([
 	"parent",
 	"commit",
@@ -73,8 +95,8 @@ interface GraphSegmentProps extends ComponentProps<"div"> {
 export const GraphSegment: FC<GraphSegmentProps> = ({ glyph, className, status, ...props }) => (
 	<div {...props} className={classes(className, styles.container)} data-status={status}>
 		<svg
-			className={classes(styles.mainSegment, glyph === "group" && styles.groupSegment)}
-			viewBox={glyph === "group" ? "0 0 16 26" : "0 0 16 28"}
+			className={classes(styles.mainSegment, isGroupGlyph(glyph) && styles.groupSegment)}
+			viewBox={isGroupGlyph(glyph) ? "0 0 16 26" : "0 0 16 28"}
 			fill="none"
 			xmlns="http://www.w3.org/2000/svg"
 			aria-hidden="true"
@@ -84,6 +106,8 @@ export const GraphSegment: FC<GraphSegmentProps> = ({ glyph, className, status, 
 				commitGlyph
 			) : glyph === "group" ? (
 				groupGlyph
+			) : glyph === "groupHead" ? (
+				groupHeadGlyph
 			) : (
 				<path d={glyphPaths[glyph]} opacity="0.4" stroke="currentColor" strokeWidth="1.5" />
 			)}

--- a/apps/lite/ui/src/routes/project/$id/workspace/UpstreamList.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/UpstreamList.tsx
@@ -178,7 +178,9 @@ const SegmentExpanderRow: FC<{
 	segmentId: string;
 	count: number;
 	expanded: boolean;
-}> = ({ projectId, segmentId, count, expanded }) => {
+	/** Set when the row opens the workspace rail, so nothing is drawn above it. */
+	opensRail: boolean;
+}> = ({ projectId, segmentId, count, expanded, opensRail }) => {
 	const dispatch = useAppDispatch();
 
 	return (
@@ -188,7 +190,9 @@ const SegmentExpanderRow: FC<{
 				    away; once they are on screen the rail just runs past the toggle. */}
 				<GraphSegment
 					className={styles.expanderGlyph}
-					glyph={expanded ? "parent" : "group"}
+					glyph={
+						opensRail ? (expanded ? "parentHead" : "groupHead") : expanded ? "parent" : "group"
+					}
 					status="LocalOnly"
 				/>
 				<GraphSegment className={styles.railStub} glyph="parent" status="LocalOnly" />
@@ -289,8 +293,12 @@ const RunTail: FC = () => (
 const listItem = (
 	projectId: string,
 	item: UpstreamListItem,
-	/** The first branch row opens the workspace rail; the rest join it. */
-	isFirstBranch: boolean,
+	/**
+	 * Set on the region's first row, which opens the workspace rail: a branch
+	 * forks it into being rather than joining it, and a fold toggle heads it
+	 * with nothing drawn above the rings.
+	 */
+	opensRail: boolean,
 ) => {
 	switch (item.type) {
 		case "commit":
@@ -300,7 +308,7 @@ const listItem = (
 				<UpstreamBranchRow
 					key={`${item.stackKey}/${item.name}`}
 					item={item}
-					glyph={isFirstBranch ? "forkRight" : "joinRight"}
+					glyph={opensRail ? "forkRight" : "joinRight"}
 				/>
 			);
 		case "expander":
@@ -311,6 +319,7 @@ const listItem = (
 					segmentId={item.segmentId}
 					count={item.count}
 					expanded={item.expanded}
+					opensRail={opensRail}
 				/>
 			);
 		default:
@@ -380,7 +389,9 @@ export const UpstreamList: FC<
 
 	const targetItems = items.slice(0, incomingItemCount);
 	const workspaceItems = items.slice(incomingItemCount);
-	const firstBranch = workspaceItems.find((item) => item.type === "branch");
+	// Whatever comes first opens the workspace rail, fold toggle or branch alike;
+	// everything under it joins a rail that is already running.
+	const railHead = workspaceItems[0];
 	// The rail's tail carries on from the last branch, so it has to be coloured
 	// the same as the segment it continues rather than always as local work.
 	const lastBranch = workspaceItems.findLast((item) => item.type === "branch");
@@ -444,7 +455,7 @@ export const UpstreamList: FC<
 					{workspaceItems.length > 0 && <div role="none" className={styles.divider} />}
 
 					{workspaceItems.flatMap((item, index) => {
-						const row = listItem(projectId, item, item === firstBranch);
+						const row = listItem(projectId, item, item === railHead);
 						// Commits only appear here as the body of an expanded run, so
 						// the last one before anything else is where a run closes.
 						const next = workspaceItems[index + 1];

--- a/apps/lite/ui/src/routes/project/$id/workspace/UpstreamList.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/UpstreamList.tsx
@@ -381,6 +381,9 @@ export const UpstreamList: FC<
 	const targetItems = items.slice(0, incomingItemCount);
 	const workspaceItems = items.slice(incomingItemCount);
 	const firstBranch = workspaceItems.find((item) => item.type === "branch");
+	// The rail's tail carries on from the last branch, so it has to be coloured
+	// the same as the segment it continues rather than always as local work.
+	const lastBranch = workspaceItems.findLast((item) => item.type === "branch");
 
 	return (
 		<div {...restProps} className={classes(restProps.className, styles.container)}>
@@ -450,7 +453,9 @@ export const UpstreamList: FC<
 							: [row];
 					})}
 
-					{workspaceItems.length > 0 && <RailTail status="LocalOnly" />}
+					{workspaceItems.length > 0 && (
+						<RailTail status={lastBranch?.integrated === true ? "Integrated" : "LocalOnly"} />
+					)}
 				</div>
 
 				{outline.truncated && (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -414,8 +414,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/but-sdk
       '@gitbutler/design-core':
-        specifier: 3.11.2
-        version: 3.11.2
+        specifier: 3.11.4
+        version: 3.11.4
       '@pierre/diffs':
         specifier: ^1.3.5
         version: 1.3.5(@shikijs/themes@4.3.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -2036,8 +2036,8 @@ packages:
   '@gitbutler/design-core@2.2.2':
     resolution: {integrity: sha512-oPPnYjwsKxwoTY6wK/fT9ylwhSIBgQxCOGJzYefbM8WFr2OuJePH9MnDnZ3K9UQlb94p+NR7m/QCFzhbDVRwxw==}
 
-  '@gitbutler/design-core@3.11.2':
-    resolution: {integrity: sha512-R4DYPQ6lerTYZgBKqDVQbsaK27SsbGbylD4DPI83Zwlbcx29H6yka7vXAjlq6c5qRfWYpfhP/53I3FBrxCTVZQ==}
+  '@gitbutler/design-core@3.11.4':
+    resolution: {integrity: sha512-ZBl47fKw9gP3YKgopIGrskbYv284/O9mlTJMLx+DbIuRZ8jLK9Faj+fARZP8EekXbHqHEV9zwZNp0EU7jj1hOg==}
 
   '@gitbutler/design-core@3.9.1':
     resolution: {integrity: sha512-kLkZ1+pqeqpBntBOSV53kYVCmY/ZFemjxsWc78GTGLgn1Op8p7bWCNxCUSU822MKLJrzmjUg99MpqdHpXGcNAQ==}
@@ -11312,7 +11312,7 @@ snapshots:
 
   '@gitbutler/design-core@2.2.2': {}
 
-  '@gitbutler/design-core@3.11.2': {}
+  '@gitbutler/design-core@3.11.4': {}
 
   '@gitbutler/design-core@3.9.1': {}
 


### PR DESCRIPTION
### Bugs:

<img width="1078" height="696" alt="Screenshot 2026-08-11 at 11-32-39" src="https://github.com/user-attachments/assets/59190516-b041-4bd2-bc63-996036320f62" />
<img width="906" height="795" alt="Screenshot 2026-08-11 at 11-33-04" src="https://github.com/user-attachments/assets/6bc594a2-0d77-456a-9683-5accfd2af09f" />


Two rail glitches in the Upstream tab's workspace region:

- The tail below the last branch was hard-coded to the local-only colour, so it stayed grey under a branch that had been integrated. It now takes its colour from the branch it continues.
- The rail's head is now the region's first row, whatever that row is. With a fold toggle on top, the branch below it joins the rail instead of forking a new one, and the toggle no longer draws a stub of rail above its rings.

The second one adds `parentHead` and `groupHead` to `GraphSegment`: the parent line and the ring stack without the overhead they normally draw for a rail above to meet. Both are non-stretchable — what a head glyph starts is the rail below it.