### PR TITLE
Lite UI: shared components and details header cleanup

### DIFF
--- a/apps/lite/ui/src/components/Badge.module.css
+++ b/apps/lite/ui/src/components/Badge.module.css
@@ -78,6 +78,12 @@
 	color: var(--text-blue);
 }
 
+.pop {
+	--_bg: var(--fill-pop-bg);
+	background-color: color-mix(in srgb, var(--_bg) var(--badge-bg-opacity), transparent);
+	color: var(--text-pop);
+}
+
 /* Matches the graph's integrated commit color, so the pill and the glyphs
    telling the same story share a hue. */
 .integrated {

--- a/apps/lite/ui/src/components/Badge.tsx
+++ b/apps/lite/ui/src/components/Badge.tsx
@@ -11,6 +11,7 @@ export type BadgeVariant =
 	| "danger"
 	| "purple"
 	| "blue"
+	| "pop"
 	| "integrated";
 
 /** @public */
@@ -57,6 +58,7 @@ export const Badge: FC<{ variant: BadgeVariant; size?: BadgeSize } & ComponentPr
 				Match.when("danger", () => styles.danger),
 				Match.when("purple", () => styles.purple),
 				Match.when("blue", () => styles.blue),
+				Match.when("pop", () => styles.pop),
 				Match.when("integrated", () => styles.integrated),
 				Match.exhaustive,
 			),

--- a/apps/lite/ui/src/components/DiffStats.module.css
+++ b/apps/lite/ui/src/components/DiffStats.module.css
@@ -1,0 +1,17 @@
+.container {
+	display: inline-flex;
+	/* Two short numbers: when a header runs out of room the heading beside them
+	   truncates instead. */
+	flex-shrink: 0;
+	align-items: center;
+	gap: 4px;
+	text-box: trim-both cap alphabetic;
+}
+
+.added {
+	color: var(--text-safe);
+}
+
+.removed {
+	color: var(--text-danger);
+}

--- a/apps/lite/ui/src/components/DiffStats.stories.tsx
+++ b/apps/lite/ui/src/components/DiffStats.stories.tsx
@@ -1,0 +1,31 @@
+import preview from "#storybook/preview";
+import { DiffStats } from "./DiffStats.tsx";
+
+const meta = preview.meta({
+	component: DiffStats,
+	args: {
+		added: 364,
+		removed: 20,
+	},
+});
+
+export const Default = meta.story({
+	args: {
+		added: 364,
+		removed: 20,
+	},
+});
+
+export const OnlyAdditions = meta.story({
+	args: {
+		added: 6,
+		removed: 0,
+	},
+});
+
+export const OnlyDeletions = meta.story({
+	args: {
+		added: 0,
+		removed: 12,
+	},
+});

--- a/apps/lite/ui/src/components/DiffStats.tsx
+++ b/apps/lite/ui/src/components/DiffStats.tsx
@@ -1,0 +1,23 @@
+import { classes } from "#ui/components/classes.ts";
+import type { ComponentProps, FC } from "react";
+import styles from "./DiffStats.module.css";
+
+type Props = {
+	added: number;
+	removed: number;
+} & ComponentProps<"span">;
+
+/**
+ * The `+N -N` line counts of a diff. Renders nothing when nothing changed, and
+ * drops either side when it is zero, so a header shows only what it has to say.
+ */
+export const DiffStats: FC<Props> = ({ added, removed, ...props }) => {
+	if (added === 0 && removed === 0) return null;
+
+	return (
+		<span {...props} className={classes(props.className, styles.container)}>
+			{added > 0 && <span className={styles.added}>+{added}</span>}
+			{removed > 0 && <span className={styles.removed}>-{removed}</span>}
+		</span>
+	);
+};

