### PR TITLE
Ignore buildkite-test-collector in knip for apps/lite

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -32,6 +32,9 @@
 			],
 			"includeEntryExports": true,
 			"ignoreDependencies": [
+				// Referenced as a string reporter in e2e/playwright.config.ts,
+				// which knip's static analysis cannot see.
+				"buildkite-test-collector",
 				"babel-plugin-react-compiler",
 				"@gitbutler/design-core",
 				"@tanstack/eslint-plugin-query",


### PR DESCRIPTION
knip:non-prod fails on master since the Buildkite Test Engine cutover: buildkite-test-collector is referenced only as a string reporter name in e2e/playwright.config.ts, which knip cannot see. Companion to #15634, which fixes the prettier half of the same lint breakage.