### PR TITLE
Add `but wt` worktree alias

### DIFF
--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -953,7 +953,7 @@ pub enum Subcommands {
     /// the same time, or for isolating changes in different workspaces.
     ///
     #[cfg(feature = "legacy")]
-    #[clap(hide = true)]
+    #[clap(hide = true, alias = "wt")]
     #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Worktree(worktree::Platform),
 

--- a/crates/but/tests/but/command/worktree.rs
+++ b/crates/but/tests/but/command/worktree.rs
@@ -3,6 +3,20 @@ use snapbox::str;
 
 use crate::utils::Sandbox;
 
+#[test]
+fn wt_alias_lists_worktrees() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+
+    env.but("wt list")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+No worktrees found
+
+"#]]);
+}
+
 /// The typical journey: create an isolated worktree off a workspace branch, do
 /// work there, then squash-integrate the result back into the workspace.
 #[test]


### PR DESCRIPTION
## Context

`but wt` was rejected even though `but worktree` exists as a hidden experimental command. The request was tracked in Linear after migrating from the earlier GitHub issue.

Fixes GB-1832

Linear issue: https://linear.app/gitbutler/issue/GB-1832/but-wt-but-worktree-if-we-still-have-a-worktree-subcommand

Related history: https://github.com/gitbutlerapp/gitbutler/issues/11078

## Change

Add `wt` as a hidden Clap alias for the existing worktree command, with a focused command-level regression test.