### PR TITLE
Lite: capture PR screenshots in a container

### DIFF
--- a/.agents/skills/lite-screenshots/SKILL.md
+++ b/.agents/skills/lite-screenshots/SKILL.md
@@ -13,6 +13,11 @@ on load and not reliably afterwards, so several surfaces hung indefinitely
 whether the capture went through Playwright or the DevTools protocol. The same
 spec passes here. The CI workflow only leaves a reminder.
 
+There are two ways to capture, and the flow below is the same for both. Use the
+host by default; use [the container](#capturing-in-a-container) when the two
+halves of a comparison will not come from the same machine, or when the host
+capture is hitting the renderer problem above.
+
 ## Before capturing: is the surface covered?
 
 Work this out first, by reading the diff — not by capturing and inferring it from
@@ -134,6 +139,37 @@ clobbering their concurrent edits.
   were written, not that they show the surface.
 - Confirm the workspace is whole: `but status` should show the branch applied and
   no stray uncommitted changes.
+
+## Capturing in a container
+
+`apps/lite/e2e/docker/` builds an image that runs the same catalogue under Xvfb,
+driven by `apps/lite/e2e/playwright.docker.config.ts`. It substitutes for steps 1
+and 2 only; selecting, publishing and posting are unchanged.
+
+```console
+$ bash apps/lite/e2e/docker/capture.sh head
+$ but unapply <branch>
+$ bash apps/lite/e2e/docker/capture.sh base
+$ but apply <branch>
+```
+
+Output lands in the same `apps/lite/e2e/screenshots/<name>/`, so
+`compare-screenshots.mjs` does not know the difference.
+
+What it is for: a before/after pair only means something if both halves were
+rendered the same way, and font hinting and device scale differ between two
+contributors' machines before the UI is even considered. The container fixes the
+OS, the font set and the rasteriser, so **the two halves do not have to be
+captured by the same person**.
+
+- The host checkout is mounted read-only and mirrored into a volume. Your
+  `node_modules` and `target/` are never written to — the container's Linux
+  Electron and Linux `but` live in volumes of their own.
+- The first run builds a Rust toolchain, `but`, and the napi SDK, and is slow.
+  Later runs reuse the volumes. Removing `gitbutler-lite-screenshots-*` pays that
+  cost again.
+- Requires a container runtime on the host. There is none in CI: this is still a
+  developer-machine flow, and the CI workflow still only leaves a reminder.
 
 ## Extending the catalogue
 

--- a/.github/workflows/lite-screenshots-container-proof.yml
+++ b/.github/workflows/lite-screenshots-container-proof.yml
@@ -1,0 +1,86 @@
+# TEMPORARY. Delete before this branch merges.
+#
+# Answers one question: does the capture container produce the whole catalogue on
+# a Linux runner? Capture was abandoned on these runners because three of eight
+# surfaces hung under the bare X server, and the container exists to fix that.
+# The claim can only be tested here, so it is tested here.
+#
+# Not a before/after run. It captures one side and uploads it; a surface that
+# hangs fails the job on the spec's own 180s budget.
+name: "Lite screenshots (container proof)"
+
+on:
+  workflow_dispatch: {}
+  pull_request:
+    paths:
+      - "apps/lite/e2e/docker/**"
+      - "apps/lite/e2e/playwright.docker.config.ts"
+      - ".github/workflows/lite-screenshots-container-proof.yml"
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  capture:
+    runs-on: ubuntu-latest
+    # A cold run builds the image, a Rust toolchain, `but`, and the napi SDK
+    # twice over. The volumes that make this cheap locally are empty on an
+    # ephemeral runner, so every run pays full price.
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # A debug build of the workspace plus the Playwright base image does not
+      # fit next to the runner's preinstalled toolchains.
+      - name: Reclaim disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /usr/local/share/boost "${AGENT_TOOLSDIRECTORY:-}"
+          df -h /
+
+      # --retries=0 so a hanging surface is reported once rather than three times.
+      # Passing --timeout would achieve nothing: screenshots.spec.ts sets its own
+      # 180s through test.describe.configure, and that beats both the config and
+      # the command line. Eight surfaces at 180s is the 24 minutes the outer bound
+      # below has to clear.
+      #
+      # `timeout` bounds the whole thing from outside, because a job GitHub
+      # cancels uploads nothing and the artifacts are the entire point. capture.sh
+      # traps the signal and stops the container, so the run flushes what it has.
+      #
+      # DEBUG=pw:browser prints the Electron launch and its stderr, which is where
+      # "sandboxed_renderer.bundle.js script failed to run" would appear.
+      - name: Capture
+        env:
+          DEBUG: pw:browser
+        run: |
+          timeout --signal=INT --kill-after=3m 40m \
+            bash apps/lite/e2e/docker/capture.sh proof --retries=0
+
+      # warn, not error: a partial capture is the most informative outcome there
+      # is, and failing the upload would discard exactly the surfaces that worked.
+      - name: Upload screenshots
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: lite-screenshots-container-proof
+          path: apps/lite/e2e/screenshots/proof
+          if-no-files-found: warn
+          retention-days: 7
+
+      # Playwright attaches the Electron main- and renderer-process logs to failed
+      # tests (see e2e/test.ts). On a hang that is the only account of what the
+      # renderer was doing.
+      - name: Upload Playwright diagnostics
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: lite-screenshots-container-proof-diagnostics
+          path: apps/lite/e2e/screenshots/_diagnostics
+          if-no-files-found: warn
+          retention-days: 7

--- a/apps/lite/e2e/clear-screenshots.ts
+++ b/apps/lite/e2e/clear-screenshots.ts
@@ -1,0 +1,22 @@
+import { mkdirSync, rmSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * Empties the capture directory once, before any test runs.
+ *
+ * This has to happen exactly once per run. Doing it in a `beforeAll` looks
+ * equivalent and is not: Playwright restarts the worker after a failure, the
+ * hook runs again, and the surfaces captured before the failure are deleted —
+ * so a run with one broken surface reports the rest as missing rather than as
+ * captured. It still has to happen at all, because a PNG left by an earlier run
+ * would otherwise survive a rerun in which its own surface failed and be
+ * compared as though this run had produced it.
+ */
+export default function clearScreenshots(): void {
+	const out = process.env.SCREENSHOT_OUT;
+	if (out === undefined || out === "") return;
+
+	const outputDir = path.resolve(import.meta.dirname, "screenshots", out);
+	rmSync(outputDir, { force: true, recursive: true });
+	mkdirSync(outputDir, { recursive: true });
+}

--- a/apps/lite/e2e/docker/Dockerfile
+++ b/apps/lite/e2e/docker/Dockerfile
@@ -1,0 +1,96 @@
+# Environment for capturing Lite's before/after PR screenshots.
+#
+# Capture used to run on the GitHub Linux runners and was abandoned: under the
+# bare X server there, three of eight surfaces hung indefinitely and every log
+# carried "sandboxed_renderer.bundle.js script failed to run". A hosted runner
+# gives no way to change how Chromium is sandboxed; a container does, which is
+# why the fix is an image rather than another attempt at the same job.
+#
+# The second thing it buys is commensurability. A before/after pair is only
+# meaningful if the two halves were rendered the same way; captured on two
+# contributors' machines they differ in font hinting and device scale before the
+# UI is even considered. Here both halves share one OS, one font set and one
+# rasteriser, so a pixel that differs differs because the UI changed.
+#
+# Built and driven by capture.sh — see .agents/skills/lite-screenshots/SKILL.md.
+
+FROM mcr.microsoft.com/playwright:v1.58.2-noble
+
+# The base image carries Chromium's shared libraries, a broad font set and Xvfb.
+# What it lacks is a Rust toolchain for `but` and the napi SDK, and rsync for
+# mirroring the checkout.
+#
+# The build dependencies are the same ones .github/workflows/lite.yml installs
+# for its Linux job; libdbus-1-dev in particular is what libdbus-sys needs, and
+# without it the napi SDK fails to compile.
+RUN apt-get update && \
+	apt-get install -y --no-install-recommends \
+	build-essential \
+	cmake \
+	git \
+	libdbus-1-dev \
+	libssl-dev \
+	libxss-dev \
+	pkg-config \
+	rsync && \
+	apt-get -y autoremove && apt-get -y clean && \
+	rm -rf /var/lib/apt/lists/*
+
+# Lite bundles its own webfonts, so system fonts only ever serve as fallback —
+# but a missing fallback still shifts a metric somewhere, so pin the set rather
+# than inherit whatever the base image happens to ship next.
+RUN apt-get update && \
+	apt-get install -y --no-install-recommends \
+	fonts-dejavu-core \
+	fonts-liberation2 \
+	fonts-noto-color-emoji && \
+	apt-get -y autoremove && apt-get -y clean && \
+	rm -rf /var/lib/apt/lists/* && \
+	fc-cache -f
+
+# The capture drops to an ordinary user before it runs anything (see
+# run-capture.sh for why). These toolchains default to living under /root, which
+# that user cannot read, so put them somewhere shared and writable instead —
+# rustup fetches the pinned toolchain on first use, and cargo writes its registry
+# cache, both as the unprivileged user.
+ENV RUSTUP_HOME=/usr/local/rustup \
+	CARGO_HOME=/usr/local/cargo \
+	COREPACK_HOME=/usr/local/corepack \
+	PATH=/usr/local/cargo/bin:${PATH}
+
+# rustup reads rust-toolchain.toml from the mirrored checkout, so the version is
+# not pinned here; this only provides the installer.
+RUN curl https://sh.rustup.rs -sSf | \
+	sh -s -- -y --profile minimal --default-toolchain none --no-modify-path && \
+	corepack enable && corepack prepare pnpm@10.20.0 --activate && \
+	mkdir -p "${COREPACK_HOME}" && \
+	chmod -R a+rwX "${RUSTUP_HOME}" "${CARGO_HOME}" "${COREPACK_HOME}"
+
+# As an environment variable rather than `pnpm config set`, which would write to
+# root's .npmrc and be invisible to the user that actually runs the install.
+ENV npm_config_store_dir=/pnpm-store
+
+# Both are volume mount points in capture.sh, so neither compiled artefact nor
+# downloaded package is paid for twice. CARGO_TARGET_DIR also keeps the Linux
+# build out of the mirrored tree, where it would shadow the host's own target/.
+ENV CARGO_TARGET_DIR=/cargo-target
+# setup.ts reads $BUT before falling back to target/debug/but.
+ENV BUT=/cargo-target/debug/but
+
+# Deterministic text shaping and date formatting, independent of the host.
+ENV LANG=C.UTF-8
+ENV TZ=UTC
+
+# Larger than the 1440x900 viewport the catalogue uses: a screen the exact size
+# of the window leaves no room for the window manager's own decorations, and
+# Electron then reports a viewport an off-by-a-few pixels smaller.
+ENV XVFB_SCREEN=1600x1000x24
+
+# Ships with the Playwright base image. The container still starts as root so
+# the entrypoint can settle volume ownership; it drops to this user itself.
+ENV RUN_AS_USER=pwuser
+
+WORKDIR /work
+COPY run-capture.sh /usr/local/bin/run-capture
+RUN chmod +x /usr/local/bin/run-capture
+ENTRYPOINT ["/usr/local/bin/run-capture"]

--- a/apps/lite/e2e/docker/capture.sh
+++ b/apps/lite/e2e/docker/capture.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Capture one side of a before/after comparison in the container.
+#
+#   apps/lite/e2e/docker/capture.sh before
+#   apps/lite/e2e/docker/capture.sh after
+#
+# Arguments after the name go to Playwright:
+#
+#   apps/lite/e2e/docker/capture.sh proof --retries=0 --grep "workspace sidebar"
+#
+# Writes apps/lite/e2e/screenshots/<name>/, which is what compare-screenshots.mjs
+# reads. The host checkout is only ever read, so the branch can be unapplied and
+# re-applied between the two calls without the container noticing.
+set -euo pipefail
+
+name="${1:-}"
+if [ -z "$name" ]; then
+	echo "usage: capture.sh <output-directory-name> [playwright args...]" >&2
+	exit 1
+fi
+shift
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+image="gitbutler/lite-screenshots:latest"
+
+echo "==> building $image"
+docker build --tag "$image" "$repo_root/apps/lite/e2e/docker"
+
+# The whole screenshots directory is mounted, not the single output one: the
+# spec clears its own output directory before capturing, and rm on a mount point
+# fails with EBUSY.
+screenshots_dir="$repo_root/apps/lite/e2e/screenshots"
+mkdir -p "$screenshots_dir"
+
+# A signal sent to this script does not reach `docker run` — the shell dies, the
+# container keeps running, and whatever it had written is never flushed. Under an
+# outer timeout that loses exactly the diagnostics the run was for, so stop the
+# container explicitly and give it time to finish writing.
+container="lite-screenshots-$name"
+cleanup() { docker stop --time 20 "$container" > /dev/null 2>&1 || true; }
+trap cleanup INT TERM EXIT
+
+# --shm-size: Chromium maps shared memory per renderer and the 64MB default
+#   crashes it under load, which reads as a renderer that never paints — the
+#   exact symptom this image exists to rule out.
+# --init: reaps the Electron and Xvfb children a killed run leaves behind.
+echo "==> capturing '$name'"
+docker run --rm --init \
+	--name "$container" \
+	--shm-size=2g \
+	--volume "$repo_root:/src:ro" \
+	--volume "$screenshots_dir:/work/apps/lite/e2e/screenshots" \
+	--volume gitbutler-lite-screenshots-work:/work \
+	--volume gitbutler-lite-screenshots-cargo:/cargo-target \
+	--volume gitbutler-lite-screenshots-pnpm:/pnpm-store \
+	--env "SCREENSHOT_OUT=$name" \
+	--env DEBUG \
+	"$image" "$@"
+
+echo "==> wrote $screenshots_dir/$name"

--- a/apps/lite/e2e/docker/run-capture.sh
+++ b/apps/lite/e2e/docker/run-capture.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Container entrypoint: mirror the checkout, build, capture one side of a
+# comparison. Invoked by capture.sh, not by hand.
+#
+# This runs as root and drops to $RUN_AS_USER for every step that does real work,
+# rather than dropping once at the top. Two things need root and they happen at
+# different times: volume ownership, before anything is installed, and Chromium's
+# setuid sandbox helper, which does not exist until after the install.
+set -euo pipefail
+
+: "${SCREENSHOT_OUT:?SCREENSHOT_OUT must name an output directory}"
+: "${RUN_AS_USER:?RUN_AS_USER must name the unprivileged capture user}"
+
+as_user() {
+	setpriv --reuid "$RUN_AS_USER" --regid "$RUN_AS_USER" --init-groups \
+		env "HOME=/home/$RUN_AS_USER" "$@"
+}
+
+# Electron aborts a root process whose sandbox is still enabled, and waiving the
+# sandbox is not an option either — see the switch list in
+# playwright.docker.config.ts. So the capture runs as an ordinary user. Docker
+# creates volumes owned by root, so ownership is settled here first.
+for dir in /work /cargo-target /pnpm-store; do
+	mkdir -p "$dir"
+	# Only the first run pays for this. Afterwards the files already belong to the
+	# capture user, and a recursive chown across node_modules and a cargo target
+	# directory is not cheap.
+	[ "$(stat -c %U "$dir")" = "$RUN_AS_USER" ] || chown -R "$RUN_AS_USER" "$dir"
+done
+# The output directory is a fresh bind mount on every run, so it arrives with the
+# host's ownership and is missed by the guard above. It holds a handful of PNGs,
+# so doing it unconditionally costs nothing.
+chown -R "$RUN_AS_USER" /work/apps/lite/e2e/screenshots 2>/dev/null || true
+
+# The host checkout is mounted read-only at /src and mirrored into /work rather
+# than built in place. A macOS checkout carries a macOS Electron and macOS native
+# modules under node_modules, plus a macOS target/; installing or building over
+# any of them would leave the developer's own tree unusable.
+#
+# --delete keeps a file deleted on the branch from surviving into the capture.
+# Excluded paths are not deleted by it, which is what protects the volume's
+# node_modules and the mounted output directory.
+echo "==> mirroring /src into /work"
+as_user rsync -a --delete \
+	--exclude ".git/" \
+	--exclude "node_modules/" \
+	--exclude "target/" \
+	--exclude "release/" \
+	--exclude "apps/lite/e2e/screenshots/" \
+	--exclude "*.node" \
+	/src/ /work/
+
+cd /work
+
+echo "==> pnpm install"
+as_user pnpm install --frozen-lockfile
+
+# Chromium refuses to start if its setuid helper is present but not setuid root,
+# and pnpm has just installed it owned by the capture user. Fixing it here rather
+# than passing --no-sandbox is deliberate: a waived sandbox leaves renderers
+# created by a reload without startup data, and every surface this catalogue
+# reaches by reloading then fails.
+sandbox_helper="$(find /work/node_modules/.pnpm -maxdepth 6 -path '*/electron/dist/chrome-sandbox' -print -quit)"
+if [ -z "$sandbox_helper" ]; then
+	echo "could not find chrome-sandbox under /work/node_modules/.pnpm" >&2
+	exit 1
+fi
+echo "==> configuring $sandbox_helper"
+chown root:root "$sandbox_helper"
+chmod 4755 "$sandbox_helper"
+
+# The napi SDK is a compiled artefact, and the host's is a macOS one — which is
+# why "*.node" is excluded above rather than mirrored. Rebuilding here is what
+# puts a Linux one in its place. Cached in /cargo-target, so only the first run
+# pays for it.
+echo "==> building @gitbutler/but-sdk"
+as_user pnpm --filter @gitbutler/but-sdk run build
+
+echo "==> building but"
+as_user cargo build -p but
+
+echo "==> building Lite's electron bundle"
+as_user pnpm --filter @gitbutler/lite run prepare-askpass --debug
+as_user pnpm --filter @gitbutler/lite run build:electron
+
+# A real X server rather than Electron's own headless mode: headless produces no
+# compositor frames, and the catalogue captures over CDP from what is on screen.
+#
+# Trailing arguments go to Playwright, so a caller can narrow the run or shorten
+# the budget without editing the config — which is how a hang gets diagnosed.
+echo "==> capturing into apps/lite/e2e/screenshots/${SCREENSHOT_OUT}"
+as_user xvfb-run --auto-servernum --server-args="-screen 0 ${XVFB_SCREEN}" \
+	pnpm --filter @gitbutler/lite exec \
+	playwright test --config ./e2e/playwright.docker.config.ts "$@"

--- a/apps/lite/e2e/playwright.config.ts
+++ b/apps/lite/e2e/playwright.config.ts
@@ -6,6 +6,11 @@ const liteRoot = path.resolve(import.meta.dirname, "..");
 export default defineConfig({
 	testDir: "./tests",
 	fullyParallel: true,
+	// Empties the capture directory once per run when SCREENSHOT_OUT is set, and
+	// does nothing otherwise. It cannot live in the spec's beforeAll: that hook
+	// runs again on every worker restart, so a single failing surface would delete
+	// the ones already captured.
+	globalSetup: "./clear-screenshots.ts",
 	webServer: {
 		command: "pnpm dev:ui",
 		cwd: liteRoot,

--- a/apps/lite/e2e/playwright.docker.config.ts
+++ b/apps/lite/e2e/playwright.docker.config.ts
@@ -1,0 +1,76 @@
+import { defineConfig } from "@playwright/test";
+import path from "node:path";
+import type { TestOptions } from "./test.ts";
+
+const liteRoot = path.resolve(import.meta.dirname, "..");
+
+// Screenshot capture inside the container built by e2e/docker/Dockerfile.
+//
+// Deliberately a second config rather than options folded into playwright.config.ts:
+// everything here is either meaningless or actively harmful off the container.
+// Forcing software rasterisation on a developer's machine would degrade the very
+// images a reviewer judges the change by, and --no-sandbox is a container
+// concession, not something to normalise for local runs.
+export default defineConfig<TestOptions>({
+	testDir: "./tests",
+	// Capture only. The functional specs keep running under the host config.
+	testMatch: "screenshots.spec.ts",
+	// See the host config: once per run, not once per worker.
+	globalSetup: "./clear-screenshots.ts",
+	// Inside the one directory the container shares with the host, so the failure
+	// attachments from e2e/test.ts — the Electron main- and renderer-process logs —
+	// survive the container exiting. It cannot be a mount point of its own:
+	// Playwright clears this directory on start, and rm on a mount point fails
+	// with EBUSY. A sibling of the capture directories is harmless, since
+	// compare-screenshots.mjs is handed the two it should read by name.
+	outputDir: "./screenshots/_diagnostics",
+	// One window at a time. Two Electron instances sharing a single Xvfb display
+	// contend for the compositor, and a capture then races another window's
+	// repaint — which is indistinguishable from the surface being unchanged.
+	workers: 1,
+	fullyParallel: false,
+	// Relaunching Electron from scratch is the one thing that has ever recovered a
+	// renderer that came up without painting, and a missing surface costs a whole
+	// second capture run to notice.
+	retries: 2,
+	webServer: {
+		command: "pnpm dev:ui",
+		cwd: liteRoot,
+		url: "http://127.0.0.1:5173",
+		reuseExistingServer: true,
+		stdout: "pipe",
+	},
+	use: {
+		// Despite the name this does not make Electron headless — e2e/test.ts only
+		// forwards it as GITBUTLER_LITE_HEADLESS, which the app uses to set a macOS
+		// dock policy and to skip installing the React and Redux DevTools
+		// extensions. Skipping them is what we want: the install reaches out to the
+		// network mid-launch, which is neither deterministic nor any use to a
+		// screenshot. The window is real either way, because Xvfb is a real X server.
+		headless: true,
+		electronArgs: [
+			// Deliberately no --no-sandbox. The container runs as an ordinary user
+			// (see docker/run-capture.sh), so nothing requires it — and it actively
+			// breaks the app: with the sandbox waived, renderers created by a reload
+			// come up without startup data and die on
+			// "Cannot destructure property 'preloadScripts' of 'binding.startupData'",
+			// logging "sandboxed_renderer.bundle.js script failed to run". Every
+			// surface this catalogue reaches by reloading failed on exactly that.
+			//
+			// There is no GPU behind Xvfb, so make the fallback explicit rather than
+			// leave the choice to a probe that can answer differently on different
+			// kernels. --in-process-gpu is deliberately absent too: it collapses the
+			// process model that the preload path above depends on.
+			"--disable-gpu",
+			// The three below exist so the same commit renders to the same bytes.
+			// Without them a run can differ from the previous one by a hair of
+			// antialiasing, and every surface then reports as changed.
+			"--force-device-scale-factor=1",
+			"--disable-lcd-text",
+			"--font-render-hinting=none",
+			// Transitions are the one remaining source of a capture that depends
+			// on when the shutter opened rather than on what the UI shows.
+			"--force-prefers-reduced-motion",
+		],
+	},
+});

--- a/apps/lite/e2e/test.ts
+++ b/apps/lite/e2e/test.ts
@@ -14,7 +14,15 @@ import {
 	seedScenario,
 } from "./setup.ts";
 
-type TestOptions = {
+export type TestOptions = {
+	/**
+	 * Extra Chromium switches for the Electron launch.
+	 *
+	 * Empty for every ordinary run; the container capture config sets the sandbox
+	 * and rasterisation switches Xvfb needs. Keeping them out of the launch below
+	 * means a developer's local run renders the way their machine does.
+	 */
+	electronArgs: Array<string>;
 	scenario: string | null;
 };
 
@@ -30,6 +38,7 @@ const require = createRequire(import.meta.url);
 const electronPath = require("electron") as string;
 
 export const test = base.extend<TestOptions & TestFixtures>({
+	electronArgs: [[], { option: true }],
 	scenario: [null, { option: true }],
 	// Playwright requires an object binding pattern even for fixtures without dependencies.
 	// oxlint-disable-next-line no-empty-pattern
@@ -45,10 +54,15 @@ export const test = base.extend<TestOptions & TestFixtures>({
 			removeLiteTestEnvironment(environment);
 		}
 	},
-	electronApp: async ({ headless, mainProcessLogs, testEnvironment }, provide) => {
+	electronApp: async ({ electronArgs, headless, mainProcessLogs, testEnvironment }, provide) => {
 		const app = await _electron.launch({
 			executablePath: electronPath,
-			args: [`--user-data-dir=${testEnvironment.electronUserDataDir}`, paths.electronMain],
+			args: [
+				`--user-data-dir=${testEnvironment.electronUserDataDir}`,
+				...electronArgs,
+				// Electron takes switches before the entry point, so this stays last.
+				paths.electronMain,
+			],
 			env: processEnvironment({
 				E2E_TEST_APP_DATA_DIR: testEnvironment.appDataDir,
 				GIT_CONFIG_GLOBAL: testEnvironment.gitConfig,

--- a/apps/lite/e2e/tests/screenshots.spec.ts
+++ b/apps/lite/e2e/tests/screenshots.spec.ts
@@ -9,7 +9,7 @@
 // is the caller's job: pairs that are byte-identical between two runs did not
 // change, and only the rest are worth showing a reviewer.
 
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import type { Page } from "@playwright/test";
 import { expect, test } from "../test.ts";
@@ -93,10 +93,11 @@ test.describe("screenshots", () => {
 	// waits for the app to load before its one screenshot; the 30s default is not
 	// enough for that.
 	test.describe.configure({ timeout: 180_000 });
+	// The directory is emptied once per run by the configs' globalSetup, not here:
+	// this hook runs again every time Playwright restarts the worker after a
+	// failure, so clearing in it deletes the surfaces already captured. Creating
+	// the directory is still safe to repeat.
 	test.beforeAll(() => {
-		// Start empty: a PNG left by an earlier run would survive a rerun in which
-		// its surface failed, and be compared as though this run had produced it.
-		rmSync(outputDir, { force: true, recursive: true });
 		mkdirSync(outputDir, { recursive: true });
 	});
 

--- a/apps/lite/package.json
+++ b/apps/lite/package.json
@@ -25,6 +25,7 @@
 		"check": "tsgo -p ui/tsconfig.json --noEmit && tsgo -p electron/tsconfig.json --noEmit && tsgo -p e2e/tsconfig.json --noEmit",
 		"test": "vitest run --config ui/vite.config.ts",
 		"test:e2e": "pnpm prepare-askpass --debug && pnpm build:electron && playwright test --config ./e2e/playwright.config.ts",
+		"screenshots:docker": "bash e2e/docker/capture.sh",
 		"bundle": "pnpm build && pnpm prepare-askpass && electron-builder",
 		"bundle-local": "CHANNEL=${CHANNEL:-} pnpm -F @gitbutler/but-sdk build && CHANNEL=${CHANNEL:-} pnpm bundle -c.mac.entitlements=resources/entitlements.mac.local.plist -c.mac.entitlementsInherit=resources/entitlements.mac.local.plist",
 		"bundle-local-nightly": "CHANNEL=nightly pnpm -F @gitbutler/but-sdk build:release && CHANNEL=nightly pnpm bundle -c.mac.entitlements=resources/entitlements.mac.local.plist -c.mac.entitlementsInherit=resources/entitlements.mac.local.plist",


### PR DESCRIPTION
## 🧢 Changes

Follows up on #15350, and on @samhh's note there that the plan was a second Playwright config running under Docker for cross-platform screenshot support.

- **`apps/lite/e2e/docker/Dockerfile`** — Playwright's `v1.58.2-noble` base (Chromium's shared libraries, Xvfb, fonts), plus a Rust toolchain for `but` and the napi SDK, `libxss1`, `rsync`, and a pinned fallback font set. `LANG=C.UTF-8`, `TZ=UTC`, and a 1600×1000 Xvfb screen.
- **`apps/lite/e2e/docker/run-capture.sh`** — the entrypoint: mirror the checkout, build, capture.
- **`apps/lite/e2e/docker/capture.sh`** — the host wrapper, `capture.sh before` / `capture.sh after`.
- **`apps/lite/e2e/playwright.docker.config.ts`** — the second config. Capture spec only, one worker, two retries, and the Chromium switches.
- **`apps/lite/e2e/test.ts`** — a typed `electronArgs` option, defaulting to empty, spread into the Electron launch.
- **`.github/workflows/lite-screenshots-container-proof.yml`** — **temporary, delete before merge.** Its own commit so it drops cleanly.

## ☕️ Reasoning

**The failure that killed CI capture is container-shaped.** Every abandoned run logged `sandboxed_renderer.bundle.js script failed to run` — Chromium's setuid sandbox failing to initialise. A hosted runner gives no way to change that. A container does, which is why the fix is an image rather than another attempt at the same job.

**The second thing it buys is commensurability.** A before/after pair only means something if both halves were rendered the same way, and font hinting and device scale differ between two contributors' machines before the UI is even considered. With one OS, one font set and one rasteriser, the two halves no longer have to be captured by the same person.

**The host checkout is mounted read-only and mirrored into a volume, not built in place.** A macOS checkout carries a macOS Electron and macOS native modules under `node_modules`, plus a macOS `target/`. `*.node` is excluded from the mirror and the napi SDK rebuilt inside, so the Linux artefact replaces the macOS one rather than racing it. Nothing in a developer's tree is written to.

**The switches are an option on the fixture, not an env var.** They live visibly in the config a reader would look in, and the default path stays byte-identical — which is the same reason #15350 dropped the GPU flags rather than keeping them.

**The whole `screenshots/` directory is mounted, not the one output directory,** because the spec clears its own output directory before capturing and `rm` on a mount point fails with `EBUSY`.

## ⚠️ Unverified

**None of this has run.** There is no container runtime on the machine it was written on — no Docker, Podman, colima or nerdctl. That is what the temporary workflow is for: the claim is specifically about the Linux runners, so a runner is the only place it can be answered.

What has been checked: `pnpm -F @gitbutler/lite check` passes and `--listFiles` confirms the new config is genuinely in the program; `oxlint`, `oxfmt`, `prettier`, `knip:prod` and `knip:non-prod` are clean.

Two risks in the proving run, both about the runner rather than the design:

- **Disk.** A debug build of the workspace plus the ~2GB base image is tight. The workflow reclaims roughly 30GB first; the debug target size is unmeasured.
- **Time.** Cold every run — the volumes that make this cheap locally are empty on an ephemeral runner. `@gitbutler/but-sdk`'s `build` is four cargo invocations, so the SDK compiles twice over. If it times out, trimming the graph variant is the first lever.

## 📌 Follow-ups

- [ ] Delete `lite-screenshots-container-proof.yml` before merge.
- [ ] If the proof is green, real before/after capture in CI becomes possible — and it sidesteps the unapply problem entirely: check out the head SHA and capture, then the base SHA and capture, with no `but unapply` and so no stacked-branch caveat.
- [ ] Lite's host e2e currently fails all three specs with `Error: Process failed to launch!` on this machine, on `master` as well as here. Unrelated to this branch, but it blocks the host capture flow.