### PR TITLE
Keep sync quiet when the forge integration is disconnected

### DIFF
--- a/apps/desktop/src/lib/forge/listingService.svelte.ts
+++ b/apps/desktop/src/lib/forge/listingService.svelte.ts
@@ -1,3 +1,4 @@
+import { parseError } from "$lib/error/parser";
 import {
 	mapForgeReviewToPullRequest,
 	type ForgeReview,
@@ -69,7 +70,18 @@ export class ListingService {
 	async refresh(projectId: string): Promise<void> {
 		// Force a live fetch so the DB cache is refreshed, then invalidate the
 		// cached listing so its subscribers re-read the just-updated data.
-		await this.backendApi.endpoints.listPrsLive.fetch(projectId);
+		//
+		// A deliberately disconnected forge fails the live fetch with
+		// `ForgeNotAuthenticated` (no stored credentials) — there is nothing
+		// to refresh then, so keep the cache-derived view without surfacing
+		// an error, matching how the backend serves cached reads in that
+		// state. Other failures (expired token, API errors) reach the caller.
+		try {
+			await this.backendApi.endpoints.listPrsLive.fetch(projectId);
+		} catch (err) {
+			if (parseError(err).code === "ForgeNotAuthenticated") return;
+			throw err;
+		}
 		this.dispatch(this.backendApi.util.invalidateTags([invalidatesList(ReduxTag.PullRequests)]));
 	}
 }

--- a/e2e/playwright/tests/fetch.spec.ts
+++ b/e2e/playwright/tests/fetch.spec.ts
@@ -1,3 +1,4 @@
+import { forgeErrorBody, githubForgeInfo, mockForge } from "../src/forge.ts";
 import { openWorkspace } from "../src/setup.ts";
 import { test } from "../src/test.ts";
 import { clickByTestId, getByTestId } from "../src/util.ts";
@@ -9,6 +10,10 @@ function git(pathToRepo: string, args: string[]): string {
 		cwd: pathToRepo,
 		encoding: "utf8",
 	}).trim();
+}
+
+function backendSuccess(subject: unknown): string {
+	return JSON.stringify({ type: "success", subject });
 }
 
 async function workspaceFetchRequests(page: Page, action?: string): Promise<Request> {
@@ -50,6 +55,84 @@ test.describe("manual workspace fetch", () => {
 		expect((await fetchRequest).postDataJSON()).toMatchObject({
 			action: "modal",
 		});
+	});
+
+	test("repeated sync stays quiet when the forge is not authenticated", async ({
+		page,
+		gitbutler,
+	}) => {
+		await gitbutler.runScript("project-with-remote-branches.sh");
+		await mockForge(page, { forge_info: githubForgeInfo() });
+
+		// Model a disconnected integration: the live refresh fails with
+		// `ForgeNotAuthenticated` while cached reads serve stale data.
+		let liveReviewRequests = 0;
+		await page.route("**/list_reviews", async (route) => {
+			const isLive = route.request().postDataJSON()?.cacheConfig === "noCache";
+			if (isLive) liveReviewRequests += 1;
+			await route.fulfill({
+				status: 200,
+				contentType: "application/json",
+				body: isLive
+					? forgeErrorBody({
+							code: "ForgeNotAuthenticated",
+							message: "Not authenticated with GitHub.",
+						})
+					: backendSuccess([]),
+			});
+		});
+
+		await openWorkspace(page);
+		const syncButton = getByTestId(page, "sync-button");
+		for (let attempt = 0; attempt < 2; attempt += 1) {
+			const fetchStatusResponse = page.waitForResponse(
+				(response) =>
+					response.url().endsWith("/workspace_fetch_status") &&
+					response.request().method() === "POST",
+			);
+			await clickByTestId(page, "sync-button");
+			await fetchStatusResponse;
+			await expect(syncButton).not.toContainText("Fetching...");
+		}
+
+		// The refresh is still attempted every sync; only the auth error is muted.
+		expect(liveReviewRequests).toBe(2);
+		// Match both the classified copy ("You are not logged in to your
+		// forge...") and the raw backend message ("Not authenticated with
+		// GitHub."), so the test still catches a regression where the error
+		// slips through unclassified and toasts with the raw wording.
+		await expect(
+			page.getByTestId("toast-info-message").filter({ hasText: /not (logged in|authenticated)/i }),
+		).toHaveCount(0);
+	});
+
+	test("sync surfaces review refresh failures that are not auth-related", async ({
+		page,
+		gitbutler,
+	}) => {
+		await gitbutler.runScript("project-with-remote-branches.sh");
+		await mockForge(page, { forge_info: githubForgeInfo() });
+
+		await page.route("**/list_reviews", async (route) => {
+			const isLive = route.request().postDataJSON()?.cacheConfig === "noCache";
+			await route.fulfill({
+				status: 200,
+				contentType: "application/json",
+				body: isLive
+					? forgeErrorBody({ code: "GitHubTokenExpired", message: "401: bad credentials" })
+					: backendSuccess([]),
+			});
+		});
+
+		await openWorkspace(page);
+		const fetchStatusResponse = page.waitForResponse("**/workspace_fetch_status");
+		await clickByTestId(page, "sync-button");
+		await fetchStatusResponse;
+		await expect(getByTestId(page, "sync-button")).not.toContainText("Fetching...");
+
+		await expect(
+			page.getByTestId("toast-info-message").filter({ hasText: "token appears expired" }),
+		).toHaveCount(1);
 	});
 
 	test("sync button shows the persisted workspace fetch timestamp after reload", async ({


### PR DESCRIPTION
Syncing forces a live review-listing refresh, which fails with a GitHub/GitLab auth error toast on every sync when the forge integration is deliberately disconnected (or was never connected).

`ListingService.refresh` now treats `ForgeNotAuthenticated` as nothing-to-refresh: that code is only produced before any network request leaves the machine, when no credentials are stored, and the backend already serves cached review reads quietly in the same state. Every other failure — expired or invalid tokens, API errors — still surfaces, as do auth errors from explicit PR actions.

Fixes GB-1930