### PR TITLE
feat(but): accept anonymous segment labels for `branch new --above/--below`

### DIFF
--- a/crates/but/src/command/legacy/branch/new.rs
+++ b/crates/but/src/command/legacy/branch/new.rs
@@ -137,6 +137,10 @@ fn resolve_above_below_target(
     id_map: &IdMap,
     target: CliIdArg,
 ) -> CliResult<NewStackedBranchTarget> {
+    if let Some(commit) = id_map.anonymous_segment_top_commit(&target.0, repo)? {
+        return Ok(NewStackedBranchTarget::Commit(commit));
+    }
+
     let resolved = target
         .resolve_in_workspace(
             repo,

--- a/crates/but/src/command/legacy/branch/new.rs
+++ b/crates/but/src/command/legacy/branch/new.rs
@@ -137,7 +137,7 @@ fn resolve_above_below_target(
     id_map: &IdMap,
     target: CliIdArg,
 ) -> CliResult<NewStackedBranchTarget> {
-    let target = target
+    let resolved = target
         .resolve_in_workspace(
             repo,
             id_map,
@@ -146,9 +146,16 @@ fn resolve_above_below_target(
         )?
         .into_branch_or_commit()?;
 
-    Ok(match target {
+    Ok(match resolved {
         BranchOrCommit::Commit(commit) => NewStackedBranchTarget::Commit(commit),
         BranchOrCommit::Branch(branch_arg) => {
+            if branch_arg.0.is_empty() {
+                return Err(bad_input(format!(
+                    "Cannot use '{target}' as a branch target because it is an anonymous stack segment"
+                ))
+                .hint("Run `but status` to find the segment's top commit, then run `but branch new <name> --above/--below <commit-id>` with that commit ID")
+                .into());
+            }
             NewStackedBranchTarget::Branch(branch_arg.resolve_local_branch_name()?)
         }
     })

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -1644,6 +1644,37 @@ impl IdMap {
         self.stack_ids.get(&stack_id)
     }
 
+    /// If `element` names exactly one anonymous stack segment (a segment without a branch
+    /// reference, like `g0`), returns the top-most commit owned by that segment.
+    ///
+    /// Anonymous segments have no name to resolve into a ref, so callers that would otherwise
+    /// treat the segment as a branch can fall back to its top commit instead.
+    pub fn anonymous_segment_top_commit(
+        &self,
+        element: &str,
+        repo: &gix::Repository,
+    ) -> anyhow::Result<Option<CommitId>> {
+        let ids = self.parse_using_repo(element, repo)?;
+        let [CliId::Branch(branch)] = ids.as_slice() else {
+            return Ok(None);
+        };
+        if !branch.name.is_empty() {
+            return Ok(None);
+        }
+
+        Ok(self
+            .indexed_stacks
+            .borrow_owner()
+            .iter()
+            .flat_map(|stack| &stack.segments)
+            .find(|segment| segment.short_id == branch.id)
+            .and_then(|segment| segment.workspace_commits.first())
+            .map(|commit| CommitId {
+                commit_id: commit.commit_id(),
+                change_id: commit.change_id.as_ref().map(|id| id.change_id.clone()),
+            }))
+    }
+
     /// Every uncommitted file of `source`, as whole-file IDs.
     ///
     /// This is what a container selector expands to, so `but commit <worktree>`

--- a/crates/but/tests/but/command/branch/new.rs
+++ b/crates/but/tests/but/command/branch/new.rs
@@ -54,21 +54,21 @@ Hint: Run `but status` for applicable targets.
 }
 
 #[test]
-fn rejects_anonymous_segment_as_target() {
+fn accepts_anonymous_segment_as_target() {
     let env =
         Sandbox::init_scenario_with_target_and_default_settings("one-stack-anonymous-segment");
     env.setup_metadata(&["A"]);
 
+    // `g0` names the anonymous segment; it should resolve to that segment's top commit rather
+    // than fail trying to build a branch reference from its (empty) name.
     env.but("branch new --above g0 new-branch")
         .assert()
-        .failure()
-        .stderr_eq(str![[r#"
-Error: Cannot use 'g0' as a branch target because it is an anonymous stack segment
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+Created branch 'new-branch' above commit [..]
 
-Hint: Run `but status` to find the segment's top commit, then run `but branch new <name> --above/--below <commit-id>` with that commit ID
-
-"#]])
-        .stdout_eq(str![]);
+"#]]);
 }
 
 #[test]

--- a/crates/but/tests/but/command/branch/new.rs
+++ b/crates/but/tests/but/command/branch/new.rs
@@ -54,6 +54,24 @@ Hint: Run `but status` for applicable targets.
 }
 
 #[test]
+fn rejects_anonymous_segment_as_target() {
+    let env =
+        Sandbox::init_scenario_with_target_and_default_settings("one-stack-anonymous-segment");
+    env.setup_metadata(&["A"]);
+
+    env.but("branch new --above g0 new-branch")
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
+Error: Cannot use 'g0' as a branch target because it is an anonymous stack segment
+
+Hint: Run `but status` to find the segment's top commit, then run `but branch new <name> --above/--below <commit-id>` with that commit ID
+
+"#]])
+        .stdout_eq(str![]);
+}
+
+#[test]
 fn rejects_head() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
     env.setup_metadata(&["A"]);


### PR DESCRIPTION
feat(but): accept anonymous segment labels for `branch new --above/--below`

## Summary

Stacked on #15603 (clear error message for the same situation).

An anonymous stack segment (like `g0`) has no branch reference, so even with
the clearer error message from the previous PR, `but branch new --above/--below
g0` still couldn't be used directly — users had to run `but status`, find the
segment's top commit ID by hand, and pass that instead.

This resolves an anonymous segment label directly to its top commit, so it
can be used as a target the same way a branch or commit ID can.

Relates to #15596

## Changes

- Added `IdMap::anonymous_segment_top_commit` (`crates/but/src/id/mod.rs`),
  which resolves a CLI element to the top-most commit of the anonymous
  segment it names, if any.
- `resolve_above_below_target` (`crates/but/src/command/legacy/branch/new.rs`)
  tries this resolution first, before falling back to the normal
  branch/commit resolution (whose empty-name guard from the previous PR
  remains as a safety net for the theoretical case of an anonymous segment
  with no commits).
- Updated the regression test added in the previous PR to assert success
  instead of the old error.

## Test plan

- [x] `cargo check -p but --all-targets`
- [x] `cargo test -p but branch::new::`
- [x] `cargo test -p but` (689 passed, 0 failed)
