### PR TITLE
Report each pushed branch's name on the remote it landed on

### DIFF
--- a/apps/desktop/src/components/forge/PushButton.svelte
+++ b/apps/desktop/src/components/forge/PushButton.svelte
@@ -2,7 +2,6 @@
 	import GerritPushModal from "$components/forge/GerritPushModal.svelte";
 	import { CLIPBOARD_SERVICE } from "$lib/backend/clipboard";
 	import { URL_SERVICE } from "$lib/backend/url";
-	import { getBranchNameFromRef } from "$lib/branches/branchUtils";
 	import { commitCommittedAtDate } from "$lib/branches/v3";
 	import { splitMessage } from "$lib/commits/commitMessage";
 	import { projectRunCommitHooks } from "$lib/config/config";
@@ -22,7 +21,6 @@
 		ScrollableContainer,
 		chipToasts,
 	} from "@gitbutler/ui";
-	import { isDefined } from "@gitbutler/ui/utils/typeguards";
 	import type { GerritPushFlag } from "$lib/stacks/stack";
 	import type { Segment } from "@gitbutler/but-sdk";
 
@@ -114,9 +112,7 @@
 				pushOpts: gerritFlags,
 			});
 
-			const upstreamBranchNames = pushResult.branchToRemote
-				.map(([_, refname]) => getBranchNameFromRef(refname, pushResult.remote))
-				.filter(isDefined);
+			const upstreamBranchNames = pushResult.branchToRemote.map(([, , name]) => name);
 			if (upstreamBranchNames.length === 0) return;
 			uiState.project(projectId).branchesToPoll.add(...upstreamBranchNames);
 

--- a/apps/desktop/src/components/forge/ReviewCreation.svelte
+++ b/apps/desktop/src/components/forge/ReviewCreation.svelte
@@ -14,7 +14,6 @@
 	import MessageEditorInput from "$components/editor/MessageEditorInput.svelte";
 	import PrTemplateSection from "$components/forge/PrTemplateSection.svelte";
 	import { AI_SERVICE } from "$lib/ai/service";
-	import { getBranchNameFromRef } from "$lib/branches/branchUtils";
 	import { splitMessage } from "$lib/commits/commitMessage";
 	import { projectAiGenEnabled, projectRunCommitHooks } from "$lib/config/config";
 	import { showError } from "$lib/error/showError";
@@ -34,7 +33,6 @@
 	import { persisted } from "@gitbutler/shared/persisted";
 	import { chipToasts, TestId } from "@gitbutler/ui";
 	import { IME_COMPOSITION_HANDLER } from "@gitbutler/ui/utils/imeHandling";
-	import { isDefined } from "@gitbutler/ui/utils/typeguards";
 	import { tick, untrack } from "svelte";
 	import type { Commit, Segment } from "@gitbutler/but-sdk";
 
@@ -170,11 +168,9 @@
 				await sleep(500);
 			}
 
-			const remoteRef = pushQuery.branchToRemote.find(([branch]) => branch === branchName)?.[1];
-
-			const upstreamBranchName = remoteRef
-				? getBranchNameFromRef(remoteRef, pushQuery.remote)
-				: undefined;
+			const upstreamBranchName = pushQuery.branchToRemote.find(
+				([branch]) => branch === branchName,
+			)?.[2];
 
 			return [upstreamBranchName, pushQuery];
 		}
@@ -214,9 +210,7 @@
 			uiState.project(projectId).exclusiveAction.set(undefined);
 
 			if (pushQuery) {
-				const upstreamBranchNames = pushQuery.branchToRemote
-					.map(([_, refname]) => getBranchNameFromRef(refname, pushQuery.remote))
-					.filter(isDefined);
+				const upstreamBranchNames = pushQuery.branchToRemote.map(([, , name]) => name);
 				if (upstreamBranchNames.length === 0) return;
 				uiState.project(projectId).branchesToPoll.add(...upstreamBranchNames);
 			}

