### PR TITLE
fix(workspace-lists): remove focus outline hack

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.module.css
@@ -68,8 +68,7 @@
 
 .commitForm {
 	margin-inline: var(--panel-padding-inline);
-	margin-block-start: 1px; /* hack to avoid outline crop on focus */
-	margin-block-end: var(--panel-padding-block);
+	margin-block: var(--panel-padding-block);
 }
 
 .stacksPanel {


### PR DESCRIPTION
Use a single `margin-block` declaration for the commit form instead of keeping a 1px top offset hack.

This aligns spacing with the panel padding and removes the workaround that was only there to prevent focus outline cropping.