### PR TITLE
fix(cli): align length of short ids for branches and worktrees

### DIFF
--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_one_worktree_file_onto_its_own_branch_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_one_worktree_file_onto_its_own_branch_001.svg
@@ -22,10 +22,10 @@
     <text x="82" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊┊</text>
     <text x="10 18 26 34" y="96" style="fill:#FFFFFF;font-weight:bold;">┊┊╭┄</text>
-    <text x="50" y="96" style="fill:#0000AA;font-weight:bold;">v</text>
-    <text x="66" y="96" style="fill:#FFFFFF;font-weight:bold;">{</text>
-    <text x="74 82 90 98 106 114 122 130 138" y="96" style="fill:#00AAAA;font-weight:bold;">wt-branch</text>
-    <text x="146" y="96" style="fill:#FFFFFF;font-weight:bold;">}</text>
+    <text x="50 58" y="96" style="fill:#0000AA;font-weight:bold;">wt</text>
+    <text x="74" y="96" style="fill:#FFFFFF;font-weight:bold;">{</text>
+    <text x="82 90 98 106 114 122 130 138 146" y="96" style="fill:#00AAAA;font-weight:bold;">wt-branch</text>
+    <text x="154" y="96" style="fill:#FFFFFF;font-weight:bold;">}</text>
     <text x="10 18 26" y="114" style="fill:#FFFFFF;font-weight:bold;">┊┊│</text>
     <text x="50 58" y="114" style="fill:#000000;font-weight:bold;">&lt;&lt;</text>
     <text x="74 82 90 98 106 114" y="114" style="fill:#000000;font-weight:bold;">commit</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_source_from_a_worktree_heading_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_source_from_a_worktree_heading_final.svg
@@ -26,10 +26,10 @@
     <text x="50 58" y="96" style="fill:#FFFFFF;font-weight:bold;">&lt;&lt;</text>
     <text x="74 82 90 98 106 114" y="96" style="fill:#FFFFFF;font-weight:bold;">source</text>
     <text x="130 138" y="96" style="fill:#FFFFFF;font-weight:bold;">&gt;&gt;</text>
-    <text x="154" y="96" style="fill:#0000AA;font-weight:bold;">v</text>
-    <text x="170" y="96" style="fill:#FFFFFF;font-weight:bold;">{</text>
-    <text x="178 186 194 202 210 218 226 234 242" y="96" style="fill:#00AAAA;font-weight:bold;">wt-branch</text>
-    <text x="250" y="96" style="fill:#FFFFFF;font-weight:bold;">}</text>
+    <text x="154 162" y="96" style="fill:#0000AA;font-weight:bold;">wt</text>
+    <text x="178" y="96" style="fill:#FFFFFF;font-weight:bold;">{</text>
+    <text x="186 194 202 210 218 226 234 242 250" y="96" style="fill:#00AAAA;font-weight:bold;">wt-branch</text>
+    <text x="258" y="96" style="fill:#FFFFFF;font-weight:bold;">}</text>
     <text x="10 18 26" y="114" style="fill:#FFFFFF;font-weight:bold;">┊┊│</text>
     <text x="50 58" y="114" style="fill:#000000;font-weight:bold;">&lt;&lt;</text>
     <text x="74 82 90 98 106 114" y="114" style="fill:#000000;font-weight:bold;">commit</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_to_a_detached_worktree_heading_is_refused.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_to_a_detached_worktree_heading_is_refused.svg
@@ -18,10 +18,10 @@
     <text x="82" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊┊</text>
     <text x="10 18 26 34" y="96" style="fill:#FFFFFF;font-weight:bold;">┊┊╭┄</text>
-    <text x="50" y="96" style="fill:#0000AA;font-weight:bold;">v</text>
-    <text x="66" y="96" style="fill:#FFFFFF;font-weight:bold;">{</text>
-    <text x="74 82" y="96" style="fill:#00AAAA;font-weight:bold;">wt</text>
-    <text x="90" y="96" style="fill:#FFFFFF;font-weight:bold;">}</text>
+    <text x="50 58" y="96" style="fill:#0000AA;font-weight:bold;">wt</text>
+    <text x="74" y="96" style="fill:#FFFFFF;font-weight:bold;">{</text>
+    <text x="82 90" y="96" style="fill:#00AAAA;font-weight:bold;">wt</text>
+    <text x="98" y="96" style="fill:#FFFFFF;font-weight:bold;">}</text>
     <text x="10 18 26" y="114" style="fill:#CCCCCC;">┊┊┊</text>
     <text x="58 66" y="114" style="fill:#0000AA;font-weight:bold;">ok</text>
     <text x="82" y="114" style="fill:#CCCCCC;">A</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/empty_commit_on_a_worktree_heading_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/empty_commit_on_a_worktree_heading_final.svg
@@ -18,10 +18,10 @@
     <text x="82" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊┊</text>
     <text x="10 18 26 34" y="96" style="fill:#CCCCCC;">┊┊╭┄</text>
-    <text x="50" y="96" style="fill:#0000AA;font-weight:bold;">v</text>
-    <text x="66" y="96" style="fill:#CCCCCC;">{</text>
-    <text x="74 82 90 98 106 114 122 130 138" y="96" style="fill:#00AAAA;">wt-branch</text>
-    <text x="146" y="96" style="fill:#CCCCCC;">}</text>
+    <text x="50 58" y="96" style="fill:#0000AA;font-weight:bold;">wt</text>
+    <text x="74" y="96" style="fill:#CCCCCC;">{</text>
+    <text x="82 90 98 106 114 122 130 138 146" y="96" style="fill:#00AAAA;">wt-branch</text>
+    <text x="154" y="96" style="fill:#CCCCCC;">}</text>
     <text x="10 18 26" y="114" style="fill:#CCCCCC;">┊┊┊</text>
     <text x="58 66" y="114" style="fill:#0000AA;font-weight:bold;">ok</text>
     <text x="82" y="114" style="fill:#CCCCCC;">A</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marks_spanning_checkouts_are_refused.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marks_spanning_checkouts_are_refused.svg
@@ -20,10 +20,10 @@
     <text x="82" y="78" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊┊</text>
     <text x="10 18 26 34" y="114" style="fill:#FFFFFF;font-weight:bold;">┊┊╭┄</text>
