### PR TITLE
Let the add-repository flow outlive the picker dialog

### DIFF
--- a/apps/lite/ui/src/components/AddProjectButton.tsx
+++ b/apps/lite/ui/src/components/AddProjectButton.tsx
@@ -1,97 +1,21 @@
-import { Toast } from "@base-ui/react";
-import { useNavigate } from "@tanstack/react-router";
 import type { FC } from "react";
-import { useAddProject } from "#ui/api/mutations.ts";
 import { getButtonClassName, type ButtonSize } from "#ui/components/Button.tsx";
-import { errorMessageForToast } from "#ui/errors.ts";
-import { writeLastOpenedProject } from "#ui/project.ts";
-
-type AddProjectOutcome = Awaited<ReturnType<typeof window.lite.addProject>>;
-
-const outcomeError = (outcome: AddProjectOutcome): string => {
-	switch (outcome.type) {
-		case "pathNotFound":
-			return "The selected path no longer exists.";
-		case "notADirectory":
-			return "The selected path is not a directory.";
-		case "bareRepository":
-			return "Bare repositories are not supported.";
-		case "nonMainWorktree":
-			return "Only a repository's main worktree can be added.";
-		case "noWorkdir":
-			return "The selected repository has no working directory.";
-		case "noDotGitDirectory":
-			return "The selected directory has no .git directory.";
-		case "reftableRefFormatUnsupported":
-			return "Repositories using reftable references are not supported.";
-		case "notAGitRepository":
-			return "The selected directory is not a Git repository.";
-		case "added":
-		case "alreadyExists":
-			return "";
-	}
-};
 
 type Props = {
 	testId: string;
 	size?: ButtonSize;
-	onBeforePick?: () => void;
+	isPending: boolean;
+	onClick: () => void;
 };
 
-export const AddProjectButton: FC<Props> = ({ testId, size, onBeforePick }) => {
-	const navigate = useNavigate();
-	const toastManager = Toast.useToastManager();
-	const { isPending, mutateAsync } = useAddProject();
-
-	const addProject = async () => {
-		onBeforePick?.();
-
-		let path: string | null;
-		try {
-			path = await window.lite.pickDirectory();
-		} catch (error) {
-			toastManager.add({
-				type: "error",
-				title: "Failed to open repository picker",
-				description: errorMessageForToast(error),
-			});
-			return;
-		}
-
-		if (path === null) return;
-
-		let outcome: AddProjectOutcome;
-		try {
-			outcome = await mutateAsync(path);
-		} catch {
-			return;
-		}
-
-		if (outcome.type === "added" || outcome.type === "alreadyExists") {
-			writeLastOpenedProject(outcome.subject.id);
-			void navigate({
-				to: "/project/$id/workspace",
-				params: { id: outcome.subject.id },
-			});
-			return;
-		}
-
-		toastManager.add({
-			type: "error",
-			title: "Could not add project",
-			description: outcomeError(outcome),
-		});
-	};
-
-	return (
-		<button
-			type="button"
-			className={getButtonClassName({ size })}
-			data-testid={testId}
-			disabled={isPending}
-			onClick={() => void addProject()}
-		>
-			{isPending ? "Adding repository…" : "Add local repository"}
-		</button>
-	);
-};
+export const AddProjectButton: FC<Props> = ({ testId, size, isPending, onClick }) => (
+	<button
+		type="button"
+		className={getButtonClassName({ size })}
+		data-testid={testId}
+		disabled={isPending}
+		onClick={onClick}
+	>
+		{isPending ? "Adding repository…" : "Add local repository"}
+	</button>
+);

