### PR TITLE
Send test results to tests.but.dev instead of Buildkite Test Engine

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -152,7 +152,13 @@ jobs:
         if: ${{ steps.playwright-cache.outputs.cache-hit != 'true' }}
       - run: pnpm test
         env:
-          BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_SUITE_TOKEN_VITEST }}
+          BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.TEST_RESULTS_TOKEN_VITEST }}
+          BUILDKITE_ANALYTICS_BASE_URL: https://tests.but.dev/v1/uploads
+          # Normalized run identity, matching what the curl-based uploads send, so
+          # every suite reports the same key/branch/sha for one CI run.
+          BUILDKITE_ANALYTICS_KEY: ${{ github.run_id }}-${{ github.run_attempt }}
+          BUILDKITE_ANALYTICS_BRANCH: ${{ github.head_ref || github.ref_name }}
+          BUILDKITE_ANALYTICS_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
   but-sdk-build-check:
     needs: changes
@@ -325,11 +331,11 @@ jobs:
         run: cargo nextest run --workspace --exclude gitbutler-tauri --exclude but-api-macros-tests --profile ci
       - name: Run doctests
         run: cargo test --doc --workspace --exclude gitbutler-tauri --exclude but-api-macros-tests
-      - name: Upload results to Buildkite Test Engine
+      - name: Upload results to tests.but.dev
         if: ${{ always() && !cancelled() }}
         continue-on-error: true
         env:
-          BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_SUITE_TOKEN_CARGO }}
+          BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.TEST_RESULTS_TOKEN_CARGO }}
           RUN_BRANCH: ${{ github.head_ref || github.ref_name }}
           RUN_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           RUN_KEY: ${{ github.run_id }}-${{ github.run_attempt }}
@@ -349,7 +355,7 @@ jobs:
             -F "tags[framework]=nextest" \
             -F "tags[language]=rust" \
             -F "tags[type]=unit" \
-            https://analytics-api.buildkite.com/v1/uploads
+            https://tests.but.dev/v1/uploads
       # It's intentional to use 'name equals run-script' so it's easy to re-run locally on failure.
       - run: make test-modern-but
       - name: test vendored
@@ -725,7 +731,13 @@ jobs:
       - name: run playwright tests
         run: pnpm test:ct
         env:
-          BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_SUITE_TOKEN_PLAYWRIGHT_CT }}
+          BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.TEST_RESULTS_TOKEN_PLAYWRIGHT_CT }}
+          BUILDKITE_ANALYTICS_BASE_URL: https://tests.but.dev/v1/uploads
+          # Normalized run identity, matching what the curl-based uploads send, so
+          # every suite reports the same key/branch/sha for one CI run.
+          BUILDKITE_ANALYTICS_KEY: ${{ github.run_id }}-${{ github.run_attempt }}
+          BUILDKITE_ANALYTICS_BRANCH: ${{ github.head_ref || github.ref_name }}
+          BUILDKITE_ANALYTICS_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ !cancelled() }}
         with:
@@ -777,7 +789,13 @@ jobs:
         # Concurrent Electron launches can fail during renderer bootstrap on GitHub's Linux runners.
         run: xvfb-run --auto-servernum pnpm --filter @gitbutler/lite test:e2e --forbid-only --workers=1
         env:
-          BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_SUITE_TOKEN_LITE_E2E }}
+          BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.TEST_RESULTS_TOKEN_LITE_E2E }}
+          BUILDKITE_ANALYTICS_BASE_URL: https://tests.but.dev/v1/uploads
+          # Normalized run identity, matching what the curl-based uploads send, so
+          # every suite reports the same key/branch/sha for one CI run.
+          BUILDKITE_ANALYTICS_KEY: ${{ github.run_id }}-${{ github.run_attempt }}
+          BUILDKITE_ANALYTICS_BRANCH: ${{ github.head_ref || github.ref_name }}
+          BUILDKITE_ANALYTICS_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -80,11 +80,11 @@ jobs:
         if: ${{ github.ref != 'refs/heads/master' }}
         run: xvfb-run pnpm test:e2e:blackbox
 
-      - name: Upload results to Buildkite Test Engine
+      - name: Upload results to tests.but.dev
         if: ${{ github.ref != 'refs/heads/master' && always() && !cancelled() }}
         continue-on-error: true
         env:
-          BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_SUITE_TOKEN_BLACKBOX }}
+          BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.TEST_RESULTS_TOKEN_BLACKBOX }}
           RUN_BRANCH: ${{ github.head_ref || github.ref_name }}
           RUN_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           RUN_KEY: ${{ github.run_id }}-${{ github.run_attempt }}
@@ -104,7 +104,7 @@ jobs:
             -F "tags[framework]=webdriverio" \
             -F "tags[language]=typescript" \
             -F "tags[type]=e2e" \
-            https://analytics-api.buildkite.com/v1/uploads
+            https://tests.but.dev/v1/uploads
       - name: Flatten test results
         if: failure()
         run: |
@@ -191,7 +191,13 @@ jobs:
       - name: Run Playwright tests
         run: pnpm exec turbo run test:e2e:playwright -- --shard="$PLAYWRIGHT_SHARD"
         env:
-          BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_SUITE_TOKEN_PLAYWRIGHT }}
+          BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.TEST_RESULTS_TOKEN_PLAYWRIGHT }}
+          BUILDKITE_ANALYTICS_BASE_URL: https://tests.but.dev/v1/uploads
+          # Normalized run identity, matching what the curl-based uploads send, so
+          # every suite reports the same key/branch/sha for one CI run.
+          BUILDKITE_ANALYTICS_KEY: ${{ github.run_id }}-${{ github.run_attempt }}
+          BUILDKITE_ANALYTICS_BRANCH: ${{ github.head_ref || github.ref_name }}
+          BUILDKITE_ANALYTICS_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           PLAYWRIGHT_SHARD: ${{ matrix.shard }}/${{ strategy.job-total }}
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()


### PR DESCRIPTION
Cut all six CI test suites over from Buildkite Test Engine to the in-house test-results service at https://tests.but.dev.

The service is wire-compatible with Buildkite's `/v1/uploads`, so this is env-only — no reporter or code changes:

- **Collector jobs** (vitest, playwright, playwright-ct, lite-e2e): set `BUILDKITE_ANALYTICS_BASE_URL`, swap the token secret, and pin `BUILDKITE_ANALYTICS_KEY/BRANCH/SHA` to the run identity the curl jobs already send — this makes all six suites agree on key/branch/sha per CI run, which the cross-suite commit view and same-commit flake detection depend on.
- **curl jobs** (cargo nextest, webdriverio blackbox): new upload URL and token secret.

Note on naming: the `BUILDKITE_ANALYTICS_*` env vars stay for now because they are the `buildkite-test-collector` package's configuration interface — renaming them would break the reporters. We plan to switch to our own test collector at a future date, at which point these become `TEST_ANALYTICS_*`-style names and the Buildkite package dependency goes away.

**Before merging**: the six `TEST_RESULTS_TOKEN_*` repo secrets must exist (values live in SSM under `/test-results/token-<suite>`). If merged without them, tests still pass but results stop flowing to either backend.

After merge, Buildkite stops receiving data immediately; rollback is reverting this commit.
