### PR TITLE
Preserve onboarding activation error context

### DIFF
--- a/apps/desktop/src/lib/telemetry/posthog.test.ts
+++ b/apps/desktop/src/lib/telemetry/posthog.test.ts
@@ -1,5 +1,42 @@
-import { sampleEvent } from "$lib/telemetry/posthog";
-import { describe, expect, test } from "vitest";
+import { EventContext } from "$lib/telemetry/eventContext";
+import { OnboardingEvent, PostHogWrapper, sampleEvent } from "$lib/telemetry/posthog";
+import { describe, expect, test, vi } from "vitest";
+import type { IBackend } from "$lib/backend";
+import type { SettingsService } from "$lib/settings/appSettings";
+
+function createPostHogWrapper() {
+	const capture = vi.fn();
+	const wrapper = new PostHogWrapper({} as SettingsService, {} as IBackend, new EventContext());
+	Reflect.set(wrapper, "_instance", { capture });
+	return { capture, wrapper };
+}
+
+describe("captureOnboarding", () => {
+	test("captures the parsed set-project-active error", () => {
+		const { capture, wrapper } = createPostHogWrapper();
+		const error = {
+			name: "Project activation failed",
+			message: "The project could not be opened",
+			code: "ProjectUnavailable",
+		};
+
+		wrapper.captureOnboarding(OnboardingEvent.SetProjectActiveFailed, error);
+
+		expect(capture).toHaveBeenCalledWith(OnboardingEvent.SetProjectActiveFailed, {
+			error_title: error.name,
+			error_message: error.message,
+			error_code: error.code,
+		});
+	});
+
+	test("does not fabricate error fields for a successful activation", () => {
+		const { capture, wrapper } = createPostHogWrapper();
+
+		wrapper.captureOnboarding(OnboardingEvent.SetProjectActive);
+
+		expect(capture).toHaveBeenCalledWith(OnboardingEvent.SetProjectActive, {});
+	});
+});
 
 describe("sampleEvent", () => {
 	test("stamps samplingRate on emitted sampled events", () => {

--- a/apps/desktop/src/lib/telemetry/posthog.ts
+++ b/apps/desktop/src/lib/telemetry/posthog.ts
@@ -31,13 +31,15 @@ export class PostHogWrapper {
 
 	captureOnboarding(event: OnboardingEvent, error?: unknown, extraProperties?: Properties) {
 		const context = this.eventContext.getAll();
-		const parsedError = parseQueryError(error);
+		const parsedError = error === undefined ? undefined : parseQueryError(error);
 		const properties = {
 			...context,
 			...extraProperties,
-			error_title: parsedError.name,
-			error_message: parsedError.message,
-			error_code: parsedError.code,
+			...(parsedError && {
+				error_title: parsedError.name,
+				error_message: parsedError.message,
+				error_code: parsedError.code,
+			}),
 		};
 		this._instance?.capture(event, properties);
 	}

--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -336,7 +336,7 @@
 				});
 			}
 		} catch (error: unknown) {
-			posthog.captureOnboarding(OnboardingEvent.SetProjectActiveFailed);
+			posthog.captureOnboarding(OnboardingEvent.SetProjectActiveFailed, error);
 			showError("Failed to set the project active", error);
 		}
 	}


### PR DESCRIPTION
## Context

During onboarding project activation calling set_project_active, the caught backend error was dropped and replaced by synthetic QUERY:UnknownError fields, while successful no-error events also received fabricated error fields.

Related public history: https://github.com/gitbutlerapp/gitbutler/pull/10153 and https://github.com/gitbutlerapp/gitbutler/pull/15630.

## Change

Pass the caught backend error to the existing failed activation event. Only include parsed error properties when the caller supplies an error. Event names and backend mutation behavior stay unchanged. Add focused coverage for failed and successful captures.