### PR TITLE
Extract createLiteApi from the preload

### DIFF
--- a/apps/lite/electron/src/lite-api.ts
+++ b/apps/lite/electron/src/lite-api.ts
@@ -1,0 +1,128 @@
+import type { AskpassPromptEvent, WatcherEvent } from "@gitbutler/but-sdk";
+import { exposedEndpoints, localEndpoints } from "./ipc.js";
+import type { LiteElectronApi, StreamAiResponseToken, WatcherSubscribeResult } from "./ipc.js";
+
+/**
+ * What a host must provide to build the renderer's api: one request/response
+ * function, one event channel, and the platform it runs on. Electron backs
+ * these with the preload's ipcRenderer; other hosts with their own channel.
+ */
+type LiteApiTransport = {
+	/** Send one request and await its result. */
+	invoke: (channel: string, ...args: Array<unknown>) => Promise<unknown>;
+	/** Hear every event on a named channel until the returned function runs. */
+	subscribe: (channel: string, listener: (payload: unknown) => void) => () => void;
+	platform: LiteElectronApi["platform"];
+};
+
+/** API members implemented below rather than forwarded. */
+type SpecialKey =
+	| "onAskpassPrompt"
+	| "onFullScreenChange"
+	| "platform"
+	| "streamAiResponse"
+	| "watcherSubscribe"
+	| "watcherUnsubscribe"
+	| "watcherStopAll";
+
+/** The same members under their endpoint names; `platform` has no channel at all. */
+const specialNames = [
+	"askpassPrompt",
+	"fullScreenChange",
+	"streamAiResponse",
+	"watcherSubscribe",
+	"watcherUnsubscribe",
+	"watcherStopAll",
+] as const;
+
+type SpecialName = (typeof specialNames)[number];
+type ForwardedKey = Exclude<keyof LiteElectronApi, SpecialKey>;
+type ListedKey = Exclude<
+	(typeof exposedEndpoints)[number] | (typeof localEndpoints)[number],
+	SpecialName
+>;
+
+/**
+ * A member missing from the endpoint lists, or listed without a member, is
+ * a compile error here rather than a runtime "No handler registered".
+ */
+type AssertNever<T extends never> = T;
+type _EveryMemberIsListed = AssertNever<Exclude<ForwardedKey, ListedKey>>;
+type _EveryListedNameHasAMember = AssertNever<Exclude<ListedKey, ForwardedKey>>;
+
+const special = new Set<string>(specialNames);
+
+/**
+ * Builds the renderer's whole api over a transport. Forwarded members are
+ * generated from the endpoint lists — each sends its arguments to the
+ * channel of the same name — so a partial api cannot be built. The cast is
+ * sound because every call site is typed through `LiteElectronApi`.
+ */
+export const createLiteApi = ({
+	invoke,
+	subscribe,
+	platform,
+}: LiteApiTransport): LiteElectronApi => {
+	/** Unsubscribers per watcher subscription; the UI knows ids, not channels. */
+	const watcherUnsubscribeBySubscription = new Map<string, () => void>();
+
+	const forwarders = Object.fromEntries(
+		[...exposedEndpoints, ...localEndpoints]
+			.filter((name) => !special.has(name))
+			.map((name) => [name, (...args: Array<unknown>) => invoke(name, ...args)]),
+	) as Omit<LiteElectronApi, SpecialKey>;
+
+	return {
+		...forwarders,
+		onAskpassPrompt: (callback) =>
+			subscribe("askpassPrompt", (payload) => {
+				callback(payload as AskpassPromptEvent);
+			}),
+		onFullScreenChange: (callback) =>
+			subscribe("fullScreenChange", (payload) => {
+				callback(payload as boolean);
+			}),
+		streamAiResponse: async (systemMessage, prompt, onToken) => {
+			const requestId = crypto.randomUUID();
+			const unsubscribe = subscribe("streamAiResponseToken", (payload) => {
+				const token = payload as StreamAiResponseToken;
+				if (token.requestId === requestId) onToken(token.token);
+			});
+			try {
+				return (await invoke("streamAiResponse", { requestId, systemMessage, prompt })) as string;
+			} finally {
+				unsubscribe();
+			}
+		},
+		/**
+		 * Listen to backend events for a project. The host keeps one watcher
+		 * per project no matter how many subscriptions exist, but does not
+		 * deduplicate subscriptions — subscribing once and unsubscribing is
+		 * the UI's job. Returns an id for `watcherUnsubscribe`.
+		 */
+		watcherSubscribe: async (projectId, callback) => {
+			const { subscriptionId, eventChannel } = (await invoke("watcherSubscribe", {
+				projectId,
+			})) as WatcherSubscribeResult;
+			const unsubscribe = subscribe(eventChannel, (payload) => {
+				callback(payload as WatcherEvent);
+			});
+			watcherUnsubscribeBySubscription.set(subscriptionId, unsubscribe);
+			return subscriptionId;
+		},
+		/** Stop listening; the project's watcher stops with its last subscription. */
+		watcherUnsubscribe: async (subscriptionId) => {
+			watcherUnsubscribeBySubscription.get(subscriptionId)?.();
+			watcherUnsubscribeBySubscription.delete(subscriptionId);
+			return invoke("watcherUnsubscribe", { subscriptionId }) as Promise<boolean>;
+		},
+		/** Drop every subscription and stop every watcher. */
+		watcherStopAll: async () => {
+			for (const unsubscribe of watcherUnsubscribeBySubscription.values()) unsubscribe();
+
+			watcherUnsubscribeBySubscription.clear();
+			return invoke("watcherStopAll") as Promise<number>;
+		},
+		platform,
+	};
+};

