### PR TITLE
forge: don't wipe cached reviews when credentials are missing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1271,6 +1271,7 @@ dependencies = [
  "anyhow",
  "but-bitbucket",
  "but-db",
+ "but-error",
  "but-forge-storage",
  "but-github",
  "but-gitlab",

--- a/apps/desktop/src/lib/error/errorClassification.ts
+++ b/apps/desktop/src/lib/error/errorClassification.ts
@@ -157,6 +157,18 @@ Your GitHub token appears expired. Please log out and back in to refresh it. (Se
 	`,
 	},
 	GitHubOrgOAuthRestricted: GH_ORG_AUTH_CLASSIFICATION,
+	/**
+	 * No forge credentials are stored — the user never authenticated or
+	 * logged out. Cached review reads fall back to the last known data;
+	 * this surfaces on explicit forge actions (sync, PR mutations), so
+	 * the copy stays operation-neutral.
+	 */
+	ForgeNotAuthenticated: {
+		severity: "warning",
+		terminal: true,
+		userMessage:
+			"You are not logged in to your forge. Connect your account under Settings → Integrations to work with pull requests.",
+	},
 	ProjectDatabaseIncompatible: {
 		severity: "error",
 		userMessage: `

--- a/crates/but-bitbucket/src/client.rs
+++ b/crates/but-bitbucket/src/client.rs
@@ -63,7 +63,8 @@ impl BitbucketClient {
         } else {
             Err(anyhow::anyhow!(
                 "No Bitbucket access token found for account '{account_id}'.\nRun 'but config forge auth' to re-authenticate."
-            ))
+            )
+            .context(NOT_AUTHENTICATED))
         }
     }
 
@@ -642,23 +643,33 @@ impl BitbucketClient {
     }
 }
 
