### PR TITLE
Lite: reveal list checkboxes only under the pointer

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.module.css
@@ -83,13 +83,15 @@
 	font-variant-numeric: tabular-nums;
 }
 
-/* Opaque, so a checked box covers the mark it shares a cell with. */
+/* Opaque, so a checked box covers the mark it shares a cell with. Appears when
+   the pointer is over that cell, not the whole row, so the row stays quiet
+   while browsing. */
 .leadingCheckbox {
 	opacity: 0;
 
 	&[data-checked],
 	&[data-indeterminate],
-	.row:hover &,
+	.leading:hover &,
 	&:focus {
 		opacity: 1;
 	}

--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/CommitRow.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/CommitRow.module.css
@@ -6,12 +6,14 @@
 	}
 }
 
+/* Appears when the pointer is over the glyph cell, not the whole row, so the
+   row stays quiet while browsing. */
 .checkbox {
 	justify-self: center;
 	opacity: 0;
 
 	&[data-checked],
-	.row:hover &,
+	.iconWithCheckbox:hover &,
 	&:focus {
 		opacity: 1;
 	}


### PR DESCRIPTION
Hovering a row in Lite lit up its checkbox together with the row background, which reads as noisy while just browsing the list.

Files, directories and commits keep the row hover background, but the checkbox now only appears when the pointer is over the checkbox cell itself (plus checked, indeterminate and focused states, as before). Two CSS selector swaps, no behaviour change otherwise.

The diff-gutter line checkbox already worked this way (only shown when hovering the gutter cell), so it needed nothing.

@PavelLaptev FYI. The checkbox was driving me crazy so i toned it down a bit