### PR TITLE
Tune CLI event reporting

### DIFF
--- a/crates/but/src/args/metrics.rs
+++ b/crates/but/src/args/metrics.rs
@@ -74,13 +74,16 @@ pub enum CommandName {
 }
 
 impl CommandName {
-    /// Percentage sample rate, between 0 and 1.
+    /// Sampling rate for successful events, in (0, 1].
     ///
-    /// 1 indicates that the command should always be submitted to posthog, and
-    /// 0 should never be submitted to posthog.
+    /// Failures bypass this policy and are emitted with a rate of 1. In PostHog,
+    /// estimate successful command totals with
+    /// `sum(1 / coalesce(samplingRate, 1))`.
     pub fn sample_rate(&self) -> f32 {
         match self {
-            Self::Unknown | Self::Status => 0.05,
+            Self::Status => 0.01,
+            Self::Diff | Self::RefreshRemoteData => 0.05,
+            Self::BranchList => 0.10,
             _ => 1.0,
         }
     }

--- a/crates/but/src/args/metrics.rs
+++ b/crates/but/src/args/metrics.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, strum::Display, clap::ValueEnum, Default)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, strum::Display, clap::ValueEnum)]
 #[serde(rename_all = "camelCase")]
 pub enum CommandName {
     Init,
@@ -44,6 +44,7 @@ pub enum CommandName {
     WorktreeUnarchive,
     WorktreeRemove,
     Switch,
+    Config,
     ForgeAuth,
     ForgeListUsers,
     ForgeForget,
@@ -63,14 +64,23 @@ pub enum CommandName {
     UpdateSuppress,
     UpdateInstall,
     Land,
+    Setup,
+    Teardown,
+    Expand,
+    Comment,
+    Completions,
+    Mcp,
+    Metrics,
+    Help,
+    Onboarding,
+    AgentLog,
+    Actions,
     SkillInstall,
     SkillCheck,
     AgentSetup,
     Pick,
     Clean,
     External,
-    #[default]
-    Unknown,
 }
 
 impl CommandName {

--- a/crates/but/src/args/metrics.rs
+++ b/crates/but/src/args/metrics.rs
@@ -53,7 +53,6 @@ pub enum CommandName {
     EnableAutoMerge,
     SetReviewReady,
     SetReviewDraft,
-    Completions,
     AliasCheck,
     AliasAdd,
     AliasRemove,
@@ -81,7 +80,7 @@ impl CommandName {
     /// 0 should never be submitted to posthog.
     pub fn sample_rate(&self) -> f32 {
         match self {
-            Self::Unknown | Self::Completions | Self::Status => 0.05,
+            Self::Unknown | Self::Status => 0.05,
             _ => 1.0,
         }
     }

--- a/crates/but/src/command/external.rs
+++ b/crates/but/src/command/external.rs
@@ -72,7 +72,7 @@ pub(crate) fn dispatch(current_dir: &Path, extra: &[OsString]) -> CliResult<()> 
         if status.success() {
             Ok(())
         } else {
-            std::process::exit(status.code().unwrap_or(1));
+            Err(CliError::ExternalCommandFailed(status.code().unwrap_or(1)))
         }
     }
 }

--- a/crates/but/src/error.rs
+++ b/crates/but/src/error.rs
@@ -109,8 +109,12 @@ pub enum CliError {
     BadInput(BadInput),
     /// We tried to execute the subcommand as an external command, but that command was not found.
     ExternalCommandNotFound(OsString),
+    /// An external subcommand failed with this exit code.
+    ExternalCommandFailed(i32),
     /// Something went wrong internally.
     Internal(anyhow::Error),
+    /// The command failed before its handler started.
+    Initialization(anyhow::Error),
     /// The CLI output was a "rejection". See [`CliOutputHuman::is_rejection`] for more details.
     CommandRejection,
 }
@@ -141,8 +145,10 @@ impl CliError {
             Self::ExternalCommandNotFound(command_name) => {
                 Self::ExternalCommandNotFound(command_name)
             }
+            Self::ExternalCommandFailed(code) => Self::ExternalCommandFailed(code),
             Self::CommandRejection => Self::CommandRejection,
             Self::Internal(value) => Self::Internal(value.context(context)),
+            Self::Initialization(value) => Self::Initialization(value.context(context)),
         }
     }
 
@@ -153,7 +159,9 @@ impl CliError {
             Self::ExternalCommandNotFound(command_name) => {
                 Self::ExternalCommandNotFound(command_name)
             }
+            Self::ExternalCommandFailed(code) => Self::ExternalCommandFailed(code),
             Self::Internal(value) => Self::Internal(value),
+            Self::Initialization(value) => Self::Initialization(value),
             Self::CommandRejection => Self::CommandRejection,
         }
     }
@@ -165,7 +173,9 @@ impl CliError {
             Self::ExternalCommandNotFound(command_name) => {
                 Self::ExternalCommandNotFound(command_name)
             }
+            Self::ExternalCommandFailed(code) => Self::ExternalCommandFailed(code),
             Self::Internal(value) => Self::Internal(value),
+            Self::Initialization(value) => Self::Initialization(value),
             Self::CommandRejection => Self::CommandRejection,
         }
     }
@@ -179,10 +189,12 @@ impl CliError {
 
                 anyhow::anyhow!("{err}")
             }
-            Self::ExternalCommandNotFound(..) | Self::CommandRejection => {
+            Self::ExternalCommandNotFound(..)
+            | Self::ExternalCommandFailed(..)
+            | Self::CommandRejection => {
                 anyhow::anyhow!("{self}")
             }
-            Self::Internal(error) => error,
+            Self::Internal(error) | Self::Initialization(error) => error,
         }
     }
 }
@@ -198,7 +210,10 @@ impl Display for CliError {
                     bad_input("Unrecognized subcommand").arg_value(command_name.to_string_lossy())
                 )
             }
-            Self::Internal(value) => value.fmt(f),
+            Self::ExternalCommandFailed(code) => {
+                write!(f, "External command exited with status {code}")
+            }
+            Self::Internal(value) | Self::Initialization(value) => value.fmt(f),
             Self::CommandRejection => {
                 // The output is printed elsewhere such as by [`OutputChannel::print_cli_output`].
                 f.write_str("Command rejected")

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -294,9 +294,11 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
     } else {
         None
     };
-    let _span =
-        tracing::info_span!("CLI", cmd = ?args.cmd.as_ref().map(|cmd| cmd.to_metrics_command()))
-            .entered();
+    let _span = tracing::info_span!(
+        "CLI",
+        cmd = ?args.cmd.as_ref().map(|cmd| cmd.to_metrics_command())
+    )
+    .entered();
 
     let namespace = option_env!("IDENTIFIER").unwrap_or("com.gitbutler.app");
     but_secret::secret::set_application_namespace(namespace);
