### PR TITLE
Fix Lite E2E branches navigation test

### DIFF
--- a/apps/lite/e2e/tests/start.spec.ts
+++ b/apps/lite/e2e/tests/start.spec.ts
@@ -14,7 +14,6 @@ test.describe("with a seeded project", () => {
 
 		const navigation = appWindow.getByRole("group", { name: "Navigation" });
 		await navigation.getByRole("button", { name: "Branches" }).click();
-		await expect(appWindow.getByRole("heading", { name: "Recent branches" })).toBeVisible();
 		await expect(appWindow.getByRole("textbox", { name: "Filter branches" })).toBeVisible();
 	});
 });


### PR DESCRIPTION
## What changed

- Remove the stale `Recent branches` heading assertion from the Lite navigation smoke test.
- Keep the visible `Filter branches` textbox assertion as the stable signal that navigation reached the Branches view.

## Root cause

The heading was removed from the Branches view after the original Lite E2E PR had passed CI. Merging the two changes left the test asserting UI that no longer exists, making master red.

## Validation

- Confirmed the unmodified test fails locally on current master: 1 failed, 2 passed.
- Confirmed the fixed test suite passes locally: 3 passed.
- Command: `mise exec -- pnpm -F @gitbutler/lite test:e2e`