### PR TITLE
Sort uncommitted files by last modified and show how recently each one changed

### DIFF
--- a/apps/lite/harness/browser/Panel.tsx
+++ b/apps/lite/harness/browser/Panel.tsx
@@ -65,6 +65,8 @@ export const Panel: FC = () => {
 		filter: uncommittedFilesFilter,
 		mode: uncommittedFilesDisplayMode,
 		collapsedDirectories: uncommittedFilesCollapsedDirectories,
+		// The panel has no recency toggle, so it lists in path order.
+		recentFirst: false,
 	});
 	const uncommittedAddressSpace = fileTreeAddressSpace(uncommittedFileRows);
 

--- a/apps/lite/harness/tests/fixtures.ts
+++ b/apps/lite/harness/tests/fixtures.ts
@@ -88,6 +88,8 @@ export const fixtureFileChange = (path: string): TreeChange => ({
 export const fixtureWorktreeChanges = (changes: Array<TreeChange>): WorktreeChanges => ({
 	changes,
 	ignoredChanges: [],
+	// Fixed mtimes so modifiedAtMs derivations are deterministic.
+	modificationTimes: Object.fromEntries(changes.map((change) => [change.path, AUTHORED_AT])),
 	assignments: [],
 	assignmentsError: null,
 	dependencies: null,

--- a/apps/lite/ui/src/components/useNow.ts
+++ b/apps/lite/ui/src/components/useNow.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from "react";
+
+/**
+ * The current time, re-read every `intervalMs`. Every consumer re-renders on
+ * the tick, so use it only where a ticking clock is needed; `null` holds the
+ * value instead.
+ */
+export const useNow = (intervalMs: number | null): number => {
+	const [now, setNow] = useState(() => Date.now());
+
+	useEffect(() => {
+		if (intervalMs === null) return;
+
+		// The held value can be arbitrarily stale, so the first read cannot wait
+		// for the interval. Scheduled, not read here: the clock is impure during
+		// render, and setting state in an effect body cascades a render.
+		const first = setTimeout(() => setNow(Date.now()));
+		const id = setInterval(() => setNow(Date.now()), intervalMs);
+		return () => {
+			clearTimeout(first);
+			clearInterval(id);
+		};
+	}, [intervalMs]);
+
+	return now;
+};

--- a/apps/lite/ui/src/projects/project.ts
+++ b/apps/lite/ui/src/projects/project.ts
@@ -104,6 +104,11 @@ type WorkspaceState = {
 	uncommittedFilesFilter: string | null;
 	filesFilter: string | null;
 	/**
+	 * Whether the uncommitted list is ordered by file modification time, newest
+	 * first. Order only: the shared list/tree display mode stays in force.
+	 */
+	uncommittedFilesRecentFirst: boolean;
+	/**
 	 * Directories whose contents the tree view hides, keyed by directory path.
 	 *
 	 * Collapsed rather than expanded, as with {@link WorkspaceState.foldedSegments}:
@@ -126,6 +131,7 @@ const createInitialWorkspaceState = (): WorkspaceState => ({
 	diffCursor: null,
 	uncommittedFilesFilter: null,
 	filesFilter: null,
+	uncommittedFilesRecentFirst: false,
 	uncommittedFilesCollapsedDirectories: {},
 	filesCollapsedDirectories: {},
 });
@@ -492,6 +498,9 @@ export const projectReducers = {
 
 		workspaceState.filesFilter = filter;
 	},
+	toggleUncommittedFilesRecentFirst: (state: ProjectState) => {
+		state.workspace.uncommittedFilesRecentFirst = !state.workspace.uncommittedFilesRecentFirst;
+	},
 	toggleUncommittedFilesDirectoryCollapsed: (state: ProjectState, { path }: { path: string }) => {
 		const collapsed = state.workspace.uncommittedFilesCollapsedDirectories;
 		if (collapsed[path]) delete collapsed[path];
@@ -617,6 +626,8 @@ export const projectSelectors = {
 		state.workspace.selectedBranchTabs[branchName],
 
 	selectUncommittedFilesFilter: (state: ProjectState) => state.workspace.uncommittedFilesFilter,
+	selectUncommittedFilesRecentFirst: (state: ProjectState) =>
+		state.workspace.uncommittedFilesRecentFirst,
 	selectFilesFilter: (state: ProjectState) => state.workspace.filesFilter,
 	selectUncommittedFilesCollapsedDirectories: (state: ProjectState) =>
 		state.workspace.uncommittedFilesCollapsedDirectories,

--- a/apps/lite/ui/src/routes/project/$id/workspace/FileRow.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/FileRow.module.css
@@ -37,3 +37,29 @@
 	flex-shrink: 0;
 	margin-right: 2px;
 }
+
+/* Contrast carries how long ago the change was; the row sets the opacity. */
+.ageBadge {
+	flex-shrink: 0;
+	align-self: center;
+	color: var(--text-2);
+	font-size: 11px;
+	font-variant-numeric: tabular-nums;
+	opacity: var(--age-badge-opacity, 1);
+}
+
+/* Inset shadow rather than background, so hover and selection fills show through. */
+.freshChange {
+	animation: fresh-change-pulse 2.4s ease-in-out infinite;
+}
+
+@keyframes fresh-change-pulse {
+	0%,
+	100% {
+		box-shadow: inset 0 0 0 999px transparent;
+	}
+
+	50% {
+		box-shadow: inset 0 0 0 999px color-mix(in srgb, var(--fill-pop-bg) 12%, transparent);
+	}
+}

--- a/apps/lite/ui/src/routes/project/$id/workspace/FileRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/FileRow.tsx
@@ -11,7 +11,7 @@ import { classes } from "#ui/components/classes.ts";
 import { changesFileHotkeys } from "#ui/hotkeys.ts";
 import { Toolbar, Tooltip } from "@base-ui/react";
 import { Match } from "effect";
-import type { ComponentProps, FC } from "react";
+import type { ComponentProps, CSSProperties, FC } from "react";
 import styles from "./FileRow.module.css";
 import treeStyles from "./FilesTree.module.css";
 import { Row, RowCheckbox, RowLabel, RowLabelContainer, RowToolbar } from "./Row.tsx";
@@ -20,8 +20,15 @@ import { DependencyIndicator } from "#ui/routes/project/$id/workspace/Dependency
 import { useFileMenuItems } from "#ui/routes/project/$id/workspace/useFileMenuItems.ts";
 import type { FileRowItem } from "./file-row.ts";
 import { TreeSteps } from "./TreeSteps.tsx";
+import { ageBadgeOpacity, formatAgeBadge, formatRelativeTime } from "#ui/time.ts";
 import type { TreeChange } from "@gitbutler/but-sdk";
 import type { FileRowTooltipPayload } from "./FileRowTooltip.tsx";
+
+/** Pulse lifetime. The 30s clock driving it can stretch this by up to a tick. */
+const FRESH_CHANGE_MAX_AGE_MS = 60_000;
+
+/** From this age up, the badge is coarse or hidden, so hover carries the full time ago. */
+const AGE_TOOLTIP_MIN_AGE_MS = 60 * 60_000;
 
 type FileRowProps = {
 	item: FileRowItem;
@@ -42,6 +49,8 @@ type FileRowProps = {
 	pathDisplay: "lead" | "trail" | "hidden";
 	focusScope: FocusScope;
 	tooltipHandle: Tooltip.Handle<FileRowTooltipPayload>;
+	/** See {@link FilesTree}'s prop of the same name. */
+	ageBadgeNow?: number | null;
 } & Omit<ComponentProps<typeof Row>, "projectId">;
 
 type FileRowPresentationalProps = Omit<FileRowProps, "canUncommit" | "uncommit"> & {
@@ -88,9 +97,23 @@ export const FileRowPresentational: FC<FileRowPresentationalProps> = ({
 	anyOperationPending,
 	menuItems,
 	tooltipHandle,
+	ageBadgeNow = null,
 	...restProps
 }) => {
 	const relativePath = item._tag === "Change" ? item.change.path : item.path;
+
+	const modifiedAtMs = item.modifiedAtMs ?? null;
+	const ageMs =
+		ageBadgeNow !== null && modifiedAtMs !== null ? Math.max(0, ageBadgeNow - modifiedAtMs) : null;
+	const ageBadge = ageMs === null ? null : formatAgeBadge(ageMs);
+	const isFresh = ageMs !== null && ageMs <= FRESH_CHANGE_MAX_AGE_MS;
+	const agedTooltip =
+		ageBadgeNow !== null &&
+		modifiedAtMs !== null &&
+		ageMs !== null &&
+		ageMs > AGE_TOOLTIP_MIN_AGE_MS
+			? formatRelativeTime(modifiedAtMs, ageBadgeNow)
+			: null;
 
 	const hasConflictHint = item._tag === "Conflict" && fileParent._tag === "UncommittedChanges";
 	// An uncommitted conflict is a state to get out of, so the row says how.
@@ -104,6 +127,7 @@ export const FileRowPresentational: FC<FileRowPresentationalProps> = ({
 	return (
 		<Row
 			{...restProps}
+			className={classes(restProps.className, isFresh && styles.freshChange)}
 			isChecked={isChecked}
 			onShiftSelect={
 				!anyOperationPending && canCheck
@@ -151,7 +175,9 @@ export const FileRowPresentational: FC<FileRowPresentationalProps> = ({
 
 			<Tooltip.Trigger
 				handle={tooltipHandle}
-				payload={{ content: rowTooltip }}
+				payload={{
+					content: agedTooltip !== null ? `${rowTooltip} — ${agedTooltip}` : rowTooltip,
+				}}
 				render={<RowLabelContainer />}
 			>
 				{item._tag === "Conflict" && (
@@ -188,6 +214,15 @@ export const FileRowPresentational: FC<FileRowPresentationalProps> = ({
 						<Icon name="kebab" />
 					</Toolbar.Button>
 				</Toolbar.Root>
+			)}
+
+			{ageBadge !== null && ageMs !== null && (
+				<span
+					className={styles.ageBadge}
+					style={{ "--age-badge-opacity": String(ageBadgeOpacity(ageMs)) } as CSSProperties}
+				>
+					{ageBadge}
+				</span>
 			)}
 
 			{!anyOperationPending &&

--- a/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.tsx
@@ -369,6 +369,11 @@ export const FilesTree: FC<
 		/** The scope this tree's hotkeys are bound to; also stamped on the tree element. */
 		focusScope: FocusScope;
 		emptyLabel?: string;
+		/**
+		 * Timestamp the row age badges are measured against; `null` hides them.
+		 * The caller owns the ticking.
+		 */
+		ageBadgeNow?: number | null;
 	} & ComponentProps<"div">
 > = ({
 	rows,
@@ -384,6 +389,7 @@ export const FilesTree: FC<
 	fileParent,
 	focusScope,
 	emptyLabel = "No changes.",
+	ageBadgeNow = null,
 	ref: refProp,
 	...props
 }) => {
@@ -718,6 +724,7 @@ export const FilesTree: FC<
 													uncommit={uncommit}
 													focusScope={focusScope}
 													tooltipHandle={tooltipHandle}
+													ageBadgeNow={ageBadgeNow}
 													branchNameByCommitId={(commitId) =>
 														headInfoIndex?.commitContextByCommitId(commitId)?.segment.refName
 															?.displayName
@@ -741,6 +748,7 @@ export const FilesTree: FC<
 											fileParent={fileParent}
 											focusScope={focusScope}
 											tooltipHandle={tooltipHandle}
+											ageBadgeNow={ageBadgeNow}
 											branchNameByCommitId={() => undefined}
 											anyOperationPending
 											menuItems={[]}

--- a/apps/lite/ui/src/routes/project/$id/workspace/Page.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Page.tsx
@@ -492,6 +492,9 @@ const PageBody: FC<{ projectId: string }> = ({ projectId }) => {
 		projectSlice.selectors.selectUncommittedFilesFilter(state, projectId),
 	);
 	const uncommittedFilesDisplayMode = useFileDisplayMode();
+	const uncommittedFilesRecentFirst = useAppSelector((state) =>
+		projectSlice.selectors.selectUncommittedFilesRecentFirst(state, projectId),
+	);
 	const uncommittedFilesCollapsedDirectories = useAppSelector((state) =>
 		projectSlice.selectors.selectUncommittedFilesCollapsedDirectories(state, projectId),
 	);
@@ -500,6 +503,7 @@ const PageBody: FC<{ projectId: string }> = ({ projectId }) => {
 		filter: uncommittedFilesFilter,
 		mode: uncommittedFilesDisplayMode,
 		collapsedDirectories: uncommittedFilesCollapsedDirectories,
+		recentFirst: uncommittedFilesRecentFirst,
 	});
 	// Directories take the cursor as files do, so the index follows the layout the
 	// list renders — and a collapsed directory takes its files out of it too.

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/UncommittedChangesRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/UncommittedChangesRow.tsx
@@ -17,7 +17,7 @@ import {
 import { projectSlice } from "#ui/projects/state.ts";
 import { getLineStats } from "#ui/routes/project/$id/workspace/lineStats.ts";
 import { focusScope } from "#ui/focus-scopes.ts";
-import { useAppSelector, useAppStore } from "#ui/store.ts";
+import { useAppDispatch, useAppSelector, useAppStore } from "#ui/store.ts";
 import { Toolbar } from "@base-ui/react";
 import type { TreeChange } from "@gitbutler/but-sdk";
 import type { FC } from "react";
@@ -41,6 +41,10 @@ export const UncommittedChangesRow: FC<{
 
 	const address = uncommittedChangesAddress;
 	const store = useAppStore();
+	const dispatch = useAppDispatch();
+	const recentFirst = useAppSelector((state) =>
+		projectSlice.selectors.selectUncommittedFilesRecentFirst(state, projectId),
+	);
 	const noOperationPending = useAppSelector(
 		(state) => projectSlice.selectors.selectPendingOperation(state, projectId)._tag === "None",
 	);
@@ -102,6 +106,16 @@ export const UncommittedChangesRow: FC<{
 		}),
 		nativeMenuSeparator,
 		...fileDisplayModeMenuItems,
+		nativeMenuSeparator,
+		// Apart from the two above: those are exclusive of each other, this is
+		// ordering and combines with either.
+		nativeMenuItem({
+			label: "Sort by Last Modified",
+			checked: recentFirst,
+			onSelect: () => {
+				dispatch(projectSlice.actions.toggleUncommittedFilesRecentFirst({ projectId }));
+			},
+		}),
 	];
 
 	return (

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.tsx
@@ -65,6 +65,7 @@ import {
 import { getOperation, type Placement, useDryRunOperation } from "#ui/operations/operation.ts";
 import { createDiffSpec } from "#ui/operations/diff-specs.ts";
 import { GraphSegment, type GraphSegmentStatus } from "#ui/components/GraphSegment.tsx";
+import { useNow } from "#ui/components/useNow.ts";
 import { segmentBottomRelativeTo } from "#ui/api/stack.ts";
 import { assert } from "#ui/assert.ts";
 import { CommitRow } from "./CommitRow.tsx";
@@ -267,6 +268,11 @@ const UncommittedChanges: FC<
 		projectSlice.selectors.selectUncommittedFilesFilter(state, projectId),
 	);
 	const fileDisplayMode = useFileDisplayMode();
+	const recentFirst = useAppSelector((state) =>
+		projectSlice.selectors.selectUncommittedFilesRecentFirst(state, projectId),
+	);
+	// Ticks only while the recency view needs its labels and freshness to age.
+	const ageBadgeNow = useNow(recentFirst ? 30_000 : null);
 	const collapsedDirectories = useAppSelector((state) =>
 		projectSlice.selectors.selectUncommittedFilesCollapsedDirectories(state, projectId),
 	);
@@ -275,6 +281,7 @@ const UncommittedChanges: FC<
 		filter,
 		mode: fileDisplayMode,
 		collapsedDirectories,
+		recentFirst,
 	});
 
 	const fileSelection = useSelection("uncommitted", addressSpace);
@@ -335,6 +342,7 @@ const UncommittedChanges: FC<
 					}
 					fileParent={uncommittedChangesFileParent}
 					rows={fileRows}
+					ageBadgeNow={recentFirst ? ageBadgeNow : null}
 					collapsedDirectories={collapsedDirectories}
 					onToggleDirectoryCollapsed={(path) =>
 						dispatch(

--- a/apps/lite/ui/src/routes/project/$id/workspace/file-row.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/file-row.ts
@@ -1,4 +1,5 @@
 import { getDependencyCommitIds, getHunkDependencyDiffsByPath } from "#ui/hunk.ts";
+import { compareFilePaths } from "#ui/file-order.ts";
 import { buildFileTreeRows, type FileDisplayMode, type FileTreeRow } from "./file-tree.ts";
 import type { TreeChange, WorktreeChanges } from "@gitbutler/but-sdk";
 
@@ -6,26 +7,34 @@ type ChangeFileRowItem = {
 	change: TreeChange;
 	dependencyCommitIds: Array<string>;
 	path: string;
+	modifiedAtMs?: number | null;
 };
 
 export const changeFileRowItem = ({
 	change,
 	dependencyCommitIds,
 	path,
+	modifiedAtMs = null,
 }: ChangeFileRowItem): FileRowItem => ({
 	_tag: "Change",
 	change,
 	dependencyCommitIds,
 	path,
+	modifiedAtMs,
 });
 
 type ConflictFileRowItem = {
 	path: string;
+	modifiedAtMs?: number | null;
 };
 
-export const conflictFileRowItem = ({ path }: ConflictFileRowItem): FileRowItem => ({
+export const conflictFileRowItem = ({
+	path,
+	modifiedAtMs = null,
+}: ConflictFileRowItem): FileRowItem => ({
 	_tag: "Conflict",
 	path,
+	modifiedAtMs,
 });
 
 export const getChangesFileRowItems = (worktreeChanges: WorktreeChanges): Array<FileRowItem> => {
@@ -33,9 +42,17 @@ export const getChangesFileRowItems = (worktreeChanges: WorktreeChanges): Array<
 		worktreeChanges.dependencies?.diffs ?? [],
 	);
 
-	// Conflicted files are kept out of `changes` until resolved.
+	// Conflicted files are kept out of `changes` until resolved, but they still
+	// sit on disk, so they carry a modification time like any other row.
 	const conflicts = worktreeChanges.ignoredChanges.flatMap((change) =>
-		change.status === "Conflict" ? [conflictFileRowItem({ path: change.path })] : [],
+		change.status === "Conflict"
+			? [
+					conflictFileRowItem({
+						path: change.path,
+						modifiedAtMs: worktreeChanges.modificationTimes[change.path] ?? null,
+					}),
+				]
+			: [],
 	);
 
 	const changes = worktreeChanges.changes.map((change) => {
@@ -48,6 +65,7 @@ export const getChangesFileRowItems = (worktreeChanges: WorktreeChanges): Array<
 			change,
 			dependencyCommitIds,
 			path: change.path,
+			modifiedAtMs: worktreeChanges.modificationTimes[change.path] ?? null,
 		});
 	});
 
@@ -63,11 +81,13 @@ export const buildUncommittedFileRows = ({
 	filter,
 	mode,
 	collapsedDirectories,
+	recentFirst,
 }: {
 	worktreeChanges: WorktreeChanges | undefined;
 	filter: string | null;
 	mode: FileDisplayMode;
 	collapsedDirectories: Record<string, true>;
+	recentFirst: boolean;
 }): Array<FileTreeRow<FileRowItem>> =>
 	buildFileTreeRows({
 		items: (worktreeChanges ? getChangesFileRowItems(worktreeChanges) : []).filter((item) =>
@@ -75,7 +95,23 @@ export const buildUncommittedFileRows = ({
 		),
 		mode,
 		collapsedDirectories,
+		compare: recentFirst ? compareRecentFirst : undefined,
 	});
+
+/**
+ * Newest first; files with no time (deletions foremost) last, by path. Missing is
+ * its own case, not a zero sentinel, so a genuine epoch mtime still sorts as one.
+ */
+const compareRecentFirst = (a: FileRowItem, b: FileRowItem): number => {
+	const aModified = a.modifiedAtMs ?? null;
+	const bModified = b.modifiedAtMs ?? null;
+	if (aModified === null || bModified === null) {
+		if (aModified !== null) return -1;
+		if (bModified !== null) return 1;
+		return compareFilePaths(a.path, b.path);
+	}
+	return bModified !== aModified ? bModified - aModified : compareFilePaths(a.path, b.path);
+};
 
 /**
  * Case-insensitive substring match over the whole path, so a directory narrows

--- a/apps/lite/ui/src/routes/project/$id/workspace/file-tree.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/file-tree.ts
@@ -136,12 +136,15 @@ export const buildFileTreeRows = <T extends { path: string }>({
 	items,
 	mode,
 	collapsedDirectories,
+	compare,
 }: {
 	items: Array<T>;
 	mode: FileDisplayMode;
 	collapsedDirectories: Record<string, true>;
+	/** Row order; path order when absent. Tree mode still groups by directory around it. */
+	compare?: (a: T, b: T) => number;
 }): Array<FileTreeRow<T>> => {
-	const orderedItems = items.toSorted((a, b) => compareFilePaths(a.path, b.path));
+	const orderedItems = items.toSorted(compare ?? ((a, b) => compareFilePaths(a.path, b.path)));
 
 	if (mode === "list") {
 		return orderedItems.map((item, index) => ({

--- a/apps/lite/ui/src/time.test.ts
+++ b/apps/lite/ui/src/time.test.ts
@@ -7,7 +7,12 @@ vi.hoisted(() => {
 	});
 });
 
-import { formatCompactDurationWith, formatRelativeTimeWith } from "./time.ts";
+import {
+	ageBadgeOpacity,
+	formatAgeBadge,
+	formatCompactDurationWith,
+	formatRelativeTimeWith,
+} from "./time.ts";
 
 describe("formatRelativeTime", () => {
 	const now = 1_800_000_000_000;
@@ -45,7 +50,6 @@ describe("formatRelativeTime", () => {
 		);
 	});
 });
-
 describe("formatCompactDuration", () => {
 	// Node lacks Intl.DurationFormat (see the stub above), so assert on the
 	// unit the formatter picks rather than on localised output.
@@ -75,5 +79,51 @@ describe("formatCompactDuration", () => {
 
 	it("carries a rounded-up minute into the next unit", () => {
 		expect(formatCompactDuration(59 * 60_000 + 59_000)).toMatchInlineSnapshot(`"{"hours":1}"`);
+	});
+});
+
+describe("formatAgeBadge", () => {
+	it("calls anything under a minute now", () => {
+		expect(formatAgeBadge(0)).toBe("now");
+		expect(formatAgeBadge(59_000)).toBe("now");
+	});
+
+	it("abbreviates minutes", () => {
+		expect(formatAgeBadge(3 * 60_000)).toBe("3m");
+		expect(formatAgeBadge(59 * 60_000)).toBe("59m");
+	});
+
+	it("abbreviates hours", () => {
+		expect(formatAgeBadge(60 * 60_000)).toBe("1h");
+		expect(formatAgeBadge(2.5 * 60 * 60_000)).toBe("2h");
+	});
+
+	it("abbreviates days and weeks", () => {
+		expect(formatAgeBadge(24 * 60 * 60_000)).toBe("1d");
+		expect(formatAgeBadge(6 * 24 * 60 * 60_000)).toBe("6d");
+		expect(formatAgeBadge(7 * 24 * 60 * 60_000)).toBe("1w");
+	});
+
+	it("labels every age, however old", () => {
+		expect(formatAgeBadge(3 * 60 * 60_000 + 1)).toBe("3h");
+		expect(formatAgeBadge(365 * 24 * 60 * 60_000)).toBe("52w");
+	});
+});
+
+describe("ageBadgeOpacity", () => {
+	it("gives a just-written change full contrast", () => {
+		expect(ageBadgeOpacity(0)).toBe(1);
+	});
+
+	it("fades monotonically as the change recedes", () => {
+		const ages = [0, 60_000, 60 * 60_000, 24 * 60 * 60_000].map(ageBadgeOpacity);
+		expect(ages).toEqual([...ages].sort((a, b) => b - a));
+		expect(new Set(ages).size).toBe(ages.length);
+	});
+
+	it("floors instead of fading to nothing", () => {
+		expect(ageBadgeOpacity(24 * 60 * 60_000)).toBeCloseTo(0.35, 5);
+		// A year old is no fainter than a day old, so the badge stays readable.
+		expect(ageBadgeOpacity(365 * 24 * 60 * 60_000)).toBeCloseTo(0.35, 5);
 	});
 });

--- a/apps/lite/ui/src/time.ts
+++ b/apps/lite/ui/src/time.ts
@@ -89,3 +89,36 @@ const stdAbsoluteTimeFormatter = new Intl.DateTimeFormat(undefined, {
 
 export const formatAbsoluteTime = (timestamp: number): string =>
 	stdAbsoluteTimeFormatter.format(timestamp);
+
+/**
+ * Abbreviated age for tight row badges: "now", "3m", "2h", "5d", "3w". Every age
+ * gets a label; how far back it is reads from {@link ageBadgeOpacity} instead.
+ */
+export const formatAgeBadge = (ageMs: number): string => {
+	const minutes = Math.floor(Math.max(0, ageMs) / 60_000);
+	if (minutes < 1) return "now";
+	if (minutes < 60) return `${minutes}m`;
+
+	const hours = Math.floor(minutes / 60);
+	if (hours < 24) return `${hours}h`;
+
+	const days = Math.floor(hours / 24);
+	return days < 7 ? `${days}d` : `${Math.floor(days / 7)}w`;
+};
+
+/** How faint an old badge is allowed to get before it stops being readable. */
+const AGE_BADGE_MIN_OPACITY = 0.35;
+
+/** The age at which a badge reaches {@link AGE_BADGE_MIN_OPACITY}. */
+const AGE_BADGE_FADE_SPAN_MINUTES = 24 * 60;
+
+/**
+ * Contrast for an age badge, easing from full strength down to a legible floor.
+ * Logarithmic: five minutes versus an hour matters far more to someone scanning
+ * than five days versus a week.
+ */
+export const ageBadgeOpacity = (ageMs: number): number => {
+	const minutes = Math.max(0, ageMs) / 60_000;
+	const fade = Math.min(1, Math.log1p(minutes) / Math.log1p(AGE_BADGE_FADE_SPAN_MINUTES));
+	return 1 - (1 - AGE_BADGE_MIN_OPACITY) * fade;
+};

--- a/crates/but-api/src/diff.rs
+++ b/crates/but-api/src/diff.rs
@@ -105,6 +105,19 @@ pub fn tree_change_diffs(
     change.unified_patch(&repo, ctx.settings.context_lines)
 }
 
+/// The UI's worktree changes, with the modification times the file lists show.
+///
+/// Composed here rather than in `but_core::diff::ui::worktree_changes()`, which
+/// leaves them out: the stat pass costs one syscall per changed file, and most
+/// of its callers want only the changes.
+fn worktree_changes_with_modification_times(
+    repo: &gix::Repository,
+) -> anyhow::Result<but_core::ui::WorktreeChanges> {
+    let mut changes: but_core::ui::WorktreeChanges = but_core::diff::worktree_changes(repo)?.into();
+    changes.modification_times = but_core::diff::ui::modification_times(repo, &changes);
+    Ok(changes)
+}
+
 /// See [`changes_in_worktree_with_perm()`].
 #[but_api(napi, provides = [WorktreeChanges])]
 #[instrument(err(Debug))]
@@ -157,12 +170,12 @@ pub fn changes_in_worktree_with_perm(
     let context_lines = ctx.settings.context_lines;
 
     if let Some((_name, wt_repo)) = crate::worktrees::open_changes_source(ctx, &changes_source)? {
-        return Ok(but_core::diff::worktree_changes(&wt_repo)?.into());
+        return Ok(worktree_changes_with_modification_times(&wt_repo)?.into());
     }
 
     if !compute_deps_and_assignments {
         let repo = ctx.repo.get()?;
-        return Ok(but_core::diff::worktree_changes(&repo)?.into());
+        return Ok(worktree_changes_with_modification_times(&repo)?.into());
     }
 
     let (repo, ws, mut db) = ctx.workspace_and_db_mut_with_perm(perm)?;
@@ -187,10 +200,14 @@ pub fn changes_in_worktree_with_perm(
     };
 
     trans.commit()?;
+
+    let mut worktree_changes: but_core::ui::WorktreeChanges = changes.into();
+    worktree_changes.modification_times =
+        but_core::diff::ui::modification_times(&repo, &worktree_changes);
     drop((repo, ws, db));
 
     Ok(WorktreeChanges {
-        worktree_changes: changes.into(),
+        worktree_changes,
         assignments,
         assignments_error: assignments_error.map(|err| serde_error::Error::new(&*err)),
         dependencies: dependencies.as_ref().ok().cloned(),

--- a/crates/but-api/tests/api/changes_in_worktree.rs
+++ b/crates/but-api/tests/api/changes_in_worktree.rs
@@ -120,5 +120,12 @@ fn head_source_reads_the_main_worktree() -> Result<()> {
         ["main-only.txt"],
         "an active linked worktree must not leak into the main worktree's changes"
     );
+    assert!(
+        changes
+            .worktree_changes
+            .modification_times
+            .contains_key("main-only.txt"),
+        "a changed file that exists on disk gets a modification time"
+    );
     Ok(())
 }

--- a/crates/but-core/src/diff/ui.rs
+++ b/crates/but-core/src/diff/ui.rs
@@ -1,8 +1,12 @@
 // TODO: all of these should go away.
 use gix::prelude::ObjectIdExt;
 
+use std::collections::BTreeMap;
+
+use bstr::ByteSlice;
+
 use crate::{
-    Commit,
+    Commit, IgnoredWorktreeTreeChangeStatus,
     commit::ConflictEntries,
     ui::{TreeChanges, WorktreeChanges},
 };
@@ -10,6 +14,47 @@ use crate::{
 /// See [`super::worktree_changes()`].
 pub fn worktree_changes(repo: &gix::Repository) -> anyhow::Result<WorktreeChanges> {
     Ok(super::worktree_changes(repo)?.into())
+}
+
+/// Modification times for `changes`, one `symlink_metadata` per path, keyed as
+/// [`WorktreeChanges::modification_times`] describes. Conflicted ignored changes
+/// are statted too — a conflict is still a file whose recency the user can ask
+/// about. Paths that cannot be statted, deletions foremost, are absent.
+///
+/// Separate from [`worktree_changes()`] so only callers wanting the times pay
+/// for the stat pass; most take just the changes.
+pub fn modification_times(
+    repo: &gix::Repository,
+    changes: &WorktreeChanges,
+) -> BTreeMap<String, u64> {
+    let Some(workdir) = repo.workdir() else {
+        return BTreeMap::new();
+    };
+    let conflicts = changes
+        .ignored_changes
+        .iter()
+        .filter(|ignored| matches!(ignored.status, IgnoredWorktreeTreeChangeStatus::Conflict))
+        .map(|ignored| ignored.path.as_bstr());
+    changes
+        .changes
+        .iter()
+        .map(|change| change.path_bytes.as_bstr())
+        .chain(conflicts)
+        .filter_map(|path_bytes| {
+            let path = workdir.join(gix::path::from_bstr(path_bytes));
+            let modified = path.symlink_metadata().ok()?.modified().ok()?;
+            let millis = modified
+                .duration_since(std::time::UNIX_EPOCH)
+                .ok()?
+                .as_millis();
+            // The same lossy conversion the paths serialize with, so the key
+            // always matches the change the frontend sees.
+            Some((
+                path_bytes.to_str_lossy().into_owned(),
+                u64::try_from(millis).ok()?,
+            ))
+        })
+        .collect()
 }
 
 /// See [`super::tree_changes_with_line_stats()`].

--- a/crates/but-core/src/ui.rs
+++ b/crates/but-core/src/ui.rs
@@ -1,4 +1,6 @@
 #![allow(missing_docs)]
+use std::collections::BTreeMap;
+
 use bstr::BString;
 use but_serde::BStringForFrontend;
 use gix::object::tree::EntryKind;
@@ -81,6 +83,10 @@ pub struct WorktreeChanges {
     pub changes: Vec<TreeChange>,
     /// Changes that were in the index that we can't handle. The user can see them and interact with them to clear them out before a commit can be made.
     pub ignored_changes: Vec<IgnoredWorktreeChange>,
+    /// Filesystem modification times in milliseconds since the Unix epoch, keyed by
+    /// the same (lossy) path as [`TreeChange::path`]. A path with nothing on disk to
+    /// stat — a deletion — is absent.
+    pub modification_times: BTreeMap<String, u64>,
 }
 
 impl WorktreeChanges {
@@ -105,6 +111,7 @@ impl From<crate::WorktreeChanges> for WorktreeChanges {
         WorktreeChanges {
             changes: changes.into_iter().map(Into::into).collect(),
             ignored_changes,
+            modification_times: BTreeMap::new(),
         }
     }
 }

--- a/crates/but-core/tests/core/diff/ui.rs
+++ b/crates/but-core/tests/core/diff/ui.rs
@@ -7,6 +7,8 @@ use crate::diff::worktree_changes::repo_in;
 fn worktree_changes() -> anyhow::Result<()> {
     let repo = repo_in("status-repo", "many-in-worktree")?;
     let actual = serde_json::to_string_pretty(&but_core::diff::ui::worktree_changes(&repo)?)?;
+    // `modificationTimes` is empty by design — the stat pass is composed in at the
+    // API layer. See `but_core::diff::ui::modification_times`.
     snapbox::assert_data_eq!(
         actual,
         snapbox::str![[r#"
@@ -366,7 +368,8 @@ fn worktree_changes() -> anyhow::Result<()> {
       "path": "removed-in-index-changed-in-worktree",
       "status": "TreeIndex"
     }
-  ]
+  ],
+  "modificationTimes": {}
 }
 "#]]
     );

--- a/crates/gitbutler-watcher/src/handler.rs
+++ b/crates/gitbutler-watcher/src/handler.rs
@@ -116,8 +116,12 @@ impl Handler {
             context_lines,
         )?;
 
+        let mut worktree_changes: but_core::ui::WorktreeChanges = wt_changes.clone().into();
+        worktree_changes.modification_times =
+            but_core::diff::ui::modification_times(&repo, &worktree_changes);
+
         let changes = but_hunk_assignment::WorktreeChanges {
-            worktree_changes: wt_changes.clone().into(),
+            worktree_changes,
             assignments: assignments.clone(),
             assignments_error: assignments_error.clone(),
             dependencies: dependencies.as_ref().ok().cloned(),

--- a/packages/but-sdk/src/generated/graph/index.d.ts
+++ b/packages/but-sdk/src/generated/graph/index.d.ts
@@ -149,7 +149,7 @@ export declare function applyBranchIntegration(projectId: string, branch: string
  *
  * See [`assign_hunk_with_perm()`] for details.
  *
- * {@link ../../../../../crates/but-api/src/diff.rs:250}
+ * {@link ../../../../../crates/but-api/src/diff.rs:267}
  */
 export declare function assignHunk(projectId: string, assignments: Array<HunkAssignmentRequest>): Promise<void>
 
@@ -289,7 +289,7 @@ export declare function branchRename(projectId: string, refName: FullNameBytes, 
 /**
  * See [`changes_in_worktree_with_perm()`].
  *
- * {@link ../../../../../crates/but-api/src/diff.rs:109}
+ * {@link ../../../../../crates/but-api/src/diff.rs:122}
  */
 export declare function changesInWorktree(projectId: string, changesSource: ChangesSource, computeDepsAndAssignments: boolean): Promise<WorktreeChanges>
 
@@ -319,7 +319,7 @@ export declare function changesInWorktree(projectId: string, changesSource: Chan
  * [`but_hunk_assignment::assignments_with_fallback()`], and
  * [`but_hunk_dependency::ui::hunk_dependencies_for_workspace_changes_by_worktree_dir()`].
  *
- * {@link ../../../../../crates/but-api/src/diff.rs:149}
+ * {@link ../../../../../crates/but-api/src/diff.rs:162}
  */
 export declare function changesInWorktreeWithPerm(projectId: string, changesSource: ChangesSource, computeDepsAndAssignments: boolean): Promise<WorktreeChanges>
 
@@ -4717,6 +4717,12 @@ export type WorktreeChanges = {
   changes: Array<TreeChange>;
   /** Changes that were in the index that we can't handle. The user can see them and interact with them to clear them out before a commit can be made. */
   ignoredChanges: Array<IgnoredWorktreeChange>;
+  /**
+   * Filesystem modification times in milliseconds since the Unix epoch, keyed by
+   * the same (lossy) path as [`TreeChange::path`]. A path with nothing on disk to
+   * stat — a deletion — is absent.
+   */
+  modificationTimes: Record<string, number>;
   assignments: Array<HunkAssignment>;
   assignmentsError: SerdeError | null;
   dependencies: HunkDependencies | null;

--- a/packages/but-sdk/src/generated/linear/index.d.ts
+++ b/packages/but-sdk/src/generated/linear/index.d.ts
@@ -149,7 +149,7 @@ export declare function applyBranchIntegration(projectId: string, branch: string
  *
  * See [`assign_hunk_with_perm()`] for details.
  *
- * {@link ../../../../../crates/but-api/src/diff.rs:250}
+ * {@link ../../../../../crates/but-api/src/diff.rs:267}
  */
 export declare function assignHunk(projectId: string, assignments: Array<HunkAssignmentRequest>): Promise<void>
 
@@ -289,7 +289,7 @@ export declare function branchRename(projectId: string, refName: FullNameBytes, 
 /**
  * See [`changes_in_worktree_with_perm()`].
  *
- * {@link ../../../../../crates/but-api/src/diff.rs:109}
+ * {@link ../../../../../crates/but-api/src/diff.rs:122}
  */
 export declare function changesInWorktree(projectId: string, changesSource: ChangesSource, computeDepsAndAssignments: boolean): Promise<WorktreeChanges>
 
@@ -319,7 +319,7 @@ export declare function changesInWorktree(projectId: string, changesSource: Chan
  * [`but_hunk_assignment::assignments_with_fallback()`], and
  * [`but_hunk_dependency::ui::hunk_dependencies_for_workspace_changes_by_worktree_dir()`].
  *
- * {@link ../../../../../crates/but-api/src/diff.rs:149}
+ * {@link ../../../../../crates/but-api/src/diff.rs:162}
  */
 export declare function changesInWorktreeWithPerm(projectId: string, changesSource: ChangesSource, computeDepsAndAssignments: boolean): Promise<WorktreeChanges>
 
@@ -4714,6 +4714,12 @@ export type WorktreeChanges = {
   changes: Array<TreeChange>;
   /** Changes that were in the index that we can't handle. The user can see them and interact with them to clear them out before a commit can be made. */
   ignoredChanges: Array<IgnoredWorktreeChange>;
+  /**
+   * Filesystem modification times in milliseconds since the Unix epoch, keyed by
+   * the same (lossy) path as [`TreeChange::path`]. A path with nothing on disk to
+   * stat — a deletion — is absent.
+   */
+  modificationTimes: Record<string, number>;
   assignments: Array<HunkAssignment>;
   assignmentsError: SerdeError | null;
   dependencies: HunkDependencies | null;


### PR DESCRIPTION
Adds a recency view to the uncommitted file list, so the files you just touched are the ones you see first.

### What it does

- **Sort by Last Modified** in the Uncommitted header's menu (next to View as List/Tree) sorts the list newest-first, off by default. It only changes the order — the list/tree shape setting stays in force.
- Every row carries an abbreviated age badge (`now`, `3m`, `2h`, `5d`, `3w`), sitting right of the kebab column.
- The badge's **contrast fades with age** rather than disappearing: full strength for a change just written, easing to a floor that stays readable. The curve is logarithmic, because the gap between five minutes and an hour matters far more when scanning than the gap between five days and a week.
- Rows older than an hour add the full time ago (`5 hours ago`) to their hover tooltip.
- Changes newer than about a minute pulse, via an inset-shadow animation that leaves hover and selection fills visible underneath. The clock ticks every 30s, so the pulse can outlast the minute by up to that much — it is decoration, and per-row timers would cost more than the imprecision.

### Where the times come from

`changesInWorktree` and the watcher's worktree payload now carry `modificationTimes` — epoch milliseconds keyed by the change's path. They are gathered in one pass in `but-core`'s UI conversion, one `symlink_metadata` per changed file, rather than a query per row.

A path with nothing on disk to stat is simply absent, so **deletions and files removed from the worktree carry no time** and sort last. That is deliberate: a file that no longer exists has no honest last-modified time, and the nearest proxy (the parent directory's mtime) is shared across sibling deletions and silently wrong if anything else in the folder changed.

### Notes

- `modification_times` is a `BTreeMap`, so the serialized key order is stable.
- The `but-core` snapshot test asserts *which* paths carry a time; the values themselves are wall-clock and match as wildcards, so the test does not depend on fixture checkout time.
- The ticking clock that ages the labels mounts only while the recency view is on.

