### PR TITLE
Shrink Lite release packages

### DIFF
--- a/.github/workflows/lite.yml
+++ b/.github/workflows/lite.yml
@@ -77,6 +77,11 @@ jobs:
         name: Upload artifacts
         with:
           name: gitbutler-lite-${{ github.run_number }}-${{ matrix.platform }}
-          path: apps/lite/release/
+          # electron-builder publishes updater files itself and also leaves the
+          # unpacked app in this directory. Keep only user-installable packages.
+          path: |
+            apps/lite/release/*.AppImage
+            apps/lite/release/*.dmg
+            apps/lite/release/*.exe
           if-no-files-found: error
           retention-days: 7

--- a/apps/lite/electron/vite.config.ts
+++ b/apps/lite/electron/vite.config.ts
@@ -11,16 +11,15 @@ const here = path.dirname(fileURLToPath(import.meta.url));
  * that resolves `electron` and a few polyfilled builtins — never relative
  * files. Bundling is what lets the preload import the endpoint lists from
  * ipc.ts instead of repeating every channel as a literal. Only the preload
- * needs this; the main process is a normal Node module graph that tsgo emits.
+ * needs this; the main process has its own ESM bundle (vite.main.config.ts).
  */
 export default defineConfig({
 	// Vite's transform covers .ts/.mts but not .cts, which the preload must
-	// be so tsgo emits it as CommonJS for Electron.
+	// be so Vite emits it as CommonJS for Electron.
 	esbuild: { include: /\.[cm]?[jt]sx?$/ },
 	build: {
 		outDir: path.join(here, "../dist/electron"),
-		// tsgo emits the rest of the main-process graph here first.
-		emptyOutDir: false,
+		emptyOutDir: true,
 		target: "es2022",
 		minify: false,
 		sourcemap: true,

--- a/apps/lite/electron/vite.main.config.ts
+++ b/apps/lite/electron/vite.main.config.ts
@@ -1,0 +1,28 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vite";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Bundles the main process into one ESM file, inlining all deps since
+ * node_modules is not shipped — except electron and @gitbutler/but-sdk,
+ * whose napi loader and native modules ship as real files in the package
+ * (see "files" in package.json).
+ */
+export default defineConfig({
+	build: {
+		outDir: path.join(here, "../dist/electron"),
+		// The preload build (vite.config.ts) runs first and empties the dir.
+		emptyOutDir: false,
+		target: "es2022",
+		minify: false,
+		sourcemap: true,
+		ssr: path.join(here, "src/main.ts"),
+		rollupOptions: {
+			external: ["electron", /^@gitbutler\/but-sdk/],
+			output: { entryFileNames: "main.js" },
+		},
+	},
+	ssr: { noExternal: true },
+});

--- a/apps/lite/package.json
+++ b/apps/lite/package.json
@@ -21,7 +21,7 @@
 		"dev:electron": "pnpm prepare-askpass && pnpm build:electron && wait-on tcp:5173 && cross-env VITE_DEV_SERVER_URL=http://127.0.0.1:5173 electron dist/electron/main.js --inspect=9229 --remote-debugging-port=9222",
 		"build": "pnpm build:ui && pnpm build:electron",
 		"build:ui": "vite build --config ui/vite.config.ts",
-		"build:electron": "tsgo -p electron/tsconfig.json && vite build --config electron/vite.config.ts",
+		"build:electron": "vite build --config electron/vite.config.ts && vite build --config electron/vite.main.config.ts",
 		"check": "tsgo -p ui/tsconfig.json --noEmit && tsgo -p electron/tsconfig.json --noEmit && tsgo -p e2e/tsconfig.json --noEmit",
 		"test": "vitest run --config ui/vite.config.ts",
 		"test:e2e": "pnpm prepare-askpass --debug && pnpm build:electron && playwright test --config ./e2e/playwright.config.ts",
@@ -34,6 +34,9 @@
 	},
 	"build": {
 		"appId": "com.gitbutler.lite",
+		"electronLanguages": [
+			"en-US"
+		],
 		"electronFuses": {
 			"runAsNode": false,
 			"enableCookieEncryption": true,
@@ -69,7 +72,12 @@
 		"files": [
 			"dist/ui/**/*",
 			"dist/electron/**/*",
-			"package.json"
+			"package.json",
+			"!node_modules/**/*",
+			"node_modules/@gitbutler/but-sdk/package.json",
+			"node_modules/@gitbutler/but-sdk/src/generated/linear/index.js",
+			"node_modules/@gitbutler/but-sdk/src/generated/linear/apiParamNames.js",
+			"node_modules/@gitbutler/but-sdk/src/generated/linear/*.node"
 		],
 		"mac": {
 			"icon": "resources/icons/macos/icon.icon",


### PR DESCRIPTION
Bundle the Electron main process and package only the runtime SDK files. Keep one installer per GitHub Actions artifact and trim Electron locales to English.

Size goes from 700MB to 144MB