### PR TITLE
Lite Upstream tab: show the pull request a target commit landed

### DIFF
--- a/apps/lite/ui/src/api/queries.ts
+++ b/apps/lite/ui/src/api/queries.ts
@@ -157,14 +157,8 @@ export const workspaceTargetCommitsQueryOptions = (projectId: string) =>
 	});
 
 /**
- * Enough older history to show the section has depth without it crowding out
- * the bands above it on arriving at the tab.
- */
-const olderTargetCommitsFirstPageSize = 10;
-
-/**
- * What each "load more" adds. Larger than the first page: asking for more is
- * deliberate, so it should cover ground rather than need pressing repeatedly.
+ * What each "load older commits" adds. Asking is deliberate, so a page should
+ * cover ground rather than need pressing repeatedly.
  */
 const olderTargetCommitsPageSize = 25;
 
@@ -173,6 +167,10 @@ const olderTargetCommitsPageSize = 25;
  * commit-id cursor. `from` is exclusive: the backend starts at that commit's
  * first parent, so passing the base listing's last commit continues the line
  * without repeating it.
+ *
+ * Fetched only on demand: consumers keep it disabled and call `fetchNextPage`
+ * when the user asks, so nothing below the workspace's fork points loads
+ * unbidden.
  *
  * Keyed under the base listing's own root, so whatever invalidates the target
  * line — a fetch, a workspace update — reaches the pages hanging off it too.
