### PR TITLE
Classify CI-check forge failures instead of collapsing them to Unknown

### DIFF
--- a/apps/desktop/src/components/forge/CIChecksBadge.svelte
+++ b/apps/desktop/src/components/forge/CIChecksBadge.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { classify } from "$lib/error/errorClassification";
 	import { CHECKS_MONITOR } from "$lib/forge/checksMonitor.svelte";
 	import { FORGE_INFO_SERVICE } from "$lib/forge/forgeInfo.svelte";
 	import { createPollBackoff } from "$lib/forge/shared/pollErrorBackoff.svelte";
@@ -90,12 +91,18 @@
 		}
 
 		if (checksQuery?.result.error) {
+			// A terminal error (PAT missing the Checks permission, org OAuth
+			// block, no forge credentials) carries actionable guidance from
+			// the backend — show that instead of a generic retry hint.
+			const classified = classify(checksQuery.result.error);
 			return {
 				style: "danger",
 				icon: "warning",
 				text: "Failed to load checks",
 				reducedText: "Error",
-				tooltip: "Failed to load checks. Click to retry.",
+				tooltip: classified.terminal
+					? classified.message
+					: "Failed to load checks. Click to retry.",
 			};
 		}
 

--- a/apps/desktop/src/lib/error/errorClassification.test.ts
+++ b/apps/desktop/src/lib/error/errorClassification.test.ts
@@ -1,3 +1,4 @@
+import { persistSwallowGitHubOrgAuthErrors } from "$lib/config/config";
 import { SilentError } from "$lib/error/error";
 import { classify } from "$lib/error/errorClassification";
 import { IpcError } from "$lib/error/normalizedError";
@@ -45,6 +46,24 @@ describe("classify", () => {
 				"list_reviews",
 			);
 			expect(classify(error).severity).toBe("silent");
+		});
+
+		test("opted-out org OAuth errors stay terminal so pollers still stop", () => {
+			persistSwallowGitHubOrgAuthErrors(true);
+			try {
+				const error = new IpcError(
+					{
+						message: "the organization has enabled OAuth App access restrictions",
+						code: "GitHubOrgOAuthRestricted",
+					},
+					"list_ci_checks",
+				);
+				const result = classify(error);
+				expect(result.severity).toBe("silent");
+				expect(result.terminal).toBe(true);
+			} finally {
+				persistSwallowGitHubOrgAuthErrors(false);
+			}
 		});
 	});
 
@@ -106,6 +125,21 @@ describe("classify", () => {
 			const result = classify(error);
 			expect(result.userMessage).toContain("expired");
 			expect(result.userMessage).toContain("log out");
+		});
+
+		test("GitHubInsufficientPermissions is terminal with permission guidance", () => {
+			const error = new IpcError(
+				{
+					message: "Your GitHub credentials don't have permission to read this.",
+					code: "GitHubInsufficientPermissions",
+				},
+				"list_ci_checks",
+			);
+			const result = classify(error);
+			expect(result.severity).toBe("error");
+			// Terminal: telemetry captures once per session and pollers stop.
+			expect(result.terminal).toBe(true);
+			expect(result.userMessage).toContain("permission");
 		});
 	});
 

