### PR TITLE
Drop the workspace outline's stack header row

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.module.css
@@ -146,14 +146,11 @@
 	text-overflow: ellipsis;
 }
 
-/* Marks a branch name that doesn't exist yet: committing is what creates it. */
+/* Marks a branch name that doesn't exist yet: committing is what creates it.
+   The pill itself is the shared badge; only its place in the trigger row is
+   this file's business, so it never shrinks away with the branch name. */
 .targetTriggerBadge {
-	margin-inline-start: 4px;
-	padding-inline: 4px;
-	border-radius: var(--radius-xs);
-	background-color: color-mix(in srgb, var(--text-1) 10%, transparent);
-	color: color-mix(in srgb, var(--text-1) 60%, transparent);
-	font-size: 10px;
+	flex-shrink: 0;
 	text-transform: uppercase;
 }
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
@@ -7,6 +7,7 @@ import {
 	headInfoQueryOptions,
 } from "#ui/api/queries.ts";
 import { getHeadInfoIndex, resolveRelativeTo } from "#ui/api/ref-info.ts";
+import { Badge } from "#ui/components/Badge.tsx";
 import { getButtonClassName } from "#ui/components/Button.tsx";
 import { classes } from "#ui/components/classes.ts";
 import { Icon } from "#ui/components/Icon.tsx";
