### PR TITLE
feat(tui): show label while in single-branch-mode

### DIFF
--- a/crates/but/src/command/legacy/status/tui/app/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/app/mod.rs
@@ -136,6 +136,7 @@ pub struct App {
     pub head_sha: String,
     pub clipboard: Clipboard,
     pub operating_mode: OperatingMode,
+    pub is_in_single_branch_mode: bool,
 }
 
 pub(super) fn changed_paths_affect_uncommitted_details<'a>(
@@ -402,7 +403,7 @@ impl App {
 
         let file_browser = show_file_browser.then(FileBrowser::default);
 
-        Ok(Self {
+        let mut app = Self {
             status_lines,
             flags,
             cursor,
@@ -431,7 +432,12 @@ impl App {
             head_sha,
             clipboard,
             operating_mode,
-        })
+            is_in_single_branch_mode: false,
+        };
+
+        app.reload_is_in_single_branch_mode(ctx)?;
+
+        Ok(app)
     }
 
     pub fn active_key_binds(&self) -> &KeyBinds {
@@ -1393,6 +1399,17 @@ impl App {
                 self.details.select_section_when_available(index, direction);
             }
         }
+
+        self.reload_is_in_single_branch_mode(ctx)?;
+
+        Ok(())
+    }
+
+    fn reload_is_in_single_branch_mode(&mut self, ctx: &Context) -> anyhow::Result<()> {
+        let guard = ctx.shared_worktree_access();
+
+        self.is_in_single_branch_mode = ctx.settings.feature_flags.single_branch
+            && gitbutler_operating_modes::in_outside_workspace_mode(ctx, guard.read_permission())?;
 
         Ok(())
     }

