### PR TITLE
Respect the singleBranch flag when all applied stacks integrate

### DIFF
--- a/crates/but-api/src/workspace.rs
+++ b/crates/but-api/src/workspace.rs
@@ -532,6 +532,7 @@ pub fn workspace_integrate_upstream_only_with_perm(
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<WorkspaceIntegrateUpstreamOutcome> {
     let mut meta = ctx.meta()?;
+    let single_branch_mode = ctx.settings.feature_flags.single_branch;
     let (workspace_state, worktree_conflicts) = {
         let project_meta = ctx.project_meta()?;
         let (repo, mut ws, mut db) = ctx.workspace_mut_and_db_mut_with_perm(perm)?;
@@ -557,6 +558,7 @@ pub fn workspace_integrate_upstream_only_with_perm(
             &mut db,
             updates,
             &review_hints,
+            single_branch_mode,
         )?;
         let worktree_conflicts = but_workspace::worktree_conflicts_for_rebase(&rebase)?;
 

--- a/crates/but-workspace/src/upstream_integration.rs
+++ b/crates/but-workspace/src/upstream_integration.rs
@@ -150,6 +150,9 @@ struct Stack {
 ///   and those that are. These edges get replaced with edges to `target.ref`
 /// - We replace all steps marked as `content_integrated` that are not
 ///   `historically_integrated` with `None` steps.
+///
+/// This variant uses no review hints and never swaps an emptied managed workspace for a canned
+/// branch; see [`integrate_upstream_with_hints()`] for both.
 pub fn integrate_upstream<'ws, 'meta, M: RefMetadata>(
     workspace: &'ws mut but_graph::Workspace,
     meta: &'meta mut M,
@@ -158,11 +161,16 @@ pub fn integrate_upstream<'ws, 'meta, M: RefMetadata>(
     db: &'meta mut but_db::DbHandle,
     updates: Vec<BottomUpdate>,
 ) -> Result<IntegrateUpstreamOutcome<'ws, 'meta, M>> {
-    integrate_upstream_with_hints(workspace, meta, project_meta, repo, db, updates, &[])
+    integrate_upstream_with_hints(workspace, meta, project_meta, repo, db, updates, &[], false)
 }
 
 /// Like [`integrate_upstream()`], but accepts merged-review-derived integration
 /// anchors to classify additional integrated history.
+///
+/// With `single_branch_mode`, a managed workspace whose applied stacks were all integrated is
+/// replaced by a checked-out canned branch at the target tip. Otherwise the emptied managed
+/// workspace stays checked out, reparented onto the target.
+#[allow(clippy::too_many_arguments)]
 pub fn integrate_upstream_with_hints<'ws, 'meta, M: RefMetadata>(
     workspace: &'ws mut but_graph::Workspace,
     meta: &'meta mut M,
@@ -171,6 +179,7 @@ pub fn integrate_upstream_with_hints<'ws, 'meta, M: RefMetadata>(
     db: &'meta mut but_db::DbHandle,
     updates: Vec<BottomUpdate>,
     review_hints: &[ReviewIntegrationHint],
+    single_branch_mode: bool,
 ) -> Result<IntegrateUpstreamOutcome<'ws, 'meta, M>> {
     if matches!(workspace.kind, but_graph::workspace::WorkspaceKind::AdHoc)
         && workspace.ref_name().is_none()
@@ -421,10 +430,13 @@ pub fn integrate_upstream_with_hints<'ws, 'meta, M: RefMetadata>(
                     *parent_order,
                 )?;
             }
-            [] if !fully_integrated_workspace_parents.is_empty() && stacks.len() > 1 => {
-                // A managed workspace must not become empty. Replace its checkout with a fresh
-                // ad-hoc branch at the latest target tip, just like a fully integrated direct
-                // checkout.
+            [] if !fully_integrated_workspace_parents.is_empty()
+                && stacks.len() > 1
+                && single_branch_mode =>
+            {
+                // In single-branch mode a managed workspace must not become empty. Replace its
+                // checkout with a uniquely named canned branch at the latest target tip, just
+                // like a fully integrated direct checkout.
                 let workspace_ref_name = workspace_ref_name
                     .as_ref()
                     .map(|name| name.as_ref())
@@ -437,7 +449,7 @@ pub fn integrate_upstream_with_hints<'ws, 'meta, M: RefMetadata>(
                 )?;
             }
             [] if !fully_integrated_workspace_parents.is_empty() => {
-                // A single integrated stack retains the existing empty managed workspace.
+                // Otherwise the existing empty managed workspace is retained.
                 editor.add_edge(workspace_commit_selector, target_ref_selector, 0)?;
             }
             _ => {}

--- a/crates/but-workspace/tests/workspace/upstream_integration.rs
+++ b/crates/but-workspace/tests/workspace/upstream_integration.rs
@@ -1706,6 +1706,7 @@ fn local_only_empty_direct_checkout_is_preserved() -> Result<()> {
             head_commit_at_merge: repo.rev_parse_single("topic")?.detach(),
             source_branch: "topic".into(),
         }],
+        false,
     )?;
     rebase.materialize(Default::default())?;
 
@@ -1765,6 +1766,7 @@ fn empty_direct_checkout_with_merged_review_for_pushed_branch_is_replaced() -> R
             head_commit_at_merge: review_head,
             source_branch: "pushed-topic".into(),
         }],
+        false,
     )?;
     out.rebase.materialize(Default::default())?;
 
@@ -1826,6 +1828,7 @@ fn empty_direct_checkout_ignores_same_named_review_for_different_head() -> Resul
             head_commit_at_merge: target_tip,
             source_branch: "pushed-topic".into(),
         }],