--- a/apps/desktop/src/lib/branches/branchUtils.test.ts
+++ b/apps/desktop/src/lib/branches/branchUtils.test.ts
@@ -1,63 +1,6 @@
 import * as BranchUtils from "$lib/branches/branchUtils";
 import { expect, test, describe } from "vitest";
 
-describe.concurrent("getBranchNameFromRef", () => {
-	test("When provided a ref with a remote prefix, it returns the branch name", () => {
-		const ref = "refs/remotes/origin/main";
-		const remote = "origin";
-
-		expect(BranchUtils.getBranchNameFromRef(ref, remote)).toBe("main");
-	});
-
-	test("When the ref is on a different remote than the one provided, it strips the ref's own remote", () => {
-		const ref = "refs/remotes/valeras/fix-open-in-browser";
-		const remote = "origin";
-
-		expect(BranchUtils.getBranchNameFromRef(ref, remote)).toBe("fix-open-in-browser");
-	});
-
-	test("When the ref is on a different remote and the branch name has separators, it keeps the whole branch name", () => {
-		const ref = "refs/remotes/valeras/feature/cool-thing";
-		const remote = "origin";
-
-		expect(BranchUtils.getBranchNameFromRef(ref, remote)).toBe("feature/cool-thing");
-	});
-
-	test("When the ref has no branch segment after the remote, it returns undefined", () => {
-		const ref = "refs/remotes/valeras";
-		const remote = "origin";
-
-		expect(BranchUtils.getBranchNameFromRef(ref, remote)).toBeUndefined();
-	});
-
-	test("When provided a ref with no remote prefix to strip, it returns the ref unchanged", () => {
-		const ref = "main";
-		const remote = "origin";
-
-		expect(BranchUtils.getBranchNameFromRef(ref, remote)).toBe("main");
-	});
-
-	test("When provided a ref with a remote prefix and multiple separators, it returns the correct branch name", () => {
-		const ref = "refs/remotes/origin/feature/cool-thing";
-		const remote = "origin";
-
-		expect(BranchUtils.getBranchNameFromRef(ref, remote)).toBe("feature/cool-thing");
-	});
-
-	test("When provided a ref with a remote that has multiple separators in it, it returns the correct branch name", () => {
-		const ref = "refs/remotes/origin/feature/cool-thing";
-		const remote = "origin/feature";
-
-		expect(BranchUtils.getBranchNameFromRef(ref, remote)).toBe("cool-thing");
-	});
-
-	test("When provided a ref but no explicit remote, it returns the branch name with the remote prefix", () => {
-		const ref = "refs/remotes/origin/main";
-
-		expect(BranchUtils.getBranchNameFromRef(ref)).toBe("origin/main");
-	});
-});
-
 describe.concurrent("getBranchRemoteFromRef", () => {
 	test("When provided a ref with a remote prefix, it returns the remote name", () => {
 		const ref = "refs/remotes/origin/main";

--- a/apps/desktop/src/lib/branches/branchUtils.ts
+++ b/apps/desktop/src/lib/branches/branchUtils.ts
@@ -10,36 +10,6 @@ export function createBranchRef(branchName: string, remote: string | undefined):
 	return `${REF_HEADS_PREFIX}${branchName}`;
 }
 
-/**
- * Get the branch name from a refname.
- *
- * If a remote is provided, the remote prefix will be removed. The remote is only
- * a hint: a single push can span remotes, so a branch may track a remote other
- * than the one the push reports. When the hint does not match the ref, the first
- * segment of the ref is taken to be the remote name.
- */
-export function getBranchNameFromRef(ref: string, remote?: string): string | undefined {
-	if (!ref.startsWith(REF_REMOTES_PREFIX)) {
-		return ref;
-	}
-	ref = ref.slice(REF_REMOTES_PREFIX.length);
-
-	if (remote === undefined) {
-		return ref;
-	}
-
-	const remotePrefix = `${remote}${BRANCH_SEPARATOR}`;
-	if (ref.startsWith(remotePrefix)) {
-		return ref.slice(remotePrefix.length);
-	}
-
-	// The ref belongs to a different remote than the one we were given, so take
-	// its first segment as the remote name instead. Without a segment after the
-	// remote there is no branch name to return.
-	const separatorIndex = ref.indexOf(BRANCH_SEPARATOR);
-	return separatorIndex === -1 ? undefined : ref.slice(separatorIndex + 1);
-}
-
 export function getBranchRemoteFromRef(ref: string): string | undefined {
 	if (ref.startsWith(REF_REMOTES_PREFIX)) {
 		ref = ref.slice(REF_REMOTES_PREFIX.length);

--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -1,4 +1,3 @@
-import { getBranchNameFromRef } from "$lib/branches/branchUtils";
 import { sortLikeFileTree } from "$lib/files/filetreeV3";
 import { showWarning } from "$lib/notifications/toasts";
 import {
@@ -396,10 +395,7 @@ export class StackService {
 					const invalidations = [invalidatesList(ReduxTag.PullRequests)];
 
 					if (result) {
-						const upstreamBranchNames = result.branchToRemote
-							.map(([_, refname]) => getBranchNameFromRef(refname, result.remote))
-							.filter(isDefined);
-						for (const name of upstreamBranchNames) {
+						for (const [, , name] of result.branchToRemote) {
 							invalidations.push(invalidatesItem(ReduxTag.Checks, name));
 						}
 					}

--- a/crates/but-api/src/legacy/workspace.rs
+++ b/crates/but-api/src/legacy/workspace.rs
@@ -577,10 +577,14 @@ pub mod json {
     #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
     #[serde(rename_all = "camelCase")]
     pub struct PushResult {
-        /// The name of the remote to which the branches were pushed.
+        /// The name of the remote the push defaulted to.
+        ///
+        /// A branch may track a different remote, so read the remote off each entry's
+        /// refname in `branchToRemote` rather than this one when acting on a branch.
         pub remote: String,
-        /// The list of pushed branches and their corresponding remote refnames.
-        pub branch_to_remote: Vec<(String, String)>,
+        /// The list of pushed branches with their remote refnames and the branch name on the remote.
+        /// Format: (branch_name, remote_refname, remote_branch_name)
+        pub branch_to_remote: Vec<(String, String, String)>,
         /// The list of branches with their before/after commit SHAs.
         /// Format: (branch_name, before_sha, after_sha)
         pub branch_sha_updates: Vec<(String, String, String)>,
@@ -598,7 +602,9 @@ pub mod json {
                     .push
                     .branch_to_remote
                     .into_iter()
-                    .map(|(name, refname)| (name, refname.to_string()))
+                    .map(|(name, refname, remote_branch_name)| {
+                        (name, refname.to_string(), remote_branch_name)
+                    })
                     .collect(),
                 branch_sha_updates: value.push.branch_sha_updates,
                 review_sync: value.review_sync,
@@ -627,6 +633,7 @@ mod tests {
                 "refs/remotes/origin/feature"
                     .try_into()
                     .expect("valid remote reference"),
+                "feature".into(),
             )],
             branch_sha_updates: Vec::new(),
         };

--- a/crates/but-workspace/src/legacy/push.rs
+++ b/crates/but-workspace/src/legacy/push.rs
@@ -78,7 +78,7 @@ pub fn workspace_branch_and_ancestors_push(
             Some(r) => r.clone(),
             None => format_remote_refname(ref_name, &push_remote)?,
         };
-        let (remote_name, _) =
+        let (remote_name, remote_branch_name) =
             extract_remote_name_and_short_name(remote_refname.as_ref(), &remote_names)
                 .with_context(|| {
                     format!("failed to determine remote name for `{remote_refname}`")
@@ -129,9 +129,11 @@ pub fn workspace_branch_and_ancestors_push(
 
         maybe_record_gerrit_push_metadata(repo, db, gerrit_mode, segment, &push_output)?;
         let branch_name = ref_name.shorten().to_str_lossy().to_string();
-        result
-            .branch_to_remote
-            .push((branch_name.clone(), remote_refname));
+        result.branch_to_remote.push((
+            branch_name.clone(),
+            remote_refname,
+            remote_branch_name.to_str_lossy().to_string(),
+        ));
         result.branch_sha_updates.push((
             branch_name,
             before_sha.to_string(),

--- a/crates/but-workspace/tests/workspace/push.rs
+++ b/crates/but-workspace/tests/workspace/push.rs
@@ -88,7 +88,7 @@ fn apply_remote_tracking_updates(
     repo: &gix::Repository,
     result: &gitbutler_git::PushResult,
 ) -> anyhow::Result<()> {
-    for ((_branch, remote_refname), (_, _, after_sha)) in result
+    for ((_branch, remote_refname, _remote_branch_name), (_, _, after_sha)) in result
         .branch_to_remote
         .iter()
         .zip(result.branch_sha_updates.iter())
@@ -152,6 +152,51 @@ fn logical_push_scope_is_selected_branch_plus_ancestors() -> anyhow::Result<()> 
 }
 
 #[test]
+fn pushed_branch_reports_its_name_on_the_remote_it_landed_on() -> anyhow::Result<()> {
+    let (tmp, repo, meta) = fixture("push")?;
+    // Track `bottom` on a second remote so its own remote differs from the push default,
+    // which is derived from the target ref and stays `origin`.
+    let fork = tmp.path().join("remote.git");
+    let workdir = repo.workdir().expect("fixtures have workdirs");
+    // The tracking ref has to exist for the branch to be seen as tracking `fork`, and it
+    // points at the base so `bottom` still has commits left to push.
+    let base = repo.rev_parse_single("main")?.detach().to_string();
+    for args in [
+        vec!["remote", "add", "fork", fork.to_str().expect("utf8 path")],
+        vec!["config", "branch.bottom.remote", "fork"],
+        vec!["config", "branch.bottom.merge", "refs/heads/bottom"],
+        vec!["update-ref", "refs/remotes/fork/bottom", base.as_str()],
+    ] {
+        let status = std::process::Command::new("git")
+            .current_dir(workdir)
+            .args(args)
+            .status()?;
+        assert!(status.success(), "fixture setup should succeed");
+    }
+    // Reopen so the configuration written above is visible.
+    let repo = gix::open(repo.path())?;
+
+    let result = push(&repo, &meta, r("refs/heads/bottom"), false, false, false)?;
+
+    assert_eq!(
+        result.remote, "origin",
+        "the push default still comes from the target ref"
+    );
+    let (branch, remote_refname, remote_branch_name) = result
+        .branch_to_remote
+        .first()
+        .expect("bottom should have been pushed");
+    assert_eq!(branch, "bottom");
+    assert_eq!(remote_refname.as_bstr(), "refs/remotes/fork/bottom");
+    assert_eq!(
+        remote_branch_name, "bottom",
+        "the branch name on the remote must be stripped of the remote the branch actually landed on, not the push default"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn pushing_bottom_of_stack_reports_only_bottom_as_pushed() -> anyhow::Result<()> {
     let (_tmp, repo, meta) = fixture("push")?;
 
@@ -160,7 +205,7 @@ fn pushing_bottom_of_stack_reports_only_bottom_as_pushed() -> anyhow::Result<()>
         result
             .branch_to_remote
             .iter()
-            .map(|(branch, _)| branch.as_str())
+            .map(|(branch, _, _)| branch.as_str())
             .collect::<Vec<_>>(),
         ["bottom"],
         "pushing the bottom branch should not push the top branch"
@@ -188,7 +233,7 @@ fn pushing_top_of_stack_reports_top_as_pushed_after_bottom_is_current() -> anyho
         result
             .branch_to_remote
             .iter()
-            .map(|(branch, _)| branch.as_str())
+            .map(|(branch, _, _)| branch.as_str())
             .collect::<Vec<_>>(),
         ["top"],
         "once the ancestors are current, pushing the top branch should report only the top"
@@ -229,7 +274,7 @@ fn force_push_protection_is_observed_when_pushing_bottom_branch() -> anyhow::Res
         result
             .branch_to_remote
             .iter()
-            .map(|(branch, _)| branch.as_str())
+            .map(|(branch, _, _)| branch.as_str())
             .collect::<Vec<_>>(),
         ["bottom"],
         "skipping force push protection should allow pushing the rewritten bottom branch"
@@ -257,7 +302,7 @@ fn force_push_protection_is_observed_when_pushing_top_branch() -> anyhow::Result
         result
             .branch_to_remote
             .iter()
-            .map(|(branch, _)| branch.as_str())
+            .map(|(branch, _, _)| branch.as_str())
             .collect::<Vec<_>>(),
         ["bottom", "top"],
         "skipping force push protection should allow pushing the bottom ancestor and top branch"

--- a/crates/but/src/command/legacy/forge/review.rs
+++ b/crates/but/src/command/legacy/forge/review.rs
@@ -663,11 +663,23 @@ async fn publish_reviews_for_branch_and_dependents(
     )?;
 
     if let Some(out) = out.for_human() {
+        // Show the remote the subject branch actually landed on, which may differ from the
+        // push default when the branch tracks another remote.
+        let remote_names = ctx.repo.get()?.remote_names();
+        let pushed_to = result
+            .branch_to_remote
+            .iter()
+            .find(|(pushed_branch, _, _)| pushed_branch == branch_name)
+            .and_then(|(_, remote_ref, _)| {
+                but_core::extract_remote_name_and_short_name(remote_ref.as_ref(), &remote_names)
+            })
+            .map(|(remote, _)| remote)
+            .unwrap_or_else(|| result.remote.clone());
         writeln!(
             out,
             "  {} Pushed to {}",
             t.sym().success,
-            t.remote_branch.paint(&result.remote)
+            t.remote_branch.paint(&pushed_to)
         )?;
     }
 

--- a/crates/but/src/command/legacy/push.rs
+++ b/crates/but/src/command/legacy/push.rs
@@ -1186,8 +1186,8 @@ fn branch_remote_ref_for_display(
     result
         .branch_to_remote
         .iter()
-        .find(|(pushed_branch, _)| pushed_branch == branch)
-        .map(|(_, remote_ref)| remote_ref.shorten().to_string())
+        .find(|(pushed_branch, _, _)| pushed_branch == branch)
+        .map(|(_, remote_ref, _)| remote_ref.shorten().to_string())
         .unwrap_or_else(|| format!("{}/{}", result.remote, branch))
 }
 
@@ -1298,6 +1298,7 @@ mod tests {
             branch_to_remote: vec![(
                 "feature".to_string(),
                 "refs/remotes/upstream/feature".try_into()?,
+                "feature".to_string(),
             )],
             branch_sha_updates: vec![],
         };

--- a/crates/gitbutler-git/src/context.rs
+++ b/crates/gitbutler-git/src/context.rs
@@ -11,11 +11,18 @@ use serde::Serialize;
 #[derive(Debug, PartialEq, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PushResult {
-    /// The name of the remote to which the branches were pushed.
+    /// The name of the remote the push defaulted to.
+    ///
+    /// A branch may track a different remote, so read the remote off each entry's
+    /// refname in [`Self::branch_to_remote`] rather than this one when acting on a branch.
     pub remote: String,
-    /// The list of pushed branches and their corresponding remote refnames.
+    /// The list of pushed branches with their remote refnames and the branch name on the remote.
+    ///
+    /// Format: `(branch_name, remote_refname, remote_branch_name)`. The last element is the
+    /// refname with `refs/remotes/<remote>/` already stripped, so callers never have to
+    /// know where the remote name ends.
     #[serde(serialize_with = "serialize_branch_to_remote")]
-    pub branch_to_remote: Vec<(String, gix::refs::FullName)>,
+    pub branch_to_remote: Vec<(String, gix::refs::FullName, String)>,
     /// The list of branches with their before/after commit SHAs.
     ///
     /// Format: `(branch_name, before_sha, after_sha)`.
@@ -295,7 +302,7 @@ where
 }
 
 fn serialize_branch_to_remote<S>(
-    branch_to_remote: &[(String, gix::refs::FullName)],
+    branch_to_remote: &[(String, gix::refs::FullName, String)],
     serializer: S,
 ) -> std::result::Result<S::Ok, S::Error>
 where
@@ -303,7 +310,9 @@ where
 {
     branch_to_remote
         .iter()
-        .map(|(branch_name, refname)| (branch_name, refname.to_string()))
+        .map(|(branch_name, refname, remote_branch_name)| {
+            (branch_name, refname.to_string(), remote_branch_name)
+        })
         .collect::<Vec<_>>()
         .serialize(serializer)
 }

--- a/packages/but-sdk/src/generated/graph/index.d.ts
+++ b/packages/but-sdk/src/generated/graph/index.d.ts
@@ -3249,10 +3249,18 @@ export type PushFlag = {
 
 /** JSON-friendly version of [`gitbutler_git::PushResult`]. */
 export type PushResult = {
-  /** The name of the remote to which the branches were pushed. */
+  /**
+   * The name of the remote the push defaulted to.
+   *
+   * A branch may track a different remote, so read the remote off each entry's
+   * refname in `branchToRemote` rather than this one when acting on a branch.
+   */
   remote: string;
-  /** The list of pushed branches and their corresponding remote refnames. */
-  branchToRemote: Array<[string, string]>;
+  /**
+   * The list of pushed branches with their remote refnames and the branch name on the remote.
+   * Format: (branch_name, remote_refname, remote_branch_name)
+   */
+  branchToRemote: Array<[string, string, string]>;
   /**
    * The list of branches with their before/after commit SHAs.
    * Format: (branch_name, before_sha, after_sha)

--- a/packages/but-sdk/src/generated/linear/index.d.ts
+++ b/packages/but-sdk/src/generated/linear/index.d.ts
@@ -3249,10 +3249,18 @@ export type PushFlag = {
 
 /** JSON-friendly version of [`gitbutler_git::PushResult`]. */
 export type PushResult = {
-  /** The name of the remote to which the branches were pushed. */
+  /**
+   * The name of the remote the push defaulted to.
+   *
+   * A branch may track a different remote, so read the remote off each entry's
+   * refname in `branchToRemote` rather than this one when acting on a branch.
+   */
   remote: string;
-  /** The list of pushed branches and their corresponding remote refnames. */
-  branchToRemote: Array<[string, string]>;
+  /**
+   * The list of pushed branches with their remote refnames and the branch name on the remote.
+   * Format: (branch_name, remote_refname, remote_branch_name)
+   */
+  branchToRemote: Array<[string, string, string]>;
   /**
    * The list of branches with their before/after commit SHAs.
    * Format: (branch_name, before_sha, after_sha)


### PR DESCRIPTION
`PushResult` carried a single `remote` for the whole push, taken from the workspace target ref, while each `branchToRemote` entry used that branch's own remote-tracking refname. Callers that paired the two got a remote that did not belong to the ref whenever a branch tracked something other than the target remote, such as a fork.

The desktop worked around this by parsing the refname itself and guessing where the remote name ends. That cannot be right in general — splitting `refs/remotes/team/fork/feature` needs the configured remote list. The push already resolves this correctly with `extract_remote_name_and_short_name`, then discarded the short name.

## Change

Carry the short name as a third element on each `branchToRemote` entry, matching the existing `branchShaUpdates` tuple. Every consumer wanted exactly that value:

- The desktop's refname parser `getBranchNameFromRef` and its tests are removed; the four call sites read the element directly.
- `but pr new` had the same class of bug in its "Pushed to" line and now shows the remote the branch actually landed on.
- `PushResult.remote` stays because it is part of the public JSON and SDK shape; it is documented as the push default rather than the branch's remote.

The `but push --json` `branchToRemote` entries grow from two to three elements. The change is additive at the end, so positional readers of the first two elements keep working.

Follows up on #15345, which stopped the resulting error toast on the frontend without fixing the source.