### PR TITLE
Classify GitHub org OAuth restrictions and surface the degraded state

### DIFF
--- a/apps/desktop/src/components/projectSettings/ForgeAccountConfig.svelte
+++ b/apps/desktop/src/components/projectSettings/ForgeAccountConfig.svelte
@@ -1,7 +1,7 @@
 <script lang="ts" generics="TAccount">
 	import { useSettingsModal } from "$lib/settings/settingsModal.svelte";
 	import { Button, CardGroup, Link, Select, SelectItem } from "@gitbutler/ui";
-	import type { Component } from "svelte";
+	import type { Component, Snippet } from "svelte";
 
 	type Props = {
 		projectId: string;
@@ -15,6 +15,8 @@
 		AccountBadge: Component<{ account: TAccount; class?: string }>;
 		docsUrl: string;
 		requestType: "pull request" | "merge request";
+		/** Degraded-integration notice rendered below the account select. */
+		notice?: Snippet;
 	};
 
 	const {
@@ -29,6 +31,7 @@
 		AccountBadge,
 		docsUrl,
 		requestType,
+		notice,
 	}: Props = $props();
 
 	const { openGeneralSettings } = useSettingsModal();
@@ -85,5 +88,9 @@
 				</SelectItem>
 			{/snippet}
 		</Select>
