### PR TITLE
Detect squash-merged branches during upstream integration

### DIFF
--- a/crates/but-core/src/changeset.rs
+++ b/crates/but-core/src/changeset.rs
@@ -94,6 +94,52 @@ impl<T: ChangesetCommit + ?Sized> ChangesetCommit for &T {
 pub struct SimilarityByCommitIds {
     /// Upstream commit IDs keyed by the workspace commit ID that matched them.
     pub matches_by_workspace_commit: HashMap<gix::ObjectId, gix::ObjectId>,
+    /// The upstream similarity table, kept so callers can run squash-merge trials.
+    upstream_lut: Identity,
+}
+
+impl SimilarityByCommitIds {
+    /// [`squash_merge_match()`] against the retained upstream table.
+    pub fn squash_merge_match(
+        &self,
+        repo: &gix::Repository,
+        base: Option<gix::ObjectId>,
+        tip: gix::ObjectId,
+    ) -> anyhow::Result<Option<gix::ObjectId>> {
+        squash_merge_match(repo, &self.upstream_lut, base, tip)
+    }
+}
+
+/// Return the commit in `lut` whose changeset matches the cumulative changes from `base` to
+/// `tip` (both commit-ish or tree-ish), i.e. the commit that would exist had the whole range
+/// been squash-merged. Only finds matches if `lut` was built with `expensive` checks.
+pub fn squash_merge_match(
+    repo: &gix::Repository,
+    lut: &Identity,
+    base: Option<gix::ObjectId>,
+    tip: gix::ObjectId,
+) -> anyhow::Result<Option<gix::ObjectId>> {
+    let Some(changeset_id) = id_for_tree_diff(repo, base, tip)? else {
+        return Ok(None);
+    };
+    Ok(lut.get(&Identifier::ChangesetId(changeset_id)).copied())
+}
+
+/// Whether a commit whose tree is `tree_id` introduces changes of its own, i.e. that tree
+/// differs from its first parent's tree, or from the empty tree if there is no parent.
+/// On a lookup failure we assume the commit carries changes, so a genuinely merged branch is
+/// never spared from squash-merge detection.
+pub fn tree_introduces_changes(
+    repo: &gix::Repository,
+    tree_id: gix::ObjectId,
+    first_parent_id: Option<gix::ObjectId>,
+) -> bool {
+    match first_parent_id {
+        None => !tree_id.is_empty_tree(),
+        Some(parent_id) => id_to_tree(repo, parent_id)
+            .map(|parent_tree| parent_tree.id != tree_id)
+            .unwrap_or(true),
+    }
 }
 
 /// Compute upstream similarity for the provided workspace commits.
@@ -137,6 +183,7 @@ pub fn compute_similarity_by_commit_ids(
 
     Ok(SimilarityByCommitIds {
         matches_by_workspace_commit,
+        upstream_lut,
     })
 }
 

--- a/crates/but-core/src/changeset.rs
+++ b/crates/but-core/src/changeset.rs
@@ -116,16 +116,20 @@ pub struct SquashCandidate {
 /// boundary: the topmost segment may carry unmerged work stacked on a squash-merged segment
 /// below it.
 ///
-/// Commits are compared by their auto-resolution tree when conflicted, and only candidates
-/// that are actually examined get decoded. `lut` must contain only commits the target gained
-/// since `base`: a cumulative-changeset match against older target history would be a
-/// coincidence, and acting on it could delete a live branch. Only finds matches if `lut` was
-/// built with `expensive` checks.
+/// Commits are compared by their auto-resolution tree when conflicted; candidates are
+/// decoded while scanning for boundaries and, once a match is found, below it. `lut` must
+/// contain only commits the target gained since `base`: a cumulative-changeset match against
+/// older target history would be a coincidence, and acting on it could delete a live branch.
+/// Only finds matches if `lut` was built with `expensive` checks.
 ///
-/// Returns the index of the matched boundary candidate and the matching commit; the caller
-/// marks the boundary and everything beneath it integrated. Candidates above the boundary
-/// must stay untouched: a no-change tip commit borrows the cumulative content beneath it and
-/// must not have its branch deleted by a match.
+/// Returns the matching commit and the index to claim from; the caller marks that candidate
+/// and everything beneath it integrated, leaving candidates above it untouched. When several
+/// candidates share the matched boundary's tree, the content between them cancels out and
+/// the match cannot tell whether it ever landed, so the lowest such index is returned —
+/// possibly a commit below the trialed boundary. This never deletes unlanded work, at the
+/// cost of keeping net-zero commits local even when a squash genuinely covered them. A
+/// no-change tip commit likewise borrows the cumulative content beneath it and is never
+/// claimed.
 pub fn squash_merge_boundary(
     repo: &gix::Repository,
     lut: &Identity,
@@ -147,7 +151,26 @@ pub fn squash_merge_boundary(
             continue;
         };
         if let Some(commit_id) = lut.get(&Identifier::ChangesetId(changeset_id)) {
-            return Ok(Some((idx, *commit_id)));
+            // A lower candidate with the same tree yields the same changeset: everything in
+            // between cancels out, and the match cannot tell whether that content ever
+            // landed (e.g. an upper segment reverting a middle one, squashed bottom only).
+            // Claim from the lowest such candidate so canceled-out commits are never
+            // deleted by a coincidental match.
+            let mut boundary = idx;
+            for (lower_idx, lower) in candidates.iter().enumerate().skip(idx + 1) {
+                // An unreadable candidate leaves the ambiguity unresolved: abandon the
+                // match rather than risk claiming content that never landed.
+                let Ok(lower_commit) = Commit::from_id(lower.id.attach(repo)) else {
+                    return Ok(None);
+                };
+                let Ok(lower_tree) = lower_commit.tree_id_or_auto_resolution() else {
+                    return Ok(None);
+                };
+                if lower_tree.detach() == tree_id {
+                    boundary = lower_idx;
+                }
+            }
+            return Ok(Some((boundary, *commit_id)));
         }
     }
     Ok(None)

--- a/crates/but-core/src/changeset.rs
+++ b/crates/but-core/src/changeset.rs
@@ -94,42 +94,70 @@ impl<T: ChangesetCommit + ?Sized> ChangesetCommit for &T {
 pub struct SimilarityByCommitIds {
     /// Upstream commit IDs keyed by the workspace commit ID that matched them.
     pub matches_by_workspace_commit: HashMap<gix::ObjectId, gix::ObjectId>,
-    /// The upstream similarity table, kept so callers can run squash-merge trials.
-    upstream_lut: Identity,
+    /// The upstream similarity table, for squash-merge trials via [`squash_merge_boundary()`].
+    pub upstream_lut: Identity,
 }
 
-impl SimilarityByCommitIds {
-    /// [`squash_merge_match()`] against the retained upstream table.
-    pub fn squash_merge_match(
-        &self,
-        repo: &gix::Repository,
-        base: Option<gix::ObjectId>,
-        tip: gix::ObjectId,
-    ) -> anyhow::Result<Option<gix::ObjectId>> {
-        squash_merge_match(repo, &self.upstream_lut, base, tip)
-    }
+/// One commit of a stack, ordered top to bottom, as input to [`squash_merge_boundary()`].
+pub struct SquashCandidate {
+    /// The commit to consider.
+    pub id: gix::ObjectId,
+    /// Whether the commit is already known to be integrated upstream.
+    pub integrated: bool,
+    /// The index of the branch segment the commit belongs to, increasing downward.
+    pub segment: usize,
 }
 
-/// Return the commit in `lut` whose changeset matches the cumulative changes from `base` to
-/// `tip` (both commit-ish or tree-ish), i.e. the commit that would exist had the whole range
-/// been squash-merged. Only finds matches if `lut` was built with `expensive` checks.
-pub fn squash_merge_match(
+/// Find the squash-merge boundary among `candidates`, a stack's commits from tip down to
+/// `base`: each segment's boundary is its topmost commit that isn't already integrated and
+/// introduces changes of its own, and boundaries are trialed top to bottom until the
+/// changeset from `base` to a boundary matches a commit in `lut` — the commit a squash-merge
+/// of that range would have produced. A failed trial retries at the next lower segment's
+/// boundary: the topmost segment may carry unmerged work stacked on a squash-merged segment
+/// below it.
+///
+/// Commits are compared by their auto-resolution tree when conflicted, and only candidates
+/// that are actually examined get decoded. `lut` must contain only commits the target gained
+/// since `base`: a cumulative-changeset match against older target history would be a
+/// coincidence, and acting on it could delete a live branch. Only finds matches if `lut` was
+/// built with `expensive` checks.
+///
+/// Returns the index of the matched boundary candidate and the matching commit; the caller
+/// marks the boundary and everything beneath it integrated. Candidates above the boundary
+/// must stay untouched: a no-change tip commit borrows the cumulative content beneath it and
+/// must not have its branch deleted by a match.
+pub fn squash_merge_boundary(
     repo: &gix::Repository,
     lut: &Identity,
     base: Option<gix::ObjectId>,
-    tip: gix::ObjectId,
-) -> anyhow::Result<Option<gix::ObjectId>> {
-    let Some(changeset_id) = id_for_tree_diff(repo, base, tip)? else {
-        return Ok(None);
-    };
-    Ok(lut.get(&Identifier::ChangesetId(changeset_id)).copied())
+    candidates: &[SquashCandidate],
+) -> anyhow::Result<Option<(usize, gix::ObjectId)>> {
+    let mut tried_segment = None;
+    for (idx, candidate) in candidates.iter().enumerate() {
+        if tried_segment == Some(candidate.segment) || candidate.integrated {
+            continue;
+        }
+        let commit = Commit::from_id(candidate.id.attach(repo))?;
+        let tree_id = commit.tree_id_or_auto_resolution()?.detach();
+        if !tree_introduces_changes(repo, tree_id, commit.inner.parents.first().copied()) {
+            continue;
+        }
+        tried_segment = Some(candidate.segment);
+        let Some(changeset_id) = id_for_tree_diff(repo, base, tree_id)? else {
+            continue;
+        };
+        if let Some(commit_id) = lut.get(&Identifier::ChangesetId(changeset_id)) {
+            return Ok(Some((idx, *commit_id)));
+        }
+    }
+    Ok(None)
 }
 
 /// Whether a commit whose tree is `tree_id` introduces changes of its own, i.e. that tree
 /// differs from its first parent's tree, or from the empty tree if there is no parent.
 /// On a lookup failure we assume the commit carries changes, so a genuinely merged branch is
 /// never spared from squash-merge detection.
-pub fn tree_introduces_changes(
+fn tree_introduces_changes(
     repo: &gix::Repository,
     tree_id: gix::ObjectId,
     first_parent_id: Option<gix::ObjectId>,

--- a/crates/but-workspace/src/changeset.rs
+++ b/crates/but-workspace/src/changeset.rs
@@ -8,14 +8,14 @@ use std::borrow::Cow;
 
 use bstr::BStr;
 use but_core::changeset::{
-    ChangeIdMode, ChangesetCommit, changeset_identifier, create_similarity_lut, lookup_similar,
-    squash_merge_match, tree_introduces_changes,
+    ChangeIdMode, ChangesetCommit, SquashCandidate, changeset_identifier, create_similarity_lut,
+    lookup_similar, squash_merge_boundary,
 };
 use gix::prelude::ObjectIdExt;
 
 use crate::{
     RefInfo,
-    ref_info::{Commit, LocalCommit, LocalCommitRelation},
+    ref_info::{Commit, LocalCommitRelation},
     ui::PushStatus,
 };
 
@@ -49,10 +49,8 @@ impl RefInfo {
     /// the target branch and the workspace base (B)…
     /// * …and change-ids in stack commits then…
     /// * …and author and message (exact match) in stack commits…
-    /// * …and (expensive) changeset-ids of
-    ///     - stack commits
-    ///     - the squash-merge between all stack-tips (ST) and the target branch to simulate squash merges
-    ///       as they could have happened.
+    /// * …and (expensive) changeset-ids of stack commits, plus a per-stack squash-merge trial
+    ///   ([`squash_merge_boundary()`]) to catch branches that landed as a single squash commit.
     ///
     /// Matches from the first two cheap stages will speed up the expensive stage, as fewer commits or combinations
     /// are left to test.
@@ -166,44 +164,34 @@ impl RefInfo {
                 continue 'next_stack;
             }
 
-            // Another round from top to bottom where we take remote and local tips of non-integrated commits
-            // and test-squash-merge them (cleanly), to see if that changeset ID is contained in upstream.
-            // If so, the whole branch everything that follows is bluntly considered integrated, as it probably is
-            // most of the time.
+            // Another round where we test-squash-merge the stack's segments against upstream,
+            // to catch branches whose commits landed as a single squash commit.
             let base_commit_id = stack.segments.last().and_then(|s| s.base);
-            let mut segments = stack.segments.iter_mut();
-            while let Some(segment) = segments.next() {
-                // Find the topmost commit that isn't already integrated and carries changes of its
-                // own; that is the integration boundary for the squash-merge trial. Commits above it
-                // are either already integrated or introduce no changes of their own, so the trial
-                // must not mark them: otherwise a no-change commit at the tip would be treated as
-                // merged - because it borrows the cumulative content of the commits below it - and
-                // its branch deleted.
-                let Some((boundary, boundary_tree_id)) =
-                    segment.commits.iter().enumerate().find_map(|(i, c)| {
-                        let carries_changes =
-                            !matches!(c.relation, LocalCommitRelation::Integrated(_))
-                                && commit_introduces_changes(repo, c);
-                        carries_changes.then_some((i, c.tree_id))
+            let candidates = stack
+                .segments
+                .iter()
+                .enumerate()
+                .flat_map(|(segment, s)| {
+                    s.commits.iter().map(move |c| SquashCandidate {
+                        id: c.id,
+                        integrated: matches!(c.relation, LocalCommitRelation::Integrated(_)),
+                        segment,
                     })
-                else {
-                    continue;
-                };
-                let Some(squashed_commit_id) =
-                    squash_merge_match(repo, &upstream_lut, base_commit_id, boundary_tree_id)?
-                else {
-                    continue;
-                };
-
-                // Mark the boundary commit and everything below it (down to the base, across the
-                // lower segments) as integrated; leave the commits above the boundary untouched.
-                for (i, segment) in Some(segment).into_iter().chain(segments).enumerate() {
-                    let skip = if i == 0 { boundary } else { 0 };
-                    for commit in segment.commits.iter_mut().skip(skip) {
-                        commit.relation = LocalCommitRelation::Integrated(squashed_commit_id)
-                    }
+                })
+                .collect::<Vec<_>>();
+            if let Some((boundary, squashed_commit_id)) =
+                squash_merge_boundary(repo, &upstream_lut, base_commit_id, &candidates)?
+            {
+                // Mark the boundary commit and everything below it (down to the base, across
+                // the lower segments) as integrated; commits above the boundary stay untouched.
+                for commit in stack
+                    .segments
+                    .iter_mut()
+                    .flat_map(|s| s.commits.iter_mut())
+                    .skip(boundary)
+                {
+                    commit.relation = LocalCommitRelation::Integrated(squashed_commit_id);
                 }
-                break;
             }
         }
         self.compute_pushstatus(graph);
@@ -358,10 +346,4 @@ fn is_similarity_candidate(commit: &crate::ref_info::LocalCommit) -> bool {
         // if any of these is also integrated.
         LocalCommitRelation::LocalAndRemote(_)
     )
-}
-
-/// Whether `commit` introduces changes of its own, comparing its raw tree id to its first
-/// parent's tree.
-fn commit_introduces_changes(repo: &gix::Repository, commit: &LocalCommit) -> bool {
-    tree_introduces_changes(repo, commit.tree_id, commit.parent_ids.first().copied())
 }

--- a/crates/but-workspace/src/changeset.rs
+++ b/crates/but-workspace/src/changeset.rs
@@ -8,8 +8,8 @@ use std::borrow::Cow;
 
 use bstr::BStr;
 use but_core::changeset::{
-    ChangeIdMode, ChangesetCommit, Identifier, changeset_identifier, create_similarity_lut,
-    id_for_tree_diff, id_to_tree, lookup_similar,
+    ChangeIdMode, ChangesetCommit, changeset_identifier, create_similarity_lut, lookup_similar,
+    squash_merge_match, tree_introduces_changes,
 };
 use gix::prelude::ObjectIdExt;
 
@@ -189,13 +189,8 @@ impl RefInfo {
                 else {
                     continue;
                 };
-                let Some(changeset_id) = id_for_tree_diff(repo, base_commit_id, boundary_tree_id)?
-                else {
-                    continue;
-                };
-
-                let identity_of_tip_to_base = Identifier::ChangesetId(changeset_id);
-                let Some(squashed_commit_id) = upstream_lut.get(&identity_of_tip_to_base).cloned()
+                let Some(squashed_commit_id) =
+                    squash_merge_match(repo, &upstream_lut, base_commit_id, boundary_tree_id)?
                 else {
                     continue;
                 };
@@ -365,15 +360,8 @@ fn is_similarity_candidate(commit: &crate::ref_info::LocalCommit) -> bool {
     )
 }
 
-/// Whether `commit` introduces changes of its own, i.e. its tree differs from its first
-/// parent's tree. This only compares tree ids and skips the full diff that [`id_for_tree_diff`]
-/// computes, which matters when scanning many commits. On a lookup failure we assume the commit
-/// carries changes, so a genuinely merged branch is never spared from squash-merge detection.
+/// Whether `commit` introduces changes of its own, comparing its raw tree id to its first
+/// parent's tree.
 fn commit_introduces_changes(repo: &gix::Repository, commit: &LocalCommit) -> bool {
-    match commit.parent_ids.first() {
-        None => !commit.tree_id.is_empty_tree(),
-        Some(parent) => id_to_tree(repo, *parent)
-            .map(|parent_tree| parent_tree.id != commit.tree_id)
-            .unwrap_or(true),
-    }
+    tree_introduces_changes(repo, commit.tree_id, commit.parent_ids.first().copied())
 }

--- a/crates/but-workspace/src/upstream_integration.rs
+++ b/crates/but-workspace/src/upstream_integration.rs
@@ -19,6 +19,8 @@ use crate::changeset::compute_similarity_by_commit_ids;
 use crate::graph_manipulation::traverse_nodes;
 use crate::resolve_tracking_branch_ref_name;
 
+mod squash;
+
 /// Whether a bottom most commit should be rebased, or a merge commit should be
 /// created at the top of the commit run.
 #[derive(Clone, Copy, PartialEq)]
@@ -606,10 +608,11 @@ fn collect_stacks<'ws, 'meta, M: RefMetadata>(
         .iter()
         .filter_map(|s| (!from_target_sha.contains(s)).then_some(*s))
         .collect::<Vec<_>>();
-    let upstream_selectors = if upstream_selectors.is_empty() {
-        from_target_ref.iter().copied().collect()
-    } else {
+    let target_advanced = !upstream_selectors.is_empty();
+    let upstream_selectors = if target_advanced {
         upstream_selectors
+    } else {
+        from_target_ref.iter().copied().collect()
     };
     let upstream_commits = commit_ids(editor, upstream_selectors)?;
     let mut workspace_selectors = HashSet::new();
@@ -654,6 +657,14 @@ fn collect_stacks<'ws, 'meta, M: RefMetadata>(
             {
                 attrs.content_integrated = true;
             }
+        }
+
+        // A squash-merge implies the target advanced past the old base. Without new target
+        // commits the similarity table above fell back to historical target commits, where a
+        // cumulative-changeset match would be a coincidence (e.g. a branch redoing a
+        // once-reverted change) that must not delete a live branch.
+        if target_advanced {
+            squash::squash_merge_trial(editor, stack, &integration)?;
         }
 
         apply_review_integration_hints(editor, stack, review_hints)?;

--- a/crates/but-workspace/src/upstream_integration.rs
+++ b/crates/but-workspace/src/upstream_integration.rs
@@ -664,6 +664,8 @@ fn collect_stacks<'ws, 'meta, M: RefMetadata>(
         // cumulative-changeset match would be a coincidence (e.g. a branch redoing a
         // once-reverted change) that must not delete a live branch.
         if target_advanced {
+            // Runs before review hints on purpose: `integrated` then means historically or
+            // content integrated, matching what the status-side trial sees.
             squash::squash_merge_trial(editor, stack, &integration)?;
         }
 

--- a/crates/but-workspace/src/upstream_integration/squash.rs
+++ b/crates/but-workspace/src/upstream_integration/squash.rs
@@ -1,0 +1,104 @@
+//! Detection of squash-merged stacks during upstream integration.
+
+use anyhow::Result;
+use but_core::RefMetadata;
+use but_core::changeset::{SimilarityByCommitIds, tree_introduces_changes};
+use but_core::commit::TreeKind;
+use but_rebase::graph_rebase::{Editor, LookupStep, Pick, Step};
+use gix::prelude::ObjectIdExt;
+
+use super::{Stack, selector_commit_id};
+
+/// Detect a squash-merged stack: the cumulative changeset of its commits matching a single
+/// upstream commit. Per-commit similarity can never find these for multi-commit stacks, which
+/// would otherwise be rebased onto content they already contain and end up as empty (and
+/// possibly conflicted) commits instead of being dropped.
+///
+/// This mirrors the squash-merge trial in `RefInfo::compute_similarity`: for each segment,
+/// top to bottom, find its topmost commit that isn't already integrated and introduces
+/// changes of its own (the boundary), compute the changeset from the stack's base to that
+/// commit, and on an upstream match mark the boundary and everything beneath it
+/// `content_integrated`. A failed trial retries at the next lower segment's boundary: the
+/// topmost segment may carry unmerged work stacked on a squash-merged segment below it.
+/// Commits above a matched boundary stay untouched: a no-change tip commit borrows the
+/// cumulative content beneath it and must not have its branch deleted by a match.
+///
+/// Only linear stacks are trialed; stacks with multiple heads or in-stack merges are left to
+/// per-commit matching.
+pub(super) fn squash_merge_trial<M: RefMetadata>(
+    editor: &Editor<'_, '_, M>,
+    stack: &mut Stack,
+    integration: &SimilarityByCommitIds,
+) -> Result<()> {
+    let repo = editor.repo();
+    let mut cursor = match stack.heads.iter().next() {
+        Some(head) if stack.heads.len() == 1 => *head,
+        _ => return Ok(()),
+    };
+    // Walk the chain top-to-bottom, collecting commits tagged with the segment they belong to
+    // (segments are delimited by `Reference` steps), and the base beneath the stack.
+    let mut picks = Vec::new();
+    let mut segment = 0usize;
+    let base = loop {
+        match editor.lookup_step(cursor)? {
+            Step::Pick(Pick { id, .. }) => picks.push((cursor, id, segment)),
+            Step::Reference { .. } => segment += 1,
+            Step::None => {}
+        }
+        let parents = editor.direct_parents(cursor)?;
+        match parents.as_slice() {
+            [] => break None,
+            [(parent, _)] if stack.nodes.contains_key(parent) => cursor = *parent,
+            [(below, _)] => match selector_commit_id(editor, *below)? {
+                Some(id) => break Some(id),
+                None => return Ok(()),
+            },
+            _ => return Ok(()),
+        }
+    };
+
+    let mut tried_segment = None;
+    for (idx, (selector, commit_id, segment)) in picks.iter().enumerate() {
+        if tried_segment == Some(*segment) {
+            continue;
+        }
+        let is_integrated = stack
+            .nodes
+            .get(selector)
+            .is_some_and(|attrs| attrs.is_integrated());
+        if is_integrated || !commit_introduces_changes(repo, *commit_id) {
+            continue;
+        }
+        tried_segment = Some(*segment);
+        if integration
+            .squash_merge_match(repo, base, *commit_id)?
+            .is_none()
+        {
+            continue;
+        }
+        // Mark the boundary and everything beneath it (across lower segments) integrated.
+        for (selector, ..) in picks.iter().skip(idx) {
+            if let Some(attrs) = stack.nodes.get_mut(selector) {
+                attrs.content_integrated = true;
+            }
+        }
+        break;
+    }
+    Ok(())
+}
+
+/// Whether `commit_id` introduces changes of its own, comparing its tree (the auto-resolution
+/// tree for conflicted commits) to its first parent's.
+fn commit_introduces_changes(repo: &gix::Repository, commit_id: gix::ObjectId) -> bool {
+    let Ok(commit) = but_core::Commit::from_id(commit_id.attach(repo)) else {
+        return true;
+    };
+    let Ok(tree_id) = commit.tree_id_or_kind(TreeKind::AutoResolution) else {
+        return true;
+    };
+    tree_introduces_changes(
+        repo,
+        tree_id.detach(),
+        commit.inner.parents.first().copied(),
+    )
+}

--- a/crates/but-workspace/src/upstream_integration/squash.rs
+++ b/crates/but-workspace/src/upstream_integration/squash.rs
@@ -2,10 +2,8 @@
 
 use anyhow::Result;
 use but_core::RefMetadata;
-use but_core::changeset::{SimilarityByCommitIds, tree_introduces_changes};
-use but_core::commit::TreeKind;
+use but_core::changeset::{SimilarityByCommitIds, SquashCandidate, squash_merge_boundary};
 use but_rebase::graph_rebase::{Editor, LookupStep, Pick, Step};
-use gix::prelude::ObjectIdExt;
 
 use super::{Stack, selector_commit_id};
 
@@ -14,14 +12,9 @@ use super::{Stack, selector_commit_id};
 /// would otherwise be rebased onto content they already contain and end up as empty (and
 /// possibly conflicted) commits instead of being dropped.
 ///
-/// This mirrors the squash-merge trial in `RefInfo::compute_similarity`: for each segment,
-/// top to bottom, find its topmost commit that isn't already integrated and introduces
-/// changes of its own (the boundary), compute the changeset from the stack's base to that
-/// commit, and on an upstream match mark the boundary and everything beneath it
-/// `content_integrated`. A failed trial retries at the next lower segment's boundary: the
-/// topmost segment may carry unmerged work stacked on a squash-merged segment below it.
-/// Commits above a matched boundary stay untouched: a no-change tip commit borrows the
-/// cumulative content beneath it and must not have its branch deleted by a match.
+/// This is the same [`squash_merge_boundary`](but_core::changeset::squash_merge_boundary)
+/// policy that `RefInfo::compute_similarity` uses, applied to the editor's step graph: on a
+/// match, the boundary and everything beneath it is marked `content_integrated`.
 ///
 /// Only linear stacks are trialed; stacks with multiple heads or in-stack merges are left to
 /// per-commit matching.
@@ -35,13 +28,24 @@ pub(super) fn squash_merge_trial<M: RefMetadata>(
         Some(head) if stack.heads.len() == 1 => *head,
         _ => return Ok(()),
     };
-    // Walk the chain top-to-bottom, collecting commits tagged with the segment they belong to
+    // Walk the chain top-to-bottom, collecting each commit's trial candidate and selector
     // (segments are delimited by `Reference` steps), and the base beneath the stack.
-    let mut picks = Vec::new();
+    let mut selectors = Vec::new();
+    let mut candidates = Vec::new();
     let mut segment = 0usize;
     let base = loop {
         match editor.lookup_step(cursor)? {
-            Step::Pick(Pick { id, .. }) => picks.push((cursor, id, segment)),
+            Step::Pick(Pick { id, .. }) => {
+                candidates.push(SquashCandidate {
+                    id,
+                    integrated: stack
+                        .nodes
+                        .get(&cursor)
+                        .is_some_and(|attrs| attrs.is_integrated()),
+                    segment,
+                });
+                selectors.push(cursor);
+            }
             Step::Reference { .. } => segment += 1,
             Step::None => {}
         }
@@ -57,48 +61,15 @@ pub(super) fn squash_merge_trial<M: RefMetadata>(
         }
     };
 
-    let mut tried_segment = None;
-    for (idx, (selector, commit_id, segment)) in picks.iter().enumerate() {
-        if tried_segment == Some(*segment) {
-            continue;
-        }
-        let is_integrated = stack
-            .nodes
-            .get(selector)
-            .is_some_and(|attrs| attrs.is_integrated());
-        if is_integrated || !commit_introduces_changes(repo, *commit_id) {
-            continue;
-        }
-        tried_segment = Some(*segment);
-        if integration
-            .squash_merge_match(repo, base, *commit_id)?
-            .is_none()
-        {
-            continue;
-        }
+    if let Some((boundary, _)) =
+        squash_merge_boundary(repo, &integration.upstream_lut, base, &candidates)?
+    {
         // Mark the boundary and everything beneath it (across lower segments) integrated.
-        for (selector, ..) in picks.iter().skip(idx) {
+        for selector in selectors.iter().skip(boundary) {
             if let Some(attrs) = stack.nodes.get_mut(selector) {
                 attrs.content_integrated = true;
             }
         }
-        break;
     }
     Ok(())
-}
-
-/// Whether `commit_id` introduces changes of its own, comparing its tree (the auto-resolution
-/// tree for conflicted commits) to its first parent's.
-fn commit_introduces_changes(repo: &gix::Repository, commit_id: gix::ObjectId) -> bool {
-    let Ok(commit) = but_core::Commit::from_id(commit_id.attach(repo)) else {
-        return true;
-    };
-    let Ok(tree_id) = commit.tree_id_or_kind(TreeKind::AutoResolution) else {
-        return true;
-    };
-    tree_introduces_changes(
-        repo,
-        tree_id.detach(),
-        commit.inner.parents.first().copied(),
-    )
 }

--- a/crates/but-workspace/tests/fixtures/scenario/squash-merged-bottom-below-canceling-segments.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/squash-merged-bottom-below-canceling-segments.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# A three-branch stack above old target M1: branch A (bottom, commits A1 and A2),
+# branch B (middle, adds Y.txt), branch C (top, deletes Y.txt again) - so the tree at
+# C's tip equals the tree at A's tip. The target ref gained a squash commit of A's
+# changes only, plus follow-up commit X. B and C never landed and must survive.
+git init
+commit-file M1.txt M1
+setup_target_to_match_main
+
+git checkout -b A
+commit-file A1.txt A1
+commit-file A2.txt A2
+git checkout -b B
+commit-file Y.txt Y
+git checkout -b C
+git rm -q Y.txt
+tick
+git commit -qm "delete Y"
+
+squashed=$(git commit-tree -p main -m "A1 + A2 (#1)" 'A^{tree}')
+git checkout --detach "$squashed"
+commit-file X.txt X
+git update-ref refs/remotes/origin/main HEAD
+
+git checkout C
+create_workspace_commit_once C

--- a/crates/but-workspace/tests/fixtures/scenario/squash-merged-branch-below-stacked-work.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/squash-merged-branch-below-stacked-work.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# Branch B with new commit B1 is stacked on branch A with commits A2 and A1, all above
+# old target M1. The target ref gained a single squash commit whose tree contains only the
+# A1+A2 changes (as a squash-merge of A alone would produce), plus follow-up commit X on
+# top. Local `main` stays at M1, the old target.
+git init
+commit-file M1.txt M1
+setup_target_to_match_main
+
+git checkout -b A
+commit-file A1.txt A1
+commit-file A2.txt A2
+git checkout -b B
+commit-file B1.txt B1
+
+squashed=$(git commit-tree -p main -m "A1 + A2 (#1)" 'A^{tree}')
+git checkout --detach "$squashed"
+commit-file X.txt X
+git update-ref refs/remotes/origin/main HEAD
+
+git checkout B
+create_workspace_commit_once B

--- a/crates/but-workspace/tests/fixtures/scenario/squash-merged-branch.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/squash-merged-branch.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# A stack has commits A2 and A1 above old target M1. The target ref gained a single
+# squash commit whose tree contains the A1+A2 changes (as a squash-merge would produce),
+# plus follow-up commit X on top. Local `main` stays at M1, the old target.
+git init
+commit-file M1.txt M1
+setup_target_to_match_main
+
+git checkout -b A
+commit-file A1.txt A1
+commit-file A2.txt A2
+
+squashed=$(git commit-tree -p main -m "A1 + A2 (#1)" 'A^{tree}')
+git checkout --detach "$squashed"
+commit-file X.txt X
+git update-ref refs/remotes/origin/main HEAD
+
+git checkout A
+create_workspace_commit_once A

--- a/crates/but-workspace/tests/workspace/upstream_integration.rs
+++ b/crates/but-workspace/tests/workspace/upstream_integration.rs
@@ -1148,6 +1148,106 @@ fn squash_merged_branch_below_stacked_work_is_pruned() -> Result<()> {
 }
 
 #[test]
+fn canceling_segments_above_squash_merged_bottom_are_not_swept_up() -> Result<()> {
+    let (_tmp, repo, mut meta, _description) =
+        named_writable_scenario_with_description("squash-merged-bottom-below-canceling-segments")?;
+    let target_sha = repo.rev_parse_single("main")?.detach();
+
+    let project_meta = target_project_meta("refs/remotes/origin/main", target_sha)?;
+    add_stack_with_segments(&mut meta, 1, "C", StackState::InWorkspace, &["B", "A"]);
+    let graph = but_graph::Graph::from_head(
+        &repo,
+        &meta,
+        project_meta.clone(),
+        Options {
+            extra_target_commit_id: Some(target_sha),
+            ..Options::limited()
+        },
+    )?;
+
+    // C's tip tree equals A's tip tree (B adds Y, C deletes it), and only A's changes
+    // were squash-merged upstream.
+    snapbox::assert_data_eq!(
+        visualize_commit_graph_all(&repo)?,
+        snapbox::str![[r#"
+* c98519c (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+* c63394f (C) delete Y
+* de9274b (B) add Y
+* 860210a (A) add A2
+* 5434680 add A1
+| * cfc7fef (origin/main) add X
+| * 80a3c61 A1 + A2 (#1)
+|/  
+* 9bede57 (main) add M1
+
+"#]]
+    );
+
+    let mut workspace = graph.into_workspace()?;
+    // One stack, three segments; nothing is detected as integrated up front.
+    snapbox::assert_data_eq!(
+        graph_workspace(&workspace).to_string(),
+        snapbox::str![[r#"
+📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣2 on 9bede57
+└── ≡📙:3:C on 9bede57 {1}
+    ├── 📙:3:C
+    │   └── ·c63394f (🏘️)
+    ├── 📙:4:B
+    │   └── ·de9274b (🏘️)
+    └── 📙:5:A
+        ├── ·860210a (🏘️)
+        └── ·5434680 (🏘️)
+
+"#]]
+    );
+
+    let project_meta = integrate_and_materialize(
+        &mut workspace,
+        &mut meta,
+        &repo,
+        vec![BottomUpdate {
+            kind: BottomUpdateKind::Rebase,
+            selector: RelativeTo::Commit(repo.rev_parse_single("A~1")?.detach()),
+        }],
+    )?;
+
+    let meta = empty_managed_workspace_metadata(&meta)?;
+    let graph =
+        but_graph::Graph::from_head(&repo, &meta, project_meta.clone(), Options::limited())?;
+    let workspace = graph.into_workspace()?;
+    // The cumulative diff at C's boundary equals the squash commit's changeset, but that
+    // must only prune A: B's and C's changes cancel out and never landed individually.
+    snapbox::assert_data_eq!(
+        graph_workspace(&workspace).to_string(),
+        snapbox::str![[r#"
+📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on cfc7fef
+└── ≡:3:C on cfc7fef {1}
+    ├── :3:C
+    │   └── ·1b83941 (🏘️)
+    └── :4:B
+        └── ·30c179e (🏘️)
+
+"#]]
+    );
+    // A's ref and commits are gone while B's and C's commits were rewritten onto the
+    // target tip, keeping the never-landed add/delete pair.
+    snapbox::assert_data_eq!(
+        visualize_commit_graph_all(&repo)?,
+        snapbox::str![[r#"
+* 845405d (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+* 1b83941 (C) delete Y
+* 30c179e (B) add Y
+* cfc7fef (origin/main) add X
+* 80a3c61 A1 + A2 (#1)
+* 9bede57 (main) add M1
+
+"#]]
+    );
+
+    Ok(())
+}
+
+#[test]
 fn fully_integrated_single_branch_with_stale_target_parent_reparents_workspace_commit() -> Result<()>
 {
     let (_tmp, repo, mut meta, _description) = named_writable_scenario_with_description(

--- a/crates/but-workspace/tests/workspace/upstream_integration.rs
+++ b/crates/but-workspace/tests/workspace/upstream_integration.rs
@@ -970,6 +970,184 @@ fn fully_integrated_single_branch_reparents_workspace_commit_to_advanced_target(
 }
 
 #[test]
+fn squash_merged_multi_commit_branch_is_pruned() -> Result<()> {
+    let (_tmp, repo, mut meta, _description) =
+        named_writable_scenario_with_description("squash-merged-branch")?;
+    let target_sha = repo.rev_parse_single("main")?.detach();
+
+    let project_meta = target_project_meta("refs/remotes/origin/main", target_sha)?;
+    add_stack(&mut meta, 1, "A", StackState::InWorkspace);
+    let graph = but_graph::Graph::from_head(
+        &repo,
+        &meta,
+        project_meta.clone(),
+        Options {
+            extra_target_commit_id: Some(target_sha),
+            ..Options::limited()
+        },
+    )?;
+
+    // Branch A holds two commits whose squashed sum is the target's new base commit.
+    snapbox::assert_data_eq!(
+        visualize_commit_graph_all(&repo)?,
+        snapbox::str![[r#"
+* 2d37747 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+* 860210a (A) add A2
+* 5434680 add A1
+| * 6204bf3 (origin/main) add X
+| * 039050a A1 + A2 (#1)
+|/  
+* 9bede57 (main) add M1
+
+"#]]
+    );
+
+    let mut workspace = graph.into_workspace()?;
+    // Neither commit is marked integrated up front - per-commit matching cannot see the squash.
+    snapbox::assert_data_eq!(
+        graph_workspace(&workspace).to_string(),
+        snapbox::str![[r#"
+📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣2 on 9bede57
+└── ≡📙:3:A on 9bede57 {1}
+    └── 📙:3:A
+        ├── ·860210a (🏘️)
+        └── ·5434680 (🏘️)
+
+"#]]
+    );
+
+    let project_meta = integrate_and_materialize(
+        &mut workspace,
+        &mut meta,
+        &repo,
+        vec![BottomUpdate {
+            kind: BottomUpdateKind::Rebase,
+            selector: RelativeTo::Commit(repo.rev_parse_single("A~1")?.detach()),
+        }],
+    )?;
+
+    let meta = empty_managed_workspace_metadata(&meta)?;
+    let graph =
+        but_graph::Graph::from_head(&repo, &meta, project_meta.clone(), Options::limited())?;
+    let workspace = graph.into_workspace()?;
+    // Neither commit matches the squash commit one-to-one, but their cumulative changeset
+    // does - the branch must be recognized as integrated and leave the workspace.
+    snapbox::assert_data_eq!(
+        graph_workspace(&workspace).to_string(),
+        snapbox::str![[r#"
+📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 6204bf3
+
+"#]]
+    );
+    // A's commits are dropped rather than rebased into empty copies above the target tip.
+    snapbox::assert_data_eq!(
+        visualize_commit_graph_all(&repo)?,
+        snapbox::str![[r#"
+* 6ad6d07 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+* 6204bf3 (origin/main) add X
+* 039050a A1 + A2 (#1)
+* 9bede57 (main) add M1
+
+"#]]
+    );
+
+    Ok(())
+}
+
+#[test]
+fn squash_merged_branch_below_stacked_work_is_pruned() -> Result<()> {
+    let (_tmp, repo, mut meta, _description) =
+        named_writable_scenario_with_description("squash-merged-branch-below-stacked-work")?;
+    let target_sha = repo.rev_parse_single("main")?.detach();
+
+    let project_meta = target_project_meta("refs/remotes/origin/main", target_sha)?;
+    add_stack_with_segments(&mut meta, 1, "B", StackState::InWorkspace, &["A"]);
+    let graph = but_graph::Graph::from_head(
+        &repo,
+        &meta,
+        project_meta.clone(),
+        Options {
+            extra_target_commit_id: Some(target_sha),
+            ..Options::limited()
+        },
+    )?;
+
+    // Branch B with unmerged work sits on branch A, whose commits were squash-merged.
+    snapbox::assert_data_eq!(
+        visualize_commit_graph_all(&repo)?,
+        snapbox::str![[r#"
+* ee705c0 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+* d96a0bd (B) add B1
+* 860210a (A) add A2
+* 5434680 add A1
+| * 6204bf3 (origin/main) add X
+| * 039050a A1 + A2 (#1)
+|/  
+* 9bede57 (main) add M1
+
+"#]]
+    );
+
+    let mut workspace = graph.into_workspace()?;
+    // One stack, two segments: B's commit on top of A's two squash-merged ones.
+    snapbox::assert_data_eq!(
+        graph_workspace(&workspace).to_string(),
+        snapbox::str![[r#"
+📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣2 on 9bede57
+└── ≡📙:3:B on 9bede57 {1}
+    ├── 📙:3:B
+    │   └── ·d96a0bd (🏘️)
+    └── 📙:4:A
+        ├── ·860210a (🏘️)
+        └── ·5434680 (🏘️)
+
+"#]]
+    );
+
+    let project_meta = integrate_and_materialize(
+        &mut workspace,
+        &mut meta,
+        &repo,
+        vec![BottomUpdate {
+            kind: BottomUpdateKind::Rebase,
+            selector: RelativeTo::Commit(repo.rev_parse_single("A~1")?.detach()),
+        }],
+    )?;
+
+    let meta = empty_managed_workspace_metadata(&meta)?;
+    let graph =
+        but_graph::Graph::from_head(&repo, &meta, project_meta.clone(), Options::limited())?;
+    let workspace = graph.into_workspace()?;
+    // The trial at B's boundary misses (B carries unmerged work), but the retry at A's
+    // boundary matches the squash commit: A is pruned while B is rebased onto the new
+    // target and keeps its commit.
+    snapbox::assert_data_eq!(
+        graph_workspace(&workspace).to_string(),
+        snapbox::str![[r#"
+📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 6204bf3
+└── ≡:3:B on 6204bf3 {1}
+    └── :3:B
+        └── ·3f21b99 (🏘️)
+
+"#]]
+    );
+    // A's refs and commits are gone; B1 was rewritten on top of the target tip.
+    snapbox::assert_data_eq!(
+        visualize_commit_graph_all(&repo)?,
+        snapbox::str![[r#"
+* 20c6172 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+* 3f21b99 (B) add B1
+* 6204bf3 (origin/main) add X
+* 039050a A1 + A2 (#1)
+* 9bede57 (main) add M1
+
+"#]]
+    );
+
+    Ok(())
+}
+
+#[test]
 fn fully_integrated_single_branch_with_stale_target_parent_reparents_workspace_commit() -> Result<()>
 {
     let (_tmp, repo, mut meta, _description) = named_writable_scenario_with_description(


### PR DESCRIPTION
## 🧢 Changes

- `but pull` (and desktop workspace updates) now recognize multi-commit branches whose PR was squash-merged upstream and remove them, instead of rebasing their commits onto content they already contain.
- The squash-merge trial policy lives once, in `but_core::changeset::squash_merge_boundary`, and both the status preflight and the integration engine consume it — the two surfaces can no longer drift apart on this classification.
- Ambiguity resolves conservatively: when a match cannot tell whether content actually landed (segments whose changes cancel out, unreadable commits, a target that never advanced), nothing gets deleted.

## ☕️ Reasoning

**How the bug manifests.** Squash-merge a multi-commit branch on the forge, then run `but pull`:

- `but status` correctly says the branch is `(merged upstream)`, but pull rebases its commits anyway — each becomes `(no changes)`, and typically the first one also `{conflicted}` when any follow-up upstream commit touched the same lines. The PR merged clean; the conflict exists only locally.
- The branch survives as a zombie lane forever: later pulls report "Everything is up to date" over it, and the rewritten commits can never be re-detected.
- Single-commit branches are unaffected, which made the bug look intermittent — it is fully deterministic on *multi-commit branch + squash merge*. Teams that squash every PR hit it on every pull ([Discord report](https://discord.com/channels/1060193121130000425/1206670506271707156/1534987959646949426): "recently all my multi-commit branches of squash-merged PR are conflicting when attempting `but pull` … lately it literally is every time").

**Root cause.** This is a regression from the pull-migration to the graph-based integration engine (e6d291a1, June 23). The legacy pull consumed the status engine's `Integrated` verdict, and that engine has a squash-merge trial: it compares the cumulative base-to-tip changeset of a stack against upstream commits. The new `collect_stacks` re-detects integration independently with per-commit changeset matching — and N commits can never individually match one squash commit, so the trial's absence made squash-merged branches invisible at pull time.

**What this does.** Three commits:

1. Run the squash trial at pull time: per segment, top to bottom, trial the cumulative changeset at the segment's boundary against upstream, retrying lower segments so a squash-merged branch is found underneath stacked unmerged work.
2. Extract the boundary policy into `but-core` and rewire the status side onto it, so both engines share one definition instead of two hand-synchronized copies — the drift that caused this bug in the first place.
3. Guard the ambiguous case: when several points in a stack have identical trees, the content between them cancels out and a match cannot prove it ever landed, so the lowest equivalent point is claimed. This prevents a squash of a bottom branch from deleting live upper branches that happen to net to zero.

Deliberate scope limits: only linear stacks are trialed (multi-head/shared-ancestry shapes fall back to per-commit matching); the trial is skipped when the target has not advanced (the similarity table then contains historical target commits, where a cumulative match would be coincidence and acting on it could delete a live branch); and workspaces already poisoned by earlier bad pulls are not healed here — that recovery half is #15154.

## 🎫 Affected issues

Fixes #15127
Fixes #14298

Related: #15154 (recovery of already-affected workspaces, still open), #8457 (same symptom on the old backend), #15241 (parallel effort on the same root cause).