### PR TITLE
Fix test-results uploads lost since #15628 merged

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -37,15 +37,16 @@
 		"playwright:install:ct": {},
 		"test": {
 			"dependsOn": ["package", "playwright:install:unit"],
-			"passThroughEnv": ["BUILDKITE_ANALYTICS_TOKEN"]
+			"passThroughEnv": ["BUILDKITE_ANALYTICS_TOKEN", "BUILDKITE_ANALYTICS_BASE_URL", "BUILDKITE_ANALYTICS_KEY", "BUILDKITE_ANALYTICS_BRANCH", "BUILDKITE_ANALYTICS_SHA"]
 		},
 		"test:e2e:playwright": {
 			"env": ["PLAYWRIGHT_BROWSERS_PATH"],
-			"passThroughEnv": ["BUILDKITE_ANALYTICS_TOKEN"],
+			"passThroughEnv": ["BUILDKITE_ANALYTICS_TOKEN", "BUILDKITE_ANALYTICS_BASE_URL", "BUILDKITE_ANALYTICS_KEY", "BUILDKITE_ANALYTICS_BRANCH", "BUILDKITE_ANALYTICS_SHA"],
 			"dependsOn": ["package"]
 		},
 		"test:ct": {
 			"env": ["PLAYWRIGHT_BROWSERS_PATH"],
+			"passThroughEnv": ["BUILDKITE_ANALYTICS_TOKEN", "BUILDKITE_ANALYTICS_BASE_URL", "BUILDKITE_ANALYTICS_KEY", "BUILDKITE_ANALYTICS_BRANCH", "BUILDKITE_ANALYTICS_SHA"],
 			"dependsOn": ["package", "playwright:install:ct"]
 		},
 		"//#globallint": {


### PR DESCRIPTION
Turbo (strict env mode) only passed `BUILDKITE_ANALYTICS_TOKEN` into the `test` and `test:e2e:playwright` tasks. The `BUILDKITE_ANALYTICS_BASE_URL/KEY/BRANCH/SHA` vars added by the tests.but.dev cutover were stripped, so the collector fell back to Buildkite's API with the new token → 401 ("A test suite could not be found with the supplied API token") → uploads silently dropped. Symptom: only cargo, blackbox, and lite-e2e results reach tests.but.dev (they don't go through turbo).

Also: `test:ct` never passed the token through at all — playwright-ct uploads appear to have been silently dead even in the Buildkite era.

Verified by running `turbo run test --filter=@gitbutler/web` against a local collection server: the upload now arrives with full run identity.