### PR TITLE
Fix single-branch status after switching

### DIFF
--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use anyhow::Context as _;
 use bstr::{BStr, BString, ByteSlice};
@@ -452,7 +452,24 @@ fn build_status_context<'a>(
                 expensive_commit_info: true,
                 ..Default::default()
             },
-        )?;
+        )?
+        .pruned_to_entrypoint();
+        let mut stacks = ws.stacks.clone();
+        if !head_info.is_entrypoint {
+            // Status reads commit details from pruned ref-info, but builds CLI IDs from graph
+            // stacks, so both views must contain the same segments when HEAD is inside a stack.
+            let visible_segment_ids: HashSet<_> = head_info
+                .stacks
+                .iter()
+                .flat_map(|stack| stack.segments.iter().map(|segment| segment.id))
+                .collect();
+            stacks.retain_mut(|stack| {
+                stack
+                    .segments
+                    .retain(|segment| visible_segment_ids.contains(&segment.id));
+                !stack.segments.is_empty()
+            });
+        }
         let mut push_statuses_by_segment_id = HashMap::<SegmentIndex, PushStatus>::new();
         let mut local_commits_by_id = HashMap::<gix::ObjectId, LocalCommit>::new();
         let mut remote_commits_by_id = HashMap::<gix::ObjectId, Commit>::new();
@@ -483,7 +500,7 @@ fn build_status_context<'a>(
             push_statuses_by_segment_id,
             local_commits_by_id,
             remote_commits_by_id,
-            ws.stacks.clone(),
+            stacks,
             resolved_target,
             commit_id_to_change_id,
         )

--- a/crates/but/tests/but/command/status.rs
+++ b/crates/but/tests/but/command/status.rs
@@ -58,6 +58,36 @@ fn single_branch_mode_lazily_initializes_an_unregistered_repository() {
 }
 
 #[test]
+fn single_branch_status_hides_branches_above_head() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings(
+        "one-stack-three-dependent-branches",
+    );
+    env.setup_single_stack_metadata_at_target(&["C", "B", "A"], "origin/main");
+    env.invoke_git("checkout B");
+
+    // Single-branch status includes checked-out B and A below it, but not C above it.
+    env.but("status")
+        .assert()
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ g0 [B]
+┊●   wwm add B
+┊│
+┊├┄ h0 [A]
+┊●   tpm add A
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
 fn worktrees() {
     let env = Sandbox::init_scenario_with_target_and_default_settings_slow("two-worktrees");
     snapbox::assert_data_eq!(

--- a/crates/but/tests/but/command/switch.rs
+++ b/crates/but/tests/but/command/switch.rs
@@ -85,6 +85,57 @@ Switched to branch 'A'
     assert_eq!(env.invoke_git("rev-parse --abbrev-ref HEAD"), "A");
 }
 
+#[cfg(feature = "legacy")]
+#[test]
+fn switching_to_lower_branch_only_shows_it_in_single_branch_mode() {
+    let env = crate::utils::Sandbox::init_scenario_with_target_and_default_settings(
+        "one-stack-two-dependent-branches",
+    );
+    env.setup_single_stack_metadata_at_target(&["B", "A"], "origin/main");
+
+    // The managed workspace shows the complete stack before switching.
+    env.but("status")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ g0 [B]
+┊●   wwm add B
+┊│
+┊├┄ h0 [A]
+┊●   tpm add A
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("switch A").assert().success();
+
+    assert_eq!(env.invoke_git("rev-parse --abbrev-ref HEAD"), "A");
+    // Switching to A should hide B above it from single-branch status.
+    env.but("status")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ g0 [A]
+┊●   tpm add A
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
 #[test]
 fn switches_back_to_workspace() {
     let env = switch_env();

--- a/crates/but/tests/fixtures/scenario/one-stack-two-dependent-branches.sh
+++ b/crates/but/tests/fixtures/scenario/one-stack-two-dependent-branches.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# A workspace with two dependent branches, each with one commit: A -> B.
+git-init-frozen
+commit-file M
+setup_target_to_match_main
+
+git checkout -b A
+commit-file A
+git checkout -b B
+commit-file B
+create_workspace_commit_once B


### PR DESCRIPTION
## Summary

- prune CLI status to the checked-out stack entrypoint in single-branch mode
- keep legacy ref-info and graph-stack views aligned
- add before/after status snapshots and reusable stacked-branch fixtures

## Root cause

`but switch` updated `HEAD` correctly, but the status builder continued feeding every segment from the enclosing managed workspace into the CLI ID map. Branches above the checked-out branch therefore remained visible.
