### PR TITLE
Preserve PR form when pushing a branch

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -2806,9 +2806,7 @@ const AppliedBranchDetails: FC<BranchDetailsProps> = ({
 			<Suspense fallback={<div className={classes(styles.loadingTab, "text-13")}>Loading…</div>}>
 				{branchTab === "pr" ? (
 					<div className={styles.prTab}>
-						{!forgeInfo?.capabilities.prService ||
-						targetBranch === undefined ||
-						branchCtx?.segment.pushStatus === "completelyUnpushed" ? (
+						{!forgeInfo?.capabilities.prService ? (
 							<PullRequestForm
 								key={branchName}
 								body={null}
@@ -2827,8 +2825,11 @@ const AppliedBranchDetails: FC<BranchDetailsProps> = ({
 							>
 								{({ data }) => {
 									const review = data.reviewsBySourceBranch.get(branchName);
+									const canSubmit =
+										targetBranch !== undefined &&
+										branchCtx?.segment.pushStatus !== "completelyUnpushed";
 
-									return !review ? (
+									return !review || !canSubmit ? (
 										<PullRequestForm
 											key={branchName}
 											body={null}
@@ -2836,7 +2837,7 @@ const AppliedBranchDetails: FC<BranchDetailsProps> = ({
 											reviewId={null}
 											sourceBranch={branchName}
 											title={null}
-											canSubmit
+											canSubmit={canSubmit}
 										/>
 									) : (
 										<ReviewView


### PR DESCRIPTION
## Context

When a completely unpushed branch is pushed from Lite while someone is drafting a pull request, the PR form remounts and can reset in-progress state or focus.

## Change

Keep the review query boundary stable across the push transition so the existing PR form remains mounted while submission becomes enabled and review data updates.

Fixes GB-1833

https://linear.app/gitbutler/issue/GB-1833/pr-form-remounts-on-push