### PR TITLE
Lite: give the workspace operations a toolbox

### DIFF
--- a/apps/lite/ui/src/api/mutations.ts
+++ b/apps/lite/ui/src/api/mutations.ts
@@ -890,12 +890,14 @@ export const useDiscardFileChanges = ({
 	/**
 	 * Discard `change`, extended to the checked files when `extendToCheckedFiles` — a row's menu
 	 * passes its own checked state, as dragging does; a list hotkey passes true, as cut and move do.
+	 * A caller with no row of its own, like the checked-set toolbar, passes a null `change` and
+	 * leans wholly on the checked set.
 	 */
 	const discard = async ({
 		change,
 		extendToCheckedFiles,
 	}: {
-		change: TreeChange;
+		change: TreeChange | null;
 		extendToCheckedFiles: boolean;
 	}): Promise<void> => {
 		const sources = projectSlice.selectors.selectCheckedAddresses(store.getState(), projectId);
@@ -906,7 +908,7 @@ export const useDiscardFileChanges = ({
 			);
 
 		if (!extendToCheckedFiles || sources.length === 0 || !areAllFilesUnder())
-			return runDiscard([createDiffSpec(change, [])]);
+			return change === null ? undefined : runDiscard([createDiffSpec(change, [])]);
 
 		// Checked files carry only paths, so their changes have to be looked up.
 		try {

--- a/apps/lite/ui/src/components/Snackbar.module.css
+++ b/apps/lite/ui/src/components/Snackbar.module.css
@@ -1,0 +1,66 @@
+.snackbar {
+	display: inline-flex;
+	column-gap: 8px;
+	align-items: center;
+	max-width: 100%;
+
+	/* The design gives the snackbar 31px around its sentence and 36px once the close button raises the
+	   row to 20px. Boxes here are border-box and the message is trimmed to its caps, so both the
+	   padding and the floor state what the design measures minus the 1px border. */
+	min-height: 31px;
+	padding: 7px 9px;
+	border: 1px solid var(--border-2);
+	/* The design names `--radius-m`; the token set spells that size `--radius-lg`. */
+	border-radius: var(--radius-lg);
+	background-color: var(--bg-1);
+	box-shadow: var(--shadow-md);
+	color: var(--text-1);
+	white-space: nowrap;
+}
+
+/* The whole verdict: the surface, the border, and the sentence stay the same across variants, so
+   the glyph is the only thing saying how the news landed. */
+.icon {
+	color: var(--snackbar-icon);
+}
+
+.info {
+	--snackbar-icon: var(--text-3);
+}
+
+.danger {
+	--snackbar-icon: var(--text-danger);
+}
+
+.safe {
+	--snackbar-icon: var(--text-safe);
+}
+
+/* Takes the width it needs and gives it back before the snackbar grows past its container: a long
+   sentence ellipsises rather than pushing the way out off the end. Centring is on the cap band
+   rather than the line box, so the row reads evenly however the font hangs its ascent and descent
+   — and since the trimmed box ends at the baseline, the clip gets its descenders back by hand. */
+.message {
+	flex: 0 1 auto;
+	min-width: 0;
+	margin-block-end: -0.25em;
+	padding-block-end: 0.25em;
+	overflow: hidden;
+	text-box: trim-both cap alphabetic;
+	text-overflow: ellipsis;
+}
+
+/* Fences the way out off from what it would be closing, down the middle of its own lane. */
+.divider {
+	align-self: stretch;
+	width: 1px;
+	min-height: 20px;
+	margin-inline: 3.5px;
+	background-color: var(--border-3);
+}
+
+/* The button's own padding is optical rather than structural, so the design seats it in a slot 2px
+   narrower on each side and lets the glyph, not the hit area, line up with the sentence above. */
+.dismiss {
+	margin-inline: -2px;
+}

--- a/apps/lite/ui/src/components/Snackbar.stories.tsx
+++ b/apps/lite/ui/src/components/Snackbar.stories.tsx
@@ -1,0 +1,76 @@
+import preview from "#storybook/preview";
+import { Snackbar, type SnackbarVariant } from "./Snackbar.tsx";
+
+const meta = preview.meta({
+	component: Snackbar,
+	argTypes: {
+		variant: {
+			control: "inline-radio",
+			options: ["info", "danger", "safe"] satisfies Array<SnackbarVariant>,
+		},
+		icon: { control: "text" },
+	},
+	args: {
+		variant: "info",
+		children: "Info. Snackbar message",
+		onDismiss: () => {},
+	},
+});
+
+/** The snackbar as the design states it: a glyph, a sentence, and a way out. */
+export const Default = meta.story({});
+
+/** One surface, three glyphs: only the leading icon says how the news landed. */
+export const AllVariants = meta.story({
+	render: () => (
+		<div style={{ display: "flex", flexDirection: "column", alignItems: "start", gap: 12 }}>
+			<Snackbar>Info. Snackbar message</Snackbar>
+			<Snackbar variant="danger">Danger. Snackbar message</Snackbar>
+			<Snackbar variant="safe">Success. Snackbar message</Snackbar>
+		</div>
+	),
+});
+
+/** With `onDismiss` the snackbar grows a divider and a close button, and the row with it. */
+export const WithDismiss = meta.story({
+	render: () => (
+		<div style={{ display: "flex", flexDirection: "column", alignItems: "start", gap: 12 }}>
+			<Snackbar onDismiss={() => {}}>Info. Snackbar message</Snackbar>
+			<Snackbar variant="danger" onDismiss={() => {}}>
+				Danger. Snackbar message
+			</Snackbar>
+			<Snackbar variant="safe" onDismiss={() => {}}>
+				Success. Snackbar message
+			</Snackbar>
+		</div>
+	),
+});
+
+/** `icon` overrides the variant's own glyph without changing what the snackbar means. */
+export const CustomIcon = meta.story({
+	render: () => (
+		<div style={{ display: "flex", flexDirection: "column", alignItems: "start", gap: 12 }}>
+			<Snackbar icon="spinner">Absorbing…</Snackbar>
+			<Snackbar icon="absorb" onDismiss={() => {}}>
+				Couldn’t work out where to absorb
+			</Snackbar>
+			<Snackbar variant="safe" icon="commit">
+				Changes absorbed into 3 commits
+			</Snackbar>
+		</div>
+	),
+});
+
+/** A sentence wider than the space it has ellipsises rather than widening the snackbar. */
+export const LongMessage = meta.story({
+	render: () => (
+		<div style={{ display: "flex", flexDirection: "column", gap: 12, width: 320 }}>
+			<Snackbar icon="absorb" onDismiss={() => {}}>
+				Couldn’t work out where to absorb these changes, so nothing was moved anywhere at all
+			</Snackbar>
+			<Snackbar variant="danger" onDismiss={() => {}}>
+				The commit could not be created because the workspace has conflicts left in it
+			</Snackbar>
+		</div>
+	),
+});

--- a/apps/lite/ui/src/components/Snackbar.tsx
+++ b/apps/lite/ui/src/components/Snackbar.tsx
@@ -1,0 +1,83 @@
+import { classes } from "#ui/components/classes.ts";
+import { getButtonClassName } from "#ui/components/Button.tsx";
+import { Icon } from "./Icon.tsx";
+import type { IconName } from "./iconNames.ts";
+import styles from "./Snackbar.module.css";
+import { Button } from "@base-ui/react";
+import { Match } from "effect";
+import type { ComponentProps, FC } from "react";
+
+/** @public */
+export type SnackbarVariant =
+	/** Something happened worth saying, with no verdict attached. */
+	| "info"
+	/** An act that failed, or refused to run. */
+	| "danger"
+	/** An act that came off. */
+	| "safe";
+
+/** The glyph a variant leads with when the caller names none of its own. */
+const defaultIcon = (variant: SnackbarVariant): IconName =>
+	Match.value(variant).pipe(
+		Match.when("info", () => "info" as const),
+		Match.when("danger", () => "danger" as const),
+		Match.when("safe", () => "tick" as const),
+		Match.exhaustive,
+	);
+
+/**
+ * One line of consequence, floated over the surface that caused it: a glyph, a sentence, and — when
+ * it needs dismissing by hand — a way out fenced off behind a divider. A whole {@link Toasts} card
+ * would state a title and a description; a snackbar has only the sentence, so it can sit close to
+ * the thing it is about rather than in the corner of the window.
+ *
+ * Every variant wears the same surface: the verdict is carried by the glyph alone, so a run of
+ * snackbars reads as one row of statements rather than a traffic light.
+ *
+ * @public
+ */
+export const Snackbar: FC<
+	{
+		variant?: SnackbarVariant;
+		/** Overrides the variant's own glyph. */
+		icon?: IconName;
+		/** Given, the snackbar carries a close button; otherwise it says its piece and nothing more. */
+		onDismiss?: () => void;
+		dismissLabel?: string;
+	} & ComponentProps<"div">
+> = ({ variant = "info", icon, onDismiss, dismissLabel = "Dismiss", children, ...props }) => (
+	<div
+		// A failure interrupts; the other two are there to be read whenever the reader gets to them.
+		role={variant === "danger" ? "alert" : "status"}
+		{...props}
+		className={classes(
+			props.className,
+			styles.snackbar,
+			"text-12",
+			Match.value(variant).pipe(
+				Match.when("info", () => styles.info),
+				Match.when("danger", () => styles.danger),
+				Match.when("safe", () => styles.safe),
+				Match.exhaustive,
+			),
+		)}
+	>
+		<Icon name={icon ?? defaultIcon(variant)} size={14} className={styles.icon} />
+		<span className={styles.message}>{children}</span>
+		{onDismiss !== undefined && (
+			<>
+				<div aria-hidden className={styles.divider} />
+				<Button
+					aria-label={dismissLabel}
+					className={classes(
+						getButtonClassName({ variant: "ghost", size: "small", iconOnly: true }),
+						styles.dismiss,
+					)}
+					onClick={onDismiss}
+				>
+					<Icon name="cross" />
+				</Button>
+			</>
+		)}
+	</div>
+);

--- a/apps/lite/ui/src/components/Toolbox.module.css
+++ b/apps/lite/ui/src/components/Toolbox.module.css
@@ -1,0 +1,107 @@
+/* A type selector rides above the toolbox it qualifies as its own card, so the choice reads as
+   something asked before the operation rather than a step within it. */
+.stack {
+	display: flex;
+	row-gap: 4px;
+	flex-direction: column;
+	align-items: stretch;
+}
+
+.toolbox {
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+	border: 1px solid var(--border-2);
+	/* The design names `--radius-m`; the token set spells that size `--radius-lg`. */
+	border-radius: var(--radius-lg);
+	background-color: var(--bg-1);
+	box-shadow: var(--shadow-md);
+}
+
+.meta {
+	display: flex;
+	column-gap: 6px;
+	align-items: center;
+
+	/* Trimming leaves the runs cap-tall, so the strip has to state the height the line box used
+	   to give it — otherwise a meta without an icon collapses around its caps. */
+	min-block-size: calc(1lh + 8px + 8px + 1px);
+	padding: 8px 10px;
+	overflow: hidden;
+	border-bottom: 1px solid var(--border-2);
+	background-color: var(--bg-mute);
+	color: var(--text-2);
+	white-space: nowrap;
+
+	/* Centre the strip on the cap band rather than on the line box, so the row reads evenly
+	   however the font distributes its ascent and descent around the caps. Bare text would land
+	   in an anonymous flex item nothing can target, so every run comes wrapped. */
+	& > * {
+		text-box-trim: trim-both;
+		text-box-edge: cap alphabetic;
+	}
+
+	/* The sentence a transfer states — "Move <source> below <target>" — leans on
+	   the surrounding mute to pick its own words out. */
+	& strong {
+		flex-shrink: 0;
+		color: var(--text-1);
+		font-weight: inherit;
+	}
+}
+
+.metaIcon {
+	flex-shrink: 0;
+	color: var(--text-3);
+}
+
+/* Each stretch of the sentence takes the width it needs and gives it back before the words around
+   it do, so a short subject leaves no gap. The cap keeps a long branch name or commit subject from
+   widening the card to hold it: past a readable run the sentence ellipsises instead. */
+.metaText {
+	flex: 0 1 auto;
+	min-width: 0;
+	max-width: 16ch;
+	/* This run clips to its box for the ellipsis, and the trimmed box ends at the baseline — so
+	   descenders get room inside the clip, taken straight back off the box that gets centred. */
+	margin-block-end: -0.25em;
+	padding-block-end: 0.25em;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+/* Pinned to the end of the strip: the chord that closes the toolbox, stated where the button used
+   to say it. */
+.metaHint {
+	flex-shrink: 0;
+	margin-inline-start: auto;
+	padding-inline-start: 8px;
+	color: var(--text-3);
+}
+
+.section {
+	display: flex;
+	column-gap: 4px;
+	align-items: center;
+	padding: 10px;
+
+	& + & {
+		border-top: 1px solid var(--border-3);
+	}
+
+	&:where(.confirm) {
+		justify-content: end;
+	}
+
+	&:where(.stretch) > * {
+		flex: 1;
+		min-width: 0;
+	}
+}
+
+.separator {
+	align-self: stretch;
+	width: 1px;
+	margin-inline: 4px;
+	background-color: var(--border-3);
+}

--- a/apps/lite/ui/src/components/Toolbox.module.css
+++ b/apps/lite/ui/src/components/Toolbox.module.css
@@ -29,7 +29,7 @@
 	padding: 8px 10px;
 	overflow: hidden;
 	border-bottom: 1px solid var(--border-2);
-	background-color: var(--bg-mute);
+	background-color: var(--bg-2);
 	color: var(--text-2);
 	white-space: nowrap;
 

--- a/apps/lite/ui/src/components/Toolbox.stories.tsx
+++ b/apps/lite/ui/src/components/Toolbox.stories.tsx
@@ -1,0 +1,171 @@
+import preview from "#storybook/preview";
+import { getButtonClassName } from "./Button.tsx";
+import { Icon } from "./Icon.tsx";
+import { Kbd } from "./Kbd.tsx";
+import {
+	Toolbox,
+	ToolboxMeta,
+	ToolboxMetaHint,
+	ToolboxMetaText,
+	ToolboxSection,
+	ToolboxSeparator,
+	ToolboxStack,
+} from "./Toolbox.tsx";
+import { ToggleGroupStyles, ToggleStyles } from "./ToggleGroup.tsx";
+import { ToggleGroup, Toggle } from "@base-ui/react";
+import type { ButtonVariant } from "./Button.tsx";
+import type { FC } from "react";
+
+const meta = preview.meta({
+	component: Toolbox,
+	parameters: {
+		// The toolbox floats over a workspace; previewing it flush against the canvas edge clips
+		// the border and shadow that give it its lift.
+		layout: "centered",
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/EBuHQGUcCaSw4Ln5uVpWkn/Lite?node-id=4272-2053",
+		},
+	},
+});
+
+const Action: FC<{ label: string; hotkey?: string; variant?: ButtonVariant; small?: boolean }> = ({
+	label,
+	hotkey,
+	variant,
+	small,
+}) => (
+	<button
+		type="button"
+		className={getButtonClassName({ variant, size: small ? "small" : "regular" })}
+	>
+		{label}
+		{hotkey !== undefined && <Kbd hotkey={hotkey} variant="button" />}
+	</button>
+);
+
+/**
+ * The acts on a checked set run without confirming, so each one is its own button. With nothing
+ * pending to abandon, the way out is a close affordance and its chord is stated in the strip.
+ */
+export const Actions = meta.story({
+	render: () => (
+		<Toolbox>
+			<ToolboxMeta icon="commit">
+				<span>3 commits selected</span>
+				<ToolboxMetaHint>Esc to close</ToolboxMetaHint>
+			</ToolboxMeta>
+			<ToolboxSection>
+				<Action label="Absorb" hotkey="A" />
+				<Action label="Cut" hotkey="Mod+X" />
+				<Action label="Discard" hotkey="Mod+Backspace" variant="danger" />
+				<ToolboxSeparator />
+				<button
+					type="button"
+					aria-label="Cancel"
+					className={getButtonClassName({ variant: "ghost", iconOnly: true })}
+				>
+					<Icon name="cross" />
+				</button>
+			</ToolboxSection>
+		</Toolbox>
+	),
+});
+
+/** An operation still being aimed asks for a placement, then for confirmation. */
+export const WithConfirmation = meta.story({
+	render: () => (
+		<Toolbox style={{ width: 270 }}>
+			<ToolboxMeta icon="file-diff">
+				<span>3 files selected</span>
+			</ToolboxMeta>
+			<ToolboxSection variant="stretch">
+				<ToggleGroup render={<ToggleGroupStyles />} defaultValue={["above"]} aria-label="Placement">
+					<Toggle render={<ToggleStyles />} value="above">
+						Above <Kbd hotkey="A" variant="button" />
+					</Toggle>
+					<Toggle render={<ToggleStyles />} value="below">
+						Below <Kbd hotkey="B" variant="button" />
+					</Toggle>
+					<Toggle render={<ToggleStyles />} value="into">
+						Into <Kbd hotkey="I" variant="button" />
+					</Toggle>
+				</ToggleGroup>
+			</ToolboxSection>
+			<ToolboxSection variant="confirm">
+				<Action label="Move commit" hotkey="Mod+Enter" variant="gray" small />
+				<Action label="Cancel" hotkey="Escape" small />
+			</ToolboxSection>
+		</Toolbox>
+	),
+});
+
+/**
+ * A transfer that can be copied picks its kind in an addon above, and states its subject as a
+ * sentence.
+ */
+export const WithTypeSelector = meta.story({
+	render: () => (
+		<ToolboxStack style={{ width: 322 }}>
+			<Toolbox>
+				<ToolboxSection variant="stretch">
+					<ToggleGroup render={<ToggleGroupStyles />} defaultValue={["move"]} aria-label="Kind">
+						<Toggle render={<ToggleStyles />} value="move">
+							Move <Kbd hotkey="M" variant="button" />
+						</Toggle>
+						<Toggle render={<ToggleStyles />} value="copy">
+							Copy <Kbd hotkey="C" variant="button" />
+						</Toggle>
+					</ToggleGroup>
+				</ToolboxSection>
+			</Toolbox>
+			<Toolbox>
+				<ToolboxMeta icon="commit">
+					<strong>Move</strong>
+					<ToolboxMetaText>docs: update endpoint documentation</ToolboxMetaText>
+					<strong>below</strong>
+					<ToolboxMetaText>migrate BaseButton to TypeScript</ToolboxMetaText>
+				</ToolboxMeta>
+				<ToolboxSection variant="stretch">
+					<ToggleGroup
+						render={<ToggleGroupStyles />}
+						defaultValue={["above"]}
+						aria-label="Placement"
+					>
+						<Toggle render={<ToggleStyles />} value="above">
+							Above <Kbd hotkey="A" variant="button" />
+						</Toggle>
+						<Toggle render={<ToggleStyles />} value="below">
+							Below <Kbd hotkey="B" variant="button" />
+						</Toggle>
+						<Toggle render={<ToggleStyles />} value="into">
+							Into <Kbd hotkey="I" variant="button" />
+						</Toggle>
+					</ToggleGroup>
+				</ToolboxSection>
+				<ToolboxSection variant="confirm">
+					<Action label="Cherry-pick" hotkey="Mod+Enter" variant="gray" small />
+					<Action label="Cancel" hotkey="Escape" small />
+				</ToolboxSection>
+			</Toolbox>
+		</ToolboxStack>
+	),
+});
+
+/** Nothing but the choice, for a toolbox that has already stated its subject elsewhere. */
+export const TypeAddon = meta.story({
+	render: () => (
+		<Toolbox style={{ width: 322 }}>
+			<ToolboxSection variant="stretch">
+				<ToggleGroup render={<ToggleGroupStyles />} defaultValue={["move"]} aria-label="Kind">
+					<Toggle render={<ToggleStyles />} value="move">
+						Move <Kbd hotkey="M" variant="button" />
+					</Toggle>
+					<Toggle render={<ToggleStyles />} value="copy">
+						Copy <Kbd hotkey="C" variant="button" />
+					</Toggle>
+				</ToggleGroup>
+			</ToolboxSection>
+		</Toolbox>
+	),
+});

--- a/apps/lite/ui/src/components/Toolbox.tsx
+++ b/apps/lite/ui/src/components/Toolbox.tsx
@@ -1,0 +1,97 @@
+import { classes } from "#ui/components/classes.ts";
+import { Icon } from "./Icon.tsx";
+import type { IconName } from "./iconNames.ts";
+import styles from "./Toolbox.module.css";
+import type { ComponentProps, FC, ReactNode } from "react";
+
+/**
+ * Toolboxes that belong to one operation, stacked. An addon — a type selector qualifying what the
+ * toolbox below it will do — is a card of its own rather than a section, so it reads as a question
+ * asked before the operation rather than a step within it.
+ *
+ * @public
+ */
+export const ToolboxStack: FC<ComponentProps<"div">> = (props) => (
+	<div {...props} className={classes(props.className, styles.stack)} />
+);
+
+/**
+ * A floating card of things to do with what is currently in hand — a checked set, a transfer
+ * being aimed, an absorb waiting on its plan. It states its subject in a {@link ToolboxMeta}
+ * strip and stacks one {@link ToolboxSection} per decision the subject still needs.
+ *
+ * @public
+ */
+export const Toolbox: FC<ComponentProps<"div">> = (props) => (
+	<div {...props} className={classes(props.className, styles.toolbox)} />
+);
+
+/**
+ * What the sections below are about, as a line of muted text. `strong` children read as the
+ * subject's own words against it.
+ *
+ * @public
+ */
+export const ToolboxMeta: FC<ComponentProps<"div"> & { icon?: IconName }> = ({
+	icon,
+	children,
+	...props
+}) => (
+	<div {...props} className={classes(props.className, styles.meta, "text-12")}>
+		{icon !== undefined && <Icon name={icon} size={14} className={styles.metaIcon} />}
+		{children}
+	</div>
+);
+
+/**
+ * A run of {@link ToolboxMeta} that gives up its width before the words around it do, so a long
+ * commit message ellipsises rather than pushing the rest of the sentence out of the card.
+ *
+ * @public
+ */
+export const ToolboxMetaText: FC<{ children: ReactNode }> = ({ children }) => (
+	<span className={styles.metaText}>{children}</span>
+);
+
+/**
+ * A hint pinned to the end of the strip. The toolbox's own acts wear their chords, so the one that
+ * closes it says so here rather than taking a labelled button's worth of the row.
+ *
+ * @public
+ */
+export const ToolboxMetaHint: FC<{ children: ReactNode }> = ({ children }) => (
+	<span className={styles.metaHint}>{children}</span>
+);
+
+/** @public */
+export type ToolboxSectionVariant =
+	/** Acts, packed from the start. */
+	| "actions"
+	/** One control — a toggle group — filling the width. */
+	| "stretch"
+	/** What ends the operation, gathered at the end. */
+	| "confirm";
+
+/** @public */
+export const ToolboxSection: FC<ComponentProps<"div"> & { variant?: ToolboxSectionVariant }> = ({
+	variant = "actions",
+	...props
+}) => (
+	<div
+		{...props}
+		className={classes(
+			props.className,
+			styles.section,
+			variant === "stretch" && styles.stretch,
+			variant === "confirm" && styles.confirm,
+		)}
+	/>
+);
+
+/**
+ * Divides one run of acts from another within a section — what leaves the operation from what
+ * carries it out.
+ *
+ * @public
+ */
+export const ToolboxSeparator: FC = () => <div className={styles.separator} />;

--- a/apps/lite/ui/src/main.tsx
+++ b/apps/lite/ui/src/main.tsx
@@ -1,4 +1,4 @@
-import { MutationCache, QueryClient, focusManager } from "@tanstack/react-query";
+import { MutationCache, QueryCache, QueryClient, focusManager } from "@tanstack/react-query";
 import { App } from "#ui/App.tsx";
 import { endpointOf, invalidateDeclared } from "#ui/api/tags.ts";
 import { createAppRouter } from "#ui/router.ts";
@@ -21,6 +21,14 @@ const queryClient: QueryClient = new QueryClient({
 			staleTime: Number.POSITIVE_INFINITY,
 		},
 	},
+	// A failed query reports itself where its data would have gone — a panel says so in place
+	// rather than raising a toast — but the reason has to land somewhere.
+	queryCache: new QueryCache({
+		onError: (error) => {
+			// oxlint-disable-next-line no-console
+			console.error(error);
+		},
+	}),
 	// A mutation's cache effects come from its endpoint's `invalidates`
 	// declaration, recognized by the `mutationFn` itself, and its failure
 	// toast from `meta.failureTitle`; per-mutation handlers keep only

--- a/apps/lite/ui/src/operations/diff-specs.ts
+++ b/apps/lite/ui/src/operations/diff-specs.ts
@@ -22,14 +22,25 @@ export const createDiffSpec = (change: TreeChange, hunkHeaders: Array<HunkHeader
 		change.status.type === "Addition" || change.status.type === "Deletion" ? [] : hunkHeaders,
 });
 
+/**
+ * Which form a hunk's headers take. `commit` names only the selected lines, which is what keeping
+ * them somewhere else — committing, moving, absorbing — asks for; `discard` names them within the
+ * whole hunk, which is what taking them away — discarding, uncommitting — asks for. Left unsaid it
+ * follows from the parent, the form moving a hunk wants: uncommitted lines are being committed,
+ * committed ones taken back out of their commit.
+ */
+type HunkAction = "commit" | "discard";
+
 const resolvedDiffSpecsFromAddress = ({
 	address,
 	worktreeChanges,
 	commitDetails,
+	hunkAction,
 }: {
 	address: Address;
 	worktreeChanges: WorktreeChanges | undefined;
 	commitDetails: CommitDetails | undefined;
+	hunkAction: HunkAction | undefined;
 }) =>
 	Match.value(address).pipe(
 		Match.withReturnType<Array<DiffSpec> | null>(),
@@ -75,7 +86,7 @@ const resolvedDiffSpecsFromAddress = ({
 
 				const hunkHeaders = diffSpecHunkHeadersForLineSelection(
 					lineSelection,
-					parent.parent._tag === "UncommittedChanges" ? "commit" : "discard",
+					hunkAction ?? (parent.parent._tag === "UncommittedChanges" ? "commit" : "discard"),
 				);
 
 				return [createDiffSpec(change, hunkHeaders)];
@@ -120,10 +131,12 @@ const resolvedDiffSpecsFromSources = ({
 	sources,
 	worktreeChanges,
 	commitDetails,
+	hunkAction,
 }: {
 	sources: Array<Address>;
 	worktreeChanges: WorktreeChanges | undefined;
 	commitDetails: CommitDetails | undefined;
+	hunkAction: HunkAction | undefined;
 }): Array<DiffSpec> | null => {
 	const diffSpecsByPath = new Map<string, DiffSpec>();
 
@@ -132,6 +145,7 @@ const resolvedDiffSpecsFromSources = ({
 			address,
 			worktreeChanges,
 			commitDetails,
+			hunkAction,
 		});
 		if (!resolvedDiffSpecs) return null;
 
@@ -158,10 +172,12 @@ export const resolveDiffSpecs = async ({
 	sources,
 	projectId,
 	queryClient,
+	hunkAction,
 }: {
 	sources: Array<Address>;
 	projectId: string;
 	queryClient: QueryClient;
+	hunkAction?: HunkAction;
 }) => {
 	const fileParent = fileParentFromSources(sources);
 	if (!fileParent) return null;
@@ -178,15 +194,18 @@ export const resolveDiffSpecs = async ({
 		sources,
 		worktreeChanges,
 		commitDetails,
+		hunkAction,
 	});
 };
 
 export const useResolveDiffSpecs = ({
 	sources,
 	projectId,
+	hunkAction,
 }: {
 	sources?: Array<Address>;
 	projectId: string;
+	hunkAction?: HunkAction;
 }) => {
 	const { data: worktreeChanges } = useQuery(changesInWorktreeQueryOptions(projectId));
 
@@ -205,5 +224,6 @@ export const useResolveDiffSpecs = ({
 		sources,
 		worktreeChanges,
 		commitDetails,
+		hunkAction,
 	});
 };

--- a/apps/lite/ui/src/operations/diff-specs.ts
+++ b/apps/lite/ui/src/operations/diff-specs.ts
@@ -109,7 +109,7 @@ const commitIdFromParent = (parent: FileParent) =>
  * Gets the file parent from an array of sibling sources, if any. Disparate file parents are not
  * currently supported.
  */
-const fileParentFromSources = (sources: Array<Address>): FileParent | null => {
+export const fileParentFromSources = (sources: Array<Address>): FileParent | null => {
 	const [source, ...rest] = sources;
 	if (!source) return null;
 

--- a/apps/lite/ui/src/projects/project.ts
+++ b/apps/lite/ui/src/projects/project.ts
@@ -81,6 +81,12 @@ type WorkspaceState = {
 	foldedSegments: Record<string, true>;
 	highlightedCommitIds: Array<string>;
 	pendingOperation: PendingOperation;
+	/**
+	 * What became of the last operation that ended without one, stated where the operation's own
+	 * controls stood. An operation that cannot run must not hold the workspace open waiting to be
+	 * aimed, so it clears itself and leaves this behind to say why.
+	 */
+	notice: string | null;
 	selectedBranchTabs: Record<string, BranchTab>;
 	/**
 	 * The diff cursor. Its five siblings live in the URL (use-cursor.ts); this
@@ -115,6 +121,7 @@ const createInitialWorkspaceState = (): WorkspaceState => ({
 	foldedSegments: {},
 	highlightedCommitIds: [],
 	pendingOperation: noPendingOperation,
+	notice: null,
 	selectedBranchTabs: {},
 	diffCursor: null,
 	uncommittedFilesFilter: null,
@@ -161,6 +168,7 @@ export const projectReducers = {
 	},
 	startInlineEdit: (state: ProjectState, edit: PendingInlineEdit) => {
 		state.workspace.pendingOperation = pendingInlineEdit(edit);
+		state.workspace.notice = null;
 	},
 	updateRewrittenBranchReferences: (
 		state: ProjectState,
@@ -201,6 +209,7 @@ export const projectReducers = {
 	},
 	startTransfer: (state: ProjectState, { transfer }: { transfer: PendingTransfer }) => {
 		state.workspace.pendingOperation = pendingTransfer(transfer);
+		state.workspace.notice = null;
 	},
 	startKeyboardTransfer: (
 		state: ProjectState,
@@ -227,6 +236,7 @@ export const projectReducers = {
 				restoreFocus,
 			}),
 		);
+		state.workspace.notice = null;
 	},
 	startAbsorb: (
 		state: ProjectState,
@@ -241,6 +251,7 @@ export const projectReducers = {
 		},
 	) => {
 		state.workspace.pendingOperation = pendingAbsorb({ sources, restoreSelection, sourceTarget });
+		state.workspace.notice = null;
 	},
 	updatePointerTransfer: (
 		state: ProjectState,
@@ -306,6 +317,14 @@ export const projectReducers = {
 	},
 	clearPendingOperation: (state: ProjectState) => {
 		state.workspace.pendingOperation = noPendingOperation;
+	},
+	/** Ends the pending operation and says why in its place. */
+	refusePendingOperation: (state: ProjectState, { notice }: { notice: string }) => {
+		state.workspace.pendingOperation = noPendingOperation;
+		state.workspace.notice = notice;
+	},
+	clearNotice: (state: ProjectState) => {
+		state.workspace.notice = null;
 	},
 	setHighlightedCommitIds: (
 		state: ProjectState,
@@ -593,6 +612,7 @@ export const projectSelectors = {
 		conflictCheckKey(conflict) in state.workspace.checkedConflicts,
 	selectCheckedConflicts: selectCheckedConflictsFor,
 	selectPendingOperation: (state: ProjectState) => state.workspace.pendingOperation,
+	selectNotice: (state: ProjectState) => state.workspace.notice,
 	selectFoldedSegments: (state: ProjectState) => state.workspace.foldedSegments,
 	selectSegmentFolded: (state: ProjectState, branchRef: string) =>
 		state.workspace.foldedSegments[branchRef] === true,

--- a/apps/lite/ui/src/routes/project/$id/workspace/OperationControls.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OperationControls.module.css
@@ -1,4 +1,7 @@
-/* The toolbox floats over the workspace; the card itself is `components/Toolbox.tsx`. */
+.notice {
+	align-self: center;
+}
+
 .container {
 	z-index: 1;
 	position: fixed;

--- a/apps/lite/ui/src/routes/project/$id/workspace/OperationControls.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OperationControls.module.css
@@ -1,78 +1,9 @@
+/* The toolbox floats over the workspace; the card itself is `components/Toolbox.tsx`. */
 .container {
-	display: flex;
 	z-index: 1;
 	position: fixed;
 	bottom: var(--panel-padding-block);
 	left: 50%;
-	row-gap: 12px;
-	flex-direction: column;
-	max-width: min(calc(100% - (2 * var(--panel-padding-inline))), 500px);
-	padding: 12px;
-	overflow: hidden;
+	max-width: min(calc(100% - (2 * var(--panel-padding-inline))), 640px);
 	transform: translateX(-50%);
-	border: 1px solid light-dark(rgb(0 0 0 / 0.2), rgb(255 255 255 / 0.16));
-	border-radius: var(--radius-2xl);
-	background-color: var(--bg-1);
-	box-shadow: var(--shadow-md);
-	text-overflow: ellipsis;
-	white-space: nowrap;
-	/* The checked-set bar carries a row of actions alongside its count, which the
-	   width the transfer toolbar needs would truncate. */
-	&:has(.actions) {
-		max-width: min(calc(100% - (2 * var(--panel-padding-inline))), 640px);
-	}
-}
-
-.toggleGroupRow {
-	display: flex;
-}
-
-.toggleGroupRowToggle {
-	display: flex;
-	row-gap: 8px;
-	flex: 1;
-	flex-direction: column;
-	justify-content: end;
-	padding: 8px;
-	border-radius: var(--radius-lg);
-	text-align: center;
-
-	&[data-pressed] {
-		background-color: var(--bg-2);
-	}
-}
-
-.operationLabel {
-	color: var(--text-2);
-}
-
-.separator {
-	border-top: 1px solid var(--border-2);
-}
-
-.controlsRow {
-	display: flex;
-	column-gap: 12px;
-	align-items: center;
-}
-
-.label {
-	overflow: hidden;
-	text-overflow: ellipsis;
-}
-
-.actions {
-	display: flex;
-	column-gap: 4px;
-	margin-left: auto;
-}
-
-.controls {
-	display: flex;
-	column-gap: 4px;
-	margin-left: auto;
-
-	& > * {
-		flex: 1;
-	}
 }

--- a/apps/lite/ui/src/routes/project/$id/workspace/OperationControls.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OperationControls.module.css
@@ -16,6 +16,11 @@
 	box-shadow: var(--shadow-md);
 	text-overflow: ellipsis;
 	white-space: nowrap;
+	/* The checked-set bar carries a row of actions alongside its count, which the
+	   width the transfer toolbar needs would truncate. */
+	&:has(.actions) {
+		max-width: min(calc(100% - (2 * var(--panel-padding-inline))), 640px);
+	}
 }
 
 .toggleGroupRow {
@@ -54,6 +59,12 @@
 .label {
 	overflow: hidden;
 	text-overflow: ellipsis;
+}
+
+.actions {
+	display: flex;
+	column-gap: 4px;
+	margin-left: auto;
 }
 
 .controls {

--- a/apps/lite/ui/src/routes/project/$id/workspace/OperationControls.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OperationControls.tsx
@@ -8,6 +8,7 @@ import {
 import { absorptionPlanQueryOptions, headInfoQueryOptions } from "#ui/api/queries.ts";
 import { getHeadInfoIndex, type HeadInfoIndex } from "#ui/api/ref-info.ts";
 import { getButtonClassName, type ButtonSize, type ButtonVariant } from "#ui/components/Button.tsx";
+import { ChipToast } from "#ui/components/ChipToast.tsx";
 import { Icon } from "#ui/components/Icon.tsx";
 import type { IconName } from "#ui/components/iconNames.ts";
 import { Kbd } from "#ui/components/Kbd.tsx";
@@ -38,7 +39,7 @@ import { Button, Toggle, ToggleGroup } from "@base-ui/react";
 import { useHotkeys, type UseHotkeyDefinition } from "@tanstack/react-hotkeys";
 import { useQuery } from "@tanstack/react-query";
 import { Match } from "effect";
-import type { FC, ReactNode } from "react";
+import { useEffect, type FC, type ReactNode } from "react";
 import styles from "./OperationControls.module.css";
 import {
 	type PendingAbsorb,
@@ -48,6 +49,9 @@ import {
 } from "#ui/operations/pending-operation.ts";
 import type { FocusScope } from "#ui/focus-scopes.ts";
 import type { AddressSpace } from "#ui/workspace/address-space.ts";
+
+/** How long a notice stands before it takes itself away. */
+const NOTICE_TIMEOUT_MS = 5_000;
 
 const Container: FC<{ children: ReactNode }> = ({ children }) => (
 	<div className={styles.container}>
@@ -143,9 +147,9 @@ const useControlHotkeys = ({
  * The way out of a toolbox that has nothing pending to abandon: a close affordance rather than a
  * peer of the acts beside it, with its chord stated in the strip above.
  */
-const CloseButton: FC<{ onCancel: () => void }> = ({ onCancel }) => (
+const CloseButton: FC<{ onCancel: () => void; size?: ButtonSize }> = ({ onCancel, size }) => (
 	<Button
-		className={getButtonClassName({ variant: "ghost", iconOnly: true })}
+		className={getButtonClassName({ variant: "ghost", iconOnly: true, size })}
 		aria-label="Cancel"
 		onMouseDown={(event) => {
 			// Prevent stealing focus from the tree.
@@ -210,33 +214,31 @@ const CheckedAddressOperationControls: FC<{
 	);
 
 	return (
-		<Container>
-			<Toolbox>
-				<ToolboxMeta icon={icon}>
-					<span>
-						{new Intl.NumberFormat().format(checkedAddressCount)} {noun}
-						{new Intl.PluralRules().select(checkedAddressCount) !== "one" && "s"} selected
-					</span>
-					<ToolboxMetaHint>
-						{formatForDisplaySorted(operationHotkeys.cancel.hotkey)} to close
-					</ToolboxMetaHint>
-				</ToolboxMeta>
-				<ToolboxSection>
-					{actions.map((action) => (
-						<ToolboxButton
-							key={action.label}
-							label={action.label}
-							hotkey={action.hotkey}
-							variant={action.variant}
-							enabled={action.enabled}
-							onClick={action.run}
-						/>
-					))}
-					{actions.length > 0 && <ToolboxSeparator />}
-					<CloseButton onCancel={cancel} />
-				</ToolboxSection>
-			</Toolbox>
-		</Container>
+		<Toolbox>
+			<ToolboxMeta icon={icon}>
+				<span>
+					{new Intl.NumberFormat().format(checkedAddressCount)} {noun}
+					{new Intl.PluralRules().select(checkedAddressCount) !== "one" && "s"} selected
+				</span>
+				<ToolboxMetaHint>
+					{formatForDisplaySorted(operationHotkeys.cancel.hotkey)} to close
+				</ToolboxMetaHint>
+			</ToolboxMeta>
+			<ToolboxSection>
+				{actions.map((action) => (
+					<ToolboxButton
+						key={action.label}
+						label={action.label}
+						hotkey={action.hotkey}
+						variant={action.variant}
+						enabled={action.enabled}
+						onClick={action.run}
+					/>
+				))}
+				{actions.length > 0 && <ToolboxSeparator />}
+				<CloseButton onCancel={cancel} />
+			</ToolboxSection>
+		</Toolbox>
 	);
 };
 
@@ -267,21 +269,38 @@ const AbsorbOperationControls: FC<{
 	const confirm: Confirm = { label: "Absorb", canRun: canAbsorb, onRun: run };
 	useControlHotkeys({ onCancel: cancel, confirm });
 
+	const sourcesLabel = addressesLabel({ headInfoIndex, addresses: pending.sources });
+
+	// The plan answers where these changes belong. With no answer — because nothing owns them, or
+	// because working it out failed — there is nothing left to aim, and an operation that cannot be
+	// aimed must not hold the workspace open: it stands down and leaves a notice saying why.
+	const refusal = isAbsorptionPlanPending
+		? null
+		: isAbsorptionPlanError
+			? `Couldn’t work out where to absorb ${sourcesLabel}`
+			: canAbsorb
+				? null
+				: `Nothing to absorb ${sourcesLabel} into`;
+
+	useEffect(() => {
+		if (refusal === null) return;
+
+		dispatch(projectSlice.actions.refusePendingOperation({ projectId, notice: refusal }));
+	}, [dispatch, projectId, refusal]);
+
+	if (refusal !== null) return null;
+
 	return (
 		<Container>
 			<Toolbox>
 				<ToolboxMeta icon={isAbsorptionPlanPending ? "spinner" : "absorb"}>
 					{isAbsorptionPlanPending ? (
 						<span>Loading absorb plan</span>
-					) : isAbsorptionPlanError ? (
-						<span>Failed to load absorb plan</span>
 					) : (
 						<>
 							<strong>Absorb</strong>
-							<ToolboxMetaText>
-								{addressesLabel({ headInfoIndex, addresses: pending.sources })}
-							</ToolboxMetaText>
-							<strong>into {absorptionPlan.length} commits</strong>
+							<ToolboxMetaText>{sourcesLabel}</ToolboxMetaText>
+							<strong>into {absorptionPlan?.length ?? 0} commits</strong>
 						</>
 					)}
 				</ToolboxMeta>
@@ -514,16 +533,43 @@ export const OperationControls: FC<{
 	const checkedAddressCount = useAppSelector((state) =>
 		projectSlice.selectors.selectCheckedAddressCount(state, projectId),
 	);
+	const notice = useAppSelector((state) => projectSlice.selectors.selectNotice(state, projectId));
+	const dispatch = useAppDispatch();
+	const clearNotice = () => dispatch(projectSlice.actions.clearNotice({ projectId }));
+
+	// A notice is the end of something, not a thing to attend to: it carries no way out of its own
+	// and leaves on a click or on its own, so the only close button on screen belongs to whatever
+	// the workspace still has in hand.
+	useEffect(() => {
+		if (notice === null) return;
+
+		const timer = setTimeout(
+			() => dispatch(projectSlice.actions.clearNotice({ projectId })),
+			NOTICE_TIMEOUT_MS,
+		);
+		return () => clearTimeout(timer);
+	}, [dispatch, notice, projectId]);
 
 	return Match.value(pendingOperation).pipe(
 		Match.tagsExhaustive({
 			None: () =>
-				checkedAddressCount > 0 && (
-					<CheckedAddressOperationControls
-						checkedAddressCount={checkedAddressCount}
-						projectId={projectId}
-						appliedAddressSpace={appliedAddressSpace}
-					/>
+				(notice !== null || checkedAddressCount > 0) && (
+					<div className={styles.container}>
+						<ToolboxStack>
+							{notice !== null && (
+								<ChipToast variant="danger" className={styles.notice} onClick={clearNotice}>
+									{notice}
+								</ChipToast>
+							)}
+							{checkedAddressCount > 0 && (
+								<CheckedAddressOperationControls
+									checkedAddressCount={checkedAddressCount}
+									projectId={projectId}
+									appliedAddressSpace={appliedAddressSpace}
+								/>
+							)}
+						</ToolboxStack>
+					</div>
 				),
 			Absorb: (pending) =>
 				headInfoIndex && (

--- a/apps/lite/ui/src/routes/project/$id/workspace/OperationControls.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OperationControls.tsx
@@ -23,6 +23,10 @@ import {
 } from "#ui/operations/operation.ts";
 import { projectSlice } from "#ui/projects/state.ts";
 import { addressLabel, addressesLabel } from "#ui/routes/project/$id/workspace/addressLabel.ts";
+import {
+	useCheckedActions,
+	type CheckedAction,
+} from "#ui/routes/project/$id/workspace/useCheckedActions.ts";
 import { useAppDispatch, useAppSelector } from "#ui/store.ts";
 import { Button, Toggle, ToggleGroup, Tooltip } from "@base-ui/react";
 import { useHotkeys, type UseHotkeyDefinition } from "@tanstack/react-hotkeys";
@@ -139,10 +143,32 @@ const Controls: FC<{
 	);
 };
 
-const CheckedAddressOperationControls: FC<{ checkedAddressCount: number; projectId: string }> = ({
-	checkedAddressCount,
-	projectId,
-}) => {
+const CheckedActions: FC<{ actions: Array<CheckedAction> }> = ({ actions }) => (
+	<div className={styles.actions}>
+		{actions.map((action) => (
+			<Button
+				key={action.label}
+				className={getButtonClassName({ variant: action.variant })}
+				disabled={!action.enabled}
+				focusableWhenDisabled
+				onMouseDown={(event) => {
+					// Prevent stealing focus from the tree.
+					if (!event.defaultPrevented) event.preventDefault();
+				}}
+				onClick={action.run}
+			>
+				{action.label}
+				{action.hotkey !== undefined && <Kbd hotkey={action.hotkey} variant="button" />}
+			</Button>
+		))}
+	</div>
+);
+
+const CheckedAddressOperationControls: FC<{
+	checkedAddressCount: number;
+	projectId: string;
+	appliedAddressSpace: AddressSpace<Address>;
+}> = ({ checkedAddressCount, projectId, appliedAddressSpace }) => {
 	const dispatch = useAppDispatch();
 
 	const checkedType = useAppSelector((state): string | null => {
@@ -157,6 +183,7 @@ const CheckedAddressOperationControls: FC<{ checkedAddressCount: number; project
 				return null;
 		}
 	});
+	const actions = useCheckedActions({ projectId, appliedAddressSpace });
 	if (checkedType === null) return;
 
 	const cancel = () => {
@@ -170,6 +197,7 @@ const CheckedAddressOperationControls: FC<{ checkedAddressCount: number; project
 					{new Intl.NumberFormat().format(checkedAddressCount)} {checkedType}
 					{new Intl.PluralRules().select(checkedAddressCount) !== "one" && "s"} selected
 				</Label>
+				{actions.length > 0 && <CheckedActions actions={actions} />}
 				<Controls onCancel={cancel} />
 			</ControlsRow>
 		</Container>
@@ -461,6 +489,7 @@ export const OperationControls: FC<{
 					<CheckedAddressOperationControls
 						checkedAddressCount={checkedAddressCount}
 						projectId={projectId}
+						appliedAddressSpace={appliedAddressSpace}
 					/>
 				),
 			Absorb: (pending) =>

--- a/apps/lite/ui/src/routes/project/$id/workspace/OperationControls.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OperationControls.tsx
@@ -345,10 +345,9 @@ const TransferTypeToggleGroup: FC<{
 };
 
 const TransferKindToggleGroup: FC<{
-	canCopy: boolean;
 	kind: TransferKind;
 	projectId: string;
-}> = ({ canCopy, kind, projectId }) => {
+}> = ({ kind, projectId }) => {
 	const dispatch = useAppDispatch();
 
 	const setKind = (kind: TransferKind) =>
@@ -363,7 +362,7 @@ const TransferKindToggleGroup: FC<{
 		{
 			hotkey: operationHotkeys.selectCopy.hotkey,
 			callback: () => setKind("copy"),
-			options: { conflictBehavior: "allow", enabled: canCopy },
+			options: { conflictBehavior: "allow" },
 		},
 	]);
 
@@ -389,11 +388,7 @@ const TransferKindToggleGroup: FC<{
 				</div>
 			</Toggle>
 
-			<Toggle
-				className={styles.toggleGroupRowToggle}
-				value={"copy" satisfies TransferKind}
-				disabled={!canCopy}
-			>
+			<Toggle className={styles.toggleGroupRowToggle} value={"copy" satisfies TransferKind}>
 				<div className="text-semibold">
 					Copy <Kbd hotkey={operationHotkeys.selectCopy.hotkey} />
 				</div>
@@ -437,7 +432,9 @@ const TransferKeyboardOperationControls: FC<{
 
 	return (
 		<Container>
-			<TransferKindToggleGroup canCopy={canCopy} kind={transfer.kind} projectId={projectId} />
+			{/* Only commits can be copied, so for any other source the row offers a choice of one:
+			    the kind is already `move` and cannot become anything else. */}
+			{canCopy && <TransferKindToggleGroup kind={transfer.kind} projectId={projectId} />}
 			<TransferTypeToggleGroup
 				projectId={projectId}
 				operations={operations}

--- a/apps/lite/ui/src/routes/project/$id/workspace/OperationControls.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OperationControls.tsx
@@ -8,7 +8,7 @@ import {
 import { absorptionPlanQueryOptions, headInfoQueryOptions } from "#ui/api/queries.ts";
 import { getHeadInfoIndex, type HeadInfoIndex } from "#ui/api/ref-info.ts";
 import { getButtonClassName, type ButtonSize, type ButtonVariant } from "#ui/components/Button.tsx";
-import { ChipToast } from "#ui/components/ChipToast.tsx";
+import { Snackbar } from "#ui/components/Snackbar.tsx";
 import { Icon } from "#ui/components/Icon.tsx";
 import type { IconName } from "#ui/components/iconNames.ts";
 import { Kbd } from "#ui/components/Kbd.tsx";
@@ -23,7 +23,7 @@ import {
 	ToolboxStack,
 } from "#ui/components/Toolbox.tsx";
 import { formatForDisplaySorted, operationHotkeys } from "#ui/hotkeys.ts";
-import type { Address } from "#ui/addresses.ts";
+import { addressEquals, addressFileParent, type Address } from "#ui/addresses.ts";
 import {
 	getOperations,
 	useExecuteOperation,
@@ -441,6 +441,63 @@ const TransferKindToggleGroup: FC<{
 	);
 };
 
+/**
+ * Why a target refuses everything it was offered. A transfer aims by moving the cursor, so a target
+ * that resolves to nothing is a step in aiming rather than a failure: the strip says what it cannot
+ * do and leaves the ways out — a different target, a different kind — where they already were.
+ */
+const transferRefusal = ({
+	headInfoIndex,
+	sources,
+	target,
+	kind,
+}: {
+	headInfoIndex: HeadInfoIndex;
+	sources: Array<Address>;
+	target: Address;
+	kind: TransferKind;
+}): ReactNode => {
+	const sourcesLabel = (
+		<ToolboxMetaText>{addressesLabel({ headInfoIndex, addresses: sources })}</ToolboxMetaText>
+	);
+
+	// Uncommitted changes are one bucket with no order and no lanes, so a change already in it has
+	// nowhere within it to go.
+	if (
+		target._tag === "UncommittedChanges" &&
+		sources.length > 0 &&
+		sources.every((source) => addressFileParent(source)?._tag === "UncommittedChanges")
+	) {
+		return (
+			<>
+				<strong>Already uncommitted:</strong>
+				{sourcesLabel}
+			</>
+		);
+	}
+
+	const verb = kind === "copy" ? "copy" : "move";
+
+	if (sources.some((source) => addressEquals(source, target))) {
+		return (
+			<>
+				<strong>Can’t {verb}</strong>
+				{sourcesLabel}
+				<strong>onto {sources.length === 1 ? "itself" : "themselves"}</strong>
+			</>
+		);
+	}
+
+	return (
+		<>
+			<strong>Can’t {verb}</strong>
+			{sourcesLabel}
+			<strong>to</strong>
+			<ToolboxMetaText>{addressLabel({ headInfoIndex, address: target })}</ToolboxMetaText>
+		</>
+	);
+};
+
 const TransferKeyboardOperationControls: FC<{
 	headInfoIndex: HeadInfoIndex;
 	projectId: string;
@@ -458,6 +515,12 @@ const TransferKeyboardOperationControls: FC<{
 
 	const operations = target ? getOperations(transfer.sources, target, transfer.kind) : null;
 	const operation = operations?.[transfer.placement];
+	// Three disabled placements and a confirm that cannot be taken say only that something is
+	// wrong. When no placement resolves, the toolbox states the reason instead.
+	const refusal =
+		target && operations && !operations.into && !operations.above && !operations.below
+			? transferRefusal({ headInfoIndex, sources: transfer.sources, target, kind: transfer.kind })
+			: null;
 	const canCopy =
 		transfer.sources.length > 0 && transfer.sources.every((source) => source._tag === "Commit");
 
@@ -497,22 +560,33 @@ const TransferKeyboardOperationControls: FC<{
 				</Toolbox>
 			)}
 			<Toolbox>
-				<ToolboxMeta icon={iconForAddress(transfer.sources[0])}>
-					<strong>{transfer.kind === "copy" ? "Copy" : "Move"}</strong>
-					<ToolboxMetaText>
-						{addressesLabel({ headInfoIndex, addresses: transfer.sources })}
-					</ToolboxMetaText>
-					<strong>{transfer.placement}</strong>
-					<ToolboxMetaText>{addressLabel({ headInfoIndex, address: target })}</ToolboxMetaText>
-				</ToolboxMeta>
-				<ToolboxSection variant="stretch">
-					<TransferTypeToggleGroup
-						projectId={projectId}
-						operations={operations}
-						placement={transfer.placement}
-					/>
-				</ToolboxSection>
-				<ConfirmSection confirm={confirm} onCancel={cancel} />
+				{refusal !== null ? (
+					<>
+						<ToolboxMeta icon="warning">{refusal}</ToolboxMeta>
+						<ToolboxSection variant="confirm">
+							<CancelButton onCancel={cancel} size="small" />
+						</ToolboxSection>
+					</>
+				) : (
+					<>
+						<ToolboxMeta icon={iconForAddress(transfer.sources[0])}>
+							<strong>{transfer.kind === "copy" ? "Copy" : "Move"}</strong>
+							<ToolboxMetaText>
+								{addressesLabel({ headInfoIndex, addresses: transfer.sources })}
+							</ToolboxMetaText>
+							<strong>{transfer.placement}</strong>
+							<ToolboxMetaText>{addressLabel({ headInfoIndex, address: target })}</ToolboxMetaText>
+						</ToolboxMeta>
+						<ToolboxSection variant="stretch">
+							<TransferTypeToggleGroup
+								projectId={projectId}
+								operations={operations}
+								placement={transfer.placement}
+							/>
+						</ToolboxSection>
+						<ConfirmSection confirm={confirm} onCancel={cancel} />
+					</>
+				)}
 			</Toolbox>
 		</Container>
 	);
@@ -557,9 +631,9 @@ export const OperationControls: FC<{
 					<div className={styles.container}>
 						<ToolboxStack>
 							{notice !== null && (
-								<ChipToast variant="danger" className={styles.notice} onClick={clearNotice}>
+								<Snackbar variant="danger" className={styles.notice} onClick={clearNotice}>
 									{notice}
-								</ChipToast>
+								</Snackbar>
 							)}
 							{checkedAddressCount > 0 && (
 								<CheckedAddressOperationControls

--- a/apps/lite/ui/src/routes/project/$id/workspace/OperationControls.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OperationControls.tsx
@@ -7,12 +7,21 @@ import {
 } from "#ui/use-cursor.ts";
 import { absorptionPlanQueryOptions, headInfoQueryOptions } from "#ui/api/queries.ts";
 import { getHeadInfoIndex, type HeadInfoIndex } from "#ui/api/ref-info.ts";
-import { getButtonClassName } from "#ui/components/Button.tsx";
-import { classes } from "#ui/components/classes.ts";
+import { getButtonClassName, type ButtonSize, type ButtonVariant } from "#ui/components/Button.tsx";
 import { Icon } from "#ui/components/Icon.tsx";
+import type { IconName } from "#ui/components/iconNames.ts";
 import { Kbd } from "#ui/components/Kbd.tsx";
-import { TooltipPopup } from "#ui/components/Tooltip.tsx";
-import { operationHotkeys } from "#ui/hotkeys.ts";
+import { ToggleGroupStyles, ToggleStyles } from "#ui/components/ToggleGroup.tsx";
+import {
+	Toolbox,
+	ToolboxMeta,
+	ToolboxMetaHint,
+	ToolboxMetaText,
+	ToolboxSection,
+	ToolboxSeparator,
+	ToolboxStack,
+} from "#ui/components/Toolbox.tsx";
+import { formatForDisplaySorted, operationHotkeys } from "#ui/hotkeys.ts";
 import type { Address } from "#ui/addresses.ts";
 import {
 	getOperations,
@@ -23,12 +32,9 @@ import {
 } from "#ui/operations/operation.ts";
 import { projectSlice } from "#ui/projects/state.ts";
 import { addressLabel, addressesLabel } from "#ui/routes/project/$id/workspace/addressLabel.ts";
-import {
-	useCheckedActions,
-	type CheckedAction,
-} from "#ui/routes/project/$id/workspace/useCheckedActions.ts";
+import { useCheckedActions } from "#ui/routes/project/$id/workspace/useCheckedActions.ts";
 import { useAppDispatch, useAppSelector } from "#ui/store.ts";
-import { Button, Toggle, ToggleGroup, Tooltip } from "@base-ui/react";
+import { Button, Toggle, ToggleGroup } from "@base-ui/react";
 import { useHotkeys, type UseHotkeyDefinition } from "@tanstack/react-hotkeys";
 import { useQuery } from "@tanstack/react-query";
 import { Match } from "effect";
@@ -44,27 +50,66 @@ import type { FocusScope } from "#ui/focus-scopes.ts";
 import type { AddressSpace } from "#ui/workspace/address-space.ts";
 
 const Container: FC<{ children: ReactNode }> = ({ children }) => (
-	<div className={classes("text-14", styles.container)}>{children}</div>
+	<div className={styles.container}>
+		<ToolboxStack>{children}</ToolboxStack>
+	</div>
 );
 
-const ControlsRow: FC<{ children: ReactNode }> = ({ children }) => (
-	<div className={styles.controlsRow}>{children}</div>
+/** The kind of thing an operation is holding, so its toolbox can say so at a glance. */
+const iconForAddress = (address: Address | undefined): IconName | undefined => {
+	switch (address?._tag) {
+		case "Commit":
+			return "commit";
+		case "File":
+			return "file-diff";
+		case "Hunk":
+			return "diff";
+		default:
+			return undefined;
+	}
+};
+
+/**
+ * Every act in a toolbox wears the chord that runs it, so the toolbox teaches the keyboard rather
+ * than standing in for it.
+ */
+const ToolboxButton: FC<{
+	label: string;
+	hotkey?: string;
+	variant?: ButtonVariant;
+	size?: ButtonSize;
+	enabled?: boolean;
+	onClick: () => void;
+}> = ({ label, hotkey, variant, size, enabled = true, onClick }) => (
+	<Button
+		className={getButtonClassName({ variant, size })}
+		disabled={!enabled}
+		focusableWhenDisabled
+		onMouseDown={(event) => {
+			// Prevent stealing focus from the tree.
+			if (!event.defaultPrevented) event.preventDefault();
+		}}
+		onClick={onClick}
+	>
+		{label}
+		{hotkey !== undefined && <Kbd hotkey={hotkey} variant="button" />}
+	</Button>
 );
 
-const Label: FC<{ children: ReactNode }> = ({ children }) => (
-	<div className={classes(styles.label, "text-bold", "text-13")}>{children}</div>
-);
+type Confirm = {
+	label: string;
+	canRun: boolean;
+	onRun: () => void;
+	extraHotkeys?: Array<Omit<UseHotkeyDefinition, "callback">>;
+};
 
-const Separator: FC = () => <div className={styles.separator} />;
-
-const Controls: FC<{
+const useControlHotkeys = ({
+	onCancel,
+	confirm,
+}: {
 	onCancel: () => void;
-	confirm?: {
-		canRun: boolean;
-		onRun: () => void;
-		extraHotkeys?: Array<Omit<UseHotkeyDefinition, "callback">>;
-	};
-}> = ({ onCancel, confirm }) => {
+	confirm?: Confirm;
+}): void => {
 	const confirmHotkeys: Array<Omit<UseHotkeyDefinition, "callback">> = [
 		...(confirm?.extraHotkeys ?? []),
 		{ hotkey: operationHotkeys.confirm.hotkey },
@@ -92,76 +137,48 @@ const Controls: FC<{
 			},
 		},
 	]);
-
-	return (
-		<div className={styles.controls}>
-			{confirm && (
-				<Tooltip.Root>
-					<Tooltip.Trigger
-						className={getButtonClassName({ variant: "gray" })}
-						onMouseDown={(event) => {
-							// Prevent stealing focus from the tree.
-							if (!event.defaultPrevented) event.preventDefault();
-						}}
-						onClick={confirm.onRun}
-						// We pass `disabled` here because we want to disable the button, not
-						// the tooltip. Other props should be passed above.
-						render={<Button focusableWhenDisabled disabled={!confirm.canRun} />}
-					>
-						Confirm
-					</Tooltip.Trigger>
-					<Tooltip.Portal>
-						<Tooltip.Positioner sideOffset={4}>
-							<Tooltip.Popup render={<TooltipPopup kbd={operationHotkeys.confirm.hotkey} />}>
-								Confirm
-							</Tooltip.Popup>
-						</Tooltip.Positioner>
-					</Tooltip.Portal>
-				</Tooltip.Root>
-			)}
-
-			<Tooltip.Root>
-				<Tooltip.Trigger
-					className={getButtonClassName({})}
-					onMouseDown={(event) => {
-						// Prevent stealing focus from the tree.
-						if (!event.defaultPrevented) event.preventDefault();
-					}}
-					onClick={onCancel}
-				>
-					Cancel
-				</Tooltip.Trigger>
-				<Tooltip.Portal>
-					<Tooltip.Positioner sideOffset={4}>
-						<Tooltip.Popup render={<TooltipPopup kbd={operationHotkeys.cancel.hotkey} />}>
-							Cancel
-						</Tooltip.Popup>
-					</Tooltip.Positioner>
-				</Tooltip.Portal>
-			</Tooltip.Root>
-		</div>
-	);
 };
 
-const CheckedActions: FC<{ actions: Array<CheckedAction> }> = ({ actions }) => (
-	<div className={styles.actions}>
-		{actions.map((action) => (
-			<Button
-				key={action.label}
-				className={getButtonClassName({ variant: action.variant })}
-				disabled={!action.enabled}
-				focusableWhenDisabled
-				onMouseDown={(event) => {
-					// Prevent stealing focus from the tree.
-					if (!event.defaultPrevented) event.preventDefault();
-				}}
-				onClick={action.run}
-			>
-				{action.label}
-				{action.hotkey !== undefined && <Kbd hotkey={action.hotkey} variant="button" />}
-			</Button>
-		))}
-	</div>
+/**
+ * The way out of a toolbox that has nothing pending to abandon: a close affordance rather than a
+ * peer of the acts beside it, with its chord stated in the strip above.
+ */
+const CloseButton: FC<{ onCancel: () => void }> = ({ onCancel }) => (
+	<Button
+		className={getButtonClassName({ variant: "ghost", iconOnly: true })}
+		aria-label="Cancel"
+		onMouseDown={(event) => {
+			// Prevent stealing focus from the tree.
+			if (!event.defaultPrevented) event.preventDefault();
+		}}
+		onClick={onCancel}
+	>
+		<Icon name="cross" />
+	</Button>
+);
+
+const CancelButton: FC<{ onCancel: () => void; size?: ButtonSize }> = ({ onCancel, size }) => (
+	<ToolboxButton
+		label="Cancel"
+		hotkey={operationHotkeys.cancel.hotkey}
+		size={size}
+		onClick={onCancel}
+	/>
+);
+
+/** What ends an operation, gathered where a dialog would put it. */
+const ConfirmSection: FC<{ confirm: Confirm; onCancel: () => void }> = ({ confirm, onCancel }) => (
+	<ToolboxSection variant="confirm">
+		<ToolboxButton
+			label={confirm.label}
+			hotkey={operationHotkeys.confirm.hotkey}
+			variant="gray"
+			size="small"
+			enabled={confirm.canRun}
+			onClick={confirm.onRun}
+		/>
+		<CancelButton onCancel={onCancel} size="small" />
+	</ToolboxSection>
 );
 
 const CheckedAddressOperationControls: FC<{
@@ -171,35 +188,54 @@ const CheckedAddressOperationControls: FC<{
 }> = ({ checkedAddressCount, projectId, appliedAddressSpace }) => {
 	const dispatch = useAppDispatch();
 
-	const checkedType = useAppSelector((state): string | null => {
-		switch (projectSlice.selectors.selectCheckedAddressesContext(state, projectId)) {
-			case "Commit":
-				return "commit";
-			case "File":
-				return "file";
-			case "Hunk":
-				return "line";
-			case null:
-				return null;
-		}
-	});
+	// A primitive, so a check that leaves the context alone doesn't re-render the bar.
+	const checkedContext = useAppSelector((state) =>
+		projectSlice.selectors.selectCheckedAddressesContext(state, projectId),
+	);
 	const actions = useCheckedActions({ projectId, appliedAddressSpace });
-	if (checkedType === null) return;
 
 	const cancel = () => {
 		dispatch(projectSlice.actions.clearCheckedAddresses({ projectId }));
 	};
+	useControlHotkeys({ onCancel: cancel });
+
+	if (checkedContext === null) return;
+
+	const { noun, icon } = Match.value(checkedContext).pipe(
+		Match.withReturnType<{ noun: string; icon: IconName }>(),
+		Match.when("Commit", () => ({ noun: "commit", icon: "commit" as const })),
+		Match.when("File", () => ({ noun: "file", icon: "file-diff" as const })),
+		Match.when("Hunk", () => ({ noun: "line", icon: "diff" as const })),
+		Match.exhaustive,
+	);
 
 	return (
 		<Container>
-			<ControlsRow>
-				<Label>
-					{new Intl.NumberFormat().format(checkedAddressCount)} {checkedType}
-					{new Intl.PluralRules().select(checkedAddressCount) !== "one" && "s"} selected
-				</Label>
-				{actions.length > 0 && <CheckedActions actions={actions} />}
-				<Controls onCancel={cancel} />
-			</ControlsRow>
+			<Toolbox>
+				<ToolboxMeta icon={icon}>
+					<span>
+						{new Intl.NumberFormat().format(checkedAddressCount)} {noun}
+						{new Intl.PluralRules().select(checkedAddressCount) !== "one" && "s"} selected
+					</span>
+					<ToolboxMetaHint>
+						{formatForDisplaySorted(operationHotkeys.cancel.hotkey)} to close
+					</ToolboxMetaHint>
+				</ToolboxMeta>
+				<ToolboxSection>
+					{actions.map((action) => (
+						<ToolboxButton
+							key={action.label}
+							label={action.label}
+							hotkey={action.hotkey}
+							variant={action.variant}
+							enabled={action.enabled}
+							onClick={action.run}
+						/>
+					))}
+					{actions.length > 0 && <ToolboxSeparator />}
+					<CloseButton onCancel={cancel} />
+				</ToolboxSection>
+			</Toolbox>
 		</Container>
 	);
 };
@@ -228,21 +264,29 @@ const AbsorbOperationControls: FC<{
 		cancelPendingOperation();
 	};
 
+	const confirm: Confirm = { label: "Absorb", canRun: canAbsorb, onRun: run };
+	useControlHotkeys({ onCancel: cancel, confirm });
+
 	return (
 		<Container>
-			<ControlsRow>
-				{isAbsorptionPlanPending ? (
-					<Icon name="spinner" aria-label="Loading absorb plan" />
-				) : isAbsorptionPlanError ? (
-					<Label>Failed to load absorb plan</Label>
-				) : (
-					<Label>
-						Absorb {addressesLabel({ headInfoIndex, addresses: pending.sources })} into{" "}
-						{absorptionPlan.length} commits
-					</Label>
-				)}
-				<Controls onCancel={cancel} confirm={{ canRun: canAbsorb, onRun: run }} />
-			</ControlsRow>
+			<Toolbox>
+				<ToolboxMeta icon={isAbsorptionPlanPending ? "spinner" : "absorb"}>
+					{isAbsorptionPlanPending ? (
+						<span>Loading absorb plan</span>
+					) : isAbsorptionPlanError ? (
+						<span>Failed to load absorb plan</span>
+					) : (
+						<>
+							<strong>Absorb</strong>
+							<ToolboxMetaText>
+								{addressesLabel({ headInfoIndex, addresses: pending.sources })}
+							</ToolboxMetaText>
+							<strong>into {absorptionPlan.length} commits</strong>
+						</>
+					)}
+				</ToolboxMeta>
+				<ConfirmSection confirm={confirm} onCancel={cancel} />
+			</Toolbox>
 		</Container>
 	);
 };
@@ -296,49 +340,34 @@ const TransferTypeToggleGroup: FC<{
 			aria-label="Placement"
 			value={[placement]}
 			onValueChange={onValueChange}
-			className={styles.toggleGroupRow}
+			render={<ToggleGroupStyles />}
 			onMouseDown={(event) => {
 				// Prevent stealing focus from the tree.
 				if (!event.defaultPrevented) event.preventDefault();
 			}}
 		>
 			<Toggle
-				className={styles.toggleGroupRowToggle}
+				render={<ToggleStyles />}
 				value={"above" satisfies Placement}
 				disabled={!operations.above}
 			>
-				{operations.above && (
-					<div className={classes("text-12", styles.operationLabel)}>{operations.above.label}</div>
-				)}
-				<div className="text-semibold">
-					Above <Kbd hotkey={operationHotkeys.selectAbove.hotkey} />
-				</div>
+				Above <Kbd hotkey={operationHotkeys.selectAbove.hotkey} variant="button" />
 			</Toggle>
 
 			<Toggle
-				className={styles.toggleGroupRowToggle}
+				render={<ToggleStyles />}
 				value={"into" satisfies Placement}
 				disabled={!operations.into}
 			>
-				{operations.into && (
-					<div className={classes("text-12", styles.operationLabel)}>{operations.into.label}</div>
-				)}
-				<div className="text-semibold">
-					Into <Kbd hotkey={operationHotkeys.selectInto.hotkey} />
-				</div>
+				Into <Kbd hotkey={operationHotkeys.selectInto.hotkey} variant="button" />
 			</Toggle>
 
 			<Toggle
-				className={styles.toggleGroupRowToggle}
+				render={<ToggleStyles />}
 				value={"below" satisfies Placement}
 				disabled={!operations.below}
 			>
-				{operations.below && (
-					<div className={classes("text-12", styles.operationLabel)}>{operations.below.label}</div>
-				)}
-				<div className="text-semibold">
-					Below <Kbd hotkey={operationHotkeys.selectBelow.hotkey} />
-				</div>
+				Below <Kbd hotkey={operationHotkeys.selectBelow.hotkey} variant="button" />
 			</Toggle>
 		</ToggleGroup>
 	);
@@ -376,22 +405,18 @@ const TransferKindToggleGroup: FC<{
 			aria-label="Transfer kind"
 			value={[kind]}
 			onValueChange={onValueChange}
-			className={styles.toggleGroupRow}
+			render={<ToggleGroupStyles />}
 			onMouseDown={(evt) => {
 				// Prevent stealing focus from the tree.
 				if (!evt.defaultPrevented) evt.preventDefault();
 			}}
 		>
-			<Toggle className={styles.toggleGroupRowToggle} value={"move" satisfies TransferKind}>
-				<div className="text-semibold">
-					Move <Kbd hotkey={operationHotkeys.selectMove.hotkey} />
-				</div>
+			<Toggle render={<ToggleStyles />} value={"move" satisfies TransferKind}>
+				Move <Kbd hotkey={operationHotkeys.selectMove.hotkey} variant="button" />
 			</Toggle>
 
-			<Toggle className={styles.toggleGroupRowToggle} value={"copy" satisfies TransferKind}>
-				<div className="text-semibold">
-					Copy <Kbd hotkey={operationHotkeys.selectCopy.hotkey} />
-				</div>
+			<Toggle render={<ToggleStyles />} value={"copy" satisfies TransferKind}>
+				Copy <Kbd hotkey={operationHotkeys.selectCopy.hotkey} variant="button" />
 			</Toggle>
 		</ToggleGroup>
 	);
@@ -411,10 +436,9 @@ const TransferKeyboardOperationControls: FC<{
 	const { mutate: executeOperation } = useExecuteOperation(projectId);
 
 	const target = getTransferTarget(keyboardTransfer(transfer), selection, activeList);
-	if (!target) return null;
 
-	const operations = getOperations(transfer.sources, target, transfer.kind);
-	const operation = operations[transfer.placement];
+	const operations = target ? getOperations(transfer.sources, target, transfer.kind) : null;
+	const operation = operations?.[transfer.placement];
 	const canCopy =
 		transfer.sources.length > 0 && transfer.sources.every((source) => source._tag === "Commit");
 
@@ -430,35 +454,47 @@ const TransferKeyboardOperationControls: FC<{
 		cancelPendingOperationAndRestoreFocus(onFocusRestore);
 	};
 
+	const confirm: Confirm = {
+		// The placement toggles say where; the operation they resolve to says what, so the
+		// confirm button is where it belongs.
+		label: operation?.label ?? "Confirm",
+		canRun: !!operation,
+		onRun: run,
+		extraHotkeys: [{ hotkey: operationHotkeys.confirmTransfer.hotkey }],
+	};
+	useControlHotkeys({ onCancel: cancel, confirm });
+
+	if (!target || !operations) return null;
+
 	return (
 		<Container>
-			{/* Only commits can be copied, so for any other source the row offers a choice of one:
+			{/* Only commits can be copied, so for any other source the addon offers a choice of one:
 			    the kind is already `move` and cannot become anything else. */}
-			{canCopy && <TransferKindToggleGroup kind={transfer.kind} projectId={projectId} />}
-			<TransferTypeToggleGroup
-				projectId={projectId}
-				operations={operations}
-				placement={transfer.placement}
-			/>
-			<Separator />
-			<ControlsRow>
-				<Label>
-					<div>Source: {addressesLabel({ headInfoIndex, addresses: transfer.sources })}</div>
-					<div>Target: {addressLabel({ headInfoIndex, address: target })}</div>
-				</Label>
-				<Controls
-					onCancel={cancel}
-					confirm={{
-						canRun: !!operation,
-						onRun: run,
-						extraHotkeys: [
-							{
-								hotkey: operationHotkeys.confirmTransfer.hotkey,
-							},
-						],
-					}}
-				/>
-			</ControlsRow>
+			{canCopy && (
+				<Toolbox>
+					<ToolboxSection variant="stretch">
+						<TransferKindToggleGroup kind={transfer.kind} projectId={projectId} />
+					</ToolboxSection>
+				</Toolbox>
+			)}
+			<Toolbox>
+				<ToolboxMeta icon={iconForAddress(transfer.sources[0])}>
+					<strong>{transfer.kind === "copy" ? "Copy" : "Move"}</strong>
+					<ToolboxMetaText>
+						{addressesLabel({ headInfoIndex, addresses: transfer.sources })}
+					</ToolboxMetaText>
+					<strong>{transfer.placement}</strong>
+					<ToolboxMetaText>{addressLabel({ headInfoIndex, address: target })}</ToolboxMetaText>
+				</ToolboxMeta>
+				<ToolboxSection variant="stretch">
+					<TransferTypeToggleGroup
+						projectId={projectId}
+						operations={operations}
+						placement={transfer.placement}
+					/>
+				</ToolboxSection>
+				<ConfirmSection confirm={confirm} onCancel={cancel} />
+			</Toolbox>
 		</Container>
 	);
 };

--- a/apps/lite/ui/src/routes/project/$id/workspace/useCheckedActions.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/useCheckedActions.ts
@@ -31,7 +31,7 @@ import { selectAfterDiscardedCommits } from "./WorkspaceLists/selectAfterDiscard
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Match } from "effect";
 
-export type CheckedAction = {
+type CheckedAction = {
 	label: string;
 	/** The chord that runs the same act from the list, shown so the toolbar teaches it. */
 	hotkey?: string;

--- a/apps/lite/ui/src/routes/project/$id/workspace/useCheckedActions.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/useCheckedActions.ts
@@ -1,0 +1,341 @@
+import {
+	useCommitDiscard,
+	useCommitDiscardChanges,
+	useCommitUncommit,
+	useCommitUncommitChanges,
+	useDiscardFileChanges,
+	useDiscardWorktreeChanges,
+} from "#ui/api/mutations.ts";
+import { changesInWorktreeQueryOptions, headInfoQueryOptions } from "#ui/api/queries.ts";
+import { getHeadInfoIndex } from "#ui/api/ref-info.ts";
+import {
+	addressIdentityKey,
+	commitAddress,
+	uncommittedChangesFileParent,
+	type Address,
+} from "#ui/addresses.ts";
+import type { ButtonVariant } from "#ui/components/Button.tsx";
+import { focusScope } from "#ui/focus-scopes.ts";
+import {
+	changesFileHotkeys,
+	diffHotkeys,
+	selectionOperationHotkeys,
+	sidebarHotkeys,
+} from "#ui/hotkeys.ts";
+import { fileParentFromSources, resolveDiffSpecs } from "#ui/operations/diff-specs.ts";
+import { projectSlice } from "#ui/projects/state.ts";
+import { useAppSelector } from "#ui/store.ts";
+import { setCursor, startAbsorb, startKeyboardTransfer } from "#ui/use-cursor.ts";
+import type { AddressSpace } from "#ui/workspace/address-space.ts";
+import { selectAfterDiscardedCommits } from "./WorkspaceLists/selectAfterDiscardedCommit.ts";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { Match } from "effect";
+
+export type CheckedAction = {
+	label: string;
+	/** The chord that runs the same act from the list, shown so the toolbar teaches it. */
+	hotkey?: string;
+	variant?: ButtonVariant;
+	enabled: boolean;
+	run: () => void;
+};
+
+/**
+ * The acts available on the checked set, as the row menus offer them but addressed to the set
+ * rather than to a row. Checking is confined to one kind at a time, so which acts apply follows
+ * from what is checked; an unactionable set gets none, and the bar shows its count alone.
+ */
+export const useCheckedActions = ({
+	projectId,
+	appliedAddressSpace,
+}: {
+	projectId: string;
+	appliedAddressSpace: AddressSpace<Address>;
+}): Array<CheckedAction> => {
+	const queryClient = useQueryClient();
+	const checkedAddresses = useAppSelector((state) =>
+		projectSlice.selectors.selectCheckedAddresses(state, projectId),
+	);
+	const { data: headInfoIndex } = useQuery({
+		...headInfoQueryOptions(projectId),
+		select: getHeadInfoIndex,
+	});
+
+	// Hooks cannot be conditional, so a non-file set still has to name a parent; it gets no file
+	// actions below, so which one it names is immaterial.
+	const fileParent = fileParentFromSources(checkedAddresses);
+	const { canDiscard, discard } = useDiscardFileChanges({
+		projectId,
+		fileParent: fileParent ?? uncommittedChangesFileParent,
+	});
+	const { isPending: isUncommitChangesPending, mutate: commitUncommitChanges } =
+		useCommitUncommitChanges();
+	const { isPending: isCommitDiscardPending, mutate: commitDiscard } = useCommitDiscard();
+	const { isPending: isCommitUncommitPending, mutate: commitUncommit } = useCommitUncommit();
+	const { isPending: isCommitDiscardChangesPending, mutate: commitDiscardChanges } =
+		useCommitDiscardChanges();
+	const { isPending: isDiscardWorktreePending, mutate: discardWorktreeChanges } =
+		useDiscardWorktreeChanges();
+
+	const cut = (sources: Array<Address>): CheckedAction => ({
+		label: "Cut",
+		hotkey: selectionOperationHotkeys.cut.hotkey,
+		enabled: true,
+		run: () => {
+			startKeyboardTransfer({ sources, kind: "move" });
+			focusScope("sidebar");
+		},
+	});
+
+	const [first] = checkedAddresses;
+	if (!first) return [];
+
+	return Match.value(first).pipe(
+		Match.withReturnType<Array<CheckedAction>>(),
+		Match.tags({
+			Commit: () => {
+				if (!checkedAddresses.every((address) => address._tag === "Commit")) return [];
+				const subjectCommitIds = checkedAddresses.map((address) => address.commitId);
+
+				return [
+					{
+						label: "Copy",
+						hotkey: sidebarHotkeys.copy.hotkey,
+						enabled: true,
+						run: () => {
+							startKeyboardTransfer({
+								sources: checkedAddresses,
+								kind: "copy",
+								placement: "above",
+							});
+							focusScope("sidebar");
+						},
+					},
+					cut(checkedAddresses),
+					{
+						label: "Uncommit",
+						hotkey: sidebarHotkeys.uncommitCommit.hotkey,
+						enabled: !isCommitUncommitPending,
+						run: () =>
+							commitUncommit({ projectId, assignTo: null, subjectCommitIds, dryRun: false }),
+					},
+					{
+						label: "Delete",
+						hotkey: sidebarHotkeys.deleteCommit.hotkey,
+						variant: "danger",
+						enabled: !isCommitDiscardPending,
+						run: () => {
+							// The cursor has to leave the set before it goes; anchoring on the topmost
+							// checked commit lands it beside the set rather than inside it.
+							const anchor = checkedAddresses.reduce((topmost, address) => {
+								const indexOf = (candidate: typeof address) =>
+									appliedAddressSpace.indexByKey.get(addressIdentityKey(candidate)) ??
+									Number.POSITIVE_INFINITY;
+								return indexOf(address) < indexOf(topmost) ? address : topmost;
+							});
+							const selectionAfterDiscard = selectAfterDiscardedCommits({
+								addressSpace: appliedAddressSpace,
+								commit: anchor,
+								discardedCommitIds: new Set(subjectCommitIds),
+								headInfoIndex,
+							});
+
+							commitDiscard(
+								{ projectId, subjectCommitIds, dryRun: false },
+								{
+									onSuccess: (response) => {
+										let latest = selectionAfterDiscard;
+
+										rewrite: if (latest?._tag === "Commit") {
+											const newId = response.workspace.replacedCommits[latest.commitId];
+											if (newId === undefined) break rewrite;
+
+											latest = commitAddress({ commitId: newId, changeId: latest.changeId });
+										}
+
+										setCursor("applied", latest);
+									},
+								},
+							);
+						},
+					},
+				];
+			},
+
+			Hunk: (hunk) => {
+				if (!checkedAddresses.every((address) => address._tag === "Hunk")) return [];
+				// We currently don't support any operations on branch hunks.
+				const parent = hunk.parent.parent;
+				if (parent._tag === "Branch") return [];
+
+				// Lines recovered from a binary file have no diff spec to name them by.
+				const canUseHunks = checkedAddresses.every(
+					(address) => !address.isResultOfBinaryToTextConversion,
+				);
+				// Taking lines away names them within their whole hunk, which is not the form the
+				// parent alone implies for uncommitted lines.
+				const resolveForRemoval = () =>
+					resolveDiffSpecs({
+						projectId,
+						queryClient,
+						sources: checkedAddresses,
+						hunkAction: "discard",
+					});
+
+				const cutLines: CheckedAction = { ...cut(checkedAddresses), enabled: canUseHunks };
+				const discardLines: CheckedAction = {
+					label: "Discard",
+					variant: "danger",
+					enabled:
+						canUseHunks &&
+						(parent._tag === "Commit" ? !isCommitDiscardChangesPending : !isDiscardWorktreePending),
+					run: () =>
+						void resolveForRemoval().then((changes) => {
+							if (!changes) return;
+
+							if (parent._tag === "Commit") {
+								commitDiscardChanges({
+									projectId,
+									commitId: parent.commitId,
+									changes,
+									dryRun: false,
+								});
+							} else {
+								discardWorktreeChanges({ projectId, worktreeChanges: changes });
+							}
+						}),
+				};
+
+				if (parent._tag === "Commit") {
+					return [
+						cutLines,
+						{
+							label: "Uncommit",
+							enabled: canUseHunks && !isUncommitChangesPending,
+							run: () =>
+								void resolveForRemoval().then((changes) => {
+									if (!changes) return;
+
+									commitUncommitChanges({
+										projectId,
+										commitId: parent.commitId,
+										assignTo: null,
+										changes,
+										dryRun: false,
+									});
+								}),
+						},
+						discardLines,
+					];
+				}
+
+				return [
+					{
+						label: "Absorb",
+						hotkey: diffHotkeys.absorb.hotkey,
+						enabled: canUseHunks,
+						run: () => {
+							// Checked hunks carry a path, but an absorb target names files by their bytes,
+							// so their changes have to be looked up. One gone stale fails the whole set.
+							const changesByPath = new Map(
+								queryClient
+									.getQueryData(changesInWorktreeQueryOptions(projectId).queryKey)
+									?.changes.map((change) => [change.path, change]),
+							);
+							const hunks = checkedAddresses.flatMap((address) => {
+								const change = changesByPath.get(address.parent.path);
+								return change
+									? [{ pathBytes: change.pathBytes, hunkHeader: address.hunkHeader }]
+									: [];
+							});
+							if (hunks.length !== checkedAddresses.length) return;
+
+							startAbsorb({
+								sources: checkedAddresses,
+								sourceTarget: { type: "hunks", subject: { hunks } },
+							});
+							focusScope("sidebar");
+						},
+					},
+					cutLines,
+					discardLines,
+				];
+			},
+
+			File: () => {
+				if (fileParent === null || !checkedAddresses.every((address) => address._tag === "File"))
+					return [];
+
+				const discardChanges: CheckedAction = {
+					label: "Discard",
+					hotkey: changesFileHotkeys.discard.hotkey,
+					variant: "danger",
+					enabled: canDiscard,
+					run: () => void discard({ change: null, extendToCheckedFiles: true }),
+				};
+
+				return Match.value(fileParent).pipe(
+					Match.withReturnType<Array<CheckedAction>>(),
+					Match.tagsExhaustive({
+						UncommittedChanges: () => [
+							{
+								label: "Absorb",
+								hotkey: changesFileHotkeys.absorb.hotkey,
+								enabled: true,
+								run: () => {
+									// Checked files carry only paths, so their changes have to be looked up.
+									// One of them gone stale fails the whole set, as discarding one does.
+									const paths = new Set(checkedAddresses.map((address) => address.path));
+									const changes = queryClient
+										.getQueryData(changesInWorktreeQueryOptions(projectId).queryKey)
+										?.changes.filter((change) => paths.has(change.path));
+									if (!changes || changes.length !== paths.size) return;
+
+									startAbsorb({
+										sources: checkedAddresses,
+										sourceTarget: {
+											type: "treeChanges",
+											subject: { changes, assignedStackId: null },
+										},
+									});
+									focusScope("sidebar");
+								},
+							},
+							cut(checkedAddresses),
+							discardChanges,
+						],
+						Commit: ({ commitId }) => [
+							cut(checkedAddresses),
+							{
+								label: "Uncommit",
+								hotkey: changesFileHotkeys.uncommit.hotkey,
+								enabled: !isUncommitChangesPending,
+								run: () => {
+									void resolveDiffSpecs({
+										projectId,
+										queryClient,
+										sources: checkedAddresses,
+									}).then((changes) => {
+										if (!changes) return;
+
+										commitUncommitChanges({
+											projectId,
+											commitId,
+											assignTo: null,
+											changes,
+											dryRun: false,
+										});
+									});
+								},
+							},
+							discardChanges,
+						],
+						// We currently don't support any operations on branch files.
+						Branch: () => [],
+					}),
+				);
+			},
+		}),
+		Match.orElse(() => []),
+	);
+};


### PR DESCRIPTION
Every workspace operation — the checked set, a keyboard transfer, an absorb —
built its own control bar by hand. This replaces all three with one shared set
of components, then fixes two cases where an operation left the user stuck.

Before:
<img width="1003" height="454" alt="image" src="https://github.com/user-attachments/assets/fd0ce050-138c-437e-badd-aa23cd4e5cb7" />

After:
<img width="1165" height="584" alt="image" src="https://github.com/user-attachments/assets/83e7416c-89fe-4bcd-848e-bb4a4483f23e" />

https://github.com/user-attachments/assets/69b3f5bc-e916-470b-9a49-5ea4cc33c44c

---

## New components

**`Toolbox`** — the shared card the operation bars are now built from.
`ToolboxMeta` is the top strip naming what the operation is about;
`ToolboxSection` is one row per decision still to make; `ToolboxStack` stacks
cards when an operation needs a qualifier above it (the Move/Copy selector).

**`Snackbar`** — a single-line message that sits next to whatever it's about,
rather than in the corner of the window like a `Toasts` card. Used here for the
"this operation can't run" notice. Info, danger and safe variants differ only by
icon.

<img width="300" alt="Snackbar variants" src="https://github.com/user-attachments/assets/0a0a01f9-3f54-4bdf-8c80-8a03a8eb2452" />

Both ship with stories.

Figma: [Snackbar](https://www.figma.com/design/cqdnAotT8n9op8WGYLOHg4/%E2%9A%9B%EF%B8%8F-Lite-Core?node-id=1706-1682&t=L6pld9agMdcYZH2R-1) and [Toolbox](https://www.figma.com/design/EBuHQGUcCaSw4Ln5uVpWkn/Lite?node-id=1363-20142&t=M1OWEkhuDX9uDXIG-1)

## Behaviour changes

**The checked-set bar now has buttons.** Before, it showed a count and Cancel,
so every action on a checked set was reachable only by hotkey or right-click
menu. It now offers the same actions the row menus do, applied to the whole set:
copy / cut / uncommit / delete for commits, absorb / cut / uncommit / discard for
files and lines. Each button shows its keyboard shortcut. Which buttons appear
follows from what's checked — you can only check one kind at a time — and a set
with no applicable actions still just shows its count.

**An absorb that can't run no longer hangs.** Starting an absorb puts the
workspace into aiming mode. If the plan came back empty, or failed to load, the
mode stayed open with a Confirm button that could never be pressed. It now exits
immediately and leaves a Snackbar explaining why. The notice clears on click,
after 5s, or when you start another operation.

**A transfer target that refuses now says why.** Aiming a transfer at somewhere
it can't go used to show three greyed-out placement buttons and a dead Confirm,
which only told you *that* something was wrong. The strip now names the reason —
already uncommitted, can't move onto itself, can't move to that target — and
leaves the placement and kind controls alone, since you re-aim by moving the
cursor.

**The Move/Copy row is hidden when only Move is possible.** Only commits can be
copied, so transferring files or lines was offering a choice of one.

## Smaller changes

- `resolveDiffSpecs` callers can pass `hunkAction` to pick the hunk header form
  explicitly. Left unset it still derives from the parent, so existing callers
  are unchanged.
- `useDiscardFileChanges` accepts `change: null` for callers with no row to seed
  from, like the new toolbar.
- The React Query *query* cache had no `onError` handler, so a rejected query
  logged nothing anywhere. It now logs to the console. Panels still report their
  own failures in place.
