### PR TITLE
Lite: make row selection legible across the workspace lists

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
@@ -79,9 +79,25 @@
 	}
 }
 
+/* Answers a hovered dependency indicator. */
 .containerHighlighted {
 	background-color: color-mix(var(--fill-pop-bg) 20%, transparent);
 	color: var(--text-1);
+
+	/* The row pointed at is often the selected one, and when that selection is
+	   focused its solid fill out-specifies the tint above — leaving a hover that
+	   changes nothing. It deepens instead of going solid: enough over the tint
+	   to separate the selected row from its fellow dependencies, not so much
+	   that a passing hover repaints the panel. */
+	&.containerSelected:has(:is(textarea, input):focus),
+	[data-selection-focus-styles="true"]
+		[data-focus-scope][data-selection-focused="true"]
+		&.containerSelected {
+		background-color: color-mix(var(--fill-pop-bg) 30%, transparent);
+		/* Restated because the selection's own rule ties this one and would
+		   otherwise leave its inverted text on a fill no longer dark enough. */
+		color: var(--text-1);
+	}
 }
 
 .toolbar {
@@ -184,9 +200,9 @@
 	   only its border marks it out. */
 	[data-selection-focus-styles="true"]
 		[data-focus-scope][data-selection-focused="true"]
-		.containerSelected
+		.containerSelected:not(.containerHighlighted)
 		&,
-	.containerSelected:has(:is(textarea, input):focus) & {
+	.containerSelected:not(.containerHighlighted):has(:is(textarea, input):focus) & {
 		--checkbox-bg: var(--fill-gray-bg);
 	}
 }
@@ -268,7 +284,7 @@
 
 	[data-selection-focus-styles="true"]
 		[data-focus-scope][data-selection-focused="true"]
-		.containerSelected
+		.containerSelected:not(.containerHighlighted)
 		& {
 		color: var(--text-2-invert);
 	}
@@ -277,9 +293,9 @@
 .buttonGhost {
 	[data-selection-focus-styles="true"]
 		[data-focus-scope][data-selection-focused="true"]
-		.containerSelected
+		.containerSelected:not(.containerHighlighted)
 		&,
-	.containerSelected:has(:is(textarea, input):focus) & {
+	.containerSelected:not(.containerHighlighted):has(:is(textarea, input):focus) & {
 		/* Duplicated styles for ghost-inverted button variant. This is necessary to
 		make the variant responsive to selection/focus changes purely with CSS. */
 
@@ -294,9 +310,9 @@
 .buttonOutline {
 	[data-selection-focus-styles="true"]
 		[data-focus-scope][data-selection-focused="true"]
-		.containerSelected
+		.containerSelected:not(.containerHighlighted)
 		&,
-	.containerSelected:has(:is(textarea, input):focus) & {
+	.containerSelected:not(.containerHighlighted):has(:is(textarea, input):focus) & {
 		/* Duplicated styles for outline-inverted button variant. This is necessary to
 		make the variant responsive to selection/focus changes purely with CSS. */
 
@@ -326,10 +342,12 @@
    badges and graph segments — so they can restyle themselves for the selected
    state without cross-module class references. Raised for both states that give
    the row its solid inverted fill: a focused selection, and a row carrying an
-   inline editor. */
+   inline editor — but not for a highlighted row, whose dependency fill is light
+   enough that its contents stay in the normal palette. The same exclusion runs
+   through the inverted text and button rules above. */
 [data-selection-focus-styles="true"]
 	[data-focus-scope][data-selection-focused="true"]
-	.containerSelected,
-.containerSelected:has(:is(textarea, input):focus) {
+	.containerSelected:not(.containerHighlighted),
+.containerSelected:not(.containerHighlighted):has(:is(textarea, input):focus) {
 	--selection-inverted: true;
 }

--- a/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
@@ -48,8 +48,29 @@
 	}
 }
 
+/* Three tiers, because a row can be selected in three different senses. Every
+   selected row keeps a fill: the lists are navigated with the keyboard, so
+   where each one's cursor sits has to stay legible from the other one. What
+   separates them is the rail below and the focused fill further down. */
 .containerSelected {
 	background-color: color-mix(var(--fill-gray-bg) var(--opacity-bg-selected-blur), transparent);
+
+	/* Only one row in the window is the source of what the details pane shows.
+	   A rail on its leading edge says so even when focus has moved away — into
+	   the other list, or into the pane itself — so two tinted rows never read
+	   as equals. */
+	&:is([data-preview-source="true"] *) {
+		position: relative;
+
+		&::before {
+			position: absolute;
+			width: 4px;
+			inset-block: 0;
+			inset-inline-start: 0;
+			background-color: var(--fill-gray-bg);
+			content: "";
+		}
+	}
 
 	&:has(:is(textarea, input):focus),
 	[data-selection-focus-styles="true"] [data-focus-scope][data-selection-focused="true"] & {

--- a/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
@@ -49,9 +49,7 @@
 }
 
 .containerSelected {
-	&:not([data-preview-source="false"] *) {
-		background-color: color-mix(var(--fill-gray-bg) var(--opacity-bg-selected-blur), transparent);
-	}
+	background-color: color-mix(var(--fill-gray-bg) var(--opacity-bg-selected-blur), transparent);
 
 	&:has(:is(textarea, input):focus),
 	[data-selection-focus-styles="true"] [data-focus-scope][data-selection-focused="true"] & {


### PR DESCRIPTION
Three related fixes to how a workspace row reports that it is selected.

### The tint on an unfocused selected row

`3553372968` narrowed the selection fill to `:not([data-preview-source="false"] *)`, so the list that was not driving the details pane showed no selection at all. Both cursors persist in the URL and both lists are keyboard destinations, so a hidden cursor is one you land on unawares. The fill is back for every selected row.

### A rail for the row that drives the pane

With both cursors tinted, nothing said which one the details pane was following — and with focus in the Changes pane, three rows could tie. The row inside `[data-preview-source="true"]` now carries a 4px rail on its leading edge. Ladder: fill = a list's cursor, fill + rail = the source of the pane, solid = the list holding focus.

NOTE: It's not ideal. But we need something right now for highlighting.

https://github.com/user-attachments/assets/877a1fa8-1e90-454f-9bec-7ba7a16b8655

<img width="2102" height="1610" alt="Screenshot 2026-08-25 at 23-40-17" src="https://github.com/user-attachments/assets/9e4ae5ba-af19-4c5c-ab8c-1f17fb53d826" />


### A hovered dependency now answers on the selected row

Reported internally: hovering a file's dependency indicator changed nothing when the commit it points at was the selected one.


https://github.com/user-attachments/assets/6c9312ba-786f-4007-adf7-41b29c80506d



The wiring was fine — `DependencyIndicator` dispatches `setHighlightedCommitIds`, `CommitRow` turns that into `containerHighlighted`. The problem was that the highlight only ever spoke through `background-color`, and on a focused selection that channel is claimed by a rule at far higher specificity, so the highlight lost outright.

It now deepens to `color-mix(var(--fill-pop-bg) 30%, transparent)` on that row, which meant opting out of the inverted-content mode the focused selection raises: `--text-2-invert` on faded text, `--text-1-invert` on ghost/outline buttons, `--fill-gray-bg` on the checkbox, and the `--selection-inverted` flag that badges and graph segments read through `@container style()`. All of that assumes a dark fill underneath; against the light dependency fill it painted white on pale teal. Each of those rules now excludes `.containerHighlighted`.
