### PR TITLE
Fix forward-realigned hunk selection

### DIFF
--- a/apps/lite/ui/src/hunk.test.ts
+++ b/apps/lite/ui/src/hunk.test.ts
@@ -1,6 +1,7 @@
 import {
 	contiguousSelectionByLine,
 	contiguousSelectionsFromHunk,
+	rangeFromLineGroups,
 	wholeHunkSelectionByLine,
 } from "#ui/hunk.ts";
 import { processFile } from "@pierre/diffs";
@@ -62,6 +63,25 @@ const realignedHunk = (() => {
 	return hunk;
 })();
 
+const FORWARD_REALIGNED_PATCH = [
+	"diff --git a/file.ts b/file.ts",
+	"--- a/file.ts",
+	"+++ b/file.ts",
+	"@@ -20,1 +28,2 @@",
+	"-assert_eq!(graph.nodes.len(), 3);",
+	"+let extra = true;",
+	"+assert_eq!(graph.nodes.len(), 4);",
+	"",
+].join("\n");
+
+const forwardRealignedHunk = (() => {
+	const parsed = processFile(FORWARD_REALIGNED_PATCH, { cacheKey: "hunk.test.forward-realigned" });
+	if (!parsed) throw new Error("Failed to parse forward-realigned patch");
+	const hunk = parsed.hunks[0];
+	if (!hunk) throw new Error("Forward-realigned patch has no hunk");
+	return hunk;
+})();
+
 describe("contiguousSelectionsFromHunk", () => {
 	it("keeps adjacent similarity-aligned change fragments contiguous", () => {
 		expect(realignedHunk.hunkContent.filter(({ type }) => type === "change")).toHaveLength(2);
@@ -74,6 +94,25 @@ describe("contiguousSelectionsFromHunk", () => {
 				],
 			},
 		]);
+	});
+
+	it("keeps the controlled range around a forward-realigned addition", () => {
+		expect(forwardRealignedHunk.hunkContent.filter(({ type }) => type === "change")).toEqual([
+			expect.objectContaining({ deletions: 0, additions: 1 }),
+			expect.objectContaining({ deletions: 1, additions: 1 }),
+		]);
+
+		const selection = contiguousSelectionsFromHunk(forwardRealignedHunk).next().value;
+		expect(selection?.lineGroups).toEqual([
+			{ side: "additions", start: 28, lines: 1 },
+			{ side: "deletions", start: 20, lines: 1 },
+			{ side: "additions", start: 29, lines: 1 },
+		]);
+		expect(selection && rangeFromLineGroups(selection.lineGroups)).toEqual({
+			start: 28,
+			side: "additions",
+			end: 29,
+		});
 	});
 });
 

--- a/apps/lite/ui/src/hunk.ts
+++ b/apps/lite/ui/src/hunk.ts
@@ -117,20 +117,17 @@ const contiguousSelectionFromContents = (
 	hunk: Hunk,
 	contents: Array<ChangeContent>,
 ): HunkLineSelection | null => {
-	let deletions: HunkLineSelectionGroup | undefined;
-	let additions: HunkLineSelectionGroup | undefined;
+	const lineGroups: Array<HunkLineSelectionGroup> = [];
 
 	for (const content of contents) {
 		for (const group of lineGroupsFromChangeContent(hunk, content)) {
-			const existing = group.side === "deletions" ? deletions : additions;
-
-			if (existing) existing.lines += group.lines;
-			else if (group.side === "deletions") deletions = group;
-			else additions = group;
+			const previous = lineGroups.at(-1);
+			if (previous?.side === group.side && previous.start + previous.lines === group.start)
+				previous.lines += group.lines;
+			else lineGroups.push(group);
 		}
 	}
 
-	const lineGroups = [deletions, additions].filter((group) => group !== undefined);
 	if (lineGroups.length === 0) return null;
 
 	return {


### PR DESCRIPTION
## What changed

- preserve Pierre change-fragment order when building one contiguous hunk selection
- merge only consecutive same-side line groups
- add a regression fixture for an addition visually realigned ahead of a deletion

## Why

Pierre 1.3.x can similarity-realign a replacement into an addition-only fragment followed by a mixed deletion/addition fragment. We correctly grouped those fragments into one operand, but reordered its line groups deletion-first. That made the controlled selection start on the middle row and left the visually preceding addition unselected.

## Validation

- Lite unit suite: 128 tests passed
- Lite typecheck
- diff whitespace check