### PR TITLE
Add root demos:lite script for Lite storybook

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 		"dev:ui": "pnpm --filter @gitbutler/ui storybook",
 		"dev:web": "turbo watch --filter @gitbutler/web dev",
 		"dev:lite": "turbo watch --filter @gitbutler/lite dev",
+		"demos:lite": "pnpm --filter @gitbutler/lite demos",
 		"dev:desktop": "cross-env CARGO_TARGET_DIR=\"$PNPM_SCRIPT_SRC_DIR/target/tauri\" pnpm dev:desktop-with-env",
 		"dev:desktop-http": "cross-env VITE_BUTLER_PORT=6978 VITE_BUTLER_HOST=localhost VITE_BUILD_TARGET=web turbo watch dev --filter=...@gitbutler/desktop",
 		"dev:desktop-with-env": "cargo build -p but && cargo build -p gitbutler-git && node ./scripts/run-desktop-tauri-with-env.mjs development pnpm tauri dev",


### PR DESCRIPTION
Running Lite's Storybook previously required cd-ing into `apps/lite/` and running `pnpm demos`. This adds a root-level `demos:lite` script so it can be launched the same way as `pnpm dev:lite`.

Uses `pnpm --filter` rather than `turbo watch` since `demos` is not a turbo task (Storybook has its own watcher), matching how `dev:ui` is wired.