### PR TITLE
lite: default diff view to selected file only

### DIFF
--- a/apps/lite/ui/src/settings.ts
+++ b/apps/lite/ui/src/settings.ts
@@ -32,7 +32,7 @@ export const defaultSettings = {
 		dark: "github-dark-default" satisfies BundledTheme,
 	},
 	theme: "system",
-	unidiff: true,
+	unidiff: false,
 } satisfies Partial<GUISettings>;
 
 export const clampAutoFetch = (ms: number): number =>


### PR DESCRIPTION
Flips the `unidiff` GUI setting default so the details pane shows only the selected file's diff by default. Users who already toggled the setting keep their stored choice.