### PR TITLE
Lite: before/after UI screenshots for pull requests

### DIFF
--- a/.agents/skills/lite-screenshots/SKILL.md
+++ b/.agents/skills/lite-screenshots/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: lite-screenshots
+description: Use when asked to add before/after screenshots of a Lite UI change to a pull request, when a PR touching apps/lite/ui needs its visual change shown, or when extending the screenshot catalogue in apps/lite/e2e/tests/screenshots.spec.ts. Captures both sides locally against seeded fixtures, publishes the surfaces that changed, and posts them to the PR.
+---
+
+A reviewer reading a CSS diff cannot see the result. This captures the Lite UI
+with the branch applied and again with it unapplied, and posts the surfaces that
+differ to the pull request.
+
+Capture runs **on this machine**, not in CI. It was tried in CI and abandoned:
+under the bare X server on the Linux runners this Electron build paints a frame
+on load and not reliably afterwards, so several surfaces hung indefinitely
+whether the capture went through Playwright or the DevTools protocol. The same
+spec passes here. The CI workflow only leaves a reminder.
+
+## Before capturing: is the surface covered?
+
+Work this out first, by reading the diff — not by capturing and inferring it from
+the result. A run that reports "8 surfaces, 0 changed" looks identical whether the
+change is invisible or whether nothing looked at it.
+
+1. Identify which screen the change affects.
+2. Check it against the catalogue in `apps/lite/e2e/tests/screenshots.spec.ts`
+   (currently: workspace sidebar, diff pane, branches tab, upstream tab, project
+   picker, uncommitted rows, commit form, settings).
+3. **Covered** — capture, as below.
+4. **Not covered** — stop and ask the developer. Adding a surface edits a shared
+   file and changes what every later pull request captures, so it is their call,
+   not one to make quietly inside a screenshot request. Tell them which screen is
+   uncovered, which fixture would reach it, and that it becomes permanent coverage
+   for everyone.
+
+If they decline, **do not post a comment**. A normal comment would report
+"N surfaces, 0 changed", which asserts the change is not visual when in truth it
+was never photographed. Say plainly that the affected screen is not in the
+catalogue and no screenshots were taken.
+
+## Prerequisites
+
+- `cargo build -p but` once, giving `target/debug/but`.
+- The branch under test applied, and **not yet merged** — the base side comes
+  from unapplying it. Check `but status` first.
+
+## The flow
+
+Run every command from the repository root.
+
+### 1. Capture the branch as it stands
+
+```console
+$ SCREENSHOT_OUT=head BUT=$PWD/target/debug/but pnpm -F @gitbutler/lite test:e2e screenshots
+```
+
+Output lands in `apps/lite/e2e/screenshots/head/` (gitignored).
+
+### 2. Capture the base
+
+```console
+$ but unapply <branch>
+$ but status        # confirm the branch is gone from the workspace
+$ SCREENSHOT_OUT=base BUT=$PWD/target/debug/but pnpm -F @gitbutler/lite test:e2e screenshots
+$ but apply <branch>
+```
+
+**Check the unapply took effect.** It silently does nothing on a stale id or an
+already-merged branch, and both runs then capture identical code — which looks
+exactly like "this change is not visual". If every pair matches in step 3, assume
+this went wrong before concluding anything about the change.
+
+Re-apply immediately, before anything else can fail and leave the workspace short
+a branch.
+
+**Stacked branches take the whole stack down.** `but unapply` on a branch that is
+part of a stack unapplies every branch in it, including ones this capture depends
+on — unapplying a stacked change also removes the spec, and the base run then has
+no tests to execute. Check `but status` first. When the branch is stacked, capture
+the base by reverting the change in the working tree instead:
+
+1. Edit the changed files back to their pre-change state by hand.
+2. Capture into `base`.
+3. `but discard <file-id>` to restore the committed version.
+
+Confirm the restore: the change must be back before anything else happens.
+
+### 3. Select what changed
+
+```console
+$ node apps/lite/e2e/compare-screenshots.mjs \
+    apps/lite/e2e/screenshots/base \
+    apps/lite/e2e/screenshots/head \
+    /tmp/publish \
+    "https://raw.githubusercontent.com/<owner>/<repo>/pr-screenshots/pr-<number>/<short-sha>" \
+    /tmp/section.md
+```
+
+It prints `total=`, `changed=`, `added=`, stages only the differing pairs into
+`/tmp/publish`, and writes the comment body. Surfaces that did not change are
+byte-identical, so they are folded into a collapsed list rather than shown.
+
+### 4. Publish the images
+
+Images go on an orphan `pr-screenshots` branch, under `pr-<number>/<short-sha>/`.
+A per-commit directory matters: reusing one path lets GitHub's image proxy serve
+the previous run's screenshots from cache, which reads as "my change did nothing".
+
+```console
+$ rm -rf /tmp/pub && mkdir /tmp/pub && cd /tmp/pub
+$ git init -q -b pr-screenshots && git remote add origin <repo-url>
+$ git fetch -q --depth 1 origin pr-screenshots && git reset -q --hard origin/pr-screenshots
+$ mkdir -p pr-<number>/<short-sha> && cp -R /tmp/publish/. pr-<number>/<short-sha>/
+$ git add -A && git commit -q -m "Screenshots for #<number>" && git push -q origin pr-screenshots
+```
+
+The branch may not exist yet; skip the fetch and reset when it does not.
+
+### 5. Post to the pull request
+
+Upsert a single comment rather than stacking one per run — find a previous
+comment starting with `<!-- lite-screenshots -->` and PATCH it, else POST.
+
+```console
+$ jq -Rs '{body: .}' /tmp/section.md > /tmp/payload.json
+$ gh api "repos/<owner>/<repo>/issues/<number>/comments" --paginate \
+    --jq 'map(select(.body | startswith("<!-- lite-screenshots -->"))) | first | .id // empty'
+$ gh api -X PATCH "repos/<owner>/<repo>/issues/comments/<id>" --input /tmp/payload.json
+```
+
+Do not edit the pull request description: rewriting text a human owns risks
+clobbering their concurrent edits.
+
+## Before finishing
+
+- **Look at the images**, do not just trust exit codes. A green run proves files
+  were written, not that they show the surface.
+- Confirm the workspace is whole: `but status` should show the branch applied and
+  no stray uncommitted changes.
+
+## Extending the catalogue
+
+Only after the developer has agreed (see the top of this document). Add the
+surface to `apps/lite/e2e/tests/screenshots.spec.ts`, then capture as usual —
+the same run proves the new surface works and shows the change. Coverage applies
+to every later pull request, not just this one.
+
+```ts
+test.describe("<area>", () => {
+	test.use({ scenario: "<fixture>.sh" });
+
+	test("<surface>", async ({ appWindow }) => {
+		await openProject(appWindow);
+		await goToTab(appWindow, "branches"); // when it lives on another tab
+		await shoot(appWindow, "<surface-name>", "<selector>");
+	});
+});
+```
+
+- `<surface-name>` becomes the filename and the heading a reviewer reads: name it
+  `commit-form`, not `outline-panel-2`.
+- Only fixtures calling `"$BUT" setup` register a project; the rest leave the app
+  on "Select a project." and every capture fails. Known good:
+  `project-in-single-branch-three-branch-stack.sh`,
+  `project-with-remote-branches.sh`, `project-with-conflicting-commits.sh`.
+- If no fixture reaches the state, build it in the test — `uncommitted` writes
+  files into `testEnvironment.workdir/local-clone` and reloads.
+- Prefer a stable id for the clip (`#outline-panel`, `#details-panel`), else a
+  CSS-module prefix or an ARIA hook. Never nth-child or a generated class.
+- One screenshot per test, taken after a fresh load. This costs nothing here and
+  keeps the spec usable if CI capture is ever revisited.
+
+## Out of scope
+
+- **Native context menus** cannot be captured; they are OS windows.
+- **Dark mode** is not covered — the harness seeds `theme: "light"`.
+- **States needing a real remote or credentials** cannot be fixtured.

