### PR TITLE
Add PostHog to Lite's main process

### DIFF
--- a/apps/lite/electron/src/main.ts
+++ b/apps/lite/electron/src/main.ts
@@ -46,6 +46,8 @@ import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { initLogging } from "./logging.js";
 import { type GUISettings, readSettings, writeSettings } from "./settings.js";
+import { initMetrics, metricsOnLogin, shutdownMetrics, withApiCommandCapture } from "./metrics.js";
+import { apiParamNames } from "@gitbutler/but-sdk/api-param-names";
 
 Object.assign(process.env, interactiveLoginShellEnvironment());
 
@@ -342,8 +344,14 @@ const registerIpcHandlers = (): void => {
 		ipcMain.handle(channel, senderValidatingListener);
 	};
 
-	for (const [name, handler] of createEndpointTable(electronHandlerOverrides))
-		senderValidatingHandle(name, (_e, params: unknown) => handler(params));
+	for (const [name, handler] of createEndpointTable(electronHandlerOverrides)) {
+		// Only but-api endpoints record `api_command`; the host's own members
+		// (clipboard, settings, dialogs) do not.
+		const captureWrapped = Object.hasOwn(apiParamNames, name)
+			? withApiCommandCapture(name, handler)
+			: handler;
+		senderValidatingHandle(name, (_e, params: unknown) => captureWrapped(params));
+	}
 	senderValidatingHandle("watcherUnsubscribe", (_e, { subscriptionId }: WatcherUnsubscribeParams) =>
 		WatcherManager.getInstance().removeSubscription(subscriptionId),
 	);
