### PR TITLE
Remove segment IDs from projection debug output

### DIFF
--- a/crates/but-api/tests/api/branch_checkout.rs
+++ b/crates/but-api/tests/api/branch_checkout.rs
@@ -111,13 +111,13 @@ fn checkout_returns_head_info_matching_fresh_head_info() -> anyhow::Result<()> {
 
     snapbox::assert_data_eq!(
         crate::support::workspace_graph(&ctx)?,
-        snapbox::str![[r"
-⌂:0:feature[🌳] <> ✓refs/remotes/origin/main on 5374caf
-└── ≡:0:feature[🌳] on 5374caf {1}
-    └── :0:feature[🌳]
+        snapbox::str![[r#"
+⌂:feature[🌳] <> ✓refs/remotes/origin/main on 5374caf
+└── ≡:feature[🌳] on 5374caf {1}
+    └── :feature[🌳]
         └── ·edd8381
 
-"]]
+"#]]
     );
 
     #[cfg(feature = "graph-workspace")]
@@ -258,9 +258,9 @@ fn checkout_new_returns_head_info_matching_fresh_head_info() -> anyhow::Result<(
     snapbox::assert_data_eq!(
         crate::support::workspace_graph(&ctx)?,
         snapbox::str![[r#"
-⌂:0:new-branch[🌳] <> ✓refs/remotes/origin/main on 5374caf
-└── ≡:0:new-branch[🌳] on 5374caf {1}
-    └── :0:new-branch[🌳]
+⌂:new-branch[🌳] <> ✓refs/remotes/origin/main on 5374caf
+└── ≡:new-branch[🌳] on 5374caf {1}
+    └── :new-branch[🌳]
 
 "#]]
     );

--- a/crates/but-graph/src/debug.rs
+++ b/crates/but-graph/src/debug.rs
@@ -238,13 +238,11 @@ impl Graph {
     pub fn ref_and_remote_debug_string(
         ref_info: Option<&crate::RefInfo>,
         remote_ref_name: Option<&gix::refs::FullName>,
-        sibling_id: Option<SegmentIndex>,
         remote_tracking_branch_id: Option<SegmentIndex>,
     ) -> String {
         Self::ref_and_remote_debug_string_inner(
             ref_info,
             remote_ref_name,
-            sibling_id,
             remote_tracking_branch_id,
             false,
         )
@@ -255,13 +253,11 @@ impl Graph {
         &self,
         ref_info: Option<&crate::RefInfo>,
         remote_ref_name: Option<&gix::refs::FullName>,
-        sibling_id: Option<SegmentIndex>,
         remote_tracking_branch_id: Option<SegmentIndex>,
     ) -> String {
         Self::ref_and_remote_debug_string_inner(
             ref_info,
             remote_ref_name,
-            sibling_id,
             remote_tracking_branch_id,
             self.has_multiple_worktrees(),
         )
@@ -270,7 +266,6 @@ impl Graph {
     fn ref_and_remote_debug_string_inner(
         ref_info: Option<&crate::RefInfo>,
         remote_ref_name: Option<&gix::refs::FullName>,
-        sibling_id: Option<SegmentIndex>,
         remote_tracking_branch_id: Option<SegmentIndex>,
         show_owned_by_repo: bool,
     ) -> String {
@@ -278,31 +273,18 @@ impl Graph {
             "{ref_name}{remote}",
             ref_name = ref_info
                 .as_ref()
-                .map(|ri| format!(
-                    "{}{maybe_id}",
-                    Graph::ref_debug_string_inner(
-                        ri.ref_name.as_ref(),
-                        ri.worktree.as_ref(),
-                        show_owned_by_repo,
-                    ),
-                    maybe_id = sibling_id
-                        .filter(|_| remote_ref_name.is_none())
-                        .map(|id| format!(" →:{}:", id.index()))
-                        .unwrap_or_default()
+                .map(|ri| Graph::ref_debug_string_inner(
+                    ri.ref_name.as_ref(),
+                    ri.worktree.as_ref(),
+                    show_owned_by_repo,
                 ))
-                .unwrap_or_else(|| format!(
-                    "anon:{maybe_id}",
-                    maybe_id = sibling_id
-                        .map(|id| format!(" →:{}:", id.index()))
-                        .unwrap_or_default()
-                )),
+                .unwrap_or_else(|| "anon:".to_string()),
             remote = remote_ref_name
                 .as_ref()
                 .map(|remote_ref_name| format!(
                     " <> {remote_name}{maybe_id}",
                     remote_name = Graph::ref_debug_string(remote_ref_name.as_ref(), None),
                     maybe_id = remote_tracking_branch_id
-                        .or(sibling_id)
                         .map(|id| format!(" →:{}:", id.index()))
                         .unwrap_or_default()
                 ))
@@ -440,7 +422,6 @@ impl Graph {
                 ref_name_and_remote = Self::ref_and_remote_debug_string_inner(
                     s.ref_info.as_ref(),
                     s.remote_tracking_ref_name.as_ref(),
-                    s.sibling_segment_id,
                     s.remote_tracking_branch_segment_id,
                     show_owned_by_repo,
                 ),

--- a/crates/but-graph/src/debug.rs
+++ b/crates/but-graph/src/debug.rs
@@ -233,19 +233,12 @@ impl Graph {
         )
     }
 
-    /// Return a useful one-line string showing the relationship between `ref_name`, `remote_ref_name` and how
-    /// they are linked with `sibling_id` and `remote_tracking_branch_id`.
+    /// Return a useful one-line string showing the relationship between `ref_name` and `remote_ref_name`.
     pub fn ref_and_remote_debug_string(
         ref_info: Option<&crate::RefInfo>,
         remote_ref_name: Option<&gix::refs::FullName>,
-        remote_tracking_branch_id: Option<SegmentIndex>,
     ) -> String {
-        Self::ref_and_remote_debug_string_inner(
-            ref_info,
-            remote_ref_name,
-            remote_tracking_branch_id,
-            false,
-        )
+        Self::ref_and_remote_debug_string_inner(ref_info, remote_ref_name, false)
     }
 
     /// Like [`Self::ref_and_remote_debug_string()`], but includes graph-contextual worktree ownership markers.
@@ -253,12 +246,10 @@ impl Graph {
         &self,
         ref_info: Option<&crate::RefInfo>,
         remote_ref_name: Option<&gix::refs::FullName>,
-        remote_tracking_branch_id: Option<SegmentIndex>,
     ) -> String {
         Self::ref_and_remote_debug_string_inner(
             ref_info,
             remote_ref_name,
-            remote_tracking_branch_id,
             self.has_multiple_worktrees(),
         )
     }
@@ -266,7 +257,6 @@ impl Graph {
     fn ref_and_remote_debug_string_inner(
         ref_info: Option<&crate::RefInfo>,
         remote_ref_name: Option<&gix::refs::FullName>,
-        remote_tracking_branch_id: Option<SegmentIndex>,
         show_owned_by_repo: bool,
     ) -> String {
         format!(
@@ -282,11 +272,8 @@ impl Graph {
             remote = remote_ref_name
                 .as_ref()
                 .map(|remote_ref_name| format!(
-                    " <> {remote_name}{maybe_id}",
+                    " <> {remote_name}",
                     remote_name = Graph::ref_debug_string(remote_ref_name.as_ref(), None),
-                    maybe_id = remote_tracking_branch_id
-                        .map(|id| format!(" →:{}:", id.index()))
-                        .unwrap_or_default()
                 ))
                 .unwrap_or_default()
         )
@@ -422,7 +409,6 @@ impl Graph {
                 ref_name_and_remote = Self::ref_and_remote_debug_string_inner(
                     s.ref_info.as_ref(),
                     s.remote_tracking_ref_name.as_ref(),
-                    s.remote_tracking_branch_segment_id,
                     show_owned_by_repo,
                 ),
                 maybe_centering_newline = if s.commits.is_empty() { "" } else { "\n" },
@@ -538,10 +524,7 @@ impl Graph {
                     {
                         continue;
                     }
-                    if s.metadata.is_some()
-                        || s.sibling_segment_id.is_some()
-                        || s.remote_tracking_branch_segment_id.is_some()
-                    {
+                    if s.metadata.is_some() || s.sibling_segment_id.is_some() {
                         continue;
                     }
                 }

--- a/crates/but-graph/src/projection/stack.rs
+++ b/crates/but-graph/src/projection/stack.rs
@@ -447,10 +447,9 @@ impl StackSegment {
             0
         };
         format!(
-            "{ep}{meta}:{id}:{ref_name_remote}{local_commits}{remote_commits}",
+            "{ep}{meta}:{ref_name_remote}{local_commits}{remote_commits}",
             ep = if self.is_entrypoint { "👉" } else { "" },
             meta = if self.metadata.is_some() { "📙" } else { "" },
-            id = self.id.index(),
             local_commits = if num_local_commits == 0 {
                 "".into()
             } else {

--- a/crates/but-graph/src/projection/stack.rs
+++ b/crates/but-graph/src/projection/stack.rs
@@ -195,11 +195,6 @@ pub struct StackSegment {
     /// The name of the remote tracking branch of this segment, if present, i.e. `refs/remotes/origin/main`.
     /// Its presence means [`commits_outside`](Self::commits_outside) are possibly available.
     pub remote_tracking_ref_name: Option<gix::refs::FullName>,
-    /// If `remote_tracking_ref_name` is `None`, and `ref_name` is a remote tracking branch, then this is set to be
-    /// the segment id of the local tracking branch, effectively doubly-linking them for ease of traversal.
-    /// If `ref_name` is `None` and this segment is the ancestor of a named segment that is known to a workspace,
-    /// this id is pointing to that named segment to allow the reconstruction of the originally desired workspace.
-    pub sibling_segment_id: Option<SegmentIndex>,
     /// If `remote_tracking_ref_name` is set, this field is also set to make accessing the respective segment easy,
     /// avoiding a search through the entire graph.
     /// It *only* ever points to the remote tracking branch segment.
@@ -320,7 +315,7 @@ impl StackSegment {
             generation: _,
             ref_info: ref ref_name,
             ref remote_tracking_ref_name,
-            sibling_segment_id,
+            sibling_segment_id: _,
             remote_tracking_branch_segment_id,
             commits: _,
             ref metadata,
@@ -382,7 +377,6 @@ impl StackSegment {
             ref_info: ref_name.clone(),
             id,
             remote_tracking_ref_name: remote_tracking_ref_name.clone(),
-            sibling_segment_id,
             remote_tracking_branch_segment_id,
             // `base` is set later in the context of the entire stack.
             base: None,
@@ -426,7 +420,6 @@ impl StackSegment {
         self.debug_string_with_ref_name_remote(Graph::ref_and_remote_debug_string(
             self.ref_info.as_ref(),
             self.remote_tracking_ref_name.as_ref(),
-            self.sibling_segment_id,
             self.remote_tracking_branch_segment_id,
         ))
     }
@@ -437,7 +430,6 @@ impl StackSegment {
             graph.ref_and_remote_debug_string_with_graph_context(
                 self.ref_info.as_ref(),
                 self.remote_tracking_ref_name.as_ref(),
-                self.sibling_segment_id,
                 self.remote_tracking_branch_segment_id,
             ),
         )

--- a/crates/but-graph/src/projection/stack.rs
+++ b/crates/but-graph/src/projection/stack.rs
@@ -420,7 +420,6 @@ impl StackSegment {
         self.debug_string_with_ref_name_remote(Graph::ref_and_remote_debug_string(
             self.ref_info.as_ref(),
             self.remote_tracking_ref_name.as_ref(),
-            self.remote_tracking_branch_segment_id,
         ))
     }
 
@@ -430,7 +429,6 @@ impl StackSegment {
             graph.ref_and_remote_debug_string_with_graph_context(
                 self.ref_info.as_ref(),
                 self.remote_tracking_ref_name.as_ref(),
-                self.remote_tracking_branch_segment_id,
             ),
         )
     }

--- a/crates/but-graph/src/projection/workspace/api/mod.rs
+++ b/crates/but-graph/src/projection/workspace/api/mod.rs
@@ -495,9 +495,8 @@ impl Workspace {
             },
         );
         format!(
-            "{meta}{sign}:{id}:{name} <> ✓{target}{bound}",
+            "{meta}{sign}:{name} <> ✓{target}{bound}",
             meta = if self.metadata.is_some() { "📕" } else { "" },
-            id = self.id.index(),
             bound = self
                 .lower_bound
                 .map(|base| format!(" on {}", base.to_hex_with_len(7)))

--- a/crates/but-graph/tests/graph/init/mod.rs
+++ b/crates/but-graph/tests/graph/init/mod.rs
@@ -341,8 +341,8 @@ fn shallow_clone_stops_at_shallow_boundary() -> anyhow::Result<()> {
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
 ⌂:0:main[🌳] <> ✓refs/remotes/origin/main on 71a64f3
-└── ≡:0:main[🌳] <> origin/main →:1: on 71a64f3 {1}
-    └── :0:main[🌳] <> origin/main →:1:
+└── ≡:0:main[🌳] <> origin/main on 71a64f3 {1}
+    └── :0:main[🌳] <> origin/main
 
 "#]]
     );
@@ -459,8 +459,8 @@ fn main_advanced_remote_advanced() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 ⌂:0:main[🌳] <> ✓refs/remotes/origin/main⇣1 on ce09734
-└── ≡:0:main[🌳] <> origin/main →:1:⇡1⇣1 on ce09734 {1}
-    └── :0:main[🌳] <> origin/main →:1:⇡1⇣1
+└── ≡:0:main[🌳] <> origin/main⇡1⇣1 on ce09734 {1}
+    └── :0:main[🌳] <> origin/main⇡1⇣1
         ├── 🟣5d29d62
         └── ·971953d
 
@@ -513,8 +513,8 @@ fn only_remote_advanced() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 ⌂:0:main[🌳] <> ✓refs/remotes/origin/main⇣2 on 971953d
-└── ≡:0:main[🌳] <> origin/main →:1:⇣1 on 971953d {1}
-    └── :0:main[🌳] <> origin/main →:1:⇣1
+└── ≡:0:main[🌳] <> origin/main⇣1 on 971953d {1}
+    └── :0:main[🌳] <> origin/main⇣1
         └── 🟣085535d
 
 "#]]
@@ -568,8 +568,8 @@ fn only_remote_advanced_with_special_branch_name() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 ⌂:0:main[🌳] <> ✓refs/remotes/origin/main⇣2 on 971953d
-└── ≡:0:main[🌳] <> origin/main →:1:⇣1 on 971953d {1}
-    └── :0:main[🌳] <> origin/main →:1:⇣1
+└── ≡:0:main[🌳] <> origin/main⇣1 on 971953d {1}
+    └── :0:main[🌳] <> origin/main⇣1
         └── 🟣085535d
 
 "#]]
@@ -1151,11 +1151,11 @@ fn stacked_rebased_remotes() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 ⌂:0:B[🌳] <> ✓refs/remotes/origin/B⇣2 on fafd9d0
-└── ≡:0:B[🌳] <> origin/B →:1:⇡1⇣1 on fafd9d0 {1}
-    ├── :0:B[🌳] <> origin/B →:1:⇡1⇣1
+└── ≡:0:B[🌳] <> origin/B⇡1⇣1 on fafd9d0 {1}
+    ├── :0:B[🌳] <> origin/B⇡1⇣1
     │   ├── 🟣682be32
     │   └── ·312f819
-    └── :2:A <> origin/A →:3:⇡1⇣1
+    └── :2:A <> origin/A⇡1⇣1
         ├── 🟣e29c23d
         └── ·e255adc
 
@@ -1196,8 +1196,8 @@ fn stacked_rebased_remotes() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 ⌂:0:B[🌳] <> ✓refs/remotes/origin/B⇣1 on 312f819
-└── ≡:0:B[🌳] <> origin/B →:1:⇣1 on 312f819 {1}
-    └── :0:B[🌳] <> origin/B →:1:⇣1
+└── ≡:0:B[🌳] <> origin/B⇣1 on 312f819 {1}
+    └── :0:B[🌳] <> origin/B⇣1
         └── 🟣682be32
 
 "#]]
@@ -1256,8 +1256,8 @@ fn stacked_rebased_remotes() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 ⌂:0:A <> ✓refs/remotes/origin/A⇣1 on fafd9d0
-└── ≡:0:A <> origin/A →:1:⇡1⇣1 on fafd9d0 {1}
-    └── :0:A <> origin/A →:1:⇡1⇣1
+└── ≡:0:A <> origin/A⇡1⇣1 on fafd9d0 {1}
+    └── :0:A <> origin/A⇡1⇣1
         ├── 🟣e29c23d
         └── ·e255adc
 

--- a/crates/but-graph/tests/graph/init/mod.rs
+++ b/crates/but-graph/tests/graph/init/mod.rs
@@ -86,9 +86,9 @@ Graph {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-⌂:0:main[🌳] <> ✓!
-└── ≡:0:main[🌳] {1}
-    └── :0:main[🌳]
+⌂:main[🌳] <> ✓!
+└── ≡:main[🌳] {1}
+    └── :main[🌳]
 
 "#]]
     );
@@ -252,11 +252,11 @@ Graph {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-⌂:0:DETACHED <> ✓!
-└── ≡:0:anon: {1}
-    ├── :0:anon:
+⌂:DETACHED <> ✓!
+└── ≡:anon: {1}
+    ├── :anon:
     │   └── ·541396b ►tags/annotated, ►tags/release/v1, ►main
-    └── :1:other
+    └── :other
         └── ·fafd9d0
 
 "#]]
@@ -340,9 +340,9 @@ fn shallow_clone_stops_at_shallow_boundary() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-⌂:0:main[🌳] <> ✓refs/remotes/origin/main on 71a64f3
-└── ≡:0:main[🌳] <> origin/main on 71a64f3 {1}
-    └── :0:main[🌳] <> origin/main
+⌂:main[🌳] <> ✓refs/remotes/origin/main on 71a64f3
+└── ≡:main[🌳] <> origin/main on 71a64f3 {1}
+    └── :main[🌳] <> origin/main
 
 "#]]
     );
@@ -405,13 +405,13 @@ fn merge_first_parent_older_non_workspace_maintains_graph_order() -> anyhow::Res
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-⌂:0:first-parent[🌳] <> ✓!
-└── ≡:0:first-parent[🌳] {1}
-    ├── :0:first-parent[🌳]
+⌂:first-parent[🌳] <> ✓!
+└── ≡:first-parent[🌳] {1}
+    ├── :first-parent[🌳]
     │   ├── ·738ea18
     │   ├── ·408ca26
     │   └── ·2854fa2
-    └── :4:main
+    └── :main
         └── ·793a434 ►tags/base
 
 "#]]
@@ -458,9 +458,9 @@ fn main_advanced_remote_advanced() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-⌂:0:main[🌳] <> ✓refs/remotes/origin/main⇣1 on ce09734
-└── ≡:0:main[🌳] <> origin/main⇡1⇣1 on ce09734 {1}
-    └── :0:main[🌳] <> origin/main⇡1⇣1
+⌂:main[🌳] <> ✓refs/remotes/origin/main⇣1 on ce09734
+└── ≡:main[🌳] <> origin/main⇡1⇣1 on ce09734 {1}
+    └── :main[🌳] <> origin/main⇡1⇣1
         ├── 🟣5d29d62
         └── ·971953d
 
@@ -512,9 +512,9 @@ fn only_remote_advanced() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-⌂:0:main[🌳] <> ✓refs/remotes/origin/main⇣2 on 971953d
-└── ≡:0:main[🌳] <> origin/main⇣1 on 971953d {1}
-    └── :0:main[🌳] <> origin/main⇣1
+⌂:main[🌳] <> ✓refs/remotes/origin/main⇣2 on 971953d
+└── ≡:main[🌳] <> origin/main⇣1 on 971953d {1}
+    └── :main[🌳] <> origin/main⇣1
         └── 🟣085535d
 
 "#]]
@@ -567,9 +567,9 @@ fn only_remote_advanced_with_special_branch_name() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-⌂:0:main[🌳] <> ✓refs/remotes/origin/main⇣2 on 971953d
-└── ≡:0:main[🌳] <> origin/main⇣1 on 971953d {1}
-    └── :0:main[🌳] <> origin/main⇣1
+⌂:main[🌳] <> ✓refs/remotes/origin/main⇣2 on 971953d
+└── ≡:main[🌳] <> origin/main⇣1 on 971953d {1}
+    └── :main[🌳] <> origin/main⇣1
         └── 🟣085535d
 
 "#]]
@@ -638,9 +638,9 @@ fn multi_root() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-⌂:0:main[🌳] <> ✓!
-└── ≡:0:main[🌳] {1}
-    └── :0:main[🌳]
+⌂:main[🌳] <> ✓!
+└── ≡:main[🌳] {1}
+    └── :main[🌳]
         ├── ·c6c8c05
         ├── ·76fc5c4
         └── ·e5d0542
@@ -723,14 +723,14 @@ fn four_diamond() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-⌂:0:merged[🌳] <> ✓!
-└── ≡:0:merged[🌳] {1}
-    ├── :0:merged[🌳]
+⌂:merged[🌳] <> ✓!
+└── ≡:merged[🌳] {1}
+    ├── :merged[🌳]
     │   └── ·8a6c109
-    ├── :1:A
+    ├── :A
     │   ├── ·62b409a
     │   └── ·592abec
-    └── :7:main
+    └── :main
         └── ·965998b
 
 "#]]
@@ -1079,11 +1079,11 @@ fn explicit_traversal_tips_use_integrated_tip_as_workspace_target_commit() -> an
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-⌂:2:merged[🌳] <> ✓refs/heads/A⇣3 on 965998b
-└── ≡:2:merged[🌳] on 965998b {1}
-    ├── :2:merged[🌳]
+⌂:merged[🌳] <> ✓refs/heads/A⇣3 on 965998b
+└── ≡:merged[🌳] on 965998b {1}
+    ├── :merged[🌳]
     │   └── ·8a6c109
-    └── :0:A
+    └── :A
         ├── ·62b409a (✓)
         └── ·592abec (✓)
 
@@ -1150,12 +1150,12 @@ fn stacked_rebased_remotes() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-⌂:0:B[🌳] <> ✓refs/remotes/origin/B⇣2 on fafd9d0
-└── ≡:0:B[🌳] <> origin/B⇡1⇣1 on fafd9d0 {1}
-    ├── :0:B[🌳] <> origin/B⇡1⇣1
+⌂:B[🌳] <> ✓refs/remotes/origin/B⇣2 on fafd9d0
+└── ≡:B[🌳] <> origin/B⇡1⇣1 on fafd9d0 {1}
+    ├── :B[🌳] <> origin/B⇡1⇣1
     │   ├── 🟣682be32
     │   └── ·312f819
-    └── :2:A <> origin/A⇡1⇣1
+    └── :A <> origin/A⇡1⇣1
         ├── 🟣e29c23d
         └── ·e255adc
 
@@ -1195,9 +1195,9 @@ fn stacked_rebased_remotes() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-⌂:0:B[🌳] <> ✓refs/remotes/origin/B⇣1 on 312f819
-└── ≡:0:B[🌳] <> origin/B⇣1 on 312f819 {1}
-    └── :0:B[🌳] <> origin/B⇣1
+⌂:B[🌳] <> ✓refs/remotes/origin/B⇣1 on 312f819
+└── ≡:B[🌳] <> origin/B⇣1 on 312f819 {1}
+    └── :B[🌳] <> origin/B⇣1
         └── 🟣682be32
 
 "#]]
@@ -1255,9 +1255,9 @@ fn stacked_rebased_remotes() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-⌂:0:A <> ✓refs/remotes/origin/A⇣1 on fafd9d0
-└── ≡:0:A <> origin/A⇡1⇣1 on fafd9d0 {1}
-    └── :0:A <> origin/A⇡1⇣1
+⌂:A <> ✓refs/remotes/origin/A⇣1 on fafd9d0
+└── ≡:A <> origin/A⇡1⇣1 on fafd9d0 {1}
+    └── :A <> origin/A⇡1⇣1
         ├── 🟣e29c23d
         └── ·e255adc
 
@@ -1335,14 +1335,14 @@ fn with_limits() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-⌂:0:C[🌳] <> ✓!
-└── ≡:0:C[🌳] {1}
-    ├── :0:C[🌳]
+⌂:C[🌳] <> ✓!
+└── ≡:C[🌳] {1}
+    ├── :C[🌳]
     │   ├── ·2a95729
     │   ├── ·6861158
     │   ├── ·4f1f248
     │   └── ·487ffce
-    └── :4:main
+    └── :main
         ├── ·edc4dee
         ├── ·01d0e1e
         ├── ·4b3e5a8
@@ -1373,9 +1373,9 @@ fn with_limits() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-⌂:0:C[🌳] <> ✓!
-└── ≡:0:C[🌳] {1}
-    └── :0:C[🌳]
+⌂:C[🌳] <> ✓!
+└── ≡:C[🌳] {1}
+    └── :C[🌳]
         └── ✂️·2a95729
 
 "#]]
@@ -1406,9 +1406,9 @@ fn with_limits() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-⌂:0:C[🌳] <> ✓!
-└── ≡:0:C[🌳] {1}
-    └── :0:C[🌳]
+⌂:C[🌳] <> ✓!
+└── ≡:C[🌳] {1}
+    └── :C[🌳]
         ├── ·2a95729
         └── ✂️·6861158
 
@@ -1471,9 +1471,9 @@ fn with_limits() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-⌂:0:C[🌳] <> ✓!
-└── ≡:0:C[🌳] {1}
-    └── :0:C[🌳]
+⌂:C[🌳] <> ✓!
+└── ≡:C[🌳] {1}
+    └── :C[🌳]
         ├── ·2a95729
         ├── ·6861158
         └── ✂️·4f1f248
@@ -1513,9 +1513,9 @@ fn with_limits() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-⌂:0:C[🌳] <> ✓!
-└── ≡:0:C[🌳] {1}
-    └── :0:C[🌳]
+⌂:C[🌳] <> ✓!
+└── ≡:C[🌳] {1}
+    └── :C[🌳]
         ├── ·2a95729
         ├── ·6861158
         └── ✂️·4f1f248
@@ -1614,9 +1614,9 @@ Statistics {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-⌂:0:C[🌳] <> ✓!
-└── ≡:0:C[🌳] {1}
-    └── :0:C[🌳]
+⌂:C[🌳] <> ✓!
+└── ≡:C[🌳] {1}
+    └── :C[🌳]
         ├── ·2a95729
         ├── ·6861158
         ├── ·4f1f248
@@ -1667,9 +1667,9 @@ Statistics {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-⌂:0:C[🌳] <> ✓! on edc4dee
-└── ≡:0:C[🌳] on edc4dee {1}
-    └── :0:C[🌳]
+⌂:C[🌳] <> ✓! on edc4dee
+└── ≡:C[🌳] on edc4dee {1}
+    └── :C[🌳]
         ├── ·2a95729
         ├── ·6861158
         ├── ·4f1f248
@@ -1718,9 +1718,9 @@ fn special_branch_names_do_not_end_up_in_segment() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-⌂:0:main[🌳] <> ✓!
-└── ≡:0:main[🌳] {1}
-    └── :0:main[🌳]
+⌂:main[🌳] <> ✓!
+└── ≡:main[🌳] {1}
+    └── :main[🌳]
         ├── ·3686017
         ├── ·9725482
         └── ·fafd9d0
@@ -1764,9 +1764,9 @@ fn ambiguous_worktrees() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-⌂:0:main[🌳@repo] <> ✓!
-└── ≡:0:main[🌳@repo] {1}
-    └── :0:main[🌳@repo]
+⌂:main[🌳@repo] <> ✓!
+└── ≡:main[🌳@repo] {1}
+    └── :main[🌳@repo]
         └── ·85efbe4 ►wt-inside-ambiguous-worktree[📁], ►wt-outside-ambiguous-worktree[📁]
 
 "#]]
@@ -1805,9 +1805,9 @@ fn ambiguous_worktrees() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-⌂:0:wt-inside-ambiguous-worktree[📁@repo] <> ✓!
-└── ≡:0:wt-inside-ambiguous-worktree[📁@repo] {1}
-    └── :0:wt-inside-ambiguous-worktree[📁@repo]
+⌂:wt-inside-ambiguous-worktree[📁@repo] <> ✓!
+└── ≡:wt-inside-ambiguous-worktree[📁@repo] {1}
+    └── :wt-inside-ambiguous-worktree[📁@repo]
         └── ·85efbe4 ►main[🌳], ►wt-outside-ambiguous-worktree[📁]
 
 "#]]
@@ -2133,10 +2133,10 @@ fn ad_hoc_same_tip_order_creates_empty_branch_segments() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-⌂:1:top <> ✓!
-└── ≡:1:top {1}
-    ├── :1:top
-    └── :0:bottom
+⌂:top <> ✓!
+└── ≡:top {1}
+    ├── :top
+    └── :bottom
         └── ·960152d ►main[🌳]
 
 "#]]
@@ -2172,9 +2172,9 @@ fn ad_hoc_order_projects_from_entrypoint_when_top_is_above_it() -> anyhow::Resul
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-⌂:0:bottom <> ✓!
-└── ≡:0:bottom {1}
-    └── :0:bottom
+⌂:bottom <> ✓!
+└── ≡:bottom {1}
+    └── :bottom
         └── ·960152d ►main[🌳]
 
 "#]]
@@ -2215,11 +2215,11 @@ fn ad_hoc_three_branch_order_preserves_middle_empty_segment() -> anyhow::Result<
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-⌂:1:top <> ✓!
-└── ≡:1:top {1}
-    ├── :1:top
-    ├── :2:middle
-    └── :0:bottom
+⌂:top <> ✓!
+└── ≡:top {1}
+    ├── :top
+    ├── :middle
+    └── :bottom
         └── ·960152d ►main[🌳]
 
 "#]]
@@ -2255,10 +2255,10 @@ fn ad_hoc_order_ignores_missing_metadata_refs_without_phantoms() -> anyhow::Resu
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-⌂:1:top <> ✓!
-└── ≡:1:top {1}
-    ├── :1:top
-    └── :0:bottom
+⌂:top <> ✓!
+└── ≡:top {1}
+    ├── :top
+    └── :bottom
         └── ·960152d ►main[🌳]
 
 "#]]
@@ -2298,9 +2298,9 @@ fn ad_hoc_order_does_not_force_diverged_refs_into_empty_stack() -> anyhow::Resul
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-⌂:0:top <> ✓!
-└── ≡:0:top {1}
-    └── :0:top
+⌂:top <> ✓!
+└── ≡:top {1}
+    └── :top
         ├── ·5cd63e5
         └── ·fa91c94 ►bottom, ►main[🌳]
 
@@ -2339,14 +2339,14 @@ fn ad_hoc_order_preserves_empty_top_above_commit_owning_branch() -> anyhow::Resu
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-⌂:3:empty-top <> ✓!
-└── ≡:3:empty-top {1}
-    ├── :3:empty-top
-    ├── :0:commit-branch
+⌂:empty-top <> ✓!
+└── ≡:empty-top {1}
+    ├── :empty-top
+    ├── :commit-branch
     │   └── ·4782705
-    ├── :1:bottom
+    ├── :bottom
     │   └── ·dbc3a4c
-    └── :2:main[🌳]
+    └── :main[🌳]
         └── ·67b14ca
 
 "#]]
@@ -2389,15 +2389,15 @@ fn ad_hoc_order_keeps_lower_empty_branches_after_non_empty_move() -> anyhow::Res
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-⌂:0:commit-branch <> ✓!
-└── ≡:0:commit-branch {1}
-    ├── :0:commit-branch
+⌂:commit-branch <> ✓!
+└── ≡:commit-branch {1}
+    ├── :commit-branch
     │   └── ·5380c0a
-    ├── :3:empty-top
-    ├── :4:empty-low
-    ├── :2:base
+    ├── :empty-top
+    ├── :empty-low
+    ├── :base
     │   └── ·a5cd64d
-    └── :1:main[🌳]
+    └── :main[🌳]
         └── ·67b14ca
 
 "#]]
@@ -2449,10 +2449,10 @@ fn ad_hoc_order_scopes_empty_segments_to_active_chain() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-⌂:1:top <> ✓!
-└── ≡:1:top {1}
-    ├── :1:top
-    └── :0:bottom
+⌂:top <> ✓!
+└── ≡:top {1}
+    ├── :top
+    └── :bottom
         └── ·960152d ►main[🌳], ►other-bottom, ►other-top
 
 "#]]
@@ -2505,9 +2505,9 @@ fn ad_hoc_branch_at_target_tip_rests_on_the_target_tip() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-⌂:0:feature[🌳] <> ✓refs/remotes/origin/main on d1b2aed
-└── ≡:0:feature[🌳] on d1b2aed {1}
-    └── :0:feature[🌳]
+⌂:feature[🌳] <> ✓refs/remotes/origin/main on d1b2aed
+└── ≡:feature[🌳] on d1b2aed {1}
+    └── :feature[🌳]
 
 "#]]
     );

--- a/crates/but-graph/tests/graph/init/with_workspace.rs
+++ b/crates/but-graph/tests/graph/init/with_workspace.rs
@@ -91,14 +91,14 @@ Commit(59a427f, ⌂|🏘)
     snapbox::assert_data_eq!(
         graph_workspace(ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on fafd9d0
-├── ≡:1:main <> origin/main⇡1⇣1 on fafd9d0
-│   └── :1:main <> origin/main⇡1⇣1
+📕🏘️:gitbutler/workspace[🌳] <> ✓! on fafd9d0
+├── ≡:main <> origin/main⇡1⇣1 on fafd9d0
+│   └── :main <> origin/main⇡1⇣1
 │       ├── 🟣1f5c47b
 │       ├── ·0a415d8 (🏘️)
 │       └── ❄️73ba99d (🏘️)
-└── ≡:3:A on fafd9d0
-    └── :3:A
+└── ≡:A on fafd9d0
+    └── :A
         ├── ·a62b0de (🏘️)
         └── ·120a217 (🏘️)
 
@@ -155,7 +155,7 @@ fn workspace_with_only_local_target() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 0a415d8
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 0a415d8
 
 "#]]
     );
@@ -195,14 +195,14 @@ fn reproduce_11483() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
-├── ≡📙:3:A on 3183e43 {1}
-│   └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+├── ≡📙:A on 3183e43 {1}
+│   └── 📙:A
 │       └── ·7236012 (🏘️)
-└── ≡📙:4:B on 3183e43 {2}
-    ├── 📙:4:B
+└── ≡📙:B on 3183e43 {2}
+    ├── 📙:B
     │   └── ·68c8a9d (🏘️)
-    └── 📙:5:below
+    └── 📙:below
 
 "#]]
     );
@@ -222,13 +222,13 @@ fn reproduce_11483() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
-├── ≡📙:3:A on 3183e43 {1}
-│   ├── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+├── ≡📙:A on 3183e43 {1}
+│   ├── 📙:A
 │   │   └── ·7236012 (🏘️)
-│   └── 📙:5:below
-└── ≡📙:4:B on 3183e43 {2}
-    └── 📙:4:B
+│   └── 📙:below
+└── ≡📙:B on 3183e43 {2}
+    └── 📙:B
         └── ·68c8a9d (🏘️)
 
 "#]]
@@ -285,12 +285,12 @@ fn workspace_projection_with_advanced_stack_tip() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-└── ≡📙:5:B on 85efbe4 {1}
-    ├── 📙:5:B
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+└── ≡📙:B on 85efbe4 {1}
+    ├── 📙:B
     │   ├── ·cc0bf57*
     │   └── ·d69fe94 (🏘️)
-    └── 📙:4:A
+    └── 📙:A
         └── ·09d8e52 (🏘️)
 
 "#]]
@@ -338,13 +338,13 @@ fn no_overzealous_stacks_due_to_workspace_metadata() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
-├── ≡:7:anon: on a821094 {2}
-│   └── :7:anon:
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+├── ≡:anon: on a821094 {2}
+│   └── :anon:
 │       ├── ·835086d (🏘️) ►four, ►three
 │       └── ·ff310d3 (🏘️)
-└── ≡📙:3:X <> origin/X⇡1 on 3183e43 {1}
-    └── 📙:3:X <> origin/X⇡1
+└── ≡📙:X <> origin/X⇡1 on 3183e43 {1}
+    └── 📙:X <> origin/X⇡1
         ├── ·0b203b5 (🏘️)
         └── ❄️4840f3b (🏘️)
 
@@ -421,9 +421,9 @@ fn single_stack_ambiguous() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡:3:B <> origin/B⇡3 on fafd9d0
-    └── :3:B <> origin/B⇡3
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡:B <> origin/B⇡3 on fafd9d0
+    └── :B <> origin/B⇡3
         ├── ·70e9a36 (🏘️)
         ├── ·320e105 (🏘️) ►tags/without-ref
         ├── ·2a31450 (🏘️) ►B-empty, ►ambiguous-01
@@ -485,11 +485,11 @@ fn single_stack_ambiguous() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:1:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡:4:B <> origin/B⇡1 on fafd9d0
-    ├── :4:B <> origin/B⇡1
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡:B <> origin/B⇡1 on fafd9d0
+    ├── :B <> origin/B⇡1
     │   └── ·70e9a36 (🏘️)
-    └── 👉:0:tags/without-ref
+    └── 👉:tags/without-ref
         ├── ·320e105 (🏘️)
         ├── ·2a31450 (🏘️) ►B-empty, ►ambiguous-01
         └── ❄70bde6b (🏘️) ►A, ►A-empty-01, ►A-empty-02, ►A-empty-03
@@ -548,11 +548,11 @@ fn single_stack_ambiguous() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:1:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡:4:B <> origin/B⇡1 on fafd9d0
-    ├── :4:B <> origin/B⇡1
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡:B <> origin/B⇡1 on fafd9d0
+    ├── :B <> origin/B⇡1
     │   └── ·70e9a36 (🏘️)
-    └── 👉:0:anon:
+    └── 👉:anon:
         ├── ·320e105 (🏘️) ►tags/without-ref
         ├── ·2a31450 (🏘️) ►B-empty, ►ambiguous-01
         └── ❄70bde6b (🏘️) ►A, ►A-empty-01, ►A-empty-02, ►A-empty-03
@@ -612,12 +612,12 @@ fn single_stack_ambiguous() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:1:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡:4:B <> origin/B⇡2 on fafd9d0
-    ├── :4:B <> origin/B⇡2
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡:B <> origin/B⇡2 on fafd9d0
+    ├── :B <> origin/B⇡2
     │   ├── ·70e9a36 (🏘️)
     │   └── ·320e105 (🏘️) ►tags/without-ref
-    └── 👉:0:anon:
+    └── 👉:anon:
         ├── ·2a31450 (🏘️) ►B-empty, ►ambiguous-01
         └── ❄70bde6b (🏘️) ►A, ►A-empty-01, ►A-empty-02, ►A-empty-03
 
@@ -673,12 +673,12 @@ fn single_stack_ambiguous() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:1:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡:4:B <> origin/B⇡2 on fafd9d0
-    ├── :4:B <> origin/B⇡2
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡:B <> origin/B⇡2 on fafd9d0
+    ├── :B <> origin/B⇡2
     │   ├── ·70e9a36 (🏘️)
     │   └── ·320e105 (🏘️) ►tags/without-ref
-    └── 👉:0:B-empty
+    └── 👉:B-empty
         ├── ·2a31450 (🏘️) ►ambiguous-01
         └── ❄70bde6b (🏘️) ►A, ►A-empty-01, ►A-empty-02, ►A-empty-03
 
@@ -765,16 +765,16 @@ fn single_stack_ws_insertions() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡📙:4:B <> origin/B⇡2 on fafd9d0 {0}
-    ├── 📙:4:B <> origin/B⇡2
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡📙:B <> origin/B⇡2 on fafd9d0 {0}
+    ├── 📙:B <> origin/B⇡2
     │   ├── ·70e9a36 (🏘️)
     │   └── ·320e105 (🏘️) ►tags/without-ref
-    ├── 📙:3:B-empty
+    ├── 📙:B-empty
     │   └── ·2a31450 (🏘️) ►ambiguous-01
-    ├── 📙:7:A-empty-03
-    ├── 📙:8:A-empty-01
-    └── 📙:9:A
+    ├── 📙:A-empty-03
+    ├── 📙:A-empty-01
+    └── 📙:A
         └── ❄70bde6b (🏘️) ►A-empty-02
 
 "#]]
@@ -834,14 +834,14 @@ fn single_stack_ws_insertions() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡📙:4:B <> origin/B⇡2 on fafd9d0 {0}
-    ├── 📙:4:B <> origin/B⇡2
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡📙:B <> origin/B⇡2 on fafd9d0 {0}
+    ├── 📙:B <> origin/B⇡2
     │   ├── ·70e9a36 (🏘️)
     │   └── ·320e105 (🏘️) ►tags/without-ref
-    ├── 📙:3:B-empty
+    ├── 📙:B-empty
     │   └── ·2a31450 (🏘️) ►ambiguous-01
-    └── 📙:10:A
+    └── 📙:A
         └── ❄70bde6b (🏘️)
 
 "#]]
@@ -898,14 +898,14 @@ fn single_stack_ws_insertions() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:1:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡📙:5:B <> origin/B⇡2 on fafd9d0 {1}
-    ├── 📙:5:B <> origin/B⇡2
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡📙:B <> origin/B⇡2 on fafd9d0 {1}
+    ├── 📙:B <> origin/B⇡2
     │   ├── ·70e9a36 (🏘️)
     │   └── ·320e105 (🏘️) ►tags/without-ref
-    ├── 📙:4:B-empty
+    ├── 📙:B-empty
     │   └── ·2a31450 (🏘️) ►ambiguous-01
-    └── 👉📙:8:A-empty-01
+    └── 👉📙:A-empty-01
         └── ❄70bde6b (🏘️) ►A-empty-02, ►A-empty-03
 
 "#]]
@@ -929,19 +929,19 @@ fn single_stack_ws_insertions() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:1:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-├── ≡📙:5:B <> origin/B⇡2 on fafd9d0 {1}
-│   ├── 📙:5:B <> origin/B⇡2
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+├── ≡📙:B <> origin/B⇡2 on fafd9d0 {1}
+│   ├── 📙:B <> origin/B⇡2
 │   │   ├── ·70e9a36 (🏘️)
 │   │   └── ·320e105 (🏘️) ►tags/without-ref
-│   ├── 📙:4:B-empty
+│   ├── 📙:B-empty
 │   │   └── ·2a31450 (🏘️) ►ambiguous-01
-│   └── 📙:10:A-empty-01
+│   └── 📙:A-empty-01
 │       └── ❄70bde6b (🏘️) ►A-empty-02, ►A-empty-03
-├── ≡👉📙:7:new-A on fafd9d0 {2}
-│   └── 👉📙:7:new-A
-└── ≡📙:8:new-B on fafd9d0 {3}
-    └── 📙:8:new-B
+├── ≡👉📙:new-A on fafd9d0 {2}
+│   └── 👉📙:new-A
+└── ≡📙:new-B on fafd9d0 {3}
+    └── 📙:new-B
 
 "#]]
     );
@@ -996,13 +996,13 @@ fn single_stack() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡:3:B on fafd9d0
-    ├── :3:B
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡:B on fafd9d0
+    ├── :B
     │   └── ·320e105 (🏘️)
-    ├── :4:B-sub
+    ├── :B-sub
     │   └── ·2a31450 (🏘️)
-    └── :5:A
+    └── :A
         └── ·70bde6b (🏘️)
 
 "#]]
@@ -1049,16 +1049,16 @@ fn single_stack() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-├── ≡📙:3:B on fafd9d0 {0}
-│   ├── 📙:3:B
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+├── ≡📙:B on fafd9d0 {0}
+│   ├── 📙:B
 │   │   └── ·320e105 (🏘️)
-│   ├── 📙:4:B-sub
+│   ├── 📙:B-sub
 │   │   └── ·2a31450 (🏘️)
-│   └── 📙:5:A
+│   └── 📙:A
 │       └── ·70bde6b (🏘️)
-└── ≡📙:6:new-A on fafd9d0 {1}
-    └── 📙:6:new-A
+└── ≡📙:new-A on fafd9d0 {1}
+    └── 📙:new-A
 
 "#]]
     );
@@ -1100,11 +1100,11 @@ fn single_merge_into_main_base_archived() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 0cc5a6f
-└── ≡📙:3:C on 0cc5a6f {0}
-    ├── 📙:3:C
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 0cc5a6f
+└── ≡📙:C on 0cc5a6f {0}
+    ├── 📙:C
     │   └── ·c6d714c (🏘️)
-    └── 📙:7:merge
+    └── 📙:merge
 
 "#]]
     );
@@ -1126,9 +1126,9 @@ fn single_merge_into_main_base_archived() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 0cc5a6f
-└── ≡📙:3:C {0}
-    └── 📙:3:C
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 0cc5a6f
+└── ≡📙:C {0}
+    └── 📙:C
         └── ·c6d714c (🏘️)
 
 "#]]
@@ -1149,12 +1149,12 @@ fn single_merge_into_main_base_archived() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 0cc5a6f
-├── ≡📙:3:C on 0cc5a6f {0}
-│   └── 📙:3:C
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 0cc5a6f
+├── ≡📙:C on 0cc5a6f {0}
+│   └── 📙:C
 │       └── ·c6d714c (🏘️)
-└── ≡📙:7:merge on 0cc5a6f {1}
-    └── 📙:7:merge
+└── ≡📙:merge on 0cc5a6f {1}
+    └── 📙:merge
 
 "#]]
     );
@@ -1174,11 +1174,11 @@ fn single_merge_into_main_base_archived() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 0cc5a6f
-├── ≡📙:7:merge on 0cc5a6f {0}
-│   └── 📙:7:merge
-└── ≡📙:3:C on 0cc5a6f {1}
-    └── 📙:3:C
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 0cc5a6f
+├── ≡📙:merge on 0cc5a6f {0}
+│   └── 📙:merge
+└── ≡📙:C on 0cc5a6f {1}
+    └── 📙:C
         └── ·c6d714c (🏘️)
 
 "#]]
@@ -1242,9 +1242,9 @@ fn minimal_merge_no_refs() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-⌂:0:gitbutler/workspace[🌳] <> ✓!
-└── ≡:0:gitbutler/workspace[🌳] {1}
-    └── :0:gitbutler/workspace[🌳]
+⌂:gitbutler/workspace[🌳] <> ✓!
+└── ≡:gitbutler/workspace[🌳] {1}
+    └── :gitbutler/workspace[🌳]
         ├── ·47e1cf1
         ├── ·f40fb16
         ├── ·450c58a
@@ -1314,9 +1314,9 @@ fn segment_on_each_incoming_connection() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-⌂:0:entrypoint <> ✓!
-└── ≡:0:entrypoint {1}
-    └── :0:entrypoint
+⌂:entrypoint <> ✓!
+└── ≡:entrypoint {1}
+    └── :entrypoint
         ├── ·98c5aba
         ├── ·807b6ce
         ├── ·6d05486
@@ -1397,18 +1397,18 @@ fn minimal_merge() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-⌂:0:gitbutler/workspace[🌳] <> ✓!
-└── ≡:0:gitbutler/workspace[🌳] {1}
-    ├── :0:gitbutler/workspace[🌳]
+⌂:gitbutler/workspace[🌳] <> ✓!
+└── ≡:gitbutler/workspace[🌳] {1}
+    ├── :gitbutler/workspace[🌳]
     │   └── ·47e1cf1
-    ├── :1:merge-2
+    ├── :merge-2
     │   └── ·f40fb16
-    ├── :2:D
+    ├── :D
     │   ├── ·450c58a
     │   └── ·0cc5a6f ►empty-1-on-merge, ►empty-2-on-merge, ►merge
-    ├── :5:B
+    ├── :B
     │   └── ·7fdb58d
-    └── :7:main <> origin/main
+    └── :main <> origin/main
         └── ❄️fafd9d0
 
 "#]]
@@ -1463,17 +1463,17 @@ fn minimal_merge() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡:6:merge-2 on fafd9d0 {0}
-    ├── :6:merge-2
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡:merge-2 on fafd9d0 {0}
+    ├── :merge-2
     │   └── ·f40fb16 (🏘️)
-    ├── :7:D
+    ├── :D
     │   └── ·450c58a (🏘️)
-    ├── 📙:9:empty-2-on-merge
-    ├── 📙:10:empty-1-on-merge
-    ├── 📙:11:merge
+    ├── 📙:empty-2-on-merge
+    ├── 📙:empty-1-on-merge
+    ├── 📙:merge
     │   └── ·0cc5a6f (🏘️)
-    └── :4:B
+    └── :B
         └── ·7fdb58d (🏘️)
 
 "#]]
@@ -1564,14 +1564,14 @@ fn entrypoint_inside_second_parent_of_workspace_diamond_is_included() -> anyhow:
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:1:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡:5:merge-2 on fafd9d0
-    ├── :5:merge-2
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡:merge-2 on fafd9d0
+    ├── :merge-2
     │   └── ·f40fb16 (🏘️)
-    ├── 👉:0:C
+    ├── 👉:C
     │   ├── ·c6d714c (🏘️)
     │   └── ·0cc5a6f (🏘️) ►empty-1-on-merge, ►empty-2-on-merge, ►merge
-    └── :6:B
+    └── :B
         └── ·7fdb58d (🏘️)
 
 "#]]
@@ -1636,11 +1636,11 @@ fn stack_configuration_is_respected_if_one_of_them_is_an_entrypoint() -> anyhow:
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on fafd9d0
-├── ≡📙:2:A on fafd9d0 {1}
-│   └── 📙:2:A
-└── ≡📙:3:B on fafd9d0 {2}
-    └── 📙:3:B
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓! on fafd9d0
+├── ≡📙:A on fafd9d0 {1}
+│   └── 📙:A
+└── ≡📙:B on fafd9d0 {2}
+    └── 📙:B
 
 "#]]
     );
@@ -1671,11 +1671,11 @@ fn stack_configuration_is_respected_if_one_of_them_is_an_entrypoint() -> anyhow:
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:1:gitbutler/workspace[🌳] <> ✓! on fafd9d0
-├── ≡📙:2:A on fafd9d0 {1}
-│   └── 📙:2:A
-└── ≡👉📙:3:B on fafd9d0 {2}
-    └── 👉📙:3:B
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓! on fafd9d0
+├── ≡📙:A on fafd9d0 {1}
+│   └── 📙:A
+└── ≡👉📙:B on fafd9d0 {2}
+    └── 👉📙:B
 
 "#]]
     );
@@ -1706,11 +1706,11 @@ fn stack_configuration_is_respected_if_one_of_them_is_an_entrypoint() -> anyhow:
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:1:gitbutler/workspace[🌳] <> ✓! on fafd9d0
-├── ≡👉📙:2:A on fafd9d0 {1}
-│   └── 👉📙:2:A
-└── ≡📙:3:B on fafd9d0 {2}
-    └── 📙:3:B
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓! on fafd9d0
+├── ≡👉📙:A on fafd9d0 {1}
+│   └── 👉📙:A
+└── ≡📙:B on fafd9d0 {2}
+    └── 📙:B
 
 "#]]
     );
@@ -1770,9 +1770,9 @@ fn just_init_with_branches() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-⌂:0:main[🌳] <> ✓refs/remotes/origin/main
-└── ≡:0:main[🌳] <> origin/main on fafd9d0 {1}
-    └── :0:main[🌳] <> origin/main
+⌂:main[🌳] <> ✓refs/remotes/origin/main
+└── ≡:main[🌳] <> origin/main on fafd9d0 {1}
+    └── :main[🌳] <> origin/main
 
 "#]]
     );
@@ -1814,9 +1814,9 @@ fn just_init_with_branches() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace <> ✓!
-└── ≡:1:main[🌳] <> origin/main
-    └── :1:main[🌳] <> origin/main
+📕🏘️⚠️:gitbutler/workspace <> ✓!
+└── ≡:main[🌳] <> origin/main
+    └── :main[🌳] <> origin/main
         └── ❄️fafd9d0 (🏘️) ►A, ►B, ►C, ►D, ►E, ►F
 
 "#]]
@@ -1857,15 +1857,15 @@ fn just_init_with_branches() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:1:gitbutler/workspace <> ✓! on fafd9d0
-├── ≡📙:3:C on fafd9d0 {0}
-│   ├── 📙:3:C
-│   ├── 📙:4:B
-│   └── 📙:5:A
-└── ≡📙:6:D on fafd9d0 {1}
-    ├── 📙:6:D
-    ├── 📙:7:E
-    └── 📙:8:F
+📕🏘️⚠️:gitbutler/workspace <> ✓! on fafd9d0
+├── ≡📙:C on fafd9d0 {0}
+│   ├── 📙:C
+│   ├── 📙:B
+│   └── 📙:A
+└── ≡📙:D on fafd9d0 {1}
+    ├── 📙:D
+    ├── 📙:E
+    └── 📙:F
 
 "#]]
     );
@@ -1903,15 +1903,15 @@ fn just_init_with_branches() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
-├── ≡📙:3:C on fafd9d0 {0}
-│   ├── 📙:3:C
-│   ├── 📙:4:B
-│   └── 📙:5:A
-└── ≡📙:6:D on fafd9d0 {1}
-    ├── 📙:6:D
-    ├── 📙:7:E
-    └── 📙:8:F
+📕🏘️⚠️:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
+├── ≡📙:C on fafd9d0 {0}
+│   ├── 📙:C
+│   ├── 📙:B
+│   └── 📙:A
+└── ≡📙:D on fafd9d0 {1}
+    ├── 📙:D
+    ├── 📙:E
+    └── 📙:F
 
 "#]]
     );
@@ -1920,15 +1920,15 @@ fn just_init_with_branches() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws.graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:A <> ✓! on fafd9d0
-├── ≡📙:3:A on fafd9d0 {0}
-│   ├── 📙:3:A
-│   ├── 📙:4:B
-│   └── 📙:5:C
-└── ≡📙:6:D on fafd9d0 {1}
-    ├── 📙:6:D
-    ├── 📙:7:E
-    └── 📙:8:F
+📕🏘️⚠️:A <> ✓! on fafd9d0
+├── ≡📙:A on fafd9d0 {0}
+│   ├── 📙:A
+│   ├── 📙:B
+│   └── 📙:C
+└── ≡📙:D on fafd9d0 {1}
+    ├── 📙:D
+    ├── 📙:E
+    └── 📙:F
 
 "#]]
     );
@@ -1973,7 +1973,7 @@ fn just_init_with_branches() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
+📕🏘️⚠️:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
 
 "#]]
     );
@@ -2059,15 +2059,15 @@ fn tips_equivalent_to_workspace_metadata_are_order_independent() -> anyhow::Resu
     snapbox::assert_data_eq!(
         workspace_baseline_workspace.to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
-├── ≡📙:3:C on fafd9d0 {0}
-│   ├── 📙:3:C
-│   ├── 📙:4:B
-│   └── 📙:5:A
-└── ≡📙:6:D on fafd9d0 {1}
-    ├── 📙:6:D
-    ├── 📙:7:E
-    └── 📙:8:F
+📕🏘️⚠️:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
+├── ≡📙:C on fafd9d0 {0}
+│   ├── 📙:C
+│   ├── 📙:B
+│   └── 📙:A
+└── ≡📙:D on fafd9d0 {1}
+    ├── 📙:D
+    ├── 📙:E
+    └── 📙:F
 
 "#]]
     );
@@ -2142,15 +2142,15 @@ fn tips_equivalent_to_workspace_metadata_are_order_independent() -> anyhow::Resu
     snapbox::assert_data_eq!(
         explicit_workspace.to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
-├── ≡📙:3:C on fafd9d0 {0}
-│   ├── 📙:3:C
-│   ├── 📙:4:B
-│   └── 📙:5:A
-└── ≡📙:6:D on fafd9d0 {1}
-    ├── 📙:6:D
-    ├── 📙:7:E
-    └── 📙:8:F
+📕🏘️⚠️:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
+├── ≡📙:C on fafd9d0 {0}
+│   ├── 📙:C
+│   ├── 📙:B
+│   └── 📙:A
+└── ≡📙:D on fafd9d0 {1}
+    ├── 📙:D
+    ├── 📙:E
+    └── 📙:F
 
 "#]]
     );
@@ -2313,11 +2313,11 @@ fn just_init_with_archived_branches() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡📙:3:C on fafd9d0 {0}
-    ├── 📙:3:C
-    ├── 📙:4:B
-    └── 📙:5:A
+📕🏘️⚠️:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡📙:C on fafd9d0 {0}
+    ├── 📙:C
+    ├── 📙:B
+    └── 📙:A
 
 "#]]
     );
@@ -2337,9 +2337,9 @@ fn just_init_with_archived_branches() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡📙:3:C {0}
-    └── 📙:3:C
+📕🏘️⚠️:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡📙:C {0}
+    └── 📙:C
 
 "#]]
     );
@@ -2356,10 +2356,10 @@ fn just_init_with_archived_branches() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡📙:3:C {0}
-    ├── 📙:3:C
-    └── 📙:4:B
+📕🏘️⚠️:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡📙:C {0}
+    ├── 📙:C
+    └── 📙:B
 
 "#]]
     );
@@ -2376,7 +2376,7 @@ fn just_init_with_archived_branches() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
+📕🏘️⚠️:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
 
 "#]]
     );
@@ -2441,9 +2441,9 @@ fn two_stacks_many_refs() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡:3:anon: on fafd9d0
-    └── :3:anon:
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡:anon: on fafd9d0
+    └── :anon:
         ├── ·16f132b (🏘️) ►F, ►G, ►S1
         └── ·917b9da (🏘️) ►D, ►E
 
@@ -2492,9 +2492,9 @@ fn two_stacks_many_refs() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:1:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡👉:0:S1 on fafd9d0
-    └── 👉:0:S1
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡👉:S1 on fafd9d0
+    └── 👉:S1
         ├── ·16f132b (🏘️) ►F, ►G
         └── ·917b9da (🏘️) ►D, ►E
 
@@ -2543,18 +2543,18 @@ fn two_stacks_many_refs() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-├── ≡📙:5:C on fafd9d0 {1}
-│   ├── 📙:5:C
-│   └── 📙:6:B
-├── ≡📙:7:A on fafd9d0 {2}
-│   └── 📙:7:A
-└── ≡📙:8:S1 on fafd9d0 {3}
-    ├── 📙:8:S1
-    ├── 📙:9:G
-    ├── 📙:10:F
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+├── ≡📙:C on fafd9d0 {1}
+│   ├── 📙:C
+│   └── 📙:B
+├── ≡📙:A on fafd9d0 {2}
+│   └── 📙:A
+└── ≡📙:S1 on fafd9d0 {3}
+    ├── 📙:S1
+    ├── 📙:G
+    ├── 📙:F
     │   └── ·16f132b (🏘️)
-    └── 📙:12:E
+    └── 📙:E
         └── ·917b9da (🏘️)
 
 "#]]
@@ -2596,18 +2596,18 @@ fn two_stacks_many_refs() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:1:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-├── ≡📙:5:C on fafd9d0 {1}
-│   ├── 📙:5:C
-│   └── 📙:6:B
-├── ≡📙:7:A on fafd9d0 {2}
-│   └── 📙:7:A
-└── ≡👉📙:8:S1 on fafd9d0 {3}
-    ├── 👉📙:8:S1
-    ├── 📙:9:G
-    ├── 📙:10:F
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+├── ≡📙:C on fafd9d0 {1}
+│   ├── 📙:C
+│   └── 📙:B
+├── ≡📙:A on fafd9d0 {2}
+│   └── 📙:A
+└── ≡👉📙:S1 on fafd9d0 {3}
+    ├── 👉📙:S1
+    ├── 📙:G
+    ├── 📙:F
     │   └── ·16f132b (🏘️)
-    └── 📙:12:E
+    └── 📙:E
         └── ·917b9da (🏘️)
 
 "#]]
@@ -2659,17 +2659,17 @@ fn just_init_with_branches_complex() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
-├── ≡📙:3:C on fafd9d0 {0}
-│   ├── 📙:3:C
-│   └── 📙:4:B
-├── ≡📙:5:A on fafd9d0 {1}
-│   └── 📙:5:A
-├── ≡📙:6:D on fafd9d0 {2}
-│   ├── 📙:6:D
-│   └── 📙:7:E
-└── ≡📙:8:F on fafd9d0 {3}
-    └── 📙:8:F
+📕🏘️⚠️:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
+├── ≡📙:C on fafd9d0 {0}
+│   ├── 📙:C
+│   └── 📙:B
+├── ≡📙:A on fafd9d0 {1}
+│   └── 📙:A
+├── ≡📙:D on fafd9d0 {2}
+│   ├── 📙:D
+│   └── 📙:E
+└── ≡📙:F on fafd9d0 {3}
+    └── 📙:F
 
 "#]]
     );
@@ -2711,17 +2711,17 @@ fn just_init_with_branches_complex() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:1:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
-├── ≡👉📙:3:C on fafd9d0 {0}
-│   ├── 👉📙:3:C
-│   └── 📙:4:B
-├── ≡📙:5:A on fafd9d0 {1}
-│   └── 📙:5:A
-├── ≡📙:6:D on fafd9d0 {2}
-│   ├── 📙:6:D
-│   └── 📙:7:E
-└── ≡📙:8:F on fafd9d0 {3}
-    └── 📙:8:F
+📕🏘️⚠️:gitbutler/workspace <> ✓refs/remotes/origin/main on fafd9d0
+├── ≡👉📙:C on fafd9d0 {0}
+│   ├── 👉📙:C
+│   └── 📙:B
+├── ≡📙:A on fafd9d0 {1}
+│   └── 📙:A
+├── ≡📙:D on fafd9d0 {2}
+│   ├── 📙:D
+│   └── 📙:E
+└── ≡📙:F on fafd9d0 {3}
+    └── 📙:F
 
 "#]]
     );
@@ -2773,7 +2773,7 @@ fn proper_remote_ahead() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣2 on 998eae6
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣2 on 998eae6
 
 "#]]
     );
@@ -2810,9 +2810,9 @@ fn proper_remote_ahead() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-⌂:0:main <> ✓refs/remotes/origin/main⇣2
-└── ≡:0:main <> origin/main⇣2 on 998eae6 {1}
-    └── :0:main <> origin/main⇣2
+⌂:main <> ✓refs/remotes/origin/main⇣2
+└── ≡:main <> origin/main⇣2 on 998eae6 {1}
+    └── :main <> origin/main⇣2
         ├── 🟣ca7baa7 (✓)
         └── 🟣7ea1468 (✓)
 
@@ -2876,9 +2876,9 @@ fn deduced_remote_ahead() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓!
-└── ≡:1:A <> origin/A⇡2⇣4
-    ├── :1:A <> origin/A⇡2⇣4
+📕🏘️:gitbutler/workspace[🌳] <> ✓!
+└── ≡:A <> origin/A⇡2⇣4
+    ├── :A <> origin/A⇡2⇣4
     │   ├── 🟣3ea1a8f
     │   ├── 🟣9c50f71
     │   ├── 🟣2cfbb79
@@ -2886,7 +2886,7 @@ fn deduced_remote_ahead() -> anyhow::Result<()> {
     │   ├── ·9d34471 (🏘️)
     │   ├── ·5b89c71 (🏘️)
     │   └── ❄️998eae6 (🏘️)
-    └── :3:main
+    └── :main
         └── ❄fafd9d0 (🏘️)
 
 "#]]
@@ -2926,9 +2926,9 @@ fn deduced_remote_ahead() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:1:gitbutler/workspace[🌳] <> ✓!
-└── ≡:2:A <> origin/A⇡2⇣4
-    ├── :2:A <> origin/A⇡2⇣4
+📕🏘️:gitbutler/workspace[🌳] <> ✓!
+└── ≡:A <> origin/A⇡2⇣4
+    ├── :A <> origin/A⇡2⇣4
     │   ├── 🟣3ea1a8f
     │   ├── 🟣9c50f71
     │   ├── 🟣2cfbb79
@@ -2936,7 +2936,7 @@ fn deduced_remote_ahead() -> anyhow::Result<()> {
     │   ├── ·9d34471 (🏘️)
     │   ├── ·5b89c71 (🏘️)
     │   └── ❄️998eae6 (🏘️)
-    └── 👉:0:main
+    └── 👉:main
         └── ❄fafd9d0 (🏘️)
 
 "#]]
@@ -2970,9 +2970,9 @@ fn deduced_remote_ahead() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓!
-└── ≡:1:A <> push-remote/A⇡2⇣4
-    ├── :1:A <> push-remote/A⇡2⇣4
+📕🏘️:gitbutler/workspace[🌳] <> ✓!
+└── ≡:A <> push-remote/A⇡2⇣4
+    ├── :A <> push-remote/A⇡2⇣4
     │   ├── 🟣3ea1a8f
     │   ├── 🟣9c50f71
     │   ├── 🟣2cfbb79
@@ -2980,7 +2980,7 @@ fn deduced_remote_ahead() -> anyhow::Result<()> {
     │   ├── ·9d34471 (🏘️)
     │   ├── ·5b89c71 (🏘️)
     │   └── ❄️998eae6 (🏘️)
-    └── :3:main
+    └── :main
         └── ❄fafd9d0 (🏘️)
 
 "#]]
@@ -3038,13 +3038,13 @@ fn stacked_rebased_remotes() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓!
-└── ≡:1:B
-    ├── :1:B
+📕🏘️:gitbutler/workspace[🌳] <> ✓!
+└── ≡:B
+    ├── :B
     │   └── ·312f819 (🏘️)
-    ├── :2:A
+    ├── :A
     │   └── ·e255adc (🏘️)
-    └── :3:main <> origin/main
+    └── :main <> origin/main
         └── ❄️fafd9d0 (🏘️)
 
 "#]]
@@ -3085,12 +3085,12 @@ fn stacked_rebased_remotes() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:1:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡:5:B <> origin/B⇡1⇣1 on fafd9d0
-    ├── :5:B <> origin/B⇡1⇣1
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡:B <> origin/B⇡1⇣1 on fafd9d0
+    ├── :B <> origin/B⇡1⇣1
     │   ├── 🟣682be32
     │   └── ·312f819 (🏘️)
-    └── 👉:0:A <> origin/A⇡1⇣1
+    └── 👉:A <> origin/A⇡1⇣1
         ├── 🟣e29c23d
         └── ·e255adc (🏘️)
 
@@ -3213,9 +3213,9 @@ fn target_with_remote_on_stack_tip() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡📙:2:A on fafd9d0 {1}
-    └── 📙:2:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡📙:A on fafd9d0 {1}
+    └── 📙:A
         └── ·e255adc (🏘️)
 
 "#]]
@@ -3234,10 +3234,10 @@ fn target_with_remote_on_stack_tip() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡📙:3:A on fafd9d0 {1}
-    ├── 📙:3:A
-    └── 📙:4:main <> origin/main⇡1
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡📙:A on fafd9d0 {1}
+    ├── 📙:A
+    └── 📙:main <> origin/main⇡1
         └── ·e255adc (🏘️)
 
 "#]]
@@ -3256,10 +3256,10 @@ fn target_with_remote_on_stack_tip() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡📙:3:main <> origin/main on fafd9d0 {1}
-    ├── 📙:3:main <> origin/main
-    └── 📙:4:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡📙:main <> origin/main on fafd9d0 {1}
+    ├── 📙:main <> origin/main
+    └── 📙:A
         └── ·e255adc (🏘️)
 
 "#]]
@@ -3345,14 +3345,14 @@ fn disambiguate_by_remote() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡:6:anon: on fafd9d0
-    ├── :6:anon:
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡:anon: on fafd9d0
+    ├── :anon:
     │   └── ·2173153 (🏘️) ►C, ►ambiguous-C
-    ├── :9:B <> origin/B⇣1
+    ├── :B <> origin/B⇣1
     │   ├── 🟣ac24e74
     │   └── ❄️312f819 (🏘️) ►ambiguous-B
-    └── :8:A <> origin/A
+    └── :A <> origin/A
         └── ❄️e255adc (🏘️) ►ambiguous-A
 
 "#]]
@@ -3404,14 +3404,14 @@ fn disambiguate_by_remote() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡📙:3:C <> origin/C on fafd9d0 {0}
-    ├── 📙:3:C <> origin/C
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡📙:C <> origin/C on fafd9d0 {0}
+    ├── 📙:C <> origin/C
     │   └── ❄️2173153 (🏘️) ►ambiguous-C
-    ├── :9:B <> origin/B⇣1
+    ├── :B <> origin/B⇣1
     │   ├── 🟣ac24e74
     │   └── ❄️312f819 (🏘️) ►ambiguous-B
-    └── :8:A <> origin/A
+    └── :A <> origin/A
         └── ❄️e255adc (🏘️) ►ambiguous-A
 
 "#]]
@@ -3498,19 +3498,19 @@ fn integrated_tips_stop_early_if_remote_is_not_configured() -> anyhow::Result<()
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓!
-└── ≡:1:B
-    ├── :1:B
+📕🏘️:gitbutler/workspace[🌳] <> ✓!
+└── ≡:B
+    ├── :B
     │   ├── ·6b1a13b (🏘️)
     │   └── ·03ad472 (🏘️)
-    ├── :2:A
+    ├── :A
     │   ├── ·79bbb29 (🏘️)
     │   ├── ·fc98174 (🏘️)
     │   ├── ·a381df5 (🏘️)
     │   ├── ·777b552 (🏘️)
     │   ├── ·ce4a760 (🏘️)
     │   └── ·01d0e1e (🏘️)
-    └── :6:main
+    └── :main
         ├── ·4b3e5a8 (🏘️)
         ├── ·34d0715 (🏘️)
         └── ·eb5f731 (🏘️)
@@ -3560,9 +3560,9 @@ fn integrated_tips_stop_early_if_remote_is_not_configured() -> anyhow::Result<()
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣6 on 79bbb29
-└── ≡📙:2:B on 79bbb29 {0}
-    └── 📙:2:B
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣6 on 79bbb29
+└── ≡📙:B on 79bbb29 {0}
+    └── 📙:B
         ├── ·6b1a13b (🏘️)
         └── ·03ad472 (🏘️)
 
@@ -3606,9 +3606,9 @@ fn integrated_tips_stop_early_if_remote_is_not_configured() -> anyhow::Result<()
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣6 on 79bbb29
-└── ≡📙:2:B on 79bbb29 {0}
-    └── 📙:2:B
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣6 on 79bbb29
+└── ≡📙:B on 79bbb29 {0}
+    └── 📙:B
         ├── ·6b1a13b (🏘️)
         └── ·03ad472 (🏘️)
 
@@ -3669,9 +3669,9 @@ fn integrated_tips_stop_early_if_remote_is_not_configured() -> anyhow::Result<()
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-⌂:0:A <> ✓refs/remotes/origin/main⇣3
-└── ≡:0:A on 79bbb29 {1}
-    └── :0:A
+⌂:A <> ✓refs/remotes/origin/main⇣3
+└── ≡:A on 79bbb29 {1}
+    └── :A
 
 "#]]
     );
@@ -3716,9 +3716,9 @@ fn integrated_tips_stop_early_if_remote_is_not_configured() -> anyhow::Result<()
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-⌂:0:A <> ✓refs/remotes/origin/main⇣6
-└── ≡:0:A on 79bbb29 {1}
-    └── :0:A
+⌂:A <> ✓refs/remotes/origin/main⇣6
+└── ≡:A on 79bbb29 {1}
+    └── :A
 
 "#]]
     );
@@ -3772,9 +3772,9 @@ fn integrated_tips_stop_early_if_remote_is_not_configured() -> anyhow::Result<()
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-⌂:0:DETACHED <> ✓refs/remotes/origin/main⇣3 on 79bbb29
-└── ≡:0:anon: on 4b3e5a8 {1}
-    └── :0:anon:
+⌂:DETACHED <> ✓refs/remotes/origin/main⇣3 on 79bbb29
+└── ≡:anon: on 4b3e5a8 {1}
+    └── :anon:
         ├── ·d0df794 (✓)
         ├── ·09c6e08 (✓)
         └── ·7b9f260 (✓)
@@ -3832,9 +3832,9 @@ fn integrated_tips_stop_early_if_remote_is_not_configured() -> anyhow::Result<()
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-⌂:0:DETACHED <> ✓refs/remotes/origin/main⇣3 on 79bbb29
-└── ≡:0:anon: on 4b3e5a8 {1}
-    └── :0:anon:
+⌂:DETACHED <> ✓refs/remotes/origin/main⇣3 on 79bbb29
+└── ≡:anon: on 4b3e5a8 {1}
+    └── :anon:
         ├── ·d0df794 (✓)
         ├── ·09c6e08 (✓)
         └── ·7b9f260 (✓)
@@ -3925,9 +3925,9 @@ fn integrated_tips_do_not_stop_early() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣3 on 79bbb29
-└── ≡:4:B on 79bbb29
-    └── :4:B
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣3 on 79bbb29
+└── ≡:B on 79bbb29
+    └── :B
         ├── ·6b1a13b (🏘️)
         └── ·03ad472 (🏘️)
 
@@ -3946,12 +3946,12 @@ fn integrated_tips_do_not_stop_early() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣3 on 4b3e5a8
-└── ≡:4:B on 4b3e5a8
-    ├── :4:B
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣3 on 4b3e5a8
+└── ≡:B on 4b3e5a8
+    ├── :B
     │   ├── ·6b1a13b (🏘️)
     │   └── ·03ad472 (🏘️)
-    └── :5:A
+    └── :A
         ├── ·79bbb29 (🏘️|✓)
         ├── ·fc98174 (🏘️|✓)
         ├── ·a381df5 (🏘️|✓)
@@ -4013,9 +4013,9 @@ fn integrated_tips_do_not_stop_early() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-⌂:0:A <> ✓refs/remotes/origin/main⇣3
-└── ≡:0:A on 79bbb29 {1}
-    └── :0:A
+⌂:A <> ✓refs/remotes/origin/main⇣3
+└── ≡:A on 79bbb29 {1}
+    └── :A
 
 "#]]
     );
@@ -4034,12 +4034,12 @@ fn integrated_tips_do_not_stop_early() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:1:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣3 on 4b3e5a8
-└── ≡:5:B on 4b3e5a8
-    ├── :5:B
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣3 on 4b3e5a8
+└── ≡:B on 4b3e5a8
+    ├── :B
     │   ├── ·6b1a13b (🏘️)
     │   └── ·03ad472 (🏘️)
-    └── 👉:0:A
+    └── 👉:A
         ├── ·79bbb29 (🏘️|✓)
         ├── ·fc98174 (🏘️|✓)
         ├── ·a381df5 (🏘️|✓)
@@ -4065,9 +4065,9 @@ fn integrated_tips_do_not_stop_early() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-⌂:0:main <> ✓refs/remotes/origin/main⇣3
-└── ≡:0:main <> origin/main⇣3 on 4b3e5a8 {1}
-    └── :0:main <> origin/main⇣3
+⌂:main <> ✓refs/remotes/origin/main⇣3
+└── ≡:main <> origin/main⇣3 on 4b3e5a8 {1}
+    └── :main <> origin/main⇣3
         ├── 🟣d0df794 (✓)
         ├── 🟣09c6e08 (✓)
         └── 🟣7b9f260 (✓)
@@ -4090,9 +4090,9 @@ fn integrated_tips_do_not_stop_early() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-⌂:0:DETACHED <> ✓refs/remotes/origin/main⇣3
-└── ≡:0:anon: on 34d0715 {1}
-    └── :0:anon:
+⌂:DETACHED <> ✓refs/remotes/origin/main⇣3
+└── ≡:anon: on 34d0715 {1}
+    └── :anon:
 
 "#]]
     );
@@ -4161,9 +4161,9 @@ fn workspace_without_target_can_see_remote() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:1:gitbutler/workspace <> ✓!
-└── ≡👉📙:0:main[🌳] <> origin/main⇡1 {0}
-    └── 👉📙:0:main[🌳] <> origin/main⇡1
+📕🏘️⚠️:gitbutler/workspace <> ✓!
+└── ≡👉📙:main[🌳] <> origin/main⇡1 {0}
+    └── 👉📙:main[🌳] <> origin/main⇡1
         └── ·3183e43 (🏘️)
 
 "#]]
@@ -4191,9 +4191,9 @@ fn workspace_without_target_can_see_remote() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:1:gitbutler/workspace <> ✓!
-└── ≡👉📙:0:main[🌳] <> origin/main⇡1 {0}
-    └── 👉📙:0:main[🌳] <> origin/main⇡1
+📕🏘️⚠️:gitbutler/workspace <> ✓!
+└── ≡👉📙:main[🌳] <> origin/main⇡1 {0}
+    └── 👉📙:main[🌳] <> origin/main⇡1
         └── ·3183e43 (🏘️)
 
 "#]]
@@ -4255,7 +4255,7 @@ fn workspace_obeys_limit_when_target_branch_is_missing() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓!
+📕🏘️:gitbutler/workspace[🌳] <> ✓!
 
 "#]]
     );
@@ -4300,9 +4300,9 @@ fn workspace_obeys_limit_when_target_branch_is_missing() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣6 on 79bbb29
-└── ≡:3:B on 79bbb29
-    └── :3:B
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣6 on 79bbb29
+└── ≡:B on 79bbb29
+    └── :B
         ├── ·6b1a13b (🏘️)
         └── ·03ad472 (🏘️)
 
@@ -4363,9 +4363,9 @@ fn three_branches_one_advanced_ws_commit_advanced_fully_pushed_empty_dependent()
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡:4:advanced-lane <> origin/advanced-lane on fafd9d0
-    └── :4:advanced-lane <> origin/advanced-lane
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡:advanced-lane <> origin/advanced-lane on fafd9d0
+    └── :advanced-lane <> origin/advanced-lane
         └── ❄️cbc6713 (🏘️) ►dependent, ►on-top-of-dependent
 
 "#]]
@@ -4413,10 +4413,10 @@ fn three_branches_one_advanced_ws_commit_advanced_fully_pushed_empty_dependent()
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡📙:5:dependent on fafd9d0 {1}
-    ├── 📙:5:dependent
-    └── 📙:6:advanced-lane <> origin/advanced-lane
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡📙:dependent on fafd9d0 {1}
+    ├── 📙:dependent
+    └── 📙:advanced-lane <> origin/advanced-lane
         └── ❄️cbc6713 (🏘️) ►on-top-of-dependent
 
 "#]]
@@ -4481,7 +4481,7 @@ fn on_top_of_target_with_history() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 2cde30a
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 2cde30a
 
 "#]]
     );
@@ -4523,15 +4523,15 @@ fn on_top_of_target_with_history() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 2cde30a
-├── ≡📙:3:C on 2cde30a {0}
-│   ├── 📙:3:C
-│   ├── 📙:4:B
-│   └── 📙:5:A
-└── ≡📙:6:D on 2cde30a {1}
-    ├── 📙:6:D
-    ├── 📙:7:E
-    └── 📙:8:F
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 2cde30a
+├── ≡📙:C on 2cde30a {0}
+│   ├── 📙:C
+│   ├── 📙:B
+│   └── 📙:A
+└── ≡📙:D on 2cde30a {1}
+    ├── 📙:D
+    ├── 📙:E
+    └── 📙:F
 
 "#]]
     );
@@ -4550,20 +4550,20 @@ fn on_top_of_target_with_history() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 2be54cd
-├── ≡📙:3:C on 2be54cd {0}
-│   ├── 📙:3:C
-│   ├── 📙:4:B
-│   └── 📙:5:A
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 2be54cd
+├── ≡📙:C on 2be54cd {0}
+│   ├── 📙:C
+│   ├── 📙:B
+│   └── 📙:A
 │       ├── ·2cde30a (🏘️|✓)
 │       ├── ·1c938f4 (🏘️|✓)
 │       ├── ·b82769f (🏘️|✓)
 │       ├── ·988032f (🏘️|✓)
 │       └── ·cd5b655 (🏘️|✓)
-└── ≡📙:6:D on 2be54cd {1}
-    ├── 📙:6:D
-    ├── 📙:7:E
-    └── 📙:8:F
+└── ≡📙:D on 2be54cd {1}
+    ├── 📙:D
+    ├── 📙:E
+    └── 📙:F
         ├── ·2cde30a (🏘️|✓)
         ├── ·1c938f4 (🏘️|✓)
         ├── ·b82769f (🏘️|✓)
@@ -4688,9 +4688,9 @@ fn partitions_with_long_and_short_connections_to_each_other() -> anyhow::Result<
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-⌂:0:main <> ✓refs/remotes/origin/main⇣11
-└── ≡:0:main <> origin/main⇣11 on 2438292 {1}
-    └── :0:main <> origin/main⇣11
+⌂:main <> ✓refs/remotes/origin/main⇣11
+└── ≡:main <> origin/main⇣11 on 2438292 {1}
+    └── :main <> origin/main⇣11
         ├── 🟣232ed06 (✓)
         ├── 🟣abcfd9a (✓)
         ├── 🟣bc86eba (✓)
@@ -4765,9 +4765,9 @@ fn partitions_with_long_and_short_connections_to_each_other() -> anyhow::Result<
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-⌂:0:main <> ✓refs/remotes/origin/main⇣11
-└── ≡:0:main <> origin/main⇣11 on 2438292 {1}
-    └── :0:main <> origin/main⇣11
+⌂:main <> ✓refs/remotes/origin/main⇣11
+└── ≡:main <> origin/main⇣11 on 2438292 {1}
+    └── :main <> origin/main⇣11
         ├── 🟣232ed06 (✓)
         ├── 🟣abcfd9a (✓)
         ├── 🟣bc86eba (✓)
@@ -4843,7 +4843,7 @@ fn partitions_with_long_and_short_connections_to_each_other() -> anyhow::Result<
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣11 on 9730cbf
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣11 on 9730cbf
 
 "#]]
     );
@@ -4925,9 +4925,9 @@ fn remote_far_in_ancestry() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 685d644
-└── ≡:3:A <> origin/A⇡3⇣2 on 685d644
-    └── :3:A <> origin/A⇡3⇣2
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 685d644
+└── ≡:A <> origin/A⇡3⇣2 on 685d644
+    └── :A <> origin/A⇡3⇣2
         ├── 🟣975754f
         ├── 🟣f48ff69
         ├── ·8407093 (🏘️)
@@ -5048,9 +5048,9 @@ fn partitions_with_long_and_short_connections_to_each_other_part_2() -> anyhow::
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-⌂:0:main <> ✓refs/remotes/origin/main⇣17
-└── ≡:0:main <> origin/main⇣17 on bce0c5e {1}
-    └── :0:main <> origin/main⇣17
+⌂:main <> ✓refs/remotes/origin/main⇣17
+└── ≡:main <> origin/main⇣17 on bce0c5e {1}
+    └── :main <> origin/main⇣17
         ├── 🟣024f837 (✓) ►long-workspace-to-target
         ├── 🟣64a8284 (✓)
         ├── 🟣b72938c (✓)
@@ -5137,7 +5137,7 @@ fn partitions_with_long_and_short_connections_to_each_other_part_2() -> anyhow::
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣17 on c9120f1
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣17 on c9120f1
 
 "#]]
     );
@@ -5153,11 +5153,11 @@ fn partitions_with_long_and_short_connections_to_each_other_part_2() -> anyhow::
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣17 on 3183e43
-└── ≡:3:workspace on 3183e43
-    ├── :3:workspace
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣17 on 3183e43
+└── ≡:workspace on 3183e43
+    ├── :workspace
     │   └── ·c9120f1 (🏘️|✓)
-    └── :4:main-to-workspace
+    └── :main-to-workspace
         └── ·1126587 (🏘️|✓)
 
 "#]]
@@ -5173,16 +5173,16 @@ fn partitions_with_long_and_short_connections_to_each_other_part_2() -> anyhow::
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣17 on 3183e43
-├── ≡:3:workspace on 3183e43
-│   ├── :3:workspace
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣17 on 3183e43
+├── ≡:workspace on 3183e43
+│   ├── :workspace
 │   │   └── ·c9120f1 (🏘️|✓)
-│   └── :4:main-to-workspace
+│   └── :main-to-workspace
 │       └── ·1126587 (🏘️|✓)
-├── ≡📙:10:A on 3183e43 {3}
-│   └── 📙:10:A
-└── ≡📙:11:B on 3183e43 {4}
-    └── 📙:11:B
+├── ≡📙:A on 3183e43 {3}
+│   └── 📙:A
+└── ≡📙:B on 3183e43 {4}
+    └── 📙:B
 
 "#]]
     );
@@ -5198,15 +5198,15 @@ fn partitions_with_long_and_short_connections_to_each_other_part_2() -> anyhow::
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣17 on 3183e43
-├── ≡:3:workspace on 3183e43
-│   ├── :3:workspace
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣17 on 3183e43
+├── ≡:workspace on 3183e43
+│   ├── :workspace
 │   │   └── ·c9120f1 (🏘️|✓)
-│   └── :4:main-to-workspace
+│   └── :main-to-workspace
 │       └── ·1126587 (🏘️|✓)
-└── ≡📙:10:A on 3183e43 {3}
-    ├── 📙:10:A
-    └── 📙:11:B
+└── ≡📙:A on 3183e43 {3}
+    ├── 📙:A
+    └── 📙:B
 
 "#]]
     );
@@ -5293,30 +5293,30 @@ fn multi_lane_with_shared_segment_one_integrated() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
-├── ≡:3:D on 3183e43
-│   ├── :3:D
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
+├── ≡:D on 3183e43
+│   ├── :D
 │   │   └── ·9895054 (🏘️)
-│   ├── :6:C
+│   ├── :C
 │   │   ├── ·de625cc (🏘️)
 │   │   ├── ·23419f8 (🏘️)
 │   │   └── ·5dc4389 (🏘️)
-│   └── :7:shared
+│   └── :shared
 │       ├── ·d4f537e (🏘️|✓)
 │       ├── ·b448757 (🏘️|✓)
 │       └── ·e9a378d (🏘️|✓)
-├── ≡:4:A on 3183e43
-│   ├── :4:A
+├── ≡:A on 3183e43
+│   ├── :A
 │   │   └── ·0bad3af (🏘️|✓)
-│   └── :7:shared
+│   └── :shared
 │       ├── ·d4f537e (🏘️|✓)
 │       ├── ·b448757 (🏘️|✓)
 │       └── ·e9a378d (🏘️|✓)
-└── ≡:5:B on 3183e43
-    ├── :5:B
+└── ≡:B on 3183e43
+    ├── :B
     │   ├── ·acdc49a (🏘️)
     │   └── ·f0117e0 (🏘️)
-    └── :7:shared
+    └── :shared
         ├── ·d4f537e (🏘️|✓)
         ├── ·b448757 (🏘️|✓)
         └── ·e9a378d (🏘️|✓)
@@ -5336,16 +5336,16 @@ fn multi_lane_with_shared_segment_one_integrated() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on d4f537e
-├── ≡:3:D on d4f537e
-│   ├── :3:D
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on d4f537e
+├── ≡:D on d4f537e
+│   ├── :D
 │   │   └── ·9895054 (🏘️)
-│   └── :6:C
+│   └── :C
 │       ├── ·de625cc (🏘️)
 │       ├── ·23419f8 (🏘️)
 │       └── ·5dc4389 (🏘️)
-└── ≡:5:B on d4f537e
-    └── :5:B
+└── ≡:B on d4f537e
+    └── :B
         ├── ·acdc49a (🏘️)
         └── ·f0117e0 (🏘️)
 
@@ -5428,30 +5428,30 @@ fn multi_lane_with_shared_segment() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
-├── ≡:2:D on 3183e43
-│   ├── :2:D
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
+├── ≡:D on 3183e43
+│   ├── :D
 │   │   └── ·9895054 (🏘️)
-│   ├── :6:C
+│   ├── :C
 │   │   ├── ·de625cc (🏘️)
 │   │   ├── ·23419f8 (🏘️)
 │   │   └── ·5dc4389 (🏘️)
-│   └── :7:shared
+│   └── :shared
 │       ├── ·d4f537e (🏘️)
 │       ├── ·b448757 (🏘️)
 │       └── ·e9a378d (🏘️)
-├── ≡:3:A on 3183e43
-│   ├── :3:A
+├── ≡:A on 3183e43
+│   ├── :A
 │   │   └── ·0bad3af (🏘️)
-│   └── :7:shared
+│   └── :shared
 │       ├── ·d4f537e (🏘️)
 │       ├── ·b448757 (🏘️)
 │       └── ·e9a378d (🏘️)
-└── ≡:4:B on 3183e43
-    ├── :4:B
+└── ≡:B on 3183e43
+    ├── :B
     │   ├── ·acdc49a (🏘️)
     │   └── ·f0117e0 (🏘️)
-    └── :7:shared
+    └── :shared
         ├── ·d4f537e (🏘️)
         ├── ·b448757 (🏘️)
         └── ·e9a378d (🏘️)
@@ -5473,30 +5473,30 @@ fn multi_lane_with_shared_segment() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:1:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
-├── ≡:4:D on 3183e43
-│   ├── :4:D
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
+├── ≡:D on 3183e43
+│   ├── :D
 │   │   └── ·9895054 (🏘️)
-│   ├── :7:C
+│   ├── :C
 │   │   ├── ·de625cc (🏘️)
 │   │   ├── ·23419f8 (🏘️)
 │   │   └── ·5dc4389 (🏘️)
-│   └── :3:shared
+│   └── :shared
 │       ├── ·d4f537e (🏘️)
 │       ├── ·b448757 (🏘️)
 │       └── ·e9a378d (🏘️)
-├── ≡👉:0:A on 3183e43
-│   ├── 👉:0:A
+├── ≡👉:A on 3183e43
+│   ├── 👉:A
 │   │   └── ·0bad3af (🏘️)
-│   └── :3:shared
+│   └── :shared
 │       ├── ·d4f537e (🏘️)
 │       ├── ·b448757 (🏘️)
 │       └── ·e9a378d (🏘️)
-└── ≡:5:B on 3183e43
-    ├── :5:B
+└── ≡:B on 3183e43
+    ├── :B
     │   ├── ·acdc49a (🏘️)
     │   └── ·f0117e0 (🏘️)
-    └── :3:shared
+    └── :shared
         ├── ·d4f537e (🏘️)
         ├── ·b448757 (🏘️)
         └── ·e9a378d (🏘️)
@@ -5597,10 +5597,10 @@ fn dependent_branch_insertion() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡📙:5:dependent on fafd9d0 {1}
-    ├── 📙:5:dependent
-    └── 📙:6:advanced-lane <> origin/advanced-lane
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡📙:dependent on fafd9d0 {1}
+    ├── 📙:dependent
+    └── 📙:advanced-lane <> origin/advanced-lane
         └── ❄️cbc6713 (🏘️)
 
 "#]]
@@ -5651,10 +5651,10 @@ fn dependent_branch_insertion() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡📙:5:advanced-lane <> origin/advanced-lane on fafd9d0 {1}
-    ├── 📙:5:advanced-lane <> origin/advanced-lane
-    └── 📙:6:dependent
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡📙:advanced-lane <> origin/advanced-lane on fafd9d0 {1}
+    ├── 📙:advanced-lane <> origin/advanced-lane
+    └── 📙:dependent
         └── ❄cbc6713 (🏘️)
 
 "#]]
@@ -5673,10 +5673,10 @@ fn dependent_branch_insertion() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:1:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡👉📙:5:advanced-lane <> origin/advanced-lane on fafd9d0 {1}
-    ├── 👉📙:5:advanced-lane <> origin/advanced-lane
-    └── 📙:6:dependent
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡👉📙:advanced-lane <> origin/advanced-lane on fafd9d0 {1}
+    ├── 👉📙:advanced-lane <> origin/advanced-lane
+    └── 📙:dependent
         └── ❄cbc6713 (🏘️)
 
 "#]]
@@ -5695,10 +5695,10 @@ fn dependent_branch_insertion() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:1:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡📙:5:advanced-lane <> origin/advanced-lane on fafd9d0 {1}
-    ├── 📙:5:advanced-lane <> origin/advanced-lane
-    └── 👉📙:6:dependent
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡📙:advanced-lane <> origin/advanced-lane on fafd9d0 {1}
+    ├── 📙:advanced-lane <> origin/advanced-lane
+    └── 👉📙:dependent
         └── ❄cbc6713 (🏘️)
 
 "#]]
@@ -5763,17 +5763,17 @@ fn multiple_stacks_with_shared_parent_and_remote() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-├── ≡📙:3:C-on-A on fafd9d0 {1}
-│   ├── 📙:3:C-on-A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+├── ≡📙:C-on-A on fafd9d0 {1}
+│   ├── 📙:C-on-A
 │   │   └── ·4f1bb32 (🏘️)
-│   └── :4:A <> origin/A⇣1
+│   └── :A <> origin/A⇣1
 │       ├── 🟣b627ca7
 │       └── ❄️e255adc (🏘️)
-└── ≡:6:B-on-A on fafd9d0
-    ├── :6:B-on-A
+└── ≡:B-on-A on fafd9d0
+    ├── :B-on-A
     │   └── ·aff8449 (🏘️)
-    └── :4:A <> origin/A⇣1
+    └── :A <> origin/A⇣1
         ├── 🟣b627ca7
         └── ❄️e255adc (🏘️)
 
@@ -5838,12 +5838,12 @@ fn a_stack_segment_can_be_a_segment_elsewhere_and_stack_order() -> anyhow::Resul
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on fafd9d0
-├── ≡📙:2:advanced-lane on fafd9d0 {0}
-│   └── 📙:2:advanced-lane
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on fafd9d0
+├── ≡📙:advanced-lane on fafd9d0 {0}
+│   └── 📙:advanced-lane
 │       └── ·cbc6713 (🏘️)
-└── ≡📙:4:lane on fafd9d0 {1}
-    └── 📙:4:lane
+└── ≡📙:lane on fafd9d0 {1}
+    └── 📙:lane
 
 "#]]
     );
@@ -5881,11 +5881,11 @@ fn a_stack_segment_can_be_a_segment_elsewhere_and_stack_order() -> anyhow::Resul
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on fafd9d0
-├── ≡📙:4:lane on fafd9d0 {0}
-│   └── 📙:4:lane
-└── ≡📙:3:advanced-lane on fafd9d0 {1}
-    └── 📙:3:advanced-lane
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on fafd9d0
+├── ≡📙:lane on fafd9d0 {0}
+│   └── 📙:lane
+└── ≡📙:advanced-lane on fafd9d0 {1}
+    └── 📙:advanced-lane
         └── ·cbc6713 (🏘️)
 
 "#]]
@@ -5929,14 +5929,14 @@ fn incomplete_metadata_uses_present_branch_to_order_stack() -> anyhow::Result<()
     snapbox::assert_data_eq!(
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:3:A on 85efbe4 {0}
-│   └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:A on 85efbe4 {0}
+│   └── 📙:A
 │       └── ·09d8e52 (🏘️)
-└── ≡:5:C on 85efbe4 {1}
-    ├── :5:C
+└── ≡:C on 85efbe4 {1}
+    ├── :C
     │   └── ·09bc93e (🏘️)
-    └── 📙:4:B
+    └── 📙:B
         └── ·c813d8d (🏘️)
 
 "#]]
@@ -6000,13 +6000,13 @@ fn two_dependent_branches_with_embedded_remote() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡📙:3:A <> origin/A⇡1⇣1 on fafd9d0 {1}
-    ├── 📙:3:A <> origin/A⇡1⇣1
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡📙:A <> origin/A⇡1⇣1 on fafd9d0 {1}
+    ├── 📙:A <> origin/A⇡1⇣1
     │   ├── 🟣2b1808c
     │   ├── ·aadad9d (🏘️)
     │   └── ·96a2408 (🏘️|✓)
-    └── :5:integrated
+    └── :integrated
         ├── ❄f15ca75 (🏘️|✓)
         └── ❄9456d79 (🏘️|✓)
 
@@ -6026,9 +6026,9 @@ fn two_dependent_branches_with_embedded_remote() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 96a2408
-└── ≡📙:3:A <> origin/A⇡1⇣1 on 96a2408 {1}
-    └── 📙:3:A <> origin/A⇡1⇣1
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 96a2408
+└── ≡📙:A <> origin/A⇡1⇣1 on 96a2408 {1}
+    └── 📙:A <> origin/A⇡1⇣1
         ├── 🟣2b1808c
         └── ·aadad9d (🏘️)
 
@@ -6098,12 +6098,12 @@ fn two_dependent_branches_rebased_with_remotes_merge_local() -> anyhow::Result<(
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 281456a
-└── ≡📙:3:B <> origin/B⇡1⇣1 on 281456a {0}
-    ├── 📙:3:B <> origin/B⇡1⇣1
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 281456a
+└── ≡📙:B <> origin/B⇡1⇣1 on 281456a {0}
+    ├── 📙:B <> origin/B⇡1⇣1
     │   ├── 🟣e0bd0a7
     │   └── ·da597e8 (🏘️)
-    └── 📙:4:A <> origin/A⇣1
+    └── 📙:A <> origin/A⇣1
         ├── 🟣0b6b861
         └── ·1818c17 (🏘️|✓)
 
@@ -6122,9 +6122,9 @@ fn two_dependent_branches_rebased_with_remotes_merge_local() -> anyhow::Result<(
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 1818c17
-└── ≡📙:4:B <> origin/B⇡1⇣1 on 1818c17 {0}
-    └── 📙:4:B <> origin/B⇡1⇣1
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 1818c17
+└── ≡📙:B <> origin/B⇡1⇣1 on 1818c17 {0}
+    └── 📙:B <> origin/B⇡1⇣1
         ├── 🟣e0bd0a7
         └── ·da597e8 (🏘️)
 
@@ -6165,11 +6165,11 @@ fn stacked_bottom_remote_still_points_at_now_split_top() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡📙:3:top on fafd9d0 {0}
-    ├── 📙:3:top
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡📙:top on fafd9d0 {0}
+    ├── 📙:top
     │   └── ❄bfbff44 (🏘️)
-    └── 📙:4:bottom <> origin/bottom⇣1
+    └── 📙:bottom <> origin/bottom⇣1
         ├── 🟣bfbff44 (🏘️)
         └── ❄️7fdb58d (🏘️)
 
@@ -6257,9 +6257,9 @@ fn two_dependent_branches_rebased_with_remotes_squash_merge_remote_ambiguous() -
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 0b6b861
-└── ≡📙:3:D <> origin/D⇡1⇣1 on 0b6b861 {0}
-    └── 📙:3:D <> origin/D⇡1⇣1
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 0b6b861
+└── ≡📙:D <> origin/D⇡1⇣1 on 0b6b861 {0}
+    └── 📙:D <> origin/D⇡1⇣1
         ├── 🟣3045ea6
         └── ·624e118 (🏘️)
 
@@ -6336,9 +6336,9 @@ fn two_dependent_branches_rebased_with_remotes_squash_merge_remote() -> anyhow::
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 0b6b861
-└── ≡📙:3:D <> origin/D⇡3⇣1 on 0b6b861 {0}
-    └── 📙:3:D <> origin/D⇡3⇣1
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 0b6b861
+└── ≡📙:D <> origin/D⇡3⇣1 on 0b6b861 {0}
+    └── 📙:D <> origin/D⇡3⇣1
         ├── 🟣bbd4ff6
         ├── ·353471f (🏘️)
         ├── ·8a4b945 (🏘️)
@@ -6389,13 +6389,13 @@ fn without_target_ref_or_managed_commit() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓!
-└── ≡:1:A <> origin/A⇣1
-    ├── :1:A <> origin/A⇣1
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓!
+└── ≡:A <> origin/A⇣1
+    ├── :A <> origin/A⇣1
     │   ├── 🟣4fe5a6f
     │   ├── ❄️a62b0de (🏘️)
     │   └── ❄️120a217 (🏘️)
-    └── :3:main
+    └── :main
         └── ❄fafd9d0 (🏘️)
 
 "#]]
@@ -6430,13 +6430,13 @@ fn without_target_ref_or_managed_commit() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:1:gitbutler/workspace[🌳] <> ✓!
-└── ≡👉:0:A <> origin/A⇣1
-    ├── 👉:0:A <> origin/A⇣1
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓!
+└── ≡👉:A <> origin/A⇣1
+    ├── 👉:A <> origin/A⇣1
     │   ├── 🟣4fe5a6f
     │   ├── ❄️a62b0de (🏘️)
     │   └── ❄️120a217 (🏘️)
-    └── :3:main
+    └── :main
         └── ❄fafd9d0 (🏘️)
 
 "#]]
@@ -6488,13 +6488,13 @@ fn without_target_ref_or_managed_commit_ambiguous() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓!
-└── ≡:1:A <> origin/A⇣1
-    ├── :1:A <> origin/A⇣1
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓!
+└── ≡:A <> origin/A⇣1
+    ├── :A <> origin/A⇣1
     │   ├── 🟣4fe5a6f
     │   ├── ❄️a62b0de (🏘️) ►B
     │   └── ❄️120a217 (🏘️)
-    └── :3:main
+    └── :main
         └── ❄fafd9d0 (🏘️)
 
 "#]]
@@ -6534,14 +6534,14 @@ fn without_target_ref_or_managed_commit_ambiguous() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:1:gitbutler/workspace[🌳] <> ✓!
-└── ≡👉:4:A <> origin/A⇣1 {1}
-    ├── 👉:4:A <> origin/A⇣1
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓!
+└── ≡👉:A <> origin/A⇣1 {1}
+    ├── 👉:A <> origin/A⇣1
     │   └── 🟣4fe5a6f
-    ├── 📙:0:B
+    ├── 📙:B
     │   ├── ❄a62b0de (🏘️)
     │   └── ❄120a217 (🏘️)
-    └── :3:main
+    └── :main
         └── ❄fafd9d0 (🏘️)
 
 "#]]
@@ -6576,12 +6576,12 @@ fn without_target_ref_or_managed_commit_ambiguous() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓!
-└── ≡📙:1:B {1}
-    ├── 📙:1:B
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓!
+└── ≡📙:B {1}
+    ├── 📙:B
     │   ├── ·a62b0de (🏘️) ►A
     │   └── ·120a217 (🏘️)
-    └── :3:main
+    └── :main
         └── ·fafd9d0 (🏘️)
 
 "#]]
@@ -6602,14 +6602,14 @@ fn without_target_ref_or_managed_commit_ambiguous() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:1:gitbutler/workspace[🌳] <> ✓!
-└── ≡📙:4:B {1}
-    ├── 📙:4:B
-    ├── 👉📙:5:A <> origin/A⇣1
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓!
+└── ≡📙:B {1}
+    ├── 📙:B
+    ├── 👉📙:A <> origin/A⇣1
     │   ├── 🟣4fe5a6f
     │   ├── ❄️a62b0de (🏘️)
     │   └── ❄️120a217 (🏘️)
-    └── :3:main
+    └── :main
         └── ❄fafd9d0 (🏘️)
 
 "#]]
@@ -6629,14 +6629,14 @@ fn without_target_ref_or_managed_commit_ambiguous() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:1:gitbutler/workspace[🌳] <> ✓!
-└── ≡👉📙:4:A <> origin/A⇣1 {1}
-    ├── 👉📙:4:A <> origin/A⇣1
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓!
+└── ≡👉📙:A <> origin/A⇣1 {1}
+    ├── 👉📙:A <> origin/A⇣1
     │   └── 🟣4fe5a6f
-    ├── 📙:5:B
+    ├── 📙:B
     │   ├── ❄a62b0de (🏘️)
     │   └── ❄120a217 (🏘️)
-    └── :3:main
+    └── :main
         └── ❄fafd9d0 (🏘️)
 
 "#]]
@@ -6690,12 +6690,12 @@ fn without_target_ref_or_managed_commit_ambiguous_with_remotes() -> anyhow::Resu
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓!
-└── ≡:1:anon:
-    ├── :1:anon:
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓!
+└── ≡:anon:
+    ├── :anon:
     │   ├── ·a62b0de (🏘️) ►A, ►B
     │   └── ·120a217 (🏘️)
-    └── :4:main <> origin/main⇡1
+    └── :main <> origin/main⇡1
         └── ·fafd9d0 (🏘️)
 
 "#]]
@@ -6732,12 +6732,12 @@ fn without_target_ref_or_managed_commit_ambiguous_with_remotes() -> anyhow::Resu
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:1:gitbutler/workspace[🌳] <> ✓!
-└── ≡👉:0:A <> origin/A
-    ├── 👉:0:A <> origin/A
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓!
+└── ≡👉:A <> origin/A
+    ├── 👉:A <> origin/A
     │   ├── ❄️a62b0de (🏘️) ►B
     │   └── ❄️120a217 (🏘️)
-    └── :4:main <> origin/main
+    └── :main <> origin/main
         └── ❄fafd9d0 (🏘️)
 
 "#]]
@@ -6757,12 +6757,12 @@ fn without_target_ref_or_managed_commit_ambiguous_with_remotes() -> anyhow::Resu
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:1:gitbutler/workspace[🌳] <> ✓!
-└── ≡👉:0:B <> origin/B
-    ├── 👉:0:B <> origin/B
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓!
+└── ≡👉:B <> origin/B
+    ├── 👉:B <> origin/B
     │   ├── ❄️a62b0de (🏘️) ►A
     │   └── ❄️120a217 (🏘️)
-    └── :4:main <> origin/main
+    └── :main <> origin/main
         └── ❄fafd9d0 (🏘️)
 
 "#]]
@@ -6806,13 +6806,13 @@ fn without_target_ref_or_managed_commit_ambiguous_with_remotes() -> anyhow::Resu
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:1:gitbutler/workspace[🌳] <> ✓!
-└── ≡👉:5:A <> origin/A {1}
-    ├── 👉:5:A <> origin/A
-    ├── 📙:0:B <> origin/B
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓!
+└── ≡👉:A <> origin/A {1}
+    ├── 👉:A <> origin/A
+    ├── 📙:B <> origin/B
     │   ├── ❄️a62b0de (🏘️)
     │   └── ❄️120a217 (🏘️)
-    └── :4:main <> origin/main
+    └── :main <> origin/main
         └── ❄fafd9d0 (🏘️)
 
 "#]]
@@ -6865,13 +6865,13 @@ fn without_target_ref_with_managed_commit() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓!
-└── ≡:1:A <> origin/A⇣1
-    ├── :1:A <> origin/A⇣1
+📕🏘️:gitbutler/workspace[🌳] <> ✓!
+└── ≡:A <> origin/A⇣1
+    ├── :A <> origin/A⇣1
     │   ├── 🟣4fe5a6f
     │   ├── ❄️a62b0de (🏘️)
     │   └── ❄️120a217 (🏘️)
-    └── :3:main
+    └── :main
         └── ❄fafd9d0 (🏘️)
 
 "#]]
@@ -6906,13 +6906,13 @@ fn without_target_ref_with_managed_commit() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:1:gitbutler/workspace[🌳] <> ✓!
-└── ≡👉:0:A <> origin/A⇣1
-    ├── 👉:0:A <> origin/A⇣1
+📕🏘️:gitbutler/workspace[🌳] <> ✓!
+└── ≡👉:A <> origin/A⇣1
+    ├── 👉:A <> origin/A⇣1
     │   ├── 🟣4fe5a6f
     │   ├── ❄️a62b0de (🏘️)
     │   └── ❄️120a217 (🏘️)
-    └── :3:main
+    └── :main
         └── ❄fafd9d0 (🏘️)
 
 "#]]
@@ -6959,7 +6959,7 @@ fn workspace_commit_pushed_to_target() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 120a217
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 120a217
 
 "#]]
     );
@@ -7006,13 +7006,13 @@ fn no_workspace_no_target_commit_under_managed_ref() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓!
-└── ≡:1:anon:
-    ├── :1:anon:
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓!
+└── ≡:anon:
+    ├── :anon:
     │   └── ·dca94a4 (🏘️)
-    ├── :2:A
+    ├── :A
     │   └── ·120a217 (🏘️)
-    └── :3:main
+    └── :main
         └── ·fafd9d0 (🏘️)
 
 "#]]
@@ -7080,16 +7080,16 @@ fn no_workspace_commit() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-├── ≡📙:3:lane on fafd9d0 {0}
-│   ├── 📙:3:lane
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+├── ≡📙:lane on fafd9d0 {0}
+│   ├── 📙:lane
 │   │   └── ·cbc6713 (🏘️)
-│   ├── 📙:7:lane-segment-01
-│   └── 📙:8:lane-segment-02
-└── ≡📙:4:lane-2 on fafd9d0 {1}
-    ├── 📙:4:lane-2
-    ├── 📙:5:lane-2-segment-01
-    └── 📙:6:lane-2-segment-02
+│   ├── 📙:lane-segment-01
+│   └── 📙:lane-segment-02
+└── ≡📙:lane-2 on fafd9d0 {1}
+    ├── 📙:lane-2
+    ├── 📙:lane-2-segment-01
+    └── 📙:lane-2-segment-02
 
 "#]]
     );
@@ -7142,16 +7142,16 @@ fn no_workspace_commit() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-├── ≡📙:4:lane-2 on fafd9d0 {0}
-│   ├── 📙:4:lane-2
-│   ├── 📙:5:lane-2-segment-01
-│   └── 📙:6:lane-2-segment-02
-└── ≡📙:3:lane on fafd9d0 {1}
-    ├── 📙:3:lane
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+├── ≡📙:lane-2 on fafd9d0 {0}
+│   ├── 📙:lane-2
+│   ├── 📙:lane-2-segment-01
+│   └── 📙:lane-2-segment-02
+└── ≡📙:lane on fafd9d0 {1}
+    ├── 📙:lane
     │   └── ·cbc6713 (🏘️)
-    ├── 📙:7:lane-segment-01
-    └── 📙:8:lane-segment-02
+    ├── 📙:lane-segment-01
+    └── 📙:lane-segment-02
 
 "#]]
     );
@@ -7205,11 +7205,11 @@ fn two_dependent_branches_first_merged_by_rebase() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 281456a
-└── ≡:3:B on 281456a
-    ├── :3:B
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 281456a
+└── ≡:B on 281456a
+    ├── :B
     │   └── ·da597e8 (🏘️)
-    └── :4:A <> origin/A⇡1⇣1
+    └── :A <> origin/A⇡1⇣1
         ├── 🟣0b6b861 (✓)
         └── ·1818c17 (🏘️)
 
@@ -7260,9 +7260,9 @@ fn special_branch_names_do_not_end_up_in_segment() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓!
-└── ≡:1:main
-    └── :1:main
+📕🏘️:gitbutler/workspace[🌳] <> ✓!
+└── ≡:main
+    └── :main
         ├── ·3686017 (🏘️)
         ├── ·9725482 (🏘️)
         └── ·fafd9d0 (🏘️)
@@ -7332,12 +7332,12 @@ fn special_branch_do_not_allow_overly_long_segments() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/gitbutler/target on ce09734
-└── ≡:3:A on ce09734
-    ├── :3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/gitbutler/target on ce09734
+└── ≡:A on ce09734
+    ├── :A
     │   ├── ·c59457b (🏘️)
     │   └── ·e146f13 (🏘️)
-    └── :5:main <> origin/main
+    └── :main <> origin/main
         └── ❄️971953d (🏘️)
 
 "#]]
@@ -7441,16 +7441,16 @@ fn branch_ahead_of_workspace() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣2 on fafd9d0
-├── ≡:6:B on 91bc3fc
-│   └── :6:B
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣2 on fafd9d0
+├── ≡:B on 91bc3fc
+│   └── :B
 │       └── ·2f8f06d (🏘️)
-├── ≡:7:C on fafd9d0
-│   └── :7:C
+├── ≡:C on fafd9d0
+│   └── :C
 │       ├── ·3f7c4e6 (🏘️)
 │       └── ·b6895d7 (🏘️)
-└── ≡:8:new-name-for-D on fafd9d0
-    └── :8:new-name-for-D
+└── ≡:new-name-for-D on fafd9d0
+    └── :new-name-for-D
         └── ·ed36e3b (🏘️)
 
 "#]]
@@ -7533,32 +7533,32 @@ fn branch_ahead_of_workspace() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣2 on fafd9d0
-├── ≡📙:19:A on fafd9d0 {0}
-│   ├── 📙:19:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣2 on fafd9d0
+├── ≡📙:A on fafd9d0 {0}
+│   ├── 📙:A
 │   │   ├── ·c83f258*
 │   │   └── ·a62b0de (🏘️|✓)
-│   └── 📙:21:A-middle <> origin/A-middle
+│   └── 📙:A-middle <> origin/A-middle
 │       ├── ·27c2545*
 │       └── ·120a217 (🏘️|✓)
-├── ≡📙:6:B on fafd9d0 {1}
-│   ├── 📙:6:B
+├── ≡📙:B on fafd9d0 {1}
+│   ├── 📙:B
 │   │   └── ·2f8f06d (🏘️)
-│   └── 📙:15:B-middle <> origin/B-middle
+│   └── 📙:B-middle <> origin/B-middle
 │       ├── ·c8f73c7*
 │       ├── ·ff75b80*
 │       ├── ·91bc3fc (🏘️|✓)
 │       └── ·cf9330f (🏘️|✓)
-├── ≡📙:8:C on fafd9d0 {2}
-│   ├── 📙:8:C
+├── ≡📙:C on fafd9d0 {2}
+│   ├── 📙:C
 │   │   └── ·3f7c4e6 (🏘️)
-│   └── 📙:20:C-bottom
+│   └── 📙:C-bottom
 │       ├── ·790a17d*
 │       ├── ·969aaec*
 │       ├── ·631be19*
 │       └── ·b6895d7 (🏘️)
-└── ≡:18:new-name-for-D on fafd9d0
-    └── :18:new-name-for-D
+└── ≡:new-name-for-D on fafd9d0
+    └── :new-name-for-D
         └── ·ed36e3b (🏘️)
 
 "#]]
@@ -7619,11 +7619,11 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_ttb() -> anyhow::Resu
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:1:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on fafd9d0
-├── ≡👉📙:4:lane on fafd9d0 {0}
-│   └── 👉📙:4:lane
-└── ≡📙:3:advanced-lane on fafd9d0 {1}
-    └── 📙:3:advanced-lane
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on fafd9d0
+├── ≡👉📙:lane on fafd9d0 {0}
+│   └── 👉📙:lane
+└── ≡📙:advanced-lane on fafd9d0 {1}
+    └── 📙:advanced-lane
         └── ·cbc6713 (🏘️)
 
 "#]]
@@ -7658,11 +7658,11 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_ttb() -> anyhow::Resu
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on fafd9d0
-├── ≡📙:4:lane on fafd9d0 {0}
-│   └── 📙:4:lane
-└── ≡📙:3:advanced-lane on fafd9d0 {1}
-    └── 📙:3:advanced-lane
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on fafd9d0
+├── ≡📙:lane on fafd9d0 {0}
+│   └── 📙:lane
+└── ≡📙:advanced-lane on fafd9d0 {1}
+    └── 📙:advanced-lane
         └── ·cbc6713 (🏘️)
 
 "#]]
@@ -7697,11 +7697,11 @@ fn two_branches_one_advanced_two_parent_ws_commit_diverged_ttb() -> anyhow::Resu
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on fafd9d0
-├── ≡📙:4:lane on fafd9d0 {0}
-│   └── 📙:4:lane
-└── ≡📙:3:advanced-lane on fafd9d0 {1}
-    └── 📙:3:advanced-lane
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on fafd9d0
+├── ≡📙:lane on fafd9d0 {0}
+│   └── 📙:lane
+└── ≡📙:advanced-lane on fafd9d0 {1}
+    └── 📙:advanced-lane
         └── ·cbc6713 (🏘️)
 
 "#]]
@@ -7779,16 +7779,16 @@ fn advanced_workspace_ref() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
-└── ≡:5:anon: on bce0c5e {1}
-    ├── :5:anon:
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
+└── ≡:anon: on bce0c5e {1}
+    ├── :anon:
     │   └── ·a7131b1 (🏘️)
-    ├── :6:intermediate-ref
+    ├── :intermediate-ref
     │   ├── ·4d3831e (🏘️)
     │   ├── ·468357f (🏘️)
     │   ├── ·118ddbb (🏘️)
     │   └── ·619d548 (🏘️)
-    └── 📙:4:B
+    └── 📙:B
         └── ·8a352d5 (🏘️)
 
 "#]]
@@ -7834,16 +7834,16 @@ fn advanced_workspace_ref() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
-└── ≡:5:anon: on bce0c5e {1}
-    ├── :5:anon:
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
+└── ≡:anon: on bce0c5e {1}
+    ├── :anon:
     │   └── ·a7131b1 (🏘️)
-    ├── :6:intermediate-ref
+    ├── :intermediate-ref
     │   ├── ·4d3831e (🏘️)
     │   ├── ·468357f (🏘️)
     │   ├── ·118ddbb (🏘️)
     │   └── ·619d548 (🏘️)
-    └── 📙:4:B
+    └── 📙:B
         └── ·8a352d5 (🏘️)
 
 "#]]
@@ -7913,16 +7913,16 @@ fn advanced_workspace_ref_single_stack() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
-└── ≡:4:anon: on bce0c5e {0}
-    ├── :4:anon:
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
+└── ≡:anon: on bce0c5e {0}
+    ├── :anon:
     │   └── ·da912a8 (🏘️)
-    ├── :5:intermediate-ref
+    ├── :intermediate-ref
     │   ├── ·198eaf8 (🏘️)
     │   ├── ·3147997 (🏘️)
     │   ├── ·9785229 (🏘️)
     │   └── ·c58f157 (🏘️)
-    └── 📙:3:A
+    └── 📙:A
         └── ·6fdab32 (🏘️)
 
 "#]]
@@ -7978,9 +7978,9 @@ fn shallow_boundary_below_workspace_lower_bound() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on b625665
-└── ≡📙:3:A <> origin/A on b625665 {1}
-    └── 📙:3:A <> origin/A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on b625665
+└── ≡📙:A <> origin/A on b625665 {1}
+    └── 📙:A <> origin/A
         └── ❄️6507810 (🏘️)
 
 "#]]
@@ -8017,9 +8017,9 @@ fn shallow_boundary_in_workspace_prevents_lower_bound() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓!
-└── ≡📙:1:A {1}
-    └── 📙:1:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓!
+└── ≡📙:A {1}
+    └── 📙:A
         └── ·6507810 (🏘️|⛰)
 
 "#]]
@@ -8080,13 +8080,13 @@ fn applied_stack_below_explicit_lower_bound() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on bce0c5e
-├── ≡:1:B on bce0c5e
-│   └── :1:B
+📕🏘️:gitbutler/workspace[🌳] <> ✓! on bce0c5e
+├── ≡:B on bce0c5e
+│   └── :B
 │       ├── ·78b1b59 (🏘️)
 │       └── ·f52fcec (🏘️)
-└── ≡:2:A on bce0c5e
-    └── :2:A
+└── ≡:A on bce0c5e
+    └── :A
         └── ·6fdab32 (🏘️)
 
 "#]]
@@ -8127,12 +8127,12 @@ fn applied_stack_below_explicit_lower_bound() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on bce0c5e
-├── ≡📙:3:A on bce0c5e {0}
-│   └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on bce0c5e
+├── ≡📙:A on bce0c5e {0}
+│   └── 📙:A
 │       └── ·6fdab32 (🏘️)
-└── ≡📙:4:B on f52fcec {1}
-    └── 📙:4:B
+└── ≡📙:B on f52fcec {1}
+    └── 📙:B
         └── ·78b1b59 (🏘️)
 
 "#]]
@@ -8174,12 +8174,12 @@ fn applied_stack_below_explicit_lower_bound() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on bce0c5e
-├── ≡📙:4:A on bce0c5e {0}
-│   └── 📙:4:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on bce0c5e
+├── ≡📙:A on bce0c5e {0}
+│   └── 📙:A
 │       └── ·6fdab32 (🏘️)
-└── ≡📙:5:B on f52fcec {1}
-    └── 📙:5:B
+└── ≡📙:B on f52fcec {1}
+    └── 📙:B
         └── ·78b1b59 (🏘️)
 
 "#]]
@@ -8241,14 +8241,14 @@ fn applied_stack_above_explicit_lower_bound() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on bce0c5e
-├── ≡:1:B on bce0c5e
-│   └── :1:B
+📕🏘️:gitbutler/workspace[🌳] <> ✓! on bce0c5e
+├── ≡:B on bce0c5e
+│   └── :B
 │       └── ·ce25240 (🏘️)
-└── ≡:2:A on bce0c5e
-    ├── :2:A
+└── ≡:A on bce0c5e
+    ├── :A
     │   └── ·de6d39c (🏘️)
-    └── :3:main <> origin/main
+    └── :main <> origin/main
         └── ❄️a821094 (🏘️)
 
 "#]]
@@ -8349,28 +8349,28 @@ fn dependent_branch_on_base() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
-├── ≡📙:3:A on 3183e43 {1}
-│   ├── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+├── ≡📙:A on 3183e43 {1}
+│   ├── 📙:A
 │   │   └── ·49d4b34 (🏘️)
-│   ├── 📙:18:below-A
-│   └── 📙:19:below-below-A
-├── ≡📙:6:B on 3183e43 {2}
-│   ├── 📙:6:B
-│   ├── 📙:7:below-B
-│   └── 📙:8:below-below-B
-└── ≡📙:9:C on 3183e43 {3}
-    ├── 📙:9:C
-    ├── 📙:10:C2-1
-    ├── 📙:11:C2-2
-    ├── 📙:12:C2-3
+│   ├── 📙:below-A
+│   └── 📙:below-below-A
+├── ≡📙:B on 3183e43 {2}
+│   ├── 📙:B
+│   ├── 📙:below-B
+│   └── 📙:below-below-B
+└── ≡📙:C on 3183e43 {3}
+    ├── 📙:C
+    ├── 📙:C2-1
+    ├── 📙:C2-2
+    ├── 📙:C2-3
     │   └── ·f9e2cb7 (🏘️)
-    ├── 📙:13:C1-3
-    ├── 📙:14:C1-2
-    ├── 📙:15:C1-1
+    ├── 📙:C1-3
+    ├── 📙:C1-2
+    ├── 📙:C1-1
     │   └── ·aaa195b (🏘️)
-    ├── 📙:16:below-C
-    └── 📙:17:below-below-C
+    ├── 📙:below-C
+    └── 📙:below-below-C
 
 "#]]
     );
@@ -8392,25 +8392,25 @@ fn dependent_branch_on_base() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
-├── ≡📙:6:B on 3183e43 {2}
-│   ├── 📙:6:B
-│   ├── 📙:7:below-B
-│   └── 📙:8:below-below-B
-├── ≡📙:9:C on 3183e43 {3}
-│   ├── 📙:9:C
-│   ├── 📙:10:C2-1
-│   ├── 📙:11:C2-2
-│   ├── 📙:12:C2-3
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+├── ≡📙:B on 3183e43 {2}
+│   ├── 📙:B
+│   ├── 📙:below-B
+│   └── 📙:below-below-B
+├── ≡📙:C on 3183e43 {3}
+│   ├── 📙:C
+│   ├── 📙:C2-1
+│   ├── 📙:C2-2
+│   ├── 📙:C2-3
 │   │   └── ·f9e2cb7 (🏘️)
-│   ├── 📙:13:C1-3
-│   ├── 📙:14:C1-2
-│   ├── 📙:15:C1-1
+│   ├── 📙:C1-3
+│   ├── 📙:C1-2
+│   ├── 📙:C1-1
 │   │   └── ·aaa195b (🏘️)
-│   ├── 📙:16:below-C
-│   └── 📙:17:below-below-C
-└── ≡📙:5:A on 3183e43 {1}
-    └── 📙:5:A
+│   ├── 📙:below-C
+│   └── 📙:below-below-C
+└── ≡📙:A on 3183e43 {1}
+    └── 📙:A
         └── ·49d4b34 (🏘️)
 
 "#]]
@@ -8454,9 +8454,9 @@ fn remote_and_integrated_tracking_branch_on_merge() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 1ee1e34
-└── ≡📙:8:A <> origin/A⇣1 on 1ee1e34 {1}
-    └── 📙:8:A <> origin/A⇣1
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 1ee1e34
+└── ≡📙:A <> origin/A⇣1 on 1ee1e34 {1}
+    └── 📙:A <> origin/A⇣1
         └── 🟣2181501
 
 "#]]
@@ -8495,9 +8495,9 @@ fn remote_and_integrated_tracking_branch_on_linear_segment() -> anyhow::Result<(
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 081bae9
-└── ≡📙:5:A <> origin/A⇣1 on 081bae9 {1}
-    └── 📙:5:A <> origin/A⇣1
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 081bae9
+└── ≡📙:A <> origin/A⇣1 on 081bae9 {1}
+    └── 📙:A <> origin/A⇣1
         └── 🟣197ddce
 
 "#]]
@@ -8542,9 +8542,9 @@ fn remote_and_integrated_tracking_branch_on_merge_extra_target() -> anyhow::Resu
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 1ee1e34
-└── ≡📙:3:A <> origin/A⇡1⇣1 on 1ee1e34 {1}
-    └── 📙:3:A <> origin/A⇡1⇣1
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 1ee1e34
+└── ≡📙:A <> origin/A⇡1⇣1 on 1ee1e34 {1}
+    └── 📙:A <> origin/A⇡1⇣1
         ├── 🟣2181501
         └── ·9f47a25 (🏘️)
 
@@ -8593,7 +8593,7 @@ fn unapplied_branch_on_base() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
 
 "#]]
     );
@@ -8611,9 +8611,9 @@ fn unapplied_branch_on_base() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡📙:3:unapplied on fafd9d0 {1}
-    └── 📙:3:unapplied
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡📙:unapplied on fafd9d0 {1}
+    └── 📙:unapplied
 
 "#]]
     );
@@ -8634,7 +8634,7 @@ fn unapplied_branch_on_base() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
 
 "#]]
     );
@@ -8723,9 +8723,9 @@ fn shared_target_base_keeps_exact_target_segment_with_inactive_unapplied_branch(
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on ce09734
-└── ≡📙:3:survivor on ce09734 {1}
-    └── 📙:3:survivor
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on ce09734
+└── ≡📙:survivor on ce09734 {1}
+    └── 📙:survivor
         ├── ·4ca0966 (🏘️)
         └── ·a3b180e (🏘️)
 
@@ -8747,13 +8747,13 @@ fn shared_target_base_keeps_exact_target_segment_with_inactive_unapplied_branch(
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on ce09734
-├── ≡📙:3:survivor on ce09734 {1}
-│   └── 📙:3:survivor
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on ce09734
+├── ≡📙:survivor on ce09734 {1}
+│   └── 📙:survivor
 │       ├── ·4ca0966 (🏘️)
 │       └── ·a3b180e (🏘️)
-└── ≡📙:4:unapplied on ce09734 {2}
-    └── 📙:4:unapplied
+└── ≡📙:unapplied on ce09734 {2}
+    └── 📙:unapplied
 
 "#]]
     );
@@ -8829,7 +8829,7 @@ fn worktree_tip_in_workspace_priority_mode() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳@repo] <> ✓refs/remotes/origin/main on fafd9d0
+📕🏘️:gitbutler/workspace[🌳@repo] <> ✓refs/remotes/origin/main on fafd9d0
 
 "#]]
     );
@@ -8988,9 +8988,9 @@ fn unapplied_branch_on_base_no_target() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓!
-└── ≡:2:main <> origin/main
-    └── :2:main <> origin/main
+📕🏘️:gitbutler/workspace[🌳] <> ✓!
+└── ≡:main <> origin/main
+    └── :main <> origin/main
         └── ❄️fafd9d0 (🏘️) ►unapplied
 
 "#]]
@@ -9024,11 +9024,11 @@ fn unapplied_branch_on_base_no_target() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-├── ≡📙:3:unapplied on fafd9d0 {1}
-│   └── 📙:3:unapplied
-└── ≡📙:4:main <> origin/main on fafd9d0 {2}
-    └── 📙:4:main <> origin/main
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+├── ≡📙:unapplied on fafd9d0 {1}
+│   └── 📙:unapplied
+└── ≡📙:main <> origin/main on fafd9d0 {2}
+    └── 📙:main <> origin/main
 
 "#]]
     );
@@ -9049,9 +9049,9 @@ fn unapplied_branch_on_base_no_target() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡📙:3:main <> origin/main on fafd9d0 {2}
-    └── 📙:3:main <> origin/main
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡📙:main <> origin/main on fafd9d0 {2}
+    └── 📙:main <> origin/main
 
 "#]]
     );
@@ -9103,11 +9103,11 @@ fn no_ws_commit_two_branches_no_target() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on bce0c5e
-├── ≡📙:3:main <> origin/main on bce0c5e {0}
-│   └── 📙:3:main <> origin/main
-└── ≡📙:4:A on bce0c5e {1}
-    └── 📙:4:A
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓! on bce0c5e
+├── ≡📙:main <> origin/main on bce0c5e {0}
+│   └── 📙:main <> origin/main
+└── ≡📙:A on bce0c5e {1}
+    └── 📙:A
 
 "#]]
     );
@@ -9173,12 +9173,12 @@ fn ambiguous_worktrees() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳@repo] <> ✓refs/remotes/origin/main⇣1 on 081bae9
-├── ≡📙:6:A <> origin/A⇣1 on 081bae9 {0}
-│   └── 📙:6:A <> origin/A⇣1
+📕🏘️:gitbutler/workspace[🌳@repo] <> ✓refs/remotes/origin/main⇣1 on 081bae9
+├── ≡📙:A <> origin/A⇣1 on 081bae9 {0}
+│   └── 📙:A <> origin/A⇣1
 │       └── 🟣197ddce
-└── ≡:5:B[📁wt-B-inside] on 081bae9
-    └── :5:B[📁wt-B-inside]
+└── ≡:B[📁wt-B-inside] on 081bae9
+    └── :B[📁wt-B-inside]
         └── ·3e01e28 (🏘️)
 
 "#]]
@@ -9231,12 +9231,12 @@ fn ambiguous_worktrees() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:1:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 081bae9
-├── ≡📙:6:A <> origin/A⇣1 on 081bae9 {0}
-│   └── 📙:6:A <> origin/A⇣1
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 081bae9
+├── ≡📙:A <> origin/A⇣1 on 081bae9 {0}
+│   └── 📙:A <> origin/A⇣1
 │       └── 🟣197ddce
-└── ≡👉:0:B[📁wt-B-inside@repo] on 081bae9
-    └── 👉:0:B[📁wt-B-inside@repo]
+└── ≡👉:B[📁wt-B-inside@repo] on 081bae9
+    └── 👉:B[📁wt-B-inside@repo]
         └── ·3e01e28 (🏘️)
 
 "#]]
@@ -9292,9 +9292,9 @@ fn duplicate_parent_connection_from_ws_commit_to_ambiguous_branch_no_advanced_ta
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡📙:3:A on fafd9d0 {1}
-    └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡📙:A on fafd9d0 {1}
+    └── 📙:A
 
 "#]]
     );
@@ -9308,11 +9308,11 @@ fn duplicate_parent_connection_from_ws_commit_to_ambiguous_branch_no_advanced_ta
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-├── ≡📙:3:A on fafd9d0 {1}
-│   └── 📙:3:A
-└── ≡📙:4:B on fafd9d0 {2}
-    └── 📙:4:B
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+├── ≡📙:A on fafd9d0 {1}
+│   └── 📙:A
+└── ≡📙:B on fafd9d0 {2}
+    └── 📙:B
 
 "#]]
     );
@@ -9327,10 +9327,10 @@ fn duplicate_parent_connection_from_ws_commit_to_ambiguous_branch_no_advanced_ta
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡📙:3:A on fafd9d0 {1}
-    ├── 📙:3:A
-    └── 📙:4:B
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡📙:A on fafd9d0 {1}
+    ├── 📙:A
+    └── 📙:B
 
 "#]]
     );
@@ -9388,9 +9388,9 @@ fn duplicate_parent_connection_from_ws_commit_to_ambiguous_branch() -> anyhow::R
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on fafd9d0
-└── ≡📙:3:A on fafd9d0 {1}
-    └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on fafd9d0
+└── ≡📙:A on fafd9d0 {1}
+    └── 📙:A
 
 "#]]
     );
@@ -9404,11 +9404,11 @@ fn duplicate_parent_connection_from_ws_commit_to_ambiguous_branch() -> anyhow::R
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on fafd9d0
-├── ≡📙:3:A on fafd9d0 {1}
-│   └── 📙:3:A
-└── ≡📙:4:B on fafd9d0 {2}
-    └── 📙:4:B
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on fafd9d0
+├── ≡📙:A on fafd9d0 {1}
+│   └── 📙:A
+└── ≡📙:B on fafd9d0 {2}
+    └── 📙:B
 
 "#]]
     );
@@ -9423,10 +9423,10 @@ fn duplicate_parent_connection_from_ws_commit_to_ambiguous_branch() -> anyhow::R
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on fafd9d0
-└── ≡📙:3:A on fafd9d0 {1}
-    ├── 📙:3:A
-    └── 📙:4:B
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on fafd9d0
+└── ≡📙:A on fafd9d0 {1}
+    ├── 📙:A
+    └── 📙:B
 
 "#]]
     );
@@ -9445,11 +9445,11 @@ fn duplicate_parent_connection_from_ws_commit_to_ambiguous_branch() -> anyhow::R
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on fafd9d0
-├── ≡📙:3:A on fafd9d0 {1}
-│   └── 📙:3:A
-└── ≡📙:4:B on fafd9d0 {2}
-    └── 📙:4:B
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on fafd9d0
+├── ≡📙:A on fafd9d0 {1}
+│   └── 📙:A
+└── ≡📙:B on fafd9d0 {2}
+    └── 📙:B
 
 "#]]
     );
@@ -9466,10 +9466,10 @@ fn duplicate_parent_connection_from_ws_commit_to_ambiguous_branch() -> anyhow::R
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on fafd9d0
-└── ≡📙:3:A on fafd9d0 {1}
-    ├── 📙:3:A
-    └── 📙:4:B
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on fafd9d0
+└── ≡📙:A on fafd9d0 {1}
+    ├── 📙:A
+    └── 📙:B
 
 "#]]
     );
@@ -9528,9 +9528,9 @@ mod edit_commit {
         snapbox::assert_data_eq!(
             graph_workspace(&graph.into_workspace()?).to_string(),
             snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡:3:A on fafd9d0
-    └── :3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡:A on fafd9d0
+    └── :A
         ├── ·a62b0de (🏘️)
         └── ·120a217 (🏘️)
 
@@ -9567,11 +9567,11 @@ mod edit_commit {
         snapbox::assert_data_eq!(
             graph_workspace(&graph.into_workspace()?).to_string(),
             snapbox::str![[r#"
-📕🏘️:1:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡:4:A on fafd9d0
-    ├── :4:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡:A on fafd9d0
+    ├── :A
     │   └── ·a62b0de (🏘️)
-    └── 👉:0:gitbutler/edit
+    └── 👉:gitbutler/edit
         └── ·120a217 (🏘️)
 
 "#]]
@@ -9634,9 +9634,9 @@ fn complex_merge_history_with_origin_main_target() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣10 on 68e62aa
-└── ≡:12:anon: on 68e62aa
-    └── :12:anon:
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣10 on 68e62aa
+└── ≡:anon: on 68e62aa
+    └── :anon:
         ├── ·4eaff93 (🏘️) ►local-stack, ►reconstructed-insert-blank-commit-branch, ►reimplement-insert-blank-commit
         ├── ·d19db1d (🏘️)
         └── ·fb0a67e (🏘️)
@@ -9664,10 +9664,10 @@ fn complex_merge_history_with_origin_main_target() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣10 on 68e62aa
-└── ≡📙:13:reimplement-insert-blank-commit on 68e62aa {0}
-    ├── 📙:13:reimplement-insert-blank-commit
-    └── 📙:14:reconstructed-insert-blank-commit-branch
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣10 on 68e62aa
+└── ≡📙:reimplement-insert-blank-commit on 68e62aa {0}
+    ├── 📙:reimplement-insert-blank-commit
+    └── 📙:reconstructed-insert-blank-commit-branch
         ├── ·4eaff93 (🏘️) ►local-stack
         ├── ·d19db1d (🏘️)
         └── ·fb0a67e (🏘️)
@@ -9730,12 +9730,12 @@ fn reproduce_12146() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on e32cf47
-├── ≡📙:5:A on e32cf47 {0}
-│   └── 📙:5:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on e32cf47
+├── ≡📙:A on e32cf47 {0}
+│   └── 📙:A
 │       └── ·81d4e38 (🏘️)
-└── ≡📙:4:B on e32cf47 {1}
-    └── 📙:4:B
+└── ≡📙:B on e32cf47 {1}
+    └── 📙:B
         ├── ·7163661 (🏘️)
         └── ·81d4e38 (🏘️)
 
@@ -9784,9 +9784,9 @@ fn integrated_merge_at_bottom_is_kept() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on f5f42e0
-└── ≡📙:3:local-stack on fafd9d0 {0}
-    └── 📙:3:local-stack
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on f5f42e0
+└── ≡📙:local-stack on fafd9d0 {0}
+    └── 📙:local-stack
         ├── ·66ea651 (🏘️)
         ├── ·e5a88a7 (🏘️)
         └── ·0b3ccaf (🏘️)
@@ -9854,9 +9854,9 @@ fn merge_from_main_keeps_all_branch_commits() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on ef56fab
-└── ≡📙:3:my-branch on fafd9d0 {0}
-    └── 📙:3:my-branch
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on ef56fab
+└── ≡📙:my-branch on fafd9d0 {0}
+    └── 📙:my-branch
         ├── ·cd76046 (🏘️)
         ├── ·f8ff9a3 (🏘️)
         └── ·6f65768 (🏘️)
@@ -9902,9 +9902,9 @@ fn integrated_commits_above_target_are_kept() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on fafd9d0
-└── ≡📙:4:my-branch on fafd9d0 {0}
-    └── 📙:4:my-branch
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on fafd9d0
+└── ≡📙:my-branch on fafd9d0 {0}
+    └── 📙:my-branch
         ├── ·312f819 (🏘️|✓)
         └── ·e255adc (🏘️|✓)
 
@@ -9928,9 +9928,9 @@ fn integrated_commits_above_target_are_kept() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 312f819
-└── ≡📙:5:my-branch on 312f819 {0}
-    └── 📙:5:my-branch
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 312f819
+└── ≡📙:my-branch on 312f819 {0}
+    └── 📙:my-branch
 
 "#]]
     );
@@ -9992,12 +9992,12 @@ fn integrated_commits_below_target_pruned_when_upstream_ahead() -> anyhow::Resul
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 322cb14
-├── ≡📙:4:my-branch on 2121f9c {0}
-│   └── 📙:4:my-branch
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 322cb14
+├── ≡📙:my-branch on 2121f9c {0}
+│   └── 📙:my-branch
 │       └── ·f5055a1 (🏘️)
-└── ≡📙:5:old-branch on 322cb14 {1}
-    └── 📙:5:old-branch
+└── ≡📙:old-branch on 322cb14 {1}
+    └── 📙:old-branch
         └── ·f458f7d (🏘️)
 
 "#]]
@@ -10042,9 +10042,9 @@ fn catchup_merge_below_target_floors_at_fork() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on d263f88
-└── ≡📙:4:X on b4bd43f {0}
-    └── 📙:4:X
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on d263f88
+└── ≡📙:X on b4bd43f {0}
+    └── 📙:X
         ├── ·f210f41 (🏘️)
         ├── ·f8cd0ce (🏘️)
         └── ·4eec82a (🏘️)
@@ -10102,9 +10102,9 @@ fn entrypoint_on_workspace_commit() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡:3:A on fafd9d0
-    └── :3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡:A on fafd9d0
+    └── :A
         ├── ·a62b0de (🏘️)
         └── ·120a217 (🏘️)
 
@@ -10140,9 +10140,9 @@ fn entrypoint_on_workspace_commit() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:1:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡:4:A on fafd9d0
-    └── :4:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡:A on fafd9d0
+    └── :A
         ├── ·a62b0de (🏘️)
         └── ·120a217 (🏘️)
 
@@ -10194,9 +10194,9 @@ fn remote_only_stack_top() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡:3:anon: on fafd9d0
-    └── :3:anon:
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡:anon: on fafd9d0
+    └── :anon:
         ├── ·a62b0de (🏘️)
         └── ·120a217 (🏘️)
 
@@ -10251,7 +10251,7 @@ fn remote_trailing_local_stack() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on cb7021b
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on cb7021b
 
 "#]]
     );
@@ -10306,9 +10306,9 @@ fn remote_ref_as_stack_top() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡:3:anon: on fafd9d0
-    └── :3:anon:
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡:anon: on fafd9d0
+    └── :anon:
         ├── ·a62b0de (🏘️)
         └── ·120a217 (🏘️)
 
@@ -10361,9 +10361,9 @@ fn worktree_ref_at_applied_branch() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳@repo] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡📙:3:foo on fafd9d0 {0}
-    └── 📙:3:foo
+📕🏘️:gitbutler/workspace[🌳@repo] <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡📙:foo on fafd9d0 {0}
+    └── 📙:foo
         └── ·e255adc (🏘️) ►wsref[📁worktree-ref-at-applied-branch-wt]
 
 "#]]
@@ -10400,10 +10400,10 @@ fn worktree_ref_at_applied_branch() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳@repo] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡📙:4:foo on fafd9d0 {0}
-    ├── 📙:4:foo
-    └── 📙:5:wsref[📁worktree-ref-at-applied-branch-wt]
+📕🏘️:gitbutler/workspace[🌳@repo] <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡📙:foo on fafd9d0 {0}
+    ├── 📙:foo
+    └── 📙:wsref[📁worktree-ref-at-applied-branch-wt]
         └── ·e255adc (🏘️)
 
 "#]]
@@ -10448,9 +10448,9 @@ fn worktree_ref_at_applied_branch_with_discovery() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳@repo] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡📙:5:foo on fafd9d0 {0}
-    └── 📙:5:foo
+📕🏘️:gitbutler/workspace[🌳@repo] <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡📙:foo on fafd9d0 {0}
+    └── 📙:foo
         └── ·e255adc (🏘️)
 
 "#]]
@@ -10482,9 +10482,9 @@ fn worktree_ref_at_applied_branch_with_discovery() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳@repo] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡📙:4:foo on fafd9d0 {0}
-    └── 📙:4:foo
+📕🏘️:gitbutler/workspace[🌳@repo] <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡📙:foo on fafd9d0 {0}
+    └── 📙:foo
         └── ·e255adc (🏘️)
 
 "#]]
@@ -10542,9 +10542,9 @@ fn worktree_ref_mid_stack() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳@repo] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡📙:3:foo on fafd9d0 {0}
-    └── 📙:3:foo
+📕🏘️:gitbutler/workspace[🌳@repo] <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡📙:foo on fafd9d0 {0}
+    └── 📙:foo
         ├── ·a62b0de (🏘️)
         └── ·120a217 (🏘️)
 
@@ -10636,9 +10636,9 @@ fn worktree_ref_as_stack_top_is_spliced_into_fork() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳@repo] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡📙:3:foo on fafd9d0 {0}
-    └── 📙:3:foo
+📕🏘️:gitbutler/workspace[🌳@repo] <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡📙:foo on fafd9d0 {0}
+    └── 📙:foo
         └── ·e255adc (🏘️)
 
 "#]]
@@ -10734,9 +10734,9 @@ fn worktree_ref_at_remote_tracked_branch() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳@repo] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡📙:7:foo <> origin/foo on fafd9d0 {0}
-    └── 📙:7:foo <> origin/foo
+📕🏘️:gitbutler/workspace[🌳@repo] <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡📙:foo <> origin/foo on fafd9d0 {0}
+    └── 📙:foo <> origin/foo
         └── ❄️e255adc (🏘️)
 
 "#]]
@@ -10777,9 +10777,9 @@ fn worktree_ref_at_remote_tracked_branch() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳@repo] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡:3:anon: on fafd9d0
-    └── :3:anon:
+📕🏘️:gitbutler/workspace[🌳@repo] <> ✓refs/remotes/origin/main on fafd9d0
+└── ≡:anon: on fafd9d0
+    └── :anon:
         └── ·e255adc (🏘️) ►foo
 
 "#]]

--- a/crates/but-graph/tests/graph/init/with_workspace.rs
+++ b/crates/but-graph/tests/graph/init/with_workspace.rs
@@ -92,8 +92,8 @@ Commit(59a427f, ⌂|🏘)
         graph_workspace(ws).to_string(),
         snapbox::str![[r#"
 📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on fafd9d0
-├── ≡:1:main <> origin/main →:2:⇡1⇣1 on fafd9d0
-│   └── :1:main <> origin/main →:2:⇡1⇣1
+├── ≡:1:main <> origin/main⇡1⇣1 on fafd9d0
+│   └── :1:main <> origin/main⇡1⇣1
 │       ├── 🟣1f5c47b
 │       ├── ·0a415d8 (🏘️)
 │       └── ❄️73ba99d (🏘️)
@@ -343,8 +343,8 @@ fn no_overzealous_stacks_due_to_workspace_metadata() -> anyhow::Result<()> {
 │   └── :7:anon:
 │       ├── ·835086d (🏘️) ►four, ►three
 │       └── ·ff310d3 (🏘️)
-└── ≡📙:3:X <> origin/X →:5:⇡1 on 3183e43 {1}
-    └── 📙:3:X <> origin/X →:5:⇡1
+└── ≡📙:3:X <> origin/X⇡1 on 3183e43 {1}
+    └── 📙:3:X <> origin/X⇡1
         ├── ·0b203b5 (🏘️)
         └── ❄️4840f3b (🏘️)
 
@@ -422,8 +422,8 @@ fn single_stack_ambiguous() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡:3:B <> origin/B →:4:⇡3 on fafd9d0
-    └── :3:B <> origin/B →:4:⇡3
+└── ≡:3:B <> origin/B⇡3 on fafd9d0
+    └── :3:B <> origin/B⇡3
         ├── ·70e9a36 (🏘️)
         ├── ·320e105 (🏘️) ►tags/without-ref
         ├── ·2a31450 (🏘️) ►B-empty, ►ambiguous-01
@@ -486,8 +486,8 @@ fn single_stack_ambiguous() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 📕🏘️:1:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡:4:B <> origin/B →:5:⇡1 on fafd9d0
-    ├── :4:B <> origin/B →:5:⇡1
+└── ≡:4:B <> origin/B⇡1 on fafd9d0
+    ├── :4:B <> origin/B⇡1
     │   └── ·70e9a36 (🏘️)
     └── 👉:0:tags/without-ref
         ├── ·320e105 (🏘️)
@@ -549,8 +549,8 @@ fn single_stack_ambiguous() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 📕🏘️:1:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡:4:B <> origin/B →:5:⇡1 on fafd9d0
-    ├── :4:B <> origin/B →:5:⇡1
+└── ≡:4:B <> origin/B⇡1 on fafd9d0
+    ├── :4:B <> origin/B⇡1
     │   └── ·70e9a36 (🏘️)
     └── 👉:0:anon:
         ├── ·320e105 (🏘️) ►tags/without-ref
@@ -613,8 +613,8 @@ fn single_stack_ambiguous() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 📕🏘️:1:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡:4:B <> origin/B →:5:⇡2 on fafd9d0
-    ├── :4:B <> origin/B →:5:⇡2
+└── ≡:4:B <> origin/B⇡2 on fafd9d0
+    ├── :4:B <> origin/B⇡2
     │   ├── ·70e9a36 (🏘️)
     │   └── ·320e105 (🏘️) ►tags/without-ref
     └── 👉:0:anon:
@@ -674,8 +674,8 @@ fn single_stack_ambiguous() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 📕🏘️:1:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡:4:B <> origin/B →:5:⇡2 on fafd9d0
-    ├── :4:B <> origin/B →:5:⇡2
+└── ≡:4:B <> origin/B⇡2 on fafd9d0
+    ├── :4:B <> origin/B⇡2
     │   ├── ·70e9a36 (🏘️)
     │   └── ·320e105 (🏘️) ►tags/without-ref
     └── 👉:0:B-empty
@@ -766,8 +766,8 @@ fn single_stack_ws_insertions() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡📙:4:B <> origin/B →:6:⇡2 on fafd9d0 {0}
-    ├── 📙:4:B <> origin/B →:6:⇡2
+└── ≡📙:4:B <> origin/B⇡2 on fafd9d0 {0}
+    ├── 📙:4:B <> origin/B⇡2
     │   ├── ·70e9a36 (🏘️)
     │   └── ·320e105 (🏘️) ►tags/without-ref
     ├── 📙:3:B-empty
@@ -835,8 +835,8 @@ fn single_stack_ws_insertions() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡📙:4:B <> origin/B →:6:⇡2 on fafd9d0 {0}
-    ├── 📙:4:B <> origin/B →:6:⇡2
+└── ≡📙:4:B <> origin/B⇡2 on fafd9d0 {0}
+    ├── 📙:4:B <> origin/B⇡2
     │   ├── ·70e9a36 (🏘️)
     │   └── ·320e105 (🏘️) ►tags/without-ref
     ├── 📙:3:B-empty
@@ -899,8 +899,8 @@ fn single_stack_ws_insertions() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 📕🏘️:1:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡📙:5:B <> origin/B →:6:⇡2 on fafd9d0 {1}
-    ├── 📙:5:B <> origin/B →:6:⇡2
+└── ≡📙:5:B <> origin/B⇡2 on fafd9d0 {1}
+    ├── 📙:5:B <> origin/B⇡2
     │   ├── ·70e9a36 (🏘️)
     │   └── ·320e105 (🏘️) ►tags/without-ref
     ├── 📙:4:B-empty
@@ -930,8 +930,8 @@ fn single_stack_ws_insertions() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 📕🏘️:1:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-├── ≡📙:5:B <> origin/B →:6:⇡2 on fafd9d0 {1}
-│   ├── 📙:5:B <> origin/B →:6:⇡2
+├── ≡📙:5:B <> origin/B⇡2 on fafd9d0 {1}
+│   ├── 📙:5:B <> origin/B⇡2
 │   │   ├── ·70e9a36 (🏘️)
 │   │   └── ·320e105 (🏘️) ►tags/without-ref
 │   ├── 📙:4:B-empty
@@ -1408,7 +1408,7 @@ fn minimal_merge() -> anyhow::Result<()> {
     │   └── ·0cc5a6f ►empty-1-on-merge, ►empty-2-on-merge, ►merge
     ├── :5:B
     │   └── ·7fdb58d
-    └── :7:main <> origin/main →:8:
+    └── :7:main <> origin/main
         └── ❄️fafd9d0
 
 "#]]
@@ -1771,8 +1771,8 @@ fn just_init_with_branches() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 ⌂:0:main[🌳] <> ✓refs/remotes/origin/main
-└── ≡:0:main[🌳] <> origin/main →:2: on fafd9d0 {1}
-    └── :0:main[🌳] <> origin/main →:2:
+└── ≡:0:main[🌳] <> origin/main on fafd9d0 {1}
+    └── :0:main[🌳] <> origin/main
 
 "#]]
     );
@@ -1815,8 +1815,8 @@ fn just_init_with_branches() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 📕🏘️⚠️:0:gitbutler/workspace <> ✓!
-└── ≡:1:main[🌳] <> origin/main →:2:
-    └── :1:main[🌳] <> origin/main →:2:
+└── ≡:1:main[🌳] <> origin/main
+    └── :1:main[🌳] <> origin/main
         └── ❄️fafd9d0 (🏘️) ►A, ►B, ►C, ►D, ►E, ►F
 
 "#]]
@@ -2811,8 +2811,8 @@ fn proper_remote_ahead() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 ⌂:0:main <> ✓refs/remotes/origin/main⇣2
-└── ≡:0:main <> origin/main →:2:⇣2 on 998eae6 {1}
-    └── :0:main <> origin/main →:2:⇣2
+└── ≡:0:main <> origin/main⇣2 on 998eae6 {1}
+    └── :0:main <> origin/main⇣2
         ├── 🟣ca7baa7 (✓)
         └── 🟣7ea1468 (✓)
 
@@ -2877,8 +2877,8 @@ fn deduced_remote_ahead() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 📕🏘️:0:gitbutler/workspace[🌳] <> ✓!
-└── ≡:1:A <> origin/A →:2:⇡2⇣4
-    ├── :1:A <> origin/A →:2:⇡2⇣4
+└── ≡:1:A <> origin/A⇡2⇣4
+    ├── :1:A <> origin/A⇡2⇣4
     │   ├── 🟣3ea1a8f
     │   ├── 🟣9c50f71
     │   ├── 🟣2cfbb79
@@ -2927,8 +2927,8 @@ fn deduced_remote_ahead() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 📕🏘️:1:gitbutler/workspace[🌳] <> ✓!
-└── ≡:2:A <> origin/A →:3:⇡2⇣4
-    ├── :2:A <> origin/A →:3:⇡2⇣4
+└── ≡:2:A <> origin/A⇡2⇣4
+    ├── :2:A <> origin/A⇡2⇣4
     │   ├── 🟣3ea1a8f
     │   ├── 🟣9c50f71
     │   ├── 🟣2cfbb79
@@ -2971,8 +2971,8 @@ fn deduced_remote_ahead() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 📕🏘️:0:gitbutler/workspace[🌳] <> ✓!
-└── ≡:1:A <> push-remote/A →:2:⇡2⇣4
-    ├── :1:A <> push-remote/A →:2:⇡2⇣4
+└── ≡:1:A <> push-remote/A⇡2⇣4
+    ├── :1:A <> push-remote/A⇡2⇣4
     │   ├── 🟣3ea1a8f
     │   ├── 🟣9c50f71
     │   ├── 🟣2cfbb79
@@ -3044,7 +3044,7 @@ fn stacked_rebased_remotes() -> anyhow::Result<()> {
     │   └── ·312f819 (🏘️)
     ├── :2:A
     │   └── ·e255adc (🏘️)
-    └── :3:main <> origin/main →:4:
+    └── :3:main <> origin/main
         └── ❄️fafd9d0 (🏘️)
 
 "#]]
@@ -3086,11 +3086,11 @@ fn stacked_rebased_remotes() -> anyhow::Result<()> {
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
 📕🏘️:1:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡:5:B <> origin/B →:6:⇡1⇣1 on fafd9d0
-    ├── :5:B <> origin/B →:6:⇡1⇣1
+└── ≡:5:B <> origin/B⇡1⇣1 on fafd9d0
+    ├── :5:B <> origin/B⇡1⇣1
     │   ├── 🟣682be32
     │   └── ·312f819 (🏘️)
-    └── 👉:0:A <> origin/A →:4:⇡1⇣1
+    └── 👉:0:A <> origin/A⇡1⇣1
         ├── 🟣e29c23d
         └── ·e255adc (🏘️)
 
@@ -3237,7 +3237,7 @@ fn target_with_remote_on_stack_tip() -> anyhow::Result<()> {
 📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
 └── ≡📙:3:A on fafd9d0 {1}
     ├── 📙:3:A
-    └── 📙:4:main <> origin/main →:1:⇡1
+    └── 📙:4:main <> origin/main⇡1
         └── ·e255adc (🏘️)
 
 "#]]
@@ -3257,8 +3257,8 @@ fn target_with_remote_on_stack_tip() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡📙:3:main <> origin/main →:1: on fafd9d0 {1}
-    ├── 📙:3:main <> origin/main →:1:
+└── ≡📙:3:main <> origin/main on fafd9d0 {1}
+    ├── 📙:3:main <> origin/main
     └── 📙:4:A
         └── ·e255adc (🏘️)
 
@@ -3349,10 +3349,10 @@ fn disambiguate_by_remote() -> anyhow::Result<()> {
 └── ≡:6:anon: on fafd9d0
     ├── :6:anon:
     │   └── ·2173153 (🏘️) ►C, ►ambiguous-C
-    ├── :9:B <> origin/B →:5:⇣1
+    ├── :9:B <> origin/B⇣1
     │   ├── 🟣ac24e74
     │   └── ❄️312f819 (🏘️) ►ambiguous-B
-    └── :8:A <> origin/A →:7:
+    └── :8:A <> origin/A
         └── ❄️e255adc (🏘️) ►ambiguous-A
 
 "#]]
@@ -3405,13 +3405,13 @@ fn disambiguate_by_remote() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡📙:3:C <> origin/C →:4: on fafd9d0 {0}
-    ├── 📙:3:C <> origin/C →:4:
+└── ≡📙:3:C <> origin/C on fafd9d0 {0}
+    ├── 📙:3:C <> origin/C
     │   └── ❄️2173153 (🏘️) ►ambiguous-C
-    ├── :9:B <> origin/B →:6:⇣1
+    ├── :9:B <> origin/B⇣1
     │   ├── 🟣ac24e74
     │   └── ❄️312f819 (🏘️) ►ambiguous-B
-    └── :8:A <> origin/A →:7:
+    └── :8:A <> origin/A
         └── ❄️e255adc (🏘️) ►ambiguous-A
 
 "#]]
@@ -4066,8 +4066,8 @@ fn integrated_tips_do_not_stop_early() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 ⌂:0:main <> ✓refs/remotes/origin/main⇣3
-└── ≡:0:main <> origin/main →:2:⇣3 on 4b3e5a8 {1}
-    └── :0:main <> origin/main →:2:⇣3
+└── ≡:0:main <> origin/main⇣3 on 4b3e5a8 {1}
+    └── :0:main <> origin/main⇣3
         ├── 🟣d0df794 (✓)
         ├── 🟣09c6e08 (✓)
         └── 🟣7b9f260 (✓)
@@ -4162,8 +4162,8 @@ fn workspace_without_target_can_see_remote() -> anyhow::Result<()> {
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
 📕🏘️⚠️:1:gitbutler/workspace <> ✓!
-└── ≡👉📙:0:main[🌳] <> origin/main →:2:⇡1 {0}
-    └── 👉📙:0:main[🌳] <> origin/main →:2:⇡1
+└── ≡👉📙:0:main[🌳] <> origin/main⇡1 {0}
+    └── 👉📙:0:main[🌳] <> origin/main⇡1
         └── ·3183e43 (🏘️)
 
 "#]]
@@ -4192,8 +4192,8 @@ fn workspace_without_target_can_see_remote() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 📕🏘️⚠️:1:gitbutler/workspace <> ✓!
-└── ≡👉📙:0:main[🌳] <> origin/main →:2:⇡1 {0}
-    └── 👉📙:0:main[🌳] <> origin/main →:2:⇡1
+└── ≡👉📙:0:main[🌳] <> origin/main⇡1 {0}
+    └── 👉📙:0:main[🌳] <> origin/main⇡1
         └── ·3183e43 (🏘️)
 
 "#]]
@@ -4364,8 +4364,8 @@ fn three_branches_one_advanced_ws_commit_advanced_fully_pushed_empty_dependent()
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡:4:advanced-lane <> origin/advanced-lane →:3: on fafd9d0
-    └── :4:advanced-lane <> origin/advanced-lane →:3:
+└── ≡:4:advanced-lane <> origin/advanced-lane on fafd9d0
+    └── :4:advanced-lane <> origin/advanced-lane
         └── ❄️cbc6713 (🏘️) ►dependent, ►on-top-of-dependent
 
 "#]]
@@ -4416,7 +4416,7 @@ fn three_branches_one_advanced_ws_commit_advanced_fully_pushed_empty_dependent()
 📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
 └── ≡📙:5:dependent on fafd9d0 {1}
     ├── 📙:5:dependent
-    └── 📙:6:advanced-lane <> origin/advanced-lane →:4:
+    └── 📙:6:advanced-lane <> origin/advanced-lane
         └── ❄️cbc6713 (🏘️) ►on-top-of-dependent
 
 "#]]
@@ -4689,8 +4689,8 @@ fn partitions_with_long_and_short_connections_to_each_other() -> anyhow::Result<
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 ⌂:0:main <> ✓refs/remotes/origin/main⇣11
-└── ≡:0:main <> origin/main →:2:⇣11 on 2438292 {1}
-    └── :0:main <> origin/main →:2:⇣11
+└── ≡:0:main <> origin/main⇣11 on 2438292 {1}
+    └── :0:main <> origin/main⇣11
         ├── 🟣232ed06 (✓)
         ├── 🟣abcfd9a (✓)
         ├── 🟣bc86eba (✓)
@@ -4766,8 +4766,8 @@ fn partitions_with_long_and_short_connections_to_each_other() -> anyhow::Result<
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 ⌂:0:main <> ✓refs/remotes/origin/main⇣11
-└── ≡:0:main <> origin/main →:2:⇣11 on 2438292 {1}
-    └── :0:main <> origin/main →:2:⇣11
+└── ≡:0:main <> origin/main⇣11 on 2438292 {1}
+    └── :0:main <> origin/main⇣11
         ├── 🟣232ed06 (✓)
         ├── 🟣abcfd9a (✓)
         ├── 🟣bc86eba (✓)
@@ -4926,8 +4926,8 @@ fn remote_far_in_ancestry() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 685d644
-└── ≡:3:A <> origin/A →:4:⇡3⇣2 on 685d644
-    └── :3:A <> origin/A →:4:⇡3⇣2
+└── ≡:3:A <> origin/A⇡3⇣2 on 685d644
+    └── :3:A <> origin/A⇡3⇣2
         ├── 🟣975754f
         ├── 🟣f48ff69
         ├── ·8407093 (🏘️)
@@ -5049,8 +5049,8 @@ fn partitions_with_long_and_short_connections_to_each_other_part_2() -> anyhow::
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 ⌂:0:main <> ✓refs/remotes/origin/main⇣17
-└── ≡:0:main <> origin/main →:2:⇣17 on bce0c5e {1}
-    └── :0:main <> origin/main →:2:⇣17
+└── ≡:0:main <> origin/main⇣17 on bce0c5e {1}
+    └── :0:main <> origin/main⇣17
         ├── 🟣024f837 (✓) ►long-workspace-to-target
         ├── 🟣64a8284 (✓)
         ├── 🟣b72938c (✓)
@@ -5600,7 +5600,7 @@ fn dependent_branch_insertion() -> anyhow::Result<()> {
 📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
 └── ≡📙:5:dependent on fafd9d0 {1}
     ├── 📙:5:dependent
-    └── 📙:6:advanced-lane <> origin/advanced-lane →:4:
+    └── 📙:6:advanced-lane <> origin/advanced-lane
         └── ❄️cbc6713 (🏘️)
 
 "#]]
@@ -5652,8 +5652,8 @@ fn dependent_branch_insertion() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡📙:5:advanced-lane <> origin/advanced-lane →:4: on fafd9d0 {1}
-    ├── 📙:5:advanced-lane <> origin/advanced-lane →:4:
+└── ≡📙:5:advanced-lane <> origin/advanced-lane on fafd9d0 {1}
+    ├── 📙:5:advanced-lane <> origin/advanced-lane
     └── 📙:6:dependent
         └── ❄cbc6713 (🏘️)
 
@@ -5674,8 +5674,8 @@ fn dependent_branch_insertion() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 📕🏘️:1:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡👉📙:5:advanced-lane <> origin/advanced-lane →:4: on fafd9d0 {1}
-    ├── 👉📙:5:advanced-lane <> origin/advanced-lane →:4:
+└── ≡👉📙:5:advanced-lane <> origin/advanced-lane on fafd9d0 {1}
+    ├── 👉📙:5:advanced-lane <> origin/advanced-lane
     └── 📙:6:dependent
         └── ❄cbc6713 (🏘️)
 
@@ -5696,8 +5696,8 @@ fn dependent_branch_insertion() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 📕🏘️:1:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡📙:5:advanced-lane <> origin/advanced-lane →:4: on fafd9d0 {1}
-    ├── 📙:5:advanced-lane <> origin/advanced-lane →:4:
+└── ≡📙:5:advanced-lane <> origin/advanced-lane on fafd9d0 {1}
+    ├── 📙:5:advanced-lane <> origin/advanced-lane
     └── 👉📙:6:dependent
         └── ❄cbc6713 (🏘️)
 
@@ -5767,13 +5767,13 @@ fn multiple_stacks_with_shared_parent_and_remote() -> anyhow::Result<()> {
 ├── ≡📙:3:C-on-A on fafd9d0 {1}
 │   ├── 📙:3:C-on-A
 │   │   └── ·4f1bb32 (🏘️)
-│   └── :4:A <> origin/A →:5:⇣1
+│   └── :4:A <> origin/A⇣1
 │       ├── 🟣b627ca7
 │       └── ❄️e255adc (🏘️)
 └── ≡:6:B-on-A on fafd9d0
     ├── :6:B-on-A
     │   └── ·aff8449 (🏘️)
-    └── :4:A <> origin/A →:5:⇣1
+    └── :4:A <> origin/A⇣1
         ├── 🟣b627ca7
         └── ❄️e255adc (🏘️)
 
@@ -6001,8 +6001,8 @@ fn two_dependent_branches_with_embedded_remote() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡📙:3:A <> origin/A →:4:⇡1⇣1 on fafd9d0 {1}
-    ├── 📙:3:A <> origin/A →:4:⇡1⇣1
+└── ≡📙:3:A <> origin/A⇡1⇣1 on fafd9d0 {1}
+    ├── 📙:3:A <> origin/A⇡1⇣1
     │   ├── 🟣2b1808c
     │   ├── ·aadad9d (🏘️)
     │   └── ·96a2408 (🏘️|✓)
@@ -6027,8 +6027,8 @@ fn two_dependent_branches_with_embedded_remote() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 96a2408
-└── ≡📙:3:A <> origin/A →:4:⇡1⇣1 on 96a2408 {1}
-    └── 📙:3:A <> origin/A →:4:⇡1⇣1
+└── ≡📙:3:A <> origin/A⇡1⇣1 on 96a2408 {1}
+    └── 📙:3:A <> origin/A⇡1⇣1
         ├── 🟣2b1808c
         └── ·aadad9d (🏘️)
 
@@ -6099,11 +6099,11 @@ fn two_dependent_branches_rebased_with_remotes_merge_local() -> anyhow::Result<(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 281456a
-└── ≡📙:3:B <> origin/B →:5:⇡1⇣1 on 281456a {0}
-    ├── 📙:3:B <> origin/B →:5:⇡1⇣1
+└── ≡📙:3:B <> origin/B⇡1⇣1 on 281456a {0}
+    ├── 📙:3:B <> origin/B⇡1⇣1
     │   ├── 🟣e0bd0a7
     │   └── ·da597e8 (🏘️)
-    └── 📙:4:A <> origin/A →:6:⇣1
+    └── 📙:4:A <> origin/A⇣1
         ├── 🟣0b6b861
         └── ·1818c17 (🏘️|✓)
 
@@ -6123,8 +6123,8 @@ fn two_dependent_branches_rebased_with_remotes_merge_local() -> anyhow::Result<(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 1818c17
-└── ≡📙:4:B <> origin/B →:6:⇡1⇣1 on 1818c17 {0}
-    └── 📙:4:B <> origin/B →:6:⇡1⇣1
+└── ≡📙:4:B <> origin/B⇡1⇣1 on 1818c17 {0}
+    └── 📙:4:B <> origin/B⇡1⇣1
         ├── 🟣e0bd0a7
         └── ·da597e8 (🏘️)
 
@@ -6169,7 +6169,7 @@ fn stacked_bottom_remote_still_points_at_now_split_top() -> anyhow::Result<()> {
 └── ≡📙:3:top on fafd9d0 {0}
     ├── 📙:3:top
     │   └── ❄bfbff44 (🏘️)
-    └── 📙:4:bottom <> origin/bottom →:5:⇣1
+    └── 📙:4:bottom <> origin/bottom⇣1
         ├── 🟣bfbff44 (🏘️)
         └── ❄️7fdb58d (🏘️)
 
@@ -6258,8 +6258,8 @@ fn two_dependent_branches_rebased_with_remotes_squash_merge_remote_ambiguous() -
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 0b6b861
-└── ≡📙:3:D <> origin/D →:4:⇡1⇣1 on 0b6b861 {0}
-    └── 📙:3:D <> origin/D →:4:⇡1⇣1
+└── ≡📙:3:D <> origin/D⇡1⇣1 on 0b6b861 {0}
+    └── 📙:3:D <> origin/D⇡1⇣1
         ├── 🟣3045ea6
         └── ·624e118 (🏘️)
 
@@ -6337,8 +6337,8 @@ fn two_dependent_branches_rebased_with_remotes_squash_merge_remote() -> anyhow::
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 0b6b861
-└── ≡📙:3:D <> origin/D →:4:⇡3⇣1 on 0b6b861 {0}
-    └── 📙:3:D <> origin/D →:4:⇡3⇣1
+└── ≡📙:3:D <> origin/D⇡3⇣1 on 0b6b861 {0}
+    └── 📙:3:D <> origin/D⇡3⇣1
         ├── 🟣bbd4ff6
         ├── ·353471f (🏘️)
         ├── ·8a4b945 (🏘️)
@@ -6390,8 +6390,8 @@ fn without_target_ref_or_managed_commit() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓!
-└── ≡:1:A <> origin/A →:2:⇣1
-    ├── :1:A <> origin/A →:2:⇣1
+└── ≡:1:A <> origin/A⇣1
+    ├── :1:A <> origin/A⇣1
     │   ├── 🟣4fe5a6f
     │   ├── ❄️a62b0de (🏘️)
     │   └── ❄️120a217 (🏘️)
@@ -6431,8 +6431,8 @@ fn without_target_ref_or_managed_commit() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 📕🏘️⚠️:1:gitbutler/workspace[🌳] <> ✓!
-└── ≡👉:0:A <> origin/A →:2:⇣1
-    ├── 👉:0:A <> origin/A →:2:⇣1
+└── ≡👉:0:A <> origin/A⇣1
+    ├── 👉:0:A <> origin/A⇣1
     │   ├── 🟣4fe5a6f
     │   ├── ❄️a62b0de (🏘️)
     │   └── ❄️120a217 (🏘️)
@@ -6489,8 +6489,8 @@ fn without_target_ref_or_managed_commit_ambiguous() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓!
-└── ≡:1:A <> origin/A →:2:⇣1
-    ├── :1:A <> origin/A →:2:⇣1
+└── ≡:1:A <> origin/A⇣1
+    ├── :1:A <> origin/A⇣1
     │   ├── 🟣4fe5a6f
     │   ├── ❄️a62b0de (🏘️) ►B
     │   └── ❄️120a217 (🏘️)
@@ -6535,8 +6535,8 @@ fn without_target_ref_or_managed_commit_ambiguous() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 📕🏘️⚠️:1:gitbutler/workspace[🌳] <> ✓!
-└── ≡👉:4:A <> origin/A →:2:⇣1 {1}
-    ├── 👉:4:A <> origin/A →:2:⇣1
+└── ≡👉:4:A <> origin/A⇣1 {1}
+    ├── 👉:4:A <> origin/A⇣1
     │   └── 🟣4fe5a6f
     ├── 📙:0:B
     │   ├── ❄a62b0de (🏘️)
@@ -6605,7 +6605,7 @@ fn without_target_ref_or_managed_commit_ambiguous() -> anyhow::Result<()> {
 📕🏘️⚠️:1:gitbutler/workspace[🌳] <> ✓!
 └── ≡📙:4:B {1}
     ├── 📙:4:B
-    ├── 👉📙:5:A <> origin/A →:2:⇣1
+    ├── 👉📙:5:A <> origin/A⇣1
     │   ├── 🟣4fe5a6f
     │   ├── ❄️a62b0de (🏘️)
     │   └── ❄️120a217 (🏘️)
@@ -6630,8 +6630,8 @@ fn without_target_ref_or_managed_commit_ambiguous() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 📕🏘️⚠️:1:gitbutler/workspace[🌳] <> ✓!
-└── ≡👉📙:4:A <> origin/A →:2:⇣1 {1}
-    ├── 👉📙:4:A <> origin/A →:2:⇣1
+└── ≡👉📙:4:A <> origin/A⇣1 {1}
+    ├── 👉📙:4:A <> origin/A⇣1
     │   └── 🟣4fe5a6f
     ├── 📙:5:B
     │   ├── ❄a62b0de (🏘️)
@@ -6733,8 +6733,8 @@ fn without_target_ref_or_managed_commit_ambiguous_with_remotes() -> anyhow::Resu
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 📕🏘️⚠️:1:gitbutler/workspace[🌳] <> ✓!
-└── ≡👉:0:A <> origin/A →:2:
-    ├── 👉:0:A <> origin/A →:2:
+└── ≡👉:0:A <> origin/A
+    ├── 👉:0:A <> origin/A
     │   ├── ❄️a62b0de (🏘️) ►B
     │   └── ❄️120a217 (🏘️)
     └── :4:main <> origin/main
@@ -6758,8 +6758,8 @@ fn without_target_ref_or_managed_commit_ambiguous_with_remotes() -> anyhow::Resu
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 📕🏘️⚠️:1:gitbutler/workspace[🌳] <> ✓!
-└── ≡👉:0:B <> origin/B →:3:
-    ├── 👉:0:B <> origin/B →:3:
+└── ≡👉:0:B <> origin/B
+    ├── 👉:0:B <> origin/B
     │   ├── ❄️a62b0de (🏘️) ►A
     │   └── ❄️120a217 (🏘️)
     └── :4:main <> origin/main
@@ -6807,9 +6807,9 @@ fn without_target_ref_or_managed_commit_ambiguous_with_remotes() -> anyhow::Resu
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 📕🏘️⚠️:1:gitbutler/workspace[🌳] <> ✓!
-└── ≡👉:5:A <> origin/A →:2: {1}
-    ├── 👉:5:A <> origin/A →:2:
-    ├── 📙:0:B <> origin/B →:3:
+└── ≡👉:5:A <> origin/A {1}
+    ├── 👉:5:A <> origin/A
+    ├── 📙:0:B <> origin/B
     │   ├── ❄️a62b0de (🏘️)
     │   └── ❄️120a217 (🏘️)
     └── :4:main <> origin/main
@@ -6866,8 +6866,8 @@ fn without_target_ref_with_managed_commit() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 📕🏘️:0:gitbutler/workspace[🌳] <> ✓!
-└── ≡:1:A <> origin/A →:2:⇣1
-    ├── :1:A <> origin/A →:2:⇣1
+└── ≡:1:A <> origin/A⇣1
+    ├── :1:A <> origin/A⇣1
     │   ├── 🟣4fe5a6f
     │   ├── ❄️a62b0de (🏘️)
     │   └── ❄️120a217 (🏘️)
@@ -6907,8 +6907,8 @@ fn without_target_ref_with_managed_commit() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 📕🏘️:1:gitbutler/workspace[🌳] <> ✓!
-└── ≡👉:0:A <> origin/A →:2:⇣1
-    ├── 👉:0:A <> origin/A →:2:⇣1
+└── ≡👉:0:A <> origin/A⇣1
+    ├── 👉:0:A <> origin/A⇣1
     │   ├── 🟣4fe5a6f
     │   ├── ❄️a62b0de (🏘️)
     │   └── ❄️120a217 (🏘️)
@@ -7209,7 +7209,7 @@ fn two_dependent_branches_first_merged_by_rebase() -> anyhow::Result<()> {
 └── ≡:3:B on 281456a
     ├── :3:B
     │   └── ·da597e8 (🏘️)
-    └── :4:A <> origin/A →:5:⇡1⇣1
+    └── :4:A <> origin/A⇡1⇣1
         ├── 🟣0b6b861 (✓)
         └── ·1818c17 (🏘️)
 
@@ -7314,9 +7314,9 @@ fn special_branch_do_not_allow_overly_long_segments() -> anyhow::Result<()> {
 │           └── ·c59457b (⌂|🏘)
 │               └── ►:4[2]:gitbutler/edit
 │                   └── ·e146f13 (⌂|🏘)
-│                       └── ►:5[3]:main <> origin/main →:6:
+│                       └── ►:5[3]:main <> origin/main
 │                           └── ·971953d (⌂|🏘)
-│                               └── ►:2[4]:gitbutler/target <> origin/gitbutler/target →:1:
+│                               └── ►:2[4]:gitbutler/target <> origin/gitbutler/target
 │                                   ├── ·ce09734 (⌂|🏘|✓)
 │                                   └── 🏁·fafd9d0 (⌂|🏘|✓)
 ├── ►:1[0]:origin/gitbutler/target
@@ -7337,7 +7337,7 @@ fn special_branch_do_not_allow_overly_long_segments() -> anyhow::Result<()> {
     ├── :3:A
     │   ├── ·c59457b (🏘️)
     │   └── ·e146f13 (🏘️)
-    └── :5:main <> origin/main →:6:
+    └── :5:main <> origin/main
         └── ❄️971953d (🏘️)
 
 "#]]
@@ -7979,8 +7979,8 @@ fn shallow_boundary_below_workspace_lower_bound() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on b625665
-└── ≡📙:3:A <> origin/A →:4: on b625665 {1}
-    └── 📙:3:A <> origin/A →:4:
+└── ≡📙:3:A <> origin/A on b625665 {1}
+    └── 📙:3:A <> origin/A
         └── ❄️6507810 (🏘️)
 
 "#]]
@@ -8248,7 +8248,7 @@ fn applied_stack_above_explicit_lower_bound() -> anyhow::Result<()> {
 └── ≡:2:A on bce0c5e
     ├── :2:A
     │   └── ·de6d39c (🏘️)
-    └── :3:main <> origin/main →:4:
+    └── :3:main <> origin/main
         └── ❄️a821094 (🏘️)
 
 "#]]
@@ -8455,8 +8455,8 @@ fn remote_and_integrated_tracking_branch_on_merge() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 1ee1e34
-└── ≡📙:8:A <> origin/A →:4:⇣1 on 1ee1e34 {1}
-    └── 📙:8:A <> origin/A →:4:⇣1
+└── ≡📙:8:A <> origin/A⇣1 on 1ee1e34 {1}
+    └── 📙:8:A <> origin/A⇣1
         └── 🟣2181501
 
 "#]]
@@ -8496,8 +8496,8 @@ fn remote_and_integrated_tracking_branch_on_linear_segment() -> anyhow::Result<(
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 081bae9
-└── ≡📙:5:A <> origin/A →:4:⇣1 on 081bae9 {1}
-    └── 📙:5:A <> origin/A →:4:⇣1
+└── ≡📙:5:A <> origin/A⇣1 on 081bae9 {1}
+    └── 📙:5:A <> origin/A⇣1
         └── 🟣197ddce
 
 "#]]
@@ -8543,8 +8543,8 @@ fn remote_and_integrated_tracking_branch_on_merge_extra_target() -> anyhow::Resu
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 1ee1e34
-└── ≡📙:3:A <> origin/A →:4:⇡1⇣1 on 1ee1e34 {1}
-    └── 📙:3:A <> origin/A →:4:⇡1⇣1
+└── ≡📙:3:A <> origin/A⇡1⇣1 on 1ee1e34 {1}
+    └── 📙:3:A <> origin/A⇡1⇣1
         ├── 🟣2181501
         └── ·9f47a25 (🏘️)
 
@@ -8989,8 +8989,8 @@ fn unapplied_branch_on_base_no_target() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 📕🏘️:0:gitbutler/workspace[🌳] <> ✓!
-└── ≡:2:main <> origin/main →:1:
-    └── :2:main <> origin/main →:1:
+└── ≡:2:main <> origin/main
+    └── :2:main <> origin/main
         └── ❄️fafd9d0 (🏘️) ►unapplied
 
 "#]]
@@ -9027,8 +9027,8 @@ fn unapplied_branch_on_base_no_target() -> anyhow::Result<()> {
 📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
 ├── ≡📙:3:unapplied on fafd9d0 {1}
 │   └── 📙:3:unapplied
-└── ≡📙:4:main <> origin/main →:1: on fafd9d0 {2}
-    └── 📙:4:main <> origin/main →:1:
+└── ≡📙:4:main <> origin/main on fafd9d0 {2}
+    └── 📙:4:main <> origin/main
 
 "#]]
     );
@@ -9050,8 +9050,8 @@ fn unapplied_branch_on_base_no_target() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡📙:3:main <> origin/main →:1: on fafd9d0 {2}
-    └── 📙:3:main <> origin/main →:1:
+└── ≡📙:3:main <> origin/main on fafd9d0 {2}
+    └── 📙:3:main <> origin/main
 
 "#]]
     );
@@ -9104,8 +9104,8 @@ fn no_ws_commit_two_branches_no_target() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on bce0c5e
-├── ≡📙:3:main <> origin/main →:2: on bce0c5e {0}
-│   └── 📙:3:main <> origin/main →:2:
+├── ≡📙:3:main <> origin/main on bce0c5e {0}
+│   └── 📙:3:main <> origin/main
 └── ≡📙:4:A on bce0c5e {1}
     └── 📙:4:A
 
@@ -9174,8 +9174,8 @@ fn ambiguous_worktrees() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 📕🏘️:0:gitbutler/workspace[🌳@repo] <> ✓refs/remotes/origin/main⇣1 on 081bae9
-├── ≡📙:6:A <> origin/A →:4:⇣1 on 081bae9 {0}
-│   └── 📙:6:A <> origin/A →:4:⇣1
+├── ≡📙:6:A <> origin/A⇣1 on 081bae9 {0}
+│   └── 📙:6:A <> origin/A⇣1
 │       └── 🟣197ddce
 └── ≡:5:B[📁wt-B-inside] on 081bae9
     └── :5:B[📁wt-B-inside]
@@ -9232,8 +9232,8 @@ fn ambiguous_worktrees() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 📕🏘️:1:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 081bae9
-├── ≡📙:6:A <> origin/A →:5:⇣1 on 081bae9 {0}
-│   └── 📙:6:A <> origin/A →:5:⇣1
+├── ≡📙:6:A <> origin/A⇣1 on 081bae9 {0}
+│   └── 📙:6:A <> origin/A⇣1
 │       └── 🟣197ddce
 └── ≡👉:0:B[📁wt-B-inside@repo] on 081bae9
     └── 👉:0:B[📁wt-B-inside@repo]
@@ -10735,8 +10735,8 @@ fn worktree_ref_at_remote_tracked_branch() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 📕🏘️:0:gitbutler/workspace[🌳@repo] <> ✓refs/remotes/origin/main on fafd9d0
-└── ≡📙:7:foo <> origin/foo →:4: on fafd9d0 {0}
-    └── 📙:7:foo <> origin/foo →:4:
+└── ≡📙:7:foo <> origin/foo on fafd9d0 {0}
+    └── 📙:7:foo <> origin/foo
         └── ❄️e255adc (🏘️)
 
 "#]]

--- a/crates/but-graph/tests/graph/init/with_workspace.rs
+++ b/crates/but-graph/tests/graph/init/with_workspace.rs
@@ -286,8 +286,8 @@ fn workspace_projection_with_advanced_stack_tip() -> anyhow::Result<()> {
         graph_workspace(ws).to_string(),
         snapbox::str![[r#"
 📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-└── ≡📙:5:B →:3: on 85efbe4 {1}
-    ├── 📙:5:B →:3:
+└── ≡📙:5:B on 85efbe4 {1}
+    ├── 📙:5:B
     │   ├── ·cc0bf57*
     │   └── ·d69fe94 (🏘️)
     └── 📙:4:A
@@ -7319,9 +7319,9 @@ fn special_branch_do_not_allow_overly_long_segments() -> anyhow::Result<()> {
 │                               └── ►:2[4]:gitbutler/target <> origin/gitbutler/target →:1:
 │                                   ├── ·ce09734 (⌂|🏘|✓)
 │                                   └── 🏁·fafd9d0 (⌂|🏘|✓)
-├── ►:1[0]:origin/gitbutler/target →:2:
+├── ►:1[0]:origin/gitbutler/target
 │   └── →:2: (gitbutler/target →:1:)
-└── ►:6[0]:origin/main →:5:
+└── ►:6[0]:origin/main
     └── →:5: (main →:6:)
 
 "#]]
@@ -7534,17 +7534,17 @@ fn branch_ahead_of_workspace() -> anyhow::Result<()> {
         graph_workspace(&graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
 📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣2 on fafd9d0
-├── ≡📙:19:A →:4: on fafd9d0 {0}
-│   ├── 📙:19:A →:4:
+├── ≡📙:19:A on fafd9d0 {0}
+│   ├── 📙:19:A
 │   │   ├── ·c83f258*
 │   │   └── ·a62b0de (🏘️|✓)
-│   └── 📙:21:A-middle <> origin/A-middle →:5:
+│   └── 📙:21:A-middle <> origin/A-middle
 │       ├── ·27c2545*
 │       └── ·120a217 (🏘️|✓)
 ├── ≡📙:6:B on fafd9d0 {1}
 │   ├── 📙:6:B
 │   │   └── ·2f8f06d (🏘️)
-│   └── 📙:15:B-middle <> origin/B-middle →:7:
+│   └── 📙:15:B-middle <> origin/B-middle
 │       ├── ·c8f73c7*
 │       ├── ·ff75b80*
 │       ├── ·91bc3fc (🏘️|✓)
@@ -7552,7 +7552,7 @@ fn branch_ahead_of_workspace() -> anyhow::Result<()> {
 ├── ≡📙:8:C on fafd9d0 {2}
 │   ├── 📙:8:C
 │   │   └── ·3f7c4e6 (🏘️)
-│   └── 📙:20:C-bottom →:9:
+│   └── 📙:20:C-bottom
 │       ├── ·790a17d*
 │       ├── ·969aaec*
 │       ├── ·631be19*

--- a/crates/but-graph/tests/graph/workspace/resolved_target_commit_id.rs
+++ b/crates/but-graph/tests/graph/workspace/resolved_target_commit_id.rs
@@ -35,9 +35,9 @@ fn ad_hoc_workspace_uses_project_target_ref() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace_determinisitcally(&ws).to_string(),
         snapbox::str![[r#"
-⌂:[..]:feature[🌳] <> ✓refs/remotes/origin/trunk⇣1 on d03b217
-└── ≡:[..]:feature[🌳] on d03b217 {1}
-    └── :[..]:feature[🌳]
+⌂:feature[🌳] <> ✓refs/remotes/origin/trunk⇣1 on d03b217
+└── ≡:feature[🌳] on d03b217 {1}
+    └── :feature[🌳]
 
 "#]]
     );
@@ -78,9 +78,9 @@ fn ad_hoc_workspace_uses_stored_project_target_commit() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace_determinisitcally(&ws).to_string(),
         snapbox::str![[r#"
-⌂:[..]:feature[🌳] <> ✓! on 3183e43
-└── ≡:[..]:feature[🌳] on 3183e43 {1}
-    └── :[..]:feature[🌳]
+⌂:feature[🌳] <> ✓! on 3183e43
+└── ≡:feature[🌳] on 3183e43 {1}
+    └── :feature[🌳]
         └── ·d03b217
 
 "#]]

--- a/crates/but-hunk-assignment/src/lib.rs
+++ b/crates/but-hunk-assignment/src/lib.rs
@@ -863,7 +863,6 @@ mod tests {
                 worktree: None,
             }),
             remote_tracking_ref_name: None,
-            sibling_segment_id: None,
             remote_tracking_branch_segment_id: None,
             id: SegmentIndex::new(id),
             commits: vec![],

--- a/crates/but-rebase/tests/rebase/graph_rebase/editor_creation.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/editor_creation.rs
@@ -417,7 +417,7 @@ fn workspace_with_empty_stack() -> Result<()> {
 │       └── 📙►:5[1]:stack-2
 │           └── →:4:
 └── ►:1[0]:origin/main
-    └── ►:2[1]:main <> origin/main →:1:
+    └── ►:2[1]:main <> origin/main
         └── ·a0f2ac5 (⌂|✓)
             └── →:4:
 
@@ -487,7 +487,7 @@ fn workspace_with_three_empty_stacks() -> Result<()> {
 │       └── 📙►:6[1]:stack-3
 │           └── →:3:
 └── ►:1[0]:origin/main
-    └── ►:2[1]:main <> origin/main →:1:
+    └── ►:2[1]:main <> origin/main
         └── ·1cf9cf4 (⌂|✓)
             └── →:3:
 

--- a/crates/but-rebase/tests/rebase/graph_rebase/editor_creation.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/editor_creation.rs
@@ -416,7 +416,7 @@ fn workspace_with_empty_stack() -> Result<()> {
 │       │           └── 🏁·fafd9d0 (⌂|🏘|✓)
 │       └── 📙►:5[1]:stack-2
 │           └── →:4:
-└── ►:1[0]:origin/main →:2:
+└── ►:1[0]:origin/main
     └── ►:2[1]:main <> origin/main →:1:
         └── ·a0f2ac5 (⌂|✓)
             └── →:4:
@@ -486,7 +486,7 @@ fn workspace_with_three_empty_stacks() -> Result<()> {
 │       │   └── →:3:
 │       └── 📙►:6[1]:stack-3
 │           └── →:3:
-└── ►:1[0]:origin/main →:2:
+└── ►:1[0]:origin/main
     └── ►:2[1]:main <> origin/main →:1:
         └── ·1cf9cf4 (⌂|✓)
             └── →:3:

--- a/crates/but-rebase/tests/rebase/graph_rebase/rebase_identities.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/rebase_identities.rs
@@ -95,9 +95,9 @@ fn four_commits_with_short_traversal() -> Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-⌂:0:main[🌳] <> ✓!
-└── ≡:0:main[🌳] {1}
-    └── :0:main[🌳]
+⌂:main[🌳] <> ✓!
+└── ≡:main[🌳] {1}
+    └── :main[🌳]
         ├── ·120e3a9
         ├── ·a96434e
         ├── ·d591dfe

--- a/crates/but-testsupport/src/graph.rs
+++ b/crates/but-testsupport/src/graph.rs
@@ -204,7 +204,6 @@ fn recurse_segment(
         ref_name_and_remote = graph.ref_and_remote_debug_string_with_graph_context(
             segment.ref_info.as_ref(),
             segment.remote_tracking_ref_name.as_ref(),
-            segment.sibling_segment_id,
             segment.remote_tracking_branch_segment_id,
         ),
     ));

--- a/crates/but-testsupport/src/graph.rs
+++ b/crates/but-testsupport/src/graph.rs
@@ -204,7 +204,6 @@ fn recurse_segment(
         ref_name_and_remote = graph.ref_and_remote_debug_string_with_graph_context(
             segment.ref_info.as_ref(),
             segment.remote_tracking_ref_name.as_ref(),
-            segment.remote_tracking_branch_segment_id,
         ),
     ));
     for (cidx, commit) in segment.commits.iter().enumerate() {

--- a/crates/but-workspace/src/ref_info.rs
+++ b/crates/but-workspace/src/ref_info.rs
@@ -795,7 +795,6 @@ impl crate::ref_info::Segment {
             base,
             base_segment_id: _,
             remote_tracking_ref_name,
-            sibling_segment_id: _,
             remote_tracking_branch_segment_id,
             id,
             commits,

--- a/crates/but-workspace/tests/workspace/branch/apply_unapply.rs
+++ b/crates/but-workspace/tests/workspace/branch/apply_unapply.rs
@@ -1209,8 +1209,8 @@ fn workspace_with_out_of_ws_ref_and_anon_stack() -> anyhow::Result<()> {
 ├── ≡:4:anon: on 3183e43
 │   └── :4:anon:
 │       └── ·d6bdeab (🏘️)
-└── ≡📙:5:outside →:3: on 3183e43 {1}
-    └── 📙:5:outside →:3:
+└── ≡📙:5:outside on 3183e43 {1}
+    └── 📙:5:outside
         ├── ·5121eb9*
         └── ·67c6397 (🏘️)
 

--- a/crates/but-workspace/tests/workspace/branch/apply_unapply.rs
+++ b/crates/but-workspace/tests/workspace/branch/apply_unapply.rs
@@ -694,8 +694,8 @@ Outcome {
             graph_workspace(&out.workspace).to_string(),
             snapbox::str![[r#"
 ⌂:0:main[🌳] <> ✓refs/remotes/origin/main on e5d0542
-└── ≡:0:main[🌳] <> origin/main →:1: on e5d0542 {1}
-    └── :0:main[🌳] <> origin/main →:1:
+└── ≡:0:main[🌳] <> origin/main on e5d0542 {1}
+    └── :0:main[🌳] <> origin/main
 
 "#]]
         );
@@ -750,8 +750,8 @@ Outcome {
             graph_workspace(&out.workspace).to_string(),
             snapbox::str![[r#"
 ⌂:0:main[🌳] <> ✓refs/remotes/origin/main on e5d0542
-└── ≡:0:main[🌳] <> origin/main →:1: on e5d0542 {1}
-    └── :0:main[🌳] <> origin/main →:1:
+└── ≡:0:main[🌳] <> origin/main on e5d0542 {1}
+    └── :0:main[🌳] <> origin/main
 
 "#]]
         );
@@ -1120,8 +1120,8 @@ fn unapply_remotely_tracked_tip_of_multi_segment_stack_can_delete_workspace_ref(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
 📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-└── ≡📙:3:B <> origin/B →:5: on 85efbe4 {42}
-    └── 📙:3:B <> origin/B →:5:
+└── ≡📙:3:B <> origin/B on 85efbe4 {42}
+    └── 📙:3:B <> origin/B
         ├── ❄️f084d61 (🏘️) ►A, ►C
         └── ❄️7076dee (🏘️) ►D, ►E
 
@@ -1166,8 +1166,8 @@ Outcome {
         graph_workspace(&out.workspace).to_string(),
         snapbox::str![[r#"
 ⌂:0:main[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-└── ≡:0:main[🌳] <> origin/main →:1: on 85efbe4 {1}
-    └── :0:main[🌳] <> origin/main →:1:
+└── ≡:0:main[🌳] <> origin/main on 85efbe4 {1}
+    └── :0:main[🌳] <> origin/main
 
 "#]]
     );
@@ -1808,8 +1808,8 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_with_target
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
 ⌂:0:main[🌳] <> ✓refs/remotes/origin/main on e5d0542
-└── ≡:0:main[🌳] <> origin/main →:1: on e5d0542 {1}
-    └── :0:main[🌳] <> origin/main →:1:
+└── ≡:0:main[🌳] <> origin/main on e5d0542 {1}
+    └── :0:main[🌳] <> origin/main
 
 "#]]
     );
@@ -1940,8 +1940,8 @@ Outcome {
         graph_workspace(&out.workspace).to_string(),
         snapbox::str![[r#"
 ⌂:0:main[🌳] <> ✓refs/remotes/origin/main on e5d0542
-└── ≡:0:main[🌳] <> origin/main →:1: on e5d0542 {1}
-    └── :0:main[🌳] <> origin/main →:1:
+└── ≡:0:main[🌳] <> origin/main on e5d0542 {1}
+    └── :0:main[🌳] <> origin/main
 
 "#]]
     );
@@ -3446,8 +3446,8 @@ fn apply_multiple_segments_of_stack_in_order_merge_if_needed() -> anyhow::Result
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
 ⌂:0:main[🌳] <> ✓refs/remotes/origin/main on 3183e43
-└── ≡:0:main[🌳] <> origin/main →:1: on 3183e43 {1}
-    └── :0:main[🌳] <> origin/main →:1:
+└── ≡:0:main[🌳] <> origin/main on 3183e43 {1}
+    └── :0:main[🌳] <> origin/main
 
 "#]]
     );
@@ -4318,8 +4318,8 @@ fn apply_two_ambiguous_stacks_with_target_with_dependent_branch() -> anyhow::Res
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
 ⌂:0:main[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-└── ≡:0:main[🌳] <> origin/main →:1: on 85efbe4 {1}
-    └── :0:main[🌳] <> origin/main →:1:
+└── ≡:0:main[🌳] <> origin/main on 85efbe4 {1}
+    └── :0:main[🌳] <> origin/main
 
 "#]]
     );
@@ -4452,8 +4452,8 @@ fn apply_two_ambiguous_stacks_with_target() -> anyhow::Result<()> {
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
 ⌂:0:main[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-└── ≡:0:main[🌳] <> origin/main →:1: on 85efbe4 {1}
-    └── :0:main[🌳] <> origin/main →:1:
+└── ≡:0:main[🌳] <> origin/main on 85efbe4 {1}
+    └── :0:main[🌳] <> origin/main
 
 "#]]
     );
@@ -4931,8 +4931,8 @@ Outcome {
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
 ⌂:0:main[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-└── ≡:0:main[🌳] <> origin/main →:1: on 85efbe4 {1}
-    └── :0:main[🌳] <> origin/main →:1:
+└── ≡:0:main[🌳] <> origin/main on 85efbe4 {1}
+    └── :0:main[🌳] <> origin/main
 
 "#]]
     );

--- a/crates/but-workspace/tests/workspace/branch/apply_unapply.rs
+++ b/crates/but-workspace/tests/workspace/branch/apply_unapply.rs
@@ -68,9 +68,9 @@ fn operation_denied_on_improper_workspace() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43
-└── ≡:2:anon: on 3183e43
-    └── :2:anon:
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓! on 3183e43
+└── ≡:anon: on 3183e43
+    └── :anon:
         ├── ·0d01196 (🏘️)
         └── ·4979833 (🏘️)
 
@@ -138,9 +138,9 @@ fn unapply_tip_of_ad_hoc_branch_is_an_error() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-⌂:0:main[🌳] <> ✓!
-└── ≡:0:main[🌳] {1}
-    └── :0:main[🌳]
+⌂:main[🌳] <> ✓!
+└── ≡:main[🌳] {1}
+    └── :main[🌳]
         ├── ·281da94
         ├── ·12995d7
         └── ·3d57fc1
@@ -194,13 +194,13 @@ fn unapply_branch_from_named_ad_hoc_workspace_affects_metadata() -> anyhow::Resu
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-⌂:0:A2 <> ✓!
-└── ≡:0:A2 {1}
-    ├── :0:A2
+⌂:A2 <> ✓!
+└── ≡:A2 {1}
+    ├── :A2
     │   └── ·f1889e7
-    ├── :1:A1
+    ├── :A1
     │   └── ·7de99e1
-    └── :2:main[🌳]
+    └── :main[🌳]
         └── ·3183e43
 
 "#]]
@@ -225,13 +225,13 @@ fn unapply_branch_from_named_ad_hoc_workspace_affects_metadata() -> anyhow::Resu
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-⌂:0:A2 <> ✓!
-└── ≡:0:A2 {1}
-    ├── :0:A2
+⌂:A2 <> ✓!
+└── ≡:A2 {1}
+    ├── :A2
     │   └── ·f1889e7
-    ├── 📙:1:on-A1
+    ├── 📙:on-A1
     │   └── ·7de99e1 ►A1
-    └── :2:main[🌳]
+    └── :main[🌳]
         └── ·3183e43
 
 "#]]
@@ -250,12 +250,12 @@ fn unapply_branch_from_named_ad_hoc_workspace_affects_metadata() -> anyhow::Resu
     snapbox::assert_data_eq!(
         graph_workspace(&out.workspace).to_string(),
         snapbox::str![[r#"
-⌂:0:A2 <> ✓!
-└── ≡:0:A2 {1}
-    ├── :0:A2
+⌂:A2 <> ✓!
+└── ≡:A2 {1}
+    ├── :A2
     │   ├── ·f1889e7
     │   └── ·7de99e1 ►A1, ►on-A1
-    └── :1:main[🌳]
+    └── :main[🌳]
         └── ·3183e43
 
 "#]]
@@ -299,7 +299,7 @@ fn ws_ref_no_ws_commit_two_virtual_stacks_on_same_commit_apply_dependent_first()
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓! on e5d0542
 
 "#]]
     );
@@ -322,9 +322,9 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
-└── ≡📙:2:B on e5d0542 {1}
-    └── 📙:2:B
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓! on e5d0542
+└── ≡📙:B on e5d0542 {1}
+    └── 📙:B
 
 "#]]
     );
@@ -336,11 +336,11 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&out.workspace).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
-├── ≡📙:2:B on e5d0542 {1}
-│   └── 📙:2:B
-└── ≡📙:3:A on e5d0542 {41}
-    └── 📙:3:A
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓! on e5d0542
+├── ≡📙:B on e5d0542 {1}
+│   └── 📙:B
+└── ≡📙:A on e5d0542 {41}
+    └── 📙:A
 
 "#]]
     );
@@ -377,9 +377,9 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
-└── ≡📙:2:B on e5d0542 {1}
-    └── 📙:2:B
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓! on e5d0542
+└── ≡📙:B on e5d0542 {1}
+    └── 📙:B
 
 "#]]
     );
@@ -406,7 +406,7 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&out.workspace).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓! on e5d0542
 
 "#]]
     );
@@ -448,11 +448,11 @@ mod workspace_disposition {
         snapbox::assert_data_eq!(
             graph_workspace(&out.workspace).to_string(),
             snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:4:virtual-base on 85efbe4 {1}
-│   └── 📙:4:virtual-base
-└── ≡📙:3:B on 85efbe4 {3}
-    └── 📙:3:B
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:virtual-base on 85efbe4 {1}
+│   └── 📙:virtual-base
+└── ≡📙:B on 85efbe4 {3}
+    └── 📙:B
         └── ·c813d8d (🏘️)
 
 "#]]
@@ -493,11 +493,11 @@ mod workspace_disposition {
         snapbox::assert_data_eq!(
             graph_workspace(&out.workspace).to_string(),
             snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:4:virtual-base on 85efbe4 {1}
-│   └── 📙:4:virtual-base
-└── ≡📙:3:B on 85efbe4 {3}
-    └── 📙:3:B
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:virtual-base on 85efbe4 {1}
+│   └── 📙:virtual-base
+└── ≡📙:B on 85efbe4 {3}
+    └── 📙:B
         └── ·c813d8d (🏘️)
 
 "#]]
@@ -566,9 +566,9 @@ Outcome {
         snapbox::assert_data_eq!(
             graph_workspace(&out.workspace).to_string(),
             snapbox::str![[r#"
-⌂:0:B[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-└── ≡📙:0:B[🌳] on 85efbe4 {1}
-    └── 📙:0:B[🌳]
+⌂:B[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+└── ≡📙:B[🌳] on 85efbe4 {1}
+    └── 📙:B[🌳]
         └── ·c813d8d
 
 "#]]
@@ -612,12 +612,12 @@ Outcome {
         snapbox::assert_data_eq!(
             graph_workspace(&out.workspace).to_string(),
             snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:3:A on 85efbe4 {2}
-│   └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:A on 85efbe4 {2}
+│   └── 📙:A
 │       └── ·09d8e52 (🏘️)
-└── ≡📙:4:B on 85efbe4 {3}
-    └── 📙:4:B
+└── ≡📙:B on 85efbe4 {3}
+    └── 📙:B
         └── ·c813d8d (🏘️)
 
 "#]]
@@ -661,9 +661,9 @@ Outcome {
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on e5d0542
-└── ≡📙:3:A on e5d0542 {41}
-    └── 📙:3:A
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on e5d0542
+└── ≡📙:A on e5d0542 {41}
+    └── 📙:A
 
 "#]]
         );
@@ -693,9 +693,9 @@ Outcome {
         snapbox::assert_data_eq!(
             graph_workspace(&out.workspace).to_string(),
             snapbox::str![[r#"
-⌂:0:main[🌳] <> ✓refs/remotes/origin/main on e5d0542
-└── ≡:0:main[🌳] <> origin/main on e5d0542 {1}
-    └── :0:main[🌳] <> origin/main
+⌂:main[🌳] <> ✓refs/remotes/origin/main on e5d0542
+└── ≡:main[🌳] <> origin/main on e5d0542 {1}
+    └── :main[🌳] <> origin/main
 
 "#]]
         );
@@ -749,9 +749,9 @@ Outcome {
         snapbox::assert_data_eq!(
             graph_workspace(&out.workspace).to_string(),
             snapbox::str![[r#"
-⌂:0:main[🌳] <> ✓refs/remotes/origin/main on e5d0542
-└── ≡:0:main[🌳] <> origin/main on e5d0542 {1}
-    └── :0:main[🌳] <> origin/main
+⌂:main[🌳] <> ✓refs/remotes/origin/main on e5d0542
+└── ≡:main[🌳] <> origin/main on e5d0542 {1}
+    └── :main[🌳] <> origin/main
 
 "#]]
         );
@@ -782,9 +782,9 @@ Outcome {
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on e5d0542
-└── ≡📙:3:A on e5d0542 {41}
-    └── 📙:3:A
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on e5d0542
+└── ≡📙:A on e5d0542 {41}
+    └── 📙:A
 
 "#]]
         );
@@ -807,9 +807,9 @@ Outcome {
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on e5d0542
-└── ≡📙:3:A on e5d0542 {41}
-    └── 📙:3:A
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on e5d0542
+└── ≡📙:A on e5d0542 {41}
+    └── 📙:A
 
 "#]]
         );
@@ -846,11 +846,11 @@ Outcome {
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-└── ≡📙:3:B on 85efbe4 {1}
-    ├── 📙:3:B
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+└── ≡📙:B on 85efbe4 {1}
+    ├── 📙:B
     │   └── ·d69fe94 (🏘️)
-    └── 📙:4:A
+    └── 📙:A
         └── ·09d8e52 (🏘️)
 
 "#]]
@@ -871,7 +871,7 @@ Outcome {
         snapbox::assert_data_eq!(
             graph_workspace(&out.workspace).to_string(),
             snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
 
 "#]]
         );
@@ -942,14 +942,14 @@ Outcome {
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:5:virtual-base on 85efbe4 {1}
-│   └── 📙:5:virtual-base
-├── ≡📙:3:A on 85efbe4 {2}
-│   └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:virtual-base on 85efbe4 {1}
+│   └── 📙:virtual-base
+├── ≡📙:A on 85efbe4 {2}
+│   └── 📙:A
 │       └── ·09d8e52 (🏘️)
-└── ≡📙:4:B on 85efbe4 {3}
-    └── 📙:4:B
+└── ≡📙:B on 85efbe4 {3}
+    └── 📙:B
         └── ·c813d8d (🏘️)
 
 "#]]
@@ -995,9 +995,9 @@ fn main_with_advanced_remote_tracking_branch() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-⌂:0:main[🌳] <> ✓!
-└── ≡:0:main[🌳] {1}
-    └── :0:main[🌳]
+⌂:main[🌳] <> ✓!
+└── ≡:main[🌳] {1}
+    └── :main[🌳]
         └── ·3183e43
 
 "#]]
@@ -1048,11 +1048,11 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓!
-└── ≡📙:1:feature {2ec}
-    ├── 📙:1:feature
+📕🏘️:gitbutler/workspace[🌳] <> ✓!
+└── ≡📙:feature {2ec}
+    ├── 📙:feature
     │   └── ·6b40b15 (🏘️)
-    └── 📙:2:main
+    └── 📙:main
         └── ·3183e43 (🏘️)
 
 "#]]
@@ -1119,9 +1119,9 @@ fn unapply_remotely_tracked_tip_of_multi_segment_stack_can_delete_workspace_ref(
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-└── ≡📙:3:B <> origin/B on 85efbe4 {42}
-    └── 📙:3:B <> origin/B
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+└── ≡📙:B <> origin/B on 85efbe4 {42}
+    └── 📙:B <> origin/B
         ├── ❄️f084d61 (🏘️) ►A, ►C
         └── ❄️7076dee (🏘️) ►D, ►E
 
@@ -1165,9 +1165,9 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&out.workspace).to_string(),
         snapbox::str![[r#"
-⌂:0:main[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-└── ≡:0:main[🌳] <> origin/main on 85efbe4 {1}
-    └── :0:main[🌳] <> origin/main
+⌂:main[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+└── ≡:main[🌳] <> origin/main on 85efbe4 {1}
+    └── :main[🌳] <> origin/main
 
 "#]]
     );
@@ -1205,12 +1205,12 @@ fn workspace_with_out_of_ws_ref_and_anon_stack() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
-├── ≡:4:anon: on 3183e43
-│   └── :4:anon:
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+├── ≡:anon: on 3183e43
+│   └── :anon:
 │       └── ·d6bdeab (🏘️)
-└── ≡📙:5:outside on 3183e43 {1}
-    └── 📙:5:outside
+└── ≡📙:outside on 3183e43 {1}
+    └── 📙:outside
         ├── ·5121eb9*
         └── ·67c6397 (🏘️)
 
@@ -1239,16 +1239,16 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&out.workspace).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
-├── ≡:5:anon: on 3183e43
-│   └── :5:anon:
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+├── ≡:anon: on 3183e43
+│   └── :anon:
 │       └── ·d6bdeab (🏘️)
-├── ≡📙:3:outside on 3183e43 {1}
-│   └── 📙:3:outside
+├── ≡📙:outside on 3183e43 {1}
+│   └── 📙:outside
 │       ├── ·5121eb9 (🏘️)
 │       └── ·67c6397 (🏘️)
-└── ≡📙:4:feature on 3183e43 {2ec}
-    └── 📙:4:feature
+└── ≡📙:feature on 3183e43 {2ec}
+    └── 📙:feature
         └── ·d03b217 (🏘️)
 
 "#]]
@@ -1274,7 +1274,7 @@ fn ws_ref_no_ws_commit_two_stacks_on_same_commit() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓! on e5d0542
 
 "#]]
     );
@@ -1297,9 +1297,9 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
-└── ≡📙:2:A on e5d0542 {41}
-    └── 📙:2:A
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓! on e5d0542
+└── ≡📙:A on e5d0542 {41}
+    └── 📙:A
 
 "#]]
     );
@@ -1331,11 +1331,11 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
-├── ≡📙:2:A on e5d0542 {41}
-│   └── 📙:2:A
-└── ≡📙:3:B on e5d0542 {42}
-    └── 📙:3:B
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓! on e5d0542
+├── ≡📙:A on e5d0542 {41}
+│   └── 📙:A
+└── ≡📙:B on e5d0542 {42}
+    └── 📙:B
 
 "#]]
     );
@@ -1354,9 +1354,9 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
-└── ≡📙:2:A on e5d0542 {41}
-    └── 📙:2:A
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓! on e5d0542
+└── ≡📙:A on e5d0542 {41}
+    └── 📙:A
 
 "#]]
     );
@@ -1378,7 +1378,7 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&out.workspace).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓! on e5d0542
 
 "#]]
     );
@@ -1407,12 +1407,12 @@ fn unapply_natural_stack_with_partial_workspace_metadata() -> anyhow::Result<()>
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:3:B on 85efbe4 {1}
-│   └── 📙:3:B
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:B on 85efbe4 {1}
+│   └── 📙:B
 │       └── ·c813d8d (🏘️)
-└── ≡:4:A on 85efbe4
-    └── :4:A
+└── ≡:A on 85efbe4
+    └── :A
         └── ·09d8e52 (🏘️)
 
 "#]]
@@ -1430,9 +1430,9 @@ fn unapply_natural_stack_with_partial_workspace_metadata() -> anyhow::Result<()>
     snapbox::assert_data_eq!(
         graph_workspace(&out.workspace).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-└── ≡📙:3:B on 85efbe4 {1}
-    └── 📙:3:B
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+└── ≡📙:B on 85efbe4 {1}
+    └── 📙:B
         └── ·c813d8d (🏘️)
 
 "#]]
@@ -1480,14 +1480,14 @@ fn unapply_natural_stack_branch_without_workspace_metadata() -> anyhow::Result<(
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 893d602
-├── ≡:3:C on 893d602
-│   ├── :3:C
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 893d602
+├── ≡:C on 893d602
+│   ├── :C
 │   │   └── ·356de85 (🏘️)
-│   └── :5:B
+│   └── :B
 │       └── ·f25f65c (🏘️)
-└── ≡:4:A on 893d602
-    └── :4:A
+└── ≡:A on 893d602
+    └── :A
         └── ·26e45af (🏘️)
 
 "#]]
@@ -1505,9 +1505,9 @@ fn unapply_natural_stack_branch_without_workspace_metadata() -> anyhow::Result<(
     snapbox::assert_data_eq!(
         graph_workspace_determinisitcally(&out.workspace).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 893d602
-└── ≡📙:3:A on 893d602 {1}
-    └── 📙:3:A
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 893d602
+└── ≡📙:A on 893d602 {1}
+    └── 📙:A
         └── ·26e45af (🏘️)
 
 "#]]
@@ -1594,9 +1594,9 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_without_tar
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-⌂:0:main[🌳] <> ✓!
-└── ≡:0:main[🌳] {1}
-    └── :0:main[🌳]
+⌂:main[🌳] <> ✓!
+└── ≡:main[🌳] {1}
+    └── :main[🌳]
         └── ·e5d0542 ►A, ►B
 
 "#]]
@@ -1621,11 +1621,11 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&out.workspace).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
-├── ≡📙:2:main on e5d0542 {1a5}
-│   └── 📙:2:main
-└── ≡📙:3:A on e5d0542 {41}
-    └── 📙:3:A
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓! on e5d0542
+├── ≡📙:main on e5d0542 {1a5}
+│   └── 📙:main
+└── ≡📙:A on e5d0542 {41}
+    └── 📙:A
 
 "#]]
     );
@@ -1667,13 +1667,13 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
-├── ≡📙:2:main on e5d0542 {1a5}
-│   └── 📙:2:main
-├── ≡📙:3:B on e5d0542 {42}
-│   └── 📙:3:B
-└── ≡📙:4:A on e5d0542 {41}
-    └── 📙:4:A
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓! on e5d0542
+├── ≡📙:main on e5d0542 {1a5}
+│   └── 📙:main
+├── ≡📙:B on e5d0542 {42}
+│   └── 📙:B
+└── ≡📙:A on e5d0542 {41}
+    └── 📙:A
 
 "#]]
     );
@@ -1701,9 +1701,9 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓!
-└── ≡:1:anon: {41}
-    └── :1:anon:
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓!
+└── ≡:anon: {41}
+    └── :anon:
         └── ·e5d0542 (🏘️) ►A, ►B, ►main
 
 "#]]
@@ -1733,9 +1733,9 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓!
-└── ≡📙:2:A {41}
-    └── 📙:2:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓!
+└── ≡📙:A {41}
+    └── 📙:A
         └── ·e5d0542 (🏘️) ►B, ►main
 
 "#]]
@@ -1768,11 +1768,11 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
-├── ≡📙:2:B on e5d0542 {42}
-│   └── 📙:2:B
-└── ≡📙:3:A on e5d0542 {41}
-    └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓! on e5d0542
+├── ≡📙:B on e5d0542 {42}
+│   └── 📙:B
+└── ≡📙:A on e5d0542 {41}
+    └── 📙:A
 
 "#]]
     );
@@ -1807,9 +1807,9 @@ fn no_ws_ref_no_ws_commit_two_stacks_on_same_commit_ad_hoc_workspace_with_target
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-⌂:0:main[🌳] <> ✓refs/remotes/origin/main on e5d0542
-└── ≡:0:main[🌳] <> origin/main on e5d0542 {1}
-    └── :0:main[🌳] <> origin/main
+⌂:main[🌳] <> ✓refs/remotes/origin/main on e5d0542
+└── ≡:main[🌳] <> origin/main on e5d0542 {1}
+    └── :main[🌳] <> origin/main
 
 "#]]
     );
@@ -1834,9 +1834,9 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on e5d0542
-└── ≡📙:3:A on e5d0542 {41}
-    └── 📙:3:A
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on e5d0542
+└── ≡📙:A on e5d0542 {41}
+    └── 📙:A
 
 "#]]
     );
@@ -1867,11 +1867,11 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on e5d0542
-├── ≡📙:3:A on e5d0542 {41}
-│   └── 📙:3:A
-└── ≡📙:4:B on e5d0542 {42}
-    └── 📙:4:B
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on e5d0542
+├── ≡📙:A on e5d0542 {41}
+│   └── 📙:A
+└── ≡📙:B on e5d0542 {42}
+    └── 📙:B
 
 "#]]
     );
@@ -1914,9 +1914,9 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on e5d0542
-└── ≡📙:3:A on e5d0542 {41}
-    └── 📙:3:A
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on e5d0542
+└── ≡📙:A on e5d0542 {41}
+    └── 📙:A
 
 "#]]
     );
@@ -1939,9 +1939,9 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&out.workspace).to_string(),
         snapbox::str![[r#"
-⌂:0:main[🌳] <> ✓refs/remotes/origin/main on e5d0542
-└── ≡:0:main[🌳] <> origin/main on e5d0542 {1}
-    └── :0:main[🌳] <> origin/main
+⌂:main[🌳] <> ✓refs/remotes/origin/main on e5d0542
+└── ≡:main[🌳] <> origin/main on e5d0542 {1}
+    └── :main[🌳] <> origin/main
 
 "#]]
     );
@@ -2049,12 +2049,12 @@ fn apply_in_managed_workspace_drops_stack_whose_ref_disappeared() -> anyhow::Res
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 893d602
-├── ≡📙:3:B on 893d602 {2}
-│   └── 📙:3:B
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 893d602
+├── ≡📙:B on 893d602 {2}
+│   └── 📙:B
 │       └── ·208b2ad (🏘️)
-└── ≡:4:anon: on 893d602
-    └── :4:anon:
+└── ≡:anon: on 893d602
+    └── :anon:
         └── ·239dcaf (🏘️)
 
 "#]]
@@ -2067,15 +2067,15 @@ fn apply_in_managed_workspace_drops_stack_whose_ref_disappeared() -> anyhow::Res
     snapbox::assert_data_eq!(
         graph_workspace(&out.workspace).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 893d602
-├── ≡:5:anon: on 893d602
-│   └── :5:anon:
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 893d602
+├── ≡:anon: on 893d602
+│   └── :anon:
 │       └── ·239dcaf (🏘️)
-├── ≡📙:3:B on 893d602 {2}
-│   └── 📙:3:B
+├── ≡📙:B on 893d602 {2}
+│   └── 📙:B
 │       └── ·208b2ad (🏘️)
-└── ≡📙:4:C on 893d602 {43}
-    └── 📙:4:C
+└── ≡📙:C on 893d602 {43}
+    └── 📙:C
         └── ·863775d (🏘️)
 
 "#]]
@@ -2201,12 +2201,12 @@ fn apply_from_enclosed_adhoc_workspace_rebuilds_around_current_and_applied() -> 
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:1:gitbutler/workspace <> ✓refs/remotes/origin/main on 893d602
-├── ≡📙:4:A on 893d602 {1}
-│   └── 📙:4:A
+📕🏘️:gitbutler/workspace <> ✓refs/remotes/origin/main on 893d602
+├── ≡📙:A on 893d602 {1}
+│   └── 📙:A
 │       └── ·ccf539c (🏘️)
-└── ≡👉📙:0:B[🌳] on 893d602 {2}
-    └── 👉📙:0:B[🌳]
+└── ≡👉📙:B[🌳] on 893d602 {2}
+    └── 👉📙:B[🌳]
         └── ·53c254d (🏘️)
 
 "#]]
@@ -2367,9 +2367,9 @@ fn apply_from_adhoc_checkout_rebuilds_around_current_and_applied() -> anyhow::Re
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-⌂:0:C[🌳] <> ✓refs/remotes/origin/main on 893d602
-└── ≡:0:C[🌳] on 893d602 {1}
-    └── :0:C[🌳]
+⌂:C[🌳] <> ✓refs/remotes/origin/main on 893d602
+└── ≡:C[🌳] on 893d602 {1}
+    └── :C[🌳]
         └── ·863775d
 
 "#]]
@@ -2515,7 +2515,7 @@ fn new_workspace_exists_elsewhere_and_to_be_applied_branch_exists_there() -> any
     snapbox::assert_data_eq!(
         graph_workspace(&ws_graph.into_workspace()?).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓! on e5d0542
 
 "#]]
     );
@@ -2535,9 +2535,9 @@ fn new_workspace_exists_elsewhere_and_to_be_applied_branch_exists_there() -> any
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-⌂:0:B <> ✓!
-└── ≡:0:B {1}
-    └── :0:B
+⌂:B <> ✓!
+└── ≡:B {1}
+    └── :B
         └── ·e5d0542 ►A, ►gitbutler/workspace[🌳], ►main
 
 "#]]
@@ -2563,11 +2563,11 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
-├── ≡📙:2:B on e5d0542 {42}
-│   └── 📙:2:B
-└── ≡📙:3:A on e5d0542 {41}
-    └── 📙:3:A
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓! on e5d0542
+├── ≡📙:B on e5d0542 {42}
+│   └── 📙:B
+└── ≡📙:A on e5d0542 {41}
+    └── 📙:A
 
 "#]]
     );
@@ -2630,11 +2630,11 @@ mod unapply_checked_out {
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️⚠️:1:gitbutler/workspace <> ✓! on e5d0542
-├── ≡📙:2:A on e5d0542 {1}
-│   └── 📙:2:A
-└── ≡👉📙:3:B[🌳] on e5d0542 {2}
-    └── 👉📙:3:B[🌳]
+📕🏘️⚠️:gitbutler/workspace <> ✓! on e5d0542
+├── ≡📙:A on e5d0542 {1}
+│   └── 📙:A
+└── ≡👉📙:B[🌳] on e5d0542 {2}
+    └── 👉📙:B[🌳]
 
 "#]]
         );
@@ -2682,12 +2682,12 @@ mod unapply_checked_out {
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43
-├── ≡📙:2:C on 3183e43 {43}
-│   └── 📙:2:C
+📕🏘️:gitbutler/workspace[🌳] <> ✓! on 3183e43
+├── ≡📙:C on 3183e43 {43}
+│   └── 📙:C
 │       └── ·aaa195b (🏘️)
-└── ≡📙:3:B on 3183e43 {42}
-    └── 📙:3:B
+└── ≡📙:B on 3183e43 {42}
+    └── 📙:B
         └── ·f57c528 (🏘️)
 
 "#]]
@@ -2707,12 +2707,12 @@ mod unapply_checked_out {
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️:1:gitbutler/workspace <> ✓! on 3183e43
-├── ≡📙:2:C on 3183e43 {43}
-│   └── 📙:2:C
+📕🏘️:gitbutler/workspace <> ✓! on 3183e43
+├── ≡📙:C on 3183e43 {43}
+│   └── 📙:C
 │       └── ·aaa195b (🏘️)
-└── ≡👉📙:0:B[🌳] on 3183e43 {42}
-    └── 👉📙:0:B[🌳]
+└── ≡👉📙:B[🌳] on 3183e43 {42}
+    └── 👉📙:B[🌳]
         └── ·f57c528 (🏘️)
 
 "#]]
@@ -2750,9 +2750,9 @@ Outcome {
         snapbox::assert_data_eq!(
             graph_workspace(&out.workspace).to_string(),
             snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓!
-└── ≡📙:1:A {1}
-    └── 📙:1:A
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓!
+└── ≡📙:A {1}
+    └── 📙:A
         └── ·e5d0542 (🏘️) ►main
 
 "#]]
@@ -2797,9 +2797,9 @@ Outcome {
         snapbox::assert_data_eq!(
             graph_workspace(&out.workspace).to_string(),
             snapbox::str![[r#"
-⌂:0:A[🌳] <> ✓!
-└── ≡📙:0:A[🌳] {1}
-    └── 📙:0:A[🌳]
+⌂:A[🌳] <> ✓!
+└── ≡📙:A[🌳] {1}
+    └── 📙:A[🌳]
         └── ·e5d0542 ►main
 
 "#]]
@@ -2838,10 +2838,10 @@ Outcome {
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️⚠️:1:gitbutler/workspace <> ✓! on e5d0542
-└── ≡📙:2:B on e5d0542 {2}
-    ├── 📙:2:B
-    └── 👉📙:3:A[🌳]
+📕🏘️⚠️:gitbutler/workspace <> ✓! on e5d0542
+└── ≡📙:B on e5d0542 {2}
+    ├── 📙:B
+    └── 👉📙:A[🌳]
 
 "#]]
         );
@@ -2870,7 +2870,7 @@ Outcome {
         snapbox::assert_data_eq!(
             graph_workspace(&out.workspace).to_string(),
             snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓! on e5d0542
 
 "#]]
         );
@@ -2912,9 +2912,9 @@ Outcome {
         snapbox::assert_data_eq!(
             graph_workspace(&out.workspace).to_string(),
             snapbox::str![[r#"
-📕🏘️⚠️:1:gitbutler/workspace <> ✓!
-└── ≡👉📙:0:B[🌳] {2}
-    └── 👉📙:0:B[🌳]
+📕🏘️⚠️:gitbutler/workspace <> ✓!
+└── ≡👉📙:B[🌳] {2}
+    └── 👉📙:B[🌳]
         └── ·e5d0542 (🏘️) ►main
 
 "#]]
@@ -2959,11 +2959,11 @@ Outcome {
         snapbox::assert_data_eq!(
             graph_workspace(&out.workspace).to_string(),
             snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓!
-└── ≡📙:1:C {43}
-    ├── 📙:1:C
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓!
+└── ≡📙:C {43}
+    ├── 📙:C
     │   └── ·aaa195b (🏘️)
-    └── :2:main
+    └── :main
         └── ·3183e43 (🏘️)
 
 "#]]
@@ -3011,11 +3011,11 @@ Outcome {
         snapbox::assert_data_eq!(
             graph_workspace(&out.workspace).to_string(),
             snapbox::str![[r#"
-📕🏘️⚠️:1:gitbutler/workspace <> ✓!
-└── ≡👉📙:0:B[🌳] {42}
-    ├── 👉📙:0:B[🌳]
+📕🏘️⚠️:gitbutler/workspace <> ✓!
+└── ≡👉📙:B[🌳] {42}
+    ├── 👉📙:B[🌳]
     │   └── ·f57c528 (🏘️)
-    └── :2:main
+    └── :main
         └── ·3183e43 (🏘️)
 
 "#]]
@@ -3062,9 +3062,9 @@ fn apply_multiple_without_target_or_metadata_or_base() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-⌂:0:main[🌳] <> ✓!
-└── ≡:0:main[🌳] {1}
-    └── :0:main[🌳]
+⌂:main[🌳] <> ✓!
+└── ≡:main[🌳] {1}
+    └── :main[🌳]
         ├── ·b1540e5
         └── ·e31e6ca
 
@@ -3089,12 +3089,12 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on e31e6ca
-├── ≡📙:1:main on e31e6ca {1a5}
-│   └── 📙:1:main
+📕🏘️:gitbutler/workspace[🌳] <> ✓! on e31e6ca
+├── ≡📙:main on e31e6ca {1a5}
+│   └── 📙:main
 │       └── ·b1540e5 (🏘️)
-└── ≡📙:2:A on e31e6ca {41}
-    └── 📙:2:A
+└── ≡📙:A on e31e6ca {41}
+    └── 📙:A
         └── ·bf53300 (🏘️)
 
 "#]]
@@ -3134,15 +3134,15 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on e31e6ca
-├── ≡📙:1:main on e31e6ca {1a5}
-│   └── 📙:1:main
+📕🏘️:gitbutler/workspace[🌳] <> ✓! on e31e6ca
+├── ≡📙:main on e31e6ca {1a5}
+│   └── 📙:main
 │       └── ·b1540e5 (🏘️)
-├── ≡📙:2:A on e31e6ca {41}
-│   └── 📙:2:A
+├── ≡📙:A on e31e6ca {41}
+│   └── 📙:A
 │       └── ·bf53300 (🏘️)
-└── ≡📙:3:B on e31e6ca {42}
-    └── 📙:3:B
+└── ≡📙:B on e31e6ca {42}
+    └── 📙:B
         └── ·0e391b2 (🏘️)
 
 "#]]
@@ -3200,12 +3200,12 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on e31e6ca
-├── ≡📙:1:main on e31e6ca {1a5}
-│   └── 📙:1:main
+📕🏘️:gitbutler/workspace[🌳] <> ✓! on e31e6ca
+├── ≡📙:main on e31e6ca {1a5}
+│   └── 📙:main
 │       └── ·b1540e5 (🏘️)
-└── ≡📙:2:A on e31e6ca {41}
-    └── 📙:2:A
+└── ≡📙:A on e31e6ca {41}
+    └── 📙:A
         └── ·bf53300 (🏘️)
 
 "#]]
@@ -3242,9 +3242,9 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓!
-└── ≡📙:1:main {1a5}
-    └── 📙:1:main
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓!
+└── ≡📙:main {1a5}
+    └── 📙:main
         ├── ·b1540e5 (🏘️)
         └── ·e31e6ca (🏘️)
 
@@ -3285,9 +3285,9 @@ fn unapply_dirty_worktree_abort_keeps_refs_and_metadata() -> anyhow::Result<()> 
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-⌂:0:main[🌳] <> ✓!
-└── ≡:0:main[🌳] {1}
-    └── :0:main[🌳]
+⌂:main[🌳] <> ✓!
+└── ≡:main[🌳] {1}
+    └── :main[🌳]
         ├── ·b1540e5
         └── ·e31e6ca
 
@@ -3307,15 +3307,15 @@ fn unapply_dirty_worktree_abort_keeps_refs_and_metadata() -> anyhow::Result<()> 
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on e31e6ca
-├── ≡📙:1:main on e31e6ca {1a5}
-│   └── 📙:1:main
+📕🏘️:gitbutler/workspace[🌳] <> ✓! on e31e6ca
+├── ≡📙:main on e31e6ca {1a5}
+│   └── 📙:main
 │       └── ·b1540e5 (🏘️)
-├── ≡📙:2:A on e31e6ca {41}
-│   └── 📙:2:A
+├── ≡📙:A on e31e6ca {41}
+│   └── 📙:A
 │       └── ·bf53300 (🏘️)
-└── ≡📙:3:B on e31e6ca {42}
-    └── 📙:3:B
+└── ≡📙:B on e31e6ca {42}
+    └── 📙:B
         └── ·0e391b2 (🏘️)
 
 "#]]
@@ -3445,9 +3445,9 @@ fn apply_multiple_segments_of_stack_in_order_merge_if_needed() -> anyhow::Result
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-⌂:0:main[🌳] <> ✓refs/remotes/origin/main on 3183e43
-└── ≡:0:main[🌳] <> origin/main on 3183e43 {1}
-    └── :0:main[🌳] <> origin/main
+⌂:main[🌳] <> ✓refs/remotes/origin/main on 3183e43
+└── ≡:main[🌳] <> origin/main on 3183e43 {1}
+    └── :main[🌳] <> origin/main
 
 "#]]
     );
@@ -3510,12 +3510,12 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
-├── ≡📙:3:unrelated on 3183e43 {3c4}
-│   └── 📙:3:unrelated
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+├── ≡📙:unrelated on 3183e43 {3c4}
+│   └── 📙:unrelated
 │       └── ·53ad0c2 (🏘️)
-└── ≡📙:4:A1 on 3183e43 {72}
-    └── 📙:4:A1
+└── ≡📙:A1 on 3183e43 {72}
+    └── 📙:A1
         └── ·7de99e1 (🏘️)
 
 "#]]
@@ -3548,14 +3548,14 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
-├── ≡📙:3:unrelated on 3183e43 {3c4}
-│   └── 📙:3:unrelated
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+├── ≡📙:unrelated on 3183e43 {3c4}
+│   └── 📙:unrelated
 │       └── ·53ad0c2 (🏘️)
-└── ≡📙:4:A2 on 3183e43 {73}
-    ├── 📙:4:A2
+└── ≡📙:A2 on 3183e43 {73}
+    ├── 📙:A2
     │   └── ·f1889e7 (🏘️)
-    └── 📙:5:A1
+    └── 📙:A1
         └── ·7de99e1 (🏘️)
 
 "#]]
@@ -3628,9 +3628,9 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
-└── ≡📙:3:unrelated on 3183e43 {3c4}
-    └── 📙:3:unrelated
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+└── ≡📙:unrelated on 3183e43 {3c4}
+    └── 📙:unrelated
         └── ·53ad0c2 (🏘️)
 
 "#]]
@@ -3659,9 +3659,9 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
-└── ≡📙:3:unrelated on 3183e43 {3c4}
-    └── 📙:3:unrelated
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+└── ≡📙:unrelated on 3183e43 {3c4}
+    └── 📙:unrelated
         └── ·53ad0c2 (🏘️)
 
 "#]]
@@ -3691,7 +3691,7 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
 
 "#]]
     );
@@ -3736,9 +3736,9 @@ fn unapply_existing_branch_outside_detached_ad_hoc_workspace_is_noop() -> anyhow
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-⌂:0:DETACHED <> ✓! on 3183e43
-└── ≡:0:anon: on 3183e43 {1}
-    └── :0:anon:
+⌂:DETACHED <> ✓! on 3183e43
+└── ≡:anon: on 3183e43 {1}
+    └── :anon:
         └── ·aaa195b ►C
 
 "#]]
@@ -3797,13 +3797,13 @@ fn unapply_branch_from_detached_ad_hoc_workspace_is_an_error() -> anyhow::Result
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-⌂:0:DETACHED <> ✓!
-└── ≡:0:anon: {1}
-    ├── :0:anon:
+⌂:DETACHED <> ✓!
+└── ≡:anon: {1}
+    ├── :anon:
     │   └── ·f1889e7 ►A2
-    ├── :1:A1
+    ├── :A1
     │   └── ·7de99e1
-    └── :2:main[🌳]
+    └── :main[🌳]
         └── ·3183e43
 
 "#]]
@@ -3843,9 +3843,9 @@ fn detached_head_journey() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-⌂:0:DETACHED <> ✓! on 3183e43
-└── ≡:0:anon: on 3183e43 {1}
-    └── :0:anon:
+⌂:DETACHED <> ✓! on 3183e43
+└── ≡:anon: on 3183e43 {1}
+    └── :anon:
         └── ·aaa195b ►C
 
 "#]]
@@ -3871,9 +3871,9 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43
-└── ≡📙:2:C on 3183e43 {43}
-    └── 📙:2:C
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓! on 3183e43
+└── ≡📙:C on 3183e43 {43}
+    └── 📙:C
         └── ·aaa195b (🏘️)
 
 "#]]
@@ -3928,12 +3928,12 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43
-├── ≡📙:2:C on 3183e43 {43}
-│   └── 📙:2:C
+📕🏘️:gitbutler/workspace[🌳] <> ✓! on 3183e43
+├── ≡📙:C on 3183e43 {43}
+│   └── 📙:C
 │       └── ·aaa195b (🏘️)
-└── ≡📙:3:B on 3183e43 {42}
-    └── 📙:3:B
+└── ≡📙:B on 3183e43 {42}
+    └── 📙:B
         └── ·f57c528 (🏘️)
 
 "#]]
@@ -3966,15 +3966,15 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43
-├── ≡📙:2:A on 3183e43 {41}
-│   └── 📙:2:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓! on 3183e43
+├── ≡📙:A on 3183e43 {41}
+│   └── 📙:A
 │       └── ·49d4b34 (🏘️)
-├── ≡📙:3:C on 3183e43 {43}
-│   └── 📙:3:C
+├── ≡📙:C on 3183e43 {43}
+│   └── 📙:C
 │       └── ·aaa195b (🏘️)
-└── ≡📙:4:B on 3183e43 {42}
-    └── 📙:4:B
+└── ≡📙:B on 3183e43 {42}
+    └── 📙:B
         └── ·f57c528 (🏘️)
 
 "#]]
@@ -4018,12 +4018,12 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43
-├── ≡📙:2:C on 3183e43 {43}
-│   └── 📙:2:C
+📕🏘️:gitbutler/workspace[🌳] <> ✓! on 3183e43
+├── ≡📙:C on 3183e43 {43}
+│   └── 📙:C
 │       └── ·aaa195b (🏘️)
-└── ≡📙:3:B on 3183e43 {42}
-    └── 📙:3:B
+└── ≡📙:B on 3183e43 {42}
+    └── 📙:B
         └── ·f57c528 (🏘️)
 
 "#]]
@@ -4051,9 +4051,9 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43
-└── ≡📙:2:C on 3183e43 {43}
-    └── 📙:2:C
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓! on 3183e43
+└── ≡📙:C on 3183e43 {43}
+    └── 📙:C
         └── ·aaa195b (🏘️)
 
 "#]]
@@ -4082,7 +4082,7 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓! on 3183e43
 
 "#]]
     );
@@ -4139,15 +4139,15 @@ fn unapply_workspace_ref_without_target_checks_out_named_stack() -> anyhow::Resu
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43
-├── ≡📙:2:A on 3183e43 {41}
-│   └── 📙:2:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓! on 3183e43
+├── ≡📙:A on 3183e43 {41}
+│   └── 📙:A
 │       └── ·49d4b34 (🏘️)
-├── ≡📙:3:C on 3183e43 {43}
-│   └── 📙:3:C
+├── ≡📙:C on 3183e43 {43}
+│   └── 📙:C
 │       └── ·aaa195b (🏘️)
-└── ≡📙:4:B on 3183e43 {42}
-    └── 📙:4:B
+└── ≡📙:B on 3183e43 {42}
+    └── 📙:B
         └── ·f57c528 (🏘️)
 
 "#]]
@@ -4189,9 +4189,9 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-⌂:0:A[🌳] <> ✓! on 3183e43
-└── ≡:0:A[🌳] on 3183e43 {1}
-    └── :0:A[🌳]
+⌂:A[🌳] <> ✓! on 3183e43
+└── ≡:A[🌳] on 3183e43 {1}
+    └── :A[🌳]
         └── ·49d4b34
 
 "#]]
@@ -4258,11 +4258,11 @@ fn unapply_workspace_ref_refuses_conflicted_named_stack_checkout() -> anyhow::Re
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓!
-└── ≡📙:1:tip-conflicted {595}
-    ├── 📙:1:tip-conflicted
+📕🏘️:gitbutler/workspace[🌳] <> ✓!
+└── ≡📙:tip-conflicted {595}
+    ├── 📙:tip-conflicted
     │   └── ·8450331 (🏘️) ►tags/conflicted
-    └── 📙:2:main
+    └── 📙:main
         └── ·a047f81 (🏘️) ►tags/normal
 
 "#]]
@@ -4317,9 +4317,9 @@ fn apply_two_ambiguous_stacks_with_target_with_dependent_branch() -> anyhow::Res
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-⌂:0:main[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-└── ≡:0:main[🌳] <> origin/main on 85efbe4 {1}
-    └── :0:main[🌳] <> origin/main
+⌂:main[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+└── ≡:main[🌳] <> origin/main on 85efbe4 {1}
+    └── :main[🌳] <> origin/main
 
 "#]]
     );
@@ -4343,9 +4343,9 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-└── ≡📙:4:E on 85efbe4 {1}
-    └── 📙:4:E
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+└── ≡📙:E on 85efbe4 {1}
+    └── 📙:E
         └── ·7076dee (🏘️) ►D
 
 "#]]
@@ -4359,12 +4359,12 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:5:E on 85efbe4 {1}
-│   └── 📙:5:E
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:E on 85efbe4 {1}
+│   └── 📙:E
 │       └── ·7076dee (🏘️) ►D
-└── ≡📙:6:C on 7076dee {43}
-    └── 📙:6:C
+└── ≡📙:C on 7076dee {43}
+    └── 📙:C
         └── ·f084d61 (🏘️) ►A, ►B
 
 "#]]
@@ -4394,12 +4394,12 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:5:E on 85efbe4 {1}
-│   └── 📙:5:E
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:E on 85efbe4 {1}
+│   └── 📙:E
 │       └── ·7076dee (🏘️) ►D
-└── ≡📙:6:B on 7076dee {2}
-    └── 📙:6:B
+└── ≡📙:B on 7076dee {2}
+    └── 📙:B
         └── ·f084d61 (🏘️) ►A, ►C
 
 "#]]
@@ -4415,13 +4415,13 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:5:E on 85efbe4 {1}
-│   └── 📙:5:E
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:E on 85efbe4 {1}
+│   └── 📙:E
 │       └── ·7076dee (🏘️) ►D
-└── ≡📙:6:C on 7076dee {2}
-    ├── 📙:6:C
-    └── 📙:7:B
+└── ≡📙:C on 7076dee {2}
+    ├── 📙:C
+    └── 📙:B
         └── ·f084d61 (🏘️) ►A
 
 "#]]
@@ -4451,9 +4451,9 @@ fn apply_two_ambiguous_stacks_with_target() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-⌂:0:main[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-└── ≡:0:main[🌳] <> origin/main on 85efbe4 {1}
-    └── :0:main[🌳] <> origin/main
+⌂:main[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+└── ≡:main[🌳] <> origin/main on 85efbe4 {1}
+    └── :main[🌳] <> origin/main
 
 "#]]
     );
@@ -4476,9 +4476,9 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-└── ≡📙:3:A on 85efbe4 {41}
-    └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+└── ≡📙:A on 85efbe4 {41}
+    └── 📙:A
         ├── ·f084d61 (🏘️) ►B, ►C
         └── ·7076dee (🏘️) ►D, ►E
 
@@ -4515,10 +4515,10 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-└── ≡📙:4:B on 85efbe4 {41}
-    ├── 📙:4:B
-    └── 📙:5:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+└── ≡📙:B on 85efbe4 {41}
+    ├── 📙:B
+    └── 📙:A
         ├── ·f084d61 (🏘️) ►C
         └── ·7076dee (🏘️) ►D, ►E
 
@@ -4557,11 +4557,11 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-└── ≡📙:4:B on 85efbe4 {41}
-    ├── 📙:4:B
-    ├── 📙:5:C
-    └── 📙:6:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+└── ≡📙:B on 85efbe4 {41}
+    ├── 📙:B
+    ├── 📙:C
+    └── 📙:A
         ├── ·f084d61 (🏘️)
         └── ·7076dee (🏘️) ►D, ►E
 
@@ -4600,13 +4600,13 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-└── ≡📙:5:B on 85efbe4 {41}
-    ├── 📙:5:B
-    ├── 📙:6:C
-    ├── 📙:7:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+└── ≡📙:B on 85efbe4 {41}
+    ├── 📙:B
+    ├── 📙:C
+    ├── 📙:A
     │   └── ·f084d61 (🏘️)
-    └── 📙:4:D
+    └── 📙:D
         └── ·7076dee (🏘️) ►E
 
 "#]]
@@ -4644,15 +4644,15 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:5:B {41}
-│   ├── 📙:5:B
-│   ├── 📙:6:C
-│   └── 📙:7:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:B {41}
+│   ├── 📙:B
+│   ├── 📙:C
+│   └── 📙:A
 │       └── ·f084d61 (🏘️)
-└── ≡📙:8:E on 85efbe4 {44}
-    ├── 📙:8:E
-    └── 📙:9:D
+└── ≡📙:E on 85efbe4 {44}
+    ├── 📙:E
+    └── 📙:D
         └── ·7076dee (🏘️)
 
 "#]]
@@ -4701,13 +4701,13 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-└── ≡📙:5:B on 85efbe4 {41}
-    ├── 📙:5:B
-    ├── 📙:6:C
-    ├── 📙:7:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+└── ≡📙:B on 85efbe4 {41}
+    ├── 📙:B
+    ├── 📙:C
+    ├── 📙:A
     │   └── ·f084d61 (🏘️)
-    └── 📙:4:D
+    └── 📙:D
         └── ·7076dee (🏘️)
 
 "#]]
@@ -4749,13 +4749,13 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-└── ≡📙:5:B on 85efbe4 {41}
-    ├── 📙:5:B
-    ├── 📙:6:C
-    ├── 📙:7:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+└── ≡📙:B on 85efbe4 {41}
+    ├── 📙:B
+    ├── 📙:C
+    ├── 📙:A
     │   └── ·f084d61 (🏘️)
-    └── 📙:4:E
+    └── 📙:E
         └── ·7076dee (🏘️)
 
 "#]]
@@ -4797,12 +4797,12 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-└── ≡📙:5:B on 85efbe4 {41}
-    ├── 📙:5:B
-    ├── 📙:6:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+└── ≡📙:B on 85efbe4 {41}
+    ├── 📙:B
+    ├── 📙:A
     │   └── ·f084d61 (🏘️)
-    └── 📙:4:E
+    └── 📙:E
         └── ·7076dee (🏘️) ►D
 
 "#]]
@@ -4844,7 +4844,7 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
 
 "#]]
     );
@@ -4886,7 +4886,7 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
 
 "#]]
     );
@@ -4930,9 +4930,9 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-⌂:0:main[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-└── ≡:0:main[🌳] <> origin/main on 85efbe4 {1}
-    └── :0:main[🌳] <> origin/main
+⌂:main[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+└── ≡:main[🌳] <> origin/main on 85efbe4 {1}
+    └── :main[🌳] <> origin/main
 
 "#]]
     );
@@ -5021,23 +5021,23 @@ fn apply_with_conflicts_shows_exact_conflict_info() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on 85efbe4
-├── ≡📙:7:main on 85efbe4 {1a5}
-│   └── 📙:7:main
-├── ≡📙:2:clean-A on 85efbe4 {271}
-│   └── 📙:2:clean-A
+📕🏘️:gitbutler/workspace[🌳] <> ✓! on 85efbe4
+├── ≡📙:main on 85efbe4 {1a5}
+│   └── 📙:main
+├── ≡📙:clean-A on 85efbe4 {271}
+│   └── 📙:clean-A
 │       └── ·d3cce74 (🏘️)
-├── ≡📙:3:conflict-F1 on 85efbe4 {3f6}
-│   └── 📙:3:conflict-F1
+├── ≡📙:conflict-F1 on 85efbe4 {3f6}
+│   └── 📙:conflict-F1
 │       └── ·bf09eae (🏘️)
-├── ≡📙:4:clean-B on 85efbe4 {272}
-│   └── 📙:4:clean-B
+├── ≡📙:clean-B on 85efbe4 {272}
+│   └── 📙:clean-B
 │       └── ·115e41b (🏘️)
-├── ≡📙:5:conflict-F2 on 85efbe4 {3f7}
-│   └── 📙:5:conflict-F2
+├── ≡📙:conflict-F2 on 85efbe4 {3f7}
+│   └── 📙:conflict-F2
 │       └── ·f2ce66d (🏘️)
-└── ≡📙:6:clean-C on 85efbe4 {273}
-    └── 📙:6:clean-C
+└── ≡📙:clean-C on 85efbe4 {273}
+    └── 📙:clean-C
         └── ·34c4591 (🏘️)
 
 "#]]
@@ -5101,23 +5101,23 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on 85efbe4
-├── ≡📙:8:main on 85efbe4 {1a5}
-│   └── 📙:8:main
-├── ≡📙:2:clean-A on 85efbe4 {271}
-│   └── 📙:2:clean-A
+📕🏘️:gitbutler/workspace[🌳] <> ✓! on 85efbe4
+├── ≡📙:main on 85efbe4 {1a5}
+│   └── 📙:main
+├── ≡📙:clean-A on 85efbe4 {271}
+│   └── 📙:clean-A
 │       └── ·d3cce74 (🏘️)
-├── ≡📙:3:conflict-F1 on 85efbe4 {3f6}
-│   └── 📙:3:conflict-F1
+├── ≡📙:conflict-F1 on 85efbe4 {3f6}
+│   └── 📙:conflict-F1
 │       └── ·bf09eae (🏘️)
-├── ≡📙:4:clean-B on 85efbe4 {272}
-│   └── 📙:4:clean-B
+├── ≡📙:clean-B on 85efbe4 {272}
+│   └── 📙:clean-B
 │       └── ·115e41b (🏘️)
-├── ≡📙:5:conflict-F2 on 85efbe4 {3f7}
-│   └── 📙:5:conflict-F2
+├── ≡📙:conflict-F2 on 85efbe4 {3f7}
+│   └── 📙:conflict-F2
 │       └── ·f2ce66d (🏘️)
-└── ≡📙:6:clean-C on 85efbe4 {273}
-    └── 📙:6:clean-C
+└── ≡📙:clean-C on 85efbe4 {273}
+    └── 📙:clean-C
         └── ·34c4591 (🏘️)
 
 "#]]
@@ -5169,20 +5169,20 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on 85efbe4
-├── ≡📙:6:main on 85efbe4 {1a5}
-│   └── 📙:6:main
-├── ≡📙:2:clean-A on 85efbe4 {271}
-│   └── 📙:2:clean-A
+📕🏘️:gitbutler/workspace[🌳] <> ✓! on 85efbe4
+├── ≡📙:main on 85efbe4 {1a5}
+│   └── 📙:main
+├── ≡📙:clean-A on 85efbe4 {271}
+│   └── 📙:clean-A
 │       └── ·d3cce74 (🏘️)
-├── ≡📙:3:clean-B on 85efbe4 {272}
-│   └── 📙:3:clean-B
+├── ≡📙:clean-B on 85efbe4 {272}
+│   └── 📙:clean-B
 │       └── ·115e41b (🏘️)
-├── ≡📙:4:clean-C on 85efbe4 {273}
-│   └── 📙:4:clean-C
+├── ≡📙:clean-C on 85efbe4 {273}
+│   └── 📙:clean-C
 │       └── ·34c4591 (🏘️)
-└── ≡📙:5:conflict-hero on 85efbe4 {52d}
-    └── 📙:5:conflict-hero
+└── ≡📙:conflict-hero on 85efbe4 {52d}
+    └── 📙:conflict-hero
         ├── ·4bbb93c (🏘️)
         └── ·98519e9 (🏘️)
 
@@ -5335,9 +5335,9 @@ fn conflicting_apply_reports_no_applied_branches_and_names_conflicting_stacks() 
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on e31e6ca
-└── ≡📙:3:A on e31e6ca {41}
-    └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on e31e6ca
+└── ≡📙:A on e31e6ca {41}
+    └── 📙:A
         └── ·bf53300 (🏘️)
 
 "#]]
@@ -5429,9 +5429,9 @@ fn unapply_with_workspace_merge_conflicts_always_works_as_conflicts_do_not_repea
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-⌂:0:main[🌳] <> ✓! on 85efbe4
-└── ≡:0:main[🌳] on 85efbe4 {1}
-    └── :0:main[🌳]
+⌂:main[🌳] <> ✓! on 85efbe4
+└── ≡:main[🌳] on 85efbe4 {1}
+    └── :main[🌳]
 
 "#]]
     );
@@ -5463,20 +5463,20 @@ fn unapply_with_workspace_merge_conflicts_always_works_as_conflicts_do_not_repea
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓! on 85efbe4
-├── ≡📙:6:main on 85efbe4 {1a5}
-│   └── 📙:6:main
-├── ≡📙:2:clean-A on 85efbe4 {271}
-│   └── 📙:2:clean-A
+📕🏘️:gitbutler/workspace[🌳] <> ✓! on 85efbe4
+├── ≡📙:main on 85efbe4 {1a5}
+│   └── 📙:main
+├── ≡📙:clean-A on 85efbe4 {271}
+│   └── 📙:clean-A
 │       └── ·d3cce74 (🏘️)
-├── ≡📙:3:clean-B on 85efbe4 {272}
-│   └── 📙:3:clean-B
+├── ≡📙:clean-B on 85efbe4 {272}
+│   └── 📙:clean-B
 │       └── ·115e41b (🏘️)
-├── ≡📙:4:clean-C on 85efbe4 {273}
-│   └── 📙:4:clean-C
+├── ≡📙:clean-C on 85efbe4 {273}
+│   └── 📙:clean-C
 │       └── ·34c4591 (🏘️)
-└── ≡📙:5:conflict-hero on 85efbe4 {52d}
-    └── 📙:5:conflict-hero
+└── ≡📙:conflict-hero on 85efbe4 {52d}
+    └── 📙:conflict-hero
         ├── ·4bbb93c (🏘️)
         └── ·98519e9 (🏘️)
 
@@ -5500,9 +5500,9 @@ fn unapply_with_workspace_merge_conflicts_always_works_as_conflicts_do_not_repea
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on 85efbe4
-└── ≡📙:2:main on 85efbe4 {1a5}
-    └── 📙:2:main
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓! on 85efbe4
+└── ≡📙:main on 85efbe4 {1a5}
+    └── 📙:main
 
 "#]]
     );
@@ -5533,11 +5533,11 @@ fn auto_checkout_of_enclosing_workspace_flat() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
-├── ≡📙:2:A on e5d0542 {1}
-│   └── 📙:2:A
-└── ≡📙:3:B on e5d0542 {2}
-    └── 📙:3:B
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓! on e5d0542
+├── ≡📙:A on e5d0542 {1}
+│   └── 📙:A
+└── ≡📙:B on e5d0542 {2}
+    └── 📙:B
 
 "#]]
     );
@@ -5576,11 +5576,11 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:1:gitbutler/workspace[🌳] <> ✓! on e5d0542
-├── ≡📙:2:A on e5d0542 {1}
-│   └── 📙:2:A
-└── ≡👉📙:3:B on e5d0542 {2}
-    └── 👉📙:3:B
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓! on e5d0542
+├── ≡📙:A on e5d0542 {1}
+│   └── 📙:A
+└── ≡👉📙:B on e5d0542 {2}
+    └── 👉📙:B
 
 "#]]
     );
@@ -5645,11 +5645,11 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
-├── ≡📙:2:A on e5d0542 {1}
-│   └── 📙:2:A
-└── ≡📙:3:B on e5d0542 {2}
-    └── 📙:3:B
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓! on e5d0542
+├── ≡📙:A on e5d0542 {1}
+│   └── 📙:A
+└── ≡📙:B on e5d0542 {2}
+    └── 📙:B
 
 "#]]
     );
@@ -5681,10 +5681,10 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:1:gitbutler/workspace[🌳] <> ✓! on e5d0542
-└── ≡👉📙:2:B on e5d0542 {2}
-    ├── 👉📙:2:B
-    └── 📙:3:A
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓! on e5d0542
+└── ≡👉📙:B on e5d0542 {2}
+    ├── 👉📙:B
+    └── 📙:A
 
 "#]]
     );
@@ -5719,7 +5719,7 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓! on e5d0542
 
 "#]]
     );
@@ -5747,9 +5747,9 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
-└── ≡📙:2:A on e5d0542 {41}
-    └── 📙:2:A
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓! on e5d0542
+└── ≡📙:A on e5d0542 {41}
+    └── 📙:A
 
 "#]]
     );
@@ -5772,11 +5772,11 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&out.workspace).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
-├── ≡📙:2:A on e5d0542 {41}
-│   └── 📙:2:A
-└── ≡📙:3:B on e5d0542 {42}
-    └── 📙:3:B
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓! on e5d0542
+├── ≡📙:A on e5d0542 {41}
+│   └── 📙:A
+└── ≡📙:B on e5d0542 {42}
+    └── 📙:B
 
 "#]]
     );
@@ -5795,11 +5795,11 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:1:gitbutler/workspace[🌳] <> ✓! on e5d0542
-├── ≡📙:2:A on e5d0542 {41}
-│   └── 📙:2:A
-└── ≡👉📙:3:B on e5d0542 {42}
-    └── 👉📙:3:B
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓! on e5d0542
+├── ≡📙:A on e5d0542 {41}
+│   └── 📙:A
+└── ≡👉📙:B on e5d0542 {42}
+    └── 👉📙:B
 
 "#]]
     );
@@ -5828,9 +5828,9 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
-└── ≡📙:2:B on e5d0542 {42}
-    └── 📙:2:B
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓! on e5d0542
+└── ≡📙:B on e5d0542 {42}
+    └── 📙:B
 
 "#]]
     );
@@ -5864,7 +5864,7 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓! on e5d0542
 
 "#]]
     );
@@ -5907,12 +5907,12 @@ fn auto_checkout_of_enclosing_workspace_with_commits() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:3:A on 85efbe4 {1}
-│   └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:A on 85efbe4 {1}
+│   └── 📙:A
 │       └── ·09d8e52 (🏘️)
-└── ≡📙:4:B on 85efbe4 {2}
-    └── 📙:4:B
+└── ≡📙:B on 85efbe4 {2}
+    └── 📙:B
         └── ·c813d8d (🏘️)
 
 "#]]
@@ -5947,12 +5947,12 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:1:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:4:A on 85efbe4 {1}
-│   └── 📙:4:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:A on 85efbe4 {1}
+│   └── 📙:A
 │       └── ·09d8e52 (🏘️)
-└── ≡👉📙:0:B on 85efbe4 {2}
-    └── 👉📙:0:B
+└── ≡👉📙:B on 85efbe4 {2}
+    └── 👉📙:B
         └── ·c813d8d (🏘️)
 
 "#]]
@@ -6018,12 +6018,12 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:3:A on 85efbe4 {1}
-│   └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:A on 85efbe4 {1}
+│   └── 📙:A
 │       └── ·09d8e52 (🏘️)
-└── ≡📙:4:B on 85efbe4 {2}
-    └── 📙:4:B
+└── ≡📙:B on 85efbe4 {2}
+    └── 📙:B
         └── ·c813d8d (🏘️)
 
 "#]]
@@ -6054,7 +6054,7 @@ fn apply_nonexisting_branch_failure() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓! on e5d0542
 
 "#]]
     );
@@ -6106,7 +6106,7 @@ fn unapply_nonexisting_branch() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on e5d0542
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓! on e5d0542
 
 "#]]
     );
@@ -6154,9 +6154,9 @@ fn unborn_apply_needs_base() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-⌂:0:main[🌳] <> ✓!
-└── ≡:0:main[🌳] {1}
-    └── :0:main[🌳]
+⌂:main[🌳] <> ✓!
+└── ≡:main[🌳] {1}
+    └── :main[🌳]
 
 "#]]
     );
@@ -6208,9 +6208,9 @@ Outcome {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-⌂:0:main[🌳] <> ✓!
-└── ≡:0:main[🌳] {1}
-    └── :0:main[🌳]
+⌂:main[🌳] <> ✓!
+└── ≡:main[🌳] {1}
+    └── :main[🌳]
 
 "#]]
     );

--- a/crates/but-workspace/tests/workspace/branch/create_reference.rs
+++ b/crates/but-workspace/tests/workspace/branch/create_reference.rs
@@ -77,7 +77,7 @@ Single commit, no main remote/target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓! on 3183e43
 
 "#]]
         );
@@ -91,9 +91,9 @@ Single commit, no main remote/target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓!
-└── ≡:1:main
-    └── :1:main
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓!
+└── ≡:main
+    └── :main
         └── ·3183e43 (🏘️)
 
 "#]]
@@ -151,7 +151,7 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
 
 "#]]
         );
@@ -170,9 +170,9 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
-└── ≡📙:3:A on 3183e43 {41}
-    └── 📙:3:A
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+└── ≡📙:A on 3183e43 {41}
+    └── 📙:A
 
 "#]]
         );
@@ -196,11 +196,11 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
-├── ≡📙:3:A on 3183e43 {41}
-│   └── 📙:3:A
-└── ≡📙:4:B on 3183e43 {42}
-    └── 📙:4:B
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+├── ≡📙:A on 3183e43 {41}
+│   └── 📙:A
+└── ≡📙:B on 3183e43 {42}
+    └── 📙:B
 
 "#]]
         );
@@ -218,11 +218,11 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
-├── ≡📙:3:A on 3183e43 {41}
-│   └── 📙:3:A
-└── ≡📙:4:B on 3183e43 {42}
-    └── 📙:4:B
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+├── ≡📙:A on 3183e43 {41}
+│   └── 📙:A
+└── ≡📙:B on 3183e43 {42}
+    └── 📙:B
 
 "#]]
         );
@@ -243,12 +243,12 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
-├── ≡📙:3:above-A on 3183e43 {41}
-│   ├── 📙:3:above-A
-│   └── 📙:4:A
-└── ≡📙:5:B on 3183e43 {42}
-    └── 📙:5:B
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+├── ≡📙:above-A on 3183e43 {41}
+│   ├── 📙:above-A
+│   └── 📙:A
+└── ≡📙:B on 3183e43 {42}
+    └── 📙:B
 
 "#]]
         );
@@ -269,13 +269,13 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
-├── ≡📙:3:above-A on 3183e43 {41}
-│   ├── 📙:3:above-A
-│   └── 📙:4:A
-└── ≡📙:5:B on 3183e43 {42}
-    ├── 📙:5:B
-    └── 📙:6:below-B
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+├── ≡📙:above-A on 3183e43 {41}
+│   ├── 📙:above-A
+│   └── 📙:A
+└── ≡📙:B on 3183e43 {42}
+    ├── 📙:B
+    └── 📙:below-B
 
 "#]]
         );
@@ -295,13 +295,13 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
-├── ≡📙:3:above-A on 3183e43 {41}
-│   ├── 📙:3:above-A
-│   └── 📙:4:A
-└── ≡📙:5:B on 3183e43 {42}
-    ├── 📙:5:B
-    └── 📙:6:below-B
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+├── ≡📙:above-A on 3183e43 {41}
+│   ├── 📙:above-A
+│   └── 📙:A
+└── ≡📙:B on 3183e43 {42}
+    ├── 📙:B
+    └── 📙:below-B
 
 "#]]
         );
@@ -344,9 +344,9 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
-└── ≡:3:A on bce0c5e
-    └── :3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
+└── ≡:A on bce0c5e
+    └── :A
         ├── ·43f9472 (🏘️)
         └── ·6fdab32 (🏘️)
 
@@ -372,11 +372,11 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
-└── ≡:4:A on bce0c5e {4cf}
-    ├── :4:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
+└── ≡:A on bce0c5e {4cf}
+    ├── :A
     │   └── ·43f9472 (🏘️)
-    └── 📙:3:above-bottom
+    └── 📙:above-bottom
         └── ·6fdab32 (🏘️)
 
 "#]]
@@ -399,13 +399,13 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
-└── ≡:4:A on bce0c5e {4cf}
-    ├── :4:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
+└── ≡:A on bce0c5e {4cf}
+    ├── :A
     │   └── ·43f9472 (🏘️)
-    ├── 📙:3:above-bottom
+    ├── 📙:above-bottom
     │   └── ·6fdab32 (🏘️)
-    └── 📙:5:bottom
+    └── 📙:bottom
 
 "#]]
         );
@@ -431,13 +431,13 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
-└── ≡📙:3:above-A-commit on bce0c5e {4cf}
-    ├── 📙:3:above-A-commit
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
+└── ≡📙:above-A-commit on bce0c5e {4cf}
+    ├── 📙:above-A-commit
     │   └── ·43f9472 (🏘️) ►A
-    ├── 📙:4:above-bottom
+    ├── 📙:above-bottom
     │   └── ·6fdab32 (🏘️)
-    └── 📙:5:bottom
+    └── 📙:bottom
 
 "#]]
         );
@@ -461,14 +461,14 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
-└── ≡📙:5:above-A-commit on bce0c5e {4cf}
-    ├── 📙:5:above-A-commit
-    ├── 📙:6:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
+└── ≡📙:above-A-commit on bce0c5e {4cf}
+    ├── 📙:above-A-commit
+    ├── 📙:A
     │   └── ·43f9472 (🏘️)
-    ├── 📙:4:above-bottom
+    ├── 📙:above-bottom
     │   └── ·6fdab32 (🏘️)
-    └── 📙:7:bottom
+    └── 📙:bottom
 
 "#]]
         );
@@ -492,15 +492,15 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
-└── ≡📙:5:above-A-commit on bce0c5e {4cf}
-    ├── 📙:5:above-A-commit
-    ├── 📙:6:above-A
-    ├── 📙:7:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
+└── ≡📙:above-A-commit on bce0c5e {4cf}
+    ├── 📙:above-A-commit
+    ├── 📙:above-A
+    ├── 📙:A
     │   └── ·43f9472 (🏘️)
-    ├── 📙:4:above-bottom
+    ├── 📙:above-bottom
     │   └── ·6fdab32 (🏘️)
-    └── 📙:8:bottom
+    └── 📙:bottom
 
 "#]]
         );
@@ -522,16 +522,16 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
-└── ≡📙:5:above-A-commit on bce0c5e {4cf}
-    ├── 📙:5:above-A-commit
-    ├── 📙:6:above-A
-    ├── 📙:7:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
+└── ≡📙:above-A-commit on bce0c5e {4cf}
+    ├── 📙:above-A-commit
+    ├── 📙:above-A
+    ├── 📙:A
     │   └── ·43f9472 (🏘️)
-    ├── 📙:8:below-A-commit
-    ├── 📙:9:above-bottom
+    ├── 📙:below-A-commit
+    ├── 📙:above-bottom
     │   └── ·6fdab32 (🏘️)
-    └── 📙:10:bottom
+    └── 📙:bottom
 
 "#]]
         );
@@ -552,17 +552,17 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
-└── ≡📙:5:above-A-commit on bce0c5e {4cf}
-    ├── 📙:5:above-A-commit
-    ├── 📙:6:above-A
-    ├── 📙:7:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
+└── ≡📙:above-A-commit on bce0c5e {4cf}
+    ├── 📙:above-A-commit
+    ├── 📙:above-A
+    ├── 📙:A
     │   └── ·43f9472 (🏘️)
-    ├── 📙:8:below-A
-    ├── 📙:9:below-A-commit
-    ├── 📙:10:above-bottom
+    ├── 📙:below-A
+    ├── 📙:below-A-commit
+    ├── 📙:above-bottom
     │   └── ·6fdab32 (🏘️)
-    └── 📙:11:bottom
+    └── 📙:bottom
 
 "#]]
         );
@@ -581,19 +581,19 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
-├── ≡📙:6:above-A-commit on bce0c5e {4cf}
-│   ├── 📙:6:above-A-commit
-│   ├── 📙:7:above-A
-│   ├── 📙:8:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
+├── ≡📙:above-A-commit on bce0c5e {4cf}
+│   ├── 📙:above-A-commit
+│   ├── 📙:above-A
+│   ├── 📙:A
 │   │   └── ·43f9472 (🏘️)
-│   ├── 📙:9:below-A
-│   ├── 📙:10:below-A-commit
-│   ├── 📙:11:above-bottom
+│   ├── 📙:below-A
+│   ├── 📙:below-A-commit
+│   ├── 📙:above-bottom
 │   │   └── ·6fdab32 (🏘️)
-│   └── 📙:12:bottom
-└── ≡📙:5:B on bce0c5e {42}
-    └── 📙:5:B
+│   └── 📙:bottom
+└── ≡📙:B on bce0c5e {42}
+    └── 📙:B
 
 "#]]
         );
@@ -615,20 +615,20 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
-├── ≡📙:7:above-A-commit on bce0c5e {4cf}
-│   ├── 📙:7:above-A-commit
-│   ├── 📙:8:above-A
-│   ├── 📙:9:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
+├── ≡📙:above-A-commit on bce0c5e {4cf}
+│   ├── 📙:above-A-commit
+│   ├── 📙:above-A
+│   ├── 📙:A
 │   │   └── ·43f9472 (🏘️)
-│   ├── 📙:10:below-A
-│   ├── 📙:11:below-A-commit
-│   ├── 📙:12:above-bottom
+│   ├── 📙:below-A
+│   ├── 📙:below-A-commit
+│   ├── 📙:above-bottom
 │   │   └── ·6fdab32 (🏘️)
-│   └── 📙:13:bottom
-└── ≡📙:5:above-B on bce0c5e {42}
-    ├── 📙:5:above-B
-    └── 📙:6:B
+│   └── 📙:bottom
+└── ≡📙:above-B on bce0c5e {42}
+    ├── 📙:above-B
+    └── 📙:B
 
 "#]]
         );
@@ -652,21 +652,21 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
-├── ≡📙:8:above-A-commit on bce0c5e {4cf}
-│   ├── 📙:8:above-A-commit
-│   ├── 📙:9:above-A
-│   ├── 📙:10:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
+├── ≡📙:above-A-commit on bce0c5e {4cf}
+│   ├── 📙:above-A-commit
+│   ├── 📙:above-A
+│   ├── 📙:A
 │   │   └── ·43f9472 (🏘️)
-│   ├── 📙:11:below-A
-│   ├── 📙:12:below-A-commit
-│   ├── 📙:13:above-bottom
+│   ├── 📙:below-A
+│   ├── 📙:below-A-commit
+│   ├── 📙:above-bottom
 │   │   └── ·6fdab32 (🏘️)
-│   └── 📙:14:bottom
-└── ≡📙:5:above-B on bce0c5e {42}
-    ├── 📙:5:above-B
-    ├── 📙:6:B
-    └── 📙:7:below-B
+│   └── 📙:bottom
+└── ≡📙:above-B on bce0c5e {42}
+    ├── 📙:above-B
+    ├── 📙:B
+    └── 📙:below-B
 
 "#]]
         );
@@ -686,21 +686,21 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
-├── ≡📙:8:above-A-commit on bce0c5e {4cf}
-│   ├── 📙:8:above-A-commit
-│   ├── 📙:9:above-A
-│   ├── 📙:10:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
+├── ≡📙:above-A-commit on bce0c5e {4cf}
+│   ├── 📙:above-A-commit
+│   ├── 📙:above-A
+│   ├── 📙:A
 │   │   └── ·43f9472 (🏘️)
-│   ├── 📙:11:below-A
-│   ├── 📙:12:below-A-commit
-│   ├── 📙:13:above-bottom
+│   ├── 📙:below-A
+│   ├── 📙:below-A-commit
+│   ├── 📙:above-bottom
 │   │   └── ·6fdab32 (🏘️)
-│   └── 📙:14:bottom
-└── ≡📙:5:above-B on bce0c5e {42}
-    ├── 📙:5:above-B
-    ├── 📙:6:B
-    └── 📙:7:below-B
+│   └── 📙:bottom
+└── ≡📙:above-B on bce0c5e {42}
+    ├── 📙:above-B
+    ├── 📙:B
+    └── 📙:below-B
 
 "#]]
         );
@@ -747,9 +747,9 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
-└── ≡📙:3:A on 3183e43 {0}
-    └── 📙:3:A
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+└── ≡📙:A on 3183e43 {0}
+    └── 📙:A
         ├── ·c2878fb (🏘️)
         └── ·49d4b34 (🏘️)
 
@@ -773,11 +773,11 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
-└── ≡📙:4:A on 3183e43 {0}
-    ├── 📙:4:A
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+└── ≡📙:A on 3183e43 {0}
+    ├── 📙:A
     │   └── ·c2878fb (🏘️)
-    └── 📙:3:above-bottom
+    └── 📙:above-bottom
         └── ·49d4b34 (🏘️)
 
 "#]]
@@ -802,13 +802,13 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
-└── ≡📙:4:A on 3183e43 {0}
-    ├── 📙:4:A
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+└── ≡📙:A on 3183e43 {0}
+    ├── 📙:A
     │   └── ·c2878fb (🏘️)
-    ├── 📙:3:above-bottom
+    ├── 📙:above-bottom
     │   └── ·49d4b34 (🏘️)
-    └── 📙:5:bottom
+    └── 📙:bottom
 
 "#]]
         );
@@ -832,14 +832,14 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
-└── ≡📙:5:A on 3183e43 {0}
-    ├── 📙:5:A
-    ├── 📙:6:above-A-commit
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+└── ≡📙:A on 3183e43 {0}
+    ├── 📙:A
+    ├── 📙:above-A-commit
     │   └── ·c2878fb (🏘️)
-    ├── 📙:3:above-bottom
+    ├── 📙:above-bottom
     │   └── ·49d4b34 (🏘️)
-    └── 📙:7:bottom
+    └── 📙:bottom
 
 "#]]
         );
@@ -863,15 +863,15 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
-└── ≡📙:5:above-A on 3183e43 {0}
-    ├── 📙:5:above-A
-    ├── 📙:6:A
-    ├── 📙:7:above-A-commit
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+└── ≡📙:above-A on 3183e43 {0}
+    ├── 📙:above-A
+    ├── 📙:A
+    ├── 📙:above-A-commit
     │   └── ·c2878fb (🏘️)
-    ├── 📙:3:above-bottom
+    ├── 📙:above-bottom
     │   └── ·49d4b34 (🏘️)
-    └── 📙:8:bottom
+    └── 📙:bottom
 
 "#]]
         );
@@ -895,15 +895,15 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
-└── ≡📙:5:above-A on 3183e43 {0}
-    ├── 📙:5:above-A
-    ├── 📙:6:A
-    ├── 📙:7:above-A-commit
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+└── ≡📙:above-A on 3183e43 {0}
+    ├── 📙:above-A
+    ├── 📙:A
+    ├── 📙:above-A-commit
     │   └── ·c2878fb (🏘️)
-    ├── 📙:3:above-bottom
+    ├── 📙:above-bottom
     │   └── ·49d4b34 (🏘️)
-    └── 📙:8:bottom
+    └── 📙:bottom
 
 "#]]
         );
@@ -925,16 +925,16 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
-└── ≡📙:5:above-A on 3183e43 {0}
-    ├── 📙:5:above-A
-    ├── 📙:6:A
-    ├── 📙:7:above-A-commit
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+└── ≡📙:above-A on 3183e43 {0}
+    ├── 📙:above-A
+    ├── 📙:A
+    ├── 📙:above-A-commit
     │   └── ·c2878fb (🏘️)
-    ├── 📙:8:below-A-commit
-    ├── 📙:9:above-bottom
+    ├── 📙:below-A-commit
+    ├── 📙:above-bottom
     │   └── ·49d4b34 (🏘️)
-    └── 📙:10:bottom
+    └── 📙:bottom
 
 "#]]
         );
@@ -955,17 +955,17 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
-└── ≡📙:5:above-A on 3183e43 {0}
-    ├── 📙:5:above-A
-    ├── 📙:6:A
-    ├── 📙:7:above-A-commit
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+└── ≡📙:above-A on 3183e43 {0}
+    ├── 📙:above-A
+    ├── 📙:A
+    ├── 📙:above-A-commit
     │   └── ·c2878fb (🏘️)
-    ├── 📙:8:below-A
-    ├── 📙:9:below-A-commit
-    ├── 📙:10:above-bottom
+    ├── 📙:below-A
+    ├── 📙:below-A-commit
+    ├── 📙:above-bottom
     │   └── ·49d4b34 (🏘️)
-    └── 📙:11:bottom
+    └── 📙:bottom
 
 "#]]
         );
@@ -984,19 +984,19 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
-├── ≡📙:6:above-A on 3183e43 {0}
-│   ├── 📙:6:above-A
-│   ├── 📙:7:A
-│   ├── 📙:8:above-A-commit
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+├── ≡📙:above-A on 3183e43 {0}
+│   ├── 📙:above-A
+│   ├── 📙:A
+│   ├── 📙:above-A-commit
 │   │   └── ·c2878fb (🏘️)
-│   ├── 📙:9:below-A
-│   ├── 📙:10:below-A-commit
-│   ├── 📙:11:above-bottom
+│   ├── 📙:below-A
+│   ├── 📙:below-A-commit
+│   ├── 📙:above-bottom
 │   │   └── ·49d4b34 (🏘️)
-│   └── 📙:12:bottom
-└── ≡📙:5:B on 3183e43 {42}
-    └── 📙:5:B
+│   └── 📙:bottom
+└── ≡📙:B on 3183e43 {42}
+    └── 📙:B
 
 "#]]
         );
@@ -1018,20 +1018,20 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
-├── ≡📙:7:above-A on 3183e43 {0}
-│   ├── 📙:7:above-A
-│   ├── 📙:8:A
-│   ├── 📙:9:above-A-commit
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+├── ≡📙:above-A on 3183e43 {0}
+│   ├── 📙:above-A
+│   ├── 📙:A
+│   ├── 📙:above-A-commit
 │   │   └── ·c2878fb (🏘️)
-│   ├── 📙:10:below-A
-│   ├── 📙:11:below-A-commit
-│   ├── 📙:12:above-bottom
+│   ├── 📙:below-A
+│   ├── 📙:below-A-commit
+│   ├── 📙:above-bottom
 │   │   └── ·49d4b34 (🏘️)
-│   └── 📙:13:bottom
-└── ≡📙:5:above-B on 3183e43 {42}
-    ├── 📙:5:above-B
-    └── 📙:6:B
+│   └── 📙:bottom
+└── ≡📙:above-B on 3183e43 {42}
+    ├── 📙:above-B
+    └── 📙:B
 
 "#]]
         );
@@ -1055,21 +1055,21 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
-├── ≡📙:8:above-A on 3183e43 {0}
-│   ├── 📙:8:above-A
-│   ├── 📙:9:A
-│   ├── 📙:10:above-A-commit
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+├── ≡📙:above-A on 3183e43 {0}
+│   ├── 📙:above-A
+│   ├── 📙:A
+│   ├── 📙:above-A-commit
 │   │   └── ·c2878fb (🏘️)
-│   ├── 📙:11:below-A
-│   ├── 📙:12:below-A-commit
-│   ├── 📙:13:above-bottom
+│   ├── 📙:below-A
+│   ├── 📙:below-A-commit
+│   ├── 📙:above-bottom
 │   │   └── ·49d4b34 (🏘️)
-│   └── 📙:14:bottom
-└── ≡📙:5:above-B on 3183e43 {42}
-    ├── 📙:5:above-B
-    ├── 📙:6:B
-    └── 📙:7:below-B
+│   └── 📙:bottom
+└── ≡📙:above-B on 3183e43 {42}
+    ├── 📙:above-B
+    ├── 📙:B
+    └── 📙:below-B
 
 "#]]
         );
@@ -1089,21 +1089,21 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
-├── ≡📙:8:above-A on 3183e43 {0}
-│   ├── 📙:8:above-A
-│   ├── 📙:9:A
-│   ├── 📙:10:above-A-commit
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+├── ≡📙:above-A on 3183e43 {0}
+│   ├── 📙:above-A
+│   ├── 📙:A
+│   ├── 📙:above-A-commit
 │   │   └── ·c2878fb (🏘️)
-│   ├── 📙:11:below-A
-│   ├── 📙:12:below-A-commit
-│   ├── 📙:13:above-bottom
+│   ├── 📙:below-A
+│   ├── 📙:below-A-commit
+│   ├── 📙:above-bottom
 │   │   └── ·49d4b34 (🏘️)
-│   └── 📙:14:bottom
-└── ≡📙:5:above-B on 3183e43 {42}
-    ├── 📙:5:above-B
-    ├── 📙:6:B
-    └── 📙:7:below-B
+│   └── 📙:bottom
+└── ≡📙:above-B on 3183e43 {42}
+    ├── 📙:above-B
+    ├── 📙:B
+    └── 📙:below-B
 
 "#]]
         );
@@ -1148,9 +1148,9 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
-└── ≡📙:3:A on 3183e43 {0}
-    └── 📙:3:A
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+└── ≡📙:A on 3183e43 {0}
+    └── 📙:A
         ├── ·c2878fb (🏘️)
         └── ·49d4b34 (🏘️)
 
@@ -1175,12 +1175,12 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
-└── ≡📙:3:A on 3183e43 {0}
-    ├── 📙:3:A
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+└── ≡📙:A on 3183e43 {0}
+    ├── 📙:A
     │   ├── ·c2878fb (🏘️)
     │   └── ·49d4b34 (🏘️)
-    └── 📙:4:bottom
+    └── 📙:bottom
 
 "#]]
         );
@@ -1220,12 +1220,12 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
-├── ≡📙:3:A on 3183e43 {0}
-│   └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+├── ≡📙:A on 3183e43 {0}
+│   └── 📙:A
 │       └── ·49d4b34 (🏘️)
-└── ≡📙:4:B on 3183e43 {1}
-    └── 📙:4:B
+└── ≡📙:B on 3183e43 {1}
+    └── 📙:B
         └── ·f57c528 (🏘️)
 
 "#]]
@@ -1248,13 +1248,13 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
-├── ≡📙:3:A on 3183e43 {0}
-│   ├── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+├── ≡📙:A on 3183e43 {0}
+│   ├── 📙:A
 │   │   └── ·49d4b34 (🏘️)
-│   └── 📙:5:a-bottom
-└── ≡📙:4:B on 3183e43 {1}
-    └── 📙:4:B
+│   └── 📙:a-bottom
+└── ≡📙:B on 3183e43 {1}
+    └── 📙:B
         └── ·f57c528 (🏘️)
 
 "#]]
@@ -1278,15 +1278,15 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
-├── ≡📙:3:A on 3183e43 {0}
-│   ├── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+├── ≡📙:A on 3183e43 {0}
+│   ├── 📙:A
 │   │   └── ·49d4b34 (🏘️)
-│   └── 📙:6:a-bottom
-└── ≡📙:4:B on 3183e43 {1}
-    ├── 📙:4:B
+│   └── 📙:a-bottom
+└── ≡📙:B on 3183e43 {1}
+    ├── 📙:B
     │   └── ·f57c528 (🏘️)
-    └── 📙:5:b-bottom
+    └── 📙:b-bottom
 
 "#]]
         );
@@ -1321,9 +1321,9 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
-└── ≡📙:3:A on bce0c5e {0}
-    └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
+└── ≡📙:A on bce0c5e {0}
+    └── 📙:A
         ├── ·43f9472 (🏘️)
         └── ·6fdab32 (🏘️)
 
@@ -1348,11 +1348,11 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
-└── ≡📙:3:A on bce0c5e {0}
-    ├── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
+└── ≡📙:A on bce0c5e {0}
+    ├── 📙:A
     │   └── ·43f9472 (🏘️)
-    └── 📙:4:foo
+    └── 📙:foo
         └── ·6fdab32 (🏘️)
 
 "#]]
@@ -1377,12 +1377,12 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
-└── ≡📙:5:A on bce0c5e {0}
-    ├── 📙:5:A
-    ├── 📙:6:new
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
+└── ≡📙:A on bce0c5e {0}
+    ├── 📙:A
+    ├── 📙:new
     │   └── ·43f9472 (🏘️)
-    └── 📙:4:foo
+    └── 📙:foo
         └── ·6fdab32 (🏘️)
 
 "#]]
@@ -1405,13 +1405,13 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
-└── ≡📙:5:above-A on bce0c5e {0}
-    ├── 📙:5:above-A
-    ├── 📙:6:A
-    ├── 📙:7:new
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
+└── ≡📙:above-A on bce0c5e {0}
+    ├── 📙:above-A
+    ├── 📙:A
+    ├── 📙:new
     │   └── ·43f9472 (🏘️)
-    └── 📙:4:foo
+    └── 📙:foo
         └── ·6fdab32 (🏘️)
 
 "#]]
@@ -1434,14 +1434,14 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
-└── ≡📙:5:above-A on bce0c5e {0}
-    ├── 📙:5:above-A
-    ├── 📙:6:A
-    ├── 📙:7:below-empty-A
-    ├── 📙:8:new
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
+└── ≡📙:above-A on bce0c5e {0}
+    ├── 📙:above-A
+    ├── 📙:A
+    ├── 📙:below-empty-A
+    ├── 📙:new
     │   └── ·43f9472 (🏘️)
-    └── 📙:4:foo
+    └── 📙:foo
         └── ·6fdab32 (🏘️)
 
 "#]]
@@ -1463,14 +1463,14 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
-└── ≡📙:5:above-A on bce0c5e {0}
-    ├── 📙:5:above-A
-    ├── 📙:6:A
-    ├── 📙:7:below-empty-A
-    ├── 📙:8:new
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
+└── ≡📙:above-A on bce0c5e {0}
+    ├── 📙:above-A
+    ├── 📙:A
+    ├── 📙:below-empty-A
+    ├── 📙:new
     │   └── ·43f9472 (🏘️)
-    └── 📙:4:foo
+    └── 📙:foo
         └── ·6fdab32 (🏘️)
 
 "#]]
@@ -1491,14 +1491,14 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
-└── ≡📙:5:above-A on bce0c5e {0}
-    ├── 📙:5:above-A
-    ├── 📙:6:A
-    ├── 📙:7:below-empty-A
-    ├── 📙:8:new
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
+└── ≡📙:above-A on bce0c5e {0}
+    ├── 📙:above-A
+    ├── 📙:A
+    ├── 📙:below-empty-A
+    ├── 📙:new
     │   └── ·43f9472 (🏘️)
-    └── 📙:4:foo
+    └── 📙:foo
         └── ·6fdab32 (🏘️)
 
 "#]]
@@ -1551,9 +1551,9 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
-└── ≡📙:3:A on 3183e43 {41}
-    └── 📙:3:A
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+└── ≡📙:A on 3183e43 {41}
+    └── 📙:A
 
 "#]]
         );
@@ -1575,10 +1575,10 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
-└── ≡📙:3:A on 3183e43 {41}
-    ├── 📙:3:A
-    └── 📙:4:below-A
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+└── ≡📙:A on 3183e43 {41}
+    ├── 📙:A
+    └── 📙:below-A
 
 "#]]
         );
@@ -1599,11 +1599,11 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
-└── ≡📙:3:above-A on 3183e43 {41}
-    ├── 📙:3:above-A
-    ├── 📙:4:A
-    └── 📙:5:below-A
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+└── ≡📙:above-A on 3183e43 {41}
+    ├── 📙:above-A
+    ├── 📙:A
+    └── 📙:below-A
 
 "#]]
         );
@@ -1633,9 +1633,9 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓!
-└── ≡📙:1:main {0}
-    └── 📙:1:main
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓!
+└── ≡📙:main {0}
+    └── 📙:main
         └── ·3183e43 (🏘️)
 
 "#]]
@@ -1680,10 +1680,10 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓!
-└── ≡📙:2:main {0}
-    ├── 📙:2:main
-    └── 📙:3:new
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓!
+└── ≡📙:main {0}
+    ├── 📙:main
+    └── 📙:new
         └── ·3183e43 (🏘️)
 
 "#]]
@@ -1709,12 +1709,12 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
-├── ≡📙:3:A on 3183e43 {0}
-│   └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+├── ≡📙:A on 3183e43 {0}
+│   └── 📙:A
 │       └── ·49d4b34 (🏘️)
-└── ≡📙:4:B on 3183e43 {1}
-    └── 📙:4:B
+└── ≡📙:B on 3183e43 {1}
+    └── 📙:B
         └── ·f57c528 (🏘️)
 
 "#]]
@@ -1738,13 +1738,13 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
-├── ≡📙:3:A on 3183e43 {0}
-│   └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+├── ≡📙:A on 3183e43 {0}
+│   └── 📙:A
 │       └── ·49d4b34 (🏘️)
-└── ≡📙:5:B on 3183e43 {1}
-    ├── 📙:5:B
-    └── 📙:6:new
+└── ≡📙:B on 3183e43 {1}
+    ├── 📙:B
+    └── 📙:new
         └── ·f57c528 (🏘️)
 
 "#]]
@@ -1859,7 +1859,7 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on bce0c5e
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on bce0c5e
 
 "#]]
         );
@@ -1935,9 +1935,9 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
-└── ≡📙:3:A on 3183e43 {0}
-    └── 📙:3:A
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+└── ≡📙:A on 3183e43 {0}
+    └── 📙:A
         ├── ·c2878fb (🏘️)
         └── ·49d4b34 (🏘️)
 
@@ -2097,9 +2097,9 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
-└── ≡📙:3:A on 3183e43 {0}
-    └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
+└── ≡📙:A on 3183e43 {0}
+    └── 📙:A
         └── ·49d4b34 (🏘️)
 
 "#]]
@@ -2132,12 +2132,12 @@ Single commit, target, no ws commit, but ws-reference
         snapbox::assert_data_eq!(
             graph_workspace(&updated_ws).to_string(),
             snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
-├── ≡📙:3:A on 3183e43 {0}
-│   └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
+├── ≡📙:A on 3183e43 {0}
+│   └── 📙:A
 │       └── ·49d4b34 (🏘️)
-└── ≡📙:5:new-branch on 3183e43 {3e5}
-    └── 📙:5:new-branch
+└── ≡📙:new-branch on 3183e43 {3e5}
+    └── 📙:new-branch
 
 "#]]
         );
@@ -2168,9 +2168,9 @@ fn errors() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-⌂:0:main[🌳] <> ✓!
-└── ≡:0:main[🌳] {1}
-    └── :0:main[🌳]
+⌂:main[🌳] <> ✓!
+└── ≡:main[🌳] {1}
+    └── :main[🌳]
 
 "#]]
     );
@@ -2216,9 +2216,9 @@ fn errors() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-⌂:[..]:main[🌳] <> ✓! on c166d42
-└── ≡:[..]:main[🌳] on c166d42 {1}
-    └── :[..]:main[🌳]
+⌂:main[🌳] <> ✓! on c166d42
+└── ≡:main[🌳] on c166d42 {1}
+    └── :main[🌳]
 
 "#]]
     );
@@ -2330,12 +2330,12 @@ fn errors() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-⌂:0:A <> ✓!
-└── ≡:0:A {1}
-    ├── :0:A
+⌂:A <> ✓!
+└── ≡:A {1}
+    ├── :A
     │   ├── ·89cc2d3
     │   └── ·d79bba9
-    └── :1:main[🌳]
+    └── :main[🌳]
         └── ·c166d42
 
 "#]]
@@ -2388,9 +2388,9 @@ fn errors() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-⌂:0:A <> ✓! on 89cc2d3
-└── ≡:0:A on 89cc2d3 {1}
-    └── :0:A
+⌂:A <> ✓! on 89cc2d3
+└── ≡:A on 89cc2d3 {1}
+    └── :A
 
 "#]]
     );
@@ -2456,9 +2456,9 @@ fn journey_with_commits() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-⌂:0:main[🌳] <> ✓!
-└── ≡:0:main[🌳] {1}
-    └── :0:main[🌳]
+⌂:main[🌳] <> ✓!
+└── ≡:main[🌳] {1}
+    └── :main[🌳]
         ├── ·281da94
         ├── ·12995d7
         └── ·3d57fc1
@@ -2483,11 +2483,11 @@ fn journey_with_commits() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-⌂:0:main[🌳] <> ✓!
-└── ≡:0:main[🌳] {1}
-    ├── :0:main[🌳]
+⌂:main[🌳] <> ✓!
+└── ≡:main[🌳] {1}
+    ├── :main[🌳]
     │   └── ·281da94
-    └── 📙:1:below-main
+    └── 📙:below-main
         ├── ·12995d7
         └── ·3d57fc1
 
@@ -2519,11 +2519,11 @@ fn journey_with_commits() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-⌂:0:main[🌳] <> ✓!
-└── ≡:0:main[🌳] {1}
-    ├── :0:main[🌳]
+⌂:main[🌳] <> ✓!
+└── ≡:main[🌳] {1}
+    ├── :main[🌳]
     │   └── ·281da94
-    └── 📙:1:below-main
+    └── 📙:below-main
         ├── ·12995d7
         └── ·3d57fc1
 
@@ -2543,13 +2543,13 @@ fn journey_with_commits() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-⌂:0:main[🌳] <> ✓!
-└── ≡:0:main[🌳] {1}
-    ├── :0:main[🌳]
+⌂:main[🌳] <> ✓!
+└── ≡:main[🌳] {1}
+    ├── :main[🌳]
     │   └── ·281da94
-    ├── 📙:1:below-main
+    ├── 📙:below-main
     │   └── ·12995d7
-    └── 📙:2:two-below-main
+    └── 📙:two-below-main
         └── ·3d57fc1
 
 "#]]
@@ -2592,13 +2592,13 @@ fn journey_with_commits() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-⌂:0:main[🌳] <> ✓!
-└── ≡:0:main[🌳] {1}
-    ├── :0:main[🌳]
+⌂:main[🌳] <> ✓!
+└── ≡:main[🌳] {1}
+    ├── :main[🌳]
     │   └── ·281da94
-    ├── 📙:1:below-main
+    ├── 📙:below-main
     │   └── ·12995d7
-    └── 📙:2:two-below-main
+    └── 📙:two-below-main
         └── ·3d57fc1
 
 "#]]
@@ -2626,13 +2626,13 @@ fn journey_with_commits() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-⌂:0:main[🌳] <> ✓!
-└── ≡📙:0:main[🌳] {1}
-    ├── 📙:0:main[🌳]
+⌂:main[🌳] <> ✓!
+└── ≡📙:main[🌳] {1}
+    ├── 📙:main[🌳]
     │   └── ·281da94
-    ├── 📙:1:below-main
+    ├── 📙:below-main
     │   └── ·12995d7
-    └── 📙:2:two-below-main
+    └── 📙:two-below-main
         └── ·3d57fc1
 
 "#]]
@@ -2686,11 +2686,11 @@ fn existing_git_ref_inside_workspace_is_adopted() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
-└── ≡:4:A on bce0c5e {632}
-    ├── :4:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
+└── ≡:A on bce0c5e {632}
+    ├── :A
     │   └── ·43f9472 (🏘️)
-    └── 📙:3:created-with-git
+    └── 📙:created-with-git
         └── ·6fdab32 (🏘️)
 
 "#]]
@@ -2726,9 +2726,9 @@ fn journey_anon_workspace() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-⌂:0:DETACHED <> ✓!
-└── ≡:0:anon: {1}
-    └── :0:anon:
+⌂:DETACHED <> ✓!
+└── ≡:anon: {1}
+    └── :anon:
         ├── ·12995d7
         └── ·3d57fc1
 
@@ -2752,11 +2752,11 @@ fn journey_anon_workspace() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-⌂:0:DETACHED <> ✓!
-└── ≡:0:anon: {1}
-    ├── :0:anon:
+⌂:DETACHED <> ✓!
+└── ≡:anon: {1}
+    ├── :anon:
     │   └── ·12995d7
-    └── 📙:1:first
+    └── 📙:first
         └── ·3d57fc1
 
 "#]]
@@ -2797,11 +2797,11 @@ fn journey_anon_workspace() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-⌂:0:second <> ✓!
-└── ≡📙:0:second {1}
-    ├── 📙:0:second
+⌂:second <> ✓!
+└── ≡📙:second {1}
+    ├── 📙:second
     │   └── ·12995d7
-    └── 📙:1:first
+    └── 📙:first
         └── ·3d57fc1
 
 "#]]
@@ -2842,9 +2842,9 @@ fn journey_anon_workspace() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-⌂:0:second <> ✓! on 3d57fc1
-└── ≡📙:0:second on 3d57fc1 {1}
-    └── 📙:0:second
+⌂:second <> ✓! on 3d57fc1
+└── ≡📙:second on 3d57fc1 {1}
+    └── 📙:second
         └── ·12995d7
 
 "#]]
@@ -2929,9 +2929,9 @@ mod ad_hoc_at_reference {
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-⌂:[..]:main[🌳] <> ✓! on 281da94
-└── ≡:[..]:main[🌳] on 281da94 {1}
-    └── :[..]:main[🌳]
+⌂:main[🌳] <> ✓! on 281da94
+└── ≡:main[🌳] on 281da94 {1}
+    └── :main[🌳]
 
 "#]]
         );
@@ -3021,10 +3021,10 @@ mod ad_hoc_at_reference {
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-⌂:[..]:main[🌳] <> ✓! on 281da94
-└── ≡:[..]:main[🌳] {1}
-    ├── :[..]:main[🌳]
-    └── 📙:[..]:empty-bottom
+⌂:main[🌳] <> ✓! on 281da94
+└── ≡:main[🌳] {1}
+    ├── :main[🌳]
+    └── 📙:empty-bottom
         ├── ·281da94 (✓)
         ├── ·12995d7 (✓)
         └── ·3d57fc1 (✓)
@@ -3075,12 +3075,12 @@ mod ad_hoc_at_reference {
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-⌂:[..]:main[🌳] <> ✓! on 281da94
-└── ≡:[..]:main[🌳] {1}
-    ├── :[..]:main[🌳]
-    ├── 📙:[..]:empty-middle
-    ├── 📙:[..]:inserted-below-middle
-    └── 📙:[..]:empty-bottom
+⌂:main[🌳] <> ✓! on 281da94
+└── ≡:main[🌳] {1}
+    ├── :main[🌳]
+    ├── 📙:empty-middle
+    ├── 📙:inserted-below-middle
+    └── 📙:empty-bottom
         ├── ·281da94 (✓)
         ├── ·12995d7 (✓)
         └── ·3d57fc1 (✓)
@@ -3103,10 +3103,10 @@ mod ad_hoc_at_reference {
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-⌂:[..]:empty-top[🌳] <> ✓! on 281da94
-└── ≡📙:[..]:empty-top[🌳] {1}
-    ├── 📙:[..]:empty-top[🌳]
-    └── :[..]:main
+⌂:empty-top[🌳] <> ✓! on 281da94
+└── ≡📙:empty-top[🌳] {1}
+    ├── 📙:empty-top[🌳]
+    └── :main
         ├── ·281da94 (✓)
         ├── ·12995d7 (✓)
         └── ·3d57fc1 (✓)
@@ -3188,11 +3188,11 @@ mod ad_hoc_at_reference {
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-⌂:[..]:main[🌳] <> ✓! on 281da94
-└── ≡:[..]:main[🌳] {1}
-    ├── :[..]:main[🌳]
-    ├── 📙:[..]:empty-middle
-    └── 📙:[..]:empty-bottom
+⌂:main[🌳] <> ✓! on 281da94
+└── ≡:main[🌳] {1}
+    ├── :main[🌳]
+    ├── 📙:empty-middle
+    └── 📙:empty-bottom
         ├── ·281da94 (✓)
         ├── ·12995d7 (✓)
         └── ·3d57fc1 (✓)

--- a/crates/but-workspace/tests/workspace/branch/move_branch.rs
+++ b/crates/but-workspace/tests/workspace/branch/move_branch.rs
@@ -39,14 +39,14 @@ fn move_top_branch_to_top_of_another_stack() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:3:A on 85efbe4 {1}
-│   └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:A on 85efbe4 {1}
+│   └── 📙:A
 │       └── ·09d8e52 (🏘️)
-└── ≡📙:4:C on 85efbe4 {2}
-    ├── 📙:4:C
+└── ≡📙:C on 85efbe4 {2}
+    ├── 📙:C
     │   └── ·09bc93e (🏘️)
-    └── 📙:5:B
+    └── 📙:B
         └── ·c813d8d (🏘️)
 
 "#]]
@@ -85,14 +85,14 @@ fn move_top_branch_to_top_of_another_stack() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:3:C on 85efbe4 {1}
-│   ├── 📙:3:C
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:C on 85efbe4 {1}
+│   ├── 📙:C
 │   │   └── ·f2cc60d (🏘️)
-│   └── 📙:4:A
+│   └── 📙:A
 │       └── ·09d8e52 (🏘️)
-└── ≡📙:5:B on 85efbe4 {2}
-    └── 📙:5:B
+└── ≡📙:B on 85efbe4 {2}
+    └── 📙:B
         └── ·c813d8d (🏘️)
 
 "#]]
@@ -165,14 +165,14 @@ fn move_bottom_branch_to_top_of_another_stack() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:3:A on 85efbe4 {1}
-│   └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:A on 85efbe4 {1}
+│   └── 📙:A
 │       └── ·09d8e52 (🏘️)
-└── ≡📙:4:C on 85efbe4 {2}
-    ├── 📙:4:C
+└── ≡📙:C on 85efbe4 {2}
+    ├── 📙:C
     │   └── ·09bc93e (🏘️)
-    └── 📙:5:B
+    └── 📙:B
         └── ·c813d8d (🏘️)
 
 "#]]
@@ -210,14 +210,14 @@ fn move_bottom_branch_to_top_of_another_stack() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:3:B on 85efbe4 {1}
-│   ├── 📙:3:B
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:B on 85efbe4 {1}
+│   ├── 📙:B
 │   │   └── ·f9061ed (🏘️)
-│   └── 📙:4:A
+│   └── 📙:A
 │       └── ·09d8e52 (🏘️)
-└── ≡📙:5:C on 85efbe4 {2}
-    └── 📙:5:C
+└── ≡📙:C on 85efbe4 {2}
+    └── 📙:C
         └── ·8e00332 (🏘️)
 
 "#]]
@@ -255,14 +255,14 @@ fn move_single_branch_to_top_of_another_stack() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:3:A on 85efbe4 {1}
-│   └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:A on 85efbe4 {1}
+│   └── 📙:A
 │       └── ·09d8e52 (🏘️)
-└── ≡📙:4:C on 85efbe4 {2}
-    ├── 📙:4:C
+└── ≡📙:C on 85efbe4 {2}
+    ├── 📙:C
     │   └── ·09bc93e (🏘️)
-    └── 📙:5:B
+    └── 📙:B
         └── ·c813d8d (🏘️)
 
 "#]]
@@ -298,13 +298,13 @@ fn move_single_branch_to_top_of_another_stack() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-└── ≡📙:3:A on 85efbe4 {2}
-    ├── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+└── ≡📙:A on 85efbe4 {2}
+    ├── 📙:A
     │   └── ·148f8f3 (🏘️)
-    ├── 📙:4:C
+    ├── 📙:C
     │   └── ·09bc93e (🏘️)
-    └── 📙:5:B
+    └── 📙:B
         └── ·c813d8d (🏘️)
 
 "#]]
@@ -342,14 +342,14 @@ fn reorder_branch_in_stack() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:3:A on 85efbe4 {1}
-│   └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:A on 85efbe4 {1}
+│   └── 📙:A
 │       └── ·09d8e52 (🏘️)
-└── ≡📙:4:C on 85efbe4 {2}
-    ├── 📙:4:C
+└── ≡📙:C on 85efbe4 {2}
+    ├── 📙:C
     │   └── ·09bc93e (🏘️)
-    └── 📙:5:B
+    └── 📙:B
         └── ·c813d8d (🏘️)
 
 "#]]
@@ -388,14 +388,14 @@ fn reorder_branch_in_stack() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:3:A on 85efbe4 {1}
-│   └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:A on 85efbe4 {1}
+│   └── 📙:A
 │       └── ·09d8e52 (🏘️)
-└── ≡📙:4:B on 85efbe4 {2}
-    ├── 📙:4:B
+└── ≡📙:B on 85efbe4 {2}
+    ├── 📙:B
     │   └── ·de0581e (🏘️)
-    └── 📙:5:C
+    └── 📙:C
         └── ·8e00332 (🏘️)
 
 "#]]
@@ -433,14 +433,14 @@ fn insert_branch_in_the_middle_of_a_stack() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:3:A on 85efbe4 {1}
-│   └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:A on 85efbe4 {1}
+│   └── 📙:A
 │       └── ·09d8e52 (🏘️)
-└── ≡📙:4:C on 85efbe4 {2}
-    ├── 📙:4:C
+└── ≡📙:C on 85efbe4 {2}
+    ├── 📙:C
     │   └── ·09bc93e (🏘️)
-    └── 📙:5:B
+    └── 📙:B
         └── ·c813d8d (🏘️)
 
 "#]]
@@ -476,13 +476,13 @@ fn insert_branch_in_the_middle_of_a_stack() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-└── ≡📙:3:C on 85efbe4 {2}
-    ├── 📙:3:C
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+└── ≡📙:C on 85efbe4 {2}
+    ├── 📙:C
     │   └── ·3e7ff55 (🏘️)
-    ├── 📙:4:A
+    ├── 📙:A
     │   └── ·4dfe841 (🏘️)
-    └── 📙:5:B
+    └── 📙:B
         └── ·c813d8d (🏘️)
 
 "#]]
@@ -515,12 +515,12 @@ fn move_empty_branch() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:3:A on 85efbe4 {1}
-│   └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:A on 85efbe4 {1}
+│   └── 📙:A
 │       └── ·09d8e52 (🏘️)
-└── ≡📙:4:B on 85efbe4 {2}
-    └── 📙:4:B
+└── ≡📙:B on 85efbe4 {2}
+    └── 📙:B
 
 "#]]
     );
@@ -553,10 +553,10 @@ fn move_empty_branch() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-└── ≡📙:4:B on 85efbe4 {1}
-    ├── 📙:4:B
-    └── 📙:5:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+└── ≡📙:B on 85efbe4 {1}
+    ├── 📙:B
+    └── 📙:A
         └── ·09d8e52 (🏘️)
 
 "#]]
@@ -588,12 +588,12 @@ fn move_branch_on_top_of_empty_branch() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:3:A on 85efbe4 {1}
-│   └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:A on 85efbe4 {1}
+│   └── 📙:A
 │       └── ·09d8e52 (🏘️)
-└── ≡📙:4:B on 85efbe4 {2}
-    └── 📙:4:B
+└── ≡📙:B on 85efbe4 {2}
+    └── 📙:B
 
 "#]]
     );
@@ -626,11 +626,11 @@ fn move_branch_on_top_of_empty_branch() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-└── ≡📙:3:A on 85efbe4 {2}
-    ├── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+└── ≡📙:A on 85efbe4 {2}
+    ├── 📙:A
     │   └── ·09d8e52 (🏘️)
-    └── 📙:4:B
+    └── 📙:B
 
 "#]]
     );
@@ -666,10 +666,10 @@ fn move_empty_branch_on_top_of_empty_branch_in_same_stack() -> anyhow::Result<()
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
-└── ≡📙:4:B on 3183e43 {1}
-    ├── 📙:4:B
-    └── 📙:5:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
+└── ≡📙:B on 3183e43 {1}
+    ├── 📙:B
+    └── 📙:A
 
 "#]]
     );
@@ -690,10 +690,10 @@ fn move_empty_branch_on_top_of_empty_branch_in_same_stack() -> anyhow::Result<()
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
-└── ≡📙:4:A on 3183e43 {1}
-    ├── 📙:4:A
-    └── 📙:5:B
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
+└── ≡📙:A on 3183e43 {1}
+    ├── 📙:A
+    └── 📙:B
 
 "#]]
     );
@@ -731,11 +731,11 @@ fn move_empty_branch_on_top_of_empty_branch_across_stacks() -> anyhow::Result<()
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
-├── ≡📙:4:A on 3183e43 {1}
-│   └── 📙:4:A
-└── ≡📙:5:B on 3183e43 {2}
-    └── 📙:5:B
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
+├── ≡📙:A on 3183e43 {1}
+│   └── 📙:A
+└── ≡📙:B on 3183e43 {2}
+    └── 📙:B
 
 "#]]
     );
@@ -756,10 +756,10 @@ fn move_empty_branch_on_top_of_empty_branch_across_stacks() -> anyhow::Result<()
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
-└── ≡📙:4:A on 3183e43 {2}
-    ├── 📙:4:A
-    └── 📙:5:B
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
+└── ≡📙:A on 3183e43 {2}
+    ├── 📙:A
+    └── 📙:B
 
 "#]]
     );
@@ -797,14 +797,14 @@ fn non_empty_move_updates_metadata_and_keeps_display_order_aligned() -> anyhow::
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:3:A on 85efbe4 {1}
-│   └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:A on 85efbe4 {1}
+│   └── 📙:A
 │       └── ·09d8e52 (🏘️)
-└── ≡📙:4:C on 85efbe4 {2}
-    ├── 📙:4:C
+└── ≡📙:C on 85efbe4 {2}
+    ├── 📙:C
     │   └── ·09bc93e (🏘️)
-    └── 📙:5:B
+    └── 📙:B
         └── ·c813d8d (🏘️)
 
 "#]]
@@ -839,14 +839,14 @@ fn non_empty_move_updates_metadata_and_keeps_display_order_aligned() -> anyhow::
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:5:B on 85efbe4 {2}
-│   └── 📙:5:B
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:B on 85efbe4 {2}
+│   └── 📙:B
 │       └── ·c813d8d (🏘️)
-└── ≡📙:4:C on 85efbe4 {1}
-    ├── 📙:4:C
+└── ≡📙:C on 85efbe4 {1}
+    ├── 📙:C
     │   └── ·f2cc60d (🏘️)
-    └── 📙:3:A
+    └── 📙:A
         └── ·09d8e52 (🏘️)
 
 "#]]
@@ -857,14 +857,14 @@ fn non_empty_move_updates_metadata_and_keeps_display_order_aligned() -> anyhow::
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:3:C on 85efbe4 {1}
-│   ├── 📙:3:C
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:C on 85efbe4 {1}
+│   ├── 📙:C
 │   │   └── ·f2cc60d (🏘️)
-│   └── 📙:4:A
+│   └── 📙:A
 │       └── ·09d8e52 (🏘️)
-└── ≡📙:5:B on 85efbe4 {2}
-    └── 📙:5:B
+└── ≡📙:B on 85efbe4 {2}
+    └── 📙:B
         └── ·c813d8d (🏘️)
 
 "#]]
@@ -1010,12 +1010,12 @@ fn move_branch_when_base_segment_has_no_ref_name() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 85efbe4
-├── ≡📙:3:A on 85efbe4 {1}
-│   └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 85efbe4
+├── ≡📙:A on 85efbe4 {1}
+│   └── 📙:A
 │       └── ·09d8e52 (🏘️)
-└── ≡📙:4:B on 85efbe4 {2}
-    └── 📙:4:B
+└── ≡📙:B on 85efbe4 {2}
+    └── 📙:B
         └── ·c813d8d (🏘️)
 
 "#]]
@@ -1050,11 +1050,11 @@ fn move_branch_when_base_segment_has_no_ref_name() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 85efbe4
-└── ≡📙:3:B on 85efbe4 {1}
-    ├── 📙:3:B
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 85efbe4
+└── ≡📙:B on 85efbe4 {1}
+    ├── 📙:B
     │   └── ·f9061ed (🏘️)
-    └── 📙:4:A
+    └── 📙:A
         └── ·09d8e52 (🏘️)
 
 "#]]
@@ -1097,12 +1097,12 @@ fn move_empty_branch_onto_non_empty_branch_with_advanced_target() -> anyhow::Res
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 85efbe4
-├── ≡📙:3:A on 85efbe4 {1}
-│   └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 85efbe4
+├── ≡📙:A on 85efbe4 {1}
+│   └── 📙:A
 │       └── ·09d8e52 (🏘️)
-└── ≡📙:5:B on 85efbe4 {2}
-    └── 📙:5:B
+└── ≡📙:B on 85efbe4 {2}
+    └── 📙:B
 
 "#]]
     );
@@ -1135,10 +1135,10 @@ fn move_empty_branch_onto_non_empty_branch_with_advanced_target() -> anyhow::Res
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 85efbe4
-└── ≡📙:5:B on 85efbe4 {1}
-    ├── 📙:5:B
-    └── 📙:6:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 85efbe4
+└── ≡📙:B on 85efbe4 {1}
+    ├── 📙:B
+    └── 📙:A
         └── ·09d8e52 (🏘️)
 
 "#]]
@@ -1178,12 +1178,12 @@ fn move_non_empty_branch_onto_empty_branch_with_advanced_target() -> anyhow::Res
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 85efbe4
-├── ≡📙:3:A on 85efbe4 {1}
-│   └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 85efbe4
+├── ≡📙:A on 85efbe4 {1}
+│   └── 📙:A
 │       └── ·09d8e52 (🏘️)
-└── ≡📙:5:B on 85efbe4 {2}
-    └── 📙:5:B
+└── ≡📙:B on 85efbe4 {2}
+    └── 📙:B
 
 "#]]
     );
@@ -1216,11 +1216,11 @@ fn move_non_empty_branch_onto_empty_branch_with_advanced_target() -> anyhow::Res
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 85efbe4
-└── ≡📙:3:A on 85efbe4 {2}
-    ├── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 85efbe4
+└── ≡📙:A on 85efbe4 {2}
+    ├── 📙:A
     │   └── ·09d8e52 (🏘️)
-    └── 📙:5:B
+    └── 📙:B
 
 "#]]
     );
@@ -1566,12 +1566,12 @@ mod single_branch_mode {
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-⌂:[..]:main[🌳] <> ✓! on 281da94
-└── ≡:[..]:main[🌳] {1}
-    ├── :[..]:main[🌳]
-    ├── 📙:[..]:empty-top
-    ├── 📙:[..]:empty-bottom
-    └── 📙:[..]:base
+⌂:main[🌳] <> ✓! on 281da94
+└── ≡:main[🌳] {1}
+    ├── :main[🌳]
+    ├── 📙:empty-top
+    ├── 📙:empty-bottom
+    └── 📙:base
         ├── ·281da94 (✓)
         ├── ·12995d7 (✓)
         └── ·3d57fc1 (✓)
@@ -1626,12 +1626,12 @@ mod single_branch_mode {
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-⌂:[..]:main[🌳] <> ✓! on 281da94
-└── ≡:[..]:main[🌳] {1}
-    ├── :[..]:main[🌳]
-    ├── 📙:[..]:empty-bottom
-    ├── 📙:[..]:empty-top
-    └── 📙:[..]:base
+⌂:main[🌳] <> ✓! on 281da94
+└── ≡:main[🌳] {1}
+    ├── :main[🌳]
+    ├── 📙:empty-bottom
+    ├── 📙:empty-top
+    └── 📙:base
         ├── ·281da94 (✓)
         ├── ·12995d7 (✓)
         └── ·3d57fc1 (✓)
@@ -1931,12 +1931,12 @@ mod single_branch_mode {
         snapbox::assert_data_eq!(
             graph_workspace(&ws).to_string(),
             snapbox::str![[r#"
-⌂:[..]:main[🌳] <> ✓! on 281da94
-└── ≡:[..]:main[🌳] {1}
-    ├── :[..]:main[🌳]
-    ├── 📙:[..]:empty-top
-    ├── 📙:[..]:empty-bottom
-    └── 📙:[..]:base
+⌂:main[🌳] <> ✓! on 281da94
+└── ≡:main[🌳] {1}
+    ├── :main[🌳]
+    ├── 📙:empty-top
+    ├── 📙:empty-bottom
+    └── 📙:base
         ├── ·281da94 (✓) ►x, ►y
         ├── ·12995d7 (✓)
         └── ·3d57fc1 (✓)

--- a/crates/but-workspace/tests/workspace/branch/remove_reference.rs
+++ b/crates/but-workspace/tests/workspace/branch/remove_reference.rs
@@ -40,7 +40,7 @@ Single commit, no main remote/target, no ws commit, but ws-reference
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓! on 3183e43
 
 "#]]
     );
@@ -87,7 +87,7 @@ Single commit, no main remote/target, no ws commit, but ws-reference
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓! on 3183e43
 
 "#]]
     );
@@ -125,11 +125,11 @@ Single commit, target, no ws commit, but ws-reference and a named segment, and b
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
-└── ≡📙:3:A on 3183e43 {0}
-    ├── 📙:3:A
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+└── ≡📙:A on 3183e43 {0}
+    ├── 📙:A
     │   └── ·c2878fb (🏘️) ►A2
-    └── :4:A1
+    └── :A1
         └── ·49d4b34 (🏘️)
 
 "#]]
@@ -156,9 +156,9 @@ Single commit, target, no ws commit, but ws-reference and a named segment, and b
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
-└── ≡:3:anon: on 3183e43
-    └── :3:anon:
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+└── ≡:anon: on 3183e43
+    └── :anon:
         ├── ·c2878fb (🏘️)
         └── ·49d4b34 (🏘️)
 
@@ -206,16 +206,16 @@ Two commits in main, target setup, ws commit, many more usable branches
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
-└── ≡📙:5:A on bce0c5e {0}
-    ├── 📙:5:A
-    ├── 📙:6:A2-3
-    ├── 📙:7:A2-2
-    ├── 📙:8:A2-1
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
+└── ≡📙:A on bce0c5e {0}
+    ├── 📙:A
+    ├── 📙:A2-3
+    ├── 📙:A2-2
+    ├── 📙:A2-1
     │   └── ·43f9472 (🏘️)
-    ├── 📙:9:A1-1
-    ├── 📙:10:A1-2
-    └── 📙:11:A1-3
+    ├── 📙:A1-1
+    ├── 📙:A1-2
+    └── 📙:A1-3
         └── ·6fdab32 (🏘️)
 
 "#]]
@@ -240,12 +240,12 @@ Two commits in main, target setup, ws commit, many more usable branches
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
-└── ≡📙:3:A1-1 on bce0c5e {0}
-    ├── 📙:3:A1-1
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
+└── ≡📙:A1-1 on bce0c5e {0}
+    ├── 📙:A1-1
     │   └── ·43f9472 (🏘️)
-    ├── 📙:5:A1-2
-    └── 📙:6:A1-3
+    ├── 📙:A1-2
+    └── 📙:A1-3
         └── ·6fdab32 (🏘️)
 
 "#]]
@@ -269,9 +269,9 @@ Two commits in main, target setup, ws commit, many more usable branches
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
-└── ≡📙:3:A1-3 on bce0c5e {0}
-    └── 📙:3:A1-3
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on bce0c5e
+└── ≡📙:A1-3 on bce0c5e {0}
+    └── 📙:A1-3
         ├── ·43f9472 (🏘️)
         └── ·6fdab32 (🏘️)
 
@@ -328,14 +328,14 @@ Single commit, no main remote/target, no ws commit, but ws-reference
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43
-├── ≡📙:2:A on 3183e43 {0}
-│   ├── 📙:2:A
-│   ├── 📙:3:B
-│   └── 📙:4:C
-└── ≡📙:5:D on 3183e43 {1}
-    ├── 📙:5:D
-    └── 📙:6:E
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓! on 3183e43
+├── ≡📙:A on 3183e43 {0}
+│   ├── 📙:A
+│   ├── 📙:B
+│   └── 📙:C
+└── ≡📙:D on 3183e43 {1}
+    ├── 📙:D
+    └── 📙:E
 
 "#]]
     );
@@ -356,13 +356,13 @@ Single commit, no main remote/target, no ws commit, but ws-reference
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43
-├── ≡📙:2:B on 3183e43 {0}
-│   ├── 📙:2:B
-│   └── 📙:3:C
-└── ≡📙:4:D on 3183e43 {1}
-    ├── 📙:4:D
-    └── 📙:5:E
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓! on 3183e43
+├── ≡📙:B on 3183e43 {0}
+│   ├── 📙:B
+│   └── 📙:C
+└── ≡📙:D on 3183e43 {1}
+    ├── 📙:D
+    └── 📙:E
 
 "#]]
     );
@@ -379,14 +379,14 @@ Single commit, no main remote/target, no ws commit, but ws-reference
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43
-├── ≡📙:2:A on 3183e43 {0}
-│   ├── 📙:2:A
-│   ├── 📙:3:B
-│   └── 📙:4:C
-└── ≡📙:5:D on 3183e43 {1}
-    ├── 📙:5:D
-    └── 📙:6:E
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓! on 3183e43
+├── ≡📙:A on 3183e43 {0}
+│   ├── 📙:A
+│   ├── 📙:B
+│   └── 📙:C
+└── ≡📙:D on 3183e43 {1}
+    ├── 📙:D
+    └── 📙:E
 
 "#]]
     );
@@ -409,13 +409,13 @@ Single commit, no main remote/target, no ws commit, but ws-reference
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43
-├── ≡📙:2:B on 3183e43 {0}
-│   ├── 📙:2:B
-│   └── 📙:3:C
-└── ≡📙:4:D on 3183e43 {1}
-    ├── 📙:4:D
-    └── 📙:5:E
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓! on 3183e43
+├── ≡📙:B on 3183e43 {0}
+│   ├── 📙:B
+│   └── 📙:C
+└── ≡📙:D on 3183e43 {1}
+    ├── 📙:D
+    └── 📙:E
 
 "#]]
     );
@@ -466,7 +466,7 @@ Single commit, no main remote/target, no ws commit, but ws-reference
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️⚠️:0:gitbutler/workspace[🌳] <> ✓! on 3183e43
+📕🏘️⚠️:gitbutler/workspace[🌳] <> ✓! on 3183e43
 
 "#]]
     );

--- a/crates/but-workspace/tests/workspace/branch/tear_off_branch.rs
+++ b/crates/but-workspace/tests/workspace/branch/tear_off_branch.rs
@@ -36,14 +36,14 @@ fn tear_off_top_most_branch() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:3:A on 85efbe4 {1}
-│   └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:A on 85efbe4 {1}
+│   └── 📙:A
 │       └── ·09d8e52 (🏘️)
-└── ≡📙:4:C on 85efbe4 {2}
-    ├── 📙:4:C
+└── ≡📙:C on 85efbe4 {2}
+    ├── 📙:C
     │   └── ·09bc93e (🏘️)
-    └── 📙:5:B
+    └── 📙:B
         └── ·c813d8d (🏘️)
 
 "#]]
@@ -83,15 +83,15 @@ fn tear_off_top_most_branch() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:3:A on 85efbe4 {1}
-│   └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:A on 85efbe4 {1}
+│   └── 📙:A
 │       └── ·09d8e52 (🏘️)
-├── ≡📙:4:B on 85efbe4 {2}
-│   └── 📙:4:B
+├── ≡📙:B on 85efbe4 {2}
+│   └── 📙:B
 │       └── ·c813d8d (🏘️)
-└── ≡📙:5:C on 85efbe4 {3}
-    └── 📙:5:C
+└── ≡📙:C on 85efbe4 {3}
+    └── 📙:C
         └── ·8e00332 (🏘️)
 
 "#]]
@@ -129,14 +129,14 @@ fn tear_off_bottom_most_branch() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:3:A on 85efbe4 {1}
-│   └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:A on 85efbe4 {1}
+│   └── 📙:A
 │       └── ·09d8e52 (🏘️)
-└── ≡📙:4:C on 85efbe4 {2}
-    ├── 📙:4:C
+└── ≡📙:C on 85efbe4 {2}
+    ├── 📙:C
     │   └── ·09bc93e (🏘️)
-    └── 📙:5:B
+    └── 📙:B
         └── ·c813d8d (🏘️)
 
 "#]]
@@ -176,15 +176,15 @@ fn tear_off_bottom_most_branch() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:3:A on 85efbe4 {1}
-│   └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:A on 85efbe4 {1}
+│   └── 📙:A
 │       └── ·09d8e52 (🏘️)
-├── ≡📙:4:C on 85efbe4 {2}
-│   └── 📙:4:C
+├── ≡📙:C on 85efbe4 {2}
+│   └── 📙:C
 │       └── ·8e00332 (🏘️)
-└── ≡📙:5:B on 85efbe4 {3}
-    └── 📙:5:B
+└── ≡📙:B on 85efbe4 {3}
+    └── 📙:B
         └── ·c813d8d (🏘️)
 
 "#]]
@@ -222,14 +222,14 @@ fn tear_off_only_branch_in_stack() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:3:A on 85efbe4 {1}
-│   └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:A on 85efbe4 {1}
+│   └── 📙:A
 │       └── ·09d8e52 (🏘️)
-└── ≡📙:4:C on 85efbe4 {2}
-    ├── 📙:4:C
+└── ≡📙:C on 85efbe4 {2}
+    ├── 📙:C
     │   └── ·09bc93e (🏘️)
-    └── 📙:5:B
+    └── 📙:B
         └── ·c813d8d (🏘️)
 
 "#]]
@@ -268,14 +268,14 @@ fn tear_off_only_branch_in_stack() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:3:A on 85efbe4 {1}
-│   └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:A on 85efbe4 {1}
+│   └── 📙:A
 │       └── ·09d8e52 (🏘️)
-└── ≡📙:4:C on 85efbe4 {2}
-    ├── 📙:4:C
+└── ≡📙:C on 85efbe4 {2}
+    ├── 📙:C
     │   └── ·09bc93e (🏘️)
-    └── 📙:5:B
+    └── 📙:B
         └── ·c813d8d (🏘️)
 
 "#]]
@@ -306,11 +306,11 @@ fn tear_off_from_single_stack_in_ws_top() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-└── ≡📙:4:B on 85efbe4 {2}
-    ├── 📙:4:B
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+└── ≡📙:B on 85efbe4 {2}
+    ├── 📙:B
     │   └── ·d69fe94 (🏘️)
-    └── 📙:3:A
+    └── 📙:A
         └── ·09d8e52 (🏘️)
 
 "#]]
@@ -348,12 +348,12 @@ fn tear_off_from_single_stack_in_ws_top() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:3:A on 85efbe4 {1}
-│   └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:A on 85efbe4 {1}
+│   └── 📙:A
 │       └── ·09d8e52 (🏘️)
-└── ≡📙:4:B on 85efbe4 {2}
-    └── 📙:4:B
+└── ≡📙:B on 85efbe4 {2}
+    └── 📙:B
         └── ·1273ba9 (🏘️)
 
 "#]]
@@ -384,11 +384,11 @@ fn tear_off_from_single_stack_in_ws_bottom() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-└── ≡📙:4:B on 85efbe4 {2}
-    ├── 📙:4:B
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+└── ≡📙:B on 85efbe4 {2}
+    ├── 📙:B
     │   └── ·d69fe94 (🏘️)
-    └── 📙:3:A
+    └── 📙:A
         └── ·09d8e52 (🏘️)
 
 "#]]
@@ -426,12 +426,12 @@ fn tear_off_from_single_stack_in_ws_bottom() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:3:B on 85efbe4 {2}
-│   └── 📙:3:B
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:B on 85efbe4 {2}
+│   └── 📙:B
 │       └── ·1273ba9 (🏘️)
-└── ≡📙:4:A on 85efbe4 {1}
-    └── 📙:4:A
+└── ≡📙:A on 85efbe4 {1}
+    └── 📙:A
         └── ·09d8e52 (🏘️)
 
 "#]]
@@ -463,10 +463,10 @@ fn tear_off_empty_branch() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-└── ≡📙:4:B on 85efbe4 {1}
-    ├── 📙:4:B
-    └── 📙:5:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+└── ≡📙:B on 85efbe4 {1}
+    ├── 📙:B
+    └── 📙:A
         └── ·09d8e52 (🏘️)
 
 "#]]
@@ -503,12 +503,12 @@ fn tear_off_empty_branch() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:3:A on 85efbe4 {1}
-│   └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:A on 85efbe4 {1}
+│   └── 📙:A
 │       └── ·09d8e52 (🏘️)
-└── ≡📙:4:B on 85efbe4 {3}
-    └── 📙:4:B
+└── ≡📙:B on 85efbe4 {3}
+    └── 📙:B
 
 "#]]
     );
@@ -539,10 +539,10 @@ fn tear_off_non_empty_branch() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-└── ≡📙:4:B on 85efbe4 {1}
-    ├── 📙:4:B
-    └── 📙:5:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+└── ≡📙:B on 85efbe4 {1}
+    ├── 📙:B
+    └── 📙:A
         └── ·09d8e52 (🏘️)
 
 "#]]
@@ -579,11 +579,11 @@ fn tear_off_non_empty_branch() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:4:B on 85efbe4 {1}
-│   └── 📙:4:B
-└── ≡📙:3:A on 85efbe4 {3}
-    └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:B on 85efbe4 {1}
+│   └── 📙:B
+└── ≡📙:A on 85efbe4 {3}
+    └── 📙:A
         └── ·09d8e52 (🏘️)
 
 "#]]

--- a/crates/but-workspace/tests/workspace/commit/discard_commit.rs
+++ b/crates/but-workspace/tests/workspace/commit/discard_commit.rs
@@ -104,14 +104,14 @@ fn discard_tip_commit_in_workspace_stack() -> Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:3:A on 85efbe4 {1}
-│   └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:A on 85efbe4 {1}
+│   └── 📙:A
 │       └── ·09d8e52 (🏘️)
-└── ≡📙:4:C on 85efbe4 {2}
-    ├── 📙:4:C
+└── ≡📙:C on 85efbe4 {2}
+    ├── 📙:C
     │   └── ·09bc93e (🏘️)
-    └── 📙:5:B
+    └── 📙:B
         └── ·c813d8d (🏘️)
 
 "#]]
@@ -123,13 +123,13 @@ fn discard_tip_commit_in_workspace_stack() -> Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(outcome.workspace).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:3:A on 85efbe4 {1}
-│   └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:A on 85efbe4 {1}
+│   └── 📙:A
 │       └── ·09d8e52 (🏘️)
-└── ≡📙:5:C on 85efbe4 {2}
-    ├── 📙:5:C
-    └── 📙:6:B
+└── ≡📙:C on 85efbe4 {2}
+    ├── 📙:C
+    └── 📙:B
         └── ·c813d8d (🏘️)
 
 "#]]
@@ -189,14 +189,14 @@ fn discard_bottom_commit_in_workspace_stack() -> Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:3:A on 85efbe4 {1}
-│   └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:A on 85efbe4 {1}
+│   └── 📙:A
 │       └── ·09d8e52 (🏘️)
-└── ≡📙:4:C on 85efbe4 {2}
-    ├── 📙:4:C
+└── ≡📙:C on 85efbe4 {2}
+    ├── 📙:C
     │   └── ·09bc93e (🏘️)
-    └── 📙:5:B
+    └── 📙:B
         └── ·c813d8d (🏘️)
 
 "#]]
@@ -208,14 +208,14 @@ fn discard_bottom_commit_in_workspace_stack() -> Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(outcome.workspace).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:3:A on 85efbe4 {1}
-│   └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:A on 85efbe4 {1}
+│   └── 📙:A
 │       └── ·09d8e52 (🏘️)
-└── ≡📙:4:C on 85efbe4 {2}
-    ├── 📙:4:C
+└── ≡📙:C on 85efbe4 {2}
+    ├── 📙:C
     │   └── ·8e00332 (🏘️)
-    └── 📙:5:B
+    └── 📙:B
 
 "#]]
     );

--- a/crates/but-workspace/tests/workspace/commit/move_commit.rs
+++ b/crates/but-workspace/tests/workspace/commit/move_commit.rs
@@ -782,7 +782,7 @@ fn move_commit_in_non_managed_workspace() -> anyhow::Result<()> {
 └── ≡:0:three[🌳] {1}
     ├── :0:three[🌳]
     │   └── ·c9f444c
-    ├── :1:two <> origin/two →:2:
+    ├── :1:two <> origin/two
     │   └── ❄️16fd221
     └── :3:one
         └── ❄8b426d0
@@ -1033,7 +1033,7 @@ fn reorder_commit_in_non_managed_workspace() -> anyhow::Result<()> {
 └── ≡:0:three[🌳] {1}
     ├── :0:three[🌳]
     │   └── ·c9f444c
-    ├── :1:two <> origin/two →:2:
+    ├── :1:two <> origin/two
     │   └── ❄️16fd221
     └── :3:one
         └── ❄8b426d0

--- a/crates/but-workspace/tests/workspace/commit/move_commit.rs
+++ b/crates/but-workspace/tests/workspace/commit/move_commit.rs
@@ -50,14 +50,14 @@ fn move_top_commit_to_top_of_another_stack() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:3:A on 85efbe4 {1}
-│   └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:A on 85efbe4 {1}
+│   └── 📙:A
 │       └── ·09d8e52 (🏘️)
-└── ≡📙:4:C on 85efbe4 {2}
-    ├── 📙:4:C
+└── ≡📙:C on 85efbe4 {2}
+    ├── 📙:C
     │   └── ·09bc93e (🏘️)
-    └── 📙:5:B
+    └── 📙:B
         └── ·c813d8d (🏘️)
 
 "#]]
@@ -114,14 +114,14 @@ fn move_top_commit_to_top_of_another_stack() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:3:A on 85efbe4 {1}
-│   └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:A on 85efbe4 {1}
+│   └── 📙:A
 │       ├── ·f2cc60d (🏘️)
 │       └── ·09d8e52 (🏘️)
-└── ≡📙:5:C on 85efbe4 {2}
-    ├── 📙:5:C
-    └── 📙:6:B
+└── ≡📙:C on 85efbe4 {2}
+    ├── 📙:C
+    └── 📙:B
         └── ·c813d8d (🏘️)
 
 "#]]
@@ -159,14 +159,14 @@ fn move_bottom_commit_to_top_of_another_stack() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:3:A on 85efbe4 {1}
-│   └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:A on 85efbe4 {1}
+│   └── 📙:A
 │       └── ·09d8e52 (🏘️)
-└── ≡📙:4:C on 85efbe4 {2}
-    ├── 📙:4:C
+└── ≡📙:C on 85efbe4 {2}
+    ├── 📙:C
     │   └── ·09bc93e (🏘️)
-    └── 📙:5:B
+    └── 📙:B
         └── ·c813d8d (🏘️)
 
 "#]]
@@ -225,15 +225,15 @@ fn move_bottom_commit_to_top_of_another_stack() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:3:A on 85efbe4 {1}
-│   └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:A on 85efbe4 {1}
+│   └── 📙:A
 │       ├── ·f9061ed (🏘️)
 │       └── ·09d8e52 (🏘️)
-└── ≡📙:4:C on 85efbe4 {2}
-    ├── 📙:4:C
+└── ≡📙:C on 85efbe4 {2}
+    ├── 📙:C
     │   └── ·8e00332 (🏘️)
-    └── 📙:5:B
+    └── 📙:B
 
 "#]]
     );
@@ -270,14 +270,14 @@ fn move_top_commit_to_bottom_of_another_stack() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:3:A on 85efbe4 {1}
-│   └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:A on 85efbe4 {1}
+│   └── 📙:A
 │       └── ·09d8e52 (🏘️)
-└── ≡📙:4:C on 85efbe4 {2}
-    ├── 📙:4:C
+└── ≡📙:C on 85efbe4 {2}
+    ├── 📙:C
     │   └── ·09bc93e (🏘️)
-    └── 📙:5:B
+    └── 📙:B
         └── ·c813d8d (🏘️)
 
 "#]]
@@ -334,14 +334,14 @@ fn move_top_commit_to_bottom_of_another_stack() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:3:A on 85efbe4 {1}
-│   └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:A on 85efbe4 {1}
+│   └── 📙:A
 │       ├── ·2506923 (🏘️)
 │       └── ·8e00332 (🏘️)
-└── ≡📙:5:C on 85efbe4 {2}
-    ├── 📙:5:C
-    └── 📙:6:B
+└── ≡📙:C on 85efbe4 {2}
+    ├── 📙:C
+    └── 📙:B
         └── ·c813d8d (🏘️)
 
 "#]]
@@ -379,14 +379,14 @@ fn move_bottom_commit_to_bottom_of_another_stack() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:3:A on 85efbe4 {1}
-│   └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:A on 85efbe4 {1}
+│   └── 📙:A
 │       └── ·09d8e52 (🏘️)
-└── ≡📙:4:C on 85efbe4 {2}
-    ├── 📙:4:C
+└── ≡📙:C on 85efbe4 {2}
+    ├── 📙:C
     │   └── ·09bc93e (🏘️)
-    └── 📙:5:B
+    └── 📙:B
         └── ·c813d8d (🏘️)
 
 "#]]
@@ -445,15 +445,15 @@ fn move_bottom_commit_to_bottom_of_another_stack() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:3:A on 85efbe4 {1}
-│   └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:A on 85efbe4 {1}
+│   └── 📙:A
 │       ├── ·4dfe841 (🏘️)
 │       └── ·c813d8d (🏘️)
-└── ≡📙:4:C on 85efbe4 {2}
-    ├── 📙:4:C
+└── ≡📙:C on 85efbe4 {2}
+    ├── 📙:C
     │   └── ·8e00332 (🏘️)
-    └── 📙:5:B
+    └── 📙:B
 
 "#]]
     );
@@ -490,14 +490,14 @@ fn move_single_commit_to_the_top_of_another_branch() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:3:A on 85efbe4 {1}
-│   └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:A on 85efbe4 {1}
+│   └── 📙:A
 │       └── ·09d8e52 (🏘️)
-└── ≡📙:4:C on 85efbe4 {2}
-    ├── 📙:4:C
+└── ≡📙:C on 85efbe4 {2}
+    ├── 📙:C
     │   └── ·09bc93e (🏘️)
-    └── 📙:5:B
+    └── 📙:B
         └── ·c813d8d (🏘️)
 
 "#]]
@@ -547,14 +547,14 @@ fn move_single_commit_to_the_top_of_another_branch() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:5:A on 85efbe4 {1}
-│   └── 📙:5:A
-└── ≡📙:3:C on 85efbe4 {2}
-    ├── 📙:3:C
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:A on 85efbe4 {1}
+│   └── 📙:A
+└── ≡📙:C on 85efbe4 {2}
+    ├── 📙:C
     │   ├── ·148f8f3 (🏘️)
     │   └── ·09bc93e (🏘️)
-    └── 📙:4:B
+    └── 📙:B
         └── ·c813d8d (🏘️)
 
 "#]]
@@ -592,14 +592,14 @@ fn move_single_commit_to_the_bottom_of_another_branch() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:3:A on 85efbe4 {1}
-│   └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:A on 85efbe4 {1}
+│   └── 📙:A
 │       └── ·09d8e52 (🏘️)
-└── ≡📙:4:C on 85efbe4 {2}
-    ├── 📙:4:C
+└── ≡📙:C on 85efbe4 {2}
+    ├── 📙:C
     │   └── ·09bc93e (🏘️)
-    └── 📙:5:B
+    └── 📙:B
         └── ·c813d8d (🏘️)
 
 "#]]
@@ -658,13 +658,13 @@ fn move_single_commit_to_the_bottom_of_another_branch() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:5:A on 85efbe4 {1}
-│   └── 📙:5:A
-└── ≡📙:3:C on 85efbe4 {2}
-    ├── 📙:3:C
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:A on 85efbe4 {1}
+│   └── 📙:A
+└── ≡📙:C on 85efbe4 {2}
+    ├── 📙:C
     │   └── ·ad476a8 (🏘️)
-    └── 📙:4:B
+    └── 📙:B
         ├── ·f9061ed (🏘️)
         └── ·09d8e52 (🏘️)
 
@@ -698,12 +698,12 @@ fn move_commit_to_empty_branch() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:3:A on 85efbe4 {1}
-│   └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:A on 85efbe4 {1}
+│   └── 📙:A
 │       └── ·09d8e52 (🏘️)
-└── ≡📙:4:B on 85efbe4 {2}
-    └── 📙:4:B
+└── ≡📙:B on 85efbe4 {2}
+    └── 📙:B
 
 "#]]
     );
@@ -746,11 +746,11 @@ fn move_commit_to_empty_branch() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:4:A on 85efbe4 {1}
-│   └── 📙:4:A
-└── ≡📙:3:B on 85efbe4 {2}
-    └── 📙:3:B
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:A on 85efbe4 {1}
+│   └── 📙:A
+└── ≡📙:B on 85efbe4 {2}
+    └── 📙:B
         └── ·09d8e52 (🏘️)
 
 "#]]
@@ -778,13 +778,13 @@ fn move_commit_in_non_managed_workspace() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-⌂:0:three[🌳] <> ✓!
-└── ≡:0:three[🌳] {1}
-    ├── :0:three[🌳]
+⌂:three[🌳] <> ✓!
+└── ≡:three[🌳] {1}
+    ├── :three[🌳]
     │   └── ·c9f444c
-    ├── :1:two <> origin/two
+    ├── :two <> origin/two
     │   └── ❄️16fd221
-    └── :3:one
+    └── :one
         └── ❄8b426d0
 
 "#]]
@@ -831,12 +831,12 @@ fn move_commit_in_non_managed_workspace() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-⌂:0:three[🌳] <> ✓!
-└── ≡:0:three[🌳] {1}
-    ├── :0:three[🌳]
+⌂:three[🌳] <> ✓!
+└── ≡:three[🌳] {1}
+    ├── :three[🌳]
     │   ├── ·c9f444c ►two
     │   └── ·16fd221
-    └── :3:one
+    └── :one
         └── ·8b426d0
 
 "#]]
@@ -872,13 +872,13 @@ fn reorder_merge_commit_above_keeps_child_commits_visible() -> anyhow::Result<()
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-⌂:[..]:child-stack[🌳] <> ✓refs/remotes/origin/main on aa67ae0
-└── ≡:[..]:child-stack[🌳] on aa67ae0 {1}
-    ├── :[..]:child-stack[🌳]
+⌂:child-stack[🌳] <> ✓refs/remotes/origin/main on aa67ae0
+└── ≡:child-stack[🌳] on aa67ae0 {1}
+    ├── :child-stack[🌳]
     │   └── ·32c8bda ►C2
-    ├── :[..]:C1
+    ├── :C1
     │   └── ·64dace5
-    └── :[..]:M
+    └── :M
         └── ·197bdf1
 
 "#]]
@@ -955,13 +955,13 @@ fn reorder_merge_commit_below_keeps_child_commits_visible() -> anyhow::Result<()
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-⌂:[..]:child-stack[🌳] <> ✓refs/remotes/origin/main on aa67ae0
-└── ≡:[..]:child-stack[🌳] on aa67ae0 {1}
-    ├── :[..]:child-stack[🌳]
+⌂:child-stack[🌳] <> ✓refs/remotes/origin/main on aa67ae0
+└── ≡:child-stack[🌳] on aa67ae0 {1}
+    ├── :child-stack[🌳]
     │   └── ·32c8bda ►C2
-    ├── :[..]:C1
+    ├── :C1
     │   └── ·64dace5
-    └── :[..]:M
+    └── :M
         └── ·197bdf1
 
 "#]]
@@ -1029,13 +1029,13 @@ fn reorder_commit_in_non_managed_workspace() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-⌂:0:three[🌳] <> ✓!
-└── ≡:0:three[🌳] {1}
-    ├── :0:three[🌳]
+⌂:three[🌳] <> ✓!
+└── ≡:three[🌳] {1}
+    ├── :three[🌳]
     │   └── ·c9f444c
-    ├── :1:two <> origin/two
+    ├── :two <> origin/two
     │   └── ❄️16fd221
-    └── :3:one
+    └── :one
         └── ❄8b426d0
 
 "#]]
@@ -1092,12 +1092,12 @@ fn reorder_commit_in_non_managed_workspace() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-⌂:0:three[🌳] <> ✓!
-└── ≡:0:three[🌳] {1}
-    ├── :0:three[🌳]
+⌂:three[🌳] <> ✓!
+└── ≡:three[🌳] {1}
+    ├── :three[🌳]
     │   ├── ·09ad3ca ►two
     │   └── ·0c38dd9
-    └── :2:one
+    └── :one
         └── ·8b426d0
 
 "#]]

--- a/crates/but-workspace/tests/workspace/commit/squash_commits.rs
+++ b/crates/but-workspace/tests/workspace/commit/squash_commits.rs
@@ -488,12 +488,12 @@ fn squash_across_stacks_subject_into_target() -> Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:3:A on 85efbe4 {1}
-│   └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:A on 85efbe4 {1}
+│   └── 📙:A
 │       └── ·09d8e52 (🏘️)
-└── ≡📙:4:B on 85efbe4 {2}
-    └── 📙:4:B
+└── ≡📙:B on 85efbe4 {2}
+    └── 📙:B
         └── ·c813d8d (🏘️)
 
 "#]]
@@ -532,11 +532,11 @@ fn squash_across_stacks_subject_into_target() -> Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:4:A on 85efbe4 {1}
-│   └── 📙:4:A
-└── ≡📙:3:B on 85efbe4 {2}
-    └── 📙:3:B
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:A on 85efbe4 {1}
+│   └── 📙:A
+└── ≡📙:B on 85efbe4 {2}
+    └── 📙:B
         └── ·a2dc4c7 (🏘️)
 
 "#]]
@@ -573,12 +573,12 @@ fn squash_across_stacks_target_into_subject() -> Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:3:A on 85efbe4 {1}
-│   └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:A on 85efbe4 {1}
+│   └── 📙:A
 │       └── ·09d8e52 (🏘️)
-└── ≡📙:4:B on 85efbe4 {2}
-    └── 📙:4:B
+└── ≡📙:B on 85efbe4 {2}
+    └── 📙:B
         └── ·c813d8d (🏘️)
 
 "#]]
@@ -617,12 +617,12 @@ fn squash_across_stacks_target_into_subject() -> Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
-├── ≡📙:3:A on 85efbe4 {1}
-│   └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 85efbe4
+├── ≡📙:A on 85efbe4 {1}
+│   └── 📙:A
 │       └── ·80db672 (🏘️)
-└── ≡📙:4:B on 85efbe4 {2}
-    └── 📙:4:B
+└── ≡📙:B on 85efbe4 {2}
+    └── 📙:B
 
 "#]]
     );

--- a/crates/but-workspace/tests/workspace/upstream_integration.rs
+++ b/crates/but-workspace/tests/workspace/upstream_integration.rs
@@ -246,15 +246,15 @@ fn diamond_partially_content_integrated_rebase() -> Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/master⇣4 on 85aa44b
-└── ≡📙:4:E on 85aa44b {1}
-    ├── 📙:4:E
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/master⇣4 on 85aa44b
+└── ≡📙:E on 85aa44b {1}
+    ├── 📙:E
     │   └── ·a6588cf (🏘️)
-    ├── :6:C
+    ├── :C
     │   └── ·4827d2f (🏘️)
-    ├── :7:B
+    ├── :B
     │   └── ·3d3bfa7 (🏘️)
-    └── :9:A
+    └── :A
         └── ·f5b02d3 (🏘️)
 
 "#]]
@@ -423,11 +423,11 @@ fn integrated_bottom_branch_no_workspace_rebase() -> Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
-⌂:[..]:A[🌳] <> ✓refs/remotes/origin/main⇣2 on 3183e43
-└── ≡:[..]:A[🌳] on 3183e43 {1}
-    ├── :[..]:A[🌳]
+⌂:A[🌳] <> ✓refs/remotes/origin/main⇣2 on 3183e43
+└── ≡:A[🌳] on 3183e43 {1}
+    ├── :A[🌳]
     │   └── ·e792f40
-    └── :[..]:B
+    └── :B
         └── ·b38b04b (✓)
 
 "#]]
@@ -575,11 +575,11 @@ fn integrated_bottom_branch_no_workspace_merge() -> Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
-⌂:[..]:A[🌳] <> ✓refs/remotes/origin/main⇣2 on 3183e43
-└── ≡:[..]:A[🌳] on 3183e43 {1}
-    ├── :[..]:A[🌳]
+⌂:A[🌳] <> ✓refs/remotes/origin/main⇣2 on 3183e43
+└── ≡:A[🌳] on 3183e43 {1}
+    ├── :A[🌳]
     │   └── ·e792f40
-    └── :[..]:B
+    └── :B
         └── ·b38b04b (✓)
 
 "#]]
@@ -774,12 +774,12 @@ fn fully_historically_integrated_branch_leaves_workspace_shape() -> Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
-├── ≡📙:4:A on 3183e43 {1}
-│   └── 📙:4:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+├── ≡📙:A on 3183e43 {1}
+│   └── 📙:A
 │       └── ·905d6e5 (🏘️|✓)
-└── ≡📙:3:B on 3183e43 {2}
-    └── 📙:3:B
+└── ≡📙:B on 3183e43 {2}
+    └── 📙:B
         └── ·b38b04b (🏘️)
 
 "#]]
@@ -813,9 +813,9 @@ fn fully_historically_integrated_branch_leaves_workspace_shape() -> Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 905d6e5
-└── ≡📙:3:B on 905d6e5 {2}
-    └── 📙:3:B
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 905d6e5
+└── ≡📙:B on 905d6e5 {2}
+    └── 📙:B
         └── ·c932222 (🏘️)
 
 "#]]
@@ -867,9 +867,9 @@ fn fully_integrated_single_branch_leaves_workspace_shape() -> Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
-└── ≡📙:3:A on 3183e43 {1}
-    └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+└── ≡📙:A on 3183e43 {1}
+    └── 📙:A
         └── ·905d6e5 (🏘️|✓)
 
 "#]]
@@ -898,7 +898,7 @@ fn fully_integrated_single_branch_leaves_workspace_shape() -> Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 905d6e5
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 905d6e5
 
 "#]]
     );
@@ -951,9 +951,9 @@ fn fully_integrated_single_branch_reparents_workspace_commit_to_advanced_target(
     snapbox::assert_data_eq!(
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 8d5739f
-└── ≡📙:3:A on 8d5739f {1}
-    └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 8d5739f
+└── ≡📙:A on 8d5739f {1}
+    └── 📙:A
         ├── ·ffde79e (🏘️|✓)
         └── ·86b55e6 (🏘️|✓)
 
@@ -983,7 +983,7 @@ fn fully_integrated_single_branch_reparents_workspace_commit_to_advanced_target(
     snapbox::assert_data_eq!(
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 6b20716
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 6b20716
 
 "#]]
     );
@@ -1041,9 +1041,9 @@ fn squash_merged_multi_commit_branch_is_pruned() -> Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣2 on 9bede57
-└── ≡📙:3:A on 9bede57 {1}
-    └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣2 on 9bede57
+└── ≡📙:A on 9bede57 {1}
+    └── 📙:A
         ├── ·860210a (🏘️)
         └── ·5434680 (🏘️)
 
@@ -1075,7 +1075,7 @@ fn squash_merged_multi_commit_branch_is_pruned() -> Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 6204bf3
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 6204bf3
 
 "#]]
     );
@@ -1134,11 +1134,11 @@ fn squash_merged_branch_below_stacked_work_is_pruned() -> Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣2 on 9bede57
-└── ≡📙:3:B on 9bede57 {1}
-    ├── 📙:3:B
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣2 on 9bede57
+└── ≡📙:B on 9bede57 {1}
+    ├── 📙:B
     │   └── ·d96a0bd (🏘️)
-    └── 📙:4:A
+    └── 📙:A
         ├── ·860210a (🏘️)
         └── ·5434680 (🏘️)
 
@@ -1171,9 +1171,9 @@ fn squash_merged_branch_below_stacked_work_is_pruned() -> Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 6204bf3
-└── ≡:3:B on 6204bf3 {1}
-    └── :3:B
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 6204bf3
+└── ≡:B on 6204bf3 {1}
+    └── :B
         └── ·3f21b99 (🏘️)
 
 "#]]
@@ -1236,13 +1236,13 @@ fn canceling_segments_above_squash_merged_bottom_are_not_swept_up() -> Result<()
     snapbox::assert_data_eq!(
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣2 on 9bede57
-└── ≡📙:3:C on 9bede57 {1}
-    ├── 📙:3:C
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣2 on 9bede57
+└── ≡📙:C on 9bede57 {1}
+    ├── 📙:C
     │   └── ·c63394f (🏘️)
-    ├── 📙:4:B
+    ├── 📙:B
     │   └── ·de9274b (🏘️)
-    └── 📙:5:A
+    └── 📙:A
         ├── ·860210a (🏘️)
         └── ·5434680 (🏘️)
 
@@ -1274,11 +1274,11 @@ fn canceling_segments_above_squash_merged_bottom_are_not_swept_up() -> Result<()
     snapbox::assert_data_eq!(
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on cfc7fef
-└── ≡:3:C on cfc7fef {1}
-    ├── :3:C
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on cfc7fef
+└── ≡:C on cfc7fef {1}
+    ├── :C
     │   └── ·1b83941 (🏘️)
-    └── :4:B
+    └── :B
         └── ·30c179e (🏘️)
 
 "#]]
@@ -1456,9 +1456,9 @@ fn non_bottom_update_selector_does_not_prune_fully_integrated_stack() -> Result<
     snapbox::assert_data_eq!(
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 8d5739f
-└── ≡📙:3:A on 8d5739f {1}
-    └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 8d5739f
+└── ≡📙:A on 8d5739f {1}
+    └── 📙:A
         ├── ·ffde79e (🏘️|✓)
         └── ·86b55e6 (🏘️|✓)
 
@@ -1511,9 +1511,9 @@ fn fully_integrated_single_branch_reparents_workspace_commit_to_advanced_merge_t
     snapbox::assert_data_eq!(
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣2 on 8d5739f
-└── ≡📙:3:A on 8d5739f {1}
-    └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣2 on 8d5739f
+└── ≡📙:A on 8d5739f {1}
+    └── 📙:A
         ├── ·ffde79e (🏘️|✓)
         └── ·86b55e6 (🏘️|✓)
 
@@ -1543,7 +1543,7 @@ fn fully_integrated_single_branch_reparents_workspace_commit_to_advanced_merge_t
     snapbox::assert_data_eq!(
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on f27db86
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on f27db86
 
 "#]]
     );
@@ -2100,12 +2100,12 @@ fn workspace_target_parent_updates_while_stack_parent_remains_anonymous_segment_
     snapbox::assert_data_eq!(
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on fe9ae6e
-├── ≡:5:anon: on fe9ae6e
-│   └── :5:anon:
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on fe9ae6e
+├── ≡:anon: on fe9ae6e
+│   └── :anon:
 │       └── ·0d97cc1 (🏘️)
-└── ≡📙:4:A on fe9ae6e {1}
-    └── 📙:4:A
+└── ≡📙:A on fe9ae6e {1}
+    └── 📙:A
         └── ·90d25da (🏘️)
 
 "#]]
@@ -2132,12 +2132,12 @@ fn workspace_target_parent_updates_while_stack_parent_remains_anonymous_segment_
     snapbox::assert_data_eq!(
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fe9ae6e
-├── ≡:5:anon: on fe9ae6e
-│   └── :5:anon:
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on fe9ae6e
+├── ≡:anon: on fe9ae6e
+│   └── :anon:
 │       └── ·0d97cc1 (🏘️)
-└── ≡📙:3:A on 20a5ffc {1}
-    └── 📙:3:A
+└── ≡📙:A on 20a5ffc {1}
+    └── 📙:A
         └── ·c529875 (🏘️)
 
 "#]]
@@ -2299,14 +2299,14 @@ fn partially_integrated_branch_leaves_multi_branch_stack() -> Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
-├── ≡📙:3:A on 3183e43 {1}
-│   ├── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+├── ≡📙:A on 3183e43 {1}
+│   ├── 📙:A
 │   │   └── ·44c9428 (🏘️)
-│   └── 📙:5:C
+│   └── 📙:C
 │       └── ·f1e7451 (🏘️|✓)
-└── ≡📙:4:B on 3183e43 {2}
-    └── 📙:4:B
+└── ≡📙:B on 3183e43 {2}
+    └── 📙:B
         └── ·b38b04b (🏘️)
 
 "#]]
@@ -2340,12 +2340,12 @@ fn partially_integrated_branch_leaves_multi_branch_stack() -> Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on f1e7451
-├── ≡📙:3:A on f1e7451 {1}
-│   └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on f1e7451
+├── ≡📙:A on f1e7451 {1}
+│   └── 📙:A
 │       └── ·44c9428 (🏘️)
-└── ≡📙:4:B on f1e7451 {2}
-    └── 📙:4:B
+└── ≡📙:B on f1e7451 {2}
+    └── 📙:B
         └── ·a27415e (🏘️)
 
 "#]]
@@ -2407,14 +2407,14 @@ fn fully_integrated_multi_branch_stack_leaves_workspace_shape() -> Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
-├── ≡📙:5:A on 3183e43 {1}
-│   ├── 📙:5:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 3183e43
+├── ≡📙:A on 3183e43 {1}
+│   ├── 📙:A
 │   │   └── ·44c9428 (🏘️|✓)
-│   └── 📙:3:C
+│   └── 📙:C
 │       └── ·f1e7451 (🏘️|✓)
-└── ≡📙:4:B on 3183e43 {2}
-    └── 📙:4:B
+└── ≡📙:B on 3183e43 {2}
+    └── 📙:B
         └── ·b38b04b (🏘️)
 
 "#]]
@@ -2448,9 +2448,9 @@ fn fully_integrated_multi_branch_stack_leaves_workspace_shape() -> Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 44c9428
-└── ≡📙:3:B on 44c9428 {2}
-    └── 📙:3:B
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 44c9428
+└── ≡📙:B on 44c9428 {2}
+    └── 📙:B
         └── ·f59d71f (🏘️)
 
 "#]]
@@ -2518,12 +2518,12 @@ fn fully_integrated_two_stacks_checkout_canned_branch_at_target_tip() -> Result<
     snapbox::assert_data_eq!(
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣2 on 3183e43
-├── ≡📙:4:A on 3183e43 {1}
-│   └── 📙:4:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣2 on 3183e43
+├── ≡📙:A on 3183e43 {1}
+│   └── 📙:A
 │       └── ·905d6e5 (🏘️|✓)
-└── ≡📙:5:B on 3183e43 {2}
-    └── 📙:5:B
+└── ≡📙:B on 3183e43 {2}
+    └── 📙:B
         └── ·b38b04b (🏘️|✓)
 
 "#]]
@@ -2628,7 +2628,7 @@ fn fully_integrated_two_stacks_keep_managed_workspace_outside_single_branch_mode
     snapbox::assert_data_eq!(
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 5f7d45e
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 5f7d45e
 
 "#]]
     );
@@ -2861,9 +2861,9 @@ fn empty_branch_with_integrated_remote_tip_is_removed() -> Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 563a7fc
-└── ≡📙:4:topic <> origin/topic on 563a7fc {1}
-    └── 📙:4:topic <> origin/topic
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 563a7fc
+└── ≡📙:topic <> origin/topic on 563a7fc {1}
+    └── 📙:topic <> origin/topic
         └── ❄️6ba217e (🏘️|✓)
 
 "#]]
@@ -2896,9 +2896,9 @@ fn empty_branch_with_integrated_remote_tip_is_removed() -> Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 563a7fc
-└── ≡:2:main <> origin/main on 563a7fc
-    └── :2:main <> origin/main
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 563a7fc
+└── ≡:main <> origin/main on 563a7fc
+    └── :main <> origin/main
         └── ❄️364a08f (🏘️|✓)
 
 "#]]
@@ -2960,9 +2960,9 @@ fn non_empty_branch_with_integrated_remote_tip_keeps_local_work() -> Result<()> 
     snapbox::assert_data_eq!(
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 563a7fc
-└── ≡📙:4:topic <> origin/topic⇡1 on 563a7fc {1}
-    └── 📙:4:topic <> origin/topic⇡1
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 563a7fc
+└── ≡📙:topic <> origin/topic⇡1 on 563a7fc {1}
+    └── 📙:topic <> origin/topic⇡1
         ├── ·f1a3cba (🏘️)
         └── ❄️6ba217e (🏘️|✓)
 
@@ -2997,11 +2997,11 @@ fn non_empty_branch_with_integrated_remote_tip_keeps_local_work() -> Result<()> 
     snapbox::assert_data_eq!(
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 563a7fc
-└── ≡📙:4:topic <> origin/topic⇡1 on 563a7fc {1}
-    ├── 📙:4:topic <> origin/topic⇡1
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 563a7fc
+└── ≡📙:topic <> origin/topic⇡1 on 563a7fc {1}
+    ├── 📙:topic <> origin/topic⇡1
     │   └── ·f3ceb3d (🏘️)
-    └── :2:main <> origin/main
+    └── :main <> origin/main
         └── ❄️364a08f (🏘️|✓)
 
 "#]]
@@ -3062,10 +3062,10 @@ fn empty_branch_above_integrated_branch_is_preserved() -> Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 563a7fc
-└── ≡📙:7:top <> origin/top on 563a7fc {1}
-    ├── 📙:7:top <> origin/top
-    └── 📙:8:bottom <> origin/bottom
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 563a7fc
+└── ≡📙:top <> origin/top on 563a7fc {1}
+    ├── 📙:top <> origin/top
+    └── 📙:bottom <> origin/bottom
         └── ❄️141de4f (🏘️|✓)
 
 "#]]
@@ -3107,9 +3107,9 @@ fn empty_branch_above_integrated_branch_is_preserved() -> Result<()> {
     snapbox::assert_data_eq!(
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 563a7fc
-└── ≡📙:2:top <> origin/top on 563a7fc {1}
-    └── 📙:2:top <> origin/top
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 563a7fc
+└── ≡📙:top <> origin/top on 563a7fc {1}
+    └── 📙:top <> origin/top
         └── ·334227d (🏘️|✓)
 
 "#]]
@@ -3392,13 +3392,13 @@ fn review_hint_integrates_squashed_two_commit_stack_in_managed_workspace() -> Re
     snapbox::assert_data_eq!(
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
-├── ≡📙:3:A on 3183e43 {1}
-│   └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
+├── ≡📙:A on 3183e43 {1}
+│   └── 📙:A
 │       ├── ·ad1d22b (🏘️)
 │       └── ·fe98e29 (🏘️)
-└── ≡📙:4:B on 3183e43 {2}
-    └── 📙:4:B
+└── ≡📙:B on 3183e43 {2}
+    └── 📙:B
         └── ·b38b04b (🏘️)
 
 "#]]
@@ -3429,9 +3429,9 @@ fn review_hint_integrates_squashed_two_commit_stack_in_managed_workspace() -> Re
     snapbox::assert_data_eq!(
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
-└── ≡📙:3:B on 3183e43 {2}
-    └── 📙:3:B
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
+└── ≡📙:B on 3183e43 {2}
+    └── 📙:B
         └── ·b38b04b (🏘️)
 
 "#]]
@@ -3506,9 +3506,9 @@ fn review_hint_integrates_squashed_two_commit_direct_checkout_branch() -> Result
     snapbox::assert_data_eq!(
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
-⌂:[..]:A[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
-└── ≡:[..]:A[🌳] on 3183e43 {1}
-    └── :[..]:A[🌳]
+⌂:A[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
+└── ≡:A[🌳] on 3183e43 {1}
+    └── :A[🌳]
         ├── ·ad1d22b
         └── ·fe98e29
 
@@ -3539,9 +3539,9 @@ fn review_hint_integrates_squashed_two_commit_direct_checkout_branch() -> Result
     snapbox::assert_data_eq!(
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
-⌂:[..]:amo-branch-1[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
-└── ≡:[..]:amo-branch-1[🌳] on 3183e43 {1}
-    └── :[..]:amo-branch-1[🌳]
+⌂:amo-branch-1[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
+└── ≡:amo-branch-1[🌳] on 3183e43 {1}
+    └── :amo-branch-1[🌳]
         └── ·56057f2 (✓)
 
 "#]]
@@ -3608,9 +3608,9 @@ fn review_hint_integrates_squashed_prefix_and_keeps_extra_commit_in_managed_work
     snapbox::assert_data_eq!(
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
-└── ≡📙:3:A on 3183e43 {1}
-    └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
+└── ≡📙:A on 3183e43 {1}
+    └── 📙:A
         ├── ·f015e95 (🏘️)
         ├── ·ad1d22b (🏘️)
         └── ·fe98e29 (🏘️)
@@ -3644,9 +3644,9 @@ fn review_hint_integrates_squashed_prefix_and_keeps_extra_commit_in_managed_work
     snapbox::assert_data_eq!(
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
-📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on e2f5892
-└── ≡📙:3:A on e2f5892 {1}
-    └── 📙:3:A
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on e2f5892
+└── ≡📙:A on e2f5892 {1}
+    └── 📙:A
         └── ·92f1780 (🏘️)
 
 "#]]
@@ -3710,9 +3710,9 @@ fn review_hint_integrates_squashed_prefix_and_keeps_extra_commit_in_direct_check
     snapbox::assert_data_eq!(
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
-⌂:[..]:A[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
-└── ≡:[..]:A[🌳] on 3183e43 {1}
-    └── :[..]:A[🌳]
+⌂:A[🌳] <> ✓refs/remotes/origin/main⇣1 on 3183e43
+└── ≡:A[🌳] on 3183e43 {1}
+    └── :A[🌳]
         ├── ·f015e95
         ├── ·ad1d22b
         └── ·fe98e29
@@ -3761,9 +3761,9 @@ fn review_hint_integrates_squashed_prefix_and_keeps_extra_commit_in_direct_check
     snapbox::assert_data_eq!(
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
-⌂:[..]:A[🌳] <> ✓refs/remotes/origin/main on e2f5892
-└── ≡:[..]:A[🌳] on e2f5892 {1}
-    └── :[..]:A[🌳]
+⌂:A[🌳] <> ✓refs/remotes/origin/main on e2f5892
+└── ≡:A[🌳] on e2f5892 {1}
+    └── :A[🌳]
         └── ·92f1780
 
 "#]]

--- a/crates/but-workspace/tests/workspace/upstream_integration.rs
+++ b/crates/but-workspace/tests/workspace/upstream_integration.rs
@@ -2862,8 +2862,8 @@ fn empty_branch_with_integrated_remote_tip_is_removed() -> Result<()> {
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
 📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 563a7fc
-└── ≡📙:4:topic <> origin/topic →:5: on 563a7fc {1}
-    └── 📙:4:topic <> origin/topic →:5:
+└── ≡📙:4:topic <> origin/topic on 563a7fc {1}
+    └── 📙:4:topic <> origin/topic
         └── ❄️6ba217e (🏘️|✓)
 
 "#]]
@@ -2897,8 +2897,8 @@ fn empty_branch_with_integrated_remote_tip_is_removed() -> Result<()> {
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
 📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 563a7fc
-└── ≡:2:main <> origin/main →:1: on 563a7fc
-    └── :2:main <> origin/main →:1:
+└── ≡:2:main <> origin/main on 563a7fc
+    └── :2:main <> origin/main
         └── ❄️364a08f (🏘️|✓)
 
 "#]]
@@ -2961,8 +2961,8 @@ fn non_empty_branch_with_integrated_remote_tip_keeps_local_work() -> Result<()> 
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
 📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 563a7fc
-└── ≡📙:4:topic <> origin/topic →:5:⇡1 on 563a7fc {1}
-    └── 📙:4:topic <> origin/topic →:5:⇡1
+└── ≡📙:4:topic <> origin/topic⇡1 on 563a7fc {1}
+    └── 📙:4:topic <> origin/topic⇡1
         ├── ·f1a3cba (🏘️)
         └── ❄️6ba217e (🏘️|✓)
 
@@ -2998,10 +2998,10 @@ fn non_empty_branch_with_integrated_remote_tip_keeps_local_work() -> Result<()> 
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
 📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 563a7fc
-└── ≡📙:4:topic <> origin/topic →:5:⇡1 on 563a7fc {1}
-    ├── 📙:4:topic <> origin/topic →:5:⇡1
+└── ≡📙:4:topic <> origin/topic⇡1 on 563a7fc {1}
+    ├── 📙:4:topic <> origin/topic⇡1
     │   └── ·f3ceb3d (🏘️)
-    └── :2:main <> origin/main →:1:
+    └── :2:main <> origin/main
         └── ❄️364a08f (🏘️|✓)
 
 "#]]
@@ -3063,9 +3063,9 @@ fn empty_branch_above_integrated_branch_is_preserved() -> Result<()> {
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
 📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main⇣1 on 563a7fc
-└── ≡📙:7:top <> origin/top →:6: on 563a7fc {1}
-    ├── 📙:7:top <> origin/top →:6:
-    └── 📙:8:bottom <> origin/bottom →:5:
+└── ≡📙:7:top <> origin/top on 563a7fc {1}
+    ├── 📙:7:top <> origin/top
+    └── 📙:8:bottom <> origin/bottom
         └── ❄️141de4f (🏘️|✓)
 
 "#]]
@@ -3108,8 +3108,8 @@ fn empty_branch_above_integrated_branch_is_preserved() -> Result<()> {
         graph_workspace(&workspace).to_string(),
         snapbox::str![[r#"
 📕🏘️:0:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/main on 563a7fc
-└── ≡📙:2:top <> origin/top →:4: on 563a7fc {1}
-    └── 📙:2:top <> origin/top →:4:
+└── ≡📙:2:top <> origin/top on 563a7fc {1}
+    └── 📙:2:top <> origin/top
         └── ·334227d (🏘️|✓)
 
 "#]]

--- a/crates/but/src/id/tests.rs
+++ b/crates/but/src/id/tests.rs
@@ -3456,7 +3456,6 @@ mod util {
         StackSegment {
             ref_info,
             remote_tracking_ref_name: None,
-            sibling_segment_id: None,
             remote_tracking_branch_segment_id: None,
             id: Default::default(),
             commits,


### PR DESCRIPTION
This makes it easier to test alternative implementations of graphs that do not create the segments in the same order (but still create the same graph).