### PR TITLE
Refresh worktree changes after external commits

### DIFF
--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -218,6 +218,7 @@
 					clientState.backendApi.util.invalidateTags([
 						invalidatesList(ReduxTag.Stacks),
 						invalidatesList(ReduxTag.StackDetails),
+						invalidatesList(ReduxTag.WorktreeChanges),
 						invalidatesList(ReduxTag.IntegrationSteps),
 						invalidatesList(ReduxTag.BranchListing),
 					]),


### PR DESCRIPTION
## Context

Committing through the CLI while Desktop is open can leave the worktree view showing files that are no longer uncommitted until a manual refresh.

## Change

Invalidate the worktree-changes cache when cross-process workspace activity is detected so active views re-read the current state.