### PR TITLE
Stabilize Lite workspace focus E2E test

### DIFF
--- a/apps/lite/e2e/tests/workspace-focus.spec.ts
+++ b/apps/lite/e2e/tests/workspace-focus.spec.ts
@@ -89,6 +89,8 @@ test.describe("workspace focus", () => {
 			selectedFile.evaluate((element) => getComputedStyle(element).backgroundColor);
 
 		await sidebar.focus();
+		// A virtualized row can be replaced between visibility and style checks, briefly yielding no computed style.
+		await expect.poll(selectedFileBackground).not.toBe("");
 		const blurredBackground = await selectedFileBackground();
 		await files.focus();
 		await expect.poll(selectedFileBackground).not.toBe(blurredBackground);


### PR DESCRIPTION
## Summary

- Wait for the virtualized file row to expose a real computed background before capturing the blurred selection baseline.
- Avoid comparing against the empty style returned while Chromium is replacing the row.

## Reproduction

I could not reproduce this on native macOS, including 10 repeated focused runs, cold Vite startup, and CDP CPU throttling up to 12x. The failure became reproducible only inside a Linux VM: an Apple Containers ARM64 microVM running Ubuntu, Xvfb, Electron with its SUID sandbox enabled, 8 GB RAM, and one Playwright worker.

Against master commit `68928e89`, the unmodified test failed 2/20 times with the same payload seen in CI:

```
Expected: ""
Received: "oklab(0.383122 0.0000174195 0.0000076592 / 0.1)"
```

The failure snapshot showed the UI in the correct blurred-focus state. The empty baseline came from the earlier one-shot computed-style read while the virtualized row was transiently replaced.

## Testing

- Before: 18 passed, 2 failed in the Linux VM.
- After: 50/50 repeated focused runs passed in the same Linux VM.
- `git diff --check` passes.

The full workspace focus spec was also attempted in the microVM. The changed test passed; two unrelated drag/reload cases hit their existing 30-second timeouts in that environment.