### PR TITLE
Put navigation state in the URL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,6 +860,7 @@ dependencies = [
  "but-llm",
  "but-meta",
  "but-path",
+ "but-project-handle",
  "but-rebase",
  "but-secret",
  "but-settings",

--- a/apps/lite/AGENTS.md
+++ b/apps/lite/AGENTS.md
@@ -30,12 +30,20 @@ export const MyComponent: FC<Props> = (p) => {
 # State
 
 Share machinery, not state: when a new surface (a tab, pane, or mode) has its
-own selection or lifecycle, give it its own sub-state with its own
+own configuration or lifecycle, give it its own sub-state with its own
 reducers/selectors (see `ui/src/projects/branches.ts`), even when it reuses the
 same operand/navigation machinery. Don't multiplex an existing state container
 behind mode conditionals — the tell is an `if (tab === ...)` guard, or a
 comment explaining a special case, in code that shouldn't know that mode
 exists.
+
+List cursors are the ratified exception: every list's cursor lives in the one
+`cursors` table (`ui/src/cursors.ts`) because the entries are structurally
+uniform — one identity-keyed value per named list, resolved against what the
+list currently shows. That uniformity is the license. The moment an entry
+needs a list-specific conditional inside the shared machinery
+(`if (list === ...)`), it has stopped being an instance of the concept —
+eject it back into its own sub-state.
 
 # Verifying your work
 

--- a/apps/lite/electron/src/main.ts
+++ b/apps/lite/electron/src/main.ts
@@ -436,7 +436,61 @@ const registerIpcHandlers = (): void => {
 	);
 };
 
-const createMainWindow = async (): Promise<void> => {
+/**
+ * A `lite://app/...` link, translated to whatever this build actually serves:
+ * the dev server in development, our own scheme when packaged. Returns null
+ * for anything that is not one of our links.
+ */
+const deepLinkTargetUrl = (link: string): string | null => {
+	const url = newUrlOrNull(link);
+	if (
+		url === null ||
+		url.protocol !== `${liteProtocolScheme}:` ||
+		url.host !== liteProtocolHost ||
+		url.pathname.includes("..")
+	)
+		return null;
+
+	const devServerUrl = process.env.VITE_DEV_SERVER_URL;
+	const base = new URL(devServerUrl ?? `${liteProtocolScheme}://${liteProtocolHost}/`);
+	const target = new URL(`${url.pathname}${url.search}`, base);
+
+	// The path decides the host when it starts with `//`, so the link's own host
+	// having checked out says nothing about where this one points.
+	if (target.protocol !== base.protocol || target.host !== base.host) return null;
+
+	return target.href;
+};
+
+/**
+ * Open a deep link in the window we already have, or start one if the app was
+ * launched by the link. The project it names is checked by the route itself,
+ * which covers every other way a URL arrives too.
+ */
+const openDeepLink = async (link: string): Promise<void> => {
+	const target = deepLinkTargetUrl(link);
+	if (target === null) {
+		// oxlint-disable-next-line no-console
+		console.error(`Ignored deep link ${link}`);
+		return;
+	}
+
+	const [existing] = BrowserWindow.getAllWindows();
+	if (!existing) {
+		await createMainWindow(target);
+		return;
+	}
+
+	if (existing.isMinimized()) existing.restore();
+	existing.focus();
+	await existing.loadURL(target);
+};
+
+/** The `lite://` link in a launch argv, if the OS started us with one. */
+const deepLinkFromArgv = (argv: Array<string>): string | undefined =>
+	argv.find((arg) => arg.startsWith(`${liteProtocolScheme}://`));
+
+const createMainWindow = async (initialUrl?: string): Promise<void> => {
 	const icon = getWindowIcon();
 	const mainWindow = new BrowserWindow({
 		width: 1024,
@@ -462,17 +516,36 @@ const createMainWindow = async (): Promise<void> => {
 
 	const devServerUrl = process.env.VITE_DEV_SERVER_URL;
 	if (devServerUrl !== undefined) {
-		await mainWindow.loadURL(devServerUrl);
+		await mainWindow.loadURL(initialUrl ?? devServerUrl);
 		return;
 	}
 
 	const rootUrl = `${liteProtocolScheme}://${liteProtocolHost}/`;
-	await mainWindow.loadURL(rootUrl);
+	await mainWindow.loadURL(initialUrl ?? rootUrl);
 	registerUpdater(mainWindow);
 	checkForUpdates();
 };
 
 app.enableSandbox(); // forces sandboxing for all renderers, even if they try to launch without
+
+// One instance owns the protocol: a second launch (how Windows and Linux
+// deliver a link) hands its argv to the first and exits.
+if (!app.requestSingleInstanceLock()) {
+	app.quit();
+} else {
+	app.on("second-instance", (_event, argv) => {
+		const link = deepLinkFromArgv(argv);
+		if (link !== undefined) void openDeepLink(link);
+	});
+
+	// macOS delivers links here instead, both to a running app and to one the
+	// link just launched.
+	app.on("open-url", (event, url) => {
+		event.preventDefault();
+		void openDeepLink(url);
+	});
+}
+
 void app.whenReady().then(async () => {
 	applyGUISettings(await readSettings());
 	await initApplicationNamespace(null);
@@ -560,7 +633,21 @@ void app.whenReady().then(async () => {
 	});
 
 	registerIpcHandlers();
-	await createMainWindow();
+
+	// Dev runs from the electron binary, which needs to be told which program
+	// and arguments to relaunch for a link.
+	if (app.isPackaged) {
+		app.setAsDefaultProtocolClient(liteProtocolScheme);
+	} else {
+		app.setAsDefaultProtocolClient(liteProtocolScheme, process.execPath, [
+			path.resolve(process.argv[1] ?? ""),
+		]);
+	}
+
+	const launchLink = deepLinkFromArgv(process.argv);
+	await createMainWindow(
+		launchLink === undefined ? undefined : (deepLinkTargetUrl(launchLink) ?? undefined),
+	);
 
 	app.on("activate", () => {
 		if (BrowserWindow.getAllWindows().length === 0) void createMainWindow();
@@ -578,11 +665,10 @@ app.on("window-all-closed", () => {
 
 app.on("web-contents-created", (_, contents) => {
 	contents.on("will-navigate", (event, navigationUrl) => {
-		const currentUrl = newUrlOrNull(contents.getURL());
 		const targetUrl = newUrlOrNull(navigationUrl);
-		// Allow HMR page reloads.
-		if (!app.isPackaged && currentUrl?.href === targetUrl?.href && isTrustedLocalOrigin(targetUrl))
-			return;
+		// Where the user is lives in the URL, so opening a link to a branch or a
+		// commit is an ordinary navigation. Anything off our origin stays blocked.
+		if (isTrustedLocalOrigin(targetUrl)) return;
 
 		// oxlint-disable-next-line no-console
 		console.error(`Blocked navigation to ${navigationUrl}`);

--- a/apps/lite/ui/src/api/mutations.ts
+++ b/apps/lite/ui/src/api/mutations.ts
@@ -1,4 +1,5 @@
 import { decodeBytes, encodeBytes } from "#ui/api/bytes.ts";
+import { remapSearchBranch, remapSearchCommits, setCursor } from "#ui/use-cursor.ts";
 import { getHeadInfoIndex } from "#ui/api/ref-info.ts";
 import {
 	currentForgeLoginQueryOptions,
@@ -118,6 +119,8 @@ export const syncCoreCaches = (
 			replacedCommits: workspace.replacedCommits,
 		}),
 	);
+	// Same tick as the headInfo push, so a `commit:` URL param never dangles.
+	remapSearchCommits(workspace.replacedCommits);
 };
 
 export const useAbsorb = ({ projectId }: { projectId: string }) =>
@@ -665,13 +668,11 @@ export const useCommitCreate = () => {
 				const newCommitCtx = headInfoIndex.commitContextByCommitId(response.newCommit);
 
 				if (newCommitCtx) {
-					dispatch(
-						projectSlice.actions.selectOutline({
-							projectId: input.projectId,
-							selection: commitOperand({
-								commitId: response.newCommit,
-								changeId: newCommitCtx.commit.changeId,
-							}),
+					setCursor(
+						"stacks",
+						commitOperand({
+							commitId: response.newCommit,
+							changeId: newCommitCtx.commit.changeId,
 						}),
 					);
 				}
@@ -817,13 +818,11 @@ export const useCommitInsertBlank = () => {
 			const newCommitCtx = headInfoIndex.commitContextByCommitId(response.newCommit);
 
 			if (newCommitCtx) {
-				dispatch(
-					projectSlice.actions.selectOutline({
-						projectId: input.projectId,
-						selection: commitOperand({
-							commitId: response.newCommit,
-							changeId: newCommitCtx.commit.changeId,
-						}),
+				setCursor(
+					"stacks",
+					commitOperand({
+						commitId: response.newCommit,
+						changeId: newCommitCtx.commit.changeId,
 					}),
 				);
 			}
@@ -1049,6 +1048,7 @@ export const useBranchRename = () => {
 					},
 				}),
 			);
+			remapSearchBranch(decodeBytes(input.refName), decodeBytes(response.newRef.fullNameBytes));
 
 			await moveDraftPR({
 				queryClient: mutation.client,

--- a/apps/lite/ui/src/cursor-url.ts
+++ b/apps/lite/ui/src/cursor-url.ts
@@ -1,0 +1,80 @@
+import { decodeBytes } from "#ui/api/bytes.ts";
+import type { ListItem, ListName } from "#ui/cursors.ts";
+import type { OutlineTab } from "#ui/projects/project.ts";
+import type { Operand } from "#ui/operands.ts";
+
+/**
+ * The workspace URL's query params: where the user is, in one flat namespace.
+ * Every param is a plain string with a total decoder, so a corrupt or stale
+ * URL degrades to defaults rather than erroring, and defaults are left out
+ * rather than written.
+ *
+ * The diff cursor has no param: its identity is the exact selected line
+ * groups, which no legible string carries, so it stays in the store.
+ */
+export type UrlQueryParams = {
+	page?: Exclude<OutlineTab, "workspace">;
+	list?: "uncommitted";
+	stacks?: string;
+	uncommitted?: string;
+	branches?: string;
+	upstream?: string;
+	files?: string;
+};
+
+/** The lists whose cursor is a URL param — every list but `diff`. */
+export type UrlListName = Exclude<ListName, "diff">;
+
+export const isUrlList = (list: ListName): list is UrlListName => list !== "diff";
+
+/**
+ * Operand codec: `branch:<full-ref>`, `change:<change-id>` (first choice — a
+ * change id survives amend and reword, so the URL needs no repair) and
+ * `commit:<commit-id>` only for a commit that has no change id. Other operands
+ * are not addressable places.
+ */
+const encodeOperand = (operand: Operand): string | null => {
+	switch (operand._tag) {
+		case "Branch":
+			return `branch:${decodeBytes(operand.branchRef)}`;
+		case "Commit":
+			return operand.changeId !== "" ? `change:${operand.changeId}` : `commit:${operand.commitId}`;
+		default:
+			return null;
+	}
+};
+
+const branchPrefix = "branch:";
+const changePrefix = "change:";
+const commitPrefix = "commit:";
+
+const encodePath = (path: string): string => path;
+
+const cursorParam: { [L in UrlListName]: (item: ListItem[L]) => string | null } = {
+	stacks: encodeOperand,
+	branches: encodeOperand,
+	upstream: encodeOperand,
+	uncommitted: encodePath,
+	files: encodePath,
+};
+
+/** The full ref name a cursor param carries, if it names a branch. */
+export const branchParamRef = (param: string | undefined): string | null =>
+	param !== undefined && param.startsWith(branchPrefix) ? param.slice(branchPrefix.length) : null;
+
+/** The commit reference a cursor param carries, if it names a commit. */
+export const commitParamRef = (
+	param: string | undefined,
+): { changeId: string } | { commitId: string } | null =>
+	param === undefined
+		? null
+		: param.startsWith(changePrefix)
+			? { changeId: param.slice(changePrefix.length) }
+			: param.startsWith(commitPrefix)
+				? { commitId: param.slice(commitPrefix.length) }
+				: null;
+
+export const encodeCursorParam = <L extends UrlListName>(
+	list: L,
+	item: ListItem[L],
+): string | null => cursorParam[list](item);

--- a/apps/lite/ui/src/cursors.ts
+++ b/apps/lite/ui/src/cursors.ts
@@ -1,0 +1,89 @@
+import {
+	branchFileParent,
+	commitFileParent,
+	hunkOperand,
+	operandEquals,
+	operandIdentityKey,
+	type BranchOperand,
+	type FileParent,
+	type HunkOperand,
+	type Operand,
+} from "#ui/operands.ts";
+
+/**
+ * The app's named lists, each with one cursor. A cursor stores the identity
+ * of the item the list rests on — never a position — and every read resolves
+ * it against whatever the list currently shows. All but `diff` live in the
+ * URL (see cursor-url.ts); `diff` lives in the store because its identity is
+ * the exact selected line groups, which no legible string carries.
+ *
+ * `uncommitted` and `files` stay path-keyed on purpose: a bare path survives
+ * root changes (select the next commit, stay on the same file). Do not
+ * "upgrade" them to File operands — the embedded parent would go stale.
+ */
+export type ListItem = {
+	stacks: Operand;
+	uncommitted: string;
+	branches: Operand;
+	upstream: Operand;
+	files: string;
+	diff: HunkOperand;
+};
+
+export type ListName = keyof ListItem;
+
+/**
+ * The workspace page's cursors, snapshotted by modes that restore on cancel.
+ * URL cursors are held in their encoded form: restoration writes the params
+ * back verbatim, no resolution needed.
+ */
+export type WorkspaceCursorSnapshot = {
+	stacks?: string;
+	uncommitted?: string;
+	files?: string;
+	diff: HunkOperand | null;
+};
+
+const pathKey = (path: string): string => path;
+
+/** One identity key per list; resolution and no-op guards share it. */
+export const cursorKey: { [L in ListName]: (item: ListItem[L]) => string } = {
+	stacks: operandIdentityKey,
+	branches: operandIdentityKey,
+	upstream: operandIdentityKey,
+	uncommitted: pathKey,
+	files: pathKey,
+	diff: (operand) => operandIdentityKey(hunkOperand(operand)),
+};
+
+/* The diff cursor is store-held, so history rewrites remap it in the store;
+   URL cursors are remapped as params (use-cursor.ts). Each remap returns its
+   input unchanged (same reference) when the rewrite does not touch it. */
+
+const remapFileParent = (parent: FileParent, replaced: Record<string, string>): FileParent => {
+	if (parent._tag !== "Commit") return parent;
+
+	const newId = replaced[parent.commitId];
+	return newId === undefined
+		? parent
+		: commitFileParent({ commitId: newId, changeId: parent.changeId });
+};
+
+export const remapDiffCursor = (
+	diff: HunkOperand,
+	replacedCommits: Record<string, string>,
+): HunkOperand => {
+	const parent = remapFileParent(diff.parent.parent, replacedCommits);
+	return parent === diff.parent.parent ? diff : { ...diff, parent: { ...diff.parent, parent } };
+};
+
+export const remapDiffCursorBranch = (
+	diff: HunkOperand,
+	oldBranch: BranchOperand,
+	newBranch: BranchOperand,
+): HunkOperand => {
+	const parent = diff.parent.parent;
+	if (parent._tag !== "Branch" || !operandEquals(parent, branchFileParent(oldBranch))) return diff;
+
+	return { ...diff, parent: { ...diff.parent, parent: branchFileParent(newBranch) } };
+};

--- a/apps/lite/ui/src/main.tsx
+++ b/apps/lite/ui/src/main.tsx
@@ -1,8 +1,7 @@
 import { MutationCache, QueryClient, focusManager } from "@tanstack/react-query";
-import { createRouter } from "@tanstack/react-router";
 import { App } from "#ui/App.tsx";
 import { endpointOf, invalidateDeclared } from "#ui/api/tags.ts";
-import { routeTree } from "#ui/routeTree.ts";
+import { createAppRouter } from "#ui/router.ts";
 import { createRoot } from "react-dom/client";
 import "./global.css";
 import { Toast } from "@base-ui/react";
@@ -60,13 +59,7 @@ focusManager.setEventListener((setFocused) => {
 	};
 });
 
-const router = createRouter({ routeTree, context: { queryClient } });
-
-declare module "@tanstack/react-router" {
-	interface Register {
-		router: typeof router;
-	}
-}
+const router = createAppRouter(queryClient);
 
 const rootElement = document.getElementById("root");
 if (!rootElement) throw new Error("Root element not found");

--- a/apps/lite/ui/src/operands.ts
+++ b/apps/lite/ui/src/operands.ts
@@ -3,6 +3,10 @@ import type { HunkLineSelection } from "#ui/hunk.ts";
 
 export type Operand =
 	| { _tag: "UncommittedChanges" }
+	/**
+	 * Applied to the workspace: no operation can act on an unapplied branch, and
+	 * `operandLabel` asserts the ref resolves to a segment.
+	 */
 	| ({ _tag: "Branch" } & BranchOperand)
 	| ({ _tag: "Commit" } & CommitOperand)
 	| ({ _tag: "File" } & FileOperand)
@@ -37,7 +41,9 @@ export const uncommittedChangesOperand: Operand = {
 	_tag: "UncommittedChanges",
 };
 
-export const branchOperand = ({ branchRef }: BranchOperand): Operand => ({
+export const branchOperand = ({
+	branchRef,
+}: BranchOperand): Extract<Operand, { _tag: "Branch" }> => ({
 	_tag: "Branch",
 	branchRef,
 });

--- a/apps/lite/ui/src/outline/mode.ts
+++ b/apps/lite/ui/src/outline/mode.ts
@@ -9,22 +9,21 @@ import {
 	uncommittedChangesOperand,
 } from "#ui/operands.ts";
 import type { Placement } from "#ui/operations/operation.ts";
-import type { SelectionState } from "#ui/projects/project.ts";
-import type { SelectionScope } from "#ui/selection-scopes.ts";
+import type { WorkspaceCursorSnapshot } from "#ui/cursors.ts";
 import type { AbsorptionTarget } from "@gitbutler/but-sdk";
 
 /** @public */
 export type AbsorbMode = {
 	source: Operand;
 	sourceTarget: AbsorptionTarget;
-	restoreSelection: SelectionState;
+	restoreSelection: WorkspaceCursorSnapshot;
 };
 
 /** @public */
 export type KeyboardTransferMode = {
 	sources: Array<Operand>;
 	placement: Placement;
-	restoreSelection: SelectionState;
+	restoreSelection: WorkspaceCursorSnapshot;
 };
 
 /** @public */
@@ -66,16 +65,16 @@ export const pointerTransferMode = ({
 export const getTransferTarget = (
 	mode: TransferMode,
 	outlineSelection: Operand | null,
-	detailsSelectionScope: SelectionScope | null,
+	workspaceList: "stacks" | "uncommitted",
 ): Operand | null =>
 	Match.value(mode).pipe(
 		Match.tagsExhaustive({
 			Pointer: (mode) => mode.target,
 			Keyboard: () =>
-				Match.value(detailsSelectionScope).pipe(
-					Match.when("uncommitted-files", () => uncommittedChangesOperand),
-					Match.when("outline", () => outlineSelection),
-					Match.orElse(() => null),
+				Match.value(workspaceList).pipe(
+					Match.when("uncommitted", () => uncommittedChangesOperand),
+					Match.when("stacks", () => outlineSelection),
+					Match.exhaustive,
 				),
 		}),
 	);

--- a/apps/lite/ui/src/project.ts
+++ b/apps/lite/ui/src/project.ts
@@ -1,7 +1,32 @@
 const lastOpenedProjectKey = "lastProject";
+const lastPlaceKey = "lastPlace";
 
 export const readLastOpenedProject = (): string | null =>
 	window.localStorage.getItem(lastOpenedProjectKey);
 
 export const writeLastOpenedProject = (projectId: string): void =>
 	window.localStorage.setItem(lastOpenedProjectKey, projectId);
+
+/**
+ * Where the user was, so a relaunch reopens it rather than just the project.
+ * Stored with its project so a stale search never lands on another one.
+ */
+export const readLastPlace = (): { projectId: string; search: string } | null => {
+	const raw = window.localStorage.getItem(lastPlaceKey);
+	if (raw === null) return null;
+
+	try {
+		const parsed: unknown = JSON.parse(raw);
+		return typeof parsed === "object" &&
+			parsed !== null &&
+			typeof (parsed as { projectId?: unknown }).projectId === "string" &&
+			typeof (parsed as { search?: unknown }).search === "string"
+			? (parsed as { projectId: string; search: string })
+			: null;
+	} catch {
+		return null;
+	}
+};
+
+export const writeLastPlace = (projectId: string, search: string): void =>
+	window.localStorage.setItem(lastPlaceKey, JSON.stringify({ projectId, search }));

--- a/apps/lite/ui/src/projects/branches.ts
+++ b/apps/lite/ui/src/projects/branches.ts
@@ -1,22 +1,13 @@
 import type { BranchFilters } from "#ui/branch.ts";
-import {
-	branchOperand,
-	commitOperand,
-	operandEquals,
-	operandIdentityKey,
-	type BranchOperand,
-	type Operand,
-} from "#ui/operands.ts";
-import {
-	resolveNavigationIndexSelection,
-	type NavigationIndex,
-} from "#ui/workspace/navigation-index.ts";
 import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
 
 export type BranchFilter = keyof BranchFilters;
 
+/**
+ * The branches tab's list configuration. Its cursor lives in the project's
+ * cursor table (`cursors.branches`), with every other list's.
+ */
 export type BranchesState = {
-	selection: Operand | null;
 	filters: BranchFilters;
 	search: string;
 	/** Branches with their commits unfolded, keyed by full ref name. */
@@ -24,7 +15,6 @@ export type BranchesState = {
 };
 
 const initialState = (): BranchesState => ({
-	selection: null,
 	filters: { showEmpty: false, onlyLocal: true, onlyStacks: false },
 	search: "",
 	unfolded: {},
@@ -34,36 +24,6 @@ const branchesSlice = createSlice({
 	name: "branches",
 	initialState,
 	reducers: {
-		select: (state, { payload: { selection } }: PayloadAction<{ selection: Operand | null }>) => {
-			if (
-				selection === null
-					? state.selection === null
-					: state.selection !== null && operandEquals(state.selection, selection)
-			)
-				return;
-
-			state.selection = selection;
-		},
-		updateRewrittenBranchReferences: (
-			state,
-			{
-				payload: { oldBranch, newBranch },
-			}: PayloadAction<{ oldBranch: BranchOperand; newBranch: BranchOperand }>,
-		) => {
-			const oldBranchOperand = branchOperand(oldBranch);
-			if (state.selection?._tag === "Branch" && operandEquals(state.selection, oldBranchOperand))
-				state.selection = branchOperand(newBranch);
-		},
-		updateRewrittenCommitReferences: (
-			state,
-			{ payload: { replacedCommits } }: PayloadAction<{ replacedCommits: Record<string, string> }>,
-		) => {
-			if (state.selection?._tag !== "Commit") return;
-
-			const newId = replacedCommits[state.selection.commitId];
-			if (newId !== undefined)
-				state.selection = commitOperand({ commitId: newId, changeId: state.selection.changeId });
-		},
 		toggleUnfolded: (state, { payload: { branchRef } }: PayloadAction<{ branchRef: string }>) => {
 			if (state.unfolded[branchRef]) delete state.unfolded[branchRef];
 			else state.unfolded[branchRef] = true;
@@ -98,37 +58,12 @@ const branchesSlice = createSlice({
 		selectBranchSearch: (state) => state.search,
 		selectUnfoldedBranches: (state) => state.unfolded,
 		selectBranchUnfolded: (state, branchRef: string) => state.unfolded[branchRef] === true,
-		/** The selection as stored, without resolving it against a navigation index. */
-		selectPrimaryBranchesSelection: (state) => state.selection,
-		selectSelectionBranches: (state, navigationIndex: NavigationIndex<Operand>) =>
-			resolveNavigationIndexSelection(navigationIndex, state.selection, operandIdentityKey),
 	},
 });
 
 export const createInitialBranchesState = (): BranchesState => branchesSlice.getInitialState();
 
 export const branchesReducers = {
-	select: (state: BranchesState, payload: { selection: Operand | null }) => {
-		branchesSlice.caseReducers.select(state, branchesSlice.actions.select(payload));
-	},
-	updateRewrittenBranchReferences: (
-		state: BranchesState,
-		payload: { oldBranch: BranchOperand; newBranch: BranchOperand },
-	) => {
-		branchesSlice.caseReducers.updateRewrittenBranchReferences(
-			state,
-			branchesSlice.actions.updateRewrittenBranchReferences(payload),
-		);
-	},
-	updateRewrittenCommitReferences: (
-		state: BranchesState,
-		payload: { replacedCommits: Record<string, string> },
-	) => {
-		branchesSlice.caseReducers.updateRewrittenCommitReferences(
-			state,
-			branchesSlice.actions.updateRewrittenCommitReferences(payload),
-		);
-	},
 	toggleUnfolded: (state: BranchesState, payload: { branchRef: string }) => {
 		branchesSlice.caseReducers.toggleUnfolded(state, branchesSlice.actions.toggleUnfolded(payload));
 	},

--- a/apps/lite/ui/src/projects/project.ts
+++ b/apps/lite/ui/src/projects/project.ts
@@ -3,8 +3,8 @@ import {
 	branchOperand,
 	commitFileParent,
 	commitOperand,
-	fileOperand,
 	hunkOperand,
+	fileOperand,
 	operandEquals,
 	operandIdentityKey,
 	type BranchOperand,
@@ -18,7 +18,6 @@ import type { Placement } from "#ui/operations/operation.ts";
 import {
 	absorbOutlineMode,
 	defaultOutlineMode,
-	isValidOutlineModeForSelection,
 	keyboardTransferMode,
 	pointerTransferMode,
 	renameBranchOutlineMode,
@@ -28,10 +27,11 @@ import {
 	type TransferMode,
 } from "#ui/outline/mode.ts";
 import {
-	resolveNavigationIndexSelection,
-	type NavigationIndex,
-} from "#ui/workspace/navigation-index.ts";
-import type { SelectionScope } from "#ui/selection-scopes.ts";
+	cursorKey,
+	remapDiffCursor,
+	remapDiffCursorBranch,
+	type WorkspaceCursorSnapshot,
+} from "#ui/cursors.ts";
 import { createSelector } from "@reduxjs/toolkit";
 import type { AbsorptionTarget } from "@gitbutler/but-sdk";
 import { Match } from "effect";
@@ -50,14 +50,8 @@ import {
 	type UpstreamState,
 } from "./upstream.ts";
 
-export type SelectionState = {
-	uncommittedFiles: string | null;
-	outline: Operand | null;
-	files: string | null;
-	diff: HunkOperand | null;
-};
-
-type DetailsSelectionScope = Extract<SelectionScope, "uncommitted-files" | "outline">;
+/** The workspace page's two lists; the one named here drives the details pane. */
+export type WorkspaceList = "stacks" | "uncommitted";
 
 type CheckableOperand = Extract<Operand, { _tag: "Commit" | "File" | "Hunk" }>;
 
@@ -75,7 +69,6 @@ const conflictCheckKey = ({ commitId, path, id }: CheckedConflict): string =>
 type WorkspaceState = {
 	checkedOperands: Record<string, CheckableOperand>;
 	checkedConflicts: Record<string, CheckedConflict>;
-	detailsSelectionScope: DetailsSelectionScope | null;
 	/**
 	 * Branch segments whose commits are hidden, keyed by full ref name.
 	 *
@@ -87,7 +80,12 @@ type WorkspaceState = {
 	highlightedCommitIds: Array<string>;
 	mode: OutlineMode;
 	selectedBranchTabs: Record<string, BranchTab>;
-	selection: SelectionState;
+	/**
+	 * The diff cursor. Its five siblings live in the URL (use-cursor.ts); this
+	 * one's identity is the exact selected line groups, which no legible param
+	 * carries, so it stays here behind the same seam.
+	 */
+	diffCursor: HunkOperand | null;
 	/**
 	 * File filter queries, or `null` while a filter is closed. An open but empty
 	 * filter is not the same as a closed one: it keeps the input in place and the
@@ -110,22 +108,14 @@ type WorkspaceState = {
 	filesCollapsedDirectories: Record<string, true>;
 };
 
-const createInitialSelectionState = (): SelectionState => ({
-	uncommittedFiles: null,
-	outline: null,
-	files: null,
-	diff: null,
-});
-
 const createInitialWorkspaceState = (): WorkspaceState => ({
 	checkedOperands: {},
 	checkedConflicts: {},
-	detailsSelectionScope: null,
 	foldedSegments: {},
 	highlightedCommitIds: [],
 	mode: defaultOutlineMode,
 	selectedBranchTabs: {},
-	selection: createInitialSelectionState(),
+	diffCursor: null,
 	uncommittedFilesFilter: null,
 	filesFilter: null,
 	uncommittedFilesCollapsedDirectories: {},
@@ -138,7 +128,6 @@ const defaultBranchTab: BranchTab = "diff";
 
 export type ProjectState = {
 	filesVisible: boolean;
-	outlineTab: OutlineTab;
 	branches: BranchesState;
 	upstream: UpstreamState;
 	workspace: WorkspaceState;
@@ -146,98 +135,31 @@ export type ProjectState = {
 
 export const createInitialProjectState = (): ProjectState => ({
 	filesVisible: false,
-	outlineTab: "workspace",
 	branches: createInitialBranchesState(),
 	upstream: createInitialUpstreamState(),
 	workspace: createInitialWorkspaceState(),
 });
 
-const hunkOperandIdentityKey = (operand: HunkOperand): string =>
-	operandIdentityKey(hunkOperand(operand));
-
 export const projectReducers = {
-	setDetailsSelectionScope: (state: ProjectState, { scope }: { scope: DetailsSelectionScope }) => {
-		state.workspace.detailsSelectionScope = scope;
-	},
-	selectUncommittedFiles: (state: ProjectState, { selection }: { selection: string | null }) => {
-		const workspaceState = state.workspace;
-		if (workspaceState.selection.uncommittedFiles === selection) return;
-
-		workspaceState.selection.uncommittedFiles = selection;
-	},
-	selectOutline: (state: ProjectState, { selection }: { selection: Operand | null }) => {
-		const workspaceState = state.workspace;
+	selectDiffCursor: (state: ProjectState, { selection }: { selection: HunkOperand | null }) => {
+		const current = state.workspace.diffCursor;
 		if (
-			selection &&
-			workspaceState.selection.outline &&
-			operandEquals(workspaceState.selection.outline, selection)
+			selection !== null &&
+			current !== null &&
+			cursorKey.diff(current) === cursorKey.diff(selection)
 		)
 			return;
 
-		workspaceState.selection.outline = selection;
-		workspaceState.selection.files = null;
-		workspaceState.selection.diff = null;
-
-		if (!selection || !isValidOutlineModeForSelection({ mode: workspaceState.mode, selection }))
-			workspaceState.mode = defaultOutlineMode;
-	},
-	selectBranches: (state: ProjectState, { selection }: { selection: Operand | null }) => {
-		branchesReducers.select(state.branches, { selection });
-	},
-	selectUpstream: (state: ProjectState, { selection }: { selection: Operand | null }) => {
-		upstreamReducers.select(state.upstream, { selection });
+		state.workspace.diffCursor = selection;
 	},
 	toggleUpstreamSegment: (state: ProjectState, { segmentId }: { segmentId: string }) => {
 		upstreamReducers.toggleSegment(state.upstream, { segmentId });
 	},
-	selectFiles: (state: ProjectState, { selection }: { selection: string | null }) => {
-		const workspaceState = state.workspace;
-		if (workspaceState.selection.files === selection) return;
-
-		workspaceState.selection.files = selection;
-	},
-	selectDiff: (state: ProjectState, { selection }: { selection: HunkOperand | null }) => {
-		const workspaceState = state.workspace;
-		if (
-			selection &&
-			workspaceState.selection.diff &&
-			operandEquals(hunkOperand(workspaceState.selection.diff), hunkOperand(selection))
-		)
-			return;
-
-		workspaceState.selection.diff = selection;
-	},
 	startRewordCommit: (state: ProjectState, { commit }: { commit: CommitOperand }) => {
-		const workspaceState = state.workspace;
-		const selection = commitOperand(commit);
-		if (
-			!workspaceState.selection.outline ||
-			!operandEquals(workspaceState.selection.outline, selection)
-		) {
-			workspaceState.selection.outline = selection;
-			workspaceState.selection.files = null;
-			workspaceState.selection.diff = null;
-			if (!isValidOutlineModeForSelection({ mode: workspaceState.mode, selection }))
-				workspaceState.mode = defaultOutlineMode;
-		}
-
-		workspaceState.mode = rewordCommitOutlineMode({ operand: commit });
+		state.workspace.mode = rewordCommitOutlineMode({ operand: commit });
 	},
 	startRenameBranch: (state: ProjectState, { branch }: { branch: BranchOperand }) => {
-		const workspaceState = state.workspace;
-		const selection = branchOperand(branch);
-		if (
-			!workspaceState.selection.outline ||
-			!operandEquals(workspaceState.selection.outline, selection)
-		) {
-			workspaceState.selection.outline = selection;
-			workspaceState.selection.files = null;
-			workspaceState.selection.diff = null;
-			if (!isValidOutlineModeForSelection({ mode: workspaceState.mode, selection }))
-				workspaceState.mode = defaultOutlineMode;
-		}
-
-		workspaceState.mode = renameBranchOutlineMode({ operand: branch });
+		state.workspace.mode = renameBranchOutlineMode({ operand: branch });
 	},
 	updateRewrittenBranchReferences: (
 		state: ProjectState,
@@ -245,15 +167,14 @@ export const projectReducers = {
 	) => {
 		const workspaceState = state.workspace;
 		const oldBranchOperand = branchOperand(oldBranch);
-		const newBranchOperand = branchOperand(newBranch);
 
-		if (
-			workspaceState.selection.outline?._tag === "Branch" &&
-			operandEquals(workspaceState.selection.outline, oldBranchOperand)
-		)
-			workspaceState.selection.outline = newBranchOperand;
-
-		branchesReducers.updateRewrittenBranchReferences(state.branches, { oldBranch, newBranch });
+		if (workspaceState.diffCursor) {
+			workspaceState.diffCursor = remapDiffCursorBranch(
+				workspaceState.diffCursor,
+				oldBranch,
+				newBranch,
+			);
+		}
 
 		if (
 			workspaceState.mode._tag === "RenameBranch" &&
@@ -281,37 +202,33 @@ export const projectReducers = {
 	},
 	enterKeyboardTransferMode: (
 		state: ProjectState,
-		{ sources, placement }: { sources: Array<Operand>; placement?: Placement },
+		{
+			sources,
+			placement,
+			restoreSelection,
+		}: {
+			sources: Array<Operand>;
+			placement?: Placement;
+			restoreSelection: WorkspaceCursorSnapshot;
+		},
 	) => {
-		const workspaceState = state.workspace;
-		workspaceState.mode = transferOutlineMode(
-			keyboardTransferMode({
-				sources,
-				placement: placement ?? "into",
-				restoreSelection: {
-					uncommittedFiles: workspaceState.selection.uncommittedFiles,
-					outline: workspaceState.selection.outline,
-					files: workspaceState.selection.files,
-					diff: workspaceState.selection.diff,
-				},
-			}),
+		state.workspace.mode = transferOutlineMode(
+			keyboardTransferMode({ sources, placement: placement ?? "into", restoreSelection }),
 		);
 	},
 	enterAbsorbMode: (
 		state: ProjectState,
-		{ source, sourceTarget }: { source: Operand; sourceTarget: AbsorptionTarget },
-	) => {
-		const workspaceState = state.workspace;
-		workspaceState.mode = absorbOutlineMode({
+		{
 			source,
-			restoreSelection: {
-				uncommittedFiles: workspaceState.selection.uncommittedFiles,
-				outline: workspaceState.selection.outline,
-				files: workspaceState.selection.files,
-				diff: workspaceState.selection.diff,
-			},
 			sourceTarget,
-		});
+			restoreSelection,
+		}: {
+			source: Operand;
+			sourceTarget: AbsorptionTarget;
+			restoreSelection: WorkspaceCursorSnapshot;
+		},
+	) => {
+		state.workspace.mode = absorbOutlineMode({ source, restoreSelection, sourceTarget });
 	},
 	updatePointerTransfer: (
 		state: ProjectState,
@@ -354,21 +271,6 @@ export const projectReducers = {
 	},
 	exitMode: (state: ProjectState) => {
 		state.workspace.mode = defaultOutlineMode;
-	},
-	cancelMode: (state: ProjectState) => {
-		const workspaceState = state.workspace;
-		const restoreSelection = Match.value(workspaceState.mode).pipe(
-			Match.tags({
-				Absorb: (mode) => mode.restoreSelection,
-				Transfer: (mode) => (mode.value._tag === "Keyboard" ? mode.value.restoreSelection : null),
-			}),
-			Match.orElse(() => null),
-		);
-		workspaceState.mode = defaultOutlineMode;
-
-		if (!restoreSelection) return;
-
-		workspaceState.selection = restoreSelection;
 	},
 	setHighlightedCommitIds: (
 		state: ProjectState,
@@ -414,18 +316,9 @@ export const projectReducers = {
 		{ replacedCommits }: { replacedCommits: Record<string, string> },
 	) => {
 		const workspaceState = state.workspace;
-		const selection = workspaceState.selection.outline;
-		if (selection?._tag === "Commit") {
-			const newId = replacedCommits[selection.commitId];
-			if (newId !== undefined) {
-				workspaceState.selection.outline = commitOperand({
-					commitId: newId,
-					changeId: selection.changeId,
-				});
-			}
-		}
 
-		branchesReducers.updateRewrittenCommitReferences(state.branches, { replacedCommits });
+		if (workspaceState.diffCursor)
+			workspaceState.diffCursor = remapDiffCursor(workspaceState.diffCursor, replacedCommits);
 
 		for (const [key, conflict] of Object.entries(workspaceState.checkedConflicts)) {
 			const newId = replacedCommits[conflict.commitId];
@@ -490,17 +383,7 @@ export const projectReducers = {
 
 		state.workspace.selectedBranchTabs[branchName] = tab;
 	},
-	setOutlineTab: (state: ProjectState, { tab }: { tab: OutlineTab }) => {
-		if (state.outlineTab === tab) return;
 
-		state.outlineTab = tab;
-		state.workspace.mode = defaultOutlineMode;
-		// The branches and upstream tabs have no uncommitted changes panel, so
-		// their selection cannot drive the details pane. Leave the scope alone on
-		// the way back, so returning to the workspace restores the panel it was
-		// showing.
-		if (tab !== "workspace") state.workspace.detailsSelectionScope = "outline";
-	},
 	toggleSegmentFolded: (state: ProjectState, { branchRef }: { branchRef: string }) => {
 		if (state.workspace.foldedSegments[branchRef]) delete state.workspace.foldedSegments[branchRef];
 		else state.workspace.foldedSegments[branchRef] = true;
@@ -653,65 +536,21 @@ const selectCheckedOperandCount = createSelector(
 
 export const projectSelectors = {
 	selectFilesVisible: (state: ProjectState) => state.filesVisible,
-	selectOutlineTab: (state: ProjectState) => state.outlineTab,
 	selectBranchTab: (state: ProjectState, branchName: string): BranchTab =>
 		state.workspace.selectedBranchTabs[branchName] ?? defaultBranchTab,
-	selectCanShowFiles: (state: ProjectState) =>
-		state.workspace.detailsSelectionScope !== "uncommitted-files",
-	selectDetailsSelectionScope: (state: ProjectState) => state.workspace.detailsSelectionScope,
+
 	selectUncommittedFilesFilter: (state: ProjectState) => state.workspace.uncommittedFilesFilter,
 	selectFilesFilter: (state: ProjectState) => state.workspace.filesFilter,
 	selectUncommittedFilesCollapsedDirectories: (state: ProjectState) =>
 		state.workspace.uncommittedFilesCollapsedDirectories,
 	selectFilesCollapsedDirectories: (state: ProjectState) =>
 		state.workspace.filesCollapsedDirectories,
-	selectSelectionUncommittedFiles: (
-		state: ProjectState,
-		navigationIndex: NavigationIndex<string>,
-	) =>
-		resolveNavigationIndexSelection(
-			navigationIndex,
-			state.workspace.selection.uncommittedFiles,
-			(path) => path,
-		),
+	/** The diff cursor as stored; its siblings live in the URL. */
+	selectDiffCursor: (state: ProjectState) => state.workspace.diffCursor,
 	/** A primitive, so checking one conflict re-renders one card. */
 	selectIsConflictChecked: (state: ProjectState, conflict: CheckedConflict): boolean =>
 		conflictCheckKey(conflict) in state.workspace.checkedConflicts,
 	selectCheckedConflicts: selectCheckedConflictsFor,
-	selectIsSelectedOutline: (
-		state: ProjectState,
-		navigationIndex: NavigationIndex<Operand>,
-		operand: Operand,
-	) => {
-		const selection = resolveNavigationIndexSelection(
-			navigationIndex,
-			state.workspace.selection.outline,
-			operandIdentityKey,
-		);
-		return selection !== null && operandEquals(selection, operand);
-	},
-	/** The selection as stored, without resolving it against a navigation index. */
-	selectPrimaryOutlineSelection: (state: ProjectState) => state.workspace.selection.outline,
-	selectSelectionOutline: (state: ProjectState, navigationIndex: NavigationIndex<Operand>) =>
-		resolveNavigationIndexSelection(
-			navigationIndex,
-			state.workspace.selection.outline,
-			operandIdentityKey,
-		),
-	selectSelectionFiles: (state: ProjectState, navigationIndex: NavigationIndex<string>) =>
-		resolveNavigationIndexSelection(
-			navigationIndex,
-			state.workspace.selection.files,
-			(item) => item,
-		),
-	selectSelectionDiff: (state: ProjectState, navigationIndex: NavigationIndex<HunkOperand>) =>
-		resolveNavigationIndexSelection(
-			navigationIndex,
-			state.workspace.selection.diff,
-			hunkOperandIdentityKey,
-		),
-	/** The diff selection as stored, without resolving it against a navigation index. */
-	selectStoredDiffSelection: (state: ProjectState) => state.workspace.selection.diff,
 	selectOutlineModeState: (state: ProjectState) => state.workspace.mode,
 	selectFoldedSegments: (state: ProjectState) => state.workspace.foldedSegments,
 	selectSegmentFolded: (state: ProjectState, branchRef: string) =>

--- a/apps/lite/ui/src/projects/upstream.ts
+++ b/apps/lite/ui/src/projects/upstream.ts
@@ -1,12 +1,10 @@
-import { operandEquals, operandIdentityKey, type Operand } from "#ui/operands.ts";
-import {
-	resolveNavigationIndexSelection,
-	type NavigationIndex,
-} from "#ui/workspace/navigation-index.ts";
 import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
 
+/**
+ * The upstream tab's list configuration. Its cursor lives in the project's
+ * cursor table (`cursors.upstream`), with every other list's.
+ */
 export type UpstreamState = {
-	selection: Operand | null;
 	/**
 	 * Expanded shared-history segments, keyed by the segment's newest commit
 	 * id. Expanding reveals the target commits between two fork points.
@@ -15,7 +13,6 @@ export type UpstreamState = {
 };
 
 const initialState = (): UpstreamState => ({
-	selection: null,
 	expandedSegments: {},
 });
 
@@ -23,36 +20,19 @@ const upstreamSlice = createSlice({
 	name: "upstream",
 	initialState,
 	reducers: {
-		select: (state, { payload: { selection } }: PayloadAction<{ selection: Operand | null }>) => {
-			if (
-				selection === null
-					? state.selection === null
-					: state.selection !== null && operandEquals(state.selection, selection)
-			)
-				return;
-
-			state.selection = selection;
-		},
 		toggleSegment: (state, { payload: { segmentId } }: PayloadAction<{ segmentId: string }>) => {
 			if (state.expandedSegments[segmentId]) delete state.expandedSegments[segmentId];
 			else state.expandedSegments[segmentId] = true;
 		},
 	},
 	selectors: {
-		/** The selection as stored, without resolving it against a navigation index. */
-		selectPrimaryUpstreamSelection: (state) => state.selection,
 		selectExpandedUpstreamSegments: (state) => state.expandedSegments,
-		selectSelectionUpstream: (state, navigationIndex: NavigationIndex<Operand>) =>
-			resolveNavigationIndexSelection(navigationIndex, state.selection, operandIdentityKey),
 	},
 });
 
 export const createInitialUpstreamState = (): UpstreamState => upstreamSlice.getInitialState();
 
 export const upstreamReducers = {
-	select: (state: UpstreamState, payload: { selection: Operand | null }) => {
-		upstreamSlice.caseReducers.select(state, upstreamSlice.actions.select(payload));
-	},
 	toggleSegment: (state: UpstreamState, payload: { segmentId: string }) => {
 		upstreamSlice.caseReducers.toggleSegment(state, upstreamSlice.actions.toggleSegment(payload));
 	},

--- a/apps/lite/ui/src/reconcile.ts
+++ b/apps/lite/ui/src/reconcile.ts
@@ -4,6 +4,7 @@
  */
 
 import { useQueries, useQuery } from "@tanstack/react-query";
+import { branchParamRef } from "#ui/cursor-url.ts";
 import {
 	branchDiffQueryOptions,
 	changesInWorktreeQueryOptions,
@@ -11,14 +12,13 @@ import {
 	headInfoQueryOptions,
 	treeChangeDiffsQueryOptions,
 } from "./api/queries.ts";
+import { currentParams, remapSearchBranch } from "#ui/use-cursor.ts";
 import { useParams } from "@tanstack/react-router";
 import { getHeadInfoIndex, type HeadInfoIndex } from "./api/ref-info.ts";
 import { useEffect, useEffectEvent, useLayoutEffect, useRef } from "react";
 import { useAppDispatch, useAppSelector } from "./store.ts";
 import { projectSlice } from "./projects/state.ts";
 import {
-	branchOperand,
-	commitOperand,
 	fileOperand,
 	operandIdentityKey,
 	type FileParent,
@@ -26,7 +26,7 @@ import {
 	uncommittedChangesFileParent,
 	weakFileParentIdentityKey,
 } from "./operands.ts";
-import { decodeBytes } from "./api/bytes.ts";
+import { decodeBytes, encodeBytes } from "./api/bytes.ts";
 import { hunkContainsHunk } from "./hunk.ts";
 import type { RefInfo, TreeChange } from "@gitbutler/but-sdk";
 import { reviewedFilesQueryOptions, usePruneReviewedFiles } from "./reviewed-files.ts";
@@ -44,36 +44,17 @@ export const useStateReconciler = (): void => {
 
 	const dispatch = useAppDispatch();
 
-	const outlineSelection = useAppSelector((state) =>
-		projectSlice.selectors.selectPrimaryOutlineSelection(state, projectId),
-	);
-	const reconcileSelectedCommit = useEffectEvent((headInfoIndex: HeadInfoIndex) => {
-		if (outlineSelection?._tag !== "Commit") return;
-
-		const curr = headInfoIndex.commitContextByCommitId(outlineSelection.commitId);
-		if (curr) return;
-
-		// Change IDs are not necessarily globally unique, but typically will be. In any case this
-		// is a best-effort fallback.
-		const commit = headInfoIndex.commitContextsByChangeId(outlineSelection.changeId)?.[0].commit;
-
-		dispatch(
-			projectSlice.actions.selectOutline({
-				projectId,
-				selection: commit
-					? commitOperand({ commitId: commit.id, changeId: commit.changeId })
-					: null,
-			}),
-		);
-	});
+	// Commit cursors need no repair here: `change:` params re-resolve by change
+	// id (encode-match), and a `commit:` param names an identity nothing survives.
 	const reconcileSelectedBranch = useEffectEvent(
 		(headInfo: RefInfo, headInfoIndex: HeadInfoIndex, prevHeadInfoIndex: HeadInfoIndex) => {
-			if (outlineSelection?._tag !== "Branch") return;
+			const refName = branchParamRef(currentParams().stacks);
+			if (refName === null) return;
 
-			const curr = headInfoIndex.branchContextByRefBytes(outlineSelection.branchRef);
-			if (curr) return;
+			const refBytes = encodeBytes(refName);
+			if (headInfoIndex.branchContextByRefBytes(refBytes)) return;
 
-			const prev = prevHeadInfoIndex.branchContextByRefBytes(outlineSelection.branchRef);
+			const prev = prevHeadInfoIndex.branchContextByRefBytes(refBytes);
 			if (!prev) return;
 
 			// We've no stable identifier for branches, so assume a rename retains its stack and segment
@@ -86,12 +67,7 @@ export const useStateReconciler = (): void => {
 			)
 				return;
 
-			dispatch(
-				projectSlice.actions.selectOutline({
-					projectId,
-					selection: branchOperand({ branchRef: sameSegmentBranch.fullNameBytes }),
-				}),
-			);
+			remapSearchBranch(refName, decodeBytes(sameSegmentBranch.fullNameBytes));
 		},
 	);
 
@@ -203,7 +179,6 @@ export const useStateReconciler = (): void => {
 		const prevHeadInfoIndex = prevHeadInfoIndexRef.current;
 		if (prevHeadInfoIndex) reconcileSelectedBranch(headInfo, headInfoIndex, prevHeadInfoIndex);
 
-		reconcileSelectedCommit(headInfoIndex);
 		reconcileCheckedCommits(headInfoIndex);
 
 		prevHeadInfoIndexRef.current = headInfoIndex;

--- a/apps/lite/ui/src/router.ts
+++ b/apps/lite/ui/src/router.ts
@@ -1,0 +1,40 @@
+import { routeTree } from "#ui/routeTree.ts";
+import { createRouter } from "@tanstack/react-router";
+import type { QueryClient } from "@tanstack/react-query";
+
+/* Every search param is a plain string (see cursor-url.ts), so the default
+   JSON search serialization would only add quoting noise. Slashes and colons
+   are legal in query values and carry most of our params' legibility. */
+const stringifySearch = (search: Record<string, unknown>): string => {
+	const parts = Object.entries(search).flatMap(([key, value]) =>
+		typeof value === "string" && value !== ""
+			? [`${key}=${encodeURIComponent(value).replaceAll("%2F", "/").replaceAll("%3A", ":")}`]
+			: [],
+	);
+	return parts.length === 0 ? "" : `?${parts.join("&")}`;
+};
+
+const parseSearch = (searchStr: string): Record<string, unknown> =>
+	Object.fromEntries(new URLSearchParams(searchStr));
+
+const buildRouter = (queryClient: QueryClient) =>
+	createRouter({ routeTree, context: { queryClient }, parseSearch, stringifySearch });
+
+type AppRouter = ReturnType<typeof buildRouter>;
+
+export const createAppRouter = (queryClient: QueryClient): AppRouter => {
+	router = buildRouter(queryClient);
+	return router;
+};
+
+/**
+ * Module-level once `createAppRouter` has run, so navigating is a plain call
+ * from anywhere rather than a hook. Only test setups see it unset.
+ */
+export let router: AppRouter;
+
+declare module "@tanstack/react-router" {
+	interface Register {
+		router: AppRouter;
+	}
+}

--- a/apps/lite/ui/src/routes/index.tsx
+++ b/apps/lite/ui/src/routes/index.tsx
@@ -1,7 +1,10 @@
 import { createRoute, redirect } from "@tanstack/react-router";
 import type { FC } from "react";
 import { Route as rootRoute } from "#ui/routes/__root.tsx";
-import { readLastOpenedProject } from "#ui/project.ts";
+import { readLastOpenedProject, readLastPlace } from "#ui/project.ts";
+
+const parseLastSearch = (search: string): Record<string, string> =>
+	Object.fromEntries(new URLSearchParams(search));
 
 // oxlint-disable-next-line react/only-export-components -- False positive?
 const IndexPage: FC = () => <p>Select a project.</p>;
@@ -16,8 +19,16 @@ export const Route = createRoute({
 			? persistedId
 			: projects[0]?.id;
 
-		if (projectId != null)
-			throw redirect({ to: "/project/$id/workspace", params: { id: projectId } });
+		if (projectId != null) {
+			// Only the place recorded for this project; anything unparseable in it
+			// is dropped by the route's own validation.
+			const place = readLastPlace();
+			throw redirect({
+				to: "/project/$id/workspace",
+				params: { id: projectId },
+				search: place?.projectId === projectId ? parseLastSearch(place.search) : {},
+			});
+		}
 
 		return null;
 	},

--- a/apps/lite/ui/src/routes/project/$id/route.tsx
+++ b/apps/lite/ui/src/routes/project/$id/route.tsx
@@ -1,4 +1,4 @@
-import { createRoute, notFound, Outlet } from "@tanstack/react-router";
+import { createRoute, notFound, Outlet, redirect } from "@tanstack/react-router";
 import { Route as rootRoute } from "#ui/routes/__root.tsx";
 import { handleProjectEvent } from "#ui/project-events.ts";
 
@@ -8,9 +8,14 @@ export const Route = createRoute({
 	remountDeps: ({ params }) => params.id,
 	// Needed for `remountDeps` to work.
 	component: () => <Outlet />,
-	beforeLoad: ({ matches, routeId }) => {
+	beforeLoad: async ({ matches, routeId, params }) => {
 		// We don't want an index route.
 		if (matches.at(-1)?.routeId === routeId) throw notFound();
+
+		// The id decodes to a path, and URLs arrive from outside the app, so open
+		// only projects it already knows about.
+		const projects = await window.lite.listProjectsStateless();
+		if (!projects.some((project) => project.id === params.id)) throw redirect({ to: "/" });
 	},
 	loader: async ({ params, context }) => {
 		// Allow the route to render and handle failure via its queries.

--- a/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.tsx
@@ -42,7 +42,7 @@ import { Field, Toolbar } from "@base-ui/react";
 import { useMergedRefs } from "@base-ui/utils/useMergedRefs";
 import { useQuery } from "@tanstack/react-query";
 import { useHotkey } from "@tanstack/react-hotkeys";
-import { type ComponentProps, type FC, Fragment, useEffect, useRef, useState } from "react";
+import { type ComponentProps, type FC, Fragment, useRef, useState } from "react";
 import {
 	Row,
 	RowFoldToggle,
@@ -55,13 +55,13 @@ import {
 } from "./Row.tsx";
 import {
 	getRowButtonClassName,
-	selectionOutOfSync,
 	treeItemId,
 	useIsSelected as useIsSelectedInList,
 } from "./Row-utils.ts";
 import { StackCard } from "./StackCard.tsx";
 import stackCardStyles from "./StackCard.module.css";
 import type { BranchesOutline } from "./useBranchesOutline.ts";
+import { setCursor, useCursorWriteBack, useResolvedCursor } from "#ui/use-cursor.ts";
 import { useApplyToWorkspace } from "./useApplyToWorkspace.ts";
 import styles from "./BranchesList.module.css";
 
@@ -81,7 +81,7 @@ const branchGraphStatus = (branch: ListedBranch): GraphSegmentStatus =>
 	branch.remoteRefs.length > 0 ? "LocalAndRemote" : "LocalOnly";
 
 const useIsSelected = (projectId: string, operand: Operand): boolean =>
-	useIsSelectedInList(projectId, operand, projectSlice.selectors.selectPrimaryBranchesSelection);
+	useIsSelectedInList(projectId, operand, "branches");
 
 const InertRow: FC<{ branch: ListedBranch; label: string }> = ({ branch, label }) => (
 	<Row interactive={false} role="treeitem" aria-label={label}>
@@ -93,7 +93,6 @@ const InertRow: FC<{ branch: ListedBranch; label: string }> = ({ branch, label }
 );
 
 const CommitItem: FC<{ projectId: string; commit: Commit }> = ({ projectId, commit }) => {
-	const dispatch = useAppDispatch();
 	const operand = commitOperand({ commitId: commit.id, changeId: commit.changeId });
 	const isSelected = useIsSelected(projectId, operand);
 	const title = commitTitle(commit.message);
@@ -105,9 +104,7 @@ const CommitItem: FC<{ projectId: string; commit: Commit }> = ({ projectId, comm
 			aria-label={title ?? "(no message)"}
 			aria-selected={isSelected}
 			isSelected={isSelected}
-			onSelect={() =>
-				dispatch(projectSlice.actions.selectBranches({ projectId, selection: operand }))
-			}
+			onSelect={() => setCursor("branches", operand)}
 		>
 			<GraphSegment
 				glyph="commit"
@@ -220,9 +217,7 @@ const BranchItem: FC<{
 		>
 			<Row
 				isSelected={isSelected}
-				onSelect={() =>
-					dispatch(projectSlice.actions.selectBranches({ projectId, selection: operand }))
-				}
+				onSelect={() => setCursor("branches", operand)}
 				onContextMenu={(event) => {
 					void showNativeContextMenu(event, menuItems);
 				}}
@@ -324,18 +319,8 @@ export const BranchesList: FC<
 		projectSlice.selectors.selectBranchSearch(state, projectId),
 	);
 
-	const selection = useAppSelector((state) =>
-		projectSlice.selectors.selectSelectionBranches(state, projectId, navigationIndex),
-	);
-	const storedSelection = useAppSelector((state) =>
-		projectSlice.selectors.selectPrimaryBranchesSelection(state, projectId),
-	);
-
-	const outOfSyncSelection = selectionOutOfSync(selection, storedSelection);
-	useEffect(() => {
-		if (outOfSyncSelection !== null)
-			dispatch(projectSlice.actions.selectBranches({ projectId, selection: outOfSyncSelection }));
-	}, [dispatch, outOfSyncSelection, projectId]);
+	const selection = useResolvedCursor("branches", navigationIndex);
+	useCursorWriteBack("branches", navigationIndex);
 
 	const hotkeysRef = useRef<HTMLDivElement>(null);
 	const { isPending: isBranchRemovePending, mutate: branchRemove } = useBranchRemove();
@@ -347,10 +332,8 @@ export const BranchesList: FC<
 
 	useNavigationIndexHotkeys({
 		navigationIndex,
-		projectId,
 		group: "Outline",
-		select: (newItem) =>
-			dispatch(projectSlice.actions.selectBranches({ projectId, selection: newItem })),
+		select: (newItem) => setCursor("branches", newItem),
 		selection,
 		selectSectionPredicate: (operand) => operand._tag === "Branch",
 		ref: hotkeysRef,
@@ -435,9 +418,6 @@ export const BranchesList: FC<
 					aria-activedescendant={selection ? treeItemId(selection) : undefined}
 					data-selection-scope={"outline" satisfies SelectionScope}
 					className={styles.tree}
-					onFocus={() =>
-						dispatch(projectSlice.actions.setDetailsSelectionScope({ projectId, scope: "outline" }))
-					}
 					ref={useMergedRefs(hotkeysRef, useAutofocusSelectionScope())}
 				>
 					{stacks.map((stack) => (

--- a/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
@@ -1,4 +1,5 @@
 import uiStyles from "#ui/components/ui.module.css";
+import { setCursor } from "#ui/use-cursor.ts";
 import { useBranchCreate, useCommitCreate, useGenerateCommitMessage } from "#ui/api/mutations.ts";
 import {
 	aiConfigurationQueryOptions,
@@ -23,7 +24,7 @@ import { createDiffSpec } from "#ui/operations/diff-specs.ts";
 import { projectSlice } from "#ui/projects/state.ts";
 import { projectAiSettingsQueryOptions } from "#ui/project-ai-settings.ts";
 import { focusSelectionScope } from "#ui/selection-scopes.ts";
-import { useAppDispatch, useAppSelector, useAppStore } from "#ui/store.ts";
+import { useAppSelector, useAppStore } from "#ui/store.ts";
 import { Button, Combobox, Tooltip } from "@base-ui/react";
 import type { InsertSide, RelativeTo, WorktreeChanges } from "@gitbutler/but-sdk";
 import { useHotkey, useHotkeys } from "@tanstack/react-hotkeys";
@@ -134,7 +135,6 @@ export const CommitForm: FC<{
 	worktreeChanges,
 	className,
 }) => {
-	const dispatch = useAppDispatch();
 	const store = useAppStore();
 	const { isPending: isCommitCreatePending, mutate: commitCreate } = useCommitCreate();
 	const { isPending: isBranchCreatePending, mutate: branchCreate } = useBranchCreate();
@@ -219,8 +219,7 @@ export const CommitForm: FC<{
 	const canAmend = canCommitOrAmendBase && canAmendCommit && amendTargetCommitId !== null;
 
 	const selectBranch = (option: CommitTargetComboboxItem | null) => {
-		if (option)
-			dispatch(projectSlice.actions.selectOutline({ projectId, selection: option.operand }));
+		if (option) setCursor("stacks", option.operand);
 		setOpen(false);
 	};
 
@@ -279,12 +278,10 @@ export const CommitForm: FC<{
 			{ projectId, newRef: null, placement: { type: "independent" } },
 			{
 				onSuccess: (response) => {
-					dispatch(
-						projectSlice.actions.selectOutline({
-							projectId,
-							selection: { _tag: "Branch", branchRef: response.newRef.fullNameBytes },
-						}),
-					);
+					setCursor("stacks", {
+						_tag: "Branch",
+						branchRef: response.newRef.fullNameBytes,
+					});
 					commitOnto({ type: "referenceBytes", subject: response.newRef.fullNameBytes });
 				},
 			},

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -1,4 +1,5 @@
 import { ResizeHandle } from "#ui/components/ResizeHandle.tsx";
+import { setCursor, useCanShowFiles, useResolvedCursor } from "#ui/use-cursor.ts";
 import { Scroller } from "#ui/components/Scroller.tsx";
 import { SuspenseQuery } from "@suspensive/react-query";
 import {
@@ -21,11 +22,14 @@ import {
 	treeChangeDiffsQueryOptions,
 } from "#ui/api/queries.ts";
 import { decodeBytes } from "#ui/api/bytes.ts";
+import type { ForgeReview } from "@gitbutler/but-sdk";
 import { branchDetailsParams } from "#ui/branch.ts";
 import { commitBody, commitTitle, shortCommitId } from "#ui/commit.ts";
 import {
 	branchFileParent,
 	branchIdentityKey,
+	type BranchOperand,
+	branchOperand,
 	commitFileParent,
 	type FileOperand,
 	fileOperand,
@@ -34,6 +38,7 @@ import {
 	type FileParent,
 	type HunkOperand,
 	type Operand,
+	uncommittedChangesFileParent,
 	weakCommitIdentityKey,
 	weakFileParentIdentityKey,
 } from "#ui/operands.ts";
@@ -305,8 +310,8 @@ const DiffContents: FC<{
 	canUncommit,
 	uncommit,
 }) => {
-	const newFocusableAnnotationIdRef = useRef<string | null>(null);
 	const dispatch = useAppDispatch();
+	const newFocusableAnnotationIdRef = useRef<string | null>(null);
 	const { mutate: createComment } = useCommentCreate();
 	const { data: editors } = useQuery(listEditorsQueryOptions);
 	const { data: settings } = useQuery({
@@ -347,11 +352,9 @@ const DiffContents: FC<{
 	);
 	const visibleNavigationIndex = withoutFoldedHunks(navigationIndex, hunkByKey, collapsedItems);
 
-	const diffSelection = useAppSelector((state) =>
-		projectSlice.selectors.selectSelectionDiff(state, projectId, visibleNavigationIndex),
-	);
+	const diffSelection = useResolvedCursor("diff", visibleNavigationIndex);
 	const hasStoredDiffSelection = useAppSelector(
-		(state) => projectSlice.selectors.selectStoredDiffSelection(state, projectId) !== null,
+		(state) => projectSlice.selectors.selectDiffCursor(state, projectId) !== null,
 	);
 	const canCheckHunks = useAppSelector((state) =>
 		projectSlice.selectors.selectCanCheckHunks(state, projectId, fileParent),
@@ -384,7 +387,7 @@ const DiffContents: FC<{
 	}, []);
 
 	const selectDiff = (selection: HunkOperand) => {
-		dispatch(projectSlice.actions.selectDiff({ projectId, selection }));
+		setCursor("diff", selection);
 
 		const selectedRange = hunkByKey.get(hunkOperandIdentityKey(selection))?.selectedLines;
 		if (!selectedRange) return;
@@ -399,7 +402,6 @@ const DiffContents: FC<{
 
 	useNavigationIndexHotkeys({
 		navigationIndex: visibleNavigationIndex,
-		projectId,
 		group: "Diff",
 		select: selectDiff,
 		selection: diffSelection,
@@ -528,7 +530,7 @@ const DiffContents: FC<{
 
 	// We currently only support selecting contiguous blocks.
 	const handleLinesSelected = (sel: CodeViewLineSelection | null): void => {
-		if (!sel) return void dispatch(projectSlice.actions.selectDiff({ projectId, selection: null }));
+		if (!sel) return setCursor("diff", null);
 
 		const file = fileByItemId.get(sel.id);
 		if (!file) throw new Error("Could not get file by item ID");
@@ -545,19 +547,14 @@ const DiffContents: FC<{
 		});
 		if (!selection) return;
 
-		dispatch(
-			projectSlice.actions.selectDiff({
-				projectId,
-				selection: {
-					parent: {
-						parent: fileParent,
-						path: file.change.path,
-					},
-					...selection,
-					isResultOfBinaryToTextConversion: file.patch.subject.isResultOfBinaryToTextConversion,
-				},
-			}),
-		);
+		setCursor("diff", {
+			parent: {
+				parent: fileParent,
+				path: file.change.path,
+			},
+			...selection,
+			isResultOfBinaryToTextConversion: file.patch.subject.isResultOfBinaryToTextConversion,
+		});
 	};
 
 	const getHunkOperandAtLine = ({
@@ -666,16 +663,11 @@ const DiffContents: FC<{
 		// file's first hunk, which stands in for the folded file, and keep the
 		// header in view. The stored selection is read off the store rather than
 		// captured, so this callback's identity does not churn with j/k moves.
-		const stored = projectSlice.selectors.selectStoredDiffSelection(store.getState(), projectId);
+		const stored = projectSlice.selectors.selectDiffCursor(store.getState(), projectId);
 		const storedFile = stored && hunkByKey.get(hunkOperandIdentityKey(stored))?.file;
 		if (storedFile?.item.id !== itemId) return;
 
-		dispatch(
-			projectSlice.actions.selectDiff({
-				projectId,
-				selection: assert(storedFile.hunks[0]).operand,
-			}),
-		);
+		setCursor("diff", assert(storedFile.hunks[0]).operand);
 		viewerRef.current?.scrollTo({ type: "item", id: itemId, align: "nearest" });
 	};
 
@@ -1235,9 +1227,7 @@ const Diff: FC<{
 		select: (cfg) => cfg.unidiff ?? defaultSettings.unidiff,
 	});
 
-	const canShowFiles = useAppSelector((state) =>
-		projectSlice.selectors.selectCanShowFiles(state, projectId),
-	);
+	const canShowFiles = useCanShowFiles();
 	const detailsFullWindow = useAppSelector(interfaceSlice.selectors.selectDetailsFullWindow);
 
 	// Change stats live in the files panel, or — in the uncommitted scope, which has no files
@@ -1266,9 +1256,7 @@ const Diff: FC<{
 		[filesItems, filesFilter, fileDisplayMode, filesCollapsedDirectories],
 	);
 	const filesNavigationIndex = useMemo(() => fileTreeNavigationIndex(filesRows), [filesRows]);
-	const filesSelection = useAppSelector((state) =>
-		projectSlice.selectors.selectSelectionFiles(state, projectId, filesNavigationIndex),
-	);
+	const filesSelection = useResolvedCursor("files", filesNavigationIndex);
 
 	// At time of writing React Compiler cannot statically analyse that these are pure derivations of
 	// the outline selection, even with the helpers inlined, hence manual memoisation.
@@ -1387,9 +1375,7 @@ const Diff: FC<{
 
 	// The diff panel resolves this selection for the viewer; the ruler wants it in
 	// file line numbers, which is what the hunk's own range already holds.
-	const diffSelection = useAppSelector((state) =>
-		projectSlice.selectors.selectSelectionDiff(state, projectId, diffViewSansAnno.navigationIndex),
-	);
+	const diffSelection = useResolvedCursor("diff", diffViewSansAnno.navigationIndex);
 	const minimapSelection = useMemo((): MinimapSelection | null => {
 		if (!diffSelection) return null;
 
@@ -1788,14 +1774,11 @@ const CommitDetails: FC<{
 	didScrollToViaFileRef: RefObject<boolean>;
 }> = ({ selection, onActiveFileSelection, viewerRef, didScrollToViaFileRef }) => {
 	const { id: projectId } = useParams({ from: "/project/$id/workspace" });
-	const dispatch = useAppDispatch();
 	const detailsFullWindow = useAppSelector(interfaceSlice.selectors.selectDetailsFullWindow);
 	const filesVisibleState = useAppSelector((state) =>
 		projectSlice.selectors.selectFilesVisible(state, projectId),
 	);
-	const canShowFiles = useAppSelector((state) =>
-		projectSlice.selectors.selectCanShowFiles(state, projectId),
-	);
+	const canShowFiles = useCanShowFiles();
 	const filesVisible = canShowFiles && filesVisibleState;
 	const [commitBodyCollapsed, setCommitBodyCollapsed] = useState(true);
 	const commitBodyId = useId();
@@ -1845,7 +1828,7 @@ const CommitDetails: FC<{
 	const body = commitBody(commitDetails.commit.message);
 
 	const selectFile = (selection: string) => {
-		dispatch(projectSlice.actions.selectFiles({ projectId, selection }));
+		setCursor("files", selection);
 	};
 
 	return (
@@ -1952,26 +1935,266 @@ const CommitDetails: FC<{
 	);
 };
 
-const BranchDetails: FC<{
-	selection: Extract<Operand, { _tag: "Branch" }>;
+/** A branch's own changes, whatever the branch's standing. */
+const BranchDiff: FC<BranchDetailsProps> = ({
+	branch,
+	onActiveFileSelection,
+	viewerRef,
+	didScrollToViaFileRef,
+}) => {
+	const { id: projectId } = useParams({ from: "/project/$id/workspace" });
+	const filesVisibleState = useAppSelector((state) =>
+		projectSlice.selectors.selectFilesVisible(state, projectId),
+	);
+	const canShowFiles = useCanShowFiles();
+	const filesVisible = canShowFiles && filesVisibleState;
+
+	const selectFile = (selection: string) => {
+		setCursor("files", selection);
+	};
+
+	return (
+		<SuspenseQuery
+			{...branchDiffQueryOptions({ projectId, branch: decodeBytes(branch.branchRef) })}
+		>
+			{({ data: branchDiff }) => (
+				<Diff
+					changes={branchDiff.changes}
+					filesVisible={filesVisible}
+					filesItems={branchDiff.changes.map((change) =>
+						changeFileRowItem({
+							change,
+							path: change.path,
+							dependencyCommitIds: [],
+						}),
+					)}
+					onPassiveFileSelection={selectFile}
+					selection={branchOperand(branch)}
+					projectId={projectId}
+					onActiveFileSelection={onActiveFileSelection}
+					viewerRef={viewerRef}
+					didScrollToViaFileRef={didScrollToViaFileRef}
+				/>
+			)}
+		</SuspenseQuery>
+	);
+};
+
+const BranchTitleRow: FC<{ branchName: string }> = ({ branchName }) => {
+	const detailsFullWindow = useAppSelector(interfaceSlice.selectors.selectDetailsFullWindow);
+
+	return (
+		<div className={styles.titleRow}>
+			{detailsFullWindow && <TopLeftControls />}
+
+			<div className={styles.title}>
+				<SelectionScopeKbd hotkey="0" scope="details" />
+				<Icon name="branch" />
+				<h3 className={classes("text-15", "text-semibold")}>{branchName}</h3>
+			</div>
+		</div>
+	);
+};
+
+/** The Diff / Pull Request toggle, for a branch with both to show. */
+const BranchTabToggle: FC<{ branchTab: BranchTab; setBranchTab: (tab: BranchTab) => void }> = ({
+	branchTab,
+	setBranchTab,
+}) => (
+	<ToggleGroup
+		render={<ToggleGroupStyles />}
+		value={[branchTab]}
+		onValueChange={(value: Array<BranchTab>) => {
+			const head = value[0];
+			if (head === undefined) return;
+			setBranchTab(head);
+		}}
+		aria-label="Branch tab"
+	>
+		<Toggle render={<ToggleStyles />} value={"diff" satisfies BranchTab}>
+			Diff
+		</Toggle>
+		<Toggle render={<ToggleStyles />} value={"pr" satisfies BranchTab}>
+			Pull Request
+		</Toggle>
+	</ToggleGroup>
+);
+
+/** `[` and `]` step between a branch's tabs; with two of them, either key toggles. */
+const useBranchTabHotkeys = ({
+	branchTab,
+	setBranchTab,
+	target,
+	enabled = true,
+}: {
+	branchTab: BranchTab;
+	setBranchTab: (tab: BranchTab) => void;
+	target: RefObject<HTMLElement | null>;
+	enabled?: boolean;
+}) => {
+	const toggle = () => {
+		switch (branchTab) {
+			case "diff": {
+				setBranchTab("pr");
+				break;
+			}
+			case "pr": {
+				setBranchTab("diff");
+				break;
+			}
+			default:
+				branchTab satisfies never;
+		}
+	};
+
+	useHotkeys(
+		(["[", "]"] as const).map((hotkey) => ({
+			hotkey,
+			callback: toggle,
+			options: { conflictBehavior: "allow" as const, enabled, target },
+		})),
+	);
+};
+
+/**
+ * An existing review: its description, the conversation and the side panel.
+ * Editing is the applied branch's affordance — the branches tab shows a review,
+ * it does not work on one.
+ */
+const ReviewView: FC<{
+	projectId: string;
+	sourceBranch: string;
+	review: ForgeReview;
+	editing?: { active: boolean; onDone: () => void };
+}> = ({ projectId, sourceBranch, review, editing }) => {
+	const { data: forgeInfo } = useQuery(forgeInfoOptions(projectId));
+
+	return (
+		<div className={styles.prLayout}>
+			<div className={styles.prMain}>
+				<PullRequestDescription
+					key={review.number}
+					body={review.body}
+					projectId={projectId}
+					reviewId={review.number}
+					sourceBranch={sourceBranch}
+					title={review.title}
+					canSubmit={editing !== undefined}
+					editing={editing?.active ?? false}
+					onDoneEditing={() => editing?.onDone()}
+				/>
+
+				{forgeInfo?.capabilities.reviewComments !== false && (
+					<PullRequestComments projectId={projectId} review={review} />
+				)}
+			</div>
+
+			<PullRequestPanel projectId={projectId} review={review} />
+		</div>
+	);
+};
+
+/** What every details view threads through to its Diff. */
+type DetailsViewProps = {
 	onActiveFileSelection: (itemId: string, firstHunk: HunkOperand | null) => void;
 	viewerRef: RefObject<DiffViewerHandle | null>;
 	didScrollToViaFileRef: RefObject<boolean>;
-}> = ({ selection, onActiveFileSelection, viewerRef, didScrollToViaFileRef }) => {
+};
+
+type BranchDetailsProps = { branch: BranchOperand } & DetailsViewProps;
+
+/**
+ * A branch the workspace does not hold, as the branches tab lists them: its
+ * changes, and its review when one already exists. Opening a review is not
+ * offered — the base comes from a branch's position in a workspace stack, which
+ * this branch has not got, so `publish_review` refuses it.
+ */
+const UnappliedBranchDetails: FC<BranchDetailsProps> = ({
+	branch,
+	onActiveFileSelection,
+	viewerRef,
+	didScrollToViaFileRef,
+}) => {
+	const { id: projectId } = useParams({ from: "/project/$id/workspace" });
+	const dispatch = useAppDispatch();
+	const branchName = branchDetailsParams(decodeBytes(branch.branchRef)).branchName;
+	const { data: forgeInfo } = useQuery(forgeInfoOptions(projectId));
+	// Same query key as the applied branch's, so the two share one listing
+	// rather than polling the forge twice. Reviews are keyed by branch name,
+	// which says nothing about whether the branch is applied.
+	const { data: review } = useQuery({
+		...listReviewsQueryOptions({ projectId, cacheConfig: "noCache" }),
+		enabled: forgeInfo?.capabilities.prService === true,
+		select: (reviews) => reviews.find((review) => review.sourceBranch === branchName) ?? null,
+	});
+
+	const branchTab = useAppSelector((state) =>
+		projectSlice.selectors.selectBranchTab(state, projectId, branchName),
+	);
+	const setBranchTab = (tab: BranchTab) => {
+		dispatch(projectSlice.actions.setSelectedBranchTab({ projectId, branchName, tab }));
+	};
+
+	const ref = useRef<HTMLDivElement>(null);
+	// The review is the only second tab on offer here, so the toggle and the keys
+	// that drive it both wait for one to exist.
+	useBranchTabHotkeys({ branchTab, setBranchTab, target: ref, enabled: !!review });
+
+	const { isPending: isApplyPending, apply } = useApplyToWorkspace(projectId);
+
+	return (
+		<div className={styles.container} ref={ref}>
+			<div className={styles.headerWrap}>
+				<BranchTitleRow branchName={branchName} />
+
+				<div className={classes(styles.tabsRow, branchTab === "pr" && styles.tabsRowPrCap)}>
+					{review && <BranchTabToggle branchTab={branchTab} setBranchTab={setBranchTab} />}
+
+					<div className={styles.tabsRowRight}>
+						<button
+							type="button"
+							className={getButtonClassName({ variant: "pop" })}
+							disabled={isApplyPending}
+							onClick={() => apply(decodeBytes(branch.branchRef))}
+						>
+							{isApplyPending && <Icon name="spinner" />}
+							Apply to workspace
+						</button>
+					</div>
+				</div>
+			</div>
+
+			<Suspense fallback={<div className={classes(styles.loadingTab, "text-13")}>Loading…</div>}>
+				{review && branchTab === "pr" ? (
+					<div className={styles.prTab}>
+						<ReviewView projectId={projectId} sourceBranch={branchName} review={review} />
+					</div>
+				) : (
+					<BranchDiff
+						branch={branch}
+						onActiveFileSelection={onActiveFileSelection}
+						viewerRef={viewerRef}
+						didScrollToViaFileRef={didScrollToViaFileRef}
+					/>
+				)}
+			</Suspense>
+		</div>
+	);
+};
+
+/** A branch applied to the workspace: its changes, and the review of them. */
+const AppliedBranchDetails: FC<BranchDetailsProps> = ({
+	branch,
+	onActiveFileSelection,
+	viewerRef,
+	didScrollToViaFileRef,
+}) => {
 	const { id: projectId } = useParams({ from: "/project/$id/workspace" });
 	const { data: forgeInfo } = useQuery(forgeInfoOptions(projectId));
 	const { data: headInfo } = useQuery(headInfoQueryOptions(projectId));
 	const headInfoIndex = headInfo ? getHeadInfoIndex(headInfo) : null;
 	const dispatch = useAppDispatch();
-	const detailsFullWindow = useAppSelector(interfaceSlice.selectors.selectDetailsFullWindow);
-	const filesVisibleState = useAppSelector((state) =>
-		projectSlice.selectors.selectFilesVisible(state, projectId),
-	);
-	const canShowFiles = useAppSelector((state) =>
-		projectSlice.selectors.selectCanShowFiles(state, projectId),
-	);
-	const filesVisible = canShowFiles && filesVisibleState;
-	const branchRef = decodeBytes(selection.branchRef);
+	const branchRef = decodeBytes(branch.branchRef);
 	const branchName = branchDetailsParams(branchRef).branchName;
 	const branchTab = useAppSelector((state) =>
 		projectSlice.selectors.selectBranchTab(state, projectId, branchName),
@@ -1991,65 +2214,11 @@ const BranchDetails: FC<{
 	};
 
 	const ref = useRef<HTMLDivElement>(null);
-
-	useHotkeys([
-		{
-			hotkey: "[",
-			callback: () => {
-				switch (branchTab) {
-					case "diff": {
-						setBranchTab("pr");
-						break;
-					}
-					case "pr": {
-						setBranchTab("diff");
-						break;
-					}
-					default:
-						branchTab satisfies never;
-				}
-			},
-			options: {
-				conflictBehavior: "allow",
-				target: ref,
-			},
-		},
-		{
-			hotkey: "]",
-			callback: () => {
-				switch (branchTab) {
-					case "diff": {
-						setBranchTab("pr");
-						break;
-					}
-					case "pr": {
-						setBranchTab("diff");
-						break;
-					}
-					default:
-						branchTab satisfies never;
-				}
-			},
-			options: {
-				conflictBehavior: "allow",
-				target: ref,
-			},
-		},
-	]);
-
-	const selectFile = (selection: string) => {
-		dispatch(projectSlice.actions.selectFiles({ projectId, selection }));
-	};
-
-	const { isPending: isApplyPending, apply } = useApplyToWorkspace(projectId);
+	useBranchTabHotkeys({ branchTab, setBranchTab, target: ref });
 
 	// Use push status of segment, not branch details; something about remote
 	// tracking refs.
-	const branchCtx = headInfoIndex?.branchContextByRefBytes(selection.branchRef);
-	// Appliedness is a workspace fact: applied iff head info resolves the ref to
-	// a segment. Unknown until head info loads, so the apply affordance stays
-	// hidden rather than flashing on applied branches.
-	const unapplied = headInfo !== undefined && branchCtx === undefined;
+	const branchCtx = headInfoIndex?.branchContextByRefBytes(branch.branchRef);
 	const parentSegment = branchCtx?.stack.segments[branchCtx.segmentIndex + 1];
 	const targetBranch =
 		!parentSegment || parentSegment.pushStatus === "integrated"
@@ -2061,48 +2230,10 @@ const BranchDetails: FC<{
 	return (
 		<div className={styles.container} ref={ref}>
 			<div className={styles.headerWrap}>
-				<div className={styles.titleRow}>
-					{detailsFullWindow && <TopLeftControls />}
-
-					<div className={styles.title}>
-						<SelectionScopeKbd hotkey="0" scope="details" />
-						<Icon name="branch" />
-						<h3 className={classes("text-15", "text-semibold")}>{branchName}</h3>
-					</div>
-				</div>
+				<BranchTitleRow branchName={branchName} />
 
 				<div className={classes(styles.tabsRow, branchTab === "pr" && styles.tabsRowPrCap)}>
-					<ToggleGroup
-						render={<ToggleGroupStyles />}
-						value={[branchTab]}
-						onValueChange={(value: Array<BranchTab>) => {
-							const head = value[0];
-							if (head === undefined) return;
-							setBranchTab(head);
-						}}
-						aria-label="Branch tab"
-					>
-						<Toggle render={<ToggleStyles />} value={"diff" satisfies BranchTab}>
-							Diff
-						</Toggle>
-						<Toggle render={<ToggleStyles />} value={"pr" satisfies BranchTab}>
-							Pull Request
-						</Toggle>
-					</ToggleGroup>
-
-					{unapplied && (
-						<div className={styles.tabsRowRight}>
-							<button
-								type="button"
-								className={getButtonClassName({ variant: "pop" })}
-								disabled={isApplyPending}
-								onClick={() => apply(branchRef)}
-							>
-								{isApplyPending && <Icon name="spinner" />}
-								Apply to workspace
-							</button>
-						</div>
-					)}
+					<BranchTabToggle branchTab={branchTab} setBranchTab={setBranchTab} />
 
 					{branchTab === "pr" && !!forgeInfo?.capabilities.prService && (
 						<Suspense>
@@ -2171,54 +2302,24 @@ const BranchDetails: FC<{
 											canSubmit
 										/>
 									) : (
-										<div className={styles.prLayout}>
-											<div className={styles.prMain}>
-												<PullRequestDescription
-													key={review.number}
-													body={review.body}
-													projectId={projectId}
-													reviewId={review.number}
-													sourceBranch={branchName}
-													title={review.title}
-													canSubmit
-													editing={prEditing}
-													onDoneEditing={() => setPrEditing(false)}
-												/>
-
-												{forgeInfo.capabilities.reviewComments !== false && (
-													<PullRequestComments projectId={projectId} review={review} />
-												)}
-											</div>
-
-											<PullRequestPanel projectId={projectId} review={review} />
-										</div>
+										<ReviewView
+											projectId={projectId}
+											sourceBranch={branchName}
+											review={review}
+											editing={{ active: prEditing, onDone: () => setPrEditing(false) }}
+										/>
 									);
 								}}
 							</SuspenseQuery>
 						)}
 					</div>
 				) : (
-					<SuspenseQuery {...branchDiffQueryOptions({ projectId, branch: branchRef })}>
-						{({ data: branchDiff }) => (
-							<Diff
-								changes={branchDiff.changes}
-								filesVisible={filesVisible}
-								filesItems={branchDiff.changes.map((change) =>
-									changeFileRowItem({
-										change,
-										path: change.path,
-										dependencyCommitIds: [],
-									}),
-								)}
-								onPassiveFileSelection={selectFile}
-								selection={selection}
-								projectId={projectId}
-								onActiveFileSelection={onActiveFileSelection}
-								viewerRef={viewerRef}
-								didScrollToViaFileRef={didScrollToViaFileRef}
-							/>
-						)}
-					</SuspenseQuery>
+					<BranchDiff
+						branch={branch}
+						onActiveFileSelection={onActiveFileSelection}
+						viewerRef={viewerRef}
+						didScrollToViaFileRef={didScrollToViaFileRef}
+					/>
 				)}
 			</Suspense>
 		</div>
@@ -2248,29 +2349,24 @@ const FileDetailsSkeleton: FC = () => {
 };
 
 const FileDetails: FC<{
-	selection: Extract<Operand, { _tag: "File" }> & {
-		parent: Extract<FileParent, { _tag: "UncommittedChanges" }>;
-	};
+	path: string;
 	onActiveFileSelection: (itemId: string, firstHunk: HunkOperand | null) => void;
 	viewerRef: RefObject<DiffViewerHandle | null>;
 	didScrollToViaFileRef: RefObject<boolean>;
-}> = ({ selection, onActiveFileSelection, viewerRef, didScrollToViaFileRef }) => {
+}> = ({ path, onActiveFileSelection, viewerRef, didScrollToViaFileRef }) => {
 	const { id: projectId } = useParams({ from: "/project/$id/workspace" });
-	const dispatch = useAppDispatch();
 	const detailsFullWindow = useAppSelector(interfaceSlice.selectors.selectDetailsFullWindow);
 	const filesVisibleState = useAppSelector((state) =>
 		projectSlice.selectors.selectFilesVisible(state, projectId),
 	);
-	const canShowFiles = useAppSelector((state) =>
-		projectSlice.selectors.selectCanShowFiles(state, projectId),
-	);
+	const canShowFiles = useCanShowFiles();
 	const filesVisible = canShowFiles && filesVisibleState;
 	const { data: worktreeChanges } = useSuspenseQuery(changesInWorktreeQueryOptions(projectId));
 	const filesItems = getChangesFileRowItems(worktreeChanges);
 	const changes = filesItems.flatMap((item) => (item._tag === "Change" ? [item.change] : []));
 
 	const selectFile = (selection: string) => {
-		dispatch(projectSlice.actions.selectUncommittedFiles({ projectId, selection }));
+		setCursor("uncommitted", selection);
 	};
 
 	const title = (
@@ -2293,7 +2389,7 @@ const FileDetails: FC<{
 					filesVisible={filesVisible}
 					filesItems={filesItems}
 					onPassiveFileSelection={selectFile}
-					selection={selection}
+					selection={fileOperand({ parent: uncommittedChangesFileParent, path })}
 					projectId={projectId}
 					onActiveFileSelection={onActiveFileSelection}
 					viewerRef={viewerRef}
@@ -2309,47 +2405,69 @@ const FileDetails: FC<{
 	);
 };
 
-export const Details: FC<{
-	selection: Operand | null;
-	onActiveFileSelection: (itemId: string, firstHunk: HunkOperand | null) => void;
-	viewerRef: RefObject<DiffViewerHandle | null>;
-	didScrollToViaFileRef: RefObject<boolean>;
-}> = ({ selection, onActiveFileSelection, viewerRef, didScrollToViaFileRef }) => {
-	if (!selection) return;
+/**
+ * One details component per outline page, as the outline has one list per
+ * page: the component tree, not a tag on the selection, carries where a
+ * selection came from. Each dispatches over the operands its own page can
+ * select, so a branch is applied or unapplied by which page shows it.
+ */
+type OutlineDetailsProps = { selection: Operand | null } & DetailsViewProps;
 
-	return Match.value(selection).pipe(
+/** A commit selection is shown the same way whichever page selected it. */
+const commitDetails = (
+	commit: Extract<Operand, { _tag: "Commit" }>,
+	viewProps: DetailsViewProps,
+): ReactNode => (
+	<Suspense fallback={<CommitDetailsSkeleton />}>
+		<CommitDetails key={weakCommitIdentityKey(commit)} selection={commit} {...viewProps} />
+	</Suspense>
+);
+
+/** The details pane for the workspace tab: branches here are applied. */
+export const WorkspaceDetails: FC<OutlineDetailsProps> = ({ selection, ...viewProps }) =>
+	selection &&
+	Match.value(selection).pipe(
 		Match.tags({
-			Commit: (commit) => (
-				<Suspense fallback={<CommitDetailsSkeleton />}>
-					<CommitDetails
-						key={weakCommitIdentityKey(commit)}
-						selection={commit}
-						onActiveFileSelection={onActiveFileSelection}
-						viewerRef={viewerRef}
-						didScrollToViaFileRef={didScrollToViaFileRef}
-					/>
-				</Suspense>
-			),
 			Branch: (branch) => (
-				<BranchDetails
-					key={branchIdentityKey(branch)}
-					selection={branch}
-					onActiveFileSelection={onActiveFileSelection}
-					viewerRef={viewerRef}
-					didScrollToViaFileRef={didScrollToViaFileRef}
-				/>
+				<AppliedBranchDetails key={branchIdentityKey(branch)} branch={branch} {...viewProps} />
 			),
+			Commit: (commit) => commitDetails(commit, viewProps),
 		}),
-		Match.when({ _tag: "File", parent: { _tag: "UncommittedChanges" } }, (file) => (
-			<Suspense fallback={<FileDetailsSkeleton />}>
-				<FileDetails
-					selection={file}
-					onActiveFileSelection={onActiveFileSelection}
-					viewerRef={viewerRef}
-					didScrollToViaFileRef={didScrollToViaFileRef}
-				/>
-			</Suspense>
-		)),
-		Match.orElseAbsurd,
+		Match.orElse(() => null),
 	);
-};
+
+/**
+ * The details pane for the upstream tab. Only commits are selectable there;
+ * its branch rows carry no operand.
+ */
+export const UpstreamDetails: FC<OutlineDetailsProps> = ({ selection, ...viewProps }) =>
+	selection &&
+	Match.value(selection).pipe(
+		Match.tags({
+			Commit: (commit) => commitDetails(commit, viewProps),
+		}),
+		Match.orElse(() => null),
+	);
+
+/**
+ * The details pane for the branches tab, which lists what the workspace does
+ * not hold: its branches are unapplied.
+ */
+export const BranchesDetails: FC<OutlineDetailsProps> = ({ selection, ...viewProps }) =>
+	selection &&
+	Match.value(selection).pipe(
+		Match.tags({
+			Branch: (branch) => (
+				<UnappliedBranchDetails key={branchIdentityKey(branch)} branch={branch} {...viewProps} />
+			),
+			Commit: (commit) => commitDetails(commit, viewProps),
+		}),
+		Match.orElse(() => null),
+	);
+
+/** The details pane for the uncommitted-files scope. */
+export const UncommittedFilesDetails: FC<{ path: string } & DetailsViewProps> = (p) => (
+	<Suspense fallback={<FileDetailsSkeleton />}>
+		<FileDetails {...p} />
+	</Suspense>
+);

--- a/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.tsx
@@ -1,4 +1,5 @@
 import rowStyles from "./Row.module.css";
+import { enterAbsorb } from "#ui/use-cursor.ts";
 import {
 	guiSettingsQueryOptions,
 	headInfoQueryOptions,
@@ -84,7 +85,6 @@ const useFilesTreeHotkeys = ({
 	const { canDiscard, discard } = useDiscardFileChanges({ projectId, fileParent });
 
 	const store = useAppStore();
-	const dispatch = useAppDispatch();
 
 	const selectedChangesFile = fileParent._tag === "UncommittedChanges" ? selection : null;
 	const selectedUncommittedChange =
@@ -93,22 +93,19 @@ const useFilesTreeHotkeys = ({
 	const absorbSelectedFile = () => {
 		if (selectedUncommittedChange === null) return;
 
-		dispatch(
-			projectSlice.actions.enterAbsorbMode({
-				projectId,
-				source: fileOperand({
-					parent: uncommittedChangesFileParent,
-					path: selectedUncommittedChange.path,
-				}),
-				sourceTarget: {
-					type: "treeChanges",
-					subject: {
-						changes: [selectedUncommittedChange],
-						assignedStackId: null,
-					},
-				},
+		enterAbsorb({
+			source: fileOperand({
+				parent: uncommittedChangesFileParent,
+				path: selectedUncommittedChange.path,
 			}),
-		);
+			sourceTarget: {
+				type: "treeChanges",
+				subject: {
+					changes: [selectedUncommittedChange],
+					assignedStackId: null,
+				},
+			},
+		});
 		focusSelectionScope("outline");
 	};
 
@@ -253,7 +250,6 @@ const useFilesTreeHotkeys = ({
 
 	useNavigationIndexHotkeys({
 		navigationIndex,
-		projectId,
 		group: "File",
 		select: onRowSelection,
 		selection,

--- a/apps/lite/ui/src/routes/project/$id/workspace/OperationControls.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OperationControls.tsx
@@ -1,4 +1,5 @@
 import { useAbsorb } from "#ui/api/mutations.ts";
+import { cancelMode, useResolvedCursor, useWorkspaceList } from "#ui/use-cursor.ts";
 import { absorptionPlanQueryOptions, headInfoQueryOptions } from "#ui/api/queries.ts";
 import { getHeadInfoIndex, type HeadInfoIndex } from "#ui/api/ref-info.ts";
 import { getButtonClassName } from "#ui/components/Button.tsx";
@@ -190,7 +191,7 @@ const AbsorbOperationControls: FC<{
 	};
 
 	const cancel = () => {
-		dispatch(projectSlice.actions.cancelMode({ projectId }));
+		cancelMode();
 	};
 
 	return (
@@ -300,17 +301,13 @@ const TransferKeyboardOperationControls: FC<{
 	mode: KeyboardTransferMode;
 	outlineNavigationIndex: NavigationIndex<Operand>;
 }> = ({ headInfoIndex, projectId, mode, outlineNavigationIndex }) => {
-	const detailsSelectionScope = useAppSelector((state) =>
-		projectSlice.selectors.selectDetailsSelectionScope(state, projectId),
-	);
-	const selection = useAppSelector((state) =>
-		projectSlice.selectors.selectSelectionOutline(state, projectId, outlineNavigationIndex),
-	);
+	const workspaceList = useWorkspaceList();
+	const selection = useResolvedCursor("stacks", outlineNavigationIndex);
 
 	const dispatch = useAppDispatch();
 	const { mutate: executeOperation } = useExecuteOperation();
 
-	const target = getTransferTarget(keyboardTransferMode(mode), selection, detailsSelectionScope);
+	const target = getTransferTarget(keyboardTransferMode(mode), selection, workspaceList);
 	if (!target) return null;
 
 	const operations = getOperations(mode.sources, target);
@@ -325,7 +322,7 @@ const TransferKeyboardOperationControls: FC<{
 	};
 
 	const cancel = () => {
-		dispatch(projectSlice.actions.cancelMode({ projectId }));
+		cancelMode();
 	};
 
 	return (

--- a/apps/lite/ui/src/routes/project/$id/workspace/OperationSourceC.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OperationSourceC.tsx
@@ -1,4 +1,5 @@
 import { type Operand, operandEquals } from "#ui/operands.ts";
+import { cancelMode } from "#ui/use-cursor.ts";
 import { getOperationSources, pointerTransferMode } from "#ui/outline/mode.ts";
 import styles from "./OperationSourceC.module.css";
 import { operandsLabel } from "./operandLabel.ts";
@@ -96,7 +97,7 @@ export const OperationSourceC: FC<
 			onDrop: ({ location }) => {
 				if (location.current.dropTargets.length > 0) return;
 
-				dispatch(projectSlice.actions.cancelMode({ projectId }));
+				cancelMode();
 			},
 		});
 	}, [dispatch, projectId]);

--- a/apps/lite/ui/src/routes/project/$id/workspace/Outline.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Outline.tsx
@@ -1,4 +1,5 @@
 import { useBranchCreate, useWorkspaceIntegrateUpstream } from "#ui/api/mutations.ts";
+import { setCursor, setPage, usePage } from "#ui/use-cursor.ts";
 import {
 	guiSettingsQueryOptions,
 	headInfoQueryOptions,
@@ -131,24 +132,17 @@ export const Outline: FC<{
 	const isDefaultMode = useAppSelector(
 		(state) => projectSlice.selectors.selectOutlineModeState(state, projectId)._tag === "Default",
 	);
-	const outlineTab = useAppSelector((state) =>
-		projectSlice.selectors.selectOutlineTab(state, projectId),
-	);
+	const outlineTab = usePage();
 
 	const selectOutlineTab = (value: Array<OutlineTab>) => {
 		const head = value[0];
 		if (head === undefined) return;
 
-		dispatch(projectSlice.actions.setOutlineTab({ projectId, tab: head }));
+		setPage(head);
 	};
 
 	const selectBranch = (branch: BranchOperand) => {
-		dispatch(
-			projectSlice.actions.selectOutline({
-				projectId,
-				selection: branchOperand(branch),
-			}),
-		);
+		setCursor("stacks", branchOperand(branch));
 		focusSelectionScope("outline");
 	};
 
@@ -268,12 +262,7 @@ export const Outline: FC<{
 		{
 			hotkey: "[",
 			callback: () => {
-				dispatch(
-					projectSlice.actions.setOutlineTab({
-						projectId,
-						tab: adjacentOutlineTab(outlineTab, -1),
-					}),
-				);
+				setPage(adjacentOutlineTab(outlineTab, -1));
 			},
 			options: {
 				conflictBehavior: "allow",
@@ -283,9 +272,7 @@ export const Outline: FC<{
 		{
 			hotkey: "]",
 			callback: () => {
-				dispatch(
-					projectSlice.actions.setOutlineTab({ projectId, tab: adjacentOutlineTab(outlineTab, 1) }),
-				);
+				setPage(adjacentOutlineTab(outlineTab, 1));
 			},
 			options: {
 				conflictBehavior: "allow",

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/BranchRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/BranchRow.tsx
@@ -1,5 +1,12 @@
 import rowStyles from "../Row.module.css";
 import {
+	currentParams,
+	enterKeyboardTransfer,
+	setCursor,
+	startRenameBranch,
+} from "#ui/use-cursor.ts";
+import { commitParamRef } from "#ui/cursor-url.ts";
+import {
 	useBranchCreate,
 	useBranchRemove,
 	useCommitInsertBlank,
@@ -36,7 +43,7 @@ import { branchOperand, operandEquals, type BranchOperand } from "#ui/operands.t
 import { projectSlice } from "#ui/projects/state.ts";
 import { focusSelectionScope } from "#ui/selection-scopes.ts";
 import { getHeadInfoIndex } from "#ui/api/ref-info.ts";
-import { useAppDispatch, useAppSelector, useAppStore } from "#ui/store.ts";
+import { useAppDispatch, useAppSelector } from "#ui/store.ts";
 import { prForgeUrl } from "#ui/pr.ts";
 import { Badge, type BadgeVariant } from "#ui/components/Badge.tsx";
 import {
@@ -154,7 +161,6 @@ export const BranchRow: FC<
 		pullRequest !== null ? forgeInfo && ciChecksSummaryUrl(pullRequest, forgeInfo) : null;
 
 	const dispatch = useAppDispatch();
-	const store = useAppStore();
 	const branchOperandV: BranchOperand = {
 		branchRef: refName.fullNameBytes,
 	};
@@ -184,12 +190,12 @@ export const BranchRow: FC<
 	const { mutateAsync: branchRename } = useBranchRename();
 
 	const startEditing = () => {
-		dispatch(projectSlice.actions.startRenameBranch({ projectId, branch: branchOperandV }));
+		startRenameBranch(branchOperandV);
 	};
 
 	const endEditing = () => {
 		dispatch(projectSlice.actions.exitMode({ projectId }));
-		dispatch(projectSlice.actions.selectOutline({ projectId, selection: operand }));
+		setCursor("stacks", operand);
 		focusSelectionScope("outline");
 	};
 
@@ -236,12 +242,7 @@ export const BranchRow: FC<
 		side === "below" && bottomRelativeTo !== null ? bottomRelativeTo : relativeTo;
 
 	const cutBranch = () => {
-		dispatch(
-			projectSlice.actions.enterKeyboardTransferMode({
-				projectId,
-				sources: [operand],
-			}),
-		);
+		enterKeyboardTransfer({ sources: [operand] });
 		focusSelectionScope("outline");
 	};
 
@@ -269,14 +270,7 @@ export const BranchRow: FC<
 			},
 			{
 				onSuccess: (response) => {
-					dispatch(
-						projectSlice.actions.selectOutline({
-							projectId,
-							selection: branchOperand({
-								branchRef: response.newRef.fullNameBytes,
-							}),
-						}),
-					);
+					setCursor("stacks", branchOperand({ branchRef: response.newRef.fullNameBytes }));
 				},
 			},
 		);
@@ -327,14 +321,13 @@ export const BranchRow: FC<
 		// Hand the selection over only when folding would hide it — the selected
 		// commit sits in this segment. Unrelated selections (and the details pane
 		// they drive) stay put.
-		const stored = projectSlice.selectors.selectPrimaryOutlineSelection(
-			store.getState(),
-			projectId,
-		);
+		const commitRef = commitParamRef(currentParams().stacks);
 		const storedSegmentRef =
-			stored?._tag === "Commit"
-				? headInfoIndex?.commitContextByCommitId(stored.commitId)?.segment.refName
-				: undefined;
+			commitRef === null
+				? undefined
+				: "changeId" in commitRef
+					? headInfoIndex?.commitContextsByChangeId(commitRef.changeId)?.[0].segment.refName
+					: headInfoIndex?.commitContextByCommitId(commitRef.commitId)?.segment.refName;
 		const foldHidesSelection =
 			!isFolded &&
 			storedSegmentRef != null &&
@@ -421,7 +414,6 @@ export const BranchRow: FC<
 	return (
 		<ItemRow
 			{...restProps}
-			projectId={projectId}
 			operand={operand}
 			onContextMenu={(event) => {
 				void showNativeContextMenu(event, menuItems);

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/CommitRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/CommitRow.tsx
@@ -1,4 +1,5 @@
 import rowStyles from "../Row.module.css";
+import { enterKeyboardTransfer, setCursor, startRewordCommit } from "#ui/use-cursor.ts";
 import {
 	useBranchCreate,
 	useCommitDiscard,
@@ -137,14 +138,7 @@ export const CommitRow: FC<
 			},
 			{
 				onSuccess: (response) => {
-					dispatch(
-						projectSlice.actions.selectOutline({
-							projectId,
-							selection: branchOperand({
-								branchRef: response.newRef.fullNameBytes,
-							}),
-						}),
-					);
+					setCursor("stacks", branchOperand({ branchRef: response.newRef.fullNameBytes }));
 				},
 			},
 		);
@@ -182,12 +176,7 @@ export const CommitRow: FC<
 						});
 					}
 
-					dispatch(
-						projectSlice.actions.selectOutline({
-							projectId,
-							selection: latestSelectionAfterDiscard,
-						}),
-					);
+					setCursor("stacks", latestSelectionAfterDiscard);
 				},
 			},
 		);
@@ -199,12 +188,7 @@ export const CommitRow: FC<
 			? projectSlice.selectors.selectCheckedOperands(state, projectId)
 			: [operand];
 
-		dispatch(
-			projectSlice.actions.enterKeyboardTransferMode({
-				projectId,
-				sources,
-			}),
-		);
+		enterKeyboardTransfer({ sources });
 		focusSelectionScope("outline");
 	};
 
@@ -223,12 +207,12 @@ export const CommitRow: FC<
 	};
 
 	const startEditing = () => {
-		dispatch(projectSlice.actions.startRewordCommit({ projectId, commit: commitOperandV }));
+		startRewordCommit(commitOperandV);
 	};
 
 	const endEditing = () => {
 		dispatch(projectSlice.actions.exitMode({ projectId }));
-		dispatch(projectSlice.actions.selectOutline({ projectId, selection: operand }));
+		setCursor("stacks", operand);
 		focusSelectionScope("outline");
 	};
 
@@ -353,7 +337,6 @@ export const CommitRow: FC<
 	return (
 		<ItemRow
 			{...restProps}
-			projectId={projectId}
 			operand={operand}
 			isChecked={isChecked}
 			isHighlighted={isHighlighted}

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/ItemRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/ItemRow.tsx
@@ -1,7 +1,6 @@
 import { NavigationIndexContext } from "../OutlineNavigationIndexContext.ts";
+import { setCursor, useIsCursorAt } from "#ui/use-cursor.ts";
 import { Row } from "../Row.tsx";
-import { projectSlice } from "#ui/projects/state.ts";
-import { useAppDispatch, useAppSelector } from "#ui/store.ts";
 import { operandIdentityKey, type Operand } from "#ui/operands.ts";
 import { navigationIndexIncludes } from "#ui/workspace/navigation-index.ts";
 import { type ComponentProps, type FC, use } from "react";
@@ -9,17 +8,13 @@ import { assert } from "#ui/assert.ts";
 
 export const ItemRow: FC<
 	{
-		projectId: string;
 		operand: Operand;
 	} & Omit<ComponentProps<typeof Row>, "inert" | "isSelected" | "onSelect">
-> = ({ projectId, operand, ...props }) => {
-	const dispatch = useAppDispatch();
+> = ({ operand, ...props }) => {
 	const navigationIndex = assert(use(NavigationIndexContext));
-	const isSelected = useAppSelector((state) =>
-		projectSlice.selectors.selectIsSelectedOutline(state, projectId, navigationIndex, operand),
-	);
+	const isSelected = useIsCursorAt("stacks", navigationIndex, operand);
 	const selectItem = () => {
-		dispatch(projectSlice.actions.selectOutline({ projectId, selection: operand }));
+		setCursor("stacks", operand);
 	};
 
 	return (

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
@@ -1,4 +1,11 @@
 import rowStyles from "../Row.module.css";
+import {
+	setCursor,
+	setWorkspaceList,
+	useIsCursorAt,
+	useResolvedCursor,
+	useWorkspaceList,
+} from "#ui/use-cursor.ts";
 import { useCommitAmend } from "#ui/api/mutations.ts";
 import { changesInWorktreeQueryOptions, headInfoQueryOptions } from "#ui/api/queries.ts";
 import { getHeadInfoIndex } from "#ui/api/ref-info.ts";
@@ -106,14 +113,11 @@ type PanelId = "uncommitted-changes-panel" | "stacks-panel";
 
 const TreeItem: FC<
 	{
-		projectId: string;
 		operand: Operand;
 	} & useRender.ComponentProps<"div">
-> = ({ projectId, operand, render, ...props }) => {
+> = ({ operand, render, ...props }) => {
 	const navigationIndex = assert(use(NavigationIndexContext));
-	const isSelected = useAppSelector((state) =>
-		projectSlice.selectors.selectIsSelectedOutline(state, projectId, navigationIndex, operand),
-	);
+	const isSelected = useIsCursorAt("stacks", navigationIndex, operand);
 
 	return useRender({
 		render,
@@ -140,17 +144,10 @@ const OperationTarget: FC<
 	const navigationIndex = assert(use(NavigationIndexContext));
 
 	type ActiveOperation = { placement: Placement; tooltip?: string | undefined };
+	const selection = useResolvedCursor("stacks", navigationIndex);
+	const workspaceList = useWorkspaceList();
 	const activeOperation = useAppSelector((state) => {
-		const selection = projectSlice.selectors.selectSelectionOutline(
-			state,
-			projectId,
-			navigationIndex,
-		);
 		const outlineMode = projectSlice.selectors.selectOutlineModeState(state, projectId);
-		const detailsSelectionScope = projectSlice.selectors.selectDetailsSelectionScope(
-			state,
-			projectId,
-		);
 
 		return Match.value(outlineMode).pipe(
 			Match.tags({
@@ -164,7 +161,7 @@ const OperationTarget: FC<
 				Transfer: ({ value: mode }): ActiveOperation | null => {
 					if (mode.placement === null) return null;
 
-					const target = getTransferTarget(mode, selection, detailsSelectionScope);
+					const target = getTransferTarget(mode, selection, workspaceList);
 					const isActive = target !== null && operandEquals(target, operand);
 					if (!isActive) return null;
 
@@ -308,9 +305,8 @@ const UncommittedChanges: FC<{
 		collapsedDirectories,
 	});
 
-	const fileSelection = useAppSelector((state) =>
-		projectSlice.selectors.selectSelectionUncommittedFiles(state, projectId, navigationIndex),
-	);
+	const fileSelection = useResolvedCursor("uncommitted", navigationIndex);
+	const workspaceList = useWorkspaceList();
 
 	const panelRef = useRef<HTMLDivElement>(null);
 	const fileListRef = useRef<HTMLDivElement>(null);
@@ -348,14 +344,7 @@ const UncommittedChanges: FC<{
 				<FilesTree
 					canUncommit={false}
 					selectionScope="uncommitted-files"
-					onFocus={() =>
-						dispatch(
-							projectSlice.actions.setDetailsSelectionScope({
-								projectId,
-								scope: "uncommitted-files",
-							}),
-						)
-					}
+					onFocus={() => setWorkspaceList("uncommitted")}
 					emptyLabel={
 						filter !== null && (worktreeChanges?.changes.length ?? 0) > 0
 							? "No matching files."
@@ -373,7 +362,10 @@ const UncommittedChanges: FC<{
 					onRowSelection={onActiveFileSelection}
 					onEdgeSpill={onEdgeSpill}
 					projectId={projectId}
-					ref={useMergedRefs(fileListRef, useAutofocusSelectionScope())}
+					ref={useMergedRefs(
+						fileListRef,
+						useAutofocusSelectionScope(workspaceList === "uncommitted"),
+					)}
 					selection={fileSelection}
 				/>
 			</Scroller>
@@ -435,7 +427,6 @@ const BranchSegment: FC<{
 
 	return (
 		<TreeItem
-			projectId={projectId}
 			operand={operand}
 			aria-label={refName.displayName}
 			aria-expanded
@@ -534,7 +525,6 @@ const SegmentContent: FC<{
 				return (
 					<TreeItem
 						key={commit.id}
-						projectId={projectId}
 						operand={operand}
 						aria-label={commitTitle(commit.message) ?? "(no message)"}
 						render={
@@ -668,24 +658,18 @@ const Stacks: FC<{
 	onEdgeSpill: (offset: -1 | 1) => void;
 }> = ({ projectId, checkCommit, onAmendCommit, canAmendCommit, onEdgeSpill }) => {
 	const navigationIndex = assert(use(NavigationIndexContext));
-	const dispatch = useAppDispatch();
 	const { data: headInfo } = useQuery(headInfoQueryOptions(projectId));
-	const selection = useAppSelector((state) =>
-		projectSlice.selectors.selectSelectionOutline(state, projectId, navigationIndex),
-	);
+	const selection = useResolvedCursor("stacks", navigationIndex);
+	const workspaceList = useWorkspaceList();
 	const dryRunOperation = useAppSelector((state) => {
 		const outlineMode = projectSlice.selectors.selectOutlineModeState(state, projectId);
-		const detailsSelectionScope = projectSlice.selectors.selectDetailsSelectionScope(
-			state,
-			projectId,
-		);
 
 		return Match.value(outlineMode).pipe(
 			Match.tags({
 				Transfer: ({ value: mode }) => {
 					if (mode.placement === null) return;
 
-					const target = getTransferTarget(mode, selection, detailsSelectionScope);
+					const target = getTransferTarget(mode, selection, workspaceList);
 					if (!target) return;
 
 					return getOperation({
@@ -724,10 +708,8 @@ const Stacks: FC<{
 				aria-activedescendant={selection ? treeItemId(selection) : undefined}
 				className={classes(styles.tree, styles.stacks)}
 				data-selection-scope={"outline" satisfies SelectionScope}
-				onFocus={() =>
-					dispatch(projectSlice.actions.setDetailsSelectionScope({ projectId, scope: "outline" }))
-				}
-				ref={hotkeysRef}
+				onFocus={() => setWorkspaceList("stacks")}
+				ref={useMergedRefs(hotkeysRef, useAutofocusSelectionScope(workspaceList === "stacks"))}
 			>
 				{(headInfo?.stacks.toReversed() ?? []).map((stack) => (
 					<StackC
@@ -766,9 +748,7 @@ export const OutlineTree: FC<
 	const { data: worktreeChanges } = useQuery(changesInWorktreeQueryOptions(projectId));
 	const headInfoIndex = headInfo ? getHeadInfoIndex(headInfo) : undefined;
 
-	const outlineSelection = useAppSelector((state) =>
-		projectSlice.selectors.selectSelectionOutline(state, projectId, navigationIndex),
-	);
+	const outlineSelection = useResolvedCursor("stacks", navigationIndex);
 	const commitTargetComboboxItems = buildCommitTargetComboboxItems({
 		headInfo,
 		headInfoIndex,
@@ -871,7 +851,7 @@ export const OutlineTree: FC<
 		if (offset !== 1) return;
 		const item = navigationIndex.items.at(0);
 		if (item === undefined) return;
-		dispatch(projectSlice.actions.selectOutline({ projectId, selection: item }));
+		setCursor("stacks", item);
 		focusSelectionScope("outline");
 	};
 	const spillIntoUncommittedChanges = (offset: -1 | 1) => {

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/UncommittedChangesRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/UncommittedChangesRow.tsx
@@ -1,4 +1,5 @@
 import { useDiscardWorktreeChanges } from "#ui/api/mutations.ts";
+import { enterAbsorb, enterKeyboardTransfer } from "#ui/use-cursor.ts";
 import { Icon } from "#ui/components/Icon.tsx";
 import { SelectionScopeKbd } from "#ui/components/SelectionScopeKbd.tsx";
 import { createDiffSpec } from "#ui/operations/diff-specs.ts";
@@ -13,7 +14,7 @@ import { uncommittedChangesOperand, type Operand } from "#ui/operands.ts";
 import { projectSlice } from "#ui/projects/state.ts";
 import { getLineStats } from "#ui/routes/project/$id/workspace/lineStats.ts";
 import { focusSelectionScope } from "#ui/selection-scopes.ts";
-import { useAppDispatch, useAppSelector } from "#ui/store.ts";
+import { useAppSelector } from "#ui/store.ts";
 import { Toolbar } from "@base-ui/react";
 import type { AbsorptionTarget, TreeChange } from "@gitbutler/but-sdk";
 import type { FC } from "react";
@@ -42,9 +43,8 @@ export const UncommittedChangesRow: FC<{
 		useDiscardWorktreeChanges();
 	const fileDisplayModeMenuItems = useFileDisplayModeMenuItems();
 
-	const dispatch = useAppDispatch();
 	const enterAbsorbMode = (source: Operand, sourceTarget: AbsorptionTarget) => {
-		dispatch(projectSlice.actions.enterAbsorbMode({ projectId, source, sourceTarget }));
+		enterAbsorb({ source, sourceTarget });
 	};
 
 	const absorb = () => {
@@ -52,12 +52,7 @@ export const UncommittedChangesRow: FC<{
 	};
 
 	const cutChanges = () => {
-		dispatch(
-			projectSlice.actions.enterKeyboardTransferMode({
-				projectId,
-				sources: [operand],
-			}),
-		);
+		enterKeyboardTransfer({ sources: [operand] });
 		focusSelectionScope("outline");
 	};
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/fold.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/fold.ts
@@ -1,4 +1,5 @@
 import { decodeBytes } from "#ui/api/bytes.ts";
+import { setCursor } from "#ui/use-cursor.ts";
 import { branchOperand } from "#ui/operands.ts";
 import { projectSlice } from "#ui/projects/state.ts";
 import type { AppDispatch } from "#ui/store.ts";
@@ -20,14 +21,8 @@ export const toggleFoldedSegment = (
 		select,
 	}: { projectId: string; branchRefBytes: Array<number>; select: boolean },
 ) => {
-	if (select) {
-		dispatch(
-			projectSlice.actions.selectOutline({
-				projectId,
-				selection: branchOperand({ branchRef: branchRefBytes }),
-			}),
-		);
-	}
+	if (select) setCursor("stacks", branchOperand({ branchRef: branchRefBytes }));
+
 	dispatch(
 		projectSlice.actions.toggleSegmentFolded({
 			projectId,

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/hotkeys.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/hotkeys.ts
@@ -8,6 +8,12 @@ import {
 	useWorkspaceBranchAndAncestorsPush,
 	useWorkspaceIntegrateUpstream,
 } from "#ui/api/mutations.ts";
+import {
+	setCursor,
+	startRenameBranch,
+	startRewordCommit,
+	useResolvedCursor,
+} from "#ui/use-cursor.ts";
 import { forgeInfoOptions, headInfoQueryOptions } from "#ui/api/queries.ts";
 import { decodeBytes } from "#ui/api/bytes.ts";
 import { getHeadInfoIndex } from "#ui/api/ref-info.ts";
@@ -84,9 +90,7 @@ export const useOutlineTreeHotkeys = ({
 	});
 	const { data: forgeInfo } = useQuery(forgeInfoOptions(projectId));
 	const store = useAppStore();
-	const selection = useAppSelector((state) =>
-		projectSlice.selectors.selectSelectionOutline(state, projectId, navigationIndex),
-	);
+	const selection = useResolvedCursor("stacks", navigationIndex);
 	const isDefaultMode = useAppSelector(
 		(state) => projectSlice.selectors.selectOutlineModeState(state, projectId)._tag === "Default",
 	);
@@ -187,14 +191,7 @@ export const useOutlineTreeHotkeys = ({
 			},
 			{
 				onSuccess: (response) => {
-					dispatch(
-						projectSlice.actions.selectOutline({
-							projectId,
-							selection: branchOperand({
-								branchRef: response.newRef.fullNameBytes,
-							}),
-						}),
-					);
+					setCursor("stacks", branchOperand({ branchRef: response.newRef.fullNameBytes }));
 				},
 			},
 		);
@@ -308,12 +305,7 @@ export const useOutlineTreeHotkeys = ({
 						});
 					}
 
-					dispatch(
-						projectSlice.actions.selectOutline({
-							projectId,
-							selection: latestSelectionAfterDiscard,
-						}),
-					);
+					setCursor("stacks", latestSelectionAfterDiscard);
 				},
 			},
 		);
@@ -432,10 +424,8 @@ export const useOutlineTreeHotkeys = ({
 	useNavigationIndexHotkeys({
 		ref,
 		navigationIndex,
-		projectId,
 		group: "Outline",
-		select: (newItem) =>
-			dispatch(projectSlice.actions.selectOutline({ projectId, selection: newItem })),
+		select: (newItem) => setCursor("stacks", newItem),
 		selection,
 		onEdgeSpill,
 		getKey: operandIdentityKey,
@@ -472,7 +462,7 @@ export const useOutlineTreeHotkeys = ({
 					{
 						hotkey: outlineHotkeys.rewordCommit.hotkey,
 						callback: () => {
-							dispatch(projectSlice.actions.startRewordCommit({ projectId, commit: selection }));
+							startRewordCommit(selection);
 						},
 						options: {
 							conflictBehavior: "allow",
@@ -484,7 +474,7 @@ export const useOutlineTreeHotkeys = ({
 					{
 						hotkey: "F2",
 						callback: () => {
-							dispatch(projectSlice.actions.startRewordCommit({ projectId, commit: selection }));
+							startRewordCommit(selection);
 						},
 						options: {
 							conflictBehavior: "allow",
@@ -497,7 +487,7 @@ export const useOutlineTreeHotkeys = ({
 					{
 						hotkey: outlineHotkeys.renameBranch.hotkey,
 						callback: () => {
-							dispatch(projectSlice.actions.startRenameBranch({ projectId, branch: selection }));
+							startRenameBranch(selection);
 						},
 						options: {
 							conflictBehavior: "allow",
@@ -509,7 +499,7 @@ export const useOutlineTreeHotkeys = ({
 					{
 						hotkey: "F2",
 						callback: () => {
-							dispatch(projectSlice.actions.startRenameBranch({ projectId, branch: selection }));
+							startRenameBranch(selection);
 						},
 						options: {
 							conflictBehavior: "allow",

--- a/apps/lite/ui/src/routes/project/$id/workspace/Row-utils.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Row-utils.ts
@@ -1,7 +1,7 @@
 import { type ButtonSize, type ButtonVariant, getButtonClassName } from "#ui/components/Button.tsx";
 import { classes } from "#ui/components/classes.ts";
-import { operandEquals, operandIdentityKey, type Operand } from "#ui/operands.ts";
-import { useAppSelector, type RootState } from "#ui/store.ts";
+import { operandIdentityKey, type Operand } from "#ui/operands.ts";
+import { useCursorMatches } from "#ui/use-cursor.ts";
 import { Match } from "effect";
 import styles from "./Row.module.css";
 
@@ -18,28 +18,8 @@ export const treeItemId = (operand: Operand): string =>
 export const useIsSelected = (
 	projectId: string,
 	operand: Operand,
-	selectStored: (state: RootState, projectId: string) => Operand | null,
-): boolean =>
-	useAppSelector((state) => {
-		const stored = selectStored(state, projectId);
-		return stored !== null && operandEquals(stored, operand);
-	});
-
-/**
- * Rows highlight by comparing against the stored selection (see
- * `useIsSelected`), so whenever resolving against the index lands elsewhere —
- * entering the tab, or the selected item leaving the index — the list must
- * store the resolved selection to keep the two in agreement. Returns the
- * selection to store, or `null` when the two already agree; each list
- * dispatches its own select action for it in an effect.
- */
-export const selectionOutOfSync = (
-	selection: Operand | null,
-	storedSelection: Operand | null,
-): Operand | null =>
-	selection !== null && (storedSelection === null || !operandEquals(storedSelection, selection))
-		? selection
-		: null;
+	list: "stacks" | "branches" | "upstream",
+): boolean => useCursorMatches(list, operand);
 
 export const getRowButtonClassName = ({
 	variant = "ghost",

--- a/apps/lite/ui/src/routes/project/$id/workspace/TopLeftControls.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/TopLeftControls.tsx
@@ -1,20 +1,17 @@
 import { getButtonClassName } from "#ui/components/Button.tsx";
+import { outlineSelectionScopeOf } from "#ui/use-cursor.ts";
 import { Icon } from "#ui/components/Icon.tsx";
 import { TooltipPopup } from "#ui/components/Tooltip.tsx";
 import { interfaceSlice } from "#ui/interface/state.ts";
-import { projectSlice } from "#ui/projects/state.ts";
 import { focusSelectionScope } from "#ui/selection-scopes.ts";
-import { useAppDispatch, useAppSelector, useAppStore } from "#ui/store.ts";
+import { useAppDispatch, useAppSelector } from "#ui/store.ts";
 import { workspaceHotkeys } from "#ui/hotkeys.ts";
 import { Tooltip } from "@base-ui/react";
-import { useParams } from "@tanstack/react-router";
 import { useEffect, useState, type FC } from "react";
 import styles from "./TopLeftControls.module.css";
 
 const FullWindowButton: FC = () => {
 	const dispatch = useAppDispatch();
-	const store = useAppStore();
-	const { id: projectId } = useParams({ from: "/project/$id/workspace" });
 	const fullWindow = useAppSelector(interfaceSlice.selectors.selectDetailsFullWindow);
 
 	const toggle = () => {
@@ -22,13 +19,8 @@ const FullWindowButton: FC = () => {
 
 		// Toggling swaps this button for the copy in the other pane, so the click leaves focus on
 		// the body. Hand it to the pane the outline is folding out of, or back into.
-		const detailsSelectionScope = projectSlice.selectors.selectDetailsSelectionScope(
-			store.getState(),
-			projectId,
-		);
-		requestAnimationFrame(() =>
-			focusSelectionScope(fullWindow ? (detailsSelectionScope ?? "outline") : "diff"),
-		);
+		const outlineSelectionScope = outlineSelectionScopeOf();
+		requestAnimationFrame(() => focusSelectionScope(fullWindow ? outlineSelectionScope : "diff"));
 	};
 
 	return (

--- a/apps/lite/ui/src/routes/project/$id/workspace/UpstreamList.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/UpstreamList.tsx
@@ -1,4 +1,5 @@
 import rowStyles from "./Row.module.css";
+import { setCursor, useCursorWriteBack, useResolvedCursor } from "#ui/use-cursor.ts";
 import { Scroller } from "#ui/components/Scroller.tsx";
 import { commitTitle } from "#ui/commit.ts";
 import { getButtonClassName } from "#ui/components/Button.tsx";
@@ -16,25 +17,13 @@ import {
 	useNavigationIndexHotkeys,
 	type SelectionScope,
 } from "#ui/selection-scopes.ts";
-import { useAppDispatch, useAppSelector } from "#ui/store.ts";
+import { useAppDispatch } from "#ui/store.ts";
 import { RelativeTime } from "#ui/components/RelativeTime.tsx";
 import { Button } from "@base-ui/react";
 import { useMergedRefs } from "@base-ui/utils/useMergedRefs";
-import {
-	type ComponentProps,
-	type FC,
-	type MouseEvent,
-	useEffect,
-	useId,
-	useRef,
-	useState,
-} from "react";
+import { type ComponentProps, type FC, type MouseEvent, useId, useRef, useState } from "react";
 import { Row, RowLabel, RowLabelContainer, RowLabelFooter } from "./Row.tsx";
-import {
-	selectionOutOfSync,
-	treeItemId,
-	useIsSelected as useIsSelectedInList,
-} from "./Row-utils.ts";
+import { treeItemId, useIsSelected as useIsSelectedInList } from "./Row-utils.ts";
 import type {
 	UpstreamBranchItem,
 	UpstreamCommitItem,
@@ -46,7 +35,7 @@ import styles from "./UpstreamList.module.css";
 const pluralRules = new Intl.PluralRules("en");
 
 const useIsSelected = (projectId: string, operand: Operand): boolean =>
-	useIsSelectedInList(projectId, operand, projectSlice.selectors.selectPrimaryUpstreamSelection);
+	useIsSelectedInList(projectId, operand, "upstream");
 
 /**
  * The target branch the incoming commits below it belong to. It heads the card
@@ -70,7 +59,6 @@ const TargetCommitRow: FC<{ projectId: string; item: UpstreamCommitItem }> = ({
 	projectId,
 	item,
 }) => {
-	const dispatch = useAppDispatch();
 	const { commit, review, inWorkspace } = item;
 	const operand = commitOperand({ commitId: commit.id, changeId: commit.changeId ?? commit.id });
 	const isSelected = useIsSelected(projectId, operand);
@@ -92,9 +80,7 @@ const TargetCommitRow: FC<{ projectId: string; item: UpstreamCommitItem }> = ({
 			aria-label={title ?? "(no message)"}
 			aria-selected={isSelected}
 			isSelected={isSelected}
-			onSelect={() =>
-				dispatch(projectSlice.actions.selectUpstream({ projectId, selection: operand }))
-			}
+			onSelect={() => setCursor("upstream", operand)}
 		>
 			<GraphSegment glyph="commit" status={inWorkspace ? "Integrated" : "Upstream"} />
 			<div className={styles.label}>
@@ -349,7 +335,6 @@ export const UpstreamList: FC<
 	onUpdateWorkspace,
 	...restProps
 }) => {
-	const dispatch = useAppDispatch();
 	// Derived once in WorkspacePage and passed down, so the rendered list and the
 	// navigation index that resolves selection are the same object.
 	const {
@@ -363,28 +348,16 @@ export const UpstreamList: FC<
 		isError,
 	} = outline;
 
-	const selection = useAppSelector((state) =>
-		projectSlice.selectors.selectSelectionUpstream(state, projectId, navigationIndex),
-	);
-	const storedSelection = useAppSelector((state) =>
-		projectSlice.selectors.selectPrimaryUpstreamSelection(state, projectId),
-	);
-
-	const outOfSyncSelection = selectionOutOfSync(selection, storedSelection);
-	useEffect(() => {
-		if (outOfSyncSelection !== null)
-			dispatch(projectSlice.actions.selectUpstream({ projectId, selection: outOfSyncSelection }));
-	}, [dispatch, outOfSyncSelection, projectId]);
+	const selection = useResolvedCursor("upstream", navigationIndex);
+	useCursorWriteBack("upstream", navigationIndex);
 
 	const headingId = useId();
 	const hotkeysRef = useRef<HTMLDivElement>(null);
 
 	useNavigationIndexHotkeys({
 		navigationIndex,
-		projectId,
 		group: "Outline",
-		select: (newItem) =>
-			dispatch(projectSlice.actions.selectUpstream({ projectId, selection: newItem })),
+		select: (newItem) => setCursor("upstream", newItem),
 		selection,
 		ref: hotkeysRef,
 		getKey: operandIdentityKey,
@@ -420,9 +393,6 @@ export const UpstreamList: FC<
 					aria-activedescendant={selection ? treeItemId(selection) : undefined}
 					data-selection-scope={"outline" satisfies SelectionScope}
 					className={styles.card}
-					onFocus={() =>
-						dispatch(projectSlice.actions.setDetailsSelectionScope({ projectId, scope: "outline" }))
-					}
 					ref={useMergedRefs(hotkeysRef, useAutofocusSelectionScope())}
 				>
 					{targetLabel !== null && <TargetHeadRow label={targetLabel} />}

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
@@ -31,12 +31,11 @@ import {
 } from "@tanstack/react-query";
 import { useNavigate, useParams } from "@tanstack/react-router";
 import { Match } from "effect";
-import { type FC, Activity, useDeferredValue, useRef } from "react";
+import { type FC, Activity, useCallback, useDeferredValue, useMemo, useRef } from "react";
 import { Group, Panel, useDefaultLayout } from "react-resizable-panels";
 import {
 	branchOperand,
 	commitOperand,
-	fileOperand,
 	operandContains,
 	operandEquals,
 	operandIdentityKey,
@@ -45,7 +44,13 @@ import {
 	type Operand,
 	uncommittedChangesFileParent,
 } from "#ui/operands.ts";
-import { Details, type DiffViewerHandle } from "./Details.tsx";
+import {
+	BranchesDetails,
+	type DiffViewerHandle,
+	UncommittedFilesDetails,
+	UpstreamDetails,
+	WorkspaceDetails,
+} from "./Details.tsx";
 import { getDiffFileNavigation } from "./diff-view.ts";
 import { pathMatchesFilter } from "./file-row.ts";
 import {
@@ -71,6 +76,14 @@ import { useBranchesOutline } from "./useBranchesOutline.ts";
 import { useUpstreamOutline } from "./useUpstreamOutline.ts";
 import type { OutlineMode } from "#ui/outline/mode.ts";
 import { useStateReconciler as useReconcileState } from "#ui/reconcile.ts";
+import {
+	setCursor,
+	useCanShowFiles,
+	useOutlineSelectionScope,
+	usePage,
+	useResolvedCursor,
+	useWorkspaceList,
+} from "#ui/use-cursor.ts";
 import { defaultSettings } from "#ui/settings.ts";
 
 // This must be unique as to not collide with other IDs, and stable because it's
@@ -84,22 +97,16 @@ const useWorkspaceHotkeys = (projectId: string) => {
 	const filesVisibleState = useAppSelector((state) =>
 		projectSlice.selectors.selectFilesVisible(state, projectId),
 	);
-	const canShowFiles = useAppSelector((state) =>
-		projectSlice.selectors.selectCanShowFiles(state, projectId),
-	);
+	const canShowFiles = useCanShowFiles();
 	const activeElement = useActiveElement();
 	const focusedSelectionScope = getFocusedSelectionScope(activeElement);
 	const isDefaultMode = useAppSelector(
 		(state) => projectSlice.selectors.selectOutlineModeState(state, projectId)._tag === "Default",
 	);
 	const outlineVisible = !detailsFullWindow;
-	const outlineSelectionScope = useAppSelector((state) =>
-		projectSlice.selectors.selectDetailsSelectionScope(state, projectId),
-	);
+	const outlineSelectionScope = useOutlineSelectionScope();
 	const filesVisible = canShowFiles && filesVisibleState;
-	const outlineTab = useAppSelector((state) =>
-		projectSlice.selectors.selectOutlineTab(state, projectId),
-	);
+	const outlineTab = usePage();
 
 	const { isPending: isRestoreSnapshotPending, mutate: restoreSnapshot } = useRestoreSnapshot({
 		projectId,
@@ -383,26 +390,26 @@ const WorkspacePage: FC = () => {
 	// container, but that comes with other complexities and tradeoffs.
 	const didScrollToViaFileRef = useRef(false);
 
-	const onActiveFileSelection = (itemId: string, firstHunk: HunkOperand | null) => {
-		dispatch(
-			projectSlice.actions.selectDiff({
-				projectId,
-				selection: firstHunk,
-			}),
-		);
+	// useCallback, not compiler memoisation: the deferred details element below
+	// keys on this identity, so it must be stable by construction.
+	const onActiveFileSelection = useCallback(
+		(itemId: string, firstHunk: HunkOperand | null) => {
+			setCursor("diff", firstHunk);
 
-		if (renderAllFiles) {
-			didScrollToViaFileRef.current = true;
-			const viewer = viewerRef.current?.getInstance();
-			// Details selection is deferred, so the ref may still point at a viewer without this file.
-			if (!viewer?.getItem(itemId)) return;
+			if (renderAllFiles) {
+				didScrollToViaFileRef.current = true;
+				const viewer = viewerRef.current?.getInstance();
+				// Details selection is deferred, so the ref may still point at a viewer without this file.
+				if (!viewer?.getItem(itemId)) return;
 
-			viewer.scrollTo({
-				type: "item",
-				id: itemId,
-			});
-		}
-	};
+				viewer.scrollTo({
+					type: "item",
+					id: itemId,
+				});
+			}
+		},
+		[renderAllFiles],
+	);
 
 	const detailsFullWindow = useAppSelector(interfaceSlice.selectors.selectDetailsFullWindow);
 	const dialog = useAppSelector(interfaceSlice.selectors.selectDialogState);
@@ -413,12 +420,7 @@ const WorkspacePage: FC = () => {
 	useWorkspaceHotkeys(projectId);
 
 	const selectBranch = (branch: BranchOperand) => {
-		dispatch(
-			projectSlice.actions.selectOutline({
-				projectId,
-				selection: branchOperand(branch),
-			}),
-		);
+		setCursor("stacks", branchOperand(branch));
 		focusSelectionScope("outline");
 	};
 
@@ -509,29 +511,13 @@ const WorkspacePage: FC = () => {
 		foldedSegments,
 	});
 
-	const outlineTab = useAppSelector((state) =>
-		projectSlice.selectors.selectOutlineTab(state, projectId),
-	);
+	const outlineTab = usePage();
 	const branchesOutline = useBranchesOutline(projectId);
 	const upstreamOutline = useUpstreamOutline(projectId);
 
-	const outlineSelection = useAppSelector((state) =>
-		projectSlice.selectors.selectSelectionOutline(state, projectId, outlineNavigationIndex),
-	);
-	const branchesSelection = useAppSelector((state) =>
-		projectSlice.selectors.selectSelectionBranches(
-			state,
-			projectId,
-			branchesOutline.navigationIndex,
-		),
-	);
-	const upstreamSelection = useAppSelector((state) =>
-		projectSlice.selectors.selectSelectionUpstream(
-			state,
-			projectId,
-			upstreamOutline.navigationIndex,
-		),
-	);
+	const outlineSelection = useResolvedCursor("stacks", outlineNavigationIndex);
+	const branchesSelection = useResolvedCursor("branches", branchesOutline.navigationIndex);
+	const upstreamSelection = useResolvedCursor("upstream", upstreamOutline.navigationIndex);
 
 	const { data: worktreeChanges } = useQuery(changesInWorktreeQueryOptions(projectId));
 	const uncommittedFilesFilter = useAppSelector((state) =>
@@ -580,40 +566,59 @@ const WorkspacePage: FC = () => {
 					})
 				: null;
 
-		dispatch(projectSlice.actions.selectUncommittedFiles({ projectId, selection }));
+		setCursor("uncommitted", selection);
 		if (navigation) onActiveFileSelection(navigation.itemId, navigation.firstHunk);
 	};
 
-	const uncommittedFilesSelection = useAppSelector((state) =>
-		projectSlice.selectors.selectSelectionUncommittedFiles(
-			state,
-			projectId,
-			uncommittedFilesNavigationIndex,
-		),
+	const uncommittedFilesSelection = useResolvedCursor(
+		"uncommitted",
+		uncommittedFilesNavigationIndex,
 	);
 
-	const detailsSelectionScope = useAppSelector((state) =>
-		projectSlice.selectors.selectDetailsSelectionScope(state, projectId),
-	);
-	const detailsSelection = Match.value(detailsSelectionScope).pipe(
-		Match.when("outline", () =>
-			Match.value(outlineTab).pipe(
-				Match.when("workspace", () => outlineSelection),
-				Match.when("upstream", () => upstreamSelection),
-				Match.when("branches", () => branchesSelection),
-				Match.exhaustive,
+	const workspaceList = useWorkspaceList();
+	// The pane's content is one component per page, as the outline has one list
+	// per tab — the component tree, not a tag on the selection, carries where a
+	// selection came from. Only the workspace page has two lists, so only its arm
+	// asks which one drives. Memoised because `useDeferredValue` compares by
+	// identity, so a freshly built element every render would defer every render.
+	const details = useMemo(() => {
+		const viewProps = { onActiveFileSelection, viewerRef, didScrollToViaFileRef };
+
+		return Match.value(outlineTab).pipe(
+			Match.when("workspace", () =>
+				Match.value(workspaceList).pipe(
+					Match.when("stacks", () => (
+						<WorkspaceDetails selection={outlineSelection} {...viewProps} />
+					)),
+					Match.when(
+						"uncommitted",
+						() =>
+							uncommittedFilesSelection !== null && (
+								<UncommittedFilesDetails path={uncommittedFilesSelection} {...viewProps} />
+							),
+					),
+					Match.exhaustive,
+				),
 			),
-		),
-		Match.when("uncommitted-files", () =>
-			uncommittedFilesSelection === null
-				? null
-				: fileOperand({ parent: uncommittedChangesFileParent, path: uncommittedFilesSelection }),
-		),
-		Match.when(null, () => null),
-		Match.exhaustive,
-	);
+			Match.when("upstream", () => (
+				<UpstreamDetails selection={upstreamSelection} {...viewProps} />
+			)),
+			Match.when("branches", () => (
+				<BranchesDetails selection={branchesSelection} {...viewProps} />
+			)),
+			Match.exhaustive,
+		);
+	}, [
+		branchesSelection,
+		onActiveFileSelection,
+		outlineSelection,
+		outlineTab,
+		uncommittedFilesSelection,
+		upstreamSelection,
+		workspaceList,
+	]);
 
-	const deferredDetailsSelection = useDeferredValue(detailsSelection);
+	const deferredDetails = useDeferredValue(details);
 
 	const { data: projects } = useSuspenseQuery(listProjectsQueryOptions);
 	const project = projects.find((candidate) => candidate.id === projectId);
@@ -691,12 +696,7 @@ const WorkspacePage: FC = () => {
 					className={styles.panel}
 					data-selection-scope={"details" satisfies SelectionScope}
 				>
-					<Details
-						selection={deferredDetailsSelection}
-						onActiveFileSelection={onActiveFileSelection}
-						viewerRef={viewerRef}
-						didScrollToViaFileRef={didScrollToViaFileRef}
-					/>
+					{deferredDetails}
 				</Panel>
 			</Group>
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/diff-hunk-drag.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/diff-hunk-drag.ts
@@ -1,4 +1,5 @@
 import { headInfoQueryOptions } from "#ui/api/queries.ts";
+import { cancelMode } from "#ui/use-cursor.ts";
 import { getHeadInfoIndex } from "#ui/api/ref-info.ts";
 import { hunkOperand, type HunkOperand } from "#ui/operands.ts";
 import { pointerTransferMode } from "#ui/outline/mode.ts";
@@ -177,8 +178,7 @@ export const useDiffHunkDrag = <T>({
 			onDrop: ({ location }) => {
 				if (location.current.dropTargets.length > 0) return;
 
-				const config = configRef.current;
-				config.dispatch(projectSlice.actions.cancelMode({ projectId: config.projectId }));
+				cancelMode();
 			},
 		});
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/route.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/route.tsx
@@ -1,9 +1,29 @@
 import { Route as projectRoute } from "#ui/routes/project/$id/route.tsx";
+import type { UrlQueryParams } from "#ui/cursor-url.ts";
 import { createRoute } from "@tanstack/react-router";
 import { Route as WorkspacePageRoute } from "./WorkspacePage.tsx";
+
+const str = (value: unknown): string | undefined =>
+	typeof value === "string" && value !== "" ? value : undefined;
 
 export const Route = createRoute({
 	getParentRoute: () => projectRoute,
 	path: "workspace",
 	component: WorkspacePageRoute,
+	// Total decoding: a param that fails its codec is absent, never an error,
+	// so a corrupt or stale URL opens the page at defaults.
+	validateSearch: (params: Record<string, unknown>): UrlQueryParams => {
+		const page = str(params.page);
+		const list = str(params.list);
+
+		return {
+			page: page === "upstream" || page === "branches" ? page : undefined,
+			list: list === "uncommitted" ? list : undefined,
+			stacks: str(params.stacks),
+			uncommitted: str(params.uncommitted),
+			branches: str(params.branches),
+			upstream: str(params.upstream),
+			files: str(params.files),
+		};
+	},
 });

--- a/apps/lite/ui/src/routes/project/$id/workspace/useApplyToWorkspace.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/useApplyToWorkspace.ts
@@ -1,8 +1,7 @@
 import { useApply } from "#ui/api/mutations.ts";
+import { setCursor, setPage } from "#ui/use-cursor.ts";
 import { encodeBytes } from "#ui/api/bytes.ts";
 import { branchOperand } from "#ui/operands.ts";
-import { projectSlice } from "#ui/projects/state.ts";
-import { useAppDispatch } from "#ui/store.ts";
 
 /**
  * Apply a branch and follow it into the workspace: on success the outline
@@ -10,7 +9,6 @@ import { useAppDispatch } from "#ui/store.ts";
  * details pane stays on the branch the user was looking at.
  */
 export const useApplyToWorkspace = (projectId: string) => {
-	const dispatch = useAppDispatch();
 	const { isPending, mutate } = useApply();
 
 	const apply = (branchRef: string) => {
@@ -23,13 +21,8 @@ export const useApplyToWorkspace = (projectId: string) => {
 					const appliedRef = response.appliedBranches[0];
 					if (!appliedRef) return;
 
-					dispatch(projectSlice.actions.setOutlineTab({ projectId, tab: "workspace" }));
-					dispatch(
-						projectSlice.actions.selectOutline({
-							projectId,
-							selection: branchOperand({ branchRef: encodeBytes(appliedRef.full) }),
-						}),
-					);
+					setPage("workspace");
+					setCursor("stacks", branchOperand({ branchRef: encodeBytes(appliedRef.full) }));
 				},
 			},
 		);

--- a/apps/lite/ui/src/routes/project/$id/workspace/useBranchesOutline.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/useBranchesOutline.ts
@@ -1,4 +1,5 @@
 import { branchDetailsQueryOptions, branchListQueryOptions } from "#ui/api/queries.ts";
+import { usePage } from "#ui/use-cursor.ts";
 import { encodeBytes } from "#ui/api/bytes.ts";
 import {
 	branchDetailsParams,
@@ -41,9 +42,7 @@ const emptyContent: OutlineContent = {
  * filtering and fold state cannot drift between the two.
  */
 export const useBranchesOutline = (projectId: string): BranchesOutline => {
-	const active = useAppSelector(
-		(state) => projectSlice.selectors.selectOutlineTab(state, projectId) === "branches",
-	);
+	const active = usePage() === "branches";
 	const filters = useAppSelector((state) =>
 		projectSlice.selectors.selectBranchFilters(state, projectId),
 	);

--- a/apps/lite/ui/src/routes/project/$id/workspace/useFileMenuItems.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/useFileMenuItems.ts
@@ -1,4 +1,5 @@
 import { useDiscardFileChanges, useOpenInProgram } from "#ui/api/mutations.ts";
+import { enterAbsorb, enterKeyboardTransfer } from "#ui/use-cursor.ts";
 import {
 	guiSettingsQueryOptions,
 	listEditorsQueryOptions,
@@ -12,7 +13,7 @@ import {
 import { type NativeMenuItem, nativeMenuItem, nativeMenuItemsFromGroups } from "#ui/native-menu.ts";
 import { fileOperand, type FileOperand } from "#ui/operands.ts";
 import { projectSlice } from "#ui/projects/state.ts";
-import { useAppDispatch, useAppSelector, useAppStore } from "#ui/store.ts";
+import { useAppSelector, useAppStore } from "#ui/store.ts";
 import { focusSelectionScope } from "#ui/selection-scopes.ts";
 import type { TreeChange } from "@gitbutler/but-sdk";
 import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
@@ -33,7 +34,6 @@ export const useFileMenuItems = ({
 	canUncommit: boolean;
 	uncommit?: (change: TreeChange, extendToCheckedFiles: boolean) => void;
 }): Array<NativeMenuItem> => {
-	const dispatch = useAppDispatch();
 	const store = useAppStore();
 	const { data: projects } = useSuspenseQuery(listProjectsQueryOptions);
 	const { data: editors } = useQuery(listEditorsQueryOptions);
@@ -69,12 +69,7 @@ export const useFileMenuItems = ({
 			? projectSlice.selectors.selectCheckedOperands(state, projectId)
 			: [source];
 
-		dispatch(
-			projectSlice.actions.enterKeyboardTransferMode({
-				projectId,
-				sources,
-			}),
-		);
+		enterKeyboardTransfer({ sources });
 		focusSelectionScope("outline");
 	};
 
@@ -159,19 +154,16 @@ export const useFileMenuItems = ({
 					]),
 					Match.when({ parent: { _tag: "UncommittedChanges" } }, (operand) => {
 						const absorb = () => {
-							dispatch(
-								projectSlice.actions.enterAbsorbMode({
-									projectId,
-									source: fileOperand(operand),
-									sourceTarget: {
-										type: "treeChanges",
-										subject: {
-											changes: [change],
-											assignedStackId: null,
-										},
+							enterAbsorb({
+								source: fileOperand(operand),
+								sourceTarget: {
+									type: "treeChanges",
+									subject: {
+										changes: [change],
+										assignedStackId: null,
 									},
-								}),
-							);
+								},
+							});
 							focusSelectionScope("outline");
 						};
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/useHunkMenuItems.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/useHunkMenuItems.ts
@@ -4,6 +4,7 @@ import {
 	useDiscardWorktreeChanges,
 	useOpenInProgram,
 } from "#ui/api/mutations.ts";
+import { enterKeyboardTransfer } from "#ui/use-cursor.ts";
 import {
 	guiSettingsQueryOptions,
 	listEditorsQueryOptions,
@@ -16,7 +17,7 @@ import { hunkOperand, type HunkOperand } from "#ui/operands.ts";
 import { createDiffSpec } from "#ui/operations/diff-specs.ts";
 import { projectSlice } from "#ui/projects/state.ts";
 import { focusSelectionScope } from "#ui/selection-scopes.ts";
-import { useAppDispatch, useAppStore } from "#ui/store.ts";
+import { useAppStore } from "#ui/store.ts";
 import type { TreeChange } from "@gitbutler/but-sdk";
 import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { Match } from "effect";
@@ -32,7 +33,6 @@ export const useHunkMenuItems = ({
 }: {
 	projectId: string;
 }): ((target: HunkMenuTarget) => Array<NativeMenuItem>) => {
-	const dispatch = useAppDispatch();
 	const store = useAppStore();
 	const { data: projects } = useSuspenseQuery(listProjectsQueryOptions);
 	const { data: editors } = useQuery(listEditorsQueryOptions);
@@ -60,12 +60,7 @@ export const useHunkMenuItems = ({
 			const sources = projectSlice.selectors.selectOperandChecked(state, projectId, source)
 				? projectSlice.selectors.selectCheckedOperands(state, projectId)
 				: [source];
-			dispatch(
-				projectSlice.actions.enterKeyboardTransferMode({
-					projectId,
-					sources,
-				}),
-			);
+			enterKeyboardTransfer({ sources });
 			focusSelectionScope("outline");
 		};
 		const discardDiffSpec = createDiffSpec(

--- a/apps/lite/ui/src/routes/project/$id/workspace/useOperationDropTarget.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/useOperationDropTarget.ts
@@ -4,6 +4,7 @@ import {
 	type Placement,
 	useExecuteOperation,
 } from "#ui/operations/operation.ts";
+import { cancelMode } from "#ui/use-cursor.ts";
 import type { Operand } from "#ui/operands.ts";
 import { projectSlice } from "#ui/projects/state.ts";
 import { useAppDispatch } from "#ui/store.ts";
@@ -120,7 +121,7 @@ export const useOperationDropTarget = ({
 						: null;
 
 				if (!operation) {
-					dispatch(projectSlice.actions.cancelMode({ projectId }));
+					cancelMode();
 					return;
 				}
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/useUpstreamOutline.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/useUpstreamOutline.ts
@@ -1,4 +1,5 @@
 import { headInfoQueryOptions, workspaceTargetCommitsQueryOptions } from "#ui/api/queries.ts";
+import { usePage } from "#ui/use-cursor.ts";
 import { commitOperand, operandIdentityKey, type Operand } from "#ui/operands.ts";
 import { projectSlice } from "#ui/projects/state.ts";
 import { useAppSelector } from "#ui/store.ts";
@@ -239,9 +240,7 @@ const buildItems = (
  * workspace page consume it, so the two cannot drift apart.
  */
 export const useUpstreamOutline = (projectId: string): UpstreamOutline => {
-	const active = useAppSelector(
-		(state) => projectSlice.selectors.selectOutlineTab(state, projectId) === "upstream",
-	);
+	const active = usePage() === "upstream";
 	const expandedSegments = useAppSelector((state) =>
 		projectSlice.selectors.selectExpandedUpstreamSegments(state, projectId),
 	);

--- a/apps/lite/ui/src/selection-scopes.ts
+++ b/apps/lite/ui/src/selection-scopes.ts
@@ -1,8 +1,7 @@
 import { selectionOperationHotkeys, type CommandGroup } from "#ui/hotkeys.ts";
+import { enterKeyboardTransfer } from "#ui/use-cursor.ts";
 import type { Placement } from "#ui/operations/operation.ts";
 import type { Operand } from "#ui/operands.ts";
-import { projectSlice } from "#ui/projects/state.ts";
-import { useAppDispatch } from "#ui/store.ts";
 import { getAdjacent, type NavigationIndex } from "#ui/workspace/navigation-index.ts";
 import { useHotkeySequences, useHotkeys } from "@tanstack/react-hotkeys";
 import { useRef } from "react";
@@ -125,11 +124,19 @@ export const focusHorizontalSelectionScope = ({
  * as it hides and reveals a subtree, and focusing on a reveal would switch the details pane away
  * from whatever the user had selected before hiding it.
  */
-export const useAutofocusSelectionScope = () => {
+export const useAutofocusSelectionScope = (enabled = true) => {
 	const attached = useRef(false);
 
 	return (el: HTMLElement | null) => {
 		if (el === null || attached.current) return;
+
+		// A list that is not the one driving the pane must not take focus on
+		// mount: its onFocus would then name it the driving list, so autofocus
+		// would decide where the URL says the user is. Checked before the latch,
+		// which records having taken the one autofocus rather than having seen a
+		// ref, so a list that starts out passive can still take it later.
+		if (!enabled) return;
+
 		attached.current = true;
 
 		// Don't steal focus if this component is mounted later on.
@@ -141,7 +148,6 @@ export const useAutofocusSelectionScope = () => {
 
 export const useNavigationIndexHotkeys = <T>({
 	navigationIndex,
-	projectId,
 	group,
 	select,
 	selection,
@@ -152,7 +158,6 @@ export const useNavigationIndexHotkeys = <T>({
 	getKey,
 }: {
 	navigationIndex: NavigationIndex<T>;
-	projectId: string;
 	group: CommandGroup;
 	select: (newItem: T) => void;
 	selection: T | null;
@@ -168,8 +173,6 @@ export const useNavigationIndexHotkeys = <T>({
 	onEdgeSpill?: (offset: -1 | 1) => void;
 	getKey: (item: T) => string;
 }) => {
-	const dispatch = useAppDispatch();
-
 	const moveSelection = (offset: -1 | 1) => {
 		const newItem =
 			selection === null
@@ -355,13 +358,7 @@ export const useNavigationIndexHotkeys = <T>({
 	const enterTransferModeForSelection = (placement: Placement) => {
 		if (selection === null || operationSourcesForItem === undefined) return;
 
-		dispatch(
-			projectSlice.actions.enterKeyboardTransferMode({
-				projectId,
-				sources: operationSourcesForItem(selection),
-				placement,
-			}),
-		);
+		enterKeyboardTransfer({ sources: operationSourcesForItem(selection), placement });
 
 		focusSelectionScope("outline");
 	};

--- a/apps/lite/ui/src/store.ts
+++ b/apps/lite/ui/src/store.ts
@@ -11,7 +11,7 @@ export const store = configureStore({
 });
 
 type AppStore = typeof store;
-export type RootState = ReturnType<AppStore["getState"]>;
+type RootState = ReturnType<AppStore["getState"]>;
 export type AppDispatch = AppStore["dispatch"];
 
 export const useAppStore = useStore.withTypes<AppStore>();

--- a/apps/lite/ui/src/use-cursor.ts
+++ b/apps/lite/ui/src/use-cursor.ts
@@ -1,0 +1,398 @@
+import {
+	cursorKey,
+	type ListItem,
+	type ListName,
+	type WorkspaceCursorSnapshot,
+} from "#ui/cursors.ts";
+import {
+	encodeCursorParam,
+	isUrlList,
+	type UrlListName,
+	type UrlQueryParams,
+} from "#ui/cursor-url.ts";
+import { isValidOutlineModeForSelection } from "#ui/outline/mode.ts";
+import { branchOperand, commitOperand } from "#ui/operands.ts";
+import type { BranchOperand, CommitOperand, Operand } from "#ui/operands.ts";
+import type { OutlineTab, WorkspaceList } from "#ui/projects/project.ts";
+import { projectSlice } from "#ui/projects/state.ts";
+import { writeLastPlace } from "#ui/project.ts";
+import { router } from "#ui/router.ts";
+import { store, useAppSelector } from "#ui/store.ts";
+import {
+	resolveNavigationIndexSelection,
+	type NavigationIndex,
+} from "#ui/workspace/navigation-index.ts";
+import type { AbsorptionTarget } from "@gitbutler/but-sdk";
+import { useSearch } from "@tanstack/react-router";
+import { useEffect } from "react";
+
+/**
+ * The one way in and out of navigation state. The URL holds the page, the
+ * driving list and every addressable cursor; the store holds only the diff
+ * cursor (see cursor-url.ts for why). Callers never see the split: reads are
+ * hooks here, writes are plain calls — the router and the store are both
+ * module-level, so moving a cursor needs no dispatch and no hook.
+ */
+
+const WORKSPACE_ROUTE = "/project/$id/workspace" as const;
+
+// Indexing the per-list map with a union collapses it to an intersection;
+// this view is what the generic paths below call.
+const encodeUnion = encodeCursorParam as (
+	list: UrlListName,
+	item: ListItem[UrlListName],
+) => string | null;
+
+/**
+ * The project the app is showing. Read here rather than passed in by callers,
+ * which only holds because one project is on screen at a time.
+ */
+const projectIdOf = (): string => {
+	const match = router.state.matches.findLast((m) => "id" in m.params);
+	if (!match) throw new Error("No project route matched");
+	return (match.params as { id: string }).id;
+};
+
+/** The params as they stand, for callbacks — components subscribe via the hooks below. */
+export const currentParams = (): UrlQueryParams => router.state.location.search as UrlQueryParams;
+
+/* ------------------------------------------------------------------ reads */
+
+/**
+ * Resolution is an encode-match: the param is compared against each index
+ * item's encoded form, so `change:<id>` still finds its commit after a
+ * rewrite gave it a new id — the whole reason commits are change-id-first.
+ * Cached per index identity; indexes are rebuilt when their data changes.
+ */
+const encodedIndexes = new WeakMap<object, Map<string, unknown>>();
+
+const encodedIndex = <L extends UrlListName>(
+	list: L,
+	navigationIndex: NavigationIndex<ListItem[L]>,
+): Map<string, ListItem[L]> => {
+	let byParam = encodedIndexes.get(navigationIndex);
+	if (!byParam) {
+		byParam = new Map();
+		for (const item of navigationIndex.items) {
+			const encoded = encodeCursorParam(list, item);
+			if (encoded !== null && !byParam.has(encoded)) byParam.set(encoded, item);
+		}
+		encodedIndexes.set(navigationIndex, byParam);
+	}
+	return byParam as Map<string, ListItem[L]>;
+};
+
+const resolveCursorParam = <L extends UrlListName>(
+	list: L,
+	param: string | undefined,
+	navigationIndex: NavigationIndex<ListItem[L]>,
+): ListItem[L] | null =>
+	(param === undefined ? undefined : encodedIndex(list, navigationIndex).get(param)) ??
+	navigationIndex.items[0] ??
+	null;
+
+/** The cursor resolved against what the list currently shows. */
+export const useResolvedCursor = <L extends ListName>(
+	list: L,
+	navigationIndex: NavigationIndex<ListItem[L]>,
+): ListItem[L] | null => {
+	// Both stores are subscribed unconditionally so hook order never depends
+	// on the list; every call site passes a literal list name anyway.
+	const param = useSearch({
+		from: WORKSPACE_ROUTE,
+		select: (params: UrlQueryParams) => (isUrlList(list) ? params[list as UrlListName] : undefined),
+	});
+	const storedDiff = useAppSelector((state) =>
+		projectSlice.selectors.selectDiffCursor(state, projectIdOf()),
+	);
+
+	return (
+		isUrlList(list)
+			? resolveCursorParam(list, param, navigationIndex as never)
+			: resolveNavigationIndexSelection(
+					navigationIndex as NavigationIndex<ListItem["diff"]>,
+					storedDiff,
+					cursorKey.diff,
+				)
+	) as ListItem[L] | null;
+};
+
+/**
+ * Whether the resolved cursor rests on `item`. A primitive, so a cursor move
+ * re-renders the two affected rows rather than the whole list.
+ */
+export const useIsCursorAt = <L extends ListName>(
+	list: L,
+	navigationIndex: NavigationIndex<ListItem[L]>,
+	item: ListItem[L],
+): boolean => {
+	const resolved = useResolvedCursor(list, navigationIndex);
+	return resolved !== null && cursorKey[list](resolved) === cursorKey[list](item);
+};
+
+/**
+ * Whether the stored cursor is `item`, without resolving against an index.
+ * Rows subscribe to this plain boolean so index rebuilds (fold, filter, data
+ * refresh) do not re-render every row.
+ */
+export const useCursorMatches = <L extends UrlListName>(list: L, item: ListItem[L]): boolean =>
+	useSearch({
+		from: WORKSPACE_ROUTE,
+		select: (params: UrlQueryParams) => params[list] === encodeCursorParam(list, item),
+	});
+
+/** The outline page shown, `workspace` unless the URL says otherwise. */
+export const usePage = (): OutlineTab =>
+	useSearch({
+		from: WORKSPACE_ROUTE,
+		select: (params: UrlQueryParams) => params.page ?? "workspace",
+	});
+
+const pageOf = (): OutlineTab => currentParams().page ?? "workspace";
+
+/** The workspace page's driving list, `stacks` unless the URL says otherwise. */
+export const useWorkspaceList = (): WorkspaceList =>
+	useSearch({
+		from: WORKSPACE_ROUTE,
+		select: (params: UrlQueryParams) => params.list ?? "stacks",
+	});
+
+const workspaceListOf = (): WorkspaceList => currentParams().list ?? "stacks";
+
+const drivenByUncommitted = (params: UrlQueryParams): boolean =>
+	(params.page ?? "workspace") === "workspace" && (params.list ?? "stacks") === "uncommitted";
+
+/**
+ * The uncommitted list is itself a file list, so while it drives the pane a
+ * second files panel would just repeat it.
+ */
+export const useCanShowFiles = (): boolean =>
+	useSearch({
+		from: WORKSPACE_ROUTE,
+		select: (params: UrlQueryParams) => !drivenByUncommitted(params),
+	});
+
+export const outlineSelectionScopeOf = (): "outline" | "uncommitted-files" =>
+	drivenByUncommitted(currentParams()) ? "uncommitted-files" : "outline";
+
+/** The focus scope of the outline panel's driving list. */
+export const useOutlineSelectionScope = (): "outline" | "uncommitted-files" =>
+	useSearch({
+		from: WORKSPACE_ROUTE,
+		select: (params: UrlQueryParams) =>
+			drivenByUncommitted(params) ? ("uncommitted-files" as const) : ("outline" as const),
+	});
+
+/* ----------------------------------------------------------------- writes */
+
+/** Within-page state never creates history entries (ruled 2026-08-13). */
+const navigateParams = (update: (prev: UrlQueryParams) => UrlQueryParams): void => {
+	// Applied against the live params rather than handed to the router as an
+	// updater: a write triggered by data arriving (a list resolving its cursor)
+	// would otherwise be given a `prev` snapshotted before the URL was parsed,
+	// dropping whatever it had not yet seen — the page param, most visibly.
+	void router.navigate({ to: ".", search: update(currentParams()), replace: true }).then(() => {
+		writeLastPlace(projectIdOf(), router.state.location.searchStr);
+	});
+};
+
+const setDiffCursor = (selection: ListItem["diff"] | null): void => {
+	store.dispatch(projectSlice.actions.selectDiffCursor({ projectId: projectIdOf(), selection }));
+};
+
+/** A stacks selection dissolves an outline mode it invalidates, as before. */
+const dissolveInvalidMode = (selection: Operand | null): void => {
+	const mode = projectSlice.selectors.selectOutlineModeState(store.getState(), projectIdOf());
+	if (mode._tag === "Default") return;
+
+	if (!selection || !isValidOutlineModeForSelection({ mode, selection }))
+		store.dispatch(projectSlice.actions.exitMode({ projectId: projectIdOf() }));
+};
+
+/** Move a list's cursor. */
+export const setCursor = <L extends ListName>(list: L, item: ListItem[L] | null): void => {
+	if (!isUrlList(list)) {
+		setDiffCursor(item as ListItem["diff"] | null);
+		return;
+	}
+
+	const encoded =
+		item === null ? undefined : (encodeUnion(list, item as ListItem[UrlListName]) ?? undefined);
+	// Selecting the same item is a no-op, side effects included; selecting
+	// null always lands (it may still have sub-cursors to clear).
+	if (item !== null && currentParams()[list] === encoded) return;
+
+	navigateParams((prev) => ({
+		...prev,
+		[list]: encoded,
+		// The file and diff cursors follow whatever the stacks cursor rests on.
+		...(list === "stacks" ? { files: undefined } : {}),
+	}));
+
+	if (list === "stacks") {
+		setDiffCursor(null);
+		dissolveInvalidMode(item as Operand | null);
+	}
+};
+
+/** Switch the outline page. Changing pages dissolves any outline mode. */
+export const setPage = (page: OutlineTab): void => {
+	if (pageOf() === page) return;
+
+	navigateParams((prev) => ({ ...prev, page: page === "workspace" ? undefined : page }));
+	store.dispatch(projectSlice.actions.exitMode({ projectId: projectIdOf() }));
+};
+
+/** Name the workspace list that drives the details pane. */
+export const setWorkspaceList = (list: WorkspaceList): void => {
+	if (workspaceListOf() === list) return;
+
+	navigateParams((prev) => ({ ...prev, list: list === "stacks" ? undefined : list }));
+};
+
+/* ------------------------------------------------- modes with restoration */
+
+const snapshotWorkspaceCursors = (): WorkspaceCursorSnapshot => {
+	const params = currentParams();
+	return {
+		stacks: params.stacks,
+		uncommitted: params.uncommitted,
+		files: params.files,
+		diff: projectSlice.selectors.selectDiffCursor(store.getState(), projectIdOf()),
+	};
+};
+
+const restoreWorkspaceCursors = (snapshot: WorkspaceCursorSnapshot): void => {
+	navigateParams((prev) => ({
+		...prev,
+		stacks: snapshot.stacks,
+		uncommitted: snapshot.uncommitted,
+		files: snapshot.files,
+	}));
+	setDiffCursor(snapshot.diff);
+};
+
+export const enterKeyboardTransfer = ({
+	sources,
+	placement,
+}: {
+	sources: Array<Operand>;
+	placement?: "above" | "below" | "into";
+}): void => {
+	store.dispatch(
+		projectSlice.actions.enterKeyboardTransferMode({
+			projectId: projectIdOf(),
+			sources,
+			placement,
+			restoreSelection: snapshotWorkspaceCursors(),
+		}),
+	);
+};
+
+export const enterAbsorb = ({
+	source,
+	sourceTarget,
+}: {
+	source: Operand;
+	sourceTarget: AbsorptionTarget;
+}): void => {
+	store.dispatch(
+		projectSlice.actions.enterAbsorbMode({
+			projectId: projectIdOf(),
+			source,
+			sourceTarget,
+			restoreSelection: snapshotWorkspaceCursors(),
+		}),
+	);
+};
+
+/** Leave the mode and put every cursor back where the mode found it. */
+export const cancelMode = (): void => {
+	const mode = projectSlice.selectors.selectOutlineModeState(store.getState(), projectIdOf());
+	const restore =
+		mode._tag === "Absorb"
+			? mode.restoreSelection
+			: mode._tag === "Transfer" && mode.value._tag === "Keyboard"
+				? mode.value.restoreSelection
+				: null;
+
+	store.dispatch(projectSlice.actions.exitMode({ projectId: projectIdOf() }));
+	if (restore) restoreWorkspaceCursors(restore);
+};
+
+export const startRewordCommit = (commit: CommitOperand): void => {
+	setCursor("stacks", commitOperand(commit));
+	store.dispatch(projectSlice.actions.startRewordCommit({ projectId: projectIdOf(), commit }));
+};
+
+export const startRenameBranch = (branch: BranchOperand): void => {
+	setCursor("stacks", branchOperand(branch));
+	store.dispatch(projectSlice.actions.startRenameBranch({ projectId: projectIdOf(), branch }));
+};
+
+/* ------------------------------------------------------- rewrite handling */
+
+const operandParams = ["stacks", "branches", "upstream"] as const;
+
+/**
+ * Rewrite `commit:` params after a commit rewrite. `change:` params need no
+ * repair — the change id survives — which is why they are the primary form.
+ */
+export const remapSearchCommits = (replacedCommits: Record<string, string>): void => {
+	navigateParams((prev) => {
+		const next = { ...prev };
+		for (const param of operandParams) {
+			const value = next[param];
+			if (value === undefined || !value.startsWith("commit:")) continue;
+
+			const newId = replacedCommits[value.slice("commit:".length)];
+			if (newId !== undefined) next[param] = `commit:${newId}`;
+		}
+		return next;
+	});
+};
+
+/** Follow a branch rename in every param that named it. */
+export const remapSearchBranch = (oldRef: string, newRef: string): void => {
+	navigateParams((prev) => {
+		const next = { ...prev };
+		for (const param of operandParams)
+			if (next[param] === `branch:${oldRef}`) next[param] = `branch:${newRef}`;
+		return next;
+	});
+};
+
+/* ------------------------------------------------------------- write-back */
+
+/**
+ * Rows highlight by comparing against the stored cursor, so whenever
+ * resolution lands elsewhere — entering the tab, or the cursor's item leaving
+ * the index — the list stores the resolved value to keep the two in
+ * agreement. One effect for every list.
+ */
+export const useCursorWriteBack = <L extends ListName>(
+	list: L,
+	navigationIndex: NavigationIndex<ListItem[L]>,
+): void => {
+	const resolved = useResolvedCursor(list, navigationIndex);
+	const storedParam = useSearch({
+		from: WORKSPACE_ROUTE,
+		select: (params: UrlQueryParams) => (isUrlList(list) ? params[list as UrlListName] : undefined),
+	});
+	const storedDiff = useAppSelector((state) =>
+		projectSlice.selectors.selectDiffCursor(state, projectIdOf()),
+	);
+
+	const outOfSync =
+		resolved !== null &&
+		(isUrlList(list)
+			? storedParam !== encodeUnion(list, resolved as ListItem[UrlListName])
+			: storedDiff === null ||
+				cursorKey.diff(storedDiff) !== cursorKey.diff(resolved as ListItem["diff"]))
+			? resolved
+			: null;
+
+	useEffect(() => {
+		if (outOfSync !== null) setCursor(list, outOfSync);
+	}, [outOfSync, list]);
+};

--- a/crates/but/Cargo.toml
+++ b/crates/but/Cargo.toml
@@ -56,6 +56,7 @@ but-update.workspace = true
 but-installer.workspace = true
 but-path.workspace = true
 but-ctx.workspace = true
+but-project-handle.workspace = true
 but-rebase.workspace = true
 but-github.workspace = true
 but-gitlab.workspace = true

--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -4,7 +4,7 @@ Agent-focused reference for useful `but` commands.
 
 ## Contents
 
-- [Inspection](#inspection-understanding-state) - `status`, `show`, `diff`
+- [Inspection](#inspection-understanding-state) - `status`, `show`, `diff`, `open`
 - [Branching](#branching) - `branch new`, `apply`, `unapply`, `branch delete`, `pick`
 - [Committing](#committing) - `commit`
 - [Editing History](#editing-history) - `squash`, `amend`, `move`, `uncommit`, `reword`, `discard`
@@ -64,6 +64,20 @@ inspect committed files or other entities one target at a time. Unlike `commit`,
 **Hunk IDs:** For uncommitted changes, `but diff` shows each hunk with an ID (e.g., `qs:5`, `uo:d`). Pass these IDs to `but commit` for fine-grained, hunk-level commits.
 
 For the full CLI ID model, `but help cli-ids` documents every ID kind and its stability.
+
+### `but open [target]`
+
+Open the GitButler app at a branch or commit, or print the link with `--print`.
+
+```bash
+but open                    # The workspace
+but open <branch-id>        # With that branch selected
+but open <commit-id>        # With that commit selected
+but open --print <id>       # Print the link instead of opening it
+```
+
+Commits are addressed by change ID where they have one, so the link keeps
+working after the commit is amended or rebased.
 
 ## Branching
 

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -446,6 +446,10 @@ pub enum Subcommands {
     #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Apply(apply::Platform),
 
+    #[cfg(feature = "legacy")]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
+    Open(open::Platform),
+
     /// Push changes in a branch to remote.
     ///
     /// `but push` will update the remote with the latest commits from the
@@ -1083,6 +1087,8 @@ pub mod discard;
 pub mod mcp;
 #[cfg(feature = "legacy")]
 pub mod r#move;
+#[cfg(feature = "legacy")]
+pub mod open;
 #[cfg(feature = "legacy")]
 pub mod pick;
 #[cfg(feature = "legacy")]

--- a/crates/but/src/args/open.rs
+++ b/crates/but/src/args/open.rs
@@ -1,0 +1,25 @@
+//! Arguments for `open`.
+
+#![deny(missing_docs)]
+
+use crate::args::atoms::CliIdArg;
+
+/// Open the project in GitButler.
+///
+/// With no argument this opens the workspace. Given a branch or a commit, the
+/// app opens with that selected, so a link can point at the thing you are
+/// talking about rather than at the app.
+///
+/// Commits are addressed by their change ID where they have one, which
+/// survives amending and rebasing — the link keeps working after the commit is
+/// rewritten.
+#[derive(Debug, clap::Parser)]
+#[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
+pub struct Platform {
+    /// The branch or commit to select, defaulting to the workspace itself.
+    pub target: Option<CliIdArg>,
+
+    /// Print the link instead of opening it.
+    #[clap(long)]
+    pub print: bool,
+}

--- a/crates/but/src/command/help.rs
+++ b/crates/but/src/command/help.rs
@@ -133,6 +133,8 @@ fn print_grouped_with_truncation(
                 #[cfg(feature = "legacy")]
                 SubcommandDiscriminant::Apply => Group::BranchingAndCommitting,
                 #[cfg(feature = "legacy")]
+                SubcommandDiscriminant::Open => Group::Inspection,
+                #[cfg(feature = "legacy")]
                 SubcommandDiscriminant::Clean => Group::BranchingAndCommitting,
                 #[cfg(feature = "legacy")]
                 SubcommandDiscriminant::Pick => Group::BranchingAndCommitting,
@@ -373,6 +375,7 @@ Inspection:
   status       Overview of the project workspace state
   diff         Displays the diff of changes in the repo
   show         Shows detailed information about a commit or branch
+  open         Open the project in GitButler
 
 Branching and Committing:
   commit       Create a commit

--- a/crates/but/src/command/legacy/mod.rs
+++ b/crates/but/src/command/legacy/mod.rs
@@ -20,6 +20,7 @@ pub mod discard;
 pub mod forge;
 pub mod land;
 pub mod r#move;
+pub mod open;
 pub mod oplog;
 pub mod pick;
 pub mod pull;

--- a/crates/but/src/command/legacy/open.rs
+++ b/crates/but/src/command/legacy/open.rs
@@ -1,0 +1,152 @@
+//! Implementation of the `but open` command.
+
+use but_ctx::Context;
+use serde::Serialize;
+
+use crate::{
+    CliResult, IdMap,
+    args::{
+        atoms::{BranchOrCommit, Purpose},
+        open::Platform,
+    },
+    theme::Theme,
+    utils::{CliOutput, CliOutputHuman, IntermediateChannel, WriteWithUtils},
+};
+
+/// What the link selects once the app is open.
+enum Selection {
+    /// The workspace, when no target was given.
+    Workspace,
+    /// A branch, by its full ref name.
+    Branch(String),
+    /// A commit, by change ID where it has one — that survives amending and
+    /// rebasing — and by object ID where it does not.
+    Commit {
+        change_id: Option<String>,
+        commit_id: gix::ObjectId,
+    },
+}
+
+struct OpenOperation {
+    project: String,
+    selection: Selection,
+    print_only: bool,
+}
+
+pub fn open(
+    ctx: &mut Context,
+    _out: IntermediateChannel<'_>,
+    args: Platform,
+) -> CliResult<OpenOutcome> {
+    let operation = resolve(ctx, args)?;
+    Ok(run(operation)?)
+}
+
+fn resolve(ctx: &mut Context, args: Platform) -> CliResult<OpenOperation> {
+    let Platform { target, print } = args;
+
+    let guard = ctx.exclusive_worktree_access();
+    let id_map = IdMap::new_from_context(ctx, guard.read_permission())?;
+    let repo = ctx.repo.get()?;
+    let project = but_project_handle::ProjectHandle::from_path(repo.git_dir())?.to_string();
+
+    let selection = match target {
+        None => Selection::Workspace,
+        Some(target) => match target
+            .resolve_in_workspace(&repo, &id_map, Purpose::Target, None)?
+            .into_branch_or_commit()?
+        {
+            // The app addresses branches by full ref name, as its own codec
+            // writes them; a short name would never match.
+            BranchOrCommit::Branch(branch) => Selection::Branch(
+                branch
+                    .resolve_existing_local_branch(&repo)?
+                    .as_bstr()
+                    .to_string(),
+            ),
+            BranchOrCommit::Commit(commit) => Selection::Commit {
+                change_id: commit.change_id.map(|id| id.to_string()),
+                commit_id: commit.commit_id,
+            },
+        },
+    };
+
+    Ok(OpenOperation {
+        project,
+        selection,
+        print_only: print,
+    })
+}
+
+fn run(operation: OpenOperation) -> anyhow::Result<OpenOutcome> {
+    let OpenOperation {
+        project,
+        selection,
+        print_only,
+    } = operation;
+
+    // The app's own address space, as `apps/lite/ui/src/cursor-url.ts` writes
+    // it: the stacks cursor names what the workspace page has selected.
+    let mut url = format!("lite://app/project/{project}/workspace");
+    let cursor = match selection {
+        Selection::Workspace => None,
+        Selection::Branch(ref_name) => Some(format!("branch:{ref_name}")),
+        Selection::Commit {
+            change_id: Some(change_id),
+            ..
+        } => Some(format!("change:{change_id}")),
+        Selection::Commit { commit_id, .. } => Some(format!("commit:{commit_id}")),
+    };
+    if let Some(cursor) = cursor {
+        url.push_str("?stacks=");
+        url.push_str(&cursor);
+    }
+
+    if !print_only {
+        but_api::open::open_url(url.clone())?;
+    }
+
+    Ok(OpenOutcome {
+        url,
+        opened: !print_only,
+    })
+}
+
+#[must_use]
+pub struct OpenOutcome {
+    url: String,
+    opened: bool,
+}
+
+impl CliOutputHuman for OpenOutcome {
+    fn on_human(
+        self,
+        out: &mut dyn WriteWithUtils,
+        _agent: bool,
+        _theme: &'static Theme,
+    ) -> anyhow::Result<()> {
+        let Self { url, opened } = self;
+
+        if opened {
+            writeln!(out, "Opening {url}")?;
+        } else {
+            writeln!(out, "{url}")?;
+        }
+
+        Ok(())
+    }
+}
+
+impl CliOutput for OpenOutcome {
+    fn on_json(self) -> impl serde::Serialize {
+        #[derive(Serialize)]
+        struct Output {
+            url: String,
+            opened: bool,
+        }
+
+        let Self { url, opened } = self;
+
+        Output { url, opened }
+    }
+}

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -843,6 +843,7 @@ async fn match_subcommand(
         | Subcommands::Amend(..)
         | Subcommands::Pick(..)
         | Subcommands::Unapply(..)
+        | Subcommands::Open(..)
         | Subcommands::Apply(..) => setup::init_ctx(
             &args,
             InitCtxOptions {
@@ -1671,6 +1672,16 @@ async fn match_subcommand(
                 unapply_args,
             )
             .emit_metrics(metrics_ctx)?;
+            out.print_cli_output(outcome)?;
+            None
+        }
+        #[cfg(feature = "legacy")]
+        Subcommands::Open(open_args) => {
+            use crate::utils::IntermediateChannel;
+
+            let outcome =
+                command::legacy::open::open(&mut ctx, IntermediateChannel::new(out), open_args)
+                    .emit_metrics(metrics_ctx)?;
             out.print_cli_output(outcome)?;
             None
         }

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -137,6 +137,8 @@ impl Subcommands {
             Subcommands::Unapply { .. } => BranchUnapply,
             #[cfg(feature = "legacy")]
             Subcommands::Apply { .. } => BranchApply,
+            #[cfg(feature = "legacy")]
+            Subcommands::Open { .. } => Open,
             Subcommands::Switch { .. } => Switch,
             #[cfg(feature = "legacy")]
             Subcommands::Worktree(worktree::Platform { cmd: _ }) => Worktree,


### PR DESCRIPTION
Where you are in the app used to live in redux, so it died on reload. It now lives in the URL.

```
?page=branches&branches=branch:refs/heads/my-feature
?stacks=change:9f3k2mq…&files=apps/lite/ui/src/App.tsx
```

## Why now

URLs are a great fit for an app with **one primary surface**, and a bad fit for an app with several parallel ones. `apps/desktop` had lanes side by side — N of the same thing, with no stable name each — so there was never a sensible way to write "where you are" as one address.

Lite has a single surface, so we can. And once we can, we should: reloads, deep links, restore-on-launch and CLI addressability all stop being features to build and start being things that fall out of having an address.

The flip side is that this only holds while the app stays single-surface. If a second parallel surface ever appears, this design has to be revisited rather than worked around.

## What you can do now

- **Link to a branch or a commit.** Paste it in a PR comment or a terminal; it opens the app right there.
- **Reload without losing your place.** Same after quitting and relaunching.
- **Open links from outside the app** — `lite://` is registered with the OS.
- **`but open`** from the CLI:

```bash
but open                    # the workspace
but open my-feature         # with that branch selected
but open --print abc        # print the link instead of opening it
```

## Links survive rewrites

Commits are addressed by **change ID** wherever they have one, falling back to the commit ID:

```
?stacks=change:9f3k2mq…      still resolves after amend, reword or rebase
?stacks=commit:dd9bc8f…      only when a commit has no change ID
```

A param that no longer matches anything falls back to the first item rather than erroring, so a stale or hand-mangled link opens the page instead of breaking it.

## For reviewers

- `use-cursor.ts` is the only module that knows where navigation state is kept. Reads are hooks, writes are plain calls — no dispatch, no `projectId` threading.
- **One cursor table.** The six lists (stacks, uncommitted, branches, upstream, files, diff) kept their cursors in three unrelated containers; they now share one table keyed by list name.
- **One rewrite remap.** When amend or squash replaces a commit, a single recursive walk re-points every cursor at its replacement. That was two hand-written implementations before, and the Upstream tab had none at all — a cursor there jumped back to the top of the list after any rewrite.
- Only the diff cursor stayed in redux — its identity is the exact selected lines, which no readable param carries.
- The details pane now knows which page it is showing, so an unapplied branch gets its own view: its diff, and its review when there is one, without the publish form that could never work for it.
