### PR TITLE
ci(lite): split lite build

### DIFF
--- a/.github/workflows/lite.yml
+++ b/.github/workflows/lite.yml
@@ -25,6 +25,9 @@ jobs:
           - platform: windows-latest # [windows, x64]
     env:
       CARGO_TERM_COLOR: always
+      CARGO_PROFILE_RELEASE_LTO: fat
+      CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 1
+      CARGO_PROFILE_RELEASE_OPT_LEVEL: 3
       CHANNEL: nightly
       VERSION: "0.0.${{ github.run_number }}"
     steps:
@@ -47,9 +50,6 @@ jobs:
         run: pnpm --filter @gitbutler/but-mcp-app build
       - name: Build but CLI
         env:
-          CARGO_PROFILE_RELEASE_LTO: fat
-          CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 1
-          CARGO_PROFILE_RELEASE_OPT_LEVEL: 3
           GITBUTLER_REQUIRE_MCP_APP: "1"
         run: cargo build --release --locked --offline -p but --features "packaged-but-distribution"
       - name: Copy but CLI into Lite resources
@@ -70,18 +70,12 @@ jobs:
       - name: Build but SDK
         env:
           CARGO_NET_OFFLINE: "true"
-          CARGO_PROFILE_RELEASE_LTO: fat
-          CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 1
-          CARGO_PROFILE_RELEASE_OPT_LEVEL: 3
         run: pnpm --filter @gitbutler/but-sdk build:release
       - name: Build Lite
         run: pnpm --filter @gitbutler/lite build
       - name: Prepare askpass
         env:
           CARGO_NET_OFFLINE: "true"
-          CARGO_PROFILE_RELEASE_LTO: fat
-          CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 1
-          CARGO_PROFILE_RELEASE_OPT_LEVEL: 3
         run: pnpm --filter @gitbutler/lite prepare-askpass
       - name: Package and publish Lite
         working-directory: apps/lite

--- a/.github/workflows/lite.yml
+++ b/.github/workflows/lite.yml
@@ -25,6 +25,8 @@ jobs:
           - platform: windows-latest # [windows, x64]
     env:
       CARGO_TERM_COLOR: always
+      CHANNEL: nightly
+      VERSION: "0.0.${{ github.run_number }}"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -37,15 +39,14 @@ jobs:
       - uses: ./.github/actions/init-env-node
       - name: Set version
         working-directory: apps/lite
-        run: pnpm version "0.0.${{ github.run_number }}" --no-git-tag-version
+        shell: bash
+        run: pnpm version "$VERSION" --no-git-tag-version
       - name: Fetch Rust dependencies
         run: cargo fetch --locked
       - name: Build MCP app
         run: pnpm --filter @gitbutler/but-mcp-app build
       - name: Build but CLI
         env:
-          CHANNEL: nightly
-          VERSION: "0.0.${{ github.run_number }}"
           CARGO_PROFILE_RELEASE_LTO: fat
           CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 1
           CARGO_PROFILE_RELEASE_OPT_LEVEL: 3
@@ -69,28 +70,22 @@ jobs:
       - name: Build but SDK
         env:
           CARGO_NET_OFFLINE: "true"
-          CHANNEL: nightly
-          VERSION: "0.0.${{ github.run_number }}"
           CARGO_PROFILE_RELEASE_LTO: fat
           CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 1
           CARGO_PROFILE_RELEASE_OPT_LEVEL: 3
         run: pnpm --filter @gitbutler/but-sdk build:release
       - name: Build Lite
-        env:
-          CHANNEL: nightly
-          VERSION: "0.0.${{ github.run_number }}"
         run: pnpm --filter @gitbutler/lite build
       - name: Prepare askpass
         env:
           CARGO_NET_OFFLINE: "true"
-          CHANNEL: nightly
-          VERSION: "0.0.${{ github.run_number }}"
+          CARGO_PROFILE_RELEASE_LTO: fat
+          CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 1
+          CARGO_PROFILE_RELEASE_OPT_LEVEL: 3
         run: pnpm --filter @gitbutler/lite prepare-askpass
       - name: Package and publish Lite
         working-directory: apps/lite
         env:
-          CHANNEL: nightly
-          VERSION: "0.0.${{ github.run_number }}"
           CSC_LINK: ${{ runner.os == 'macOS' && secrets.APPLE_CERTIFICATE || '' }}
           CSC_KEY_PASSWORD: ${{ runner.os == 'macOS' && secrets.APPLE_CERTIFICATE_PASSWORD || '' }}
           APPLE_ID: ${{ runner.os == 'macOS' && secrets.APPLE_ID || '' }}

