### PR TITLE
TEST — do not merge, do not review

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
@@ -23,8 +23,9 @@
 	display: flex;
 	flex-shrink: 0;
 	align-items: center;
-	height: 44px;
+	height: 64px;
 	padding-inline: var(--panel-padding-inline);
+	background-color: var(--bg-2);
 }
 
 /* Square, and edge to edge in every list that has them: a row's fill is a band


### PR DESCRIPTION
Throwaway pull request to exercise the `lite-screenshots` skill end to end: the ad-hoc capture lane, the git-data-API publishing path, and the `screenshots needed` → `screenshots` label swap.

The diff makes section headers taller and fills them, so the change is unmistakable in a capture. It will be closed and the branch deleted once the run is done.