### PR TITLE
Update `gix` for the best-yet `merge` implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,7 +250,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
  "wl-clipboard-rs",
  "x11rb",
 ]
@@ -2180,7 +2180,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2636,7 +2636,7 @@ dependencies = [
  "openssl-sys",
  "schannel",
  "socket2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2651,7 +2651,7 @@ dependencies = [
  "openssl-sys",
  "pkg-config",
  "vcpkg",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2937,7 +2937,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3181,7 +3181,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3803,7 +3803,7 @@ dependencies = [
 [[package]]
 name = "git-meta-lib"
 version = "0.1.12"
-source = "git+https://github.com/git-meta/git-meta?rev=61cabd2840197cda3caf1852a925b101ea0c244f#61cabd2840197cda3caf1852a925b101ea0c244f"
+source = "git+https://github.com/git-meta/git-meta?rev=d5ad47dcd2935f0ca1836cef0cbab03ca1431190#d5ad47dcd2935f0ca1836cef0cbab03ca1431190"
 dependencies = [
  "gix",
  "rusqlite",
@@ -4223,8 +4223,8 @@ dependencies = [
 
 [[package]]
 name = "gix"
-version = "0.86.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+version = "0.87.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "gix-actor",
  "gix-attributes",
@@ -4249,13 +4249,15 @@ dependencies = [
  "gix-mailmap",
  "gix-merge",
  "gix-negotiate",
+ "gix-note",
  "gix-object",
  "gix-odb",
  "gix-pack",
- "gix-path 0.12.3",
+ "gix-path 0.12.5",
  "gix-pathspec",
  "gix-prompt",
  "gix-protocol",
+ "gix-quote",
  "gix-ref",
  "gix-refspec",
  "gix-revision",
@@ -4270,7 +4272,7 @@ dependencies = [
  "gix-traverse",
  "gix-url",
  "gix-utils",
- "gix-validate 0.11.3",
+ "gix-validate 0.11.4",
  "gix-worktree",
  "gix-worktree-state",
  "gix-worktree-stream",
@@ -4285,8 +4287,8 @@ dependencies = [
 
 [[package]]
 name = "gix-actor"
-version = "0.41.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+version = "0.42.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "bstr",
  "gix-date",
@@ -4296,13 +4298,13 @@ dependencies = [
 
 [[package]]
 name = "gix-attributes"
-version = "0.34.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+version = "0.35.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "bstr",
  "gix-features",
  "gix-glob",
- "gix-path 0.12.3",
+ "gix-path 0.12.5",
  "gix-quote",
  "gix-trace 0.1.21",
  "serde",
@@ -4313,27 +4315,27 @@ dependencies = [
 
 [[package]]
 name = "gix-bitmap"
-version = "0.3.3"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+version = "0.4.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "gix-error",
 ]
 
 [[package]]
 name = "gix-chunk"
-version = "0.7.3"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+version = "0.8.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "gix-error",
 ]
 
 [[package]]
 name = "gix-command"
-version = "0.9.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+version = "0.10.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "bstr",
- "gix-path 0.12.3",
+ "gix-path 0.12.5",
  "gix-quote",
  "gix-trace 0.1.21",
  "shell-words",
@@ -4341,8 +4343,8 @@ dependencies = [
 
 [[package]]
 name = "gix-commitgraph"
-version = "0.38.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+version = "0.39.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "bstr",
  "gix-chunk",
@@ -4355,14 +4357,14 @@ dependencies = [
 
 [[package]]
 name = "gix-config"
-version = "0.59.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+version = "0.60.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "bstr",
  "gix-config-value",
  "gix-features",
  "gix-glob",
- "gix-path 0.12.3",
+ "gix-path 0.12.5",
  "gix-ref",
  "gix-sec",
  "gix-utils",
@@ -4373,27 +4375,28 @@ dependencies = [
 
 [[package]]
 name = "gix-config-value"
-version = "0.19.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+version = "0.19.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "bitflags 2.13.0",
  "bstr",
- "gix-path 0.12.3",
+ "gix-path 0.12.5",
  "libc",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-credentials"
-version = "0.39.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+version = "0.40.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "bstr",
  "gix-command",
  "gix-config-value",
  "gix-date",
- "gix-path 0.12.3",
+ "gix-path 0.12.5",
  "gix-prompt",
+ "gix-quote",
  "gix-sec",
  "gix-trace 0.1.21",
  "gix-url",
@@ -4403,8 +4406,8 @@ dependencies = [
 
 [[package]]
 name = "gix-date"
-version = "0.15.6"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+version = "0.16.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "bstr",
  "gix-error",
@@ -4415,8 +4418,8 @@ dependencies = [
 
 [[package]]
 name = "gix-diff"
-version = "0.66.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+version = "0.67.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "bstr",
  "gix-attributes",
@@ -4427,7 +4430,7 @@ dependencies = [
  "gix-imara-diff",
  "gix-index",
  "gix-object",
- "gix-path 0.12.3",
+ "gix-path 0.12.5",
  "gix-pathspec",
  "gix-tempfile",
  "gix-trace 0.1.21",
@@ -4438,8 +4441,8 @@ dependencies = [
 
 [[package]]
 name = "gix-dir"
-version = "0.28.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+version = "0.29.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "bstr",
  "gix-discover",
@@ -4447,7 +4450,7 @@ dependencies = [
  "gix-ignore",
  "gix-index",
  "gix-object",
- "gix-path 0.12.3",
+ "gix-path 0.12.5",
  "gix-pathspec",
  "gix-trace 0.1.21",
  "gix-utils",
@@ -4457,13 +4460,13 @@ dependencies = [
 
 [[package]]
 name = "gix-discover"
-version = "0.54.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+version = "0.55.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "bstr",
  "dunce",
  "gix-fs",
- "gix-path 0.12.3",
+ "gix-path 0.12.5",
  "gix-ref",
  "gix-sec",
  "thiserror 2.0.18",
@@ -4471,21 +4474,21 @@ dependencies = [
 
 [[package]]
 name = "gix-error"
-version = "0.2.5"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+version = "0.3.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "bstr",
 ]
 
 [[package]]
 name = "gix-features"
-version = "0.49.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+version = "0.49.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "bytes",
  "crc32fast",
  "crossbeam-channel",
- "gix-path 0.12.3",
+ "gix-path 0.12.5",
  "gix-trace 0.1.21",
  "gix-utils",
  "libc",
@@ -4497,8 +4500,8 @@ dependencies = [
 
 [[package]]
 name = "gix-filter"
-version = "0.33.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+version = "0.34.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "bstr",
  "encoding_rs",
@@ -4507,7 +4510,7 @@ dependencies = [
  "gix-hash",
  "gix-object",
  "gix-packetline",
- "gix-path 0.12.3",
+ "gix-path 0.12.5",
  "gix-quote",
  "gix-trace 0.1.21",
  "gix-utils",
@@ -4517,32 +4520,32 @@ dependencies = [
 
 [[package]]
 name = "gix-fs"
-version = "0.22.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+version = "0.22.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "bstr",
  "gix-features",
- "gix-path 0.12.3",
+ "gix-path 0.12.5",
  "gix-utils",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-glob"
-version = "0.27.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+version = "0.27.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "bitflags 2.13.0",
  "bstr",
  "gix-features",
- "gix-path 0.12.3",
+ "gix-path 0.12.5",
  "serde",
 ]
 
 [[package]]
 name = "gix-hash"
-version = "0.26.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+version = "0.26.2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "faster-hex",
  "gix-features",
@@ -4555,7 +4558,7 @@ dependencies = [
 [[package]]
 name = "gix-hashtable"
 version = "0.16.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "gix-hash",
  "hashbrown 0.17.1",
@@ -4564,12 +4567,12 @@ dependencies = [
 
 [[package]]
 name = "gix-ignore"
-version = "0.22.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+version = "0.22.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "bstr",
  "gix-glob",
- "gix-path 0.12.3",
+ "gix-path 0.12.5",
  "gix-trace 0.1.21",
  "serde",
  "unicode-bom",
@@ -4577,8 +4580,8 @@ dependencies = [
 
 [[package]]
 name = "gix-imara-diff"
-version = "0.2.4"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+version = "0.2.5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "bstr",
  "hashbrown 0.17.1",
@@ -4586,8 +4589,8 @@ dependencies = [
 
 [[package]]
 name = "gix-index"
-version = "0.54.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+version = "0.55.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "bitflags 2.13.0",
  "bstr",
@@ -4601,7 +4604,7 @@ dependencies = [
  "gix-object",
  "gix-traverse",
  "gix-utils",
- "gix-validate 0.11.3",
+ "gix-validate 0.11.4",
  "hashbrown 0.17.1",
  "itoa",
  "libc",
@@ -4615,7 +4618,7 @@ dependencies = [
 [[package]]
 name = "gix-lock"
 version = "24.0.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "gix-tempfile",
  "gix-utils",
@@ -4624,8 +4627,8 @@ dependencies = [
 
 [[package]]
 name = "gix-mailmap"
-version = "0.33.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+version = "0.34.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "bstr",
  "gix-actor",
@@ -4636,8 +4639,8 @@ dependencies = [
 
 [[package]]
 name = "gix-merge"
-version = "0.19.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+version = "0.20.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "bstr",
  "gix-command",
@@ -4648,7 +4651,7 @@ dependencies = [
  "gix-imara-diff",
  "gix-index",
  "gix-object",
- "gix-path 0.12.3",
+ "gix-path 0.12.5",
  "gix-quote",
  "gix-revision",
  "gix-revwalk",
@@ -4661,8 +4664,8 @@ dependencies = [
 
 [[package]]
 name = "gix-negotiate"
-version = "0.34.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+version = "0.35.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "bitflags 2.13.0",
  "gix-commitgraph",
@@ -4673,18 +4676,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix-note"
+version = "0.1.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+dependencies = [
+ "gix-error",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+]
+
+[[package]]
 name = "gix-object"
-version = "0.63.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+version = "0.64.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "bstr",
  "gix-actor",
+ "gix-command",
  "gix-date",
  "gix-features",
  "gix-hash",
  "gix-hashtable",
+ "gix-tempfile",
  "gix-utils",
- "gix-validate 0.11.3",
+ "gix-validate 0.11.4",
  "itoa",
  "serde",
  "smallvec",
@@ -4693,8 +4709,8 @@ dependencies = [
 
 [[package]]
 name = "gix-odb"
-version = "0.83.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+version = "0.84.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "arc-swap",
  "gix-features",
@@ -4703,7 +4719,7 @@ dependencies = [
  "gix-hashtable",
  "gix-object",
  "gix-pack",
- "gix-path 0.12.3",
+ "gix-path 0.12.5",
  "gix-quote",
  "gix-zlib",
  "memmap2",
@@ -4715,17 +4731,18 @@ dependencies = [
 
 [[package]]
 name = "gix-pack"
-version = "0.73.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+version = "0.74.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "clru",
+ "crossbeam-deque",
  "gix-chunk",
  "gix-error",
  "gix-features",
  "gix-hash",
  "gix-hashtable",
  "gix-object",
- "gix-path 0.12.3",
+ "gix-path 0.12.5",
  "gix-tempfile",
  "gix-zlib",
  "memmap2",
@@ -4738,8 +4755,8 @@ dependencies = [
 
 [[package]]
 name = "gix-packetline"
-version = "0.22.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+version = "0.22.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "bstr",
  "faster-hex",
@@ -4761,33 +4778,33 @@ dependencies = [
 
 [[package]]
 name = "gix-path"
-version = "0.12.3"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+version = "0.12.5"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "bstr",
  "gix-trace 0.1.21",
- "gix-validate 0.11.3",
+ "gix-validate 0.11.4",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-pathspec"
-version = "0.19.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+version = "0.20.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "bitflags 2.13.0",
  "bstr",
  "gix-attributes",
  "gix-config-value",
  "gix-glob",
- "gix-path 0.12.3",
+ "gix-path 0.12.5",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-prompt"
-version = "0.16.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+version = "0.17.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -4798,8 +4815,8 @@ dependencies = [
 
 [[package]]
 name = "gix-protocol"
-version = "0.64.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+version = "0.65.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "bisync",
  "bstr",
@@ -4824,8 +4841,8 @@ dependencies = [
 
 [[package]]
 name = "gix-quote"
-version = "0.7.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+version = "0.8.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "bstr",
  "gix-error",
@@ -4834,8 +4851,8 @@ dependencies = [
 
 [[package]]
 name = "gix-ref"
-version = "0.66.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+version = "0.67.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "gix-actor",
  "gix-features",
@@ -4843,10 +4860,10 @@ dependencies = [
  "gix-hash",
  "gix-lock",
  "gix-object",
- "gix-path 0.12.3",
+ "gix-path 0.12.5",
  "gix-tempfile",
  "gix-utils",
- "gix-validate 0.11.3",
+ "gix-validate 0.11.4",
  "memmap2",
  "serde",
  "thiserror 2.0.18",
@@ -4854,23 +4871,20 @@ dependencies = [
 
 [[package]]
 name = "gix-refspec"
-version = "0.44.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+version = "0.45.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "bstr",
- "gix-error",
- "gix-glob",
  "gix-hash",
- "gix-revision",
- "gix-validate 0.11.3",
+ "gix-validate 0.11.4",
  "smallvec",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-revision"
-version = "0.48.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+version = "0.49.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "bitflags 2.13.0",
  "bstr",
@@ -4888,8 +4902,8 @@ dependencies = [
 
 [[package]]
 name = "gix-revwalk"
-version = "0.34.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+version = "0.35.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "gix-commitgraph",
  "gix-date",
@@ -4904,10 +4918,10 @@ dependencies = [
 [[package]]
 name = "gix-sec"
 version = "0.14.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "bitflags 2.13.0",
- "gix-path 0.12.3",
+ "gix-path 0.12.5",
  "libc",
  "serde",
  "windows-sys 0.61.2",
@@ -4916,7 +4930,7 @@ dependencies = [
 [[package]]
 name = "gix-shallow"
 version = "0.13.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "bstr",
  "gix-hash",
@@ -4928,8 +4942,8 @@ dependencies = [
 
 [[package]]
 name = "gix-status"
-version = "0.33.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+version = "0.34.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "bstr",
  "filetime",
@@ -4941,7 +4955,7 @@ dependencies = [
  "gix-hash",
  "gix-index",
  "gix-object",
- "gix-path 0.12.3",
+ "gix-path 0.12.5",
  "gix-pathspec",
  "gix-worktree",
  "hashbrown 0.16.1",
@@ -4952,12 +4966,12 @@ dependencies = [
 
 [[package]]
 name = "gix-submodule"
-version = "0.33.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+version = "0.34.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "bstr",
  "gix-config",
- "gix-path 0.12.3",
+ "gix-path 0.12.5",
  "gix-pathspec",
  "gix-refspec",
  "gix-url",
@@ -4967,7 +4981,7 @@ dependencies = [
 [[package]]
 name = "gix-tempfile"
 version = "24.0.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "dashmap",
  "gix-fs",
@@ -4981,16 +4995,23 @@ dependencies = [
 [[package]]
 name = "gix-testtools"
 version = "0.20.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "bstr",
  "crc",
  "fastrand",
  "fs_extra",
+ "gix-config",
  "gix-discover",
  "gix-fs",
  "gix-hash",
+ "gix-index",
  "gix-lock",
+ "gix-object",
+ "gix-odb",
+ "gix-path 0.12.5",
+ "gix-ref",
+ "gix-shallow",
  "gix-tempfile",
  "gix-worktree",
  "io-close",
@@ -5009,15 +5030,15 @@ checksum = "44dc45eae785c0eb14173e0f152e6e224dcf4d45b6a6999a3aed22af541ad678"
 [[package]]
 name = "gix-trace"
 version = "0.1.21"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "gix-transport"
-version = "0.58.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+version = "0.59.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "base64 0.22.1",
  "bstr",
@@ -5025,7 +5046,7 @@ dependencies = [
  "gix-credentials",
  "gix-features",
  "gix-packetline",
- "gix-path 0.12.3",
+ "gix-path 0.12.5",
  "gix-quote",
  "gix-sec",
  "gix-url",
@@ -5037,8 +5058,8 @@ dependencies = [
 
 [[package]]
 name = "gix-traverse"
-version = "0.60.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+version = "0.61.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "bitflags 2.13.0",
  "gix-commitgraph",
@@ -5053,11 +5074,11 @@ dependencies = [
 
 [[package]]
 name = "gix-url"
-version = "0.37.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+version = "0.38.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "bstr",
- "gix-path 0.12.3",
+ "gix-path 0.12.5",
  "gix-utils",
  "percent-encoding",
  "serde",
@@ -5066,8 +5087,8 @@ dependencies = [
 
 [[package]]
 name = "gix-utils"
-version = "0.3.5"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+version = "0.3.6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "bstr",
  "fastrand",
@@ -5086,16 +5107,16 @@ dependencies = [
 
 [[package]]
 name = "gix-validate"
-version = "0.11.3"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+version = "0.11.4"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "bstr",
 ]
 
 [[package]]
 name = "gix-worktree"
-version = "0.55.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+version = "0.56.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "bstr",
  "gix-attributes",
@@ -5106,15 +5127,15 @@ dependencies = [
  "gix-ignore",
  "gix-index",
  "gix-object",
- "gix-path 0.12.3",
- "gix-validate 0.11.3",
+ "gix-path 0.12.5",
+ "gix-validate 0.11.4",
  "serde",
 ]
 
 [[package]]
 name = "gix-worktree-state"
-version = "0.33.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+version = "0.34.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "bstr",
  "gix-features",
@@ -5122,7 +5143,7 @@ dependencies = [
  "gix-fs",
  "gix-index",
  "gix-object",
- "gix-path 0.12.3",
+ "gix-path 0.12.5",
  "gix-worktree",
  "io-close",
  "thiserror 2.0.18",
@@ -5130,8 +5151,8 @@ dependencies = [
 
 [[package]]
 name = "gix-worktree-stream"
-version = "0.35.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+version = "0.36.0"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "gix-attributes",
  "gix-error",
@@ -5140,7 +5161,7 @@ dependencies = [
  "gix-fs",
  "gix-hash",
  "gix-object",
- "gix-path 0.12.3",
+ "gix-path 0.12.5",
  "gix-traverse",
  "parking_lot",
 ]
@@ -5148,7 +5169,7 @@ dependencies = [
 [[package]]
 name = "gix-zlib"
 version = "0.1.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=83e074c1e2d070059febaaab1022058948855101#83e074c1e2d070059febaaab1022058948855101"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -5903,7 +5924,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6846,7 +6867,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7363,7 +7384,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -8056,7 +8077,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8636,7 +8657,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8694,7 +8715,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10261,7 +10282,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10329,7 +10350,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11671,7 +11692,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -207,11 +207,11 @@ bstr = "1.12.1"
 zip = { version = "4", default-features = false, features = ["bzip2"] }
 # Add the `tracing` or `tracing-detail` features to see more of gitoxide in the logs. Useful to see which programs it invokes.
 # When adjusting this, update `gix-testtools` as well!
-gix = { version = "0.86.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "83e074c1e2d070059febaaab1022058948855101", default-features = false, features = [
+gix = { version = "0.87.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "6704303ed5ef3403b129e2b6cc4a9214432ffd03", default-features = false, features = [
     "sha1",
     "sha256",
 ] }
-gix-testtools = { version = "0.20.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "83e074c1e2d070059febaaab1022058948855101" }
+gix-testtools = { version = "0.20.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "6704303ed5ef3403b129e2b6cc4a9214432ffd03" }
 
 
 git2 = { version = "0.21.0", features = [
@@ -304,15 +304,15 @@ self_cell = "1.2.2"
 unicode-segmentation = "1.13.2"
 urlencoding = "2.1"
 inventory = "0.3"
-git-meta-lib = { git = "https://github.com/git-meta/git-meta", rev = "61cabd2840197cda3caf1852a925b101ea0c244f" }
+git-meta-lib = { git = "https://github.com/git-meta/git-meta", rev = "d5ad47dcd2935f0ca1836cef0cbab03ca1431190" }
 smallvec = "1.15.1"
 
 sapling-renderdag = "0.1.0"
 
 [patch.crates-io]
-# Keep workspace crates that use the `gix 0.86` line on the same git revision.
+# Keep workspace crates that use the `gix 0.87` line on the same git revision.
 # This was relevant to force `git-meta` to use our version.
-gix = { git = "https://github.com/GitoxideLabs/gitoxide", rev = "83e074c1e2d070059febaaab1022058948855101" }
+gix = { git = "https://github.com/GitoxideLabs/gitoxide", rev = "6704303ed5ef3403b129e2b6cc4a9214432ffd03" }
 git2 = { git = "https://github.com/gitbutlerapp/git2-rs", rev = "a87a7bb3f6843504339fe7434ee0732a3e968f3e" }
 
 [workspace.lints.clippy]

--- a/crates/but-api/src/branch.rs
+++ b/crates/but-api/src/branch.rs
@@ -1007,7 +1007,7 @@ pub fn branch_create_with_perm(
             .ok()
             .flatten()
             .as_ref()
-            .is_some_and(|head_ref| head_ref.as_ref() == anchor_ref.as_ref())
+            .is_some_and(|head_ref| head_ref == anchor_ref)
     });
     let new_ws = but_workspace::branch::create_reference(
         new_ref.as_ref(),
@@ -1108,7 +1108,7 @@ pub fn branch_remove_with_perm(
             .head_name()
             .ok()
             .flatten()
-            .is_some_and(|head| head.as_ref() == ref_name.as_ref());
+            .is_some_and(|head| head == ref_name);
         if is_checked_out {
             let (stack, _segment) = ws
                 .find_segment_and_stack_by_refname(ref_name.as_ref())
@@ -1254,7 +1254,7 @@ pub fn branch_rename_with_perm(
     let new_ref = gix::refs::Category::LocalBranch.to_full_name(normalized.as_bstr())?;
 
     // Renaming onto the same name is a no-op that still returns the current view.
-    if ref_name.as_ref() == new_ref.as_ref() {
+    if ref_name == new_ref {
         let mut meta = ctx.meta()?;
         let (repo, ws, mut db) = ctx.workspace_mut_and_db_mut_with_perm(perm)?;
         repo.find_reference(ref_name.as_ref())
@@ -1334,7 +1334,7 @@ pub fn branch_rename_with_perm(
             .head_name()
             .ok()
             .flatten()
-            .is_some_and(|head| head.as_ref() == ref_name.as_ref());
+            .is_some_and(|head| head == ref_name);
 
         let prefix_related = refs_are_prefix_related(ref_name.as_ref(), new_ref.as_ref());
         let mut backup_reference = None;

--- a/crates/but-api/src/json.rs
+++ b/crates/but-api/src/json.rs
@@ -541,7 +541,7 @@ mod maybe_lossy_full_name_ref_tests {
             serde_json::from_str::<MaybeLossyFullNameRef>("\"refs/heads/main\"")
                 .expect("valid full ref name")
                 .into();
-        assert_eq!(actual.expect("present").as_bstr(), "refs/heads/main");
+        assert_eq!(actual.expect("present"), "refs/heads/main");
 
         let actual: Option<gix::refs::FullName> =
             serde_json::from_str::<MaybeLossyFullNameRef>("null")
@@ -560,7 +560,7 @@ mod maybe_lossy_full_name_ref_tests {
         )
         .expect("valid full ref name bytes")
         .into();
-        assert_eq!(actual.as_bstr(), "refs/heads/main");
+        assert_eq!(actual, "refs/heads/main");
 
         serde_json::from_str::<FullNameBytes>("[109,97,105,110]")
             .expect_err("partial ref names are rejected");

--- a/crates/but-api/src/legacy/forge.rs
+++ b/crates/but-api/src/legacy/forge.rs
@@ -1709,7 +1709,7 @@ fn review_updates_after_push(
                 segment
                     .ref_info
                     .as_ref()
-                    .is_some_and(|ref_info| ref_info.ref_name.as_ref() == branch)
+                    .is_some_and(|ref_info| ref_info.ref_name == branch)
             })
         })
         .with_context(|| {
@@ -1916,7 +1916,7 @@ fn stack_and_segment_for_branch<'a>(
                     segment
                         .ref_info
                         .as_ref()
-                        .is_some_and(|ref_info| ref_info.ref_name.as_ref() == branch)
+                        .is_some_and(|ref_info| ref_info.ref_name == branch)
                 })
                 .map(|index| (stack, index))
         })
@@ -1977,7 +1977,7 @@ fn remote_contains(
         return Ok(true);
     }
     match repo.merge_base(ancestor, descendant) {
-        Ok(base) => Ok(base.detach() == ancestor),
+        Ok(base) => Ok(base == ancestor),
         Err(gix::repository::merge_base::Error::FindMergeBase(_))
         | Err(gix::repository::merge_base::Error::NotFound { .. }) => Ok(false),
         Err(err) => Err(err.into()),

--- a/crates/but-api/src/legacy/workspace.rs
+++ b/crates/but-api/src/legacy/workspace.rs
@@ -139,7 +139,7 @@ fn handle_gerrit(
             if matches!(commit.state, but_workspace::ui::CommitState::Integrated) {
                 return Ok(());
             }
-            if commit.id.to_string() == meta.commit_id {
+            if commit.id == meta.commit_id {
                 // Pushed, and identical at the remote
                 commit.state = but_workspace::ui::CommitState::LocalAndRemote(commit.id);
             } else {

--- a/crates/but-api/src/resolve/apply.rs
+++ b/crates/but-api/src/resolve/apply.rs
@@ -373,7 +373,7 @@ pub(crate) fn apply(
         && match *commit.parents.as_slice() {
             [parent] => but_core::Commit::from_id(parent.attach(&repo))
                 .and_then(|parent| parent.tree_id_or_auto_resolution())
-                .is_ok_and(|parent_tree| parent_tree.detach() == merged_tree_id),
+                .is_ok_and(|parent_tree| parent_tree == merged_tree_id),
             _ => false,
         };
     if unresolved {

--- a/crates/but-api/tests/api/branch_apply.rs
+++ b/crates/but-api/tests/api/branch_apply.rs
@@ -90,7 +90,7 @@ fn undo_apply_from_ad_hoc_checkout_restores_checkout_and_workspace() -> anyhow::
         "undoing the apply must return to the original ad-hoc branch"
     );
     assert_eq!(
-        ctx.repo.get()?.head_id()?.detach(),
+        ctx.repo.get()?.head_id()?,
         checkout_before,
         "undoing the apply must restore the original ad-hoc commit"
     );
@@ -98,8 +98,7 @@ fn undo_apply_from_ad_hoc_checkout_restores_checkout_and_workspace() -> anyhow::
         ctx.repo
             .get()?
             .find_reference(but_core::WORKSPACE_REF_NAME)?
-            .peel_to_id()?
-            .detach(),
+            .peel_to_id()?,
         workspace_before,
         "undoing the apply must restore the prior managed workspace commit"
     );

--- a/crates/but-api/tests/api/branch_checkout.rs
+++ b/crates/but-api/tests/api/branch_checkout.rs
@@ -14,7 +14,7 @@ fn checkout_branch_switches_head_and_returns_workspace() -> anyhow::Result<()> {
 
     let repo = ctx.repo.get()?;
     let head_name = repo.head_name()?.expect("HEAD is symbolic after checkout");
-    assert_eq!(head_name.as_bstr(), "refs/heads/feature");
+    assert_eq!(head_name, "refs/heads/feature");
     assert_workspace_ref(&result.workspace, "refs/heads/feature");
 
     Ok(())
@@ -46,9 +46,9 @@ fn branch_checkout_new_creates_named_branch_at_target_and_checks_it_out() -> any
 
     let repo = ctx.repo.get()?;
     let head_name = repo.head_name()?.expect("HEAD is symbolic after checkout");
-    assert_eq!(head_name.as_bstr(), "refs/heads/new-branch");
+    assert_eq!(head_name, "refs/heads/new-branch");
     let mut created = repo.find_reference("refs/heads/new-branch")?;
-    assert_eq!(created.peel_to_id()?.detach(), target_commit_id);
+    assert_eq!(created.peel_to_id()?, target_commit_id);
     assert_workspace_ref(&result.workspace, "refs/heads/new-branch");
 
     Ok(())
@@ -95,7 +95,7 @@ fn checkout_returns_head_info_matching_fresh_head_info() -> anyhow::Result<()> {
     {
         let repo = ctx.repo.get()?;
         let head_name = repo.head_name()?.expect("HEAD is symbolic after checkout");
-        assert_eq!(head_name.as_bstr(), "refs/heads/feature");
+        assert_eq!(head_name, "refs/heads/feature");
 
         snapbox::assert_data_eq!(
             crate::support::repository_graph(&repo)?,
@@ -234,11 +234,11 @@ fn checkout_new_returns_head_info_matching_fresh_head_info() -> anyhow::Result<(
     {
         let repo = ctx.repo.get()?;
         let head_name = repo.head_name()?.expect("HEAD is symbolic after checkout");
-        assert_eq!(head_name.as_bstr(), "refs/heads/new-branch");
+        assert_eq!(head_name, "refs/heads/new-branch");
 
         let mut created = repo.find_reference("refs/heads/new-branch")?;
         assert_eq!(
-            created.peel_to_id()?.detach(),
+            created.peel_to_id()?,
             target_commit_id,
             "new branch should be created at the configured project target"
         );

--- a/crates/but-api/tests/api/branch_create.rs
+++ b/crates/but-api/tests/api/branch_create.rs
@@ -24,7 +24,7 @@ fn branch_create_above_checked_out_ref_checks_out_new_ref_in_ad_hoc_workspace() 
     let head_name = repo
         .head_name()?
         .expect("creating above checked-out branch checks out the new ref");
-    assert_eq!(head_name.as_ref(), new_ref.as_ref());
+    assert_eq!(head_name, new_ref);
     assert_workspace_ref(&result.workspace, "refs/heads/top");
 
     let order = ctx
@@ -57,7 +57,7 @@ fn branch_create_below_checked_out_ref_keeps_head_in_ad_hoc_workspace() -> anyho
     let head_name = repo
         .head_name()?
         .expect("HEAD remains symbolic after create-below");
-    assert_eq!(head_name.as_ref(), anchor_ref.as_ref());
+    assert_eq!(head_name, anchor_ref);
     assert_workspace_ref(&result.workspace, "refs/heads/main");
     assert!(repo.try_find_reference(new_ref.as_ref())?.is_some());
 

--- a/crates/but-api/tests/api/branch_move.rs
+++ b/crates/but-api/tests/api/branch_move.rs
@@ -111,14 +111,8 @@ fn move_non_empty_branch_dry_run_previews_new_tip_without_mutating_repository() 
 
     let repo = ctx.repo.get()?;
     assert_eq!(repo.head_name()?.as_ref(), Some(&head_before));
-    assert_eq!(
-        repo.rev_parse_single(subject.as_ref())?.detach(),
-        subject_tip_before
-    );
-    assert_eq!(
-        repo.rev_parse_single(target.as_ref())?.detach(),
-        target_tip_before
-    );
+    assert_eq!(repo.rev_parse_single(subject.as_ref())?, subject_tip_before);
+    assert_eq!(repo.rev_parse_single(target.as_ref())?, target_tip_before);
     drop(repo);
     assert_eq!(
         ctx.meta()?.branch_stack_order(target.as_ref())?,
@@ -232,10 +226,7 @@ fn move_empty_top_branch_below_middle_preserves_commit_ownership() -> anyhow::Re
     let empty_top: gix::refs::FullName = "refs/heads/C".try_into()?;
     let middle_tip_before = ctx.repo.get()?.rev_parse_single(middle.as_ref())?.detach();
     assert_eq!(
-        ctx.repo
-            .get()?
-            .rev_parse_single(empty_top.as_ref())?
-            .detach(),
+        ctx.repo.get()?.rev_parse_single(empty_top.as_ref())?,
         middle_tip_before,
         "the top branch starts empty"
     );
@@ -251,12 +242,12 @@ fn move_empty_top_branch_below_middle_preserves_commit_ownership() -> anyhow::Re
     let repo = ctx.repo.get()?;
     let bottom_tip = repo.rev_parse_single(bottom.as_ref())?.detach();
     assert_eq!(
-        repo.rev_parse_single(middle.as_ref())?.detach(),
+        repo.rev_parse_single(middle.as_ref())?,
         middle_tip_before,
         "the middle branch keeps owning its commit"
     );
     assert_eq!(
-        repo.rev_parse_single(empty_top.as_ref())?.detach(),
+        repo.rev_parse_single(empty_top.as_ref())?,
         bottom_tip,
         "the moved branch stays empty at its new position"
     );

--- a/crates/but-api/tests/api/branch_remove.rs
+++ b/crates/but-api/tests/api/branch_remove.rs
@@ -90,10 +90,7 @@ fn branch_remove_deletes_middle_empty_branch_and_keeps_head() -> anyhow::Result<
 
     let repo = ctx.repo.get()?;
     // Removing a branch that isn't checked out leaves HEAD on the tip.
-    assert_eq!(
-        repo.head_name()?.expect("HEAD is symbolic").as_ref(),
-        tip.as_ref()
-    );
+    assert_eq!(repo.head_name()?.expect("HEAD is symbolic"), tip);
     assert!(repo.try_find_reference(middle.as_ref())?.is_none());
     // The order relinks the tip straight onto the base.
     let order = ctx
@@ -121,10 +118,7 @@ fn branch_remove_checked_out_empty_tip_moves_head_to_ref_below() -> anyhow::Resu
 
     let repo = ctx.repo.get()?;
     // HEAD lands on the reference that was directly underneath the removed tip.
-    assert_eq!(
-        repo.head_name()?.expect("HEAD is symbolic").as_ref(),
-        middle.as_ref()
-    );
+    assert_eq!(repo.head_name()?.expect("HEAD is symbolic"), middle);
     assert!(repo.try_find_reference(tip.as_ref())?.is_none());
     assert_workspace_ref(&result.workspace, "refs/heads/middle");
 
@@ -153,10 +147,7 @@ fn branch_remove_rejects_checked_out_branch_with_commits() -> anyhow::Result<()>
     // Nothing was removed.
     let repo = ctx.repo.get()?;
     assert!(repo.try_find_reference(main.as_ref())?.is_some());
-    assert_eq!(
-        repo.head_name()?.expect("HEAD is symbolic").as_ref(),
-        main.as_ref()
-    );
+    assert_eq!(repo.head_name()?.expect("HEAD is symbolic"), main);
 
     Ok(())
 }
@@ -187,10 +178,7 @@ fn branch_remove_refuses_when_checked_out_in_another_worktree() -> anyhow::Resul
         repo.try_find_reference(middle.as_ref())?.is_some(),
         "the checked-out branch must remain"
     );
-    assert_eq!(
-        repo.head_name()?.expect("HEAD is symbolic").as_ref(),
-        tip.as_ref()
-    );
+    assert_eq!(repo.head_name()?.expect("HEAD is symbolic"), tip);
 
     Ok(())
 }

--- a/crates/but-api/tests/api/branch_rename.rs
+++ b/crates/but-api/tests/api/branch_rename.rs
@@ -23,10 +23,7 @@ fn branch_rename_middle_branch_keeps_head_and_order() -> anyhow::Result<()> {
 
     let repo = ctx.repo.get()?;
     // Renaming a branch that isn't checked out leaves HEAD on the tip.
-    assert_eq!(
-        repo.head_name()?.expect("HEAD is symbolic").as_ref(),
-        tip.as_ref()
-    );
+    assert_eq!(repo.head_name()?.expect("HEAD is symbolic"), tip);
     assert!(repo.try_find_reference(middle.as_ref())?.is_none());
     assert!(repo.try_find_reference(renamed.as_ref())?.is_some());
     // The order keeps the branch in place under the new name.
@@ -54,12 +51,9 @@ fn branch_rename_checked_out_branch_moves_head_to_new_name() -> anyhow::Result<(
 
     let repo = ctx.repo.get()?;
     // Renaming the checked-out branch carries HEAD over to the new name.
-    assert_eq!(
-        repo.head_name()?.expect("HEAD is symbolic").as_ref(),
-        renamed.as_ref()
-    );
+    assert_eq!(repo.head_name()?.expect("HEAD is symbolic"), renamed);
     assert!(repo.try_find_reference(tip.as_ref())?.is_none());
-    assert_eq!(result.new_ref.as_ref(), renamed.as_ref());
+    assert_eq!(result.new_ref, renamed);
     assert_workspace_ref(&result.workspace, "refs/heads/renamed-tip");
 
     let order = ctx
@@ -91,10 +85,7 @@ fn branch_rename_rejects_a_name_that_already_exists() -> anyhow::Result<()> {
     // Nothing changed: the original branch is intact and still checked out.
     let repo = ctx.repo.get()?;
     assert!(repo.try_find_reference(tip.as_ref())?.is_some());
-    assert_eq!(
-        repo.head_name()?.expect("HEAD is symbolic").as_ref(),
-        tip.as_ref()
-    );
+    assert_eq!(repo.head_name()?.expect("HEAD is symbolic"), tip);
 
     Ok(())
 }
@@ -217,7 +208,7 @@ fn branch_rename_normalizes_the_requested_name() -> anyhow::Result<()> {
     // The resulting ref matches what the non-legacy normalizer produces.
     let expected_short = but_core::branch::normalize_short_name("My Fancy Branch")?;
     let expected = gix::refs::Category::LocalBranch.to_full_name(expected_short.as_bstr())?;
-    assert_eq!(result.new_ref.as_ref(), expected.as_ref());
+    assert_eq!(result.new_ref, expected);
 
     let repo = ctx.repo.get()?;
     assert!(repo.try_find_reference(tip.as_ref())?.is_none());
@@ -244,7 +235,7 @@ fn branch_rename_keeps_a_managed_stack_branch_applied() -> anyhow::Result<()> {
     let result =
         but_api::branch::branch_rename(&mut ctx, feature.clone(), "renamed-feature".into())?;
     let renamed = gix::refs::FullName::try_from("refs/heads/renamed-feature")?;
-    assert_eq!(result.new_ref.as_ref(), renamed.as_ref());
+    assert_eq!(result.new_ref, renamed);
 
     let repo = ctx.repo.get()?;
     assert!(repo.try_find_reference(feature.as_ref())?.is_none());
@@ -384,7 +375,7 @@ fn branch_rename_into_a_directory_prefix() -> anyhow::Result<()> {
     // `foo` and `foo/bar` can't coexist as refs, so this must not fail with "Could not create
     // branch": the rename is done atomically instead.
     let result = but_api::branch::branch_rename(&mut ctx, foo.clone(), "foo/bar".into())?;
-    assert_eq!(result.new_ref.as_ref(), foo_bar.as_ref());
+    assert_eq!(result.new_ref, foo_bar);
 
     let repo = ctx.repo.get()?;
     assert!(
@@ -396,10 +387,7 @@ fn branch_rename_into_a_directory_prefix() -> anyhow::Result<()> {
         "the prefixed ref must exist"
     );
     // HEAD followed the rename onto the new, prefixed name.
-    assert_eq!(
-        repo.head_name()?.expect("HEAD is symbolic").as_ref(),
-        foo_bar.as_ref()
-    );
+    assert_eq!(repo.head_name()?.expect("HEAD is symbolic"), foo_bar);
 
     Ok(())
 }
@@ -418,7 +406,7 @@ fn branch_rename_out_of_a_directory_prefix() -> anyhow::Result<()> {
     // Collapsing `foo/bar` back down to `foo` reuses the now-empty `foo/` directory as a ref file,
     // which the atomic rename must handle.
     let result = but_api::branch::branch_rename(&mut ctx, foo_bar.clone(), "foo".into())?;
-    assert_eq!(result.new_ref.as_ref(), foo.as_ref());
+    assert_eq!(result.new_ref, foo);
 
     let repo = ctx.repo.get()?;
     assert!(
@@ -429,10 +417,7 @@ fn branch_rename_out_of_a_directory_prefix() -> anyhow::Result<()> {
         repo.try_find_reference(foo.as_ref())?.is_some(),
         "the collapsed ref must exist"
     );
-    assert_eq!(
-        repo.head_name()?.expect("HEAD is symbolic").as_ref(),
-        foo.as_ref()
-    );
+    assert_eq!(repo.head_name()?.expect("HEAD is symbolic"), foo);
 
     Ok(())
 }
@@ -473,13 +458,13 @@ fn prefix_rename_restores_source_when_destination_is_locked() -> anyhow::Result<
         panic!("the source branch must be restored; destination exists: {destination_exists}")
     });
     assert_eq!(
-        restored.peel_to_id()?.detach(),
+        restored.peel_to_id()?,
         source_id,
         "rollback must restore the source at its original commit"
     );
     assert_eq!(
-        repo.head_name()?.expect("HEAD is symbolic").as_ref(),
-        source.as_ref(),
+        repo.head_name()?.expect("HEAD is symbolic"),
+        source,
         "HEAD must continue to name the restored source branch"
     );
     let recovery_ref = repo

--- a/crates/but-api/tests/api/commit_cherry_pick.rs
+++ b/crates/but-api/tests/api/commit_cherry_pick.rs
@@ -81,7 +81,7 @@ fn cherry_pick_materializes_multiple_deduped_commits_and_returns_new_commit_ids(
     let new_tip = result.new_commits[1];
     let repo = ctx.repo.get()?;
     assert_eq!(
-        repo.rev_parse_single(main_ref.as_ref())?.detach(),
+        repo.rev_parse_single(main_ref.as_ref())?,
         new_tip,
         "materialization should move the destination reference"
     );
@@ -89,8 +89,7 @@ fn cherry_pick_materializes_multiple_deduped_commits_and_returns_new_commit_ids(
         repo.find_commit(new_first)?
             .parent_ids()
             .next()
-            .expect("the copied commit has the old branch tip as parent")
-            .detach(),
+            .expect("the copied commit has the old branch tip as parent"),
         main_tip
     );
 
@@ -136,7 +135,7 @@ fn cherry_pick_dry_run_does_not_persist_commits_or_move_the_reference() -> anyho
 
     let repo = ctx.repo.get()?;
     assert_eq!(
-        repo.rev_parse_single(main_ref.as_ref())?.detach(),
+        repo.rev_parse_single(main_ref.as_ref())?,
         main_tip,
         "dry-run should not move the destination reference"
     );
@@ -189,7 +188,7 @@ fn cherry_pick_from_a_branch_outside_the_workspace() -> anyhow::Result<()> {
     assert_eq!(result.new_commits.len(), 1);
     let repo = ctx.repo.get()?;
     assert_eq!(
-        repo.rev_parse_single(main_ref.as_ref())?.detach(),
+        repo.rev_parse_single(main_ref.as_ref())?,
         result.new_commits[0],
         "the copy becomes the new branch tip"
     );
@@ -197,8 +196,7 @@ fn cherry_pick_from_a_branch_outside_the_workspace() -> anyhow::Result<()> {
         repo.find_commit(result.new_commits[0])?
             .parent_ids()
             .next()
-            .expect("the copy is stacked onto the previous tip")
-            .detach(),
+            .expect("the copy is stacked onto the previous tip"),
         main_tip
     );
     assert_ne!(
@@ -233,7 +231,7 @@ fn cherry_pick_multiple_commits_from_outside_the_workspace() -> anyhow::Result<(
     assert_eq!(result.new_commits.len(), 2);
     let repo = ctx.repo.get()?;
     assert_eq!(
-        repo.rev_parse_single(main_ref.as_ref())?.detach(),
+        repo.rev_parse_single(main_ref.as_ref())?,
         result.new_commits[1],
         "the last source given ends up as the branch tip"
     );
@@ -241,8 +239,7 @@ fn cherry_pick_multiple_commits_from_outside_the_workspace() -> anyhow::Result<(
         repo.find_commit(result.new_commits[1])?
             .parent_ids()
             .next()
-            .expect("the copies are stacked in the order given")
-            .detach(),
+            .expect("the copies are stacked in the order given"),
         result.new_commits[0]
     );
     let titles = result

--- a/crates/but-api/tests/api/support.rs
+++ b/crates/but-api/tests/api/support.rs
@@ -102,7 +102,7 @@ pub fn assert_workspace_ref(workspace: &but_api::WorkspaceState, expected: &str)
         .workspace_ref_info
         .as_ref()
         .expect("checked out branch is the workspace ref");
-    assert_eq!(workspace_ref.ref_name.as_bstr(), expected);
+    assert_eq!(workspace_ref.ref_name, expected);
 }
 
 /// Assert the mutation response's workspace projection contains `expected` as its checked-out ref,

--- a/crates/but-core/src/lib.rs
+++ b/crates/but-core/src/lib.rs
@@ -136,8 +136,7 @@ pub const WORKSPACE_REF_NAME: &str = "refs/heads/gitbutler/workspace";
 ///
 /// `but_db::worktrees` keeps a hand-copy of this to stay off but-core; change both.
 pub fn is_workspace_ref_name(ref_name: &FullNameRef) -> bool {
-    ref_name.as_bstr() == WORKSPACE_REF_NAME
-        || ref_name.as_bstr() == "refs/heads/gitbutler/integration"
+    ref_name == WORKSPACE_REF_NAME || ref_name == "refs/heads/gitbutler/integration"
 }
 
 /// A utility to extract the name of the remote from a remote tracking ref with `ref_name`,

--- a/crates/but-core/src/ref_metadata.rs
+++ b/crates/but-core/src/ref_metadata.rs
@@ -529,7 +529,7 @@ fn ensure_unique_branch_names<'a>(
 ) -> Result<()> {
     let mut seen = Vec::<gix::refs::FullName>::new();
     for name in names {
-        if seen.iter().any(|seen| seen.as_ref() == name) {
+        if seen.iter().any(|seen| seen == name) {
             bail!("Cannot reconcile {source}: branch name '{name}' occurs more than once");
         }
         seen.push(name.to_owned());
@@ -546,7 +546,7 @@ fn remove_branch_from_stacks(
         && let Some(branch_idx) = stack
             .branches
             .iter()
-            .position(|branch| branch.ref_name.as_ref() == name)
+            .position(|branch| branch.ref_name == name)
     {
         return Some(stack.branches.remove(branch_idx));
     }
@@ -555,7 +555,7 @@ fn remove_branch_from_stacks(
         let branch_idx = stack
             .branches
             .iter()
-            .position(|branch| branch.ref_name.as_ref() == name)?;
+            .position(|branch| branch.ref_name == name)?;
         Some(stack.branches.remove(branch_idx))
     })
 }
@@ -606,7 +606,7 @@ impl Workspace {
     /// Use `kind` for filtering.
     pub fn contains_ref(&self, name: &gix::refs::FullNameRef, kind: StackKind) -> bool {
         self.stacks(kind)
-            .any(|stack| stack.branches.iter().any(|b| b.ref_name.as_ref() == name))
+            .any(|stack| stack.branches.iter().any(|b| b.ref_name == name))
     }
 
     /// Find a given `name` within our stack branches and return it for modification.
@@ -616,12 +616,8 @@ impl Workspace {
         name: &gix::refs::FullNameRef,
         kind: StackKind,
     ) -> Option<&mut WorkspaceStackBranch> {
-        self.stacks_mut(kind).find_map(|stack| {
-            stack
-                .branches
-                .iter_mut()
-                .find(|b| b.ref_name.as_ref() == name)
-        })
+        self.stacks_mut(kind)
+            .find_map(|stack| stack.branches.iter_mut().find(|b| b.ref_name == name))
     }
 
     /// Find a given `name` within our stack branches and return it.
@@ -632,7 +628,7 @@ impl Workspace {
         kind: StackKind,
     ) -> Option<&WorkspaceStackBranch> {
         self.stacks(kind)
-            .find_map(|stack| stack.branches.iter().find(|b| b.ref_name.as_ref() == name))
+            .find_map(|stack| stack.branches.iter().find(|b| b.ref_name == name))
     }
 
     /// Find a given `name` within our stack branches and return the stack itself.
@@ -646,7 +642,7 @@ impl Workspace {
             stack
                 .branches
                 .iter()
-                .find_map(|b| (b.ref_name.as_ref() == name).then_some(stack))
+                .find_map(|b| (b.ref_name == name).then_some(stack))
         })
     }
 
@@ -666,9 +662,11 @@ impl Workspace {
                     || stack.workspacecommit_relation.is_in_workspace()
             })
             .find_map(|(stack_idx, stack)| {
-                stack.branches.iter().enumerate().find_map(|(seg_idx, b)| {
-                    (b.ref_name.as_ref() == name).then_some((stack_idx, seg_idx))
-                })
+                stack
+                    .branches
+                    .iter()
+                    .enumerate()
+                    .find_map(|(seg_idx, b)| (b.ref_name == name).then_some((stack_idx, seg_idx)))
             })
     }
 }

--- a/crates/but-core/src/repo_ext.rs
+++ b/crates/but-core/src/repo_ext.rs
@@ -485,6 +485,6 @@ fn committer_signature() -> gix::actor::Signature {
 fn commit_time(overriding_variable_name: &str) -> gix::date::Time {
     std::env::var(overriding_variable_name)
         .ok()
-        .and_then(|time| gix::date::parse(&time, Some(std::time::SystemTime::now())).ok())
+        .and_then(|time| gix::date::parse(&time, Some(gix::date::Zoned::now())).ok())
         .unwrap_or_else(gix::date::Time::now_local_or_utc)
 }

--- a/crates/but-core/tests/core/commit.rs
+++ b/crates/but-core/tests/core/commit.rs
@@ -27,7 +27,7 @@ fn is_conflicted() -> anyhow::Result<()> {
         "conflict metadata alone does not make an ordinary tree conflicted"
     );
     assert_eq!(
-        marked_ordinary.tree_id_or_auto_resolution()?.detach(),
+        marked_ordinary.tree_id_or_auto_resolution()?,
         marked_ordinary.tree,
         "an ordinary tree is used even if the commit retained conflict metadata"
     );

--- a/crates/but-ctx/tests/ctx/main.rs
+++ b/crates/but-ctx/tests/ctx/main.rs
@@ -431,7 +431,7 @@ fn worktree_adoption_archives_preexisting_worktrees() -> anyhow::Result<()> {
     );
     assert_eq!(
         head.id,
-        ctx.repo.get()?.rev_parse_single("feat-c")?.detach(),
+        ctx.repo.get()?.rev_parse_single("feat-c")?,
         "the head is the worktree's own HEAD, which has advanced past the main one"
     );
     assert_eq!(

--- a/crates/but-debug/src/command/api.rs
+++ b/crates/but-debug/src/command/api.rs
@@ -67,8 +67,7 @@ fn resolve_stack_id(ctx: &but_ctx::Context, stack: &str) -> Result<StackId> {
     fn stack_matches(stack: &but_graph::workspace::Stack, name: &str) -> bool {
         stack.segments.iter().any(|segment| {
             segment.ref_name().is_some_and(|ref_name| {
-                ref_name.as_bstr() == name.as_bytes()
-                    || ref_name.shorten().as_bstr() == name.as_bytes()
+                ref_name == name || ref_name.shorten().as_bstr() == name.as_bytes()
             })
         })
     }

--- a/crates/but-graph/src/api.rs
+++ b/crates/but-graph/src/api.rs
@@ -759,7 +759,7 @@ impl Graph {
                 s.commits.iter().find_map(|c| {
                     c.refs
                         .iter()
-                        .any(|ri| ri.ref_name.as_ref() == name)
+                        .any(|ri| ri.ref_name == name)
                         .then_some((s, c))
                 })
             }

--- a/crates/but-graph/src/init/mod.rs
+++ b/crates/but-graph/src/init/mod.rs
@@ -1763,11 +1763,10 @@ fn initial_tips_from_workspace_metadata<T: RefMetadata>(
     let mut workspaces = obtain_workspace_infos(repo, entrypoint_ref.map(|rn| rn.as_ref()), meta)?;
     let has_project_meta = project_meta != &ProjectMeta::default();
     if has_project_meta
-        && entrypoint_ref
-            .is_some_and(|ref_name| ref_name.as_bstr() == WORKSPACE_REF_NAME.as_bytes())
+        && entrypoint_ref.is_some_and(|ref_name| ref_name == WORKSPACE_REF_NAME)
         && !workspaces
             .iter()
-            .any(|(_, ref_name, _)| ref_name.as_bstr() == WORKSPACE_REF_NAME.as_bytes())
+            .any(|(_, ref_name, _)| ref_name == WORKSPACE_REF_NAME)
     {
         let workspace_ref: gix::refs::FullName = WORKSPACE_REF_NAME.try_into()?;
         if let Some(workspace_tip) = try_refname_to_id(repo, workspace_ref.as_ref())? {

--- a/crates/but-graph/src/init/post.rs
+++ b/crates/but-graph/src/init/post.rs
@@ -1988,7 +1988,7 @@ fn rebuild_same_tip_segment_chain_by_branch_order<T: RefMetadata>(
             )?;
             graph.insert_segment(new_segment)
         };
-        if ref_name.as_ref() == entrypoint_ref {
+        if ref_name == entrypoint_ref {
             entrypoint_segment_id = Some(segment_id);
         }
         ordered_segment_ids.push(segment_id);

--- a/crates/but-graph/src/projection/workspace/api/mod.rs
+++ b/crates/but-graph/src/projection/workspace/api/mod.rs
@@ -132,7 +132,7 @@ impl Workspace {
                             stack
                                 .branches
                                 .iter()
-                                .any(|branch| branch.ref_name.as_ref() == projected_ref)
+                                .any(|branch| branch.ref_name == projected_ref)
                         })
                     })
             }) else {
@@ -260,7 +260,7 @@ impl Workspace {
             return false;
         };
 
-        t.ref_name.as_ref() == name
+        t.ref_name == name
             || self
                 .graph
                 .lookup_sibling_segment(t.segment_index)

--- a/crates/but-graph/src/segment.rs
+++ b/crates/but-graph/src/segment.rs
@@ -26,7 +26,7 @@ impl Commit {
 
     /// Return information about the reference that matches `name`.
     pub fn ref_by_name(&self, name: &gix::refs::FullNameRef) -> Option<&RefInfo> {
-        self.refs.iter().find(|ri| ri.ref_name.as_ref() == name)
+        self.refs.iter().find(|ri| ri.ref_name == name)
     }
 }
 

--- a/crates/but-graph/tests/graph/init/with_workspace.rs
+++ b/crates/but-graph/tests/graph/init/with_workspace.rs
@@ -1558,7 +1558,7 @@ fn entrypoint_inside_second_parent_of_workspace_diamond_is_included() -> anyhow:
         entrypoint_stack_segment
             .commits
             .iter()
-            .any(|commit| commit.id == id.detach()),
+            .any(|commit| commit.id == id),
         "the entrypoint stack segment must contain the custom traversal commit"
     );
     snapbox::assert_data_eq!(

--- a/crates/but-rebase/src/graph_rebase/materialize.rs
+++ b/crates/but-rebase/src/graph_rebase/materialize.rs
@@ -93,7 +93,7 @@ fn open_linked_checkout_repos(
             let worktree_repo = proxy.clone().into_repo()?;
             let actual_ref = worktree_repo.head_name()?;
             let actual_head = worktree_repo.head_id()?.detach();
-            if actual_ref.as_ref() != spec.ref_name.as_ref() || actual_head != spec.initial_head {
+            if actual_ref != spec.ref_name || actual_head != spec.initial_head {
                 bail!(
                     "Visible worktree {} changed since the editor was created: \
                      expected {} at {}, got {} at {}",
@@ -147,7 +147,7 @@ impl<'ws, 'graph, M: RefMetadata> SuccessfulRebase<'ws, 'graph, M> {
             let (target, actual_ref) = self
                 .checkout_target(*selector)?
                 .with_context(|| format!("Visible worktree {worktree_name} HEAD was removed"))?;
-            if actual_ref.as_ref() != expected_ref.as_ref() {
+            if actual_ref != *expected_ref {
                 bail!(
                     "Visible worktree {worktree_name} HEAD changed shape during the edit: \
                      expected {}, got {}",

--- a/crates/but-rebase/src/graph_rebase/mod.rs
+++ b/crates/but-rebase/src/graph_rebase/mod.rs
@@ -387,7 +387,7 @@ impl<'ws, 'meta, M: RefMetadata> SuccessfulRebase<'ws, 'meta, M> {
             .find(|node| {
                 matches!(
                     &self.graph[*node],
-                    Step::Reference { refname, .. } if refname.as_ref() == ref_name
+                    Step::Reference { refname, .. } if refname == ref_name
                 )
             })
             .with_context(|| format!("Could not find reference '{ref_name}' in rebase result"))?;

--- a/crates/but-rebase/src/graph_rebase/rebase.rs
+++ b/crates/but-rebase/src/graph_rebase/rebase.rs
@@ -190,12 +190,8 @@ impl<'ws, 'graph, M: RefMetadata> Editor<'ws, 'graph, M> {
         // Find deleted references. `initial_references` only contains mutable
         // references, so immutable references are never considered for deletion.
         for reference in self.initial_references.iter() {
-            if !ref_edits
-                .iter()
-                .any(|e| e.name.as_ref() == reference.as_ref())
-                && !unchanged_references
-                    .iter()
-                    .any(|e| e.as_ref() == reference.as_ref())
+            if !ref_edits.iter().any(|e| e.name == *reference)
+                && !unchanged_references.iter().any(|e| e == reference)
             {
                 ref_edits.push(RefEdit {
                     name: reference.clone(),

--- a/crates/but-rebase/tests/rebase/graph_rebase/materialize.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/materialize.rs
@@ -257,10 +257,7 @@ fn both_methods_update_references_identically() -> Result<()> {
         let outcome = outcome.materialize(Default::default())?;
         assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
-        (
-            repo.rev_parse_single("main")?.detach().to_string(),
-            overlayed,
-        )
+        (repo.rev_parse_single("main")?.detach(), overlayed)
     };
 
     // Test with materialize_without_checkout
@@ -287,10 +284,7 @@ fn both_methods_update_references_identically() -> Result<()> {
         let outcome = outcome.materialize_without_checkout()?;
         assert_eq!(overlayed, graph_tree(&outcome.workspace.graph).to_string());
 
-        (
-            repo.rev_parse_single("main")?.detach().to_string(),
-            overlayed,
-        )
+        (repo.rev_parse_single("main")?.detach(), overlayed)
     };
 
     snapbox::assert_data_eq!(
@@ -313,7 +307,7 @@ fn both_methods_update_references_identically() -> Result<()> {
     );
 
     snapbox::assert_data_eq!(
-        ref_after_materialize,
+        ref_after_materialize.to_string(),
         snapbox::str!["a96434e2505c2ea0896cf4f58fec0778e074d3da"]
     );
 
@@ -481,7 +475,7 @@ fn materialize_keeps_immutable_refs_unchanged_while_updating_local_refs() -> Res
         .raw()
     );
 
-    assert_eq!(repo.rev_parse_single("main")?.detach(), main_before);
+    assert_eq!(repo.rev_parse_single("main")?, main_before);
 
     Ok(())
 }
@@ -505,7 +499,7 @@ fn materialize_does_not_delete_immutable_refs_removed_from_graph() -> Result<()>
     let outcome = editor.rebase()?;
     outcome.materialize(Default::default())?;
 
-    assert_eq!(repo.rev_parse_single("main")?.detach(), main_before);
+    assert_eq!(repo.rev_parse_single("main")?, main_before);
 
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
@@ -563,7 +557,7 @@ fn visible_attached_and_detached_worktrees_follow_a_rewritten_commit() -> Result
         Some("refs/heads/middle".try_into()?),
         "the branch-backed worktree stays attached"
     );
-    assert_eq!(attached.head_id()?.detach(), new_middle);
+    assert_eq!(attached.head_id()?, new_middle);
     assert!(
         !attached_dir.join("a").exists(),
         "the attached worktree removes the rename source"
@@ -582,7 +576,7 @@ fn visible_attached_and_detached_worktrees_follow_a_rewritten_commit() -> Result
         None,
         "the detached worktree stays detached"
     );
-    assert_eq!(detached.head_id()?.detach(), new_middle);
+    assert_eq!(detached.head_id()?, new_middle);
     assert_eq!(
         std::fs::read_to_string(detached.git_dir().join("HEAD"))?,
         format!("{new_middle}\n")
@@ -665,7 +659,7 @@ fn changes_consumed_from_a_linked_worktree_cancel_during_its_checkout() -> Resul
     editor.set_worktree_merge_base_override(gix::bstr::BStr::new("wt"), consumed_tree)?;
     editor.rebase()?.materialize(Default::default())?;
 
-    assert_eq!(repo.rev_parse_single("middle")?.detach(), amended);
+    assert_eq!(repo.rev_parse_single("middle")?, amended);
     assert_eq!(
         std::fs::read_to_string(worktree_dir.join("test.txt"))?,
         "line 1\nline 1.1\nline 1.2\nline 2\nline 3\n",
@@ -722,7 +716,7 @@ fn materialize_without_checkout_moves_detached_worktree_heads_only() -> Result<(
 
     let detached = linked_repo(&repo, "wt-detached")?;
     assert_eq!(
-        detached.head_id()?.detach(),
+        detached.head_id()?,
         new_middle,
         "the detached worktree's HEAD follows the rewrite through the ref transaction"
     );
@@ -754,7 +748,7 @@ fn a_detached_worktree_that_moved_since_editor_creation_is_rejected() -> Result<
     let detached = linked_repo(&repo, "wt-detached")?;
     let elsewhere = repo.rev_parse_single("main")?.detach();
     but_core::worktree::safe_checkout_from_head(elsewhere, &detached, Default::default())?;
-    assert_eq!(detached.head_id()?.detach(), elsewhere);
+    assert_eq!(detached.head_id()?, elsewhere);
 
     let err = outcome
         .materialize_without_checkout()
@@ -764,7 +758,7 @@ fn a_detached_worktree_that_moved_since_editor_creation_is_rejected() -> Result<
         "{err:#}"
     );
     assert_eq!(
-        linked_repo(&repo, "wt-detached")?.head_id()?.detach(),
+        linked_repo(&repo, "wt-detached")?.head_id()?,
         elsewhere,
         "the worktree keeps what someone else put there"
     );
@@ -809,7 +803,7 @@ fn insert_below_worktree_ref_moves_only_that_ref() -> Result<()> {
     editor.rebase()?.materialize(Default::default())?;
 
     assert_eq!(
-        repo.rev_parse_single("main")?.detach(),
+        repo.rev_parse_single("main")?,
         old_main,
         "nothing above the worktree branch is rebased"
     );
@@ -844,7 +838,7 @@ fn insert_below_worktree_ref_moves_only_that_ref() -> Result<()> {
         "the branch-backed worktree stays attached"
     );
     assert_eq!(
-        attached.head_id()?.detach(),
+        attached.head_id()?,
         new_middle,
         "the checkout follows the moved branch"
     );

--- a/crates/but-rebase/tests/rebase/main.rs
+++ b/crates/but-rebase/tests/rebase/main.rs
@@ -448,7 +448,7 @@ RebaseOutput {
     );
     assert_ne!(
         out.top_commit.attach(&repo).object()?.peel_to_tree()?.id,
-        repo.rev_parse_single("main^{tree}")?.detach(),
+        repo.rev_parse_single("main^{tree}")?,
         "The newly re-merged tree is different as a conflict was auto-resolved"
     );
 

--- a/crates/but-transaction/src/lib.rs
+++ b/crates/but-transaction/src/lib.rs
@@ -394,8 +394,8 @@ where
                         if !ok_to_skip
                             && let Some(ref target_local_branch) = target_local_branch
                             && matches!(step, Step::Reference { ref refname, .. }
-                                if refname.as_bstr() == target_local_branch ||
-                                    refname.as_bstr() == b"refs/heads/gitbutler/target")
+                                if refname == target_local_branch ||
+                                    refname == "refs/heads/gitbutler/target")
                         {
                             ok_to_skip = true;
                         }

--- a/crates/but-workspace/src/branch/apply.rs
+++ b/crates/but-workspace/src/branch/apply.rs
@@ -272,7 +272,7 @@ pub fn apply(
         WorkspaceKind::Managed { ref_info }
         | WorkspaceKind::ManagedMissingWorkspaceCommit { ref_info } => head_ref_name
             .as_ref()
-            .is_some_and(|head| head.as_ref() == ref_info.ref_name.as_ref()),
+            .is_some_and(|head| head == &ref_info.ref_name),
         WorkspaceKind::AdHoc => false,
     };
     let branch_has_applied_metadata =
@@ -451,12 +451,10 @@ pub fn apply(
                 .iter()
                 .any(|b| projected_refs.contains(b.ref_name.as_ref().as_bstr()));
             let stack_is_kept = stack.branches.iter().any(|b| {
-                branches_to_apply
-                    .iter()
-                    .any(|rn| rn.as_ref() == b.ref_name.as_ref())
+                branches_to_apply.iter().any(|rn| rn == &b.ref_name)
                     || head_ref_name
                         .as_ref()
-                        .is_some_and(|head| head.as_ref() == b.ref_name.as_ref())
+                        .is_some_and(|head| head == &b.ref_name)
             });
             if dropped_from_projection || (head_branch_in_workspace && !stack_is_kept) {
                 stack.workspacecommit_relation = Outside;

--- a/crates/but-workspace/src/branch/integrate_branch_upstream/mod.rs
+++ b/crates/but-workspace/src/branch/integrate_branch_upstream/mod.rs
@@ -258,7 +258,7 @@ pub fn get_initial_integration_steps_for_branch<M: RefMetadata>(
         .target_ref
         .as_ref()
         .map(|target| target.ref_name.clone())
-        .filter(|target_ref_name| target_ref_name.as_ref() != upstream_ref_name.as_ref());
+        .filter(|target_ref_name| *target_ref_name != *upstream_ref_name);
 
     let editor = Editor::create(workspace, meta, repo, db)?;
 

--- a/crates/but-workspace/src/branch/unapply.rs
+++ b/crates/but-workspace/src/branch/unapply.rs
@@ -221,7 +221,7 @@ pub(crate) mod function {
         }
 
         if let Some(workspace_ref_name) = workspace_ref_name.as_ref()
-            && workspace_ref_name.as_ref() == branch
+            && workspace_ref_name == branch
         {
             return unapply_workspace_reference(
                 ws,
@@ -338,7 +338,7 @@ pub(crate) mod function {
                 && stack
                     .branches
                     .iter()
-                    .any(|stack_branch| stack_branch.ref_name.as_ref() == branch)
+                    .any(|stack_branch| stack_branch.ref_name == branch)
         }) {
             bail!(
                 "BUG: branch '{}' is still present in rebuilt workspace metadata after unapply",

--- a/crates/but-workspace/src/commit/mod.rs
+++ b/crates/but-workspace/src/commit/mod.rs
@@ -749,7 +749,7 @@ fn commit_signature(time: gix::date::Time) -> gix::actor::Signature {
 fn commit_time(overriding_variable_name: &str) -> gix::date::Time {
     std::env::var(overriding_variable_name)
         .ok()
-        .and_then(|time| gix::date::parse(&time, Some(std::time::SystemTime::now())).ok())
+        .and_then(|time| gix::date::parse(&time, Some(gix::date::Zoned::now())).ok())
         .unwrap_or_else(gix::date::Time::now_local_or_utc)
 }
 

--- a/crates/but-workspace/src/upstream_integration.rs
+++ b/crates/but-workspace/src/upstream_integration.rs
@@ -253,9 +253,7 @@ pub fn integrate_upstream_with_hints<'ws, 'meta, M: RefMetadata>(
                     .iter()
                     .zip(&updates_with_selectors)
                     .find_map(|(update, (selector, _))| match &update.selector {
-                        RelativeTo::Reference(ref_name)
-                            if ref_name.as_ref() == head_ref_name.as_ref() =>
-                        {
+                        RelativeTo::Reference(ref_name) if ref_name == head_ref_name => {
                             Some(*selector)
                         }
                         _ => None,
@@ -265,7 +263,7 @@ pub fn integrate_upstream_with_hints<'ws, 'meta, M: RefMetadata>(
 
     let target_ref_selector = target_ref.ref_name.to_selector(&editor)?;
     let target_sha_selector = target_sha.to_selector(&editor)?;
-    let target_ref_commit_selector = target_ref_commit.detach().to_selector(&editor)?;
+    let target_ref_commit_selector = target_ref_commit.to_selector(&editor)?;
 
     let from_target_ref = traverse_nodes(&editor, target_ref_selector)?;
     let mut from_target_sha = traverse_nodes(&editor, target_sha_selector)?;
@@ -377,7 +375,7 @@ pub fn integrate_upstream_with_hints<'ws, 'meta, M: RefMetadata>(
                 let Step::Reference { refname, .. } = editor.lookup_step(*head)? else {
                     continue;
                 };
-                if refname.as_ref() == target_ref.ref_name.as_ref() {
+                if refname == target_ref.ref_name {
                     continue;
                 }
                 fully_integrated_workspace_parents.insert(*head);
@@ -414,7 +412,7 @@ pub fn integrate_upstream_with_hints<'ws, 'meta, M: RefMetadata>(
             [(parent_selector, parent_order)]
                 if !selected_stack_nodes.contains(parent_selector)
                     && selector_commit_id(&editor, *parent_selector)? == Some(target_sha)
-                    && target_sha != target_ref_commit.detach() =>
+                    && target_sha != target_ref_commit =>
             {
                 // Only parent is the old target sha, and that's not the latest tip of the target
                 // ref. This is a workspace with no stacks, or an unnamed empty lane at the base
@@ -529,9 +527,9 @@ pub fn integrate_upstream_with_hints<'ws, 'meta, M: RefMetadata>(
                     let target_selector = match editor.lookup_step(child)? {
                         Step::Reference { refname, .. }
                             if !head_is_workspace_commit
-                                && direct_checkout_head_ref_name.as_ref().is_some_and(
-                                    |head_ref| head_ref.as_ref() == refname.as_ref(),
-                                ) =>
+                                && direct_checkout_head_ref_name
+                                    .as_ref()
+                                    .is_some_and(|head_ref| *head_ref == refname) =>
                         {
                             // A direct local ref cannot be parented through the target reference
                             // node when both refs already participate in the same reachable graph.
@@ -912,7 +910,7 @@ fn empty_local_reference_remote_tip_integrated<'ws, 'meta, M: RefMetadata>(
     let Ok(remote_ref_name) = resolve_tracking_branch_ref_name(ref_name, editor.repo()) else {
         return Ok(false);
     };
-    if remote_ref_name.as_bstr() == target_ref_name.as_bstr() {
+    if *remote_ref_name == *target_ref_name {
         return Ok(false);
     }
 
@@ -931,7 +929,7 @@ fn empty_local_reference_remote_tip_integrated<'ws, 'meta, M: RefMetadata>(
     Ok(editor
         .repo()
         .merge_base(remote_tip_id, target_ref_commit)
-        .is_ok_and(|merge_base| merge_base.detach() == remote_tip_id))
+        .is_ok_and(|merge_base| merge_base == remote_tip_id))
 }
 
 /// Return `true` if `ref_name` currently resolves to either the old target

--- a/crates/but-workspace/tests/workspace/branch/create_reference.rs
+++ b/crates/but-workspace/tests/workspace/branch/create_reference.rs
@@ -2147,7 +2147,7 @@ Single commit, target, no ws commit, but ws-reference
         let new_tip = repo.find_reference(new_ref)?.peel_to_id()?.detach();
         assert_eq!(
             new_tip,
-            repo.rev_parse_single("main~1")?.detach(),
+            repo.rev_parse_single("main~1")?,
             "the new branch must be anchored at M1, inside the workspace"
         );
         Ok(())
@@ -3253,7 +3253,7 @@ mod ad_hoc_at_reference {
             "reusing an existing ref that points at a different commit must be rejected"
         );
         // The failure must be atomic: the ref is untouched and no order was persisted.
-        assert_eq!(repo.find_reference(existing_ref)?.id().detach(), older);
+        assert_eq!(repo.find_reference(existing_ref)?.id(), older);
         assert_eq!(meta.branch_stack_order(main_ref)?, None);
         Ok(())
     }

--- a/crates/but-workspace/tests/workspace/branch/integrate_branch_upstream.rs
+++ b/crates/but-workspace/tests/workspace/branch/integrate_branch_upstream.rs
@@ -1229,10 +1229,7 @@ fn integrate_branch_with_merge_step_does_not_require_preceding_commit() -> Resul
         .raw()
     );
 
-    assert_eq!(
-        repo.rev_parse_single("origin/A")?.detach(),
-        remote_tip_before
-    );
+    assert_eq!(repo.rev_parse_single("origin/A")?, remote_tip_before);
 
     Ok(())
 }
@@ -1315,10 +1312,7 @@ fn integrate_upstream_commits_into_local() -> Result<()> {
 "#]]
     );
 
-    assert_eq!(
-        repo.rev_parse_single("origin/A")?.detach(),
-        remote_tip_before
-    );
+    assert_eq!(repo.rev_parse_single("origin/A")?, remote_tip_before);
 
     Ok(())
 }
@@ -1398,7 +1392,7 @@ fn integrate_upstream_commits_into_local_with_merge_step() -> Result<()> {
         .raw()
     );
 
-    let branch_tip = repo.find_commit(repo.rev_parse_single("A")?.detach())?;
+    let branch_tip = repo.find_commit(repo.rev_parse_single("A")?)?;
     let branch_tip_parents = branch_tip.parent_ids().collect::<Vec<_>>();
     assert_eq!(
         branch_tip_parents.len(),
@@ -1420,8 +1414,7 @@ fn integrate_upstream_commits_into_local_with_merge_step() -> Result<()> {
         "merge step should produce a merge commit"
     );
     assert_eq!(
-        merge_parents[1].detach(),
-        remote_commit_1,
+        merge_parents[1], remote_commit_1,
         "merge step should retain the selected remote commit as the second parent"
     );
 
@@ -1500,7 +1493,7 @@ fn integrate_upstream_commits_into_local_with_all_locals_then_merge_second_remot
         .raw()
     );
 
-    let branch_tip = repo.find_commit(repo.rev_parse_single("A")?.detach())?;
+    let branch_tip = repo.find_commit(repo.rev_parse_single("A")?)?;
     assert_eq!(
         branch_tip.message_raw()?,
         format!("Merge {remote_commit_2} into previous commit")
@@ -1508,9 +1501,9 @@ fn integrate_upstream_commits_into_local_with_all_locals_then_merge_second_remot
 
     let merge_parents = branch_tip.parent_ids().collect::<Vec<_>>();
     assert_eq!(merge_parents.len(), 2, "tip should be a merge commit");
-    assert_eq!(merge_parents[1].detach(), remote_commit_2);
+    assert_eq!(merge_parents[1], remote_commit_2);
 
-    let first_parent = repo.find_commit(merge_parents[0].detach())?;
+    let first_parent = repo.find_commit(merge_parents[0])?;
     assert_eq!(first_parent.message_raw()?, "local change in A 2\n");
 
     Ok(())
@@ -1582,7 +1575,7 @@ fn integrate_upstream_commits_into_local_with_two_merges_in_sequence() -> Result
         .raw()
     );
 
-    let branch_tip = repo.find_commit(repo.rev_parse_single("A")?.detach())?;
+    let branch_tip = repo.find_commit(repo.rev_parse_single("A")?)?;
     assert_eq!(
         branch_tip.message_raw()?,
         format!("Merge {remote_commit_2} into previous commit")
@@ -1591,12 +1584,11 @@ fn integrate_upstream_commits_into_local_with_two_merges_in_sequence() -> Result
     let branch_tip_parents = branch_tip.parent_ids().collect::<Vec<_>>();
     assert_eq!(branch_tip_parents.len(), 2, "tip should be a merge commit");
     assert_eq!(
-        branch_tip_parents[1].detach(),
-        remote_commit_2,
+        branch_tip_parents[1], remote_commit_2,
         "second merge should keep the selected commit as second parent"
     );
 
-    let first_parent = repo.find_commit(branch_tip_parents[0].detach())?;
+    let first_parent = repo.find_commit(branch_tip_parents[0])?;
     assert_eq!(first_parent.message_raw()?, "local change in A 2\n");
     let first_parent_parents = first_parent.parent_ids().collect::<Vec<_>>();
     assert_eq!(
@@ -1604,7 +1596,7 @@ fn integrate_upstream_commits_into_local_with_two_merges_in_sequence() -> Result
         1,
         "the picked local commit before the self-merge should remain linear"
     );
-    let remote_merge = repo.find_commit(first_parent_parents[0].detach())?;
+    let remote_merge = repo.find_commit(first_parent_parents[0])?;
     assert_eq!(
         remote_merge.message_raw()?,
         format!("Merge {remote_commit_1} into previous commit"),
@@ -2371,7 +2363,7 @@ fn integrate_upstream_commits_into_local_with_squashed_local_commits() -> Result
 "#]]
     );
 
-    let branch_tip = repo.find_commit(repo.rev_parse_single("A")?.detach())?;
+    let branch_tip = repo.find_commit(repo.rev_parse_single("A")?)?;
     assert_eq!(branch_tip.message_raw()?, "squashed local commits");
 
     Ok(())
@@ -2439,7 +2431,7 @@ fn integrate_upstream_commits_into_local_with_squashed_remote_commits() -> Resul
 "#]]
     );
 
-    let branch_tip = repo.find_commit(repo.rev_parse_single("A")?.detach())?;
+    let branch_tip = repo.find_commit(repo.rev_parse_single("A")?)?;
     assert_eq!(branch_tip.message_raw()?, "squashed remote commits");
 
     Ok(())
@@ -2566,7 +2558,7 @@ fn integrate_upstream_commits_into_local_with_squashed_remote_into_local_conflic
 "#]]
     );
 
-    let branch_tip = repo.find_commit(repo.rev_parse_single("A")?.detach())?;
+    let branch_tip = repo.find_commit(repo.rev_parse_single("A")?)?;
     assert!(Commit::from_id(branch_tip.id.attach(&repo))?.is_conflicted());
     snapbox::assert_data_eq!(
         branch_tip.message_raw()?.to_string(),
@@ -2666,7 +2658,7 @@ fn integrate_upstream_commits_into_local_with_merge_remote_into_local_conflicts(
         .raw()
     );
 
-    let branch_tip = repo.find_commit(repo.rev_parse_single("A")?.detach())?;
+    let branch_tip = repo.find_commit(repo.rev_parse_single("A")?)?;
     assert!(
         Commit::from_id(branch_tip.id.attach(&repo))?.is_conflicted(),
         "merge integration should materialize a conflicted commit when upstream and local changes conflict",
@@ -2686,12 +2678,11 @@ fn integrate_upstream_commits_into_local_with_merge_remote_into_local_conflicts(
         "conflicted merge integration should still produce a merge commit",
     );
     assert_eq!(
-        merge_parents[1].detach(),
-        remote_commit_1,
+        merge_parents[1], remote_commit_1,
         "merge integration should retain the upstream commit as the second parent even when conflicted",
     );
 
-    let first_parent = repo.find_commit(merge_parents[0].detach())?;
+    let first_parent = repo.find_commit(merge_parents[0])?;
     assert_eq!(
         first_parent.message_raw()?,
         "local change in A 1\n",
@@ -2830,7 +2821,7 @@ fn integrate_upstream_precomputes_squash_before_later_step_graph_rewiring() -> R
     };
     let squashed_commit = repo.find_commit(squashed_commit_id)?;
     assert_eq!(
-        squashed_commit.tree_id()?.detach(),
+        squashed_commit.tree_id()?,
         expected_squash_tree,
         "squash tree should be computed from the original repo topology before later graph rewiring",
     );

--- a/crates/but-workspace/tests/workspace/commit/commit_amend.rs
+++ b/crates/but-workspace/tests/workspace/commit/commit_amend.rs
@@ -319,7 +319,7 @@ mod from_worktree {
         let new_id = materialized.lookup_pick(selector)?;
 
         assert_eq!(
-            repo.rev_parse_single("feat")?.detach(),
+            repo.rev_parse_single("feat")?,
             new_id,
             "the worktree's branch moved to the amended commit"
         );
@@ -370,7 +370,7 @@ mod from_worktree {
 
         let outcome = commit_amend(
             editor,
-            repo.rev_parse_single("feat")?.detach(),
+            repo.rev_parse_single("feat")?,
             vec![selected],
             0,
             ChangeSource::Worktree {
@@ -537,12 +537,8 @@ mod from_worktree {
         .unwrap_err();
         assert!(err.to_string().contains("no checkout recorded"), "{err}");
 
-        assert_eq!(
-            repo.rev_parse_single("feat")?.detach(),
-            f1_id,
-            "nothing moved"
-        );
-        assert_eq!(repo.head_id()?.detach(), m1_id, "nothing moved");
+        assert_eq!(repo.rev_parse_single("feat")?, f1_id, "nothing moved");
+        assert_eq!(repo.head_id()?, m1_id, "nothing moved");
         Ok(())
     }
 
@@ -578,16 +574,12 @@ mod from_worktree {
         let new_id = materialized.lookup_pick(selector)?;
 
         assert_eq!(
-            repo.rev_parse_single("feat")?.detach(),
+            repo.rev_parse_single("feat")?,
             new_id,
             "the worktree's branch moved to the new commit"
         );
         assert_eq!(
-            repo.find_commit(new_id)?
-                .parent_ids()
-                .next()
-                .unwrap()
-                .detach(),
+            repo.find_commit(new_id)?.parent_ids().next().unwrap(),
             f1_id,
             "the new commit sits on top of the worktree's previous tip"
         );

--- a/crates/but-workspace/tests/workspace/commit/commit_create.rs
+++ b/crates/but-workspace/tests/workspace/commit/commit_create.rs
@@ -49,13 +49,13 @@ fn commit_above_commit() -> Result<()> {
     let new_commit = repo.find_commit(new_commit_id)?;
     assert_eq!(new_commit.message_raw()?, "insert above commit");
     assert_eq!(
-        new_commit.parent_ids().next().expect("one parent").detach(),
+        new_commit.parent_ids().next().expect("one parent"),
         two_id,
         "new commit should be based on the target commit when inserted above"
     );
     let mut two_ref = repo.find_reference("two")?;
     assert_eq!(
-        two_ref.peel_to_id()?.detach(),
+        two_ref.peel_to_id()?,
         new_commit_id,
         "the two reference should now point to the inserted commit"
     );
@@ -97,7 +97,7 @@ fn commit_below_commit() -> Result<()> {
     let new_commit = repo.find_commit(new_commit_id)?;
     assert_eq!(new_commit.message_raw()?, "insert below commit");
     assert_eq!(
-        new_commit.parent_ids().next().expect("one parent").detach(),
+        new_commit.parent_ids().next().expect("one parent"),
         one_id,
         "new commit should be based on the target's first parent when inserted below"
     );
@@ -139,13 +139,13 @@ fn commit_above_reference() -> Result<()> {
     let new_commit = repo.find_commit(new_commit_id)?;
     assert_eq!(new_commit.message_raw()?, "insert above reference");
     assert_eq!(
-        new_commit.parent_ids().next().expect("one parent").detach(),
+        new_commit.parent_ids().next().expect("one parent"),
         two_id,
         "new commit should be based on the referenced commit"
     );
     let mut two_ref = repo.find_reference("two")?;
     assert_eq!(
-        two_ref.peel_to_id()?.detach(),
+        two_ref.peel_to_id()?,
         two_id,
         "when inserting above a reference, the reference keeps pointing to the original commit"
     );
@@ -192,11 +192,7 @@ fn commit_below_merge_commit_uses_first_parent() -> Result<()> {
     let new_commit = repo.find_commit(new_commit_id)?;
     assert_eq!(new_commit.message_raw()?, "insert below merge");
     assert_eq!(
-        new_commit
-            .parent_ids()
-            .next()
-            .expect("has a parent")
-            .detach(),
+        new_commit.parent_ids().next().expect("has a parent"),
         first_parent_id,
         "for below merge commits, we base creation on first parent"
     );

--- a/crates/but-workspace/tests/workspace/commit/move_commit.rs
+++ b/crates/but-workspace/tests/workspace/commit/move_commit.rs
@@ -11,11 +11,11 @@ use crate::ref_info::with_workspace_commit::utils::{
 };
 
 fn parent_subjects(repo: &gix::Repository, rev: &str) -> anyhow::Result<Vec<String>> {
-    let commit = repo.find_commit(repo.rev_parse_single(rev)?.detach())?;
+    let commit = repo.find_commit(repo.rev_parse_single(rev)?)?;
     commit
         .parent_ids()
         .map(|parent_id| {
-            let parent = repo.find_commit(parent_id.detach())?;
+            let parent = repo.find_commit(parent_id)?;
             Ok(parent.message_raw()?.trim_end().to_str_lossy().to_string())
         })
         .collect()

--- a/crates/but-workspace/tests/workspace/commit/squash_commits.rs
+++ b/crates/but-workspace/tests/workspace/commit/squash_commits.rs
@@ -48,7 +48,7 @@ fn squash_top_commit_into_parent() -> Result<()> {
         "combined message should be target followed by subject with one blank line"
     );
     assert_eq!(
-        squashed_commit.tree_id()?.detach(),
+        squashed_commit.tree_id()?,
         subject_tree,
         "squashed commit should take the top-most (subject) tree"
     );
@@ -197,7 +197,7 @@ fn squash_reorders_when_subject_is_not_on_top() -> Result<()> {
         "combined message should respect target-then-subject order"
     );
     assert_eq!(
-        squashed_commit.tree_id()?.detach(),
+        squashed_commit.tree_id()?,
         target_tree,
         "when subject is above target in ancestry, the target tree is top-most and must be kept"
     );
@@ -515,7 +515,7 @@ fn squash_across_stacks_subject_into_target() -> Result<()> {
 
     let squashed_commit = repo.find_commit(squashed_id)?;
     assert_eq!(squashed_commit.message_raw()?, "B\n\nA\n");
-    assert_eq!(squashed_commit.tree_id()?.detach(), subject_tree);
+    assert_eq!(squashed_commit.tree_id()?, subject_tree);
 
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
@@ -600,7 +600,7 @@ fn squash_across_stacks_target_into_subject() -> Result<()> {
 
     let squashed_commit = repo.find_commit(squashed_id)?;
     assert_eq!(squashed_commit.message_raw()?, "A\n\nB\n");
-    assert_eq!(squashed_commit.tree_id()?.detach(), subject_tree);
+    assert_eq!(squashed_commit.tree_id()?, subject_tree);
 
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,

--- a/crates/but-workspace/tests/workspace/commit/uncommit_changes.rs
+++ b/crates/but-workspace/tests/workspace/commit/uncommit_changes.rs
@@ -668,7 +668,7 @@ fn uncommit_changes_from_commits_all_failures_does_not_rebase() -> Result<()> {
         "all failed sources should avoid producing a rebase"
     );
     assert_eq!(
-        repo.rev_parse_single("three")?.detach(),
+        repo.rev_parse_single("three")?,
         three_before,
         "refs should be unchanged when there is no rebase to materialize"
     );

--- a/crates/but-workspace/tests/workspace/push.rs
+++ b/crates/but-workspace/tests/workspace/push.rs
@@ -161,7 +161,7 @@ fn pushed_branch_reports_its_name_on_the_remote_it_landed_on() -> anyhow::Result
     let workdir = repo.workdir().expect("fixtures have workdirs");
     // The tracking ref has to exist for the branch to be seen as tracking `fork`, and it
     // points at the base so `bottom` still has commits left to push.
-    let base = repo.rev_parse_single("main")?.detach().to_string();
+    let base = repo.rev_parse_single("main")?.to_string();
     for args in [
         vec!["remote", "add", "fork", fork.to_str().expect("utf8 path")],
         vec!["config", "branch.bottom.remote", "fork"],
@@ -188,7 +188,7 @@ fn pushed_branch_reports_its_name_on_the_remote_it_landed_on() -> anyhow::Result
         .first()
         .expect("bottom should have been pushed");
     assert_eq!(branch, "bottom");
-    assert_eq!(remote_refname.as_bstr(), "refs/remotes/fork/bottom");
+    assert_eq!(remote_refname, "refs/remotes/fork/bottom");
     assert_eq!(
         remote_branch_name, "bottom",
         "the branch name on the remote must be stripped of the remote the branch actually landed on, not the push default"

--- a/crates/but-workspace/tests/workspace/upstream_integration.rs
+++ b/crates/but-workspace/tests/workspace/upstream_integration.rs
@@ -108,10 +108,7 @@ fn diamond_partially_historically_integrated_rebase() -> Result<()> {
         .raw()
     );
 
-    assert_eq!(
-        repo.rev_parse_single("origin/master")?.detach(),
-        remote_tip_before
-    );
+    assert_eq!(repo.rev_parse_single("origin/master")?, remote_tip_before);
 
     Ok(())
 }
@@ -466,8 +463,8 @@ fn integrated_bottom_branch_no_workspace_rebase() -> Result<()> {
         "the integrated bottom branch should be removed from the refs after rebase integration"
     );
     assert_eq!(
-        repo.rev_parse_single("A^")?.detach(),
-        repo.rev_parse_single("origin/main")?.detach(),
+        repo.rev_parse_single("A^")?,
+        repo.rev_parse_single("origin/main")?,
         "the top branch should be reparented directly onto the integrated target tip"
     );
 
@@ -522,12 +519,12 @@ fn integrated_bottom_branch_does_not_delete_local_main_or_master() -> Result<()>
         "ordinary integrated local branches should still be removed",
     );
     assert_eq!(
-        repo.rev_parse_single("main")?.detach(),
+        repo.rev_parse_single("main")?,
         integrated_bottom_commit,
         "local main should be protected from integrated-branch deletion",
     );
     assert_eq!(
-        repo.rev_parse_single("master")?.detach(),
+        repo.rev_parse_single("master")?,
         integrated_bottom_commit,
         "local master should be protected from integrated-branch deletion",
     );
@@ -622,7 +619,7 @@ fn integrated_bottom_branch_no_workspace_merge() -> Result<()> {
         "the integrated bottom branch should be removed from the refs after merge integration"
     );
 
-    let branch_tip = repo.find_commit(repo.rev_parse_single("A")?.detach())?;
+    let branch_tip = repo.find_commit(repo.rev_parse_single("A")?)?;
     let parents = branch_tip.parent_ids().collect::<Vec<_>>();
     assert_eq!(
         parents.len(),
@@ -630,8 +627,8 @@ fn integrated_bottom_branch_no_workspace_merge() -> Result<()> {
         "merge integration should create a merge commit at the top of the stack"
     );
     assert_eq!(
-        parents[1].detach(),
-        repo.rev_parse_single("origin/main")?.detach(),
+        parents[1],
+        repo.rev_parse_single("origin/main")?,
         "merge integration should keep the integrated target tip as the second parent"
     );
 
@@ -700,7 +697,7 @@ fn merge_upstream_with_conflicting_target_materializes_conflicted_merge_commit()
         .raw()
     );
 
-    let branch_tip = repo.find_commit(repo.rev_parse_single("A")?.detach())?;
+    let branch_tip = repo.find_commit(repo.rev_parse_single("A")?)?;
     assert!(
         Commit::from_id(branch_tip.id.attach(&repo))?.is_conflicted(),
         "upstream integration merge should materialize a conflicted commit when target and stack changes conflict",
@@ -713,8 +710,8 @@ fn merge_upstream_with_conflicting_target_materializes_conflicted_merge_commit()
         "upstream integration merge should preserve merge ancestry in conflicted cases",
     );
     assert_eq!(
-        parents[1].detach(),
-        repo.rev_parse_single("origin/A")?.detach(),
+        parents[1],
+        repo.rev_parse_single("origin/A")?,
         "upstream integration merge should keep the target branch tip as second parent",
     );
 
@@ -1394,8 +1391,8 @@ fn fully_integrated_branch_with_selected_empty_sibling_keeps_following_it() -> R
     // must leave the workspace commit following B — B has its own rebase onto the target —
     // rather than treating B's edge as a stale base and stealing the workspace commit from it.
     assert_eq!(
-        repo.rev_parse_single("B")?.detach(),
-        repo.rev_parse_single("origin/main")?.detach(),
+        repo.rev_parse_single("B")?,
+        repo.rev_parse_single("origin/main")?,
         "the selected empty branch survives and rebases onto the advanced target tip"
     );
     assert_eq!(
@@ -1665,7 +1662,7 @@ fn empty_integrated_direct_checkout_is_replaced() -> Result<()> {
         "the empty local branch should be classified through its tracking tip"
     );
     assert_eq!(
-        repo.merge_base(remote_topic_tip, target_tip)?.detach(),
+        repo.merge_base(remote_topic_tip, target_tip)?,
         remote_topic_tip,
         "the tracking tip should be reachable from the target"
     );
@@ -1710,7 +1707,7 @@ fn empty_integrated_direct_checkout_is_replaced() -> Result<()> {
         "an empty checked-out branch should be removed when its tracking tip is integrated"
     );
     assert_eq!(
-        repo.head_id()?.detach(),
+        repo.head_id()?,
         target_tip,
         "replacement checkout should land at the latest target tip"
     );
@@ -1827,7 +1824,7 @@ fn empty_direct_checkout_with_merged_review_for_pushed_branch_is_replaced() -> R
         "an empty checked-out branch should be removed when its associated review is merged"
     );
     assert_eq!(
-        repo.head_id()?.detach(),
+        repo.head_id()?,
         target_tip,
         "replacement checkout should land at the latest target tip"
     );
@@ -2014,8 +2011,8 @@ fn empty_workspace_reparents_workspace_commit_to_advanced_target() -> Result<()>
     integrate_and_materialize(&mut workspace, &mut meta, &repo, &mut db, vec![])?;
 
     assert_eq!(
-        repo.rev_parse_single("gitbutler/workspace^")?.detach(),
-        repo.rev_parse_single("origin/main")?.detach(),
+        repo.rev_parse_single("gitbutler/workspace^")?,
+        repo.rev_parse_single("origin/main")?,
         "empty workspace commit should move from stored target commit to current target ref tip"
     );
 
@@ -2055,7 +2052,7 @@ fn empty_workspace_reparents_workspace_commit_to_merge_advanced_target() -> Resu
 
     assert_eq!(
         workspace_first_parent(&repo)?,
-        repo.rev_parse_single("origin/main")?.detach(),
+        repo.rev_parse_single("origin/main")?,
         "empty workspace commit should move to the target tip when the target advanced through a merge"
     );
 
@@ -2210,9 +2207,8 @@ fn dry_run_reports_dirty_worktree_conflicts_against_resulting_workspace_head() -
     assert_eq!(
         repo.head()?
             .id()
-            .context("HEAD should point to gitbutler/workspace")?
-            .detach(),
-        repo.rev_parse_single("gitbutler/workspace")?.detach(),
+            .context("HEAD should point to gitbutler/workspace")?,
+        repo.rev_parse_single("gitbutler/workspace")?,
         "dry-run conflict preview must not materialize the rebase"
     );
 
@@ -2692,7 +2688,7 @@ fn orphan_reparent_content_integrated_stack_to_target_tip() -> Result<()> {
 
     assert_eq!(
         workspace_first_parent(&repo)?,
-        repo.rev_parse_single("origin/main")?.detach(),
+        repo.rev_parse_single("origin/main")?,
         "orphaned workspace commit should be reparented to the advanced target tip after content integration"
     );
 
@@ -2775,12 +2771,12 @@ fn orphan_reparent_does_not_run_when_parent_remains() -> Result<()> {
 
     assert_eq!(
         workspace_first_parent(&repo)?,
-        repo.rev_parse_single("B")?.detach(),
+        repo.rev_parse_single("B")?,
         "workspace commit should stay parented to the remaining stack"
     );
     assert_ne!(
         workspace_first_parent(&repo)?,
-        repo.rev_parse_single("origin/main")?.detach(),
+        repo.rev_parse_single("origin/main")?,
         "target should not be added while another workspace parent remains"
     );
 
@@ -2820,7 +2816,7 @@ fn orphan_reparent_empty_stack_to_target_tip() -> Result<()> {
 
     assert_eq!(
         workspace_first_parent(&repo)?,
-        repo.rev_parse_single("origin/main")?.detach(),
+        repo.rev_parse_single("origin/main")?,
         "orphaned workspace commit should be reparented to the target tip after integrating an empty stack"
     );
 
@@ -2989,7 +2985,7 @@ fn non_empty_branch_with_integrated_remote_tip_keeps_local_work() -> Result<()> 
         "branch should remain because it still has local work above its integrated tracking tip",
     );
     assert_eq!(
-        repo.find_commit(repo.rev_parse_single("topic")?.detach())?
+        repo.find_commit(repo.rev_parse_single("topic")?)?
             .message_raw()?
             .to_str()?
             .trim_end(),
@@ -3225,7 +3221,7 @@ fn orphan_reparent_same_target_tip_keeps_single_parent() -> Result<()> {
 
     assert_eq!(
         workspace_first_parent(&repo)?,
-        repo.rev_parse_single("origin/main")?.detach(),
+        repo.rev_parse_single("origin/main")?,
         "orphaned workspace commit should stay on the target tip when it already equals the removed parent"
     );
     assert_eq!(
@@ -3345,8 +3341,8 @@ fn review_hint_fully_integrates_direct_checkout_branch() -> Result<()> {
         "fully review-integrated direct checkout branch should be replaced",
     );
     assert_eq!(
-        repo.head_id()?.detach(),
-        repo.rev_parse_single("origin/main")?.detach(),
+        repo.head_id()?,
+        repo.rev_parse_single("origin/main")?,
         "replacement checkout should land at the advanced target tip",
     );
 
@@ -3564,8 +3560,8 @@ fn review_hint_integrates_squashed_two_commit_direct_checkout_branch() -> Result
         "squash-integrated direct checkout branch should be replaced",
     );
     assert_eq!(
-        repo.head_id()?.detach(),
-        repo.rev_parse_single("origin/main")?.detach(),
+        repo.head_id()?,
+        repo.rev_parse_single("origin/main")?,
         "replacement checkout should land at the squashed target tip",
     );
 
@@ -3846,12 +3842,12 @@ fn review_hint_integrates_prefix_but_keeps_extra_local_commit() -> Result<()> {
         "branch should remain because a local commit still sits above the merged review head",
     );
     assert_eq!(
-        repo.rev_parse_single("A^")?.detach(),
-        repo.rev_parse_single("origin/main")?.detach(),
+        repo.rev_parse_single("A^")?,
+        repo.rev_parse_single("origin/main")?,
         "remaining local tip should be rebased onto the advanced target",
     );
     assert_eq!(
-        repo.find_commit(repo.rev_parse_single("A")?.detach())?
+        repo.find_commit(repo.rev_parse_single("A")?)?
             .message_raw()?
             .to_str()?
             .trim_end(),
@@ -3937,8 +3933,7 @@ fn workspace_first_parent(repo: &gix::Repository) -> Result<gix::ObjectId> {
 }
 
 fn workspace_parent_ids(repo: &gix::Repository) -> Result<Vec<gix::ObjectId>> {
-    let workspace_commit =
-        repo.find_commit(repo.rev_parse_single("gitbutler/workspace")?.detach())?;
+    let workspace_commit = repo.find_commit(repo.rev_parse_single("gitbutler/workspace")?)?;
     Ok(workspace_commit
         .parent_ids()
         .map(|id| id.detach())
@@ -3946,8 +3941,7 @@ fn workspace_parent_ids(repo: &gix::Repository) -> Result<Vec<gix::ObjectId>> {
 }
 
 fn workspace_parent_count(repo: &gix::Repository) -> Result<usize> {
-    let workspace_commit =
-        repo.find_commit(repo.rev_parse_single("gitbutler/workspace")?.detach())?;
+    let workspace_commit = repo.find_commit(repo.rev_parse_single("gitbutler/workspace")?)?;
     Ok(workspace_commit.parent_ids().count())
 }
 

--- a/crates/but/src/command/legacy/branch/list.rs
+++ b/crates/but/src/command/legacy/branch/list.rs
@@ -175,7 +175,7 @@ pub fn list(
                 // If the merge-base equals the branch head, the branch is already fully contained
                 // in the target and has no commits ahead to show.
                 repo.merge_base_with_graph(branch.head, target_oid, &mut graph)
-                    .map(|merge_base| merge_base.detach() != branch.head)
+                    .map(|merge_base| merge_base != branch.head)
                     .unwrap_or(true)
             })
             .take(num_branches_to_take)
@@ -416,7 +416,7 @@ fn check_branches_merge_cleanly(
                     match repo.merge_base_with_graph(target_commit_id, branch.tip, &mut graph) {
                         Ok(merge_base) => {
                             let merge_base_tree_id =
-                                repo.find_commit(merge_base.detach())?.tree_id()?.detach();
+                                repo.find_commit(merge_base)?.tree_id()?.detach();
 
                             // Check if branch merges cleanly into target
                             let merges_cleanly = repo
@@ -450,8 +450,7 @@ fn check_branches_merge_cleanly(
                 // Find merge base
                 match repo.merge_base_with_graph(target_commit_id, branch.head, &mut graph) {
                     Ok(merge_base) => {
-                        let merge_base_tree_id =
-                            repo.find_commit(merge_base.detach())?.tree_id()?.detach();
+                        let merge_base_tree_id = repo.find_commit(merge_base)?.tree_id()?.detach();
 
                         // Check if branch merges cleanly into target
                         let merges_cleanly = repo

--- a/crates/but/src/command/legacy/reword2.rs
+++ b/crates/but/src/command/legacy/reword2.rs
@@ -506,7 +506,7 @@ fn reword_branch(
     let new_name = validate_branch_name(new_name)?;
 
     let result = but_api::branch::branch_rename_with_perm(ctx, ref_name.clone(), new_name, perm)?;
-    if result.new_ref.as_ref() == ref_name.as_ref() {
+    if result.new_ref == ref_name {
         Ok(BranchRename::Unchanged)
     } else {
         Ok(BranchRename::Renamed(result.new_ref.shorten().to_string()))

--- a/crates/but/src/command/legacy/show.rs
+++ b/crates/but/src/command/legacy/show.rs
@@ -25,8 +25,8 @@ pub(crate) fn show_commit(
     // First check if this is a branch by trying to find it in the branch list
     let branches = but_api::legacy::virtual_branches::list_branches(ctx, None)?;
     let branch_match = branches.iter().find(|b| {
-        b.name.to_string() == commit_id_str
-            || b.name.to_string().to_lowercase() == commit_id_str.to_lowercase()
+        b.name.as_bytes() == commit_id_str.as_bytes()
+            || b.name.to_str_lossy().to_lowercase() == commit_id_str.to_lowercase()
     });
 
     if let Some(branch) = branch_match {
@@ -472,7 +472,10 @@ struct StackChainBranch {
 fn find_branch_oid(ctx: &Context, branch_name: &str) -> Result<gix::ObjectId> {
     // First check list_branches
     let branches = but_api::legacy::virtual_branches::list_branches(ctx, None)?;
-    if let Some(branch) = branches.iter().find(|b| b.name.to_string() == branch_name) {
+    if let Some(branch) = branches
+        .iter()
+        .find(|b| b.name.as_bytes() == branch_name.as_bytes())
+    {
         return Ok(branch.head);
     }
 

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -1007,7 +1007,7 @@ fn empty_branch_is_merged_upstream(
     }
 
     repo.merge_base(remote_tip_id, status_ctx.target_tip_id)
-        .is_ok_and(|merge_base| merge_base.detach() == remote_tip_id)
+        .is_ok_and(|merge_base| merge_base == remote_tip_id)
 }
 
 fn remote_tracking_ref_is_target_branch(
@@ -1016,7 +1016,7 @@ fn remote_tracking_ref_is_target_branch(
 ) -> bool {
     status_ctx.base_branch.as_ref().is_some_and(|base_branch| {
         target_remote_tracking_ref_name(base_branch)
-            .is_some_and(|target_ref_name| remote_ref_name.as_bstr() == target_ref_name.as_bytes())
+            .is_some_and(|target_ref_name| remote_ref_name == target_ref_name.as_str())
     })
 }
 

--- a/crates/but/src/command/mcp/mod.rs
+++ b/crates/but/src/command/mcp/mod.rs
@@ -683,7 +683,6 @@ fn branch_details(request: BranchDetailsRequest) -> Result<BranchDetailsView> {
         let repo = resolved.ctx.repo.get()?;
         repo.find_reference(request.branch.as_str())?
             .peel_to_id()?
-            .detach()
             .to_string()
     };
     let last_updated_at = commits.iter().map(|commit| commit.committed_at).max();

--- a/crates/but/src/utils/merged_upstream.rs
+++ b/crates/but/src/utils/merged_upstream.rs
@@ -138,7 +138,7 @@ impl MergedUpstream {
             }
             if repo
                 .merge_base(remote_tip, target_tip)
-                .is_ok_and(|merge_base| merge_base.detach() == remote_tip)
+                .is_ok_and(|merge_base| merge_base == remote_tip)
             {
                 self.merged_branches.insert(ref_info.ref_name.clone());
             }

--- a/crates/but/tests/but/command/status.rs
+++ b/crates/but/tests/but/command/status.rs
@@ -14,13 +14,18 @@ fn single_branch_mode_lazily_initializes_an_unregistered_repository() {
     let status = status_json(&env);
     let project_meta = env.project_meta();
     assert_eq!(
-        project_meta.target_ref.as_ref().map(ToString::to_string),
-        Some("refs/remotes/origin/main".into()),
+        project_meta
+            .target_ref
+            .as_ref()
+            .expect("target is persisted"),
+        "refs/remotes/origin/main",
         "the inferred target should be persisted"
     );
     assert_eq!(
-        project_meta.target_commit_id.map(|id| id.to_string()),
-        Some(env.invoke_git("merge-base HEAD origin/main")),
+        *project_meta
+            .target_commit_id
+            .expect("target commit is persisted"),
+        env.invoke_git("merge-base HEAD origin/main"),
         "the inferred merge base should be persisted"
     );
     assert_eq!(

--- a/crates/gitbutler-branch-actions/src/base.rs
+++ b/crates/gitbutler-branch-actions/src/base.rs
@@ -164,7 +164,7 @@ pub(crate) fn set_base_branch(
         let target_ref_matches = project_meta
             .target_ref
             .as_ref()
-            .is_some_and(|target_ref| target_ref.to_string() == target_branch_ref.to_string());
+            .is_some_and(|target_ref| target_branch_ref == target_ref.as_ref());
         (
             workspace_ref_exists && project_meta.target_commit_id.is_some() && target_ref_matches,
             project_meta.target_ref,
@@ -212,18 +212,17 @@ pub(crate) fn set_base_branch(
     project_meta.remote_url_with_fallback(&repo)?;
 
     // TODO: make sure this is a real branch
-    let head_name: Refname = current_head
+    let head_ref_name = current_head
         .referent_name()
-        .map(|name| {
-            name.to_string()
-                .parse()
-                .expect("BUG: we have to avoid using these legacy types")
-        })
         .context("Failed to get HEAD reference name")?;
+    let head_is_workspace = head_ref_name == WORKSPACE_REF_NAME;
+    let head_name: Refname = head_ref_name
+        .to_string()
+        .parse()
+        .expect("BUG: we have to avoid using these legacy types");
     if workspace_ref_exists
-        && !head_name.to_string().eq(WORKSPACE_REF_NAME)
-        && existing_target_ref
-            .is_none_or(|target_ref| target_ref.to_string() != target_branch_ref.to_string())
+        && !head_is_workspace
+        && existing_target_ref.is_none_or(|target_ref| target_branch_ref != target_ref.as_ref())
     {
         bail_precondition!(
             "cannot change the target while HEAD is outside the GitButler workspace - return to workspace first"
@@ -232,7 +231,7 @@ pub(crate) fn set_base_branch(
     ctx.set_project_meta(project_meta)?;
 
     let mut workspace_to_initialize = None;
-    if !head_name.to_string().eq(WORKSPACE_REF_NAME) {
+    if !head_is_workspace {
         // if there are any commits on the head branch or uncommitted changes in the working directory, we need to
         // put them into a virtual branch
 

--- a/crates/gitbutler-branch-actions/src/integration.rs
+++ b/crates/gitbutler-branch-actions/src/integration.rs
@@ -77,7 +77,7 @@ pub(crate) fn update_workspace_commit_from_workspace(
     let workspace_filepath = repo.path().join("workspace");
     let mut prev_branch = read_workspace_file(&workspace_filepath)?;
     if let Some(branch) = &prev_branch
-        && branch.head != GITBUTLER_WORKSPACE_REFERENCE.to_string()
+        && branch.head != but_core::WORKSPACE_REF_NAME
     {
         // we are moving from a regular branch to our gitbutler workspace branch, write a file to
         // .git/workspace with the previous head and name

--- a/crates/gitbutler-operating-modes/src/lib.rs
+++ b/crates/gitbutler-operating-modes/src/lib.rs
@@ -28,7 +28,7 @@ pub const EDIT_BRANCH_REF: &str = "refs/heads/gitbutler/edit";
 pub fn is_well_known_workspace_ref(ref_name: &gix::refs::FullNameRef) -> bool {
     OPEN_WORKSPACE_REFS
         .iter()
-        .any(|workspace_ref| ref_name.as_bstr() == *workspace_ref)
+        .any(|workspace_ref| ref_name == *workspace_ref)
 }
 
 fn edit_mode_metadata_path(ctx: &Context) -> PathBuf {
@@ -131,7 +131,7 @@ pub fn operating_mode(ctx: &Context, perm: &RepoShared) -> Result<OperatingMode>
     };
     if is_well_known_workspace_ref(head_ref_name) {
         Ok(OperatingMode::OpenWorkspace)
-    } else if head_ref_name.as_bstr() == EDIT_BRANCH_REF {
+    } else if head_ref_name == EDIT_BRANCH_REF {
         let edit_mode_metadata = read_edit_mode_metadata(ctx);
 
         match edit_mode_metadata {

--- a/crates/gitbutler-oplog/src/oplog.rs
+++ b/crates/gitbutler-oplog/src/oplog.rs
@@ -1020,7 +1020,7 @@ fn restore_snapshot(
                 checkout.commit_id
             );
         }
-        if checkout.ref_name.as_ref() == workspace_ref
+        if checkout.ref_name == workspace_ref
             && restored_workspace_commit != Some(checkout.commit_id)
         {
             bail!("snapshot checkout and workspace commits disagree");
@@ -1109,7 +1109,7 @@ fn restore_snapshot(
     reset_index_to_tree(ctx, index_tree_entry.id().detach(), index_conflicts_tree_id)?;
 
     if let Some(checkout) = restored_checkout {
-        if checkout.ref_name.as_ref() != workspace_ref {
+        if checkout.ref_name != workspace_ref {
             repo.reference(
                 checkout.ref_name.as_ref(),
                 checkout.commit_id,

--- a/crates/gitbutler-oplog/tests/oplog/integration.rs
+++ b/crates/gitbutler-oplog/tests/oplog/integration.rs
@@ -501,10 +501,7 @@ fn restore_reconstitutes_missing_commit() -> anyhow::Result<()> {
         "restore recreates the missing commit"
     );
     assert_eq!(
-        gix_repo
-            .find_reference("refs/heads/A")?
-            .peel_to_id()?
-            .detach(),
+        gix_repo.find_reference("refs/heads/A")?.peel_to_id()?,
         second,
         "restore moves the branch back to the recreated commit"
     );
@@ -574,8 +571,7 @@ fn restore_repoints_workspace_and_worktree() -> anyhow::Result<()> {
     assert_eq!(
         gix_repo
             .find_reference(but_core::WORKSPACE_REF_NAME)?
-            .peel_to_id()?
-            .detach(),
+            .peel_to_id()?,
         original_workspace,
         "restore repoints the workspace ref to the snapshotted commit"
     );
@@ -644,7 +640,7 @@ fn restore_round_trips_workspace_and_ad_hoc_checkouts() -> anyhow::Result<()> {
         "undoing a transition to ad-hoc mode must check out the managed workspace"
     );
     assert_eq!(
-        repo.find_reference(workspace_ref)?.peel_to_id()?.detach(),
+        repo.find_reference(workspace_ref)?.peel_to_id()?,
         original_workspace,
         "undoing a transition to ad-hoc mode must recreate the original workspace ref"
     );
@@ -660,7 +656,7 @@ fn restore_round_trips_workspace_and_ad_hoc_checkouts() -> anyhow::Result<()> {
         "redoing the transition must return to the ad-hoc branch"
     );
     assert_eq!(
-        repo.head_id()?.detach(),
+        repo.head_id()?,
         ad_hoc_commit,
         "redoing the transition must restore the ad-hoc commit"
     );

--- a/crates/gitbutler-repo/Cargo.toml
+++ b/crates/gitbutler-repo/Cargo.toml
@@ -20,7 +20,7 @@ gitbutler-reference.workspace = true
 
 git2.workspace = true
 git2-hooks.workspace = true
-gix = { workspace = true, features = ["merge", "status", "tree-editor"] }
+gix = { workspace = true, features = ["merge", "status"] }
 anyhow.workspace = true
 bstr.workspace = true
 tracing.workspace = true

--- a/crates/gitbutler-repo/src/lib.rs
+++ b/crates/gitbutler-repo/src/lib.rs
@@ -40,6 +40,6 @@ pub fn signature_gix(purpose: SignaturePurpose) -> gix::actor::Signature {
 fn commit_time(overriding_variable_name: &str) -> gix::date::Time {
     std::env::var(overriding_variable_name)
         .ok()
-        .and_then(|time| gix::date::parse(&time, Some(std::time::SystemTime::now())).ok())
+        .and_then(|time| gix::date::parse(&time, Some(gix::date::Zoned::now())).ok())
         .unwrap_or_else(gix::date::Time::now_local_or_utc)
 }

--- a/crates/gitbutler-repo/src/traversal.rs
+++ b/crates/gitbutler-repo/src/traversal.rs
@@ -48,7 +48,7 @@ pub fn commit_ids_excluding_reachable_from_with_graph(
 
         let reaches_hidden_history = match repo.merge_base_with_graph(commit_id, stop_before, graph)
         {
-            Ok(merge_base) => merge_base.detach() == commit_id,
+            Ok(merge_base) => merge_base == commit_id,
             Err(gix::repository::merge_base_with_graph::Error::NotFound { .. }) => false,
             Err(err) => return Err(err.into()),
         };

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -121,7 +121,7 @@ fn main() -> anyhow::Result<()> {
 
                 // TODO(mtsgrd): Is there a better way to disable devtools in E2E tests?
                 #[cfg(debug_assertions)]
-                if tauri_app.config().product_name != Some("GitButler Test".to_string()) {
+                if tauri_app.config().product_name.as_deref() != Some("GitButler Test") {
                     window.open_devtools();
                 }
 


### PR DESCRIPTION
5000 changes, 1000 renames, one merge in a 95k file tree, in 10ms, and 100% tested conformity with merge-ORT related to the merged tree itself.
Besides, the merge implementation now conforms to Git merge-ORT in all ways I could test (*with some differences only in conflict index generation*).

### Tasks

* [x] update `gix`
* [x] See if tests can now be less cumbersume as well
