### PR TITLE
Detect DeepSeek Harness (dsh) as an AI agent

### DIFF
--- a/crates/but/src/command/agent/plan.rs
+++ b/crates/but/src/command/agent/plan.rs
@@ -75,7 +75,9 @@ impl AgentTarget {
             detect_agent::Agent::GitHubCopilot => Some(Self::GitHubCopilot),
             detect_agent::Agent::OpenCode => Some(Self::OpenCode),
             detect_agent::Agent::Poolside => Some(Self::Poolside),
-            detect_agent::Agent::Devin | detect_agent::Agent::Dirac => Some(Self::AgentSkills),
+            detect_agent::Agent::Devin
+            | detect_agent::Agent::Dirac
+            | detect_agent::Agent::DeepSeekHarness => Some(Self::AgentSkills),
             detect_agent::Agent::GeminiCli
             | detect_agent::Agent::KiroCli
             | detect_agent::Agent::Junie

--- a/crates/but/src/command/agent/tests.rs
+++ b/crates/but/src/command/agent/tests.rs
@@ -23,6 +23,14 @@ fn dirac_uses_shared_agent_skills_target() {
 }
 
 #[test]
+fn deepseek_harness_uses_shared_agent_skills_target() {
+    assert_eq!(
+        AgentTarget::from_detected(detect_agent::Agent::DeepSeekHarness),
+        Some(AgentTarget::AgentSkills)
+    );
+}
+
+#[test]
 fn generated_default_policy_includes_baseline_and_default_preferences() {
     let policy = render_managed_policy_block(&WizardAnswers::default());
 

--- a/crates/but/src/command/skill/mod.rs
+++ b/crates/but/src/command/skill/mod.rs
@@ -275,7 +275,7 @@ fn skill_format_for_agent(agent: Agent, global: bool) -> Option<&'static SkillFo
         Agent::Replit | Agent::Amp => "Universal Agents",
         Agent::Crush => "Crush",
         Agent::Goose => "Goose",
-        Agent::Cline | Agent::Dirac => "Agent Skills",
+        Agent::Cline | Agent::Dirac | Agent::DeepSeekHarness => "Agent Skills",
         Agent::RooCode => "Roo Code",
         Agent::Trae => "Trae",
         Agent::TabnineCli => "Tabnine CLI",

--- a/crates/but/src/utils/detect_agent.rs
+++ b/crates/but/src/utils/detect_agent.rs
@@ -55,6 +55,7 @@ environment_variables! {
     CODEBUDDY_PROJECT_DIR = "CODEBUDDY_PROJECT_DIR",
     GROK_AGENT = "GROK_AGENT",
     OPENCLAW_SHELL = "OPENCLAW_SHELL",
+    DSH_SHELL = "DSH_SHELL",
     PS1 = "PS1",
     PROMPT_COMMAND = "PROMPT_COMMAND",
     OZ_HARNESS = "OZ_HARNESS",
@@ -102,6 +103,7 @@ pub enum Agent {
     Warp,
     OpenHands,
     OpenClaw,
+    DeepSeekHarness,
     Unknown,
 }
 
@@ -145,6 +147,7 @@ impl Agent {
             Self::Warp => "warp",
             Self::OpenHands => "openhands",
             Self::OpenClaw => "openclaw",
+            Self::DeepSeekHarness => "deepseek-harness",
             Self::Unknown => "unknown",
         }
     }
@@ -303,6 +306,11 @@ pub fn detect_with(lookup: impl Fn(&str) -> Option<OsString>) -> Option<Agent> {
     if is_value(GOOSE_TERMINAL, "1") {
         return Some(Agent::Goose);
     }
+    // DeepSeek Harness (`dsh`) sets `DSH_SHELL=1` on every shell-tool child and
+    // strips inherited `DSH_*` first, so the marker cannot leak across harnesses.
+    if is_value(DSH_SHELL, "1") {
+        return Some(Agent::DeepSeekHarness);
+    }
     // These runtime markers are inherited by nested agents, so a nested agent's
     // own marker above must win over the outer command runner.
     if contains(AWS_EXECUTION_ENV, "AmazonQ-For-CLI") {
@@ -425,6 +433,7 @@ fn match_agent_name(val: &str) -> Option<Agent> {
         "warp" | "warp-oz" => Agent::Warp,
         "openhands" | "open-hands" => Agent::OpenHands,
         "openclaw" | "open-claw" => Agent::OpenClaw,
+        "dsh" | "deepseek" | "deepseek-harness" => Agent::DeepSeekHarness,
         _ => return None,
     })
 }

--- a/crates/but/src/utils/detect_agent/tests.rs
+++ b/crates/but/src/utils/detect_agent/tests.rs
@@ -317,6 +317,8 @@ fn ai_agent_accepts_known_aliases() {
         ("warp-oz", Agent::Warp),
         ("open-hands", Agent::OpenHands),
         ("open-claw", Agent::OpenClaw),
+        ("dsh", Agent::DeepSeekHarness),
+        ("deepseek", Agent::DeepSeekHarness),
     ];
 
     for (name, agent) in cases {
@@ -511,6 +513,7 @@ fn detect_new_invocation_specific_markers() {
         ("GROK_AGENT", "1", Agent::GrokBuild),
         ("OZ_HARNESS", "oz", Agent::Warp),
         ("OPENCLAW_SHELL", "exec", Agent::OpenClaw),
+        ("DSH_SHELL", "1", Agent::DeepSeekHarness),
         ("GOOSE_TERMINAL", "1", Agent::Goose),
     ];
 
@@ -552,6 +555,7 @@ fn reject_non_agent_runtime_values() {
         ("GROK_AGENT", "true"),
         ("OPENCLAW_SHELL", "tui-local"),
         ("OPENCLAW_SHELL", "acp-client"),
+        ("DSH_SHELL", "true"),
         ("GOOSE_TERMINAL", "true"),
     ] {
         assert_eq!(
@@ -573,6 +577,11 @@ fn nested_agent_marker_wins_over_outer_runtime_markers() {
             detect_with(env_from(&[(var, value), ("CLAUDE_CODE", "1")])),
             Some(Agent::ClaudeCode),
             "Claude should win over inherited {var}",
+        );
+        assert_eq!(
+            detect_with(env_from(&[(var, value), ("DSH_SHELL", "1")])),
+            Some(Agent::DeepSeekHarness),
+            "DeepSeek Harness should win over inherited {var}",
         );
     }
 }
@@ -676,6 +685,7 @@ fn agent_name_roundtrip() {
         Agent::Warp,
         Agent::OpenHands,
         Agent::OpenClaw,
+        Agent::DeepSeekHarness,
         Agent::Unknown,
     ];
     for agent in agents {
@@ -719,6 +729,7 @@ fn agent_name_roundtrip() {
             | Agent::Warp
             | Agent::OpenHands
             | Agent::OpenClaw
+            | Agent::DeepSeekHarness
             | Agent::Unknown => {}
         }
         let lookup = env_from(&[("AI_AGENT", agent.as_str())]);


### PR DESCRIPTION
DeepSeek Harness (`dsh`) sets `DSH_SHELL=1` on every shell-tool child and strips inherited `DSH_*` first, so that variable is the detection marker (it sets neither `AI_AGENT` nor `AGENT`). Also accepts `dsh` / `deepseek` / `deepseek-harness` via `AI_AGENT`.

dsh loads `AGENTS.md` and `.agents/skills`, so `but skill` and the setup wizard map it to the existing shared "Agent Skills" format.