### PR TITLE
Fix push error toast for branches tracking another remote

### DIFF
--- a/apps/desktop/src/lib/branches/branchUtils.test.ts
+++ b/apps/desktop/src/lib/branches/branchUtils.test.ts
@@ -9,11 +9,32 @@ describe.concurrent("getBranchNameFromRef", () => {
 		expect(BranchUtils.getBranchNameFromRef(ref, remote)).toBe("main");
 	});
 
-	test("When provided a ref with a remote prefix that can't be found, it throws an error", () => {
+	test("When the ref is on a different remote than the one provided, it strips the ref's own remote", () => {
+		const ref = "refs/remotes/valeras/fix-open-in-browser";
+		const remote = "origin";
+
+		expect(BranchUtils.getBranchNameFromRef(ref, remote)).toBe("fix-open-in-browser");
+	});
+
+	test("When the ref is on a different remote and the branch name has separators, it keeps the whole branch name", () => {
+		const ref = "refs/remotes/valeras/feature/cool-thing";
+		const remote = "origin";
+
+		expect(BranchUtils.getBranchNameFromRef(ref, remote)).toBe("feature/cool-thing");
+	});
+
+	test("When the ref has no branch segment after the remote, it returns undefined", () => {
+		const ref = "refs/remotes/valeras";
+		const remote = "origin";
+
+		expect(BranchUtils.getBranchNameFromRef(ref, remote)).toBeUndefined();
+	});
+
+	test("When provided a ref with no remote prefix to strip, it returns the ref unchanged", () => {
 		const ref = "main";
 		const remote = "origin";
 
-		expect(() => BranchUtils.getBranchNameFromRef(ref, remote)).toThrowError();
+		expect(BranchUtils.getBranchNameFromRef(ref, remote)).toBe("main");
 	});
 
 	test("When provided a ref with a remote prefix and multiple separators, it returns the correct branch name", () => {

--- a/apps/desktop/src/lib/branches/branchUtils.ts
+++ b/apps/desktop/src/lib/branches/branchUtils.ts
@@ -13,22 +13,31 @@ export function createBranchRef(branchName: string, remote: string | undefined):
 /**
  * Get the branch name from a refname.
  *
- * If a remote is provided, the remote prefix will be removed.
+ * If a remote is provided, the remote prefix will be removed. The remote is only
+ * a hint: a single push can span remotes, so a branch may track a remote other
+ * than the one the push reports. When the hint does not match the ref, the first
+ * segment of the ref is taken to be the remote name.
  */
 export function getBranchNameFromRef(ref: string, remote?: string): string | undefined {
-	if (ref.startsWith(REF_REMOTES_PREFIX)) {
-		ref = ref.replace(REF_REMOTES_PREFIX, "");
+	if (!ref.startsWith(REF_REMOTES_PREFIX)) {
+		return ref;
+	}
+	ref = ref.slice(REF_REMOTES_PREFIX.length);
+
+	if (remote === undefined) {
+		return ref;
 	}
 
-	if (remote !== undefined) {
-		const originPrefix = `${remote}${BRANCH_SEPARATOR}`;
-		if (!ref.startsWith(originPrefix)) {
-			throw new Error("Failed to parse branch name as reference");
-		}
-		ref = ref.replace(originPrefix, "");
+	const remotePrefix = `${remote}${BRANCH_SEPARATOR}`;
+	if (ref.startsWith(remotePrefix)) {
+		return ref.slice(remotePrefix.length);
 	}
 
-	return ref;
+	// The ref belongs to a different remote than the one we were given, so take
+	// its first segment as the remote name instead. Without a segment after the
+	// remote there is no branch name to return.
+	const separatorIndex = ref.indexOf(BRANCH_SEPARATOR);
+	return separatorIndex === -1 ? undefined : ref.slice(separatorIndex + 1);
 }
 
 export function getBranchRemoteFromRef(ref: string): string | undefined {


### PR DESCRIPTION
Pushing a branch whose upstream is a remote other than the project's target remote (a fork remote, say) surfaced `Failed to parse branch name as reference` in the GUI — on a push that had actually succeeded.

## Cause

`PushResult` carries a single `remote` for the whole push, taken from the workspace target ref, while each `branchToRemote` entry uses that branch's own remote-tracking refname. For a branch tracking a fork, the frontend received `remote: "origin"` alongside `refs/remotes/<fork>/<branch>`, and `getBranchNameFromRef` threw on the mismatch.

Because the throw happened after the push completed, the user saw an error instead of the success toast, and the pushed branches were never registered for CI check polling.

## Change

The `remote` argument becomes a hint rather than an assertion: it is stripped when it matches the ref, and otherwise the ref's own first segment is taken as the remote name. Refs without a remote prefix are returned unchanged rather than losing a segment.

A single push can legitimately span remotes, so no one value of `remote` can be right for every entry. Making the per-branch remote authoritative in the backend is the more complete fix — it spans `gitbutler-git`, `but-workspace`, `but`, `but-api` and the SDK, and would change the `but push --json` shape, so it is left for a follow-up.