### PR TITLE
Fix lite e2e for the folded branches filter

### DIFF
--- a/apps/lite/e2e/tests/start.spec.ts
+++ b/apps/lite/e2e/tests/start.spec.ts
@@ -14,6 +14,13 @@ test.describe("with a seeded project", () => {
 
 		const navigation = appWindow.getByRole("group", { name: "Navigation" });
 		await navigation.getByRole("button", { name: "Branches" }).click();
+		// The header, not the list: the seeded remote branches are filtered out by
+		// the default local-only filter, so the tree is empty and has no height.
+		await expect(appWindow.getByText("Recent branches")).toBeVisible();
+
+		// The filter is folded into the header until asked for, so opening it is
+		// what proves the tab is interactive rather than merely painted.
+		await appWindow.getByRole("button", { name: "Filter branches" }).click();
 		await expect(appWindow.getByRole("textbox", { name: "Filter branches" })).toBeVisible();
 	});
 });


### PR DESCRIPTION
`master` is red: #15363 folded the branches tab's filter field into a
toggle, and `start.spec.ts` asserted that field is visible on arriving at
the tab. That PR merged 21 seconds before its `lite-e2e` job started, so
the failure landed rather than gating it.

The navigation test now asserts the tab's header instead, then opens the
filter and asserts the input — which restores what the old line covered
incidentally and additionally covers the toggle.

The tree cannot stand in for the header: `project-with-remote-branches.sh`
seeds only remote branches, the default local-only filter hides them, and
the resulting empty tree has no height, so Playwright reads it as not
visible.

Verified with `pnpm -F @gitbutler/lite test:e2e` — 3 passed, 8 skipped.