### PR TITLE
Add agent guidance against over-built fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,11 @@ this order:
   (desktop, web, Lite, CLI/TUI, N-API, SDK, and docs) and update it or explicitly
   determine that it is unaffected.
 - Run targeted validation for the area touched.
+- Before adding new machinery to fix a behavior bug, reproduce the bug in a failing
+  test and survey the target file's existing loops and classifications as candidate
+  hosts; let the tests, not the diagnosis, set how much implementation the fix needs.
+- When a fix calls for a new mechanism (a new module, a new public API, or a parallel
+  walk where one already exists), propose the intended shape before building it.
 
 ## Scoped Instructions
 


### PR DESCRIPTION
## 🧢 Changes

Two Working Style bullets in `AGENTS.md`, aimed at agent-authored changes:

- Before adding new machinery to fix a behavior bug, reproduce the bug in a failing test **and survey the target file's existing loops and classifications as candidate hosts**; let the tests, not the diagnosis, set how much implementation the fix needs.
- When a fix calls for a new mechanism (a new module, a new public API, or a parallel walk where one already exists), propose the intended shape before building it.

## ☕️ Reasoning

Motivating incident: #15309 fixed the squash-detection gap by porting a sibling engine's mechanism behind a new module and shared abstraction — then #15322 implemented the same behavior, passing the same regression fixtures, as a handful of conditions in `collect_stacks`' existing reference traversal. Multiple strict review rounds on the former never surfaced the simpler shape, because review critiques the frame it is handed.

The two rules attack that failure at its cheapest point: the moment before machinery gets written. The first makes the tests (not the diagnosis) size the implementation and forces a look at what the call site already provides; the second routes any genuinely new mechanism past a human before it exists, rather than after five polish passes.

An earlier revision of this PR also added a mandatory `clean-room-check` skill (a blind-rederivation review protocol). It was cut after discussion as audit theater: late, expensive, and self-graded, where these implement-time rules are the actual treatment.
