### PR TITLE
Count changed lines, not patch sides

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -112,7 +112,11 @@ import {
 import { buildIndexByKey, getAdjacent } from "#ui/workspace/address-space.ts";
 import { ChangeStats } from "#ui/routes/project/$id/workspace/ChangeStats.tsx";
 import { ChangesHeaderRow } from "#ui/routes/project/$id/workspace/ChangesHeaderRow.tsx";
-import { getLineStats } from "#ui/routes/project/$id/workspace/lineStats.ts";
+import {
+	getLineStats,
+	patchLineStats,
+	type LineStats,
+} from "#ui/routes/project/$id/workspace/lineStats.ts";
 import { FilesTree } from "#ui/routes/project/$id/workspace/FilesTree.tsx";
 import { createDiffSpec } from "#ui/operations/diff-specs.ts";
 import { TopLeftControls } from "#ui/routes/project/$id/workspace/TopLeftControls.tsx";
@@ -1342,6 +1346,7 @@ const DiffContents: FC<{
 							hasDiff={item.fileDiff.hunks.length !== 0}
 							collapsed={item.collapsed ?? false}
 							reviewState={reviewState}
+							lineStats={patchLineStats(file.patch)}
 							selected={item.id === selectedFoldedFileId}
 							setCollapsed={handleSetCollapsed(item.id)}
 							setReviewed={handleSetReviewed(item.id, file.change.path, version)}
@@ -1469,6 +1474,8 @@ type DiffFileHeaderProps = {
 	hasDiff: boolean;
 	collapsed: boolean;
 	reviewState: "reviewed" | "changed" | null;
+	/** The change's counted deltas, or `null` when there is no patch to count. */
+	lineStats: LineStats | null;
 	/** Whether the folded file's stand-in hunk holds the diff selection. */
 	selected: boolean;
 	setCollapsed: (collapsed: boolean) => void;
@@ -1552,10 +1559,16 @@ const DiffFileHeader: FC<DiffFileHeaderProps> = (p) => {
 					{reviewLabel}
 				</button>
 				<ChangeTypeBadge type={p.item.fileDiff.type} />
-				<span>
-					<span className={styles.fileDiffAdded}>+{p.item.fileDiff.additionLines.length}</span>{" "}
-					<span className={styles.fileDiffDeleted}>-{p.item.fileDiff.deletionLines.length}</span>
-				</span>
+				{p.lineStats && (p.lineStats.linesAdded > 0 || p.lineStats.linesRemoved > 0) && (
+					<span>
+						{p.lineStats.linesAdded > 0 && (
+							<span className={styles.fileDiffAdded}>+{p.lineStats.linesAdded}</span>
+						)}{" "}
+						{p.lineStats.linesRemoved > 0 && (
+							<span className={styles.fileDiffDeleted}>-{p.lineStats.linesRemoved}</span>
+						)}
+					</span>
+				)}
 
 				<Toolbar.Root aria-label="File actions" className={styles.fileHeaderActions}>
 					<Toolbar.Button

--- a/apps/lite/ui/src/routes/project/$id/workspace/lineStats.test.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/lineStats.test.ts
@@ -1,0 +1,70 @@
+import { assert } from "#ui/assert.ts";
+import { getLineStats, patchLineStats } from "#ui/routes/project/$id/workspace/lineStats.ts";
+import {
+	parsePreparedDiffFile,
+	prepareDiffFiles,
+} from "#ui/routes/project/$id/workspace/diff-view.ts";
+import { uncommittedChangesFileParent } from "#ui/addresses.ts";
+import type { ChangeState, DiffHunk, TreeChange, UnifiedPatch } from "@gitbutler/but-sdk";
+import { describe, expect, it } from "vitest";
+
+const state = (id: string): ChangeState => ({ id, kind: "Blob" });
+
+const modification = (path: string): TreeChange => ({
+	path,
+	pathBytes: [],
+	status: {
+		type: "Modification",
+		subject: { previousState: state("a"), state: state("b"), flags: null },
+	},
+});
+
+/** One changed line in a three-line file — the rest of the hunk is context. */
+const oneLineEdit: DiffHunk = {
+	oldStart: 1,
+	oldLines: 3,
+	newStart: 1,
+	newLines: 3,
+	diff: ["@@ -1,3 +1,3 @@", " one", "-two", "+TWO", " three", ""].join("\n"),
+};
+
+const patch = (hunks: Array<DiffHunk>, linesAdded: number, linesRemoved: number): UnifiedPatch => ({
+	type: "Patch",
+	subject: { hunks, isResultOfBinaryToTextConversion: false, linesAdded, linesRemoved },
+});
+
+describe("patchLineStats", () => {
+	it("reports the change deltas, not the size of each side of the patch", () => {
+		const change = modification("file.ts");
+		const unified = patch([oneLineEdit], 1, 1);
+
+		expect(patchLineStats(unified)).toEqual({ linesAdded: 1, linesRemoved: 1 });
+
+		// The parsed patch's line arrays hold every line present on each side,
+		// context included, so their lengths overcount a one-line edit — a header
+		// that reads them renders "+3 -3" for this hunk.
+		const prepared = prepareDiffFiles({
+			fileParent: uncommittedChangesFileParent,
+			changes: [change],
+			treeChangeDiffs: [unified],
+		});
+		const fileDiff = parsePreparedDiffFile(assert(prepared[0]));
+		expect(fileDiff.additionLines).toHaveLength(3);
+		expect(fileDiff.deletionLines).toHaveLength(3);
+	});
+
+	it("has no counts for a change without a patch", () => {
+		expect(patchLineStats({ type: "Binary" })).toBeNull();
+		expect(patchLineStats({ type: "TooLarge", subject: { sizeInBytes: 1e9 } })).toBeNull();
+		expect(patchLineStats(null)).toBeNull();
+		expect(patchLineStats(undefined)).toBeNull();
+	});
+});
+
+describe("getLineStats", () => {
+	it("totals the counted changes and skips the uncountable ones", () => {
+		expect(
+			getLineStats([patch([oneLineEdit], 1, 1), { type: "Binary" }, null, patch([], 4, 2)]),
+		).toEqual({ linesAdded: 5, linesRemoved: 3 });
+	});
+});

--- a/apps/lite/ui/src/routes/project/$id/workspace/lineStats.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/lineStats.ts
@@ -5,12 +5,26 @@ export type LineStats = {
 	linesRemoved: number;
 };
 
+/**
+ * One change's added/removed counts, or `null` when it has no patch to count
+ * (binary, or too large).
+ *
+ * The backend counts changed lines; the parsed patch's `additionLines` and
+ * `deletionLines` hold every line present on each side, context included, so
+ * reading their lengths inflates the numbers.
+ */
+export function patchLineStats(patch: UnifiedPatch | null | undefined): LineStats | null {
+	if (patch?.type !== "Patch") return null;
+	return { linesAdded: patch.subject.linesAdded, linesRemoved: patch.subject.linesRemoved };
+}
+
 export function getLineStats(diffs: Array<UnifiedPatch | null | undefined>): LineStats {
 	const stats: LineStats = { linesAdded: 0, linesRemoved: 0 };
 	for (const diff of diffs) {
-		if (diff?.type !== "Patch") continue;
-		stats.linesAdded += diff.subject.linesAdded;
-		stats.linesRemoved += diff.subject.linesRemoved;
+		const fileStats = patchLineStats(diff);
+		if (!fileStats) continue;
+		stats.linesAdded += fileStats.linesAdded;
+		stats.linesRemoved += fileStats.linesRemoved;
 	}
 	return stats;
 }


### PR DESCRIPTION
A small, self-contained fix for the per-file diff counts.

**The bug**: the per-file `+N -N` in the details file list read the parsed patch's `additionLines`/`deletionLines` lengths — but those arrays hold every line present on each side, *context included*. A one-line edit in a three-line hunk rendered as `+3 -3`.

- `patchLineStats(patch)` returns one change's counted deltas straight from the backend's `linesAdded`/`linesRemoved`, or `null` when there's no patch to count (binary, too large); `getLineStats` now sums through it
- `DiffFileHeader` takes the counted stats and hides the span when there's nothing to count, instead of reading the parsed arrays
- tests pin the distinction: the parsed arrays overcount *by design* — they feed rendering, not counting
