### PR TITLE
clean: clean up no-commit paths to target

### DIFF
--- a/crates/but-transaction/src/lib.rs
+++ b/crates/but-transaction/src/lib.rs
@@ -392,8 +392,9 @@ where
                         let mut ok_to_skip = matches!(step, Step::None);
                         if !ok_to_skip
                             && let Some(ref target_local_branch) = target_local_branch
-                            && matches!(step, Step::Reference { refname, .. }
-                                if refname.as_bstr() == target_local_branch)
+                            && matches!(step, Step::Reference { ref refname, .. }
+                                if refname.as_bstr() == target_local_branch ||
+                                    refname.as_bstr() == b"refs/heads/gitbutler/target")
                         {
                             ok_to_skip = true;
                         }

--- a/crates/but/src/command/legacy/branch/mod.rs
+++ b/crates/but/src/command/legacy/branch/mod.rs
@@ -45,6 +45,7 @@ pub fn delete(
         &mut meta,
         guard.write_permission(),
         discard::DiscardOperation::Branches(branches),
+        gitbutler_oplog::entry::OperationKind::Discard,
     )?)
 }
 

--- a/crates/but/src/command/legacy/clean.rs
+++ b/crates/but/src/command/legacy/clean.rs
@@ -1,12 +1,11 @@
 use std::collections::HashSet;
 
+use but_api::WorkspaceState;
 use but_core::ref_metadata::StackId;
-use gitbutler_oplog::{
-    OplogExt,
-    entry::{OperationKind, SnapshotDetails},
-};
+use nonempty::NonEmpty;
 
 use crate::{
+    command::legacy::discard::{self},
     theme::{self, Paint},
     utils::OutputChannel,
 };
