### PR TITLE
Fix initial diff text selection

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -68,10 +68,11 @@ import {
 	type CodeViewDiffItem,
 	type CodeView as CodeViewClass,
 	type CodeViewLineSelection,
+	type CodeViewOptions,
 	type DiffLineAnnotation,
 	isDiffAnnotation,
 } from "@pierre/diffs";
-import { CodeView, type CodeViewHandle } from "@pierre/diffs/react";
+import { CodeView, type CodeViewHandle, useStableCallback } from "@pierre/diffs/react";
 import {
 	keepPreviousData,
 	useQuery,
@@ -962,6 +963,25 @@ const DiffContents: FC<{
 		);
 	};
 
+	// Keep this option's identity fixed while reading the latest diff state. An inline callback (or
+	// useCallback with the render-local helpers as dependencies) invalidates the compiler's cached
+	// CodeView on focus, causing Pierre to rebuild its DOM during native text selection.
+	const handleLineNumberClick: NonNullable<CodeViewOptions<Annotation>["onLineNumberClick"]> =
+		useStableCallback(({ event, numberElement }, context) => {
+			if (event.detail !== 2) return;
+			const target = diffLineTargetFromElement({
+				element: numberElement,
+				itemId: context.item.id,
+			});
+			if (!target) return;
+			const operand = getHunkOperandAtLine(target);
+			if (!operand) return;
+			const range = rangeFromLineGroups(operand.lineGroups);
+			if (!range) return;
+
+			applySelectedLines({ id: target.itemId, range });
+		});
+
 	const getContiguousHunkOperandAtLine = ({
 		itemId,
 		lineNumber,
@@ -1359,20 +1379,7 @@ const DiffContents: FC<{
 					themeType: settings?.theme ?? defaultSettings.theme,
 					stickyHeaders: true,
 					enableLineSelection: true,
-					onLineNumberClick: ({ event, numberElement }, context) => {
-						if (event.detail !== 2) return;
-						const target = diffLineTargetFromElement({
-							element: numberElement,
-							itemId: context.item.id,
-						});
-						if (!target) return;
-						const operand = getHunkOperandAtLine(target);
-						if (!operand) return;
-						const range = rangeFromLineGroups(operand.lineGroups);
-						if (!range) return;
-
-						applySelectedLines({ id: target.itemId, range });
-					},
+					onLineNumberClick: handleLineNumberClick,
 					layout: codeViewLayout,
 					// This appears to validate before our custom header has been slotted, in which case - if
 					// our metrics are correct - we should see deltas in multiples of our custom header height


### PR DESCRIPTION
## Summary

- keep the Pierre line-number callback identity stable while reading current diff state
- preserve React Compiler memoization of CodeView across its initial focus transition
- prevent Pierre from rebuilding the diff DOM during native text selection

## Root cause

The arbitrary diff ranges change added an inline `onLineNumberClick` callback. Its changing identity invalidated the compiler-cached `CodeView` on focus, causing Pierre to synchronously rebuild the text nodes under an in-progress browser selection.

## Validation

- reproduced against the regression and compared with the pre-change snapshot
- verified the first native text drag succeeds with no Pierre update or render
- `pnpm -F @gitbutler/lite check`
- type-aware oxlint
- `git diff --check`