--- a/apps/lite/ui/src/components/FileStatusBadge.module.css
+++ b/apps/lite/ui/src/components/FileStatusBadge.module.css
@@ -1,0 +1,26 @@
+.badge {
+	flex-shrink: 0;
+	align-self: center;
+	/* Sized off the text so the column stays aligned at any font size. */
+	width: 1.1em;
+	font-weight: var(--text-weight-semibold);
+	font-family: var(--text-fontfamily-base);
+	text-box: trim-both cap alphabetic;
+	text-align: center;
+
+	&[data-status-type="Addition"] {
+		color: var(--change-status-addition);
+	}
+
+	&[data-status-type="Deletion"] {
+		color: var(--change-status-deletion);
+	}
+
+	&[data-status-type="Modification"] {
+		color: var(--change-status-modification);
+	}
+
+	&[data-status-type="Rename"] {
+		color: var(--change-status-rename);
+	}
+}

--- a/apps/lite/ui/src/components/FileStatusBadge.stories.tsx
+++ b/apps/lite/ui/src/components/FileStatusBadge.stories.tsx
@@ -1,0 +1,48 @@
+import preview from "#storybook/preview";
+import { FileStatusBadge, type FileStatusType } from "./FileStatusBadge.tsx";
+
+const statuses: Array<FileStatusType> = ["Addition", "Deletion", "Modification", "Rename"];
+
+const meta = preview.meta({
+	component: FileStatusBadge,
+	argTypes: {
+		status: {
+			control: "select",
+			options: statuses,
+		},
+		fontSize: {
+			control: { type: "range", min: 8, max: 64, step: 1 },
+		},
+	},
+	args: {
+		status: "Addition",
+		fontSize: 11,
+	},
+});
+
+export const Default = meta.story({
+	args: {
+		status: "Addition",
+		fontSize: 10,
+	},
+});
+
+export const AllStatuses = meta.story({
+	args: {
+		status: "Addition",
+		fontSize: 11,
+	},
+	render: (args) => (
+		<div style={{ display: "flex", gap: 16, alignItems: "center" }}>
+			{statuses.map((status) => (
+				<div
+					key={status}
+					style={{ display: "flex", flexDirection: "column", gap: 8, alignItems: "center" }}
+				>
+					<FileStatusBadge {...args} status={status} />
+					<span style={{ fontSize: 11, opacity: 0.5 }}>{status}</span>
+				</div>
+			))}
+		</div>
+	),
+});

--- a/apps/lite/ui/src/components/FileStatusBadge.tsx
+++ b/apps/lite/ui/src/components/FileStatusBadge.tsx
@@ -1,0 +1,32 @@
+import { classes } from "#ui/components/classes.ts";
+import type { TreeChange } from "@gitbutler/but-sdk";
+import { Match } from "effect";
+import type { ComponentProps, CSSProperties, FC } from "react";
+import styles from "./FileStatusBadge.module.css";
+
+/** @public */
+export type FileStatusType = TreeChange["status"]["type"];
+
+type Props = {
+	status: FileStatusType;
+	/** Font size in pixels. The badge's width follows it. */
+	fontSize?: number;
+} & ComponentProps<"span">;
+
+export const FileStatusBadge: FC<Props> = ({ status, fontSize = 11, ...props }) => (
+	<span
+		aria-label={status}
+		{...props}
+		className={classes(props.className, styles.badge)}
+		data-status-type={status}
+		style={{ fontSize: `${fontSize}px`, ...props.style } satisfies CSSProperties}
+	>
+		{Match.value(status).pipe(
+			Match.when("Addition", () => "A"),
+			Match.when("Deletion", () => "D"),
+			Match.when("Modification", () => "M"),
+			Match.when("Rename", () => "R"),
+			Match.exhaustive,
+		)}
+	</span>
+);

--- a/apps/lite/ui/src/components/Kbd.module.css
+++ b/apps/lite/ui/src/components/Kbd.module.css
@@ -26,6 +26,7 @@
 }
 
 .button .key {
+	min-width: 0;
 	padding: 0;
 	background-color: transparent;
 	box-shadow: none;

--- a/apps/lite/ui/src/routes/project/$id/workspace/ChangeStats.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/ChangeStats.module.css
@@ -6,17 +6,3 @@
 	flex-shrink: 0;
 	align-items: center;
 }
