### PR TITLE
Handle Shift-click on commit rows

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/CommitRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/CommitRow.tsx
@@ -343,6 +343,11 @@ export const CommitRow: FC<
 			operand={operand}
 			isChecked={isChecked}
 			isHighlighted={isHighlighted}
+			onShiftSelect={
+				isDefaultMode && canCheck
+					? () => checkCommit({ commitId: commit.id, shiftKey: true })
+					: undefined
+			}
 			onContextMenu={(event) => {
 				void showNativeContextMenu(event, menuItems);
 			}}

--- a/apps/lite/ui/src/routes/project/$id/workspace/Row.test.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Row.test.tsx
@@ -1,0 +1,79 @@
+/** @vitest-environment jsdom */
+
+import { flushSync } from "react-dom";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Row } from "./Row.tsx";
+
+describe("Row", () => {
+	let container: HTMLDivElement;
+	let root: Root;
+
+	beforeEach(() => {
+		container = document.createElement("div");
+		document.body.append(container);
+		root = createRoot(container);
+	});
+
+	afterEach(() => {
+		root.unmount();
+		container.remove();
+	});
+
+	it("uses Shift-click for a row-body action without changing descendant behavior", () => {
+		const onSelect = vi.fn();
+		const onShiftSelect = vi.fn();
+		flushSync(() =>
+			root.render(
+				<Row onSelect={onSelect} onShiftSelect={onShiftSelect}>
+					<span data-body>Body</span>
+					<a href="#target">Link</a>
+					<button type="button">Button</button>
+					<input type="checkbox" />
+				</Row>,
+			),
+		);
+
+		container
+			.querySelector("[data-body]")
+			?.dispatchEvent(new MouseEvent("click", { bubbles: true, shiftKey: true }));
+		expect(onShiftSelect).toHaveBeenCalledOnce();
+		expect(onSelect).not.toHaveBeenCalled();
+
+		container
+			.querySelector("[data-body]")
+			?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+		expect(onSelect).toHaveBeenCalledOnce();
+
+		container
+			.querySelector("a")
+			?.dispatchEvent(new MouseEvent("click", { bubbles: true, shiftKey: true }));
+		expect(onShiftSelect).toHaveBeenCalledOnce();
+		expect(onSelect).toHaveBeenCalledTimes(2);
+
+		container
+			.querySelector("button")
+			?.dispatchEvent(new MouseEvent("click", { bubbles: true, shiftKey: true }));
+		container
+			.querySelector("input")
+			?.dispatchEvent(new MouseEvent("click", { bubbles: true, shiftKey: true }));
+		expect(onShiftSelect).toHaveBeenCalledOnce();
+		expect(onSelect).toHaveBeenCalledTimes(2);
+	});
+
+	it("keeps Shift-click as selection when no Shift action is available", () => {
+		const onSelect = vi.fn();
+		flushSync(() =>
+			root.render(
+				<Row onSelect={onSelect}>
+					<span data-body>Body</span>
+				</Row>,
+			),
+		);
+
+		container
+			.querySelector("[data-body]")
+			?.dispatchEvent(new MouseEvent("click", { bubbles: true, shiftKey: true }));
+		expect(onSelect).toHaveBeenCalledOnce();
+	});
+});

--- a/apps/lite/ui/src/routes/project/$id/workspace/Row.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Row.tsx
@@ -19,10 +19,19 @@ const isFromInteractiveDescendant = (event: MouseEvent<HTMLDivElement>): boolean
 	return interactiveElement !== null && event.currentTarget.contains(interactiveElement);
 };
 
+const isFromNonRowBody = (event: MouseEvent<HTMLDivElement>): boolean => {
+	if (!(event.target instanceof Element)) return false;
+	const interactiveElement = event.target.closest(
+		"a, button, input, select, textarea, [contenteditable]",
+	);
+	return interactiveElement !== null && event.currentTarget.contains(interactiveElement);
+};
+
 export const Row: FC<
 	{
 		isSelected?: boolean;
 		onSelect?: () => void;
+		onShiftSelect?: () => void;
 		/** @default false */
 		isHighlighted?: boolean;
 		/**
@@ -37,6 +46,7 @@ export const Row: FC<
 > = ({
 	isSelected,
 	onSelect,
+	onShiftSelect,
 	isHighlighted,
 	isChecked,
 	interactive = true,
@@ -81,12 +91,10 @@ export const Row: FC<
 			onClick={(event) => {
 				props.onClick?.(event);
 
-				if (
-					!event.defaultPrevented &&
-					// Prevent clicks on interactive descendants from stealing selection.
-					!isFromInteractiveDescendant(event)
-				)
-					onSelect?.();
+				if (event.defaultPrevented || isFromInteractiveDescendant(event)) return;
+
+				if (event.shiftKey && onShiftSelect && !isFromNonRowBody(event)) onShiftSelect();
+				else onSelect?.();
 			}}
 		/>
 	);


### PR DESCRIPTION
## Context

Shift-clicking an enabled Lite commit row selected it instead of extending the checked range; only the checkbox forwarded the modifier.

Fixes GB-1830: https://linear.app/gitbutler/issue/GB-1830/shift-click-entire-row-for-multichecking

## Change

Route Shift-clicks on ordinary row content through the existing commit-checkbox range behavior. Interactive controls and normal row selection keep their existing handling.