### PR TITLE
Replace lines changed with a +x -y stat for accuracy

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/operandLabel.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/operandLabel.ts
@@ -34,8 +34,18 @@ export const operandLabel = ({
 					(sum, group) => sum + (group.side === "deletions" ? group.lines : 0),
 					0,
 				);
-				const count = Math.max(add, del);
-				return `${count} changed line${count !== 1 ? "s" : ""}`;
+				const all = add + del;
+
+				// Probably shouldn't happen?
+				if (all == 0) return "0 changed lines";
+
+				let words = "";
+				if (add > 0) words += `+${add}`;
+				if (add > 0 && del > 0) words += ` `;
+				if (del > 0) words += `-${del}`;
+				if (all === 1) words += " line";
+				else words += " lines";
+				return words;
 			},
 		}),
 	);

--- a/apps/lite/ui/src/routes/project/$id/workspace/operandLabel.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/operandLabel.ts
@@ -26,7 +26,15 @@ export const operandLabel = ({
 					: shortCommitId(commitId);
 			},
 			Hunk: ({ lineGroups }) => {
-				const count = lineGroups.reduce((sum, group) => sum + group.lines, 0);
+				const add = lineGroups.reduce(
+					(sum, group) => sum + (group.side === "additions" ? group.lines : 0),
+					0,
+				);
+				const del = lineGroups.reduce(
+					(sum, group) => sum + (group.side === "deletions" ? group.lines : 0),
+					0,
+				);
+				const count = Math.max(add, del);
 				return `${count} changed line${count !== 1 ? "s" : ""}`;
 			},
 		}),


### PR DESCRIPTION
Use a `+x -y line(s)` for the hunk drag preview. This avoids ambiguity around what a "changed line" even is.