### PR TITLE
Fixes a subtle bug where some non-local references were getting updated as a

### DIFF
--- a/crates/but-rebase/src/graph_rebase/creation.rs
+++ b/crates/but-rebase/src/graph_rebase/creation.rs
@@ -116,13 +116,15 @@ impl<'ws, 'meta, M: RefMetadata> Editor<'ws, 'meta, M> {
 
         for sid in segments_to_add {
             let segment = &workspace.graph[sid];
-            let mutable = mutable_segments.contains(&sid);
+            let segment_mutable = mutable_segments.contains(&sid);
             let mut nodes = vec![];
 
             if let Some(ref_info) = &segment.ref_info {
                 let refname = ref_info.ref_name.clone();
+                let reference_mutable =
+                    segment_mutable && refname.category() == Some(gix::refs::Category::LocalBranch);
                 // Only mutable references are tracked for potential deletion.
-                if mutable
+                if reference_mutable
                     && ref_info
                         .worktree
                         .as_ref()
@@ -132,7 +134,7 @@ impl<'ws, 'meta, M: RefMetadata> Editor<'ws, 'meta, M> {
                 }
                 let ix = graph.add_node(Step::Reference {
                     refname: refname.clone(),
-                    mutable,
+                    mutable: reference_mutable,
                 });
                 reference_to_ix.insert(refname.clone(), ix);
                 if Some(refname.as_ref()) == entrypoint.segment.ref_name() {
@@ -150,7 +152,9 @@ impl<'ws, 'meta, M: RefMetadata> Editor<'ws, 'meta, M> {
 
                 for ref_info in &commit.refs {
                     let refname = ref_info.ref_name.clone();
-                    if mutable
+                    let reference_mutable = segment_mutable
+                        && refname.category() == Some(gix::refs::Category::LocalBranch);
+                    if reference_mutable
                         && ref_info
                             .worktree
                             .as_ref()
@@ -160,7 +164,7 @@ impl<'ws, 'meta, M: RefMetadata> Editor<'ws, 'meta, M> {
                     }
                     let ix = graph.add_node(Step::Reference {
                         refname: refname.clone(),
-                        mutable,
+                        mutable: reference_mutable,
                     });
                     reference_to_ix.insert(refname, ix);
                     if let Some(previous_ix) = nodes.last() {
@@ -176,7 +180,7 @@ impl<'ws, 'meta, M: RefMetadata> Editor<'ws, 'meta, M> {
                     pick.sign_commit = options.default_sign_commit;
                     pick
                 };
-                pick.mutable = mutable;
+                pick.mutable = segment_mutable;
                 let ix = graph.add_node(Step::Pick(pick));
                 commit_to_pick_ix.insert(commit.id, ix);
                 if let Some(previous_ix) = nodes.last() {

--- a/crates/but-rebase/tests/rebase/graph_rebase/edge.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/edge.rs
@@ -152,7 +152,7 @@ fn adding_a_valid_edge_is_successful() -> Result<()> {
 │ ●  984fd1c C: new file with 10 lines
 ├─╯
 ◎  refs/heads/main
-◎  refs/tags/base
+◎  refs/tags/base (immutable)
 ●  8f0d338 base
 "#]]
     );

--- a/crates/but-rebase/tests/rebase/graph_rebase/editor_creation.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/editor_creation.rs
@@ -82,7 +82,7 @@ fn merge_in_the_middle() -> Result<()> {
 │ ●  984fd1c C: new file with 10 lines
 ├─╯
 ◎  refs/heads/main
-◎  refs/tags/base
+◎  refs/tags/base (immutable)
 ●  8f0d338 base
 "#]]
     );
@@ -136,7 +136,7 @@ fn three_branches_merged() -> Result<()> {
 │   ●  68a2fc3 C: add 10 lines to new file
 │   ●  984fd1c C: new file with 10 lines
 ├───╯
-◎  refs/tags/base
+◎  refs/tags/base (immutable)
 ●  8f0d338 base
 "#]]
     );
@@ -258,7 +258,7 @@ fn first_parent_leg_long() -> Result<()> {
 │ ●  984fd1c C: new file with 10 lines
 ├─╯
 ◎  refs/heads/main
-◎  refs/tags/base
+◎  refs/tags/base (immutable)
 ●  8f0d338 base
 "#]]
     );
@@ -329,7 +329,7 @@ fn second_parent_leg_long() -> Result<()> {
 │ ●  984fd1c C: new file with 10 lines
 ├─╯
 ◎  refs/heads/main
-◎  refs/tags/base
+◎  refs/tags/base (immutable)
 ●  8f0d338 base
 "#]]
     );
@@ -672,7 +672,7 @@ fn merge_first_parent_older_than_second() -> Result<()> {
 │ ●  72614bb new commit 1 on second-parent
 ├─╯
 ◎  refs/heads/main
-◎  refs/tags/base
+◎  refs/tags/base (immutable)
 ●  793a434 base
 "#]]
     );

--- a/crates/but-rebase/tests/rebase/graph_rebase/insert.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/insert.rs
@@ -274,8 +274,8 @@ fn insert_above_commit_with_two_children() -> Result<()> {
                 ├── ►:2[2]:A
                 │   └── ·72d9d9b (⌂|1)
                 │       └── ►:4[3]:main
-                │           ├── ·3dc4e45 (⌂|1) ►tags/base
-                │           └── 🏁·8f0d338 (⌂|1)
+                │           ├── ·3dc4e45 (⌂|1)
+                │           └── 🏁·8f0d338 (⌂|1) ►tags/base
                 └── ►:3[2]:B
                     └── ·df0cf44 (⌂|1)
                         └── →:4: (main)
@@ -294,8 +294,8 @@ fn insert_above_commit_with_two_children() -> Result<()> {
 | * df0cf44 (B) C: new file with 10 lines
 * | 72d9d9b (A) A: 10 lines on top
 |/  
-* 3dc4e45 (tag: base, main) Commit above base commit
-* 8f0d338 base
+* 3dc4e45 (main) Commit above base commit
+* 8f0d338 (tag: base) base
 
 "#]]
         .raw()


### PR DESCRIPTION
result of rebase operations.

We almost _never_ want to update non-local references