### PR TITLE
Fit the Lite uncommitted pane to its content

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.module.css
@@ -3,6 +3,14 @@
 		/* The focus state is displayed on the item row instead. */
 		outline: none;
 	}
+
+	/* The uncommitted panel is never taller than its content: the panel layout
+	   only says how tall the user would like it, flexbox caps it at what there
+	   is to show and hands the rest to the stacks. `!important` overrides the
+	   inline `max-height: 100%` the panel element ships with. */
+	> :has(> .uncommittedChangesOuterPanel) {
+		max-height: max-content !important;
+	}
 }
 
 .uncommittedChangesOuterPanel {


### PR DESCRIPTION
The uncommitted pane in Lite is never taller than what it has to show. With no files it is just the header, the "Nothing to commit" row and the commit button; with a couple of files it fits them exactly; once the list overflows it behaves as before, scrolling at the height the user dragged it to. Files leaving shrink the pane, files returning grow it back up to that height, and the commit form expanding pushes it out as needed.

Nothing changed in the panel machinery: the `react-resizable-panels` layout still records the height the user wants (and is what gets persisted), while flexbox caps the panel element at `max-content` and hands the rest to the stacks pane. Dragging still sets the preferred height; a drag past the content edge adjusts that preference without moving the pixels, so an empty pane can be pre-sized for what is about to land.