--- a/apps/lite/ui/src/components/useAddLocalRepository.ts
+++ b/apps/lite/ui/src/components/useAddLocalRepository.ts
@@ -1,0 +1,78 @@
+import { Toast } from "@base-ui/react";
+import { useNavigate } from "@tanstack/react-router";
+import { useAddProject } from "#ui/api/mutations.ts";
+import { errorMessageForToast } from "#ui/errors.ts";
+import { writeLastOpenedProject } from "#ui/project.ts";
+
+type AddProjectOutcome = Awaited<ReturnType<typeof window.lite.addProject>>;
+type AddProjectFailure = Exclude<AddProjectOutcome, { type: "added" | "alreadyExists" }>;
+
+const failureMessage = (failure: AddProjectFailure): string => {
+	switch (failure.type) {
+		case "pathNotFound":
+			return "The selected path no longer exists.";
+		case "notADirectory":
+			return "The selected path is not a directory.";
+		case "bareRepository":
+			return "Bare repositories are not supported.";
+		case "nonMainWorktree":
+			return "Only a repository's main worktree can be added.";
+		case "noWorkdir":
+			return "The selected repository has no working directory.";
+		case "noDotGitDirectory":
+			return "The selected directory has no .git directory.";
+		case "reftableRefFormatUnsupported":
+			return "Repositories using reftable references are not supported.";
+		case "notAGitRepository":
+			return "The selected directory is not a Git repository.";
+	}
+};
+
+// Must be called from a component that outlives the button: the flow spans a
+// native dialog and a mutation, and the picker-dialog footer hosting the
+// button unmounts as soon as the dialog closes.
+export const useAddLocalRepository = () => {
+	const navigate = useNavigate();
+	const toastManager = Toast.useToastManager();
+	const { isPending, mutateAsync } = useAddProject();
+
+	const addLocalRepository = async () => {
+		let path: string | null;
+		try {
+			path = await window.lite.pickDirectory();
+		} catch (error) {
+			toastManager.add({
+				type: "error",
+				title: "Failed to open repository picker",
+				description: errorMessageForToast(error),
+			});
+			return;
+		}
+
+		if (path === null) return;
+
+		let outcome: AddProjectOutcome;
+		try {
+			outcome = await mutateAsync(path);
+		} catch {
+			return;
+		}
+
+		if (outcome.type === "added" || outcome.type === "alreadyExists") {
+			writeLastOpenedProject(outcome.subject.id);
+			void navigate({
+				to: "/project/$id/workspace",
+				params: { id: outcome.subject.id },
+			});
+			return;
+		}
+
+		toastManager.add({
+			type: "error",
+			title: "Could not add project",
+			description: failureMessage(outcome),
+		});
+	};
+
+	return { addLocalRepository, isPending };
+};

--- a/apps/lite/ui/src/routes/index.tsx
+++ b/apps/lite/ui/src/routes/index.tsx
@@ -2,6 +2,7 @@ import { createRoute, redirect } from "@tanstack/react-router";
 import { LiteTestId } from "@gitbutler/ui/utils/testIds";
 import type { FC } from "react";
 import { AddProjectButton } from "#ui/components/AddProjectButton.tsx";
+import { useAddLocalRepository } from "#ui/components/useAddLocalRepository.ts";
 import { Route as rootRoute } from "#ui/routes/__root.tsx";
 import { readLastOpenedProject, readLastPlace } from "#ui/project.ts";
 import styles from "./IndexPage.module.css";
@@ -10,13 +11,21 @@ const parseLastSearch = (search: string): Record<string, string> =>
 	Object.fromEntries(new URLSearchParams(search));
 
 // oxlint-disable-next-line react/only-export-components -- False positive?
