### PR TITLE
Add file review marking

### DIFF
--- a/apps/lite/ui/src/api/queries.ts
+++ b/apps/lite/ui/src/api/queries.ts
@@ -31,7 +31,12 @@ type GlobalQueryKey =
  * memoizes an imperative preview: its key carries the operation and changes it
  * was measured against, and nothing refreshes it in place.
  */
-type LocalQueryKey = "commitMessageDraft" | "dryRun" | "prMergeMethod" | "prDraft";
+type LocalQueryKey =
+	| "commitMessageDraft"
+	| "dryRun"
+	| "prMergeMethod"
+	| "prDraft"
+	| "reviewedFiles";
 
 export type QueryKey = ProjectQueryKey | GlobalQueryKey | LocalQueryKey;
 

--- a/apps/lite/ui/src/hotkeys.ts
+++ b/apps/lite/ui/src/hotkeys.ts
@@ -328,6 +328,9 @@ export const diffHotkeys = {
 		hotkey: "Z",
 		meta: { group: "Diff", name: "Fold/unfold file" },
 	},
+	toggleReviewedFile: {
+		hotkey: "R",
+	},
 	toggleDiffStyle: {
 		hotkey: "Mod+B",
 		meta: { group: "Diff", name: "Toggle diff style" },

--- a/apps/lite/ui/src/operands.ts
+++ b/apps/lite/ui/src/operands.ts
@@ -105,7 +105,7 @@ const fileParentIdentityKey = (fp: FileParent): string => {
 	}
 };
 