-    <text x="50" y="114" style="fill:#0000AA;font-weight:bold;">v</text>
-    <text x="66" y="114" style="fill:#FFFFFF;font-weight:bold;">{</text>
-    <text x="74 82 90 98 106 114 122 130 138" y="114" style="fill:#00AAAA;font-weight:bold;">wt-branch</text>
-    <text x="146" y="114" style="fill:#FFFFFF;font-weight:bold;">}</text>
+    <text x="50 58" y="114" style="fill:#0000AA;font-weight:bold;">wt</text>
+    <text x="74" y="114" style="fill:#FFFFFF;font-weight:bold;">{</text>
+    <text x="82 90 98 106 114 122 130 138 146" y="114" style="fill:#00AAAA;font-weight:bold;">wt-branch</text>
+    <text x="154" y="114" style="fill:#FFFFFF;font-weight:bold;">}</text>
     <text x="10 18 26" y="132" style="fill:#CCCCCC;">┊┊┊</text>
     <text x="58 66" y="132" style="fill:#0000AA;font-weight:bold;">ok</text>
     <text x="82" y="132" style="fill:#CCCCCC;">A</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/move_commit_below_a_worktree_heading_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/move_commit_below_a_worktree_heading_001.svg
@@ -22,10 +22,10 @@
     <text x="82" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊┊</text>
     <text x="10 18 26 34" y="96" style="fill:#FFFFFF;font-weight:bold;">┊┊╭┄</text>
-    <text x="50" y="96" style="fill:#0000AA;font-weight:bold;">v</text>
-    <text x="66" y="96" style="fill:#FFFFFF;font-weight:bold;">{</text>
-    <text x="74 82 90 98 106 114 122 130 138" y="96" style="fill:#00AAAA;font-weight:bold;">wt-branch</text>
-    <text x="146" y="96" style="fill:#FFFFFF;font-weight:bold;">}</text>
+    <text x="50 58" y="96" style="fill:#0000AA;font-weight:bold;">wt</text>
+    <text x="74" y="96" style="fill:#FFFFFF;font-weight:bold;">{</text>
+    <text x="82 90 98 106 114 122 130 138 146" y="96" style="fill:#00AAAA;font-weight:bold;">wt-branch</text>
+    <text x="154" y="96" style="fill:#FFFFFF;font-weight:bold;">}</text>
     <text x="10 18 26" y="114" style="fill:#FFFFFF;font-weight:bold;">┊┊│</text>
     <text x="50 58" y="114" style="fill:#000000;font-weight:bold;">&lt;&lt;</text>
     <text x="74 82 90 98" y="114" style="fill:#000000;font-weight:bold;">move</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/move_commit_below_a_worktree_heading_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/move_commit_below_a_worktree_heading_002.svg
@@ -18,10 +18,10 @@
     <text x="82" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊┊</text>
     <text x="10 18 26 34" y="96" style="fill:#CCCCCC;">┊┊╭┄</text>
-    <text x="50" y="96" style="fill:#0000AA;font-weight:bold;">v</text>
-    <text x="66" y="96" style="fill:#CCCCCC;">{</text>
-    <text x="74 82 90 98 106 114 122 130 138" y="96" style="fill:#00AAAA;">wt-branch</text>
-    <text x="146" y="96" style="fill:#CCCCCC;">}</text>
+    <text x="50 58" y="96" style="fill:#0000AA;font-weight:bold;">wt</text>
+    <text x="74" y="96" style="fill:#CCCCCC;">{</text>
+    <text x="82 90 98 106 114 122 130 138 146" y="96" style="fill:#00AAAA;">wt-branch</text>
+    <text x="154" y="96" style="fill:#CCCCCC;">}</text>
     <text x="10 18 26" y="114" style="fill:#CCCCCC;">┊┊┊</text>
     <text x="58 66" y="114" style="fill:#0000AA;font-weight:bold;">ok</text>
     <text x="82" y="114" style="fill:#CCCCCC;">A</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/sibling_worktree_lanes_are_separated_after_uncommitted_files_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/sibling_worktree_lanes_are_separated_after_uncommitted_files_001.svg
@@ -18,31 +18,31 @@
     <text x="82" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊┊</text>
     <text x="10 18 26 34" y="96" style="fill:#CCCCCC;">┊┊╭┄</text>
-    <text x="50" y="96" style="fill:#0000AA;font-weight:bold;">v</text>
-    <text x="66" y="96" style="fill:#CCCCCC;">{</text>
-    <text x="74 82 90 98 106 114 122 130 138" y="96" style="fill:#00AAAA;">wt-branch</text>
-    <text x="146" y="96" style="fill:#CCCCCC;">}</text>
+    <text x="50 58" y="96" style="fill:#0000AA;font-weight:bold;">wt</text>
+    <text x="74" y="96" style="fill:#CCCCCC;">{</text>
+    <text x="82 90 98 106 114 122 130 138 146" y="96" style="fill:#00AAAA;">wt-branch</text>
+    <text x="154" y="96" style="fill:#CCCCCC;">}</text>
     <text x="10 18 26" y="114" style="fill:#CCCCCC;">┊┊┊</text>
     <text x="58 66" y="114" style="fill:#0000AA;font-weight:bold;">ok</text>
     <text x="82" y="114" style="fill:#CCCCCC;">A</text>
     <text x="98 106 114 122 130 138 146 154 162 170 178" y="114" style="fill:#00AA00;">wt-file.txt</text>
     <text x="10 18 26" y="132" style="fill:#CCCCCC;">┊┊┊</text>
     <text x="10 18 26 34 42" y="150" style="fill:#CCCCCC;">┊┊┊╭┄</text>
