### PR TITLE
One sidebar header, one details pane

### DIFF
--- a/apps/lite/ui/src/api/ref-info.ts
+++ b/apps/lite/ui/src/api/ref-info.ts
@@ -17,6 +17,8 @@ type CommitIndex = {
 };
 
 export type HeadInfoIndex = {
+	/** Whether the workspace holds a branch at this ref — appliedness. */
+	isApplied: (ref: Array<number>) => boolean;
 	branchContextByRefBytes: (ref: Array<number>) => (StackIndex & SegmentIndex) | undefined;
 	commitContextByCommitId: (
 		commitId: string,
@@ -70,6 +72,7 @@ const buildHeadInfoIndex = (headInfo: RefInfo): HeadInfoIndex => {
 	}
 
 	return {
+		isApplied: (ref: Array<number>) => branchContextByRef.has(branchRefKey(ref)),
 		branchContextByRefBytes: (ref: Array<number>) => branchContextByRef.get(branchRefKey(ref)),
 		commitContextByCommitId: (commitId: string) => commitContextByCommitId.get(commitId),
 		commitContextsByChangeId: (changeId: string) => commitContextsByChangeId.get(changeId),

--- a/apps/lite/ui/src/reconcile.ts
+++ b/apps/lite/ui/src/reconcile.ts
@@ -52,7 +52,7 @@ export const useStateReconciler = (): void => {
 			if (refName === null) return;
 
 			const refBytes = encodeBytes(refName);
-			if (headInfoIndex.branchContextByRefBytes(refBytes)) return;
+			if (headInfoIndex.isApplied(refBytes)) return;
 
 			const prev = prevHeadInfoIndex.branchContextByRefBytes(refBytes);
 			if (!prev) return;
@@ -163,7 +163,7 @@ export const useStateReconciler = (): void => {
 	const reconcileCheckedBranchFiles = useEffectEvent(
 		(headInfoIndex: HeadInfoIndex, checkedBranchFilesByBranchName: Map<string, Set<string>>) => {
 			const invalidated = checkedBranchFiles.flatMap((file) =>
-				!headInfoIndex.branchContextByRefBytes(file.parent.branchRef) ||
+				!headInfoIndex.isApplied(file.parent.branchRef) ||
 				checkedBranchFilesByBranchName.get(decodeBytes(file.parent.branchRef))?.has(file.path) ===
 					false
 					? file.address

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -2987,14 +2987,6 @@ const FileDetails: FC<{
 	);
 };
 
-/**
- * One details component per sidebar page, as the sidebar has one list per
- * page: the component tree, not a tag on the selection, carries where a
- * selection came from. Each dispatches over the addresses its own page can
- * select, so a branch is applied or unapplied by which page shows it.
- */
-type SidebarDetailsProps = { selection: Address | null } & DetailsViewProps;
-
 /** A commit selection is shown the same way whichever page selected it. */
 const commitDetails = (
 	commit: Extract<Address, { _tag: "Commit" }>,
@@ -3011,60 +3003,40 @@ const commitDetails = (
 	</Suspense>
 );
 
-/** The details pane for the workspace tab: branches here are applied. */
-export const WorkspaceDetails: FC<SidebarDetailsProps> = ({ selection, ...viewProps }) =>
-	selection &&
-	Match.value(selection).pipe(
-		Match.tags({
-			Branch: (branch) => (
-				<AppliedBranchDetails key={branchIdentityKey(branch)} branch={branch} {...viewProps} />
-			),
-			Commit: (commit) => commitDetails(commit, viewProps),
-		}),
-		Match.orElse(() => null),
-	);
-
 /**
- * The details pane for the upstream tab. Only commits are selectable there;
- * its branch rows carry no address.
+ * The one details pane for every address-carrying selection. It dispatches on
+ * the selection itself: a branch is applied or unapplied by what the
+ * workspace holds (`headInfo`), not by which page selected it — the address
+ * says what the value is; the data says how it stands. A commit is shown the
+ * same way whichever page selected it.
  */
-export const UpstreamDetails: FC<SidebarDetailsProps & { review: TargetCommitReview | null }> = ({
-	selection,
-	review,
-	...viewProps
-}) => {
+export const Details: FC<
+	{ selection: Address | null; review: TargetCommitReview | null } & DetailsViewProps
+> = ({ selection, review, ...viewProps }) => {
 	const { id: projectId } = useParams({ from: "/project/$id/workspace" });
 	// The Pull Request tab fetches the review from the forge, so it is only
 	// offered on a forge that serves them.
 	const { data: forgeInfo } = useQuery(forgeInfoOptions(projectId));
+	const { data: headInfo } = useQuery(headInfoQueryOptions(projectId));
 	const landedReview = forgeInfo?.capabilities.prService ? review : null;
 
-	return (
-		selection &&
-		Match.value(selection).pipe(
-			Match.tags({
-				Commit: (commit) => commitDetails(commit, viewProps, landedReview),
-			}),
-			Match.orElse(() => null),
-		)
-	);
-};
+	// No selection exists before the lists render, and the lists derive from
+	// headInfo — by the time anything is selectable, it has loaded.
+	if (!selection || !headInfo) return null;
 
-/**
- * The details pane for the branches tab, which lists what the workspace does
- * not hold: its branches are unapplied.
- */
-export const BranchesDetails: FC<SidebarDetailsProps> = ({ selection, ...viewProps }) =>
-	selection &&
-	Match.value(selection).pipe(
+	return Match.value(selection).pipe(
 		Match.tags({
-			Branch: (branch) => (
-				<UnappliedBranchDetails key={branchIdentityKey(branch)} branch={branch} {...viewProps} />
-			),
-			Commit: (commit) => commitDetails(commit, viewProps),
+			Branch: (branch) =>
+				getHeadInfoIndex(headInfo).isApplied(branch.branchRef) ? (
+					<AppliedBranchDetails key={branchIdentityKey(branch)} branch={branch} {...viewProps} />
+				) : (
+					<UnappliedBranchDetails key={branchIdentityKey(branch)} branch={branch} {...viewProps} />
+				),
+			Commit: (commit) => commitDetails(commit, viewProps, landedReview),
 		}),
 		Match.orElse(() => null),
 	);
+};
 
 /** The details pane for the uncommitted-files scope. */
 export const UncommittedFilesDetails: FC<{ path: string } & DetailsViewProps> = (p) => (

--- a/apps/lite/ui/src/routes/project/$id/workspace/Page.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Page.tsx
@@ -55,13 +55,7 @@ import {
 	type Address,
 	uncommittedChangesFileParent,
 } from "#ui/addresses.ts";
-import {
-	BranchesDetails,
-	type DiffViewerHandle,
-	UncommittedFilesDetails,
-	UpstreamDetails,
-	WorkspaceDetails,
-} from "./Details.tsx";
+import { Details, type DiffViewerHandle, UncommittedFilesDetails } from "./Details.tsx";
 import { getDiffFileNavigation } from "./diff-view.ts";
 import { buildUncommittedFileRows } from "./file-row.ts";
 import { fileTreeAddressSpace, selectedFilePath } from "./file-tree.ts";
@@ -592,13 +586,12 @@ const PageBody: FC = () => {
 	const uncommittedFilesSelection = useSelection("uncommitted", uncommittedAddressSpace);
 
 	const activeList = useActiveList();
-	// The pane's content is one component per page, as the sidebar has one list
-	// per page — the component tree, not a tag on the selection, carries where a
-	// selection came from. Only the workspace page has two lists, so only its arm
-	// asks which one drives. Memoised because `useDeferredValue` compares by
-	// identity, so a freshly built element every render would defer every render.
-	// Looked up outside the memo so the details only rebuild when the review
-	// itself changes, not on every list rerun.
+	// The page picks only which list's cursor drives the pane; one Details
+	// component then dispatches on the selection itself. The uncommitted arm is
+	// the genuine fork — its cursor is a path, not an address. Memoised because
+	// `useDeferredValue` compares by identity, so a freshly built element every
+	// render would defer every render. Looked up outside the memo so the details
+	// only rebuild when the review itself changes, not on every list rerun.
 	const upstreamReview =
 		upstreamSelection?._tag === "Commit"
 			? upstreamCommitReview(upstreamList, upstreamSelection.commitId)
@@ -610,7 +603,7 @@ const PageBody: FC = () => {
 			Match.when("workspace", () =>
 				Match.value(activeList).pipe(
 					Match.when("applied", () => (
-						<WorkspaceDetails selection={appliedSelection} {...viewProps} />
+						<Details selection={appliedSelection} review={null} {...viewProps} />
 					)),
 					Match.when(
 						"uncommitted",
@@ -623,10 +616,10 @@ const PageBody: FC = () => {
 				),
 			),
 			Match.when("upstream", () => (
-				<UpstreamDetails selection={upstreamSelection} review={upstreamReview} {...viewProps} />
+				<Details selection={upstreamSelection} review={upstreamReview} {...viewProps} />
 			)),
 			Match.when("branches", () => (
-				<BranchesDetails selection={branchesSelection} {...viewProps} />
+				<Details selection={branchesSelection} review={null} {...viewProps} />
 			)),
 			Match.exhaustive,
 		);

--- a/apps/lite/ui/src/routes/project/$id/workspace/Sidebar.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Sidebar.module.css
@@ -20,52 +20,6 @@
 	}
 }
 
-/* Too narrow for the project name, keep only the folder mark. */
-@container (max-width: 275px) {
-	.workspaceNameLabel {
-		display: none;
-	}
-}
-
-.workspaceControls {
-	display: flex;
-	column-gap: 12px;
-	align-items: center;
-}
-
-.workspaceControlsLeft {
-	display: flex;
-	align-items: center;
-	min-width: 0;
-	gap: 4px;
-}
-
-.workspaceControlsActions {
-	display: flex;
-	align-items: center;
-	margin-inline-start: auto;
-	gap: 2px;
-}
-
-.workspaceName {
-	--button-gap: 8px;
-	display: flex;
-	align-items: center;
-	min-width: 0;
-}
-
-/* The folder mark is not square, so opt out of the button's icon sizing. */
-.workspaceNameFolder.workspaceNameFolder {
-	width: 17px;
-	height: 14px;
-}
-
-.workspaceNameLabel {
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-}
-
 .page {
 	border-top: 1px solid var(--border-section);
 }

--- a/apps/lite/ui/src/routes/project/$id/workspace/Sidebar.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Sidebar.tsx
@@ -7,98 +7,35 @@ import {
 	workspaceFetchStatusQueryOptions,
 } from "#ui/api/queries.ts";
 import { stackBottomRelativeTo } from "#ui/api/stack.ts";
-import { getButtonClassName } from "#ui/components/Button.tsx";
-import { classes } from "#ui/components/classes.ts";
 import { errorMessageForToast } from "#ui/errors.ts";
 import { Icon } from "#ui/components/Icon.tsx";
 import { TooltipPopup } from "#ui/components/Tooltip.tsx";
-import { globalHotkeys, workspaceHotkeys } from "#ui/hotkeys.ts";
+import { workspaceHotkeys } from "#ui/hotkeys.ts";
 import type { Address } from "#ui/addresses.ts";
 import { projectSlice } from "#ui/projects/state.ts";
 import { interfaceSlice } from "#ui/interface/state.ts";
 import { useAppDispatch, useAppSelector } from "#ui/store.ts";
-import { formatRelativeTime } from "#ui/time.ts";
 import type { AddressSpace } from "#ui/workspace/address-space.ts";
 import { Button, Toast, Toggle, ToggleGroup, Tooltip } from "@base-ui/react";
 import type { BottomUpdate, ProjectForFrontend } from "@gitbutler/but-sdk";
-import { LiteTestId } from "@gitbutler/ui/utils/testIds";
-import { useIsFetching, useIsMutating, useQuery } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { useHotkeys } from "@tanstack/react-hotkeys";
-import { Match } from "effect";
-import { type FC, useRef, useState } from "react";
+import { type FC, useRef } from "react";
 import { ToggleGroupStyles, ToggleStyles } from "#ui/components/ToggleGroup.tsx";
 import { WorkspaceLists } from "#ui/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.tsx";
 import { BranchesList } from "#ui/routes/project/$id/workspace/BranchesList.tsx";
 import type { BranchesListData } from "#ui/routes/project/$id/workspace/useBranchesList.ts";
-import { FolderIcon } from "#ui/components/FolderIcon.tsx";
 import { UpstreamList } from "#ui/routes/project/$id/workspace/UpstreamList.tsx";
 import type { UpstreamListData } from "#ui/routes/project/$id/workspace/useUpstreamList.ts";
 import { assert } from "#ui/assert.ts";
 import { Badge } from "#ui/components/Badge.tsx";
 import type { PageId } from "#ui/projects/project.ts";
 import styles from "./Sidebar.module.css";
-import { TopLeftControls } from "#ui/routes/project/$id/workspace/TopLeftControls.tsx";
+import { SidebarHeader } from "#ui/routes/project/$id/workspace/SidebarHeader.tsx";
 import { useNewBranch } from "#ui/routes/project/$id/workspace/useNewBranch.ts";
 import { showNativeMenuFromTrigger } from "#ui/native-menu.ts";
 import { RowToolbar } from "#ui/routes/project/$id/workspace/Row.tsx";
 import { getRowButtonClassName } from "#ui/routes/project/$id/workspace/Row-utils.ts";
-
-const ActivitySpinner: FC<{
-	/** Suppressed while the fetch button shows its own spinner, to avoid two spinners at once. */
-	suppressed: boolean;
-}> = (p) => {
-	const fetchingCount = useIsFetching();
-	const mutatingCount = useIsMutating();
-
-	const isFetching = fetchingCount > 0;
-	const isMutating = mutatingCount > 0;
-
-	const status = Match.value({ isFetching, isMutating }).pipe(
-		Match.when({ isFetching: true, isMutating: true }, () => "Syncing"),
-		Match.when({ isFetching: true }, () => "Loading"),
-		Match.when({ isMutating: true }, () => "Saving"),
-		Match.orElse(() => null),
-	);
-
-	return !p.suppressed && status !== null && <Icon name="spinner" aria-label={status} />;
-};
-
-const FetchFromRemotesButton: FC<{
-	canFetch: boolean;
-	isPending: boolean;
-	lastSuccessfulMs?: number | null;
-	onFetch: () => void;
-}> = (p) => {
-	const [tooltipNow, setTooltipNow] = useState(() => Date.now());
-
-	return (
-		<Tooltip.Root
-			onOpenChange={(open) => {
-				if (open) setTooltipNow(Date.now());
-			}}
-		>
-			<Tooltip.Trigger
-				aria-label={workspaceHotkeys.fetchFromRemotes.meta.name}
-				className={getButtonClassName({ iconOnly: true, variant: "ghost" })}
-				onClick={p.onFetch}
-				// We pass `disabled` here because we want to disable the button, not
-				// the tooltip.
-				render={<Button focusableWhenDisabled disabled={!p.canFetch} />}
-			>
-				<Icon name={p.isPending ? "spinner" : "refresh"} />
-			</Tooltip.Trigger>
-			<Tooltip.Portal>
-				<Tooltip.Positioner sideOffset={4}>
-					<Tooltip.Popup render={<TooltipPopup kbd={workspaceHotkeys.fetchFromRemotes.hotkey} />}>
-						{workspaceHotkeys.fetchFromRemotes.meta.name}
-						{p.lastSuccessfulMs != null &&
-							` (${formatRelativeTime(p.lastSuccessfulMs, tooltipNow)})`}
-					</Tooltip.Popup>
-				</Tooltip.Positioner>
-			</Tooltip.Portal>
-		</Tooltip.Root>
-	);
-};
 
 /** The tabs in the order they are shown, for cycling with `[` and `]`. */
 const pageOrder: Array<PageId> = ["workspace", "upstream", "branches"];
@@ -199,10 +136,6 @@ export const Sidebar: FC<{
 
 	const canCreateBranch = newBranch.enabled;
 
-	const canApplyBranch = noOperationPending;
-
-	const canOpenSettings = noOperationPending;
-
 	const ref = useRef<HTMLDivElement>(null);
 
 	useHotkeys([
@@ -212,7 +145,7 @@ export const Sidebar: FC<{
 			options: {
 				conflictBehavior: "allow",
 				meta: workspaceHotkeys.applyBranch.meta,
-				enabled: canApplyBranch,
+				enabled: noOperationPending,
 			},
 		},
 		{
@@ -280,65 +213,16 @@ export const Sidebar: FC<{
 	return (
 		<div className={styles.container} ref={ref}>
 			<div className={styles.top}>
-				<header className={styles.workspaceControls}>
-					<TopLeftControls />
-
-					<div className={styles.workspaceControlsLeft}>
-						<Tooltip.Root>
-							<Tooltip.Trigger
-								aria-label={`${globalHotkeys.selectProject.meta.name} (current: ${project.title})`}
-								data-testid={LiteTestId.ProjectPickerButton}
-								className={classes(
-									getButtonClassName({ variant: "ghost" }),
-									"text-15",
-									"text-bold",
-									styles.workspaceName,
-								)}
-								onClick={openProjectPicker}
-							>
-								<FolderIcon className={styles.workspaceNameFolder} />
-								<span className={styles.workspaceNameLabel}>{project.title}</span>
-							</Tooltip.Trigger>
-							<Tooltip.Portal>
-								<Tooltip.Positioner sideOffset={4}>
-									<Tooltip.Popup render={<TooltipPopup kbd={globalHotkeys.selectProject.hotkey} />}>
-										{globalHotkeys.selectProject.meta.name}
-									</Tooltip.Popup>
-								</Tooltip.Positioner>
-							</Tooltip.Portal>
-						</Tooltip.Root>
-						<ActivitySpinner suppressed={isWorkspaceFetchFromRemotesPending} />
-					</div>
-
-					<div className={styles.workspaceControlsActions}>
-						<FetchFromRemotesButton
-							canFetch={canFetchFromRemotes}
-							isPending={isWorkspaceFetchFromRemotesPending}
-							lastSuccessfulMs={workspaceFetchStatus?.lastSuccessfulMs}
-							onFetch={fetchFromRemotes}
-						/>
-
-						<Tooltip.Root>
-							<Tooltip.Trigger
-								aria-label={workspaceHotkeys.settings.meta.name}
-								className={getButtonClassName({ iconOnly: true, variant: "ghost" })}
-								onClick={openSettings}
-								// We pass `disabled` here because we want to disable the button, not
-								// the tooltip. Other props should be passed above.
-								render={<Button focusableWhenDisabled disabled={!canOpenSettings} />}
-							>
-								<Icon name="settings" />
-							</Tooltip.Trigger>
-							<Tooltip.Portal>
-								<Tooltip.Positioner sideOffset={4}>
-									<Tooltip.Popup render={<TooltipPopup kbd={workspaceHotkeys.settings.hotkey} />}>
-										{workspaceHotkeys.settings.meta.name}
-									</Tooltip.Popup>
-								</Tooltip.Positioner>
-							</Tooltip.Portal>
-						</Tooltip.Root>
-					</div>
-				</header>
+				<SidebarHeader
+					project={project}
+					canFetch={canFetchFromRemotes}
+					isFetchPending={isWorkspaceFetchFromRemotesPending}
+					lastSuccessfulFetchMs={workspaceFetchStatus?.lastSuccessfulMs}
+					onFetch={fetchFromRemotes}
+					canOpenSettings={noOperationPending}
+					onOpenSettings={openSettings}
+					onOpenProjectPicker={openProjectPicker}
+				/>
 
 				<ToggleGroup
 					render={<ToggleGroupStyles />}

--- a/apps/lite/ui/src/routes/project/$id/workspace/SidebarHeader.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/SidebarHeader.module.css
@@ -1,0 +1,46 @@
+/* Too narrow for the project name, keep only the folder mark. The size is
+   the sidebar's `top` container, where the header renders. */
+@container (max-width: 275px) {
+	.workspaceNameLabel {
+		display: none;
+	}
+}
+
+.workspaceControls {
+	display: flex;
+	column-gap: 12px;
+	align-items: center;
+}
+
+.workspaceControlsLeft {
+	display: flex;
+	align-items: center;
+	min-width: 0;
+	gap: 4px;
+}
+
+.workspaceControlsActions {
+	display: flex;
+	align-items: center;
+	margin-inline-start: auto;
+	gap: 2px;
+}
+
+.workspaceName {
+	--button-gap: 8px;
+	display: flex;
+	align-items: center;
+	min-width: 0;
+}
+
+/* The folder mark is not square, so opt out of the button's icon sizing. */
+.workspaceNameFolder.workspaceNameFolder {
+	width: 17px;
+	height: 14px;
+}
+
+.workspaceNameLabel {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}

--- a/apps/lite/ui/src/routes/project/$id/workspace/SidebarHeader.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/SidebarHeader.tsx
@@ -1,0 +1,149 @@
+import { getButtonClassName } from "#ui/components/Button.tsx";
+import { classes } from "#ui/components/classes.ts";
+import { FolderIcon } from "#ui/components/FolderIcon.tsx";
+import { Icon } from "#ui/components/Icon.tsx";
+import { TooltipPopup } from "#ui/components/Tooltip.tsx";
+import { globalHotkeys, workspaceHotkeys } from "#ui/hotkeys.ts";
+import { TopLeftControls } from "#ui/routes/project/$id/workspace/TopLeftControls.tsx";
+import { formatRelativeTime } from "#ui/time.ts";
+import { Button, Tooltip } from "@base-ui/react";
+import type { ProjectForFrontend } from "@gitbutler/but-sdk";
+import { LiteTestId } from "@gitbutler/ui/utils/testIds";
+import { useIsFetching, useIsMutating } from "@tanstack/react-query";
+import { Match } from "effect";
+import { type FC, useState } from "react";
+import styles from "./SidebarHeader.module.css";
+
+const ActivitySpinner: FC<{
+	/** Suppressed while the fetch button shows its own spinner, to avoid two spinners at once. */
+	suppressed: boolean;
+}> = (p) => {
+	const fetchingCount = useIsFetching();
+	const mutatingCount = useIsMutating();
+
+	const isFetching = fetchingCount > 0;
+	const isMutating = mutatingCount > 0;
+
+	const status = Match.value({ isFetching, isMutating }).pipe(
+		Match.when({ isFetching: true, isMutating: true }, () => "Syncing"),
+		Match.when({ isFetching: true }, () => "Loading"),
+		Match.when({ isMutating: true }, () => "Saving"),
+		Match.orElse(() => null),
+	);
+
+	return !p.suppressed && status !== null && <Icon name="spinner" aria-label={status} />;
+};
+
+const FetchFromRemotesButton: FC<{
+	canFetch: boolean;
+	isPending: boolean;
+	lastSuccessfulMs?: number | null;
+	onFetch: () => void;
+}> = (p) => {
+	const [tooltipNow, setTooltipNow] = useState(() => Date.now());
+
+	return (
+		<Tooltip.Root
+			onOpenChange={(open) => {
+				if (open) setTooltipNow(Date.now());
+			}}
+		>
+			<Tooltip.Trigger
+				aria-label={workspaceHotkeys.fetchFromRemotes.meta.name}
+				className={getButtonClassName({ iconOnly: true, variant: "ghost" })}
+				onClick={p.onFetch}
+				// We pass `disabled` here because we want to disable the button, not
+				// the tooltip.
+				render={<Button focusableWhenDisabled disabled={!p.canFetch} />}
+			>
+				<Icon name={p.isPending ? "spinner" : "refresh"} />
+			</Tooltip.Trigger>
+			<Tooltip.Portal>
+				<Tooltip.Positioner sideOffset={4}>
+					<Tooltip.Popup render={<TooltipPopup kbd={workspaceHotkeys.fetchFromRemotes.hotkey} />}>
+						{workspaceHotkeys.fetchFromRemotes.meta.name}
+						{p.lastSuccessfulMs != null &&
+							` (${formatRelativeTime(p.lastSuccessfulMs, tooltipNow)})`}
+					</Tooltip.Popup>
+				</Tooltip.Positioner>
+			</Tooltip.Portal>
+		</Tooltip.Root>
+	);
+};
+
+/**
+ * The app chrome at the top of the sidebar: window controls, the project
+ * picker, activity, fetch and settings. Purely presentational — the
+ * fetch/update wiring stays with the Sidebar, which also feeds it to the
+ * upstream list and the hotkeys.
+ */
+export const SidebarHeader: FC<{
+	project: ProjectForFrontend;
+	canFetch: boolean;
+	isFetchPending: boolean;
+	lastSuccessfulFetchMs?: number | null;
+	onFetch: () => void;
+	canOpenSettings: boolean;
+	onOpenSettings: () => void;
+	onOpenProjectPicker: () => void;
+}> = (p) => (
+	<header className={styles.workspaceControls}>
+		<TopLeftControls />
+
+		<div className={styles.workspaceControlsLeft}>
+			<Tooltip.Root>
+				<Tooltip.Trigger
+					aria-label={`${globalHotkeys.selectProject.meta.name} (current: ${p.project.title})`}
+					data-testid={LiteTestId.ProjectPickerButton}
+					className={classes(
+						getButtonClassName({ variant: "ghost" }),
+						"text-15",
+						"text-bold",
+						styles.workspaceName,
+					)}
+					onClick={p.onOpenProjectPicker}
+				>
+					<FolderIcon className={styles.workspaceNameFolder} />
+					<span className={styles.workspaceNameLabel}>{p.project.title}</span>
+				</Tooltip.Trigger>
+				<Tooltip.Portal>
+					<Tooltip.Positioner sideOffset={4}>
+						<Tooltip.Popup render={<TooltipPopup kbd={globalHotkeys.selectProject.hotkey} />}>
+							{globalHotkeys.selectProject.meta.name}
+						</Tooltip.Popup>
+					</Tooltip.Positioner>
+				</Tooltip.Portal>
+			</Tooltip.Root>
+			<ActivitySpinner suppressed={p.isFetchPending} />
+		</div>
+
+		<div className={styles.workspaceControlsActions}>
+			<FetchFromRemotesButton
+				canFetch={p.canFetch}
+				isPending={p.isFetchPending}
+				lastSuccessfulMs={p.lastSuccessfulFetchMs}
+				onFetch={p.onFetch}
+			/>
+
+			<Tooltip.Root>
+				<Tooltip.Trigger
+					aria-label={workspaceHotkeys.settings.meta.name}
+					className={getButtonClassName({ iconOnly: true, variant: "ghost" })}
+					onClick={p.onOpenSettings}
+					// We pass `disabled` here because we want to disable the button, not
+					// the tooltip. Other props should be passed above.
+					render={<Button focusableWhenDisabled disabled={!p.canOpenSettings} />}
+				>
+					<Icon name="settings" />
+				</Tooltip.Trigger>
+				<Tooltip.Portal>
+					<Tooltip.Positioner sideOffset={4}>
+						<Tooltip.Popup render={<TooltipPopup kbd={workspaceHotkeys.settings.hotkey} />}>
+							{workspaceHotkeys.settings.meta.name}
+						</Tooltip.Popup>
+					</Tooltip.Positioner>
+				</Tooltip.Portal>
+			</Tooltip.Root>
+		</div>
+	</header>
+);


### PR DESCRIPTION
Structure work on top of #15431. Two commits: the sidebar stops bundling app chrome with its lists, and the three details panes become one.

**Extract the sidebar header**

- the sidebar bundled app chrome — window controls, project picker, activity spinner, fetch, settings — with page switching and list hosting. The chrome is now `SidebarHeader`, purely presentational
- the fetch/update wiring stays in the Sidebar: it feeds the header, the upstream list, *and* the hotkeys — shared consumers are why it couldn't move into the header

**One details pane, dispatching on the selection**

- the three per-page details components differed by exactly one bit: what a Branch selection means — applied (workspace page) or unapplied (branches page). That's a workspace fact `headInfo` already knows, so the page was a proxy for data
- one `Details` now dispatches on the selection itself; `HeadInfoIndex` gains `isApplied`, so the question is named wherever it's asked — the reconciliation checks that tested appliedness through the truthiness of a context lookup now say it too
- the page keeps only the pick of which list's cursor drives the pane; the uncommitted arm stays a genuine fork — its cursor is a path, not an address
- known edge, accepted: unapplying a branch from its own pane flips it to the unapplied variant a frame earlier than the cursor resolution that follows

Verified with the full battery and the lite e2e suite.
