### PR TITLE
lite: open details on the Pull Request tab when one is on offer

### DIFF
--- a/apps/lite/ui/src/projects/project.ts
+++ b/apps/lite/ui/src/projects/project.ts
@@ -132,8 +132,6 @@ const createInitialWorkspaceState = (): WorkspaceState => ({
 
 export type PageId = "workspace" | "upstream" | "branches";
 
-const defaultBranchTab: BranchTab = "diff";
-
 export type ProjectState = {
 	filesVisible: boolean;
 	branches: BranchesState;
@@ -596,8 +594,13 @@ const selectCheckedAddressCount = createSelector(
 
 export const projectSelectors = {
 	selectFilesVisible: (state: ProjectState) => state.filesVisible,
-	selectBranchTab: (state: ProjectState, branchName: string): BranchTab =>
-		state.workspace.selectedBranchTabs[branchName] ?? defaultBranchTab,
+	/**
+	 * The explicitly chosen tab, or `undefined` when none was picked — the
+	 * caller supplies the default, since whether the Pull Request tab is worth
+	 * opening on depends on forge data the store does not hold.
+	 */
+	selectBranchTab: (state: ProjectState, branchName: string): BranchTab | undefined =>
+		state.workspace.selectedBranchTabs[branchName],
 
 	selectUncommittedFilesFilter: (state: ProjectState) => state.workspace.uncommittedFilesFilter,
 	selectFilesFilter: (state: ProjectState) => state.workspace.filesFilter,

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -2556,8 +2556,11 @@ const CommitDetails: FC<{
 
 	// The tab is per selection: selecting another commit remounts this
 	// component, and a landed review is read, not worked on, so nothing needs
-	// to remember the choice.
-	const [tab, setTab] = useState<BranchTab>("diff");
+	// to remember the choice. The review is what the commit is listed for, so
+	// it opens on the review — derived rather than seeded into the state, as
+	// the review can resolve after mount.
+	const [chosenTab, setTab] = useState<BranchTab | null>(null);
+	const tab = chosenTab ?? (review ? "pr" : "diff");
 	const ref = useRef<HTMLDivElement>(null);
 	useBranchTabHotkeys({ branchTab: tab, setBranchTab: setTab, target: ref, enabled: !!review });
 
@@ -2959,9 +2962,12 @@ const UnappliedBranchDetails: FC<BranchDetailsProps> = ({
 		select: (reviews) => reviews.find((review) => review.sourceBranch === branchName) ?? null,
 	});
 
-	const branchTab = useAppSelector((state) =>
+	const chosenTab = useAppSelector((state) =>
 		projectSlice.selectors.selectBranchTab(state, projectId, branchName),
 	);
+	// The review is what the branch is judged by, so a branch that has one
+	// opens on it; without one only the diff is on offer.
+	const branchTab = chosenTab ?? (review ? "pr" : "diff");
 	const setBranchTab = (tab: BranchTab) => {
 		dispatch(projectSlice.actions.setSelectedBranchTab({ projectId, branchName, tab }));
 	};
@@ -3030,9 +3036,13 @@ const AppliedBranchDetails: FC<BranchDetailsProps> = ({
 	const dispatch = useAppDispatch();
 	const branchRef = decodeBytes(branch.branchRef);
 	const branchName = branchDetailsParams(branchRef).branchName;
-	const branchTab = useAppSelector((state) =>
+	const chosenTab = useAppSelector((state) =>
 		projectSlice.selectors.selectBranchTab(state, projectId, branchName),
 	);
+	// The review is where an applied branch is headed, so a forge that serves
+	// pull requests opens on that tab — the create form when none exists yet.
+	// Without such a forge the tab is a dead form, so the diff leads.
+	const branchTab = chosenTab ?? (forgeInfo?.capabilities.prService ? "pr" : "diff");
 
 	const setBranchTab = (tab: BranchTab) => {
 		dispatch(projectSlice.actions.setSelectedBranchTab({ projectId, branchName, tab }));


### PR DESCRIPTION
The Diff/Pull Request toggle defaulted to the diff everywhere. The review is usually what these surfaces are opened for, so the default is now the PR tab wherever it has something to show:

- applied branches (workspace tab) on a forge that serves pull requests — the existing review, or the create-PR form when none exists yet
- unapplied branches (branches tab) that have a review
- upstream merge commits with a landed review

An explicit tab choice still sticks per branch. Mechanically, the store selector now returns only the explicit choice and each surface supplies its own fallback, since whether the PR tab is worth opening on depends on forge data the store does not hold.