@@ -534,16 +535,18 @@ export const CommitForm: FC<{
 								name={commitTarget?.operand._tag === "Commit" ? "commit" : "branch"}
 								size={14}
 							/>
-							<span className={styles.targetTriggerLabel}>
-								{hasNoBranches ? (
-									<>
-										{draftBranchLabel}
-										<span className={styles.targetTriggerBadge}>new</span>
-									</>
-								) : (
+							{hasNoBranches ? (
+								<>
+									<span className={styles.targetTriggerLabel}>{draftBranchLabel}</span>
+									<Badge variant="lightGray" className={styles.targetTriggerBadge}>
+										new
+									</Badge>
+								</>
+							) : (
+								<span className={styles.targetTriggerLabel}>
 									<Combobox.Value placeholder="Select commit target" />
-								)}
-							</span>
+								</span>
+							)}
 						</Combobox.Trigger>
 						<Tooltip.Portal>
 							<Tooltip.Positioner sideOffset={4}>

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
@@ -63,16 +63,10 @@
 .actions {
 	display: flex;
 	align-items: center;
-	padding-inline: 10px var(--panel-padding-inline);
 	/* With a separate header above (commit/branch views), use tighter padding. */
-	padding-block: 8px;
+	padding: 8px;
 	gap: 12px;
 	border-bottom: 1px solid var(--border-section);
-
-	/* No files panel to the left, so align with the panel padding. */
-	/* &.filesHidden {
-		padding-inline-start: 8px;
-	} */
 
 	/* Lone layout: the title lives in this row, match the panel padding. */
 	.containerLone & {

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -2109,7 +2109,7 @@ const Diff: FC<{
 				)}
 
 				<Panel id={"diff-panel" satisfies PanelId} minSize={300} className={styles.panel}>
-					<div className={classes(styles.actions, !filesVisible && styles.filesHidden)}>
+					<div className={styles.actions}>
 						{canShowFiles && <FilesToggle />}
 
 						{headerSlot}

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/BranchRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/BranchRow.tsx
@@ -548,47 +548,47 @@ export const BranchRow: FC<
 								}${workspaceBranchAndAncestorsPushDisabledReason !== null ? ` (${workspaceBranchAndAncestorsPushDisabledReason})` : ""}`;
 
 								return (
-									<>
-										<RowMetaSeparator />
-										<Tooltip.Root>
-											<Tooltip.Trigger
-												aria-label={pushButtonLabel}
-												onClick={pushBranch}
-												className={getRowButtonClassName({ variant: "outline" })}
-												// We pass `disabled` here because we want to disable the button, not
-												// the tooltip. Other props should be passed above.
-												render={
-													<Button
-														focusableWhenDisabled
-														disabled={workspaceBranchAndAncestorsPushDisabled}
-													/>
-												}
-											>
-												Push
-												{isWorkspaceBranchAndAncestorsPushPending ? (
-													<Icon name="spinner" />
-												) : pushesMultipleBranches ? (
-													<Icon size={12} name="arrow-double-up" />
-												) : (
-													<Icon size={12} name="arrow-up" />
-												)}
-											</Tooltip.Trigger>
-											<Tooltip.Portal>
-												<Tooltip.Positioner sideOffset={4}>
-													<Tooltip.Popup
-														render={
-															<TooltipPopup
-																kbd={outlineHotkeys.workspaceBranchAndAncestorsPush.hotkey}
-																kbdScope="outline"
-															/>
-														}
-													>
-														{pushButtonLabel}
-													</Tooltip.Popup>
-												</Tooltip.Positioner>
-											</Tooltip.Portal>
-										</Tooltip.Root>
-									</>
+									<Tooltip.Root>
+										<Tooltip.Trigger
+											aria-label={pushButtonLabel}
+											onClick={pushBranch}
+											className={classes(
+												getRowButtonClassName({ variant: "outline" }),
+												rowStyles.metaButton,
+											)}
+											// We pass `disabled` here because we want to disable the button, not
+											// the tooltip. Other props should be passed above.
+											render={
+												<Button
+													focusableWhenDisabled
+													disabled={workspaceBranchAndAncestorsPushDisabled}
+												/>
+											}
+										>
+											Push
+											{isWorkspaceBranchAndAncestorsPushPending ? (
+												<Icon name="spinner" />
+											) : pushesMultipleBranches ? (
+												<Icon size={12} name="arrow-double-up" />
+											) : (
+												<Icon size={12} name="arrow-up" />
+											)}
+										</Tooltip.Trigger>
+										<Tooltip.Portal>
+											<Tooltip.Positioner sideOffset={4}>
+												<Tooltip.Popup
+													render={
+														<TooltipPopup
+															kbd={outlineHotkeys.workspaceBranchAndAncestorsPush.hotkey}
+															kbdScope="outline"
+														/>
+													}
+												>
+													{pushButtonLabel}
+												</Tooltip.Popup>
+											</Tooltip.Positioner>
+										</Tooltip.Portal>
+									</Tooltip.Root>
 								);
 							})()}
 					</RowMeta>

--- a/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
@@ -24,7 +24,7 @@
 	flex-shrink: 0;
 	align-items: center;
 	height: 44px;
-	padding-inline: 14px;
+	padding-inline: var(--panel-padding-inline);
 }
 
 /* Square, and edge to edge in every list that has them: a row's fill is a band

--- a/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
@@ -227,6 +227,12 @@
 	opacity: 0.4;
 }
 
+/* Button sitting in a meta row: stands a little further off from the facts it
+   follows, since no separator dot divides them. */
+.metaButton {
+	margin-left: 4px;
+}
+
 /* Item that yields space to its siblings by truncating its text. */
 .metaItemShrinkable {
 	flex-shrink: 1;

--- a/apps/lite/ui/src/routes/project/$id/workspace/UpstreamList.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/UpstreamList.module.css
@@ -18,8 +18,14 @@
 	background-color: var(--bg-2);
 }
 
-/* The bands run the full width of the panel, so nothing insets them and no gap
-   separates them: each one's own hairline floor is the whole division. */
+/* Titles the pane, like the other tabs' headings. */
+.header {
+	flex-shrink: 0;
+	border-block-end: 1px solid var(--border-section);
+}
+
+/* The regions run the full width of the panel, so nothing insets them and no
+   gap separates them: each one's own hairline floor is the whole division. */
 .list {
 	display: flex;
 	flex-grow: 1;
@@ -31,42 +37,6 @@
 	}
 }
 
-/* Named bands rather than cards: they divide one listing, so they carry the
-   panel's own recessed fill and are only ruled off from what follows. Shorter
-   and quieter than the outline's pane headings — three of them fall inside one
-   list, where a full-height heading each would read as three panels. */
-.sectionHeader {
-	display: flex;
-	column-gap: 12px;
-	flex-shrink: 0;
-	align-items: center;
-	height: 32px;
-	padding-inline: 13px 4px;
-	padding-block: 4px;
-	border-block-end: 1px solid var(--border-section);
-	background-color: var(--bg-2);
-}
-
-/* The key badge and the icon are one leading cluster, so the label closes up
-   to them rather than sitting the full gap away from a lone glyph. */
-.withKbd {
-	column-gap: 8px;
-}
-
-.sectionHeaderIcon {
-	flex-shrink: 0;
-	color: var(--text-3);
-}
-
-.sectionHeaderLabel {
-	flex-grow: 1;
-	min-width: 0;
-	overflow: hidden;
-	color: var(--text-2);
-	text-overflow: ellipsis;
-	white-space: nowrap;
-}
-
 /* The rows inside carry their own inline inset, so a section only holds them
    off its ceiling and floor. */
 .section {
@@ -75,6 +45,15 @@
 	padding-block: 6px;
 	border-block-end: 1px solid var(--border-section);
 	background-color: var(--bg-1);
+}
+
+/* The one break in the listing: what is coming in above, where the workspace
+   stands against it below. A hairline is what divides one region from the next,
+   so the halves are parted by the panel's own fill showing through instead —
+   ruled on both sides, so each half still closes and opens on a floor. */
+.regionBreak {
+	margin-block-start: 8px;
+	border-block-start: 1px solid var(--border-section);
 }
 
 /* A band that acts on the listing rather than showing part of it: the update

--- a/apps/lite/ui/src/routes/project/$id/workspace/UpstreamList.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/UpstreamList.tsx
@@ -10,7 +10,6 @@ import {
 	type GraphSegmentStatus,
 } from "#ui/components/GraphSegment.tsx";
 import { Icon } from "#ui/components/Icon.tsx";
-import type { IconName } from "#ui/components/iconNames.ts";
 import { commitOperand, operandIdentityKey, type Operand } from "#ui/operands.ts";
 import { projectSlice } from "#ui/projects/state.ts";
 import {
@@ -28,15 +27,8 @@ import {
 import { Button } from "@base-ui/react";
 import { useMergedRefs } from "@base-ui/utils/useMergedRefs";
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
-import {
-	type ComponentProps,
-	type FC,
-	type MouseEvent,
-	type ReactNode,
-	useRef,
-	useState,
-} from "react";
-import { Row, RowLabel, RowLabelContainer, RowLabelFooter } from "./Row.tsx";
+import { type ComponentProps, type FC, type MouseEvent, useRef, useState } from "react";
+import { Row, RowLabel, RowLabelContainer, RowLabelFooter, SectionHeaderRow } from "./Row.tsx";
 import { treeItemId, useIsSelected as useIsSelectedInList } from "./Row-utils.ts";
 import type {
 	UpstreamBranchItem,
@@ -50,26 +42,6 @@ const pluralRules = new Intl.PluralRules("en");
 
 const useIsSelected = (projectId: string, operand: Operand): boolean =>
 	useIsSelectedInList(projectId, operand, "upstream");
-
-/**
- * The band naming the section below it.
- *
- * Not the outline's `SectionHeaderRow`: that one titles a whole pane and is
- * sized to it. Three of these divide a single listing, so they are shorter and
- * quieter — a rule with a name on it rather than a heading over a panel.
- */
-const UpstreamSectionHeader: FC<{
-	icon: IconName;
-	label: string;
-	/** The key that focuses the list, shown only on the band that heads it. */
-	kbd?: ReactNode;
-}> = ({ icon, label, kbd }) => (
-	<div role="none" className={classes(styles.sectionHeader, kbd !== undefined && styles.withKbd)}>
-		{kbd}
-		<Icon className={styles.sectionHeaderIcon} name={icon} size={14} />
-		<span className={classes("text-12", styles.sectionHeaderLabel)}>{label}</span>
-	</div>
-);
 
 /**
  * The target branch the incoming commits below it belong to. It heads the card
@@ -96,7 +68,7 @@ const TargetCommitRow: FC<{
 	 * Overrides the rail colour the commit's own position would give it. The
 	 * older section is one unbroken length of target line, so its rows keep the
 	 * target's colour rather than each reporting that the workspace has them —
-	 * which is the whole section's premise, and its heading already says so.
+	 * which is true of every row there, and so tells the reader nothing.
 	 */
 	status?: GraphSegmentStatus;
 }> = ({ projectId, item, status }) => {
@@ -333,7 +305,10 @@ const LoadMoreOlder: FC<{ projectId: string }> = ({ projectId }) => {
 				disabled={isFetching}
 				onClick={() => void fetchNextPage()}
 			>
-				{isFetching ? <Icon name="spinner" /> : isError ? "Try again" : "Load more"}
+				{/* Names what it pages in rather than saying "more": it closes a run
+				    nothing titles, so it is the only thing that says what is down
+				    there. */}
+				{isFetching ? <Icon name="spinner" /> : isError ? "Try again" : "Load older commits"}
 			</button>
 		</div>
 	);
@@ -457,12 +432,25 @@ export const UpstreamList: FC<
 	// The rail's tail carries on from the last branch, so it has to be coloured
 	// the same as the segment it continues rather than always as local work.
 	const lastBranch = workspaceItems.findLast((item) => item.type === "branch");
+	// The listing parts once, under everything about what is coming in. Whichever
+	// region opens what is below carries that break.
+	const breaksFromIncoming = workspaceItems.length > 0 ? "workspace" : "older";
 
 	return (
 		<div {...restProps} className={classes(restProps.className, styles.container)}>
-			{/* One graph across three bands: what is coming in, where the
+			{/* Headed like the other tabs: one title over the whole pane, held out
+			    of the scroller so it stays put while the listing moves. */}
+			<SectionHeaderRow
+				className={styles.header}
+				label="Incoming changes"
+				childrenBefore={<SelectionScopeKbd hotkey="1" scope="outline" />}
+			/>
+
+			{/* One graph across three regions: what is coming in, where the
 			    workspace's branches sit against it, and the history behind them.
-			    The headings divide the listing; the rails carry through it. */}
+			    Nothing names them — each region's own floor divides it from the
+			    next, and the rails carry through. The one wider break falls under
+			    everything about what is coming in; see `.regionBreak`. */}
 			<div
 				tabIndex={0}
 				role="tree"
@@ -472,12 +460,6 @@ export const UpstreamList: FC<
 				className={classes(uiStyles.scroller, styles.list)}
 				ref={useMergedRefs(hotkeysRef, useAutofocusSelectionScope())}
 			>
-				<UpstreamSectionHeader
-					icon="arrow-down"
-					label="Incoming changes"
-					kbd={<SelectionScopeKbd hotkey="1" scope="outline" />}
-				/>
-
 				<div role="none" className={styles.section}>
 					{targetLabel !== null && <TargetHeadRow label={targetLabel} />}
 
@@ -515,50 +497,54 @@ export const UpstreamList: FC<
 				)}
 
 				{workspaceItems.length > 0 && (
-					<>
-						<UpstreamSectionHeader icon="workbench" label="Workspace branches" />
+					<div
+						role="none"
+						className={classes(
+							styles.section,
+							breaksFromIncoming === "workspace" && styles.regionBreak,
+						)}
+					>
+						{workspaceItems.flatMap((item, index) => {
+							const row = listItem(projectId, item, item === railHead);
+							// Commits only appear here as the body of an expanded run, so
+							// the last one before anything else is where a run closes.
+							const next = workspaceItems[index + 1];
+							return item.type === "commit" && next !== undefined && next.type !== "commit"
+								? [row, <RunTail key={`${item.commit.id}-tail`} />]
+								: [row];
+						})}
 
-						<div role="none" className={styles.section}>
-							{workspaceItems.flatMap((item, index) => {
-								const row = listItem(projectId, item, item === railHead);
-								// Commits only appear here as the body of an expanded run, so
-								// the last one before anything else is where a run closes.
-								const next = workspaceItems[index + 1];
-								return item.type === "commit" && next !== undefined && next.type !== "commit"
-									? [row, <RunTail key={`${item.commit.id}-tail`} />]
-									: [row];
-							})}
-
-							<RailEdge
-								status={lastBranch?.integrated === true ? "Integrated" : "LocalOnly"}
-								edge="tail"
-							/>
-						</div>
-					</>
+						<RailEdge
+							status={lastBranch?.integrated === true ? "Integrated" : "LocalOnly"}
+							edge="tail"
+						/>
+					</div>
 				)}
 
 				{olderItems.length > 0 && (
-					<>
-						<UpstreamSectionHeader icon="docs" label="Older integrated commits" />
+					<div
+						role="none"
+						className={classes(
+							styles.section,
+							breaksFromIncoming === "older" && styles.regionBreak,
+						)}
+					>
+						{/* The run opens mid-line rather than at a fork, so a stub
+						    supplies the rail the first row would otherwise start from
+						    nothing. */}
+						<RailEdge status="Upstream" edge="head" />
 
-						<div role="none" className={styles.section}>
-							{/* The run opens mid-line rather than at a fork, so a stub
-							    supplies the rail the first row would otherwise start from
-							    nothing. */}
-							<RailEdge status="Upstream" edge="head" />
+						{olderItems.map((item) => (
+							<TargetCommitRow
+								key={item.commit.id}
+								projectId={projectId}
+								item={item}
+								status="Upstream"
+							/>
+						))}
 
-							{olderItems.map((item) => (
-								<TargetCommitRow
-									key={item.commit.id}
-									projectId={projectId}
-									item={item}
-									status="Upstream"
-								/>
-							))}
-
-							<RailEdge status="Upstream" edge="tail" />
-						</div>
-					</>
+						<RailEdge status="Upstream" edge="tail" />
+					</div>
 				)}
 
 				<LoadMoreOlder projectId={projectId} />


### PR DESCRIPTION
The outline's per-stack header row ("Stack of N branches") carried no information
the branch rows below it don't already show, so it goes, and `StackRow` with it.
The stack-wide menu items it hosted move into `useStackMenuItems`, shared by the
branch rows.

Stacked on #<PR 1 number> — review that one first; this diff is only the delta.

Two things worth a reviewer's eye, neither a bug:

- `useStackMenuItems` is now subscribed per branch row: `isDefaultMode` duplicates
  a selector `BranchRow` already runs, and `anyFolded` rescans the whole stack once
  per branch row per dispatch, so a stack crossing folded/unfolded re-renders every
  branch row. Fine at current stack sizes; worth knowing it's O(branches²).
- Stack-wide actions ("Unapply Whole Stack", "Update Stack (Rebases)") now hang
  only off `BranchRow`, which renders only for segments with a `refName`. If a
  stack can exist with no named segment, those actions would have no host. I
  couldn't construct one — flagging in case someone knows otherwise.

Validation: `pnpm -F @gitbutler/lite check` and `pnpm knip:prod` pass. No test
references the removed "Stack menu" / "Stack actions" / "Fold All Branches" labels.