--- a/apps/lite/electron/src/preload.cts
+++ b/apps/lite/electron/src/preload.cts
@@ -1,164 +1,23 @@
 import { contextBridge, ipcRenderer } from "electron";
-import { exposedEndpoints, localEndpoints } from "./ipc.js";
-import type { LiteElectronApi, WatcherSubscribeResult } from "./ipc";
-import type { AskpassPromptEvent, WatcherEvent } from "@gitbutler/but-sdk";
-import type { StreamAiResponseToken } from "./ipc";
+import { createLiteApi } from "./lite-api.js";
 
 /**
- * The map of subscription IDs to channels and callbacks.
- *
- * This is needed in order to maintain separate changes for each subscription.
- * The subscription ID is known to the UI, but the channel is not.
+ * The electron binding of the renderer's api: `createLiteApi` builds the
+ * whole surface; this file only supplies the transport it runs over.
  */
-const watcherListenerBySubscription = new Map<
-	string,
-	{
-		eventChannel: string;
-		listener: (_event: Electron.IpcRendererEvent, payload: WatcherEvent) => void;
-	}
->();
-
-/** API members implemented below rather than forwarded. */
-type SpecialKey =
-	| "onAskpassPrompt"
-	| "onFullScreenChange"
-	| "platform"
-	| "streamAiResponse"
-	| "watcherSubscribe"
-	| "watcherUnsubscribe"
-	| "watcherStopAll";
-
-/** The same members under their endpoint names; `platform` has no channel at all. */
-const specialNames = [
-	"askpassPrompt",
-	"fullScreenChange",
-	"streamAiResponse",
-	"watcherSubscribe",
-	"watcherUnsubscribe",
-	"watcherStopAll",
-] as const;
-
-type SpecialName = (typeof specialNames)[number];
-type ForwardedKey = Exclude<keyof LiteElectronApi, SpecialKey>;
-type ListedKey = Exclude<
-	(typeof exposedEndpoints)[number] | (typeof localEndpoints)[number],
-	SpecialName
->;
-
-/**
- * Wiring a member on only one side fails here: both aliases must resolve to
- * `never`, so a member missing from the lists, or listed without a member,
- * is a compile error rather than a runtime "No handler registered".
- */
-type AssertNever<T extends never> = T;
-type _EveryMemberIsListed = AssertNever<Exclude<ForwardedKey, ListedKey>>;
-type _EveryListedNameHasAMember = AssertNever<Exclude<ListedKey, ForwardedKey>>;
-
-const special = new Set<string>(specialNames);
-
-/**
- * electron declares `invoke` as `Promise<any>`, which spreads unchecked into
- * every caller. Narrowing it to `unknown` — by annotation, not assertion —
- * makes each wire result something a reader has to pin down.
- */
-const invoke = (channel: string, ...args: Array<unknown>): Promise<unknown> =>
-	ipcRenderer.invoke(channel, ...args);
-
-/**
- * Every forwarded member hands its arguments to the channel of the same
- * name, so they are generated from the lists rather than written out. The
- * cast is sound because arguments and results are typed at every call site
- * through `LiteElectronApi`.
- */
-const forwarders = Object.fromEntries(
-	[...exposedEndpoints, ...localEndpoints]
-		.filter((name) => !special.has(name))
-		.map((name) => [name, (...args: Array<unknown>) => invoke(name, ...args)]),
-) as Omit<LiteElectronApi, SpecialKey>;
-
-const api: LiteElectronApi = {
-	...forwarders,
-	onAskpassPrompt: (callback) => {
-		const listener = (_event: Electron.IpcRendererEvent, payload: AskpassPromptEvent) => {
-			callback(payload);
+const api = createLiteApi({
+	// electron types `invoke` as `Promise<any>`; the annotation narrows it
+	// to `unknown` so wire results are not silently `any` everywhere.
+	invoke: (channel: string, ...args: Array<unknown>): Promise<unknown> =>
+		ipcRenderer.invoke(channel, ...args),
+	subscribe: (channel, listener) => {
+		const ipcListener = (_event: Electron.IpcRendererEvent, payload: unknown) => {
+			listener(payload);
 		};
-		ipcRenderer.on("askpassPrompt", listener);
-		return () => ipcRenderer.removeListener("askpassPrompt", listener);
-	},
-	onFullScreenChange: (callback) => {
-		const listener = (_event: Electron.IpcRendererEvent, fullScreen: boolean) => {
-			callback(fullScreen);
-		};
-		ipcRenderer.on("fullScreenChange", listener);
-		return () => ipcRenderer.removeListener("fullScreenChange", listener);
-	},
-	streamAiResponse: async (systemMessage, prompt, onToken) => {
-		const requestId = crypto.randomUUID();
-		const listener = (_event: Electron.IpcRendererEvent, payload: StreamAiResponseToken) => {
-			if (payload.requestId === requestId) onToken(payload.token);
-		};
-		ipcRenderer.on("streamAiResponseToken", listener);
-		try {
-			return (await invoke("streamAiResponse", { requestId, systemMessage, prompt })) as string;
-		} finally {
-			ipcRenderer.removeListener("streamAiResponseToken", listener);
-		}
-	},
-	/**
-	 * Subscribe to a project.
-	 *
-	 * This sets up a listener to project updates from the Rust-end.
-	 *
-	 * **Usage**
-	 * It's expected that one window has max one subscription per project, although it is possible to have multiple.
-	 * The node-end of the application will deduplicate project watchers (there will only ever be one watcher) but
-	 * there is no deduplication in terms of project subscriptions.
-	 *
-	 * The responsability of subscribing once and correctly unsubscribing to a project is shifted to the UI.
-	 *
-	 * @param projectId - The ID of the project to subscribe to.
-	 * @param callback - The callback function to pass the event information to.
-	 * @returns A subscription ID.
-	 */
-	watcherSubscribe: async (projectId, callback) => {
-		const { subscriptionId, eventChannel } = (await invoke("watcherSubscribe", {
-			projectId,
-		})) as WatcherSubscribeResult;
-		const listener = (_event: Electron.IpcRendererEvent, payload: WatcherEvent) => {
-			callback(payload);
-		};
-		watcherListenerBySubscription.set(subscriptionId, { eventChannel, listener });
-		ipcRenderer.on(eventChannel, listener);
-		return subscriptionId;
-	},
-	/**
-	 * Stop watching a project.
-	 *
-	 * Remove the listener for a given subscription channel.
-	 * If this is the last subscription to a project, the watcher will stop.
-	 * @param subscriptionId
-	 */
-	watcherUnsubscribe: async (subscriptionId) => {
-		const registration = watcherListenerBySubscription.get(subscriptionId);
-		if (registration) {
-			ipcRenderer.removeListener(registration.eventChannel, registration.listener);
-			watcherListenerBySubscription.delete(subscriptionId);
-		}
-		return invoke("watcherUnsubscribe", { subscriptionId }) as Promise<boolean>;
-	},
-	/**
-	 * Stop all watchers.
-	 *
-	 * Remove all subscription listners and stop all watchers.
-	 */
-	watcherStopAll: async () => {
-		for (const { eventChannel, listener } of watcherListenerBySubscription.values())
-			ipcRenderer.removeListener(eventChannel, listener);
-
-		watcherListenerBySubscription.clear();
-		return invoke("watcherStopAll") as Promise<number>;
+		ipcRenderer.on(channel, ipcListener);
+		return () => ipcRenderer.removeListener(channel, ipcListener);
 	},
 	platform: process.platform,
-};
+});
 
 contextBridge.exposeInMainWorld("lite", api);


### PR DESCRIPTION
The preload built `window.lite` by hand, one member at a time. Building the api now lives in `lite-api.ts`; the preload only supplies the transport it runs over.

- `createLiteApi(transport)` builds the whole surface from the endpoint lists: each forwarded member sends its arguments to the channel of the same name, so a partial api cannot be built
- the transport is three things: `invoke`, `subscribe`, and the platform. electron backs them with ipcRenderer; another host can back them with its own channel
- a member missing from the lists, or listed without a member, is a compile error instead of a runtime "No handler registered"
- the preload shrinks to a couple dozen lines of electron-specific binding