### PR TITLE
Extract the endpoint table from electron main

### DIFF
--- a/apps/lite/electron/src/endpoint-table.ts
+++ b/apps/lite/electron/src/endpoint-table.ts
@@ -1,0 +1,108 @@
+import * as sdk from "@gitbutler/but-sdk";
+import { apiParamNames } from "@gitbutler/but-sdk/api-param-names";
+import { exposedEndpoints, type Endpoint, type LiteElectronApi, type PayloadFor } from "./ipc.js";
+
+/**
+ * Maps endpoint names to SDK calls. Handlers are generated from each call's
+ * argument names, so arguments cannot end up in the wrong order. Each host
+ * (electron main, the harness host) registers the table on its own channel
+ * and injects the few handlers only it can provide.
+ */
+
+/** Members the renderer implements itself; they have no host-side handler. */
+type RendererOnlyKey = "onAskpassPrompt" | "onFullScreenChange" | "platform";
+
+/** Handlers needing the transport event itself, or taking variadic arguments. */
+type ImperativeKey =
+	| "isFullScreen"
+	| "pathJoin"
+	| "showNativeMenu"
+	| "streamAiResponse"
+	| "watcherSubscribe"
+	// The preload wraps the id in an object, so the payload is not the argument.
+	| "watcherUnsubscribe";
+
+export type TableKey = Exclude<keyof LiteElectronApi, RendererOnlyKey | ImperativeKey>;
+
+/**
+ * Handler types are read off `LiteElectronApi`, so a payload or result that
+ * drifts from what the renderer expects is a compile error.
+ */
+export type Handler<K extends TableKey> = LiteElectronApi[K] extends (params: infer P) => infer R
+	? (params: P) => R | Awaited<R>
+	: never;
+
+export type HandlerOverrides = { [K in TableKey]?: Handler<K> };
+
+/** A table entry, callable with whatever a host's channel delivered. */
+type TableHandler = (params: unknown) => unknown;
+
+/**
+ * A derived handler pulls each argument out of the payload by name, so it
+ * cannot pass them in the wrong order. A hand-written call can, silently:
+ * `commitMoveChangesBetween` takes two commit ids that are both strings.
+ */
+const derivedHandler =
+	(key: Endpoint) =>
+	(params: unknown): unknown => {
+		const names: ReadonlyArray<string> = apiParamNames[key];
+		const call = sdk[key] as (...args: Array<unknown>) => unknown;
+		// A lone argument is sent as itself; the rest arrive as a payload.
+		return names.length === 1
+			? call(params)
+			: call(...names.map((name) => (params as Record<string, unknown>)[name]));
+	};
+
+type DerivedKey = Extract<TableKey, Endpoint>;
+
+/**
+ * Members only a host can answer. Hosts check their overrides against this
+ * type, so forgetting one is a compile error.
+ */
+export type HostOnlyKey = Exclude<TableKey, Endpoint>;
+
+type PayloadOf<K extends TableKey> = Parameters<LiteElectronApi[K]>[0];
+
+/**
+ * Compile-time check that every derived handler can supply its call's
+ * arguments: multi-argument calls need a payload carrying every name,
+ * single-argument calls take the payload itself. Anything else must be
+ * an override.
+ */
+type CannotSupplyItsArguments = {
+	[K in DerivedKey]: (typeof apiParamNames)[K]["length"] extends 0
+		? never
+		: (typeof apiParamNames)[K]["length"] extends 1
+			? PayloadOf<K> extends Parameters<(typeof sdk)[K]>[0]
+				? never
+				: K
+			: PayloadOf<K> extends PayloadFor<K>
+				? never
+				: K;
+}[DerivedKey];
+type AssertNever<T extends never> = T;
+type _EveryDerivedHandlerCanSupplyItsArguments = AssertNever<CannotSupplyItsArguments>;
+
+/**
+ * Builds the full table: a derived handler for every exposed endpoint not
+ * overridden, then the overrides. Overrides register even when nothing was
+ * derived for them — that is how host-only members get in.
+ */
+export const createEndpointTable = (
+	hostOverrides: HandlerOverrides,
+): ReadonlyArray<[string, TableHandler]> => {
+	const overrides: HandlerOverrides = hostOverrides;
+	const table: Array<[string, TableHandler]> = [];
+
+	for (const key of exposedEndpoints) {
+		if (key in overrides) continue;
+		table.push([key, derivedHandler(key)]);
+	}
+	// The one unchecked step, kept here so hosts can call the table directly:
+	// each override really does take its own payload type, and only the wire
+	// data a host passes can say whether that is what arrived.
+	for (const [name, handler] of Object.entries(overrides))
+		table.push([name, handler as TableHandler]);
+
+	return table;
+};

--- a/apps/lite/electron/src/main.ts
+++ b/apps/lite/electron/src/main.ts
@@ -1,17 +1,18 @@
 import { checkForUpdates, registerUpdater, setAutoUpdateEnabled } from "./updater.js";
 import WatcherManager from "./watcher.js";
 import * as sdk from "@gitbutler/but-sdk";
-import { apiParamNames } from "@gitbutler/but-sdk/api-param-names";
 import {
-	exposedEndpoints,
-	type PayloadFor,
-	type Endpoint,
-	type LiteElectronApi,
-	type ShowNativeMenuParams,
-	type StreamAiResponseParams,
-	type WatcherSubscribeParams,
-	type WatcherUnsubscribeParams,
-	type NativeMenuPopupItem,
+	createEndpointTable,
+	type Handler,
+	type HandlerOverrides,
+	type HostOnlyKey,
+} from "./endpoint-table.js";
+import type {
+	ShowNativeMenuParams,
+	StreamAiResponseParams,
+	WatcherSubscribeParams,
+	WatcherUnsubscribeParams,
+	NativeMenuPopupItem,
 } from "./ipc.js";
 import {
 	askpassInit,
@@ -255,35 +256,11 @@ const newUrlOrNull = (url: string): URL | null => {
 	}
 };
 
