### PR TITLE
Preserve branch order when switching workspaces

### DIFF
--- a/crates/but-meta/src/legacy/mod.rs
+++ b/crates/but-meta/src/legacy/mod.rs
@@ -760,7 +760,7 @@ impl RefMetadata for VirtualBranchesTomlMetadata {
 }
 
 /// Ref metadata backed by legacy TOML for historical workspace metadata and by
-/// the project database for ad-hoc branch order metadata.
+/// the project database for branch order shared with ad-hoc projections.
 pub struct BranchOrderMetadata {
     legacy: VirtualBranchesTomlMetadata,
     db: Option<but_db::DbHandle>,
@@ -814,7 +814,18 @@ impl RefMetadata for BranchOrderMetadata {
     }
 
     fn set_workspace(&mut self, value: &Self::Handle<Workspace>) -> anyhow::Result<()> {
-        self.legacy.set_workspace(value)
+        self.legacy.set_workspace(value)?;
+        if !self.read_only {
+            for stack in &value.stacks {
+                let order = stack
+                    .branches
+                    .iter()
+                    .map(|branch| branch.ref_name.clone())
+                    .collect::<Vec<_>>();
+                self.set_branch_stack_order(&order)?;
+            }
+        }
+        Ok(())
     }
 
     fn set_branch(&mut self, value: &Self::Handle<Branch>) -> anyhow::Result<()> {

--- a/crates/but-meta/tests/meta/ref_metadata_legacy.rs
+++ b/crates/but-meta/tests/meta/ref_metadata_legacy.rs
@@ -9,7 +9,7 @@ use but_core::{
     },
 };
 use but_meta::{
-    VirtualBranchesTomlMetadata,
+    BranchOrderMetadata, VirtualBranchesTomlMetadata,
     virtual_branches_legacy_types::{Stack as LegacyStack, StackBranch},
 };
 use but_testsupport::{
@@ -76,6 +76,55 @@ fn read_only_store_does_not_write_on_drop() -> anyhow::Result<()> {
         std::fs::read_to_string(&writable_toml_path)?,
         original,
         "read-only metadata is projection input and must not reconcile or persist on drop"
+    );
+    Ok(())
+}
+
+#[test]
+fn managed_workspace_order_is_available_to_ad_hoc_workspaces() -> anyhow::Result<()> {
+    let tmp = TempDir::new()?;
+    let mut store =
+        BranchOrderMetadata::from_paths(tmp.path().join("virtual-branches.toml"), tmp.path())?;
+    let workspace_name: gix::refs::FullName = "refs/heads/gitbutler/workspace".try_into()?;
+    let mut workspace = store.workspace(workspace_name.as_ref())?;
+    let refs = ["C", "A", "D", "B"]
+        .map(|name| format!("refs/heads/{name}").try_into())
+        .into_iter()
+        .collect::<Result<Vec<gix::refs::FullName>, _>>()?;
+    workspace.stacks = vec![
+        WorkspaceStack {
+            id: StackId::from_number_for_testing(1),
+            workspacecommit_relation: Merged,
+            branches: refs[..3]
+                .iter()
+                .cloned()
+                .map(|ref_name| WorkspaceStackBranch {
+                    ref_name,
+                    archived: false,
+                })
+                .collect(),
+        },
+        WorkspaceStack {
+            id: StackId::from_number_for_testing(2),
+            workspacecommit_relation: Merged,
+            branches: vec![WorkspaceStackBranch {
+                ref_name: refs[3].clone(),
+                archived: false,
+            }],
+        },
+    ];
+
+    store.set_workspace(&workspace)?;
+
+    assert_eq!(
+        store.branch_stack_order(refs[1].as_ref())?,
+        Some(refs[..3].to_vec()),
+        "managed stack order should be reusable after checking out its middle branch"
+    );
+    assert_eq!(
+        store.branch_stack_order(refs[3].as_ref())?,
+        Some(vec![refs[3].clone()]),
+        "independent stacks should remain independent"
     );
     Ok(())
 }

--- a/crates/but/tests/but/command/switch.rs
+++ b/crates/but/tests/but/command/switch.rs
@@ -139,30 +139,35 @@ Hint: run `but help` for all commands
 #[cfg(feature = "legacy")]
 #[test]
 fn switching_to_reordered_empty_branch_preserves_lower_branches() {
-    use but_core::{RefMetadata as _, ref_metadata::WorkspaceStackBranch};
-    use std::ops::DerefMut as _;
-
     let env = crate::utils::Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
-    for branch in ["A", "B", "C", "D"] {
-        env.invoke_git(&format!("branch {branch} main"));
-    }
-    env.setup_metadata_at_target(&["A", "B"], "origin/main");
+    env.but("branch new A").assert().success();
+    env.but("branch new B").assert().success();
+    env.but("branch new D --above A").assert().success();
+    env.but("branch new C --above D").assert().success();
+    env.but("move A --above D").assert().success();
 
-    // Match the managed-workspace order after adding C and D above A, then moving D below A.
-    {
-        let ctx = env.context();
-        let mut meta = ctx.meta().unwrap();
-        let workspace_ref: &gix::refs::FullNameRef =
-            but_core::WORKSPACE_REF_NAME.try_into().unwrap();
-        let mut workspace = meta.workspace(workspace_ref).unwrap();
-        workspace.deref_mut().stacks[0].branches = ["C", "A", "D"]
-            .map(|name| WorkspaceStackBranch {
-                ref_name: format!("refs/heads/{name}").try_into().unwrap(),
-                archived: false,
-            })
-            .into();
-        meta.set_workspace(&workspace).unwrap();
-    }
+    env.but("status")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ g0 [B] (no commits)
+├╯
+┊
+┊╭┄ h0 [C] (no commits)
+┊│
+┊├┄ i0 [A] (no commits)
+┊│
+┊├┄ j0 [D] (no commits)
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
 
     env.but("switch A")
         .assert()
@@ -174,16 +179,23 @@ Switched to branch 'A'
 "#]]);
     assert_eq!(env.invoke_git("rev-parse --abbrev-ref HEAD"), "A");
 
-    let status = status_json(&env);
-    let stacks = status["stacks"].as_array().unwrap();
-    assert_eq!(stacks.len(), 1);
-    let branch_names = stacks[0]["branches"]
-        .as_array()
-        .unwrap()
-        .iter()
-        .map(|branch| branch["name"].as_str().unwrap())
-        .collect::<Vec<_>>();
-    assert_eq!(branch_names, ["A", "D"]);
+    env.but("status")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ g0 [A] (no commits)
+┊│
+┊├┄ h0 [D] (no commits)
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
 }
 
 #[test]

--- a/crates/but/tests/but/command/switch.rs
+++ b/crates/but/tests/but/command/switch.rs
@@ -136,6 +136,56 @@ Hint: run `but help` for all commands
 "#]]);
 }
 
