### PR TITLE
Fix graph segment swaps with existing connections

### DIFF
--- a/crates/but-graph/src/init/walk/mod.rs
+++ b/crates/but-graph/src/init/walk/mod.rs
@@ -1,6 +1,6 @@
 //! Utilities for graph-walking specifically.
 use std::{
-    cmp::Ordering,
+    cmp::{Ordering, Reverse},
     collections::{BTreeMap, BTreeSet},
     ops::Deref,
 };
@@ -345,13 +345,18 @@ pub fn swap_queued_segments(queue: &mut Queue, a: SegmentIndex, b: SegmentIndex)
 
 pub fn swap_commits_and_connections(graph: &mut PetGraph, a: SegmentIndex, b: SegmentIndex) {
     // Connections describe the commits owned by a segment, so they must move with the commits.
-    let connections = graph
+    let touched_sources = graph
         .edge_references()
         .filter(|edge| {
             [edge.source(), edge.target()]
                 .into_iter()
                 .any(|node| node == a || node == b)
         })
+        .map(|edge| edge.source())
+        .collect::<BTreeSet<_>>();
+    let mut connections = graph
+        .edge_references()
+        .filter(|edge| touched_sources.contains(&edge.source()))
         .map(EdgeOwned::from)
         .collect::<Vec<_>>();
     for connection in &connections {
@@ -361,7 +366,7 @@ pub fn swap_commits_and_connections(graph: &mut PetGraph, a: SegmentIndex, b: Se
         let (a, b) = graph.index_twice_mut(a, b);
         std::mem::swap(&mut a.commits, &mut b.commits);
     }
-    for connection in connections {
+    for connection in &mut connections {
         let swap = |node| {
             if node == a {
                 b
@@ -371,11 +376,12 @@ pub fn swap_commits_and_connections(graph: &mut PetGraph, a: SegmentIndex, b: Se
                 node
             }
         };
-        graph.add_edge(
-            swap(connection.source),
-            swap(connection.target),
-            connection.weight,
-        );
+        connection.source = swap(connection.source);
+        connection.target = swap(connection.target);
+    }
+    connections.sort_by_key(|edge| (edge.source, Reverse(edge.weight.parent_order)));
+    for connection in connections {
+        graph.add_edge(connection.source, connection.target, connection.weight);
     }
 }
 

--- a/crates/but-graph/src/init/walk/mod.rs
+++ b/crates/but-graph/src/init/walk/mod.rs
@@ -8,7 +8,7 @@ use std::{
 use anyhow::{Context as _, bail};
 use but_core::{RefMetadata, is_workspace_ref_name, ref_metadata};
 use gix::{hashtable::hash_map::Entry, reference::Category, traverse::commit::Either};
-use petgraph::{Direction, prelude::EdgeRef};
+use petgraph::{Direction, prelude::EdgeRef, visit::IntoEdgeReferences};
 
 use crate::{
     Commit, CommitFlags, CommitIndex, Edge, Graph, Segment, SegmentIndex, SegmentMetadata,
@@ -344,12 +344,38 @@ pub fn swap_queued_segments(queue: &mut Queue, a: SegmentIndex, b: SegmentIndex)
 }
 
 pub fn swap_commits_and_connections(graph: &mut PetGraph, a: SegmentIndex, b: SegmentIndex) {
+    // Connections describe the commits owned by a segment, so they must move with the commits.
+    let connections = graph
+        .edge_references()
+        .filter(|edge| {
+            [edge.source(), edge.target()]
+                .into_iter()
+                .any(|node| node == a || node == b)
+        })
+        .map(EdgeOwned::from)
+        .collect::<Vec<_>>();
+    for connection in &connections {
+        graph.remove_edge(connection.id);
+    }
     {
         let (a, b) = graph.index_twice_mut(a, b);
         std::mem::swap(&mut a.commits, &mut b.commits);
     }
-    if graph.edges(a).next().is_some() || graph.edges(b).next().is_some() {
-        todo!("swap connections of nodes as well")
+    for connection in connections {
+        let swap = |node| {
+            if node == a {
+                b
+            } else if node == b {
+                a
+            } else {
+                node
+            }
+        };
+        graph.add_edge(
+            swap(connection.source),
+            swap(connection.target),
+            connection.weight,
+        );
     }
 }
 

--- a/crates/but-graph/src/init/walk/tests.rs
+++ b/crates/but-graph/src/init/walk/tests.rs
@@ -1,5 +1,51 @@
 use super::*;
 
+#[test]
+fn swapping_commits_also_swaps_incident_connections() {
+    let mut graph = PetGraph::default();
+    let a = graph.add_node(Segment::default());
+    let b = graph.add_node(Segment::default());
+    let before = graph.add_node(Segment::default());
+    let after = graph.add_node(Segment::default());
+    let edge = Edge {
+        src: None,
+        src_id: None,
+        dst: None,
+        dst_id: None,
+        parent_order: 0,
+    };
+    graph.add_edge(before, a, edge);
+    graph.add_edge(a, after, edge);
+    graph.add_edge(b, before, edge);
+
+    swap_commits_and_connections(&mut graph, a, b);
+
+    assert!(
+        graph.find_edge(before, b).is_some(),
+        "incoming connections move from a to b"
+    );
+    assert!(
+        graph.find_edge(b, after).is_some(),
+        "outgoing connections move from a to b"
+    );
+    assert!(
+        graph.find_edge(a, before).is_some(),
+        "connections move from b to a"
+    );
+    assert!(
+        graph.find_edge(before, a).is_none(),
+        "a no longer owns its old incoming connection"
+    );
+    assert!(
+        graph.find_edge(a, after).is_none(),
+        "a no longer owns its old outgoing connection"
+    );
+    assert!(
+        graph.find_edge(b, before).is_none(),
+        "b no longer owns its old outgoing connection"
+    );
+}
+
 fn gtt(generation: Option<u32>, committer_time: u64) -> GenThenTime {
     GenThenTime {
         generation,

--- a/crates/but-graph/src/init/walk/tests.rs
+++ b/crates/but-graph/src/init/walk/tests.rs
@@ -7,6 +7,7 @@ fn swapping_commits_also_swaps_incident_connections() {
     let b = graph.add_node(Segment::default());
     let before = graph.add_node(Segment::default());
     let after = graph.add_node(Segment::default());
+    let other_parent = graph.add_node(Segment::default());
     let edge = Edge {
         src: None,
         src_id: None,
@@ -14,9 +15,18 @@ fn swapping_commits_also_swaps_incident_connections() {
         dst_id: None,
         parent_order: 0,
     };
-    graph.add_edge(before, a, edge);
+    graph.add_edge(
+        before,
+        a,
+        Edge {
+            parent_order: 1,
+            ..edge
+        },
+    );
+    graph.add_edge(before, other_parent, edge);
     graph.add_edge(a, after, edge);
     graph.add_edge(b, before, edge);
+    graph.add_edge(a, b, edge);
 
     swap_commits_and_connections(&mut graph, a, b);
 
@@ -33,6 +43,10 @@ fn swapping_commits_also_swaps_incident_connections() {
         "connections move from b to a"
     );
     assert!(
+        graph.find_edge(b, a).is_some(),
+        "connections directly between swapped segments reverse"
+    );
+    assert!(
         graph.find_edge(before, a).is_none(),
         "a no longer owns its old incoming connection"
     );
@@ -43,6 +57,14 @@ fn swapping_commits_also_swaps_incident_connections() {
     assert!(
         graph.find_edge(b, before).is_none(),
         "b no longer owns its old outgoing connection"
+    );
+    assert_eq!(
+        graph
+            .edges_directed(before, Direction::Outgoing)
+            .map(|edge| edge.weight().parent_order)
+            .collect::<Vec<_>>(),
+        [0, 1],
+        "outgoing connections remain in parent traversal order"
     );
 }
 

--- a/crates/but-graph/src/init/walk/tests.rs
+++ b/crates/but-graph/src/init/walk/tests.rs
@@ -7,7 +7,6 @@ fn swapping_commits_also_swaps_incident_connections() {
     let b = graph.add_node(Segment::default());
     let before = graph.add_node(Segment::default());
     let after = graph.add_node(Segment::default());
-    let other_parent = graph.add_node(Segment::default());
     let edge = Edge {
         src: None,
         src_id: None,
@@ -15,15 +14,7 @@ fn swapping_commits_also_swaps_incident_connections() {
         dst_id: None,
         parent_order: 0,
     };
-    graph.add_edge(
-        before,
-        a,
-        Edge {
-            parent_order: 1,
-            ..edge
-        },
-    );
-    graph.add_edge(before, other_parent, edge);
+    graph.add_edge(before, a, edge);
     graph.add_edge(a, after, edge);
     graph.add_edge(b, before, edge);
     graph.add_edge(a, b, edge);
@@ -58,13 +49,41 @@ fn swapping_commits_also_swaps_incident_connections() {
         graph.find_edge(b, before).is_none(),
         "b no longer owns its old outgoing connection"
     );
+}
+
+#[test]
+fn swapping_connections_preserves_untouched_sibling_parent_order() {
+    let mut graph = PetGraph::default();
+    let a = graph.add_node(Segment::default());
+    let b = graph.add_node(Segment::default());
+    let source = graph.add_node(Segment::default());
+    let other_parent = graph.add_node(Segment::default());
+    let edge = Edge {
+        src: None,
+        src_id: None,
+        dst: None,
+        dst_id: None,
+        parent_order: 0,
+    };
+    graph.add_edge(
+        source,
+        a,
+        Edge {
+            parent_order: 1,
+            ..edge
+        },
+    );
+    graph.add_edge(source, other_parent, edge);
+
+    swap_commits_and_connections(&mut graph, a, b);
+
     assert_eq!(
         graph
-            .edges_directed(before, Direction::Outgoing)
-            .map(|edge| edge.weight().parent_order)
+            .edges_directed(source, Direction::Outgoing)
+            .map(|edge| (edge.target(), edge.weight().parent_order))
             .collect::<Vec<_>>(),
-        [0, 1],
-        "outgoing connections remain in parent traversal order"
+        [(other_parent, 0), (b, 1)],
+        "the swapped connection stays after its untouched sibling"
     );
 }
 


### PR DESCRIPTION
I need this in order to be able to fast-forward the local target (e.g. main) to match the integrated upstream from the target ref (e.g. origin/main).

## Summary

- move incident graph connections when swapping commit ownership between segments
- replace the connected-segment `todo!` panic with the completed swap
- cover incoming and outgoing connections with a focused unit test
