### PR TITLE
Lite: add a Snackbar component

### DIFF
--- a/apps/lite/ui/src/components/Snackbar.module.css
+++ b/apps/lite/ui/src/components/Snackbar.module.css
@@ -1,0 +1,66 @@
+.snackbar {
+	display: inline-flex;
+	column-gap: 8px;
+	align-items: center;
+	max-width: 100%;
+
+	/* The design gives the snackbar 31px around its sentence and 36px once the close button raises the
+	   row to 20px. Boxes here are border-box and the message is trimmed to its caps, so both the
+	   padding and the floor state what the design measures minus the 1px border. */
+	min-height: 31px;
+	padding: 7px 9px;
+	border: 1px solid var(--border-2);
+	/* The design names `--radius-m`; the token set spells that size `--radius-lg`. */
+	border-radius: var(--radius-lg);
+	background-color: var(--bg-1);
+	box-shadow: var(--shadow-md);
+	color: var(--text-1);
+	white-space: nowrap;
+}
+
+/* The whole verdict: the surface, the border, and the sentence stay the same across variants, so
+   the glyph is the only thing saying how the news landed. */
+.icon {
+	color: var(--snackbar-icon);
+}
+
+.info {
+	--snackbar-icon: var(--text-3);
+}
+
+.danger {
+	--snackbar-icon: var(--text-danger);
+}
+
+.safe {
+	--snackbar-icon: var(--text-safe);
+}
+
+/* Takes the width it needs and gives it back before the snackbar grows past its container: a long
+   sentence ellipsises rather than pushing the way out off the end. Centring is on the cap band
+   rather than the line box, so the row reads evenly however the font hangs its ascent and descent
+   — and since the trimmed box ends at the baseline, the clip gets its descenders back by hand. */
+.message {
+	flex: 0 1 auto;
+	min-width: 0;
+	margin-block-end: -0.25em;
+	padding-block-end: 0.25em;
+	overflow: hidden;
+	text-box: trim-both cap alphabetic;
+	text-overflow: ellipsis;
+}
+
+/* Fences the way out off from what it would be closing, down the middle of its own lane. */
+.divider {
+	align-self: stretch;
+	width: 1px;
+	min-height: 20px;
+	margin-inline: 3.5px;
+	background-color: var(--border-3);
+}
+
+/* The button's own padding is optical rather than structural, so the design seats it in a slot 2px
+   narrower on each side and lets the glyph, not the hit area, line up with the sentence above. */
+.dismiss {
+	margin-inline: -2px;
+}

--- a/apps/lite/ui/src/components/Snackbar.stories.tsx
+++ b/apps/lite/ui/src/components/Snackbar.stories.tsx
@@ -1,0 +1,76 @@
+import preview from "#storybook/preview";
+import { Snackbar, type SnackbarVariant } from "./Snackbar.tsx";
+
+const meta = preview.meta({
+	component: Snackbar,
+	argTypes: {
+		variant: {
+			control: "inline-radio",
+			options: ["info", "danger", "safe"] satisfies Array<SnackbarVariant>,
+		},
+		icon: { control: "text" },
+	},
+	args: {
+		variant: "info",
+		children: "Info. Snackbar message",
+		onDismiss: () => {},
+	},
+});
+
+/** The snackbar as the design states it: a glyph, a sentence, and a way out. */
+export const Default = meta.story({});
+
+/** One surface, three glyphs: only the leading icon says how the news landed. */
+export const AllVariants = meta.story({
+	render: () => (
+		<div style={{ display: "flex", flexDirection: "column", alignItems: "start", gap: 12 }}>
+			<Snackbar>Info. Snackbar message</Snackbar>
+			<Snackbar variant="danger">Danger. Snackbar message</Snackbar>
+			<Snackbar variant="safe">Success. Snackbar message</Snackbar>
+		</div>
+	),
+});
+
+/** With `onDismiss` the snackbar grows a divider and a close button, and the row with it. */
+export const WithDismiss = meta.story({
+	render: () => (
+		<div style={{ display: "flex", flexDirection: "column", alignItems: "start", gap: 12 }}>
+			<Snackbar onDismiss={() => {}}>Info. Snackbar message</Snackbar>
+			<Snackbar variant="danger" onDismiss={() => {}}>
+				Danger. Snackbar message
+			</Snackbar>
+			<Snackbar variant="safe" onDismiss={() => {}}>
+				Success. Snackbar message
+			</Snackbar>
+		</div>
+	),
+});
+
+/** `icon` overrides the variant's own glyph without changing what the snackbar means. */
+export const CustomIcon = meta.story({
+	render: () => (
+		<div style={{ display: "flex", flexDirection: "column", alignItems: "start", gap: 12 }}>
+			<Snackbar icon="spinner">Absorbing…</Snackbar>
+			<Snackbar icon="absorb" onDismiss={() => {}}>
+				Couldn’t work out where to absorb
+			</Snackbar>
+			<Snackbar variant="safe" icon="commit">
+				Changes absorbed into 3 commits
+			</Snackbar>
+		</div>
+	),
+});
+
+/** A sentence wider than the space it has ellipsises rather than widening the snackbar. */
+export const LongMessage = meta.story({
+	render: () => (
+		<div style={{ display: "flex", flexDirection: "column", gap: 12, width: 320 }}>
+			<Snackbar icon="absorb" onDismiss={() => {}}>
+				Couldn’t work out where to absorb these changes, so nothing was moved anywhere at all
+			</Snackbar>
+			<Snackbar variant="danger" onDismiss={() => {}}>
+				The commit could not be created because the workspace has conflicts left in it
+			</Snackbar>
+		</div>
+	),
+});

