### PR TITLE
Fix contiguous hunk selections

### DIFF
--- a/apps/lite/ui/src/hunk.test.ts
+++ b/apps/lite/ui/src/hunk.test.ts
@@ -1,4 +1,8 @@
-import { contiguousSelectionByLine, wholeHunkSelectionByLine } from "#ui/hunk.ts";
+import {
+	contiguousSelectionByLine,
+	contiguousSelectionsFromHunk,
+	wholeHunkSelectionByLine,
+} from "#ui/hunk.ts";
 import { processFile } from "@pierre/diffs";
 import { describe, expect, it } from "vitest";
 
@@ -35,6 +39,43 @@ const hunks = (() => {
 	if (!parsed) throw new Error("Failed to parse patch");
 	return parsed.hunks;
 })();
+
+const REALIGNED_PATCH = [
+	"diff --git a/file.ts b/file.ts",
+	"--- a/file.ts",
+	"+++ b/file.ts",
+	"@@ -1,5 +1,4 @@",
+	" let snapshot = snapshot_with_missing_peer_dep_nv();",
+	"-let snapshot =",
+	"-  NpmResolutionSnapshot::new(snapshot.into_valid().unwrap());",
+	"+let snapshot = NpmResolutionSnapshot::new(snapshot.into_valid().unwrap());",
+	" let graph = Graph::from_snapshot(snapshot);",
+	" assert_eq!(graph.nodes.len(), 3);",
+	"",
+].join("\n");
+
+const realignedHunk = (() => {
+	const parsed = processFile(REALIGNED_PATCH, { cacheKey: "hunk.test.realigned" });
+	if (!parsed) throw new Error("Failed to parse realigned patch");
+	const hunk = parsed.hunks[0];
+	if (!hunk) throw new Error("Realigned patch has no hunk");
+	return hunk;
+})();
+
+describe("contiguousSelectionsFromHunk", () => {
+	it("keeps adjacent similarity-aligned change fragments contiguous", () => {
+		expect(realignedHunk.hunkContent.filter(({ type }) => type === "change")).toHaveLength(2);
+		expect(contiguousSelectionsFromHunk(realignedHunk).toArray()).toEqual([
+			{
+				hunkHeader: { oldStart: 1, oldLines: 5, newStart: 1, newLines: 4 },
+				lineGroups: [
+					{ side: "deletions", start: 2, lines: 2 },
+					{ side: "additions", start: 2, lines: 1 },
+				],
+			},
+		]);
+	});
+});
 
 describe("wholeHunkSelectionByLine", () => {
 	it("takes every changed run of the hunk holding a context line", () => {

--- a/apps/lite/ui/src/hunk.ts
+++ b/apps/lite/ui/src/hunk.ts
@@ -113,13 +113,24 @@ export const rangeFromLineGroups = (
 	return range;
 };
 
-const contiguousSelectionFromContent = (
+const contiguousSelectionFromContents = (
 	hunk: Hunk,
-	content: Hunk["hunkContent"][number],
+	contents: Array<ChangeContent>,
 ): HunkLineSelection | null => {
-	if (content.type !== "change") return null;
+	let deletions: HunkLineSelectionGroup | undefined;
+	let additions: HunkLineSelectionGroup | undefined;
 
-	const lineGroups = lineGroupsFromChangeContent(hunk, content);
+	for (const content of contents) {
+		for (const group of lineGroupsFromChangeContent(hunk, content)) {
+			const existing = group.side === "deletions" ? deletions : additions;
+
+			if (existing) existing.lines += group.lines;
+			else if (group.side === "deletions") deletions = group;
+			else additions = group;
+		}
+	}
+
+	const lineGroups = [deletions, additions].filter((group) => group !== undefined);
 	if (lineGroups.length === 0) return null;
 
 	return {
@@ -128,17 +139,24 @@ const contiguousSelectionFromContent = (
 	};
 };
 
-export const contiguousSelectionsFromHunk = (hunk: Hunk): Array<HunkLineSelection> =>
-	hunk.hunkContent.flatMap((content) => contiguousSelectionFromContent(hunk, content) ?? []);
+export function* contiguousSelectionsFromHunk(hunk: Hunk): Generator<HunkLineSelection, void> {
+	let contents: Array<ChangeContent> = [];
 
-export const firstContiguousSelectionFromHunk = (hunk: Hunk): HunkLineSelection | null => {
 	for (const content of hunk.hunkContent) {
-		const sel = contiguousSelectionFromContent(hunk, content);
-		if (sel) return sel;
+		if (content.type === "change") {
+			contents.push(content);
+			continue;
+		}
+
+		const selection = contiguousSelectionFromContents(hunk, contents);
+		if (selection) yield selection;
+
+		contents = [];
 	}
 
-	return null;
-};
+	const selection = contiguousSelectionFromContents(hunk, contents);
+	if (selection) yield selection;
+}
 
 /** A line as the diff view names it: a number, read on one side of the change. */
 type LineQuery = {
@@ -178,7 +196,9 @@ export const wholeHunkSelectionByLine = (query: LineQuery): HunkLineSelection | 
 	const hunk = hunkByLine(query);
 	if (!hunk) return null;
 
-	const lineGroups = contiguousSelectionsFromHunk(hunk).flatMap((sel) => sel.lineGroups);
+	const lineGroups = contiguousSelectionsFromHunk(hunk)
+		.flatMap((sel) => sel.lineGroups)
+		.toArray();
 	if (lineGroups.length === 0) return null;
 
 	return {

--- a/apps/lite/ui/src/routes/project/$id/workspace/diff-view.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/diff-view.ts
@@ -2,7 +2,6 @@ import { assert } from "#ui/assert.ts";
 import { hash } from "#ui/hash.ts";
 import {
 	contiguousSelectionsFromHunk,
-	firstContiguousSelectionFromHunk,
 	rangeFromLineGroups,
 	synthesizeFilePatch,
 } from "#ui/hunk.ts";
@@ -130,7 +129,7 @@ export const getDiffFileNavigation = ({
 		if (fstDiffHunk) {
 			const fstHunk = parseFileDiff(synthesizeFilePatch(change, [fstDiffHunk]), itemId).hunks[0];
 			if (fstHunk) {
-				const fstSelection = firstContiguousSelectionFromHunk(fstHunk);
+				const fstSelection = contiguousSelectionsFromHunk(fstHunk).next().value;
 				if (fstSelection) {
 					return {
 						itemId,


### PR DESCRIPTION
## Summary

- group adjacent Pierre change fragments into one contiguous Lite hunk selection
- keep hunk enumeration lazy and materialize it only where an array is required
- add regression coverage for a similarity-aligned two-line replacement

## Root cause

`@pierre/diffs` 1.3.x introduced similarity-based change realignment. A single contiguous replacement can now be represented as multiple adjacent `ChangeContent` entries, while Lite treated every entry as a separate selectable hunk. Grouping consecutive change entries until a context boundary restores the intended selection and preserves the pre-1.3 line-group shape.

## Validation

- `pnpm -F @gitbutler/lite test -- ui/src/hunk.test.ts` (78 tests passed)
- `pnpm -F @gitbutler/lite check`
- `git diff --check`