### PR TITLE
Highlight commits from diff dependency locks

### DIFF
--- a/apps/desktop/src/components/diff/UnifiedDiffView.svelte
+++ b/apps/desktop/src/components/diff/UnifiedDiffView.svelte
@@ -7,6 +7,7 @@
 	import binarySvg from "$lib/assets/empty-state/binary.svg?raw";
 	import emptyFileSvg from "$lib/assets/empty-state/empty-file.svg?raw";
 	import tooLargeSvg from "$lib/assets/empty-state/too-large.svg?raw";
+	import { highlightDependencyCommitRows } from "$lib/dependencies/dependencyHighlights";
 	import { DEPENDENCY_SERVICE } from "$lib/dependencies/dependencyService.svelte";
 	import { draggableChips } from "$lib/dragging/draggable";
 	import { HunkDropDataV3 } from "$lib/dragging/draggables";
@@ -309,6 +310,8 @@
 									afterLineNumber: params.afterLineNumber,
 								});
 							}}
+							onLockHover={(locks) =>
+								highlightDependencyCommitRows(locks.map((lock) => lock.commitId))}
 						>
 							{#snippet lockWarning(locks)}
 								<LineLocksWarning {projectId} {locks} />

--- a/apps/desktop/src/components/files/FileListItemContainer.svelte
+++ b/apps/desktop/src/components/files/FileListItemContainer.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import ChangedFilesContextMenu from "$components/shared/ChangedFilesContextMenu.svelte";
+	import { highlightDependencyCommitRows } from "$lib/dependencies/dependencyHighlights";
 	import { draggableChips } from "$lib/dragging/draggable";
 	import { FileChangeDropData } from "$lib/dragging/draggables";
 	import { DROPZONE_REGISTRY } from "$lib/dragging/registry";
@@ -17,6 +18,7 @@
 	import { FileListItem, TestId } from "@gitbutler/ui";
 	import { DRAG_STATE_SERVICE } from "@gitbutler/ui/drag/dragStateService.svelte";
 	import { type FocusableOptions } from "@gitbutler/ui/focus/focusTypes";
+	import { onDestroy } from "svelte";
 	import type { ConflictEntriesObj } from "$lib/files/conflicts";
 	import type { HunkLockTarget } from "@gitbutler/but-sdk";
 	import type { TreeChange } from "@gitbutler/but-sdk";
@@ -76,6 +78,7 @@
 
 	let contextMenu = $state<ReturnType<typeof ChangedFilesContextMenu>>();
 	let draggableEl: HTMLDivElement | undefined = $state();
+	let clearLockHighlight: (() => void) | undefined;
 
 	const previousTooltipText = $derived(
 		change.status.type === "Rename" && change.status.subject.previousPath
@@ -129,20 +132,15 @@
 	});
 
 	function handleLockHover() {
-		lockedCommitIds.forEach((commitId) => {
-			const commitRows = document.querySelectorAll(`[data-commit-id="${commitId}"]`);
-			commitRows.forEach((row) => {
-				row.classList.add("dependency-highlighted");
-			});
-		});
+		clearLockHighlight = highlightDependencyCommitRows(lockedCommitIds);
 	}
 
 	function handleLockUnhover() {
-		const highlighted = document.querySelectorAll(".dependency-highlighted");
-		highlighted.forEach((row) => {
-			row.classList.remove("dependency-highlighted");
-		});
+		clearLockHighlight?.();
+		clearLockHighlight = undefined;
 	}
+
+	onDestroy(() => clearLockHighlight?.());
 </script>
 
 <div

