### PR TITLE
Give the screenshot skill an ad-hoc lane and a truthful label

### DIFF
--- a/.agents/skills/lite-screenshots/SKILL.md
+++ b/.agents/skills/lite-screenshots/SKILL.md
@@ -24,22 +24,53 @@ change is invisible or whether nothing looked at it.
    (currently: workspace sidebar, diff pane, branches tab, upstream tab, project
    picker, uncommitted rows, commit form, settings).
 3. **Covered** — capture, as below.
-4. **Not covered** — stop and ask the developer. Adding a surface edits a shared
-   file and changes what every later pull request captures, so it is their call,
-   not one to make quietly inside a screenshot request. Tell them which screen is
-   uncovered, which fixture would reach it, and that it becomes permanent coverage
-   for everyone.
+4. **Not covered** — stop and ask the developer, offering the two lanes below.
+   Either way it is their call, not one to make quietly inside a screenshot
+   request. Tell them which screen is uncovered and which fixture would reach it.
+   - **Add it to the catalogue** when the gap is a _screen_ — something anyone
+     working nearby will change again. It edits a shared file and becomes
+     permanent coverage for every later pull request. See "Extending the
+     catalogue" below.
+   - **Capture it ad hoc** when the gap is a _state_ — a conflicted commit
+     mid-resolution, an empty list, one specific dialog — that no future pull
+     request is likely to want. Nothing shared changes and nothing is left
+     behind. See "One-off capture" below.
 
-If they decline, **do not post a comment**. A normal comment would report
+   Prefer the catalogue when it is a close call. The ad-hoc lane photographs the
+   change once and protects nothing afterwards, and a catalogue that stops growing
+   makes every later request re-derive the same fixtures.
+
+If they decline both, **do not post a comment**. A normal comment would report
 "N surfaces, 0 changed", which asserts the change is not visual when in truth it
 was never photographed. Say plainly that the affected screen is not in the
 catalogue and no screenshots were taken.
+
+## Changes the capture cannot see
+
+Some diffs are invisible to this harness for reasons that have nothing to do with
+the change being non-visual. Rule these out before reading a "0 changed" result
+as an answer:
+
+- **Scrollbars and their gutter.** macOS hides scrollbars unless a mouse is
+  attached, and a styled `::-webkit-scrollbar` does _not_ override that — the
+  scroller simply reserves no gutter. On a machine set to "When scrolling", any
+  change to the track, thumb, gutter width, or a separator meeting the gutter
+  captures identically on both sides. Set System Settings → Appearance → Show
+  scroll bars → **Always** for the run, and say in the comment that you did.
+- **Hover, focus, and drag states** are not entered by the spec.
+- **Anything behind a scroll position** — surfaces are captured at the top.
 
 ## Prerequisites
 
 - `cargo build -p but` once, giving `target/debug/but`.
 - The branch under test applied, and **not yet merged** — the base side comes
   from unapplying it. Check `but status` first.
+- **Run every capture through `env -u ELECTRON_RUN_AS_NODE`.** An agent hosted
+  inside VS Code (itself Electron) inherits `ELECTRON_RUN_AS_NODE=1`, which makes
+  the Electron the test launches behave as plain Node. Every surface then fails
+  with `Error: Process failed to launch!` and nothing says why — the binary is
+  fine, and running it by hand from another shell works. Check with
+  `env | grep ELECTRON`.
 
 ## The flow
 
@@ -48,7 +79,8 @@ Run every command from the repository root.
 ### 1. Capture the branch as it stands
 
 ```console
-$ SCREENSHOT_OUT=head BUT=$PWD/target/debug/but pnpm -F @gitbutler/lite test:e2e screenshots
+$ env -u ELECTRON_RUN_AS_NODE SCREENSHOT_OUT=head BUT=$PWD/target/debug/but \
+    pnpm -F @gitbutler/lite test:e2e screenshots.spec.ts
 ```
 
 Output lands in `apps/lite/e2e/screenshots/head/` (gitignored).