@@ -433,7 +441,8 @@ const completeLogin = async (url: URL): Promise<boolean> => {
 	if (accessToken === null) return true;
 
 	try {
-		await sdk.loginAndPersist(accessToken);
+		const profile = await sdk.loginAndPersist(accessToken);
+		void metricsOnLogin(profile);
 	} catch (error) {
 		// oxlint-disable-next-line no-console
 		console.error("Failed to sign in from a login link", error);
@@ -573,6 +582,10 @@ void app.whenReady().then(async () => {
 	configureAskpass();
 
 	if (app.isPackaged) {
+		// Packaged-only so dev builds send nothing, and awaited so the client
+		// exists before the IPC handlers and the launch-link login below run.
+		await initMetrics(app.getVersion());
+
 		registerLiteProtocolHandler();
 
 		// Basic non-Strict CSP based on https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html#basic-non-strict-csp-policy
@@ -682,12 +695,20 @@ void app.whenReady().then(async () => {
 	});
 });
 
-app.on("before-quit", () => {
-	WatcherManager.getInstance().destroy();
+app.on("before-quit", (event) => {
+	WatcherManager.destroyInstance();
+
+	// The metrics queue lives in memory, so hold the quit until it has
+	// flushed; the re-issued quit finds nothing to flush and goes through.
+	const flushing = shutdownMetrics();
+	if (flushing !== null) {
+		event.preventDefault();
+		void flushing.then(() => app.quit());
+	}
 });
 
 app.on("window-all-closed", () => {
-	WatcherManager.getInstance().destroy();
+	WatcherManager.destroyInstance();
 	if (process.platform !== "darwin") app.quit();
 });
 

--- a/apps/lite/electron/src/metrics.ts
+++ b/apps/lite/electron/src/metrics.ts
@@ -1,0 +1,128 @@
+import { getAppSettings, getUserProfileLocal, updateTelemetryDistinctId } from "@gitbutler/but-sdk";
+import type { UserProfile } from "@gitbutler/but-sdk";
+import { PostHog } from "posthog-node";
+import { randomUUID } from "node:crypto";
+
+/**
+ * Product metrics for the main process. Events go to the same PostHog
+ * project as the desktop app, the web app, and the CLI; the `appName` and
+ * `container` properties tell the surfaces apart. Conventions shared with
+ * those senders: snake_case event names, camelCase properties, and only
+ * counts, enums, and booleans as values — never message text, paths, or
+ * anything else a user typed.
+ *
+ * The distinct id is the one every surface shares through the settings file
+ * (`telemetry.appDistinctId`): `user_<id>` once any surface has seen a login,
+ * a random UUID otherwise. The CLI on the same machine reads whatever is
+ * stored there.
+ */
+
+// The same publishable project key the desktop app and the web app use.
+const POSTHOG_API_KEY = "phc_yJx46mXv6kA5KTuM2eEQ6IwNTgl5YW3feKV5gi7mfGG";
+const POSTHOG_HOST = "https://eu.i.posthog.com";
+const APP_NAME = "gitbutler-lite";
+const CONTAINER = "electron";
+const SHUTDOWN_TIMEOUT_MS = 2000;
+
+let client: PostHog | null = null;
+let distinctId = "";
+let appVersion = "";
+
+/**
+ * Reads the shared app settings and starts the client. A no-op when metrics
+ * are disabled. Never throws: the app must start even when metrics cannot.
+ *
+ * Await this before registering IPC handlers, so the first commands of the
+ * session are captured and a launch via a login link cannot race the
+ * identity below.
+ */
+export const initMetrics = async (version: string): Promise<void> => {
+	try {
+		const telemetry = (await getAppSettings()).telemetry;
+		if (!telemetry.appMetricsEnabled) return;
+
+		appVersion = version;
+		// The client exists from here on even if resolving the identity below
+		// fails; a session then captures under the stored or fresh id.
+		distinctId = telemetry.appDistinctId ?? randomUUID();
+		client = new PostHog(POSTHOG_API_KEY, { host: POSTHOG_HOST });
+
+		const profile = await getUserProfileLocal();
+		if (profile !== null) await metricsOnLogin(profile);
+		else if (distinctId !== telemetry.appDistinctId) await updateTelemetryDistinctId(distinctId);
+	} catch (error) {
+		// oxlint-disable-next-line no-console
+		console.error("Failed to initialize metrics", error);
+	}
+};
+
+const capture = (event: string, properties: Record<string, unknown>): void => {
+	client?.capture({
+		distinctId,
+		event,
+		properties: {
+			...properties,
+			appName: APP_NAME,
+			appVersion,
+			container: CONTAINER,
+			// Only events for a logged-in account may create a PostHog person
+			// profile; anonymous installs stay person-less (and cheaper).
+			$process_person_profile: distinctId.startsWith("user_"),
+		},
+	});
+};
+
+/**
+ * Wraps an endpoint-table handler so every but-api call captures one
+ * `api_command` event carrying the command name, its duration, and whether
+ * it failed.
+ */
+export const withApiCommandCapture =
+	(command: string, handler: (params: unknown) => unknown) =>
+	async (params: unknown): Promise<unknown> => {
+		if (client === null) return handler(params);
+		const start = performance.now();
+		const record = (failure: boolean) =>
+			capture("api_command", {
+				command,
+				durationMs: Math.round(performance.now() - start),
+				failure,
+			});
+		try {
+			const result = await handler(params);
+			record(false);
+			return result;
+		} catch (error) {
+			record(true);
+			throw error;
+		}
+	};
+
+/**
+ * Switches events to the account's identity after a login and shares it with
+ * the other surfaces through the settings file. Never rejects, so callers may
+ * fire-and-forget it. A sign-out deliberately keeps the identity — unlike the
+ * desktop app, which resets it — since it is still the same person using us.
+ */
+export const metricsOnLogin = async (profile: UserProfile): Promise<void> => {
+	if (client === null) return;
+	distinctId = `user_${profile.id}`;
+	try {
+		await updateTelemetryDistinctId(distinctId);
+	} catch (error) {
+		// oxlint-disable-next-line no-console
+		console.error("Failed to persist the metrics distinct id", error);
+	}
+};
+
+/**
+ * Flushes queued events, since the client only holds them in memory. Returns
+ * null when there is nothing to flush, so quitting can proceed immediately —
+ * and does so on the second call, making the quit handler reentrant.
+ */
+export const shutdownMetrics = (): Promise<void> | null => {
+	if (client === null) return null;
+	const flushing = client;
+	client = null;
+	return flushing.shutdown(SHUTDOWN_TIMEOUT_MS).catch(() => undefined);
+};

--- a/apps/lite/electron/src/updater.ts
+++ b/apps/lite/electron/src/updater.ts
@@ -1,6 +1,7 @@
 import { app, type BrowserWindow, dialog } from "electron";
 import electronUpdater, { type AppUpdater, type UpdateDownloadedEvent } from "electron-updater";
 import { env } from "node:process";
+import { shutdownMetrics } from "./metrics.js";
 
 let updaterWindow: BrowserWindow | null = null;
 let updaterRegistered = false;
@@ -28,7 +29,12 @@ const showUpdateDownloadedDialog = async (event: UpdateDownloadedEvent): Promise
 		detail: "Restart GitButler to install the update, or keep working and it installs on quit.",
 	});
 
-	if (response === 0) getAutoUpdater().quitAndInstall(false);
+	if (response === 0) {
+		// Flush metrics here; left to the quit handler it would preventDefault
+		// the updater's own quit and break the restart-into-new-version flow.
+		await shutdownMetrics();
+		getAutoUpdater().quitAndInstall(false);
+	}
 };
 
 export const registerUpdater = (mainWindow: BrowserWindow): void => {

--- a/apps/lite/electron/src/watcher.ts
+++ b/apps/lite/electron/src/watcher.ts
@@ -72,6 +72,11 @@ export default class WatcherManager {
 		return this.instance;
 	}
 
+	/** Shutdown teardown; unlike `getInstance().destroy()` it does not create a manager just to destroy it. */
+	static destroyInstance(): void {
+		WatcherManager.instance?.destroy();
+	}
+
 	/**
 	 * Start watching a project and subscribe to it.
 	 *

--- a/apps/lite/package.json
+++ b/apps/lite/package.json
@@ -154,6 +154,7 @@
 		"fuse.js": "^7.1.0",
 		"idb-keyval": "^6.3.0",
 		"ms": "^4.0.0-nightly.202508271359",
+		"posthog-node": "5.21.0",
 		"react": "^19.2.4",
 		"react-dom": "^19.2.4",
 		"react-markdown": "^10.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -476,6 +476,9 @@ importers:
       ms:
         specifier: ^4.0.0-nightly.202508271359
         version: 4.0.0-nightly.202508271359
+      posthog-node:
+        specifier: 5.21.0
+        version: 5.21.0
       react:
         specifier: ^19.2.4
         version: 19.2.4
@@ -3756,6 +3759,9 @@ packages:
 
   '@posthog/core@1.48.1':
     resolution: {integrity: sha512-mxw31XdYgt/SnlwqLPAcltK67q+QmsiYjVLGQ4GbBc8OJ7O4yRFSDwAXt8QsokHokeyEZtTRWM6jDHL7LYMx1A==}
+
+  '@posthog/core@1.9.1':
+    resolution: {integrity: sha512-kRb1ch2dhQjsAapZmu6V66551IF2LnCbc1rnrQqnR7ArooVyJN9KOPXre16AJ3ObJz2eTfuP7x25BMyS2Y5Exw==}
 
   '@posthog/types@1.404.1':
     resolution: {integrity: sha512-i2Gei6ARfOSBeTN4s2yUP1p97s2UNI+1NWmtLjhnR/V6t3RFOfI1sBWKcJNWHjtoOCCWoAFU+PNPY6SgT2VtEQ==}
@@ -8714,6 +8720,10 @@ packages:
   posthog-js@1.417.1:
     resolution: {integrity: sha512-QpZnHA2PieGq9+W03LBw23DnN9CD1zM37DcXnpZkg+C5iAwYXLiZs8qof0Yi/BhY35PYuhVmv93nhztyHjVaJw==}
 
+  posthog-node@5.21.0:
+    resolution: {integrity: sha512-M7v/+Zyz/z3ZDC4u896K2Lb/pLbPA1Czo6Tp/WeQ1vuBsJtJajqWO3vRev3BHFTP92nao5YCrU0aIM+Flwbv1A==}
+    engines: {node: '>=20'}
+
   postject@1.0.0-alpha.6:
     resolution: {integrity: sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==}
     engines: {node: '>=14.0.0'}
@@ -12930,6 +12940,10 @@ snapshots:
   '@posthog/core@1.48.1':
     dependencies:
       '@posthog/types': 1.404.1
+
+  '@posthog/core@1.9.1':
+    dependencies:
+      cross-spawn: 7.0.6
 
   '@posthog/types@1.404.1': {}
 
@@ -18886,6 +18900,10 @@ snapshots:
       query-selector-shadow-dom: 1.0.1
       web-vitals: 5.3.0
       web-vitals-soft-navs: web-vitals@6.0.0
+
+  posthog-node@5.21.0:
+    dependencies:
+      '@posthog/core': 1.9.1
 
   postject@1.0.0-alpha.6:
     dependencies:


### PR DESCRIPTION
Sets up posthog-node in the Electron main process, sharing the app-settings id and enable flag with the other surfaces. The key is the same publishable one the desktop and web apps use; unpackaged builds are unaffected.