--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -16,6 +16,10 @@ CLI:
   - changed-files:
       - any-glob-to-any-file: apps/web/**/*
 
+"@gitbutler/lite":
+  - changed-files:
+      - any-glob-to-any-file: apps/lite/**/*
+
 "@gitbutler/ui":
   - changed-files:
       - any-glob-to-any-file: packages/ui/**/*
@@ -23,3 +27,9 @@ CLI:
 "@gitbutler/no-relative-imports":
   - changed-files:
       - any-glob-to-any-file: packages/no-relative-imports/**/*
+
+# Drives the Lite UI Screenshots workflow. Applying it by hand opts a change in
+# that this rule does not cover, such as a layout change with no CSS in it.
+screenshots:
+  - changed-files:
+      - any-glob-to-any-file: apps/lite/ui/**/*.css

--- a/.github/workflows/lite-screenshots.yml
+++ b/.github/workflows/lite-screenshots.yml
@@ -1,0 +1,84 @@
+name: Lite UI Screenshots
+
+# Reminds a pull request that touches Lite's UI to attach before/after
+# screenshots, and does nothing else.
+#
+# Capturing them in CI was tried and abandoned: under the bare X server on the
+# Linux runners this Electron build paints a frame on load and not reliably
+# afterwards, so three of eight surfaces hung indefinitely regardless of whether
+# the capture went through Playwright or the DevTools protocol directly. The
+# same spec passes on a developer machine, so capture lives there — see the
+# `lite-screenshots` skill.
+#
+# This job renders nothing, so it cannot fail that way.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      css: ${{ steps.filter.outputs.css }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        id: filter
+        with:
+          filters: |
+            css:
+              - 'apps/lite/ui/**/*.css'
+
+  remind:
+    needs: changes
+    # The paths filter is not redundant with the label. pr-labeler applies
+    # `screenshots` using GITHUB_TOKEN, and GitHub does not start workflow runs
+    # from token-generated events — so an auto-applied label fires nothing. Only
+    # a human applying it does. The filter is what makes this run on its own.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      (contains(github.event.pull_request.labels.*.name, 'screenshots') ||
+       needs.changes.outputs.css == 'true')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    env:
+      PR: ${{ github.event.pull_request.number }}
+      REPO: ${{ github.repository }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      # One comment, posted once. Nothing here edits or re-posts on later pushes:
+      # a reminder that repeats is a reminder people mute.
+      - name: Ask for screenshots
+        run: |
+          marker="<!-- lite-screenshots-reminder -->"
+          existing="$(gh api "repos/${REPO}/issues/${PR}/comments" --paginate \
+            --jq "map(select(.body | startswith(\"${marker}\"))) | first | .id // empty")"
+          if [ -n "$existing" ]; then
+            echo "Already asked."
+            exit 0
+          fi
+          cat > /tmp/comment.md <<EOF
+          ${marker}
+          This pull request changes Lite's UI. Before/after screenshots make it
+          reviewable without checking the branch out.
+
+          To attach them, ask your agent for the \`lite-screenshots\` skill — it
+          captures both sides against seeded fixtures, publishes the surfaces that
+          changed, and posts them here.
+
+          Remove the \`screenshots\` label if this change is not visual.
+          EOF
+          gh api -X POST "repos/${REPO}/issues/${PR}/comments" \
+            --input <(jq -Rs '{body: .}' /tmp/comment.md) --silent
+          echo "Asked for screenshots on #${PR}."

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ tsconfig.tsbuildinfo
 test-results*
 playwright-report
 packages/ui/tests/.cache
+apps/lite/e2e/screenshots/
 
 # storybook
 *storybook.log

--- a/apps/lite/e2e/compare-screenshots.mjs
+++ b/apps/lite/e2e/compare-screenshots.mjs
@@ -1,0 +1,142 @@
+// Compares two screenshot runs, stages the pairs that actually changed, and
+// renders the markdown section for a pull request.
+//
+//   node compare-screenshots.mjs <beforeDir> <afterDir> <publishDir> <baseUrl> <sectionFile>
+//
+// Surfaces are captured unconditionally, so "which ones matter" is decided here:
+// identical fixtures and viewport mean an untouched surface is byte-identical.
+// The rendered section always states the denominator, because a broken run and a
+// run with no visual changes both produce zero differing pairs.
+
+import { createHash } from "node:crypto";
+import { copyFileSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+const args = process.argv.slice(2);
+const beforeDir = args[0] ?? "";
+const afterDir = args[1] ?? "";
+const publishDir = args[2] ?? "";
+const baseUrl = args[3] ?? "";
+const sectionFile = args[4] ?? "";
+if ([beforeDir, afterDir, publishDir, baseUrl, sectionFile].some((arg) => arg === "")) {
+	process.stderr.write(
+		"usage: compare-screenshots.mjs <beforeDir> <afterDir> <publishDir> <baseUrl> <sectionFile>\n",
+	);
+	process.exit(1);
+}
+
+/** @param {string} file */
+const digest = (file) => createHash("sha256").update(readFileSync(file)).digest("hex");
+
+/** @param {string} dir */
+const pngs = (dir) => readdirSync(dir).filter((name) => name.endsWith(".png"));
+
+const afterShots = new Set(pngs(afterDir));
+const beforeShots = new Set(pngs(beforeDir));
+
+const changed = [];
+const unchanged = [];
+const added = [];
+/** In the base run but not the head run: the head capture lost a surface. */
+const missing = [];
+
+// Walk the union, not the head run alone. Counting only what the head produced
+// would report a complete-looking total for a run that dropped surfaces.
+for (const name of [...new Set([...beforeShots, ...afterShots])].sort()) {
+	const surface = path.basename(name, ".png");
+	if (!afterShots.has(name)) {
+		missing.push(surface);
+		continue;
+	}
+	if (!beforeShots.has(name)) {
+		// A surface the catalogue gained, or one the base could not render.
+		added.push(surface);
+		continue;
+	}
+	if (digest(path.join(beforeDir, name)) === digest(path.join(afterDir, name))) {
+		unchanged.push(surface);
+		continue;
+	}
+	changed.push(surface);
+}
+
+const total = changed.length + unchanged.length + added.length + missing.length;
+
+// Refuse to describe a run that cannot support a conclusion. Both of these would
+// otherwise render as "none of them changed", which asserts the change is not
+// visual when in fact nothing usable was captured.
+if (total === 0) {
+	process.stderr.write(`No screenshots in ${beforeDir} or ${afterDir}; nothing to compare.\n`);
+	process.exit(1);
+}
+if (missing.length > 0) {
+	process.stderr.write(
+		`Captured in the base run but missing from the head run: ${missing.join(", ")}.\n` +
+			"The head capture is incomplete, so the comparison would be misleading.\n",
+	);
+	process.exit(1);
+}
+
+// Start from an empty directory. Left-over pairs from an earlier run would be
+// published as though this run had produced them.
+rmSync(publishDir, { force: true, recursive: true });
+for (const phase of ["before", "after"])
+	mkdirSync(path.join(publishDir, phase), { recursive: true });
+for (const surface of [...changed, ...added]) {
+	const name = `${surface}.png`;
+	if (beforeShots.has(name))
+		copyFileSync(path.join(beforeDir, name), path.join(publishDir, "before", name));
+	copyFileSync(path.join(afterDir, name), path.join(publishDir, "after", name));
+}
+
+/**
+ * @param {string} phase
+ * @param {string} surface
+ */
+const img = (phase, surface) => `<img src="${baseUrl}/${phase}/${surface}.png" width="420">`;
+
+const lines = ["<!-- lite-screenshots -->", "## 📸 UI screenshots", ""];
+
+if (changed.length === 0 && added.length === 0) {
+	lines.push(
+		`Captured ${total} surfaces; none of them changed.`,
+		"",
+		"If you expected a visual difference here, treat this as a failed run rather than",
+		"a clean bill of health — the two runs may have built the same code.",
+	);
+} else {
+	lines.push(
+		`Captured ${total} surfaces, ${changed.length + added.length} changed.`,
+		"",
+		"Both runs use the same seeded fixtures and viewport, so surfaces missing below are byte-identical.",
+		"",
+	);
+	for (const surface of changed) {
+		lines.push(
+			`### ${surface}`,
+			"",
+			"| Before | After |",
+			"| --- | --- |",
+			`| ${img("before", surface)} | ${img("after", surface)} |`,
+			"",
+		);
+	}
+	for (const surface of added) {
+		const caption = "New surface — no baseline to compare against.";
+		lines.push(`### ${surface}`, "", caption, "", img("after", surface), "");
+	}
+	if (unchanged.length > 0) {
+		lines.push(
+			"<details>",
+			`<summary>${unchanged.length} surfaces unchanged</summary>`,
+			"",
+			unchanged.map((surface) => `\`${surface}\``).join(", "),
+			"",
+			"</details>",
+			"",
+		);
+	}
+}
+
+writeFileSync(sectionFile, `${lines.join("\n")}\n`);
+process.stdout.write(`total=${total}\nchanged=${changed.length}\nadded=${added.length}\n`);