@@ -328,13 +330,6 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
     let app_settings = app_settings()?.clone();
 
     let result = match args.cmd.take() {
-        Some(cmd @ Subcommands::External(_)) => {
-            let metrics_ctx = cmd.to_metrics_context(&app_settings, &args.current_dir);
-            let Subcommands::External(extra) = cmd else {
-                unreachable!("external command was matched above")
-            };
-            command::external::dispatch(&args.current_dir, &extra).emit_metrics(metrics_ctx)
-        }
         None => {
             // No arguments means run the default alias
             // The default alias expands to "status" which provides a helpful entry point
@@ -371,9 +366,10 @@ pub async fn handle_args(args: impl Iterator<Item = OsString>) -> Result<()> {
     }
 
     match result {
-        Err(CliError::Internal(err)) => Err(err),
+        Err(CliError::Internal(err) | CliError::Initialization(err)) => Err(err),
         Err(CliError::CommandRejection) => std::process::exit(1),
         Err(CliError::BadInput(bad_input)) => print_and_exit_non_zero(bad_input),
+        Err(CliError::ExternalCommandFailed(code)) => std::process::exit(code),
         Err(CliError::ExternalCommandNotFound(command_name)) => {
             // Commands removed by the revamp (`rub`) land here as unknown
             // external subcommands; teach their replacements before the error.
@@ -526,6 +522,11 @@ fn print_and_exit_non_zero<T: std::fmt::Display>(err: T) -> ! {
     std::process::exit(1)
 }
 
+enum DispatchOutcome {
+    Return,
+    ExitWithoutDestructors(anyhow::Result<()>),
+}
+
 async fn match_subcommand(
     cmd: Subcommands,
     args: Args,
@@ -554,6 +555,7 @@ async fn match_subcommand(
                 | Subcommands::Help { .. }
                 | Subcommands::Completions { .. }
                 | Subcommands::Metrics { .. }
+                | Subcommands::External(_)
         );
     let show_agent_skill_notice =
         app_settings.agent_skill_notices && out.format().is_human_text() && notice_worthy_command;
@@ -597,21 +599,41 @@ async fn match_subcommand(
         metrics_ctx.push_extra_prop("retiredCommitSyntax", true);
     }
 
-    let mut ctx = match cmd {
+    match dispatch_subcommand(cmd, args, app_settings, &mut output).await {
+        Ok(DispatchOutcome::Return) => Ok(()).emit_metrics(metrics_ctx),
+        Ok(DispatchOutcome::ExitWithoutDestructors(result)) => result
+            .emit_metrics(metrics_ctx)
+            .show_root_cause_error_then_exit_without_destructors(output),
+        Err(err) => Err(err).emit_metrics(metrics_ctx),
+    }
+}
+
+async fn dispatch_subcommand(
+    cmd: Subcommands,
+    args: Args,
+    app_settings: AppSettings,
+    output: &mut OutputChannel,
+) -> CliResult<DispatchOutcome> {
+    let out = &mut *output;
+
+    let ctx = match cmd {
+        Subcommands::External(extra) => {
+            return command::external::dispatch(&args.current_dir, &extra)
+                .map(|()| DispatchOutcome::Return);
+        }
         Subcommands::Metrics {
             command_name,
             props,
         } => {
             use args::metrics::CommandName;
+            let props = utils::metrics::prepare_transport_props(&props)?;
             let mut event = utils::metrics::Event::new(command_name.into());
-            if let Ok(props) = utils::metrics::Props::from_json_string(&props) {
-                props.update_event(&mut event);
-            }
+            props.update_event(&mut event);
             if matches!(command_name, CommandName::Commit | CommandName::CommitEmpty) {
                 utils::metrics::add_workspace_shape(&mut event, &args.current_dir);
             }
             utils::metrics::capture_event_blocking(&app_settings, event).await;
-            return Ok(());
+            return Ok(DispatchOutcome::Return);
         }
         Subcommands::Gui { new_window, path } => {
             let path = path
@@ -619,39 +641,38 @@ async fn match_subcommand(
                 .map(|path| args.current_dir.join(path))
                 .unwrap_or_else(|| args.current_dir.clone());
             return command::gui::open(&path, new_window)
-                .emit_metrics(metrics_ctx)
+                .map(|()| DispatchOutcome::Return)
                 .map_err(CliError::from);
         }
         Subcommands::Completions { shell } => {
             return command::completions::generate_completions(shell)
-                .emit_metrics(metrics_ctx)
+                .map(|()| DispatchOutcome::Return)
                 .map_err(CliError::from);
         }
         Subcommands::Update(update_args::Platform { cmd }) => {
             return command::update::handle(cmd, out, &app_settings)
-                .emit_metrics(metrics_ctx)
+                .map(|()| DispatchOutcome::Return)
                 .map_err(CliError::from);
         }
         Subcommands::Help { topic } => {
             command::help::print(out, topic)?;
-            return Ok(());
+            return Ok(DispatchOutcome::Return);
         }
         Subcommands::Onboarding => {
-            return command::onboarding::handle(out).map_err(CliError::from);
+            return command::onboarding::handle(out)
+                .map(|()| DispatchOutcome::Return)
+                .map_err(CliError::from);
         }
         Subcommands::Config(args::config::Platform { cmd }) => {
             // Handle subcommands that don't require a repo context
-            return match &cmd {
+            return (match &cmd {
                 Some(args::config::Subcommands::Metrics { status }) => {
                     command::config::metrics_config(out, *status)
                         .await
-                        .emit_metrics(metrics_ctx)
                         .map_err(CliError::from)
                 }
                 Some(args::config::Subcommands::Feature { flag, status }) => {
-                    command::config::feature_config(out, *flag, *status)
-                        .emit_metrics(metrics_ctx)
-                        .map_err(CliError::from)
+                    command::config::feature_config(out, *flag, *status).map_err(CliError::from)
                 }
                 #[cfg(feature = "legacy")]
                 Some(args::config::Subcommands::Forge {
@@ -669,13 +690,11 @@ async fn match_subcommand(
                     )?;
                     command::config::exec(&mut ctx, out, cmd)
                         .await
-                        .emit_metrics(metrics_ctx)
                         .map_err(CliError::from)
                 }
                 Some(args::config::Subcommands::Forge { cmd: forge_cmd }) => {
                     command::config::forge_config(out, forge_cmd.clone())
                         .await
-                        .emit_metrics(metrics_ctx)
                         .map_err(CliError::from)
                 }
                 Some(args::config::Subcommands::Ai {
@@ -683,7 +702,6 @@ async fn match_subcommand(
                     local,
                     global,
                 }) if !local => command::config::ai_config(out, ai_cmd.clone(), *local, *global)
-                    .emit_metrics(metrics_ctx)
                     .map_err(CliError::from),
                 _ => {
                     // Other subcommands need a repo context
@@ -696,16 +714,17 @@ async fn match_subcommand(
                             }, out)?;
                             command::config::exec(&mut ctx, out, cmd)
                                 .await
-                                .emit_metrics(metrics_ctx).map_err(CliError::from)
+                                .map_err(CliError::from)
                         } else {
                             let mut ctx = but_ctx::Context::discover(&args.current_dir)?;
                             command::config::exec(&mut ctx, out, cmd)
                                 .await
-                                .emit_metrics(metrics_ctx).map_err(CliError::from)
+                                .map_err(CliError::from)
                         }
                     }
                 }
-            };
+            })
+            .map(|()| DispatchOutcome::Return);
         }
         Subcommands::Skill(args::skill::Platform { cmd }) => {
             // Skill commands use repository context when available, but can run
@@ -715,7 +734,9 @@ async fn match_subcommand(
             let mut ctx = match ctx {
                 Ok(ctx) => Some(ctx),
                 Err(err) if is_not_in_git_repository_error(&err) => None,
-                Err(err) => return Err(CliError::Internal(err)),
+                Err(err) => {
+                    return Err(CliError::Internal(err));
+                }
             };
             let result = command::skill::handle(ctx.as_mut(), out, cmd);
 
@@ -723,28 +744,33 @@ async fn match_subcommand(
             if let Err(ref e) = result
                 && e.downcast_ref::<command::skill::UserCancelled>().is_some()
             {
-                return Ok(());
+                return Ok(DispatchOutcome::Return);
             }
 
-            return result.emit_metrics(metrics_ctx).map_err(CliError::from);
+            return result
+                .map(|()| DispatchOutcome::Return)
+                .map_err(CliError::from);
         }
         Subcommands::Agent(agent::Platform { cmd }) => {
             let result = command::agent::handle(&args.current_dir, out, cmd);
 
-            return result.emit_metrics(metrics_ctx).map_err(CliError::from);
+            return result
+                .map(|()| DispatchOutcome::Return)
+                .map_err(CliError::from);
         }
         Subcommands::Mcp(args::mcp::Platform { cmd }) => {
-            return match cmd {
+            return (match cmd {
                 args::mcp::Subcommands::Serve => {
                     command::mcp::serve().await.map_err(CliError::from)
                 }
-            };
+            })
+            .map(|()| DispatchOutcome::Return);
         }
         Subcommands::Edit { file } => {
             let path = args.current_dir.join(&file);
-            tui::editor::edit_file(&path)
-                .emit_metrics(metrics_ctx)
-                .show_root_cause_error_then_exit_without_destructors(output)
+            return Ok(DispatchOutcome::ExitWithoutDestructors(
+                tui::editor::edit_file(&path),
+            ));
         }
         #[cfg(feature = "legacy")]
         Subcommands::Setup { init } => {
@@ -773,7 +799,7 @@ async fn match_subcommand(
                 guard.write_permission(),
             )
             .context("Failed to set up GitButler project.")
-            .emit_metrics(metrics_ctx)
+            .map(|()| DispatchOutcome::Return)
             .map_err(CliError::from);
         }
         Subcommands::_Open { .. } => setup::init_ctx(
@@ -783,9 +809,9 @@ async fn match_subcommand(
                 ..Default::default()
             },
             out,
-        )?,
+        ),
         Subcommands::_Expand { .. } | Subcommands::Alias(..) => {
-            but_ctx::Context::discover(&args.current_dir)?
+            but_ctx::Context::discover(&args.current_dir)
         }
         Subcommands::Branch(branch::Platform { ref cmd }) => setup::init_ctx(
             &args,
@@ -800,7 +826,7 @@ async fn match_subcommand(
                 },
             },
             out,
-        )?,
+        ),
         #[cfg(feature = "legacy")]
         Subcommands::Switch(..) => setup::init_ctx(
             &args,
@@ -809,9 +835,9 @@ async fn match_subcommand(
                 ..Default::default()
             },
             out,
-        )?,
+        ),
         Subcommands::_Comment(..) | Subcommands::Worktree(..) => {
-            setup::init_ctx(&args, InitCtxOptions::default(), out)?
+            setup::init_ctx(&args, InitCtxOptions::default(), out)
         }
         #[cfg(feature = "legacy")]
         Subcommands::Actions { .. }
@@ -822,7 +848,7 @@ async fn match_subcommand(
         | Subcommands::Undo(..)
         | Subcommands::Redo(..)
         | Subcommands::RefreshRemoteData { .. }
-        | Subcommands::Land { .. } => setup::init_ctx(&args, InitCtxOptions::default(), out)?,
+        | Subcommands::Land { .. } => setup::init_ctx(&args, InitCtxOptions::default(), out),
         #[cfg(feature = "legacy")]
         Subcommands::Clean { .. }
         | Subcommands::Status { .. }
@@ -849,7 +875,7 @@ async fn match_subcommand(
                 ..Default::default()
             },
             out,
-        )?,
+        ),
         #[cfg(feature = "legacy")]
         Subcommands::Tui(..) => setup::init_ctx(
             &args,
@@ -858,7 +884,7 @@ async fn match_subcommand(
                 ..Default::default()
             },
             out,
-        )?,
+        ),
         #[cfg(feature = "legacy")]
         Subcommands::Teardown { .. } => setup::init_ctx(
             &args,
@@ -868,13 +894,14 @@ async fn match_subcommand(
                 ..Default::default()
             },
             out,
-        )?,
+        ),
         Subcommands::AgentLog { .. } => {
             unreachable!("agentlog command is handled before metrics setup")
         }
-        Subcommands::External(_) => {
-            unreachable!("external commands are delegated before reaching match_subcommand")
-        }
+    };
+    let mut ctx = match ctx {
+        Ok(ctx) => ctx,
+        Err(err) => return Err(CliError::Initialization(err)),
     };
 
     // If `Some`, and if result is `Ok`, this is passed to
@@ -912,11 +939,11 @@ async fn match_subcommand(
             use crate::utils::IntermediateChannel;
 
             let out = IntermediateChannel::new(out);
-            command::open::open(&ctx, out, sources, program_id).emit_metrics(metrics_ctx)?;
+            command::open::open(&ctx, out, sources, program_id)?;
             None
         }
         Subcommands::_Expand { cli_id } => {
-            let outcome = command::expand::handle(&ctx, cli_id).emit_metrics(metrics_ctx)?;
+            let outcome = command::expand::handle(&ctx, cli_id)?;
             out.print_cli_output(outcome)?;
             None
         }
@@ -926,23 +953,19 @@ async fn match_subcommand(
                 active: false,
             }) {
                 worktree::Subcommands::List { archived, active } => {
-                    let outcome = command::worktree::list::list(&ctx, archived, active)
-                        .emit_metrics(metrics_ctx)?;
+                    let outcome = command::worktree::list::list(&ctx, archived, active)?;
                     out.print_cli_output(outcome)?;
                 }
                 worktree::Subcommands::Archive { worktree } => {
-                    let outcome = command::worktree::archive::set_archived(&ctx, &worktree, true)
-                        .emit_metrics(metrics_ctx)?;
+                    let outcome = command::worktree::archive::set_archived(&ctx, &worktree, true)?;
                     out.print_cli_output(outcome)?;
                 }
                 worktree::Subcommands::Unarchive { worktree } => {
-                    let outcome = command::worktree::archive::set_archived(&ctx, &worktree, false)
-                        .emit_metrics(metrics_ctx)?;
+                    let outcome = command::worktree::archive::set_archived(&ctx, &worktree, false)?;
                     out.print_cli_output(outcome)?;
                 }
                 worktree::Subcommands::Remove { force, worktree } => {
-                    let outcome = command::worktree::remove::remove(&mut ctx, &worktree, force)
-                        .emit_metrics(metrics_ctx)?;
+                    let outcome = command::worktree::remove::remove(&mut ctx, &worktree, force)?;
                     out.print_cli_output(outcome)?;
                 }
             }
@@ -950,7 +973,7 @@ async fn match_subcommand(
         }
         Subcommands::Alias(alias_args::Platform { cmd }) => match cmd {
             Some(alias_args::Subcommands::List) | None => {
-                command::alias::list(&*ctx.repo.get()?, out).emit_metrics(metrics_ctx)?;
+                command::alias::list(&*ctx.repo.get()?, out)?;
                 None
             }
             Some(alias_args::Subcommands::Add {
@@ -958,13 +981,11 @@ async fn match_subcommand(
                 value,
                 global,
             }) => {
-                command::alias::add(&mut ctx, out, &name, &value, global.into())
-                    .emit_metrics(metrics_ctx)?;
+                command::alias::add(&mut ctx, out, &name, &value, global.into())?;
                 None
             }
             Some(alias_args::Subcommands::Remove { name, global }) => {
-                command::alias::remove(&mut ctx, out, &name, global.into())
-                    .emit_metrics(metrics_ctx)?;
+                command::alias::remove(&mut ctx, out, &name, global.into())?;
                 None
             }
         },
@@ -989,8 +1010,7 @@ async fn match_subcommand(
             }) => {
                 command::legacy::branch::list_branches(
                     &mut ctx, out, filter, local, remote, all, no_ahead, review, no_check, empty,
-                )
-                .emit_metrics(metrics_ctx)?;
+                )?;
                 None
             }
             #[cfg(feature = "legacy")]
@@ -1003,8 +1023,7 @@ async fn match_subcommand(
             }) => {
                 command::legacy::branch::show_branches(
                     &mut ctx, out, branch, review, files, ai, check,
-                )
-                .emit_metrics(metrics_ctx)?;
+                )?;
                 None
             }
             #[cfg(feature = "legacy")]
