### PR TITLE
Fix hunkless file selection in all-files diff

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -263,6 +263,7 @@ const withAnnotations = (
 });
 
 const DiffContents: FC<{
+	activeFileItemId: string | null;
 	selectionScopeRef: RefObject<HTMLDivElement | null>;
 	onViewerFileSelection: (path: string) => void;
 	fileParent: FileParent;
@@ -279,6 +280,7 @@ const DiffContents: FC<{
 	viewerRef: RefObject<CodeViewHandle<Annotation> | null>;
 	didScrollToViaFileRef: RefObject<boolean>;
 }> = ({
+	activeFileItemId,
 	selectionScopeRef,
 	onViewerFileSelection,
 	fileParent,
@@ -360,11 +362,13 @@ const DiffContents: FC<{
 			: null;
 
 	useLayoutEffect(() => {
-		if (!diffSelectionHunk) return;
+		// The resolved hunk can belong to another file when the active file is hunkless.
+		const itemId = activeFileItemId ?? diffSelectionHunk?.file.item.id;
+		if (itemId === undefined) return;
 
 		viewerRef.current?.scrollTo({
 			type: "item",
-			id: diffSelectionHunk.file.item.id,
+			id: itemId,
 			align: "start",
 			behavior: "instant",
 		});
@@ -1312,6 +1316,10 @@ const Diff: FC<{
 	);
 
 	const diffView = withAnnotations(diffViewSansAnno, annotationsByPath);
+	const activeFileItemId =
+		activeFilePath === null
+			? null
+			: (diffViewSansAnno.fileByPath.get(activeFilePath)?.item.id ?? null);
 
 	const allFilesReviewed =
 		preparedDiffFiles.length > 0 &&
@@ -1621,6 +1629,7 @@ const Diff: FC<{
 							ref={useMergedRefs(selectionScopeRef, diffContentsEl, useAutofocusSelectionScope())}
 						>
 							<DiffContents
+								activeFileItemId={activeFileItemId}
 								onViewerFileSelection={onPassiveFileSelection}
 								fileParent={fileParent}
 								projectId={projectId}

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
@@ -393,7 +393,11 @@ const WorkspacePage: FC = () => {
 
 		if (renderAllFiles) {
 			didScrollToViaFileRef.current = true;
-			viewerRef.current?.scrollTo({
+			const viewer = viewerRef.current?.getInstance();
+			// Details selection is deferred, so the ref may still point at a viewer without this file.
+			if (!viewer?.getItem(itemId)) return;
+
+			viewer.scrollTo({
 				type: "item",
 				id: itemId,
 			});


### PR DESCRIPTION
## What changed

- Prefer the active file as the initial CodeView target when it has no hunks.
- Skip an imperative scroll when the deferred Details view still points to a CodeView that does not contain the selected file.

## Why

Selecting a binary or otherwise hunkless uncommitted file could resolve a hunk from the previously active file. During the deferred Details transition, WorkspacePage could also call scrollTo on the outgoing CodeView, producing an unknown-item warning and leaving the new file off-screen.

## User impact

Hunkless files now open at the correct position in the all-files diff, and the stale CodeView warning is avoided without allowing file selection to bounce back.

## Validation

- pnpm -F @gitbutler/lite check
- Reproduced before and verified after a full Cmd+R reload with a long text file followed by a binary file
- Confirmed the binary file remained selected and visible, the warning was absent, and same-view file selection still scrolled correctly