### PR TITLE
Fix signing in from Lite

### DIFF
--- a/apps/lite/electron/src/main.ts
+++ b/apps/lite/electron/src/main.ts
@@ -100,7 +100,7 @@ const imgSrc = [
 	"https://gitbutler-public.s3.amazonaws.com",
 ].join(" ");
 
-const liteProtocolScheme = "lite";
+const liteProtocolScheme = "but";
 const liteProtocolHost = "app";
 const contentRootURL = pathToFileURL(path.join(currentDirPath, "../ui"));
 const askpassExecutableName =
@@ -437,7 +437,7 @@ const registerIpcHandlers = (): void => {
 };
 
 /**
- * A `lite://app/...` link, translated to whatever this build actually serves:
+ * A `but://app/...` link, translated to whatever this build actually serves:
  * the dev server in development, our own scheme when packaged. Returns null
  * for anything that is not one of our links.
  */
@@ -463,11 +463,36 @@ const deepLinkTargetUrl = (link: string): string | null => {
 };
 
 /**
+ * Sign in from a `but://login?access_token=…` link, which is how the login page
+ * hands the account back once it knows which client asked.
+ */
+const completeLogin = async (url: URL): Promise<boolean> => {
+	if (url.host !== "login") return false;
+
+	const accessToken = url.searchParams.get("access_token");
+	if (accessToken === null) return true;
+
+	try {
+		await sdk.loginAndPersist(accessToken);
+	} catch (error) {
+		// oxlint-disable-next-line no-console
+		console.error("Failed to sign in from a login link", error);
+	}
+	return true;
+};
+
+/**
  * Open a deep link in the window we already have, or start one if the app was
  * launched by the link. The project it names is checked by the route itself,
  * which covers every other way a URL arrives too.
  */
 const openDeepLink = async (link: string): Promise<void> => {
+	const url = newUrlOrNull(link);
+	if (url !== null && url.protocol === `${liteProtocolScheme}:` && (await completeLogin(url))) {
+		BrowserWindow.getAllWindows()[0]?.focus();
+		return;
+	}
+
 	const target = deepLinkTargetUrl(link);
 	if (target === null) {
 		// oxlint-disable-next-line no-console
@@ -486,7 +511,7 @@ const openDeepLink = async (link: string): Promise<void> => {
 	await existing.loadURL(target);
 };
 
-/** The `lite://` link in a launch argv, if the OS started us with one. */
+/** The `but://` link in a launch argv, if the OS started us with one. */
 const deepLinkFromArgv = (argv: Array<string>): string | undefined =>
 	argv.find((arg) => arg.startsWith(`${liteProtocolScheme}://`));
 
@@ -645,6 +670,11 @@ void app.whenReady().then(async () => {
 	}
 
 	const launchLink = deepLinkFromArgv(process.argv);
+	// Windows and Linux deliver a cold-launch link only through argv, never as
+	// `open-url`, so a login link arriving that way has to be handled here too.
+	const launchUrl = launchLink === undefined ? null : newUrlOrNull(launchLink);
+	if (launchUrl?.protocol === `${liteProtocolScheme}:`) await completeLogin(launchUrl);
+
 	await createMainWindow(
 		launchLink === undefined ? undefined : (deepLinkTargetUrl(launchLink) ?? undefined),
 	);

--- a/apps/lite/ui/src/routes/project/$id/workspace/Settings/Account.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Settings/Account.tsx
@@ -42,9 +42,23 @@ const SignedOut: FC = () => {
 		setError(null);
 		try {
 			const login = await window.lite.getLoginToken();
-			await window.lite.openInWebBrowser(login.url);
+			// Names the client for the login page, as apps/desktop does with its
+			// build type. Without it the page can only offer a token to copy.
+			const url = new URL(login.url);
+			url.searchParams.set("bt", "release");
+			await window.lite.openInWebBrowser(url.toString());
+			// The page sends the account back over `but://login`, which the main
+			// process persists, so this waits for the account to appear rather
+			// than for a reply of its own.
 			await pollUntilSuccess({
-				attempt: () => window.lite.loginAndPersist(login.token),
+				attempt: async () => {
+					// Signed out reads as `null` rather than an error, which would end
+					// the poll on its first try. The message is only ever seen if the
+					// poll then runs out of time, so it reads as the failure.
+					const profile = await window.lite.getUserProfileLocal();
+					if (profile === null) throw new Error("The browser did not finish signing in");
+					return profile;
+				},
 				intervalMs: pollIntervalMs,
 				timeoutMs: pollTimeoutMs,
 				signal: controller.signal,

--- a/crates/but/src/command/legacy/open.rs
+++ b/crates/but/src/command/legacy/open.rs
@@ -87,7 +87,7 @@ fn run(operation: OpenOperation) -> anyhow::Result<OpenOutcome> {
 
     // The app's own address space, as `apps/lite/ui/src/cursor-url.ts` writes
     // it: the stacks cursor names what the workspace page has selected.
-    let mut url = format!("lite://app/project/{project}/workspace");
+    let mut url = format!("but://app/project/{project}/workspace");
     let cursor = match selection {
         Selection::Workspace => None,
         Selection::Branch(ref_name) => Some(format!("branch:{ref_name}")),


### PR DESCRIPTION
Signing in from Lite's settings page never completed. The browser landed on a page offering an access token to copy, and the dialog sat on **Waiting for browser…** forever.

Two separate causes:

### Lite didn't name itself

The login URL carried no build type, so the page fell back to its copy-a-token path — the fallback for a client it can't hand an account to. It now sends `bt` the way apps/desktop does:

```ts
url.searchParams.set("bt", "release");
```

With that, the page hands the account back over `but://login`, and the main process persists it.

### A signed-out read looked like success

The dialog polled `getUserProfileLocal()`, which resolves to `null` when signed out — and the poll helper accepts any resolved value. So the very first attempt "succeeded" and the wait ended before the browser had done anything. It now waits for a profile to exist.

### Also: one scheme, not two

Deep links used a new `lite://` scheme. That was a mistake — the client already registers `but://`, which is what the login page redirects to. Renamed everywhere, including `but open`:

```bash
but open --print my-feature   # but://app/…
```

---

**Still needs a click.** The web page hands the link to the OS from its button's click handler, so you press *Open client* once. Removing that is a change on the web side, not here.