### PR TITLE
Tidy up CLI command context

### DIFF
--- a/crates/but/src/command/agent/mod.rs
+++ b/crates/but/src/command/agent/mod.rs
@@ -8,7 +8,7 @@ use nonempty::NonEmpty;
 
 use crate::{
     args::agent,
-    command::skill,
+    command::{CommandOutcome, skill},
     theme::{self, Paint},
     utils::{InputOutputChannel, OutputChannel, PromptLine, detect_agent},
 };
@@ -45,7 +45,7 @@ pub fn handle(
     current_dir: &Path,
     out: &mut OutputChannel,
     cmd: Option<agent::Subcommands>,
-) -> Result<()> {
+) -> Result<CommandOutcome> {
     match cmd {
         // Bare `but agent` runs the setup wizard, same as `but agent setup`.
         None => setup(current_dir, out, false),
@@ -53,11 +53,11 @@ pub fn handle(
     }
 }
 
-fn setup(current_dir: &Path, out: &mut OutputChannel, print_only: bool) -> Result<()> {
+fn setup(current_dir: &Path, out: &mut OutputChannel, print_only: bool) -> Result<CommandOutcome> {
     if print_only {
         let default_policy = render_managed_policy_block(&WizardAnswers::default());
         print_policy(out, &default_policy)?;
-        return Ok(());
+        return Ok(CommandOutcome::AgentSetupPrintOnly);
     }
 
     let repo = discover_repo(current_dir);
@@ -77,7 +77,10 @@ fn setup(current_dir: &Path, out: &mut OutputChannel, print_only: bool) -> Resul
 
     match plan {
         Some(plan) => apply_plan(out, current_dir, &plan),
-        None => print_cancelled(out),
+        None => {
+            print_cancelled(out)?;
+            Ok(CommandOutcome::AgentSetupCancelled)
+        }
     }
 }
 
@@ -710,7 +713,7 @@ fn write_policy_preview(writer: &mut impl fmt::Write, policy: &str) -> fmt::Resu
     Ok(())
 }
 
-fn apply_plan(out: &mut OutputChannel, current_dir: &Path, plan: &Plan) -> Result<()> {
+fn apply_plan(out: &mut OutputChannel, current_dir: &Path, plan: &Plan) -> Result<CommandOutcome> {
     // Run `but setup` first: it is the step most likely to fail (it needs a
     // discoverable repo + project registration) and aborts before any file is
     // written, keeping the intro's "nothing is written until you confirm"
@@ -730,6 +733,14 @@ fn apply_plan(out: &mut OutputChannel, current_dir: &Path, plan: &Plan) -> Resul
             .with_context(|| format!("Failed to update {}", write.path.display()))?;
     }
 
+    let outcome = CommandOutcome::AgentSetupCompleted {
+        manual_instructions_required: !plan.print_only_notes.is_empty(),
+    };
+    print_setup_complete(out)?;
+    Ok(outcome)
+}
+
+fn print_setup_complete(out: &mut OutputChannel) -> Result<()> {
     if let Some(writer) = out.for_human() {
         let t = theme::get();
         writeln!(writer)?;

--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -45,15 +45,17 @@ use crate::{
     },
 };
 
+#[derive(Debug, Clone)]
 #[must_use]
 pub struct CommitOutcome {
     pub new_commit: CommitId,
     pub branch_name: Option<BranchNameTarget>,
+    pub(crate) changed_path_count: usize,
 }
 
 /// `--json` should only include newly created things. So if the branch already existed it
 /// wont be included in the JSON output.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum BranchNameTarget {
     Existing(FullName),
     New(FullName),
@@ -69,6 +71,7 @@ impl CliOutputHuman for CommitOutcome {
         let Self {
             new_commit,
             branch_name,
+            changed_path_count: _,
         } = self;
 
         match branch_name {
@@ -106,6 +109,7 @@ impl CliOutput for CommitOutcome {
         let Self {
             new_commit,
             branch_name,
+            changed_path_count: _,
         } = self;
 
         let branch_name = match branch_name {
@@ -321,6 +325,7 @@ pub fn run(
 
         builder.into_diff_specs()
     };
+    let changed_path_count = changes.len();
     let rejection_target = commit_op.rejection_target();
     let snapshot_details = SnapshotDetails::new(OperationKind::CreateCommit);
     let ((new_commit, branch_name), ws) = but_transaction::with_transaction_with_perm(
@@ -357,17 +362,17 @@ pub fn run(
     )
     .map_err(|err| rejection::explain_after_rollback(ctx, perm, "commit", rejection_target, err))?;
 
-    if checkout_after_create && let Some(BranchNameTarget::New(branch_name)) = &branch_name {
+    let outcome = CommitOutcome {
+        new_commit,
+        branch_name,
+        changed_path_count,
+    };
+    if checkout_after_create && let Some(BranchNameTarget::New(branch_name)) = &outcome.branch_name
+    {
         but_api::branch::branch_checkout_with_perm(ctx, branch_name.clone(), perm)?;
     }
 
-    Ok((
-        CommitOutcome {
-            new_commit,
-            branch_name,
-        },
-        ws,
-    ))
+    Ok((outcome, ws))
 }
 
 /// Targeting modes for committing.

--- a/crates/but/src/command/legacy/status/tui/app/commit_mode.rs
+++ b/crates/but/src/command/legacy/status/tui/app/commit_mode.rs
@@ -554,6 +554,7 @@ where
         commit::CommitOutcome {
             new_commit,
             branch_name: _,
+            ..
         },
         _ws,
     ) = commit::run(

--- a/crates/but/src/command/mod.rs
+++ b/crates/but/src/command/mod.rs
@@ -20,3 +20,15 @@ pub mod push;
 pub mod skill;
 pub mod update;
 pub mod worktree;
+
+/// The durable result of a command, independent of rendering and transport.
+#[derive(Debug, Clone)]
+pub enum CommandOutcome {
+    AgentSetupPrintOnly,
+    AgentSetupCancelled,
+    AgentSetupCompleted {
+        manual_instructions_required: bool,
+    },
+    #[cfg(feature = "legacy")]
+    Commit(legacy::commit::CommitOutcome),
+}

--- a/crates/but/src/command/skill/mod.rs
+++ b/crates/but/src/command/skill/mod.rs
@@ -19,7 +19,7 @@ pub(crate) use freshness::{agent_skill_notice, agent_skill_update_notice};
 
 /// Error type for user-initiated cancellation
 #[derive(Debug, Clone, Copy)]
-pub struct UserCancelled;
+struct UserCancelled;
 
 impl std::fmt::Display for UserCancelled {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -383,7 +383,10 @@ pub fn handle(
             global,
             path,
             detect,
-        } => install_skill(ctx, out, global, path, detect),
+        } => match install_skill(ctx, out, global, path, detect) {
+            Err(error) if error.downcast_ref::<UserCancelled>().is_some() => Ok(()),
+            result => result,
+        },
         skill::Subcommands::Check {
             global,
             local,

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -524,6 +524,7 @@ fn print_and_exit_non_zero<T: std::fmt::Display>(err: T) -> ! {
 
 enum DispatchOutcome {
     Return,
+    ReturnWithOutcome(command::CommandOutcome),
     ExitWithoutDestructors(anyhow::Result<()>),
 }
 
@@ -601,6 +602,12 @@ async fn match_subcommand(
 
     match dispatch_subcommand(cmd, args, app_settings, &mut output).await {
         Ok(DispatchOutcome::Return) => Ok(()).emit_metrics(metrics_ctx),
+        Ok(DispatchOutcome::ReturnWithOutcome(outcome)) => {
+            if let Some(metrics_ctx) = metrics_ctx.as_mut() {
+                metrics_ctx.record_outcome(&outcome);
+            }
+            Ok(()).emit_metrics(metrics_ctx)
+        }
         Ok(DispatchOutcome::ExitWithoutDestructors(result)) => result
             .emit_metrics(metrics_ctx)
             .show_root_cause_error_then_exit_without_destructors(output),
@@ -625,11 +632,13 @@ async fn dispatch_subcommand(
             command_name,
             props,
         } => {
-            use args::metrics::CommandName;
             let props = utils::metrics::prepare_transport_props(&props)?;
             let mut event = utils::metrics::Event::new(command_name.into());
             props.update_event(&mut event);
-            if matches!(command_name, CommandName::Commit | CommandName::CommitEmpty) {
+            if matches!(
+                command_name,
+                args::metrics::CommandName::Commit | args::metrics::CommandName::CommitEmpty
+            ) {
                 utils::metrics::add_workspace_shape(&mut event, &args.current_dir);
             }
             utils::metrics::capture_event_blocking(&app_settings, event).await;
@@ -738,24 +747,13 @@ async fn dispatch_subcommand(
                     return Err(CliError::Internal(err));
                 }
             };
-            let result = command::skill::handle(ctx.as_mut(), out, cmd);
-
-            // Handle user cancellation gracefully (exit 0 instead of error)
-            if let Err(ref e) = result
-                && e.downcast_ref::<command::skill::UserCancelled>().is_some()
-            {
-                return Ok(DispatchOutcome::Return);
-            }
-
-            return result
+            return command::skill::handle(ctx.as_mut(), out, cmd)
                 .map(|()| DispatchOutcome::Return)
                 .map_err(CliError::from);
         }
         Subcommands::Agent(agent::Platform { cmd }) => {
-            let result = command::agent::handle(&args.current_dir, out, cmd);
-
-            return result
-                .map(|()| DispatchOutcome::Return)
+            return command::agent::handle(&args.current_dir, out, cmd)
+                .map(DispatchOutcome::ReturnWithOutcome)
                 .map_err(CliError::from);
         }
         Subcommands::Mcp(args::mcp::Platform { cmd }) => {
@@ -912,6 +910,8 @@ async fn dispatch_subcommand(
     // If `Some`, and if result is `Ok`, this is passed to
     // `run_status_after_if_requested()`.
     let mut status_after_data: Option<bool> = None;
+    #[cfg(feature = "legacy")]
+    let mut command_outcome = None;
     let ws: Option<WorkspaceState> = match cmd {
         Subcommands::Metrics { .. }
         | Subcommands::Gui { .. }
@@ -1236,7 +1236,9 @@ async fn dispatch_subcommand(
                 IntermediateChannel::new(out),
                 commit_args,
             )?;
+            let metrics_outcome = command::CommandOutcome::Commit(outcome.clone());
             out.print_cli_output(outcome)?;
+            command_outcome = Some(metrics_outcome);
             Some(ws)
         }
         #[cfg(feature = "legacy")]
@@ -1697,6 +1699,10 @@ async fn dispatch_subcommand(
         );
     }
 
+    #[cfg(feature = "legacy")]
+    if let Some(outcome) = command_outcome {
+        return Ok(DispatchOutcome::ReturnWithOutcome(outcome));
+    }
     Ok(DispatchOutcome::Return)
 }
 

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -4,6 +4,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use but_error::AnyhowContextExt;
 use but_settings::AppSettings;
 use clap::ValueEnum;
 use command_group::AsyncCommandGroup;
@@ -14,44 +15,12 @@ use serde::{Deserialize, Serialize};
 use crate::{
     CliError,
     args::{Subcommands, config, metrics::CommandName},
+    command::CommandOutcome,
     utils::{ResultMetricsExt, binary_path},
 };
 
-const ERROR_MESSAGE_MAX_CHARS: usize = 1024;
 const UNRECOGNIZED_SUBCOMMAND_MAX_CHARS: usize = 64;
 const INVALID_UNRECOGNIZED_SUBCOMMAND: &str = "<invalid>";
-
-pub(super) mod types {
-    use crate::args::metrics::CommandName;
-
-    /// All we need to emit metrics as part of a command invocation, in the background, as spun-off process.
-    pub struct OneshotMetricsContext {
-        pub(super) start: std::time::Instant,
-        pub command: CommandName,
-        pub(super) extra_props: Vec<(String, serde_json::Value)>,
-        pub(super) current_dir: std::path::PathBuf,
-    }
-}
-use types::OneshotMetricsContext;
-
-impl OneshotMetricsContext {
-    pub fn new(
-        cmd: CommandName,
-        extra_props: Vec<(String, serde_json::Value)>,
-        current_dir: PathBuf,
-    ) -> Self {
-        Self {
-            start: std::time::Instant::now(),
-            command: cmd,
-            extra_props,
-            current_dir,
-        }
-    }
-
-    pub(crate) fn push_extra_prop<T: Serialize>(&mut self, key: &str, value: T) {
-        push_prop(&mut self.extra_props, key, value);
-    }
-}
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, strum::Display)]
 #[serde(rename_all = "camelCase")]
@@ -247,10 +216,41 @@ impl Subcommands {
     /// `sourceKind` and `targetKind` describe the kind a command expects, not a
     /// resolved runtime ID.
     pub(crate) fn to_metrics_extra_props(&self) -> Vec<(String, serde_json::Value)> {
+        #[cfg(feature = "legacy")]
+        use crate::args::commit;
         use crate::args::skill;
 
         let mut props = Vec::new();
         match self {
+            #[cfg(feature = "legacy")]
+            Subcommands::Commit(commit::Platform {
+                branch,
+                empty,
+                above,
+                below,
+                interactive,
+                changes,
+                ..
+            }) => {
+                let target_mode = match (branch, above, below) {
+                    (Some(Some(_)), None, None) => "namedBranch",
+                    (Some(None), None, None) => "generatedBranch",
+                    (None, Some(_), None) => "above",
+                    (None, None, Some(_)) => "below",
+                    _ => "default",
+                };
+                let selection_mode = if !changes.is_empty() {
+                    "explicitChanges"
+                } else if *interactive {
+                    "interactive"
+                } else if *empty {
+                    "empty"
+                } else {
+                    "allChanges"
+                };
+                push_prop(&mut props, "targetMode", target_mode);
+                push_prop(&mut props, "selectionMode", selection_mode);
+            }
             #[cfg(feature = "legacy")]
             Subcommands::Uncommit(..) => {
                 push_prop(&mut props, "sourceKind", "commitOrCommittedFile");
@@ -270,12 +270,9 @@ impl Subcommands {
                 push_prop(&mut props, "sourceKind", "commitOrBranch");
                 push_prop(&mut props, "targetKind", "commitOrBranchOrUnassigned");
             }
-            Subcommands::Skill(skill::Platform { cmd }) => match cmd {
-                skill::Subcommands::Install { .. } => {}
-                skill::Subcommands::Check { update, .. } => {
-                    push_prop(&mut props, "skillCheckUpdate", *update);
-                }
-            },
+            Subcommands::Skill(skill::Platform {
+                cmd: skill::Subcommands::Check { update, .. },
+            }) => push_prop(&mut props, "skillCheckUpdate", *update),
             Subcommands::External(extra) => {
                 if let Some(command_name) = extra.first() {
                     push_prop(
@@ -297,6 +294,96 @@ fn push_prop<T: Serialize>(props: &mut Vec<(String, serde_json::Value)>, key: &s
     }
 }
 
+/// Everything needed to emit one CLI event after a command finishes.
+pub struct OneshotMetricsContext {
+    start: std::time::Instant,
+    pub command: CommandName,
+    extra_props: Vec<(String, serde_json::Value)>,
+    current_dir: PathBuf,
+}
+
+impl OneshotMetricsContext {
+    pub fn new(
+        cmd: CommandName,
+        extra_props: Vec<(String, serde_json::Value)>,
+        current_dir: PathBuf,
+    ) -> Self {
+        Self {
+            start: std::time::Instant::now(),
+            command: cmd,
+            extra_props,
+            current_dir,
+        }
+    }
+
+    pub(crate) fn push_extra_prop<T: Serialize>(&mut self, key: &str, value: T) {
+        push_prop(&mut self.extra_props, key, value);
+    }
+
+    pub(crate) fn record_outcome(&mut self, outcome: &CommandOutcome) {
+        self.extra_props.extend(command_outcome_props(outcome));
+    }
+}
+
+fn command_outcome_props(outcome: &CommandOutcome) -> Vec<(String, serde_json::Value)> {
+    let mut props = Vec::new();
+    match outcome {
+        CommandOutcome::AgentSetupPrintOnly => {
+            push_prop(&mut props, "agentSetupOutcome", "printOnly");
+        }
+        CommandOutcome::AgentSetupCancelled => {
+            push_prop(&mut props, "agentSetupOutcome", "cancelled");
+        }
+        CommandOutcome::AgentSetupCompleted {
+            manual_instructions_required,
+        } => {
+            push_prop(
+                &mut props,
+                "agentSetupOutcome",
+                if *manual_instructions_required {
+                    "completedWithManualStep"
+                } else {
+                    "completed"
+                },
+            );
+            push_prop(
+                &mut props,
+                "agentSetupManualInstructionsRequired",
+                *manual_instructions_required,
+            );
+        }
+        #[cfg(feature = "legacy")]
+        CommandOutcome::Commit(outcome) => {
+            use crate::command::legacy::commit::BranchNameTarget;
+
+            let target_kind = match &outcome.branch_name {
+                Some(BranchNameTarget::New(_)) => "newBranch",
+                Some(BranchNameTarget::Existing(_)) => "existingBranch",
+                None => "commit",
+            };
+            push_prop(&mut props, "stateChanged", true);
+            push_prop(&mut props, "createdBranch", target_kind == "newBranch");
+            push_prop(&mut props, "resolvedTargetKind", target_kind);
+            push_prop(
+                &mut props,
+                "changedPathCountBucket",
+                change_count_bucket(outcome.changed_path_count),
+            );
+        }
+    }
+    props
+}
+
+pub(crate) fn change_count_bucket(count: usize) -> &'static str {
+    match count {
+        0 => "0",
+        1 => "1",
+        2..=3 => "2to3",
+        4..=10 => "4to10",
+        _ => "11plus",
+    }
+}
+
 impl From<CommandName> for EventKind {
     fn from(command_name: CommandName) -> Self {
         EventKind::Cli(command_name)
@@ -314,11 +401,7 @@ impl Props {
         }
     }
 
-    fn from_anyhow_result<T>(
-        start: std::time::Instant,
-        result: &anyhow::Result<T>,
-        command: CommandName,
-    ) -> Props {
+    fn from_anyhow_result<T>(start: std::time::Instant, result: &anyhow::Result<T>) -> Props {
         let mut props = Props::new();
         props.insert("durationMs", start.elapsed().as_millis());
         let Some(error) = result.as_ref().err() else {
@@ -326,15 +409,11 @@ impl Props {
             return props;
         };
 
-        props.insert_internal_error_details(error, command);
+        props.insert_internal_error_details(error);
         props
     }
 
-    fn from_cli_error_result<T>(
-        start: std::time::Instant,
-        result: &Result<T, CliError>,
-        command: CommandName,
-    ) -> Props {
+    fn from_cli_error_result<T>(start: std::time::Instant, result: &Result<T, CliError>) -> Props {
         let mut props = Props::new();
         props.insert("durationMs", start.elapsed().as_millis());
         let Some(error) = result.as_ref().err() else {
@@ -368,7 +447,7 @@ impl Props {
                 props.insert("errorKind", "externalCommandFailed");
             }
             CliError::Internal(error) => {
-                props.insert_internal_error_details(error, command);
+                props.insert_internal_error_details(error);
             }
             CliError::Initialization(_) => {
                 props.insert("error", "Internal error");
@@ -390,22 +469,26 @@ impl Props {
         }
     }
 
-    fn insert_internal_error_details(&mut self, error: &anyhow::Error, command: CommandName) {
+    fn insert_internal_error_details(&mut self, error: &anyhow::Error) {
         #[cfg(feature = "legacy")]
-        if error.is::<crate::utils::rejection::ExplainedRejection>() {
+        let is_explained_rejection = error.is::<crate::utils::rejection::ExplainedRejection>();
+        #[cfg(not(feature = "legacy"))]
+        let is_explained_rejection = false;
+        if is_explained_rejection {
             self.insert("error", "Command rejection");
             self.insert("errorKind", "commandRejection");
-            return;
-        }
-
-        self.insert("error", "Internal error");
-        self.insert("errorKind", "internal");
-        if captures_detailed_error_message(command) {
-            self.insert("errorMessage", error_message(error));
-            self.insert(
-                "errorRoot",
-                error_message(error.root_cause()).trim().to_string(),
-            );
+            self.insert("errorCode", "changesRejected");
+            self.insert("retryable", false);
+            self.insert("stateChanged", false);
+        } else {
+            self.insert("error", "Internal error");
+            self.insert("errorKind", "internal");
+            let custom_context = error.custom_context();
+            if let Some(context) = custom_context
+                && context.code != but_error::Code::Unknown
+            {
+                self.insert("errorCode", context.code.to_string());
+            }
         }
     }
 
@@ -447,29 +530,6 @@ pub(crate) fn prepare_transport_props(json: &str) -> anyhow::Result<Props> {
     Ok(props)
 }
 
-fn error_message(error: &(impl std::fmt::Display + ?Sized)) -> String {
-    let error_message = format!("{error:#}");
-    let mut message = error_message.as_str();
-
-    if let Some((value, _)) = message.split_once("\nHint: ") {
-        message = value;
-    }
-    let message =
-        if let Some((value, _)) = message.split_once(". If you just performed a Git operation") {
-            format!("{value}.")
-        } else {
-            message.to_string()
-        };
-
-    let message = message
-        .lines()
-        .map(str::trim)
-        .filter(|line| !line.is_empty())
-        .collect::<Vec<_>>()
-        .join(" ");
-    truncate_error_message(message)
-}
-
 fn unrecognized_subcommand_metric_value(command_name: &std::ffi::OsStr) -> String {
     let command_name = command_name.to_string_lossy();
     let command_name = command_name.trim();
@@ -504,17 +564,6 @@ fn external_subcommand_metric_value(command_name: &std::ffi::OsStr) -> String {
         .chars()
         .take(UNRECOGNIZED_SUBCOMMAND_MAX_CHARS)
         .collect()
-}
-
-fn captures_detailed_error_message(command: CommandName) -> bool {
-    matches!(
-        command,
-        CommandName::Commit | CommandName::Uncommit | CommandName::Amend | CommandName::Squash
-    )
-}
-
-fn truncate_error_message(message: String) -> String {
-    message.chars().take(ERROR_MESSAGE_MAX_CHARS).collect()
 }
 
 /// Add lane and branch counts to `event`, read from the managed workspace at `current_dir`;
@@ -705,7 +754,7 @@ impl<T> ResultMetricsExt<T, anyhow::Error> for anyhow::Result<T> {
             return self;
         };
 
-        let mut props = Props::from_anyhow_result(start, &self, command);
+        let mut props = Props::from_anyhow_result(start, &self);
         props.extend(extra_props);
         emit_metrics(command, props, &current_dir, self.is_err());
         self
@@ -724,7 +773,7 @@ impl<T> ResultMetricsExt<T, CliError> for Result<T, CliError> {
             return self;
         };
 
-        let mut props = Props::from_cli_error_result(start, &self, command);
+        let mut props = Props::from_cli_error_result(start, &self);
         props.extend(extra_props);
         emit_metrics(command, props, &current_dir, self.is_err());
         self

--- a/crates/but/src/utils/metrics/tests.rs
+++ b/crates/but/src/utils/metrics/tests.rs
@@ -1,8 +1,12 @@
 use super::*;
+
 use crate::{
     args::{Subcommands, agent, branch, config, update},
     bad_input,
 };
+
+#[cfg(feature = "legacy")]
+use crate::args::commit;
 
 use crate::args::atoms::CliIdArg;
 
@@ -17,211 +21,6 @@ fn assert_command(subcommand: Subcommands, expected: &str) {
         Event::new(EventKind::Cli(subcommand.to_metrics_command())).props["command"],
         serde_json::json!(expected)
     );
-}
-
-#[test]
-fn status_events_include_one_percent_sampling_rate() {
-    let props = sample_props(Props::new(), CommandName::Status, false, 0.005)
-        .expect("draw below the rate should capture");
-
-    assert_eq!(
-        props.values["samplingRate"],
-        serde_json::json!(0.01),
-        "status events should carry their effective sampling rate"
-    );
-}
-
-#[test]
-fn cli_command_sampling_policy_matches_expected_rates() {
-    let sampled_commands = CommandName::value_variants()
-        .iter()
-        .filter_map(|command| {
-            let rate = command.sample_rate();
-            (rate < 1.0).then(|| {
-                (
-                    command
-                        .to_possible_value()
-                        .expect("command names have clap values")
-                        .get_name()
-                        .to_owned(),
-                    rate,
-                )
-            })
-        })
-        .collect::<Vec<_>>();
-
-    assert_eq!(
-        sampled_commands,
-        vec![
-            ("status".into(), 0.01),
-            ("diff".into(), 0.05),
-            ("branch-list".into(), 0.10),
-            ("refresh-remote-data".into(), 0.05),
-        ],
-        "only the selected read-only commands should be sampled"
-    );
-}
-
-#[test]
-fn full_rate_cli_events_include_sampling_rate() {
-    let props = sample_props(Props::new(), CommandName::Commit, false, 1.0)
-        .expect("full-rate events should always capture");
-
-    assert_eq!(
-        props.values["samplingRate"],
-        serde_json::json!(1.0),
-        "full-rate events should record their rate"
-    );
-}
-
-#[test]
-fn command_rejections_bypass_sampling() {
-    let result = Err::<(), _>(CliError::CommandRejection);
-    let props =
-        Props::from_cli_error_result(std::time::Instant::now(), &result, CommandName::Status);
-    let props = sample_props(props, CommandName::Status, result.is_err(), 1.0)
-        .expect("failed events should bypass sampling");
-
-    assert_eq!(
-        (&props.values["errorKind"], &props.values["samplingRate"]),
-        (
-            &serde_json::json!("commandRejection"),
-            &serde_json::json!(1.0)
-        ),
-        "typed failures should use the full sampling rate"
-    );
-}
-
-#[test]
-fn successful_sampled_events_can_be_dropped() {
-    assert!(
-        sample_props(Props::new(), CommandName::Status, false, 0.5).is_none(),
-        "successful status events above the rate should be dropped"
-    );
-}
-
-#[test]
-fn transport_rejects_malformed_or_invalid_rates() {
-    for json in [
-        "not-json",
-        r#"{"samplingRate":"invalid"}"#,
-        r#"{"samplingRate":0}"#,
-        r#"{"samplingRate":1.1}"#,
-    ] {
-        assert!(
-            prepare_transport_props(json).is_err(),
-            "invalid transport properties must not produce an event: {json}"
-        );
-    }
-}
-
-#[test]
-fn transport_keeps_a_valid_parent_rate_without_resampling() {
-    let props = prepare_transport_props(r#"{"samplingRate":0.01}"#)
-        .expect("a valid transport payload should parse");
-
-    assert_eq!(
-        props.values["samplingRate"],
-        serde_json::json!(0.01),
-        "the parent's effective rate must survive transport"
-    );
-}
-
-#[test]
-fn legacy_transport_events_without_a_rate_use_full_rate() {
-    let props = prepare_transport_props("{}").expect("empty properties are valid JSON");
-
-    assert_eq!(
-        props.values["samplingRate"],
-        serde_json::json!(1.0),
-        "legacy events were emitted at the full rate"
-    );
-}
-
-#[test]
-fn transport_failures_without_a_rate_are_kept() {
-    let props = prepare_transport_props(r#"{"error":"Internal error","errorKind":"internal"}"#)
-        .expect("failure properties are valid JSON");
-
-    assert_eq!(
-        props.values["samplingRate"],
-        serde_json::json!(1.0),
-        "transport failures should use the full sampling rate"
-    );
-}
-
-#[test]
-fn commands_with_their_own_event_lifecycle_do_not_create_cli_context() {
-    let mut settings = AppSettings::default();
-    settings.telemetry.app_metrics_enabled = true;
-
-    let commands = [
-        Subcommands::Completions { shell: None },
-        Subcommands::Mcp(crate::args::mcp::Platform {
-            cmd: crate::args::mcp::Subcommands::Serve,
-        }),
-        Subcommands::Metrics {
-            command_name: CommandName::Status,
-            props: "{}".into(),
-        },
-    ];
-
-    assert!(
-        commands.iter().all(|command| command
-            .to_metrics_context(&settings, Path::new("."))
-            .is_none()),
-        "commands that own or intentionally omit reporting should not get a CLI context"
-    );
-}
-
-#[test]
-fn workspace_shape_never_initializes_a_project() {
-    but_testsupport::isolated_app_data_dir(|| {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let repo_dir = tmp.path().join("repo");
-        gix::init(&repo_dir).expect("init plain repo");
-        let mut event = Event::new(EventKind::Cli(CommandName::Commit));
-
-        // A plain repository without GitButler state must stay untouched.
-        add_workspace_shape(&mut event, &repo_dir);
-        let data_dir = repo_dir.join(".git/gitbutler");
-        assert!(!data_dir.exists());
-        assert!(!event.props.contains_key("totalLanesInWorkspace"));
-
-        // Even with a project data dir present, the project database must not be created.
-        std::fs::create_dir(&data_dir).expect("create project data dir");
-        add_workspace_shape(&mut event, &repo_dir);
-        assert_eq!(
-            std::fs::read_dir(&data_dir).expect("read data dir").count(),
-            0
-        );
-        assert!(!event.props.contains_key("totalLanesInWorkspace"));
-    });
-}
-
-#[test]
-fn workspace_shape_counts_lanes_and_stacked_branches() {
-    but_testsupport::isolated_app_data_dir(|| {
-        let sandbox =
-            but_testsupport::Sandbox::open_or_init_scenario_with_target_and_default_settings(
-                "one-stack-three-dependent-branches",
-            );
-        let repo = sandbox.open_repo();
-        let workdir = repo.workdir().expect("scenario is not bare").to_owned();
-        // The shape is only read from repositories that already carry a project database.
-        but_db::DbHandle::new_in_directory(repo.git_dir().join("gitbutler"))
-            .expect("create project db");
-
-        let mut event = Event::new(EventKind::Cli(CommandName::Commit));
-        add_workspace_shape(&mut event, &workdir);
-
-        assert_eq!(event.props["totalLanesInWorkspace"], serde_json::json!(1));
-        assert_eq!(
-            event.props["totalBranchesInWorkspace"],
-            serde_json::json!(3)
-        );
-        assert_eq!(event.props["maxBranchesPerLane"], serde_json::json!(3));
-    });
 }
 
 #[test]
@@ -391,6 +190,81 @@ fn extra_props_keep_useful_source_and_target_kinds() {
     }
 }
 
+#[cfg(feature = "legacy")]
+#[test]
+fn commit_extra_props_describe_targeting_and_selection_without_ids() {
+    let cases = [
+        (
+            Some(Some("private-branch")),
+            None,
+            None,
+            false,
+            false,
+            0,
+            "namedBranch",
+            "allChanges",
+        ),
+        (
+            Some(None),
+            None,
+            None,
+            false,
+            true,
+            0,
+            "generatedBranch",
+            "empty",
+        ),
+        (
+            None,
+            Some("private-commit"),
+            None,
+            true,
+            false,
+            0,
+            "above",
+            "interactive",
+        ),
+        (
+            None,
+            None,
+            Some("private-commit"),
+            false,
+            false,
+            2,
+            "below",
+            "explicitChanges",
+        ),
+    ];
+
+    for (branch, above, below, interactive, empty, change_count, target, selection) in cases {
+        let command = Subcommands::Commit(commit::Platform {
+            message: Some(vec!["private message".into()]),
+            no_message: false,
+            branch: branch.map(|name| name.map(|name| CliIdArg(name.into()))),
+            above: above.map(|value| CliIdArg(value.into())),
+            below: below.map(|value| CliIdArg(value.into())),
+            empty,
+            interactive,
+            changes: (0..change_count)
+                .map(|index| CliIdArg(format!("private-change-{index}")))
+                .collect(),
+            allow_merged: Default::default(),
+        });
+        let props = command.to_metrics_extra_props();
+
+        assert_eq!(prop(&props, "targetMode"), Some(&serde_json::json!(target)));
+        assert_eq!(
+            prop(&props, "selectionMode"),
+            Some(&serde_json::json!(selection))
+        );
+        let json = serde_json::to_string(&props).expect("metric props serialize");
+        assert!(
+            !json.contains("private"),
+            "metric props must not contain user IDs"
+        );
+    }
+}
+
 #[test]
 fn external_extra_props_include_sanitized_subcommand() {
     let props = Subcommands::External(vec![" typo-OK ".into()]).to_metrics_extra_props();
@@ -413,30 +287,11 @@ fn external_extra_props_include_sanitized_subcommand() {
 }
 
 #[test]
-fn internal_error_details_are_allowlisted() {
-    let anyhow_result = Err::<(), _>(
-        anyhow::anyhow!("stale id. If you just performed a Git operation, refresh")
-            .context("Failed to uncommit."),
-    );
-
-    let props = Props::from_anyhow_result(
-        std::time::Instant::now(),
-        &anyhow_result,
-        CommandName::Uncommit,
-    );
-
-    assert_eq!(props.values["error"], "Internal error");
-    assert_eq!(props.values["errorKind"], "internal");
-    assert_eq!(
-        props.values["errorMessage"],
-        "Failed to uncommit.: stale id."
-    );
-    assert_eq!(props.values["errorRoot"], "stale id.");
-
-    let result =
-        Err::<(), _>(anyhow::anyhow!("private-branch-name failed").context("private-path failed"));
-
-    let props = Props::from_anyhow_result(std::time::Instant::now(), &result, CommandName::Status);
+fn internal_errors_omit_private_details() {
+    let result = Err::<(), _>(CliError::Internal(
+        anyhow::anyhow!("private-branch-name failed").context("private-path failed"),
+    ));
+    let props = Props::from_cli_error_result(std::time::Instant::now(), &result);
 
     assert_eq!(props.values["error"], "Internal error");
     assert_eq!(props.values["errorKind"], "internal");
@@ -447,27 +302,12 @@ fn internal_error_details_are_allowlisted() {
 }
 
 #[test]
-fn commit_internal_error_details_are_captured() {
-    let result = Err::<(), _>(CliError::Internal(
-        anyhow::anyhow!("stale id. If you just performed a Git operation, refresh")
-            .context("Failed to commit."),
-    ));
-
-    let props =
-        Props::from_cli_error_result(std::time::Instant::now(), &result, CommandName::Commit);
-
-    assert_eq!(props.values["errorMessage"], "Failed to commit.: stale id.");
-    assert_eq!(props.values["errorRoot"], "stale id.");
-}
-
-#[test]
 fn initialization_errors_use_distinct_kind_without_private_details() {
     let result = Err::<(), _>(CliError::Initialization(anyhow::anyhow!(
         "No git repository found at /Users/alice/secret-client"
     )));
 
-    let props =
-        Props::from_cli_error_result(std::time::Instant::now(), &result, CommandName::Commit);
+    let props = Props::from_cli_error_result(std::time::Instant::now(), &result);
 
     assert_eq!(props.values["errorKind"], "initialization");
     assert!(
@@ -485,15 +325,25 @@ fn explained_commit_rejections_omit_private_details() {
         ),
     )));
 
-    let props =
-        Props::from_cli_error_result(std::time::Instant::now(), &result, CommandName::Commit);
+    let props = Props::from_cli_error_result(std::time::Instant::now(), &result);
 
     assert_eq!(props.values["error"], "Command rejection");
     assert_eq!(props.values["errorKind"], "commandRejection");
+    assert_eq!(props.values["errorCode"], "changesRejected");
+    assert_eq!(props.values["retryable"], false);
+    assert_eq!(props.values["stateChanged"], false);
     assert!(!props.values.contains_key("errorMessage"));
     assert!(!props.values.contains_key("errorRoot"));
     assert!(!props.as_json_string().contains("private/path"));
     assert!(!props.as_json_string().contains("private-branch"));
+}
+
+#[test]
+fn command_failures_do_not_guess_mutation_outcomes() {
+    let result = Err::<(), _>(CliError::Internal(anyhow::anyhow!("private failure")));
+    let props = Props::from_cli_error_result(std::time::Instant::now(), &result);
+
+    assert!(!props.values.contains_key("agentSetupOutcome"));
 }
 
 #[test]
@@ -506,11 +356,7 @@ fn cli_error_metrics_use_low_cardinality_failure_details() {
             .into(),
     );
 
-    let props = Props::from_cli_error_result(
-        std::time::Instant::now(),
-        &bad_input_result,
-        CommandName::Commit,
-    );
+    let props = Props::from_cli_error_result(std::time::Instant::now(), &bad_input_result);
 
     assert_eq!(props.values["errorKind"], "badInput");
     assert_eq!(props.values["error"], "Bad input");
@@ -525,11 +371,7 @@ fn cli_error_metrics_use_low_cardinality_failure_details() {
     );
 
     let external_result = Err::<(), _>(CliError::ExternalCommandNotFound("typo".into()));
-    let props = Props::from_cli_error_result(
-        std::time::Instant::now(),
-        &external_result,
-        CommandName::External,
-    );
+    let props = Props::from_cli_error_result(std::time::Instant::now(), &external_result);
 
     assert_eq!(props.values["error"], "Unrecognized subcommand");
     assert_eq!(props.values["errorKind"], "externalCommandNotFound");
@@ -537,28 +379,16 @@ fn cli_error_metrics_use_low_cardinality_failure_details() {
     assert!(!props.values.contains_key("errorMessage"));
 
     let external_result = Err::<(), _>(CliError::ExternalCommandFailed(42));
-    let props = Props::from_cli_error_result(
-        std::time::Instant::now(),
-        &external_result,
-        CommandName::External,
-    );
+    let props = Props::from_cli_error_result(std::time::Instant::now(), &external_result);
     assert_eq!(props.values["error"], "External command failed");
     assert_eq!(props.values["errorKind"], "externalCommandFailed");
 
     let external_result = Err::<(), _>(CliError::ExternalCommandNotFound(" typo-123_OK ".into()));
-    let props = Props::from_cli_error_result(
-        std::time::Instant::now(),
-        &external_result,
-        CommandName::External,
-    );
+    let props = Props::from_cli_error_result(std::time::Instant::now(), &external_result);
     assert_eq!(props.values["unrecognizedSubcommand"], "typo-123_OK");
 
     let external_result = Err::<(), _>(CliError::ExternalCommandNotFound("/tmp/private".into()));
-    let props = Props::from_cli_error_result(
-        std::time::Instant::now(),
-        &external_result,
-        CommandName::External,
-    );
+    let props = Props::from_cli_error_result(std::time::Instant::now(), &external_result);
     assert_eq!(
         props.values["unrecognizedSubcommand"],
         INVALID_UNRECOGNIZED_SUBCOMMAND
@@ -567,11 +397,7 @@ fn cli_error_metrics_use_low_cardinality_failure_details() {
 
     let long_command = "a".repeat(UNRECOGNIZED_SUBCOMMAND_MAX_CHARS + 1);
     let external_result = Err::<(), _>(CliError::ExternalCommandNotFound(long_command.into()));
-    let props = Props::from_cli_error_result(
-        std::time::Instant::now(),
-        &external_result,
-        CommandName::External,
-    );
+    let props = Props::from_cli_error_result(std::time::Instant::now(), &external_result);
     assert_eq!(
         props.values["unrecognizedSubcommand"]
             .as_str()
@@ -582,36 +408,287 @@ fn cli_error_metrics_use_low_cardinality_failure_details() {
 }
 
 #[test]
-fn detailed_error_messages_are_normalized_and_capped() {
-    let multiline_result =
-        Err::<(), _>(anyhow::anyhow!("first line\nsecond line").context("Failed to uncommit."));
-
-    let props = Props::from_anyhow_result(
-        std::time::Instant::now(),
-        &multiline_result,
-        CommandName::Uncommit,
+fn change_count_buckets_are_low_cardinality() {
+    let values = [0, 1, 2, 3, 4, 10, 11, 100].map(change_count_bucket);
+    assert_eq!(
+        values,
+        [
+            "0", "1", "2to3", "2to3", "4to10", "4to10", "11plus", "11plus"
+        ]
     );
+}
+
+#[test]
+fn agent_setup_outcome_properties_are_centralized() {
+    use crate::command::CommandOutcome;
+
+    let mut ctx = OneshotMetricsContext::new(CommandName::AgentSetup, Vec::new(), ".".into());
+    ctx.record_outcome(&CommandOutcome::AgentSetupCompleted {
+        manual_instructions_required: true,
+    });
 
     assert_eq!(
-        props.values["errorMessage"],
-        "Failed to uncommit.: first line second line"
-    );
-    assert_eq!(props.values["errorRoot"], "first line second line");
-
-    let long_result = Err::<(), _>(anyhow::anyhow!("{}", "a".repeat(1100)));
-
-    let props = Props::from_anyhow_result(
-        std::time::Instant::now(),
-        &long_result,
-        CommandName::Uncommit,
-    );
-
-    assert_eq!(
-        props.values["errorMessage"].as_str().unwrap().len(),
-        ERROR_MESSAGE_MAX_CHARS
+        prop(&ctx.extra_props, "agentSetupOutcome"),
+        Some(&serde_json::json!("completedWithManualStep"))
     );
     assert_eq!(
-        props.values["errorRoot"].as_str().unwrap().len(),
-        ERROR_MESSAGE_MAX_CHARS
+        prop(&ctx.extra_props, "agentSetupManualInstructionsRequired"),
+        Some(&serde_json::json!(true))
+    );
+
+    for (outcome, expected) in [
+        (CommandOutcome::AgentSetupPrintOnly, "printOnly"),
+        (CommandOutcome::AgentSetupCancelled, "cancelled"),
+    ] {
+        let mut ctx = OneshotMetricsContext::new(CommandName::AgentSetup, Vec::new(), ".".into());
+        ctx.record_outcome(&outcome);
+        assert_eq!(
+            prop(&ctx.extra_props, "agentSetupOutcome"),
+            Some(&serde_json::json!(expected))
+        );
+    }
+}
+
+#[cfg(feature = "legacy")]
+#[test]
+fn commit_outcome_properties_are_low_cardinality() {
+    use crate::{
+        command::legacy::commit::{BranchNameTarget, CommitOutcome},
+        id::CommitId,
+    };
+
+    let branch_name = gix::refs::FullName::try_from("refs/heads/private-branch").unwrap();
+    let outcome = CommitOutcome {
+        new_commit: CommitId {
+            commit_id: gix::ObjectId::null(gix::hash::Kind::Sha1),
+            change_id: None,
+        },
+        branch_name: Some(BranchNameTarget::New(branch_name)),
+        changed_path_count: 11,
+    };
+    let mut ctx = OneshotMetricsContext::new(CommandName::Commit, Vec::new(), ".".into());
+    ctx.record_outcome(&crate::command::CommandOutcome::Commit(outcome));
+
+    assert_eq!(
+        prop(&ctx.extra_props, "createdBranch"),
+        Some(&serde_json::json!(true))
+    );
+    assert_eq!(
+        prop(&ctx.extra_props, "resolvedTargetKind"),
+        Some(&serde_json::json!("newBranch"))
+    );
+    assert_eq!(
+        prop(&ctx.extra_props, "changedPathCountBucket"),
+        Some(&serde_json::json!("11plus"))
+    );
+    assert_eq!(
+        prop(&ctx.extra_props, "stateChanged"),
+        Some(&serde_json::json!(true))
+    );
+    let serialized = serde_json::to_string(&ctx.extra_props).unwrap();
+    assert!(!serialized.contains("private-branch"));
+    assert!(!serialized.contains("0000000000000000000000000000000000000000"));
+}
+
+#[test]
+fn workspace_shape_never_initializes_a_project() {
+    but_testsupport::isolated_app_data_dir(|| {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let repo_dir = tmp.path().join("repo");
+        gix::init(&repo_dir).expect("init plain repo");
+        let mut event = Event::new(EventKind::Cli(CommandName::Commit));
+
+        add_workspace_shape(&mut event, &repo_dir);
+        let data_dir = repo_dir.join(".git/gitbutler");
+        assert!(!data_dir.exists());
+        assert!(!event.props.contains_key("totalLanesInWorkspace"));
+
+        std::fs::create_dir(&data_dir).expect("create project data dir");
+        add_workspace_shape(&mut event, &repo_dir);
+        assert_eq!(
+            std::fs::read_dir(&data_dir).expect("read data dir").count(),
+            0
+        );
+        assert!(!event.props.contains_key("totalLanesInWorkspace"));
+    });
+}
+
+#[test]
+fn workspace_shape_counts_lanes_and_stacked_branches() {
+    but_testsupport::isolated_app_data_dir(|| {
+        let sandbox =
+            but_testsupport::Sandbox::open_or_init_scenario_with_target_and_default_settings(
+                "one-stack-three-dependent-branches",
+            );
+        let repo = sandbox.open_repo();
+        let workdir = repo.workdir().expect("scenario is not bare").to_owned();
+        but_db::DbHandle::new_in_directory(repo.git_dir().join("gitbutler"))
+            .expect("create project db");
+
+        let mut event = Event::new(EventKind::Cli(CommandName::Commit));
+        add_workspace_shape(&mut event, &workdir);
+
+        assert_eq!(event.props["totalLanesInWorkspace"], serde_json::json!(1));
+        assert_eq!(
+            event.props["totalBranchesInWorkspace"],
+            serde_json::json!(3)
+        );
+        assert_eq!(event.props["maxBranchesPerLane"], serde_json::json!(3));
+    });
+}
+
+#[test]
+fn status_events_include_one_percent_sampling_rate() {
+    let props = sample_props(Props::new(), CommandName::Status, false, 0.005)
+        .expect("draw below the rate should capture");
+
+    assert_eq!(
+        props.values["samplingRate"],
+        serde_json::json!(0.01),
+        "status events should carry their effective sampling rate"
+    );
+}
+
+#[test]
+fn cli_command_sampling_policy_matches_expected_rates() {
+    let sampled_commands = CommandName::value_variants()
+        .iter()
+        .filter_map(|command| {
+            let rate = command.sample_rate();
+            (rate < 1.0).then(|| {
+                (
+                    command
+                        .to_possible_value()
+                        .expect("command names have clap values")
+                        .get_name()
+                        .to_owned(),
+                    rate,
+                )
+            })
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        sampled_commands,
+        vec![
+            ("status".into(), 0.01),
+            ("diff".into(), 0.05),
+            ("branch-list".into(), 0.10),
+            ("refresh-remote-data".into(), 0.05),
+        ],
+        "only the selected read-only commands should be sampled"
+    );
+}
+
+#[test]
+fn full_rate_cli_events_include_sampling_rate() {
+    let props = sample_props(Props::new(), CommandName::Commit, false, 1.0)
+        .expect("full-rate events should always capture");
+
+    assert_eq!(
+        props.values["samplingRate"],
+        serde_json::json!(1.0),
+        "full-rate events should record their rate"
+    );
+}
+
+#[test]
+fn command_rejections_bypass_sampling() {
+    let result = Err::<(), _>(CliError::CommandRejection);
+    let props = Props::from_cli_error_result(std::time::Instant::now(), &result);
+    let props = sample_props(props, CommandName::Status, result.is_err(), 1.0)
+        .expect("failed events should bypass sampling");
+
+    assert_eq!(
+        (&props.values["errorKind"], &props.values["samplingRate"]),
+        (
+            &serde_json::json!("commandRejection"),
+            &serde_json::json!(1.0)
+        ),
+        "typed failures should use the full sampling rate"
+    );
+}
+
+#[test]
+fn successful_sampled_events_can_be_dropped() {
+    assert!(
+        sample_props(Props::new(), CommandName::Status, false, 0.5).is_none(),
+        "successful status events above the rate should be dropped"
+    );
+}
+
+#[test]
+fn transport_rejects_malformed_or_invalid_rates() {
+    for json in [
+        "not-json",
+        r#"{"samplingRate":"invalid"}"#,
+        r#"{"samplingRate":0}"#,
+        r#"{"samplingRate":1.1}"#,
+    ] {
+        assert!(
+            prepare_transport_props(json).is_err(),
+            "invalid transport properties must not produce an event: {json}"
+        );
+    }
+}
+
+#[test]
+fn transport_keeps_a_valid_parent_rate_without_resampling() {
+    let props = prepare_transport_props(r#"{"samplingRate":0.01}"#)
+        .expect("a valid transport payload should parse");
+
+    assert_eq!(
+        props.values["samplingRate"],
+        serde_json::json!(0.01),
+        "the parent's effective rate must survive transport"
+    );
+}
+
+#[test]
+fn legacy_transport_events_without_a_rate_use_full_rate() {
+    let props = prepare_transport_props("{}").expect("empty properties are valid JSON");
+
+    assert_eq!(
+        props.values["samplingRate"],
+        serde_json::json!(1.0),
+        "legacy events were emitted at the full rate"
+    );
+}
+
+#[test]
+fn transport_failures_without_a_rate_are_kept() {
+    let props = prepare_transport_props(r#"{"error":"Internal error","errorKind":"internal"}"#)
+        .expect("failure properties are valid JSON");
+
+    assert_eq!(
+        props.values["samplingRate"],
+        serde_json::json!(1.0),
+        "transport failures should use the full sampling rate"
+    );
+}
+
+#[test]
+fn commands_with_their_own_event_lifecycle_do_not_create_cli_context() {
+    let mut settings = AppSettings::default();
+    settings.telemetry.app_metrics_enabled = true;
+
+    let commands = [
+        Subcommands::Completions { shell: None },
+        Subcommands::Mcp(crate::args::mcp::Platform {
+            cmd: crate::args::mcp::Subcommands::Serve,
+        }),
+        Subcommands::Metrics {
+            command_name: CommandName::Status,
+            props: "{}".into(),
+        },
+    ];
+
+    assert!(
+        commands.iter().all(|command| {
+            command
+                .to_metrics_context(&settings, std::path::Path::new("."))
+                .is_none()
+        }),
+        "commands that own or intentionally omit reporting should not get a CLI context"
     );
 }

--- a/crates/but/src/utils/mod.rs
+++ b/crates/but/src/utils/mod.rs
@@ -19,7 +19,7 @@ mod debug_as_type;
 pub(crate) use debug_as_type::DebugAsType;
 
 pub mod metrics;
-pub use metrics::types::OneshotMetricsContext;
+pub use metrics::OneshotMetricsContext;
 
 use crate::id::CommitId;
 


### PR DESCRIPTION
Adds a bit more context around commit and agent setup results, cleans up error classification, and cuts down noise from common read-only commands.

The command path is unchanged, and skill install stays out of it.