### PR TITLE
Test ad-hoc commit and push workflows

### DIFF
--- a/crates/but/tests/but/command/commit.rs
+++ b/crates/but/tests/but/command/commit.rs
@@ -102,6 +102,188 @@ Hint: run `but help` for all commands
 }
 
 #[test]
+fn commits_on_the_checked_out_branch_in_single_branch_mode() {
+    let env = Sandbox::open_with_default_settings("one-fork");
+    env.but("config feature single-branch enable")
+        .assert()
+        .success();
+    let old_head = env.invoke_git("rev-parse HEAD");
+    env.file("existing.txt", "content\n");
+
+    env.but("status")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+╭┄ zz [uncommitted]
+┊   pr A existing.txt
+┊
+┊╭┄ ma [main]
+┊●   nmy M (no changes)
+├╯
+┊
+┴ e31e6ca (common base) 2000-01-02 add init
+
+Hint: run `but diff` to see uncommitted changes and `but commit -b <branch> -m "message" <id>` to commit them
+
+"#]]);
+
+    env.but("commit -m 'commit on main'")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+Created commit 1 on branch 'main'
+
+"#]]);
+
+    env.but("status")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ ma [main]
+┊●   1 commit on main
+┊●   nmy M (no changes)
+├╯
+┊
+┴ e31e6ca (common base) 2000-01-02 add init
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    assert_eq!(
+        env.invoke_git("symbolic-ref --short HEAD"),
+        "main",
+        "committing to the checked-out branch should keep it checked out"
+    );
+    assert_eq!(
+        env.invoke_git("rev-parse HEAD^"),
+        old_head,
+        "the commit should advance the checked-out branch"
+    );
+    assert_eq!(env.invoke_git("show HEAD:existing.txt"), "content");
+    assert!(
+        env.open_repo()
+            .try_find_reference(but_core::WORKSPACE_REF_NAME)
+            .unwrap()
+            .is_none(),
+        "committing to an existing branch must not create a managed workspace"
+    );
+}
+
+#[test]
+fn commits_at_each_branch_in_an_existing_single_branch_stack() {
+    let env = Sandbox::open_with_default_settings("one-fork");
+    env.but("config feature single-branch enable")
+        .assert()
+        .success();
+
+    env.but("branch new middle").assert().success();
+    env.but("commit --empty -b middle -m 'middle base'")
+        .assert()
+        .success();
+    env.but("branch new top").assert().success();
+    env.but("commit --empty -b top -m 'top base'")
+        .assert()
+        .success();
+
+    env.file("bottom.txt", "bottom\n");
+    env.but("status")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+╭┄ zz [uncommitted]
+┊   tk A bottom.txt
+┊
+┊╭┄ to [top]
+┊●   1#0 top base (no changes)
+┊│
+┊├┄ mi [middle]
+┊●   1#1 middle base (no changes)
+┊│
+┊├┄ ma [main]
+┊●   nmy M (no changes)
+┊●   ply add init
+├╯
+┊
+┴ e31e6ca (common base) 2000-01-02 add init
+
+Hint: run `but diff` to see uncommitted changes and `but commit -b <branch> -m "message" <id>` to commit them
+
+"#]]);
+
+    env.but("commit -b main -m 'bottom position'")
+        .assert()
+        .success();
+    env.file("middle.txt", "middle\n");
+    env.but("commit -b middle -m 'middle position'")
+        .assert()
+        .success();
+    env.file("top.txt", "top\n");
+    env.but("commit -b top -m 'top position'")
+        .assert()
+        .success();
+
+    env.but("status")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ to [top]
+┊●   1#0 top position
+┊●   1#1 top base (no changes)
+┊│
+┊├┄ mi [middle]
+┊●   1#2 middle position
+┊●   1#3 middle base (no changes)
+┊│
+┊├┄ ma [main]
+┊●   1#4 bottom position
+┊●   nmy M (no changes)
+├╯
+┊
+┴ e31e6ca (common base) 2000-01-02 add init
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    assert_eq!(
+        env.invoke_git("log --format=%s --reverse origin/main..top"),
+        "M\nbottom position\nmiddle base\nmiddle position\ntop base\ntop position",
+        "commits should remain ordered at the bottom, middle, and top branch positions"
+    );
+    assert_eq!(
+        env.invoke_git("show -s --format=%s main"),
+        "bottom position"
+    );
+    assert_eq!(
+        env.invoke_git("show -s --format=%s middle"),
+        "middle position"
+    );
+    assert_eq!(env.invoke_git("show -s --format=%s top"), "top position");
+    assert_eq!(
+        env.invoke_git("symbolic-ref --short HEAD"),
+        "top",
+        "committing lower in the stack should preserve the checked-out top branch"
+    );
+    assert!(
+        env.open_repo()
+            .try_find_reference(but_core::WORKSPACE_REF_NAME)
+            .unwrap()
+            .is_none(),
+        "stacked commits must remain outside managed workspace mode"
+    );
+}
+
+#[test]
 fn commits_on_top_of_a_checked_out_managed_workspace_branch() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
     env.setup_metadata(&["A"]);

--- a/crates/but/tests/but/command/push.rs
+++ b/crates/but/tests/but/command/push.rs
@@ -24,6 +24,67 @@ fn repo_with_unpushed_branch() -> Sandbox {
     env
 }
 
