### PR TITLE
Limit noisy Lite command events

### DIFF
--- a/apps/lite/electron/src/api-command-sampling.ts
+++ b/apps/lite/electron/src/api-command-sampling.ts
@@ -1,0 +1,103 @@
+import type { Endpoint } from "./ipc.js";
+
+const API_COMMAND_SAMPLE_RATES: Readonly<Partial<Record<Endpoint, number>>> = {
+	treeChangeDiffs: 0.01,
+	branchDiff: 0.1,
+	changesInWorktree: 0.1,
+	commentsList: 0.1,
+	commitDetailsWithLineStats: 0.1,
+	headInfo: 0.1,
+	listProjectsStateless: 0.1,
+	listReviews: 0.1,
+	workspaceFetchStatus: 0.1,
+	workspaceTargetCommits: 0.1,
+};
+
+interface FailureLimitConfig {
+	bucketSize: number;
+	refillIntervalMs: number;
+}
+
+interface CaptureDecision {
+	occurrenceCount?: number;
+	samplingRate: number;
+}
+
+interface SamplerOptions {
+	failureLimit?: FailureLimitConfig;
+	now?: () => number;
+	random?: () => number;
+}
+
+interface FailureBucket {
+	lastRefillAt: number;
+	suppressed: number;
+	tokens: number;
+}
+
+const DEFAULT_FAILURE_LIMIT: FailureLimitConfig = {
+	bucketSize: 10,
+	refillIntervalMs: 10_000,
+};
+const MAX_BUCKET_SIZE = 1_000;
+const MAX_REFILL_INTERVAL_SECONDS = 3_600;
+
+const apiCommandSampleRate = (command: string): number =>
+	API_COMMAND_SAMPLE_RATES[command as Endpoint] ?? 1;
+
+const isIntegerBetween = (value: unknown, maximum: number): value is number =>
+	typeof value === "number" && Number.isSafeInteger(value) && value > 0 && value <= maximum;
+
+export const apiCommandFailureLimitConfig = (payload: unknown): FailureLimitConfig => {
+	if (payload === null || typeof payload !== "object" || Array.isArray(payload))
+		return DEFAULT_FAILURE_LIMIT;
+
+	const { bucketSize, refillIntervalSeconds } = payload as Record<string, unknown>;
+	if (
+		!isIntegerBetween(bucketSize, MAX_BUCKET_SIZE) ||
+		!isIntegerBetween(refillIntervalSeconds, MAX_REFILL_INTERVAL_SECONDS)
+	)
+		return DEFAULT_FAILURE_LIMIT;
+
+	return { bucketSize, refillIntervalMs: refillIntervalSeconds * 1_000 };
+};
+
+export const createApiCommandSampler = ({
+	failureLimit = DEFAULT_FAILURE_LIMIT,
+	now = () => performance.now(),
+	random = Math.random,
+}: SamplerOptions = {}): ((command: string, failure: boolean) => CaptureDecision | null) => {
+	const buckets = new Map<string, FailureBucket>();
+
+	return (command, failure) => {
+		const samplingRate = apiCommandSampleRate(command);
+		if (!failure) return random() < samplingRate ? { samplingRate } : null;
+
+		const timestamp = now();
+		let bucket = buckets.get(command);
+		if (bucket === undefined) {
+			bucket = {
+				lastRefillAt: timestamp,
+				suppressed: 0,
+				tokens: failureLimit.bucketSize,
+			};
+			buckets.set(command, bucket);
+		}
+
+		const refills = Math.floor((timestamp - bucket.lastRefillAt) / failureLimit.refillIntervalMs);
+		if (refills > 0) {
+			bucket.tokens = Math.min(failureLimit.bucketSize, bucket.tokens + refills);
+			bucket.lastRefillAt += refills * failureLimit.refillIntervalMs;
+		}
+
+		if (bucket.tokens === 0) {
+			bucket.suppressed++;
+			return null;
+		}
+
+		bucket.tokens--;
+		const occurrenceCount = bucket.suppressed + 1;
+		bucket.suppressed = 0;
+		return { occurrenceCount, samplingRate: 1 };
+	};
+};

