### PR TITLE
Give the agent setup wizard a send-off with next steps

### DIFF
--- a/apps/web/src/routes/cli/scripts.json
+++ b/apps/web/src/routes/cli/scripts.json
@@ -36,7 +36,13 @@
 					"  <span class='t-dim'>~/.claude/skills/gitbutler</span>",
 					"<span class='t-success'>✓</span> Added workflow instructions to <span class='t-highlight'>~/.claude/CLAUDE.md</span>",
 					"",
-					"<span class='t-success'>✓</span> <span class='t-teal'>GitButler agent setup complete.</span>"
+					"<span class='t-success'>✓</span> <span class='t-teal'>GitButler agent setup complete.</span>",
+					"",
+					"Just tell your agent what you want — <span class='t-cyan'>\"commit this\"</span>, <span class='t-cyan'>\"amend the fixes where they belong\"</span>, <span class='t-cyan'>\"open a PR\"</span>.",
+					"",
+					"Parallel sessions just work: each agent commits to its own branch, stacking when one builds on another.",
+					"",
+					"<span class='t-dim'>More things to try: https://docs.gitbutler.com/ai-agents/useful-requests</span>"
 				]
 			}
 		]

--- a/crates/but/src/command/agent/mod.rs
+++ b/crates/but/src/command/agent/mod.rs
@@ -743,11 +743,32 @@ fn apply_plan(out: &mut OutputChannel, current_dir: &Path, plan: &Plan) -> Resul
 fn print_setup_complete(out: &mut OutputChannel) -> Result<()> {
     if let Some(writer) = out.for_human() {
         let t = theme::get();
+        let ask = |text: &str| t.config_value.paint(format!("\"{text}\""));
         writeln!(writer)?;
         writeln!(
             writer,
             "{} GitButler agent setup complete.",
             t.sym().success
+        )?;
+        writeln!(writer)?;
+        writeln!(
+            writer,
+            "Just tell your agent what you want — {}, {}, {}.",
+            ask("commit this"),
+            ask("amend the fixes where they belong"),
+            ask("open a PR")
+        )?;
+        writeln!(writer)?;
+        writeln!(
+            writer,
+            "Parallel sessions just work: each agent commits to its own branch, stacking when one builds on another."
+        )?;
+        writeln!(writer)?;
+        writeln!(
+            writer,
+            "{}",
+            t.hint
+                .paint("More things to try: https://docs.gitbutler.com/ai-agents/useful-requests")
         )?;
     }
     Ok(())


### PR DESCRIPTION
The wizard previously ended with a bare "setup complete" line. It now closes with a short outro: three example asks to try with your agent, a note that parallel sessions each commit to their own branch (stacking when one builds on another), and a link to the useful-requests docs page.

The example asks are painted with the full-strength value color (the dim command-suggestion style was illegible as body text), and the docs link is dimmed to match the existing "Learn more" line.