### PR TITLE
Don't let the askpass accept deadline kill slow fetches

### DIFF
--- a/crates/gitbutler-git/Cargo.toml
+++ b/crates/gitbutler-git/Cargo.toml
@@ -65,7 +65,7 @@ file-id = { git = "https://github.com/notify-rs/notify", rev = "978fe719b066a8ce
 [dev-dependencies]
 but-testsupport.workspace = true
 snapbox.workspace = true
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }
 
 [lints]
 workspace = true

--- a/crates/gitbutler-git/src/executor/mod.rs
+++ b/crates/gitbutler-git/src/executor/mod.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, path::Path, time::Duration};
+use std::{collections::HashMap, path::Path};
 
 #[cfg(any(test, feature = "tokio"))]
 pub mod tokio;
@@ -179,7 +179,10 @@ pub trait AskpassServer: core::fmt::Display {
     type SocketHandle: Socket + Send + Sync + 'static;
 
     /// Waits for a connection to the server to be established.
-    async fn accept(&self, timeout: Option<Duration>) -> Result<Self::SocketHandle, Self::Error>;
+    ///
+    /// Waits indefinitely; callers that need a deadline should wrap the
+    /// future themselves (e.g. with `tokio::time::timeout`).
+    async fn accept(&self) -> Result<Self::SocketHandle, Self::Error>;
 }
 
 #[cfg(unix)]