+        false,
     )?;
     out.rebase.materialize(Default::default())?;
 
@@ -2456,7 +2459,7 @@ fn fully_integrated_two_stacks_checkout_canned_branch_at_target_tip() -> Result<
     );
 
     let mut db = but_testsupport::in_memory_db();
-    let out = integrate_upstream(
+    let out = integrate_upstream_with_hints(
         &mut workspace,
         &mut meta,
         project_meta,
@@ -2472,6 +2475,8 @@ fn fully_integrated_two_stacks_checkout_canned_branch_at_target_tip() -> Result<
                 selector: RelativeTo::Commit(repo.rev_parse_single("B")?.detach()),
             },
         ],
+        &[],
+        true,
     )?;
 
     let preview = out.rebase.overlayed_graph()?.into_workspace()?;
@@ -2497,6 +2502,76 @@ fn fully_integrated_two_stacks_checkout_canned_branch_at_target_tip() -> Result<
     );
     assert_eq!(repo.find_reference(fallback_ref.as_ref())?.id(), target_tip);
     assert_eq!(repo.head_name()?, Some(fallback_ref));
+
+    Ok(())
+}
+
+#[test]
+fn fully_integrated_two_stacks_keep_managed_workspace_outside_single_branch_mode() -> Result<()> {
+    let (_tmp, repo, mut meta, _description) =
+        named_writable_scenario_with_description("fully-integrated-two-stacks")?;
+    let target_sha = repo.rev_parse_single("main~2")?.detach();
+
+    let project_meta = target_project_meta("refs/remotes/origin/main", target_sha)?;
+    add_stack(&mut meta, 1, "A", StackState::InWorkspace);
+    add_stack(&mut meta, 2, "B", StackState::InWorkspace);
+    let graph = but_graph::Graph::from_head(
+        &repo,
+        &meta,
+        project_meta.clone(),
+        Options {
+            extra_target_commit_id: Some(target_sha),
+            ..Options::limited()
+        },
+    )?;
+    let mut workspace = graph.into_workspace()?;
+
+    let project_meta = integrate_and_materialize(
+        &mut workspace,
+        &mut meta,
+        &repo,
+        vec![
+            BottomUpdate {
+                kind: BottomUpdateKind::Rebase,
+                selector: RelativeTo::Commit(repo.rev_parse_single("A")?.detach()),
+            },
+            BottomUpdate {
+                kind: BottomUpdateKind::Rebase,
+                selector: RelativeTo::Commit(repo.rev_parse_single("B")?.detach()),
+            },
+        ],
+    )?;
+
+    let meta = empty_managed_workspace_metadata(&meta)?;
+    let graph =
+        but_graph::Graph::from_head(&repo, &meta, project_meta.clone(), Options::limited())?;
+    let workspace = graph.into_workspace()?;
+    // Without single-branch mode the emptied managed workspace stays checked out at the target.
+    snapbox::assert_data_eq!(
+        graph_workspace(&workspace).to_string(),
+        snapbox::str![[r#"
+📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 5f7d45e
+
+"#]]
+    );
+    snapbox::assert_data_eq!(
+        visualize_commit_graph_all(&repo)?,
+        snapbox::str![[r#"
+* b44fd24 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+*   5f7d45e (origin/main, main) Merging B into base
+|\  
+| * b38b04b add B1
+* |   1f7670a Merging A into base
+|\ \  
+| |/  
+|/|   
+| * 905d6e5 add A1
+|/  
+* 3183e43 M1
+
+"#]]
+        .raw()
+    );
 
     Ok(())
 }
@@ -3091,7 +3166,7 @@ fn fully_integrated_two_stacks_checkout_canned_branch_at_merge_target() -> Resul
     let mut workspace = graph.into_workspace()?;
 
     let mut db = but_testsupport::in_memory_db();
-    let out = integrate_upstream(
+    let out = integrate_upstream_with_hints(
         &mut workspace,
         &mut meta,
         project_meta,
@@ -3107,6 +3182,8 @@ fn fully_integrated_two_stacks_checkout_canned_branch_at_merge_target() -> Resul
                 selector: RelativeTo::Commit(repo.rev_parse_single("B")?.detach()),
             },
         ],
+        &[],
+        true,
     )?;
     out.rebase.materialize(Default::default())?;
 
@@ -3162,6 +3239,7 @@ fn review_hint_fully_integrates_direct_checkout_branch() -> Result<()> {
             head_commit_at_merge: review_head,
             source_branch: "A".into(),
         }],
+        false,
     )?;
     out.rebase.materialize(Default::default())?;
 
@@ -3249,6 +3327,7 @@ fn review_hint_integrates_squashed_two_commit_stack_in_managed_workspace() -> Re
             head_commit_at_merge: review_head,
             source_branch: "A".into(),
         }],
