### PR TITLE
Lite UI fixes: keyboard keys, textarea padding, menu label

### DIFF
--- a/apps/lite/package.json
+++ b/apps/lite/package.json
@@ -136,7 +136,7 @@
 		"@base-ui/react": "^1.6.0",
 		"@base-ui/utils": "^0.3.1",
 		"@gitbutler/but-sdk": "workspace:*",
-		"@gitbutler/design-core": "3.12.5",
+		"@gitbutler/design-core": "3.13.2",
 		"@pierre/diffs": "^1.3.5",
 		"@pierre/theming": "^1.0.1",
 		"@reduxjs/toolkit": "catalog:redux",

--- a/apps/lite/ui/src/components/Field.module.css
+++ b/apps/lite/ui/src/components/Field.module.css
@@ -40,7 +40,8 @@
 
 .fieldControlTextarea {
 	height: auto;
-	padding-block: 6px;
+	padding-inline: 12px;
+	padding-block: 12px;
 	field-sizing: content;
 	min-height: 6lh;
 	max-height: 20lh;

--- a/apps/lite/ui/src/components/FocusScopeKbd.module.css
+++ b/apps/lite/ui/src/components/FocusScopeKbd.module.css
@@ -2,7 +2,11 @@
 	display: flex;
 }
 
+/* Fixed square, so the base key's padding would only fight it: zero it out and
+   let `align-content` center the trimmed cap-height box in the 15px height. */
 .key {
+	align-content: center;
 	width: 15px;
 	height: 15px;
+	padding: 0;
 }

--- a/apps/lite/ui/src/components/Kbd.module.css
+++ b/apps/lite/ui/src/components/Kbd.module.css
@@ -5,24 +5,23 @@
 }
 
 .key {
-	--outline-color: light-dark(
-		color-mix(in srgb, var(--text-1) 10%, transparent),
-		color-mix(in srgb, var(--text-1) 20%, transparent)
-	);
-	display: inline-flex;
+	--outline-color: color-mix(in srgb, var(--text-1) 16%, transparent);
+	/* Not a flex container: `text-box-trim` applies only to block containers and
+	   inline boxes, so a bare text child of a flex box lands in an anonymous item
+	   we cannot target. The parent `.keys` still centers the cap-height box. */
+	display: block;
 	position: relative;
-	align-items: center;
-	justify-content: center;
-	padding: 2px 3px;
+	min-width: 14px;
+	padding: 4px 3px;
 	border-radius: var(--radius-xs);
-	background-color: var(--bg-1);
-	box-shadow:
-		0 1px 3px 0 rgba(0, 0, 0, 0.18),
-		0 0 0 1px var(--outline-color);
+	background-color: color-mix(in srgb, var(--scale-gray-60) 5%, transparent);
+	box-shadow: 0 0 0 1px var(--outline-color);
 	color: color-mix(in srgb, var(--text-1) 60%, transparent);
 	font-size: 11px;
 	line-height: 1.2;
 	font-family: inherit;
+	text-box: trim-both cap alphabetic;
+	text-align: center;
 	white-space: nowrap;
 }
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/useStackMenuItems.test.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/useStackMenuItems.test.tsx
@@ -47,7 +47,7 @@ const stack = { id: "stack-id", base: null, segments: [] } as Stack;
 const Probe: FC = () => {
 	const unapply = useStackMenuItems(projectId, stack).find(
 		(item): item is Extract<NativeMenuItem, { _tag: "Item" }> =>
-			item._tag === "Item" && item.label === "Unapply Whole Stack",
+			item._tag === "Item" && item.label === "Unapply Stack",
 	);
 	return <output data-enabled={String(unapply?.enabled)} />;
 };

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/useStackMenuItems.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/useStackMenuItems.ts
@@ -81,7 +81,7 @@ export const useStackMenuItems = (projectId: string, stack: Stack): Array<Native
 			},
 		}),
 		nativeMenuItem({
-			label: "Unapply Whole Stack",
+			label: "Unapply Stack",
 			enabled: isOpenWorkspace === true && noOperationPending && !isUnapplyStackPending,
 			onSelect: () => {
 				// In the future we should have an unapply API that doesn't require an ID.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -423,8 +423,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/but-sdk
       '@gitbutler/design-core':
-        specifier: 3.12.5
-        version: 3.12.5
+        specifier: 3.13.2
+        version: 3.13.2
       '@pierre/diffs':
         specifier: ^1.3.5
         version: 1.3.5(@shikijs/themes@4.3.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -2063,8 +2063,8 @@ packages:
   '@gitbutler/design-core@2.2.2':
     resolution: {integrity: sha512-oPPnYjwsKxwoTY6wK/fT9ylwhSIBgQxCOGJzYefbM8WFr2OuJePH9MnDnZ3K9UQlb94p+NR7m/QCFzhbDVRwxw==}
 
-  '@gitbutler/design-core@3.12.5':
-    resolution: {integrity: sha512-gLUlsSj9HayNxADej97RMK7TvySo5we025/AfA3F/dmqZJcl2+s0srHqkrMOc6v6NoLbS5yBgoa2/49ORqQ4Dw==}
+  '@gitbutler/design-core@3.13.2':
+    resolution: {integrity: sha512-YJngSkGzpoWBQFw2R9a4efl6d2m8x6rZKeuSYWsjQK6TKpYR0oPuA6WF2BY+t7atCgEgZ8GienThZzM2qSPBow==}
 
   '@gitbutler/design-core@3.9.1':
     resolution: {integrity: sha512-kLkZ1+pqeqpBntBOSV53kYVCmY/ZFemjxsWc78GTGLgn1Op8p7bWCNxCUSU822MKLJrzmjUg99MpqdHpXGcNAQ==}
@@ -6639,7 +6639,6 @@ packages:
   eslint@9.39.5:
     resolution: {integrity: sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -11393,7 +11392,7 @@ snapshots:
 
   '@gitbutler/design-core@2.2.2': {}
 
-  '@gitbutler/design-core@3.12.5': {}
+  '@gitbutler/design-core@3.13.2': {}
 
   '@gitbutler/design-core@3.9.1': {}
 


### PR DESCRIPTION

A few small UI corrections in Lite, plus a design-core bump.

- **Keyboard keys**: `text-box-trim` on `.key` was inert because the element was `inline-flex` — the declaration only applies to block containers and inline boxes, and the text child landed in an untargetable anonymous flex item. The key is now a block centered with `text-align`; `.keys` still handles vertical centering. `FocusScopeKbd` pins its key to a fixed 15px square where the base padding fought the trimmed cap-height box, so padding is zeroed there and the glyph is centered with `align-content`. The key face is also restyled: flat tinted background and a single outline ring instead of the drop shadow, with a `min-width` so single glyphs stay square-ish.
- **Textarea padding**: the textarea was inheriting the single-line input's 8px inline / 6px block padding; the design specifies 12px on every edge.
- **Stack menu label**: "Unapply Whole Stack" → "Unapply Stack" (test expectation updated alongside).
- **Dependency**: bump `@gitbutler/design-core` 3.12.5 → 3.13.2 in the Lite app.

No behavior changes beyond the styling and the menu wording.