--- a/apps/lite/ui/src/components/Snackbar.tsx
+++ b/apps/lite/ui/src/components/Snackbar.tsx
@@ -1,0 +1,83 @@
+import { classes } from "#ui/components/classes.ts";
+import { getButtonClassName } from "#ui/components/Button.tsx";
+import { Icon } from "./Icon.tsx";
+import type { IconName } from "./iconNames.ts";
+import styles from "./Snackbar.module.css";
+import { Button } from "@base-ui/react";
+import { Match } from "effect";
+import type { ComponentProps, FC } from "react";
+
+/** @public */
+export type SnackbarVariant =
+	/** Something happened worth saying, with no verdict attached. */
+	| "info"
+	/** An act that failed, or refused to run. */
+	| "danger"
+	/** An act that came off. */
+	| "safe";
+
+/** The glyph a variant leads with when the caller names none of its own. */
+const defaultIcon = (variant: SnackbarVariant): IconName =>
+	Match.value(variant).pipe(
+		Match.when("info", () => "info" as const),
+		Match.when("danger", () => "danger" as const),
+		Match.when("safe", () => "tick" as const),
+		Match.exhaustive,
+	);
+
+/**
+ * One line of consequence, floated over the surface that caused it: a glyph, a sentence, and — when
+ * it needs dismissing by hand — a way out fenced off behind a divider. A whole {@link Toasts} card
+ * would state a title and a description; a snackbar has only the sentence, so it can sit close to
+ * the thing it is about rather than in the corner of the window.
+ *
+ * Every variant wears the same surface: the verdict is carried by the glyph alone, so a run of
+ * snackbars reads as one row of statements rather than a traffic light.
+ *
+ * @public
+ */
+export const Snackbar: FC<
+	{
+		variant?: SnackbarVariant;
+		/** Overrides the variant's own glyph. */
+		icon?: IconName;
+		/** Given, the snackbar carries a close button; otherwise it says its piece and nothing more. */
+		onDismiss?: () => void;
+		dismissLabel?: string;
+	} & ComponentProps<"div">
+> = ({ variant = "info", icon, onDismiss, dismissLabel = "Dismiss", children, ...props }) => (
+	<div
+		// A failure interrupts; the other two are there to be read whenever the reader gets to them.
+		role={variant === "danger" ? "alert" : "status"}
+		{...props}
+		className={classes(
+			props.className,
+			styles.snackbar,
+			"text-12",
+			Match.value(variant).pipe(
+				Match.when("info", () => styles.info),
+				Match.when("danger", () => styles.danger),
+				Match.when("safe", () => styles.safe),
+				Match.exhaustive,
+			),
+		)}
+	>
+		<Icon name={icon ?? defaultIcon(variant)} size={14} className={styles.icon} />
+		<span className={styles.message}>{children}</span>
+		{onDismiss !== undefined && (
+			<>
+				<div aria-hidden className={styles.divider} />
+				<Button
+					aria-label={dismissLabel}
+					className={classes(
+						getButtonClassName({ variant: "ghost", size: "small", iconOnly: true }),
+						styles.dismiss,
+					)}
+					onClick={onDismiss}
+				>
+					<Icon name="cross" />
+				</Button>
+			</>
+		)}
+	</div>
+);


### PR DESCRIPTION
One line of consequence, floated over the surface that caused it: a glyph,
a sentence, and optionally a close button fenced off behind a divider.
Where a Toasts card states a title and a description, a snackbar has only
the sentence, so it can sit close to the thing it is about.

Every variant wears the same surface — the info, danger and safe glyphs
are the only thing saying how the news landed.

<img width="300" alt="Screenshot 2026-08-25 at 20-29-56" src="https://github.com/user-attachments/assets/0a0a01f9-3f54-4bdf-8c80-8a03a8eb2452" />