+        false,
     )?;
     out.rebase.materialize(Default::default())?;
 
@@ -3359,6 +3438,7 @@ fn review_hint_integrates_squashed_two_commit_direct_checkout_branch() -> Result
             head_commit_at_merge: review_head,
             source_branch: "A".into(),
         }],
+        false,
     )?;
     out.rebase.materialize(Default::default())?;
     let graph = but_graph::Graph::from_head(&repo, &meta, project_meta, Options::limited())?;
@@ -3559,6 +3639,7 @@ fn review_hint_integrates_squashed_prefix_and_keeps_extra_commit_in_direct_check
             head_commit_at_merge: review_head,
             source_branch: "A".into(),
         }],
+        false,
     )?;
     rebase.materialize(Default::default())?;
 
@@ -3652,6 +3733,7 @@ fn review_hint_integrates_prefix_but_keeps_extra_local_commit() -> Result<()> {
             head_commit_at_merge: review_head,
             source_branch: "A".into(),
         }],
+        false,
     )?;
     out.rebase.materialize(Default::default())?;
 
@@ -3738,6 +3820,7 @@ fn integrate_with_hints_and_materialize<M: RefMetadata>(
         &mut db,
         updates,
         review_hints,
+        false,
     )?;
     let materialized = rebase.materialize(Default::default())?;
     if let Some(ref_name) = materialized.workspace.ref_name()

--- a/crates/but/tests/but/command/pull.rs
+++ b/crates/but/tests/but/command/pull.rs
@@ -670,6 +670,38 @@ Hint: run `but help` for all commands
 }
 
 #[test]
