### PR TITLE
Cover empty stack apply transition

### DIFF
--- a/crates/but/tests/but/command/branch/apply.rs
+++ b/crates/but/tests/but/command/branch/apply.rs
@@ -8,6 +8,69 @@ use crate::utils::{CommandExt, Sandbox};
 
 use utils::create_local_branch_with_commit;
 
+#[cfg(feature = "legacy")]
+#[test]
+fn applying_empty_branch_from_single_branch_mode_preserves_current_stack() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.but("config feature single-branch enable")
+        .assert()
+        .success();
+    env.but("branch new A").assert().success();
+    env.but("branch new B --above A").assert().success();
+    env.but("branch new C --above B").assert().success();
+    env.but("branch new D").assert().success();
+    env.but("switch C").assert().success();
+
+    env.but("status")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ g0 [C] (no commits)
+┊│
+┊├┄ h0 [B] (no commits)
+┊│
+┊├┄ i0 [A] (no commits)
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("apply D").assert().success();
+    assert_eq!(
+        env.invoke_git("rev-parse --abbrev-ref HEAD"),
+        "gitbutler/workspace"
+    );
+
+    env.but("status")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ g0 [D] (no commits)
+├╯
+┊
+┊╭┄ h0 [C] (no commits)
+┊│
+┊├┄ i0 [B] (no commits)
+┊│
+┊├┄ j0 [A] (no commits)
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
 #[cfg(not(feature = "legacy"))]
 #[test]
 fn single_branch() {

--- a/e2e/playwright/tests/singleBranch/moveBranch.spec.ts
+++ b/e2e/playwright/tests/singleBranch/moveBranch.spec.ts
@@ -1,4 +1,5 @@
 import {
+	applyBranchFromBranchesView,
 	branchHeader,
 	createDependentBranch,
 	expectCurrentBranchChip,
@@ -64,6 +65,35 @@ test("keeps managed branch order after checking out a middle branch", async ({
 	await assertSymbolicHead("A", localClone);
 	await expect(stack(page)).toHaveCount(1);
 	await expectBranchHeaderOrder(page, ["A", "D"]);
+});
+
+test("keeps the ad-hoc stack when applying an independent empty branch", async ({
+	page,
+	gitbutler,
+}) => {
+	await gitbutler.runScript("project-with-remote-branches.sh");
+	await openSingleBranchWorkspace(page);
+	const localClone = gitbutler.pathInWorkdir("local-clone");
+
+	await createNewBranch(page, "A");
+	await expect(stack(page)).toHaveCount(1);
+	await createDependentBranch(page, "B", "A");
+	await expectBranchHeaderOrder(page, ["B", "A"], "A");
+	await createDependentBranch(page, "C", "A");
+	await expectBranchHeaderOrder(page, ["C", "B", "A"], "A");
+	await createNewBranch(page, "D");
+	await expect(stack(page)).toHaveCount(2);
+
+	execFileSync("git", ["checkout", "C"], { cwd: localClone });
+	await assertSymbolicHead("C", localClone);
+	await expect(stack(page)).toHaveCount(1);
+	await expectBranchHeaderOrder(page, ["C", "B", "A"]);
+
+	await applyBranchFromBranchesView(page, "D");
+	await assertSymbolicHead("gitbutler/workspace", localClone);
+	await expect(stack(page)).toHaveCount(2);
+	await expectBranchHeaderOrder(page, ["C", "B", "A"], "A");
+	await expectBranchHeaderOrder(page, ["D"], "D");
 });
 
 test("can reorder empty branches by dragging within the single-branch stack", async ({


### PR DESCRIPTION
## Stack

- Depends on #15414.
- Base branch: `design-playwright-branch-order-regression`.

## Summary

- add a `but apply` regression for transitioning from ad-hoc `[C, B, A]` on `HEAD=C` to a managed workspace containing `[C, B, A]` and independent `[D]`
- add the equivalent Playwright desktop regression with the single-branch feature enabled
- assert that `HEAD` moves to `gitbutler/workspace`

## Result

No production fix is needed on top of #15414: the branch-order persistence introduced there already preserves the complete empty stack during this inverse transition.