--- a/apps/lite/electron/src/metrics.ts
+++ b/apps/lite/electron/src/metrics.ts
@@ -2,6 +2,7 @@ import { getAppSettings, getUserProfileLocal, updateTelemetryDistinctId } from "
 import type { UserProfile } from "@gitbutler/but-sdk";
 import { PostHog } from "posthog-node";
 import { randomUUID } from "node:crypto";
+import { apiCommandFailureLimitConfig, createApiCommandSampler } from "./api-command-sampling.js";
 
 /**
  * Product metrics for the main process. Events go to the same PostHog
@@ -15,6 +16,12 @@ import { randomUUID } from "node:crypto";
  * (`telemetry.appDistinctId`): `user_<id>` once any surface has seen a login,
  * a random UUID otherwise. The CLI on the same machine reads whatever is
  * stored there.
+ *
+ * In PostHog, estimate successful command totals with
+ * `sum(1 / coalesce(samplingRate, 1))`.
+ * Failures are not randomly sampled; use `sum(coalesce(occurrenceCount, 1))`
+ * because one retained event may represent suppressed repeats. Its `durationMs`
+ * still describes only the retained call.
  */
 
 // The same publishable project key the desktop app and the web app use.
@@ -23,10 +30,42 @@ const POSTHOG_HOST = "https://eu.i.posthog.com";
 const APP_NAME = "gitbutler-lite";
 const CONTAINER = "electron";
 const SHUTDOWN_TIMEOUT_MS = 2000;
+const FAILURE_LIMIT_FLAG = "lite-api-command-failure-limit";
+const FAILURE_LIMIT_CONFIG_ID = "gitbutler-lite-failure-limit";
+const FAILURE_LIMIT_CONFIG_TIMEOUT_MS = 1_000;
 
 let client: PostHog | null = null;
 let distinctId = "";
 let appVersion = "";