@@ -1020,8 +1039,7 @@ async fn match_subcommand(
                     &mut ctx,
                     IntermediateChannel::new(out),
                     new_args,
-                )
-                .emit_metrics(metrics_ctx)?;
+                )?;
                 out.print_cli_output(outcome)?;
                 None
             }
@@ -1038,8 +1056,7 @@ async fn match_subcommand(
                     &mut ctx,
                     IntermediateChannel::new(out),
                     branches,
-                )
-                .emit_metrics(metrics_ctx)?;
+                )?;
                 out.print_cli_output(outcome)?;
                 Some(ws)
             }
@@ -1061,8 +1078,7 @@ async fn match_subcommand(
                     verbose,
                     interactive,
                     out,
-                )
-                .emit_metrics(metrics_ctx)?;
+                )?;
                 None
             }
             Some(branch::Subcommands::Move { .. }) => {
@@ -1080,8 +1096,7 @@ async fn match_subcommand(
                 &mut ctx,
                 IntermediateChannel::new(out),
                 switch_args,
-            )
-            .emit_metrics(metrics_ctx)?;
+            )?;
             out.print_cli_output(outcome)?;
             None
         }
@@ -1101,9 +1116,7 @@ async fn match_subcommand(
             None
         }
         #[cfg(feature = "legacy")]
-        Subcommands::Pull { check } => command::legacy::pull::handle(&mut ctx, out, check)
-            .await
-            .emit_metrics(metrics_ctx)?,
+        Subcommands::Pull { check } => command::legacy::pull::handle(&mut ctx, out, check).await?,
         #[cfg(feature = "legacy")]
         Subcommands::Fetch => {
             use std::fmt::Write;
@@ -1115,9 +1128,7 @@ async fn match_subcommand(
                     "Assuming you meant to check for upstream work, running `but pull --check`"
                 )
             )?;
-            command::legacy::pull::handle(&mut ctx, out, true)
-                .await
-                .emit_metrics(metrics_ctx)?
+            command::legacy::pull::handle(&mut ctx, out, true).await?
         }
         #[cfg(feature = "legacy")]
         Subcommands::Clean {
@@ -1142,8 +1153,7 @@ async fn match_subcommand(
                     dry_run,
                     include_upstream,
                 },
-            )
-            .emit_metrics(metrics_ctx)?
+            )?
         }
         #[cfg(feature = "legacy")]
         Subcommands::Status {
@@ -1174,8 +1184,7 @@ async fn match_subcommand(
                 out,
                 flags,
                 command::legacy::status::StatusRenderMode::Oneshot,
-            )
-            .emit_metrics(metrics_ctx)?;
+            )?;
             None
         }
         #[cfg(feature = "legacy")]
@@ -1195,8 +1204,7 @@ async fn match_subcommand(
                 out,
                 StatusFlags::for_tui(),
                 StatusRenderMode::Tui(options),
-            )
-            .emit_metrics(metrics_ctx)?;
+            )?;
             None
         }
         #[cfg(feature = "legacy")]
@@ -1204,16 +1212,15 @@ async fn match_subcommand(
             use crate::utils::IntermediateChannel;
 
             let outcome =
-                command::legacy::diff::diff(&mut ctx, IntermediateChannel::new(out), diff_args)
-                    .emit_metrics(metrics_ctx)?;
+                command::legacy::diff::diff(&mut ctx, IntermediateChannel::new(out), diff_args)?;
             out.print_cli_output(outcome)?;
             None
         }
         #[cfg(feature = "legacy")]
         Subcommands::Show { commit, verbose } => {
-            command::legacy::show::show_commit(&mut ctx, out, &commit, verbose)
-                .emit_metrics(metrics_ctx)
-                .show_root_cause_error_then_exit_without_destructors(output)
+            return Ok(DispatchOutcome::ExitWithoutDestructors(
+                command::legacy::show::show_commit(&mut ctx, out, &commit, verbose),
+            ));
         }
         #[cfg(feature = "legacy")]
         Subcommands::Commit(commit_args) => {
@@ -1228,8 +1235,7 @@ async fn match_subcommand(
                 &mut ctx,
                 IntermediateChannel::new(out),
                 commit_args,
-            )
-            .emit_metrics(metrics_ctx)?;
+            )?;
             out.print_cli_output(outcome)?;
             Some(ws)
         }
@@ -1246,8 +1252,7 @@ async fn match_subcommand(
                 &mut ctx,
                 IntermediateChannel::new(out),
                 squash_args,
-            )
-            .emit_metrics(metrics_ctx)?;
+            )?;
             out.print_cli_output(outcome)?;
             ws
         }
@@ -1260,17 +1265,17 @@ async fn match_subcommand(
             status_after_data = Some(status_after);
 
             newly_conflicted_data = Some(command::legacy::conflict_notice::snapshot(&ctx));
-            let (outcome, ws) =
-                command::legacy::r#move::r#move(&mut ctx, IntermediateChannel::new(out), move_args)
-                    .emit_metrics(metrics_ctx)?;
+            let (outcome, ws) = command::legacy::r#move::r#move(
+                &mut ctx,
+                IntermediateChannel::new(out),
+                move_args,
+            )?;
             out.print_cli_output(outcome)?;
             Some(ws)
         }
         #[cfg(feature = "legacy")]
         Subcommands::Push(push_args) => {
-            command::legacy::push::handle(push_args, &mut ctx, out)
-                .await
-                .emit_metrics(metrics_ctx)?;
+            command::legacy::push::handle(push_args, &mut ctx, out).await?;
             None
         }
         #[cfg(feature = "legacy")]
@@ -1285,8 +1290,7 @@ async fn match_subcommand(
                 &mut ctx,
                 IntermediateChannel::new(out),
                 reword_args,
-            )
-            .emit_metrics(metrics_ctx)?;
+            )?;
             out.print_cli_output(outcome)?;
             ws
         }
@@ -1312,8 +1316,7 @@ async fn match_subcommand(
                 // sorry
                 ShowDiffInEditor::from_args(diff, no_diff).unwrap_or(ShowDiffInEditor::Unspecified),
                 allow_merged,
-            )
-            .emit_metrics(metrics_ctx)?;
+            )?;
             None
         }
         #[cfg(feature = "legacy")]
@@ -1325,24 +1328,20 @@ async fn match_subcommand(
                     } else {
                         None
                     };
-                    command::legacy::oplog::show_oplog(&mut ctx, out, since.as_deref(), filter)
-                        .emit_metrics(metrics_ctx)?;
+                    command::legacy::oplog::show_oplog(&mut ctx, out, since.as_deref(), filter)?;
                     None
                 }
                 Some(args::oplog::Subcommands::Snapshot { message }) => {
-                    command::legacy::oplog::create_snapshot(&mut ctx, out, message.as_deref())
-                        .emit_metrics(metrics_ctx)?;
+                    command::legacy::oplog::create_snapshot(&mut ctx, out, message.as_deref())?;
                     None
                 }
                 Some(args::oplog::Subcommands::Restore { oplog_sha }) => {
-                    command::legacy::oplog::restore_to_oplog(&mut ctx, out, &oplog_sha)
-                        .emit_metrics(metrics_ctx)?;
+                    command::legacy::oplog::restore_to_oplog(&mut ctx, out, &oplog_sha)?;
                     None
                 }
                 None => {
                     // Default to list when no subcommand is provided
-                    command::legacy::oplog::show_oplog(&mut ctx, out, None, None)
-                        .emit_metrics(metrics_ctx)?;
+                    command::legacy::oplog::show_oplog(&mut ctx, out, None, None)?;
                     None
                 }
             }
@@ -1359,8 +1358,7 @@ async fn match_subcommand(
                 &mut ctx,
                 IntermediateChannel::new(out),
                 undo_args,
-            )
-            .emit_metrics(metrics_ctx)?;
+            )?;
             out.print_cli_output(outcome)?;
             None
         }
@@ -1376,8 +1374,7 @@ async fn match_subcommand(
                 &mut ctx,
                 IntermediateChannel::new(out),
                 redo_args,
-            )
-            .emit_metrics(metrics_ctx)?;
+            )?;
             out.print_cli_output(outcome)?;
             None
         }
@@ -1397,8 +1394,7 @@ async fn match_subcommand(
                 source.as_deref(),
                 dry_run,
                 allow_merged,
-            )
-            .emit_metrics(metrics_ctx)?;
+            )?;
             None
         }
         #[cfg(feature = "legacy")]
@@ -1414,8 +1410,7 @@ async fn match_subcommand(
                 &mut ctx,
                 IntermediateChannel::new(out),
                 discard_args,
-            )
-            .emit_metrics(metrics_ctx)?;
+            )?;
             out.print_cli_output(outcome)?;
             Some(ws)
         }
@@ -1423,16 +1418,14 @@ async fn match_subcommand(
             use crate::utils::IntermediateChannel;
 
             let outcome =
-                command::comment::comment(&mut ctx, IntermediateChannel::new(out), comment_args)
-                    .emit_metrics(metrics_ctx)?;
+                command::comment::comment(&mut ctx, IntermediateChannel::new(out), comment_args)?;
             out.print_cli_output(outcome)?;
             None
         }
         #[cfg(feature = "legacy")]
         Subcommands::Teardown { checkout_to } => {
             command::legacy::teardown::teardown(&mut ctx, checkout_to, out)
-                .map_err(|err| err.context("Failed to teardown GitButler project."))
-                .emit_metrics(metrics_ctx)?;
+                .map_err(|err| err.context("Failed to teardown GitButler project."))?;
             None
         }
         #[cfg(feature = "legacy")]
@@ -1495,8 +1488,7 @@ async fn match_subcommand(
                         out,
                     )
                     .await
-                    .context("Failed to create forge review for branch.")
-                    .emit_metrics(metrics_ctx)?;
+                    .context("Failed to create forge review for branch.")?;
                     None
                 }
                 Some(forge::pr::Subcommands::Template { template_path }) => {
@@ -1505,29 +1497,25 @@ async fn match_subcommand(
                         template_path,
                         out,
                     )
-                    .context("Failed to set forge review template.")
-                    .emit_metrics(metrics_ctx)?;
+                    .context("Failed to set forge review template.")?;
                     None
                 }
                 Some(forge::pr::Subcommands::AutoMerge { selector, off }) => {
                     command::legacy::forge::review::enable_auto_merge(&mut ctx, selector, off, out)
                         .await
-                        .context("Failed to set the auto-merge state.")
-                        .emit_metrics(metrics_ctx)?;
+                        .context("Failed to set the auto-merge state.")?;
                     None
                 }
                 Some(forge::pr::Subcommands::SetDraft { selector }) => {
                     command::legacy::forge::review::set_draftiness(&mut ctx, selector, true, out)
                         .await
-                        .context("Failed to set reviews as draft.")
-                        .emit_metrics(metrics_ctx)?;
+                        .context("Failed to set reviews as draft.")?;
                     None
                 }
                 Some(forge::pr::Subcommands::SetReady { selector }) => {
                     command::legacy::forge::review::set_draftiness(&mut ctx, selector, false, out)
                         .await
-                        .context("Failed to set reviews as ready-for-review.")
-                        .emit_metrics(metrics_ctx)?;
+                        .context("Failed to set reviews as ready-for-review.")?;
                     None
                 }
                 None => {
@@ -1544,8 +1532,7 @@ async fn match_subcommand(
                         out,
                     )
                     .await
-                    .context("Failed to create forge review for branch.")
-                    .emit_metrics(metrics_ctx)?;
+                    .context("Failed to create forge review for branch.")?;
                     None
                 }
             }