-/** Members the renderer implements itself; they have no main-side handler. */
-type RendererOnlyKey = "onAskpassPrompt" | "onFullScreenChange" | "platform";
-
-/** Handlers needing the IPC event itself, or taking variadic arguments. */
-type ImperativeKey =
-	| "isFullScreen"
-	| "pathJoin"
-	| "showNativeMenu"
-	| "streamAiResponse"
-	| "watcherSubscribe"
-	// The preload wraps the id in an object, so the payload is not the argument.
-	| "watcherUnsubscribe";
-
-type TableKey = Exclude<keyof LiteElectronApi, RendererOnlyKey | ImperativeKey>;
-
 /**
- * A handler takes what the renderer sends and returns what it expects, both
- * read off `LiteElectronApi`, so a payload or result that drifts from the
- * renderer's view is a compile error.
+ * Members only electron main can answer: its own capabilities, injected into
+ * the endpoint table. `HostOnlyKey` makes forgetting one a compile error.
  */
-type Handler<K extends TableKey> = LiteElectronApi[K] extends (params: infer P) => infer R
-	? (params: P) => R | Awaited<R>
-	: never;
-
-/**
- * Members the main process answers itself: electron's own capabilities.
- * Listing one here is what takes it out of the derived set.
- */
-const ipcHandlerOverrides = {
+const electronHandlerOverrides = {
 	askpassSubmitPromptResponse: ({ id, response }) => askpassSubmitPromptResponse(id, response),
 	clipboardWriteText: (text) => {
 		clipboard.writeText(text, "clipboard");
@@ -315,51 +292,7 @@ const ipcHandlerOverrides = {
 		applyGUISettings(settings);
 		await writeSettings(settings);
 	},
-} satisfies { [K in TableKey]?: Handler<K> };
-
-type OverrideKey = keyof typeof ipcHandlerOverrides;
-type DerivedKey = Exclude<TableKey, OverrideKey>;
-
-/** Narrowing rather than asserting: an exposed endpoint may be either. */
-const isOverride = (key: Endpoint): key is Endpoint & OverrideKey => key in ipcHandlerOverrides;
-
-/**
- * Every other endpoint reads its arguments out of the payload by name, so
- * it cannot pass them in the wrong order — which a hand-written call can,
- * silently: `commitMoveChangesBetween` takes source and destination commit
- * ids that are both strings.
- */
-const derivedHandler =
-	(key: DerivedKey) =>
-	(params: unknown): unknown => {
-		const names: ReadonlyArray<string> = apiParamNames[key];
-		const call = sdk[key] as (...args: Array<unknown>) => unknown;
-		// A lone argument is sent as itself; the rest arrive as a payload.
-		return names.length === 1
-			? call(params)
-			: call(...names.map((name) => (params as Record<string, unknown>)[name]));
-	};
-
-type PayloadOf<K extends TableKey> = Parameters<LiteElectronApi[K]>[0];
-
-/**
- * A derived handler can only supply arguments its payload carries, so the
- * multi-argument ones must carry every name and the single-argument ones
- * must be the argument. Anything else has to be an override.
- */
-type CannotSupplyItsArguments = {
-	[K in DerivedKey]: (typeof apiParamNames)[K]["length"] extends 0
-		? never
-		: (typeof apiParamNames)[K]["length"] extends 1
-			? PayloadOf<K> extends Parameters<(typeof sdk)[K]>[0]
-				? never
-				: K
-			: PayloadOf<K> extends PayloadFor<K>
-				? never
-				: K;
-}[DerivedKey];
-type AssertNever<T extends never> = T;
-type _EveryDerivedHandlerCanSupplyItsArguments = AssertNever<CannotSupplyItsArguments>;
+} satisfies HandlerOverrides & { [K in HostOnlyKey]: Handler<K> };
 
 const registerIpcHandlers = (): void => {
 	const senderValidatingHandle: typeof ipcMain.handle = (channel, listener) => {
@@ -382,14 +315,8 @@ const registerIpcHandlers = (): void => {
 		ipcMain.handle(channel, senderValidatingListener);
 	};
 
-	for (const key of exposedEndpoints) {
-		if (isOverride(key)) continue;
-		senderValidatingHandle(key, (_e, params: unknown) => derivedHandler(key)(params));
-	}
-	for (const [name, handler] of Object.entries(ipcHandlerOverrides)) {
-		const call = handler as (params: unknown) => unknown;
-		senderValidatingHandle(name, (_e, params: unknown) => call(params));
-	}
+	for (const [name, handler] of createEndpointTable(electronHandlerOverrides))
+		senderValidatingHandle(name, (_e, params: unknown) => handler(params));
 	senderValidatingHandle("watcherUnsubscribe", (_e, { subscriptionId }: WatcherUnsubscribeParams) =>
 		WatcherManager.getInstance().removeSubscription(subscriptionId),
 	);


### PR DESCRIPTION
electron main wired every API endpoint to its SDK call by hand. That mapping now lives in one place, `endpoint-table.ts`, and main just registers the finished table on ipcMain.

- handlers are generated from each SDK call's argument names, so a call cannot pass its arguments in the wrong order (easy to do silently when they are all strings)
- handler payload and result types are read off `LiteElectronApi`, so drifting from what the renderer expects is a compile error
- members only electron can answer (dialogs, clipboard, settings...) are injected as overrides, and `HostOnlyKey` makes forgetting one a compile error
- this also lets another host register the same table on its own channel, which is where the plugin work is headed