### PR TITLE
Avoid exhausting IDs for untracked files

### DIFF
--- a/crates/but/src/id/id_usage.rs
+++ b/crates/but/src/id/id_usage.rs
@@ -83,7 +83,7 @@ impl UintId {
 }
 
 /// A tracker of which [UintId]s have been used.
-#[derive(Default, Debug)]
+#[derive(Clone, Default, Debug)]
 pub(crate) struct IdUsage {
     /// A [UintId] is used if it's in this set.
     uint_ids_used: HashSet<UintId>,
@@ -108,9 +108,34 @@ impl IdUsage {
         Ok(result)
     }
 
+    pub(crate) fn skip_available(&mut self) {
+        self.forward_next_uint_id_to_not_conflict_with_marked();
+        if self.next_uint_id.0 < UintId::LIMIT {
+            self.next_uint_id = UintId(self.next_uint_id.0 + 1);
+        }
+    }
+
     pub(crate) fn forward_next_uint_id_to_not_conflict_with_marked(&mut self) {
         while self.uint_ids_used.remove(&self.next_uint_id) {
             self.next_uint_id = UintId(self.next_uint_id.0 + 1);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn true_exhaustion_remains_an_error() {
+        let mut usage = IdUsage::default();
+        for value in 0..UintId::LIMIT {
+            usage.mark_used(UintId(value));
+        }
+
+        assert_eq!(
+            usage.next_available().unwrap_err().to_string(),
+            "too many IDs"
+        );
     }
 }

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -614,6 +614,7 @@ impl IdMap {
             &uncommitted_short_filenames,
             &commit_id_to_change_id,
         )?;
+        let mut fallback_id_usage = id_usage.clone();
 
         let mut uncommitted_files: BTreeMap<ChangeId, UncommittedFile> = BTreeMap::new();
         for hunks in partitioned_hunks {
@@ -622,9 +623,11 @@ impl IdMap {
             // Ensure that uncommitted files do not collide with CLI IDs generated after
             if let Some(uint_id) = UintId::from_name(&reverse_hex[..2]) {
                 id_usage.mark_used(uint_id);
+                fallback_id_usage.mark_used(uint_id);
             }
             if let Some(uint_id) = UintId::from_name(&reverse_hex[..3]) {
                 id_usage.mark_used(uint_id);
+                fallback_id_usage.mark_used(uint_id);
             }
             uncommitted_files.insert(
                 reverse_hex,
@@ -633,9 +636,18 @@ impl IdMap {
                     short_id_hunks: hunks.map(|hunk| (UnqualifiedHunkId::default(), hunk)),
                 },
             );
-            // Skip an ID for stability of other IDs below with respect to older
-            // versions of the GitButler CLI.
-            id_usage.next_available()?;
+            // Preserve generated IDs from before path-derived file IDs were introduced. If these
+            // synthetic skips exhaust the bounded space, fall back to the allocator containing
+            // only real allocations and path collision reservations.
+            id_usage.skip_available();
+        }
+        let mut compatibility_probe = id_usage.clone();
+        let compatibility_has_room_for_stacks = stacks
+            .iter()
+            .filter(|stack| stack.id.is_some())
+            .all(|_| compatibility_probe.next_available().is_ok());
+        if !compatibility_has_room_for_stacks {
+            id_usage = fallback_id_usage;
         }
         let mut reverse_hex_short_ids: Vec<(ChangeId, Option<&mut ShortId>)> = uncommitted_files
             .iter_mut()

--- a/crates/but/src/id/tests.rs
+++ b/crates/but/src/id/tests.rs
@@ -365,6 +365,68 @@ uncommitted_hunks: [ nx:q, yz:q ]
 }
 
 #[test]
+fn many_uncommitted_files_do_not_exhaust_generated_ids() -> anyhow::Result<()> {
+    const FILE_COUNT: usize = 26_641;
+    let stacks = vec![
+        Stack {
+            id: Some(StackId::from_number_for_testing(1)),
+            ..stack([segment("0", [id(1)], None, [])])
+        },
+        Stack {
+            id: Some(StackId::from_number_for_testing(2)),
+            ..stack([segment("1", [id(2)], None, [])])
+        },
+    ];
+    let hunks = (0..FILE_COUNT)
+        .map(|index| hunk(&format!("untracked-{index}")))
+        .collect();
+
+    let id_map = IdMap::new(stacks, hunks, gix::hashtable::HashMap::default())?;
+
+    assert_eq!(
+        id_map.uncommitted_files.len(),
+        FILE_COUNT,
+        "all uncommitted files should receive path-derived IDs"
+    );
+    let file_id = id_map
+        .uncommitted_files
+        .values()
+        .next()
+        .expect("at least one uncommitted file")
+        .short_id
+        .clone();
+    let resolved_file = id_map.parse(&file_id, Box::new(|_, _| unreachable!()))?;
+    assert!(matches!(
+        resolved_file.as_slice(),
+        [CliId::UncommittedHunkOrFile(_)]
+    ));
+    assert_eq!(resolved_file[0].to_short_string(), file_id);
+
+    let real_ids: Vec<_> = id_map
+        .branch_ids()
+        .into_iter()
+        .chain(id_map.stack_ids.values().map(CliId::to_short_string))
+        .collect();
+    assert_eq!(real_ids.len(), 4);
+    for (index, real_id) in real_ids.iter().enumerate() {
+        assert!(
+            !real_ids[..index].contains(real_id),
+            "real IDs should be unique"
+        );
+        let resolved = id_map.parse(real_id, Box::new(|_, _| unreachable!()))?;
+        assert!(
+            matches!(
+                resolved.as_slice(),
+                [CliId::Branch(_) | CliId::Stack { .. }]
+            ),
+            "real IDs should resolve after synthetic fallback"
+        );
+        assert_eq!(resolved[0].to_short_string(), *real_id);
+    }
+    Ok(())
+}
+
+#[test]
 fn branch_that_is_substring_of_other_substring_still_gets_id() -> anyhow::Result<()> {
     let stacks = vec![
         stack([segment("substring", [id(1)], None, [])]),


### PR DESCRIPTION
## Context

Observed in a repository with an unignored generated `target/` directory containing about 28,510 files: `but status` and other workspace commands failed with `Error: too many IDs`. Adding `target/` to `.gitignore` restored the CLI commands while the GUI continued to work.

## Change

Preserve the legacy compatibility skips for ordinary repositories, then fall back to an allocator containing only real allocations and path-collision reservations when synthetic skips exhaust the bounded ID space.