### PR TITLE
fix(but): clear error when an anonymous segment is used as a `branch new` target

### DIFF
--- a/crates/but/src/command/legacy/branch/new.rs
+++ b/crates/but/src/command/legacy/branch/new.rs
@@ -137,7 +137,7 @@ fn resolve_above_below_target(
     id_map: &IdMap,
     target: CliIdArg,
 ) -> CliResult<NewStackedBranchTarget> {
-    let target = target
+    let resolved = target
         .resolve_in_workspace(
             repo,
             id_map,
@@ -146,9 +146,16 @@ fn resolve_above_below_target(
         )?
         .into_branch_or_commit()?;
 
-    Ok(match target {
+    Ok(match resolved {
         BranchOrCommit::Commit(commit) => NewStackedBranchTarget::Commit(commit),
         BranchOrCommit::Branch(branch_arg) => {
+            if branch_arg.0.is_empty() {
+                return Err(bad_input(format!(
+                    "Cannot use '{target}' as a branch target because it is an anonymous stack segment"
+                ))
+                .hint("Run `but status` to find the segment's top commit, then run `but branch new <name> --above/--below <commit-id>` with that commit ID")
+                .into());
+            }
             NewStackedBranchTarget::Branch(branch_arg.resolve_local_branch_name()?)
         }
     })

--- a/crates/but/tests/but/command/branch/new.rs
+++ b/crates/but/tests/but/command/branch/new.rs
@@ -54,6 +54,24 @@ Hint: Run `but status` for applicable targets.
 }
 
 #[test]
+fn rejects_anonymous_segment_as_target() {
+    let env =
+        Sandbox::init_scenario_with_target_and_default_settings("one-stack-anonymous-segment");
+    env.setup_metadata(&["A"]);
+
+    env.but("branch new --above g0 new-branch")
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
+Error: Cannot use 'g0' as a branch target because it is an anonymous stack segment
+
+Hint: Run `but status` to find the segment's top commit, then run `but branch new <name> --above/--below <commit-id>` with that commit ID
+
+"#]])
+        .stdout_eq(str![]);
+}
+
+#[test]
 fn rejects_head() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
     env.setup_metadata(&["A"]);


### PR DESCRIPTION
## Summary

`but branch new <name> --above/--below <target>` crashed with a confusing
"Reference name cannot end with a slash" error when `<target>` was the label
of an anonymous stack segment (e.g. `g0`) — a segment that has no branch
reference. The label resolved to a branch with an empty name, and that empty
name was fed straight into `refs/heads/` ref construction, producing an
invalid, unhelpful error.

This returns a clear `bad_input` error with a hint instead, matching the
existing pattern already used for the same situation in `but unapply`.

Fixes #15596

## Changes

- `resolve_above_below_target` (`crates/but/src/command/legacy/branch/new.rs`)
  now detects an empty-named branch resolution (anonymous segment) and
  returns:
  ```
  Cannot use '<segment>' as a branch target because it is an anonymous stack segment

  Hint: Run `but status` to find the segment's top commit, then run `but branch new <name> --above/--below <commit-id>` with that commit ID
  ```
- Added a regression test using the existing `one-stack-anonymous-segment`
  fixture.

## Test plan

- [x] `cargo check -p but --all-targets`
- [x] `cargo test -p but branch::new::`
- [x] `cargo test -p but` (689 passed, 0 failed)