### PR TITLE
Back off failing merge-status polls and classify transport errors

### DIFF
--- a/apps/desktop/src/components/forge/PullRequestCard.svelte
+++ b/apps/desktop/src/components/forge/PullRequestCard.svelte
@@ -83,24 +83,37 @@
 	// GitHub token is rate-limited) and restores the schedule on recovery.
 	let elapsedMs = $state<number>(0);
 	let isClosed = $state(false);
-	const backoff = createPollBackoff({
+	const prBackoff = createPollBackoff({
 		getResult: () => prQuery.result,
 		getElapsedMs: () => elapsedMs,
 		getShouldStop: () => isClosed,
 	});
-	const pollingInterval = $derived(poll ? backoff.pollingInterval : undefined);
+	const prPollingInterval = $derived(poll ? prBackoff.pollingInterval : undefined);
 
 	const prQuery = $derived(
 		prService.get(projectId, prNumber, {
 			forceRefetch: true,
-			subscriptionOptions: { pollingInterval },
+			subscriptionOptions: { pollingInterval: prPollingInterval },
 		}),
 	);
 	const pr = $derived(prQuery.response);
+	// The merge-status endpoint hits the forge fresh on every call and can fail
+	// while the PR query is fine, so it needs its own error backoff — sharing the
+	// PR query's interval would keep retrying on the fast schedule.
+	const mergeStatusBackoff = createPollBackoff({
+		getResult: () => mergeStatusQuery.result,
+		getElapsedMs: () => elapsedMs,
+		getShouldStop: () => isClosed,
+	});
+	const mergeStatusPollingInterval = $derived(
+		poll ? mergeStatusBackoff.pollingInterval : undefined,
+	);
 	// GitHub computes `mergeable_state` lazily: the first read after a push says
 	// `unknown`, so it needs re-reading or Merge stays disabled.
 	const mergeStatusQuery = $derived(
-		prService.getMergeStatus(projectId, prNumber, { subscriptionOptions: { pollingInterval } }),
+		prService.getMergeStatus(projectId, prNumber, {
+			subscriptionOptions: { pollingInterval: mergeStatusPollingInterval },
+		}),
 	);
 	const prMergeStatus = $derived(mergeStatusQuery.response);
 
@@ -154,7 +167,11 @@
 			tooltip = name + " base is too far behind";
 		} else if (prMergeStatus?.mergeableState === "dirty") {
 			tooltip = name + " has conflicts";
-		} else if (!prMergeStatus?.isMergeable) {
+		} else if (!prMergeStatus) {
+			// Loading, or the status fetch failed — don't claim "not mergeable"
+			// when the state simply isn't known.
+			tooltip = name + " merge status not loaded";
+		} else if (!prMergeStatus.isMergeable) {
 			tooltip = name + " is not mergeable";
 		} else {
 			disabled = false;

--- a/crates/but-forge/src/review.rs
+++ b/crates/but-forge/src/review.rs
@@ -2002,13 +2002,14 @@ pub async fn get_review_merge_status(
     match forge {
         ForgeName::GitHub => {
             let preferred_account = preferred_forge_user.as_ref().and_then(|user| user.github());
-            let pr_number = review_number
-                .try_into()
-                .context("PR: Failed to cast usize to i64, somehow")?;
-            let status = but_github::GitHubClient::from_storage(storage, preferred_account)?
-                .get_pull_request_merge_status(owner, repo, pr_number)
-                .await
-                .context("Failed to fetch PR merge status")?;
+            let status = but_github::pr::get_merge_status(
+                preferred_account,
+                owner,
+                repo,
+                review_number,
+                storage,
+            )
+            .await?;
             Ok(ReviewMergeStatus {
                 mergeable_state: status.mergeable_state,
                 comments_count: status.comments_count,
@@ -2018,13 +2019,13 @@ pub async fn get_review_merge_status(
         ForgeName::GitLab => {
             let preferred_account = preferred_forge_user.as_ref().and_then(|user| user.gitlab());
             let project_id = GitLabProjectId::new(owner, repo);
-            let mr_iid = review_number
-                .try_into()
-                .context("MR: Failed to cast usize to i64, somehow")?;
-            let status = but_gitlab::GitLabClient::from_storage(storage, preferred_account)?
-                .get_merge_request_merge_status(project_id, mr_iid)
-                .await
-                .context("Failed to fetch MR merge status")?;
+            let status = but_gitlab::mr::get_merge_status(
+                preferred_account,
+                project_id,
+                review_number,
+                storage,
+            )
+            .await?;
             Ok(ReviewMergeStatus {
                 mergeable_state: status.mergeable_state,
                 comments_count: status.comments_count,

--- a/crates/but-github/src/client.rs
+++ b/crates/but-github/src/client.rs
@@ -467,9 +467,7 @@ impl GitHubClient {
             self.base_url, owner, repo, pr_number
         );
         let response = self.client.get(&url).send().await?;
-        if !response.status().is_success() {
-            bail!("Failed to get PR merge status: {}", response.status());
-        }
+        let response = ensure_success(response).await?;
         let body: PrMergeStatusResponse = response.json().await?;
         let is_mergeable = matches!(
             body.mergeable_state.as_deref(),

--- a/crates/but-github/src/pr.rs
+++ b/crates/but-github/src/pr.rs
@@ -118,6 +118,21 @@ pub async fn get(
     Ok(pr)
 }
 
+pub async fn get_merge_status(
+    preferred_account: Option<&crate::GithubAccountIdentifier>,
+    owner: &str,
+    repo: &str,
+    pr_number: usize,
+    storage: &but_forge_storage::Controller,
+) -> Result<crate::client::PullRequestMergeStatus> {
+    let pr_number = pr_number.try_into().context("PR number is too large")?;
+    GitHubClient::from_storage(storage, preferred_account)?
+        .get_pull_request_merge_status(owner, repo, pr_number)
+        .await
+        .map_err(classify_forge_error)
+        .context("Failed to fetch PR merge status")
+}
+
 pub async fn list_comments(
     preferred_account: Option<&crate::GithubAccountIdentifier>,
     owner: &str,

--- a/crates/but-gitlab/src/mr.rs
+++ b/crates/but-gitlab/src/mr.rs
@@ -96,6 +96,20 @@ pub async fn get(
     Ok(mr)
 }
 
+pub async fn get_merge_status(
+    preferred_account: Option<&crate::GitlabAccountIdentifier>,
+    project_id: GitLabProjectId,
+    mr_iid: usize,
+    storage: &but_forge_storage::Controller,
+) -> Result<crate::client::MergeRequestMergeStatus> {
+    let mr_iid = mr_iid.try_into().context("MR number is too large")?;
+    GitLabClient::from_storage(storage, preferred_account)?
+        .get_merge_request_merge_status(project_id, mr_iid)
+        .await
+        .map_err(classify_forge_error)
+        .context("Failed to fetch MR merge status")
+}
+
 pub async fn update(
     preferred_account: Option<&crate::GitlabAccountIdentifier>,
     params: crate::client::UpdateMergeRequestParams<'_>,

--- a/e2e/playwright/tests/forge.spec.ts
+++ b/e2e/playwright/tests/forge.spec.ts
@@ -332,6 +332,46 @@ test("merge button is disabled when the MR is not mergeable", async ({ page, git
 	await expect(mergeButton).toBeDisabled();
 });
 
+test("a failing merge-status poll backs off instead of hammering the endpoint", async ({
+	page,
+	gitbutler,
+}) => {
+	// A recent `modifiedAt` keeps the healthy schedule on its fast 5s interval,
+	// so the back-off to 30s shows up as a drop in request cadence (see the
+	// equivalent checks-poll test above). Routed before `openReviewBranchView`
+	// so even the first status request fails.
+	const now = new Date().toISOString();
+	let statusRequests = 0;
+	await page.route("**/get_review_merge_status", async (route) => {
+		statusRequests += 1;
+		await route.fulfill({
+			status: 200,
+			contentType: "application/json",
+			body: forgeErrorBody({ code: "Unknown", message: "Failed to fetch PR merge status" }),
+		});
+	});
+
+	const mergeButton = await openReviewBranchView(
+		page,
+		gitbutler,
+		{ forge_info: gitlabForgeInfo(), get_review_base_repo_url: null },
+		{ modifiedAt: now, createdAt: now, lastSyncAt: now },
+	);
+	// Status never loaded: merge stays unavailable, but as "not loaded",
+	// never as a definitive "not mergeable".
+	await expect(mergeButton).toBeDisabled();
+	await mergeButton.hover();
+	await expect(page.locator(".tooltip-container")).toContainText("merge status not loaded");
+	await expect.poll(() => statusRequests).toBeGreaterThan(0);
+
+	const afterFirstError = statusRequests;
+	// Longer than the fast 5s interval, shorter than the 30s back-off: a
+	// hammering poller would fire ~2 more times in this window, a backed-off
+	// one ~0.
+	await page.waitForTimeout(13_000);
+	expect(statusRequests - afterFirstError).toBeLessThanOrEqual(1);
+});
+
 async function cacheReview(
 	gitbutler: { runScript: (s: string, a?: string[]) => Promise<void> },
 	review: ForgeReview,


### PR DESCRIPTION
Fixes GB-1922

Desktop 0.22.1's merge-status polling retried transient failures every 5s and falsely presented the PR as "not mergeable":

- The status query borrowed the healthy PR-details query's polling interval, so its own failures never tripped the error backoff. It now gets its own `createPollBackoff`, stepping out to 30s on the first failure like the checks poll does.
- The GitHub/GitLab merge-status reads called the clients raw, bypassing `classify_forge_error` — transient DNS/TLS/timeout failures surfaced as `Unknown`. They now go through wrapper functions in `pr.rs`/`mr.rs` like every other read path, so transport failures classify as `NetworkError` (and GitHub 401s as expired tokens via `ensure_success`).
- When the status hasn't loaded, the merge button tooltip now says so instead of claiming the PR is not mergeable. Enablement is unchanged.

Includes a Playwright cadence test mirroring the existing checks-backoff test: a failing status endpoint must not produce more than one extra request in a 13s window.