### PR TITLE
Add npmrc to support default linker

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 engine-strict=true
 auto-install-peers=true
+node-linker=isolated


### PR DESCRIPTION
Other pnpm linker options can disrupt electron builds