### PR TITLE
fix: edit mode no longer crashes or lies about non-UTF-8 conflicts

### DIFF
--- a/apps/desktop/src/components/diff/ImageDiff.svelte
+++ b/apps/desktop/src/components/diff/ImageDiff.svelte
@@ -22,8 +22,8 @@
 	};
 
 	function buildImageDataUrl(
-		content: string | undefined,
-		mimeType: string | undefined,
+		content: string | null | undefined,
+		mimeType: string | null | undefined,
 		path: string,
 	): string | null {
 		if (!content) return null;
@@ -127,8 +127,7 @@
 			let fileInfo;
 
 			if (source.type === "workspace") {
-				const { data } = await fileService.readFromWorkspace(source.path, projectId);
-				fileInfo = data;
+				fileInfo = await fileService.readFromWorkspace(source.path, projectId);
 			} else if (source.type === "blob") {
 				fileInfo = await fileService.readFromBlob(source.path, projectId, source.blobId);
 			}

--- a/apps/desktop/src/components/test/edit-mode-conflict-states/ConflictStatesHarness.svelte
+++ b/apps/desktop/src/components/test/edit-mode-conflict-states/ConflictStatesHarness.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
 	/**
 	 * Test harness that mirrors the conflict-tracking $effect from
-	 * EditCommitPanel. It reads conflicted files via fileService and
-	 * maintains a reactive conflictStates map, exactly like the real
-	 * component does.
+	 * EditCommitPanel: an effect re-runs refreshConflictStates whenever
+	 * the watched response changes, exactly like the real component does.
 	 */
-	import { getConflictState } from "$lib/files/conflictEntryPresence";
+	import { refreshConflictStates } from "$lib/files/conflictCheck";
 	import { SvelteMap } from "svelte/reactivity";
 	import type { ConflictState } from "$lib/files/conflictEntryPresence";
 	import type { FileService } from "$lib/files/fileService";
@@ -29,15 +28,7 @@
 
 	$effect(() => {
 		void uncommittedResponse;
-
-		for (const file of files) {
-			if (!file.conflictEntryPresence) continue;
-			const presence = file.conflictEntryPresence;
-			const path = file.path;
-			fileService.readFromWorkspace(path, projectId).then((result) => {
-				conflictStates.set(path, getConflictState(presence, result.data.content));
-			});
-		}
+		refreshConflictStates(files, fileService, projectId, conflictStates);
 	});
 </script>
 

--- a/apps/desktop/src/components/test/edit-mode-conflict-states/ConflictStatesHarness.svelte.test.ts
+++ b/apps/desktop/src/components/test/edit-mode-conflict-states/ConflictStatesHarness.svelte.test.ts
@@ -3,7 +3,7 @@ import { render, screen } from "@testing-library/svelte";
 import { tick } from "svelte";
 import { describe, expect, test, vi } from "vitest";
 import type { FileService } from "$lib/files/fileService";
-import type { ConflictEntryPresence } from "@gitbutler/but-sdk";
+import type { ConflictEntryPresence, FileInfo } from "@gitbutler/but-sdk";
 
 const BOTH_SIDES: ConflictEntryPresence = { ancestor: true, ours: true, theirs: true };
 
@@ -17,10 +17,14 @@ function resolvedContent() {
 
 function createFileService(contentByPath: Record<string, string>): FileService {
 	return {
-		readFromWorkspace: vi.fn(async (path: string) => ({
-			data: { content: contentByPath[path] ?? "" },
-			isLarge: false,
-		})),
+		readFromWorkspace: vi.fn(async (path: string): Promise<FileInfo> => {
+			return {
+				content: contentByPath[path] ?? null,
+				fileName: path,
+				size: null,
+				mimeType: null,
+			};
+		}),
 	} as unknown as FileService;
 }
 
@@ -98,7 +102,7 @@ describe("conflict state tracking", () => {
 		expect(fileService.readFromWorkspace).toHaveBeenCalledTimes(2);
 	});
 
-	test("does not re-read when only non-conflicted files change", async () => {
+	test("never reads files without conflict presence, even when the effect re-runs", async () => {
 		const fileService = createFileService({
 			"conflict.txt": conflictContent(),
 		});

--- a/apps/desktop/src/components/workspace/EditCommitPanel.svelte
+++ b/apps/desktop/src/components/workspace/EditCommitPanel.svelte
@@ -5,8 +5,8 @@
 	import EditModeFileListItem from "$components/workspace/EditModeFileListItem.svelte";
 	import { getEditorUri, URL_SERVICE } from "$lib/backend/url";
 	import { splitMessage } from "$lib/commits/commitMessage";
-	import { hasUnresolvedConflictsOnDisk } from "$lib/files/conflictCheck";
-	import { conflictEntryHint, getConflictState } from "$lib/files/conflictEntryPresence";
+	import { hasUnresolvedConflictsOnDisk, refreshConflictStates } from "$lib/files/conflictCheck";
+	import { conflictEntryHint } from "$lib/files/conflictEntryPresence";
 	import { FILE_SERVICE } from "$lib/files/fileService";
 	import { computeChangeStatus } from "$lib/files/fileStatus";
 	import { MODE_SERVICE } from "$lib/mode/modeService";
@@ -135,14 +135,7 @@
 		// Subscribe to uncommittedFiles so we re-read when files change on disk.
 		void uncommittedFiles.response;
 
-		for (const file of files) {
-			if (!file.conflictEntryPresence) continue;
-			const presence = file.conflictEntryPresence;
-			const path = file.path;
-			fileService.readFromWorkspace(path, projectId).then((result) => {
-				conflictStates.set(path, getConflictState(presence, result.data.content));
-			});
-		}
+		refreshConflictStates(files, fileService, projectId, conflictStates);
 	});
 
 	async function abort(force: boolean) {

--- a/apps/desktop/src/components/workspace/EditModeFileListItem.svelte
+++ b/apps/desktop/src/components/workspace/EditModeFileListItem.svelte
@@ -28,8 +28,10 @@
 		oncontextmenu,
 	}: Props = $props();
 
+	// "unknown" counts as conflicted: better to offer "Mark resolved" for a
+	// file we cannot judge than to falsely present it as resolved.
 	const conflicted = $derived(
-		conflictEntryPresence !== undefined && conflictState === "conflicted" && !manuallyResolved,
+		conflictEntryPresence !== undefined && conflictState !== "resolved" && !manuallyResolved,
 	);
 </script>
 

--- a/apps/desktop/src/lib/files/conflictCheck.test.ts
+++ b/apps/desktop/src/lib/files/conflictCheck.test.ts
@@ -1,7 +1,7 @@
 import { hasUnresolvedConflictsOnDisk } from "$lib/files/conflictCheck";
 import { describe, expect, test, vi } from "vitest";
 import type { FileService } from "$lib/files/fileService";
-import type { ConflictEntryPresence } from "@gitbutler/but-sdk";
+import type { ConflictEntryPresence, FileInfo } from "@gitbutler/but-sdk";
 
 const BOTH_SIDES_PRESENT: ConflictEntryPresence = {
 	ancestor: true,
@@ -15,12 +15,16 @@ const OURS_DELETED: ConflictEntryPresence = {
 	theirs: true,
 };
 
-function mockFileService(contentByPath: Record<string, string>): FileService {
+function mockFileService(contentByPath: Record<string, string | null>): FileService {
 	return {
-		readFromWorkspace: vi.fn(async (path: string) => ({
-			data: { content: contentByPath[path] ?? "" },
-			isLarge: false,
-		})),
+		readFromWorkspace: vi.fn(async (path: string): Promise<FileInfo> => {
+			return {
+				content: contentByPath[path] ?? null,
+				fileName: path,
+				size: null,
+				mimeType: null,
+			};
+		}),
 	} as unknown as FileService;
 }
 
@@ -53,6 +57,40 @@ describe("hasUnresolvedConflictsOnDisk", () => {
 		const fileService = mockFileService({
 			"deleted.txt": "clean content\n",
 		});
+
+		const result = await hasUnresolvedConflictsOnDisk(files, new Set(), fileService, "proj");
+
+		expect(result).toBe(true);
+	});
+
+	test("treats unjudgeable content (non-UTF-8/binary) as unresolved", async () => {
+		const files = [
+			{
+				path: "utf16.txt",
+				conflictEntryPresence: BOTH_SIDES_PRESENT,
+			},
+		];
+		const fileService = mockFileService({
+			"utf16.txt": null,
+		});
+
+		const result = await hasUnresolvedConflictsOnDisk(files, new Set(), fileService, "proj");
+
+		expect(result).toBe(true);
+	});
+
+	test("treats a failed read as unresolved instead of throwing", async () => {
+		const files = [
+			{
+				path: "gone.txt",
+				conflictEntryPresence: BOTH_SIDES_PRESENT,
+			},
+		];
+		const fileService = {
+			readFromWorkspace: vi.fn(async () => {
+				throw new Error("file is ignored");
+			}),
+		} as unknown as FileService;
 
 		const result = await hasUnresolvedConflictsOnDisk(files, new Set(), fileService, "proj");
 

--- a/apps/desktop/src/lib/files/conflictCheck.ts
+++ b/apps/desktop/src/lib/files/conflictCheck.ts
@@ -1,4 +1,5 @@
 import { getConflictState } from "$lib/files/conflictEntryPresence";
+import type { ConflictState } from "$lib/files/conflictEntryPresence";
 import type { FileService } from "$lib/files/fileService";
 import type { ConflictEntryPresence } from "@gitbutler/but-sdk";
 
@@ -8,9 +9,35 @@ interface ConflictFile {
 }
 
 /**
+ * Re-reads each conflicted file from disk and records its conflict state
+ * in `states` as the reads land. A file that cannot be read counts as
+ * "unknown" rather than failing the whole refresh.
+ */
+export function refreshConflictStates(
+	files: ConflictFile[],
+	fileService: FileService,
+	projectId: string,
+	states: Map<string, ConflictState>,
+) {
+	for (const file of files) {
+		if (!file.conflictEntryPresence) continue;
+		const presence = file.conflictEntryPresence;
+		const path = file.path;
+		fileService
+			.readFromWorkspace(path, projectId)
+			.then((info) => states.set(path, getConflictState(presence, info)))
+			.catch(() => states.set(path, "unknown"));
+	}
+}
+
+/**
  * Re-reads conflicted files from disk to check whether conflicts are
  * truly unresolved. The reactive UI state can lag behind actual file
  * contents, so this gives an authoritative answer at call time.
+ *
+ * A file whose state cannot be determined (unreadable, non-UTF-8, or
+ * binary content) counts as unresolved; marking it resolved by hand is
+ * how the user overrules that.
  */
 export async function hasUnresolvedConflictsOnDisk(
 	files: ConflictFile[],
@@ -21,9 +48,9 @@ export async function hasUnresolvedConflictsOnDisk(
 	for (const file of files) {
 		if (!file.conflictEntryPresence) continue;
 		if (manuallyResolved.has(file.path)) continue;
-		const result = await fileService.readFromWorkspace(file.path, projectId);
-		const state = getConflictState(file.conflictEntryPresence, result.data.content);
-		if (state === "conflicted") {
+		const info = await fileService.readFromWorkspace(file.path, projectId).catch(() => undefined);
+		const state = getConflictState(file.conflictEntryPresence, info);
+		if (state !== "resolved") {
 			return true;
 		}
 	}

--- a/apps/desktop/src/lib/files/conflictEntryPresence.test.ts
+++ b/apps/desktop/src/lib/files/conflictEntryPresence.test.ts
@@ -1,0 +1,42 @@
+import { getConflictState } from "$lib/files/conflictEntryPresence";
+import { describe, expect, test } from "vitest";
+import type { ConflictEntryPresence, FileInfo } from "@gitbutler/but-sdk";
+
+const BOTH_SIDES: ConflictEntryPresence = { ancestor: true, ours: true, theirs: true };
+
+function fileInfo(content: string | null, mimeType: string | null = null): FileInfo {
+	return { content, fileName: "file.txt", size: null, mimeType };
+}
+
+describe("getConflictState", () => {
+	test("delete/modify conflicts are conflicted regardless of content", () => {
+		const oursDeleted: ConflictEntryPresence = { ancestor: true, ours: false, theirs: true };
+		expect(getConflictState(oursDeleted, fileInfo(null))).toBe("conflicted");
+	});
+
+	test("content with conflict markers is conflicted", () => {
+		expect(getConflictState(BOTH_SIDES, fileInfo("<<<<<<< ours\n=======\n>>>>>>>\n"))).toBe(
+			"conflicted",
+		);
+	});
+
+	test("clean text is resolved", () => {
+		expect(getConflictState(BOTH_SIDES, fileInfo("all good\n"))).toBe("resolved");
+	});
+
+	test("a marker mid-line does not count as conflicted", () => {
+		expect(getConflictState(BOTH_SIDES, fileInfo('const s = "<<<<<<<";\n'))).toBe("resolved");
+	});
+
+	test("null content (non-UTF-8 or binary) is unknown", () => {
+		expect(getConflictState(BOTH_SIDES, fileInfo(null))).toBe("unknown");
+	});
+
+	test("base64 image content is unknown, not scanned as text", () => {
+		expect(getConflictState(BOTH_SIDES, fileInfo("aGVsbG8=", "image/png"))).toBe("unknown");
+	});
+
+	test("a file that could not be read is unknown", () => {
+		expect(getConflictState(BOTH_SIDES, undefined)).toBe("unknown");
+	});
+});

--- a/apps/desktop/src/lib/files/conflictEntryPresence.ts
+++ b/apps/desktop/src/lib/files/conflictEntryPresence.ts
@@ -1,4 +1,4 @@
-import type { ConflictEntryPresence } from "@gitbutler/but-sdk";
+import type { ConflictEntryPresence, FileInfo } from "@gitbutler/but-sdk";
 
 export function emptyConflictEntryPresence(): ConflictEntryPresence {
 	return {
@@ -44,15 +44,17 @@ export type ConflictState = "conflicted" | "resolved" | "unknown";
 
 export function getConflictState(
 	conflictEntryPresence: ConflictEntryPresence,
-	file: string,
+	file: FileInfo | undefined,
 ): ConflictState {
 	if (!conflictEntryPresence.ours || !conflictEntryPresence.theirs) {
 		return "conflicted";
 	}
 
-	if (looksConflicted(file)) {
-		return "conflicted";
+	// No content (the file could not be read or is not valid UTF-8), or
+	// base64 content (mimeType is set): we cannot scan for conflict markers.
+	if (file === undefined || file.content === null || file.mimeType !== null) {
+		return "unknown";
 	}
 
-	return "resolved";
+	return looksConflicted(file.content) ? "conflicted" : "resolved";
 }

--- a/apps/desktop/src/lib/files/file.ts
+++ b/apps/desktop/src/lib/files/file.ts
@@ -1,6 +1,0 @@
-export type FileInfo = {
-	content: string;
-	name?: string;
-	mimeType?: string;
-	size?: number;
-};

--- a/apps/desktop/src/lib/files/fileService.ts
+++ b/apps/desktop/src/lib/files/fileService.ts
@@ -1,7 +1,7 @@
 import { InjectionToken } from "@gitbutler/core/context";
 import type { IBackend } from "$lib/backend";
-import type { FileInfo } from "$lib/files/file";
 import type { BackendApi } from "$lib/state/backendApi";
+import type { FileInfo } from "@gitbutler/but-sdk";
 
 export const FILE_SERVICE = new InjectionToken<FileService>("FileService");
 
@@ -11,15 +11,11 @@ export class FileService {
 		private backendApi: BackendApi,
 	) {}
 
-	async readFromWorkspace(filePath: string, projectId: string) {
-		const data: FileInfo = await this.backend.invoke("get_workspace_file", {
+	async readFromWorkspace(filePath: string, projectId: string): Promise<FileInfo> {
+		return await this.backend.invoke("get_workspace_file", {
 			relativePath: filePath,
 			projectId: projectId,
 		});
-		return {
-			data,
-			isLarge: isLarge(data.size),
-		};
 	}
 
 	async readFromCommit(filePath: string, projectId: string, commitId: string): Promise<FileInfo> {
@@ -60,8 +56,4 @@ export class FileService {
 			limit,
 		});
 	}
-}
-
-function isLarge(size: number | undefined) {
-	return size && size > 5 * 1024 * 1024 ? true : false;
 }


### PR DESCRIPTION
Fixes [GB-1886](https://linear.app/gitbutler/issue/GB-1886/edit-mode-crashes-on-non-utf-8-conflicts-with-cannot-read-properties): since 0.19.8, opening or saving edit mode with a modify/modify conflict on a non-UTF-8 file crashed with `Cannot read properties of null (reading 'split')`.

The backend deliberately returns `content: null` for files it cannot transport as UTF-8, and base64 content (with a `mimeType`) for images. Edit mode fed both straight into conflict-marker scanning: null crashed load and save, and base64 can never match `<<<<<<<`, so image conflicts were silently shown as resolved.

Changes:

- `getConflictState` now takes the whole `FileInfo` and mirrors Lite's classifier: unreadable, null, or base64 content classifies as `unknown`.
- `unknown` counts as unresolved — the file row shows the conflict warning with a "Mark resolved" button, and saving asks for confirmation instead of silently committing files that may still contain conflict markers (git writes real markers into non-UTF-8 text files). This matches Lite and the original edit-mode behavior; marking the file resolved by hand is how the user overrules it.
- A failed workspace read also classifies as `unknown` instead of leaving the save button dead on an unhandled rejection.
- The hand-written desktop `FileInfo` type had drifted from the wire shape (non-null `content`, phantom `name` field) and is deleted in favor of the generated SDK type. `readFromWorkspace` now returns `FileInfo` directly like its siblings — its `{ data, isLarge }` wrapper had no `isLarge` consumers.
- The conflict re-read loop shared by the edit panel and its test harness is extracted into `refreshConflictStates`, so the harness now exercises the shipped code.