### PR TITLE
Make repeated commit moves a true no-op

### DIFF
--- a/crates/but-api/src/commit/move_commit.rs
+++ b/crates/but-api/src/commit/move_commit.rs
@@ -1,6 +1,7 @@
 use but_api_macros::but_api;
 use but_core::{DryRun, sync::RepoExclusive};
 use but_oplog::legacy::{OperationKind, SnapshotDetails};
+use but_rebase::graph_rebase::MoveMaterialization;
 use but_rebase::graph_rebase::mutate::{InsertSide, RelativeTo};
 use tracing::instrument;
 
@@ -50,17 +51,16 @@ pub fn commit_move_only_with_perm(
     dry_run: DryRun,
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<CommitMoveResult> {
-    let mut meta = ctx.meta()?;
-    let (repo, mut ws, mut db) = ctx.workspace_mut_and_db_mut_with_perm(perm)?;
-    let editor = but_rebase::graph_rebase::Editor::create(&mut ws, &mut meta, &repo, &mut db)?;
-    let rebase =
-        but_workspace::commit::move_commits(editor, subject_commit_ids, relative_to, side)?;
-
-    Ok(CommitMoveResult {
-        workspace: WorkspaceState::from_successful_rebase(rebase, &repo, dry_run)?,
-    })
+    if let Some(current) = preflight_with_perm(ctx, &subject_commit_ids, &relative_to, side, perm)?
+    {
+        return Ok(current);
+    }
+    commit_move_only_inner(ctx, subject_commit_ids, relative_to, side, dry_run, perm)
 }
 
+// Keep private helpers below the exported API declarations. The SDK generator
+// records this attribute's line in source links, so inserting helpers above it
+// creates generated-only churn.
 /// Moves `subject_commit_ids` to `side` of `relative_to` and records an oplog
 /// snapshot on success.
 ///
@@ -105,18 +105,65 @@ pub fn commit_move_with_perm(
     dry_run: DryRun,
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<CommitMoveResult> {
+    if let Some(current) = preflight_with_perm(ctx, &subject_commit_ids, &relative_to, side, perm)?
+    {
+        return Ok(current);
+    }
     let maybe_oplog_entry = but_oplog::UnmaterializedOplogSnapshot::from_details_with_perm(
         ctx,
         SnapshotDetails::new(OperationKind::MoveCommit).with_count(subject_commit_ids.len()),
         perm.read_permission(),
         dry_run,
     );
-
-    let res = commit_move_only_with_perm(ctx, subject_commit_ids, relative_to, side, dry_run, perm);
+    let result = commit_move_only_inner(ctx, subject_commit_ids, relative_to, side, dry_run, perm);
     if let Some(snapshot) = maybe_oplog_entry
-        && res.is_ok()
+        && result.is_ok()
     {
         snapshot.commit(ctx, perm).ok();
     }
-    res
+    result
+}
+
+fn commit_move_only_inner(
+    ctx: &mut but_ctx::Context,
+    subject_commit_ids: Vec<gix::ObjectId>,
+    relative_to: RelativeTo,
+    side: InsertSide,
+    dry_run: DryRun,
+    perm: &mut RepoExclusive,
+) -> anyhow::Result<CommitMoveResult> {
+    let mut meta = ctx.meta()?;
+    let (repo, mut ws, mut db) = ctx.workspace_mut_and_db_mut_with_perm(perm)?;
+    let editor = but_rebase::graph_rebase::Editor::create(&mut ws, &mut meta, &repo, &mut db)?;
+    let rebase =
+        but_workspace::commit::move_commits(editor, subject_commit_ids, relative_to, side)?;
+    let workspace = WorkspaceState::from_successful_rebase(rebase, &repo, dry_run)?;
+    Ok(CommitMoveResult { workspace })
+}
+
+/// Return the current workspace state when move materialization can safely be skipped.
+fn preflight_with_perm(
+    ctx: &mut but_ctx::Context,
+    subject_commit_ids: &[gix::ObjectId],
+    relative_to: &RelativeTo,
+    side: InsertSide,
+    perm: &mut RepoExclusive,
+) -> anyhow::Result<Option<CommitMoveResult>> {
+    let mut meta = ctx.meta()?;
+    let (repo, mut ws, mut db) = ctx.workspace_mut_and_db_mut_with_perm(perm)?;
+    let effect = but_workspace::commit::move_commit::preflight_move_commits(
+        &mut ws,
+        &mut meta,
+        &repo,
+        &mut db,
+        subject_commit_ids.iter().copied(),
+        relative_to.clone(),
+        side,
+    )?;
+    if effect == MoveMaterialization::Required {
+        return Ok(None);
+    }
+    let workspace =
+        WorkspaceState::from_workspace_with_db(&ws, &mut meta, &repo, Default::default(), &mut db)?;
+    Ok(Some(CommitMoveResult { workspace }))
 }

--- a/crates/but-api/tests/api/commit_move.rs
+++ b/crates/but-api/tests/api/commit_move.rs
@@ -1,0 +1,164 @@
+use but_core::DryRun;
+use but_rebase::graph_rebase::mutate::{InsertSide, RelativeTo};
+use gitbutler_oplog::OplogExt as _;
+
+fn loose_object_count(repo: &gix::Repository) -> anyhow::Result<String> {
+    let output = but_testsupport::git(repo)
+        .args(["count-objects", "-v"])
+        .output()?;
+    anyhow::ensure!(output.status.success(), "git count-objects failed");
+    Ok(String::from_utf8(output.stdout)?)
+}
+
+#[test]
+fn repeated_move_returns_current_state_without_another_snapshot() -> anyhow::Result<()> {
+    let (repo, _tmp) =
+        crate::support::writable_scenario("../../../../but/tests/fixtures/scenario/two-stacks");
+    crate::support::persist_default_target(&repo)?;
+    let mut ctx = but_ctx::Context::from_repo_for_testing(repo)?.with_memory_app_cache();
+    let (source, target): (gix::ObjectId, gix::refs::FullName) = {
+        let repo = ctx.repo.get()?;
+        (
+            repo.rev_parse_single("refs/heads/A")?.detach(),
+            "refs/heads/B".try_into()?,
+        )
+    };
+
+    let first = but_api::commit::move_commit::commit_move(
+        &mut ctx,
+        vec![source],
+        RelativeTo::Reference(target.clone()),
+        InsertSide::Below,
+        DryRun::No,
+    )?;
+    let moved = first
+        .workspace
+        .replaced_commits
+        .get(&source)
+        .copied()
+        .unwrap_or(source);
+    let refs_before_repeat = but_testsupport::visualize_commit_graph_all(&*ctx.repo.get()?)?;
+    let oplog_head = ctx.oplog_head()?;
+    let oplog_file = std::fs::read(ctx.project_data_dir().join("operations-log.toml"))?;
+    let objects_before_repeat = loose_object_count(&*ctx.repo.get()?)?;
+
+    let repeated = but_api::commit::move_commit::commit_move(
+        &mut ctx,
+        vec![moved],
+        RelativeTo::Reference(target),
+        InsertSide::Below,
+        DryRun::No,
+    )?;
+
+    assert!(
+        repeated.workspace.replaced_commits.is_empty(),
+        "the repeated result should describe the unchanged current workspace"
+    );
+    assert_eq!(
+        but_testsupport::visualize_commit_graph_all(&*ctx.repo.get()?)?,
+        refs_before_repeat,
+        "the repeated API call should leave every reference unchanged"
+    );
+    assert_eq!(
+        ctx.oplog_head()?,
+        oplog_head,
+        "the no-op should leave the oplog head unchanged"
+    );
+    assert_eq!(
+        std::fs::read(ctx.project_data_dir().join("operations-log.toml"))?,
+        oplog_file,
+        "the no-op should not change oplog state"
+    );
+    assert_eq!(
+        loose_object_count(&*ctx.repo.get()?)?,
+        objects_before_repeat,
+        "the no-op should not write snapshot objects"
+    );
+    let moves = ctx
+        .snapshots_iter(None, Vec::new(), None)?
+        .filter_map(Result::ok)
+        .filter(|snapshot| {
+            snapshot.details.as_ref().is_some_and(|details| {
+                details.operation == but_oplog::legacy::OperationKind::MoveCommit
+            })
+        })
+        .count();
+    assert_eq!(moves, 1, "only the first API move should be recorded");
+    Ok(())
+}
+
+#[test]
+fn repeated_move_in_ad_hoc_workspace_is_unchanged() -> anyhow::Result<()> {
+    let (repo, _tmp) = crate::support::repo_with_feature_branch()?;
+    crate::support::set_project_target_to_feature(&repo)?;
+    let mut ctx = but_ctx::Context::from_repo_for_testing(repo)?.with_memory_app_cache();
+    let (source, target): (gix::ObjectId, gix::refs::FullName) = {
+        let repo = ctx.repo.get()?;
+        (
+            repo.rev_parse_single("refs/heads/main")?.detach(),
+            "refs/heads/feature".try_into()?,
+        )
+    };
+
+    let first = but_api::commit::move_commit::commit_move(
+        &mut ctx,
+        vec![source],
+        RelativeTo::Reference(target.clone()),
+        InsertSide::Below,
+        DryRun::No,
+    )?;
+    let moved = first
+        .workspace
+        .replaced_commits
+        .get(&source)
+        .copied()
+        .unwrap_or(source);
+    let refs_before_repeat = but_testsupport::visualize_commit_graph_all(&*ctx.repo.get()?)?;
+    let oplog_head = ctx.oplog_head()?;
+    let oplog_file = std::fs::read(ctx.project_data_dir().join("operations-log.toml"))?;
+    let objects_before_repeat = loose_object_count(&*ctx.repo.get()?)?;
+
+    let repeated = but_api::commit::move_commit::commit_move(
+        &mut ctx,
+        vec![moved],
+        RelativeTo::Reference(target),
+        InsertSide::Below,
+        DryRun::No,
+    )?;
+
+    assert!(
+        repeated.workspace.replaced_commits.is_empty(),
+        "a repeated move must not report replacement commit mappings"
+    );
+    assert_eq!(
+        but_testsupport::visualize_commit_graph_all(&*ctx.repo.get()?)?,
+        refs_before_repeat,
+        "a repeated move must leave refs and commit graph unchanged"
+    );
+    assert_eq!(
+        ctx.oplog_head()?,
+        oplog_head,
+        "a repeated move must leave the oplog head unchanged"
+    );
+    assert_eq!(
+        std::fs::read(ctx.project_data_dir().join("operations-log.toml"))?,
+        oplog_file,
+        "a repeated move must leave the oplog file unchanged"
+    );
+    assert_eq!(
+        loose_object_count(&*ctx.repo.get()?)?,
+        objects_before_repeat,
+        "a repeated move must not create loose objects"
+    );
+    assert_eq!(
+        ctx.snapshots_iter(None, Vec::new(), None)?
+            .filter_map(Result::ok)
+            .filter(|snapshot| snapshot.details.as_ref().is_some_and(|details| {
+                details.operation == but_oplog::legacy::OperationKind::MoveCommit
+            }))
+            .count(),
+        1,
+        "only the real move should create a MOVE snapshot"
+    );
+    Ok(())
+}

--- a/crates/but-api/tests/api/main.rs
+++ b/crates/but-api/tests/api/main.rs
@@ -7,6 +7,7 @@ mod branch_remove;
 mod branch_rename;
 mod changes_in_worktree;
 mod commit_cherry_pick;
+mod commit_move;
 mod commit_uncommit;
 #[cfg(feature = "legacy")]
 mod forge_info;

--- a/crates/but-rebase/src/graph_rebase/mod.rs
+++ b/crates/but-rebase/src/graph_rebase/mod.rs
@@ -318,7 +318,101 @@ pub struct SuccessfulRebase<'ws, 'meta, M: RefMetadata> {
     db: &'meta mut but_db::DbHandle,
 }
 
+/// Whether it is safe to skip materializing a completed whole-commit move.
+///
+/// A tree-identical rewrite of the synthetic workspace commit and its matching workspace-ref
+/// update may be skippable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MoveMaterialization {
+    /// Materialization cannot be skipped.
+    Required,
+    /// Materialization can be skipped while preserving all user commits, references, and checkout
+    /// state.
+    Skippable,
+}
+
 impl<'ws, 'meta, M: RefMetadata> SuccessfulRebase<'ws, 'meta, M> {
+    /// Determine whether it is safe to skip materializing this completed whole-commit move.
+    pub fn move_materialization(&self) -> Result<MoveMaterialization> {
+        let managed_workspace = self
+            .workspace
+            .graph
+            .managed_entrypoint_commit(&self.repo)?
+            .map(|commit| commit.id);
+
+        let mut workspace_rewrite = None;
+        for (old_id, new_id) in self.history.commit_mappings() {
+            if managed_workspace != Some(old_id) {
+                return Ok(MoveMaterialization::Required);
+            }
+            if self.repo.find_commit(old_id)?.tree_id()?
+                != self.repo.find_commit(new_id)?.tree_id()?
+            {
+                return Ok(MoveMaterialization::Required);
+            }
+            workspace_rewrite = Some((old_id, new_id));
+        }
+        for edit in &self.ref_edits {
+            let is_workspace_rewrite = self
+                .workspace
+                .ref_name()
+                .is_some_and(|name| name == edit.name)
+                && workspace_rewrite.is_some_and(|(old_id, new_id)| {
+                    matches!(
+                        &edit.change,
+                        gix::refs::transaction::Change::Update {
+                            expected: gix::refs::transaction::PreviousValue::MustExistAndMatch(
+                                gix::refs::Target::Object(old)
+                            ),
+                            new: gix::refs::Target::Object(new),
+                            ..
+                        } if *old == old_id && *new == new_id
+                    )
+                });
+            if !is_workspace_rewrite {
+                return Ok(MoveMaterialization::Required);
+            }
+        }
+        let head_name = self.repo.head_name()?;
+        let head_id = self.repo.head_id()?.detach();
+        for checkout in &self.checkouts {
+            match checkout {
+                Checkout::Head {
+                    selector,
+                    merge_base_override,
+                } => {
+                    let Some((target, ref_name)) = self.checkout_target(*selector)? else {
+                        return Ok(MoveMaterialization::Required);
+                    };
+                    if merge_base_override.is_some()
+                        || ref_name.as_ref() != head_name.as_ref()
+                        || (target != head_id && workspace_rewrite != Some((head_id, target)))
+                    {
+                        return Ok(MoveMaterialization::Required);
+                    }
+                }
+                Checkout::Worktree {
+                    selector,
+                    ref_name,
+                    initial_head,
+                    merge_base_override,
+                    ..
+                } => {
+                    let Some((target, target_ref)) = self.checkout_target(*selector)? else {
+                        return Ok(MoveMaterialization::Required);
+                    };
+                    if merge_base_override.is_some()
+                        || target != *initial_head
+                        || target_ref != *ref_name
+                    {
+                        return Ok(MoveMaterialization::Required);
+                    }
+                }
+            }
+        }
+        Ok(MoveMaterialization::Skippable)
+    }
+
     /// Returns the in-memory repository that backs this rebase preview.
     ///
     /// This repository may contain objects that have not been persisted yet,

--- a/crates/but-rebase/tests/rebase/graph_rebase/materialize.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/materialize.rs
@@ -1,7 +1,7 @@
 //! Tests for `materialize` vs `materialize_without_checkout` behavior differences
 use anyhow::{Context, Result};
 use but_graph::Graph;
-use but_rebase::graph_rebase::{Editor, Step};
+use but_rebase::graph_rebase::{Editor, MoveMaterialization, Step};
 use but_testsupport::{
     StackState, git_status, graph_tree, visualize_commit_graph_all,
     visualize_disk_tree_skip_dot_git,
@@ -335,6 +335,11 @@ fn materialize_repoints_head_when_checkout_reference_is_replaced() -> Result<()>
     editor.replace(main_selector, Step::new_reference(replacement_ref.clone()))?;
 
     let outcome = editor.rebase()?;
+    assert_eq!(
+        outcome.move_materialization()?,
+        MoveMaterialization::Required,
+        "a reference-only edit is not safe to skip materializing"
+    );
     let overlayed = graph_tree(&outcome.overlayed_graph()?).to_string();
     snapbox::assert_data_eq!(
         &overlayed,

--- a/crates/but-rebase/tests/rebase/graph_rebase/workspace_commit_behaviour.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/workspace_commit_behaviour.rs
@@ -2,7 +2,7 @@
 
 use anyhow::Result;
 use but_graph::Graph;
-use but_rebase::graph_rebase::{Editor, LookupStep, Pick, Step};
+use but_rebase::graph_rebase::{Editor, LookupStep, MoveMaterialization, Pick, Step};
 use but_testsupport::{cat_commit, graph_tree, visualize_commit_graph_all};
 use snapbox::prelude::*;
 
@@ -51,6 +51,11 @@ fn workspace_remains_unchanged_with_no_operations() -> Result<()> {
     );
 
     let outcome = editor.rebase()?;
+    assert_eq!(
+        outcome.move_materialization()?,
+        MoveMaterialization::Skippable,
+        "an untouched managed workspace is safe to skip materializing"
+    );
     let overlayed = graph_tree(&outcome.overlayed_graph()?).to_string();
     snapbox::assert_data_eq!(
         &overlayed,
@@ -243,6 +248,11 @@ fn ad_hoc_workspace_keeps_regular_defaults() -> Result<()> {
     );
 
     let outcome = editor.rebase()?;
+    assert_eq!(
+        outcome.move_materialization()?,
+        MoveMaterialization::Skippable,
+        "an untouched ad-hoc workspace is safe to skip materializing"
+    );
     let overlayed = graph_tree(&outcome.overlayed_graph()?).to_string();
     snapbox::assert_data_eq!(
         &overlayed,

--- a/crates/but-workspace/src/commit/move_commit.rs
+++ b/crates/but-workspace/src/commit/move_commit.rs
@@ -1,9 +1,9 @@
 //! Move a commit within or across branches and stacks.
 
 use anyhow::bail;
-use but_core::RefMetadata;
+use but_core::{RefMetadata, commit::SignCommit};
 use but_rebase::graph_rebase::{
-    Editor, Step, SuccessfulRebase,
+    Editor, GraphEditorOptions, MoveMaterialization, Step, SuccessfulRebase,
     mutate::{InsertSide, RelativeTo},
 };
 
@@ -57,4 +57,23 @@ pub fn move_commits<'ws, 'meta, M: RefMetadata>(
     }
 
     editor.rebase()
+}
+
+/// Determine whether it is safe to skip materializing a whole-commit move.
+/// Signing is disabled so classification cannot invoke a signer or alter signing fallback state.
+pub fn preflight_move_commits<'meta, M: RefMetadata>(
+    workspace: &mut but_graph::Workspace,
+    meta: &'meta mut M,
+    repo: &gix::Repository,
+    db: &'meta mut but_db::DbHandle,
+    subject_commit_ids: impl IntoIterator<Item = gix::ObjectId>,
+    relative_to: RelativeTo,
+    side: InsertSide,
+) -> anyhow::Result<MoveMaterialization> {
+    let options = GraphEditorOptions {
+        default_sign_commit: SignCommit::No,
+        extra_mutable_refs: Vec::new(),
+    };
+    let editor = Editor::create_with_opts(workspace, meta, repo, db, &options)?;
+    move_commits(editor, subject_commit_ids, relative_to, side)?.move_materialization()
 }

--- a/crates/but-workspace/tests/workspace/commit/move_commit.rs
+++ b/crates/but-workspace/tests/workspace/commit/move_commit.rs
@@ -1,6 +1,7 @@
 use bstr::ByteSlice;
+use but_core::{GitConfigSettings, RepositoryExt as _};
 use but_rebase::graph_rebase::{
-    Editor,
+    Editor, MoveMaterialization,
     mutate::{InsertSide, RelativeTo},
 };
 use but_testsupport::{graph_workspace, visualize_commit_graph_all};
@@ -19,6 +20,52 @@ fn parent_subjects(repo: &gix::Repository, rev: &str) -> anyhow::Result<Vec<Stri
             Ok(parent.message_raw()?.trim_end().to_str_lossy().to_string())
         })
         .collect()
+}
+
+#[test]
+fn move_preflight_does_not_invoke_commit_signing() -> anyhow::Result<()> {
+    let (_tmp, graph, mut repo, mut meta, _description, mut db) =
+        named_writable_scenario_with_description_and_graph(
+            "ws-ref-ws-commit-single-stack-double-stack",
+            |meta| {
+                add_stack_with_segments(meta, 1, "A", StackState::InWorkspace, &[]);
+                add_stack_with_segments(meta, 2, "C", StackState::InWorkspace, &["B"]);
+            },
+        )?;
+    repo.set_git_settings(&GitConfigSettings {
+        gitbutler_sign_commits: Some(true),
+        signing_key: Some("BAD-key".into()),
+        signing_format: Some("ssh".into()),
+        gpg_ssh_program: Some("/definitely/missing/signer".into()),
+        ..Default::default()
+    })?;
+    repo.reload()?;
+    let mut ws = graph.into_workspace()?;
+    let source = repo.rev_parse_single("C")?.detach();
+    let target = repo.rev_parse_single("A")?.detach();
+
+    let effect = but_workspace::commit::move_commit::preflight_move_commits(
+        &mut ws,
+        &mut meta,
+        &repo,
+        &mut db,
+        [source],
+        RelativeTo::Commit(target),
+        InsertSide::Above,
+    )?;
+
+    assert_eq!(
+        effect,
+        MoveMaterialization::Required,
+        "a real move must require materialization"
+    );
+    repo.reload()?;
+    assert_eq!(
+        repo.config_snapshot().boolean("gitbutler.signCommits"),
+        Some(true),
+        "preflight must not change signing fallback state"
+    );
+    Ok(())
 }
 
 #[test]
@@ -62,12 +109,27 @@ fn move_top_commit_to_top_of_another_stack() -> anyhow::Result<()> {
 
 "#]]
     );
-    let editor = Editor::create(&mut ws, &mut meta, &repo, &mut db)?;
     let a_commit = repo.rev_parse_single("A")?.detach();
     let b_commit = repo.rev_parse_single("B")?.detach();
     let c_commit = repo.rev_parse_single("C")?.detach();
 
+    let effect = but_workspace::commit::move_commit::preflight_move_commits(
+        &mut ws,
+        &mut meta,
+        &repo,
+        &mut db,
+        [c_commit],
+        RelativeTo::Commit(a_commit),
+        InsertSide::Above,
+    )?;
+    assert_eq!(
+        effect,
+        MoveMaterialization::Required,
+        "moving the commit between branches cannot skip materialization"
+    );
+
     // Put C commit at the top of A
+    let editor = Editor::create(&mut ws, &mut meta, &repo, &mut db)?;
     let rebase = but_workspace::commit::move_commits(
         editor,
         [c_commit],
@@ -84,6 +146,21 @@ fn move_top_commit_to_top_of_another_stack() -> anyhow::Result<()> {
     let new_c_commit = commit_mapping.get(&c_commit);
     let tip_of_a_branch = repo.rev_parse_single("A")?.detach();
     let tip_of_c_branch = repo.rev_parse_single("C")?.detach();
+
+    let repeated_effect = but_workspace::commit::move_commit::preflight_move_commits(
+        &mut ws,
+        &mut meta,
+        &repo,
+        &mut db,
+        [tip_of_a_branch],
+        RelativeTo::Commit(a_commit),
+        InsertSide::Above,
+    )?;
+    assert_eq!(
+        repeated_effect,
+        MoveMaterialization::Skippable,
+        "the repeated move is safe to skip materializing"
+    );
 
     assert_eq!(
         Some(&tip_of_a_branch),

--- a/crates/but/src/command/legacy/move.rs
+++ b/crates/but/src/command/legacy/move.rs
@@ -7,8 +7,8 @@ use but_api::{
 };
 use but_core::{DiffSpec, DryRun, RefMetadata, ref_metadata::StackId, sync::RepoExclusive};
 use but_ctx::Context;
-use but_rebase::graph_rebase::mutate::RelativeTo;
-use but_transaction::Transaction;
+use but_rebase::graph_rebase::{MoveMaterialization, mutate::RelativeTo};
+use but_transaction::{Commit, Transaction};
 use but_workspace::branch::create_reference::Anchor;
 use gitbutler_oplog::entry::{OperationKind, SnapshotDetails};
 use gix::refs::FullName;
@@ -35,6 +35,7 @@ use crate::{
 };
 
 pub enum MoveOutcome {
+    NoOp,
     Commits {
         sources: NonEmpty<CommitId>,
         moved_commits: NonEmpty<CommitId>,
@@ -65,6 +66,7 @@ impl CliOutputHuman for MoveOutcome {
         _theme: &Theme,
     ) -> anyhow::Result<()> {
         match self {
+            Self::NoOp => write!(out, "Nothing to move")?,
             Self::Commits {
                 sources,
                 moved_commits: _,
@@ -151,6 +153,7 @@ impl CliOutput for MoveOutcome {
             rename_all_fields = "camelCase"
         )]
         enum Output {
+            NoOp,
             Commits {
                 commits: Vec<MovedCommit>,
                 #[serde(skip_serializing_if = "Option::is_none")]
@@ -177,6 +180,7 @@ impl CliOutput for MoveOutcome {
         }
 
         match self {
+            Self::NoOp => Output::NoOp,
             Self::Commits {
                 sources,
                 moved_commits,
@@ -227,7 +231,7 @@ pub fn r#move(
     ctx: &mut Context,
     _out: IntermediateChannel<'_>,
     args: Platform,
-) -> CliResult<(MoveOutcome, WorkspaceState)> {
+) -> CliResult<(MoveOutcome, Option<WorkspaceState>)> {
     let mut guard = ctx.exclusive_worktree_access();
     let mut meta = ctx.meta()?;
     let id_map = IdMap::new_from_context(ctx, guard.read_permission())?;
@@ -300,6 +304,33 @@ pub struct MoveCommitsRelativeToOperation {
 }
 
 impl MoveCommitsRelativeToOperation {
+    fn preflight_is_no_op(
+        &self,
+        ctx: &mut Context,
+        meta: &mut impl RefMetadata,
+        perm: &mut RepoExclusive,
+    ) -> anyhow::Result<bool> {
+        let (relative_to, side) = match &self.target {
+            MoveTarget::Commit { commit, side } => {
+                (RelativeTo::Commit(commit.commit_id), (*side).into())
+            }
+            MoveTarget::BranchTip { name } => {
+                (RelativeTo::Reference(name.clone()), Side::Below.into())
+            }
+            MoveTarget::BranchBucket { .. } => return Ok(false),
+        };
+        let (repo, mut ws, mut db) = ctx.workspace_mut_and_db_mut_with_perm(perm)?;
+        Ok(but_workspace::commit::move_commit::preflight_move_commits(
+            &mut ws,
+            meta,
+            &repo,
+            &mut db,
+            self.sources.iter().map(|source| source.commit_id),
+            relative_to,
+            side,
+        )? == MoveMaterialization::Skippable)
+    }
+
     fn execute(
         self,
         tx: &mut Transaction<'_, '_, impl RefMetadata>,
@@ -329,7 +360,6 @@ impl MoveCommitsRelativeToOperation {
         };
 
         tx.move_commits(self.sources.iter().map(|c| c.commit_id), relative_to, side)?;
-
         Ok(new_branch_name)
     }
 }
@@ -923,7 +953,12 @@ pub fn run(
     meta: &mut impl RefMetadata,
     perm: &mut RepoExclusive,
     move_op: MoveOperation,
-) -> anyhow::Result<(MoveOutcome, WorkspaceState)> {
+) -> anyhow::Result<(MoveOutcome, Option<WorkspaceState>)> {
+    if let MoveOperation::CommitsRelativeTo(op) = &move_op
+        && op.preflight_is_no_op(ctx, meta, perm)?
+    {
+        return Ok((MoveOutcome::NoOp, None));
+    }
     let snapshot_details = match &move_op {
         MoveOperation::CommitsRelativeTo(_) | MoveOperation::CommitsToNewBranch(_) => {
             SnapshotDetails::new(OperationKind::MoveCommit)
@@ -934,14 +969,14 @@ pub fn run(
         MoveOperation::StackBranch(_) => SnapshotDetails::new(OperationKind::MoveBranch),
         MoveOperation::UnstackBranch(_) => SnapshotDetails::new(OperationKind::TearOffBranch),
     };
-    let (outcome, ws) = but_transaction::with_transaction_with_perm(
+    let (outcome, workspace) = but_transaction::with_transaction_with_perm(
         ctx,
         meta,
         perm,
         snapshot_details,
         DryRun::No,
         |mut tx| {
-            let outcome = match move_op {
+            Ok(Commit(match move_op {
                 MoveOperation::CommitsRelativeTo(op) => {
                     let sources = op.sources.clone();
                     let target = op.target.clone();
@@ -1014,11 +1049,9 @@ pub fn run(
                     op.execute(&mut tx)?;
                     MoveOutcome::UnstackBranch { source_branch }
                 }
-            };
-
-            Ok(but_transaction::Commit(outcome))
+            }))
         },
     )?;
 
-    Ok((outcome, ws))
+    Ok((outcome, Some(workspace)))
 }

--- a/crates/but/src/command/legacy/status/tui/app/move_mode.rs
+++ b/crates/but/src/command/legacy/status/tui/app/move_mode.rs
@@ -362,12 +362,15 @@ impl App {
             }
         };
 
-        let selection_after_reload = move_with(ctx, move_op)?;
+        let outcome = move_with(ctx, move_op)?;
 
-        messages.extend([
-            Message::EnterNormalModeAfterConfirmingOperation,
-            Message::Reload(selection_after_reload, ReloadCause::Mutation),
-        ]);
+        messages.push(Message::EnterNormalModeAfterConfirmingOperation);
+        if !matches!(outcome, MoveOperationOutcome::NoOp) {
+            messages.push(Message::Reload(
+                selection_after_move(outcome),
+                ReloadCause::Mutation,
+            ));
+        }
 
         Ok(())
     }
@@ -402,15 +405,16 @@ fn move_commits_operation(
     ))
 }
 
-fn move_with(
-    ctx: &mut Context,
-    move_op: MoveOperation,
-) -> anyhow::Result<Option<SelectAfterReload>> {
+fn move_with(ctx: &mut Context, move_op: MoveOperation) -> anyhow::Result<MoveOperationOutcome> {
     let mut guard = ctx.exclusive_worktree_access();
     let mut meta = ctx.meta()?;
     let (outcome, _ws) = r#move::run(ctx, &mut meta, guard.write_permission(), move_op)?;
+    Ok(outcome)
+}
 
-    Ok(match outcome {
+pub(crate) fn selection_after_move(outcome: MoveOperationOutcome) -> Option<SelectAfterReload> {
+    match outcome {
+        MoveOperationOutcome::NoOp => None,
         MoveOperationOutcome::Commits { moved_commits, .. } => {
             Some(SelectAfterReload::Commit(moved_commits.head.commit_id))
         }
@@ -421,5 +425,5 @@ fn move_with(
         | MoveOperationOutcome::UnstackBranch { source_branch } => Some(SelectAfterReload::Branch(
             source_branch.shorten().to_string(),
         )),
-    })
+    }
 }

--- a/crates/but/src/command/legacy/status/tui/tests/move_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/move_tests.rs
@@ -7,6 +7,38 @@ use crate::command::legacy::status::tui::tests::utils::{
 };
 
 #[test]
+fn no_op_move_preserves_open_details_state() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
+
+    let mut tui = test_status_tui(env);
+
+    tui.input([KeyCode::Down, KeyCode::Down]);
+    tui.input('d');
+    tui.render_with_messages(None, Vec::new());
+    tui.input('m');
+    let details_selection = tui
+        .input(KeyCode::Up)
+        .app()
+        .details
+        .selection()
+        .cloned()
+        .expect("the open details view should describe the move target");
+
+    let result = tui.input(KeyCode::Enter);
+
+    assert!(
+        result.app().is_details_visible,
+        "a no-op move should leave the details view open"
+    );
+    assert_eq!(
+        result.app().details.selection(),
+        Some(&details_selection),
+        "a no-op move should not reload and clear the open details state"
+    );
+}
+
+#[test]
 fn esc_leaves_move_mode() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
     env.setup_metadata(&["A"]);

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -1264,7 +1264,7 @@ async fn match_subcommand(
                 command::legacy::r#move::r#move(&mut ctx, IntermediateChannel::new(out), move_args)
                     .emit_metrics(metrics_ctx)?;
             out.print_cli_output(outcome)?;
-            Some(ws)
+            ws
         }
         #[cfg(feature = "legacy")]
         Subcommands::Push(push_args) => {

--- a/crates/but/tests/but/command/move.rs
+++ b/crates/but/tests/but/command/move.rs
@@ -1,3 +1,4 @@
+use gitbutler_oplog::OplogExt as _;
 use snapbox::IntoData as _;
 
 use crate::{
@@ -2652,6 +2653,154 @@ fn move_commit_to_branch_smoke() {
     assert!(
         branch_b_commits_after.contains(&source_cli_id),
         "moved commit should be present on branch B"
+    );
+}
+
+#[test]
+fn repeating_move_commit_to_branch_is_a_no_op() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
+
+    let before = status_json(&env);
+    let source = branch_commit_cli_ids(&before, "A")[0].clone();
+
+    env.but(format!("move {source} --branch B"))
+        .assert()
+        .success();
+    let moved = status_json(&env);
+    let objects_before_repeat = but_testsupport::git(&env.open_repo())
+        .args(["count-objects", "-v"])
+        .output()
+        .expect("count objects after the real move")
+        .stdout;
+
+    env.but(format!("move {source} --branch B"))
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Nothing to move
+
+"#]]);
+    assert_eq!(
+        status_json(&env),
+        moved,
+        "repeating the move should leave workspace status unchanged"
+    );
+
+    env.but(format!("--json move {source} --branch B"))
+        .allow_json()
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+{
+  "type": "noOp"
+}
+
+"#]]);
+
+    env.but("oplog list")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Operations History
+──────────────────────────────────────────────────
+[..] 2000-01-02 00:00:00 [MOVE] Moved commit
+
+"#]]);
+    assert_eq!(
+        but_testsupport::git(&env.open_repo())
+            .args(["count-objects", "-v"])
+            .output()
+            .expect("count objects after repeated moves")
+            .stdout,
+        objects_before_repeat,
+        "repeated CLI moves should not write snapshot objects"
+    );
+
+    env.but("undo").assert().success();
+    assert_eq!(
+        status_json(&env),
+        before,
+        "one undo after repeated moves should restore the original refs and status"
+    );
+}
+
+#[test]
+fn repeating_move_in_single_branch_mode_is_a_no_op() {
+    let env = Sandbox::open_with_default_settings("one-fork");
+    env.but("config feature single-branch enable")
+        .assert()
+        .success();
+    env.file("second", "second\n");
+    env.but("commit -m 'add second'").assert().success();
+    let before = status_json(&env);
+    let commits = branch_commit_cli_ids(&before, "main");
+    let source = commits[1].clone();
+    let target = commits[0].clone();
+
+    env.but(format!("move {source} --above {target}"))
+        .assert()
+        .success();
+    let status_before_repeat = status_json(&env);
+    let commits = branch_commit_cli_ids(&status_before_repeat, "main");
+    let moved_source = commits[0].clone();
+    let moved_target = commits[1].clone();
+    let refs_before_repeat = env.invoke_git("show-ref");
+    let ctx = env.context();
+    let oplog_head = ctx.oplog_head().expect("oplog head after the real move");
+    let oplog_file = std::fs::read(ctx.project_data_dir().join("operations-log.toml"))
+        .expect("oplog file after the real move");
+    let objects_before_repeat = but_testsupport::git(&env.open_repo())
+        .args(["count-objects", "-v"])
+        .output()
+        .expect("count objects after the real move")
+        .stdout;
+
+    env.but(format!("move {moved_source} --above {moved_target}"))
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Nothing to move
+
+"#]]);
+
+    assert_eq!(
+        status_json(&env),
+        status_before_repeat,
+        "a repeated normal-Git move should leave workspace status unchanged"
+    );
+    assert_eq!(
+        env.invoke_git("show-ref"),
+        refs_before_repeat,
+        "a repeated normal-Git move should leave references unchanged"
+    );
+    assert_eq!(
+        ctx.oplog_head()
+            .expect("oplog head after the repeated move"),
+        oplog_head,
+        "a repeated normal-Git move should not create an oplog entry"
+    );
+    assert_eq!(
+        std::fs::read(ctx.project_data_dir().join("operations-log.toml"))
+            .expect("oplog file after the repeated move"),
+        oplog_file,
+        "a repeated normal-Git move should not change oplog state"
+    );
+    assert_eq!(
+        but_testsupport::git(&env.open_repo())
+            .args(["count-objects", "-v"])
+            .output()
+            .expect("count objects after the repeated move")
+            .stdout,
+        objects_before_repeat,
+        "a repeated normal-Git move should not write objects"
+    );
+    assert!(
+        env.open_repo()
+            .try_find_reference(but_core::WORKSPACE_REF_NAME)
+            .expect("workspace ref lookup succeeds")
+            .is_none(),
+        "single-branch mode should remain outside the managed workspace"
     );
 }
 

--- a/crates/but/tests/but/command/undo/undo_move.rs
+++ b/crates/but/tests/but/command/undo/undo_move.rs
@@ -26,3 +26,13 @@ fn undo_move_commit_to_branch() {
             .success();
     });
 }
+
+#[test]
+fn undo_move_commit_to_new_branch() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
+    env.setup_metadata(&["A"]);
+
+    run_mutate_undo_roundtrip_test(&env, |env| {
+        env.but("move ywx --branch new-branch").assert().success();
+    });
+}


### PR DESCRIPTION
## Context

Trigger: run the same whole-commit move to the same destination twice.

Symptom: the repeated command reported a mutation and added an unnecessary undo entry despite unchanged repository and workspace state.

## Change

Classify whole-commit move results before snapshot creation and skip materialization when it is safe. The shared classifier runs without commit signing and preserves snapshots for every real move across CLI, TUI, and API paths.

The CLI JSON output adds a new additive `{ "type": "noOp" }` variant for the truthful no-op result.

The TUI preserves its current view instead of triggering a mutation reload for a no-op.
