### PR TITLE
Avoid refetching removed branch diffs

### DIFF
--- a/apps/desktop/src/lib/stacks/stackEndpoints.test.ts
+++ b/apps/desktop/src/lib/stacks/stackEndpoints.test.ts
@@ -198,7 +198,7 @@ describe("buildStackEndpoints", () => {
 		expect(endpoints.commitMove.invalidatesTags).toEqual([
 			invalidatesList(ReduxTag.HeadSha),
 			invalidatesList(ReduxTag.WorktreeChanges),
-			invalidatesList(ReduxTag.BranchChanges),
+			invalidatesType(ReduxTag.BranchChanges),
 			invalidatesList(ReduxTag.Stacks),
 			invalidatesList(ReduxTag.StackDetails),
 		]);
@@ -256,7 +256,7 @@ describe("buildStackEndpoints", () => {
 			invalidatesList(ReduxTag.HeadSha),
 			invalidatesList(ReduxTag.WorktreeChanges),
 			invalidatesList(ReduxTag.Stacks),
-			invalidatesList(ReduxTag.BranchChanges),
+			invalidatesType(ReduxTag.BranchChanges),
 			invalidatesItem(ReduxTag.StackDetails, "stack-1"),
 		]);
 	});
@@ -420,7 +420,7 @@ describe("buildStackEndpoints", () => {
 			invalidatesList(ReduxTag.WorktreeChanges),
 			invalidatesList(ReduxTag.Stacks),
 			invalidatesList(ReduxTag.StackDetails),
-			invalidatesList(ReduxTag.BranchChanges),
+			invalidatesType(ReduxTag.BranchChanges),
 			invalidatesList(ReduxTag.BranchListing),
 			invalidatesType(ReduxTag.BaseBranchData),
 		]);