--- a/crates/but/src/command/legacy/status/tui/render.rs
+++ b/crates/but/src/command/legacy/status/tui/render.rs
@@ -1031,9 +1031,26 @@ fn render_hot_bar(app: &App, area: Rect, frame: &mut Frame) {
 
     frame.render_widget(" ", layout[1]);
 
-    app.mode
-        .as_mode_render()
-        .render_hot_bar_content(app, layout[2], frame);
+    if app.is_in_single_branch_mode {
+        let content_layout =
+            Layout::horizontal([Constraint::Min(1), Constraint::Length(5)]).split(layout[2]);
+
+        app.mode
+            .as_mode_render()
+            .render_hot_bar_content(app, content_layout[0], frame);
+
+        frame.render_widget(
+            Span::styled(
+                " SBM ",
+                Style::default().bg(ModeDiscriminant::Normal.bg(app.theme)),
+            ),
+            content_layout[1],
+        );
+    } else {
+        app.mode
+            .as_mode_render()
+            .render_hot_bar_content(app, layout[2], frame);
+    }
 
     if let Some(started_at) = loading_spinner_started_at {
         let mut line = RenderSingleLineSpans::new(frame, layout[3]);

--- a/crates/but/src/command/legacy/status/tui/tests/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/mod.rs
@@ -29,6 +29,7 @@ mod marking_tests;
 mod move_tests;
 mod open_tests;
 mod pick_tests;
+mod single_branch_mode;
 mod squash_tests;
 mod stack_tests;
 mod utils;

--- a/crates/but/src/command/legacy/status/tui/tests/single_branch_mode.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/single_branch_mode.rs
@@ -1,0 +1,15 @@
+use but_testsupport::Sandbox;
+use snapbox::file;
+
+use crate::command::legacy::status::tui::tests::utils::test_status_tui;
+
+#[test]
+fn shows_single_branch_mode_label_in_hot_bar() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("single-branch-mode");
+
+    let mut tui = test_status_tui(env);
+
+    tui.reload().assert_rendered_term_svg_eq(file![
+        "snapshots/shows_single_branch_mode_label_in_hot_bar_001.svg"
+    ]);
+}

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/shows_single_branch_mode_label_in_hot_bar_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/shows_single_branch_mode_label_in_hot_bar_001.svg
@@ -1,0 +1,56 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="380" viewBox="0 0 820 380">
+  <rect x="0" y="0" width="820" height="380" fill="#000000" />
+  <rect x="10" y="10" width="800" height="18" fill="#45475A" />
+  <rect x="10" y="352" width="80" height="18" fill="#555555" />
+  <rect x="770" y="352" width="40" height="18" fill="#555555" />
+  <g font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">
+    <text x="10 18" y="24" style="fill:#FFFFFF;font-weight:bold;">╭┄</text>
+    <text x="34 42" y="24" style="fill:#0000AA;font-weight:bold;">zz</text>
+    <text x="58" y="24" style="fill:#FFFFFF;font-weight:bold;">[</text>
+    <text x="66 74 82 90 98 106 114 122 130 138 146" y="24" style="fill:#00AAAA;font-weight:bold;">uncommitted</text>
+    <text x="154" y="24" style="fill:#FFFFFF;font-weight:bold;">]</text>
+    <text x="170 178 186" y="24" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="202 210 218 226 234 242 250 258" y="24" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
+    <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
+    <text x="10 18 26" y="60" style="fill:#CCCCCC;">┊╭┄</text>
+    <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;">ma</text>
+    <text x="66" y="60" style="fill:#CCCCCC;">[</text>
+    <text x="74 82 90 98" y="60" style="fill:#00AA00;">main</text>
+    <text x="106" y="60" style="fill:#CCCCCC;">]</text>
+    <text x="122 130 138" y="60" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="154 162 170 178 186 194 202 210" y="60" style="fill:#CCCCCC;opacity:0.75;">commits)</text>
+    <text x="10 18" y="78" style="fill:#CCCCCC;">├╯</text>
+    <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
+    <text x="10" y="114" style="fill:#CCCCCC;">┴</text>
+    <text x="26 34 42 50 58 66 74" y="114" style="fill:#CCCCCC;opacity:0.75;">b1540e5</text>
+    <text x="90 98 106 114 122 130 138" y="114" style="fill:#CCCCCC;">(common</text>
+    <text x="154 162 170 178 186" y="114" style="fill:#CCCCCC;">base)</text>
+    <text x="202 210 218 226 234 242 250 258 266 274" y="114" style="fill:#CCCCCC;opacity:0.75;">2000-01-02</text>
+    <text x="290" y="114" style="fill:#CCCCCC;">M</text>
+    <text x="26 34 42 50 58 66" y="366" style="fill:#FFFFFF;">normal</text>
+    <text x="98 106 114" y="366" style="fill:#0000AA;">↑/k</text>
+    <text x="130 138" y="366" style="fill:#CCCCCC;opacity:0.75;">up</text>
+    <text x="154" y="366" style="fill:#CCCCCC;opacity:0.75;">•</text>
+    <text x="170 178 186" y="366" style="fill:#0000AA;">↓/j</text>
+    <text x="202 210 218 226" y="366" style="fill:#CCCCCC;opacity:0.75;">down</text>
+    <text x="242" y="366" style="fill:#CCCCCC;opacity:0.75;">•</text>
+    <text x="258" y="366" style="fill:#0000AA;">c</text>
+    <text x="274 282 290 298 306 314" y="366" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="330" y="366" style="fill:#CCCCCC;opacity:0.75;">•</text>
+    <text x="346" y="366" style="fill:#0000AA;">r</text>
+    <text x="362 370 378 386 394 402" y="366" style="fill:#CCCCCC;opacity:0.75;">squash</text>
+    <text x="418" y="366" style="fill:#CCCCCC;opacity:0.75;">•</text>
+    <text x="434" y="366" style="fill:#0000AA;">m</text>
+    <text x="450 458 466 474" y="366" style="fill:#CCCCCC;opacity:0.75;">move</text>
+    <text x="490" y="366" style="fill:#CCCCCC;opacity:0.75;">•</text>
+    <text x="506" y="366" style="fill:#0000AA;">b</text>
+    <text x="522 530 538 546 554 562" y="366" style="fill:#CCCCCC;opacity:0.75;">branch</text>
+    <text x="578" y="366" style="fill:#CCCCCC;opacity:0.75;">•</text>
+    <text x="594" y="366" style="fill:#0000AA;">?</text>
+    <text x="610 618 626 634" y="366" style="fill:#CCCCCC;opacity:0.75;">help</text>
+    <text x="650" y="366" style="fill:#CCCCCC;opacity:0.75;">•</text>
+    <text x="666" y="366" style="fill:#0000AA;">q</text>
+    <text x="682 690 698 706" y="366" style="fill:#CCCCCC;opacity:0.75;">quit</text>
+    <text x="778 786 794" y="366" style="fill:#CCCCCC;">SBM</text>
+  </g>
+</svg>

--- a/crates/but/src/command/legacy/status/tui/tests/utils.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/utils.rs
@@ -95,6 +95,10 @@ pub fn test_status_tui_with_options(mut env: Sandbox, options: TestTuiOptions) -
         StatusRenderMode::Tui(launch_options.clone()),
     )
     .expect("failed to build status context");
+
+    // App::new acquires a new guard so have to drop this before calling that
+    drop(guard);
+
     let initial_target = resolve_tui_target(
         &ctx.repo.get().unwrap(),
         &status_ctx.id_map,


### PR DESCRIPTION
I've found this useful while developing because its not clear from the status
itself if you're in SBM or not. When we actually roll out SBM this label can be
removed.