### PR TITLE
forge: serve stale open reviews when a refresh hits a network error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1350,6 +1350,7 @@ dependencies = [
  "reqwest",
  "schemars 1.2.1",
  "serde",
+ "serde_json",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/crates/but-bitbucket/Cargo.toml
+++ b/crates/but-bitbucket/Cargo.toml
@@ -25,6 +25,7 @@ anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 reqwest = { workspace = true, features = ["json"] }
+serde_json.workspace = true
 urlencoding.workspace = true
 base64.workspace = true
 schemars = { workspace = true, optional = true }
@@ -32,7 +33,6 @@ but-schemars = { workspace = true, optional = true }
 
 [dev-dependencies]
 reqwest = { workspace = true, features = ["blocking"] }
-serde_json.workspace = true
 tokio = { workspace = true, features = ["macros", "rt"] }
 
 [lints]

--- a/crates/but-bitbucket/src/lib.rs
+++ b/crates/but-bitbucket/src/lib.rs
@@ -157,9 +157,26 @@ pub async fn get_bb_user(
 
 /// Check if an error is a network connectivity error.
 ///
-/// This includes DNS resolution failures, connection timeouts, connection refused, etc.
+/// This includes DNS resolution failures, connection timeouts, connection
+/// refused, and connections dropped while the response body was being read.
+/// reqwest wraps both body I/O failures and malformed payloads as the same
+/// decode kind, so the source chain decides: a serde cause means the payload
+/// was malformed, anything else means the transport failed mid-response.
 fn is_network_error(err: &reqwest::Error) -> bool {
-    err.is_timeout() || err.is_connect() || err.is_request()
+    if err.is_timeout() || err.is_connect() || err.is_request() {
+        return true;
+    }
+    if !err.is_decode() {
+        return false;
+    }
+    let mut source = std::error::Error::source(err);
+    while let Some(cause) = source {
+        if cause.downcast_ref::<serde_json::Error>().is_some() {
+            return false;
+        }
+        source = cause.source();
+    }
+    true
 }
 
 /// Stable 64-bit hash (FNV-1a) for synthesizing numeric ids from the string

--- a/crates/but-bitbucket/src/pr.rs
+++ b/crates/but-bitbucket/src/pr.rs
@@ -11,7 +11,25 @@ pub async fn list(
     BitbucketClient::from_storage(storage, preferred_account)?
         .list_open_prs(workspace, repo_slug)
         .await
+        .map_err(classify_forge_error)
         .context("Failed to list open pull requests")
+}
+
+/// Tag transport failures with `but_error::Code::NetworkError` so the desktop
+/// can present them appropriately (silent for offline) and cached readers can
+/// keep serving the last known data. Only applied to read paths — mutations
+/// should still surface failures.
+pub(crate) fn classify_forge_error(err: anyhow::Error) -> anyhow::Error {
+    if err
+        .downcast_ref::<reqwest::Error>()
+        .is_some_and(crate::is_network_error)
+    {
+        return err.context(but_error::Context::new_static(
+            but_error::Code::NetworkError,
+            "Unable to connect to Bitbucket.",
+        ));
+    }
+    err
 }
 
 pub async fn list_recently_closed(
@@ -23,6 +41,7 @@ pub async fn list_recently_closed(
     BitbucketClient::from_storage(storage, preferred_account)?
         .list_recently_closed_prs(workspace, repo_slug)
         .await
+        .map_err(classify_forge_error)
         .context("Failed to list recently closed pull requests")
 }
 
@@ -36,6 +55,7 @@ pub async fn list_all_for_target(
     BitbucketClient::from_storage(storage, preferred_account)?
         .list_prs_for_target(workspace, repo_slug, target_branch)
         .await
+        .map_err(classify_forge_error)
         .context("Failed to list pull requests for target branch")
 }
 
@@ -50,6 +70,7 @@ pub async fn get(
     BitbucketClient::from_storage(storage, preferred_account)?
         .get_pull_request(workspace, repo_slug, id)
         .await
+        .map_err(classify_forge_error)
         .context("Failed to get pull request")
 }
 
@@ -109,4 +130,93 @@ pub async fn set_draft_state(
         .set_pull_request_draft_state(&params)
         .await
         .context("Failed to set pull request draft state")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Serve one request with the given raw HTTP response, then hang up.
+    fn one_shot_server(response: &'static [u8]) -> std::net::SocketAddr {
+        use std::io::{Read, Write};
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0u8; 1024];
+            let _ = stream.read(&mut request);
+            let _ = stream.write_all(response);
+        });
+        addr
+    }
+
+    #[test]
+    fn interrupted_response_bodies_carry_the_network_error_code() {
+        // The response promises more bytes than arrive before the connection
+        // closes — the shape of a network dropping mid-transfer.
+        let addr = one_shot_server(
+            b"HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: 100\r\n\r\n[{\"id\"",
+        );
+        let reqwest_err = reqwest::blocking::get(format!("http://{addr}/"))
+            .unwrap()
+            .json::<serde_json::Value>()
+            .unwrap_err();
+        let err = classify_forge_error(anyhow::Error::from(reqwest_err));
+        assert_eq!(
+            err.downcast_ref::<but_error::Context>().map(|ctx| ctx.code),
+            Some(but_error::Code::NetworkError),
+            "a connection lost while reading the body is an outage like any other"
+        );
+    }
+
+    #[test]
+    fn malformed_payloads_stay_unclassified() {
+        // The body arrives in full but is not JSON — a forge-side problem,
+        // not an outage.
+        let addr = one_shot_server(
+            b"HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: 12\r\n\r\nnot-json-12b",
+        );
+        let reqwest_err = reqwest::blocking::get(format!("http://{addr}/"))
+            .unwrap()
+            .json::<serde_json::Value>()
+            .unwrap_err();
+        let err = classify_forge_error(anyhow::Error::from(reqwest_err));
+        assert!(
+            err.downcast_ref::<but_error::Context>().is_none(),
+            "an unparseable payload must not be presented as an offline network"
+        );
+    }
+
+    #[test]
+    fn connection_failures_carry_the_network_error_code() {
+        // Binding an ephemeral port and dropping the listener leaves a port
+        // that was just proven closed; connecting to it produces the same
+        // `reqwest::Error` shape as an unreachable Bitbucket host.
+        let port = std::net::TcpListener::bind("127.0.0.1:0")
+            .unwrap()
+            .local_addr()
+            .unwrap()
+            .port();
+        let reqwest_err = reqwest::blocking::Client::new()
+            .get(format!("http://127.0.0.1:{port}"))
+            .send()
+            .unwrap_err();
+        let err = classify_forge_error(anyhow::Error::from(reqwest_err));
+        assert_eq!(
+            err.downcast_ref::<but_error::Context>().map(|ctx| ctx.code),
+            Some(but_error::Code::NetworkError),
+            "cached readers key their stale-data fallback off this code"
+        );
+    }
+
+    #[test]
+    fn api_failures_stay_unclassified() {
+        let err = classify_forge_error(anyhow::anyhow!(
+            "Failed to list open pull requests: 500 Internal Server Error"
+        ));
+        assert!(
+            err.downcast_ref::<but_error::Context>().is_none(),
+            "a forge-side failure must not be presented as an offline network"
+        );
+    }
 }

