### PR TITLE
Lite: generate the PR title and description

### DIFF
--- a/apps/lite/ui/src/ai-streaming.test.ts
+++ b/apps/lite/ui/src/ai-streaming.test.ts
@@ -1,0 +1,56 @@
+import { streamGeneratedText } from "#ui/ai-streaming.ts";
+import { describe, expect, it, vi } from "vitest";
+
+describe("streamGeneratedText", () => {
+	it("leaves the field alone when the stream fails before writing anything", async () => {
+		const onValue = vi.fn();
+		const onFailure = vi.fn();
+		await expect(
+			streamGeneratedText(
+				async () => {
+					throw new Error("failed before response");
+				},
+				onValue,
+				onFailure,
+			),
+		).rejects.toThrow("failed before response");
+
+		expect(onValue).not.toHaveBeenCalled();
+		expect(onFailure).not.toHaveBeenCalled();
+	});
+
+	it("asks for a restore once a partial answer has overwritten the field", async () => {
+		const onValue = vi.fn();
+		const onFailure = vi.fn();
+		await expect(
+			streamGeneratedText(
+				async (onToken) => {
+					onToken("partial");
+					throw new Error("failed during response");
+				},
+				onValue,
+				onFailure,
+			),
+		).rejects.toThrow("failed during response");
+
+		expect(onValue.mock.calls).toEqual([["partial"]]);
+		expect(onFailure).toHaveBeenCalledOnce();
+	});
+
+	it("streams each partial, then the whole response", async () => {
+		const onValue = vi.fn();
+		const onFailure = vi.fn();
+		await streamGeneratedText(
+			async (onToken) => {
+				onToken("feat: ");
+				onToken("generated");
+				return "feat: generated";
+			},
+			onValue,
+			onFailure,
+		);
+
+		expect(onValue.mock.calls).toEqual([["feat: "], ["feat: generated"], ["feat: generated"]]);
+		expect(onFailure).not.toHaveBeenCalled();
+	});
+});

--- a/apps/lite/ui/src/ai-streaming.ts
+++ b/apps/lite/ui/src/ai-streaming.ts
@@ -1,0 +1,34 @@
+/**
+ * Driving a streamed AI response into a form field.
+ *
+ * Shared by every generator (commit messages, PR descriptions) rather than
+ * owned by one, because they all face the same problem: a stream that dies
+ * halfway has already overwritten what the user wrote.
+ */
+
+/**
+ * Streams partial values, and calls `onFailure` to put the field back if a
+ * stream dies once it has already overwritten something.
+ *
+ * Restoring is a callback rather than a value this could write back through
+ * `onValue`, because a caller may split the stream across several fields —
+ * there is then no single value whose round trip reproduces what was there.
+ */
+export const streamGeneratedText = async (
+	stream: (onToken: (token: string) => void) => Promise<string>,
+	onValue: (value: string) => void,
+	onFailure: () => void,
+): Promise<string> => {
+	let partial = "";
+	try {
+		const response = await stream((token) => {
+			partial += token;
+			onValue(partial);
+		});
+		onValue(response);
+		return response;
+	} catch (error) {
+		if (partial.length > 0) onFailure();
+		throw error;
+	}
+};

--- a/apps/lite/ui/src/api/mutations.ts
+++ b/apps/lite/ui/src/api/mutations.ts
@@ -2,6 +2,7 @@ import { decodeBytes, encodeBytes } from "#ui/api/bytes.ts";
 import { remapSearchBranch, remapSearchCommits, setCursor } from "#ui/use-cursor.ts";
 import { getHeadInfoIndex } from "#ui/api/ref-info.ts";
 import {
+	branchDetailsQueryOptions,
 	currentForgeLoginQueryOptions,
 	getReviewQueryOptions,
 	headInfoQueryOptions,
@@ -16,10 +17,16 @@ import { shortCommitId } from "#ui/commit.ts";
 import {
 	buildCommitMessagePrompt,
 	COMMIT_MESSAGE_SYSTEM_PROMPT,
-	streamCommitMessage,
 } from "#ui/commit-message-generation.ts";
+import { streamGeneratedText } from "#ui/ai-streaming.ts";
+import { branchDetailsParams } from "#ui/branch.ts";
+import {
+	buildPrDescriptionPrompt,
+	PR_DESCRIPTION_SYSTEM_PROMPT,
+	splitGeneratedDescription,
+} from "#ui/pr-description-generation.ts";
 import { errorMessageForToast } from "#ui/errors.ts";
-import { toBase64 } from "#ui/uploads.ts";
+import { oversizedFile, toBase64, UPLOAD_SIZE_LIMIT } from "#ui/uploads.ts";
 import { createDiffSpec, resolveDiffSpecs } from "#ui/operations/diff-specs.ts";
 import {
 	discardChangesToastOptions,
@@ -87,10 +94,10 @@ export const useGenerateCommitMessage = () => {
 				),
 			]);
 			const prompt = buildCommitMessagePrompt(settings.commitMessagePrompt, input.changes, patches);
