### PR TITLE
Checkout a new branch after full upstream integration

### DIFF
--- a/crates/but-workspace/src/upstream_integration.rs
+++ b/crates/but-workspace/src/upstream_integration.rs
@@ -421,7 +421,7 @@ pub fn integrate_upstream_with_hints<'ws, 'meta, M: RefMetadata>(
                     *parent_order,
                 )?;
             }
-            [] if !fully_integrated_workspace_parents.is_empty() => {
+            [] if !fully_integrated_workspace_parents.is_empty() && stacks.len() > 1 => {
                 // A managed workspace must not become empty. Replace its checkout with a fresh
                 // ad-hoc branch at the latest target tip, just like a fully integrated direct
                 // checkout.
@@ -435,6 +435,10 @@ pub fn integrate_upstream_with_hints<'ws, 'meta, M: RefMetadata>(
                     workspace_ref_name,
                     target_ref_commit_selector,
                 )?;
+            }
+            [] if !fully_integrated_workspace_parents.is_empty() => {
+                // A single integrated stack retains the existing empty managed workspace.
+                editor.add_edge(workspace_commit_selector, target_ref_selector, 0)?;
             }
             _ => {}
         }

--- a/crates/but-workspace/src/upstream_integration.rs
+++ b/crates/but-workspace/src/upstream_integration.rs
@@ -195,6 +195,7 @@ pub fn integrate_upstream_with_hints<'ws, 'meta, M: RefMetadata>(
     let head_commit = repo.find_commit(head_commit.id)?;
     let head_commit_id = head_commit.id;
     let head_is_workspace_commit = is_managed_workspace_by_message(head_commit.message_raw()?);
+    let workspace_ref_name = workspace.ref_name().map(ToOwned::to_owned);
     let direct_checkout_head_ref_name = if head_is_workspace_commit {
         None
     } else {
@@ -352,7 +353,7 @@ pub fn integrate_upstream_with_hints<'ws, 'meta, M: RefMetadata>(
                 && let Some(head_ref_name) = direct_checkout_head_ref_name.as_ref()
                 && head_ref_name.as_ref().category() == Some(gix::refs::Category::LocalBranch)
             {
-                direct_checkout_replacement_ref = Some(replace_direct_checkout_ref_with_fallback(
+                direct_checkout_replacement_ref = Some(replace_checkout_ref_with_fallback(
                     &mut editor,
                     repo,
                     head_ref_name.as_ref(),
@@ -421,8 +422,19 @@ pub fn integrate_upstream_with_hints<'ws, 'meta, M: RefMetadata>(
                 )?;
             }
             [] if !fully_integrated_workspace_parents.is_empty() => {
-                // Orphaned workspace, reparent onto the target ref.
-                editor.add_edge(workspace_commit_selector, target_ref_selector, 0)?;
+                // A managed workspace must not become empty. Replace its checkout with a fresh
+                // ad-hoc branch at the latest target tip, just like a fully integrated direct
+                // checkout.
+                let workspace_ref_name = workspace_ref_name
+                    .as_ref()
+                    .map(|name| name.as_ref())
+                    .context("Managed workspace has no reference")?;
+                replace_checkout_ref_with_fallback(
+                    &mut editor,
+                    repo,
+                    workspace_ref_name,
+                    target_ref_commit_selector,
+                )?;
             }
             _ => {}
         }
@@ -1084,19 +1096,17 @@ fn selector_commit_id<M: RefMetadata>(
     })
 }
 
-/// Replace a fully integrated direct-checkout branch with a new canned local branch at the
-/// latest target tip.
+/// Replace a fully integrated checkout reference with a new canned local branch at the latest
+/// target tip.
 ///
-/// In a managed workspace, a fully integrated stack can simply be detached from the workspace
-/// commit and the workspace commit is reparented to the target. A direct checkout has no
-/// workspace commit to keep `HEAD` alive, so deleting the checked-out branch would leave `HEAD`
+/// Deleting the checked-out branch or empty managed workspace reference would leave `HEAD`
 /// pointing at a missing ref. Instead, reuse the checkout reference step for a fresh branch name
 /// and point it at the latest target commit.
 ///
 /// The old checkout reference can be on the target ancestry path. Before repointing the step to
 /// the target tip, `disconnect_segment_from()` rewires its children around the old reference to
 /// preserve the existing graph and avoid introducing a cycle.
-fn replace_direct_checkout_ref_with_fallback<M: RefMetadata>(
+fn replace_checkout_ref_with_fallback<M: RefMetadata>(
     editor: &mut Editor<'_, '_, M>,
     repo: &gix::Repository,
     head_ref_name: &gix::refs::FullNameRef,

--- a/crates/but-workspace/tests/workspace/upstream_integration.rs
+++ b/crates/but-workspace/tests/workspace/upstream_integration.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use bstr::ByteSlice;
-use but_core::{Commit, RefMetadata, is_workspace_ref_name, ref_metadata::ProjectMeta};
+use but_core::{Commit, RefMetadata, ref_metadata::ProjectMeta};
 use but_graph::init::{Options, Tip};
 use but_rebase::graph_rebase::mutate::RelativeTo;
 use but_testsupport::{
@@ -832,7 +832,7 @@ fn fully_historically_integrated_branch_leaves_workspace_shape() -> Result<()> {
 }
 
 #[test]
-fn fully_integrated_single_branch_checks_out_canned_branch() -> Result<()> {
+fn fully_integrated_single_branch_leaves_workspace_shape() -> Result<()> {
     let (_tmp, repo, mut meta, _description) =
         named_writable_scenario_with_description("fully-integrated-single-branch")?;
     let target_sha = repo.rev_parse_single("main")?.detach();
@@ -871,7 +871,7 @@ fn fully_integrated_single_branch_checks_out_canned_branch() -> Result<()> {
 "#]]
     );
 
-    integrate_and_materialize(
+    let project_meta = integrate_and_materialize(
         &mut workspace,
         &mut meta,
         &repo,
@@ -880,13 +880,33 @@ fn fully_integrated_single_branch_checks_out_canned_branch() -> Result<()> {
             selector: RelativeTo::Commit(repo.rev_parse_single("A")?.detach()),
         }],
     )?;
-    assert_ad_hoc_checkout_at_target(&repo)?;
+
+    let meta = empty_managed_workspace_metadata(&meta)?;
+    let graph =
+        but_graph::Graph::from_head(&repo, &meta, project_meta.clone(), Options::limited())?;
+    let workspace = graph.into_workspace()?;
+    snapbox::assert_data_eq!(
+        graph_workspace(&workspace).to_string(),
+        snapbox::str![[r#"
+📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 905d6e5
+
+"#]]
+    );
+    snapbox::assert_data_eq!(
+        visualize_commit_graph_all(&repo)?,
+        snapbox::str![[r#"
+* f88e9ce (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+* 905d6e5 (origin/main) add A1
+* 3183e43 (main) M1
+
+"#]]
+    );
 
     Ok(())
 }
 
 #[test]
-fn fully_integrated_single_branch_checks_out_canned_branch_at_advanced_target() -> Result<()> {
+fn fully_integrated_single_branch_reparents_workspace_commit_to_advanced_target() -> Result<()> {
     let (_tmp, repo, mut meta, _description) =
         named_writable_scenario_with_description("fully-integrated-single-branch-target-advanced")?;
     let target_sha = repo.rev_parse_single("main")?.detach();
@@ -929,7 +949,7 @@ fn fully_integrated_single_branch_checks_out_canned_branch_at_advanced_target() 
 "#]]
     );
 
-    integrate_and_materialize(
+    let project_meta = integrate_and_materialize(
         &mut workspace,
         &mut meta,
         &repo,
@@ -938,7 +958,29 @@ fn fully_integrated_single_branch_checks_out_canned_branch_at_advanced_target() 
             selector: RelativeTo::Commit(repo.rev_parse_single("A^")?.detach()),
         }],
     )?;
-    assert_ad_hoc_checkout_at_target(&repo)?;
+
+    let meta = empty_managed_workspace_metadata(&meta)?;
+    let graph =
+        but_graph::Graph::from_head(&repo, &meta, project_meta.clone(), Options::limited())?;
+    let workspace = graph.into_workspace()?;
+    snapbox::assert_data_eq!(
+        graph_workspace(&workspace).to_string(),
+        snapbox::str![[r#"
+📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 6b20716
+
+"#]]
+    );
+    snapbox::assert_data_eq!(
+        visualize_commit_graph_all(&repo)?,
+        snapbox::str![[r#"
+* fa202eb (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+* 6b20716 (origin/main) add X
+* ffde79e add A
+* 86b55e6 add B
+* 8d5739f (main) add C
+
+"#]]
+    );
 
     Ok(())
 }
@@ -990,7 +1032,7 @@ fn squash_merged_multi_commit_branch_is_pruned() -> Result<()> {
 "#]]
     );
 
-    integrate_and_materialize(
+    let project_meta = integrate_and_materialize(
         &mut workspace,
         &mut meta,
         &repo,
@@ -999,7 +1041,31 @@ fn squash_merged_multi_commit_branch_is_pruned() -> Result<()> {
             selector: RelativeTo::Commit(repo.rev_parse_single("A~1")?.detach()),
         }],
     )?;
-    assert_ad_hoc_checkout_at_target(&repo)?;
+
+    let meta = empty_managed_workspace_metadata(&meta)?;
+    let graph =
+        but_graph::Graph::from_head(&repo, &meta, project_meta.clone(), Options::limited())?;
+    let workspace = graph.into_workspace()?;
+    // Neither commit matches the squash commit one-to-one, but their cumulative changeset
+    // does - the branch must be recognized as integrated and leave the workspace.
+    snapbox::assert_data_eq!(
+        graph_workspace(&workspace).to_string(),
+        snapbox::str![[r#"
+📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 6204bf3
+
+"#]]
+    );
+    // A's commits are dropped rather than rebased into empty copies above the target tip.
+    snapbox::assert_data_eq!(
+        visualize_commit_graph_all(&repo)?,
+        snapbox::str![[r#"
+* 6ad6d07 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+* 6204bf3 (origin/main) add X
+* 039050a A1 + A2 (#1)
+* 9bede57 (main) add M1
+
+"#]]
+    );
 
     Ok(())
 }
@@ -1360,7 +1426,7 @@ fn non_bottom_update_selector_does_not_prune_fully_integrated_stack() -> Result<
 }
 
 #[test]
-fn fully_integrated_single_branch_checks_out_canned_branch_at_advanced_merge_target() -> Result<()>
+fn fully_integrated_single_branch_reparents_workspace_commit_to_advanced_merge_target() -> Result<()>
 {
     let (_tmp, repo, mut meta, _description) = named_writable_scenario_with_description(
         "fully-integrated-single-branch-target-advanced-through-merge",
@@ -1410,7 +1476,7 @@ fn fully_integrated_single_branch_checks_out_canned_branch_at_advanced_merge_tar
 "#]]
     );
 
-    integrate_and_materialize(
+    let project_meta = integrate_and_materialize(
         &mut workspace,
         &mut meta,
         &repo,
@@ -1419,7 +1485,33 @@ fn fully_integrated_single_branch_checks_out_canned_branch_at_advanced_merge_tar
             selector: RelativeTo::Commit(repo.rev_parse_single("A^")?.detach()),
         }],
     )?;
-    assert_ad_hoc_checkout_at_target(&repo)?;
+
+    let meta = empty_managed_workspace_metadata(&meta)?;
+    let graph =
+        but_graph::Graph::from_head(&repo, &meta, project_meta.clone(), Options::limited())?;
+    let workspace = graph.into_workspace()?;
+    snapbox::assert_data_eq!(
+        graph_workspace(&workspace).to_string(),
+        snapbox::str![[r#"
+📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on f27db86
+
+"#]]
+    );
+    snapbox::assert_data_eq!(
+        visualize_commit_graph_all(&repo)?,
+        snapbox::str![[r#"
+* d60856a (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+* f27db86 (origin/main) add X
+*   4f5589a D
+|\  
+| * ffde79e add A
+| * 86b55e6 add B
+|/  
+* 8d5739f (main) add C
+
+"#]]
+        .raw()
+    );
 
     Ok(())
 }
@@ -2410,7 +2502,7 @@ fn fully_integrated_two_stacks_checkout_canned_branch_at_target_tip() -> Result<
 }
 
 #[test]
-fn content_integrated_stack_checks_out_canned_branch_at_target_tip() -> Result<()> {
+fn orphan_reparent_content_integrated_stack_to_target_tip() -> Result<()> {
     let (_tmp, repo, mut meta, _description) = named_writable_scenario_with_description(
         "fully-content-integrated-single-branch-target-advanced",
     )?;
@@ -2439,7 +2531,11 @@ fn content_integrated_stack_checks_out_canned_branch_at_target_tip() -> Result<(
         }],
     )?;
 
-    assert_ad_hoc_checkout_at_target(&repo)?;
+    assert_eq!(
+        workspace_first_parent(&repo)?,
+        repo.rev_parse_single("origin/main")?.detach(),
+        "orphaned workspace commit should be reparented to the advanced target tip after content integration"
+    );
 
     Ok(())
 }
@@ -2634,8 +2730,31 @@ fn empty_branch_with_integrated_remote_tip_is_removed() -> Result<()> {
         "workspace metadata should no longer expose the integrated empty branch"
     );
     out.rebase.materialize(Default::default())?;
-    assert!(repo.try_find_reference("topic")?.is_none());
-    assert_ad_hoc_checkout_at_target(&repo)?;
+    let graph = but_graph::Graph::from_head(&repo, &meta, project_meta, Options::limited())?;
+    let workspace = graph.into_workspace()?;
+    snapbox::assert_data_eq!(
+        graph_workspace(&workspace).to_string(),
+        snapbox::str![[r#"
+📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 563a7fc
+└── ≡:2:main <> origin/main →:1: on 563a7fc
+    └── :2:main <> origin/main →:1:
+        └── ❄️364a08f (🏘️|✓)
+
+"#]]
+    );
+    snapbox::assert_data_eq!(
+        visualize_commit_graph_all(&repo)?,
+        snapbox::str![[r#"
+* cf134fb (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+*   364a08f (origin/main, main) merge topic
+|\  
+| * 6ba217e (origin/topic) add topic
+|/  
+* 563a7fc add base
+
+"#]]
+        .raw()
+    );
 
     Ok(())
 }
@@ -2905,7 +3024,7 @@ fn integrated_bottom_under_empty_direct_checkout_is_removed_and_top_is_preserved
 }
 
 #[test]
-fn fully_integrated_stack_at_target_tip_checks_out_canned_branch() -> Result<()> {
+fn orphan_reparent_same_target_tip_keeps_single_parent() -> Result<()> {
     let (_tmp, repo, mut meta, _description) =
         named_writable_scenario_with_description("fully-integrated-single-branch")?;
     let target_sha = repo.rev_parse_single("main")?.detach();
@@ -2933,7 +3052,16 @@ fn fully_integrated_stack_at_target_tip_checks_out_canned_branch() -> Result<()>
         }],
     )?;
 
-    assert_ad_hoc_checkout_at_target(&repo)?;
+    assert_eq!(
+        workspace_first_parent(&repo)?,
+        repo.rev_parse_single("origin/main")?.detach(),
+        "orphaned workspace commit should stay on the target tip when it already equals the removed parent"
+    );
+    assert_eq!(
+        workspace_parent_count(&repo)?,
+        1,
+        "workspace commit should not gain duplicate parents"
+    );
 
     Ok(())
 }
@@ -3570,7 +3698,6 @@ fn integrate_and_materialize<M: RefMetadata>(
     let materialized = rebase.materialize(Default::default())?;
     if let Some(ref_name) = materialized.workspace.ref_name()
         && let Some(ws_meta) = ws_meta
-        && is_workspace_ref_name(ref_name)
     {
         let mut md = materialized.meta.workspace(ref_name)?;
         *md = ws_meta;
@@ -3615,7 +3742,6 @@ fn integrate_with_hints_and_materialize<M: RefMetadata>(
     let materialized = rebase.materialize(Default::default())?;
     if let Some(ref_name) = materialized.workspace.ref_name()
         && let Some(ws_meta) = ws_meta
-        && is_workspace_ref_name(ref_name)
     {
         let mut md = materialized.meta.workspace(ref_name)?;
         *md = ws_meta;
@@ -3639,25 +3765,10 @@ fn workspace_parent_ids(repo: &gix::Repository) -> Result<Vec<gix::ObjectId>> {
         .collect())
 }
 
-fn assert_ad_hoc_checkout_at_target(repo: &gix::Repository) -> Result<()> {
-    let head_name = repo.head_name()?.context("HEAD should remain attached")?;
-    assert_eq!(
-        head_name.category(),
-        Some(gix::refs::Category::LocalBranch),
-        "replacement checkout should be a local branch"
-    );
-    assert_ne!(head_name.as_bstr(), but_core::WORKSPACE_REF_NAME.as_bytes());
-    assert!(
-        repo.try_find_reference(but_core::WORKSPACE_REF_NAME)?
-            .is_none(),
-        "empty managed workspace reference should be removed"
-    );
-    assert_eq!(
-        repo.head_id()?.detach(),
-        repo.rev_parse_single("origin/main")?.detach(),
-        "replacement checkout should point at the latest target tip"
-    );
-    Ok(())
+fn workspace_parent_count(repo: &gix::Repository) -> Result<usize> {
+    let workspace_commit =
+        repo.find_commit(repo.rev_parse_single("gitbutler/workspace")?.detach())?;
+    Ok(workspace_commit.parent_ids().count())
 }
 
 fn force_prefixless_canned_branch_name(repo: &mut gix::Repository) -> Result<()> {

--- a/crates/but-workspace/tests/workspace/upstream_integration.rs
+++ b/crates/but-workspace/tests/workspace/upstream_integration.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use bstr::ByteSlice;
-use but_core::{Commit, RefMetadata, ref_metadata::ProjectMeta};
+use but_core::{Commit, RefMetadata, is_workspace_ref_name, ref_metadata::ProjectMeta};
 use but_graph::init::{Options, Tip};
 use but_rebase::graph_rebase::mutate::RelativeTo;
 use but_testsupport::{
@@ -832,7 +832,7 @@ fn fully_historically_integrated_branch_leaves_workspace_shape() -> Result<()> {
 }
 
 #[test]
-fn fully_integrated_single_branch_leaves_workspace_shape() -> Result<()> {
+fn fully_integrated_single_branch_checks_out_canned_branch() -> Result<()> {
     let (_tmp, repo, mut meta, _description) =
         named_writable_scenario_with_description("fully-integrated-single-branch")?;
     let target_sha = repo.rev_parse_single("main")?.detach();
@@ -871,7 +871,7 @@ fn fully_integrated_single_branch_leaves_workspace_shape() -> Result<()> {
 "#]]
     );
 
-    let project_meta = integrate_and_materialize(
+    integrate_and_materialize(
         &mut workspace,
         &mut meta,
         &repo,
@@ -880,33 +880,13 @@ fn fully_integrated_single_branch_leaves_workspace_shape() -> Result<()> {
             selector: RelativeTo::Commit(repo.rev_parse_single("A")?.detach()),
         }],
     )?;
-
-    let meta = empty_managed_workspace_metadata(&meta)?;
-    let graph =
-        but_graph::Graph::from_head(&repo, &meta, project_meta.clone(), Options::limited())?;
-    let workspace = graph.into_workspace()?;
-    snapbox::assert_data_eq!(
-        graph_workspace(&workspace).to_string(),
-        snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 905d6e5
-
-"#]]
-    );
-    snapbox::assert_data_eq!(
-        visualize_commit_graph_all(&repo)?,
-        snapbox::str![[r#"
-* f88e9ce (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-* 905d6e5 (origin/main) add A1
-* 3183e43 (main) M1
-
-"#]]
-    );
+    assert_ad_hoc_checkout_at_target(&repo)?;
 
     Ok(())
 }
 
 #[test]
-fn fully_integrated_single_branch_reparents_workspace_commit_to_advanced_target() -> Result<()> {
+fn fully_integrated_single_branch_checks_out_canned_branch_at_advanced_target() -> Result<()> {
     let (_tmp, repo, mut meta, _description) =
         named_writable_scenario_with_description("fully-integrated-single-branch-target-advanced")?;
     let target_sha = repo.rev_parse_single("main")?.detach();
@@ -949,7 +929,7 @@ fn fully_integrated_single_branch_reparents_workspace_commit_to_advanced_target(
 "#]]
     );
 
-    let project_meta = integrate_and_materialize(
+    integrate_and_materialize(
         &mut workspace,
         &mut meta,
         &repo,
@@ -958,29 +938,7 @@ fn fully_integrated_single_branch_reparents_workspace_commit_to_advanced_target(
             selector: RelativeTo::Commit(repo.rev_parse_single("A^")?.detach()),
         }],
     )?;
-
-    let meta = empty_managed_workspace_metadata(&meta)?;
-    let graph =
-        but_graph::Graph::from_head(&repo, &meta, project_meta.clone(), Options::limited())?;
-    let workspace = graph.into_workspace()?;
-    snapbox::assert_data_eq!(
-        graph_workspace(&workspace).to_string(),
-        snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 6b20716
-
-"#]]
-    );
-    snapbox::assert_data_eq!(
-        visualize_commit_graph_all(&repo)?,
-        snapbox::str![[r#"
-* fa202eb (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-* 6b20716 (origin/main) add X
-* ffde79e add A
-* 86b55e6 add B
-* 8d5739f (main) add C
-
-"#]]
-    );
+    assert_ad_hoc_checkout_at_target(&repo)?;
 
     Ok(())
 }
@@ -1032,7 +990,7 @@ fn squash_merged_multi_commit_branch_is_pruned() -> Result<()> {
 "#]]
     );
 
-    let project_meta = integrate_and_materialize(
+    integrate_and_materialize(
         &mut workspace,
         &mut meta,
         &repo,
@@ -1041,31 +999,7 @@ fn squash_merged_multi_commit_branch_is_pruned() -> Result<()> {
             selector: RelativeTo::Commit(repo.rev_parse_single("A~1")?.detach()),
         }],
     )?;
-
-    let meta = empty_managed_workspace_metadata(&meta)?;
-    let graph =
-        but_graph::Graph::from_head(&repo, &meta, project_meta.clone(), Options::limited())?;
-    let workspace = graph.into_workspace()?;
-    // Neither commit matches the squash commit one-to-one, but their cumulative changeset
-    // does - the branch must be recognized as integrated and leave the workspace.
-    snapbox::assert_data_eq!(
-        graph_workspace(&workspace).to_string(),
-        snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 6204bf3
-
-"#]]
-    );
-    // A's commits are dropped rather than rebased into empty copies above the target tip.
-    snapbox::assert_data_eq!(
-        visualize_commit_graph_all(&repo)?,
-        snapbox::str![[r#"
-* 6ad6d07 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-* 6204bf3 (origin/main) add X
-* 039050a A1 + A2 (#1)
-* 9bede57 (main) add M1
-
-"#]]
-    );
+    assert_ad_hoc_checkout_at_target(&repo)?;
 
     Ok(())
 }
@@ -1426,7 +1360,7 @@ fn non_bottom_update_selector_does_not_prune_fully_integrated_stack() -> Result<
 }
 
 #[test]
-fn fully_integrated_single_branch_reparents_workspace_commit_to_advanced_merge_target() -> Result<()>
+fn fully_integrated_single_branch_checks_out_canned_branch_at_advanced_merge_target() -> Result<()>
 {
     let (_tmp, repo, mut meta, _description) = named_writable_scenario_with_description(
         "fully-integrated-single-branch-target-advanced-through-merge",
@@ -1476,7 +1410,7 @@ fn fully_integrated_single_branch_reparents_workspace_commit_to_advanced_merge_t
 "#]]
     );
 
-    let project_meta = integrate_and_materialize(
+    integrate_and_materialize(
         &mut workspace,
         &mut meta,
         &repo,
@@ -1485,33 +1419,7 @@ fn fully_integrated_single_branch_reparents_workspace_commit_to_advanced_merge_t
             selector: RelativeTo::Commit(repo.rev_parse_single("A^")?.detach()),
         }],
     )?;
-
-    let meta = empty_managed_workspace_metadata(&meta)?;
-    let graph =
-        but_graph::Graph::from_head(&repo, &meta, project_meta.clone(), Options::limited())?;
-    let workspace = graph.into_workspace()?;
-    snapbox::assert_data_eq!(
-        graph_workspace(&workspace).to_string(),
-        snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on f27db86
-
-"#]]
-    );
-    snapbox::assert_data_eq!(
-        visualize_commit_graph_all(&repo)?,
-        snapbox::str![[r#"
-* d60856a (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-* f27db86 (origin/main) add X
-*   4f5589a D
-|\  
-| * ffde79e add A
-| * 86b55e6 add B
-|/  
-* 8d5739f (main) add C
-
-"#]]
-        .raw()
-    );
+    assert_ad_hoc_checkout_at_target(&repo)?;
 
     Ok(())
 }
@@ -2398,10 +2306,13 @@ fn fully_integrated_multi_branch_stack_leaves_workspace_shape() -> Result<()> {
 }
 
 #[test]
-fn fully_integrated_two_stacks_leave_workspace_shape() -> Result<()> {
-    let (_tmp, repo, mut meta, _description) =
+fn fully_integrated_two_stacks_checkout_canned_branch_at_target_tip() -> Result<()> {
+    let (_tmp, mut repo, mut meta, _description) =
         named_writable_scenario_with_description("fully-integrated-two-stacks")?;
+    force_prefixless_canned_branch_name(&mut repo)?;
     let target_sha = repo.rev_parse_single("main~2")?.detach();
+    let target_tip = repo.rev_parse_single("origin/main")?.detach();
+    let fallback_ref: gix::refs::FullName = "refs/heads/branch-1".try_into()?;
 
     let project_meta = target_project_meta("refs/remotes/origin/main", target_sha)?;
     add_stack(&mut meta, 1, "A", StackState::InWorkspace);
@@ -2452,10 +2363,13 @@ fn fully_integrated_two_stacks_leave_workspace_shape() -> Result<()> {
 "#]]
     );
 
-    let project_meta = integrate_and_materialize(
+    let mut db = but_testsupport::in_memory_db();
+    let out = integrate_upstream(
         &mut workspace,
         &mut meta,
+        project_meta,
         &repo,
+        &mut db,
         vec![
             BottomUpdate {
                 kind: BottomUpdateKind::Rebase,
@@ -2468,41 +2382,35 @@ fn fully_integrated_two_stacks_leave_workspace_shape() -> Result<()> {
         ],
     )?;
 
-    let meta = empty_managed_workspace_metadata(&meta)?;
-    let graph =
-        but_graph::Graph::from_head(&repo, &meta, project_meta.clone(), Options::limited())?;
-    let workspace = graph.into_workspace()?;
-    snapbox::assert_data_eq!(
-        graph_workspace(&workspace).to_string(),
-        snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 5f7d45e
-
-"#]]
+    let preview = out.rebase.overlayed_graph()?.into_workspace()?;
+    assert_eq!(
+        preview.ref_name(),
+        Some(fallback_ref.as_ref()),
+        "dry-run overlay should show the canned branch as the checkout"
     );
-    snapbox::assert_data_eq!(
-        visualize_commit_graph_all(&repo)?,
-        snapbox::str![[r#"
-* b44fd24 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-*   5f7d45e (origin/main, main) Merging B into base
-|\  
-| * b38b04b add B1
-* |   1f7670a Merging A into base
-|\ \  
-| |/  
-|/|   
-| * 905d6e5 add A1
-|/  
-* 3183e43 M1
-
-"#]]
-        .raw()
+    assert!(
+        repo.try_find_reference(fallback_ref.as_ref())?.is_none(),
+        "dry-run preview should not create the canned branch on disk"
     );
+    drop(preview);
+
+    out.rebase.materialize(Default::default())?;
+
+    assert!(repo.try_find_reference("A")?.is_none());
+    assert!(repo.try_find_reference("B")?.is_none());
+    assert!(
+        repo.try_find_reference(but_core::WORKSPACE_REF_NAME)?
+            .is_none(),
+        "the empty managed workspace reference should be removed"
+    );
+    assert_eq!(repo.find_reference(fallback_ref.as_ref())?.id(), target_tip);
+    assert_eq!(repo.head_name()?, Some(fallback_ref));
 
     Ok(())
 }
 
 #[test]
-fn orphan_reparent_content_integrated_stack_to_target_tip() -> Result<()> {
+fn content_integrated_stack_checks_out_canned_branch_at_target_tip() -> Result<()> {
     let (_tmp, repo, mut meta, _description) = named_writable_scenario_with_description(
         "fully-content-integrated-single-branch-target-advanced",
     )?;
@@ -2531,11 +2439,7 @@ fn orphan_reparent_content_integrated_stack_to_target_tip() -> Result<()> {
         }],
     )?;
 
-    assert_eq!(
-        workspace_first_parent(&repo)?,
-        repo.rev_parse_single("origin/main")?.detach(),
-        "orphaned workspace commit should be reparented to the advanced target tip after content integration"
-    );
+    assert_ad_hoc_checkout_at_target(&repo)?;
 
     Ok(())
 }
@@ -2730,31 +2634,8 @@ fn empty_branch_with_integrated_remote_tip_is_removed() -> Result<()> {
         "workspace metadata should no longer expose the integrated empty branch"
     );
     out.rebase.materialize(Default::default())?;
-    let graph = but_graph::Graph::from_head(&repo, &meta, project_meta, Options::limited())?;
-    let workspace = graph.into_workspace()?;
-    snapbox::assert_data_eq!(
-        graph_workspace(&workspace).to_string(),
-        snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 563a7fc
-└── ≡:2:main <> origin/main →:1: on 563a7fc
-    └── :2:main <> origin/main →:1:
-        └── ❄️364a08f (🏘️|✓)
-
-"#]]
-    );
-    snapbox::assert_data_eq!(
-        visualize_commit_graph_all(&repo)?,
-        snapbox::str![[r#"
-* cf134fb (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-*   364a08f (origin/main, main) merge topic
-|\  
-| * 6ba217e (origin/topic) add topic
-|/  
-* 563a7fc add base
-
-"#]]
-        .raw()
-    );
+    assert!(repo.try_find_reference("topic")?.is_none());
+    assert_ad_hoc_checkout_at_target(&repo)?;
 
     Ok(())
 }
@@ -3024,7 +2905,7 @@ fn integrated_bottom_under_empty_direct_checkout_is_removed_and_top_is_preserved
 }
 
 #[test]
-fn orphan_reparent_same_target_tip_keeps_single_parent() -> Result<()> {
+fn fully_integrated_stack_at_target_tip_checks_out_canned_branch() -> Result<()> {
     let (_tmp, repo, mut meta, _description) =
         named_writable_scenario_with_description("fully-integrated-single-branch")?;
     let target_sha = repo.rev_parse_single("main")?.detach();
@@ -3052,26 +2933,20 @@ fn orphan_reparent_same_target_tip_keeps_single_parent() -> Result<()> {
         }],
     )?;
 
-    assert_eq!(
-        workspace_first_parent(&repo)?,
-        repo.rev_parse_single("origin/main")?.detach(),
-        "orphaned workspace commit should stay on the target tip when it already equals the removed parent"
-    );
-    assert_eq!(
-        workspace_parent_count(&repo)?,
-        1,
-        "workspace commit should not gain duplicate parents"
-    );
+    assert_ad_hoc_checkout_at_target(&repo)?;
 
     Ok(())
 }
 
 #[test]
-fn orphan_reparent_two_stacks_through_merge_target() -> Result<()> {
-    let (_tmp, repo, mut meta, _description) = named_writable_scenario_with_description(
+fn fully_integrated_two_stacks_checkout_canned_branch_at_merge_target() -> Result<()> {
+    let (_tmp, mut repo, mut meta, _description) = named_writable_scenario_with_description(
         "fully-integrated-two-stacks-merge-target-advanced",
     )?;
+    force_prefixless_canned_branch_name(&mut repo)?;
     let target_sha = repo.rev_parse_single("main~3")?.detach();
+    let target_tip = repo.rev_parse_single("origin/main")?.detach();
+    let fallback_ref: gix::refs::FullName = "refs/heads/branch-1".try_into()?;
 
     let project_meta = target_project_meta("refs/remotes/origin/main", target_sha)?;
     add_stack(&mut meta, 1, "A", StackState::InWorkspace);
@@ -3087,10 +2962,13 @@ fn orphan_reparent_two_stacks_through_merge_target() -> Result<()> {
     )?;
     let mut workspace = graph.into_workspace()?;
 
-    integrate_and_materialize(
+    let mut db = but_testsupport::in_memory_db();
+    let out = integrate_upstream(
         &mut workspace,
         &mut meta,
+        project_meta,
         &repo,
+        &mut db,
         vec![
             BottomUpdate {
                 kind: BottomUpdateKind::Rebase,
@@ -3102,12 +2980,14 @@ fn orphan_reparent_two_stacks_through_merge_target() -> Result<()> {
             },
         ],
     )?;
+    out.rebase.materialize(Default::default())?;
 
     assert_eq!(
-        workspace_first_parent(&repo)?,
-        repo.rev_parse_single("origin/main")?.detach(),
-        "orphaned workspace commit should be reparented to the merge-advanced target tip"
+        repo.find_reference(fallback_ref.as_ref())?.id(),
+        target_tip,
+        "canned branch should point at the exact merge target tip"
     );
+    assert_eq!(repo.head_name()?, Some(fallback_ref));
 
     Ok(())
 }
@@ -3690,6 +3570,7 @@ fn integrate_and_materialize<M: RefMetadata>(
     let materialized = rebase.materialize(Default::default())?;
     if let Some(ref_name) = materialized.workspace.ref_name()
         && let Some(ws_meta) = ws_meta
+        && is_workspace_ref_name(ref_name)
     {
         let mut md = materialized.meta.workspace(ref_name)?;
         *md = ws_meta;
@@ -3734,6 +3615,7 @@ fn integrate_with_hints_and_materialize<M: RefMetadata>(
     let materialized = rebase.materialize(Default::default())?;
     if let Some(ref_name) = materialized.workspace.ref_name()
         && let Some(ws_meta) = ws_meta
+        && is_workspace_ref_name(ref_name)
     {
         let mut md = materialized.meta.workspace(ref_name)?;
         *md = ws_meta;
@@ -3757,10 +3639,25 @@ fn workspace_parent_ids(repo: &gix::Repository) -> Result<Vec<gix::ObjectId>> {
         .collect())
 }
 
-fn workspace_parent_count(repo: &gix::Repository) -> Result<usize> {
-    let workspace_commit =
-        repo.find_commit(repo.rev_parse_single("gitbutler/workspace")?.detach())?;
-    Ok(workspace_commit.parent_ids().count())
+fn assert_ad_hoc_checkout_at_target(repo: &gix::Repository) -> Result<()> {
+    let head_name = repo.head_name()?.context("HEAD should remain attached")?;
+    assert_eq!(
+        head_name.category(),
+        Some(gix::refs::Category::LocalBranch),
+        "replacement checkout should be a local branch"
+    );
+    assert_ne!(head_name.as_bstr(), but_core::WORKSPACE_REF_NAME.as_bytes());
+    assert!(
+        repo.try_find_reference(but_core::WORKSPACE_REF_NAME)?
+            .is_none(),
+        "empty managed workspace reference should be removed"
+    );
+    assert_eq!(
+        repo.head_id()?.detach(),
+        repo.rev_parse_single("origin/main")?.detach(),
+        "replacement checkout should point at the latest target tip"
+    );
+    Ok(())
 }
 
 fn force_prefixless_canned_branch_name(repo: &mut gix::Repository) -> Result<()> {

--- a/crates/but/tests/but/command/pull.rs
+++ b/crates/but/tests/but/command/pull.rs
@@ -619,7 +619,7 @@ Hint: run `but help` for all commands
 }
 
 #[test]
-fn pull_reparents_workspace_to_target_after_all_stacks_integrate() {
+fn pull_checks_out_canned_branch_after_all_stacks_integrate() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("pull-two-integrated-stacks");
     env.setup_metadata_at_target(&["A", "B"], "origin/main");
 
@@ -644,21 +644,28 @@ Hint: origin/main moved ahead; run `but pull` to update the workspace
     env.but("status").assert().success().stdout_eq(str![[r#"
 ╭┄ zz [uncommitted] (no changes)
 ┊
+┊╭┄ br [a-branch-1] (no commits)
+├╯
+┊
 ┴ 7e5d4e1 (common base) 2000-01-02 add upstream
 
-Hint: run `but branch new` to create a new branch to work on
+Hint: run `but help` for all commands
 
 "#]]);
 
-    assert_eq!(
-        rev_parse(&env, "gitbutler/workspace^"),
-        rev_parse(&env, "origin/main"),
-        "once all stacks are integrated, the workspace should be parented to the advanced target"
+    assert_eq!(env.invoke_git("symbolic-ref --short HEAD"), "a-branch-1");
+    assert_eq!(rev_parse(&env, "HEAD"), rev_parse(&env, "origin/main"));
+    assert!(
+        env.open_repo()
+            .try_find_reference(but_core::WORKSPACE_REF_NAME)
+            .unwrap()
+            .is_none(),
+        "the empty managed workspace reference should be removed"
     );
     assert_eq!(
         status_stack_count(&env),
-        0,
-        "no stacks should remain applied once both are integrated"
+        1,
+        "the canned branch should become the ad-hoc checkout"
     );
 }
 

--- a/e2e/playwright/tests/singleBranch/upstreamIntegration.spec.ts
+++ b/e2e/playwright/tests/singleBranch/upstreamIntegration.spec.ts
@@ -3,7 +3,13 @@ import {
 	expectCurrentBranchChip,
 	openSingleBranchWorkspace,
 } from "./helpers.ts";
-import { assertBranch, assertCleanWorktree, assertCommitSubjects } from "../../src/branch.ts";
+import {
+	assertBranch,
+	assertCleanWorktree,
+	assertCommitSubjects,
+	assertRefDoesNotExist,
+} from "../../src/branch.ts";
+import { applyUpstream } from "../../src/setup.ts";
 import { test } from "../../src/test.ts";
 import {
 	clickByTestId,
@@ -157,6 +163,34 @@ test("creates a new branch on top of the advanced target after branch is fully i
 	expect(git(localClone, ["rev-parse", replacementBranch])).toBe(
 		git(localClone, ["rev-parse", TARGET_REMOTE_BRANCH]),
 	);
+	await assertCleanWorktree(localClone);
+	await expectNoErrorToast(page);
+});
+
+test("checks out a new branch after all managed stacks are integrated", async ({
+	page,
+	gitbutler,
+}) => {
+	await gitbutler.runScript("project-with-stacks.sh");
+	await applyUpstream(gitbutler, "branch1", "branch2");
+	await openSingleBranchWorkspace(page);
+
+	const localClone = gitbutler.pathInWorkdir("local-clone");
+	await assertBranch("gitbutler/workspace", localClone);
+	await expect(stack(page)).toHaveCount(2);
+
+	await gitbutler.runScript("merge-upstream-branch-to-base.sh", ["branch1"]);
+	await gitbutler.runScript("merge-upstream-branch-to-base.sh", ["branch2"]);
+	await syncAndIntegrateWorkspace(page);
+
+	await expectLocalBranchNotToExist(localClone, "branch1");
+	await expectLocalBranchNotToExist(localClone, "branch2");
+	await assertRefDoesNotExist("refs/heads/gitbutler/workspace", localClone);
+	const replacementBranch = await replacementBranchAtTarget(localClone);
+	await assertBranch(replacementBranch, localClone);
+	await expectCurrentBranchChip(page, replacementBranch);
+	await expect(stack(page)).toHaveCount(1);
+	await expect(getByTestId(page, "branch-card")).toContainText(replacementBranch);
 	await assertCleanWorktree(localClone);
 	await expectNoErrorToast(page);
 });

--- a/e2e/playwright/tests/upstreamIntegration.spec.ts
+++ b/e2e/playwright/tests/upstreamIntegration.spec.ts
@@ -121,12 +121,10 @@ test("should show incoming conflicts with uncommitted files in an empty workspac
 	await expect(worktreeConflicts).toContainText("a_file");
 });
 
-test("should check out a new branch when the only stack is integrated", async ({
+test("should handle the update of workspace with integrated branch gracefully", async ({
 	page,
 	gitbutler,
 }) => {
-	const localClone = gitbutler.pathInWorkdir("local-clone");
-
 	await gitbutler.runScript("project-with-remote-branches.sh");
 	await applyUpstream(gitbutler, "branch1");
 	await openWorkspace(page);
@@ -136,12 +134,10 @@ test("should check out a new branch when the only stack is integrated", async ({
 	await gitbutler.runScript("merge-upstream-branch-to-base.sh", ["branch1"]);
 	await syncAndIntegrate(page);
 
-	const replacementBranch = await expectAdHocBranchAtOriginMaster(localClone);
-	await expect(stack(page)).toHaveCount(1);
-	await expect(getByTestId(page, "branch-card")).toContainText(replacementBranch);
+	await waitForTestIdToNotExist(page, "stack");
 });
 
-test("should check out a new branch at the advanced target after integrating all stacks", async ({
+test("should reparent workspace commit to advanced target after integrating all stacks", async ({
 	page,
 	gitbutler,
 }) => {
@@ -158,12 +154,11 @@ test("should check out a new branch at the advanced target after integrating all
 	);
 	await syncAndIntegrate(page);
 
-	const replacementBranch = await expectAdHocBranchAtOriginMaster(localClone);
-	await expect(stack(page)).toHaveCount(1);
-	await expect(getByTestId(page, "branch-card")).toContainText(replacementBranch);
+	await waitForTestIdToNotExist(page, "stack");
+	await expectWorkspaceCommitParentToBeOriginMaster(localClone);
 });
 
-test("should check out a new branch at the advanced merge target after integrating all stacks", async ({
+test("should reparent workspace commit to advanced merge target after integrating all stacks", async ({
 	page,
 	gitbutler,
 }) => {
@@ -180,9 +175,8 @@ test("should check out a new branch at the advanced merge target after integrati
 	);
 	await syncAndIntegrate(page);
 
-	const replacementBranch = await expectAdHocBranchAtOriginMaster(localClone);
-	await expect(stack(page)).toHaveCount(1);
-	await expect(getByTestId(page, "branch-card")).toContainText(replacementBranch);
+	await waitForTestIdToNotExist(page, "stack");
+	await expectWorkspaceCommitParentToBeOriginMaster(localClone);
 });
 
 test("should handle the update of workspace with integrated parent branch in stack gracefully", async ({
@@ -246,6 +240,27 @@ test("should keep the remaining stack when only one of two stacks is integrated"
 	await expect(getByTestId(page, "branch-card")).toHaveCount(1);
 	await expect(getByTestId(page, "branch-card")).toContainText("branch2");
 	await expectWorkspaceCommitToStayParentedToRemainingStack(localClone);
+});
+
+test("should check out a new branch when both applied stacks are integrated", async ({
+	page,
+	gitbutler,
+}) => {
+	const localClone = gitbutler.pathInWorkdir("local-clone");
+
+	await gitbutler.runScript("project-with-stacks.sh");
+	await applyUpstream(gitbutler, "branch1", "branch2");
+	await openWorkspace(page);
+
+	await expect(stack(page)).toHaveCount(2);
+
+	await gitbutler.runScript("merge-upstream-branch-to-base.sh", ["branch1"]);
+	await gitbutler.runScript("merge-upstream-branch-to-base.sh", ["branch2"]);
+	await syncAndIntegrate(page);
+
+	const replacementBranch = await expectAdHocBranchAtOriginMaster(localClone);
+	await expect(stack(page)).toHaveCount(1);
+	await expect(getByTestId(page, "branch-card")).toContainText(replacementBranch);
 });
 
 test("should update an empty workspace when the target ref advances", async ({

--- a/e2e/playwright/tests/upstreamIntegration.spec.ts
+++ b/e2e/playwright/tests/upstreamIntegration.spec.ts
@@ -29,7 +29,7 @@ async function expectWorkspaceCommitParentToBeOriginMaster(pathToRepo: string) {
 
 async function expectAdHocBranchAtOriginMaster(pathToRepo: string): Promise<string> {
 	await expect
-		.poll(() => git(pathToRepo, ["branch", "--show-current"]), {
+		.poll(() => git(pathToRepo, ["symbolic-ref", "--short", "HEAD"]), {
 			message: "Expected a regular branch to be checked out",
 			intervals: [100, 200, 500, 1000],
 		})
@@ -42,7 +42,7 @@ async function expectAdHocBranchAtOriginMaster(pathToRepo: string): Promise<stri
 	await expect
 		.poll(() => git(pathToRepo, ["rev-parse", "HEAD"]))
 		.toBe(git(pathToRepo, ["rev-parse", "origin/master"]));
-	return git(pathToRepo, ["branch", "--show-current"]);
+	return git(pathToRepo, ["symbolic-ref", "--short", "HEAD"]);
 }
 
 async function expectWorkspaceCommitToStayParentedToRemainingStack(pathToRepo: string) {

--- a/e2e/playwright/tests/upstreamIntegration.spec.ts
+++ b/e2e/playwright/tests/upstreamIntegration.spec.ts
@@ -27,6 +27,24 @@ async function expectWorkspaceCommitParentToBeOriginMaster(pathToRepo: string) {
 		.toBe(git(pathToRepo, ["rev-parse", "origin/master"]));
 }
 
+async function expectAdHocBranchAtOriginMaster(pathToRepo: string): Promise<string> {
+	await expect
+		.poll(() => git(pathToRepo, ["branch", "--show-current"]), {
+			message: "Expected a regular branch to be checked out",
+			intervals: [100, 200, 500, 1000],
+		})
+		.not.toBe("gitbutler/workspace");
+	await expect
+		.poll(() =>
+			git(pathToRepo, ["for-each-ref", "--format=%(refname)", "refs/heads/gitbutler/workspace"]),
+		)
+		.toBe("");
+	await expect
+		.poll(() => git(pathToRepo, ["rev-parse", "HEAD"]))
+		.toBe(git(pathToRepo, ["rev-parse", "origin/master"]));
+	return git(pathToRepo, ["branch", "--show-current"]);
+}
+
 async function expectWorkspaceCommitToStayParentedToRemainingStack(pathToRepo: string) {
 	await expect
 		.poll(() => git(pathToRepo, ["rev-parse", "gitbutler/workspace^@"]).split("\n").length, {
@@ -103,10 +121,12 @@ test("should show incoming conflicts with uncommitted files in an empty workspac
 	await expect(worktreeConflicts).toContainText("a_file");
 });
 
-test("should handle the update of workspace with integrated branch gracefully", async ({
+test("should check out a new branch when the only stack is integrated", async ({
 	page,
 	gitbutler,
 }) => {
+	const localClone = gitbutler.pathInWorkdir("local-clone");
+
 	await gitbutler.runScript("project-with-remote-branches.sh");
 	await applyUpstream(gitbutler, "branch1");
 	await openWorkspace(page);
@@ -116,10 +136,12 @@ test("should handle the update of workspace with integrated branch gracefully", 
 	await gitbutler.runScript("merge-upstream-branch-to-base.sh", ["branch1"]);
 	await syncAndIntegrate(page);
 
-	await waitForTestIdToNotExist(page, "stack");
+	const replacementBranch = await expectAdHocBranchAtOriginMaster(localClone);
+	await expect(stack(page)).toHaveCount(1);
+	await expect(getByTestId(page, "branch-card")).toContainText(replacementBranch);
 });
 
-test("should reparent workspace commit to advanced target after integrating all stacks", async ({
+test("should check out a new branch at the advanced target after integrating all stacks", async ({
 	page,
 	gitbutler,
 }) => {
@@ -136,11 +158,12 @@ test("should reparent workspace commit to advanced target after integrating all 
 	);
 	await syncAndIntegrate(page);
 
-	await waitForTestIdToNotExist(page, "stack");
-	await expectWorkspaceCommitParentToBeOriginMaster(localClone);
+	const replacementBranch = await expectAdHocBranchAtOriginMaster(localClone);
+	await expect(stack(page)).toHaveCount(1);
+	await expect(getByTestId(page, "branch-card")).toContainText(replacementBranch);
 });
 
-test("should reparent workspace commit to advanced merge target after integrating all stacks", async ({
+test("should check out a new branch at the advanced merge target after integrating all stacks", async ({
 	page,
 	gitbutler,
 }) => {
@@ -157,8 +180,9 @@ test("should reparent workspace commit to advanced merge target after integratin
 	);
 	await syncAndIntegrate(page);
 
-	await waitForTestIdToNotExist(page, "stack");
-	await expectWorkspaceCommitParentToBeOriginMaster(localClone);
+	const replacementBranch = await expectAdHocBranchAtOriginMaster(localClone);
+	await expect(stack(page)).toHaveCount(1);
+	await expect(getByTestId(page, "branch-card")).toContainText(replacementBranch);
 });
 
 test("should handle the update of workspace with integrated parent branch in stack gracefully", async ({
@@ -222,24 +246,6 @@ test("should keep the remaining stack when only one of two stacks is integrated"
 	await expect(getByTestId(page, "branch-card")).toHaveCount(1);
 	await expect(getByTestId(page, "branch-card")).toContainText("branch2");
 	await expectWorkspaceCommitToStayParentedToRemainingStack(localClone);
-});
-
-test("should handle the update of the workspace with two integrated stacks gracefully", async ({
-	page,
-	gitbutler,
-}) => {
-	await gitbutler.runScript("project-with-stacks.sh");
-	await applyUpstream(gitbutler, "branch1", "branch2");
-	await openWorkspace(page);
-
-	await expect(stack(page)).toHaveCount(2);
-
-	await gitbutler.runScript("merge-upstream-branch-to-base.sh", ["branch1"]);
-	await gitbutler.runScript("merge-upstream-branch-to-base.sh", ["branch2"]);
-	await syncAndIntegrate(page);
-
-	await expect(stack(page)).toHaveCount(0);
-	await waitForTestIdToNotExist(page, "integrate-upstream-commits-button");
 });
 
 test("should update an empty workspace when the target ref advances", async ({


### PR DESCRIPTION
## 🧢 Changes

- Replace an emptied managed workspace with a uniquely named ad-hoc branch at the latest target commit.
- Cover single-stack, multi-stack, merge-target, dry-run, and UI transitions in Rust and Playwright tests.

## ☕️ Reasoning

- Upstream integration should never leave users in an empty managed workspace when every applied stack was integrated.
