### PR TITLE
fix(but): explain anonymous segment unapply failure

### DIFF
--- a/crates/but/src/command/legacy/unapply.rs
+++ b/crates/but/src/command/legacy/unapply.rs
@@ -92,6 +92,13 @@ fn resolve(
         .into_branch_or_stack()?
     {
         BranchOrStack::Branch(branch_arg) => {
+            if branch_arg.0.is_empty() {
+                return Err(bad_input(format!(
+                    "Cannot unapply segment '{target}' because it has no branch reference"
+                ))
+                .hint("Run `but branch new <name> --above <commit-id>` with the segment's top commit ID from `but status`, then run `but unapply <name>`.")
+                .into());
+            }
             let branch = branch_arg.resolve_local_branch_name()?;
 
             let stack = head_info.stacks.iter().find(|stack| {

--- a/crates/but/tests/but/command/branch/unapply.rs
+++ b/crates/but/tests/but/command/branch/unapply.rs
@@ -9,6 +9,35 @@ use crate::{
 };
 
 #[test]
+fn anonymous_segment_reports_recovery_workflow() {
+    let env =
+        Sandbox::init_scenario_with_target_and_default_settings("one-stack-anonymous-segment");
+    env.setup_metadata(&["A"]);
+
+    env.but("unapply g0")
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
+Error: Cannot unapply segment 'g0' because it has no branch reference
+
+Hint: Run `but branch new <name> --above <commit-id>` with the segment's top commit ID from `but status`, then run `but unapply <name>`.
+
+"#]])
+        .stdout_eq(str![]);
+
+    let anonymous_commit = env.invoke_git("rev-parse gitbutler/workspace^");
+    env.but("branch new recovered --above sxu")
+        .assert()
+        .success();
+    env.but("unapply recovered").assert().success();
+    assert_eq!(
+        env.invoke_git("rev-parse recovered"),
+        anonymous_commit,
+        "recovery branch should preserve the anonymous commit"
+    );
+}
+
+#[test]
 fn single_branch() {
     let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack");
     snapbox::assert_data_eq!(


### PR DESCRIPTION
## Context

Running `but unapply` with the CLI ID of an anonymous segment currently reaches ref validation and prints `Reference name cannot end with a slash`. Because the segment has no branch reference, the command gives no usable recovery path.

Related context: [#14497](https://github.com/gitbutlerapp/gitbutler/issues/14497), [#14700](https://github.com/gitbutlerapp/gitbutler/pull/14700), and [#15188](https://github.com/gitbutlerapp/gitbutler/pull/15188). #14497 covers the broader anonymous-segment state and is not closed by this change.

## Change

Reject that target before ref validation and explain how to create a branch at the segment's top commit before unapplying it. Named-branch and stack-ID unapply behavior stays unchanged.