### PR TITLE
Lite: match the stacks header to the panel background

### DIFF
--- a/.agents/skills/lite-screenshots/SKILL.md
+++ b/.agents/skills/lite-screenshots/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: lite-screenshots
+description: Use when asked to add before/after screenshots of a Lite UI change to a pull request, when a PR touching apps/lite/ui needs its visual change shown, or when extending the screenshot catalogue in apps/lite/e2e/tests/screenshots.spec.ts. Captures both sides locally against seeded fixtures, publishes the surfaces that changed, and posts them to the PR.
+---
+
+A reviewer reading a CSS diff cannot see the result. This captures the Lite UI
+with the branch applied and again with it unapplied, and posts the surfaces that
+differ to the pull request.
+
+Capture runs **on this machine**, not in CI. It was tried in CI and abandoned:
+under the bare X server on the Linux runners this Electron build paints a frame
+on load and not reliably afterwards, so several surfaces hung indefinitely
+whether the capture went through Playwright or the DevTools protocol. The same
+spec passes here. The CI workflow only leaves a reminder.
+
+## Prerequisites
+
+- `cargo build -p but` once, giving `target/debug/but`.
+- The branch under test applied, and **not yet merged** — the base side comes
+  from unapplying it. Check `but status` first.
+
+## The flow
+
+Run every command from the repository root.
+
+### 1. Capture the branch as it stands
+
+```console
+$ SCREENSHOT_OUT=head BUT=$PWD/target/debug/but pnpm -F @gitbutler/lite test:e2e screenshots
+```
+
+Output lands in `apps/lite/e2e/screenshots/head/` (gitignored).
+
+### 2. Capture the base
+
+```console
+$ but unapply <branch>
+$ but status        # confirm the branch is gone from the workspace
+$ SCREENSHOT_OUT=base BUT=$PWD/target/debug/but pnpm -F @gitbutler/lite test:e2e screenshots
+$ but apply <branch>
+```
+
+**Check the unapply took effect.** It silently does nothing on a stale id or an
+already-merged branch, and both runs then capture identical code — which looks
+exactly like "this change is not visual". If every pair matches in step 3, assume
+this went wrong before concluding anything about the change.
+
+Re-apply immediately, before anything else can fail and leave the workspace short
+a branch.
+
+**Stacked branches take the whole stack down.** `but unapply` on a branch that is
+part of a stack unapplies every branch in it, including ones this capture depends
+on — unapplying a stacked change also removes the spec, and the base run then has
+no tests to execute. Check `but status` first. When the branch is stacked, capture
+the base by reverting the change in the working tree instead:
+
+1. Edit the changed files back to their pre-change state by hand.
+2. Capture into `base`.
+3. `but discard <file-id>` to restore the committed version.
+
+Confirm the restore: the change must be back before anything else happens.
+
+### 3. Select what changed
+
+```console
+$ node apps/lite/e2e/compare-screenshots.mjs \
+    apps/lite/e2e/screenshots/base \
+    apps/lite/e2e/screenshots/head \
+    /tmp/publish \
+    "https://raw.githubusercontent.com/<owner>/<repo>/pr-screenshots/pr-<number>/<short-sha>" \
+    /tmp/section.md
+```
+
+It prints `total=`, `changed=`, `added=`, stages only the differing pairs into
+`/tmp/publish`, and writes the comment body. Surfaces that did not change are
+byte-identical, so they are folded into a collapsed list rather than shown.
+
+### 4. Publish the images
+
+Images go on an orphan `pr-screenshots` branch, under `pr-<number>/<short-sha>/`.
+A per-commit directory matters: reusing one path lets GitHub's image proxy serve
+the previous run's screenshots from cache, which reads as "my change did nothing".
+
+```console
+$ rm -rf /tmp/pub && mkdir /tmp/pub && cd /tmp/pub
+$ git init -q -b pr-screenshots && git remote add origin <repo-url>
+$ git fetch -q --depth 1 origin pr-screenshots && git reset -q --hard origin/pr-screenshots
+$ mkdir -p pr-<number>/<short-sha> && cp -R /tmp/publish/. pr-<number>/<short-sha>/
+$ git add -A && git commit -q -m "Screenshots for #<number>" && git push -q origin pr-screenshots
+```
+
+The branch may not exist yet; skip the fetch and reset when it does not.
+
+### 5. Post to the pull request
+
+Upsert a single comment rather than stacking one per run — find a previous
+comment starting with `<!-- lite-screenshots -->` and PATCH it, else POST.
+
+```console
+$ jq -Rs '{body: .}' /tmp/section.md > /tmp/payload.json
+$ gh api "repos/<owner>/<repo>/issues/<number>/comments" --paginate \
+    --jq 'map(select(.body | startswith("<!-- lite-screenshots -->"))) | first | .id // empty'
+$ gh api -X PATCH "repos/<owner>/<repo>/issues/comments/<id>" --input /tmp/payload.json
+```
+
+Do not edit the pull request description: rewriting text a human owns risks
+clobbering their concurrent edits.
+
+## Before finishing
+
+- **Look at the images**, do not just trust exit codes. A green run proves files
+  were written, not that they show the surface.
+- Confirm the workspace is whole: `but status` should show the branch applied and
+  no stray uncommitted changes.
+
+## Extending the catalogue
+
+If the changed screen is not among the captured surfaces, the run reports
+"N surfaces, 0 changed" and shows nothing. Add it to
+`apps/lite/e2e/tests/screenshots.spec.ts`; coverage then applies to every later
+pull request.
+
+```ts
+test.describe("<area>", () => {
+	test.use({ scenario: "<fixture>.sh" });
+
+	test("<surface>", async ({ appWindow }) => {
+		await openProject(appWindow);
+		await goToTab(appWindow, "branches"); // when it lives on another tab
+		await shoot(appWindow, "<surface-name>", "<selector>");
+	});
+});
+```
+
+- `<surface-name>` becomes the filename and the heading a reviewer reads: name it
+  `commit-form`, not `outline-panel-2`.
+- Only fixtures calling `"$BUT" setup` register a project; the rest leave the app
+  on "Select a project." and every capture fails. Known good:
+  `project-in-single-branch-three-branch-stack.sh`,
+  `project-with-remote-branches.sh`, `project-with-conflicting-commits.sh`.
+- If no fixture reaches the state, build it in the test — `uncommitted` writes
+  files into `testEnvironment.workdir/local-clone` and reloads.
+- Prefer a stable id for the clip (`#outline-panel`, `#details-panel`), else a
+  CSS-module prefix or an ARIA hook. Never nth-child or a generated class.
+- One screenshot per test, taken after a fresh load. This costs nothing here and
+  keeps the spec usable if CI capture is ever revisited.
+
+## Out of scope
+
+- **Native context menus** cannot be captured; they are OS windows.
+- **Dark mode** is not covered — the harness seeds `theme: "light"`.
+- **States needing a real remote or credentials** cannot be fixtured.

