### PR TITLE
Follow the CLI samplingRate pattern for desktop event sampling

### DIFF
--- a/apps/desktop/src/lib/telemetry/posthog.test.ts
+++ b/apps/desktop/src/lib/telemetry/posthog.test.ts
@@ -1,0 +1,42 @@
+import { sampleEvent } from "$lib/telemetry/posthog";
+import { describe, expect, test } from "vitest";
+
+describe("sampleEvent", () => {
+	test("stamps samplingRate on emitted sampled events", () => {
+		expect(sampleEvent("tauri_command", { command: "head_info", failure: false }, 0.01)).toEqual({
+			command: "head_info",
+			failure: false,
+			samplingRate: 0.05,
+		});
+	});
+
+	test("drops successful sampled events above the rate", () => {
+		expect(sampleEvent("tauri_command", { command: "head_info", failure: false }, 0.5)).toBeNull();
+		expect(
+			sampleEvent(
+				"tauri_command",
+				{ command: "workspace_fetch_from_remotes", failure: false },
+				0.5,
+			),
+		).toBeNull();
+	});
+
+	test("failures bypass sampling and are stamped with rate 1", () => {
+		for (const draw of [0.99, 1]) {
+			expect(
+				sampleEvent(
+					"tauri_command",
+					{ command: "workspace_fetch_from_remotes", failure: true },
+					draw,
+				),
+			).toEqual({ command: "workspace_fetch_from_remotes", failure: true, samplingRate: 1 });
+		}
+	});
+
+	test("leaves unsampled events untouched", () => {
+		expect(sampleEvent("tauri_command", { command: "stack_details" }, 0.99)).toEqual({
+			command: "stack_details",
+		});
+		expect(sampleEvent("some_event", undefined, 0.99)).toEqual({});
+	});
+});

--- a/apps/desktop/src/lib/telemetry/posthog.ts
+++ b/apps/desktop/src/lib/telemetry/posthog.ts
@@ -19,11 +19,11 @@ export class PostHogWrapper {
 	) {}
 
 	capture(eventName: string, properties?: Properties) {
-		if (shouldIgnoreEvent(eventName, properties)) return;
+		const sampled = sampleEvent(eventName, properties);
+		if (!sampled) return;
 		const context = this.eventContext.getAll();
-		const newProperties = { ...context, ...properties };
-		const skipClientRateLimiting =
-			eventName === "tauri_command" && properties?.command !== undefined;
+		const newProperties = { ...context, ...sampled };
+		const skipClientRateLimiting = eventName === "tauri_command" && sampled.command !== undefined;
 		this._instance?.capture(eventName, newProperties, {
 			skip_client_rate_limiting: skipClientRateLimiting,
 		});
@@ -105,31 +105,37 @@ export class PostHogWrapper {
 	}
 }
 
-type EventDescription = {
-	name: string;
-	command: string;
-};
+/**
+ * Sampling rates for successful high-volume `tauri_command` events, in (0, 1].
+ *
+ * Events with `failure: true` bypass this policy and are emitted with a rate
+ * of 1. In PostHog, estimate successful command totals with
+ * `sum(1 / coalesce(samplingRate, 1))`.
+ */
+const SAMPLED_COMMANDS = new Map<string, number>([
+	["head_info", 0.05],
+	["get_base_branch_data", 0.5],
+	["workspace_fetch_from_remotes", 0.5],
+]);
 
-const HIGH_VOLUME_EVENTS: EventDescription[] = [{ name: "tauri_command", command: "head_info" }];
-
-const MID_VOLUME_EVENTS: EventDescription[] = [
-	{ name: "tauri_command", command: "get_base_branch_data" },
-	{ name: "tauri_command", command: "workspace_fetch_from_remotes" },
-];
-
-function shouldIgnoreEvent(eventName: string, properties: Properties | undefined): boolean {
-	if (HIGH_VOLUME_EVENTS.some((e) => e.name === eventName && e.command === properties?.command)) {
-		if (Math.random() < 0.95) {
-			return true;
-		}
-	}
-
-	if (MID_VOLUME_EVENTS.some((e) => e.name === eventName && e.command === properties?.command)) {
-		if (Math.random() < 0.5) {
-			return true;
-		}
-	}
-	return false;
+/**
+ * Applies per-command sampling: returns the properties to capture (stamped
+ * with the effective `samplingRate` for sampled commands), or null when the
+ * event should be dropped.
+ */
+export function sampleEvent(
+	eventName: string,
+	properties: Properties | undefined,
+	draw = Math.random(),
+): Properties | null {
+	const rate =
+		eventName === "tauri_command" && typeof properties?.command === "string"
+			? SAMPLED_COMMANDS.get(properties.command)
+			: undefined;
+	if (rate === undefined) return properties ?? {};
+	if (properties?.failure === true) return { ...properties, samplingRate: 1 };
+	if (draw >= rate) return null;
+	return { ...properties, samplingRate: rate };
 }
 
 export enum OnboardingEvent {


### PR DESCRIPTION
Sampled tauri_command events now carry their effective samplingRate so dashboard counts can be weighted by 1/samplingRate, and events with failure: true bypass sampling entirely so failure fidelity is no longer halved. Rates themselves are unchanged.

Fixes GB-1931