### PR TITLE
Stabilize Lite apply branch E2E test

### DIFF
--- a/apps/lite/e2e/tests/branches.spec.ts
+++ b/apps/lite/e2e/tests/branches.spec.ts
@@ -13,10 +13,12 @@ test.describe("branches", () => {
 		await expect(secondCommit).toHaveCount(0);
 		await expect(firstCommit).toHaveCount(0);
 
-		await appWindow.keyboard.press("ControlOrMeta+Shift+A");
-
 		const picker = appWindow.getByRole("dialog", { name: "Apply branch" });
-		await expect(picker).toBeVisible();
+		// Hotkeys register in a passive effect, so retry the keypress if the workspace renders first.
+		await expect(async () => {
+			await appWindow.keyboard.press("ControlOrMeta+Shift+A");
+			await expect(picker).toBeVisible({ timeout: 500 });
+		}).toPass({ timeout: 5_000 });
 
 		const search = picker.getByRole("combobox", { name: /search for branches/i });
 		await search.fill("branch1");


### PR DESCRIPTION
## Summary

- Retry the Apply Branch shortcut and its visibility assertion together while the hotkey registration becomes ready.
- Keep the branch application flow and its existing assertions unchanged.

## Validation

- Added a temporary local two-second delay before enabling the Apply Branch hotkey.
- Confirmed the original one-shot test failed under that synthetic delay, waiting for the picker that never opened.
- Confirmed the retrying test passed under the identical delay, then removed the instrumentation.
- Confirmed the clean targeted test passes, including 10 serial repetitions.
- Full Lite E2E, Lite unit tests, typecheck, lint, formatting, and dependency checks passed.