### PR TITLE
Ask for screenshots once, and not while a PR is a draft

### DIFF
--- a/.agents/skills/lite-screenshots/SKILL.md
+++ b/.agents/skills/lite-screenshots/SKILL.md
@@ -203,9 +203,10 @@ Only after a comment with images actually went up. A pull request labelled
 reviewer the change has been shown when it has not. If you declined to post (an
 uncovered surface, a capture that failed), leave `screenshots needed` where it is.
 
-Seeing both labels later is expected, not a bug to tidy away: the labeler re-adds
-`screenshots needed` on the next push, which says a set exists and the code has
-moved since. Recapturing swaps it away again — the command above is idempotent.
+`screenshots needed` is asked for once per pull request and never re-applied, so
+the swap is final — a later push does not put it back, and a set posted here is
+not a claim about code pushed after it. Recapture when the surfaces move; the
+command above is idempotent either way.
 
 If you ever post images that are **not** captures of the running app — a page
 rendered from the branch's CSS, say, when the harness cannot be run — label them

--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -27,16 +27,3 @@ CLI:
 "@gitbutler/no-relative-imports":
   - changed-files:
       - any-glob-to-any-file: packages/no-relative-imports/**/*
-
-# Drives the Lite UI Screenshots workflow. Applying it by hand opts a change in
-# that this rule does not cover, such as a layout change with no CSS in it.
-#
-# This label is a request, not a record: it says screenshots are wanted, and the
-# `lite-screenshots` skill swaps it for `screenshots` once they are posted.
-#
-# The labeler runs on every push, so a later commit re-adds it alongside
-# `screenshots` — which is the honest reading: a set was posted, and the code has
-# moved since. Recapturing swaps it away again.
-"screenshots needed":
-  - changed-files:
-      - any-glob-to-any-file: apps/lite/ui/**/*.css

--- a/.github/workflows/lite-screenshots.yml
+++ b/.github/workflows/lite-screenshots.yml
@@ -1,8 +1,14 @@
 name: Lite UI Screenshots
 
-# Reminds a pull request that touches Lite's UI to attach before/after
-# screenshots, tagging the designer so a visual change does not go by unseen.
-# It renders nothing itself.
+# Asks a pull request that touches Lite's UI for before/after screenshots:
+# applies `screenshots needed` and comments once, tagging the designer so a
+# visual change does not go by unseen. It renders nothing itself.
+#
+# Asking is a one-time event, deliberately. The label and the comment go up
+# together the first time, and neither comes back afterwards — so removing the
+# label sticks, and swapping it for `screenshots` sticks. It used to be applied
+# by pr-labeler, which runs on every push and only ever adds, so it returned on
+# the push that landed the screenshots and read as though they were never given.
 #
 # Capturing them in CI was tried and abandoned: under the bare X server on the
 # Linux runners this Electron build paints a frame on load and not reliably
@@ -15,7 +21,7 @@ name: Lite UI Screenshots
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened, labeled, ready_for_review]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
@@ -26,6 +32,9 @@ permissions:
 
 jobs:
   changes:
+    # Nobody is being asked to review a draft yet, so nothing asks it for
+    # screenshots. `ready_for_review` above is what picks it up later.
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     outputs:
       css: ${{ steps.filter.outputs.css }}
@@ -42,12 +51,15 @@ jobs:
 
   remind:
     needs: changes
-    # The paths filter is not redundant with the label. pr-labeler applies
-    # `screenshots needed` using GITHUB_TOKEN, and GitHub does not start workflow runs
-    # from token-generated events — so an auto-applied label fires nothing. Only
-    # a human applying it does. The filter is what makes this run on its own.
+    # The paths filter is not redundant with the label. The label this job
+    # applies is applied with GITHUB_TOKEN, and GitHub does not start workflow
+    # runs from token-generated events, so it cannot trigger this workflow
+    # again. The filter is what makes the job run on its own; the label term
+    # covers a human applying it by hand to opt in a change the glob misses,
+    # such as a layout change with no CSS in it.
     if: >-
       github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.draft == false &&
       (contains(github.event.pull_request.labels.*.name, 'screenshots needed') ||
        needs.changes.outputs.css == 'true')
     runs-on: ubuntu-latest
@@ -63,8 +75,11 @@ jobs:
       # without putting the pull request in anyone's review queue.
       DESIGNER: PavelLaptev
     steps:
-      # One comment, posted once. Nothing here edits or re-posts on later pushes:
-      # a reminder that repeats is a reminder people mute.
+      # One label and one comment, both put up once. Nothing here edits, re-posts
+      # or re-labels on later pushes: a reminder that repeats is a reminder people
+      # mute, and a label that comes back is one nobody can answer.
+      #
+      # The comment is the record of having asked, so it guards the label too.
       - name: Ask for screenshots
         run: |
           marker="<!-- lite-screenshots-reminder -->"
@@ -74,6 +89,10 @@ jobs:
             echo "Already asked."
             exit 0
           fi
+          # Additive and idempotent: a label already there is not an error, and a
+          # human who applied it by hand to opt this change in keeps it.
+          gh api -X POST "repos/${REPO}/issues/${PR}/labels" \
+            -f "labels[]=screenshots needed" --silent
           cat > /tmp/comment.md <<EOF
           ${marker}
           This pull request changes Lite's UI, so it is labelled
@@ -85,7 +104,8 @@ jobs:
           this repository does it against seeded fixtures).
 
           Swap the label for \`screenshots\` once they are posted, or remove it if
-          this change is not visual.
+          this change is not visual. Either sticks — this is asked once per pull
+          request, so later pushes will not put it back.
           EOF
           # No point tagging them on their own pull request.
           if [ "${AUTHOR}" != "${DESIGNER}" ]; then


### PR DESCRIPTION
`screenshots needed` was applied by pr-labeler, which runs on every push and only ever adds — sync-labels is off so a hand-applied label survives. Removing the label therefore never stuck, and swapping it for `screenshots` was undone by the next push, including the push that landed the screenshots.

The screenshots workflow now owns the label and applies it in the step that posts the reminder, behind the same marker-comment guard: the ask goes up once per pull request and never returns. Applying it stays additive, so a label a human put on by hand to opt in a change the CSS glob misses is left alone.

Drafts are skipped outright — nobody is being asked to review one yet — and `ready_for_review` joins the trigger types, since the default opened/synchronize/reopened set never fires when a draft goes ready and a PR drafted through all its CSS work would otherwise never be asked.

This gives up the one thing the re-add was doing: both labels together used to say a set exists and the code has moved since. Nothing flags stale screenshots now.