### PR TITLE
Clarify the active source for Lite diff previews

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OutlineTree/OutlineTree.tsx
@@ -323,6 +323,7 @@ const UncommittedChanges: FC<{
 			>
 				<FilesTree
 					canUncommit={false}
+					data-preview-source={workspaceList === "uncommitted"}
 					selectionScope="uncommitted-files"
 					onFocus={() => setWorkspaceList("uncommitted")}
 					emptyLabel={
@@ -720,6 +721,7 @@ const Stacks: FC<{
 				aria-activedescendant={selection ? treeItemId(selection) : undefined}
 				className={classes(styles.tree, styles.stacks)}
 				data-selection-scope={"outline" satisfies SelectionScope}
+				data-preview-source={workspaceList === "stacks"}
 				onFocus={() => setWorkspaceList("stacks")}
 				ref={useMergedRefs(hotkeysRef, useAutofocusSelectionScope(workspaceList === "stacks"))}
 			>

--- a/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
@@ -48,7 +48,9 @@
 }
 
 .containerSelected {
-	background-color: color-mix(var(--fill-gray-bg) var(--opacity-bg-selected-blur), transparent);
+	&:not([data-preview-source="false"] *) {
+		background-color: color-mix(var(--fill-gray-bg) var(--opacity-bg-selected-blur), transparent);
+	}
 
 	&:has(:is(textarea, input):focus),
 	[data-selection-focus-styles="true"] [data-selection-scope]:focus & {


### PR DESCRIPTION
## Context

People can keep distinct remembered selections in Uncommitted and Stacks and branches. After moving into the diff preview, both source lists remain visually plausible when the preview owns focus, so it is unclear which selection drives the displayed diff. This slows verification and invites acting from the wrong context. Previously, the workaround was to move focus back to a list to confirm its source.

## Change

Mark each workspace source list from the existing URL-backed active-list state and suppress the selected-row fill for the inactive list. The driving selection remains legible both while its list is focused and while focus is in the preview, without discarding either remembered cursor.