### PR TITLE
Merge the workspace-list contexts behind a provider and hooks

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/AddressSpaceContext.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/AddressSpaceContext.ts
@@ -1,6 +1,0 @@
-import type { Address } from "#ui/addresses.ts";
-import type { AddressSpace } from "#ui/workspace/address-space.ts";
-import { createContext } from "react";
-
-export const AddressSpaceContext = createContext<AddressSpace<Address> | null>(null);
-AddressSpaceContext.displayName = "AddressSpaceContext";

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/CommitRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/CommitRow.tsx
@@ -1,4 +1,5 @@
 import rowStyles from "../Row.module.css";
+import { useAddressSpace } from "./context.tsx";
 import { startKeyboardTransfer, setCursor, startInlineEdit } from "#ui/use-cursor.ts";
 import {
 	useBranchCreate,
@@ -13,7 +14,6 @@ import { ConflictIcon } from "#ui/components/ConflictIcon.tsx";
 import { GraphSegment } from "#ui/components/GraphSegment.tsx";
 import { Icon } from "#ui/components/Icon.tsx";
 import { TooltipPopup } from "#ui/components/Tooltip.tsx";
-import { assert } from "#ui/assert.ts";
 import { commitBody, commitForgeUrl, commitIsDiverged, commitTitle } from "#ui/commit.ts";
 import { errorMessageForToast } from "#ui/errors.ts";
 import {
@@ -36,10 +36,9 @@ import { useAppDispatch, useAppSelector, useAppStore } from "#ui/store.ts";
 import type { Commit } from "@gitbutler/but-sdk";
 import { Toast, Toolbar, Tooltip } from "@base-ui/react";
 import { useQuery } from "@tanstack/react-query";
-import { type ComponentProps, type FC, use, useOptimistic, useTransition } from "react";
+import { type ComponentProps, type FC, useOptimistic, useTransition } from "react";
 import { RowCheckbox, RowLabel, RowLabelContainer, RowToolbar } from "../Row.tsx";
 import { getRowButtonClassName } from "../Row-utils.ts";
-import { AddressSpaceContext } from "../AddressSpaceContext.ts";
 import { InlineEditor } from "./InlineEditor.tsx";
 import { insertBlankCommitMenuItem } from "./insertBlankCommitMenuItem.ts";
 import { ItemRow } from "./ItemRow.tsx";
@@ -85,7 +84,7 @@ export const CommitRow: FC<
 
 	const dispatch = useAppDispatch();
 	const store = useAppStore();
-	const addressSpace = assert(use(AddressSpaceContext));
+	const addressSpace = useAddressSpace();
 	const noOperationPending = useAppSelector(
 		(state) => projectSlice.selectors.selectPendingOperation(state, projectId)._tag === "None",
 	);

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/ItemRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/ItemRow.tsx
@@ -1,17 +1,16 @@
-import { AddressSpaceContext } from "../AddressSpaceContext.ts";
 import { setCursor, useIsCursorAt } from "#ui/use-cursor.ts";
 import { Row } from "../Row.tsx";
+import { useAddressSpace } from "./context.tsx";
 import { addressIdentityKey, type Address } from "#ui/addresses.ts";
 import { addressSpaceIncludes } from "#ui/workspace/address-space.ts";
-import { type ComponentProps, type FC, use } from "react";
-import { assert } from "#ui/assert.ts";
+import type { ComponentProps, FC } from "react";
 
 export const ItemRow: FC<
 	{
 		address: Address;
 	} & Omit<ComponentProps<typeof Row>, "inert" | "isSelected" | "onSelect">
 > = ({ address, ...props }) => {
-	const addressSpace = assert(use(AddressSpaceContext));
+	const addressSpace = useAddressSpace();
 	const isSelected = useIsCursorAt("applied", addressSpace, address);
 	const selectItem = () => {
 		setCursor("applied", address);

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.tsx
@@ -29,7 +29,6 @@ import {
 	type OperationTargetOutline,
 } from "#ui/routes/project/$id/workspace/OperationTarget.tsx";
 import { useOperationDropTarget } from "#ui/routes/project/$id/workspace/useOperationDropTarget.ts";
-import { AddressSpaceContext } from "#ui/routes/project/$id/workspace/AddressSpaceContext.ts";
 import { useAppDispatch, useAppSelector, useAppStore } from "#ui/store.ts";
 import { classes } from "#ui/components/classes.ts";
 import { addressSpaceIncludes, type AddressSpace } from "#ui/workspace/address-space.ts";
@@ -63,6 +62,11 @@ import { Row, RowLabel, RowLabelContainer, SectionHeaderRow } from "../Row.tsx";
 import { StackCard } from "../StackCard.tsx";
 import stackCardStyles from "../StackCard.module.css";
 import { treeItemId } from "../Row-utils.ts";
+import {
+	useAbsorptionTargetCommitIds,
+	useAddressSpace,
+	WorkspaceListsProvider,
+} from "./context.tsx";
 import { getOperation, type Placement, useDryRunOperation } from "#ui/operations/operation.ts";
 import { createDiffSpec } from "#ui/operations/diff-specs.ts";
 import { GraphSegment, type GraphSegmentStatus } from "#ui/components/GraphSegment.tsx";
@@ -98,9 +102,6 @@ import {
 const DryRunWorkspaceContext = createContext<WorkspaceState | null>(null);
 DryRunWorkspaceContext.displayName = "DryRunWorkspaceContext";
 
-const AbsorptionTargetCommitIdsContext = createContext<ReadonlySet<string> | null>(null);
-AbsorptionTargetCommitIdsContext.displayName = "AbsorptionTargetCommitIdsContext";
-
 // This must be unique as to not collide with other IDs, and stable because it's
 // stored in local storage.
 type PanelId = "uncommitted-changes-panel" | "stacks-panel";
@@ -110,7 +111,7 @@ const TreeItem: FC<
 		address: Address;
 	} & useRender.ComponentProps<"div">
 > = ({ address, render, ...props }) => {
-	const addressSpace = assert(use(AddressSpaceContext));
+	const addressSpace = useAddressSpace();
 	const isSelected = useIsCursorAt("applied", addressSpace, address);
 
 	return useRender({
@@ -134,8 +135,8 @@ const OperationTarget: FC<
 > = ({ enabled, address, projectId, outline, render, ...props }) => {
 	const dropRef = useOperationDropTarget({ enabled, target: address, projectId });
 
-	const absorptionTargetCommitIds = assert(use(AbsorptionTargetCommitIdsContext));
-	const addressSpace = assert(use(AddressSpaceContext));
+	const absorptionTargetCommitIds = useAbsorptionTargetCommitIds();
+	const addressSpace = useAddressSpace();
 
 	type ActiveOperation = { placement: Placement; tooltip?: string | undefined };
 	const selection = useSelection("applied", addressSpace);
@@ -213,7 +214,7 @@ const AddressC: FC<
 		outline: OperationTargetOutline;
 	} & useRender.ComponentProps<"div">
 > = ({ projectId, address, outline, render, ...props }) => {
-	const addressSpace = assert(use(AddressSpaceContext));
+	const addressSpace = useAddressSpace();
 
 	return useRender({
 		render: (
@@ -439,7 +440,7 @@ const BranchSegment: FC<{
 const EmptySegmentContent: FC<{
 	segment: Segment;
 }> = ({ segment }) => {
-	const addressSpace = assert(use(AddressSpaceContext));
+	const addressSpace = useAddressSpace();
 
 	const refName = assert(segment.refName);
 	const inert = !addressSpaceIncludes(
@@ -544,7 +545,7 @@ const SegmentRailConnector: FC<{
 	projectId: string;
 	segment: Segment;
 }> = ({ projectId, segment }) => {
-	const addressSpace = assert(use(AddressSpaceContext));
+	const addressSpace = useAddressSpace();
 
 	// A plain boolean, so this re-renders only when this segment's own fold
 	// state changes rather than on every fold anywhere.
@@ -662,7 +663,7 @@ const Stacks: FC<{
 	canAmendCommit: boolean;
 	onEdgeSpill: (offset: -1 | 1) => void;
 }> = ({ projectId, checkCommit, onAmendCommit, canAmendCommit, onEdgeSpill }) => {
-	const addressSpace = assert(use(AddressSpaceContext));
+	const addressSpace = useAddressSpace();
 	const { data: headInfo } = useQuery(headInfoQueryOptions(projectId));
 	const selection = useSelection("applied", addressSpace);
 	const activeList = useActiveList();
@@ -870,74 +871,75 @@ export const WorkspaceLists: FC<
 	};
 
 	return (
-		<AddressSpaceContext value={addressSpace}>
-			<AbsorptionTargetCommitIdsContext value={absorptionTargetCommitIds}>
-				<Group
-					{...props}
-					id={layoutId}
-					orientation="vertical"
-					className={classes(props.className, styles.tree)}
-					defaultLayout={sidebarLayout.defaultLayout}
-					onLayoutChanged={sidebarLayout.onLayoutChanged}
+		<WorkspaceListsProvider
+			addressSpace={addressSpace}
+			absorptionTargetCommitIds={absorptionTargetCommitIds}
+		>
+			<Group
+				{...props}
+				id={layoutId}
+				orientation="vertical"
+				className={classes(props.className, styles.tree)}
+				defaultLayout={sidebarLayout.defaultLayout}
+				onLayoutChanged={sidebarLayout.onLayoutChanged}
+			>
+				<Panel
+					id={"uncommitted-changes-panel" satisfies PanelId}
+					className={styles.uncommittedChangesOuterPanel}
+					defaultSize={280}
+					minSize={200}
+					groupResizeBehavior="preserve-pixel-size"
 				>
-					<Panel
-						id={"uncommitted-changes-panel" satisfies PanelId}
-						className={styles.uncommittedChangesOuterPanel}
-						defaultSize={280}
-						minSize={200}
-						groupResizeBehavior="preserve-pixel-size"
-					>
-						<OperationSourceC
-							projectId={projectId}
-							source={uncommittedChangesAddress}
-							outline="inside"
-							render={
-								<OperationTarget
-									enabled
-									projectId={projectId}
-									address={uncommittedChangesAddress}
-									outline="inside"
-									render={
-										<UncommittedChanges
-											addressSpace={uncommittedAddressSpace}
-											commitTarget={commitTarget}
-											projectId={projectId}
-											targetComboboxItems={commitTargetComboboxItems}
-											hasNoBranches={hasNoBranches}
-											onAmendCommit={amendCommit}
-											canAmendCommit={canAmendCommit}
-											onActiveFileSelection={onActiveFileSelection}
-											onEdgeSpill={spillIntoStacks}
-											worktreeChanges={worktreeChanges}
-										/>
-									}
-								/>
-							}
-						/>
-					</Panel>
-
-					<ResizeHandle />
-
-					<Panel id={"stacks-panel" satisfies PanelId} className={styles.stacksPanel} minSize={120}>
-						<SectionHeaderRow
-							label="Stacks and branches"
-							childrenBefore={<FocusScopeKbd hotkey="2" scope="sidebar" />}
-							className={styles.stacksHeader}
-							actions={stacksHeaderActions}
-						/>
-
-						<div className={classes(uiStyles.scroller, styles.stacksScroller)}>
-							<Stacks
+					<OperationSourceC
+						projectId={projectId}
+						source={uncommittedChangesAddress}
+						outline="inside"
+						render={
+							<OperationTarget
+								enabled
 								projectId={projectId}
-								checkCommit={checkCommit}
-								onAmendCommit={amendCommit}
-								canAmendCommit={canAmendCommit}
-								onEdgeSpill={spillIntoUncommittedChanges}
+								address={uncommittedChangesAddress}
+								outline="inside"
+								render={
+									<UncommittedChanges
+										addressSpace={uncommittedAddressSpace}
+										commitTarget={commitTarget}
+										projectId={projectId}
+										targetComboboxItems={commitTargetComboboxItems}
+										hasNoBranches={hasNoBranches}
+										onAmendCommit={amendCommit}
+										canAmendCommit={canAmendCommit}
+										onActiveFileSelection={onActiveFileSelection}
+										onEdgeSpill={spillIntoStacks}
+										worktreeChanges={worktreeChanges}
+									/>
+								}
 							/>
-						</div>
-					</Panel>
-				</Group>
-			</AbsorptionTargetCommitIdsContext>
-		</AddressSpaceContext>
+						}
+					/>
+				</Panel>
+
+				<ResizeHandle />
+
+				<Panel id={"stacks-panel" satisfies PanelId} className={styles.stacksPanel} minSize={120}>
+					<SectionHeaderRow
+						label="Stacks and branches"
+						childrenBefore={<FocusScopeKbd hotkey="2" scope="sidebar" />}
+						className={styles.stacksHeader}
+						actions={stacksHeaderActions}
+					/>
+
+					<div className={classes(uiStyles.scroller, styles.stacksScroller)}>
+						<Stacks
+							projectId={projectId}
+							checkCommit={checkCommit}
+							onAmendCommit={amendCommit}
+							canAmendCommit={canAmendCommit}
+							onEdgeSpill={spillIntoUncommittedChanges}
+						/>
+					</div>
+				</Panel>
+			</Group>
+		</WorkspaceListsProvider>
 	);
 };

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/context.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/context.tsx
@@ -1,0 +1,31 @@
+// oxlint-disable react/only-export-components -- The context module exports its provider and hooks together by design.
+import { assert } from "#ui/assert.ts";
+import type { Address } from "#ui/addresses.ts";
+import type { AddressSpace } from "#ui/workspace/address-space.ts";
+import { createContext, use, type FC, type ReactNode } from "react";
+
+/**
+ * Shared with every row: the address space rows resolve against, and the
+ * commits the pending absorption would land in. One context because the two
+ * change together and their consumers overlap. Only the hooks below read
+ * it, and they assert the provider, so the `null` default never reaches a
+ * consumer.
+ */
+type WorkspaceListsContext = {
+	addressSpace: AddressSpace<Address>;
+	absorptionTargetCommitIds: ReadonlySet<string>;
+};
+
+const Context = createContext<WorkspaceListsContext | null>(null);
+Context.displayName = "WorkspaceListsContext";
+
+export const WorkspaceListsProvider: FC<WorkspaceListsContext & { children: ReactNode }> = ({
+	addressSpace,
+	absorptionTargetCommitIds,
+	children,
+}) => <Context value={{ addressSpace, absorptionTargetCommitIds }}>{children}</Context>;
+
+export const useAddressSpace = (): AddressSpace<Address> => assert(use(Context)).addressSpace;
+
+export const useAbsorptionTargetCommitIds = (): ReadonlySet<string> =>
+	assert(use(Context)).absorptionTargetCommitIds;


### PR DESCRIPTION
The workspace lists had two React contexts sitting next to each other: one for the address space rows resolve against, one for the commits a pending absorption would land in. They were provided on adjacent lines, consumed by overlapping components, and both needed `assert(use(...))` at every call site.

They are now one context, and the `createContext` itself is module-private.

- consumers get `useAddressSpace()` and `useAbsorptionTargetCommitIds()` instead of a context object, so the `| null` default and the assert stop leaking to nine call sites
- merging costs no extra re-renders: the two values change together, once per render of the lists
- `AddressSpaceContext.ts` is deleted; the absorption context was already file-local and dissolves into the merge

No behavior change.