--- a/apps/lite/e2e/tests/screenshots.spec.ts
+++ b/apps/lite/e2e/tests/screenshots.spec.ts
@@ -1,0 +1,184 @@
+// Surface catalogue for before/after PR screenshots.
+//
+// Opt-in: this spec is skipped unless SCREENSHOT_OUT names an output directory,
+// so ordinary `test:e2e` runs (including CI) are unaffected.
+//
+//   SCREENSHOT_OUT=after pnpm -F @gitbutler/lite test:e2e screenshots
+//
+// Every surface is captured on every run. Deciding which ones actually changed
+// is the caller's job: pairs that are byte-identical between two runs did not
+// change, and only the rest are worth showing a reviewer.
+
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import type { Page } from "@playwright/test";
+import { expect, test } from "../test.ts";
+
+const out = process.env.SCREENSHOT_OUT;
+const enabled = out !== undefined && out !== "";
+
+// A wide-but-ordinary window, so panes are laid out the way a reviewer sees them.
+const VIEWPORT = { width: 1440, height: 900 };
+
+const outputDir = path.resolve(import.meta.dirname, "../screenshots", out ?? "unused");
+
+const shoot = async (appWindow: Page, name: string, selector: string): Promise<void> => {
+	const target = appWindow.locator(selector);
+	await expect(target).toBeVisible();
+	// Let transitions and any late layout settle before the shutter.
+	await appWindow.waitForTimeout(400);
+
+	const box = await target.boundingBox();
+	if (box === null) throw new Error(`${name}: ${selector} has no bounding box`);
+
+	// Capture over the DevTools protocol rather than through page.screenshot().
+	// Playwright waits for the compositor to hand it a fresh frame, and under a
+	// bare X server this renderer only produces one on load, so that wait never
+	// returns for a surface reached any other way. CDP takes what is on screen.
+	const session = await appWindow.context().newCDPSession(appWindow);
+	try {
+		const shot = (await session.send("Page.captureScreenshot", {
+			format: "png",
+			clip: { x: box.x, y: box.y, width: box.width, height: box.height, scale: 1 },
+		})) as { data: string };
+		writeFileSync(path.join(outputDir, `${name}.png`), Buffer.from(shot.data, "base64"));
+	} finally {
+		await session.detach();
+	}
+};
+
+const openProject = async (appWindow: Page): Promise<void> => {
+	await expect(appWindow).toHaveURL(/\/project\/[^/]+\/workspace/);
+	await expect(appWindow.getByRole("button", { name: /select project/i })).toBeVisible();
+	await appWindow.setViewportSize(VIEWPORT);
+
+	// On CI the renderer the window starts with sometimes never produces a frame
+	// ("sandboxed_renderer.bundle.js script failed to run"), and a screenshot then
+	// waits for a paint that never arrives. Reloading gets a renderer that works.
+	await appWindow.reload();
+	await appWindow.getByRole("main").waitFor();
+	await expect(appWindow.getByRole("button", { name: /select project/i })).toBeVisible();
+};
+
+// Under a bare X server the renderer only paints a capturable frame on load: a
+// screenshot taken after an in-app state change waits for a frame that never
+// arrives. So every surface is reached by navigating or reloading, never by
+// clicking, and is photographed immediately afterwards — which is also why each
+// surface gets its own test rather than sharing a window.
+const goToTab = async (
+	appWindow: Page,
+	tab: "workspace" | "upstream" | "branches",
+): Promise<void> => {
+	// The outline page lives in the query string, so this is a real navigation.
+	await appWindow.evaluate((page) => {
+		window.location.search = page === "workspace" ? "" : `?page=${page}`;
+	}, tab);
+	await appWindow.getByRole("main").waitFor();
+	// Navigating alone leaves the renderer without a frame a screenshot can take;
+	// only an explicit reload reliably produces one.
+	await appWindow.reload();
+	await appWindow.getByRole("main").waitFor();
+	await expect(appWindow.getByRole("button", { name: /select project/i })).toBeVisible();
+
+	// Assert the tab actually changed. Every other post-condition here is present
+	// on all three tabs, so without this a navigation that silently stayed put
+	// would write the workspace panel into branches-tab.png and pass.
+	const expected = tab === "workspace" ? "" : `page=${tab}`;
+	await expect.poll(async () => new URL(appWindow.url()).search).toContain(expected);
+};
+
+test.describe("screenshots", () => {
+	test.skip(!enabled, "set SCREENSHOT_OUT to capture screenshots");
+	// Each test launches Electron, seeds a repository with the `but` binary, and
+	// waits for the app to load before its one screenshot; the 30s default is not
+	// enough for that.
+	test.describe.configure({ timeout: 180_000 });
+	test.beforeAll(() => {
+		// Start empty: a PNG left by an earlier run would survive a rerun in which
+		// its surface failed, and be compared as though this run had produced it.
+		rmSync(outputDir, { force: true, recursive: true });
+		mkdirSync(outputDir, { recursive: true });
+	});
+
+	test.describe("stack", () => {
+		test.use({ scenario: "project-in-single-branch-three-branch-stack.sh" });
+
+		test("workspace sidebar", async ({ appWindow }) => {
+			await openProject(appWindow);
+			await shoot(appWindow, "workspace-sidebar", "#outline-panel");
+		});
+
+		test("diff pane", async ({ appWindow }) => {
+			await openProject(appWindow);
+			await shoot(appWindow, "details-pane", "#details-panel");
+		});
+	});
+
+	test.describe("remote branches", () => {
+		test.use({ scenario: "project-with-remote-branches.sh" });
+
+		test("branches tab", async ({ appWindow }) => {
+			await openProject(appWindow);
+			await goToTab(appWindow, "branches");
+			await shoot(appWindow, "branches-tab", "#outline-panel");
+		});
+
+		test("upstream tab", async ({ appWindow }) => {
+			await openProject(appWindow);
+			await goToTab(appWindow, "upstream");
+			await shoot(appWindow, "upstream-tab", "#outline-panel");
+		});
+
+		test("project picker", async ({ appWindow }) => {
+			await openProject(appWindow);
+			await appWindow.getByRole("button", { name: /select project/i }).click();
+			await shoot(appWindow, "project-picker", '[class*="PickerDialog-module_popup"]');
+		});
+	});
+
+	test.describe("uncommitted changes", () => {
+		// The dirty-worktree fixtures don't register a project, so reuse a scenario
+		// that does and make the working tree dirty here instead.
+		test.use({ scenario: "project-in-single-branch-three-branch-stack.sh" });
+
+		/** Leaves the seeded clone with one added and one modified file. */
+		const dirty = async (appWindow: Page, workdir: string): Promise<void> => {
+			const clone = path.join(workdir, "local-clone");
+			writeFileSync(path.join(clone, "added.txt"), "a new, uncommitted file\n");
+			writeFileSync(path.join(clone, "base.txt"), "base, now modified\n");
+			await appWindow.reload();
+			await appWindow.getByRole("main").waitFor();
+			// Wait for the rows themselves. Without this both runs can photograph an
+			// empty list, match, and be reported as "unchanged" — a surface silently
+			// contributing nothing while looking like coverage.
+			await expect(appWindow.getByText("added.txt")).toBeVisible();
+		};
+
+		test("uncommitted file rows", async ({ appWindow, testEnvironment }) => {
+			await openProject(appWindow);
+			await dirty(appWindow, testEnvironment.workdir);
+			await shoot(appWindow, "uncommitted", "#outline-panel");
+		});
+
+		test("commit form", async ({ appWindow, testEnvironment }) => {
+			await openProject(appWindow);
+			await dirty(appWindow, testEnvironment.workdir);
+			// Expanding the form is in-app state, not a navigation, so this surface
+			// depends on a click producing a frame the way the dialogs do.
+			await appWindow.getByRole("button", { name: /start commit/i }).click();
+			await shoot(appWindow, "commit-form", "#outline-panel");
+		});
+	});
+
+	test.describe("settings", () => {
+		test.use({ scenario: "project-in-single-branch-three-branch-stack.sh" });
+
+		test("settings dialog", async ({ appWindow }) => {
+			await openProject(appWindow);
+			// Settings is held in Redux rather than the URL, so it can only be opened
+			// by clicking — as with the project picker.
+			await appWindow.getByRole("button", { name: "Settings" }).click();
+			await shoot(appWindow, "settings", '[aria-labelledby="settings-heading"]');
+		});
+	});
+});


