### PR TITLE
meta: keep a stack's own head when duplicate names exist in other stacks

### DIFF
--- a/crates/but-meta/src/legacy/mod.rs
+++ b/crates/but-meta/src/legacy/mod.rs
@@ -483,8 +483,9 @@ impl RefMetadata for VirtualBranchesTomlMetadata {
         }
         let previous_content = self.snapshot.content.clone();
 
-        // Find exactly one stack-id per branch name, and assign all branches to it.
         // `stacks` is the target state, and we have to make an actual stack look like it.
+        // Branch names are not globally unique: each stack keeps the head it already owns,
+        // and duplicate names in other stacks stay where they are.
         let mut seen_stack_ids = HashSet::new();
         for stack in &value.stacks {
             if stack.branches.is_empty() {
@@ -503,6 +504,16 @@ impl RefMetadata for VirtualBranchesTomlMetadata {
                 .contains_key(&stack.id)
                 .then_some(stack.id);
             for stack_branch in &stack.branches {
+                // Duplicate names can exist in other stacks as stale leftovers, which
+                // `reconcile_projected_stacks` tolerates. When this stack already has its
+                // own head for the name, keep it: the by-order lookup below would find the
+                // lowest-ordered copy instead and move it here, taking it away from the
+                // stack that legitimately holds it.
+                if stack_id.is_some_and(|stack_id| {
+                    stack_has_head(self.data(), stack_id, stack_branch.ref_name.as_ref())
+                }) {
+                    continue;
+                }
                 let branch = self.branch(stack_branch.ref_name.as_ref())?;
                 if branch.is_default() {
                     branches_to_create.push(stack_branch);
@@ -1104,6 +1115,20 @@ fn default_workspace() -> Workspace {
 
 fn full_branch_name(name: &str) -> Option<gix::refs::FullName> {
     gix::refs::FullName::try_from(format!("refs/heads/{name}")).ok()
+}
+
+fn stack_has_head(
+    data: &VirtualBranches,
+    stack_id: StackId,
+    ref_name: &gix::refs::FullNameRef,
+) -> bool {
+    let short_name = ref_name.shorten();
+    data.branches.get(&stack_id).is_some_and(|stack| {
+        stack
+            .heads
+            .iter()
+            .any(|head| short_name == head.name.as_str())
+    })
 }
 
 fn stack_head_oid(

--- a/crates/but-meta/tests/meta/ref_metadata_legacy.rs
+++ b/crates/but-meta/tests/meta/ref_metadata_legacy.rs
@@ -1740,6 +1740,139 @@ fn removes_within_stack_duplicate_heads_even_when_mapped_to_a_segment_13345() ->
     Ok(())
 }
 
+/// A stale unapplied stack may still list a branch that meanwhile lives in an applied
+/// stack - `reconcile_projected_stacks` tolerates such duplicates as stale hints.
+/// Writing the workspace back must not move the applied stack's copy into the stale
+/// stack; that regrouping made snapshots record every branch below the tip as
+/// unapplied, so restoring them stranded those branches (#15573).
+#[test]
+fn duplicate_names_in_unapplied_stacks_do_not_steal_applied_branches() -> anyhow::Result<()> {
+    let (mut store, _tmp) = empty_vb_store_rw()?;
+    let lower_head = gix::ObjectId::from_str("1111111111111111111111111111111111111111")?;
+    let tip_head = gix::ObjectId::from_str("2222222222222222222222222222222222222222")?;
+    let stale_head = gix::ObjectId::from_str("3333333333333333333333333333333333333333")?;
+
+    let applied = LegacyStack::new_with_just_heads(
+        vec![
+            StackBranch {
+                head: lower_head,
+                name: "lower".into(),
+                pr_number: None,
+                archived: false,
+                review_id: None,
+            },
+            StackBranch {
+                head: tip_head,
+                name: "tip".into(),
+                pr_number: None,
+                archived: false,
+                review_id: None,
+            },
+        ],
+        0,
+        true,
+    );
+    let stale = LegacyStack::new_with_just_heads(
+        vec![StackBranch {
+            head: stale_head,
+            name: "lower".into(),
+            pr_number: None,
+            archived: false,
+            review_id: None,
+        }],
+        1,
+        false,
+    );
+    let applied_id = applied.id;
+    let stale_id = stale.id;
+    store.data_mut().branches.insert(applied_id, applied);
+    store.data_mut().branches.insert(stale_id, stale);
+
+    // Reading the workspace and writing it back unchanged must not regroup branches.
+    let workspace_name: gix::refs::FullName = "refs/heads/gitbutler/workspace".try_into()?;
+    let ws = store.workspace(workspace_name.as_ref())?;
+    store.set_workspace(&ws)?;
+
+    let names = |stack_id: StackId| {
+        store.data().branches.get(&stack_id).map(|stack| {
+            stack
+                .heads
+                .iter()
+                .map(|head| head.name.clone())
+                .collect::<Vec<_>>()
+        })
+    };
+    assert_eq!(
+        names(applied_id),
+        Some(vec!["lower".to_string(), "tip".to_string()]),
+        "the applied stack keeps all its branches",
+    );
+    assert_eq!(
+        names(stale_id),
+        Some(vec!["lower".to_string()]),
+        "the stale stack keeps only its own copy",
+    );
+    assert_eq!(
+        store.data().branches[&stale_id].heads[0].head,
+        stale_head,
+        "the stale copy is untouched",
+    );
+    Ok(())
+}
+
+/// Two applied stacks may share a segment, so both legitimately list the same
+/// branch name. A workspace roundtrip must leave each stack's own copy in place
+/// instead of moving the lower-ordered one into whichever stack is written last.
+#[test]
+fn shared_segment_names_stay_in_their_own_applied_stacks() -> anyhow::Result<()> {
+    let (mut store, _tmp) = empty_vb_store_rw()?;
+    let shared_head = gix::ObjectId::from_str("1111111111111111111111111111111111111111")?;
+
+    let names = |heads: &[&str]| {
+        heads
+            .iter()
+            .map(|name| StackBranch {
+                head: shared_head,
+                name: (*name).into(),
+                pr_number: None,
+                archived: false,
+                review_id: None,
+            })
+            .collect::<Vec<_>>()
+    };
+    let stack_a = LegacyStack::new_with_just_heads(names(&["shared", "A"]), 0, true);
+    let stack_b = LegacyStack::new_with_just_heads(names(&["shared", "B"]), 1, true);
+    let stack_a_id = stack_a.id;
+    let stack_b_id = stack_b.id;
+    store.data_mut().branches.insert(stack_a_id, stack_a);
+    store.data_mut().branches.insert(stack_b_id, stack_b);
+
+    let workspace_name: gix::refs::FullName = "refs/heads/gitbutler/workspace".try_into()?;
+    let ws = store.workspace(workspace_name.as_ref())?;
+    store.set_workspace(&ws)?;
+
+    let head_names = |stack_id: StackId| {
+        store.data().branches.get(&stack_id).map(|stack| {
+            stack
+                .heads
+                .iter()
+                .map(|head| head.name.clone())
+                .collect::<Vec<_>>()
+        })
+    };
+    assert_eq!(
+        head_names(stack_a_id),
+        Some(vec!["shared".to_string(), "A".to_string()]),
+        "the first applied stack keeps its copy of the shared segment",
+    );
+    assert_eq!(
+        head_names(stack_b_id),
+        Some(vec!["shared".to_string(), "B".to_string()]),
+        "the second applied stack keeps its copy of the shared segment",
+    );
+    Ok(())
+}
+
 #[cfg(unix)]
 #[test]
 fn falls_back_to_in_memory_db_when_persistent_db_open_fails() -> anyhow::Result<()> {


### PR DESCRIPTION
Fixes #15573

### The bug

`VirtualBranchesTomlMetadata::set_workspace` looks up each incoming branch by the lowest-ordered name match across **all** stacks. When the same branch name exists in two stacks — an applied stack plus a stale unapplied leftover — writing the workspace back finds the applied stack's copy first and moves it into the stale stack, taking it away from the stack that legitimately holds it.

Such duplicates are a supported state, not corruption: shared segments legitimately list one branch in several applied stacks, and `reconcile_projected_stacks` explicitly tolerates duplicates as "stale hints". Write-time cleanup preserves duplicates that resolve to the same projected segment, so once one exists it persists.

### How it manifests

Every workspace metadata write funnels through `set_workspace`, so once a duplicate exists the stored metadata quietly degrades: branches of the applied stack migrate one by one into stale unapplied singleton stacks. The workspace UI stays correct the whole time — it is derived from the ref graph, not this metadata — so the user gets no warning. From there:

- **Snapshots record a lie.** `prepare_snapshot` builds the `virtual_branches.toml` embedded in every oplog snapshot through this same call, so snapshots record only the tip branch as applied.
- **Restore executes the lie.** Restoring such a snapshot (undo/redo) rewinds only the tip segment's ref, leaves every other segment ref pointing at the abandoned pre-restore chain, and marks those branches unapplied. The stack is now structurally invalid: `but apply` correctly refuses with `conflicts with existing stack`, and `but undo` repeats the same one-ref restore — no in-product recovery. This is the scenario in #15573, and its reproducer matches this mechanism exactly, down to which branch survives (the only one without a stale duplicate) and the duplicated head pairs in the snapshot metadata.
- **Unapply breaks too.** The same duplicate state makes unapplying a stack fail with `branch name '…' occurs more than once`.

### The fix

Before falling back to the by-order global lookup, keep the head the stack being written already owns. This is a no-op for duplicate-free metadata (unique names find the same copy either way), and legitimate cross-stack moves are unchanged (a branch not owned by the target stack takes the same path as before). It stops both the live metadata drift and the recording of degenerate snapshots, for the stale-duplicate case as well as for shared segments across applied stacks.

Snapshots already recorded with degenerate metadata still restore badly — recorded history can't be rewritten. What changes for affected users is that the before-restore snapshot taken during any restore is now built correctly, so one bad restore is recoverable with redo instead of being a dead end. Garbage-collecting the stale duplicate entries themselves is left as a follow-up.