### PR TITLE
Refresh the workspace whenever HEAD moves

### DIFF
--- a/apps/lite/e2e/tests/head-moves.spec.ts
+++ b/apps/lite/e2e/tests/head-moves.spec.ts
@@ -1,0 +1,108 @@
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import { processEnvironment, type LiteTestEnvironment } from "../setup.ts";
+import { expect, test } from "../test.ts";
+
+/**
+ * Move HEAD from outside the app, the way a terminal `git checkout` does.
+ *
+ * The app is told about this by the watcher rather than by its own mutations,
+ * so nothing here touches the UI: the assertions are about what the workspace
+ * shows once the events have landed.
+ */
+const git = (environment: LiteTestEnvironment, ...args: Array<string>): void => {
+	execFileSync("git", args, {
+		cwd: path.join(environment.workdir, "local-clone"),
+		env: processEnvironment({ GIT_CONFIG_GLOBAL: environment.gitConfig }),
+		stdio: "pipe",
+	});
+};
+
+const checkout = (environment: LiteTestEnvironment, ...args: Array<string>): void =>
+	git(environment, "checkout", ...args);
+
+test.describe("head moves", () => {
+	// Ends on `gitbutler/workspace` with one applied lane, so leaving the
+	// workspace and coming back are both visible in the stacks list.
+	test.use({ scenario: "project-with-editable-commit.sh" });
+
+	test("refreshes the workspace when HEAD moves outside the app", async ({
+		appWindow,
+		testEnvironment,
+	}) => {
+		const lane = appWindow.getByRole("treeitem", { name: "edit-branch", exact: true });
+		const master = appWindow.getByRole("treeitem", { name: "master", exact: true });
+
+		// In the workspace: the applied lane is what the sidebar lists.
+		await expect(lane).toBeVisible();
+		await expect(master).toHaveCount(0);
+
+		// Onto a branch: the workspace is left behind, and the checked-out branch
+		// is all there is to show.
+		checkout(testEnvironment, "master");
+		await expect(lane).toHaveCount(0);
+		await expect(master).toBeVisible();
+
+		// Detached: no branch at HEAD, so no branch to list.
+		checkout(testEnvironment, "--detach");
+		await expect(master).toHaveCount(0);
+		await expect(lane).toHaveCount(0);
+
+		// Back onto the workspace ref: the lane returns without the app being
+		// told anything other than that HEAD moved.
+		checkout(testEnvironment, "gitbutler/workspace");
+		await expect(lane).toBeVisible();
+		await expect(master).toHaveCount(0);
+	});
+
+	test("refreshes the workspace when only HEAD itself is rewritten", async ({
+		appWindow,
+		testEnvironment,
+	}) => {
+		const lane = appWindow.getByRole("treeitem", { name: "edit-branch", exact: true });
+		const master = appWindow.getByRole("treeitem", { name: "master", exact: true });
+
+		await expect(lane).toBeVisible();
+
+		// Not a checkout: this rewrites `.git/HEAD` and leaves the worktree, the
+		// index and the reflog alone. The workspace has to follow HEAD however it
+		// moved, not only when a checkout moves it.
+		git(testEnvironment, "symbolic-ref", "HEAD", "refs/heads/master");
+		await expect(lane).toHaveCount(0);
+		await expect(master).toBeVisible();
+	});
+});
+
+test.describe("head moves between branches", () => {
+	// Ends on `C` with `A` and `B` behind it as local branches. Moving between
+	// them leaves the operating mode reading `OutsideWorkspace` throughout, so
+	// only the branch it names changes.
+	test.use({ scenario: "project-in-single-branch-three-branch-stack.sh" });
+
+	test("refreshes when HEAD moves between branches without changing the mode", async ({
+		appWindow,
+		testEnvironment,
+	}) => {
+		const top = appWindow.getByRole("treeitem", { name: "C", exact: true });
+		const bottom = appWindow.getByRole("treeitem", { name: "A", exact: true });
+		const middle = appWindow.getByRole("treeitem", { name: "B", exact: true });
+
+		// On the tip of the stack, all three branches are in view.
+		await expect(top).toBeVisible();
+		await expect(middle).toBeVisible();
+		await expect(bottom).toBeVisible();
+
+		// Down to the bottom of the stack: same mode, different branch, so the
+		// two above HEAD have to leave the list.
+		checkout(testEnvironment, "A");
+		await expect(bottom).toBeVisible();
+		await expect(top).toHaveCount(0);
+		await expect(middle).toHaveCount(0);
+
+		// And back up, to catch a refresh that only works in one direction.
+		checkout(testEnvironment, "C");
+		await expect(top).toBeVisible();
+		await expect(middle).toBeVisible();
+		await expect(bottom).toBeVisible();
+	});
+});

