### PR TITLE
Update `gix` so `cargo install` works again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,7 +183,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -207,7 +207,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -250,7 +250,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
  "wl-clipboard-rs",
  "x11rb",
 ]
@@ -620,21 +620,6 @@ checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "bisync"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5020822f6d6f23196ccaf55e228db36f9de1cf788052b37992e17cbc96ec41a7"
-dependencies = [
- "bisync_macros",
-]
-
-[[package]]
-name = "bisync_macros"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d21f40d350a700f6aa107e45fb26448cf489d34794b2ba4522181dc9f1173af6"
 
 [[package]]
 name = "bit-set"
@@ -2180,7 +2165,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2636,7 +2621,7 @@ dependencies = [
  "openssl-sys",
  "schannel",
  "socket2",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2651,7 +2636,7 @@ dependencies = [
  "openssl-sys",
  "pkg-config",
  "vcpkg",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2937,7 +2922,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3181,7 +3166,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4223,8 +4208,8 @@ dependencies = [
 
 [[package]]
 name = "gix"
-version = "0.87.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+version = "0.87.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "gix-actor",
  "gix-attributes",
@@ -4288,7 +4273,7 @@ dependencies = [
 [[package]]
 name = "gix-actor"
 version = "0.42.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "bstr",
  "gix-date",
@@ -4299,7 +4284,7 @@ dependencies = [
 [[package]]
 name = "gix-attributes"
 version = "0.35.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "bstr",
  "gix-features",
@@ -4316,7 +4301,7 @@ dependencies = [
 [[package]]
 name = "gix-bitmap"
 version = "0.4.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "gix-error",
 ]
@@ -4324,7 +4309,7 @@ dependencies = [
 [[package]]
 name = "gix-chunk"
 version = "0.8.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "gix-error",
 ]
@@ -4332,7 +4317,7 @@ dependencies = [
 [[package]]
 name = "gix-command"
 version = "0.10.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "bstr",
  "gix-path 0.12.5",
@@ -4344,7 +4329,7 @@ dependencies = [
 [[package]]
 name = "gix-commitgraph"
 version = "0.39.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "bstr",
  "gix-chunk",
@@ -4358,7 +4343,7 @@ dependencies = [
 [[package]]
 name = "gix-config"
 version = "0.60.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "bstr",
  "gix-config-value",
@@ -4376,7 +4361,7 @@ dependencies = [
 [[package]]
 name = "gix-config-value"
 version = "0.19.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "bitflags 2.13.0",
  "bstr",
@@ -4388,7 +4373,7 @@ dependencies = [
 [[package]]
 name = "gix-credentials"
 version = "0.40.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "bstr",
  "gix-command",
@@ -4407,7 +4392,7 @@ dependencies = [
 [[package]]
 name = "gix-date"
 version = "0.16.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "bstr",
  "gix-error",
@@ -4418,8 +4403,8 @@ dependencies = [
 
 [[package]]
 name = "gix-diff"
-version = "0.67.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+version = "0.67.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "bstr",
  "gix-attributes",
@@ -4441,8 +4426,8 @@ dependencies = [
 
 [[package]]
 name = "gix-dir"
-version = "0.29.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+version = "0.29.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "bstr",
  "gix-discover",
@@ -4461,7 +4446,7 @@ dependencies = [
 [[package]]
 name = "gix-discover"
 version = "0.55.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "bstr",
  "dunce",
@@ -4475,7 +4460,7 @@ dependencies = [
 [[package]]
 name = "gix-error"
 version = "0.3.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "bstr",
 ]
@@ -4483,7 +4468,7 @@ dependencies = [
 [[package]]
 name = "gix-features"
 version = "0.49.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -4501,7 +4486,7 @@ dependencies = [
 [[package]]
 name = "gix-filter"
 version = "0.34.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "bstr",
  "encoding_rs",
@@ -4521,7 +4506,7 @@ dependencies = [
 [[package]]
 name = "gix-fs"
 version = "0.22.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "bstr",
  "gix-features",
@@ -4533,7 +4518,7 @@ dependencies = [
 [[package]]
 name = "gix-glob"
 version = "0.27.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "bitflags 2.13.0",
  "bstr",
@@ -4545,7 +4530,7 @@ dependencies = [
 [[package]]
 name = "gix-hash"
 version = "0.26.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "faster-hex",
  "gix-features",
@@ -4558,7 +4543,7 @@ dependencies = [
 [[package]]
 name = "gix-hashtable"
 version = "0.16.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "gix-hash",
  "hashbrown 0.17.1",
@@ -4568,7 +4553,7 @@ dependencies = [
 [[package]]
 name = "gix-ignore"
 version = "0.22.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "bstr",
  "gix-glob",
@@ -4581,7 +4566,7 @@ dependencies = [
 [[package]]
 name = "gix-imara-diff"
 version = "0.2.5"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "bstr",
  "hashbrown 0.17.1",
@@ -4590,7 +4575,7 @@ dependencies = [
 [[package]]
 name = "gix-index"
 version = "0.55.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "bitflags 2.13.0",
  "bstr",
@@ -4618,7 +4603,7 @@ dependencies = [
 [[package]]
 name = "gix-lock"
 version = "24.0.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "gix-tempfile",
  "gix-utils",
@@ -4626,9 +4611,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix-macros"
+version = "0.1.6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "gix-mailmap"
-version = "0.34.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+version = "0.34.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "bstr",
  "gix-actor",
@@ -4639,8 +4634,8 @@ dependencies = [
 
 [[package]]
 name = "gix-merge"
-version = "0.20.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+version = "0.20.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "bstr",
  "gix-command",
@@ -4664,8 +4659,8 @@ dependencies = [
 
 [[package]]
 name = "gix-negotiate"
-version = "0.35.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+version = "0.35.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "bitflags 2.13.0",
  "gix-commitgraph",
@@ -4677,8 +4672,8 @@ dependencies = [
 
 [[package]]
 name = "gix-note"
-version = "0.1.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+version = "0.1.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "gix-error",
  "gix-hash",
@@ -4689,7 +4684,7 @@ dependencies = [
 [[package]]
 name = "gix-object"
 version = "0.64.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "bstr",
  "gix-actor",
@@ -4710,7 +4705,7 @@ dependencies = [
 [[package]]
 name = "gix-odb"
 version = "0.84.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "arc-swap",
  "gix-features",
@@ -4731,8 +4726,8 @@ dependencies = [
 
 [[package]]
 name = "gix-pack"
-version = "0.74.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+version = "0.74.2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "clru",
  "crossbeam-deque",
@@ -4755,8 +4750,8 @@ dependencies = [
 
 [[package]]
 name = "gix-packetline"
-version = "0.22.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+version = "0.22.2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "bstr",
  "faster-hex",
@@ -4779,7 +4774,7 @@ dependencies = [
 [[package]]
 name = "gix-path"
 version = "0.12.5"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "bstr",
  "gix-trace 0.1.21",
@@ -4790,7 +4785,7 @@ dependencies = [
 [[package]]
 name = "gix-pathspec"
 version = "0.20.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "bitflags 2.13.0",
  "bstr",
@@ -4804,7 +4799,7 @@ dependencies = [
 [[package]]
 name = "gix-prompt"
 version = "0.17.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -4815,16 +4810,16 @@ dependencies = [
 
 [[package]]
 name = "gix-protocol"
-version = "0.65.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+version = "0.65.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
- "bisync",
  "bstr",
  "gix-credentials",
  "gix-date",
  "gix-features",
  "gix-hash",
  "gix-lock",
+ "gix-macros",
  "gix-negotiate",
  "gix-object",
  "gix-ref",
@@ -4842,7 +4837,7 @@ dependencies = [
 [[package]]
 name = "gix-quote"
 version = "0.8.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "bstr",
  "gix-error",
@@ -4852,7 +4847,7 @@ dependencies = [
 [[package]]
 name = "gix-ref"
 version = "0.67.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "gix-actor",
  "gix-features",
@@ -4871,8 +4866,8 @@ dependencies = [
 
 [[package]]
 name = "gix-refspec"
-version = "0.45.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+version = "0.45.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "bstr",
  "gix-hash",
@@ -4883,8 +4878,8 @@ dependencies = [
 
 [[package]]
 name = "gix-revision"
-version = "0.49.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+version = "0.49.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "bitflags 2.13.0",
  "bstr",
@@ -4903,7 +4898,7 @@ dependencies = [
 [[package]]
 name = "gix-revwalk"
 version = "0.35.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "gix-commitgraph",
  "gix-date",
@@ -4918,7 +4913,7 @@ dependencies = [
 [[package]]
 name = "gix-sec"
 version = "0.14.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "bitflags 2.13.0",
  "gix-path 0.12.5",
@@ -4930,7 +4925,7 @@ dependencies = [
 [[package]]
 name = "gix-shallow"
 version = "0.13.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "bstr",
  "gix-hash",
@@ -4942,8 +4937,8 @@ dependencies = [
 
 [[package]]
 name = "gix-status"
-version = "0.34.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+version = "0.34.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "bstr",
  "filetime",
@@ -4967,7 +4962,7 @@ dependencies = [
 [[package]]
 name = "gix-submodule"
 version = "0.34.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "bstr",
  "gix-config",
@@ -4981,7 +4976,7 @@ dependencies = [
 [[package]]
 name = "gix-tempfile"
 version = "24.0.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "dashmap",
  "gix-fs",
@@ -4995,7 +4990,7 @@ dependencies = [
 [[package]]
 name = "gix-testtools"
 version = "0.20.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "bstr",
  "crc",
@@ -5030,15 +5025,15 @@ checksum = "44dc45eae785c0eb14173e0f152e6e224dcf4d45b6a6999a3aed22af541ad678"
 [[package]]
 name = "gix-trace"
 version = "0.1.21"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "gix-transport"
-version = "0.59.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+version = "0.59.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "base64 0.22.1",
  "bstr",
@@ -5059,7 +5054,7 @@ dependencies = [
 [[package]]
 name = "gix-traverse"
 version = "0.61.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "bitflags 2.13.0",
  "gix-commitgraph",
@@ -5075,7 +5070,7 @@ dependencies = [
 [[package]]
 name = "gix-url"
 version = "0.38.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "bstr",
  "gix-path 0.12.5",
@@ -5088,7 +5083,7 @@ dependencies = [
 [[package]]
 name = "gix-utils"
 version = "0.3.6"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "bstr",
  "fastrand",
@@ -5108,7 +5103,7 @@ dependencies = [
 [[package]]
 name = "gix-validate"
 version = "0.11.4"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "bstr",
 ]
@@ -5116,7 +5111,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree"
 version = "0.56.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "bstr",
  "gix-attributes",
@@ -5134,8 +5129,8 @@ dependencies = [
 
 [[package]]
 name = "gix-worktree-state"
-version = "0.34.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+version = "0.34.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "bstr",
  "gix-features",
@@ -5151,8 +5146,8 @@ dependencies = [
 
 [[package]]
 name = "gix-worktree-stream"
-version = "0.36.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+version = "0.36.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "gix-attributes",
  "gix-error",
@@ -5169,7 +5164,7 @@ dependencies = [
 [[package]]
 name = "gix-zlib"
 version = "0.1.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=6704303ed5ef3403b129e2b6cc4a9214432ffd03#6704303ed5ef3403b129e2b6cc4a9214432ffd03"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -5924,7 +5919,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6611,7 +6606,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6867,7 +6862,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8077,7 +8072,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8657,7 +8652,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8715,7 +8710,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9405,7 +9400,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10282,7 +10277,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10314,7 +10309,7 @@ dependencies = [
  "parking_lot",
  "rustix 1.1.4",
  "signal-hook 0.3.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10350,7 +10345,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10969,7 +10964,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11046,7 +11041,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11692,7 +11687,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -207,11 +207,11 @@ bstr = "1.12.1"
 zip = { version = "4", default-features = false, features = ["bzip2"] }
 # Add the `tracing` or `tracing-detail` features to see more of gitoxide in the logs. Useful to see which programs it invokes.
 # When adjusting this, update `gix-testtools` as well!
-gix = { version = "0.87.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "6704303ed5ef3403b129e2b6cc4a9214432ffd03", default-features = false, features = [
+gix = { version = "0.87.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "dda600d7ee29a6bda4cf1047d0d1782e76b16f98", default-features = false, features = [
     "sha1",
     "sha256",
 ] }
-gix-testtools = { version = "0.20.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "6704303ed5ef3403b129e2b6cc4a9214432ffd03" }
+gix-testtools = { version = "0.20.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "dda600d7ee29a6bda4cf1047d0d1782e76b16f98" }
 
 
 git2 = { version = "0.21.0", features = [
@@ -312,7 +312,7 @@ sapling-renderdag = "0.1.0"
 [patch.crates-io]
 # Keep workspace crates that use the `gix 0.87` line on the same git revision.
 # This was relevant to force `git-meta` to use our version.
-gix = { git = "https://github.com/GitoxideLabs/gitoxide", rev = "6704303ed5ef3403b129e2b6cc4a9214432ffd03" }
+gix = { git = "https://github.com/GitoxideLabs/gitoxide", rev = "dda600d7ee29a6bda4cf1047d0d1782e76b16f98" }
 git2 = { git = "https://github.com/gitbutlerapp/git2-rs", rev = "a87a7bb3f6843504339fe7434ee0732a3e968f3e" }
 
 [workspace.lints.clippy]


### PR DESCRIPTION
The `bisync` dependency was yanked, which broke all downstream installations. It was unyanked in the meantime, but will probably be yanked again.

Without this PR, release-builds *would* fail if they update dependencies.
In any case, the next dependency update would fail while `bisync` is still in the tree.
