### PR TITLE
Upload lite e2e results to Buildkite Test Engine

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -776,6 +776,8 @@ jobs:
       - name: Run Lite E2E tests
         # Concurrent Electron launches can fail during renderer bootstrap on GitHub's Linux runners.
         run: xvfb-run --auto-servernum pnpm --filter @gitbutler/lite test:e2e --forbid-only --workers=1
+        env:
+          BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_SUITE_TOKEN_LITE_E2E }}
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:

--- a/apps/lite/e2e/playwright.config.ts
+++ b/apps/lite/e2e/playwright.config.ts
@@ -6,7 +6,10 @@ const liteRoot = path.resolve(import.meta.dirname, "..");
 export default defineConfig({
 	testDir: "./tests",
 	fullyParallel: true,
-	reporter: process.env.CI ? [["list"], ["buildkite-test-collector/playwright/reporter"]] : "list",
+	reporter:
+		process.env.CI === "true"
+			? [["list"], ["buildkite-test-collector/playwright/reporter"]]
+			: "list",
 	webServer: {
 		command: "pnpm dev:ui",
 		cwd: liteRoot,

--- a/apps/lite/e2e/playwright.config.ts
+++ b/apps/lite/e2e/playwright.config.ts
@@ -6,6 +6,7 @@ const liteRoot = path.resolve(import.meta.dirname, "..");
 export default defineConfig({
 	testDir: "./tests",
 	fullyParallel: true,
+	reporter: process.env.CI ? [["list"], ["buildkite-test-collector/playwright/reporter"]] : "list",
 	webServer: {
 		command: "pnpm dev:ui",
 		cwd: liteRoot,

--- a/apps/lite/package.json
+++ b/apps/lite/package.json
@@ -180,6 +180,7 @@
 		"@typescript/native-preview": "7.0.0-dev.20260707.2",
 		"@vitejs/plugin-react": "^5.2.0",
 		"babel-plugin-react-compiler": "^1.0.0",
+		"buildkite-test-collector": "^1.9.5",
 		"concurrently": "^9.2.1",
 		"cross-env": "^10.1.0",
 		"electron": "^44.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -549,6 +549,9 @@ importers:
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0
+      buildkite-test-collector:
+        specifier: ^1.9.5
+        version: 1.9.5
       concurrently:
         specifier: ^9.2.1
         version: 9.2.1


### PR DESCRIPTION
The lite e2e tests were the only CI suite not reporting to Buildkite Test Engine.

- Add the `buildkite-test-collector` Playwright reporter to the lite e2e config, enabled on CI like the other Playwright suites
- Pass `BUILDKITE_ANALYTICS_TOKEN` to the lite-e2e job from the new `BUILDKITE_SUITE_TOKEN_LITE_E2E` secret