### PR TITLE
Fast-forward local target after upstream integration

### DIFF
--- a/crates/but-api/src/workspace.rs
+++ b/crates/but-api/src/workspace.rs
@@ -602,11 +602,13 @@ pub fn workspace_integrate_upstream_only_with_perm(
 
         let materialized = rebase.materialize(Default::default())?;
         project_meta.persist(&repo)?;
-        but_workspace::fast_forward_local_tracking_branch(
+        if let Err(err) = but_workspace::fast_forward_local_tracking_branch(
             &repo,
             project_meta.target_ref_or_err()?.as_ref(),
             project_meta.target_commit_id_or_err()?,
-        )?;
+        ) {
+            warn!(?err, "failed to fast-forward local target branch");
+        }
 
         if let Some(ref_name) = materialized.workspace.ref_name()
             && let Some(ws_meta) = ws_meta

--- a/crates/but-api/src/workspace.rs
+++ b/crates/but-api/src/workspace.rs
@@ -602,6 +602,11 @@ pub fn workspace_integrate_upstream_only_with_perm(
 
         let materialized = rebase.materialize(Default::default())?;
         project_meta.persist(&repo)?;
+        but_workspace::fast_forward_local_tracking_branch(
+            &repo,
+            project_meta.target_ref_or_err()?.as_ref(),
+            project_meta.target_commit_id_or_err()?,
+        )?;
 
         if let Some(ref_name) = materialized.workspace.ref_name()
             && let Some(ws_meta) = ws_meta

--- a/crates/but-api/src/workspace.rs
+++ b/crates/but-api/src/workspace.rs
@@ -530,9 +530,35 @@ pub fn workspace_integrate_upstream_with_perm(
     dry_run: DryRun,
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<WorkspaceIntegrateUpstreamOutcome> {
-    let maybe_oplog_entry = but_oplog::UnmaterializedOplogSnapshot::from_details_with_perm(
+    let local_target_ref = (|| -> anyhow::Result<Option<gix::refs::FullName>> {
+        let project_meta = ctx.project_meta()?;
+        let Some(target_ref) = project_meta.target_ref.as_ref() else {
+            return Ok(None);
+        };
+        let repo = ctx.repo.get()?;
+        let Some(target_reference) = repo.try_find_reference(target_ref)? else {
+            return Ok(None);
+        };
+        but_workspace::local_tracking_branch_to_fast_forward(
+            &repo,
+            target_reference.name(),
+            target_reference.id().detach(),
+        )
+    })();
+    let local_target_ref = match local_target_ref {
+        Ok(local_target_ref) => local_target_ref,
+        Err(err) => {
+            warn!(
+                ?err,
+                "failed to identify local target branch for undo snapshot"
+            );
+            None
+        }
+    };
+    let maybe_oplog_entry = but_oplog::UnmaterializedOplogSnapshot::from_details_with_ref_and_perm(
         ctx,
         SnapshotDetails::new(OperationKind::MergeUpstream),
+        local_target_ref.as_ref().map(|name| name.as_ref()),
         perm.read_permission(),
         dry_run,
     );

--- a/crates/but-oplog/src/lib.rs
+++ b/crates/but-oplog/src/lib.rs
@@ -94,11 +94,26 @@ mod oplog_snapshot {
             perm: &RepoShared,
             dry_run: DryRun,
         ) -> Option<Self> {
+            Self::from_details_with_ref_and_perm(ctx, details, None, perm, dry_run)
+        }
+
+        /// Create a snapshot that also preserves `ref_name` for undo and redo.
+        pub fn from_details_with_ref_and_perm(
+            ctx: &but_ctx::Context,
+            details: gitbutler_oplog::entry::SnapshotDetails,
+            ref_name: Option<&gix::refs::FullNameRef>,
+            perm: &RepoShared,
+            dry_run: DryRun,
+        ) -> Option<Self> {
             if dry_run.into() {
                 return None;
             }
 
-            let tree_id = match ctx.prepare_snapshot(perm) {
+            let tree_id = match ref_name {
+                Some(ref_name) => ctx.prepare_snapshot_with_ref(ref_name, perm),
+                None => ctx.prepare_snapshot(perm),
+            };
+            let tree_id = match tree_id {
                 Ok(tree_id) => tree_id,
                 Err(err) => {
                     tracing::warn!(?err, "Failed to prepare unmaterialized oplog snapshot");

--- a/crates/but-workspace/src/lib.rs
+++ b/crates/but-workspace/src/lib.rs
@@ -66,7 +66,7 @@ use but_graph::{SegmentIndex, workspace::TargetCommit};
 mod upstream_integration;
 pub use upstream_integration::{
     BottomUpdate, BottomUpdateKind, IntegrateUpstreamOutcome, ReviewIntegrationHint,
-    integrate_upstream, integrate_upstream_with_hints,
+    fast_forward_local_tracking_branch, integrate_upstream, integrate_upstream_with_hints,
 };
 mod worktree;
 pub use worktree::{resolve_worktree_conflicts, worktree_conflicts_for_rebase};

--- a/crates/but-workspace/src/lib.rs
+++ b/crates/but-workspace/src/lib.rs
@@ -67,6 +67,7 @@ mod upstream_integration;
 pub use upstream_integration::{
     BottomUpdate, BottomUpdateKind, IntegrateUpstreamOutcome, ReviewIntegrationHint,
     fast_forward_local_tracking_branch, integrate_upstream, integrate_upstream_with_hints,
+    local_tracking_branch_to_fast_forward,
 };
 mod worktree;
 pub use worktree::{resolve_worktree_conflicts, worktree_conflicts_for_rebase};

--- a/crates/but-workspace/src/upstream_integration.rs
+++ b/crates/but-workspace/src/upstream_integration.rs
@@ -1180,31 +1180,40 @@ pub fn fast_forward_local_tracking_branch(
             let target_short_name =
                 but_core::extract_remote_name_and_short_name(target_ref, &repo.remote_names())
                     .map(|(_, short_name)| short_name);
-            let mut fallback = None;
-            for reference in repo.references()?.prefixed("refs/heads/")? {
-                let Ok(reference) = reference else {
-                    continue;
-                };
-                let tracks_target = repo
-                    .branch_remote_tracking_ref_name(
-                        reference.name(),
-                        gix::remote::Direction::Fetch,
-                    )
+            let tracks_target = |name: &gix::refs::FullNameRef| -> Result<bool> {
+                Ok(repo
+                    .branch_remote_tracking_ref_name(name, gix::remote::Direction::Fetch)
                     .transpose()?
-                    .is_some_and(|name| name.as_bstr() == target_ref.as_bstr());
-                if !tracks_target {
-                    continue;
-                }
-                if target_short_name
-                    .as_ref()
-                    .is_some_and(|name| name.as_bstr() == reference.name().shorten())
+                    .is_some_and(|name| name.as_bstr() == target_ref.as_bstr()))
+            };
+            let preferred = if let Some(short_name) = target_short_name.as_ref() {
+                let preferred =
+                    gix::refs::Category::LocalBranch.to_full_name(short_name.as_bstr())?;
+                if let Some(reference) = repo.try_find_reference(&preferred)?
+                    && tracks_target(reference.name())?
                 {
-                    fallback = Some(reference.name().to_owned());
-                    break;
+                    Some(preferred)
+                } else {
+                    None
                 }
-                fallback.get_or_insert_with(|| reference.name().to_owned());
+            } else {
+                None
+            };
+            if preferred.is_some() {
+                preferred
+            } else {
+                let mut fallback = None;
+                for reference in repo.references()?.prefixed("refs/heads/")? {
+                    let Ok(reference) = reference else {
+                        continue;
+                    };
+                    if !tracks_target(reference.name())? {
+                        continue;
+                    }
+                    fallback.get_or_insert_with(|| reference.name().to_owned());
+                }
+                fallback
             }
-            fallback
         }
         _ => None,
     };

--- a/crates/but-workspace/src/upstream_integration.rs
+++ b/crates/but-workspace/src/upstream_integration.rs
@@ -1166,3 +1166,68 @@ fn preserve_pick_parents<M: RefMetadata>(
     editor.replace(selector, Step::Pick(pick))?;
     Ok(())
 }
+
+/// Fast-forward the local branch that tracks a remote `target_ref`, preferring the same name.
+///
+/// Local target refs, missing tracking branches, and non-fast-forward updates are left unchanged.
+pub fn fast_forward_local_tracking_branch(
+    repo: &gix::Repository,
+    target_ref: &gix::refs::FullNameRef,
+    target_id: gix::ObjectId,
+) -> Result<()> {
+    let local_ref_name = match target_ref.category() {
+        Some(gix::refs::Category::RemoteBranch) => {
+            let target_short_name =
+                but_core::extract_remote_name_and_short_name(target_ref, &repo.remote_names())
+                    .map(|(_, short_name)| short_name);
+            let mut fallback = None;
+            for reference in repo.references()?.prefixed("refs/heads/")? {
+                let Ok(reference) = reference else {
+                    continue;
+                };
+                let tracks_target = repo
+                    .branch_remote_tracking_ref_name(
+                        reference.name(),
+                        gix::remote::Direction::Fetch,
+                    )
+                    .transpose()?
+                    .is_some_and(|name| name.as_bstr() == target_ref.as_bstr());
+                if !tracks_target {
+                    continue;
+                }
+                if target_short_name
+                    .as_ref()
+                    .is_some_and(|name| name.as_bstr() == reference.name().shorten())
+                {
+                    fallback = Some(reference.name().to_owned());
+                    break;
+                }
+                fallback.get_or_insert_with(|| reference.name().to_owned());
+            }
+            fallback
+        }
+        _ => None,
+    };
+    let Some(local_ref_name) = local_ref_name else {
+        return Ok(());
+    };
+    let mut local_ref = repo.find_reference(&local_ref_name)?;
+    let local_id = local_ref.peel_to_id()?.detach();
+    if local_id == target_id
+        || !repo
+            .merge_base(local_id, target_id)
+            .is_ok_and(|base| base.detach() == local_id)
+    {
+        return Ok(());
+    }
+
+    repo.reference(
+        local_ref_name,
+        target_id,
+        gix::refs::transaction::PreviousValue::ExistingMustMatch(gix::refs::Target::Object(
+            local_id,
+        )),
+        "integrate upstream: fast-forward local target",
+    )?;
+    Ok(())
+}

--- a/crates/but-workspace/src/upstream_integration.rs
+++ b/crates/but-workspace/src/upstream_integration.rs
@@ -1169,12 +1169,36 @@ fn preserve_pick_parents<M: RefMetadata>(
 
 /// Fast-forward the local branch that tracks a remote `target_ref`, preferring the same name.
 ///
-/// Local target refs, missing tracking branches, and non-fast-forward updates are left unchanged.
+/// Local target refs, missing tracking branches, checked-out branches, and non-fast-forward updates
+/// are left unchanged.
 pub fn fast_forward_local_tracking_branch(
     repo: &gix::Repository,
     target_ref: &gix::refs::FullNameRef,
     target_id: gix::ObjectId,
 ) -> Result<()> {
+    let Some(local_ref_name) = local_tracking_branch_to_fast_forward(repo, target_ref, target_id)?
+    else {
+        return Ok(());
+    };
+    let local_id = repo.find_reference(&local_ref_name)?.id().detach();
+
+    repo.reference(
+        local_ref_name,
+        target_id,
+        gix::refs::transaction::PreviousValue::ExistingMustMatch(gix::refs::Target::Object(
+            local_id,
+        )),
+        "integrate upstream: fast-forward local target",
+    )?;
+    Ok(())
+}
+
+/// Return the local tracking branch that can safely be fast-forwarded to `target_id`.
+pub fn local_tracking_branch_to_fast_forward(
+    repo: &gix::Repository,
+    target_ref: &gix::refs::FullNameRef,
+    target_id: gix::ObjectId,
+) -> Result<Option<gix::refs::FullName>> {
     let local_ref_name = match target_ref.category() {
         Some(gix::refs::Category::RemoteBranch) => {
             let target_short_name =
@@ -1218,7 +1242,7 @@ pub fn fast_forward_local_tracking_branch(
         _ => None,
     };
     let Some(local_ref_name) = local_ref_name else {
-        return Ok(());
+        return Ok(None);
     };
     let mut local_ref = repo.find_reference(&local_ref_name)?;
     let local_id = local_ref.peel_to_id()?.detach();
@@ -1227,16 +1251,14 @@ pub fn fast_forward_local_tracking_branch(
             .merge_base(local_id, target_id)
             .is_ok_and(|base| base.detach() == local_id)
     {
-        return Ok(());
+        return Ok(None);
+    }
+    if but_core::branch::SafeDelete::new(repo)?
+        .worktree_dirs_with_ref(&local_ref)
+        .is_some()
+    {
+        return Ok(None);
     }
 
-    repo.reference(
-        local_ref_name,
-        target_id,
-        gix::refs::transaction::PreviousValue::ExistingMustMatch(gix::refs::Target::Object(
-            local_id,
-        )),
-        "integrate upstream: fast-forward local target",
-    )?;
-    Ok(())
+    Ok(Some(local_ref_name))
 }

--- a/crates/but-workspace/tests/fixtures/scenario/local-target-tracking.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/local-target-tracking.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+git init
+commit-file file.txt one
+git branch feature
+git remote add origin ../origin
+git update-ref refs/remotes/origin/main HEAD
+echo two >file.txt
+git commit -am two

--- a/crates/but-workspace/tests/workspace/upstream_integration.rs
+++ b/crates/but-workspace/tests/workspace/upstream_integration.rs
@@ -4,11 +4,12 @@ use but_core::{Commit, RefMetadata, ref_metadata::ProjectMeta};
 use but_graph::init::{Options, Tip};
 use but_rebase::graph_rebase::mutate::RelativeTo;
 use but_testsupport::{
-    CommandExt, InMemoryRefMetadata, git, graph_workspace, visualize_commit_graph_all,
+    CommandExt, InMemoryRefMetadata, git, git_at_dir, graph_workspace, open_repo,
+    visualize_commit_graph_all,
 };
 use but_workspace::{
-    BottomUpdate, BottomUpdateKind, ReviewIntegrationHint, integrate_upstream,
-    integrate_upstream_with_hints, worktree_conflicts_for_rebase,
+    BottomUpdate, BottomUpdateKind, ReviewIntegrationHint, fast_forward_local_tracking_branch,
+    integrate_upstream, integrate_upstream_with_hints, worktree_conflicts_for_rebase,
 };
 use gix::prelude::ObjectIdExt;
 use gix::refs::transaction::PreviousValue;
@@ -3956,5 +3957,138 @@ fn remove_managed_workspace_ref(repo: &gix::Repository) -> Result<()> {
     if let Some(reference) = repo.try_find_reference(but_core::WORKSPACE_REF_NAME)? {
         reference.delete()?;
     }
+    Ok(())
+}
+
+fn repo_with_local_target_branches() -> Result<(gix::Repository, tempfile::TempDir)> {
+    let tmp = tempfile::tempdir()?;
+    git_at_dir(tmp.path()).args(["init", "-b", "main"]).run();
+    git_at_dir(tmp.path())
+        .args(["config", "user.name", "GitButler"])
+        .run();
+    git_at_dir(tmp.path())
+        .args(["config", "user.email", "gitbutler@example.com"])
+        .run();
+    std::fs::write(tmp.path().join("file.txt"), "one\n")?;
+    git_at_dir(tmp.path()).args(["add", "file.txt"]).run();
+    git_at_dir(tmp.path()).args(["commit", "-m", "one"]).run();
+    git_at_dir(tmp.path()).args(["branch", "feature"]).run();
+    git_at_dir(tmp.path())
+        .args(["config", "remote.origin.url", "../origin"])
+        .run();
+    git_at_dir(tmp.path())
+        .args([
+            "config",
+            "remote.origin.fetch",
+            "+refs/heads/*:refs/remotes/origin/*",
+        ])
+        .run();
+    git_at_dir(tmp.path())
+        .args(["update-ref", "refs/remotes/origin/main", "HEAD"])
+        .run();
+    std::fs::write(tmp.path().join("file.txt"), "two\n")?;
+    git_at_dir(tmp.path()).args(["commit", "-am", "two"]).run();
+    Ok((open_repo(tmp.path())?, tmp))
+}
+
+fn configure_tracking(tmp: &tempfile::TempDir, branch: &str) {
+    git_at_dir(tmp.path())
+        .args(["config", &format!("branch.{branch}.remote"), "origin"])
+        .run();
+    git_at_dir(tmp.path())
+        .args([
+            "config",
+            &format!("branch.{branch}.merge"),
+            "refs/heads/main",
+        ])
+        .run();
+}
+
+#[test]
+fn fast_forwards_local_target_branch() -> Result<()> {
+    let (_repo, tmp) = repo_with_local_target_branches()?;
+    configure_tracking(&tmp, "feature");
+    git_at_dir(tmp.path())
+        .args(["update-ref", "refs/remotes/origin/main", "refs/heads/main"])
+        .run();
+    let repo = open_repo(tmp.path())?;
+    let target_ref: gix::refs::FullName = "refs/remotes/origin/main".try_into()?;
+    let target_id = repo.find_reference(&target_ref)?.id().detach();
+
+    fast_forward_local_tracking_branch(&repo, target_ref.as_ref(), target_id)?;
+
+    assert_eq!(
+        repo.find_reference("refs/heads/feature")?.id().detach(),
+        target_id,
+        "the local tracking branch should fast-forward to the target"
+    );
+    Ok(())
+}
+
+#[test]
+fn leaves_diverged_local_target_branch_unchanged() -> Result<()> {
+    let (_repo, tmp) = repo_with_local_target_branches()?;
+    git_at_dir(tmp.path())
+        .args(["update-ref", "refs/remotes/origin/main", "refs/heads/main"])
+        .run();
+    git_at_dir(tmp.path()).args(["checkout", "feature"]).run();
+    std::fs::write(tmp.path().join("feature.txt"), "feature\n")?;
+    git_at_dir(tmp.path()).args(["add", "feature.txt"]).run();
+    git_at_dir(tmp.path())
+        .args(["commit", "-m", "feature"])
+        .run();
+    configure_tracking(&tmp, "feature");
+    let repo = open_repo(tmp.path())?;
+    let target_ref: gix::refs::FullName = "refs/remotes/origin/main".try_into()?;
+    let target_id = repo.find_reference(&target_ref)?.id().detach();
+    let local_id = repo.find_reference("refs/heads/feature")?.id().detach();
+
+    fast_forward_local_tracking_branch(&repo, target_ref.as_ref(), target_id)?;
+
+    assert_eq!(
+        repo.find_reference("refs/heads/feature")?.id().detach(),
+        local_id,
+        "a diverged local target branch must stay unchanged"
+    );
+    Ok(())
+}
+
+#[test]
+fn leaves_local_target_refs_unchanged() -> Result<()> {
+    let (repo, _tmp) = repo_with_local_target_branches()?;
+    let local_target: gix::refs::FullName = "refs/heads/feature".try_into()?;
+    let local_id = repo.find_reference(&local_target)?.id().detach();
+    let newer_id = repo.find_reference("refs/heads/main")?.id().detach();
+
+    fast_forward_local_tracking_branch(&repo, local_target.as_ref(), newer_id)?;
+
+    assert_eq!(
+        repo.find_reference(&local_target)?.id().detach(),
+        local_id,
+        "local target refs must not be updated"
+    );
+    Ok(())
+}
+
+#[test]
+fn prefers_same_named_local_target_branch() -> Result<()> {
+    let (_repo, tmp) = repo_with_local_target_branches()?;
+    configure_tracking(&tmp, "feature");
+    configure_tracking(&tmp, "main");
+    git_at_dir(tmp.path())
+        .args(["update-ref", "refs/remotes/origin/main", "refs/heads/main"])
+        .run();
+    let repo = open_repo(tmp.path())?;
+    let target_ref: gix::refs::FullName = "refs/remotes/origin/main".try_into()?;
+    let target_id = repo.find_reference(&target_ref)?.id().detach();
+    let feature_id = repo.find_reference("refs/heads/feature")?.id().detach();
+
+    fast_forward_local_tracking_branch(&repo, target_ref.as_ref(), target_id)?;
+
+    assert_eq!(
+        repo.find_reference("refs/heads/feature")?.id().detach(),
+        feature_id,
+        "the same-named main branch should be preferred over another tracker"
+    );
     Ok(())
 }

--- a/crates/but-workspace/tests/workspace/upstream_integration.rs
+++ b/crates/but-workspace/tests/workspace/upstream_integration.rs
@@ -4051,6 +4051,7 @@ fn prefers_same_named_local_target_branch() -> Result<()> {
     git_at_dir(tmp.path())
         .args(["update-ref", "refs/remotes/origin/main", "refs/heads/main"])
         .run();
+    git_at_dir(tmp.path()).args(["checkout", "feature"]).run();
     git_at_dir(tmp.path())
         .args(["update-ref", "refs/heads/main", "refs/heads/feature"])
         .run();
@@ -4070,6 +4071,42 @@ fn prefers_same_named_local_target_branch() -> Result<()> {
         repo.find_reference("refs/heads/feature")?.id().detach(),
         feature_id,
         "the same-named main branch should be preferred over another tracker"
+    );
+    Ok(())
+}
+
+#[test]
+fn leaves_checked_out_local_target_branch_unchanged() -> Result<()> {
+    let (_repo, tmp) = repo_with_local_target_branches()?;
+    configure_tracking(&tmp, "main");
+    git_at_dir(tmp.path())
+        .args(["update-ref", "refs/remotes/origin/main", "refs/heads/main"])
+        .run();
+    git_at_dir(tmp.path()).args(["checkout", "feature"]).run();
+    git_at_dir(tmp.path())
+        .args(["update-ref", "refs/heads/main", "refs/heads/feature"])
+        .run();
+    let linked = tempfile::tempdir()?;
+    let linked_path = linked.path().join("main");
+    git_at_dir(tmp.path())
+        .args([
+            "worktree",
+            "add",
+            linked_path.to_str().expect("utf-8 path"),
+            "main",
+        ])
+        .run();
+    let repo = open_repo(tmp.path())?;
+    let target_ref: gix::refs::FullName = "refs/remotes/origin/main".try_into()?;
+    let target_id = repo.find_reference(&target_ref)?.id().detach();
+    let local_id = repo.find_reference("refs/heads/main")?.id().detach();
+
+    fast_forward_local_tracking_branch(&repo, target_ref.as_ref(), target_id)?;
+
+    assert_eq!(
+        repo.find_reference("refs/heads/main")?.id().detach(),
+        local_id,
+        "a checked-out target branch must stay aligned with its worktree"
     );
     Ok(())
 }

--- a/crates/but-workspace/tests/workspace/upstream_integration.rs
+++ b/crates/but-workspace/tests/workspace/upstream_integration.rs
@@ -4078,6 +4078,9 @@ fn prefers_same_named_local_target_branch() -> Result<()> {
     git_at_dir(tmp.path())
         .args(["update-ref", "refs/remotes/origin/main", "refs/heads/main"])
         .run();
+    git_at_dir(tmp.path())
+        .args(["update-ref", "refs/heads/main", "refs/heads/feature"])
+        .run();
     let repo = open_repo(tmp.path())?;
     let target_ref: gix::refs::FullName = "refs/remotes/origin/main".try_into()?;
     let target_id = repo.find_reference(&target_ref)?.id().detach();
@@ -4085,6 +4088,11 @@ fn prefers_same_named_local_target_branch() -> Result<()> {
 
     fast_forward_local_tracking_branch(&repo, target_ref.as_ref(), target_id)?;
 
+    assert_eq!(
+        repo.find_reference("refs/heads/main")?.id().detach(),
+        target_id,
+        "the same-named main branch should fast-forward to the target"
+    );
     assert_eq!(
         repo.find_reference("refs/heads/feature")?.id().detach(),
         feature_id,

--- a/crates/but-workspace/tests/workspace/upstream_integration.rs
+++ b/crates/but-workspace/tests/workspace/upstream_integration.rs
@@ -3961,34 +3961,7 @@ fn remove_managed_workspace_ref(repo: &gix::Repository) -> Result<()> {
 }
 
 fn repo_with_local_target_branches() -> Result<(gix::Repository, tempfile::TempDir)> {
-    let tmp = tempfile::tempdir()?;
-    git_at_dir(tmp.path()).args(["init", "-b", "main"]).run();
-    git_at_dir(tmp.path())
-        .args(["config", "user.name", "GitButler"])
-        .run();
-    git_at_dir(tmp.path())
-        .args(["config", "user.email", "gitbutler@example.com"])
-        .run();
-    std::fs::write(tmp.path().join("file.txt"), "one\n")?;
-    git_at_dir(tmp.path()).args(["add", "file.txt"]).run();
-    git_at_dir(tmp.path()).args(["commit", "-m", "one"]).run();
-    git_at_dir(tmp.path()).args(["branch", "feature"]).run();
-    git_at_dir(tmp.path())
-        .args(["config", "remote.origin.url", "../origin"])
-        .run();
-    git_at_dir(tmp.path())
-        .args([
-            "config",
-            "remote.origin.fetch",
-            "+refs/heads/*:refs/remotes/origin/*",
-        ])
-        .run();
-    git_at_dir(tmp.path())
-        .args(["update-ref", "refs/remotes/origin/main", "HEAD"])
-        .run();
-    std::fs::write(tmp.path().join("file.txt"), "two\n")?;
-    git_at_dir(tmp.path()).args(["commit", "-am", "two"]).run();
-    Ok((open_repo(tmp.path())?, tmp))
+    Ok(crate::utils::writable_scenario("local-target-tracking"))
 }
 
 fn configure_tracking(tmp: &tempfile::TempDir, branch: &str) {

--- a/crates/but/tests/but/command/pull.rs
+++ b/crates/but/tests/but/command/pull.rs
@@ -123,6 +123,29 @@ fn undo_and_redo_restore_the_local_target_branch() {
 }
 
 #[test]
+fn undo_leaves_a_local_target_checked_out_in_a_linked_worktree_unchanged() {
+    let env = target_branch_pull_scenario(false);
+    env.but("pull").assert().success();
+    let target = rev_parse(&env, "main");
+    let workspace_head = rev_parse(&env, "HEAD");
+    let worktree = env.app_data_dir().join("linked-main");
+    env.invoke_git(&format!("worktree add -q \"{}\" main", worktree.display()));
+
+    env.but("undo").assert().failure();
+
+    assert_eq!(
+        rev_parse(&env, "main"),
+        target,
+        "undo must not move a branch checked out in a linked worktree"
+    );
+    assert_eq!(
+        rev_parse(&env, "HEAD"),
+        workspace_head,
+        "a refused undo must not change the managed workspace"
+    );
+}
+
+#[test]
 fn single_branch_pull_fast_forwards_the_local_target_branch() {
     assert_pull_fast_forwards_local_target(single_branch_target_branch_pull_scenario(false));
 }

--- a/crates/but/tests/but/command/pull.rs
+++ b/crates/but/tests/but/command/pull.rs
@@ -44,22 +44,15 @@ fn merge_into_upstream(env: &Sandbox, branch: &str, add_upstream_commit: bool) {
     env.invoke_git("fetch origin");
 }
 
-fn managed_target_branch_pull_scenario(diverged: bool) -> Sandbox {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("pull-two-integrated-stacks");
+fn target_branch_pull_scenario(diverged: bool) -> Sandbox {
+    let env = Sandbox::init_scenario_with_target_and_default_settings(
+        "pull-two-integrated-stacks-with-local-target",
+    );
     env.setup_metadata_at_target(&["A", "B"], "A~1");
-    env.but("config feature single-branch disable")
-        .assert()
-        .success();
     let old_target = env
         .project_meta()
         .target_commit_id
         .expect("fixture has a target commit");
-    env.invoke_git("init --bare .git/upstream.git");
-    env.invoke_git("push .git/upstream.git refs/heads/main:refs/heads/main");
-    env.invoke_git("remote set-url origin .git/upstream.git");
-    env.invoke_git("config branch.main.remote origin");
-    env.invoke_git("config branch.main.merge refs/heads/main");
-    env.invoke_git(&format!("update-ref refs/heads/main {old_target}"));
     if diverged {
         let local_commit = env.invoke_git(&format!(
             "commit-tree {old_target}^{{tree}} -p {old_target} -m local-main"
@@ -69,62 +62,19 @@ fn managed_target_branch_pull_scenario(diverged: bool) -> Sandbox {
     env
 }
 
-fn commit_graph(env: &Sandbox) -> String {
-    env.git_log()
-        .lines()
-        .map(str::trim_end)
-        .collect::<Vec<_>>()
-        .join("\n")
-        + "\n"
+fn single_branch_target_branch_pull_scenario(diverged: bool) -> Sandbox {
+    let env = target_branch_pull_scenario(diverged);
+    env.but("config feature single-branch enable")
+        .assert()
+        .success();
+    env
 }
 
-#[test]
-fn pull_fast_forwards_the_local_target_branch() {
-    let env = managed_target_branch_pull_scenario(false);
+fn assert_pull_fast_forwards_local_target(env: Sandbox) {
     assert_ne!(rev_parse(&env, "main"), rev_parse(&env, "origin/main"));
-    // The pre-integration graph keeps local main at the old target.
-    snapbox::assert_data_eq!(
-        commit_graph(&env),
-        snapbox::str![[r#"
-*   c128bce (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-|/
-| | * 7e5d4e1 (origin/main, origin/HEAD) add upstream
-| | *   613fca8 merge B
-| | |/
-| |_|/
-|/| |
-* | | d3e2ba3 (B) add B
-| | * c0a497b merge A
-| |/|
-|/|/
-| * 9477ae7 (A) add A
-|/
-* 0dc3733 (main) add M
-
-"#]]
-    );
 
     env.but("pull").assert().success();
 
-    // The post-integration graph moves local main to origin/main.
-    snapbox::assert_data_eq!(
-        commit_graph(&env),
-        snapbox::str![[r#"
-* 1f7c7b0 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-* 7e5d4e1 (origin/main, origin/HEAD, main, gitbutler/target) add upstream
-*   613fca8 merge B
-|/
-| * d3e2ba3 add B
-* |   c0a497b merge A
-|/ /
-| |/
-|/|
-| * 9477ae7 add A
-|/
-* 0dc3733 add M
-
-"#]]
-    );
     assert_eq!(
         rev_parse(&env, "main"),
         rev_parse(&env, "origin/main"),
@@ -132,64 +82,37 @@ fn pull_fast_forwards_the_local_target_branch() {
     );
 }
 
-#[test]
-fn pull_leaves_a_diverged_local_target_branch_unchanged() {
-    let env = managed_target_branch_pull_scenario(true);
+fn assert_pull_preserves_diverged_local_target(env: Sandbox) {
     let local_main = rev_parse(&env, "main");
-    // The pre-integration graph shows the local-only commit diverging from origin/main.
-    snapbox::assert_data_eq!(
-        commit_graph(&env),
-        snapbox::str![[r#"
-*   c128bce (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-|/
-| | * f587c40 (main) local-main
-| | | * 7e5d4e1 (origin/main, origin/HEAD) add upstream
-| | | *   613fca8 merge B
-| | | |/
-| |_|_|/
-|/| | |
-* | | | d3e2ba3 (B) add B
-| |/ /
-|/| |
-| | * c0a497b merge A
-| |/|
-|/|/
-| * 9477ae7 (A) add A
-|/
-* 0dc3733 add M
-
-"#]]
-    );
 
     env.but("pull").assert().success();
 
-    // The post-integration graph retains the diverged local main ref.
-    snapbox::assert_data_eq!(
-        commit_graph(&env),
-        snapbox::str![[r#"
-* 1f7c7b0 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-* 7e5d4e1 (origin/main, origin/HEAD, gitbutler/target) add upstream
-*   613fca8 merge B
-|/
-| * d3e2ba3 add B
-* |   c0a497b merge A
-|/ /
-| |/
-|/|
-| * 9477ae7 add A
-|/
-| * f587c40 (main) local-main
-|/
-* 0dc3733 add M
-
-"#]]
-    );
     assert_eq!(
         rev_parse(&env, "main"),
         local_main,
         "pull must preserve local commits on a diverged target branch"
     );
     assert_ne!(rev_parse(&env, "main"), rev_parse(&env, "origin/main"));
+}
+
+#[test]
+fn pull_fast_forwards_the_local_target_branch() {
+    assert_pull_fast_forwards_local_target(target_branch_pull_scenario(false));
+}
+
+#[test]
+fn single_branch_pull_fast_forwards_the_local_target_branch() {
+    assert_pull_fast_forwards_local_target(single_branch_target_branch_pull_scenario(false));
+}
+
+#[test]
+fn pull_leaves_a_diverged_local_target_branch_unchanged() {
+    assert_pull_preserves_diverged_local_target(target_branch_pull_scenario(true));
+}
+
+#[test]
+fn single_branch_pull_leaves_a_diverged_local_target_branch_unchanged() {
+    assert_pull_preserves_diverged_local_target(single_branch_target_branch_pull_scenario(true));
 }
 
 #[test]

--- a/crates/but/tests/but/command/pull.rs
+++ b/crates/but/tests/but/command/pull.rs
@@ -101,6 +101,28 @@ fn pull_fast_forwards_the_local_target_branch() {
 }
 
 #[test]
+fn undo_and_redo_restore_the_local_target_branch() {
+    let env = target_branch_pull_scenario(false);
+    let old_target = rev_parse(&env, "main");
+    let new_target = rev_parse(&env, "origin/main");
+
+    env.but("pull").assert().success();
+    env.but("undo").assert().success();
+    assert_eq!(
+        rev_parse(&env, "main"),
+        old_target,
+        "undo should restore the local target branch"
+    );
+
+    env.but("redo").assert().success();
+    assert_eq!(
+        rev_parse(&env, "main"),
+        new_target,
+        "redo should fast-forward the local target branch again"
+    );
+}
+
+#[test]
 fn single_branch_pull_fast_forwards_the_local_target_branch() {
     assert_pull_fast_forwards_local_target(single_branch_target_branch_pull_scenario(false));
 }

--- a/crates/but/tests/but/command/pull.rs
+++ b/crates/but/tests/but/command/pull.rs
@@ -44,6 +44,154 @@ fn merge_into_upstream(env: &Sandbox, branch: &str, add_upstream_commit: bool) {
     env.invoke_git("fetch origin");
 }
 
+fn managed_target_branch_pull_scenario(diverged: bool) -> Sandbox {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("pull-two-integrated-stacks");
+    env.setup_metadata_at_target(&["A", "B"], "A~1");
+    env.but("config feature single-branch disable")
+        .assert()
+        .success();
+    let old_target = env
+        .project_meta()
+        .target_commit_id
+        .expect("fixture has a target commit");
+    env.invoke_git("init --bare .git/upstream.git");
+    env.invoke_git("push .git/upstream.git refs/heads/main:refs/heads/main");
+    env.invoke_git("remote set-url origin .git/upstream.git");
+    env.invoke_git("config branch.main.remote origin");
+    env.invoke_git("config branch.main.merge refs/heads/main");
+    env.invoke_git(&format!("update-ref refs/heads/main {old_target}"));
+    if diverged {
+        let local_commit = env.invoke_git(&format!(
+            "commit-tree {old_target}^{{tree}} -p {old_target} -m local-main"
+        ));
+        env.invoke_git(&format!("update-ref refs/heads/main {local_commit}"));
+    }
+    env
+}
+
+fn commit_graph(env: &Sandbox) -> String {
+    env.git_log()
+        .lines()
+        .map(str::trim_end)
+        .collect::<Vec<_>>()
+        .join("\n")
+        + "\n"
+}
+
+#[test]
+fn pull_fast_forwards_the_local_target_branch() {
+    let env = managed_target_branch_pull_scenario(false);
+    assert_ne!(rev_parse(&env, "main"), rev_parse(&env, "origin/main"));
+    // The pre-integration graph keeps local main at the old target.
+    snapbox::assert_data_eq!(
+        commit_graph(&env),
+        snapbox::str![[r#"
+*   c128bce (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+|/
+| | * 7e5d4e1 (origin/main, origin/HEAD) add upstream
+| | *   613fca8 merge B
+| | |/
+| |_|/
+|/| |
+* | | d3e2ba3 (B) add B
+| | * c0a497b merge A
+| |/|
+|/|/
+| * 9477ae7 (A) add A
+|/
+* 0dc3733 (main) add M
+
+"#]]
+    );
+
+    env.but("pull").assert().success();
+
+    // The post-integration graph moves local main to origin/main.
+    snapbox::assert_data_eq!(
+        commit_graph(&env),
+        snapbox::str![[r#"
+* 1f7c7b0 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+* 7e5d4e1 (origin/main, origin/HEAD, main, gitbutler/target) add upstream
+*   613fca8 merge B
+|/
+| * d3e2ba3 add B
+* |   c0a497b merge A
+|/ /
+| |/
+|/|
+| * 9477ae7 add A
+|/
+* 0dc3733 add M
+
+"#]]
+    );
+    assert_eq!(
+        rev_parse(&env, "main"),
+        rev_parse(&env, "origin/main"),
+        "pull should fast-forward the local target branch"
+    );
+}
+
+#[test]
+fn pull_leaves_a_diverged_local_target_branch_unchanged() {
+    let env = managed_target_branch_pull_scenario(true);
+    let local_main = rev_parse(&env, "main");
+    // The pre-integration graph shows the local-only commit diverging from origin/main.
+    snapbox::assert_data_eq!(
+        commit_graph(&env),
+        snapbox::str![[r#"
+*   c128bce (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+|/
+| | * f587c40 (main) local-main
+| | | * 7e5d4e1 (origin/main, origin/HEAD) add upstream
+| | | *   613fca8 merge B
+| | | |/
+| |_|_|/
+|/| | |
+* | | | d3e2ba3 (B) add B
+| |/ /
+|/| |
+| | * c0a497b merge A
+| |/|
+|/|/
+| * 9477ae7 (A) add A
+|/
+* 0dc3733 add M
+
+"#]]
+    );
+
+    env.but("pull").assert().success();
+
+    // The post-integration graph retains the diverged local main ref.
+    snapbox::assert_data_eq!(
+        commit_graph(&env),
+        snapbox::str![[r#"
+* 1f7c7b0 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+* 7e5d4e1 (origin/main, origin/HEAD, gitbutler/target) add upstream
+*   613fca8 merge B
+|/
+| * d3e2ba3 add B
+* |   c0a497b merge A
+|/ /
+| |/
+|/|
+| * 9477ae7 add A
+|/
+| * f587c40 (main) local-main
+|/
+* 0dc3733 add M
+
+"#]]
+    );
+    assert_eq!(
+        rev_parse(&env, "main"),
+        local_main,
+        "pull must preserve local commits on a diverged target branch"
+    );
+    assert_ne!(rev_parse(&env, "main"), rev_parse(&env, "origin/main"));
+}
+
 #[test]
 fn single_branch_pull_replaces_a_fully_integrated_checkout() {
     let env = single_branch_integration_scenario();

--- a/crates/but/tests/fixtures/scenario/pull-two-integrated-stacks-with-local-target.sh
+++ b/crates/but/tests/fixtures/scenario/pull-two-integrated-stacks-with-local-target.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/pull-two-integrated-stacks.sh"
+
+old_target=$(git rev-parse A~1)
+git init --bare .git/upstream.git
+git push .git/upstream.git refs/heads/main:refs/heads/main
+git remote set-url origin .git/upstream.git
+git config branch.main.remote origin
+git config branch.main.merge refs/heads/main
+git update-ref refs/heads/main "$old_target"

--- a/crates/gitbutler-oplog/src/oplog.rs
+++ b/crates/gitbutler-oplog/src/oplog.rs
@@ -142,6 +142,13 @@ pub trait OplogExt {
     /// If there are files that are untracked and larger than `SNAPSHOT_FILE_LIMIT_BYTES`, they are excluded from snapshot creation and restoring.
     fn prepare_snapshot(&self, perm: &RepoShared) -> Result<gix::ObjectId>;
 
+    /// Like [`prepare_snapshot`](Self::prepare_snapshot), additionally preserving one reference.
+    fn prepare_snapshot_with_ref(
+        &self,
+        ref_name: &gix::refs::FullNameRef,
+        perm: &RepoShared,
+    ) -> Result<gix::ObjectId>;
+
     /// Commits the snapshot tree that is created with the [`prepare_snapshot`](Self::prepare_snapshot) method,
     /// which yielded the `snapshot_tree_id` for the entire snapshot state.
     /// Use `details` to provide metadata about the snapshot.
@@ -227,6 +234,15 @@ pub trait OplogExt {
 impl OplogExt for Context {
     fn prepare_snapshot(&self, perm: &RepoShared) -> Result<gix::ObjectId> {
         prepare_snapshot(self, perm)
+    }
+
+    fn prepare_snapshot_with_ref(
+        &self,
+        ref_name: &gix::refs::FullNameRef,
+        perm: &RepoShared,
+    ) -> Result<gix::ObjectId> {
+        prepare_snapshot_with_target_and_ref(self, perm, Some(ref_name))
+            .map(|snapshot| snapshot.tree_id)
     }
 
     fn commit_snapshot(
@@ -521,6 +537,37 @@ struct SnapshotCheckout {
     commit_id: gix::ObjectId,
 }
 
+struct SnapshotReference {
+    ref_name: gix::refs::FullName,
+    target: Option<gix::ObjectId>,
+}
+
+fn snapshot_reference(
+    snapshot_tree: &gix::Tree<'_>,
+    repo: &gix::Repository,
+) -> Result<Option<SnapshotReference>> {
+    let Some(name_entry) = snapshot_tree.lookup_entry_by_path("additional-ref/name")? else {
+        return Ok(None);
+    };
+    let name_blob = repo.find_blob(name_entry.id())?;
+    let ref_name = gix::refs::FullName::try_from(name_blob.data.as_bstr())
+        .context("snapshot additional ref is invalid")?;
+    if ref_name.category() != Some(gix::refs::Category::LocalBranch) {
+        bail!("snapshot additional ref is not a local branch");
+    }
+    let target = snapshot_tree
+        .lookup_entry_by_path("additional-ref/target")?
+        .map(|entry| {
+            let blob = repo.find_blob(entry.id())?;
+            gix::ObjectId::from_hex(&blob.data).context("snapshot additional ref target is invalid")
+        })
+        .transpose()?;
+    if target.is_some_and(|target| target.is_null()) {
+        bail!("snapshot additional ref target is null");
+    }
+    Ok(Some(SnapshotReference { ref_name, target }))
+}
+
 fn snapshot_checkout(
     snapshot_tree: &gix::Tree<'_>,
     repo: &gix::Repository,
@@ -707,6 +754,14 @@ fn prepare_snapshot_with_target(
     ctx: &Context,
     shared_access: &RepoShared,
 ) -> Result<PreparedSnapshot> {
+    prepare_snapshot_with_target_and_ref(ctx, shared_access, None)
+}
+
+fn prepare_snapshot_with_target_and_ref(
+    ctx: &Context,
+    shared_access: &RepoShared,
+    additional_ref: Option<&gix::refs::FullNameRef>,
+) -> Result<PreparedSnapshot> {
     let repo = ctx.repo.get()?;
     let empty_tree_id = repo.empty_tree().id;
     let workspace_ref: &gix::refs::FullNameRef = WORKSPACE_REF_NAME.try_into()?;
@@ -742,6 +797,21 @@ fn prepare_snapshot_with_target(
         &project_meta,
     )?)?)?;
     snapshot_tree.upsert(PROJECT_META_FILE, EntryKind::Blob, project_meta_blob)?;
+
+    if let Some(ref_name) = additional_ref {
+        snapshot_tree.upsert(
+            "additional-ref/name",
+            EntryKind::Blob,
+            repo.write_blob(ref_name.as_bstr())?,
+        )?;
+        if let Some(reference) = repo.try_find_reference(ref_name)? {
+            snapshot_tree.upsert(
+                "additional-ref/target",
+                EntryKind::Blob,
+                repo.write_blob(reference.id().to_string().as_bytes())?,
+            )?;
+        }
+    }
 
     let mut head = repo.head()?;
     if let Some(head_ref) = head
@@ -949,11 +1019,21 @@ fn restore_snapshot(
     let (restored_project_meta, restored_virtual_branches) =
         snapshot_metadata(&snapshot_tree, &repo)?;
     let restored_checkout = snapshot_checkout(&snapshot_tree, &repo)?;
+    let restored_reference = snapshot_reference(&snapshot_tree, &repo)?;
     let restored_target = restored_project_meta.target_commit_id_or_err()?;
     let restored_vb_toml = toml::to_string(&restored_virtual_branches)?;
 
-    let before_restore_snapshot_tree_id =
-        prepare_snapshot(ctx, exclusive_access.read_permission())?;
+    let before_restore_snapshot_tree_id = match restored_reference.as_ref() {
+        Some(reference) => {
+            prepare_snapshot_with_target_and_ref(
+                ctx,
+                exclusive_access.read_permission(),
+                Some(reference.ref_name.as_ref()),
+            )?
+            .tree_id
+        }
+        None => prepare_snapshot(ctx, exclusive_access.read_permission())?,
+    };
     let before_restore_snapshot_workdir_tree_id =
         get_v3_workdir_tree(repo.find_tree(before_restore_snapshot_tree_id)?)?
             .context("Could not get workdir tree of snapshot created before the restore")?;
@@ -1095,6 +1175,23 @@ fn restore_snapshot(
     for stack in legacy_virtual_branches::in_workspace_stacks(vb_state.data()) {
         for branch in &stack.heads {
             legacy_virtual_branches::set_reference_to_stored_head(branch, &gix_repo).ok();
+        }
+    }
+    if let Some(reference) = restored_reference {
+        match reference.target {
+            Some(target) => {
+                repo.reference(
+                    reference.ref_name,
+                    target,
+                    gix::refs::transaction::PreviousValue::Any,
+                    "restore snapshot additional ref",
+                )?;
+            }
+            None => {
+                if let Some(reference) = repo.try_find_reference(reference.ref_name.as_ref())? {
+                    reference.delete()?;
+                }
+            }
         }
     }
     ctx.set_project_meta(restored_project_meta)?;

--- a/crates/gitbutler-oplog/src/oplog.rs
+++ b/crates/gitbutler-oplog/src/oplog.rs
@@ -1023,6 +1023,18 @@ fn restore_snapshot(
     let restored_target = restored_project_meta.target_commit_id_or_err()?;
     let restored_vb_toml = toml::to_string(&restored_virtual_branches)?;
 
+    if let Some(reference) = restored_reference.as_ref()
+        && let Some(current_reference) = repo.try_find_reference(reference.ref_name.as_ref())?
+        && current_reference.target().try_id().map(ToOwned::to_owned) != reference.target
+        && let Some(dirs) =
+            but_core::branch::SafeDelete::new(&repo)?.worktree_dirs_with_ref(&current_reference)
+    {
+        bail!(
+            "Cannot restore branch '{}' because it is checked out in worktrees: {dirs:?}",
+            reference.ref_name.shorten()
+        );
+    }
+
     let before_restore_snapshot_tree_id = match restored_reference.as_ref() {
         Some(reference) => {
             prepare_snapshot_with_target_and_ref(

--- a/e2e/playwright/tests/upstreamIntegration.spec.ts
+++ b/e2e/playwright/tests/upstreamIntegration.spec.ts
@@ -138,6 +138,44 @@ test("should reparent workspace commit to advanced target after integrating all 
 
 	await waitForTestIdToNotExist(page, "stack");
 	await expectWorkspaceCommitParentToBeOriginMaster(localClone);
+	expect(git(localClone, ["rev-parse", "master"])).toBe(
+		git(localClone, ["rev-parse", "origin/master"]),
+	);
+});
+
+test("should preserve a diverged local target branch during upstream integration", async ({
+	page,
+	gitbutler,
+}) => {
+	const localClone = gitbutler.pathInWorkdir("local-clone");
+
+	await gitbutler.runScript("project-with-remote-branches.sh");
+	await applyUpstream(gitbutler, "branch1");
+	await openWorkspace(page);
+
+	const oldMaster = git(localClone, ["rev-parse", "master"]);
+	const localMaster = git(localClone, [
+		"-c",
+		"user.name=GitButler",
+		"-c",
+		"user.email=gitbutler@example.com",
+		"commit-tree",
+		"master^{tree}",
+		"-p",
+		oldMaster,
+		"-m",
+		"local master",
+	]);
+	git(localClone, ["update-ref", "refs/heads/master", localMaster]);
+
+	await gitbutler.runScript(
+		"project-with-remote-branches__fast-forward-base-through-branch1-and-add-commit.sh",
+	);
+	await syncAndIntegrate(page);
+
+	await waitForTestIdToNotExist(page, "stack");
+	expect(git(localClone, ["rev-parse", "master"])).toBe(localMaster);
+	expect(git(localClone, ["rev-parse", "origin/master"])).not.toBe(localMaster);
 });
 
 test("should reparent workspace commit to advanced merge target after integrating all stacks", async ({


### PR DESCRIPTION
## Summary

- Fast-forward the preferred local branch tracking the remote target after upstream integration.
- Leave diverged, local-target, and checked-out tracking branches unchanged.
- Preserve the updated tracking branch across undo and redo, with workspace, CLI, and desktop E2E coverage.