### PR TITLE
Lite: gate drag dry runs behind an experimental setting

### DIFF
--- a/apps/lite/electron/src/settings.ts
+++ b/apps/lite/electron/src/settings.ts
@@ -22,6 +22,7 @@ const guiSettingsV1 = type({
 	"diffOverflow?": "'scroll' | 'wrap'",
 	"diffStyle?": '"unified" | "split"',
 	"diffTabSize?": "number",
+	"dryRunOperations?": "boolean",
 	"editorId?": "string",
 	"fileDisplayMode?": "'list' | 'tree'",
 	"lineDiffType?": "'word-alt' | 'word' | 'char' | 'none'",

--- a/apps/lite/ui/src/operations/operation.ts
+++ b/apps/lite/ui/src/operations/operation.ts
@@ -15,6 +15,8 @@ import type { DiffSpec, InsertSide, RelativeTo } from "@gitbutler/but-sdk";
 import { type Operand, operandEquals, operandFileParent } from "#ui/operands.ts";
 import { resolveDiffSpecs, useResolveDiffSpecs } from "#ui/operations/diff-specs.ts";
 import { decodeBytes } from "#ui/api/bytes.ts";
+import { guiSettingsQueryOptions } from "#ui/api/queries.ts";
+import { defaultSettings } from "#ui/settings.ts";
 import { useAppDispatch } from "#ui/store.ts";
 import { useParams } from "@tanstack/react-router";
 import { errorMessageForToast } from "#ui/errors.ts";
@@ -188,11 +190,17 @@ const executeOperation = async ({
 
 export const useDryRunOperation = ({
 	projectId,
-	operation,
+	operation: requestedOperation,
 }: {
 	projectId: string;
 	operation?: Operation;
 }) => {
+	const { data: dryRunsEnabled } = useQuery({
+		...guiSettingsQueryOptions,
+		select: (cfg) => cfg.dryRunOperations ?? defaultSettings.dryRunOperations,
+	});
+	// Blank the operation when disabled so nothing below it does any work.
+	const operation = dryRunsEnabled ? requestedOperation : undefined;
 	const changes = useResolveDiffSpecs({
 		projectId,
 		sources: operation && "sources" in operation ? operation.sources : undefined,

--- a/apps/lite/ui/src/routes/project/$id/workspace/Settings/Experimental.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Settings/Experimental.tsx
@@ -1,0 +1,28 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+import type { FC } from "react";
+import { guiSettingsQueryOptions } from "#ui/api/queries.ts";
+import { useSaveGUISettings } from "#ui/api/mutations.ts";
+import { Switch } from "#ui/components/Switch.tsx";
+import { defaultSettings } from "#ui/settings.ts";
+import { Row, Section } from "./Section.tsx";
+
+export const Experimental: FC = () => {
+	const { data: settings } = useSuspenseQuery(guiSettingsQueryOptions);
+	const { mutate: saveGUISettings } = useSaveGUISettings();
+
+	return (
+		<Section>
+			<Row
+				label="Preview operations while dragging"
+				labelId="dry-run-operations"
+				hint="Dry-runs a drag-and-drop before it lands to show the outcome, such as conflicts. Slows dragging down."
+			>
+				<Switch
+					aria-labelledby="dry-run-operations"
+					checked={settings.dryRunOperations ?? defaultSettings.dryRunOperations}
+					onCheckedChange={(dryRunOperations) => saveGUISettings({ dryRunOperations })}
+				/>
+			</Row>
+		</Section>
+	);
+};

--- a/apps/lite/ui/src/routes/project/$id/workspace/Settings/Settings.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Settings/Settings.tsx
@@ -12,6 +12,7 @@ import {
 } from "./pages.ts";
 import { Appearance } from "./Appearance.tsx";
 import { Ai } from "./Ai.tsx";
+import { Experimental } from "./Experimental.tsx";
 import { General } from "./General.tsx";
 import { Git } from "./Git.tsx";
 import { Integrations } from "./Integrations.tsx";
@@ -31,6 +32,7 @@ const pageContent: Record<SettingsPageKey, FC<{ projectId: string }>> = {
 	"global:ai": Ai,
 	"global:git": Git,
 	"global:integrations": Integrations,
+	"global:experimental": Experimental,
 	"project:project": Project,
 	"project:ai": ProjectAi,
 	"project:git": ProjectGit,

--- a/apps/lite/ui/src/routes/project/$id/workspace/Settings/pages.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Settings/pages.ts
@@ -27,6 +27,7 @@ export const settingsPages = [
 	{ key: "global:ai", label: "AI", icon: "ai" },
 	{ key: "global:git", label: "Git", icon: "branch" },
 	{ key: "global:integrations", label: "Integrations", icon: "globe" },
+	{ key: "global:experimental", label: "Experimental", icon: "danger" },
 	{ key: "project:project", label: "Project", icon: "workbench" },
 	{ key: "project:ai", label: "AI", icon: "ai" },
 	{ key: "project:git", label: "Git", icon: "branch" },

--- a/apps/lite/ui/src/settings.ts
+++ b/apps/lite/ui/src/settings.ts
@@ -12,6 +12,9 @@ export const defaultSettings = {
 	diffOverflow: "scroll",
 	diffStyle: "split",
 	diffTabSize: 4,
+	// Previewing while dragging runs a dry run for every target the pointer crosses, and
+	// each one takes the same workspace lock as the real operation. Off until that's cheap.
+	dryRunOperations: false,
 	// Lite has always shown a flat list; the tree is the mode you opt into.
 	fileDisplayMode: "list",
 	// Pierre's own default, named here so the setting has somewhere to fall back to.


### PR DESCRIPTION
Dry runs contend for the same workspace lock as the real operation, so previewing while dragging runs one extra backend operation per target the pointer crosses. This makes them opt-in.

- New `dryRunOperations` GUI setting, off by default
- Exposed on a new global **Experimental** settings page (one switch: "Preview operations while dragging")
- `useDryRunOperation` blanks the operation when the setting is off, so no spec resolution or dry-run query runs