--- a/apps/desktop/src/lib/dependencies/dependencyHighlights.test.ts
+++ b/apps/desktop/src/lib/dependencies/dependencyHighlights.test.ts
@@ -1,0 +1,28 @@
+import { highlightDependencyCommitRows } from "$lib/dependencies/dependencyHighlights";
+import { afterEach, describe, expect, test } from "vitest";
+
+afterEach(() => document.body.replaceChildren());
+
+describe("dependency commit highlighting", () => {
+	test("keeps rows highlighted until every interaction owner clears", () => {
+		document.body.innerHTML = `
+			<div data-commit-id="first"></div>
+			<div data-commit-id="shared"></div>
+			<div data-commit-id="second"></div>
+		`;
+
+		const clearFirst = highlightDependencyCommitRows(["first", "shared", "absent"]);
+		const clearSecond = highlightDependencyCommitRows(["shared", "second"]);
+
+		expect(document.querySelectorAll(".dependency-highlighted")).toHaveLength(3);
+		clearFirst();
+		expect(document.querySelector('[data-commit-id="first"]')).not.toHaveClass(
+			"dependency-highlighted",
+		);
+		expect(document.querySelector('[data-commit-id="shared"]')).toHaveClass(
+			"dependency-highlighted",
+		);
+		clearSecond();
+		expect(document.querySelectorAll(".dependency-highlighted")).toHaveLength(0);
+	});
+});

--- a/apps/desktop/src/lib/dependencies/dependencyHighlights.ts
+++ b/apps/desktop/src/lib/dependencies/dependencyHighlights.ts
@@ -1,0 +1,29 @@
+const highlightCounts = new WeakMap<Element, number>();
+
+export function highlightDependencyCommitRows(commitIds: string[]): () => void {
+	const highlightedRows = new Set<Element>();
+	for (const commitId of commitIds) {
+		const commitRows = document.querySelectorAll(`[data-commit-id="${commitId}"]`);
+		commitRows.forEach((row) => highlightedRows.add(row));
+	}
+
+	highlightedRows.forEach((row) => {
+		highlightCounts.set(row, (highlightCounts.get(row) ?? 0) + 1);
+		row.classList.add("dependency-highlighted");
+	});
+
+	let active = true;
+	return () => {
+		if (!active) return;
+		active = false;
+		highlightedRows.forEach((row) => {
+			const remaining = (highlightCounts.get(row) ?? 1) - 1;
+			if (remaining === 0) {
+				highlightCounts.delete(row);
+				row.classList.remove("dependency-highlighted");
+			} else {
+				highlightCounts.set(row, remaining);
+			}
+		});
+	};
+}

--- a/packages/ui/src/lib/components/hunkDiff/HunkDiff.svelte
+++ b/packages/ui/src/lib/components/hunkDiff/HunkDiff.svelte
@@ -39,6 +39,7 @@
 		onLineClick?: (params: LineSelectionParams) => void;
 		handleLineContextMenu?: (params: ContextMenuParams) => void;
 		lockWarning?: Snippet<[DependencyLock[]]>;
+		onLockHover?: (locks: DependencyLock[]) => (() => void) | undefined;
 	}
 
 	const {
@@ -63,6 +64,7 @@
 		handleLineContextMenu,
 		draggingDisabled,
 		lockWarning,
+		onLockHover,
 	}: Props = $props();
 
 	const BORDER_WIDTH = 1;
@@ -204,6 +206,7 @@
 					{hideCheckboxes}
 					{handleLineContextMenu}
 					{lockWarning}
+					{onLockHover}
 				/>
 			{:else if tableWrapperElem}
 				<tbody>

--- a/packages/ui/src/lib/components/hunkDiff/HunkDiffBody.svelte
+++ b/packages/ui/src/lib/components/hunkDiff/HunkDiffBody.svelte
@@ -34,6 +34,7 @@
 		handleLineContextMenu?: (params: ContextMenuParams) => void;
 		comment?: string;
 		lockWarning?: Snippet<[DependencyLock[]]>;
+		onLockHover?: (locks: DependencyLock[]) => (() => void) | undefined;
 	}
 
 	const {
@@ -53,6 +54,7 @@
 		hideCheckboxes,
 		handleLineContextMenu,
 		lockWarning,
+		onLockHover,
 	}: Props = $props();
 
 	const lineSelection = new LineSelection();
@@ -177,6 +179,7 @@
 				{hideCheckboxes}
 				{handleLineContextMenu}
 				{lockWarning}
+				{onLockHover}
 				hunkHasLocks={lineLocks && lineLocks.length > 0}
 			/>
 		{/each}

--- a/packages/ui/src/lib/components/hunkDiff/HunkDiffRow.svelte
+++ b/packages/ui/src/lib/components/hunkDiff/HunkDiffRow.svelte
@@ -18,8 +18,8 @@
 		type Row,
 	} from "$lib/utils/diffParsing";
 	import { getHunkLineId } from "$lib/utils/hunk";