--- a/crates/gitbutler-git/src/executor/tokio/unix.rs
+++ b/crates/gitbutler-git/src/executor/tokio/unix.rs
@@ -2,7 +2,6 @@ use std::{
     fs::Permissions,
     os::unix::fs::{MetadataExt, PermissionsExt},
     path::Path,
-    time::Duration,
 };
 
 use tokio::{
@@ -72,14 +71,13 @@ impl AskpassServer for TokioAskpassServer {
     type Error = std::io::Error;
     type SocketHandle = BufStream<UnixStream>;
 
-    async fn accept(&self, timeout: Option<Duration>) -> Result<Self::SocketHandle, Self::Error> {
-        let res = if let Some(timeout) = timeout {
-            tokio::time::timeout(timeout, self.server.as_ref().unwrap().accept()).await?
-        } else {
-            self.server.as_ref().unwrap().accept().await
-        };
-
-        res.map(|(s, _)| BufStream::new(s))
+    async fn accept(&self) -> Result<Self::SocketHandle, Self::Error> {
+        self.server
+            .as_ref()
+            .unwrap()
+            .accept()
+            .await
+            .map(|(s, _)| BufStream::new(s))
     }
 }
 

--- a/crates/gitbutler-git/src/executor/tokio/windows.rs
+++ b/crates/gitbutler-git/src/executor/tokio/windows.rs
@@ -1,4 +1,4 @@
-use std::{os::windows::io::AsRawHandle, path::Path, time::Duration};
+use std::{os::windows::io::AsRawHandle, path::Path};
 
 use tokio::{
     io::{AsyncBufReadExt, AsyncWriteExt, BufStream},
@@ -71,14 +71,10 @@ impl AskpassServer for TokioAskpassServer {
     type Error = std::io::Error;
     type SocketHandle = BufStream<NamedPipeServer>;
 
-    async fn accept(&self, timeout: Option<Duration>) -> Result<Self::SocketHandle, Self::Error> {
+    async fn accept(&self) -> Result<Self::SocketHandle, Self::Error> {
         let mut server = self.server.lock().await;
 
-        if let Some(timeout) = timeout {
-            tokio::time::timeout(timeout, server.connect()).await??;
-        } else {
-            server.connect().await?;
-        }
+        server.connect().await?;
 
         // Windows is weird. The server becomes the peer connection,
         // and before we use the new connection, we first create

--- a/crates/gitbutler-git/src/repository.rs
+++ b/crates/gitbutler-git/src/repository.rs
@@ -2,7 +2,6 @@ use std::{
     collections::HashMap,
     ffi::OsString,
     path::{Path, PathBuf},
-    time::Duration,
 };
 
 use futures::{FutureExt, select};
@@ -27,7 +26,7 @@ pub enum RepositoryError<
 > {
     #[error("failed to execute git command: {0}")]
     Exec(Eexec),
-    #[error("failed to create askpass server: {0}")]
+    #[error("failed to accept connection to askpass server: {0}")]
     AskpassServer(Easkpass),
     #[error("i/o error communicating with askpass utility: {0}")]
     AskpassIo(Esocket),
@@ -233,7 +232,7 @@ where
             res = child_process => {
                 return res;
             },
-            res = sock_server.accept(Some(Duration::from_secs(120))).fuse() => {
+            res = sock_server.accept().fuse() => {
                 let mut sock = res.map_err(Error::<E>::AskpassServer)?;
 
                 // get the PID of the peer

--- a/crates/gitbutler-git/tests/git/main.rs
+++ b/crates/gitbutler-git/tests/git/main.rs
@@ -1,5 +1,60 @@
 mod refspec;
 
+/// Uses a shell script as `remote.origin.uploadpack`, so unix only.
+#[cfg(unix)]
+mod slow_fetch {
+    use std::time::{Duration, Instant};
+
+    use but_testsupport::{gix_testtools::tempfile::TempDir, invoke_bash_at_dir};
+    use gitbutler_git::tokio::TokioExecutor;
+
+    /// A fetch whose Git operation outlives any askpass accept deadline must run to
+    /// completion; the askpass socket only matters if Git actually asks for credentials.
+    /// Regression test for slow fetches dying after 120s as
+    /// "failed to create askpass server: timed out".
+    ///
+    /// The paused clock auto-advances whenever the runtime is only waiting on the real
+    /// Git child, so a reintroduced accept deadline of any length (the bug had 120s)
+    /// fires immediately and fails this test without real waiting.
+    #[tokio::test(start_paused = true)]
+    async fn slow_fetch_without_prompt_completes() {
+        let tmp = TempDir::new().unwrap();
+        invoke_bash_at_dir(
+            r#"
+            set -eu
+            git init -q source
+            git -C source commit -q --allow-empty -m init
+            git clone -q --bare source origin.git
+            git clone -q origin.git client
+            cat > slow-upload-pack.sh <<'EOF'
+#!/bin/sh
+sleep 3
+exec git upload-pack "$@"
+EOF
+            chmod +x slow-upload-pack.sh
+            git -C client config remote.origin.uploadpack "$PWD/slow-upload-pack.sh"
+            "#,
+            tmp.path(),
+        );
+
+        let start = Instant::now();
+        // Answering `None` turns any unexpected credential prompt into a fetch
+        // error, proving the no-prompt path completes on its own.
+        gitbutler_git::fetch(
+            tmp.path().join("client"),
+            TokioExecutor,
+            "origin",
+            Some(|_prompt: String| async { None::<String> }),
+        )
+        .await
+        .expect("a slow fetch that never prompts for credentials completes");
+        assert!(
+            start.elapsed() >= Duration::from_secs(3),
+            "the delayed upload-pack should have been exercised"
+        );
+    }
+}
+
 #[cfg(test)]
 mod askpass {
     use std::time::Duration;
@@ -29,9 +84,9 @@ mod askpass {
                 .stdout_eq("super_secret_password\n");
         });
 
-        let mut sock = sock_server
-            .accept(Some(Duration::from_secs(10)))
+        let mut sock = tokio::time::timeout(Duration::from_secs(10), sock_server.accept())
             .await
+            .expect("timed out waiting for askpass connection")
             .expect("accept():");
 
         let peer_secret = sock.read_line().await.expect("read_line() peer_secret:");


### PR DESCRIPTION
The askpass event loop raced the running Git child against `accept()` with a fixed 120s deadline and mapped expiry to `failed to create askpass server: timed out`, killing legitimate slow fetches (and pushes/clones) that never prompted for credentials.

The deadline is unnecessary: the select loop already ends when Git exits, so this removes the timeout plumbing from `AskpassServer` entirely and lets `accept` wait as long as the child runs. The error variant's message is corrected too — it only ever fires for `accept`, never for server creation.

One deliberate tradeoff: the deadline doubled as an accidental watchdog for wedged fetches. It never existed in the direct/CLI path and each answered prompt re-armed it, so it never bounded the operation; transports and callers own cancellation. If we want a real fetch watchdog it belongs at the `but-api` boundary as an honestly-labeled operation timeout (possible follow-up).

Includes a regression test: a fetch whose `upload-pack` is delayed past any accept deadline must complete without prompting.

Fixes GB-1890