-			return streamCommitMessage(
+			return streamGeneratedText(
 				(onToken) => window.lite.streamAiResponse(COMMIT_MESSAGE_SYSTEM_PROMPT, prompt, onToken),
 				input.onValue,
-				input.previousMessage,
+				() => input.onValue(input.previousMessage),
 			);
 		},
 		meta: { failureTitle: "Failed to generate commit message" },
@@ -211,6 +218,44 @@ export const usePublishReview = () =>
 		meta: { failureTitle: "Failed to create pull request" },
 	});
 
+type GeneratePrDescriptionInput = {
+	projectId: string;
+	sourceBranch: string;
+	previousTitle: string;
+	previousBody: string;
+	/** Receives the body only; the title lands once the answer is complete. */
+	onBody: (body: string) => void;
+};
+
+/** Loads the branch's commits and streams a generated PR title and description. */
+export const useGeneratePrDescription = () => {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: async (input: GeneratePrDescriptionInput) => {
+			const details = await queryClient.ensureQueryData(
+				branchDetailsQueryOptions({
+					projectId: input.projectId,
+					...branchDetailsParams(input.sourceBranch),
+				}),
+			);
+			const prompt = buildPrDescriptionPrompt(
+				input.previousTitle,
+				input.previousBody,
+				details.commits,
+			);
+			// Only the body is ever written mid-stream, so only the body is put
+			// back — the title is not touched until the answer is complete.
+			const response = await streamGeneratedText(
+				(onToken) => window.lite.streamAiResponse(PR_DESCRIPTION_SYSTEM_PROMPT, prompt, onToken),
+				(partial) => input.onBody(splitGeneratedDescription(partial).body),
+				() => input.onBody(input.previousBody),
+			);
+			return splitGeneratedDescription(response);
+		},
+		meta: { failureTitle: "Failed to generate description" },
+	});
+};
+
 /**
  * Upload files and return them in the order given, so the markdown they turn
  * into matches the order they were picked or dropped in.
@@ -220,8 +265,16 @@ export const usePublishReview = () =>
  */
 export const useUploadFiles = () =>
 	useMutation({
-		mutationFn: async (files: Array<File>) =>
-			Promise.all(
+		mutationFn: async (files: Array<File>) => {
+			const tooLarge = oversizedFile(files);
+			if (tooLarge !== undefined) {
+				throw new Error(
+					`${tooLarge.name} is ${(tooLarge.size / (1024 * 1024)).toFixed(1)} MB, over the ${
+						UPLOAD_SIZE_LIMIT / (1024 * 1024)
+					} MB upload limit`,
+				);
+			}
+			return Promise.all(
 				files.map(async (file) =>
 					window.lite.uploadFile({
 						filename: file.name,
@@ -229,7 +282,8 @@ export const useUploadFiles = () =>
 						data_base64: await toBase64(file),
 					}),
 				),
-			),
+			);
+		},
 		meta: { failureTitle: "Failed to upload files" },
 	});
 

