### PR TITLE
Stabilize Lite apply branch E2E test

### DIFF
--- a/apps/lite/e2e/tests/branches.spec.ts
+++ b/apps/lite/e2e/tests/branches.spec.ts
@@ -20,7 +20,7 @@ test.describe("branches", () => {
 
 		const search = picker.getByRole("combobox", { name: /search for branches/i });
 		await search.fill("branch1");
-		await search.press("Enter");
+		await picker.getByRole("option", { name: /^branch1 / }).click();
 
 		await expect(picker).toBeHidden();
 		await expect(branch).toBeVisible();


### PR DESCRIPTION
## What changed

Wait for and click the `branch1` picker option instead of pressing Enter immediately after filling the search field.

## Root cause

The branch list is loaded asynchronously. On a slower CI run, Enter was sent before the matching option had rendered, so no selection occurred and the Apply Branch dialog remained open.

## Validation

- Affected test repeated 10 times with CI settings: 10 passed.
- Full Lite E2E suite with CI settings: 3 passed.
- `mise exec -- pnpm -F @gitbutler/lite test:e2e --forbid-only --workers=1 --grep "applies a remote branch" --repeat-each=10`
- `mise exec -- pnpm -F @gitbutler/lite test:e2e --forbid-only --workers=1`