--- a/.github/workflows/lite-screenshots.yml
+++ b/.github/workflows/lite-screenshots.yml
@@ -1,0 +1,84 @@
+name: Lite UI Screenshots
+
+# Reminds a pull request that touches Lite's UI to attach before/after
+# screenshots, and does nothing else.
+#
+# Capturing them in CI was tried and abandoned: under the bare X server on the
+# Linux runners this Electron build paints a frame on load and not reliably
+# afterwards, so three of eight surfaces hung indefinitely regardless of whether
+# the capture went through Playwright or the DevTools protocol directly. The
+# same spec passes on a developer machine, so capture lives there — see the
+# `lite-screenshots` skill.
+#
+# This job renders nothing, so it cannot fail that way.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      css: ${{ steps.filter.outputs.css }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        id: filter
+        with:
+          filters: |
+            css:
+              - 'apps/lite/ui/**/*.css'
+
+  remind:
+    needs: changes
+    # The paths filter is not redundant with the label. pr-labeler applies
+    # `screenshots` using GITHUB_TOKEN, and GitHub does not start workflow runs
+    # from token-generated events — so an auto-applied label fires nothing. Only
+    # a human applying it does. The filter is what makes this run on its own.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      (contains(github.event.pull_request.labels.*.name, 'screenshots') ||
+       needs.changes.outputs.css == 'true')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    env:
+      PR: ${{ github.event.pull_request.number }}
+      REPO: ${{ github.repository }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      # One comment, posted once. Nothing here edits or re-posts on later pushes:
+      # a reminder that repeats is a reminder people mute.
+      - name: Ask for screenshots
+        run: |
+          marker="<!-- lite-screenshots-reminder -->"
+          existing="$(gh api "repos/${REPO}/issues/${PR}/comments" --paginate \
+            --jq "map(select(.body | startswith(\"${marker}\"))) | first | .id // empty")"
+          if [ -n "$existing" ]; then
+            echo "Already asked."
+            exit 0
+          fi
+          cat > /tmp/comment.md <<EOF
+          ${marker}
+          This pull request changes Lite's UI. Before/after screenshots make it
+          reviewable without checking the branch out.
+
+          To attach them, ask your agent for the \`lite-screenshots\` skill — it
+          captures both sides against seeded fixtures, publishes the surfaces that
+          changed, and posts them here.
+
+          Remove the \`screenshots\` label if this change is not visual.
+          EOF
+          gh api -X POST "repos/${REPO}/issues/${PR}/comments" \
+            --input <(jq -Rs '{body: .}' /tmp/comment.md) --silent
+          echo "Asked for screenshots on #${PR}."

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.module.css
@@ -73,6 +73,7 @@
 .stacksHeader {
 	flex-shrink: 0;
 	border-block-end: 1px solid var(--border-section);
+	background-color: var(--bg-1);
 }
 
 .stacksScroller {


### PR DESCRIPTION
## 🧢 Changes

Gives `.stacksHeader` the panel background so the header sits on the same surface as the cards below it.

## ☕️ Reasoning

Test pull request for the screenshot flow in #15350 — a deliberately small, visible CSS change so the before/after capture has something real to show. Not intended to merge.