### PR TITLE
Lite: rework the PR tab — comment feed, sticky chrome, tab strip

### DIFF
--- a/apps/lite/ui/src/components/Clamped.module.css
+++ b/apps/lite/ui/src/components/Clamped.module.css
@@ -32,7 +32,6 @@
 	/* The designed link treatment: dotted, on the font's own underline. */
 	text-decoration: underline dotted;
 	text-underline-position: from-font;
-	cursor: pointer;
 	opacity: 0.7;
 
 	&:hover {

--- a/apps/lite/ui/src/components/Clamped.module.css
+++ b/apps/lite/ui/src/components/Clamped.module.css
@@ -12,8 +12,13 @@
 	right: 0;
 	bottom: 0;
 	left: 0;
-	height: 32px;
-	background: linear-gradient(to bottom, transparent, var(--bg-1));
+	/* Sized as a ~31px ramp plus a solid band just deep enough to seat the
+	   trigger's line. */
+	height: 56px;
+	/* Reaching full opacity at 55% is what clears the text: a straight ramp to
+	   the bottom stays translucent under the label, so it would read as
+	   printed over the prose. */
+	background: linear-gradient(to bottom, transparent, var(--bg-1) 55%);
 	content: "";
 	pointer-events: none;
 }
@@ -23,11 +28,28 @@
 	padding: 0;
 	border: none;
 	background: none;
-	color: var(--text-2);
-	font: inherit;
+	color: var(--text-1);
+	/* The designed link treatment: dotted, on the font's own underline. */
+	text-decoration: underline dotted;
+	text-underline-position: from-font;
 	cursor: pointer;
+	opacity: 0.7;
 
 	&:hover {
-		color: var(--text-1);
+		opacity: 1;
 	}
+}
+
+.toggleOverlay {
+	/* Above the fade, which is itself above the clipped content. */
+	z-index: 2;
+	position: absolute;
+	bottom: 0;
+	left: 0;
+}
+
+/* Unfolded there is no fade to seat the trigger, and the content's last child
+   has no bottom margin of its own, so the gap is this rule's job. */
+.toggleInline {
+	margin-block-start: 8px;
 }

--- a/apps/lite/ui/src/components/Clamped.tsx
+++ b/apps/lite/ui/src/components/Clamped.tsx
@@ -60,14 +60,25 @@ export const Clamped: FC<{
 				className={classes(isFolded && styles.clamped, isFolded && styles.overflowing)}
 			>
 				<div ref={innerRef}>{children}</div>
+				{/* Folded, the trigger rides on the fade instead of sitting under it,
+				    so it costs the clamp no extra row. */}
+				{isFolded && (
+					<button
+						className={classes("text-13", "text-body", styles.toggle, styles.toggleOverlay)}
+						onClick={() => setExpanded(true)}
+						type="button"
+					>
+						Show more
+					</button>
+				)}
 			</div>
-			{(folded || expanded) && (
+			{expanded && (
 				<button
-					className={classes("text-12", styles.toggle)}
-					onClick={() => setExpanded(!expanded)}
+					className={classes("text-13", "text-body", styles.toggle, styles.toggleInline)}
+					onClick={() => setExpanded(false)}
 					type="button"
 				>
-					{expanded ? "Show less" : "Show more"}
+					Show less
 				</button>
 			)}
 		</>

--- a/apps/lite/ui/src/components/Markdown.module.css
+++ b/apps/lite/ui/src/components/Markdown.module.css
@@ -46,13 +46,73 @@
 		margin-block: 8px;
 	}
 
+	/* The design-core reset drops `list-style` app-wide, which suits the
+	   navigational lists the UI is built from but leaves authored prose with
+	   no markers at all. Markdown is the one place a list is content rather
+	   than layout, so the markers come back — and nesting alternates the
+	   glyph the way the UA would. */
 	ul,
 	ol {
 		padding-inline-start: 24px;
+		list-style-position: outside;
+	}
+
+	ul {
+		list-style-type: disc;
+	}
+
+	ul ul {
+		list-style-type: circle;
+	}
+
+	ul ul ul {
+		list-style-type: square;
+	}
+
+	ol {
+		list-style-type: decimal;
+	}
+
+	/* A marker is punctuation around the prose, not part of it. */
+	li::marker {
+		color: var(--text-2);
 	}
 
 	li + li {
 		margin-block-start: 2px;
+	}
+
+	/* A nested list belongs to its parent item, so it keeps the item-to-item
+	   rhythm instead of the 8px that separates top-level blocks. */
+	li > ul,
+	li > ol {
+		margin-block: 2px;
+	}
+
+	/* A loose list wraps every item in a paragraph; those inherit the 8px
+	   block margin and blow the list open. Interior paragraphs keep it, so a
+	   genuinely multi-paragraph item still reads as one. */
+	li > p:first-child {
+		margin-block-start: 0;
+	}
+
+	li > p:last-child {
+		margin-block-end: 0;
+	}
+
+	/* A GFM task item brings its own checkbox glyph, so it drops the marker
+	   and hangs the box in the marker's gutter instead. Sanitization strips
+	   the `task-list-item` class, so the checkbox is what identifies them. */
+	li:has(> input[type="checkbox"]) {
+		list-style: none;
+
+		> input[type="checkbox"] {
+			width: 13px;
+			height: 13px;
+			/* -19 + 13 + 6 = 0: the text lines up with plain items above. */
+			margin-inline: -19px 6px;
+			vertical-align: -2px;
+		}
 	}
 
 	code {
@@ -120,9 +180,30 @@
 		overflow-wrap: normal;
 	}
 
+	th {
+		background-color: var(--bg-2);
+		font-weight: 600;
+		text-align: start;
+	}
+
 	hr {
 		margin-block: 12px;
 		border: none;
 		border-top: 1px solid var(--border-3);
+	}
+
+	/* `kbd` and `details` are in the sanitizer's allowlist, so both reach the
+	   page — a keycap needs to read as one, and a fold needs to look clickable. */
+	kbd {
+		padding: 1px 5px;
+		border: 1px solid var(--border-3);
+		border-radius: var(--radius-button);
+		background-color: var(--bg-2);
+		font-size: 12px;
+		font-family: var(--text-fontfamily-mono);
+	}
+
+	summary {
+		cursor: pointer;
 	}
 }

--- a/apps/lite/ui/src/components/Markdown.module.css
+++ b/apps/lite/ui/src/components/Markdown.module.css
@@ -81,6 +81,10 @@
 	}
 
 	blockquote {
+		/* The UA default is `margin-inline: 40px`, which the `margin-block`
+		   rule above leaves standing — it would indent the quote bar well
+		   past the surrounding prose. */
+		margin-inline: 0;
 		padding-inline-start: 12px;
 		border-inline-start: 3px solid var(--border-2);
 		color: var(--text-2);

--- a/apps/lite/ui/src/hotkeys.ts
+++ b/apps/lite/ui/src/hotkeys.ts
@@ -297,6 +297,11 @@ export const pullRequestHotkeys = {
 	update: {
 		hotkey: "Mod+Enter",
 	},
+	/* Same chord as `update`, but bound on the comment composer rather than the
+	   description form, so only the focused one fires. */
+	comment: {
+		hotkey: "Mod+Enter",
+	},
 } satisfies Record<string, HotkeyWithMeta>;
 
 export const selectionOperationHotkeys = {

--- a/apps/lite/ui/src/pr.ts
+++ b/apps/lite/ui/src/pr.ts
@@ -22,10 +22,25 @@ export const usePersistMergeMethod = () =>
 			ctx.client.setQueryData(mergeMethodQueryOptions(input.projectId).queryKey, input.method),
 	});
 
