### PR TITLE
feat(but): add support for resolving committed hunk IDs

### DIFF
--- a/crates/but/src/args/atoms/cli_id.rs
+++ b/crates/but/src/args/atoms/cli_id.rs
@@ -7,7 +7,7 @@ use crate::{
     CliError, CliId, CliResult, IdMap,
     args::atoms::BranchArg,
     bad_input,
-    id::{CommitId, CommitIdRef, CommittedFileId, IdAndHunk, UncommittedHunkOrFile},
+    id::{CommitId, CommitIdRef, CommittedFileId, CommittedHunk, IdAndHunk, UncommittedHunkOrFile},
     theme,
     utils::change_source::ChangeSourceId,
 };
@@ -96,6 +96,7 @@ impl CliIdArg {
             CliId::CommittedFile { committed_file, .. } => {
                 ResolvedCliIdArg::CommittedFile(committed_file)
             }
+            CliId::CommittedHunk(committed) => ResolvedCliIdArg::CommittedHunk(Box::new(committed)),
             CliId::Uncommitted { .. } => ResolvedCliIdArg::Uncommitted,
             CliId::Worktree { name, .. } => ResolvedCliIdArg::Worktree(name),
             CliId::Stack { id, stack_id } => ResolvedCliIdArg::Stack { id, stack_id },
@@ -349,6 +350,7 @@ impl CliIdArg {
             CliId::UncommittedHunkOrFile(..) => "an uncommitted change",
             CliId::PathPrefix { .. } => "a path",
             CliId::CommittedFile { .. } => "a committed file",
+            CliId::CommittedHunk(..) => "a committed change",
             CliId::Uncommitted { .. } => "uncommitted changes",
             CliId::Worktree { .. } => "a worktree",
             CliId::Stack { .. } => "a stack",
@@ -409,6 +411,7 @@ fn try_resolve_cli_id(
                 CliId::UncommittedHunkOrFile(..) => uncommitted.push(id),
                 CliId::PathPrefix { .. }
                 | CliId::CommittedFile { .. }
+                | CliId::CommittedHunk { .. }
                 | CliId::Uncommitted { .. }
                 | CliId::Worktree { .. }
                 | CliId::Stack { .. } => {}
@@ -492,6 +495,7 @@ pub enum ResolvedCliIdArg {
     Branch(BranchArg),
     UncommittedHunkOrFile(Box<UncommittedHunkOrFile>),
     CommittedFile(CommittedFileId),
+    CommittedHunk(Box<CommittedHunk>),
     Uncommitted,
     /// A linked worktree, named by its stable name.
     Worktree(BString),
@@ -536,6 +540,7 @@ impl ResolvedCliIdArg {
             ResolvedCliIdArg::UncommittedHunkOrFile { .. } => "an uncommitted file or hunk",
             ResolvedCliIdArg::PathPrefix { .. } => "a path prefix",
             ResolvedCliIdArg::CommittedFile { .. } => "a committed file",
+            ResolvedCliIdArg::CommittedHunk { .. } => "a committed hunk",
             ResolvedCliIdArg::Branch { .. } => "a branch",
             ResolvedCliIdArg::Commit { .. } => "a commit",
             ResolvedCliIdArg::Uncommitted => "uncommitted changes",
@@ -554,6 +559,9 @@ impl ResolvedCliIdArg {
             }
             ResolvedCliIdArg::CommittedFile(committed_file) => {
                 ResolvedCliIdArgRef::CommittedFile(committed_file)
+            }
+            ResolvedCliIdArg::CommittedHunk(committed_hunk) => {
+                ResolvedCliIdArgRef::CommittedHunk(committed_hunk)
             }
             ResolvedCliIdArg::PathPrefix { id, hunks } => {
                 ResolvedCliIdArgRef::PathPrefix { id, hunks }
@@ -600,6 +608,11 @@ impl PartialEq<CliId> for ResolvedCliIdArg {
                     return lhs == rhs;
                 }
             }
+            ResolvedCliIdArg::CommittedHunk(lhs) => {
+                if let CliId::CommittedHunk(rhs) = other {
+                    return &**lhs == rhs;
+                }
+            }
             ResolvedCliIdArg::Uncommitted => {
                 return matches!(other, CliId::Uncommitted { .. });
             }
@@ -641,6 +654,7 @@ impl std::fmt::Display for ResolvedCliIdArg {
             ResolvedCliIdArg::UncommittedHunkOrFile(..) => f.write_str("uncommitted file or hunk"),
             ResolvedCliIdArg::PathPrefix { .. } => f.write_str("path"),
             ResolvedCliIdArg::CommittedFile(..) => f.write_str("committed file"),
+            ResolvedCliIdArg::CommittedHunk(..) => f.write_str("committed hunk"),
             ResolvedCliIdArg::Uncommitted => f.write_str("uncommitted changes"),
             ResolvedCliIdArg::Worktree(name) => write!(f, "worktree {name}"),
             ResolvedCliIdArg::Stack { .. } => f.write_str("stack"),
@@ -656,6 +670,7 @@ pub enum ResolvedCliIdArgRef<'a> {
     Branch(&'a str),
     UncommittedHunkOrFile(&'a UncommittedHunkOrFile),
     CommittedFile(&'a CommittedFileId),
+    CommittedHunk(&'a CommittedHunk),
     PathPrefix {
         id: &'a str,
         hunks: &'a NonEmpty<IdAndHunk>,

--- a/crates/but/src/command/expand.rs
+++ b/crates/but/src/command/expand.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 use crate::{
     CliId, CliResult, IdMap,
     args::atoms::CliIdArg,
-    id::{CommitId, CommittedFileId},
+    id::{CommitId, CommittedFileId, CommittedHunk},
     theme::Theme,
     utils::{CliOutput, CliOutputHuman, WriteWithUtils},
 };
@@ -34,6 +34,11 @@ enum Resource {
     CommittedFile {
         commit_id: String,
         path: String,
+    },
+    CommittedHunk {
+        commit_id: String,
+        path: String,
+        hunk_header: String,
     },
     PathPrefix {
         path: String,
@@ -67,6 +72,13 @@ impl std::fmt::Display for Resource {
             }
             Resource::CommittedFile { commit_id, path } => {
                 write!(f, "committed file: {commit_id} {path}")
+            }
+            Resource::CommittedHunk {
+                commit_id,
+                path,
+                hunk_header,
+            } => {
+                write!(f, "committed hunk: {commit_id} {path} {hunk_header}")
             }
             Resource::PathPrefix { path } => write!(f, "path prefix: {path}"),
             Resource::Uncommitted => f.write_str("uncommitted area"),
@@ -168,6 +180,20 @@ fn resources_from_cli_id(cli_id: CliId) -> Vec<Resource> {
         } => vec![Resource::CommittedFile {
             commit_id: commit_id.to_string(),
             path: path.to_string(),
+        }],
+        CliId::CommittedHunk(CommittedHunk {
+            committed_file: CommittedFileId {
+                commit_id, path, ..
+            },
+            hunk,
+            ..
+        }) => vec![Resource::CommittedHunk {
+            commit_id: commit_id.to_string(),
+            path: path.to_string(),
+            hunk_header: hunk
+                .hunk_header
+                .map(format_hunk_header)
+                .unwrap_or_else(|| "<no hunk header>".to_string()),
         }],
         CliId::PathPrefix { id, .. } => vec![Resource::PathPrefix { path: id }],
         CliId::Uncommitted { .. } => vec![Resource::Uncommitted],

--- a/crates/but/src/command/legacy/diff.rs
+++ b/crates/but/src/command/legacy/diff.rs
@@ -464,6 +464,9 @@ fn resolve(ctx: &Context, id_map: &IdMap, args: Platform) -> CliResult<DiffOpera
             },
             path,
         }),
+        ResolvedCliIdArg::CommittedHunk(..) => {
+            Err(bad_input("viewing diffs for committed hunks is not supported").into())
+        }
         ResolvedCliIdArg::PathPrefix { id, hunks } => Ok(DiffOperation::PathPrefix { id, hunks }),
         ResolvedCliIdArg::Worktree(name) => Ok(DiffOperation::Worktree { name }),
         ResolvedCliIdArg::Stack { .. } => {

--- a/crates/but/src/command/legacy/discard.rs
+++ b/crates/but/src/command/legacy/discard.rs
@@ -293,6 +293,13 @@ fn resolve(repo: &gix::Repository, id_map: &IdMap, args: Platform) -> CliResult<
             ResolvedCliIdArg::CommittedFile(committed_file) => {
                 committed_file_sources.push(committed_file)
             }
+            ResolvedCliIdArg::CommittedHunk(..) => {
+                return Err(bad_input("Committed hunks cannot be discarded")
+                    .arg_name("<CHANGES>")
+                    .arg_value(value)
+                    .hint("Use committed file CLI IDs instead")
+                    .into());
+            }
             ResolvedCliIdArg::UncommittedHunkOrFile(change) => {
                 uncommitted_change_sources.push(UncommittedDiscardSource::HunkOrFile(*change))
             }

--- a/crates/but/src/command/legacy/pick.rs
+++ b/crates/but/src/command/legacy/pick.rs
@@ -182,6 +182,7 @@ fn resolve(
                         ResolvedCliIdArg::Branch(..)
                         | ResolvedCliIdArg::UncommittedHunkOrFile(..)
                         | ResolvedCliIdArg::CommittedFile(..)
+                        | ResolvedCliIdArg::CommittedHunk(..)
                         | ResolvedCliIdArg::Uncommitted
                         | ResolvedCliIdArg::PathPrefix { .. }
                         | ResolvedCliIdArg::Worktree(..)

--- a/crates/but/src/command/legacy/squash.rs
+++ b/crates/but/src/command/legacy/squash.rs
@@ -878,6 +878,7 @@ pub fn resolve_target(
         }
         ResolvedCliIdArgRef::UncommittedHunkOrFile(..)
         | ResolvedCliIdArgRef::CommittedFile { .. }
+        | ResolvedCliIdArgRef::CommittedHunk { .. }
         | ResolvedCliIdArgRef::PathPrefix { .. }
         | ResolvedCliIdArgRef::Worktree(..)
         | ResolvedCliIdArgRef::Stack { .. } => Err(ResolveTargetError::InvalidTarget),
@@ -1085,6 +1086,7 @@ impl<'a> Squashable<'a> {
                     UncommittedSquashSource::PathPrefix(Cow::Borrowed(hunks)),
                 ));
             }
+            ResolvedCliIdArgRef::CommittedHunk(..) => "a committed hunk",
             ResolvedCliIdArgRef::Worktree(..) => "a worktree",
             ResolvedCliIdArgRef::Stack { .. } => "a stack",
         };

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -581,6 +581,7 @@ fn build_status_context<'a>(
         sources,
         commit_id_to_change_id,
         crate::id::worktree_commits_by_name(&worktrees),
+        ctx.settings.context_lines,
     )?;
 
     let stacks = id_map.stacks();

--- a/crates/but/src/command/legacy/status/tui/app/cherry_pick_mode.rs
+++ b/crates/but/src/command/legacy/status/tui/app/cherry_pick_mode.rs
@@ -161,6 +161,7 @@ impl App {
                         CliId::UncommittedHunkOrFile(..)
                         | CliId::PathPrefix { .. }
                         | CliId::CommittedFile { .. }
+                        | CliId::CommittedHunk { .. }
                         | CliId::Branch(..)
                         | CliId::Uncommitted { .. }
                         | CliId::Worktree { .. }
@@ -246,6 +247,7 @@ impl App {
                 CliId::UncommittedHunkOrFile(..)
                 | CliId::PathPrefix { .. }
                 | CliId::CommittedFile { .. }
+                | CliId::CommittedHunk(..)
                 | CliId::Uncommitted { .. }
                 | CliId::Stack { .. } => Ok(None),
             }
@@ -275,6 +277,7 @@ impl App {
             | CliId::UncommittedHunkOrFile(..)
             | CliId::PathPrefix { .. }
             | CliId::CommittedFile { .. }
+            | CliId::CommittedHunk { .. }
             | CliId::Uncommitted { .. }
             | CliId::Worktree { .. }
             | CliId::Stack { .. } => Ok(None),

--- a/crates/but/src/command/legacy/status/tui/app/commit_mode.rs
+++ b/crates/but/src/command/legacy/status/tui/app/commit_mode.rs
@@ -167,7 +167,10 @@ impl CommitSource {
             // A worktree heading names that checkout's uncommitted area, so it is a source in
             // exactly the way `zz` is one for the main worktree.
             CliId::Worktree { name, .. } => Some(CommitSource::Worktree(name.clone())),
-            CliId::PathPrefix { .. } | CliId::CommittedFile { .. } | CliId::Stack { .. } => None,
+            CliId::PathPrefix { .. }
+            | CliId::CommittedFile { .. }
+            | CliId::CommittedHunk { .. }
+            | CliId::Stack { .. } => None,
         }
     }
 }
@@ -386,6 +389,7 @@ impl App {
             CliId::UncommittedHunkOrFile(..)
             | CliId::PathPrefix { .. }
             | CliId::CommittedFile { .. }
+            | CliId::CommittedHunk { .. }
             | CliId::Uncommitted { .. }
             | CliId::Stack { .. } => return Ok(()),
         };
@@ -433,6 +437,7 @@ impl App {
 
             CliId::PathPrefix { .. }
             | CliId::CommittedFile { .. }
+            | CliId::CommittedHunk { .. }
             | CliId::Commit { .. }
             | CliId::Worktree { .. }
             | CliId::Stack { .. } => return Ok(()),

--- a/crates/but/src/command/legacy/status/tui/app/discard.rs
+++ b/crates/but/src/command/legacy/status/tui/app/discard.rs
@@ -230,9 +230,10 @@ impl App {
                         },
                     )
                 }
-                CliId::Stack { .. } | CliId::PathPrefix { .. } | CliId::Worktree { .. } => {
-                    return Ok(());
-                }
+                CliId::CommittedHunk(..)
+                | CliId::Stack { .. }
+                | CliId::PathPrefix { .. }
+                | CliId::Worktree { .. } => return Ok(()),
             },
         });
 

--- a/crates/but/src/command/legacy/status/tui/app/jump_mode.rs
+++ b/crates/but/src/command/legacy/status/tui/app/jump_mode.rs
@@ -125,6 +125,7 @@ fn jump_id_has_prefix(id: &CliId, query: &str) -> bool {
         | CliId::Worktree { id, .. }
         | CliId::Stack { id, .. } => id.starts_with(query),
         CliId::Branch(branch) => branch.id.starts_with(query),
+        CliId::CommittedHunk(..) => false,
     }
 }
 

--- a/crates/but/src/command/legacy/status/tui/app/mark.rs
+++ b/crates/but/src/command/legacy/status/tui/app/mark.rs
@@ -697,7 +697,10 @@ impl App {
                     | Mode::Stack(..) => {}
                 }
             }
-            CliId::PathPrefix { .. } | CliId::Stack { .. } | CliId::Worktree { .. } => {}
+            CliId::CommittedHunk(..)
+            | CliId::PathPrefix { .. }
+            | CliId::Stack { .. }
+            | CliId::Worktree { .. } => {}
         }
 
         if self.marks_ref().is_empty() {

--- a/crates/but/src/command/legacy/status/tui/app/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/app/mod.rs
@@ -338,6 +338,7 @@ impl App {
             | ResolvedCliIdArg::Branch(..)
             | ResolvedCliIdArg::UncommittedHunkOrFile(..)
             | ResolvedCliIdArg::CommittedFile(..)
+            | ResolvedCliIdArg::CommittedHunk(..)
             | ResolvedCliIdArg::Uncommitted
             | ResolvedCliIdArg::PathPrefix { .. }
             | ResolvedCliIdArg::Worktree(..)
@@ -1160,6 +1161,7 @@ impl App {
                                             }
                                             CliId::PathPrefix { .. }
                                             | CliId::CommittedFile { .. }
+                                            | CliId::CommittedHunk { .. }
                                             | CliId::Branch(..)
                                             | CliId::Commit { .. }
                                             | CliId::Stack { .. }
@@ -1207,6 +1209,7 @@ impl App {
                         }
                         CliId::PathPrefix { .. }
                         | CliId::CommittedFile { .. }
+                        | CliId::CommittedHunk { .. }
                         | CliId::Branch(..)
                         | CliId::Commit { .. }
                         | CliId::Worktree { .. }
@@ -1589,9 +1592,10 @@ impl App {
                 uncommitted.hunks.first().hunk.path.to_str_lossy()
             }
             CliId::Worktree { name, .. } => name.to_str_lossy(),
-            CliId::PathPrefix { .. } | CliId::Uncommitted { .. } | CliId::Stack { .. } => {
-                return Ok(());
-            }
+            CliId::CommittedHunk(..)
+            | CliId::PathPrefix { .. }
+            | CliId::Uncommitted { .. }
+            | CliId::Stack { .. } => return Ok(()),
         };
 
         self.clipboard.set_text(what_to_copy)?;
@@ -1642,9 +1646,10 @@ impl App {
             CliId::Worktree { id, name } => {
                 copy_selection_picker::worktree_picker(name.to_owned(), id.to_owned(), self.theme)
             }
-            CliId::PathPrefix { .. } | CliId::Uncommitted { .. } | CliId::Stack { .. } => {
-                return Ok(());
-            }
+            CliId::CommittedHunk(..)
+            | CliId::PathPrefix { .. }
+            | CliId::Uncommitted { .. }
+            | CliId::Stack { .. } => return Ok(()),
         };
         self.modal = Some(Modal::CopySelectionPicker {
             picker: Box::new(picker),
@@ -1677,7 +1682,8 @@ impl App {
                         committed_file: CommittedFileId { path, .. },
                         id: _,
                     } => Openable::try_from_relpath(&*ctx.repo.get()?, path.as_bstr()).map(Some),
-                    CliId::Commit { .. }
+                    CliId::CommittedHunk(..)
+                    | CliId::Commit { .. }
                     | CliId::Branch(_)
                     | CliId::PathPrefix { .. }
                     | CliId::Uncommitted { .. }

--- a/crates/but/src/command/legacy/status/tui/app/move_mode.rs
+++ b/crates/but/src/command/legacy/status/tui/app/move_mode.rs
@@ -156,6 +156,7 @@ impl MoveSource {
             CliId::UncommittedHunkOrFile(..)
             | CliId::PathPrefix { .. }
             | CliId::CommittedFile { .. }
+            | CliId::CommittedHunk { .. }
             | CliId::Uncommitted { .. }
             | CliId::Worktree { .. }
             | CliId::Stack { .. } => None,

--- a/crates/but/src/command/legacy/status/tui/app/reword.rs
+++ b/crates/but/src/command/legacy/status/tui/app/reword.rs
@@ -166,6 +166,7 @@ impl App {
             CliId::UncommittedHunkOrFile(..)
             | CliId::PathPrefix { .. }
             | CliId::CommittedFile { .. }
+            | CliId::CommittedHunk { .. }
             | CliId::Uncommitted { .. }
             | CliId::Worktree { .. }
             | CliId::Stack { .. } => return Ok(()),

--- a/crates/but/src/command/legacy/status/tui/app/squash_mode.rs
+++ b/crates/but/src/command/legacy/status/tui/app/squash_mode.rs
@@ -401,7 +401,10 @@ impl App {
             } => {
                 self.squash_start_with_source(SquashSource::CommittedFile(committed_file.clone()));
             }
-            CliId::PathPrefix { .. } | CliId::Stack { .. } | CliId::Worktree { .. } => {}
+            CliId::CommittedHunk(..)
+            | CliId::PathPrefix { .. }
+            | CliId::Stack { .. }
+            | CliId::Worktree { .. } => {}
         }
     }
 

--- a/crates/but/src/command/legacy/status/tui/app/stack_mode.rs
+++ b/crates/but/src/command/legacy/status/tui/app/stack_mode.rs
@@ -33,7 +33,7 @@ use crate::{
         },
         unapply::{self, UnapplyOperation},
     },
-    id::{BranchId, CommitId, CommittedFileId},
+    id::{BranchId, CommitId, CommittedFileId, CommittedHunk},
     theme::Theme,
     utils::time::format_relative_time,
 };
@@ -109,6 +109,7 @@ impl ReorderStackSource {
             | CliId::UncommittedHunkOrFile(..)
             | CliId::PathPrefix { .. }
             | CliId::CommittedFile { .. }
+            | CliId::CommittedHunk { .. }
             | CliId::Commit { .. }
             | CliId::Worktree { .. }
             | CliId::Uncommitted { .. } => false,
@@ -245,7 +246,8 @@ fn stack_id_for_cli_id(cli_id: &CliId, status_lines: &[StatusOutputLine]) -> Opt
         | CliId::Branch(..)
         | CliId::Uncommitted { .. }
         | CliId::Worktree { .. }
-        | CliId::Stack { .. } => false,
+        | CliId::Stack { .. }
+        | CliId::CommittedHunk(..) => false,
     };
 
     match cli_id {
@@ -258,6 +260,7 @@ fn stack_id_for_cli_id(cli_id: &CliId, status_lines: &[StatusOutputLine]) -> Opt
                     CliId::UncommittedHunkOrFile(..)
                     | CliId::PathPrefix { .. }
                     | CliId::CommittedFile { .. }
+                    | CliId::CommittedHunk { .. }
                     | CliId::Branch(..)
                     | CliId::Commit { .. }
                     | CliId::Uncommitted { .. }
@@ -288,7 +291,8 @@ fn stack_id_for_cli_id(cli_id: &CliId, status_lines: &[StatusOutputLine]) -> Opt
         CliId::UncommittedHunkOrFile(..)
         | CliId::PathPrefix { .. }
         | CliId::Worktree { .. }
-        | CliId::Uncommitted { .. } => None,
+        | CliId::Uncommitted { .. }
+        | CliId::CommittedHunk(..) => None,
     }
 }
 
@@ -465,6 +469,7 @@ impl App {
             CliId::UncommittedHunkOrFile(..)
             | CliId::PathPrefix { .. }
             | CliId::CommittedFile { .. }
+            | CliId::CommittedHunk { .. }
             | CliId::Commit { .. }
             | CliId::Uncommitted { .. }
             | CliId::Worktree { .. }
@@ -734,7 +739,12 @@ fn row_stack_ids(lines: &[StatusOutputLine]) -> Vec<Option<StackId>> {
                 CliId::CommittedFile {
                     committed_file: CommittedFileId { commit_id, .. },
                     id: _,
-                } => {
+                }
+                | CliId::CommittedHunk(CommittedHunk {
+                    committed_file: CommittedFileId { commit_id, .. },
+                    id: _,
+                    hunk: _,
+                }) => {
                     let stack_id = commit_stack_ids
                         .get(commit_id)
                         .copied()
@@ -796,6 +806,7 @@ fn stack_id_from_cli_id(cli_id: &CliId) -> Option<StackId> {
         CliId::UncommittedHunkOrFile(..)
         | CliId::PathPrefix { .. }
         | CliId::CommittedFile { .. }
+        | CliId::CommittedHunk(..)
         | CliId::Commit { .. }
         | CliId::Worktree { .. }
         | CliId::Uncommitted { .. } => None,

--- a/crates/but/src/command/legacy/status/tui/cursor/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/cursor/mod.rs
@@ -92,6 +92,11 @@ impl Cursor {
             | ResolvedCliIdArg::Uncommitted
             | ResolvedCliIdArg::UncommittedHunkOrFile(..)
             | ResolvedCliIdArg::CommittedFile(..) => {}
+            ResolvedCliIdArg::CommittedHunk(..) => {
+                return Err(bad_input("Selecting committed hunks is not supported")
+                    .hint(hint)
+                    .into());
+            }
             ResolvedCliIdArg::PathPrefix { .. } => {
                 return Err(bad_input("Selecting path prefixes is not supported")
                     .hint(hint)
@@ -111,6 +116,7 @@ impl Cursor {
                         CliId::UncommittedHunkOrFile(file) => hunk_is_child_of(file, hunk),
                         CliId::PathPrefix { .. }
                         | CliId::CommittedFile { .. }
+                        | CliId::CommittedHunk { .. }
                         | CliId::Branch(..)
                         | CliId::Commit { .. }
                         | CliId::Uncommitted { .. }
@@ -125,7 +131,8 @@ impl Cursor {
                 | ResolvedCliIdArg::Uncommitted
                 | ResolvedCliIdArg::PathPrefix { .. }
                 | ResolvedCliIdArg::Worktree(..)
-                | ResolvedCliIdArg::Stack { .. } => target == **cli_id,
+                | ResolvedCliIdArg::Stack { .. }
+                | ResolvedCliIdArg::CommittedHunk(..) => target == **cli_id,
             })
         }) else {
             return Ok(None);
@@ -469,7 +476,7 @@ impl Cursor {
                 | Some(CliId::Uncommitted { .. })
                 | Some(CliId::Worktree { .. })
                 | Some(CliId::Stack { .. }) => matches!(show_files, FilesStatusFlag::All),
-                None => false,
+                Some(CliId::CommittedHunk(..)) | None => false,
             };
 
             if !file_is_visible {
@@ -1018,6 +1025,7 @@ pub(super) fn same_entity_for_reload(previous: &CliId, current: &CliId) -> bool 
                 false
             }
         }
+        CliId::CommittedHunk(..) => false,
         CliId::Branch(previous) => {
             if let CliId::Branch(current) = current {
                 previous == current
@@ -1094,7 +1102,8 @@ fn select_after_reload_for_cli_id(cli_id: &Arc<CliId>) -> SelectAfterReload {
             committed_file: CommittedFileId { commit_id, .. },
             id: _,
         } => SelectAfterReload::FirstFileInCommit(*commit_id),
-        CliId::Uncommitted { .. }
+        CliId::CommittedHunk(..)
+        | CliId::Uncommitted { .. }
         | CliId::UncommittedHunkOrFile(..)
         | CliId::PathPrefix { .. }
         | CliId::Branch(..)
@@ -1366,6 +1375,7 @@ pub fn is_selectable_in_mode(
                     CliId::UncommittedHunkOrFile(..) | CliId::Uncommitted { .. } => true,
                     CliId::PathPrefix { .. }
                     | CliId::CommittedFile { .. }
+                    | CliId::CommittedHunk { .. }
                     | CliId::Branch(..)
                     | CliId::Commit { .. }
                     | CliId::Worktree { .. }

--- a/crates/but/src/command/legacy/status/tui/cursor/tests.rs
+++ b/crates/but/src/command/legacy/status/tui/cursor/tests.rs
@@ -147,6 +147,7 @@ fn uncommitted_source(cli_ids: &[Arc<CliId>]) -> CommitSource {
             CliId::Uncommitted { .. }
             | CliId::PathPrefix { .. }
             | CliId::CommittedFile { .. }
+            | CliId::CommittedHunk { .. }
             | CliId::Branch(BranchId { .. })
             | CliId::Stack { .. }
             | CliId::Worktree { .. }

--- a/crates/but/src/command/legacy/status/tui/details.rs
+++ b/crates/but/src/command/legacy/status/tui/details.rs
@@ -385,6 +385,10 @@ impl Details {
                 self.diff_not_supported("(viewing diffs for stacks is not supported)");
                 Ok(true)
             }
+            CliId::CommittedHunk(..) => {
+                self.diff_not_supported("(viewing diffs for committed hunks is not supported)");
+                Ok(true)
+            }
             CliId::PathPrefix { .. } => {
                 self.reset_line_reader();
                 self.clear_lines();
@@ -1259,6 +1263,7 @@ impl Details {
             CliId::UncommittedHunkOrFile(..) | CliId::Uncommitted { .. } => true,
             CliId::PathPrefix { .. }
             | CliId::CommittedFile { .. }
+            | CliId::CommittedHunk { .. }
             | CliId::Branch(..)
             | CliId::Commit { .. }
             | CliId::Worktree { .. }

--- a/crates/but/src/command/legacy/status/tui/file_browser.rs
+++ b/crates/but/src/command/legacy/status/tui/file_browser.rs
@@ -66,6 +66,7 @@ impl FileBrowser {
             CliId::UncommittedHunkOrFile(..)
             | CliId::PathPrefix { .. }
             | CliId::CommittedFile { .. }
+            | CliId::CommittedHunk { .. }
             | CliId::Branch(..)
             | CliId::Commit { .. }
             | CliId::Worktree { .. }

--- a/crates/but/src/command/legacy/status/tui/key_bind/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/key_bind/mod.rs
@@ -1556,6 +1556,7 @@ impl KeyBindCondition {
                     CliId::UncommittedHunkOrFile(..) | CliId::Uncommitted { .. } => true,
                     CliId::PathPrefix { .. }
                     | CliId::CommittedFile { .. }
+                    | CliId::CommittedHunk { .. }
                     | CliId::Branch(..)
                     | CliId::Commit { .. }
                     | CliId::Worktree { .. }

--- a/crates/but/src/command/legacy/status/tui/remember_selection.rs
+++ b/crates/but/src/command/legacy/status/tui/remember_selection.rs
@@ -100,6 +100,6 @@ fn line_id(id: &CliId) -> Option<String> {
         }
         CliId::Uncommitted { id } => format!("uncommitted:{id}"),
         CliId::Worktree { name, .. } => format!("worktree:{name}"),
-        CliId::PathPrefix { .. } | CliId::Stack { .. } => return None,
+        CliId::CommittedHunk(..) | CliId::PathPrefix { .. } | CliId::Stack { .. } => return None,
     })
 }

--- a/crates/but/src/command/legacy/status/tui/tests/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/mod.rs
@@ -1331,6 +1331,7 @@ fn open_tui_on_uncommitted_hunk(show_diff: bool) -> TestTui<App> {
                 CliId::UncommittedHunkOrFile(..)
                 | CliId::PathPrefix { .. }
                 | CliId::CommittedFile { .. }
+                | CliId::CommittedHunk { .. }
                 | CliId::Branch(..)
                 | CliId::Commit { .. }
                 | CliId::Uncommitted { .. }

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -209,7 +209,7 @@ fn short_ids_from_tree_changes(
     tree_changes: Vec<but_core::TreeChange>,
 ) -> anyhow::Result<Vec<(NonEmpty<but_core::TreeChange>, ChangeId, ShortId)>> {
     let FileInfo { changes } = FileInfo::from_tree_changes(tree_changes)?;
-    let mut short_ids: Vec<(NonEmpty<but_core::TreeChange>, ChangeId, ShortId)> = Vec::new();
+    let mut short_ids = Vec::new();
     for (path, changes) in changes {
         // Committed files are namespaced under their commit's ID, so they never
         // compete with the uncommitted namespace and need no source of their own.
@@ -232,33 +232,143 @@ fn short_ids_from_tree_changes(
     Ok(short_ids)
 }
 
-type ChangesInCommitFn<'a> = Box<
-    dyn FnMut(gix::ObjectId, Option<gix::ObjectId>) -> anyhow::Result<Vec<but_core::TreeChange>>
-        + 'a,
->;
+trait ChangesInCommit {
+    fn tree_changes(
+        &self,
+        commit_id: gix::ObjectId,
+        parent_id: Option<gix::ObjectId>,
+    ) -> anyhow::Result<Vec<but_core::TreeChange>>;
+
+    fn patch_for_tree_change(
+        &self,
+        tree_change: &but_core::TreeChange,
+        context_lines: u32,
+    ) -> anyhow::Result<Option<but_core::UnifiedPatch>>;
+}
+
+struct ChangesInCommitImpl<'a> {
+    repo: &'a gix::Repository,
+}
+
+impl<'a> ChangesInCommit for ChangesInCommitImpl<'a> {
+    fn tree_changes(
+        &self,
+        commit_id: gix::ObjectId,
+        parent_id: Option<gix::ObjectId>,
+    ) -> anyhow::Result<Vec<but_core::TreeChange>> {
+        but_core::diff::tree_changes(self.repo, parent_id, commit_id)
+    }
+
+    fn patch_for_tree_change(
+        &self,
+        tree_change: &but_core::TreeChange,
+        context_lines: u32,
+    ) -> anyhow::Result<Option<but_core::UnifiedPatch>> {
+        tree_change.unified_patch(self.repo, context_lines)
+    }
+}
+
 trait Node<'a>: std::fmt::Debug {
     fn parse(
         self: Box<Self>,
         element: &str,
         id_map: &'a IdMap,
-        changes_in_commit_fn: &mut ChangesInCommitFn<'a>,
+        changes_in_commit: &dyn ChangesInCommit,
     ) -> anyhow::Result<Vec<Box<dyn Node<'a> + 'a>>>;
 
     fn to_cli_id(self: Box<Self>, short_id: &str, id_map: &IdMap) -> anyhow::Result<Option<CliId>>;
+}
+
+/// Internal type forming a superset of [`CliId::CommittedFile`] to propagate the
+/// [`but_core::TreeChange`] that's later (sometimes) used to resolve hunk IDs within the file,
+/// without exposing it outside this module.
+#[derive(Debug)]
+struct CommittedFile {
+    /// The committed file identifier.
+    committed_file: CommittedFileId,
+    /// The short CLI ID for this file (typically 2 characters)
+    short_id: ShortId,
+    /// Tree change from the commit's first-parent diff.
+    ///
+    /// This should in practice always contain a single change, but according to the docs on
+    /// [FileInfo::changes], there have been cases where a single path resolved to multiple tree
+    /// changes. As we currently cannot structurally guarantee this does not happen, we need this
+    /// awkward list here.
+    tree_changes: NonEmpty<but_core::TreeChange>,
+}
+
+impl<'a> Node<'a> for CommittedFile {
+    fn parse(
+        self: Box<Self>,
+        element: &str,
+        id_map: &'a IdMap,
+        changes_in_commit: &dyn ChangesInCommit,
+    ) -> anyhow::Result<Vec<Box<dyn Node<'a> + 'a>>> {
+        let mut matches = Vec::<Box<dyn Node<'a> + 'a>>::new();
+
+        let mut hunks: Vec<but_core::SingleHunk> = vec![];
+
+        for tree_change in self.tree_changes.iter() {
+            let Some(patch @ but_core::UnifiedPatch::Patch { .. }) =
+                changes_in_commit.patch_for_tree_change(tree_change, id_map.diff_context_lines)?
+            else {
+                // If it's anything but a Patch variant, we can't possibly refer to a hunk inside of it
+                continue;
+            };
+
+            hunks.extend(but_core::SingleHunk::from_tree_change(
+                tree_change,
+                Some(patch),
+            ));
+        }
+
+        let mut short_ids_and_hunks: Vec<_> = hunks
+            .into_iter()
+            .map(|hunk| (UnqualifiedHunkId::default(), hunk))
+            .collect();
+
+        IdMap::assign_content_based_hunk_ids(short_ids_and_hunks.iter_mut())?;
+
+        for (hunk_short_id, hunk) in short_ids_and_hunks {
+            if hunk_short_id.matches_prefix(element) {
+                let short_id = format!("{}:{}", self.short_id, hunk_short_id.short_id());
+                let cli_id = CliId::CommittedHunk(CommittedHunk {
+                    committed_file: self.committed_file.clone(),
+                    id: short_id,
+                    hunk,
+                });
+                matches.push(Box::new(Leaf { cli_id }));
+            }
+        }
+
+        Ok(matches)
+    }
+
+    fn to_cli_id(
+        self: Box<Self>,
+        _short_id: &str,
+        _id_map: &IdMap,
+    ) -> anyhow::Result<Option<CliId>> {
+        Ok(Some(CliId::CommittedFile {
+            committed_file: self.committed_file,
+            id: self.short_id,
+        }))
+    }
 }
 
 #[derive(Debug)]
 struct Leaf {
     cli_id: CliId,
 }
+
 impl<'a> Node<'a> for Leaf {
     fn parse(
         self: Box<Self>,
         _element: &str,
         _id_map: &'a IdMap,
-        _changes_in_commit_fn: &mut ChangesInCommitFn<'a>,
+        _changes_in_commit: &dyn ChangesInCommit,
     ) -> anyhow::Result<Vec<Box<dyn Node<'a> + 'a>>> {
-        Ok(Vec::new())
+        Ok(vec![])
     }
 
     fn to_cli_id(
@@ -337,17 +447,15 @@ impl WorkspaceCommitWithId {
 /// Methods to calculate the short IDs of committed files.
 impl WorkspaceCommitWithId {
     /// Calculate the short IDs of all changes in this commit.
-    pub fn tree_changes<F>(
+    pub fn tree_changes(
         &self,
-        mut changes_in_commit_fn: F,
-    ) -> anyhow::Result<Vec<TreeChangeWithId>>
-    where
-        F: FnMut(gix::ObjectId, Option<gix::ObjectId>) -> anyhow::Result<Vec<but_core::TreeChange>>,
-    {
-        let rhs_indexes = short_ids_from_tree_changes(changes_in_commit_fn(
-            self.commit_id(),
-            self.first_parent_id(),
-        )?)?;
+        mut tree_changes: impl FnMut(
+            gix::ObjectId,
+            Option<gix::ObjectId>,
+        ) -> anyhow::Result<Vec<but_core::TreeChange>>,
+    ) -> anyhow::Result<Vec<TreeChangeWithId>> {
+        let rhs_indexes =
+            short_ids_from_tree_changes(tree_changes(self.commit_id(), self.first_parent_id())?)?;
         Ok(rhs_indexes
             .into_iter()
             .flat_map(|(changes, _change_id, short_id)| {
@@ -381,37 +489,36 @@ impl<'a> Node<'a> for &'a WorkspaceCommitWithId {
         self: Box<Self>,
         element: &str,
         _id_map: &'a IdMap,
-        changes_in_commit_fn: &mut ChangesInCommitFn<'a>,
+        changes_in_commit: &dyn ChangesInCommit,
     ) -> anyhow::Result<Vec<Box<dyn Node<'a> + 'a>>> {
         let mut matches = Vec::<Box<dyn Node<'a> + 'a>>::new();
-        let rhs_indexes = short_ids_from_tree_changes(changes_in_commit_fn(
-            self.commit_id(),
-            self.first_parent_id(),
-        )?)?;
+        let rhs_indexes = short_ids_from_tree_changes(
+            changes_in_commit.tree_changes(self.commit_id(), self.first_parent_id())?,
+        )?;
         for (tree_changes, change_id, short_id) in rhs_indexes {
             let is_match = change_id.starts_with(element.as_bytes())
                 || tree_changes.first().path == BStr::new(element);
             if is_match {
-                matches.push(Box::new(Leaf {
-                    cli_id: CliId::CommittedFile {
-                        committed_file: CommittedFileId {
-                            commit_id: self.commit_id(),
-                            path: tree_changes.first().path.clone(),
-                            change_id: self
-                                .change_id
-                                .as_ref()
-                                .map(|change_id| change_id.change_id.clone()),
-                        },
-                        id: format!(
-                            "{}:{}",
-                            self.change_id
-                                .as_ref()
-                                .map(|cid| &cid.short_id)
-                                .unwrap_or(&self.short_id),
-                            short_id
-                        ),
+                let committed_file_node = CommittedFile {
+                    committed_file: CommittedFileId {
+                        commit_id: self.commit_id(),
+                        path: tree_changes.first().path.clone(),
+                        change_id: self
+                            .change_id
+                            .as_ref()
+                            .map(|change_id| change_id.change_id.clone()),
                     },
-                }));
+                    short_id: format!(
+                        "{}:{}",
+                        self.change_id
+                            .as_ref()
+                            .map(|cid| &cid.short_id)
+                            .unwrap_or(&self.short_id),
+                        short_id
+                    ),
+                    tree_changes,
+                };
+                matches.push(Box::new(committed_file_node))
             }
         }
         Ok(matches)
@@ -451,7 +558,7 @@ impl<'a> Node<'a> for &'a RemoteCommitWithId {
         self: Box<Self>,
         _element: &str,
         _id_map: &'a IdMap,
-        _changes_in_commit_fn: &mut ChangesInCommitFn<'a>,
+        _changes_in_commit: &dyn ChangesInCommit,
     ) -> anyhow::Result<Vec<Box<dyn Node<'a> + 'a>>> {
         Ok(Vec::new())
     }
@@ -502,7 +609,7 @@ impl<'a> Node<'a> for &'a SegmentWithId {
         self: Box<Self>,
         _element: &str,
         _id_map: &'a IdMap,
-        _changes_in_commit_fn: &mut ChangesInCommitFn<'a>,
+        _changes_in_commit: &dyn ChangesInCommit,
     ) -> anyhow::Result<Vec<Box<dyn Node<'a> + 'a>>> {
         // TODO: it may be confusing for the user if `branch_id:something`
         // silently does not match instead of an error message being printed.
@@ -536,7 +643,7 @@ impl<'a> Node<'a> for &'a StackWithId {
         self: Box<Self>,
         element: &str,
         id_map: &'a IdMap,
-        _changes_in_commit_fn: &mut ChangesInCommitFn<'a>,
+        _changes_in_commit: &dyn ChangesInCommit,
     ) -> anyhow::Result<Vec<Box<dyn Node<'a> + 'a>>> {
         // Parse known suffixes.
         if element.ends_with('/') {
@@ -584,6 +691,10 @@ pub struct IdMap {
     stack_ids: BTreeMap<StackId, CliId>,
     /// The ID representing the uncommitted area, i.e. uncommitted files that aren't assigned to a stack.
     uncommitted: CliId,
+    /// The amount of context lines to use when calculating diffs. This is necessary for on-demand
+    /// resolution of committed hunks as different context line settings may produce different
+    /// hunks.
+    diff_context_lines: u32,
 
     /// Maps full reverse hex IDs to uncommitted files.
     pub uncommitted_files: BTreeMap<ChangeId, UncommittedFile>,
@@ -627,6 +738,7 @@ impl IdMap {
         sources: Vec<SourceChanges>,
         commit_id_to_change_id: gix::hashtable::HashMap<gix::ObjectId, ChangeId>,
         mut worktree_commits: BTreeMap<BString, Vec<StackCommit>>,
+        diff_context_lines: u32,
     ) -> anyhow::Result<Self> {
         // Taken before partitioning, which drops sources without changes: a clean
         // worktree still gets an ID, so `but status` can list it and name it.
@@ -851,6 +963,7 @@ impl IdMap {
             uncommitted_files,
             uncommitted_hunks,
             worktrees,
+            diff_context_lines,
         })
     }
 
@@ -1012,6 +1125,7 @@ impl IdMap {
             sources,
             commit_id_to_change_id,
             worktree_commits_by_name(&worktrees),
+            ctx.settings.context_lines,
         )
     }
 }
@@ -1362,7 +1476,7 @@ impl<'a> Node<'a> for &'a WorktreeWithId {
         self: Box<Self>,
         element: &str,
         id_map: &'a IdMap,
-        _changes_in_commit_fn: &mut ChangesInCommitFn<'a>,
+        _changes_in_commit: &dyn ChangesInCommit,
     ) -> anyhow::Result<Vec<Box<dyn Node<'a> + 'a>>> {
         // `<worktree>:<path>` is how a path that is dirty in several checkouts is
         // narrowed down to one, mirroring `zz:<path>` for the main worktree.
@@ -1393,7 +1507,7 @@ impl<'a> Node<'a> for Unstaged {
         self: Box<Self>,
         element: &str,
         id_map: &'a IdMap,
-        _changes_in_commit_fn: &mut ChangesInCommitFn<'a>,
+        _changes_in_commit: &dyn ChangesInCommit,
     ) -> anyhow::Result<Vec<Box<dyn Node<'a> + 'a>>> {
         // `zz` means the main worktree, so `zz:<path>` must never reach into a
         // linked worktree that happens to have the same path dirty.
@@ -1416,12 +1530,12 @@ impl IdMap {
     ///
     /// Besides generated IDs, this method also accepts filenames, which are
     /// interpreted as uncommitted, uncommitted files.
-    pub fn parse<'a>(
-        &'a self,
+    fn parse(
+        &self,
         entity: &str,
-        changes_in_commit_fn: ChangesInCommitFn<'a>,
+        changes_in_commit: &dyn ChangesInCommit,
     ) -> anyhow::Result<Vec<CliId>> {
-        self.parse_with(entity, changes_in_commit_fn, SourceScope::Any)
+        self.parse_with(entity, changes_in_commit, SourceScope::Any)
     }
 
     /// Like [IdMap::parse], but the leading element resolves in the
@@ -1434,18 +1548,18 @@ impl IdMap {
     /// [`CliId::Uncommitted`], `dir/` yields [`CliId::PathPrefix`], and
     /// `X@{stack}` resolves its stack (and can yield
     /// [`CliId::Stack`]); callers validate the kinds they accept.
-    pub fn parse_uncommitted<'a>(
-        &'a self,
+    fn parse_uncommitted(
+        &self,
         entity: &str,
-        changes_in_commit_fn: ChangesInCommitFn<'a>,
+        changes_in_commit: &dyn ChangesInCommit,
     ) -> anyhow::Result<Vec<CliId>> {
-        self.parse_with(entity, changes_in_commit_fn, SourceScope::UncommittedOnly)
+        self.parse_with(entity, changes_in_commit, SourceScope::UncommittedOnly)
     }
 
-    fn parse_with<'a>(
-        &'a self,
+    fn parse_with(
+        &self,
         entity: &str,
-        mut changes_in_commit_fn: ChangesInCommitFn<'a>,
+        changes_in_commit: &dyn ChangesInCommit,
         scope: SourceScope,
     ) -> anyhow::Result<Vec<CliId>> {
         let mut cli_ids = Vec::new();
@@ -1456,8 +1570,8 @@ impl IdMap {
                 // `a:filename:with:colon:b` will parse to `a`,
                 // `filename:with:colon`, `b`).
                 for node in self.parse_element_scoped(lhs, scope)? {
-                    for node in node.parse(mhs, self, &mut changes_in_commit_fn)? {
-                        for node in node.parse(rhs, self, &mut changes_in_commit_fn)? {
+                    for node in node.parse(mhs, self, changes_in_commit)? {
+                        for node in node.parse(rhs, self, changes_in_commit)? {
                             if let Some(cli_id) = node.to_cli_id(entity, self)? {
                                 cli_ids.push(cli_id);
                             }
@@ -1466,7 +1580,7 @@ impl IdMap {
                 }
             } else {
                 for node in self.parse_element_scoped(lhs, scope)? {
-                    for node in node.parse(rhs, self, &mut changes_in_commit_fn)? {
+                    for node in node.parse(rhs, self, changes_in_commit)? {
                         if let Some(cli_id) = node.to_cli_id(entity, self)? {
                             cli_ids.push(cli_id);
                         }
@@ -1493,41 +1607,36 @@ impl IdMap {
 
         Ok(deduped)
     }
-    /// Convenience for [IdMap::parse] if a [gix::Repository] is available.
+    /// Parse IDs using a [gix::Repository] to inspect committed changes.
     pub fn parse_using_repo<'a>(
         &'a self,
         entity: &str,
         repo: &'a gix::Repository,
     ) -> anyhow::Result<Vec<CliId>> {
-        self.parse(
-            entity,
-            Box::new(move |commit_id, parent_id| {
-                but_core::diff::tree_changes(repo, parent_id, commit_id)
-            }),
-        )
+        let changes_in_commit = ChangesInCommitImpl { repo };
+
+        self.parse(entity, &changes_in_commit)
     }
 
-    /// Convenience for [IdMap::parse] if a [Context] is available.
+    /// Convenience for [IdMap::parse_using_repo] if a [Context] is available.
     pub fn parse_using_context(&self, entity: &str, ctx: &Context) -> anyhow::Result<Vec<CliId>> {
         let repo = &*ctx.repo.get()?;
         self.parse_using_repo(entity, repo)
     }
 
-    /// Convenience for [IdMap::parse_uncommitted] if a [gix::Repository] is available.
+    /// Parse uncommitted IDs using a [gix::Repository].
     pub fn parse_uncommitted_using_repo<'a>(
         &'a self,
         entity: &str,
         repo: &'a gix::Repository,
     ) -> anyhow::Result<Vec<CliId>> {
-        self.parse_uncommitted(
-            entity,
-            Box::new(move |commit_id, parent_id| {
-                but_core::diff::tree_changes(repo, parent_id, commit_id)
-            }),
-        )
+        // TODO simplify - no need for changes in commit when parsing uncommitted only
+        let changes_in_commit = ChangesInCommitImpl { repo };
+
+        self.parse_uncommitted(entity, &changes_in_commit)
     }
 
-    /// Convenience for [IdMap::parse_uncommitted] if a [Context] is available.
+    /// Convenience for [IdMap::parse_uncommitted_using_repo] if a [Context] is available.
     pub fn parse_uncommitted_using_context(
         &self,
         entity: &str,
@@ -1608,6 +1717,7 @@ fn cli_ids_refer_to_same_entity(lhs: &CliId, rhs: &CliId) -> bool {
                 id: _,
             },
         ) => l == r,
+        (CliId::CommittedHunk(l), CliId::CommittedHunk(r)) => l == r,
         (CliId::Branch(l), CliId::Branch(r)) => l == r,
         (
             CliId::Stack {
@@ -1653,6 +1763,23 @@ pub struct UncommittedHunkOrFile {
     pub is_entire_file: bool,
     /// The checkout these hunks were read from.
     pub source: ChangeSourceId,
+}
+
+#[derive(Debug, Clone)]
+/// A committed hunk.
+pub struct CommittedHunk {
+    /// The committed file to which the hunk belongs.
+    pub committed_file: CommittedFileId,
+    /// The short ID of this hunk.
+    pub id: ShortId,
+    /// The hunk itself.
+    pub hunk: but_core::SingleHunk,
+}
+
+impl PartialEq for CommittedHunk {
+    fn eq(&self, other: &Self) -> bool {
+        self.committed_file == other.committed_file && self.hunk.identifies_same_hunk(&other.hunk)
+    }
 }
 
 impl PartialEq for UncommittedHunkOrFile {
@@ -1724,6 +1851,8 @@ pub enum CliId {
         /// The short CLI ID for this file (typically 2 characters)
         id: ShortId,
     },
+    /// A committed hunk
+    CommittedHunk(CommittedHunk),
     /// A branch.
     Branch(BranchId),
     /// A commit in the workspace identified by its SHA.
@@ -1772,6 +1901,7 @@ impl PartialEq for CliId {
                     id: _,
                 },
             ) => l == r,
+            (CliId::CommittedHunk(l), CliId::CommittedHunk(r)) => l == r,
             (Self::Branch(l), Self::Branch(r)) => l == r,
             (Self::Commit { commit: l, id: _ }, Self::Commit { commit: r, id: _ }) => l == r,
             (Self::Stack { id: l_id, .. }, Self::Stack { id: r_id, .. }) => l_id == r_id,
@@ -1792,6 +1922,7 @@ impl CliId {
             CliId::UncommittedHunkOrFile { .. } => "an uncommitted file or hunk",
             CliId::PathPrefix { .. } => "a path prefix",
             CliId::CommittedFile { .. } => "a committed file",
+            CliId::CommittedHunk { .. } => "a committed file or hunk",
             CliId::Branch(..) => "a branch",
             CliId::Commit { .. } => "a commit",
             CliId::Uncommitted { .. } => "the uncommitted area",
@@ -1806,6 +1937,7 @@ impl CliId {
             CliId::UncommittedHunkOrFile(UncommittedHunkOrFile { id, .. })
             | CliId::PathPrefix { id, .. }
             | CliId::CommittedFile { id, .. }
+            | CliId::CommittedHunk(CommittedHunk { id, .. })
             | CliId::Branch(BranchId { id, .. })
             | CliId::Commit { id, .. }
             | CliId::Stack { id, .. }
@@ -1822,6 +1954,7 @@ impl CliId {
             CliId::PathPrefix { .. }
             | CliId::UncommittedHunkOrFile(..)
             | CliId::CommittedFile { .. }
+            | CliId::CommittedHunk { .. }
             | CliId::Commit { .. }
             | CliId::Worktree { .. }
             | CliId::Uncommitted { .. } => None,
@@ -1882,7 +2015,7 @@ impl<'a> Node<'a> for &'a UncommittedFile {
         self: Box<Self>,
         element: &str,
         _id_map: &'a IdMap,
-        _changes_in_commit_fn: &mut ChangesInCommitFn<'a>,
+        _changes_in_commit: &dyn ChangesInCommit,
     ) -> anyhow::Result<Vec<Box<dyn Node<'a> + 'a>>> {
         match element.strip_prefix(INDEX_SEPARATOR) {
             Some(maybe_index) if let Ok(index) = usize::from_str(maybe_index) => {
@@ -1949,7 +2082,7 @@ impl<'a> Node<'a> for &'a UncommittedHunk {
         self: Box<Self>,
         _element: &str,
         _id_map: &'a IdMap,
-        _changes_in_commit_fn: &mut ChangesInCommitFn<'a>,
+        _changes_in_commit: &dyn ChangesInCommit,
     ) -> anyhow::Result<Vec<Box<dyn Node<'a> + 'a>>> {
         Ok(Vec::new())
     }

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -309,17 +309,10 @@ impl<'a> Node<'a> for CommittedFile {
         let mut hunks: Vec<but_core::SingleHunk> = vec![];
 
         for tree_change in self.tree_changes.iter() {
-            let Some(patch @ but_core::UnifiedPatch::Patch { .. }) =
-                changes_in_commit.patch_for_tree_change(tree_change, id_map.diff_context_lines)?
-            else {
-                // If it's anything but a Patch variant, we can't possibly refer to a hunk inside of it
-                continue;
-            };
+            let patch =
+                changes_in_commit.patch_for_tree_change(tree_change, id_map.diff_context_lines)?;
 
-            hunks.extend(but_core::SingleHunk::from_tree_change(
-                tree_change,
-                Some(patch),
-            ));
+            hunks.extend(but_core::SingleHunk::from_tree_change(tree_change, patch));
         }
 
         let mut short_ids_and_hunks: Vec<_> = hunks

--- a/crates/but/src/id/tests.rs
+++ b/crates/but/src/id/tests.rs
@@ -1,3 +1,10 @@
+//! Explicit low-level tests for the IdMap.
+//!
+//! Some more complex state is very laborious and error prone to setup, such as for resolving
+//! committed and uncommitted hunks. This is sparsely tested here. There are complimentary
+//! `but`-level tests in `crates/but/tests/but/command/expand.rs` that validate this functionality
+//! more closely.
+
 use anyhow::bail;
 use bstr::BString;
 use but_core::{ChangeId, ref_metadata::StackId};
@@ -8,9 +15,57 @@ use snapbox::{assert_data_eq, prelude::*};
 use crate::{
     CliId, IdMap,
     args::atoms::CliIdArg,
-    id::{BranchId, CommitId, id_usage::UintId},
+    id::{BranchId, ChangesInCommit, CommitId, id_usage::UintId},
     utils::change_source::ChangeSourceId,
 };
+
+struct TestChanges<T>(T);
+
+impl<T> ChangesInCommit for TestChanges<T>
+where
+    T: Fn(gix::ObjectId, Option<gix::ObjectId>) -> anyhow::Result<Vec<but_core::TreeChange>>,
+{
+    fn tree_changes(
+        &self,
+        commit_id: gix::ObjectId,
+        parent_id: Option<gix::ObjectId>,
+    ) -> anyhow::Result<Vec<but_core::TreeChange>> {
+        self.0(commit_id, parent_id)
+    }
+
+    fn patch_for_tree_change(
+        &self,
+        _tree_change: &but_core::TreeChange,
+        _context_lines: u32,
+    ) -> anyhow::Result<Option<but_core::UnifiedPatch>> {
+        unimplemented!("Test patch resolution not implemented!")
+    }
+}
+
+#[test]
+fn committed_hunk_equality() {
+    let committed_hunk = |commit_id| super::CommittedHunk {
+        committed_file: super::CommittedFileId {
+            commit_id,
+            path: BString::from("file.txt"),
+            change_id: None,
+        },
+        id: "ignored by equality".into(),
+        hunk: hunk("file.txt"),
+    };
+
+    assert_eq!(
+        committed_hunk(id(1)),
+        committed_hunk(id(1)),
+        "same hunk in same commit is equal to itself"
+    );
+
+    assert_ne!(
+        committed_hunk(id(1)),
+        committed_hunk(id(2)),
+        "identical hunks in different commits are not equal"
+    );
+}
 
 #[test]
 fn uint_id_from_short_id() {
@@ -57,6 +112,7 @@ fn commit_id_works_with_two_or_more_characters() -> anyhow::Result<()> {
         Vec::new(),
         gix::hashtable::HashMap::default(),
         Default::default(),
+        3,
     )?;
     snapbox::assert_data_eq!(
         id_map.debug_state().to_debug(),
@@ -81,12 +137,12 @@ branches: [ no ]
         id: "0".to_string(),
     }];
     assert_eq!(
-        id_map.parse("0", Box::new(changed_paths_fn))?,
+        id_map.parse("0", &TestChanges(changed_paths_fn))?,
         expected,
         "one character is sufficient to parse a commit ID"
     );
     assert_eq!(
-        id_map.parse("01", Box::new(changed_paths_fn))?,
+        id_map.parse("01", &TestChanges(changed_paths_fn))?,
         expected,
         "two characters work too"
     );
@@ -105,6 +161,7 @@ fn commit_id_appearing_multiple_times() -> anyhow::Result<()> {
         Vec::new(),
         gix::hashtable::HashMap::default(),
         Default::default(),
+        3,
     )?;
     let changed_paths_fn = |commit_id: gix::ObjectId,
                             parent_id: Option<gix::ObjectId>|
@@ -114,7 +171,9 @@ fn commit_id_appearing_multiple_times() -> anyhow::Result<()> {
 
     // The commit should only appear once with a short ID.
     snapbox::assert_data_eq!(
-        id_map.parse("01", Box::new(changed_paths_fn))?.to_debug(),
+        id_map
+            .parse("01", &TestChanges(changed_paths_fn))?
+            .to_debug(),
         snapbox::str![[r#"
 [
     Commit {
@@ -142,6 +201,7 @@ fn commit_ids_become_longer_if_ambiguous() -> anyhow::Result<()> {
         Vec::new(),
         gix::hashtable::HashMap::default(),
         Default::default(),
+        3,
     )?;
     snapbox::assert_data_eq!(
         id_map.debug_state().to_debug(),
@@ -218,11 +278,14 @@ fn exact_branch_short_id_takes_priority() {
             .into_iter()
             .collect(),
         Default::default(),
+        3,
     )
     .unwrap();
 
     assert_eq!(
-        id_map.parse("tp", Box::new(|_, _| unreachable!())).unwrap(),
+        id_map
+            .parse("tp", &TestChanges(|_, _| unreachable!()))
+            .unwrap(),
         [CliId::Branch(BranchId {
             name: "tp-branch".into(),
             id: "tp".into(),
@@ -240,6 +303,7 @@ fn branches_work_with_single_character() -> anyhow::Result<()> {
         Vec::new(),
         gix::hashtable::HashMap::default(),
         Default::default(),
+        3,
     )?;
     let changed_paths_fn = |commit_id: gix::ObjectId,
                             parent_id: Option<gix::ObjectId>|
@@ -262,12 +326,12 @@ branches: [ g0 ]
         stack_id: None,
     })];
     assert_eq!(
-        id_map.parse("f", Box::new(changed_paths_fn))?,
+        id_map.parse("f", &TestChanges(changed_paths_fn))?,
         expected,
         "it's OK to have a CliID that is longer, but it would be up to the UI to not show them"
     );
     assert_eq!(
-        id_map.parse("g0", Box::new(changed_paths_fn))?,
+        id_map.parse("g0", &TestChanges(changed_paths_fn))?,
         expected,
         "the ID also works"
     );
@@ -282,6 +346,7 @@ fn branches_avoid_uncommitted_area_id() -> anyhow::Result<()> {
         Vec::new(),
         gix::hashtable::HashMap::default(),
         Default::default(),
+        3,
     )?;
     let changed_paths_fn = |commit_id: gix::ObjectId,
                             parent_id: Option<gix::ObjectId>|
@@ -304,7 +369,7 @@ branches: [ za ]
         stack_id: None,
     })];
     assert_eq!(
-        id_map.parse("za", Box::new(changed_paths_fn))?,
+        id_map.parse("za", &TestChanges(changed_paths_fn))?,
         expected,
         "avoids uncommitted area ID (zz)"
     );
@@ -322,6 +387,7 @@ fn branches_avoid_invalid_ids() -> anyhow::Result<()> {
         Vec::new(),
         gix::hashtable::HashMap::default(),
         Default::default(),
+        3,
     )?;
     snapbox::assert_data_eq!(
         id_map.debug_state().to_debug(),
@@ -344,7 +410,7 @@ branches: [ ax, yz ]
         stack_id: None,
     })];
     assert_eq!(
-        id_map.parse("yz", Box::new(changed_paths_fn))?,
+        id_map.parse("yz", &TestChanges(changed_paths_fn))?,
         expected,
         "avoids non-alphanumeric, taking first alphanumeric pair"
     );
@@ -354,7 +420,7 @@ branches: [ ax, yz ]
         stack_id: None,
     })];
     assert_eq!(
-        id_map.parse("ax", Box::new(changed_paths_fn))?,
+        id_map.parse("ax", &TestChanges(changed_paths_fn))?,
         expected,
         "avoids hexdigit pair which can be confused with a commit ID"
     );
@@ -370,6 +436,7 @@ fn branches_avoid_uncommitted_filenames() -> anyhow::Result<()> {
         vec![source_changes(ChangeSourceId::Head, hunks)],
         gix::hashtable::HashMap::default(),
         Default::default(),
+        3,
     )?;
     let changed_paths_fn = |commit_id: gix::ObjectId,
                             parent_id: Option<gix::ObjectId>|
@@ -394,7 +461,7 @@ uncommitted_hunks: [ nx:q, yz:q ]
         stack_id: None,
     })];
     assert_eq!(
-        id_map.parse("ghij", Box::new(changed_paths_fn))?,
+        id_map.parse("ghij", &TestChanges(changed_paths_fn))?,
         expected,
         "avoids 'gh' and 'hi', which conflict with filenames"
     );
@@ -423,6 +490,7 @@ fn many_uncommitted_files_do_not_exhaust_generated_ids() -> anyhow::Result<()> {
         vec![source_changes(ChangeSourceId::Head, hunks)],
         gix::hashtable::HashMap::default(),
         Default::default(),
+        3,
     )?;
 
     assert_eq!(
@@ -437,7 +505,7 @@ fn many_uncommitted_files_do_not_exhaust_generated_ids() -> anyhow::Result<()> {
         .expect("at least one uncommitted file")
         .short_id
         .clone();
-    let resolved_file = id_map.parse(&file_id, Box::new(|_, _| unreachable!()))?;
+    let resolved_file = id_map.parse(&file_id, &TestChanges(|_, _| unreachable!()))?;
     assert!(matches!(
         resolved_file.as_slice(),
         [CliId::UncommittedHunkOrFile(_)]
@@ -455,7 +523,7 @@ fn many_uncommitted_files_do_not_exhaust_generated_ids() -> anyhow::Result<()> {
             !real_ids[..index].contains(real_id),
             "real IDs should be unique"
         );
-        let resolved = id_map.parse(real_id, Box::new(|_, _| unreachable!()))?;
+        let resolved = id_map.parse(real_id, &TestChanges(|_, _| unreachable!()))?;
         assert!(
             matches!(
                 resolved.as_slice(),
@@ -479,6 +547,7 @@ fn branch_that_is_substring_of_other_substring_still_gets_id() -> anyhow::Result
         Vec::new(),
         gix::hashtable::HashMap::default(),
         Default::default(),
+        3,
     )?;
     let changed_paths_fn = |commit_id: gix::ObjectId,
                             parent_id: Option<gix::ObjectId>|
@@ -500,14 +569,17 @@ branches: [ su, up ]
         id: "su".into(),
         stack_id: None,
     })];
-    assert_eq!(id_map.parse("su", Box::new(changed_paths_fn))?, expected,);
+    assert_eq!(
+        id_map.parse("su", &TestChanges(changed_paths_fn))?,
+        expected,
+    );
     let expected = [CliId::Branch(BranchId {
         name: "supersubstring".into(),
         id: "up".into(),
         stack_id: None,
     })];
     assert_eq!(
-        id_map.parse("supersubstring", Box::new(changed_paths_fn))?,
+        id_map.parse("supersubstring", &TestChanges(changed_paths_fn))?,
         expected,
         "'su' would collide with substring, so 'up' is chosen"
     );
@@ -536,6 +608,7 @@ fn non_commit_ids_do_not_collide() -> anyhow::Result<()> {
         vec![source_changes(ChangeSourceId::Head, hunks)],
         gix::hashtable::HashMap::default(),
         Default::default(),
+        3,
     )?;
     snapbox::assert_data_eq!(
         id_map.debug_state().to_debug(),
@@ -705,6 +778,7 @@ fn uncommitted_file_to_id_qualifies_hunk_ids() -> anyhow::Result<()> {
         vec![source_changes(ChangeSourceId::Head, hunks)],
         gix::hashtable::HashMap::default(),
         Default::default(),
+        3,
     )?;
     let uncommitted_file = id_map
         .uncommitted_files
@@ -741,6 +815,7 @@ fn ids_are_case_sensitive() -> anyhow::Result<()> {
         vec![source_changes(ChangeSourceId::Head, hunks)],
         gix::hashtable::HashMap::default(),
         Default::default(),
+        3,
     )?;
     let changed_paths_fn = |commit_id: gix::ObjectId,
                             parent_id: Option<gix::ObjectId>|
@@ -764,7 +839,9 @@ uncommitted_hunks: [ ln:q ]
     );
 
     snapbox::assert_data_eq!(
-        id_map.parse("0a", Box::new(changed_paths_fn))?.to_debug(),
+        id_map
+            .parse("0a", &TestChanges(changed_paths_fn))?
+            .to_debug(),
         snapbox::str![[r#"
 [
     Commit {
@@ -779,13 +856,15 @@ uncommitted_hunks: [ ln:q ]
 "#]]
     );
     assert_eq!(
-        id_map.parse("0A", Box::new(changed_paths_fn))?,
+        id_map.parse("0A", &TestChanges(changed_paths_fn))?,
         [],
         "the case matters for commits"
     );
 
     snapbox::assert_data_eq!(
-        id_map.parse("h0", Box::new(changed_paths_fn))?.to_debug(),
+        id_map
+            .parse("h0", &TestChanges(changed_paths_fn))?
+            .to_debug(),
         snapbox::str![[r#"
 [
     Branch(
@@ -800,13 +879,15 @@ uncommitted_hunks: [ ln:q ]
 "#]]
     );
     assert_eq!(
-        id_map.parse("H0", Box::new(changed_paths_fn))?,
+        id_map.parse("H0", &TestChanges(changed_paths_fn))?,
         [],
         "the case matters for branches"
     );
 
     snapbox::assert_data_eq!(
-        id_map.parse("ln", Box::new(changed_paths_fn))?.to_debug(),
+        id_map
+            .parse("ln", &TestChanges(changed_paths_fn))?
+            .to_debug(),
         snapbox::str![[r#"
 [
     UncommittedHunkOrFile(
@@ -832,14 +913,14 @@ uncommitted_hunks: [ ln:q ]
 "#]]
     );
     assert_eq!(
-        id_map.parse("LN", Box::new(changed_paths_fn))?,
+        id_map.parse("LN", &TestChanges(changed_paths_fn))?,
         [],
         "the case matters for uncommitted files"
     );
 
     snapbox::assert_data_eq!(
         id_map
-            .parse("0a:zt", Box::new(changed_paths_fn))?
+            .parse("0a:zt", &TestChanges(changed_paths_fn))?
             .to_debug(),
         snapbox::str![[r#"
 [
@@ -856,7 +937,7 @@ uncommitted_hunks: [ ln:q ]
 "#]]
     );
     assert_eq!(
-        id_map.parse("0a:ZT", Box::new(changed_paths_fn))?,
+        id_map.parse("0a:ZT", &TestChanges(changed_paths_fn))?,
         [],
         "the case matters for committed files"
     );
@@ -873,6 +954,7 @@ fn uncommitted_files_disambiguate_between_themselves() -> anyhow::Result<()> {
         vec![source_changes(ChangeSourceId::Head, hunks)],
         gix::hashtable::HashMap::default(),
         Default::default(),
+        3,
     )?;
     let changed_paths_fn = |commit_id: gix::ObjectId,
                             parent_id: Option<gix::ObjectId>|
@@ -886,7 +968,9 @@ fn uncommitted_files_disambiguate_between_themselves() -> anyhow::Result<()> {
 
     // Ambiguous ID returns every possible match
     snapbox::assert_data_eq!(
-        id_map.parse("kp", Box::new(changed_paths_fn))?.to_debug(),
+        id_map
+            .parse("kp", &TestChanges(changed_paths_fn))?
+            .to_debug(),
         snapbox::str![[r#"
 [
     UncommittedHunkOrFile(
@@ -931,7 +1015,9 @@ fn uncommitted_files_disambiguate_between_themselves() -> anyhow::Result<()> {
     );
 
     snapbox::assert_data_eq!(
-        id_map.parse("kpo", Box::new(changed_paths_fn))?.to_debug(),
+        id_map
+            .parse("kpo", &TestChanges(changed_paths_fn))?
+            .to_debug(),
         snapbox::str![[r#"
 [
     UncommittedHunkOrFile(
@@ -957,7 +1043,9 @@ fn uncommitted_files_disambiguate_between_themselves() -> anyhow::Result<()> {
 "#]]
     );
     snapbox::assert_data_eq!(
-        id_map.parse("kpr", Box::new(changed_paths_fn))?.to_debug(),
+        id_map
+            .parse("kpr", &TestChanges(changed_paths_fn))?
+            .to_debug(),
         snapbox::str![[r#"
 [
     UncommittedHunkOrFile(
@@ -1002,6 +1090,7 @@ fn same_path_in_several_sources_gets_distinct_ids() -> anyhow::Result<()> {
         ],
         gix::hashtable::HashMap::default(),
         Default::default(),
+        3,
     )?;
 
     let ids: Vec<_> = id_map
@@ -1054,6 +1143,7 @@ fn worktree_container_id() -> anyhow::Result<()> {
         ],
         gix::hashtable::HashMap::default(),
         Default::default(),
+        3,
     )?;
     let changed_paths_fn = |commit_id: gix::ObjectId,
                             parent_id: Option<gix::ObjectId>|
@@ -1061,7 +1151,7 @@ fn worktree_container_id() -> anyhow::Result<()> {
         bail!("unexpected IDs {commit_id} {parent_id:?}");
     };
 
-    let by_name = id_map.parse("wt-a", Box::new(changed_paths_fn))?;
+    let by_name = id_map.parse("wt-a", &TestChanges(changed_paths_fn))?;
     snapbox::assert_data_eq!(
         by_name.to_debug(),
         snapbox::str![[r#"
@@ -1077,7 +1167,7 @@ fn worktree_container_id() -> anyhow::Result<()> {
 
     // The short ID resolves to the same worktree.
     let short_id = by_name[0].to_short_string();
-    let by_id = id_map.parse(&short_id, Box::new(changed_paths_fn))?;
+    let by_id = id_map.parse(&short_id, &TestChanges(changed_paths_fn))?;
     assert_eq!(by_id, by_name, "name and short ID name the same worktree");
 
     let one_char_prefix = short_id
@@ -1087,13 +1177,13 @@ fn worktree_container_id() -> anyhow::Result<()> {
         .to_string();
     assert!(
         id_map
-            .parse(&one_char_prefix, Box::new(changed_paths_fn))?
+            .parse(&one_char_prefix, &TestChanges(changed_paths_fn))?
             .is_empty(),
         "worktree short IDs require an exact match"
     );
 
     // `<worktree>:<path>` disambiguates a path that is dirty in several checkouts.
-    let scoped = id_map.parse("wt-a:file", Box::new(changed_paths_fn))?;
+    let scoped = id_map.parse("wt-a:file", &TestChanges(changed_paths_fn))?;
     assert_eq!(scoped.len(), 1, "scoped to one checkout");
     let CliId::UncommittedHunkOrFile(scoped) = &scoped[0] else {
         bail!("expected an uncommitted file, got {scoped:?}");
@@ -1134,6 +1224,7 @@ fn branch_and_worktree_short_ids_do_not_collide() -> anyhow::Result<()> {
         )],
         gix::hashtable::HashMap::default(),
         Default::default(),
+        3,
     )?;
 
     snapbox::assert_data_eq!(
@@ -1164,6 +1255,7 @@ fn generated_branch_ids_do_not_collide_with_worktree_names() -> anyhow::Result<(
         ],
         gix::hashtable::HashMap::default(),
         Default::default(),
+        3,
     )?;
 
     let branch_ids = id_map.branch_ids();
@@ -1191,7 +1283,7 @@ fn generated_branch_ids_do_not_collide_with_worktree_names() -> anyhow::Result<(
     };
     for worktree in id_map.worktrees.values() {
         assert_eq!(
-            id_map.parse(&worktree.short_id, Box::new(changed_paths_fn))?,
+            id_map.parse(&worktree.short_id, &TestChanges(changed_paths_fn))?,
             [CliId::Worktree {
                 id: worktree.short_id.clone(),
                 name: worktree.name.clone(),
@@ -1215,6 +1307,7 @@ fn zz_scopes_filenames_to_the_main_worktree() -> anyhow::Result<()> {
         ],
         gix::hashtable::HashMap::default(),
         Default::default(),
+        3,
     )?;
     let changed_paths_fn = |commit_id: gix::ObjectId,
                             parent_id: Option<gix::ObjectId>|
@@ -1222,7 +1315,7 @@ fn zz_scopes_filenames_to_the_main_worktree() -> anyhow::Result<()> {
         bail!("unexpected IDs {commit_id} {parent_id:?}");
     };
 
-    let scoped = id_map.parse("zz:file", Box::new(changed_paths_fn))?;
+    let scoped = id_map.parse("zz:file", &TestChanges(changed_paths_fn))?;
     assert_eq!(scoped.len(), 1, "`zz` only ever matches the main worktree");
     let CliId::UncommittedHunkOrFile(scoped) = &scoped[0] else {
         bail!("expected an uncommitted file, got {scoped:?}");
@@ -1235,7 +1328,7 @@ fn zz_scopes_filenames_to_the_main_worktree() -> anyhow::Result<()> {
 
     // A bare filename is deliberately unscoped, so it reports both and the
     // caller turns that into an ambiguity error.
-    let unscoped = id_map.parse("file", Box::new(changed_paths_fn))?;
+    let unscoped = id_map.parse("file", &TestChanges(changed_paths_fn))?;
     assert_eq!(
         unscoped.len(),
         2,
@@ -1262,6 +1355,7 @@ fn uncommitted_files_disambiguate_with_branch() -> anyhow::Result<()> {
         vec![source_changes(ChangeSourceId::Head, hunks)],
         gix::hashtable::HashMap::default(),
         Default::default(),
+        3,
     )?;
     let changed_paths_fn = |commit_id: gix::ObjectId,
                             parent_id: Option<gix::ObjectId>|
@@ -1275,7 +1369,9 @@ fn uncommitted_files_disambiguate_with_branch() -> anyhow::Result<()> {
 
     // Only the branch is returned when querying by short ID
     snapbox::assert_data_eq!(
-        id_map.parse("qs", Box::new(changed_paths_fn))?.to_debug(),
+        id_map
+            .parse("qs", &TestChanges(changed_paths_fn))?
+            .to_debug(),
         snapbox::str![[r#"
 [
     Branch(
@@ -1292,7 +1388,9 @@ fn uncommitted_files_disambiguate_with_branch() -> anyhow::Result<()> {
 
     // Still only the branch when querying by full name
     snapbox::assert_data_eq!(
-        id_map.parse("qsy", Box::new(changed_paths_fn))?.to_debug(),
+        id_map
+            .parse("qsy", &TestChanges(changed_paths_fn))?
+            .to_debug(),
         snapbox::str![[r#"
 [
     Branch(
@@ -1309,7 +1407,9 @@ fn uncommitted_files_disambiguate_with_branch() -> anyhow::Result<()> {
 
     // More characters must be specified to get the file
     snapbox::assert_data_eq!(
-        id_map.parse("qsyn", Box::new(changed_paths_fn))?.to_debug(),
+        id_map
+            .parse("qsyn", &TestChanges(changed_paths_fn))?
+            .to_debug(),
         snapbox::str![[r#"
 [
     UncommittedHunkOrFile(
@@ -1347,6 +1447,7 @@ fn longer_id_is_ok() -> anyhow::Result<()> {
         vec![source_changes(ChangeSourceId::Head, hunks)],
         gix::hashtable::HashMap::default(),
         Default::default(),
+        3,
     )?;
     let changed_paths_fn = |commit_id: gix::ObjectId,
                             parent_id: Option<gix::ObjectId>|
@@ -1360,7 +1461,9 @@ fn longer_id_is_ok() -> anyhow::Result<()> {
 
     // "kp" would be sufficient (see the "id" field in the output), but "kpr" works too
     snapbox::assert_data_eq!(
-        id_map.parse("kpr", Box::new(changed_paths_fn))?.to_debug(),
+        id_map
+            .parse("kpr", &TestChanges(changed_paths_fn))?
+            .to_debug(),
         snapbox::str![[r#"
 [
     UncommittedHunkOrFile(
@@ -1398,6 +1501,7 @@ fn reverse_hex_filename_is_its_own_id() -> anyhow::Result<()> {
         vec![source_changes(ChangeSourceId::Head, hunks)],
         gix::hashtable::HashMap::default(),
         Default::default(),
+        3,
     )?;
     let changed_paths_fn = |commit_id: gix::ObjectId,
                             parent_id: Option<gix::ObjectId>|
@@ -1411,7 +1515,9 @@ fn reverse_hex_filename_is_its_own_id() -> anyhow::Result<()> {
 
     // "klmxyz" does not have an autogenerated ID
     snapbox::assert_data_eq!(
-        id_map.parse("kl", Box::new(changed_paths_fn))?.to_debug(),
+        id_map
+            .parse("kl", &TestChanges(changed_paths_fn))?
+            .to_debug(),
         snapbox::str![[r#"
 [
     UncommittedHunkOrFile(
@@ -1449,6 +1555,7 @@ fn branch_and_file_by_name() -> anyhow::Result<()> {
         vec![source_changes(ChangeSourceId::Head, hunks)],
         gix::hashtable::HashMap::default(),
         Default::default(),
+        3,
     )?;
     let changed_paths_fn = |commit_id: gix::ObjectId,
                             parent_id: Option<gix::ObjectId>|
@@ -1464,7 +1571,9 @@ fn branch_and_file_by_name() -> anyhow::Result<()> {
     // have priority over the other (i.e. if there is both a branch and a file
     // that matches, the result is ambiguous).
     snapbox::assert_data_eq!(
-        id_map.parse("foo", Box::new(changed_paths_fn))?.to_debug(),
+        id_map
+            .parse("foo", &TestChanges(changed_paths_fn))?
+            .to_debug(),
         snapbox::str![[r#"
 [
     Branch(
@@ -1512,6 +1621,7 @@ fn colon_uncommitted_filename() -> anyhow::Result<()> {
         vec![source_changes(ChangeSourceId::Head, hunks)],
         gix::hashtable::HashMap::default(),
         Default::default(),
+        3,
     )?;
     let changed_paths_fn = |commit_id: gix::ObjectId,
                             parent_id: Option<gix::ObjectId>|
@@ -1522,7 +1632,7 @@ fn colon_uncommitted_filename() -> anyhow::Result<()> {
     // Short branch works
     snapbox::assert_data_eq!(
         id_map
-            .parse("gg@{stack}:assigned", Box::new(changed_paths_fn))?
+            .parse("gg@{stack}:assigned", &TestChanges(changed_paths_fn))?
             .to_debug(),
         snapbox::str![[r#"
 [
@@ -1552,7 +1662,7 @@ fn colon_uncommitted_filename() -> anyhow::Result<()> {
     // Long branch works
     snapbox::assert_data_eq!(
         id_map
-            .parse("gggg@{stack}:assigned", Box::new(changed_paths_fn))?
+            .parse("gggg@{stack}:assigned", &TestChanges(changed_paths_fn))?
             .to_debug(),
         snapbox::str![[r#"
 [
@@ -1582,7 +1692,7 @@ fn colon_uncommitted_filename() -> anyhow::Result<()> {
     // Uncommitted works
     snapbox::assert_data_eq!(
         id_map
-            .parse("zz:uncommitted", Box::new(changed_paths_fn))?
+            .parse("zz:uncommitted", &TestChanges(changed_paths_fn))?
             .to_debug(),
         snapbox::str![[r#"
 [
@@ -1621,6 +1731,7 @@ fn uncommitted_path() -> anyhow::Result<()> {
         vec![source_changes(ChangeSourceId::Head, hunks)],
         gix::hashtable::HashMap::default(),
         Default::default(),
+        3,
     )?;
     let changed_paths_fn = |commit_id: gix::ObjectId,
                             parent_id: Option<gix::ObjectId>|
@@ -1631,7 +1742,7 @@ fn uncommitted_path() -> anyhow::Result<()> {
     // Returns one ID with all hunk assignments
     snapbox::assert_data_eq!(
         id_map
-            .parse("prefix/", Box::new(changed_paths_fn))?
+            .parse("prefix/", &TestChanges(changed_paths_fn))?
             .to_debug(),
         snapbox::str![[r#"
 [
@@ -1667,7 +1778,7 @@ fn uncommitted_path() -> anyhow::Result<()> {
     // If nothing matches, returns no ID
     snapbox::assert_data_eq!(
         id_map
-            .parse("doesnotmatch/", Box::new(changed_paths_fn))?
+            .parse("doesnotmatch/", &TestChanges(changed_paths_fn))?
             .to_debug(),
         snapbox::str![[r#"
 []
@@ -1675,6 +1786,51 @@ fn uncommitted_path() -> anyhow::Result<()> {
 "#]]
     );
 
+    Ok(())
+}
+
+/// This test represents a bad state: This shouldn't really happened, but if it does we don't want
+/// to just lose changes.
+///
+/// See [super::FileInfo::changes] for details on this situation.
+#[test]
+fn duplicate_tree_changes_for_committed_files_are_coalesced_for_short_id_assignment()
+-> anyhow::Result<()> {
+    let first = tree_change_addition("file.txt");
+    let second = but_core::TreeChange {
+        path: BString::from("file.txt"),
+        status: but_core::TreeStatus::Deletion {
+            previous_state: first.status.state().unwrap(),
+        },
+    };
+
+    let changes = super::short_ids_from_tree_changes(vec![first, second])?;
+
+    assert_eq!(
+        changes.len(),
+        1,
+        "duplicate path/commit tree change goes into single bucket"
+    );
+
+    assert_eq!(
+        changes[0].0.len(),
+        2,
+        "both tree changes are individually represented"
+    );
+    assert!(
+        matches!(
+            changes[0].0[0].status,
+            but_core::TreeStatus::Addition { .. }
+        ),
+        "first tree change is retained"
+    );
+    assert!(
+        matches!(
+            changes[0].0[1].status,
+            but_core::TreeStatus::Deletion { .. }
+        ),
+        "second tree change is retained"
+    );
     Ok(())
 }
 
@@ -1686,6 +1842,7 @@ fn committed_files_are_deduplicated_by_commit_oid_path() -> anyhow::Result<()> {
         Vec::new(),
         gix::hashtable::HashMap::default(),
         Default::default(),
+        3,
     )?;
 
     // Simulate a changed_paths function that returns the same file twice
@@ -1705,17 +1862,17 @@ fn committed_files_are_deduplicated_by_commit_oid_path() -> anyhow::Result<()> {
     };
 
     // Verify we can look up both files both by ID and filename
-    assert!(id_map.parse("02:uv", Box::new(changed_paths_fn))?.len() == 1);
-    assert!(id_map.parse("02:xw", Box::new(changed_paths_fn))?.len() == 1);
+    assert!(id_map.parse("02:uv", &TestChanges(changed_paths_fn))?.len() == 1);
+    assert!(id_map.parse("02:xw", &TestChanges(changed_paths_fn))?.len() == 1);
     assert!(
         id_map
-            .parse("02:file.txt", Box::new(changed_paths_fn))?
+            .parse("02:file.txt", &TestChanges(changed_paths_fn))?
             .len()
             == 1
     );
     assert!(
         id_map
-            .parse("02:other.txt", Box::new(changed_paths_fn))?
+            .parse("02:other.txt", &TestChanges(changed_paths_fn))?
             .len()
             == 1
     );
@@ -1737,6 +1894,7 @@ fn committed_file_can_be_referenced_by_either_change_id_or_commit_id() {
         Vec::new(),
         commit_id_to_change_id,
         Default::default(),
+        3,
     )
     .unwrap();
 
@@ -1755,7 +1913,7 @@ fn committed_file_can_be_referenced_by_either_change_id_or_commit_id() {
 
     assert_data_eq!(
         id_map
-            .parse("0:u", Box::new(changed_paths_fn))
+            .parse("0:u", &TestChanges(changed_paths_fn))
             .unwrap()
             .to_debug(),
         snapbox::str![[r#"
@@ -1776,7 +1934,7 @@ fn committed_file_can_be_referenced_by_either_change_id_or_commit_id() {
     );
     assert_data_eq!(
         id_map
-            .parse("s:u", Box::new(changed_paths_fn))
+            .parse("s:u", &TestChanges(changed_paths_fn))
             .unwrap()
             .to_debug(),
         snapbox::str![[r#"
@@ -1806,6 +1964,7 @@ fn short_uncommitted_files_are_properly_reverse_hexed() -> anyhow::Result<()> {
         vec![source_changes(ChangeSourceId::Head, hunks)],
         gix::hashtable::HashMap::default(),
         Default::default(),
+        3,
     )?;
     let changed_paths_fn = |commit_id: gix::ObjectId,
                             parent_id: Option<gix::ObjectId>|
@@ -1818,7 +1977,9 @@ fn short_uncommitted_files_are_properly_reverse_hexed() -> anyhow::Result<()> {
     };
 
     snapbox::assert_data_eq!(
-        id_map.parse("k", Box::new(changed_paths_fn))?.to_debug(),
+        id_map
+            .parse("k", &TestChanges(changed_paths_fn))?
+            .to_debug(),
         snapbox::str![[r#"
 [
     UncommittedHunkOrFile(
@@ -1845,7 +2006,9 @@ fn short_uncommitted_files_are_properly_reverse_hexed() -> anyhow::Result<()> {
     );
 
     snapbox::assert_data_eq!(
-        id_map.parse("kl", Box::new(changed_paths_fn))?.to_debug(),
+        id_map
+            .parse("kl", &TestChanges(changed_paths_fn))?
+            .to_debug(),
         snapbox::str![[r#"
 [
     UncommittedHunkOrFile(
@@ -1872,7 +2035,9 @@ fn short_uncommitted_files_are_properly_reverse_hexed() -> anyhow::Result<()> {
     );
 
     snapbox::assert_data_eq!(
-        id_map.parse("klm", Box::new(changed_paths_fn))?.to_debug(),
+        id_map
+            .parse("klm", &TestChanges(changed_paths_fn))?
+            .to_debug(),
         snapbox::str![[r#"
 [
     UncommittedHunkOrFile(
@@ -1922,6 +2087,7 @@ fn uncommitted_hunks_by_numeric_index() -> anyhow::Result<()> {
         vec![source_changes(ChangeSourceId::Head, hunks)],
         gix::hashtable::HashMap::default(),
         Default::default(),
+        3,
     )?;
     let changed_paths_fn = |commit_id: gix::ObjectId,
                             parent_id: Option<gix::ObjectId>|
@@ -1931,7 +2097,7 @@ fn uncommitted_hunks_by_numeric_index() -> anyhow::Result<()> {
 
     snapbox::assert_data_eq!(
         id_map
-            .parse("uncommitted1.txt:#0", Box::new(changed_paths_fn))?
+            .parse("uncommitted1.txt:#0", &TestChanges(changed_paths_fn))?
             .to_debug(),
         snapbox::str![[r#"
 [
@@ -1962,7 +2128,7 @@ fn uncommitted_hunks_by_numeric_index() -> anyhow::Result<()> {
     // Short IDs for the filename part also work; should return exactly the same as above
     snapbox::assert_data_eq!(
         id_map
-            .parse("ro:#0", Box::new(changed_paths_fn))?
+            .parse("ro:#0", &TestChanges(changed_paths_fn))?
             .to_debug(),
         snapbox::str![[r#"
 [
@@ -1993,7 +2159,7 @@ fn uncommitted_hunks_by_numeric_index() -> anyhow::Result<()> {
     // Files can also be accessed through zz
     snapbox::assert_data_eq!(
         id_map
-            .parse("zz:uncommitted1.txt:#0", Box::new(changed_paths_fn))?
+            .parse("zz:uncommitted1.txt:#0", &TestChanges(changed_paths_fn))?
             .to_debug(),
         snapbox::str![[r#"
 [
@@ -2069,6 +2235,7 @@ fn uncommitted_hunks_by_id() -> anyhow::Result<()> {
         vec![source_changes(ChangeSourceId::Head, hunks)],
         gix::hashtable::HashMap::default(),
         Default::default(),
+        3,
     )?;
     let changed_paths_fn = |commit_id: gix::ObjectId,
                             parent_id: Option<gix::ObjectId>|
@@ -2077,7 +2244,9 @@ fn uncommitted_hunks_by_id() -> anyhow::Result<()> {
     };
 
     snapbox::assert_data_eq!(
-        id_map.parse("ro:3", Box::new(changed_paths_fn))?.to_debug(),
+        id_map
+            .parse("ro:3", &TestChanges(changed_paths_fn))?
+            .to_debug(),
         snapbox::str![[r#"
 [
     UncommittedHunkOrFile(
@@ -2109,7 +2278,9 @@ fn uncommitted_hunks_by_id() -> anyhow::Result<()> {
     );
 
     snapbox::assert_data_eq!(
-        id_map.parse("ro:f", Box::new(changed_paths_fn))?.to_debug(),
+        id_map
+            .parse("ro:f", &TestChanges(changed_paths_fn))?
+            .to_debug(),
         snapbox::str![[r#"
 [
     UncommittedHunkOrFile(
@@ -2141,7 +2312,9 @@ fn uncommitted_hunks_by_id() -> anyhow::Result<()> {
     );
 
     snapbox::assert_data_eq!(
-        id_map.parse("ro:1", Box::new(changed_paths_fn))?.to_debug(),
+        id_map
+            .parse("ro:1", &TestChanges(changed_paths_fn))?
+            .to_debug(),
         snapbox::str![[r#"
 [
     UncommittedHunkOrFile(
@@ -2175,7 +2348,7 @@ fn uncommitted_hunks_by_id() -> anyhow::Result<()> {
     // hunk without diff gets q identifier
     snapbox::assert_data_eq!(
         id_map
-            .parse("hunk_without_diff.txt:q", Box::new(changed_paths_fn))?
+            .parse("hunk_without_diff.txt:q", &TestChanges(changed_paths_fn))?
             .to_debug(),
         snapbox::str![[r#"
 [
@@ -2237,6 +2410,7 @@ fn uncommitted_hunks_by_id_increase_id_length_as_necessary() -> anyhow::Result<(
         vec![source_changes(ChangeSourceId::Head, hunks)],
         gix::hashtable::HashMap::default(),
         Default::default(),
+        3,
     )?;
     let changed_paths_fn = |commit_id: gix::ObjectId,
                             parent_id: Option<gix::ObjectId>|
@@ -2246,7 +2420,7 @@ fn uncommitted_hunks_by_id_increase_id_length_as_necessary() -> anyhow::Result<(
 
     snapbox::assert_data_eq!(
         id_map
-            .parse("ro:78", Box::new(changed_paths_fn))?
+            .parse("ro:78", &TestChanges(changed_paths_fn))?
             .to_debug(),
         snapbox::str![[r#"
 [
@@ -2280,7 +2454,7 @@ fn uncommitted_hunks_by_id_increase_id_length_as_necessary() -> anyhow::Result<(
 
     snapbox::assert_data_eq!(
         id_map
-            .parse("ro:79", Box::new(changed_paths_fn))?
+            .parse("ro:79", &TestChanges(changed_paths_fn))?
             .to_debug(),
         snapbox::str![[r#"
 [
@@ -2345,6 +2519,7 @@ fn uncommitted_hunks_overspecifying_id_prefix() -> anyhow::Result<()> {
         vec![source_changes(ChangeSourceId::Head, hunks)],
         gix::hashtable::HashMap::default(),
         Default::default(),
+        3,
     )?;
     let changed_paths_fn = |commit_id: gix::ObjectId,
                             parent_id: Option<gix::ObjectId>|
@@ -2354,7 +2529,7 @@ fn uncommitted_hunks_overspecifying_id_prefix() -> anyhow::Result<()> {
 
     snapbox::assert_data_eq!(
         id_map
-            .parse("ro:78", Box::new(changed_paths_fn))?
+            .parse("ro:78", &TestChanges(changed_paths_fn))?
             .to_debug(),
         snapbox::str![[r#"
 [
@@ -2425,6 +2600,7 @@ fn uncommitted_hunks_overspecifying_id_prefix_with_collision_disambiguation() ->
         vec![source_changes(ChangeSourceId::Head, hunks)],
         gix::hashtable::HashMap::default(),
         Default::default(),
+        3,
     )?;
     let changed_paths_fn = |commit_id: gix::ObjectId,
                             parent_id: Option<gix::ObjectId>|
@@ -2434,7 +2610,7 @@ fn uncommitted_hunks_overspecifying_id_prefix_with_collision_disambiguation() ->
 
     snapbox::assert_data_eq!(
         id_map
-            .parse("ro:3eeb#0-2", Box::new(changed_paths_fn))?
+            .parse("ro:3eeb#0-2", &TestChanges(changed_paths_fn))?
             .to_debug(),
         snapbox::str![[r#"
 [
@@ -2510,6 +2686,7 @@ fn underspecifying_hunk_ids() -> anyhow::Result<()> {
         vec![source_changes(ChangeSourceId::Head, hunks)],
         gix::hashtable::HashMap::default(),
         Default::default(),
+        3,
     )?;
     let changed_paths_fn = |commit_id: gix::ObjectId,
                             parent_id: Option<gix::ObjectId>|
@@ -2519,7 +2696,9 @@ fn underspecifying_hunk_ids() -> anyhow::Result<()> {
 
     // Underspecifying with just first character finds all hunks
     snapbox::assert_data_eq!(
-        id_map.parse("ro:7", Box::new(changed_paths_fn))?.to_debug(),
+        id_map
+            .parse("ro:7", &TestChanges(changed_paths_fn))?
+            .to_debug(),
         snapbox::str![[r#"
 [
     UncommittedHunkOrFile(
@@ -2597,7 +2776,7 @@ fn underspecifying_hunk_ids() -> anyhow::Result<()> {
     // Underspecifying with collision index only finds hunk with precisely matching collision index.
     snapbox::assert_data_eq!(
         id_map
-            .parse("ro:7#0-2", Box::new(changed_paths_fn))?
+            .parse("ro:7#0-2", &TestChanges(changed_paths_fn))?
             .to_debug(),
         snapbox::str![[r#"
 [
@@ -2631,7 +2810,9 @@ fn underspecifying_hunk_ids() -> anyhow::Result<()> {
 
     // An entirely empty prefix matches nothing
     snapbox::assert_data_eq!(
-        id_map.parse("ro:", Box::new(changed_paths_fn))?.to_debug(),
+        id_map
+            .parse("ro:", &TestChanges(changed_paths_fn))?
+            .to_debug(),
         snapbox::str![[r#"
 []
 
@@ -2642,7 +2823,7 @@ fn underspecifying_hunk_ids() -> anyhow::Result<()> {
     // unless you are explicitly indexing into the file's hunks
     snapbox::assert_data_eq!(
         id_map
-            .parse("ro:#0-2", Box::new(changed_paths_fn))?
+            .parse("ro:#0-2", &TestChanges(changed_paths_fn))?
             .to_debug(),
         snapbox::str![[r#"
 []
@@ -2685,6 +2866,7 @@ fn uncommitted_hunks_by_id_collision_handling() -> anyhow::Result<()> {
         vec![source_changes(ChangeSourceId::Head, hunks)],
         gix::hashtable::HashMap::default(),
         Default::default(),
+        3,
     )?;
     let changed_paths_fn = |commit_id: gix::ObjectId,
                             parent_id: Option<gix::ObjectId>|
@@ -2694,7 +2876,7 @@ fn uncommitted_hunks_by_id_collision_handling() -> anyhow::Result<()> {
 
     snapbox::assert_data_eq!(
         id_map
-            .parse("ro:3#0-2", Box::new(changed_paths_fn))?
+            .parse("ro:3#0-2", &TestChanges(changed_paths_fn))?
             .to_debug(),
         snapbox::str![[r#"
 [
@@ -2728,7 +2910,7 @@ fn uncommitted_hunks_by_id_collision_handling() -> anyhow::Result<()> {
 
     snapbox::assert_data_eq!(
         id_map
-            .parse("ro:3#1-2", Box::new(changed_paths_fn))?
+            .parse("ro:3#1-2", &TestChanges(changed_paths_fn))?
             .to_debug(),
         snapbox::str![[r#"
 [
@@ -2777,6 +2959,7 @@ fn commit_matches_are_deduplicated_by_commit_oid() -> anyhow::Result<()> {
         Vec::new(),
         gix::hashtable::HashMap::default(),
         Default::default(),
+        3,
     )?;
     let changed_paths_fn = |commit_id: gix::ObjectId,
                             parent_id: Option<gix::ObjectId>|
@@ -2784,7 +2967,7 @@ fn commit_matches_are_deduplicated_by_commit_oid() -> anyhow::Result<()> {
         bail!("unexpected IDs {commit_id} {parent_id:?}");
     };
 
-    let matches = id_map.parse("02", Box::new(changed_paths_fn))?;
+    let matches = id_map.parse("02", &TestChanges(changed_paths_fn))?;
     assert_eq!(matches.len(), 1);
     assert!(
         matches.iter().any(
@@ -2806,6 +2989,7 @@ fn dedupe_does_not_hide_ambiguity_between_distinct_commits() -> anyhow::Result<(
         Vec::new(),
         gix::hashtable::HashMap::default(),
         Default::default(),
+        3,
     )?;
     let changed_paths_fn = |commit_id: gix::ObjectId,
                             parent_id: Option<gix::ObjectId>|
@@ -2813,7 +2997,7 @@ fn dedupe_does_not_hide_ambiguity_between_distinct_commits() -> anyhow::Result<(
         bail!("unexpected IDs {commit_id} {parent_id:?}");
     };
 
-    let matches = id_map.parse("21", Box::new(changed_paths_fn))?;
+    let matches = id_map.parse("21", &TestChanges(changed_paths_fn))?;
     assert_eq!(
         matches.len(),
         2,
@@ -2846,6 +3030,7 @@ fn dedupe_does_not_hide_ambiguity_between_branches_in_different_stacks() -> anyh
         Vec::new(),
         gix::hashtable::HashMap::default(),
         Default::default(),
+        3,
     )?;
     let changed_paths_fn = |commit_id: gix::ObjectId,
                             parent_id: Option<gix::ObjectId>|
@@ -2853,7 +3038,7 @@ fn dedupe_does_not_hide_ambiguity_between_branches_in_different_stacks() -> anyh
         bail!("unexpected IDs {commit_id} {parent_id:?}");
     };
 
-    let matches = id_map.parse("foo", Box::new(changed_paths_fn))?;
+    let matches = id_map.parse("foo", &TestChanges(changed_paths_fn))?;
     assert_eq!(
         matches.len(),
         2,
@@ -2884,6 +3069,7 @@ fn dedupe_treats_unmanaged_branches_with_same_name_as_the_same_branch() -> anyho
         Vec::new(),
         gix::hashtable::HashMap::default(),
         Default::default(),
+        3,
     )?;
     let changed_paths_fn = |commit_id: gix::ObjectId,
                             parent_id: Option<gix::ObjectId>|
@@ -2891,7 +3077,7 @@ fn dedupe_treats_unmanaged_branches_with_same_name_as_the_same_branch() -> anyho
         bail!("unexpected IDs {commit_id} {parent_id:?}");
     };
 
-    let matches = id_map.parse("foo", Box::new(changed_paths_fn))?;
+    let matches = id_map.parse("foo", &TestChanges(changed_paths_fn))?;
     assert!(
         matches!(
             matches.as_slice(),
@@ -2920,6 +3106,7 @@ fn find_commits_by_change_id() {
         Vec::new(),
         commit_id_to_change_id,
         Default::default(),
+        3,
     )
     .unwrap();
     snapbox::assert_data_eq!(
@@ -2940,7 +3127,7 @@ branches: [ no ]
     // Should match both commits if we use a common prefix
     snapbox::assert_data_eq!(
         id_map
-            .parse("sws", Box::new(changed_paths_fn))
+            .parse("sws", &TestChanges(changed_paths_fn))
             .unwrap()
             .to_debug(),
         snapbox::str![[r#"
@@ -2970,7 +3157,7 @@ branches: [ no ]
 
     snapbox::assert_data_eq!(
         id_map
-            .parse("swst", Box::new(changed_paths_fn))
+            .parse("swst", &TestChanges(changed_paths_fn))
             .unwrap()
             .to_debug(),
         snapbox::str![[r#"
@@ -2991,7 +3178,7 @@ branches: [ no ]
 
     snapbox::assert_data_eq!(
         id_map
-            .parse("swsr", Box::new(changed_paths_fn))
+            .parse("swsr", &TestChanges(changed_paths_fn))
             .unwrap()
             .to_debug(),
         snapbox::str![[r#"
@@ -3033,6 +3220,7 @@ fn uncommitted_selector_is_not_shadowed_by_commit_change_id() -> anyhow::Result<
         )],
         gix::hashtable::HashMap::default(),
         Default::default(),
+        3,
     )?;
     let file_id = commitless
         .all_ids()
@@ -3059,17 +3247,18 @@ fn uncommitted_selector_is_not_shadowed_by_commit_change_id() -> anyhow::Result<
         )],
         commit_id_to_change_id,
         Default::default(),
+        3,
     )?;
 
     // In the full namespace the commit shadows the previously issued file ID.
-    let full = id_map.parse(&file_id, changed_paths_fn())?;
+    let full = id_map.parse(&file_id, &TestChanges(changed_paths_fn()))?;
     assert!(
         matches!(full.as_slice(), [CliId::Commit { .. }]),
         "the commit change ID shadows the file ID in the full namespace: {full:?}"
     );
 
     // Scoped to uncommitted files, the same selector still finds the file.
-    let scoped = id_map.parse_uncommitted(&file_id, changed_paths_fn())?;
+    let scoped = id_map.parse_uncommitted(&file_id, &TestChanges(changed_paths_fn()))?;
     match scoped.as_slice() {
         [CliId::UncommittedHunkOrFile(uncommitted)] => {
             assert_eq!(
@@ -3082,7 +3271,8 @@ fn uncommitted_selector_is_not_shadowed_by_commit_change_id() -> anyhow::Result<
     }
 
     // Hunk selectors under the file keep working too.
-    let hunk = id_map.parse_uncommitted(&format!("{file_id}:q"), changed_paths_fn())?;
+    let hunk =
+        id_map.parse_uncommitted(&format!("{file_id}:q"), &TestChanges(changed_paths_fn()))?;
     assert!(
         matches!(hunk.as_slice(), [CliId::UncommittedHunkOrFile(_)]),
         "hunk selector resolves in the scoped namespace: {hunk:?}"
@@ -3128,12 +3318,13 @@ fn a_file_literally_named_zz_competes_with_the_uncommitted_area() -> anyhow::Res
         vec![source_changes(ChangeSourceId::Head, vec![hunk("zz")])],
         gix::hashtable::HashMap::default(),
         Default::default(),
+        3,
     )?;
 
     // `zz` names the whole area, so a dirty file of the same name must surface
     // as a competing match for the resolver to report - not silently win, the
     // same way a file named after a worktree competes with the worktree.
-    let scoped = id_map.parse_uncommitted("zz", Box::new(changed_paths_fn))?;
+    let scoped = id_map.parse_uncommitted("zz", &TestChanges(changed_paths_fn))?;
     match scoped.as_slice() {
         [
             CliId::UncommittedHunkOrFile(uncommitted),
@@ -3161,9 +3352,10 @@ fn uncommitted_scope_does_not_prefix_match_a_branch_short_id() -> anyhow::Result
         vec![source_changes(ChangeSourceId::Head, vec![hunk("foo242")])],
         gix::hashtable::HashMap::default(),
         Default::default(),
+        3,
     )?;
 
-    let full = id_map.parse("kp", Box::new(changed_paths_fn))?;
+    let full = id_map.parse("kp", &TestChanges(changed_paths_fn))?;
     assert!(
         matches!(full.as_slice(), [CliId::Branch(..)]),
         "precondition: the full namespace resolves 'kp' to the branch: {full:?}"
@@ -3172,7 +3364,7 @@ fn uncommitted_scope_does_not_prefix_match_a_branch_short_id() -> anyhow::Result
     // The scoped parser must NOT silently resolve the displayed branch ID to
     // the file by hex-prefix accident — an empty result lets callers produce
     // the targeted "is a branch" error via their full-namespace fallback.
-    let scoped = id_map.parse_uncommitted("kp", Box::new(changed_paths_fn))?;
+    let scoped = id_map.parse_uncommitted("kp", &TestChanges(changed_paths_fn))?;
     assert_eq!(
         scoped,
         vec![],
@@ -3180,7 +3372,7 @@ fn uncommitted_scope_does_not_prefix_match_a_branch_short_id() -> anyhow::Result
     );
 
     // A longer prefix that no branch owns still resolves the file.
-    let scoped = id_map.parse_uncommitted("kpo", Box::new(changed_paths_fn))?;
+    let scoped = id_map.parse_uncommitted("kpo", &TestChanges(changed_paths_fn))?;
     assert!(
         matches!(scoped.as_slice(), [CliId::UncommittedHunkOrFile(_)]),
         "file prefixes beyond the branch ID keep resolving: {scoped:?}"
@@ -3222,6 +3414,7 @@ fn change_ids_are_disambiguated_on_collision() {
         Vec::new(),
         commit_id_to_change_id,
         Default::default(),
+        3,
     )
     .unwrap();
     snapbox::assert_data_eq!(
@@ -3242,7 +3435,7 @@ branches: [ no ]
     // Should match both commits if we use a common prefix
     snapbox::assert_data_eq!(
         id_map
-            .parse("sws", Box::new(changed_paths_fn))
+            .parse("sws", &TestChanges(changed_paths_fn))
             .unwrap()
             .to_debug(),
         snapbox::str![[r#"
@@ -3272,7 +3465,7 @@ branches: [ no ]
 
     snapbox::assert_data_eq!(
         id_map
-            .parse("s#0", Box::new(changed_paths_fn))
+            .parse("s#0", &TestChanges(changed_paths_fn))
             .unwrap()
             .to_debug(),
         snapbox::str![[r#"
@@ -3293,7 +3486,7 @@ branches: [ no ]
 
     snapbox::assert_data_eq!(
         id_map
-            .parse("s#1", Box::new(changed_paths_fn))
+            .parse("s#1", &TestChanges(changed_paths_fn))
             .unwrap()
             .to_debug(),
         snapbox::str![[r#"
@@ -3350,13 +3543,13 @@ fn worktree_commits_share_the_commit_namespace() -> anyhow::Result<()> {
     )]
     .into_iter()
     .collect();
-    let id_map = IdMap::new(stacks, sources, commit_id_to_change_id, worktree_commits)?;
+    let id_map = IdMap::new(stacks, sources, commit_id_to_change_id, worktree_commits, 3)?;
 
     // The worktree commit resolves by its change ID, disambiguated against the
     // workspace commit's "swst".
     snapbox::assert_data_eq!(
         id_map
-            .parse("swsr", Box::new(changed_paths_fn))
+            .parse("swsr", &TestChanges(changed_paths_fn))
             .unwrap()
             .to_debug(),
         snapbox::str![[r#"
@@ -3378,7 +3571,7 @@ fn worktree_commits_share_the_commit_namespace() -> anyhow::Result<()> {
     // The shared hex prefix is ambiguous across the two sets.
     assert_eq!(
         id_map
-            .parse("21", Box::new(changed_paths_fn))
+            .parse("21", &TestChanges(changed_paths_fn))
             .unwrap()
             .len(),
         2,
@@ -3388,7 +3581,7 @@ fn worktree_commits_share_the_commit_namespace() -> anyhow::Result<()> {
     // One more nybble singles out the workspace commit, whose short ID grew to match.
     snapbox::assert_data_eq!(
         id_map
-            .parse("21a", Box::new(changed_paths_fn))
+            .parse("21a", &TestChanges(changed_paths_fn))
             .unwrap()
             .to_debug(),
         snapbox::str![[r#"
@@ -3411,6 +3604,8 @@ fn worktree_commits_share_the_commit_namespace() -> anyhow::Result<()> {
 
 mod util {
     use std::{cmp::Ordering, fmt::Formatter};
+
+    use super::TestChanges;
 
     use anyhow::bail;
     use bstr::BString;
@@ -3554,6 +3749,7 @@ mod util {
                 uncommitted_files,
                 uncommitted_hunks,
                 worktrees: _,
+                diff_context_lines: _,
             } = self;
             let changed_paths_fn = |commit_id: gix::ObjectId,
                                     parent_id: Option<gix::ObjectId>|
@@ -3572,7 +3768,7 @@ mod util {
                 )
                 .chain(uncommitted_hunks.keys().cloned())
                 .flat_map(|id| {
-                    self.parse(&id, Box::new(changed_paths_fn))
+                    self.parse(&id, &TestChanges(changed_paths_fn))
                         .expect("BUG: valid ID means no error")
                 })
                 .sorted_by(id_cmp)
@@ -3594,6 +3790,7 @@ mod util {
                 uncommitted_files,
                 uncommitted_hunks,
                 worktrees,
+                diff_context_lines: _,
             } = self.inner;
             let commits_count = self.inner.commit_ids().len();
             writeln!(f, "workspace_and_remote_commits_count: {}", &commits_count)?;

--- a/crates/but/src/utils/diff_rendering.rs
+++ b/crates/but/src/utils/diff_rendering.rs
@@ -1348,6 +1348,7 @@ mod tests {
                     CliId::UncommittedHunkOrFile(hunk) => Some(hunk.id.as_str()),
                     CliId::PathPrefix { .. }
                     | CliId::CommittedFile { .. }
+                    | CliId::CommittedHunk { .. }
                     | CliId::Branch(..)
                     | CliId::Commit { .. }
                     | CliId::Uncommitted { .. }

--- a/crates/but/src/utils/diff_specs.rs
+++ b/crates/but/src/utils/diff_specs.rs
@@ -87,6 +87,9 @@ impl<'a> DiffSpecBuilder<'a> {
             CliId::Stack { .. } => {
                 anyhow::bail!("Cannot compute diff specs for stacks")
             }
+            CliId::CommittedHunk(_) => {
+                anyhow::bail!("Cannot (yet) compute diff specs for committed hunks")
+            }
         }
     }
 

--- a/crates/but/tests/but/command/expand.rs
+++ b/crates/but/tests/but/command/expand.rs
@@ -232,6 +232,342 @@ branch: tp tp-branch
 }
 
 #[test]
+fn resolves_committed_hunk() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
+
+    env.file("file", "content");
+
+    env.but("diff")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+───────────╮
+ qs:7 file │
+───────────╯
+
+@@ -1,0 +1,1 @@
+───────────────
+  ┊ 1 │ +content
+
+"#]]);
+
+    env.but("commit -m 'Add file'")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Created commit 1 on new branch 'a-branch-1'
+
+"#]]);
+
+    env.but("_expand 1:qs:7")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Matches: 1
+
+committed hunk: d4d928e2cf0ad11076e9419d8f946642e8650d6b file @@ -1,0 +1,1 @@
+
+"#]]);
+}
+
+#[test]
+fn identical_committed_hunks_qualified_by_commit() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
+
+    let repeated_content = "line\n".repeat(10);
+
+    env.file("file", format!("{repeated_content}{repeated_content}"));
+
+    env.but("commit -m 'Add file'")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Created commit 1 on new branch 'a-branch-1'
+
+"#]]);
+
+    env.file(
+        "file",
+        format!("{repeated_content}new-line\n{repeated_content}"),
+    );
+
+    env.but("diff")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+───────────╮
+ qs:b file │
+───────────╯
+
+@@ -8,6 +8,7 @@
+───────────────
+ 8 ┊  8 │  line
+ 9 ┊  9 │  line
+10 ┊ 10 │  line
+   ┊ 11 │ +new-line
+11 ┊ 12 │  line
+12 ┊ 13 │  line
+13 ┊ 14 │  line
+
+"#]]);
+
+    env.but("commit -m 'Add new line'")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Created commit 1 on branch 'a-branch-1'
+
+"#]]);
+
+    // revert to original state so we can get _exactly_ the same hunk again
+    env.file("file", format!("{repeated_content}{repeated_content}"));
+    env.but("diff")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+───────────╮
+ qs:2 file │
+───────────╯
+
+@@ -8,7 +8,6 @@
+───────────────
+ 8 ┊  8 │  line
+ 9 ┊  9 │  line
+10 ┊ 10 │  line
+11 ┊    │ -new-line
+12 ┊ 11 │  line
+13 ┊ 12 │  line
+14 ┊ 13 │  line
+
+"#]]);
+    env.but("commit -m 'Revert'")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Created commit 1 on branch 'a-branch-1'
+
+"#]]);
+
+    env.file(
+        "file",
+        format!("{repeated_content}new-line\n{repeated_content}"),
+    );
+    env.but("diff")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+───────────╮
+ qs:b file │
+───────────╯
+
+@@ -8,6 +8,7 @@
+───────────────
+ 8 ┊  8 │  line
+ 9 ┊  9 │  line
+10 ┊ 10 │  line
+   ┊ 11 │ +new-line
+11 ┊ 12 │  line
+12 ┊ 13 │  line
+13 ┊ 14 │  line
+
+"#]]);
+
+    env.but("commit -m 'Add new line'")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Created commit 1 on branch 'a-branch-1'
+
+"#]]);
+
+    env.but("status -fv")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ br [a-branch-1]
+┊● 1#0 author 2000-01-01 00:00:00 +0000 (sha 6f4b52a)
+┊│     Add new line
+┊│     1#0:q M file
+┊● 1#1 author 2000-01-01 00:00:00 +0000 (sha 120d589)
+┊│     Revert
+┊│     1#1:q M file
+┊● 1#2 author 2000-01-01 00:00:00 +0000 (sha bc7dd74)
+┊│     Add new line
+┊│     1#2:q M file
+┊● 1#3 author 2000-01-01 00:00:00 +0000 (sha 86543ac)
+┊│     Add file
+┊│     1#3:q A file
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    // Without qualifying the collision ID for the change IDs, we get both commits that add the
+    // new-line text
+    env.but("_expand 1:qs:b")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Matches: 2
+
+committed hunk: 6f4b52a36cae46b54446f6a90d6781bacbce12dc file @@ -8,6 +8,7 @@
+committed hunk: bc7dd74811af27895beecb37a245cc34291274ad file @@ -8,6 +8,7 @@
+
+"#]]);
+
+    // Can selectively get the tip commit's hunk
+    env.but("_expand 1#0:qs:b")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Matches: 1
+
+committed hunk: 6f4b52a36cae46b54446f6a90d6781bacbce12dc file @@ -8,6 +8,7 @@
+
+"#]]);
+
+    // Can selectively get the older commit's hunk
+    env.but("_expand 1#2:qs:b")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Matches: 1
+
+committed hunk: bc7dd74811af27895beecb37a245cc34291274ad file @@ -8,6 +8,7 @@
+
+"#]]);
+}
+
+#[test]
+fn resolves_committed_hunk_id_duplicates() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
+
+    let repeated_content = "line\n".repeat(10);
+
+    env.file(
+        "file",
+        format!("{repeated_content}{repeated_content}{repeated_content}"),
+    );
+
+    env.but("commit -m 'Add file'")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Created commit 1 on new branch 'a-branch-1'
+
+"#]]);
+    env.file(
+        "file",
+        format!("{repeated_content}new_line\n{repeated_content}new_line\n{repeated_content}"),
+    );
+
+    env.but("diff")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+───────────────╮
+ qs:8#0-2 file │
+───────────────╯
+
+@@ -8,6 +8,7 @@
+───────────────
+ 8 ┊  8 │  line
+ 9 ┊  9 │  line
+10 ┊ 10 │  line
+   ┊ 11 │ +new_line
+11 ┊ 12 │  line
+12 ┊ 13 │  line
+13 ┊ 14 │  line
+
+───────────────╮
+ qs:8#1-2 file │
+───────────────╯
+
+@@ -18,6 +19,7 @@
+─────────────────
+18 ┊ 19 │  line
+19 ┊ 20 │  line
+20 ┊ 21 │  line
+   ┊ 22 │ +new_line
+21 ┊ 23 │  line
+22 ┊ 24 │  line
+23 ┊ 25 │  line
+
+"#]]);
+
+    env.but("commit -m 'Edit file'")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Created commit 1 on branch 'a-branch-1'
+
+"#]]);
+
+    env.file("file", "");
+    env.but("commit -m 'Delete content'").assert().success();
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ br [a-branch-1]
+┊●   1#0 Delete content
+┊│     1#0:q M file
+┊●   1#1 Edit file
+┊│     1#1:q M file
+┊●   1#2 Add file
+┊│     1#2:q A file
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("_expand 1#1:qs:8")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Matches: 2
+
+committed hunk: ecdc91c3a88413a31b1a2ba4000198593dbcbb9e file @@ -8,6 +8,7 @@
+committed hunk: ecdc91c3a88413a31b1a2ba4000198593dbcbb9e file @@ -18,6 +19,7 @@
+
+"#]]);
+
+    env.but("_expand 1#1:qs:8#0-2")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Matches: 1
+
+committed hunk: ecdc91c3a88413a31b1a2ba4000198593dbcbb9e file @@ -8,6 +8,7 @@
+
+"#]]);
+
+    env.but("_expand 1#1:qs:8#1-2")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Matches: 1
+
+committed hunk: ecdc91c3a88413a31b1a2ba4000198593dbcbb9e file @@ -18,6 +19,7 @@
+
+"#]]);
+}
+
+#[test]
 fn requires_exactly_one_argument() {
     let env = Sandbox::empty();
 

--- a/crates/but/tests/but/command/expand.rs
+++ b/crates/but/tests/but/command/expand.rs
@@ -8,6 +8,15 @@ fn expand_env() -> Sandbox {
     env
 }
 
+/// A valid PNG file, useful if you want to test binary files.
+const PNG_BINARY_CONTENT: &[u8] = &[
+    0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+    0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x04, 0x00, 0x00, 0x00, 0xB5, 0x1C, 0x0C,
+    0x02, 0x00, 0x00, 0x00, 0x0B, 0x49, 0x44, 0x41, 0x54, 0x78, 0xDA, 0x63, 0x64, 0xF8, 0x0F, 0x00,
+    0x01, 0x05, 0x01, 0x01, 0x27, 0x18, 0xE3, 0x66, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44,
+    0xAE, 0x42, 0x60, 0x82,
+];
+
 #[test]
 fn resolves_cli_id_atom() {
     let env = expand_env();
@@ -267,6 +276,44 @@ Created commit 1 on new branch 'a-branch-1'
 Matches: 1
 
 committed hunk: d4d928e2cf0ad11076e9419d8f946642e8650d6b file @@ -1,0 +1,1 @@
+
+"#]]);
+}
+
+#[test]
+fn resolves_binary_committed_hunk() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
+
+    env.file("image.png", PNG_BINARY_CONTENT);
+
+    env.but("diff")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+────────────────╮
+ nx:q image.png │
+────────────────╯
+
+No diff available - file is either empty, binary, or too large
+
+"#]]);
+
+    env.but("commit -m 'Add binary file'")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Created commit 1 on new branch 'a-branch-1'
+
+"#]]);
+
+    env.but("_expand 1:nx:q")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Matches: 1
+
+committed hunk: 80ebb9fd760bfb1522b5eb209be8b2783494c1b8 image.png <no hunk header>
 
 "#]]);
 }


### PR DESCRIPTION
Adds preliminary support for resolving committed hunk IDs. Committed hunk IDs are currently not exposed anywhere, you just need to know what they are to use them. The only command that can currently use committed hunk IDs is `_expand`, so meaningful support in e.g. `squash` and `move` remains to be implemented.

The current implementation is _very_ inefficient if multiple IDs need to be resolved, as every ID is individually parsed and independently requires tree and blob level diffing, even if they belong to the same committed file. We need some form of caching moving forward. I'm thinking a per-command explicit caching strategy for the commands that do resolve multiple IDs, and those that don't simply need not be concerned with caching. I don't want hidden caching as it's so easy to create subtle bugs if the underlying state changes, and you don't even know there's a cache involved.

We're also currently dropping rename information in parsing (it's present in the TreeChange) - I will add that in as it's needed.

### Review notes

@davidpdrsn I think it's especially important you check this from the perspective of the TUI.

* I've added in basically no support for the TUI yet. In a couple of places I've just added a line or two that would be easy to forget to add later, while now it's obvious as the `CommittedHunk` variant is missing.
* `CommittedHunk` is a distinct type from `CommittedFile`. This fits the parsing patterns much better than making it a single `CommittedHunkOrFile`. I did consider it might not work with how selection operates in the TUI, but at a glance it looks like each selected uncommitted hunk becomes its own `UncommittedHunkOrFile` that are coalesced only later, which we could adapt to work for distinct `CommittedHunk` and `CommittedFile`.
* Rust nit-picks welcome as usual

@Caleb-T-Owens Could you quickly browse over from a worktree perspective? In my mind, as committed files are already scoped to commits, these changes should have no impact on worktrees. Also trying it out in practice, resolution seems fine.