### PR TITLE
Address conflicts stably in the resolution dialog

### DIFF
--- a/apps/lite/ui/src/api/mutations.ts
+++ b/apps/lite/ui/src/api/mutations.ts
@@ -828,9 +828,7 @@ export const useResolveCommitConflictHunks = () => {
 		mutationFn: window.lite.resolveCommitConflictHunks,
 		onSuccess: async (response, input, _context, mutation) => {
 			syncCoreCaches(mutation.client, dispatch, input.projectId, response);
-			// The conflicts that remain renumber, so a check made against the old
-			// numbering would address a different conflict from the one clicked.
-			dispatch(projectSlice.actions.clearCheckedConflicts({ projectId: input.projectId }));
+			// No check clearing: ids survive the rewrite, resolved ones stop matching.
 
 			// A commit with a manual-only file left is still conflicted, however
 			// many hunks were resolved, so both lists must be empty to be done.
@@ -841,6 +839,20 @@ export const useResolveCommitConflictHunks = () => {
 					description: response.commitEmptied
 						? "The commit keeps nothing of its own now, so it no longer changes anything. Undo from the operations history if that wasn't the intent."
 						: "The commit is no longer conflicted.",
+					priority: "low",
+				});
+			} else {
+				const remaining = response.remaining.reduce((sum, file) => sum + file.hunks, 0);
+				toastManager.add({
+					type: "success",
+					title:
+						response.resolved === 1
+							? "Conflict resolved"
+							: `${response.resolved} conflicts resolved`,
+					description:
+						remaining > 0
+							? `${remaining} conflict${remaining === 1 ? "" : "s"} remaining in this commit.`
+							: "The remaining files can only be resolved in edit mode.",
 					priority: "low",
 				});
 			}

--- a/apps/lite/ui/src/projects/project.ts
+++ b/apps/lite/ui/src/projects/project.ts
@@ -64,14 +64,13 @@ type CheckableOperand = Extract<Operand, { _tag: "Commit" | "File" }>;
 export type BranchTab = "diff" | "pr";
 
 /**
- * A conflict checked for a batch resolution. Keyed by commit as well as
- * position: resolving rewrites the commit and renumbers the hunks that remain,
- * so checks must never carry across an apply.
+ * A conflict checked for a batch resolution. Ids survive the rewrites that
+ * compact hunk positions, so checks carry across; the commit id is remapped.
  */
-type CheckedConflict = { commitId: string; path: string; hunk: number };
+type CheckedConflict = { commitId: string; path: string; id: string };
 
