### PR TITLE
Fix mutations without an actionName

### DIFF
--- a/apps/desktop/src/lib/branches/branchEndpoints.test.ts
+++ b/apps/desktop/src/lib/branches/branchEndpoints.test.ts
@@ -43,6 +43,15 @@ describe("buildBranchEndpoints", () => {
 		]);
 	});
 
+	test("names the switch-back mutation", () => {
+		const endpoints = buildBranchEndpoints(createEndpointBuilder());
+
+		expect(endpoints.switchBackToWorkspace.extraOptions).toEqual({
+			command: "switch_back_to_workspace",
+			actionName: "Switch Back to Workspace",
+		});
+	});
+
 	test("defaults workspace fetch action to auto", () => {
 		const endpoints = buildBranchEndpoints(createEndpointBuilder());
 

--- a/apps/desktop/src/lib/branches/branchEndpoints.ts
+++ b/apps/desktop/src/lib/branches/branchEndpoints.ts
@@ -30,6 +30,8 @@ export function buildBranchEndpoints(build: BackendEndpointBuilder) {
 			providesTags: [providesType(ReduxTag.WorkspaceFetchStatus)],
 		}),
 		workspaceFetchFromRemotes: build.mutation<void, { projectId: string; action?: string }>({
+			// No actionName: auto-fetch runs this on a timer, and a named event
+			// would sidestep the per-command sampling of tauri_command events.
 			extraOptions: { command: "workspace_fetch_from_remotes" },
 			query: ({ projectId, action }) => ({
 				projectId,
@@ -73,7 +75,7 @@ export function buildBranchEndpoints(build: BackendEndpointBuilder) {
 			],
 		}),
 		switchBackToWorkspace: build.mutation<BaseBranch, { projectId: string }>({
-			extraOptions: { command: "switch_back_to_workspace" },
+			extraOptions: { command: "switch_back_to_workspace", actionName: "Switch Back to Workspace" },
 			query: (args) => args,
 			invalidatesTags: [
 				invalidatesType(ReduxTag.ForgeProvider),

--- a/apps/desktop/src/lib/git/gitEndpoints.ts
+++ b/apps/desktop/src/lib/git/gitEndpoints.ts
@@ -57,6 +57,9 @@ export function buildGitEndpoints(build: BackendEndpointBuilder) {
 		}),
 
 		// ── Git Hooks ───────────────────────────────────────────────
+		// No actionName on hook mutations: a failing hook resolves with
+		// status "failure" instead of rejecting, so a named Successful/Failed
+		// event would mislabel real hook failures.
 		preCommitDiffspecs: build.mutation<HookStatus, { projectId: string; changes: DiffSpec[] }>({
 			extraOptions: { command: "pre_commit_hook_diffspecs" },
 			query: (args) => args,

--- a/apps/desktop/src/lib/mode/modeEndpoints.test.ts
+++ b/apps/desktop/src/lib/mode/modeEndpoints.test.ts
@@ -1,0 +1,21 @@
+import { buildModeEndpoints } from "$lib/mode/modeEndpoints";
+import { describe, expect, test } from "vitest";
+import type { BackendEndpointBuilder } from "$lib/state/backendApi";
+
+function createEndpointBuilder(): BackendEndpointBuilder {
+	return {
+		mutation: (definition) => definition,
+		query: (definition) => definition,
+	} as BackendEndpointBuilder;
+}
+
+describe("buildModeEndpoints", () => {
+	test("names the enter-edit-mode mutation", () => {
+		const endpoints = buildModeEndpoints(createEndpointBuilder());
+
+		expect(endpoints.enterEditMode.extraOptions).toEqual({
+			command: "enter_edit_mode",
+			actionName: "Enter Edit Mode",
+		});
+	});
+});

--- a/apps/desktop/src/lib/mode/modeEndpoints.ts
+++ b/apps/desktop/src/lib/mode/modeEndpoints.ts
@@ -6,7 +6,7 @@ import type { ConflictEntryPresence, HeadAndMode, HeadSha, TreeChange } from "@g
 export function buildModeEndpoints(build: BackendEndpointBuilder) {
 	return {
 		enterEditMode: build.mutation<void, { projectId: string; commitId: string; stackId: string }>({
-			extraOptions: { command: "enter_edit_mode" },
+			extraOptions: { command: "enter_edit_mode", actionName: "Enter Edit Mode" },
 			query: (args) => args,
 			invalidatesTags: [
 				invalidatesList(ReduxTag.InitalEditListing),

--- a/apps/desktop/src/lib/state/customHooks.svelte.test.ts
+++ b/apps/desktop/src/lib/state/customHooks.svelte.test.ts
@@ -1,0 +1,94 @@
+import { butlerModule } from "$lib/state/butlerModule";
+import { ReduxTag } from "$lib/state/tags";
+import { configureStore } from "@reduxjs/toolkit";
+import { buildCreateApi, coreModule } from "@reduxjs/toolkit/query";
+import { describe, expect, test, vi } from "vitest";
+import type { TauriBaseQueryFn } from "$lib/state/backendQuery";
+import type { HookContext } from "$lib/state/context";
+import type { PostHogWrapper } from "$lib/telemetry/posthog";
+
+function setup() {
+	const capture = vi.fn();
+	const ctx: HookContext = {
+		getState: () => store.getState(),
+		getDispatch: () => store.dispatch,
+		posthog: { capture } as unknown as PostHogWrapper,
+	};
+	async function baseQuery(
+		args: Parameters<TauriBaseQueryFn>[0],
+		_api: Parameters<TauriBaseQueryFn>[1],
+		_extraOptions: Parameters<TauriBaseQueryFn>[2],
+	): Promise<Awaited<ReturnType<TauriBaseQueryFn>>> {
+		if ((args as { fail?: boolean } | undefined)?.fail) {
+			return { error: { origin: "ipc", name: "API error", message: "it broke" } };
+		}
+		return { data: undefined };
+	}
+	const api = buildCreateApi(
+		coreModule(),
+		butlerModule(ctx),
+	)({
+		reducerPath: "backend",
+		tagTypes: Object.values(ReduxTag),
+		baseQuery,
+		endpoints: (build) => ({
+			unnamedMutation: build.mutation<void, { fail?: boolean }>({
+				extraOptions: { command: "some_command" },
+				query: (args) => args,
+			}),
+			namedMutation: build.mutation<void, { fail?: boolean }>({
+				extraOptions: { command: "some_command", actionName: "Some Action" },
+				query: (args) => args,
+			}),
+		}),
+	});
+	const store = configureStore({
+		reducer: { [api.reducerPath]: api.reducer },
+		middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(api.middleware),
+	});
+	return { api, capture };
+}
+
+function capturedEventNames(capture: ReturnType<typeof vi.fn>) {
+	return capture.mock.calls.map((call) => call[0]);
+}
+
+describe("mutation tracking", () => {
+	test("a failed unnamed mutation emits tauri_command but no legacy event", async () => {
+		const { api, capture } = setup();
+
+		await expect(api.endpoints.unnamedMutation.mutate({ fail: true })).rejects.toMatchObject({
+			message: "it broke",
+		});
+
+		expect(capturedEventNames(capture)).toEqual(["tauri_command"]);
+		expect(capture).toHaveBeenCalledWith(
+			"tauri_command",
+			expect.objectContaining({ command: "some_command", failure: true }),
+		);
+	});
+
+	test("a successful unnamed mutation emits tauri_command but no legacy event", async () => {
+		const { api, capture } = setup();
+
+		await api.endpoints.unnamedMutation.mutate({});
+
+		expect(capturedEventNames(capture)).toEqual(["tauri_command"]);
+	});
+
+	test("a named mutation still emits the legacy events", async () => {
+		const { api, capture } = setup();
+
+		await api.endpoints.namedMutation.mutate({});
+		await expect(api.endpoints.namedMutation.mutate({ fail: true })).rejects.toMatchObject({
+			message: "it broke",
+		});
+
+		expect(capturedEventNames(capture)).toEqual([
+			"tauri_command",
+			"Some Action Successful",
+			"tauri_command",
+			"Some Action Failed",
+		]);
+	});
+});

--- a/apps/desktop/src/lib/state/customHooks.svelte.ts
+++ b/apps/desktop/src/lib/state/customHooks.svelte.ts
@@ -380,15 +380,17 @@ export function buildMutationHook<
 		});
 
 		/** TODO: How long do we need to send these duplicates? */
-		const legacyName = args.failure ? `${actionName} Failed` : `${actionName} Successful`;
-		posthog?.capture(legacyName, {
-			...args.properties,
-			actionName,
-			command,
-			durationMs,
-			failure: args.failure,
-			error: args.error,
-		});
+		if (actionName !== undefined) {
+			const legacyName = args.failure ? `${actionName} Failed` : `${actionName} Successful`;
+			posthog?.capture(legacyName, {
+				...args.properties,
+				actionName,
+				command,
+				durationMs,
+				failure: args.failure,
+				error: args.error,
+			});
+		}
 	}
 
 	/**


### PR DESCRIPTION
Mutations that omit `actionName` produced a duplicate named `undefined Failed` / `undefined Successful`, collapsing unrelated failures under one meaningless name. The canonical `tauri_command` capture already carries the command, failure flag, duration, and parsed error, so the duplicate is now skipped when no name is set.

Switch back to workspace and enter edit mode now declare proper action names. Fetch stays unnamed on purpose: auto-fetch runs it on a timer, and a named event would sidestep the per-command sampling applied to `tauri_command`. Hook mutations also stay unnamed: a failing hook resolves with a failure status instead of rejecting, so a named Successful/Failed event would mislabel real hook failures.

Fixes GB-1929