-
-.lineStats {
-	display: inline-flex;
-	align-items: center;
-	gap: 4px;
-}
-
-.linesAdded {
-	color: var(--text-safe);
-}
-
-.linesRemoved {
-	color: var(--text-danger);
-}

--- a/apps/lite/ui/src/routes/project/$id/workspace/ChangeStats.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/ChangeStats.tsx
@@ -1,5 +1,6 @@
 import { Badge } from "#ui/components/Badge.tsx";
 import { classes } from "#ui/components/classes.ts";
+import { DiffStats } from "#ui/components/DiffStats.tsx";
 import { TooltipPopup } from "#ui/components/Tooltip.tsx";
 import { Tooltip } from "@base-ui/react";
 import type { FC } from "react";
@@ -39,18 +40,13 @@ export const ChangeStats: FC<{
 			<Tooltip.Trigger
 				render={
 					<span aria-label={spoken.join(", ")} className={classes(styles.container, className)}>
-						<Badge variant="fillGray">{fileCount}</Badge>
+						<Badge variant="lightGray">{fileCount}</Badge>
 
-						{(lineStats.linesAdded > 0 || lineStats.linesRemoved > 0) && (
-							<span className={classes("text-12", styles.lineStats)}>
-								{lineStats.linesAdded > 0 && (
-									<span className={styles.linesAdded}>+{lineStats.linesAdded}</span>
-								)}
-								{lineStats.linesRemoved > 0 && (
-									<span className={styles.linesRemoved}>-{lineStats.linesRemoved}</span>
-								)}
-							</span>
-						)}
+						<DiffStats
+							added={lineStats.linesAdded}
+							removed={lineStats.linesRemoved}
+							className="text-12"
+						/>
 					</span>
 				}
 			/>

--- a/apps/lite/ui/src/routes/project/$id/workspace/ChangeTypeBadge.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/ChangeTypeBadge.tsx
@@ -1,19 +1,21 @@
-import { Badge, type BadgeVariant } from "#ui/components/Badge.tsx";
+import { FileStatusBadge, type FileStatusType } from "#ui/components/FileStatusBadge.tsx";
 import type { CodeViewDiffItem } from "@pierre/diffs";
 import { Match } from "effect";
 import type { FC } from "react";
 
+/** Adapts the diff viewer's file type to the status the rest of the app speaks. */
 export const ChangeTypeBadge: FC<{ type: CodeViewDiffItem<unknown>["fileDiff"]["type"] }> = ({
 	type,
-}) => {
-	const [label, variant] = Match.value(type).pipe(
-		Match.withReturnType<[string, BadgeVariant]>(),
-		Match.when("new", () => ["Added", "safe"]),
-		Match.whenOr("change", "rename-changed", () => ["Modified", "blue"]),
-		Match.when("rename-pure", () => ["Renamed", "purple"]),
-		Match.when("deleted", () => ["Deleted", "danger"]),
-		Match.exhaustive,
-	);
-
-	return <Badge variant={variant}>{label}</Badge>;
-};
+}) => (
+	<FileStatusBadge
+		fontSize={12}
+		status={Match.value(type).pipe(
+			Match.withReturnType<FileStatusType>(),
+			Match.when("new", () => "Addition"),
+			Match.whenOr("change", "rename-changed", () => "Modification"),
+			Match.when("rename-pure", () => "Rename"),
+			Match.when("deleted", () => "Deletion"),
+			Match.exhaustive,
+		)}
+	/>
+);

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
@@ -255,7 +255,7 @@
 
 .fileHeader {
 	display: grid;
-	grid-template-columns: auto 1fr auto auto auto auto;
+	grid-template-columns: auto 1fr auto auto auto;
 	column-gap: 12px;
 	align-items: center;
 	justify-content: space-between;
@@ -277,8 +277,7 @@
 	&::before {
 		position: absolute;
 		width: 3px;
-		inset: 4px auto 4px 0;
-		border-radius: 0 2px 2px 0;
+		inset: 0 auto 0 0;
 		/* The row-selection fill, dimmed like row selections in a blurred
 		   panel; full strength while the diff pane owns focus. */
 		background-color: color-mix(var(--fill-gray-bg) var(--opacity-bg-selected-blur), transparent);
@@ -294,6 +293,12 @@
 
 .fileHeaderActions {
 	display: flex;
+}
+
+.fileMeta {
+	display: flex;
+	align-items: center;
+	gap: 6px;
 }
 
 .fileReview {
@@ -359,6 +364,12 @@
 	min-height: 28px;
 	gap: 8px;
 	color: var(--text-3);
+}
+
+/* The toggle leads the meta row, so it keeps the row's own rhythm but sits a
+   touch further from the author than the meta items sit from each other. */
+.commitDetailsMetaTabs {
+	margin-inline-end: 4px;
 }
 
 .commitDetailsMetaSha {

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
@@ -268,9 +268,9 @@
 	}
 }
 
-/* A folded file's header stands in for its hidden, selected hunks. A plain
-   accent bar marks it for now; positioned absolutely so the layout is
-   untouched. */
+/* Marks the file holding the diff selection — including a folded one, whose
+   header stands in for its hidden hunks. A plain accent bar for now;
+   positioned absolutely so the layout is untouched. */
 .fileHeaderSelected {
 	position: relative;
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
@@ -327,14 +327,6 @@
 	text-overflow: ellipsis;
 }
 
-.fileDiffAdded {
-	color: var(--text-safe);
-}
-
-.fileDiffDeleted {
-	color: #d34832;
-}
-
 .pathInit {
 	color: var(--text-2);
 }

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -1737,10 +1737,12 @@ const DiffFileHeader: FC<DiffFileHeaderProps> = (p) => {
 					</span>
 					{reviewLabel}
 				</button>
-				<ChangeTypeBadge type={p.item.fileDiff.type} />
-				{p.lineStats && (
-					<DiffStats added={p.lineStats.linesAdded} removed={p.lineStats.linesRemoved} />
-				)}
+				<div className={styles.fileMeta}>
+					<ChangeTypeBadge type={p.item.fileDiff.type} />
+					{p.lineStats && (
+						<DiffStats added={p.lineStats.linesAdded} removed={p.lineStats.linesRemoved} />
+					)}
+				</div>
 
 				<Toolbar.Root aria-label="File actions" className={styles.fileHeaderActions}>
 					<Toolbar.Button
@@ -2645,6 +2647,13 @@ const CommitDetails: FC<{
 					</p>
 				)}
 				<div className={classes("text-13", styles.commitDetailsMeta)}>
+					{review && (
+						<BranchTabToggle
+							branchTab={tab}
+							setBranchTab={setTab}
+							className={styles.commitDetailsMetaTabs}
+						/>
+					)}
 					<img
 						src={commitDetails.commit.author.gravatarUrl}
 						className={styles.avatar}
@@ -2669,12 +2678,6 @@ const CommitDetails: FC<{
 						copyValue={commitDetails.commit.id}
 					/>
 				</div>
-
-				{review && (
-					<div className={styles.tabsRow}>
-						<BranchTabToggle branchTab={tab} setBranchTab={setTab} />
-					</div>
-				)}
 			</div>
 
 			{review && tab === "pr" ? (
@@ -2790,9 +2793,10 @@ const BranchTabToggle: FC<{
 	branchTab: BranchTab;
 	setBranchTab: (tab: BranchTab) => void;
 	prDisabled?: boolean;
-}> = ({ branchTab, setBranchTab, prDisabled = false }) => (
+	className?: string;
+}> = ({ branchTab, setBranchTab, prDisabled = false, className }) => (
 	<ToggleGroup
-		render={<ToggleGroupStyles />}
+		render={<ToggleGroupStyles className={className} />}
 		value={[branchTab]}
 		onValueChange={(value: Array<BranchTab>) => {
 			const head = value[0];

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -128,6 +128,7 @@ import {
 } from "#ui/focus-scopes.ts";
 import { buildIndexByKey, getAdjacent } from "#ui/workspace/address-space.ts";
 import { ChangeStats } from "#ui/routes/project/$id/workspace/ChangeStats.tsx";
+import { DiffStats } from "#ui/components/DiffStats.tsx";
 import { ChangesHeaderRow } from "#ui/routes/project/$id/workspace/ChangesHeaderRow.tsx";
 import {
 	getLineStats,
@@ -1737,15 +1738,8 @@ const DiffFileHeader: FC<DiffFileHeaderProps> = (p) => {
 					{reviewLabel}
 				</button>
 				<ChangeTypeBadge type={p.item.fileDiff.type} />
-				{p.lineStats && (p.lineStats.linesAdded > 0 || p.lineStats.linesRemoved > 0) && (
-					<span>
-						{p.lineStats.linesAdded > 0 && (
-							<span className={styles.fileDiffAdded}>+{p.lineStats.linesAdded}</span>
-						)}{" "}
-						{p.lineStats.linesRemoved > 0 && (
-							<span className={styles.fileDiffDeleted}>-{p.lineStats.linesRemoved}</span>
-						)}
-					</span>
+				{p.lineStats && (
+					<DiffStats added={p.lineStats.linesAdded} removed={p.lineStats.linesRemoved} />
 				)}
 
 				<Toolbar.Root aria-label="File actions" className={styles.fileHeaderActions}>

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -522,12 +522,15 @@ const DiffContents: FC<{
 	}, [selectedLines]);
 	const selectedLinesHunk = storedSelectionHunk ?? diffSelection;
 	const effectiveDiffStyle = diffStyle ?? defaultSettings.diffStyle;
-	// A primitive, null while the selection sits on a visible hunk, so the item
-	// list and header closures below only pick up new identities when a folded
-	// file gains or loses the selection — not on every j/k move.
+	// Primitives, so the item list and header closures below only pick up new
+	// identities when the selection crosses into another file — not on every
+	// j/k move within one.
+	const selectedFileItemId = diffSelectionHunk?.file.item.id ?? null;
+	// Null while the selection sits on a visible hunk: only a folded file needs
+	// its stand-in hunk rebuilt when it gains or loses the selection.
 	const selectedFoldedFileId =
-		diffSelectionHunk != null && collapsedItems.has(diffSelectionHunk.file.item.id)
-			? diffSelectionHunk.file.item.id
+		selectedFileItemId != null && collapsedItems.has(selectedFileItemId)
+			? selectedFileItemId
 			: null;
 
 	useLayoutEffect(() => {
@@ -1479,7 +1482,7 @@ const DiffContents: FC<{
 							collapsed={item.collapsed ?? false}
 							reviewState={reviewState}
 							lineStats={patchLineStats(file.patch)}
-							selected={item.id === selectedFoldedFileId}
+							selected={item.id === selectedFileItemId}
 							setCollapsed={handleSetCollapsed(item.id)}
 							setReviewed={handleSetReviewed(item.id, file.change.path, version)}
 							canUncommit={canUncommit}
@@ -1645,7 +1648,7 @@ type DiffFileHeaderProps = {
 	reviewState: "reviewed" | "changed" | null;
 	/** The change's counted deltas, or `null` when there is no patch to count. */
 	lineStats: LineStats | null;
-	/** Whether the folded file's stand-in hunk holds the diff selection. */
+	/** Whether the diff selection sits in this file. */
 	selected: boolean;
 	setCollapsed: (collapsed: boolean) => void;
 	setReviewed: (reviewed: boolean) => void;

--- a/apps/lite/ui/src/routes/project/$id/workspace/FileRow.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/FileRow.module.css
@@ -7,32 +7,6 @@
 	margin-inline-end: 0;
 }
 
-.statusBadge {
-	flex-shrink: 0;
-	align-self: center;
-	width: 12px;
-	font-weight: 700;
-	font-size: 11px;
-	font-family: var(--text-fontfamily-base);
-	text-align: right;
-
-	&[data-status-type="Addition"] {
-		color: var(--change-status-addition);
-	}
-
-	&[data-status-type="Deletion"] {
-		color: var(--change-status-deletion);
-	}
-
-	&[data-status-type="Modification"] {
-		color: var(--change-status-modification);
-	}
-
-	&[data-status-type="Rename"] {
-		color: var(--change-status-rename);
-	}
-}
-
 .conflictIcon {
 	flex-shrink: 0;
 	margin-right: 2px;

--- a/apps/lite/ui/src/routes/project/$id/workspace/FileRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/FileRow.tsx
@@ -1,5 +1,6 @@
 import { ConflictIcon } from "#ui/components/ConflictIcon.tsx";
 import { FileIcon } from "#ui/components/FileIcon.tsx";
+import { FileStatusBadge } from "#ui/components/FileStatusBadge.tsx";
 import rowStyles from "./Row.module.css";
 import { showNativeContextMenu, showNativeMenuFromTrigger } from "#ui/native-menu.ts";
 import type { FileParent } from "#ui/addresses.ts";
@@ -10,7 +11,6 @@ import { Icon } from "#ui/components/Icon.tsx";
 import { classes } from "#ui/components/classes.ts";
 import { changesFileHotkeys } from "#ui/hotkeys.ts";
 import { Toolbar, Tooltip } from "@base-ui/react";
-import { Match } from "effect";
 import type { ComponentProps, CSSProperties, FC } from "react";
 import styles from "./FileRow.module.css";
 import treeStyles from "./FilesTree.module.css";
@@ -250,21 +250,10 @@ export const FileRowPresentational: FC<FileRowPresentationalProps> = ({
 				<Tooltip.Trigger
 					handle={tooltipHandle}
 					payload={{ content: item.change.status.type }}
-					className={styles.statusBadge}
-					aria-label={item.change.status.type}
-					data-status-type={item.change.status.type}
 					// By default it's a button, but we don't want this to be
 					// interactive.
-					render={<span />}
-				>
-					{Match.value(item.change.status).pipe(
-						Match.when({ type: "Addition" }, () => "A"),
-						Match.when({ type: "Deletion" }, () => "D"),
-						Match.when({ type: "Modification" }, () => "M"),
-						Match.when({ type: "Rename" }, () => "R"),
-						Match.exhaustive,
-					)}
-				</Tooltip.Trigger>
+					render={<FileStatusBadge status={item.change.status.type} />}
+				/>
 			)}
 		</Row>
 	);


### PR DESCRIPTION
Assorted Lite UI refactors, extracting repeated markup into shared components.

- Extract the file status badge into `FileStatusBadge` (with stories), used by `ChangeTypeBadge`, `Details`, and `FileRow`
- Add a `pop` badge variant
- Extract the diff line counts into a `DiffStats` component (with stories), used by `ChangeStats` and `Details`
- Allow `Kbd` key buttons to shrink
- Tighten the details header layout

---

## Screenshots

### New components

<img width="1349" height="470" alt="FileStatusBadge and DiffStats stories" src="https://github.com/user-attachments/assets/bd80d780-ce2d-4263-8062-ae36c75021e8" />

<img width="431" height="237" alt="Details header" src="https://github.com/user-attachments/assets/d069a1cf-c2ca-40b8-a331-786a469c9054" />

### Minified status icon

| Before | After |
| --- | --- |
| <img alt="Status icon before" src="https://github.com/user-attachments/assets/1bd4e115-9996-47f7-9170-6936924b18c9" /> | <img alt="Status icon after" src="https://github.com/user-attachments/assets/572a7e5a-0cdb-4760-98f1-2d7b7e482246" /> |

### Lighter files count badge

| Before | After |
| --- | --- |
| <img alt="Files count badge before" src="https://github.com/user-attachments/assets/e0fd339a-d8b6-4ce0-a1e0-2fed6650cbdb" /> | <img alt="Files count badge after" src="https://github.com/user-attachments/assets/fce152d4-e3f1-4634-b1dc-f7b17b595941" /> |
