### PR TITLE
Prevent branch details refetch after local deletion

### DIFF
--- a/apps/desktop/src/components/views/BranchesView.svelte
+++ b/apps/desktop/src/components/views/BranchesView.svelte
@@ -33,7 +33,7 @@
 	import { AsyncButton, Button, Modal, TestId } from "@gitbutler/ui";
 	import { focusable } from "@gitbutler/ui/focus/focusable";
 	import { getTimeAgo } from "@gitbutler/ui/utils/timeAgo";
-	import { untrack } from "svelte";
+	import { tick, untrack } from "svelte";
 	import type { BranchFilterOption, SidebarEntrySubject } from "$lib/branches/branchListing";
 	type Props = {
 		projectId: string;
@@ -122,12 +122,28 @@
 	}
 
 	async function deleteLocalBranch(branchName: string) {
-		await stackService.deleteLocalBranch({
-			projectId,
-			refname: `refs/heads/${branchName}`,
-			givenName: branchName,
-		});
-		// Unselect branch
+		const selectionToRestore =
+			selection.type === "branch" &&
+			selection.branchName === branchName &&
+			selection.remote === undefined
+				? selection
+				: undefined;
+		let temporarySelection: BranchesSelection | undefined;
+		if (selectionToRestore) {
+			selection = { type: "target" };
+			temporarySelection = selection;
+			await tick();
+		}
+		try {
+			await stackService.deleteLocalBranch({
+				projectId,
+				refname: `refs/heads/${branchName}`,
+				givenName: branchName,
+			});
+		} catch (error) {
+			if (selectionToRestore && selection === temporarySelection) selection = selectionToRestore;
+			throw error;
+		}
 		await baseBranchService.refreshBaseBranch(projectId);
 	}
 

--- a/crates/but-workspace/src/branch_details.rs
+++ b/crates/but-workspace/src/branch_details.rs
@@ -38,7 +38,10 @@ pub fn branch_details(
         .context("The branch to integrate with must be present")?;
     let integration_branch_id = integration_branch.peel_to_id()?;
 
-    let mut branch = repo.find_reference(name)?;
+    let Some(mut branch) = repo.try_find_reference(name)? else {
+        return Err(anyhow::anyhow!("The reference '{name}' did not exist")
+            .context(but_error::Code::BranchNotFound));
+    };
     let branch_id = branch.peel_to_id()?;
 
     let mut remote_tracking_branch = repo

--- a/crates/but-workspace/tests/workspace/branch_details.rs
+++ b/crates/but-workspace/tests/workspace/branch_details.rs
@@ -1,5 +1,6 @@
 mod without_workspace {
     use but_core::ref_metadata::ProjectMeta;
+    use but_error::{AnyhowContextExt, Code};
     use but_testsupport::InMemoryRefMetadata;
 
     use crate::utils::read_only_in_memory_scenario_named;
@@ -26,6 +27,32 @@ mod without_workspace {
             details.commits.len(),
             2,
             "only commits above the configured project target are returned"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn classifies_a_missing_branch() -> anyhow::Result<()> {
+        let repo =
+            read_only_in_memory_scenario_named("with-remotes-no-workspace", "nothing-to-push")?;
+        let meta = InMemoryRefMetadata::default();
+        let project_meta = ProjectMeta {
+            target_ref: Some("refs/remotes/origin/main".try_into()?),
+            ..Default::default()
+        };
+
+        let error = but_workspace::branch_details(
+            &repo,
+            "refs/heads/missing".try_into()?,
+            &meta,
+            &project_meta,
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            error.custom_context().map(|context| context.code),
+            Some(Code::BranchNotFound),
+            "missing branch refs should be recoverable by API consumers"
         );
         Ok(())
     }


### PR DESCRIPTION
## Context

Deleting a selected local branch succeeds, but the active details view can refetch the deleted ref. This makes a "The reference did not exist" error appear after successful deletion. Deleting an unselected branch preserves selection.

Related history: https://github.com/gitbutlerapp/gitbutler/issues/5144

FYI @PavelLaptev

## Change

Move selected-branch cleanup ahead of deletion and wait for the details view to unmount before query invalidation. Restore selection if deletion fails. The branch listing still refreshes, and missing branch details are classified so genuinely stale selections recover.

Restores behavior lost in https://github.com/gitbutlerapp/gitbutler/pull/12020