### PR TITLE
Add a text search to the diff viewer

### DIFF
--- a/apps/lite/ui/src/hotkeys.ts
+++ b/apps/lite/ui/src/hotkeys.ts
@@ -359,4 +359,8 @@ export const diffHotkeys = {
 		hotkey: "E",
 		meta: { group: "Diff", name: "Open in editor" },
 	},
+	search: {
+		hotkey: "Mod+F",
+		meta: { group: "Diff", name: "Search diff" },
+	},
 } satisfies Record<string, HotkeyWithMeta>;

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -192,6 +192,9 @@ import {
 } from "./diff-view.ts";
 import { DiffMinimap } from "./DiffMinimap.tsx";
 import { ImageDiff } from "./ImageDiff.tsx";
+import { DiffSearchBar } from "./DiffSearchBar.tsx";
+import type { DiffSearchMatch } from "./diff-search.ts";
+import { diffSearchMarksUnsafeCSS, useDiffSearchMarks } from "./diff-search-marks.ts";
 import {
 	getMinimapFiles,
 	measureWrapColumns,
@@ -1278,6 +1281,11 @@ const DiffContents: FC<{
 			checkHunkLines,
 			fileParent._tag === "Branch" ? undefined : handleCreateComment,
 		);
+	const {
+		onPostRender: handleMarkedDiffPostRender,
+		setSearchMatches,
+		searchMarks,
+	} = useDiffSearchMarks(handleDiffPostRender);
 
 	const handOffCollapsedSelection = (itemId: string): void => {
 		// Folding hides the selected hunk's lines; hand the selection to the
@@ -1296,6 +1304,34 @@ const DiffContents: FC<{
 		setManualCollapse(itemId, collapsed);
 		if (collapsed && !collapsedItems.has(itemId)) handOffCollapsedSelection(itemId);
 	};
+
+	// Stable so typing in the search bar only re-renders the bar, never this
+	// component; the callback still reads the render-fresh helpers it closes over.
+	const navigateToSearchMatch = useStableCallback((match: DiffSearchMatch): void => {
+		if (collapsedItems.has(match.itemId)) setManualCollapse(match.itemId, false);
+
+		applySelectedLines({
+			id: match.itemId,
+			range: {
+				start: match.lineNumber,
+				side: match.side,
+				end: match.lineNumber,
+				endSide: match.side,
+			},
+		});
+
+		// A frame later, so an unfold above reaches CodeView's layout before the
+		// scroll asks it where the line is.
+		requestAnimationFrame(() => {
+			viewerRef.current?.scrollTo({
+				type: "line",
+				id: match.itemId,
+				lineNumber: match.lineNumber,
+				side: match.side,
+				align: "center",
+			});
+		});
+	});
 
 	const handleSetReviewed =
 		(itemId: string, path: string, version: number) => (reviewed: boolean) => {
@@ -1486,7 +1522,7 @@ const DiffContents: FC<{
 					// as defined in the metrics. We'll see an additional set of logs if there are other issues
 					// with our metrics.
 					__devOnlyValidateItemHeights: false,
-					onPostRender: handleDiffPostRender,
+					onPostRender: handleMarkedDiffPostRender,
 					itemMetrics: codeViewItemMetrics,
 					unsafeCSS: `
           :host {
@@ -1542,6 +1578,7 @@ const DiffContents: FC<{
           }
 
           ${diffGutterUnsafeCSS}
+          ${diffSearchMarksUnsafeCSS}
         `,
 				}}
 				style={{
@@ -1554,6 +1591,13 @@ const DiffContents: FC<{
 
 			{diffGutterPortals}
 
+			<DiffSearchBar
+				items={items}
+				focusScopeRef={focusScopeRef}
+				onNavigate={navigateToSearchMatch}
+				onMatchesChange={setSearchMatches}
+			/>
+
 			{minimapFiles && (
 				<DiffMinimap
 					viewerRef={viewerRef}
@@ -1561,6 +1605,7 @@ const DiffContents: FC<{
 					diffStyle={effectiveDiffStyle}
 					annotationsByPath={annotationsByPath}
 					selection={minimapSelection}
+					searchMarks={searchMarks}
 				/>
 			)}
 		</>

--- a/apps/lite/ui/src/routes/project/$id/workspace/DiffMinimap.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DiffMinimap.module.css
@@ -39,6 +39,18 @@
 	initial-value: transparent;
 }
 
+@property --minimap-search {
+	syntax: "<color>";
+	inherits: true;
+	initial-value: transparent;
+}
+
+@property --minimap-search-current {
+	syntax: "<color>";
+	inherits: true;
+	initial-value: transparent;
+}
+
 .minimap {
 	/* Mixed towards the background the way the diff tints its own changed rows,
 	   just further, since a mark can be a single pixel tall. This is the colour
@@ -59,6 +71,11 @@
 	/* Behind the marks it covers rather than over them, so a selected hunk still
 	   reads as added or removed. */
 	--minimap-selection: color-mix(in srgb, var(--fill-pop-bg) 16%, transparent);
+	/* The same amber the diff washes matching lines in, over the marks so a match
+	   is findable in a dense file; the current one opaque enough to pick out of
+	   its neighbours at a pixel a line. */
+	--minimap-search: color-mix(in srgb, var(--fill-warn-bg) 45%, transparent);
+	--minimap-search-current: var(--fill-warn-bg);
 	/* Overlaid on the code's right edge, so a diff at rest keeps the whole
 	   pane. Ends where the map does: at a fixed scale a short diff doesn't
 	   reach the foot of the pane. */

--- a/apps/lite/ui/src/routes/project/$id/workspace/DiffMinimap.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DiffMinimap.tsx
@@ -9,7 +9,9 @@ import {
 	useLayoutEffect,
 	useRef,
 	useState,
+	useSyncExternalStore,
 } from "react";
+import type { SearchMarks } from "./diff-search-marks.ts";
 import type { Annotation } from "./diff-view.ts";
 import {
 	getMinimapGeometry,
@@ -51,7 +53,16 @@ export const DiffMinimap: FC<{
 	diffStyle: GUISettings["diffStyle"];
 	annotationsByPath: LocalAnnotationsByPath;
 	selection: MinimapSelection | null;
-}> = ({ viewerRef, files, diffStyle, annotationsByPath, selection }) => {
+	/**
+	 * Subscribed to rather than passed as matches, so a keystroke in the search
+	 * bar repaints this ruler without re-rendering the diff pane around it.
+	 */
+	searchMarks: {
+		subscribe: (listener: () => void) => () => void;
+		getSnapshot: () => SearchMarks;
+	};
+}> = ({ viewerRef, files, diffStyle, annotationsByPath, selection, searchMarks }) => {
+	const marks = useSyncExternalStore(searchMarks.subscribe, searchMarks.getSnapshot);
 	const rulerRef = useRef<HTMLDivElement>(null);
 	const canvasRef = useRef<HTMLCanvasElement>(null);
 	const markerRef = useRef<HTMLDivElement>(null);
@@ -68,7 +79,7 @@ export const DiffMinimap: FC<{
 		scale: number;
 		scrollable: number;
 	} | null>(null);
-	const dataRef = useRef({ files, diffStyle, annotationsByPath, selection });
+	const dataRef = useRef({ files, diffStyle, annotationsByPath, selection, marks });
 	const geometryRef = useRef<MinimapGeometry | null>(null);
 	const layoutRef = useRef<MinimapLayout | null>(null);
 	/** Where the map is wound to, which it keeps until the lens runs out of ruler. */
@@ -136,7 +147,7 @@ export const DiffMinimap: FC<{
 
 		const draw = (layout: MinimapLayout): void => {
 			const data = dataRef.current;
-			const { files, diffStyle, annotationsByPath, selection } = data;
+			const { files, diffStyle, annotationsByPath, selection, marks } = data;
 			const geometry = getMinimapGeometry(viewer, files);
 
 			geometryRef.current = geometry;
@@ -146,7 +157,13 @@ export const DiffMinimap: FC<{
 			const overlays =
 				lastOverlays !== null && lastData === data && sameMinimapGeometry(lastGeometry, geometry)
 					? lastOverlays
-					: getMinimapOverlays({ files, geometry, annotationsByPath, selection });
+					: getMinimapOverlays({
+							files,
+							geometry,
+							annotationsByPath,
+							selection,
+							searchMarks: marks,
+						});
 
 			lastData = data;
 			lastGeometry = geometry;
@@ -314,10 +331,11 @@ export const DiffMinimap: FC<{
 			previous.files !== files ||
 			previous.diffStyle !== diffStyle ||
 			previous.annotationsByPath !== annotationsByPath ||
-			previous.selection !== selection;
+			previous.selection !== selection ||
+			previous.marks !== marks;
 		if (!changed) return;
 
-		dataRef.current = { files, diffStyle, annotationsByPath, selection };
+		dataRef.current = { files, diffStyle, annotationsByPath, selection, marks };
 		resyncRef.current?.();
 	});
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/DiffSearchBar.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DiffSearchBar.module.css
@@ -1,0 +1,27 @@
+.searchBar {
+	display: flex;
+	z-index: 2;
+	position: absolute;
+	top: 8px;
+	/* Clear of the minimap, which owns the right edge. */
+	right: 68px;
+	align-items: center;
+	padding: 4px;
+	gap: 4px;
+	border: 1px solid var(--border-section);
+	border-radius: 10px;
+	background-color: var(--bg-1);
+	box-shadow:
+		0 0.5px 1px rgb(0 0 0 / 0.12),
+		0 2px 4px -1px rgb(0 0 0 / 0.04),
+		0 12px 14px -4px rgb(0 0 0 / 0.04);
+}
+
+.searchField {
+	width: 200px;
+}
+
+.matchCount {
+	color: var(--text-2);
+	white-space: nowrap;
+}

--- a/apps/lite/ui/src/routes/project/$id/workspace/DiffSearchBar.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DiffSearchBar.tsx
@@ -1,0 +1,190 @@
+import { assert } from "#ui/assert.ts";
+import { getButtonClassName } from "#ui/components/Button.tsx";
+import { classes } from "#ui/components/classes.ts";
+import { FieldControlWithIcon, FieldRootStyles } from "#ui/components/Field.tsx";
+import { Icon } from "#ui/components/Icon.tsx";
+import { focusScope } from "#ui/focus-scopes.ts";
+import { diffHotkeys } from "#ui/hotkeys.ts";
+import { Field } from "@base-ui/react";
+import type { CodeViewItem } from "@pierre/diffs";
+import { useHotkey } from "@tanstack/react-hotkeys";
+import {
+	type FC,
+	type KeyboardEvent,
+	type RefObject,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
+import { diffSearchMatches, type DiffSearchMatch } from "./diff-search.ts";
+import styles from "./DiffSearchBar.module.css";
+
+type Props = {
+	items: Array<CodeViewItem<unknown>>;
+	/** The diff's focus scope, where the open hotkey listens. */
+	focusScopeRef: RefObject<HTMLDivElement | null>;
+	onNavigate: (match: DiffSearchMatch) => void;
+	/** Keeps the viewer's match marks in step with what this bar found. */
+	onMatchesChange: (matches: Array<DiffSearchMatch>, current: DiffSearchMatch | null) => void;
+};
+
+/**
+ * Text search over the whole diff. The viewer virtualizes its rendering, so
+ * the browser's own find only sees the rendered window; this searches the
+ * model instead and navigates by scrolling the viewer, marking each match
+ * with the diff's line selection.
+ */
+export const DiffSearchBar: FC<Props> = ({ items, focusScopeRef, onNavigate, onMatchesChange }) => {
+	/** The query, or `null` while the search is closed. */
+	const [query, setQuery] = useState<string | null>(null);
+	const [index, setIndex] = useState(0);
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	const matches = useMemo(
+		() => (query === null ? [] : diffSearchMatches(items, query)),
+		[items, query],
+	);
+	// Clamped rather than stored: the diff can refresh under a held index.
+	const current = matches.length === 0 ? null : Math.min(index, matches.length - 1);
+
+	// The marks live in the viewer's DOM, outside React, so they are synced as
+	// an effect: on every new match list, and away again on unmount. Lifting
+	// the matches into the parent instead would re-render the whole diff pane
+	// on every keystroke.
+	// oxlint-disable react-you-might-not-need-an-effect/no-pass-data-to-parent
+	useEffect(() => {
+		onMatchesChange(matches, current === null ? null : (matches[current] ?? null));
+	}, [matches, current, onMatchesChange]);
+	useEffect(() => () => onMatchesChange([], null), [onMatchesChange]);
+	// oxlint-enable react-you-might-not-need-an-effect/no-pass-data-to-parent
+
+	// Typing lands on the first match as the query narrows. This waits for the
+	// memo above rather than scanning again in the change handler: the scan
+	// walks every line of every file, and a second one per keystroke is felt on
+	// a large diff. Keyed on the query, so a background diff refresh — which
+	// gives `matches` a new identity — does not yank the scroll position.
+	const lastNavigatedQuery = useRef<string | null>(null);
+	// oxlint-disable react-you-might-not-need-an-effect/no-event-handler
+	// oxlint-disable react-you-might-not-need-an-effect/no-pass-data-to-parent
+	useEffect(() => {
+		if (query === null || query === "" || lastNavigatedQuery.current === query) return;
+
+		lastNavigatedQuery.current = query;
+		const first = matches[0];
+		if (first) onNavigate(first);
+	}, [query, matches, onNavigate]);
+	// oxlint-enable react-you-might-not-need-an-effect/no-event-handler
+	// oxlint-enable react-you-might-not-need-an-effect/no-pass-data-to-parent
+
+	const open = (): void => {
+		if (query === null) {
+			setQuery("");
+			setIndex(0);
+			return;
+		}
+
+		const input = inputRef.current;
+		if (!input) return;
+		input.focus();
+		// Land the caret after the query, so returning to it extends the search
+		// rather than overwriting it.
+		input.setSelectionRange(input.value.length, input.value.length);
+	};
+
+	const close = (): void => {
+		setQuery(null);
+		setIndex(0);
+		// Hand focus back to the diff the search was walking, rather than
+		// dropping it on the body when the input unmounts.
+		focusScope("diff");
+	};
+
+	const step = (offset: -1 | 1): void => {
+		if (current === null) return;
+
+		const next = (current + offset + matches.length) % matches.length;
+		setIndex(next);
+		onNavigate(assert(matches[next]));
+	};
+
+	useHotkey(diffHotkeys.search.hotkey, open, {
+		conflictBehavior: "allow",
+		meta: diffHotkeys.search.meta,
+		target: focusScopeRef,
+	});
+
+	if (query === null) return null;
+
+	const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>): void => {
+		// Escape closes the search rather than reaching anything behind it,
+		// which has nothing to cancel while the input holds focus.
+		if (event.key === "Escape") {
+			event.preventDefault();
+			event.stopPropagation();
+			close();
+			return;
+		}
+
+		if (event.key === "Enter") {
+			event.preventDefault();
+			event.stopPropagation();
+			step(event.shiftKey ? -1 : 1);
+		}
+	};
+
+	return (
+		<search className={styles.searchBar}>
+			<Field.Root render={<FieldRootStyles />} className={styles.searchField}>
+				<FieldControlWithIcon
+					ref={inputRef}
+					className="text-13"
+					icon={<Icon name="search" />}
+					aria-label="Search diff"
+					placeholder="Search diff"
+					value={query}
+					onChange={(event) => {
+						setQuery(event.currentTarget.value);
+						setIndex(0);
+					}}
+					onKeyDown={handleKeyDown}
+					// oxlint-disable-next-line jsx_a11y/no-autofocus
+					autoFocus
+				/>
+			</Field.Root>
+
+			{query !== "" && (
+				<span className={classes("text-12", styles.matchCount)} aria-live="polite">
+					{current === null ? "No results" : `${current + 1} of ${matches.length}`}
+				</span>
+			)}
+
+			<button
+				type="button"
+				aria-label="Previous match"
+				disabled={matches.length === 0}
+				className={getButtonClassName({ size: "small", variant: "ghost", iconOnly: true })}
+				onClick={() => step(-1)}
+			>
+				<Icon name="chevron-up" />
+			</button>
+			<button
+				type="button"
+				aria-label="Next match"
+				disabled={matches.length === 0}
+				className={getButtonClassName({ size: "small", variant: "ghost", iconOnly: true })}
+				onClick={() => step(1)}
+			>
+				<Icon name="chevron-down" />
+			</button>
+			<button
+				type="button"
+				aria-label="Close search"
+				className={getButtonClassName({ size: "small", variant: "ghost", iconOnly: true })}
+				onClick={close}
+			>
+				<Icon name="cross" />
+			</button>
+		</search>
+	);
+};

--- a/apps/lite/ui/src/routes/project/$id/workspace/diff-minimap-canvas.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/diff-minimap-canvas.ts
@@ -281,6 +281,8 @@ type MinimapPalette = {
 	pin: string;
 	selection: string;
 	rule: string;
+	search: string;
+	searchCurrent: string;
 };
 
 let palette: MinimapPalette | null = null;
@@ -301,6 +303,8 @@ const readMinimapPalette = (canvas: HTMLCanvasElement): MinimapPalette => {
 		pin: tokens.getPropertyValue("--minimap-pin"),
 		selection: tokens.getPropertyValue("--minimap-selection"),
 		rule: tokens.getPropertyValue("--minimap-file-rule"),
+		search: tokens.getPropertyValue("--minimap-search"),
+		searchCurrent: tokens.getPropertyValue("--minimap-search-current"),
 	};
 	return palette;
 };
@@ -451,6 +455,14 @@ export const paintMinimap = (
 		marks.putImageData(surface.image, 0, 0);
 		// Drawn rather than written, so the band beneath shows through the gaps.
 		context.drawImage(surface.canvas, 0, 0, width, height);
+	}
+
+	// Over the marks, so a match is findable in a dense file, but under the rules
+	// and pins. Full width and at least a device pixel tall, since a match is a
+	// single line and would otherwise vanish on a long diff.
+	for (const match of overlays.matches) {
+		context.fillStyle = match.current ? fills.searchCurrent : fills.search;
+		context.fillRect(0, match.top * scale - offset, width, Math.max(scale, thinnest));
 	}
 
 	// Drawn last and opaque, so a rule reads over the marks it crosses rather

--- a/apps/lite/ui/src/routes/project/$id/workspace/diff-minimap.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/diff-minimap.ts
@@ -1,6 +1,8 @@
 import type { LocalAnnotationsByPath } from "#ui/annotation.ts";
 import type { GUISettings } from "#electron/settings.ts";
 import type { CodeView } from "@pierre/diffs";
+import type { SearchMarks } from "./diff-search-marks.ts";
+import type { DiffSearchMatch } from "./diff-search.ts";
 import {
 	type Annotation,
 	codeViewItemMetrics,
@@ -455,6 +457,10 @@ const lineTop = (file: MinimapFile, side: ChangeSide, line: number): number | nu
 	return null;
 };
 
+/** Identifies a match across the two views drawing it. */
+const searchMatchKey = (itemId: string, match: DiffSearchMatch): string =>
+	`${itemId} ${match.side} ${match.lineNumber}`;
+
 /** The range the diff currently has selected, in file line numbers. */
 export type MinimapSelection = {
 	itemId: string;
@@ -468,6 +474,8 @@ export type MinimapOverlays = {
 	/** Comment positions, in scroll-content pixels. */
 	pins: Array<number>;
 	band: { top: number; height: number } | null;
+	/** Search matches, in scroll-content pixels, the current one flagged. */
+	matches: Array<{ top: number; current: boolean }>;
 };
 
 /**
@@ -480,14 +488,28 @@ export const getMinimapOverlays = ({
 	geometry,
 	annotationsByPath,
 	selection,
+	searchMarks,
 }: {
 	files: Array<MinimapFile>;
 	geometry: MinimapGeometry;
 	annotationsByPath: LocalAnnotationsByPath;
 	selection: MinimapSelection | null;
+	searchMarks: SearchMarks;
 }): MinimapOverlays => {
 	const pins: Array<number> = [];
+	const matches: Array<{ top: number; current: boolean }> = [];
 	let band: { top: number; height: number } | null = null;
+
+	const currentKey =
+		searchMarks.current === null
+			? null
+			: searchMatchKey(searchMarks.current.itemId, searchMarks.current);
+	const matchesByItem = new Map<string, Array<DiffSearchMatch>>();
+	for (const match of searchMarks.matches) {
+		const forItem = matchesByItem.get(match.itemId);
+		if (forItem) forItem.push(match);
+		else matchesByItem.set(match.itemId, [match]);
+	}
 
 	for (const [index, file] of files.entries()) {
 		const block = geometry.blocks[index];
@@ -502,6 +524,15 @@ export const getMinimapOverlays = ({
 		for (const annotation of annotationsByPath.get(file.path) ?? []) {
 			const top = place(annotation.side, annotation.lineNumber);
 			if (top !== null) pins.push(top);
+		}
+
+		for (const match of matchesByItem.get(file.itemId) ?? []) {
+			// A context match is numbered on the additions side; in split view its
+			// deletions-column twin sits on the same row, so one mark says it.
+			const top = place(match.side, match.lineNumber);
+			if (top === null) continue;
+
+			matches.push({ top, current: searchMatchKey(file.itemId, match) === currentKey });
 		}
 
 		if (selection?.itemId !== file.itemId) continue;
@@ -529,7 +560,7 @@ export const getMinimapOverlays = ({
 		band = { top, height: Math.max(bottom - top, 0) };
 	}
 
-	return { pins, band };
+	return { pins, band, matches };
 };
 
 /**

--- a/apps/lite/ui/src/routes/project/$id/workspace/diff-search-marks.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/diff-search-marks.ts
@@ -1,0 +1,148 @@
+import type { CodeViewOptions, SelectionSide } from "@pierre/diffs";
+import { useLayoutEffect, useRef } from "react";
+import { diffLineTargetFromElement } from "./diff-line-target.ts";
+import type { DiffSearchMatch } from "./diff-search.ts";
+
+type OnPostRender<T> = NonNullable<CodeViewOptions<T>["onPostRender"]>;
+
+const SEARCH_MATCH_ATTRIBUTE = "data-gitbutler-search-match";
+
+/**
+ * A light wash on every matching line, and a stronger one across the whole
+ * current match — contrast alone tells the two apart.
+ */
+export const diffSearchMarksUnsafeCSS = `
+	[data-line][${SEARCH_MATCH_ATTRIBUTE}] {
+		background-color: color-mix(var(--fill-warn-bg) 14%, transparent);
+	}
+
+	[data-column-number][${SEARCH_MATCH_ATTRIBUTE}] {
+		background-color: color-mix(var(--fill-warn-bg) 32%, transparent);
+	}
+
+	[data-line][${SEARCH_MATCH_ATTRIBUTE}="current"] {
+		background-color: color-mix(var(--fill-warn-bg) 34%, transparent);
+	}
+
+	[data-column-number][${SEARCH_MATCH_ATTRIBUTE}="current"] {
+		background-color: color-mix(var(--fill-warn-bg) 70%, transparent);
+	}
+`;
+
+const markKey = (itemId: string, side: SelectionSide, lineNumber: number): string =>
+	`${itemId} ${side} ${lineNumber}`;
+
+const keysOf = (match: DiffSearchMatch): Array<string> => {
+	const keys = [markKey(match.itemId, match.side, match.lineNumber)];
+	if (match.deletionsColumnLine !== undefined)
+		keys.push(markKey(match.itemId, "deletions", match.deletionsColumnLine));
+	return keys;
+};
+
+/** What matched, and which of those the search is standing on. */
+export type SearchMarks = {
+	matches: Array<DiffSearchMatch>;
+	current: DiffSearchMatch | null;
+};
+
+const NO_MARKS: SearchMarks = { matches: [], current: null };
+
+type SearchMarkStore<T> = {
+	onPostRender: OnPostRender<T>;
+	setMatches: (matches: Array<DiffSearchMatch>, current: DiffSearchMatch | null) => void;
+	/** For React consumers painting their own view of the matches — the minimap. */
+	subscribe: (listener: () => void) => () => void;
+	getSnapshot: () => SearchMarks;
+	cleanUp: () => void;
+};
+
+/**
+ * Stamps every rendered line that holds a search match, the way the gutter
+ * store stamps its controls: the virtualizer re-renders items as the window
+ * moves, and each post-render re-walks that item's lines against the current
+ * match set. A query change re-walks every registered item instead, since no
+ * render happens on its behalf.
+ */
+const createSearchMarkStore = <T>(getOnPostRender: () => OnPostRender<T>): SearchMarkStore<T> => {
+	const itemIdsByHost = new Map<HTMLElement, string>();
+	const listeners = new Set<() => void>();
+	let keys: ReadonlySet<string> = new Set();
+	let currentKeys: ReadonlySet<string> = new Set();
+	let snapshot: SearchMarks = NO_MARKS;
+
+	const markHost = (host: HTMLElement, itemId: string): void => {
+		const shadowRoot = host.shadowRoot;
+		if (!shadowRoot) return;
+
+		for (const element of shadowRoot.querySelectorAll<HTMLElement>(
+			"[data-column-number], [data-line]",
+		)) {
+			const target = diffLineTargetFromElement({ element, itemId });
+			const key = target === null ? null : markKey(target.itemId, target.side, target.lineNumber);
+			if (key !== null && currentKeys.has(key))
+				element.setAttribute(SEARCH_MATCH_ATTRIBUTE, "current");
+			else if (key !== null && keys.has(key)) element.setAttribute(SEARCH_MATCH_ATTRIBUTE, "");
+			else element.removeAttribute(SEARCH_MATCH_ATTRIBUTE);
+		}
+	};
+
+	return {
+		onPostRender: (host, instance, phase, context) => {
+			if (phase === "unmount" || context.type !== "diff") {
+				itemIdsByHost.delete(host);
+			} else {
+				itemIdsByHost.set(host, context.item.id);
+				markHost(host, context.item.id);
+			}
+			// CodeView exposes this callback as file/diff overloads; forward the exact invocation.
+			Reflect.apply(getOnPostRender(), undefined, [host, instance, phase, context]);
+		},
+		setMatches: (matches, current) => {
+			keys = new Set(matches.flatMap(keysOf));
+			currentKeys = new Set(current === null ? [] : keysOf(current));
+			for (const [host, itemId] of itemIdsByHost) markHost(host, itemId);
+
+			// A fresh identity only when there is something to draw, so a closed
+			// search doesn't wake subscribers on every diff refresh.
+			snapshot = matches.length === 0 ? NO_MARKS : { matches, current };
+			for (const listener of listeners) listener();
+		},
+		subscribe: (listener) => {
+			listeners.add(listener);
+			return () => listeners.delete(listener);
+		},
+		getSnapshot: () => snapshot,
+		cleanUp: () => {
+			keys = new Set();
+			currentKeys = new Set();
+			for (const [host, itemId] of itemIdsByHost) markHost(host, itemId);
+			itemIdsByHost.clear();
+			snapshot = NO_MARKS;
+			listeners.clear();
+		},
+	};
+};
+
+export const useDiffSearchMarks = <T>(
+	onPostRender: OnPostRender<T>,
+): {
+	onPostRender: OnPostRender<T>;
+	setSearchMatches: SearchMarkStore<T>["setMatches"];
+	/** Hand to the minimap, which draws the same matches at its own scale. */
+	searchMarks: Pick<SearchMarkStore<T>, "subscribe" | "getSnapshot">;
+} => {
+	const onPostRenderRef = useRef(onPostRender);
+	onPostRenderRef.current = onPostRender;
+
+	const storeRef = useRef<SearchMarkStore<T>>(null);
+	storeRef.current ??= createSearchMarkStore(() => onPostRenderRef.current);
+	const store = storeRef.current;
+
+	useLayoutEffect(() => () => store.cleanUp(), [store]);
+
+	return {
+		onPostRender: store.onPostRender,
+		setSearchMatches: store.setMatches,
+		searchMarks: store,
+	};
+};

--- a/apps/lite/ui/src/routes/project/$id/workspace/diff-search.test.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/diff-search.test.ts
@@ -1,0 +1,108 @@
+import { diffSearchMatches } from "./diff-search.ts";
+import { processFile, type CodeViewDiffItem } from "@pierre/diffs";
+import { describe, expect, it } from "vitest";
+
+const diffItem = (id: string, patch: string): CodeViewDiffItem<unknown> => {
+	const fileDiff = processFile(patch, { cacheKey: id });
+	if (!fileDiff) throw new Error("Failed to parse patch");
+	return { type: "diff", id, fileDiff };
+};
+
+// Two hunks: the first mixes context and changed runs, the second starts at
+// different line numbers on either side, so a walk that mixed the sides up
+// would report the wrong lines.
+const ITEM = diffItem(
+	"file.ts",
+	[
+		"diff --git a/file.ts b/file.ts",
+		"--- a/file.ts",
+		"+++ b/file.ts",
+		"@@ -1,8 +1,9 @@",
+		" one",
+		"-two",
+		"+TWO",
+		" three",
+		" four",
+		"-five",
+		"+FIVE",
+		"+FIVE AND A HALF",
+		" six",
+		" seven",
+		" eight",
+		"@@ -20,5 +21,5 @@",
+		" twenty",
+		"-twentyone",
+		"+TWENTYONE",
+		" twentytwo",
+		" twentythree",
+		" twentyfour",
+		"",
+	].join("\n"),
+);
+
+describe("diffSearchMatches", () => {
+	it("finds nothing for an empty query", () => {
+		expect(diffSearchMatches([ITEM], "")).toEqual([]);
+	});
+
+	it("finds a deleted line on the deletions side with its old line number", () => {
+		expect(diffSearchMatches([ITEM], "two")).toContainEqual({
+			itemId: "file.ts",
+			side: "deletions",
+			lineNumber: 2,
+		});
+	});
+
+	it("finds an added line on the additions side with its new line number", () => {
+		expect(diffSearchMatches([ITEM], "FIVE AND A HALF")).toEqual([
+			{ itemId: "file.ts", side: "additions", lineNumber: 6 },
+		]);
+	});
+
+	it("finds a context line once, on the additions side, carrying its deletions-column number", () => {
+		expect(diffSearchMatches([ITEM], "four")).toEqual([
+			{ itemId: "file.ts", side: "additions", lineNumber: 4, deletionsColumnLine: 4 },
+			{ itemId: "file.ts", side: "additions", lineNumber: 25, deletionsColumnLine: 24 },
+		]);
+	});
+
+	it("matches case-insensitively and reports one match per line and side", () => {
+		expect(diffSearchMatches([ITEM], "five")).toEqual([
+			{ itemId: "file.ts", side: "deletions", lineNumber: 5 },
+			{ itemId: "file.ts", side: "additions", lineNumber: 5 },
+			{ itemId: "file.ts", side: "additions", lineNumber: 6 },
+		]);
+	});
+
+	it("carries line numbers across hunks from each hunk header", () => {
+		expect(diffSearchMatches([ITEM], "twentyone")).toEqual([
+			{ itemId: "file.ts", side: "deletions", lineNumber: 21 },
+			{ itemId: "file.ts", side: "additions", lineNumber: 22 },
+		]);
+	});
+
+	it("walks files in the order given", () => {
+		const other = diffItem(
+			"other.ts",
+			[
+				"diff --git a/other.ts b/other.ts",
+				"--- a/other.ts",
+				"+++ b/other.ts",
+				"@@ -1,1 +1,2 @@",
+				" one",
+				"+twenty",
+				"",
+			].join("\n"),
+		);
+
+		expect(diffSearchMatches([other, ITEM], "twenty").map((match) => match.itemId)).toEqual([
+			"other.ts",
+			"file.ts",
+			"file.ts",
+			"file.ts",
+			"file.ts",
+			"file.ts",
+			"file.ts",
+		]);
+	});
+});

--- a/apps/lite/ui/src/routes/project/$id/workspace/diff-search.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/diff-search.ts
@@ -1,0 +1,79 @@
+import type { CodeViewItem, SelectionSide } from "@pierre/diffs";
+
+export type DiffSearchMatch = {
+	itemId: string;
+	side: SelectionSide;
+	lineNumber: number;
+	/**
+	 * A context line is numbered by the column holding it, and a split diff
+	 * holds it twice — this is its number in the deletions column, so marking
+	 * can reach both cells. Navigation only ever uses `lineNumber`.
+	 */
+	deletionsColumnLine?: number;
+};
+
+/**
+ * Every diff line containing the query, in render order: files as given,
+ * hunks top to bottom, deletions before additions within a change block. One
+ * match per line and side; context lines match once, on the additions side.
+ * Matching is a case-insensitive substring test.
+ *
+ * The whole model is scanned, not just what the virtualizer has rendered —
+ * that is the point: the browser's own find only sees the rendered window.
+ */
+export const diffSearchMatches = (
+	items: Array<CodeViewItem<unknown>>,
+	query: string,
+): Array<DiffSearchMatch> => {
+	if (query === "") return [];
+
+	const needle = query.toLowerCase();
+	const matches: Array<DiffSearchMatch> = [];
+
+	for (const item of items) {
+		// Whole-file items (image diffs) have no lines to search.
+		if (item.type !== "diff") continue;
+
+		const { additionLines, deletionLines, hunks } = item.fileDiff;
+		const lineHasMatch = (text: string | undefined): boolean =>
+			text !== undefined && text.toLowerCase().includes(needle);
+
+		for (const hunk of hunks) {
+			// The content blocks carry indexes into the line arrays but not line
+			// numbers, which accumulate from the hunk header as the blocks pass.
+			let additionLine = hunk.additionStart;
+			let deletionLine = hunk.deletionStart;
+
+			for (const block of hunk.hunkContent) {
+				if (block.type === "context") {
+					for (let i = 0; i < block.lines; i++) {
+						if (lineHasMatch(additionLines[block.additionLineIndex + i])) {
+							matches.push({
+								itemId: item.id,
+								side: "additions",
+								lineNumber: additionLine + i,
+								deletionsColumnLine: deletionLine + i,
+							});
+						}
+					}
+					additionLine += block.lines;
+					deletionLine += block.lines;
+				} else {
+					for (let i = 0; i < block.deletions; i++) {
+						if (lineHasMatch(deletionLines[block.deletionLineIndex + i]))
+							matches.push({ itemId: item.id, side: "deletions", lineNumber: deletionLine + i });
+					}
+					deletionLine += block.deletions;
+
+					for (let i = 0; i < block.additions; i++) {
+						if (lineHasMatch(additionLines[block.additionLineIndex + i]))
+							matches.push({ itemId: item.id, side: "additions", lineNumber: additionLine + i });
+					}
+					additionLine += block.additions;
+				}
+			}
+		}
+	}
+
+	return matches;
+};


### PR DESCRIPTION
The diff viewer virtualizes its rendering, so the browser's own find only sees the rendered window — on a large diff that's a sliver of the content. This adds a search over the whole diff model.

- `Mod+F` in the diff scope opens a floating search bar; `Enter` / `Shift+Enter` step through matches with wraparound, `Escape` closes and hands focus back to the diff
- Matches come from scanning Pierre's parsed hunks — one match per line and side, case-insensitive — so files the virtualizer hasn't rendered are found too
- Navigating scrolls the viewer and marks the match with the existing line selection, so search is just fast cursor movement: `j`/`k`, checking, and absorb continue from the match; folded files unfold on navigate

Why not the library: `@pierre/diffs` only ships search inside edit mode (a `SearchPanelWidget` bound to one item's `TextDocument`). Read-only cross-diff search is requested upstream in pierrecomputer/pierre#846 and the maintainer intends to build it on the edit-mode foundations — when it ships, this can be swapped out.

<img width="1558" height="1161" alt="image" src="https://github.com/user-attachments/assets/2015b78f-fc46-40c8-aa87-5661fbb6bd52" />
