### PR TITLE
Don't rerender Outline when touching WorkspacePage

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
@@ -497,8 +497,9 @@ const WorkspacePage: FC = () => {
 			absorptionPlanQueryOptions({ projectId, target }),
 		),
 	});
-	const absorptionTargetCommitIds = new Set(
-		absorptionPlanQuery?.data?.map(({ commitId }) => commitId),
+	const absorptionTargetCommitIds = useMemo(
+		() => new Set(absorptionPlanQuery?.data?.map(({ commitId }) => commitId)),
+		[absorptionPlanQuery?.data],
 	);
 
 	const foldedSegments = useAppSelector((state) =>


### PR DESCRIPTION
## 🧢 Changes
In Lite, `Outline` is no longer re-rendered when its parent `WorkspacePage` is. Its object props `absorptionTargetCommitIds` and `outlineNavigationIndex` are now memoed and referentially stable.

## ☕️ Reasoning
Clicking on "+" re-rendered the `Outline` / sidebar. This happened because the new comment form receives focus, which re-renders `WorkspacePage` and its child `Outline` along with it. `Outline` is somewhat expensive to re-render and unnecessary so.

## 📌 Todos
- [ ] Add a render test, e.g. "re-rendering WorkspacePage doesn't re-render Outline"