+#[cfg(feature = "legacy")]
+#[test]
+fn switching_to_reordered_empty_branch_preserves_lower_branches() {
+    use but_core::{RefMetadata as _, ref_metadata::WorkspaceStackBranch};
+    use std::ops::DerefMut as _;
+
+    let env = crate::utils::Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    for branch in ["A", "B", "C", "D"] {
+        env.invoke_git(&format!("branch {branch} main"));
+    }
+    env.setup_metadata_at_target(&["A", "B"], "origin/main");
+
+    // Match the managed-workspace order after adding C and D above A, then moving D below A.
+    {
+        let ctx = env.context();
+        let mut meta = ctx.meta().unwrap();
+        let workspace_ref: &gix::refs::FullNameRef =
+            but_core::WORKSPACE_REF_NAME.try_into().unwrap();
+        let mut workspace = meta.workspace(workspace_ref).unwrap();
+        workspace.deref_mut().stacks[0].branches = ["C", "A", "D"]
+            .map(|name| WorkspaceStackBranch {
+                ref_name: format!("refs/heads/{name}").try_into().unwrap(),
+                archived: false,
+            })
+            .into();
+        meta.set_workspace(&workspace).unwrap();
+    }
+
+    env.but("switch A")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+Switched to branch 'A'
+
+"#]]);
+    assert_eq!(env.invoke_git("rev-parse --abbrev-ref HEAD"), "A");
+
+    let status = status_json(&env);
+    let stacks = status["stacks"].as_array().unwrap();
+    assert_eq!(stacks.len(), 1);
+    let branch_names = stacks[0]["branches"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|branch| branch["name"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(branch_names, ["A", "D"]);
+}
+
 #[test]
 fn switches_back_to_workspace() {
     let env = switch_env();

--- a/e2e/playwright/tests/singleBranch/helpers.ts
+++ b/e2e/playwright/tests/singleBranch/helpers.ts
@@ -1,5 +1,5 @@
 import { openWorkspace } from "../../src/setup.ts";
-import { clickByTestId, getByTestId, waitForTestId } from "../../src/util.ts";
+import { clickByTestId, getByTestId, stack, waitForTestId } from "../../src/util.ts";
 import { expect, type Locator, type Page } from "@playwright/test";
 import type { GitButler } from "../../src/setup.ts";
 
@@ -36,8 +36,17 @@ export function branchHeader(page: Page, branchName: string): Locator {
 	return page.locator(`[data-testid="branch-header"][data-testid-branch-header="${branchName}"]`);
 }
 
-export async function createDependentBranch(page: Page, branchName: string): Promise<void> {
-	await clickByTestId(page, "branch-header-add-dependent-branch-button");
+export async function createDependentBranch(
+	page: Page,
+	branchName: string,
+	stackBranch?: string,
+): Promise<void> {
+	const addButton = stackBranch
+		? stack(page)
+				.filter({ has: branchHeader(page, stackBranch) })
+				.getByTestId("branch-header-add-dependent-branch-button")
+		: getByTestId(page, "branch-header-add-dependent-branch-button");
+	await addButton.click();
 	const modal = await waitForTestId(page, "branch-header-add-dependent-branch-modal");
 	await modal.locator("input").fill(branchName);
 	await clickByTestId(page, "branch-header-add-dependent-branch-modal-action-button");

--- a/e2e/playwright/tests/singleBranch/moveBranch.spec.ts
+++ b/e2e/playwright/tests/singleBranch/moveBranch.spec.ts
@@ -45,6 +45,7 @@ test("keeps managed branch order after checking out a middle branch", async ({
 	const localClone = gitbutler.pathInWorkdir("local-clone");
 
 	await createNewBranch(page, "A");
+	await expect(stack(page)).toHaveCount(1);
 	await createNewBranch(page, "B");
 	await expect(stack(page)).toHaveCount(2);
 

--- a/e2e/playwright/tests/singleBranch/moveBranch.spec.ts
+++ b/e2e/playwright/tests/singleBranch/moveBranch.spec.ts
@@ -6,12 +6,25 @@ import {
 	setupSingleBranchProject,
 	SINGLE_BRANCH_NAME,
 } from "./helpers.ts";
-import { assertBranch, assertCommitSubjects, branchTip } from "../../src/branch.ts";
+import {
+	assertBranch,
+	assertCommitSubjects,
+	assertSymbolicHead,
+	branchTip,
+	createNewBranch,
+} from "../../src/branch.ts";
 import { updateCommitMessage } from "../../src/commit.ts";
 import { writeToFile } from "../../src/file.ts";
 import { test } from "../../src/test.ts";
-import { clickByTestId, commitRow, dragAndDropByLocator, getByTestId } from "../../src/util.ts";
+import {
+	clickByTestId,
+	commitRow,
+	dragAndDropByLocator,
+	getByTestId,
+	stack,
+} from "../../src/util.ts";
 import { expect, type Page } from "@playwright/test";
+import { execFileSync } from "node:child_process";
 import type { GitButler } from "../../src/setup.ts";
 
 test.use({
@@ -21,6 +34,35 @@ test.use({
 			featureFlags: { singleBranch: true },
 		},
 	},
+});
+
+test("keeps managed branch order after checking out a middle branch", async ({
+	page,
+	gitbutler,
+}) => {
+	await gitbutler.runScript("project-with-remote-branches.sh");
+	await openSingleBranchWorkspace(page);
+	const localClone = gitbutler.pathInWorkdir("local-clone");
+
+	await createNewBranch(page, "A");
+	await createNewBranch(page, "B");
+	await expect(stack(page)).toHaveCount(2);
+
+	await createDependentBranch(page, "D", "A");
+	await createDependentBranch(page, "C", "A");
+	await expectBranchHeaderOrder(page, ["C", "D", "A"], "A");
+
+	await dragAndDropByLocator(page, branchHeader(page, "A"), branchHeader(page, "D"), {
+		force: true,
+		position: { x: 120, y: 0 },
+	});
+	await expectBranchHeaderOrder(page, ["C", "A", "D"], "A");
+
+	execFileSync("git", ["checkout", "A"], { cwd: localClone });
+
+	await assertSymbolicHead("A", localClone);
+	await expect(stack(page)).toHaveCount(1);
+	await expectBranchHeaderOrder(page, ["A", "D"]);
 });
 
 test("can reorder empty branches by dragging within the single-branch stack", async ({
@@ -268,11 +310,16 @@ async function dragBranchToInsertionDropzone(
 	await page.mouse.up();
 }
 
-async function expectBranchHeaderOrder(page: Page, expectedBranchNames: string[]): Promise<void> {
+async function expectBranchHeaderOrder(
+	page: Page,
+	expectedBranchNames: string[],
+	stackBranch?: string,
+): Promise<void> {
+	const root = stackBranch ? stack(page).filter({ has: branchHeader(page, stackBranch) }) : page;
 	await expect
 		.poll(
 			async () =>
-				await page
+				await root
 					.locator('[data-testid="branch-header"]')
 					.evaluateAll((headers) =>
 						headers.map((header) => header.getAttribute("data-testid-branch-header")),


### PR DESCRIPTION
We need this in order to maintain the ordering of empty branches when moving from a multi-checkout to single-checkout

## Summary

- mirror managed workspace stack order into the shared branch-order database
- preserve lower empty branches when checking out a middle branch in ad-hoc mode
- add metadata, Playwright desktop, and `but switch` regression coverage
