### PR TITLE
Rework the Lite diff checking and selecting

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/DiffGutterPortals.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DiffGutterPortals.module.css
@@ -1,5 +1,12 @@
-.checkbox {
+/* In the diff gutter a checkbox is the whole cell, not a box sitting in one: checking a line fills
+   its column edge to edge, so a run of checked lines reads as one block. Doubled for specificity
+   over the shared checkbox's own rules. */
+.checkbox.checkbox {
+	inline-size: 100%;
+	block-size: 100%;
 	margin: 0;
+	border-radius: 0;
+	box-shadow: none;
 	opacity: var(--gitbutler-diff-gutter-checkbox-opacity, 0);
 
 	&[data-checked],
@@ -7,10 +14,46 @@
 	&:focus {
 		opacity: 1;
 	}
+
+	/* Unchecked, the cell shows what checking it would do: a film of the fill and a ghost of the
+	   tick. Both are mixed from the cell's own foreground rather than a fixed token, because a
+	   selected line inverts to a dark background and a dark ghost would vanish into it. Aiming at
+	   the cell itself brings both a step closer. */
+	&:not([data-checked], [data-indeterminate]) {
+		background-color: color-mix(in srgb, currentColor 10%, transparent);
+		color: inherit;
+
+		&:hover {
+			background-color: color-mix(in srgb, currentColor 18%, transparent);
+			/* Outspecifies the shared checkbox's own hover border, which this cell has no room for. */
+			box-shadow: none;
+		}
+
+		/* The indicator is the root's only child, and its class belongs to another module. */
+		& > * {
+			transform: scale(1);
+			opacity: 0.3;
+		}
+
+		&:hover > * {
+			opacity: 0.55;
+		}
+	}
+
+	&:is([data-checked], [data-indeterminate]) {
+		background-color: var(--fill-pop-bg);
+		color: var(--fill-pop-fg);
+	}
+}
+
+/* The band under it paints the hunk column in every state, so this checkbox only has to add the
+   mark that says which line the hunk starts on. */
+.checkbox.checkbox.hunkCheckbox,
+.checkbox.checkbox.hunkCheckbox:hover {
+	background-color: transparent;
 }
 
 .comment {
-	z-index: 1;
-	position: relative;
-	translate: calc(50% + 1px) 0;
+	display: flex;
+	align-items: center;
 }

--- a/apps/lite/ui/src/routes/project/$id/workspace/DiffGutterPortals.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DiffGutterPortals.module.css
@@ -2,11 +2,14 @@
    its column edge to edge, so a run of checked lines reads as one block. Doubled for specificity
    over the shared checkbox's own rules. */
 .checkbox.checkbox {
+	/* The cell is the box, so it answers with fill alone — never a ring, in any state. The shared
+	   checkbox draws every one of its borders at this width, so zeroing it is enough. */
+	--border-width: 0;
+
 	inline-size: 100%;
 	block-size: 100%;
 	margin: 0;
 	border-radius: 0;
-	box-shadow: none;
 	opacity: var(--gitbutler-diff-gutter-checkbox-opacity, 0);
 
 	&[data-checked],
@@ -25,8 +28,6 @@
 
 		&:hover {
 			background-color: color-mix(in srgb, currentColor 18%, transparent);
-			/* Outspecifies the shared checkbox's own hover border, which this cell has no room for. */
-			box-shadow: none;
 		}
 
 		/* The indicator is the root's only child, and its class belongs to another module. */

--- a/apps/lite/ui/src/routes/project/$id/workspace/DiffGutterPortals.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DiffGutterPortals.tsx
@@ -5,7 +5,7 @@ import { Icon } from "#ui/components/Icon.tsx";
 import type { Address } from "#ui/addresses.ts";
 import { projectSlice } from "#ui/projects/state.ts";
 import { useAppSelector } from "#ui/store.ts";
-import { Fragment, memo, type FC, useSyncExternalStore } from "react";
+import { Fragment, memo, type FC, useEffect, useSyncExternalStore } from "react";
 import { createPortal } from "react-dom";
 import type { DiffLineTarget } from "./diff-line-target.ts";
 import styles from "./DiffGutterPortals.module.css";
@@ -33,6 +33,10 @@ export type GutterTarget = {
 export type GutterStore = {
 	getSnapshot: () => ReadonlyArray<GutterTarget>;
 	subscribe: (listener: () => void) => () => void;
+	/** Reports whether a hunk holds any checked line, which is what its band stands for. */
+	setGroupChecked: (host: HTMLElement, groupKey: string, checked: boolean) => void;
+	/** Reports whether the hunk accepts a check at all, since its column answers clicks. */
+	setGroupCheckable: (host: HTMLElement, groupKey: string, checkable: boolean) => void;
 };
 
 const LineCheckbox: FC<{
@@ -76,27 +80,25 @@ const CommentButton: FC<{
 	getTarget: () => DiffLineTarget | undefined;
 	onComment: (target: DiffLineTarget) => void;
 }> = (p) => (
-	<button
-		slot={p.slotName}
-		type="button"
-		onPointerDown={(event) => {
-			// This control lives inside a line-number cell, but pressing it is not a line selection.
-			event.preventDefault();
-			event.stopPropagation();
-		}}
-		onClick={(event) => {
-			event.stopPropagation();
-			const target = p.getTarget();
-			if (target) p.onComment(target);
-		}}
-		aria-label="Annotate"
-		className={classes(
-			getButtonClassName({ variant: "pop", size: "small", iconOnly: true }),
-			styles.comment,
-		)}
-	>
-		<Icon name="plus" />
-	</button>
+	<span slot={p.slotName} className={styles.comment}>
+		<button
+			type="button"
+			onPointerDown={(event) => {
+				// This control lives inside a line-number cell, but pressing it is not a line selection.
+				event.preventDefault();
+				event.stopPropagation();
+			}}
+			onClick={(event) => {
+				event.stopPropagation();
+				const target = p.getTarget();
+				if (target) p.onComment(target);
+			}}
+			aria-label="Annotate"
+			className={getButtonClassName({ variant: "ghost", size: "small", iconOnly: true })}
+		>
+			<Icon name="plus" />
+		</button>
+	</span>
 );
 
 const HunkCheckbox: FC<{
@@ -109,6 +111,9 @@ const HunkCheckbox: FC<{
 		lineAddresses: Array<Extract<Address, { _tag: "Hunk" }>>,
 		shiftKey: boolean,
 	) => void;
+	store: GutterStore;
+	host: HTMLElement;
+	groupKey: string;
 }> = (p) => {
 	const checkedState = useAppSelector((state): HunkCheckedState => {
 		const checkedCount = p.lineAddresses.filter((address) =>
@@ -120,11 +125,25 @@ const HunkCheckbox: FC<{
 	const canCheck = useAppSelector((state) =>
 		projectSlice.selectors.selectCanCheckHunks(state, p.projectId, p.address.parent.parent),
 	);
+	// The band spans lines this checkbox does not stand on, and answers clicks along all of them, so
+	// the store learns both what to paint and whether the act is available at all from here. The
+	// store, host and key are what the reports are addressed to, so they are read off p rather than
+	// handed in as closures, which would be new every render and make each report run twice.
+	const { store, host, groupKey } = p;
+	useEffect(() => {
+		store.setGroupChecked(host, groupKey, checkedState !== "unchecked");
+		return () => store.setGroupChecked(host, groupKey, false);
+	}, [store, host, groupKey, checkedState]);
+	useEffect(() => {
+		store.setGroupCheckable(host, groupKey, canCheck);
+		return () => store.setGroupCheckable(host, groupKey, false);
+	}, [store, host, groupKey, canCheck]);
 	if (!canCheck) return null;
 
 	return (
 		<Checkbox
 			slot={p.slotName}
+			className={classes(styles.checkbox, styles.hunkCheckbox)}
 			checked={checkedState === "checked"}
 			indeterminate={checkedState === "indeterminate"}
 			onMouseDown={(event) => {
@@ -138,7 +157,6 @@ const HunkCheckbox: FC<{
 				p.onCheck(p.address, p.lineAddresses, shiftKey);
 			}}
 			aria-label="Check hunk"
-			className={styles.checkbox}
 		/>
 	);
 };
@@ -180,6 +198,9 @@ export const DiffGutterPortals = memo(function DiffGutterPortals({
 							slotName={group.parentSlotName}
 							lineAddresses={group.lines.map((line) => line.address)}
 							onCheck={onCheckHunk}
+							store={store}
+							host={host}
+							groupKey={group.key}
 						/>
 						{group.lines.map((line) => (
 							<LineCheckbox

--- a/apps/lite/ui/src/routes/project/$id/workspace/addressLabel.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/addressLabel.ts
@@ -4,7 +4,8 @@ import { Match } from "effect";
 import type { Address } from "#ui/addresses.ts";
 import { assert } from "#ui/assert.ts";
 
-const hunkLabel = (addresses: Array<Extract<Address, { _tag: "Hunk" }>>) => {
+/** What a set of hunk lines amounts to: "+3 -1 lines", the words a drag of them carries. */
+export const hunkAddressesLabel = (addresses: Array<Extract<Address, { _tag: "Hunk" }>>) => {
 	const add = addresses.reduce(
 		(sum, address) =>
 			sum +
@@ -58,7 +59,7 @@ export const addressLabel = ({
 					? `${commitTitle(commit.message) ?? "(no message)"}${commit.hasConflicts ? " ⚠️" : ""}`
 					: shortCommitId(commitId);
 			},
-			Hunk: (address) => hunkLabel([address]),
+			Hunk: (address) => hunkAddressesLabel([address]),
 		}),
 	);
 
@@ -70,7 +71,7 @@ export const addressesLabel = ({
 	headInfoIndex: HeadInfoIndex;
 }) => {
 	if (addresses.length > 0 && addresses.every((address) => address._tag === "Hunk"))
-		return hunkLabel(addresses);
+		return hunkAddressesLabel(addresses);
 	if (addresses.length !== 1) return `${addresses.length.toLocaleString()} items`;
 
 	return addressLabel({ address: assert(addresses[0]), headInfoIndex });

--- a/apps/lite/ui/src/routes/project/$id/workspace/diff-gutter.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/diff-gutter.ts
@@ -227,17 +227,44 @@ export const diffGutterUnsafeCSS = `
 		);
 	}
 
-	/* What the grip under the pointer is holding: the same dashed outline the drag itself paints,
-	   in a quieter weight. Declared first so a line that is already an operation source keeps the
-	   stronger mark. */
-	[${DRAG_PREVIEW_ATTRIBUTE}] {
-		outline: 1px dashed var(--border-2);
-		outline-offset: -1px;
+	/* A mark is drawn as a box laid over the line rather than an outline of it, so that a run of
+	   marked lines can close as one: each line drops the edge it shares with a marked neighbour,
+	   leaving the dashes only around the outside. The lines of a run are siblings and equally tall,
+	   so their side dashes keep step. */
+	[${DRAG_PREVIEW_ATTRIBUTE}]::after,
+	[${OPERATION_SOURCE_ATTRIBUTE}]::after {
+		content: "";
+		position: absolute;
+		inset: 0;
+		border-radius: var(--radius-md);
+		pointer-events: none;
 	}
 
-	[${OPERATION_SOURCE_ATTRIBUTE}] {
-		outline: 2px dashed var(--border-1);
-		outline-offset: -2px;
+	/* What the grip under the pointer is holding: the same dashed box the drag itself paints, in a
+	   quieter weight. Declared first so a line that is already an operation source keeps the
+	   stronger mark. */
+	[${DRAG_PREVIEW_ATTRIBUTE}]::after {
+		border: 1px dashed var(--text-1);
+	}
+
+	[${OPERATION_SOURCE_ATTRIBUTE}]::after {
+		border: 2px dashed var(--border-1);
+	}
+
+	/* Only the ends of a run are corners; the edge a line shares with a marked neighbour goes, and
+	   the rounding with it. */
+	[${DRAG_PREVIEW_ATTRIBUTE}] + [${DRAG_PREVIEW_ATTRIBUTE}]::after,
+	[${OPERATION_SOURCE_ATTRIBUTE}] + [${OPERATION_SOURCE_ATTRIBUTE}]::after {
+		border-block-start: none;
+		border-start-start-radius: 0;
+		border-start-end-radius: 0;
+	}
+
+	[${DRAG_PREVIEW_ATTRIBUTE}]:has(+ [${DRAG_PREVIEW_ATTRIBUTE}])::after,
+	[${OPERATION_SOURCE_ATTRIBUTE}]:has(+ [${OPERATION_SOURCE_ATTRIBUTE}])::after {
+		border-block-end: none;
+		border-end-start-radius: 0;
+		border-end-end-radius: 0;
 	}
 `;
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/diff-gutter.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/diff-gutter.ts
@@ -7,6 +7,8 @@ import {
 	type HunkAddress,
 	type Address,
 } from "#ui/addresses.ts";
+import { assert } from "#ui/assert.ts";
+import { icons } from "#ui/components/icons.ts";
 import { getOperationSources } from "#ui/operations/pending-operation.ts";
 import { projectSlice } from "#ui/projects/state.ts";
 import { useAppStore } from "#ui/store.ts";
@@ -23,17 +25,56 @@ const GUTTER_SLOT_KIND_ATTRIBUTE = "data-gitbutler-diff-gutter-slot-kind";
 const GUTTER_DRAG_HANDLE_ATTRIBUTE = "data-hunk-drag-handle";
 const GUTTER_GROUP_ATTRIBUTE = "data-gitbutler-diff-gutter-group";
 const GUTTER_HOVERED_ATTRIBUTE = "data-gitbutler-diff-gutter-hovered";
+const ACTIONS_ATTRIBUTE = "data-gitbutler-diff-actions";
+const ACTIONS_FILLED_ATTRIBUTE = "data-gitbutler-diff-actions-filled";
+const ACTIONS_DRAGGABLE_ATTRIBUTE = "data-gitbutler-diff-actions-draggable";
+const DRAG_PREVIEW_ATTRIBUTE = "data-gitbutler-diff-drag-preview";
+const HUNK_BAND_ATTRIBUTE = "data-gitbutler-diff-hunk-band";
+const HUNK_BAND_CHECKED_ATTRIBUTE = "data-checked";
 const COMMENT_SLOT_ATTRIBUTE = "data-gitbutler-diff-comment-slot";
 const OPERATION_SOURCE_ATTRIBUTE = "data-gitbutler-operation-source";
+const CHECK_DRAG_ATTRIBUTE = "data-gitbutler-diff-check-drag";
 
 export const diffGutterUnsafeCSS = `
+	/* While a press is painting checkboxes, the lines it crosses are the gesture's, not text. */
+	:host([${CHECK_DRAG_ATTRIBUTE}]) {
+		user-select: none;
+	}
+
 	:host {
 		--gitbutler-diff-gutter-control-width: 1lh;
-		--gitbutler-diff-gutter-width: calc(3 * var(--gitbutler-diff-gutter-control-width));
+		/* Two columns of the same width, the hunk's and the line's, the first flush with the panel's
+		   edge so nothing shows between the two. A panel's resize handle expands its 1px separator to
+		   a 10px hit target that reaches ~4.5px in, so that sliver of the hunk column answers the
+		   resize first; the rest of it is the hunk's own. */
+		--gitbutler-diff-gutter-width: calc(2 * var(--gitbutler-diff-gutter-control-width));
+		/* The break between the gutter and the change bar, as wide as the one the numbers already
+		   keep from the code. It cannot be left unpainted — the line's fill is one box, and the
+		   controls sit over it — so it is painted in the surface the other break reveals, which is
+		   Pierre's own and not the app's, since the two part ways in the dark theme. */
+		--gitbutler-diff-gutter-seam: 2px;
+		--gitbutler-diff-gutter-seam-color: var(--diffs-background, var(--bg-1));
 	}
 
 	[data-column-number] {
 		padding-left: calc(2ch + var(--gitbutler-diff-gutter-width));
+	}
+
+	/* The gutter ends where the file's own margin begins, so the line's fill stops short of the
+	   change bar and picks up again past it — the same seam the numbers keep from the code. The
+	   controls sit above this, and the fill is the row's, so only a stripe of the surface can
+	   separate them. */
+	[data-indicators="bars"] [data-column-number] {
+		padding-left: calc(
+			2ch + var(--gitbutler-diff-gutter-width) + var(--gitbutler-diff-gutter-seam)
+		);
+		background-image: linear-gradient(
+			to right,
+			transparent var(--gitbutler-diff-gutter-width),
+			var(--gitbutler-diff-gutter-seam-color) var(--gitbutler-diff-gutter-width),
+			var(--gitbutler-diff-gutter-seam-color) calc(var(--gitbutler-diff-gutter-width) + var(--gitbutler-diff-gutter-seam)),
+			transparent calc(var(--gitbutler-diff-gutter-width) + var(--gitbutler-diff-gutter-seam))
+		);
 	}
 
 	slot[${GUTTER_SLOT_ATTRIBUTE}] {
@@ -45,51 +86,126 @@ export const diffGutterUnsafeCSS = `
 		justify-content: center;
 	}
 
+	/* The hunk's checkbox is the head of its band, so it stands over the column the band paints. */
 	slot[${GUTTER_SLOT_KIND_ATTRIBUTE}="hunk"] {
-		inset-inline-start: var(--gitbutler-diff-gutter-control-width);
+		inset-inline-start: 0;
 	}
 
 	slot[${GUTTER_SLOT_KIND_ATTRIBUTE}="line"] {
-		inset-inline-start: calc(2 * var(--gitbutler-diff-gutter-control-width));
+		inset-inline-start: var(--gitbutler-diff-gutter-control-width);
 	}
 
-	[${GUTTER_DRAG_HANDLE_ATTRIBUTE}] {
+	/* The hunk column is one strip per hunk, drawn on every one of its lines: a ghost of itself
+	   while the pointer is in its column, the pop fill once anything in the hunk is checked. Clicking
+	   anywhere along it checks the hunk, and because the strip is exactly as tall as the hunk,
+	   nothing has to explain how far that reaches. */
+	[${HUNK_BAND_ATTRIBUTE}] {
 		position: absolute;
 		inset-block: 0;
 		inset-inline-start: 0;
 		width: var(--gitbutler-diff-gutter-control-width);
-		display: if(style(--gitbutler-diff-gutter-can-drag: true): flex; else: none);
-		align-items: center;
-		justify-content: center;
-		opacity: var(--gitbutler-diff-gutter-drag-opacity, 0);
 	}
 
-	[${GUTTER_DRAG_HANDLE_ATTRIBUTE}]::before {
-		content: "";
-		width: 8px;
-		height: 12px;
-		background: radial-gradient(circle, currentColor 1px, transparent 1.5px) 0 0 / 4px 4px;
+	[${HUNK_BAND_ATTRIBUTE}][${GUTTER_HOVERED_ATTRIBUTE}] {
+		background-color: color-mix(in srgb, currentColor 10%, transparent);
 	}
 
-	slot[${COMMENT_SLOT_ATTRIBUTE}] {
+	[${HUNK_BAND_ATTRIBUTE}][${HUNK_BAND_CHECKED_ATTRIBUTE}] {
+		background-color: color-mix(in srgb, var(--fill-pop-bg) 60%, transparent);
+	}
+
+	/* One card per view, moved to whichever number cell is hovered, carrying the acts that belong
+	   to a single line: the grip that drags it, and whatever the annotate slot brings. A translate
+	   of its own width parks its start edge on the cell's end, so the numbers stay readable. Either
+	   act alone is enough to be worth a card; with neither there is nothing to show. */
+	[${ACTIONS_ATTRIBUTE}] {
 		position: absolute;
 		inset-block: 0;
 		inset-inline-end: 0;
-		display: flex;
+		translate: 80% 0;
 		z-index: 4;
+		display: none;
+		align-items: center;
+		height: 24px;
+		margin-block: auto;
+		padding: 2px;
+		border-radius: var(--radius-card);
+		background-color: var(--bg-1);
+		box-shadow: var(--shadow-tooltip);
 	}
 
+	/* Written before the filled rule so that a line which cannot be dragged but can be annotated
+	   still gets its card. */
+	[${ACTIONS_ATTRIBUTE}][${ACTIONS_DRAGGABLE_ATTRIBUTE}] {
+		display: if(style(--gitbutler-diff-gutter-can-drag: true): flex; else: none);
+	}
+
+	[${ACTIONS_ATTRIBUTE}][${ACTIONS_FILLED_ATTRIBUTE}] {
+		display: flex;
+	}
+
+	/* The grip states itself quietly — the card is already an answer to hovering the line — and
+	   firms up only once the pointer is on the grip itself. It appears only on lines a drag would
+	   actually take: added and removed ones, never the context between them. */
+	[${GUTTER_DRAG_HANDLE_ATTRIBUTE}] {
+		/* The width below is the icon's own, so the rule beside it is added rather than taken. */
+		box-sizing: content-box;
+		display: none;
+		flex-shrink: 0;
+		align-items: center;
+		justify-content: center;
+		width: 16px;
+		height: 20px;
+		opacity: 0.3;
+		color: var(--text-1);
+		cursor: grab;
+	}
+
+	[${ACTIONS_DRAGGABLE_ATTRIBUTE}] > [${GUTTER_DRAG_HANDLE_ATTRIBUTE}] {
+		display: if(style(--gitbutler-diff-gutter-can-drag: true): flex; else: none);
+	}
+
+	[${GUTTER_DRAG_HANDLE_ATTRIBUTE}]:hover {
+		opacity: 0.6;
+	}
+
+	[${GUTTER_DRAG_HANDLE_ATTRIBUTE}] > svg {
+		width: 16px;
+		height: 16px;
+	}
+
+	/* The grip and whatever the annotate slot brings are separate acts, so a rule stands between
+	   them. It belongs to the grip, and so is gone on any line the grip itself is gone from. */
+	[${ACTIONS_ATTRIBUTE}][${ACTIONS_FILLED_ATTRIBUTE}] > [${GUTTER_DRAG_HANDLE_ATTRIBUTE}] {
+		margin-inline-end: 3px;
+		padding-inline-end: 3px;
+		border-inline-end: 1px solid var(--border-2);
+	}
+
+	slot[${COMMENT_SLOT_ATTRIBUTE}] {
+		display: flex;
+	}
+
+	/* A checkbox states itself only where checking is what a press would do. The rest of the number
+	   cell starts a line selection instead, so hovering it leaves the columns as they were: the hunk
+	   checkbox answers its own column anywhere down the hunk, the line checkbox only its own cell. */
 	slot[${GUTTER_SLOT_KIND_ATTRIBUTE}="hunk"][${GUTTER_HOVERED_ATTRIBUTE}],
-	[data-column-number]:hover > slot[${GUTTER_SLOT_KIND_ATTRIBUTE}="line"] {
+	slot[${GUTTER_SLOT_KIND_ATTRIBUTE}="line"]:hover {
 		--gitbutler-diff-gutter-checkbox-opacity: 1;
 	}
 
-	[data-column-number]:hover > [${GUTTER_DRAG_HANDLE_ATTRIBUTE}] {
-		--gitbutler-diff-gutter-drag-opacity: 1;
+	[data-indicators="bars"] [data-column-number]::before {
+		inset-inline-start: calc(
+			var(--gitbutler-diff-gutter-width) + var(--gitbutler-diff-gutter-seam)
+		);
 	}
 
-	[data-indicators="bars"] [data-column-number]::before {
-		inset-inline-start: var(--gitbutler-diff-gutter-width);
+	/* What the grip under the pointer is holding: the same dashed outline the drag itself paints,
+	   in a quieter weight. Declared first so a line that is already an operation source keeps the
+	   stronger mark. */
+	[${DRAG_PREVIEW_ATTRIBUTE}] {
+		outline: 1px dashed var(--border-2);
+		outline-offset: -1px;
 	}
 
 	[${OPERATION_SOURCE_ATTRIBUTE}] {
@@ -110,26 +226,117 @@ type GetHunkAddress = (target: DiffLineTarget) => HunkAddress | null;
 
 const removeGutterControls = (host: HTMLElement): void => {
 	for (const control of host.shadowRoot?.querySelectorAll(
-		`[${GUTTER_SLOT_ATTRIBUTE}], [${GUTTER_DRAG_HANDLE_ATTRIBUTE}], [${COMMENT_SLOT_ATTRIBUTE}]`,
+		`[${GUTTER_SLOT_ATTRIBUTE}], [${HUNK_BAND_ATTRIBUTE}], [${ACTIONS_ATTRIBUTE}]`,
 	) ?? [])
 		control.remove();
 };
 
-const clearOperationSources = (host: HTMLElement): void => {
+const clearLineMarks = (host: HTMLElement): void => {
 	for (const line of host.shadowRoot?.querySelectorAll<HTMLElement>(
-		`[${OPERATION_SOURCE_ATTRIBUTE}]`,
-	) ?? [])
+		`[${OPERATION_SOURCE_ATTRIBUTE}], [${DRAG_PREVIEW_ATTRIBUTE}]`,
+	) ?? []) {
 		line.removeAttribute(OPERATION_SOURCE_ATTRIBUTE);
+		line.removeAttribute(DRAG_PREVIEW_ATTRIBUTE);
+	}
 };
 
-const isOperationSourceLine = (sources: Array<Address> | null, line: HunkAddress): boolean =>
+const sourcesContainLine = (sources: Array<Address> | null, line: HunkAddress): boolean =>
 	sources?.some((source) => source._tag === "Hunk" && hunkAddressContainsLine(source, line)) ??
 	false;
 
-const keepDragHandlePointerDownOutOfLineSelection = (event: PointerEvent): void => {
+const sourcesKey = (sources: Array<Address> | null): string =>
+	sources?.map(addressIdentityKey).join("|") ?? "";
+
+const dragPreviewSourcesByHost = new Map<HTMLElement, Array<Address>>();
+const dragPreviewKeysByHost = new Map<HTMLElement, string>();
+const dragPreviewSyncByHost = new Map<HTMLElement, () => void>();
+
+/**
+ * Marks the lines the grip under the pointer would take, before the drag starts.
+ *
+ * Only the drag module knows that rule — checked lines, else the selection the line falls in, else
+ * the whole containing hunk — and only the gutter walk knows which element each address landed on,
+ * so the two meet here. Passing null clears the marks.
+ */
+export const setDiffDragPreviewSources = (
+	host: HTMLElement,
+	sources: Array<Address> | null,
+): void => {
+	const key = sourcesKey(sources);
+	if ((dragPreviewKeysByHost.get(host) ?? "") === key) return;
+
+	if (sources === null || sources.length === 0) {
+		dragPreviewSourcesByHost.delete(host);
+		dragPreviewKeysByHost.delete(host);
+	} else {
+		dragPreviewSourcesByHost.set(host, sources);
+		dragPreviewKeysByHost.set(host, key);
+	}
+	dragPreviewSyncByHost.get(host)?.();
+};
+
+const forgetDragPreview = (host: HTMLElement): void => {
+	dragPreviewSourcesByHost.delete(host);
+	dragPreviewKeysByHost.delete(host);
+	dragPreviewSyncByHost.delete(host);
+};
+
+const keepPointerDownOutOfLineSelection = (event: PointerEvent): void => {
 	// Pierre treats every descendant of a number cell as a line-selection target. The grip still
-	// needs its native dragstart to bubble to the registered host, but its initiating press does not.
+	// needs its native dragstart to bubble to the registered host, but its initiating press does not,
+	// and pressing the hunk band is a check rather than a selection.
 	event.stopPropagation();
+};
+
+type ActionsCard = {
+	card: HTMLElement;
+	slot: HTMLSlotElement;
+};
+
+const createActionsCard = (slotName: string): ActionsCard => {
+	const card = document.createElement("span");
+	card.setAttribute(ACTIONS_ATTRIBUTE, "");
+
+	const dragHandle = document.createElement("span");
+	dragHandle.setAttribute(GUTTER_DRAG_HANDLE_ATTRIBUTE, "");
+	dragHandle.setAttribute("aria-hidden", "true");
+	// The grip is what the native drag starts on; the host below it is what Atlaskit registered.
+	dragHandle.setAttribute("draggable", "true");
+	dragHandle.addEventListener("pointerdown", keepPointerDownOutOfLineSelection);
+	// Bundled app asset, same source the Icon component draws from.
+	dragHandle.innerHTML = assert(icons.get("drag-vertical"));
+
+	const slot = document.createElement("slot");
+	slot.name = slotName;
+	slot.setAttribute(COMMENT_SLOT_ATTRIBUTE, "");
+	// Comments are optional; the card shows for them alone when dragging is unavailable.
+	slot.addEventListener("slotchange", () => {
+		card.toggleAttribute(ACTIONS_FILLED_ATTRIBUTE, slot.assignedNodes().length > 0);
+	});
+
+	card.append(dragHandle, slot);
+	return { card, slot };
+};
+
+const ensureHunkBand = (
+	cell: HTMLElement,
+	groupKey: string,
+	onClick: (event: MouseEvent) => void,
+): HTMLElement => {
+	let band = cell.querySelector<HTMLElement>(`:scope > [${HUNK_BAND_ATTRIBUTE}]`);
+	if (!band) {
+		band = document.createElement("span");
+		band.setAttribute(HUNK_BAND_ATTRIBUTE, "");
+		band.setAttribute("aria-hidden", "true");
+		cell.prepend(band);
+	}
+	// Set on every pass, not just on creation: a band that outlives a hot reload is reused, and a
+	// band that only looks clickable is worse than none. The listener is a stable reference, so
+	// re-adding it is a no-op.
+	band.setAttribute(GUTTER_GROUP_ATTRIBUTE, groupKey);
+	band.addEventListener("pointerdown", keepPointerDownOutOfLineSelection);
+	band.addEventListener("click", onClick);
+	return band;
 };
 
 const createGutterStore = <T>(
@@ -137,6 +344,13 @@ const createGutterStore = <T>(
 	getLineAddress: () => GetHunkAddress,
 	getParentAddress: () => GetHunkAddress,
 	getOperationSourceAddresses: () => Array<Address> | null,
+	getOnCheckHunk: () => (
+		address: HunkAddress,
+		lineAddresses: Array<Extract<Address, { _tag: "Hunk" }>>,
+		shiftKey: boolean,
+	) => void,
+	getOnCheckLine: () => (address: HunkAddress, shiftKey: boolean) => void,
+	isAddressChecked: (address: Extract<Address, { _tag: "Hunk" }>) => boolean,
 ): InternalGutterStore<T> => {
 	const listeners = new Set<() => void>();
 	const targets = new Map<HTMLElement, GutterTarget>();
@@ -144,7 +358,10 @@ const createGutterStore = <T>(
 	const controlsByGroupByHost = new Map<HTMLElement, Map<string, Array<HTMLElement>>>();
 	const removeHoverListenersByHost = new Map<HTMLElement, () => void>();
 	const itemIdsByHost = new Map<HTMLElement, string>();
-	const commentSlotsByHost = new Map<HTMLElement, HTMLSlotElement>();
+	const actionCardsByHost = new Map<HTMLElement, ActionsCard>();
+	const bandsByGroupByHost = new Map<HTMLElement, Map<string, Array<HTMLElement>>>();
+	const checkedGroupsByHost = new Map<HTMLElement, Set<string>>();
+	const checkableGroupsByHost = new Map<HTMLElement, Set<string>>();
 	const commentTargetsByHost = new Map<HTMLElement, DiffLineTarget>();
 	let nextKey = 0;
 	let notificationQueued = false;
@@ -161,6 +378,7 @@ const createGutterStore = <T>(
 		});
 	};
 
+	/** The hunk whose own column the pointer is in, which is the only hunk the gutter answers for. */
 	const setHoveredGroup = (host: HTMLElement, groupKey: string | undefined): void => {
 		const previousGroupKey = hoveredGroupKeys.get(host);
 		if (previousGroupKey === groupKey) return;
@@ -175,27 +393,203 @@ const createGutterStore = <T>(
 		else hoveredGroupKeys.set(host, groupKey);
 	};
 
-	const gutterGroupKeyFromEvent = (event: Event): string | undefined => {
-		const cell = event
+	const paintBand = (band: HTMLElement, checked: boolean): void => {
+		band.toggleAttribute(HUNK_BAND_CHECKED_ATTRIBUTE, checked);
+	};
+
+	// The column is one tall checkbox: its band answers a click anywhere down the hunk with the same
+	// act as the checkbox at the top of it. A drag never produces a click, so the two gestures do not
+	// have to be told apart here.
+	const handleBandClick = (event: MouseEvent): void => {
+		const band = event.currentTarget;
+		if (!(band instanceof HTMLElement)) return;
+
+		const groupKey = band.getAttribute(GUTTER_GROUP_ATTRIBUTE);
+		const root = band.getRootNode();
+		const host = root instanceof ShadowRoot ? root.host : null;
+		if (groupKey === null || !(host instanceof HTMLElement)) return;
+		if (!checkableGroupsByHost.get(host)?.has(groupKey)) return;
+
+		const group = targets.get(host)?.groups.find((candidate) => candidate.key === groupKey);
+		if (!group) return;
+
+		// This lands inside a line-number cell, but it is not a line selection.
+		event.stopPropagation();
+		event.preventDefault();
+		getOnCheckHunk()(
+			group.parentAddress,
+			group.lines.map((line) => line.address),
+			event.shiftKey,
+		);
+	};
+
+	const setGroupChecked = (host: HTMLElement, groupKey: string, checked: boolean): void => {
+		const checkedGroups = checkedGroupsByHost.get(host) ?? new Set<string>();
+		if (checkedGroups.has(groupKey) === checked) return;
+
+		if (checked) checkedGroups.add(groupKey);
+		else checkedGroups.delete(groupKey);
+		checkedGroupsByHost.set(host, checkedGroups);
+		for (const band of bandsByGroupByHost.get(host)?.get(groupKey) ?? []) paintBand(band, checked);
+	};
+
+	const setGroupCheckable = (host: HTMLElement, groupKey: string, checkable: boolean): void => {
+		const groups = checkableGroupsByHost.get(host) ?? new Set<string>();
+		if (groups.has(groupKey) === checkable) return;
+
+		if (checkable) groups.add(groupKey);
+		else groups.delete(groupKey);
+		checkableGroupsByHost.set(host, groups);
+	};
+
+	/**
+	 * The hunk whose column the pointer is in: its band, or the checkbox standing in the band's
+	 * place on the hunk's first line. Anywhere else in the number cell answers a press with a line
+	 * selection, so the gutter has nothing to offer there.
+	 */
+	const hunkColumnGroupKeyFromEvent = (event: Event): string | undefined => {
+		const column = event
 			.composedPath()
 			.find(
 				(target): target is HTMLElement =>
-					target instanceof HTMLElement && target.hasAttribute("data-column-number"),
+					target instanceof HTMLElement &&
+					(target.hasAttribute(HUNK_BAND_ATTRIBUTE) ||
+						target.getAttribute(GUTTER_SLOT_KIND_ATTRIBUTE) === "hunk"),
 			);
-		return (
-			cell
-				?.querySelector<HTMLSlotElement>(`:scope > slot[${GUTTER_SLOT_ATTRIBUTE}]`)
-				?.getAttribute(GUTTER_GROUP_ATTRIBUTE) ?? undefined
-		);
+		return column?.getAttribute(GUTTER_GROUP_ATTRIBUTE) ?? undefined;
+	};
+
+	/**
+	 * A press on a line checkbox that has since moved onto other lines, painting each one it
+	 * crosses to whatever the press did to the line it started on.
+	 */
+	let checkDrag: {
+		host: HTMLElement;
+		startAddress: Extract<Address, { _tag: "Hunk" }>;
+		startKey: string;
+		checked: boolean;
+		painted: Set<string>;
+		moved: boolean;
+	} | null = null;
+
+	const lineAddressAtPoint = (
+		host: HTMLElement,
+		clientX: number,
+		clientY: number,
+	): Extract<Address, { _tag: "Hunk" }> | null => {
+		const shadowRoot = host.shadowRoot;
+		const itemId = itemIdsByHost.get(host);
+		if (!shadowRoot || itemId === undefined) return null;
+
+		const element = shadowRoot.elementFromPoint(clientX, clientY);
+		if (!(element instanceof HTMLElement)) return null;
+
+		// A checkbox is the host's own child assigned to a slot, so the cell holding it is only an
+		// ancestor of the slot, never of the checkbox.
+		const cell =
+			element.closest<HTMLElement>("[data-column-number]") ??
+			element.assignedSlot?.closest<HTMLElement>("[data-column-number]") ??
+			null;
+		if (!cell) return null;
+
+		const target = diffLineTargetFromElement({ element: cell, itemId });
+		if (target?.lineType !== "change") return null;
+
+		const address = getLineAddress()(target);
+		return address ? hunkAddress(address) : null;
+	};
+
+	const paintCheckDragLine = (address: Extract<Address, { _tag: "Hunk" }>): void => {
+		if (!checkDrag) return;
+
+		const key = addressIdentityKey(address);
+		if (checkDrag.painted.has(key)) return;
+
+		checkDrag.painted.add(key);
+		// Each line is set, not toggled, so a line the press already agrees with is left alone.
+		if (isAddressChecked(address) !== checkDrag.checked) getOnCheckLine()(address, false);
+	};
+
+	const handleCheckDragMove = (event: PointerEvent): void => {
+		if (!checkDrag) return;
+
+		const address = lineAddressAtPoint(checkDrag.host, event.clientX, event.clientY);
+		if (!address) return;
+
+		const key = addressIdentityKey(address);
+		// Until the press reaches another line it is still a click, and the checkbox answers it.
+		if (!checkDrag.moved && key === checkDrag.startKey) return;
+
+		if (!checkDrag.moved) {
+			checkDrag.moved = true;
+			checkDrag.host.setAttribute(CHECK_DRAG_ATTRIBUTE, "");
+			paintCheckDragLine(checkDrag.startAddress);
+		}
+		paintCheckDragLine(address);
+	};
+
+	/**
+	 * Opens the paint gesture. It sits on the slot rather than the tree above it because Pierre
+	 * reads a press on any descendant of a number cell as the start of a line-range selection, and
+	 * its listener is on an ancestor of this one.
+	 */
+	const handleLineSlotPointerDown = (event: Event): void => {
+		if (!(event instanceof PointerEvent) || event.button !== 0) return;
+
+		const slot = event.currentTarget;
+		if (!(slot instanceof HTMLElement)) return;
+
+		const root = slot.getRootNode();
+		const host = root instanceof ShadowRoot ? root.host : null;
+		if (!(host instanceof HTMLElement)) return;
+
+		const address = lineAddressAtPoint(host, event.clientX, event.clientY);
+		if (!address) return;
+
+		event.stopPropagation();
+		endCheckDrag();
+		checkDrag = {
+			host,
+			startAddress: address,
+			startKey: addressIdentityKey(address),
+			checked: !isAddressChecked(address),
+			painted: new Set(),
+			moved: false,
+		};
+		window.addEventListener("pointermove", handleCheckDragMove);
+		window.addEventListener("pointerup", endCheckDrag);
+		window.addEventListener("pointercancel", endCheckDrag);
+	};
+
+	const swallowCheckDragClick = (event: Event): void => {
+		event.stopPropagation();
+		event.preventDefault();
+	};
+
+	const endCheckDrag = (): void => {
+		if (!checkDrag) return;
+
+		const { host, moved } = checkDrag;
+		checkDrag = null;
+		host.removeAttribute(CHECK_DRAG_ATTRIBUTE);
+		window.removeEventListener("pointermove", handleCheckDragMove);
+		window.removeEventListener("pointerup", endCheckDrag);
+		window.removeEventListener("pointercancel", endCheckDrag);
+		if (!moved) return;
+
+		// The press still lands as a click on the checkbox it started on, which would undo the first
+		// line the drag painted.
+		window.addEventListener("click", swallowCheckDragClick, { capture: true, once: true });
+		setTimeout(() => window.removeEventListener("click", swallowCheckDragClick, { capture: true }));
 	};
 
 	const ensureHoverListeners = (host: HTMLElement, shadowRoot: ShadowRoot): void => {
 		if (removeHoverListenersByHost.has(host)) return;
 
-		// CSS can see the hovered number cell, but cannot match its dynamic hunk key to the parent
-		// checkbox at the top of the group. The line checkbox and drag handle stay local to :hover.
+		// CSS can see the hovered column, but cannot match its dynamic hunk key to the rest of the
+		// hunk's own band or to the checkbox at the top of it. The line checkbox stays local to :hover.
 		const handlePointerOver = (event: Event) => {
-			setHoveredGroup(host, gutterGroupKeyFromEvent(event));
+			setHoveredGroup(host, hunkColumnGroupKeyFromEvent(event));
 
 			const cell = event
 				.composedPath()
@@ -207,20 +601,31 @@ const createGutterStore = <T>(
 			if (!cell || itemId === undefined) return;
 
 			const target = diffLineTargetFromElement({ element: cell, itemId });
-			const slot = commentSlotsByHost.get(host);
-			if (!target || !slot) return;
+			const actions = actionCardsByHost.get(host);
+			if (!target || !actions) return;
 
 			commentTargetsByHost.set(host, target);
-			cell.appendChild(slot);
+			// A context line has no hunk to hand over, so the card arrives there without its grip.
+			actions.card.toggleAttribute(ACTIONS_DRAGGABLE_ATTRIBUTE, target.lineType === "change");
+			// Pointer events keep arriving as the pointer crosses the card's own children.
+			// Re-appending the card to the cell it already sits in would take it out of the
+			// document and put it back, losing the hover its grip is styled by.
+			if (actions.card.parentElement !== cell) cell.appendChild(actions.card);
 		};
 		const handlePointerLeave = () => {
 			setHoveredGroup(host, undefined);
 			commentTargetsByHost.delete(host);
-			commentSlotsByHost.get(host)?.remove();
+			actionCardsByHost.get(host)?.card.remove();
 		};
 		shadowRoot.addEventListener("pointerover", handlePointerOver);
 		host.addEventListener("pointerleave", handlePointerLeave);
+		// The drag module tells us what the grip holds; repainting it is this walk's job.
+		dragPreviewSyncByHost.set(host, () => {
+			const itemId = itemIdsByHost.get(host);
+			if (itemId !== undefined) syncTarget(host, itemId);
+		});
 		removeHoverListenersByHost.set(host, () => {
+			if (checkDrag?.host === host) endCheckDrag();
 			shadowRoot.removeEventListener("pointerover", handlePointerOver);
 			host.removeEventListener("pointerleave", handlePointerLeave);
 		});
@@ -232,10 +637,14 @@ const createGutterStore = <T>(
 		hoveredGroupKeys.delete(host);
 		controlsByGroupByHost.delete(host);
 		itemIdsByHost.delete(host);
-		commentSlotsByHost.delete(host);
+		actionCardsByHost.delete(host);
+		bandsByGroupByHost.delete(host);
+		checkedGroupsByHost.delete(host);
+		checkableGroupsByHost.delete(host);
 		commentTargetsByHost.delete(host);
+		forgetDragPreview(host);
 		removeGutterControls(host);
-		clearOperationSources(host);
+		clearLineMarks(host);
 		if (!targets.delete(host)) return;
 		publish();
 	};
@@ -249,23 +658,24 @@ const createGutterStore = <T>(
 
 		const existing = targets.get(host);
 		const key = existing?.key ?? nextKey++;
-		let commentSlot = commentSlotsByHost.get(host);
-		if (!commentSlot) {
-			commentSlot = document.createElement("slot");
-			commentSlot.name = `gitbutler-diff-comment-${key}`;
-			commentSlot.setAttribute(COMMENT_SLOT_ATTRIBUTE, "");
-			commentSlotsByHost.set(host, commentSlot);
+		let actions = actionCardsByHost.get(host);
+		if (!actions) {
+			actions = createActionsCard(`gitbutler-diff-comment-${key}`);
+			actionCardsByHost.set(host, actions);
 		}
 		const comment =
 			existing?.comment ??
 			({
-				slotName: commentSlot.name,
+				slotName: actions.slot.name,
 				getTarget: () => commentTargetsByHost.get(host),
 			} satisfies GutterTarget["comment"]);
 		const groupsByKey = new Map<string, GutterCheckboxGroup>();
 		const controlsByGroup = new Map<string, Array<HTMLElement>>();
+		const bandsByGroup = new Map<string, Array<HTMLElement>>();
+		const checkedGroups = checkedGroupsByHost.get(host);
 		const usedControls = new Set<HTMLElement>();
 		const operationSources = getOperationSourceAddresses();
+		const dragPreviewSources = dragPreviewSourcesByHost.get(host) ?? null;
 		itemIdsByHost.set(host, itemId);
 		ensureHoverListeners(host, shadowRoot);
 
@@ -289,7 +699,11 @@ const createGutterStore = <T>(
 					: null;
 			codeLine?.toggleAttribute(
 				OPERATION_SOURCE_ATTRIBUTE,
-				isOperationSourceLine(operationSources, checkedLineAddress),
+				sourcesContainLine(operationSources, checkedLineAddress),
+			);
+			codeLine?.toggleAttribute(
+				DRAG_PREVIEW_ATTRIBUTE,
+				sourcesContainLine(dragPreviewSources, checkedLineAddress),
 			);
 			const groupKey = addressIdentityKey(checkedParentAddress);
 			const lineSlotName = `gitbutler-diff-gutter-line-${key}-${index}`;
@@ -337,28 +751,29 @@ const createGutterStore = <T>(
 			}
 			slot.name = lineSlotName;
 			slot.setAttribute(GUTTER_GROUP_ATTRIBUTE, groupKey);
+			// A stable reference, so a slot that outlives a hot reload takes this only once.
+			slot.addEventListener("pointerdown", handleLineSlotPointerDown);
 			usedControls.add(slot);
 
-			let dragHandle = cell.querySelector<HTMLElement>(
-				`:scope > [${GUTTER_DRAG_HANDLE_ATTRIBUTE}]`,
-			);
-			if (!dragHandle) {
-				dragHandle = document.createElement("span");
-				dragHandle.setAttribute(GUTTER_DRAG_HANDLE_ATTRIBUTE, "");
-				dragHandle.setAttribute("aria-hidden", "true");
-				dragHandle.addEventListener("pointerdown", keepDragHandlePointerDownOutOfLineSelection);
-				cell.prepend(dragHandle);
-			}
-			dragHandle.setAttribute(GUTTER_GROUP_ATTRIBUTE, groupKey);
-			usedControls.add(dragHandle);
+			const band = ensureHunkBand(cell, groupKey, handleBandClick);
+			paintBand(band, checkedGroups?.has(groupKey) ?? false);
+			band.toggleAttribute(GUTTER_HOVERED_ATTRIBUTE, hoveredGroupKeys.get(host) === groupKey);
+			const groupBands = bandsByGroup.get(groupKey);
+			if (groupBands) groupBands.push(band);
+			else bandsByGroup.set(groupKey, [band]);
+			const groupControls = controlsByGroup.get(groupKey);
+			if (groupControls) groupControls.push(band);
+			else controlsByGroup.set(groupKey, [band]);
+			usedControls.add(band);
 		}
 		controlsByGroupByHost.set(host, controlsByGroup);
+		bandsByGroupByHost.set(host, bandsByGroup);
 		const hoveredGroupKey = hoveredGroupKeys.get(host);
 		if (hoveredGroupKey !== undefined && !controlsByGroup.has(hoveredGroupKey))
 			setHoveredGroup(host, undefined);
 
 		for (const control of shadowRoot.querySelectorAll<HTMLElement>(
-			`slot[${GUTTER_SLOT_ATTRIBUTE}], [${GUTTER_DRAG_HANDLE_ATTRIBUTE}]`,
+			`slot[${GUTTER_SLOT_ATTRIBUTE}], [${HUNK_BAND_ATTRIBUTE}]`,
 		))
 			if (!usedControls.has(control)) control.remove();
 
@@ -393,6 +808,8 @@ const createGutterStore = <T>(
 
 	return {
 		getSnapshot: () => snapshot,
+		setGroupChecked,
+		setGroupCheckable,
 		onPostRender: (host, instance, phase, context) => {
 			if (phase === "unmount" || context.type !== "diff") removeTarget(host);
 			else syncTarget(host, context.item.id);
@@ -409,14 +826,18 @@ const createGutterStore = <T>(
 		cleanUp: () => {
 			for (const host of targets.keys()) {
 				removeHoverListenersByHost.get(host)?.();
+				forgetDragPreview(host);
 				removeGutterControls(host);
-				clearOperationSources(host);
+				clearLineMarks(host);
 			}
 			removeHoverListenersByHost.clear();
 			hoveredGroupKeys.clear();
 			controlsByGroupByHost.clear();
 			itemIdsByHost.clear();
-			commentSlotsByHost.clear();
+			actionCardsByHost.clear();
+			bandsByGroupByHost.clear();
+			checkedGroupsByHost.clear();
+			checkableGroupsByHost.clear();
 			commentTargetsByHost.clear();
 			targets.clear();
 			snapshot = [];
@@ -449,6 +870,10 @@ export const useDiffGutterCheckboxes = <T>(
 	const appStore = useAppStore();
 	const projectIdRef = useRef(projectId);
 	projectIdRef.current = projectId;
+	const onCheckHunkRef = useRef(onCheckHunk);
+	onCheckHunkRef.current = onCheckHunk;
+	const onCheckLineRef = useRef(onCheckLine);
+	onCheckLineRef.current = onCheckLine;
 
 	const storeRef = useRef<InternalGutterStore<T>>(null);
 	storeRef.current ??= createGutterStore(
@@ -458,6 +883,14 @@ export const useDiffGutterCheckboxes = <T>(
 		() =>
 			getOperationSources(
 				projectSlice.selectors.selectPendingOperation(appStore.getState(), projectIdRef.current),
+			),
+		() => onCheckHunkRef.current,
+		() => onCheckLineRef.current,
+		(address) =>
+			projectSlice.selectors.selectAddressChecked(
+				appStore.getState(),
+				projectIdRef.current,
+				address,
 			),
 	);
 	const store = storeRef.current;

--- a/apps/lite/ui/src/routes/project/$id/workspace/diff-gutter.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/diff-gutter.ts
@@ -29,6 +29,7 @@ const ACTIONS_ATTRIBUTE = "data-gitbutler-diff-actions";
 const ACTIONS_FILLED_ATTRIBUTE = "data-gitbutler-diff-actions-filled";
 const ACTIONS_DRAGGABLE_ATTRIBUTE = "data-gitbutler-diff-actions-draggable";
 const DRAG_PREVIEW_ATTRIBUTE = "data-gitbutler-diff-drag-preview";
+const DRAG_COUNT_ATTRIBUTE = "data-gitbutler-diff-drag-count";
 const HUNK_BAND_ATTRIBUTE = "data-gitbutler-diff-hunk-band";
 const HUNK_BAND_CHECKED_ATTRIBUTE = "data-checked";
 const COMMENT_SLOT_ATTRIBUTE = "data-gitbutler-diff-comment-slot";
@@ -53,6 +54,8 @@ export const diffGutterUnsafeCSS = `
 		   controls sit over it — so it is painted in the surface the other break reveals, which is
 		   Pierre's own and not the app's, since the two part ways in the dark theme. */
 		--gitbutler-diff-gutter-seam: 2px;
+		/* The inset of the card's first control, which the count above it lines up with. */
+		--gitbutler-diff-actions-padding: 2px;
 		--gitbutler-diff-gutter-seam-color: var(--diffs-background, var(--bg-1));
 	}
 
@@ -128,7 +131,7 @@ export const diffGutterUnsafeCSS = `
 		align-items: center;
 		height: 24px;
 		margin-block: auto;
-		padding: 2px;
+		padding: var(--gitbutler-diff-actions-padding);
 		border-radius: var(--radius-card);
 		background-color: var(--bg-1);
 		box-shadow: var(--shadow-tooltip);
@@ -172,6 +175,30 @@ export const diffGutterUnsafeCSS = `
 	[${GUTTER_DRAG_HANDLE_ATTRIBUTE}] > svg {
 		width: 16px;
 		height: 16px;
+	}
+
+	/* What the grip is holding, in the words its drag preview will repeat. It floats clear of the
+	   card rather than sitting in it, so reaching the grip never moves what the pointer is aiming
+	   at. Only a hovered grip fills it, and an empty one is not there at all. */
+	[${DRAG_COUNT_ATTRIBUTE}] {
+		position: absolute;
+		inset-block-end: calc(100% + 4px);
+		/* Clear of the card's own padding, so the count and the grip share a leading edge. */
+		inset-inline-start: var(--gitbutler-diff-actions-padding);
+		z-index: 1;
+		padding: 2px 6px;
+		border-radius: var(--radius-card);
+		background-color: var(--bg-1);
+		box-shadow: var(--shadow-tooltip);
+		color: var(--text-1);
+		font-size: 11px;
+		line-height: 1.4;
+		white-space: nowrap;
+		pointer-events: none;
+	}
+
+	[${DRAG_COUNT_ATTRIBUTE}]:empty {
+		display: none;
 	}
 
 	/* The grip and whatever the annotate slot brings are separate acts, so a rule stands between
@@ -248,6 +275,7 @@ const sourcesKey = (sources: Array<Address> | null): string =>
 	sources?.map(addressIdentityKey).join("|") ?? "";
 
 const dragPreviewSourcesByHost = new Map<HTMLElement, Array<Address>>();
+const dragPreviewLabelsByHost = new Map<HTMLElement, string>();
 const dragPreviewKeysByHost = new Map<HTMLElement, string>();
 const dragPreviewSyncByHost = new Map<HTMLElement, () => void>();
 
@@ -261,6 +289,7 @@ const dragPreviewSyncByHost = new Map<HTMLElement, () => void>();
 export const setDiffDragPreviewSources = (
 	host: HTMLElement,
 	sources: Array<Address> | null,
+	label?: string,
 ): void => {
 	const key = sourcesKey(sources);
 	if ((dragPreviewKeysByHost.get(host) ?? "") === key) return;
@@ -268,9 +297,12 @@ export const setDiffDragPreviewSources = (
 	if (sources === null || sources.length === 0) {
 		dragPreviewSourcesByHost.delete(host);
 		dragPreviewKeysByHost.delete(host);
+		dragPreviewLabelsByHost.delete(host);
 	} else {
 		dragPreviewSourcesByHost.set(host, sources);
 		dragPreviewKeysByHost.set(host, key);
+		if (label === undefined) dragPreviewLabelsByHost.delete(host);
+		else dragPreviewLabelsByHost.set(host, label);
 	}
 	dragPreviewSyncByHost.get(host)?.();
 };
@@ -278,6 +310,7 @@ export const setDiffDragPreviewSources = (
 const forgetDragPreview = (host: HTMLElement): void => {
 	dragPreviewSourcesByHost.delete(host);
 	dragPreviewKeysByHost.delete(host);
+	dragPreviewLabelsByHost.delete(host);
 	dragPreviewSyncByHost.delete(host);
 };
 
@@ -290,6 +323,7 @@ const keepPointerDownOutOfLineSelection = (event: PointerEvent): void => {
 
 type ActionsCard = {
 	card: HTMLElement;
+	count: HTMLElement;
 	slot: HTMLSlotElement;
 };
 
@@ -306,6 +340,10 @@ const createActionsCard = (slotName: string): ActionsCard => {
 	// Bundled app asset, same source the Icon component draws from.
 	dragHandle.innerHTML = assert(icons.get("drag-vertical"));
 
+	const count = document.createElement("span");
+	count.setAttribute(DRAG_COUNT_ATTRIBUTE, "");
+	count.setAttribute("aria-hidden", "true");
+
 	const slot = document.createElement("slot");
 	slot.name = slotName;
 	slot.setAttribute(COMMENT_SLOT_ATTRIBUTE, "");
@@ -314,8 +352,8 @@ const createActionsCard = (slotName: string): ActionsCard => {
 		card.toggleAttribute(ACTIONS_FILLED_ATTRIBUTE, slot.assignedNodes().length > 0);
 	});
 
-	card.append(dragHandle, slot);
-	return { card, slot };
+	card.append(dragHandle, count, slot);
+	return { card, count, slot };
 };
 
 const ensureHunkBand = (
@@ -669,6 +707,7 @@ const createGutterStore = <T>(
 				slotName: actions.slot.name,
 				getTarget: () => commentTargetsByHost.get(host),
 			} satisfies GutterTarget["comment"]);
+		actions.count.textContent = dragPreviewLabelsByHost.get(host) ?? "";
 		const groupsByKey = new Map<string, GutterCheckboxGroup>();
 		const controlsByGroup = new Map<string, Array<HTMLElement>>();
 		const bandsByGroup = new Map<string, Array<HTMLElement>>();

--- a/apps/lite/ui/src/routes/project/$id/workspace/diff-gutter.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/diff-gutter.ts
@@ -60,7 +60,30 @@ export const diffGutterUnsafeCSS = `
 	}
 
 	[data-column-number] {
-		padding-left: calc(2ch + var(--gitbutler-diff-gutter-width));
+		/* Where the gutter's business ends and the file's own margin begins. */
+		--gitbutler-diff-number-start: var(--gitbutler-diff-gutter-width);
+		--gitbutler-diff-number-film: transparent;
+
+		padding-left: calc(2ch + var(--gitbutler-diff-number-start));
+		background-image: linear-gradient(
+			to right,
+			transparent var(--gitbutler-diff-number-start),
+			var(--gitbutler-diff-number-film) var(--gitbutler-diff-number-start)
+		);
+	}
+
+	/* A press on the numbers selects lines, so they take a film under the pointer to say so. It is
+	   mixed from the line's own foreground, the way the checkboxes are, so a changed line answers in
+	   its own colour rather than in ink. The gutter has its own answers, and a pointer resting on
+	   one of them is not asking for this. */
+	[data-column-number]:hover:not(
+			:has(
+				> slot[${GUTTER_SLOT_ATTRIBUTE}]:hover,
+				> [${HUNK_BAND_ATTRIBUTE}]:hover,
+				> [${ACTIONS_ATTRIBUTE}]:hover
+			)
+		) {
+		--gitbutler-diff-number-film: color-mix(in srgb, currentColor 10%, transparent);
 	}
 
 	/* The gutter ends where the file's own margin begins, so the line's fill stops short of the
@@ -68,16 +91,23 @@ export const diffGutterUnsafeCSS = `
 	   controls sit above this, and the fill is the row's, so only a stripe of the surface can
 	   separate them. */
 	[data-indicators="bars"] [data-column-number] {
-		padding-left: calc(
-			2ch + var(--gitbutler-diff-gutter-width) + var(--gitbutler-diff-gutter-seam)
+		--gitbutler-diff-number-start: calc(
+			var(--gitbutler-diff-gutter-width) + var(--gitbutler-diff-gutter-seam)
 		);
-		background-image: linear-gradient(
-			to right,
-			transparent var(--gitbutler-diff-gutter-width),
-			var(--gitbutler-diff-gutter-seam-color) var(--gitbutler-diff-gutter-width),
-			var(--gitbutler-diff-gutter-seam-color) calc(var(--gitbutler-diff-gutter-width) + var(--gitbutler-diff-gutter-seam)),
-			transparent calc(var(--gitbutler-diff-gutter-width) + var(--gitbutler-diff-gutter-seam))
-		);
+
+		background-image:
+			linear-gradient(
+				to right,
+				transparent var(--gitbutler-diff-gutter-width),
+				var(--gitbutler-diff-gutter-seam-color) var(--gitbutler-diff-gutter-width),
+				var(--gitbutler-diff-gutter-seam-color) var(--gitbutler-diff-number-start),
+				transparent var(--gitbutler-diff-number-start)
+			),
+			linear-gradient(
+				to right,
+				transparent var(--gitbutler-diff-number-start),
+				var(--gitbutler-diff-number-film) var(--gitbutler-diff-number-start)
+			);
 	}
 
 	slot[${GUTTER_SLOT_ATTRIBUTE}] {

--- a/apps/lite/ui/src/routes/project/$id/workspace/diff-hunk-drag.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/diff-hunk-drag.ts
@@ -21,7 +21,7 @@ import { createRoot } from "react-dom/client";
 import type { DragData } from "./DragData.ts";
 import { parseDragData } from "./DragData.ts";
 import { DragPreview } from "./OperationSourceC.tsx";
-import { addressesLabel } from "./addressLabel.ts";
+import { addressesLabel, hunkAddressesLabel } from "./addressLabel.ts";
 import { setDiffDragPreviewSources } from "./diff-gutter.ts";
 import { diffLineTargetFromElement, type DiffLineTarget } from "./diff-line-target.ts";
 
@@ -135,12 +135,21 @@ export const useDiffHunkDrag = <T>({
 					(target) =>
 						target instanceof HTMLElement && target.hasAttribute(HUNK_DRAG_HANDLE_ATTRIBUTE),
 				);
-			setDiffDragPreviewSources(
-				host,
+			const sources =
 				overHandle && event instanceof PointerEvent && configRef.current.canDrag()
 					? resolveSources(event)
-					: null,
-			);
+					: null;
+			// The same words the drag preview will carry, so the grip answers before it is pressed.
+			// Checked sources can reach past hunks, and those are only ever counted.
+			let label: string | undefined;
+			if (sources) {
+				const hunks = sources.flatMap((source) => (source._tag === "Hunk" ? [source] : []));
+				label =
+					hunks.length === sources.length
+						? hunkAddressesLabel(hunks)
+						: `${sources.length.toLocaleString()} items`;
+			}
+			setDiffDragPreviewSources(host, sources, label);
 		};
 		const handlePointerLeave = () => setDiffDragPreviewSources(host, null);
 		const shadowRoot = host.shadowRoot;

--- a/apps/lite/ui/src/routes/project/$id/workspace/diff-hunk-drag.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/diff-hunk-drag.ts
@@ -11,10 +11,7 @@ import {
 import { pointerTransfer } from "#ui/operations/pending-operation.ts";
 import { projectSlice } from "#ui/projects/state.ts";
 import { useAppStore } from "#ui/store.ts";
-import {
-	draggable,
-	type ElementGetFeedbackArgs,
-} from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
+import { draggable } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
 import { centerUnderPointer } from "@atlaskit/pragmatic-drag-and-drop/element/center-under-pointer";
 import { setCustomNativeDragPreview } from "@atlaskit/pragmatic-drag-and-drop/element/set-custom-native-drag-preview";
 import type { CodeViewOptions } from "@pierre/diffs";
@@ -25,6 +22,7 @@ import type { DragData } from "./DragData.ts";
 import { parseDragData } from "./DragData.ts";
 import { DragPreview } from "./OperationSourceC.tsx";
 import { addressesLabel } from "./addressLabel.ts";
+import { setDiffDragPreviewSources } from "./diff-gutter.ts";
 import { diffLineTargetFromElement, type DiffLineTarget } from "./diff-line-target.ts";
 
 const HUNK_DRAG_HANDLE_ATTRIBUTE = "data-hunk-drag-handle";
@@ -36,10 +34,12 @@ type Registration = {
 	cleanup: () => void;
 };
 
+type Point = { clientX: number; clientY: number };
+
 const hunkLineAtPoint = (
 	host: HTMLElement,
 	itemId: string,
-	input: ElementGetFeedbackArgs["input"],
+	input: Point,
 ): DiffLineTarget | null => {
 	const element = host.shadowRoot?.elementFromPoint(input.clientX, input.clientY);
 	const lineNumberElement = element
@@ -48,21 +48,6 @@ const hunkLineAtPoint = (
 	if (!(lineNumberElement instanceof HTMLElement)) return null;
 
 	return diffLineTargetFromElement({ element: lineNumberElement, itemId });
-};
-
-const syncHunkDragHandles = (host: HTMLElement): void => {
-	const shadowRoot = host.shadowRoot;
-	if (!shadowRoot) return;
-
-	for (const element of shadowRoot.querySelectorAll<HTMLElement>(`[${HUNK_DRAG_HANDLE_ATTRIBUTE}]`))
-		element.setAttribute("draggable", "true");
-};
-
-const cleanHunkDragHandles = (host: HTMLElement): void => {
-	for (const element of host.shadowRoot?.querySelectorAll<HTMLElement>(
-		`[${HUNK_DRAG_HANDLE_ATTRIBUTE}]`,
-	) ?? [])
-		element.removeAttribute("draggable");
 };
 
 export const useDiffHunkDrag = <T>({
@@ -110,11 +95,9 @@ export const useDiffHunkDrag = <T>({
 		if (phase === "unmount") {
 			existing?.cleanup();
 			registrations.delete(host);
-			cleanHunkDragHandles(host);
 			return;
 		}
 
-		syncHunkDragHandles(host);
 		if (existing) {
 			existing.itemId = context.item.id;
 			return;
@@ -124,7 +107,7 @@ export const useDiffHunkDrag = <T>({
 			itemId: context.item.id,
 			cleanup: () => {},
 		};
-		const resolveSources = (input: ElementGetFeedbackArgs["input"]): DragData["sources"] | null => {
+		const resolveSources = (input: Point): DragData["sources"] | null => {
 			const target = hunkLineAtPoint(host, registration.itemId, input);
 			if (!target) return null;
 
@@ -143,7 +126,28 @@ export const useDiffHunkDrag = <T>({
 				: [hunkAddress(hunk)];
 		};
 
-		registration.cleanup = draggable({
+		// The grip says what it holds before it is pressed: the same lines the drop would move,
+		// which is the containing hunk unless checked lines or the selection widen it.
+		const handlePointerOver = (event: Event) => {
+			const overHandle = event
+				.composedPath()
+				.some(
+					(target) =>
+						target instanceof HTMLElement && target.hasAttribute(HUNK_DRAG_HANDLE_ATTRIBUTE),
+				);
+			setDiffDragPreviewSources(
+				host,
+				overHandle && event instanceof PointerEvent && configRef.current.canDrag()
+					? resolveSources(event)
+					: null,
+			);
+		};
+		const handlePointerLeave = () => setDiffDragPreviewSources(host, null);
+		const shadowRoot = host.shadowRoot;
+		shadowRoot?.addEventListener("pointerover", handlePointerOver);
+		host.addEventListener("pointerleave", handlePointerLeave);
+
+		const stopDragging = draggable({
 			element: host,
 			canDrag: ({ input }) => configRef.current.canDrag() && resolveSources(input) !== null,
 			getInitialData: ({ input }): DragData => ({
@@ -173,6 +177,8 @@ export const useDiffHunkDrag = <T>({
 				});
 			},
 			onDragStart: ({ source }) => {
+				// The pending operation paints its own sources from here on.
+				setDiffDragPreviewSources(host, null);
 				const config = configRef.current;
 				const sources = parseDragData(source.data)?.sources;
 				if (!sources) return;
@@ -195,6 +201,13 @@ export const useDiffHunkDrag = <T>({
 			},
 		});
 
+		registration.cleanup = () => {
+			stopDragging();
+			shadowRoot?.removeEventListener("pointerover", handlePointerOver);
+			host.removeEventListener("pointerleave", handlePointerLeave);
+			setDiffDragPreviewSources(host, null);
+		};
+
 		// Native drag originates on the marked shadow children. Atlaskit still needs the host
 		// registered because the composed dragstart event is retargeted to it at document.
 		host.removeAttribute("draggable");
@@ -204,10 +217,7 @@ export const useDiffHunkDrag = <T>({
 	useLayoutEffect(() => {
 		const registrations = registrationsRef.current;
 		return () => {
-			for (const [host, registration] of registrations) {
-				registration.cleanup();
-				cleanHunkDragHandles(host);
-			}
+			for (const registration of registrations.values()) registration.cleanup();
 			registrations.clear();
 		};
 	}, []);


### PR DESCRIPTION
Related [GB-1912](https://linear.app/gitbutler/issue/GB-1912/update-the-diff-design)

https://github.com/user-attachments/assets/a30b8910-e167-49f9-a789-ce1c5420f4fd

## Columns

- The hunk column and the line column are now the same width and the first sits flush with the panel edge — the 6px lead-in it used to start past is gone.
- The hunk column is a band drawn down the whole hunk rather than a checkbox on its first line, and answers a click anywhere along it, so nothing has to explain how far a hunk check reaches.
- A 2px seam parts the gutter from the change bar, the same break the numbers already kept from the code. It is painted in `--diffs-background` rather than the app's own surface token, because the two part ways in the dark theme.

## Hover

- A checkbox states itself only where checking is what a press would do: the hunk checkbox answers its own column anywhere down the hunk, the line checkbox only its own cell. Hovering the numbers, which starts a line selection, leaves both alone.
- The numbers answer a hover of their own — Pierre gives an interactive number column a pointer cursor and nothing else. The film is mixed from the line's own foreground, so a changed line answers in its own colour.
- Gutter checkboxes lost their ring: in the gutter a checkbox is the whole cell, so it answers with fill alone.

https://github.com/user-attachments/assets/116ef24a-aa99-4f47-b5d7-99596917ffae


## The floating card

- The grip and the annotate button leave the line-number cells for a single floating card, one per view, that follows the hovered cell and parks past the gutter's end edge — which is what freed the third gutter column.
- The grip is ruled off from the annotate button beside it, and appears only on lines a drag would actually take.
- Hovering the grip says what it holds — `+3 -1 lines`, the words the drag preview will repeat — in a chip floating clear of the card, so reaching the grip never moves what the pointer is aiming at.

https://github.com/user-attachments/assets/7a45f710-1b21-4707-9545-d0e52b43f852


https://github.com/user-attachments/assets/10fc848a-4a1b-4dc4-8c29-9cd9a5e99685


## Marks

- A run of marked lines closes as one box instead of one box per line. The mark left the outline it was for a box laid over the line, since outlines paint last and neighbouring ones can never join; marked lines are siblings, so CSS alone tells where a run starts and ends.

## Checking by drag

- Press a line checkbox and drag: every line crossed is set to whatever the press did to the line it started on. Start on an unchecked line and the run is checked, start on a checked one and it clears.

https://github.com/user-attachments/assets/379cab32-a6e3-4f4e-a8d8-a9c7eeb19993


https://github.com/user-attachments/assets/f591e538-bce2-49b4-8060-17f867720869


## Test plan

- Verified against the running app over the DevTools protocol: column geometry, hover states (including forced `:hover` on real checkboxes and cells), the drag-to-check gesture end to end, the grip's count chip, and run grouping.
- `pnpm oxlint`, `pnpm prettier --check`, `tsgo -p ui/tsconfig.json --noEmit`, and the Lite unit suite (248 tests) all pass locally.
- Light theme only; the seam colour is the variable the existing numbers/code break already reveals.
