### PR TITLE
Tidy the file lists' scroll affordances

### DIFF
--- a/apps/lite/ui/src/components/ui.module.css
+++ b/apps/lite/ui/src/components/ui.module.css
@@ -30,8 +30,18 @@
 	overscroll-behavior: contain;
 }
 
-/* Shows a separator line at a scroller's top edge while it is scrolled down. */
+/* Shows a separator line at a scroller's top edge while it is scrolled down,
+   and keeps the scrollbar gutter free of a band of its own so rows and
+   scrollbar sit on the same surface, with only the thumb to show for it.
+
+   The two go together: the gutter is reserved, content cannot paint into it,
+   so the sticky line stops a scrollbar's width short of the edge. The track
+   paints that last stretch itself, under the same scroll state, and the two
+   halves appear and disappear as one line. */
 .scrollerWithSeparator {
+	--scrollbar-track-bg: transparent;
+	--scrollbar-track-border: transparent;
+
 	container-type: scroll-state;
 
 	&:before {
@@ -47,6 +57,12 @@
 
 		@container scroll-state(scrollable: top) {
 			opacity: 1;
+		}
+	}
+
+	&::-webkit-scrollbar-track:vertical {
+		@container scroll-state(scrollable: top) {
+			border-top: 1px solid var(--border-section);
 		}
 	}
 }

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.module.css
@@ -39,6 +39,10 @@
 
 	flex-grow: 1;
 
+	/* The ramp below overlays the last rows rather than taking flow space, so
+	   keep rows scrolled into view (e.g. arrow-key navigation) clear of it. */
+	scroll-padding-block-end: var(--scroll-gradient-height);
+
 	/* Gradient ramp that fades out the scrolling items, shown only once the
 	   list has been scrolled away from the top and there is still more content
 	   below. An untouched list shows no ramp. */

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.module.css
@@ -38,29 +38,26 @@
 	--scroll-gradient-height: 14px;
 
 	flex-grow: 1;
-	--scroll-gradient-overlap: 4px;
 
-	/* The sticky gradient below takes up flow space at the end of the content.
-	   Account for it when scrolling rows into view (e.g. arrow-key navigation),
-	   so the last row can reach the true bottom and the gradient fades out. */
-	scroll-padding-block-end: calc(var(--scroll-gradient-height) - var(--scroll-gradient-overlap));
-
-	/* Gradient ramp that fades out the scrolling items, shown only while there
-	   is more content to scroll to below. */
+	/* Gradient ramp that fades out the scrolling items, shown only once the
+	   list has been scrolled away from the top and there is still more content
+	   below. An untouched list shows no ramp. */
 	&::after {
 		display: block;
 		z-index: 1;
 		position: sticky;
 		bottom: 0;
 		height: var(--scroll-gradient-height);
-		margin-block-start: calc(-1 * var(--scroll-gradient-overlap));
+		/* Pulled back by its own height so it claims no flow space and leaves no
+		   gap under the last row; it overlays the content instead. */
+		margin-block-start: calc(-1 * var(--scroll-gradient-height));
 		background: linear-gradient(to top, var(--bg-1) 20%, transparent);
 		content: "";
 		opacity: 0;
 		pointer-events: none;
 		transition: opacity 120ms ease;
 
-		@container scroll-state(scrollable: bottom) {
+		@container scroll-state((scrollable: top) and (scrollable: bottom)) {
 			opacity: 1;
 		}
 	}


### PR DESCRIPTION
Tidy up the scroll affordances on the two file lists — the uncommitted list in the workspace and the file tree in the details pane.

### The fade ramp only shows once you scroll

The gradient at the bottom of the uncommitted list appeared whenever the list overflowed, so an untouched list already showed a fade. It now waits until the list is actually scrolled away from the top (`scrollable: top` *and* `scrollable: bottom`).

Its pseudo-element also only pulled back 4px of its 14px height, leaving a permanent 10px gap under the last row whether or not the ramp was visible. It now cancels its full height, so it claims no flow space and overlays the rows instead. The scroll padding is kept at the ramp's full height so keyboard navigation doesn't park the selected row underneath it.

### The separator runs edge to edge

The scrollbar reserves a gutter that content cannot paint into, so the sticky separator stopped a scrollbar's width short of the panel edge. The gutter's own band and hairline used to make that read as deliberate; on lists whose rows share the panel surface it just looked like a notch.

`.scrollerWithSeparator` now flattens the gutter and has the scrollbar track paint the missing stretch itself, under the same scroll state as the sticky half, so both halves appear and disappear as one line. `.scrollerFlatGutter`, briefly a separate class, was folded in — it had exactly the same two call sites, and the flat gutter is what makes the two-half line necessary in the first place.

`.scroller` keeps its banded gutter by default: the stacks, upstream, and branches lists put `--bg-1` cards on a `--bg-2` panel, where that hairline still marks where the content surface ends.

### Verification

The scrollbar-track half rests on a container query reaching `::-webkit-scrollbar-track:vertical`, which is unusual enough to be worth checking rather than assuming. Rendered the shipped rule verbatim in Chromium with the gutter confirmed reserved (190px client vs 200px offset): nothing at rest, unbroken edge-to-edge line when scrolled. Note that macOS Chrome uses overlay scrollbars by default, so reproducing this needs `-AppleShowScrollBars Always` passed to the browser process — otherwise `::-webkit-scrollbar` never renders and every case looks identical.

Typecheck and Prettier pass. Not yet eyeballed in a running build.