--- a/.github/workflows/lite.yml
+++ b/.github/workflows/lite.yml
@@ -38,26 +38,22 @@ jobs:
       - name: Set version
         working-directory: apps/lite
         run: pnpm version "0.0.${{ github.run_number }}" --no-git-tag-version
-      - name: Build
-        shell: bash
+      - name: Fetch Rust dependencies
+        run: cargo fetch --locked
+      - name: Build MCP app
+        run: pnpm --filter @gitbutler/but-mcp-app build
+      - name: Build but CLI
         env:
           CHANNEL: nightly
           VERSION: "0.0.${{ github.run_number }}"
-          CSC_LINK: ${{ runner.os == 'macOS' && secrets.APPLE_CERTIFICATE || '' }}
-          CSC_KEY_PASSWORD: ${{ runner.os == 'macOS' && secrets.APPLE_CERTIFICATE_PASSWORD || '' }}
-          APPLE_ID: ${{ runner.os == 'macOS' && secrets.APPLE_ID || '' }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ runner.os == 'macOS' && secrets.APPLE_PASSWORD || '' }}
-          APPLE_TEAM_ID: ${{ runner.os == 'macOS' && secrets.APPLE_PROVIDER_SHORT_NAME || '' }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           CARGO_PROFILE_RELEASE_LTO: fat
           CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 1
           CARGO_PROFILE_RELEASE_OPT_LEVEL: 3
           GITBUTLER_REQUIRE_MCP_APP: "1"
+        run: cargo build --release --locked --offline -p but --features "packaged-but-distribution"
+      - name: Copy but CLI into Lite resources
+        shell: bash
         run: |
-          pnpm --filter @gitbutler/but-mcp-app build
-          cargo build --release -p but --features "packaged-but-distribution"
-
           but_path=`find ./target/release -name but | head -n 1`
           if [ -z "$but_path" ]; then
             but_path=`find ./target/release -name but.exe | head -n 1`
@@ -70,9 +66,39 @@ jobs:
 
           mkdir ./apps/lite/resources/bin
           cp "$but_path" ./apps/lite/resources/bin/
-
-          pnpm --filter @gitbutler/but-sdk build:release
-          pnpm --filter @gitbutler/lite bundle --publish always
+      - name: Build but SDK
+        env:
+          CARGO_NET_OFFLINE: "true"
+          CHANNEL: nightly
+          VERSION: "0.0.${{ github.run_number }}"
+          CARGO_PROFILE_RELEASE_LTO: fat
+          CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 1
+          CARGO_PROFILE_RELEASE_OPT_LEVEL: 3
+        run: pnpm --filter @gitbutler/but-sdk build:release
+      - name: Build Lite
+        env:
+          CHANNEL: nightly
+          VERSION: "0.0.${{ github.run_number }}"
+        run: pnpm --filter @gitbutler/lite build
+      - name: Prepare askpass
+        env:
+          CARGO_NET_OFFLINE: "true"
+          CHANNEL: nightly
+          VERSION: "0.0.${{ github.run_number }}"
+        run: pnpm --filter @gitbutler/lite prepare-askpass
+      - name: Package and publish Lite
+        working-directory: apps/lite
+        env:
+          CHANNEL: nightly
+          VERSION: "0.0.${{ github.run_number }}"
+          CSC_LINK: ${{ runner.os == 'macOS' && secrets.APPLE_CERTIFICATE || '' }}
+          CSC_KEY_PASSWORD: ${{ runner.os == 'macOS' && secrets.APPLE_CERTIFICATE_PASSWORD || '' }}
+          APPLE_ID: ${{ runner.os == 'macOS' && secrets.APPLE_ID || '' }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ runner.os == 'macOS' && secrets.APPLE_PASSWORD || '' }}
+          APPLE_TEAM_ID: ${{ runner.os == 'macOS' && secrets.APPLE_PROVIDER_SHORT_NAME || '' }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: pnpm exec electron-builder --publish always
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         name: Upload artifacts
         with:


### PR DESCRIPTION
Splits the huge build step into multiple tinier steps.

We've had quite a few failures in building/publishing Lite over the past month, especially for macOS. It seems to mostly be related to sporadic networking issues. With a more granular split of the build, I'll be able to pinpoinp where we have flakyness more easily, and if necessary implement retries.