### PR TITLE
Attribute apply conflicts with the target to the target

### DIFF
--- a/apps/desktop/src/lib/stacks/stack.ts
+++ b/apps/desktop/src/lib/stacks/stack.ts
@@ -33,6 +33,18 @@ function prettyNamedListIfPossible(expectedNames: number, names: string[]): stri
 }
 
 export function handleApplyOutcome(outcome: ApplyOutcome) {
+	if (outcome.status === "conflictsWithTarget") {
+		const files = outcome.targetConflicts;
+		const fileList =
+			files.length > 0 ? `\n\nConflicting files:\n\n${files.map((f) => `- ${f}`).join("\n")}` : "";
+		showWarning(
+			"Couldn't apply branch due to conflicts",
+			`It is behind the workspace target and conflicts with it. Update the branch with the latest target changes, then try applying again.${fileList}`,
+			undefined,
+			TestId.BranchApplyConflictToast,
+		);
+		return;
+	}
 	if (outcome.status !== "conflictAborted") return;
 	const names = outcome.conflictingStacks.map((stack) => stack.shortName);
 	const single = names.length === 1;

--- a/apps/lite/ui/src/api/mutations.ts
+++ b/apps/lite/ui/src/api/mutations.ts
@@ -102,7 +102,19 @@ export const useApply = () => {
 	return useMutation({
 		mutationFn: window.lite.apply,
 		onSuccess: async (response, input, _context, mutation) => {
-			if (response.conflictingStacks.length > 0) {
+			if (response.status === "conflictsWithTarget") {
+				const files = response.targetConflicts;
+				const fileList =
+					files.length > 0
+						? `\n\nConflicting files:\n${files.map((f) => `- ${f}`).join("\n")}`
+						: "";
+				toastManager.add({
+					type: "error",
+					title: "Failed to apply branch",
+					description: `'${input.existingBranch}' is behind the workspace target and conflicts with it. Update the branch with the latest target changes, then try applying again.${fileList}`,
+					priority: "high",
+				});
+			} else if (response.conflictingStacks.length > 0) {
 				const toastId = toastManager.add({
 					type: "error",
 					title: "Failed to apply branch",

--- a/apps/lite/ui/src/components/Toasts.module.css
+++ b/apps/lite/ui/src/components/Toasts.module.css
@@ -29,6 +29,11 @@
 	gap: 12px;
 }
 
+.description {
+	/* Descriptions may carry line-separated lists, e.g. conflicting files. */
+	white-space: pre-line;
+}
+
 .actions {
 	display: flex;
 	flex-wrap: wrap;

--- a/apps/lite/ui/src/components/Toasts.tsx
+++ b/apps/lite/ui/src/components/Toasts.tsx
@@ -20,7 +20,7 @@ export const Toasts: FC = () => {
 									// Default is `p` which restricts content elements.
 									<div />
 								}
-								className="text-13"
+								className={classes("text-13", styles.description)}
 							/>
 							<div className={styles.actions}>
 								{toast.actionProps && <Toast.Action className={getButtonClassName({})} />}

--- a/crates/but-api/src/branch.rs
+++ b/crates/but-api/src/branch.rs
@@ -98,12 +98,17 @@ pub mod json {
         pub workspace_changed: bool,
         /// Branches activated or recorded by the operation.
         ///
-        /// This is empty for `alreadyApplied` and `conflictAborted`, and populated for `applied`.
+        /// This is empty for `alreadyApplied`, `conflictAborted` and `conflictsWithTarget`, and populated for `applied`.
         pub applied_branches: Vec<crate::json::FullRefName>,
         /// Whether the workspace reference had to be created.
         pub workspace_ref_created: bool,
         /// Stacks that conflicted while applying the branch.
         pub conflicting_stacks: Vec<ConflictingStack>,
+        /// Worktree-relative paths at which the branch conflicts with the workspace target.
+        ///
+        /// Only populated for `conflictsWithTarget`.
+        #[cfg_attr(feature = "export-schema", schemars(with = "Vec<String>"))]
+        pub target_conflicts: Vec<but_serde::BStringForFrontend>,
     }
 
     /// A stack that conflicted while applying a branch.
@@ -131,6 +136,7 @@ pub mod json {
                 workspace_ref_created,
                 workspace_merge: _,
                 conflicting_stacks,
+                target_conflicts,
             } = value;
 
             ApplyOutcome {
@@ -138,6 +144,7 @@ pub mod json {
                 workspace_changed,
                 applied_branches: applied_branches.into_iter().map(Into::into).collect(),
                 workspace_ref_created,
+                target_conflicts: target_conflicts.into_iter().map(Into::into).collect(),
                 conflicting_stacks: conflicting_stacks
                     .into_iter()
                     .map(|stack| {

--- a/crates/but-workspace/src/branch/apply.rs
+++ b/crates/but-workspace/src/branch/apply.rs
@@ -36,6 +36,9 @@ pub enum OutcomeStatus {
     Applied,
     /// A workspace merge was attempted and conflicts prevented persistence.
     ConflictAborted,
+    /// The branch conflicts with the workspace target it is based behind, so no stack is to blame.
+    /// The branch itself needs updating with the target changes before it can be applied.
+    ConflictsWithTarget,
 }
 #[cfg(feature = "export-schema")]
 but_schemars::register_sdk_type!(OutcomeStatus);
@@ -47,6 +50,7 @@ impl OutcomeStatus {
             OutcomeStatus::AlreadyApplied => "alreadyApplied",
             OutcomeStatus::Applied => "applied",
             OutcomeStatus::ConflictAborted => "conflictAborted",
+            OutcomeStatus::ConflictsWithTarget => "conflictsWithTarget",
         }
     }
 
@@ -86,6 +90,10 @@ pub struct Outcome {
     /// Each entry includes the stable stack id and its tip ref name, so callers don't have to
     /// recover names from the returned workspace graph.
     pub conflicting_stacks: Vec<ConflictingStack>,
+    /// Worktree-relative paths at which the branch conflicts with the workspace target.
+    ///
+    /// Only populated when [Outcome::status] is [OutcomeStatus::ConflictsWithTarget].
+    pub target_conflicts: Vec<bstr::BString>,
 }
 
 impl Outcome {
@@ -104,6 +112,7 @@ impl std::fmt::Debug for Outcome {
             workspace_ref_created,
             workspace_merge: _,
             conflicting_stacks,
+            target_conflicts,
             applied_branches,
         } = self;
         let mut f = f.debug_struct("Outcome");
@@ -122,6 +131,19 @@ impl std::fmt::Debug for Outcome {
             );
         if !conflicting_stacks.is_empty() {
             f.field("conflicting_stacks", conflicting_stacks);
+        }
+        if !target_conflicts.is_empty() {
+            f.field(
+                "target_conflicts",
+                &format!(
+                    "[{}]",
+                    target_conflicts
+                        .iter()
+                        .map(|path| path.to_string())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ),
+            );
         }
         f.finish()
     }
@@ -191,7 +213,7 @@ use tracing::instrument;
 use crate::{
     WorkspaceCommit,
     branch::{anon_stacks, ensure_no_missing_stacks},
-    commit::merge::Tip,
+    commit::merge::{Tip, peel_to_tree},
     ref_info::WorkspaceExt,
 };
 
@@ -269,6 +291,7 @@ pub fn apply(
             workspace_ref_created,
             workspace_merge: None,
             conflicting_stacks: Vec::new(),
+            target_conflicts: Vec::new(),
             applied_branches: Vec::new(),
         });
     } else if !branch_has_applied_metadata && ws.refname_is_segment(branch.as_ref()) {
@@ -316,6 +339,7 @@ pub fn apply(
             workspace_ref_created: false,
             workspace_merge: None,
             conflicting_stacks: Vec::new(),
+            target_conflicts: Vec::new(),
             applied_branches,
         });
     };
@@ -551,6 +575,7 @@ pub fn apply(
             workspace_ref_created: needs_ws_ref_creation,
             workspace_merge: None,
             conflicting_stacks: Vec::new(),
+            target_conflicts: Vec::new(),
             applied_branches,
         });
     }
@@ -562,13 +587,30 @@ pub fn apply(
         );
     }
 
+    let mut in_memory_repo = repo.clone().for_tree_diffing()?.with_object_memory();
+    // The workspace merge only knows stack tips, so a branch that conflicts with the target
+    // it is based behind would blame whatever stacks stand between it and the target delta -
+    // even empty ones. Detect that case upfront and attribute it to the target instead.
+    if on_workspace_conflict.should_abort()
+        && let Some(target_conflicts) =
+            branch_conflicts_with_target(&ws, branch.as_ref(), &in_memory_repo)?
+    {
+        return Ok(Outcome {
+            workspace: ws,
+            status: OutcomeStatus::ConflictsWithTarget,
+            workspace_ref_created: false,
+            workspace_merge: None,
+            conflicting_stacks: Vec::new(),
+            target_conflicts,
+            applied_branches: Vec::new(),
+        });
+    }
     let existing_stacks_superseded_by_branch =
         find_superseded_stacks(branch.as_ref(), &ws, &mut ws_md);
     // At this point, the workspace-metadata already knows the new branch(es), but the workspace itself
     // doesn't see one or more of to-be-applied branches (to become stacks).
     // These are, however, part of the graph by now, and we want to try to create a workspace
     // merge.
-    let mut in_memory_repo = repo.clone().for_tree_diffing()?.with_object_memory();
     let mut merge_result = WorkspaceCommit::from_new_merge_with_metadata(
         filter_superseded_metadata_stacks(
             ws_md.stacks.iter(),
@@ -594,6 +636,7 @@ pub fn apply(
             workspace_ref_created: false,
             workspace_merge: Some(merge_result),
             conflicting_stacks,
+            target_conflicts: Vec::new(),
             applied_branches: Vec::new(),
         });
     }
@@ -708,6 +751,7 @@ pub fn apply(
                 workspace_ref_created: false,
                 workspace_merge: Some(merge_result),
                 conflicting_stacks,
+                target_conflicts: Vec::new(),
                 applied_branches: Vec::new(),
             });
         }
@@ -775,8 +819,53 @@ pub fn apply(
         workspace_ref_created: needs_ws_ref_creation,
         workspace_merge: Some(merge_result),
         conflicting_stacks,
+        target_conflicts: Vec::new(),
         applied_branches,
     })
+}
+
+/// Return the worktree-relative paths at which the tree of `branch` conflicts with the
+/// workspace's integration frame - the target commit if set, or the workspace lower bound
+/// otherwise - when merged from their common ancestor.
+///
+/// This is `None` whenever there is no conflict or the question cannot be answered, e.g.
+/// without a frame or with `branch` missing from the graph, so callers fall back to the
+/// ordinary stack merge.
+fn branch_conflicts_with_target(
+    ws: &but_graph::Workspace,
+    branch: &FullNameRef,
+    repo: &gix::Repository,
+) -> anyhow::Result<Option<Vec<bstr::BString>>> {
+    let frame = (ws.target_commit.as_ref())
+        .map(|target| (target.segment_index, target.commit_id))
+        .or(ws.lower_bound_segment_id.zip(ws.lower_bound));
+    let branch_tip = ws.graph.segment_and_commit_by_ref_name(branch);
+    let (Some((frame_sidx, frame_id)), Some((branch_segment, branch_commit))) = (frame, branch_tip)
+    else {
+        return Ok(None);
+    };
+    let Some(base) = (ws.graph.find_merge_base(frame_sidx, branch_segment.id))
+        .and_then(|base_sidx| ws.graph.tip_skip_empty(base_sidx))
+    else {
+        return Ok(None);
+    };
+
+    // No fail-fast here - the conflicting paths are reported, so all of them are wanted.
+    let merge = repo.merge_trees(
+        peel_to_tree(base.id.attach(repo))?,
+        peel_to_tree(frame_id.attach(repo))?,
+        peel_to_tree(branch_commit.id.attach(repo))?,
+        repo.default_merge_labels(),
+        repo.tree_merge_options()?,
+    )?;
+    let conflict_kind = gix::merge::tree::TreatAsUnresolved::git();
+    let conflicting_paths: Vec<_> = merge
+        .conflicts
+        .iter()
+        .filter(|conflict| conflict.is_unresolved(conflict_kind))
+        .map(|conflict| conflict.ours.location().to_owned())
+        .collect();
+    Ok((!conflicting_paths.is_empty()).then_some(conflicting_paths))
 }
 
 /// Map conflicting merge tips back to workspace stack metadata.

--- a/crates/but-workspace/src/commit/mod.rs
+++ b/crates/but-workspace/src/commit/mod.rs
@@ -599,7 +599,7 @@ pub mod merge {
         Ok((peel_to_tree(base_commit_id)?, base_sidx))
     }
 
-    fn peel_to_tree(commit: gix::Id) -> anyhow::Result<gix::ObjectId> {
+    pub(crate) fn peel_to_tree(commit: gix::Id) -> anyhow::Result<gix::ObjectId> {
         let commit = but_core::Commit::from_id(commit)?;
         Ok(commit.tree_id_or_auto_resolution()?.detach())
     }

--- a/crates/but-workspace/tests/fixtures/scenario/hero-behind-target-with-empty-stacks.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/hero-behind-target-with-empty-stacks.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### Description
+# The workspace is an empty commit on an advanced target, with `lane-1` and `lane-2` parked
+# on the base without content of their own. `hero` and `hero-clean` are based on the previous
+# target position; `hero` changes the same file the target advanced with, `hero-clean` only
+# adds an unrelated file.
+git init
+tick
+echo original >shared.txt && echo original >shared2.txt && git add shared.txt shared2.txt && git commit -m M1
+setup_target_to_match_main
+
+git checkout -b hero main
+tick
+echo hero-change >shared.txt && echo hero-change >shared2.txt && git commit -am "hero: change shared files"
+
+git checkout -b hero-clean main
+tick
+commit-file unrelated.txt
+
+git checkout main
+tick
+echo target-advance >shared.txt && echo target-advance >shared2.txt && git commit -am "target: change shared files"
+git update-ref refs/remotes/origin/main main
+
+git branch lane-1 main
+git branch lane-2 main
+
+tick
+create_workspace_commit_once

--- a/crates/but-workspace/tests/workspace/branch/apply_unapply.rs
+++ b/crates/but-workspace/tests/workspace/branch/apply_unapply.rs
@@ -4837,6 +4837,98 @@ Outcome {
 }
 
 #[test]
+fn apply_hero_behind_conflicting_target_blames_target_not_empty_stacks() -> anyhow::Result<()> {
+    let (_tmp, graph, repo, mut meta, _description) =
+        named_writable_scenario_with_description_and_graph(
+            "hero-behind-target-with-empty-stacks",
+            |meta| {
+                add_stack_with_segments(meta, 1, "lane-1", StackState::InWorkspace, &[]);
+                add_stack_with_segments(meta, 2, "lane-2", StackState::InWorkspace, &[]);
+            },
+        )?;
+    let initial_commits = visualize_commit_graph_all(&repo)?;
+    snapbox::assert_data_eq!(
+        initial_commits.clone(),
+        snapbox::str![[r#"
+* 00b2e41 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+* 870e585 (origin/main, main, lane-2, lane-1) target: change shared files
+| * c477c76 (hero-clean) add unrelated.txt
+|/  
+| * 9d63ce1 (hero) hero: change shared files
+|/  
+* dbb6f12 M1
+
+"#]]
+    );
+
+    let ws = graph.into_workspace()?;
+    snapbox::assert_data_eq!(
+        graph_workspace(&ws).to_string(),
+        snapbox::str![[r#"
+📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 870e585
+├── ≡📙:3:lane-1 on 870e585 {1}
+│   └── 📙:3:lane-1
+└── ≡📙:4:lane-2 on 870e585 {2}
+    └── 📙:4:lane-2
+
+"#]]
+    );
+
+    let out =
+        but_workspace::branch::apply(r("refs/heads/hero"), ws, &repo, &mut meta, apply_options())?;
+    assert_eq!(
+        out.status,
+        OutcomeStatus::ConflictsWithTarget,
+        "the conflict is with the target delta the hero is based behind, not with any stack"
+    );
+    assert!(
+        out.conflicting_stacks.is_empty(),
+        "empty lanes have no content of their own and must never be blamed"
+    );
+    assert_eq!(
+        out.target_conflicts,
+        ["shared.txt", "shared2.txt"],
+        "all paths conflicting with the target are reported, not just the first"
+    );
+    assert!(
+        out.workspace_merge.is_none(),
+        "no workspace merge was attempted"
+    );
+    // Nothing was persisted.
+    snapbox::assert_data_eq!(visualize_commit_graph_all(&repo)?, initial_commits.clone());
+
+    // A branch equally behind the target but without conflicting content still applies normally.
+    let out = but_workspace::branch::apply(
+        r("refs/heads/hero-clean"),
+        out.workspace,
+        &repo,
+        &mut meta,
+        apply_options(),
+    )?;
+    assert_eq!(
+        out.status,
+        OutcomeStatus::Applied,
+        "clean drift behind the target must not be refused"
+    );
+    snapbox::assert_data_eq!(
+        graph_workspace(&out.workspace).to_string(),
+        snapbox::str![[r#"
+📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on dbb6f12
+├── ≡📙:5:lane-1 on 870e585 {1}
+│   └── 📙:5:lane-1
+├── ≡📙:6:lane-2 on 870e585 {2}
+│   └── 📙:6:lane-2
+└── ≡📙:3:hero-clean on dbb6f12 {3de}
+    └── 📙:3:hero-clean
+        └── ·c477c76 (🏘️)
+
+"#]]
+    );
+
+    Ok(())
+}
+
+#[test]
 fn apply_with_conflicts_shows_exact_conflict_info() -> anyhow::Result<()> {
     let (_tmp, _graph, repo, mut meta, _description) =
         named_writable_scenario_with_description_and_graph(

--- a/crates/but/src/command/legacy/apply.rs
+++ b/crates/but/src/command/legacy/apply.rs
@@ -101,6 +101,7 @@ impl CliOutput for ApplyOutcome {
             applied_branches: Vec<String>,
             workspace_ref_created: bool,
             conflicting_stacks: Vec<String>,
+            target_conflicts: Vec<String>,
         }
 
         impl From<but_workspace::branch::apply::Outcome> for Output {
@@ -118,6 +119,11 @@ impl CliOutput for ApplyOutcome {
                         .conflicting_stacks
                         .into_iter()
                         .map(|stack| stack.ref_name.to_string())
+                        .collect(),
+                    target_conflicts: value
+                        .target_conflicts
+                        .into_iter()
+                        .map(|path| path.to_string())
                         .collect(),
                 }
             }
@@ -153,6 +159,19 @@ impl std::fmt::Display for ConflictAbortedOutcome {
                 f,
                 "'{short_name}' conflicts with existing stack: {conflicting_stack_names}"
             )
+        } else if matches!(self.outcome.status, OutcomeStatus::ConflictsWithTarget) {
+            let short_name = self.requested_branch.shorten();
+            write!(
+                f,
+                "'{short_name}' is behind the workspace target and conflicts with it; update the branch with the target changes instead of unapplying stacks"
+            )?;
+            if !self.outcome.target_conflicts.is_empty() {
+                write!(f, "\nConflicting files:")?;
+                for path in &self.outcome.target_conflicts {
+                    write!(f, "\n  {path}")?;
+                }
+            }
+            Ok(())
         } else if matches!(self.outcome.status, OutcomeStatus::ConflictAborted) {
             let short_name = self.requested_branch.shorten();
             write!(
@@ -218,7 +237,7 @@ pub fn run(
             requested_branch: reference.name,
             outcome,
         }),
-        OutcomeStatus::ConflictAborted => {
+        OutcomeStatus::ConflictAborted | OutcomeStatus::ConflictsWithTarget => {
             Ok(ApplyOutcome::ConflictAborted(ConflictAbortedOutcome {
                 requested_branch: reference.name,
                 outcome,

--- a/crates/but/tests/but/command/branch/apply.rs
+++ b/crates/but/tests/but/command/branch/apply.rs
@@ -198,7 +198,8 @@ fn local_branch_with_json_output() {
     "refs/heads/feature-branch"
   ],
   "workspaceRefCreated": false,
-  "conflictingStacks": []
+  "conflictingStacks": [],
+  "targetConflicts": []
 }
 
 "#]])
@@ -562,6 +563,39 @@ Failed to apply branch: 'conflicting-branch' conflicts with existing stack: A
 }
 
 #[test]
+fn apply_branch_behind_conflicting_target_blames_target_not_stacks() {
+    let env = Sandbox::open_or_init_scenario_with_target_and_default_settings(
+        "apply-hero-behind-conflicting-target",
+    );
+    snapbox::assert_data_eq!(
+        env.git_log(),
+        snapbox::str![[r#"
+* 8f9e28f (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+* 177a12f (origin/main, origin/HEAD, main, lane-2, lane-1) target: change shared.txt
+| * ab2bd4c (hero) hero: change shared.txt
+|/  
+* d6bfd03 M1
+
+"#]]
+    );
+
+    env.setup_metadata(&["lane-1", "lane-2"]);
+
+    // The conflict is with the target delta the branch is based behind - the empty lanes
+    // must not be blamed nor unapplied.
+    env.but("apply hero")
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
+Failed to apply branch: 'hero' is behind the workspace target and conflicts with it; update the branch with the target changes instead of unapplying stacks
+Conflicting files:
+  shared.txt
+
+"#]])
+        .stdout_eq(str![""]);
+}
+
+#[test]
 fn apply_branch_conflicting_with_workspace_reports_json_error() {
     let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack");
     snapbox::assert_data_eq!(
@@ -599,7 +633,8 @@ fn apply_branch_conflicting_with_workspace_reports_json_error() {
   "workspaceRefCreated": false,
   "conflictingStacks": [
     "refs/heads/A"
-  ]
+  ],
+  "targetConflicts": []
 }
 
 "#]])

--- a/crates/but/tests/fixtures/scenario/apply-hero-behind-conflicting-target.sh
+++ b/crates/but/tests/fixtures/scenario/apply-hero-behind-conflicting-target.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# The workspace is an empty commit on an advanced target with two content-less lanes parked
+# on it, while `hero` is based on the previous target position and changes the file the
+# target advanced with.
+git-init-frozen
+tick
+echo original >shared.txt && git add shared.txt && git commit -m M1
+setup_target_to_match_main
+
+git checkout -b hero main
+tick
+echo hero-change >shared.txt && git commit -am 'hero: change shared.txt'
+
+git checkout main
+tick
+echo target-advance >shared.txt && git commit -am 'target: change shared.txt'
+git update-ref refs/remotes/origin/main main
+
+git branch lane-1 main
+git branch lane-2 main
+
+tick
+create_workspace_commit_once

--- a/packages/but-sdk/src/generated/graph/index.d.ts
+++ b/packages/but-sdk/src/generated/graph/index.d.ts
@@ -1357,13 +1357,19 @@ export type ApplyOutcome = {
   /**
    * Branches activated or recorded by the operation.
    *
-   * This is empty for `alreadyApplied` and `conflictAborted`, and populated for `applied`.
+   * This is empty for `alreadyApplied`, `conflictAborted` and `conflictsWithTarget`, and populated for `applied`.
    */
   appliedBranches: Array<FullRefName>;
   /** Whether the workspace reference had to be created. */
   workspaceRefCreated: boolean;
   /** Stacks that conflicted while applying the branch. */
   conflictingStacks: Array<ConflictingStack>;
+  /**
+   * Worktree-relative paths at which the branch conflicts with the workspace target.
+   *
+   * Only populated for `conflictsWithTarget`.
+   */
+  targetConflicts: Array<string>;
 };
 
 /** Represents the author of a commit. */
@@ -3080,7 +3086,7 @@ export type OperatingMode = {
 export type OperationKind = "CreateCommit" | "CreateBranch" | "StashIntoBranch" | "SetBaseBranch" | "MergeUpstream" | "UpdateWorkspaceBase" | "MoveHunk" | "UpdateBranchName" | "UpdateBranchNotes" | "ReorderBranches" | "UpdateBranchRemoteName" | "GenericBranchUpdate" | "DeleteBranch" | "ApplyBranch" | "DiscardLines" | "DiscardHunk" | "DiscardFile" | "DiscardChanges" | "Discard" | "AmendCommit" | "Absorb" | "AutoCommit" | "UndoCommit" | "DiscardCommit" | "UnapplyBranch" | "CherryPick" | "SquashCommit" | "UpdateCommitMessage" | "MoveCommit" | "MoveBranch" | "TearOffBranch" | "ReorderCommit" | "InsertBlankCommit" | "MoveCommitFile" | "FileChanges" | "EnterEditMode" | "ResolveConflicts" | "ResolveConflictsAi" | "SyncWorkspace" | "CreateDependentBranch" | "RemoveDependentBranch" | "UpdateDependentBranchName" | "UpdateDependentBranchDescription" | "UpdateDependentBranchPrNumber" | "AutoHandleChangesBefore" | "AutoHandleChangesAfter" | "SplitBranch" | "CleanWorkspace" | "OnDemandSnapshot" | "Unknown" | "RestoreFromSnapshotViaUndo" | "RestoreFromSnapshotViaRedo" | "RestoreFromSnapshot";
 
 /** What kind of apply operation completed. */
-export type OutcomeStatus = "alreadyApplied" | "applied" | "conflictAborted";
+export type OutcomeStatus = "alreadyApplied" | "applied" | "conflictAborted" | "conflictsWithTarget";
 
 export type OutsideWorkspaceMetadata = {
   /** The name of the currently checked out branch or None if in detached head state. */

--- a/packages/but-sdk/src/generated/linear/index.d.ts
+++ b/packages/but-sdk/src/generated/linear/index.d.ts
@@ -1357,13 +1357,19 @@ export type ApplyOutcome = {
   /**
    * Branches activated or recorded by the operation.
    *
-   * This is empty for `alreadyApplied` and `conflictAborted`, and populated for `applied`.
+   * This is empty for `alreadyApplied`, `conflictAborted` and `conflictsWithTarget`, and populated for `applied`.
    */
   appliedBranches: Array<FullRefName>;
   /** Whether the workspace reference had to be created. */
   workspaceRefCreated: boolean;
   /** Stacks that conflicted while applying the branch. */
   conflictingStacks: Array<ConflictingStack>;
+  /**
+   * Worktree-relative paths at which the branch conflicts with the workspace target.
+   *
+   * Only populated for `conflictsWithTarget`.
+   */
+  targetConflicts: Array<string>;
 };
 
 /** Represents the author of a commit. */
@@ -3080,7 +3086,7 @@ export type OperatingMode = {
 export type OperationKind = "CreateCommit" | "CreateBranch" | "StashIntoBranch" | "SetBaseBranch" | "MergeUpstream" | "UpdateWorkspaceBase" | "MoveHunk" | "UpdateBranchName" | "UpdateBranchNotes" | "ReorderBranches" | "UpdateBranchRemoteName" | "GenericBranchUpdate" | "DeleteBranch" | "ApplyBranch" | "DiscardLines" | "DiscardHunk" | "DiscardFile" | "DiscardChanges" | "Discard" | "AmendCommit" | "Absorb" | "AutoCommit" | "UndoCommit" | "DiscardCommit" | "UnapplyBranch" | "CherryPick" | "SquashCommit" | "UpdateCommitMessage" | "MoveCommit" | "MoveBranch" | "TearOffBranch" | "ReorderCommit" | "InsertBlankCommit" | "MoveCommitFile" | "FileChanges" | "EnterEditMode" | "ResolveConflicts" | "ResolveConflictsAi" | "SyncWorkspace" | "CreateDependentBranch" | "RemoveDependentBranch" | "UpdateDependentBranchName" | "UpdateDependentBranchDescription" | "UpdateDependentBranchPrNumber" | "AutoHandleChangesBefore" | "AutoHandleChangesAfter" | "SplitBranch" | "CleanWorkspace" | "OnDemandSnapshot" | "Unknown" | "RestoreFromSnapshotViaUndo" | "RestoreFromSnapshotViaRedo" | "RestoreFromSnapshot";
 
 /** What kind of apply operation completed. */
-export type OutcomeStatus = "alreadyApplied" | "applied" | "conflictAborted";
+export type OutcomeStatus = "alreadyApplied" | "applied" | "conflictAborted" | "conflictsWithTarget";
 
 export type OutsideWorkspaceMetadata = {
   /** The name of the currently checked out branch or None if in detached head state. */


### PR DESCRIPTION
Applying a branch that was created before the target moved could fail like this:

> Couldn't apply branch due to conflicts. It conflicts with stack `mg-branch-75` and stack `mg-branch-76`. Unapply them first, then try applying again.

…where both of those stacks are **empty**. An empty stack has no content, so it can never conflict with anything — and unapplying them doesn't fix anything either. This PR makes apply blame the real culprit: the target.

### The situation

```
*  4d06721  (origin/main, lane-1, lane-2)   target moved: changed shared.txt
|
| *  ab2bd4c  (hero)                        also changed shared.txt
|/
*  d6bfd03                                  where hero branched off
```

`hero` conflicts with the **target** — both changed `shared.txt` since `hero` branched off. The empty lanes are just parked on the new target commit and have nothing to do with it.

### Why the wrong suspect got blamed

The workspace commit is a merge of *stack tips* — no merge tip represents the target itself, so "the branch conflicts with the target" was unrepresentable. When the merge hit that conflict, the blame search skipped stack tips one by one until the branch merged alone, then reported every skipped tip as conflicting. An empty lane's tip *is* the new target commit, so from the merge's (older) base it looks like it authored the entire target delta.

### The fix

Before any stack blame runs, test the branch directly against the target with an ordinary three-way merge from their common ancestor. If that conflicts, stop right there: report a new `conflictsWithTarget` outcome that names the conflicting files and blames no stacks.

```
$ but apply hero
Failed to apply branch: 'hero' is behind the workspace target and conflicts with it; update the branch with the target changes instead of unapplying stacks
Conflicting files:
  shared.txt
```

Desktop and lite show the equivalent message as a toast, with the file list at the bottom.

### What doesn't change

- A branch that genuinely conflicts with a sibling stack's content is still blamed on that stack.
- A branch behind the target *without* conflicting changes still applies as before.
- Materializing (non-abort) apply is untouched — this only gates the abort-and-report path.

Fixture-backed tests at core and CLI level, plus verification against the field repro above (it now reports the target conflict with all three conflicting files).

Follow-up ideas from the same diagnosis: make "empty stacks never conflict" structural in the blame search, and ultimately let apply proceed by rebasing the branch onto the target with conflicted commits (reviving #14919) instead of refusing.