+	{/if}
+
+	{#if notice}
+		{@render notice()}
 	{/if}
 </CardGroup.Item>

--- a/apps/desktop/src/components/projectSettings/ForgeForm.svelte
+++ b/apps/desktop/src/components/projectSettings/ForgeForm.svelte
@@ -4,6 +4,7 @@
 	import GitLabAccountBadge from "$components/forge/GitLabAccountBadge.svelte";
 	import ForgeAccountConfig from "$components/projectSettings/ForgeAccountConfig.svelte";
 	import { GIT_CONFIG_SERVICE } from "$lib/config/gitConfigService";
+	import { isNormalizedError } from "$lib/error/normalizedError";
 	import {
 		bitbucketAccountIdentifierToString,
 		stringToBitbucketAccountIdentifier,
@@ -20,15 +21,17 @@
 		stringToGitLabAccountIdentifier,
 	} from "$lib/forge/gitlab/gitlabUserService.svelte";
 	import { usePreferredGitLabUsername } from "$lib/forge/gitlab/hooks.svelte";
+	import { LISTING_SERVICE } from "$lib/forge/listingService.svelte";
 	import { PROJECTS_SERVICE } from "$lib/project/projectsService";
 	import { inject } from "@gitbutler/core/context";
 	import { reactive } from "@gitbutler/shared/reactiveUtils.svelte";
-	import { CardGroup, Select, SelectItem } from "@gitbutler/ui";
+	import { CardGroup, InfoMessage, Link, Select, SelectItem } from "@gitbutler/ui";
 
 	import type { Project } from "$lib/project/project";
 	import type {
 		BitbucketAccountIdentifier,
 		ForgeName,
+		ForgeUser,
 		GitHubStackingMode,
 		GithubAccountIdentifier,
 		GitlabAccountIdentifier,
@@ -71,6 +74,15 @@
 		reactive(() => projectId),
 	);
 
+	// The workspace's polled review listing keeps this cache entry current,
+	// so it reflects whether the integration currently works at all.
+	const listingService = inject(LISTING_SERVICE);
+	const listingState = $derived(listingService.listingState(projectId));
+	const listingError = $derived(listingState.result.error);
+	const githubOrgRestricted = $derived(
+		isNormalizedError(listingError) && listingError.code === "GitHubOrgOAuthRestricted",
+	);
+
 	// GitLab hooks
 	const { preferredGitLabAccount, gitlabAccounts } = usePreferredGitLabUsername(
 		reactive(() => projectId),
@@ -94,25 +106,28 @@
 		projectsService.updateProject(mutableProject);
 	}
 
-	function updatePreferredGitHubAccount(projectId: string, account: GithubAccountIdentifier) {
-		projectsService.updatePreferredForgeUser(projectId, {
-			provider: "github",
-			details: account,
-		});
+	async function updatePreferredForgeUser(projectId: string, forgeUser: ForgeUser) {
+		await projectsService.updatePreferredForgeUser(projectId, forgeUser);
+		// The cached review listing was fetched with the previous account's
+		// credentials; refresh it so a credential-caused failure (e.g. an
+		// org OAuth restriction) clears as soon as the account changes
+		// instead of on the next 15-minute poll.
+		await listingService.refresh(projectId);
 	}
 
-	function updatePreferredGitLabAccount(projectId: string, account: GitlabAccountIdentifier) {
-		projectsService.updatePreferredForgeUser(projectId, {
-			provider: "gitlab",
-			details: account,
-		});
+	async function updatePreferredGitHubAccount(projectId: string, account: GithubAccountIdentifier) {
+		await updatePreferredForgeUser(projectId, { provider: "github", details: account });
 	}
 
-	function updatePreferredBitbucketAccount(projectId: string, account: BitbucketAccountIdentifier) {
-		projectsService.updatePreferredForgeUser(projectId, {
-			provider: "bitbucket",
-			details: account,
-		});
+	async function updatePreferredGitLabAccount(projectId: string, account: GitlabAccountIdentifier) {
+		await updatePreferredForgeUser(projectId, { provider: "gitlab", details: account });
+	}
+
+	async function updatePreferredBitbucketAccount(
+		projectId: string,
+		account: BitbucketAccountIdentifier,
+	) {
+		await updatePreferredForgeUser(projectId, { provider: "bitbucket", details: account });
 	}
 
 	async function updateReviewStackingDescription(value: ReviewStackingDescription) {
@@ -244,7 +259,26 @@
 			AccountBadge={GitHubAccountBadge}
 			docsUrl="https://docs.gitbutler.com/features/forge-integration/github-integration"
 			requestType="pull request"
-		/>
+		>
+			{#snippet notice()}
+				{#if githubOrgRestricted}
+					<InfoMessage style="warning" filled outlined={false}>
+						{#snippet title()}
+							Restricted by a GitHub organization
+						{/snippet}
+						{#snippet content()}
+							An organization that owns this repository has blocked the GitButler OAuth app, so pull
+							requests can't be listed or created right now. Ask an organization owner to approve
+							the app, or connect an account that uses a personal access token — see the
+							<Link
+								href="https://docs.gitbutler.com/features/forge-integration/github-integration?utm_source=gitbutler-app&utm_medium=settings-banner&utm_campaign=org-oauth-restriction#connect-a-github-account"
+								>docs</Link
+							>.
+						{/snippet}
+					</InfoMessage>
+				{/if}
+			{/snippet}
+		</ForgeAccountConfig>
 	{/if}
 
 	{#if forgeInfo?.name === "gitlab"}

--- a/apps/desktop/src/lib/error/error.test.ts
+++ b/apps/desktop/src/lib/error/error.test.ts
@@ -14,6 +14,80 @@ function fakePosthog() {
  * flowing through with their severity attached.
  */
 describe("emitQueryError", () => {
+	test("rate limits separate list_reviews signatures independently", () => {
+		const { posthog, capture } = fakePosthog();
+		const context = { command: "list_reviews_signature_partition_test" };
+
+		for (let index = 0; index < 5; index++) {
+			emitQueryError(
+				posthog,
+				{
+					name: "API error: (list_reviews)",
+					message: "403 Forbidden: OAuth App access restrictions",
+				},
+				context,
+			);
+		}
+		emitQueryError(
+			posthog,
+			{
+				name: "API error: (list_reviews)",
+				message: "Open pull request listing changed while paginating",
+			},
+			context,
+		);
+
+		expect(capture).toHaveBeenCalledTimes(6);
+	});
+
+	test("terminal states are captured once per session", () => {
+		const { posthog, capture } = fakePosthog();
+		const context = { command: "list_reviews_terminal_test", terminal: true };
+		const error = {
+			name: "API error: (list_reviews)",
+			message: "403 Forbidden: OAuth App access restrictions",
+		};
+
+		for (let index = 0; index < 10; index++) {
+			emitQueryError(posthog, error, context);
+		}
+		// A different terminal failure still gets its first capture.
+		emitQueryError(
+			posthog,
+			{ ...error, message: "403 Forbidden: some other terminal state" },
+			context,
+		);
+
+		expect(capture).toHaveBeenCalledTimes(2);
+	});
+
+	test("terminal states with a code dedupe on the code, not the message", () => {
+		const { posthog, capture } = fakePosthog();
+		const context = { command: "list_reviews_terminal_code_test", terminal: true };
+
+		// The forge's wording can vary per org/repo; the code is the state.
+		emitQueryError(
+			posthog,
+			{
+				name: "API error: (list_reviews)",
+				message: "403 Forbidden: org A has enabled restrictions",
+				code: "GitHubOrgOAuthRestricted",
+			},
+			context,
+		);
+		emitQueryError(
+			posthog,
+			{
+				name: "API error: (list_reviews)",
+				message: "403 Forbidden: differently worded restriction",
+				code: "GitHubOrgOAuthRestricted",
+			},
+			context,
+		);
+
+		expect(capture).toHaveBeenCalledTimes(1);
+	});
+
 	test("silent severity is not captured", () => {
 		const { posthog, capture } = fakePosthog();
 		emitQueryError(

--- a/apps/desktop/src/lib/error/error.ts
+++ b/apps/desktop/src/lib/error/error.ts
@@ -137,6 +137,11 @@ export function parseQueryError(error: unknown): QueryError {
 	};
 }
 
+// Terminal states (persistent environment conditions, e.g. an org-level
+// OAuth restriction hit by every poll) are captured once per app session —
+// repeats carry no new information and would just flood the error stream.
+const capturedTerminalKeys = new Set<string>();
+
 export function emitQueryError(
 	posthog: PostHogWrapper | undefined,
 	error: unknown,
@@ -144,6 +149,7 @@ export function emitQueryError(
 		command?: string;
 		actionName?: string;
 		severity?: "error" | "warning" | "silent";
+		terminal?: boolean;
 	},
 ) {
 	const { name, message, code } = parseQueryError(error);
@@ -155,8 +161,23 @@ export function emitQueryError(
 	// known noise), not defects — keep them out of error telemetry.
 	if (context?.severity === "silent") return;
 	if (!posthog) return;
-	const key = `${context?.command ?? ""}|${name}`;
-	if (!shouldCaptureQueryError(key)) return;
+	if (context?.terminal) {
+		// The code identifies the state; messages may embed volatile detail
+		// (e.g. the forge's own wording), which would defeat the dedup. This
+		// path is deliberately outside the windowed limiter: volume is
+		// bounded by the set itself — at most one capture per terminal state
+		// per session — and an unrelated error flood must not starve it.
+		const terminalKey = `${context?.command ?? ""}|${code ?? message}`;
+		if (capturedTerminalKeys.has(terminalKey)) return;
+		capturedTerminalKeys.add(terminalKey);
+	} else {
+		// IPC errors share one name per command (`API error: (<command>)`),
+		// so the message must be part of the key — otherwise one hot failure
+		// (e.g. a polled 403) exhausts the per-key budget for every other
+		// failure of the same command. The global limit bounds total volume.
+		const key = `${context?.command ?? ""}|${name}|${message}`;
+		if (!shouldCaptureQueryError(key)) return;
+	}
 	posthog.capture(QUERY_ERROR_EVENT_NAME, {
 		error_title: name,
 		error_message: message,

--- a/apps/desktop/src/lib/error/errorClassification.test.ts
+++ b/apps/desktop/src/lib/error/errorClassification.test.ts
@@ -120,6 +120,26 @@ describe("classify", () => {
 	});
 
 	describe("title resolution", () => {
+		test("recognises a GitHub org OAuth restriction from a real list_reviews IPC error", () => {
+			// The backend tags the org-restriction 403 with a dedicated code
+			// (`classify_forge_error` in `but-github`); the classification's
+			// title override must beat the generic `API error: (<command>)`
+			// name so the opt-out action is reachable.
+			const error = new IpcError(
+				{
+					message:
+						'Failed to list open pull requests\n\nCaused by:\n    1: 403 Forbidden: {"message":"Although you appear to have the correct authorization credentials, the organization has enabled OAuth App access restrictions."}\n    2: HTTP 403',
+					code: "GitHubOrgOAuthRestricted",
+				},
+				"list_reviews",
+			);
+
+			const result = classify(error);
+
+			expect(result.title).toBe("GitHub Organizations OAuth Error");
+			expect(result.actionHint?.label).toBe("Don't show this again");
+		});
+
 		test("uses the error's own name when present (IPC commands)", () => {
 			const error = new IpcError({ message: "boom" }, "workspace_branch_and_ancestors_push");
 			expect(classify(error, "Caller title").title).toBe(
@@ -138,11 +158,13 @@ describe("classify", () => {
 		});
 
 		test("rewrites the GitHub-org-auth message prefix to a stable title", () => {
-			expect(
-				classify(
-					"Although you appear to have the correct authorization credentials, the org has SSO enforced.",
-				).title,
-			).toBe("GitHub Organizations OAuth Error");
+			// The octokit path carries no backend code, so the message
+			// pattern must yield the same classification as the code entry.
+			const result = classify(
+				"Although you appear to have the correct authorization credentials, the org has SSO enforced.",
+			);
+			expect(result.title).toBe("GitHub Organizations OAuth Error");
+			expect(result.actionHint?.label).toBe("Don't show this again");
 		});
 	});
 });

--- a/apps/desktop/src/lib/error/errorClassification.ts
+++ b/apps/desktop/src/lib/error/errorClassification.ts
@@ -10,7 +10,8 @@ export type Severity = "error" | "warning" | "silent";
 
 export type ActionHint = {
 	label: string;
-	onClick: () => void;
+	/** `dismiss` closes the toast the action was clicked on. */
+	onClick: (dismiss: () => void) => void;
 };
 
 /**
@@ -26,6 +27,18 @@ export type ActionHint = {
  */
 export type Classification = {
 	severity: Severity;
+	/**
+	 * Replaces the error's own name as the toast/capture title. IPC errors
+	 * all arrive named `API error: (<command>)`, so a code that identifies
+	 * a specific condition needs this to surface under a stable title.
+	 */
+	title?: string;
+	/**
+	 * A persistent environment state rather than a one-off defect —
+	 * repeated occurrences carry no new information, so telemetry
+	 * captures it once per session instead of once per occurrence.
+	 */
+	terminal?: boolean;
 	userMessage?: string;
 	actionHint?: ActionHint;
 };
@@ -35,6 +48,7 @@ export type ClassifiedError = {
 	message: string;
 	code?: Code;
 	severity: Severity;
+	terminal?: boolean;
 	userMessage?: string;
 	actionHint?: ActionHint;
 };
@@ -42,17 +56,29 @@ export type ClassifiedError = {
 const GH_ORG_AUTH_ERROR = "GitHub Organizations OAuth Error";
 
 /**
- * Rewrite distinctive raw-message prefixes to a stable title so two
- * variants of the same root cause land under the same Sentry/PostHog
- * bucket — and so title-keyed rules below can match.
+ * A GitHub organization has blocked the GitButler OAuth app. Terminal
+ * until the org approves the app or the user switches credentials, and
+ * `list_reviews` polling keeps rediscovering it — the action lets the
+ * user opt out of repeats (honoured by the swallow check in `classify`).
+ *
+ * Shared between the code-keyed entry (IPC errors, tagged by the
+ * backend) and the message-pattern entry (octokit errors, which never
+ * pass through the backend and so carry no code).
  */
-const MESSAGE_PATTERN_TITLES: Record<string, string> = {
-	"Although you appear to have the correct authorization credentials,": GH_ORG_AUTH_ERROR,
-};
-
-const GITHUB_ORG_AUTH_ACTION: ActionHint = {
-	label: "Don't show this again",
-	onClick: () => persistSwallowGitHubOrgAuthErrors(true),
+const GH_ORG_AUTH_CLASSIFICATION: Classification = {
+	severity: "error",
+	terminal: true,
+	title: GH_ORG_AUTH_ERROR,
+	actionHint: {
+		label: "Don't show this again",
+		onClick: (dismiss) => {
+			persistSwallowGitHubOrgAuthErrors(true);
+			dismiss();
+		},
+	},
+	userMessage: `
+A GitHub organization has restricted access for the GitButler OAuth app. Ask an organization owner to approve the app, or connect GitHub with a personal access token instead — see the [GitHub integration docs](https://docs.gitbutler.com/features/forge-integration/github-integration?utm_source=gitbutler-app&utm_medium=error-toast&utm_campaign=org-oauth-restriction#connect-a-github-account).
+	`,
 };
 
 /**
@@ -130,6 +156,7 @@ With \`seahorse\` or equivalent, create a \`Login\` password store, right click 
 Your GitHub token appears expired. Please log out and back in to refresh it. (Settings -> Integrations -> Forget)
 	`,
 	},
+	GitHubOrgOAuthRestricted: GH_ORG_AUTH_CLASSIFICATION,
 	ProjectDatabaseIncompatible: {
 		severity: "error",
 		userMessage: `
@@ -175,14 +202,12 @@ const MESSAGE_PATTERNS: ReadonlyArray<{
 				"The `gitbutler-git` binary is missing. Run `cargo build -p gitbutler-git` to build it.",
 		},
 	},
+	{
+		matches: ({ message }) =>
+			message.startsWith("Although you appear to have the correct authorization credentials,"),
+		classification: GH_ORG_AUTH_CLASSIFICATION,
+	},
 ];
-
-function titleFromMessagePattern(message: string): string | undefined {
-	for (const [prefix, title] of Object.entries(MESSAGE_PATTERN_TITLES)) {
-		if (message.startsWith(prefix)) return title;
-	}
-	return undefined;
-}
 
 /**
  * Combine the parsed error with the per-code classification table
@@ -202,7 +227,10 @@ export function classify(error: unknown, callerTitle?: string): ClassifiedError 
 	}
 
 	const { name, message, code, origin } = parseError(error);
-	const title = name ?? titleFromMessagePattern(message) ?? callerTitle ?? message;
+	const byMessage = MESSAGE_PATTERNS.find((p) => p.matches({ code, message }))?.classification;
+	const byCode = code ? CLASSIFICATIONS[code] : undefined;
+	const effective = byMessage ?? byCode;
+	const title = effective?.title ?? name ?? callerTitle ?? message;
 
 	if (isUnrecoverableBundlingError(message)) {
 		return { title, message, code, severity: "silent" };
@@ -216,22 +244,17 @@ export function classify(error: unknown, callerTitle?: string): ClassifiedError 
 		return { title, message, code, severity: "silent" };
 	}
 
-	const byMessage = MESSAGE_PATTERNS.find((p) => p.matches({ code, message }))?.classification;
-	const byCode = code ? CLASSIFICATIONS[code] : undefined;
-	const effective = byMessage ?? byCode;
 	if (effective?.severity === "silent") {
 		return { title, message, code, severity: "silent" };
 	}
-
-	const actionHint =
-		effective?.actionHint ?? (title === GH_ORG_AUTH_ERROR ? GITHUB_ORG_AUTH_ACTION : undefined);
 
 	return {
 		title,
 		message,
 		code,
 		severity: effective?.severity ?? "error",
+		terminal: effective?.terminal,
 		userMessage: effective?.userMessage,
-		actionHint,
+		actionHint: effective?.actionHint,
 	};
 }

--- a/apps/desktop/src/lib/forge/listingService.svelte.ts
+++ b/apps/desktop/src/lib/forge/listingService.svelte.ts
@@ -56,6 +56,16 @@ export class ListingService {
 		return branchNames.map((branch) => prSelectors.selectById(result, branch)).filter(isDefined);
 	}
 
+	/**
+	 * Latest cached `list_reviews` result for the project, read without
+	 * subscribing or fetching. The workspace's polled listing keeps this
+	 * current; its `error` lets settings surface a degraded integration
+	 * state (e.g. an org-level OAuth restriction).
+	 */
+	listingState(projectId: string) {
+		return this.backendApi.endpoints.listPrs.useQueryState(projectId);
+	}
+
 	async refresh(projectId: string): Promise<void> {
 		// Force a live fetch so the DB cache is refreshed, then invalidate the
 		// cached listing so its subscribers re-read the just-updated data.

--- a/apps/desktop/src/lib/state/customHooks.svelte.ts
+++ b/apps/desktop/src/lib/state/customHooks.svelte.ts
@@ -128,10 +128,12 @@ export function buildQueryHooks<Definitions extends ExtensionDefinitions>({
 			if (result.error) {
 				const error = result.error;
 				// track({ failure: true, startTime, error });
+				const classified = classify(error);
 				emitQueryError(posthog, error, {
 					command,
 					actionName,
-					severity: classify(error).severity,
+					severity: classified.severity,
+					terminal: classified.terminal,
 				});
 			}
 			if (options?.transform && data) {

--- a/crates/but-error/src/lib.rs
+++ b/crates/but-error/src/lib.rs
@@ -171,6 +171,10 @@ pub enum Code {
     /// "Not Found -" — kept here so the wire-level `Code` enum is the
     /// single source of truth for codes the desktop app may surface.
     GitHubTokenExpired,
+    /// A GitHub organization has enabled OAuth App access restrictions and
+    /// blocked the GitButler OAuth app. Terminal until the org approves the
+    /// app or the user switches credentials — retrying won't help.
+    GitHubOrgOAuthRestricted,
     /// The operation was rejected because the current state doesn't allow it.
     /// Not a bug — the user's request simply can't be fulfilled right now.
     /// The frontend should present this as a warning rather than an error.

--- a/crates/but-github/src/pr.rs
+++ b/crates/but-github/src/pr.rs
@@ -79,13 +79,25 @@ pub(crate) fn classify_forge_error(err: anyhow::Error) -> anyhow::Error {
             "Unable to connect to GitHub.",
         ));
     }
-    if let Some(http_err) = err.downcast_ref::<HttpStatusError>()
-        && http_err.status == reqwest::StatusCode::UNAUTHORIZED
-    {
-        return err.context(but_error::Context::new_static(
-            but_error::Code::GitHubTokenExpired,
-            "GitHub authentication failed.",
-        ));
+    if let Some(http_err) = err.downcast_ref::<HttpStatusError>() {
+        if http_err.status == reqwest::StatusCode::UNAUTHORIZED {
+            return err.context(but_error::Context::new_static(
+                but_error::Code::GitHubTokenExpired,
+                "GitHub authentication failed.",
+            ));
+        }
+        // GitHub explains an organization-level OAuth App block in the 403
+        // body, which `ensure_success` keeps as context in the chain.
+        if http_err.status == reqwest::StatusCode::FORBIDDEN
+            && err
+                .chain()
+                .any(|cause| cause.to_string().contains("OAuth App access restrictions"))
+        {
+            return err.context(but_error::Context::new_static(
+                but_error::Code::GitHubOrgOAuthRestricted,
+                "A GitHub organization has restricted access for the GitButler OAuth app. Ask an organization owner to approve it, or authenticate with a personal access token instead.",
+            ));
+        }
     }
     err
 }
@@ -421,4 +433,41 @@ pub async fn set_auto_merge(
         .set_pull_request_auto_merge(&params)
         .await
         .context("Failed to update PR auto-merge state")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Shape the error like `ensure_success` does: the status-carrying error
+    /// wrapped by what the forge said in the response body.
+    fn http_error(status: reqwest::StatusCode, body: &str) -> anyhow::Error {
+        anyhow::Error::from(HttpStatusError { status }).context(body.to_string())
+    }
+
+    #[test]
+    fn org_oauth_restriction_403_gets_dedicated_code() {
+        let err = classify_forge_error(http_error(
+            reqwest::StatusCode::FORBIDDEN,
+            r#"403 Forbidden: {"message":"Although you appear to have the correct authorization credentials, the organization has enabled OAuth App access restrictions."}"#,
+        ));
+        let ctx = err.downcast_ref::<but_error::Context>();
+        assert_eq!(
+            ctx.map(|c| c.code),
+            Some(but_error::Code::GitHubOrgOAuthRestricted),
+            "the frontend keys its presentation off this code"
+        );
+    }
+
+    #[test]
+    fn other_403s_stay_unclassified() {
+        let err = classify_forge_error(http_error(
+            reqwest::StatusCode::FORBIDDEN,
+            r#"403 Forbidden: {"message":"Resource not accessible by integration"}"#,
+        ));
+        assert!(
+            err.downcast_ref::<but_error::Context>().is_none(),
+            "an unrelated 403 must not be presented as an org OAuth restriction"
+        );
+    }
 }

--- a/packages/but-sdk/src/generated/graph/index.d.ts
+++ b/packages/but-sdk/src/generated/graph/index.d.ts
@@ -1970,7 +1970,7 @@ export type Claude = {
  *
  * In practice, it should match its [frontend counterpart](https://github.com/gitbutlerapp/gitbutler/blob/fa973fd8f1ae8807621f47601803d98b8a9cf348/app/src/lib/backend/ipc.ts#L5).
  */
-export type Code = "Validation" | "RepoOwnership" | "ProjectGitAuth" | "DefaultTargetNotFound" | "CommitSigningFailed" | "CommitMergeConflictFailure" | "ProjectMissing" | "AuthorMissing" | "BranchNotFound" | "SecretKeychainNotFound" | "MissingLoginKeychain" | "GitForcePushProtection" | "NetworkError" | "ProjectDatabaseIncompatible" | "DefaultTerminalNotFound" | "Unknown" | "GitNonFastForward" | "CliInstallCancelled" | "GitHubTokenExpired" | "PreconditionFailed" | "EditorExitedWithNonZeroStatus";
+export type Code = "Validation" | "RepoOwnership" | "ProjectGitAuth" | "DefaultTargetNotFound" | "CommitSigningFailed" | "CommitMergeConflictFailure" | "ProjectMissing" | "AuthorMissing" | "BranchNotFound" | "SecretKeychainNotFound" | "MissingLoginKeychain" | "GitForcePushProtection" | "NetworkError" | "ProjectDatabaseIncompatible" | "DefaultTerminalNotFound" | "Unknown" | "GitNonFastForward" | "CliInstallCancelled" | "GitHubTokenExpired" | "GitHubOrgOAuthRestricted" | "PreconditionFailed" | "EditorExitedWithNonZeroStatus";
 
 /** Commit that is part of a legacy stack branch and contains state derived in relation to it. */
 export type Commit = {

--- a/packages/but-sdk/src/generated/linear/index.d.ts
+++ b/packages/but-sdk/src/generated/linear/index.d.ts
@@ -1970,7 +1970,7 @@ export type Claude = {
  *
  * In practice, it should match its [frontend counterpart](https://github.com/gitbutlerapp/gitbutler/blob/fa973fd8f1ae8807621f47601803d98b8a9cf348/app/src/lib/backend/ipc.ts#L5).
  */
-export type Code = "Validation" | "RepoOwnership" | "ProjectGitAuth" | "DefaultTargetNotFound" | "CommitSigningFailed" | "CommitMergeConflictFailure" | "ProjectMissing" | "AuthorMissing" | "BranchNotFound" | "SecretKeychainNotFound" | "MissingLoginKeychain" | "GitForcePushProtection" | "NetworkError" | "ProjectDatabaseIncompatible" | "DefaultTerminalNotFound" | "Unknown" | "GitNonFastForward" | "CliInstallCancelled" | "GitHubTokenExpired" | "PreconditionFailed" | "EditorExitedWithNonZeroStatus";
+export type Code = "Validation" | "RepoOwnership" | "ProjectGitAuth" | "DefaultTargetNotFound" | "CommitSigningFailed" | "CommitMergeConflictFailure" | "ProjectMissing" | "AuthorMissing" | "BranchNotFound" | "SecretKeychainNotFound" | "MissingLoginKeychain" | "GitForcePushProtection" | "NetworkError" | "ProjectDatabaseIncompatible" | "DefaultTerminalNotFound" | "Unknown" | "GitNonFastForward" | "CliInstallCancelled" | "GitHubTokenExpired" | "GitHubOrgOAuthRestricted" | "PreconditionFailed" | "EditorExitedWithNonZeroStatus";
 
 /** Commit that is part of a legacy stack branch and contains state derived in relation to it. */
 export type Commit = {


### PR DESCRIPTION
When a GitHub organization blocks the GitButler OAuth app, `list_reviews` failed as a generic `API error: (list_reviews)` with code `Unknown`: the org-auth title, the "Don't show this again" opt-out, and any remediation guidance were unreachable, and the 15-minute listing poll kept re-reporting the same terminal 403.

- The backend now tags the restriction 403 with a dedicated `Code::GitHubOrgOAuthRestricted`, and the desktop resolves the stable title, opt-out action, and remediation copy (org approval, or a personal access token with a docs link) from one code-keyed classification, shared with the codeless octokit path.
- Terminal environment states like this are reported once per session instead of on every poll, and one hot failure no longer masks other failures of the same command.
- The project settings GitHub integration card shows the restriction inline — right above the account selector, which is the way out when switching to a PAT-backed account.

Fixes GB-1901
Fixes GB-1902

