### PR TITLE
Add Lite AI commit message generation

### DIFF
--- a/apps/lite/ui/src/api/mutations.ts
+++ b/apps/lite/ui/src/api/mutations.ts
@@ -8,9 +8,15 @@ import {
 	listCommentReactionsQueryOptions,
 	listReviewCommentsQueryOptions,
 	listReviewReactionsQueryOptions,
+	treeChangeDiffsQueryOptions,
 	workspaceFetchQueryOptions,
 } from "#ui/api/queries.ts";
 import { shortCommitId } from "#ui/commit.ts";
+import {
+	buildCommitMessagePrompt,
+	COMMIT_MESSAGE_SYSTEM_PROMPT,
+	streamCommitMessage,
+} from "#ui/commit-message-generation.ts";
 import { errorMessageForToast } from "#ui/errors.ts";
 import { createDiffSpec, resolveDiffSpecs } from "#ui/operations/diff-specs.ts";
 import {
@@ -19,6 +25,7 @@ import {
 } from "#ui/operations/toastOptions.tsx";
 import { commitOperand, filesUnder, type FileParent } from "#ui/operands.ts";
 import { projectSlice } from "#ui/projects/state.ts";
+import { projectAiSettingsQueryOptions } from "#ui/project-ai-settings.ts";
 import { type AppDispatch, useAppDispatch, useAppStore } from "#ui/store.ts";
 import { formatRelativeTime } from "#ui/time.ts";
 import { Toast } from "@base-ui/react";
@@ -54,6 +61,39 @@ const pluralRules = new Intl.PluralRules("en");
 // oxlint-disable-next-line typescript/no-explicit-any
 type PromiseReturnType<T> = T extends (...args: Array<any>) => Promise<infer U> ? U : never;
 type AnyResponse = PromiseReturnType<(typeof window.lite)[keyof typeof window.lite]>;
+
+type GenerateCommitMessageInput = {
+	projectId: string;
+	changes: Array<TreeChange>;
+	previousMessage: string;
+	onValue: (value: string) => void;
+};
+
+/** Loads selected patches and streams a generated commit message to the caller. */
+export const useGenerateCommitMessage = () => {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: async (input: GenerateCommitMessageInput) => {
+			const [settings, patches] = await Promise.all([
+				queryClient.ensureQueryData(projectAiSettingsQueryOptions(input.projectId)),
+				Promise.all(
+					input.changes.map((change) =>
+						queryClient.ensureQueryData(
+							treeChangeDiffsQueryOptions({ projectId: input.projectId, change }),
+						),
+					),
+				),
+			]);
+			const prompt = buildCommitMessagePrompt(settings.commitMessagePrompt, input.changes, patches);
+			return streamCommitMessage(
+				(onToken) => window.lite.streamAiResponse(COMMIT_MESSAGE_SYSTEM_PROMPT, prompt, onToken),
+				input.onValue,
+				input.previousMessage,
+			);
+		},
+		meta: { failureTitle: "Failed to generate commit message" },
+	});
+};
 
 export const syncCoreCaches = (
 	queryClient: QueryClient,

--- a/apps/lite/ui/src/api/queries.ts
+++ b/apps/lite/ui/src/api/queries.ts
@@ -37,6 +37,7 @@ type LocalQueryKey =
 	| "dryRun"
 	| "prMergeMethod"
 	| "prDraft"
+	| "projectAiSettings"
 	| "reviewedFiles";
 
 export type QueryKey = ProjectQueryKey | GlobalQueryKey | LocalQueryKey;

--- a/apps/lite/ui/src/commit-message-generation.test.ts
+++ b/apps/lite/ui/src/commit-message-generation.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest";
+import type { TreeChange, UnifiedPatch } from "@gitbutler/but-sdk";
+import {
+	buildCommitMessagePrompt,
+	changesSelectedForCommit,
+	commitMessageGenerationButtonState,
+	streamCommitMessage,
+} from "./commit-message-generation.ts";
+
+const change = (path: string): TreeChange =>
+	({ path, status: { type: "Modification" } }) as TreeChange;
+
+describe("commit message generation", () => {
+	it("shows only configured project AI and disables the button while busy", () => {
+		expect(
+			commitMessageGenerationButtonState({
+				enabled: true,
+				configured: true,
+				busy: false,
+				changeCount: 1,
+			}),
+		).toEqual({ visible: true, disabled: false });
+		expect(
+			commitMessageGenerationButtonState({
+				enabled: false,
+				configured: true,
+				busy: true,
+				changeCount: 1,
+			}),
+		).toEqual({ visible: false, disabled: true });
+	});
+
+	it("uses all changes when nothing is checked and otherwise filters by path", () => {
+		const changes = [change("one.ts"), change("two.ts")];
+		expect(changesSelectedForCommit(changes, new Set())).toEqual(changes);
+		expect(changesSelectedForCommit(changes, new Set(["two.ts"]))).toEqual([changes[1]]);
+	});
+
+	it("formats patch markers and caps the appended diff", () => {
+		const patch = {
+			type: "Patch",
+			subject: { hunks: [{ diff: `@@ -1 +1 @@\n-${"a".repeat(6_000)}` }] },
+		} as UnifiedPatch;
+		const prompt = buildCommitMessagePrompt("Instructions", [change("one.ts")], [patch]);
+		const diff = prompt.match(/```diff\n([\s\S]*)\n```$/)?.[1];
+
+		expect(prompt).toContain("File: one.ts (Modification)");
+		expect(diff).toHaveLength(5_000);
+	});
+
+	it("preserves the current value until the first token", async () => {
+		const onValue = vi.fn();
+		await expect(
+			streamCommitMessage(async () => {
+				throw new Error("failed before response");
+			}, onValue),
+		).rejects.toThrow("failed before response");
+		expect(onValue).not.toHaveBeenCalled();
+
+		await streamCommitMessage(async (onToken) => {
+			onToken("feat: ");
+			onToken("generated");
+			return "feat: generated";
+		}, onValue);
+		expect(onValue.mock.calls).toEqual([["feat: "], ["feat: generated"], ["feat: generated"]]);
+	});
+});

--- a/apps/lite/ui/src/commit-message-generation.test.ts
+++ b/apps/lite/ui/src/commit-message-generation.test.ts
@@ -48,20 +48,41 @@ describe("commit message generation", () => {
 		expect(diff).toHaveLength(5_000);
 	});
 
-	it("preserves the current value until the first token", async () => {
+	it("preserves the current value on a failed stream", async () => {
 		const onValue = vi.fn();
 		await expect(
-			streamCommitMessage(async () => {
-				throw new Error("failed before response");
-			}, onValue),
+			streamCommitMessage(
+				async () => {
+					throw new Error("failed before response");
+				},
+				onValue,
+				"original",
+			),
 		).rejects.toThrow("failed before response");
 		expect(onValue).not.toHaveBeenCalled();
 
-		await streamCommitMessage(async (onToken) => {
-			onToken("feat: ");
-			onToken("generated");
-			return "feat: generated";
-		}, onValue);
+		await expect(
+			streamCommitMessage(
+				async (onToken) => {
+					onToken("partial");
+					throw new Error("failed during response");
+				},
+				onValue,
+				"original",
+			),
+		).rejects.toThrow("failed during response");
+		expect(onValue.mock.calls).toEqual([["partial"], ["original"]]);
+
+		onValue.mockClear();
+		await streamCommitMessage(
+			async (onToken) => {
+				onToken("feat: ");
+				onToken("generated");
+				return "feat: generated";
+			},
+			onValue,
+			"original",
+		);
 		expect(onValue.mock.calls).toEqual([["feat: "], ["feat: generated"], ["feat: generated"]]);
 	});
 });

--- a/apps/lite/ui/src/commit-message-generation.ts
+++ b/apps/lite/ui/src/commit-message-generation.ts
@@ -43,6 +43,7 @@ export const buildCommitMessagePrompt = (
 	return `${instructions.trim()}\n\nSelected changes:\n\`\`\`diff\n${diff}\n\`\`\``;
 };
 
+/** Streams partial values and restores the previous value if a started stream fails. */
 export const streamCommitMessage = async (
 	stream: (onToken: (token: string) => void) => Promise<string>,
 	onValue: (value: string) => void,

--- a/apps/lite/ui/src/commit-message-generation.ts
+++ b/apps/lite/ui/src/commit-message-generation.ts
@@ -1,0 +1,57 @@
+import type { TreeChange, UnifiedPatch } from "@gitbutler/but-sdk";
+
+export const COMMIT_MESSAGE_SYSTEM_PROMPT =
+	"You write Git commit messages. Return only the commit message, without Markdown or commentary.";
+const COMMIT_MESSAGE_DIFF_LIMIT = 5_000;
+
+export const commitMessageGenerationButtonState = ({
+	enabled,
+	configured,
+	busy,
+	changeCount,
+}: {
+	enabled: boolean;
+	configured: boolean;
+	busy: boolean;
+	changeCount: number;
+}) => ({ visible: enabled && configured, disabled: busy || changeCount === 0 });
+
+export const changesSelectedForCommit = (
+	changes: Array<TreeChange>,
+	checkedPaths: ReadonlySet<string>,
+): Array<TreeChange> =>
+	checkedPaths.size === 0 ? changes : changes.filter((change) => checkedPaths.has(change.path));
+
+const formatPatch = (change: TreeChange, patch: UnifiedPatch | null): string => {
+	const heading = `File: ${change.path} (${change.status.type})`;
+	if (patch === null) return `${heading}\nDiff unavailable.`;
+	if (patch.type === "Binary") return `${heading}\nBinary file changed.`;
+	if (patch.type === "TooLarge")
+		return `${heading}\nDiff omitted because the file is ${patch.subject.sizeInBytes} bytes.`;
+	return `${heading}\n${patch.subject.hunks.map((hunk) => hunk.diff).join("\n")}`;
+};
+
+export const buildCommitMessagePrompt = (
+	instructions: string,
+	changes: Array<TreeChange>,
+	patches: Array<UnifiedPatch | null>,
+): string => {
+	const diff = changes
+		.map((change, index) => formatPatch(change, patches[index] ?? null))
+		.join("\n\n")
+		.slice(0, COMMIT_MESSAGE_DIFF_LIMIT);
+	return `${instructions.trim()}\n\nSelected changes:\n\`\`\`diff\n${diff}\n\`\`\``;
+};
+
+export const streamCommitMessage = async (
+	stream: (onToken: (token: string) => void) => Promise<string>,
+	onValue: (value: string) => void,
+): Promise<string> => {
+	let partial = "";
+	const response = await stream((token) => {
+		partial += token;
+		onValue(partial);
+	});
+	onValue(response);
+	return response;
+};

--- a/apps/lite/ui/src/commit-message-generation.ts
+++ b/apps/lite/ui/src/commit-message-generation.ts
@@ -46,12 +46,18 @@ export const buildCommitMessagePrompt = (
 export const streamCommitMessage = async (
 	stream: (onToken: (token: string) => void) => Promise<string>,
 	onValue: (value: string) => void,
+	previousValue: string,
 ): Promise<string> => {
 	let partial = "";
-	const response = await stream((token) => {
-		partial += token;
-		onValue(partial);
-	});
-	onValue(response);
-	return response;
+	try {
+		const response = await stream((token) => {
+			partial += token;
+			onValue(partial);
+		});
+		onValue(response);
+		return response;
+	} catch (error) {
+		if (partial.length > 0) onValue(previousValue);
+		throw error;
+	}
 };

--- a/apps/lite/ui/src/project-ai-settings.test.ts
+++ b/apps/lite/ui/src/project-ai-settings.test.ts
@@ -1,0 +1,38 @@
+/** @vitest-environment jsdom */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+	DEFAULT_COMMIT_MESSAGE_PROMPT,
+	projectAiSettingsQueryOptions,
+	writeProjectAiSettings,
+} from "./project-ai-settings.ts";
+
+const readProjectAiSettings = async (projectId: string) => {
+	const queryFn = projectAiSettingsQueryOptions(projectId).queryFn;
+	if (typeof queryFn !== "function") throw new Error("Missing project AI settings query");
+	return await queryFn({} as never);
+};
+
+describe("project AI settings", () => {
+	beforeEach(() => window.localStorage.clear());
+
+	it("defaults to disabled with the commit prompt", async () => {
+		await expect(readProjectAiSettings("project")).resolves.toEqual({
+			enabled: false,
+			commitMessagePrompt: DEFAULT_COMMIT_MESSAGE_PROMPT,
+		});
+	});
+
+	it("persists per project and restores an empty prompt", async () => {
+		writeProjectAiSettings("one", { enabled: true, commitMessagePrompt: "Custom" });
+		writeProjectAiSettings("two", { enabled: false, commitMessagePrompt: "  " });
+
+		await expect(readProjectAiSettings("one")).resolves.toEqual({
+			enabled: true,
+			commitMessagePrompt: "Custom",
+		});
+		await expect(readProjectAiSettings("two")).resolves.toMatchObject({
+			commitMessagePrompt: DEFAULT_COMMIT_MESSAGE_PROMPT,
+		});
+	});
+});

--- a/apps/lite/ui/src/project-ai-settings.ts
+++ b/apps/lite/ui/src/project-ai-settings.ts
@@ -1,0 +1,57 @@
+import { queryOptions } from "@tanstack/react-query";
+
+export const DEFAULT_COMMIT_MESSAGE_PROMPT = `Write a commit message for these changes.
+Only respond with the commit message, without notes or Markdown.
+Explain what changed and why, focusing on the most important changes.
+Use present tense and a semantic commit prefix.
+Keep the title under 50 characters and hard-wrap body lines at 72 characters.
+Do not use emoji or start lines with the hash symbol.`;
+
+export type ProjectAiSettings = {
+	enabled: boolean;
+	commitMessagePrompt: string;
+};
+
+const defaultProjectAiSettings: ProjectAiSettings = {
+	enabled: false,
+	commitMessagePrompt: DEFAULT_COMMIT_MESSAGE_PROMPT,
+};
+
+const storageKey = (projectId: string) => `project_ai_settings:v1:${projectId}`;
+
+const readProjectAiSettings = (projectId: string): ProjectAiSettings => {
+	try {
+		const stored: unknown = JSON.parse(
+			window.localStorage.getItem(storageKey(projectId)) ?? "null",
+		);
+		if (
+			typeof stored === "object" &&
+			stored !== null &&
+			"enabled" in stored &&
+			"commitMessagePrompt" in stored
+		) {
+			const { enabled, commitMessagePrompt } = stored;
+			if (typeof enabled === "boolean" && typeof commitMessagePrompt === "string") {
+				return {
+					enabled,
+					commitMessagePrompt:
+						commitMessagePrompt.trim().length > 0
+							? commitMessagePrompt.trim()
+							: DEFAULT_COMMIT_MESSAGE_PROMPT,
+				};
+			}
+		}
+	} catch {
+		// Invalid renderer-owned settings fall back to defaults.
+	}
+	return defaultProjectAiSettings;
+};
+
+export const writeProjectAiSettings = (projectId: string, settings: ProjectAiSettings): void =>
+	window.localStorage.setItem(storageKey(projectId), JSON.stringify(settings));
+
+export const projectAiSettingsQueryOptions = (projectId: string) =>
+	queryOptions({
+		queryKey: ["projectAiSettings", projectId],
+		queryFn: () => readProjectAiSettings(projectId),
+	});

--- a/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
@@ -20,7 +20,6 @@ import {
 	streamCommitMessage,
 } from "#ui/commit-message-generation.ts";
 import { draftCommitMessageQueryOptions, usePersistDraftCommitMessage } from "#ui/draft.ts";
-import { errorMessageForToast } from "#ui/errors.ts";
 import { changesHotkeys, outlineHotkeys, toElectronAccelerator } from "#ui/hotkeys.ts";
 import { nativeMenuItem, showNativeMenuFromTrigger, type NativeMenuItem } from "#ui/native-menu.ts";
 import { operandEquals, operandIdentityKey, type Operand } from "#ui/operands.ts";
@@ -29,10 +28,10 @@ import { projectSlice } from "#ui/projects/state.ts";
 import { projectAiSettingsQueryOptions } from "#ui/project-ai-settings.ts";
 import { focusSelectionScope } from "#ui/selection-scopes.ts";
 import { useAppDispatch, useAppSelector, useAppStore } from "#ui/store.ts";
-import { Button, Combobox, Toast, Tooltip } from "@base-ui/react";
-import type { InsertSide, RelativeTo, WorktreeChanges } from "@gitbutler/but-sdk";
+import { Button, Combobox, Tooltip } from "@base-ui/react";
+import type { InsertSide, RelativeTo, TreeChange, WorktreeChanges } from "@gitbutler/but-sdk";
 import { useHotkey, useHotkeys } from "@tanstack/react-hotkeys";
-import { useIsMutating, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useIsMutating, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Match } from "effect";
 import {
 	type FC,
@@ -142,7 +141,6 @@ export const CommitForm: FC<{
 	const dispatch = useAppDispatch();
 	const store = useAppStore();
 	const client = useQueryClient();
-	const toastManager = Toast.useToastManager();
 	const { isPending: isCommitCreatePending, mutate: commitCreate } = useCommitCreate();
 	const { isPending: isBranchCreatePending, mutate: branchCreate } = useBranchCreate();
 
@@ -158,6 +156,38 @@ export const CommitForm: FC<{
 	const { data: isProjectAiEnabled = false } = useQuery({
 		...projectAiSettingsQueryOptions(projectId),
 		select: (settings) => settings.enabled,
+	});
+	const { isPending: isGenerating, mutate: generateMessage } = useMutation({
+		mutationFn: async ({
+			changes,
+			previousMessage,
+		}: {
+			changes: Array<TreeChange>;
+			previousMessage: string;
+		}) => {
+			const [settings, patches] = await Promise.all([
+				client.ensureQueryData(projectAiSettingsQueryOptions(projectId)),
+				Promise.all(
+					changes.map((change) =>
+						client.ensureQueryData(treeChangeDiffsQueryOptions({ projectId, change })),
+					),
+				),
+			]);
+			const prompt = buildCommitMessagePrompt(settings.commitMessagePrompt, changes, patches);
+			return streamCommitMessage(
+				(onToken) => window.lite.streamAiResponse(COMMIT_MESSAGE_SYSTEM_PROMPT, prompt, onToken),
+				(value) => {
+					if (commitTextareaRef.current) commitTextareaRef.current.value = value;
+				},
+				previousMessage,
+			);
+		},
+		onSuccess: (response) => {
+			const message = response.trim();
+			if (commitTextareaRef.current) commitTextareaRef.current.value = message;
+			persistDraftMessage({ projectId, message });
+		},
+		meta: { failureTitle: "Failed to generate commit message" },
 	});
 
 	const isDefaultMode = useAppSelector(
@@ -186,7 +216,6 @@ export const CommitForm: FC<{
 	const [open, setOpen] = useState(false);
 	const [isExpanded, setIsExpanded] = useState(false);
 	const [commitLabelHidden, setCommitLabelHidden] = useState(false);
-	const [isGenerating, setIsGenerating] = useState(false);
 	const generationButton = commitMessageGenerationButtonState({
 		enabled: isProjectAiEnabled,
 		configured: isAiConfigured,
@@ -310,7 +339,7 @@ export const CommitForm: FC<{
 		createCommit();
 	};
 
-	const generateCommitMessage = async () => {
+	const generateCommitMessage = () => {
 		if (!worktreeChanges || isGenerating) return;
 
 		const checkedPaths = projectSlice.selectors.selectCheckedUncommittedFilePaths(
@@ -320,38 +349,13 @@ export const CommitForm: FC<{
 		const changes = changesSelectedForCommit(worktreeChanges.changes, checkedPaths);
 		if (changes.length === 0) return;
 
-		setIsGenerating(true);
-		try {
-			const [settings, patches] = await Promise.all([
-				client.ensureQueryData(projectAiSettingsQueryOptions(projectId)),
-				Promise.all(
-					changes.map((change) =>
-						client.ensureQueryData(treeChangeDiffsQueryOptions({ projectId, change })),
-					),
-				),
-			]);
-			const prompt = buildCommitMessagePrompt(settings.commitMessagePrompt, changes, patches);
-			const response = await streamCommitMessage(
-				(onToken) => window.lite.streamAiResponse(COMMIT_MESSAGE_SYSTEM_PROMPT, prompt, onToken),
-				(value) => {
-					if (commitTextareaRef.current) commitTextareaRef.current.value = value;
-				},
-			);
-			const message = response.trim();
-			if (commitTextareaRef.current) commitTextareaRef.current.value = message;
-			persistDraftMessage({ projectId, message });
-		} catch (error) {
-			toastManager.add({
-				type: "error",
-				title: "Failed to generate commit message",
-				description: errorMessageForToast(error),
-				priority: "high",
-			});
-		} finally {
-			setIsGenerating(false);
-		}
+		generateMessage({
+			changes,
+			previousMessage: commitTextareaRef.current?.value ?? draftMessage ?? "",
+		});
 	};
 	const commitMenuItems: Array<NativeMenuItem> = [
+		// oxlint-disable-next-line react-hooks-js/refs -- The ref is only read by the onSelect callback.
 		nativeMenuItem({
 			label: "Commit",
 			enabled: canCommit,
@@ -622,7 +626,7 @@ export const CommitForm: FC<{
 							<Tooltip.Trigger
 								aria-label="Generate commit message"
 								className={getButtonClassName({ variant: "outline", iconOnly: true })}
-								onClick={() => void generateCommitMessage()}
+								onClick={generateCommitMessage}
 								render={
 									<Button
 										focusableWhenDisabled

--- a/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
@@ -1,10 +1,9 @@
 import uiStyles from "#ui/components/ui.module.css";
-import { useBranchCreate, useCommitCreate } from "#ui/api/mutations.ts";
+import { useBranchCreate, useCommitCreate, useGenerateCommitMessage } from "#ui/api/mutations.ts";
 import {
 	aiConfigurationQueryOptions,
 	branchCannedNameQueryOptions,
 	headInfoQueryOptions,
-	treeChangeDiffsQueryOptions,
 } from "#ui/api/queries.ts";
 import { getHeadInfoIndex, resolveRelativeTo } from "#ui/api/ref-info.ts";
 import { getButtonClassName } from "#ui/components/Button.tsx";
@@ -13,11 +12,8 @@ import { Icon } from "#ui/components/Icon.tsx";
 import { Kbd } from "#ui/components/Kbd.tsx";
 import { TooltipPopup } from "#ui/components/Tooltip.tsx";
 import {
-	buildCommitMessagePrompt,
 	changesSelectedForCommit,
 	commitMessageGenerationButtonState,
-	COMMIT_MESSAGE_SYSTEM_PROMPT,
-	streamCommitMessage,
 } from "#ui/commit-message-generation.ts";
 import { draftCommitMessageQueryOptions, usePersistDraftCommitMessage } from "#ui/draft.ts";
 import { changesHotkeys, outlineHotkeys, toElectronAccelerator } from "#ui/hotkeys.ts";
@@ -29,9 +25,9 @@ import { projectAiSettingsQueryOptions } from "#ui/project-ai-settings.ts";
 import { focusSelectionScope } from "#ui/selection-scopes.ts";
 import { useAppDispatch, useAppSelector, useAppStore } from "#ui/store.ts";
 import { Button, Combobox, Tooltip } from "@base-ui/react";
-import type { InsertSide, RelativeTo, TreeChange, WorktreeChanges } from "@gitbutler/but-sdk";
+import type { InsertSide, RelativeTo, WorktreeChanges } from "@gitbutler/but-sdk";
 import { useHotkey, useHotkeys } from "@tanstack/react-hotkeys";
-import { useIsMutating, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useIsMutating, useQuery } from "@tanstack/react-query";
 import { Match } from "effect";
 import {
 	type FC,
@@ -140,9 +136,9 @@ export const CommitForm: FC<{
 }) => {
 	const dispatch = useAppDispatch();
 	const store = useAppStore();
-	const client = useQueryClient();
 	const { isPending: isCommitCreatePending, mutate: commitCreate } = useCommitCreate();
 	const { isPending: isBranchCreatePending, mutate: branchCreate } = useBranchCreate();
+	const { isPending: isGenerating, mutate: generateMessage } = useGenerateCommitMessage();
 
 	const commitTextareaRef = useRef<HTMLTextAreaElement | null>(null);
 	const formRef = useRef<HTMLFormElement | null>(null);
@@ -157,39 +153,6 @@ export const CommitForm: FC<{
 		...projectAiSettingsQueryOptions(projectId),
 		select: (settings) => settings.enabled,
 	});
-	const { isPending: isGenerating, mutate: generateMessage } = useMutation({
-		mutationFn: async ({
-			changes,
-			previousMessage,
-		}: {
-			changes: Array<TreeChange>;
-			previousMessage: string;
-		}) => {
-			const [settings, patches] = await Promise.all([
-				client.ensureQueryData(projectAiSettingsQueryOptions(projectId)),
-				Promise.all(
-					changes.map((change) =>
-						client.ensureQueryData(treeChangeDiffsQueryOptions({ projectId, change })),
-					),
-				),
-			]);
-			const prompt = buildCommitMessagePrompt(settings.commitMessagePrompt, changes, patches);
-			return streamCommitMessage(
-				(onToken) => window.lite.streamAiResponse(COMMIT_MESSAGE_SYSTEM_PROMPT, prompt, onToken),
-				(value) => {
-					if (commitTextareaRef.current) commitTextareaRef.current.value = value;
-				},
-				previousMessage,
-			);
-		},
-		onSuccess: (response) => {
-			const message = response.trim();
-			if (commitTextareaRef.current) commitTextareaRef.current.value = message;
-			persistDraftMessage({ projectId, message });
-		},
-		meta: { failureTitle: "Failed to generate commit message" },
-	});
-
 	const isDefaultMode = useAppSelector(
 		(state) => projectSlice.selectors.selectOutlineModeState(state, projectId)._tag === "Default",
 	);
@@ -349,10 +312,23 @@ export const CommitForm: FC<{
 		const changes = changesSelectedForCommit(worktreeChanges.changes, checkedPaths);
 		if (changes.length === 0) return;
 
-		generateMessage({
-			changes,
-			previousMessage: commitTextareaRef.current?.value ?? draftMessage ?? "",
-		});
+		generateMessage(
+			{
+				projectId,
+				changes,
+				previousMessage: commitTextareaRef.current?.value ?? draftMessage ?? "",
+				onValue: (value) => {
+					if (commitTextareaRef.current) commitTextareaRef.current.value = value;
+				},
+			},
+			{
+				onSuccess: (response) => {
+					const message = response.trim();
+					if (commitTextareaRef.current) commitTextareaRef.current.value = message;
+					persistDraftMessage({ projectId, message });
+				},
+			},
+		);
 	};
 	const commitMenuItems: Array<NativeMenuItem> = [
 		// oxlint-disable-next-line react-hooks-js/refs -- The ref is only read by the onSelect callback.

--- a/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
@@ -1,24 +1,38 @@
 import uiStyles from "#ui/components/ui.module.css";
 import { useBranchCreate, useCommitCreate } from "#ui/api/mutations.ts";
-import { branchCannedNameQueryOptions, headInfoQueryOptions } from "#ui/api/queries.ts";
+import {
+	aiConfigurationQueryOptions,
+	branchCannedNameQueryOptions,
+	headInfoQueryOptions,
+	treeChangeDiffsQueryOptions,
+} from "#ui/api/queries.ts";
 import { getHeadInfoIndex, resolveRelativeTo } from "#ui/api/ref-info.ts";
 import { getButtonClassName } from "#ui/components/Button.tsx";
 import { classes } from "#ui/components/classes.ts";
 import { Icon } from "#ui/components/Icon.tsx";
 import { Kbd } from "#ui/components/Kbd.tsx";
 import { TooltipPopup } from "#ui/components/Tooltip.tsx";
+import {
+	buildCommitMessagePrompt,
+	changesSelectedForCommit,
+	commitMessageGenerationButtonState,
+	COMMIT_MESSAGE_SYSTEM_PROMPT,
+	streamCommitMessage,
+} from "#ui/commit-message-generation.ts";
 import { draftCommitMessageQueryOptions, usePersistDraftCommitMessage } from "#ui/draft.ts";
+import { errorMessageForToast } from "#ui/errors.ts";
 import { changesHotkeys, outlineHotkeys, toElectronAccelerator } from "#ui/hotkeys.ts";
 import { nativeMenuItem, showNativeMenuFromTrigger, type NativeMenuItem } from "#ui/native-menu.ts";
 import { operandEquals, operandIdentityKey, type Operand } from "#ui/operands.ts";
 import { createDiffSpec } from "#ui/operations/diff-specs.ts";
 import { projectSlice } from "#ui/projects/state.ts";
+import { projectAiSettingsQueryOptions } from "#ui/project-ai-settings.ts";
 import { focusSelectionScope } from "#ui/selection-scopes.ts";
 import { useAppDispatch, useAppSelector, useAppStore } from "#ui/store.ts";
-import { Button, Combobox, Tooltip } from "@base-ui/react";
+import { Button, Combobox, Toast, Tooltip } from "@base-ui/react";
 import type { InsertSide, RelativeTo, WorktreeChanges } from "@gitbutler/but-sdk";
 import { useHotkey, useHotkeys } from "@tanstack/react-hotkeys";
-import { useIsMutating, useQuery } from "@tanstack/react-query";
+import { useIsMutating, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Match } from "effect";
 import {
 	type FC,
@@ -127,6 +141,8 @@ export const CommitForm: FC<{
 }) => {
 	const dispatch = useAppDispatch();
 	const store = useAppStore();
+	const client = useQueryClient();
+	const toastManager = Toast.useToastManager();
 	const { isPending: isCommitCreatePending, mutate: commitCreate } = useCommitCreate();
 	const { isPending: isBranchCreatePending, mutate: branchCreate } = useBranchCreate();
 
@@ -135,6 +151,14 @@ export const CommitForm: FC<{
 
 	const { data: draftMessage } = useQuery(draftCommitMessageQueryOptions(projectId));
 	const { mutate: persistDraftMessage } = usePersistDraftCommitMessage();
+	const { data: isAiConfigured = false } = useQuery({
+		...aiConfigurationQueryOptions,
+		select: (configuration) => configuration.isConfigured,
+	});
+	const { data: isProjectAiEnabled = false } = useQuery({
+		...projectAiSettingsQueryOptions(projectId),
+		select: (settings) => settings.enabled,
+	});
 
 	const isDefaultMode = useAppSelector(
 		(state) => projectSlice.selectors.selectOutlineModeState(state, projectId)._tag === "Default",
@@ -162,6 +186,13 @@ export const CommitForm: FC<{
 	const [open, setOpen] = useState(false);
 	const [isExpanded, setIsExpanded] = useState(false);
 	const [commitLabelHidden, setCommitLabelHidden] = useState(false);
+	const [isGenerating, setIsGenerating] = useState(false);
+	const generationButton = commitMessageGenerationButtonState({
+		enabled: isProjectAiEnabled,
+		configured: isAiConfigured,
+		busy: isGenerating || isCommitOrAmendPending,
+		changeCount: worktreeChanges?.changes.length ?? 0,
+	});
 
 	// Track whether the container query hides the label, including while resizing.
 	// This is a ref callback rather than a mount effect because the form is
@@ -182,11 +213,13 @@ export const CommitForm: FC<{
 		return () => observer.disconnect();
 	};
 
-	const canCommitOrAmendBase = isDefaultMode && commitTarget !== null && !isCommitOrAmendPending;
+	const canCommitOrAmendBase =
+		isDefaultMode && commitTarget !== null && !isCommitOrAmendPending && !isGenerating;
 	// Without branches there is no target to pick, but the commit creates one, so
 	// it must not be blocked. Amending still needs a commit that already exists.
 	const canCommit =
-		canCommitOrAmendBase || (isDefaultMode && hasNoBranches && !isCommitOrAmendPending);
+		canCommitOrAmendBase ||
+		(isDefaultMode && hasNoBranches && !isCommitOrAmendPending && !isGenerating);
 	const amendTargetCommitId =
 		commitTarget && headInfoIndex
 			? resolveRelativeTo({ headInfoIndex, relativeTo: commitTarget.relativeTo })
@@ -276,8 +309,49 @@ export const CommitForm: FC<{
 
 		createCommit();
 	};
+
+	const generateCommitMessage = async () => {
+		if (!worktreeChanges || isGenerating) return;
+
+		const checkedPaths = projectSlice.selectors.selectCheckedUncommittedFilePaths(
+			store.getState(),
+			projectId,
+		);
+		const changes = changesSelectedForCommit(worktreeChanges.changes, checkedPaths);
+		if (changes.length === 0) return;
+
+		setIsGenerating(true);
+		try {
+			const [settings, patches] = await Promise.all([
+				client.ensureQueryData(projectAiSettingsQueryOptions(projectId)),
+				Promise.all(
+					changes.map((change) =>
+						client.ensureQueryData(treeChangeDiffsQueryOptions({ projectId, change })),
+					),
+				),
+			]);
+			const prompt = buildCommitMessagePrompt(settings.commitMessagePrompt, changes, patches);
+			const response = await streamCommitMessage(
+				(onToken) => window.lite.streamAiResponse(COMMIT_MESSAGE_SYSTEM_PROMPT, prompt, onToken),
+				(value) => {
+					if (commitTextareaRef.current) commitTextareaRef.current.value = value;
+				},
+			);
+			const message = response.trim();
+			if (commitTextareaRef.current) commitTextareaRef.current.value = message;
+			persistDraftMessage({ projectId, message });
+		} catch (error) {
+			toastManager.add({
+				type: "error",
+				title: "Failed to generate commit message",
+				description: errorMessageForToast(error),
+				priority: "high",
+			});
+		} finally {
+			setIsGenerating(false);
+		}
+	};
 	const commitMenuItems: Array<NativeMenuItem> = [
-		// oxlint-disable-next-line react-hooks-js/refs -- False positive. Ref is only accessed in `onSelect` event handler.
 		nativeMenuItem({
 			label: "Commit",
 			enabled: canCommit,
@@ -338,7 +412,7 @@ export const CommitForm: FC<{
 		},
 		{
 			conflictBehavior: "allow",
-			enabled: isExpanded,
+			enabled: isExpanded && !isGenerating,
 		},
 	);
 
@@ -456,7 +530,7 @@ export const CommitForm: FC<{
 				}}
 				aria-label={commitTextareaLabel}
 				disabled={!isDefaultMode}
-				readOnly={isCommitOrAmendPending}
+				readOnly={isCommitOrAmendPending || isGenerating}
 				placeholder={commitTextareaLabel}
 				defaultValue={draftMessage ?? ""}
 				className={classes("text-13", "text-body", styles.textarea, uiStyles.overlayScrollbar)}
@@ -469,7 +543,7 @@ export const CommitForm: FC<{
 					open={open}
 					onOpenChange={setOpen}
 					onValueChange={selectBranch}
-					disabled={!isDefaultMode || isCommitOrAmendPending || hasNoBranches}
+					disabled={!isDefaultMode || isCommitOrAmendPending || isGenerating || hasNoBranches}
 				>
 					<Tooltip.Root>
 						<Combobox.Trigger
@@ -527,7 +601,11 @@ export const CommitForm: FC<{
 								focusSelectionScope("uncommitted-files");
 							}}
 							render={
-								<Button focusableWhenDisabled disabled={isCommitOrAmendPending} type="button" />
+								<Button
+									focusableWhenDisabled
+									disabled={isCommitOrAmendPending || isGenerating}
+									type="button"
+								/>
 							}
 						>
 							Cancel
@@ -538,6 +616,32 @@ export const CommitForm: FC<{
 							</Tooltip.Positioner>
 						</Tooltip.Portal>
 					</Tooltip.Root>
+
+					{generationButton.visible && (
+						<Tooltip.Root>
+							<Tooltip.Trigger
+								aria-label="Generate commit message"
+								className={getButtonClassName({ variant: "outline", iconOnly: true })}
+								onClick={() => void generateCommitMessage()}
+								render={
+									<Button
+										focusableWhenDisabled
+										type="button"
+										disabled={generationButton.disabled}
+									/>
+								}
+							>
+								<Icon name={isGenerating ? "spinner" : "ai"} />
+							</Tooltip.Trigger>
+							<Tooltip.Portal>
+								<Tooltip.Positioner sideOffset={4}>
+									<Tooltip.Popup render={<TooltipPopup />}>
+										{isGenerating ? "Generating commit message…" : "Generate commit message"}
+									</Tooltip.Popup>
+								</Tooltip.Positioner>
+							</Tooltip.Portal>
+						</Tooltip.Root>
+					)}
 
 					{/* The tooltip is redundant while the label is visible. */}
 					<Tooltip.Root disabled={!commitLabelHidden}>

--- a/apps/lite/ui/src/routes/project/$id/workspace/Settings/Account.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Settings/Account.tsx
@@ -1,7 +1,7 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef, useState, type FC } from "react";
 import type { UserProfile } from "@gitbutler/but-sdk";
-import { userProfileQueryOptions } from "#ui/api/queries.ts";
+import { aiConfigurationQueryOptions, userProfileQueryOptions } from "#ui/api/queries.ts";
 import { getButtonClassName } from "#ui/components/Button.tsx";
 import { classes } from "#ui/components/classes.ts";
 import { errorMessageForToast } from "#ui/errors.ts";
@@ -50,6 +50,7 @@ const SignedOut: FC = () => {
 				signal: controller.signal,
 			});
 			await client.invalidateQueries({ queryKey: userProfileQueryOptions.queryKey });
+			await client.invalidateQueries({ queryKey: aiConfigurationQueryOptions.queryKey });
 		} catch (caught) {
 			// Abandoning is not a failure to report.
 			if (!controller.signal.aborted) setError(errorMessageForToast(caught));
@@ -148,6 +149,7 @@ const SignedIn: FC<{ profile: UserProfile }> = ({ profile }) => {
 		try {
 			await window.lite.deleteUser();
 			await client.invalidateQueries({ queryKey: userProfileQueryOptions.queryKey });
+			await client.invalidateQueries({ queryKey: aiConfigurationQueryOptions.queryKey });
 		} catch (caught) {
 			// Otherwise the click leaves a rejected promise and the account still showing.
 			setError(errorMessageForToast(caught));

--- a/apps/lite/ui/src/routes/project/$id/workspace/Settings/ProjectAi.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Settings/ProjectAi.module.css
@@ -1,0 +1,7 @@
+.prompt {
+	box-sizing: border-box;
+	width: 100%;
+	min-height: 180px;
+	padding: 8px;
+	resize: vertical;
+}

--- a/apps/lite/ui/src/routes/project/$id/workspace/Settings/ProjectAi.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Settings/ProjectAi.tsx
@@ -1,0 +1,72 @@
+import { useSuspenseQueries, useQueryClient } from "@tanstack/react-query";
+import { useState, type FC } from "react";
+import { aiConfigurationQueryOptions } from "#ui/api/queries.ts";
+import { Switch } from "#ui/components/Switch.tsx";
+import {
+	DEFAULT_COMMIT_MESSAGE_PROMPT,
+	projectAiSettingsQueryOptions,
+	writeProjectAiSettings,
+	type ProjectAiSettings,
+} from "#ui/project-ai-settings.ts";
+import styles from "./ProjectAi.module.css";
+import { Row, Section } from "./Section.tsx";
+
+export const ProjectAi: FC<{ projectId: string }> = ({ projectId }) => {
+	const [{ data: configuration }, { data: stored }] = useSuspenseQueries({
+		queries: [aiConfigurationQueryOptions, projectAiSettingsQueryOptions(projectId)],
+	});
+	const client = useQueryClient();
+	const [prompt, setPrompt] = useState(stored.commitMessagePrompt);
+
+	const save = (update: Partial<ProjectAiSettings>) => {
+		const settings = {
+			...(client.getQueryData(projectAiSettingsQueryOptions(projectId).queryKey) ?? stored),
+			...update,
+		};
+		writeProjectAiSettings(projectId, settings);
+		client.setQueryData(projectAiSettingsQueryOptions(projectId).queryKey, settings);
+	};
+	const savePrompt = () => {
+		const commitMessagePrompt =
+			prompt.trim().length > 0 ? prompt.trim() : DEFAULT_COMMIT_MESSAGE_PROMPT;
+		setPrompt(commitMessagePrompt);
+		save({ commitMessagePrompt });
+	};
+
+	return (
+		<Section>
+			<Row
+				label="Commit message generation"
+				labelId="project-ai-enabled"
+				hint={
+					configuration.isConfigured
+						? "Sends selected file diffs to the configured provider when you generate a message."
+						: "Configure credentials for a provider under Application → AI first."
+				}
+			>
+				<Switch
+					aria-labelledby="project-ai-enabled"
+					checked={stored.enabled && configuration.isConfigured}
+					disabled={!configuration.isConfigured}
+					onCheckedChange={(enabled) => save({ enabled })}
+				/>
+			</Row>
+
+			{stored.enabled && configuration.isConfigured && (
+				<Row
+					label="Commit prompt"
+					htmlFor="project-ai-commit-prompt"
+					hint="The selected file diffs are appended automatically."
+				>
+					<textarea
+						id="project-ai-commit-prompt"
+						className={styles.prompt}
+						value={prompt}
+						onChange={(event) => setPrompt(event.currentTarget.value)}
+						onBlur={savePrompt}
+					/>
+				</Row>
+			)}
+		</Section>
+	);
+};

--- a/apps/lite/ui/src/routes/project/$id/workspace/Settings/ProjectAi.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Settings/ProjectAi.tsx
@@ -57,6 +57,7 @@ export const ProjectAi: FC<{ projectId: string }> = ({ projectId }) => {
 					label="Commit prompt"
 					htmlFor="project-ai-commit-prompt"
 					hint="The selected file diffs are appended automatically."
+					stacked
 				>
 					<textarea
 						id="project-ai-commit-prompt"

--- a/apps/lite/ui/src/routes/project/$id/workspace/Settings/Section.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Settings/Section.module.css
@@ -34,6 +34,19 @@
 	justify-content: space-between;
 }
 
+.stacked {
+	& > .label,
+	& > .control,
+	& > .hint {
+		grid-column: 1 / -1;
+	}
+
+	& > .control {
+		grid-row: 3;
+		justify-content: stretch;
+	}
+}
+
 .label {
 	color: var(--text-1);
 	text-wrap: pretty;

--- a/apps/lite/ui/src/routes/project/$id/workspace/Settings/Section.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Settings/Section.tsx
@@ -20,6 +20,8 @@ export const Section: FC<SectionProps> = (p) => (
 
 type RowProps = {
 	label: string;
+	/** Places the control below the label and hint, spanning the row. */
+	stacked?: boolean;
 	/** Ties the label to a native control. Composite widgets pass `labelId` instead. */
 	htmlFor?: string;
 	/** Names the label so a composite widget can point `aria-labelledby` at it. */
@@ -35,7 +37,7 @@ type RowProps = {
  * label is not always a `<label>`.
  */
 export const Row: FC<RowProps> = (p) => (
-	<div className={styles.row}>
+	<div className={classes(styles.row, p.stacked && styles.stacked)}>
 		{p.htmlFor === undefined ? (
 			<span id={p.labelId} className={classes("text-semibold", styles.label)}>
 				{p.label}

--- a/apps/lite/ui/src/routes/project/$id/workspace/Settings/Settings.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Settings/Settings.tsx
@@ -16,6 +16,7 @@ import { General } from "./General.tsx";
 import { Git } from "./Git.tsx";
 import { Integrations } from "./Integrations.tsx";
 import { Project } from "./Project.tsx";
+import { ProjectAi } from "./ProjectAi.tsx";
 import { ProjectExperimental } from "./ProjectExperimental.tsx";
 import { ProjectGit } from "./ProjectGit.tsx";
 
@@ -31,6 +32,7 @@ const pageContent: Record<SettingsPageKey, FC<{ projectId: string }>> = {
 	"global:git": Git,
 	"global:integrations": Integrations,
 	"project:project": Project,
+	"project:ai": ProjectAi,
 	"project:git": ProjectGit,
 	"project:experimental": ProjectExperimental,
 };

--- a/apps/lite/ui/src/routes/project/$id/workspace/Settings/pages.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Settings/pages.ts
@@ -28,6 +28,7 @@ export const settingsPages = [
 	{ key: "global:git", label: "Git", icon: "branch" },
 	{ key: "global:integrations", label: "Integrations", icon: "globe" },
 	{ key: "project:project", label: "Project", icon: "workbench" },
+	{ key: "project:ai", label: "AI", icon: "ai" },
 	{ key: "project:git", label: "Git", icon: "branch" },
 	{ key: "project:experimental", label: "Experimental", icon: "danger" },
 ] as const satisfies ReadonlyArray<SettingsPage>;

--- a/crates/but-llm/src/anthropic.rs
+++ b/crates/but-llm/src/anthropic.rs
@@ -11,8 +11,8 @@ use schemars::{JsonSchema, schema_for};
 use serde::de::DeserializeOwned;
 
 use crate::{
-    AI_ANTHROPIC_SECRET_HANDLE, StreamToolCallResult, ToolCall, ToolCallContent,
-    ToolResponseContent, chat::ChatMessage, client::LLMClient,
+    AI_ANTHROPIC_SECRET_HANDLE, GITBUTLER_ACCESS_TOKEN_HANDLE, StreamToolCallResult, ToolCall,
+    ToolCallContent, ToolResponseContent, chat::ChatMessage, client::LLMClient,
 };
 
 const ANTHROPIC_API_BASE: &str = "https://api.anthropic.com/v1";
@@ -134,7 +134,7 @@ impl AnthropicProvider {
         self.credentials.0.clone()
     }
     fn gitbutler_proxied_creds() -> Result<(CredentialsKind, Sensitive<String>)> {
-        let creds = secret::retrieve("gitbutler_access_token", secret::Namespace::BuildKind)?
+        let creds = secret::retrieve(GITBUTLER_ACCESS_TOKEN_HANDLE, secret::Namespace::BuildKind)?
             .ok_or(anyhow::anyhow!(
                 "No GitButler token available. Log-in to use the GitButler Anthropic provider"
             ))?;

--- a/crates/but-llm/src/config.rs
+++ b/crates/but-llm/src/config.rs
@@ -19,6 +19,7 @@ pub const AI_OPENROUTER_ENDPOINT_KEY: &str = "gitbutler.aiOpenRouterEndpoint";
 pub const AI_OPENAI_SECRET_HANDLE: &str = "aiOpenAIKey";
 pub const AI_ANTHROPIC_SECRET_HANDLE: &str = "aiAnthropicKey";
 pub const AI_OPENROUTER_SECRET_HANDLE: &str = "aiOpenRouterKey";
+pub const GITBUTLER_ACCESS_TOKEN_HANDLE: &str = "gitbutler_access_token";
 
 pub const DEFAULT_OPENAI_MODEL: &str = "gpt-5.4-nano";
 pub const DEFAULT_ANTHROPIC_MODEL: &str = "claude-haiku-4-5";
@@ -190,6 +191,30 @@ impl AiConfiguration {
             LLMProviderKind::OpenRouter => {}
         }
         Ok(())
+    }
+
+    /// Return whether the active provider has valid settings and its required credentials.
+    pub fn is_configured(
+        &self,
+        has_openai_key: bool,
+        has_anthropic_key: bool,
+        has_gitbutler_token: bool,
+    ) -> bool {
+        if self.validate_active().is_err() {
+            return false;
+        }
+        match self.provider {
+            LLMProviderKind::OpenAi => match self.openai.key_option {
+                CredentialsKeyOption::BringYourOwn => has_openai_key,
+                CredentialsKeyOption::ButlerApi => has_gitbutler_token,
+            },
+            LLMProviderKind::Anthropic => match self.anthropic.key_option {
+                CredentialsKeyOption::BringYourOwn => has_anthropic_key,
+                CredentialsKeyOption::ButlerApi => has_gitbutler_token,
+            },
+            LLMProviderKind::Ollama | LLMProviderKind::LMStudio => true,
+            LLMProviderKind::OpenRouter => false,
+        }
     }
 
     pub fn apply(&self, config: &mut gix::config::File) -> Result<()> {
@@ -463,6 +488,43 @@ mod tests {
         assert!(
             configuration.validate().is_err(),
             "own-key endpoints must remain valid URLs"
+        );
+    }
+
+    #[test]
+    fn configured_requires_the_active_providers_credentials() {
+        let mut config = AiConfiguration::default();
+        assert!(
+            !config.is_configured(false, false, false),
+            "GitButler-proxied OpenAI needs an account token"
+        );
+        assert!(
+            config.is_configured(false, false, true),
+            "an account token configures GitButler-proxied OpenAI"
+        );
+
+        config.openai.key_option = CredentialsKeyOption::BringYourOwn;
+        assert!(
+            config.is_configured(true, false, false),
+            "BYOK OpenAI needs only its own key"
+        );
+
+        config.provider = LLMProviderKind::Anthropic;
+        config.anthropic.key_option = CredentialsKeyOption::BringYourOwn;
+        assert!(
+            config.is_configured(false, true, false),
+            "BYOK Anthropic needs its own key"
+        );
+
+        config.provider = LLMProviderKind::Ollama;
+        assert!(
+            config.is_configured(false, false, false),
+            "a valid local provider needs no credentials"
+        );
+        config.ollama.endpoint.clear();
+        assert!(
+            !config.is_configured(false, false, false),
+            "an invalid local provider is not configured"
         );
     }
 }

--- a/crates/but-llm/src/openai.rs
+++ b/crates/but-llm/src/openai.rs
@@ -7,7 +7,7 @@ use schemars::JsonSchema;
 use serde::de::DeserializeOwned;
 
 use crate::{
-    AI_OPENAI_SECRET_HANDLE,
+    AI_OPENAI_SECRET_HANDLE, GITBUTLER_ACCESS_TOKEN_HANDLE,
     chat::ChatMessage,
     client::LLMClient,
     openai_utils::{
@@ -80,7 +80,7 @@ impl OpenAiProvider {
     }
 
     fn gitbutler_proxied_creds() -> Result<(CredentialsKind, Sensitive<String>)> {
-        let creds = secret::retrieve("gitbutler_access_token", secret::Namespace::BuildKind)?
+        let creds = secret::retrieve(GITBUTLER_ACCESS_TOKEN_HANDLE, secret::Namespace::BuildKind)?
             .ok_or(anyhow::anyhow!(
                 "No GitButler token available. Log-in to use the GitButler OpenAI provider"
             ))?;

--- a/crates/but-napi/src/ai.rs
+++ b/crates/but-napi/src/ai.rs
@@ -5,8 +5,8 @@ use but_core::git_config::edit_config;
 use but_llm::{
     AI_ANTHROPIC_SECRET_HANDLE, AI_OPENAI_SECRET_HANDLE, AI_OPENROUTER_SECRET_HANDLE,
     AiConfiguration as DomainConfiguration, AnthropicConfiguration, ChatMessage,
-    CredentialsKeyOption, LLMProvider, LLMProviderKind, LmStudioConfiguration, OllamaConfiguration,
-    OpenAiConfiguration, clear_ai_configuration,
+    CredentialsKeyOption, GITBUTLER_ACCESS_TOKEN_HANDLE, LLMProvider, LLMProviderKind,
+    LmStudioConfiguration, OllamaConfiguration, OpenAiConfiguration, clear_ai_configuration,
 };
 use but_secret::{Sensitive, secret};
 use napi::{
@@ -35,6 +35,7 @@ pub struct AiConfiguration {
     pub ollama_model: String,
     pub lmstudio_endpoint: String,
     pub lmstudio_model: String,
+    pub is_configured: bool,
 }
 
 #[derive(Clone)]
@@ -57,31 +58,42 @@ pub struct AiConfigurationUpdate {
     pub lmstudio_model: String,
 }
 
-fn has_secret(handle: &str) -> Result<bool> {
-    Ok(secret::retrieve(handle, secret::Namespace::Global)?.is_some())
+fn has_secret(handle: &str, namespace: secret::Namespace) -> Result<bool> {
+    Ok(secret::retrieve(handle, namespace)?.is_some())
 }
 
 fn get_configuration() -> Result<AiConfiguration> {
     let config = gix::config::File::from_globals()?;
     let configuration = DomainConfiguration::from_git_config(&config)?;
 
+    let openai_has_api_key = has_secret(AI_OPENAI_SECRET_HANDLE, secret::Namespace::Global)?;
+    let anthropic_has_api_key = has_secret(AI_ANTHROPIC_SECRET_HANDLE, secret::Namespace::Global)?;
+    let has_gitbutler_token =
+        has_secret(GITBUTLER_ACCESS_TOKEN_HANDLE, secret::Namespace::BuildKind)?;
+    let is_configured = configuration.is_configured(
+        openai_has_api_key,
+        anthropic_has_api_key,
+        has_gitbutler_token,
+    );
+
     Ok(AiConfiguration {
         provider: configuration.provider.as_git_config_value().into(),
         openai_key_option: configuration.openai.key_option.as_git_config_value().into(),
         openai_model: configuration.openai.model,
         openai_custom_endpoint: configuration.openai.custom_endpoint,
-        openai_has_api_key: has_secret(AI_OPENAI_SECRET_HANDLE)?,
+        openai_has_api_key,
         anthropic_key_option: configuration
             .anthropic
             .key_option
             .as_git_config_value()
             .into(),
         anthropic_model: configuration.anthropic.model,
-        anthropic_has_api_key: has_secret(AI_ANTHROPIC_SECRET_HANDLE)?,
+        anthropic_has_api_key,
         ollama_endpoint: configuration.ollama.endpoint,
         ollama_model: configuration.ollama.model,
         lmstudio_endpoint: configuration.lmstudio.endpoint,
         lmstudio_model: configuration.lmstudio.model,
+        is_configured,
     })
 }
 
@@ -160,8 +172,8 @@ fn domain_configuration(
 }
 
 fn update_configuration(update: AiConfigurationUpdate) -> Result<AiConfiguration> {
-    let openai_has_key = has_secret(AI_OPENAI_SECRET_HANDLE)?;
-    let anthropic_has_key = has_secret(AI_ANTHROPIC_SECRET_HANDLE)?;
+    let openai_has_key = has_secret(AI_OPENAI_SECRET_HANDLE, secret::Namespace::Global)?;
+    let anthropic_has_key = has_secret(AI_ANTHROPIC_SECRET_HANDLE, secret::Namespace::Global)?;
     validate_update(&update, openai_has_key, anthropic_has_key)?;
 
     if let Some(value) = submitted_key(update.openai_api_key.clone()) {

--- a/packages/but-sdk/src/generated/graph/index.d.ts
+++ b/packages/but-sdk/src/generated/graph/index.d.ts
@@ -1134,6 +1134,7 @@ export interface AiConfiguration {
   ollamaModel: string
   lmstudioEndpoint: string
   lmstudioModel: string
+  isConfigured: boolean
 }
 
 export interface AiConfigurationUpdate {

--- a/packages/but-sdk/src/generated/linear/index.d.ts
+++ b/packages/but-sdk/src/generated/linear/index.d.ts
@@ -1134,6 +1134,7 @@ export interface AiConfiguration {
   ollamaModel: string
   lmstudioEndpoint: string
   lmstudioModel: string
+  isConfigured: boolean
 }
 
 export interface AiConfigurationUpdate {


### PR DESCRIPTION
## 🧢 Changes

- Add project-scoped AI enablement and commit prompt settings in Lite.
- Generate commit messages from the exact selected file patches with streamed output and loading/error states.
- Expose Rust-calculated provider readiness through `AiConfiguration.isConfigured`.

### Visuals

https://github.com/user-attachments/assets/7371bf90-3802-443c-b586-62412f5e17a6

<img width="948" height="439" alt="Screenshot 2026-08-13 at 15 58 13" src="https://github.com/user-attachments/assets/4e81a9a6-a31f-4e88-b080-509a1ea01ebd" />