+fn repo_with_unpushed_single_branch() -> (Sandbox, std::path::PathBuf) {
+    let env = Sandbox::open_with_default_settings("one-fork");
+    env.but("config feature single-branch enable")
+        .assert()
+        .success();
+
+    let remote = env.app_data_dir().join("origin.git");
+    env.invoke_bash(format!(
+        "git clone -q --bare . {remote} && git remote set-url origin {remote}",
+        remote = remote.display(),
+    ));
+
+    env.file("unpushed.txt", "content\n");
+    env.but("commit -m 'unpushed work'").assert().success();
+
+    (env, remote)
+}
+
+fn assert_single_branch_status_before_push(env: &Sandbox) {
+    env.but("status")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ ma [main]
+┊●   1 unpushed work
+┊●   nmy M (no changes)
+├╯
+┊
+┴ e31e6ca (common base) 2000-01-02 add init
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+fn assert_single_branch_status_after_push(env: &Sandbox) {
+    env.but("status")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ ma [main] (merged upstream)
+┊●   1 unpushed work
+┊●   nmy M (no changes)
+┊●   ply add init
+├╯
+┊
+┊● d50ec84 (upstream: origin/main) 2 new commits
+├╯ e31e6ca (common base) 2000-01-02 add init
+
+Hint: origin/main moved ahead; run `but pull` to update the workspace
+Hint: branches marked `(merged upstream)` have landed; run `but pull` to remove them, or start new work on another branch
+
+"#]]);
+}
+
 fn configure_other_tracking_remote(env: &Sandbox) -> std::path::PathBuf {
     let remote_base = env.invoke_git("rev-parse refs/heads/branchB^");
     let other = env.app_data_dir().join("other.git");
@@ -37,6 +98,58 @@ fn configure_other_tracking_remote(env: &Sandbox) -> std::path::PathBuf {
         other = other.display(),
     ));
     other
+}
+
+#[test]
+fn pushes_an_explicit_checked_out_branch_in_single_branch_mode() {
+    let (env, remote) = repo_with_unpushed_single_branch();
+    let local_tip = env.invoke_git("rev-parse main");
+    assert_single_branch_status_before_push(&env);
+
+    env.but("push main").assert().success();
+    assert_single_branch_status_after_push(&env);
+
+    assert_eq!(
+        env.invoke_git(&format!(
+            "--git-dir={} rev-parse refs/heads/main",
+            remote.display()
+        )),
+        local_tip,
+        "explicit push should update the checked-out branch on the remote"
+    );
+    assert!(
+        env.open_repo()
+            .try_find_reference(but_core::WORKSPACE_REF_NAME)
+            .unwrap()
+            .is_none(),
+        "pushing must not create a managed workspace"
+    );
+}
+
+#[test]
+fn bare_push_pushes_the_checked_out_branch_in_single_branch_mode() {
+    let (env, remote) = repo_with_unpushed_single_branch();
+    let local_tip = env.invoke_git("rev-parse main");
+    assert_single_branch_status_before_push(&env);
+
+    env.but("push").assert().success();
+    assert_single_branch_status_after_push(&env);
+
+    assert_eq!(
+        env.invoke_git(&format!(
+            "--git-dir={} rev-parse refs/heads/main",
+            remote.display()
+        )),
+        local_tip,
+        "bare push should select and update the checked-out branch"
+    );
+    assert!(
+        env.open_repo()
+            .try_find_reference(but_core::WORKSPACE_REF_NAME)
+            .unwrap()
+            .is_none(),
+        "pushing must not create a managed workspace"
+    );
 }
 
 /// An unreachable remote that is not the target's must not block a dry-run push:

--- a/crates/but/tests/but/command/push.rs
+++ b/crates/but/tests/but/command/push.rs
@@ -24,16 +24,20 @@ fn repo_with_unpushed_branch() -> Sandbox {
     env
 }
 
+fn shell_quote_path(path: &std::path::Path) -> String {
+    shell_words::quote(&path.display().to_string()).into_owned()
+}
+
 fn repo_with_unpushed_single_branch() -> (Sandbox, std::path::PathBuf) {
     let env = Sandbox::open_with_default_settings("one-fork");
     env.but("config feature single-branch enable")
         .assert()
         .success();
 
-    let remote = env.app_data_dir().join("origin.git");
+    let remote = env.app_data_dir().join("origin with spaces.git");
+    let remote_arg = shell_quote_path(&remote);
     env.invoke_bash(format!(
-        "git clone -q --bare . {remote} && git remote set-url origin {remote}",
-        remote = remote.display(),
+        "git clone -q --bare . {remote_arg} && git remote set-url origin {remote_arg}",
     ));
 
     env.file("unpushed.txt", "content\n");
@@ -112,7 +116,7 @@ fn pushes_an_explicit_checked_out_branch_in_single_branch_mode() {
     assert_eq!(
         env.invoke_git(&format!(
             "--git-dir={} rev-parse refs/heads/main",
-            remote.display()
+            shell_quote_path(&remote)
         )),
         local_tip,
         "explicit push should update the checked-out branch on the remote"
@@ -138,7 +142,7 @@ fn bare_push_pushes_the_checked_out_branch_in_single_branch_mode() {
     assert_eq!(
         env.invoke_git(&format!(
             "--git-dir={} rev-parse refs/heads/main",
-            remote.display()
+            shell_quote_path(&remote)
         )),
         local_tip,
         "bare push should select and update the checked-out branch"


### PR DESCRIPTION
## What changed

- cover commits on the checked-out branch in ad-hoc single-branch mode
- cover commits at the bottom, middle, and top refs of an existing stacked branch chain
- cover explicit and argument-less pushes to a real bare remote
- snapshot `but status` before and after each workflow while retaining direct Git ref and ancestry assertions

## Why

Most CLI tests initialize a managed `gitbutler/workspace`, leaving normal Git checkouts under-tested. These journeys verify that commit and push workflows operate on real checked-out refs without creating the managed workspace ref.

The post-push snapshot also documents the current target-base behavior: after `origin/main` advances, status marks the branch merged upstream and recommends `but pull`.
