### PR TITLE
Fix GitLab merge request pagination

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1365,6 +1365,7 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "thiserror 2.0.18",
+ "tokio",
  "tracing",
  "urlencoding",
 ]

--- a/crates/but-gitlab/Cargo.toml
+++ b/crates/but-gitlab/Cargo.toml
@@ -31,6 +31,7 @@ but-schemars = { workspace = true, optional = true }
 
 [dev-dependencies]
 reqwest = { workspace = true, features = ["blocking"] }
+tokio = { workspace = true, features = ["rt"] }
 
 [lints]
 workspace = true

--- a/crates/but-gitlab/src/client.rs
+++ b/crates/but-gitlab/src/client.rs
@@ -9,6 +9,9 @@ use crate::GitLabProjectId;
 
 const GITLAB_API_BASE_URL: &str = "https://gitlab.com/api/v4";
 const GITLAB_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+// Independent of GitLab's configurable offset, this generous cap accommodates realistic
+// self-hosted projects while bounding runaway pagination.
+const MAX_MERGE_REQUEST_REQUESTS: usize = 10_000;
 const MAX_PIPELINE_JOB_PAGES: usize = 25;
 
 /// An HTTP error with a status code, returned when the API responds with a non-success status.
@@ -138,20 +141,12 @@ impl GitLabClient {
 
     pub async fn list_open_mrs(&self, project_id: GitLabProjectId) -> Result<Vec<MergeRequest>> {
         let url = format!("{}/projects/{}/merge_requests", self.base_url, project_id);
-
-        let response = self
-            .client
-            .get(&url)
-            .query(&[("state", "opened"), ("order_by", "created_at")])
-            .send()
-            .await?;
-
-        if !response.status().is_success() {
-            bail!("Failed to list open merge requests: {}", response.status());
-        }
-
-        let mrs: Vec<GitLabMergeRequest> = response.json().await?;
-        Ok(mrs.into_iter().map(Into::into).collect())
+        self.list_merge_requests(
+            &url,
+            &[("state", "opened"), ("order_by", "created_at")],
+            "Failed to list open merge requests",
+        )
+        .await
     }
 
     pub async fn list_mrs_for_target(
@@ -161,28 +156,17 @@ impl GitLabClient {
     ) -> Result<Vec<MergeRequest>> {
         let url = format!("{}/projects/{}/merge_requests", self.base_url, project_id);
 
-        let response = self
-            .client
-            .get(&url)
-            .query(&[
+        self.list_merge_requests(
+            &url,
+            &[
                 ("state", "all"),
                 ("target_branch", target_branch),
                 ("order_by", "updated_at"),
                 ("sort", "desc"),
-                ("per_page", "100"),
-            ])
-            .send()
-            .await?;
-
-        if !response.status().is_success() {
-            bail!(
-                "Failed to list merge requests for target branch: {}",
-                response.status()
-            );
-        }
-
-        let mrs: Vec<GitLabMergeRequest> = response.json().await?;
-        Ok(mrs.into_iter().map(Into::into).collect())
+            ],
+            "Failed to list merge requests for target branch",
+        )
+        .await
     }
 
     pub async fn list_mrs_for_commit(
@@ -195,22 +179,50 @@ impl GitLabClient {
             self.base_url, project_id, commit_sha
         );
 
-        let response = self
-            .client
-            .get(&url)
-            .query(&[("per_page", "100")])
-            .send()
-            .await?;
+        self.list_merge_requests(&url, &[], "Failed to list merge requests for commit")
+            .await
+    }
 
-        if !response.status().is_success() {
-            bail!(
-                "Failed to list merge requests for commit: {}",
-                response.status()
-            );
+    async fn list_merge_requests(
+        &self,
+        url: &str,
+        query: &[(&str, &str)],
+        error_message: &str,
+    ) -> Result<Vec<MergeRequest>> {
+        let mut mrs = Vec::new();
+        let mut next_page = Some("1".to_string());
+        let mut seen_pages = HashSet::new();
+
+        while let Some(page) = next_page.take() {
+            if !merge_request_page_is_safe(&page, &mut seen_pages) {
+                bail!("Stopped listing GitLab merge requests after unsafe pagination state");
+            }
+
+            let response = self
+                .client
+                .get(url)
+                .query(query)
+                .query(&[("per_page", "100"), ("page", page.as_str())])
+                .send()
+                .await?;
+            if !response.status().is_success() {
+                bail!("{error_message}: {}", response.status());
+            }
+
+            next_page = next_page_from_headers(response.headers());
+            let mut page_mrs: Vec<GitLabMergeRequest> = response.json().await?;
+            if page_mrs.is_empty() {
+                break;
+            }
+            mrs.append(&mut page_mrs);
         }
 
-        let mrs: Vec<GitLabMergeRequest> = response.json().await?;
-        Ok(mrs.into_iter().map(Into::into).collect())
+        let mut seen = HashSet::new();
+        Ok(mrs
+            .into_iter()
+            .filter(|mr| seen.insert(mr.iid))
+            .map(Into::into)
+            .collect())
     }
 
     pub async fn create_merge_request(
@@ -700,6 +712,13 @@ impl GitLabClient {
     }
 }
 
+fn merge_request_page_is_safe(page: &str, seen_pages: &mut HashSet<usize>) -> bool {
+    let Ok(page) = page.parse::<usize>() else {
+        return false;
+    };
+    page > 0 && seen_pages.len() < MAX_MERGE_REQUEST_REQUESTS && seen_pages.insert(page)
+}
+
 fn next_page_from_headers(headers: &HeaderMap) -> Option<String> {
     headers
         .get("x-next-page")
@@ -1079,9 +1098,9 @@ pub(crate) fn resolve_account(
 #[cfg(test)]
 mod tests {
     use super::{
-        GitLabMergeRequest, GitLabPipelineJob, GitLabPipelineRef, MergeRequest,
-        next_page_from_headers, normalize_pipeline_jobs, repo_owner_from_path_with_namespace,
-        update_draft_state_in_title,
+        GitLabMergeRequest, GitLabPipelineJob, GitLabPipelineRef, MAX_MERGE_REQUEST_REQUESTS,
+        MergeRequest, merge_request_page_is_safe, next_page_from_headers, normalize_pipeline_jobs,
+        repo_owner_from_path_with_namespace, update_draft_state_in_title,
     };
     use reqwest::header::{HeaderMap, HeaderValue};
 
@@ -1115,6 +1134,20 @@ mod tests {
 
         headers.insert("x-next-page", HeaderValue::from_static(""));
         assert_eq!(next_page_from_headers(&headers), None);
+    }
+
+    #[test]
+    fn bounds_merge_request_page_requests_independently_of_server_offsets() {
+        let mut seen_pages =
+            (1..MAX_MERGE_REQUEST_REQUESTS).collect::<std::collections::HashSet<_>>();
+        assert!(
+            merge_request_page_is_safe("50001", &mut seen_pages),
+            "the final safe request should accept a server page above GitLab's default offset"
+        );
+        assert!(
+            !merge_request_page_is_safe("50002", &mut seen_pages),
+            "a distinct page should be rejected after the request-count safety bound"
+        );
     }
 
     #[test]

--- a/crates/but-gitlab/tests/gitlab_mr_pagination.rs
+++ b/crates/but-gitlab/tests/gitlab_mr_pagination.rs
@@ -1,0 +1,340 @@
+use but_gitlab::{GitLabClient, GitLabProjectId};
+use reqwest::Url;
+use std::io::{ErrorKind, Read as _, Write as _};
+use std::net::TcpListener;
+use std::time::{Duration, Instant};
+
+struct MockResponse {
+    body: String,
+    next_page: Option<&'static str>,
+}
+
+struct MockServer {
+    handle: std::thread::JoinHandle<Vec<String>>,
+}
+
+impl MockServer {
+    fn finish(self) -> Vec<String> {
+        self.handle.join().expect("mock server should finish")
+    }
+}
+
+fn mock_client(responses: Vec<MockResponse>) -> (GitLabClient, MockServer) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("mock server should bind");
+    listener
+        .set_nonblocking(true)
+        .expect("mock server should be nonblocking");
+    let address = listener
+        .local_addr()
+        .expect("mock server should have an address");
+    let handle = std::thread::spawn(move || {
+        let mut requests = Vec::new();
+        for response in responses {
+            let deadline = Instant::now() + Duration::from_secs(2);
+            let mut stream = loop {
+                match listener.accept() {
+                    Ok((stream, _)) => break stream,
+                    Err(err)
+                        if err.kind() == ErrorKind::WouldBlock && Instant::now() < deadline =>
+                    {
+                        std::thread::sleep(Duration::from_millis(5));
+                    }
+                    Err(err) => panic!("expected another paginated request: {err}"),
+                }
+            };
+            stream
+                .set_nonblocking(false)
+                .expect("accepted stream should be blocking");
+
+            let mut request = Vec::new();
+            let mut chunk = [0; 1024];
+            while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+                let read = stream
+                    .read(&mut chunk)
+                    .expect("mock server should read the request");
+                assert_ne!(read, 0, "request should include complete HTTP headers");
+                request.extend_from_slice(&chunk[..read]);
+            }
+            let request = String::from_utf8(request).expect("request should be valid UTF-8");
+            let path = request
+                .lines()
+                .next()
+                .and_then(|line| line.split_whitespace().nth(1))
+                .expect("request should include a path")
+                .to_owned();
+            requests.push(path);
+
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nX-Next-Page: {}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                response.next_page.unwrap_or_default(),
+                response.body.len(),
+                response.body
+            )
+            .expect("mock server should write the response");
+        }
+        requests
+    });
+
+    let token = Default::default();
+    let client = GitLabClient::new_with_host_override(&token, &format!("http://{address}"))
+        .expect("test client should be created");
+    (client, MockServer { handle })
+}
+
+fn mr(iid: i64, source_branch: &str) -> String {
+    format!(
+        r#"{{"web_url":"https://gitlab.example/mr/{iid}","iid":{iid},"title":"MR {iid}","description":null,"author":null,"labels":[],"draft":false,"source_branch":"{source_branch}","target_branch":"main","sha":"0123456789abcdef0123456789abcdef01234567","merge_commit_sha":null,"squash_commit_sha":null,"created_at":null,"updated_at":null,"merged_at":null,"closed_at":null,"project_id":7,"source_project_id":7,"target_project_id":7,"assignees":[],"reviewers":[],"merge_when_pipeline_succeeds":false}}"#
+    )
+}
+
+fn page(mrs: &[String]) -> String {
+    format!("[{}]", mrs.join(","))
+}
+
+fn assert_requests(
+    requests: &[String],
+    endpoint: &str,
+    expected_query: &[(&str, &str)],
+    pages: &[&str],
+) {
+    assert_eq!(
+        requests.len(),
+        pages.len(),
+        "one request should be made for each advertised page"
+    );
+    for (request, page) in requests.iter().zip(pages) {
+        let url = Url::parse(&format!("http://localhost{request}"))
+            .expect("MR listing request should be a valid URL");
+        assert_eq!(
+            url.path(),
+            endpoint,
+            "request should use the expected MR listing endpoint"
+        );
+        let mut actual_query = url
+            .query_pairs()
+            .map(|(key, value)| (key.into_owned(), value.into_owned()))
+            .collect::<Vec<_>>();
+        let mut expected_query = expected_query
+            .iter()
+            .copied()
+            .chain([("page", *page), ("per_page", "100")])
+            .map(|(key, value)| (key.to_owned(), value.to_owned()))
+            .collect::<Vec<_>>();
+        actual_query.sort_unstable();
+        expected_query.sort_unstable();
+        assert_eq!(
+            actual_query, expected_query,
+            "MR listing should contain exactly the expected decoded query pairs: {request}"
+        );
+    }
+}
+
+fn run(future: impl std::future::Future<Output = ()>) {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("test runtime should be created")
+        .block_on(future);
+}
+
+#[test]
+fn list_open_mrs_includes_a_page_two_match_without_duplicates() {
+    run(async {
+        let first = mr(1, "other");
+        let duplicate = mr(1, "other");
+        let matching = mr(2, "mm/15-client");
+        let (client, server) = mock_client(vec![
+            MockResponse {
+                body: page(&[first]),
+                next_page: Some("2"),
+            },
+            MockResponse {
+                body: page(&[duplicate, matching]),
+                next_page: None,
+            },
+        ]);
+
+        let mrs = client
+            .list_open_mrs(GitLabProjectId::new("group", "repo"))
+            .await
+            .expect("all open MR pages should be listed");
+        assert_eq!(
+            mrs.iter().map(|mr| mr.iid).collect::<Vec<_>>(),
+            vec![1, 2],
+            "overlapping pages should not duplicate merge requests"
+        );
+        assert_eq!(
+            mrs.iter()
+                .find(|mr| mr.source_branch == "mm/15-client")
+                .map(|mr| mr.iid),
+            Some(2),
+            "an existing page-two MR should be visible to branch association"
+        );
+        let requests = server.finish();
+        assert_requests(
+            &requests,
+            "/api/v4/projects/group%2Frepo/merge_requests",
+            &[("state", "opened"), ("order_by", "created_at")],
+            &["1", "2"],
+        );
+    });
+}
+
+#[test]
+fn list_mrs_for_target_includes_page_two() {
+    run(async {
+        let (client, server) = mock_client(vec![
+            MockResponse {
+                body: page(&[mr(1, "first")]),
+                next_page: Some("2"),
+            },
+            MockResponse {
+                body: page(&[mr(2, "second")]),
+                next_page: None,
+            },
+        ]);
+
+        let mrs = client
+            .list_mrs_for_target(GitLabProjectId::new("group", "repo"), "main")
+            .await
+            .expect("all target MR pages should be listed");
+        assert_eq!(
+            mrs.iter().map(|mr| mr.iid).collect::<Vec<_>>(),
+            vec![1, 2],
+            "target listings should include page two"
+        );
+        let requests = server.finish();
+        assert_requests(
+            &requests,
+            "/api/v4/projects/group%2Frepo/merge_requests",
+            &[
+                ("state", "all"),
+                ("target_branch", "main"),
+                ("order_by", "updated_at"),
+                ("sort", "desc"),
+            ],
+            &["1", "2"],
+        );
+    });
+}
+
+#[test]
+fn list_mrs_for_commit_includes_page_two() {
+    run(async {
+        let (client, server) = mock_client(vec![
+            MockResponse {
+                body: page(&[mr(1, "first")]),
+                next_page: Some("2"),
+            },
+            MockResponse {
+                body: page(&[mr(2, "second")]),
+                next_page: None,
+            },
+        ]);
+
+        let mrs = client
+            .list_mrs_for_commit(
+                GitLabProjectId::new("group", "repo"),
+                "0123456789abcdef0123456789abcdef01234567",
+            )
+            .await
+            .expect("all commit MR pages should be listed");
+        assert_eq!(
+            mrs.iter().map(|mr| mr.iid).collect::<Vec<_>>(),
+            vec![1, 2],
+            "commit listings should include page two"
+        );
+        assert_requests(
+            &server.finish(),
+            "/api/v4/projects/group%2Frepo/repository/commits/0123456789abcdef0123456789abcdef01234567/merge_requests",
+            &[],
+            &["1", "2"],
+        );
+    });
+}
+
+#[test]
+fn list_open_mrs_stops_after_a_normal_first_page() {
+    run(async {
+        let (client, server) = mock_client(vec![MockResponse {
+            body: page(&[mr(1, "first")]),
+            next_page: None,
+        }]);
+
+        let mrs = client
+            .list_open_mrs(GitLabProjectId::new("group", "repo"))
+            .await
+            .expect("a normal first page should be listed");
+        assert_eq!(mrs.len(), 1, "the first page should be returned unchanged");
+        assert_requests(
+            &server.finish(),
+            "/api/v4/projects/group%2Frepo/merge_requests",
+            &[("state", "opened"), ("order_by", "created_at")],
+            &["1"],
+        );
+    });
+}
+
+#[test]
+fn list_open_mrs_stops_on_an_empty_page() {
+    run(async {
+        let (client, server) = mock_client(vec![
+            MockResponse {
+                body: page(&[mr(1, "first")]),
+                next_page: Some("2"),
+            },
+            MockResponse {
+                body: page(&[]),
+                next_page: Some("3"),
+            },
+        ]);
+
+        let mrs = client
+            .list_open_mrs(GitLabProjectId::new("group", "repo"))
+            .await
+            .expect("an empty page should terminate pagination");
+        assert_eq!(
+            mrs.iter().map(|mr| mr.iid).collect::<Vec<_>>(),
+            vec![1],
+            "an empty page should preserve earlier results"
+        );
+        assert_requests(
+            &server.finish(),
+            "/api/v4/projects/group%2Frepo/merge_requests",
+            &[("state", "opened"), ("order_by", "created_at")],
+            &["1", "2"],
+        );
+    });
+}
+
+#[test]
+fn list_open_mrs_rejects_a_repeated_page() {
+    run(async {
+        let (client, server) = mock_client(vec![
+            MockResponse {
+                body: page(&[mr(1, "first")]),
+                next_page: Some("2"),
+            },
+            MockResponse {
+                body: page(&[mr(2, "second")]),
+                next_page: Some("2"),
+            },
+        ]);
+
+        let error = client
+            .list_open_mrs(GitLabProjectId::new("group", "repo"))
+            .await
+            .expect_err("a repeated page token should terminate with an error");
+        assert!(
+            error.to_string().contains("unsafe pagination state"),
+            "repeated pagination should return a bounded error: {error:#}"
+        );
+        assert_requests(
+            &server.finish(),
+            "/api/v4/projects/group%2Frepo/merge_requests",
+            &[("state", "opened"), ("order_by", "created_at")],
+            &["1", "2"],
+        );
+    });
+}


### PR DESCRIPTION
## Context

GitLab repositories with more than 20 merge requests could hide an existing merge request on a later API page. GitButler would then miss its badge and branch relationship, sometimes attempt a duplicate creation that failed with a 409, or associate it with the wrong target branch.

Fixes #15390
https://github.com/gitbutlerapp/gitbutler/issues/15390

## Change

Paginate all GitLab merge-request listing paths at 100 items per page. The shared request path preserves each endpoint's filters, deduplicates overlapping results, and terminates safely on empty, repeated, or excessive pagination states.