### PR TITLE
fix: make Open in browser work from the first try.

### DIFF
--- a/apps/desktop/src/components/branch/BranchHeaderContextMenu.svelte
+++ b/apps/desktop/src/components/branch/BranchHeaderContextMenu.svelte
@@ -205,6 +205,7 @@
 					label="Open in browser"
 					icon="open-in-browser"
 					testId={TestId.BranchHeaderContextMenu_OpenInBrowser}
+					disabled={!branchUrl}
 					onclick={() => {
 						if (branchUrl) urlService.openExternalUrl(branchUrl);
 						close();


### PR DESCRIPTION
## 🧢 Changes
Disable "Open in browser" menu item until `branchUrl` is evaluated.

## ☕️ Reasoning
`branchUrl` is Svelte's `$direved` value, that is lazy and not (re-)evaluated until it is actually read. `branchUrl` is only read inside the menu item’s click handler. On the first click, reading it initialises `compareBranchUrlQuery`, which starts the async `forgeCompareBranchUrl` request—but its response is still `undefined` and onClick handler does nothing.

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
