### PR TITLE
Fix worktree-status failures on overlapping staged and unstaged changes

### DIFF
--- a/crates/but-core/src/diff/worktree.rs
+++ b/crates/but-core/src/diff/worktree.rs
@@ -1,4 +1,4 @@
-use std::{io::Read, path::PathBuf};
+use std::{collections::BTreeMap, io::Read, path::PathBuf};
 
 use anyhow::{Context as _, bail};
 use bstr::{BStr, BString, ByteSlice, ByteVec};
@@ -496,107 +496,112 @@ fn worktree_changes_inner(
         }
     }
 
-    // Pairing and merge order decide the output, and gix emits index/worktree status in
-    // thread-pool completion order, so sort both sides by path to stay deterministic.
-    tree_index_changes.sort_unstable_by(|a, b| a.path.cmp(&b.path));
-    index_worktree_changes.sort_unstable_by(|a, b| a.path.cmp(&b.path));
-    let mut rename_sources_by_path: Vec<(&BStr, usize)> = tree_index_changes
+    // gix emits index/worktree status in thread-pool completion order; sort to make claims
+    // deterministic. Deletions go first as merging them can put a freed path back on the
+    // claim map, and additions last so they can claim any path freed before them — which
+    // also keeps a recreated rename source from claiming a rename away from the change
+    // that continues its destination.
+    index_worktree_changes.sort_unstable_by(|a, b| {
+        let rank = |change: &TreeChange| match change.status {
+            TreeStatus::Deletion { .. } => 0,
+            TreeStatus::Modification { .. } | TreeStatus::Rename { .. } => 1,
+            TreeStatus::Addition { .. } => 2,
+        };
+        rank(a).cmp(&rank(b)).then_with(|| a.path.cmp(&b.path))
+    });
+    let mut rename_dest_by_source: Vec<(BString, BString)> = tree_index_changes
         .iter()
-        .enumerate()
-        .filter_map(|(idx, change)| change.previous_path().map(|path| (path, idx)))
+        .filter_map(|change| {
+            change
+                .previous_path()
+                .map(|source| (source.to_owned(), change.path.clone()))
+        })
         .collect();
-    rename_sources_by_path.sort_unstable();
+    rename_dest_by_source.sort_unstable();
+    let mut tree_index_by_path: BTreeMap<BString, TreeChange> = tree_index_changes
+        .into_iter()
+        .map(|change| (change.path.clone(), change))
+        .collect();
 
     let mut changes =
-        Vec::<TreeChange>::with_capacity(tree_index_changes.len() + index_worktree_changes.len());
-    let mut partners: Vec<Option<TreeChange>> = tree_index_changes.iter().map(|_| None).collect();
-    // Pair each index/worktree change with the tree/index change that describes the same file.
-    // An index/worktree change at a tree/index change's own path continues that index entry,
-    // so those pairs form first; only afterwards may an untracked file claim the source path
-    // a tree/index rename left behind.
-    let mut source_path_claimants = Vec::new();
-    for index_wt_change in index_worktree_changes {
-        let claimed = [
-            index_wt_change.previous_path(),
-            Some(index_wt_change.path.as_bstr()),
-        ]
-        .into_iter()
-        .flatten()
-        .find_map(|path| {
-            tree_index_changes
-                .binary_search_by(|change| change.path.as_bstr().cmp(path))
-                .ok()
-        })
-        .filter(|&idx| partners[idx].is_none());
-        match claimed {
-            Some(idx) => partners[idx] = Some(index_wt_change),
-            None => source_path_claimants.push(index_wt_change),
-        }
-    }
-    for index_wt_change in source_path_claimants {
-        let claimed = rename_sources_by_path
-            .binary_search_by(|(source, _)| (*source).cmp(index_wt_change.path.as_bstr()))
-            .ok()
-            .map(|pos| rename_sources_by_path[pos].1)
-            .filter(|&idx| partners[idx].is_none());
-        match claimed {
-            Some(idx) => partners[idx] = Some(index_wt_change),
-            None => changes.push(index_wt_change),
-        }
-    }
-
+        Vec::<TreeChange>::with_capacity(tree_index_by_path.len() + index_worktree_changes.len());
     let (mut filter, index) = repo.filter_pipeline(None)?;
     let mut path_check = gix::status::plumbing::SymlinkCheck::new(
         repo.workdir().map(ToOwned::to_owned).context("non-bare")?,
     );