--- a/apps/desktop/src/lib/error/errorClassification.ts
+++ b/apps/desktop/src/lib/error/errorClassification.ts
@@ -158,6 +158,19 @@ Your GitHub token appears expired. Please log out and back in to refresh it. (Se
 	},
 	GitHubOrgOAuthRestricted: GH_ORG_AUTH_CLASSIFICATION,
 	/**
+	 * The GitHub token can't read the requested resource — a fine-grained
+	 * PAT missing a read permission such as Checks. Terminal until the
+	 * user grants it or reconnects.
+	 */
+	GitHubInsufficientPermissions: {
+		severity: "error",
+		terminal: true,
+		title: "GitHub Permissions Error",
+		userMessage: `
+Your GitHub token doesn't have permission to read part of this repository (for example CI checks). Grant the token the missing read permission on GitHub, or reconnect GitHub under Settings → Integrations.
+		`,
+	},
+	/**
 	 * No forge credentials are stored — the user never authenticated or
 	 * logged out. Cached review reads fall back to the last known data;
 	 * this surfaces on explicit forge actions (sync, PR mutations), so
@@ -244,20 +257,19 @@ export function classify(error: unknown, callerTitle?: string): ClassifiedError 
 	const effective = byMessage ?? byCode;
 	const title = effective?.title ?? name ?? callerTitle ?? message;
 
-	if (isUnrecoverableBundlingError(message)) {
-		return { title, message, code, severity: "silent" };
-	}
-	// Silence octokit's offline "Load failed" — happens whenever the user
-	// loses network, surfaces nothing actionable.
-	if (origin === "http" && message === "Load failed") {
-		return { title, message, code, severity: "silent" };
-	}
-	if (title === GH_ORG_AUTH_ERROR && getSwallowGitHubOrgAuthErrors()) {
-		return { title, message, code, severity: "silent" };
-	}
-
-	if (effective?.severity === "silent") {
-		return { title, message, code, severity: "silent" };
+	// Expected states rather than defects: suppress the toast and capture,
+	// but carry `terminal` through so pollers still stop on unretryable
+	// states (e.g. an org-auth error the user opted out of seeing).
+	const silenced =
+		isUnrecoverableBundlingError(message) ||
+		// Octokit's offline "Load failed" — happens whenever the user
+		// loses network, surfaces nothing actionable.
+		(origin === "http" && message === "Load failed") ||
+		// The org-auth toast opt-out ("Don't show this again").
+		(title === GH_ORG_AUTH_ERROR && getSwallowGitHubOrgAuthErrors()) ||
+		effective?.severity === "silent";
+	if (silenced) {
+		return { title, message, code, severity: "silent", terminal: effective?.terminal };
 	}
 
 	return {

--- a/apps/desktop/src/lib/forge/bitbucket/bitbucketUserService.svelte.ts
+++ b/apps/desktop/src/lib/forge/bitbucket/bitbucketUserService.svelte.ts
@@ -1,4 +1,4 @@
-import { providesItem, providesList, ReduxTag } from "$lib/state/tags";
+import { invalidatesList, providesItem, providesList, ReduxTag } from "$lib/state/tags";
 import { InjectionToken } from "@gitbutler/core/context";
 import type { BackendApi } from "$lib/state/backendApi";
 import type { ReactiveQuery } from "$lib/state/butlerModule";
@@ -116,7 +116,11 @@ function injectBackendEndpoints(api: BackendApi) {
 				query: (account) => ({
 					account,
 				}),
-				invalidatesTags: [providesList(ReduxTag.BitbucketUserList)],
+				invalidatesTags: [
+					providesList(ReduxTag.BitbucketUserList),
+					invalidatesList(ReduxTag.PullRequests),
+					invalidatesList(ReduxTag.Checks),
+				],
 			}),
 			getBitbucketUser: build.query<
 				BitbucketAuthenticatedUserSensitive | null,
@@ -143,7 +147,11 @@ function injectBackendEndpoints(api: BackendApi) {
 					actionName: "Clear All Bitbucket Accounts",
 				},
 				query: () => ({}),
-				invalidatesTags: [providesList(ReduxTag.BitbucketUserList)],
+				invalidatesTags: [
+					providesList(ReduxTag.BitbucketUserList),
+					invalidatesList(ReduxTag.PullRequests),
+					invalidatesList(ReduxTag.Checks),
+				],
 			}),
 			storeBitbucketApiToken: build.mutation<
 				BitbucketAuthStatusResponse,
@@ -154,7 +162,11 @@ function injectBackendEndpoints(api: BackendApi) {
 					actionName: "Store Bitbucket API Token",
 				},
 				query: (args) => args,
-				invalidatesTags: [providesList(ReduxTag.BitbucketUserList)],
+				invalidatesTags: [
+					providesList(ReduxTag.BitbucketUserList),
+					invalidatesList(ReduxTag.PullRequests),
+					invalidatesList(ReduxTag.Checks),
+				],
 			}),
 		}),
 	});

--- a/apps/desktop/src/lib/forge/github/githubUserService.svelte.ts
+++ b/apps/desktop/src/lib/forge/github/githubUserService.svelte.ts
@@ -1,4 +1,4 @@
-import { providesItem, providesList, ReduxTag } from "$lib/state/tags";
+import { invalidatesList, providesItem, providesList, ReduxTag } from "$lib/state/tags";
 import { InjectionToken } from "@gitbutler/core/context";
 import type { BackendApi } from "$lib/state/backendApi";
 import type { ReactiveQuery } from "$lib/state/butlerModule";
@@ -160,7 +160,11 @@ function injectBackendEndpoints(api: BackendApi) {
 				query: (account) => ({
 					account,
 				}),
-				invalidatesTags: [providesList(ReduxTag.GitHubUserList)],
+				invalidatesTags: [
+					providesList(ReduxTag.GitHubUserList),
+					invalidatesList(ReduxTag.PullRequests),
+					invalidatesList(ReduxTag.Checks),
+				],
 			}),
 			initDeviceOauth: build.mutation<Verification, void>({
 				extraOptions: {
@@ -175,7 +179,11 @@ function injectBackendEndpoints(api: BackendApi) {
 					actionName: "Check GitHub Auth Status",
 				},
 				query: (args) => args,
-				invalidatesTags: [providesList(ReduxTag.GitHubUserList)],
+				invalidatesTags: [
+					providesList(ReduxTag.GitHubUserList),
+					invalidatesList(ReduxTag.PullRequests),
+					invalidatesList(ReduxTag.Checks),
+				],
 			}),
 			getGitHubUser: build.query<
 				GithubAuthenticatedUserSensitive | null,
@@ -202,7 +210,11 @@ function injectBackendEndpoints(api: BackendApi) {
 					actionName: "Clear All GitHub Accounts",
 				},
 				query: () => ({}),
-				invalidatesTags: [providesList(ReduxTag.GitHubUserList)],
+				invalidatesTags: [
+					providesList(ReduxTag.GitHubUserList),
+					invalidatesList(ReduxTag.PullRequests),
+					invalidatesList(ReduxTag.Checks),
+				],
 			}),
 			storeGitHubPat: build.mutation<GithubAuthStatusResponse, { accessToken: string }>({
 				extraOptions: {
@@ -210,7 +222,11 @@ function injectBackendEndpoints(api: BackendApi) {
 					actionName: "Store GitHub PAT",
 				},
 				query: (args) => args,
-				invalidatesTags: [providesList(ReduxTag.GitHubUserList)],
+				invalidatesTags: [
+					providesList(ReduxTag.GitHubUserList),
+					invalidatesList(ReduxTag.PullRequests),
+					invalidatesList(ReduxTag.Checks),
+				],
 			}),
 			storeGithuibEnterprisePat: build.mutation<
 				GithubAuthStatusResponse,
@@ -221,7 +237,11 @@ function injectBackendEndpoints(api: BackendApi) {
 					actionName: "Store GitHub Enterprise PAT",
 				},
 				query: (args) => args,
-				invalidatesTags: [providesList(ReduxTag.GitHubUserList)],
+				invalidatesTags: [
+					providesList(ReduxTag.GitHubUserList),
+					invalidatesList(ReduxTag.PullRequests),
+					invalidatesList(ReduxTag.Checks),
+				],
 			}),
 		}),
 	});

--- a/apps/desktop/src/lib/forge/gitlab/gitlabUserService.svelte.ts
+++ b/apps/desktop/src/lib/forge/gitlab/gitlabUserService.svelte.ts
@@ -1,5 +1,5 @@
 import { getUserErrorCode } from "$lib/backend/ipc";
-import { providesItem, providesList, ReduxTag } from "$lib/state/tags";
+import { invalidatesList, providesItem, providesList, ReduxTag } from "$lib/state/tags";
 import { InjectionToken } from "@gitbutler/core/context";
 import type { SecretsService } from "$lib/secrets/secretsService";
 import type { BackendApi } from "$lib/state/backendApi";
@@ -167,7 +167,11 @@ function injectBackendEndpoints(api: BackendApi) {
 				query: (account) => ({
 					account,
 				}),
-				invalidatesTags: [providesList(ReduxTag.GitLabUserList)],
+				invalidatesTags: [
+					providesList(ReduxTag.GitLabUserList),
+					invalidatesList(ReduxTag.PullRequests),
+					invalidatesList(ReduxTag.Checks),
+				],
 			}),
 			getGitLabUser: build.query<
 				GitlabAuthenticatedUserSensitive | null,
@@ -194,7 +198,11 @@ function injectBackendEndpoints(api: BackendApi) {
 					actionName: "Clear All GitLab Accounts",
 				},
 				query: () => ({}),
-				invalidatesTags: [providesList(ReduxTag.GitLabUserList)],
+				invalidatesTags: [
+					providesList(ReduxTag.GitLabUserList),
+					invalidatesList(ReduxTag.PullRequests),
+					invalidatesList(ReduxTag.Checks),
+				],
 			}),
 			storeGitLabPat: build.mutation<GitlabAuthStatusResponse, { accessToken: string }>({
 				extraOptions: {
@@ -202,7 +210,11 @@ function injectBackendEndpoints(api: BackendApi) {
 					actionName: "Store GitLab PAT",
 				},
 				query: (args) => args,
-				invalidatesTags: [providesList(ReduxTag.GitLabUserList)],
+				invalidatesTags: [
+					providesList(ReduxTag.GitLabUserList),
+					invalidatesList(ReduxTag.PullRequests),
+					invalidatesList(ReduxTag.Checks),
+				],
 			}),
 			storeGitLabEnterprisePat: build.mutation<
 				GitlabAuthStatusResponse,
@@ -213,7 +225,11 @@ function injectBackendEndpoints(api: BackendApi) {
 					actionName: "Store GitLab Enterprise PAT",
 				},
 				query: (args) => args,
-				invalidatesTags: [providesList(ReduxTag.GitLabUserList)],
+				invalidatesTags: [
+					providesList(ReduxTag.GitLabUserList),
+					invalidatesList(ReduxTag.PullRequests),
+					invalidatesList(ReduxTag.Checks),
+				],
 			}),
 		}),
 	});

--- a/apps/desktop/src/lib/forge/shared/pollErrorBackoff.svelte.ts
+++ b/apps/desktop/src/lib/forge/shared/pollErrorBackoff.svelte.ts
@@ -1,7 +1,8 @@
+import { classify } from "$lib/error/errorClassification";
 import { getPollingInterval } from "$lib/forge/shared/progressivePolling";
 
 /** The bits of a query result the backoff cares about. */
