### PR TITLE
Treat stale conflict trailers as ordinary commits

### DIFF
--- a/crates/but-api/src/diff.rs
+++ b/crates/but-api/src/diff.rs
@@ -50,11 +50,11 @@ pub mod json {
                 line_stats,
                 conflict_entries,
             } = value;
-            let mut commit: but_workspace::ui::Commit = commit.into();
-            commit.has_conflicts = conflict_entries.is_some();
-
             CommitDetails {
-                commit,
+                commit: but_workspace::ui::Commit::from_commit_owned(
+                    commit,
+                    conflict_entries.is_some(),
+                ),
                 changes: diff_with_first_parent.into_iter().map(Into::into).collect(),
                 line_stats,
                 conflict_entries,

--- a/crates/but-api/src/diff.rs
+++ b/crates/but-api/src/diff.rs
@@ -50,9 +50,11 @@ pub mod json {
                 line_stats,
                 conflict_entries,
             } = value;
+            let mut commit: but_workspace::ui::Commit = commit.into();
+            commit.has_conflicts = conflict_entries.is_some();
 
             CommitDetails {
-                commit: commit.into(),
+                commit,
                 changes: diff_with_first_parent.into_iter().map(Into::into).collect(),
                 line_stats,
                 conflict_entries,

--- a/crates/but-api/src/diff.rs
+++ b/crates/but-api/src/diff.rs
@@ -46,15 +46,13 @@ pub mod json {
         fn from(value: but_core::diff::CommitDetails) -> Self {
             let but_core::diff::CommitDetails {
                 commit,
+                has_conflicts,
                 diff_with_first_parent,
                 line_stats,
                 conflict_entries,
             } = value;
             CommitDetails {
-                commit: but_workspace::ui::Commit::from_commit_owned(
-                    commit,
-                    conflict_entries.is_some(),
-                ),
+                commit: but_workspace::ui::Commit::from_commit_owned(commit, has_conflicts),
                 changes: diff_with_first_parent.into_iter().map(Into::into).collect(),
                 line_stats,
                 conflict_entries,

--- a/crates/but-core/src/commit/conflict.rs
+++ b/crates/but-core/src/commit/conflict.rs
@@ -1,7 +1,5 @@
 use bstr::{BStr, BString, ByteSlice};
 
-use super::Headers;
-
 /// The prefix prepended to the commit subject line to mark a conflicted commit.
 const CONFLICT_MESSAGE_PREFIX: &[u8] = b"[conflict] ";
 
@@ -60,8 +58,7 @@ pub fn add_conflict_markers(message: &BStr) -> BString {
 }
 
 /// Strip conflict markers from a commit message.
-/// Returns the message unchanged when it is not conflicted (per
-/// [`message_is_conflicted`]).
+/// Returns the message unchanged when it carries no conflict trailer.
 ///
 /// Strips the `[conflict] ` subject prefix (if present) and the
 /// `GitButler-Conflict` trailer line together with all its indented
@@ -109,12 +106,6 @@ pub fn strip_conflict_markers(message: &BStr) -> BString {
             out
         },
     )
-}
-
-/// Returns `true` when the commit is conflicted either by message marker
-/// (current encoding) or by the legacy `gitbutler-conflicted` header.
-pub fn is_conflicted(message: &BStr, headers: Option<&Headers>) -> bool {
-    message_is_conflicted(message) || headers.is_some_and(Headers::is_conflicted)
 }
 
 /// Returns `true` when the commit message contains a `GitButler-Conflict:`
@@ -202,7 +193,7 @@ fn push_with_line_endings(out: &mut BString, text: &[u8], line_ending: &[u8]) {
 #[cfg(test)]
 mod tests {
     use crate::commit::{
-        Headers, add_conflict_markers, is_conflicted, message_is_conflicted,
+        Headers, add_conflict_markers, message_is_conflicted,
         rewrite_conflict_markers_on_message_change, strip_conflict_markers,
     };
     use bstr::{BStr, BString, ByteSlice};
@@ -430,18 +421,18 @@ mod tests {
 
     #[test]
     fn detects_conflicts_from_headers_too() {
-        assert!(is_conflicted(
-            BStr::new("ordinary message"),
-            Some(&Headers {
+        assert!(
+            Headers {
                 change_id: None,
                 conflicted: Some(1),
-            }),
-        ));
-        assert!(!is_conflicted(
-            BStr::new("ordinary message"),
-            Some(&Headers::default()),
-        ));
-        assert!(!is_conflicted(BStr::new("ordinary message"), None));
+            }
+            .is_conflicted(),
+            "the legacy header alone marks conflict metadata"
+        );
+        assert!(
+            !Headers::default().is_conflicted(),
+            "no conflict metadata without the legacy header"
+        );
     }
 
     /// The `GitButler-Conflict` trailer must always be the last trailer in

--- a/crates/but-core/src/commit/mod.rs
+++ b/crates/but-core/src/commit/mod.rs
@@ -567,10 +567,28 @@ impl<'repo> Commit<'repo> {
 
     /// Return `true` if this commit contains a tree that is conflicted.
     ///
-    /// Checks the commit message for conflict markers first (new style),
-    /// then falls back to the `gitbutler-conflicted` header (legacy).
+    /// Conflict metadata is only authoritative when the tree contains at least
+    /// one synthetic conflict entry. This avoids treating copied conflict
+    /// trailers on otherwise ordinary commits as conflict state while keeping
+    /// partial synthetic layouts visible as malformed conflicts.
     pub fn is_conflicted(&self) -> bool {
-        is_conflicted(self.inner.message.as_ref(), self.headers().as_ref())
+        if !is_conflicted(self.inner.message.as_ref(), self.headers().as_ref()) {
+            return false;
+        }
+
+        let Ok(tree) = self
+            .inner
+            .tree
+            .attach(self.id.repo)
+            .object()
+            .map(|object| object.into_tree())
+        else {
+            return true;
+        };
+        tree.iter().any(|entry| {
+            entry.is_err()
+                || entry.is_ok_and(|entry| is_synthetic_conflict_entry(entry.filename().as_bytes()))
+        })
     }
 
     /// If the commit is conflicted, then it returns the auto-resolution tree,
@@ -666,6 +684,18 @@ impl<'repo> Commit<'repo> {
             .change_id
             .expect("change-id is ensured")
     }
+}
+
+fn is_synthetic_conflict_entry(name: &[u8]) -> bool {
+    [TreeKind::AutoResolution, TreeKind::ConflictFiles]
+        .into_iter()
+        .any(|kind| name == kind.as_tree_entry_name().as_bytes())
+        || [b".conflict-side-".as_slice(), b".conflict-base-"]
+            .into_iter()
+            .any(|prefix| {
+                name.strip_prefix(prefix)
+                    .is_some_and(|index| !index.is_empty() && index.iter().all(u8::is_ascii_digit))
+            })
 }
 
 /// Conflict specific details

--- a/crates/but-core/src/commit/mod.rs
+++ b/crates/but-core/src/commit/mod.rs
@@ -455,6 +455,11 @@ pub enum TreeKind {
     ConflictFiles,
 }
 
+/// Name prefixes of the numbered side/base entries in a synthetic conflict tree.
+/// Keep in sync with [`TreeKind::as_tree_entry_name()`].
+const CONFLICT_SIDE_PREFIX: &str = ".conflict-side-";
+const CONFLICT_BASE_PREFIX: &str = ".conflict-base-";
+
 impl TreeKind {
     /// Return then name of the entry this tree would take in the 'meta' tree that captures cherry-pick conflicts.
     pub fn as_tree_entry_name(&self) -> &'static str {
@@ -571,6 +576,9 @@ impl<'repo> Commit<'repo> {
     /// one synthetic conflict entry. This avoids treating copied conflict
     /// trailers on otherwise ordinary commits as conflict state while keeping
     /// partial synthetic layouts visible as malformed conflicts.
+    ///
+    /// When the tree cannot be read at all, the metadata is trusted as-is and
+    /// the commit reports as conflicted.
     pub fn is_conflicted(&self) -> bool {
         let has_conflict_metadata = message_is_conflicted(self.inner.message.as_ref())
             || self
@@ -580,18 +588,15 @@ impl<'repo> Commit<'repo> {
             return false;
         }
 
-        let Ok(tree) = self
-            .inner
-            .tree
-            .attach(self.id.repo)
-            .object()
-            .map(|object| object.into_tree())
-        else {
+        let Ok(tree) = self.id.repo.find_tree(self.inner.tree) else {
             return true;
         };
         tree.iter().any(|entry| {
-            entry.is_err()
-                || entry.is_ok_and(|entry| is_synthetic_conflict_entry(entry.filename().as_bytes()))
+            entry.map_or(true, |entry| {
+                let name = entry.filename();
+                name == TreeKind::AutoResolution.as_tree_entry_name().as_bytes()
+                    || name.starts_with(b".conflict-")
+            })
         })
     }
 
@@ -653,7 +658,7 @@ impl<'repo> Commit<'repo> {
         let tree = self.inner.tree.attach(self.id.repo).object()?.into_tree();
         let mut ids = Vec::new();
         let mut i = 0;
-        while let Some(entry) = tree.find_entry(format!(".conflict-base-{i}")) {
+        while let Some(entry) = tree.find_entry(format!("{CONFLICT_BASE_PREFIX}{i}")) {
             ids.push(entry.id().detach());
             i += 1;
         }
@@ -668,7 +673,7 @@ impl<'repo> Commit<'repo> {
         let tree = self.inner.tree.attach(self.id.repo).object()?.into_tree();
         let mut ids = SmallVec::new();
         let mut i = 0;
-        while let Some(entry) = tree.find_entry(format!(".conflict-side-{i}")) {
+        while let Some(entry) = tree.find_entry(format!("{CONFLICT_SIDE_PREFIX}{i}")) {
             ids.push(entry.id().detach());
             i += 1;
         }
@@ -688,18 +693,6 @@ impl<'repo> Commit<'repo> {
             .change_id
             .expect("change-id is ensured")
     }
-}
-
-fn is_synthetic_conflict_entry(name: &[u8]) -> bool {
-    [TreeKind::AutoResolution, TreeKind::ConflictFiles]
-        .into_iter()
-        .any(|kind| name == kind.as_tree_entry_name().as_bytes())
-        || [b".conflict-side-".as_slice(), b".conflict-base-"]
-            .into_iter()
-            .any(|prefix| {
-                name.strip_prefix(prefix)
-                    .is_some_and(|index| !index.is_empty() && index.iter().all(u8::is_ascii_digit))
-            })
 }
 
 /// Conflict specific details
@@ -879,10 +872,18 @@ pub fn write_conflicted_tree(
 
     let mut tree = repo.find_tree(resolved_tree_id)?.edit()?;
     for (i, tree_id) in tree_expression.base_tree_ids.iter().enumerate() {
-        tree.upsert(format!(".conflict-base-{i}"), EntryKind::Tree, *tree_id)?;
+        tree.upsert(
+            format!("{CONFLICT_BASE_PREFIX}{i}"),
+            EntryKind::Tree,
+            *tree_id,
+        )?;
     }
     for (i, tree_id) in tree_expression.side_tree_ids.iter().enumerate() {
-        tree.upsert(format!(".conflict-side-{i}"), EntryKind::Tree, *tree_id)?;
+        tree.upsert(
+            format!("{CONFLICT_SIDE_PREFIX}{i}"),
+            EntryKind::Tree,
+            *tree_id,
+        )?;
     }
     tree.upsert(
         TreeKind::AutoResolution.as_tree_entry_name(),

--- a/crates/but-core/src/commit/mod.rs
+++ b/crates/but-core/src/commit/mod.rs
@@ -572,7 +572,11 @@ impl<'repo> Commit<'repo> {
     /// trailers on otherwise ordinary commits as conflict state while keeping
     /// partial synthetic layouts visible as malformed conflicts.
     pub fn is_conflicted(&self) -> bool {
-        if !is_conflicted(self.inner.message.as_ref(), self.headers().as_ref()) {
+        let has_conflict_metadata = message_is_conflicted(self.inner.message.as_ref())
+            || self
+                .headers()
+                .is_some_and(|headers| headers.is_conflicted());
+        if !has_conflict_metadata {
             return false;
         }
 
@@ -844,9 +848,9 @@ pub fn conflict_entries_from_merge_outcome(
 }
 
 mod conflict;
+use conflict::message_is_conflicted;
 pub use conflict::{
-    add_conflict_markers, is_conflicted, message_is_conflicted,
-    rewrite_conflict_markers_on_message_change, strip_conflict_markers,
+    add_conflict_markers, rewrite_conflict_markers_on_message_change, strip_conflict_markers,
 };
 pub mod tree_expression;
 

--- a/crates/but-core/src/diff/commit_details.rs
+++ b/crates/but-core/src/diff/commit_details.rs
@@ -3,6 +3,9 @@
 pub struct CommitDetails {
     /// The fully decoded commit.
     pub commit: crate::CommitOwned,
+    /// Whether [`commit`](Self::commit) is conflicted, per [`crate::Commit::is_conflicted()`],
+    /// captured here as the detached commit cannot determine it anymore.
+    pub has_conflicts: bool,
     /// The changes between the tree of the first parent and this commit.
     pub diff_with_first_parent: Vec<crate::TreeChange>,
     /// The stats of the changes, which are computed only when explicitly requested.
@@ -41,9 +44,11 @@ impl CommitDetails {
             .transpose()?;
 
         let commit = crate::Commit::try_from(commit)?;
+        let has_conflicts = commit.is_conflicted();
         let conflict_entries = commit.conflict_entries()?;
         Ok(CommitDetails {
             commit: commit.detach(),
+            has_conflicts,
             diff_with_first_parent: changes.into_tree_changes(),
             line_stats: line_stats.map(Into::into),
             conflict_entries,

--- a/crates/but-core/tests/core/commit.rs
+++ b/crates/but-core/tests/core/commit.rs
@@ -4,10 +4,69 @@ use but_testsupport::gix_testtools;
 fn is_conflicted() -> anyhow::Result<()> {
     let repo = conflict_repo("normal-and-artificial")?;
     let normal = but_core::Commit::from_id(repo.rev_parse_single("normal")?)?;
-    assert!(!normal.is_conflicted());
+    assert!(
+        !normal.is_conflicted(),
+        "an ordinary commit is not conflicted"
+    );
 
     let conflicted = but_core::Commit::from_id(repo.rev_parse_single("conflicted")?)?;
-    assert!(conflicted.is_conflicted());
+    assert!(
+        conflicted.is_conflicted(),
+        "a legacy synthetic conflict remains conflicted"
+    );
+
+    let marked_conflict = but_core::Commit::from_id(repo.rev_parse_single("marked-conflict")?)?;
+    assert!(
+        marked_conflict.is_conflicted(),
+        "a marked synthetic conflict remains conflicted"
+    );
+
+    let marked_ordinary = but_core::Commit::from_id(repo.rev_parse_single("marked-ordinary")?)?;
+    assert!(
+        !marked_ordinary.is_conflicted(),
+        "conflict metadata alone does not make an ordinary tree conflicted"
+    );
+    assert_eq!(
+        marked_ordinary.tree_id_or_auto_resolution()?.detach(),
+        marked_ordinary.tree,
+        "an ordinary tree is used even if the commit retained conflict metadata"
+    );
+    assert_eq!(
+        marked_ordinary.conflict_entries()?,
+        None,
+        "ordinary commits do not project conflict details"
+    );
+    assert_eq!(
+        but_core::diff::CommitDetails::from_commit_id(marked_ordinary.id, false)?.conflict_entries,
+        None,
+        "commit details do not project a stale conflict trailer as conflict state"
+    );
+
+    let partial = but_core::Commit::from_id(repo.rev_parse_single("partial-conflict")?)?;
+    assert!(
+        partial.is_conflicted(),
+        "a partial synthetic layout is still recognized as a conflict"
+    );
+    let error = partial
+        .tree_id_or_auto_resolution()
+        .expect_err("the auto-resolution tree is missing");
+    assert!(
+        error
+            .to_string()
+            .contains("Unexpected tree in conflicting commit"),
+        "a partial synthetic layout must report a malformed conflict: {error}"
+    );
+
+    let high_index_partial =
+        but_core::Commit::from_id(repo.rev_parse_single("high-index-partial-conflict")?)?;
+    assert!(
+        high_index_partial.is_conflicted(),
+        "a numbered synthetic entry is recognized without lower-numbered entries"
+    );
+    assert!(
+        high_index_partial.tree_id_or_auto_resolution().is_err(),
+        "a high-index-only partial layout remains an explicit error"
+    );
     Ok(())
 }
 

--- a/crates/but-core/tests/fixtures/conflict-commits.sh
+++ b/crates/but-core/tests/fixtures/conflict-commits.sh
@@ -27,6 +27,26 @@ EOF
 
   conflict_tree=$(git write-tree)
 
+  git tag marked-conflict "$(git commit-tree "$conflict_tree" -p HEAD \
+    -m "marked conflict" -m "GitButler-Conflict: true")"
+
+  normal_tree=$(git rev-parse normal^{tree})
+  git tag marked-ordinary "$(git commit-tree "$normal_tree" -p HEAD \
+    -m "marked ordinary commit" -m "GitButler-Conflict: true")"
+
+  git update-index --force-remove .auto-resolution/file
+  partial_conflict_tree=$(git write-tree)
+  git tag partial-conflict "$(git commit-tree "$partial_conflict_tree" -p HEAD \
+    -m "marked partial conflict" -m "GitButler-Conflict: true")"
+
+  git read-tree --empty
+  git update-index --index-info <<EOF
+100644 blob $empty_blob	.conflict-side-2/file
+EOF
+  high_index_partial_tree=$(git write-tree)
+  git tag high-index-partial-conflict "$(git commit-tree "$high_index_partial_tree" -p HEAD \
+    -m "marked high-index partial conflict" -m "GitButler-Conflict: true")"
+
   conflict_commit=$(git hash-object -wt commit --stdin <<EOF
 tree $conflict_tree
 parent $(git rev-parse HEAD)

--- a/crates/but-workspace/src/ref_info.rs
+++ b/crates/but-workspace/src/ref_info.rs
@@ -108,28 +108,11 @@ impl Commit {
         commit: but_core::Commit<'_>,
         graph_commit: &but_graph::Commit,
     ) -> Self {
-        let has_conflicts = commit.is_conflicted();
-        let hdr = commit.headers();
-        let commit = commit.inner;
-        let message = but_core::commit::strip_conflict_markers(commit.message.as_ref());
         Commit {
             id: graph_commit.id,
-            parent_ids: commit.parents.into_iter().collect(),
-            tree_id: commit.tree,
-            message,
-            has_conflicts,
-            author: commit
-                .author
-                .to_ref(&mut gix::date::parse::TimeBuf::default())
-                .into(),
-            committer: commit
-                .committer
-                .to_ref(&mut gix::date::parse::TimeBuf::default())
-                .into(),
             refs: graph_commit.refs.clone(),
             flags: graph_commit.flags.into(),
-            change_id: hdr.and_then(|hdr| hdr.change_id),
-            gerrit_review_url: None,
+            ..commit.into()
         }
     }
 }

--- a/crates/but-workspace/src/ref_info.rs
+++ b/crates/but-workspace/src/ref_info.rs
@@ -105,11 +105,12 @@ impl Commit {
 
     /// A special constructor for very specific case.
     pub(crate) fn from_commit_ahead_of_workspace_commit(
-        commit: gix::objs::Commit,
+        commit: but_core::Commit<'_>,
         graph_commit: &but_graph::Commit,
     ) -> Self {
-        let hdr = but_core::commit::Headers::try_from_commit(&commit);
-        let has_conflicts = but_core::commit::is_conflicted(commit.message.as_ref(), hdr.as_ref());
+        let has_conflicts = commit.is_conflicted();
+        let hdr = commit.headers();
+        let commit = commit.inner;
         let message = but_core::commit::strip_conflict_markers(commit.message.as_ref());
         Commit {
             id: graph_commit.id,
@@ -510,7 +511,10 @@ pub(crate) fn find_ancestor_workspace_commit(
             }
             commits_outside.push(
                 crate::ref_info::Commit::from_commit_ahead_of_workspace_commit(
-                    commit.inner,
+                    but_core::Commit {
+                        id: commit.id,
+                        inner: commit.inner,
+                    },
                     graph_commit,
                 ),
             );

--- a/crates/but-workspace/src/ui/mod.rs
+++ b/crates/but-workspace/src/ui/mod.rs
@@ -82,29 +82,8 @@ impl TryFrom<gix::Commit<'_>> for Commit {
     type Error = anyhow::Error;
     fn try_from(commit: gix::Commit<'_>) -> Result<Self, Self::Error> {
         let commit = but_core::Commit::try_from(commit)?;
-        let commit_id = commit.id.detach();
         let has_conflicts = commit.is_conflicted();
-        let commit = commit.inner;
-        let headers = commit::Headers::try_from_commit(&commit);
-        let change_id = headers
-            .unwrap_or_default()
-            .ensure_change_id(commit_id)
-            .change_id
-            .expect("change-id is ensured")
-            .to_string();
-        let message = but_core::commit::strip_conflict_markers(commit.message.as_ref());
-        Ok(Commit {
-            id: commit_id,
-            parent_ids: commit.parents.into_iter().collect(),
-            message,
-            has_conflicts,
-            state: CommitState::LocalAndRemote(commit_id),
-            authored_at: i128::from(commit.author.time.seconds) * 1000,
-            committed_at: i128::from(commit.committer.time.seconds) * 1000,
-            author: commit.author.to_ref(&mut TimeBuf::default()).into(),
-            change_id,
-            gerrit_review_url: None,
-        })
+        Ok(Commit::from_commit_owned(commit.detach(), has_conflicts))
     }
 }
 
@@ -112,14 +91,9 @@ impl Commit {
     /// Convert a detached `commit`. Its tree is not accessible without a repository,
     /// so the caller must provide `has_conflicts` as determined by
     /// [`but_core::Commit::is_conflicted()`] or an equivalent source.
-    pub fn from_commit_owned(CommitOwned { id, inner }: CommitOwned, has_conflicts: bool) -> Self {
-        let headers = commit::Headers::try_from_commit(&inner);
-        let change_id = headers
-            .unwrap_or_default()
-            .ensure_change_id(id)
-            .change_id
-            .expect("change-id is ensured")
-            .to_string();
+    pub fn from_commit_owned(commit: CommitOwned, has_conflicts: bool) -> Self {
+        let change_id = commit.change_id().to_string();
+        let CommitOwned { id, inner } = commit;
         let gix::objs::Commit {
             tree: _,
             parents,
@@ -138,7 +112,7 @@ impl Commit {
             state: CommitState::LocalAndRemote(id),
             authored_at: author.time.seconds as i128 * 1000,
             committed_at: committer.time.seconds as i128 * 1000,
-            author: author.to_ref(&mut TimeBuf::default()).into(),
+            author: author.to_ref(&mut TimeBuf::default()).trim().into(),
             change_id,
             gerrit_review_url: None,
         }

--- a/crates/but-workspace/src/ui/mod.rs
+++ b/crates/but-workspace/src/ui/mod.rs
@@ -108,11 +108,12 @@ impl TryFrom<gix::Commit<'_>> for Commit {
     }
 }
 
-impl From<but_core::CommitOwned> for Commit {
-    fn from(CommitOwned { id, inner }: CommitOwned) -> Self {
+impl Commit {
+    /// Convert a detached `commit`. Its tree is not accessible without a repository,
+    /// so the caller must provide `has_conflicts` as determined by
+    /// [`but_core::Commit::is_conflicted()`] or an equivalent source.
+    pub fn from_commit_owned(CommitOwned { id, inner }: CommitOwned, has_conflicts: bool) -> Self {
         let headers = commit::Headers::try_from_commit(&inner);
-        let has_conflicts =
-            but_core::commit::is_conflicted(inner.message.as_ref(), headers.as_ref());
         let change_id = headers
             .unwrap_or_default()
             .ensure_change_id(id)

--- a/crates/but-workspace/src/ui/mod.rs
+++ b/crates/but-workspace/src/ui/mod.rs
@@ -81,26 +81,27 @@ but_schemars::register_sdk_type!(Commit);
 impl TryFrom<gix::Commit<'_>> for Commit {
     type Error = anyhow::Error;
     fn try_from(commit: gix::Commit<'_>) -> Result<Self, Self::Error> {
-        let commit_id = commit.id;
-        let commit = commit.decode()?;
-        let headers = but_core::commit::Headers::try_from_commit_headers(|| commit.extra_headers());
-        let has_conflicts = but_core::commit::is_conflicted(commit.message, headers.as_ref());
+        let commit = but_core::Commit::try_from(commit)?;
+        let commit_id = commit.id.detach();
+        let has_conflicts = commit.is_conflicted();
+        let commit = commit.inner;
+        let headers = commit::Headers::try_from_commit(&commit);
         let change_id = headers
             .unwrap_or_default()
             .ensure_change_id(commit_id)
             .change_id
             .expect("change-id is ensured")
             .to_string();
-        let message = but_core::commit::strip_conflict_markers(commit.message);
+        let message = but_core::commit::strip_conflict_markers(commit.message.as_ref());
         Ok(Commit {
             id: commit_id,
-            parent_ids: commit.parents().collect(),
+            parent_ids: commit.parents.into_iter().collect(),
             message,
             has_conflicts,
             state: CommitState::LocalAndRemote(commit_id),
-            authored_at: i128::from(commit.author()?.time()?.seconds) * 1000,
-            committed_at: i128::from(commit.time()?.seconds) * 1000,
-            author: commit.author()?.into(),
+            authored_at: i128::from(commit.author.time.seconds) * 1000,
+            committed_at: i128::from(commit.committer.time.seconds) * 1000,
+            author: commit.author.to_ref(&mut TimeBuf::default()).into(),
             change_id,
             gerrit_review_url: None,
         })

--- a/crates/but-workspace/tests/workspace/target_history.rs
+++ b/crates/but-workspace/tests/workspace/target_history.rs
@@ -15,6 +15,16 @@ fn log_target_first_parent_uses_persisted_target_outside_workspace() -> anyhow::
     git_at_dir(&remote_dir)
         .args(["commit", "-m", "initial"])
         .run();
+    git_at_dir(&remote_dir)
+        .args([
+            "commit",
+            "--allow-empty",
+            "-m",
+            "marked ordinary commit",
+            "-m",
+            "GitButler-Conflict: true",
+        ])
+        .run();
 
     git_at_dir(&remote_dir)
         .args(["checkout", "-b", "feature"])
@@ -61,6 +71,10 @@ fn log_target_first_parent_uses_persisted_target_outside_workspace() -> anyhow::
         commits.first().map(|commit| commit.id),
         Some(main_tip),
         "outside-workspace target history must use persisted GitButler target metadata, not the current branch upstream"
+    );
+    assert!(
+        commits.first().is_some_and(|commit| !commit.has_conflicts),
+        "target history must not project a stale conflict trailer as conflict state"
     );
     Ok(())
 }

--- a/crates/gitbutler-commit/src/commit_ext.rs
+++ b/crates/gitbutler-commit/src/commit_ext.rs
@@ -21,11 +21,7 @@ impl CommitExt for gix::Commit<'_> {
     }
 
     fn is_conflicted(&self) -> bool {
-        let Ok(commit) = self.decode() else {
-            return false;
-        };
-        let headers = Headers::try_from_commit_headers(|| commit.extra_headers());
-        but_core::commit::is_conflicted(commit.message, headers.as_ref())
+        but_core::Commit::try_from(self.clone()).is_ok_and(|commit| commit.is_conflicted())
     }
 }
 


### PR DESCRIPTION
## Context

A clean commit can retain a GitButler-Conflict trailer after rebase-and-merge. Treating the trailer alone as active conflict state then breaks status, pull, and commit for workspaces based below it.

Fixes #15298.

## Change

Require synthetic conflict-tree entries before treating conflict metadata as active state. Ordinary rebased commits remain usable while valid and malformed synthetic layouts stay visible.