### PR DESCRIPTION
## 🧢 Changes

Before/after screenshots of Lite's UI for a pull request, captured on a developer machine and posted to the PR.

- **`apps/lite/e2e/tests/screenshots.spec.ts`** — a catalogue of eight surfaces (workspace sidebar, diff pane, branches tab, upstream tab, project picker, uncommitted rows, commit form, settings) captured through the existing Electron e2e harness across seeded fixtures. Skipped unless `SCREENSHOT_OUT` is set, so `test:e2e` and the `lite-e2e` CI job are unaffected.
- **`apps/lite/e2e/compare-screenshots.mjs`** — hashes two runs, stages only the pairs that differ, and renders the comment body.
- **`.agents/skills/lite-screenshots/SKILL.md`** — the flow an agent follows on request: capture the branch, unapply it, capture the base, re-apply, compare, publish the changed pairs, post one comment. Also documents how to add a surface.
- **`.github/workflows/lite-screenshots.yml`** — leaves a one-off reminder on PRs that touch `apps/lite/ui/**/*.css` or carry the `screenshots` label. It renders nothing.
- **`.github/pr-labeler.yml`** — applies `screenshots` to PRs touching `apps/lite/ui/**/*.css`, and adds the `@gitbutler/lite` label that was missing alongside the existing per-package ones.