-    let mut deferred_deletions = Vec::new();
-    for (tree_index_change, index_wt_change) in tree_index_changes.into_iter().zip(partners) {
-        let Some(index_wt_change) = index_wt_change else {
-            if matches!(tree_index_change.status, TreeStatus::Deletion { .. }) {
-                deferred_deletions.push(tree_index_change);
-            } else {
-                changes.push(tree_index_change);
+    for index_wt_change in index_worktree_changes {
+        // Claim the tree/index change this one continues: the entry at its index-side path,
+        // or for an untracked file, the rename that left its path behind. A claim removes
+        // the entry, so every tree/index change merges at most once.
+        let index_side_path = index_wt_change
+            .previous_path()
+            .unwrap_or(index_wt_change.path.as_bstr());
+        let claimed = match tree_index_by_path.remove(index_side_path) {
+            Some(tree_index_change) => Some(tree_index_change),
+            None if matches!(
+                index_wt_change.status,
+                TreeStatus::Addition {
+                    is_untracked: true,
+                    ..
+                }
+            ) =>
+            {
+                rename_dest_by_source
+                    .binary_search_by(|(source, _)| {
+                        source.as_bstr().cmp(index_wt_change.path.as_bstr())
+                    })
+                    .ok()
+                    .and_then(|pos| tree_index_by_path.remove(&rename_dest_by_source[pos].1))
             }
-            continue;
+            None => None,
         };
-        merge_pair(
-            tree_index_change,
-            index_wt_change,
-            &mut changes,
-            &mut ignored_changes,
-            &mut filter,
-            &index,
-            &mut path_check,
-        )?;
-    }
-    changes.sort_by(|a, b| a.path.cmp(&b.path));
-    // A worktree rename can move a file onto a path whose staged deletion found no partner
-    // above; fold the deletion into that rename so each path keeps a single change.
-    let must_resort = !deferred_deletions.is_empty();
-    for deletion in deferred_deletions {
-        let renamed_onto_deleted_path = changes
-            .binary_search_by(|change| change.path.cmp(&deletion.path))
-            .ok()
-            .filter(|&pos| matches!(changes[pos].status, TreeStatus::Rename { .. }));
-        match renamed_onto_deleted_path {
-            Some(pos) => {
-                let rename = changes.remove(pos);
-                merge_pair(
-                    deletion,
-                    rename,
-                    &mut changes,
-                    &mut ignored_changes,
-                    &mut filter,
-                    &index,
-                    &mut path_check,
-                )?;
+        let was_claimed = claimed.is_some();
+        let mut merged = match claimed {
+            Some(tree_index_change) => merge_pair(
+                tree_index_change,
+                index_wt_change,
+                &mut changes,
+                &mut ignored_changes,
+                &mut filter,
+                &index,
+                &mut path_check,
+            )?,
+            None => Some(index_wt_change),
+        };
+        // A rename can land on a path whose own staged deletion is still unclaimed;
+        // fold that deletion in so each path keeps a single change.
+        while let Some(change) = merged.take() {
+            match &change.status {
+                // A merge that nets out to a deletion freed its path from index and
+                // worktree alike, so a file observed later — an untracked recreation —
+                // may claim and continue it.
+                TreeStatus::Deletion { .. } if was_claimed => {
+                    tree_index_by_path.insert(change.path.clone(), change);
+                }
+                TreeStatus::Rename { .. }
+                    if tree_index_by_path
+                        .get(change.path.as_bstr())
+                        .is_some_and(|ti| matches!(ti.status, TreeStatus::Deletion { .. })) =>
+                {
+                    let deletion = tree_index_by_path
+                        .remove(change.path.as_bstr())
+                        .expect("presence just checked");
+                    merged = merge_pair(
+                        deletion,
+                        change,
+                        &mut changes,
+                        &mut ignored_changes,
+                        &mut filter,
+                        &index,
+                        &mut path_check,
+                    )?;
+                }
+                _ => changes.push(change),
             }
-            None => changes.push(deletion),
         }
     }
-    if must_resort {
-        changes.sort_by(|a, b| a.path.cmp(&b.path));
-    }
+    changes.extend(tree_index_by_path.into_values());
+    changes.sort_by(|a, b| a.path.cmp(&b.path));
     ignored_changes.sort_unstable_by(|a, b| (&a.path, a.status).cmp(&(&b.path, b.status)));
     ignored_changes.dedup();
 
@@ -608,8 +613,9 @@ fn worktree_changes_inner(
     })
 }
 
-/// Merge the pair into a tree/worktree change appended to `changes`, recording what was
-/// absorbed in `ignored_changes`.
+/// Merge the pair into a single tree/worktree change, returned for the caller to place, or
+/// pushed straight into `changes` when the merge splits the pair into two changes again.
+/// What was absorbed is recorded in `ignored_changes`.
 fn merge_pair(
     tree_index_change: TreeChange,
     index_wt_change: TreeChange,
@@ -618,21 +624,26 @@ fn merge_pair(
     filter: &mut gix::filter::Pipeline<'_>,
     index: &gix::index::State,
     path_check: &mut gix::status::plumbing::SymlinkCheck,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<Option<TreeChange>> {
     let change_path = tree_index_change.path.clone();
-    let status = match merge_changes(
+    let (merged, status) = match merge_changes(
         tree_index_change,
         index_wt_change,
         filter,
         index,
         path_check,
     )? {
-        [None, None] => IgnoredWorktreeTreeChangeStatus::TreeIndexWorktreeChangeIneffective,
-        [Some(merged), None] | [None, Some(merged)] => {
-            changes.push(merged);
-            IgnoredWorktreeTreeChangeStatus::TreeIndex
+        [None, None] => (
+            None,
+            IgnoredWorktreeTreeChangeStatus::TreeIndexWorktreeChangeIneffective,
+        ),
+        [Some(mut merged), None] | [None, Some(mut merged)] => {
+            recalculate_mode_flags(&mut merged);
+            (Some(merged), IgnoredWorktreeTreeChangeStatus::TreeIndex)
         }
-        [Some(first), Some(second)] => {
+        [Some(mut first), Some(mut second)] => {
+            recalculate_mode_flags(&mut first);
+            recalculate_mode_flags(&mut second);
             ignored_changes.push(IgnoredWorktreeChange {
                 path: first.path.clone(),
                 status: IgnoredWorktreeTreeChangeStatus::TreeIndex,
@@ -643,14 +654,33 @@ fn merge_pair(
                 status: IgnoredWorktreeTreeChangeStatus::TreeIndex,
             });
             changes.push(second);
-            return Ok(());
+            return Ok(None);
         }
     };
     ignored_changes.push(IgnoredWorktreeChange {
         path: change_path,
         status,
     });
-    Ok(())
+    Ok(merged)
+}
+
+/// Merging rewrites one side of a change's state pair while keeping the flags computed for
+/// the pair it was collected with; recompute them so they describe the final pair.
+fn recalculate_mode_flags(change: &mut TreeChange) {
+    match &mut change.status {
+        TreeStatus::Modification {
+            previous_state,
+            state,
+            flags,
+        }
+        | TreeStatus::Rename {
+            previous_state,
+            state,
+            flags,
+            ..
+        } => *flags = ModeFlags::calculate(previous_state, state),
+        TreeStatus::Addition { .. } | TreeStatus::Deletion { .. } => {}
+    }
 }
 
 /// Merge changes from tree/index into changes of `index_wt` and assure the merged result isn't a no-op,
@@ -670,7 +700,6 @@ fn merge_changes(
     let merged = match (&mut tree_index.status, &mut index_wt.status) {
         (TreeStatus::Modification { .. }, TreeStatus::Addition { .. })
         | (TreeStatus::Deletion { .. }, TreeStatus::Deletion { .. })
-        | (TreeStatus::Deletion { .. }, TreeStatus::Rename { .. })
         | (TreeStatus::Deletion { .. }, TreeStatus::Modification { .. })
         | (
             TreeStatus::Deletion { .. },
@@ -726,9 +755,43 @@ fn merge_changes(
             index_wt.status = TreeStatus::Modification {
                 previous_state: *previous_state,
                 state: *state,
-                flags: None,
+                flags: None, /* recalculated after the merge */
             };
             index_wt
+        }
+        (
+            TreeStatus::Deletion { previous_state },
+            TreeStatus::Rename {
+                previous_path,
+                previous_state: previous_state_wt,
+                state,
+                ..
+            },
+        ) => {
+            // A file was deleted from the index while a worktree rename moved another file
+            // onto the deleted path: the source is gone, and the destination now holds
+            // the renamed content in place of the deleted file.
+            let source_deletion = TreeChange {
+                path: std::mem::take(previous_path),
+                status: TreeStatus::Deletion {
+                    previous_state: *previous_state_wt,
+                },
+            };
+            let destination = TreeChange {
+                path: index_wt.path,
+                status: TreeStatus::Modification {
+                    previous_state: *previous_state,
+                    state: *state,
+                    flags: None, /* recalculated after the merge */
+                },
+            };
+            return Ok(
+                if merged_change_is_effective(&destination, filter, index, path_check)? {
+                    [Some(destination), Some(source_deletion)]
+                } else {
+                    single(source_deletion)
+                },
+            );
         }
         (
             TreeStatus::Modification { previous_state, .. },
@@ -832,18 +895,35 @@ fn merge_changes(
         }
     };
 
-    let current = id_or_hash_from_worktree(
-        merged.status.state(),
-        merged.path.as_bstr(),
-        filter,
-        index,
-        path_check,
-    )?;
+    Ok(
+        if merged_change_is_effective(&merged, filter, index, path_check)? {
+            single(merged)
+        } else {
+            [None, None]
+        },
+    )
+}
+
+/// A merged change is ineffective when its current state matches its previous state in both
+/// kind and content, where content may have to be hashed from the worktree as ids can be
+/// null there.
+fn merged_change_is_effective(
+    merged: &TreeChange,
+    filter: &mut gix::filter::Pipeline<'_>,
+    index: &gix::index::State,
+    path_check: &mut gix::status::plumbing::SymlinkCheck,
+) -> anyhow::Result<bool> {
+    let state = merged.status.state();
     let (prev_state, prev_path) = merged
         .status
         .previous_state_and_path()
         .map(|(a, b)| (Some(a), b))
         .unwrap_or((None, None));
+    if state.map(|s| s.kind) != prev_state.map(|s| s.kind) {
+        return Ok(true);
+    }
+    let current =
+        id_or_hash_from_worktree(state, merged.path.as_bstr(), filter, index, path_check)?;
     let previous = id_or_hash_from_worktree(
         prev_state,
         prev_path.unwrap_or(merged.path.as_bstr()),
@@ -851,11 +931,7 @@ fn merge_changes(
         index,
         path_check,
     )?;
-    Ok(if current == previous {
-        [None, None]
-    } else {
-        single(merged)
-    })
+    Ok(current != previous)
 }
 
 // TODO(gix): worktree-status already can do hashing and to-git conversions while dealing with links, but it's not exposed.

--- a/crates/but-core/src/diff/worktree.rs
+++ b/crates/but-core/src/diff/worktree.rs
@@ -1,4 +1,4 @@
-use std::{cmp::Ordering, io::Read, path::PathBuf};
+use std::{io::Read, path::PathBuf};
 
 use anyhow::{Context as _, bail};
 use bstr::{BStr, BString, ByteSlice, ByteVec};
@@ -22,7 +22,6 @@ use crate::{
 };
 
 /// Identify where a [`TreeChange`] is from.
-#[derive(Debug, Clone, Copy, Ord, PartialOrd, Eq, PartialEq)]
 enum Origin {
     /// The change was detected when doing a diff between a tree (`HEAD^{tree}`) and an index (`.git/index`).
     TreeIndex,
@@ -98,7 +97,8 @@ fn worktree_changes_inner(
         .into_iter(None)?;
 
     let work_dir = repo.workdir().context("need non-bare repository")?;
-    let mut tmp = Vec::new();
+    let mut tree_index_changes = Vec::new();
+    let mut index_worktree_changes = Vec::new();
     let mut ignored_changes = Vec::new();
     let mut index_conflicts = Vec::new();
     let mut index_changes = Vec::new();
@@ -489,71 +489,116 @@ fn worktree_changes_inner(
                 )
             }
         };
-        tmp.push(change);
+        let (origin, change) = change;
+        match origin {
+            Origin::TreeIndex => tree_index_changes.push(change),
+            Origin::IndexWorktree => index_worktree_changes.push(change),
+        }
     }
 
-    tmp.sort_by(|(a_origin, a), (b_origin, b)| {
-        cmp_prefer_overlapping(a, b).then(a_origin.cmp(b_origin).reverse())
-    });
+    // Pairing and merge order decide the output, and gix emits index/worktree status in
+    // thread-pool completion order, so sort both sides by path to stay deterministic.
+    tree_index_changes.sort_unstable_by(|a, b| a.path.cmp(&b.path));
+    index_worktree_changes.sort_unstable_by(|a, b| a.path.cmp(&b.path));
+    let mut rename_sources_by_path: Vec<(&BStr, usize)> = tree_index_changes
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, change)| change.previous_path().map(|path| (path, idx)))
+        .collect();
+    rename_sources_by_path.sort_unstable();
 
-    let mut last_change = None::<&TreeChange>;
-    let mut changes = Vec::<TreeChange>::with_capacity(tmp.len());
+    let mut changes =
+        Vec::<TreeChange>::with_capacity(tree_index_changes.len() + index_worktree_changes.len());
+    let mut partners: Vec<Option<TreeChange>> = tree_index_changes.iter().map(|_| None).collect();
+    // Pair each index/worktree change with the tree/index change that describes the same file.
+    // An index/worktree change at a tree/index change's own path continues that index entry,
+    // so those pairs form first; only afterwards may an untracked file claim the source path
+    // a tree/index rename left behind.
+    let mut source_path_claimants = Vec::new();
+    for index_wt_change in index_worktree_changes {
+        let claimed = [
+            index_wt_change.previous_path(),
+            Some(index_wt_change.path.as_bstr()),
+        ]
+        .into_iter()
+        .flatten()
+        .find_map(|path| {
+            tree_index_changes
+                .binary_search_by(|change| change.path.as_bstr().cmp(path))
+                .ok()
+        })
+        .filter(|&idx| partners[idx].is_none());
+        match claimed {
+            Some(idx) => partners[idx] = Some(index_wt_change),
+            None => source_path_claimants.push(index_wt_change),
+        }
+    }
+    for index_wt_change in source_path_claimants {
+        let claimed = rename_sources_by_path
+            .binary_search_by(|(source, _)| (*source).cmp(index_wt_change.path.as_bstr()))
+            .ok()
+            .map(|pos| rename_sources_by_path[pos].1)
+            .filter(|&idx| partners[idx].is_none());
+        match claimed {
+            Some(idx) => partners[idx] = Some(index_wt_change),
+            None => changes.push(index_wt_change),
+        }
+    }
+
     let (mut filter, index) = repo.filter_pipeline(None)?;
     let mut path_check = gix::status::plumbing::SymlinkCheck::new(
         repo.workdir().map(ToOwned::to_owned).context("non-bare")?,
     );
-    for (_origin, change) in tmp {
-        // At this point we know that the current `change` is the tree/index variant
-        // of a prior change between index/worktree.
-        if last_change
-            .as_ref()
-            .is_some_and(|last_change| cmp_prefer_overlapping(last_change, &change).is_eq())
-        {
-            last_change = None;
-            // This is usually two modifications, but it's also possible that
-            // This one is a rename. In that case, we want the rename, combined
-            // with the current state pointing to the worktree,
-            // which we expect to be a modification
-            let index_wt_change = changes
-                .pop()
-                .expect("the reason we are here is the previous change");
-            let change_path = change.path.clone();
-            let tree_index_change = change;
-            let status = match merge_changes(
-                tree_index_change,
-                index_wt_change,
-                &mut filter,
-                &index,
-                &mut path_check,
-            )? {
-                [None, None] => IgnoredWorktreeTreeChangeStatus::TreeIndexWorktreeChangeIneffective,
-                [Some(merged), None] | [None, Some(merged)] => {
-                    changes.push(merged);
-                    IgnoredWorktreeTreeChangeStatus::TreeIndex
-                }
-                [Some(first), Some(second)] => {
-                    ignored_changes.push(IgnoredWorktreeChange {
-                        path: first.path.clone(),
-                        status: IgnoredWorktreeTreeChangeStatus::TreeIndex,
-                    });
-                    changes.push(first);
-                    ignored_changes.push(IgnoredWorktreeChange {
-                        path: second.path.clone(),
-                        status: IgnoredWorktreeTreeChangeStatus::TreeIndex,
-                    });
-                    changes.push(second);
-                    continue;
-                }
-            };
-            ignored_changes.push(IgnoredWorktreeChange {
-                path: change_path,
-                status,
-            });
+    let mut deferred_deletions = Vec::new();
+    for (tree_index_change, index_wt_change) in tree_index_changes.into_iter().zip(partners) {
+        let Some(index_wt_change) = index_wt_change else {
+            if matches!(tree_index_change.status, TreeStatus::Deletion { .. }) {
+                deferred_deletions.push(tree_index_change);
+            } else {
+                changes.push(tree_index_change);
+            }
             continue;
-        }
-        changes.push(change);
-        last_change = changes.last();
+        };
+        merge_pair(
+            tree_index_change,
+            index_wt_change,
+            &mut changes,
+            &mut ignored_changes,
+            &mut filter,
+            &index,
+            &mut path_check,
+        )?;
     }
+    changes.sort_by(|a, b| a.path.cmp(&b.path));
+    // A worktree rename can move a file onto a path whose staged deletion found no partner
+    // above; fold the deletion into that rename so each path keeps a single change.
+    let must_resort = !deferred_deletions.is_empty();
+    for deletion in deferred_deletions {
+        let renamed_onto_deleted_path = changes
+            .binary_search_by(|change| change.path.cmp(&deletion.path))
+            .ok()
+            .filter(|&pos| matches!(changes[pos].status, TreeStatus::Rename { .. }));
+        match renamed_onto_deleted_path {
+            Some(pos) => {
+                let rename = changes.remove(pos);
+                merge_pair(
+                    deletion,
+                    rename,
+                    &mut changes,
+                    &mut ignored_changes,
+                    &mut filter,
+                    &index,
+                    &mut path_check,
+                )?;
+            }
+            None => changes.push(deletion),
+        }
+    }
+    if must_resort {
+        changes.sort_by(|a, b| a.path.cmp(&b.path));
+    }
+    ignored_changes.sort_unstable_by(|a, b| (&a.path, a.status).cmp(&(&b.path, b.status)));
+    ignored_changes.dedup();
 
     Ok(WorktreeChanges {
         changes,
@@ -563,15 +608,49 @@ fn worktree_changes_inner(
     })
 }
 
-fn cmp_prefer_overlapping(a: &TreeChange, b: &TreeChange) -> Ordering {
-    if a.path == b.path
-        || a.previous_path() == Some(b.path.as_bstr())
-        || Some(a.path.as_bstr()) == b.previous_path()
-    {
-        Ordering::Equal
-    } else {
-        a.path.cmp(&b.path)
-    }
+/// Merge the pair into a tree/worktree change appended to `changes`, recording what was
+/// absorbed in `ignored_changes`.
+fn merge_pair(
+    tree_index_change: TreeChange,
+    index_wt_change: TreeChange,
+    changes: &mut Vec<TreeChange>,
+    ignored_changes: &mut Vec<IgnoredWorktreeChange>,
+    filter: &mut gix::filter::Pipeline<'_>,
+    index: &gix::index::State,
+    path_check: &mut gix::status::plumbing::SymlinkCheck,
+) -> anyhow::Result<()> {
+    let change_path = tree_index_change.path.clone();
+    let status = match merge_changes(
+        tree_index_change,
+        index_wt_change,
+        filter,
+        index,
+        path_check,
+    )? {
+        [None, None] => IgnoredWorktreeTreeChangeStatus::TreeIndexWorktreeChangeIneffective,
+        [Some(merged), None] | [None, Some(merged)] => {
+            changes.push(merged);
+            IgnoredWorktreeTreeChangeStatus::TreeIndex
+        }
+        [Some(first), Some(second)] => {
+            ignored_changes.push(IgnoredWorktreeChange {
+                path: first.path.clone(),
+                status: IgnoredWorktreeTreeChangeStatus::TreeIndex,
+            });
+            changes.push(first);
+            ignored_changes.push(IgnoredWorktreeChange {
+                path: second.path.clone(),
+                status: IgnoredWorktreeTreeChangeStatus::TreeIndex,
+            });
+            changes.push(second);
+            return Ok(());
+        }
+    };
+    ignored_changes.push(IgnoredWorktreeChange {
+        path: change_path,
+        status,
+    });
+    Ok(())
 }
 
 /// Merge changes from tree/index into changes of `index_wt` and assure the merged result isn't a no-op,

--- a/crates/but-core/src/lib.rs
+++ b/crates/but-core/src/lib.rs
@@ -484,7 +484,7 @@ pub struct ChangeState {
 }
 
 /// The status we can't handle, which always originated in the worktree.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
 pub enum IgnoredWorktreeTreeChangeStatus {
     /// A conflicting entry in the index. The worktree state of the entry is unclear.
@@ -499,7 +499,7 @@ pub enum IgnoredWorktreeTreeChangeStatus {
 but_schemars::register_sdk_type!(IgnoredWorktreeTreeChangeStatus);
 
 /// A way to indicate that a path in the index isn't suitable for committing and needs to be dealt with.
-#[derive(Clone, Serialize)]
+#[derive(Clone, PartialEq, Eq, Serialize)]
 #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
 pub struct IgnoredWorktreeChange {
     /// The worktree-relative path to the change.

--- a/crates/but-core/tests/core/diff/worktree_changes.rs
+++ b/crates/but-core/tests/core/diff/worktree_changes.rs
@@ -2038,6 +2038,8 @@ WorktreeChanges {
 fn modified_in_index_and_worktree_rename_add() -> Result<()> {
     let repo = repo("modified-in-index-and-worktree-rename-add")?;
     let actual = diff::worktree_changes(&repo)?;
+    // The index rename and the recreated source merge into two untracked additions,
+    // emitted in path order ("file" before "file-renamed-in-index").
     snapbox::assert_data_eq!(
         actual.to_debug(),
         snapbox::str![[r#"
@@ -2066,11 +2068,11 @@ WorktreeChanges {
     ],
     ignored_changes: [
         IgnoredWorktreeChange {
-            path: "file-renamed-in-index",
+            path: "file",
             status: TreeIndex,
         },
         IgnoredWorktreeChange {
-            path: "file",
+            path: "file-renamed-in-index",
             status: TreeIndex,
         },
     ],
@@ -2104,6 +2106,373 @@ WorktreeChanges {
         snapbox::str![[r#"
 @@ -1,0 +1,1 @@
 +initial
+
+"#]]
+    );
+    Ok(())
+}
+
+#[test]
+fn modified_in_index_and_worktree_del_rename() -> Result<()> {
+    // A deletion staged for `replaced` while the worktree renames `file` onto that path:
+    // the net effect is a modification of `replaced` and a deletion of `file`.
+    let repo = repo("modified-in-index-and-worktree-del-rename")?;
+    let actual = diff::worktree_changes(&repo)?;
+    snapbox::assert_data_eq!(
+        actual.to_debug(),
+        snapbox::str![[r#"
+WorktreeChanges {
+    changes: [
+        TreeChange {
+            path: "file",
+            status: Deletion {
+                previous_state: ChangeState {
+                    id: Sha1(e79c5e8f964493290a409888d5413a737e8e5dd5),
+                    kind: Blob,
+                },
+            },
+        },
+        TreeChange {
+            path: "replaced",
+            status: Modification {
+                previous_state: ChangeState {
+                    id: Sha1(c452352bbbff3f54ba625e2466377c4c037ca4af),
+                    kind: Blob,
+                },
+                state: ChangeState {
+                    id: Sha1(0000000000000000000000000000000000000000),
+                    kind: Blob,
+                },
+                flags: None,
+            },
+        },
+    ],
+    ignored_changes: [
+        IgnoredWorktreeChange {
+            path: "file",
+            status: TreeIndex,
+        },
+        IgnoredWorktreeChange {
+            path: "replaced",
+            status: TreeIndex,
+        },
+    ],
+}
+
+"#]]
+    );
+
+    // With identical content the destination is unchanged, leaving only the source deletion.
+    let repo =
+        crate::diff::worktree_changes::repo("modified-in-index-and-worktree-del-rename-noop")?;
+    snapbox::assert_data_eq!(
+        diff::worktree_changes(&repo)?.to_debug(),
+        snapbox::str![[r#"
+WorktreeChanges {
+    changes: [
+        TreeChange {
+            path: "file",
+            status: Deletion {
+                previous_state: ChangeState {
+                    id: Sha1(1275430f1765c63e539cb0452565563bd6aef6a6),
+                    kind: Blob,
+                },
+            },
+        },
+    ],
+    ignored_changes: [
+        IgnoredWorktreeChange {
+            path: "replaced",
+            status: TreeIndex,
+        },
+    ],
+}
+
+"#]]
+    );
+    Ok(())
+}
+
+#[test]
+fn modified_in_index_and_worktree_del_rename_of_modified() -> Result<()> {
+    // Like `del_rename`, but the rename source also has a staged modification. The rename
+    // first absorbs that modification, then folds into the staged deletion of its
+    // destination, so the net result matches plain `del_rename`: one change per path.
+    let repo = repo("modified-in-index-and-worktree-del-rename-of-modified")?;
+    let actual = diff::worktree_changes(&repo)?;
+    snapbox::assert_data_eq!(
+        actual.to_debug(),
+        snapbox::str![[r#"
+WorktreeChanges {
+    changes: [
+        TreeChange {
+            path: "file",
+            status: Deletion {
+                previous_state: ChangeState {
+                    id: Sha1(e79c5e8f964493290a409888d5413a737e8e5dd5),
+                    kind: Blob,
+                },
+            },
+        },
+        TreeChange {
+            path: "replaced",
+            status: Modification {
+                previous_state: ChangeState {
+                    id: Sha1(c452352bbbff3f54ba625e2466377c4c037ca4af),
+                    kind: Blob,
+                },
+                state: ChangeState {
+                    id: Sha1(0000000000000000000000000000000000000000),
+                    kind: Blob,
+                },
+                flags: None,
+            },
+        },
+    ],
+    ignored_changes: [
+        IgnoredWorktreeChange {
+            path: "file",
+            status: TreeIndex,
+        },
+        IgnoredWorktreeChange {
+            path: "replaced",
+            status: TreeIndex,
+        },
+    ],
+}
+
+"#]]
+    );
+    Ok(())
+}
+
+#[test]
+fn modified_in_index_and_worktree_del_rename_of_modified_twice() -> Result<()> {
+    // Two independent del+rename-of-modified groups must both fold; the second fold's
+    // lookup must not be confused by the first fold's results.
+    let repo = repo("modified-in-index-and-worktree-del-rename-of-modified-twice")?;
+    let actual = diff::worktree_changes(&repo)?;
+    snapbox::assert_data_eq!(
+        actual.to_debug(),
+        snapbox::str![[r#"
+WorktreeChanges {
+    changes: [
+        TreeChange {
+            path: "file-a",
+            status: Deletion {
+                previous_state: ChangeState {
+                    id: Sha1(aaf5a69a08ed8573de2dcf0fa9b3f3b53fd0578b),
+                    kind: Blob,
+                },
+            },
+        },
+        TreeChange {
+            path: "file-b",
+            status: Deletion {
+                previous_state: ChangeState {
+                    id: Sha1(d88594a326575a0a15d681630e568d9fa3f55959),
+                    kind: Blob,
+                },
+            },
+        },
+        TreeChange {
+            path: "replaced-a",
+            status: Modification {
+                previous_state: ChangeState {
+                    id: Sha1(045431e52f630b3e91a5847c8d13e49db533a145),
+                    kind: Blob,
+                },
+                state: ChangeState {
+                    id: Sha1(0000000000000000000000000000000000000000),
+                    kind: Blob,
+                },
+                flags: None,
+            },
+        },
+        TreeChange {
+            path: "replaced-b",
+            status: Modification {
+                previous_state: ChangeState {
+                    id: Sha1(45f1ae81e503659d0ab1fae16666661a950d3a8f),
+                    kind: Blob,
+                },
+                state: ChangeState {
+                    id: Sha1(0000000000000000000000000000000000000000),
+                    kind: Blob,
+                },
+                flags: None,
+            },
+        },
+    ],
+    ignored_changes: [
+        IgnoredWorktreeChange {
+            path: "file-a",
+            status: TreeIndex,
+        },
+        IgnoredWorktreeChange {
+            path: "file-b",
+            status: TreeIndex,
+        },
+        IgnoredWorktreeChange {
+            path: "replaced-a",
+            status: TreeIndex,
+        },
+        IgnoredWorktreeChange {
+            path: "replaced-b",
+            status: TreeIndex,
+        },
+    ],
+}
+
+"#]]
+    );
+    Ok(())
+}
+
+#[test]
+fn renamed_in_index_destination_deleted_and_source_recreated() -> Result<()> {
+    // The staged rename and the worktree deletion of its destination collapse into a
+    // deletion of the source, which the recreated source file then continues:
+    // the net result is a single modification of `a`.
+    let repo = repo("renamed-in-index-destination-deleted-and-source-recreated")?;
+    let actual = diff::worktree_changes(&repo)?;
+    snapbox::assert_data_eq!(
+        actual.to_debug(),
+        snapbox::str![[r#"
+WorktreeChanges {
+    changes: [
+        TreeChange {
+            path: "a",
+            status: Modification {
+                previous_state: ChangeState {
+                    id: Sha1(d95f3ad14dee633a758d2e331151e950dd13e4ed),
+                    kind: Blob,
+                },
+                state: ChangeState {
+                    id: Sha1(0000000000000000000000000000000000000000),
+                    kind: Blob,
+                },
+                flags: None,
+            },
+        },
+    ],
+    ignored_changes: [
+        IgnoredWorktreeChange {
+            path: "a",
+            status: TreeIndex,
+        },
+        IgnoredWorktreeChange {
+            path: "b",
+            status: TreeIndex,
+        },
+    ],
+}
+
+"#]]
+    );
+    Ok(())
+}
+
+#[test]
+fn renamed_in_index_source_recreated_and_destination_modified() -> Result<()> {
+    // The worktree modification of `z` continues the index entry the rename `a` → `z`
+    // created, so it must win the pairing even though the recreated `a` sorts first and
+    // also matches the rename via its source path. The recreation stays a plain
+    // untracked addition.
+    let repo = repo("renamed-in-index-source-recreated-and-destination-modified")?;
+    let actual = diff::worktree_changes(&repo)?;
+    snapbox::assert_data_eq!(
+        actual.to_debug(),
+        snapbox::str![[r#"
+WorktreeChanges {
+    changes: [
+        TreeChange {
+            path: "a",
+            status: Addition {
+                state: ChangeState {
+                    id: Sha1(0000000000000000000000000000000000000000),
+                    kind: Blob,
+                },
+                is_untracked: true,
+            },
+        },
+        TreeChange {
+            path: "z",
+            status: Rename {
+                previous_path: "a",
+                previous_state: ChangeState {
+                    id: Sha1(d95f3ad14dee633a758d2e331151e950dd13e4ed),
+                    kind: Blob,
+                },
+                state: ChangeState {
+                    id: Sha1(0000000000000000000000000000000000000000),
+                    kind: Blob,
+                },
+                flags: None,
+            },
+        },
+    ],
+    ignored_changes: [
+        IgnoredWorktreeChange {
+            path: "z",
+            status: TreeIndex,
+        },
+    ],
+}
+
+"#]]
+    );
+    Ok(())
+}
+
+#[test]
+fn swapped_in_index_and_modified_in_worktree() -> Result<()> {
+    // Swapping `a` and `b` in the index leaves both paths present, so the tree/index diff
+    // reports two modifications rather than renames. A worktree edit of `a` merges with
+    // its staged modification while `b` stays untouched.
+    let repo = repo("swapped-in-index-and-modified-in-worktree")?;
+    let actual = diff::worktree_changes(&repo)?;
+    snapbox::assert_data_eq!(
+        actual.to_debug(),
+        snapbox::str![[r#"
+WorktreeChanges {
+    changes: [
+        TreeChange {
+            path: "a",
+            status: Modification {
+                previous_state: ChangeState {
+                    id: Sha1(045431e52f630b3e91a5847c8d13e49db533a145),
+                    kind: Blob,
+                },
+                state: ChangeState {
+                    id: Sha1(0000000000000000000000000000000000000000),
+                    kind: Blob,
+                },
+                flags: None,
+            },
+        },
+        TreeChange {
+            path: "b",
+            status: Modification {
+                previous_state: ChangeState {
+                    id: Sha1(45f1ae81e503659d0ab1fae16666661a950d3a8f),
+                    kind: Blob,
+                },
+                state: ChangeState {
+                    id: Sha1(045431e52f630b3e91a5847c8d13e49db533a145),
+                    kind: Blob,
+                },
+                flags: None,
+            },
+        },
+    ],
+    ignored_changes: [
+        IgnoredWorktreeChange {
+            path: "a",
+            status: TreeIndex,
+        },
+    ],
+}
 
 "#]]
     );

--- a/crates/but-core/tests/core/diff/worktree_changes.rs
+++ b/crates/but-core/tests/core/diff/worktree_changes.rs
@@ -2044,20 +2044,20 @@ fn modified_in_index_and_worktree_rename_add() -> Result<()> {
 WorktreeChanges {
     changes: [
         TreeChange {
-            path: "file-renamed-in-index",
+            path: "file",
             status: Addition {
                 state: ChangeState {
-                    id: Sha1(e79c5e8f964493290a409888d5413a737e8e5dd5),
+                    id: Sha1(0000000000000000000000000000000000000000),
                     kind: Blob,
                 },
                 is_untracked: true,
             },
         },
         TreeChange {
-            path: "file",
+            path: "file-renamed-in-index",
             status: Addition {
                 state: ChangeState {
-                    id: Sha1(0000000000000000000000000000000000000000),
+                    id: Sha1(e79c5e8f964493290a409888d5413a737e8e5dd5),
                     kind: Blob,
                 },
                 is_untracked: true,
@@ -2093,17 +2093,82 @@ WorktreeChanges {
     snapbox::assert_data_eq!(
         hunks1[0].diff.to_string(),
         snapbox::str![[r#"
-@@ -1,0 +1,1 @@
+@@ -1,0 +1,2 @@
 +initial
++wt-change
 
 "#]]
     );
     snapbox::assert_data_eq!(
         hunks2[0].diff.to_string(),
         snapbox::str![[r#"
-@@ -1,0 +1,2 @@
+@@ -1,0 +1,1 @@
 +initial
-+wt-change
+
+"#]]
+    );
+    Ok(())
+}
+
+#[test]
+fn overlapping_changes_at_three_paths_group_deterministically() -> Result<()> {
+    // An index rename `z` → `a`, a recreated `z` in the worktree, and an unrelated staged
+    // change at `b` used to be sorted with a comparator whose overlap-equality was not
+    // transitive, panicking with "comparison function does not implement a total order"
+    // on unlucky input orders.
+    let repo = repo("renamed-in-index-source-recreated-and-neighbor-modified")?;
+    let actual = diff::worktree_changes(&repo)?;
+    snapbox::assert_data_eq!(
+        actual.to_debug(),
+        snapbox::str![[r#"
+WorktreeChanges {
+    changes: [
+        TreeChange {
+            path: "a",
+            status: Addition {
+                state: ChangeState {
+                    id: Sha1(d95f3ad14dee633a758d2e331151e950dd13e4ed),
+                    kind: Blob,
+                },
+                is_untracked: true,
+            },
+        },
+        TreeChange {
+            path: "b",
+            status: Modification {
+                previous_state: ChangeState {
+                    id: Sha1(0a5dc9c0e656cd31f81f9d40fe6f58dbad39cb72),
+                    kind: Blob,
+                },
+                state: ChangeState {
+                    id: Sha1(050a45de5f26e3ad0a0dbb34d8b522854bf2730a),
+                    kind: Blob,
+                },
+                flags: None,
+            },
+        },
+        TreeChange {
+            path: "z",
+            status: Addition {
+                state: ChangeState {
+                    id: Sha1(0000000000000000000000000000000000000000),
+                    kind: Blob,
+                },
+                is_untracked: true,
+            },
+        },
+    ],
+    ignored_changes: [
+        IgnoredWorktreeChange {
+            path: "a",
+            status: TreeIndex,
+        },
+        IgnoredWorktreeChange {
+            path: "z",
+            status: TreeIndex,
+        },
+    ],
+}
 
 "#]]
     );

--- a/crates/but-core/tests/fixtures/worktree-changes.sh
+++ b/crates/but-core/tests/fixtures/worktree-changes.sh
@@ -204,6 +204,15 @@ git init modified-in-index-and-worktree-rename-add
   echo $'initial\nwt-change' >file
 )
 
+git init renamed-in-index-source-recreated-and-neighbor-modified
+(cd renamed-in-index-source-recreated-and-neighbor-modified
+  echo content >z && echo neighbor >b
+  git add . && git commit -m "init"
+  git mv z a
+  echo staged >>b && git add b
+  echo recreated >z
+)
+
 git init modified-in-index-and-worktree-add-rename
 (cd modified-in-index-and-worktree-add-rename
   echo initial >file && git add .

--- a/crates/but-core/tests/fixtures/worktree-changes.sh
+++ b/crates/but-core/tests/fixtures/worktree-changes.sh
@@ -204,6 +204,67 @@ git init modified-in-index-and-worktree-rename-add
   echo $'initial\nwt-change' >file
 )
 
+git init modified-in-index-and-worktree-del-rename
+(cd modified-in-index-and-worktree-del-rename
+  echo replaced-content >replaced && echo initial >file
+  git add . && git commit -m "init"
+  git rm replaced
+  mv file replaced
+)
+
+git init modified-in-index-and-worktree-del-rename-noop
+(cd modified-in-index-and-worktree-del-rename-noop
+  echo same >replaced && echo same >file
+  git add . && git commit -m "init"
+  git rm replaced
+  mv file replaced
+)
+
+git init modified-in-index-and-worktree-del-rename-of-modified
+(cd modified-in-index-and-worktree-del-rename-of-modified
+  echo replaced-content >replaced && echo initial >file
+  git add . && git commit -m "init"
+  git rm replaced
+  echo staged >>file && git add file
+  mv file replaced
+)
+
+git init modified-in-index-and-worktree-del-rename-of-modified-twice
+(cd modified-in-index-and-worktree-del-rename-of-modified-twice
+  echo a-content >replaced-a && echo b-content >replaced-b
+  echo initial-a >file-a && echo initial-b >file-b
+  git add . && git commit -m "init"
+  git rm replaced-a replaced-b
+  echo staged-a >>file-a && echo staged-b >>file-b && git add file-a file-b
+  mv file-a replaced-a && mv file-b replaced-b
+)
+
+git init renamed-in-index-destination-deleted-and-source-recreated
+(cd renamed-in-index-destination-deleted-and-source-recreated
+  echo content >a
+  git add . && git commit -m "init"
+  git mv a b
+  rm b
+  echo recreated-differently >a
+)
+
+git init renamed-in-index-source-recreated-and-destination-modified
+(cd renamed-in-index-source-recreated-and-destination-modified
+  echo content >a
+  git add . && git commit -m "init"
+  git mv a z
+  echo wt-change >>z
+  echo recreated >a
+)
+
+git init swapped-in-index-and-modified-in-worktree
+(cd swapped-in-index-and-modified-in-worktree
+  echo a-content >a && echo b-content >b
+  git add . && git commit -m "init"
+  git mv a tmp && git mv b a && git mv tmp b
+  echo wt-change >>a
+)
+
 git init renamed-in-index-source-recreated-and-neighbor-modified
 (cd renamed-in-index-source-recreated-and-neighbor-modified
   echo content >z && echo neighbor >b

--- a/crates/but-workspace/tests/workspace/tree_manipulation/hunk.rs
+++ b/crates/but-workspace/tests/workspace/tree_manipulation/hunk.rs
@@ -145,11 +145,11 @@ eleven
         else {
             unreachable!("We know there are hunks")
         };
-        assert_ne!(
-            hunks.len(),
-            0,
-            "the reason we see it is file modifications: {change:#?}"
-        );
+        if hunks.is_empty() {
+            // Only the executable-bit change of the worktree file remains; it has no
+            // content hunks and is discarded separately.
+            break;
+        }
 
         let before = file_content()?;
         let mut last_hunk = hunks
@@ -205,6 +205,7 @@ eleven
 "#]]
         .raw()
     );
+    assert_residual_executable_bit_change(&repo, filename)?;
     Ok(())
 }
 
@@ -224,11 +225,11 @@ fn from_beginning() -> anyhow::Result<()> {
         else {
             unreachable!("We know there are hunks")
         };
-        assert_ne!(
-            hunks.len(),
-            0,
-            "the reason we see it is file modifications: {change:#?}"
-        );
+        if hunks.is_empty() {
+            // Only the executable-bit change of the worktree file remains; it has no
+            // content hunks and is discarded separately.
+            break;
+        }
 
         let before = file_content()?;
         let mut first_hun_hunk = hunks.remove(0);
@@ -281,6 +282,43 @@ fn from_beginning() -> anyhow::Result<()> {
 
 "#]]
         .raw()
+    );
+    assert_residual_executable_bit_change(&repo, filename)?;
+    Ok(())
+}
+
+/// After all content hunks are discarded, the worktree file still differs from `HEAD^{tree}`
+/// by its executable bit, and that change stays visible so it can be discarded separately.
+fn assert_residual_executable_bit_change(
+    repo: &gix::Repository,
+    filename: &str,
+) -> anyhow::Result<()> {
+    let residual = but_core::diff::worktree_changes(repo)?
+        .changes
+        .into_iter()
+        .find(|change| change.path == filename)
+        .expect("the executable-bit change remains");
+    snapbox::assert_data_eq!(
+        residual.to_debug(),
+        snapbox::str![[r#"
+TreeChange {
+    path: "file-in-index",
+    status: Modification {
+        previous_state: ChangeState {
+            id: Sha1(3d3b36f021391fa57312d7dfd1ad8cf5a13dca6d),
+            kind: Blob,
+        },
+        state: ChangeState {
+            id: Sha1(0000000000000000000000000000000000000000),
+            kind: BlobExecutable,
+        },
+        flags: Some(
+            ExecutableBitAdded,
+        ),
+    },
+}
+
+"#]]
     );
     Ok(())
 }
@@ -941,6 +979,22 @@ WorktreeChanges {
             },
         },
         TreeChange {
+            path: "file-in-index",
+            status: Modification {
+                previous_state: ChangeState {
+                    id: Sha1(3d3b36f021391fa57312d7dfd1ad8cf5a13dca6d),
+                    kind: Blob,
+                },
+                state: ChangeState {
+                    id: Sha1(0000000000000000000000000000000000000000),
+                    kind: BlobExecutable,
+                },
+                flags: Some(
+                    ExecutableBitAdded,
+                ),
+            },
+        },
+        TreeChange {
             path: "file-renamed",
             status: Rename {
                 previous_path: "file-to-be-renamed",
@@ -976,7 +1030,7 @@ WorktreeChanges {
     ignored_changes: [
         IgnoredWorktreeChange {
             path: "file-in-index",
-            status: TreeIndexWorktreeChangeIneffective,
+            status: TreeIndex,
         },
     ],
 }


### PR DESCRIPTION
This fixes two ways `worktree_changes` — the boiled-down `git status` behind every uncommitted-changes view — could fail for the whole repository because of a single file:

1. **Panic: "comparison function does not correctly implement a total order"** ([GB-1887](https://linear.app/gitbutler/issue/GB-1887/changes-in-worktree-panics-comparison-function-does-not-implement-a)). Overlapping tree→index and index→worktree records were grouped by sorting with a comparator that reported overlapping records as *equal*. Overlap is not transitive, so with three records like an index rename `z → a`, a recreated `z`, and an unrelated `b`, the comparator formed a cycle, violated strict weak ordering, and Rust's sort detected it and panicked — failing the whole status query.

2. **"BUG: entered unreachable code" on a staged deletion overlapped by a worktree rename** ([GB-1894](https://linear.app/gitbutler/issue/GB-1894/changes-in-worktree-rejects-staged-deletion-unstaged-rename-as)). `git rm a && mv b a` is a perfectly legal state: a staged deletion of `a` plus a detected worktree rename `b → a`. The merge step hard-coded that combination as impossible and errored the entire query.

### How

Pairing no longer relies on sorting at all. Tree→index changes go into a path-keyed map where a claim removes the entry; one deterministic pass over the index→worktree changes lets each change claim the entry it continues, and a rename walks its own chain: it first absorbs the staged change at its source, then settles onto its destination's staged deletion — which is where the previously "unreachable" pair is merged into its net effect (a modification at the destination plus a deletion of the source).

This also establishes an invariant the rest of the app already assumes: the result contains **at most one change per path**, deterministically ordered, no matter how staged and unstaged changes overlap. The no-op check that drops ineffective merges now also compares the entry kind, so a mode-only difference (e.g. an executable bit) is reported as a real change instead of disappearing.