--- a/crates/but-api/src/watcher.rs
+++ b/crates/but-api/src/watcher.rs
@@ -73,14 +73,28 @@ impl WatcherEventKind {
     /// [`crate::tags`]. A fetch moves remote-tracking refs and refreshes the
     /// forge cache; activity means the repository changed; worktree changes
     /// mean the files did.
-    pub fn invalidates(self) -> &'static [CacheTag] {
+    pub fn invalidates(self) -> Vec<CacheTag> {
         use CacheTag as T;
         match self {
             WatcherEventKind::GitFetch => {
-                &[T::Branches, T::TargetCommits, T::FetchStatus, T::Reviews]
+                vec![T::Branches, T::TargetCommits, T::FetchStatus, T::Reviews]
             }
-            WatcherEventKind::GitHead => &[T::OperatingMode],
-            WatcherEventKind::GitActivity | WatcherEventKind::WorkspaceActivity => &[
+            // HEAD moving restates the whole repository: which branches and
+            // commits compose the workspace, and what the uncommitted diff is
+            // measured against — so a move between two branches changes
+            // everything an activity event would, even though no commit landed.
+            // It changes the mode on top of that.
+            //
+            // Taken from the activity arm rather than restated, so a tag added
+            // there cannot be forgotten here. A checkout also writes the reflog
+            // and so raises `GitActivity` alongside this, but that is a property
+            // of `git checkout`, not of HEAD moving.
+            WatcherEventKind::GitHead => {
+                let mut tags = vec![T::OperatingMode];
+                tags.extend(WatcherEventKind::GitActivity.invalidates());
+                tags
+            }
+            WatcherEventKind::GitActivity | WatcherEventKind::WorkspaceActivity => vec![
                 T::Branches,
                 T::TargetCommits,
                 T::Workspace,
@@ -92,7 +106,7 @@ impl WatcherEventKind {
                 T::Comments,
             ],
             WatcherEventKind::WorktreeChanges => {
-                &[T::Diffs, T::WorktreeChanges, T::AbsorptionPlan, T::Comments]
+                vec![T::Diffs, T::WorktreeChanges, T::AbsorptionPlan, T::Comments]
             }
         }
     }

--- a/packages/but-sdk/src/generated/graph/cacheTags.d.ts
+++ b/packages/but-sdk/src/generated/graph/cacheTags.d.ts
@@ -83,7 +83,7 @@ export declare const apiInvalidates: {
 export declare const watcherInvalidates: {
 	readonly gitActivity: readonly ["Branches", "TargetCommits", "Workspace", "Commits", "Diffs", "WorktreeChanges", "Worktrees", "AbsorptionPlan", "Comments"];
 	readonly gitFetch: readonly ["Branches", "TargetCommits", "FetchStatus", "Reviews"];
-	readonly gitHead: readonly ["OperatingMode"];
+	readonly gitHead: readonly ["OperatingMode", "Branches", "TargetCommits", "Workspace", "Commits", "Diffs", "WorktreeChanges", "Worktrees", "AbsorptionPlan", "Comments"];
 	readonly workspaceActivity: readonly ["Branches", "TargetCommits", "Workspace", "Commits", "Diffs", "WorktreeChanges", "Worktrees", "AbsorptionPlan", "Comments"];
 	readonly worktreeChanges: readonly ["Diffs", "WorktreeChanges", "AbsorptionPlan", "Comments"];
 };

--- a/packages/but-sdk/src/generated/graph/cacheTags.js
+++ b/packages/but-sdk/src/generated/graph/cacheTags.js
@@ -81,7 +81,7 @@ export const apiInvalidates = {
 export const watcherInvalidates = {
 	gitActivity: ["Branches", "TargetCommits", "Workspace", "Commits", "Diffs", "WorktreeChanges", "Worktrees", "AbsorptionPlan", "Comments"],
 	gitFetch: ["Branches", "TargetCommits", "FetchStatus", "Reviews"],
-	gitHead: ["OperatingMode"],
+	gitHead: ["OperatingMode", "Branches", "TargetCommits", "Workspace", "Commits", "Diffs", "WorktreeChanges", "Worktrees", "AbsorptionPlan", "Comments"],
 	workspaceActivity: ["Branches", "TargetCommits", "Workspace", "Commits", "Diffs", "WorktreeChanges", "Worktrees", "AbsorptionPlan", "Comments"],
 	worktreeChanges: ["Diffs", "WorktreeChanges", "AbsorptionPlan", "Comments"],
 };

--- a/packages/but-sdk/src/generated/linear/cacheTags.d.ts
+++ b/packages/but-sdk/src/generated/linear/cacheTags.d.ts
@@ -83,7 +83,7 @@ export declare const apiInvalidates: {
 export declare const watcherInvalidates: {
 	readonly gitActivity: readonly ["Branches", "TargetCommits", "Workspace", "Commits", "Diffs", "WorktreeChanges", "Worktrees", "AbsorptionPlan", "Comments"];
 	readonly gitFetch: readonly ["Branches", "TargetCommits", "FetchStatus", "Reviews"];
-	readonly gitHead: readonly ["OperatingMode"];
+	readonly gitHead: readonly ["OperatingMode", "Branches", "TargetCommits", "Workspace", "Commits", "Diffs", "WorktreeChanges", "Worktrees", "AbsorptionPlan", "Comments"];
 	readonly workspaceActivity: readonly ["Branches", "TargetCommits", "Workspace", "Commits", "Diffs", "WorktreeChanges", "Worktrees", "AbsorptionPlan", "Comments"];
 	readonly worktreeChanges: readonly ["Diffs", "WorktreeChanges", "AbsorptionPlan", "Comments"];
 };

--- a/packages/but-sdk/src/generated/linear/cacheTags.js
+++ b/packages/but-sdk/src/generated/linear/cacheTags.js
@@ -81,7 +81,7 @@ export const apiInvalidates = {
 export const watcherInvalidates = {
 	gitActivity: ["Branches", "TargetCommits", "Workspace", "Commits", "Diffs", "WorktreeChanges", "Worktrees", "AbsorptionPlan", "Comments"],
 	gitFetch: ["Branches", "TargetCommits", "FetchStatus", "Reviews"],
-	gitHead: ["OperatingMode"],
+	gitHead: ["OperatingMode", "Branches", "TargetCommits", "Workspace", "Commits", "Diffs", "WorktreeChanges", "Worktrees", "AbsorptionPlan", "Comments"],
 	workspaceActivity: ["Branches", "TargetCommits", "Workspace", "Commits", "Diffs", "WorktreeChanges", "Worktrees", "AbsorptionPlan", "Comments"],
 	worktreeChanges: ["Diffs", "WorktreeChanges", "AbsorptionPlan", "Comments"],
 };


### PR DESCRIPTION
The head event declared only the operating mode stale, so a HEAD move refreshed
the mode and nothing else. The workspace still updated — but only because `git
checkout` writes the reflog as well, and that raises the separate `gitActivity`
event.

Moving between two branches is where it shows. The mode reads
`OutsideWorkspace` before and after, so nothing about the mode changes and
`gitActivity` was doing all the work. Suppressing each event in the client, on
the old code:

| suppressed | branch → branch refresh |
| --- | --- |
| `gitActivity` | **fails** |
| `gitHead` (the whole head event) | passes |

The head event contributed nothing. With this change the first row passes too.

- `GitHead` now declares what a repository change declares, plus the mode, so
  the refresh is stated rather than inherited from a sibling event that happens
  to arrive with it.
- The regenerated `cacheTags` diff is the one `gitHead` line. It was generated
  from a tree holding only this change, so other in-flight API work in the
  shared workspace is not swept into it.
- Three e2e tests: workspace → branch → detached → workspace, a bare `git
  symbolic-ref` rewrite of HEAD, and branch → branch with the mode unchanged.

No UI change. An earlier revision of this branch added a HEAD indicator to the
sidebar; that was dropped.