+/**
+ * All fields optional so a record written by an older build still reads.
+ *
+ * `labels` and `reviewers` are settings for a PR that does not exist yet: the
+ * forge takes neither when creating one, so they are held here until there is
+ * a review to apply them to.
+ */
 type DraftPR = {
 	title?: string;
 	body?: string;
 	isDraft?: boolean;
+	labels?: Array<string>;
+	reviewers?: Array<string>;
+};
+
+/** The part of a draft the panel beside the create form owns. */
+export type DraftPRExtras = {
+	labels: Array<string>;
+	reviewers: Array<string>;
 };
 
 // Branch name isn't stable identity. Ideally in the future this'd be written to Git metadata.

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
@@ -226,7 +226,7 @@
 
 .prTab {
 	width: 100%;
-	max-width: 1200px;
+	max-width: 1000px;
 	margin: 0 auto;
 	padding-inline: var(--panel-padding-inline);
 	padding-block: 12px var(--panel-padding-block);

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
@@ -234,6 +234,7 @@
 
 .prLayout {
 	display: flex;
+	align-items: flex-start;
 	gap: var(--pr-layout-gap);
 }
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
@@ -95,7 +95,9 @@
 
 .loadingTab {
 	padding-inline: var(--panel-padding-inline);
-	padding-block: 12px var(--panel-padding-block);
+	/* Deeper than the panel's own block padding: the tab ends on the comment
+	   composer, which needs room under it rather than the viewport edge. */
+	padding-block: 12px 24px;
 }
 
 .diffTab {
@@ -224,12 +226,21 @@
 	margin-inline-start: auto;
 }
 
+/* The tab owns its scrolling, the way the diff tab does. Without this the
+   content overflows all the way up to the page pane, which carries the
+   details header out of view with it. */
+.prTabScroll {
+	overflow-y: auto;
+}
+
 .prTab {
 	width: 100%;
 	max-width: 1000px;
 	margin: 0 auto;
 	padding-inline: var(--panel-padding-inline);
-	padding-block: 12px var(--panel-padding-block);
+	/* Deeper than the panel's own block padding: the tab ends on the comment
+	   composer, which needs room under it rather than the viewport edge. */
+	padding-block: 12px 24px;
 }
 
 .prLayout {

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
@@ -1,15 +1,14 @@
 .container {
-	/* Shared by the PR layout and the header so the primary-action buttons
-	   align with the panel column's right edge. The panel consumes
-	   --pr-panel-width for its own flex-basis. */
-	--pr-main-max: 700px;
+	/* The PR layout's columns. They live up here because .prLayout caps itself
+	   at their sum, and because the panel — a separate module, so no literal to
+	   share — reads --pr-panel-width for its own flex-basis. */
+	--pr-main-max: 900px;
 	--pr-panel-width: 315px;
 	--pr-layout-gap: 16px;
-	--pr-content-max: calc(var(--pr-main-max) + var(--pr-layout-gap) + var(--pr-panel-width));
 
 	display: grid;
 	grid-template-rows: auto minmax(0, 1fr);
-	row-gap: 12px;
+	row-gap: 0;
 }
 
 .containerLone {
@@ -24,7 +23,11 @@
 	/* Symmetric so the header actions share a right edge with the content
 	   columns below, which all inset by the same token. */
 	padding-inline: var(--panel-padding-inline);
-	padding-block-start: var(--panel-padding-block);
+	padding-block: var(--panel-padding-block) 12px;
+	/* The header draws its own bottom edge, so the tab row reads as a strip
+	   spanning the pane rather than a control floating in empty space. Every
+	   view below it — diff, PR, loading — starts flush under this line. */
+	border-bottom: 1px solid var(--border-section);
 }
 
 .titleRow {
@@ -44,6 +47,8 @@
 	grid-template-columns: auto auto 1fr;
 	column-gap: 8px;
 	align-items: center;
+	/* Long names ellipsize rather than shove the row's actions off the edge. */
+	min-width: 0;
 }
 
 .titleContentWrapper {
@@ -81,15 +86,6 @@
 	gap: 6px;
 }
 
-.panels {
-	border-top: 1px solid var(--border-section);
-
-	/* No header above in the lone layout; the border would shift content down 1px. */
-	.containerLone & {
-		border-top: none;
-	}
-}
-
 .panel {
 	/* Stretch/shrink single child element to fit this element. */
 	display: grid;
@@ -99,7 +95,7 @@
 
 .loadingTab {
 	padding-inline: var(--panel-padding-inline);
-	padding-block-end: var(--panel-padding-block);
+	padding-block: 12px var(--panel-padding-block);
 }
 
 .diffTab {
@@ -224,39 +220,25 @@
 	column-gap: 12px;
 }
 
-/* While the PR tab is showing, cap the row to the PR content width so the
-   primary actions align with the panel column instead of the pane edge. */
-.tabsRowPrCap {
-	max-width: var(--pr-content-max);
-}
-
 .tabsRowRight {
 	margin-inline-start: auto;
 }
 
 .prTab {
-	/* The container grid clamps this row to the pane height while the pane
-	   scrolls the overflow; size to content instead so the end padding lands
-	   after the composer rather than mid-content. */
-	align-self: start;
+	width: 100%;
+	max-width: 1200px;
+	margin: 0 auto;
 	padding-inline: var(--panel-padding-inline);
-	padding-block-end: var(--panel-padding-block);
+	padding-block: 12px var(--panel-padding-block);
 }
 
 .prLayout {
 	display: flex;
-	flex-wrap: wrap;
-	align-items: flex-start;
-	/* Cap the whole row so the panel sits just right of the main column
-	   instead of drifting to the pane's far edge at wide widths. */
-	max-width: var(--pr-content-max);
 	gap: var(--pr-layout-gap);
 }
 
 .prMain {
-	flex: 1 1 400px;
-	min-width: 0;
-	max-width: var(--pr-main-max);
+	flex: 1;
 }
 
 .fileHeader {

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -2963,7 +2963,7 @@ const UnappliedBranchDetails: FC<BranchDetailsProps> = ({
 					<div className={styles.tabsRowRight}>
 						<button
 							type="button"
-							className={getButtonClassName({ variant: "pop" })}
+							className={getButtonClassName({ variant: "gray" })}
 							disabled={isApplyPending}
 							onClick={() => apply(decodeBytes(branch.branchRef))}
 						>

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -2633,8 +2633,10 @@ const CommitDetails: FC<{
 			</div>
 
 			{review && tab === "pr" ? (
-				<div className={styles.prTab}>
-					<LandedReviewView projectId={projectId} reviewId={review.number} />
+				<div className={styles.prTabScroll}>
+					<div className={styles.prTab}>
+						<LandedReviewView projectId={projectId} reviewId={review.number} />
+					</div>
 				</div>
 			) : (
 				<Diff
@@ -2974,8 +2976,10 @@ const UnappliedBranchDetails: FC<BranchDetailsProps> = ({
 
 			<Suspense fallback={<div className={classes(styles.loadingTab, "text-13")}>Loading…</div>}>
 				{review && branchTab === "pr" ? (
-					<div className={styles.prTab}>
-						<ReviewView projectId={projectId} sourceBranch={branchName} review={review} />
+					<div className={styles.prTabScroll}>
+						<div className={styles.prTab}>
+							<ReviewView projectId={projectId} sourceBranch={branchName} review={review} />
+						</div>
 					</div>
 				) : (
 					<BranchDiff
@@ -3075,45 +3079,47 @@ const AppliedBranchDetails: FC<BranchDetailsProps> = ({
 
 			<Suspense fallback={<div className={classes(styles.loadingTab, "text-13")}>Loading…</div>}>
 				{branchTab === "pr" ? (
-					<div className={styles.prTab}>
-						{!forgeInfo?.capabilities.prService ? (
-							<NewPullRequestView
-								projectId={projectId}
-								branchName={branchName}
-								targetBranch={targetBranch}
-								canSubmit={false}
-							/>
-						) : (
-							<SuspenseQuery
-								{...listReviewsQueryOptions({
-									projectId,
-									cacheConfig: "noCache",
-								})}
-							>
-								{({ data }) => {
-									const review = data.reviewsBySourceBranch.get(branchName);
-									const canSubmit =
-										targetBranch !== undefined &&
-										branchCtx?.segment.pushStatus !== "completelyUnpushed";
+					<div className={styles.prTabScroll}>
+						<div className={styles.prTab}>
+							{!forgeInfo?.capabilities.prService ? (
+								<NewPullRequestView
+									projectId={projectId}
+									branchName={branchName}
+									targetBranch={targetBranch}
+									canSubmit={false}
+								/>
+							) : (
+								<SuspenseQuery
+									{...listReviewsQueryOptions({
+										projectId,
+										cacheConfig: "noCache",
+									})}
+								>
+									{({ data }) => {
+										const review = data.reviewsBySourceBranch.get(branchName);
+										const canSubmit =
+											targetBranch !== undefined &&
+											branchCtx?.segment.pushStatus !== "completelyUnpushed";
 
-									return !review || !canSubmit ? (
-										<NewPullRequestView
-											projectId={projectId}
-											branchName={branchName}
-											targetBranch={targetBranch}
-											canSubmit={canSubmit}
-										/>
-									) : (
-										<ReviewView
-											projectId={projectId}
-											sourceBranch={branchName}
-											review={review}
-											editing={{ active: prEditing, onDone: () => setPrEditing(false) }}
-										/>
-									);
-								}}
-							</SuspenseQuery>
-						)}
+										return !review || !canSubmit ? (
+											<NewPullRequestView
+												projectId={projectId}
+												branchName={branchName}
+												targetBranch={targetBranch}
+												canSubmit={canSubmit}
+											/>
+										) : (
+											<ReviewView
+												projectId={projectId}
+												sourceBranch={branchName}
+												review={review}
+												editing={{ active: prEditing, onDone: () => setPrEditing(false) }}
+											/>
+										);
+									}}
+								</SuspenseQuery>
+							)}
+						</div>
 					</div>
 				) : (
 					<BranchDiff

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -2224,7 +2224,6 @@ const Diff: FC<{
 		<div className={styles.diffTab}>
 			<Group
 				id={layoutId}
-				className={styles.panels}
 				defaultLayout={diffLayout.defaultLayout}
 				onLayoutChanged={diffLayout.onLayoutChanged}
 			>
@@ -2621,7 +2620,7 @@ const CommitDetails: FC<{
 				</div>
 
 				{review && (
-					<div className={classes(styles.tabsRow, tab === "pr" && styles.tabsRowPrCap)}>
+					<div className={styles.tabsRow}>
 						<BranchTabToggle branchTab={tab} setBranchTab={setTab} />
 					</div>
 				)}
@@ -2721,17 +2720,24 @@ const BranchTitleRow: FC<{ branchName: string }> = ({ branchName }) => {
 			<div className={styles.title}>
 				<FocusScopeKbd hotkey="0" scope="details" />
 				<Icon name="branch" />
-				<h3 className={classes("text-15", "text-semibold")}>{branchName}</h3>
+				<h3 className={classes(styles.titleContent, "text-15", "text-semibold")}>{branchName}</h3>
 			</div>
 		</div>
 	);
 };
 
-/** The Diff / Pull Request toggle, for a branch with both to show. */
-const BranchTabToggle: FC<{ branchTab: BranchTab; setBranchTab: (tab: BranchTab) => void }> = ({
-	branchTab,
-	setBranchTab,
-}) => (
+/**
+ * The Diff / Pull Request toggle. A branch with no review keeps the toggle —
+ * the tab goes disabled and says so, where dropping the toggle would instead
+ * read as the control having gone missing. The reason rides in the label
+ * because a disabled button takes no pointer events, so a tooltip on it would
+ * never open.
+ */
+const BranchTabToggle: FC<{
+	branchTab: BranchTab;
+	setBranchTab: (tab: BranchTab) => void;
+	prDisabled?: boolean;
+}> = ({ branchTab, setBranchTab, prDisabled = false }) => (
 	<ToggleGroup
 		render={<ToggleGroupStyles />}
 		value={[branchTab]}
@@ -2745,8 +2751,8 @@ const BranchTabToggle: FC<{ branchTab: BranchTab; setBranchTab: (tab: BranchTab)
 		<Toggle render={<ToggleStyles />} value={"diff" satisfies BranchTab}>
 			Diff
 		</Toggle>
-		<Toggle render={<ToggleStyles />} value={"pr" satisfies BranchTab}>
-			Pull Request
+		<Toggle render={<ToggleStyles />} value={"pr" satisfies BranchTab} disabled={prDisabled}>
+			{prDisabled ? "No pull request" : "Pull Request"}
 		</Toggle>
 	</ToggleGroup>
 );
@@ -2879,8 +2885,8 @@ const UnappliedBranchDetails: FC<BranchDetailsProps> = ({
 			<div className={styles.headerWrap}>
 				<BranchTitleRow branchName={branchName} />
 
-				<div className={classes(styles.tabsRow, branchTab === "pr" && styles.tabsRowPrCap)}>
-					{review && <BranchTabToggle branchTab={branchTab} setBranchTab={setBranchTab} />}
+				<div className={styles.tabsRow}>
+					<BranchTabToggle branchTab={branchTab} setBranchTab={setBranchTab} prDisabled={!review} />
 
 					<div className={styles.tabsRowRight}>
 						<button
@@ -2965,7 +2971,7 @@ const AppliedBranchDetails: FC<BranchDetailsProps> = ({
 			<div className={styles.headerWrap}>
 				<BranchTitleRow branchName={branchName} />
 
-				<div className={classes(styles.tabsRow, branchTab === "pr" && styles.tabsRowPrCap)}>
+				<div className={styles.tabsRow}>
 					<BranchTabToggle branchTab={branchTab} setBranchTab={setBranchTab} />
 
 					{branchTab === "pr" && !!forgeInfo?.capabilities.prService && (

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -3,11 +3,14 @@ import { startAbsorb, setCursor, useCanShowFiles, useSelection } from "#ui/use-c
 import uiStyles from "#ui/components/ui.module.css";
 import { SuspenseQuery } from "@suspensive/react-query";
 import {
+	useAddReviewLabels,
 	useCommitUncommitChanges,
 	useOpenInProgram,
+	useRequestReview,
 	useResolveCommitConflictHunks,
 	useSaveGUISettings,
 } from "#ui/api/mutations.ts";
+import { type DraftPRExtras, draftPRQueryOptions, usePersistDraftPR } from "#ui/pr.ts";
 import {
 	blobFileQueryOptions,
 	branchDiffQueryOptions,
@@ -59,7 +62,10 @@ import { TooltipPopup } from "#ui/components/Tooltip.tsx";
 import { ToggleGroupStyles, ToggleStyles } from "#ui/components/ToggleGroup.tsx";
 import { OperationSourceC } from "#ui/routes/project/$id/workspace/OperationSourceC.tsx";
 import { PullRequestComments } from "#ui/routes/project/$id/workspace/PullRequestComments.tsx";
-import { PullRequestPanel } from "#ui/routes/project/$id/workspace/PullRequestPanel.tsx";
+import {
+	NewPullRequestPanel,
+	PullRequestPanel,
+} from "#ui/routes/project/$id/workspace/PullRequestPanel.tsx";
 import {
 	PullRequestDescription,
 	PullRequestForm,
@@ -2831,6 +2837,70 @@ const ReviewView: FC<{
 	);
 };
 
+/**
+ * The Pull Request tab for a branch that has no PR yet: the create form, with
+ * the panel beside it summarizing what would be published.
+ */
+const NewPullRequestView: FC<{
+	projectId: string;
+	branchName: string;
+	targetBranch: string | undefined;
+	canSubmit: boolean;
+}> = ({ projectId, branchName, targetBranch, canSubmit }) => {
+	// Same record the form persists its title and body to, read here for the
+	// fields the panel owns. Both writers merge, so neither wipes the other.
+	const { data: draft } = useSuspenseQuery(draftPRQueryOptions({ projectId, branchName }));
+	const { mutate: persistDraftPR } = usePersistDraftPR();
+	const [extras, setExtras] = useState<DraftPRExtras>({
+		labels: draft?.labels ?? [],
+		reviewers: draft?.reviewers ?? [],
+	});
+
+	const changeExtras = (next: DraftPRExtras) => {
+		setExtras(next);
+		persistDraftPR({ projectId, branchName, draft: { ...draft, ...next } });
+	};
+
+	const { mutate: addReviewLabels } = useAddReviewLabels();
+	const { mutate: requestReview } = useRequestReview();
+
+	// The forge takes none of these when a PR is created — GitHub's create
+	// endpoint accepts neither labels nor reviewers — so they are applied the
+	// moment the PR exists. Each mutation toasts its own failure and the PR
+	// stands regardless; the real panel replaces this one and can set by hand
+	// whatever did not land.
+	const applyExtras = (reviewId: number) => {
+		if (extras.labels.length > 0) addReviewLabels({ projectId, reviewId, labels: extras.labels });
+		if (extras.reviewers.length > 0)
+			requestReview({ projectId, reviewId, logins: extras.reviewers });
+	};
+
+	return (
+		<div className={styles.prLayout}>
+			<div className={styles.prMain}>
+				<PullRequestForm
+					key={branchName}
+					body={null}
+					projectId={projectId}
+					reviewId={null}
+					sourceBranch={branchName}
+					title={null}
+					canSubmit={canSubmit}
+					afterPublish={applyExtras}
+				/>
+			</div>
+
+			<NewPullRequestPanel
+				projectId={projectId}
+				sourceBranch={branchName}
+				targetBranch={targetBranch}
+				extras={extras}
+				onExtrasChange={changeExtras}
+			/>
+		</div>
+	);
+};
+
 /** What every details view threads through to its Diff. */
 type DetailsViewProps = {
 	projectId: string;
@@ -3007,13 +3077,10 @@ const AppliedBranchDetails: FC<BranchDetailsProps> = ({
 				{branchTab === "pr" ? (
 					<div className={styles.prTab}>
 						{!forgeInfo?.capabilities.prService ? (
-							<PullRequestForm
-								key={branchName}
-								body={null}
+							<NewPullRequestView
 								projectId={projectId}
-								reviewId={null}
-								sourceBranch={branchName}
-								title={null}
+								branchName={branchName}
+								targetBranch={targetBranch}
 								canSubmit={false}
 							/>
 						) : (
@@ -3030,13 +3097,10 @@ const AppliedBranchDetails: FC<BranchDetailsProps> = ({
 										branchCtx?.segment.pushStatus !== "completelyUnpushed";
 
 									return !review || !canSubmit ? (
-										<PullRequestForm
-											key={branchName}
-											body={null}
+										<NewPullRequestView
 											projectId={projectId}
-											reviewId={null}
-											sourceBranch={branchName}
-											title={null}
+											branchName={branchName}
+											targetBranch={targetBranch}
 											canSubmit={canSubmit}
 										/>
 									) : (

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestComments.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestComments.module.css
@@ -201,15 +201,18 @@
 	/* Every event trails a dash, centred on the glyph column (12px inset plus
 	   half the 12px glyph) — including the last one before a card or the
 	   composer, which is what carries the feed's rhythm across a change of
-	   kind. Cards themselves stay dash-free. */
+	   kind. Cards themselves stay dash-free. It hangs from 4px under the first
+	   line down to the row's bottom edge, so a summary that wraps grows the
+	   dash rather than opening a hole in the column beside the extra lines. */
 	&::after {
 		position: absolute;
+		top: calc(1lh + 4px);
 		bottom: 0;
 		left: 18px;
 		width: 1px;
-		height: 7.5px;
-		background-color: var(--border-2);
+		background-color: var(--border-3);
 		content: "";
+		opacity: 0.8;
 	}
 }
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestComments.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestComments.module.css
@@ -229,11 +229,10 @@
 }
 
 /* A referenced object — actor, branch, sha — set apart from the connective
-   prose by a dotted rule rather than by weight or colour. */
+   prose by contrast. Not underlined: none of these are interactive, and an
+   underline would advertise a link that isn't there. */
 .eventRef {
-	text-decoration: underline dotted;
-	text-decoration-skip-ink: none;
-	text-underline-position: from-font;
+	color: var(--text-1);
 }
 
 .eventMono {

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestComments.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestComments.module.css
@@ -1,152 +1,332 @@
+/* The feed is its own section under the description, so a rule separates
+   the two rather than distance alone. */
 .comments {
-	margin-block-start: 48px;
-}
-
-.commentsHeading {
-	margin-block-end: 8px;
-	color: var(--text-2);
-	font-weight: 600;
+	/* The rule needs air on both sides: the margin clears the description's
+	   reactions above it, the padding clears the first feed row below. */
+	margin-block-start: 24px;
+	padding-block: 24px;
+	border-block-start: 1px solid var(--border-section);
 }
 
 .commentsEmpty {
 	color: var(--text-3);
 }
 
+/* Spacing is per-pair rather than one uniform gap: comments cluster tightly,
+   events cluster tighter still, and a change of kind opens the list up. */
 .commentList {
 	display: flex;
 	flex-direction: column;
-	gap: 16px;
 }
 
-.comment {
+.card + .card {
+	margin-block-start: 6px;
+}
+
+.event + .event {
+	margin-block-start: 4px;
+}
+
+.card + .event,
+.event + .card {
+	margin-block-start: 14px;
+}
+
+/* ---- Card (comments and review submissions) ---------------------------- */
+
+.card {
 	display: flex;
 	flex-direction: column;
-	padding: 10px 12px;
-	gap: 4px;
 	border: 1px solid var(--border-3);
-	border-radius: var(--radius-lg);
+	border-radius: var(--radius-card);
+	background-color: var(--bg-1);
 }
 
 /* An optimistic comment still in flight to the forge. */
-.commentSending {
+.cardSending {
 	opacity: 0.6;
 }
 
-.commentMeta {
+.cardBody {
 	display: flex;
-	align-items: center;
+	flex-direction: column;
+	padding: 14px;
 	gap: 8px;
 }
 
-.commentTime {
+.cardHeader {
+	display: flex;
+	align-items: flex-start;
+	min-height: 20px;
+	gap: 8px;
+}
+
+.cardIdentity {
+	display: flex;
+	flex: 1;
+	align-items: center;
+	min-width: 0;
+	gap: 6px;
+}
+
+.avatar {
+	flex-shrink: 0;
+	width: 18px;
+	height: 18px;
+	object-fit: cover;
+	border-radius: 50%;
+	background-color: var(--bg-2);
+}
+
+.authorLogin {
+	overflow: hidden;
+	color: var(--text-1);
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.cardTime {
+	flex-shrink: 0;
+	color: var(--text-2);
+}
+
+.cardEdited {
+	flex-shrink: 0;
 	color: var(--text-3);
 }
 
-.commentActions {
-	display: flex;
-	align-items: center;
-	margin-inline-start: auto;
-	padding: 0;
-	border: none;
-	background: none;
-	color: var(--text-2);
-	cursor: pointer;
-	/* Quiet until the comment is hovered; keyboard focus and an in-flight
-	   delete keep it visible. */
+/* Quiet until the card is hovered; keyboard focus and an in-flight delete
+   keep it visible. */
+.kebab {
+	flex-shrink: 0;
 	opacity: 0;
-	transition: opacity 120ms ease;
+	transition: opacity var(--transition-fast);
 
-	&:hover {
-		color: var(--text-1);
-	}
-
-	.comment:hover &,
+	.card:hover &,
 	&:focus-visible,
 	&:disabled {
 		opacity: 1;
 	}
 }
 
-/* Timeline rows that are events (opened, reviewed) rather than comments:
- * no card chrome, just the meta line and an optional indented body. */
-.event {
-	display: flex;
-	position: relative;
-	flex-direction: column;
-	padding-inline: 12px;
-	gap: 4px;
-
-	/* Short connector dashes in the gaps around event rows, centered on the
-	   icon column. Adjacent events' below/above stubs coincide, so each gap
-	   shows exactly one dash; the comment cards stay dash-free. */
-	&:not(:first-child)::before,
-	&:not(:last-child)::after {
-		position: absolute;
-		left: 20px;
-		width: 1px;
-		background-color: var(--border-2);
-		content: "";
-	}
-
-	&::before {
-		top: -12px;
-		height: 8px;
-	}
-
-	&::after {
-		bottom: -12px;
-		height: 8px;
-	}
-}
-
-.eventText {
-	color: var(--text-2);
-}
-
-.eventBody {
-	padding: 10px 12px;
-	border: 1px solid var(--border-3);
-	border-radius: var(--radius-lg);
-}
-
-.eventActor {
+.cardContent {
 	color: var(--text-1);
 }
 
-.eventSha {
-	font-family: var(--text-fontfamily-mono);
-}
-
-.commentFooter {
+/* The rule above the footer is inset from the card edge, so it is drawn
+   inside the footer's padding rather than as a border on the card. */
+.cardFooter {
 	display: flex;
+	position: relative;
 	align-items: center;
-	margin-block-start: 4px;
-	padding-block-start: 8px;
-	gap: 8px;
-	border-top: 1px solid var(--border-section);
-}
+	padding: 12px 14px;
+	gap: 4px;
 
-.replyButton {
-	margin-inline-start: auto;
-	padding: 0;
-	border: none;
-	background: none;
-	color: var(--text-2);
-	cursor: pointer;
-
-	&:hover {
-		color: var(--text-1);
+	&::before {
+		position: absolute;
+		top: 0;
+		right: 14px;
+		left: 14px;
+		height: 1px;
+		background-color: var(--border-3);
+		content: "";
 	}
 }
 
+/* ---- In-card editor ---------------------------------------------------- */
+
+.editor {
+	display: flex;
+	flex-direction: column;
+	border-radius: var(--radius-button);
+	outline: 1px solid var(--border-2);
+	outline-offset: -1px;
+	transition: outline-color var(--transition-fast);
+
+	&:focus-within {
+		outline: var(--focus-ring);
+		outline-offset: -1.5px;
+	}
+}
+
+.editorInput {
+	--scrollbar-track-bg: transparent;
+	--scrollbar-track-border: transparent;
+	padding: 12px 14px;
+	border: none;
+	background: none;
+	color: var(--text-1);
+	field-sizing: content;
+	min-height: 3lh;
+	max-height: 20lh;
+	resize: none;
+
+	&:focus {
+		outline: none;
+	}
+}
+
+.editorActions {
+	display: flex;
+	position: relative;
+	justify-content: flex-end;
+	padding: 12px;
+	gap: 4px;
+
+	&::before {
+		position: absolute;
+		top: 0;
+		right: 12px;
+		left: 12px;
+		height: 1px;
+		background-color: var(--border-3);
+		content: "";
+	}
+}
+
+/* ---- Feed event rows --------------------------------------------------- */
+
+/* No card chrome: a 12px glyph column, then one line of muted meta. */
+.event {
+	display: flex;
+	position: relative;
+	/* Rows wrap, so the glyph pins to the first line rather than centring on
+	   the whole block. */
+	align-items: flex-start;
+	padding-inline-start: 12px;
+	/* Reserves the trailing connector: a 4px gap, then the 7.5px stub. */
+	padding-block-end: 11.5px;
+	gap: 10px;
+
+	/* Every event trails a dash, centred on the glyph column (12px inset plus
+	   half the 12px glyph) — including the last one before a card or the
+	   composer, which is what carries the feed's rhythm across a change of
+	   kind. Cards themselves stay dash-free. */
+	&::after {
+		position: absolute;
+		bottom: 0;
+		left: 18px;
+		width: 1px;
+		height: 7.5px;
+		background-color: var(--border-2);
+		content: "";
+	}
+}
+
+.eventIcon {
+	flex-shrink: 0;
+	/* Centred on the first line's box, not on the row. */
+	margin-block-start: calc((1lh - 12px) / 2);
+	color: var(--text-2);
+}
+
+/* Plain text flow, not a flex row: a long summary wraps to the next line with
+   a hanging indent under itself, and the trailing time rides along with it
+   instead of being pushed against the right edge. */
+.eventMeta {
+	min-width: 0;
+	color: var(--text-2);
+}
+
+/* A referenced object — actor, branch, sha — set apart from the connective
+   prose by a dotted rule rather than by weight or colour. */
+.eventRef {
+	text-decoration: underline dotted;
+	text-decoration-skip-ink: none;
+	text-underline-position: from-font;
+}
+
+.eventMono {
+	font-family: var(--text-fontfamily-mono);
+}
+
+/* ---- Composer ---------------------------------------------------------- */
+
+/* Toolbar, source, and action footer share one card surface, so the focus
+   ring belongs to the card. */
 .composer {
 	display: flex;
 	flex-direction: column;
-	margin-block-start: 16px;
-	gap: 8px;
+	margin-block-start: 14px;
+	border-radius: var(--radius-card);
+	outline: 1px solid var(--border-2);
+	outline-offset: -1px;
+	background-color: var(--bg-1);
+	transition: outline-color var(--transition-fast);
+
+	&:hover:not(:focus-within) {
+		outline-color: var(--border-1);
+	}
+
+	&:focus-within {
+		outline: var(--focus-ring);
+		outline-offset: -1.5px;
+	}
 }
 
-.composerActions {
+.composerToolbar {
+	padding: 8px 8px 2px;
+	/* Transparent until the body scrolls, so revealing it shifts no layout. */
+	border-bottom: 1px solid transparent;
+	transition: border-color var(--transition-fast);
+
+	[data-body-scrolled] > & {
+		border-bottom-color: var(--border-3);
+	}
+}
+
+.composerBody {
 	display: flex;
-	justify-content: flex-end;
+	align-items: flex-start;
+	padding: 16px;
+	gap: 12px;
+}
+
+.composerInput {
+	--scrollbar-track-bg: transparent;
+	--scrollbar-track-border: transparent;
+	flex: 1;
+	min-width: 0;
+	padding: 0;
+	border: none;
+	background: none;
+	color: var(--text-1);
+	field-sizing: content;
+	min-height: 2lh;
+	max-height: 20lh;
+	resize: none;
+
+	&:focus {
+		outline: none;
+	}
+
+	&::placeholder {
+		color: var(--text-3);
+	}
+}
+
+.composerFooter {
+	display: flex;
+	position: relative;
+	align-items: center;
+	justify-content: space-between;
+	padding: 12px;
+	gap: 12px;
+
+	&::before {
+		position: absolute;
+		top: 0;
+		right: 12px;
+		left: 12px;
+		height: 1px;
+		background-color: var(--border-3);
+		content: "";
+	}
+}
+
+.composerFooterStart {
+	display: flex;
+	align-items: center;
+	min-width: 0;
+	gap: 2px;
 }

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestComments.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestComments.tsx
@@ -331,7 +331,7 @@ const FeedEvent: FC<{ icon: IconName; timestamp: number | null; children: ReactN
 			{timestamp !== null && (
 				<>
 					{" "}
-					<span aria-hidden>•</span> <RelativeTime timestamp={timestamp} />
+					<span aria-hidden>·</span> <RelativeTime timestamp={timestamp} />
 				</>
 			)}
 		</div>

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestComments.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestComments.tsx
@@ -10,17 +10,27 @@ import {
 	listCommentReactionsQueryOptions,
 	listReviewCommentsQueryOptions,
 	listReviewSubmissionsQueryOptions,
+	listReviewsQueryOptions,
 	listReviewTimelineEventsQueryOptions,
+	reviewerCandidatesQueryOptions,
+	userProfileQueryOptions,
 } from "#ui/api/queries.ts";
-import { nativeMenuItem, showNativeMenuFromTrigger } from "#ui/native-menu.ts";
+import { nativeMenuItem, type NativeMenuItem, showNativeMenuFromTrigger } from "#ui/native-menu.ts";
+import * as md from "#ui/markdown-editing.ts";
+import { applyToTextarea } from "#ui/markdown-textarea.ts";
+import { TooltipPopup } from "#ui/components/Tooltip.tsx";
+import { Tooltip } from "@base-ui/react";
+import { Badge, type BadgeVariant } from "#ui/components/Badge.tsx";
 import { getButtonClassName } from "#ui/components/Button.tsx";
 import { Clamped } from "#ui/components/Clamped.tsx";
 import { classes } from "#ui/components/classes.ts";
-import { FieldTextareaStyles } from "#ui/components/Field.tsx";
 import { Icon } from "#ui/components/Icon.tsx";
+import { Kbd } from "#ui/components/Kbd.tsx";
+import type { IconName } from "#ui/components/iconNames.ts";
 import { Markdown } from "#ui/components/Markdown.tsx";
+import { MarkdownAttachments } from "#ui/components/MarkdownAttachments.tsx";
+import { MarkdownToolbar } from "#ui/components/MarkdownToolbar.tsx";
 import { RelativeTime } from "#ui/components/RelativeTime.tsx";
-import { ReviewUser } from "#ui/routes/project/$id/workspace/PullRequestPanel.tsx";
 import {
 	groupReactors,
 	Reactions,
@@ -30,10 +40,116 @@ import type {
 	ForgeReviewComment,
 	ForgeReviewSubmission,
 	ForgeReviewTimelineEvent,
+	ForgeReviewUser,
 } from "@gitbutler/but-sdk";
+import { pullRequestHotkeys } from "#ui/hotkeys.ts";
+import { useHotkey } from "@tanstack/react-hotkeys";
 import { useQuery } from "@tanstack/react-query";
-import { type FC, useRef, useState } from "react";
+import { type FC, type ReactNode, type RefObject, useRef, useState } from "react";
 import styles from "./PullRequestComments.module.css";
+
+/** The card header's identity: round avatar plus the login, as designed. */
+const Author: FC<{ user: ForgeReviewUser }> = ({ user }) => (
+	<>
+		<Avatar src={user.avatarUrl} />
+		<span className={classes("text-13", "text-semibold", styles.authorLogin)}>{user.login}</span>
+	</>
+);
+
+const Avatar: FC<{ src: string | null | undefined }> = ({ src }) =>
+	src != null ? (
+		<img src={src} className={styles.avatar} alt="" />
+	) : (
+		<span className={styles.avatar} />
+	);
+
+/**
+ * The card shell shared by comments and review submissions: an identity row
+ * carrying time and an optional verdict badge, a body, and an optional
+ * footer separated by an inset rule.
+ */
+const Card: FC<{
+	author: ForgeReviewUser | null;
+	badge?: { variant: BadgeVariant; label: string };
+	timestamp: number | null;
+	/** Shown in place of the time while an optimistic write is in flight. */
+	pendingLabel?: string;
+	edited?: boolean;
+	actions?: ReactNode;
+	footer?: ReactNode;
+	className?: string;
+	children?: ReactNode;
+}> = ({
+	author,
+	badge,
+	timestamp,
+	pendingLabel,
+	edited = false,
+	actions,
+	footer,
+	className,
+	children,
+}) => (
+	<div className={classes(styles.card, className)}>
+		<div className={styles.cardBody}>
+			<div className={styles.cardHeader}>
+				<div className={styles.cardIdentity}>
+					{author !== null && <Author user={author} />}
+					{badge !== undefined && <Badge variant={badge.variant}>{badge.label}</Badge>}
+					{pendingLabel !== undefined ? (
+						<span className={classes("text-12", styles.cardTime)}>{pendingLabel}</span>
+					) : (
+						timestamp !== null && (
+							<RelativeTime timestamp={timestamp} className={classes("text-12", styles.cardTime)} />
+						)
+					)}
+					{edited && <span className={classes("text-12", styles.cardEdited)}>edited</span>}
+				</div>
+				{actions}
+			</div>
+			{children !== undefined && <div className={styles.cardContent}>{children}</div>}
+		</div>
+		{footer !== undefined && <div className={styles.cardFooter}>{footer}</div>}
+	</div>
+);
+
+/**
+ * The in-card editor: a bordered box holding the source and its own action
+ * row, so the surrounding card chrome stays put while editing.
+ */
+const BodyEditor: FC<{
+	value: string;
+	onChange: (value: string) => void;
+	onCancel: () => void;
+	onSave: () => void;
+	saving: boolean;
+	label: string;
+	saveLabel: string;
+}> = ({ value, onChange, onCancel, onSave, saving, label, saveLabel }) => (
+	<div className={styles.editor}>
+		<textarea
+			aria-label={label}
+			className={classes("text-13", "text-body", styles.editorInput)}
+			disabled={saving}
+			onChange={(evt) => onChange(evt.currentTarget.value)}
+			value={value}
+		/>
+		<div className={styles.editorActions}>
+			<button className={getButtonClassName({})} disabled={saving} onClick={onCancel} type="button">
+				Cancel
+			</button>
+			<button
+				className={getButtonClassName({ variant: "gray" })}
+				disabled={saving || value.trim() === ""}
+				onClick={onSave}
+				type="button"
+			>
+				{saveLabel}
+				<Icon name={saving ? "spinner" : "tick"} />
+			</button>
+		</div>
+	</div>
+);
 
 const Comment: FC<{
 	projectId: string;
@@ -86,182 +202,170 @@ const Comment: FC<{
 		);
 	};
 
-	return (
-		<div className={classes(styles.comment, isSending && styles.commentSending)}>
-			<div className={styles.commentMeta}>
-				{comment.author !== null && <ReviewUser user={comment.author} />}
-				{isSending ? (
-					<span className={classes("text-12", styles.commentTime)}>Sending…</span>
-				) : (
-					createdAtMs !== null && (
-						<RelativeTime
-							timestamp={createdAtMs}
-							className={classes("text-12", styles.commentTime)}
-						/>
-					)
-				)}
-				{isOwn && !isSending && !editing && (
-					<button
-						aria-label="Comment actions"
-						className={styles.commentActions}
-						disabled={isDeleting}
-						onClick={(evt) =>
-							void showNativeMenuFromTrigger(evt.currentTarget, [
-								nativeMenuItem({
-									label: "Edit comment",
-									onSelect: () => {
-										setEditBody(comment.body);
-										setEditing(true);
-									},
-								}),
-								nativeMenuItem({
-									label: "Delete comment",
-									onSelect: () => {
-										// Forge deletion is permanent; double-check.
-										if (window.confirm("Delete this comment? This cannot be undone."))
-											deleteReviewComment({ projectId, commentId: comment.id });
-									},
-								}),
-							])
-						}
-						type="button"
-					>
-						{isDeleting ? <Icon name="spinner" /> : <Icon name="kebab-vertical" />}
-					</button>
-				)}
-			</div>
+	const actions = isOwn && !isSending && !editing && (
+		<button
+			aria-label="Comment actions"
+			className={classes(getButtonClassName({ variant: "ghost", iconOnly: true }), styles.kebab)}
+			disabled={isDeleting}
+			onClick={(evt) =>
+				void showNativeMenuFromTrigger(evt.currentTarget, [
+					nativeMenuItem({
+						label: "Edit comment",
+						onSelect: () => {
+							setEditBody(comment.body);
+							setEditing(true);
+						},
+					}),
+					nativeMenuItem({
+						label: "Delete comment",
+						onSelect: () => {
+							// Forge deletion is permanent; double-check.
+							if (window.confirm("Delete this comment? This cannot be undone."))
+								deleteReviewComment({ projectId, commentId: comment.id });
+						},
+					}),
+				])
+			}
+			type="button"
+		>
+			<Icon name={isDeleting ? "spinner" : "kebab"} />
+		</button>
+	);
 
+	return (
+		<Card
+			author={comment.author}
+			className={isSending ? styles.cardSending : undefined}
+			timestamp={createdAtMs}
+			pendingLabel={isSending ? "Sending…" : undefined}
+			edited={comment.modifiedAt !== null && comment.modifiedAt !== comment.createdAt}
+			actions={actions}
+			footer={
+				editing || isSending ? undefined : (
+					<>
+						<Reactions
+							reactions={comment.reactions}
+							reactors={reactors}
+							myLogin={currentLogin}
+							// Until the reactor list arrives we can't tell which
+							// reactions are the caller's own, and a toggle could
+							// double-add; display-only for that moment.
+							onToggle={hasReactions && reactors === undefined ? undefined : toggleReaction}
+						/>
+						<button
+							className={getButtonClassName({ variant: "ghost" })}
+							onClick={() => onReply(comment)}
+							type="button"
+						>
+							Reply
+						</button>
+					</>
+				)
+			}
+		>
 			{editing ? (
-				<div className={styles.composer}>
-					<FieldTextareaStyles
-						value={editBody}
-						onChange={(evt) => setEditBody(evt.currentTarget.value)}
-						disabled={isSaving}
-					/>
-					<div className={styles.composerActions}>
-						<button
-							className={getButtonClassName({})}
-							disabled={isSaving}
-							onClick={() => setEditing(false)}
-							type="button"
-						>
-							Cancel
-						</button>
-						<button
-							className={getButtonClassName({ variant: "pop" })}
-							disabled={isSaving || editBody.trim() === ""}
-							onClick={handleSave}
-							type="button"
-						>
-							{isSaving && <Icon name="spinner" />}
-							Save
-						</button>
-					</div>
-				</div>
+				<BodyEditor
+					label="Edit comment"
+					onCancel={() => setEditing(false)}
+					onChange={setEditBody}
+					onSave={handleSave}
+					saveLabel="Save changes"
+					saving={isSaving}
+					value={editBody}
+				/>
 			) : (
-				<>
-					<Clamped maxHeight="240px">
-						<Markdown>{comment.body}</Markdown>
-					</Clamped>
-					{!isSending && (
-						<div className={styles.commentFooter}>
-							<Reactions
-								reactions={comment.reactions}
-								reactors={reactors}
-								myLogin={currentLogin}
-								// Until the reactor list arrives we can't tell which
-								// reactions are the caller's own, and a toggle could
-								// double-add; display-only for that moment.
-								onToggle={hasReactions && reactors === undefined ? undefined : toggleReaction}
-							/>
-							<button
-								className={classes("text-12", styles.replyButton)}
-								onClick={() => onReply(comment)}
-								type="button"
-							>
-								Reply
-							</button>
-						</div>
-					)}
-				</>
+				<Clamped maxHeight="240px">
+					<Markdown>{comment.body}</Markdown>
+				</Clamped>
 			)}
-		</div>
+		</Card>
 	);
 };
 
-const submissionVerdictText: Record<ForgeReviewSubmission["state"], string> = {
-	approved: "approved these changes",
-	changesRequested: "requested changes",
-	commented: "reviewed",
-	dismissed: "had their review dismissed",
+/** The verdict a submission carries into its card header. */
+const submissionBadge: Record<
+	ForgeReviewSubmission["state"],
+	{ variant: BadgeVariant; label: string }
+> = {
+	approved: { variant: "safe", label: "Approved changes" },
+	changesRequested: { variant: "danger", label: "Requested changes" },
+	commented: { variant: "lightGray", label: "Reviewed" },
+	dismissed: { variant: "lightGray", label: "Review dismissed" },
 };
 
 const Submission: FC<{ submission: ForgeReviewSubmission }> = ({ submission }) => {
 	const submittedAtMs = submission.submittedAt === null ? null : Date.parse(submission.submittedAt);
 
 	return (
-		<div className={styles.event}>
-			<div className={styles.commentMeta}>
-				{submission.author !== null && <ReviewUser user={submission.author} />}
-				<span className={classes("text-12", styles.eventText)}>
-					{submissionVerdictText[submission.state]}
-				</span>
-				{submittedAtMs !== null && (
-					<RelativeTime
-						timestamp={submittedAtMs}
-						className={classes("text-12", styles.commentTime)}
-					/>
-				)}
-			</div>
-			{submission.body !== null && (
-				<div className={styles.eventBody}>
+		<Card
+			author={submission.author}
+			badge={submissionBadge[submission.state]}
+			timestamp={submittedAtMs}
+		>
+			{submission.body === null || submission.body.trim() === "" ? undefined : (
+				<Clamped maxHeight="240px">
 					<Markdown>{submission.body}</Markdown>
-				</div>
+				</Clamped>
 			)}
-		</div>
+		</Card>
 	);
 };
 
+/**
+ * A non-card timeline row: a 12px glyph in its own column, then one line of
+ * muted meta text ending in the relative time. Actors and shas within the
+ * text carry a dotted underline, which is what distinguishes the referenced
+ * objects from the connective prose.
+ */
+const FeedEvent: FC<{ icon: IconName; timestamp: number | null; children: ReactNode }> = ({
+	icon,
+	timestamp,
+	children,
+}) => (
+	<div className={classes("text-12", styles.event)}>
+		<Icon name={icon} size={12} className={styles.eventIcon} />
+		{/* One flowing paragraph, so a long summary wraps under itself and the
+		    time trails the prose instead of being pinned to the far edge. */}
+		<div className={styles.eventMeta}>
+			{children}
+			{timestamp !== null && (
+				<>
+					{" "}
+					<span aria-hidden>•</span> <RelativeTime timestamp={timestamp} />
+				</>
+			)}
+		</div>
+	</div>
+);
+
+/** A referenced object inside an event line — an actor, a branch, a sha. */
+const Ref: FC<{ children: ReactNode; mono?: boolean }> = ({ children, mono = false }) => (
+	<span className={classes(styles.eventRef, mono && styles.eventMono)}>{children}</span>
+);
+
 const TimelineEvent: FC<{ event: ForgeReviewTimelineEvent }> = ({ event }) => {
 	const createdAtMs = event.createdAt === null ? null : Date.parse(event.createdAt);
-	const time = createdAtMs !== null && (
-		<RelativeTime timestamp={createdAtMs} className={classes("text-12", styles.commentTime)} />
-	);
 
 	if (event.kind === "committed") {
 		return (
-			<div className={styles.event}>
-				<div className={styles.commentMeta}>
-					<Icon name="commit" />
-					<span className={classes("text-12", styles.eventText)}>
-						{event.commitAuthorName !== null && (
-							<span className={styles.eventActor}>{event.commitAuthorName} </span>
-						)}
-						committed <span className={styles.eventSha}>{event.commitSha?.slice(0, 7)}</span>{" "}
-						{event.commitSummary}
-					</span>
-					{time}
-				</div>
-			</div>
+			<FeedEvent icon="commit" timestamp={createdAtMs}>
+				{event.commitAuthorName !== null && <Ref>{event.commitAuthorName}</Ref>} committed{" "}
+				{event.commitSha !== null && <Ref mono>{event.commitSha.slice(0, 7)}</Ref>}{" "}
+				{event.commitSummary}
+			</FeedEvent>
 		);
 	}
 
 	return (
-		<div className={styles.event}>
-			<div className={styles.commentMeta}>
-				{event.actor !== null ? <ReviewUser user={event.actor} /> : <Icon name="user" />}
-				<span className={classes("text-12", styles.eventText)}>
-					requested a review
-					{event.requestedReviewer !== null && (
-						<>
-							{" "}
-							from <span className={styles.eventActor}>{event.requestedReviewer.login}</span>
-						</>
-					)}
-				</span>
-				{time}
-			</div>
-		</div>
+		<FeedEvent icon="user" timestamp={createdAtMs}>
+			{event.actor !== null && <Ref>{event.actor.login}</Ref>} requested a review
+			{event.requestedReviewer !== null && (
+				<>
+					{" "}
+					from <Ref>{event.requestedReviewer.login}</Ref>
+				</>
+			)}
+		</FeedEvent>
 	);
 };
 
@@ -304,6 +408,176 @@ const timelineItems = (
 	return items.sort((a, b) => a.at - b.at);
 };
 
+/**
+ * The signed-in user's forge avatar. There is no endpoint for it, so it is
+ * read off whichever timeline entry they authored — exact when it hits, but
+ * blank on a review they have not posted to yet, which is the common case.
+ * The caller falls back to the GitButler profile picture for that.
+ */
+const ownForgeAvatar = (
+	items: Array<TimelineItem>,
+	currentLogin: string | null | undefined,
+): string | null => {
+	if (currentLogin == null) return null;
+	for (const item of items) {
+		const author =
+			item.kind === "comment"
+				? item.comment.author
+				: item.kind === "submission"
+					? item.submission.author
+					: null;
+		if (author?.login === currentLogin && author.avatarUrl !== null) return author.avatarUrl;
+	}
+	return null;
+};
+
+/* An empty native menu opens as a bare rectangle, which reads as a broken
+   button rather than an empty list — say why instead. */
+const orEmptyNotice = (items: Array<NativeMenuItem>, notice: string): Array<NativeMenuItem> =>
+	items.length > 0 ? items : [nativeMenuItem({ label: notice, enabled: false })];
+
+/**
+ * Insert an `@mention` or a `#reference` at the caret. Candidates come from
+ * the forge — collaborators and open reviews — and are picked from a native
+ * menu, the same way the panel's reviewer and label pickers work.
+ */
+const ForgeInserts: FC<{
+	projectId: string;
+	targetRef: RefObject<HTMLTextAreaElement | null>;
+	onInput: (value: string) => void;
+}> = ({ projectId, targetRef, onInput }) => {
+	const { data: candidates } = useQuery(reviewerCandidatesQueryOptions(projectId));
+	const { data: reviews } = useQuery(
+		listReviewsQueryOptions({
+			projectId,
+			cacheConfig: { cacheWithFallback: { max_age_seconds: 300 } },
+		}),
+	);
+
+	const insert = (snippet: string) => {
+		const target = targetRef.current;
+		if (target !== null) onInput(applyToTextarea(target, md.insert(snippet)));
+	};
+
+	const button = (
+		label: string,
+		icon: IconName,
+		items: () => Array<NativeMenuItem>,
+		notice: string,
+	) => (
+		<Tooltip.Root>
+			<Tooltip.Trigger
+				className={getButtonClassName({ variant: "ghost", iconOnly: true })}
+				render={<button aria-label={label} type="button" />}
+				// Keeps the caret in the textarea: a plain click would blur it
+				// first, so the insert would have no position to act on.
+				onMouseDown={(evt) => evt.preventDefault()}
+				onClick={(evt) =>
+					void showNativeMenuFromTrigger(evt.currentTarget, orEmptyNotice(items(), notice))
+				}
+			>
+				<Icon name={icon} />
+			</Tooltip.Trigger>
+			<Tooltip.Portal>
+				<Tooltip.Positioner sideOffset={4}>
+					<Tooltip.Popup render={<TooltipPopup />}>{label}</Tooltip.Popup>
+				</Tooltip.Positioner>
+			</Tooltip.Portal>
+		</Tooltip.Root>
+	);
+
+	return (
+		<>
+			{button(
+				"Mention someone",
+				"user",
+				() =>
+					(candidates ?? []).map((candidate) =>
+						nativeMenuItem({
+							label: candidate.login,
+							onSelect: () => insert(`@${candidate.login} `),
+						}),
+					),
+				"No one to mention",
+			)}
+			{button(
+				"Reference a pull request",
+				"hash",
+				() =>
+					(reviews?.reviews ?? []).map((review) =>
+						nativeMenuItem({
+							label: `#${review.number} ${review.title}`,
+							onSelect: () => insert(`#${review.number} `),
+						}),
+					),
+				"No pull requests to reference",
+			)}
+		</>
+	);
+};
+
+/** The bottom composer: toolbar, avatar + source, then the action footer. */
+const Composer: FC<{
+	draft: string;
+	setDraft: (update: string | ((current: string) => string)) => void;
+	onSubmit: () => void;
+	textareaRef: RefObject<HTMLTextAreaElement | null>;
+	avatarUrl: string | null | undefined;
+	projectId: string;
+}> = ({ draft, setDraft, onSubmit, textareaRef, avatarUrl, projectId }) => {
+	const [scrolled, setScrolled] = useState(false);
+	const empty = draft.trim() === "";
+	const composerRef = useRef<HTMLDivElement | null>(null);
+
+	// Scoped to the composer, so the same chord on the description form below
+	// still submits that instead.
+	useHotkey(pullRequestHotkeys.comment.hotkey, onSubmit, {
+		conflictBehavior: "allow",
+		enabled: !empty,
+		target: composerRef,
+	});
+
+	return (
+		<div className={styles.composer} data-body-scrolled={scrolled || undefined} ref={composerRef}>
+			<MarkdownToolbar
+				className={styles.composerToolbar}
+				onInput={setDraft}
+				targetRef={textareaRef}
+			/>
+
+			<div className={styles.composerBody}>
+				<Avatar src={avatarUrl} />
+				<textarea
+					aria-label="Write a comment"
+					className={classes("text-13", "text-body", styles.composerInput)}
+					onChange={(evt) => setDraft(evt.currentTarget.value)}
+					// Only the flip re-renders: React bails out of an unchanged state.
+					onScroll={(evt) => setScrolled(evt.currentTarget.scrollTop > 0)}
+					placeholder="Write a comment…"
+					ref={textareaRef}
+					value={draft}
+				/>
+			</div>
+
+			<div className={styles.composerFooter}>
+				<div className={styles.composerFooterStart}>
+					<MarkdownAttachments onInput={setDraft} targetRef={textareaRef} />
+					<ForgeInserts onInput={setDraft} projectId={projectId} targetRef={textareaRef} />
+				</div>
+				<button
+					className={getButtonClassName({ variant: "gray" })}
+					disabled={empty}
+					onClick={onSubmit}
+					type="button"
+				>
+					Comment
+					<Kbd hotkey={pullRequestHotkeys.comment.hotkey} variant="button" />
+				</button>
+			</div>
+		</div>
+	);
+};
+
 export const PullRequestComments: FC<{ projectId: string; review: ForgeReview }> = ({
 	projectId,
 	review,
@@ -317,6 +591,9 @@ export const PullRequestComments: FC<{ projectId: string; review: ForgeReview }>
 	);
 	const { data: events } = useQuery(listReviewTimelineEventsQueryOptions({ projectId, reviewId }));
 	const { data: currentLogin } = useQuery(currentForgeLoginQueryOptions(projectId));
+	// The forge has no "authenticated user" endpoint, so the GitButler account
+	// picture stands in until the caller has actually posted here.
+	const { data: profile } = useQuery(userProfileQueryOptions);
 	const { mutate: createReviewComment } = useCreateReviewComment();
 	const [draft, setDraft] = useState("");
 	const composerRef = useRef<HTMLTextAreaElement | null>(null);
@@ -349,26 +626,16 @@ export const PullRequestComments: FC<{ projectId: string; review: ForgeReview }>
 
 	return (
 		<div className={styles.comments}>
-			<h4 className={classes("text-14", styles.commentsHeading)}>Activity</h4>
-
 			{isPending || submissionsPending ? (
 				<div className={classes("text-13", styles.commentsEmpty)}>Loading…</div>
 			) : (
 				<div className={styles.commentList}>
 					{items.map((item) =>
 						item.kind === "opened" ? (
-							<div key="opened" className={styles.event}>
-								<div className={styles.commentMeta}>
-									{item.review.author !== null && <ReviewUser user={item.review.author} />}
-									<span className={classes("text-12", styles.eventText)}>
-										opened this pull request
-									</span>
-									<RelativeTime
-										timestamp={item.at}
-										className={classes("text-12", styles.commentTime)}
-									/>
-								</div>
-							</div>
+							<FeedEvent key="opened" icon="pr" timestamp={item.at}>
+								{item.review.author !== null && <Ref>{item.review.author.login}</Ref>} opened this
+								pull request
+							</FeedEvent>
 						) : item.kind === "comment" ? (
 							<Comment
 								key={`comment-${item.comment.id}`}
@@ -387,24 +654,14 @@ export const PullRequestComments: FC<{ projectId: string; review: ForgeReview }>
 				</div>
 			)}
 
-			<div className={styles.composer}>
-				<FieldTextareaStyles
-					ref={composerRef}
-					placeholder="Write a comment…"
-					value={draft}
-					onChange={(evt) => setDraft(evt.currentTarget.value)}
-				/>
-				<div className={styles.composerActions}>
-					<button
-						className={getButtonClassName({ variant: "pop" })}
-						disabled={draft.trim() === ""}
-						onClick={handleSubmit}
-						type="button"
-					>
-						Comment
-					</button>
-				</div>
-			</div>
+			<Composer
+				avatarUrl={ownForgeAvatar(items, currentLogin) ?? profile?.picture}
+				projectId={projectId}
+				draft={draft}
+				onSubmit={handleSubmit}
+				setDraft={setDraft}
+				textareaRef={composerRef}
+			/>
 		</div>
 	);
 };

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestForm.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestForm.module.css
@@ -16,7 +16,6 @@
 	display: flex;
 	row-gap: 8px;
 	flex-direction: column;
-	max-width: 700px;
 }
 
 /* The description composer: toolbar, source textarea, and action footer all

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestForm.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestForm.tsx
@@ -95,7 +95,23 @@ export const PullRequestForm: FC<{
 	onAfterSubmit?: () => void;
 	/** Adds a Cancel button that discards edits and calls this. */
 	onCancel?: () => void;
-}> = ({ projectId, sourceBranch, reviewId, title, body, canSubmit, onAfterSubmit, onCancel }) => {
+	/**
+	 * Called with the new PR's number right after it is created, for the
+	 * settings the forge cannot take at creation time (labels, reviewers,
+	 * auto-merge). Never called when editing an existing PR.
+	 */
+	afterPublish?: (reviewId: number) => void;
+}> = ({
+	projectId,
+	sourceBranch,
+	reviewId,
+	title,
+	body,
+	canSubmit,
+	onAfterSubmit,
+	onCancel,
+	afterPublish,
+}) => {
 	const { isPending: isPublishReviewPending, mutate: publishReview } = usePublishReview();
 	const { isPending: isUpdateReviewPending, mutate: updateReview } = useUpdateReview();
 	const formRef = useRef<HTMLFormElement | null>(null);
@@ -169,7 +185,9 @@ export const PullRequestForm: FC<{
 			persistDraftPR({
 				projectId,
 				branchName: sourceBranch,
-				draft: localDocument,
+				// Merged, not replaced: the panel beside this form owns the
+				// record's other fields and would otherwise be wiped.
+				draft: { ...persistedDocument, ...localDocument },
 			});
 		} else if (persistedDocument) {
 			deleteDraftPR({ projectId, branchName: sourceBranch });
@@ -242,16 +260,19 @@ export const PullRequestForm: FC<{
 		if (!canSubmit || isAnyPending || localDocument.title.trim() === "") return;
 
 		if (reviewId === null) {
-			publishReview({
-				projectId,
-				params: {
-					title: localDocument.title,
-					body: localDocument.body,
-					draft: localDocument.isDraft,
-					localBranch: sourceBranch,
-					sourceBranch,
+			publishReview(
+				{
+					projectId,
+					params: {
+						title: localDocument.title,
+						body: localDocument.body,
+						draft: localDocument.isDraft,
+						localBranch: sourceBranch,
+						sourceBranch,
+					},
 				},
-			});
+				{ onSuccess: (outcome) => afterPublish?.(outcome.review.number) },
+			);
 		} else {
 			updateReview(
 				{

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.module.css
@@ -1,5 +1,10 @@
 .panel {
 	display: flex;
+	/* Holds its place while the description and feed scroll past. The tab's
+	   own padding is what `top` matches, so it neither jumps nor drifts as it
+	   pins. */
+	position: sticky;
+	top: 12px;
 	/* Width is set by the details container so the header can align with
 	   the panel column (see --pr-panel-width in Details.module.css). */
 	flex: 0 0 var(--pr-panel-width, 315px);

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.tsx
@@ -107,7 +107,7 @@ const LabelsPlaceholder: FC = () => (
 	</div>
 );
 
-export const ReviewUser: FC<{ user: ForgeReviewUser }> = ({ user }) => (
+const ReviewUser: FC<{ user: ForgeReviewUser }> = ({ user }) => (
 	<div className={classes("text-13", styles.user)} title={user.name ?? user.login}>
 		{user.avatarUrl !== null ? (
 			<img src={user.avatarUrl} className={styles.avatar} alt="" />

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.tsx
@@ -6,6 +6,7 @@ import {
 	useWithdrawReviewRequest,
 } from "#ui/api/mutations.ts";
 import {
+	currentForgeLoginQueryOptions,
 	forgeInfoOptions,
 	listCIChecksQueryOptions,
 	listReviewSubmissionsQueryOptions,
@@ -18,7 +19,8 @@ import { classes } from "#ui/components/classes.ts";
 import { Icon } from "#ui/components/Icon.tsx";
 import type { IconName } from "#ui/components/iconNames.ts";
 import { TooltipPopup } from "#ui/components/Tooltip.tsx";
-import { nativeMenuItem, showNativeMenuFromTrigger } from "#ui/native-menu.ts";
+import { type NativeMenuItem, nativeMenuItem, showNativeMenuFromTrigger } from "#ui/native-menu.ts";
+import type { DraftPRExtras } from "#ui/pr.ts";
 import { formatAbsoluteTime, formatCompactDuration, formatRelativeTime } from "#ui/time.ts";
 import type {
 	CiCheck,
@@ -58,6 +60,24 @@ const Section: FC<{
 		</div>
 		{p.children}
 	</div>
+);
+
+/**
+ * A native menu with no items opens as an empty rectangle, which reads as a
+ * broken button rather than an empty list — say why instead.
+ */
+const orEmptyNotice = (items: Array<NativeMenuItem>, notice: string): Array<NativeMenuItem> =>
+	items.length > 0 ? items : [nativeMenuItem({ label: notice, enabled: false })];
+
+const pickerButton = (label: string, onClick: (evt: MouseEvent<HTMLButtonElement>) => void) => (
+	<button
+		aria-label={label}
+		className={getButtonClassName({ variant: "ghost", size: "small", iconOnly: true })}
+		onClick={onClick}
+		type="button"
+	>
+		<Icon name="plus" />
+	</button>
 );
 
 /** Muted stand-ins shown while a section has nothing in it yet. */
@@ -149,6 +169,142 @@ const CopyableBranch: FC<{ name: string }> = ({ name }) => {
 				</Tooltip.Positioner>
 			</Tooltip.Portal>
 		</Tooltip.Root>
+	);
+};
+
+/**
+ * The side panel while a PR is still being drafted: what the PR would be made
+ * of, so the summary the form asks for can be written against something.
+ *
+ * Reviewers and labels are absent rather than shown empty — `publish_review`
+ * takes neither, so there would be nothing to set until the PR exists.
+ */
+export const NewPullRequestPanel: FC<{
+	projectId: string;
+	sourceBranch: string;
+	/** Unknown while the branch is completely unpushed, which also blocks submit. */
+	targetBranch: string | undefined;
+	/** Held here until the PR exists; see {@link DraftPRExtras}. */
+	extras: DraftPRExtras;
+	onExtrasChange: (extras: DraftPRExtras) => void;
+}> = ({ projectId, sourceBranch, targetBranch, extras, onExtrasChange }) => {
+	const { data: forgeInfo } = useQuery(forgeInfoOptions(projectId));
+	const canManage = forgeInfo?.capabilities.reviewManagement === true;
+	const { data: repoLabels } = useQuery({
+		...repoLabelsQueryOptions(projectId),
+		enabled: canManage,
+	});
+	const { data: reviewerCandidates } = useQuery({
+		...reviewerCandidatesQueryOptions(projectId),
+		enabled: canManage,
+	});
+	const { data: currentLogin } = useQuery(currentForgeLoginQueryOptions(projectId));
+
+	// Cached data still reads after the capability flips off, so gate on the
+	// capability rather than on the cache being populated.
+	const canPickLabels = canManage && repoLabels !== undefined;
+	const canPickReviewers = canManage && reviewerCandidates !== undefined;
+
+	const toggle = (list: Array<string>, value: string): Array<string> =>
+		list.includes(value) ? list.filter((entry) => entry !== value) : [...list, value];
+
+	const openLabelMenu = (evt: MouseEvent<HTMLButtonElement>) => {
+		if (!canPickLabels) return;
+		void showNativeMenuFromTrigger(
+			evt.currentTarget,
+			orEmptyNotice(
+				repoLabels.map((label) =>
+					nativeMenuItem({
+						label: label.name,
+						checked: extras.labels.includes(label.name),
+						onSelect: () =>
+							onExtrasChange({ ...extras, labels: toggle(extras.labels, label.name) }),
+					}),
+				),
+				"This repository has no labels",
+			),
+		);
+	};
+
+	const openReviewerMenu = (evt: MouseEvent<HTMLButtonElement>) => {
+		if (!canPickReviewers) return;
+		void showNativeMenuFromTrigger(
+			evt.currentTarget,
+			orEmptyNotice(
+				reviewerCandidates
+					// The author can't review their own PR, so a solo repository
+					// leaves nothing to pick.
+					.filter((candidate) => candidate.login !== currentLogin)
+					.map((candidate) =>
+						nativeMenuItem({
+							label: candidate.login,
+							checked: extras.reviewers.includes(candidate.login),
+							onSelect: () =>
+								onExtrasChange({ ...extras, reviewers: toggle(extras.reviewers, candidate.login) }),
+						}),
+					),
+				"No one else can be asked to review",
+			),
+		);
+	};
+
+	const pickedReviewers = extras.reviewers.map((login) => ({
+		login,
+		user: reviewerCandidates?.find((candidate) => candidate.login === login),
+	}));
+	const pickedLabels = extras.labels.map(
+		(name) =>
+			repoLabels?.find((label) => label.name === name) ?? { name, color: null, description: null },
+	);
+
+	return (
+		<aside className={styles.panel}>
+			<Section
+				heading="Reviewers"
+				action={canPickReviewers && pickerButton("Request a review", openReviewerMenu)}
+			>
+				{pickedReviewers.length === 0 ? (
+					<PeoplePlaceholder />
+				) : (
+					pickedReviewers.map(({ login, user }) =>
+						user === undefined ? (
+							<span key={login} className="text-13">
+								{login}
+							</span>
+						) : (
+							<ReviewUser key={login} user={user} />
+						),
+					)
+				)}
+			</Section>
+
+			<Section
+				heading="Labels"
+				action={canPickLabels && pickerButton("Edit labels", openLabelMenu)}
+			>
+				{pickedLabels.length === 0 ? (
+					<LabelsPlaceholder />
+				) : (
+					<div className={styles.labels}>
+						{pickedLabels.map((label) => (
+							<Label key={label.name} label={label} />
+						))}
+					</div>
+				)}
+			</Section>
+
+			<Section heading="Branches">
+				<div className={classes("text-13", styles.branches)}>
+					<CopyableBranch name={sourceBranch} />
+					{targetBranch !== undefined && (
+						<>
+							<span className={styles.branchArrow}>→</span>
+							<span className={styles.targetBranch}>{targetBranch}</span>
+						</>
+					)}
+				</div>
+			</Section>
+		</aside>
 	);
 };
 
@@ -414,17 +570,6 @@ export const PullRequestPanel: FC<{ projectId: string; review: ForgeReview }> = 
 				}),
 		);
 	};
-
-	const pickerButton = (label: string, onClick: (evt: MouseEvent<HTMLButtonElement>) => void) => (
-		<button
-			aria-label={label}
-			className={getButtonClassName({ variant: "ghost", size: "small", iconOnly: true })}
-			onClick={onClick}
-			type="button"
-		>
-			<Icon name="plus" />
-		</button>
-	);
 
 	const [statusLabel, statusVariant, statusIcon] = Match.value(reviewStatus(review)).pipe(
 		Match.withReturnType<[string, BadgeVariant, IconName]>(),

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestReactions.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestReactions.module.css
@@ -4,11 +4,15 @@
 	gap: 4px;
 }
 
+/* A pill, not an outlined tag: the tally reads as a filled count chip. */
 .reactionChip {
-	padding: 2px 8px;
-	border: 1px solid var(--border-3);
-	border-radius: 100px;
-	background: none;
+	display: inline-flex;
+	align-items: center;
+	padding: 4px 8px;
+	gap: 4px;
+	border: none;
+	border-radius: 14px;
+	background-color: var(--bg-2);
 	color: var(--text-2);
 }
 
@@ -16,26 +20,18 @@
 	cursor: pointer;
 
 	&:hover:not(:disabled) {
-		border-color: var(--border-2);
+		background-color: color-mix(in srgb, var(--fill-gray-bg) 12%, var(--bg-2));
 	}
 }
 
+/* The caller's own reaction inverts, so their tallies stand out from the rest
+   of the row at a glance. */
 .reactionChipMine {
-	border-color: var(--text-blue);
-	color: var(--text-blue);
-}
+	background-color: var(--fill-gray-bg);
+	color: var(--fill-gray-fg);
 
-.addReaction {
-	display: flex;
-	align-items: center;
-	padding: 0;
-	border: none;
-	background: none;
-	color: var(--text-2);
-	cursor: pointer;
-
-	&:hover {
-		color: var(--text-1);
+	&.reactionChipButton:hover:not(:disabled) {
+		background-color: color-mix(in srgb, var(--fill-gray-bg) 85%, var(--scale-gray-0));
 	}
 }
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestReactions.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestReactions.module.css
@@ -17,8 +17,6 @@
 }
 
 .reactionChipButton {
-	cursor: pointer;
-
 	&:hover:not(:disabled) {
 		background-color: color-mix(in srgb, var(--fill-gray-bg) 12%, var(--bg-2));
 	}

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestReactions.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestReactions.tsx
@@ -1,3 +1,4 @@
+import { getButtonClassName } from "#ui/components/Button.tsx";
 import { classes } from "#ui/components/classes.ts";
 import { Icon } from "#ui/components/Icon.tsx";
 import { TooltipPopup } from "#ui/components/Tooltip.tsx";
@@ -102,7 +103,8 @@ export const Reactions: FC<{
 								chip.mine !== undefined && styles.reactionChipMine,
 							)}
 						>
-							{glyph} {chip.count}
+							<span>{glyph}</span>
+							<span className="text-semibold">{chip.count}</span>
 						</span>
 					) : (
 						<button
@@ -117,7 +119,8 @@ export const Reactions: FC<{
 							)}
 							onClick={() => toggle(chip.kind, chip.mine)}
 						>
-							{glyph} {chip.count}
+							<span>{glyph}</span>
+							<span className="text-semibold">{chip.count}</span>
 						</button>
 					);
 				if (chip.who === undefined || chip.who.length === 0) return chipNode;
@@ -140,7 +143,11 @@ export const Reactions: FC<{
 				<Popover.Root open={pickerOpen} onOpenChange={setPickerOpen}>
 					<Popover.Trigger
 						render={
-							<button aria-label="Add reaction" className={styles.addReaction} type="button" />
+							<button
+								aria-label="Add reaction"
+								className={getButtonClassName({ variant: "ghost", iconOnly: true })}
+								type="button"
+							/>
 						}
 					>
 						<Icon name="smiley" />


### PR DESCRIPTION
Brings the Pull Request tab in line with the new Figma designs, and fixes
several layout bugs that surfaced along the way.

## Comment feed

Rebuilt against the [feed][1] and [comment][2] components:

- Comments and review submissions now share one card shell — avatar,
  semibold login, optional verdict badge, relative time, `edited` marker.
  Submissions render as badged cards rather than bare event lines.
- Event rows get the designed anatomy: a 12px glyph column, and muted meta
  flowing as one paragraph so a long commit summary wraps under itself
  instead of truncating with the time pinned to the far edge. Each row
  trails a connector stub — including the last one before a card, which is
  what carries the rhythm across a change of kind.
- Per-pair spacing read off the design: 6px between comments, 4px between
  events, 14px across kinds.
- Reaction chips become filled pills; your own reaction inverts.
- The composer gains a formatting toolbar, your avatar, and attach,
  mention and reference pickers, plus a labelled Comment button bound to
  `Mod+Enter`.

Mention and reference candidates come from `listReviewerCandidates` and
`listReviews`, picked from a native menu the same way the panel's reviewer
and label pickers already work.

## Layout fixes

- **The PR tab never owned its scrolling**, unlike the diff tab, so its
  content overflowed up to the page pane and carried the details header out
  of view. It now scrolls itself, which pins the header by construction,
  and the review panel is sticky beneath it.
- **Blockquotes inherited the UA `margin-inline: 40px`.** The markdown
  styles set `margin-block` but left the inline margins standing, indenting
  the quote bar well past the surrounding prose. Shared fix, so it affects
  every surface rendering markdown.

## Not in scope

The [events board][3] proposes ~25 event kinds — merged, closed, labeled,
deployment, checks, and the GitButler-specific ones. Today
`ForgeReviewTimelineEventKind` is only `"committed" | "reviewRequested"`,
so the rest need forge-layer work in `crates/` plus an SDK regen. The row
anatomy here is table-driven, so each new kind is a small addition once the
data exists. Likewise, `#` references cover pull requests only — there is
no issue-listing endpoint.

## Testing

`pnpm -F @gitbutler/lite check`, `pnpm oxlint`, `pnpm knip:prod`,
`pnpm -F @gitbutler/lite test` and prettier all pass. Layout and behaviour
were verified against a live PR in the dev app over CDP — scroll pinning,
composer rendering, and the mention/reference menus resolving real
candidates. No screenshot fixtures were added; there is no seeded
comment-feed surface in `apps/lite/e2e`.

[1]: https://www.figma.com/design/EBuHQGUcCaSw4Ln5uVpWkn/Lite?node-id=4197-186223
[2]: https://www.figma.com/design/EBuHQGUcCaSw4Ln5uVpWkn/Lite?node-id=4197-186130
[3]: https://www.figma.com/design/EBuHQGUcCaSw4Ln5uVpWkn/Lite?node-id=4230-16090

🤖 Generated with [Claude Code](https://claude.com/claude-code)