### PR TITLE
Update Node version requirement to at least 24

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -139,7 +139,7 @@ $ curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf | sh
 
 3. Node
 
-Next, ensure you've got at least Node 20 installed. If you're on Mac OS or Linux and you're missing `node`, you can use your favorite package manager like `brew` or `apt`.
+Next, ensure you've got at least Node 22 installed. If you're on Mac OS or Linux and you're missing `node`, you can use your favorite package manager like `brew` or `apt`.
 
 Alternatively, you can use the following Node installer from Vercel to get the latest version.
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -19,7 +19,7 @@ This directory contains all end-to-end (E2E) tests for GitButler. We use two dif
 
 Before running E2E tests, ensure you have:
 
-1. **Node.js** (v20.11+): See [DEVELOPMENT.md](../DEVELOPMENT.md) for installation
+1. **Node.js** (v22.12+): See [DEVELOPMENT.md](../DEVELOPMENT.md) for installation
 2. **pnpm** (v10.17.0): Enabled via `corepack enable` in the project root
 3. **Built application**: E2E tests require a built version of the app
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -19,7 +19,7 @@ This directory contains all end-to-end (E2E) tests for GitButler. We use two dif
 
 Before running E2E tests, ensure you have:
 
-1. **Node.js** (v22.12+): See [DEVELOPMENT.md](../DEVELOPMENT.md) for installation
+1. **Node.js** (v24+): See [DEVELOPMENT.md](../DEVELOPMENT.md) for installation
 2. **pnpm** (v10.17.0): Enabled via `corepack enable` in the project root
 3. **Built application**: E2E tests require a built version of the app
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"private": true,
 	"repository": "https://github.com/gitbutlerapp/gitbutler.git",
 	"engines": {
-		"node": ">=20.11"
+		"node": ">=22.12.0"
 	},
 	"type": "module",
 	"packageManager": "pnpm@10.20.0",


### PR DESCRIPTION
## 🧢 Changes

While setting up my development environment (for fixing a different issue), I noticed that Node 20 is in fact insufficient, even though the docs say that 20 should be enough. Changing to 22, since thats what the package.json says should be used. 

