### PR TITLE
Fix the upstream tab's incoming count

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/Sidebar.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Sidebar.tsx
@@ -45,6 +45,14 @@ const adjacentPage = (tab: PageId, offset: -1 | 1): PageId => {
 	return assert(pageOrder[(index + offset + pageOrder.length) % pageOrder.length]);
 };
 
+/**
+ * Counts past this are shown as `99+`: the badge sits inside a tab, where a
+ * third digit takes width from the tab labels, and at that size the number is
+ * a rough sense of how far behind the workspace is rather than a figure to
+ * read. The upstream page states the exact count.
+ */
+const maxBadgeCount = 99;
+
 export const Sidebar: FC<{
 	absorptionTargetCommitIds: ReadonlySet<string>;
 	branchesList: BranchesListData;
@@ -246,7 +254,11 @@ export const Sidebar: FC<{
 						<Icon name="inbox" />
 						<span className={styles.tabLabel}>Upstream</span>
 						{upstreamList.incomingCount > 0 && (
-							<Badge variant="fillGray">{upstreamList.incomingCount}</Badge>
+							<Badge variant="fillGray">
+								{upstreamList.incomingCount > maxBadgeCount
+									? `${maxBadgeCount}+`
+									: upstreamList.incomingCount}
+							</Badge>
 						)}
 					</Toggle>
 					<Toggle

--- a/apps/lite/ui/src/routes/project/$id/workspace/useUpstreamList.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/useUpstreamList.ts
@@ -84,10 +84,10 @@ export type UpstreamListData = {
 	/** The target's display label, like `origin/main`, or `null` without a target. */
 	targetLabel: string | null;
 	/**
-	 * How many listed commits an update would bring in. Counted from the
-	 * first-parent rows once the listing is loaded so the label always agrees
-	 * with them; before that, the graph's all-commits count approximates it
-	 * for the page badge.
+	 * How many listed commits an update would bring in, counted from the
+	 * first-parent rows. The page label and the sidebar badge both read it, so
+	 * they always agree with the rows and with each other, whichever page is
+	 * shown.
 	 */
 	incomingCount: number;
 	/** Whether any workspace branch was detected as integrated upstream. */
@@ -299,7 +299,12 @@ export const useUpstreamList = (projectId: string): UpstreamListData => {
 	// on unrelated renders.
 	return useQueries({
 		queries: [
-			{ ...workspaceTargetCommitsQueryOptions(projectId), enabled: active },
+			// Kept enabled while another page is shown: the sidebar badge counts
+			// the same rows the tab lists, so the listing has to stay current
+			// even when nothing renders it. Disabling it would leave the badge
+			// on whatever was cached the last time the tab was open, with the
+			// invalidations that follow a fetch reaching no observer.
+			workspaceTargetCommitsQueryOptions(projectId),
 			{ ...headInfoQueryOptions(projectId), enabled: active },
 		],
 		combine: ([targetResult, headInfoResult]): UpstreamListData => {
@@ -307,9 +312,7 @@ export const useUpstreamList = (projectId: string): UpstreamListData => {
 			const targetCommits = targetPage?.commits ?? [];
 			const headInfo = headInfoResult.data;
 
-			const incomingCount = targetPage
-				? targetCommits.filter((commit) => !commit.inWorkspace).length
-				: (headInfo?.target?.commitsAhead ?? 0);
+			const incomingCount = targetCommits.filter((commit) => !commit.inWorkspace).length;
 			const targetLabel = headInfo?.target
 				? `${headInfo.target.remoteTrackingRef.remoteName}/${headInfo.target.remoteTrackingRef.displayName}`
 				: null;


### PR DESCRIPTION
The number on the Upstream tab counted two different things depending on which
page was shown, and went stale once the tab had been visited.

**It changed when you clicked the tab.** `incomingCount` fell back to the
graph's `commitsAhead` while another page was shown, and used the first-parent
row count once the tab was open. `commitsAhead` sums every segment's commits,
so a merged PR contributed its merge commit *plus* everything the merge brought
in — a one-commit PR showed as `2` from the workspace tab and `1` from the
upstream tab, listing a single row either way. It now always counts the
first-parent rows, so the badge, the page label, and the rows agree.

**It went stale after the first visit.** Both queries behind the hook were
`enabled: active`. Once the tab had been opened, the cached listing kept
winning the fallback, and the invalidation that follows a `gitFetch` reached no
enabled observer — so commits that arrived while the workspace tab was shown
did not reach the badge until the tab was clicked. The listing query now stays
enabled; the item and address-space derivation is still gated on the tab being
active, so an inactive tab only pays for the count. The listing itself is a
bounded local first-parent walk, already refetched on every fetch event.

**The badge caps at `99+`.** It sits inside a tab toggle, where a third digit
takes width from the tab labels, and being a hundred commits behind is
ordinary. The upstream page still states the exact count.