### PR TITLE
Keep conflict markers when rewording a conflicted commit

### DIFF
--- a/crates/but-workspace/src/commit/reword.rs
+++ b/crates/but-workspace/src/commit/reword.rs
@@ -19,7 +19,10 @@ pub fn reword<'ws, 'meta, M: RefMetadata>(
 ) -> Result<(SuccessfulRebase<'ws, 'meta, M>, Selector)> {
     let (target_selector, mut commit) = editor.find_selectable_commit(commit)?;
 
-    commit.message = new_message.to_owned();
+    commit.message = but_core::commit::rewrite_conflict_markers_on_message_change(
+        commit.message.as_ref(),
+        new_message.to_owned(),
+    );
     let new_id = editor.new_commit(commit, DateMode::CommitterUpdateAuthorKeep)?;
 
     editor.replace(target_selector, Step::new_pick(new_id))?;

--- a/crates/but-workspace/tests/fixtures/scenario/with-conflict-marked-message.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/with-conflict-marked-message.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+git init
+echo "A repository with a conflicting commit marked via the message trailer (no legacy header)" >.git/description
+
+echo content >file && git add . && git commit -m "init"
+git tag normal
+
+conflict_files_id=$(git hash-object -wt blob --stdin <<EOF
+ancestorEntries = [ "a-one", "a-two" ]
+ourEntries = [ "o-one", "o-two" ]
+theirEntries = [ "t-one", "t-two" ]
+EOF
+)
+
+empty_blob=$(git hash-object -wt blob /dev/null)
+git update-index --index-info <<EOF
+100644 blob $empty_blob	.auto-resolution/file
+100644 blob $empty_blob	.conflict-base-0/file
+100644 blob $conflict_files_id	.conflict-files
+100644 blob $empty_blob	.conflict-side-0/file
+100644 blob $empty_blob	.conflict-side-1/file
+100644 blob $empty_blob	README.txt
+EOF
+
+conflict_tree=$(git write-tree)
+
+conflict_commit=$(git hash-object -wt commit --stdin <<EOF
+tree $conflict_tree
+parent $(git rev-parse HEAD)
+author GitButler <gitbutler@gitbutler.com> 1730625617 +0100
+committer Sebastian Thiel <sebastian.thiel@icloud.com> 1736343261 +0100
+gitbutler-headers-version 2
+gitbutler-change-id 0f74c342-1cd3-4408-b965-6c2dfac89857
+
+[conflict] GitButler WIP Commit
+
+GitButler-Conflict: This is a GitButler-managed conflicted commit. Files are auto-resolved
+   using the "ours" side. The commit tree contains additional directories:
+     .conflict-side-0  — our tree
+     .conflict-side-1  — their tree
+     .conflict-base-0  — the merge base tree
+     .auto-resolution  — the auto-resolved tree
+     .conflict-files   — metadata about conflicted files
+   To manually resolve, check out this commit, remove the directories
+   listed above, resolve the conflicts, and amend the commit.
+EOF
+)
+git reset --hard $conflict_commit
+git tag conflicted

--- a/crates/but-workspace/tests/workspace/commit/reword.rs
+++ b/crates/but-workspace/tests/workspace/commit/reword.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use but_rebase::graph_rebase::Editor;
-use but_testsupport::visualize_commit_graph_all;
+use but_testsupport::{cat_commit, visualize_commit_graph_all};
 use but_workspace::commit::reword;
 
 use crate::ref_info::with_workspace_commit::utils::named_writable_scenario_with_description_and_graph as writable_scenario;
@@ -77,6 +77,61 @@ fn reword_middle_commit() -> Result<()> {
     );
 
     assert_eq!(head_tree, repo.head_tree_id()?);
+
+    Ok(())
+}
+
+#[test]
+fn reword_conflicted_commit_keeps_conflict_markers() -> Result<()> {
+    let (_tmp, graph, repo, mut meta, _description) =
+        writable_scenario("with-conflict-marked-message", |_| {})?;
+    snapbox::assert_data_eq!(
+        visualize_commit_graph_all(&repo)?,
+        snapbox::str![[r#"
+* 7c77c78 (HEAD -> main, tag: conflicted) [conflict] GitButler WIP Commit
+* a047f81 (tag: normal) init
+
+"#]]
+    );
+
+    let id = repo.rev_parse_single("conflicted")?;
+    let mut ws = graph.into_workspace()?;
+    let editor = Editor::create(&mut ws, &mut meta, &repo)?;
+    reword(editor, id.detach(), b"New name".into())?
+        .0
+        .materialize(Default::default())?;
+
+    // Prefix and trailer are re-applied, so the commit still reads as conflicted.
+    snapbox::assert_data_eq!(
+        cat_commit(&repo, "main")?,
+        snapbox::str![[r#"
+tree c986d61715fc89d762de9e07087f6afc621fa4af
+parent a047f8183ba2bb7eb00ef89e60050c5fde740483
+author GitButler <gitbutler@gitbutler.com> 1730625617 +0100
+committer Committer (Memory Override) <committer@example.com> 946771200 +0000
+gitbutler-headers-version 2
+change-id 0f74c342-1cd3-4408-b965-6c2dfac89857
+
+[conflict] New name
+
+GitButler-Conflict: This is a GitButler-managed conflicted commit. Files are auto-resolved
+   using the "ours" side. The commit tree contains additional directories:
+     .conflict-side-0  — our tree
+     .conflict-side-1  — their tree
+     .conflict-base-0  — the merge base tree
+     .auto-resolution  — the auto-resolved tree
+     .conflict-files   — metadata about conflicted files
+   To manually resolve, check out this commit, remove the directories
+   listed above, resolve the conflicts, and amend the commit.
+
+"#]]
+    );
+
+    let commit = but_core::Commit::from_id(repo.rev_parse_single("main")?)?;
+    assert!(
+        commit.is_conflicted(),
+        "rewording must not drop the conflicted state"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
`but reword` on a conflicted commit swapped in the new message wholesale, dropping the `[conflict] ` prefix and the `GitButler-Conflict:` trailer. The commit stopped registering as conflicted while its tree kept the conflict layout — commit details then rendered every `.conflict-*` file as a change, enough to OOM the lite renderer.

Fix: route the new message through `rewrite_conflict_markers_on_message_change`, same as the legacy rebase engine already does. Regression test rewords a message-marked conflicted commit; that needed a new fixture, since the existing one encodes conflict state in the legacy header, which reword never touched.