### PR TITLE
Discard multiple commits

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/CommitRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/CommitRow.tsx
@@ -43,7 +43,7 @@ import { NavigationIndexContext } from "../OutlineNavigationIndexContext.ts";
 import { InlineEditor } from "./InlineEditor.tsx";
 import { insertBlankCommitMenuItem } from "./insertBlankCommitMenuItem.ts";
 import { ItemRow } from "./ItemRow.tsx";
-import { selectAfterDiscardedCommit } from "./selectAfterDiscardedCommit.ts";
+import { selectAfterDiscardedCommits } from "./selectAfterDiscardedCommit.ts";
 import styles from "./CommitRow.module.css";
 import { getHeadInfoIndex } from "#ui/api/ref-info.ts";
 
@@ -150,16 +150,21 @@ export const CommitRow: FC<
 	});
 
 	const deleteCommit = () => {
-		const selectionAfterDiscard = selectAfterDiscardedCommit({
+		const state = store.getState();
+		const subjectCommitIds = projectSlice.selectors.selectOperandChecked(state, projectId, operand)
+			? projectSlice.selectors.selectCheckedCommitIds(state, projectId)
+			: new Set([commit.id]);
+		const selectionAfterDiscard = selectAfterDiscardedCommits({
 			navigationIndex,
 			commit: commitOperandV,
+			discardedCommitIds: subjectCommitIds,
 			headInfoIndex,
 		});
 
 		commitDiscard(
 			{
 				projectId,
-				subjectCommitId: commit.id,
+				subjectCommitIds: Array.from(subjectCommitIds),
 				dryRun: false,
 			},
 			{

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/hotkeys.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/hotkeys.ts
@@ -39,7 +39,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Match } from "effect";
 import type { RefObject } from "react";
 import { toggleFoldedSegment } from "./fold.ts";
-import { selectAfterDiscardedCommit } from "./selectAfterDiscardedCommit.ts";
+import { selectAfterDiscardedCommits } from "./selectAfterDiscardedCommit.ts";
 import {
 	canRemoveBranchReference,
 	downstackPushStatusDisabled,
@@ -278,17 +278,24 @@ export const useOutlineTreeHotkeys = ({
 
 	const deleteSelectedCommit = () => {
 		if (!selection || selection._tag !== "Commit") return;
+		const checkedCommitIds = projectSlice.selectors.selectCheckedCommitIds(
+			store.getState(),
+			projectId,
+		);
+		const subjectCommitIds =
+			checkedCommitIds.size > 0 ? checkedCommitIds : new Set([selection.commitId]);
 
-		const selectionAfterDiscard = selectAfterDiscardedCommit({
+		const selectionAfterDiscard = selectAfterDiscardedCommits({
 			navigationIndex,
 			commit: { commitId: selection.commitId, changeId: selection.changeId },
+			discardedCommitIds: subjectCommitIds,
 			headInfoIndex,
 		});
 
 		commitDiscard(
 			{
 				projectId,
-				subjectCommitId: selection.commitId,
+				subjectCommitIds: Array.from(subjectCommitIds),
 				dryRun: false,
 			},
 			{

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/selectAfterDiscardedCommit.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/selectAfterDiscardedCommit.ts
@@ -8,23 +8,33 @@ import {
 } from "#ui/operands.ts";
 import type { NavigationIndex } from "#ui/workspace/navigation-index.ts";
 
-export const selectAfterDiscardedCommit = ({
+export const selectAfterDiscardedCommits = ({
 	navigationIndex,
 	commit,
+	discardedCommitIds,
 	headInfoIndex,
 }: {
 	navigationIndex: NavigationIndex<Operand>;
 	commit: CommitOperand;
+	discardedCommitIds: ReadonlySet<string>;
 	headInfoIndex: HeadInfoIndex | undefined;
 }): Operand | null => {
+	if (!discardedCommitIds.has(commit.commitId)) return commitOperand(commit);
+
 	const commitIndex = navigationIndex.indexByKey.get(operandIdentityKey(commitOperand(commit)));
 	if (commitIndex === undefined) return null;
 
-	const nextCommit = navigationIndex.items[commitIndex + 1];
-	if (nextCommit?._tag === "Commit") return nextCommit;
+	for (let index = commitIndex + 1; ; index++) {
+		const nextCommit = navigationIndex.items[index];
+		if (nextCommit?._tag !== "Commit") break;
+		if (!discardedCommitIds.has(nextCommit.commitId)) return nextCommit;
+	}
 
-	const prevCommit = navigationIndex.items[commitIndex - 1];
-	if (prevCommit?._tag === "Commit") return prevCommit;
+	for (let index = commitIndex - 1; ; index--) {
+		const prevCommit = navigationIndex.items[index];
+		if (prevCommit?._tag !== "Commit") break;
+		if (!discardedCommitIds.has(prevCommit.commitId)) return prevCommit;
+	}
 
 	const commitCtx = headInfoIndex?.commitContextByCommitId(commit.commitId);
 	if (!commitCtx?.segment.refName) return null;

--- a/crates/but-api/src/commit/discard_commit.rs
+++ b/crates/but-api/src/commit/discard_commit.rs
@@ -7,10 +7,24 @@ use tracing::instrument;
 
 use crate::commit::types::{CommitDiscardResult, MoveChangesResult};
 
-/// Discard `subject_commit_id`, removing it from the branch history.
+fn unique_subject_commit_ids(
+    subject_commit_ids: Vec<gix::ObjectId>,
+) -> anyhow::Result<Vec<gix::ObjectId>> {
+    let mut seen = gix::hashtable::HashSet::default();
+    let subject_commit_ids = subject_commit_ids
+        .into_iter()
+        .filter(|commit_id| seen.insert(*commit_id))
+        .collect::<Vec<_>>();
+    if subject_commit_ids.is_empty() {
+        anyhow::bail!("no commit IDs provided for discard");
+    }
+    Ok(subject_commit_ids)
+}
+
+/// Discard `subject_commit_ids`, removing them from branch history.
 ///
-/// Unlike [`super::uncommit::commit_uncommit()`], the commit's changes are **not**
-/// reassigned to the workspace — they are permanently removed from the branch.
+/// Unlike [`super::uncommit::commit_uncommit()`], the commits' changes are **not**
+/// reassigned to the workspace — they are permanently removed from their branches.
 ///
 /// When `dry_run` is enabled, the returned workspace previews the discard
 /// without materializing the rebase.
@@ -18,43 +32,45 @@ use crate::commit::types::{CommitDiscardResult, MoveChangesResult};
 #[but_api(try_from = crate::commit::json::CommitDiscardResult)]
 pub fn commit_discard_only(
     ctx: &mut but_ctx::Context,
-    subject_commit_id: gix::ObjectId,
+    subject_commit_ids: Vec<gix::ObjectId>,
     dry_run: DryRun,
 ) -> anyhow::Result<CommitDiscardResult> {
     let mut guard = ctx.exclusive_worktree_access();
-    commit_discard_only_with_perm(ctx, subject_commit_id, dry_run, guard.write_permission())
+    commit_discard_only_with_perm(ctx, subject_commit_ids, dry_run, guard.write_permission())
 }
 
-/// Discard `subject_commit_id` under caller-held exclusive repository access.
+/// Discard `subject_commit_ids` under caller-held exclusive repository access.
 ///
-/// The commit is removed from branch history and its changes are **lost**
+/// The commits are removed from branch history and their changes are **lost**
 /// (not reassigned to the workspace). This variant does not create an oplog
 /// entry. When `dry_run` is enabled, it returns the projected workspace state
 /// without materializing the rebase.
 pub fn commit_discard_only_with_perm(
     ctx: &mut but_ctx::Context,
-    subject_commit_id: gix::ObjectId,
+    subject_commit_ids: Vec<gix::ObjectId>,
     dry_run: DryRun,
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<CommitDiscardResult> {
+    let subject_commit_ids = unique_subject_commit_ids(subject_commit_ids)?;
     let mut meta = ctx.meta()?;
     let (repo, mut ws, mut db) = ctx.workspace_mut_and_db_mut_with_perm(perm)?;
     let editor = Editor::create(&mut ws, &mut meta, &repo, &mut db)?;
 
-    let rebase = but_workspace::commit::discard_commits(editor, [subject_commit_id])?;
+    let rebase =
+        but_workspace::commit::discard_commits(editor, subject_commit_ids.iter().copied())?;
 
     let workspace = WorkspaceState::from_successful_rebase(rebase, &repo, dry_run)?;
 
     Ok(CommitDiscardResult {
-        discarded_commit: subject_commit_id,
+        discarded_commits: subject_commit_ids,
         workspace,
     })
 }
 
-/// Discard `subject_commit_id`, removing it from the branch history.
+/// Discard `subject_commit_ids`, removing them from branch history.
 ///
-/// Unlike [`super::uncommit::commit_uncommit()`], the commit's changes are **not**
-/// reassigned to the workspace — they are permanently removed from the branch.
+/// Unlike [`super::uncommit::commit_uncommit()`], the commits' changes are **not**
+/// reassigned to the workspace — they are permanently removed from their branches.
 ///
 /// When `dry_run` is enabled, the returned workspace previews the discard and
 /// no oplog entry is persisted. See [`commit_discard_with_perm()`] for details.
@@ -62,28 +78,30 @@ pub fn commit_discard_only_with_perm(
 #[instrument(err(Debug))]
 pub fn commit_discard(
     ctx: &mut but_ctx::Context,
-    subject_commit_id: gix::ObjectId,
+    subject_commit_ids: Vec<gix::ObjectId>,
     dry_run: DryRun,
 ) -> anyhow::Result<CommitDiscardResult> {
     let mut guard = ctx.exclusive_worktree_access();
-    commit_discard_with_perm(ctx, subject_commit_id, dry_run, guard.write_permission())
+    commit_discard_with_perm(ctx, subject_commit_ids, dry_run, guard.write_permission())
 }
 
-/// Discard `subject_commit_id` under caller-held exclusive repository access
+/// Discard `subject_commit_ids` under caller-held exclusive repository access
 /// and record an oplog snapshot on success.
 ///
-/// The commit is removed from branch history and its changes are **lost**
+/// The commits are removed from branch history and their changes are **lost**
 /// (not reassigned to the workspace). An oplog snapshot is recorded so the
 /// operation can be reverted from the timeline. When `dry_run` is enabled,
 /// it returns the projected workspace state and skips oplog persistence.
 pub fn commit_discard_with_perm(
     ctx: &mut but_ctx::Context,
-    subject_commit_id: gix::ObjectId,
+    subject_commit_ids: Vec<gix::ObjectId>,
     dry_run: DryRun,
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<CommitDiscardResult> {
+    let subject_commit_ids = unique_subject_commit_ids(subject_commit_ids)?;
     let details = SnapshotDetails::new(OperationKind::DiscardCommit)
-        .with_trailers([Trailer::Sha(subject_commit_id)]);
+        .with_count(subject_commit_ids.len())
+        .with_trailers(subject_commit_ids.iter().copied().map(Trailer::Sha));
     let maybe_oplog_entry = but_oplog::UnmaterializedOplogSnapshot::from_details_with_perm(
         ctx,
         details,
@@ -91,7 +109,7 @@ pub fn commit_discard_with_perm(
         dry_run,
     );
 
-    let res = commit_discard_only_with_perm(ctx, subject_commit_id, dry_run, perm);
+    let res = commit_discard_only_with_perm(ctx, subject_commit_ids, dry_run, perm);
     if let Some(snapshot) = maybe_oplog_entry
         && res.is_ok()
     {

--- a/crates/but-api/src/commit/json.rs
+++ b/crates/but-api/src/commit/json.rs
@@ -302,15 +302,15 @@ impl TryFrom<EngineCommitMoveResult> for CommitMoveResult {
         })
     }
 }
-/// JSON transport type for discarding a commit.
+/// JSON transport type for discarding one or more commits.
 #[derive(Debug, Serialize)]
 #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct CommitDiscardResult {
-    /// The commit that was discarded as a result of this operation.
-    #[cfg_attr(feature = "export-schema", schemars(with = "String"))]
-    pub discarded_commit: HexHash,
-    /// Workspace state after discarding the commit.
+    /// The commits that were discarded as a result of this operation.
+    #[cfg_attr(feature = "export-schema", schemars(with = "Vec<String>"))]
+    pub discarded_commits: Vec<HexHash>,
+    /// Workspace state after discarding the commits.
     pub workspace: crate::json::WorkspaceState,
 }
 
@@ -322,12 +322,12 @@ impl TryFrom<EngineCommitDiscardResult> for CommitDiscardResult {
 
     fn try_from(value: EngineCommitDiscardResult) -> Result<Self, Self::Error> {
         let EngineCommitDiscardResult {
-            discarded_commit,
+            discarded_commits,
             workspace,
         } = value;
 
         Ok(Self {
-            discarded_commit: discarded_commit.into(),
+            discarded_commits: discarded_commits.into_iter().map(Into::into).collect(),
             workspace: workspace.try_into()?,
         })
     }

--- a/crates/but-api/src/commit/types.rs
+++ b/crates/but-api/src/commit/types.rs
@@ -93,11 +93,11 @@ pub struct CommitInsertBlankResult {
     pub workspace: WorkspaceState,
 }
 
-/// Outcome of discarding a commit.
+/// Outcome of discarding one or more commits.
 pub struct CommitDiscardResult {
-    /// The ID of the commit discarded.
-    pub discarded_commit: gix::ObjectId,
-    /// Workspace state after discarding the commit.
+    /// The IDs of the commits discarded.
+    pub discarded_commits: Vec<gix::ObjectId>,
+    /// Workspace state after discarding the commits.
     pub workspace: WorkspaceState,
 }
 

--- a/crates/but/src/command/legacy/oplog.rs
+++ b/crates/but/src/command/legacy/oplog.rs
@@ -108,6 +108,18 @@ pub(crate) fn show_oplog(
                             details.operation.title().to_owned()
                         }
                     }
+                    OperationKind::DiscardCommit => {
+                        let commit_count = details
+                            .trailers
+                            .iter()
+                            .filter(|trailer| matches!(trailer, Trailer::Sha(_)))
+                            .count();
+                        if commit_count > 1 {
+                            format!("Discarded {commit_count} commits")
+                        } else {
+                            details.operation.title().to_owned()
+                        }
+                    }
                     OperationKind::RestoreFromSnapshotViaUndo
                     | OperationKind::RestoreFromSnapshotViaRedo
                     | OperationKind::RestoreFromSnapshot => {
@@ -152,7 +164,6 @@ pub(crate) fn show_oplog(
                     | OperationKind::Absorb
                     | OperationKind::AutoCommit
                     | OperationKind::UndoCommit
-                    | OperationKind::DiscardCommit
                     | OperationKind::UnapplyBranch
                     | OperationKind::CherryPick
                     | OperationKind::SquashCommit

--- a/packages/but-sdk/src/generated/graph/apiParamNames.d.ts
+++ b/packages/but-sdk/src/generated/graph/apiParamNames.d.ts
@@ -32,7 +32,7 @@ export declare const apiParamNames: {
 	readonly commitConflicts: readonly ["projectId", "commitId"];
 	readonly commitCreate: readonly ["projectId", "relativeTo", "side", "changes", "changesSource", "message", "dryRun"];
 	readonly commitDetailsWithLineStats: readonly ["projectId", "commitId"];
-	readonly commitDiscard: readonly ["projectId", "subjectCommitId", "dryRun"];
+	readonly commitDiscard: readonly ["projectId", "subjectCommitIds", "dryRun"];
 	readonly commitDiscardChanges: readonly ["projectId", "commitId", "changes", "dryRun"];
 	readonly commitInsertBlank: readonly ["projectId", "relativeTo", "side", "dryRun"];
 	readonly commitMove: readonly ["projectId", "subjectCommitIds", "relativeTo", "side", "dryRun"];

--- a/packages/but-sdk/src/generated/graph/apiParamNames.js
+++ b/packages/but-sdk/src/generated/graph/apiParamNames.js
@@ -32,7 +32,7 @@ export const apiParamNames = {
 	commitConflicts: ["projectId", "commitId"],
 	commitCreate: ["projectId", "relativeTo", "side", "changes", "changesSource", "message", "dryRun"],
 	commitDetailsWithLineStats: ["projectId", "commitId"],
-	commitDiscard: ["projectId", "subjectCommitId", "dryRun"],
+	commitDiscard: ["projectId", "subjectCommitIds", "dryRun"],
 	commitDiscardChanges: ["projectId", "commitId", "changes", "dryRun"],
 	commitInsertBlank: ["projectId", "relativeTo", "side", "dryRun"],
 	commitMove: ["projectId", "subjectCommitIds", "relativeTo", "side", "dryRun"],

--- a/packages/but-sdk/src/generated/graph/index.d.ts
+++ b/packages/but-sdk/src/generated/graph/index.d.ts
@@ -299,15 +299,15 @@ export declare function commitCreate(projectId: string, relativeTo: RelativeTo, 
 export declare function commitDetailsWithLineStats(projectId: string, commitId: string): Promise<CommitDetails>
 
 /**
- * Discard `subject_commit_id`, removing it from the branch history.
+ * Discard `subject_commit_ids`, removing them from branch history.
  *
- * Unlike [`super::uncommit::commit_uncommit()`], the commit's changes are **not**
- * reassigned to the workspace — they are permanently removed from the branch.
+ * Unlike [`super::uncommit::commit_uncommit()`], the commits' changes are **not**
+ * reassigned to the workspace — they are permanently removed from their branches.
  *
  * When `dry_run` is enabled, the returned workspace previews the discard and
  * no oplog entry is persisted. See [`commit_discard_with_perm()`] for details.
  */
-export declare function commitDiscard(projectId: string, subjectCommitId: string, dryRun: boolean): Promise<CommitDiscardResult>
+export declare function commitDiscard(projectId: string, subjectCommitIds: Array<string>, dryRun: boolean): Promise<CommitDiscardResult>
 
 /**
  * Discard specific changes from `commit_id`, removing them from the commit
@@ -1891,11 +1891,11 @@ export type CommitDetails = {
   conflictEntries: ConflictEntries | null;
 };
 
-/** JSON transport type for discarding a commit. */
+/** JSON transport type for discarding one or more commits. */
 export type CommitDiscardResult = {
-  /** The commit that was discarded as a result of this operation. */
-  discardedCommit: string;
-  /** Workspace state after discarding the commit. */
+  /** The commits that were discarded as a result of this operation. */
+  discardedCommits: Array<string>;
+  /** Workspace state after discarding the commits. */
   workspace: WorkspaceState;
 };
 

--- a/packages/but-sdk/src/generated/linear/apiParamNames.d.ts
+++ b/packages/but-sdk/src/generated/linear/apiParamNames.d.ts
@@ -32,7 +32,7 @@ export declare const apiParamNames: {
 	readonly commitConflicts: readonly ["projectId", "commitId"];
 	readonly commitCreate: readonly ["projectId", "relativeTo", "side", "changes", "changesSource", "message", "dryRun"];
 	readonly commitDetailsWithLineStats: readonly ["projectId", "commitId"];
-	readonly commitDiscard: readonly ["projectId", "subjectCommitId", "dryRun"];
+	readonly commitDiscard: readonly ["projectId", "subjectCommitIds", "dryRun"];
 	readonly commitDiscardChanges: readonly ["projectId", "commitId", "changes", "dryRun"];
 	readonly commitInsertBlank: readonly ["projectId", "relativeTo", "side", "dryRun"];
 	readonly commitMove: readonly ["projectId", "subjectCommitIds", "relativeTo", "side", "dryRun"];

--- a/packages/but-sdk/src/generated/linear/apiParamNames.js
+++ b/packages/but-sdk/src/generated/linear/apiParamNames.js
@@ -32,7 +32,7 @@ export const apiParamNames = {
 	commitConflicts: ["projectId", "commitId"],
 	commitCreate: ["projectId", "relativeTo", "side", "changes", "changesSource", "message", "dryRun"],
 	commitDetailsWithLineStats: ["projectId", "commitId"],
-	commitDiscard: ["projectId", "subjectCommitId", "dryRun"],
+	commitDiscard: ["projectId", "subjectCommitIds", "dryRun"],
 	commitDiscardChanges: ["projectId", "commitId", "changes", "dryRun"],
 	commitInsertBlank: ["projectId", "relativeTo", "side", "dryRun"],
 	commitMove: ["projectId", "subjectCommitIds", "relativeTo", "side", "dryRun"],

--- a/packages/but-sdk/src/generated/linear/index.d.ts
+++ b/packages/but-sdk/src/generated/linear/index.d.ts
@@ -299,15 +299,15 @@ export declare function commitCreate(projectId: string, relativeTo: RelativeTo, 
 export declare function commitDetailsWithLineStats(projectId: string, commitId: string): Promise<CommitDetails>
 
 /**
- * Discard `subject_commit_id`, removing it from the branch history.
+ * Discard `subject_commit_ids`, removing them from branch history.
  *
- * Unlike [`super::uncommit::commit_uncommit()`], the commit's changes are **not**
- * reassigned to the workspace — they are permanently removed from the branch.
+ * Unlike [`super::uncommit::commit_uncommit()`], the commits' changes are **not**
+ * reassigned to the workspace — they are permanently removed from their branches.
  *
  * When `dry_run` is enabled, the returned workspace previews the discard and
  * no oplog entry is persisted. See [`commit_discard_with_perm()`] for details.
  */
-export declare function commitDiscard(projectId: string, subjectCommitId: string, dryRun: boolean): Promise<CommitDiscardResult>
+export declare function commitDiscard(projectId: string, subjectCommitIds: Array<string>, dryRun: boolean): Promise<CommitDiscardResult>
 
 /**
  * Discard specific changes from `commit_id`, removing them from the commit
@@ -1891,11 +1891,11 @@ export type CommitDetails = {
   conflictEntries: ConflictEntries | null;
 };
 
-/** JSON transport type for discarding a commit. */
+/** JSON transport type for discarding one or more commits. */
 export type CommitDiscardResult = {
-  /** The commit that was discarded as a result of this operation. */
-  discardedCommit: string;
-  /** Workspace state after discarding the commit. */
+  /** The commits that were discarded as a result of this operation. */
+  discardedCommits: Array<string>;
+  /** Workspace state after discarding the commits. */
   workspace: WorkspaceState;
 };
 


### PR DESCRIPTION
SDK update that is in turn used to support the functionality in Lite.