### PR TITLE
Allow opting out of agent skill notices

### DIFF
--- a/crates/but-settings/assets/defaults.jsonc
+++ b/crates/but-settings/assets/defaults.jsonc
@@ -3,6 +3,8 @@
 	"contextLines": 3,
 	// Whether the user has passed the onboarding flow.
 	"onboardingComplete": false,
+	// Whether the CLI shows agent skill installation and freshness notices.
+	"agentSkillNotices": true,
 	"telemetry": {
 		// Whether the anonymous metrics are enabled.
 		"appMetricsEnabled": true,

--- a/crates/but-settings/src/lib.rs
+++ b/crates/but-settings/src/lib.rs
@@ -7,6 +7,8 @@ pub struct AppSettings {
     pub context_lines: u32,
     /// Whether the user has passed the onboarding flow.
     pub onboarding_complete: bool,
+    /// Whether the CLI shows agent skill installation and freshness notices.
+    pub agent_skill_notices: bool,
     /// Telemetry settings
     pub telemetry: app_settings::TelemetrySettings,
     /// Client ID for the GitHub OAuth application.

--- a/crates/but-testsupport/src/sandbox.rs
+++ b/crates/but-testsupport/src/sandbox.rs
@@ -494,6 +494,7 @@ impl Sandbox {
         let settings = AppSettings {
             context_lines: 3,
             onboarding_complete: true,
+            agent_skill_notices: true,
             telemetry: TelemetrySettings {
                 app_metrics_enabled: false,
                 app_error_reporting_enabled: false,

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -555,7 +555,8 @@ async fn match_subcommand(
                 | Subcommands::Completions { .. }
                 | Subcommands::Metrics { .. }
         );
-    let show_agent_skill_notice = out.format().is_human_text() && notice_worthy_command;
+    let show_agent_skill_notice =
+        app_settings.agent_skill_notices && out.format().is_human_text() && notice_worthy_command;
     let agent_skill_notice = show_agent_skill_notice
         .then(|| command::skill::agent_skill_notice(&args.current_dir))
         .flatten();
@@ -1563,7 +1564,12 @@ async fn match_subcommand(
             let result = command::legacy::resolve::handle(&mut ctx, out, cmd, targets, ai)
                 .context("Failed to handle conflict resolution.");
             if result.is_ok() {
-                run_status_after_if_requested(status_after, &mut ctx, out);
+                run_status_after_if_requested(
+                    status_after,
+                    app_settings.agent_skill_notices,
+                    &mut ctx,
+                    out,
+                );
             }
             result
                 .emit_metrics(metrics_ctx)
@@ -1693,7 +1699,12 @@ async fn match_subcommand(
     }
     #[cfg(feature = "legacy")]
     if let Some(status_after) = status_after_data {
-        run_status_after_if_requested(status_after, &mut ctx, out);
+        run_status_after_if_requested(
+            status_after,
+            app_settings.agent_skill_notices,
+            &mut ctx,
+            out,
+        );
     }
 
     Ok(())
@@ -1746,11 +1757,13 @@ fn is_not_in_git_repository_error(err: &anyhow::Error) -> bool {
 #[cfg(feature = "legacy")]
 fn run_status_after_if_requested(
     status_after: bool,
+    agent_skill_notices: bool,
     ctx: &mut but_ctx::Context,
     out: &mut OutputChannel,
 ) {
     if !status_after {
-        if out.is_json()
+        if agent_skill_notices
+            && out.is_json()
             && let Some(notice) = command::skill::agent_skill_update_notice()
         {
             eprintln!("{notice}");
@@ -1758,7 +1771,7 @@ fn run_status_after_if_requested(
         return;
     }
     let mutation_json = out.take_json_buffer();
-    run_status_after(ctx, out, mutation_json);
+    run_status_after(agent_skill_notices, ctx, out, mutation_json);
 }
 
 /// Run workspace status output after a mutation command when explicitly requested.
@@ -1775,15 +1788,14 @@ fn run_status_after_if_requested(
 /// a warning is printed to stderr.
 #[cfg(feature = "legacy")]
 fn run_status_after(
+    agent_skill_notices: bool,
     ctx: &mut but_ctx::Context,
     out: &mut OutputChannel,
     mutation_json: Option<serde_json::Value>,
 ) {
     use crate::command::legacy::status::StatusFlags;
 
-    let agent_skill_notice = out
-        .format()
-        .is_json()
+    let agent_skill_notice = (agent_skill_notices && out.format().is_json())
         .then(command::skill::agent_skill_update_notice)
         .flatten();
 

--- a/crates/but/tests/but/command/skill.rs
+++ b/crates/but/tests/but/command/skill.rs
@@ -8,6 +8,17 @@ fn relative_agent_skill_path(agent_dir: &str) -> std::path::PathBuf {
         .join("gitbutler")
 }
 
+#[cfg(feature = "legacy")]
+fn disable_agent_skill_notices(env: &Sandbox) {
+    let settings_path = env.app_data_dir().join("gitbutler/settings.json");
+    let mut settings: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(&settings_path).expect("settings were written"),
+    )
+    .expect("settings are valid JSON");
+    settings["agentSkillNotices"] = false.into();
+    std::fs::write(settings_path, settings.to_string()).expect("settings are writable");
+}
+
 fn path_ends_with_gitbutler_agents_dir(path: &str) -> bool {
     let normalized = path.replace('\\', "/");
     normalized.ends_with("/.agents/skills/gitbutler")
@@ -164,6 +175,72 @@ fn agent_skill_notice_gating() {
         String::from_utf8_lossy(&failed.stdout).starts_with("⚠ AGENT ACTION REQUIRED"),
         "failed normal commands receive the same pre-dispatch notice"
     );
+}
+
+#[test]
+#[cfg(feature = "legacy")]
+fn agent_skill_notices_can_be_disabled_in_persisted_settings() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
+
+    disable_agent_skill_notices(&env);
+
+    for _ in 0..2 {
+        env.but("status")
+            .env("AI_AGENT", "codex")
+            .assert()
+            .success()
+            // Repeated status output remains normal while notices are disabled.
+            .stdout_eq(snapbox::str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: commits are listed newest first. The first token on each line is the ID to use in commands.
+Hint: run `but branch new` to create a new branch to work on
+
+"#]]);
+    }
+
+    env.but("alias list")
+        .env("AI_AGENT", "codex")
+        .assert()
+        .success()
+        // Other notice-worthy human commands also retain their normal output.
+        .stdout_eq(snapbox::str![[r#"
+Default aliases (overridable):
+
+  default  →  status
+  st       →  status
+  stf      →  status --files
+  c        →  commit
+  s        →  squash
+  m        →  move
+  wt       →  worktree
+
+"#]]);
+
+    env.but("--json alias list")
+        .env("AI_AGENT", "codex")
+        .allow_json()
+        .assert()
+        .success()
+        // JSON output keeps its existing command-specific shape.
+        .stdout_eq(snapbox::str![[r#"
+{
+  "user": [],
+  "default": {
+    "default": "status",
+    "st": "status",
+    "stf": "status --files",
+    "c": "commit",
+    "s": "squash",
+    "m": "move",
+    "wt": "worktree"
+  }
+}
+
+"#]]);
 }
 
 #[test]
@@ -368,7 +445,8 @@ fn json_agent_command_repairs_stale_global_skill_without_wrapping_stdout() {
 
     let claude_skill_path = env.home_dir().join(".claude/skills/gitbutler/SKILL.md");
     let expected = std::fs::read_to_string(&claude_skill_path).unwrap();
-    std::fs::write(&claude_skill_path, "---\nname: but\nversion: old\n---\n").unwrap();
+    let stale_skill = "---\nname: but\nversion: old\n---\n";
+    std::fs::write(&claude_skill_path, stale_skill).unwrap();
     env.file("file.txt", "Some text");
 
     let output = env
@@ -398,6 +476,59 @@ fn json_agent_command_repairs_stale_global_skill_without_wrapping_stdout() {
         std::fs::read_to_string(&claude_skill_path).unwrap(),
         expected,
         "a JSON agent command should still refresh other agents' global skill installations"
+    );
+
+    disable_agent_skill_notices(&env);
+    std::fs::write(&claude_skill_path, stale_skill).unwrap();
+    env.file("another-file.txt", "More text");
+
+    let output = env
+        .but("commit --no-message --json --status-after")
+        .env("AI_AGENT", "codex")
+        .allow_json()
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "the opted-out JSON mutation succeeds"
+    );
+    let stdout: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert!(
+        stdout.get("status").is_some() && stdout.get("agent_skill_notice").is_none(),
+        "the opted-out JSON result includes status without a skill notice: {stdout}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&claude_skill_path).unwrap(),
+        stale_skill,
+        "disabling notices also skips the freshness work that produces them"
+    );
+
+    env.file("third-file.txt", "Even more text");
+    let output = env
+        .but("commit --no-message --json")
+        .env("AI_AGENT", "codex")
+        .allow_json()
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "the opted-out JSON mutation without status-after succeeds"
+    );
+    let stdout: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert!(
+        stdout.get("commitId").is_some()
+            && stdout.get("changeId").is_some()
+            && stdout.get("status").is_none(),
+        "the opted-out JSON mutation remains native: {stdout}"
+    );
+    assert!(
+        !String::from_utf8_lossy(&output.stderr).contains("was out of date and was updated"),
+        "the opted-out JSON mutation must not emit a freshness notice"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&claude_skill_path).unwrap(),
+        stale_skill,
+        "the no-status-after path must also skip skill freshness work"
     );
 }
 

--- a/packages/but-sdk/src/generated/graph/index.d.ts
+++ b/packages/but-sdk/src/generated/graph/index.d.ts
@@ -1507,6 +1507,8 @@ export type AppSettings = {
   contextLines: number;
   /** Whether the user has passed the onboarding flow. */
   onboardingComplete: boolean;
+  /** Whether the CLI shows agent skill installation and freshness notices. */
+  agentSkillNotices: boolean;
   /** Telemetry settings */
   telemetry: TelemetrySettings;
   /** Client ID for the GitHub OAuth application. */

--- a/packages/but-sdk/src/generated/linear/index.d.ts
+++ b/packages/but-sdk/src/generated/linear/index.d.ts
@@ -1507,6 +1507,8 @@ export type AppSettings = {
   contextLines: number;
   /** Whether the user has passed the onboarding flow. */
   onboardingComplete: boolean;
+  /** Whether the CLI shows agent skill installation and freshness notices. */
+  agentSkillNotices: boolean;
   /** Telemetry settings */
   telemetry: TelemetrySettings;
   /** Client ID for the GitHub OAuth application. */


### PR DESCRIPTION
## Context

A custom GitButler skill workflow under an AI agent still triggers repeated official install notices. The repeated warning makes agents install the official skill or abandon the custom read-only workflow. The default warning and JSON behavior remain unchanged for users who do not opt out. Related public history: https://github.com/gitbutlerapp/gitbutler/pull/15167

## Change

Add a hidden persisted `agentSkillNotices` setting. It defaults to `true`; setting it to `false` suppresses human skill installation and freshness notices.

FYI @PavelLaptev