@@ -58,7 +90,8 @@ Output lands in `apps/lite/e2e/screenshots/head/` (gitignored).
 ```console
 $ but unapply <branch>
 $ but status        # confirm the branch is gone from the workspace
-$ SCREENSHOT_OUT=base BUT=$PWD/target/debug/but pnpm -F @gitbutler/lite test:e2e screenshots
+$ env -u ELECTRON_RUN_AS_NODE SCREENSHOT_OUT=base BUT=$PWD/target/debug/but \
+    pnpm -F @gitbutler/lite test:e2e screenshots.spec.ts
 $ but apply <branch>
 ```
 
@@ -103,15 +136,42 @@ Images go on an orphan `pr-screenshots` branch, under `pr-<number>/<short-sha>/`
 A per-commit directory matters: reusing one path lets GitHub's image proxy serve
 the previous run's screenshots from cache, which reads as "my change did nothing".
 
+Write them with the git data API rather than a local clone. There is nothing to
+clone, nothing to clean up, and no local `git` writes — which agents are often
+not permitted to make outside the project, and which cannot touch the GitButler
+workspace by accident.
+
 ```console
-$ rm -rf /tmp/pub && mkdir /tmp/pub && cd /tmp/pub
-$ git init -q -b pr-screenshots && git remote add origin <repo-url>
-$ git fetch -q --depth 1 origin pr-screenshots && git reset -q --hard origin/pr-screenshots
-$ mkdir -p pr-<number>/<short-sha> && cp -R /tmp/publish/. pr-<number>/<short-sha>/
-$ git add -A && git commit -q -m "Screenshots for #<number>" && git push -q origin pr-screenshots
+$ REPO=<owner>/<repo>; DIR=pr-<number>/<short-sha>
+$ HEAD_SHA=$(gh api repos/$REPO/git/refs/heads/pr-screenshots --jq '.object.sha')
+$ BASE_TREE=$(gh api repos/$REPO/git/commits/$HEAD_SHA --jq '.tree.sha')
+
+# One blob per image. base64 must be stripped of newlines.
+$ jq -n --rawfile c <(base64 -i /tmp/publish/<name>.png) \
+      '{content: ($c | gsub("\n";"")), encoding: "base64"}' > /tmp/blob.json
+$ BLOB=$(gh api -X POST repos/$REPO/git/blobs --input /tmp/blob.json --jq '.sha')
+
+# One tree and one commit for all of them, then move the ref.
+$ jq -n --arg t "$BASE_TREE" --arg b "$BLOB" --arg d "$DIR" '{base_tree: $t, tree: [
+      {path: ($d + "/<name>.png"), mode: "100644", type: "blob", sha: $b}]}' > /tmp/tree.json
+$ TREE=$(gh api -X POST repos/$REPO/git/trees --input /tmp/tree.json --jq '.sha')
+$ jq -n --arg t "$TREE" --arg p "$HEAD_SHA" \
+      '{message: "Screenshots for #<number>", tree: $t, parents: [$p]}' > /tmp/commit.json
+$ COMMIT=$(gh api -X POST repos/$REPO/git/commits --input /tmp/commit.json --jq '.sha')
+$ gh api -X PATCH repos/$REPO/git/refs/heads/pr-screenshots -f sha="$COMMIT"
 ```
 
-The branch may not exist yet; skip the fetch and reset when it does not.
+When the branch does not exist yet, omit `base_tree` and `parents`, then create
+the ref with `POST git/refs -f ref=refs/heads/pr-screenshots -f sha=$COMMIT`.
+
+**Fetch one raw URL before posting.** A comment full of broken images is worse
+than no comment, and the failure is invisible until someone opens the pull
+request:
+
+```console
+$ curl -s -o /dev/null -w '%{http_code}\n' \
+    https://raw.githubusercontent.com/<owner>/<repo>/pr-screenshots/<dir>/<name>.png
+```
 
 ### 5. Post to the pull request
 
