### PR TITLE
Reset the query cache when a pane boundary recovers

### DIFF
--- a/apps/lite/ui/src/components/ErrorBoundary.query.test.tsx
+++ b/apps/lite/ui/src/components/ErrorBoundary.query.test.tsx
@@ -1,0 +1,118 @@
+/** @vitest-environment jsdom */
+
+import { act, Suspense, type FC, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	QueryClient,
+	QueryClientProvider,
+	QueryErrorResetBoundary,
+	useSuspenseQuery,
+} from "@tanstack/react-query";
+
+import { ErrorBoundary } from "./ErrorBoundary.tsx";
+
+declare global {
+	var IS_REACT_ACT_ENVIRONMENT: boolean | undefined;
+}
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+let shouldFail = true;
+
+const Data: FC = () => {
+	const { data } = useSuspenseQuery({
+		// Keys are branded to the app's own set (see api/queries.ts), so this
+		// borrows a real one; the client below is this test's alone.
+		queryKey: ["reviewedFiles"],
+		queryFn: async () => {
+			if (shouldFail) throw new Error("query failed");
+			return "loaded";
+		},
+	});
+	return <p>{data}</p>;
+};
+
+describe("ErrorBoundary with a suspense query", () => {
+	let container: HTMLDivElement;
+	let root: Root;
+	let queryClient: QueryClient;
+
+	beforeEach(() => {
+		vi.spyOn(console, "error").mockImplementation(() => {});
+		shouldFail = true;
+		// Mirrors main.tsx.
+		queryClient = new QueryClient({
+			defaultOptions: { queries: { retry: false, staleTime: Number.POSITIVE_INFINITY } },
+		});
+		container = document.createElement("div");
+		document.body.append(container);
+		root = createRoot(container);
+	});
+
+	afterEach(() => {
+		act(() => root.unmount());
+		container.remove();
+		vi.restoreAllMocks();
+	});
+
+	// Mirrors how WorkspacePage wires its panes: the boundary always gets the
+	// query reset, which is what lets a failed suspense query be retried.
+	const render = (resetKeys: ReadonlyArray<unknown>) => {
+		const tree: ReactNode = (
+			<QueryClientProvider client={queryClient}>
+				<QueryErrorResetBoundary>
+					{({ reset }) => (
+						<ErrorBoundary resetKeys={resetKeys} onReset={reset}>
+							<Suspense fallback={<p>loading</p>}>
+								<Data />
+							</Suspense>
+						</ErrorBoundary>
+					)}
+				</QueryErrorResetBoundary>
+			</QueryClientProvider>
+		);
+		act(() => root.render(tree));
+	};
+
+	const settle = async () => {
+		await act(async () => {
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		});
+	};
+
+	it("shows the failure", async () => {
+		render(["a"]);
+		await settle();
+		expect(container.textContent).toContain("Something went wrong.");
+	});
+
+	it("recovers on a reset key once the query would succeed", async () => {
+		render(["a"]);
+		await settle();
+		expect(container.textContent).toContain("Something went wrong.");
+
+		shouldFail = false;
+		render(["b"]);
+		await settle();
+		await settle();
+
+		expect(container.textContent).toContain("loaded");
+	});
+
+	it("recovers on Retry once the query would succeed", async () => {
+		render(["a"]);
+		await settle();
+		expect(container.textContent).toContain("Something went wrong.");
+
+		shouldFail = false;
+		const retry = [...container.querySelectorAll("button")].find(
+			(button) => button.textContent === "Retry",
+		);
+		act(() => retry?.click());
+		await settle();
+		await settle();
+
+		expect(container.textContent).toContain("loaded");
+	});
+});

--- a/apps/lite/ui/src/components/ErrorBoundary.tsx
+++ b/apps/lite/ui/src/components/ErrorBoundary.tsx
@@ -47,14 +47,6 @@ export class ErrorBoundary extends Component<Props, State> {
 		return { error: asError(error) };
 	}
 