-const IndexPage: FC = () => (
-	<section className={styles.page} data-testid={LiteTestId.OnboardingPage}>
-		<h1>Welcome to GitButler Lite</h1>
-		<p>Add a local Git repository to get started.</p>
-		<AddProjectButton testId={LiteTestId.OnboardingAddLocalProjectButton} />
-	</section>
-);
+const IndexPage: FC = () => {
+	const { addLocalRepository, isPending } = useAddLocalRepository();
+
+	return (
+		<section className={styles.page} data-testid={LiteTestId.OnboardingPage}>
+			<h1>Welcome to GitButler Lite</h1>
+			<p>Add a local Git repository to get started.</p>
+			<AddProjectButton
+				testId={LiteTestId.OnboardingAddLocalProjectButton}
+				isPending={isPending}
+				onClick={() => void addLocalRepository()}
+			/>
+		</section>
+	);
+};
 
 export const Route = createRoute({
 	getParentRoute: () => rootRoute,

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspacePage.tsx
@@ -18,6 +18,7 @@ import { projectSlice } from "#ui/projects/state.ts";
 import { interfaceSlice } from "#ui/interface/state.ts";
 import { PickerDialog } from "#ui/components/PickerDialog.tsx";
 import { AddProjectButton } from "#ui/components/AddProjectButton.tsx";
+import { useAddLocalRepository } from "#ui/components/useAddLocalRepository.ts";
 import { ResizeHandle } from "#ui/components/ResizeHandle.tsx";
 import { globalHotkeys, workspaceHotkeys } from "#ui/hotkeys.ts";
 import { writeLastOpenedProject } from "#ui/project.ts";
@@ -308,6 +309,8 @@ type ProjectPickerProps = {
 	projects: Array<ProjectForFrontend>;
 	selectedProjectId: string;
 	onOpenChange: (open: boolean) => void;
+	onAddProject: () => void;
+	isAddingProject: boolean;
 };
 
 const ProjectPicker: FC<ProjectPickerProps> = (p) => {
@@ -331,7 +334,11 @@ const ProjectPicker: FC<ProjectPickerProps> = (p) => {
 				<AddProjectButton
 					testId={LiteTestId.ProjectPickerAddLocalProjectButton}
 					size="small"
-					onBeforePick={() => p.onOpenChange(false)}
+					isPending={p.isAddingProject}
+					onClick={() => {
+						p.onOpenChange(false);
+						p.onAddProject();
+					}}
 				/>
 			}
 			getItemKey={(project) => project.id}
@@ -429,6 +436,10 @@ const WorkspacePage: FC = () => {
 		if (open) dispatch(interfaceSlice.actions.openDialog({ dialog: { _tag: "ProjectPicker" } }));
 		else dispatch(interfaceSlice.actions.closeDialog());
 	};
+
+	// Owned here rather than by the picker's footer button: the flow outlives
+	// the dialog, which unmounts on close.
+	const { addLocalRepository, isPending: isAddingProject } = useAddLocalRepository();
 
 	const setSettingsOpen = (open: boolean) => {
 		if (open) dispatch(interfaceSlice.actions.openDialog({ dialog: { _tag: "Settings" } }));
@@ -717,6 +728,8 @@ const WorkspacePage: FC = () => {
 							projects={projects}
 							selectedProjectId={projectId}
 							onOpenChange={setProjectPickerOpen}
+							onAddProject={() => void addLocalRepository()}
+							isAddingProject={isAddingProject}
 						/>
 					),
 					Settings: () => (

--- a/e2e/playwright/scripts/project-with-named-branch.sh
+++ b/e2e/playwright/scripts/project-with-named-branch.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 echo "GIT CONFIG $GIT_CONFIG_GLOBAL"
 echo "DATA DIR $E2E_TEST_APP_DATA_DIR"
 echo "BUT $BUT"


### PR DESCRIPTION
Follow-up to #15365, closing out problems found in review of the add-local-repository flow.

**The bug worth explaining**

Adding a repository from the project picker closed the picker *before* picking — deliberately, so the dropdown wouldn't hang open behind the OS-modal directory dialog. But the button owned the whole async flow (pick -> add -> navigate -> toasts), and closing the dialog unmounted the button. From that point the flow ran as a closure held by a dead component:

- the pending state vanished with the button: reopen the picker mid-add and you'd get a fresh, clickable "Add local repository" — second native dialog, potential double-add
- the failure toasts fired through a hook instance from an unmounted subtree — worked only because the provider scoping happened to be friendly

The onboarding page never had the problem (nothing closes there), which is why it was easy to miss: the same component was sound in one host and undermined by the other host's own close-before-pick callback.

**The fix**

- the flow moves into `useAddLocalRepository`, hosted by the page — which outlives the dialog. Its own file, so the component file keeps fast refresh happy
- `AddProjectButton` is now purely presentational (`isPending`/`onClick`); the picker closes itself inside `onClick` before delegating up — same UX, but the flow's owner never unmounts
- `isAddingProject` threads back down, so a reopened picker shows "Adding repository…" disabled instead of inviting a second click

**Riding along**

- `failureMessage` is total over `AddProjectFailure`: the success arms leave the switch instead of returning `""`
- `set -euo pipefail` in the `project-with-named-branch` e2e fixture

Verified with the onboarding and project-picker e2e journeys.