### PR TITLE
Navigate to deep links instead of reloading the window

### DIFF
--- a/apps/lite/e2e/tests/deep-links.spec.ts
+++ b/apps/lite/e2e/tests/deep-links.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "../test.ts";
+
+type ProbedWindow = Window & { deepLinkProbe?: boolean };
+
+test.use({ scenario: "project-with-remote-branches.sh" });
+
+test("a deep link navigates the open window instead of reloading it", async ({
+	appWindow,
+	electronApp,
+}) => {
+	await expect(appWindow).toHaveURL(/\/project\/[^/]+\/workspace$/);
+	const workspacePath = new URL(appWindow.url()).pathname;
+
+	// Only a page load clears this, so it is what tells a navigation from a reload.
+	await appWindow.evaluate(() => {
+		(window as ProbedWindow).deepLinkProbe = true;
+	});
+
+	await electronApp.evaluate(({ app }, link) => {
+		app.emit("open-url", { preventDefault: () => undefined }, link);
+	}, `but://app${workspacePath}?page=branches`);
+
+	await expect(appWindow).toHaveURL(/[?&]page=branches/);
+	await expect(appWindow.getByText("Recent branches")).toBeVisible();
+	expect(await appWindow.evaluate(() => (window as ProbedWindow).deepLinkProbe)).toBe(true);
+});