+/// Marks credential lookups that came up empty, so consumers can tell "the
+/// user is not authenticated" apart from a failing forge and e.g. keep
+/// serving cached data instead of surfacing an error.
+pub(crate) const NOT_AUTHENTICATED: but_error::Context = but_error::Context::new_static(
+    but_error::Code::ForgeNotAuthenticated,
+    "Not authenticated with Bitbucket.",
+);
+
 pub(crate) fn resolve_account(
     preferred_account: Option<&crate::BitbucketAccountIdentifier>,
     storage: &but_forge_storage::Controller,
 ) -> Result<crate::BitbucketAccountIdentifier, anyhow::Error> {
     let known_accounts = crate::token::list_known_bitbucket_accounts(storage)?;
     let Some(default_account) = known_accounts.first() else {
-        bail!(
+        return Err(anyhow::anyhow!(
             "No authenticated Bitbucket users found.\nRun 'but config forge auth' to authenticate with Bitbucket."
-        );
+        )
+        .context(NOT_AUTHENTICATED));
     };
     let account = if let Some(account) = preferred_account {
         if known_accounts.contains(account) {
             account
         } else {
-            bail!(
+            return Err(anyhow::anyhow!(
                 "Preferred Bitbucket account '{account}' has not authenticated yet.\nRun 'but config forge auth' to authenticate, or choose another account."
-            );
+            )
+            .context(NOT_AUTHENTICATED));
         }
     } else {
         default_account

--- a/crates/but-bitbucket/src/pr.rs
+++ b/crates/but-bitbucket/src/pr.rs
@@ -8,13 +8,10 @@ pub async fn list(
     repo_slug: &str,
     storage: &but_forge_storage::Controller,
 ) -> Result<Vec<crate::client::BitbucketPullRequest>> {
-    if let Ok(bb) = BitbucketClient::from_storage(storage, preferred_account) {
-        bb.list_open_prs(workspace, repo_slug)
-            .await
-            .context("Failed to list open pull requests")
-    } else {
-        Ok(vec![])
-    }
+    BitbucketClient::from_storage(storage, preferred_account)?
+        .list_open_prs(workspace, repo_slug)
+        .await
+        .context("Failed to list open pull requests")
 }
 
 pub async fn list_recently_closed(
@@ -23,13 +20,10 @@ pub async fn list_recently_closed(
     repo_slug: &str,
     storage: &but_forge_storage::Controller,
 ) -> Result<Vec<crate::client::BitbucketPullRequest>> {
-    if let Ok(bb) = BitbucketClient::from_storage(storage, preferred_account) {
-        bb.list_recently_closed_prs(workspace, repo_slug)
-            .await
-            .context("Failed to list recently closed pull requests")
-    } else {
-        Ok(vec![])
-    }
+    BitbucketClient::from_storage(storage, preferred_account)?
+        .list_recently_closed_prs(workspace, repo_slug)
+        .await
+        .context("Failed to list recently closed pull requests")
 }
 
 pub async fn list_all_for_target(
@@ -39,13 +33,10 @@ pub async fn list_all_for_target(
     target_branch: &str,
     storage: &but_forge_storage::Controller,
 ) -> Result<Vec<crate::client::BitbucketPullRequest>> {
-    if let Ok(bb) = BitbucketClient::from_storage(storage, preferred_account) {
-        bb.list_prs_for_target(workspace, repo_slug, target_branch)
-            .await
-            .context("Failed to list pull requests for target branch")
-    } else {
-        Ok(vec![])
-    }
+    BitbucketClient::from_storage(storage, preferred_account)?
+        .list_prs_for_target(workspace, repo_slug, target_branch)
+        .await
+        .context("Failed to list pull requests for target branch")
 }
 
 pub async fn get(

--- a/crates/but-error/src/lib.rs
+++ b/crates/but-error/src/lib.rs
@@ -175,6 +175,10 @@ pub enum Code {
     /// blocked the GitButler OAuth app. Terminal until the org approves the
     /// app or the user switches credentials — retrying won't help.
     GitHubOrgOAuthRestricted,
+    /// No credentials are stored for the forge integration — the user never
+    /// authenticated or logged out. Cached forge data stays valid; retrying
+    /// without re-authenticating won't help.
+    ForgeNotAuthenticated,
     /// The operation was rejected because the current state doesn't allow it.
     /// Not a bug — the user's request simply can't be fulfilled right now.
     /// The frontend should present this as a warning rather than an error.

--- a/crates/but-forge/Cargo.toml
+++ b/crates/but-forge/Cargo.toml
@@ -21,6 +21,7 @@ doctest = false
 
 [dependencies]
 but-utils.workspace = true
+but-error.workspace = true
 but-github.workspace = true
 but-gitlab.workspace = true
 but-bitbucket.workspace = true

--- a/crates/but-forge/src/review.rs
+++ b/crates/but-forge/src/review.rs
@@ -535,13 +535,32 @@ pub fn list_forge_reviews_with_cache(
             {
                 return Ok(reviews.into_iter().filter(ForgeReview::is_open).collect());
             }
-            sync_listed_reviews(preferred_forge_user, forge_repo_info, storage, db)?
+            match sync_listed_reviews(preferred_forge_user, forge_repo_info, storage, db) {
+                Ok(reviews) => reviews,
+                // Missing credentials say nothing about the forge's state:
+                // keep serving the last known reviews instead of failing
+                // every cached read while the user is logged out. Explicit
+                // `NoCache` reads still surface the re-authentication error.
+                Err(err) if is_not_authenticated(&err) => crate::list_cached_forge_reviews(db)?
+                    .into_iter()
+                    .filter(ForgeReview::is_open)
+                    .collect(),
+                Err(err) => return Err(err),
+            }
         }
         CacheConfig::NoCache => {
             sync_listed_reviews(preferred_forge_user, forge_repo_info, storage, db)?
         }
     };
     Ok(reviews)
+}
+
+/// Whether an error means "no forge credentials are stored" — the providers
+/// tag their failed credential lookups with this code.
+fn is_not_authenticated(err: &anyhow::Error) -> bool {
+    use but_error::AnyhowContextExt as _;
+    err.custom_context()
+        .is_some_and(|ctx| ctx.code == but_error::Code::ForgeNotAuthenticated)
 }
 
 /// Fetch the open listing and fold it into the cache, recording the fate of
@@ -3428,6 +3447,49 @@ mod tests {
         assert!(
             open_review_vanished(&[(1, false), (3, false)], &listing),
             "an open row missing from the listing is about to be deleted, so its fate must be swept first"
+        );
+    }
+
+    #[test]
+    fn missing_credentials_do_not_turn_a_stale_cache_into_an_empty_listing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut db = but_db::DbHandle::new_in_directory(tmp.path()).unwrap();
+        // No accounts are stored, so client construction fails before any
+        // network request — the listing must not pretend the forge is empty.
+        let storage = but_forge_storage::Controller::from_path(tmp.path());
+        // `cached_review` stamps `last_sync_at` at the epoch, well past the
+        // fallback window, so the cached read attempts a live refresh.
+        db.forge_reviews_mut()
+            .unwrap()
+            .set_all(vec![cached_review(1, None, None).try_into().unwrap()])
+            .unwrap();
+
+        let reviews = list_forge_reviews_with_cache(
+            None,
+            &repo_info("owner", "repo"),
+            &storage,
+            &mut db,
+            Some(CacheConfig::CacheWithFallback {
+                max_age_seconds: 300,
+            }),
+        )
+        .unwrap();
+
+        let listed: Vec<i64> = reviews.iter().map(|review| review.number).collect();
+        assert_eq!(
+            listed,
+            vec![1],
+            "a failed credential lookup must serve the last known open reviews"
+        );
+        let persisted: Vec<i64> = crate::list_cached_forge_reviews(&db)
+            .unwrap()
+            .iter()
+            .map(|review| review.number)
+            .collect();
+        assert_eq!(
+            persisted,
+            vec![1],
+            "a failed credential lookup must not delete the last known open reviews"
         );
     }
 

--- a/crates/but-github/src/client.rs
+++ b/crates/but-github/src/client.rs
@@ -79,7 +79,8 @@ impl GitHubClient {
         } else {
             Err(anyhow::anyhow!(
                 "No GitHub access token found for account '{account_id}'.\nRun 'but config forge auth' to re-authenticate."
-            ))
+            )
+            .context(NOT_AUTHENTICATED))
         }
     }
 
