### PR TITLE
Lite: use the new commit line tokens for graph rails

### DIFF
--- a/apps/lite/package.json
+++ b/apps/lite/package.json
@@ -135,7 +135,7 @@
 		"@base-ui/react": "^1.6.0",
 		"@base-ui/utils": "^0.3.1",
 		"@gitbutler/but-sdk": "workspace:*",
-		"@gitbutler/design-core": "3.11.4",
+		"@gitbutler/design-core": "3.12.3",
 		"@pierre/diffs": "^1.3.5",
 		"@pierre/theming": "^1.0.1",
 		"@reduxjs/toolkit": "catalog:redux",

--- a/apps/lite/ui/src/components/Badge.module.css
+++ b/apps/lite/ui/src/components/Badge.module.css
@@ -8,10 +8,10 @@
 	border-radius: 10px;
 	--badge-bg-opacity: 20%;
 
-	/* Selected rows set --badge-inverted; flipping to the opposite color scheme
-	   makes every light-dark() token inside the badge resolve to its inverted
-	   value, matching the row's inverted selection background. */
-	@container style(--badge-inverted: true) {
+	/* Selected rows set --selection-inverted; flipping to the opposite color
+	   scheme makes every light-dark() token inside the badge resolve to its
+	   inverted value, matching the row's inverted selection background. */
+	@container style(--selection-inverted: true) {
 		--badge-bg-opacity: 40%;
 		color-scheme: dark;
 

--- a/apps/lite/ui/src/components/Badge.stories.tsx
+++ b/apps/lite/ui/src/components/Badge.stories.tsx
@@ -44,7 +44,7 @@ export const Inverted = meta.story({
 	render: () => (
 		<div
 			style={{
-				["--badge-inverted" as string]: "true",
+				["--selection-inverted" as string]: "true",
 				display: "flex",
 				gap: 8,
 				alignItems: "center",

--- a/apps/lite/ui/src/components/GraphSegment.module.css
+++ b/apps/lite/ui/src/components/GraphSegment.module.css
@@ -6,23 +6,45 @@
 
 	&[data-status="LocalOnly"] {
 		--commit-status-color: var(--commit-local);
+		--commit-line-color: var(--commit-local-line);
 	}
 
 	&[data-status="LocalAndRemote"] {
 		--commit-status-color: var(--commit-remote);
+		--commit-line-color: var(--commit-remote-line);
 	}
 
 	&[data-status="Integrated"] {
 		--commit-status-color: var(--commit-integrated);
+		--commit-line-color: var(--commit-integrated-line);
 	}
 
 	&[data-status="Upstream"] {
 		--commit-status-color: var(--commit-upstream);
+		--commit-line-color: var(--commit-upstream-line);
 	}
 
 	&[data-status="Diverged"] {
 		--commit-status-color: var(--commit-local);
+		--commit-line-color: var(--commit-local-line);
 	}
+
+	/* Selected rows set --selection-inverted; flipping to the opposite color
+	   scheme resolves the line tokens to their inverted values, so the rail
+	   stays legible against the row's inverted selection background. */
+	@container style(--selection-inverted: true) {
+		color-scheme: dark;
+
+		@media (prefers-color-scheme: dark) {
+			color-scheme: light;
+		}
+	}
+}
+
+/* The rail itself is drawn in its own token rather than a faded-out version of
+   the glyph colour, so the line keeps its contrast in both themes. */
+.line {
+	stroke: var(--commit-line-color);
 }
 
 .mainSegment {

--- a/apps/lite/ui/src/components/GraphSegment.tsx
+++ b/apps/lite/ui/src/components/GraphSegment.tsx
@@ -28,7 +28,7 @@ const glyphPaths = {
 
 const commitGlyph = (
 	<>
-		<path opacity="0.4" d="M8 0V11M8 17V28" stroke="currentColor" strokeWidth="1.5" />
+		<path className={styles.line} d="M8 0V11M8 17V28" strokeWidth="1.5" />
 		<path
 			d="M11.5 14C11.5 15.933 9.933 17.5 8 17.5C6.067 17.5 4.5 15.933 4.5 14C4.5 12.067 6.067 10.5 8 10.5C9.933 10.5 11.5 12.067 11.5 14Z"
 			stroke="currentColor"
@@ -42,7 +42,7 @@ const groupRingsPath =
 
 const groupGlyph = (
 	<>
-		<path opacity="0.4" d="M8 0V2.78571M8 17.0038V26" stroke="currentColor" strokeWidth="1.5" />
+		<path className={styles.line} d="M8 0V2.78571M8 17.0038V26" strokeWidth="1.5" />
 		<path d={groupRingsPath} stroke="currentColor" strokeWidth="1.5" />
 	</>
 );
@@ -50,7 +50,7 @@ const groupGlyph = (
 /** The rings without the tail above them, for a row that starts a rail. */
 const groupHeadGlyph = (
 	<>
-		<path opacity="0.4" d="M8 17.0038V26" stroke="currentColor" strokeWidth="1.5" />
+		<path className={styles.line} d="M8 17.0038V26" strokeWidth="1.5" />
 		<path d={groupRingsPath} stroke="currentColor" strokeWidth="1.5" />
 	</>
 );
@@ -109,7 +109,7 @@ export const GraphSegment: FC<GraphSegmentProps> = ({ glyph, className, status, 
 			) : glyph === "groupHead" ? (
 				groupHeadGlyph
 			) : (
-				<path d={glyphPaths[glyph]} opacity="0.4" stroke="currentColor" strokeWidth="1.5" />
+				<path className={styles.line} d={glyphPaths[glyph]} strokeWidth="1.5" />
 			)}
 		</svg>
 
@@ -123,7 +123,7 @@ export const GraphSegment: FC<GraphSegmentProps> = ({ glyph, className, status, 
 				aria-hidden="true"
 				focusable="false"
 			>
-				<path d={glyphPaths.parent} opacity="0.4" stroke="currentColor" strokeWidth="1.5" />
+				<path className={styles.line} d={glyphPaths.parent} strokeWidth="1.5" />
 			</svg>
 		)}
 	</div>

--- a/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
@@ -305,9 +305,9 @@
 	}
 }
 
-/* Flag consumed by Badge.module.css via `@container style()` so badges can
-   restyle themselves for the selected state without cross-module class
-   references. */
+/* Flag consumed via `@container style()` by the components that sit in a row —
+   badges and graph segments — so they can restyle themselves for the selected
+   state without cross-module class references. */
 [data-selection-focus-styles="true"] [data-selection-scope]:focus .containerSelected {
-	--badge-inverted: true;
+	--selection-inverted: true;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -423,8 +423,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/but-sdk
       '@gitbutler/design-core':
-        specifier: 3.11.4
-        version: 3.11.4
+        specifier: 3.12.3
+        version: 3.12.3
       '@pierre/diffs':
         specifier: ^1.3.5
         version: 1.3.5(@shikijs/themes@4.3.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -2051,8 +2051,8 @@ packages:
   '@gitbutler/design-core@2.2.2':
     resolution: {integrity: sha512-oPPnYjwsKxwoTY6wK/fT9ylwhSIBgQxCOGJzYefbM8WFr2OuJePH9MnDnZ3K9UQlb94p+NR7m/QCFzhbDVRwxw==}
 
-  '@gitbutler/design-core@3.11.4':
-    resolution: {integrity: sha512-ZBl47fKw9gP3YKgopIGrskbYv284/O9mlTJMLx+DbIuRZ8jLK9Faj+fARZP8EekXbHqHEV9zwZNp0EU7jj1hOg==}
+  '@gitbutler/design-core@3.12.3':
+    resolution: {integrity: sha512-oMvWcr/Fq6gjR0/rxt/rl/+V427KqBB53paFA586dg/LE57LwFdKMAAWXZ0jLPZlG0gLdhOOavFKMENGd/Jbag==}
 
   '@gitbutler/design-core@3.9.1':
     resolution: {integrity: sha512-kLkZ1+pqeqpBntBOSV53kYVCmY/ZFemjxsWc78GTGLgn1Op8p7bWCNxCUSU822MKLJrzmjUg99MpqdHpXGcNAQ==}
@@ -5278,6 +5278,7 @@ packages:
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@zip.js/zip.js@2.8.11':
     resolution: {integrity: sha512-0fztsk/0ryJ+2PPr9EyXS5/Co7OK8q3zY/xOoozEWaUsL5x+C0cyZ4YyMuUffOO2Dx/rAdq4JMPqW0VUtm+vzA==}
@@ -11341,7 +11342,7 @@ snapshots:
 
   '@gitbutler/design-core@2.2.2': {}
 
-  '@gitbutler/design-core@3.11.4': {}
+  '@gitbutler/design-core@3.12.3': {}
 
   '@gitbutler/design-core@3.9.1': {}
 


### PR DESCRIPTION
The commit graph drew its rails as the glyph colour at `opacity="0.4"`. design-core 3.12.3 ships dedicated tokens for exactly this — `--commit-local-line`, `--commit-remote-line`, `--commit-integrated-line`, `--commit-upstream-line` — so the rails now use those and the opacity is gone. Each is a `light-dark()` pair, so the line keeps its intended contrast in both themes instead of whatever 40% of the glyph colour happened to land on.

Selected rows invert their background, which left the rail reading against the wrong side of that pair. Rows already published a flag for this case (`--badge-inverted`, which Badge answered by flipping `color-scheme` so its `light-dark()` tokens resolved inverted). GraphSegment now answers the same flag rather than growing a parallel mechanism; since badges are no longer the only consumer, the flag is renamed `--selection-inverted`.

### Commits

1. Bump design-core to 3.12.3 to have new line colors and more contrasty bg fill color.
2. Rename the row selection inversion flag — pure rename, no behaviour change
3. Draw the rails in their own colour

### Notes

This follows Badge in keying the inversion off `prefers-color-scheme`, so it tracks the system theme rather than an explicit in-app override, if one exists.

Purely visual — typecheck passes, but the selected-row states are worth eyeballing.

### Screenshots

#### New line colors

<table>
  <thead>
    <tr>
      <th width="80">Theme</th>
      <th width="440">Before</th>
      <th width="440">After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><b>Light</b></td>
      <td><img src="https://github.com/user-attachments/assets/4fd4f9f9-1e06-453a-b513-6a060cb5c8b6" alt="Light theme, rails at 0.4 opacity" width="420" /></td>
      <td><img src="https://github.com/user-attachments/assets/cf1f5375-0c11-45db-9f31-5774e75e51f0" alt="Light theme, rails using the new line tokens" width="420" /></td>
    </tr>
    <tr>
      <td><b>Dark</b></td>
      <td><img src="https://github.com/user-attachments/assets/7bded51c-3fe6-4f07-8a26-1d9c1dcd8dd0" alt="Dark theme, rails at 0.4 opacity" width="420" /></td>
      <td><img src="https://github.com/user-attachments/assets/e19139c4-6187-4c36-8389-08fbd7eae663" alt="Dark theme, rails using the new line tokens" width="420" /></td>
    </tr>
  </tbody>
</table>

#### Contrasty gray bg color

<table>
  <thead>
    <tr>
      <th width="80">Theme</th>
      <th width="440">Before</th>
      <th width="440">After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><b>Light</b></td>
      <td><img src="https://github.com/user-attachments/assets/d7638974-0974-4167-b741-c7d0cf1abca0" alt="Light theme, previous selected-row fill" width="420" /></td>
      <td><img src="https://github.com/user-attachments/assets/1e30b735-5360-48e9-a685-c4176209b75f" alt="Light theme, contrastier selected-row fill" width="420" /></td>
    </tr>
    <tr>
      <td><b>Dark</b></td>
      <td><img src="https://github.com/user-attachments/assets/395a17a9-3718-4135-81ed-d9c690395ff5" alt="Dark theme, previous selected-row fill" width="420" /></td>
      <td><img src="https://github.com/user-attachments/assets/76690376-df7e-4453-9e53-c5f528b7f302" alt="Dark theme, contrastier selected-row fill" width="420" /></td>
    </tr>
  </tbody>
</table>