--- a/crates/but-forge/src/review.rs
+++ b/crates/but-forge/src/review.rs
@@ -537,15 +537,17 @@ pub fn list_forge_reviews_with_cache(
             }
             match sync_listed_reviews(preferred_forge_user, forge_repo_info, storage, db) {
                 Ok(reviews) => reviews,
-                // Missing credentials say nothing about the forge's state:
-                // keep serving the last known reviews instead of failing
-                // every cached read while the user is logged out. Explicit
-                // `NoCache` reads still surface the re-authentication error.
-                Err(err) if is_not_authenticated(&err) => crate::list_cached_forge_reviews(db)?
-                    .into_iter()
-                    .filter(ForgeReview::is_open)
-                    .collect(),
-                Err(err) => return Err(err),
+                Err(err) => {
+                    let cached_open: Vec<ForgeReview> = crate::list_cached_forge_reviews(db)?
+                        .into_iter()
+                        .filter(ForgeReview::is_open)
+                        .collect();
+                    if serves_stale_reviews(&err, !cached_open.is_empty()) {
+                        cached_open
+                    } else {
+                        return Err(err);
+                    }
+                }
             }
         }
         CacheConfig::NoCache => {
@@ -555,12 +557,23 @@ pub fn list_forge_reviews_with_cache(
     Ok(reviews)
 }
 
-/// Whether an error means "no forge credentials are stored" — the providers
-/// tag their failed credential lookups with this code.
-fn is_not_authenticated(err: &anyhow::Error) -> bool {
+/// Whether a failed live refresh should keep serving the last known open
+/// reviews instead of surfacing the error. Explicit `NoCache` reads never
+/// come here and still surface every failure.
+///
+/// Missing credentials say nothing about the forge's state, so the cached
+/// listing stays valid even when it is empty. A network error is transient,
+/// but an empty cache has no "confirmed empty at time T" watermark worth
+/// serving, so cold listings still surface the failure. Anything else
+/// (404, invalid tokens, API errors) can require user action and is
+/// returned. The providers tag their errors with these codes.
+fn serves_stale_reviews(err: &anyhow::Error, has_open_reviews: bool) -> bool {
     use but_error::AnyhowContextExt as _;
-    err.custom_context()
-        .is_some_and(|ctx| ctx.code == but_error::Code::ForgeNotAuthenticated)
+    match err.custom_context().map(|ctx| ctx.code) {
+        Some(but_error::Code::ForgeNotAuthenticated) => true,
+        Some(but_error::Code::NetworkError) => has_open_reviews,
+        _ => false,
+    }
 }
 
 /// Fetch the open listing and fold it into the cache, recording the fate of
@@ -3490,6 +3503,36 @@ mod tests {
             persisted,
             vec![1],
             "a failed credential lookup must not delete the last known open reviews"
+        );
+    }
+
+    #[test]
+    fn only_outage_shaped_sync_failures_serve_the_stale_cache() {
+        let not_authenticated =
+            anyhow::anyhow!("no accounts").context(but_error::Context::new_static(
+                but_error::Code::ForgeNotAuthenticated,
+                "Not authenticated.",
+            ));
+        let network = anyhow::anyhow!("connection refused").context(
+            but_error::Context::new_static(but_error::Code::NetworkError, "Unable to connect."),
+        );
+        let api_failure = anyhow::anyhow!("Failed to list open pull requests: 500");
+
+        assert!(
+            serves_stale_reviews(&not_authenticated, false),
+            "missing credentials say nothing about the forge, even an empty cache stays valid"
+        );
+        assert!(
+            serves_stale_reviews(&network, true),
+            "a transient outage must not wipe out the last known open reviews"
+        );
+        assert!(
+            !serves_stale_reviews(&network, false),
+            "an empty cache has nothing usable, cold listings still surface the outage"
+        );
+        assert!(
+            !serves_stale_reviews(&api_failure, true),
+            "a forge-side failure can require user action and must be surfaced"
         );
     }
 

--- a/crates/but-github/src/lib.rs
+++ b/crates/but-github/src/lib.rs
@@ -318,9 +318,26 @@ pub async fn get_gh_user(
 
 /// Check if an error is a network connectivity error.
 ///
-/// This includes DNS resolution failures, connection timeouts, connection refused, etc.
+/// This includes DNS resolution failures, connection timeouts, connection
+/// refused, and connections dropped while the response body was being read.
+/// reqwest wraps both body I/O failures and malformed payloads as the same
+/// decode kind, so the source chain decides: a serde cause means the payload
+/// was malformed, anything else means the transport failed mid-response.
 pub(crate) fn is_network_error(err: &reqwest::Error) -> bool {
-    err.is_timeout() || err.is_connect() || err.is_request()
+    if err.is_timeout() || err.is_connect() || err.is_request() {
+        return true;
+    }
+    if !err.is_decode() {
+        return false;
+    }
+    let mut source = std::error::Error::source(err);
+    while let Some(cause) = source {
+        if cause.downcast_ref::<serde_json::Error>().is_some() {
+            return false;
+        }
+        source = cause.source();
+    }
+    true
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]

--- a/crates/but-gitlab/Cargo.toml
+++ b/crates/but-gitlab/Cargo.toml
@@ -25,6 +25,7 @@ anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 reqwest = { workspace = true, features = ["json"] }
+serde_json.workspace = true
 urlencoding.workspace = true
 schemars = { workspace = true, optional = true }
 but-schemars = { workspace = true, optional = true }

--- a/crates/but-gitlab/src/lib.rs
+++ b/crates/but-gitlab/src/lib.rs
@@ -186,9 +186,26 @@ pub async fn get_gl_user(
 
 /// Check if an error is a network connectivity error.
 ///
-/// This includes DNS resolution failures, connection timeouts, connection refused, etc.
+/// This includes DNS resolution failures, connection timeouts, connection
+/// refused, and connections dropped while the response body was being read.
+/// reqwest wraps both body I/O failures and malformed payloads as the same
+/// decode kind, so the source chain decides: a serde cause means the payload
+/// was malformed, anything else means the transport failed mid-response.
 fn is_network_error(err: &reqwest::Error) -> bool {
-    err.is_timeout() || err.is_connect() || err.is_request()
+    if err.is_timeout() || err.is_connect() || err.is_request() {
+        return true;
+    }
+    if !err.is_decode() {
+        return false;
+    }
+    let mut source = std::error::Error::source(err);
+    while let Some(cause) = source {
+        if cause.downcast_ref::<serde_json::Error>().is_some() {
+            return false;
+        }
+        source = cause.source();
+    }
+    true
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]

--- a/crates/but-gitlab/src/mr.rs
+++ b/crates/but-gitlab/src/mr.rs
@@ -10,6 +10,7 @@ pub async fn list(
     GitLabClient::from_storage(storage, preferred_account)?
         .list_open_mrs(project_id)
         .await
+        .map_err(classify_forge_error)
         .context("Failed to list open merge requests")
 }
 
@@ -21,6 +22,7 @@ pub async fn list_recently_closed(
     GitLabClient::from_storage(storage, preferred_account)?
         .list_recently_closed_mrs(project_id)
         .await
+        .map_err(classify_forge_error)
         .context("Failed to list recently closed merge requests")
 }
 
@@ -33,6 +35,7 @@ pub async fn list_all_for_target(
     GitLabClient::from_storage(storage, preferred_account)?
         .list_mrs_for_target(project_id, target_branch)
         .await
+        .map_err(classify_forge_error)
         .context("Failed to list merge requests for target branch")
 }
 
@@ -45,7 +48,25 @@ pub async fn list_for_commit(
     GitLabClient::from_storage(storage, preferred_account)?
         .list_mrs_for_commit(project_id, commit_sha)
         .await
+        .map_err(classify_forge_error)
         .context("Failed to list merge requests for commit")
+}
+
+/// Tag transport failures with `but_error::Code::NetworkError` so the desktop
+/// can present them appropriately (silent for offline) and cached readers can
+/// keep serving the last known data. Only applied to read paths — mutations
+/// should still surface failures.
+pub(crate) fn classify_forge_error(err: anyhow::Error) -> anyhow::Error {
+    if err
+        .downcast_ref::<reqwest::Error>()
+        .is_some_and(crate::is_network_error)
+    {
+        return err.context(but_error::Context::new_static(
+            but_error::Code::NetworkError,
+            "Unable to connect to GitLab.",
+        ));
+    }
+    err
 }
 
 pub async fn create(
@@ -70,6 +91,7 @@ pub async fn get(
     let mr = GitLabClient::from_storage(storage, preferred_account)?
         .get_merge_request(project_id, mr_iid)
         .await
+        .map_err(classify_forge_error)
         .context("Failed to get merge request")?;
     Ok(mr)
 }
@@ -117,4 +139,93 @@ pub async fn set_auto_merge(
         .set_merge_request_auto_merge(&params)
         .await
         .context("Failed to set MR auto-merge state")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Serve one request with the given raw HTTP response, then hang up.
+    fn one_shot_server(response: &'static [u8]) -> std::net::SocketAddr {
+        use std::io::{Read, Write};
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0u8; 1024];
+            let _ = stream.read(&mut request);
+            let _ = stream.write_all(response);
+        });
+        addr
+    }
+
+    #[test]
+    fn interrupted_response_bodies_carry_the_network_error_code() {
+        // The response promises more bytes than arrive before the connection
+        // closes — the shape of a network dropping mid-transfer.
+        let addr = one_shot_server(
+            b"HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: 100\r\n\r\n[{\"iid\"",
+        );
+        let reqwest_err = reqwest::blocking::get(format!("http://{addr}/"))
+            .unwrap()
+            .json::<serde_json::Value>()
+            .unwrap_err();
+        let err = classify_forge_error(anyhow::Error::from(reqwest_err));
+        assert_eq!(
+            err.downcast_ref::<but_error::Context>().map(|ctx| ctx.code),
+            Some(but_error::Code::NetworkError),
+            "a connection lost while reading the body is an outage like any other"
+        );
+    }
+
+    #[test]
+    fn malformed_payloads_stay_unclassified() {
+        // The body arrives in full but is not JSON — a forge-side problem,
+        // not an outage.
+        let addr = one_shot_server(
+            b"HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: 12\r\n\r\nnot-json-12b",
+        );
+        let reqwest_err = reqwest::blocking::get(format!("http://{addr}/"))
+            .unwrap()
+            .json::<serde_json::Value>()
+            .unwrap_err();
+        let err = classify_forge_error(anyhow::Error::from(reqwest_err));
+        assert!(
+            err.downcast_ref::<but_error::Context>().is_none(),
+            "an unparseable payload must not be presented as an offline network"
+        );
+    }
+
+    #[test]
+    fn connection_failures_carry_the_network_error_code() {
+        // Binding an ephemeral port and dropping the listener leaves a port
+        // that was just proven closed; connecting to it produces the same
+        // `reqwest::Error` shape as an unreachable GitLab host.
+        let port = std::net::TcpListener::bind("127.0.0.1:0")
+            .unwrap()
+            .local_addr()
+            .unwrap()
+            .port();
+        let reqwest_err = reqwest::blocking::Client::new()
+            .get(format!("http://127.0.0.1:{port}"))
+            .send()
+            .unwrap_err();
+        let err = classify_forge_error(anyhow::Error::from(reqwest_err));
+        assert_eq!(
+            err.downcast_ref::<but_error::Context>().map(|ctx| ctx.code),
+            Some(but_error::Code::NetworkError),
+            "cached readers key their stale-data fallback off this code"
+        );
+    }
+
+    #[test]
+    fn api_failures_stay_unclassified() {
+        let err = classify_forge_error(anyhow::anyhow!(
+            "Failed to list open merge requests: 500 Internal Server Error"
+        ));
+        assert!(
+            err.downcast_ref::<but_error::Context>().is_none(),
+            "a forge-side failure must not be presented as an offline network"
+        );
+    }
 }


### PR DESCRIPTION
When a cached review listing went stale, `CacheWithFallback` ran a live sync and returned any failure — so a transient forge or network outage wiped the review list for every cached read. This was the largest unresolved `list_reviews` error cohort in production.

- `CacheWithFallback` now serves the last known open reviews when the sync fails with a `NetworkError` and the cache has at least one, mirroring the existing missing-credentials fallback. An empty cache has no "confirmed empty" watermark, so cold listings still surface the failure, as do explicit `NoCache` reads and every other error (404, invalid tokens, API failures).
- GitLab and Bitbucket transport failures were untyped `Unknown` errors. Their read paths now classify connect/timeout/request failures as `NetworkError`, matching the GitHub provider — which also lets the desktop's existing silent network-error handling apply to all three forges.

Fixes GB-1914