--- a/apps/lite/ui/src/commit-message-generation.test.ts
+++ b/apps/lite/ui/src/commit-message-generation.test.ts
@@ -1,10 +1,9 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import type { TreeChange, UnifiedPatch } from "@gitbutler/but-sdk";
 import {
 	buildCommitMessagePrompt,
 	changesSelectedForCommit,
 	commitMessageGenerationButtonState,
-	streamCommitMessage,
 } from "./commit-message-generation.ts";
 
 const change = (path: string): TreeChange =>
@@ -72,43 +71,5 @@ describe("commit message generation", () => {
 
 		expect(prompt).toContain("File: one.ts (Modification)");
 		expect(diff).toHaveLength(5_000);
-	});
-
-	it("preserves the current value on a failed stream", async () => {
-		const onValue = vi.fn();
-		await expect(
-			streamCommitMessage(
-				async () => {
-					throw new Error("failed before response");
-				},
-				onValue,
-				"original",
-			),
-		).rejects.toThrow("failed before response");
-		expect(onValue).not.toHaveBeenCalled();
-
-		await expect(
-			streamCommitMessage(
-				async (onToken) => {
-					onToken("partial");
-					throw new Error("failed during response");
-				},
-				onValue,
-				"original",
-			),
-		).rejects.toThrow("failed during response");
-		expect(onValue.mock.calls).toEqual([["partial"], ["original"]]);
-
-		onValue.mockClear();
-		await streamCommitMessage(
-			async (onToken) => {
-				onToken("feat: ");
-				onToken("generated");
-				return "feat: generated";
-			},
-			onValue,
-			"original",
-		);
-		expect(onValue.mock.calls).toEqual([["feat: "], ["feat: generated"], ["feat: generated"]]);
 	});
 });

--- a/apps/lite/ui/src/commit-message-generation.ts
+++ b/apps/lite/ui/src/commit-message-generation.ts
@@ -54,23 +54,3 @@ export const buildCommitMessagePrompt = (
 		.slice(0, COMMIT_MESSAGE_DIFF_LIMIT);
 	return `${instructions.trim()}\n\nSelected changes:\n\`\`\`diff\n${diff}\n\`\`\``;
 };
-
-/** Streams partial values and restores the previous value if a started stream fails. */
-export const streamCommitMessage = async (
-	stream: (onToken: (token: string) => void) => Promise<string>,
-	onValue: (value: string) => void,
-	previousValue: string,
-): Promise<string> => {
-	let partial = "";
-	try {
-		const response = await stream((token) => {
-			partial += token;
-			onValue(partial);
-		});
-		onValue(response);
-		return response;
-	} catch (error) {
-		if (partial.length > 0) onValue(previousValue);
-		throw error;
-	}
-};