@@ -2001,23 +2002,33 @@ impl From<GitHubPullRequest> for PullRequest {
     }
 }
 
+/// Marks credential lookups that came up empty, so consumers can tell "the
+/// user is not authenticated" apart from a failing forge and e.g. keep
+/// serving cached data instead of surfacing an error.
+pub(crate) const NOT_AUTHENTICATED: but_error::Context = but_error::Context::new_static(
+    but_error::Code::ForgeNotAuthenticated,
+    "Not authenticated with GitHub.",
+);
+
 pub(crate) fn resolve_account(
     preferred_account: Option<&crate::GithubAccountIdentifier>,
     storage: &but_forge_storage::Controller,
 ) -> Result<crate::GithubAccountIdentifier, anyhow::Error> {
     let known_accounts = crate::token::list_known_github_accounts(storage)?;
     let Some(default_account) = known_accounts.first() else {
-        bail!(
+        return Err(anyhow::anyhow!(
             "No authenticated GitHub users found.\nRun 'but config forge auth' to authenticate with GitHub."
-        );
+        )
+        .context(NOT_AUTHENTICATED));
     };
     let account = if let Some(account) = preferred_account {
         if known_accounts.contains(account) {
             account
         } else {
-            bail!(
+            return Err(anyhow::anyhow!(
                 "Preferred GitHub account '{account}' has not authenticated yet.\nRun 'but config forge auth' to authenticate, or choose another account."
-            );
+            )
+            .context(NOT_AUTHENTICATED));
         }
     } else {
         default_account

--- a/crates/but-github/src/pr.rs
+++ b/crates/but-github/src/pr.rs
@@ -8,14 +8,11 @@ pub async fn list(
     repo: &str,
     storage: &but_forge_storage::Controller,
 ) -> Result<Vec<crate::client::PullRequest>> {
-    if let Ok(gh) = GitHubClient::from_storage(storage, preferred_account) {
-        gh.list_open_pulls(owner, repo)
-            .await
-            .map_err(classify_forge_error)
-            .context("Failed to list open pull requests")
-    } else {
-        Ok(vec![])
-    }
+    GitHubClient::from_storage(storage, preferred_account)?
+        .list_open_pulls(owner, repo)
+        .await
+        .map_err(classify_forge_error)
+        .context("Failed to list open pull requests")
 }
 pub async fn list_recently_closed(
     preferred_account: Option<&crate::GithubAccountIdentifier>,
@@ -23,14 +20,11 @@ pub async fn list_recently_closed(
     repo: &str,
     storage: &but_forge_storage::Controller,
 ) -> Result<Vec<crate::client::PullRequest>> {
-    if let Ok(gh) = GitHubClient::from_storage(storage, preferred_account) {
-        gh.list_recently_closed_pulls(owner, repo)
-            .await
-            .map_err(classify_forge_error)
-            .context("Failed to list recently closed pull requests")
-    } else {
-        Ok(vec![])
-    }
+    GitHubClient::from_storage(storage, preferred_account)?
+        .list_recently_closed_pulls(owner, repo)
+        .await
+        .map_err(classify_forge_error)
+        .context("Failed to list recently closed pull requests")
 }
 
 pub async fn list_all_for_branch(
@@ -40,14 +34,11 @@ pub async fn list_all_for_branch(
     branch: &str,
     storage: &but_forge_storage::Controller,
 ) -> Result<Vec<crate::client::PullRequest>> {
-    if let Ok(gh) = GitHubClient::from_storage(storage, preferred_account) {
-        gh.list_pulls_for_base(owner, repo, branch)
-            .await
-            .map_err(classify_forge_error)
-            .context("Failed to list pull requests for branch")
-    } else {
-        Ok(vec![])
-    }
+    GitHubClient::from_storage(storage, preferred_account)?
+        .list_pulls_for_base(owner, repo, branch)
+        .await
+        .map_err(classify_forge_error)
+        .context("Failed to list pull requests for branch")
 }
 
 pub async fn list_for_commit(
@@ -57,14 +48,11 @@ pub async fn list_for_commit(
     commit_sha: &str,
     storage: &but_forge_storage::Controller,
 ) -> Result<Vec<crate::client::PullRequest>> {
-    if let Ok(gh) = GitHubClient::from_storage(storage, preferred_account) {
-        gh.list_pulls_for_commit(owner, repo, commit_sha)
-            .await
-            .map_err(classify_forge_error)
-            .context("Failed to list pull requests for commit")
-    } else {
-        Ok(vec![])
-    }
+    GitHubClient::from_storage(storage, preferred_account)?
+        .list_pulls_for_commit(owner, repo, commit_sha)
+        .await
+        .map_err(classify_forge_error)
+        .context("Failed to list pull requests for commit")
 }
 
 /// Tag transport / auth failures with a `but_error::Code` so the desktop

--- a/crates/but-gitlab/src/client.rs
+++ b/crates/but-gitlab/src/client.rs
@@ -78,7 +78,8 @@ impl GitLabClient {
         } else {
             Err(anyhow::anyhow!(
                 "No GitLab access token found for account '{account_id}'.\nRun 'but config forge auth' to re-authenticate."
-            ))
+            )
+            .context(NOT_AUTHENTICATED))
         }
     }
 
@@ -1118,23 +1119,33 @@ fn source_project_differs_from_target(
     source_project_id != target_project_id
 }
 
+/// Marks credential lookups that came up empty, so consumers can tell "the
+/// user is not authenticated" apart from a failing forge and e.g. keep
+/// serving cached data instead of surfacing an error.
+pub(crate) const NOT_AUTHENTICATED: but_error::Context = but_error::Context::new_static(
+    but_error::Code::ForgeNotAuthenticated,
+    "Not authenticated with GitLab.",
+);
+
 pub(crate) fn resolve_account(
     preferred_account: Option<&crate::GitlabAccountIdentifier>,
     storage: &but_forge_storage::Controller,
 ) -> Result<crate::GitlabAccountIdentifier, anyhow::Error> {
     let known_accounts = crate::token::list_known_gitlab_accounts(storage)?;
     let Some(default_account) = known_accounts.first() else {
-        bail!(
+        return Err(anyhow::anyhow!(
             "No authenticated GitLab users found.\nRun 'but config forge auth' to authenticate with GitLab."
-        );
+        )
+        .context(NOT_AUTHENTICATED));
     };
     let account = if let Some(account) = preferred_account {
         if known_accounts.contains(account) {
             account
         } else {
-            bail!(
+            return Err(anyhow::anyhow!(
                 "Preferred GitLab account '{account}' has not authenticated yet.\nRun 'but config forge auth' to authenticate, or choose another account."
-            );
+            )
+            .context(NOT_AUTHENTICATED));
         }
     } else {
         default_account

--- a/crates/but-gitlab/src/mr.rs
+++ b/crates/but-gitlab/src/mr.rs
@@ -7,13 +7,10 @@ pub async fn list(
     project_id: GitLabProjectId,
     storage: &but_forge_storage::Controller,
 ) -> Result<Vec<crate::client::MergeRequest>> {
-    if let Ok(gl) = GitLabClient::from_storage(storage, preferred_account) {
-        gl.list_open_mrs(project_id)
-            .await
-            .context("Failed to list open merge requests")
-    } else {
-        Ok(vec![])
-    }
+    GitLabClient::from_storage(storage, preferred_account)?
+        .list_open_mrs(project_id)
+        .await
+        .context("Failed to list open merge requests")
 }
 
 pub async fn list_recently_closed(
@@ -21,13 +18,10 @@ pub async fn list_recently_closed(
     project_id: GitLabProjectId,
     storage: &but_forge_storage::Controller,
 ) -> Result<Vec<crate::client::MergeRequest>> {
-    if let Ok(gl) = GitLabClient::from_storage(storage, preferred_account) {
-        gl.list_recently_closed_mrs(project_id)
-            .await
-            .context("Failed to list recently closed merge requests")
-    } else {
-        Ok(vec![])
-    }
+    GitLabClient::from_storage(storage, preferred_account)?
+        .list_recently_closed_mrs(project_id)
+        .await
+        .context("Failed to list recently closed merge requests")
 }
 
 pub async fn list_all_for_target(
@@ -36,13 +30,10 @@ pub async fn list_all_for_target(
     target_branch: &str,
     storage: &but_forge_storage::Controller,
 ) -> Result<Vec<crate::client::MergeRequest>> {
-    if let Ok(gl) = GitLabClient::from_storage(storage, preferred_account) {
-        gl.list_mrs_for_target(project_id, target_branch)
-            .await
-            .context("Failed to list merge requests for target branch")
-    } else {
-        Ok(vec![])
-    }
+    GitLabClient::from_storage(storage, preferred_account)?
+        .list_mrs_for_target(project_id, target_branch)
+        .await
+        .context("Failed to list merge requests for target branch")
 }
 
 pub async fn list_for_commit(
@@ -51,13 +42,10 @@ pub async fn list_for_commit(
     commit_sha: &str,
     storage: &but_forge_storage::Controller,
 ) -> Result<Vec<crate::client::MergeRequest>> {
-    if let Ok(gl) = GitLabClient::from_storage(storage, preferred_account) {
-        gl.list_mrs_for_commit(project_id, commit_sha)
-            .await
-            .context("Failed to list merge requests for commit")
-    } else {
-        Ok(vec![])
-    }
+    GitLabClient::from_storage(storage, preferred_account)?
+        .list_mrs_for_commit(project_id, commit_sha)
+        .await
+        .context("Failed to list merge requests for commit")
 }
 
 pub async fn create(

--- a/packages/but-sdk/src/generated/graph/index.d.ts
+++ b/packages/but-sdk/src/generated/graph/index.d.ts
@@ -2374,7 +2374,7 @@ export type Claude = {
  *
  * In practice, it should match its [frontend counterpart](https://github.com/gitbutlerapp/gitbutler/blob/fa973fd8f1ae8807621f47601803d98b8a9cf348/app/src/lib/backend/ipc.ts#L5).
  */
-export type Code = "Validation" | "RepoOwnership" | "ProjectGitAuth" | "DefaultTargetNotFound" | "CommitSigningFailed" | "CommitMergeConflictFailure" | "ProjectMissing" | "AuthorMissing" | "BranchNotFound" | "SecretKeychainNotFound" | "MissingLoginKeychain" | "GitForcePushProtection" | "NetworkError" | "ProjectDatabaseIncompatible" | "DefaultTerminalNotFound" | "Unknown" | "GitNonFastForward" | "CliInstallCancelled" | "GitHubTokenExpired" | "GitHubOrgOAuthRestricted" | "PreconditionFailed" | "EditorExitedWithNonZeroStatus";
+export type Code = "Validation" | "RepoOwnership" | "ProjectGitAuth" | "DefaultTargetNotFound" | "CommitSigningFailed" | "CommitMergeConflictFailure" | "ProjectMissing" | "AuthorMissing" | "BranchNotFound" | "SecretKeychainNotFound" | "MissingLoginKeychain" | "GitForcePushProtection" | "NetworkError" | "ProjectDatabaseIncompatible" | "DefaultTerminalNotFound" | "Unknown" | "GitNonFastForward" | "CliInstallCancelled" | "GitHubTokenExpired" | "GitHubOrgOAuthRestricted" | "ForgeNotAuthenticated" | "PreconditionFailed" | "EditorExitedWithNonZeroStatus";
 
 /** Commit that is part of a legacy stack branch and contains state derived in relation to it. */
 export type Commit = {

--- a/packages/but-sdk/src/generated/linear/index.d.ts
+++ b/packages/but-sdk/src/generated/linear/index.d.ts
@@ -2374,7 +2374,7 @@ export type Claude = {
  *
  * In practice, it should match its [frontend counterpart](https://github.com/gitbutlerapp/gitbutler/blob/fa973fd8f1ae8807621f47601803d98b8a9cf348/app/src/lib/backend/ipc.ts#L5).
  */
-export type Code = "Validation" | "RepoOwnership" | "ProjectGitAuth" | "DefaultTargetNotFound" | "CommitSigningFailed" | "CommitMergeConflictFailure" | "ProjectMissing" | "AuthorMissing" | "BranchNotFound" | "SecretKeychainNotFound" | "MissingLoginKeychain" | "GitForcePushProtection" | "NetworkError" | "ProjectDatabaseIncompatible" | "DefaultTerminalNotFound" | "Unknown" | "GitNonFastForward" | "CliInstallCancelled" | "GitHubTokenExpired" | "GitHubOrgOAuthRestricted" | "PreconditionFailed" | "EditorExitedWithNonZeroStatus";
+export type Code = "Validation" | "RepoOwnership" | "ProjectGitAuth" | "DefaultTargetNotFound" | "CommitSigningFailed" | "CommitMergeConflictFailure" | "ProjectMissing" | "AuthorMissing" | "BranchNotFound" | "SecretKeychainNotFound" | "MissingLoginKeychain" | "GitForcePushProtection" | "NetworkError" | "ProjectDatabaseIncompatible" | "DefaultTerminalNotFound" | "Unknown" | "GitNonFastForward" | "CliInstallCancelled" | "GitHubTokenExpired" | "GitHubOrgOAuthRestricted" | "ForgeNotAuthenticated" | "PreconditionFailed" | "EditorExitedWithNonZeroStatus";
 
 /** Commit that is part of a legacy stack branch and contains state derived in relation to it. */
 export type Commit = {


### PR DESCRIPTION
The GitHub, GitLab, and Bitbucket review-list helpers turned a failed client construction (no stored account or token) into a successful empty listing. The cache reconciled that as "the forge has no open reviews" and deleted every cached open row past the 60s grace, silently losing branch–PR associations. Observed trigger in production: users removing their GitHub credentials.

- Credential lookups that come up empty are now tagged with a new `ForgeNotAuthenticated` error code and propagated instead of faked as an empty listing. Only the genuine "no account / no token" branches are tagged, so storage/keychain failures keep their own classification.
- Cached reads (`CacheWithFallback`) recognize the code and keep serving the last known reviews while the user is logged out — the polled desktop listing stays quiet and nothing is reconciled. Other listing errors (network, org OAuth restriction) propagate as before.
- Explicit `NoCache` reads surface the re-authentication error; the desktop classifies it as a once-per-session warning pointing at Settings → Integrations.

Fixes GB-1913 (https://linear.app/gitbutler/issue/GB-1913/cached-prs-disappear-when-forge-credentials-are-missing)