### PR TITLE
Lite: reveal a file in the OS file manager

### DIFF
--- a/apps/lite/electron/src/ipc.ts
+++ b/apps/lite/electron/src/ipc.ts
@@ -35,6 +35,8 @@ export type LiteElectronApi = SDK & {
 	pathJoin: (...paths: Array<string>) => Promise<string>;
 	pickDirectory: () => Promise<string | null>;
 	resetAiConfiguration: () => Promise<AiConfiguration>;
+	/** Reveal a file in the OS file manager, selected in its containing folder. */
+	showItemInFolder: (path: string) => Promise<void>;
 	showNativeMenu: (params: ShowNativeMenuParams) => Promise<string | null>;
 	streamAiResponse: (
 		systemMessage: string,
@@ -71,6 +73,7 @@ export const localEndpoints = [
 	"pathJoin",
 	"pickDirectory",
 	"readGUISettings",
+	"showItemInFolder",
 	"showNativeMenu",
 	"streamAiResponse",
 	"watcherStopAll",

--- a/apps/lite/electron/src/main.ts
+++ b/apps/lite/electron/src/main.ts
@@ -311,6 +311,11 @@ const electronHandlerOverrides = {
 
 		return shell.openExternal(url);
 	},
+	showItemInFolder: (itemPath) => {
+		// Unlike shell.openExternal, this only selects the item in the file
+		// manager; it never launches it, so a path is all it takes.
+		shell.showItemInFolder(itemPath);
+	},
 	pickDirectory: async () => {
 		const { canceled, filePaths } = await dialog.showOpenDialog({ properties: ["openDirectory"] });
 		return canceled ? null : (filePaths[0] ?? null);

--- a/apps/lite/harness/deepseek/cli.mjs
+++ b/apps/lite/harness/deepseek/cli.mjs
@@ -55,6 +55,8 @@ const hostOverrides = {
 	openInWebBrowser: () => undefined,
 	pickDirectory: () => null,
 	clipboardWriteText: () => undefined,
+	// No file manager to reveal into from the harness.
+	showItemInFolder: () => undefined,
 	getAiConfiguration: () => defaultAiConfiguration(),
 	updateAiConfiguration: () => defaultAiConfiguration(),
 	resetAiConfiguration: () => defaultAiConfiguration(),

--- a/apps/lite/ui/src/hotkeys.ts
+++ b/apps/lite/ui/src/hotkeys.ts
@@ -266,6 +266,14 @@ export const changesHotkeys = {
 	},
 } satisfies Record<string, HotkeyWithMeta>;
 
+/** What the platform calls revealing a file in its file manager. */
+export const revealInFolderLabel =
+	globalThis.window.lite.platform === "darwin"
+		? "Reveal in Finder"
+		: globalThis.window.lite.platform === "win32"
+			? "Show in File Explorer"
+			: "Show in File Manager";
+
 export const changesFileHotkeys = {
 	absorb: {
 		hotkey: "A",
@@ -286,6 +294,10 @@ export const changesFileHotkeys = {
 	openInEditor: {
 		hotkey: "E",
 		meta: { group: "File", name: "Open in editor" },
+	},
+	revealInFolder: {
+		hotkey: "Shift+E",
+		meta: { group: "File", name: revealInFolderLabel },
 	},
 	toggleFoldDirectory: {
 		hotkey: "Z",
@@ -371,6 +383,10 @@ export const diffHotkeys = {
 	openInEditor: {
 		hotkey: "E",
 		meta: { group: "Diff", name: "Open in editor" },
+	},
+	revealInFolder: {
+		hotkey: "Shift+E",
+		meta: { group: "Diff", name: revealInFolderLabel },
 	},
 	search: {
 		hotkey: "Mod+F",

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -184,6 +184,7 @@ import { diffGutterUnsafeCSS, useDiffGutterCheckboxes } from "./diff-gutter.ts";
 import { useDiffHunkDrag } from "./diff-hunk-drag.ts";
 import { diffLineTargetFromElement, type DiffLineTarget } from "./diff-line-target.ts";
 import { useHunkMenuItems } from "./useHunkMenuItems.ts";
+import { useRevealInFolder } from "./useRevealInFolder.ts";
 import { ChangeTypeBadge } from "./ChangeTypeBadge.tsx";
 import { AnnotationCard } from "#ui/routes/project/$id/workspace/AnnotationCard.tsx";
 import { ConflictBar } from "#ui/routes/project/$id/workspace/ConflictBar.tsx";
@@ -438,6 +439,7 @@ const DiffContents: FC<{
 	});
 	const { mutate: openInProgram } = useOpenInProgram();
 	const hunkMenuItems = useHunkMenuItems({ projectId });
+	const revealInFolder = useRevealInFolder(projectId);
 	const store = useAppStore();
 	const queryClient = useQueryClient();
 	const lineCheckRangeAnchor = useRef<string>(null);
@@ -920,6 +922,19 @@ const DiffContents: FC<{
 				conflictBehavior: "allow",
 				target: focusScopeRef,
 				meta: diffHotkeys.openInEditor.meta,
+			},
+		},
+		{
+			hotkey: diffHotkeys.revealInFolder.hotkey,
+			callback: () => {
+				if (!diffSelectionHunk) return;
+				void revealInFolder(diffSelectionHunk.file.change.path);
+			},
+			options: {
+				enabled: !!diffSelectionHunk,
+				conflictBehavior: "allow",
+				target: focusScopeRef,
+				meta: diffHotkeys.revealInFolder.meta,
 			},
 		},
 	]);

--- a/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.tsx
@@ -35,6 +35,7 @@ import { OperationSourceC } from "#ui/routes/project/$id/workspace/OperationSour
 import { focusScope, useAddressSpaceHotkeys, type FocusScope } from "#ui/focus-scopes.ts";
 import { addressSpaceIncludes, type AddressSpace } from "#ui/workspace/address-space.ts";
 import { changesFileHotkeys } from "#ui/hotkeys.ts";
+import { useRevealInFolder } from "./useRevealInFolder.ts";
 import { useHotkeys } from "@tanstack/react-hotkeys";
 import { useMergedRefs } from "@base-ui/utils/useMergedRefs";
 import { FileRow, FileRowPresentational } from "./FileRow.tsx";
@@ -89,6 +90,7 @@ const useFilesTreeHotkeys = ({
 		select: (cfg) => editors?.find((editor) => editor.id === cfg.editorId),
 	});
 	const { mutate: openInProgram } = useOpenInProgram();
+	const revealInFolder = useRevealInFolder(projectId);
 	const { canDiscard, discard } = useDiscardFileChanges({ projectId, fileParent });
 
 	const store = useAppStore();
@@ -246,6 +248,22 @@ const useFilesTreeHotkeys = ({
 				enabled: preferredEditor && selectedChangesFile !== null,
 				target: ref,
 				meta: changesFileHotkeys.openInEditor.meta,
+			},
+		},
+		{
+			hotkey: changesFileHotkeys.revealInFolder.hotkey,
+			// Not limited to uncommitted files the way the editor binding above
+			// is: a row's path locates the file in the worktree whichever list
+			// it came from, which is all revealing it needs.
+			callback: () => {
+				if (selection === null) return;
+				void revealInFolder(selection);
+			},
+			options: {
+				conflictBehavior: "allow",
+				enabled: selectedRow?._tag === "File",
+				target: ref,
+				meta: changesFileHotkeys.revealInFolder.meta,
 			},
 		},
 		{

--- a/apps/lite/ui/src/routes/project/$id/workspace/useHunkMenuItems.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/useHunkMenuItems.ts
@@ -10,11 +10,17 @@ import {
 	listEditorsQueryOptions,
 	listProjectsQueryOptions,
 } from "#ui/api/queries.ts";
-import { diffHotkeys, selectionOperationHotkeys, toElectronAccelerator } from "#ui/hotkeys.ts";
+import {
+	diffHotkeys,
+	revealInFolderLabel,
+	selectionOperationHotkeys,
+	toElectronAccelerator,
+} from "#ui/hotkeys.ts";
 import { diffSpecHunkHeadersForLineSelection } from "#ui/hunk.ts";
 import { type NativeMenuItem, nativeMenuItem, nativeMenuItemsFromGroups } from "#ui/native-menu.ts";
 import { hunkAddress, type HunkAddress, type Address } from "#ui/addresses.ts";
 import { createDiffSpec } from "#ui/operations/diff-specs.ts";
+import { useRevealInFolder } from "./useRevealInFolder.ts";
 import { projectSlice } from "#ui/projects/state.ts";
 import { focusScope } from "#ui/focus-scopes.ts";
 import { useAppStore } from "#ui/store.ts";
@@ -54,6 +60,7 @@ export const useHunkMenuItems = ({
 	const { isPending: isDiscardWorktreeChangesPending, mutate: discardWorktreeChanges } =
 		useDiscardWorktreeChanges();
 	const { isPending: isOpenInProgramPending, mutate: openInProgram } = useOpenInProgram();
+	const revealInFolder = useRevealInFolder(projectId);
 
 	return ({ sources, checkedProbe, usesSelectedLines, change, hunk, lineNumber }) => {
 		const state = store.getState();
@@ -108,6 +115,11 @@ export const useHunkMenuItems = ({
 									}),
 								) ?? [],
 						}),
+				nativeMenuItem({
+					label: revealInFolderLabel,
+					accelerator: toElectronAccelerator(diffHotkeys.revealInFolder.hotkey),
+					onSelect: () => revealInFolder(change.path),
+				}),
 				nativeMenuItem({
 					label: "Copy Path",
 					submenu: [

--- a/apps/lite/ui/src/routes/project/$id/workspace/usePathMenuItems.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/usePathMenuItems.ts
@@ -4,17 +4,10 @@ import {
 	listEditorsQueryOptions,
 	listProjectsQueryOptions,
 } from "#ui/api/queries.ts";
-import { changesFileHotkeys, toElectronAccelerator } from "#ui/hotkeys.ts";
+import { changesFileHotkeys, revealInFolderLabel, toElectronAccelerator } from "#ui/hotkeys.ts";
 import { type NativeMenuItem, nativeMenuItem } from "#ui/native-menu.ts";
+import { useRevealInFolder } from "./useRevealInFolder.ts";
 import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
-
-/** What the platform calls revealing a file in its file manager. */
-const revealLabel =
-	window.lite.platform === "darwin"
-		? "Reveal in Finder"
-		: window.lite.platform === "win32"
-			? "Show in File Explorer"
-			: "Show in File Manager";
 
 /**
  * What a file offers wherever it is listed: open it, reveal it, copy its
@@ -41,6 +34,7 @@ export const usePathMenuItems = ({
 	if (!selectedProject) throw new Error("Could not find selected project");
 
 	const { isPending: isOpenInProgramPending, mutate: openInProgram } = useOpenInProgram();
+	const revealInFolder = useRevealInFolder(projectId);
 
 	return [
 		preferredEditor
@@ -74,11 +68,9 @@ export const usePathMenuItems = ({
 						) ?? [],
 				}),
 		nativeMenuItem({
-			label: revealLabel,
-			onSelect: async () => {
-				const absolutePath = await window.lite.pathJoin(selectedProject.path, path);
-				await window.lite.showItemInFolder(absolutePath);
-			},
+			label: revealInFolderLabel,
+			accelerator: toElectronAccelerator(changesFileHotkeys.revealInFolder.hotkey),
+			onSelect: () => revealInFolder(path),
 		}),
 		nativeMenuItem({
 			label: "Copy Path",

--- a/apps/lite/ui/src/routes/project/$id/workspace/usePathMenuItems.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/usePathMenuItems.ts
@@ -8,9 +8,17 @@ import { changesFileHotkeys, toElectronAccelerator } from "#ui/hotkeys.ts";
 import { type NativeMenuItem, nativeMenuItem } from "#ui/native-menu.ts";
 import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 
+/** What the platform calls revealing a file in its file manager. */
+const revealLabel =
+	window.lite.platform === "darwin"
+		? "Reveal in Finder"
+		: window.lite.platform === "win32"
+			? "Show in File Explorer"
+			: "Show in File Manager";
+
 /**
- * What a file offers wherever it is listed: open it, copy its path. Neither
- * action asks what the file belongs to, so surfaces with no notion of a
+ * What a file offers wherever it is listed: open it, reveal it, copy its
+ * path. None of these ask what the file belongs to, so surfaces with no notion of a
  * parent — edit mode, where every file belongs to the commit being edited —
  * can offer them too. Resolving the editor and the project's location still
  * takes queries, which every row calling this subscribes to.
@@ -65,6 +73,13 @@ export const usePathMenuItems = ({
 							}),
 						) ?? [],
 				}),
+		nativeMenuItem({
+			label: revealLabel,
+			onSelect: async () => {
+				const absolutePath = await window.lite.pathJoin(selectedProject.path, path);
+				await window.lite.showItemInFolder(absolutePath);
+			},
+		}),
 		nativeMenuItem({
 			label: "Copy Path",
 			submenu: [

--- a/apps/lite/ui/src/routes/project/$id/workspace/useRevealInFolder.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/useRevealInFolder.ts
@@ -1,0 +1,22 @@
+import { listProjectsQueryOptions } from "#ui/api/queries.ts";
+import { useSuspenseQuery } from "@tanstack/react-query";
+
+/**
+ * Reveals a repository-relative path in the OS file manager. Only the
+ * project's location turns that path absolute, so it is resolved here rather
+ * than at each of the surfaces — file rows, hunks, the diff — that offer the
+ * action. Selecting the path alone keeps callers off the projects list's
+ * identity.
+ */
+export const useRevealInFolder = (projectId: string): ((path: string) => Promise<void>) => {
+	const { data: projectPath } = useSuspenseQuery({
+		...listProjectsQueryOptions,
+		select: (projects) => projects.find((project) => project.id === projectId)?.path,
+	});
+	if (projectPath === undefined) throw new Error("Could not find selected project");
+
+	return async (path) => {
+		const absolutePath = await window.lite.pathJoin(projectPath, path);
+		await window.lite.showItemInFolder(absolutePath);
+	};
+};

--- a/apps/lite/ui/src/routes/project/$id/workspace/useRevealInFolder.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/useRevealInFolder.ts
@@ -1,21 +1,22 @@
 import { listProjectsQueryOptions } from "#ui/api/queries.ts";
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
 
 /**
  * Reveals a repository-relative path in the OS file manager. Only the
  * project's location turns that path absolute, so it is resolved here rather
  * than at each of the surfaces — file rows, hunks, the diff — that offer the
- * action. Selecting the path alone keeps callers off the projects list's
- * identity.
+ * action. The list is read when the action runs rather than subscribed to:
+ * nothing here renders it, and a surface that suspended on it would tear down
+ * the very rows it lists.
  */
 export const useRevealInFolder = (projectId: string): ((path: string) => Promise<void>) => {
-	const { data: projectPath } = useSuspenseQuery({
-		...listProjectsQueryOptions,
-		select: (projects) => projects.find((project) => project.id === projectId)?.path,
-	});
-	if (projectPath === undefined) throw new Error("Could not find selected project");
+	const queryClient = useQueryClient();
 
 	return async (path) => {
+		const projects = queryClient.getQueryData(listProjectsQueryOptions.queryKey);
+		const projectPath = projects?.find((project) => project.id === projectId)?.path;
+		if (projectPath === undefined) throw new Error("Could not find selected project");
+
 		const absolutePath = await window.lite.pathJoin(projectPath, path);
 		await window.lite.showItemInFolder(absolutePath);
 	};


### PR DESCRIPTION
The file context menu could open a file in the editor or copy its path, but not show it where it lives.

<img width="529" height="295" alt="image" src="https://github.com/user-attachments/assets/61c36667-281d-47ff-9c3a-eb9e21a81fba" />


### Reveal action

- `usePathMenuItems` gains a reveal item between "Open in …" and "Copy Path", labelled per platform: **Reveal in Finder** (macOS), **Show in File Explorer** (Windows), **Show in File Manager** (elsewhere). Because it lives in that hook, it appears everywhere the hook is used: worktree and commit file rows, and edit mode.
- The hunk context menu gains the same item, so the diff pane offers it too.
- A new `showItemInFolder` member on the renderer API, listed in `localEndpoints` so the preload forwards it, answered in electron main by `shell.showItemInFolder`. Unlike `openExternal` it only selects the item and never launches it, so no protocol guard is needed. The harness host gets an inert stub — it has no file manager to reveal into.
- `useRevealInFolder` holds the one piece of shared work, turning a repo-relative path absolute against the project's location. It selects just that path out of the projects query, so the new subscribers don't re-render on the list's identity.

### Hotkey

`Shift+E`, in both the file list and the diff pane. Open in editor is `E`, and the keymap already spells a letter's sibling action `Shift+<letter>` (`Z`/`Shift+Z`, `P`/`Shift+P`); `Shift+E` was unused. Both menus show the accelerator.

In the file list the binding is not limited to uncommitted files the way the `E` binding beside it is — a row's path locates the file in the worktree whichever list it came from — and it is gated to file rows, so it no-ops on a directory.

### Validation

`pnpm -F @gitbutler/lite check` and `test` pass; oxlint, knip, oxfmt and prettier are clean. Not yet exercised by hand in the running app.