@@ -128,12 +188,102 @@ $ gh api -X PATCH "repos/<owner>/<repo>/issues/comments/<id>" --input /tmp/paylo
 Do not edit the pull request description: rewriting text a human owns risks
 clobbering their concurrent edits.
 
+### 6. Swap the label
+
+`screenshots needed` is the request; `screenshots` is the record. Move the pull
+request from one to the other once the comment is posted, so the label says what
+is true:
+
+```console
+$ gh pr edit <number> --remove-label "screenshots needed" --add-label "screenshots"
+```
+
+Only after a comment with images actually went up. A pull request labelled
+`screenshots` with none attached is worse than an unlabelled one — it tells a
+reviewer the change has been shown when it has not. If you declined to post (an
+uncovered surface, a capture that failed), leave `screenshots needed` where it is.
+
+Seeing both labels later is expected, not a bug to tidy away: the labeler re-adds
+`screenshots needed` on the next push, which says a set exists and the code has
+moved since. Recapturing swaps it away again — the command above is idempotent.
+
+If you ever post images that are **not** captures of the running app — a page
+rendered from the branch's CSS, say, when the harness cannot be run — label them
+as such in the comment and mark it `<!-- lite-screenshots-replica -->` instead.
+A reviewer assumes a screenshot is a photograph of the app; anything else has to
+say so, and the different marker keeps a later real run from overwriting it.
+
 ## Before finishing
 
 - **Look at the images**, do not just trust exit codes. A green run proves files
   were written, not that they show the surface.
 - Confirm the workspace is whole: `but status` should show the branch applied and
   no stray uncommitted changes.
+
+## One-off capture
+
+For a state the catalogue should not carry permanently. The run command filters
+by filename, so any spec whose name contains `screenshots` is picked up by the
+same command and writes into the same `SCREENSHOT_OUT` directory — the compare
+step cannot tell the difference.
+
+Write `apps/lite/e2e/tests/screenshots-adhoc.spec.ts`, importing the shared
+helpers rather than copying them (every workaround in them was earned, and a copy
+loses the comments explaining why):
+
+```ts
+import { enabled, openProject, shoot } from "../screenshot-helpers.ts";
+import { test } from "../test.ts";
+
+test.describe("screenshots", () => {
+	test.skip(!enabled, "set SCREENSHOT_OUT to capture screenshots");
+	test.describe.configure({ timeout: 180_000 });
+	test.use({ scenario: "project-in-single-branch-three-branch-stack.sh" });
+
+	test("<surface>", async ({ appWindow }) => {
+		await openProject(appWindow);
+		// ...reach the state...
+		await shoot(appWindow, "<surface-name>", "<selector>");
+	});
+});
+```
+
+The same fixture and selector rules as the catalogue apply — see below.
+
+Then capture both sides as usual, and:
+
+- **Delete the file** once the base run is done. It is untracked and not ignored,
+  so left behind it shows up as a stray change in `but status` and eventually in
+  someone's commit. The "confirm the workspace is whole" check at the end is what
+  catches this.
+- **Say in the comment** that the surface was captured ad hoc and is not covered
+  going forward, so nobody reads it as a regression guarantee.
+
+**Never run the two specs in one command.** The config sets `fullyParallel`, and
+the catalogue spec wipes `SCREENSHOT_OUT` in a `beforeAll` — run concurrently, that
+wipe lands in the middle of the ad-hoc capture and deletes it. What survives is a
+plausible-looking directory missing exactly the surface you were asked for.
+
+The trailing argument is a **substring match on the file path**, so a bare
+`screenshots` selects the ad-hoc spec as well and puts you straight into that race.
+Name the file: `screenshots.spec.ts` for the catalogue, `screenshots-adhoc` for the
+ad-hoc spec. Steps 1 and 2 above already do.
+
+Capture the ad-hoc surface **alone**, filtering to its filename, into its own
+output directory on each side:
+
+```console
+$ env -u ELECTRON_RUN_AS_NODE SCREENSHOT_OUT=adhoc-head BUT=$PWD/target/debug/but \
+    pnpm -F @gitbutler/lite test:e2e screenshots-adhoc
+```
+
+Its own directory also avoids inheriting stale PNGs from an earlier catalogue run,
+since only the catalogue spec cleans up after itself. Then compare
+`adhoc-base` against `adhoc-head` as in step 3.
+
+When a change touches both a covered screen and an uncovered state, run the
+catalogue first and the ad-hoc spec second, in separate commands, pointing both at
+the same directory — that order is safe because only the first one wipes.
 
 ## Extending the catalogue
 