@@ -1557,8 +1544,15 @@ async fn match_subcommand(
             ci,
             updates,
         } => {
-            command::legacy::refresh::handle(&mut ctx, out, fetch, prs, ci, updates, &app_settings)
-                .emit_metrics(metrics_ctx)?;
+            command::legacy::refresh::handle(
+                &mut ctx,
+                out,
+                fetch,
+                prs,
+                ci,
+                updates,
+                &app_settings,
+            )?;
             None
         }
         #[cfg(feature = "legacy")]
@@ -1576,9 +1570,7 @@ async fn match_subcommand(
                     out,
                 );
             }
-            result
-                .emit_metrics(metrics_ctx)
-                .show_root_cause_error_then_exit_without_destructors(output)
+            return Ok(DispatchOutcome::ExitWithoutDestructors(result));
         }
         #[cfg(feature = "legacy")]
         Subcommands::Uncommit(uncommit_args) => {
@@ -1593,8 +1585,7 @@ async fn match_subcommand(
                 &mut ctx,
                 IntermediateChannel::new(out),
                 uncommit_args,
-            )
-            .emit_metrics(metrics_ctx)?;
+            )?;
             out.print_cli_output(outcome)?;
             ws
         }
@@ -1608,8 +1599,7 @@ async fn match_subcommand(
 
             newly_conflicted_data = Some(command::legacy::conflict_notice::snapshot(&ctx));
             let (outcome, ws) =
-                command::legacy::amend::amend(&mut ctx, IntermediateChannel::new(out), amend_args)
-                    .emit_metrics(metrics_ctx)?;
+                command::legacy::amend::amend(&mut ctx, IntermediateChannel::new(out), amend_args)?;
             out.print_cli_output(outcome)?;
             ws
         }
@@ -1623,8 +1613,7 @@ async fn match_subcommand(
             let conflicts_before = command::legacy::conflict_notice::snapshot(&ctx);
             let result =
                 command::legacy::land::handle(&mut ctx, out, &branch, yes, no_ff, whole_stack)
-                    .context("Failed to land branch.")
-                    .emit_metrics(metrics_ctx);
+                    .context("Failed to land branch.");
             if result.is_ok() {
                 command::legacy::conflict_notice::report_newly_conflicted(
                     &ctx,
@@ -1632,7 +1621,7 @@ async fn match_subcommand(
                     conflicts_before,
                 );
             }
-            result.show_root_cause_error_then_exit_without_destructors(output)
+            return Ok(DispatchOutcome::ExitWithoutDestructors(result));
         }
         #[cfg(feature = "legacy")]
         Subcommands::Pick(pick_args) => {
@@ -1644,8 +1633,7 @@ async fn match_subcommand(
 
             newly_conflicted_data = Some(command::legacy::conflict_notice::snapshot(&ctx));
             let (outcome, ws) =
-                command::legacy::pick::pick(&mut ctx, IntermediateChannel::new(out), pick_args)
-                    .emit_metrics(metrics_ctx)?;
+                command::legacy::pick::pick(&mut ctx, IntermediateChannel::new(out), pick_args)?;
             out.print_cli_output(outcome)?;
             Some(ws)
         }
@@ -1661,8 +1649,7 @@ async fn match_subcommand(
                 &mut ctx,
                 IntermediateChannel::new(out),
                 unapply_args,
-            )
-            .emit_metrics(metrics_ctx)?;
+            )?;
             out.print_cli_output(outcome)?;
             None
         }
@@ -1671,8 +1658,7 @@ async fn match_subcommand(
             use crate::utils::IntermediateChannel;
 
             let outcome =
-                command::legacy::open::open(&mut ctx, IntermediateChannel::new(out), open_args)
-                    .emit_metrics(metrics_ctx)?;
+                command::legacy::open::open(&mut ctx, IntermediateChannel::new(out), open_args)?;
             out.print_cli_output(outcome)?;
             None
         }
@@ -1685,8 +1671,7 @@ async fn match_subcommand(
             status_after_data = Some(status_after);
 
             let outcome =
-                command::legacy::apply::apply(&mut ctx, IntermediateChannel::new(out), apply_args)
-                    .emit_metrics(metrics_ctx)?;
+                command::legacy::apply::apply(&mut ctx, IntermediateChannel::new(out), apply_args)?;
             out.print_cli_output(outcome)?;
             None
         }
@@ -1712,7 +1697,7 @@ async fn match_subcommand(
         );
     }
 