## ☕️ Reasoning

Nearly all the machinery already existed: `_electron.launch()` in `apps/lite/e2e/test.ts` drives the real app, and the fixture scripts under `e2e/playwright/scripts/` seed real repositories with the `but` binary. What was missing was the capture, a comparison, and somewhere to put the result.

**Capture is local, not CI.** Running it on the Linux runners was implemented and abandoned after nine runs. Under the bare X server this Electron build paints a capturable frame on load and not reliably afterwards: three of eight surfaces hung indefinitely, identically, whether the capture went through `locator.screenshot()`, `page.screenshot({clip})`, or `Page.captureScreenshot` over a raw DevTools session, and with GPU compositing both on and off. Every log carried `sandboxed_renderer.bundle.js script failed to run`. The same spec passes on a developer machine, so that is where capture runs. The workflow now only asks.

**Fixtures, not real projects.** Captures come from seeded scenarios, so nothing published exposes a contributor's repository names, branches, or paths.

**Surfaces are captured unconditionally rather than inferred from changed files.** A per-file mapping would rot, and it breaks on exactly the interesting cases — a change to `global.css` affects every pane. Selection happens by diffing two runs instead: identical fixtures and viewport mean an untouched surface is byte-identical.

**The reminder triggers on a paths filter as well as the label, and the two are not redundant.** `pr-labeler` applies `screenshots` using `GITHUB_TOKEN`, and GitHub does not start workflow runs from token-generated events — so an auto-applied label fires nothing on its own. Only a human applying it does. The paths filter is what makes the reminder appear without anyone remembering.

**The result is a comment, not an edit to the description**, so the bot never rewrites text a human owns. Images live under the head SHA, because reusing one path lets GitHub's image proxy serve stale screenshots — which reads as "my change did nothing".

## 📌 Follow-ups

- [x] Prove the publish path end to end. Done on a throwaway PR (#15351, now closed): a one-line CSS change produced "8 surfaces, 4 changed", published to the `pr-screenshots` branch and posted as a comment. Its images have since been pruned.
- [ ] Three surfaces (`branches-tab`, `upstream-tab`, `settings`) never captured on CI. They pass locally, so they are in the catalogue, but the underlying renderer question is unanswered if CI capture is ever revisited.
- [ ] Automatic coverage is gone with CI capture: someone must ask. The reminder comment is the mitigation.

## ⚠️ Known gaps

- **The catalogue covers eight surfaces.** A change to an uncatalogued screen produces no images, which is why the comparison always reports the total rather than only what it found.
- **Light mode only** — the harness seeds `theme: "light"`.
- **One viewport**, 1440×900; responsive breakage is invisible.
- **Native context menus** cannot be captured at all.
- **`contains()` matches substrings**, so a future label such as `no-screenshots` would also match `screenshots`.

