### PR TITLE
Correct `MacOS` references to `macOS`

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -246,7 +246,7 @@ Often the behaviour depends on the current context: the repository being display
 To do that, _launch the application from a terminal_ as shown in the paragraph above this one, or right below, but with `graphviz` installed.
 The `dot` program should be available in `PATH` so it can run from the terminal.
 
-Doing so can look like this on MacOS, for example:
+Doing so can look like this on macOS, for example:
 
 ###### For the stable build
 

--- a/apps/web/src/lib/components/marketing/Footer.svelte
+++ b/apps/web/src/lib/components/marketing/Footer.svelte
@@ -29,7 +29,7 @@
 							</svg>
 
 							<a href={jsonLinks.downloads.appleSilicon.url} class="download-link">
-								MacOS ({jsonLinks.downloads.appleSilicon.label})
+								macOS ({jsonLinks.downloads.appleSilicon.label})
 							</a>
 						</div>
 

--- a/crates/gitbutler-filemonitor/vendor/debouncer/tests/fixtures/add_create_dir_event_twice.hjson
+++ b/crates/gitbutler-filemonitor/vendor/debouncer/tests/fixtures/add_create_dir_event_twice.hjson
@@ -1,6 +1,6 @@
 // https://github.com/spacedriveapp/spacedrive/blob/90a350946914be7f91ba692887ca03db659d530a/core/src/location/manager/watcher/macos.rs
 //
-// This is a MacOS specific event that happens when a folder is created through Finder.
+// This is a macOS specific event that happens when a folder is created through Finder.
 // It creates a folder but 2 events are triggered in FSEvents.
 {
     state: {}

--- a/crates/gitbutler-filemonitor/vendor/debouncer/tests/fixtures/add_modify_content_event_after_create_event.hjson
+++ b/crates/gitbutler-filemonitor/vendor/debouncer/tests/fixtures/add_modify_content_event_after_create_event.hjson
@@ -1,6 +1,6 @@
 // https://github.com/spacedriveapp/spacedrive/blob/90a350946914be7f91ba692887ca03db659d530a/core/src/location/manager/watcher/macos.rs
 
-// MacOS emits a Create File and then an Update Content event when a file is created.
+// macOS emits a Create File and then an Update Content event when a file is created.
 {
     state: {
         queues: {

--- a/crates/gitbutler-git/src/executor/mod.rs
+++ b/crates/gitbutler-git/src/executor/mod.rs
@@ -95,7 +95,7 @@ pub unsafe trait GitExecutor {
     ///
     /// ## Unix
     ///
-    /// On Unix-like systems (including MacOS), this is a unix
+    /// On Unix-like systems (including macOS), this is a unix
     /// domain socket. The path of the socket is returned as
     /// a handle type that is format-able as a string which is
     /// passed to the askpass utility as `GITBUTLER_ASKPASS_SOCKET`.

--- a/crates/gitbutler-tauri/src/window.rs
+++ b/crates/gitbutler-tauri/src/window.rs
@@ -304,7 +304,7 @@ pub fn create(
             // Note that these lights get reset when the Window label is changed!
             // See https://github.com/tauri-apps/tauri/issues/13044 .
             // TODO: stop doing this entirely and work with the defaults, my preference,
-            //       create a build script that makes it clear which MacOS version we are using
+            //       create a build script that makes it clear which macOS version we are using
             //       to conditionally compile the right value.
             let y_offset_for_small_dots_in_pre_tahoe = 25.0;
             window.setup_traffic_lights_inset(LogicalPosition::new(

--- a/e2e/blackbox/Dockerfile
+++ b/e2e/blackbox/Dockerfile
@@ -1,4 +1,4 @@
-# Container for running E2E tests on MacOS
+# Container for running E2E tests on macOS
 #
 # 1. docker build --tag gitbutler/e2e:latest
 # 2. docker run --name e2e-agent --detach -p 2222:22 -v $GITBUTLER_REPO:/root/gitbutler \


### PR DESCRIPTION
## 🧢 Changes

Change `MacOS` references to `macOS`

## ☕️ Reasoning

`macOS` is the correct styling.

Mostly just wanted to fix it on the main webpage but did the rest of the files(documentation and comments) while I was at it too.