-const conflictCheckKey = ({ commitId, path, hunk }: CheckedConflict): string =>
-	`${commitId}\u0000${path}\u0000${hunk}`;
+const conflictCheckKey = ({ commitId, path, id }: CheckedConflict): string =>
+	`${commitId}\u0000${path}\u0000${id}`;
 
 type WorkspaceState = {
 	checkedOperands: Record<string, CheckableOperand>;
@@ -427,6 +426,14 @@ export const projectReducers = {
 		}
 
 		branchesReducers.updateRewrittenCommitReferences(state.branches, { replacedCommits });
+
+		for (const [key, conflict] of Object.entries(workspaceState.checkedConflicts)) {
+			const newId = replacedCommits[conflict.commitId];
+			if (newId === undefined) continue;
+			delete workspaceState.checkedConflicts[key];
+			const moved = { ...conflict, commitId: newId };
+			workspaceState.checkedConflicts[conflictCheckKey(moved)] = moved;
+		}
 
 		for (const [key, operand] of Object.entries(workspaceState.checkedOperands)) {
 			let newOperand: CheckableOperand | null = null;

--- a/apps/lite/ui/src/routes/project/$id/workspace/ConflictBar.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/ConflictBar.tsx
@@ -46,9 +46,16 @@ export const ConflictBar: FC<Props> = (p) => {
 	const total = p.conflicts.reduce((sum, file) => sum + file.hunks.length, 0);
 	if (total === 0 && p.manual.length === 0) return null;
 
+	// Ids resolve to current positions; stale checks match nothing.
+	const liveByPath = new Map(p.conflicts.map((file) => [file.path, file]));
+	const checkedLive = checked.flatMap((check) => {
+		const index = liveByPath.get(check.path)?.hunks.findIndex((hunk) => hunk.id === check.id);
+		return index === undefined || index === -1 ? [] : [{ path: check.path, hunk: index + 1 }];
+	});
+
 	const apply = (resolution: HunkResolution) => {
-		if (p.busy || checked.length === 0) return;
-		p.onResolve(checked.map(({ path, hunk }) => ({ path, hunk, resolution })));
+		if (p.busy || checkedLive.length === 0) return;
+		p.onResolve(checkedLive.map(({ path, hunk }) => ({ path, hunk, resolution })));
 	};
 
 	return (
@@ -89,12 +96,12 @@ export const ConflictBar: FC<Props> = (p) => {
 										id="resolve-conflicts-heading"
 										className={classes("text-14", "text-bold", styles.heading)}
 									>
-										{checked.length > 0
-											? `${checked.length} of ${total} conflict${total === 1 ? "" : "s"} selected`
+										{checkedLive.length > 0
+											? `${checkedLive.length} of ${total} conflict${total === 1 ? "" : "s"} selected`
 											: `Resolve ${total} conflict${total === 1 ? "" : "s"}`}
 									</h1>
 
-									{checked.length > 0 && (
+									{checkedLive.length > 0 && (
 										<div className={styles.actions}>
 											<button
 												type="button"

--- a/apps/lite/ui/src/routes/project/$id/workspace/ConflictedFiles.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/ConflictedFiles.tsx
@@ -144,10 +144,9 @@ export const ConflictedFiles: FC<Props> = (p) => {
 		<EditProvider createEditor={createEditor}>
 			{p.conflicts.map((file) => (
 				<ConflictedFileC
-					// The library reads a file's contents once per mount, and every
-					// resolution rewrites the commit — remount to pick up the fresh
-					// marker text while the dialog stays open.
-					key={`${p.commitId}:${file.path}`}
+					// Contents are read once per mount and change exactly when the hunk
+					// set does. Never key on the commit id: it updates ahead of the refetch.
+					key={`${file.path}:${file.hunks.map((hunk) => hunk.id).join()}`}
 					projectId={p.projectId}
 					commitId={p.commitId}
 					file={file}
@@ -248,7 +247,7 @@ const ConflictActions: FC<{
 	// than mirroring keystrokes into state, which would re-render the slot
 	// for nothing.
 	const editorRef = useRef<Editor<unknown> | null>(null);
-	const conflict = { commitId: p.commitId, path: p.path, hunk: p.hunk };
+	const conflict = { commitId: p.commitId, path: p.path, id: p.conflict.id };
 	// A primitive, so checking one conflict re-renders one slot rather than all.
 	const checked = useAppSelector((state) =>
 		projectSlice.selectors.selectIsConflictChecked(state, p.projectId, conflict),

--- a/crates/but-api/src/resolve/apply.rs
+++ b/crates/but-api/src/resolve/apply.rs
@@ -444,6 +444,7 @@ mod tests {
             hunks: blocks
                 .iter()
                 .map(|block| super::super::context::ConflictHunk {
+                    id: String::new(),
                     line: 0,
                     context_before: String::new(),
                     ours: lines[block.ours.clone()].join("\n"),

--- a/crates/but-api/src/resolve/context.rs
+++ b/crates/but-api/src/resolve/context.rs
@@ -38,6 +38,10 @@ fn merge_labels() -> gix::merge::blob::builtin_driver::text::Labels<'static> {
 #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct ConflictHunk {
+    /// Survives the rewrites resolving causes, unlike `hunks` positions: a
+    /// hash of the three sides — which narrowing keeps, unlike contexts —
+    /// plus an occurrence counter. Treat an id that stops matching as dropped.
+    pub id: String,
     /// The 1-based line where the conflicted region starts, counted in the
     /// intended result — the merge with every conflict taking the commit's
     /// side, the new side of [`ConflictedFile::change`] — so anchors land in
@@ -408,6 +412,7 @@ fn extract_hunks(lines: &[&str], blocks: &[ConflictBlock]) -> Vec<ConflictHunk> 
     // merged-text line minus everything earlier blocks contribute beyond
     // their theirs lines.
     let mut removed_before = 0;
+    let mut occurrences: std::collections::HashMap<u64, usize> = std::collections::HashMap::new();
     let mut hunks = Vec::with_capacity(blocks.len());
     for (index, block) in blocks.iter().enumerate() {
         let previous_end = if index == 0 {
@@ -422,12 +427,28 @@ fn extract_hunks(lines: &[&str], blocks: &[ConflictBlock]) -> Vec<ConflictHunk> 
         let context_before_start = block.start.saturating_sub(CONTEXT_LINES).max(previous_end);
         let context_after_end = (block.end + 1 + CONTEXT_LINES).min(next_start);
 
+        let ours = join(block.ours.clone());
+        let base = block.base.clone().map(join);
+        let theirs = join(block.theirs.clone());
+        let sides_hash = {
+            use std::hash::{Hash as _, Hasher as _};
+            let mut hasher = std::collections::hash_map::DefaultHasher::new();
+            ours.hash(&mut hasher);
+            base.hash(&mut hasher);
+            theirs.hash(&mut hasher);
+            hasher.finish()
+        };
+        let occurrence = occurrences.entry(sides_hash).or_insert(0);
+        let id = format!("{sides_hash:016x}-{occurrence}");
+        *occurrence += 1;
+
         hunks.push(ConflictHunk {
+            id,
             line: (block.start - removed_before + 1) as u32,
             context_before: join(context_before_start..block.start),
-            ours: join(block.ours.clone()),
-            base: block.base.clone().map(join),
-            theirs: join(block.theirs.clone()),
+            ours,
+            base,
+            theirs,
             context_after: join((block.end + 1)..context_after_end),
         });
         removed_before += (block.end - block.start + 1) - block.theirs.len();

--- a/crates/but-api/tests/api/resolve_hunks.rs
+++ b/crates/but-api/tests/api/resolve_hunks.rs
@@ -63,6 +63,11 @@ fn conflicts_are_listed_without_entering_edit_mode() -> Result<()> {
     assert!(intended.contains("changed by this commit"));
     assert!(!intended.contains("<<<<<<<"), "never marker text");
 
+    assert_ne!(
+        file.hunks[0].id, file.hunks[1].id,
+        "distinct conflicts never share an id"
+    );
+
     // The marker text carries display labels; parsing its blocks in order is
     // what a marker-aware renderer does, so it must line up with `hunks`.
     assert_eq!(file.merged_text.matches("<<<<<<< auto resolved").count(), 2);
@@ -145,10 +150,17 @@ fn partial_resolution_narrows_the_conflict_then_completes() -> Result<()> {
     }
 
     // The narrowed commit reports exactly the one remaining conflict.
+    let survivor_id = commit_conflicts(&ctx, conflicted_commit)?.files[0].hunks[1]
+        .id
+        .clone();
     let conflicts = commit_conflicts(&ctx, first.new_commit)?;
     assert_eq!(conflicts.files.len(), 1);
     let file = &conflicts.files[0];
     assert_eq!(file.hunks.len(), 1, "one conflict must remain");
+    assert_eq!(
+        file.hunks[0].id, survivor_id,
+        "a surviving conflict keeps its id while its position compacts"
+    );
     assert_eq!(file.hunks[0].ours, "line six changed by the new base");
     assert_eq!(file.hunks[0].theirs, "line six changed by this commit");
     assert_eq!(

--- a/packages/but-sdk/src/generated/graph/index.d.ts
+++ b/packages/but-sdk/src/generated/graph/index.d.ts
@@ -1929,6 +1929,12 @@ export type ConflictEntryPresence = {
  */
 export type ConflictHunk = {
   /**
+   * Survives the rewrites resolving causes, unlike `hunks` positions: a
+   * hash of the three sides — which narrowing keeps, unlike contexts —
+   * plus an occurrence counter. Treat an id that stops matching as dropped.
+   */
+  id: string;
+  /**
    * The 1-based line where the conflicted region starts, counted in the
    * intended result — the merge with every conflict taking the commit's
    * side, the new side of [`ConflictedFile::change`] — so anchors land in

--- a/packages/but-sdk/src/generated/linear/index.d.ts
+++ b/packages/but-sdk/src/generated/linear/index.d.ts
@@ -1929,6 +1929,12 @@ export type ConflictEntryPresence = {
  */
 export type ConflictHunk = {
   /**
+   * Survives the rewrites resolving causes, unlike `hunks` positions: a
+   * hash of the three sides — which narrowing keeps, unlike contexts —
+   * plus an occurrence counter. Treat an id that stops matching as dropped.
+   */
+  id: string;
+  /**
    * The 1-based line where the conflicted region starts, counted in the
    * intended result — the merge with every conflict taking the commit's
    * side, the new side of [`ConflictedFile::change`] — so anchors land in


### PR DESCRIPTION
Follow-up to #15300: fixes the resolution dialog resolving the **wrong conflict**, and gives conflicts a stable identity so batch checks survive.

## 🐛 The bug

Clicking *Accept current change* on the first conflict could resolve the second — with both regions still on screen and only one of them carrying action buttons. All three symptoms were one torn render:

| Symptom | Cause |
| --- | --- |
| Both conflicts stayed visible | The marker view renders the text it mounted with; the remount key (`commitId:path`) didn't change when a refetch landed after the id had already updated |
| Only one row of buttons | Actions look their hunk up in the *live* data, which had compacted to one — the second slot found nothing |
| Clicking "first" resolved "second" | The surviving row was bound to the compacted numbering while visually sitting above the old first region |

**Fix**: marker views are keyed on their marker text, so the regions shown and the hunks addressed always come from the same payload — the torn state is unrepresentable.

## 🔑 Stable conflict identity

Hunks were addressed only by position in the current commit's conflict list, and every resolution rewrites the commit and compacts positions — which is why batch checkboxes had to be wiped after each apply.

Each hunk now carries an `id` hashed from its three sides (auto resolved / original base / as authored) plus an occurrence counter for identical conflicts. Narrowing never rewrites a surviving conflict's sides — only its contexts, which are excluded — so the id holds across the whole resolution session:

- checkboxes are keyed on the id and **survive sibling resolutions** (commit id remapped alongside the other rewrite references),
- stale checks simply stop matching any live conflict,
- batch actions translate ids to whatever position they hold at apply time.

## ✅ Feedback

Partial resolutions now toast like the final one: *Conflict resolved — N remaining in this commit.*

Verified end-to-end: check the second conflict → individually resolve the first → the check survives the rewrite ("1 of 1 conflict selected") → batch-accept resolves exactly the checked one. Backend id tests cover distinctness and survival across a narrowing rewrite.