--- a/apps/lite/ui/src/pr-description-generation.test.ts
+++ b/apps/lite/ui/src/pr-description-generation.test.ts
@@ -1,0 +1,127 @@
+import {
+	buildPrDescriptionPrompt,
+	prDescriptionGenerationButtonState,
+	splitGeneratedDescription,
+} from "#ui/pr-description-generation.ts";
+import type { Commit } from "@gitbutler/but-sdk";
+import { describe, expect, test } from "vitest";
+
+const commit = (message: string) => ({ message }) as Commit;
+
+describe("prDescriptionGenerationButtonState", () => {
+	const base = { enabled: true, configured: true, busy: false, commitCount: 1 };
+
+	test("reports an unconfigured provider ahead of a disabled project setting", () => {
+		expect(
+			prDescriptionGenerationButtonState({ ...base, configured: false, enabled: false }),
+		).toEqual({ disabled: true, hint: "Set up AI in Settings → Application → AI" });
+	});
+
+	test("asks for the project setting once a provider exists", () => {
+		expect(prDescriptionGenerationButtonState({ ...base, enabled: false })).toEqual({
+			disabled: true,
+			hint: "Enable AI in Settings → Project → AI",
+		});
+	});
+
+	test("says nothing while the branch's commits are still loading", () => {
+		expect(prDescriptionGenerationButtonState({ ...base, commitCount: undefined })).toEqual({
+			disabled: true,
+			hint: null,
+		});
+	});
+
+	test("has nothing to describe without commits", () => {
+		expect(prDescriptionGenerationButtonState({ ...base, commitCount: 0 })).toEqual({
+			disabled: true,
+			hint: "No commits to describe",
+		});
+	});
+
+	test("locks while busy, but keeps the plain label", () => {
+		expect(prDescriptionGenerationButtonState({ ...base, busy: true })).toEqual({
+			disabled: true,
+			hint: null,
+		});
+	});
+
+	test("is ready when set up and idle", () => {
+		expect(prDescriptionGenerationButtonState(base)).toEqual({ disabled: false, hint: null });
+	});
+});
+
+describe("buildPrDescriptionPrompt", () => {
+	test("orders commits oldest first, as the work happened", () => {
+		const prompt = buildPrDescriptionPrompt("", "", [commit("newest"), commit("oldest")]);
+		expect(prompt.indexOf("oldest")).toBeLessThan(prompt.indexOf("newest"));
+	});
+
+	test("omits empty title and body rather than sending blank sections", () => {
+		const prompt = buildPrDescriptionPrompt("  ", "", [commit("only commit")]);
+		expect(prompt).not.toContain("Working title");
+		expect(prompt).not.toContain("Description so far");
+	});
+
+	test("passes a partly written title and body as context", () => {
+		const prompt = buildPrDescriptionPrompt("Add uploads", "Still drafting", [commit("c")]);
+		expect(prompt).toContain("Add uploads");
+		expect(prompt).toContain("Still drafting");
+	});
+});
+
+describe("splitGeneratedDescription", () => {
+	test("takes the first line as the title and the rest as the body", () => {
+		expect(splitGeneratedDescription("Add file uploads\n\n- one\n- two")).toEqual({
+			title: "Add file uploads",
+			body: "- one\n- two",
+		});
+	});
+
+	test("drops a body heading that just restates the title", () => {
+		expect(splitGeneratedDescription("Add file uploads\n\n# Add file uploads\n\n- one")).toEqual({
+			title: "Add file uploads",
+			body: "- one",
+		});
+	});
+
+	test("keeps a body heading that says something else", () => {
+		expect(splitGeneratedDescription("Add file uploads\n\n## Background\n\n- one")).toEqual({
+			title: "Add file uploads",
+			body: "## Background\n\n- one",
+		});
+	});
+
+	test("strips markup the model wrapped the title in anyway", () => {
+		expect(splitGeneratedDescription('# "Add file uploads"\n\nbody').title).toBe(
+			"Add file uploads",
+		);
+	});
+
+	test("has no body yet when only the title has streamed in", () => {
+		expect(splitGeneratedDescription("Add file up")).toEqual({
+			title: "Add file up",
+			body: "",
+		});
+	});
+});
+
+describe("splitGeneratedDescription: fenced answers", () => {
+	test("unwraps a whole answer wrapped in a fence", () => {
+		expect(splitGeneratedDescription("```markdown\nAdd uploads\n\n- one\n```")).toEqual({
+			title: "Add uploads",
+			body: "- one",
+		});
+	});
+
+	test("keeps a fenced code block that is only part of the body", () => {
+		const body = "Run it:\n\n```sh\nnpm test\n```\n\nThen check the output.";
+		expect(splitGeneratedDescription(`Add uploads\n\n${body}`).body).toBe(body);
+	});
+
+	test("drops a lone opener mid-stream, before the closing fence arrives", () => {
+		expect(splitGeneratedDescription("```markdown\nAdd file up")).toEqual({
+			title: "Add file up",
+			body: "",
+		});
+	});
+});

