### PR TITLE
But graph worktree placement

### DIFF
--- a/crates/but-ctx/tests/ctx/main.rs
+++ b/crates/but-ctx/tests/ctx/main.rs
@@ -847,14 +847,17 @@ fn workspace_from_head_seeds_active_worktree_tips() -> anyhow::Result<()> {
             "the graph preserves the stable name of each active worktree"
         );
     }
+    // The worktree branch never owns its commit: it is an empty segment
+    // forking onto the anonymous commit-owning segment below.
     snapbox::assert_data_eq!(
         workspace_graph(&ctx)?,
         snapbox::str![[r#"
 
-└── ►:1[0]:feat-b[📁wt-b]
-    └── ·7d7d38f (⌂)
-        └── 👉►:0[1]:main[🌳@repo]
-            └── 🏁·85efbe4 (⌂|1)
+└── ►:2[0]:feat-b[📁wt-b]
+    └── ►:1[1]:anon:
+        └── ·7d7d38f (⌂)
+            └── 👉►:0[2]:main[🌳@repo]
+                └── 🏁·85efbe4 (⌂|1)
 
 "#]]
     );

--- a/crates/but-graph/src/init/post.rs
+++ b/crates/but-graph/src/init/post.rs
@@ -11,7 +11,8 @@ use petgraph::{Direction, graph::NodeIndex, prelude::EdgeRef, visit::NodeRef};
 use tracing::instrument;
 
 use crate::{
-    Commit, CommitFlags, CommitIndex, Edge, EntryPointCommit, Graph, SegmentIndex, SegmentMetadata,
+    Commit, CommitFlags, CommitIndex, Edge, EntryPointCommit, Graph, Segment, SegmentIndex,
+    SegmentMetadata,
     init::{
         PetGraph, TipRole, branch_segment_from_name_and_meta,
         overlay::{OverlayMetadata, OverlayRepo},
@@ -97,6 +98,15 @@ impl Graph {
             configured_remote_tracking_branches,
             &worktree_by_branch,
         )?;
+
+        // Branches checked out in linked worktrees leave the lanes the passes
+        // above put them in - the worktree classification wins over workspace
+        // metadata. This must run after everything that names segments: the
+        // remote improvements above can re-name an anonymous segment from the
+        // refs left on its first commit, which would re-couple a fork to the
+        // lane it points into. The pass maintains remote/sibling links itself
+        // when it moves a name.
+        self.fork_out_worktree_checkout_refs(meta, &worktree_by_branch)?;
 
         // Finally, once all segments were added, it's good to generations
         // have to figure out early abort conditions, or to know what's ahead of another.
@@ -219,11 +229,6 @@ impl Graph {
                 // ref-name is known to not be the desired one, and the first commit of this segment has the name
                 // we seek. For that, we now create a new
                 let new_ep_sidx_first_commit_idx = s.commits.first().map(|_| 0);
-                let incoming_edges = collect_edges_at_commit_in_traversal_order(
-                    &self.inner,
-                    (new_ep_sidx, new_ep_sidx_first_commit_idx),
-                    Direction::Incoming,
-                );
                 let mut entrypoint_segment = branch_segment_from_name_and_meta(
                     Some((desired_ref_name.ref_name, None)),
                     meta,
@@ -235,28 +240,18 @@ impl Graph {
                     ri.worktree = desired_ref_name.worktree;
                 }
                 let entrypoint_sidx = self.insert_segment_set_entrypoint(entrypoint_segment);
+                self.move_incoming_edges(
+                    (new_ep_sidx, new_ep_sidx_first_commit_idx),
+                    entrypoint_sidx,
+                    None,
+                    None,
+                );
                 self.connect_segments(
                     entrypoint_sidx,
                     None,
                     new_ep_sidx,
                     new_ep_sidx_first_commit_idx,
                 );
-                // Preserve incoming traversal order after moving the edges to
-                // the new entrypoint segment.
-                for edge in incoming_edges.into_iter().rev() {
-                    self.inner.add_edge(
-                        edge.source,
-                        entrypoint_sidx,
-                        Edge {
-                            src: edge.weight.src,
-                            src_id: edge.weight.src_id,
-                            dst: None,
-                            dst_id: None,
-                            parent_order: edge.weight.parent_order,
-                        },
-                    );
-                    self.inner.remove_edge(edge.id);
-                }
                 self.entrypoint = Some((entrypoint_sidx, ep_commit));
             } else {
                 let entrypoint_commit_id = s
@@ -479,27 +474,17 @@ impl Graph {
             0,
         );
 
-        let (src, src_id) = {
-            let s = &self[new_segment_sidx];
-            let last = s.commits.len() - 1;
-            (Some(last), Some(s.commits[last].id))
-        };
-        // Preserve outgoing traversal order after moving all outgoing edges
-        // from the old segment to the new segment.
-        for edge in edges_to_reconnect.into_iter().rev() {
-            self.inner.add_edge(
-                new_segment_sidx,
-                edge.target,
-                Edge {
-                    src,
-                    src_id,
-                    dst: edge.weight.dst,
-                    dst_id: edge.weight.dst_id,
-                    parent_order: edge.weight.parent_order,
-                },
-            );
-            self.inner.remove_edge(edge.id);
-        }
+        // Move all outgoing edges from the old segment to the new segment,
+        // re-sourced at its last commit.
+        let last_commit_id = self[new_segment_sidx]
+            .commits
+            .last()
+            .map(|commit| commit.id);
+        reconnect_outgoing_edges(
+            &mut self.inner,
+            edges_to_reconnect,
+            (new_segment_sidx, last_commit_id),
+        );
 
         if cidx_for_new_segment == 0 {
             // The top-segment is still connected with edges that think they link to a commit, so adjust them.
@@ -1608,6 +1593,308 @@ impl Graph {
             )?;
         }
         Ok(())
+    }
+
+    /// Give each branch that a linked worktree has checked out its own empty
+    /// segment, forking directly into the commit it points at, see
+    /// [worktree tips](Graph::worktree_tips).
+    ///
+    /// Being checked out somewhere is transient state: it decides where the
+    /// branch is drawn and which checkout follows a rewrite, never what the
+    /// lanes contain. Such branches are therefore presented through the
+    /// worktree listing rather than as stack rows, and rewriting history
+    /// relative to them must never rewrite the lane they point into. Wherever
+    /// the branch currently lives - naming a commit-owning segment, chained
+    /// into a lane as an empty segment, or riding on a commit in its refs -
+    /// it is re-attached uniformly as a fork: an empty segment nothing routes
+    /// through, whose only connection lands on its commit. Since a connection
+    /// into a named segment implicitly passes that segment's reference, the
+    /// commit-owning segment is made anonymous, its rewritable name extracted
+    /// into an empty segment that keeps its place in the lane; remote names
+    /// stay put as they cannot be rewritten from a worktree's perspective,
+    /// and refs remaining on the commit itself keep their usual meaning of
+    /// moving with it.
+    ///
+    /// For the same reason this classification wins over workspace metadata,
+    /// demoting whatever earlier passes stacked inline, while the durable
+    /// metadata itself keeps such branches recorded in their stacks (see
+    /// `Workspace::metadata_from_projection()`). Exempt is only the subject
+    /// of this graph's view: the branch checked out by the repository that
+    /// built the graph, and the entrypoint ref.
+    fn fork_out_worktree_checkout_refs<T: RefMetadata>(
+        &mut self,
+        meta: &OverlayMetadata<'_, T>,
+        worktree_by_branch: &WorktreeByBranch,
+    ) -> anyhow::Result<()> {
+        let mut seen = BTreeSet::new();
+        let checkout_refs: Vec<gix::refs::FullName> = self
+            .worktree_tips
+            .iter()
+            .filter_map(|tip| tip.ref_name.clone())
+            .filter(|ref_name| {
+                !worktree_by_branch
+                    .get(ref_name)
+                    .is_some_and(|worktrees| worktrees.iter().any(|wt| wt.owned_by_repo))
+            })
+            // The entrypoint is the subject of this graph's view, even when it is
+            // checked out in a linked worktree - keep it addressable as a lane.
+            .filter(|ref_name| Some(ref_name) != self.entrypoint_ref.as_ref())
+            .filter(|ref_name| seen.insert(ref_name.clone()))
+            .collect();
+        let mut identity_left_the_lane = BTreeSet::new();
+        for ref_name in checkout_refs {
+            if let Some((fork_sidx, vacated_sidx)) =
+                self.fork_out_worktree_checkout_ref(ref_name, meta, worktree_by_branch)?
+            {
+                identity_left_the_lane.insert(fork_sidx);
+                identity_left_the_lane.extend(vacated_sidx);
+            }
+        }
+        // Anonymous lane segments may still carry sibling links planted by the
+        // workspace upgrades for stack reconstruction, which must point at
+        // named in-lane segments. A link to a fork would resurrect the
+        // worktree branch as a stack row, and a link to the anonymous segment
+        // its identity vacated denotes nothing anymore - cut both. The remote
+        // back-links established above live on named remote segments and stay.
+        if !identity_left_the_lane.is_empty() {
+            for sidx in self.segments().collect::<Vec<_>>() {
+                let segment = &mut self[sidx];
+                if segment.ref_info.is_none()
+                    && segment
+                        .sibling_segment_id
+                        .is_some_and(|sibling| identity_left_the_lane.contains(&sibling))
+                {
+                    segment.sibling_segment_id = None;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Returns the fork segment now carrying `ref_name` along with the lane
+    /// segment its identity vacated, if any, or `None` if the ref could not be
+    /// placed.
+    fn fork_out_worktree_checkout_ref<T: RefMetadata>(
+        &mut self,
+        ref_name: gix::refs::FullName,
+        meta: &OverlayMetadata<'_, T>,
+        worktree_by_branch: &WorktreeByBranch,
+    ) -> anyhow::Result<Option<(SegmentIndex, Option<SegmentIndex>)>> {
+        enum Location {
+            Named(SegmentIndex),
+            OnCommit(SegmentIndex, CommitIndex),
+        }
+        let location = self.segments().find_map(|sidx| {
+            let segment = &self[sidx];
+            if segment.ref_name() == Some(ref_name.as_ref()) {
+                return Some(Location::Named(sidx));
+            }
+            segment
+                .commits
+                .iter()
+                .enumerate()
+                .find_map(|(cidx, commit)| {
+                    commit
+                        .refs
+                        .iter()
+                        .any(|ri| ri.ref_name == ref_name)
+                        .then_some(Location::OnCommit(sidx, cidx))
+                })
+        });
+        let Some(location) = location else {
+            // Traversal limits or an overlay can leave the ref out of the graph.
+            tracing::debug!(
+                ref_name = %ref_name.as_bstr(),
+                "worktree-checked-out ref not in graph, leaving it as is"
+            );
+            return Ok(None);
+        };
+
+        let (fork_sidx, vacated_sidx, commit_id) = match location {
+            Location::Named(sidx) if self[sidx].workspace_metadata().is_some() => {
+                // Never dismantle a workspace segment.
+                return Ok(None);
+            }
+            Location::Named(sidx) if self[sidx].commits.is_empty() => {
+                // An empty segment, possibly chained into a lane by branch
+                // metadata. Splice it out of the chain and re-attach it as a
+                // fork onto its commit below.
+                let Some(commit_id) = self
+                    .resolve_to_unambiguously_pointed_to_commit(sidx)
+                    .map(|(commit, _sidx)| commit.id)
+                else {
+                    tracing::debug!(
+                        ref_name = %ref_name.as_bstr(),
+                        "empty worktree-checked-out segment points at no unambiguous commit"
+                    );
+                    return Ok(None);
+                };
+                let outgoing: Vec<EdgeOwned> = self
+                    .inner
+                    .edges_directed(sidx, Direction::Outgoing)
+                    .map(Into::into)
+                    .collect();
+                let [outgoing] = outgoing.as_slice() else {
+                    unreachable!("the commit was resolved through a single outgoing connection")
+                };
+                let (target, dst, dst_id, outgoing_id) = (
+                    outgoing.target,
+                    outgoing.weight.dst,
+                    outgoing.weight.dst_id,
+                    outgoing.id,
+                );
+                self.move_incoming_edges((sidx, None), target, dst, dst_id);
+                self.inner.remove_edge(outgoing_id);
+                if let Some(ref_info) = self[sidx].ref_info.as_mut() {
+                    ref_info.commit_id = Some(commit_id);
+                }
+                (sidx, None, commit_id)
+            }
+            Location::Named(sidx) => {
+                // The ref names a commit-owning segment: the commits stay
+                // behind in the now anonymous segment, while everything
+                // ref-related moves onto the new fork segment.
+                let commit_id = self[sidx]
+                    .commits
+                    .first()
+                    .map(|commit| commit.id)
+                    .expect("just verified the segment owns commits");
+                (
+                    self.split_off_ref_identity(sidx, commit_id),
+                    Some(sidx),
+                    commit_id,
+                )
+            }
+            Location::OnCommit(sidx, cidx) => {
+                let commit = &mut self[sidx].commits[cidx];
+                let commit_id = commit.id;
+                commit.refs.retain(|ri| ri.ref_name != ref_name);
+                let mut fork_segment = branch_segment_from_name_and_meta(
+                    Some((ref_name.clone(), None)),
+                    meta,
+                    None,
+                    worktree_by_branch,
+                )?;
+                if let Some(ref_info) = fork_segment.ref_info.as_mut() {
+                    ref_info.commit_id = Some(commit_id);
+                }
+                (self.insert_segment(fork_segment), None, commit_id)
+            }
+        };
+
+        // Attach the fork to the segment owning the commit, making sure the
+        // commit starts that segment and no local branch names it.
+        let owner_sidx = self.segment_id_by_commit_id(commit_id)?;
+        let owner_sidx = match self[owner_sidx]
+            .commit_index_of(commit_id)
+            .context("BUG: the owning segment must contain the commit")?
+        {
+            0 => owner_sidx,
+            cidx => self.split_segment(owner_sidx, cidx, None, None, meta, worktree_by_branch)?,
+        };
+        // Only rewritable names can couple the fork to a rewrite, so only
+        // local branches are extracted: routing through a remote reference is
+        // harmless as the editor never rewrites remotes, and workspace
+        // segments must survive as the workspace's own head. Tags and other
+        // refs on the commit itself also stay in place.
+        if self[owner_sidx]
+            .ref_name()
+            .is_some_and(|rn| rn.category() == Some(Category::LocalBranch))
+            && self[owner_sidx].workspace_metadata().is_none()
+        {
+            self.hoist_segment_identity_into_empty_segment(owner_sidx);
+        }
+        self.connect_segments(fork_sidx, None, owner_sidx, Some(0));
+        Ok(Some((fork_sidx, vacated_sidx)))
+    }
+
+    /// Move the identity of `sidx` into a new empty segment that takes over
+    /// all incoming connections of `sidx`, leaving `sidx` anonymous while the
+    /// new segment keeps its place in the lane. Everything denoting the
+    /// identity - the entrypoint and third-party reconstruction links - moves
+    /// along. Returns the new segment's index.
+    fn hoist_segment_identity_into_empty_segment(&mut self, sidx: SegmentIndex) -> SegmentIndex {
+        let commit_id = self[sidx]
+            .commits
+            .first()
+            .map(|commit| commit.id)
+            .expect("callers only hoist commit-owning segments");
+        let empty_sidx = self.split_off_ref_identity(sidx, commit_id);
+        self.move_incoming_edges((sidx, Some(0)), empty_sidx, None, None);
+        self.connect_segments(empty_sidx, None, sidx, Some(0));
+        if let Some((ep_sidx, _)) = self.entrypoint.as_mut()
+            && *ep_sidx == sidx
+        {
+            *ep_sidx = empty_sidx;
+        }
+        for other_sidx in self.segments().collect::<Vec<_>>() {
+            if other_sidx == sidx || other_sidx == empty_sidx {
+                continue;
+            }
+            let segment = &mut self[other_sidx];
+            if segment.ref_info.is_none() && segment.sibling_segment_id == Some(sidx) {
+                segment.sibling_segment_id = Some(empty_sidx);
+            }
+        }
+        empty_sidx
+    }
+
+    /// Take everything ref-related from `sidx` - name, metadata, and
+    /// remote/sibling links - into a new empty segment, leaving `sidx`
+    /// anonymous, with the remote's back-link following to the new home.
+    /// The moved ref-info remembers `commit_id` as the commit it points at.
+    /// Connections are left untouched.
+    fn split_off_ref_identity(&mut self, sidx: SegmentIndex, commit_id: ObjectId) -> SegmentIndex {
+        let segment = &mut self[sidx];
+        let mut ref_info = segment.ref_info.take();
+        if let Some(ref_info) = ref_info.as_mut() {
+            ref_info.commit_id = Some(commit_id);
+        }
+        let metadata = segment.metadata.take();
+        let remote_tracking_ref_name = segment.remote_tracking_ref_name.take();
+        let remote_sidx = segment.remote_tracking_branch_segment_id.take();
+        let sibling_segment_id = segment.sibling_segment_id.take();
+        let new_sidx = self.insert_segment(Segment {
+            ref_info,
+            metadata,
+            remote_tracking_ref_name,
+            remote_tracking_branch_segment_id: remote_sidx,
+            sibling_segment_id,
+            ..Default::default()
+        });
+        if let Some(remote_sidx) = remote_sidx {
+            self[remote_sidx].sibling_segment_id = Some(new_sidx);
+        }
+        new_sidx
+    }
+
+    /// Move all incoming connections of `from` onto `to`, retargeting their
+    /// destination to `(dst, dst_id)` while keeping source positions and
+    /// traversal order.
+    fn move_incoming_edges(
+        &mut self,
+        from: (SegmentIndex, Option<CommitIndex>),
+        to: SegmentIndex,
+        dst: Option<CommitIndex>,
+        dst_id: Option<ObjectId>,
+    ) {
+        let incoming =
+            collect_edges_at_commit_in_traversal_order(&self.inner, from, Direction::Incoming);
+        // Preserve incoming traversal order by re-adding in reverse.
+        for edge in incoming.into_iter().rev() {
+            self.inner.add_edge(
+                edge.source,
+                to,
+                Edge {
+                    src: edge.weight.src,
+                    src_id: edge.weight.src_id,
+                    dst,
+                    dst_id,
+                    parent_order: edge.weight.parent_order,
+                },
+            );
+            self.inner.remove_edge(edge.id);
+        }
     }
 }
 

--- a/crates/but-graph/src/lib.rs
+++ b/crates/but-graph/src/lib.rs
@@ -284,6 +284,13 @@ pub struct Graph {
     /// callers previewing worktree changes may replace it before redoing. They are
     /// ignored by [`Graph::from_head()`] when `HEAD` is unborn, as no traversal
     /// happens there.
+    ///
+    /// Post-processing represents each branch listed here as an empty segment
+    /// forking directly onto the commit it points at, so it never owns commits,
+    /// no lane routes through it, and rewrites relative to it stay local.
+    /// Exempt is the subject of the graph's view - the branch this repository
+    /// itself has checked out, and the entrypoint ref - as well as refs the
+    /// traversal could not place.
     pub worktree_tips: Vec<init::WorktreeTip>,
     /// Project-wide metadata used for target ref, target commit, and push remote resolution.
     pub project_meta: but_core::ref_metadata::ProjectMeta,

--- a/crates/but-graph/src/projection/workspace/api/mod.rs
+++ b/crates/but-graph/src/projection/workspace/api/mod.rs
@@ -104,12 +104,23 @@ impl Workspace {
     /// Unlike [`Self::metadata`], applied stacks absent from the projection are
     /// treated as outside the workspace, and branches absent from a projected
     /// stack are excluded.
+    ///
+    /// Branches checked out in linked worktrees are deliberately absent from
+    /// projected stacks, but they remain part of their recorded stack - being
+    /// checked out elsewhere is transient state, not a workspace change - so
+    /// they count as present here.
     pub fn metadata_from_projection(
         &self,
     ) -> anyhow::Result<Option<but_core::ref_metadata::Workspace>> {
         let Some(mut metadata) = self.metadata.clone() else {
             return Ok(None);
         };
+        let worktree_refs: std::collections::BTreeSet<&gix::refs::FullName> = self
+            .graph
+            .worktree_tips
+            .iter()
+            .filter_map(|tip| tip.ref_name.as_ref())
+            .collect();
         for stack in &mut metadata.stacks {
             if !stack.workspacecommit_relation.is_in_workspace() {
                 continue;
@@ -125,15 +136,23 @@ impl Workspace {
                         })
                     })
             }) else {
+                if stack
+                    .branches
+                    .iter()
+                    .any(|branch| worktree_refs.contains(&branch.ref_name))
+                {
+                    continue;
+                }
                 stack.workspacecommit_relation =
                     but_core::ref_metadata::WorkspaceCommitRelation::Outside;
                 continue;
             };
             stack.branches.retain(|branch| {
-                projected_stack
-                    .segments
-                    .iter()
-                    .any(|segment| segment.ref_name() == Some(branch.ref_name.as_ref()))
+                worktree_refs.contains(&branch.ref_name)
+                    || projected_stack
+                        .segments
+                        .iter()
+                        .any(|segment| segment.ref_name() == Some(branch.ref_name.as_ref()))
             });
         }
         self.reconcile_metadata(&mut metadata)?;

--- a/crates/but-graph/tests/fixtures/scenarios.sh
+++ b/crates/but-graph/tests/fixtures/scenarios.sh
@@ -1738,4 +1738,47 @@ EOF
        commit x2
      create_workspace_commit_once X
   )
+
+  # A branch checked out in a linked worktree points at the tip commit of an
+  # applied workspace branch, so the worktree ref competes with the stack
+  # branch for that commit.
+  git init worktree-ref-at-applied-branch
+  (cd worktree-ref-at-applied-branch
+    commit init
+    setup_target_to_match_main
+    git checkout -b foo
+      commit A
+    git worktree add -b wsref ../worktree-ref-at-applied-branch-wt foo
+    create_workspace_commit_once foo
+  )
+
+  # A branch checked out in a linked worktree points at the tip of an applied
+  # branch that also has a remote tracking branch.
+  git init worktree-ref-at-remote-tracked-branch
+  (cd worktree-ref-at-remote-tracked-branch
+    commit init
+    setup_target_to_match_main
+    git checkout -b foo
+      commit A
+    git checkout -b soon-origin-foo foo
+    git checkout -b soon-origin-wsref foo
+    git checkout foo
+    setup_remote_tracking soon-origin-foo foo "move"
+    setup_remote_tracking soon-origin-wsref wsref "move"
+    git worktree add -b wsref ../worktree-ref-at-remote-tracked-branch-wt foo
+    create_workspace_commit_once foo
+  )
+
+  # A branch checked out in a linked worktree points into the middle of an
+  # applied branch's commits, below its tip.
+  git init worktree-ref-mid-stack
+  (cd worktree-ref-mid-stack
+    commit init
+    setup_target_to_match_main
+    git checkout -b foo
+      commit A1
+      commit A2
+    git worktree add -b wsref ../worktree-ref-mid-stack-wt foo~1
+    create_workspace_commit_once foo
+  )
 )

--- a/crates/but-graph/tests/graph/init/with_workspace.rs
+++ b/crates/but-graph/tests/graph/init/with_workspace.rs
@@ -10316,3 +10316,584 @@ fn remote_ref_as_stack_top() -> anyhow::Result<()> {
     );
     Ok(())
 }
+
+#[test]
+fn worktree_ref_at_applied_branch() -> anyhow::Result<()> {
+    let (repo, mut meta, mut db) =
+        read_only_in_memory_scenario("ws/worktree-ref-at-applied-branch")?;
+    snapbox::assert_data_eq!(
+        visualize_commit_graph_all(&repo)?,
+        snapbox::str![[r#"
+* dd0cca8 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+* e255adc (wsref, foo) A
+* fafd9d0 (origin/main, main) init
+
+"#]]
+    );
+
+    // Without metadata for `wsref`, the applied branch `foo` names the commit-owning
+    // segment and the worktree-checked-out `wsref` stays as a ref on the commit.
+    // Note that the shape is the same with or without seeded worktree tips.
+    add_stack_with_segments(&mut meta, 0, "foo", StackState::InWorkspace, &[]);
+    let graph = Graph::from_head(
+        &repo,
+        &*meta,
+        default_project_meta(),
+        &mut db,
+        standard_options(),
+    )?
+    .validated()?;
+    snapbox::assert_data_eq!(
+        graph_dag(&graph),
+        snapbox::str![[r#"
+◎  👉📕gitbutler/workspace[🌳@repo]
+●  ·dd0cca8 (⌂|🏘|01)
+◎  📙foo
+│ ◎  wsref[📁worktree-ref-at-applied-branch-wt]
+├─╯
+●  ·e255adc (⌂|🏘|01)
+│ ◎  origin/main
+├─╯
+◎  main <> origin/main
+●  🏁·fafd9d0 (⌂|🏘|✓|11)
+"#]]
+    );
+    snapbox::assert_data_eq!(
+        graph_workspace(&graph.into_workspace()?).to_string(),
+        snapbox::str![[r#"
+📕🏘️:0:gitbutler/workspace[🌳@repo] <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡📙:3:foo on fafd9d0 {0}
+    └── 📙:3:foo
+        └── ·e255adc (🏘️) ►wsref[📁worktree-ref-at-applied-branch-wt]
+
+"#]]
+    );
+
+    // With `wsref` recorded as a dependent branch below `foo`, it becomes an
+    // in-lane commit-owning segment, so it shows up as a stack branch even though
+    // the worktree listing represents it as well.
+    let (repo, mut meta, mut db) =
+        read_only_in_memory_scenario("ws/worktree-ref-at-applied-branch")?;
+    add_stack_with_segments(&mut meta, 0, "foo", StackState::InWorkspace, &["wsref"]);
+    let graph = Graph::from_head(
+        &repo,
+        &*meta,
+        default_project_meta(),
+        &mut db,
+        standard_options(),
+    )?
+    .validated()?;
+    snapbox::assert_data_eq!(
+        graph_dag(&graph),
+        snapbox::str![[r#"
+◎  👉📕gitbutler/workspace[🌳@repo]
+●  ·dd0cca8 (⌂|🏘|01)
+◎  📙foo
+◎  📙wsref[📁worktree-ref-at-applied-branch-wt]
+●  ·e255adc (⌂|🏘|01)
+│ ◎  origin/main
+├─╯
+◎  main <> origin/main
+●  🏁·fafd9d0 (⌂|🏘|✓|11)
+"#]]
+    );
+    snapbox::assert_data_eq!(
+        graph_workspace(&graph.into_workspace()?).to_string(),
+        snapbox::str![[r#"
+📕🏘️:0:gitbutler/workspace[🌳@repo] <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡📙:4:foo on fafd9d0 {0}
+    ├── 📙:4:foo
+    └── 📙:5:wsref[📁worktree-ref-at-applied-branch-wt]
+        └── ·e255adc (🏘️)
+
+"#]]
+    );
+    Ok(())
+}
+
+#[test]
+fn worktree_ref_at_applied_branch_with_discovery() -> anyhow::Result<()> {
+    let options = || but_graph::init::Options {
+        worktrees: true,
+        ..standard_options()
+    };
+    // With the worktree tip discovered, `wsref` leaves the lane: the commit is
+    // owned by an anonymous segment, `foo` keeps its place in the lane as an
+    // empty segment, and `wsref` forks directly into the commit.
+    let (repo, mut meta, mut db) =
+        read_only_in_memory_scenario("ws/worktree-ref-at-applied-branch")?;
+    add_stack_with_segments(&mut meta, 0, "foo", StackState::InWorkspace, &[]);
+    // Adoption already ran, so the fixture worktree counts as active.
+    db.worktree_meta_mut().mark_adopted()?;
+    let graph =
+        Graph::from_head(&repo, &*meta, default_project_meta(), &mut db, options())?.validated()?;
+    snapbox::assert_data_eq!(
+        graph_dag(&graph),
+        snapbox::str![[r#"
+◎  👉📕gitbutler/workspace[🌳@repo]
+●  ·dd0cca8 (⌂|🏘|01)
+◎  📙foo
+│ ◎  wsref[📁worktree-ref-at-applied-branch-wt]
+├─╯
+●  ·e255adc (⌂|🏘|01)
+│ ◎  origin/main
+├─╯
+◎  main <> origin/main
+●  🏁·fafd9d0 (⌂|🏘|✓|11)
+"#]]
+    );
+    assert_worktree_ref_is_fork(&graph, "wsref")?;
+    // The worktree branch is no longer a stack row - the worktree listing
+    // represents it instead.
+    snapbox::assert_data_eq!(
+        graph_workspace(&graph.into_workspace()?).to_string(),
+        snapbox::str![[r#"
+📕🏘️:0:gitbutler/workspace[🌳@repo] <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡📙:5:foo on fafd9d0 {0}
+    └── 📙:5:foo
+        └── ·e255adc (🏘️)
+
+"#]]
+    );
+
+    // Even when workspace metadata records `wsref` as a dependent branch below
+    // `foo`, the worktree classification wins and the shape is the same.
+    let (repo, mut meta, mut db) =
+        read_only_in_memory_scenario("ws/worktree-ref-at-applied-branch")?;
+    add_stack_with_segments(&mut meta, 0, "foo", StackState::InWorkspace, &["wsref"]);
+    db.worktree_meta_mut().mark_adopted()?;
+    let graph =
+        Graph::from_head(&repo, &*meta, default_project_meta(), &mut db, options())?.validated()?;
+    snapbox::assert_data_eq!(
+        graph_dag(&graph),
+        snapbox::str![[r#"
+◎  👉📕gitbutler/workspace[🌳@repo]
+●  ·dd0cca8 (⌂|🏘|01)
+◎  📙foo
+│ ◎  📙wsref[📁worktree-ref-at-applied-branch-wt]
+├─╯
+●  ·e255adc (⌂|🏘|01)
+│ ◎  origin/main
+├─╯
+◎  main <> origin/main
+●  🏁·fafd9d0 (⌂|🏘|✓|11)
+"#]]
+    );
+    snapbox::assert_data_eq!(
+        graph_workspace(&graph.into_workspace()?).to_string(),
+        snapbox::str![[r#"
+📕🏘️:0:gitbutler/workspace[🌳@repo] <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡📙:4:foo on fafd9d0 {0}
+    └── 📙:4:foo
+        └── ·e255adc (🏘️)
+
+"#]]
+    );
+    Ok(())
+}
+
+#[test]
+fn worktree_ref_mid_stack() -> anyhow::Result<()> {
+    let (repo, mut meta, mut db) = read_only_in_memory_scenario("ws/worktree-ref-mid-stack")?;
+    snapbox::assert_data_eq!(
+        visualize_commit_graph_all(&repo)?,
+        snapbox::str![[r#"
+* 3ea2742 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+* a62b0de (foo) A2
+* 120a217 (wsref) A1
+* fafd9d0 (origin/main, main) init
+
+"#]]
+    );
+    add_stack_with_segments(&mut meta, 0, "foo", StackState::InWorkspace, &[]);
+    db.worktree_meta_mut().mark_adopted()?;
+    // The worktree branch points below `foo`'s tip: its commit is split into an
+    // anonymous segment that stays in the lane, and the branch forks into it.
+    // Rewrites relative to `wsref` thus never touch `foo` or the workspace.
+    let graph = Graph::from_head(
+        &repo,
+        &*meta,
+        default_project_meta(),
+        &mut db,
+        but_graph::init::Options {
+            worktrees: true,
+            ..standard_options()
+        },
+    )?
+    .validated()?;
+    snapbox::assert_data_eq!(
+        graph_dag(&graph),
+        snapbox::str![[r#"
+◎  👉📕gitbutler/workspace[🌳@repo]
+●  ·3ea2742 (⌂|🏘|01)
+◎  📙foo
+●  ·a62b0de (⌂|🏘|01)
+│ ◎  wsref[📁worktree-ref-mid-stack-wt]
+├─╯
+●  ·120a217 (⌂|🏘|01)
+│ ◎  origin/main
+├─╯
+◎  main <> origin/main
+●  🏁·fafd9d0 (⌂|🏘|✓|11)
+"#]]
+    );
+    assert_worktree_ref_is_fork(&graph, "wsref")?;
+    // Both commits still belong to `foo`'s stack row.
+    snapbox::assert_data_eq!(
+        graph_workspace(&graph.into_workspace()?).to_string(),
+        snapbox::str![[r#"
+📕🏘️:0:gitbutler/workspace[🌳@repo] <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡📙:3:foo on fafd9d0 {0}
+    └── 📙:3:foo
+        ├── ·a62b0de (🏘️)
+        └── ·120a217 (🏘️)
+
+"#]]
+    );
+    Ok(())
+}
+
+/// Assert `short_name` is represented as a worktree fork: an empty named
+/// segment that nothing routes through, whose single outgoing connection lands
+/// on the first commit of a differently-owned segment.
+fn assert_worktree_ref_is_fork(graph: &Graph, short_name: &str) -> anyhow::Result<()> {
+    use anyhow::Context as _;
+    use but_graph::petgraph::{Direction, visit::EdgeRef};
+    let full_name: gix::refs::FullName = format!("refs/heads/{short_name}").try_into()?;
+    let segment = graph
+        .segment_by_ref_name(full_name.as_ref())
+        .with_context(|| format!("{short_name} must still be addressable by name"))?;
+    assert!(
+        segment.commits.is_empty(),
+        "worktree-checked-out refs never own commits"
+    );
+    assert_eq!(
+        graph
+            .edges_directed(segment.id, Direction::Incoming)
+            .count(),
+        0,
+        "no lane routes through a worktree ref"
+    );
+    let outgoing: Vec<_> = graph
+        .edges_directed(segment.id, Direction::Outgoing)
+        .collect();
+    assert_eq!(outgoing.len(), 1, "a fork attaches to exactly one commit");
+    let target = &graph[outgoing[0].target()];
+    assert!(
+        target
+            .ref_name()
+            .is_none_or(|rn| { rn.category() != Some(gix::refs::Category::LocalBranch) })
+            || target.workspace_metadata().is_some(),
+        "no local branch names the commit-owning segment, so the editor \
+         attaches the fork to the commit instead of another reference"
+    );
+    assert_eq!(
+        segment.ref_info.as_ref().and_then(|ri| ri.commit_id),
+        target.commits.first().map(|c| c.id),
+        "the fork lands on the first commit of the owning segment, \
+         which the ref-info also remembers"
+    );
+    Ok(())
+}
+
+#[test]
+fn worktree_ref_as_stack_top_is_spliced_into_fork() -> anyhow::Result<()> {
+    // Workspace metadata records `wsref` as the stack top above `foo`, which the
+    // workspace upgrades represent as an empty segment chained into the lane.
+    // The worktree classification wins: the chained segment is spliced out and
+    // re-attached as a fork onto the commit, while `foo` keeps the lane.
+    let (repo, mut meta, mut db) =
+        read_only_in_memory_scenario("ws/worktree-ref-at-applied-branch")?;
+    add_stack_with_segments(&mut meta, 0, "wsref", StackState::InWorkspace, &["foo"]);
+    db.worktree_meta_mut().mark_adopted()?;
+    let graph = Graph::from_head(
+        &repo,
+        &*meta,
+        default_project_meta(),
+        &mut db,
+        but_graph::init::Options {
+            worktrees: true,
+            ..standard_options()
+        },
+    )?
+    .validated()?;
+    snapbox::assert_data_eq!(
+        graph_dag(&graph),
+        snapbox::str![[r#"
+◎  👉📕gitbutler/workspace[🌳@repo]
+●  ·dd0cca8 (⌂|🏘|01)
+◎  📙foo
+│ ◎  📙wsref[📁worktree-ref-at-applied-branch-wt]
+├─╯
+●  ·e255adc (⌂|🏘|01)
+│ ◎  origin/main
+├─╯
+◎  main <> origin/main
+●  🏁·fafd9d0 (⌂|🏘|✓|11)
+"#]]
+    );
+    assert_worktree_ref_is_fork(&graph, "wsref")?;
+    snapbox::assert_data_eq!(
+        graph_workspace(&graph.into_workspace()?).to_string(),
+        snapbox::str![[r#"
+📕🏘️:0:gitbutler/workspace[🌳@repo] <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡📙:3:foo on fafd9d0 {0}
+    └── 📙:3:foo
+        └── ·e255adc (🏘️)
+
+"#]]
+    );
+    Ok(())
+}
+
+#[test]
+fn worktree_ref_as_entrypoint_keeps_its_lane() -> anyhow::Result<()> {
+    // Viewing the graph from the worktree branch itself - like branch details
+    // for it would - keeps the ref addressable as a lane instead of forking it
+    // out from under the entrypoint.
+    let (repo, mut meta, mut db) =
+        read_only_in_memory_scenario("ws/worktree-ref-at-applied-branch")?;
+    add_stack_with_segments(&mut meta, 0, "foo", StackState::InWorkspace, &[]);
+    db.worktree_meta_mut().mark_adopted()?;
+    let (wsref_id, wsref_ref) = id_at(&repo, "wsref");
+    let graph = Graph::from_commit_traversal(
+        wsref_id,
+        wsref_ref,
+        &*meta,
+        default_project_meta(),
+        &mut db,
+        but_graph::init::Options {
+            worktrees: true,
+            ..standard_options()
+        },
+    )?
+    .validated()?;
+    snapbox::assert_data_eq!(
+        graph_dag(&graph),
+        snapbox::str![[r#"
+◎  📕gitbutler/workspace[🌳@repo]
+●  ·dd0cca8 (⌂|🏘)
+◎  👉wsref[📁worktree-ref-at-applied-branch-wt]
+◎  📙foo
+●  ·e255adc (⌂|🏘|01)
+│ ◎  origin/main
+├─╯
+◎  main <> origin/main
+●  🏁·fafd9d0 (⌂|🏘|✓|11)
+"#]]
+    );
+    Ok(())
+}
+
+#[test]
+fn worktree_ref_at_remote_tracked_branch() -> anyhow::Result<()> {
+    // Both the applied branch sharing the commit and the worktree branch have
+    // remotes: hoisting `foo` must keep its remote linkage, and the pass must
+    // run after the remote improvements - otherwise those would re-name the
+    // anonymous owner from the refs left on the commit, or wire the worktree
+    // branch's remote through the fork, re-coupling it to the lane.
+    let (repo, mut meta, mut db) =
+        read_only_in_memory_scenario("ws/worktree-ref-at-remote-tracked-branch")?;
+    snapbox::assert_data_eq!(
+        visualize_commit_graph_all(&repo)?,
+        snapbox::str![[r#"
+* dd0cca8 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+* e255adc (origin/wsref, origin/foo, wsref, foo) A
+* fafd9d0 (origin/main, main) init
+
+"#]]
+    );
+    add_stack_with_segments(&mut meta, 0, "foo", StackState::InWorkspace, &[]);
+    db.worktree_meta_mut().mark_adopted()?;
+    let options = || but_graph::init::Options {
+        worktrees: true,
+        ..standard_options()
+    };
+    let graph =
+        Graph::from_head(&repo, &*meta, default_project_meta(), &mut db, options())?.validated()?;
+    assert_worktree_ref_is_fork(&graph, "wsref")?;
+    snapbox::assert_data_eq!(
+        graph_dag(&graph),
+        snapbox::str![[r#"
+◎  👉📕gitbutler/workspace[🌳@repo]
+●  ·dd0cca8 (⌂|🏘|001)
+│ ◎  wsref[📁worktree-ref-at-remote-tracked-branch-wt]
+│ │ ◎  origin/foo
+├───╯
+│ │ ◎  origin/main
+│ │ │ ◎  origin/wsref
+├─────╯
+◎ │ │  📙foo <> origin/foo
+├─╯ │
+●   │  ·e255adc (⌂|🏘|101)
+├───╯
+◎  main <> origin/main
+●  🏁·fafd9d0 (⌂|🏘|✓|111)
+"#]]
+    );
+    snapbox::assert_data_eq!(
+        graph_workspace(&graph.into_workspace()?).to_string(),
+        snapbox::str![[r#"
+📕🏘️:0:gitbutler/workspace[🌳@repo] <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡📙:7:foo <> origin/foo →:4: on fafd9d0 {0}
+    └── 📙:7:foo <> origin/foo →:4:
+        └── ❄️e255adc (🏘️)
+
+"#]]
+    );
+
+    // With `wsref` itself recorded as the stack branch, traversal names the
+    // commit-owning segment after it and the pass demotes it in place, moving
+    // the remote linkage onto the fork. The owner stays anonymous even though
+    // `foo`, with its own remote, is left on the commit - which is exactly what
+    // running after the remote improvements guarantees.
+    let (repo, mut meta, mut db) =
+        read_only_in_memory_scenario("ws/worktree-ref-at-remote-tracked-branch")?;
+    add_stack_with_segments(&mut meta, 0, "wsref", StackState::InWorkspace, &[]);
+    db.worktree_meta_mut().mark_adopted()?;
+    let graph =
+        Graph::from_head(&repo, &*meta, default_project_meta(), &mut db, options())?.validated()?;
+    assert_worktree_ref_is_fork(&graph, "wsref")?;
+    snapbox::assert_data_eq!(
+        graph_dag(&graph),
+        snapbox::str![[r#"
+◎  foo
+│ ◎  👉📕gitbutler/workspace[🌳@repo]
+│ ●  ·dd0cca8 (⌂|🏘|001)
+├─╯
+│ ◎  📙wsref[📁worktree-ref-at-remote-tracked-branch-wt] <> origin/wsref
+├─╯
+│ ◎  origin/foo
+├─╯
+│ ◎  origin/main
+│ │ ◎  origin/wsref
+├───╯
+● │  ·e255adc (⌂|🏘|101)
+├─╯
+◎  main <> origin/main
+●  🏁·fafd9d0 (⌂|🏘|✓|111)
+"#]]
+    );
+    snapbox::assert_data_eq!(
+        graph_workspace(&graph.into_workspace()?).to_string(),
+        snapbox::str![[r#"
+📕🏘️:0:gitbutler/workspace[🌳@repo] <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡:3:anon: on fafd9d0
+    └── :3:anon:
+        └── ·e255adc (🏘️) ►foo
+
+"#]]
+    );
+    Ok(())
+}
+
+#[test]
+fn worktree_ref_beside_entrypoint_branch() -> anyhow::Result<()> {
+    // Viewing the graph from `foo` while the worktree branch shares its commit:
+    // extracting `foo`'s name into an empty in-lane segment must carry the
+    // entrypoint along, and the worktree branch still forks out.
+    let (repo, mut meta, mut db) =
+        read_only_in_memory_scenario("ws/worktree-ref-at-applied-branch")?;
+    add_stack_with_segments(&mut meta, 0, "foo", StackState::InWorkspace, &[]);
+    db.worktree_meta_mut().mark_adopted()?;
+    let (foo_id, foo_ref) = id_at(&repo, "foo");
+    let graph = Graph::from_commit_traversal(
+        foo_id,
+        foo_ref,
+        &*meta,
+        default_project_meta(),
+        &mut db,
+        but_graph::init::Options {
+            worktrees: true,
+            ..standard_options()
+        },
+    )?
+    .validated()?;
+    assert_worktree_ref_is_fork(&graph, "wsref")?;
+    snapbox::assert_data_eq!(
+        graph_dag(&graph),
+        snapbox::str![[r#"
+◎  📕gitbutler/workspace[🌳@repo]
+●  ·dd0cca8 (⌂|🏘)
+◎  👉📙foo
+│ ◎  wsref[📁worktree-ref-at-applied-branch-wt]
+├─╯
+●  ·e255adc (⌂|🏘|01)
+│ ◎  origin/main
+├─╯
+◎  main <> origin/main
+●  🏁·fafd9d0 (⌂|🏘|✓|11)
+"#]]
+    );
+    Ok(())
+}
+
+#[test]
+fn worktree_ref_survives_metadata_normalization() -> anyhow::Result<()> {
+    let options = || but_graph::init::Options {
+        worktrees: true,
+        ..standard_options()
+    };
+    // As a dependent branch below `foo`: the projection hides `wsref`, but
+    // deriving metadata from the projection must not drop it from its stack -
+    // being checked out in a worktree is transient, not a workspace change.
+    let (repo, mut meta, mut db) =
+        read_only_in_memory_scenario("ws/worktree-ref-at-applied-branch")?;
+    add_stack_with_segments(&mut meta, 0, "foo", StackState::InWorkspace, &["wsref"]);
+    db.worktree_meta_mut().mark_adopted()?;
+    let ws = Graph::from_head(&repo, &*meta, default_project_meta(), &mut db, options())?
+        .validated()?
+        .into_workspace()?;
+    let md = ws
+        .metadata_from_projection()?
+        .expect("workspace metadata exists");
+    let stack = md
+        .stacks
+        .iter()
+        .find(|stack| {
+            stack
+                .branches
+                .iter()
+                .any(|branch| branch.ref_name.as_ref().shorten() == "foo")
+        })
+        .expect("foo's stack is recorded");
+    assert!(
+        stack
+            .branches
+            .iter()
+            .any(|branch| branch.ref_name.as_ref().shorten() == "wsref"),
+        "the worktree-checked-out branch stays recorded in its stack"
+    );
+    assert!(
+        stack.workspacecommit_relation.is_in_workspace(),
+        "the stack remains applied"
+    );
+
+    // As the only branch of its stack: no projected stack matches it at all,
+    // yet it must not be flipped to outside-the-workspace.
+    let (repo, mut meta, mut db) =
+        read_only_in_memory_scenario("ws/worktree-ref-at-applied-branch")?;
+    add_stack_with_segments(&mut meta, 0, "wsref", StackState::InWorkspace, &[]);
+    db.worktree_meta_mut().mark_adopted()?;
+    let ws = Graph::from_head(&repo, &*meta, default_project_meta(), &mut db, options())?
+        .validated()?
+        .into_workspace()?;
+    let md = ws
+        .metadata_from_projection()?
+        .expect("workspace metadata exists");
+    let stack = md
+        .stacks
+        .iter()
+        .find(|stack| {
+            stack
+                .branches
+                .iter()
+                .any(|branch| branch.ref_name.as_ref().shorten() == "wsref")
+        })
+        .expect("the single-branch stack is still recorded");
+    assert!(
+        stack.workspacecommit_relation.is_in_workspace(),
+        "a stack whose only branch is checked out in a worktree remains applied"
+    );
+    Ok(())
+}

--- a/crates/but-rebase/tests/rebase/graph_rebase/materialize.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/materialize.rs
@@ -770,3 +770,84 @@ fn a_detached_worktree_that_moved_since_editor_creation_is_rejected() -> Result<
     );
     Ok(())
 }
+
+/// Inserting below a worktree-checked-out branch moves only that branch:
+/// the lane its commit belongs to is not rebased, because the branch is
+/// represented as a fork directly onto the commit it points at.
+#[test]
+fn insert_below_worktree_ref_moves_only_that_ref() -> Result<()> {
+    use but_rebase::graph_rebase::mutate::{InsertSide, RelativeTo};
+
+    let (repo, _tmpdir, mut meta, mut db) = worktree_fixture("worktree-checkout-heads")?;
+    snapbox::assert_data_eq!(
+        visualize_commit_graph_all(&repo)?,
+        snapbox::str![[r#"
+* a96434e (HEAD -> main) b
+* d591dfe (middle) a
+* 35b8235 base
+
+"#]]
+    );
+    let old_main = repo.rev_parse_single("main")?.detach();
+    let old_middle = repo.rev_parse_single("middle")?.detach();
+
+    let graph = graph_with_worktrees(&repo, &*meta, &mut db)?.validated()?;
+    let mut ws = graph.into_workspace()?;
+    let mut editor = Editor::create(&mut ws, &mut *meta, &repo, &mut db)?;
+
+    // A commit to insert, with the same tree the worktree already has.
+    let mut template = but_core::Commit::from_id(repo.rev_parse_single("middle")?)?;
+    template.message = "only for the worktree branch".into();
+    template.parents = vec![].into();
+    let new_commit = repo.write_object(template.inner)?.detach();
+
+    editor.insert(
+        RelativeTo::Reference("refs/heads/middle".try_into()?),
+        Step::new_pick(new_commit),
+        InsertSide::Below,
+    )?;
+    editor.rebase()?.materialize(Default::default())?;
+
+    assert_eq!(
+        repo.rev_parse_single("main")?.detach(),
+        old_main,
+        "nothing above the worktree branch is rebased"
+    );
+    let new_middle = repo.rev_parse_single("middle")?.detach();
+    assert_ne!(new_middle, old_middle, "the worktree branch moved");
+    assert_eq!(
+        repo.find_commit(new_middle)?
+            .parent_ids()
+            .map(|id| id.detach())
+            .collect::<Vec<_>>(),
+        [old_middle],
+        "the inserted commit sits directly on the commit the branch pointed at"
+    );
+    snapbox::assert_data_eq!(
+        visualize_commit_graph_all(&repo)?,
+        snapbox::str![[r#"
+* a96434e (HEAD -> main) b
+| * 3c608ef (middle) only for the worktree branch
+|/  
+* d591dfe a
+* 35b8235 base
+
+"#]]
+        .raw()
+    );
+
+    // The linked checkout followed its branch and is clean.
+    let attached = linked_repo(&repo, "wt")?;
+    assert_eq!(
+        attached.head_name()?,
+        Some("refs/heads/middle".try_into()?),
+        "the branch-backed worktree stays attached"
+    );
+    assert_eq!(
+        attached.head_id()?.detach(),
+        new_middle,
+        "the checkout follows the moved branch"
+    );
+    snapbox::assert_data_eq!(git_status(&attached)?, snapbox::str![""]);
+    Ok(())
+}

--- a/crates/but-workspace/tests/workspace/commit/move_commit.rs
+++ b/crates/but-workspace/tests/workspace/commit/move_commit.rs
@@ -1157,17 +1157,20 @@ fn move_mixed_main_and_worktree_commits_to_another_worktree() -> anyhow::Result<
     )?
     .materialize(Default::default())?;
 
-    // Both moved commits land on `other` and `main` falls back onto `stack-base`. The
-    // placeholder left where `feat`'s commit sat keeps `feat` directly above `other`, so
-    // it resolves through the placeholder onto the moved commit; `stable` and `target`
-    // sit below the insertion point and stay on the base commit.
+    // Both moved commits land on `other`, and only on `other`: worktree-checked-out
+    // branches fork directly into the commit they point at, so inserting below `other`
+    // neither rebases `main`/`stack-base` nor drags `feat` along. The placeholder left
+    // where `feat`'s commit sat resolves through to the commit below, so `feat` falls
+    // back onto the base it donated its commit from; `stable` and `target` stay on the
+    // base commit as well.
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
         snapbox::str![[r#"
-* 0529812 (HEAD -> main, stack-base) stack base
-* 9a81bea (other, feat) worktree source
-* 6f6bfe8 workspace source
-* 35b8235 (target, stable) base
+* 4119f49 (HEAD -> main, stack-base) stack base
+| * 9a81bea (other) worktree source
+| * 6f6bfe8 workspace source
+|/  
+* 35b8235 (target, stable, feat) base
 
 "#]]
         .raw()
@@ -1177,7 +1180,7 @@ fn move_mixed_main_and_worktree_commits_to_another_worktree() -> anyhow::Result<
     assert_eq!(
         git_status_at_dir(workdir.join("wt"))?,
         "",
-        "the source linked checkout follows its moved ref"
+        "the source linked checkout follows its moved-out ref cleanly"
     );
     assert_eq!(
         git_status_at_dir(workdir.join("other"))?,
@@ -1185,8 +1188,8 @@ fn move_mixed_main_and_worktree_commits_to_another_worktree() -> anyhow::Result<
         "the destination linked checkout follows its rewritten ref"
     );
     assert!(
-        workdir.join("wt/wt-file").exists(),
-        "`feat` tracks its commit to the destination, so the source linked checkout has it too"
+        !workdir.join("wt/wt-file").exists(),
+        "`feat` stays behind on the base, so its checkout no longer contains the moved-away commit's file"
     );
     assert_eq!(
         std::fs::read_to_string(workdir.join("other/ws-file"))?,

--- a/crates/but/src/utils/merged_upstream.rs
+++ b/crates/but/src/utils/merged_upstream.rs
@@ -67,6 +67,21 @@ impl MergedUpstream {
                 }
             }
         }
+        // A branch checked out in a linked worktree is forked out of the stack
+        // rows entirely and shown only here (see `Graph::worktree_tips` and
+        // `Graph::fork_out_worktree_checkout_refs`), so the loop above never
+        // sees its name. Its classification still lives on the stack segment
+        // that owns the commit, keyed only by commit id now - `integrated_commits`
+        // already has it from the pass above, so a worktree sitting exactly on
+        // one is exactly the merged-upstream case.
+        for worktree in &head_info.worktrees {
+            if worktree.commits.is_empty()
+                && let Some(ref_name) = &worktree.ref_name
+                && this.integrated_commits.contains(&worktree.head)
+            {
+                this.merged_branches.insert(ref_name.clone());
+            }
+        }
         this.collect_merged_empty_branches(repo, head_info);
         this
     }

--- a/crates/but/tests/but/command/commit.rs
+++ b/crates/but/tests/but/command/commit.rs
@@ -3060,13 +3060,14 @@ Hint: run `but help` for all commands
 "#]]);
 }
 
-/// A worktree freshly checked out at a stack branch's tip shares that commit with the
-/// branch, and the editor's shared-ref insert moves both refs: the stack branch
-/// fast-forwards onto the new commit, which thereby enters the workspace. Existing editor
-/// semantics - the TUI's heading gesture and an explicit `-b <worktree>` behave the same -
+/// A worktree freshly checked out at a stack branch's tip starts as its own fork that
+/// merely shares that commit: being checked out is transient state and never couples
+/// identities. So committing from the worktree only fast-forwards its own branch onto
+/// the new commit; the stack branch it forked from stays put. Existing editor semantics,
+/// namely the TUI's heading gesture and an explicit `-b <worktree>`, behave the same;
 /// pinned here so a deliberate change to it shows up.
 #[test]
-fn commit_from_a_worktree_sharing_its_branch_tip_moves_both_refs() {
+fn commit_from_a_worktree_sharing_its_branch_tip_advances_only_the_worktree() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
     env.setup_metadata(&["A", "B"]);
     enable_worktree_manipulation(&env);
@@ -3082,15 +3083,18 @@ Created commit 1 on branch 'wt-feature'
 
 "#]]);
 
-    // Both refs sit on the new commit, which the workspace commit thereby merges.
+    // Only wt-feature advances onto the new commit; A, the branch it forked from,
+    // stays on its old tip.
     snapbox::assert_data_eq!(
         env.git_log(),
         snapbox::str![[r#"
-*   57c3c19 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+*   b963596 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
 |/  
-| * cc2a9bc (wt-feature, A) note from the worktree
-| * 9477ae7 add A
-* | d3e2ba3 (B) add B
+| * d3e2ba3 (B) add B
+| | * cc2a9bc (wt-feature) note from the worktree
+| |/  
+|/|   
+* | 9477ae7 (A) add A
 |/  
 * 0dc3733 (origin/main, origin/HEAD, main, gitbutler/target) add M
 

--- a/crates/but/tests/but/command/commit.rs
+++ b/crates/but/tests/but/command/commit.rs
@@ -2731,8 +2731,6 @@ Created commit 1 on branch 'A'
 ┊╭┄ g0 [A]
 ┊●   1 note from worktree
 ┊│     1:u A note.txt
-┊│
-┊├┄ wt [wt-feature 📁 [..]worktrees/wt-feature]
 ┊┊
 ┊┊╭┄ m {wt-feature} (no changes)
 ┊├╯


### PR DESCRIPTION
```
* refs/heads/gitbutler/workspace
* GitButler Workspace Commit
* refs/heads/foo
| * refs/heads/worktree
|/
* a
```

is preferable to the before 

```
* refs/heads/gitbutler/workspace
* GitButler Workspace Commit
* refs/heads/foo
* refs/heads/worktree
* a
```

because it allows committing beneath the worktree without also moving the `foo` reference, and it also is better aligned with the way we draw the UI in the TUI (and soon lite!)