-	// Derived during render rather than in componentDidUpdate, which would cost a
-	// second render pass to clear.
-	static getDerivedStateFromProps(props: Props, state: State): State | null {
-		const resetKeys = props.resetKeys ?? [];
-		if (!keysChanged(state.resetKeys, resetKeys)) return null;
-		return { error: null, resetKeys };
-	}
-
 	componentDidCatch(error: unknown): void {
 		// The fallback shows only the message, and swallowing the rest once cost
 		// a session two wrong bisections.
@@ -62,7 +54,17 @@ export class ErrorBoundary extends Component<Props, State> {
 		console.error(error);
 	}
 
-	handleRetry(): void {
+	componentDidUpdate(previous: Props): void {
+		if (!this.state.error) return;
+		if (!keysChanged(previous.resetKeys ?? [], this.props.resetKeys ?? [])) return;
+		// Deliberately a commit-phase reset, not `getDerivedStateFromProps`:
+		// `onReset` has to run before the children render again. A suspense query
+		// holds its error until the query cache is reset, so clearing during
+		// render puts the children straight back into the same throw.
+		this.reset();
+	}
+
+	reset(): void {
 		this.props.onReset?.();
 		this.setState({ error: null, resetKeys: this.props.resetKeys ?? [] });
 	}
@@ -74,11 +76,7 @@ export class ErrorBoundary extends Component<Props, State> {
 			<div className={styles.error}>
 				<h1 className={styles.errorTitle}>Something went wrong.</h1>
 				<div className={styles.errorActions}>
-					<button
-						type="button"
-						className={getButtonClassName({})}
-						onClick={() => this.handleRetry()}
-					>
+					<button type="button" className={getButtonClassName({})} onClick={() => this.reset()}>
 						Retry
 					</button>
 				</div>

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
@@ -27,6 +27,7 @@ import {
 	QueryErrorResetBoundary,
 	useQueries,
 	useQuery,
+	useQueryErrorResetBoundary,
 	useSuspenseQuery,
 } from "@tanstack/react-query";
 import { useNavigate, useParams } from "@tanstack/react-router";
@@ -655,6 +656,10 @@ const WorkspacePage: FC = () => {
 		panelIds,
 	});
 
+	/* A suspense query keeps throwing its cached error until the query cache is
+	   reset, so a pane that fails on one cannot recover without this. */
+	const { reset: resetQueryErrors } = useQueryErrorResetBoundary();
+
 	const selectedProject = projects.find((project) => project.id === projectId);
 	if (!selectedProject) throw new Error("Could not find selected project");
 
@@ -679,7 +684,7 @@ const WorkspacePage: FC = () => {
 					>
 						{/* No reset key: the child is built inline, so its identity changes
 						    every render. Recovery here is the fallback's Retry button. */}
-						<ErrorBoundary>
+						<ErrorBoundary onReset={resetQueryErrors}>
 							<Outline
 								projectId={projectId}
 								project={selectedProject}
@@ -703,7 +708,9 @@ const WorkspacePage: FC = () => {
 					{/* Keyed on the deferred view itself, not on the URL: the deferred
 					    value still holds the old view for a beat after navigating, so a
 					    URL key would clear the error onto the element that just threw. */}
-					<ErrorBoundary resetKeys={[deferredDetails]}>{deferredDetails}</ErrorBoundary>
+					<ErrorBoundary resetKeys={[deferredDetails]} onReset={resetQueryErrors}>
+						{deferredDetails}
+					</ErrorBoundary>
 				</Panel>
 			</Group>
 


### PR DESCRIPTION
Follow-up to #15339, which merged before Copilot's review could be acted on. Copilot was right, and this fixes it.

## The bug

The pane error boundaries from #15339 could clear their own state but never reset the **query cache**. A `useSuspenseQuery` keeps throwing its cached error until `reset()` is called, so the children rendered straight back into the same throw.

Two things had to be wrong together, and both were:

| | before | after |
| --- | --- | --- |
| pane boundaries receive `onReset` | ❌ never wired | ✅ from `useQueryErrorResetBoundary()` |
| when the error is cleared | during render, in `getDerivedStateFromProps` — too early for `onReset` to run at all | in the commit phase, so `onReset` runs *before* children re-render |

Net effect: a failed suspense query in the details pane was stuck permanently, and **Retry could not help** — exactly the "quiet dead pane" failure the `resetKeys` work was meant to prevent. `Details.tsx` has 4 `useSuspenseQuery` call sites, so this was reachable.

## The fix

- `ErrorBoundary` resets in `componentDidUpdate` rather than `getDerivedStateFromProps`. The extra render pass is the point: `onReset` must land before the children render again.
- Both panes in `WorkspacePage` pass `onReset={resetQueryErrors}`.

## Verification

`ErrorBoundary.query.test.tsx` drives a real `QueryClient` with a failing suspense query and covers both routes back — via a reset key, and via **Retry**.

Both tests fail if the `onReset` call is removed, so they guard the actual defect rather than the shape of the code:

```
× recovers on a reset key once the query would succeed
× recovers on Retry once the query would succeed
```

`pnpm -F @gitbutler/lite check`, component tests (27 passing), `oxlint`, `knip` — clean.