--- a/apps/lite/ui/src/pr-description-generation.ts
+++ b/apps/lite/ui/src/pr-description-generation.ts
@@ -1,0 +1,130 @@
+/**
+ * Generating a pull request description from the branch's commits.
+ *
+ * Commits are the context, not the diff: they already carry the author's own
+ * account of what each change was for, which is what a description is, and
+ * they stay small enough to send whole where a branch diff would not.
+ */
+
+import type { Commit } from "@gitbutler/but-sdk";
+
+export const PR_DESCRIPTION_SYSTEM_PROMPT = `You write pull requests.
+Return the title on the first line, then a blank line, then the description body as Markdown.
+The title is plain text: no leading "#", no quotes, no prefix.
+Never repeat the title as a heading or first line of the body — it is shown above the body already.
+Return nothing else: no commentary, no surrounding code fence.`;
+
+const COMMIT_MESSAGE_LIMIT = 5_000;
+
+/**
+ * Mirrors {@link commitMessageGenerationButtonState}: the button is always
+ * rendered so generation is discoverable before it is set up, and `hint`
+ * replaces the plain action label in the tooltip. An unconfigured provider is
+ * reported ahead of a disabled project setting, because the setting cannot be
+ * turned on without one.
+ */
+export const prDescriptionGenerationButtonState = ({
+	enabled,
+	configured,
+	busy,
+	commitCount,
+}: {
+	enabled: boolean;
+	configured: boolean;
+	busy: boolean;
+	/** `undefined` while the branch's commits are still loading. */
+	commitCount: number | undefined;
+}): { disabled: boolean; hint: string | null } => {
+	if (!configured) return { disabled: true, hint: "Set up AI in Settings → Application → AI" };
+	if (!enabled) return { disabled: true, hint: "Enable AI in Settings → Project → AI" };
+	// Not yet known is not the same as none: claiming "no commits" while the
+	// branch is still loading reads as a verdict rather than a wait.
+	if (commitCount === undefined) return { disabled: true, hint: null };
+	if (commitCount === 0) return { disabled: true, hint: "No commits to describe" };
+
+	return { disabled: busy, hint: null };
+};
+
+/**
+ * The title and body already typed are context, not something to preserve:
+ * the model is asked to describe the commits, and a half-written body is a
+ * hint about the intent rather than text to keep.
+ */
+export const buildPrDescriptionPrompt = (
+	title: string,
+	body: string,
+	commits: ReadonlyArray<Commit>,
+): string => {
+	// Oldest first, so the messages read as the order the work happened in.
+	const messages = commits
+		.map((commit) => commit.message.trim())
+		.reverse()
+		.join("\n\n---\n\n")
+		.slice(0, COMMIT_MESSAGE_LIMIT);
+
+	const sections = [
+		"Write the title and description for this pull request.",
+		"List the most important changes. Use bullet points. Be concise.",
+	];
+	if (title.trim() !== "") sections.push(`Working title:\n\`\`\`\n${title.trim()}\n\`\`\``);
+	if (body.trim() !== "")
+		sections.push(`Description so far, to build on:\n\`\`\`\n${body.trim()}\n\`\`\``);
+	sections.push(`Commit messages:\n\`\`\`\n${messages}\n\`\`\``);
+
+	return sections.join("\n\n");
+};
+
+/**
+ * Models often wrap a whole answer in a fence, and mid-stream the closing one
+ * has not arrived yet — so a lone opener is dropped too, or the title would
+ * briefly read "```markdown". A fence that only covers part of the answer is
+ * real content and left alone.
+ */
+const stripSurroundingFence = (text: string): string => {
+	const trimmed = text.trim();
+	if (!trimmed.startsWith("```")) return trimmed;
+
+	const fenced = /^```[a-z]*\n([\s\S]*)\n```$/.exec(trimmed);
+	if (fenced?.[1] !== undefined && !fenced[1].includes("```")) return fenced[1].trim();
+
+	const firstNewline = trimmed.indexOf("\n");
+	if (firstNewline === -1) return "";
+	const withoutOpener = trimmed.slice(firstNewline + 1);
+	return withoutOpener.includes("```") ? trimmed : withoutOpener.trim();
+};
+
+/** Strip anything the model put around a title despite being told not to. */
+const cleanTitle = (line: string): string =>
+	line
+		.trim()
+		.replace(/^#+\s*/, "")
+		.replace(/^["'`]|["'`]$/g, "")
+		.trim();
+
+/**
+ * Split a generated answer into its title and body.
+ *
+ * The body's first line is dropped when it just restates the title: the form
+ * shows the title above the body, so a heading there renders it twice. The
+ * prompt asks for this too, but models do it anyway often enough to be worth
+ * catching here — which is also what makes this safe to run on every partial
+ * while the answer streams in.
+ */
+export const splitGeneratedDescription = (text: string): { title: string; body: string } => {
+	const cleaned = stripSurroundingFence(text);
+	const firstNewline = cleaned.indexOf("\n");
+	if (firstNewline === -1) return { title: cleanTitle(cleaned), body: "" };
+
+	const title = cleanTitle(cleaned.slice(0, firstNewline));
+	const rest = cleaned.slice(firstNewline + 1).trim();
+
+	const restNewline = rest.indexOf("\n");
+	const firstBodyLine = restNewline === -1 ? rest : rest.slice(0, restNewline);
+	const echoesTitle =
+		title !== "" && cleanTitle(firstBodyLine).toLowerCase() === title.toLowerCase();
+
+	return {
+		title,
+		body: echoesTitle ? (restNewline === -1 ? "" : rest.slice(restNewline + 1).trim()) : rest,
+	};
+};

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestForm.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestForm.tsx
@@ -1,5 +1,6 @@
 import {
 	useAddReviewReaction,
+	useGeneratePrDescription,
 	useMergeReview,
 	usePublishReview,
 	useRemoveReviewReaction,
@@ -8,6 +9,8 @@ import {
 	useUpdateReview,
 } from "#ui/api/mutations.ts";
 import {
+	aiConfigurationQueryOptions,
+	branchDetailsQueryOptions,
 	currentForgeLoginQueryOptions,
 	getReviewMergeStatusQueryOptions,
 	listReviewReactionsQueryOptions,
@@ -23,13 +26,15 @@ import { classes } from "#ui/components/classes.ts";
 import { DropdownButton } from "#ui/components/DropdownButton.tsx";
 import { FieldControlStyles, FieldRootStyles } from "#ui/components/Field.tsx";
 import { Icon } from "#ui/components/Icon.tsx";
-import type { IconName } from "#ui/components/iconNames.ts";
 import { Markdown } from "#ui/components/Markdown.tsx";
+import { branchDetailsParams } from "#ui/branch.ts";
 import { MarkdownAttachments } from "#ui/components/MarkdownAttachments.tsx";
 import { MarkdownToolbar } from "#ui/components/MarkdownToolbar.tsx";
 import { SwitchButton } from "#ui/components/SwitchButton.tsx";
 import { TooltipPopup } from "#ui/components/Tooltip.tsx";
 import { pullRequestHotkeys } from "#ui/hotkeys.ts";
+import { prDescriptionGenerationButtonState } from "#ui/pr-description-generation.ts";
+import { projectAiSettingsQueryOptions } from "#ui/project-ai-settings.ts";
 import {
 	nativeMenuItem,
 	nativeMenuItemsFromGroups,
@@ -53,7 +58,7 @@ import type {
 } from "@gitbutler/but-sdk";
 import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { useHotkey } from "@tanstack/react-hotkeys";
-import { type FC, type SubmitEventHandler, Suspense, useRef, useState } from "react";
+import { type FC, type SubmitEventHandler, Suspense, useEffect, useRef, useState } from "react";
 import styles from "./PullRequestForm.module.css";
 
 /**
@@ -110,6 +115,27 @@ export const PullRequestForm: FC<{
 		body: persistedDocument?.body ?? body ?? "",
 		isDraft: persistedDocument?.isDraft ?? false,
 	});
+	const { data: isAiConfigured = false } = useQuery({
+		...aiConfigurationQueryOptions,
+		select: (configuration) => configuration.isConfigured,
+	});
+	const { data: isProjectAiEnabled = false } = useQuery({
+		...projectAiSettingsQueryOptions(projectId),
+		select: (settings) => settings.enabled,
+	});
+	const { data: branchDetails } = useQuery(
+		branchDetailsQueryOptions({ projectId, ...branchDetailsParams(sourceBranch) }),
+	);
+	const { isPending: isGenerating, mutate: generateDescriptionMutation } =
+		useGeneratePrDescription();
+	/**
+	 * The document as of the latest render, for callbacks that fire long after
+	 * the render that created them — an upload or a generated answer landing.
+	 */
+	const latestDocument = useRef(localDocument);
+	useEffect(() => {
+		latestDocument.current = localDocument;
+	});
 	const { mutate: persistDraftPR } = usePersistDraftPR();
 	const { mutate: deleteDraftPR } = useDeleteDraftPR();
 
@@ -154,6 +180,61 @@ export const PullRequestForm: FC<{
 		const resetDocument = { ...remoteOrEmptyDocument, isDraft: false };
 		setLocalDocument(resetDocument);
 		deleteDraftPR({ projectId, branchName: sourceBranch });
+	};
+
+	const generationButton = prDescriptionGenerationButtonState({
+		enabled: isProjectAiEnabled,
+		configured: isAiConfigured,
+		busy: isGenerating || isAnyPending,
+		commitCount: branchDetails?.commits.length,
+	});
+
+	const generateDescription = () => {
+		if (isGenerating) return;
+
+		generateDescriptionMutation(
+			{
+				projectId,
+				sourceBranch,
+				previousTitle: localDocument.title,
+				previousBody: localDocument.body,
+				// Streamed straight into the DOM: routing every token through state
+				// would re-render the form, and that render would overwrite the
+				// textarea from the state the DOM is deliberately running ahead of.
+				// The title is held back until the end for the same reason — it is
+				// one line, so it costs nothing to wait.
+				onBody: (body) => {
+					if (bodyRef.current !== null) bodyRef.current.value = body;
+				},
+			},
+			{
+				onSuccess: ({ title, body }) => {
+					if (bodyRef.current !== null) bodyRef.current.value = body;
+					// Built from the document as it stands now, not as it was at click
+					// time: the Draft switch and the title stay live while the answer
+					// streams, and this both overwrites state and persists it.
+					const current = latestDocument.current;
+					const generated = {
+						...current,
+						// An answer with no title at all leaves the typed one alone.
+						title: title === "" ? current.title : title,
+						body,
+					};
+					setLocalDocument(generated);
+					// Persisted here rather than left to the form's blur: generating
+					// takes no focus that could later leave the form — the button
+					// disables itself while it runs, which drops focus outright — so
+					// switching tabs would unmount the form having saved nothing.
+					persistDraftPR({
+						projectId,
+						branchName: sourceBranch,
+						draft: { ...persistedDocument, ...generated },
+					});
+				},
+				// A failed stream restores the previous body in the DOM only;
+				// state never moved, so there is nothing to put back here.
+			},
+		);
 	};
 
 	const handleSubmit: SubmitEventHandler<HTMLFormElement> = (evt) => {
@@ -236,17 +317,33 @@ export const PullRequestForm: FC<{
 						<div className={styles.footerStart}>
 							<MarkdownAttachments
 								disabled={isAnyPending}
-								onInput={(nextBody) => setLocalDocument({ ...localDocument, body: nextBody })}
+								// An upload can land long after the click, so this updates from
+								// the current document, not the one captured at click time.
+								onInput={(nextBody) => setLocalDocument((prev) => ({ ...prev, body: nextBody }))}
 								targetRef={bodyRef}
 							/>
 							<div aria-hidden className={styles.footerSeparator} />
-							{/* Description generation has no backend yet; it is shown disabled
-							    so the composer's shape matches the design. */}
-							<UnavailableAction
-								icon="ai-text"
-								label="Generate a description"
-								reason="Generating a description isn't supported yet"
-							/>
+							<Tooltip.Root>
+								{/* Disabled buttons swallow hover, so the wrapper span carries the tooltip. */}
+								<Tooltip.Trigger render={<span className={styles.disabledActionWrap} />}>
+									<button
+										aria-label="Generate title and description"
+										className={getButtonClassName({ variant: "ghost", iconOnly: true })}
+										disabled={generationButton.disabled}
+										onClick={generateDescription}
+										type="button"
+									>
+										<Icon name={isGenerating ? "spinner" : "ai-text"} />
+									</button>
+								</Tooltip.Trigger>
+								<Tooltip.Portal>
+									<Tooltip.Positioner sideOffset={4}>
+										<Tooltip.Popup render={<TooltipPopup />}>
+											{generationButton.hint ?? "Generate title and description"}
+										</Tooltip.Popup>
+									</Tooltip.Positioner>
+								</Tooltip.Portal>
+							</Tooltip.Root>
 						</div>
 
 						<div className={styles.footerEnd}>
@@ -300,27 +397,6 @@ export const PullRequestForm: FC<{
 };
 
 /** A designed action whose backing feature does not exist yet. */
-const UnavailableAction: FC<{ icon: IconName; label: string; reason: string }> = (p) => (
-	<Tooltip.Root>
-		{/* Disabled buttons swallow hover, so the wrapper span carries the tooltip. */}
-		<Tooltip.Trigger render={<span className={styles.disabledActionWrap} />}>
-			<button
-				aria-label={p.label}
-				className={getButtonClassName({ variant: "ghost", iconOnly: true })}
-				disabled
-				type="button"
-			>
-				<Icon name={p.icon} />
-			</button>
-		</Tooltip.Trigger>
-		<Tooltip.Portal>
-			<Tooltip.Positioner sideOffset={4}>
-				<Tooltip.Popup render={<TooltipPopup />}>{p.reason}</Tooltip.Popup>
-			</Tooltip.Positioner>
-		</Tooltip.Portal>
-	</Tooltip.Root>
-);
-
 /** Fold the raw reaction list into chip tallies plus who-reacted names. */
 const reviewReactionsSelect = (
 	reactions: Array<ForgeReviewReaction>,

--- a/apps/lite/ui/src/uploads.ts
+++ b/apps/lite/ui/src/uploads.ts
@@ -9,6 +9,17 @@
 
 import type { Upload } from "@gitbutler/but-sdk";
 
+/**
+ * The backend enforces this too, but only after the bytes have crossed IPC —
+ * checking here keeps a doomed file from being read and base64-encoded (~1.4x
+ * its size) just to be rejected.
+ */
+export const UPLOAD_SIZE_LIMIT = 10 * 1024 * 1024;
+
+/** The first file too large to upload, if any. */
+export const oversizedFile = (files: ReadonlyArray<File>): File | undefined =>
+	files.find((file) => file.size > UPLOAD_SIZE_LIMIT);
+
 /** What the file picker offers, matching what the desktop app accepts. */
 export const ACCEPTED_FILE_TYPES = ["image/*", "application/*", "text/*", "audio/*", "video/*"];
 


### PR DESCRIPTION
Stacked on #15507 — that PR makes the paperclip work, this one makes the wand
beside it work. Together they leave nothing in the composer disabled.

The branch's commit messages are the context, not the diff: they already carry
the author's account of what each change was for, which is what a description
is, and they stay small enough to send whole. Same context desktop's
`describePR` uses.

Decisions worth a look:

- **The answer is one text** — title on the first line, then the body — split
  as it streams. Models restate the title as a body heading even when told not
  to, so that line is dropped when it echoes the title. The prompt alone was
  not enough; this was the original bug report.
- **The body streams into the DOM; the title lands at the end.** A state
  update per token would re-render the form, and that render would overwrite
  the textarea from the state the DOM is deliberately running ahead of.
- **The result is persisted on success**, not left to the form's blur. The
  button disables itself while generating, which drops focus out of the form
  entirely, so no `focusout` follows — switching tabs unmounted the form having
  saved nothing and the generated text was lost. This is what `CommitForm`
  already does for generated commit messages.
- **Generating replaces a title you already typed**, but yours is passed as
  context so a deliberate one tends to survive in spirit. An answer with no
  title leaves yours alone.
- **Gating mirrors the commit-message button**: unconfigured provider before
  disabled project setting, and "no commits to describe" only once the branch
  has actually loaded — not while it is still loading.

`streamGeneratedText` moves out of `commit-message-generation` now that two
generators share it. Its restore-on-failure is a callback rather than a value:
this caller splits one stream across two fields, so there is no single value
whose round trip reproduces what was there.

Verified against the running app over CDP: generation produces a title and a
body with no duplicated heading, and both survive a tab round-trip. Unit tests
cover the prompt, the split, the de-duplication and the streaming contract; the
persistence fix itself is component wiring with no fixture to hang a test on,
so it is verified live only.