-    Ok(())
+    Ok(DispatchOutcome::Return)
 }
 
 fn run_agentlog_command(

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -62,19 +62,6 @@ pub enum EventKind {
     Cli(CommandName),
 }
 
-impl EventKind {
-    /// Percentage sample rate, between 0 and 1.
-    ///
-    /// 1 indicates that the command should always be submitted to posthog, and
-    /// 0 should never be submitted to posthog.
-    pub fn sample_rate(&self) -> f32 {
-        match self {
-            Self::Mcp | Self::McpInternal => 1.0,
-            Self::Cli(c) => c.sample_rate(),
-        }
-    }
-}
-
 impl Subcommands {
     /// Create all context that is needed to emit metrics for `self` once, if `settings` permit.
     pub fn to_metrics_context(
@@ -85,10 +72,14 @@ impl Subcommands {
         if !settings.telemetry.app_metrics_enabled {
             return None;
         }
-        // The comments experiment is still being validated, and completions are shell-startup noise.
+        // Comments are still experimental, completions are shell-startup noise, and MCP and the
+        // transport child own their own events.
         if matches!(
             self,
-            Subcommands::_Comment(_) | Subcommands::Completions { .. }
+            Subcommands::_Comment(_)
+                | Subcommands::Completions { .. }
+                | Subcommands::Mcp(_)
+                | Subcommands::Metrics { .. }
         ) {
             return None;
         }
@@ -101,14 +92,21 @@ impl Subcommands {
         ))
     }
 
-    /// Turn `self` into a `CommandName` that serves as metric identifier.
+    /// Return the low-cardinality event identifier.
     pub(crate) fn to_metrics_command(&self) -> CommandName {
         use CommandName::*;
 
         use crate::args::{agent, alias as alias_args, branch, forge, skill, update, worktree};
         match self {
-            // Unreachable: these commands opt out of metrics in `to_metrics_context`.
-            Subcommands::_Comment(_) | Subcommands::Completions { .. } => Unknown,
+            Subcommands::_Comment(_) => Comment,
+            Subcommands::Completions { .. } => Completions,
+            Subcommands::Mcp(_) => Mcp,
+            Subcommands::Metrics { .. } => Metrics,
+            Subcommands::Help { .. } => Help,
+            Subcommands::Onboarding => Onboarding,
+            Subcommands::AgentLog { .. } => AgentLog,
+            #[cfg(feature = "legacy")]
+            Subcommands::Actions(_) => Actions,
             #[cfg(feature = "legacy")]
             Subcommands::Status { .. } => Status,
             #[cfg(feature = "legacy")]
@@ -185,11 +183,10 @@ impl Subcommands {
                 Some(forge::pr::Subcommands::SetDraft { .. }) => SetReviewDraft,
                 Some(forge::pr::Subcommands::SetReady { .. }) => SetReviewReady,
             },
-            Subcommands::Mcp(_) => Unknown,
             #[cfg(feature = "legacy")]
-            Subcommands::Actions(_) | Subcommands::Setup { .. } | Subcommands::Teardown { .. } => {
-                Unknown
-            }
+            Subcommands::Setup { .. } => Setup,
+            #[cfg(feature = "legacy")]
+            Subcommands::Teardown { .. } => Teardown,
             Subcommands::Config(config::Platform { cmd }) => match cmd {
                 Some(config::Subcommands::Forge {
                     cmd: Some(config::ForgeSubcommand::Auth),
@@ -200,16 +197,14 @@ impl Subcommands {
                 Some(config::Subcommands::Forge {
                     cmd: Some(config::ForgeSubcommand::ListUsers),
                 }) => ForgeListUsers,
-                _ => Unknown,
+                _ => Config,
             },
-            Subcommands::Help { .. } => Unknown,
-            Subcommands::_Expand { .. } => Unknown,
+            Subcommands::_Expand { .. } => Expand,
             Subcommands::Alias(alias_args::Platform { cmd }) => match cmd {
                 None | Some(alias_args::Subcommands::List) => AliasCheck,
                 Some(alias_args::Subcommands::Add { .. }) => AliasAdd,
                 Some(alias_args::Subcommands::Remove { .. }) => AliasRemove,
             },
-            Subcommands::Metrics { .. } => Unknown,
             Subcommands::Update(update::Platform { cmd }) => match cmd {
                 update::Subcommands::Check => UpdateCheck,
                 update::Subcommands::Suppress { .. } => UpdateSuppress,
@@ -243,8 +238,6 @@ impl Subcommands {
             Subcommands::Edit { .. } => Edit,
             #[cfg(feature = "legacy")]
             Subcommands::Clean { .. } => Clean,
-            Subcommands::Onboarding => Unknown,
-            Subcommands::AgentLog { .. } => Unknown,
             Subcommands::External(_) => External,
         }
     }
@@ -370,8 +363,16 @@ impl Props {
                     unrecognized_subcommand_metric_value(command_name),
                 );
             }
+            CliError::ExternalCommandFailed(_) => {
+                props.insert("error", "External command failed");
+                props.insert("errorKind", "externalCommandFailed");
+            }
             CliError::Internal(error) => {
                 props.insert_internal_error_details(error, command);
+            }
+            CliError::Initialization(_) => {
+                props.insert("error", "Internal error");
+                props.insert("errorKind", "initialization");
             }
         }
         props
@@ -422,6 +423,28 @@ impl Props {
             event.insert_prop(key, value);
         }
     }
+}
+
+fn sample_props(mut props: Props, command: CommandName, failed: bool, draw: f32) -> Option<Props> {
+    let sampling_rate = if failed { 1.0 } else { command.sample_rate() };
+    if sampling_rate < draw {
+        return None;
+    }
+    props.insert("samplingRate", sampling_rate);
+    Some(props)
+}
+
+pub(crate) fn prepare_transport_props(json: &str) -> anyhow::Result<Props> {
+    let mut props = Props::from_json_string(json)?;
+    if let Some(rate) = props.values.get("samplingRate") {
+        anyhow::ensure!(
+            rate.as_f64().is_some_and(|rate| rate > 0.0 && rate <= 1.0),
+            "`samplingRate` must be a number in (0, 1]"
+        );
+    } else {
+        props.insert("samplingRate", 1.0);
+    }
+    Ok(props)
 }
 
 fn error_message(error: &(impl std::fmt::Display + ?Sized)) -> String {
@@ -588,7 +611,6 @@ impl Event {
         if let EventKind::Cli(command) = event_name {
             event.insert_prop("command", command);
         }
-        event.update_sampling_rate();
         event.insert_prop("appVersion", option_env!("VERSION").unwrap_or_default());
         event.insert_prop("releaseChannel", option_env!("CHANNEL").unwrap_or_default());
         event.insert_prop("appName", option_env!("CARGO_BIN_NAME").unwrap_or_default());
@@ -604,16 +626,6 @@ impl Event {
         if let Ok(value) = serde_json::to_value(prop) {
             let _ = self.props.insert(key.into(), value);
         }
-    }
-
-    fn update_sampling_rate(&mut self) -> f32 {
-        let sample_rate = if self.props.contains_key("errorKind") {
-            1.0
-        } else {
-            self.event_name.sample_rate()
-        };
-        self.insert_prop("samplingRate", sample_rate);
-        sample_rate
     }
 
     fn normalize_os(os: &str) -> String {
@@ -639,13 +651,9 @@ pub async fn capture_event_blocking(app_settings: &AppSettings, event: Event) {
 /// Note that `client` is *only* available if telemetry is enabled.
 async fn do_capture(
     client: &Client,
-    mut event: Event,
+    event: Event,
     app_settings: &AppSettings,
 ) -> Result<(), posthog_rs::Error> {
-    if event.update_sampling_rate() < rand::rng().sample::<f32, _>(OpenClosed01) {
-        return Ok(());
-    }
-
     let id = app_settings
         .telemetry
         .app_distinct_id
@@ -699,7 +707,7 @@ impl<T> ResultMetricsExt<T, anyhow::Error> for anyhow::Result<T> {
 
         let mut props = Props::from_anyhow_result(start, &self, command);
         props.extend(extra_props);
-        emit_metrics(command, &props, &current_dir);
+        emit_metrics(command, props, &current_dir, self.is_err());
         self
     }
 }
@@ -718,7 +726,7 @@ impl<T> ResultMetricsExt<T, CliError> for Result<T, CliError> {
 
         let mut props = Props::from_cli_error_result(start, &self, command);
         props.extend(extra_props);
-        emit_metrics(command, &props, &current_dir);
+        emit_metrics(command, props, &current_dir, self.is_err());
         self
     }
 }
@@ -739,10 +747,18 @@ pub(crate) fn emit_retired_syntax_hint(command: CommandName) {
     }
     let mut props = Props::new();
     props.insert("retiredSyntaxHint", true);
-    emit_metrics(command, &props, Path::new("."));
+    emit_metrics(command, props, Path::new("."), true);
 }
 
-fn emit_metrics(command: CommandName, props: &Props, current_dir: &Path) {
+fn emit_metrics(command: CommandName, props: Props, current_dir: &Path, failed: bool) {
+    let Some(props) = sample_props(
+        props,
+        command,
+        failed,
+        rand::rng().sample::<f32, _>(OpenClosed01),
+    ) else {
+        return;
+    };
     let Some(v) = command.to_possible_value() else {
         tracing::warn!("BUG: didn't get string value for {command:?}");
         return;
@@ -780,429 +796,4 @@ fn emit_metrics(command: CommandName, props: &Props, current_dir: &Path) {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::{
-        args::{Subcommands, agent, update},
-        bad_input,
-    };
-
-    #[cfg(feature = "legacy")]
-    use crate::args::atoms::CliIdArg;
-
-    fn prop<'a>(
-        props: &'a [(String, serde_json::Value)],
-        key: &str,
-    ) -> Option<&'a serde_json::Value> {
-        props
-            .iter()
-            .find_map(|(prop_key, value)| (prop_key.as_str() == key).then_some(value))
-    }
-
-    fn assert_command(subcommand: Subcommands, expected: &str) {
-        assert_eq!(
-            Event::new(EventKind::Cli(subcommand.to_metrics_command())).props["command"],
-            serde_json::json!(expected)
-        );
-    }
-
-    #[test]
-    fn status_events_include_one_percent_sampling_rate() {
-        let event = Event::new(EventKind::Cli(CommandName::Status));
-
-        assert_eq!(
-            event.props["samplingRate"],
-            serde_json::json!(0.01),
-            "status events should carry their effective sampling rate"
-        );
-    }
-
-    #[test]
-    fn cli_command_sampling_policy_matches_expected_rates() {
-        assert_eq!(
-            [
-                CommandName::Status.sample_rate(),
-                CommandName::Diff.sample_rate(),
-                CommandName::RefreshRemoteData.sample_rate(),
-                CommandName::BranchList.sample_rate(),
-                CommandName::Unknown.sample_rate(),
-            ],
-            [0.01, 0.05, 0.05, 0.10, 1.0],
-            "only the selected read-only commands should be sampled"
-        );
-    }
-
-    #[test]
-    fn full_rate_cli_events_include_sampling_rate() {
-        let event = Event::new(EventKind::Cli(CommandName::Commit));
-
-        assert_eq!(event.props["samplingRate"], serde_json::json!(1.0));
-    }
-
-    #[test]
-    fn failed_sampled_cli_events_use_full_sampling_rate() {
-        let mut event = Event::new(EventKind::Cli(CommandName::Status));
-        event.insert_prop("errorKind", "internal");
-
-        event.update_sampling_rate();
-
-        assert_eq!(
-            event.props["samplingRate"],
-            serde_json::json!(1.0),
-            "failed events should bypass command sampling"
-        );
-    }
-
-    #[test]
-    fn completions_do_not_create_metrics_context() {
-        let mut settings = AppSettings::default();
-        settings.telemetry.app_metrics_enabled = true;
-
-        let context =
-            Subcommands::Completions { shell: None }.to_metrics_context(&settings, Path::new("."));
-
-        assert!(
-            context.is_none(),
-            "shell completions should not emit a metrics event"
-        );
-    }
-
-    #[test]
-    fn workspace_shape_never_initializes_a_project() {
-        but_testsupport::isolated_app_data_dir(|| {
-            let tmp = tempfile::tempdir().expect("tempdir");
-            let repo_dir = tmp.path().join("repo");
-            gix::init(&repo_dir).expect("init plain repo");
-            let mut event = Event::new(EventKind::Cli(CommandName::Commit));
-
-            // A plain repository without GitButler state must stay untouched.
-            add_workspace_shape(&mut event, &repo_dir);
-            let data_dir = repo_dir.join(".git/gitbutler");
-            assert!(!data_dir.exists());
-            assert!(!event.props.contains_key("totalLanesInWorkspace"));
-
-            // Even with a project data dir present, the project database must not be created.
-            std::fs::create_dir(&data_dir).expect("create project data dir");
-            add_workspace_shape(&mut event, &repo_dir);
-            assert_eq!(
-                std::fs::read_dir(&data_dir).expect("read data dir").count(),
-                0
-            );
-            assert!(!event.props.contains_key("totalLanesInWorkspace"));
-        });
-    }
-
-    #[test]
-    fn workspace_shape_counts_lanes_and_stacked_branches() {
-        but_testsupport::isolated_app_data_dir(|| {
-            let sandbox =
-                but_testsupport::Sandbox::open_or_init_scenario_with_target_and_default_settings(
-                    "one-stack-three-dependent-branches",
-                );
-            let repo = sandbox.open_repo();
-            let workdir = repo.workdir().expect("scenario is not bare").to_owned();
-            // The shape is only read from repositories that already carry a project database.
-            but_db::DbHandle::new_in_directory(repo.git_dir().join("gitbutler"))
-                .expect("create project db");
-
-            let mut event = Event::new(EventKind::Cli(CommandName::Commit));
-            add_workspace_shape(&mut event, &workdir);
-
-            assert_eq!(event.props["totalLanesInWorkspace"], serde_json::json!(1));
-            assert_eq!(
-                event.props["totalBranchesInWorkspace"],
-                serde_json::json!(3)
-            );
-            assert_eq!(event.props["maxBranchesPerLane"], serde_json::json!(3));
-        });
-    }
-
-    #[test]
-    fn metrics_use_invoked_command_names() {
-        assert_command(
-            Subcommands::Update(update::Platform {
-                cmd: update::Subcommands::Check,
-            }),
-            "updateCheck",
-        );
-        assert_command(
-            Subcommands::Update(update::Platform {
-                cmd: update::Subcommands::Suppress { days: 7 },
-            }),
-            "updateSuppress",
-        );
-        assert_command(
-            Subcommands::Agent(agent::Platform {
-                cmd: Some(agent::Subcommands::Setup { print: false }),
-            }),
-            "agentSetup",
-        );
-        // Bare `but agent` (no subcommand) maps to the same metric.
-        assert_command(
-            Subcommands::Agent(agent::Platform { cmd: None }),
-            "agentSetup",
-        );
-        #[cfg(feature = "legacy")]
-        assert_command(
-            Subcommands::Move(crate::args::r#move::Platform {
-                branch: Some(Some(CliIdArg("main".to_owned()))),
-                above: None,
-                below: None,
-                unstack: false,
-                sources: Vec::from([CliIdArg("ci".to_owned())]),
-                allow_merged: Default::default(),
-            }),
-            "move",
-        );
-
-        #[cfg(all(unix, not(feature = "packaged-but-distribution")))]
-        assert_command(
-            Subcommands::Update(update::Platform {
-                cmd: update::Subcommands::Install {
-                    target: Some("0.20.0".into()),
-                },
-            }),
-            "updateInstall",
-        );
-
-        #[cfg(feature = "legacy")]
-        {
-            assert_command(
-                Subcommands::Amend(crate::args::amend::Platform {
-                    target: CliIdArg("c1".into()),
-                    sources: vec![CliIdArg("a1".into())],
-                    allow_merged: Default::default(),
-                }),
-                "amend",
-            );
-        }
-    }
-
-    #[test]
-    fn extra_props_keep_useful_source_and_target_kinds() {
-        #[cfg(feature = "legacy")]
-        {
-            let moved = Subcommands::Move(crate::args::r#move::Platform {
-                branch: Some(Some(CliIdArg("main".to_owned()))),
-                above: None,
-                below: None,
-                unstack: false,
-                sources: Vec::from([CliIdArg("ci".to_owned())]),
-                allow_merged: Default::default(),
-            });
-            let props = moved.to_metrics_extra_props();
-            assert_eq!(
-                prop(&props, "sourceKind"),
-                Some(&serde_json::json!("commitOrBranch"))
-            );
-            assert_eq!(
-                prop(&props, "targetKind"),
-                Some(&serde_json::json!("commitOrBranchOrUnassigned"))
-            );
-        }
-    }
-
-    #[test]
-    fn external_extra_props_include_sanitized_subcommand() {
-        let props = Subcommands::External(vec![" typo-OK ".into()]).to_metrics_extra_props();
-        assert_eq!(
-            prop(&props, "externalSubcommand"),
-            Some(&serde_json::json!("typo-OK"))
-        );
-
-        let props = Subcommands::External(vec!["/tmp/private".into()]).to_metrics_extra_props();
-        assert_eq!(
-            prop(&props, "externalSubcommand"),
-            Some(&serde_json::json!(INVALID_UNRECOGNIZED_SUBCOMMAND))
-        );
-
-        let props = Subcommands::External(vec!["customer123".into()]).to_metrics_extra_props();
-        assert_eq!(
-            prop(&props, "externalSubcommand"),
-            Some(&serde_json::json!(INVALID_UNRECOGNIZED_SUBCOMMAND))
-        );
-    }
-
-    #[test]
-    fn internal_error_details_are_allowlisted() {
-        let anyhow_result = Err::<(), _>(
-            anyhow::anyhow!("stale id. If you just performed a Git operation, refresh")
-                .context("Failed to uncommit."),
-        );
-
-        let props = Props::from_anyhow_result(
-            std::time::Instant::now(),
-            &anyhow_result,
-            CommandName::Uncommit,
-        );
-
-        assert_eq!(props.values["error"], "Internal error");
-        assert_eq!(props.values["errorKind"], "internal");
-        assert_eq!(
-            props.values["errorMessage"],
-            "Failed to uncommit.: stale id."
-        );
-        assert_eq!(props.values["errorRoot"], "stale id.");
-
-        let result = Err::<(), _>(
-            anyhow::anyhow!("private-branch-name failed").context("private-path failed"),
-        );
-
-        let props =
-            Props::from_anyhow_result(std::time::Instant::now(), &result, CommandName::Status);
-
-        assert_eq!(props.values["error"], "Internal error");
-        assert_eq!(props.values["errorKind"], "internal");
-        assert!(!props.values.contains_key("errorMessage"));
-        assert!(!props.values.contains_key("errorRoot"));
-        assert!(!props.as_json_string().contains("private-branch-name"));
-        assert!(!props.as_json_string().contains("private-path"));
-    }
-
-    #[test]
-    fn commit_internal_error_details_are_captured() {
-        let result = Err::<(), _>(CliError::Internal(
-            anyhow::anyhow!("stale id. If you just performed a Git operation, refresh")
-                .context("Failed to commit."),
-        ));
-
-        let props =
-            Props::from_cli_error_result(std::time::Instant::now(), &result, CommandName::Commit);
-
-        assert_eq!(props.values["errorMessage"], "Failed to commit.: stale id.");
-        assert_eq!(props.values["errorRoot"], "stale id.");
-    }
-
-    #[cfg(feature = "legacy")]
-    #[test]
-    fn explained_commit_rejections_omit_private_details() {
-        let result = Err::<(), _>(CliError::Internal(anyhow::Error::new(
-            crate::utils::rejection::ExplainedRejection(
-                "Cannot commit private/path on private-branch".to_string(),
-            ),
-        )));
-
-        let props =
-            Props::from_cli_error_result(std::time::Instant::now(), &result, CommandName::Commit);
-
-        assert_eq!(props.values["error"], "Command rejection");
-        assert_eq!(props.values["errorKind"], "commandRejection");
-        assert!(!props.values.contains_key("errorMessage"));
-        assert!(!props.values.contains_key("errorRoot"));
-        assert!(!props.as_json_string().contains("private/path"));
-        assert!(!props.as_json_string().contains("private-branch"));
-    }
-
-    #[test]
-    fn cli_error_metrics_use_low_cardinality_failure_details() {
-        let bad_input_result = Err::<(), _>(
-            bad_input("Branch 'branch-with-private-name' not found")
-                .arg_name("<BRANCH>")
-                .arg_value("another-private-branch-name")
-                .hint("Use a branch name")
-                .into(),
-        );
-
-        let props = Props::from_cli_error_result(
-            std::time::Instant::now(),
-            &bad_input_result,
-            CommandName::Commit,
-        );
-
-        assert_eq!(props.values["errorKind"], "badInput");
-        assert_eq!(props.values["error"], "Bad input");
-        assert!(!props.values.contains_key("errorMessage"));
-        assert_eq!(props.values["badInputArgName"], "<BRANCH>");
-        assert_eq!(props.values["badInputHasHint"], true);
-        assert!(!props.as_json_string().contains("branch-with-private-name"));
-        assert!(
-            !props
-                .as_json_string()
-                .contains("another-private-branch-name")
-        );
-
-        let external_result = Err::<(), _>(CliError::ExternalCommandNotFound("typo".into()));
-        let props = Props::from_cli_error_result(
-            std::time::Instant::now(),
-            &external_result,
-            CommandName::External,
-        );
-
-        assert_eq!(props.values["error"], "Unrecognized subcommand");
-        assert_eq!(props.values["errorKind"], "externalCommandNotFound");
-        assert_eq!(props.values["unrecognizedSubcommand"], "typo");
-        assert!(!props.values.contains_key("errorMessage"));
-
-        let external_result =
-            Err::<(), _>(CliError::ExternalCommandNotFound(" typo-123_OK ".into()));
-        let props = Props::from_cli_error_result(
-            std::time::Instant::now(),
-            &external_result,
-            CommandName::External,
-        );
-        assert_eq!(props.values["unrecognizedSubcommand"], "typo-123_OK");
-
-        let external_result =
-            Err::<(), _>(CliError::ExternalCommandNotFound("/tmp/private".into()));
-        let props = Props::from_cli_error_result(
-            std::time::Instant::now(),
-            &external_result,
-            CommandName::External,
-        );
-        assert_eq!(
-            props.values["unrecognizedSubcommand"],
-            INVALID_UNRECOGNIZED_SUBCOMMAND
-        );
-        assert!(!props.as_json_string().contains("/tmp/private"));
-
-        let long_command = "a".repeat(UNRECOGNIZED_SUBCOMMAND_MAX_CHARS + 1);
-        let external_result = Err::<(), _>(CliError::ExternalCommandNotFound(long_command.into()));
-        let props = Props::from_cli_error_result(
-            std::time::Instant::now(),
-            &external_result,
-            CommandName::External,
-        );
-        assert_eq!(
-            props.values["unrecognizedSubcommand"]
-                .as_str()
-                .expect("metric value is a string")
-                .len(),
-            UNRECOGNIZED_SUBCOMMAND_MAX_CHARS
-        );
-    }
-
-    #[test]
-    fn detailed_error_messages_are_normalized_and_capped() {
-        let multiline_result =
-            Err::<(), _>(anyhow::anyhow!("first line\nsecond line").context("Failed to uncommit."));
-
-        let props = Props::from_anyhow_result(
-            std::time::Instant::now(),
-            &multiline_result,
-            CommandName::Uncommit,
-        );
-
-        assert_eq!(
-            props.values["errorMessage"],
-            "Failed to uncommit.: first line second line"
-        );
-        assert_eq!(props.values["errorRoot"], "first line second line");
-
-        let long_result = Err::<(), _>(anyhow::anyhow!("{}", "a".repeat(1100)));
-
-        let props = Props::from_anyhow_result(
-            std::time::Instant::now(),
-            &long_result,
-            CommandName::Uncommit,
-        );
-
-        assert_eq!(
-            props.values["errorMessage"].as_str().unwrap().len(),
-            ERROR_MESSAGE_MAX_CHARS
-        );
-        assert_eq!(
-            props.values["errorRoot"].as_str().unwrap().len(),
-            ERROR_MESSAGE_MAX_CHARS
-        );
-    }
-}
+mod tests;

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -586,7 +586,7 @@ impl Event {
         if let EventKind::Cli(command) = event_name {
             event.insert_prop("command", command);
         }
-        event.insert_prop("samplingRate", event_name.sample_rate());
+        event.update_sampling_rate();
         event.insert_prop("appVersion", option_env!("VERSION").unwrap_or_default());
         event.insert_prop("releaseChannel", option_env!("CHANNEL").unwrap_or_default());
         event.insert_prop("appName", option_env!("CARGO_BIN_NAME").unwrap_or_default());
@@ -602,6 +602,16 @@ impl Event {
         if let Ok(value) = serde_json::to_value(prop) {
             let _ = self.props.insert(key.into(), value);
         }
+    }
+
+    fn update_sampling_rate(&mut self) -> f32 {
+        let sample_rate = if self.props.contains_key("errorKind") {
+            1.0
+        } else {
+            self.event_name.sample_rate()
+        };
+        self.insert_prop("samplingRate", sample_rate);
+        sample_rate
     }
 
     fn normalize_os(os: &str) -> String {
@@ -627,10 +637,10 @@ pub async fn capture_event_blocking(app_settings: &AppSettings, event: Event) {
 /// Note that `client` is *only* available if telemetry is enabled.
 async fn do_capture(
     client: &Client,
-    event: Event,
+    mut event: Event,
     app_settings: &AppSettings,
 ) -> Result<(), posthog_rs::Error> {
-    if event.event_name.sample_rate() < rand::rng().sample::<f32, _>(OpenClosed01) {
+    if event.update_sampling_rate() < rand::rng().sample::<f32, _>(OpenClosed01) {
         return Ok(());
     }
 
@@ -806,6 +816,20 @@ mod tests {
         let event = Event::new(EventKind::Cli(CommandName::Commit));
 
         assert_eq!(event.props["samplingRate"], serde_json::json!(1.0));
+    }
+
+    #[test]
+    fn failed_sampled_cli_events_use_full_sampling_rate() {
+        let mut event = Event::new(EventKind::Cli(CommandName::Status));
+        event.insert_prop("errorKind", "internal");
+
+        event.update_sampling_rate();
+
+        assert_eq!(
+            event.props["samplingRate"],
+            serde_json::json!(1.0),
+            "failed events should bypass command sampling"
+        );
     }
 
     #[test]

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -586,6 +586,7 @@ impl Event {
         if let EventKind::Cli(command) = event_name {
             event.insert_prop("command", command);
         }
+        event.insert_prop("samplingRate", event_name.sample_rate());
         event.insert_prop("appVersion", option_env!("VERSION").unwrap_or_default());
         event.insert_prop("releaseChannel", option_env!("CHANNEL").unwrap_or_default());
         event.insert_prop("appName", option_env!("CARGO_BIN_NAME").unwrap_or_default());
@@ -791,6 +792,20 @@ mod tests {
             Event::new(EventKind::Cli(subcommand.to_metrics_command())).props["command"],
             serde_json::json!(expected)
         );
+    }
+
+    #[test]
+    fn sampled_cli_events_include_sampling_rate() {
+        let event = Event::new(EventKind::Cli(CommandName::Status));
+
+        assert_eq!(event.props["samplingRate"], serde_json::json!(0.05));
+    }
+
+    #[test]
+    fn full_rate_cli_events_include_sampling_rate() {
+        let event = Event::new(EventKind::Cli(CommandName::Commit));
+
+        assert_eq!(event.props["samplingRate"], serde_json::json!(1.0));
     }
 
     #[test]

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -85,8 +85,11 @@ impl Subcommands {
         if !settings.telemetry.app_metrics_enabled {
             return None;
         }
-        // The comments experiment emits no metrics while the idea is being validated.
-        if matches!(self, Subcommands::_Comment(_)) {
+        // The comments experiment is still being validated, and completions are shell-startup noise.
+        if matches!(
+            self,
+            Subcommands::_Comment(_) | Subcommands::Completions { .. }
+        ) {
             return None;
         }
         let cmd = self.to_metrics_command();
@@ -104,8 +107,8 @@ impl Subcommands {
 
         use crate::args::{agent, alias as alias_args, branch, forge, skill, update, worktree};
         match self {
-            // Unreachable: the comments experiment opts out of metrics in `to_metrics_context`.
-            Subcommands::_Comment(_) => Unknown,
+            // Unreachable: these commands opt out of metrics in `to_metrics_context`.
+            Subcommands::_Comment(_) | Subcommands::Completions { .. } => Unknown,
             #[cfg(feature = "legacy")]
             Subcommands::Status { .. } => Status,
             #[cfg(feature = "legacy")]
@@ -199,7 +202,6 @@ impl Subcommands {
                 }) => ForgeListUsers,
                 _ => Unknown,
             },
-            Subcommands::Completions { .. } => Completions,
             Subcommands::Help { .. } => Unknown,
             Subcommands::_Expand { .. } => Unknown,
             Subcommands::Alias(alias_args::Platform { cmd }) => match cmd {
@@ -829,6 +831,20 @@ mod tests {
             event.props["samplingRate"],
             serde_json::json!(1.0),
             "failed events should bypass command sampling"
+        );
+    }
+
+    #[test]
+    fn completions_do_not_create_metrics_context() {
+        let mut settings = AppSettings::default();
+        settings.telemetry.app_metrics_enabled = true;
+
+        let context =
+            Subcommands::Completions { shell: None }.to_metrics_context(&settings, Path::new("."));
+
+        assert!(
+            context.is_none(),
+            "shell completions should not emit a metrics event"
         );
     }
 

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -807,10 +807,29 @@ mod tests {
     }
 
     #[test]
-    fn sampled_cli_events_include_sampling_rate() {
+    fn status_events_include_one_percent_sampling_rate() {
         let event = Event::new(EventKind::Cli(CommandName::Status));
 
-        assert_eq!(event.props["samplingRate"], serde_json::json!(0.05));
+        assert_eq!(
+            event.props["samplingRate"],
+            serde_json::json!(0.01),
+            "status events should carry their effective sampling rate"
+        );
+    }
+
+    #[test]
+    fn cli_command_sampling_policy_matches_expected_rates() {
+        assert_eq!(
+            [
+                CommandName::Status.sample_rate(),
+                CommandName::Diff.sample_rate(),
+                CommandName::RefreshRemoteData.sample_rate(),
+                CommandName::BranchList.sample_rate(),
+                CommandName::Unknown.sample_rate(),
+            ],
+            [0.01, 0.05, 0.05, 0.10, 1.0],
+            "only the selected read-only commands should be sampled"
+        );
     }
 
     #[test]

--- a/crates/but/src/utils/metrics/tests.rs
+++ b/crates/but/src/utils/metrics/tests.rs
@@ -1,0 +1,617 @@
+use super::*;
+use crate::{
+    args::{Subcommands, agent, branch, config, update},
+    bad_input,
+};
+
+use crate::args::atoms::CliIdArg;
+
+fn prop<'a>(props: &'a [(String, serde_json::Value)], key: &str) -> Option<&'a serde_json::Value> {
+    props
+        .iter()
+        .find_map(|(prop_key, value)| (prop_key.as_str() == key).then_some(value))
+}
+
+fn assert_command(subcommand: Subcommands, expected: &str) {
+    assert_eq!(
+        Event::new(EventKind::Cli(subcommand.to_metrics_command())).props["command"],
+        serde_json::json!(expected)
+    );
+}
+
+#[test]
+fn status_events_include_one_percent_sampling_rate() {
+    let props = sample_props(Props::new(), CommandName::Status, false, 0.005)
+        .expect("draw below the rate should capture");
+
+    assert_eq!(
+        props.values["samplingRate"],
+        serde_json::json!(0.01),
+        "status events should carry their effective sampling rate"
+    );
+}
+
+#[test]
+fn cli_command_sampling_policy_matches_expected_rates() {
+    let sampled_commands = CommandName::value_variants()
+        .iter()
+        .filter_map(|command| {
+            let rate = command.sample_rate();
+            (rate < 1.0).then(|| {
+                (
+                    command
+                        .to_possible_value()
+                        .expect("command names have clap values")
+                        .get_name()
+                        .to_owned(),
+                    rate,
+                )
+            })
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        sampled_commands,
+        vec![
+            ("status".into(), 0.01),
+            ("diff".into(), 0.05),
+            ("branch-list".into(), 0.10),
+            ("refresh-remote-data".into(), 0.05),
+        ],
+        "only the selected read-only commands should be sampled"
+    );
+}
+
+#[test]
+fn full_rate_cli_events_include_sampling_rate() {
+    let props = sample_props(Props::new(), CommandName::Commit, false, 1.0)
+        .expect("full-rate events should always capture");
+
+    assert_eq!(
+        props.values["samplingRate"],
+        serde_json::json!(1.0),
+        "full-rate events should record their rate"
+    );
+}
+
+#[test]
+fn command_rejections_bypass_sampling() {
+    let result = Err::<(), _>(CliError::CommandRejection);
+    let props =
+        Props::from_cli_error_result(std::time::Instant::now(), &result, CommandName::Status);
+    let props = sample_props(props, CommandName::Status, result.is_err(), 1.0)
+        .expect("failed events should bypass sampling");
+
+    assert_eq!(
+        (&props.values["errorKind"], &props.values["samplingRate"]),
+        (
+            &serde_json::json!("commandRejection"),
+            &serde_json::json!(1.0)
+        ),
+        "typed failures should use the full sampling rate"
+    );
+}
+
+#[test]
+fn successful_sampled_events_can_be_dropped() {
+    assert!(
+        sample_props(Props::new(), CommandName::Status, false, 0.5).is_none(),
+        "successful status events above the rate should be dropped"
+    );
+}
+
+#[test]
+fn transport_rejects_malformed_or_invalid_rates() {
+    for json in [
+        "not-json",
+        r#"{"samplingRate":"invalid"}"#,
+        r#"{"samplingRate":0}"#,
+        r#"{"samplingRate":1.1}"#,
+    ] {
+        assert!(
+            prepare_transport_props(json).is_err(),
+            "invalid transport properties must not produce an event: {json}"
+        );
+    }
+}
+
+#[test]
+fn transport_keeps_a_valid_parent_rate_without_resampling() {
+    let props = prepare_transport_props(r#"{"samplingRate":0.01}"#)
+        .expect("a valid transport payload should parse");
+
+    assert_eq!(
+        props.values["samplingRate"],
+        serde_json::json!(0.01),
+        "the parent's effective rate must survive transport"
+    );
+}
+
+#[test]
+fn legacy_transport_events_without_a_rate_use_full_rate() {
+    let props = prepare_transport_props("{}").expect("empty properties are valid JSON");
+
+    assert_eq!(
+        props.values["samplingRate"],
+        serde_json::json!(1.0),
+        "legacy events were emitted at the full rate"
+    );
+}
+
+#[test]
+fn transport_failures_without_a_rate_are_kept() {
+    let props = prepare_transport_props(r#"{"error":"Internal error","errorKind":"internal"}"#)
+        .expect("failure properties are valid JSON");
+
+    assert_eq!(
+        props.values["samplingRate"],
+        serde_json::json!(1.0),
+        "transport failures should use the full sampling rate"
+    );
+}
+
+#[test]
+fn commands_with_their_own_event_lifecycle_do_not_create_cli_context() {
+    let mut settings = AppSettings::default();
+    settings.telemetry.app_metrics_enabled = true;
+
+    let commands = [
+        Subcommands::Completions { shell: None },
+        Subcommands::Mcp(crate::args::mcp::Platform {
+            cmd: crate::args::mcp::Subcommands::Serve,
+        }),
+        Subcommands::Metrics {
+            command_name: CommandName::Status,
+            props: "{}".into(),
+        },
+    ];
+
+    assert!(
+        commands.iter().all(|command| command
+            .to_metrics_context(&settings, Path::new("."))
+            .is_none()),
+        "commands that own or intentionally omit reporting should not get a CLI context"
+    );
+}
+
+#[test]
+fn workspace_shape_never_initializes_a_project() {
+    but_testsupport::isolated_app_data_dir(|| {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let repo_dir = tmp.path().join("repo");
+        gix::init(&repo_dir).expect("init plain repo");
+        let mut event = Event::new(EventKind::Cli(CommandName::Commit));
+
+        // A plain repository without GitButler state must stay untouched.
+        add_workspace_shape(&mut event, &repo_dir);
+        let data_dir = repo_dir.join(".git/gitbutler");
+        assert!(!data_dir.exists());
+        assert!(!event.props.contains_key("totalLanesInWorkspace"));
+
+        // Even with a project data dir present, the project database must not be created.
+        std::fs::create_dir(&data_dir).expect("create project data dir");
+        add_workspace_shape(&mut event, &repo_dir);
+        assert_eq!(
+            std::fs::read_dir(&data_dir).expect("read data dir").count(),
+            0
+        );
+        assert!(!event.props.contains_key("totalLanesInWorkspace"));
+    });
+}
+
+#[test]
+fn workspace_shape_counts_lanes_and_stacked_branches() {
+    but_testsupport::isolated_app_data_dir(|| {
+        let sandbox =
+            but_testsupport::Sandbox::open_or_init_scenario_with_target_and_default_settings(
+                "one-stack-three-dependent-branches",
+            );
+        let repo = sandbox.open_repo();
+        let workdir = repo.workdir().expect("scenario is not bare").to_owned();
+        // The shape is only read from repositories that already carry a project database.
+        but_db::DbHandle::new_in_directory(repo.git_dir().join("gitbutler"))
+            .expect("create project db");
+
+        let mut event = Event::new(EventKind::Cli(CommandName::Commit));
+        add_workspace_shape(&mut event, &workdir);
+
+        assert_eq!(event.props["totalLanesInWorkspace"], serde_json::json!(1));
+        assert_eq!(
+            event.props["totalBranchesInWorkspace"],
+            serde_json::json!(3)
+        );
+        assert_eq!(event.props["maxBranchesPerLane"], serde_json::json!(3));
+    });
+}
+
+#[test]
+fn metrics_use_invoked_command_names() {
+    assert_command(
+        Subcommands::Update(update::Platform {
+            cmd: update::Subcommands::Check,
+        }),
+        "updateCheck",
+    );
+    assert_command(
+        Subcommands::Update(update::Platform {
+            cmd: update::Subcommands::Suppress { days: 7 },
+        }),
+        "updateSuppress",
+    );
+    assert_command(
+        Subcommands::Agent(agent::Platform {
+            cmd: Some(agent::Subcommands::Setup { print: false }),
+        }),
+        "agentSetup",
+    );
+    // Bare `but agent` (no subcommand) maps to the same metric.
+    assert_command(
+        Subcommands::Agent(agent::Platform { cmd: None }),
+        "agentSetup",
+    );
+    assert_command(
+        Subcommands::Branch(branch::Platform { cmd: None }),
+        "branchList",
+    );
+    #[cfg(feature = "legacy")]
+    assert_command(
+        Subcommands::Move(crate::args::r#move::Platform {
+            branch: Some(Some(CliIdArg("main".to_owned()))),
+            above: None,
+            below: None,
+            unstack: false,
+            sources: Vec::from([CliIdArg("ci".to_owned())]),
+            allow_merged: Default::default(),
+        }),
+        "move",
+    );
+
+    #[cfg(all(unix, not(feature = "packaged-but-distribution")))]
+    assert_command(
+        Subcommands::Update(update::Platform {
+            cmd: update::Subcommands::Install {
+                target: Some("0.20.0".into()),
+            },
+        }),
+        "updateInstall",
+    );
+
+    #[cfg(feature = "legacy")]
+    {
+        assert_command(
+            Subcommands::Amend(crate::args::amend::Platform {
+                target: CliIdArg("c1".into()),
+                sources: vec![CliIdArg("a1".into())],
+                allow_merged: Default::default(),
+            }),
+            "amend",
+        );
+    }
+}
+
+#[test]
+fn formerly_unknown_commands_use_explicit_names() {
+    assert_command(
+        Subcommands::_Expand {
+            cli_id: CliIdArg("c1".into()),
+        },
+        "expand",
+    );
+    assert_command(
+        Subcommands::Config(config::Platform { cmd: None }),
+        "config",
+    );
+    assert_command(
+        Subcommands::Config(config::Platform {
+            cmd: Some(config::Subcommands::User { cmd: None }),
+        }),
+        "config",
+    );
+    assert_command(
+        Subcommands::Config(config::Platform {
+            cmd: Some(config::Subcommands::Metrics { status: None }),
+        }),
+        "config",
+    );
+
+    #[cfg(feature = "legacy")]
+    {
+        assert_command(Subcommands::Setup { init: false }, "setup");
+        assert_command(Subcommands::Teardown { checkout_to: None }, "teardown");
+    }
+}
+
+#[test]
+fn formerly_unclassified_commands_have_explicit_names() {
+    let commands = [
+        (
+            Subcommands::_Comment(crate::args::comment::Platform {
+                cmd: crate::args::comment::Subcommands::List {
+                    wait: false,
+                    timeout: 60,
+                },
+            }),
+            "comment",
+        ),
+        (Subcommands::Completions { shell: None }, "completions"),
+        (Subcommands::Help { topic: None }, "help"),
+        (Subcommands::Onboarding, "onboarding"),
+        (
+            Subcommands::Mcp(crate::args::mcp::Platform {
+                cmd: crate::args::mcp::Subcommands::Serve,
+            }),
+            "mcp",
+        ),
+        (
+            Subcommands::Metrics {
+                command_name: CommandName::Status,
+                props: "{}".into(),
+            },
+            "metrics",
+        ),
+        (
+            Subcommands::AgentLog {
+                cmd: but_agentlog::Command::Sync,
+            },
+            "agentLog",
+        ),
+        #[cfg(feature = "legacy")]
+        (
+            Subcommands::Actions(crate::args::actions::Platform { cmd: None }),
+            "actions",
+        ),
+    ];
+
+    for (command, expected) in commands {
+        assert_command(command, expected);
+    }
+}
+
+#[test]
+fn extra_props_keep_useful_source_and_target_kinds() {
+    #[cfg(feature = "legacy")]
+    {
+        let moved = Subcommands::Move(crate::args::r#move::Platform {
+            branch: Some(Some(CliIdArg("main".to_owned()))),
+            above: None,
+            below: None,
+            unstack: false,
+            sources: Vec::from([CliIdArg("ci".to_owned())]),
+            allow_merged: Default::default(),
+        });
+        let props = moved.to_metrics_extra_props();
+        assert_eq!(
+            prop(&props, "sourceKind"),
+            Some(&serde_json::json!("commitOrBranch"))
+        );
+        assert_eq!(
+            prop(&props, "targetKind"),
+            Some(&serde_json::json!("commitOrBranchOrUnassigned"))
+        );
+    }
+}
+
+#[test]
+fn external_extra_props_include_sanitized_subcommand() {
+    let props = Subcommands::External(vec![" typo-OK ".into()]).to_metrics_extra_props();
+    assert_eq!(
+        prop(&props, "externalSubcommand"),
+        Some(&serde_json::json!("typo-OK"))
+    );
+
+    let props = Subcommands::External(vec!["/tmp/private".into()]).to_metrics_extra_props();
+    assert_eq!(
+        prop(&props, "externalSubcommand"),
+        Some(&serde_json::json!(INVALID_UNRECOGNIZED_SUBCOMMAND))
+    );
+
+    let props = Subcommands::External(vec!["customer123".into()]).to_metrics_extra_props();
+    assert_eq!(
+        prop(&props, "externalSubcommand"),
+        Some(&serde_json::json!(INVALID_UNRECOGNIZED_SUBCOMMAND))
+    );
+}
+
+#[test]
+fn internal_error_details_are_allowlisted() {
+    let anyhow_result = Err::<(), _>(
+        anyhow::anyhow!("stale id. If you just performed a Git operation, refresh")
+            .context("Failed to uncommit."),
+    );
+
+    let props = Props::from_anyhow_result(
+        std::time::Instant::now(),
+        &anyhow_result,
+        CommandName::Uncommit,
+    );
+
+    assert_eq!(props.values["error"], "Internal error");
+    assert_eq!(props.values["errorKind"], "internal");
+    assert_eq!(
+        props.values["errorMessage"],
+        "Failed to uncommit.: stale id."
+    );
+    assert_eq!(props.values["errorRoot"], "stale id.");
+
+    let result =
+        Err::<(), _>(anyhow::anyhow!("private-branch-name failed").context("private-path failed"));
+
+    let props = Props::from_anyhow_result(std::time::Instant::now(), &result, CommandName::Status);
+
+    assert_eq!(props.values["error"], "Internal error");
+    assert_eq!(props.values["errorKind"], "internal");
+    assert!(!props.values.contains_key("errorMessage"));
+    assert!(!props.values.contains_key("errorRoot"));
+    assert!(!props.as_json_string().contains("private-branch-name"));
+    assert!(!props.as_json_string().contains("private-path"));
+}
+
+#[test]
+fn commit_internal_error_details_are_captured() {
+    let result = Err::<(), _>(CliError::Internal(
+        anyhow::anyhow!("stale id. If you just performed a Git operation, refresh")
+            .context("Failed to commit."),
+    ));
+
+    let props =
+        Props::from_cli_error_result(std::time::Instant::now(), &result, CommandName::Commit);
+
+    assert_eq!(props.values["errorMessage"], "Failed to commit.: stale id.");
+    assert_eq!(props.values["errorRoot"], "stale id.");
+}
+
+#[test]
+fn initialization_errors_use_distinct_kind_without_private_details() {
+    let result = Err::<(), _>(CliError::Initialization(anyhow::anyhow!(
+        "No git repository found at /Users/alice/secret-client"
+    )));
+
+    let props =
+        Props::from_cli_error_result(std::time::Instant::now(), &result, CommandName::Commit);
+
+    assert_eq!(props.values["errorKind"], "initialization");
+    assert!(
+        !props.as_json_string().contains("secret-client"),
+        "initialization failures must stay low-cardinality"
+    );
+}
+
+#[cfg(feature = "legacy")]
+#[test]
+fn explained_commit_rejections_omit_private_details() {
+    let result = Err::<(), _>(CliError::Internal(anyhow::Error::new(
+        crate::utils::rejection::ExplainedRejection(
+            "Cannot commit private/path on private-branch".to_string(),
+        ),
+    )));
+
+    let props =
+        Props::from_cli_error_result(std::time::Instant::now(), &result, CommandName::Commit);
+
+    assert_eq!(props.values["error"], "Command rejection");
+    assert_eq!(props.values["errorKind"], "commandRejection");
+    assert!(!props.values.contains_key("errorMessage"));
+    assert!(!props.values.contains_key("errorRoot"));
+    assert!(!props.as_json_string().contains("private/path"));
+    assert!(!props.as_json_string().contains("private-branch"));
+}
+
+#[test]
+fn cli_error_metrics_use_low_cardinality_failure_details() {
+    let bad_input_result = Err::<(), _>(
+        bad_input("Branch 'branch-with-private-name' not found")
+            .arg_name("<BRANCH>")
+            .arg_value("another-private-branch-name")
+            .hint("Use a branch name")
+            .into(),
+    );
+
+    let props = Props::from_cli_error_result(
+        std::time::Instant::now(),
+        &bad_input_result,
+        CommandName::Commit,
+    );
+
+    assert_eq!(props.values["errorKind"], "badInput");
+    assert_eq!(props.values["error"], "Bad input");
+    assert!(!props.values.contains_key("errorMessage"));
+    assert_eq!(props.values["badInputArgName"], "<BRANCH>");
+    assert_eq!(props.values["badInputHasHint"], true);
+    assert!(!props.as_json_string().contains("branch-with-private-name"));
+    assert!(
+        !props
+            .as_json_string()
+            .contains("another-private-branch-name")
+    );
+
+    let external_result = Err::<(), _>(CliError::ExternalCommandNotFound("typo".into()));
+    let props = Props::from_cli_error_result(
+        std::time::Instant::now(),
+        &external_result,
+        CommandName::External,
+    );
+
+    assert_eq!(props.values["error"], "Unrecognized subcommand");
+    assert_eq!(props.values["errorKind"], "externalCommandNotFound");
+    assert_eq!(props.values["unrecognizedSubcommand"], "typo");
+    assert!(!props.values.contains_key("errorMessage"));
+
+    let external_result = Err::<(), _>(CliError::ExternalCommandFailed(42));
+    let props = Props::from_cli_error_result(
+        std::time::Instant::now(),
+        &external_result,
+        CommandName::External,
+    );
+    assert_eq!(props.values["error"], "External command failed");
+    assert_eq!(props.values["errorKind"], "externalCommandFailed");
+
+    let external_result = Err::<(), _>(CliError::ExternalCommandNotFound(" typo-123_OK ".into()));
+    let props = Props::from_cli_error_result(
+        std::time::Instant::now(),
+        &external_result,
+        CommandName::External,
+    );
+    assert_eq!(props.values["unrecognizedSubcommand"], "typo-123_OK");
+
+    let external_result = Err::<(), _>(CliError::ExternalCommandNotFound("/tmp/private".into()));
+    let props = Props::from_cli_error_result(
+        std::time::Instant::now(),
+        &external_result,
+        CommandName::External,
+    );
+    assert_eq!(
+        props.values["unrecognizedSubcommand"],
+        INVALID_UNRECOGNIZED_SUBCOMMAND
+    );
+    assert!(!props.as_json_string().contains("/tmp/private"));
+
+    let long_command = "a".repeat(UNRECOGNIZED_SUBCOMMAND_MAX_CHARS + 1);
+    let external_result = Err::<(), _>(CliError::ExternalCommandNotFound(long_command.into()));
+    let props = Props::from_cli_error_result(
+        std::time::Instant::now(),
+        &external_result,
+        CommandName::External,
+    );
+    assert_eq!(
+        props.values["unrecognizedSubcommand"]
+            .as_str()
+            .expect("metric value is a string")
+            .len(),
+        UNRECOGNIZED_SUBCOMMAND_MAX_CHARS
+    );
+}
+
+#[test]
+fn detailed_error_messages_are_normalized_and_capped() {
+    let multiline_result =
+        Err::<(), _>(anyhow::anyhow!("first line\nsecond line").context("Failed to uncommit."));
+
+    let props = Props::from_anyhow_result(
+        std::time::Instant::now(),
+        &multiline_result,
+        CommandName::Uncommit,
+    );
+
+    assert_eq!(
+        props.values["errorMessage"],
+        "Failed to uncommit.: first line second line"
+    );
+    assert_eq!(props.values["errorRoot"], "first line second line");
+
+    let long_result = Err::<(), _>(anyhow::anyhow!("{}", "a".repeat(1100)));
+
+    let props = Props::from_anyhow_result(
+        std::time::Instant::now(),
+        &long_result,
+        CommandName::Uncommit,
+    );
+
+    assert_eq!(
+        props.values["errorMessage"].as_str().unwrap().len(),
+        ERROR_MESSAGE_MAX_CHARS
+    );
+    assert_eq!(
+        props.values["errorRoot"].as_str().unwrap().len(),
+        ERROR_MESSAGE_MAX_CHARS
+    );
+}

--- a/crates/but/tests/but/command/external.rs
+++ b/crates/but/tests/but/command/external.rs
@@ -36,6 +36,28 @@ args: one two
 }
 
 #[test]
+fn preserves_external_command_exit_code_without_extra_error() {
+    let env = Sandbox::empty();
+    let bin = env.projects_root().join("external-cmd-bin");
+    fs::create_dir_all(&bin).unwrap();
+    let helper = bin.join("but-forecast");
+    fs::write(&helper, "#!/bin/sh\nexit 42\n").unwrap();
+    let mut perms = fs::metadata(&helper).unwrap().permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&helper, perms).unwrap();
+
+    let path = std::env::var("PATH").unwrap_or_default();
+    let new_path = format!("{}:{path}", bin.display());
+
+    // The parent must preserve the helper's status without adding its own diagnostic.
+    env.but("forecast")
+        .env("PATH", new_path)
+        .assert()
+        .code(42)
+        .stderr_eq(str![[]]);
+}
+
+#[test]
 fn prefers_builtin_command_when_external_command_clashes() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
     let bin = env.projects_root().join("external-cmd-bin");


### PR DESCRIPTION
Reduce noise from frequent read-only commands while keeping failure reporting complete.

- omit shell completion invocations
- use explicit rates for noisy read-only commands
- classify command names explicitly
- preserve external command exits and bounded failure details