-const weakFileParentIdentityKey = (fp: FileParent): string => {
+export const weakFileParentIdentityKey = (fp: FileParent): string => {
 	switch (fp._tag) {
 		case "UncommittedChanges":
 			return uncommittedChangesIdentityKey;

--- a/apps/lite/ui/src/reconcile.ts
+++ b/apps/lite/ui/src/reconcile.ts
@@ -13,7 +13,7 @@ import {
 } from "./api/queries.ts";
 import { useParams } from "@tanstack/react-router";
 import { getHeadInfoIndex, type HeadInfoIndex } from "./api/ref-info.ts";
-import { useEffectEvent, useLayoutEffect, useRef } from "react";
+import { useEffect, useEffectEvent, useLayoutEffect, useRef } from "react";
 import { useAppDispatch, useAppSelector } from "./store.ts";
 import { projectSlice } from "./projects/state.ts";
 import {
@@ -23,15 +23,21 @@ import {
 	operandIdentityKey,
 	type FileParent,
 	type Operand,
+	uncommittedChangesFileParent,
+	weakFileParentIdentityKey,
 } from "./operands.ts";
 import { decodeBytes } from "./api/bytes.ts";
 import { hunkContainsHunk } from "./hunk.ts";
 import type { RefInfo, TreeChange } from "@gitbutler/but-sdk";
+import { reviewedFilesQueryOptions, usePruneReviewedFiles } from "./reviewed-files.ts";
 
 /**
- * Reconcile state between Redux and React Query. This hook should be called very high up in the
- * tree so that synchronous dispatches in layout effects don't waste too much work. This hook
- * remains subscribed to any queries that are relevant to the current state.
+ * Reconcile in-memory and persisted client state against current repository data, most notably
+ * between Redux and React Query.
+ *
+ * This hook should be called very high up in the tree so that synchronous dispatches in layout
+ * effects don't waste too much work. This hook remains subscribed to queries relevant to state that
+ * may need reconciliation.
  */
 export const useStateReconciler = (): void => {
 	const { id: projectId } = useParams({ from: "/project/$id/workspace" });
@@ -125,6 +131,11 @@ export const useStateReconciler = (): void => {
 	const checkedUncommittedFiles = checkedFiles.filter(
 		(file) => file.parent._tag === "UncommittedChanges",
 	);
+	const reviewedFilesContextId = weakFileParentIdentityKey(uncommittedChangesFileParent);
+	const { data: reviewedUncommittedFiles } = useQuery(
+		reviewedFilesQueryOptions(projectId, reviewedFilesContextId),
+	);
+	const { mutate: pruneReviewedFiles } = usePruneReviewedFiles();
 	const reconcileCheckedUncommittedFiles = useEffectEvent(
 		(worktreeChangesByPath: Map<string, TreeChange>) => {
 			const invalidated = checkedUncommittedFiles.flatMap((file) =>
@@ -201,13 +212,38 @@ export const useStateReconciler = (): void => {
 	const { data: worktreeChangesByPath } = useQuery({
 		...changesInWorktreeQueryOptions(projectId),
 		select: (data) => new Map(data.changes.map((change) => [change.path, change])),
-		enabled: checkedUncommittedFiles.length > 0,
+		enabled:
+			checkedUncommittedFiles.length > 0 ||
+			(reviewedUncommittedFiles && reviewedUncommittedFiles.size > 0),
 	});
+
 	useLayoutEffect(() => {
 		if (!worktreeChangesByPath) return;
 
 		reconcileCheckedUncommittedFiles(worktreeChangesByPath);
 	}, [worktreeChangesByPath]);
+
+	const pruneReviewedUncommittedFiles = useEffectEvent(
+		(worktreeChangesByPath: Map<string, TreeChange>) => {
+			if (!reviewedUncommittedFiles) return;
+
+			const stalePaths = new Set(reviewedUncommittedFiles.keys()).difference(
+				new Set(worktreeChangesByPath.keys()),
+			);
+			if (stalePaths.size === 0) return;
+
+			pruneReviewedFiles({
+				projectId,
+				contextId: reviewedFilesContextId,
+				paths: stalePaths,
+			});
+		},
+	);
+	useEffect(() => {
+		if (!worktreeChangesByPath) return;
+
+		pruneReviewedUncommittedFiles(worktreeChangesByPath);
+	}, [reviewedUncommittedFiles, worktreeChangesByPath]);
 
 	const checkedCommitFileCommitIds = new Set(
 		checkedCommitFiles.map((file) => file.parent.commitId),

--- a/apps/lite/ui/src/reviewed-files.ts
+++ b/apps/lite/ui/src/reviewed-files.ts
@@ -1,0 +1,110 @@
+import { queryOptions, useMutation } from "@tanstack/react-query";
+import * as idb from "idb-keyval";
+
+/** Positively reviewed diff versions keyed by file path within one file-parent context. */
+export type ReviewedFileVersions = Map<string, Set<number>>;
+
+type ReviewedFile = { path: string; version: number };
+
+const reviewedFilesKey = (projectId: string, contextId: string): string =>
+	`reviewed_files:v1:${projectId}:${contextId}`;
+
+export const reviewedFilesQueryOptions = (projectId: string, contextId: string) =>
+	queryOptions({
+		queryKey: ["reviewedFiles", projectId, contextId],
+		queryFn: async (): Promise<ReviewedFileVersions> =>
+			(await idb.get<ReviewedFileVersions>(reviewedFilesKey(projectId, contextId))) ?? new Map(),
+	});
+
+const updateReviewedFileVersions = (
+	reviewedFiles: ReviewedFileVersions,
+	files: Array<ReviewedFile>,
+	reviewed: boolean,
+): ReviewedFileVersions => {
+	const next = new Map(reviewedFiles);
+	for (const { path, version } of files) {
+		const versions = next.get(path);
+		if (reviewed) {
+			if (!versions?.has(version)) next.set(path, new Set(versions).add(version));
+			continue;
+		}
+
+		if (!versions?.has(version)) continue;
+		const nextVersions = new Set(versions);
+		nextVersions.delete(version);
+		if (nextVersions.size === 0) next.delete(path);
+		else next.set(path, nextVersions);
+	}
+
+	return next;
+};
+
+export type SetFilesReviewedInput = {
+	projectId: string;
+	contextId: string;
+	files: Array<ReviewedFile>;
+	reviewed: boolean;
+};
+
+export const useSetFilesReviewed = () =>
+	useMutation({
+		mutationFn: async ({ projectId, contextId, files, reviewed }: SetFilesReviewedInput) =>
+			idb.update<ReviewedFileVersions>(reviewedFilesKey(projectId, contextId), (reviewedFiles) =>
+				updateReviewedFileVersions(reviewedFiles ?? new Map(), files, reviewed),
+			),
+		onMutate: (input, ctx) => {
+			const queryKey = reviewedFilesQueryOptions(input.projectId, input.contextId).queryKey;
+			const previous = ctx.client.getQueryData<ReviewedFileVersions>(queryKey);
+
+			ctx.client.setQueryData(queryKey, (reviewedFiles: ReviewedFileVersions | undefined) =>
+				updateReviewedFileVersions(reviewedFiles ?? new Map(), input.files, input.reviewed),
+			);
+
+			return previous;
+		},
+		onError: (_error, input, previous, ctx) => {
+			ctx.client.setQueryData(
+				reviewedFilesQueryOptions(input.projectId, input.contextId).queryKey,
+				previous ?? new Map(),
+			);
+		},
+	});
+
+const pruneReviewedFiles = (
+	reviewedFiles: ReviewedFileVersions,
+	paths: Iterable<string>,
+): ReviewedFileVersions => {
+	const next = new Map(reviewedFiles);
+	for (const path of paths) next.delete(path);
+	return next;
+};
+
+type PruneReviewedFilesInput = {
+	projectId: string;
+	contextId: string;
+	paths: Iterable<string>;
+};
+
+export const usePruneReviewedFiles = () =>
+	useMutation({
+		mutationFn: async ({ projectId, contextId, paths }: PruneReviewedFilesInput) =>
+			idb.update<ReviewedFileVersions>(reviewedFilesKey(projectId, contextId), (reviewedFiles) =>
+				pruneReviewedFiles(reviewedFiles ?? new Map(), paths),
+			),
+		onMutate: (input, ctx) => {
+			const queryKey = reviewedFilesQueryOptions(input.projectId, input.contextId).queryKey;
+			const previous = ctx.client.getQueryData<ReviewedFileVersions>(queryKey);
+
+			ctx.client.setQueryData(queryKey, (reviewedFiles: ReviewedFileVersions | undefined) =>
+				pruneReviewedFiles(reviewedFiles ?? new Map(), input.paths),
+			);
+
+			return previous;
+		},
+		onError: (_error, input, previous, ctx) => {
+			ctx.client.setQueryData(
+				reviewedFilesQueryOptions(input.projectId, input.contextId).queryKey,
+				previous ?? new Map(),
+			);
+		},
+	});

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
@@ -274,7 +274,7 @@
 
 .fileHeader {
 	display: grid;
-	grid-template-columns: auto 1fr auto auto auto;
+	grid-template-columns: auto 1fr auto auto auto auto;
 	column-gap: 12px;
 	align-items: center;
 	justify-content: space-between;
@@ -311,6 +311,29 @@
 
 .fileHeaderActions {
 	display: flex;
+}
+
+.fileReview {
+	--button-height: 22px;
+	--button-gap: 6px;
+}
+
+.fileReviewIndicator {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 14px;
+	height: 14px;
+	border-radius: var(--radius-xs);
+	background-color: var(--bg-1);
+	box-shadow: inset 0 0 0 1px var(--border-2);
+
+	[aria-pressed="true"] &,
+	[aria-pressed="mixed"] & {
+		background-color: var(--fill-pop-bg);
+		box-shadow: inset 0 0 0 1px var(--fill-pop-bg);
+		color: var(--fill-pop-fg);
+	}
 }
 
 .filePath {

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -33,6 +33,7 @@ import {
 	type HunkOperand,
 	type Operand,
 	weakCommitIdentityKey,
+	weakFileParentIdentityKey,
 } from "#ui/operands.ts";
 import type { BranchTab } from "#ui/projects/project.ts";
 import { projectSlice } from "#ui/projects/state.ts";
@@ -151,11 +152,18 @@ import {
 	type DiffView,
 	getDiffView,
 	hunkOperandIdentityKey,
+	prepareDiffFiles,
 	withoutFoldedHunks,
 } from "./diff-view.ts";
 import { DiffMinimap } from "./DiffMinimap.tsx";
 import { getMinimapFiles, measureWrapColumns, type MinimapSelection } from "./diff-minimap.ts";
 import { checkedRange, navigationIndexRange } from "#ui/checking.ts";
+import {
+	type ReviewedFileVersions,
+	reviewedFilesQueryOptions,
+	type SetFilesReviewedInput,
+	useSetFilesReviewed,
+} from "#ui/reviewed-files.ts";
 
 export type DiffViewerHandle = CodeViewHandle<Annotation>;
 
@@ -166,6 +174,12 @@ type PanelId = "files-panel" | "diff-panel";
 const EMPTY_ANNOTATIONS_BY_PATH: LocalAnnotationsByPath = new Map();
 const EMPTY_CONFLICTS: Array<ConflictedFile> = [];
 const EMPTY_MANUAL: Array<ManualConflict> = [];
+
+const isInteractiveElement = (target: EventTarget): boolean =>
+	target instanceof Element &&
+	target.matches(
+		'a, button, input, select, textarea, [contenteditable]:not([contenteditable="false"])',
+	);
 
 const getCommitFileRowItems = ({
 	commitDetails,
@@ -259,6 +273,10 @@ const DiffContents: FC<{
 	diffBackgrounds?: GUISettings["diffBackground"];
 	diffOverflow?: GUISettings["diffOverflow"];
 	diffStyle?: GUISettings["diffStyle"];
+	reviewedFiles: ReviewedFileVersions;
+	manualCollapseByItem: Map<string, boolean>;
+	setManualCollapse: (itemId: string, collapsed: boolean | undefined) => void;
+	setFilesReviewed: (input: SetFilesReviewedInput) => void;
 	viewerRef: RefObject<CodeViewHandle<Annotation> | null>;
 	didScrollToViaFileRef: RefObject<boolean>;
 }> = ({
@@ -272,11 +290,13 @@ const DiffContents: FC<{
 	diffBackgrounds,
 	diffOverflow,
 	diffStyle,
+	reviewedFiles,
+	manualCollapseByItem,
+	setManualCollapse,
+	setFilesReviewed,
 	viewerRef,
 	didScrollToViaFileRef,
 }) => {
-	const [collapsedItems, setCollapsedItems] = useState<Set<string>>(new Set());
-	const visibleNavigationIndex = withoutFoldedHunks(navigationIndex, hunkByKey, collapsedItems);
 	const newFocusableAnnotationIdRef = useRef<string | null>(null);
 	const dispatch = useAppDispatch();
 	const { mutate: createComment } = useCommentCreate();
@@ -298,6 +318,26 @@ const DiffContents: FC<{
 	const store = useAppStore();
 	const hunkCheckRangeAnchor = useRef<string>(null);
 	const hunkCheckRangeEnd = useRef<string>(null);
+
+	const collapsedItems: Set<string> = new Set(
+		items.flatMap((item) => {
+			const manuallyCollapsed = manualCollapseByItem.get(item.id);
+			if (manuallyCollapsed !== undefined) return manuallyCollapsed ? item.id : [];
+
+			const file = fileByItemId.get(item.id);
+			if (!file) return [];
+
+			const {
+				change: { path },
+				item: { version },
+			} = file;
+			if (version === undefined) return [];
+
+			const reviewedLatestVersion = reviewedFiles.get(path)?.has(version);
+			return reviewedLatestVersion ? item.id : [];
+		}),
+	);
+	const visibleNavigationIndex = withoutFoldedHunks(navigationIndex, hunkByKey, collapsedItems);
 
 	const diffSelection = useAppSelector((state) =>
 		projectSlice.selectors.selectSelectionDiff(state, projectId, visibleNavigationIndex),
@@ -369,17 +409,7 @@ const DiffContents: FC<{
 	});
 
 	function toggleSelectedHunkChecked(event: KeyboardEvent): void {
-		if (
-			diffSelection === null ||
-			event
-				.composedPath()
-				.some(
-					(target) =>
-						target instanceof HTMLElement &&
-						target.hasAttribute("data-gitbutler-diff-gutter-checkbox"),
-				)
-		)
-			return;
+		if (diffSelection === null || event.composedPath().some(isInteractiveElement)) return;
 
 		event.preventDefault();
 		event.stopPropagation();
@@ -427,6 +457,23 @@ const DiffContents: FC<{
 				conflictBehavior: "allow",
 				target: selectionScopeRef,
 				meta: diffHotkeys.toggleFoldFile.meta,
+			},
+		},
+		{
+			hotkey: diffHotkeys.toggleReviewedFile.hotkey,
+			callback: () => {
+				if (!diffSelectionHunk) return;
+
+				const { id, version } = diffSelectionHunk.file.item;
+				if (version === undefined) throw new Error("Diff view item missing version");
+
+				const { path } = diffSelectionHunk.file.change;
+				handleSetReviewed(id, path, version)(!reviewedFiles.get(path)?.has(version));
+			},
+			options: {
+				enabled: hasStoredDiffSelection && !!diffSelectionHunk,
+				conflictBehavior: "allow",
+				target: selectionScopeRef,
 			},
 		},
 		{
@@ -604,16 +651,7 @@ const DiffContents: FC<{
 	const { onPostRender: handleDiffPostRender, portals: diffGutterPortals } =
 		useDiffGutterCheckboxes(handleHunkPostRender, getHunkOperandAtLine, projectId, checkHunk);
 
-	const handleSetCollapsed = (itemId: string) => (collapsed: boolean) => {
-		const s = new Set(collapsedItems);
-
-		if (collapsed) s.add(itemId);
-		else s.delete(itemId);
-
-		setCollapsedItems(s);
-
-		if (!collapsed) return;
-
+	const handOffCollapsedSelection = (itemId: string): void => {
 		// Folding hides the selected hunk's lines; hand the selection to the
 		// file's first hunk, which stands in for the folded file, and keep the
 		// header in view. The stored selection is read off the store rather than
@@ -630,6 +668,23 @@ const DiffContents: FC<{
 		);
 		viewerRef.current?.scrollTo({ type: "item", id: itemId, align: "nearest" });
 	};
+
+	const handleSetCollapsed = (itemId: string) => (collapsed: boolean) => {
+		setManualCollapse(itemId, collapsed);
+		if (collapsed && !collapsedItems.has(itemId)) handOffCollapsedSelection(itemId);
+	};
+
+	const handleSetReviewed =
+		(itemId: string, path: string, version: number) => (reviewed: boolean) => {
+			setFilesReviewed({
+				projectId,
+				contextId: weakFileParentIdentityKey(fileParent),
+				files: [{ path, version }],
+				reviewed,
+			});
+			setManualCollapse(itemId, undefined);
+			if (reviewed && !collapsedItems.has(itemId)) handOffCollapsedSelection(itemId);
+		};
 
 	// We must change the version for updates to the collapsed property to be respected. The versions
 	// should be as stable as possible, collapsed or not, for performance. The selected flag is
@@ -665,9 +720,20 @@ const DiffContents: FC<{
 					if (item.type === "file") throw new Error("Only diff items may be rendered");
 
 					const file = fileByItemId.get(item.id);
-
 					// CodeView may briefly hold onto stale snapshots of our data.
 					if (!file) return <div style={{ height: codeViewItemMetrics.diffHeaderHeight }} />;
+
+					const { version } = file.item;
+					if (version === undefined) throw new Error("Diff view item missing version");
+
+					const allReviewedVersions = reviewedFiles.get(file.change.path);
+					const hasReviewedThisVersion = !!allReviewedVersions?.has(version);
+					const reviewState =
+						allReviewedVersions !== undefined
+							? hasReviewedThisVersion
+								? "reviewed"
+								: "changed"
+							: null;
 
 					return (
 						<DiffFileHeader
@@ -677,8 +743,10 @@ const DiffContents: FC<{
 							change={file.change}
 							hasDiff={item.fileDiff.hunks.length !== 0}
 							collapsed={item.collapsed ?? false}
+							reviewState={reviewState}
 							selected={item.id === selectedFoldedFileId}
 							setCollapsed={handleSetCollapsed(item.id)}
+							setReviewed={handleSetReviewed(item.id, file.change.path, version)}
 						/>
 					);
 				}}
@@ -830,9 +898,11 @@ type DiffFileHeaderProps = {
 	change: TreeChange;
 	hasDiff: boolean;
 	collapsed: boolean;
+	reviewState: "reviewed" | "changed" | null;
 	/** Whether the folded file's stand-in hunk holds the diff selection. */
 	selected: boolean;
 	setCollapsed: (collapsed: boolean) => void;
+	setReviewed: (reviewed: boolean) => void;
 };
 
 const DiffFileHeader: FC<DiffFileHeaderProps> = (p) => {
@@ -848,6 +918,12 @@ const DiffFileHeader: FC<DiffFileHeaderProps> = (p) => {
 	const fileName = lastSepIdx !== -1 ? p.change.path.slice(lastSepIdx + 1) : p.change.path;
 
 	const collapseLabel = p.collapsed ? "Unfold" : "Fold";
+	const reviewLabel =
+		p.reviewState === "reviewed"
+			? "Reviewed"
+			: p.reviewState === "changed"
+				? "Needs review"
+				: "Not reviewed";
 
 	return (
 		<OperationSourceC projectId={p.projectId} source={fileOperand(p.operand)} outline="inside">
@@ -885,6 +961,22 @@ const DiffFileHeader: FC<DiffFileHeaderProps> = (p) => {
 					{fileName}
 					{directoryPath !== null && <span className={styles.pathInit}>{directoryPath}</span>}
 				</h4>
+				<button
+					type="button"
+					aria-pressed={p.reviewState === "changed" ? "mixed" : p.reviewState === "reviewed"}
+					className={classes(
+						getButtonClassName({ variant: "outline", size: "small" }),
+						styles.fileReview,
+					)}
+					onClick={() => p.setReviewed(p.reviewState !== "reviewed")}
+				>
+					<span className={styles.fileReviewIndicator} aria-hidden="true">
+						{p.reviewState !== null && (
+							<Icon size={10} name={p.reviewState === "reviewed" ? "tick" : "minus"} />
+						)}
+					</span>
+					{reviewLabel}
+				</button>
 				<ChangeTypeBadge type={p.item.fileDiff.type} />
 				<span>
 					<span className={styles.fileDiffAdded}>+{p.item.fileDiff.additionLines.length}</span>{" "}
@@ -1102,6 +1194,18 @@ const Diff: FC<{
 	const localAnnotationFormId = useId();
 	const selectionScopeRef = useRef<HTMLDivElement>(null);
 	const dispatch = useAppDispatch();
+	const { mutate: setFilesReviewed } = useSetFilesReviewed();
+	const [manualCollapseByItem, setManualCollapseByItem] = useState<Map<string, boolean>>(new Map());
+	const setManualCollapse = (itemId: string, collapsed: boolean | undefined): void => {
+		setManualCollapseByItem((current) => {
+			if (collapsed === current.get(itemId)) return current;
+
+			const next = new Map(current);
+			if (collapsed === undefined) next.delete(itemId);
+			else next.set(itemId, collapsed);
+			return next;
+		});
+	};
 	// One mutation for the batch bar and every card, so `isPending` means "a
 	// resolution is in flight" rather than "this one's is". Each apply rewrites
 	// the commit, and a second started meanwhile would address the id it replaced.
@@ -1165,6 +1269,10 @@ const Diff: FC<{
 			),
 		[selection],
 	);
+	const reviewedFilesContextId = weakFileParentIdentityKey(fileParent);
+	const { data: reviewedFiles } = useSuspenseQuery(
+		reviewedFilesQueryOptions(projectId, reviewedFilesContextId),
+	);
 
 	// Eagerly fetch all diffs regardless of unidiff setting, both for UX and for the total line
 	// stats.
@@ -1192,22 +1300,36 @@ const Diff: FC<{
 	const shownFileIndex = renderAllFiles
 		? null
 		: changes.findIndex((change) => change.path === activeFilePath);
+	const preparedDiffFiles = useMemo(
+		() => prepareDiffFiles({ fileParent, changes, treeChangeDiffs }),
+		[fileParent, changes, treeChangeDiffs],
+	);
 
 	const diffViewSansAnno = useMemo(
 		() =>
-			getDiffView({
-				fileParent,
-				changes:
-					shownFileIndex === null ? changes : changes.slice(shownFileIndex, shownFileIndex + 1),
-				treeChangeDiffs:
-					shownFileIndex === null
-						? treeChangeDiffs
-						: treeChangeDiffs.slice(shownFileIndex, shownFileIndex + 1),
-			}),
-		[fileParent, shownFileIndex, changes, treeChangeDiffs],
+			getDiffView(
+				shownFileIndex === null
+					? preparedDiffFiles
+					: preparedDiffFiles.slice(shownFileIndex, shownFileIndex + 1),
+			),
+		[shownFileIndex, preparedDiffFiles],
 	);
 
 	const diffView = withAnnotations(diffViewSansAnno, annotationsByPath);
+
+	const allFilesReviewed =
+		preparedDiffFiles.length > 0 &&
+		preparedDiffFiles.every(({ change, version }) => reviewedFiles.get(change.path)?.has(version));
+
+	const toggleAllFilesReviewed = (): void => {
+		setManualCollapseByItem(new Map());
+		setFilesReviewed({
+			projectId,
+			contextId: reviewedFilesContextId,
+			files: preparedDiffFiles.map(({ change, version }) => ({ path: change.path, version })),
+			reviewed: !allFilesReviewed,
+		});
+	};
 
 	// The diff panel resolves this selection for the viewer; the ruler wants it in
 	// file line numbers, which is what the hunk's own range already holds.
@@ -1297,25 +1419,16 @@ const Diff: FC<{
 		() =>
 			minimapShown
 				? getMinimapFiles({
-						fileParent,
-						changes: shownIndex < 0 ? changes : changes.slice(shownIndex, shownIndex + 1),
-						treeChangeDiffs:
-							shownIndex < 0 ? treeChangeDiffs : treeChangeDiffs.slice(shownIndex, shownIndex + 1),
+						files:
+							shownIndex < 0
+								? preparedDiffFiles
+								: preparedDiffFiles.slice(shownIndex, shownIndex + 1),
 						diffStyle,
 						tabSize,
 						wrapColumns,
 					})
 				: [],
-		[
-			minimapShown,
-			shownIndex,
-			fileParent,
-			changes,
-			treeChangeDiffs,
-			diffStyle,
-			tabSize,
-			wrapColumns,
-		],
+		[minimapShown, shownIndex, preparedDiffFiles, diffStyle, tabSize, wrapColumns],
 	);
 
 	useHotkeys([
@@ -1447,6 +1560,13 @@ const Diff: FC<{
 						)}
 
 						<Toolbar.Root aria-label="Diff controls" className={styles.diffControls}>
+							<Toolbar.Button
+								className={getButtonClassName({ variant: "outline" })}
+								disabled={preparedDiffFiles.length === 0}
+								onClick={toggleAllFilesReviewed}
+							>
+								{allFilesReviewed ? "Mark all unreviewed" : "Mark all reviewed"}
+							</Toolbar.Button>
 							<ToggleGroupStyles>
 								<Toolbar.Button
 									render={
@@ -1516,6 +1636,10 @@ const Diff: FC<{
 								diffBackgrounds={diffSettings?.diffBackground}
 								diffOverflow={diffSettings?.diffOverflow}
 								diffStyle={diffStyle}
+								reviewedFiles={reviewedFiles}
+								manualCollapseByItem={manualCollapseByItem}
+								setManualCollapse={setManualCollapse}
+								setFilesReviewed={setFilesReviewed}
 								selectionScopeRef={selectionScopeRef}
 								viewerRef={viewerRef}
 								didScrollToViaFileRef={didScrollToViaFileRef}

--- a/apps/lite/ui/src/routes/project/$id/workspace/DiffGutterPortals.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DiffGutterPortals.tsx
@@ -55,7 +55,6 @@ const HunkCheckboxes: FC<{
 				p.onCheck({ operand: p.operand, shiftKey });
 			}}
 			aria-label="Select hunk"
-			data-gitbutler-diff-gutter-checkbox=""
 			className={styles.checkbox}
 		/>
 	));

--- a/apps/lite/ui/src/routes/project/$id/workspace/diff-minimap.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/diff-minimap.ts
@@ -1,13 +1,12 @@
 import type { LocalAnnotationsByPath } from "#ui/annotation.ts";
-import { weakFileIdentityKey, type FileParent } from "#ui/operands.ts";
 import type { GUISettings } from "#electron/settings.ts";
-import type { TreeChange, UnifiedPatch } from "@gitbutler/but-sdk";
 import type { CodeView } from "@pierre/diffs";
 import {
 	type Annotation,
 	codeViewItemMetrics,
 	codeViewLayout,
-	parseChangeDiff,
+	parsePreparedDiffFile,
+	type PreparedDiffFile,
 } from "./diff-view.ts";
 
 /**
@@ -187,27 +186,23 @@ const pairSplitRows = (deletions: RunMetrics, additions: RunMetrics): void => {
  * separator bar — so a change's offset is a sum of whole rows and bars rather
  * than a share of the file's line count.
  *
- * Item IDs are derived the same way as in `getDiffView` rather than read back
- * off it, so the minimap doesn't inherit that view's selection-driven churn.
+ * Item IDs and synthesized patches come from the same prepared files as the
+ * diff view, avoiding another versioning pass.
  */
 export const getMinimapFiles = ({
-	fileParent,
-	changes,
-	treeChangeDiffs,
+	files,
 	diffStyle,
 	tabSize,
 	wrapColumns,
 }: {
-	fileParent: FileParent;
-	changes: Array<TreeChange>;
-	treeChangeDiffs: Array<UnifiedPatch | null>;
+	files: Array<PreparedDiffFile>;
 	diffStyle: GUISettings["diffStyle"];
 	tabSize: number;
 	/** Columns a line gets before it wraps, or null when the viewer scrolls instead. */
 	wrapColumns: number | null;
 }): Array<MinimapFile> => {
-	const changedLines = treeChangeDiffs.reduce(
-		(total, diff) =>
+	const changedLines = files.reduce(
+		(total, { treeChangeDiff: diff }) =>
 			total + (diff?.type === "Patch" ? diff.subject.linesAdded + diff.subject.linesRemoved : 0),
 		0,
 	);
@@ -215,8 +210,9 @@ export const getMinimapFiles = ({
 
 	const split = diffStyle === "split";
 
-	return changes.map((change, changeIndex) => {
-		const { fileDiff } = parseChangeDiff(change, treeChangeDiffs[changeIndex] ?? null);
+	return files.map((file) => {
+		const { change, fileId } = file;
+		const fileDiff = parsePreparedDiffFile(file);
 		const marks: Array<MinimapMark> = [];
 		const anchors: Array<MinimapAnchor> = [];
 		let top = codeViewItemMetrics.diffHeaderHeight;
@@ -331,7 +327,7 @@ export const getMinimapFiles = ({
 		}
 
 		return {
-			itemId: weakFileIdentityKey({ parent: fileParent, path: change.path }),
+			itemId: fileId,
 			path: change.path,
 			contentHeight: top + codeViewItemMetrics.paddingBottom,
 			marks,

--- a/apps/lite/ui/src/routes/project/$id/workspace/diff-view.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/diff-view.ts
@@ -41,10 +41,19 @@ export const codeViewItemMetrics = {
 	paddingBottom: 9,
 } satisfies Partial<VirtualFileMetrics>;
 
-type DiffViewDeps = {
+type PrepareDiffFilesDeps = {
 	fileParent: FileParent;
 	changes: Array<TreeChange>;
 	treeChangeDiffs: Array<UnifiedPatch | null>;
+};
+
+export type PreparedDiffFile = {
+	file: FileOperand;
+	fileId: string;
+	change: TreeChange;
+	treeChangeDiff: UnifiedPatch | null;
+	patch: string;
+	version: number;
 };
 
 export type DiffViewFile = {
@@ -83,19 +92,36 @@ const parseFileDiff = (
 };
 
 /**
- * Parse a change into CodeView's diff shape. Shared with the minimap, which
- * needs the same hunk layout — going through here keeps both on one parse
- * cache entry instead of paying for the patch twice.
+ * Prepare stable file IDs and patch versions once for both review state and
+ * the rendered diff. Parsing remains separate so single-file mode only builds
+ * Pierre's diff shape for the selected file.
  */
-export const parseChangeDiff = (
-	change: TreeChange,
-	patch: UnifiedPatch | null,
-): { version: number; fileDiff: CodeViewDiffItem<Annotation>["fileDiff"] } => {
-	const combined = synthesizeFilePatch(change, patch?.type === "Patch" ? patch.subject.hunks : []);
-	const version = hash(combined);
+export const prepareDiffFiles = ({
+	fileParent,
+	changes,
+	treeChangeDiffs,
+}: PrepareDiffFilesDeps): Array<PreparedDiffFile> =>
+	changes.map((change, index) => {
+		const file: FileOperand = { parent: fileParent, path: change.path };
+		const treeChangeDiff = treeChangeDiffs[index] ?? null;
+		const patch = synthesizeFilePatch(
+			change,
+			treeChangeDiff?.type === "Patch" ? treeChangeDiff.subject.hunks : [],
+		);
 
-	return { version, fileDiff: parseFileDiff(combined, String(version)) };
-};
+		return {
+			file,
+			fileId: weakFileIdentityKey(file),
+			change,
+			treeChangeDiff,
+			patch,
+			version: hash(patch),
+		};
+	});
+
+export const parsePreparedDiffFile = (
+	file: PreparedDiffFile,
+): CodeViewDiffItem<Annotation>["fileDiff"] => parseFileDiff(file.patch, String(file.version));
 
 type DiffFileNavigation = {
 	itemId: string;
@@ -142,7 +168,7 @@ export const getDiffFileNavigation = ({
 };
 
 /** Build relationships between our SDK data and Pierre's view. */
-export const getDiffView = ({ fileParent, changes, treeChangeDiffs }: DiffViewDeps): DiffView => {
+export const getDiffView = (files: Array<PreparedDiffFile>): DiffView => {
 	const navigationIndex: NavigationIndex<HunkOperand> = {
 		items: [],
 		indexByKey: new Map(),
@@ -154,20 +180,13 @@ export const getDiffView = ({ fileParent, changes, treeChangeDiffs }: DiffViewDe
 	const fileByPath = new Map<string, DiffViewFile>();
 	const hunkByKey = new Map<string, DiffViewHunk>();
 
-	for (const [ci, change] of changes.entries()) {
-		const mdiff = treeChangeDiffs[ci];
-
-		const file: FileOperand = {
-			parent: fileParent,
-			path: change.path,
-		};
-
-		const { version, fileDiff } = parseChangeDiff(change, mdiff ?? null);
+	for (const prepared of files) {
+		const { file, fileId, change, treeChangeDiff: mdiff, version } = prepared;
 		const item: CodeViewDiffItem<Annotation> = {
 			type: "diff",
-			id: weakFileIdentityKey(file),
+			id: fileId,
 			version,
-			fileDiff,
+			fileDiff: parsePreparedDiffFile(prepared),
 		};
 
 		items.push(item);
@@ -176,7 +195,7 @@ export const getDiffView = ({ fileParent, changes, treeChangeDiffs }: DiffViewDe
 			operand: file,
 			item,
 			change,
-			patch: mdiff ?? null,
+			patch: mdiff,
 			hunks: [],
 		};
 


### PR DESCRIPTION
Adds a "mark as reviewed" button to diffs as an experiment.

Many diff viewers offer similar. As a persistent alternative to folding it felt missing, both for agent and PR review.

Rather than making it a boolean, I've derived a third state which is "needs review", meaning roughly that we've reviewed this file in this context before but not this version of it.

For a potential future more ambitious version of this feature, consider also interdiffs.