### PR TITLE
Tidy up the branches tab and PR affordances

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.tsx
@@ -513,14 +513,6 @@ export const BranchesList: FC<
 			</div>
 
 			<Scroller className={styles.listArea} viewportClassName={styles.list}>
-				<h4
-					id={headingId}
-					className={classes("text-13", "text-bold", styles.heading, styles.headingTitle)}
-				>
-					<SelectionScopeKbd hotkey="1" scope="outline" />
-					Recent branches
-				</h4>
-
 				{stacks.length === 0 && (
 					<p className={classes("text-13", styles.msg)}>
 						{isPending

--- a/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.tsx
@@ -20,7 +20,6 @@ import {
 	type GraphSegmentStatus,
 } from "#ui/components/GraphSegment.tsx";
 import { Icon } from "#ui/components/Icon.tsx";
-import { SelectionScopeKbd } from "#ui/components/SelectionScopeKbd.tsx";
 import { branchesHotkeys, toElectronAccelerator } from "#ui/hotkeys.ts";
 import {
 	nativeMenuItem,
@@ -38,7 +37,7 @@ import {
 } from "#ui/selection-scopes.ts";
 import { useAppDispatch, useAppSelector } from "#ui/store.ts";
 import { RelativeTime } from "#ui/components/RelativeTime.tsx";
-import type { Commit, ListedBranch, ListedStack } from "@gitbutler/but-sdk";
+import type { Commit, ListedBranch } from "@gitbutler/but-sdk";
 import { Field, Toolbar } from "@base-ui/react";
 import { useMergedRefs } from "@base-ui/utils/useMergedRefs";
 import { useQuery } from "@tanstack/react-query";
@@ -68,7 +67,7 @@ import {
 	treeItemId,
 	useIsSelected as useIsSelectedInList,
 } from "./Row-utils.ts";
-import { StackCard, StackCardHeader, StackFoldAllButton } from "./StackCard.tsx";
+import { StackCard } from "./StackCard.tsx";
 import stackCardStyles from "./StackCard.module.css";
 import type { BranchesOutline } from "./useBranchesOutline.ts";
 import styles from "./BranchesList.module.css";
@@ -145,11 +144,12 @@ const BranchCommits: FC<{ projectId: string; branch: ListedBranch }> = ({ projec
 	));
 };
 
-const BranchItem: FC<{ projectId: string; branch: ListedBranch; isTopBranch: boolean }> = ({
-	projectId,
-	branch,
-	isTopBranch,
-}) => {
+const BranchItem: FC<{
+	projectId: string;
+	branch: ListedBranch;
+	isTopBranch: boolean;
+	isStacked: boolean;
+}> = ({ projectId, branch, isTopBranch, isStacked }) => {
 	const dispatch = useAppDispatch();
 	const branchRef = branch.refName.full;
 	const operand = branchOperand({ branchRef: encodeBytes(branchRef) });
@@ -206,7 +206,9 @@ const BranchItem: FC<{ projectId: string; branch: ListedBranch; isTopBranch: boo
 
 	const menuItems: Array<NativeMenuItem> = [
 		nativeMenuItem({
-			label: "Apply to Workspace",
+			// Branches run from the tip down, so applying the top branch of a stack
+			// brings the whole stack with it — the label says so.
+			label: isTopBranch && isStacked ? "Apply Stack to Workspace" : "Apply to Workspace",
 			enabled: !isApplyPending,
 			onSelect: applyBranch,
 		}),
@@ -321,88 +323,6 @@ const BranchItem: FC<{ projectId: string; branch: ListedBranch; isTopBranch: boo
 				</div>
 			)}
 		</div>
-	);
-};
-
-const BranchStackRow: FC<{ projectId: string; stack: ListedStack }> = ({ projectId, stack }) => {
-	const dispatch = useAppDispatch();
-	// A branch with no commits of its own has nothing to unfold, matching the
-	// affordance on the branch rows themselves.
-	const unfoldableRefs = stack.branches
-		.filter((branch) => !branchIsEmpty(branch))
-		.map((branch) => branch.refName.full);
-	// A plain boolean, so this re-renders only when the stack crosses between
-	// fully folded and not — see useIsSelected for the same reasoning.
-	const anyUnfolded = useAppSelector((state) =>
-		unfoldableRefs.some((branchRef) =>
-			projectSlice.selectors.selectBranchUnfolded(state, projectId, branchRef),
-		),
-	);
-
-	const { isPending: isApplyPending, mutate: apply } = useApply();
-
-	const applyStack = () => {
-		apply(
-			// Branches run from the tip down, so applying the tip applies the
-			// whole stack.
-			{ projectId, existingBranch: assert(stack.branches[0]).refName.full },
-			{
-				onSuccess: (response) => {
-					const appliedRef = response.appliedBranches[0];
-					if (!appliedRef) return;
-
-					dispatch(projectSlice.actions.setOutlineTab({ projectId, tab: "workspace" }));
-					dispatch(
-						projectSlice.actions.selectOutline({
-							projectId,
-							selection: branchOperand({ branchRef: encodeBytes(appliedRef.full) }),
-						}),
-					);
-				},
-			},
-		);
-	};
-
-	const menuItems: Array<NativeMenuItem> = [
-		nativeMenuItem({
-			label: "Apply Stack to Workspace",
-			enabled: !isApplyPending,
-			onSelect: applyStack,
-		}),
-	];
-
-	return (
-		<StackCardHeader
-			toolbarLabel="Stack actions"
-			onContextMenu={(event) => {
-				void showNativeContextMenu(event, menuItems);
-			}}
-		>
-			<StackFoldAllButton
-				hasMultipleBranches={stack.branches.length > 1}
-				folded={!anyUnfolded}
-				disabled={unfoldableRefs.length === 0}
-				onToggle={() =>
-					dispatch(
-						projectSlice.actions.setBranchesUnfolded({
-							projectId,
-							branchRefs: unfoldableRefs,
-							unfolded: !anyUnfolded,
-						}),
-					)
-				}
-			/>
-
-			<Toolbar.Button
-				aria-label="Stack menu"
-				onClick={(event) => {
-					void showNativeMenuFromTrigger(event.currentTarget, menuItems);
-				}}
-				className={getRowButtonClassName({ iconOnly: true })}
-			>
-				<Icon name="kebab" />
-			</Toolbar.Button>
-		</StackCardHeader>
 	);
 };
 
@@ -543,12 +463,16 @@ export const BranchesList: FC<
 							// oxlint-disable-next-line jsx-a11y/prefer-tag-over-role -- A stack is an ARIA group of tree items.
 							role="group"
 							aria-label="Stack"
-							header={<BranchStackRow projectId={projectId} stack={stack} />}
 							bodyClassName={styles.stackBody}
 						>
 							{stack.branches.map((branch, index) => (
 								<Fragment key={branch.refName.full}>
-									<BranchItem projectId={projectId} branch={branch} isTopBranch={index === 0} />
+									<BranchItem
+										projectId={projectId}
+										branch={branch}
+										isTopBranch={index === 0}
+										isStacked={stack.branches.length > 1}
+									/>
 
 									{/* Carries the rail down to the next branch, and past the
 									    last one as the card's floor — as the workspace card's

--- a/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.tsx
@@ -42,16 +42,7 @@ import { Field, Toolbar } from "@base-ui/react";
 import { useMergedRefs } from "@base-ui/utils/useMergedRefs";
 import { useQuery } from "@tanstack/react-query";
 import { useHotkey } from "@tanstack/react-hotkeys";
-import {
-	type ComponentProps,
-	type FC,
-	Fragment,
-	type MouseEvent,
-	useEffect,
-	useId,
-	useRef,
-	useState,
-} from "react";
+import { type ComponentProps, type FC, Fragment, useEffect, useId, useRef, useState } from "react";
 import {
 	Row,
 	RowFoldToggle,
@@ -199,9 +190,7 @@ const BranchItem: FC<{
 		);
 	};
 
-	const openReviewInBrowser = async (evt: MouseEvent<HTMLAnchorElement>): Promise<void> => {
-		evt.preventDefault();
-
+	const openReviewInBrowser = async (): Promise<void> => {
 		if (review) await window.lite.openInWebBrowser(review.htmlUrl);
 	};
 
@@ -212,6 +201,12 @@ const BranchItem: FC<{
 			label: isTopBranch && isStacked ? "Apply Stack to Workspace" : "Apply to Workspace",
 			enabled: !isApplyPending,
 			onSelect: applyBranch,
+		}),
+		nativeMenuSeparator,
+		nativeMenuItem({
+			label: "Open Pull Request In Browser",
+			enabled: review !== null,
+			onSelect: openReviewInBrowser,
 		}),
 		nativeMenuSeparator,
 		nativeMenuItem({
@@ -296,16 +291,14 @@ const BranchItem: FC<{
 						{review !== null && (
 							<>
 								{(showsAuthorMeta || showsCommitCount) && <RowMetaSeparator />}
-								<a
-									href={review.htmlUrl}
+								<span
 									title={review.title}
-									onClick={(evt) => void openReviewInBrowser(evt)}
 									className={classes(rowStyles.fadedText, rowStyles.metaItem)}
 								>
 									<Icon size={14} name="pr" />
 									{review.unitSymbol}
 									{review.number}
-								</a>
+								</span>
 							</>
 						)}
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.tsx
@@ -59,6 +59,7 @@ import {
 	RowLabelContainer,
 	RowLabelGroup,
 	RowMeta,
+	RowMetaSeparator,
 	RowToolbar,
 } from "./Row.tsx";
 import {
@@ -223,6 +224,14 @@ const BranchItem: FC<{
 
 	const lastAuthorName = branch.lastAuthor?.name;
 
+	const showsAuthorMeta = lastAuthorName !== undefined || branch.updatedAtMs !== null;
+	/* The branch's own commits, matching what unfolding reveals.
+	   commitsAheadOfTarget would also count the branches below it in a stack, so
+	   every row above the bottom would overstate. Only while folded: the count
+	   stands in for the commits it hides, so showing it alongside them would just
+	   be noise. */
+	const showsCommitCount = !unfolded && branch.commitCount !== null && branch.commitCount > 0;
+
 	return (
 		<div
 			id={treeItemId(operand)}
@@ -262,19 +271,7 @@ const BranchItem: FC<{
 					</RowLabelContainer>
 
 					<RowMeta>
-						{/* The branch's own commits, matching what unfolding reveals.
-						    commitsAheadOfTarget would also count the branches below it
-						    in a stack, so every row above the bottom would overstate.
-						    Only while folded: the count stands in for the commits it
-						    hides, so showing it alongside them would just be noise. */}
-						{!unfolded && branch.commitCount !== null && branch.commitCount > 0 && (
-							<span className={classes(rowStyles.fadedText, rowStyles.metaItem)}>
-								<Icon size={14} name="commit" />
-								{branch.commitCount}
-							</span>
-						)}
-
-						{(lastAuthorName !== undefined || branch.updatedAtMs !== null) && (
+						{showsAuthorMeta && (
 							<span
 								className={classes(rowStyles.fadedText, rowStyles.metaItem)}
 								title={branch.lastAuthor?.email}
@@ -286,17 +283,30 @@ const BranchItem: FC<{
 							</span>
 						)}
 
+						{showsCommitCount && (
+							<>
+								{showsAuthorMeta && <RowMetaSeparator />}
+								<span className={classes(rowStyles.fadedText, rowStyles.metaItem)}>
+									<Icon size={14} name="commit" />
+									{branch.commitCount}
+								</span>
+							</>
+						)}
+
 						{review !== null && (
-							<a
-								href={review.htmlUrl}
-								title={review.title}
-								onClick={(evt) => void openReviewInBrowser(evt)}
-								className={classes(rowStyles.fadedText, rowStyles.metaItem)}
-							>
-								<Icon size={14} name="pr" />
-								{review.unitSymbol}
-								{review.number}
-							</a>
+							<>
+								{(showsAuthorMeta || showsCommitCount) && <RowMetaSeparator />}
+								<a
+									href={review.htmlUrl}
+									title={review.title}
+									onClick={(evt) => void openReviewInBrowser(evt)}
+									className={classes(rowStyles.fadedText, rowStyles.metaItem)}
+								>
+									<Icon size={14} name="pr" />
+									{review.unitSymbol}
+									{review.number}
+								</a>
+							</>
 						)}
 
 						{isApplyPending && <Icon name="spinner" />}

--- a/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.tsx
@@ -42,7 +42,7 @@ import { Field, Toolbar } from "@base-ui/react";
 import { useMergedRefs } from "@base-ui/utils/useMergedRefs";
 import { useQuery } from "@tanstack/react-query";
 import { useHotkey } from "@tanstack/react-hotkeys";
-import { type ComponentProps, type FC, Fragment, useEffect, useId, useRef, useState } from "react";
+import { type ComponentProps, type FC, Fragment, useEffect, useRef, useState } from "react";
 import {
 	Row,
 	RowFoldToggle,
@@ -356,7 +356,6 @@ export const BranchesList: FC<
 			dispatch(projectSlice.actions.selectBranches({ projectId, selection: outOfSyncSelection }));
 	}, [dispatch, outOfSyncSelection, projectId]);
 
-	const headingId = useId();
 	const hotkeysRef = useRef<HTMLDivElement>(null);
 	const { isPending: isBranchRemovePending, mutate: branchRemove } = useBranchRemove();
 	const selectedBranchIsLocal =
@@ -451,7 +450,7 @@ export const BranchesList: FC<
 				<div
 					tabIndex={0}
 					role="tree"
-					aria-labelledby={headingId}
+					aria-label="Branches"
 					aria-activedescendant={selection ? treeItemId(selection) : undefined}
 					data-selection-scope={"outline" satisfies SelectionScope}
 					className={styles.tree}

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/BranchRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/BranchRow.tsx
@@ -45,6 +45,7 @@ import {
 	RowLabelContainer,
 	RowLabelGroup,
 	RowMeta,
+	RowMetaSeparator,
 	RowToolbar,
 } from "../Row.tsx";
 import { getRowButtonClassName } from "../Row-utils.ts";
@@ -488,10 +489,13 @@ export const BranchRow: FC<
 						{/* Only while folded: the count stands in for the commits it hides,
 						    so showing it alongside them would just be noise. */}
 						{isFolded && (
-							<span className={classes(rowStyles.fadedText, rowStyles.metaItem)}>
-								<Icon size={14} name="commit" />
-								{commitCount}
-							</span>
+							<>
+								<span className={classes(rowStyles.fadedText, rowStyles.metaItem)}>
+									<Icon size={14} name="commit" />
+									{commitCount}
+								</span>
+								<RowMetaSeparator />
+							</>
 						)}
 
 						<span
@@ -514,24 +518,31 @@ export const BranchRow: FC<
 						</span>
 
 						{mforgeUrl != null && (
-							<a
-								href={mforgeUrl}
-								onClick={(evt) => void openPRInBrowser(evt)}
-								className={classes(rowStyles.fadedText, rowStyles.metaItem)}
-							>
-								<Icon size={14} name="pr" />
-								PR
-							</a>
+							<>
+								<RowMetaSeparator />
+								<a
+									href={mforgeUrl}
+									onClick={(evt) => void openPRInBrowser(evt)}
+									className={classes(rowStyles.fadedText, rowStyles.metaItem)}
+								>
+									<Icon size={14} name="pr" />
+									PR
+								</a>
+							</>
 						)}
 
-						{ciChecks?.aggregate &&
-							(ciURL != null ? (
-								<a href={ciURL} onClick={(evt) => void openCIChecksInBrowser(evt)}>
+						{ciChecks?.aggregate && (
+							<>
+								<RowMetaSeparator />
+								{ciURL != null ? (
+									<a href={ciURL} onClick={(evt) => void openCIChecksInBrowser(evt)}>
+										<CIBubble checks={ciChecks.aggregate} />
+									</a>
+								) : (
 									<CIBubble checks={ciChecks.aggregate} />
-								</a>
-							) : (
-								<CIBubble checks={ciChecks.aggregate} />
-							))}
+								)}
+							</>
+						)}
 
 						{downstackPushStatus.anyRequiresPush &&
 							(() => {

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/BranchRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/BranchRow.tsx
@@ -486,7 +486,7 @@ export const BranchRow: FC<
 					<RowMeta>
 						{/* Only while folded: the count stands in for the commits it hides,
 						    so showing it alongside them would just be noise. */}
-						{isFolded && (
+						{isFolded && commitCount > 0 && (
 							<>
 								<span className={classes(rowStyles.fadedText, rowStyles.metaItem)}>
 									<Icon size={14} name="commit" />

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/BranchRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/BranchRow.tsx
@@ -301,9 +301,7 @@ export const BranchRow: FC<
 		});
 	};
 
-	const openPRInBrowser = async (evt?: MouseEvent<HTMLAnchorElement>): Promise<void> => {
-		evt?.preventDefault();
-
+	const openPRInBrowser = async (): Promise<void> => {
 		if (mforgeUrl != null) await window.lite.openInWebBrowser(mforgeUrl);
 	};
 
@@ -381,7 +379,7 @@ export const BranchRow: FC<
 		}),
 		nativeMenuSeparator,
 		nativeMenuItem({
-			label: "Open In Browser",
+			label: "Open Pull Request In Browser",
 			enabled: mforgeUrl != null,
 			accelerator: toElectronAccelerator(outlineHotkeys.openPRInBrowser.hotkey),
 			onSelect: openPRInBrowser,
@@ -517,17 +515,13 @@ export const BranchRow: FC<
 							</span>
 						</span>
 
-						{mforgeUrl != null && (
+						{pullRequest !== null && (
 							<>
 								<RowMetaSeparator />
-								<a
-									href={mforgeUrl}
-									onClick={(evt) => void openPRInBrowser(evt)}
-									className={classes(rowStyles.fadedText, rowStyles.metaItem)}
-								>
+								<span className={classes(rowStyles.fadedText, rowStyles.metaItem)}>
 									<Icon size={14} name="pr" />
 									PR
-								</a>
+								</span>
 							</>
 						)}
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/BranchRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/BranchRow.tsx
@@ -515,6 +515,8 @@ export const BranchRow: FC<
 							</span>
 						</span>
 
+						{/* The checks belong to the PR, so they ride alongside its label
+						    rather than standing as their own meta item. */}
 						{pullRequest !== null && (
 							<>
 								<RowMetaSeparator />
@@ -522,19 +524,15 @@ export const BranchRow: FC<
 									<Icon size={14} name="pr" />
 									PR
 								</span>
-							</>
-						)}
 
-						{ciChecks?.aggregate && (
-							<>
-								<RowMetaSeparator />
-								{ciURL != null ? (
-									<a href={ciURL} onClick={(evt) => void openCIChecksInBrowser(evt)}>
+								{ciChecks?.aggregate &&
+									(ciURL != null ? (
+										<a href={ciURL} onClick={(evt) => void openCIChecksInBrowser(evt)}>
+											<CIBubble checks={ciChecks.aggregate} />
+										</a>
+									) : (
 										<CIBubble checks={ciChecks.aggregate} />
-									</a>
-								) : (
-									<CIBubble checks={ciChecks.aggregate} />
-								)}
+									))}
 							</>
 						)}
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
@@ -224,7 +224,7 @@
 .meta {
 	display: flex;
 	align-items: center;
-	gap: 8px;
+	gap: 6px;
 }
 
 .metaItem {
@@ -234,6 +234,12 @@
 	/* Match small button height to prevent layout shift when buttons appear/disappear. */
 	height: 20px;
 	gap: 4px;
+}
+
+/* Dot drawn between meta items. */
+.metaSeparator {
+	flex-shrink: 0;
+	opacity: 0.4;
 }
 
 /* Item that yields space to its siblings by truncating its text. */

--- a/apps/lite/ui/src/routes/project/$id/workspace/Row.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Row.tsx
@@ -159,6 +159,13 @@ export const RowMeta: FC<ComponentProps<"div">> = (props) => (
 	<RowLabelFooter {...props} className={classes(props.className, "text-13", styles.meta)} />
 );
 
+/** The dot drawn between {@link RowMeta} items. */
+export const RowMetaSeparator: FC = () => (
+	<span aria-hidden className={classes(styles.metaSeparator, "text-12")}>
+		•
+	</span>
+);
+
 export const RowLabel: FC<
 	{ heading?: boolean; singleLine?: boolean } & useRender.ComponentProps<"div">
 > = ({ heading, singleLine, render, ...props }) =>


### PR DESCRIPTION
- Remove the section header and the per-stack headers from the branches tab.
- Add a separator between items.
- PR meta in the workspace outline and the branches list is now plain text instead of a link; opening the PR in a browser moved to the branch kebab/context menu ("Open Pull Request In Browser").