### PR TITLE
fix(tui): dont allow selecting worktrees in branch mode

### DIFF
--- a/crates/but/src/command/legacy/status/tui/render.rs
+++ b/crates/but/src/command/legacy/status/tui/render.rs
@@ -1331,10 +1331,10 @@ pub fn branch_operation_display(
 ) -> Option<&'static str> {
     match data {
         StatusOutputLineData::UncommittedChanges { .. }
-        | StatusOutputLineData::WorktreeUncommittedChanges { .. }
         | StatusOutputLineData::Branch { .. }
         | StatusOutputLineData::MergeBase => Some("branch"),
         StatusOutputLineData::UpdateNotice
+        | StatusOutputLineData::WorktreeUncommittedChanges { .. }
         | StatusOutputLineData::Connector
         | StatusOutputLineData::BetweenStacks
         | StatusOutputLineData::StagedChanges { .. }


### PR DESCRIPTION
You can't do anything with worktrees yet so selecting them shouldn't be possible.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #15587 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #15586
<!-- GitButler Footer Boundary Bottom -->