### PR TITLE
refactor(tui): introduce `StatusOutputLineData::WorktreeUncommittedChanges`

### DIFF
--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -1834,7 +1834,11 @@ fn print_uncommitted_group(
             Vec::new()
         },
     };
-    output.unstaged_changes(in_lane(depth, [Span::raw("╭┄ ")]), line, cli_id)?;
+    if matches!(cli_id, CliId::Worktree { .. }) {
+        output.uncommitted_changes_in_worktree(in_lane(depth, [Span::raw("╭┄ ")]), line, cli_id)?;
+    } else {
+        output.uncommitted_changes(in_lane(depth, [Span::raw("╭┄ ")]), line, cli_id)?;
+    }
     if !files.is_empty() {
         print_files(
             repo, status_ctx, None, None, files, changes, true, depth, output,

--- a/crates/but/src/command/legacy/status/output.rs
+++ b/crates/but/src/command/legacy/status/output.rs
@@ -99,7 +99,7 @@ impl StatusOutput<'_> {
         )
     }
 
-    pub fn unstaged_changes(
+    pub fn uncommitted_changes(
         &mut self,
         connector: Vec<Span<'static>>,
         line: UncommittedLineContent,
@@ -109,6 +109,21 @@ impl StatusOutput<'_> {
             Some(connector),
             StatusOutputContent::Uncommitted(line),
             StatusOutputLineData::UncommittedChanges {
+                cli_id: Arc::new(id),
+            },
+        )
+    }
+
+    pub fn uncommitted_changes_in_worktree(
+        &mut self,
+        connector: Vec<Span<'static>>,
+        line: UncommittedLineContent,
+        id: CliId,
+    ) -> anyhow::Result<()> {
+        self.push_line(
+            Some(connector),
+            StatusOutputContent::Uncommitted(line),
+            StatusOutputLineData::WorktreeUncommittedChanges {
                 cli_id: Arc::new(id),
             },
         )
@@ -361,6 +376,7 @@ impl StatusOutputLine {
             StatusOutputLineData::StagedChanges { .. }
             | StatusOutputLineData::StagedFile { .. }
             | StatusOutputLineData::UncommittedChanges { .. }
+            | StatusOutputLineData::WorktreeUncommittedChanges { .. }
             | StatusOutputLineData::UncommittedFile { .. }
             | StatusOutputLineData::CommitMessage
             | StatusOutputLineData::MergeBase
@@ -391,6 +407,9 @@ pub enum StatusOutputLineData {
     UncommittedChanges {
         cli_id: Arc<CliId>,
     },
+    WorktreeUncommittedChanges {
+        cli_id: Arc<CliId>,
+    },
     UncommittedFile {
         cli_id: Arc<CliId>,
     },
@@ -419,6 +438,7 @@ impl StatusOutputLineData {
     pub fn cli_id(&self) -> Option<&Arc<CliId>> {
         match self {
             StatusOutputLineData::UncommittedChanges { cli_id }
+            | StatusOutputLineData::WorktreeUncommittedChanges { cli_id }
             | StatusOutputLineData::UncommittedFile { cli_id }
             | StatusOutputLineData::Branch { cli_id, .. }
             | StatusOutputLineData::StagedChanges { cli_id }

--- a/crates/but/src/command/legacy/status/tui/app/branch_mode.rs
+++ b/crates/but/src/command/legacy/status/tui/app/branch_mode.rs
@@ -168,6 +168,7 @@ impl App {
                 outcome.name.shorten().to_string()
             }
             StatusOutputLineData::UncommittedChanges { .. }
+            | StatusOutputLineData::WorktreeUncommittedChanges { .. }
             | StatusOutputLineData::MergeBase
             | StatusOutputLineData::UncommittedFile { .. } => {
                 let mut guard = ctx.exclusive_worktree_access();

--- a/crates/but/src/command/legacy/status/tui/app/cherry_pick_mode.rs
+++ b/crates/but/src/command/legacy/status/tui/app/cherry_pick_mode.rs
@@ -42,10 +42,11 @@ impl ModeRender for CherryPickMode {
             && !self.source.contains(target)
         {
             self.insert_side.into()
-        } else if matches!(data, StatusOutputLineData::Branch { .. }) {
-            ExtensionDirection::Below
-        } else if let StatusOutputLineData::UncommittedChanges { cli_id } = data
-            && let CliId::Worktree { .. } = &**cli_id
+        } else if matches!(data, StatusOutputLineData::Branch { .. })
+            || matches!(
+                data,
+                StatusOutputLineData::WorktreeUncommittedChanges { .. }
+            )
         {
             ExtensionDirection::Below
         } else {

--- a/crates/but/src/command/legacy/status/tui/app/commit_mode.rs
+++ b/crates/but/src/command/legacy/status/tui/app/commit_mode.rs
@@ -77,7 +77,7 @@ impl ModeRender for CommitMode {
     fn operation_extension(&self, data: &StatusOutputLineData) -> Option<OperationExtension<'_>> {
         let is_worktree_heading = matches!(
             data,
-            StatusOutputLineData::UncommittedChanges { cli_id } if matches!(&**cli_id, CliId::Worktree { .. })
+            StatusOutputLineData::WorktreeUncommittedChanges { .. }
         );
         let direction = if matches!(data, StatusOutputLineData::Commit { .. }) {
             self.insert_side.into()

--- a/crates/but/src/command/legacy/status/tui/app/mark.rs
+++ b/crates/but/src/command/legacy/status/tui/app/mark.rs
@@ -865,6 +865,7 @@ fn handle_mark_uncommitted(
             | StatusOutputLineData::StagedChanges { .. }
             | StatusOutputLineData::StagedFile { .. }
             | StatusOutputLineData::UncommittedChanges { .. }
+            | StatusOutputLineData::WorktreeUncommittedChanges { .. }
             | StatusOutputLineData::Branch { .. }
             | StatusOutputLineData::Commit { .. }
             | StatusOutputLineData::CommitMessage

--- a/crates/but/src/command/legacy/status/tui/app/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/app/mod.rs
@@ -1164,6 +1164,7 @@ impl App {
                                     | StatusOutputLineData::StagedChanges { .. }
                                     | StatusOutputLineData::StagedFile { .. }
                                     | StatusOutputLineData::UncommittedChanges { .. }
+                                    | StatusOutputLineData::WorktreeUncommittedChanges { .. }
                                     | StatusOutputLineData::Branch { .. }
                                     | StatusOutputLineData::Commit { .. }
                                     | StatusOutputLineData::CommitMessage
@@ -1500,7 +1501,7 @@ impl App {
                     ReloadCause::Mutation,
                 ));
             }
-            StatusOutputLineData::UncommittedChanges { cli_id } => {
+            StatusOutputLineData::WorktreeUncommittedChanges { cli_id } => {
                 // A worktree heading is the top of its lane, so the empty commit goes to the tip
                 // of the branch checked out there. The main `zz` heading names no branch, so it
                 // stays a no-op.
@@ -1533,6 +1534,7 @@ impl App {
                 ));
             }
             StatusOutputLineData::UpdateNotice
+            | StatusOutputLineData::UncommittedChanges { .. }
             | StatusOutputLineData::Connector
             | StatusOutputLineData::BetweenStacks
             | StatusOutputLineData::StagedChanges { .. }

--- a/crates/but/src/command/legacy/status/tui/app/move_mode.rs
+++ b/crates/but/src/command/legacy/status/tui/app/move_mode.rs
@@ -79,9 +79,10 @@ impl ModeRender for MoveMode {
                     ExtensionDirection::Above
                 },
             })
-        } else if let StatusOutputLineData::UncommittedChanges { cli_id } = data
-            && matches!(&**cli_id, CliId::Worktree { .. })
-        {
+        } else if matches!(
+            data,
+            StatusOutputLineData::WorktreeUncommittedChanges { .. }
+        ) {
             // Below the heading is the top of the worktree's lane, which is where the moved
             // commit goes. A branch source has no place there.
             match &*self.source {
@@ -307,7 +308,7 @@ impl App {
                     return Ok(());
                 }
             }
-            StatusOutputLineData::UncommittedChanges { cli_id } => {
+            StatusOutputLineData::WorktreeUncommittedChanges { cli_id } => {
                 if let CliId::Worktree { name, .. } = &**cli_id {
                     let repo = ctx.repo.get()?;
                     MoveTarget::WorktreeTip(crate::utils::worktrees::worktree_branch(
@@ -320,6 +321,7 @@ impl App {
             }
             StatusOutputLineData::MergeBase => MoveTarget::MergeBase,
             StatusOutputLineData::UpdateNotice
+            | StatusOutputLineData::UncommittedChanges { .. }
             | StatusOutputLineData::Connector
             | StatusOutputLineData::BetweenStacks
             | StatusOutputLineData::StagedChanges { .. }

--- a/crates/but/src/command/legacy/status/tui/app/stack_mode.rs
+++ b/crates/but/src/command/legacy/status/tui/app/stack_mode.rs
@@ -167,7 +167,8 @@ impl FuzzyPickerItem for ApplyBranchItem {
 
 fn line_uses_top_stack_for_stack_mode(line: &StatusOutputLine) -> bool {
     match &line.data {
-        StatusOutputLineData::UncommittedChanges { .. } => true,
+        StatusOutputLineData::UncommittedChanges { .. }
+        | StatusOutputLineData::WorktreeUncommittedChanges { .. } => true,
         StatusOutputLineData::UncommittedFile { cli_id }
         | StatusOutputLineData::StagedFile { cli_id }
         | StatusOutputLineData::File { cli_id } => {
@@ -221,6 +222,7 @@ fn stack_id_for_line(
         | StatusOutputLineData::Connector
         | StatusOutputLineData::BetweenStacks
         | StatusOutputLineData::UncommittedChanges { .. }
+        | StatusOutputLineData::WorktreeUncommittedChanges { .. }
         | StatusOutputLineData::CommitMessage
         | StatusOutputLineData::EmptyCommitMessage
         | StatusOutputLineData::MergeBase
@@ -268,6 +270,7 @@ fn stack_id_for_cli_id(cli_id: &CliId, status_lines: &[StatusOutputLine]) -> Opt
                 | StatusOutputLineData::StagedChanges { .. }
                 | StatusOutputLineData::StagedFile { .. }
                 | StatusOutputLineData::UncommittedChanges { .. }
+                | StatusOutputLineData::WorktreeUncommittedChanges { .. }
                 | StatusOutputLineData::UncommittedFile { .. }
                 | StatusOutputLineData::Branch { .. }
                 | StatusOutputLineData::CommitMessage

--- a/crates/but/src/command/legacy/status/tui/cursor/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/cursor/mod.rs
@@ -489,6 +489,7 @@ impl Cursor {
                 StatusOutputLineData::Commit { .. }
                 | StatusOutputLineData::Branch { .. }
                 | StatusOutputLineData::StagedChanges { .. }
+                | StatusOutputLineData::WorktreeUncommittedChanges { .. }
                 | StatusOutputLineData::UncommittedChanges { .. } => line.data.cli_id(),
                 StatusOutputLineData::UpdateNotice
                 | StatusOutputLineData::Connector
@@ -904,6 +905,7 @@ fn is_discard_commit_boundary(line: &StatusOutputLine) -> bool {
         StatusOutputLineData::Branch { .. }
         | StatusOutputLineData::StagedChanges { .. }
         | StatusOutputLineData::UncommittedChanges { .. }
+        | StatusOutputLineData::WorktreeUncommittedChanges { .. }
         | StatusOutputLineData::MergeBase => true,
         StatusOutputLineData::UpdateNotice
         | StatusOutputLineData::Connector
@@ -941,6 +943,7 @@ fn is_section_header(line: &StatusOutputLine, mode: &Mode) -> bool {
                 line.data,
                 StatusOutputLineData::Branch { .. }
                     | StatusOutputLineData::UncommittedChanges { .. }
+                    | StatusOutputLineData::WorktreeUncommittedChanges { .. }
                     | StatusOutputLineData::MergeBase
             )
         }
@@ -1058,6 +1061,7 @@ pub fn is_selectable_in_mode(
                 if !matches!(
                     &line.data,
                     StatusOutputLineData::UncommittedChanges { .. }
+                        | StatusOutputLineData::WorktreeUncommittedChanges { .. }
                         | StatusOutputLineData::UncommittedFile { .. },
                 ) {
                     return false;

--- a/crates/but/src/command/legacy/status/tui/cursor/tests.rs
+++ b/crates/but/src/command/legacy/status/tui/cursor/tests.rs
@@ -37,6 +37,13 @@ fn uncommitted_area(id: &str) -> Arc<CliId> {
     Arc::new(CliId::Uncommitted { id: id.into() })
 }
 
+fn worktree_area(name: &str, id: &str) -> Arc<CliId> {
+    Arc::new(CliId::Worktree {
+        id: id.into(),
+        name: name.into(),
+    })
+}
+
 fn commit_id(hex: &str) -> CommitId {
     CommitId {
         commit_id: gix::ObjectId::from_hex(hex.as_bytes()).unwrap(),
@@ -1664,6 +1671,49 @@ fn move_next_section_moves_to_next_jump_target() {
 }
 
 #[test]
+fn section_navigation_stops_on_worktree_headings() {
+    let lines = vec![
+        branch_line("main", "b0"),
+        line(StatusOutputLineData::Commit {
+            cli_id: commit_cli_id("1111111111111111111111111111111111111111", "c0"),
+            stack_id: None,
+            classification: CommitClassification::LocalOnly,
+        }),
+        line(StatusOutputLineData::WorktreeUncommittedChanges {
+            cli_id: worktree_area("worktree", "w0"),
+        }),
+        uncommitted_file_line("worktree-file", "u0"),
+        branch_line("other", "b1"),
+    ];
+
+    let cursor = Cursor(0)
+        .move_next_section(
+            &lines,
+            &Mode::Normal(NormalMode::default()),
+            FilesStatusFlag::All,
+        )
+        .expect("the worktree heading is the next section");
+    assert_eq!(
+        cursor,
+        Cursor(2),
+        "next-section navigation stops on the worktree heading"
+    );
+
+    let cursor = Cursor(4)
+        .move_previous_section(
+            &lines,
+            &Mode::Normal(NormalMode::default()),
+            FilesStatusFlag::All,
+        )
+        .expect("the worktree heading is the previous section");
+    assert_eq!(
+        cursor,
+        Cursor(2),
+        "previous-section navigation stops on the worktree heading"
+    );
+}
+
+#[test]
 fn move_next_section_does_not_move_when_no_jump_target_below() {
     let lines = vec![
         line(StatusOutputLineData::UncommittedChanges {
@@ -2013,6 +2063,22 @@ fn move_stack_skips_noop_target_below_source() {
     assert_eq!(
         Cursor(3).move_down(&lines, &mode, FilesStatusFlag::All),
         Some(Cursor(6))
+    );
+}
+
+#[test]
+fn worktree_heading_remains_selectable_with_uncommitted_marks() {
+    let marked_file = uncommitted_file_line("marked.txt", "u0");
+    let mode = Mode::Normal(NormalMode {
+        marks: marks([markable(marked_file.data.cli_id().unwrap())]),
+    });
+    let worktree_heading = line(StatusOutputLineData::WorktreeUncommittedChanges {
+        cli_id: worktree_area("worktree", "w0"),
+    });
+
+    assert!(
+        is_selectable_in_mode(&worktree_heading, mode.as_ref(), FilesStatusFlag::All,),
+        "linked-worktree headings remain selectable while uncommitted changes are marked",
     );
 }
 

--- a/crates/but/src/command/legacy/status/tui/render.rs
+++ b/crates/but/src/command/legacy/status/tui/render.rs
@@ -431,6 +431,7 @@ fn row_stack_ids(lines: &[StatusOutputLine]) -> Vec<Option<StackId>> {
             },
             StatusOutputLineData::UpdateNotice
             | StatusOutputLineData::UncommittedChanges { .. }
+            | StatusOutputLineData::WorktreeUncommittedChanges { .. }
             | StatusOutputLineData::UncommittedFile { .. }
             | StatusOutputLineData::MergeBase
             | StatusOutputLineData::UpstreamChanges
@@ -1228,9 +1229,7 @@ pub fn commit_operation_display(
         // A linked worktree's heading doubles as the top of its lane, which is the only place a
         // commit made from that checkout can go. Scoping to a stack excludes it, as a worktree
         // branch is by definition outside the workspace.
-        StatusOutputLineData::UncommittedChanges { cli_id }
-            if matches!(&**cli_id, CliId::Worktree { .. }) =>
-        {
+        StatusOutputLineData::WorktreeUncommittedChanges { .. } => {
             scope_to_stack.is_none().then_some("commit to worktree")
         }
         StatusOutputLineData::StagedChanges { .. }
@@ -1268,9 +1267,7 @@ pub fn move_operation_display(
             StatusOutputLineData::Branch { .. } => Some("move commit to branch"),
             // A linked worktree's heading doubles as the top of its lane, which is the only
             // place in the lane a whole commit can move to.
-            StatusOutputLineData::UncommittedChanges { cli_id }
-                if matches!(&**cli_id, CliId::Worktree { .. }) =>
-            {
+            StatusOutputLineData::WorktreeUncommittedChanges { .. } => {
                 Some("move commit to worktree")
             }
             StatusOutputLineData::UpdateNotice
@@ -1303,9 +1300,7 @@ pub fn move_operation_display(
                     Some("move commits to branch")
                 }
             }
-            StatusOutputLineData::UncommittedChanges { cli_id }
-                if matches!(&**cli_id, CliId::Worktree { .. }) =>
-            {
+            StatusOutputLineData::WorktreeUncommittedChanges { .. } => {
                 if marks.len() == 1 {
                     Some("move commit to worktree")
                 } else {
@@ -1338,6 +1333,7 @@ pub fn move_operation_display(
             | StatusOutputLineData::StagedChanges { .. }
             | StatusOutputLineData::StagedFile { .. }
             | StatusOutputLineData::UncommittedChanges { .. }
+            | StatusOutputLineData::WorktreeUncommittedChanges { .. }
             | StatusOutputLineData::UncommittedFile { .. }
             | StatusOutputLineData::CommitMessage
             | StatusOutputLineData::EmptyCommitMessage
@@ -1361,6 +1357,7 @@ pub fn reorder_operation_display(
         | StatusOutputLineData::StagedChanges { .. }
         | StatusOutputLineData::StagedFile { .. }
         | StatusOutputLineData::UncommittedChanges { .. }
+        | StatusOutputLineData::WorktreeUncommittedChanges { .. }
         | StatusOutputLineData::UncommittedFile { .. }
         | StatusOutputLineData::Branch { .. }
         | StatusOutputLineData::Commit { .. }
@@ -1397,6 +1394,7 @@ pub fn stack_operation_display(
         | StatusOutputLineData::StagedChanges { .. }
         | StatusOutputLineData::StagedFile { .. }
         | StatusOutputLineData::UncommittedChanges { .. }
+        | StatusOutputLineData::WorktreeUncommittedChanges { .. }
         | StatusOutputLineData::UncommittedFile { .. }
         | StatusOutputLineData::Commit { .. }
         | StatusOutputLineData::CommitMessage
@@ -1421,14 +1419,9 @@ pub fn cherry_pick_operation_display(
             InsertSide::Above => Some("pick above"),
             InsertSide::Below => Some("pick below"),
         },
-        StatusOutputLineData::UncommittedChanges { cli_id } => {
-            if let CliId::Worktree { .. } = &**cli_id {
-                Some("pick to worktree")
-            } else {
-                None
-            }
-        }
+        StatusOutputLineData::WorktreeUncommittedChanges { .. } => Some("pick to worktree"),
         StatusOutputLineData::UpdateNotice
+        | StatusOutputLineData::UncommittedChanges { .. }
         | StatusOutputLineData::Connector
         | StatusOutputLineData::BetweenStacks
         | StatusOutputLineData::StagedChanges { .. }
@@ -1451,6 +1444,7 @@ pub fn branch_operation_display(
 ) -> Option<&'static str> {
     match data {
         StatusOutputLineData::UncommittedChanges { .. }
+        | StatusOutputLineData::WorktreeUncommittedChanges { .. }
         | StatusOutputLineData::Branch { .. }
         | StatusOutputLineData::MergeBase => Some("branch"),
         StatusOutputLineData::UpdateNotice

--- a/crates/but/src/command/legacy/status/tui/tests/worktree_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/worktree_tests.rs
@@ -25,14 +25,13 @@ fn worktree_tui() -> (TestTui<App>, String) {
     )
     .expect("app data dir is writable");
     let editor_command = format!("sh {}", editor_script.display());
-    let mut tui = test_status_tui_with_options(
+    let tui = test_status_tui_with_options(
         env,
         TestTuiOptions {
             worktree_manipulation: true,
             ..Default::default()
         },
     );
-    tui.reload();
     (tui, editor_command)
 }
 


### PR DESCRIPTION
I think its a footgun that both `StatusOutputLineData::UncommittedChanges`
could point at both uncommitted changes and worktree changes.