### PR TITLE
Use upstream posthog-rs from crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7772,11 +7772,14 @@ dependencies = [
 
 [[package]]
 name = "posthog-rs"
-version = "0.4.1"
-source = "git+https://github.com/gitbutlerapp/posthog-rs?rev=664c9245f79aaedcdd025b9f3c141b62bb866b8e#664c9245f79aaedcdd025b9f3c141b62bb866b8e"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "898ac9a6f7db8030b45431704eaf7a86d3f0575d8b6f13851fc99158e62d1e51"
 dependencies = [
  "chrono",
  "derive_builder",
+ "flate2",
+ "os_info",
  "regex",
  "reqwest",
  "semver",

--- a/crates/but/Cargo.toml
+++ b/crates/but/Cargo.toml
@@ -94,7 +94,7 @@ gitbutler-git = { workspace = true, optional = true }
 gitbutler-watcher = { workspace = true, optional = true }
 
 schemars.workspace = true
-posthog-rs = { git = "https://github.com/gitbutlerapp/posthog-rs", rev = "664c9245f79aaedcdd025b9f3c141b62bb866b8e" }
+posthog-rs = { version = "0.23.3", default-features = false, features = ["async-client"] }
 serde.workspace = true
 shell-words.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "io-std"] }

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -606,8 +606,10 @@ impl Event {
 
 /// Capture an event *only* if `app_settings.telemetry.app_metrics_enabled` is `true`.
 pub async fn capture_event_blocking(app_settings: &AppSettings, event: Event) {
-    if let Some(client) = posthog_client(app_settings.clone()) {
-        do_capture(&client.await, event, app_settings).await.ok();
+    if let Some(client) = posthog_client(app_settings).await {
+        do_capture(&client, event, app_settings).await.ok();
+        // Explicit shutdown so dropping the client doesn't block the executor thread.
+        client.shutdown().await;
     }
 }
 
@@ -630,7 +632,8 @@ async fn do_capture(
     for (key, prop) in event.props {
         let _ = posthog_event.insert_prop(key, prop);
     }
-    client.capture(posthog_event).await
+    // The CLI exits right after this, so send inline instead of via the background queue.
+    client.capture_immediate(posthog_event).await.map(|_| ())
 }
 
 fn machine() -> String {
@@ -645,19 +648,18 @@ fn machine() -> String {
 }
 
 /// Creates a PostHog client if metrics are enabled and the API key is set.
-fn posthog_client(app_settings: AppSettings) -> Option<impl Future<Output = posthog_rs::Client>> {
-    if app_settings.telemetry.app_metrics_enabled
-        && let Some(api_key) = option_env!("POSTHOG_API_KEY")
-    {
-        let options = posthog_rs::ClientOptionsBuilder::default()
-            .api_key(api_key.to_string())
-            .host("https://eu.i.posthog.com".to_string())
-            .build()
-            .ok()?;
-        Some(posthog_rs::client(options))
-    } else {
-        None
+async fn posthog_client(app_settings: &AppSettings) -> Option<Client> {
+    if !app_settings.telemetry.app_metrics_enabled {
+        return None;
     }
+    let api_key = option_env!("POSTHOG_API_KEY")?;
+    let options = posthog_rs::ClientOptionsBuilder::default()
+        .api_key(api_key.to_string())
+        .host("https://eu.i.posthog.com".to_string())
+        .is_server(false)
+        .build()
+        .ok()?;
+    Some(posthog_rs::client(options).await)
 }
 
 impl<T> ResultMetricsExt<T, anyhow::Error> for anyhow::Result<T> {


### PR DESCRIPTION
Replaces the `gitbutlerapp/posthog-rs` fork (0.4.1) with `posthog-rs` 0.23.3 from crates.io. The fork only carried a reqwest 0.13 bump, which upstream now has, so the lockfile keeps a single reqwest.

Adjustments for the new API:
- `capture()` is now fire-and-forget into a background worker; the CLI uses `capture_immediate()` and shuts the client down explicitly so events still send inline before exit.
- `is_server(false)`, since 0.23 stamps `$is_server: true` by default and this is a client-side CLI.
- Default features trimmed (`error-tracking` pulled in backtrace/findshlibs we don't use).