### PR TITLE
Fix discarding a checked-out empty top branch

### DIFF
--- a/crates/but-rebase/src/graph_rebase/commit.rs
+++ b/crates/but-rebase/src/graph_rebase/commit.rs
@@ -8,7 +8,7 @@ use gix::prelude::ObjectIdExt;
 use crate::{
     commit::{DateMode, create},
     graph_rebase::{
-        Editor, Pick, Selector, Step, ToCommitSelector, ToReferenceSelector,
+        Editor, LookupStep as _, Pick, Selector, Step, ToCommitSelector, ToReferenceSelector,
         util::collect_ordered_parents,
     },
 };
@@ -33,6 +33,52 @@ impl<M: RefMetadata> Editor<'_, '_, M> {
                 super::Checkout::Worktree { .. } => {}
             }
         }
+    }
+
+    /// Move this editor's `HEAD` checkout to the first surviving parent reference.
+    pub fn retarget_head_checkout_to_parent_reference(
+        &mut self,
+        from: impl ToReferenceSelector,
+    ) -> Result<()> {
+        let from = self
+            .history
+            .normalize_selector(from.to_reference_selector(self)?)?;
+        let Some((head_checkout_idx, head_selector)) =
+            self.checkouts
+                .iter()
+                .enumerate()
+                .find_map(|(idx, checkout)| match checkout {
+                    super::Checkout::Head { selector, .. } => Some((idx, *selector)),
+                    super::Checkout::Worktree { .. } => None,
+                })
+        else {
+            return Ok(());
+        };
+        if self.history.normalize_selector(head_selector)? != from {
+            return Ok(());
+        }
+
+        let mut candidates = self.direct_parents(from)?;
+        candidates.sort_by_key(|(_, order)| std::cmp::Reverse(*order));
+        while let Some((candidate, _)) = candidates.pop() {
+            match self.lookup_step(candidate)? {
+                Step::Reference { .. } => {
+                    if let super::Checkout::Head { selector, .. } =
+                        &mut self.checkouts[head_checkout_idx]
+                    {
+                        *selector = candidate;
+                    }
+                    return Ok(());
+                }
+                Step::None => {
+                    let mut parents = self.direct_parents(candidate)?;
+                    parents.sort_by_key(|(_, order)| std::cmp::Reverse(*order));
+                    candidates.extend(parents);
+                }
+                Step::Pick(_) => {}
+            }
+        }
+        Ok(())
     }
 
     /// Like [`Self::set_merge_base_override()`], but for the checkout of the linked

--- a/crates/but-transaction/src/lib.rs
+++ b/crates/but-transaction/src/lib.rs
@@ -341,6 +341,7 @@ where
     pub fn remove_reference(&mut self, ref_name: &FullNameRef) -> anyhow::Result<()> {
         self.rebase(|mut editor, _| {
             let ref_selector = editor.select_reference(ref_name)?;
+            editor.retarget_head_checkout_to_parent_reference(ref_selector)?;
 
             let must_disconnect_child = 'must_disconnect: {
                 let Some(target_selector) = editor.target_selector() else {

--- a/crates/but/tests/but/command/discard.rs
+++ b/crates/but/tests/but/command/discard.rs
@@ -1,4 +1,5 @@
 use bstr::ByteSlice;
+use but_core::RefMetadata;
 
 use crate::{
     command::util::{self, commit_file_with_worktree_changes_as_two_hunks},
@@ -891,4 +892,84 @@ Discarded uncommitted changes from src/discard-me.ts
 Hint: run `but help` for all commands
 
 "#]]);
+}
+
+#[test]
+fn discards_checked_out_empty_top_branch_in_single_branch_mode() {
+    let env = Sandbox::open_with_default_settings("one-fork");
+    env.but("config feature single-branch enable")
+        .assert()
+        .success();
+    let main_before = env.invoke_git("rev-parse main");
+
+    env.but("branch new top --anchor main").assert().success();
+    assert_eq!(
+        env.invoke_git("symbolic-ref --short HEAD"),
+        "top",
+        "creating an empty dependent top branch should check it out"
+    );
+
+    env.but("discard top").assert().success();
+
+    let repo = env.open_repo();
+    assert!(
+        repo.try_find_reference("refs/heads/top").unwrap().is_none(),
+        "discard should remove only the selected branch"
+    );
+    assert_eq!(
+        env.invoke_git("symbolic-ref --short HEAD"),
+        "main",
+        "HEAD should move to the surviving branch below"
+    );
+    assert_eq!(
+        env.invoke_git("rev-parse main"),
+        main_before,
+        "discarding an empty branch should preserve commits"
+    );
+    assert_eq!(
+        env.invoke_git("status --porcelain"),
+        "",
+        "discard should leave a clean worktree"
+    );
+
+    let ctx = env.context();
+    let main = gix::refs::FullName::try_from("refs/heads/main").unwrap();
+    assert_eq!(
+        ctx.meta()
+            .unwrap()
+            .branch_stack_order(main.as_ref())
+            .unwrap(),
+        None,
+        "discard should remove the obsolete branch-order entry"
+    );
+    env.but("status").assert().success();
+}
+
+#[test]
+fn discards_checked_out_empty_branches_regardless_of_argument_order() {
+    let env = Sandbox::open_with_default_settings("one-fork");
+    env.but("config feature single-branch enable")
+        .assert()
+        .success();
+    env.but("branch new middle --anchor main")
+        .assert()
+        .success();
+    env.but("branch new top --anchor middle").assert().success();
+    assert_eq!(env.invoke_git("symbolic-ref --short HEAD"), "top");
+
+    env.but("discard middle top").assert().success();
+
+    let repo = env.open_repo();
+    for branch in ["middle", "top"] {
+        let ref_name = format!("refs/heads/{branch}");
+        assert!(
+            repo.try_find_reference(ref_name.as_str())
+                .unwrap()
+                .is_none(),
+            "discard should remove {branch}"
+        );
+    }
+    assert_eq!(env.invoke_git("symbolic-ref --short HEAD"), "main");
+    assert_eq!(env.invoke_git("status --porcelain"), "");
+    env.but("status").assert().success();
 }


### PR DESCRIPTION
## Context

In single-branch mode, create an empty dependent top branch so it becomes checked out, then run `but discard <branch>`. The command fails with `Checkout selector is pointing to none` and leaves the branch in place.

## Change

When reference removal targets the current checkout, retarget HEAD to the named parent reference before transaction materialization. This removes only the selected empty ref, cleans its branch-order entry, and keeps the surviving branch checked out.

Fixes GB-1848

https://linear.app/gitbutler/issue/GB-1848/sbm-discarding-top-branch-doesnt-work