### PR TITLE
Improve agent steering guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,10 +20,15 @@ this order:
 
 ## Working Style
 
-- Make focused, reviewable changes.
+- Treat questions about the codebase as read-only unless the user asks for changes.
+- Make focused, reviewable changes; avoid unrelated rewrites.
+- Use the simplest design that solves the actual problem; do not add
+  speculative machinery, and remove machinery your change makes unnecessary.
 - Inspect nearby code before introducing patterns.
 - Prefer existing APIs, tests, and conventions.
-- Avoid unrelated rewrites.
+- Before declaring shared behavior done, check each applicable surface and contract
+  (desktop, web, Lite, CLI/TUI, N-API, SDK, and docs) and update it or explicitly
+  determine that it is unaffected.
 - Run targeted validation for the area touched.
 
 ## Scoped Instructions

--- a/crates/AGENTS.md
+++ b/crates/AGENTS.md
@@ -38,6 +38,11 @@ vendored, or fixture data unless the task is specifically about that code.
 - When an API offers both action-only and timeline-recording behavior, keep the
   `*_only*` function free of oplog side effects; prepare a best-effort oplog
   snapshot in the wrapper and commit it only after the mutation succeeds.
+- New user-facing mutations should participate in undo: record an oplog
+  snapshot via the existing `SnapshotDetails`/`OperationKind` wrapper pattern,
+  and call out any mutation intentionally left out of the timeline rather than
+  omitting it silently. Undo is snapshot-based; do not design bespoke inverse
+  operations for it.
 - Before changing or reviewing code that derives graph/workspace/branch/stack/commit
   relationships, reachability, dependencies, ordering, operation targets, or Git
   graph/history/ref-placement mutations, use `crates/WORKSPACE_MODEL.md` as the


### PR DESCRIPTION
Clarify that question-shaped requests are read-only, preserve scope discipline, and require checking applicable product surfaces. Document the snapshot-based undo expectation for new Rust mutations.

## Validation

- `pnpm exec prettier --check AGENTS.md crates/AGENTS.md`
- `git diff --check`