### PR TITLE
Fix project deletion cache invalidation

### DIFF
--- a/apps/desktop/src/components/onboarding/ProjectSetupTarget.svelte
+++ b/apps/desktop/src/components/onboarding/ProjectSetupTarget.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { goto } from "$app/navigation";
 	import ProjectNameLabel from "$components/shared/ProjectNameLabel.svelte";
 	import ReduxResult from "$components/shared/ReduxResult.svelte";
 	import gerritLogoSvg from "$lib/assets/gerrit-logo.svg?raw";
@@ -75,6 +76,8 @@
 	const projectsService = inject(PROJECTS_SERVICE);
 	async function deleteProjectAndGoBack() {
 		await projectsService.deleteProject(projectId);
+		await projectsService.fetchProjects();
+		await goto("/");
 	}
 
 	const itSmellsLikeGerrit = $derived(projectsService.areYouGerritKiddingMe(projectId));

--- a/apps/desktop/src/lib/project/projectEndpoints.test.ts
+++ b/apps/desktop/src/lib/project/projectEndpoints.test.ts
@@ -1,0 +1,63 @@
+import { buildGitEndpoints } from "$lib/git/gitEndpoints";
+import { buildProjectEndpoints } from "$lib/project/projectEndpoints";
+import { ReduxTag } from "$lib/state/tags";
+import { describe, expect, test } from "vitest";
+import type { Project } from "$lib/project/project";
+import type { BackendEndpointBuilder } from "$lib/state/backendApi";
+import type { GitConfigSettings } from "@gitbutler/but-sdk";
+
+function createEndpointBuilder(): BackendEndpointBuilder {
+	return {
+		mutation: (definition) => definition,
+		query: (definition) => definition,
+	} as BackendEndpointBuilder;
+}
+
+describe("project cache tags", () => {
+	test("defines project query and mutation tags", () => {
+		const endpoints = buildProjectEndpoints(createEndpointBuilder());
+		const projectTags = endpoints.project.providesTags;
+		const deleteTags = endpoints.deleteProject.invalidatesTags;
+		const updateTags = endpoints.updateProject.invalidatesTags;
+		if (
+			typeof projectTags !== "function" ||
+			typeof deleteTags !== "function" ||
+			typeof updateTags !== "function"
+		) {
+			throw new Error("Expected project tag definitions to be callable");
+		}
+
+		expect(projectTags(undefined, undefined, { projectId: "project-1" }, undefined)).toEqual([
+			{ type: ReduxTag.Project, id: "project-1" },
+		]);
+		expect(deleteTags(undefined, undefined, { projectId: "project-1" }, undefined)).toEqual([
+			{ type: ReduxTag.Project, id: "LIST" },
+		]);
+		expect(
+			updateTags(undefined, undefined, { project: { id: "project-1" } as Project }, undefined),
+		).toEqual([
+			{ type: ReduxTag.Project, id: "project-1" },
+			{ type: ReduxTag.Project, id: "LIST" },
+		]);
+	});
+
+	test("setGbConfig invalidates its project item", () => {
+		const endpoints = buildGitEndpoints(createEndpointBuilder());
+		const tags = endpoints.setGbConfig.invalidatesTags;
+		if (typeof tags !== "function") {
+			throw new Error("Expected setGbConfig.invalidatesTags to be callable");
+		}
+
+		expect(
+			tags(
+				undefined,
+				undefined,
+				{ projectId: "project-1", config: {} as GitConfigSettings },
+				undefined,
+			),
+		).toEqual([
+			{ type: ReduxTag.GitButlerConfig, id: "project-1" },
+			{ type: ReduxTag.Project, id: "project-1" },
+		]);
+	});
+});

--- a/apps/desktop/src/lib/project/projectEndpoints.ts
+++ b/apps/desktop/src/lib/project/projectEndpoints.ts
@@ -28,7 +28,7 @@ export function buildProjectEndpoints(build: BackendEndpointBuilder) {
 		project: build.query<Project, { projectId: string; noValidation?: boolean }>({
 			extraOptions: { command: "get_project" },
 			query: (args) => args,
-			providesTags: (_result, _error, args) => providesItem(ReduxTag.Project, args.projectId),
+			providesTags: (_result, _error, args) => [{ type: ReduxTag.Project, id: args.projectId }],
 		}),
 		addProject: build.mutation<AddProjectOutcome, { path: string }>({
 			extraOptions: { command: "add_project" },


### PR DESCRIPTION
## Context

Observed trigger: deleting a project while its per-project query remains subscribed.

Experienced symptom: the deleted handle is refetched and can surface a project-not-found error during navigation. The setup Cancel path also relied on that failed refetch to leave the deleted project route.

## Change

- Give the per-project query only its item cache tag, so project-list invalidation no longer refetches a deleted handle.
- Make setup Cancel explicitly wait for deletion and the refreshed project list before navigating home.
- Pin the intended list/item invalidation contracts in focused endpoint tests.

FYI @PavelLaptev

## Validation

- Desktop tests (386)
- Svelte check
- Formatting and lint
- Desktop production build
