### PR TITLE
Fix Lite default log level (error -> info)

### DIFF
--- a/crates/but-napi/src/logs.rs
+++ b/crates/but-napi/src/logs.rs
@@ -55,9 +55,12 @@ fn init(identifier: &str, also_to_stderr: bool) -> anyhow::Result<String> {
         *slot = Some(guard);
     }
 
+    // An unset (or unparsable) LOG_LEVEL means `info`. Don't feed "" to the
+    // parser: `LevelFilter` parses the empty string as `ERROR`.
     let log_level = std::env::var("LOG_LEVEL")
-        .unwrap_or_default()
-        .parse::<LevelFilter>()
+        .ok()
+        .filter(|value| !value.is_empty())
+        .and_then(|value| value.parse::<LevelFilter>().ok())
         .unwrap_or(LevelFilter::INFO)
         .into_level();
     let filter = filter_fn(move |meta| should_log(log_level, meta));


### PR DESCRIPTION
Follow-up to #15480. tracing's `LevelFilter` parses the empty string as `ERROR`, so routing an unset `LOG_LEVEL` through `unwrap_or_default()` into the parser silently made errors-only the default: packaged Lite sessions with no errors produced a 0-byte `GitButler.<date>.log`. Treat unset or unparsable `LOG_LEVEL` as `info`, matching the desktop app, so non-error API request spans are recorded again.