### PR TITLE
Hide the diff minimap when the diff barely scrolls

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/diff-minimap.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/diff-minimap.ts
@@ -337,6 +337,13 @@ export const getMinimapFiles = ({
 };
 
 /**
+ * Windows of diff below which the native scrollbar says everything a map could:
+ * a couple of flicks of the wheel covers it, and a ruler is only worth its
+ * column once scrolling stops being enough to hold the whole shape in your head.
+ */
+const MIN_MAPPED_WINDOWS = 3;
+
+/**
  * File positions, or null when the diff is too short to be worth mapping.
  *
  * Tops are exact rather than sampled: CodeView lays out every item, including
@@ -350,6 +357,11 @@ export const getMinimapGeometry = (
 	const total = contentHeight(viewer);
 	const first = files[0];
 	if (first === undefined) return null;
+
+	// A window of zero is a pane that hasn't been laid out yet, not a short diff;
+	// the resize that gives it a height brings us back.
+	const window = viewer.getHeight();
+	if (window > 0 && total < window * MIN_MAPPED_WINDOWS) return null;
 
 	const blocks: Array<{ top: number; height: number }> = [];
 


### PR DESCRIPTION
The minimap ruler took a column on every diff, including ones a flick of the
wheel covers, where it says nothing the native scrollbar does not. Below three
windows of content it now stands down.

Expressed as a null geometry rather than a new flag: `getMinimapGeometry`
already returns `null` for "nothing worth mapping", so this path hides the ruler
and hands the scrollbar back with no new wiring — both the CSS and the geometry
doc already described this case, it was simply never enforced.

The threshold is measured in windows to match `MAX_MAP_TRACKS` next door, where
a track is a ruler-full. A window of zero is a pane that hasn't been laid out
yet rather than a short diff, so it is excluded from the test; the resize that
gives the pane a height brings the map back.