### PR TITLE
Stable-order pagination for open GitHub pull request listing

### DIFF
--- a/crates/but-github/src/client.rs
+++ b/crates/but-github/src/client.rs
@@ -202,7 +202,9 @@ impl GitHubClient {
 
     /// Fetch every page of a GitHub list endpoint, 100 items per page,
     /// stopping at the first short page or after `max_pages` (a silent
-    /// truncation bound for pathological list sizes).
+    /// truncation bound for pathological list sizes; callers that must
+    /// detect overflow pass one page beyond their limit and check the
+    /// returned item count).
     async fn get_all_pages<T: serde::de::DeserializeOwned>(
         &self,
         url: &str,
@@ -247,43 +249,38 @@ impl GitHubClient {
         Ok(response)
     }
 
-    /// Fetch the list of the open PRs on a repo.
+    /// Fetch the list of the open PRs on a repo, most recently updated first.
+    ///
+    /// Pages are fetched in ascending creation-time order so offset
+    /// pagination stays stable while the repository is active: updates never
+    /// move a PR and new PRs only append. A close or reopen racing the scan
+    /// can still shift a page boundary, duplicating a boundary PR (the
+    /// freshest copy is kept) or omitting one (a later refresh restores it,
+    /// though the review cache may briefly drop its row in between).
     pub async fn list_open_pulls(&self, owner: &str, repo: &str) -> Result<Vec<PullRequest>> {
+        const MAX_PAGES: usize = 100;
         let url = format!(
-            "{}/repos/{}/{}/pulls?state=open&sort=updated&direction=desc",
+            "{}/repos/{}/{}/pulls?state=open&sort=created&direction=asc",
             self.base_url, owner, repo
         );
-        let mut previous_numbers = None;
-        let mut retried = false;
-        loop {
-            let pulls = self.get_all_pages::<GitHubPullRequest>(&url, 101).await?;
-            anyhow::ensure!(
-                pulls.len() <= 10_000,
-                "Open pull request listing exceeded 100 pages"
-            );
-            if pulls.len() < 100 {
-                return Ok(pulls.into_iter().map(Into::into).collect());
-            }
-
-            let mut seen = std::collections::HashSet::new();
-            let numbers = pulls.iter().map(|pull| pull.number).collect::<Vec<_>>();
-            let changed = numbers.iter().any(|number| !seen.insert(number))
-                || previous_numbers
-                    .as_ref()
-                    .is_some_and(|previous| previous != &numbers);
-            if changed {
-                anyhow::ensure!(
-                    !retried,
-                    "Open pull request listing changed while paginating"
-                );
-                retried = true;
-            } else if previous_numbers.is_some() {
-                return Ok(pulls.into_iter().map(Into::into).collect());
-            }
-            if seen.len() == numbers.len() {
-                previous_numbers = Some(numbers);
-            }
-        }
+        let pulls = self
+            .get_all_pages::<GitHubPullRequest>(&url, MAX_PAGES + 1)
+            .await?;
+        // Every fetched page being full means the listing may extend past
+        // what was fetched; a short final page is complete however far past
+        // the nominal bound it runs.
+        anyhow::ensure!(
+            pulls.len() < (MAX_PAGES + 1) * 100,
+            "Open pull request listing exceeded {MAX_PAGES} pages"
+        );
+        // Later duplicates overwrite earlier ones, keeping the freshest copy.
+        let pulls: std::collections::BTreeMap<_, _> =
+            pulls.into_iter().map(|pull| (pull.number, pull)).collect();
+        let mut pulls = pulls.into_values().collect::<Vec<_>>();
+        // RFC 3339 timestamps compare chronologically as strings; consumers
+        // that pick one PR per branch rely on the freshest coming first.
+        pulls.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+        Ok(pulls.into_iter().map(Into::into).collect())
     }
 
     /// List the PRs for a given target.

--- a/crates/but-github/tests/open_pull_pagination.rs
+++ b/crates/but-github/tests/open_pull_pagination.rs
@@ -8,7 +8,6 @@ use but_github::GitHubClient;
 use but_secret::Sensitive;
 use serde_json::json;
 
-#[derive(Clone)]
 struct MockResponse {
     page: usize,
     status: reqwest::StatusCode,
@@ -62,6 +61,9 @@ fn fixture(responses: Vec<MockResponse>) -> (GitHubClient, std::thread::JoinHand
                     Err(error) => panic!("failed to accept request: {error}"),
                 }
             };
+            // Accepted streams inherit non-blocking from the listener on some
+            // platforms; reads below expect to block until data arrives.
+            stream.set_nonblocking(false).unwrap();
             let mut request = Vec::new();
             while !request.windows(4).any(|bytes| bytes == b"\r\n\r\n") {
                 let mut buffer = [0; 1024];
@@ -82,10 +84,10 @@ fn fixture(responses: Vec<MockResponse>) -> (GitHubClient, std::thread::JoinHand
             assert_eq!(
                 query,
                 vec![
-                    ("direction".to_string(), "desc".to_string()),
+                    ("direction".to_string(), "asc".to_string()),
                     ("page".to_string(), response.page.to_string()),
                     ("per_page".to_string(), "100".to_string()),
-                    ("sort".to_string(), "updated".to_string()),
+                    ("sort".to_string(), "created".to_string()),
                     ("state".to_string(), "open".to_string()),
                 ],
                 "every page keeps the open pull request query parameters"
@@ -111,10 +113,7 @@ fn fixture(responses: Vec<MockResponse>) -> (GitHubClient, std::thread::JoinHand
 
 #[tokio::test(flavor = "current_thread")]
 async fn list_open_pulls_fetches_more_than_one_page() {
-    let first_page = (1..=100).map(pull).collect();
     let (client, server) = fixture(vec![
-        MockResponse::ok(1, first_page),
-        MockResponse::ok(2, vec![pull(101)]),
         MockResponse::ok(1, (1..=100).map(pull).collect()),
         MockResponse::ok(2, vec![pull(101)]),
     ]);
@@ -129,11 +128,22 @@ async fn list_open_pulls_fetches_more_than_one_page() {
     server.join().unwrap();
 }
 
+fn full_pages(count: usize) -> Vec<MockResponse> {
+    (0..count)
+        .map(|page| {
+            MockResponse::ok(
+                page + 1,
+                (page * 100 + 1..=(page + 1) * 100)
+                    .map(|number| pull(number as i64))
+                    .collect(),
+            )
+        })
+        .collect()
+}
+
 #[tokio::test(flavor = "current_thread")]
-async fn list_open_pulls_checks_after_an_exact_page() {
+async fn list_open_pulls_stops_after_an_empty_second_page() {
     let (client, server) = fixture(vec![
-        MockResponse::ok(1, (1..=100).map(pull).collect()),
-        MockResponse::ok(2, Vec::new()),
         MockResponse::ok(1, (1..=100).map(pull).collect()),
         MockResponse::ok(2, Vec::new()),
     ]);
@@ -149,14 +159,12 @@ async fn list_open_pulls_checks_after_an_exact_page() {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn list_open_pulls_retries_after_insertion_drift() {
+async fn list_open_pulls_deduplicates_a_page_boundary_shift() {
+    let mut repeated = pull(100);
+    repeated["title"] = "PR 100 refetched".into();
     let (client, server) = fixture(vec![
         MockResponse::ok(1, (1..=100).map(pull).collect()),
-        MockResponse::ok(2, vec![pull(100), pull(102)]),
-        MockResponse::ok(1, (1..=100).map(pull).collect()),
-        MockResponse::ok(2, vec![pull(101), pull(102)]),
-        MockResponse::ok(1, (1..=100).map(pull).collect()),
-        MockResponse::ok(2, vec![pull(101), pull(102)]),
+        MockResponse::ok(2, vec![repeated, pull(102)]),
     ]);
 
     let pulls = client.list_open_pulls("o", "r").await.unwrap();
@@ -164,27 +172,22 @@ async fn list_open_pulls_retries_after_insertion_drift() {
 
     assert_eq!(
         numbers,
-        (1..=102).collect::<Vec<_>>(),
-        "the retry returns the complete listing rather than stale first-scan data"
+        (1..=100).chain([102]).collect::<Vec<_>>(),
+        "a pull repeated by a mid-scan page shift appears once"
+    );
+    let boundary = pulls.iter().find(|pull| pull.number == 100).unwrap();
+    assert_eq!(
+        boundary.title, "PR 100 refetched",
+        "the later fetch of a duplicated pull is fresher and wins"
     );
     server.join().unwrap();
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn list_open_pulls_retries_after_removal_page_drift() {
-    let current_first_page = (1..=100).map(pull).collect::<Vec<_>>();
-    let current_second_page = (102..=201).map(pull).collect::<Vec<_>>();
-    let current_third_page = vec![pull(202), pull(203)];
+async fn list_open_pulls_tolerates_a_skipped_pull_after_a_mid_scan_close() {
     let (client, server) = fixture(vec![
         MockResponse::ok(1, (1..=100).map(pull).collect()),
-        MockResponse::ok(2, (101..=200).map(pull).collect()),
-        MockResponse::ok(3, current_third_page.clone()),
-        MockResponse::ok(1, current_first_page.clone()),
-        MockResponse::ok(2, current_second_page),
-        MockResponse::ok(3, current_third_page.clone()),
-        MockResponse::ok(1, current_first_page),
-        MockResponse::ok(2, (102..=201).map(pull).collect()),
-        MockResponse::ok(3, current_third_page),
+        MockResponse::ok(2, vec![pull(102), pull(103)]),
     ]);
 
     let pulls = client.list_open_pulls("o", "r").await.unwrap();
@@ -192,29 +195,35 @@ async fn list_open_pulls_retries_after_removal_page_drift() {
 
     assert_eq!(
         numbers,
-        (1..=100).chain(102..=203).collect::<Vec<_>>(),
-        "the retry drops the closed pull and restores the shifted pull"
+        (1..=100).chain([102, 103]).collect::<Vec<_>>(),
+        "a pull shifted across an already-fetched boundary is absent until the next refresh instead of failing the listing"
     );
     server.join().unwrap();
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn list_open_pulls_fails_after_repeated_page_drift() {
-    let responses = vec![
-        MockResponse::ok(1, (1..=100).map(pull).collect()),
-        MockResponse::ok(2, vec![pull(100), pull(102)]),
-    ];
-    let mut repeated = responses.clone();
-    repeated.extend(responses);
-    let (client, server) = fixture(repeated);
+async fn list_open_pulls_returns_most_recently_updated_first() {
+    let updated = |number: i64, timestamp: &str| {
+        let mut pull = pull(number);
+        pull["updated_at"] = timestamp.into();
+        pull
+    };
+    let (client, server) = fixture(vec![MockResponse::ok(
+        1,
+        vec![
+            updated(1, "2026-08-20T00:00:00Z"),
+            updated(2, "2026-08-24T00:00:00Z"),
+            updated(3, "2026-08-22T00:00:00Z"),
+        ],
+    )]);
 
-    let error = client.list_open_pulls("o", "r").await.unwrap_err();
+    let pulls = client.list_open_pulls("o", "r").await.unwrap();
+    let numbers: Vec<_> = pulls.iter().map(|pull| pull.number).collect();
 
-    assert!(
-        error
-            .to_string()
-            .contains("Open pull request listing changed while paginating"),
-        "repeated drift must error instead of returning a partial listing: {error:#}"
+    assert_eq!(
+        numbers,
+        vec![2, 3, 1],
+        "consumers picking one review per branch rely on the freshest pull coming first"
     );
     server.join().unwrap();
 }
@@ -231,19 +240,8 @@ async fn list_open_pulls_stops_after_a_short_first_page() {
 
 #[tokio::test(flavor = "current_thread")]
 async fn list_open_pulls_accepts_exactly_the_page_limit() {
-    let mut scan = (0..100)
-        .map(|page| {
-            MockResponse::ok(
-                page + 1,
-                (page * 100 + 1..=(page + 1) * 100)
-                    .map(|number| pull(number as i64))
-                    .collect(),
-            )
-        })
-        .collect::<Vec<_>>();
-    scan.push(MockResponse::ok(101, Vec::new()));
-    let mut responses = scan.clone();
-    responses.extend(scan);
+    let mut responses = full_pages(100);
+    responses.push(MockResponse::ok(101, Vec::new()));
     let (client, server) = fixture(responses);
 
     let pulls = client.list_open_pulls("o", "r").await.unwrap();
@@ -257,19 +255,24 @@ async fn list_open_pulls_accepts_exactly_the_page_limit() {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn list_open_pulls_fails_when_page_101_is_nonempty() {
-    let mut responses = (0..100)
-        .map(|page| {
-            MockResponse::ok(
-                page + 1,
-                (page * 100 + 1..=(page + 1) * 100)
-                    .map(|number| pull(number as i64))
-                    .collect(),
-            )
-        })
-        .collect::<Vec<_>>();
+async fn list_open_pulls_accepts_a_short_page_past_the_limit() {
+    let mut responses = full_pages(100);
     responses.push(MockResponse::ok(101, vec![pull(10_001)]));
     let (client, server) = fixture(responses);
+
+    let pulls = client.list_open_pulls("o", "r").await.unwrap();
+
+    assert_eq!(
+        pulls.len(),
+        10_001,
+        "a short page 101 completes the listing instead of tripping the bound"
+    );
+    server.join().unwrap();
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn list_open_pulls_fails_when_page_101_is_full() {
+    let (client, server) = fixture(full_pages(101));
 
     let error = client.list_open_pulls("o", "r").await.unwrap_err();
 
@@ -277,7 +280,7 @@ async fn list_open_pulls_fails_when_page_101_is_nonempty() {
         error
             .to_string()
             .contains("Open pull request listing exceeded 100 pages"),
-        "a nonempty page 101 exceeds the safety bound: {error:#}"
+        "101 full pages mean the listing may extend past the safety bound: {error:#}"
     );
     server.join().unwrap();
 }


### PR DESCRIPTION
Fixes [GB-1884](https://linear.app/gitbutler/issue/GB-1884/list-reviews-fails-on-active-repos-with-100-prs-open-pull-request).

`list_reviews` failed on active repos with 100+ open PRs: the listing was fetched under `sort=updated`, which reshuffles on any PR activity, and the drift-verification loop required two identical full snapshots before returning — active repos could never settle, so the refresh failed outright with "Open pull request listing changed while paginating".

Fetch sorted by creation time ascending instead, which makes offset pagination stable: updates never move a PR and new PRs only append. A single scan then suffices, so the drift-verification loop is deleted and API traffic for large repos is halved. A close or reopen racing the scan can still shift a page boundary — duplicates keep their freshest copy, and an omitted PR returns on the next refresh.

The returned listing stays most-recently-updated first: desktop, lite, and TUI consumers pick one review per source branch positionally and expect the freshest PR to win, so the fetch order stays an internal detail.

Also fixes a latent mock-server race in the pagination tests: accepted streams inherited non-blocking from the listener and panicked on WouldBlock reads.