### PR TITLE
Tag the designer on Lite visual changes

### DIFF
--- a/.github/workflows/lite-screenshots.yml
+++ b/.github/workflows/lite-screenshots.yml
@@ -1,7 +1,8 @@
 name: Lite UI Screenshots
 
 # Reminds a pull request that touches Lite's UI to attach before/after
-# screenshots, and does nothing else.
+# screenshots, tagging the designer so a visual change does not go by unseen.
+# It renders nothing itself.
 #
 # Capturing them in CI was tried and abandoned: under the bare X server on the
 # Linux runners this Electron build paints a frame on load and not reliably
@@ -56,6 +57,11 @@ jobs:
       PR: ${{ github.event.pull_request.number }}
       REPO: ${{ github.repository }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      AUTHOR: ${{ github.event.pull_request.user.login }}
+      # Who to tag on Lite's visual changes. One name, in one place, to change.
+      # A mention, not a review request: it says a visual change landed here
+      # without putting the pull request in anyone's review queue.
+      DESIGNER: PavelLaptev
     steps:
       # One comment, posted once. Nothing here edits or re-posts on later pushes:
       # a reminder that repeats is a reminder people mute.
@@ -81,6 +87,10 @@ jobs:
           Swap the label for \`screenshots\` once they are posted, or remove it if
           this change is not visual.
           EOF
+          # No point tagging them on their own pull request.
+          if [ "${AUTHOR}" != "${DESIGNER}" ]; then
+            printf '\ncc @%s — visual change.\n' "${DESIGNER}" >> /tmp/comment.md
+          fi
           gh api -X POST "repos/${REPO}/issues/${PR}/comments" \
             --input <(jq -Rs '{body: .}' /tmp/comment.md) --silent
           echo "Asked for screenshots on #${PR}."


### PR DESCRIPTION
The reminder workflow tells a pull request that screenshots are wanted, but says nothing to the person who would want to look at them — so a visual change can sit there fully labelled and still go unseen.

This adds a mention to the comment it already posts:

> cc @PavelLaptev — visual change.

Skipped when they opened the pull request themselves, since tagging someone on their own work is pure noise. It rides on the existing comment, which is posted exactly once, so later pushes stay quiet.

### A mention, not a review request

I built the review-request version first (`POST /pulls/{n}/requested_reviewers`) and backed it out. A review request puts the pull request in someone's queue and shows up as blocking work; the intent here is narrower — say a visual change landed, and let them decide whether to look. The mention notifies without the queue.

That also drops the machinery the request version needed: a `ready_for_review` trigger so a draft would not miss its request, a `draft == false` guard, and two API calls per run to avoid re-requesting a review already given.

### On the guard that would have shipped broken

The abandoned version checked `[.requested_reviewers[].login] | index($login)` against the string `"null"`. Run against a real pull request, `index` prints **nothing** when the login is absent — so the empty string compared unequal to `"null"`, the guard inverted, and it would have skipped requesting a review every single time while reporting success.

Worth recording because the surviving code is small and looks obvious: the fix was `any(...)`, which prints a real `true`/`false`, verified against a pull request with no reviews (`false`) and one with a review (`true`). Similarly `--slurp` cannot be combined with `gh`'s own `--jq`, and `--paginate --jq` emits one result *per page* — so a two-page result would have printed `false\nfalse` and never matched anything.

### Verification

The comment assembly was dry-run locally with the same heredoc and append the workflow uses; output is the body above with the mention as its own trailing paragraph. Prettier passes.

Not verified: the workflow itself has not run, since it can only run once this is on a pull request. Its behaviour on that first run is the thing to watch.