### PR TITLE
Show the file-row tooltip only when it earns its place

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/FileRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/FileRow.tsx
@@ -11,7 +11,7 @@ import { classes } from "#ui/components/classes.ts";
 import { changesFileHotkeys } from "#ui/hotkeys.ts";
 import { Toolbar, Tooltip } from "@base-ui/react";
 import { Match } from "effect";
-import type { ComponentProps, FC } from "react";
+import { type ComponentProps, type FC, useEffect, useRef, useState } from "react";
 import styles from "./FileRow.module.css";
 import treeStyles from "./FilesTree.module.css";
 import { Row, RowCheckbox, RowLabel, RowLabelContainer, RowToolbar } from "./Row.tsx";
@@ -82,8 +82,30 @@ export const FileRow: FC<
 	const directoryPath = lastSepIdx !== -1 ? relativePath.slice(0, lastSepIdx) : null;
 	const fileName = lastSepIdx !== -1 ? relativePath.slice(lastSepIdx + 1) : relativePath;
 
+	// The tooltip only repeats the label, so it opens only when the label is
+	// ellipsized and cannot say it all. Measured as it opens, never stale.
+	const [rowTooltipOpen, setRowTooltipOpen] = useState(false);
+	const rowLabelRef = useRef<HTMLDivElement>(null);
+	const labelIsTruncated = () => {
+		const label = rowLabelRef.current;
+		return label !== null && label.scrollWidth > label.clientWidth;
+	};
+
+	useEffect(() => {
+		if (!rowTooltipOpen) return;
+		// A tooltip does not follow the list, so any scroll dismisses it. The
+		// listener exists only while a tooltip is open: one per list, not row.
+		const dismiss = () => setRowTooltipOpen(false);
+		document.addEventListener("scroll", dismiss, true);
+		return () => document.removeEventListener("scroll", dismiss, true);
+	}, [rowTooltipOpen]);
+
 	return (
-		<Tooltip.Root disableHoverablePopup>
+		<Tooltip.Root
+			open={rowTooltipOpen}
+			onOpenChange={(open) => setRowTooltipOpen(open && labelIsTruncated())}
+			disableHoverablePopup
+		>
 			<Tooltip.Trigger
 				// We pass the ID here instead of including it with the other props as a
 				// workaround for Base UI issue:
@@ -150,7 +172,7 @@ export const FileRow: FC<
 							aria-label="Conflicted"
 						/>
 					)}
-					<RowLabel singleLine>
+					<RowLabel singleLine ref={rowLabelRef}>
 						{directoryPath !== null && pathDisplay === "lead" && (
 							<span className={classes(styles.pathLead, rowStyles.fadedText)}>
 								{directoryPath}/


### PR DESCRIPTION
Every file row offered a hover tooltip that just repeated its own label. It now opens only when it can add something the row cannot show.

- the row measures its label (`scrollWidth` vs `clientWidth`) through a ResizeObserver, so window resizes and layout shifts re-decide whether the path is ellipsized
- any scroll dismisses the tooltip — it does not follow the list, and would otherwise linger outside the scroll container. The listener only exists while a tooltip is open, so a long file list holds at most one document listener rather than one per row
- conflicted uncommitted rows keep their get-out hint ("Resolve the conflict, then right-click → Mark as Resolved") in the tooltip