### PR TITLE
Rework the install.sh route handler

### DIFF
--- a/apps/web/src/lib/analytics/posthog.ts
+++ b/apps/web/src/lib/analytics/posthog.ts
@@ -1,11 +1,10 @@
+import { POSTHOG_API_KEY } from "$lib/analytics/posthogKey";
 import posthog from "posthog-js";
 import type { User } from "$lib/user/userService";
 
-const API_KEY = "phc_yJx46mXv6kA5KTuM2eEQ6IwNTgl5YW3feKV5gi7mfGG";
-
 export function initPostHog() {
 	if (location.hostname !== "gitbutler.com") return;
-	posthog.init(API_KEY, {
+	posthog.init(POSTHOG_API_KEY, {
 		api_host: "https://eu.posthog.com",
 		defaults: "2026-06-25",
 		cookie_persisted_properties: ["app_distinct_id"],

--- a/apps/web/src/lib/analytics/posthogKey.ts
+++ b/apps/web/src/lib/analytics/posthogKey.ts
@@ -1,0 +1,3 @@
+// Leaf module so server routes can use the key without pulling posthog-js
+// (the browser SDK, not tree-shakeable) into their bundle.
+export const POSTHOG_API_KEY = "phc_yJx46mXv6kA5KTuM2eEQ6IwNTgl5YW3feKV5gi7mfGG";

--- a/apps/web/src/routes/install.sh/+server.ts
+++ b/apps/web/src/routes/install.sh/+server.ts
@@ -1,18 +1,64 @@
+import { POSTHOG_API_KEY } from "$lib/analytics/posthogKey";
 // Import the install script as a raw string using Vite's ?raw suffix
 import installScript from "$scripts/install.sh?raw";
+import { isIP } from "node:net";
+import type { RequestEvent } from "./$types";
 
-export function GET() {
-	return new Response(installScript, {
-		headers: {
-			"Content-Type": "text/plain; charset=utf-8",
-			// No caching - users should always get the latest version
-			// This is critical for security fixes and bug patches
-			"Cache-Control": "no-cache, no-store, must-revalidate",
-			Pragma: "no-cache",
-			Expires: "0",
-			// Security headers - defense in depth
-			"Content-Security-Policy": "default-src 'none'",
-			"X-Content-Type-Options": "nosniff",
-		},
-	});
+const RESPONSE_HEADERS = {
+	"Content-Type": "text/plain; charset=utf-8",
+	// No caching - users should always get the latest version
+	// This is critical for security fixes and bug patches
+	"Cache-Control": "no-cache, no-store, must-revalidate",
+	Pragma: "no-cache",
+	Expires: "0",
+	// Security headers - defense in depth
+	"Content-Security-Policy": "default-src 'none'",
+	"X-Content-Type-Options": "nosniff",
+};
+
+export async function GET(event: RequestEvent) {
+	await captureFetch(event);
+	return new Response(installScript, { headers: RESPONSE_HEADERS });
+}
+
+// Counts script fetches server-side so the curl URL needs no query params.
+// The await is required — Vercel kills promises still pending when the
+// response returns — so the timeout caps how long a slow PostHog can delay
+// the installer. Failures are logged but never break serving the script.
+async function captureFetch({ request, url }: RequestEvent) {
+	if (url.hostname !== "gitbutler.com") return;
+	try {
+		const ip = clientIp(request);
+		const response = await fetch("https://eu.i.posthog.com/capture/", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				api_key: POSTHOG_API_KEY,
+				event: "install_script_fetched",
+				distinct_id: crypto.randomUUID(),
+				properties: {
+					$process_person_profile: false,
+					...(ip ? { $ip: ip } : {}),
+					$raw_user_agent: request.headers.get("user-agent") ?? "",
+				},
+			}),
+			signal: AbortSignal.timeout(500),
+		});
+		if (!response.ok) console.error(`install.sh capture rejected: ${response.status}`);
+		// Drain the connection so undici can return it to the pool.
+		await response.body?.cancel();
+	} catch (error) {
+		console.error("install.sh capture failed:", error);
+	}
+}
+
+// The last x-forwarded-for entry is the peer Vercel itself observed, so a
+// client-supplied header can't spoof it; x-vercel-forwarded-for is the
+// unspoofable client address when present. Undefined omits $ip entirely
+// (sending $ip: null would disable PostHog's GeoIP for the event).
+function clientIp(request: Request): string | undefined {
+	const header =
+		request.headers.get("x-vercel-forwarded-for") ?? request.headers.get("x-forwarded-for");
+	const candidate = header?.split(",").at(-1)?.trim() ?? "";
+	return isIP(candidate) ? candidate : undefined;
 }

--- a/apps/web/src/routes/install.sh/README.md
+++ b/apps/web/src/routes/install.sh/README.md
@@ -8,6 +8,10 @@ This directory serves the GitButler CLI installation script at `https://gitbutle
 - **Alias**: Uses the `$scripts` alias (defined in `svelte.config.js`) to avoid brittle relative paths
 - **Import method**: Uses Vite's `?raw` suffix to import the script as a plain string at build time
 - **Deployment**: Works in Vercel's serverless environment since the script is bundled at build time
+- **Fetch counting**: On the production host, each request also sends an `install_script_fetched`
+  event to PostHog before responding (best-effort, short timeout, failures only logged). This is
+  why the route must keep running per-request — do not add ISR or CDN caching, or the counting
+  silently stops.
 
 ## Usage
 
@@ -26,6 +30,9 @@ Located in `install.test.ts`, verifies:
 - Script can be imported via the `$scripts` alias
 - Script contains critical installation steps
 - Script has proper bash structure and error handling
+- The GET handler serves the script even when the PostHog capture fails, sends the expected
+  event payload on the production host only, and derives the client IP safely from
+  forwarding headers
 
 Run with:
 

--- a/apps/web/src/routes/install.sh/install.test.ts
+++ b/apps/web/src/routes/install.sh/install.test.ts
@@ -1,5 +1,76 @@
+import { GET } from "./+server";
 import installScript from "$scripts/install.sh?raw";
-import { describe, it, expect } from "vitest";
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
+
+function requestEvent(host: string, headers: Record<string, string> = {}) {
+	const url = new URL(`https://${host}/install.sh`);
+	return {
+		request: new Request(url, { headers: { "user-agent": "curl/8.4.0", ...headers } }),
+		url,
+	} as unknown as Parameters<typeof GET>[0];
+}
+
+describe("GET /install.sh", () => {
+	let fetchMock: ReturnType<typeof vi.fn>;
+
+	// Stub fetch before every test so no test can ever send a real event to
+	// production PostHog (Node's real fetch is live in this environment).
+	beforeEach(() => {
+		fetchMock = vi.fn().mockResolvedValue(new Response(null));
+		vi.stubGlobal("fetch", fetchMock);
+		vi.spyOn(console, "error").mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
+	});
+
+	it("serves the script even when the capture request fails", async () => {
+		fetchMock.mockRejectedValue(new Error("posthog down"));
+		const response = await GET(requestEvent("gitbutler.com"));
+		expect(response.status).toBe(200);
+		expect(response.headers.get("Content-Type")).toBe("text/plain; charset=utf-8");
+		expect(await response.text()).toBe(installScript);
+		expect(console.error).toHaveBeenCalled();
+	});
+
+	it("captures a fetch event on the production host", async () => {
+		await GET(requestEvent("gitbutler.com", { "x-vercel-forwarded-for": "203.0.113.7" }));
+		expect(fetchMock).toHaveBeenCalledOnce();
+		const [target, init] = fetchMock.mock.calls[0];
+		expect(target).toBe("https://eu.i.posthog.com/capture/");
+		const body = JSON.parse(init.body);
+		expect(body.api_key).toBeTruthy();
+		expect(body.event).toBe("install_script_fetched");
+		expect(body.properties.$process_person_profile).toBe(false);
+		expect(body.properties.$raw_user_agent).toBe("curl/8.4.0");
+		expect(body.properties.$ip).toBe("203.0.113.7");
+	});
+
+	it("takes the peer address from a client-forged x-forwarded-for chain", async () => {
+		await GET(requestEvent("gitbutler.com", { "x-forwarded-for": "1.2.3.4, 203.0.113.7" }));
+		const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+		expect(body.properties.$ip).toBe("203.0.113.7");
+	});
+
+	it("omits $ip for non-IP header values", async () => {
+		await GET(requestEvent("gitbutler.com", { "x-forwarded-for": "unknown" }));
+		const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+		expect(body.properties).not.toHaveProperty("$ip");
+	});
+
+	it("omits $ip when no forwarding header exists", async () => {
+		await GET(requestEvent("gitbutler.com"));
+		const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+		expect(body.properties).not.toHaveProperty("$ip");
+	});
+
+	it("does not capture on non-production hosts", async () => {
+		await GET(requestEvent("localhost"));
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+});
 
 describe("Install script import", () => {
 	it("successfully imports the install script", () => {


### PR DESCRIPTION
Serves the install script from a small dedicated handler and adds unit tests for the route (serving, failure tolerance, and client-address handling). Also notes each production fetch of the script, without touching the curl command or URL.