@@ -43,10 +42,10 @@ pub fn handle(
     ctx: &mut but_ctx::Context,
     out: &mut OutputChannel,
     options: CleanOptions,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<Option<WorkspaceState>> {
     let empty_branches = find_empty_branches(ctx, options.include_upstream)?;
 
-    if empty_branches.is_empty() {
+    let Some(empty_branches) = NonEmpty::from_vec(empty_branches) else {
         if let Some(out) = out.for_json() {
             out.write_value(&CleanResult {
                 deleted: &[],
@@ -56,8 +55,8 @@ pub fn handle(
         } else if let Some(out) = out.for_human() {
             writeln!(out, "No empty branches found.")?;
         }
-        return Ok(());
-    }
+        return Ok(None);
+    };
 
     if options.dry_run {
         let cleaned: Vec<CleanedBranch> = empty_branches
@@ -84,43 +83,34 @@ pub fn handle(
                 t.important.paint(count.to_string())
             )?;
         }
-        return Ok(());
+        return Ok(None);
     }
 
-    // Create a single oplog snapshot before performing all deletions.
     let mut guard = ctx.exclusive_worktree_access();
-    ctx.create_snapshot(
-        SnapshotDetails::new(OperationKind::CleanWorkspace),
+    let mut meta = ctx.meta()?;
+    let (_outcome, ws) = discard::run(
+        ctx,
+        &mut meta,
         guard.write_permission(),
-    )
-    .ok();
+        discard::DiscardOperation::Branches(
+            empty_branches
+                .as_ref()
+                .try_map(|b| gix::refs::FullName::try_from(format!("refs/heads/{}", b.1)))?,
+        ),
+        gitbutler_oplog::entry::OperationKind::CleanWorkspace,
+    )?;
 
     let mut deleted = Vec::new();
-    let mut failed = Vec::new();
-
     for (_stack_id, branch_name) in &empty_branches {
-        match but_api::legacy::stack::remove_branch_only(ctx, branch_name, guard.write_permission())
-        {
-            Ok(()) => {
-                deleted.push(CleanedBranch {
-                    name: branch_name.clone(),
-                });
-            }
-            Err(err) => {
-                failed.push(FailedBranch {
-                    name: branch_name.clone(),
-                    error: err.to_string(),
-                });
-            }
-        }
+        deleted.push(CleanedBranch {
+            name: branch_name.clone(),
+        });
     }
-
-    let num_failed = failed.len();
 
     if let Some(out) = out.for_json() {
         out.write_value(&CleanResult {
             deleted: &deleted,
-            failed: &failed,
+            failed: &[],
             dry_run: false,
         })?;
     } else if let Some(out) = out.for_human() {
@@ -140,22 +130,9 @@ pub fn handle(
                 t.important.paint(deleted.len().to_string())
             )?;
         }
-        for f in &failed {
-            writeln!(
-                out,
-                "{} Failed to delete branch '{}': {}",
-                t.sym().error,
-                f.name,
-                f.error
-            )?;
-        }
     }
 
-    if num_failed == 0 {
-        Ok(())
-    } else {
-        anyhow::bail!("failed to delete {num_failed} branch(es)")
-    }
+    Ok(Some(ws))
 }
 
 /// Find all empty branches in the workspace.

--- a/crates/but/src/command/legacy/discard.rs
+++ b/crates/but/src/command/legacy/discard.rs
@@ -267,7 +267,13 @@ pub fn discard(
         resolve(&repo, &id_map, args)?
     };
 
-    Ok(run(ctx, &mut meta, guard.write_permission(), operation)?)
+    Ok(run(
+        ctx,
+        &mut meta,
+        guard.write_permission(),
+        operation,
+        gitbutler_oplog::entry::OperationKind::Discard,
+    )?)
 }
 
 fn resolve(repo: &gix::Repository, id_map: &IdMap, args: Platform) -> CliResult<DiscardOperation> {
@@ -373,6 +379,7 @@ pub fn run(
     meta: &mut impl RefMetadata,
     perm: &mut RepoExclusive,
     operation: DiscardOperation,
+    oplog_operation_kind: OperationKind,
 ) -> anyhow::Result<(DiscardOutcome, WorkspaceState)> {
     let executable = match operation {
         DiscardOperation::Branches(branches) => {
@@ -449,7 +456,7 @@ pub fn run(
         ctx,
         meta,
         perm,
-        SnapshotDetails::new(OperationKind::Discard),
+        SnapshotDetails::new(oplog_operation_kind),
         DryRun::No,
         |mut tx| {
             let outcome = match executable {

--- a/crates/but/src/command/legacy/status/tui/app/discard.rs
+++ b/crates/but/src/command/legacy/status/tui/app/discard.rs
@@ -358,6 +358,12 @@ pub(in crate::command::legacy::status::tui) fn run_discard(
 ) -> anyhow::Result<DiscardOutcome> {
     let mut guard = ctx.exclusive_worktree_access();
     let mut meta = ctx.meta()?;
-    let (outcome, _ws) = discard::run(ctx, &mut meta, guard.write_permission(), operation)?;
+    let (outcome, _ws) = discard::run(
+        ctx,
+        &mut meta,
+        guard.write_permission(),
+        operation,
+        gitbutler_oplog::entry::OperationKind::Discard,
+    )?;
     Ok(outcome)
 }

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -1091,8 +1091,7 @@ async fn match_subcommand(
                     include_upstream,
                 },
             )
-            .emit_metrics(metrics_ctx)?;
-            None
+            .emit_metrics(metrics_ctx)?
         }
         #[cfg(feature = "legacy")]
         Subcommands::Worktree(worktree::Platform { cmd }) => {

--- a/crates/but/tests/but/command/clean.rs
+++ b/crates/but/tests/but/command/clean.rs
@@ -37,10 +37,8 @@ fn removes_empty_branch() {
     snapbox::assert_data_eq!(
         env.git_log(),
         snapbox::str![[r#"
-*   0e97f4a (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-|/  
-| * 9477ae7 (A) add A
-|/  
+* 7fa7db9 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+* 9477ae7 (A) add A
 * 0dc3733 (origin/main, origin/HEAD, main, gitbutler/target) add M
 
 "#]]

--- a/crates/but/tests/but/command/undo.rs
+++ b/crates/but/tests/but/command/undo.rs
@@ -509,3 +509,15 @@ a135744 2000-01-02 00:00:00 [COMMIT] Created commit
 
 "#]]);
 }
+
+#[test]
+fn can_undo_but_clean() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
+
+    env.but("branch new empty-branch").assert().success();
+
+    run_mutate_undo_roundtrip_test(&env, |env| {
+        env.but("clean").assert().success();
+    });
+}


### PR DESCRIPTION
I noticed that refs/heads/gitbutler/target can also sometimes appear in between the workspace commit and the target commit, so I have also taken that into consideration when deciding whether to clean up the path between the workspace commit and the target commit.
