### PR TITLE
Clarify uncommitted-conflict hint in `but status`

### DIFF
--- a/crates/but/skill/SKILL.md
+++ b/crates/but/skill/SKILL.md
@@ -186,7 +186,7 @@ A wrong resolution is reverted with `but undo`.
 
 ### Conflicts in uncommitted files
 
-`but status` marks uncommitted files with unresolved merge conflicts `{conflicted}`; they are excluded from committable changes and outside `but resolve` mode. Choose the desired contents or delete the file, then `but resolve <path>...` to mark it resolved with that state; it then shows as an ordinary uncommitted change.
+`but status` marks uncommitted files with unresolved merge conflicts `{conflicted}`; they are excluded from committable changes and outside `but resolve` mode. Edit the file to the wanted contents (or delete it), then `but resolve <path>...` to mark it resolved with that state; it then shows as an ordinary uncommitted change.
 
 ## Git-to-But Map
 

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -752,7 +752,7 @@ fn print_conflicted_files_warning(
     }
     let t = crate::theme::get();
     output.warning(Vec::from([Span::styled(
-        "⚠ Uncommitted file conflicts: choose the desired file state, then run `but resolve <path>...`.",
+        "⚠ Uncommitted file conflicts: edit each file to the wanted contents (or delete it), then run `but resolve <path>...` to mark it resolved.",
         t.attention,
     )]))?;
     Ok(())

--- a/crates/but/tests/but/command/discard.rs
+++ b/crates/but/tests/but/command/discard.rs
@@ -397,7 +397,7 @@ Discarded commit 1
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
-⚠ Uncommitted file conflicts: choose the desired file state, then run `but resolve <path>...`.
+⚠ Uncommitted file conflicts: edit each file to the wanted contents (or delete it), then run `but resolve <path>...` to mark it resolved.
 
 Hint: run `but help` for all commands
 
@@ -461,7 +461,7 @@ Discarded commit 1
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
-⚠ Uncommitted file conflicts: choose the desired file state, then run `but resolve <path>...`.
+⚠ Uncommitted file conflicts: edit each file to the wanted contents (or delete it), then run `but resolve <path>...` to mark it resolved.
 
 Hint: run `but help` for all commands
 

--- a/crates/but/tests/but/command/pull.rs
+++ b/crates/but/tests/but/command/pull.rs
@@ -1062,7 +1062,7 @@ To undo this operation:
 ├╯
 ┊
 ┴ 7f73771 (common base) 2000-01-02 upstream change
-⚠ Uncommitted file conflicts: choose the desired file state, then run `but resolve <path>...`.
+⚠ Uncommitted file conflicts: edit each file to the wanted contents (or delete it), then run `but resolve <path>...` to mark it resolved.
 
 Hint: run `but help` for all commands
 

--- a/crates/but/tests/but/command/status.rs
+++ b/crates/but/tests/but/command/status.rs
@@ -1316,7 +1316,7 @@ printf '100644 %s 1\tconflicted.txt\n100644 %s 2\tconflicted.txt\n100644 %s 3\tc
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
-⚠ Uncommitted file conflicts: choose the desired file state, then run `but resolve <path>...`.
+⚠ Uncommitted file conflicts: edit each file to the wanted contents (or delete it), then run `but resolve <path>...` to mark it resolved.
 
 Hint: run `but help` for all commands
 


### PR DESCRIPTION
The hint shown for conflicted uncommitted files said "choose the desired file state, then run `but resolve <path>...`". "Choose" suggests a selection UI exists; for an agent (or human) the actual step is to edit the file to the wanted contents or delete it. The hint now says that explicitly.