### PR TITLE
Sample failure events at the command rate

### DIFF
--- a/apps/desktop/src/lib/telemetry/posthog.test.ts
+++ b/apps/desktop/src/lib/telemetry/posthog.test.ts
@@ -21,16 +21,21 @@ describe("sampleEvent", () => {
 		).toBeNull();
 	});
 
-	test("failures bypass sampling and are stamped with rate 1", () => {
-		for (const draw of [0.99, 1]) {
-			expect(
-				sampleEvent(
-					"tauri_command",
-					{ command: "workspace_fetch_from_remotes", failure: true },
-					draw,
-				),
-			).toEqual({ command: "workspace_fetch_from_remotes", failure: true, samplingRate: 1 });
-		}
+	test("samples failures like successes", () => {
+		expect(
+			sampleEvent(
+				"tauri_command",
+				{ command: "workspace_fetch_from_remotes", failure: true },
+				0.01,
+			),
+		).toEqual({ command: "workspace_fetch_from_remotes", failure: true, samplingRate: 0.5 });
+		expect(
+			sampleEvent(
+				"tauri_command",
+				{ command: "workspace_fetch_from_remotes", failure: true },
+				0.99,
+			),
+		).toBeNull();
 	});
 
 	test("leaves unsampled events untouched", () => {

--- a/apps/desktop/src/lib/telemetry/posthog.ts
+++ b/apps/desktop/src/lib/telemetry/posthog.ts
@@ -106,10 +106,11 @@ export class PostHogWrapper {
 }
 
 /**
- * Sampling rates for successful high-volume `tauri_command` events, in (0, 1].
+ * Sampling rates for high-volume `tauri_command` events, in (0, 1].
  *
- * Events with `failure: true` bypass this policy and are emitted with a rate
- * of 1. In PostHog, estimate successful command totals with
+ * Failures are sampled like successes so a persistent failure storm on one of
+ * these commands cannot flood PostHog at full rate. Sampled events are stamped
+ * with their `samplingRate`; estimate totals in PostHog with
  * `sum(1 / coalesce(samplingRate, 1))`.
  */
 const SAMPLED_COMMANDS = new Map<string, number>([
@@ -133,7 +134,6 @@ export function sampleEvent(
 			? SAMPLED_COMMANDS.get(properties.command)
 			: undefined;
 	if (rate === undefined) return properties ?? {};
-	if (properties?.failure === true) return { ...properties, samplingRate: 1 };
 	if (draw >= rate) return null;
 	return { ...properties, samplingRate: rate };
 }


### PR DESCRIPTION
GB-1931 made `tauri_command` failure events bypass sampling at full rate, mirroring the CLI. That fits the CLI, where command volume is bounded by invocation, but desktop commands fire from watchers and pollers: a persistently failing high-volume command (e.g. `head_info` on every workspace refresh) would flood PostHog unbounded, since `tauri_command` events also skip posthog-js's client rate limiter.

This samples failures at the same rate as successes instead. The `samplingRate` stamp keeps failure counts reconstructible in dashboards by weighting with `1/samplingRate`, and storm volume is bounded by the same factor as successes. One rule for all sampled-command events — no failure special cases.