--- a/apps/lite/electron/src/endpoint-table.ts
+++ b/apps/lite/electron/src/endpoint-table.ts
@@ -10,7 +10,7 @@ import { exposedEndpoints, type Endpoint, type LiteElectronApi, type PayloadFor 
  */
 
 /** Members the renderer implements itself; they have no host-side handler. */
-type RendererOnlyKey = "onAskpassPrompt" | "onFullScreenChange" | "platform";
+type RendererOnlyKey = "onAskpassPrompt" | "onDeepLink" | "onFullScreenChange" | "platform";
 
 /** Handlers needing the transport event itself, or taking variadic arguments. */
 type ImperativeKey =

--- a/apps/lite/electron/src/ipc.ts
+++ b/apps/lite/electron/src/ipc.ts
@@ -18,6 +18,8 @@ export type LiteElectronApi = {
 	onAskpassPrompt: (callback: (event: AskpassPromptEvent) => void) => () => void;
 	askpassSubmitPromptResponse: (params: AskpassSubmitPromptResponseParams) => Promise<void>;
 	clipboardWriteText: (text: string) => Promise<void>;
+	/** A `but://app/...` link the app was asked to open, as an in-app path. */
+	onDeepLink: (callback: (path: string) => void) => () => void;
 	getAiConfiguration: () => Promise<AiConfiguration>;
 	getVersion: () => Promise<string>;
 	isFullScreen: () => Promise<boolean>;
@@ -54,6 +56,7 @@ export const localEndpoints = [
 	"askpassPrompt",
 	"askpassSubmitPromptResponse",
 	"clipboardWriteText",
+	"deepLink",
 	"fullScreenChange",
 	"getVersion",
 	"isFullScreen",

--- a/apps/lite/electron/src/lite-api.ts
+++ b/apps/lite/electron/src/lite-api.ts
@@ -18,6 +18,7 @@ type LiteApiTransport = {
 /** API members implemented below rather than forwarded. */
 type SpecialKey =
 	| "onAskpassPrompt"
+	| "onDeepLink"
 	| "onFullScreenChange"
 	| "platform"
 	| "streamAiResponse"
@@ -28,6 +29,7 @@ type SpecialKey =
 /** The same members under their endpoint names; `platform` has no channel at all. */
 const specialNames = [
 	"askpassPrompt",
+	"deepLink",
 	"fullScreenChange",
 	"streamAiResponse",
 	"watcherSubscribe",
@@ -77,6 +79,10 @@ export const createLiteApi = ({
 		onAskpassPrompt: (callback) =>
 			subscribe("askpassPrompt", (payload) => {
 				callback(payload as AskpassPromptEvent);
+			}),
+		onDeepLink: (callback) =>
+			subscribe("deepLink", (payload) => {
+				callback(payload as string);
 			}),
 		onFullScreenChange: (callback) =>
 			subscribe("fullScreenChange", (payload) => {

--- a/apps/lite/electron/src/main.ts
+++ b/apps/lite/electron/src/main.ts
@@ -369,11 +369,12 @@ const registerIpcHandlers = (): void => {
 };
 
 /**
- * A `but://app/...` link, translated to whatever this build actually serves:
- * the dev server in development, our own scheme when packaged. Returns null
- * for anything that is not one of our links.
+ * Where a `but://app/...` link points, in both forms a window can take it:
+ * `url` for one that has to load the page (the dev server in development, our
+ * own scheme when packaged), `path` for one whose router can just navigate
+ * there. Null for anything that is not one of our links.
  */
-const deepLinkTargetUrl = (link: string): string | null => {
+const deepLinkTarget = (link: string): { url: string; path: string } | null => {
 	const url = newUrlOrNull(link);
 	if (
 		url === null ||
@@ -391,7 +392,7 @@ const deepLinkTargetUrl = (link: string): string | null => {
 	// having checked out says nothing about where this one points.
 	if (target.protocol !== base.protocol || target.host !== base.host) return null;
 
-	return target.href;
+	return { url: target.href, path: `${target.pathname}${target.search}` };
 };
 
 /**
@@ -421,8 +422,10 @@ const showAndFocusWindow = (window: BrowserWindow): void => {
 
 /**
  * Open a deep link in the window we already have, or start one if the app was
- * launched by the link. The project it names is checked by the route itself,
- * which covers every other way a URL arrives too.
+ * launched by the link. A running window navigates to the link rather than
+ * reloading the page, so the app keeps its state and its history. The project
+ * the link names is checked by the route itself, which covers every other way
+ * a URL arrives too.
  */
 const openDeepLink = async (link: string): Promise<void> => {
 	const url = newUrlOrNull(link);
@@ -432,7 +435,7 @@ const openDeepLink = async (link: string): Promise<void> => {
 		return;
 	}
 
-	const target = deepLinkTargetUrl(link);
+	const target = deepLinkTarget(link);
 	if (target === null) {
 		// oxlint-disable-next-line no-console
 		console.error(`Ignored deep link ${link}`);
@@ -441,12 +444,20 @@ const openDeepLink = async (link: string): Promise<void> => {
 
 	const [existing] = BrowserWindow.getAllWindows();
 	if (!existing) {
-		await createMainWindow(target);
+		await createMainWindow(target.url);
 		return;
 	}
 
 	showAndFocusWindow(existing);
-	await existing.loadURL(target);
+
+	// A page still loading has no listener yet, so it has to be given the link
+	// as the page to load.
+	if (existing.webContents.isLoading()) {
+		await existing.loadURL(target.url);
+		return;
+	}
+
+	existing.webContents.send("deepLink", target.path);
 };
 
 /** The `but://` link in a launch argv, if the OS started us with one. */
@@ -632,7 +643,7 @@ void app.whenReady().then(async () => {
 	if (launchUrl?.protocol === `${liteProtocolScheme}:`) await completeLogin(launchUrl);
 
 	await createMainWindow(
-		launchLink === undefined ? undefined : (deepLinkTargetUrl(launchLink) ?? undefined),
+		launchLink === undefined ? undefined : (deepLinkTarget(launchLink)?.url ?? undefined),
 	);
 
 	app.on("activate", () => {

--- a/apps/lite/ui/src/main.tsx
+++ b/apps/lite/ui/src/main.tsx
@@ -62,6 +62,15 @@ focusManager.setEventListener((setFocused) => {
 
 const router = createAppRouter(queryClient, routeTree);
 
+// A link opened while the app is running is a navigation, not a page load: the
+// main process hands over the path it names and the router goes there, keeping
+// the state and the history the window already has. `href` is the option for a
+// path built elsewhere: the router splits it and parses the query with the
+// app's own parseSearch, so there is nothing to take apart here.
+window.lite.onDeepLink((path) => {
+	void router.navigate({ href: path });
+});
+
 const rootElement = document.getElementById("root");
 if (!rootElement) throw new Error("Root element not found");
 


### PR DESCRIPTION
A `but://app/...` link arriving at a running app called `loadURL`, which throws the page away and rebuilds it. It now navigates instead, the same as following a link inside the app.

- Main sends the link's in-app path over a `deepLink` channel and the renderer's router goes there, so the window keeps its state and its history.
- `deepLinkTarget` (was `deepLinkTargetUrl`) returns both forms of the destination: `url` for a window that has to load a page, `path` for one that can navigate. Origin checks unchanged.
- A page still loading has no listener yet, so it still gets `loadURL`.
- `onDeepLink` rides the same wiring as the `fullScreenChange` event next to it.

### Verified

Fired at the dev app's main process, standing in for the OS:

```js
app.emit("open-url", { preventDefault() {} }, "but://app/project/<id>/workspace?page=branches")
```

- It switched project and page, and a marker set on the page beforehand was still there — so no document load.
- An unknown project id still redirects in-app; `but://app//evil.example.com/steal` is still ignored.
- New e2e test does the same: mark the page, fire the link, check the url changed and the marker survived.