### PR TITLE
Add apply-to-workspace button to unapplied branch details

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.tsx
@@ -1,6 +1,6 @@
 import rowStyles from "./Row.module.css";
 import { Scroller } from "#ui/components/Scroller.tsx";
-import { useApply, useBranchRemove } from "#ui/api/mutations.ts";
+import { useBranchRemove } from "#ui/api/mutations.ts";
 import { branchDetailsQueryOptions } from "#ui/api/queries.ts";
 import { decodeBytes, encodeBytes } from "#ui/api/bytes.ts";
 import { assert } from "#ui/assert.ts";
@@ -62,6 +62,7 @@ import {
 import { StackCard } from "./StackCard.tsx";
 import stackCardStyles from "./StackCard.module.css";
 import type { BranchesOutline } from "./useBranchesOutline.ts";
+import { useApplyToWorkspace } from "./useApplyToWorkspace.ts";
 import styles from "./BranchesList.module.css";
 
 /** The filter menu, in the order it is shown. */
@@ -163,31 +164,11 @@ const BranchItem: FC<{
 
 	const review = branch.review;
 
-	const { isPending: isApplyPending, mutate: apply } = useApply();
+	const { isPending: isApplyPending, apply } = useApplyToWorkspace(projectId);
 	const { isPending: isBranchRemovePending, mutate: branchRemove } = useBranchRemove();
 
 	const toggleUnfolded = () => {
 		dispatch(projectSlice.actions.toggleBranchUnfolded({ projectId, branchRef }));
-	};
-
-	const applyBranch = () => {
-		apply(
-			{ projectId, existingBranch: branchRef },
-			{
-				onSuccess: (response) => {
-					const appliedRef = response.appliedBranches[0];
-					if (!appliedRef) return;
-
-					dispatch(projectSlice.actions.setOutlineTab({ projectId, tab: "workspace" }));
-					dispatch(
-						projectSlice.actions.selectOutline({
-							projectId,
-							selection: branchOperand({ branchRef: encodeBytes(appliedRef.full) }),
-						}),
-					);
-				},
-			},
-		);
 	};
 
 	const openReviewInBrowser = async (): Promise<void> => {
@@ -200,7 +181,7 @@ const BranchItem: FC<{
 			// brings the whole stack with it — the label says so.
 			label: isTopBranch && isStacked ? "Apply Stack to Workspace" : "Apply to Workspace",
 			enabled: !isApplyPending,
-			onSelect: applyBranch,
+			onSelect: () => apply(branchRef),
 		}),
 		nativeMenuSeparator,
 		nativeMenuItem({

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -167,6 +167,7 @@ import {
 	type SetFilesReviewedInput,
 	useSetFilesReviewed,
 } from "#ui/reviewed-files.ts";
+import { useApplyToWorkspace } from "./useApplyToWorkspace.ts";
 
 export type DiffViewerHandle = CodeViewHandle<Annotation>;
 
@@ -2040,9 +2041,15 @@ const BranchDetails: FC<{
 		dispatch(projectSlice.actions.selectFiles({ projectId, selection }));
 	};
 
+	const { isPending: isApplyPending, apply } = useApplyToWorkspace(projectId);
+
 	// Use push status of segment, not branch details; something about remote
 	// tracking refs.
 	const branchCtx = headInfoIndex?.branchContextByRefBytes(selection.branchRef);
+	// Appliedness is a workspace fact: applied iff head info resolves the ref to
+	// a segment. Unknown until head info loads, so the apply affordance stays
+	// hidden rather than flashing on applied branches.
+	const unapplied = headInfo !== undefined && branchCtx === undefined;
 	const parentSegment = branchCtx?.stack.segments[branchCtx.segmentIndex + 1];
 	const targetBranch =
 		!parentSegment || parentSegment.pushStatus === "integrated"
@@ -2082,6 +2089,20 @@ const BranchDetails: FC<{
 							Pull Request
 						</Toggle>
 					</ToggleGroup>
+
+					{unapplied && (
+						<div className={styles.tabsRowRight}>
+							<button
+								type="button"
+								className={getButtonClassName({ variant: "pop" })}
+								disabled={isApplyPending}
+								onClick={() => apply(branchRef)}
+							>
+								{isApplyPending && <Icon name="spinner" />}
+								Apply to workspace
+							</button>
+						</div>
+					)}
 
 					{branchTab === "pr" && !!forgeInfo?.capabilities.prService && (
 						<Suspense>

--- a/apps/lite/ui/src/routes/project/$id/workspace/useApplyToWorkspace.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/useApplyToWorkspace.ts
@@ -1,0 +1,39 @@
+import { useApply } from "#ui/api/mutations.ts";
+import { encodeBytes } from "#ui/api/bytes.ts";
+import { branchOperand } from "#ui/operands.ts";
+import { projectSlice } from "#ui/projects/state.ts";
+import { useAppDispatch } from "#ui/store.ts";
+
+/**
+ * Apply a branch and follow it into the workspace: on success the outline
+ * switches to the workspace tab with the applied branch selected, so the
+ * details pane stays on the branch the user was looking at.
+ */
+export const useApplyToWorkspace = (projectId: string) => {
+	const dispatch = useAppDispatch();
+	const { isPending, mutate } = useApply();
+
+	const apply = (branchRef: string) => {
+		mutate(
+			{ projectId, existingBranch: branchRef },
+			{
+				// A conflicting apply succeeds with nothing applied; useApply
+				// already toasts it, so there is nothing to follow.
+				onSuccess: (response) => {
+					const appliedRef = response.appliedBranches[0];
+					if (!appliedRef) return;
+
+					dispatch(projectSlice.actions.setOutlineTab({ projectId, tab: "workspace" }));
+					dispatch(
+						projectSlice.actions.selectOutline({
+							projectId,
+							selection: branchOperand({ branchRef: encodeBytes(appliedRef.full) }),
+						}),
+					);
+				},
+			},
+		);
+	};
+
+	return { isPending, apply };
+};


### PR DESCRIPTION
Branch details now resolves appliedness from head info (a branch is
applied iff it resolves to a workspace segment) and shows an Apply to
workspace button in the tabs row when it does not. The apply-and-follow
behavior (switch to the workspace tab, select the applied branch) moves
out of BranchesList into a shared useApplyToWorkspace hook so the list's
context menu and the new button stay one code path.