### PR TITLE
lite: apply selected-file diff only while the file list is visible

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -1961,7 +1961,7 @@ const Diff: FC<{
 		[unsortedChanges],
 	);
 
-	const { data: renderAllFiles } = useSuspenseQuery({
+	const { data: allInOneDiff } = useSuspenseQuery({
 		...guiSettingsQueryOptions,
 		select: (cfg) => cfg.unidiff ?? defaultSettings.unidiff,
 	});
@@ -1969,10 +1969,15 @@ const Diff: FC<{
 	const canShowFiles = useCanShowFiles();
 	const detailsFullWindow = useAppSelector(interfaceSlice.selectors.selectDetailsFullWindow);
 
-	// Change stats live in the files panel, or — in the uncommitted scope, which has no files
-	// panel — in the sidebar's "Uncommitted" row. Surface them in the toolbar below whenever
-	// whichever of those owns them is hidden, so they never disappear entirely.
-	const statsShownElsewhere = canShowFiles ? filesVisible : !detailsFullWindow;
+	// The file list lives in the files panel, or — in the uncommitted scope, which has no
+	// files panel — in the sidebar's "Uncommitted" rows, hidden only by full-window mode.
+	const fileListVisible = canShowFiles ? filesVisible : !detailsFullWindow;
+	// Change stats live alongside that list; surface them in the toolbar below whenever
+	// it is hidden, so they never disappear entirely.
+	const statsShownElsewhere = fileListVisible;
+	// Selected-file-only diffing leans on the file list to say which file the pane is
+	// showing, so without the list every file renders regardless of the setting.
+	const renderAllFiles = allInOneDiff || !fileListVisible;
 
 	const filesFilter = useAppSelector((state) =>
 		projectSlice.selectors.selectFilesFilter(state, projectId),

--- a/apps/lite/ui/src/routes/project/$id/workspace/Page.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Page.tsx
@@ -328,6 +328,9 @@ const PageBody: FC<{ projectId: string }> = ({ projectId }) => {
 
 	const dispatch = useAppDispatch();
 
+	// The stored setting is enough here even though the details pane also renders all
+	// files whenever the file list is hidden: file activation only ever comes from a
+	// visible list, and while the list is visible the pane follows the setting.
 	const { data: renderAllFiles } = useSuspenseQuery({
 		...guiSettingsQueryOptions,
 		select: (cfg) => cfg.unidiff ?? defaultSettings.unidiff,


### PR DESCRIPTION
Follow-up to #15570. The selected-file-only diff mode relies on a visible file list to say which file the pane is showing. When that list is hidden — the files panel toggled off, or the sidebar's uncommitted rows behind full-window mode — a lone unlabelled diff is confusing, so the pane falls back to rendering every file.

The stored setting alone still drives the scroll-on-activation behavior in the page, since file activation can only come from a visible list, where the pane follows the setting.