+fn pull_keeps_empty_workspace_after_all_stacks_integrate_outside_single_branch_mode() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("pull-two-integrated-stacks");
+    env.setup_metadata_at_target(&["A", "B"], "origin/main");
+    env.but("config feature single-branch disable")
+        .assert()
+        .success();
+
+    env.but("pull").assert().success();
+
+    env.but("status").assert().success().stdout_eq(str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┴ 7e5d4e1 (common base) 2000-01-02 add upstream
+
+Hint: run `but branch new` to create a new branch to work on
+
+"#]]);
+
+    assert_eq!(
+        env.invoke_git("symbolic-ref --short HEAD"),
+        "gitbutler/workspace",
+        "outside single-branch mode the managed workspace stays checked out"
+    );
+    assert_eq!(
+        rev_parse(&env, "gitbutler/workspace^"),
+        rev_parse(&env, "origin/main"),
+        "the emptied workspace is reparented onto the advanced target"
+    );
+    assert_eq!(status_stack_count(&env), 0);
+}
+
+#[test]
 fn pull_reparents_empty_workspace_when_target_advances() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
     env.setup_metadata_at_target(&[], "origin/main");

--- a/e2e/playwright/tests/upstreamIntegration.spec.ts
+++ b/e2e/playwright/tests/upstreamIntegration.spec.ts
@@ -27,24 +27,6 @@ async function expectWorkspaceCommitParentToBeOriginMaster(pathToRepo: string) {
 		.toBe(git(pathToRepo, ["rev-parse", "origin/master"]));
 }
 
-async function expectAdHocBranchAtOriginMaster(pathToRepo: string): Promise<string> {
-	await expect
-		.poll(() => git(pathToRepo, ["symbolic-ref", "--short", "HEAD"]), {
-			message: "Expected a regular branch to be checked out",
-			intervals: [100, 200, 500, 1000],
-		})
-		.not.toBe("gitbutler/workspace");
-	await expect
-		.poll(() =>
-			git(pathToRepo, ["for-each-ref", "--format=%(refname)", "refs/heads/gitbutler/workspace"]),
-		)
-		.toBe("");
-	await expect
-		.poll(() => git(pathToRepo, ["rev-parse", "HEAD"]))
-		.toBe(git(pathToRepo, ["rev-parse", "origin/master"]));
-	return git(pathToRepo, ["symbolic-ref", "--short", "HEAD"]);
-}
-
 async function expectWorkspaceCommitToStayParentedToRemainingStack(pathToRepo: string) {
 	await expect
 		.poll(() => git(pathToRepo, ["rev-parse", "gitbutler/workspace^@"]).split("\n").length, {
@@ -242,7 +224,7 @@ test("should keep the remaining stack when only one of two stacks is integrated"
 	await expectWorkspaceCommitToStayParentedToRemainingStack(localClone);
 });
 
-test("should check out a new branch when both applied stacks are integrated", async ({
+test("should keep the empty workspace when both applied stacks are integrated", async ({
 	page,
 	gitbutler,
 }) => {
@@ -258,9 +240,9 @@ test("should check out a new branch when both applied stacks are integrated", as
 	await gitbutler.runScript("merge-upstream-branch-to-base.sh", ["branch2"]);
 	await syncAndIntegrate(page);
 
-	const replacementBranch = await expectAdHocBranchAtOriginMaster(localClone);
-	await expect(stack(page)).toHaveCount(1);
-	await expect(getByTestId(page, "branch-card")).toContainText(replacementBranch);
+	await expect(stack(page)).toHaveCount(0);
+	await expectWorkspaceCommitParentToBeOriginMaster(localClone);
+	expect(git(localClone, ["symbolic-ref", "--short", "HEAD"])).toBe("gitbutler/workspace");
 });
 
 test("should update an empty workspace when the target ref advances", async ({


### PR DESCRIPTION
Since #15357, updating the workspace after every applied stack had merged replaced the `gitbutler/workspace` ref with a freshly checked-out canned branch (e.g. `kv-branch-44`) — a single-branch-mode transition that ignored the `singleBranch` feature flag. Users outside single-branch mode were dropped out of their workspace and lost the workspace ref. This affected desktop, Lite and the CLI alike, since all go through `workspace_integrate_upstream_only_with_perm`.

`integrate_upstream_with_hints` now takes `single_branch_mode`, supplied from `ctx.settings.feature_flags.single_branch` in but-api. Without it the emptied managed workspace stays checked out, reparented onto the advanced target, as before #15357. The single-branch behavior is unchanged when the flag is on.

Tests: flag-off counterparts added in but-workspace and the CLI `pull` suite; the non-single-branch Playwright test goes back to expecting the workspace to survive (the singleBranch suite already covers the transition).