+	import { onDestroy, type Snippet } from "svelte";
 	import type LineSelection from "$components/hunkDiff/lineSelection.svelte";
-	import type { Snippet } from "svelte";
 
 	interface Props {
 		idx: number;
@@ -36,6 +36,7 @@
 		minWidth: number;
 		lockWarning?: Snippet<[DependencyLock[]]>;
 		hunkHasLocks?: boolean;
+		onLockHover?: (locks: DependencyLock[]) => (() => void) | undefined;
 	}
 
 	const {
@@ -53,13 +54,54 @@
 		minWidth,
 		lockWarning,
 		hunkHasLocks,
+		onLockHover,
 	}: Props = $props();
 
 	let stagingColumnWidth = $state<number>(0);
+	let lockHovered = false;
+	let lockFocused = false;
+	let clearLockHighlight: (() => void) | undefined;
 
 	const locked = $derived(row.locks !== undefined && row.locks.length > 0);
 	const clickable = $derived(isClickable);
 	const isSelectingForCommit = $derived(staged !== undefined && !hideCheckboxes);
+
+	function handleLockHover(locks: DependencyLock[]) {
+		if (!lockFocused) clearLockHighlight = onLockHover?.(locks);
+		lockHovered = true;
+	}
+
+	function handleLockUnhover() {
+		lockHovered = false;
+		if (!lockFocused) clearHighlight();
+	}
+
+	function handleLockFocus(locks: DependencyLock[]) {
+		if (!lockHovered) clearLockHighlight = onLockHover?.(locks);
+		lockFocused = true;
+	}
+
+	function handleLockBlur() {
+		lockFocused = false;
+		if (!lockHovered) clearHighlight();
+	}
+
+	function clearHighlight() {
+		clearLockHighlight?.();
+		clearLockHighlight = undefined;
+	}
+
+	function clearLockInteraction() {
+		lockHovered = false;
+		lockFocused = false;
+		clearHighlight();
+	}
+
+	function clearHighlightOnDestroy(_node: HTMLElement) {
+		return { destroy: clearLockInteraction };
+	}
+
+	onDestroy(clearLockInteraction);
 </script>
 
 {#snippet countColumn(side: CountColumnSide)}
@@ -153,16 +195,27 @@
 				class:locked
 				class:staged
 			>
-				<InfoButton
-					inheritColor
-					size="small"
-					icon="lock"
-					iconSize={10}
-					maxWidth="15rem"
-					iconTopOffset="0"
+				<button
+					type="button"
+					class="table__lockButton"
+					aria-label="Highlight depended-on commits"
+					use:clearHighlightOnDestroy
+					onmouseenter={() => handleLockHover(row.locks ?? [])}
+					onmouseleave={handleLockUnhover}
+					onfocus={() => handleLockFocus(row.locks ?? [])}
+					onblur={handleLockBlur}
 				>
-					{@render lockWarning(row.locks ?? [])}
-				</InfoButton>
+					<InfoButton
+						inheritColor
+						size="small"
+						icon="lock"
+						iconSize={10}
+						maxWidth="15rem"
+						iconTopOffset="0"
+					>
+						{@render lockWarning(row.locks ?? [])}
+					</InfoButton>
+				</button>
 			</td>
 		{:else}
 			<td
@@ -230,6 +283,14 @@
 		cursor: text;
 		tab-size: var(--tab-size);
 		user-select: text;
+	}
+
+	.table__lockButton {
+		display: inline-flex;
+		padding: 0;
+		border: 0;
+		background: transparent;
+		color: inherit;
 	}
 
 	.table__row-header {


### PR DESCRIPTION
## Context

In Desktop's unified diff, when someone hovers or keyboard-focuses a dependency lock in the diff gutter, depended-on commit rows remain unhighlighted. Without the highlight, it is unclear which earlier commits the line depends on. No workaround has been reported. Source: [GitHub issue #15340](https://github.com/gitbutlerapp/gitbutler/issues/15340).

Fixes #15340

## Change

Wire gutter lock hover and focus through the existing commit dependency highlight behavior. Owner-scoped cleanup preserves overlapping interactions while leaving tooltip content, file-list highlighting, unlocked lines, and commit selection unchanged.