### PR TITLE
Configure fallback committer when opening repositories

### DIFF
--- a/crates/but-ctx/src/lib.rs
+++ b/crates/but-ctx/src/lib.rs
@@ -17,6 +17,7 @@ use but_core::{
 use but_path::AppChannel;
 use but_settings::AppSettings;
 use but_utils::OnDemandCache;
+use gix::config::tree::Key as _;
 use tracing::instrument;
 
 /// Legacy types that shouldn't be used.
@@ -1057,10 +1058,17 @@ fn new_ondemand_repo(gitdir: PathBuf, repo_open_mode: RepoOpenMode) -> OnDemand<
 }
 
 fn open_repo(gitdir: &Path, repo_open_mode: RepoOpenMode) -> anyhow::Result<gix::Repository> {
-    match repo_open_mode {
-        RepoOpenMode::Standard => Ok(gix::open(gitdir)?),
-        RepoOpenMode::Isolated => Ok(gix::open_opts(gitdir, gix::open::Options::isolated())?),
+    let options = match repo_open_mode {
+        RepoOpenMode::Standard => gix::open::Options::default(),
+        RepoOpenMode::Isolated => gix::open::Options::isolated(),
     }
+    .config_overrides([
+        gix::config::tree::gitoxide::Committer::NAME_FALLBACK
+            .validated_assignment("GitButler".into())?,
+        gix::config::tree::gitoxide::Committer::EMAIL_FALLBACK
+            .validated_assignment("gitbutler@gitbutler.com".into())?,
+    ]);
+    Ok(gix::open_opts(gitdir, options)?)
 }
 
 #[instrument(level = "trace")]

--- a/crates/gitbutler-branch-actions/src/base.rs
+++ b/crates/gitbutler-branch-actions/src/base.rs
@@ -12,7 +12,7 @@ use but_error::{Code, bail_precondition};
 use but_graph::FirstParent;
 use gitbutler_project::{FetchResult, Project};
 use gitbutler_reference::{Refname, RemoteRefname};
-use gitbutler_repo::{SignaturePurpose, first_parent_commit_ids_until, signature_gix};
+use gitbutler_repo::first_parent_commit_ids_until;
 use serde::Serialize;
 use tracing::instrument;
 
@@ -246,10 +246,10 @@ pub(crate) fn set_base_branch(
 
             let stack_ref_name = if branch_matches_target {
                 let stack_ref_name = but_core::branch::unique_canned_refname(&repo)?;
-                create_internal_reference(
-                    &repo,
-                    stack_ref_name.clone(),
+                repo.reference(
+                    stack_ref_name.as_ref(),
                     current_head_commit,
+                    gix::refs::transaction::PreviousValue::MustNotExist,
                     "initialize stack",
                 )?;
                 stack_ref_name
@@ -268,10 +268,10 @@ pub(crate) fn set_base_branch(
             meta.set_workspace(&workspace)?;
             drop((workspace, meta));
             if !branch_matches_target {
-                create_internal_reference(
-                    &repo,
-                    WORKSPACE_REF_NAME.try_into()?,
+                repo.reference(
+                    WORKSPACE_REF_NAME,
                     current_head_commit,
+                    gix::refs::transaction::PreviousValue::MustNotExist,
                     "initialize workspace",
                 )?;
                 workspace_to_initialize = Some(ctx.workspace_from_ref_uncached(
@@ -291,41 +291,6 @@ pub(crate) fn set_base_branch(
     }
 
     get_base_branch_data(ctx, perm.read_permission())
-}
-
-fn create_internal_reference(
-    repo: &gix::Repository,
-    name: gix::refs::FullName,
-    target: gix::ObjectId,
-    message: &str,
-) -> Result<()> {
-    let configured_committer = repo.committer().transpose()?;
-    let fallback_committer;
-    let mut fallback_time = gix::date::parse::TimeBuf::default();
-    let committer = match configured_committer {
-        Some(committer) => committer,
-        None => {
-            fallback_committer = signature_gix(SignaturePurpose::Committer);
-            fallback_committer.to_ref(&mut fallback_time)
-        }
-    };
-    repo.edit_references_as(
-        [gix::refs::transaction::RefEdit {
-            change: gix::refs::transaction::Change::Update {
-                log: gix::refs::transaction::LogChange {
-                    mode: gix::refs::transaction::RefLog::AndReference,
-                    force_create_reflog: false,
-                    message: message.into(),
-                },
-                expected: gix::refs::transaction::PreviousValue::MustNotExist,
-                new: gix::refs::Target::Object(target),
-            },
-            name,
-            deref: false,
-        }],
-        Some(committer),
-    )?;
-    Ok(())
 }
 
 fn set_exclude_decoration(ctx: &Context) -> Result<()> {

--- a/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/set_base_branch.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/set_base_branch.rs
@@ -84,13 +84,19 @@ fn works_without_git_identity() {
             },
         )
         .unwrap();
-        let mut context_repo = ctx.repo.get_mut().unwrap();
-        context_repo.reload().unwrap();
-        assert!(
-            context_repo.committer().is_none(),
-            "the repository has no Git identity"
+        let fallback_committer_identity = {
+            let context_repo = ctx.repo.get().unwrap();
+            let committer = context_repo.committer().transpose().unwrap().unwrap();
+            (committer.name.to_owned(), committer.email.to_owned())
+        };
+        assert_eq!(
+            fallback_committer_identity,
+            (
+                gitbutler_repo::GITBUTLER_COMMIT_AUTHOR_NAME.into(),
+                gitbutler_repo::GITBUTLER_COMMIT_AUTHOR_EMAIL.into(),
+            ),
+            "the context provides GitButler's fallback committer"
         );
-        drop(context_repo);
 
         let mut guard = ctx.exclusive_worktree_access();
         gitbutler_branch_actions::set_base_branch(
@@ -125,10 +131,7 @@ fn works_without_git_identity() {
                     "initialize workspace"
                 },
             ),
-            (
-                gitbutler_repo::GITBUTLER_COMMIT_AUTHOR_NAME.into(),
-                gitbutler_repo::GITBUTLER_COMMIT_AUTHOR_EMAIL.into(),
-            ),
+            fallback_committer_identity,
             "identity-free onboarding uses GitButler for its reflog"
         );
     }


### PR DESCRIPTION
The good thing about this solution is that it works for all current and future reference creations while no Git identity is set.

----
Set gitoxide's committer name and email fallbacks on repositories opened through
Context. This allows reference reflogs before a user configures a Git identity
while preserving configured identities.

Restores direct reference creation, superseding
https://github.com/gitbutlerapp/gitbutler/pull/15591 and undoing
073c77063834177e3674639709cb1d13c32c252b.