@@ -184,10 +182,9 @@ export const olderTargetCommitsInfiniteQueryOptions = (projectId: string, from: 
 			window.lite.workspaceTargetCommits({
 				projectId,
 				from: pageParam,
-				// The first page is the one nobody asked for, and it is the only
-				// fetch whose cursor is still the one the walk started from.
-				limit: pageParam === from ? olderTargetCommitsFirstPageSize : olderTargetCommitsPageSize,
+				limit: olderTargetCommitsPageSize,
 			}),
+		enabled: false,
 		initialPageParam: from,
 		getNextPageParam: (lastPage) =>
 			lastPage.hasMore ? lastPage.commits.at(-1)?.commit.id : undefined,

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -15,6 +15,7 @@ import {
 	commitConflictsQueryOptions,
 	commitDetailsWithLineStatsQueryOptions,
 	forgeInfoOptions,
+	getReviewQueryOptions,
 	guiSettingsQueryOptions,
 	headInfoQueryOptions,
 	listEditorsQueryOptions,
@@ -22,7 +23,7 @@ import {
 	treeChangeDiffsQueryOptions,
 } from "#ui/api/queries.ts";
 import { decodeBytes } from "#ui/api/bytes.ts";
-import type { ForgeReview } from "@gitbutler/but-sdk";
+import type { ForgeReview, TargetCommitReview } from "@gitbutler/but-sdk";
 import { branchDetailsParams } from "#ui/branch.ts";
 import { commitBody, commitTitle, shortCommitId } from "#ui/commit.ts";
 import {
@@ -2306,10 +2307,12 @@ const CommitDetailsSkeleton: FC = () => {
 
 const CommitDetails: FC<{
 	selection: Extract<Operand, { _tag: "Commit" }>;
+	/** The merged review the commit landed, when known: adds a Pull Request tab. */
+	review?: TargetCommitReview | null;
 	onActiveFileSelection: (itemId: string, firstHunk: HunkOperand | null) => void;
 	viewerRef: RefObject<DiffViewerHandle | null>;
 	didScrollToViaFileRef: RefObject<boolean>;
-}> = ({ selection, onActiveFileSelection, viewerRef, didScrollToViaFileRef }) => {
+}> = ({ selection, review, onActiveFileSelection, viewerRef, didScrollToViaFileRef }) => {
 	const { id: projectId } = useParams({ from: "/project/$id/workspace" });
 	const detailsFullWindow = useAppSelector(interfaceSlice.selectors.selectDetailsFullWindow);
 	const filesVisibleState = useAppSelector((state) =>
@@ -2368,8 +2371,15 @@ const CommitDetails: FC<{
 		setCursor("files", selection);
 	};
 
+	// The tab is per selection: selecting another commit remounts this
+	// component, and a landed review is read, not worked on, so nothing needs
+	// to remember the choice.
+	const [tab, setTab] = useState<BranchTab>("diff");
+	const ref = useRef<HTMLDivElement>(null);
+	useBranchTabHotkeys({ branchTab: tab, setBranchTab: setTab, target: ref, enabled: !!review });
+
 	return (
-		<div className={styles.container}>
+		<div className={styles.container} ref={ref}>
 			<div className={styles.headerWrap}>
 				<div className={styles.titleRow}>
 					{detailsFullWindow && <TopLeftControls />}
@@ -2452,24 +2462,51 @@ const CommitDetails: FC<{
 						copyValue={commitDetails.commit.id}
 					/>
 				</div>
+
+				{review && (
+					<div className={classes(styles.tabsRow, tab === "pr" && styles.tabsRowPrCap)}>
+						<BranchTabToggle branchTab={tab} setBranchTab={setTab} />
+					</div>
+				)}
 			</div>
 
-			<Diff
-				changes={changes}
-				filesVisible={filesVisible}
-				filesItems={filesItems}
-				conflicts={conflicts?.files}
-				manualConflicts={conflicts?.manual}
-				conflictsStale={conflictsStale}
-				onPassiveFileSelection={selectFile}
-				selection={selection}
-				projectId={projectId}
-				onActiveFileSelection={onActiveFileSelection}
-				viewerRef={viewerRef}
-				didScrollToViaFileRef={didScrollToViaFileRef}
-			/>
+			{review && tab === "pr" ? (
+				<div className={styles.prTab}>
+					<LandedReviewView projectId={projectId} reviewId={review.number} />
+				</div>
+			) : (
+				<Diff
+					changes={changes}
+					filesVisible={filesVisible}
+					filesItems={filesItems}
+					conflicts={conflicts?.files}
+					manualConflicts={conflicts?.manual}
+					conflictsStale={conflictsStale}
+					onPassiveFileSelection={selectFile}
+					selection={selection}
+					projectId={projectId}
+					onActiveFileSelection={onActiveFileSelection}
+					viewerRef={viewerRef}
+					didScrollToViaFileRef={didScrollToViaFileRef}
+				/>
+			)}
 		</div>
 	);
+};
+
+/**
+ * A review a target commit landed, fetched by number: the listing only knows
+ * the number, title and link, while the view needs the whole review.
+ */
+const LandedReviewView: FC<{ projectId: string; reviewId: number }> = ({ projectId, reviewId }) => {
+	const { data: review, isError } = useQuery(getReviewQueryOptions({ projectId, reviewId }));
+	if (isError) {
+		return (
+			<div className={classes(styles.loadingTab, "text-13")}>Could not load the pull request.</div>
+		);
+	}
+	if (!review) return <div className={classes(styles.loadingTab, "text-13")}>Loading…</div>;
+	return <ReviewView projectId={projectId} sourceBranch={review.sourceBranch} review={review} />;
 };
 
 /** A branch's own changes, whatever the branch's standing. */
@@ -2954,9 +2991,15 @@ type OutlineDetailsProps = { selection: Operand | null } & DetailsViewProps;
 const commitDetails = (
 	commit: Extract<Operand, { _tag: "Commit" }>,
 	viewProps: DetailsViewProps,
+	review?: TargetCommitReview | null,
 ): ReactNode => (
 	<Suspense fallback={<CommitDetailsSkeleton />}>
-		<CommitDetails key={weakCommitIdentityKey(commit)} selection={commit} {...viewProps} />
+		<CommitDetails
+			key={weakCommitIdentityKey(commit)}
+			selection={commit}
+			review={review}
+			{...viewProps}
+		/>
 	</Suspense>
 );
 
@@ -2977,14 +3020,27 @@ export const WorkspaceDetails: FC<OutlineDetailsProps> = ({ selection, ...viewPr
  * The details pane for the upstream tab. Only commits are selectable there;
  * its branch rows carry no operand.
  */
-export const UpstreamDetails: FC<OutlineDetailsProps> = ({ selection, ...viewProps }) =>
-	selection &&
-	Match.value(selection).pipe(
-		Match.tags({
-			Commit: (commit) => commitDetails(commit, viewProps),
-		}),
-		Match.orElse(() => null),
+export const UpstreamDetails: FC<OutlineDetailsProps & { review: TargetCommitReview | null }> = ({
+	selection,
+	review,
+	...viewProps
+}) => {
+	const { id: projectId } = useParams({ from: "/project/$id/workspace" });
+	// The Pull Request tab fetches the review from the forge, so it is only
+	// offered on a forge that serves them.
+	const { data: forgeInfo } = useQuery(forgeInfoOptions(projectId));
+	const landedReview = forgeInfo?.capabilities.prService ? review : null;
+
+	return (
+		selection &&
+		Match.value(selection).pipe(
+			Match.tags({
+				Commit: (commit) => commitDetails(commit, viewProps, landedReview),
+			}),
+			Match.orElse(() => null),
+		)
 	);
+};
 
 /**
  * The details pane for the branches tab, which lists what the workspace does

--- a/apps/lite/ui/src/routes/project/$id/workspace/UpstreamList.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/UpstreamList.tsx
@@ -272,19 +272,23 @@ const UpdateBlock: FC<{
  * is reported instead, since a silently absent band would read as "no more
  * history" and leave nothing to retry with.
  */
-const LoadMoreOlder: FC<{ projectId: string }> = ({ projectId }) => {
+/**
+ * Asks for the next page of older history. The pages query is disabled, so
+ * this button is the only thing that ever fetches it: the first press opens
+ * the section, later ones extend it.
+ */
+const LoadMoreOlder: FC<{ projectId: string; hasOlder: boolean }> = ({ projectId, hasOlder }) => {
 	// Shares the base listing the outline already reads; this only takes the
 	// cursor its last commit supplies.
 	const { data: olderFrom = null } = useQuery({
 		...workspaceTargetCommitsQueryOptions(projectId),
 		select: (page) => page.commits.at(-1)?.commit.id ?? null,
 	});
-	const { fetchNextPage, hasNextPage, isFetching, isError } = useInfiniteQuery({
-		...olderTargetCommitsInfiniteQueryOptions(projectId, olderFrom ?? ""),
-		enabled: olderFrom !== null,
-	});
+	const { fetchNextPage, isFetching, isError } = useInfiniteQuery(
+		olderTargetCommitsInfiniteQueryOptions(projectId, olderFrom ?? ""),
+	);
 
-	if (!hasNextPage && !isError) return null;
+	if (olderFrom === null || (!hasOlder && !isError)) return null;
 
 	return (
 		<div role="none" className={styles.block}>
@@ -392,6 +396,7 @@ export const UpstreamList: FC<
 		items,
 		incomingItemCount,
 		olderItems,
+		hasOlder,
 		targetLabel,
 		incomingCount,
 		hasIntegrated,
@@ -541,7 +546,7 @@ export const UpstreamList: FC<
 					</div>
 				)}
 
-				<LoadMoreOlder projectId={projectId} />
+				<LoadMoreOlder projectId={projectId} hasOlder={hasOlder} />
 			</div>
 		</div>
 	);

--- a/apps/lite/ui/src/routes/project/$id/workspace/UpstreamList.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/UpstreamList.tsx
@@ -27,7 +27,7 @@ import {
 import { Button } from "@base-ui/react";
 import { useMergedRefs } from "@base-ui/utils/useMergedRefs";
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
-import { type ComponentProps, type FC, type MouseEvent, useRef, useState } from "react";
+import { type ComponentProps, type FC, useRef, useState } from "react";
 import { Row, RowLabel, RowLabelContainer, RowLabelFooter, SectionHeaderRow } from "./Row.tsx";
 import { treeItemId, useIsSelected as useIsSelectedInList } from "./Row-utils.ts";
 import type {
@@ -82,12 +82,6 @@ const TargetCommitRow: FC<{
 
 	const authorName = commit.author.name;
 
-	const openReviewInBrowser = async (evt: MouseEvent<HTMLAnchorElement>): Promise<void> => {
-		evt.preventDefault();
-
-		if (review) await window.lite.openInWebBrowser(review.htmlUrl);
-	};
-
 	return (
 		<Row
 			id={treeItemId(operand)}
@@ -121,16 +115,14 @@ const TargetCommitRow: FC<{
 					</span>
 
 					{review !== null && (
-						<a
-							href={review.htmlUrl}
+						<span
 							title={review.title}
-							onClick={(evt) => void openReviewInBrowser(evt)}
 							className={classes(rowStyles.fadedText, styles.labelMetaItem)}
 						>
 							<Icon name="pr" />
 							{review.unitSymbol}
 							{review.number}
-						</a>
+						</span>
 					)}
 				</RowLabelFooter>
 			</div>

--- a/apps/lite/ui/src/routes/project/$id/workspace/UpstreamList.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/UpstreamList.tsx
@@ -75,7 +75,9 @@ const TargetCommitRow: FC<{
 	const { commit, review, inWorkspace } = item;
 	const operand = commitOperand({ commitId: commit.id, changeId: commit.changeId ?? commit.id });
 	const isSelected = useIsSelected(projectId, operand);
-	const title = commitTitle(commit.message);
+	// A commit that landed a review is shown as that review: its title says
+	// what changed, where "Merge pull request #N from …" only says that it did.
+	const title = review?.title ?? commitTitle(commit.message);
 	const [now] = useState(() => Date.now());
 
 	const authorName = commit.author.name;

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
@@ -73,7 +73,7 @@ import { OperationControls } from "#ui/routes/project/$id/workspace/OperationCon
 import { ErrorBoundary } from "#ui/components/ErrorBoundary.tsx";
 import { Settings } from "./Settings/Settings.tsx";
 import { useBranchesOutline } from "./useBranchesOutline.ts";
-import { useUpstreamOutline } from "./useUpstreamOutline.ts";
+import { upstreamCommitReview, useUpstreamOutline } from "./useUpstreamOutline.ts";
 import type { OutlineMode } from "#ui/outline/mode.ts";
 import { useStateReconciler as useReconcileState } from "#ui/reconcile.ts";
 import {
@@ -582,6 +582,12 @@ const WorkspacePage: FC = () => {
 	// selection came from. Only the workspace page has two lists, so only its arm
 	// asks which one drives. Memoised because `useDeferredValue` compares by
 	// identity, so a freshly built element every render would defer every render.
+	// Looked up outside the memo so the details only rebuild when the review
+	// itself changes, not on every outline rerun.
+	const upstreamReview =
+		upstreamSelection?._tag === "Commit"
+			? upstreamCommitReview(upstreamOutline, upstreamSelection.commitId)
+			: null;
 	const details = useMemo(() => {
 		const viewProps = { onActiveFileSelection, viewerRef, didScrollToViaFileRef };
 
@@ -602,7 +608,7 @@ const WorkspacePage: FC = () => {
 				),
 			),
 			Match.when("upstream", () => (
-				<UpstreamDetails selection={upstreamSelection} {...viewProps} />
+				<UpstreamDetails selection={upstreamSelection} review={upstreamReview} {...viewProps} />
 			)),
 			Match.when("branches", () => (
 				<BranchesDetails selection={branchesSelection} {...viewProps} />
@@ -615,6 +621,7 @@ const WorkspacePage: FC = () => {
 		outlineSelection,
 		outlineTab,
 		uncommittedFilesSelection,
+		upstreamReview,
 		upstreamSelection,
 		workspaceList,
 	]);

--- a/apps/lite/ui/src/routes/project/$id/workspace/useUpstreamOutline.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/useUpstreamOutline.ts
@@ -8,7 +8,7 @@ import { commitOperand, operandIdentityKey, type Operand } from "#ui/operands.ts
 import { projectSlice } from "#ui/projects/state.ts";
 import { useAppSelector } from "#ui/store.ts";
 import { buildIndexByKey, type NavigationIndex } from "#ui/workspace/navigation-index.ts";
-import type { RefInfo, TargetCommit } from "@gitbutler/but-sdk";
+import type { RefInfo, TargetCommit, TargetCommitReview } from "@gitbutler/but-sdk";
 import { useInfiniteQuery, useQueries, useQuery } from "@tanstack/react-query";
 
 // Stable empties for the inactive-tab result, so consumers' identities do not
@@ -97,6 +97,17 @@ export type UpstreamOutline = {
 	 */
 	isPending: boolean;
 	isError: boolean;
+};
+
+/** The review the listing attaches to a commit, wherever the commit sits in it. */
+export const upstreamCommitReview = (
+	outline: UpstreamOutline,
+	commitId: string,
+): TargetCommitReview | null => {
+	const item = [...outline.items, ...outline.olderItems].find(
+		(item) => item.type === "commit" && item.commit.id === commitId,
+	);
+	return item?.type === "commit" ? item.review : null;
 };
 
 type WorkspaceStackBranches = {

--- a/apps/lite/ui/src/routes/project/$id/workspace/useUpstreamOutline.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/useUpstreamOutline.ts
@@ -79,6 +79,8 @@ export type UpstreamOutline = {
 	 * it stays out of the interleaved listing above.
 	 */
 	olderItems: Array<UpstreamCommitItem>;
+	/** Whether older history remains to be asked for below what is shown. */
+	hasOlder: boolean;
 	/** The target's display label, like `origin/main`, or `null` without a target. */
 	targetLabel: string | null;
 	/**
@@ -285,10 +287,11 @@ export const useUpstreamOutline = (projectId: string): UpstreamOutline => {
 		enabled: active,
 		select: (page) => page.commits.at(-1)?.commit.id ?? null,
 	});
-	const { data: olderPages } = useInfiniteQuery({
-		...olderTargetCommitsInfiniteQueryOptions(projectId, olderFrom ?? ""),
-		enabled: active && olderFrom !== null,
-	});
+	// Disabled by its options: pages arrive only once "load older commits"
+	// asked for them, so before that the section stays closed.
+	const { data: olderPages } = useInfiniteQuery(
+		olderTargetCommitsInfiniteQueryOptions(projectId, olderFrom ?? ""),
+	);
 	// The whole derivation lives in `combine` so its result keeps a stable
 	// identity: react-query caches it on the query results and the `combine`
 	// reference — which itself only changes when a captured input like the
@@ -321,6 +324,7 @@ export const useUpstreamOutline = (projectId: string): UpstreamOutline => {
 					items: noItems,
 					incomingItemCount: 0,
 					olderItems: noCommits,
+					hasOlder: false,
 					targetLabel,
 					incomingCount,
 					hasIntegrated: false,
@@ -340,11 +344,17 @@ export const useUpstreamOutline = (projectId: string): UpstreamOutline => {
 			// The paged history continues below the base listing's last commit, so
 			// the run trailing the deepest fork point heads the section those pages
 			// fill out. Leaving it off would open a hole the rail draws across.
+			// The whole section, run included, waits for the first page to be asked
+			// for: on arriving at the tab nothing below the fork points is shown.
 			const olderPageItems = olderPages?.pages.flatMap((page) => page.commits).map(asItem) ?? [];
 			const olderItems =
-				trailingRun.length === 0 && olderPageItems.length === 0
+				olderPages === undefined || (trailingRun.length === 0 && olderPageItems.length === 0)
 					? noCommits
 					: [...trailingRun, ...olderPageItems];
+			const hasOlder =
+				olderPages === undefined
+					? trailingRun.length > 0 || (targetPage?.hasMore ?? false)
+					: (olderPages.pages.at(-1)?.hasMore ?? false);
 
 			// Commit rows are selectable wherever they appear, older ones
 			// included, so the index runs on into the older section and arrow
@@ -374,6 +384,7 @@ export const useUpstreamOutline = (projectId: string): UpstreamOutline => {
 				items,
 				incomingItemCount,
 				olderItems,
+				hasOlder,
 				targetLabel,
 				incomingCount,
 				hasIntegrated: stacks.some((stack) => stack.integrated.length > 0),

--- a/crates/but-api/src/target_commits.rs
+++ b/crates/but-api/src/target_commits.rs
@@ -4,8 +4,10 @@ use std::collections::{HashMap, HashSet};
 
 use crate::json::HexHash;
 use crate::workspace::target_branch_name;
+use bstr::ByteSlice;
 use but_api_macros::but_api;
 use but_forge::ForgeReview;
+use serde::Serialize;
 use tracing::{instrument, warn};
 
 /// The target-commit listing stops after this many commits so degenerate
@@ -32,13 +34,13 @@ const TARGET_COMMITS_PAGE_SIZE: usize = 50;
 /// commits, allowing clients to page through target history older than the
 /// workspace's fork point.
 ///
-/// Each commit is enriched with the cached merged review (PR/MR) it landed,
-/// when the forge cache recorded that commit as the review's integration
-/// commit. This covers merge, squash, and rebase integrations to the extent
-/// the forge reports them; it reads only the local cache and performs no
-/// network requests or diffs, and enrichment failures degrade to unannotated
-/// commits.
-#[but_api(napi, json::TargetCommitPage, provides = [TargetCommits])]
+/// Each commit is enriched with the merged review (PR/MR) it landed, when
+/// the forge cache recorded that commit as the review's integration commit
+/// or, failing that, when the commit's own message names it (see
+/// [`but_forge::merged_review_from_message`]). Enrichment reads only local
+/// state and performs no network requests or diffs, and its failures degrade
+/// to unannotated commits.
+#[but_api(napi, provides = [TargetCommits])]
 #[instrument(err(Debug))]
 pub fn workspace_target_commits(
     ctx: &but_ctx::Context,
@@ -77,17 +79,14 @@ pub fn workspace_target_commits(
 
     let incoming: HashSet<_> = ws.incoming_target_commit_ids()?.into_iter().collect();
     let project_meta = ctx.project_meta()?;
-    let mut reviews_by_integration_sha =
-        match merged_reviews_by_integration_sha(&ws, &project_meta, &db) {
-            Ok(reviews) => reviews,
-            Err(err) => {
-                warn!(
-                    ?err,
-                    "failed to read cached forge reviews; listing target commits without them"
-                );
-                HashMap::new()
-            }
-        };
+    // Review enrichment is best-effort: either source failing leaves the
+    // commits unannotated rather than failing the listing.
+    let mut reviews_by_integration_sha = merged_reviews_by_integration_sha(&ws, &project_meta, &db)
+        .inspect_err(|err| warn!(?err, "failed to read cached forge reviews"))
+        .unwrap_or_default();
+    let forge_info = target_forge_info(&project_meta, &repo)
+        .inspect_err(|err| warn!(?err, "failed to determine the target's forge"))
+        .unwrap_or_default();
 
     let natural_end = match (paging, cursor) {
         (false, Some(tip)) => natural_end_of_line(&repo, &ws, tip)?,
@@ -108,9 +107,13 @@ pub fn workspace_target_commits(
             .parent_ids()
             .next()
             .map(|parent_id| parent_id.detach());
+        let commit: but_workspace::ui::UpstreamCommit = commit.try_into()?;
+        let review = reviews_by_integration_sha
+            .remove(&id)
+            .or_else(|| TargetCommitReview::from_message(&commit, forge_info.as_ref()?));
         commits.push(TargetCommit {
-            commit: commit.try_into()?,
-            review: reviews_by_integration_sha.remove(&id),
+            commit,
+            review,
             in_workspace,
         });
         if !paging
@@ -184,7 +187,9 @@ fn natural_end_of_line(
 }
 
 /// One bounded page of target commits and the state needed to continue it.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Serialize)]
+#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct TargetCommitPage {
     /// The commits in this page, newest first.
     pub commits: Vec<TargetCommit>,
@@ -192,16 +197,98 @@ pub struct TargetCommitPage {
     pub has_more: bool,
 }
 
+#[cfg(feature = "export-schema")]
+but_schemars::register_sdk_type!(TargetCommitPage);
+
 /// A commit on the target branch's first-parent line, its relation to the
-/// workspace, and the cached merged review it landed, if known.
-#[derive(Debug)]
+/// workspace, and the merged review it landed, if known.
+#[derive(Debug, Serialize)]
+#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct TargetCommit {
     /// The commit itself.
     pub commit: but_workspace::ui::UpstreamCommit,
-    /// The merged review this commit integrated, according to the forge cache.
-    pub review: Option<ForgeReview>,
+    /// The merged review this commit integrated, if known.
+    pub review: Option<TargetCommitReview>,
     /// Whether the commit is already reachable from the workspace.
     pub in_workspace: bool,
+}
+
+#[cfg(feature = "export-schema")]
+but_schemars::register_sdk_type!(TargetCommit);
+
+/// The merged review a target commit landed.
+///
+/// Only what the target-commit listing displays; the full review is
+/// available from the per-review APIs. The source branch lets clients match
+/// workspace branches to the commit that landed them; it is empty when
+/// unknown.
+#[derive(Debug, Serialize)]
+#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "camelCase")]
+pub struct TargetCommitReview {
+    /// The number identifying the review within its repository, e.g. `123`.
+    pub number: i64,
+    /// The title of the review.
+    pub title: String,
+    /// The URL to view the review in a web browser.
+    pub html_url: String,
+    /// The forge's symbol for this review type, e.g. `#` for GitHub pull
+    /// requests and `!` for GitLab merge requests. Precedes `number` when
+    /// displayed.
+    pub unit_symbol: String,
+    /// The short name of the branch the review proposed, e.g. `feature-branch`.
+    pub source_branch: String,
+}
+
+#[cfg(feature = "export-schema")]
+but_schemars::register_sdk_type!(TargetCommitReview);
+
+impl From<ForgeReview> for TargetCommitReview {
+    fn from(value: ForgeReview) -> Self {
+        Self {
+            number: value.number,
+            title: value.title,
+            html_url: value.html_url,
+            unit_symbol: value.unit_symbol,
+            source_branch: value.source_branch,
+        }
+    }
+}
+
+impl TargetCommitReview {
+    /// The review the commit's own message says it merged, for commits the
+    /// forge cache has no record of; see [`but_forge::merged_review_from_message`].
+    fn from_message(
+        commit: &but_workspace::ui::UpstreamCommit,
+        forge_info: &but_forge::ForgeInfo,
+    ) -> Option<Self> {
+        let message = commit.message.to_str().ok()?;
+        let review = but_forge::merged_review_from_message(&forge_info.name, message)?;
+        Some(Self {
+            number: review.number,
+            title: review.title.to_owned(),
+            html_url: format!(
+                "{}{}{}",
+                forge_info.base_url, forge_info.pr_url_path, review.number
+            ),
+            unit_symbol: forge_info.unit.symbol.clone(),
+            source_branch: review.source_branch.unwrap_or_default().to_owned(),
+        })
+    }
+}
+
+/// The forge the target remote points at, when known.
+fn target_forge_info(
+    project_meta: &but_core::ref_metadata::ProjectMeta,
+    repo: &gix::Repository,
+) -> anyhow::Result<Option<but_forge::ForgeInfo>> {
+    let remote_url = project_meta.remote_url_with_fallback(repo)?;
+    // Accounts only refine custom hosts; the forge itself is known without them.
+    let accounts = but_forge::get_all_forge_accounts()
+        .inspect_err(|err| warn!(?err, "failed to load forge accounts"))
+        .unwrap_or_default();
+    Ok(but_forge::forge_info(&remote_url, &accounts))
 }
 
 /// Merged reviews targeting the workspace's target branch, keyed by the target
@@ -213,7 +300,7 @@ fn merged_reviews_by_integration_sha(
     ws: &but_graph::Workspace,
     project_meta: &but_core::ref_metadata::ProjectMeta,
     db: &but_db::DbHandle,
-) -> anyhow::Result<HashMap<gix::ObjectId, ForgeReview>> {
+) -> anyhow::Result<HashMap<gix::ObjectId, TargetCommitReview>> {
     let Some(target_branch_name) =
         target_branch_name(&ws.graph.symbolic_remote_names, project_meta)
     else {
@@ -227,102 +314,9 @@ fn merged_reviews_by_integration_sha(
         }
         for sha in &review.integration_commit_shas {
             if let Ok(id) = gix::ObjectId::from_hex(sha.as_bytes()) {
-                reviews_by_sha.insert(id, review.clone());
+                reviews_by_sha.insert(id, review.clone().into());
             }
         }
     }
     Ok(reviews_by_sha)
-}
-
-/// JSON transport types for the target-commit listing.
-pub mod json {
-    use serde::Serialize;
-
-    /// JSON transport type for the cached merged review attached to a
-    /// target commit.
-    ///
-    /// Only what the target-commit listing displays; the full review is
-    /// available from the per-review APIs. `sourceBranch` is included so
-    /// clients can match workspace branches to the commit that landed them.
-    #[derive(Debug, Serialize)]
-    #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-    #[serde(rename_all = "camelCase")]
-    pub struct TargetCommitReview {
-        /// The number identifying the review within its repository, e.g. `123`.
-        pub number: i64,
-        /// The title of the review.
-        pub title: String,
-        /// The URL to view the review in a web browser.
-        pub html_url: String,
-        /// The forge's symbol for this review type, e.g. `#` for GitHub pull
-        /// requests and `!` for GitLab merge requests. Precedes `number` when
-        /// displayed.
-        pub unit_symbol: String,
-        /// The short name of the branch the review proposed, e.g. `feature-branch`.
-        pub source_branch: String,
-    }
-
-    #[cfg(feature = "export-schema")]
-    but_schemars::register_sdk_type!(TargetCommitReview);
-
-    impl From<but_forge::ForgeReview> for TargetCommitReview {
-        fn from(value: but_forge::ForgeReview) -> Self {
-            Self {
-                number: value.number,
-                title: value.title,
-                html_url: value.html_url,
-                unit_symbol: value.unit_symbol,
-                source_branch: value.source_branch,
-            }
-        }
-    }
-
-    /// JSON transport type for a commit on the target branch's first-parent line.
-    #[derive(Debug, Serialize)]
-    #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-    #[serde(rename_all = "camelCase")]
-    pub struct TargetCommit {
-        /// The commit itself.
-        pub commit: but_workspace::ui::UpstreamCommit,
-        /// The merged review this commit integrated, if the forge cache knows it.
-        pub review: Option<TargetCommitReview>,
-        /// Whether the commit is already reachable from the workspace.
-        pub in_workspace: bool,
-    }
-
-    #[cfg(feature = "export-schema")]
-    but_schemars::register_sdk_type!(TargetCommit);
-
-    impl From<super::TargetCommit> for TargetCommit {
-        fn from(value: super::TargetCommit) -> Self {
-            Self {
-                commit: value.commit,
-                review: value.review.map(Into::into),
-                in_workspace: value.in_workspace,
-            }
-        }
-    }
-
-    /// A bounded page from the target branch's first-parent history.
-    #[derive(Debug, Serialize)]
-    #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
-    #[serde(rename_all = "camelCase")]
-    pub struct TargetCommitPage {
-        /// The commits in this page, newest first.
-        pub commits: Vec<TargetCommit>,
-        /// Whether the relative walk was clipped before its natural bound.
-        pub has_more: bool,
-    }
-
-    #[cfg(feature = "export-schema")]
-    but_schemars::register_sdk_type!(TargetCommitPage);
-
-    impl From<super::TargetCommitPage> for TargetCommitPage {
-        fn from(value: super::TargetCommitPage) -> Self {
-            Self {
-                commits: value.commits.into_iter().map(Into::into).collect(),
-                has_more: value.has_more,
-            }
-        }
-    }
 }

--- a/crates/but-api/tests/api/target_commits.rs
+++ b/crates/but-api/tests/api/target_commits.rs
@@ -71,6 +71,82 @@ fn reports_clipping_and_accepts_a_zero_limit() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Without a forge cache entry, a GitHub merge-button commit still names the
+/// pull request it landed, read from its own message.
+#[test]
+fn github_merge_commit_names_its_pull_request_from_the_message() -> anyhow::Result<()> {
+    let (repo, tmp) = repo_with_feature_branch()?;
+    git_at_dir(tmp.path())
+        .args([
+            "config",
+            "remote.origin.url",
+            "git@github.com:owner/repo.git",
+        ])
+        .run();
+    write_file(tmp.path(), "file.txt", "three\n")?;
+    git_at_dir(tmp.path())
+        .args([
+            "commit",
+            "-am",
+            "Merge pull request #42 from owner/topic\n\nAdd the third line\n",
+        ])
+        .run();
+    git_at_dir(tmp.path())
+        .args(["update-ref", "refs/remotes/origin/main", "HEAD"])
+        .run();
+    git_at_dir(tmp.path()).args(["switch", "feature"]).run();
+    git_at_dir(tmp.path())
+        .args(["switch", "-c", "gitbutler/workspace"])
+        .run();
+    git_at_dir(tmp.path())
+        .args([
+            "commit",
+            "--allow-empty",
+            "-m",
+            "GitButler Workspace Commit",
+        ])
+        .run();
+    drop(repo);
+
+    let mut ctx =
+        but_ctx::Context::from_repo_for_testing(open_repo(tmp.path())?)?.with_memory_app_cache();
+    let target_ref = gix::refs::FullName::try_from("refs/remotes/origin/main")?;
+    but_api::workspace::set_target_ref_and_init_project(&mut ctx, target_ref.as_ref(), None)?;
+
+    let page = but_api::target_commits::workspace_target_commits(&ctx, None, None)?;
+    let reviews: Vec<_> = page
+        .commits
+        .iter()
+        .map(|commit| {
+            commit.review.as_ref().map(|review| {
+                (
+                    review.number,
+                    review.title.as_str(),
+                    review.html_url.as_str(),
+                    review.unit_symbol.as_str(),
+                    review.source_branch.as_str(),
+                )
+            })
+        })
+        .collect();
+    assert_eq!(
+        reviews,
+        [
+            Some((
+                42,
+                "Add the third line",
+                "https://github.com/owner/repo/pull/42",
+                "#",
+                "topic"
+            )),
+            None,
+            None,
+        ],
+        "only the merge commit names a review; plain commits stay unannotated"
+    );
+    Ok(())
+}
+
 /// A still-applied stack landed upstream through a merge commit: the workspace
 /// lower bound becomes the stack tip, which sits on the merge's *second*
 /// parent and is never met by the first-parent walk. The stack's base bounds

--- a/crates/but-forge/src/lib.rs
+++ b/crates/but-forge/src/lib.rs
@@ -8,6 +8,8 @@ mod ci;
 mod db;
 pub use db::list_cached_forge_reviews;
 mod forge_info;
+mod merge_message;
+pub use merge_message::{MergedReviewFromMessage, merged_review_from_message};
 mod repo;
 mod review;
 pub use association::{pr_numbers_by_head, preferred_review, review_for_head_ref, reviews_by_head};

--- a/crates/but-forge/src/merge_message.rs
+++ b/crates/but-forge/src/merge_message.rs
@@ -1,0 +1,155 @@
+//! Reading the review a forge-authored merge commit message says it landed.
+
+use crate::ForgeName;
+
+/// The review a forge's own merge commit message names, read from the
+/// message alone.
+#[derive(Debug, PartialEq, Eq)]
+pub struct MergedReviewFromMessage<'a> {
+    /// The review number, e.g. `123` in `Merge pull request #123 from …`.
+    pub number: i64,
+    /// The review title, when the message carries it.
+    pub title: &'a str,
+    /// The branch the review proposed, when the message carries it.
+    pub source_branch: Option<&'a str>,
+}
+
+/// Best-effort recognition of the commit messages a forge writes when it
+/// merges a review, so target commits can name their review without the
+/// forge cache knowing about it. Handles GitHub's merge-button message
+/// (`Merge pull request #N from owner/branch` with the title as body) and
+/// its squash-merge subject (`title (#N)`); rebase merges leave no trace.
+/// Being message-based, it trusts what the message says: an edited merge
+/// body or a hand-written `(#N)` issue reference is taken at face value.
+/// Other forges are not recognised yet.
+pub fn merged_review_from_message<'a>(
+    forge: &ForgeName,
+    message: &'a str,
+) -> Option<MergedReviewFromMessage<'a>> {
+    match forge {
+        ForgeName::GitHub => github_merged_review(message),
+        ForgeName::GitLab | ForgeName::Bitbucket | ForgeName::Azure => None,
+    }
+}
+
+fn github_merged_review(message: &str) -> Option<MergedReviewFromMessage<'_>> {
+    let (subject, body) = message.split_once('\n').unwrap_or((message, ""));
+    let subject = subject.trim_end();
+
+    if let Some(rest) = subject.strip_prefix("Merge pull request #") {
+        let (number, head) = rest.split_once(" from ")?;
+        let number = review_number(number)?;
+        // The head is `owner:branch` for forks in older messages and
+        // `owner/branch` otherwise; either way the branch follows the owner
+        // and ends at the first whitespace, should the subject have been edited.
+        let head = head.split_whitespace().next()?;
+        let source_branch = head.split_once(['/', ':']).map(|(_, branch)| branch);
+        // GitHub puts the pull request title as the first paragraph of the body.
+        let title = body.trim().lines().next().unwrap_or("").trim();
+        return Some(MergedReviewFromMessage {
+            number,
+            title: if title.is_empty() { subject } else { title },
+            source_branch,
+        });
+    }
+
+    let (title, suffix) = subject.rsplit_once(" (#")?;
+    let number = review_number(suffix.strip_suffix(')')?)?;
+    (!title.is_empty()).then_some(MergedReviewFromMessage {
+        number,
+        title,
+        source_branch: None,
+    })
+}
+
+/// Digits only: `i64::from_str` would also accept a sign.
+fn review_number(digits: &str) -> Option<i64> {
+    (!digits.is_empty() && digits.bytes().all(|b| b.is_ascii_digit()))
+        .then(|| digits.parse().ok())
+        .flatten()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn github_merge_button_message() {
+        let message = "Merge pull request #15383 from gitbutlerapp/lite-graph-rails\n\nLite: use the new commit line tokens for graph rails\n";
+        assert_eq!(
+            merged_review_from_message(&ForgeName::GitHub, message),
+            Some(MergedReviewFromMessage {
+                number: 15383,
+                title: "Lite: use the new commit line tokens for graph rails",
+                source_branch: Some("lite-graph-rails"),
+            })
+        );
+    }
+
+    #[test]
+    fn github_merge_button_message_without_body_keeps_subject_as_title() {
+        assert_eq!(
+            merged_review_from_message(
+                &ForgeName::GitHub,
+                "Merge pull request #7 from bob:fix/typo"
+            ),
+            Some(MergedReviewFromMessage {
+                number: 7,
+                title: "Merge pull request #7 from bob:fix/typo",
+                source_branch: Some("fix/typo"),
+            })
+        );
+    }
+
+    #[test]
+    fn github_merge_button_message_with_edited_subject_keeps_the_branch_name() {
+        assert_eq!(
+            merged_review_from_message(&ForgeName::GitHub, "Merge pull request #12 from a/b (#3)")
+                .map(|review| review.source_branch),
+            Some(Some("b")),
+        );
+    }
+
+    #[test]
+    fn github_squash_merge_subject() {
+        assert_eq!(
+            merged_review_from_message(
+                &ForgeName::GitHub,
+                "Fix the thing (#42)\n\n* first\n* second"
+            ),
+            Some(MergedReviewFromMessage {
+                number: 42,
+                title: "Fix the thing",
+                source_branch: None,
+            })
+        );
+    }
+
+    #[test]
+    fn unrelated_messages_and_other_forges_are_not_recognised() {
+        for message in [
+            "Fix the thing",
+            "Merge branch 'feature' into main",
+            "Merge pull request from nowhere",
+            "Merge pull request #x from a/b",
+            "Merge pull request #-1 from a/b",
+            "Refers to (#12) somewhere",
+            "Bump deps (#-3)",
+            " (#42)",
+        ] {
+            assert_eq!(
+                merged_review_from_message(&ForgeName::GitHub, message),
+                None,
+                "{message:?} names no review"
+            );
+        }
+        assert_eq!(
+            merged_review_from_message(
+                &ForgeName::GitLab,
+                "Merge pull request #1 from a/b\n\ntitle"
+            ),
+            None,
+            "only GitHub's message shapes are recognised"
+        );
+    }
+}

--- a/packages/but-sdk/src/generated/graph/index.d.ts
+++ b/packages/but-sdk/src/generated/graph/index.d.ts
@@ -1106,12 +1106,12 @@ export declare function workspaceIntegrateUpstream(projectId: string, updates: A
  * commits, allowing clients to page through target history older than the
  * workspace's fork point.
  *
- * Each commit is enriched with the cached merged review (PR/MR) it landed,
- * when the forge cache recorded that commit as the review's integration
- * commit. This covers merge, squash, and rebase integrations to the extent
- * the forge reports them; it reads only the local cache and performs no
- * network requests or diffs, and enrichment failures degrade to unannotated
- * commits.
+ * Each commit is enriched with the merged review (PR/MR) it landed, when
+ * the forge cache recorded that commit as the review's integration commit
+ * or, failing that, when the commit's own message names it (see
+ * [`but_forge::merged_review_from_message`]). Enrichment reads only local
+ * state and performs no network requests or diffs, and its failures degrade
+ * to unannotated commits.
  */
 export declare function workspaceTargetCommits(projectId: string, from: string | null, limit: number | null): Promise<TargetCommitPage>
 export declare class WatcherHandle {
@@ -3719,17 +3719,20 @@ export type Target = {
   isCurrent: boolean;
 };
 
-/** JSON transport type for a commit on the target branch's first-parent line. */
+/**
+ * A commit on the target branch's first-parent line, its relation to the
+ * workspace, and the merged review it landed, if known.
+ */
 export type TargetCommit = {
   /** The commit itself. */
   commit: UpstreamCommit;
-  /** The merged review this commit integrated, if the forge cache knows it. */
+  /** The merged review this commit integrated, if known. */
   review: TargetCommitReview | null;
   /** Whether the commit is already reachable from the workspace. */
   inWorkspace: boolean;
 };
 
-/** A bounded page from the target branch's first-parent history. */
+/** One bounded page of target commits and the state needed to continue it. */
 export type TargetCommitPage = {
   /** The commits in this page, newest first. */
   commits: Array<TargetCommit>;
@@ -3738,12 +3741,12 @@ export type TargetCommitPage = {
 };
 
 /**
- * JSON transport type for the cached merged review attached to a
- * target commit.
+ * The merged review a target commit landed.
  *
  * Only what the target-commit listing displays; the full review is
- * available from the per-review APIs. `sourceBranch` is included so
- * clients can match workspace branches to the commit that landed them.
+ * available from the per-review APIs. The source branch lets clients match
+ * workspace branches to the commit that landed them; it is empty when
+ * unknown.
  */
 export type TargetCommitReview = {
   /** The number identifying the review within its repository, e.g. `123`. */

--- a/packages/but-sdk/src/generated/linear/index.d.ts
+++ b/packages/but-sdk/src/generated/linear/index.d.ts
@@ -1106,12 +1106,12 @@ export declare function workspaceIntegrateUpstream(projectId: string, updates: A
  * commits, allowing clients to page through target history older than the
  * workspace's fork point.
  *
- * Each commit is enriched with the cached merged review (PR/MR) it landed,
- * when the forge cache recorded that commit as the review's integration
- * commit. This covers merge, squash, and rebase integrations to the extent
- * the forge reports them; it reads only the local cache and performs no
- * network requests or diffs, and enrichment failures degrade to unannotated
- * commits.
+ * Each commit is enriched with the merged review (PR/MR) it landed, when
+ * the forge cache recorded that commit as the review's integration commit
+ * or, failing that, when the commit's own message names it (see
+ * [`but_forge::merged_review_from_message`]). Enrichment reads only local
+ * state and performs no network requests or diffs, and its failures degrade
+ * to unannotated commits.
  */
 export declare function workspaceTargetCommits(projectId: string, from: string | null, limit: number | null): Promise<TargetCommitPage>
 export declare class WatcherHandle {
@@ -3719,17 +3719,20 @@ export type Target = {
   isCurrent: boolean;
 };
 
-/** JSON transport type for a commit on the target branch's first-parent line. */
+/**
+ * A commit on the target branch's first-parent line, its relation to the
+ * workspace, and the merged review it landed, if known.
+ */
 export type TargetCommit = {
   /** The commit itself. */
   commit: UpstreamCommit;
-  /** The merged review this commit integrated, if the forge cache knows it. */
+  /** The merged review this commit integrated, if known. */
   review: TargetCommitReview | null;
   /** Whether the commit is already reachable from the workspace. */
   inWorkspace: boolean;
 };
 
-/** A bounded page from the target branch's first-parent history. */
+/** One bounded page of target commits and the state needed to continue it. */
 export type TargetCommitPage = {
   /** The commits in this page, newest first. */
   commits: Array<TargetCommit>;
@@ -3738,12 +3741,12 @@ export type TargetCommitPage = {
 };
 
 /**
- * JSON transport type for the cached merged review attached to a
- * target commit.
+ * The merged review a target commit landed.
  *
  * Only what the target-commit listing displays; the full review is
- * available from the per-review APIs. `sourceBranch` is included so
- * clients can match workspace branches to the commit that landed them.
+ * available from the per-review APIs. The source branch lets clients match
+ * workspace branches to the commit that landed them; it is empty when
+ * unknown.
  */
 export type TargetCommitReview = {
   /** The number identifying the review within its repository, e.g. `123`. */


### PR DESCRIPTION
The Upstream tab lists target-branch commits, which on a merge-button repo are a wall of "Merge pull request #N from …". Rows already carried the merged review when the forge cache had recorded the integration commit, but the cache only holds open reviews plus the few merged ones fetched per integrated branch, so most rows showed nothing.

When the cache has no match, the listing now reads GitHub's own merge-button and squash-merge message shapes (number, title, source branch) and builds the review link from the project's forge info — no network, no extra fetches. Lite shows the review title as the row label when one is known, with the `#N` link next to it. Other forges keep the cache-only path.

- `but_forge::merged_review_from_message` — GitHub-only, plain string ops, digits-only numbers; unmatched messages yield nothing.
- `TargetCommitReview` is now the domain type built from either source; the field-identical `json` mirror module in `target_commits.rs` is removed.
- Enrichment stays best-effort: a missing target remote or unreadable forge settings logs and leaves rows unannotated instead of failing the listing.


FYI @PavelLaptev 

<img width="579" height="668" alt="image" src="https://github.com/user-attachments/assets/ed1d3073-0da9-4f83-83eb-73651ccc651a" />
