### PR TITLE
skill: clarify but pr guidance for stacked branches

### DIFF
--- a/crates/but/skill/SKILL.md
+++ b/crates/but/skill/SKILL.md
@@ -150,7 +150,7 @@ To make one existing branch depend on another: `but move <child-branch-name> --a
 
 `but pr new <branch-name>` pushes the selected branch and its ancestors, then creates the PR in one step — no prior `but push`. Provide `-F pr_message.txt`, `-t`, or `-m` with real newlines (zsh/bash: `-m $'Title\n\nBody'`) so no editor opens. If forge auth is missing, run `but config forge auth`.
 
-For stacked branches `but pr` is mandatory (it sets PR bases and stack metadata; `gh pr create` breaks that). To publish a whole stack: `but pr new <top-branch-name> -t`. Manage with `but pr auto-merge|set-draft|set-ready <selector>`; selectors can be a branch name, current branch/stack CLI ID, or numeric review ID. See `references/reference.md` for details.
+If you do create a PR for a stacked branch, use `but pr` — not `gh pr create` (only `but pr` sets PR bases and stack metadata; `gh pr create` breaks that). To publish a whole stack: `but pr new <top-branch-name> -t`. Manage with `but pr auto-merge|set-draft|set-ready <selector>`; selectors can be a branch name, current branch/stack CLI ID, or numeric review ID. See `references/reference.md` for details.
 
 ### Dependency conflict with another branch
 


### PR DESCRIPTION
The skill said "for stacked branches `but pr` is mandatory", which could be read as requiring the agent to create a PR whenever branches are stacked. The actual requirement: if a PR is created for a stacked branch, it must go through `but pr` (not `gh pr create`) so PR bases and stack metadata are set correctly. Reworded to say that.