### PR TITLE
Finish the focus-scope rename in the css modules

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
@@ -166,7 +166,7 @@
 		}
 	}
 
-	[data-selection-focus-styles="true"] [data-selection-scope="diff"]:focus-within & {
+	[data-selection-focus-styles="true"] [data-focus-scope="diff"]:focus-within & {
 		--diffs-bg-selection-number-override: var(--fill-gray-bg);
 
 		diffs-container {
@@ -291,7 +291,7 @@
 		content: "";
 	}
 
-	[data-selection-focus-styles="true"] [data-selection-scope="diff"]:focus-within &::before {
+	[data-selection-focus-styles="true"] [data-focus-scope="diff"]:focus-within &::before {
 		background-color: var(--fill-gray-bg);
 	}
 }

--- a/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
@@ -53,7 +53,7 @@
 	}
 
 	&:has(:is(textarea, input):focus),
-	[data-selection-focus-styles="true"] [data-selection-scope]:focus & {
+	[data-selection-focus-styles="true"] [data-focus-scope]:focus & {
 		background-color: var(--fill-gray-bg);
 		color: var(--fill-gray-fg);
 	}
@@ -162,7 +162,7 @@
 	/* On the focused selection's solid fill, an unchecked box painted in --bg-1
 	   reads as a light chip punched out of the row. It takes the fill instead, so
 	   only its border marks it out. */
-	[data-selection-focus-styles="true"] [data-selection-scope]:focus .containerSelected &,
+	[data-selection-focus-styles="true"] [data-focus-scope]:focus .containerSelected &,
 	.containerSelected:has(:is(textarea, input):focus) & {
 		--checkbox-bg: var(--fill-gray-bg);
 	}
@@ -243,13 +243,13 @@
 .fadedText {
 	color: var(--text-2);
 
-	[data-selection-focus-styles="true"] [data-selection-scope]:focus .containerSelected & {
+	[data-selection-focus-styles="true"] [data-focus-scope]:focus .containerSelected & {
 		color: var(--text-2-invert);
 	}
 }
 
 .buttonGhost {
-	[data-selection-focus-styles="true"] [data-selection-scope]:focus .containerSelected &,
+	[data-selection-focus-styles="true"] [data-focus-scope]:focus .containerSelected &,
 	.containerSelected:has(:is(textarea, input):focus) & {
 		/* Duplicated styles for ghost-inverted button variant. This is necessary to
 		make the variant responsive to selection/focus changes purely with CSS. */
@@ -263,7 +263,7 @@
 }
 
 .buttonOutline {
-	[data-selection-focus-styles="true"] [data-selection-scope]:focus .containerSelected &,
+	[data-selection-focus-styles="true"] [data-focus-scope]:focus .containerSelected &,
 	.containerSelected:has(:is(textarea, input):focus) & {
 		/* Duplicated styles for outline-inverted button variant. This is necessary to
 		make the variant responsive to selection/focus changes purely with CSS. */
@@ -295,7 +295,7 @@
    state without cross-module class references. Raised for both states that give
    the row its solid inverted fill: a focused selection, and a row carrying an
    inline editor. */
-[data-selection-focus-styles="true"] [data-selection-scope]:focus .containerSelected,
+[data-selection-focus-styles="true"] [data-focus-scope]:focus .containerSelected,
 .containerSelected:has(:is(textarea, input):focus) {
 	--selection-inverted: true;
 }


### PR DESCRIPTION
A while back the focus machinery was renamed off the select stem (`data-selection-scope` -> `data-focus-scope`, 3ea0e473b9). That sweep caught the TSX setters and the JS readers, but not the CSS — so a handful of selectors kept matching an attribute nothing sets anymore, and the styles they gate quietly stopped applying.

- `Row.module.css`: the selected-row tinting that reacts to which list currently has focus was dead
- `Details.module.css`: the diff pane's focus-within styles too
- pure attribute rename in the selectors, no rule changes