--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -30,6 +30,13 @@ CLI:
 
 # Drives the Lite UI Screenshots workflow. Applying it by hand opts a change in
 # that this rule does not cover, such as a layout change with no CSS in it.
-screenshots:
+#
+# This label is a request, not a record: it says screenshots are wanted, and the
+# `lite-screenshots` skill swaps it for `screenshots` once they are posted.
+#
+# The labeler runs on every push, so a later commit re-adds it alongside
+# `screenshots` — which is the honest reading: a set was posted, and the code has
+# moved since. Recapturing swaps it away again.
+"screenshots needed":
   - changed-files:
       - any-glob-to-any-file: apps/lite/ui/**/*.css

--- a/.github/workflows/lite-screenshots.yml
+++ b/.github/workflows/lite-screenshots.yml
@@ -42,12 +42,12 @@ jobs:
   remind:
     needs: changes
     # The paths filter is not redundant with the label. pr-labeler applies
-    # `screenshots` using GITHUB_TOKEN, and GitHub does not start workflow runs
+    # `screenshots needed` using GITHUB_TOKEN, and GitHub does not start workflow runs
     # from token-generated events — so an auto-applied label fires nothing. Only
     # a human applying it does. The filter is what makes this run on its own.
     if: >-
       github.event.pull_request.head.repo.full_name == github.repository &&