+let failureLimit = apiCommandFailureLimitConfig(undefined);
+let sampleApiCommand = createApiCommandSampler({ failureLimit });
+
+const setDistinctId = (nextDistinctId: string): void => {
+	if (distinctId !== nextDistinctId) sampleApiCommand = createApiCommandSampler({ failureLimit });
+	distinctId = nextDistinctId;
+};
+
+const configureFailureLimit = async (metricsClient: PostHog): Promise<void> => {
+	try {
+		const payload = await metricsClient.getFeatureFlagPayload(
+			FAILURE_LIMIT_FLAG,
+			FAILURE_LIMIT_CONFIG_ID,
+		);
+		if (client !== metricsClient) return;
+
+		const nextFailureLimit = apiCommandFailureLimitConfig(payload);
+		if (
+			nextFailureLimit.bucketSize === failureLimit.bucketSize &&
+			nextFailureLimit.refillIntervalMs === failureLimit.refillIntervalMs
+		)
+			return;
+
+		failureLimit = nextFailureLimit;
+		sampleApiCommand = createApiCommandSampler({ failureLimit });
+	} catch {
+		// The built-in defaults are safe when remote configuration is unavailable.
+	}
+};
 
 /**
  * Reads the shared app settings and starts the client. A no-op when metrics
@@ -44,12 +83,18 @@ export const initMetrics = async (version: string): Promise<void> => {
 		appVersion = version;
 		// The client exists from here on even if resolving the identity below
 		// fails; a session then captures under the stored or fresh id.
-		distinctId = telemetry.appDistinctId ?? randomUUID();
-		client = new PostHog(POSTHOG_API_KEY, { host: POSTHOG_HOST });
+		setDistinctId(telemetry.appDistinctId ?? randomUUID());
+		client = new PostHog(POSTHOG_API_KEY, {
+			host: POSTHOG_HOST,
+			featureFlagsRequestTimeoutMs: FAILURE_LIMIT_CONFIG_TIMEOUT_MS,
+		});
 
 		const profile = await getUserProfileLocal();
 		if (profile !== null) await metricsOnLogin(profile);
 		else if (distinctId !== telemetry.appDistinctId) await updateTelemetryDistinctId(distinctId);
+		// Bound the remote lookup so IPC capture starts with one stable policy
+		// without making app startup depend on PostHog being reachable.
+		await configureFailureLimit(client);
 	} catch (error) {
 		// oxlint-disable-next-line no-console
 		console.error("Failed to initialize metrics", error);
@@ -82,12 +127,16 @@ export const withApiCommandCapture =
 	async (params: unknown): Promise<unknown> => {
 		if (client === null) return handler(params);
 		const start = performance.now();
-		const record = (failure: boolean) =>
+		const record = (failure: boolean) => {
+			const decision = sampleApiCommand(command, failure);
+			if (decision === null) return;
 			capture("api_command", {
 				command,
 				durationMs: Math.round(performance.now() - start),
 				failure,
+				...decision,
 			});
+		};
 		try {
 			const result = await handler(params);
 			record(false);
@@ -106,7 +155,7 @@ export const withApiCommandCapture =
  */
 export const metricsOnLogin = async (profile: UserProfile): Promise<void> => {
 	if (client === null) return;
-	distinctId = `user_${profile.id}`;
+	setDistinctId(`user_${profile.id}`);
 	try {
 		await updateTelemetryDistinctId(distinctId);
 	} catch (error) {

--- a/apps/lite/harness/tests/api-command-sampling.test.ts
+++ b/apps/lite/harness/tests/api-command-sampling.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from "vitest";
+import {
+	apiCommandFailureLimitConfig,
+	createApiCommandSampler,
+} from "../../electron/src/api-command-sampling.ts";
+
+describe("api command sampling", () => {
+	test("heavily samples watcher-driven diff reads", () => {
+		expect(createApiCommandSampler({ random: () => 0.009 })("treeChangeDiffs", false)).toEqual({
+			samplingRate: 0.01,
+		});
+		expect(createApiCommandSampler({ random: () => 0.01 })("treeChangeDiffs", false)).toBeNull();
+	});
+
+	test("samples other high-volume background reads", () => {
+		expect(createApiCommandSampler({ random: () => 0.09 })("workspaceFetchStatus", false)).toEqual({
+			samplingRate: 0.1,
+		});
+		expect(
+			createApiCommandSampler({ random: () => 0.1 })("workspaceFetchStatus", false),
+		).toBeNull();
+	});
+
+	test("always captures user-triggered commands", () => {
+		expect(createApiCommandSampler({ random: () => 0.99 })("commitCreate", false)).toEqual({
+			samplingRate: 1,
+		});
+	});
+});
+
+describe("api command failure limiting", () => {
+	test("captures intermittent failures", () => {
+		let now = 0;
+		const sample = createApiCommandSampler({ now: () => now });
+
+		for (let index = 0; index < 20; index++) {
+			now = index * 10_000;
+			expect(sample("treeChangeDiffs", true)).toEqual({
+				occurrenceCount: 1,
+				samplingRate: 1,
+			});
+		}
+	});
+
+	test("limits bursts and carries suppressed occurrences into the next event", () => {
+		let now = 0;
+		const sample = createApiCommandSampler({ now: () => now });
+
+		for (let index = 0; index < 10; index++)
+			expect(sample("treeChangeDiffs", true)?.occurrenceCount).toBe(1);
+
+		expect(sample("treeChangeDiffs", true)).toBeNull();
+		now = 9_999;
+		expect(sample("treeChangeDiffs", true)).toBeNull();
+		now = 10_000;
+		expect(sample("treeChangeDiffs", true)?.occurrenceCount).toBe(3);
+	});
+
+	test("limits each command independently", () => {
+		const sample = createApiCommandSampler({
+			failureLimit: { bucketSize: 1, refillIntervalMs: 10_000 },
+			now: () => 0,
+		});
+
+		expect(sample("treeChangeDiffs", true)?.occurrenceCount).toBe(1);
+		expect(sample("treeChangeDiffs", true)).toBeNull();
+		expect(sample("workspaceFetchStatus", true)?.occurrenceCount).toBe(1);
+	});
+
+	test("success sampling does not consume or reset failure tokens", () => {
+		let now = 0;
+		let random = 0;
+		const sample = createApiCommandSampler({
+			failureLimit: { bucketSize: 1, refillIntervalMs: 10_000 },
+			now: () => now,
+			random: () => random,
+		});
+
+		expect(sample("treeChangeDiffs", false)).not.toBeNull();
+		expect(sample("treeChangeDiffs", true)?.occurrenceCount).toBe(1);
+		expect(sample("treeChangeDiffs", true)).toBeNull();
+		random = 0.99;
+		expect(sample("treeChangeDiffs", false)).toBeNull();
+		expect(sample("treeChangeDiffs", true)).toBeNull();
+		now = 10_000;
+		expect(sample("treeChangeDiffs", true)?.occurrenceCount).toBe(3);
+	});
+
+	test("caps refilled tokens after a long idle", () => {
+		let now = 0;
+		const sample = createApiCommandSampler({
+			failureLimit: { bucketSize: 2, refillIntervalMs: 10_000 },
+			now: () => now,
+		});
+
+		expect(sample("treeChangeDiffs", true)).not.toBeNull();
+		expect(sample("treeChangeDiffs", true)).not.toBeNull();
+		expect(sample("treeChangeDiffs", true)).toBeNull();
+		now = 100_000;
+		expect(sample("treeChangeDiffs", true)?.occurrenceCount).toBe(2);
+		expect(sample("treeChangeDiffs", true)?.occurrenceCount).toBe(1);
+		expect(sample("treeChangeDiffs", true)).toBeNull();
+	});
+
+	test("accepts a validated feature flag payload", () => {
+		expect(apiCommandFailureLimitConfig({ bucketSize: 20, refillIntervalSeconds: 5 })).toEqual({
+			bucketSize: 20,
+			refillIntervalMs: 5_000,
+		});
+		expect(apiCommandFailureLimitConfig({ bucketSize: 0, refillIntervalSeconds: "fast" })).toEqual({
+			bucketSize: 10,
+			refillIntervalMs: 10_000,
+		});
+		expect(apiCommandFailureLimitConfig({ bucketSize: 1_001, refillIntervalSeconds: 10 })).toEqual({
+			bucketSize: 10,
+			refillIntervalMs: 10_000,
+		});
+	});
+});

--- a/apps/lite/harness/tests/metrics.test.ts
+++ b/apps/lite/harness/tests/metrics.test.ts
@@ -1,0 +1,117 @@
+import type { UserProfile } from "@gitbutler/but-sdk";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+interface CapturedEvent {
+	distinctId: string;
+	event: string;
+	properties: Record<string, unknown>;
+}
+
+const mocks = vi.hoisted(() => ({
+	client: {
+		capture: vi.fn<(event: CapturedEvent) => void>(),
+		getFeatureFlagPayload: vi.fn(),
+		shutdown: vi.fn(),
+	},
+	getAppSettings: vi.fn(),
+	getUserProfileLocal: vi.fn(),
+	updateTelemetryDistinctId: vi.fn(),
+}));
+
+vi.mock("@gitbutler/but-sdk", () => ({
+	getAppSettings: mocks.getAppSettings,
+	getUserProfileLocal: mocks.getUserProfileLocal,
+	updateTelemetryDistinctId: mocks.updateTelemetryDistinctId,
+}));
+
+vi.mock("posthog-node", () => ({
+	PostHog: vi.fn(function PostHog() {
+		return mocks.client;
+	}),
+}));
+
+const profile = (id: number): UserProfile => ({
+	id,
+	name: null,
+	login: null,
+	email: null,
+	picture: "",
+	githubUsername: null,
+});
+
+const initMetrics = async (failureLimit?: {
+	bucketSize: number;
+	refillIntervalSeconds: number;
+}) => {
+	mocks.client.getFeatureFlagPayload.mockResolvedValue(failureLimit);
+	const metrics = await import("../../electron/src/metrics.ts");
+	await metrics.initMetrics("1.2.3");
+	return metrics;
+};
+
+describe("api command metrics", () => {
+	beforeEach(() => {
+		vi.resetModules();
+		vi.clearAllMocks();
+		mocks.getAppSettings.mockResolvedValue({
+			telemetry: { appMetricsEnabled: true, appDistinctId: "user_1" },
+		});
+		mocks.getUserProfileLocal.mockResolvedValue(null);
+		mocks.updateTelemetryDistinctId.mockResolvedValue(undefined);
+		mocks.client.shutdown.mockResolvedValue(undefined);
+	});
+
+	test("captures successful commands with their sampling rate", async () => {
+		const metrics = await initMetrics();
+		const handler = vi.fn().mockResolvedValue("result");
+
+		await expect(metrics.withApiCommandCapture("commitCreate", handler)(null)).resolves.toBe(
+			"result",
+		);
+		const captured = mocks.client.capture.mock.lastCall?.[0];
+		expect(captured?.distinctId).toBe("user_1");
+		expect(captured?.event).toBe("api_command");
+		expect(captured?.properties).toMatchObject({
+			command: "commitCreate",
+			failure: false,
+			samplingRate: 1,
+		});
+		expect(captured?.properties).not.toHaveProperty("occurrenceCount");
+		await metrics.shutdownMetrics();
+	});
+
+	test("applies failure limits, rethrows errors, and resets buckets on login", async () => {
+		const metrics = await initMetrics({ bucketSize: 1, refillIntervalSeconds: 10 });
+		const error = new Error("failed");
+		const wrapped = metrics.withApiCommandCapture(
+			"treeChangeDiffs",
+			vi.fn().mockRejectedValue(error),
+		);
+
+		await expect(wrapped(null)).rejects.toBe(error);
+		expect(mocks.client.getFeatureFlagPayload).toHaveBeenCalledWith(
+			"lite-api-command-failure-limit",
+			"gitbutler-lite-failure-limit",
+		);
+		const capturedFailure = mocks.client.capture.mock.lastCall?.[0];
+		expect(capturedFailure?.distinctId).toBe("user_1");
+		expect(capturedFailure?.event).toBe("api_command");
+		expect(capturedFailure?.properties).toMatchObject({
+			command: "treeChangeDiffs",
+			failure: true,
+			occurrenceCount: 1,
+			samplingRate: 1,
+		});
+
+		mocks.client.capture.mockClear();
+		await expect(wrapped(null)).rejects.toBe(error);
+		expect(mocks.client.capture).not.toHaveBeenCalled();
+
+		await metrics.metricsOnLogin(profile(2));
+		await expect(wrapped(null)).rejects.toBe(error);
+		const capturedAfterLogin = mocks.client.capture.mock.lastCall?.[0];
+		expect(capturedAfterLogin?.distinctId).toBe("user_2");
+		expect(capturedAfterLogin?.properties.occurrenceCount).toBe(1);
+		await metrics.shutdownMetrics();
+	});
+});

--- a/apps/lite/harness/tsconfig.json
+++ b/apps/lite/harness/tsconfig.json
@@ -25,6 +25,7 @@
 		"../ui/src",
 		"../electron/src/ipc.ts",
 		"../electron/src/lite-api.ts",
-		"../electron/src/endpoint-table.ts"
+		"../electron/src/endpoint-table.ts",
+		"../electron/src/api-command-sampling.ts"
 	]
 }


### PR DESCRIPTION
Reduce the volume of high-frequency Lite read-command events while keeping mutations intact.

Failures bypass random sampling and use a remotely configurable per-command burst limit, folding suppressed repeats into occurrence counts.