### PR TITLE
Sort out the cursor vocabulary

### DIFF
--- a/apps/lite/ui/src/api/mutations.ts
+++ b/apps/lite/ui/src/api/mutations.ts
@@ -691,7 +691,7 @@ export const useCommitCreate = () => {
 
 				if (newCommitCtx) {
 					setCursor(
-						"stacks",
+						"applied",
 						commitOperand({
 							commitId: response.newCommit,
 							changeId: newCommitCtx.commit.changeId,
@@ -847,7 +847,7 @@ export const useCommitInsertBlank = () => {
 
 			if (newCommitCtx) {
 				setCursor(
-					"stacks",
+					"applied",
 					commitOperand({
 						commitId: response.newCommit,
 						changeId: newCommitCtx.commit.changeId,

--- a/apps/lite/ui/src/cursor-url.ts
+++ b/apps/lite/ui/src/cursor-url.ts
@@ -1,5 +1,5 @@
 import { decodeBytes } from "#ui/api/bytes.ts";
-import type { ListItem, ListName } from "#ui/cursors.ts";
+import type { CursorItem, CursorName } from "#ui/cursors.ts";
 import type { PageId } from "#ui/projects/project.ts";
 import type { Operand } from "#ui/operands.ts";
 
@@ -14,8 +14,8 @@ import type { Operand } from "#ui/operands.ts";
  */
 export type UrlQueryParams = {
 	page?: Exclude<PageId, "workspace">;
-	list?: "uncommitted";
-	stacks?: string;
+	active?: "uncommitted";
+	applied?: string;
 	uncommitted?: string;
 	branches?: string;
 	upstream?: string;
@@ -23,9 +23,9 @@ export type UrlQueryParams = {
 };
 
 /** The lists whose cursor is a URL param — every list but `diff`. */
-export type UrlListName = Exclude<ListName, "diff">;
+export type UrlCursorName = Exclude<CursorName, "diff">;
 
-export const isUrlList = (list: ListName): list is UrlListName => list !== "diff";
+export const isUrlCursor = (list: CursorName): list is UrlCursorName => list !== "diff";
 
 /**
  * Operand codec: `branch:<full-ref>`, `change:<change-id>` (first choice — a
@@ -50,8 +50,8 @@ const commitPrefix = "commit:";
 
 const encodePath = (path: string): string => path;
 
-const cursorParam: { [L in UrlListName]: (item: ListItem[L]) => string | null } = {
-	stacks: encodeOperand,
+const cursorParam: { [L in UrlCursorName]: (item: CursorItem[L]) => string | null } = {
+	applied: encodeOperand,
 	branches: encodeOperand,
 	upstream: encodeOperand,
 	uncommitted: encodePath,
@@ -74,7 +74,7 @@ export const commitParamRef = (
 				? { commitId: param.slice(commitPrefix.length) }
 				: null;
 
-export const encodeCursorParam = <L extends UrlListName>(
+export const encodeCursorParam = <L extends UrlCursorName>(
 	list: L,
-	item: ListItem[L],
+	item: CursorItem[L],
 ): string | null => cursorParam[list](item);

--- a/apps/lite/ui/src/cursor-url.ts
+++ b/apps/lite/ui/src/cursor-url.ts
@@ -17,7 +17,7 @@ export type UrlQueryParams = {
 	active?: "uncommitted";
 	applied?: string;
 	uncommitted?: string;
-	branches?: string;
+	unapplied?: string;
 	upstream?: string;
 	files?: string;
 };
@@ -52,7 +52,7 @@ const encodePath = (path: string): string => path;
 
 const cursorParam: { [L in UrlCursorName]: (item: CursorItem[L]) => string | null } = {
 	applied: encodeOperand,
-	branches: encodeOperand,
+	unapplied: encodeOperand,
 	upstream: encodeOperand,
 	uncommitted: encodePath,
 	files: encodePath,

--- a/apps/lite/ui/src/cursors.ts
+++ b/apps/lite/ui/src/cursors.ts
@@ -24,7 +24,7 @@ import {
 export type CursorItem = {
 	applied: Operand;
 	uncommitted: string;
-	branches: Operand;
+	unapplied: Operand;
 	upstream: Operand;
 	files: string;
 	diff: HunkOperand;
@@ -51,7 +51,7 @@ const pathKey = (path: string): string => path;
 /** One identity key per list; resolution and no-op guards share it. */
 export const cursorKey: { [L in CursorName]: (item: CursorItem[L]) => string } = {
 	applied: operandIdentityKey,
-	branches: operandIdentityKey,
+	unapplied: operandIdentityKey,
 	upstream: operandIdentityKey,
 	uncommitted: pathKey,
 	files: pathKey,

--- a/apps/lite/ui/src/cursors.ts
+++ b/apps/lite/ui/src/cursors.ts
@@ -21,8 +21,8 @@ import {
  * root changes (select the next commit, stay on the same file). Do not
  * "upgrade" them to File operands — the embedded parent would go stale.
  */
-export type ListItem = {
-	stacks: Operand;
+export type CursorItem = {
+	applied: Operand;
 	uncommitted: string;
 	branches: Operand;
 	upstream: Operand;
@@ -30,7 +30,7 @@ export type ListItem = {
 	diff: HunkOperand;
 };
 
-export type ListName = keyof ListItem;
+export type CursorName = keyof CursorItem;
 
 /**
  * The workspace page's cursors, snapshotted by pending operations that restore on cancel.
@@ -39,8 +39,8 @@ export type ListName = keyof ListItem;
  */
 export type WorkspaceCursorSnapshot = {
 	page?: "upstream" | "branches";
-	list?: "uncommitted";
-	stacks?: string;
+	active?: "uncommitted";
+	applied?: string;
 	uncommitted?: string;
 	files?: string;
 	diff: HunkOperand | null;
@@ -49,8 +49,8 @@ export type WorkspaceCursorSnapshot = {
 const pathKey = (path: string): string => path;
 
 /** One identity key per list; resolution and no-op guards share it. */
-export const cursorKey: { [L in ListName]: (item: ListItem[L]) => string } = {
-	stacks: operandIdentityKey,
+export const cursorKey: { [L in CursorName]: (item: CursorItem[L]) => string } = {
+	applied: operandIdentityKey,
 	branches: operandIdentityKey,
 	upstream: operandIdentityKey,
 	uncommitted: pathKey,

--- a/apps/lite/ui/src/focus-scopes.ts
+++ b/apps/lite/ui/src/focus-scopes.ts
@@ -79,12 +79,12 @@ export const focusHorizontalScope = ({
 	filesVisible,
 	offset,
 	sidebarFocusScope,
-	sidebarVisible,
+	detailsFullWindow,
 }: {
 	filesVisible: boolean;
 	offset: -1 | 1;
 	sidebarFocusScope: Extract<FocusScope, "uncommitted-files" | "sidebar"> | null;
-	sidebarVisible: boolean;
+	detailsFullWindow: boolean;
 }) => {
 	if (!paneNavigationAllowed()) return;
 
@@ -97,7 +97,7 @@ export const focusHorizontalScope = ({
 	// "details" resolves to whichever of its child scopes is mounted (diff or
 	// pr tab), so the rightmost slot works on both tabs.
 	const orderedFocusScopes: Array<FocusScope> = [
-		...(sidebarVisible ? [currentSidebarFocusScope ?? "sidebar"] : []),
+		...(detailsFullWindow ? [] : [currentSidebarFocusScope ?? "sidebar"]),
 		...(filesVisible ? (["files"] satisfies Array<FocusScope>) : []),
 		"details",
 	];
@@ -129,8 +129,8 @@ export const useAutofocusScope = (enabled = true) => {
 	return (el: HTMLElement | null) => {
 		if (el === null || attached.current) return;
 
-		// A list that is not the one driving the pane must not take focus on
-		// mount: its onFocus would then name it the driving list, so autofocus
+		// A list that is not the active one must not take focus on
+		// mount: its onFocus would then name it the active list, so autofocus
 		// would decide where the URL says the user is. Checked before the latch,
 		// which records having taken the one autofocus rather than having seen a
 		// ref, so a list that starts out passive can still take it later.

--- a/apps/lite/ui/src/operations/pending-operation.ts
+++ b/apps/lite/ui/src/operations/pending-operation.ts
@@ -72,15 +72,15 @@ export const getTransferKind = (transfer: PendingTransfer): TransferKind =>
 export const getTransferTarget = (
 	transfer: PendingTransfer,
 	appliedSelection: Operand | null,
-	workspaceList: "stacks" | "uncommitted",
+	activeList: "applied" | "uncommitted",
 ): Operand | null =>
 	Match.value(transfer).pipe(
 		Match.tagsExhaustive({
 			Pointer: (transfer) => transfer.target,
 			Keyboard: () =>
-				Match.value(workspaceList).pipe(
+				Match.value(activeList).pipe(
 					Match.when("uncommitted", () => uncommittedChangesOperand),
-					Match.when("stacks", () => appliedSelection),
+					Match.when("applied", () => appliedSelection),
 					Match.exhaustive,
 				),
 		}),

--- a/apps/lite/ui/src/projects/project.ts
+++ b/apps/lite/ui/src/projects/project.ts
@@ -51,7 +51,7 @@ import {
 } from "./upstream.ts";
 
 /** The workspace page's two lists; the one named here drives the details pane. */
-export type WorkspaceList = "stacks" | "uncommitted";
+export type ActiveList = "applied" | "uncommitted";
 
 type CheckableOperand = Extract<Operand, { _tag: "Commit" | "File" | "Hunk" }>;
 

--- a/apps/lite/ui/src/projects/project.ts
+++ b/apps/lite/ui/src/projects/project.ts
@@ -50,7 +50,7 @@ import {
 	type UpstreamState,
 } from "./upstream.ts";
 
-/** The workspace page's two lists; the one named here drives the details pane. */
+/** The workspace page's two lists; the one named here is active and drives the details pane. */
 export type ActiveList = "applied" | "uncommitted";
 
 type CheckableOperand = Extract<Operand, { _tag: "Commit" | "File" | "Hunk" }>;

--- a/apps/lite/ui/src/reconcile.ts
+++ b/apps/lite/ui/src/reconcile.ts
@@ -48,7 +48,7 @@ export const useStateReconciler = (): void => {
 	// id (encode-match), and a `commit:` param names an identity nothing survives.
 	const reconcileSelectedBranch = useEffectEvent(
 		(headInfo: RefInfo, headInfoIndex: HeadInfoIndex, prevHeadInfoIndex: HeadInfoIndex) => {
-			const refName = branchParamRef(currentParams().stacks);
+			const refName = branchParamRef(currentParams().applied);
 			if (refName === null) return;
 
 			const refBytes = encodeBytes(refName);

--- a/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.tsx
@@ -84,7 +84,7 @@ const filterMenuLabels: Array<[keyof BranchFilters, string]> = [
 const branchGraphStatus = (branch: ListedBranch): GraphSegmentStatus =>
 	branch.remoteRefs.length > 0 ? "LocalAndRemote" : "LocalOnly";
 
-const useIsSelected = (operand: Operand): boolean => useIsSelectedInList(operand, "branches");
+const useIsSelected = (operand: Operand): boolean => useIsSelectedInList(operand, "unapplied");
 
 const InertRow: FC<{ branch: ListedBranch; label: string }> = ({ branch, label }) => (
 	<Row interactive={false} role="treeitem" aria-label={label}>
@@ -117,7 +117,7 @@ const CommitItem: FC<{ commit: Commit }> = ({ commit }) => {
 			aria-label={title ?? "(no message)"}
 			aria-selected={isSelected}
 			isSelected={isSelected}
-			onSelect={() => setCursor("branches", operand)}
+			onSelect={() => setCursor("unapplied", operand)}
 			onContextMenu={(event) => void showNativeContextMenu(event, menuItems)}
 		>
 			<GraphSegment
@@ -229,7 +229,7 @@ const BranchItem: FC<{
 		>
 			<Row
 				isSelected={isSelected}
-				onSelect={() => setCursor("branches", operand)}
+				onSelect={() => setCursor("unapplied", operand)}
 				onContextMenu={(event) => {
 					void showNativeContextMenu(event, menuItems);
 				}}
@@ -348,8 +348,8 @@ export const BranchesList: FC<
 		(state) => projectSlice.selectors.selectPendingOperation(state, projectId)._tag === "None",
 	);
 
-	const selection = useSelection("branches", navigationIndex);
-	useCursorWriteBack("branches", navigationIndex);
+	const selection = useSelection("unapplied", navigationIndex);
+	useCursorWriteBack("unapplied", navigationIndex);
 
 	const panelRef = useRef<HTMLDivElement>(null);
 	const hotkeysRef = useRef<HTMLDivElement>(null);
@@ -363,7 +363,7 @@ export const BranchesList: FC<
 	useNavigationIndexHotkeys({
 		navigationIndex,
 		group: "Sidebar",
-		select: (newItem) => setCursor("branches", newItem),
+		select: (newItem) => setCursor("unapplied", newItem),
 		selection,
 		selectSectionPredicate: (operand) => operand._tag === "Branch",
 		ref: hotkeysRef,
@@ -410,7 +410,7 @@ export const BranchesList: FC<
 				? undefined
 				: operandIdentityKey(branchOperand({ branchRef: encodeBytes(firstBranch.refName.full) })),
 		onEnterList: () => {
-			if (selection !== null) setCursor("branches", selection);
+			if (selection !== null) setCursor("unapplied", selection);
 		},
 		panelRef,
 		listRef: hotkeysRef,

--- a/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.tsx
@@ -84,8 +84,7 @@ const filterMenuLabels: Array<[keyof BranchFilters, string]> = [
 const branchGraphStatus = (branch: ListedBranch): GraphSegmentStatus =>
 	branch.remoteRefs.length > 0 ? "LocalAndRemote" : "LocalOnly";
 
-const useIsSelected = (projectId: string, operand: Operand): boolean =>
-	useIsSelectedInList(projectId, operand, "branches");
+const useIsSelected = (operand: Operand): boolean => useIsSelectedInList(operand, "branches");
 
 const InertRow: FC<{ branch: ListedBranch; label: string }> = ({ branch, label }) => (
 	<Row interactive={false} role="treeitem" aria-label={label}>
@@ -96,9 +95,9 @@ const InertRow: FC<{ branch: ListedBranch; label: string }> = ({ branch, label }
 	</Row>
 );
 
-const CommitItem: FC<{ projectId: string; commit: Commit }> = ({ projectId, commit }) => {
+const CommitItem: FC<{ commit: Commit }> = ({ commit }) => {
 	const operand = commitOperand({ commitId: commit.id, changeId: commit.changeId });
-	const isSelected = useIsSelected(projectId, operand);
+	const isSelected = useIsSelected(operand);
 	const title = commitTitle(commit.message);
 	const copyCommit = () =>
 		startKeyboardTransfer({ sources: [operand], kind: "copy", placement: "above" });
@@ -144,9 +143,7 @@ const BranchCommits: FC<{ projectId: string; branch: ListedBranch }> = ({ projec
 	const commits = branchOwnCommits(branch, branchDetails.commits);
 	if (commits.length === 0) return <InertRow branch={branch} label="No commits." />;
 
-	return commits.map((commit) => (
-		<CommitItem key={commit.id} projectId={projectId} commit={commit} />
-	));
+	return commits.map((commit) => <CommitItem key={commit.id} commit={commit} />);
 };
 
 const BranchItem: FC<{
@@ -165,7 +162,7 @@ const BranchItem: FC<{
 		useAppSelector((state) =>
 			projectSlice.selectors.selectBranchUnfolded(state, projectId, branchRef),
 		) && canUnfold;
-	const isSelected = useIsSelected(projectId, operand);
+	const isSelected = useIsSelected(operand);
 	const [now] = useState(() => Date.now());
 
 	// Same topology as the applied list: nothing above the branch means the

--- a/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.tsx
@@ -63,7 +63,7 @@ import {
 	startKeyboardTransfer,
 	setCursor,
 	useCursorWriteBack,
-	useResolvedCursor,
+	useSelection,
 } from "#ui/use-cursor.ts";
 import { useApplyToWorkspace } from "./useApplyToWorkspace.ts";
 import type { NewBranchActions } from "./useNewBranch.ts";
@@ -351,7 +351,7 @@ export const BranchesList: FC<
 		(state) => projectSlice.selectors.selectPendingOperation(state, projectId)._tag === "None",
 	);
 
-	const selection = useResolvedCursor("branches", navigationIndex);
+	const selection = useSelection("branches", navigationIndex);
 	useCursorWriteBack("branches", navigationIndex);
 
 	const panelRef = useRef<HTMLDivElement>(null);

--- a/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
@@ -220,7 +220,7 @@ export const CommitForm: FC<{
 	const canAmend = canCommitOrAmendBase && canAmendCommit && amendTargetCommitId !== null;
 
 	const selectBranch = (option: CommitTargetComboboxItem | null) => {
-		if (option) setCursor("stacks", option.operand);
+		if (option) setCursor("applied", option.operand);
 		setOpen(false);
 	};
 
@@ -279,7 +279,7 @@ export const CommitForm: FC<{
 			{ projectId, newRef: null, placement: { type: "independent" } },
 			{
 				onSuccess: (response) => {
-					setCursor("stacks", {
+					setCursor("applied", {
 						_tag: "Branch",
 						branchRef: response.newRef.fullNameBytes,
 					});

--- a/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
@@ -115,7 +115,7 @@ export const CommitForm: FC<{
 	 * Whether the workspace holds no branch to commit onto. Committing is still
 	 * allowed — the branch is created on submit — so this is deliberately kept
 	 * apart from `commitTarget`, whose items carry an `Operand` that drives the
-	 * sidebar selection and which a branch that doesn't exist yet cannot have.
+	 * applied selection and which a branch that doesn't exist yet cannot have.
 	 */
 	hasNoBranches: boolean;
 	startCommitButtonId: string;

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -1,5 +1,5 @@
 import { ResizeHandle } from "#ui/components/ResizeHandle.tsx";
-import { startAbsorb, setCursor, useCanShowFiles, useResolvedCursor } from "#ui/use-cursor.ts";
+import { startAbsorb, setCursor, useCanShowFiles, useSelection } from "#ui/use-cursor.ts";
 import uiStyles from "#ui/components/ui.module.css";
 import { SuspenseQuery } from "@suspensive/react-query";
 import {
@@ -421,7 +421,7 @@ const DiffContents: FC<{
 	);
 	const visibleNavigationIndex = withoutFoldedHunks(navigationIndex, hunkByKey, collapsedItems);
 
-	const diffSelection = useResolvedCursor("diff", visibleNavigationIndex);
+	const diffSelection = useSelection("diff", visibleNavigationIndex);
 	const hasStoredDiffSelection = useAppSelector(
 		(state) => projectSlice.selectors.selectDiffCursor(state, projectId) !== null,
 	);
@@ -1816,7 +1816,7 @@ const Diff: FC<{
 		[filesItems, filesFilter, fileDisplayMode, filesCollapsedDirectories],
 	);
 	const filesNavigationIndex = useMemo(() => fileTreeNavigationIndex(filesRows), [filesRows]);
-	const filesSelection = useResolvedCursor("files", filesNavigationIndex);
+	const filesSelection = useSelection("files", filesNavigationIndex);
 
 	// At time of writing React Compiler cannot statically analyse that these are pure derivations of
 	// the sidebar selection, even with the helpers inlined, hence manual memoisation.

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -64,7 +64,12 @@ import {
 import { useAppDispatch, useAppSelector, useAppStore } from "#ui/store.ts";
 import { classes } from "#ui/components/classes.ts";
 import { Toggle, ToggleGroup, Toolbar, Tooltip } from "@base-ui/react";
-import type { CommitDetails, ConflictedFile, ManualConflict, TreeChange } from "@gitbutler/but-sdk";
+import type {
+	CommitDetails as CommitDetailsData,
+	ConflictedFile,
+	ManualConflict,
+	TreeChange,
+} from "@gitbutler/but-sdk";
 import {
 	type CodeViewDiffItem,
 	type CodeView as CodeViewClass,
@@ -212,7 +217,7 @@ const getCommitFileRowItems = ({
 	commitDetails,
 	manual = EMPTY_MANUAL,
 }: {
-	commitDetails: CommitDetails;
+	commitDetails: CommitDetailsData;
 	/**
 	 * Conflicted files the resolve API cannot address. They have no diff to
 	 * show, which is exactly what a conflict row is — so they keep the commit

--- a/apps/lite/ui/src/routes/project/$id/workspace/OperationControls.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OperationControls.tsx
@@ -1,5 +1,5 @@
 import { useAbsorb } from "#ui/api/mutations.ts";
-import { cancelPendingOperation, useResolvedCursor, useWorkspaceList } from "#ui/use-cursor.ts";
+import { cancelPendingOperation, useSelection, useActiveList } from "#ui/use-cursor.ts";
 import { absorptionPlanQueryOptions, headInfoQueryOptions } from "#ui/api/queries.ts";
 import { getHeadInfoIndex, type HeadInfoIndex } from "#ui/api/ref-info.ts";
 import { getButtonClassName } from "#ui/components/Button.tsx";
@@ -373,15 +373,15 @@ const TransferKeyboardOperationControls: FC<{
 	headInfoIndex: HeadInfoIndex;
 	projectId: string;
 	transfer: KeyboardTransfer;
-	sidebarNavigationIndex: NavigationIndex<Operand>;
-}> = ({ headInfoIndex, projectId, transfer, sidebarNavigationIndex }) => {
-	const workspaceList = useWorkspaceList();
-	const selection = useResolvedCursor("stacks", sidebarNavigationIndex);
+	appliedNavigationIndex: NavigationIndex<Operand>;
+}> = ({ headInfoIndex, projectId, transfer, appliedNavigationIndex }) => {
+	const activeList = useActiveList();
+	const selection = useSelection("applied", appliedNavigationIndex);
 
 	const dispatch = useAppDispatch();
 	const { mutate: executeOperation } = useExecuteOperation();
 
-	const target = getTransferTarget(keyboardTransfer(transfer), selection, workspaceList);
+	const target = getTransferTarget(keyboardTransfer(transfer), selection, activeList);
 	if (!target) return null;
 
 	const operations = getOperations(transfer.sources, target, transfer.kind);
@@ -432,8 +432,8 @@ const TransferKeyboardOperationControls: FC<{
 	);
 };
 
-export const OperationControls: FC<{ sidebarNavigationIndex: NavigationIndex<Operand> }> = ({
-	sidebarNavigationIndex,
+export const OperationControls: FC<{ appliedNavigationIndex: NavigationIndex<Operand> }> = ({
+	appliedNavigationIndex,
 }) => {
 	const { id: projectId } = useParams({ from: "/project/$id/workspace" });
 	const pendingOperation = useAppSelector((state) =>
@@ -473,7 +473,7 @@ export const OperationControls: FC<{ sidebarNavigationIndex: NavigationIndex<Ope
 									headInfoIndex={headInfoIndex}
 									projectId={projectId}
 									transfer={transfer}
-									sidebarNavigationIndex={sidebarNavigationIndex}
+									appliedNavigationIndex={appliedNavigationIndex}
 								/>
 							),
 					}),

--- a/apps/lite/ui/src/routes/project/$id/workspace/Row-utils.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Row-utils.ts
@@ -18,7 +18,7 @@ export const treeItemId = (operand: Operand): string =>
 export const useIsSelected = (
 	projectId: string,
 	operand: Operand,
-	list: "stacks" | "branches" | "upstream",
+	list: "applied" | "branches" | "upstream",
 ): boolean => useCursorMatches(list, operand);
 
 export const getRowButtonClassName = ({

--- a/apps/lite/ui/src/routes/project/$id/workspace/Row-utils.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Row-utils.ts
@@ -17,7 +17,7 @@ export const treeItemId = (operand: Operand): string =>
  */
 export const useIsSelected = (
 	operand: Operand,
-	name: "applied" | "branches" | "upstream",
+	name: "applied" | "unapplied" | "upstream",
 ): boolean => useCursorMatches(name, operand);
 
 export const getRowButtonClassName = ({

--- a/apps/lite/ui/src/routes/project/$id/workspace/Row-utils.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Row-utils.ts
@@ -9,17 +9,16 @@ export const treeItemId = (operand: Operand): string =>
 	`sidebar-treeitem-${encodeURIComponent(operandIdentityKey(operand))}`;
 
 /**
- * Whether the tab's stored selection is this operand. Rows subscribe to this
+ * Whether the stored cursor rests on this operand. Rows subscribe to this
  * plain boolean instead of consuming the navigation index, so index rebuilds
  * (fold, filter, data refresh) do not re-render every row. The list keeps the
- * stored selection normalized to the resolved one via
- * `useNormalizedSelection`.
+ * stored cursor aligned with the resolved selection via
+ * `useCursorWriteBack`.
  */
 export const useIsSelected = (
-	projectId: string,
 	operand: Operand,
-	list: "applied" | "branches" | "upstream",
-): boolean => useCursorMatches(list, operand);
+	name: "applied" | "branches" | "upstream",
+): boolean => useCursorMatches(name, operand);
 
 export const getRowButtonClassName = ({
 	variant = "ghost",

--- a/apps/lite/ui/src/routes/project/$id/workspace/Sidebar.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Sidebar.tsx
@@ -113,7 +113,7 @@ export const Sidebar: FC<{
 	branchesList: BranchesListData;
 	upstreamList: UpstreamListData;
 	navigationIndex: NavigationIndex<Operand>;
-	uncommittedFilesNavigationIndex: NavigationIndex<string>;
+	uncommittedNavigationIndex: NavigationIndex<string>;
 	onActiveFileSelection: (selection: string) => void;
 	project: ProjectForFrontend;
 	projectId: string;
@@ -122,7 +122,7 @@ export const Sidebar: FC<{
 	branchesList,
 	upstreamList,
 	navigationIndex,
-	uncommittedFilesNavigationIndex,
+	uncommittedNavigationIndex,
 	onActiveFileSelection,
 	project,
 	projectId,
@@ -396,7 +396,7 @@ export const Sidebar: FC<{
 				<WorkspaceLists
 					className={styles.page}
 					navigationIndex={navigationIndex}
-					uncommittedFilesNavigationIndex={uncommittedFilesNavigationIndex}
+					uncommittedNavigationIndex={uncommittedNavigationIndex}
 					absorptionTargetCommitIds={absorptionTargetCommitIds}
 					projectId={projectId}
 					onActiveFileSelection={onActiveFileSelection}

--- a/apps/lite/ui/src/routes/project/$id/workspace/UpstreamList.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/UpstreamList.tsx
@@ -1,5 +1,5 @@
 import rowStyles from "./Row.module.css";
-import { setCursor, useCursorWriteBack, useResolvedCursor } from "#ui/use-cursor.ts";
+import { setCursor, useCursorWriteBack, useSelection } from "#ui/use-cursor.ts";
 import uiStyles from "#ui/components/ui.module.css";
 import { commitTitle } from "#ui/commit.ts";
 import { getButtonClassName } from "#ui/components/Button.tsx";
@@ -394,7 +394,7 @@ export const UpstreamList: FC<
 		isError,
 	} = list;
 
-	const selection = useResolvedCursor("upstream", navigationIndex);
+	const selection = useSelection("upstream", navigationIndex);
 	useCursorWriteBack("upstream", navigationIndex);
 
 	const hotkeysRef = useRef<HTMLDivElement>(null);

--- a/apps/lite/ui/src/routes/project/$id/workspace/UpstreamList.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/UpstreamList.tsx
@@ -36,8 +36,7 @@ import styles from "./UpstreamList.module.css";
 
 const pluralRules = new Intl.PluralRules("en");
 
-const useIsSelected = (projectId: string, operand: Operand): boolean =>
-	useIsSelectedInList(projectId, operand, "upstream");
+const useIsSelected = (operand: Operand): boolean => useIsSelectedInList(operand, "upstream");
 
 /**
  * The target branch the incoming commits below it belong to. It heads the card
@@ -58,7 +57,6 @@ const TargetHeadRow: FC<{ label: string }> = ({ label }) => (
 );
 
 const TargetCommitRow: FC<{
-	projectId: string;
 	item: UpstreamCommitItem;
 	/**
 	 * Overrides the rail colour the commit's own position would give it. The
@@ -67,10 +65,10 @@ const TargetCommitRow: FC<{
 	 * which is true of every row there, and so tells the reader nothing.
 	 */
 	status?: GraphSegmentStatus;
-}> = ({ projectId, item, status }) => {
+}> = ({ item, status }) => {
 	const { commit, review, inWorkspace } = item;
 	const operand = commitOperand({ commitId: commit.id, changeId: commit.changeId ?? commit.id });
-	const isSelected = useIsSelected(projectId, operand);
+	const isSelected = useIsSelected(operand);
 	// A commit that landed a review is shown as that review: its title says
 	// what changed, where "Merge pull request #N from …" only says that it did.
 	const title = review?.title ?? commitTitle(commit.message);
@@ -345,7 +343,7 @@ const listItem = (
 ) => {
 	switch (item.type) {
 		case "commit":
-			return <TargetCommitRow key={item.commit.id} projectId={projectId} item={item} />;
+			return <TargetCommitRow key={item.commit.id} item={item} />;
 		case "branch":
 			return (
 				<UpstreamBranchRow
@@ -523,12 +521,7 @@ export const UpstreamList: FC<
 						<RailEdge status="Upstream" edge="head" />
 
 						{olderItems.map((item) => (
-							<TargetCommitRow
-								key={item.commit.id}
-								projectId={projectId}
-								item={item}
-								status="Upstream"
-							/>
+							<TargetCommitRow key={item.commit.id} item={item} status="Upstream" />
 						))}
 
 						<RailEdge status="Upstream" edge="tail" />

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/BranchRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/BranchRow.tsx
@@ -204,7 +204,7 @@ export const BranchRow: FC<
 
 	const endEditing = () => {
 		dispatch(projectSlice.actions.clearPendingOperation({ projectId }));
-		setCursor("stacks", operand);
+		setCursor("applied", operand);
 		focusScope("sidebar");
 	};
 
@@ -279,7 +279,7 @@ export const BranchRow: FC<
 			},
 			{
 				onSuccess: (response) => {
-					setCursor("stacks", branchOperand({ branchRef: response.newRef.fullNameBytes }));
+					setCursor("applied", branchOperand({ branchRef: response.newRef.fullNameBytes }));
 				},
 			},
 		);
@@ -330,7 +330,7 @@ export const BranchRow: FC<
 		// Hand the selection over only when folding would hide it — the selected
 		// commit sits in this segment. Unrelated selections (and the details pane
 		// they drive) stay put.
-		const commitRef = commitParamRef(currentParams().stacks);
+		const commitRef = commitParamRef(currentParams().applied);
 		const storedSegmentRef =
 			commitRef === null
 				? undefined

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/CommitRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/CommitRow.tsx
@@ -137,7 +137,7 @@ export const CommitRow: FC<
 			},
 			{
 				onSuccess: (response) => {
-					setCursor("stacks", branchOperand({ branchRef: response.newRef.fullNameBytes }));
+					setCursor("applied", branchOperand({ branchRef: response.newRef.fullNameBytes }));
 				},
 			},
 		);
@@ -180,7 +180,7 @@ export const CommitRow: FC<
 						});
 					}
 
-					setCursor("stacks", latestSelectionAfterDiscard);
+					setCursor("applied", latestSelectionAfterDiscard);
 				},
 			},
 		);
@@ -227,7 +227,7 @@ export const CommitRow: FC<
 
 	const endEditing = () => {
 		dispatch(projectSlice.actions.clearPendingOperation({ projectId }));
-		setCursor("stacks", operand);
+		setCursor("applied", operand);
 		focusScope("sidebar");
 	};
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/CommitRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/CommitRow.tsx
@@ -413,8 +413,8 @@ export const CommitRow: FC<
 					label="Commit message"
 					onMount={(el) => {
 						const firstNewline = el.value.indexOf("\n");
-						const cursorPosition = firstNewline !== -1 ? firstNewline : el.value.length;
-						el.setSelectionRange(cursorPosition, cursorPosition);
+						const caretPosition = firstNewline !== -1 ? firstNewline : el.value.length;
+						el.setSelectionRange(caretPosition, caretPosition);
 					}}
 					onSubmit={saveNewMessage}
 					onExit={endEditing}

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/ItemRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/ItemRow.tsx
@@ -12,9 +12,9 @@ export const ItemRow: FC<
 	} & Omit<ComponentProps<typeof Row>, "inert" | "isSelected" | "onSelect">
 > = ({ operand, ...props }) => {
 	const navigationIndex = assert(use(NavigationIndexContext));
-	const isSelected = useIsCursorAt("stacks", navigationIndex, operand);
+	const isSelected = useIsCursorAt("applied", navigationIndex, operand);
 	const selectItem = () => {
-		setCursor("stacks", operand);
+		setCursor("applied", operand);
 	};
 
 	return (

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.tsx
@@ -1,10 +1,10 @@
 import rowStyles from "../Row.module.css";
 import {
 	setCursor,
-	setWorkspaceList,
+	setActiveList,
 	useIsCursorAt,
-	useResolvedCursor,
-	useWorkspaceList,
+	useSelection,
+	useActiveList,
 } from "#ui/use-cursor.ts";
 import { useCommitAmend } from "#ui/api/mutations.ts";
 import { changesInWorktreeQueryOptions, headInfoQueryOptions } from "#ui/api/queries.ts";
@@ -71,7 +71,7 @@ import { segmentBottomRelativeTo } from "#ui/api/stack.ts";
 import { assert } from "#ui/assert.ts";
 import { CommitRow } from "./CommitRow.tsx";
 import { BranchRow } from "./BranchRow.tsx";
-import { useWorkspaceListsHotkeys } from "./hotkeys.ts";
+import { useActiveListsHotkeys } from "./hotkeys.ts";
 import { UncommittedChangesRow } from "./UncommittedChangesRow.tsx";
 import { ListFilterRow } from "../ListFilterRow.tsx";
 import { useListFilter } from "../useListFilter.ts";
@@ -111,7 +111,7 @@ const TreeItem: FC<
 	} & useRender.ComponentProps<"div">
 > = ({ operand, render, ...props }) => {
 	const navigationIndex = assert(use(NavigationIndexContext));
-	const isSelected = useIsCursorAt("stacks", navigationIndex, operand);
+	const isSelected = useIsCursorAt("applied", navigationIndex, operand);
 
 	return useRender({
 		render,
@@ -138,8 +138,8 @@ const OperationTarget: FC<
 	const navigationIndex = assert(use(NavigationIndexContext));
 
 	type ActiveOperation = { placement: Placement; tooltip?: string | undefined };
-	const selection = useResolvedCursor("stacks", navigationIndex);
-	const workspaceList = useWorkspaceList();
+	const selection = useSelection("applied", navigationIndex);
+	const activeList = useActiveList();
 	const activeOperation = useAppSelector((state) => {
 		const pendingOperation = projectSlice.selectors.selectPendingOperation(state, projectId);
 
@@ -155,7 +155,7 @@ const OperationTarget: FC<
 				Transfer: ({ value: mode }): ActiveOperation | null => {
 					if (mode.placement === null) return null;
 
-					const target = getTransferTarget(mode, selection, workspaceList);
+					const target = getTransferTarget(mode, selection, activeList);
 					const isActive = target !== null && operandEquals(target, operand);
 					if (!isActive) return null;
 
@@ -276,8 +276,8 @@ const UncommittedChanges: FC<{
 		collapsedDirectories,
 	});
 
-	const fileSelection = useResolvedCursor("uncommitted", navigationIndex);
-	const workspaceList = useWorkspaceList();
+	const fileSelection = useSelection("uncommitted", navigationIndex);
+	const activeList = useActiveList();
 
 	const panelRef = useRef<HTMLDivElement>(null);
 	const fileListRef = useRef<HTMLDivElement>(null);
@@ -319,9 +319,9 @@ const UncommittedChanges: FC<{
 			>
 				<FilesTree
 					canUncommit={false}
-					data-preview-source={workspaceList === "uncommitted"}
+					data-preview-source={activeList === "uncommitted"}
 					focusScope="uncommitted-files"
-					onFocus={() => setWorkspaceList("uncommitted")}
+					onFocus={() => setActiveList("uncommitted")}
 					emptyLabel={
 						filter !== null && (worktreeChanges?.changes.length ?? 0) > 0
 							? "No matching files."
@@ -339,7 +339,7 @@ const UncommittedChanges: FC<{
 					onRowSelection={onActiveFileSelection}
 					onEdgeSpill={onEdgeSpill}
 					projectId={projectId}
-					ref={useMergedRefs(fileListRef, useAutofocusScope(workspaceList === "uncommitted"))}
+					ref={useMergedRefs(fileListRef, useAutofocusScope(activeList === "uncommitted"))}
 					selection={fileSelection}
 				/>
 			</div>
@@ -536,7 +536,7 @@ const SegmentContent: FC<{
  * It dims with the rows it joins, so it has to ask about the same operand the
  * row above it stands for: the last commit while the segment is unfolded, and
  * the branch itself once it is folded, because folding takes the commits out of
- * the navigation index (see `buildSidebarNavigationIndex`). Asking after a
+ * the navigation index (see `buildAppliedNavigationIndex`). Asking after a
  * folded commit would always miss, dimming the connector to half the weight of
  * the rail on either side of it and breaking the line between branches.
  */
@@ -664,8 +664,8 @@ const Stacks: FC<{
 }> = ({ projectId, checkCommit, onAmendCommit, canAmendCommit, onEdgeSpill }) => {
 	const navigationIndex = assert(use(NavigationIndexContext));
 	const { data: headInfo } = useQuery(headInfoQueryOptions(projectId));
-	const selection = useResolvedCursor("stacks", navigationIndex);
-	const workspaceList = useWorkspaceList();
+	const selection = useSelection("applied", navigationIndex);
+	const activeList = useActiveList();
 	const dryRunOperation = useAppSelector((state) => {
 		const pendingOperation = projectSlice.selectors.selectPendingOperation(state, projectId);
 
@@ -674,7 +674,7 @@ const Stacks: FC<{
 				Transfer: ({ value: mode }) => {
 					if (mode.placement === null) return;
 
-					const target = getTransferTarget(mode, selection, workspaceList);
+					const target = getTransferTarget(mode, selection, activeList);
 					if (!target) return;
 
 					return getOperation({
@@ -697,7 +697,7 @@ const Stacks: FC<{
 	const dryRunWorkspace = dryRunOperationResult?.workspace ?? null;
 
 	const hotkeysRef = useRef<HTMLDivElement>(null);
-	useWorkspaceListsHotkeys({
+	useActiveListsHotkeys({
 		navigationIndex,
 		projectId,
 		ref: hotkeysRef,
@@ -714,9 +714,9 @@ const Stacks: FC<{
 				aria-activedescendant={selection ? treeItemId(selection) : undefined}
 				className={classes(styles.tree, styles.stacks)}
 				data-focus-scope={"sidebar" satisfies FocusScope}
-				data-preview-source={workspaceList === "stacks"}
-				onFocus={() => setWorkspaceList("stacks")}
-				ref={useMergedRefs(hotkeysRef, useAutofocusScope(workspaceList === "stacks"))}
+				data-preview-source={activeList === "applied"}
+				onFocus={() => setActiveList("applied")}
+				ref={useMergedRefs(hotkeysRef, useAutofocusScope(activeList === "applied"))}
 			>
 				{(headInfo?.stacks.toReversed() ?? []).map((stack) => (
 					<StackC
@@ -737,7 +737,7 @@ export const WorkspaceLists: FC<
 	{
 		projectId: string;
 		navigationIndex: NavigationIndex<Operand>;
-		uncommittedFilesNavigationIndex: NavigationIndex<string>;
+		uncommittedNavigationIndex: NavigationIndex<string>;
 		absorptionTargetCommitIds: ReadonlySet<string>;
 		onActiveFileSelection: (selection: string) => void;
 		stacksHeaderActions?: ReactNode;
@@ -745,7 +745,7 @@ export const WorkspaceLists: FC<
 > = ({
 	projectId,
 	navigationIndex,
-	uncommittedFilesNavigationIndex,
+	uncommittedNavigationIndex,
 	absorptionTargetCommitIds,
 	onActiveFileSelection,
 	stacksHeaderActions,
@@ -755,7 +755,7 @@ export const WorkspaceLists: FC<
 	const { data: worktreeChanges } = useQuery(changesInWorktreeQueryOptions(projectId));
 	const headInfoIndex = headInfo ? getHeadInfoIndex(headInfo) : undefined;
 
-	const appliedSelection = useResolvedCursor("stacks", navigationIndex);
+	const appliedSelection = useSelection("applied", navigationIndex);
 	const commitTargetComboboxItems = buildCommitTargetComboboxItems({
 		headInfo,
 		headInfoIndex,
@@ -858,12 +858,12 @@ export const WorkspaceLists: FC<
 		if (offset !== 1) return;
 		const item = navigationIndex.items.at(0);
 		if (item === undefined) return;
-		setCursor("stacks", item);
+		setCursor("applied", item);
 		focusScope("sidebar");
 	};
 	const spillIntoUncommittedChanges = (offset: -1 | 1) => {
 		if (offset !== -1) return;
-		const path = uncommittedFilesNavigationIndex.items.at(-1);
+		const path = uncommittedNavigationIndex.items.at(-1);
 		if (path === undefined) return;
 		onActiveFileSelection(path);
 		focusScope("uncommitted-files");
@@ -899,7 +899,7 @@ export const WorkspaceLists: FC<
 									outline="inside"
 									render={
 										<UncommittedChanges
-											navigationIndex={uncommittedFilesNavigationIndex}
+											navigationIndex={uncommittedNavigationIndex}
 											commitTarget={commitTarget}
 											projectId={projectId}
 											targetComboboxItems={commitTargetComboboxItems}

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/fold.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/fold.ts
@@ -21,7 +21,7 @@ export const toggleFoldedSegment = (
 		select,
 	}: { projectId: string; branchRefBytes: Array<number>; select: boolean },
 ) => {
-	if (select) setCursor("stacks", branchOperand({ branchRef: branchRefBytes }));
+	if (select) setCursor("applied", branchOperand({ branchRef: branchRefBytes }));
 
 	dispatch(
 		projectSlice.actions.toggleSegmentFolded({

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/hotkeys.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/hotkeys.ts
@@ -8,12 +8,7 @@ import {
 	useWorkspaceBranchAndAncestorsPush,
 	useWorkspaceIntegrateUpstream,
 } from "#ui/api/mutations.ts";
-import {
-	startKeyboardTransfer,
-	setCursor,
-	startInlineEdit,
-	useResolvedCursor,
-} from "#ui/use-cursor.ts";
+import { startKeyboardTransfer, setCursor, startInlineEdit, useSelection } from "#ui/use-cursor.ts";
 import { forgeInfoOptions, headInfoQueryOptions } from "#ui/api/queries.ts";
 import { decodeBytes } from "#ui/api/bytes.ts";
 import { getHeadInfoIndex } from "#ui/api/ref-info.ts";
@@ -69,7 +64,7 @@ const pushContextForSegment = ({
 	};
 };
 
-export const useWorkspaceListsHotkeys = ({
+export const useActiveListsHotkeys = ({
 	navigationIndex,
 	projectId,
 	ref,
@@ -90,7 +85,7 @@ export const useWorkspaceListsHotkeys = ({
 	});
 	const { data: forgeInfo } = useQuery(forgeInfoOptions(projectId));
 	const store = useAppStore();
-	const selection = useResolvedCursor("stacks", navigationIndex);
+	const selection = useSelection("applied", navigationIndex);
 	const noOperationPending = useAppSelector(
 		(state) => projectSlice.selectors.selectPendingOperation(state, projectId)._tag === "None",
 	);
@@ -191,7 +186,7 @@ export const useWorkspaceListsHotkeys = ({
 			},
 			{
 				onSuccess: (response) => {
-					setCursor("stacks", branchOperand({ branchRef: response.newRef.fullNameBytes }));
+					setCursor("applied", branchOperand({ branchRef: response.newRef.fullNameBytes }));
 				},
 			},
 		);
@@ -312,7 +307,7 @@ export const useWorkspaceListsHotkeys = ({
 						});
 					}
 
-					setCursor("stacks", latestSelectionAfterDiscard);
+					setCursor("applied", latestSelectionAfterDiscard);
 				},
 			},
 		);
@@ -439,7 +434,7 @@ export const useWorkspaceListsHotkeys = ({
 		ref,
 		navigationIndex,
 		group: "Sidebar",
-		select: (newItem) => setCursor("stacks", newItem),
+		select: (newItem) => setCursor("applied", newItem),
 		selection,
 		onEdgeSpill,
 		getKey: operandIdentityKey,

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
@@ -100,7 +100,6 @@ const useWorkspaceHotkeys = (projectId: string) => {
 	const noOperationPending = useAppSelector(
 		(state) => projectSlice.selectors.selectPendingOperation(state, projectId)._tag === "None",
 	);
-	const sidebarVisible = !detailsFullWindow;
 	const sidebarFocusScope = useSidebarFocusScope();
 	const filesVisible = canShowFiles && filesVisibleState;
 	const page = usePage();
@@ -115,7 +114,7 @@ const useWorkspaceHotkeys = (projectId: string) => {
 			filesVisible,
 			offset,
 			sidebarFocusScope,
-			sidebarVisible,
+			detailsFullWindow,
 		});
 	};
 	const focusPaneLeft = () => {
@@ -158,7 +157,7 @@ const useWorkspaceHotkeys = (projectId: string) => {
 			hotkey: workspaceHotkeys.toggleFiles.hotkey,
 			callback: () => {
 				if (focusedFocusScope === "files" && filesVisible)
-					focusScope(sidebarVisible ? "sidebar" : "diff");
+					focusScope(detailsFullWindow ? "diff" : "sidebar");
 
 				dispatch(projectSlice.actions.toggleFiles({ projectId }));
 			},
@@ -179,14 +178,14 @@ const useWorkspaceHotkeys = (projectId: string) => {
 					hotkey: "1",
 					callback: () => focusScope("uncommitted-files"),
 					options: {
-						enabled: sidebarVisible,
+						enabled: !detailsFullWindow,
 					},
 				},
 				{
 					hotkey: "2",
 					callback: () => focusScope("sidebar"),
 					options: {
-						enabled: sidebarVisible,
+						enabled: !detailsFullWindow,
 					},
 				},
 			]),
@@ -195,7 +194,7 @@ const useWorkspaceHotkeys = (projectId: string) => {
 					hotkey: "1",
 					callback: () => focusScope("sidebar"),
 					options: {
-						enabled: sidebarVisible,
+						enabled: !detailsFullWindow,
 					},
 				},
 			]),
@@ -204,7 +203,7 @@ const useWorkspaceHotkeys = (projectId: string) => {
 					hotkey: "1",
 					callback: () => focusScope("sidebar"),
 					options: {
-						enabled: sidebarVisible,
+						enabled: !detailsFullWindow,
 					},
 				},
 			]),

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
@@ -527,7 +527,7 @@ const WorkspacePage: FC = () => {
 	const upstreamList = useUpstreamList(projectId);
 
 	const appliedSelection = useSelection("applied", appliedNavigationIndex);
-	const branchesSelection = useSelection("branches", branchesList.navigationIndex);
+	const branchesSelection = useSelection("unapplied", branchesList.navigationIndex);
 	const upstreamSelection = useSelection("upstream", upstreamList.navigationIndex);
 
 	const { data: worktreeChanges } = useQuery(changesInWorktreeQueryOptions(projectId));

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
@@ -78,8 +78,8 @@ import {
 	useCanShowFiles,
 	useSidebarFocusScope,
 	usePage,
-	useResolvedCursor,
-	useWorkspaceList,
+	useSelection,
+	useActiveList,
 } from "#ui/use-cursor.ts";
 import { defaultSettings } from "#ui/settings.ts";
 
@@ -246,7 +246,7 @@ const hasAnyOperation = (sources: Array<Operand>, target: Operand, kind: Transfe
 	return !!operations.into || !!operations.above || !!operations.below;
 };
 
-const buildSidebarNavigationIndex = ({
+const buildAppliedNavigationIndex = ({
 	headInfo,
 	pendingOperation,
 	absorptionTargetCommitIds,
@@ -428,7 +428,7 @@ const WorkspacePage: FC = () => {
 	useWorkspaceHotkeys(projectId);
 
 	const selectBranch = (branch: BranchOperand) => {
-		setCursor("stacks", branchOperand(branch));
+		setCursor("applied", branchOperand(branch));
 		focusScope("sidebar");
 	};
 
@@ -516,7 +516,7 @@ const WorkspacePage: FC = () => {
 	const foldedSegments = useAppSelector((state) =>
 		projectSlice.selectors.selectFoldedSegments(state, projectId),
 	);
-	const sidebarNavigationIndex = buildSidebarNavigationIndex({
+	const appliedNavigationIndex = buildAppliedNavigationIndex({
 		headInfo,
 		pendingOperation,
 		absorptionTargetCommitIds,
@@ -527,9 +527,9 @@ const WorkspacePage: FC = () => {
 	const branchesList = useBranchesList(projectId);
 	const upstreamList = useUpstreamList(projectId);
 
-	const appliedSelection = useResolvedCursor("stacks", sidebarNavigationIndex);
-	const branchesSelection = useResolvedCursor("branches", branchesList.navigationIndex);
-	const upstreamSelection = useResolvedCursor("upstream", upstreamList.navigationIndex);
+	const appliedSelection = useSelection("applied", appliedNavigationIndex);
+	const branchesSelection = useSelection("branches", branchesList.navigationIndex);
+	const upstreamSelection = useSelection("upstream", upstreamList.navigationIndex);
 
 	const { data: worktreeChanges } = useQuery(changesInWorktreeQueryOptions(projectId));
 	const uncommittedFilesFilter = useAppSelector((state) =>
@@ -547,7 +547,7 @@ const WorkspacePage: FC = () => {
 	});
 	// Directories take the cursor as files do, so the index follows the layout the
 	// list renders — and a collapsed directory takes its files out of it too.
-	const uncommittedFilesNavigationIndex = fileTreeNavigationIndex(uncommittedFileRows);
+	const uncommittedNavigationIndex = fileTreeNavigationIndex(uncommittedFileRows);
 	const uncommittedTreeChangeDiffs = useQueries({
 		queries:
 			worktreeChanges?.changes.map((change) =>
@@ -582,12 +582,9 @@ const WorkspacePage: FC = () => {
 		if (navigation) onActiveFileSelection(navigation.itemId, navigation.firstHunk);
 	};
 
-	const uncommittedFilesSelection = useResolvedCursor(
-		"uncommitted",
-		uncommittedFilesNavigationIndex,
-	);
+	const uncommittedFilesSelection = useSelection("uncommitted", uncommittedNavigationIndex);
 
-	const workspaceList = useWorkspaceList();
+	const activeList = useActiveList();
 	// The pane's content is one component per page, as the sidebar has one list
 	// per page — the component tree, not a tag on the selection, carries where a
 	// selection came from. Only the workspace page has two lists, so only its arm
@@ -604,8 +601,8 @@ const WorkspacePage: FC = () => {
 
 		return Match.value(page).pipe(
 			Match.when("workspace", () =>
-				Match.value(workspaceList).pipe(
-					Match.when("stacks", () => (
+				Match.value(activeList).pipe(
+					Match.when("applied", () => (
 						<WorkspaceDetails selection={appliedSelection} {...viewProps} />
 					)),
 					Match.when(
@@ -634,7 +631,7 @@ const WorkspacePage: FC = () => {
 		uncommittedFilesSelection,
 		upstreamReview,
 		upstreamSelection,
-		workspaceList,
+		activeList,
 	]);
 
 	const deferredDetails = useDeferredValue(details);
@@ -704,8 +701,8 @@ const WorkspacePage: FC = () => {
 								project={selectedProject}
 								branchesList={branchesList}
 								upstreamList={upstreamList}
-								navigationIndex={sidebarNavigationIndex}
-								uncommittedFilesNavigationIndex={uncommittedFilesNavigationIndex}
+								navigationIndex={appliedNavigationIndex}
+								uncommittedNavigationIndex={uncommittedNavigationIndex}
 								absorptionTargetCommitIds={absorptionTargetCommitIds}
 								onActiveFileSelection={onActiveUncommittedFileSelection}
 							/>
@@ -726,7 +723,7 @@ const WorkspacePage: FC = () => {
 				</Panel>
 			</Group>
 
-			<OperationControls sidebarNavigationIndex={sidebarNavigationIndex} />
+			<OperationControls appliedNavigationIndex={appliedNavigationIndex} />
 
 			{Match.value(dialog).pipe(
 				Match.tagsExhaustive({

--- a/apps/lite/ui/src/routes/project/$id/workspace/route.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/route.tsx
@@ -21,7 +21,7 @@ export const Route = createRoute({
 			active: active === "uncommitted" ? active : undefined,
 			applied: str(params.applied),
 			uncommitted: str(params.uncommitted),
-			branches: str(params.branches),
+			unapplied: str(params.unapplied),
 			upstream: str(params.upstream),
 			files: str(params.files),
 		};

--- a/apps/lite/ui/src/routes/project/$id/workspace/route.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/route.tsx
@@ -14,12 +14,12 @@ export const Route = createRoute({
 	// so a corrupt or stale URL opens the page at defaults.
 	validateSearch: (params: Record<string, unknown>): UrlQueryParams => {
 		const page = str(params.page);
-		const list = str(params.list);
+		const active = str(params.active);
 
 		return {
 			page: page === "upstream" || page === "branches" ? page : undefined,
-			list: list === "uncommitted" ? list : undefined,
-			stacks: str(params.stacks),
+			active: active === "uncommitted" ? active : undefined,
+			applied: str(params.applied),
 			uncommitted: str(params.uncommitted),
 			branches: str(params.branches),
 			upstream: str(params.upstream),

--- a/apps/lite/ui/src/routes/project/$id/workspace/useApplyToWorkspace.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/useApplyToWorkspace.ts
@@ -22,7 +22,7 @@ export const useApplyToWorkspace = (projectId: string) => {
 					if (!appliedRef) return;
 
 					setPage("workspace");
-					setCursor("stacks", branchOperand({ branchRef: encodeBytes(appliedRef.full) }));
+					setCursor("applied", branchOperand({ branchRef: encodeBytes(appliedRef.full) }));
 				},
 			},
 		);

--- a/apps/lite/ui/src/routes/project/$id/workspace/useNewBranch.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/useNewBranch.ts
@@ -48,7 +48,7 @@ export const useNewBranch = (projectId: string): NewBranchActions => {
 					// where it can be seen — and selecting it there is what opens it for
 					// renaming, which is the first thing a canned name wants.
 					setPage("workspace");
-					setCursor("stacks", branchOperand({ branchRef: response.newRef.fullNameBytes }));
+					setCursor("applied", branchOperand({ branchRef: response.newRef.fullNameBytes }));
 					focusScope("sidebar");
 				},
 			},

--- a/apps/lite/ui/src/use-cursor.ts
+++ b/apps/lite/ui/src/use-cursor.ts
@@ -1,13 +1,13 @@
 import {
 	cursorKey,
-	type ListItem,
-	type ListName,
+	type CursorItem,
+	type CursorName,
 	type WorkspaceCursorSnapshot,
 } from "#ui/cursors.ts";
 import {
 	encodeCursorParam,
-	isUrlList,
-	type UrlListName,
+	isUrlCursor,
+	type UrlCursorName,
 	type UrlQueryParams,
 } from "#ui/cursor-url.ts";
 import {
@@ -15,7 +15,7 @@ import {
 	type InlineEditOperand,
 } from "#ui/operations/pending-operation.ts";
 import type { Operand } from "#ui/operands.ts";
-import type { PageId, WorkspaceList } from "#ui/projects/project.ts";
+import type { PageId, ActiveList } from "#ui/projects/project.ts";
 import { projectSlice } from "#ui/projects/state.ts";
 import { writeLastPlace } from "#ui/project.ts";
 import { router } from "#ui/router.ts";
@@ -42,8 +42,8 @@ const WORKSPACE_ROUTE = "/project/$id/workspace" as const;
 // Indexing the per-list map with a union collapses it to an intersection;
 // this view is what the generic paths below call.
 const encodeUnion = encodeCursorParam as (
-	list: UrlListName,
-	item: ListItem[UrlListName],
+	list: UrlCursorName,
+	item: CursorItem[UrlCursorName],
 ) => string | null;
 
 /**
@@ -69,10 +69,10 @@ export const currentParams = (): UrlQueryParams => router.state.location.search 
  */
 const encodedIndexes = new WeakMap<object, Map<string, unknown>>();
 
-const encodedIndex = <L extends UrlListName>(
+const encodedIndex = <L extends UrlCursorName>(
 	list: L,
-	navigationIndex: NavigationIndex<ListItem[L]>,
-): Map<string, ListItem[L]> => {
+	navigationIndex: NavigationIndex<CursorItem[L]>,
+): Map<string, CursorItem[L]> => {
 	let byParam = encodedIndexes.get(navigationIndex);
 	if (!byParam) {
 		byParam = new Map();
@@ -82,54 +82,55 @@ const encodedIndex = <L extends UrlListName>(
 		}
 		encodedIndexes.set(navigationIndex, byParam);
 	}
-	return byParam as Map<string, ListItem[L]>;
+	return byParam as Map<string, CursorItem[L]>;
 };
 
-const resolveCursorParam = <L extends UrlListName>(
+const resolveCursorParam = <L extends UrlCursorName>(
 	list: L,
 	param: string | undefined,
-	navigationIndex: NavigationIndex<ListItem[L]>,
-): ListItem[L] | null =>
+	navigationIndex: NavigationIndex<CursorItem[L]>,
+): CursorItem[L] | null =>
 	(param === undefined ? undefined : encodedIndex(list, navigationIndex).get(param)) ??
 	navigationIndex.items[0] ??
 	null;
 
 /** The cursor resolved against what the list currently shows. */
-export const useResolvedCursor = <L extends ListName>(
+export const useSelection = <L extends CursorName>(
 	list: L,
-	navigationIndex: NavigationIndex<ListItem[L]>,
-): ListItem[L] | null => {
+	navigationIndex: NavigationIndex<CursorItem[L]>,
+): CursorItem[L] | null => {
 	// Both stores are subscribed unconditionally so hook order never depends
 	// on the list; every call site passes a literal list name anyway.
 	const param = useSearch({
 		from: WORKSPACE_ROUTE,
-		select: (params: UrlQueryParams) => (isUrlList(list) ? params[list as UrlListName] : undefined),
+		select: (params: UrlQueryParams) =>
+			isUrlCursor(list) ? params[list as UrlCursorName] : undefined,
 	});
 	const storedDiff = useAppSelector((state) =>
 		projectSlice.selectors.selectDiffCursor(state, projectIdOf()),
 	);
 
 	return (
-		isUrlList(list)
+		isUrlCursor(list)
 			? resolveCursorParam(list, param, navigationIndex as never)
 			: resolveNavigationIndexSelection(
-					navigationIndex as NavigationIndex<ListItem["diff"]>,
+					navigationIndex as NavigationIndex<CursorItem["diff"]>,
 					storedDiff,
 					cursorKey.diff,
 				)
-	) as ListItem[L] | null;
+	) as CursorItem[L] | null;
 };
 
 /**
  * Whether the resolved cursor rests on `item`. A primitive, so a cursor move
  * re-renders the two affected rows rather than the whole list.
  */
-export const useIsCursorAt = <L extends ListName>(
+export const useIsCursorAt = <L extends CursorName>(
 	list: L,
-	navigationIndex: NavigationIndex<ListItem[L]>,
-	item: ListItem[L],
+	navigationIndex: NavigationIndex<CursorItem[L]>,
+	item: CursorItem[L],
 ): boolean => {
-	const resolved = useResolvedCursor(list, navigationIndex);
+	const resolved = useSelection(list, navigationIndex);
 	return resolved !== null && cursorKey[list](resolved) === cursorKey[list](item);
 };
 
@@ -138,7 +139,7 @@ export const useIsCursorAt = <L extends ListName>(
  * Rows subscribe to this plain boolean so index rebuilds (fold, filter, data
  * refresh) do not re-render every row.
  */
-export const useCursorMatches = <L extends UrlListName>(list: L, item: ListItem[L]): boolean =>
+export const useCursorMatches = <L extends UrlCursorName>(list: L, item: CursorItem[L]): boolean =>
 	useSearch({
 		from: WORKSPACE_ROUTE,
 		select: (params: UrlQueryParams) => params[list] === encodeCursorParam(list, item),
@@ -154,16 +155,16 @@ export const usePage = (): PageId =>
 const pageOf = (): PageId => currentParams().page ?? "workspace";
 
 /** The workspace page's driving list, `stacks` unless the URL says otherwise. */
-export const useWorkspaceList = (): WorkspaceList =>
+export const useActiveList = (): ActiveList =>
 	useSearch({
 		from: WORKSPACE_ROUTE,
-		select: (params: UrlQueryParams) => params.list ?? "stacks",
+		select: (params: UrlQueryParams) => params.active ?? "applied",
 	});
 
-const workspaceListOf = (): WorkspaceList => currentParams().list ?? "stacks";
+const activeListOf = (): ActiveList => currentParams().active ?? "applied";
 
 const drivenByUncommitted = (params: UrlQueryParams): boolean =>
-	(params.page ?? "workspace") === "workspace" && (params.list ?? "stacks") === "uncommitted";
+	(params.page ?? "workspace") === "workspace" && (params.active ?? "applied") === "uncommitted";
 
 /**
  * The uncommitted list is itself a file list, so while it drives the pane a
@@ -199,7 +200,7 @@ const navigateParams = (update: (prev: UrlQueryParams) => UrlQueryParams): void 
 	});
 };
 
-const setDiffCursor = (selection: ListItem["diff"] | null): void => {
+const setDiffCursor = (selection: CursorItem["diff"] | null): void => {
 	store.dispatch(projectSlice.actions.selectDiffCursor({ projectId: projectIdOf(), selection }));
 };
 
@@ -216,14 +217,14 @@ const dissolveInvalidOperation = (selection: Operand | null): void => {
 };
 
 /** Move a list's cursor. */
-export const setCursor = <L extends ListName>(list: L, item: ListItem[L] | null): void => {
-	if (!isUrlList(list)) {
-		setDiffCursor(item as ListItem["diff"] | null);
+export const setCursor = <L extends CursorName>(list: L, item: CursorItem[L] | null): void => {
+	if (!isUrlCursor(list)) {
+		setDiffCursor(item as CursorItem["diff"] | null);
 		return;
 	}
 
 	const encoded =
-		item === null ? undefined : (encodeUnion(list, item as ListItem[UrlListName]) ?? undefined);
+		item === null ? undefined : (encodeUnion(list, item as CursorItem[UrlCursorName]) ?? undefined);
 	// Selecting the same item is a no-op, side effects included; selecting
 	// null always lands (it may still have sub-cursors to clear).
 	if (item !== null && currentParams()[list] === encoded) return;
@@ -232,10 +233,10 @@ export const setCursor = <L extends ListName>(list: L, item: ListItem[L] | null)
 		...prev,
 		[list]: encoded,
 		// The file and diff cursors follow whatever the stacks cursor rests on.
-		...(list === "stacks" ? { files: undefined } : {}),
+		...(list === "applied" ? { files: undefined } : {}),
 	}));
 
-	if (list === "stacks") {
+	if (list === "applied") {
 		setDiffCursor(null);
 		dissolveInvalidOperation(item as Operand | null);
 	}
@@ -250,10 +251,10 @@ export const setPage = (page: PageId): void => {
 };
 
 /** Name the workspace list that drives the details pane. */
-export const setWorkspaceList = (list: WorkspaceList): void => {
-	if (workspaceListOf() === list) return;
+export const setActiveList = (list: ActiveList): void => {
+	if (activeListOf() === list) return;
 
-	navigateParams((prev) => ({ ...prev, list: list === "stacks" ? undefined : list }));
+	navigateParams((prev) => ({ ...prev, active: list === "applied" ? undefined : list }));
 };
 
 /* -------------------------- pending operations with restoration */
@@ -262,8 +263,8 @@ const snapshotWorkspaceCursors = (): WorkspaceCursorSnapshot => {
 	const params = currentParams();
 	return {
 		page: params.page,
-		list: params.list,
-		stacks: params.stacks,
+		active: params.active,
+		applied: params.applied,
 		uncommitted: params.uncommitted,
 		files: params.files,
 		diff: projectSlice.selectors.selectDiffCursor(store.getState(), projectIdOf()),
@@ -274,8 +275,8 @@ const restoreWorkspaceCursors = (snapshot: WorkspaceCursorSnapshot): void => {
 	navigateParams((prev) => ({
 		...prev,
 		page: snapshot.page,
-		list: snapshot.list,
-		stacks: snapshot.stacks,
+		active: snapshot.active,
+		applied: snapshot.applied,
 		uncommitted: snapshot.uncommitted,
 		files: snapshot.files,
 	}));
@@ -293,7 +294,7 @@ export const startKeyboardTransfer = ({
 }): void => {
 	const restoreSelection = snapshotWorkspaceCursors();
 	if (restoreSelection.page !== undefined)
-		navigateParams((prev) => ({ ...prev, page: undefined, list: undefined }));
+		navigateParams((prev) => ({ ...prev, page: undefined, active: undefined }));
 
 	store.dispatch(
 		projectSlice.actions.startKeyboardTransfer({
@@ -338,13 +339,13 @@ export const cancelPendingOperation = (): void => {
 };
 
 export const startInlineEdit = (operand: InlineEditOperand): void => {
-	setCursor("stacks", operand);
+	setCursor("applied", operand);
 	store.dispatch(projectSlice.actions.startInlineEdit({ projectId: projectIdOf(), operand }));
 };
 
 /* ------------------------------------------------------- rewrite handling */
 
-const operandParams = ["stacks", "branches", "upstream"] as const;
+const operandParams = ["applied", "branches", "upstream"] as const;
 
 /**
  * Rewrite `commit:` params after a commit rewrite. `change:` params need no
@@ -382,14 +383,15 @@ export const remapSearchBranch = (oldRef: string, newRef: string): void => {
  * the index — the list stores the resolved value to keep the two in
  * agreement. One effect for every list.
  */
-export const useCursorWriteBack = <L extends ListName>(
+export const useCursorWriteBack = <L extends CursorName>(
 	list: L,
-	navigationIndex: NavigationIndex<ListItem[L]>,
+	navigationIndex: NavigationIndex<CursorItem[L]>,
 ): void => {
-	const resolved = useResolvedCursor(list, navigationIndex);
+	const resolved = useSelection(list, navigationIndex);
 	const storedParam = useSearch({
 		from: WORKSPACE_ROUTE,
-		select: (params: UrlQueryParams) => (isUrlList(list) ? params[list as UrlListName] : undefined),
+		select: (params: UrlQueryParams) =>
+			isUrlCursor(list) ? params[list as UrlCursorName] : undefined,
 	});
 	const storedDiff = useAppSelector((state) =>
 		projectSlice.selectors.selectDiffCursor(state, projectIdOf()),
@@ -397,10 +399,10 @@ export const useCursorWriteBack = <L extends ListName>(
 
 	const outOfSync =
 		resolved !== null &&
-		(isUrlList(list)
-			? storedParam !== encodeUnion(list, resolved as ListItem[UrlListName])
+		(isUrlCursor(list)
+			? storedParam !== encodeUnion(list, resolved as CursorItem[UrlCursorName])
 			: storedDiff === null ||
-				cursorKey.diff(storedDiff) !== cursorKey.diff(resolved as ListItem["diff"]))
+				cursorKey.diff(storedDiff) !== cursorKey.diff(resolved as CursorItem["diff"]))
 			? resolved
 			: null;
 

--- a/apps/lite/ui/src/use-cursor.ts
+++ b/apps/lite/ui/src/use-cursor.ts
@@ -31,7 +31,7 @@ import { useEffect } from "react";
 
 /**
  * The one way in and out of navigation state. The URL holds the page, the
- * driving list and every addressable cursor; the store holds only the diff
+ * active list and every addressable cursor; the store holds only the diff
  * cursor (see cursor-url.ts for why). Callers never see the split: reads are
  * hooks here, writes are plain calls — the router and the store are both
  * module-level, so moving a cursor needs no dispatch and no hook.
@@ -145,7 +145,7 @@ export const useCursorMatches = <L extends UrlCursorName>(list: L, item: CursorI
 		select: (params: UrlQueryParams) => params[list] === encodeCursorParam(list, item),
 	});
 
-/** The sidebar page shown, `workspace` unless the URL says otherwise. */
+/** The page shown, `workspace` unless the URL says otherwise. */
 export const usePage = (): PageId =>
 	useSearch({
 		from: WORKSPACE_ROUTE,
@@ -154,7 +154,7 @@ export const usePage = (): PageId =>
 
 const pageOf = (): PageId => currentParams().page ?? "workspace";
 
-/** The workspace page's driving list, `stacks` unless the URL says otherwise. */
+/** The workspace page's active list, `applied` unless the URL says otherwise. */
 export const useActiveList = (): ActiveList =>
 	useSearch({
 		from: WORKSPACE_ROUTE,
@@ -179,7 +179,7 @@ export const useCanShowFiles = (): boolean =>
 export const sidebarFocusScopeOf = (): "sidebar" | "uncommitted-files" =>
 	drivenByUncommitted(currentParams()) ? "uncommitted-files" : "sidebar";
 
-/** The focus scope of the sidebar's driving list. */
+/** The focus scope of the sidebar's active list. */
 export const useSidebarFocusScope = (): "sidebar" | "uncommitted-files" =>
 	useSearch({
 		from: WORKSPACE_ROUTE,
@@ -204,7 +204,7 @@ const setDiffCursor = (selection: CursorItem["diff"] | null): void => {
 	store.dispatch(projectSlice.actions.selectDiffCursor({ projectId: projectIdOf(), selection }));
 };
 
-/** A stacks selection dissolves a pending operation it invalidates, as before. */
+/** An applied selection dissolves a pending operation it invalidates, as before. */
 const dissolveInvalidOperation = (selection: Operand | null): void => {
 	const pendingOperation = projectSlice.selectors.selectPendingOperation(
 		store.getState(),
@@ -232,7 +232,7 @@ export const setCursor = <L extends CursorName>(list: L, item: CursorItem[L] | n
 	navigateParams((prev) => ({
 		...prev,
 		[list]: encoded,
-		// The file and diff cursors follow whatever the stacks cursor rests on.
+		// The file and diff cursors follow whatever the applied cursor rests on.
 		...(list === "applied" ? { files: undefined } : {}),
 	}));
 
@@ -242,7 +242,7 @@ export const setCursor = <L extends CursorName>(list: L, item: CursorItem[L] | n
 	}
 };
 
-/** Switch the sidebar page. Changing pages dissolves any pending operation. */
+/** Switch the page. Changing pages dissolves any pending operation. */
 export const setPage = (page: PageId): void => {
 	if (pageOf() === page) return;
 

--- a/apps/lite/ui/src/use-cursor.ts
+++ b/apps/lite/ui/src/use-cursor.ts
@@ -345,7 +345,7 @@ export const startInlineEdit = (operand: InlineEditOperand): void => {
 
 /* ------------------------------------------------------- rewrite handling */
 
-const operandParams = ["applied", "branches", "upstream"] as const;
+const operandParams = ["applied", "unapplied", "upstream"] as const;
 
 /**
  * Rewrite `commit:` params after a commit rewrite. `change:` params need no


### PR DESCRIPTION
Follow-up to #15422, next in the train. Three small commits that make the cursor machinery say what it means. No behavior change — just names.

**Carve cursors from lists and name the applied list**

The key type spanning all the lists (and the diff) tracks cursors, so the machinery is now named after that:

- `ListName`/`ListItem` -> `CursorName`/`CursorItem`
- `useResolvedCursor` -> `useSelection`: every call site already named the result `selection` — reads return selections, writes move cursors
- `WorkspaceList` -> `ActiveList` (`?list` -> `?active`): which of the workspace page's two lists feeds Details — only one is active at a time
- the "stacks" cursor -> "applied" (`?stacks` -> `?applied`): no stack was ever selectable — the list only holds branch and commit items, and "applied" is true of both. "stacks" stays a data word (`Stack`, `headInfo.stacks`)
- indexes follow their lists: `appliedNavigationIndex`, `uncommittedNavigationIndex`
- old URLs just fall back to defaults — no migration needed

**Vocabulary long tail**

Small stuff riding along, none worth its own commit:

- `sidebarVisible` deleted: it was `!detailsFullWindow` wearing a costume, and the Sidebar never even consumed it — sites now use the real fact
- `cursorPosition` -> `caretPosition` in CommitRow, so the one text caret can't be confused with list cursors
- the `CommitDetails` SDK-type/component name clash aliased away (`CommitDetailsData`)
- Row-utils `useIsSelected` dropped a `projectId` parameter nobody used, and its doc cited a function that no longer exists
- doc comments caught up with the vocabulary (active list, applied, pending operation)

**Rename the branches cursor to unapplied**

The branches page shows stacks, so a cursor named "branches" claimed a content kind its list doesn't hold:

- cursor "branches" -> "unapplied" (`?branches` -> `?unapplied`): the page only ever shows unapplied and standalone stacks
- the cursors now read applied / unapplied / upstream — the partition carved at appliedness
- pages keep naming surfaces: the page value and its "Branches" label stay; cursors name what the list holds