### PR TITLE
Fade the diff minimap in on scroll and out at rest

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
@@ -122,27 +122,19 @@
 
 .diffContentsContainer {
 	display: grid;
-	/* Bound the row to the pane. Left to size itself, it takes the height of the
-	   ruler's canvas — which has no height of its own but its bitmap's, which the
-	   painter sizes from this row. At a fractional device pixel ratio the rounding
-	   in that loop doesn't cancel and the pane grows a little on every frame. */
+	/* Anchors the minimap overlay. */
+	position: relative;
+	/* Bound the row to the pane rather than letting the diff size it. */
 	grid-template-rows: minmax(0, 1fr);
-	/* Code, then the minimap ruler — which collapses the column when it has
-	   nothing to map. */
-	grid-template-columns: minmax(0, 1fr) auto;
+	grid-template-columns: minmax(0, 1fr);
 	/* Second row of `.diffArea`, named rather than implied: the conflict bar
 	   above renders nothing unless there are conflicts, and auto placement would
 	   otherwise drop this into that row's `auto` track and size it to the diff. */
 	grid-row: 2;
 
 	&:has([data-minimap-navigable="true"]) .diffContents {
-		/* The ruler's edge, drawn from the code's side of it. The ruler ends where
-		   its map does — at a fixed scale a short diff doesn't reach the foot of the
-		   pane — while this column always fills the row, so the line runs unbroken
-		   from here. */
-		border-right: 1px solid var(--border-section);
-		/* Drop the native scrollbar only while the minimap is showing, so a diff too
-		   short to map keeps one. */
+		/* Drop the native scrollbar while the minimap stands in for it; a diff
+		   too short to map keeps one. */
 		scrollbar-width: none;
 
 		&::-webkit-scrollbar {

--- a/apps/lite/ui/src/routes/project/$id/workspace/DiffMinimap.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DiffMinimap.module.css
@@ -59,15 +59,31 @@
 	/* Behind the marks it covers rather than over them, so a selected hunk still
 	   reads as added or removed. */
 	--minimap-selection: color-mix(in srgb, var(--fill-pop-bg) 16%, transparent);
-	position: relative;
-
-	/* Ends where the map does rather than stretching past it. At a fixed scale a
-	   short diff simply doesn't reach the foot of the pane, and ruler below the
-	   last line is ruler the lens can never travel to. */
-	align-self: start;
+	/* Overlaid on the code's right edge, so a diff at rest keeps the whole
+	   pane. Ends where the map does: at a fixed scale a short diff doesn't
+	   reach the foot of the pane. */
+	position: absolute;
+	top: 0;
+	right: 0;
 	width: 56px;
 	height: var(--minimap-track-height, 100%);
+	/* Its own backdrop and edge, so the marks stay readable over code. */
+	border-left: 1px solid var(--border-section);
+	background-color: var(--bg-1);
 	cursor: default;
+
+	/* Hidden until the ruler's effect wakes it; no pointer events so clicks
+	   fall through to the code. */
+	opacity: 0;
+	pointer-events: none;
+	transition: opacity 0.4s ease;
+}
+
+.minimap[data-minimap-awake="true"] {
+	opacity: 1;
+	pointer-events: auto;
+	/* The awake state's duration governs the fade in. */
+	transition-duration: 0.15s;
 }
 
 /* Nothing worth mapping: no files, or the diff is barely taller than the pane. */

--- a/apps/lite/ui/src/routes/project/$id/workspace/DiffMinimap.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DiffMinimap.tsx
@@ -95,6 +95,25 @@ export const DiffMinimap: FC<{
 		let lastOffset: number | null = null;
 		let lastScrollTop: number | null = null;
 
+		// Shown while the diff scrolls or the pointer is on it; hidden again
+		// after a moment of stillness.
+		let shown = false;
+		let pointed = false;
+		let linger: ReturnType<typeof setTimeout> | null = null;
+		const settle = (): void => {
+			linger = null;
+			if (pointed || !shown) return;
+			shown = false;
+			rulerRef.current?.setAttribute("data-minimap-awake", "false");
+		};
+		const wake = (): void => {
+			if (linger !== null) clearTimeout(linger);
+			linger = setTimeout(settle, 1200);
+			if (shown) return;
+			shown = true;
+			rulerRef.current?.setAttribute("data-minimap-awake", "true");
+		};
+
 		/**
 		 * What the ruler was last told, so a frame that would repeat itself doesn't
 		 * dirty style for nothing — the paint reads layout back, and a write between
@@ -150,7 +169,10 @@ export const DiffMinimap: FC<{
 			const scrollTop = viewer.getScrollTop();
 			const scrolled = lastScrollTop !== null && scrollTop !== lastScrollTop;
 			lastScrollTop = scrollTop;
-			if (scrolled) freeRef.current = false;
+			if (scrolled) {
+				freeRef.current = false;
+				wake();
+			}
 
 			const moved = scrolled && !grabRef.current ? "draws" : freeRef.current ? "free" : "holds";
 			const layout = getMinimapLayout(viewer, track, scrollTop, offsetRef.current, moved);
@@ -229,6 +251,22 @@ export const DiffMinimap: FC<{
 		};
 		ruler?.addEventListener("wheel", onWheel, { passive: false });
 
+		// A hidden ruler takes no pointer events, so hovering can only hold it
+		// up, never summon it.
+		const onEnter = (): void => {
+			pointed = true;
+			if (linger !== null) {
+				clearTimeout(linger);
+				linger = null;
+			}
+		};
+		const onLeave = (): void => {
+			pointed = false;
+			if (shown && linger === null) linger = setTimeout(settle, 1200);
+		};
+		ruler?.addEventListener("pointerenter", onEnter);
+		ruler?.addEventListener("pointerleave", onLeave);
+
 		// Canvas colours are sampled, not live CSS, so they need reading again and
 		// repainting when the tokens behind them resolve differently.
 		const scheme = globalThis.matchMedia("(prefers-color-scheme: dark)");
@@ -257,11 +295,14 @@ export const DiffMinimap: FC<{
 		return () => {
 			resyncRef.current = null;
 			if (frame !== null) cancelAnimationFrame(frame);
+			if (linger !== null) clearTimeout(linger);
 			unsubscribe();
 			resizeObserver.disconnect();
 			scheme.removeEventListener("change", onScheme);
 			pixels?.removeEventListener("change", onPixels);
 			ruler?.removeEventListener("wheel", onWheel);
+			ruler?.removeEventListener("pointerenter", onEnter);
+			ruler?.removeEventListener("pointerleave", onLeave);
 		};
 	}, [viewerRef]);
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/Settings/Appearance.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Settings/Appearance.tsx
@@ -109,18 +109,6 @@ export const Appearance: FC = () => {
 			</Section>
 
 			<Section heading="Diff">
-				<Row
-					label="Minimap"
-					labelId="minimap"
-					hint="A map of the diff down the right-hand edge, standing in for the scrollbar."
-				>
-					<Switch
-						aria-labelledby="minimap"
-						checked={settings.minimap ?? defaultSettings.minimap}
-						onCheckedChange={(minimap) => saveGUISettings({ minimap })}
-					/>
-				</Row>
-
 				<Row label="Diff files" labelId="unidiff">
 					<ToggleGroup
 						aria-labelledby="unidiff"

--- a/apps/lite/ui/src/routes/project/$id/workspace/Settings/Experimental.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Settings/Experimental.tsx
@@ -23,6 +23,18 @@ export const Experimental: FC = () => {
 					onCheckedChange={(dryRunOperations) => saveGUISettings({ dryRunOperations })}
 				/>
 			</Row>
+
+			<Row
+				label="Minimap"
+				labelId="minimap"
+				hint="A map of the diff down the right-hand edge, standing in for the scrollbar."
+			>
+				<Switch
+					aria-labelledby="minimap"
+					checked={settings.minimap ?? defaultSettings.minimap}
+					onCheckedChange={(minimap) => saveGUISettings({ minimap })}
+				/>
+			</Row>
 		</Section>
 	);
 };

--- a/apps/lite/ui/src/settings.ts
+++ b/apps/lite/ui/src/settings.ts
@@ -19,7 +19,8 @@ export const defaultSettings = {
 	fileDisplayMode: "list",
 	// Pierre's own default, named here so the setting has somewhere to fall back to.
 	lineDiffType: "word-alt",
-	minimap: true,
+	// Experimental; opt in from the Experimental settings.
+	minimap: false,
 	// Lite has always led with the file name; desktop leads with the path.
 	pathFirst: false,
 	terminalId: "",


### PR DESCRIPTION
The minimap ruler now behaves like an overlay scrollbar: invisible at rest, faded in while the diff scrolls, held up while the pointer is on it, and faded out after ~1.2s of stillness.

- Wake/settle are DOM attribute writes inside the existing scroll-sync effect, so no React state joins the scroll path
- While hidden the ruler takes no pointer events: hovering can hold it up but never summon it, and clicks fall through to the code
- It is now a true overlay on the code's right edge with its own backdrop and border that fade with it; the reserved grid column and the code-side border are gone, so a resting diff keeps the whole pane

Also rides along: the minimap now defaults to **off** and its toggle moves from *Appearance › Diff* to the **Experimental** pane, beside the other opt-in feature. Users who never touched the toggle opt in from there; explicitly stored choices in either direction keep working.
