### PR TITLE
Test ad-hoc pull integration (and but-graph fixes)

### DIFF
--- a/crates/but-api/tests/api/branch_checkout.rs
+++ b/crates/but-api/tests/api/branch_checkout.rs
@@ -148,7 +148,7 @@ fn checkout_returns_head_info_matching_fresh_head_info() -> anyhow::Result<()> {
         );
 
         snapbox::assert_data_eq!(
-            returned_head_info,
+            without_segment_indices(&returned_head_info),
             snapbox::str![[r#"
 RefInfo {
     workspace_ref_info: Some(
@@ -180,7 +180,6 @@ RefInfo {
             ),
             segments: [
                 ref_info::ui::Segment {
-                    id: NodeIndex(0),
                     ref_name: "►feature[🌳]",
                     remote_tracking_ref_name: "None",
                     commits: [
@@ -200,19 +199,16 @@ RefInfo {
             ref_name: FullName(
                 "refs/remotes/origin/main",
             ),
-            segment_index: NodeIndex(1),
             commits_ahead: 0,
         },
     ),
     target_commit: Some(
         TargetCommit {
             commit_id: Sha1(5374caf21933aee76b72bad8d6e30949c7a30e04),
-            segment_index: NodeIndex(2),
         },
     ),
     is_target_current: true,
     lower_bound: Some(
-        NodeIndex(2),
     ),
     is_managed_ref: false,
     is_managed_commit: false,

--- a/crates/but-api/tests/api/branch_checkout.rs
+++ b/crates/but-api/tests/api/branch_checkout.rs
@@ -134,8 +134,16 @@ fn checkout_returns_head_info_matching_fresh_head_info() -> anyhow::Result<()> {
     {
         let returned_head_info = format!("{:#?}", result.workspace.head_info);
         let fresh_head_info = format!("{:#?}", crate::support::fresh_head_info(&ctx)?);
+        let without_segment_indices = |value: &str| {
+            value
+                .lines()
+                .filter(|line| !line.contains("NodeIndex("))
+                .collect::<Vec<_>>()
+                .join("\n")
+        };
         assert_eq!(
-            returned_head_info, fresh_head_info,
+            without_segment_indices(&returned_head_info),
+            without_segment_indices(&fresh_head_info),
             "checkout API should return the same head info a fresh post-checkout read sees"
         );
 
@@ -192,19 +200,19 @@ RefInfo {
             ref_name: FullName(
                 "refs/remotes/origin/main",
             ),
-            segment_index: NodeIndex(2),
+            segment_index: NodeIndex(1),
             commits_ahead: 0,
         },
     ),
     target_commit: Some(
         TargetCommit {
             commit_id: Sha1(5374caf21933aee76b72bad8d6e30949c7a30e04),
-            segment_index: NodeIndex(1),
+            segment_index: NodeIndex(2),
         },
     ),
     is_target_current: true,
     lower_bound: Some(
-        NodeIndex(1),
+        NodeIndex(2),
     ),
     is_managed_ref: false,
     is_managed_commit: false,

--- a/crates/but-graph/src/init/mod.rs
+++ b/crates/but-graph/src/init/mod.rs
@@ -1363,7 +1363,7 @@ fn initial_tips_from_tips(
         auxiliary_integrated_tip_ids.insert(extra_target);
         push_integrated_tip_once(&mut tips, extra_target);
     }
-    let frontload_workspace_related_tips = has_workspace_related_tips(&tips);
+    let frontload_workspace_related_tips = has_workspace_related_tips(&tips, project_meta);
     if frontload_workspace_related_tips {
         auxiliary_integrated_tip_ids.extend(tips.iter().filter_map(|tip| {
             tip.is_anonymous_integrated_target_context()
@@ -1371,7 +1371,11 @@ fn initial_tips_from_tips(
         }));
     }
     collapse_anonymous_integrated_tips_into_named_targets(&mut tips);
-    let tips = tips_in_queue_order(tips, &auxiliary_integrated_tip_ids);
+    let tips = tips_in_queue_order(
+        tips,
+        frontload_workspace_related_tips,
+        &auxiliary_integrated_tip_ids,
+    );
     let workspace_tips = tips
         .iter()
         .filter(|tip| matches!(tip.role, TipRole::Workspace))
@@ -1464,9 +1468,9 @@ fn collapse_anonymous_integrated_tips_into_named_targets(tips: &mut Vec<Tip>) {
 /// order so existing explicit traversal behavior stays predictable.
 fn tips_in_queue_order(
     tips: Vec<Tip>,
+    has_workspace_related_tips: bool,
     auxiliary_integrated_tip_ids: &BTreeSet<gix::ObjectId>,
 ) -> Vec<Tip> {
-    let has_workspace_related_tips = has_workspace_related_tips(&tips);
     let workspace_branch_order = workspace_branch_order_from_tips(&tips);
     let mut tips: Vec<_> = tips.into_iter().enumerate().collect();
     tips.sort_by(|(a_idx, a), (b_idx, b)| {
@@ -1504,14 +1508,21 @@ fn tips_in_queue_order(
 /// Workspace, workspace-stack, and target-local tips are not just additional
 /// roots. Their relative order influences which segment owns a shared commit
 /// and how post-processing reconstructs virtual workspace and stack segments.
+/// A named target matching the configured project target needs the same ordering,
+/// regardless of whether its tip was metadata-derived or supplied explicitly.
 /// Detecting such tips switches sorting from "mostly preserve caller order" to
 /// "rebuild the metadata order deterministically".
-fn has_workspace_related_tips(tips: &[Tip]) -> bool {
+fn has_workspace_related_tips(tips: &[Tip], project_meta: &ProjectMeta) -> bool {
     tips.iter().any(|tip| {
         matches!(
             tip.role,
             TipRole::Workspace | TipRole::TargetLocal { .. } | TipRole::WorkspaceStackBranch { .. }
         ) || matches!(tip.metadata, Some(SegmentMetadata::Workspace(_)))
+            || matches!(tip.role, TipRole::TargetRemote)
+                && project_meta
+                    .target_ref
+                    .as_ref()
+                    .is_some_and(|target_ref| tip.ref_name.as_ref() == Some(target_ref))
     })
 }
 
@@ -1717,7 +1728,6 @@ fn initial_tips_from_workspace_metadata<T: RefMetadata>(
 
     for (ws_tip, ws_ref, ws_meta) in workspaces {
         workspace_metas.push(ws_meta.clone());
-        additional_target_commits.extend(project_meta.target_commit_id);
         tips.push(
             Tip::new(ws_tip)
                 .with_ref_name(Some(ws_ref.clone()))
@@ -1726,26 +1736,13 @@ fn initial_tips_from_workspace_metadata<T: RefMetadata>(
                 .with_is_entrypoint(Some(&ws_ref) == entrypoint_ref),
         );
 
-        let target = if let Some((target_ref, target_ref_id, local_info)) =
-            workspace_target_tip(repo, project_meta.target_ref.as_ref())?
-        {
-            let local_info =
-                local_info.filter(|(_local_ref_name, local_tip)| !queued_ids.contains(local_tip));
-            tips.push(
-                Tip::new(target_ref_id)
-                    .with_ref_name(Some(target_ref))
-                    .with_role(TipRole::TargetRemote),
-            );
-            if let Some((local_ref_name, local_tip)) = local_info.clone() {
-                tips.push(Tip::new(local_tip).with_role(TipRole::TargetLocal { local_ref_name }));
-            }
-            Some((
-                target_ref_id,
-                local_info.map(|(_local_ref_name, local_tip)| local_tip),
-            ))
-        } else {
-            None
-        };
+        let target = append_project_target_tips(
+            repo,
+            project_meta,
+            &queued_ids,
+            &mut tips,
+            &mut additional_target_commits,
+        )?;
         queued_ids.push(ws_tip);
         if let Some((target_ref_id, local_tip)) = target {
             queued_ids.push(target_ref_id);
@@ -1753,6 +1750,16 @@ fn initial_tips_from_workspace_metadata<T: RefMetadata>(
                 queued_ids.push(local_tip);
             }
         }
+    }
+
+    if workspace_metas.is_empty() {
+        append_project_target_tips(
+            repo,
+            project_meta,
+            &queued_ids,
+            &mut tips,
+            &mut additional_target_commits,
+        )?;
     }
 
     if let Some(extra_target) = extra_target_commit_id {
@@ -1801,6 +1808,37 @@ fn initial_tips_from_workspace_metadata<T: RefMetadata>(
     }
 
     Ok(tips)
+}
+
+/// Seed project-level targets and return the remote and optional local tip IDs.
+///
+/// An ad-hoc `HEAD` may no longer reach the current target after upstream integrates it, so both
+/// the named target and its previously stored position must be explicit traversal tips.
+fn append_project_target_tips(
+    repo: &OverlayRepo<'_>,
+    project_meta: &ProjectMeta,
+    queued_ids: &[gix::ObjectId],
+    tips: &mut Vec<Tip>,
+    additional_target_commits: &mut Vec<gix::ObjectId>,
+) -> anyhow::Result<Option<(gix::ObjectId, Option<gix::ObjectId>)>> {
+    additional_target_commits.extend(project_meta.target_commit_id);
+    if let Some((target_ref, target_ref_id, local_info)) =
+        workspace_target_tip(repo, project_meta.target_ref.as_ref())?
+    {
+        let local_info =
+            local_info.filter(|(_local_ref_name, local_tip)| !queued_ids.contains(local_tip));
+        let local_tip = local_info.as_ref().map(|(_, local_tip)| *local_tip);
+        tips.push(
+            Tip::new(target_ref_id)
+                .with_ref_name(Some(target_ref))
+                .with_role(TipRole::TargetRemote),
+        );
+        if let Some((local_ref_name, local_tip)) = local_info {
+            tips.push(Tip::new(local_tip).with_role(TipRole::TargetLocal { local_ref_name }));
+        }
+        return Ok(Some((target_ref_id, local_tip)));
+    }
+    Ok(None)
 }
 
 fn push_integrated_tip_once(tips: &mut Vec<Tip>, id: gix::ObjectId) {

--- a/crates/but-graph/tests/fixtures/scenarios.sh
+++ b/crates/but-graph/tests/fixtures/scenarios.sh
@@ -40,6 +40,19 @@ git init only-remote-advanced
   add_main_remote_setup
 )
 
+git init ad-hoc-branch-integrated-upstream
+(cd ad-hoc-branch-integrated-upstream
+  commit M1
+  git checkout -b old-target
+    commit OLD
+  git checkout -b feature main
+    commit F1
+  git checkout -b soon-upstream-trunk
+    commit RM1
+  setup_remote_tracking soon-upstream-trunk trunk "move"
+  git checkout feature
+)
+
 cp -R only-remote-advanced only-remote-advanced-with-special-branch-name
 (cd only-remote-advanced-with-special-branch-name
   git branch gitbutler/target :/^M1

--- a/crates/but-graph/tests/graph/workspace/resolved_target_commit_id.rs
+++ b/crates/but-graph/tests/graph/workspace/resolved_target_commit_id.rs
@@ -35,9 +35,9 @@ fn ad_hoc_workspace_uses_project_target_ref() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace_determinisitcally(&ws).to_string(),
         snapbox::str![[r#"
-⌂:0:feature[🌳] <> ✓refs/remotes/origin/trunk⇣1 on d03b217
-└── ≡:0:feature[🌳] on 3183e43 {1}
-    └── :0:feature[🌳]
+⌂:[..]:feature[🌳] <> ✓refs/remotes/origin/trunk⇣1 on d03b217
+└── ≡:[..]:feature[🌳] on 3183e43 {1}
+    └── :[..]:feature[🌳]
 
 "#]]
     );
@@ -78,9 +78,9 @@ fn ad_hoc_workspace_uses_stored_project_target_commit() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace_determinisitcally(&ws).to_string(),
         snapbox::str![[r#"
-⌂:1:feature[🌳] <> ✓! on 3183e43
-└── ≡:1:feature[🌳] on 3183e43 {1}
-    └── :1:feature[🌳]
+⌂:[..]:feature[🌳] <> ✓! on 3183e43
+└── ≡:[..]:feature[🌳] on 3183e43 {1}
+    └── :[..]:feature[🌳]
         └── ·d03b217
 
 "#]]

--- a/crates/but-graph/tests/graph/workspace/resolved_target_commit_id.rs
+++ b/crates/but-graph/tests/graph/workspace/resolved_target_commit_id.rs
@@ -1,6 +1,6 @@
 use but_core::ref_metadata::ProjectMeta;
 use but_graph::{Graph, workspace::WorkspaceKind};
-use but_testsupport::visualize_commit_graph_all;
+use but_testsupport::{graph_workspace_determinisitcally, visualize_commit_graph_all};
 use snapbox::IntoData;
 
 use super::target_meta;
@@ -12,6 +12,17 @@ use crate::init::utils::{
 #[test]
 fn ad_hoc_workspace_uses_project_target_ref() -> anyhow::Result<()> {
     let (repo, meta) = read_only_in_memory_scenario("ad-hoc-branch-integrated-upstream")?;
+    snapbox::assert_data_eq!(
+        visualize_commit_graph_all(&repo)?.replace("  \n", "\n"),
+        snapbox::str![[r#"
+* 7ad98e8 (old-target) OLD
+| * d623019 (origin/trunk) RM1
+| * d03b217 (HEAD -> feature) F1
+|/
+* 3183e43 (main) M1
+
+"#]]
+    );
     let expected_target = repo.rev_parse_single("refs/remotes/origin/trunk")?.detach();
     let project_meta = ProjectMeta {
         target_ref: Some("refs/remotes/origin/trunk".try_into()?),
@@ -21,6 +32,15 @@ fn ad_hoc_workspace_uses_project_target_ref() -> anyhow::Result<()> {
     let ws = Graph::from_head(&repo, &*meta, project_meta, standard_options())?
         .validated()?
         .into_workspace()?;
+    snapbox::assert_data_eq!(
+        graph_workspace_determinisitcally(&ws).to_string(),
+        snapbox::str![[r#"
+⌂:0:feature[🌳] <> ✓refs/remotes/origin/trunk⇣1 on d03b217
+└── ≡:0:feature[🌳] on 3183e43 {1}
+    └── :0:feature[🌳]
+
+"#]]
+    );
 
     assert!(matches!(ws.kind, WorkspaceKind::AdHoc));
     assert_eq!(
@@ -35,6 +55,17 @@ fn ad_hoc_workspace_uses_project_target_ref() -> anyhow::Result<()> {
 #[test]
 fn ad_hoc_workspace_uses_stored_project_target_commit() -> anyhow::Result<()> {
     let (repo, meta) = read_only_in_memory_scenario("ad-hoc-branch-integrated-upstream")?;
+    snapbox::assert_data_eq!(
+        visualize_commit_graph_all(&repo)?.replace("  \n", "\n"),
+        snapbox::str![[r#"
+* 7ad98e8 (old-target) OLD
+| * d623019 (origin/trunk) RM1
+| * d03b217 (HEAD -> feature) F1
+|/
+* 3183e43 (main) M1
+
+"#]]
+    );
     let expected_target = repo.rev_parse_single(":/OLD")?.detach();
     let project_meta = ProjectMeta {
         target_commit_id: Some(expected_target),
@@ -44,6 +75,16 @@ fn ad_hoc_workspace_uses_stored_project_target_commit() -> anyhow::Result<()> {
     let ws = Graph::from_head(&repo, &*meta, project_meta, standard_options())?
         .validated()?
         .into_workspace()?;
+    snapbox::assert_data_eq!(
+        graph_workspace_determinisitcally(&ws).to_string(),
+        snapbox::str![[r#"
+⌂:1:feature[🌳] <> ✓! on 3183e43
+└── ≡:1:feature[🌳] on 3183e43 {1}
+    └── :1:feature[🌳]
+        └── ·d03b217
+
+"#]]
+    );
 
     assert!(matches!(ws.kind, WorkspaceKind::AdHoc));
     assert_eq!(ws.stored_target_commit_id(), Some(expected_target));

--- a/crates/but-graph/tests/graph/workspace/resolved_target_commit_id.rs
+++ b/crates/but-graph/tests/graph/workspace/resolved_target_commit_id.rs
@@ -1,4 +1,5 @@
-use but_graph::Graph;
+use but_core::ref_metadata::ProjectMeta;
+use but_graph::{Graph, workspace::WorkspaceKind};
 use but_testsupport::visualize_commit_graph_all;
 use snapbox::IntoData;
 
@@ -7,6 +8,48 @@ use crate::init::utils::{
     add_workspace, add_workspace_with_target, read_only_in_memory_scenario, standard_options,
     standard_options_with_extra_target,
 };
+
+#[test]
+fn ad_hoc_workspace_uses_project_target_ref() -> anyhow::Result<()> {
+    let (repo, meta) = read_only_in_memory_scenario("ad-hoc-branch-integrated-upstream")?;
+    let expected_target = repo.rev_parse_single("refs/remotes/origin/trunk")?.detach();
+    let project_meta = ProjectMeta {
+        target_ref: Some("refs/remotes/origin/trunk".try_into()?),
+        ..Default::default()
+    };
+
+    let ws = Graph::from_head(&repo, &*meta, project_meta, standard_options())?
+        .validated()?
+        .into_workspace()?;
+
+    assert!(matches!(ws.kind, WorkspaceKind::AdHoc));
+    assert_eq!(
+        ws.target_ref_name().map(ToString::to_string),
+        Some("refs/remotes/origin/trunk".into())
+    );
+    assert_eq!(ws.target_ref_tip_commit_id(), Some(expected_target));
+
+    Ok(())
+}
+
+#[test]
+fn ad_hoc_workspace_uses_stored_project_target_commit() -> anyhow::Result<()> {
+    let (repo, meta) = read_only_in_memory_scenario("ad-hoc-branch-integrated-upstream")?;
+    let expected_target = repo.rev_parse_single(":/OLD")?.detach();
+    let project_meta = ProjectMeta {
+        target_commit_id: Some(expected_target),
+        ..Default::default()
+    };
+
+    let ws = Graph::from_head(&repo, &*meta, project_meta, standard_options())?
+        .validated()?
+        .into_workspace()?;
+
+    assert!(matches!(ws.kind, WorkspaceKind::AdHoc));
+    assert_eq!(ws.stored_target_commit_id(), Some(expected_target));
+
+    Ok(())
+}
 
 #[test]
 fn returns_target_tip_when_stacks_have_different_bases() -> anyhow::Result<()> {

--- a/crates/but-workspace/tests/workspace/branch/create_reference.rs
+++ b/crates/but-workspace/tests/workspace/branch/create_reference.rs
@@ -2124,9 +2124,9 @@ fn errors() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-⌂:0:main[🌳] <> ✓! on c166d42
-└── ≡:0:main[🌳] {1}
-    └── :0:main[🌳]
+⌂:1:main[🌳] <> ✓! on c166d42
+└── ≡:1:main[🌳] on c166d42 {1}
+    └── :1:main[🌳]
 
 "#]]
     );
@@ -2820,9 +2820,9 @@ mod ad_hoc_at_reference {
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-⌂:0:main[🌳] <> ✓! on 281da94
-└── ≡:0:main[🌳] {1}
-    └── :0:main[🌳]
+⌂:1:main[🌳] <> ✓! on 281da94
+└── ≡:1:main[🌳] on 281da94 {1}
+    └── :1:main[🌳]
 
 "#]]
         );
@@ -2905,13 +2905,13 @@ mod ad_hoc_at_reference {
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-⌂:1:main[🌳] <> ✓! on 281da94
-└── ≡:1:main[🌳] {1}
-    ├── :1:main[🌳]
+⌂:2:main[🌳] <> ✓! on 281da94
+└── ≡:2:main[🌳] {1}
+    ├── :2:main[🌳]
     └── 📙:0:empty-bottom
-        ├── ·281da94
-        ├── ·12995d7
-        └── ·3d57fc1
+        ├── ·281da94 (✓)
+        ├── ·12995d7 (✓)
+        └── ·3d57fc1 (✓)
 
 "#]]
         );
@@ -2958,15 +2958,15 @@ mod ad_hoc_at_reference {
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-⌂:1:main[🌳] <> ✓! on 281da94
-└── ≡:1:main[🌳] {1}
-    ├── :1:main[🌳]
-    ├── 📙:2:empty-middle
-    ├── 📙:3:inserted-below-middle
+⌂:2:main[🌳] <> ✓! on 281da94
+└── ≡:2:main[🌳] {1}
+    ├── :2:main[🌳]
+    ├── 📙:3:empty-middle
+    ├── 📙:4:inserted-below-middle
     └── 📙:0:empty-bottom
-        ├── ·281da94
-        ├── ·12995d7
-        └── ·3d57fc1
+        ├── ·281da94 (✓)
+        ├── ·12995d7 (✓)
+        └── ·3d57fc1 (✓)
 
 "#]]
         );
@@ -2990,9 +2990,9 @@ mod ad_hoc_at_reference {
 └── ≡📙:1:empty-top[🌳] {1}
     ├── 📙:1:empty-top[🌳]
     └── :0:main
-        ├── ·281da94
-        ├── ·12995d7
-        └── ·3d57fc1
+        ├── ·281da94 (✓)
+        ├── ·12995d7 (✓)
+        └── ·3d57fc1 (✓)
 
 "#]]
         );
@@ -3069,14 +3069,14 @@ mod ad_hoc_at_reference {
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-⌂:1:main[🌳] <> ✓! on 281da94
-└── ≡:1:main[🌳] {1}
-    ├── :1:main[🌳]
-    ├── 📙:2:empty-middle
+⌂:2:main[🌳] <> ✓! on 281da94
+└── ≡:2:main[🌳] {1}
+    ├── :2:main[🌳]
+    ├── 📙:3:empty-middle
     └── 📙:0:empty-bottom
-        ├── ·281da94
-        ├── ·12995d7
-        └── ·3d57fc1
+        ├── ·281da94 (✓)
+        ├── ·12995d7 (✓)
+        └── ·3d57fc1 (✓)
 
 "#]]
         );

--- a/crates/but-workspace/tests/workspace/branch/create_reference.rs
+++ b/crates/but-workspace/tests/workspace/branch/create_reference.rs
@@ -2124,9 +2124,9 @@ fn errors() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-⌂:1:main[🌳] <> ✓! on c166d42
-└── ≡:1:main[🌳] on c166d42 {1}
-    └── :1:main[🌳]
+⌂:[..]:main[🌳] <> ✓! on c166d42
+└── ≡:[..]:main[🌳] on c166d42 {1}
+    └── :[..]:main[🌳]
 
 "#]]
     );
@@ -2820,9 +2820,9 @@ mod ad_hoc_at_reference {
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-⌂:1:main[🌳] <> ✓! on 281da94
-└── ≡:1:main[🌳] on 281da94 {1}
-    └── :1:main[🌳]
+⌂:[..]:main[🌳] <> ✓! on 281da94
+└── ≡:[..]:main[🌳] on 281da94 {1}
+    └── :[..]:main[🌳]
 
 "#]]
         );
@@ -2905,10 +2905,10 @@ mod ad_hoc_at_reference {
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-⌂:2:main[🌳] <> ✓! on 281da94
-└── ≡:2:main[🌳] {1}
-    ├── :2:main[🌳]
-    └── 📙:0:empty-bottom
+⌂:[..]:main[🌳] <> ✓! on 281da94
+└── ≡:[..]:main[🌳] {1}
+    ├── :[..]:main[🌳]
+    └── 📙:[..]:empty-bottom
         ├── ·281da94 (✓)
         ├── ·12995d7 (✓)
         └── ·3d57fc1 (✓)
@@ -2958,12 +2958,12 @@ mod ad_hoc_at_reference {
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-⌂:2:main[🌳] <> ✓! on 281da94
-└── ≡:2:main[🌳] {1}
-    ├── :2:main[🌳]
-    ├── 📙:3:empty-middle
-    ├── 📙:4:inserted-below-middle
-    └── 📙:0:empty-bottom
+⌂:[..]:main[🌳] <> ✓! on 281da94
+└── ≡:[..]:main[🌳] {1}
+    ├── :[..]:main[🌳]
+    ├── 📙:[..]:empty-middle
+    ├── 📙:[..]:inserted-below-middle
+    └── 📙:[..]:empty-bottom
         ├── ·281da94 (✓)
         ├── ·12995d7 (✓)
         └── ·3d57fc1 (✓)
@@ -2986,10 +2986,10 @@ mod ad_hoc_at_reference {
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-⌂:1:empty-top[🌳] <> ✓! on 281da94
-└── ≡📙:1:empty-top[🌳] {1}
-    ├── 📙:1:empty-top[🌳]
-    └── :0:main
+⌂:[..]:empty-top[🌳] <> ✓! on 281da94
+└── ≡📙:[..]:empty-top[🌳] {1}
+    ├── 📙:[..]:empty-top[🌳]
+    └── :[..]:main
         ├── ·281da94 (✓)
         ├── ·12995d7 (✓)
         └── ·3d57fc1 (✓)
@@ -3069,11 +3069,11 @@ mod ad_hoc_at_reference {
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-⌂:2:main[🌳] <> ✓! on 281da94
-└── ≡:2:main[🌳] {1}
-    ├── :2:main[🌳]
-    ├── 📙:3:empty-middle
-    └── 📙:0:empty-bottom
+⌂:[..]:main[🌳] <> ✓! on 281da94
+└── ≡:[..]:main[🌳] {1}
+    ├── :[..]:main[🌳]
+    ├── 📙:[..]:empty-middle
+    └── 📙:[..]:empty-bottom
         ├── ·281da94 (✓)
         ├── ·12995d7 (✓)
         └── ·3d57fc1 (✓)

--- a/crates/but-workspace/tests/workspace/branch/move_branch.rs
+++ b/crates/but-workspace/tests/workspace/branch/move_branch.rs
@@ -1558,12 +1558,12 @@ mod single_branch_mode {
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-⌂:2:main[🌳] <> ✓! on 281da94
-└── ≡:2:main[🌳] {1}
-    ├── :2:main[🌳]
-    ├── 📙:3:empty-top
-    ├── 📙:4:empty-bottom
-    └── 📙:0:base
+⌂:[..]:main[🌳] <> ✓! on 281da94
+└── ≡:[..]:main[🌳] {1}
+    ├── :[..]:main[🌳]
+    ├── 📙:[..]:empty-top
+    ├── 📙:[..]:empty-bottom
+    └── 📙:[..]:base
         ├── ·281da94 (✓)
         ├── ·12995d7 (✓)
         └── ·3d57fc1 (✓)
@@ -1617,12 +1617,12 @@ mod single_branch_mode {
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-⌂:2:main[🌳] <> ✓! on 281da94
-└── ≡:2:main[🌳] {1}
-    ├── :2:main[🌳]
-    ├── 📙:3:empty-bottom
-    ├── 📙:4:empty-top
-    └── 📙:0:base
+⌂:[..]:main[🌳] <> ✓! on 281da94
+└── ≡:[..]:main[🌳] {1}
+    ├── :[..]:main[🌳]
+    ├── 📙:[..]:empty-bottom
+    ├── 📙:[..]:empty-top
+    └── 📙:[..]:base
         ├── ·281da94 (✓)
         ├── ·12995d7 (✓)
         └── ·3d57fc1 (✓)
@@ -1913,12 +1913,12 @@ mod single_branch_mode {
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-⌂:2:main[🌳] <> ✓! on 281da94
-└── ≡:2:main[🌳] {1}
-    ├── :2:main[🌳]
-    ├── 📙:3:empty-top
-    ├── 📙:4:empty-bottom
-    └── 📙:0:base
+⌂:[..]:main[🌳] <> ✓! on 281da94
+└── ≡:[..]:main[🌳] {1}
+    ├── :[..]:main[🌳]
+    ├── 📙:[..]:empty-top
+    ├── 📙:[..]:empty-bottom
+    └── 📙:[..]:base
         ├── ·281da94 (✓) ►x, ►y
         ├── ·12995d7 (✓)
         └── ·3d57fc1 (✓)

--- a/crates/but-workspace/tests/workspace/branch/move_branch.rs
+++ b/crates/but-workspace/tests/workspace/branch/move_branch.rs
@@ -1558,15 +1558,15 @@ mod single_branch_mode {
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-⌂:1:main[🌳] <> ✓! on 281da94
-└── ≡:1:main[🌳] {1}
-    ├── :1:main[🌳]
-    ├── 📙:2:empty-top
-    ├── 📙:3:empty-bottom
+⌂:2:main[🌳] <> ✓! on 281da94
+└── ≡:2:main[🌳] {1}
+    ├── :2:main[🌳]
+    ├── 📙:3:empty-top
+    ├── 📙:4:empty-bottom
     └── 📙:0:base
-        ├── ·281da94
-        ├── ·12995d7
-        └── ·3d57fc1
+        ├── ·281da94 (✓)
+        ├── ·12995d7 (✓)
+        └── ·3d57fc1 (✓)
 
 "#]]
         );
@@ -1617,15 +1617,15 @@ mod single_branch_mode {
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-⌂:1:main[🌳] <> ✓! on 281da94
-└── ≡:1:main[🌳] {1}
-    ├── :1:main[🌳]
-    ├── 📙:2:empty-bottom
-    ├── 📙:3:empty-top
+⌂:2:main[🌳] <> ✓! on 281da94
+└── ≡:2:main[🌳] {1}
+    ├── :2:main[🌳]
+    ├── 📙:3:empty-bottom
+    ├── 📙:4:empty-top
     └── 📙:0:base
-        ├── ·281da94
-        ├── ·12995d7
-        └── ·3d57fc1
+        ├── ·281da94 (✓)
+        ├── ·12995d7 (✓)
+        └── ·3d57fc1 (✓)
 
 "#]]
         );
@@ -1913,15 +1913,15 @@ mod single_branch_mode {
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-⌂:1:main[🌳] <> ✓! on 281da94
-└── ≡:1:main[🌳] {1}
-    ├── :1:main[🌳]
-    ├── 📙:2:empty-top
-    ├── 📙:3:empty-bottom
+⌂:2:main[🌳] <> ✓! on 281da94
+└── ≡:2:main[🌳] {1}
+    ├── :2:main[🌳]
+    ├── 📙:3:empty-top
+    ├── 📙:4:empty-bottom
     └── 📙:0:base
-        ├── ·281da94 ►x, ►y
-        ├── ·12995d7
-        └── ·3d57fc1
+        ├── ·281da94 (✓) ►x, ►y
+        ├── ·12995d7 (✓)
+        └── ·3d57fc1 (✓)
 
 "#]]
         );

--- a/crates/but-workspace/tests/workspace/commit/move_commit.rs
+++ b/crates/but-workspace/tests/workspace/commit/move_commit.rs
@@ -884,9 +884,9 @@ fn reorder_merge_commit_above_keeps_child_commits_visible() -> anyhow::Result<()
 └── ≡:0:child-stack[🌳] on aa67ae0 {1}
     ├── :0:child-stack[🌳]
     │   └── ·32c8bda ►C2
-    ├── :3:C1
+    ├── :2:C1
     │   └── ·64dace5
-    └── :4:M
+    └── :3:M
         └── ·197bdf1
 
 "#]]
@@ -968,9 +968,9 @@ fn reorder_merge_commit_below_keeps_child_commits_visible() -> anyhow::Result<()
 └── ≡:0:child-stack[🌳] on aa67ae0 {1}
     ├── :0:child-stack[🌳]
     │   └── ·32c8bda ►C2
-    ├── :3:C1
+    ├── :2:C1
     │   └── ·64dace5
-    └── :4:M
+    └── :3:M
         └── ·197bdf1
 
 "#]]

--- a/crates/but-workspace/tests/workspace/commit/move_commit.rs
+++ b/crates/but-workspace/tests/workspace/commit/move_commit.rs
@@ -880,13 +880,13 @@ fn reorder_merge_commit_above_keeps_child_commits_visible() -> anyhow::Result<()
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-⌂:0:child-stack[🌳] <> ✓refs/remotes/origin/main on aa67ae0
-└── ≡:0:child-stack[🌳] on aa67ae0 {1}
-    ├── :0:child-stack[🌳]
+⌂:[..]:child-stack[🌳] <> ✓refs/remotes/origin/main on aa67ae0
+└── ≡:[..]:child-stack[🌳] on aa67ae0 {1}
+    ├── :[..]:child-stack[🌳]
     │   └── ·32c8bda ►C2
-    ├── :2:C1
+    ├── :[..]:C1
     │   └── ·64dace5
-    └── :3:M
+    └── :[..]:M
         └── ·197bdf1
 
 "#]]
@@ -964,13 +964,13 @@ fn reorder_merge_commit_below_keeps_child_commits_visible() -> anyhow::Result<()
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-⌂:0:child-stack[🌳] <> ✓refs/remotes/origin/main on aa67ae0
-└── ≡:0:child-stack[🌳] on aa67ae0 {1}
-    ├── :0:child-stack[🌳]
+⌂:[..]:child-stack[🌳] <> ✓refs/remotes/origin/main on aa67ae0
+└── ≡:[..]:child-stack[🌳] on aa67ae0 {1}
+    ├── :[..]:child-stack[🌳]
     │   └── ·32c8bda ►C2
-    ├── :2:C1
+    ├── :[..]:C1
     │   └── ·64dace5
-    └── :3:M
+    └── :[..]:M
         └── ·197bdf1
 
 "#]]

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
@@ -3521,7 +3521,7 @@ RefInfo {
             base: None,
             segments: [
                 ref_info::ui::Segment {
-                    id: NodeIndex(0),
+                    id: NodeIndex([..]),
                     ref_name: "►disjoint[🌳]",
                     remote_tracking_ref_name: "None",
                     commits: [],
@@ -3539,19 +3539,19 @@ RefInfo {
             ref_name: FullName(
                 "refs/remotes/origin/main",
             ),
-            segment_index: NodeIndex(1),
+            segment_index: NodeIndex([..]),
             commits_ahead: 0,
         },
     ),
     target_commit: Some(
         TargetCommit {
             commit_id: Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
-            segment_index: NodeIndex(2),
+            segment_index: NodeIndex([..]),
         },
     ),
     is_target_current: true,
     lower_bound: Some(
-        NodeIndex(0),
+        NodeIndex([..]),
     ),
     is_managed_ref: false,
     is_managed_commit: false,

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
@@ -3539,14 +3539,14 @@ RefInfo {
             ref_name: FullName(
                 "refs/remotes/origin/main",
             ),
-            segment_index: NodeIndex(2),
+            segment_index: NodeIndex(1),
             commits_ahead: 0,
         },
     ),
     target_commit: Some(
         TargetCommit {
             commit_id: Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
-            segment_index: NodeIndex(1),
+            segment_index: NodeIndex(2),
         },
     ),
     is_target_current: true,

--- a/crates/but-workspace/tests/workspace/upstream_integration.rs
+++ b/crates/but-workspace/tests/workspace/upstream_integration.rs
@@ -417,11 +417,11 @@ fn integrated_bottom_branch_no_workspace_rebase() -> Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
-⌂:0:A[🌳] <> ✓refs/remotes/origin/main⇣2 on 3183e43
-└── ≡:0:A[🌳] on 3183e43 {1}
-    ├── :0:A[🌳]
+⌂:[..]:A[🌳] <> ✓refs/remotes/origin/main⇣2 on 3183e43
+└── ≡:[..]:A[🌳] on 3183e43 {1}
+    ├── :[..]:A[🌳]
     │   └── ·e792f40
-    └── :3:B
+    └── :[..]:B
         └── ·b38b04b (✓)
 
 "#]]
@@ -566,11 +566,11 @@ fn integrated_bottom_branch_no_workspace_merge() -> Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
-⌂:0:A[🌳] <> ✓refs/remotes/origin/main⇣2 on 3183e43
-└── ≡:0:A[🌳] on 3183e43 {1}
-    ├── :0:A[🌳]
+⌂:[..]:A[🌳] <> ✓refs/remotes/origin/main⇣2 on 3183e43
+└── ≡:[..]:A[🌳] on 3183e43 {1}
+    ├── :[..]:A[🌳]
     │   └── ·e792f40
-    └── :3:B
+    └── :[..]:B
         └── ·b38b04b (✓)
 
 "#]]
@@ -3003,9 +3003,9 @@ fn review_hint_integrates_squashed_two_commit_direct_checkout_branch() -> Result
     snapbox::assert_data_eq!(
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
-⌂:0:A[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
-└── ≡:0:A[🌳] on 3183e43 {1}
-    └── :0:A[🌳]
+⌂:[..]:A[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
+└── ≡:[..]:A[🌳] on 3183e43 {1}
+    └── :[..]:A[🌳]
         ├── ·ad1d22b
         └── ·fe98e29
 
@@ -3034,9 +3034,9 @@ fn review_hint_integrates_squashed_two_commit_direct_checkout_branch() -> Result
     snapbox::assert_data_eq!(
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
-⌂:0:amo-branch-1[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
-└── ≡:0:amo-branch-1[🌳] on 3183e43 {1}
-    └── :0:amo-branch-1[🌳]
+⌂:[..]:amo-branch-1[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
+└── ≡:[..]:amo-branch-1[🌳] on 3183e43 {1}
+    └── :[..]:amo-branch-1[🌳]
         └── ·56057f2 (✓)
 
 "#]]
@@ -3197,9 +3197,9 @@ fn review_hint_integrates_squashed_prefix_and_keeps_extra_commit_in_direct_check
     snapbox::assert_data_eq!(
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
-⌂:0:A[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
-└── ≡:0:A[🌳] on 3183e43 {1}
-    └── :0:A[🌳]
+⌂:[..]:A[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
+└── ≡:[..]:A[🌳] on 3183e43 {1}
+    └── :[..]:A[🌳]
         ├── ·f015e95
         ├── ·ad1d22b
         └── ·fe98e29
@@ -3245,9 +3245,9 @@ fn review_hint_integrates_squashed_prefix_and_keeps_extra_commit_in_direct_check
     snapbox::assert_data_eq!(
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
-⌂:0:A[🌳] <> ✓refs/remotes/origin/main on e2f5892
-└── ≡:0:A[🌳] on e2f5892 {1}
-    └── :0:A[🌳]
+⌂:[..]:A[🌳] <> ✓refs/remotes/origin/main on e2f5892
+└── ≡:[..]:A[🌳] on e2f5892 {1}
+    └── :[..]:A[🌳]
         └── ·92f1780
 
 "#]]

--- a/crates/but-workspace/tests/workspace/upstream_integration.rs
+++ b/crates/but-workspace/tests/workspace/upstream_integration.rs
@@ -417,9 +417,9 @@ fn integrated_bottom_branch_no_workspace_rebase() -> Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
-⌂:1:A[🌳] <> ✓refs/remotes/origin/main⇣2 on 3183e43
-└── ≡:1:A[🌳] on 3183e43 {1}
-    ├── :1:A[🌳]
+⌂:0:A[🌳] <> ✓refs/remotes/origin/main⇣2 on 3183e43
+└── ≡:0:A[🌳] on 3183e43 {1}
+    ├── :0:A[🌳]
     │   └── ·e792f40
     └── :3:B
         └── ·b38b04b (✓)
@@ -566,9 +566,9 @@ fn integrated_bottom_branch_no_workspace_merge() -> Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
-⌂:1:A[🌳] <> ✓refs/remotes/origin/main⇣2 on 3183e43
-└── ≡:1:A[🌳] on 3183e43 {1}
-    ├── :1:A[🌳]
+⌂:0:A[🌳] <> ✓refs/remotes/origin/main⇣2 on 3183e43
+└── ≡:0:A[🌳] on 3183e43 {1}
+    ├── :0:A[🌳]
     │   └── ·e792f40
     └── :3:B
         └── ·b38b04b (✓)
@@ -3003,9 +3003,9 @@ fn review_hint_integrates_squashed_two_commit_direct_checkout_branch() -> Result
     snapbox::assert_data_eq!(
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
-⌂:1:A[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
-└── ≡:1:A[🌳] on 3183e43 {1}
-    └── :1:A[🌳]
+⌂:0:A[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
+└── ≡:0:A[🌳] on 3183e43 {1}
+    └── :0:A[🌳]
         ├── ·ad1d22b
         └── ·fe98e29
 
@@ -3037,7 +3037,7 @@ fn review_hint_integrates_squashed_two_commit_direct_checkout_branch() -> Result
 ⌂:0:amo-branch-1[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
 └── ≡:0:amo-branch-1[🌳] on 3183e43 {1}
     └── :0:amo-branch-1[🌳]
-        └── ·56057f2
+        └── ·56057f2 (✓)
 
 "#]]
     );
@@ -3197,9 +3197,9 @@ fn review_hint_integrates_squashed_prefix_and_keeps_extra_commit_in_direct_check
     snapbox::assert_data_eq!(
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
-⌂:1:A[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
-└── ≡:1:A[🌳] on 3183e43 {1}
-    └── :1:A[🌳]
+⌂:0:A[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
+└── ≡:0:A[🌳] on 3183e43 {1}
+    └── :0:A[🌳]
         ├── ·f015e95
         ├── ·ad1d22b
         └── ·fe98e29
@@ -3245,9 +3245,9 @@ fn review_hint_integrates_squashed_prefix_and_keeps_extra_commit_in_direct_check
     snapbox::assert_data_eq!(
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
-⌂:1:A[🌳] <> ✓refs/remotes/origin/main on e2f5892
-└── ≡:1:A[🌳] on e2f5892 {1}
-    └── :1:A[🌳]
+⌂:0:A[🌳] <> ✓refs/remotes/origin/main on e2f5892
+└── ≡:0:A[🌳] on e2f5892 {1}
+    └── :0:A[🌳]
         └── ·92f1780
 
 "#]]

--- a/crates/but/tests/but/command/branch/new.rs
+++ b/crates/but/tests/but/command/branch/new.rs
@@ -217,7 +217,6 @@ Created branch 'middle'
 ┊│
 ┊├┄ ma [main]
 ┊●   nmy M (no changes)
-┊●   ply add init
 ├╯
 ┊
 ┴ e31e6ca (common base) 2000-01-02 add init
@@ -248,7 +247,6 @@ Created branch 'bottom' below branch 'middle'
 ┊│
 ┊├┄ ma [main]
 ┊●   nmy M (no changes)
-┊●   ply add init
 ├╯
 ┊
 ┴ e31e6ca (common base) 2000-01-02 add init
@@ -281,7 +279,6 @@ Created branch 'top' above branch 'middle'
 ┊│
 ┊├┄ ma [main]
 ┊●   nmy M (no changes)
-┊●   ply add init
 ├╯
 ┊
 ┴ e31e6ca (common base) 2000-01-02 add init
@@ -316,7 +313,6 @@ Created branch 'between-middle-and-top' above branch 'middle'
 ┊│
 ┊├┄ ma [main]
 ┊●   nmy M (no changes)
-┊●   ply add init
 ├╯
 ┊
 ┴ e31e6ca (common base) 2000-01-02 add init
@@ -392,7 +388,6 @@ Created branch 'middle'
 ┊│
 ┊├┄ ma [main]
 ┊●   nmy M (no changes)
-┊●   ply add init
 ├╯
 ┊
 ┴ e31e6ca (common base) 2000-01-02 add init
@@ -428,7 +423,6 @@ Created branch 'top' above branch 'middle'
 ┊│
 ┊├┄ ma [main]
 ┊●   nmy M (no changes)
-┊●   ply add init
 ├╯
 ┊
 ┴ e31e6ca (common base) 2000-01-02 add init
@@ -467,7 +461,6 @@ Created branch 'bottom' below branch 'middle'
 ┊│
 ┊├┄ ma [main]
 ┊●   nmy M (no changes)
-┊●   ply add init
 ├╯
 ┊
 ┴ e31e6ca (common base) 2000-01-02 add init
@@ -509,7 +502,6 @@ Created branch 'between-middle-and-top' above branch 'middle'
 ┊│
 ┊├┄ ma [main]
 ┊●   nmy M (no changes)
-┊●   ply add init
 ├╯
 ┊
 ┴ e31e6ca (common base) 2000-01-02 add init

--- a/crates/but/tests/but/command/commit.rs
+++ b/crates/but/tests/but/command/commit.rs
@@ -67,8 +67,6 @@ Created commit 1 on new branch 'feature'
 ┊│
 ┊├┄ ma [main]
 ┊●   nmy M (no changes)
-┊●   ply add init
-┊│     ply:k A init
 ├╯
 ┊
 ┴ e31e6ca (common base) 2000-01-02 add init
@@ -208,7 +206,6 @@ fn commits_at_each_branch_in_an_existing_single_branch_stack() {
 ┊│
 ┊├┄ ma [main]
 ┊●   nmy M (no changes)
-┊●   ply add init
 ├╯
 ┊
 ┴ e31e6ca (common base) 2000-01-02 add init

--- a/crates/but/tests/but/command/land.rs
+++ b/crates/but/tests/but/command/land.rs
@@ -1,4 +1,73 @@
+use snapbox::str;
+
 use crate::utils::{CommandExt, Sandbox};
+
+#[test]
+fn land_rejects_single_branch_mode() {
+    let env = Sandbox::open_with_default_settings("one-fork");
+    env.but("config feature single-branch enable")
+        .assert()
+        .success();
+    let head = env.invoke_git("rev-parse HEAD");
+
+    env.but("status")
+        .env("NO_BG_TASKS", "1")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ ma [main]
+┊●   nmy M (no changes)
+├╯
+┊
+┴ e31e6ca (common base) 2000-01-02 add init
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("land main --yes")
+        .assert()
+        .failure()
+        .stdout_eq(str![])
+        .stderr_eq(str![[r#"
+Failed to land branch. `but land` requires an active GitButler workspace (`gitbutler/workspace`). Switch into the workspace and try again.
+
+"#]]);
+
+    env.but("status")
+        .env("NO_BG_TASKS", "1")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ ma [main]
+┊●   nmy M (no changes)
+├╯
+┊
+┴ e31e6ca (common base) 2000-01-02 add init
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    assert_eq!(
+        env.invoke_git("rev-parse HEAD"),
+        head,
+        "a rejected land must not move the checked-out branch"
+    );
+    assert!(
+        env.open_repo()
+            .try_find_reference(but_core::WORKSPACE_REF_NAME)
+            .unwrap()
+            .is_none(),
+        "a rejected land must not create a managed workspace"
+    );
+}
 
 /// Headline real-remote path: landing a branch that is ahead of `origin/main` fast-forwards the
 /// remote target (no merge commit), leaves the local `main` untouched, and rebases the sibling

--- a/crates/but/tests/but/command/pull.rs
+++ b/crates/but/tests/but/command/pull.rs
@@ -2,6 +2,326 @@ use snapbox::str;
 
 use crate::utils::{CommandExt, Sandbox};
 
+fn single_branch_integration_scenario() -> Sandbox {
+    let env = Sandbox::open_with_default_settings("repo-with-remote-and-head");
+    env.but("config feature single-branch enable")
+        .assert()
+        .success();
+    env.but("status").env("NO_BG_TASKS", "1").assert().success();
+    let repo = env.open_repo();
+    let mut project_meta = env.project_meta();
+    project_meta.target_ref = Some("refs/remotes/origin/main".try_into().unwrap());
+    project_meta.target_commit_id = Some(
+        repo.rev_parse_single("refs/remotes/origin/main")
+            .unwrap()
+            .detach(),
+    );
+    project_meta.persist(&repo).unwrap();
+    env.invoke_git(
+        "config --replace-all remote.origin.fetch +refs/heads/main:refs/remotes/origin/main",
+    );
+    env.invoke_git("remote set-url origin .");
+    env
+}
+
+fn commit_file(env: &Sandbox, branch: &str) {
+    env.file(format!("{branch}.txt"), format!("{branch}\n"));
+    env.but(format!("commit -b {branch} -m 'add {branch}'"))
+        .assert()
+        .success();
+}
+
+fn merge_into_upstream(env: &Sandbox, branch: &str, add_upstream_commit: bool) {
+    let head = env.invoke_git("symbolic-ref --short HEAD");
+    env.invoke_git("checkout main");
+    env.invoke_git(&format!("merge --no-ff -m 'merge {branch}' {branch}"));
+    if add_upstream_commit {
+        env.file("upstream.txt", "upstream\n");
+        env.invoke_git("add upstream.txt");
+        env.invoke_git("commit -m 'add upstream'");
+    }
+    env.invoke_git(&format!("checkout {head}"));
+    env.invoke_git("fetch origin");
+}
+
+#[test]
+fn single_branch_pull_replaces_a_fully_integrated_checkout() {
+    let env = single_branch_integration_scenario();
+    env.but("branch new A").assert().success();
+    commit_file(&env, "A");
+    let old_head = rev_parse(&env, "A");
+    merge_into_upstream(&env, "A", true);
+
+    env.but("status")
+        .env("NO_BG_TASKS", "1")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ g0 [A] (merged upstream)
+┊●   1 add A
+├╯
+┊
+┊● f12cbfa (upstream: origin/main) 2 new commits
+├╯ 85efbe4 (common base) 2000-01-02 M
+
+Hint: origin/main moved ahead; run `but pull` to update the workspace
+Hint: branches marked `(merged upstream)` have landed; run `but pull` to remove them, or start new work on another branch
+
+"#]]);
+
+    env.but("pull --check")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+
+Base branch:	origin/main
+Upstream:	2 new commits on origin/main
+
+  f12cbfa add upstream[..]
+  b17b7d2 merge A[..]
+
+Branch Status
+  [integrated] A
+
+Run `but pull` to update your branches
+
+"#]]);
+    assert_eq!(
+        rev_parse(&env, "HEAD"),
+        old_head,
+        "pull --check is a dry run"
+    );
+    assert!(
+        git_ref_exists(&env, "refs/heads/A"),
+        "pull --check must not remove the integrated branch"
+    );
+
+    env.but("pull").assert().success();
+
+    env.but("status")
+        .env("NO_BG_TASKS", "1")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ br [a-branch-1] (no commits)
+├╯
+┊
+┴ f12cbfa (common base) 2000-01-02 add upstream
+
+Hint: run `but help` for all commands
+
+"#]]);
+    assert!(
+        !git_ref_exists(&env, "refs/heads/A"),
+        "pull should remove the fully integrated branch"
+    );
+    assert_ne!(
+        env.invoke_git("symbolic-ref --short HEAD"),
+        "A",
+        "the removed checkout should be replaced"
+    );
+    assert_eq!(
+        rev_parse(&env, "HEAD"),
+        rev_parse(&env, "origin/main"),
+        "the replacement checkout should point at the advanced target"
+    );
+    assert!(!git_ref_exists(&env, but_core::WORKSPACE_REF_NAME));
+}
+
+#[test]
+fn single_branch_pull_prunes_an_integrated_lower_branch() {
+    let env = single_branch_integration_scenario();
+    env.but("branch new C").assert().success();
+    commit_file(&env, "C");
+    env.but("branch new A").assert().success();
+    commit_file(&env, "A");
+    let old_head = rev_parse(&env, "A");
+    let old_lower = rev_parse(&env, "C");
+    merge_into_upstream(&env, "C", true);
+
+    env.but("status")
+        .env("NO_BG_TASKS", "1")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ g0 [A]
+┊●   1#0 add A
+┊│
+┊├┄ h0 [C] (merged upstream)
+┊●   1#1 add C
+├╯
+┊
+┊● 1a9cade (upstream: origin/main) 2 new commits
+├╯ 85efbe4 (common base) 2000-01-02 M
+
+Hint: origin/main moved ahead; run `but pull` to update the workspace
+Hint: branches marked `(merged upstream)` have landed; run `but pull` to remove them, or start new work on another branch
+
+"#]]);
+
+    env.but("pull --check")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+
+Base branch:	origin/main
+Upstream:	2 new commits on origin/main
+
+  1a9cade add upstream[..]
+  c251e1d merge C[..]
+
+Branch Status
+  [ok] A
+  [integrated] C
+
+Run `but pull` to update your branches
+
+"#]]);
+    assert_eq!(rev_parse(&env, "A"), old_head, "pull --check is a dry run");
+    assert_eq!(rev_parse(&env, "C"), old_lower, "pull --check is a dry run");
+
+    env.but("pull").assert().success();
+
+    env.but("status")
+        .env("NO_BG_TASKS", "1")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ g0 [A]
+┊●   1 add A
+├╯
+┊
+┴ 1a9cade (common base) 2000-01-02 add upstream
+
+Hint: run `but help` for all commands
+
+"#]]);
+    assert!(
+        !git_ref_exists(&env, "refs/heads/C"),
+        "pull should remove the integrated lower branch"
+    );
+    assert_eq!(
+        env.invoke_git("symbolic-ref --short HEAD"),
+        "A",
+        "the surviving top branch should stay checked out"
+    );
+    assert_eq!(
+        rev_parse(&env, "A^"),
+        rev_parse(&env, "origin/main"),
+        "the surviving branch should be rebased onto the advanced target"
+    );
+    assert!(!git_ref_exists(&env, but_core::WORKSPACE_REF_NAME));
+}
+
+#[test]
+fn single_branch_pull_keeps_an_empty_branch_above_an_integrated_branch() {
+    let env = single_branch_integration_scenario();
+    env.but("branch new bottom").assert().success();
+    commit_file(&env, "bottom");
+    env.but("branch new top").assert().success();
+    let old_tip = rev_parse(&env, "top");
+    merge_into_upstream(&env, "bottom", false);
+
+    env.but("status")
+        .env("NO_BG_TASKS", "1")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ to [top] (no commits)
+┊│
+┊├┄ bo [bottom] (merged upstream)
+┊●   1 add bottom
+├╯
+┊
+┊● 9f8a4d4 (upstream: origin/main) 1 new commit
+├╯ 85efbe4 (common base) 2000-01-02 M
+
+Hint: origin/main moved ahead; run `but pull` to update the workspace
+Hint: branches marked `(merged upstream)` have landed; run `but pull` to remove them, or start new work on another branch
+
+"#]]);
+
+    env.but("pull --check")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+
+Base branch:	origin/main
+Upstream:	1 new commits on origin/main
+
+  9f8a4d4 merge bottom[..]
+
+Branch Status
+  [ok] top
+  [integrated] bottom
+
+Run `but pull` to update your branches
+
+"#]]);
+    assert_eq!(rev_parse(&env, "top"), old_tip, "pull --check is a dry run");
+    assert_eq!(
+        rev_parse(&env, "bottom"),
+        old_tip,
+        "pull --check must preserve the integrated lower branch"
+    );
+
+    env.but("pull").assert().success();
+
+    env.but("status")
+        .env("NO_BG_TASKS", "1")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ to [top] (no commits)
+├╯
+┊
+┴ 9f8a4d4 (common base) 2000-01-02 merge bottom
+
+Hint: run `but help` for all commands
+
+"#]]);
+    assert!(
+        !git_ref_exists(&env, "refs/heads/bottom"),
+        "pull should remove the integrated lower branch"
+    );
+    assert!(
+        git_ref_exists(&env, "refs/heads/top"),
+        "the local-only empty top branch should survive"
+    );
+    assert_eq!(
+        env.invoke_git("symbolic-ref --short HEAD"),
+        "top",
+        "the empty top branch should stay checked out"
+    );
+    assert_eq!(
+        rev_parse(&env, "top"),
+        rev_parse(&env, "origin/main"),
+        "the empty top branch should advance to the target"
+    );
+    assert!(!git_ref_exists(&env, but_core::WORKSPACE_REF_NAME));
+}
+
 /// An unreachable remote that is not the target's must not block pulling: `fetch_from_remotes`
 /// only fails when the target's own fetch remote failed, so a dead unrelated remote (old fork,
 /// deleted mirror) is tolerated.

--- a/crates/but/tests/but/command/push.rs
+++ b/crates/but/tests/but/command/push.rs
@@ -77,7 +77,6 @@ fn assert_single_branch_status_after_push(env: &Sandbox) {
 ┊╭┄ ma [main] (merged upstream)
 ┊●   1 unpushed work
 ┊●   nmy M (no changes)
-┊●   ply add init
 ├╯
 ┊
 ┊● d50ec84 (upstream: origin/main) 2 new commits


### PR DESCRIPTION
At this point, this is more of a but-graph fix than a CLI test coverage PR.

While adding some tests for the CLI, I discovered a gap in the but-graph handling of ad-hoc workspaces. We didn't correctly use the project target information and, in turn, we didn't calculate the correct projection for single-branch mode.

Adding the fix, changed a bunch of snapshots.

---

## Summary

- add CLI coverage for `pull --check` and `pull` from true ad-hoc checkouts across full integration, partial integration, and partial integration with an empty top branch
- add coverage showing `land` rejects ad-hoc mode without changing repository state
- complete project-target discovery for ad-hoc workspace graphs

## `but-graph` changes

Target configuration now lives in repository-level `ProjectMeta`, but graph initialization still discovered those targets inside the loop over managed workspace metadata. An ad-hoc checkout has no workspace metadata entries, so that loop never ran. As a result, the graph could omit both:

- the configured target ref and its local tracking ref
- the stored target commit representing the previous integration base

This is especially visible after upstream integrates a checked-out branch and moves forward: the new target tip is a descendant of `HEAD`, so an ancestry walk starting at `HEAD` cannot discover it on its own. Without an explicit target tip, the workspace projection loses its target and pull cannot classify the integration correctly.

`append_project_target_tips()` now provides the shared target-seeding path for managed and ad-hoc graphs. It adds the named remote target as a `TargetRemote` traversal tip, adds a distinct local tracking tip when available, and queues the stored target commit as an integrated tip.

A named tip matching `ProjectMeta.target_ref` now activates the same deterministic workspace queue ordering whether the graph was built from discovered metadata or explicit tips. Generic explicit integrated tips still preserve their existing ordering. This removes the constructor-dependent target ownership that made fresh and mutation-returned projections disagree, while retaining established behavior for callers that are not supplying the configured project target.

Two graph-level regressions isolate the migration boundary: one target ref is unreachable from `HEAD` and undiscoverable through branch configuration, while the stored target commit is on a separate history. Removing the new seeding path makes both regressions fail.
