### PR TITLE
Fix branch integration cycle after local upstream merge

### DIFF
--- a/crates/but-workspace/src/branch/integrate_branch_upstream/mod.rs
+++ b/crates/but-workspace/src/branch/integrate_branch_upstream/mod.rs
@@ -19,6 +19,7 @@ use crate::{
     divergence::{
         BranchMergeBaseCommits, classify_selectors_against_target_ref, commit_ids_from_selectors,
         find_local_commit_until_merge_base, get_commits_until_merge_base,
+        traverse_pick_ancestor_ids,
     },
 };
 use crate::{graph_manipulation::determine_parent_selector, resolve_tracking_branch_ref_name};
@@ -296,6 +297,28 @@ pub fn get_initial_integration_steps_for_branch<M: RefMetadata>(
         .transpose()?
         .unwrap_or_default();
 
+    let first_local_not_integrated =
+        editable_local_commits(&local_commits, &target_relations).next();
+    let retained_base_selector = match first_local_not_integrated {
+        Some(commit_id) => local_commits
+            .iter()
+            .position(|candidate| *candidate == commit_id)
+            .and_then(|index| local_commit_selectors.get(index + 1).copied())
+            .unwrap_or(merge_base_selector),
+        None => local_commit_selectors
+            .first()
+            .copied()
+            .unwrap_or(merge_base_selector),
+    };
+    let retained_ancestor_ids = traverse_pick_ancestor_ids(&editor, retained_base_selector)?;
+    // Replaying an upstream commit already present below the rebuilt segment would make reconnecting
+    // a retained local merge cyclic. Commits reachable only through the segment being replaced must
+    // remain in the plan, notably when PickRemote discards that local merge.
+    let upstream_commits = upstream_commits
+        .into_iter()
+        .filter(|id| !retained_ancestor_ids.contains(id))
+        .collect::<Vec<_>>();
+
     // Step 4: Build the initial set of integration steps.
     let change_ids = if matches!(strategy, BranchIntegrationStrategy::SmartSquash) {
         explicit_change_ids(
@@ -336,8 +359,7 @@ pub fn get_initial_integration_steps_for_branch<M: RefMetadata>(
     let integration = InteractiveIntegration {
         steps: initial_steps,
         merge_base,
-        first_local_not_integrated: editable_local_commits(&local_commits, &target_relations)
-            .next(),
+        first_local_not_integrated,
     };
     let mut divergence = IntegrationDivergenceDisplay {
         branch_ref_name: ref_name.to_owned(),

--- a/crates/but-workspace/src/divergence.rs
+++ b/crates/but-workspace/src/divergence.rs
@@ -3,7 +3,10 @@
 use anyhow::{Context as _, Result};
 use but_core::RefMetadata;
 use but_rebase::graph_rebase::{Editor, LookupStep, Pick, Selector, Step, ToSelector};
-use std::{borrow::Cow, collections::HashMap};
+use std::{
+    borrow::Cow,
+    collections::{HashMap, HashSet},
+};
 
 use crate::graph_manipulation::traverse_nodes;
 
@@ -223,7 +226,7 @@ fn child_on_head_first_parent_path<M: RefMetadata>(
 fn find_first_parent_merge_base<M: RefMetadata>(
     editor: &Editor<'_, '_, M>,
     local_tip: Selector,
-    upstream_ancestors: &HashMap<gix::ObjectId, Selector>,
+    upstream_ancestors: &HashSet<gix::ObjectId>,
 ) -> Result<Option<gix::ObjectId>> {
     let mut current = Some(local_tip);
     while let Some(selector) = current {
@@ -235,12 +238,12 @@ fn find_first_parent_merge_base<M: RefMetadata>(
         else {
             return Ok(None);
         };
-        if upstream_ancestors.contains_key(&id) {
+        if upstream_ancestors.contains(&id) {
             return Ok(Some(id));
         }
         if let Some(preserved_parents) = preserved_parents {
             for parent_id in preserved_parents {
-                if upstream_ancestors.contains_key(&parent_id) {
+                if upstream_ancestors.contains(&parent_id) {
                     return Ok(Some(parent_id));
                 }
             }
@@ -254,11 +257,11 @@ fn find_first_parent_merge_base<M: RefMetadata>(
     Ok(None)
 }
 
-fn traverse_pick_ancestor_ids<M: RefMetadata>(
+pub(crate) fn traverse_pick_ancestor_ids<M: RefMetadata>(
     editor: &Editor<'_, '_, M>,
     tip: Selector,
-) -> Result<HashMap<gix::ObjectId, Selector>> {
-    let mut out = HashMap::new();
+) -> Result<HashSet<gix::ObjectId>> {
+    let mut out = HashSet::new();
     let mut seen = std::collections::HashSet::from([tip]);
     let mut tips = vec![tip];
 
@@ -269,7 +272,7 @@ fn traverse_pick_ancestor_ids<M: RefMetadata>(
                 preserved_parents,
                 ..
             }) => {
-                out.entry(id).or_insert(tip);
+                out.insert(id);
                 preserved_parents
             }
             Step::Reference { .. } | Step::None => None,
@@ -283,7 +286,7 @@ fn traverse_pick_ancestor_ids<M: RefMetadata>(
 
         if let Some(preserved_parents) = preserved_parents {
             for parent_id in preserved_parents {
-                out.entry(parent_id).or_insert(tip);
+                out.insert(parent_id);
                 if let Some(parent) = editor.try_select_commit(parent_id)
                     && seen.insert(parent)
                 {

--- a/crates/but-workspace/tests/workspace/branch/integrate_branch_upstream.rs
+++ b/crates/but-workspace/tests/workspace/branch/integrate_branch_upstream.rs
@@ -3124,6 +3124,162 @@ fn apply_initial_steps_example_2_also_applies_integrated_local_commits() -> Resu
 }
 
 #[test]
+fn apply_initial_steps_does_not_replay_an_upstream_commit_already_merged_locally() -> Result<()> {
+    let (_tmp, mut repo) =
+        build_branch_integration_example_repo(ExampleScenario::LocalMergeContainsUpstreamCommit {
+            target_contains_merge: true,
+        })?;
+    configure_tracking_for_branch_a(&mut repo)?;
+    let local_merge = repo.rev_parse_single("A~1")?.detach();
+    let local_tip = repo.rev_parse_single("A")?.detach();
+    let upstream_parent = repo.rev_parse_single("origin/A~1")?.detach();
+    let upstream_tip = repo.rev_parse_single("origin/A")?.detach();
+
+    let initial = initial_integration_for_branch(
+        r("refs/heads/A"),
+        &repo,
+        Some(r("refs/remotes/origin/main")),
+    )?;
+    assert_eq!(
+        pick_step_ids(&initial.integration.steps),
+        vec![upstream_tip, local_tip],
+        "the plan should omit the upstream commit already reachable through the local merge",
+    );
+    let (mut workspace, mut meta) = integration_workspace_for_branch(
+        r("refs/heads/A"),
+        &repo,
+        Some(r("refs/remotes/origin/main")),
+    )?;
+    let mut db = but_testsupport::in_memory_db();
+    let rebase = integrate_branch_with_steps(
+        r("refs/heads/A"),
+        initial.integration,
+        &mut workspace,
+        &mut meta,
+        &repo,
+        &mut db,
+    )?;
+    rebase.materialize(Default::default())?;
+
+    assert_eq!(
+        repo.rev_parse_single("A~2")?.detach(),
+        local_merge,
+        "the existing local merge should remain the base of the rebuilt commits",
+    );
+    let local_merge_parents = repo
+        .find_commit(local_merge)?
+        .parent_ids()
+        .map(|id| id.detach())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        local_merge_parents.get(1),
+        Some(&upstream_parent),
+        "the local merge should retain the upstream commit as its second parent",
+    );
+    assert_eq!(
+        repo.find_commit(repo.rev_parse_single("A")?.detach())?
+            .message_raw()?,
+        repo.find_commit(local_tip)?.message_raw()?,
+        "the local tip should remain the child-most rebuilt commit",
+    );
+    assert_eq!(
+        repo.find_commit(repo.rev_parse_single("A~1")?.detach())?
+            .message_raw()?,
+        repo.find_commit(upstream_tip)?.message_raw()?,
+        "only the missing upstream tip should be inserted above the local merge",
+    );
+
+    Ok(())
+}
+
+#[test]
+fn pick_remote_replays_upstream_commit_only_reachable_through_discarded_local_merge() -> Result<()>
+{
+    let (_tmp, mut repo) =
+        build_branch_integration_example_repo(ExampleScenario::LocalMergeContainsUpstreamCommit {
+            target_contains_merge: false,
+        })?;
+    configure_tracking_for_branch_a(&mut repo)?;
+    let upstream_parent = repo.rev_parse_single("origin/A~1")?.detach();
+    let upstream_tip = repo.rev_parse_single("origin/A")?.detach();
+
+    let initial = initial_integration_for_branch_with_strategy(
+        r("refs/heads/A"),
+        &repo,
+        Some(r("refs/remotes/origin/main")),
+        BranchIntegrationStrategy::PickRemote,
+    )?;
+    assert_eq!(
+        pick_step_ids(&initial.integration.steps),
+        vec![upstream_parent, upstream_tip],
+        "pick-remote should keep upstream commits whose containing local merge is discarded",
+    );
+
+    let (mut workspace, mut meta) = integration_workspace_for_branch(
+        r("refs/heads/A"),
+        &repo,
+        Some(r("refs/remotes/origin/main")),
+    )?;
+    let mut db = but_testsupport::in_memory_db();
+    integrate_branch_with_steps(
+        r("refs/heads/A"),
+        initial.integration,
+        &mut workspace,
+        &mut meta,
+        &repo,
+        &mut db,
+    )?
+    .materialize(Default::default())?;
+    assert_eq!(
+        repo.find_commit(repo.rev_parse_single("A~1")?.detach())?
+            .message_raw()?,
+        repo.find_commit(upstream_parent)?.message_raw()?,
+        "the rebuilt branch should retain the upstream parent's changes",
+    );
+
+    Ok(())
+}
+
+#[test]
+fn pick_remote_does_not_replay_upstream_commit_reachable_below_rebuild_boundary() -> Result<()> {
+    let (_tmp, mut repo) =
+        build_branch_integration_example_repo(ExampleScenario::LocalMergeContainsUpstreamCommit {
+            target_contains_merge: true,
+        })?;
+    configure_tracking_for_branch_a(&mut repo)?;
+    let upstream_tip = repo.rev_parse_single("origin/A")?.detach();
+
+    let initial = initial_integration_for_branch_with_strategy(
+        r("refs/heads/A"),
+        &repo,
+        Some(r("refs/remotes/origin/main")),
+        BranchIntegrationStrategy::PickRemote,
+    )?;
+    assert_eq!(
+        pick_step_ids(&initial.integration.steps),
+        vec![upstream_tip],
+        "pick-remote should omit upstream commits retained below the rebuild boundary",
+    );
+    let (mut workspace, mut meta) = integration_workspace_for_branch(
+        r("refs/heads/A"),
+        &repo,
+        Some(r("refs/remotes/origin/main")),
+    )?;
+    let mut db = but_testsupport::in_memory_db();
+    integrate_branch_with_steps(
+        r("refs/heads/A"),
+        initial.integration,
+        &mut workspace,
+        &mut meta,
+        &repo,
+        &mut db,
+    )?
+    .materialize(Default::default())?;
+
+    Ok(())
+}
+
+#[test]
 fn initial_steps_example_3_keeps_integrated_upstream_commits_editable() -> Result<()> {
     let (_tmp, mut repo) = build_branch_integration_example_repo(
         ExampleScenario::UpstreamCommitHistoricallyIntegratedOnTarget,
@@ -3221,6 +3377,7 @@ enum ExampleScenario {
     ExtraTargetHistoryExcludedFromDivergence,
     LocalCommitHistoricallyIntegratedOnTarget,
     UpstreamCommitHistoricallyIntegratedOnTarget,
+    LocalMergeContainsUpstreamCommit { target_contains_merge: bool },
 }
 
 fn build_branch_integration_example_repo(
@@ -3277,6 +3434,29 @@ fn build_branch_integration_example_repo(
 
             run_git(&repo_dir, &["checkout", "-b", "upstream-a", &x])?;
             append_and_commit(&repo_dir, "story.txt", "D\n", "D")?;
+        }
+        ExampleScenario::LocalMergeContainsUpstreamCommit {
+            target_contains_merge,
+        } => {
+            run_git(&repo_dir, &["checkout", "-b", "A", &a])?;
+            append_and_commit(&repo_dir, "local.txt", "A1\n", "A1")?;
+
+            run_git(&repo_dir, &["checkout", "-b", "upstream-a", &a])?;
+            append_and_commit(&repo_dir, "upstream.txt", "U1\n", "U1")?;
+            let u1 = git_rev_parse(&repo_dir, "HEAD")?;
+            append_and_commit(&repo_dir, "upstream.txt", "U2\n", "U2")?;
+
+            run_git(&repo_dir, &["checkout", "A"])?;
+            run_git(&repo_dir, &["merge", "--no-ff", &u1, "-m", "L"])?;
+            run_git(
+                &repo_dir,
+                &[
+                    "branch",
+                    "target-main",
+                    if target_contains_merge { "HEAD" } else { &a },
+                ],
+            )?;
+            append_and_commit(&repo_dir, "local.txt", "C\n", "C")?;
         }
     }
 


### PR DESCRIPTION
Fixes [GB-1904](https://linear.app/gitbutler/issue/GB-1904/apply-branch-integration-fails-with-add-edge-introduces-a-cycle).

Branch integration could fail with “BUG: Add edge introduces a cycle” when a local branch had already merged part of its tracking branch and the tracking branch subsequently advanced. For example:

    M─A1─L─C       local branch
     \   ╱
      U1─U2        tracking branch

Here L retains U1 as a merge parent, while U2 is the only genuinely missing upstream commit. The initial integration plan nevertheless classified both U1 and U2 as upstream-only and tried to replay U1 above L. Reconnecting the preserved merge history then produced the cycle U1 → L → U1.

The divergence planner now removes upstream first-parent commits that are already reachable from the local tip through any parent. The resulting plan replays only U2 and C, preserving L and its merge parentage. The change stays in divergence discovery; it does not add cycle-tolerance to the graph editor or change execution for manually supplied plans.