-type PollResult = { isError?: boolean; startedTimeStamp?: number } | undefined;
+type PollResult = { isError?: boolean; error?: unknown; startedTimeStamp?: number } | undefined;
 
 /**
  * Progressive polling that backs off as a query keeps failing.
@@ -11,6 +12,11 @@ type PollResult = { isError?: boolean; startedTimeStamp?: number } | undefined;
  * failures persist (offline, rate-limited, repo access lost) — see
  * {@link getPollingInterval}. A successful fetch (including refetch-on-focus /
  * reconnect or a manual retry) resets the count and restores the schedule.
+ *
+ * An error whose classification is `terminal` (a PAT missing a permission,
+ * an org OAuth block, no forge credentials) stops automatic polling entirely
+ * — no interval will fix it. Refetch-on-focus and manual retries still
+ * probe, and a success clears the stop.
  *
  * The failure count is `$state` written from an `$effect`, not a `$derived` off
  * the query: `pollingInterval` feeds the query's own subscription, so deriving
@@ -27,6 +33,7 @@ export function createPollBackoff(deps: {
 	getShouldStop: () => boolean;
 }) {
 	let consecutiveErrors = $state(0);
+	let terminalError = $state(false);
 	// Not reactive: just remembers which poll we last counted, so a re-running
 	// effect doesn't double-count a single failed request.
 	let lastPolledStamp: number | undefined = undefined;
@@ -39,9 +46,13 @@ export function createPollBackoff(deps: {
 		if (!errored) {
 			// A healthy (or absent) result clears the backoff.
 			if (consecutiveErrors !== 0) consecutiveErrors = 0;
+			if (terminalError) terminalError = false;
 			lastPolledStamp = stamp;
 			return;
 		}
+
+		const terminal = result?.error ? (classify(result.error).terminal ?? false) : false;
+		if (terminal !== terminalError) terminalError = terminal;
 
 		if (consecutiveErrors === 0) {
 			// First failed poll: step out to the short interval.
@@ -58,7 +69,11 @@ export function createPollBackoff(deps: {
 
 	return {
 		get pollingInterval() {
-			return getPollingInterval(deps.getElapsedMs(), deps.getShouldStop(), consecutiveErrors);
+			return getPollingInterval(
+				deps.getElapsedMs(),
+				deps.getShouldStop() || terminalError,
+				consecutiveErrors,
+			);
 		},
 	};
 }

--- a/crates/but-bitbucket/src/checks.rs
+++ b/crates/but-bitbucket/src/checks.rs
@@ -1,0 +1,22 @@
+use anyhow::{Context as _, Result};
+
+use crate::client::BitbucketClient;
+
+/// Fetch commit build statuses for a ref, classifying transport failures as
+/// `NetworkError` like the other read paths.
+///
+/// Returns `None` when the ref can't be resolved (e.g. a deleted branch) —
+/// an expected "no checks" state the caller must not cache.
+pub async fn list_for_ref(
+    preferred_account: Option<&crate::BitbucketAccountIdentifier>,
+    workspace: &str,
+    repo_slug: &str,
+    reference: &str,
+    storage: &but_forge_storage::Controller,
+) -> Result<Option<Vec<crate::BitbucketBuildStatus>>> {
+    BitbucketClient::from_storage(storage, preferred_account)?
+        .list_checks_for_ref(workspace, repo_slug, reference)
+        .await
+        .map_err(crate::pr::classify_forge_error)
+        .context("Failed to list checks for ref")
+}

--- a/crates/but-bitbucket/src/client.rs
+++ b/crates/but-bitbucket/src/client.rs
@@ -648,7 +648,7 @@ impl BitbucketClient {
 /// serving cached data instead of surfacing an error.
 pub(crate) const NOT_AUTHENTICATED: but_error::Context = but_error::Context::new_static(
     but_error::Code::ForgeNotAuthenticated,
-    "Not authenticated with Bitbucket.",
+    "Not authenticated with Bitbucket. Connect your account under Settings → Integrations.",
 );
 
 pub(crate) fn resolve_account(

--- a/crates/but-bitbucket/src/lib.rs
+++ b/crates/but-bitbucket/src/lib.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context as _, Result};
 use but_secret::Sensitive;
 
+pub mod checks;
 mod client;
 pub mod pr;
 mod repo;

--- a/crates/but-error/src/lib.rs
+++ b/crates/but-error/src/lib.rs
@@ -179,6 +179,11 @@ pub enum Code {
     /// blocked the GitButler OAuth app. Terminal until the org approves the
     /// app or the user switches credentials — retrying won't help.
     GitHubOrgOAuthRestricted,
+    /// GitHub returned 403 "Resource not accessible by personal access
+    /// token" — the token works but lacks a read permission such as Checks.
+    /// Terminal until the user grants the permission or reconnects with
+    /// other credentials.
+    GitHubInsufficientPermissions,
     /// No credentials are stored for the forge integration — the user never
     /// authenticated or logged out. Cached forge data stays valid; retrying
     /// without re-authenticating won't help.

--- a/crates/but-forge/src/ci.rs
+++ b/crates/but-forge/src/ci.rs
@@ -133,17 +133,22 @@ fn ci_checks_for_ref(
             let preferred_account = preferred_forge_user
                 .as_ref()
                 .and_then(|user| user.gitlab().cloned());
-            let gl = but_gitlab::GitLabClient::from_storage(storage, preferred_account.as_ref())?;
 
             // Clone owned data for thread
             let project_id = but_gitlab::GitLabProjectId::new(owner, repo);
+            let storage = storage.clone();
             let reference = reference.to_string();
             let reference_for_checks = reference.clone();
 
             let pipelines = std::thread::spawn(move || -> anyhow::Result<_> {
                 let runtime = tokio::runtime::Runtime::new()
                     .map_err(|err| anyhow::anyhow!("Failed to create tokio runtime: {err}"))?;
-                runtime.block_on(gl.list_pipeline_jobs_for_ref(project_id, &reference))
+                runtime.block_on(but_gitlab::checks::list_pipeline_jobs_for_ref(
+                    preferred_account.as_ref(),
+                    project_id,
+                    &reference,
+                    &storage,
+                ))
             })
             .join()
             .map_err(|e| anyhow::anyhow!("Failed to join thread: {e:?}"))??;
@@ -162,19 +167,24 @@ fn ci_checks_for_ref(
             let preferred_account = preferred_forge_user
                 .as_ref()
                 .and_then(|user| user.bitbucket().cloned());
-            let bb =
-                but_bitbucket::BitbucketClient::from_storage(storage, preferred_account.as_ref())?;
 
             // Clone owned data for thread
             let workspace = owner.clone();
             let repo_slug = repo.clone();
+            let storage = storage.clone();
             let reference = reference.to_string();
             let reference_for_checks = reference.clone();
 
             let statuses = std::thread::spawn(move || -> anyhow::Result<_> {
                 let runtime = tokio::runtime::Runtime::new()
                     .map_err(|err| anyhow::anyhow!("Failed to create tokio runtime: {err}"))?;
-                runtime.block_on(bb.list_checks_for_ref(&workspace, &repo_slug, &reference))
+                runtime.block_on(but_bitbucket::checks::list_for_ref(
+                    preferred_account.as_ref(),
+                    &workspace,
+                    &repo_slug,
+                    &reference,
+                    &storage,
+                ))
             })
             .join()
             .map_err(|e| anyhow::anyhow!("Failed to join thread: {e:?}"))??;

--- a/crates/but-github/src/client.rs
+++ b/crates/but-github/src/client.rs
@@ -2005,7 +2005,7 @@ impl From<GitHubPullRequest> for PullRequest {
 /// serving cached data instead of surfacing an error.
 pub(crate) const NOT_AUTHENTICATED: but_error::Context = but_error::Context::new_static(
     but_error::Code::ForgeNotAuthenticated,
-    "Not authenticated with GitHub.",
+    "Not authenticated with GitHub. Connect your account under Settings → Integrations.",
 );
 
 pub(crate) fn resolve_account(

--- a/crates/but-github/src/pr.rs
+++ b/crates/but-github/src/pr.rs
@@ -86,6 +86,24 @@ pub(crate) fn classify_forge_error(err: anyhow::Error) -> anyhow::Error {
                 "A GitHub organization has restricted access for the GitButler OAuth app. Ask an organization owner to approve it, or authenticate with a personal access token instead.",
             ));
         }
+        // "Resource not accessible by personal access token": the token
+        // works but lacks a permission, e.g. a fine-grained PAT without
+        // Checks read access. Terminal until the user grants it. Other
+        // permission-shaped 403 wordings (integration tokens, SAML
+        // enforcement) deliberately stay `Unknown` until telemetry shows
+        // they actually occur.
+        if http_err.status == reqwest::StatusCode::FORBIDDEN
+            && err.chain().any(|cause| {
+                cause
+                    .to_string()
+                    .contains("Resource not accessible by personal access token")
+            })
+        {
+            return err.context(but_error::Context::new_static(
+                but_error::Code::GitHubInsufficientPermissions,
+                "Your GitHub token doesn't have permission to read this. Grant the token the missing repository read permission (such as Checks), or reconnect GitHub with different credentials.",
+            ));
+        }
     }
     err
 }
@@ -463,14 +481,33 @@ mod tests {
     }
 
     #[test]
-    fn other_403s_stay_unclassified() {
+    fn pat_permission_403_gets_dedicated_code() {
         let err = classify_forge_error(http_error(
             reqwest::StatusCode::FORBIDDEN,
-            r#"403 Forbidden: {"message":"Resource not accessible by integration"}"#,
+            r#"403 Forbidden: {"message":"Resource not accessible by personal access token"}"#,
         ));
-        assert!(
-            err.downcast_ref::<but_error::Context>().is_none(),
-            "an unrelated 403 must not be presented as an org OAuth restriction"
+        let ctx = err.downcast_ref::<but_error::Context>();
+        assert_eq!(
+            ctx.map(|c| c.code),
+            Some(but_error::Code::GitHubInsufficientPermissions),
+            "a PAT permission 403 is terminal and needs its remediation surfaced"
         );
+    }
+
+    #[test]
+    fn other_403s_stay_unclassified() {
+        // Only production-observed wordings are classified; the rest keep
+        // their raw message and stay visible in telemetry as `Unknown`.
+        for body in [
+            r#"403 Forbidden: {"message":"Resource not accessible by integration"}"#,
+            r#"403 Forbidden: {"message":"API rate limit exceeded for user ID 1."}"#,
+            r#"403 Forbidden: {"message":"Repository access blocked"}"#,
+        ] {
+            let err = classify_forge_error(http_error(reqwest::StatusCode::FORBIDDEN, body));
+            assert!(
+                err.downcast_ref::<but_error::Context>().is_none(),
+                "an unrecognized 403 must not be misclassified: {body}"
+            );
+        }
     }
 }

--- a/crates/but-gitlab/src/checks.rs
+++ b/crates/but-gitlab/src/checks.rs
@@ -1,0 +1,18 @@
+use anyhow::{Context as _, Result};
+
+use crate::{GitLabProjectId, client::GitLabClient};
+
+/// Fetch pipeline jobs for a ref, classifying transport failures as
+/// `NetworkError` like the other read paths.
+pub async fn list_pipeline_jobs_for_ref(
+    preferred_account: Option<&crate::GitlabAccountIdentifier>,
+    project_id: GitLabProjectId,
+    reference: &str,
+    storage: &but_forge_storage::Controller,
+) -> Result<Vec<crate::GitLabPipelineJob>> {
+    GitLabClient::from_storage(storage, preferred_account)?
+        .list_pipeline_jobs_for_ref(project_id, reference)
+        .await
+        .map_err(crate::mr::classify_forge_error)
+        .context("Failed to list pipeline jobs for ref")
+}

--- a/crates/but-gitlab/src/client.rs
+++ b/crates/but-gitlab/src/client.rs
@@ -1124,7 +1124,7 @@ fn source_project_differs_from_target(
 /// serving cached data instead of surfacing an error.
 pub(crate) const NOT_AUTHENTICATED: but_error::Context = but_error::Context::new_static(
     but_error::Code::ForgeNotAuthenticated,
-    "Not authenticated with GitLab.",
+    "Not authenticated with GitLab. Connect your account under Settings → Integrations.",
 );
 
 pub(crate) fn resolve_account(

--- a/crates/but-gitlab/src/lib.rs
+++ b/crates/but-gitlab/src/lib.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context as _, Result};
 use but_secret::Sensitive;
 
+pub mod checks;
 mod client;
 pub mod mr;
 mod project;

--- a/packages/but-sdk/src/generated/graph/index.d.ts
+++ b/packages/but-sdk/src/generated/graph/index.d.ts
@@ -2374,7 +2374,7 @@ export type Claude = {
  *
  * In practice, it should match its [frontend counterpart](https://github.com/gitbutlerapp/gitbutler/blob/fa973fd8f1ae8807621f47601803d98b8a9cf348/app/src/lib/backend/ipc.ts#L5).
  */
