### PR TITLE
Fix branch move checkout in single-branch mode

### DIFF
--- a/crates/but/src/command/legacy/move.rs
+++ b/crates/but/src/command/legacy/move.rs
@@ -918,12 +918,31 @@ fn resolve_sources(
     }
 }
 
+/// Branch moves bypass `but-transaction`, which cannot persist the branch order or check out the
+/// new tip returned by single-branch moves, and use the checkout-aware `but-api` path instead.
 pub fn run(
     ctx: &mut Context,
     meta: &mut impl RefMetadata,
     perm: &mut RepoExclusive,
     move_op: MoveOperation,
 ) -> anyhow::Result<(MoveOutcome, WorkspaceState)> {
+    if let MoveOperation::StackBranch(op) = &move_op {
+        let result = but_api::branch::move_branch_with_perm(
+            ctx,
+            op.source_branch.as_ref(),
+            op.target_branch.as_ref(),
+            DryRun::No,
+            perm,
+        )?;
+        return Ok((
+            MoveOutcome::StackBranch {
+                source_branch: op.source_branch.clone(),
+                target_branch: op.target_branch.clone(),
+            },
+            result.workspace,
+        ));
+    }
+
     let snapshot_details = match &move_op {
         MoveOperation::CommitsRelativeTo(_) | MoveOperation::CommitsToNewBranch(_) => {
             SnapshotDetails::new(OperationKind::MoveCommit)

--- a/crates/but/tests/but/command/move.rs
+++ b/crates/but/tests/but/command/move.rs
@@ -1780,6 +1780,475 @@ Hint: run `but help` for all commands
 "#]]);
 }
 
+fn assert_status(env: &Sandbox, expected: impl snapbox::IntoData) {
+    env.but("status").assert().success().stdout_eq(expected);
+}
+
+fn assert_head(env: &Sandbox, expected: &str) {
+    assert_eq!(
+        env.invoke_git("symbolic-ref --short HEAD"),
+        expected,
+        "HEAD should point to the top projected branch"
+    );
+}
+
+#[test]
+fn move_empty_branch_above_checked_out_branch_checks_it_out() {
+    let env = Sandbox::open_with_default_settings("single-branch-mode");
+    env.but("branch new top").assert().success();
+    env.but("branch new moved --below top").assert().success();
+    assert_status(
+        &env,
+        snapbox::str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ to [top] (no commits)
+┊│
+┊├┄ mo [moved] (no commits)
+├╯
+┊
+┴ b1540e5 (common base) 2000-01-02 M
+
+Hint: run `but help` for all commands
+
+"#]],
+    );
+
+    env.but("move moved --above top").assert().success();
+
+    assert_status(
+        &env,
+        snapbox::str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ mo [moved] (no commits)
+┊│
+┊├┄ to [top] (no commits)
+├╯
+┊
+┴ b1540e5 (common base) 2000-01-02 M
+
+Hint: run `but help` for all commands
+
+"#]],
+    );
+    assert_head(&env, "moved");
+}
+
+#[test]
+fn move_empty_branch_below_the_tip_preserves_checkout() {
+    let env = Sandbox::open_with_default_settings("single-branch-mode");
+    env.but("branch new empty-low").assert().success();
+    env.but("branch new empty-mid --above empty-low")
+        .assert()
+        .success();
+    env.but("branch new empty-top --above empty-mid")
+        .assert()
+        .success();
+    assert_status(
+        &env,
+        snapbox::str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ em [empty-top] (no commits)
+┊│
+┊├┄ mp [empty-mid] (no commits)
+┊│
+┊├┄ pt [empty-low] (no commits)
+├╯
+┊
+┴ b1540e5 (common base) 2000-01-02 M
+
+Hint: run `but help` for all commands
+
+"#]],
+    );
+
+    env.but("move empty-low --above empty-mid")
+        .assert()
+        .success();
+
+    assert_status(
+        &env,
+        snapbox::str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ em [empty-top] (no commits)
+┊│
+┊├┄ mp [empty-low] (no commits)
+┊│
+┊├┄ pt [empty-mid] (no commits)
+├╯
+┊
+┴ b1540e5 (common base) 2000-01-02 M
+
+Hint: run `but help` for all commands
+
+"#]],
+    );
+    assert_head(&env, "empty-top");
+}
+
+#[test]
+fn move_commit_branch_above_empty_dependents_keeps_them_empty() {
+    let env = Sandbox::open_with_default_settings("single-branch-mode");
+    env.but("branch new commit-branch").assert().success();
+    env.file("commit-branch", "content");
+    env.but("commit -b commit-branch -m 'commit branch'")
+        .assert()
+        .success();
+    env.but("branch new empty-low --above commit-branch")
+        .assert()
+        .success();
+    env.but("branch new empty-top --above empty-low")
+        .assert()
+        .success();
+    assert_status(
+        &env,
+        snapbox::str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ em [empty-top] (no commits)
+┊│
+┊├┄ mp [empty-low] (no commits)
+┊│
+┊├┄ co [commit-branch]
+┊●   1 commit branch
+├╯
+┊
+┴ b1540e5 (common base) 2000-01-02 M
+
+Hint: run `but help` for all commands
+
+"#]],
+    );
+
+    env.but("move commit-branch --above empty-top")
+        .assert()
+        .success();
+
+    assert_status(
+        &env,
+        snapbox::str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ co [commit-branch]
+┊●   1 commit branch
+┊│
+┊├┄ em [empty-top] (no commits)
+┊│
+┊├┄ mp [empty-low] (no commits)
+├╯
+┊
+┴ b1540e5 (common base) 2000-01-02 M
+
+Hint: run `but help` for all commands
+
+"#]],
+    );
+    assert_head(&env, "commit-branch");
+    let main_tip = env.invoke_git("rev-parse main");
+    assert_eq!(
+        env.invoke_git("rev-parse empty-top"),
+        main_tip,
+        "the top empty branch should remain empty"
+    );
+    assert_eq!(
+        env.invoke_git("rev-parse empty-low"),
+        main_tip,
+        "the lower empty branch should remain empty"
+    );
+}
+
+#[test]
+fn move_middle_non_empty_branch_above_checked_out_branch() {
+    let env = Sandbox::open_with_default_settings("single-branch-three-dependent-branches");
+    assert_status(
+        &env,
+        snapbox::str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ g0 [C]
+┊●   vuw add C
+┊│
+┊├┄ h0 [B]
+┊●   myy add B
+┊│
+┊├┄ i0 [A]
+┊●   nmq add A
+├╯
+┊
+┴ 3712f84 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]],
+    );
+
+    env.but("move B --above C").assert().success();
+
+    assert_status(
+        &env,
+        snapbox::str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ g0 [B]
+┊●   myy add B
+┊│
+┊├┄ h0 [C]
+┊●   vuw add C
+┊│
+┊├┄ i0 [A]
+┊●   nmq add A
+├╯
+┊
+┴ 3712f84 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]],
+    );
+    assert_head(&env, "B");
+    assert_eq!(
+        env.invoke_git("log --format=%s origin/main..HEAD"),
+        "add B\nadd C\nadd A",
+        "moving B should preserve the rewritten commit order"
+    );
+}
+
+#[test]
+fn move_bottom_non_empty_branch_above_checked_out_branch() {
+    let env = Sandbox::open_with_default_settings("single-branch-three-dependent-branches");
+    assert_status(
+        &env,
+        snapbox::str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ g0 [C]
+┊●   vuw add C
+┊│
+┊├┄ h0 [B]
+┊●   myy add B
+┊│
+┊├┄ i0 [A]
+┊●   nmq add A
+├╯
+┊
+┴ 3712f84 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]],
+    );
+
+    env.but("move A --above C").assert().success();
+
+    assert_status(
+        &env,
+        snapbox::str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ g0 [A]
+┊●   nmq add A
+┊│
+┊├┄ h0 [C]
+┊●   vuw add C
+┊│
+┊├┄ i0 [B]
+┊●   myy add B
+├╯
+┊
+┴ 3712f84 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]],
+    );
+    assert_head(&env, "A");
+    assert_eq!(
+        env.invoke_git("log --format=%s origin/main..HEAD"),
+        "add A\nadd C\nadd B",
+        "moving A should preserve the rewritten commit order"
+    );
+}
+
+#[test]
+fn move_checked_out_branch_down_checks_out_new_tip() {
+    let env = Sandbox::open_with_default_settings("single-branch-three-dependent-branches");
+    assert_status(
+        &env,
+        snapbox::str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ g0 [C]
+┊●   vuw add C
+┊│
+┊├┄ h0 [B]
+┊●   myy add B
+┊│
+┊├┄ i0 [A]
+┊●   nmq add A
+├╯
+┊
+┴ 3712f84 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]],
+    );
+
+    env.but("move C --above A").assert().success();
+
+    assert_status(
+        &env,
+        snapbox::str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ g0 [B]
+┊●   myy add B
+┊│
+┊├┄ h0 [C]
+┊●   vuw add C
+┊│
+┊├┄ i0 [A]
+┊●   nmq add A
+├╯
+┊
+┴ 3712f84 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]],
+    );
+    assert_head(&env, "B");
+    assert_eq!(
+        env.invoke_git("log --format=%s origin/main..HEAD"),
+        "add B\nadd C\nadd A",
+        "moving C down should preserve the rewritten commit order"
+    );
+}
+
+#[test]
+fn move_empty_checked_out_branch_down_keeps_it_empty() {
+    let env = Sandbox::open_with_default_settings("single-branch-three-dependent-branches");
+    env.invoke_git("checkout B");
+    env.invoke_git("branch -D C");
+    env.but("branch new C --above B").assert().success();
+    let b_tip = env.invoke_git("rev-parse B");
+    let a_tip = env.invoke_git("rev-parse A");
+    assert_status(
+        &env,
+        snapbox::str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ g0 [C] (no commits)
+┊│
+┊├┄ h0 [B]
+┊●   myy add B
+┊│
+┊├┄ i0 [A]
+┊●   nmq add A
+├╯
+┊
+┴ 3712f84 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]],
+    );
+
+    env.but("move C --above A").assert().success();
+
+    assert_status(
+        &env,
+        snapbox::str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ g0 [B]
+┊●   myy add B
+┊│
+┊├┄ h0 [C] (no commits)
+┊│
+┊├┄ i0 [A]
+┊●   nmq add A
+├╯
+┊
+┴ 3712f84 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]],
+    );
+    assert_head(&env, "B");
+    assert_eq!(
+        env.invoke_git("rev-parse B"),
+        b_tip,
+        "B should keep its commit"
+    );
+    assert_eq!(
+        env.invoke_git("rev-parse C"),
+        a_tip,
+        "C should remain empty at its new position"
+    );
+}
+
+#[test]
+fn move_bottom_branch_above_checked_out_middle_leaves_hidden_tip_unchanged() {
+    let env = Sandbox::open_with_default_settings("single-branch-three-dependent-branches");
+    let hidden_tip = env.invoke_git("rev-parse C");
+    env.invoke_git("checkout B");
+    assert_status(
+        &env,
+        snapbox::str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ g0 [B]
+┊●   myy add B
+┊│
+┊├┄ h0 [A]
+┊●   nmq add A
+├╯
+┊
+┴ 3712f84 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]],
+    );
+
+    env.but("move A --above B").assert().success();
+
+    assert_status(
+        &env,
+        snapbox::str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ g0 [A]
+┊●   nmq add A
+┊│
+┊├┄ h0 [B]
+┊●   myy add B
+├╯
+┊
+┴ 3712f84 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]],
+    );
+    assert_head(&env, "A");
+    assert_eq!(
+        env.invoke_git("rev-parse C"),
+        hidden_tip,
+        "the branch hidden above the old checkout should remain unchanged"
+    );
+    assert_eq!(
+        env.invoke_git("log --format=%s origin/main..HEAD"),
+        "add A\nadd B",
+        "only the projected stack should be rewritten"
+    );
+}
+
 #[test]
 #[ignore = "We can't move branches below other branches right now :( https://linear.app/gitbutler/issue/GB-1735/support-all-permutations-of-moving-branches-and-commits"]
 fn move_branch_below_to_other_stack() {

--- a/crates/but/tests/fixtures/scenario/single-branch-three-dependent-branches.sh
+++ b/crates/but/tests/fixtures/scenario/single-branch-three-dependent-branches.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source "${BASH_SOURCE[0]%/*}/shared.sh"
+
+### General Description
+
+# An ad-hoc workspace with three dependent branches, each with one commit:
+# main <- A <- B <- C, with C checked out.
+git-init-frozen
+commit-file init
+
+git checkout main
+  commit-file M
+setup_target_to_match_main
+
+git checkout -b A
+  commit-file A
+git checkout -b B
+  commit-file B
+git checkout -b C
+  commit-file C


### PR DESCRIPTION
## Summary

- route branch moves through the checkout-aware API because transactions cannot persist ad-hoc branch order or apply the new tip checkout
- add CLI regression coverage matching the desktop single-branch move scenarios, with before/after `but status` snapshots
- add a reusable three-branch ad-hoc fixture

## Impact

Moving a branch to the top of a single-branch stack now checks out that branch and keeps the complete reordered stack projected.

fixes GB-1847