### PR TITLE
Read the route param once and drill the project id

### DIFF
--- a/apps/lite/ui/src/focus-scopes.ts
+++ b/apps/lite/ui/src/focus-scopes.ts
@@ -6,7 +6,6 @@ import type { Placement } from "#ui/operations/operation.ts";
 import type { Address } from "#ui/addresses.ts";
 import { getAdjacent, type AddressSpace } from "#ui/workspace/address-space.ts";
 import { useHotkeySequences, useHotkeys } from "@tanstack/react-hotkeys";
-import { useParams } from "@tanstack/react-router";
 import { useRef } from "react";
 
 export type FocusScope = "details" | "uncommitted-files" | "sidebar" | "files" | "diff" | "pr";
@@ -156,7 +155,9 @@ export const useAddressSpaceHotkeys = <T>({
 	onEdgeSpill,
 	getKey,
 	directionalNavigation = true,
+	projectId,
 }: {
+	projectId: string;
 	addressSpace: AddressSpace<T>;
 	group: CommandGroup;
 	select: (newItem: T) => void;
@@ -175,7 +176,6 @@ export const useAddressSpaceHotkeys = <T>({
 	/** Disable arrow and Vim directional keys when a surface owns finer-grained navigation. */
 	directionalNavigation?: boolean;
 }) => {
-	const { id: projectId } = useParams({ from: "/project/$id/workspace" });
 	const operationHotkeysEnabled = useAppSelector(
 		(state) =>
 			operationSourcesForItem === undefined ||

--- a/apps/lite/ui/src/operations/operation.ts
+++ b/apps/lite/ui/src/operations/operation.ts
@@ -18,7 +18,6 @@ import { decodeBytes } from "#ui/api/bytes.ts";
 import { guiSettingsQueryOptions } from "#ui/api/queries.ts";
 import { defaultSettings } from "#ui/settings.ts";
 import { useAppDispatch } from "#ui/store.ts";
-import { useParams } from "@tanstack/react-router";
 import { errorMessageForToast } from "#ui/errors.ts";
 import { syncCoreCaches } from "#ui/api/mutations.ts";
 
@@ -237,8 +236,7 @@ export const useDryRunOperation = ({
 	});
 };
 
-export const useExecuteOperation = () => {
-	const { id: projectId } = useParams({ from: "/project/$id/workspace" });
+export const useExecuteOperation = (projectId: string) => {
 	const dispatch = useAppDispatch();
 	const queryClient = useQueryClient();
 	const toastManager = Toast.useToastManager();

--- a/apps/lite/ui/src/reconcile.ts
+++ b/apps/lite/ui/src/reconcile.ts
@@ -13,7 +13,6 @@ import {
 	treeChangeDiffsQueryOptions,
 } from "./api/queries.ts";
 import { currentParams, remapSearchBranch } from "#ui/use-cursor.ts";
-import { useParams } from "@tanstack/react-router";
 import { getHeadInfoIndex, type HeadInfoIndex } from "./api/ref-info.ts";
 import { useEffect, useEffectEvent, useLayoutEffect, useRef } from "react";
 import { useAppDispatch, useAppSelector } from "./store.ts";
@@ -39,9 +38,7 @@ import { reviewedFilesQueryOptions, usePruneReviewedFiles } from "./reviewed-fil
  * effects don't waste too much work. This hook remains subscribed to queries relevant to state that
  * may need reconciliation.
  */
-export const useStateReconciler = (): void => {
-	const { id: projectId } = useParams({ from: "/project/$id/workspace" });
-
+export const useStateReconciler = (projectId: string): void => {
 	const dispatch = useAppDispatch();
 
 	// Commit cursors need no repair here: `change:` params re-resolve by change

--- a/apps/lite/ui/src/routes/project/$id/workspace/BranchPicker.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/BranchPicker.tsx
@@ -3,7 +3,6 @@ import { PickerDialog } from "#ui/components/PickerDialog.tsx";
 import type { BranchAddress } from "#ui/addresses.ts";
 import type { Segment, Stack } from "@gitbutler/but-sdk";
 import { useQuery } from "@tanstack/react-query";
-import { useParams } from "@tanstack/react-router";
 import type { FC } from "react";
 
 type BranchPickerOption = {
@@ -13,6 +12,7 @@ type BranchPickerOption = {
 };
 
 type Props = {
+	projectId: string;
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 	onSelectBranch: (branch: BranchAddress) => void;
@@ -39,8 +39,7 @@ const stackToBranchPickerOptions = (stack: Stack): Array<BranchPickerOption> =>
 		return option ? [option] : [];
 	});
 
-export const BranchPicker: FC<Props> = ({ open, onOpenChange, onSelectBranch }) => {
-	const { id: projectId } = useParams({ from: "/project/$id/workspace" });
+export const BranchPicker: FC<Props> = ({ projectId, open, onOpenChange, onSelectBranch }) => {
 	const { data: headInfo } = useQuery(headInfoQueryOptions(projectId));
 	const selectBranch = (option: BranchPickerOption) => {
 		onOpenChange(false);

--- a/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.tsx
@@ -361,6 +361,7 @@ export const BranchesList: FC<
 	};
 
 	useAddressSpaceHotkeys({
+		projectId,
 		addressSpace,
 		group: "Sidebar",
 		select: (newItem) => setCursor("unapplied", newItem),

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -85,7 +85,6 @@ import {
 	useSuspenseQueries,
 	useSuspenseQuery,
 } from "@tanstack/react-query";
-import { useParams } from "@tanstack/react-router";
 import { Match } from "effect";
 import {
 	type ComponentProps,
@@ -566,6 +565,7 @@ const DiffContents: FC<{
 	};
 
 	useAddressSpaceHotkeys({
+		projectId,
 		addressSpace: visibleAddressSpace,
 		group: "Diff",
 		select: selectDiff,
@@ -1586,8 +1586,7 @@ const DiffFileHeader: FC<DiffFileHeaderProps> = (p) => {
 	);
 };
 
-const FilesToggle: FC = () => {
-	const { id: projectId } = useParams({ from: "/project/$id/workspace" });
+const FilesToggle: FC<{ projectId: string }> = ({ projectId }) => {
 	const dispatch = useAppDispatch();
 	const filesVisible = useAppSelector((state) =>
 		projectSlice.selectors.selectFilesVisible(state, projectId),
@@ -2158,7 +2157,7 @@ const Diff: FC<{
 
 				<Panel id={"diff-panel" satisfies PanelId} minSize={300} className={styles.panel}>
 					<div className={styles.actions}>
-						{canShowFiles && <FilesToggle />}
+						{canShowFiles && <FilesToggle projectId={projectId} />}
 
 						{headerSlot}
 
@@ -2327,13 +2326,20 @@ const CommitDetailsSkeleton: FC = () => {
 
 const CommitDetails: FC<{
 	selection: Extract<Address, { _tag: "Commit" }>;
+	projectId: string;
 	/** The merged review the commit landed, when known: adds a Pull Request tab. */
 	review?: TargetCommitReview | null;
 	onActiveFileSelection: (itemId: string, firstHunk: HunkAddress | null) => void;
 	viewerRef: RefObject<DiffViewerHandle | null>;
 	didScrollToViaFileRef: RefObject<boolean>;
-}> = ({ selection, review, onActiveFileSelection, viewerRef, didScrollToViaFileRef }) => {
-	const { id: projectId } = useParams({ from: "/project/$id/workspace" });
+}> = ({
+	selection,
+	review,
+	projectId,
+	onActiveFileSelection,
+	viewerRef,
+	didScrollToViaFileRef,
+}) => {
 	const detailsFullWindow = useAppSelector(interfaceSlice.selectors.selectDetailsFullWindow);
 	const filesVisibleState = useAppSelector((state) =>
 		projectSlice.selectors.selectFilesVisible(state, projectId),
@@ -2532,11 +2538,11 @@ const LandedReviewView: FC<{ projectId: string; reviewId: number }> = ({ project
 /** A branch's own changes, whatever the branch's standing. */
 const BranchDiff: FC<BranchDetailsProps> = ({
 	branch,
+	projectId,
 	onActiveFileSelection,
 	viewerRef,
 	didScrollToViaFileRef,
 }) => {
-	const { id: projectId } = useParams({ from: "/project/$id/workspace" });
 	const filesVisibleState = useAppSelector((state) =>
 		projectSlice.selectors.selectFilesVisible(state, projectId),
 	);
@@ -2690,6 +2696,7 @@ const ReviewView: FC<{
 
 /** What every details view threads through to its Diff. */
 type DetailsViewProps = {
+	projectId: string;
 	onActiveFileSelection: (itemId: string, firstHunk: HunkAddress | null) => void;
 	viewerRef: RefObject<DiffViewerHandle | null>;
 	didScrollToViaFileRef: RefObject<boolean>;
@@ -2705,11 +2712,11 @@ type BranchDetailsProps = { branch: BranchAddress } & DetailsViewProps;
  */
 const UnappliedBranchDetails: FC<BranchDetailsProps> = ({
 	branch,
+	projectId,
 	onActiveFileSelection,
 	viewerRef,
 	didScrollToViaFileRef,
 }) => {
-	const { id: projectId } = useParams({ from: "/project/$id/workspace" });
 	const dispatch = useAppDispatch();
 	const branchName = branchDetailsParams(decodeBytes(branch.branchRef)).branchName;
 	const { data: forgeInfo } = useQuery(forgeInfoOptions(projectId));
@@ -2765,6 +2772,7 @@ const UnappliedBranchDetails: FC<BranchDetailsProps> = ({
 					</div>
 				) : (
 					<BranchDiff
+						projectId={projectId}
 						branch={branch}
 						onActiveFileSelection={onActiveFileSelection}
 						viewerRef={viewerRef}
@@ -2779,11 +2787,11 @@ const UnappliedBranchDetails: FC<BranchDetailsProps> = ({
 /** A branch applied to the workspace: its changes, and the review of them. */
 const AppliedBranchDetails: FC<BranchDetailsProps> = ({
 	branch,
+	projectId,
 	onActiveFileSelection,
 	viewerRef,
 	didScrollToViaFileRef,
 }) => {
-	const { id: projectId } = useParams({ from: "/project/$id/workspace" });
 	const { data: forgeInfo } = useQuery(forgeInfoOptions(projectId));
 	const { data: headInfo } = useQuery(headInfoQueryOptions(projectId));
 	const headInfoIndex = headInfo ? getHeadInfoIndex(headInfo) : null;
@@ -2910,6 +2918,7 @@ const AppliedBranchDetails: FC<BranchDetailsProps> = ({
 					</div>
 				) : (
 					<BranchDiff
+						projectId={projectId}
 						branch={branch}
 						onActiveFileSelection={onActiveFileSelection}
 						viewerRef={viewerRef}
@@ -2945,11 +2954,11 @@ const FileDetailsSkeleton: FC = () => {
 
 const FileDetails: FC<{
 	path: string;
+	projectId: string;
 	onActiveFileSelection: (itemId: string, firstHunk: HunkAddress | null) => void;
 	viewerRef: RefObject<DiffViewerHandle | null>;
 	didScrollToViaFileRef: RefObject<boolean>;
-}> = ({ path, onActiveFileSelection, viewerRef, didScrollToViaFileRef }) => {
-	const { id: projectId } = useParams({ from: "/project/$id/workspace" });
+}> = ({ path, projectId, onActiveFileSelection, viewerRef, didScrollToViaFileRef }) => {
 	const detailsFullWindow = useAppSelector(interfaceSlice.selectors.selectDetailsFullWindow);
 	const filesVisibleState = useAppSelector((state) =>
 		projectSlice.selectors.selectFilesVisible(state, projectId),
@@ -3026,7 +3035,7 @@ const commitDetails = (
 export const Details: FC<
 	{ selection: Address | null; review: TargetCommitReview | null } & DetailsViewProps
 > = ({ selection, review, ...viewProps }) => {
-	const { id: projectId } = useParams({ from: "/project/$id/workspace" });
+	const { projectId } = viewProps;
 	// The Pull Request tab fetches the review from the forge, so it is only
 	// offered on a forge that serves them.
 	const { data: forgeInfo } = useQuery(forgeInfoOptions(projectId));

--- a/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.tsx
@@ -267,6 +267,7 @@ const useFilesTreeHotkeys = ({
 	]);
 
 	useAddressSpaceHotkeys({
+		projectId,
 		addressSpace,
 		group: "File",
 		select: onRowSelection,

--- a/apps/lite/ui/src/routes/project/$id/workspace/OperationControls.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OperationControls.tsx
@@ -22,7 +22,6 @@ import { useAppDispatch, useAppSelector } from "#ui/store.ts";
 import { Button, Toggle, ToggleGroup, Tooltip } from "@base-ui/react";
 import { useHotkeys, type UseHotkeyDefinition } from "@tanstack/react-hotkeys";
 import { useQuery } from "@tanstack/react-query";
-import { useParams } from "@tanstack/react-router";
 import { Match } from "effect";
 import type { FC, ReactNode } from "react";
 import styles from "./OperationControls.module.css";
@@ -379,7 +378,7 @@ const TransferKeyboardOperationControls: FC<{
 	const selection = useSelection("applied", appliedAddressSpace);
 
 	const dispatch = useAppDispatch();
-	const { mutate: executeOperation } = useExecuteOperation();
+	const { mutate: executeOperation } = useExecuteOperation(projectId);
 
 	const target = getTransferTarget(keyboardTransfer(transfer), selection, activeList);
 	if (!target) return null;
@@ -432,10 +431,10 @@ const TransferKeyboardOperationControls: FC<{
 	);
 };
 
-export const OperationControls: FC<{ appliedAddressSpace: AddressSpace<Address> }> = ({
-	appliedAddressSpace,
-}) => {
-	const { id: projectId } = useParams({ from: "/project/$id/workspace" });
+export const OperationControls: FC<{
+	projectId: string;
+	appliedAddressSpace: AddressSpace<Address>;
+}> = ({ projectId, appliedAddressSpace }) => {
 	const pendingOperation = useAppSelector((state) =>
 		projectSlice.selectors.selectPendingOperation(state, projectId),
 	);

--- a/apps/lite/ui/src/routes/project/$id/workspace/Page.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Page.tsx
@@ -376,12 +376,11 @@ const ProjectPicker: FC<ProjectPickerProps> = (p) => {
 	);
 };
 
-const PageBody: FC = () => {
-	useReconcileState();
+const PageBody: FC<{ projectId: string }> = ({ projectId }) => {
+	useReconcileState(projectId);
 
 	const dispatch = useAppDispatch();
 
-	const { id: projectId } = useParams({ from: "/project/$id/workspace" });
 	const { data: renderAllFiles } = useSuspenseQuery({
 		...guiSettingsQueryOptions,
 		select: (cfg) => cfg.unidiff ?? defaultSettings.unidiff,
@@ -597,7 +596,7 @@ const PageBody: FC = () => {
 			? upstreamCommitReview(upstreamList, upstreamSelection.commitId)
 			: null;
 	const details = useMemo(() => {
-		const viewProps = { onActiveFileSelection, viewerRef, didScrollToViaFileRef };
+		const viewProps = { projectId, onActiveFileSelection, viewerRef, didScrollToViaFileRef };
 
 		return Match.value(page).pipe(
 			Match.when("workspace", () =>
@@ -624,6 +623,7 @@ const PageBody: FC = () => {
 			Match.exhaustive,
 		);
 	}, [
+		projectId,
 		branchesSelection,
 		onActiveFileSelection,
 		appliedSelection,
@@ -723,7 +723,7 @@ const PageBody: FC = () => {
 				</Panel>
 			</Group>
 
-			<OperationControls appliedAddressSpace={appliedAddressSpace} />
+			<OperationControls projectId={projectId} appliedAddressSpace={appliedAddressSpace} />
 
 			{Match.value(dialog).pipe(
 				Match.tagsExhaustive({
@@ -732,7 +732,12 @@ const PageBody: FC = () => {
 						<ApplyBranchPicker open onOpenChange={setApplyBranchPickerOpen} projectId={projectId} />
 					),
 					BranchPicker: () => (
-						<BranchPicker open onOpenChange={setBranchPickerOpen} onSelectBranch={selectBranch} />
+						<BranchPicker
+							projectId={projectId}
+							open
+							onOpenChange={setBranchPickerOpen}
+							onSelectBranch={selectBranch}
+						/>
 					),
 					CommandPalette: () => <CommandPalette open onOpenChange={setCommandPaletteOpen} />,
 					ProjectPicker: () => (
@@ -770,7 +775,7 @@ export const Page: FC = () => {
 		<QueryErrorResetBoundary>
 			{({ reset }) => (
 				<ErrorBoundary onReset={reset}>
-					<PageBody />
+					<PageBody projectId={projectId} />
 				</ErrorBoundary>
 			)}
 		</QueryErrorResetBoundary>

--- a/apps/lite/ui/src/routes/project/$id/workspace/UpstreamList.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/UpstreamList.tsx
@@ -398,6 +398,7 @@ export const UpstreamList: FC<
 	const hotkeysRef = useRef<HTMLDivElement>(null);
 
 	useAddressSpaceHotkeys({
+		projectId,
 		addressSpace,
 		group: "Sidebar",
 		select: (newItem) => setCursor("upstream", newItem),

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/hotkeys.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/hotkeys.ts
@@ -431,6 +431,7 @@ export const useActiveListsHotkeys = ({
 	};
 
 	useAddressSpaceHotkeys({
+		projectId,
 		ref,
 		addressSpace,
 		group: "Sidebar",

--- a/apps/lite/ui/src/routes/project/$id/workspace/useOperationDropTarget.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/useOperationDropTarget.ts
@@ -46,7 +46,7 @@ export const useOperationDropTarget = ({
 	projectId: string;
 }) => {
 	const dispatch = useAppDispatch();
-	const { mutate: executeOperation } = useExecuteOperation();
+	const { mutate: executeOperation } = useExecuteOperation(projectId);
 	const dropRef = useRef<HTMLElement>(null);
 
 	const getData = useEffectEvent(({ input, element, source }: GetDataArgs) => {


### PR DESCRIPTION
useParams({ from: "/project/$id/workspace" }) appeared fourteen times across seven files — a hard route dependency in code that otherwise only needs a string.

- Exactly one useParams remains, in the route component Page; PageBody takes projectId as a prop
- DetailsViewProps gains projectId; details components read it via the existing viewProps spreads
- useStateReconciler, useExecuteOperation and useAddressSpaceHotkeys take projectId as an argument; BranchPicker, OperationControls and FilesToggle as a prop
- The workspace subtree is renderable in tests and Storybook with nothing but a string

No behavior change.