-export type Code = "Validation" | "RepoOwnership" | "ProjectGitAuth" | "DefaultTargetNotFound" | "CommitSigningFailed" | "CommitMergeConflictFailure" | "ProjectMissing" | "AuthorMissing" | "BranchNotFound" | "SecretKeychainNotFound" | "MissingLoginKeychain" | "GitForcePushProtection" | "NetworkError" | "ProjectDatabaseIncompatible" | "DefaultTerminalNotFound" | "Unknown" | "GitNonFastForward" | "CliInstallCancelled" | "GitHubTokenExpired" | "GitLabUnauthorized" | "GitLabForbidden" | "GitHubOrgOAuthRestricted" | "ForgeNotAuthenticated" | "PreconditionFailed" | "EditorExitedWithNonZeroStatus";
+export type Code = "Validation" | "RepoOwnership" | "ProjectGitAuth" | "DefaultTargetNotFound" | "CommitSigningFailed" | "CommitMergeConflictFailure" | "ProjectMissing" | "AuthorMissing" | "BranchNotFound" | "SecretKeychainNotFound" | "MissingLoginKeychain" | "GitForcePushProtection" | "NetworkError" | "ProjectDatabaseIncompatible" | "DefaultTerminalNotFound" | "Unknown" | "GitNonFastForward" | "CliInstallCancelled" | "GitHubTokenExpired" | "GitLabUnauthorized" | "GitLabForbidden" | "GitHubOrgOAuthRestricted" | "GitHubInsufficientPermissions" | "ForgeNotAuthenticated" | "PreconditionFailed" | "EditorExitedWithNonZeroStatus";
 
 /** Commit that is part of a legacy stack branch and contains state derived in relation to it. */
 export type Commit = {

--- a/packages/but-sdk/src/generated/linear/index.d.ts
+++ b/packages/but-sdk/src/generated/linear/index.d.ts
@@ -2374,7 +2374,7 @@ export type Claude = {
  *
  * In practice, it should match its [frontend counterpart](https://github.com/gitbutlerapp/gitbutler/blob/fa973fd8f1ae8807621f47601803d98b8a9cf348/app/src/lib/backend/ipc.ts#L5).
  */
-export type Code = "Validation" | "RepoOwnership" | "ProjectGitAuth" | "DefaultTargetNotFound" | "CommitSigningFailed" | "CommitMergeConflictFailure" | "ProjectMissing" | "AuthorMissing" | "BranchNotFound" | "SecretKeychainNotFound" | "MissingLoginKeychain" | "GitForcePushProtection" | "NetworkError" | "ProjectDatabaseIncompatible" | "DefaultTerminalNotFound" | "Unknown" | "GitNonFastForward" | "CliInstallCancelled" | "GitHubTokenExpired" | "GitLabUnauthorized" | "GitLabForbidden" | "GitHubOrgOAuthRestricted" | "ForgeNotAuthenticated" | "PreconditionFailed" | "EditorExitedWithNonZeroStatus";
+export type Code = "Validation" | "RepoOwnership" | "ProjectGitAuth" | "DefaultTargetNotFound" | "CommitSigningFailed" | "CommitMergeConflictFailure" | "ProjectMissing" | "AuthorMissing" | "BranchNotFound" | "SecretKeychainNotFound" | "MissingLoginKeychain" | "GitForcePushProtection" | "NetworkError" | "ProjectDatabaseIncompatible" | "DefaultTerminalNotFound" | "Unknown" | "GitNonFastForward" | "CliInstallCancelled" | "GitHubTokenExpired" | "GitLabUnauthorized" | "GitLabForbidden" | "GitHubOrgOAuthRestricted" | "GitHubInsufficientPermissions" | "ForgeNotAuthenticated" | "PreconditionFailed" | "EditorExitedWithNonZeroStatus";
 
 /** Commit that is part of a legacy stack branch and contains state derived in relation to it. */
 export type Commit = {


### PR DESCRIPTION
Fixes GB-1923

`list_ci_checks` reached the desktop as a generic `Unknown` error for GitHub PAT-permission 403s and any GitLab/Bitbucket transport failure: the CI badge could only say 'Error' with no remediation, and a permanent permission failure kept being re-polled.

- **but-github**: the shared `classify_forge_error` now tags 403 `Resource not accessible by personal access token` as the new terminal `GitHubInsufficientPermissions` code, covering checks and all other reads that share the classifier. Only this production-observed wording is matched — other permission-shaped 403s (integration tokens, SAML enforcement) and rate limiting deliberately stay `Unknown` so they remain visible in telemetry until evidence says otherwise.
- **but-gitlab / but-bitbucket**: CI checks reads go through new classified wrappers (mirroring the existing read-wrapper pattern), so DNS/timeout/connection failures surface as `NetworkError` like the review read paths.
- **Desktop**: the new code gets a terminal classification with remediation copy, and `terminal` now survives `classify()`'s silent returns (so an opted-out org-auth error still counts as terminal). Terminal-classified errors stop automatic polling in the shared poll backoff — no interval fixes a missing permission — while refetch-on-focus and manual retry still probe and recover. The CI badge tooltip shows the backend's guidance instead of the generic 'Click to retry'.

GitHub 422 unresolvable-ref handling and the transient 30s/5m error backoff are unchanged.