@@ -429,6 +429,7 @@ describe("buildStackEndpoints", () => {
 	test("uses branch_land and invalidates target and stack state", () => {
 		const endpoints = buildStackEndpoints(createEndpointBuilder());
 		const query = endpoints.landBranch.query;
+		const invalidatesTags = endpoints.landBranch.invalidatesTags;
 
 		expect(endpoints.landBranch.extraOptions).toEqual({
 			command: "branch_land",
@@ -451,12 +452,28 @@ describe("buildStackEndpoints", () => {
 
 		// The base-branch query provides a type-level tag, so it must be invalidated
 		// with invalidatesType rather than invalidatesList.
-		expect(endpoints.landBranch.invalidatesTags).toEqual([
+		if (typeof invalidatesTags !== "function") {
+			throw new Error("Expected landBranch.invalidatesTags to be callable");
+		}
+
+		expect(
+			invalidatesTags(
+				undefined,
+				undefined,
+				{
+					projectId: "project-1",
+					branch: "feature",
+					noFf: false,
+					wholeStack: true,
+				},
+				undefined,
+			),
+		).toEqual([
 			invalidatesList(ReduxTag.HeadSha),
 			invalidatesList(ReduxTag.WorktreeChanges),
 			invalidatesList(ReduxTag.Stacks),
 			invalidatesList(ReduxTag.StackDetails),
-			invalidatesList(ReduxTag.BranchChanges),
+			invalidatesType(ReduxTag.BranchChanges),
 			invalidatesList(ReduxTag.BranchListing),
 			invalidatesType(ReduxTag.BaseBranchData),
 		]);

--- a/apps/desktop/src/lib/stacks/stackEndpoints.ts
+++ b/apps/desktop/src/lib/stacks/stackEndpoints.ts
@@ -201,6 +201,16 @@ export const changesSelectors = changesAdapter.getSelectors();
 
 export const selectChangesByPaths = createSelectByIds<TreeChange>();
 
+function branchChangesInvalidations(headInfo?: RefInfo) {
+	if (!headInfo) return [invalidatesType(ReduxTag.BranchChanges)];
+
+	return headInfo.stacks.flatMap((stack) =>
+		stack.segments.flatMap((segment) =>
+			segment.refName ? [invalidatesItem(ReduxTag.BranchChanges, segment.refName.displayName)] : [],
+		),
+	);
+}
+
 export function buildStackEndpoints(build: BackendEndpointBuilder) {
 	return {
 		workspaceDetails: build.query<WorkspaceDetails, { projectId: string }>({
@@ -223,7 +233,7 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 				actionName: "Update Workspace",
 			},
 			query: (args) => args,
-			invalidatesTags: (_result, _error, args) => {
+			invalidatesTags: (result, _error, args) => {
 				if (args.dryRun) return [];
 
 				return [
@@ -231,7 +241,7 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 					invalidatesList(ReduxTag.WorktreeChanges),
 					invalidatesList(ReduxTag.Stacks),
 					invalidatesList(ReduxTag.StackDetails),
-					invalidatesList(ReduxTag.BranchChanges),
+					...branchChangesInvalidations(result?.workspaceState.headInfo),
 					invalidatesList(ReduxTag.BranchListing),
 					invalidatesType(ReduxTag.BaseBranchData),
 				];
@@ -392,7 +402,8 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 		>({
 			extraOptions: { command: "branch_diff" },
 			query: (args) => args,
-			providesTags: (_result, _error, { branch }) => providesItem(ReduxTag.BranchChanges, branch),
+			// Do not use providesItem: its LIST sentinel collides with the valid branch name "LIST".
+			providesTags: (_result, _error, { branch }) => [{ type: ReduxTag.BranchChanges, id: branch }],
 			transformResponse(rsp: TreeChanges) {
 				return {
 					changes: changesAdapter.addMany(changesAdapter.getInitialState(), rsp.changes),
@@ -435,7 +446,7 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 			}),
 			invalidatesTags: (_result, _error, { stackId }) => [
 				invalidatesList(ReduxTag.HeadSha),
-				invalidatesList(ReduxTag.BranchChanges),
+				invalidatesType(ReduxTag.BranchChanges),
 				invalidatesList(ReduxTag.WorktreeChanges),
 				...(stackId ? [invalidatesItem(ReduxTag.StackDetails, stackId)] : []),
 			],
@@ -523,7 +534,7 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 				dryRun: false,
 			}),
 			invalidatesTags: [
-				invalidatesList(ReduxTag.BranchChanges),
+				invalidatesType(ReduxTag.BranchChanges),
 				invalidatesList(ReduxTag.WorktreeChanges),
 				invalidatesList(ReduxTag.HeadSha),
 			],
@@ -551,7 +562,7 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 			transformResponse: normalizeCreateCommitOutcome,
 			invalidatesTags: [
 				invalidatesList(ReduxTag.WorktreeChanges),
-				invalidatesList(ReduxTag.BranchChanges),
+				invalidatesType(ReduxTag.BranchChanges),
 				invalidatesList(ReduxTag.HeadSha),
 			],
 		}),
@@ -650,7 +661,7 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 				return [
 					invalidatesList(ReduxTag.HeadSha),
 					invalidatesList(ReduxTag.WorktreeChanges),
-					invalidatesList(ReduxTag.BranchChanges),
+					invalidatesType(ReduxTag.BranchChanges),
 				];
 			},
 		}),
@@ -706,7 +717,7 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 			invalidatesTags: [
 				invalidatesList(ReduxTag.HeadSha),
 				invalidatesList(ReduxTag.WorktreeChanges), // Cherry-picking can cause conflicts
-				invalidatesList(ReduxTag.BranchChanges),
+				invalidatesType(ReduxTag.BranchChanges),
 				invalidatesList(ReduxTag.Stacks),
 				invalidatesList(ReduxTag.StackDetails),
 			],
@@ -737,7 +748,7 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 			invalidatesTags: [
 				invalidatesList(ReduxTag.HeadSha),
 				invalidatesList(ReduxTag.WorktreeChanges), // Moving commits can cause conflicts
-				invalidatesList(ReduxTag.BranchChanges),
+				invalidatesType(ReduxTag.BranchChanges),
 				invalidatesList(ReduxTag.Stacks),
 				invalidatesList(ReduxTag.StackDetails),
 			],
@@ -763,7 +774,7 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 			invalidatesTags: [
 				invalidatesList(ReduxTag.HeadSha),
 				invalidatesList(ReduxTag.WorktreeChanges), // Moving commits can cause conflicts
-				invalidatesList(ReduxTag.BranchChanges),
+				invalidatesType(ReduxTag.BranchChanges),
 				// Reordering empty branches in single-branch mode is metadata-only and doesn't move
 				// HEAD, so the stack/branch list must be invalidated explicitly to reflect the new order.
 				invalidatesList(ReduxTag.Stacks),
@@ -791,7 +802,7 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 				invalidatesList(ReduxTag.HeadSha),
 				invalidatesList(ReduxTag.WorktreeChanges), // Moving commits can cause conflicts
 				invalidatesList(ReduxTag.Stacks),
-				invalidatesList(ReduxTag.BranchChanges),
+				invalidatesType(ReduxTag.BranchChanges),
 				...(args.sourceStackId ? [invalidatesItem(ReduxTag.StackDetails, args.sourceStackId)] : []),
 			],
 		}),
@@ -804,12 +815,12 @@ export function buildStackEndpoints(build: BackendEndpointBuilder) {
 				actionName: "Land Branch",
 			},
 			query: (args) => args,
-			invalidatesTags: [
+			invalidatesTags: (result) => [
 				invalidatesList(ReduxTag.HeadSha),
 				invalidatesList(ReduxTag.WorktreeChanges),
 				invalidatesList(ReduxTag.Stacks),
 				invalidatesList(ReduxTag.StackDetails),
-				invalidatesList(ReduxTag.BranchChanges),
+				...branchChangesInvalidations(result?.workspace.headInfo),
 				invalidatesList(ReduxTag.BranchListing),
 				invalidatesType(ReduxTag.BaseBranchData),
 			],

--- a/apps/desktop/src/lib/stacks/stackInvalidation.test.ts
+++ b/apps/desktop/src/lib/stacks/stackInvalidation.test.ts
@@ -1,0 +1,118 @@
+import { buildStackEndpoints } from "$lib/stacks/stackEndpoints";
+import { ReduxTag } from "$lib/state/tags";
+import { configureStore } from "@reduxjs/toolkit";
+import { createApi, type BaseQueryFn } from "@reduxjs/toolkit/query";
+import { expect, test, vi } from "vitest";
+import type { BackendEndpointBuilder } from "$lib/state/backendApi";
+import type { RefInfo, WorkspaceIntegrateUpstreamOutcome } from "@gitbutler/but-sdk";
+
+const projectId = "project-1";
+const removed = "removed";
+const surviving = "LIST";
+const sameStack = "same-stack";
+const otherStack = "other-stack";
+const headInfo = {
+	stacks: [
+		{
+			id: "stack-1",
+			base: null,
+			segments: [
+				{ refName: null },
+				{ refName: { displayName: surviving, fullNameBytes: [] } },
+				{ refName: { displayName: sameStack, fullNameBytes: [] } },
+				{ refName: { displayName: surviving, fullNameBytes: [] } },
+			],
+		},
+		{
+			id: "stack-2",
+			base: null,
+			segments: [{ refName: { displayName: otherStack, fullNameBytes: [] } }],
+		},
+	],
+} as RefInfo;
+const integrationResult = {
+	workspaceState: { headInfo, replacedCommits: {}, checkoutConflictOccurred: false },
+	worktreeConflicts: [],
+} satisfies WorkspaceIntegrateUpstreamOutcome;
+
+type TestBaseQuery = BaseQueryFn<unknown, unknown, string, { command?: string }>;
+
+function setup() {
+	const calls: { command: string | undefined; args: unknown }[] = [];
+	async function baseQuery(
+		args: Parameters<TestBaseQuery>[0],
+		_api: Parameters<TestBaseQuery>[1],
+		extraOptions: Parameters<TestBaseQuery>[2],
+	): Promise<Awaited<ReturnType<TestBaseQuery>>> {
+		calls.push({ command: extraOptions.command, args });
+		return {
+			data:
+				extraOptions.command === "workspace_integrate_upstream"
+					? integrationResult
+					: extraOptions.command === "branch_land"
+						? { workspace: { headInfo } }
+						: { changes: [], stats: { linesAdded: 0, linesRemoved: 0, filesChanged: 0 } },
+		};
+	}
+	const api = createApi({
+		baseQuery,
+		reducerPath: "stackInvalidationApi",
+		tagTypes: Object.values(ReduxTag),
+		invalidationBehavior: "immediately",
+		endpoints: (build) => buildStackEndpoints(build as BackendEndpointBuilder),
+	});
+	const store = configureStore({
+		reducer: { [api.reducerPath]: api.reducer },
+		middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(api.middleware),
+	});
+	return { api, calls, store };
+}
+
+function branchDiffCalls(calls: ReturnType<typeof setup>["calls"], branch: string) {
+	return calls.filter(
+		(call) =>
+			call.command === "branch_diff" &&
+			(call.args as { branch?: string } | undefined)?.branch === branch,
+	).length;
+}
+
+test("integration refetches every surviving branch without refetching the removed branch", async () => {
+	const { api, calls, store } = setup();
+	const unsubscribe: (() => void)[] = [];
+	const pending: PromiseLike<unknown>[] = [];
+	for (const branch of [removed, surviving, sameStack, otherStack]) {
+		const subscription = store.dispatch(
+			api.endpoints.branchChanges.initiate({ projectId, branch }),
+		);
+		pending.push(subscription);
+		unsubscribe.push(() => subscription.unsubscribe());
+	}
+	await Promise.all(pending);
+
+	await store.dispatch(
+		api.endpoints.workspaceIntegrateUpstream.initiate({ projectId, updates: [], dryRun: false }),
+	);
+
+	await vi.waitFor(() => {
+		expect(branchDiffCalls(calls, removed)).toBe(1);
+		expect(branchDiffCalls(calls, surviving)).toBe(2);
+		expect(branchDiffCalls(calls, sameStack)).toBe(2);
+		expect(branchDiffCalls(calls, otherStack)).toBe(2);
+	});
+
+	await store.dispatch(
+		api.endpoints.landBranch.initiate({
+			projectId,
+			branch: removed,
+			noFf: false,
+			wholeStack: false,
+		}),
+	);
+	await vi.waitFor(() => {
+		expect(branchDiffCalls(calls, removed)).toBe(1);
+		expect(branchDiffCalls(calls, surviving)).toBe(3);
+		expect(branchDiffCalls(calls, sameStack)).toBe(3);
+		expect(branchDiffCalls(calls, otherStack)).toBe(3);
+	});
+	unsubscribe.forEach((dispose) => dispose());
+});


### PR DESCRIPTION
Avoid refetching removed branch diffs

## Context

Trigger: integrate upstream or land a branch while its branch diff query is subscribed.

Impact: the removed reference was refetched and surfaced an invalid-reference error in the branch view.

Source: https://github.com/gitbutlerapp/gitbutler/issues/5144

## Change

Use each mutation's complete post-operation workspace to invalidate only surviving branch-diff queries. Namespace branch item tags so a valid branch named `LIST` cannot collide with the list sentinel, while preserving the broad fallback when a mutation result is unavailable.

Add store-backed coverage for both integration and landing, including multi-branch stacks, anonymous segments, duplicate refs, and the `LIST` edge case.