### PR TITLE
Never strand uncommitted changes when saving an edit

### DIFF
--- a/crates/gitbutler-edit-mode/src/lib.rs
+++ b/crates/gitbutler-edit-mode/src/lib.rs
@@ -388,14 +388,7 @@ pub(crate) fn save_and_return_to_workspace(ctx: &Context, perm: &mut RepoExclusi
     let new_workspace = WorkspaceState::create(ctx, perm.read_permission())?;
     let uncommtied_changes = get_uncommitted_changes(repo)?;
 
-    update_uncommitted_changes_with_tree(
-        ctx,
-        old_workspace,
-        new_workspace,
-        Some(uncommtied_changes),
-        Some(true),
-        perm,
-    )?;
+    restore_uncommitted_changes(ctx, old_workspace, new_workspace, uncommtied_changes, perm)?;
 
     // Currently if the index goes wonky then files don't appear quite right.
     // This just makes sure the index is all good.
@@ -416,6 +409,46 @@ pub(crate) fn save_and_return_to_workspace(ctx: &Context, perm: &mut RepoExclusi
 
     cleanup_edit_mode(ctx, repo)?;
 
+    Ok(())
+}
+
+/// Bring the stashed uncommitted changes back after the workspace moved.
+///
+/// Transplanting them onto the recomputed workspace is best, but that
+/// recomputation merges every stack head against the stored target and can
+/// fail on workspaces that only hold together through the recorded workspace
+/// commit. Failing there used to abort the save halfway: the rewrite was
+/// already durable, the stash was never restored, and its ref never cleaned
+/// up — the files just vanished. Fall back to checking the stash out
+/// verbatim: noisier diffs beat lost work.
+#[doc(hidden)]
+pub fn restore_uncommitted_changes(
+    ctx: &Context,
+    old: WorkspaceState,
+    new: WorkspaceState,
+    stashed_tree: gix::ObjectId,
+    perm: &mut RepoExclusive,
+) -> Result<()> {
+    if let Err(err) =
+        update_uncommitted_changes_with_tree(ctx, old, new, Some(stashed_tree), Some(true), perm)
+    {
+        tracing::warn!(
+            ?err,
+            "could not transplant stashed changes onto the new workspace; restoring them verbatim"
+        );
+        #[expect(deprecated, reason = "checkout/materialization boundary")]
+        let repo = &*ctx.git2_repo.get()?;
+        let tree = repo.find_tree(stashed_tree.to_git2())?;
+        repo.checkout_tree(
+            tree.as_object(),
+            Some(CheckoutBuilder::new().force().remove_untracked(true)),
+        )
+        .with_context(|| {
+            format!(
+                "Failed to restore stashed uncommitted changes; they are preserved in {UNCOMMITTED_CHANGES_REF}"
+            )
+        })?;
+    }
     Ok(())
 }
 

--- a/crates/gitbutler-edit-mode/tests/edit_mode.rs
+++ b/crates/gitbutler-edit-mode/tests/edit_mode.rs
@@ -600,3 +600,53 @@ Some(
 
     Ok(())
 }
+
+/// The `save_with_unmergeable_workspace` fixture holds two stacks based on
+/// two different rewrites of `shared`, so recomputing a workspace tree from
+/// its heads against the stored target conflicts — the exact failure that
+/// used to abort a save halfway and strand the stash.
+#[test]
+fn stashed_changes_survive_a_failing_workspace_recomputation() -> Result<()> {
+    use gitbutler_workspace::branch_trees::WorkspaceState;
+
+    let (mut ctx, _tempdir) = command_ctx("save_with_unmergeable_workspace")?;
+    let repo = ctx.repo.get()?;
+    let worktree_dir = repo.workdir().unwrap().to_owned();
+
+    let branchy = repo.rev_parse_single("refs/heads/branchy")?.detach();
+    let other = repo.rev_parse_single("refs/heads/other")?.detach();
+    let target = repo.rev_parse_single("refs/remotes/origin/main")?.detach();
+
+    // The stash: the workspace tree plus one file that must not be lost.
+    let head_tree_id = repo.head_commit()?.tree_id()?.detach();
+    let mut tree = repo.find_tree(head_tree_id)?.edit()?;
+    tree.upsert(
+        "notes.md",
+        gix::object::tree::EntryKind::Blob,
+        repo.write_blob(b"do not lose me\n")?.detach(),
+    )?;
+    let stash = tree.write()?.detach();
+
+    let old = WorkspaceState::create_from_heads_and_target(&repo, &[branchy, other], target)?;
+    let new = WorkspaceState::create_from_heads_and_target(&repo, &[branchy, other], target)?;
+    drop(repo);
+
+    let mut guard = ctx.exclusive_worktree_access();
+    // The transplant fails on this workspace; the fallback restores verbatim.
+    gitbutler_edit_mode::restore_uncommitted_changes(
+        &ctx,
+        old,
+        new,
+        stash,
+        guard.write_permission(),
+    )?;
+
+    snapbox::assert_data_eq!(
+        std::fs::read_to_string(worktree_dir.join("notes.md"))?,
+        snapbox::str![[r#"
+do not lose me
+
+"#]]
+    );
+    Ok(())
+}

--- a/crates/gitbutler-edit-mode/tests/fixtures/edit_mode.sh
+++ b/crates/gitbutler-edit-mode/tests/fixtures/edit_mode.sh
@@ -111,3 +111,30 @@ EOF
 
   git tag conflicted-target $conflict_commit
 )
+
+git clone repo save_with_unmergeable_workspace
+(cd save_with_unmergeable_workspace
+  git config user.name "Author"
+  git config user.email "author@example.com"
+
+  # Two heads that rewrite `shared` divergently from the same base: merging
+  # them into one workspace tree conflicts. The restore test hand-builds
+  # workspace states from these heads to make the transplant fail.
+  echo base > shared
+  git add shared && git commit -m "add shared"
+  git update-ref refs/remotes/origin/main main
+
+  git checkout -b branchy
+  echo b > file
+  echo branchy-side > shared
+  git add file shared && git commit -m "foobar"
+
+  git checkout -b other main
+  echo other-side > shared
+  git add shared && git commit -m "other"
+
+  ws=$(git commit-tree main^{tree} -p branchy -p other -m "GitButler Workspace Commit")
+  git branch gitbutler/workspace $ws
+  git symbolic-ref HEAD refs/heads/gitbutler/workspace
+  git reset --hard gitbutler/workspace
+)


### PR DESCRIPTION
Entering edit mode stashes your uncommitted changes into
refs/gitbutler/edit-uncommitted-changes; saving restores them by
transplanting them onto the recomputed workspace tree. That recomputation
merges every stack head against their common base and can fail on
workspaces that only hold together through the recorded workspace commit.

When it failed, the save aborted halfway: the commit rewrite was already
durable and HEAD was already back on the workspace, but the stash was
never restored and its ref never cleaned up. The error said 'merge
conflict when computing workspace tree' - nothing pointed at the stranded
files, and the app looked like the save had succeeded.

- when the transplant fails, fall back to checking the stash out verbatim:
  the diffs may be noisier, but the files come back and the ref is cleaned
  up like any other save
- if even that fails, the error now names the ref holding the changes
- the test builds a workspace whose heads rewrote the same file
  divergently, so the transplant genuinely fails and the fallback is what
  brings the files back