### PR TITLE
Rest emptied stack bottoms on the commit they point to

### DIFF
--- a/crates/but-api/tests/api/branch_checkout.rs
+++ b/crates/but-api/tests/api/branch_checkout.rs
@@ -257,12 +257,12 @@ fn checkout_new_returns_head_info_matching_fresh_head_info() -> anyhow::Result<(
 
     snapbox::assert_data_eq!(
         crate::support::workspace_graph(&ctx)?,
-        snapbox::str![[r"
+        snapbox::str![[r#"
 ⌂:0:new-branch[🌳] <> ✓refs/remotes/origin/main on 5374caf
-└── ≡:0:new-branch[🌳] {1}
+└── ≡:0:new-branch[🌳] on 5374caf {1}
     └── :0:new-branch[🌳]
 
-"]]
+"#]]
     );
 
     #[cfg(feature = "graph-workspace")]
@@ -312,7 +312,9 @@ RefInfo {
             id: Some(
                 00000000-0000-0000-0000-000000000001,
             ),
-            base: None,
+            base: Some(
+                Sha1(5374caf21933aee76b72bad8d6e30949c7a30e04),
+            ),
             segments: [
                 ref_info::ui::Segment {
                     id: NodeIndex(0),
@@ -323,7 +325,7 @@ RefInfo {
                     commits_outside: None,
                     metadata: "None",
                     push_status: CompletelyUnpushed,
-                    base: "None",
+                    base: "5374caf",
                 },
             ],
         },

--- a/crates/but-graph/src/projection/stack.rs
+++ b/crates/but-graph/src/projection/stack.rs
@@ -72,16 +72,27 @@ impl Stack {
         stack
     }
 
-    /// Recompute the last segment's base from its bottom commit's first-parent neighbour.
+    /// Recompute the last segment's base from its bottom commit's first-parent neighbour, or,
+    /// once pruning emptied the segment, from the commit its tip points to.
     ///
     /// Needed after the stack's bottom is truncated (e.g. by integrated-trunk pruning),
     /// which leaves the collection-time base pointing at a segment no longer in the stack.
     pub(crate) fn recompute_last_segment_base(&mut self, graph: &PetGraph) {
-        let Some((last_segment, last_aggregated_sidx)) = self.segments.last_mut().and_then(|s| {
-            let sidx = s.commits_by_segment.last().map(|t| t.0)?;
-            Some((s, sidx))
-        }) else {
+        let Some(last_segment) = self.segments.last_mut() else {
             return;
+        };
+        let last_aggregated_sidx = match last_segment.commits_by_segment.last() {
+            Some((sidx, _)) => *sidx,
+            None => {
+                // The projection holds no commits for this segment. If its graph segment still
+                // does, those were pruned as integrated and the branch now rests on the commit
+                // it points to. A truly empty ref keeps its collection-time base.
+                if let Some(first) = graph[last_segment.id].commits.first() {
+                    last_segment.base = Some(first.id);
+                    last_segment.base_segment_id = Some(last_segment.id);
+                }
+                return;
+            }
         };
         let first_parent_sidx = graph
             .neighbors_directed(last_aggregated_sidx, Direction::Outgoing)

--- a/crates/but-graph/src/projection/workspace/init.rs
+++ b/crates/but-graph/src/projection/workspace/init.rs
@@ -122,6 +122,12 @@ impl Graph {
         ws.mark_remote_reachability(self)?;
         ws.add_commits_on_remote(self);
         ws.truncate_single_stack_to_match_base();
+        // Pruning and truncation may have moved or emptied a stack's bottom; each stack now
+        // rests on the parent of its bottom-most remaining commit, or on the commit its tip
+        // points to when nothing remains.
+        for stack in &mut ws.stacks {
+            stack.recompute_last_segment_base(&self.inner);
+        }
         Ok(ws)
     }
 
@@ -1182,10 +1188,6 @@ impl WorkspaceState {
             // mode keeps the branch shell, but prunes integrated target/base commits from it.
             prune_integrated_stack_segments(stack, &prune_segments, keep_if_fully_integrated);
             remove_empty_branches(stack, metadata, &keep_empty_segment_ids);
-            if upstream_advanced_past_target {
-                // Pruning moved the stack's bottom; refresh its base to the new fork point.
-                stack.recompute_last_segment_base(&graph.inner);
-            }
         }
         self.stacks.retain(|stack| !stack.segments.is_empty());
     }

--- a/crates/but-graph/tests/graph/init/mod.rs
+++ b/crates/but-graph/tests/graph/init/mod.rs
@@ -335,7 +335,7 @@ fn shallow_clone_stops_at_shallow_boundary() -> anyhow::Result<()> {
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
 ⌂:0:main[🌳] <> ✓refs/remotes/origin/main on 71a64f3
-└── ≡:0:main[🌳] <> origin/main →:1: {1}
+└── ≡:0:main[🌳] <> origin/main →:1: on 71a64f3 {1}
     └── :0:main[🌳] <> origin/main →:1:
 
 "#]]
@@ -503,7 +503,7 @@ fn only_remote_advanced() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 ⌂:0:main[🌳] <> ✓refs/remotes/origin/main⇣2 on 971953d
-└── ≡:0:main[🌳] <> origin/main →:1:⇣1 {1}
+└── ≡:0:main[🌳] <> origin/main →:1:⇣1 on 971953d {1}
     └── :0:main[🌳] <> origin/main →:1:⇣1
         └── 🟣085535d
 
@@ -557,7 +557,7 @@ fn only_remote_advanced_with_special_branch_name() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 ⌂:0:main[🌳] <> ✓refs/remotes/origin/main⇣2 on 971953d
-└── ≡:0:main[🌳] <> origin/main →:1:⇣1 {1}
+└── ≡:0:main[🌳] <> origin/main →:1:⇣1 on 971953d {1}
     └── :0:main[🌳] <> origin/main →:1:⇣1
         └── 🟣085535d
 
@@ -1172,7 +1172,7 @@ fn stacked_rebased_remotes() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 ⌂:0:B[🌳] <> ✓refs/remotes/origin/B⇣1 on 312f819
-└── ≡:0:B[🌳] <> origin/B →:1:⇣1 on e255adc {1}
+└── ≡:0:B[🌳] <> origin/B →:1:⇣1 on 312f819 {1}
     └── :0:B[🌳] <> origin/B →:1:⇣1
         └── 🟣682be32
 
@@ -2331,6 +2331,59 @@ fn ad_hoc_order_scopes_empty_segments_to_active_chain() -> anyhow::Result<()> {
         └── ·960152d ►main[🌳], ►other-bottom, ►other-top
 
 "#]]
+    );
+    Ok(())
+}
+
+#[test]
+fn ad_hoc_branch_at_target_tip_rests_on_the_target_tip() -> anyhow::Result<()> {
+    let tmp = but_testsupport::gix_testtools::tempfile::TempDir::new()?;
+    let repo = gix::ThreadSafeRepository::init_opts(
+        tmp.path(),
+        gix::create::Kind::WithWorktree,
+        gix::create::Options::default(),
+        but_testsupport::open_repo_config()?,
+    )?
+    .to_thread_local();
+    let m1 = commit(&repo, "M1")?;
+    create_branches(&repo, m1, ["refs/heads/feature"])?;
+    repo.edit_reference(gix::refs::transaction::RefEdit {
+        change: gix::refs::transaction::Change::Update {
+            log: gix::refs::transaction::LogChange::default(),
+            expected: gix::refs::transaction::PreviousValue::Any,
+            new: gix::refs::Target::Symbolic(ref_name("refs/heads/feature")),
+        },
+        name: ref_name("HEAD"),
+        deref: false,
+    })?;
+    let f1 = commit_with_parent(&repo, "F1", m1)?;
+    // The checked-out branch and the target both point at F1, while the target's local
+    // tracking branch `main` stayed behind at M1.
+    create_branches(&repo, f1, ["refs/remotes/origin/main"])?;
+    let meta = in_memory_meta(tmp.path())?;
+    let project_meta = but_core::ref_metadata::ProjectMeta {
+        target_ref: Some(ref_name("refs/remotes/origin/main")),
+        ..Default::default()
+    };
+    let ws = Graph::from_head(&repo, &*meta, project_meta, standard_options())?
+        .validated()?
+        .into_workspace()?;
+
+    // The branch is inline with the target, so it has no commits of its own and rests
+    // on the target tip — not on the stale local `main` further down.
+    snapbox::assert_data_eq!(
+        graph_workspace(&ws).to_string(),
+        snapbox::str![[r#"
+⌂:0:feature[🌳] <> ✓refs/remotes/origin/main on d1b2aed
+└── ≡:0:feature[🌳] on d1b2aed {1}
+    └── :0:feature[🌳]
+
+"#]]
+    );
+    assert_eq!(
+        ws.stacks[0].base(),
+        Some(f1),
+        "an empty branch at the target tip rests on the commit it points to"
     );
     Ok(())
 }

--- a/crates/but-graph/tests/graph/init/with_workspace.rs
+++ b/crates/but-graph/tests/graph/init/with_workspace.rs
@@ -1645,7 +1645,7 @@ fn just_init_with_branches() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 ⌂:0:main[🌳] <> ✓refs/remotes/origin/main
-└── ≡:0:main[🌳] <> origin/main →:2: {1}
+└── ≡:0:main[🌳] <> origin/main →:2: on fafd9d0 {1}
     └── :0:main[🌳] <> origin/main →:2:
 
 "#]]
@@ -2628,7 +2628,7 @@ fn proper_remote_ahead() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 ⌂:0:main <> ✓refs/remotes/origin/main⇣2
-└── ≡:0:main <> origin/main →:2:⇣2 {1}
+└── ≡:0:main <> origin/main →:2:⇣2 on 998eae6 {1}
     └── :0:main <> origin/main →:2:⇣2
         ├── 🟣ca7baa7 (✓)
         └── 🟣7ea1468 (✓)
@@ -3427,7 +3427,7 @@ fn integrated_tips_stop_early_if_remote_is_not_configured() -> anyhow::Result<()
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 ⌂:0:A <> ✓refs/remotes/origin/main⇣3
-└── ≡:0:A on 4b3e5a8 {1}
+└── ≡:0:A on 79bbb29 {1}
     └── :0:A
 
 "#]]
@@ -3473,7 +3473,7 @@ fn integrated_tips_stop_early_if_remote_is_not_configured() -> anyhow::Result<()
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 ⌂:0:A <> ✓refs/remotes/origin/main⇣6
-└── ≡:0:A {1}
+└── ≡:0:A on 79bbb29 {1}
     └── :0:A
 
 "#]]
@@ -3760,7 +3760,7 @@ fn integrated_tips_do_not_stop_early() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 ⌂:0:A <> ✓refs/remotes/origin/main⇣3
-└── ≡:0:A on 4b3e5a8 {1}
+└── ≡:0:A on 79bbb29 {1}
     └── :0:A
 
 "#]]
@@ -3810,7 +3810,7 @@ fn integrated_tips_do_not_stop_early() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 ⌂:0:main <> ✓refs/remotes/origin/main⇣3
-└── ≡:0:main <> origin/main →:2:⇣3 {1}
+└── ≡:0:main <> origin/main →:2:⇣3 on 4b3e5a8 {1}
     └── :0:main <> origin/main →:2:⇣3
         ├── 🟣d0df794 (✓)
         ├── 🟣09c6e08 (✓)
@@ -3829,7 +3829,7 @@ fn integrated_tips_do_not_stop_early() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 ⌂:0:DETACHED <> ✓refs/remotes/origin/main⇣3
-└── ≡:0:anon: {1}
+└── ≡:0:anon: on 34d0715 {1}
     └── :0:anon:
 
 "#]]
@@ -4391,7 +4391,7 @@ fn partitions_with_long_and_short_connections_to_each_other() -> anyhow::Result<
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 ⌂:0:main <> ✓refs/remotes/origin/main⇣11
-└── ≡:0:main <> origin/main →:2:⇣11 {1}
+└── ≡:0:main <> origin/main →:2:⇣11 on 2438292 {1}
     └── :0:main <> origin/main →:2:⇣11
         ├── 🟣232ed06 (✓)
         ├── 🟣abcfd9a (✓)
@@ -4467,7 +4467,7 @@ fn partitions_with_long_and_short_connections_to_each_other() -> anyhow::Result<
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 ⌂:0:main <> ✓refs/remotes/origin/main⇣11
-└── ≡:0:main <> origin/main →:2:⇣11 {1}
+└── ≡:0:main <> origin/main →:2:⇣11 on 2438292 {1}
     └── :0:main <> origin/main →:2:⇣11
         ├── 🟣232ed06 (✓)
         ├── 🟣abcfd9a (✓)
@@ -4742,7 +4742,7 @@ fn partitions_with_long_and_short_connections_to_each_other_part_2() -> anyhow::
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 ⌂:0:main <> ✓refs/remotes/origin/main⇣17
-└── ≡:0:main <> origin/main →:2:⇣17 {1}
+└── ≡:0:main <> origin/main →:2:⇣17 on bce0c5e {1}
     └── :0:main <> origin/main →:2:⇣17
         ├── 🟣024f837 (✓) ►long-workspace-to-target
         ├── 🟣64a8284 (✓)
@@ -6965,7 +6965,7 @@ fn branch_ahead_of_workspace() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣2 on fafd9d0
-├── ≡:6:B on fafd9d0
+├── ≡:6:B on 91bc3fc
 │   └── :6:B
 │       └── ·2f8f06d (🏘️)
 ├── ≡:7:C on fafd9d0
@@ -7608,7 +7608,7 @@ fn applied_stack_below_explicit_lower_bound() -> anyhow::Result<()> {
 ├── ≡📙:3:A on bce0c5e {0}
 │   └── 📙:3:A
 │       └── ·6fdab32 (🏘️)
-└── ≡📙:4:B on bce0c5e {1}
+└── ≡📙:4:B on f52fcec {1}
     └── 📙:4:B
         └── ·78b1b59 (🏘️)
 
@@ -9126,7 +9126,7 @@ fn integrated_merge_at_bottom_is_kept() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on f5f42e0
-└── ≡📙:3:local-stack {0}
+└── ≡📙:3:local-stack on fafd9d0 {0}
     └── 📙:3:local-stack
         ├── ·66ea651 (🏘️)
         ├── ·e5a88a7 (🏘️)
@@ -9190,7 +9190,7 @@ fn merge_from_main_keeps_all_branch_commits() -> anyhow::Result<()> {
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
 📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on ef56fab
-└── ≡📙:3:my-branch {0}
+└── ≡📙:3:my-branch on fafd9d0 {0}
     └── 📙:3:my-branch
         ├── ·cd76046 (🏘️)
         ├── ·f8ff9a3 (🏘️)

--- a/crates/but-graph/tests/graph/workspace/resolved_target_commit_id.rs
+++ b/crates/but-graph/tests/graph/workspace/resolved_target_commit_id.rs
@@ -36,7 +36,7 @@ fn ad_hoc_workspace_uses_project_target_ref() -> anyhow::Result<()> {
         graph_workspace_determinisitcally(&ws).to_string(),
         snapbox::str![[r#"
 ⌂:[..]:feature[🌳] <> ✓refs/remotes/origin/trunk⇣1 on d03b217
-└── ≡:[..]:feature[🌳] on 3183e43 {1}
+└── ≡:[..]:feature[🌳] on d03b217 {1}
     └── :[..]:feature[🌳]
 
 "#]]

--- a/crates/but-workspace/tests/workspace/branch/apply_unapply.rs
+++ b/crates/but-workspace/tests/workspace/branch/apply_unapply.rs
@@ -691,7 +691,7 @@ Outcome {
             graph_workspace(&out.workspace).to_string(),
             snapbox::str![[r#"
 ⌂:0:main[🌳] <> ✓refs/remotes/origin/main on e5d0542
-└── ≡:0:main[🌳] <> origin/main →:1: {1}
+└── ≡:0:main[🌳] <> origin/main →:1: on e5d0542 {1}
     └── :0:main[🌳] <> origin/main →:1:
 
 "#]]
@@ -746,7 +746,7 @@ Outcome {
             graph_workspace(&out.workspace).to_string(),
             snapbox::str![[r#"
 ⌂:0:main[🌳] <> ✓refs/remotes/origin/main on e5d0542
-└── ≡:0:main[🌳] <> origin/main →:1: {1}
+└── ≡:0:main[🌳] <> origin/main →:1: on e5d0542 {1}
     └── :0:main[🌳] <> origin/main →:1:
 
 "#]]
@@ -1159,7 +1159,7 @@ Outcome {
         graph_workspace(&out.workspace).to_string(),
         snapbox::str![[r#"
 ⌂:0:main[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-└── ≡:0:main[🌳] <> origin/main →:1: {1}
+└── ≡:0:main[🌳] <> origin/main →:1: on 85efbe4 {1}
     └── :0:main[🌳] <> origin/main →:1:
 
 "#]]
@@ -1795,7 +1795,7 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_with_target
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
 ⌂:0:main[🌳] <> ✓refs/remotes/origin/main on e5d0542
-└── ≡:0:main[🌳] <> origin/main →:1: {1}
+└── ≡:0:main[🌳] <> origin/main →:1: on e5d0542 {1}
     └── :0:main[🌳] <> origin/main →:1:
 
 "#]]
@@ -1927,7 +1927,7 @@ Outcome {
         graph_workspace(&out.workspace).to_string(),
         snapbox::str![[r#"
 ⌂:0:main[🌳] <> ✓refs/remotes/origin/main on e5d0542
-└── ≡:0:main[🌳] <> origin/main →:1: {1}
+└── ≡:0:main[🌳] <> origin/main →:1: on e5d0542 {1}
     └── :0:main[🌳] <> origin/main →:1:
 
 "#]]
@@ -3424,7 +3424,7 @@ fn apply_multiple_segments_of_stack_in_order_merge_if_needed() -> anyhow::Result
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
 ⌂:0:main[🌳] <> ✓refs/remotes/origin/main on 3183e43
-└── ≡:0:main[🌳] <> origin/main →:1: {1}
+└── ≡:0:main[🌳] <> origin/main →:1: on 3183e43 {1}
     └── :0:main[🌳] <> origin/main →:1:
 
 "#]]
@@ -4294,7 +4294,7 @@ fn apply_two_ambiguous_stacks_with_target_with_dependent_branch() -> anyhow::Res
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
 ⌂:0:main[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-└── ≡:0:main[🌳] <> origin/main →:1: {1}
+└── ≡:0:main[🌳] <> origin/main →:1: on 85efbe4 {1}
     └── :0:main[🌳] <> origin/main →:1:
 
 "#]]
@@ -4428,7 +4428,7 @@ fn apply_two_ambiguous_stacks_with_target() -> anyhow::Result<()> {
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
 ⌂:0:main[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-└── ≡:0:main[🌳] <> origin/main →:1: {1}
+└── ≡:0:main[🌳] <> origin/main →:1: on 85efbe4 {1}
     └── :0:main[🌳] <> origin/main →:1:
 
 "#]]
@@ -4907,7 +4907,7 @@ Outcome {
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
 ⌂:0:main[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-└── ≡:0:main[🌳] <> origin/main →:1: {1}
+└── ≡:0:main[🌳] <> origin/main →:1: on 85efbe4 {1}
     └── :0:main[🌳] <> origin/main →:1:
 
 "#]]
@@ -5405,7 +5405,7 @@ fn unapply_with_workspace_merge_conflicts_always_works_as_conflicts_do_not_repea
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
 ⌂:0:main[🌳] <> ✓! on 85efbe4
-└── ≡:0:main[🌳] {1}
+└── ≡:0:main[🌳] on 85efbe4 {1}
     └── :0:main[🌳]
 
 "#]]

--- a/crates/but-workspace/tests/workspace/branch/create_reference.rs
+++ b/crates/but-workspace/tests/workspace/branch/create_reference.rs
@@ -2295,7 +2295,7 @@ fn errors() -> anyhow::Result<()> {
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
 ⌂:0:A <> ✓! on 89cc2d3
-└── ≡:0:A {1}
+└── ≡:0:A on 89cc2d3 {1}
     └── :0:A
 
 "#]]

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/exhaustive_with_squash_merges.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/journey/exhaustive_with_squash_merges.rs
@@ -131,7 +131,9 @@ Ok(
                 id: Some(
                     00000000-0000-0000-0000-000000000001,
                 ),
-                base: None,
+                base: Some(
+                    Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
+                ),
                 segments: [
                     ref_info::ui::Segment {
                         id: NodeIndex(0),
@@ -142,7 +144,7 @@ Ok(
                         commits_outside: None,
                         metadata: "None",
                         push_status: CompletelyUnpushed,
-                        base: "None",
+                        base: "fafd9d0",
                     },
                 ],
             },
@@ -220,7 +222,9 @@ Ok(
                 id: Some(
                     00000000-0000-0000-0000-000000000001,
                 ),
-                base: None,
+                base: Some(
+                    Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
+                ),
                 segments: [
                     ref_info::ui::Segment {
                         id: NodeIndex(0),
@@ -231,7 +235,7 @@ Ok(
                         commits_outside: None,
                         metadata: "None",
                         push_status: NothingToPush,
-                        base: "None",
+                        base: "fafd9d0",
                     },
                 ],
             },
@@ -300,7 +304,9 @@ Ok(
                 id: Some(
                     00000000-0000-0000-0000-000000000001,
                 ),
-                base: None,
+                base: Some(
+                    Sha1(fafd9d08a839d99db60b222cd58e2e0bfaf1f7b2),
+                ),
                 segments: [
                     ref_info::ui::Segment {
                         id: NodeIndex(0),
@@ -311,7 +317,7 @@ Ok(
                         commits_outside: None,
                         metadata: "None",
                         push_status: NothingToPush,
-                        base: "None",
+                        base: "fafd9d0",
                     },
                 ],
             },

--- a/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
+++ b/crates/but-workspace/tests/workspace/ref_info/with_workspace_commit/mod.rs
@@ -3518,7 +3518,9 @@ RefInfo {
             id: Some(
                 00000000-0000-0000-0000-000000000001,
             ),
-            base: None,
+            base: Some(
+                Sha1(32791d22e276ec0ed87d14f906321137356bc6d6),
+            ),
             segments: [
                 ref_info::ui::Segment {
                     id: NodeIndex([..]),
@@ -3529,7 +3531,7 @@ RefInfo {
                     commits_outside: None,
                     metadata: Branch,
                     push_status: CompletelyUnpushed,
-                    base: "None",
+                    base: "32791d2",
                 },
             ],
         },
@@ -4362,7 +4364,9 @@ RefInfo {
             id: Some(
                 00000000-0000-0000-0000-000000000001,
             ),
-            base: None,
+            base: Some(
+                Sha1(c166d42d4ef2e5e742d33554d03805cfb0b24d11),
+            ),
             segments: [
                 ref_info::ui::Segment {
                     id: NodeIndex(0),
@@ -4373,7 +4377,7 @@ RefInfo {
                     commits_outside: None,
                     metadata: Branch,
                     push_status: CompletelyUnpushed,
-                    base: "None",
+                    base: "c166d42",
                 },
             ],
         },


### PR DESCRIPTION
In single-branch mode, when the checked-out branch sits at the target tip (e.g. the canned branch created once all stacks integrate), its commits are pruned as integrated and its stack ends up empty. The stack's `base` kept its collection-time value — the first commit of whatever segment came next along the first parent, typically the stale local tracking branch (`master`) or any old local ref below. `head_info` then reported the branch as resting far below the target, and Lite's Upstream tab drew every target commit above the branch as if it were behind.

| before | after |
|---|---|
| `origin/master` → "6 commits between" → `kv-branch-3` | `kv-branch-3` directly at `origin/master` |

`recompute_last_segment_base` now handles an emptied bottom: if the graph segment still owns commits (pruned as integrated), the branch rests on the commit it points to; a truly empty ref keeps resting on its ancestor. The projection recomputes every stack's base once, after all pruning and truncation passes, rather than only when upstream advanced — so a pruned bottom always names the parent of its bottom-most remaining commit.

Note for graph owners: this also refreshes the base of non-empty stacks whose integrated bottom commit was pruned when upstream has not advanced (e.g. `B on fafd9d0` → `on 91bc3fc`, the parent of B's bottom-most displayed commit). Every changed snapshot is an emptied/pruned bottom now naming the commit it actually rests on.