-    <text x="58" y="150" style="fill:#0000AA;font-weight:bold;">w</text>
-    <text x="74" y="150" style="fill:#CCCCCC;">{</text>
-    <text x="82 90 98 106 114 122 130 138 146 154 162 170" y="150" style="fill:#00AAAA;">wt-child-one</text>
-    <text x="178" y="150" style="fill:#CCCCCC;">}</text>
-    <text x="194 202 210" y="150" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="226 234 242 250 258 266 274 282" y="150" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="58 66" y="150" style="fill:#0000AA;font-weight:bold;">ch</text>
+    <text x="82" y="150" style="fill:#CCCCCC;">{</text>
+    <text x="90 98 106 114 122 130 138 146 154 162 170 178" y="150" style="fill:#00AAAA;">wt-child-one</text>
+    <text x="186" y="150" style="fill:#CCCCCC;">}</text>
+    <text x="202 210 218" y="150" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="234 242 250 258 266 274 282 290" y="150" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10 18 26 34" y="168" style="fill:#CCCCCC;">┊┊├╯</text>
     <text x="10 18 26" y="186" style="fill:#CCCCCC;">┊┊┊</text>
     <text x="10 18 26 34 42" y="204" style="fill:#CCCCCC;">┊┊┊╭┄</text>
-    <text x="58" y="204" style="fill:#0000AA;font-weight:bold;">r</text>
-    <text x="74" y="204" style="fill:#CCCCCC;">{</text>
-    <text x="82 90 98 106 114 122 130 138 146 154 162 170" y="204" style="fill:#00AAAA;">wt-child-two</text>
-    <text x="178" y="204" style="fill:#CCCCCC;">}</text>
-    <text x="194 202 210" y="204" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="226 234 242 250 258 266 274 282" y="204" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="58 66" y="204" style="fill:#0000AA;font-weight:bold;">hi</text>
+    <text x="82" y="204" style="fill:#CCCCCC;">{</text>
+    <text x="90 98 106 114 122 130 138 146 154 162 170 178" y="204" style="fill:#00AAAA;">wt-child-two</text>
+    <text x="186" y="204" style="fill:#CCCCCC;">}</text>
+    <text x="202 210 218" y="204" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="234 242 250 258 266 274 282 290" y="204" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10 18 26 34" y="222" style="fill:#CCCCCC;">┊┊├╯</text>
     <text x="10 18 26" y="240" style="fill:#CCCCCC;">┊┊●</text>
     <text x="58" y="240" style="fill:#AA00AA;">n</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/worktree_lane_is_navigable_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/worktree_lane_is_navigable_final.svg
@@ -18,10 +18,10 @@
     <text x="82" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊┊</text>
     <text x="10 18 26 34" y="96" style="fill:#CCCCCC;">┊┊╭┄</text>
-    <text x="50" y="96" style="fill:#0000AA;font-weight:bold;">v</text>
-    <text x="66" y="96" style="fill:#CCCCCC;">{</text>
-    <text x="74 82 90 98 106 114 122 130 138" y="96" style="fill:#00AAAA;">wt-branch</text>
-    <text x="146" y="96" style="fill:#CCCCCC;">}</text>
+    <text x="50 58" y="96" style="fill:#0000AA;font-weight:bold;">wt</text>
+    <text x="74" y="96" style="fill:#CCCCCC;">{</text>
+    <text x="82 90 98 106 114 122 130 138 146" y="96" style="fill:#00AAAA;">wt-branch</text>
+    <text x="154" y="96" style="fill:#CCCCCC;">}</text>
     <text x="10 18 26" y="114" style="fill:#CCCCCC;">┊┊┊</text>
     <text x="58 66" y="114" style="fill:#0000AA;font-weight:bold;">ok</text>
     <text x="82" y="114" style="fill:#CCCCCC;">A</text>

