### PR TITLE
Fast-forward local target after upstream integration

### DIFF
--- a/crates/but-api/src/workspace.rs
+++ b/crates/but-api/src/workspace.rs
@@ -602,11 +602,13 @@ pub fn workspace_integrate_upstream_only_with_perm(
 
         let materialized = rebase.materialize(Default::default())?;
         project_meta.persist(&repo)?;
-        but_workspace::fast_forward_local_tracking_branch(
+        if let Err(err) = but_workspace::fast_forward_local_tracking_branch(
             &repo,
             project_meta.target_ref_or_err()?.as_ref(),
             project_meta.target_commit_id_or_err()?,
-        )?;
+        ) {
+            warn!(?err, "failed to fast-forward local target branch");
+        }
 
         if let Some(ref_name) = materialized.workspace.ref_name()
             && let Some(ws_meta) = ws_meta

--- a/crates/but-api/src/workspace.rs
+++ b/crates/but-api/src/workspace.rs
@@ -602,6 +602,11 @@ pub fn workspace_integrate_upstream_only_with_perm(
 
         let materialized = rebase.materialize(Default::default())?;
         project_meta.persist(&repo)?;
+        but_workspace::fast_forward_local_tracking_branch(
+            &repo,
+            project_meta.target_ref_or_err()?.as_ref(),
+            project_meta.target_commit_id_or_err()?,
+        )?;
 
         if let Some(ref_name) = materialized.workspace.ref_name()
             && let Some(ws_meta) = ws_meta

--- a/crates/but-graph/src/init/walk/mod.rs
+++ b/crates/but-graph/src/init/walk/mod.rs
@@ -1,6 +1,6 @@
 //! Utilities for graph-walking specifically.
 use std::{
-    cmp::Ordering,
+    cmp::{Ordering, Reverse},
     collections::{BTreeMap, BTreeSet},
     ops::Deref,
 };
@@ -345,13 +345,18 @@ pub fn swap_queued_segments(queue: &mut Queue, a: SegmentIndex, b: SegmentIndex)
 
 pub fn swap_commits_and_connections(graph: &mut PetGraph, a: SegmentIndex, b: SegmentIndex) {
     // Connections describe the commits owned by a segment, so they must move with the commits.
-    let connections = graph
+    let touched_sources = graph
         .edge_references()
         .filter(|edge| {
             [edge.source(), edge.target()]
                 .into_iter()
                 .any(|node| node == a || node == b)
         })
+        .map(|edge| edge.source())
+        .collect::<BTreeSet<_>>();
+    let mut connections = graph
+        .edge_references()
+        .filter(|edge| touched_sources.contains(&edge.source()))
         .map(EdgeOwned::from)
         .collect::<Vec<_>>();
     for connection in &connections {
@@ -361,7 +366,7 @@ pub fn swap_commits_and_connections(graph: &mut PetGraph, a: SegmentIndex, b: Se
         let (a, b) = graph.index_twice_mut(a, b);
         std::mem::swap(&mut a.commits, &mut b.commits);
     }
-    for connection in connections {
+    for connection in &mut connections {
         let swap = |node| {
             if node == a {
                 b
@@ -371,11 +376,12 @@ pub fn swap_commits_and_connections(graph: &mut PetGraph, a: SegmentIndex, b: Se
                 node
             }
         };
-        graph.add_edge(
-            swap(connection.source),
-            swap(connection.target),
-            connection.weight,
-        );
+        connection.source = swap(connection.source);
+        connection.target = swap(connection.target);
+    }
+    connections.sort_by_key(|edge| (edge.source, Reverse(edge.weight.parent_order)));
+    for connection in connections {
+        graph.add_edge(connection.source, connection.target, connection.weight);
     }
 }
 

--- a/crates/but-graph/src/init/walk/mod.rs
+++ b/crates/but-graph/src/init/walk/mod.rs
@@ -8,7 +8,7 @@ use std::{
 use anyhow::{Context as _, bail};
 use but_core::{RefMetadata, is_workspace_ref_name, ref_metadata};
 use gix::{hashtable::hash_map::Entry, reference::Category, traverse::commit::Either};
-use petgraph::{Direction, prelude::EdgeRef};
+use petgraph::{Direction, prelude::EdgeRef, visit::IntoEdgeReferences};
 
 use crate::{
     Commit, CommitFlags, CommitIndex, Edge, Graph, Segment, SegmentIndex, SegmentMetadata,
@@ -344,12 +344,38 @@ pub fn swap_queued_segments(queue: &mut Queue, a: SegmentIndex, b: SegmentIndex)
 }
 
 pub fn swap_commits_and_connections(graph: &mut PetGraph, a: SegmentIndex, b: SegmentIndex) {
+    // Connections describe the commits owned by a segment, so they must move with the commits.
+    let connections = graph
+        .edge_references()
+        .filter(|edge| {
+            [edge.source(), edge.target()]
+                .into_iter()
+                .any(|node| node == a || node == b)
+        })
+        .map(EdgeOwned::from)
+        .collect::<Vec<_>>();
+    for connection in &connections {
+        graph.remove_edge(connection.id);
+    }
     {
         let (a, b) = graph.index_twice_mut(a, b);
         std::mem::swap(&mut a.commits, &mut b.commits);
     }
-    if graph.edges(a).next().is_some() || graph.edges(b).next().is_some() {
-        todo!("swap connections of nodes as well")
+    for connection in connections {
+        let swap = |node| {
+            if node == a {
+                b
+            } else if node == b {
+                a
+            } else {
+                node
+            }
+        };
+        graph.add_edge(
+            swap(connection.source),
+            swap(connection.target),
+            connection.weight,
+        );
     }
 }
 

--- a/crates/but-graph/src/init/walk/tests.rs
+++ b/crates/but-graph/src/init/walk/tests.rs
@@ -1,5 +1,51 @@
 use super::*;
 
+#[test]
+fn swapping_commits_also_swaps_incident_connections() {
+    let mut graph = PetGraph::default();
+    let a = graph.add_node(Segment::default());
+    let b = graph.add_node(Segment::default());
+    let before = graph.add_node(Segment::default());
+    let after = graph.add_node(Segment::default());
+    let edge = Edge {
+        src: None,
+        src_id: None,
+        dst: None,
+        dst_id: None,
+        parent_order: 0,
+    };
+    graph.add_edge(before, a, edge);
+    graph.add_edge(a, after, edge);
+    graph.add_edge(b, before, edge);
+
+    swap_commits_and_connections(&mut graph, a, b);
+
+    assert!(
+        graph.find_edge(before, b).is_some(),
+        "incoming connections move from a to b"
+    );
+    assert!(
+        graph.find_edge(b, after).is_some(),
+        "outgoing connections move from a to b"
+    );
+    assert!(
+        graph.find_edge(a, before).is_some(),
+        "connections move from b to a"
+    );
+    assert!(
+        graph.find_edge(before, a).is_none(),
+        "a no longer owns its old incoming connection"
+    );
+    assert!(
+        graph.find_edge(a, after).is_none(),
+        "a no longer owns its old outgoing connection"
+    );
+    assert!(
+        graph.find_edge(b, before).is_none(),
+        "b no longer owns its old outgoing connection"
+    );
+}
+
 fn gtt(generation: Option<u32>, committer_time: u64) -> GenThenTime {
     GenThenTime {
         generation,

--- a/crates/but-graph/src/init/walk/tests.rs
+++ b/crates/but-graph/src/init/walk/tests.rs
@@ -7,6 +7,7 @@ fn swapping_commits_also_swaps_incident_connections() {
     let b = graph.add_node(Segment::default());
     let before = graph.add_node(Segment::default());
     let after = graph.add_node(Segment::default());
+    let other_parent = graph.add_node(Segment::default());
     let edge = Edge {
         src: None,
         src_id: None,
@@ -14,9 +15,18 @@ fn swapping_commits_also_swaps_incident_connections() {
         dst_id: None,
         parent_order: 0,
     };
-    graph.add_edge(before, a, edge);
+    graph.add_edge(
+        before,
+        a,
+        Edge {
+            parent_order: 1,
+            ..edge
+        },
+    );
+    graph.add_edge(before, other_parent, edge);
     graph.add_edge(a, after, edge);
     graph.add_edge(b, before, edge);
+    graph.add_edge(a, b, edge);
 
     swap_commits_and_connections(&mut graph, a, b);
 
@@ -33,6 +43,10 @@ fn swapping_commits_also_swaps_incident_connections() {
         "connections move from b to a"
     );
     assert!(
+        graph.find_edge(b, a).is_some(),
+        "connections directly between swapped segments reverse"
+    );
+    assert!(
         graph.find_edge(before, a).is_none(),
         "a no longer owns its old incoming connection"
     );
@@ -43,6 +57,14 @@ fn swapping_commits_also_swaps_incident_connections() {
     assert!(
         graph.find_edge(b, before).is_none(),
         "b no longer owns its old outgoing connection"
+    );
+    assert_eq!(
+        graph
+            .edges_directed(before, Direction::Outgoing)
+            .map(|edge| edge.weight().parent_order)
+            .collect::<Vec<_>>(),
+        [0, 1],
+        "outgoing connections remain in parent traversal order"
     );
 }
 

--- a/crates/but-graph/src/init/walk/tests.rs
+++ b/crates/but-graph/src/init/walk/tests.rs
@@ -7,7 +7,6 @@ fn swapping_commits_also_swaps_incident_connections() {
     let b = graph.add_node(Segment::default());
     let before = graph.add_node(Segment::default());
     let after = graph.add_node(Segment::default());
-    let other_parent = graph.add_node(Segment::default());
     let edge = Edge {
         src: None,
         src_id: None,
@@ -15,15 +14,7 @@ fn swapping_commits_also_swaps_incident_connections() {
         dst_id: None,
         parent_order: 0,
     };
-    graph.add_edge(
-        before,
-        a,
-        Edge {
-            parent_order: 1,
-            ..edge
-        },
-    );
-    graph.add_edge(before, other_parent, edge);
+    graph.add_edge(before, a, edge);
     graph.add_edge(a, after, edge);
     graph.add_edge(b, before, edge);
     graph.add_edge(a, b, edge);
@@ -58,13 +49,41 @@ fn swapping_commits_also_swaps_incident_connections() {
         graph.find_edge(b, before).is_none(),
         "b no longer owns its old outgoing connection"
     );
+}
+
+#[test]
+fn swapping_connections_preserves_untouched_sibling_parent_order() {
+    let mut graph = PetGraph::default();
+    let a = graph.add_node(Segment::default());
+    let b = graph.add_node(Segment::default());
+    let source = graph.add_node(Segment::default());
+    let other_parent = graph.add_node(Segment::default());
+    let edge = Edge {
+        src: None,
+        src_id: None,
+        dst: None,
+        dst_id: None,
+        parent_order: 0,
+    };
+    graph.add_edge(
+        source,
+        a,
+        Edge {
+            parent_order: 1,
+            ..edge
+        },
+    );
+    graph.add_edge(source, other_parent, edge);
+
+    swap_commits_and_connections(&mut graph, a, b);
+
     assert_eq!(
         graph
-            .edges_directed(before, Direction::Outgoing)
-            .map(|edge| edge.weight().parent_order)
+            .edges_directed(source, Direction::Outgoing)
+            .map(|edge| (edge.target(), edge.weight().parent_order))
             .collect::<Vec<_>>(),
-        [0, 1],
-        "outgoing connections remain in parent traversal order"
+        [(other_parent, 0), (b, 1)],
+        "the swapped connection stays after its untouched sibling"
     );
 }
 

--- a/crates/but-workspace/src/lib.rs
+++ b/crates/but-workspace/src/lib.rs
@@ -66,7 +66,7 @@ use but_graph::{SegmentIndex, workspace::TargetCommit};
 mod upstream_integration;
 pub use upstream_integration::{
     BottomUpdate, BottomUpdateKind, IntegrateUpstreamOutcome, ReviewIntegrationHint,
-    integrate_upstream, integrate_upstream_with_hints,
+    fast_forward_local_tracking_branch, integrate_upstream, integrate_upstream_with_hints,
 };
 mod worktree;
 pub use worktree::{resolve_worktree_conflicts, worktree_conflicts_for_rebase};

--- a/crates/but-workspace/src/upstream_integration.rs
+++ b/crates/but-workspace/src/upstream_integration.rs
@@ -1180,31 +1180,40 @@ pub fn fast_forward_local_tracking_branch(
             let target_short_name =
                 but_core::extract_remote_name_and_short_name(target_ref, &repo.remote_names())
                     .map(|(_, short_name)| short_name);
-            let mut fallback = None;
-            for reference in repo.references()?.prefixed("refs/heads/")? {
-                let Ok(reference) = reference else {
-                    continue;
-                };
-                let tracks_target = repo
-                    .branch_remote_tracking_ref_name(
-                        reference.name(),
-                        gix::remote::Direction::Fetch,
-                    )
+            let tracks_target = |name: &gix::refs::FullNameRef| -> Result<bool> {
+                Ok(repo
+                    .branch_remote_tracking_ref_name(name, gix::remote::Direction::Fetch)
                     .transpose()?
-                    .is_some_and(|name| name.as_bstr() == target_ref.as_bstr());
-                if !tracks_target {
-                    continue;
-                }
-                if target_short_name
-                    .as_ref()
-                    .is_some_and(|name| name.as_bstr() == reference.name().shorten())
+                    .is_some_and(|name| name.as_bstr() == target_ref.as_bstr()))
+            };
+            let preferred = if let Some(short_name) = target_short_name.as_ref() {
+                let preferred =
+                    gix::refs::Category::LocalBranch.to_full_name(short_name.as_bstr())?;
+                if let Some(reference) = repo.try_find_reference(&preferred)?
+                    && tracks_target(reference.name())?
                 {
-                    fallback = Some(reference.name().to_owned());
-                    break;
+                    Some(preferred)
+                } else {
+                    None
                 }
-                fallback.get_or_insert_with(|| reference.name().to_owned());
+            } else {
+                None
+            };
+            if preferred.is_some() {
+                preferred
+            } else {
+                let mut fallback = None;
+                for reference in repo.references()?.prefixed("refs/heads/")? {
+                    let Ok(reference) = reference else {
+                        continue;
+                    };
+                    if !tracks_target(reference.name())? {
+                        continue;
+                    }
+                    fallback.get_or_insert_with(|| reference.name().to_owned());
+                }
+                fallback
             }
-            fallback
         }
         _ => None,
     };

--- a/crates/but-workspace/src/upstream_integration.rs
+++ b/crates/but-workspace/src/upstream_integration.rs
@@ -1166,3 +1166,68 @@ fn preserve_pick_parents<M: RefMetadata>(
     editor.replace(selector, Step::Pick(pick))?;
     Ok(())
 }
+
+/// Fast-forward the local branch that tracks a remote `target_ref`, preferring the same name.
+///
+/// Local target refs, missing tracking branches, and non-fast-forward updates are left unchanged.
+pub fn fast_forward_local_tracking_branch(
+    repo: &gix::Repository,
+    target_ref: &gix::refs::FullNameRef,
+    target_id: gix::ObjectId,
+) -> Result<()> {
+    let local_ref_name = match target_ref.category() {
+        Some(gix::refs::Category::RemoteBranch) => {
+            let target_short_name =
+                but_core::extract_remote_name_and_short_name(target_ref, &repo.remote_names())
+                    .map(|(_, short_name)| short_name);
+            let mut fallback = None;
+            for reference in repo.references()?.prefixed("refs/heads/")? {
+                let Ok(reference) = reference else {
+                    continue;
+                };
+                let tracks_target = repo
+                    .branch_remote_tracking_ref_name(
+                        reference.name(),
+                        gix::remote::Direction::Fetch,
+                    )
+                    .transpose()?
+                    .is_some_and(|name| name.as_bstr() == target_ref.as_bstr());
+                if !tracks_target {
+                    continue;
+                }
+                if target_short_name
+                    .as_ref()
+                    .is_some_and(|name| name.as_bstr() == reference.name().shorten())
+                {
+                    fallback = Some(reference.name().to_owned());
+                    break;
+                }
+                fallback.get_or_insert_with(|| reference.name().to_owned());
+            }
+            fallback
+        }
+        _ => None,
+    };
+    let Some(local_ref_name) = local_ref_name else {
+        return Ok(());
+    };
+    let mut local_ref = repo.find_reference(&local_ref_name)?;
+    let local_id = local_ref.peel_to_id()?.detach();
+    if local_id == target_id
+        || !repo
+            .merge_base(local_id, target_id)
+            .is_ok_and(|base| base.detach() == local_id)
+    {
+        return Ok(());
+    }
+
+    repo.reference(
+        local_ref_name,
+        target_id,
+        gix::refs::transaction::PreviousValue::ExistingMustMatch(gix::refs::Target::Object(
+            local_id,
+        )),
+        "integrate upstream: fast-forward local target",
+    )?;
+    Ok(())
+}

--- a/crates/but-workspace/tests/fixtures/scenario/local-target-tracking.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/local-target-tracking.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+git init
+commit-file file.txt one
+git branch feature
+git remote add origin ../origin
+git update-ref refs/remotes/origin/main HEAD
+echo two >file.txt
+git commit -am two

--- a/crates/but-workspace/tests/workspace/upstream_integration.rs
+++ b/crates/but-workspace/tests/workspace/upstream_integration.rs
@@ -4,11 +4,12 @@ use but_core::{Commit, RefMetadata, ref_metadata::ProjectMeta};
 use but_graph::init::{Options, Tip};
 use but_rebase::graph_rebase::mutate::RelativeTo;
 use but_testsupport::{
-    CommandExt, InMemoryRefMetadata, git, graph_workspace, visualize_commit_graph_all,
+    CommandExt, InMemoryRefMetadata, git, git_at_dir, graph_workspace, open_repo,
+    visualize_commit_graph_all,
 };
 use but_workspace::{
-    BottomUpdate, BottomUpdateKind, ReviewIntegrationHint, integrate_upstream,
-    integrate_upstream_with_hints, worktree_conflicts_for_rebase,
+    BottomUpdate, BottomUpdateKind, ReviewIntegrationHint, fast_forward_local_tracking_branch,
+    integrate_upstream, integrate_upstream_with_hints, worktree_conflicts_for_rebase,
 };
 use gix::prelude::ObjectIdExt;
 use gix::refs::transaction::PreviousValue;
@@ -3956,5 +3957,138 @@ fn remove_managed_workspace_ref(repo: &gix::Repository) -> Result<()> {
     if let Some(reference) = repo.try_find_reference(but_core::WORKSPACE_REF_NAME)? {
         reference.delete()?;
     }
+    Ok(())
+}
+
+fn repo_with_local_target_branches() -> Result<(gix::Repository, tempfile::TempDir)> {
+    let tmp = tempfile::tempdir()?;
+    git_at_dir(tmp.path()).args(["init", "-b", "main"]).run();
+    git_at_dir(tmp.path())
+        .args(["config", "user.name", "GitButler"])
+        .run();
+    git_at_dir(tmp.path())
+        .args(["config", "user.email", "gitbutler@example.com"])
+        .run();
+    std::fs::write(tmp.path().join("file.txt"), "one\n")?;
+    git_at_dir(tmp.path()).args(["add", "file.txt"]).run();
+    git_at_dir(tmp.path()).args(["commit", "-m", "one"]).run();
+    git_at_dir(tmp.path()).args(["branch", "feature"]).run();
+    git_at_dir(tmp.path())
+        .args(["config", "remote.origin.url", "../origin"])
+        .run();
+    git_at_dir(tmp.path())
+        .args([
+            "config",
+            "remote.origin.fetch",
+            "+refs/heads/*:refs/remotes/origin/*",
+        ])
+        .run();
+    git_at_dir(tmp.path())
+        .args(["update-ref", "refs/remotes/origin/main", "HEAD"])
+        .run();
+    std::fs::write(tmp.path().join("file.txt"), "two\n")?;
+    git_at_dir(tmp.path()).args(["commit", "-am", "two"]).run();
+    Ok((open_repo(tmp.path())?, tmp))
+}
+
+fn configure_tracking(tmp: &tempfile::TempDir, branch: &str) {
+    git_at_dir(tmp.path())
+        .args(["config", &format!("branch.{branch}.remote"), "origin"])
+        .run();
+    git_at_dir(tmp.path())
+        .args([
+            "config",
+            &format!("branch.{branch}.merge"),
+            "refs/heads/main",
+        ])
+        .run();
+}
+
+#[test]
+fn fast_forwards_local_target_branch() -> Result<()> {
+    let (_repo, tmp) = repo_with_local_target_branches()?;
+    configure_tracking(&tmp, "feature");
+    git_at_dir(tmp.path())
+        .args(["update-ref", "refs/remotes/origin/main", "refs/heads/main"])
+        .run();
+    let repo = open_repo(tmp.path())?;
+    let target_ref: gix::refs::FullName = "refs/remotes/origin/main".try_into()?;
+    let target_id = repo.find_reference(&target_ref)?.id().detach();
+
+    fast_forward_local_tracking_branch(&repo, target_ref.as_ref(), target_id)?;
+
+    assert_eq!(
+        repo.find_reference("refs/heads/feature")?.id().detach(),
+        target_id,
+        "the local tracking branch should fast-forward to the target"
+    );
+    Ok(())
+}
+
+#[test]
+fn leaves_diverged_local_target_branch_unchanged() -> Result<()> {
+    let (_repo, tmp) = repo_with_local_target_branches()?;
+    git_at_dir(tmp.path())
+        .args(["update-ref", "refs/remotes/origin/main", "refs/heads/main"])
+        .run();
+    git_at_dir(tmp.path()).args(["checkout", "feature"]).run();
+    std::fs::write(tmp.path().join("feature.txt"), "feature\n")?;
+    git_at_dir(tmp.path()).args(["add", "feature.txt"]).run();
+    git_at_dir(tmp.path())
+        .args(["commit", "-m", "feature"])
+        .run();
+    configure_tracking(&tmp, "feature");
+    let repo = open_repo(tmp.path())?;
+    let target_ref: gix::refs::FullName = "refs/remotes/origin/main".try_into()?;
+    let target_id = repo.find_reference(&target_ref)?.id().detach();
+    let local_id = repo.find_reference("refs/heads/feature")?.id().detach();
+
+    fast_forward_local_tracking_branch(&repo, target_ref.as_ref(), target_id)?;
+
+    assert_eq!(
+        repo.find_reference("refs/heads/feature")?.id().detach(),
+        local_id,
+        "a diverged local target branch must stay unchanged"
+    );
+    Ok(())
+}
+
+#[test]
+fn leaves_local_target_refs_unchanged() -> Result<()> {
+    let (repo, _tmp) = repo_with_local_target_branches()?;
+    let local_target: gix::refs::FullName = "refs/heads/feature".try_into()?;
+    let local_id = repo.find_reference(&local_target)?.id().detach();
+    let newer_id = repo.find_reference("refs/heads/main")?.id().detach();
+
+    fast_forward_local_tracking_branch(&repo, local_target.as_ref(), newer_id)?;
+
+    assert_eq!(
+        repo.find_reference(&local_target)?.id().detach(),
+        local_id,
+        "local target refs must not be updated"
+    );
+    Ok(())
+}
+
+#[test]
+fn prefers_same_named_local_target_branch() -> Result<()> {
+    let (_repo, tmp) = repo_with_local_target_branches()?;
+    configure_tracking(&tmp, "feature");
+    configure_tracking(&tmp, "main");
+    git_at_dir(tmp.path())
+        .args(["update-ref", "refs/remotes/origin/main", "refs/heads/main"])
+        .run();
+    let repo = open_repo(tmp.path())?;
+    let target_ref: gix::refs::FullName = "refs/remotes/origin/main".try_into()?;
+    let target_id = repo.find_reference(&target_ref)?.id().detach();
+    let feature_id = repo.find_reference("refs/heads/feature")?.id().detach();
+
+    fast_forward_local_tracking_branch(&repo, target_ref.as_ref(), target_id)?;
+
+    assert_eq!(
+        repo.find_reference("refs/heads/feature")?.id().detach(),
+        feature_id,
+        "the same-named main branch should be preferred over another tracker"
+    );
     Ok(())
 }

--- a/crates/but-workspace/tests/workspace/upstream_integration.rs
+++ b/crates/but-workspace/tests/workspace/upstream_integration.rs
@@ -4078,6 +4078,9 @@ fn prefers_same_named_local_target_branch() -> Result<()> {
     git_at_dir(tmp.path())
         .args(["update-ref", "refs/remotes/origin/main", "refs/heads/main"])
         .run();
+    git_at_dir(tmp.path())
+        .args(["update-ref", "refs/heads/main", "refs/heads/feature"])
+        .run();
     let repo = open_repo(tmp.path())?;
     let target_ref: gix::refs::FullName = "refs/remotes/origin/main".try_into()?;
     let target_id = repo.find_reference(&target_ref)?.id().detach();
@@ -4085,6 +4088,11 @@ fn prefers_same_named_local_target_branch() -> Result<()> {
 
     fast_forward_local_tracking_branch(&repo, target_ref.as_ref(), target_id)?;
 
+    assert_eq!(
+        repo.find_reference("refs/heads/main")?.id().detach(),
+        target_id,
+        "the same-named main branch should fast-forward to the target"
+    );
     assert_eq!(
         repo.find_reference("refs/heads/feature")?.id().detach(),
         feature_id,

--- a/crates/but-workspace/tests/workspace/upstream_integration.rs
+++ b/crates/but-workspace/tests/workspace/upstream_integration.rs
@@ -3961,34 +3961,7 @@ fn remove_managed_workspace_ref(repo: &gix::Repository) -> Result<()> {
 }
 
 fn repo_with_local_target_branches() -> Result<(gix::Repository, tempfile::TempDir)> {
-    let tmp = tempfile::tempdir()?;
-    git_at_dir(tmp.path()).args(["init", "-b", "main"]).run();
-    git_at_dir(tmp.path())
-        .args(["config", "user.name", "GitButler"])
-        .run();
-    git_at_dir(tmp.path())
-        .args(["config", "user.email", "gitbutler@example.com"])
-        .run();
-    std::fs::write(tmp.path().join("file.txt"), "one\n")?;
-    git_at_dir(tmp.path()).args(["add", "file.txt"]).run();
-    git_at_dir(tmp.path()).args(["commit", "-m", "one"]).run();
-    git_at_dir(tmp.path()).args(["branch", "feature"]).run();
-    git_at_dir(tmp.path())
-        .args(["config", "remote.origin.url", "../origin"])
-        .run();
-    git_at_dir(tmp.path())
-        .args([
-            "config",
-            "remote.origin.fetch",
-            "+refs/heads/*:refs/remotes/origin/*",
-        ])
-        .run();
-    git_at_dir(tmp.path())
-        .args(["update-ref", "refs/remotes/origin/main", "HEAD"])
-        .run();
-    std::fs::write(tmp.path().join("file.txt"), "two\n")?;
-    git_at_dir(tmp.path()).args(["commit", "-am", "two"]).run();
-    Ok((open_repo(tmp.path())?, tmp))
+    Ok(crate::utils::writable_scenario("local-target-tracking"))
 }
 
 fn configure_tracking(tmp: &tempfile::TempDir, branch: &str) {

--- a/crates/but/tests/but/command/pull.rs
+++ b/crates/but/tests/but/command/pull.rs
@@ -44,22 +44,15 @@ fn merge_into_upstream(env: &Sandbox, branch: &str, add_upstream_commit: bool) {
     env.invoke_git("fetch origin");
 }
 
-fn managed_target_branch_pull_scenario(diverged: bool) -> Sandbox {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("pull-two-integrated-stacks");
+fn target_branch_pull_scenario(diverged: bool) -> Sandbox {
+    let env = Sandbox::init_scenario_with_target_and_default_settings(
+        "pull-two-integrated-stacks-with-local-target",
+    );
     env.setup_metadata_at_target(&["A", "B"], "A~1");
-    env.but("config feature single-branch disable")
-        .assert()
-        .success();
     let old_target = env
         .project_meta()
         .target_commit_id
         .expect("fixture has a target commit");
-    env.invoke_git("init --bare .git/upstream.git");
-    env.invoke_git("push .git/upstream.git refs/heads/main:refs/heads/main");
-    env.invoke_git("remote set-url origin .git/upstream.git");
-    env.invoke_git("config branch.main.remote origin");
-    env.invoke_git("config branch.main.merge refs/heads/main");
-    env.invoke_git(&format!("update-ref refs/heads/main {old_target}"));
     if diverged {
         let local_commit = env.invoke_git(&format!(
             "commit-tree {old_target}^{{tree}} -p {old_target} -m local-main"
@@ -69,62 +62,19 @@ fn managed_target_branch_pull_scenario(diverged: bool) -> Sandbox {
     env
 }
 
-fn commit_graph(env: &Sandbox) -> String {
-    env.git_log()
-        .lines()
-        .map(str::trim_end)
-        .collect::<Vec<_>>()
-        .join("\n")
-        + "\n"
+fn single_branch_target_branch_pull_scenario(diverged: bool) -> Sandbox {
+    let env = target_branch_pull_scenario(diverged);
+    env.but("config feature single-branch enable")
+        .assert()
+        .success();
+    env
 }
 
-#[test]
-fn pull_fast_forwards_the_local_target_branch() {
-    let env = managed_target_branch_pull_scenario(false);
+fn assert_pull_fast_forwards_local_target(env: Sandbox) {
     assert_ne!(rev_parse(&env, "main"), rev_parse(&env, "origin/main"));
-    // The pre-integration graph keeps local main at the old target.
-    snapbox::assert_data_eq!(
-        commit_graph(&env),
-        snapbox::str![[r#"
-*   c128bce (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-|/
-| | * 7e5d4e1 (origin/main, origin/HEAD) add upstream
-| | *   613fca8 merge B
-| | |/
-| |_|/
-|/| |
-* | | d3e2ba3 (B) add B
-| | * c0a497b merge A
-| |/|
-|/|/
-| * 9477ae7 (A) add A
-|/
-* 0dc3733 (main) add M
-
-"#]]
-    );
 
     env.but("pull").assert().success();
 
-    // The post-integration graph moves local main to origin/main.
-    snapbox::assert_data_eq!(
-        commit_graph(&env),
-        snapbox::str![[r#"
-* 1f7c7b0 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-* 7e5d4e1 (origin/main, origin/HEAD, main, gitbutler/target) add upstream
-*   613fca8 merge B
-|/
-| * d3e2ba3 add B
-* |   c0a497b merge A
-|/ /
-| |/
-|/|
-| * 9477ae7 add A
-|/
-* 0dc3733 add M
-
-"#]]
-    );
     assert_eq!(
         rev_parse(&env, "main"),
         rev_parse(&env, "origin/main"),
@@ -132,64 +82,37 @@ fn pull_fast_forwards_the_local_target_branch() {
     );
 }
 
-#[test]
-fn pull_leaves_a_diverged_local_target_branch_unchanged() {
-    let env = managed_target_branch_pull_scenario(true);
+fn assert_pull_preserves_diverged_local_target(env: Sandbox) {
     let local_main = rev_parse(&env, "main");
-    // The pre-integration graph shows the local-only commit diverging from origin/main.
-    snapbox::assert_data_eq!(
-        commit_graph(&env),
-        snapbox::str![[r#"
-*   c128bce (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-|/
-| | * f587c40 (main) local-main
-| | | * 7e5d4e1 (origin/main, origin/HEAD) add upstream
-| | | *   613fca8 merge B
-| | | |/
-| |_|_|/
-|/| | |
-* | | | d3e2ba3 (B) add B
-| |/ /
-|/| |
-| | * c0a497b merge A
-| |/|
-|/|/
-| * 9477ae7 (A) add A
-|/
-* 0dc3733 add M
-
-"#]]
-    );
 
     env.but("pull").assert().success();
 
-    // The post-integration graph retains the diverged local main ref.
-    snapbox::assert_data_eq!(
-        commit_graph(&env),
-        snapbox::str![[r#"
-* 1f7c7b0 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-* 7e5d4e1 (origin/main, origin/HEAD, gitbutler/target) add upstream
-*   613fca8 merge B
-|/
-| * d3e2ba3 add B
-* |   c0a497b merge A
-|/ /
-| |/
-|/|
-| * 9477ae7 add A
-|/
-| * f587c40 (main) local-main
-|/
-* 0dc3733 add M
-
-"#]]
-    );
     assert_eq!(
         rev_parse(&env, "main"),
         local_main,
         "pull must preserve local commits on a diverged target branch"
     );
     assert_ne!(rev_parse(&env, "main"), rev_parse(&env, "origin/main"));
+}
+
+#[test]
+fn pull_fast_forwards_the_local_target_branch() {
+    assert_pull_fast_forwards_local_target(target_branch_pull_scenario(false));
+}
+
+#[test]
+fn single_branch_pull_fast_forwards_the_local_target_branch() {
+    assert_pull_fast_forwards_local_target(single_branch_target_branch_pull_scenario(false));
+}
+
+#[test]
+fn pull_leaves_a_diverged_local_target_branch_unchanged() {
+    assert_pull_preserves_diverged_local_target(target_branch_pull_scenario(true));
+}
+
+#[test]
+fn single_branch_pull_leaves_a_diverged_local_target_branch_unchanged() {
+    assert_pull_preserves_diverged_local_target(single_branch_target_branch_pull_scenario(true));
 }
 
 #[test]

--- a/crates/but/tests/but/command/pull.rs
+++ b/crates/but/tests/but/command/pull.rs
@@ -44,6 +44,154 @@ fn merge_into_upstream(env: &Sandbox, branch: &str, add_upstream_commit: bool) {
     env.invoke_git("fetch origin");
 }
 
+fn managed_target_branch_pull_scenario(diverged: bool) -> Sandbox {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("pull-two-integrated-stacks");
+    env.setup_metadata_at_target(&["A", "B"], "A~1");
+    env.but("config feature single-branch disable")
+        .assert()
+        .success();
+    let old_target = env
+        .project_meta()
+        .target_commit_id
+        .expect("fixture has a target commit");
+    env.invoke_git("init --bare .git/upstream.git");
+    env.invoke_git("push .git/upstream.git refs/heads/main:refs/heads/main");
+    env.invoke_git("remote set-url origin .git/upstream.git");
+    env.invoke_git("config branch.main.remote origin");
+    env.invoke_git("config branch.main.merge refs/heads/main");
+    env.invoke_git(&format!("update-ref refs/heads/main {old_target}"));
+    if diverged {
+        let local_commit = env.invoke_git(&format!(
+            "commit-tree {old_target}^{{tree}} -p {old_target} -m local-main"
+        ));
+        env.invoke_git(&format!("update-ref refs/heads/main {local_commit}"));
+    }
+    env
+}
+
+fn commit_graph(env: &Sandbox) -> String {
+    env.git_log()
+        .lines()
+        .map(str::trim_end)
+        .collect::<Vec<_>>()
+        .join("\n")
+        + "\n"
+}
+
+#[test]
+fn pull_fast_forwards_the_local_target_branch() {
+    let env = managed_target_branch_pull_scenario(false);
+    assert_ne!(rev_parse(&env, "main"), rev_parse(&env, "origin/main"));
+    // The pre-integration graph keeps local main at the old target.
+    snapbox::assert_data_eq!(
+        commit_graph(&env),
+        snapbox::str![[r#"
+*   c128bce (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+|/
+| | * 7e5d4e1 (origin/main, origin/HEAD) add upstream
+| | *   613fca8 merge B
+| | |/
+| |_|/
+|/| |
+* | | d3e2ba3 (B) add B
+| | * c0a497b merge A
+| |/|
+|/|/
+| * 9477ae7 (A) add A
+|/
+* 0dc3733 (main) add M
+
+"#]]
+    );
+
+    env.but("pull").assert().success();
+
+    // The post-integration graph moves local main to origin/main.
+    snapbox::assert_data_eq!(
+        commit_graph(&env),
+        snapbox::str![[r#"
+* 1f7c7b0 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+* 7e5d4e1 (origin/main, origin/HEAD, main, gitbutler/target) add upstream
+*   613fca8 merge B
+|/
+| * d3e2ba3 add B
+* |   c0a497b merge A
+|/ /
+| |/
+|/|
+| * 9477ae7 add A
+|/
+* 0dc3733 add M
+
+"#]]
+    );
+    assert_eq!(
+        rev_parse(&env, "main"),
+        rev_parse(&env, "origin/main"),
+        "pull should fast-forward the local target branch"
+    );
+}
+
+#[test]
+fn pull_leaves_a_diverged_local_target_branch_unchanged() {
+    let env = managed_target_branch_pull_scenario(true);
+    let local_main = rev_parse(&env, "main");
+    // The pre-integration graph shows the local-only commit diverging from origin/main.
+    snapbox::assert_data_eq!(
+        commit_graph(&env),
+        snapbox::str![[r#"
+*   c128bce (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+|/
+| | * f587c40 (main) local-main
+| | | * 7e5d4e1 (origin/main, origin/HEAD) add upstream
+| | | *   613fca8 merge B
+| | | |/
+| |_|_|/
+|/| | |
+* | | | d3e2ba3 (B) add B
+| |/ /
+|/| |
+| | * c0a497b merge A
+| |/|
+|/|/
+| * 9477ae7 (A) add A
+|/
+* 0dc3733 add M
+
+"#]]
+    );
+
+    env.but("pull").assert().success();
+
+    // The post-integration graph retains the diverged local main ref.
+    snapbox::assert_data_eq!(
+        commit_graph(&env),
+        snapbox::str![[r#"
+* 1f7c7b0 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+* 7e5d4e1 (origin/main, origin/HEAD, gitbutler/target) add upstream
+*   613fca8 merge B
+|/
+| * d3e2ba3 add B
+* |   c0a497b merge A
+|/ /
+| |/
+|/|
+| * 9477ae7 add A
+|/
+| * f587c40 (main) local-main
+|/
+* 0dc3733 add M
+
+"#]]
+    );
+    assert_eq!(
+        rev_parse(&env, "main"),
+        local_main,
+        "pull must preserve local commits on a diverged target branch"
+    );
+    assert_ne!(rev_parse(&env, "main"), rev_parse(&env, "origin/main"));
+}
+
 #[test]
 fn single_branch_pull_replaces_a_fully_integrated_checkout() {
     let env = single_branch_integration_scenario();

--- a/crates/but/tests/fixtures/scenario/pull-two-integrated-stacks-with-local-target.sh
+++ b/crates/but/tests/fixtures/scenario/pull-two-integrated-stacks-with-local-target.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/pull-two-integrated-stacks.sh"
+
+old_target=$(git rev-parse A~1)
+git init --bare .git/upstream.git
+git push .git/upstream.git refs/heads/main:refs/heads/main
+git remote set-url origin .git/upstream.git
+git config branch.main.remote origin
+git config branch.main.merge refs/heads/main
+git update-ref refs/heads/main "$old_target"

--- a/e2e/playwright/tests/upstreamIntegration.spec.ts
+++ b/e2e/playwright/tests/upstreamIntegration.spec.ts
@@ -138,6 +138,44 @@ test("should reparent workspace commit to advanced target after integrating all 
 
 	await waitForTestIdToNotExist(page, "stack");
 	await expectWorkspaceCommitParentToBeOriginMaster(localClone);
+	expect(git(localClone, ["rev-parse", "master"])).toBe(
+		git(localClone, ["rev-parse", "origin/master"]),
+	);
+});
+
+test("should preserve a diverged local target branch during upstream integration", async ({
+	page,
+	gitbutler,
+}) => {
+	const localClone = gitbutler.pathInWorkdir("local-clone");
+
+	await gitbutler.runScript("project-with-remote-branches.sh");
+	await applyUpstream(gitbutler, "branch1");
+	await openWorkspace(page);
+
+	const oldMaster = git(localClone, ["rev-parse", "master"]);
+	const localMaster = git(localClone, [
+		"-c",
+		"user.name=GitButler",
+		"-c",
+		"user.email=gitbutler@example.com",
+		"commit-tree",
+		"master^{tree}",
+		"-p",
+		oldMaster,
+		"-m",
+		"local master",
+	]);
+	git(localClone, ["update-ref", "refs/heads/master", localMaster]);
+
+	await gitbutler.runScript(
+		"project-with-remote-branches__fast-forward-base-through-branch1-and-add-commit.sh",
+	);
+	await syncAndIntegrate(page);
+
+	await waitForTestIdToNotExist(page, "stack");
+	expect(git(localClone, ["rev-parse", "master"])).toBe(localMaster);
+	expect(git(localClone, ["rev-parse", "origin/master"])).not.toBe(localMaster);
 });
 
 test("should reparent workspace commit to advanced merge target after integrating all stacks", async ({


### PR DESCRIPTION
## Summary

- Fast-forward the preferred local branch tracking the remote target after upstream integration.
- Leave diverged tracking branches and local target refs unchanged.
- Cover the behavior in workspace tests, CLI before/after graph snapshots, and desktop E2E tests.