-      (contains(github.event.pull_request.labels.*.name, 'screenshots') ||
+      (contains(github.event.pull_request.labels.*.name, 'screenshots needed') ||
        needs.changes.outputs.css == 'true')
     runs-on: ubuntu-latest
     permissions:
@@ -70,14 +70,16 @@ jobs:
           fi
           cat > /tmp/comment.md <<EOF
           ${marker}
-          This pull request changes Lite's UI. Before/after screenshots make it
-          reviewable without checking the branch out.
+          This pull request changes Lite's UI, so it is labelled
+          \`screenshots needed\`. Before/after screenshots make it reviewable
+          without checking the branch out.
 
-          To attach them, ask your agent for the \`lite-screenshots\` skill — it
-          captures both sides against seeded fixtures, publishes the surfaces that
-          changed, and posts them here.
+          Attach them however you like — drag images straight into a comment, or
+          have an agent capture them for you (the \`lite-screenshots\` skill in
+          this repository does it against seeded fixtures).
 
-          Remove the \`screenshots\` label if this change is not visual.
+          Swap the label for \`screenshots\` once they are posted, or remove it if
+          this change is not visual.
           EOF
           gh api -X POST "repos/${REPO}/issues/${PR}/comments" \
             --input <(jq -Rs '{body: .}' /tmp/comment.md) --silent

--- a/apps/lite/e2e/screenshot-helpers.ts
+++ b/apps/lite/e2e/screenshot-helpers.ts
@@ -1,0 +1,91 @@
+// Shared machinery for the screenshot specs: where captures land, how a surface
+// is photographed, and how one is reached at all.
+//
+// It lives apart from `tests/screenshots.spec.ts` so a throwaway spec can import
+// it — see the `lite-screenshots` skill on capturing a surface the catalogue
+// does not cover. Every workaround in here was earned; copying it into an ad-hoc
+// file loses the comments explaining why.
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import type { Page } from "@playwright/test";
+import { expect } from "./test.ts";
+
+const out = process.env.SCREENSHOT_OUT;
+export const enabled = out !== undefined && out !== "";
+
+// A wide-but-ordinary window, so panes are laid out the way a reviewer sees them.
+export const VIEWPORT = { width: 1440, height: 900 };
+
+export const outputDir = path.resolve(import.meta.dirname, "./screenshots", out ?? "unused");
+
+export const shoot = async (appWindow: Page, name: string, selector: string): Promise<void> => {
+	const target = appWindow.locator(selector);
+	await expect(target).toBeVisible();
+	// Let transitions and any late layout settle before the shutter.
+	await appWindow.waitForTimeout(400);
+
+	const box = await target.boundingBox();
+	if (box === null) throw new Error(`${name}: ${selector} has no bounding box`);
+
+	// Capture over the DevTools protocol rather than through page.screenshot().
+	// Playwright waits for the compositor to hand it a fresh frame, and under a
+	// bare X server this renderer only produces one on load, so that wait never
+	// returns for a surface reached any other way. CDP takes what is on screen.
+	const session = await appWindow.context().newCDPSession(appWindow);
+	try {
+		const shot = (await session.send("Page.captureScreenshot", {
+			format: "png",
+			clip: { x: box.x, y: box.y, width: box.width, height: box.height, scale: 1 },
+		})) as { data: string };
+		// Not only the catalogue spec writes here: an ad-hoc spec points
+		// SCREENSHOT_OUT at a directory nothing has created yet.
+		mkdirSync(outputDir, { recursive: true });
+		writeFileSync(path.join(outputDir, `${name}.png`), Buffer.from(shot.data, "base64"));
+	} finally {
+		await session.detach();
+	}
+};
+
+export const openProject = async (appWindow: Page): Promise<void> => {
+	await expect(appWindow).toHaveURL(/\/project\/[^/]+\/workspace/);
+	await expect(appWindow.getByRole("button", { name: /select project/i })).toBeVisible();
+	await appWindow.setViewportSize(VIEWPORT);
+
+	// On CI the renderer the window starts with sometimes never produces a frame
+	// ("sandboxed_renderer.bundle.js script failed to run"), and a screenshot then
+	// waits for a paint that never arrives. Reloading gets a renderer that works.
+	await appWindow.reload();
+	await appWindow.getByRole("main").waitFor();
+	await expect(appWindow.getByRole("button", { name: /select project/i })).toBeVisible();
+};
+
+// Under a bare X server the renderer only paints a capturable frame on load: a
+// screenshot taken after an in-app state change waits for a frame that never
+// arrives. So every surface is reached by navigating or reloading, never by
+// clicking, and is photographed immediately afterwards — which is also why each
+// surface gets its own test rather than sharing a window.
+export const goToTab = async (
+	appWindow: Page,
+	tab: "workspace" | "upstream" | "branches",
+): Promise<void> => {
+	// The sidebar page lives in the query string, so this is a real navigation.
+	await appWindow.evaluate((page) => {
+		window.location.search = page === "workspace" ? "" : `?page=${page}`;
+	}, tab);
+	await appWindow.getByRole("main").waitFor();
+	// Navigating alone leaves the renderer without a frame a screenshot can take;
+	// only an explicit reload reliably produces one.
+	await appWindow.reload();
+	await appWindow.getByRole("main").waitFor();
+	await expect(appWindow.getByRole("button", { name: /select project/i })).toBeVisible();
+
+	// Assert the tab actually changed. Every other post-condition here is present
+	// on all three tabs, so without this a navigation that silently stayed put
+	// would write the workspace panel into branches-tab.png and pass. The
+	// workspace is the absence of the parameter, so it is asserted the other way
+	// round — `toContain("")` would pass on any tab at all.
+	const search = async (): Promise<string> => new URL(appWindow.url()).search;
+	if (tab === "workspace") await expect.poll(search).not.toContain("page=");
+	else await expect.poll(search).toContain(`page=${tab}`);
+};

--- a/apps/lite/e2e/tests/screenshots.spec.ts
+++ b/apps/lite/e2e/tests/screenshots.spec.ts
@@ -3,7 +3,7 @@
 // Opt-in: this spec is skipped unless SCREENSHOT_OUT names an output directory,
 // so ordinary `test:e2e` runs (including CI) are unaffected.
 //
-//   SCREENSHOT_OUT=after pnpm -F @gitbutler/lite test:e2e screenshots
+//   SCREENSHOT_OUT=after pnpm -F @gitbutler/lite test:e2e screenshots.spec.ts
 //
 // Every surface is captured on every run. Deciding which ones actually changed
 // is the caller's job: pairs that are byte-identical between two runs did not
@@ -12,80 +12,8 @@
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import type { Page } from "@playwright/test";
+import { enabled, goToTab, openProject, outputDir, shoot } from "../screenshot-helpers.ts";
 import { expect, test } from "../test.ts";
-
-const out = process.env.SCREENSHOT_OUT;
-const enabled = out !== undefined && out !== "";
-
-// A wide-but-ordinary window, so panes are laid out the way a reviewer sees them.
-const VIEWPORT = { width: 1440, height: 900 };
-
-const outputDir = path.resolve(import.meta.dirname, "../screenshots", out ?? "unused");
-
-const shoot = async (appWindow: Page, name: string, selector: string): Promise<void> => {
-	const target = appWindow.locator(selector);
-	await expect(target).toBeVisible();
-	// Let transitions and any late layout settle before the shutter.
-	await appWindow.waitForTimeout(400);
-
-	const box = await target.boundingBox();
-	if (box === null) throw new Error(`${name}: ${selector} has no bounding box`);
-
-	// Capture over the DevTools protocol rather than through page.screenshot().
-	// Playwright waits for the compositor to hand it a fresh frame, and under a
-	// bare X server this renderer only produces one on load, so that wait never
-	// returns for a surface reached any other way. CDP takes what is on screen.
-	const session = await appWindow.context().newCDPSession(appWindow);
-	try {
-		const shot = (await session.send("Page.captureScreenshot", {
-			format: "png",
-			clip: { x: box.x, y: box.y, width: box.width, height: box.height, scale: 1 },
-		})) as { data: string };
-		writeFileSync(path.join(outputDir, `${name}.png`), Buffer.from(shot.data, "base64"));
-	} finally {
-		await session.detach();
-	}
-};
-
-const openProject = async (appWindow: Page): Promise<void> => {
-	await expect(appWindow).toHaveURL(/\/project\/[^/]+\/workspace/);
-	await expect(appWindow.getByRole("button", { name: /select project/i })).toBeVisible();
-	await appWindow.setViewportSize(VIEWPORT);
-
-	// On CI the renderer the window starts with sometimes never produces a frame
-	// ("sandboxed_renderer.bundle.js script failed to run"), and a screenshot then
-	// waits for a paint that never arrives. Reloading gets a renderer that works.
-	await appWindow.reload();
-	await appWindow.getByRole("main").waitFor();
-	await expect(appWindow.getByRole("button", { name: /select project/i })).toBeVisible();
-};
-
-// Under a bare X server the renderer only paints a capturable frame on load: a
-// screenshot taken after an in-app state change waits for a frame that never
-// arrives. So every surface is reached by navigating or reloading, never by
-// clicking, and is photographed immediately afterwards — which is also why each
-// surface gets its own test rather than sharing a window.
-const goToTab = async (
-	appWindow: Page,
-	tab: "workspace" | "upstream" | "branches",
-): Promise<void> => {
-	// The sidebar page lives in the query string, so this is a real navigation.
-	await appWindow.evaluate((page) => {
-		window.location.search = page === "workspace" ? "" : `?page=${page}`;
-	}, tab);
-	await appWindow.getByRole("main").waitFor();
-	// Navigating alone leaves the renderer without a frame a screenshot can take;
-	// only an explicit reload reliably produces one.
-	await appWindow.reload();
-	await appWindow.getByRole("main").waitFor();
-	await expect(appWindow.getByRole("button", { name: /select project/i })).toBeVisible();
-
-	// Assert the tab actually changed. Every other post-condition here is present
-	// on all three tabs, so without this a navigation that silently stayed put
-	// would write the workspace panel into branches-tab.png and pass.
-	const expected = tab === "workspace" ? "" : `page=${tab}`;
-	await expect.poll(async () => new URL(appWindow.url()).search).toContain(expected);
-};
 
 test.describe("screenshots", () => {
 	test.skip(!enabled, "set SCREENSHOT_OUT to capture screenshots");


### PR DESCRIPTION
Corrections to the `lite-screenshots` skill, each from hitting the limit in practice while screenshotting #15462 and then dry-running the whole flow on a throwaway draft PR.

### Publishing no longer needs a local clone

The documented flow was `git init` + `git remote add` + `push` into a temp directory. An agent is often not permitted to make local git writes outside the project, and that denial dead-ends the run *after* the images exist. It now writes them with the git data API — blobs, one tree, one commit, move the ref — and fetches a raw URL before commenting, because a comment full of broken images is worse than no comment and the failure is invisible until someone opens the PR.

### A surface outside the catalogue can be captured without extending it

Previously the only option was adding the surface permanently, which is right for a *screen* and heavy for a *state* nobody else will want. The capture helpers move to `apps/lite/e2e/screenshot-helpers.ts` so a throwaway spec can import them rather than copy the bare-X-server workarounds without the comments explaining them. The skill now documents both lanes and steers to the catalogue on close calls.

### The label says what is true

`screenshots` read as a record when it was a request. CI now asks with `screenshots needed`, and it becomes `screenshots` once a comment with images actually goes up — never before, and not at merge. A later push re-adds `screenshots needed` alongside it, which is the honest reading: a set exists and the code has moved since.

The reminder comment is reworded to match. It names the label as state rather than as an instruction, and leaves the method open — drag images into a comment, or have an agent capture them — instead of presenting the skill as the only way to satisfy it.

### Blind spots and traps, now written down

- `ELECTRON_RUN_AS_NODE=1` is inherited by any agent hosted inside VS Code, which makes the Electron under test behave as plain Node. Every surface fails with `Error: Process failed to launch!` and nothing says why — the binary is fine and works from another shell. All capture commands now run through `env -u`.
- macOS hides scrollbars unless a mouse is attached, and a styled `::-webkit-scrollbar` does not override it. Any gutter or track change then captures identically on both sides and reports "0 changed", which reads as "not visual".
- The trailing argument to `test:e2e` is a substring match on the path, so a bare `screenshots` selects the ad-hoc spec too — and with `fullyParallel` the catalogue's `beforeAll` wipe deletes the ad-hoc capture mid-run. Commands now name the file.

### Verification

Dry-run end to end on a throwaway draft PR (#15465, since closed): 8 surfaces captured per side in ~20s, `changed=8`, 16 images published through the new API path with raw URLs checked, comment posted, label swapped `screenshots needed` → `screenshots`, branch unapplied and re-applied with the tree clean afterwards.

Review findings all fixed and each verified rather than assumed: the filter split (`screenshots.spec.ts` selects 8 tests in 1 file, bare `screenshots` selects 9 in 2), the ad-hoc lane writing into a directory nothing created (`shoot` now makes it), and the catalogue still passing 8/8 with the corrected tab assertion — `toContain("")` passed on any tab at all, so a navigation that stayed put would have been photographed as the workspace.