--- a/crates/but/src/command/legacy/status/tui/tests/worktree_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/worktree_tests.rs
@@ -70,7 +70,7 @@ fn worktree_lane_is_navigable() {
     tui.input(KeyCode::Down)
         .assert_current_line_eq(str!["┊╭┄ g0 [A]"]);
     tui.input(KeyCode::Down)
-        .assert_current_line_eq(str!["┊┊╭┄ v {wt-branch}"]);
+        .assert_current_line_eq(str!["┊┊╭┄ wt {wt-branch}"]);
     tui.input(KeyCode::Down)
         .assert_current_line_eq(str!["┊┊┊   ok A wt-file.txt"]);
     tui.input(KeyCode::Down)
@@ -96,12 +96,12 @@ fn remember_selection_on_worktree_heading() {
 
     tui.reload();
     tui.input([KeyCode::Down, KeyCode::Down])
-        .assert_current_line_eq(str!["┊┊╭┄ v {wt-branch}"]);
+        .assert_current_line_eq(str!["┊┊╭┄ wt {wt-branch}"]);
     tui.input('q');
 
     let mut tui = test_status_tui_with_options(tui.into_env(), options());
     tui.reload()
-        .assert_current_line_eq(str!["┊┊╭┄ v {wt-branch}"]);
+        .assert_current_line_eq(str!["┊┊╭┄ wt {wt-branch}"]);
 }
 
 /// A worktree heading names that checkout's uncommitted area, the way `zz` names the main
@@ -112,11 +112,11 @@ fn commit_source_from_a_worktree_heading() {
 
     tui.reload();
     tui.input([KeyCode::Down, KeyCode::Down])
-        .assert_current_line_eq(str!["┊┊╭┄ v {wt-branch}"]);
+        .assert_current_line_eq(str!["┊┊╭┄ wt {wt-branch}"]);
 
     // The heading claims the source inline; its extension line advertises the destination.
     tui.input('c')
-        .assert_current_line_eq(str!["┊┊╭┄ << source >> v {wt-branch}"])
+        .assert_current_line_eq(str!["┊┊╭┄ << source >> wt {wt-branch}"])
         .assert_rendered_term_svg_eq(file![
             "snapshots/commit_source_from_a_worktree_heading_final.svg"
         ]);
@@ -130,7 +130,7 @@ fn commit_all_changes_of_a_worktree() {
 
     tui.reload();
     tui.input([KeyCode::Down, KeyCode::Down])
-        .assert_current_line_eq(str!["┊┊╭┄ v {wt-branch}"]);
+        .assert_current_line_eq(str!["┊┊╭┄ wt {wt-branch}"]);
 
     tui.input('c');
     with_var("GIT_EDITOR", Some(editor), || {
@@ -169,7 +169,7 @@ fn commit_one_worktree_file_onto_its_own_branch() {
     // Up onto the worktree's own lane heading, which offers itself as the destination via the
     // `<< commit to worktree >>` extension line.
     tui.input(KeyCode::Up)
-        .assert_current_line_eq(str!["┊┊╭┄ v {wt-branch}"])
+        .assert_current_line_eq(str!["┊┊╭┄ wt {wt-branch}"])
         .assert_rendered_term_svg_eq(file![
             "snapshots/commit_one_worktree_file_onto_its_own_branch_001.svg"
         ]);
@@ -207,7 +207,7 @@ fn commit_a_main_worktree_change_onto_a_worktree() {
         .assert_current_line_eq(str!["╭┄ << source >> << noop >> zz [uncommitted]"]);
 
     tui.input([KeyCode::Down, KeyCode::Down])
-        .assert_current_line_eq(str!["┊┊╭┄ v {wt-branch}"]);
+        .assert_current_line_eq(str!["┊┊╭┄ wt {wt-branch}"]);
 
     with_var("GIT_EDITOR", Some(editor), || {
         tui.input(KeyCode::Enter);
@@ -251,7 +251,7 @@ fn marks_spanning_checkouts_are_refused() {
 
     tui.input('c');
     tui.input(KeyCode::Up)
-        .assert_current_line_eq(str!["┊┊╭┄ v {wt-branch}"]);
+        .assert_current_line_eq(str!["┊┊╭┄ wt {wt-branch}"]);
 
     // The refusal shows as an error and nothing was committed.
     tui.input(KeyCode::Enter)
@@ -286,10 +286,10 @@ fn commit_to_a_detached_worktree_heading_is_refused() {
     // Detached, the heading falls back to the worktree's name.
     tui.reload();
     tui.input([KeyCode::Down, KeyCode::Down])
-        .assert_current_line_eq(str!["┊┊╭┄ v {wt}"]);
+        .assert_current_line_eq(str!["┊┊╭┄ wt {wt}"]);
 
     tui.input('c')
-        .assert_current_line_eq(str!["┊┊╭┄ << source >> v {wt}"]);
+        .assert_current_line_eq(str!["┊┊╭┄ << source >> wt {wt}"]);
 
     tui.input(KeyCode::Enter).assert_rendered_term_svg_eq(file![
         "snapshots/commit_to_a_detached_worktree_heading_is_refused.svg"
@@ -316,7 +316,7 @@ fn empty_commit_on_a_worktree_heading() {
 
     tui.reload();
     tui.input([KeyCode::Down, KeyCode::Down])
-        .assert_current_line_eq(str!["┊┊╭┄ v {wt-branch}"]);
+        .assert_current_line_eq(str!["┊┊╭┄ wt {wt-branch}"]);
 
     tui.input('n')
         .assert_rendered_term_svg_eq(file![
@@ -341,7 +341,7 @@ fn move_commit_below_a_worktree_heading() {
     tui.input('m');
     // Past the worktree's own commit, onto its heading.
     tui.input([KeyCode::Up, KeyCode::Up])
-        .assert_current_line_eq(str!["┊┊╭┄ v {wt-branch}"])
+        .assert_current_line_eq(str!["┊┊╭┄ wt {wt-branch}"])
         .assert_rendered_term_svg_eq(file![
             "snapshots/move_commit_below_a_worktree_heading_001.svg"
         ]);

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -141,17 +141,6 @@ fn create_reverse_hex_id(source: &ChangeSourceId, path_bytes: &[u8]) -> anyhow::
     Ok(change_id)
 }
 
-/// Create a CLI ID for the linked worktree named `name`.
-///
-/// Hashed in its own domain so a worktree never collides with a file that happens
-/// to be named after it.
-fn create_worktree_reverse_hex_id(name: &BStr) -> anyhow::Result<ChangeId> {
-    let mut hasher = gix::hash::hasher(gix::hash::Kind::Sha1);
-    hasher.update(b"worktree\0");
-    hasher.update(name);
-    Ok(ChangeId::from_bytes(hasher.try_finalize()?.as_bytes()))
-}
-
 /// Assign short IDs to each `Some` entry such that they are unambiguous with respect to every other
 /// entry.
 ///
@@ -600,15 +589,15 @@ pub struct IdMap {
     pub uncommitted_files: BTreeMap<ChangeId, UncommittedFile>,
     /// Uncommitted hunks.
     pub uncommitted_hunks: HashMap<ShortId, UncommittedHunk>,
-    /// Maps full reverse hex IDs to the linked worktrees that have CLI IDs.
-    pub worktrees: BTreeMap<ChangeId, WorktreeWithId>,
+    /// Maps stable worktree names to the linked worktrees that have CLI IDs.
+    pub worktrees: BTreeMap<BString, WorktreeWithId>,
 }
 
 /// A linked worktree with its short ID, naming that checkout's uncommitted area
 /// the way `zz` names the main worktree's.
 #[derive(Debug, Clone)]
 pub struct WorktreeWithId {
-    /// The short CLI ID for this worktree (typically 2 characters).
+    /// The name-derived short CLI ID for this worktree (at least 2 characters).
     pub short_id: ShortId,
     /// The stable worktree name, i.e. the directory name under
     /// `$GIT_COMMON_DIR/worktrees/`.
@@ -652,7 +641,7 @@ impl IdMap {
         let StacksInfo {
             mut stacks,
             mut id_usage,
-            non_hex_used_short_ids,
+            mut non_hex_used_short_ids,
         } = StacksInfo::new(
             stacks,
             &uncommitted_short_filenames,
@@ -695,16 +684,13 @@ impl IdMap {
             id_usage = fallback_id_usage;
         }
 
-        let mut worktrees: BTreeMap<ChangeId, WorktreeWithId> = BTreeMap::new();
+        let mut worktrees: BTreeMap<BString, WorktreeWithId> = BTreeMap::new();
         for name in worktree_names {
-            let reverse_hex = create_worktree_reverse_hex_id(name.as_ref())?;
-            // Ensure that worktrees do not collide with CLI IDs generated after
-            if let Some(uint_id) = UintId::from_name(&reverse_hex[..2]) {
-                id_usage.mark_used(uint_id);
-            }
-            if let Some(uint_id) = UintId::from_name(&reverse_hex[..3]) {
-                id_usage.mark_used(uint_id);
-            }
+            let short_id = stacks_info::allocate_name_short_id(
+                name.as_ref(),
+                &mut id_usage,
+                &mut non_hex_used_short_ids,
+            )?;
             let commits = worktree_commits
                 .remove(&name)
                 .unwrap_or_default()
@@ -719,9 +705,9 @@ impl IdMap {
                 })
                 .collect();
             worktrees.insert(
-                reverse_hex,
+                name.clone(),
                 WorktreeWithId {
-                    short_id: ShortId::default(),
+                    short_id,
                     name,
                     commits,
                 },
@@ -762,11 +748,9 @@ impl IdMap {
             reverse_hex_short_ids.push((ChangeId::from(BString::from(short_id.as_str())), None));
         }
 
-        // Worktrees share the uncommitted namespace, so they disambiguate against
-        // files and commit change IDs like everything else in it. Their commits share the
-        // change ID namespace with workspace commits, so both are disambiguated together.
-        for (reverse_hex, worktree) in worktrees.iter_mut() {
-            reverse_hex_short_ids.push((reverse_hex.clone(), Some(&mut worktree.short_id)));
+        // Worktree commits share the change ID namespace with workspace commits, so both are
+        // disambiguated together.
+        for worktree in worktrees.values_mut() {
             for change_id in worktree
                 .commits
                 .iter_mut()
@@ -1143,13 +1127,12 @@ impl IdMap {
             .collect()
     }
 
-    /// All linked worktrees whose full reverse-hex ID starts with `element`.
-    fn worktree_id_prefix_matches<'a>(&'a self, element: &str) -> Vec<Box<dyn Node<'a> + 'a>> {
-        let element_bstring = BString::from(element);
+    /// The linked worktree whose short ID exactly matches `element`, if any.
+    fn parse_worktree_short_id<'a>(&'a self, element: &str) -> Vec<Box<dyn Node<'a> + 'a>> {
         self.worktrees
-            .range(ChangeId::from(element_bstring.clone())..)
-            .take_while(|(reverse_hex, _)| reverse_hex.starts_with(&element_bstring))
-            .map(|(_, worktree)| Box::new(worktree) as Box<dyn Node<'a> + 'a>)
+            .values()
+            .filter(|worktree| worktree.short_id == element)
+            .map(|worktree| Box::new(worktree) as Box<dyn Node<'a> + 'a>)
             .collect()
     }
 
@@ -1235,6 +1218,8 @@ impl IdMap {
 
         if scope == SourceScope::Any {
             self.push_generated_id_matches(element, &mut matches);
+        } else {
+            matches.extend(self.parse_worktree_short_id(element));
         }
 
         // We only match against uncommitted files if there are no other matches. The reason for
@@ -1242,8 +1227,8 @@ impl IdMap {
         // shortening". However, as the reverse hex IDs of uncommitted files may collide with branch
         // names and/or branch short IDs, we only match against uncommitted files if there are no
         // other matches. This allows branch name short IDs to be prefixes of uncommitted file short
-        // IDs — and in the uncommitted scope, where container IDs never match, an element that
-        // exactly equals a displayed branch or stack ID deliberately matches nothing rather than
+        // IDs — and in the uncommitted scope, where branch and stack IDs never match, an element
+        // that exactly equals one of their displayed IDs deliberately matches nothing rather than
         // resolving to a file it was never shown for.
         if matches.is_empty() {
             if scope == SourceScope::UncommittedOnly
@@ -1252,14 +1237,13 @@ impl IdMap {
                 return Ok(vec![]);
             }
             matches = self.uncommitted_file_id_prefix_matches(element);
-            matches.extend(self.worktree_id_prefix_matches(element));
         }
 
         Ok(matches)
     }
 
-    /// Commit, stack-ID, and branch-short-ID matches for `element`, appended
-    /// to `matches`. Only meaningful in the full namespace.
+    /// Commit, stack, branch, and worktree short-ID matches for `element`, appended to
+    /// `matches`. Only meaningful in the full namespace.
     fn push_generated_id_matches<'a>(
         &'a self,
         element: &str,
@@ -1275,6 +1259,16 @@ impl IdMap {
                     return;
                 }
             }
+        }
+
+        // Worktree short IDs use the same exact-match semantics and allocator as branch short IDs.
+        if let Some(worktree) = self
+            .worktrees
+            .values()
+            .find(|worktree| worktree.short_id == element)
+        {
+            matches.push(Box::new(worktree));
+            return;
         }
 
         // Match against commits
@@ -1749,7 +1743,7 @@ pub enum CliId {
     /// A linked worktree, naming that checkout's uncommitted area the way
     /// [`Self::Uncommitted`] names the main worktree's.
     Worktree {
-        /// The short CLI ID for this worktree (typically 2 characters).
+        /// The name-derived short CLI ID for this worktree (at least 2 characters).
         id: ShortId,
         /// The stable worktree name, i.e. the directory name under
         /// `$GIT_COMMON_DIR/worktrees/`.

--- a/crates/but/src/id/stacks_info.rs
+++ b/crates/but/src/id/stacks_info.rs
@@ -55,40 +55,73 @@ fn stacks_info_without_short_ids(
     stacks_info
 }
 
+fn mark_name_short_id_used(
+    candidate: &[u8],
+    id_usage: &mut IdUsage,
+    non_hex_used_short_ids: &mut HashSet<ShortId>,
+) -> Option<ShortId> {
+    let short_id = UintId::from_name(candidate)
+        .map(|uint_id| {
+            id_usage.mark_used(uint_id);
+            uint_id.to_short_id()
+        })
+        .or_else(|| {
+            // If it's not a valid UintId, it's still acceptable if it
+            // cannot be confused for a commit ID (and is valid UTF-8).
+            if candidate.iter().all(|c| c.is_ascii_alphanumeric())
+                && !candidate.iter().all(|c| c.is_ascii_hexdigit())
+            {
+                String::from_utf8(candidate.to_vec()).ok()
+            } else {
+                None
+            }
+        })?;
+
+    non_hex_used_short_ids
+        .insert(short_id.clone())
+        .then_some(short_id)
+}
+
+fn allocate_generated_short_id(
+    id_usage: &mut IdUsage,
+    non_hex_used_short_ids: &mut HashSet<ShortId>,
+) -> anyhow::Result<ShortId> {
+    // `IdUsage` advances past generated IDs, so also retain their textual form for later
+    // name-derived allocations, which detect collisions through this shared set.
+    loop {
+        let short_id = id_usage.next_available()?.to_short_id();
+        if non_hex_used_short_ids.insert(short_id.clone()) {
+            return Ok(short_id);
+        }
+    }
+}
+
+pub(crate) fn allocate_name_short_id(
+    name: &[u8],
+    id_usage: &mut IdUsage,
+    non_hex_used_short_ids: &mut HashSet<ShortId>,
+) -> anyhow::Result<ShortId> {
+    // Find the first non-conflicting pair or triple and use it.
+    for candidate in name.windows(2).chain(name.windows(3)) {
+        if let Some(short_id) = mark_name_short_id_used(candidate, id_usage, non_hex_used_short_ids)
+        {
+            return Ok(short_id);
+        }
+    }
+    // If none are available, use the next generated ID.
+    allocate_generated_short_id(id_usage, non_hex_used_short_ids)
+}
+
 fn populate_branch_short_ids(
     stacks: &mut [StackWithId],
     id_usage: &mut IdUsage,
     non_hex_used_short_ids: &mut HashSet<ShortId>,
     uncommitted_short_filenames: &HashSet<BString>,
 ) -> anyhow::Result<()> {
-    // Fill the `non_hex_used_short_ids` and `id_usage` data structures.
-    //
-    // Returns None if the candidate was bad, Some(false) if it was already taken and Some(true) if
-    // it was successfully "acquired".
-    let mut maybe_mark_used = |candidate: &[u8], id_usage: &mut IdUsage| {
-        let short_id = UintId::from_name(candidate)
-            .map(|uint_id| {
-                id_usage.mark_used(uint_id);
-                uint_id.to_short_id()
-            })
-            .or_else(|| {
-                // If it's not a valid UintId, it's still acceptable if it
-                // cannot be confused for a commit ID (and is valid UTF-8).
-                if candidate.iter().all(|c| c.is_ascii_alphanumeric())
-                    && !candidate.iter().all(|c| c.is_ascii_hexdigit())
-                {
-                    String::from_utf8(candidate.to_vec()).ok()
-                } else {
-                    None
-                }
-            })?;
-
-        Some(non_hex_used_short_ids.insert(short_id))
-    };
-
-    maybe_mark_used(UNCOMMITTED.as_bytes(), id_usage);
-    for uncommitted_short_filename in uncommitted_short_filenames.iter() {
-        maybe_mark_used(uncommitted_short_filename, id_usage);
+    let _ = mark_name_short_id_used(UNCOMMITTED.as_bytes(), id_usage, non_hex_used_short_ids);
+    for uncommitted_short_filename in uncommitted_short_filenames {
+        let _ =
+            mark_name_short_id_used(uncommitted_short_filename, id_usage, non_hex_used_short_ids);
     }
 
     // Populate branch short IDs in `stacks`.
@@ -97,23 +130,12 @@ fn populate_branch_short_ids(
         .flat_map(|stack| stack.segments.iter_mut())
     {
         if let Some(branch_name) = segment.branch_name() {
-            segment.short_id = 'short_id: {
-                // Find first non-conflicting pair or triple (i.e. used in
-                // exactly one branch) and use it.
-                for candidate in branch_name.windows(2).chain(branch_name.windows(3)) {
-                    if let Ok(short_id) = str::from_utf8(candidate)
-                        && let Some(true) = maybe_mark_used(candidate, id_usage)
-                    {
-                        break 'short_id short_id.to_owned();
-                    }
-                }
-                // If none available, use next available ID.
-                id_usage.next_available()?.to_short_id()
-            };
+            segment.short_id =
+                allocate_name_short_id(branch_name, id_usage, non_hex_used_short_ids)?;
         } else {
-            // This sgement is anonymous, so we have no name to base the ID on. We just assign it a
+            // This segment is anonymous, so we have no name to base the ID on. We just assign it a
             // generic ID, which allows some rudimentary stuff to work (e.g. `but status`).
-            segment.short_id = id_usage.next_available()?.to_short_id();
+            segment.short_id = allocate_generated_short_id(id_usage, non_hex_used_short_ids)?;
         }
     }
 

--- a/crates/but/src/id/tests.rs
+++ b/crates/but/src/id/tests.rs
@@ -1067,7 +1067,7 @@ fn worktree_container_id() -> anyhow::Result<()> {
         snapbox::str![[r#"
 [
     Worktree {
-        id: "y",
+        id: "wt",
         name: "wt-a",
     },
 ]
@@ -1076,8 +1076,21 @@ fn worktree_container_id() -> anyhow::Result<()> {
     );
 
     // The short ID resolves to the same worktree.
-    let by_id = id_map.parse(&by_name[0].to_short_string(), Box::new(changed_paths_fn))?;
+    let short_id = by_name[0].to_short_string();
+    let by_id = id_map.parse(&short_id, Box::new(changed_paths_fn))?;
     assert_eq!(by_id, by_name, "name and short ID name the same worktree");
+
+    let one_char_prefix = short_id
+        .chars()
+        .next()
+        .expect("worktree short IDs are non-empty")
+        .to_string();
+    assert!(
+        id_map
+            .parse(&one_char_prefix, Box::new(changed_paths_fn))?
+            .is_empty(),
+        "worktree short IDs require an exact match"
+    );
 
     // `<worktree>:<path>` disambiguates a path that is dirty in several checkouts.
     let scoped = id_map.parse("wt-a:file", Box::new(changed_paths_fn))?;
@@ -1106,6 +1119,86 @@ fn worktree_container_id() -> anyhow::Result<()> {
             .is_empty(),
         "a clean worktree expands to nothing"
     );
+
+    Ok(())
+}
+
+/// Branches and worktrees draw from the same name-derived short-ID namespace.
+#[test]
+fn branch_and_worktree_short_ids_do_not_collide() -> anyhow::Result<()> {
+    let id_map = IdMap::new(
+        vec![stack([segment("work-branch", [], None, [])])],
+        vec![source_changes(
+            ChangeSourceId::Worktree("worktree-01".into()),
+            Vec::new(),
+        )],
+        gix::hashtable::HashMap::default(),
+        Default::default(),
+    )?;
+
+    snapbox::assert_data_eq!(
+        id_map.debug_state().to_debug(),
+        snapbox::str![[r#"
+workspace_and_remote_commits_count: 0
+branches: [ wo ]
+worktrees: [ or worktree-01 ]
+
+
+"#]]
+    );
+
+    Ok(())
+}
+
+/// Generated IDs for named and anonymous branch segments remain reserved when
+/// worktree IDs are allocated later.
+#[test]
+fn generated_branch_ids_do_not_collide_with_worktree_names() -> anyhow::Result<()> {
+    let mut anonymous_segment = segment("unused", [], None, []);
+    anonymous_segment.ref_info = None;
+    let id_map = IdMap::new(
+        vec![stack([segment("ab", [], None, []), anonymous_segment])],
+        vec![
+            source_changes(ChangeSourceId::Worktree("g0-worktree".into()), Vec::new()),
+            source_changes(ChangeSourceId::Worktree("h0-worktree".into()), Vec::new()),
+        ],
+        gix::hashtable::HashMap::default(),
+        Default::default(),
+    )?;
+
+    let branch_ids = id_map.branch_ids();
+    assert_eq!(
+        branch_ids,
+        ["g0", "h0"],
+        "the named fallback and anonymous segment use generated IDs"
+    );
+    let worktree_ids: Vec<_> = id_map
+        .worktrees
+        .values()
+        .map(|worktree| worktree.short_id.as_str())
+        .collect();
+    for branch_id in &branch_ids {
+        assert!(
+            !worktree_ids.contains(&branch_id.as_str()),
+            "generated branch ID {branch_id} remains reserved"
+        );
+    }
+
+    let changed_paths_fn = |commit_id: gix::ObjectId,
+                            parent_id: Option<gix::ObjectId>|
+     -> anyhow::Result<Vec<but_core::TreeChange>> {
+        bail!("unexpected IDs {commit_id} {parent_id:?}");
+    };
+    for worktree in id_map.worktrees.values() {
+        assert_eq!(
+            id_map.parse(&worktree.short_id, Box::new(changed_paths_fn))?,
+            [CliId::Worktree {
+                id: worktree.short_id.clone(),
+                name: worktree.name.clone(),
+            }],
+            "each displayed worktree ID resolves to its worktree"
+        );
+    }
 
     Ok(())
 }

--- a/crates/but/tests/but/command/amend.rs
+++ b/crates/but/tests/but/command/amend.rs
@@ -359,7 +359,7 @@ Amended tpm
 ┊
 ┊╭┄ g0 [A]
 ┊┊
-┊┊╭┄ m {wt-feature} (no changes)
+┊┊╭┄ wt {wt-feature} (no changes)
 ┊├╯
 ┊●   tpm add A
 ┊│     tpm:t A A
@@ -388,7 +388,7 @@ fn amend_a_worktrees_whole_uncommitted_area() {
     env.but("status").assert().success();
     add_dirty_worktree(&env, "wt-feature", "A");
 
-    env.but("amend m --target lrm")
+    env.but("amend wt --target lrm")
         .assert()
         .success()
         .stderr_eq(str![])
@@ -406,7 +406,7 @@ Amended lrm
 ┊
 ┊╭┄ g0 [A]
 ┊┊
-┊┊╭┄ m {wt-feature} (no changes)
+┊┊╭┄ wt {wt-feature} (no changes)
 ┊├╯
 ┊●   tpm add A
 ┊│     tpm:t A A
@@ -474,7 +474,7 @@ fn amend_a_clean_worktree_has_nothing_to_amend() {
 ┊
 ┊╭┄ g0 [A]
 ┊┊
-┊┊╭┄ n {wt-clean} (no changes)
+┊┊╭┄ wt {wt-clean} (no changes)
 ┊├╯
 ┊●   tpm add A
 ├╯
@@ -489,7 +489,7 @@ Hint: run `but help` for all commands
 
 "#]]);
 
-    env.but("amend n --target tpm")
+    env.but("amend wt --target tpm")
         .assert()
         .failure()
         .stdout_eq(str![])

--- a/crates/but/tests/but/command/commit.rs
+++ b/crates/but/tests/but/command/commit.rs
@@ -2695,7 +2695,7 @@ fn commit_a_file_from_a_linked_worktree() {
 ┊
 ┊╭┄ g0 [A]
 ┊┊
-┊┊╭┄ m {wt-feature}
+┊┊╭┄ wt {wt-feature}
 ┊┊┊   nl A note.txt
 ┊├╯
 ┊●   tpm add A
@@ -2732,7 +2732,7 @@ Created commit 1 on branch 'A'
 ┊●   1 note from worktree
 ┊│     1:u A note.txt
 ┊┊
-┊┊╭┄ m {wt-feature} (no changes)
+┊┊╭┄ wt {wt-feature} (no changes)
 ┊├╯
 ┊●   tpm add A
 ┊│     tpm:t A A
@@ -2760,7 +2760,7 @@ fn commit_a_worktrees_whole_uncommitted_area() {
     env.but("status").assert().success();
     add_dirty_worktree(&env, "wt-feature", "A");
 
-    env.but("commit m -b B -m 'everything from the worktree'")
+    env.but("commit wt -b B -m 'everything from the worktree'")
         .assert()
         .success()
         .stderr_eq(snapbox::str![])
@@ -2778,7 +2778,7 @@ Created commit 1 on branch 'B'
 ┊
 ┊╭┄ g0 [A]
 ┊┊
-┊┊╭┄ m {wt-feature} (no changes)
+┊┊╭┄ wt {wt-feature} (no changes)
 ┊├╯
 ┊●   tpm add A
 ┊│     tpm:t A A
@@ -2886,7 +2886,7 @@ fn commit_below_a_worktree_targets_its_branch_tip() {
     let wt_dir = crate::command::util::add_worktree_with_commit(&env, "wt-inside", "A");
     env.file("main.txt", "from the main checkout\n");
 
-    env.but("commit --below po -m 'onto the worktree branch'")
+    env.but("commit --below wt -m 'onto the worktree branch'")
         .assert()
         .success()
         .stderr_eq(snapbox::str![])
@@ -2927,12 +2927,12 @@ fn commit_above_a_worktree_is_refused() {
     env.but("status").assert().success();
     crate::command::util::add_worktree_with_commit(&env, "wt-inside", "A");
 
-    env.but("commit --above po -m 'nope'")
+    env.but("commit --above wt -m 'nope'")
         .assert()
         .failure()
         .stdout_eq(snapbox::str![])
         .stderr_eq(snapbox::str![[r#"
-Error: Bad input 'po' for '--above'
+Error: Bad input 'wt' for '--above'
 
 Cannot place a commit above a worktree
 
@@ -2951,7 +2951,7 @@ fn commit_b_targets_a_worktree_by_id() {
     crate::command::util::add_worktree_with_commit(&env, "wt-inside", "A");
     env.file("main.txt", "from the main checkout\n");
 
-    env.but("commit -b po -m 'by worktree id'")
+    env.but("commit -b wt -m 'by worktree id'")
         .assert()
         .success()
         .stderr_eq(snapbox::str![])
@@ -3002,7 +3002,7 @@ fn commit_from_a_worktree_defaults_to_its_own_branch() {
     let wt_dir = crate::command::util::add_worktree_with_commit(&env, "wt-feature", "A");
     std::fs::write(wt_dir.join("note.txt"), "dirty\n").unwrap();
 
-    env.but("commit m -m 'note from the worktree'")
+    env.but("commit wt -m 'note from the worktree'")
         .assert()
         .success()
         .stderr_eq(snapbox::str![])
@@ -3038,7 +3038,7 @@ Created commit 1 on branch 'wt-feature'
 ┊
 ┊╭┄ g0 [A]
 ┊┊
-┊┊╭┄ m {wt-feature} (no changes)
+┊┊╭┄ wt {wt-feature} (no changes)
 ┊┊●   1 note from the worktree
 ┊┊│     1:u A note.txt
 ┊┊●   nsn add W
@@ -3074,7 +3074,7 @@ fn commit_from_a_worktree_sharing_its_branch_tip_advances_only_the_worktree() {
     env.but("status").assert().success();
     add_dirty_worktree(&env, "wt-feature", "A");
 
-    env.but("commit m -m 'note from the worktree'")
+    env.but("commit wt -m 'note from the worktree'")
         .assert()
         .success()
         .stderr_eq(snapbox::str![])

--- a/crates/but/tests/but/command/move.rs
+++ b/crates/but/tests/but/command/move.rs
@@ -2952,7 +2952,7 @@ fn move_commit_below_a_worktree() {
     env.but("status").assert().success();
     crate::command::util::add_worktree_with_commit(&env, "wt-inside", "A");
 
-    env.but("move lrm --below po")
+    env.but("move lrm --below wt")
         .assert()
         .success()
         .stderr_eq(snapbox::str![])
@@ -2988,12 +2988,12 @@ fn move_commit_above_a_worktree_is_refused() {
     env.but("status").assert().success();
     crate::command::util::add_worktree_with_commit(&env, "wt-inside", "A");
 
-    env.but("move lrm --above po")
+    env.but("move lrm --above wt")
         .assert()
         .failure()
         .stdout_eq(snapbox::str![])
         .stderr_eq(snapbox::str![[r#"
-Error: Bad input 'po' for '--above'
+Error: Bad input 'wt' for '--above'
 
 Cannot place a commit above a worktree
 

--- a/crates/but/tests/but/command/status.rs
+++ b/crates/but/tests/but/command/status.rs
@@ -1553,7 +1553,7 @@ fn worktree_lanes() {
 ┊
 ┊╭┄ g0 [A]
 ┊┊
-┊┊╭┄ po {wt-inside}
+┊┊╭┄ in {wt-inside}
 ┊┊┊   wx A note.txt
 ┊┊┊
 ┊┊●   pwn worktree work (no changes)
@@ -1563,12 +1563,12 @@ fn worktree_lanes() {
 ┊
 ┊╭┄ h0 [B]
 ┊┊
-┊┊╭┄ zn {wt-at} (no changes)
+┊┊╭┄ wt {wt-at} (no changes)
 ┊├╯
 ┊●   lrm add B
 ├╯
 ┊
-┊╭┄ o {wt-outside} (no changes)
+┊╭┄ ou {wt-outside} (no changes)
 ┊●   zum off the target (no changes)
 ├╯
 ┊
@@ -1617,7 +1617,7 @@ wx:a note.txt│
     );
     // The worktree ID names that checkout's whole uncommitted area, and a filename
     // scoped by worktree name reaches into that checkout only.
-    env.but("diff po").assert().success().stdout_eq(
+    env.but("diff in").assert().success().stdout_eq(
         snapbox::str![[r#"
 ─────────────╮
 wx:a note.txt│
@@ -1648,7 +1648,7 @@ wx:a note.txt│
         snapbox::str![[r#"
 [
   {
-    "cliId": "zn",
+    "cliId": "wt",
     "name": "wt-at",
     "reference": null,
     "base": {
@@ -1659,7 +1659,7 @@ wx:a note.txt│
     "commits": []
   },
   {
-    "cliId": "po",
+    "cliId": "in",
     "name": "wt-inside",
     "reference": "refs/heads/wt-inside",
     "base": {
@@ -1689,7 +1689,7 @@ wx:a note.txt│
     ]
   },
   {
-    "cliId": "o",
+    "cliId": "ou",
     "name": "wt-outside",
     "reference": "refs/heads/wt-outside",
     "base": {
@@ -1754,9 +1754,9 @@ fn stacked_worktree_lanes() {
 ┊
 ┊╭┄ g0 [A]
 ┊┊
-┊┊╭┄ m {wt-first} (no changes)
+┊┊╭┄ wt {wt-first} (no changes)
 ┊┊┊
-┊┊┊╭┄ p {wt-second} (no changes)
+┊┊┊╭┄ se {wt-second} (no changes)
 ┊┊┊●   zzk second work (no changes)
 ┊┊├╯
 ┊┊●   tlr first work (no changes)


### PR DESCRIPTION
Makes short ids for worktrees have a min length of 2, matching branches.