### PR TITLE
Fix operation history crashing on every load

### DIFF
--- a/apps/desktop/src/components/history/SnapshotCard.svelte
+++ b/apps/desktop/src/components/history/SnapshotCard.svelte
@@ -195,7 +195,7 @@
 
 	const historyService = inject(HISTORY_SERVICE);
 	const snapshotDiff = $derived(
-		historyService.snapshotDiff({ projectId, snapshotId: entry.id, childId }),
+		historyService.snapshotDiff({ projectId, snapshotId: entry.commitId, childId }),
 	);
 </script>
 
@@ -234,7 +234,7 @@
 		<div class="snapshot-details">
 			<h4 class="snapshot-title text-13 text-body text-semibold">
 				<span>{operation.text}</span>
-				<span class="snapshot-sha text-12 text-body"> • {getShortSha(entry.id)}</span>
+				<span class="snapshot-sha text-12 text-body"> • {getShortSha(entry.commitId)}</span>
 			</h4>
 
 			{#if operation.commitMessage}
@@ -250,7 +250,7 @@
 				{#if files.length > 0 && !isRestoreSnapshot}
 					<FileListProvider
 						changes={files}
-						selectionId={{ type: "snapshot", snapshotId: entry.id }}
+						selectionId={{ type: "snapshot", snapshotId: entry.commitId }}
 						allowUnselect={false}
 					>
 						<SnapshotSection

--- a/apps/desktop/src/lib/history/history.ts
+++ b/apps/desktop/src/lib/history/history.ts
@@ -37,7 +37,7 @@ class SnapshotPager {
 		const data = await this.fetch();
 		if (data.length) {
 			this.snapshots.set(data);
-			this.cursor = data.at(-1)?.id;
+			this.cursor = data.at(-1)?.commitId;
 		}
 	}
 
@@ -51,7 +51,7 @@ class SnapshotPager {
 			this.isAllLoaded.set(true);
 		} else {
 			this.snapshots.update((snapshots) => [...snapshots, ...more]);
-			this.cursor = more.at(-1)?.id;
+			this.cursor = more.at(-1)?.commitId;
 		}
 	}
 

--- a/apps/desktop/src/lib/history/types.ts
+++ b/apps/desktop/src/lib/history/types.ts
@@ -60,7 +60,8 @@ export interface SnapshotDetails {
 }
 
 export interface Snapshot {
-	id: string;
+	/** Wire field is `commitId`; see `but_api::legacy::oplog::json::Snapshot`. */
+	commitId: string;
 	details?: SnapshotDetails;
 	/** Milliseconds since epoch. */
 	createdAt: number;

--- a/apps/desktop/src/routes/[projectId]/history/+page.svelte
+++ b/apps/desktop/src/routes/[projectId]/history/+page.svelte
@@ -56,7 +56,7 @@
 		if (snapshots.length === 0) return [];
 
 		const idToIndexMap = new Map<string, number>();
-		snapshots.forEach((snapshot, index) => idToIndexMap.set(snapshot.id, index));
+		snapshots.forEach((snapshot, index) => idToIndexMap.set(snapshot.commitId, index));
 
 		const ranges = snapshots.flatMap((snapshot, startIndex) => {
 			if (
@@ -75,7 +75,7 @@
 			return []; // flatMap ignores empty arrays
 		});
 
-		return ranges.map((snapshot) => snapshot.id);
+		return ranges.map((snapshot) => snapshot.commitId);
 	}
 
 	let scrollContainer: HTMLDivElement | undefined = $state();
@@ -111,7 +111,7 @@
 						onLastInView();
 					}}
 				>
-					{#each $snapshots as entry, idx (entry.id)}
+					{#each $snapshots as entry, idx (entry.commitId)}
 						{#if idx === 0 || createdOnDay(entry.createdAt) !== createdOnDay($snapshots[idx - 1]?.createdAt ?? 0)}
 							<div class="history-view__snapshots__date-header">
 								<h4 class="text-12 text-semibold">
@@ -124,12 +124,12 @@
 							<SnapshotCard
 								{projectId}
 								{entry}
-								childId={idx > 0 ? $snapshots[idx - 1]?.id : undefined}
-								isWithinRestore={withinRestoreItems.includes(entry.id)}
+								childId={idx > 0 ? $snapshots[idx - 1]?.commitId : undefined}
+								isWithinRestore={withinRestoreItems.includes(entry.commitId)}
 								restoring={restoration.current.isLoading}
 								onRestoreClick={async () => {
 									try {
-										await restore({ projectId, sha: entry.id });
+										await restore({ projectId, sha: entry.commitId });
 									} finally {
 										// In some cases, restoring the snapshot doesn't update the UI correctly
 										// Until we have that figured out, we need to reload the page.
@@ -137,7 +137,7 @@
 									}
 								}}
 								onDiffClick={() => {
-									currentSelectionId = createSnapshotSelection({ snapshotId: entry.id });
+									currentSelectionId = createSnapshotSelection({ snapshotId: entry.commitId });
 								}}
 							/>
 						{/if}


### PR DESCRIPTION
28a8593f5d replaced the oplog transport type while porting the list to Lite. The old gitbutler_oplog::entry::Snapshot carried #[serde(rename = "id")] on its commit_id; the new but_api::legacy::oplog::json::Snapshot does not, so the wire field became commitId. The desktop's hand-written Snapshot interface still read id, leaving every entry.id undefined.

The snapshot list is keyed by that id, so two undefined keys threw each_key_duplicate and replaced the whole history view with 'Something went wrong' as soon as a second snapshot existed.

Renames the desktop type and its uses to commitId, matching the DTO and the generated SDK that Lite already consumes.