### PR TITLE
Handle retained submodule checkout after index deletion

### DIFF
--- a/crates/but-core/src/diff/worktree.rs
+++ b/crates/but-core/src/diff/worktree.rs
@@ -953,6 +953,17 @@ fn id_or_hash_from_worktree(
     }
 
     let path = path_check.verified_path_allow_nonexisting(rela_path)?;
+    if change.kind == EntryKind::Commit {
+        let repo = gix::open_opts(
+            path.to_path_buf(),
+            gix::open::Options::isolated().with(gix::sec::Trust::Reduced),
+        )
+        .with_context(|| format!("open embedded repository at {}", path.display()))?;
+        return Ok(repo
+            .head_id()
+            .context("resolve embedded repository HEAD")?
+            .detach());
+    }
     let md = path.symlink_metadata()?;
     let repo = filter.repo;
     let id = if md.is_file() {

--- a/crates/but-core/tests/core/diff/worktree_changes.rs
+++ b/crates/but-core/tests/core/diff/worktree_changes.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use but_core::{UnifiedPatch, WorktreeChanges, diff};
+use but_core::{IgnoredWorktreeTreeChangeStatus, TreeStatus, UnifiedPatch, WorktreeChanges, diff};
 use but_testsupport::gix_testtools;
 use snapbox::prelude::*;
 
@@ -437,6 +437,136 @@ WorktreeChanges {
         "Can only diff blobs and links, not Commit"
     );
     Ok(())
+}
+
+#[test]
+fn submodule_removed_from_index_with_retained_head_is_ineffective() -> Result<()> {
+    let repo = repo("submodule-removed-from-index-retained-head")?;
+    for actual in [
+        diff::worktree_changes(&repo)?,
+        diff::worktree_changes_no_renames(&repo)?,
+    ] {
+        assert!(
+            actual.changes.is_empty(),
+            "the retained checkout still matches the committed gitlink"
+        );
+        let [ignored] = actual.ignored_changes.as_slice() else {
+            panic!("the merged index and worktree change should be marked ineffective")
+        };
+        let path: &[u8] = ignored.path.as_ref();
+        assert_eq!(path, b"submodule", "the submodule path was merged");
+        assert_eq!(
+            ignored.status,
+            IgnoredWorktreeTreeChangeStatus::TreeIndexWorktreeChangeIneffective,
+            "the retained checkout cancels the net worktree change"
+        );
+        assert_staged_submodule_deletion(&actual);
+    }
+    Ok(())
+}
+
+#[test]
+fn submodule_removed_from_index_with_changed_head_is_modified() -> Result<()> {
+    let repo = repo("submodule-removed-from-index-changed-head")?;
+    for actual in [
+        diff::worktree_changes(&repo)?,
+        diff::worktree_changes_no_renames(&repo)?,
+    ] {
+        let [change] = actual.changes.as_slice() else {
+            panic!("the changed retained checkout should produce one effective change")
+        };
+        let path: &[u8] = change.path.as_ref();
+        assert_eq!(path, b"submodule", "the changed path is the submodule");
+        let TreeStatus::Modification {
+            previous_state,
+            state,
+            flags,
+        } = change.status
+        else {
+            panic!("the changed retained checkout should be a modification")
+        };
+        assert_eq!(
+            previous_state.kind,
+            gix::object::tree::EntryKind::Commit,
+            "the previous state is a gitlink"
+        );
+        assert_eq!(
+            state.kind,
+            gix::object::tree::EntryKind::Commit,
+            "the current state is a gitlink"
+        );
+        assert!(
+            state.id.is_null(),
+            "worktree states remain lazily hashed in the returned change"
+        );
+        assert_eq!(flags, None, "the entry kind did not change");
+        let [ignored] = actual.ignored_changes.as_slice() else {
+            panic!("the staged deletion should be marked as superseded by the worktree")
+        };
+        assert_eq!(
+            ignored.status,
+            IgnoredWorktreeTreeChangeStatus::TreeIndex,
+            "the retained checkout supersedes the staged deletion"
+        );
+        assert_staged_submodule_deletion(&actual);
+    }
+    Ok(())
+}
+
+#[test]
+fn submodule_removed_from_index_with_plain_directory_is_not_opened_as_repository() -> Result<()> {
+    let repo = repo("submodule-removed-from-index-plain-directory")?;
+    for actual in [
+        diff::worktree_changes(&repo)?,
+        diff::worktree_changes_no_renames(&repo)?,
+    ] {
+        assert!(
+            actual.changes.iter().any(|change| {
+                let path: &[u8] = change.path.as_ref();
+                path == b"submodule"
+                    && matches!(
+                        change.status,
+                        TreeStatus::Deletion { previous_state }
+                            if previous_state.kind == gix::object::tree::EntryKind::Commit
+                    )
+            }),
+            "the staged gitlink deletion remains a deletion"
+        );
+        assert!(
+            actual.changes.iter().any(|change| {
+                let path: &[u8] = change.path.as_ref();
+                path == b"submodule/modified"
+                    && matches!(
+                        change.status,
+                        TreeStatus::Addition { state, .. }
+                            if state.kind == gix::object::tree::EntryKind::Blob
+                    )
+            }),
+            "the plain directory is traversed for untracked files"
+        );
+        assert_staged_submodule_deletion(&actual);
+    }
+    Ok(())
+}
+
+fn assert_staged_submodule_deletion(actual: &WorktreeChanges) {
+    let [
+        gix::diff::index::Change::Deletion {
+            location,
+            entry_mode,
+            ..
+        },
+    ] = actual.index_changes.as_slice()
+    else {
+        panic!("the index should retain exactly the staged submodule deletion")
+    };
+    let location: &[u8] = location.as_ref();
+    assert_eq!(location, b"submodule", "the index deletion path is intact");
+    assert_eq!(
+        *entry_mode,
+        gix::index::entry::Mode::COMMIT,
+        "the index deletion remains a gitlink"
+    );
 }
 
 #[test]

--- a/crates/but-core/tests/fixtures/worktree-changes.sh
+++ b/crates/but-core/tests/fixtures/worktree-changes.sh
@@ -294,6 +294,21 @@ git init submodule-changed-head
   )
 )
 
+git init submodule-removed-from-index-retained-head
+(cd submodule-removed-from-index-retained-head
+  git submodule add ../modified-in-index submodule
+  git commit -m "init"
+  git rm --cached submodule
+)
+
+cp -Rv submodule-removed-from-index-retained-head submodule-removed-from-index-changed-head
+(cd submodule-removed-from-index-changed-head/submodule
+  echo change >>modified && git commit -am "change retained submodule HEAD"
+)
+
+cp -Rv submodule-removed-from-index-retained-head submodule-removed-from-index-plain-directory
+rm -rf submodule-removed-from-index-plain-directory/submodule/.git
+
 cp -Rv submodule-changed-head submodule-changed-head-ignore-all
 (cd submodule-changed-head-ignore-all
   echo $'\tignore = all\n' >>.gitmodules


### PR DESCRIPTION
## Context

Trigger: remove a committed submodule from the index while leaving its embedded checkout at the same path.

Symptom: worktree status tries to hash the retained repository directory as a file and fails, which can block workspace updates and other repository operations.

## Change

Resolve null commit IDs from the retained embedded repository's checked-out HEAD using isolated reduced-trust repository options. Preserve the staged gitlink deletion in index changes, suppress same-HEAD net changes, and keep changed-HEAD and plain-directory behavior intact in both rename modes.
