### PR TITLE
PR activity notifications in lite

### DIFF
--- a/apps/lite/electron/src/settings.ts
+++ b/apps/lite/electron/src/settings.ts
@@ -29,6 +29,7 @@ const guiSettingsV1 = type({
 	"lineDiffType?": "'word-alt' | 'word' | 'char' | 'none'",
 	"minimap?": "boolean",
 	"pathFirst?": "boolean",
+	"prNotifications?": "'loud' | 'quiet' | 'off'",
 	"terminalId?": "string",
 	"syntaxHighlighting?": {
 		"light?": "string",

--- a/apps/lite/harness/browser/Panel.tsx
+++ b/apps/lite/harness/browser/Panel.tsx
@@ -15,6 +15,8 @@ import { buildUncommittedFileRows } from "#ui/routes/project/$id/workspace/file-
 import { fileTreeAddressSpace } from "#ui/routes/project/$id/workspace/file-tree.ts";
 import { useFileDisplayMode } from "#ui/routes/project/$id/workspace/useFileDisplayMode.ts";
 import { WorkspaceLists } from "#ui/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.tsx";
+import { useReviewActivityInbox } from "#ui/review-notifications.ts";
+import { useStampReviewsSeen } from "#ui/review-seen.ts";
 import { useAppSelector } from "#ui/store.ts";
 import { setCursor } from "#ui/use-cursor.ts";
 import styles from "./Panel.module.css";
@@ -25,6 +27,10 @@ import styles from "./Panel.module.css";
  */
 export const Panel: FC = () => {
 	const { id: projectId } = useParams({ from: "/project/$id/workspace" });
+	// The panel toasts review activity like the app does — same detector, same
+	// declarations — so the harness rig can exercise the flow end to end.
+	useReviewActivityInbox(projectId);
+	useStampReviewsSeen(projectId);
 	const pendingOperation = useAppSelector((state) =>
 		projectSlice.selectors.selectPendingOperation(state, projectId),
 	);

--- a/apps/lite/harness/deepseek/client.js
+++ b/apps/lite/harness/deepseek/client.js
@@ -43,6 +43,24 @@ return {
 			stopped: false,
 			detailsDisposer: null,
 		};
+
+		// ---- `but` CLI availability, driving the missing-CLI banner ----
+		const butStore = { available: null, listeners: new Set() };
+		const setButAvailable = (available) => {
+			butStore.available = available;
+			// Listeners are React state setters: they need the value, not a bare call.
+			for (const listener of [...butStore.listeners]) listener(available);
+		};
+		const useButAvailable = () => {
+			const [available, setAvailable] = React.useState(butStore.available);
+			React.useEffect(() => {
+				butStore.listeners.add(setAvailable);
+				return () => {
+					butStore.listeners.delete(setAvailable);
+				};
+			}, []);
+			return available;
+		};
 		const closePanel = () => {
 			if (state.detailsDisposer) {
 				state.detailsDisposer();
@@ -93,27 +111,33 @@ return {
 				// A second menu supersedes an open one: resolve the old as cancelled.
 				if (menuState.menu) menuState.menu.close();
 				const items = (payload && payload.items) || [];
-				// The lite side hands the file path along as opaque context; the app's
-				// native menus ignore it. Only the plugin appends its own action.
-				const path =
-					payload && payload.context && typeof payload.context.path === "string"
-						? payload.context.path
+				// The lite side hands what the menu is for along as opaque context
+				// (a file path, a branch ref, or a commit's ids); the app's native
+				// menus ignore it. Only the plugin appends its own action.
+				const context =
+					payload && payload.context && typeof payload.context === "object"
+						? payload.context
 						: null;
-				const withGitButler =
-					path !== null
-						? [
-								...items,
-								{ _tag: "Separator" },
-								{
-									_tag: "Item",
-									label: "Open in GitButler",
-									itemId: BUT_OPEN_IN_GITBUTLER_ID,
-								},
-							]
-						: items;
+				const hasTarget =
+					context !== null &&
+					(typeof context.path === "string" ||
+						typeof context.branchRef === "string" ||
+						typeof context.changeId === "string" ||
+						typeof context.commitId === "string");
+				const withGitButler = hasTarget
+					? [
+							...items,
+							{ _tag: "Separator" },
+							{
+								_tag: "Item",
+								label: "Open in GitButler",
+								itemId: BUT_OPEN_IN_GITBUTLER_ID,
+							},
+						]
+					: items;
 				setMenu({
 					items: withGitButler,
-					butPath: path,
+					context: context,
 					position: (payload && payload.position) || { x: 0, y: 0 },
 					resolve: resolve,
 					close: () => {
@@ -170,17 +194,23 @@ return {
 			anchor.click();
 			anchor.remove();
 		};
-		// Open the real GitButler (lite) app at this file in the uncommitted list.
+		// Open the real GitButler (lite) app where the menu's row lives: an
+		// uncommitted file in the uncommitted list, or a branch/commit in the
+		// applied list (change id first — it survives amend and reword).
 		const openInGitButler = async (menu) => {
-			const path = menu && menu.butPath;
+			const context = menu && menu.context;
 			const project = await ensureProject();
-			if (!path || !project) return;
-			clickDeepLink(
-				"but://app/project/" +
-					encodeURIComponent(project.id) +
-					"/workspace?active=uncommitted&uncommitted=" +
-					encodeURIComponent(path),
-			);
+			if (!context || !project) return;
+			const base = "but://app/project/" + encodeURIComponent(project.id) + "/workspace?";
+			if (typeof context.path === "string" && context.path !== "") {
+				clickDeepLink(base + "active=uncommitted&uncommitted=" + encodeURIComponent(context.path));
+			} else if (typeof context.changeId === "string" && context.changeId !== "") {
+				clickDeepLink(base + "applied=change:" + encodeURIComponent(context.changeId));
+			} else if (typeof context.commitId === "string" && context.commitId !== "") {
+				clickDeepLink(base + "applied=commit:" + encodeURIComponent(context.commitId));
+			} else if (typeof context.branchRef === "string" && context.branchRef !== "") {
+				clickDeepLink(base + "applied=branch:" + encodeURIComponent(context.branchRef));
+			}
 		};
 
 		// ---- open-in-editor via deep link ----
@@ -219,6 +249,7 @@ return {
 				const mounted = await host.call("but.mount");
 				state.project = mounted && mounted.project;
 				state.platform = (mounted && mounted.platform) || "darwin";
+				if (mounted && typeof mounted.but === "boolean") setButAvailable(mounted.but);
 			}
 			return state.project;
 		};
@@ -298,9 +329,221 @@ return {
 		};
 
 		// ---- the details-column panel body ----
+		const BUT_DOWNLOAD_URL = "https://gitbutler.com/download";
+		const BUT_INSTALL_COMMAND = "curl -fsSL https://gitbutler.com/install.sh | sh";
+
+		// The SDK's clipboardWriteText is a no-op on this harness, so copying
+		// goes through the browser clipboard instead (localhost is a secure
+		// context, so navigator.clipboard is available), with the legacy
+		// textarea fallback for good measure.
+		const copyText = async (text) => {
+			try {
+				if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+					await navigator.clipboard.writeText(text);
+					return true;
+				}
+			} catch (ignored) {
+				/* fall through to the fallback */
+			}
+			try {
+				const textarea = document.createElement("textarea");
+				textarea.value = text;
+				textarea.style.position = "fixed";
+				textarea.style.opacity = "0";
+				document.body.append(textarea);
+				textarea.select();
+				const ok = document.execCommand && document.execCommand("copy");
+				textarea.remove();
+				return ok === true;
+			} catch (ignored) {
+				return false;
+			}
+		};
+
+		// The copy button at the end of the install command. Feedback via the
+		// timer service (setTimeout is trapped in the client sandbox).
+		const CopyCommandButton = () => {
+			const [copied, setCopied] = React.useState(false);
+			const resetTimerRef = React.useRef(null);
+			React.useEffect(
+				() => () => {
+					if (resetTimerRef.current) resetTimerRef.current();
+				},
+				[],
+			);
+			const copy = async () => {
+				const ok = await copyText(BUT_INSTALL_COMMAND);
+				if (!ok) return;
+				setCopied(true);
+				if (resetTimerRef.current) resetTimerRef.current();
+				resetTimerRef.current = timer.timeout(() => {
+					resetTimerRef.current = null;
+					setCopied(false);
+				}, 1500);
+			};
+			return React.createElement(
+				"button",
+				{
+					type: "button",
+					onClick: copy,
+					title: copied ? "Copied" : "Copy install command",
+					"aria-label": copied ? "Copied" : "Copy install command",
+					style: {
+						display: "inline-flex",
+						alignItems: "center",
+						justifyContent: "center",
+						padding: "2px",
+						border: "none",
+						background: "none",
+						color: "inherit",
+						cursor: "pointer",
+						opacity: copied ? 1 : 0.75,
+					},
+				},
+				copied
+					? React.createElement(
+							"svg",
+							{
+								width: 14,
+								height: 14,
+								viewBox: "0 0 16 16",
+								fill: "none",
+								xmlns: "http://www.w3.org/2000/svg",
+							},
+							React.createElement("path", {
+								d: "M14 4L6.8 11L2 6.33333",
+								stroke: "currentColor",
+								strokeWidth: 1.5,
+								vectorEffect: "non-scaling-stroke",
+							}),
+						)
+					: React.createElement(
+							"svg",
+							{
+								width: 14,
+								height: 14,
+								viewBox: "0 0 16 16",
+								fill: "none",
+								xmlns: "http://www.w3.org/2000/svg",
+							},
+							React.createElement("path", {
+								d: "M2.5 6.75V11.75C2.5 12.8546 3.39543 13.75 4.5 13.75H8.5C9.60457 13.75 10.5 12.8546 10.5 11.75V6.75C10.5 5.64543 9.60457 4.75 8.5 4.75H4.5C3.39543 4.75 2.5 5.64543 2.5 6.75Z",
+								stroke: "currentColor",
+								strokeWidth: 1.5,
+								vectorEffect: "non-scaling-stroke",
+							}),
+							React.createElement("path", {
+								d: "M5.5 4.75V4.25C5.5 3.14543 6.39543 2.25 7.5 2.25H11.5C12.6046 2.25 13.5 3.14543 13.5 4.25V9.25C13.5 10.3546 12.6046 11.25 11.5 11.25H10.5",
+								stroke: "currentColor",
+								strokeWidth: 1.5,
+								vectorEffect: "non-scaling-stroke",
+							}),
+						),
+			);
+		};
+
+		// The GitButler logomark, inlined from the web app's GitbutlerLogoLink
+		// (the client cannot import the bundle's Icon component).
+		const ButIcon = () =>
+			React.createElement(
+				"svg",
+				{
+					width: 64,
+					height: 64,
+					viewBox: "0 0 23 22",
+					fill: "none",
+					xmlns: "http://www.w3.org/2000/svg",
+					style: { opacity: 0.9 },
+				},
+				React.createElement("path", {
+					d: "M0 22V0L11.4819 9.63333L23 0V22L11.4819 12.4L0 22Z",
+					fill: "currentColor",
+				}),
+			);
+
+		// The panel is useless without GitButler, so a missing CLI replaces the
+		// whole view rather than banner over a broken app: full-size, centered
+		// on both axes, with the install command and the download link.
+		const ButMissingScreen = () =>
+			React.createElement(
+				"div",
+				{
+					style: {
+						width: "100%",
+						height: "100%",
+						minHeight: 0,
+						display: "flex",
+						flexDirection: "column",
+						alignItems: "center",
+						justifyContent: "center",
+						gap: 12,
+						padding: 24,
+						textAlign: "center",
+						background: "var(--bg-1, #18181b)",
+						color: "var(--text-1, #fafafa)",
+					},
+				},
+				React.createElement(ButIcon),
+				React.createElement(
+					"h2",
+					{ style: { fontSize: 15, fontWeight: 600, margin: 0 } },
+					"GitButler CLI isn't available",
+				),
+				React.createElement(
+					"p",
+					{
+						style: {
+							fontSize: 12,
+							opacity: 0.75,
+							margin: 0,
+							maxWidth: 260,
+							lineHeight: 1.5,
+						},
+					},
+					"The panel needs the `but` command to reach your GitButler data. Install it with:",
+				),
+				React.createElement(
+					"div",
+					{
+						style: {
+							display: "inline-flex",
+							alignItems: "center",
+							gap: 6,
+							padding: "4px 6px 4px 10px",
+							borderRadius: 6,
+							background: "color-mix(in srgb, currentColor 10%, transparent)",
+							fontFamily: "ui-monospace, monospace",
+							fontSize: 11,
+						},
+					},
+					React.createElement("span", null, BUT_INSTALL_COMMAND),
+					React.createElement(CopyCommandButton),
+				),
+				React.createElement(
+					"a",
+					{
+						href: BUT_DOWNLOAD_URL,
+						target: "_blank",
+						rel: "noreferrer",
+						style: {
+							marginTop: 4,
+							padding: "6px 14px",
+							borderRadius: 8,
+							border: "1px solid color-mix(in srgb, currentColor 30%, transparent)",
+							color: "inherit",
+							fontSize: 12,
+							fontWeight: 600,
+							textDecoration: "none",
+						},
+					},
+					"Download GitButler",
+				),
+			);
+
 		const PanelBody = () => {
 			const ref = React.useRef(null);
 			const [error, setError] = React.useState(null);
+			const butAvailable = useButAvailable();
 			React.useEffect(() => {
 				let cancelled = false;
 				const container = ref.current;
@@ -308,7 +551,10 @@ return {
 				void (async () => {
 					try {
 						const [bundle, project] = await Promise.all([ensureBundle(), ensureProject()]);
-						if (cancelled || !project || !bundle) return;
+						// A missing `but` means the panel cannot work at all, so
+						// the fullscreen unavailable state replaces the app and
+						// nothing is mounted underneath it.
+						if (cancelled || !project || !bundle || butStore.available === false) return;
 						// The IIFE text + appended return yields the createPanel FUNCTION
 						// (vite lib mode exports the default directly), which is then
 						// called with the transport. The bundle's React 19 + its own root
@@ -341,6 +587,7 @@ return {
 					}
 				};
 			}, []);
+			if (butAvailable === false) return React.createElement(ButMissingScreen);
 			return React.createElement(
 				"div",
 				{ ref: ref, style: { width: "100%", height: "100%", minHeight: 0, overflow: "hidden" } },
@@ -511,7 +758,9 @@ return {
 				gap: 10,
 				padding: "5px 10px",
 				borderRadius: 5,
-				cursor: "default",
+				// The plugin is a browser surface: a clickable item says so. The
+				// desktop app's native menus don't render in a page at all.
+				cursor: "pointer",
 				position: "relative",
 			};
 			const hoverBg = "color-mix(in srgb, currentColor 14%, transparent)";

--- a/apps/lite/harness/deepseek/host.js
+++ b/apps/lite/harness/deepseek/host.js
@@ -44,6 +44,17 @@ return {
 			}
 		};
 
+		// Whether the `but` CLI is on PATH. Only the panel's mount probes it,
+		// so the check is one PATH lookup per plugin session, not per call.
+		const checkBut = async () => {
+			try {
+				await subprocess.resolveExecutable("but");
+				return true;
+			} catch (error) {
+				return false;
+			}
+		};
+
 		// Find the repo root: the client-forwarded workdir first, then every
 		// durable workspace path, then the sandbox root as a last resort. The
 		// first one containing apps/lite/harness/deepseek/cli.mjs wins. The
@@ -201,8 +212,13 @@ return {
 					]);
 					b.project = project;
 					b.platform = (ping && ping.platform) || "darwin";
+					// The panel itself runs off the repo's SDK bridge, not the
+					// `but` binary — but `but` is how a user reaches GitButler
+					// from the terminal (and the app the deep links land in), so
+					// a missing CLI is worth flagging to the panel.
+					b.but = await checkBut();
 				}
-				return { project: b.project, platform: b.platform };
+				return { project: b.project, platform: b.platform, but: b.but };
 			}),
 		);
 
@@ -228,7 +244,34 @@ return {
 			harness.handle("but.ipc", async (args) => {
 				const b = await ensureBridge();
 				if (!args || !args.endpoint) throw new Error("GitButler panel: but.ipc needs an endpoint");
-				return b.call("invoke", { endpoint: args.endpoint, params: args.params }, 30000);
+				try {
+					return await b.call("invoke", { endpoint: args.endpoint, params: args.params }, 30000);
+				} catch (error) {
+					// A branch can vanish between the list the panel derived from
+					// and the diff fetch (delete, integrate, pull): its diff is
+					// empty, not an error. Tolerate the missing ref so the panel
+					// does not surface the transient; anything else still throws.
+					if (
+						args.endpoint === "branchDiff" &&
+						/did not exist/.test(String((error && error.message) || error))
+					) {
+						return null;
+					}
+					// Listing open PRs paginates the forge; the listing can change
+					// mid-fetch (a PR opened or closed while pages were pulled).
+					// The panel only reads the list for badges, so a failed pass
+					// reads as "no open PRs right now" rather than crashing the
+					// panel's IPC.
+					if (
+						args.endpoint === "listReviews" &&
+						/changed while paginating|Failed to list open pull requests/.test(
+							String((error && error.message) || error),
+						)
+					) {
+						return [];
+					}
+					throw error;
+				}
 			}),
 		);
 

--- a/apps/lite/harness/tests/fixtures.ts
+++ b/apps/lite/harness/tests/fixtures.ts
@@ -1,6 +1,8 @@
 import type {
 	AiConfiguration,
 	Commit,
+	ForgeInfo,
+	ForgeReview,
 	ProjectForFrontend,
 	RefInfo,
 	Segment,
@@ -129,6 +131,51 @@ const fixtureAiConfiguration: AiConfiguration = {
  * The app-wide queries every mounted panel runs regardless of fixture: enough
  * of an answer for the components to render, nothing project-specific.
  */
+/** A GitHub-shaped forge with every capability, for review-flow tests. */
+export const fixtureForgeInfo = (): ForgeInfo => ({
+	name: "github",
+	baseUrl: "https://github.example/repo",
+	commitUrlPath: "/commit/",
+	prUrlPath: "/pull/",
+	unit: { name: "pull request", abbr: "PR", symbol: "#" },
+	posthogLabel: "PR",
+	capabilities: {
+		checks: false,
+		repoInfo: true,
+		prService: true,
+		listService: true,
+		reviewComments: true,
+		reviewManagement: true,
+	},
+});
+
+export const fixtureForgeReview = (overrides: Partial<ForgeReview> = {}): ForgeReview => ({
+	htmlUrl: "https://github.example/repo/pull/7",
+	number: 7,
+	title: "A fixture change",
+	body: null,
+	author: null,
+	labels: [],
+	draft: false,
+	sourceBranch: "feature-one",
+	targetBranch: "main",
+	sha: "0".repeat(40),
+	integrationCommitShas: [],
+	createdAt: "2026-01-01T09:00:00Z",
+	modifiedAt: "2026-01-01T10:00:00Z",
+	mergedAt: null,
+	closedAt: null,
+	repositorySshUrl: null,
+	repositoryHttpsUrl: null,
+	repoOwner: null,
+	headRepoIsFork: false,
+	reviewers: [],
+	autoMergeEnabled: false,
+	unitSymbol: "#",
+	lastSyncAt: "2026-01-01T10:00:00Z",
+	...overrides,
+});
+
 export const globalHandlers = (projectId: string): FakeHandlers => ({
 	readGUISettings: (): GUISettings => ({ version: 1 }),
 	listEditors: () => [],

--- a/apps/lite/harness/tests/panel.test.tsx
+++ b/apps/lite/harness/tests/panel.test.tsx
@@ -5,6 +5,8 @@ import { createFakeTransport, createWatcherHandlers, type FakeHandlers } from ".
 import {
 	fixtureCommit,
 	fixtureFileChange,
+	fixtureForgeInfo,
+	fixtureForgeReview,
 	fixtureHeadInfo,
 	fixtureSegment,
 	fixtureWorktreeChanges,
@@ -27,7 +29,23 @@ const PROJECT_ID = "fixture-project";
  */
 const settle = { timeout: 15_000 } as const;
 
-const mountPanel = (handlers: FakeHandlers) => {
+/**
+ * @param seenMarks watermarks to start from, as the app would have stamped on
+ * an earlier run. Local storage is shared across the tests in this file, so it
+ * is cleared either way.
+ */
+/** The inbox as the detector wrote it, straight from the store's key. */
+const inboxEntries = (): Array<{ kind: string; review: number; author: string | null }> =>
+	JSON.parse(localStorage.getItem(`pr_activity_inbox:v1:${PROJECT_ID}`) ?? "[]") as Array<{
+		kind: string;
+		review: number;
+		author: string | null;
+	}>;
+
+const mountPanel = (handlers: FakeHandlers, seenMarks?: Record<number, string>) => {
+	localStorage.clear();
+	if (seenMarks !== undefined)
+		localStorage.setItem(`pr_activity_seen:v1:${PROJECT_ID}`, JSON.stringify(seenMarks));
 	const watcher = createWatcherHandlers();
 	const fake = createFakeTransport({
 		...globalHandlers(PROJECT_ID),
@@ -134,6 +152,112 @@ test("a watcher event refreshes the uncommitted files", async () => {
 	panel.push(eventChannel, event);
 
 	await vi.waitFor(() => expect(panel.container.textContent).toContain("new-file.ts"), settle);
+
+	panel.unmount();
+});
+
+test("someone else's review activity files one coalesced inbox entry and the unread dot", async () => {
+	// A mutable listing: the first answer is the detector's baseline, the
+	// second is the activity, as two forge polls would return.
+	let review = fixtureForgeReview({ modifiedAt: "2026-01-01T10:00:00Z" });
+	let comments: Array<unknown> = [];
+
+	const panel = mountPanel({
+		headInfo: () =>
+			fixtureHeadInfo([[fixtureSegment({ branch: review.sourceBranch, commits: [] })]]),
+		changesInWorktree: () => fixtureWorktreeChanges([]),
+		forgeInfo: () => fixtureForgeInfo(),
+		listReviews: () => [review],
+		currentForgeLogin: () => "me",
+		listReviewComments: () => comments,
+		listReviewSubmissions: () => [],
+		listReviewTimelineEvents: () => [],
+	});
+
+	// The PR chip proves the baseline listing landed, and that nothing is
+	// unread yet — history must never replay as notifications.
+	await vi.waitFor(() => expect(panel.container.textContent).toContain("PR"), settle);
+	expect(document.querySelector('[title="New activity on this pull request"]')).toBeNull();
+
+	// Someone comments; the forge bumps the review and a fetch notices.
+	review = { ...review, modifiedAt: "2026-01-01T11:00:00Z" };
+	comments = [
+		{
+			id: 1,
+			body: "Have you considered a smaller diff?",
+			author: { id: 2, login: "alice", name: null, email: null, avatarUrl: null, isBot: false },
+			createdAt: "2026-01-01T10:30:00Z",
+			modifiedAt: null,
+			htmlUrl: "",
+			reactions: [],
+		},
+	];
+	const eventChannel = panel.watcher.channels.at(0);
+	if (eventChannel === undefined) throw new Error("no watcher subscription armed");
+	const event: WatcherEvent = { name: "gitFetch", payload: { type: "gitFetch", subject: null } };
+	panel.push(eventChannel, event);
+
+	// One coalesced, attributed inbox entry — and the unread dot alongside it.
+	await vi.waitFor(() => expect(inboxEntries()).toHaveLength(1), settle);
+	expect(inboxEntries()[0]).toMatchObject({ kind: "comment", review: 7, author: "alice" });
+	await vi.waitFor(
+		() =>
+			expect(document.querySelector('[title="New activity on this pull request"]')).not.toBeNull(),
+		settle,
+	);
+
+	panel.unmount();
+});
+
+test("a mention toasts even when the review's branch is not in the workspace", async () => {
+	// One applied review to anchor the baseline, and one on a branch the
+	// workspace does not hold — only a mention may speak for the latter.
+	const mine = fixtureForgeReview({ modifiedAt: "2026-01-01T10:00:00Z" });
+	let outside = fixtureForgeReview({
+		number: 8,
+		sourceBranch: "a-colleagues-branch",
+		modifiedAt: "2026-01-01T10:00:00Z",
+	});
+	let comments: Array<unknown> = [];
+
+	const panel = mountPanel({
+		headInfo: () => fixtureHeadInfo([[fixtureSegment({ branch: mine.sourceBranch, commits: [] })]]),
+		changesInWorktree: () => fixtureWorktreeChanges([]),
+		forgeInfo: () => fixtureForgeInfo(),
+		listReviews: () => [mine, outside],
+		currentForgeLogin: () => "me",
+		listReviewComments: (params: { reviewId: number }) =>
+			params.reviewId === outside.number ? comments : [],
+		listReviewSubmissions: () => [],
+		listReviewTimelineEvents: () => [],
+	});
+
+	await vi.waitFor(() => expect(panel.container.textContent).toContain("PR"), settle);
+
+	outside = { ...outside, modifiedAt: "2026-01-01T11:00:00Z" };
+	comments = [
+		{
+			id: 1,
+			body: "wdyt @me?",
+			author: { id: 2, login: "alice", name: null, email: null, avatarUrl: null, isBot: false },
+			createdAt: "2026-01-01T10:30:00Z",
+			modifiedAt: null,
+			htmlUrl: "",
+			reactions: [],
+		},
+	];
+	const eventChannel = panel.watcher.channels.at(0);
+	if (eventChannel === undefined) throw new Error("no watcher subscription armed");
+	panel.push(eventChannel, {
+		name: "gitFetch",
+		payload: { type: "gitFetch", subject: null },
+	} satisfies WatcherEvent);
+
+	await vi.waitFor(
+		() =>
+			expect(inboxEntries().find((entry) => entry.review === 8)).toMatchObject({ kind: "mention" }),
+		settle,
+	);
 
 	panel.unmount();
 });

--- a/apps/lite/ui/src/api/mutations.ts
+++ b/apps/lite/ui/src/api/mutations.ts
@@ -666,6 +666,23 @@ export const useMergeReview = (projectId: string) =>
 		meta: { failureTitle: "Failed to merge pull request" },
 	});
 
+/**
+ * Review numbers this session merged through `useMergeReview`. Kept beside
+ * the mutation so the key and payload shape cannot drift apart unseen.
+ */
+export const selfMergedNumbers = (client: QueryClient, projectId: string): Set<number> =>
+	new Set(
+		client
+			.getMutationCache()
+			.findAll({ mutationKey: [projectId, "mergeReview"], status: "success" })
+			.flatMap((mutation) => {
+				const variables = mutation.state.variables as
+					| Parameters<typeof window.lite.mergeReview>[0]
+					| undefined;
+				return variables ? [variables.reviewId] : [];
+			}),
+	);
+
 export const useSetReviewDraftiness = (projectId: string) =>
 	useMutation({
 		mutationKey: [projectId, "setReviewDraftiness"],

--- a/apps/lite/ui/src/components/RelativeTime.tsx
+++ b/apps/lite/ui/src/components/RelativeTime.tsx
@@ -1,5 +1,5 @@
 import { TooltipPopup } from "#ui/components/Tooltip.tsx";
-import { formatAbsoluteTime, formatRelativeTime } from "#ui/time.ts";
+import { formatAbsoluteTime, formatCompactRelativeTime, formatRelativeTime } from "#ui/time.ts";
 import { Tooltip } from "@base-ui/react";
 import type { FC } from "react";
 
@@ -8,11 +8,13 @@ export const RelativeTime: FC<{
 	timestamp: number;
 	/** Pin "now" for stable output across re-renders, as the row lists do. */
 	now?: number;
+	/** "26m" instead of "26 minutes ago", for dense rows. */
+	compact?: boolean;
 	className?: string;
-}> = ({ timestamp, now, className }) => (
+}> = ({ timestamp, now, compact = false, className }) => (
 	<Tooltip.Root>
 		<Tooltip.Trigger render={<span className={className} />}>
-			{formatRelativeTime(timestamp, now)}
+			{compact ? formatCompactRelativeTime(timestamp, now) : formatRelativeTime(timestamp, now)}
 		</Tooltip.Trigger>
 		<Tooltip.Portal>
 			<Tooltip.Positioner sideOffset={4}>

--- a/apps/lite/ui/src/review-activity.test.ts
+++ b/apps/lite/ui/src/review-activity.test.ts
@@ -1,0 +1,294 @@
+import {
+	activityItems,
+	attentionOf,
+	seenLedger,
+	itemMentions,
+	observeReviews,
+	type ReviewActivityItem,
+} from "./review-activity.ts";
+import type {
+	ForgeReview,
+	ForgeReviewComment,
+	ForgeReviewSubmission,
+	ForgeReviewTimelineEvent,
+	ForgeReviewUser,
+} from "@gitbutler/but-sdk";
+import { describe, expect, it } from "vitest";
+
+const user = (login: string): ForgeReviewUser => ({
+	id: 1,
+	login,
+	name: null,
+	email: null,
+	avatarUrl: null,
+	isBot: false,
+});
+
+const review = (overrides: Partial<ForgeReview> = {}): ForgeReview => ({
+	htmlUrl: "https://forge.example/pr/7",
+	number: 7,
+	title: "A change",
+	body: null,
+	author: null,
+	labels: [],
+	draft: false,
+	sourceBranch: "feature",
+	targetBranch: "main",
+	sha: "abc",
+	integrationCommitShas: [],
+	createdAt: "2026-08-28T09:00:00Z",
+	modifiedAt: "2026-08-28T10:00:00Z",
+	mergedAt: null,
+	closedAt: null,
+	repositorySshUrl: null,
+	repositoryHttpsUrl: null,
+	repoOwner: null,
+	headRepoIsFork: false,
+	reviewers: [],
+	autoMergeEnabled: false,
+	unitSymbol: "#",
+	lastSyncAt: "2026-08-28T10:00:00Z",
+	...overrides,
+});
+
+const comment = (author: string | null, atMs: number, body = ""): ReviewActivityItem => ({
+	kind: "comment",
+	author,
+	body,
+	atMs,
+});
+
+const verdict = (
+	author: string | null,
+	state: "approved" | "changesRequested" | "commented" | "dismissed",
+	atMs: number,
+	body: string | null = null,
+): ReviewActivityItem => ({ kind: "verdict", author, state, body, atMs });
+
+describe("attentionOf", () => {
+	it("treats someone else's comment as loud", () => {
+		expect(attentionOf(comment("alice", 1), "me")).toBe("loud");
+	});
+
+	it("treats the user's own activity as silent, whatever it is", () => {
+		expect(attentionOf(comment("me", 1), "me")).toBe("silent");
+		expect(attentionOf(verdict("me", "approved", 1), "me")).toBe("silent");
+	});
+
+	it("compares logins case-insensitively", () => {
+		expect(attentionOf(comment("Me", 1), "mE")).toBe("silent");
+	});
+
+	it("treats review verdicts as loud except dismissals", () => {
+		for (const state of ["approved", "changesRequested", "commented"] as const)
+			expect(attentionOf(verdict("alice", state, 1), "me")).toBe("loud");
+
+		expect(attentionOf(verdict("alice", "dismissed", 1), "me")).toBe("quiet");
+	});
+
+	it("treats a review request as loud only when it names the user", () => {
+		const request = (requestedReviewer: string | null): ReviewActivityItem => ({
+			kind: "reviewRequested",
+			author: "alice",
+			requestedReviewer,
+			atMs: 1,
+		});
+		expect(attentionOf(request("me"), "me")).toBe("loud");
+		expect(attentionOf(request("bob"), "me")).toBe("quiet");
+		expect(attentionOf(request(null), "me")).toBe("quiet");
+	});
+
+	it("treats commits as quiet", () => {
+		expect(attentionOf({ kind: "committed", author: "alice", atMs: 1 }, "me")).toBe("quiet");
+	});
+
+	it("stays sane without a known login: comments loud, requests quiet", () => {
+		expect(attentionOf(comment("alice", 1), null)).toBe("loud");
+		expect(
+			attentionOf(
+				{ kind: "reviewRequested", author: "alice", requestedReviewer: "bob", atMs: 1 },
+				null,
+			),
+		).toBe("quiet");
+	});
+});
+
+describe("seenLedger", () => {
+	it("reports activity that arrived while the app was closed", () => {
+		// The watermark trails the review: the user has not seen this yet, so
+		// the very first observation must report it rather than absorb it.
+		const listing = [review({ modifiedAt: "2026-08-28T11:00:00Z" })];
+		const ledger = seenLedger(listing, { 7: "2026-08-28T10:00:00Z" });
+		const { changed } = observeReviews(ledger, listing);
+		expect(changed).toHaveLength(1);
+		expect(changed[0]?.sinceMs).toBe(Date.parse("2026-08-28T10:00:00Z"));
+	});
+
+	it("stays silent for a review with no watermark", () => {
+		const listing = [review()];
+		expect(observeReviews(seenLedger(listing, {}), listing).changed).toEqual([]);
+	});
+
+	it("stays silent once the watermark has caught up", () => {
+		const listing = [review({ modifiedAt: "2026-08-28T11:00:00Z" })];
+		const ledger = seenLedger(listing, { 7: "2026-08-28T11:00:00Z" });
+		expect(observeReviews(ledger, listing).changed).toEqual([]);
+	});
+});
+
+describe("observeReviews", () => {
+	it("never reports a review on first sight", () => {
+		const listing = [review()];
+		const { changed } = observeReviews(seenLedger([], {}), listing);
+		expect(changed).toEqual([]);
+	});
+
+	it("reports a review whose modifiedAt moved, with the previous mark as the cut", () => {
+		const before = review({ modifiedAt: "2026-08-28T10:00:00Z" });
+		const after = review({ modifiedAt: "2026-08-28T11:00:00Z" });
+		const { changed } = observeReviews(seenLedger([before], {}), [after]);
+		expect(changed).toHaveLength(1);
+		expect(changed[0]?.sinceMs).toBe(Date.parse("2026-08-28T10:00:00Z"));
+		expect(changed[0]?.settledNow).toBeNull();
+	});
+
+	it("stays quiet while nothing moves", () => {
+		const same = review();
+		expect(observeReviews(seenLedger([same], {}), [same]).changed).toEqual([]);
+	});
+
+	it("reports the poll on which a review settles", () => {
+		const open = review();
+		const merged = review({
+			modifiedAt: "2026-08-28T11:00:00Z",
+			mergedAt: "2026-08-28T11:00:00Z",
+		});
+		expect(observeReviews(seenLedger([open], {}), [merged]).changed[0]?.settledNow).toBe("merged");
+
+		const closed = review({
+			modifiedAt: "2026-08-28T11:00:00Z",
+			closedAt: "2026-08-28T11:00:00Z",
+		});
+		expect(observeReviews(seenLedger([open], {}), [closed]).changed[0]?.settledNow).toBe("closed");
+	});
+
+	it("does not re-report settling on later activity of a settled review", () => {
+		const merged = review({ mergedAt: "2026-08-28T11:00:00Z" });
+		const laterStill = review({
+			mergedAt: "2026-08-28T11:00:00Z",
+			modifiedAt: "2026-08-28T12:00:00Z",
+		});
+		expect(
+			observeReviews(seenLedger([merged], {}), [laterStill]).changed[0]?.settledNow,
+		).toBeNull();
+	});
+
+	it("forgets reviews the listing no longer carries", () => {
+		const gone = review({ number: 9 });
+		const { next } = observeReviews(seenLedger([gone], {}), []);
+		expect(next.size).toBe(0);
+	});
+});
+
+describe("activityItems", () => {
+	const at = (iso: string) => Date.parse(iso);
+
+	it("keeps only items strictly after the cut, and drops undated ones", () => {
+		const comments: Array<ForgeReviewComment> = [
+			{
+				id: 1,
+				body: "old",
+				author: user("alice"),
+				createdAt: "2026-08-28T09:00:00Z",
+				modifiedAt: null,
+				htmlUrl: "",
+				reactions: [],
+			},
+			{
+				id: 2,
+				body: "new",
+				author: user("alice"),
+				createdAt: "2026-08-28T11:00:00Z",
+				modifiedAt: null,
+				htmlUrl: "",
+				reactions: [],
+			},
+			{
+				id: 3,
+				body: "undated",
+				author: user("alice"),
+				createdAt: null,
+				modifiedAt: null,
+				htmlUrl: "",
+				reactions: [],
+			},
+		];
+		const items = activityItems(comments, [], [], at("2026-08-28T10:00:00Z"));
+		expect(items).toHaveLength(1);
+		expect(items[0]).toMatchObject({ kind: "comment", author: "alice" });
+	});
+
+	it("maps submissions and timeline events onto their kinds", () => {
+		const submissions: Array<ForgeReviewSubmission> = [
+			{
+				id: 1,
+				author: user("alice"),
+				state: "changesRequested",
+				body: null,
+				submittedAt: "2026-08-28T11:00:00Z",
+				htmlUrl: "",
+			},
+		];
+		const events: Array<ForgeReviewTimelineEvent> = [
+			{
+				kind: "reviewRequested",
+				actor: user("bob"),
+				requestedReviewer: user("me"),
+				commitSha: null,
+				commitSummary: null,
+				commitAuthorName: null,
+				createdAt: "2026-08-28T11:30:00Z",
+			},
+			{
+				kind: "committed",
+				actor: null,
+				requestedReviewer: null,
+				commitSha: "abc",
+				commitSummary: "wip",
+				commitAuthorName: "carol",
+				createdAt: "2026-08-28T11:40:00Z",
+			},
+		];
+		const items = activityItems([], submissions, events, 0);
+		expect(items.map((item) => item.kind)).toEqual(["verdict", "reviewRequested", "committed"]);
+	});
+});
+
+describe("itemMentions", () => {
+	it("matches a mention of the login, case-insensitively", () => {
+		expect(itemMentions(comment("alice", 1, "ping @Me please"), "me")).toBe(true);
+		expect(itemMentions(verdict("alice", "commented", 1, "@me look"), "me")).toBe(true);
+	});
+
+	it("requires the whole login, not a prefix of a longer one", () => {
+		expect(itemMentions(comment("alice", 1, "cc @me-too"), "me")).toBe(false);
+		expect(itemMentions(comment("alice", 1, "mail me@example.com"), "me")).toBe(false);
+	});
+
+	it("never matches without a login or a body", () => {
+		expect(itemMentions(comment("alice", 1, "@me"), null)).toBe(false);
+		expect(itemMentions({ kind: "committed", author: "alice", atMs: 1 }, "me")).toBe(false);
+	});
+});
+
+describe("mentions", () => {
+	it("makes even a dismissed verdict loud", () => {
+		expect(attentionOf(verdict("alice", "dismissed", 1, "sorry @me, superseded"), "me")).toBe(
+			"loud",
+		);
+	});
+
+	it("stays silent for a mention in the user's own text", () => {
+		expect(attentionOf(comment("me", 1, "note to @me"), "me")).toBe("silent");
+	});
+});

--- a/apps/lite/ui/src/review-activity.ts
+++ b/apps/lite/ui/src/review-activity.ts
@@ -1,0 +1,203 @@
+/**
+ * @file Deciding which review activity deserves the user's attention.
+ *
+ * The axis: is a human waiting on you? Everything here is pure so the test
+ * suite can drive it with fabricated events; `review-notifications.ts` feeds
+ * it live listings and turns its verdicts into toasts.
+ */
+
+import type {
+	ForgeReview,
+	ForgeReviewComment,
+	ForgeReviewSubmission,
+	ForgeReviewSubmissionState,
+	ForgeReviewTimelineEvent,
+} from "@gitbutler/but-sdk";
+
+/**
+ * One thing that happened on a review, reduced to what classification needs.
+ *
+ * @public exported for the fabricated events in the test suite.
+ */
+export type ReviewActivityItem =
+	| { kind: "comment"; author: string | null; body: string; atMs: number }
+	| {
+			kind: "verdict";
+			author: string | null;
+			state: ForgeReviewSubmissionState;
+			body: string | null;
+			atMs: number;
+	  }
+	| {
+			kind: "reviewRequested";
+			author: string | null;
+			requestedReviewer: string | null;
+			atMs: number;
+	  }
+	| { kind: "committed"; author: string | null; atMs: number };
+
+type Attention = "loud" | "quiet" | "silent";
+
+/** Forge logins compare case-insensitively. */
+const sameLogin = (a: string | null, b: string | null): boolean =>
+	a !== null && b !== null && a.toLowerCase() === b.toLowerCase();
+
+/**
+ * Whether the item's text @-mentions the login. Login characters may follow
+ * an ordinary word boundary (`@alice-b` is not `@alice`), so the ends are
+ * checked explicitly.
+ */
+export const itemMentions = (item: ReviewActivityItem, login: string | null): boolean => {
+	if (login === null) return false;
+	const body = item.kind === "comment" || item.kind === "verdict" ? item.body : null;
+	if (body === null) return false;
+	const escaped = login.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+	return new RegExp(`(?<![\\w-])@${escaped}(?![\\w-])`, "i").test(body);
+};
+
+/**
+ * Loud means a human is waiting on the user. Own actions are silent, a
+ * mention always waits, a dismissed verdict is bookkeeping rather than a
+ * message, and a review request only matters when it names the user.
+ */
+export const attentionOf = (item: ReviewActivityItem, selfLogin: string | null): Attention => {
+	if (sameLogin(item.author, selfLogin)) return "silent";
+	if (itemMentions(item, selfLogin)) return "loud";
+	switch (item.kind) {
+		case "comment":
+			return "loud";
+		case "verdict":
+			return item.state === "dismissed" ? "quiet" : "loud";
+		case "reviewRequested":
+			return sameLogin(item.requestedReviewer, selfLogin) ? "loud" : "quiet";
+		case "committed":
+			return "quiet";
+	}
+};
+
+/** What the detector remembers about a review between polls. */
+export type ReviewObservation = {
+	modifiedAtMs: number;
+	settled: boolean;
+};
+
+export type ActivityLedger = ReadonlyMap<number, ReviewObservation>;
+
+export type ReviewChange = {
+	review: ForgeReview;
+	/** Activity strictly after this counts as new. */
+	sinceMs: number;
+	/** The settling observed on this poll, if the review just settled. */
+	settledNow: "merged" | "closed" | null;
+};
+
+const parseMs = (value: string | null): number => {
+	if (value === null) return 0;
+	const ms = Date.parse(value);
+	return Number.isNaN(ms) ? 0 : ms;
+};
+
+const observationOf = (review: ForgeReview): ReviewObservation => ({
+	modifiedAtMs: parseMs(review.modifiedAt),
+	settled: review.mergedAt !== null || review.closedAt !== null,
+});
+
+/**
+ * Fold one poll's listing into the ledger and report which reviews moved.
+ * First sight is recorded but never reported — at app start everything is
+ * first seen, and replaying history would be a storm. Unlisted reviews drop
+ * out of the ledger.
+ */
+export const observeReviews = (
+	ledger: ActivityLedger,
+	reviews: Array<ForgeReview>,
+): { changed: Array<ReviewChange>; next: ActivityLedger } => {
+	const changed: Array<ReviewChange> = [];
+	const next = new Map<number, ReviewObservation>();
+	for (const review of reviews) {
+		const now = observationOf(review);
+		next.set(review.number, now);
+		const prev = ledger.get(review.number);
+		if (prev === undefined || now.modifiedAtMs <= prev.modifiedAtMs) continue;
+		changed.push({
+			review,
+			sinceMs: prev.modifiedAtMs,
+			settledNow:
+				!prev.settled && now.settled ? (review.mergedAt !== null ? "merged" : "closed") : null,
+		});
+	}
+	return { changed, next };
+};
+
+/**
+ * The ledger to start from: what the user has already seen, so activity that
+ * arrived while the app was closed still announces itself once. A review with
+ * no watermark baselines at its current state — first sight is never news.
+ */
+export const seenLedger = (
+	reviews: Array<ForgeReview>,
+	seen: Record<number, string>,
+): ActivityLedger =>
+	new Map(
+		reviews.map((review) => {
+			const mark = seen[review.number];
+			return [
+				review.number,
+				mark === undefined
+					? observationOf(review)
+					: { ...observationOf(review), modifiedAtMs: parseMs(mark) },
+			];
+		}),
+	);
+
+/**
+ * Reduce the fetched conversation to items strictly after `sinceMs`. Undated
+ * entries are left out — they would re-report on every poll.
+ */
+export const activityItems = (
+	comments: Array<ForgeReviewComment>,
+	submissions: Array<ForgeReviewSubmission>,
+	events: Array<ForgeReviewTimelineEvent>,
+	sinceMs: number,
+): Array<ReviewActivityItem> => {
+	const items: Array<ReviewActivityItem> = [];
+	for (const comment of comments) {
+		const atMs = parseMs(comment.createdAt);
+		if (atMs > sinceMs) {
+			items.push({
+				kind: "comment",
+				author: comment.author?.login ?? null,
+				body: comment.body,
+				atMs,
+			});
+		}
+	}
+	for (const submission of submissions) {
+		const atMs = parseMs(submission.submittedAt);
+		if (atMs > sinceMs) {
+			items.push({
+				kind: "verdict",
+				author: submission.author?.login ?? null,
+				state: submission.state,
+				body: submission.body,
+				atMs,
+			});
+		}
+	}
+	for (const event of events) {
+		const atMs = parseMs(event.createdAt);
+		if (atMs <= sinceMs) continue;
+		const author = event.actor?.login ?? null;
+		if (event.kind === "reviewRequested") {
+			items.push({
+				kind: "reviewRequested",
+				author,
+				requestedReviewer: event.requestedReviewer?.login ?? null,
+				atMs,
+			});
+		} else {
+			items.push({ kind: "committed", author, atMs });
+		}
+	}
+	return items;
+};

--- a/apps/lite/ui/src/review-arrival.module.css
+++ b/apps/lite/ui/src/review-arrival.module.css
@@ -1,0 +1,7 @@
+/* Colocated "new" marker: small pop-colored text that rides inside prose
+   lines and flex rows alike. */
+.fresh {
+	display: inline-flex;
+	align-items: center;
+	color: var(--fill-pop-bg);
+}

--- a/apps/lite/ui/src/review-arrival.tsx
+++ b/apps/lite/ui/src/review-arrival.tsx
@@ -1,0 +1,101 @@
+/**
+ * @file Marking what arrived since the user last looked.
+ *
+ * The PR view provides `SeenOnArrivalContext` from `review-seen.ts`; any
+ * timeline entry newer than that snapshot — or recorded as skipped on an
+ * earlier visit — wears this marker. The marker is also the seer: once it
+ * has sat in the focused viewport for a beat, it reports its item seen, and
+ * only then does the next visit consider the item read.
+ */
+
+import { classes } from "#ui/components/classes.ts";
+import {
+	isItemSkipped,
+	markItemSeen,
+	registerReviewItems,
+	SeenOnArrivalContext,
+	unregisterReviewItems,
+} from "#ui/review-seen.ts";
+import type { ForgeReviewUser } from "@gitbutler/but-sdk";
+import { useContext, useEffect, useRef, useState, type FC } from "react";
+import styles from "./review-arrival.module.css";
+
+/** In view this long, focused, before an item counts as looked at. */
+const seenBeatMs = 1000;
+
+/**
+ * Registers a surface's unread-eligible items — what the dwell may record
+ * as skipped — keyed the way their markers key themselves. Renders nothing.
+ */
+export const RegisterFreshItems: FC<{
+	source: string;
+	items: Array<{ key: string; atMs: number }>;
+}> = ({ source, items }) => {
+	const { projectId, reviewNumber } = useContext(SeenOnArrivalContext);
+	useEffect(() => {
+		registerReviewItems(projectId, reviewNumber, source, items);
+		return () => unregisterReviewItems(projectId, reviewNumber, source);
+	}, [projectId, reviewNumber, source, items]);
+	return null;
+};
+
+/** "New" beside a timeline entry that landed after the reader last looked. */
+export const FreshBadge: FC<{
+	timestamp: number | null;
+	author?: ForgeReviewUser | null;
+	/** The item's stable key; without one the marker cannot be seen away. */
+	itemKey?: string;
+}> = ({ timestamp, author, itemKey }) => {
+	const { sinceMs, selfLogin, projectId, reviewNumber } = useContext(SeenOnArrivalContext);
+	const ref = useRef<HTMLSpanElement | null>(null);
+	// Decided at mount and held: store writes must not pull the marker out
+	// from under the reader mid-visit. The next visit re-decides.
+	const [show] = useState(() => {
+		// The reader's own actions post-date arrival by definition; not news.
+		const own =
+			author != null &&
+			selfLogin !== null &&
+			author.login.toLowerCase() === selfLogin.toLowerCase();
+		if (own || timestamp === null) return false;
+		return (
+			timestamp > sinceMs ||
+			(itemKey !== undefined && isItemSkipped(projectId, reviewNumber, itemKey))
+		);
+	});
+
+	useEffect(() => {
+		const el = ref.current;
+		if (!show || itemKey === undefined || el === null) return;
+		let timer: number | undefined;
+		let inView = false;
+		const arm = () => {
+			clearTimeout(timer);
+			timer = window.setTimeout(() => {
+				if (document.hasFocus()) markItemSeen(projectId, reviewNumber, itemKey);
+			}, seenBeatMs);
+		};
+		const observer = new IntersectionObserver(([entry]) => {
+			inView = entry?.isIntersecting ?? false;
+			if (inView) arm();
+			else clearTimeout(timer);
+		});
+		observer.observe(el);
+		// An unfocused beat writes nothing; regaining focus re-arms it.
+		const onFocus = () => {
+			if (inView) arm();
+		};
+		window.addEventListener("focus", onFocus);
+		return () => {
+			clearTimeout(timer);
+			observer.disconnect();
+			window.removeEventListener("focus", onFocus);
+		};
+	}, [show, itemKey, projectId, reviewNumber]);
+
+	if (!show) return null;
+	return (
+		<span className={classes("text-11", "text-semibold", styles.fresh)} ref={ref}>
+			New
+		</span>
+	);
+};

--- a/apps/lite/ui/src/review-inbox-bell.module.css
+++ b/apps/lite/ui/src/review-inbox-bell.module.css
@@ -1,0 +1,143 @@
+/* A ghost header button, plus an anchor for the unread dot. */
+.bell {
+	position: relative;
+}
+
+/* Focus shows as the hover tint: a ring around a header icon reads as
+   clutter, and the tint keeps keyboard position visible. */
+.bell:focus-visible {
+	outline: none;
+	background-color: var(--list-item-hover-bg);
+}
+
+.bellDot {
+	position: absolute;
+	top: 4px;
+	right: 4px;
+	width: 7px;
+	height: 7px;
+	border: 1.5px solid var(--bg-1);
+	border-radius: 50%;
+	background-color: var(--fill-danger-bg);
+}
+
+.panel {
+	display: flex;
+	flex-direction: column;
+	width: 380px;
+	max-height: min(60vh, 560px);
+	overflow: hidden;
+	border: 1px solid var(--border-2);
+	border-radius: 8px;
+	/* The popup takes focus on open; the browser would paint its own
+	   accent-colored ring on a div no app rule covers. */
+	outline: none;
+	background-color: var(--bg-1);
+	box-shadow: 0 8px 24px rgb(0 0 0 / 15%);
+}
+
+.panelHeader {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 10px 12px;
+	border-bottom: 1px solid var(--border-3);
+}
+
+.markAll {
+	padding: 0;
+	border: none;
+	background: none;
+	color: var(--text-2);
+	text-decoration: underline dotted;
+	text-underline-position: from-font;
+	cursor: pointer;
+}
+
+.empty {
+	padding: 20px 12px;
+	color: var(--text-3);
+	text-align: center;
+}
+
+.list {
+	overflow-y: auto;
+}
+
+.entry {
+	display: flex;
+	align-items: flex-start;
+	width: 100%;
+	padding: 10px 12px;
+	gap: 8px;
+	border: none;
+	border-bottom: 1px solid var(--border-3);
+	background: none;
+	/* The list reads as a murmur; the red dots and kind icons carry it. */
+	color: var(--text-2);
+	text-align: start;
+	cursor: pointer;
+}
+
+.entry:last-child {
+	border-bottom: none;
+}
+
+.entry:hover {
+	background-color: var(--list-item-hover-bg);
+}
+
+.entryIcon {
+	flex-shrink: 0;
+	margin-block-start: 1px;
+	color: var(--text-3);
+}
+
+.entryIconLoud {
+	color: var(--fill-pop-bg);
+}
+
+.entryBody {
+	display: flex;
+	flex-grow: 1;
+	flex-direction: column;
+	min-width: 0;
+	gap: 2px;
+}
+
+/* Leads the row, one step above the murmur: the title is what you scan
+   for, and it wraps rather than truncates. */
+.entryTitle {
+	color: var(--text-1);
+	overflow-wrap: anywhere;
+}
+
+.entryAction {
+	color: var(--text-3);
+}
+
+.entrySnippet {
+	overflow: hidden;
+	color: var(--text-3);
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.entryEnd {
+	display: flex;
+	flex-shrink: 0;
+	align-items: center;
+	gap: 6px;
+}
+
+/* Blue, not the bell's red: within the list it marks state, not alarm. */
+.entryUnseen {
+	width: 6px;
+	height: 6px;
+	border-radius: 50%;
+	background-color: var(--fill-blue-bg);
+}
+
+.entryTime {
+	color: var(--text-3);
+}

--- a/apps/lite/ui/src/review-inbox-bell.tsx
+++ b/apps/lite/ui/src/review-inbox-bell.tsx
@@ -1,0 +1,192 @@
+/**
+ * @file The bell: the inbox's face in the window corner.
+ *
+ * A red dot says entries wait unseen; the popover lists them richly, each
+ * kind with its own shape, newest first. Opening the panel does not mark
+ * anything seen — clicking an entry does, the same way seeing works
+ * everywhere else in this feature.
+ */
+
+import { forgeInfoOptions, headInfoQueryOptions } from "#ui/api/queries.ts";
+import { branchAddress } from "#ui/addresses.ts";
+import { Icon } from "#ui/components/Icon.tsx";
+import type { IconName } from "#ui/components/iconNames.ts";
+import { RelativeTime } from "#ui/components/RelativeTime.tsx";
+import { classes } from "#ui/components/classes.ts";
+import { getButtonClassName } from "#ui/components/Button.tsx";
+import { projectSlice } from "#ui/projects/state.ts";
+import { appliedRefsByName } from "#ui/review-notifications.ts";
+import {
+	markInboxSeen,
+	useInboxEntries,
+	useInboxUnseenCount,
+	type InboxEntry,
+	type InboxKind,
+} from "#ui/review-inbox.ts";
+import { usePrNotificationsLevel } from "#ui/review-seen.ts";
+import { store } from "#ui/store.ts";
+import { setCursor, setPage } from "#ui/use-cursor.ts";
+import { Popover } from "@base-ui/react";
+import { useQuery } from "@tanstack/react-query";
+import { useState, type FC } from "react";
+import styles from "./review-inbox-bell.module.css";
+
+const kindIcon: Record<InboxKind, IconName> = {
+	comment: "text-block",
+	mention: "text-block",
+	approved: "tick-circle",
+	changesRequested: "cross-circle",
+	reviewRequested: "user",
+	committed: "commit",
+	merged: "branch-merge",
+	closed: "pr-close",
+};
+
+/** The sentence fragment after the author — "commented on", "approved". */
+const kindPhrase = (entry: InboxEntry): string => {
+	const many = entry.count > 1;
+	switch (entry.kind) {
+		case "comment":
+			return many ? `left ${entry.count} comments on` : "commented on";
+		case "mention":
+			return "mentioned you on";
+		case "approved":
+			return "approved";
+		case "changesRequested":
+			return "requested changes on";
+		case "reviewRequested":
+			return "requested your review on";
+		case "committed":
+			return many ? `pushed ${entry.count} commits to` : "pushed a commit to";
+		case "merged":
+			return "merged";
+		case "closed":
+			return "closed";
+	}
+};
+
+const Entry: FC<{
+	projectId: string;
+	entry: InboxEntry;
+	/** Shared by the bell: one head-info subscription serves every row. */
+	appliedRefs: Map<string, Array<number>> | undefined;
+	/** The panel closes itself once a click has somewhere to go. */
+	onNavigate: () => void;
+}> = ({ projectId, entry, appliedRefs, onNavigate }) => {
+	const open = () => {
+		// Still loading is not "not in the workspace": acting now could open
+		// the forge for a local branch, and eat the unread mark doing it.
+		if (appliedRefs === undefined) return;
+		onNavigate();
+		markInboxSeen(projectId, [entry.id]);
+		const branchRef = appliedRefs.get(entry.sourceBranch);
+		// A review outside the workspace has no local branch to select, so
+		// it opens on the forge instead.
+		if (branchRef === undefined) {
+			void window.lite.openInWebBrowser(entry.htmlUrl);
+			return;
+		}
+		setPage("workspace");
+		setCursor("applied", branchAddress({ branchRef }));
+		store.dispatch(
+			projectSlice.actions.setSelectedBranchTab({
+				projectId,
+				branchName: entry.sourceBranch,
+				tab: "pr",
+			}),
+		);
+	};
+
+	return (
+		<button className={styles.entry} onClick={open} type="button">
+			<Icon
+				name={kindIcon[entry.kind]}
+				className={classes(styles.entryIcon, entry.kind === "mention" && styles.entryIconLoud)}
+			/>
+			<span className={styles.entryBody}>
+				<span className={classes("text-12", styles.entryTitle)}>{entry.reviewTitle}</span>
+				<span className={classes("text-11", styles.entryAction)}>
+					{entry.author !== null && <span>{entry.author} </span>}
+					{kindPhrase(entry)} {entry.unitSymbol}
+					{entry.review}
+				</span>
+				{entry.snippet !== null && (
+					<span className={classes("text-11", styles.entrySnippet)}>{entry.snippet}</span>
+				)}
+			</span>
+			<span className={styles.entryEnd}>
+				{!entry.seen && <span aria-hidden className={styles.entryUnseen} />}
+				<RelativeTime
+					timestamp={Date.parse(entry.at)}
+					compact
+					className={classes("text-11", styles.entryTime)}
+				/>
+			</span>
+		</button>
+	);
+};
+
+/**
+ * The bell in the sidebar header. It owns its visibility: nothing renders
+ * without forge review support, or below the loud dial.
+ */
+export const NotificationBell: FC<{ projectId: string }> = ({ projectId }) => {
+	const [open, setOpen] = useState(false);
+	const { data: forgeInfo } = useQuery(forgeInfoOptions(projectId));
+	// Unconditional: behind `&&` the hook count would change mid-mount.
+	const level = usePrNotificationsLevel();
+	const shown = level === "loud" && !!forgeInfo?.capabilities.prService;
+	const entries = useInboxEntries(projectId, shown);
+	const unseen = useInboxUnseenCount(projectId, shown);
+	const { data: appliedRefs } = useQuery({
+		...headInfoQueryOptions(projectId),
+		select: appliedRefsByName,
+		enabled: shown,
+	});
+	if (!shown) return null;
+
+	return (
+		<Popover.Root open={open} onOpenChange={setOpen}>
+			<Popover.Trigger
+				aria-label={unseen > 0 ? `Notifications, ${unseen} unread` : "Notifications"}
+				className={classes(getButtonClassName({ iconOnly: true, variant: "ghost" }), styles.bell)}
+			>
+				<Icon name="bell" />
+				{unseen > 0 && <span aria-hidden className={styles.bellDot} />}
+			</Popover.Trigger>
+			<Popover.Portal>
+				<Popover.Positioner align="start" sideOffset={6}>
+					<Popover.Popup className={styles.panel}>
+						<div className={styles.panelHeader}>
+							<span className={classes("text-12", "text-semibold")}>Notifications</span>
+							{unseen > 0 && (
+								<button
+									className={classes("text-12", styles.markAll)}
+									onClick={() => markInboxSeen(projectId)}
+									type="button"
+								>
+									Mark all read
+								</button>
+							)}
+						</div>
+						{entries.length === 0 ? (
+							<div className={classes("text-12", styles.empty)}>Nothing yet</div>
+						) : (
+							<div className={styles.list}>
+								{entries.map((entry) => (
+									<Entry
+										key={entry.id}
+										projectId={projectId}
+										entry={entry}
+										appliedRefs={appliedRefs}
+										onNavigate={() => setOpen(false)}
+									/>
+								))}
+							</div>
+						)}
+					</Popover.Popup>
+				</Popover.Positioner>
+			</Popover.Portal>
+		</Popover.Root>
+	);
+};

--- a/apps/lite/ui/src/review-inbox.test.ts
+++ b/apps/lite/ui/src/review-inbox.test.ts
@@ -1,0 +1,73 @@
+/** @vitest-environment jsdom */
+import { addInboxEntries, markInboxSeen, type InboxEntry } from "./review-inbox.ts";
+import { describe, expect, it } from "vitest";
+
+/**
+ * The module caches per storage key, so each test gets its own project id
+ * rather than sharing a window-wide reset.
+ */
+let nextProject = 0;
+const freshProject = () => `test-project-${nextProject++}`;
+
+const stored = (projectId: string): Array<InboxEntry> =>
+	JSON.parse(
+		localStorage.getItem(`pr_activity_inbox:v1:${projectId}`) ?? "[]",
+	) as Array<InboxEntry>;
+
+const at = (minute: number) => `2026-08-30T10:${String(minute).padStart(2, "0")}:00.000Z`;
+
+const entry = (id: string, minute: number, overrides: Partial<InboxEntry> = {}): InboxEntry => ({
+	id,
+	kind: "comment",
+	review: 7,
+	reviewTitle: "A fixture change",
+	unitSymbol: "#",
+	sourceBranch: "feature-one",
+	htmlUrl: "https://example.com/7",
+	author: "alice",
+	count: 1,
+	snippet: null,
+	at: at(minute),
+	seen: false,
+	...overrides,
+});
+
+describe("addInboxEntries", () => {
+	it("keeps the list ordered by each entry's own time, across polls", () => {
+		const projectId = freshProject();
+		addInboxEntries(projectId, [entry("a", 30)]);
+		// A later poll files an entry whose newest item is older — it must
+		// sort by its time, not jump the queue for arriving late.
+		addInboxEntries(projectId, [entry("b", 10), entry("c", 40)]);
+
+		expect(stored(projectId).map((e) => e.id)).toEqual(["c", "a", "b"]);
+	});
+
+	it("leaves an already-filed id exactly where it is, seen state and all", () => {
+		const projectId = freshProject();
+		addInboxEntries(projectId, [entry("a", 10)]);
+		markInboxSeen(projectId, ["a"]);
+		// The review bumped again but this kind's bucket did not change.
+		addInboxEntries(projectId, [entry("a", 10), entry("b", 20)]);
+
+		expect(stored(projectId).map((e) => [e.id, e.seen])).toEqual([
+			["b", false],
+			["a", true],
+		]);
+	});
+
+	it("drops the oldest past the cap", () => {
+		const projectId = freshProject();
+		addInboxEntries(
+			projectId,
+			Array.from({ length: 105 }, (_, i) =>
+				entry(`e${i}`, 0, { at: new Date(1756500000000 + i * 60000).toISOString() }),
+			),
+		);
+
+		const kept = stored(projectId);
+		expect(kept).toHaveLength(100);
+		expect(kept[0]?.id).toBe("e104");
+		expect(kept[99]?.id).toBe("e5");
+	});
+});

--- a/apps/lite/ui/src/review-inbox.ts
+++ b/apps/lite/ui/src/review-inbox.ts
@@ -1,0 +1,192 @@
+/**
+ * @file The notification inbox behind the bell.
+ *
+ * One entry per review, kind and poll — the detector writes what happened,
+ * structured, and the bell renders it richly. Same store discipline as the
+ * watermarks: local storage, disposable, capped, validated at parse, pure
+ * in-memory snapshots.
+ */
+
+import { useSyncExternalStore } from "react";
+
+export type InboxKind =
+	| "comment"
+	| "mention"
+	| "approved"
+	| "changesRequested"
+	| "reviewRequested"
+	| "committed"
+	| "merged"
+	| "closed";
+
+export type InboxEntry = {
+	id: string;
+	kind: InboxKind;
+	review: number;
+	reviewTitle: string;
+	unitSymbol: string;
+	sourceBranch: string;
+	htmlUrl: string;
+	author: string | null;
+	/** How many items this entry coalesces — "3 comments". */
+	count: number;
+	snippet: string | null;
+	at: string;
+	seen: boolean;
+};
+
+const inboxKinds: ReadonlyArray<string> = [
+	"comment",
+	"mention",
+	"approved",
+	"changesRequested",
+	"reviewRequested",
+	"committed",
+	"merged",
+	"closed",
+];
+
+const storageKey = (projectId: string) => `pr_activity_inbox:v1:${projectId}`;
+
+/** Newest kept; the overflow was old news nobody opened. */
+const inboxCap = 100;
+
+const listeners = new Set<() => void>();
+let cached: { key: string; entries: Array<InboxEntry> } | null = null;
+
+// Storage can throw — disabled, partitioned, or over quota — and a throw
+// here would crash every subscriber's render. The inbox degrades instead.
+const storageGet = (key: string): string | null => {
+	try {
+		return localStorage.getItem(key);
+	} catch {
+		return null;
+	}
+};
+const storageSet = (key: string, value: string): void => {
+	try {
+		localStorage.setItem(key, value);
+	} catch {
+		// The in-memory copy still serves this session.
+	}
+};
+
+const parseEntries = (raw: string | null): Array<InboxEntry> => {
+	if (raw === null) return [];
+	try {
+		const stored: unknown = JSON.parse(raw);
+		if (!Array.isArray(stored)) return [];
+		// Ordered here, not just at write time: a list stored by an older
+		// build keeps whatever order it had until something new files.
+		return stored
+			.filter((entry): entry is InboxEntry => {
+				if (typeof entry !== "object" || entry === null) return false;
+				const e = entry as Record<string, unknown>;
+				return (
+					typeof e.id === "string" &&
+					typeof e.kind === "string" &&
+					inboxKinds.includes(e.kind) &&
+					typeof e.review === "number" &&
+					typeof e.reviewTitle === "string" &&
+					typeof e.unitSymbol === "string" &&
+					typeof e.sourceBranch === "string" &&
+					typeof e.htmlUrl === "string" &&
+					(e.author === null || typeof e.author === "string") &&
+					typeof e.count === "number" &&
+					(e.snippet === null || typeof e.snippet === "string") &&
+					typeof e.at === "string" &&
+					!Number.isNaN(Date.parse(e.at)) &&
+					typeof e.seen === "boolean"
+				);
+			})
+			.sort((a, b) => Date.parse(b.at) - Date.parse(a.at))
+			.slice(0, inboxCap);
+	} catch {
+		return [];
+	}
+};
+
+const readEntries = (projectId: string): Array<InboxEntry> => {
+	const key = storageKey(projectId);
+	if (cached?.key === key) return cached.entries;
+	const entries = parseEntries(storageGet(key));
+	cached = { key, entries };
+	return entries;
+};
+
+const notify = (): void => {
+	for (const listener of listeners) listener();
+};
+
+const writeEntries = (projectId: string, entries: Array<InboxEntry>): void => {
+	storageSet(storageKey(projectId), JSON.stringify(entries));
+	cached = { key: storageKey(projectId), entries };
+	notify();
+};
+
+let watchingStorage = false;
+
+const onStorage = (event: StorageEvent): void => {
+	// A null key is a wholesale clear; other keys are someone else's business.
+	if (event.key !== null && !event.key.startsWith("pr_activity_")) return;
+	cached = null;
+	notify();
+};
+
+const subscribeInbox = (listener: () => void): (() => void) => {
+	// On first use, so merely importing this module listens to nothing.
+	if (!watchingStorage) {
+		watchingStorage = true;
+		window.addEventListener("storage", onStorage);
+	}
+	// A first subscriber is a fresh surface: re-read whatever storage holds.
+	if (listeners.size === 0) cached = null;
+	listeners.add(listener);
+	return () => listeners.delete(listener);
+};
+
+const subscribeNothing = (): (() => void) => () => {};
+
+/**
+ * File the poll's entries, keeping the list ordered by each entry's own
+ * time. An id already filed is left exactly where it is, seen state and
+ * all — a review bumping again must not resurface an old entry as new.
+ */
+export const addInboxEntries = (projectId: string, entries: Array<InboxEntry>): void => {
+	if (entries.length === 0) return;
+	const existing = readEntries(projectId);
+	const known = new Set(existing.map((entry) => entry.id));
+	const fresh = entries.filter((entry) => !known.has(entry.id));
+	if (fresh.length === 0) return;
+	const next = [...fresh, ...existing]
+		.sort((a, b) => Date.parse(b.at) - Date.parse(a.at))
+		.slice(0, inboxCap);
+	writeEntries(projectId, next);
+};
+
+/** Mark the given entries seen; without ids, everything. */
+export const markInboxSeen = (projectId: string, ids?: ReadonlyArray<string>): void => {
+	const entries = readEntries(projectId);
+	const wanted = ids === undefined ? null : new Set(ids);
+	if (!entries.some((entry) => !entry.seen && (wanted === null || wanted.has(entry.id)))) return;
+	writeEntries(
+		projectId,
+		entries.map((entry) =>
+			!entry.seen && (wanted === null || wanted.has(entry.id)) ? { ...entry, seen: true } : entry,
+		),
+	);
+};
+
+/** The inbox, newest first — a stable array identity between writes. */
+export const useInboxEntries = (projectId: string, enabled: boolean): Array<InboxEntry> =>
+	useSyncExternalStore(enabled ? subscribeInbox : subscribeNothing, () =>
+		enabled ? readEntries(projectId) : emptyInbox,
+	);
+
+const emptyInbox: Array<InboxEntry> = [];
+
+/** How many entries are unseen — the bell's dot. */
+export const useInboxUnseenCount = (projectId: string, enabled: boolean): number =>
+	useSyncExternalStore(enabled ? subscribeInbox : subscribeNothing, () =>
+		enabled ? readEntries(projectId).filter((entry) => !entry.seen).length : 0,
+	);

--- a/apps/lite/ui/src/review-notifications.ts
+++ b/apps/lite/ui/src/review-notifications.ts
@@ -1,0 +1,225 @@
+/**
+ * @file Turning review activity into inbox entries.
+ *
+ * The decisions are pure and live in `review-activity.ts`; the hook here
+ * feeds them the listing the app polls anyway. The unread dots stay the
+ * record — the bell is the cross-review view of the same facts.
+ */
+
+import {
+	activityItems,
+	attentionOf,
+	itemMentions,
+	observeReviews,
+	seenLedger,
+	type ActivityLedger,
+	type ReviewActivityItem,
+	type ReviewChange,
+} from "#ui/review-activity.ts";
+import {
+	currentForgeLoginQueryOptions,
+	forgeInfoOptions,
+	headInfoQueryOptions,
+	listReviewCommentsQueryOptions,
+	listReviewSubmissionsQueryOptions,
+	listReviewTimelineEventsQueryOptions,
+	listReviewsQueryOptions,
+} from "#ui/api/queries.ts";
+import { addInboxEntries, type InboxEntry, type InboxKind } from "#ui/review-inbox.ts";
+import { readSeenMarks, usePrNotificationsLevel } from "#ui/review-seen.ts";
+import { selfMergedNumbers } from "#ui/api/mutations.ts";
+import type { ForgeReview, RefInfo } from "@gitbutler/but-sdk";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useEffectEvent, useRef } from "react";
+
+/** @public shared with the bell, whose entry clicks jump the same way. */
+export const appliedRefsByName = (headInfo: RefInfo): Map<string, Array<number>> =>
+	new Map(
+		headInfo.stacks.flatMap((stack) =>
+			stack.segments.flatMap((segment) =>
+				segment.refName
+					? [[segment.refName.displayName, segment.refName.fullNameBytes] as const]
+					: [],
+			),
+		),
+	);
+
+/** The kind an item files under; mentions outrank the item's own shape. */
+const inboxKindOf = (item: ReviewActivityItem, login: string | null): InboxKind => {
+	if (itemMentions(item, login)) return "mention";
+	switch (item.kind) {
+		case "comment":
+			return "comment";
+		case "verdict":
+			// A "commented" verdict is the note a comment batch arrives with.
+			if (item.state === "approved") return "approved";
+			if (item.state === "changesRequested") return "changesRequested";
+			return "comment";
+		case "reviewRequested":
+			return "reviewRequested";
+		case "committed":
+			return "committed";
+	}
+};
+
+const firstLine = (body: string | null): string | null => {
+	const line = body?.split("\n").find((candidate) => candidate.trim() !== "");
+	return line === undefined ? null : line.trim().slice(0, 140);
+};
+
+/** One coalesced entry: a kind's items on one review in one poll. */
+const entryOf = (
+	review: ForgeReview,
+	kind: InboxKind,
+	bucket: Array<ReviewActivityItem>,
+): InboxEntry => {
+	const newest = bucket.reduce<ReviewActivityItem | null>(
+		(best, item) => (best === null || item.atMs > best.atMs ? item : best),
+		null,
+	);
+	const at =
+		newest === null
+			? (review.modifiedAt ?? new Date().toISOString())
+			: new Date(newest.atMs).toISOString();
+	return {
+		id: `${review.number}:${kind}:${at}`,
+		kind,
+		review: review.number,
+		reviewTitle: review.title,
+		unitSymbol: review.unitSymbol,
+		sourceBranch: review.sourceBranch,
+		htmlUrl: review.htmlUrl,
+		author: newest?.author ?? null,
+		count: Math.max(bucket.length, 1),
+		snippet:
+			newest !== null && (newest.kind === "comment" || newest.kind === "verdict")
+				? firstLine(newest.body)
+				: null,
+		at,
+		seen: false,
+	};
+};
+
+/**
+ * Watch the review listing and file activity into the inbox. The first
+ * listing observed is the baseline — nothing older is filed; the dots carry
+ * that. Applied-branch reviews file everything short of silent, the rest
+ * only mentions, and a kind's items on one review coalesce into one entry.
+ */
+export const useReviewActivityInbox = (projectId: string): void => {
+	const client = useQueryClient();
+	const level = usePrNotificationsLevel();
+
+	const { data: forgeInfo } = useQuery(forgeInfoOptions(projectId));
+	const enabled = level === "loud" && !!forgeInfo?.capabilities.prService;
+	const { data: reviews } = useQuery({
+		...listReviewsQueryOptions({ projectId, cacheConfig: "noCache" }),
+		enabled,
+	});
+	const { data: appliedRefs } = useQuery({
+		...headInfoQueryOptions(projectId),
+		select: appliedRefsByName,
+		enabled,
+	});
+	const { data: selfLogin, isPending: loginPending } = useQuery({
+		...currentForgeLoginQueryOptions(projectId),
+		enabled,
+	});
+
+	const ledger = useRef<ActivityLedger | null>(null);
+
+	const entriesOf = useEffectEvent(async (change: ReviewChange, applied: boolean) => {
+		const login = selfLogin ?? null;
+		if (change.settledNow !== null) {
+			if (!applied || selfMergedNumbers(client, projectId).has(change.review.number)) return [];
+			return [entryOf(change.review, change.settledNow, [])];
+		}
+		// Without conversation listings there is nothing to classify — the
+		// bump stays a quiet dot rather than guessing at loudness.
+		if (forgeInfo?.capabilities.reviewComments === false) return [];
+		const reviewId = change.review.number;
+		// The client caches at staleTime Infinity; without an explicit 0 these
+		// would silently answer from cache and re-classify old items as new.
+		const [comments, submissions, events] = await Promise.all([
+			client.fetchQuery({
+				...listReviewCommentsQueryOptions({ projectId, reviewId }),
+				staleTime: 0,
+			}),
+			client.fetchQuery({
+				...listReviewSubmissionsQueryOptions({ projectId, reviewId }),
+				staleTime: 0,
+			}),
+			// Mentions live in comment and verdict text, so a review outside
+			// the workspace does not need the timeline.
+			applied
+				? client.fetchQuery({
+						...listReviewTimelineEventsQueryOptions({ projectId, reviewId }),
+						staleTime: 0,
+					})
+				: Promise.resolve([]),
+		]);
+		// Outside the workspace only a mention is the user's business; on an
+		// applied branch anything short of silent lands in the inbox — the
+		// bell holds quiet facts like pushes that a toast never carried.
+		const items = activityItems(comments, submissions, events, change.sinceMs).filter((item) => {
+			const attention = attentionOf(item, login);
+			if (attention === "silent") return false;
+			if (!applied && !itemMentions(item, login)) return false;
+			// A request naming someone else, or a dismissed verdict, is
+			// bookkeeping rather than a message.
+			if (item.kind === "reviewRequested" && attention !== "loud") return false;
+			if (item.kind === "verdict" && item.state === "dismissed") return false;
+			return true;
+		});
+		const buckets = new Map<InboxKind, Array<ReviewActivityItem>>();
+		for (const item of items) {
+			const kind = inboxKindOf(item, login);
+			const bucket = buckets.get(kind);
+			if (bucket) bucket.push(item);
+			else buckets.set(kind, [item]);
+		}
+		return [...buckets].map(([kind, bucket]) => entryOf(change.review, kind, bucket));
+	});
+
+	const observe = useEffectEvent(async (listing: Array<ForgeReview>) => {
+		if (!appliedRefs) return;
+		if (ledger.current === null) {
+			// Seeded from what has actually been seen, so activity that landed
+			// while the app was closed still speaks up.
+			ledger.current = seenLedger(listing, readSeenMarks(projectId));
+		}
+		const { changed, next } = observeReviews(ledger.current, listing);
+		ledger.current = next;
+		if (changed.length === 0) return;
+
+		// Classified in parallel: one slow review must not hold back the rest.
+		const entries = (
+			await Promise.all(
+				changed.map(async (change) => {
+					try {
+						return await entriesOf(change, appliedRefs.has(change.review.sourceBranch));
+					} catch {
+						// A flaky forge read costs one entry; the unread dot still shows.
+						return [];
+					}
+				}),
+			)
+		).flat();
+		addInboxEntries(projectId, entries);
+	});
+
+	// A disabled detector forgets its baseline, so re-enabling starts from
+	// the then-current listing instead of replaying the interim as news.
+	useEffect(() => {
+		if (!enabled) ledger.current = null;
+	}, [enabled, projectId]);
+
+	// `appliedRefs` in the deps takes the baseline as soon as both the
+	// listing and the applied set exist, whichever resolves last. The login
+	// holds it too: classifying before it loads would consume a bump with
+	// mention detection blind, and the ledger never re-examines a change.
+	// A login query *error* proceeds with no login rather than going deaf.
+	useEffect(() => {
+		if (enabled && reviews && !loginPending) void observe(reviews.reviews);
+	}, [enabled, reviews, appliedRefs, loginPending]);
+};

--- a/apps/lite/ui/src/review-seen.test.ts
+++ b/apps/lite/ui/src/review-seen.test.ts
@@ -1,0 +1,108 @@
+/** @vitest-environment jsdom */
+import { isItemSkipped, markItemSeen, markReviewSeen, registerReviewItems } from "./review-seen.ts";
+import { describe, expect, it } from "vitest";
+
+/**
+ * The module caches per storage key, so each test gets its own project id
+ * rather than sharing a window-wide reset.
+ */
+let nextProject = 0;
+const freshProject = () => `test-project-${nextProject++}`;
+
+const unseenOf = (projectId: string): Record<string, Array<[string, string]>> =>
+	JSON.parse(localStorage.getItem(`pr_activity_unseen:v1:${projectId}`) ?? "{}") as Record<
+		string,
+		Array<[string, string]>
+	>;
+const marksOf = (projectId: string): Record<string, string> =>
+	JSON.parse(localStorage.getItem(`pr_activity_seen:v1:${projectId}`) ?? "{}") as Record<
+		string,
+		string
+	>;
+
+const at = (minute: number) => `2026-08-30T10:${String(minute).padStart(2, "0")}:00.000Z`;
+const atMs = (minute: number) => Date.parse(at(minute));
+
+describe("markReviewSeen", () => {
+	it("records registered items above the old watermark as skips", () => {
+		const projectId = freshProject();
+		localStorage.setItem(`pr_activity_seen:v1:${projectId}`, JSON.stringify({ 7: at(0) }));
+		registerReviewItems(projectId, 7, "conversation", [
+			{ key: "c:1", atMs: atMs(5) },
+			{ key: "c:2", atMs: atMs(10) },
+		]);
+
+		markReviewSeen(projectId, 7, at(15));
+
+		expect(marksOf(projectId)[7]).toBe(at(15));
+		expect(unseenOf(projectId)[7]?.map(([key]) => key)).toEqual(["c:1", "c:2"]);
+	});
+
+	it("does not skip items already below the watermark, or looked at first", () => {
+		const projectId = freshProject();
+		localStorage.setItem(`pr_activity_seen:v1:${projectId}`, JSON.stringify({ 7: at(6) }));
+		registerReviewItems(projectId, 7, "conversation", [
+			{ key: "c:1", atMs: atMs(5) },
+			{ key: "c:2", atMs: atMs(10) },
+			{ key: "c:3", atMs: atMs(12) },
+		]);
+		// Looked at before the dwell fired: pre-empted, never a skip.
+		markItemSeen(projectId, 7, "c:3");
+
+		markReviewSeen(projectId, 7, at(15));
+
+		expect(unseenOf(projectId)[7]?.map(([key]) => key)).toEqual(["c:2"]);
+	});
+
+	it("keeps existing skips across further advances, capped oldest-first", () => {
+		const projectId = freshProject();
+		localStorage.setItem(`pr_activity_seen:v1:${projectId}`, JSON.stringify({ 7: at(0) }));
+		registerReviewItems(
+			projectId,
+			7,
+			"conversation",
+			Array.from({ length: 55 }, (_, i) => ({ key: `c:${i}`, atMs: atMs(1) + i * 1000 })),
+		);
+
+		markReviewSeen(projectId, 7, at(15));
+
+		const kept = unseenOf(projectId)[7] ?? [];
+		expect(kept).toHaveLength(50);
+		// The oldest five dropped: reading as seen is the safe failure.
+		expect(kept[0]?.[0]).toBe("c:5");
+	});
+
+	it("merges what several surfaces registered", () => {
+		const projectId = freshProject();
+		localStorage.setItem(`pr_activity_seen:v1:${projectId}`, JSON.stringify({ 7: at(0) }));
+		registerReviewItems(projectId, 7, "conversation", [{ key: "c:1", atMs: atMs(5) }]);
+		registerReviewItems(projectId, 7, "timeline", [{ key: "e:committed:x", atMs: atMs(6) }]);
+
+		markReviewSeen(projectId, 7, at(15));
+
+		expect(unseenOf(projectId)[7]?.map(([key]) => key)).toEqual(["c:1", "e:committed:x"]);
+	});
+});
+
+describe("markItemSeen", () => {
+	it("clears a recorded skip, and the review with the last of them", () => {
+		const projectId = freshProject();
+		localStorage.setItem(
+			`pr_activity_unseen:v1:${projectId}`,
+			JSON.stringify({
+				7: [
+					["c:1", at(5)],
+					["c:2", at(10)],
+				],
+			}),
+		);
+
+		expect(isItemSkipped(projectId, 7, "c:1")).toBe(true);
+		markItemSeen(projectId, 7, "c:1");
+		expect(isItemSkipped(projectId, 7, "c:1")).toBe(false);
+		expect(unseenOf(projectId)[7]?.map(([key]) => key)).toEqual(["c:2"]);
+
+		markItemSeen(projectId, 7, "c:2");
+		expect(unseenOf(projectId)[7]).toBeUndefined();
+	});
+});

--- a/apps/lite/ui/src/review-seen.ts
+++ b/apps/lite/ui/src/review-seen.ts
@@ -1,0 +1,444 @@
+/**
+ * @file Which review activity the user has seen.
+ *
+ * One watermark per review — "everything up to this `modifiedAt` has been
+ * seen" — in local storage: disposable, per-machine, and synchronous, so a
+ * plain external store rather than a query. Every hook returns a primitive,
+ * so React skips the render when a write leaves it unchanged.
+ */
+
+import {
+	currentForgeLoginQueryOptions,
+	forgeInfoOptions,
+	guiSettingsQueryOptions,
+	listReviewsQueryOptions,
+} from "#ui/api/queries.ts";
+import { defaultSettings } from "#ui/settings.ts";
+import { useQuery } from "@tanstack/react-query";
+import { createContext, useEffect, useEffectEvent, useState, useSyncExternalStore } from "react";
+
+/**
+ * The PR-notifications dial: loud files activity into the bell, quiet
+ * keeps only the unread dots, off hides the tracking UI entirely.
+ */
+export const usePrNotificationsLevel = (): "loud" | "quiet" | "off" => {
+	const { data: level } = useQuery({
+		...guiSettingsQueryOptions,
+		select: (settings) => settings.prNotifications ?? defaultSettings.prNotifications,
+	});
+	return level ?? defaultSettings.prNotifications;
+};
+
+/** Watermark by review number, as the ISO stamps the forge reports. */
+type SeenMarks = Record<number, string>;
+
+const storageKey = (projectId: string) => `pr_activity_seen:v1:${projectId}`;
+
+const listeners = new Set<() => void>();
+// Snapshot reads are pure in-memory lookups — a write fans out to one per
+// branch row. Storage is touched only on a miss, a write, or invalidation.
+let cached: { key: string; marks: SeenMarks } | null = null;
+
+// Storage can throw — disabled, partitioned, or over quota — and a throw
+// here would crash every subscriber's render. Tracking degrades instead.
+const storageGet = (key: string): string | null => {
+	try {
+		return localStorage.getItem(key);
+	} catch {
+		return null;
+	}
+};
+const storageSet = (key: string, value: string): void => {
+	try {
+		localStorage.setItem(key, value);
+	} catch {
+		// The in-memory copy still serves this session.
+	}
+};
+
+/**
+ * Only valid watermarks survive the parse: a foreign entry or unparseable
+ * stamp would baseline the detector at epoch and replay history as news.
+ */
+const parseMarks = (raw: string | null): SeenMarks => {
+	if (raw === null) return {};
+	try {
+		const stored: unknown = JSON.parse(raw);
+		if (typeof stored !== "object" || stored === null || Array.isArray(stored)) return {};
+		const marks: SeenMarks = {};
+		for (const [number, seen] of Object.entries(stored)) {
+			if (typeof seen === "string" && /^\d+$/.test(number) && !Number.isNaN(Date.parse(seen)))
+				marks[Number(number)] = seen;
+		}
+		return marks;
+	} catch {
+		return {};
+	}
+};
+
+const readMarks = (projectId: string): SeenMarks => {
+	const key = storageKey(projectId);
+	if (cached?.key === key) return cached.marks;
+	const marks = parseMarks(storageGet(key));
+	cached = { key, marks };
+	return marks;
+};
+
+/**
+ * Items the reader jumped over: below the watermark yet still unread. The
+ * complement is stored on purpose — a list of *read* items would grow with
+ * everything ever read once one stubborn item pinned the mark, while skipped
+ * items stay few by nature and dropping one merely reads as seen.
+ */
+type UnseenEntries = Record<number, Array<[key: string, at: string]>>;
+
+const unseenStorageKey = (projectId: string) => `pr_activity_unseen:v1:${projectId}`;
+let cachedUnseen: { key: string; entries: UnseenEntries } | null = null;
+
+/** Skipped items per review, oldest first; dropping the overflow reads as seen. */
+const unseenCap = 50;
+
+const parseUnseen = (raw: string | null): UnseenEntries => {
+	if (raw === null) return {};
+	try {
+		const stored: unknown = JSON.parse(raw);
+		if (typeof stored !== "object" || stored === null || Array.isArray(stored)) return {};
+		const entries: UnseenEntries = {};
+		for (const [number, list] of Object.entries(stored)) {
+			if (!/^\d+$/.test(number) || !Array.isArray(list)) continue;
+			const kept = list.filter(
+				(entry): entry is [string, string] =>
+					Array.isArray(entry) &&
+					typeof entry[0] === "string" &&
+					typeof entry[1] === "string" &&
+					!Number.isNaN(Date.parse(entry[1])),
+			);
+			// The newest survive the cap, as the writer keeps them.
+			if (kept.length > 0) entries[Number(number)] = kept.slice(-unseenCap);
+		}
+		return entries;
+	} catch {
+		return {};
+	}
+};
+
+const readUnseen = (projectId: string): UnseenEntries => {
+	const key = unseenStorageKey(projectId);
+	if (cachedUnseen?.key === key) return cachedUnseen.entries;
+	const entries = parseUnseen(storageGet(key));
+	cachedUnseen = { key, entries };
+	return entries;
+};
+
+const setUnseen = (projectId: string, entries: UnseenEntries): void => {
+	storageSet(unseenStorageKey(projectId), JSON.stringify(entries));
+	cachedUnseen = { key: unseenStorageKey(projectId), entries };
+};
+
+const writeUnseen = (projectId: string, entries: UnseenEntries): void => {
+	setUnseen(projectId, entries);
+	notify();
+};
+
+/**
+ * What the PR view is showing, so the dwell knows which items above the old
+ * watermark were on offer, and which the reader already looked at. In memory
+ * only: it is re-registered every visit, and losing the pending set merely
+ * shows a marker once more.
+ */
+const shownItems = new Map<string, Map<string, Array<{ key: string; atMs: number }>>>();
+const pendingSeen = new Map<string, Set<string>>();
+const reviewSlot = (projectId: string, reviewNumber: number) => `${projectId}:${reviewNumber}`;
+
+/** Whether one item is recorded as skipped — unread below the watermark. */
+export const isItemSkipped = (projectId: string, reviewNumber: number, key: string): boolean =>
+	(readUnseen(projectId)[reviewNumber] ?? []).some(([k]) => k === key);
+
+/**
+ * Tell the store which unread-eligible items one surface of the review is
+ * showing. Sources register independently so a surface that renders only
+ * part of the timeline does not erase another's registration.
+ */
+export const registerReviewItems = (
+	projectId: string,
+	reviewNumber: number,
+	source: string,
+	items: Array<{ key: string; atMs: number }>,
+): void => {
+	const slot = reviewSlot(projectId, reviewNumber);
+	const sources = shownItems.get(slot) ?? new Map<string, Array<{ key: string; atMs: number }>>();
+	sources.set(source, items);
+	shownItems.set(slot, sources);
+};
+
+/**
+ * A surface unmounted: its registration must not linger as "on offer", and
+ * the map must not grow with every review ever visited.
+ */
+export const unregisterReviewItems = (
+	projectId: string,
+	reviewNumber: number,
+	source: string,
+): void => {
+	const slot = reviewSlot(projectId, reviewNumber);
+	const sources = shownItems.get(slot);
+	sources?.delete(source);
+	if (sources?.size === 0) shownItems.delete(slot);
+};
+
+/**
+ * One item was actually looked at. Before the dwell has advanced the
+ * watermark it pre-empts the skip; after, it clears the skip.
+ */
+export const markItemSeen = (projectId: string, reviewNumber: number, key: string): void => {
+	const entries = readUnseen(projectId);
+	const skipped = entries[reviewNumber];
+	if (skipped?.some(([k]) => k === key)) {
+		const next = { ...entries };
+		const kept = skipped.filter(([k]) => k !== key);
+		if (kept.length > 0) next[reviewNumber] = kept;
+		else delete next[reviewNumber];
+		writeUnseen(projectId, next);
+		return;
+	}
+	const slot = reviewSlot(projectId, reviewNumber);
+	const pending = pendingSeen.get(slot) ?? new Set<string>();
+	pending.add(key);
+	pendingSeen.set(slot, pending);
+};
+
+const notify = (): void => {
+	for (const listener of listeners) listener();
+};
+
+const writeMarks = (projectId: string, marks: SeenMarks): void => {
+	storageSet(storageKey(projectId), JSON.stringify(marks));
+	cached = { key: storageKey(projectId), marks };
+	notify();
+};
+
+let watchingStorage = false;
+
+/** A write from another window arrives as a storage event. */
+const onStorage = (event: StorageEvent): void => {
+	// A null key is a wholesale clear; anything else outside this feature's
+	// keys is someone else's business.
+	if (event.key !== null && !event.key.startsWith("pr_activity_")) return;
+	cached = null;
+	cachedUnseen = null;
+	notify();
+};
+
+const subscribeMarks = (listener: () => void): (() => void) => {
+	// On first use, so merely importing this module listens to nothing.
+	if (!watchingStorage) {
+		watchingStorage = true;
+		window.addEventListener("storage", onStorage);
+	}
+	// A first subscriber is a fresh surface: re-read whatever storage holds.
+	if (listeners.size === 0) {
+		cached = null;
+		cachedUnseen = null;
+	}
+	listeners.add(listener);
+	return () => listeners.delete(listener);
+};
+
+/** A disabled hook stays out of the fan-out entirely. */
+const subscribeNothing = (): (() => void) => () => {};
+
+/** The stored watermarks, for the activity detector's startup baseline. */
+export const readSeenMarks = (projectId: string): Record<number, string> => readMarks(projectId);
+
+/** Whether activity at `modifiedAt` is newer than the watermark. */
+const pastMark = (modifiedAt: string | null, seen: string | undefined): boolean =>
+	modifiedAt !== null && seen !== undefined && Date.parse(modifiedAt) > Date.parse(seen);
+
+/** Unread: the review moved past the watermark, or skipped items remain. */
+const isUnread = (
+	projectId: string,
+	number: number,
+	modifiedAt: string | null,
+	marks: SeenMarks,
+): boolean =>
+	pastMark(modifiedAt, marks[number]) || (readUnseen(projectId)[number]?.length ?? 0) > 0;
+
+/**
+ * Whether one review has unread activity — a boolean, so a watermark moving
+ * on another review leaves this subscriber alone.
+ */
+export const useReviewUnread = (
+	projectId: string,
+	review: { number: number; modifiedAt: string | null },
+	enabled: boolean,
+): boolean => {
+	const { number, modifiedAt } = review;
+	return useSyncExternalStore(enabled ? subscribeMarks : subscribeNothing, () =>
+		enabled ? isUnread(projectId, number, modifiedAt, readMarks(projectId)) : false,
+	);
+};
+
+/** How many of `reviews` have unread activity — again a primitive. */
+export const useUnreadReviewCount = (
+	projectId: string,
+	reviews: Array<{ number: number; modifiedAt: string | null }>,
+	enabled: boolean,
+): number =>
+	useSyncExternalStore(enabled ? subscribeMarks : subscribeNothing, () => {
+		if (!enabled) return 0;
+		const marks = readMarks(projectId);
+		return reviews.filter((review) => isUnread(projectId, review.number, review.modifiedAt, marks))
+			.length;
+	});
+
+/**
+ * Stamp reviews seen when first listed and prune marks for delisted ones.
+ * An absent mark reads as seen, so the stamp is what makes only activity
+ * after first sight count as unread. Mounted once per project surface.
+ */
+export const useStampReviewsSeen = (projectId: string): void => {
+	const { data: forgeInfo } = useQuery(forgeInfoOptions(projectId));
+	// Unconditional: behind `&&` the hook count would change mid-mount.
+	const level = usePrNotificationsLevel();
+	const enabled = !!forgeInfo?.capabilities.prService && level !== "off";
+	const { data: listed } = useQuery({
+		...listReviewsQueryOptions({ projectId, cacheConfig: "noCache" }),
+		enabled,
+		// A plain array keeps this subscriber's data small.
+		select: (reviews) =>
+			reviews.map((review) => ({ number: review.number, modifiedAt: review.modifiedAt })),
+	});
+
+	const reconcile = useEffectEvent((reviews: NonNullable<typeof listed>) => {
+		const marks = readMarks(projectId);
+		const next: SeenMarks = {};
+		let stamped = false;
+		for (const { number, modifiedAt } of reviews) {
+			const seen = marks[number];
+			if (seen !== undefined) {
+				next[number] = seen;
+			} else if (modifiedAt !== null) {
+				next[number] = modifiedAt;
+				stamped = true;
+			}
+		}
+		// A mark whose review is gone from the listing is dead weight.
+		const pruned = Object.keys(next).length !== Object.keys(marks).length;
+		if (stamped || pruned) writeMarks(projectId, next);
+
+		const unseen = readUnseen(projectId);
+		const keptUnseen: UnseenEntries = {};
+		for (const [number, entries] of Object.entries(unseen))
+			if (Number(number) in next) keptUnseen[Number(number)] = entries;
+		if (Object.keys(keptUnseen).length !== Object.keys(unseen).length)
+			writeUnseen(projectId, keptUnseen);
+	});
+
+	useEffect(() => {
+		if (listed) reconcile(listed);
+	}, [listed]);
+};
+
+/** What had been seen when the PR view opened; nothing is new outside one. */
+type SeenOnArrival = {
+	sinceMs: number;
+	selfLogin: string | null;
+	projectId: string;
+	reviewNumber: number;
+};
+
+export const SeenOnArrivalContext = createContext<SeenOnArrival>({
+	sinceMs: Infinity,
+	selfLogin: null,
+	projectId: "",
+	reviewNumber: 0,
+});
+
+/**
+ * The watermark as it stood when the view mounted — a snapshot, because the
+ * dwell advances the live mark right after arrival and the "New" badges
+ * must not vanish under the reader. The next visit starts clean.
+ */
+export const useSeenOnArrival = (projectId: string, reviewNumber: number): SeenOnArrival => {
+	const { data: selfLogin } = useQuery(currentForgeLoginQueryOptions(projectId));
+	const level = usePrNotificationsLevel();
+	const [sinceMs] = useState(() => {
+		const mark = readMarks(projectId)[reviewNumber];
+		const ms = mark === undefined ? Number.NaN : Date.parse(mark);
+		// No watermark means the review was never tracked; nothing is new.
+		return Number.isNaN(ms) ? Infinity : ms;
+	});
+	// Off means off: no markers, and no seen-state writes from the observer.
+	if (level === "off") return { sinceMs: Infinity, selfLogin: null, projectId, reviewNumber: 0 };
+	return { sinceMs, selfLogin: selfLogin ?? null, projectId, reviewNumber };
+};
+
+/**
+ * Advance the watermark, recording the registered items above it that the
+ * reader has not looked at as skips — their markers survive the advance and
+ * the dot stays lit until each is seen.
+ *
+ * @public exported for the store transitions in the test suite.
+ */
+export const markReviewSeen = (projectId: string, number: number, modifiedAt: string): void => {
+	const floor = readMarks(projectId)[number];
+	const floorMs = floor === undefined ? Infinity : Date.parse(floor);
+	const slot = reviewSlot(projectId, number);
+	const pending = pendingSeen.get(slot) ?? new Set<string>();
+	const skipped = new Map((readUnseen(projectId)[number] ?? []).map(([k, at]) => [k, at]));
+	for (const item of [...(shownItems.get(slot)?.values() ?? [])].flat()) {
+		if (item.atMs > floorMs && !pending.has(item.key) && !skipped.has(item.key))
+			skipped.set(item.key, new Date(item.atMs).toISOString());
+	}
+	pendingSeen.delete(slot);
+	const entries = [...skipped]
+		.sort(([, a], [, b]) => Date.parse(a) - Date.parse(b))
+		// Beyond the cap the oldest are dropped: reading as seen is the safe
+		// failure, and a skip that old was never getting read.
+		.slice(-unseenCap);
+	const nextUnseen = { ...readUnseen(projectId) };
+	if (entries.length > 0) nextUnseen[number] = entries;
+	else delete nextUnseen[number];
+	// One notify for both writes: each fans out to a snapshot per row.
+	setUnseen(projectId, nextUnseen);
+	writeMarks(projectId, { ...readMarks(projectId), [number]: modifiedAt });
+};
+
+/** A beat, so flicking past a review does not eat its unread state. */
+const dwellMs = 1000;
+
+/**
+ * Advance the review's watermark while its PR tab is on screen: a dwell
+ * after mount or new activity, re-armed when the window regains focus so
+ * viewing an unfocused window does not count as seeing.
+ */
+export const useMarkReviewSeenOnView = (
+	projectId: string,
+	review: { number: number; modifiedAt: string | null },
+	enabled: boolean,
+): void => {
+	const { number, modifiedAt } = review;
+	// Nothing unread means nothing to write, on remount or with tracking off.
+	const behind = useReviewUnread(projectId, review, enabled);
+
+	const mark = useEffectEvent(() => {
+		if (modifiedAt === null || !behind || !document.hasFocus()) return;
+		markReviewSeen(projectId, number, modifiedAt);
+	});
+
+	// `behind` in the deps re-arms the dwell once the watermarks load.
+	useEffect(() => {
+		if (modifiedAt === null || !behind) return;
+		let timer: number | undefined;
+		const arm = () => {
+			clearTimeout(timer);
+			timer = window.setTimeout(mark, dwellMs);
+		};
+		window.addEventListener("focus", arm);
+		if (document.hasFocus()) arm();
+		return () => {
+			clearTimeout(timer);
+			window.removeEventListener("focus", arm);
+		};
+	}, [projectId, number, modifiedAt, behind]);
+};

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -33,6 +33,14 @@ import {
 	treeChangeDiffsQueryOptions,
 	workspaceFileQueryOptions,
 } from "#ui/api/queries.ts";
+import {
+	SeenOnArrivalContext,
+	useMarkReviewSeenOnView,
+	usePrNotificationsLevel,
+	useReviewUnread,
+	useSeenOnArrival,
+} from "#ui/review-seen.ts";
+import rowStyles from "./Row.module.css";
 import { decodeBytes } from "#ui/api/bytes.ts";
 import type { ForgeReview, TargetCommitReview } from "@gitbutler/but-sdk";
 import { branchDetailsParams } from "#ui/branch.ts";
@@ -2734,7 +2742,16 @@ const LandedReviewView: FC<{ projectId: string; reviewId: number }> = ({ project
 		);
 	}
 	if (!review) return <div className={classes(styles.loadingTab, "text-13")}>Loading…</div>;
-	return <ReviewView projectId={projectId} sourceBranch={review.sourceBranch} review={review} />;
+	// Keyed: a switch to another review is a new visit, so the arrival
+	// snapshot and its markers start clean rather than surviving in place.
+	return (
+		<ReviewView
+			key={review.number}
+			projectId={projectId}
+			sourceBranch={review.sourceBranch}
+			review={review}
+		/>
+	);
 };
 
 /** A branch's own changes, whatever the branch's standing. */
@@ -2808,8 +2825,10 @@ const BranchTabToggle: FC<{
 	branchTab: BranchTab;
 	setBranchTab: (tab: BranchTab) => void;
 	prDisabled?: boolean;
+	/** Marks the Pull Request tab with an unread-activity dot. */
+	prUnread?: boolean;
 	className?: string;
-}> = ({ branchTab, setBranchTab, prDisabled = false, className }) => (
+}> = ({ branchTab, setBranchTab, prDisabled = false, prUnread = false, className }) => (
 	<ToggleGroup
 		render={<ToggleGroupStyles className={className} />}
 		value={[branchTab]}
@@ -2825,6 +2844,11 @@ const BranchTabToggle: FC<{
 		</Toggle>
 		<Toggle render={<ToggleStyles />} value={"pr" satisfies BranchTab} disabled={prDisabled}>
 			{prDisabled ? "No pull request" : "Pull Request"}
+			{!prDisabled && prUnread && (
+				<span className={rowStyles.unreadDot}>
+					<span className={rowStyles.unreadLabel}>New activity</span>
+				</span>
+			)}
 		</Toggle>
 	</ToggleGroup>
 );
@@ -2870,13 +2894,14 @@ const useBranchTabHotkeys = ({
  * Editing is the applied branch's affordance — the branches tab shows a review,
  * it does not work on one.
  */
-const ReviewView: FC<{
+const ReviewLayout: FC<{
 	projectId: string;
 	sourceBranch: string;
 	review: ForgeReview;
 	editing?: { active: boolean; onDone: () => void };
 }> = ({ projectId, sourceBranch, review, editing }) => {
 	const { data: forgeInfo } = useQuery(forgeInfoOptions(projectId));
+	useMarkReviewSeenOnView(projectId, review, usePrNotificationsLevel() !== "off");
 
 	return (
 		<div className={styles.prLayout}>
@@ -2900,6 +2925,19 @@ const ReviewView: FC<{
 
 			<PullRequestPanel projectId={projectId} review={review} />
 		</div>
+	);
+};
+
+/**
+ * An existing review, with what had been seen at arrival snapshotted so the
+ * conversation can badge what is actually new.
+ */
+const ReviewView: FC<ComponentProps<typeof ReviewLayout>> = (p) => {
+	const seenOnArrival = useSeenOnArrival(p.projectId, p.review.number);
+	return (
+		<SeenOnArrivalContext.Provider value={seenOnArrival}>
+			<ReviewLayout {...p} />
+		</SeenOnArrivalContext.Provider>
 	);
 };
 
@@ -3017,10 +3055,22 @@ const UnappliedBranchDetails: FC<BranchDetailsProps> = ({
 	const landedReviewId = listedLandedNumber ?? null;
 
 	const reviewTab = review ? (
-		<ReviewView projectId={projectId} sourceBranch={branchName} review={review} />
+		<ReviewView
+			key={review.number}
+			projectId={projectId}
+			sourceBranch={branchName}
+			review={review}
+		/>
 	) : landedReviewId !== null ? (
 		<LandedReviewView projectId={projectId} reviewId={landedReviewId} />
 	) : null;
+
+	const notificationsLevel = usePrNotificationsLevel();
+	const prUnread = useReviewUnread(
+		projectId,
+		{ number: review?.number ?? 0, modifiedAt: review?.modifiedAt ?? null },
+		review != null && forgeInfo?.capabilities.prService === true && notificationsLevel !== "off",
+	);
 
 	const chosenTab = useAppSelector((state) =>
 		projectSlice.selectors.selectBranchTab(state, projectId, branchName),
@@ -3049,6 +3099,7 @@ const UnappliedBranchDetails: FC<BranchDetailsProps> = ({
 						branchTab={branchTab}
 						setBranchTab={setBranchTab}
 						prDisabled={reviewTab === null}
+						prUnread={prUnread}
 					/>
 
 					<div className={styles.tabsRowRight}>
@@ -3150,13 +3201,27 @@ const AppliedBranchDetails: FC<BranchDetailsProps> = ({
 		branchTab === "pr" && hasOpenReview === false,
 	);
 
+	// Subscribed regardless of the chosen tab: the dot on the toggle is what
+	// tells a reader parked on the diff that the review moved.
+	const notificationsLevel = usePrNotificationsLevel();
+	const { data: openReview } = useQuery({
+		...listReviewsQueryOptions({ projectId, cacheConfig: "noCache" }),
+		enabled: !!forgeInfo?.capabilities.prService && notificationsLevel !== "off",
+		select: (reviews) => reviews.find((review) => review.sourceBranch === branchName) ?? null,
+	});
+	const prUnread = useReviewUnread(
+		projectId,
+		{ number: openReview?.number ?? 0, modifiedAt: openReview?.modifiedAt ?? null },
+		!!openReview && !!forgeInfo?.capabilities.prService && notificationsLevel !== "off",
+	);
+
 	return (
 		<div className={styles.container} ref={ref}>
 			<div className={styles.headerWrap}>
 				<BranchTitleRow branchName={branchName} />
 
 				<div className={styles.tabsRow}>
-					<BranchTabToggle branchTab={branchTab} setBranchTab={setBranchTab} />
+					<BranchTabToggle branchTab={branchTab} setBranchTab={setBranchTab} prUnread={prUnread} />
 
 					{branchTab === "pr" && !!forgeInfo?.capabilities.prService && (
 						<Suspense>
@@ -3223,6 +3288,7 @@ const AppliedBranchDetails: FC<BranchDetailsProps> = ({
 											/>
 										) : (
 											<ReviewView
+												key={review.number}
 												projectId={projectId}
 												sourceBranch={branchName}
 												review={review}

--- a/apps/lite/ui/src/routes/project/$id/workspace/Page.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Page.tsx
@@ -76,6 +76,8 @@ import { Settings } from "./Settings/Settings.tsx";
 import { useBranchesList } from "./useBranchesList.ts";
 import { upstreamCommitReview, useUpstreamList } from "./useUpstreamList.ts";
 import { useStateReconciler as useReconcileState } from "#ui/reconcile.ts";
+import { useReviewActivityInbox } from "#ui/review-notifications.ts";
+import { useStampReviewsSeen } from "#ui/review-seen.ts";
 import {
 	setCursor,
 	setActiveList,
@@ -313,6 +315,8 @@ const ProjectPicker: FC<ProjectPickerProps> = (p) => {
 
 const PageBody: FC<{ projectId: string }> = ({ projectId }) => {
 	useReconcileState(projectId);
+	useReviewActivityInbox(projectId);
+	useStampReviewsSeen(projectId);
 
 	// A virtualised drag source may unmount before the drag ends, leaving us stuck in a pending
 	// operation state. This monitor is essentially a finally block for this scenario; its onDrop runs

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestComments.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestComments.tsx
@@ -43,6 +43,8 @@ import type {
 	ForgeReviewUser,
 } from "@gitbutler/but-sdk";
 import { pullRequestHotkeys } from "#ui/hotkeys.ts";
+import { FreshBadge, RegisterFreshItems } from "#ui/review-arrival.tsx";
+import { useMemo } from "react";
 import { useHotkey } from "@tanstack/react-hotkeys";
 import { useQuery } from "@tanstack/react-query";
 import { type FC, type ReactNode, type RefObject, useRef, useState } from "react";
@@ -74,6 +76,8 @@ const Card: FC<{
 	timestamp: number | null;
 	/** Shown in place of the time while an optimistic write is in flight. */
 	pendingLabel?: string;
+	/** The card's stable item key, so its "New" marker can be seen away. */
+	freshKey?: string;
 	edited?: boolean;
 	actions?: ReactNode;
 	footer?: ReactNode;
@@ -84,6 +88,7 @@ const Card: FC<{
 	badge,
 	timestamp,
 	pendingLabel,
+	freshKey,
 	edited = false,
 	actions,
 	footer,
@@ -104,6 +109,7 @@ const Card: FC<{
 						)
 					)}
 					{edited && <span className={classes("text-12", styles.cardEdited)}>edited</span>}
+					<FreshBadge timestamp={timestamp} author={author} itemKey={freshKey} />
 				</div>
 				{actions}
 			</div>
@@ -237,6 +243,7 @@ const Comment: FC<{
 			author={comment.author}
 			className={isSending ? styles.cardSending : undefined}
 			timestamp={createdAtMs}
+			freshKey={comment.id > 0 ? `c:${comment.id}` : undefined}
 			pendingLabel={isSending ? "Sending…" : undefined}
 			edited={comment.modifiedAt !== null && comment.modifiedAt !== comment.createdAt}
 			actions={actions}
@@ -301,6 +308,7 @@ const Submission: FC<{ submission: ForgeReviewSubmission }> = ({ submission }) =
 			author={submission.author}
 			badge={submissionBadge[submission.state]}
 			timestamp={submittedAtMs}
+			freshKey={`s:${submission.id}`}
 		>
 			{submission.body === null || submission.body.trim() === "" ? undefined : (
 				<Clamped maxHeight="240px">
@@ -317,11 +325,13 @@ const Submission: FC<{ submission: ForgeReviewSubmission }> = ({ submission }) =
  * text carry a dotted underline, which is what distinguishes the referenced
  * objects from the connective prose.
  */
-const FeedEvent: FC<{ icon: IconName; timestamp: number | null; children: ReactNode }> = ({
-	icon,
-	timestamp,
-	children,
-}) => (
+const FeedEvent: FC<{
+	icon: IconName;
+	timestamp: number | null;
+	freshKey?: string;
+	author?: ForgeReviewUser | null;
+	children: ReactNode;
+}> = ({ icon, timestamp, freshKey, author, children }) => (
 	<div className={classes("text-12", styles.event)}>
 		<Icon name={icon} size={12} className={styles.eventIcon} />
 		{/* One flowing paragraph, so a long summary wraps under itself and the
@@ -334,6 +344,7 @@ const FeedEvent: FC<{ icon: IconName; timestamp: number | null; children: ReactN
 					<span aria-hidden>·</span> <RelativeTime timestamp={timestamp} />
 				</>
 			)}
+			<FreshBadge timestamp={timestamp} author={author} itemKey={freshKey} />
 		</div>
 	</div>
 );
@@ -346,9 +357,11 @@ const Ref: FC<{ children: ReactNode; mono?: boolean }> = ({ children, mono = fal
 const TimelineEvent: FC<{ event: ForgeReviewTimelineEvent }> = ({ event }) => {
 	const createdAtMs = event.createdAt === null ? null : Date.parse(event.createdAt);
 
+	const freshKey = event.createdAt === null ? undefined : `e:${event.kind}:${event.createdAt}`;
+
 	if (event.kind === "committed") {
 		return (
-			<FeedEvent icon="commit" timestamp={createdAtMs}>
+			<FeedEvent icon="commit" timestamp={createdAtMs} freshKey={freshKey}>
 				{event.commitAuthorName !== null && <Ref>{event.commitAuthorName}</Ref>} committed{" "}
 				{event.commitSha !== null && <Ref mono>{event.commitSha.slice(0, 7)}</Ref>}{" "}
 				{event.commitSummary}
@@ -357,7 +370,7 @@ const TimelineEvent: FC<{ event: ForgeReviewTimelineEvent }> = ({ event }) => {
 	}
 
 	return (
-		<FeedEvent icon="user" timestamp={createdAtMs}>
+		<FeedEvent icon="user" timestamp={createdAtMs} freshKey={freshKey} author={event.actor}>
 			{event.actor !== null && <Ref>{event.actor.login}</Ref>} requested a review
 			{event.requestedReviewer !== null && (
 				<>
@@ -598,6 +611,33 @@ export const PullRequestComments: FC<{ projectId: string; review: ForgeReview }>
 	const [draft, setDraft] = useState("");
 	const composerRef = useRef<HTMLTextAreaElement | null>(null);
 
+	// What the dwell may record as skipped: the conversation's own unread-
+	// eligible items. Memoized: this component re-renders per draft
+	// keystroke, and the derivation walks every listing.
+	const freshItems = useMemo(() => {
+		const own = (login: string | null | undefined) =>
+			currentLogin != null && login != null && login.toLowerCase() === currentLogin.toLowerCase();
+		return [
+			...(comments ?? [])
+				.filter(
+					(comment) => comment.id > 0 && comment.createdAt !== null && !own(comment.author?.login),
+				)
+				.map((comment) => ({ key: `c:${comment.id}`, atMs: Date.parse(comment.createdAt ?? "") })),
+			...(submissions ?? [])
+				.filter((submission) => submission.submittedAt !== null && !own(submission.author?.login))
+				.map((submission) => ({
+					key: `s:${submission.id}`,
+					atMs: Date.parse(submission.submittedAt ?? ""),
+				})),
+			...(events ?? [])
+				.filter((event) => event.createdAt !== null && !own(event.actor?.login))
+				.map((event) => ({
+					key: `e:${event.kind}:${event.createdAt ?? ""}`,
+					atMs: Date.parse(event.createdAt ?? ""),
+				})),
+		];
+	}, [comments, submissions, events, currentLogin]);
+
 	const handleSubmit = () => {
 		const body = draft.trim();
 		if (body === "") return;
@@ -626,6 +666,7 @@ export const PullRequestComments: FC<{ projectId: string; review: ForgeReview }>
 
 	return (
 		<div className={styles.comments}>
+			<RegisterFreshItems source="conversation" items={freshItems} />
 			{isPending || submissionsPending ? (
 				<div className={classes("text-13", styles.commentsEmpty)}>Loading…</div>
 			) : (

--- a/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
@@ -251,6 +251,28 @@
 	opacity: 0.4;
 }
 
+/* Unread-activity dot on a meta item such as the PR chip. */
+.unreadDot {
+	/* Anchors the hidden label; unanchored it would land at the document's
+	   own coordinates and stretch the page. */
+	position: relative;
+	flex-shrink: 0;
+	width: 6px;
+	height: 6px;
+	border-radius: 50%;
+	background-color: var(--fill-pop-bg);
+}
+
+/* What the dot means, for readers the dot cannot reach. Lives inside the
+   dot so the pair costs one flex slot and the label stays anchored. */
+.unreadLabel {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+}
+
 /* Button sitting in a meta row: stands a little further off from the facts it
    follows, since no separator dot divides them. */
 .metaButton {

--- a/apps/lite/ui/src/routes/project/$id/workspace/Settings/General.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Settings/General.tsx
@@ -94,6 +94,26 @@ export const General: FC = () => {
 						onCheckedChange={(autoUpdate) => saveGUISettings({ autoUpdate })}
 					/>
 				</Row>
+
+				<Row
+					label="Pull request activity"
+					htmlFor="pr-notifications"
+					hint="Loud collects notifications in the bell; quiet keeps just the unread dots."
+				>
+					<select
+						id="pr-notifications"
+						value={settings.prNotifications ?? defaultSettings.prNotifications}
+						onChange={(evt) => {
+							const value = evt.currentTarget.value;
+							if (value === "loud" || value === "quiet" || value === "off")
+								saveGUISettings({ prNotifications: value });
+						}}
+					>
+						<option value="loud">Loud</option>
+						<option value="quiet">Quiet</option>
+						<option value="off">Off</option>
+					</select>
+				</Row>
 			</Section>
 
 			<Section heading="Danger zone">

--- a/apps/lite/ui/src/routes/project/$id/workspace/Sidebar.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Sidebar.tsx
@@ -1,11 +1,15 @@
 import { useWorkspaceIntegrateUpstream } from "#ui/api/mutations.ts";
 import { setPage, usePage } from "#ui/use-cursor.ts";
 import {
+	forgeInfoOptions,
 	guiSettingsQueryOptions,
 	headInfoQueryOptions,
+	listReviewsQueryOptions,
 	workspaceFetchQueryOptions,
 	workspaceFetchStatusQueryOptions,
 } from "#ui/api/queries.ts";
+import { NotificationBell } from "#ui/review-inbox-bell.tsx";
+import { usePrNotificationsLevel, useUnreadReviewCount } from "#ui/review-seen.ts";
 import { stackBottomRelativeTo } from "#ui/api/stack.ts";
 import { errorMessageForToast } from "#ui/errors.ts";
 import { Icon } from "#ui/components/Icon.tsx";
@@ -52,6 +56,38 @@ const adjacentPage = (tab: PageId, offset: -1 | 1): PageId => {
  * read. The upstream page states the exact count.
  */
 const maxBadgeCount = 99;
+
+/**
+ * How many applied-branch pull requests have unread activity. Its own
+ * component so its subscriptions wake only this badge, not the sidebar.
+ */
+const WorkspaceActivityBadge: FC<{ projectId: string }> = ({ projectId }) => {
+	const { data: forgeInfo } = useQuery(forgeInfoOptions(projectId));
+	const notificationsLevel = usePrNotificationsLevel();
+	const prService = !!forgeInfo?.capabilities.prService && notificationsLevel !== "off";
+	const { data: appliedBranches } = useQuery({
+		...headInfoQueryOptions(projectId),
+		enabled: prService,
+		select: (headInfo) =>
+			new Set(
+				headInfo.stacks.flatMap((stack) =>
+					stack.segments.flatMap((segment) => segment.refName?.displayName ?? []),
+				),
+			),
+	});
+	const { data: appliedReviews } = useQuery({
+		...listReviewsQueryOptions({ projectId, cacheConfig: "noCache" }),
+		enabled: prService,
+		select: (reviews) =>
+			reviews
+				.filter((review) => appliedBranches?.has(review.sourceBranch) === true)
+				.map((review) => ({ number: review.number, modifiedAt: review.modifiedAt })),
+	});
+	const count = useUnreadReviewCount(projectId, appliedReviews ?? [], prService);
+	if (count === 0) return null;
+
+	return <Badge variant="fillGray">{count > maxBadgeCount ? `${maxBadgeCount}+` : count}</Badge>;
+};
 
 export const Sidebar: FC<{
 	absorptionTargetCommitIds: ReadonlySet<string>;
@@ -222,6 +258,7 @@ export const Sidebar: FC<{
 		<div className={styles.container} ref={ref}>
 			<div className={styles.top}>
 				<SidebarHeader
+					bell={<NotificationBell projectId={projectId} />}
 					project={project}
 					canFetch={canFetchFromRemotes}
 					isFetchPending={isWorkspaceFetchFromRemotesPending}
@@ -245,6 +282,7 @@ export const Sidebar: FC<{
 					>
 						<Icon name="workbench" />
 						<span className={styles.tabLabel}>Workspace</span>
+						<WorkspaceActivityBadge projectId={projectId} />
 					</Toggle>
 					<Toggle
 						render={<ToggleStyles />}

--- a/apps/lite/ui/src/routes/project/$id/workspace/SidebarHeader.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/SidebarHeader.module.css
@@ -1,7 +1,11 @@
 /* Too narrow for the project name, keep only the folder mark. The size is
-   the sidebar's `top` container, where the header renders. */
+   the sidebar's `top` container, where the header renders. The ambient
+   spinner goes with it: it cannot compress, and past the group's minimum
+   content it would paint over the action icons — the fetch button still
+   shows its own spinner for the case that matters. */
 @container (max-width: 275px) {
-	.workspaceNameLabel {
+	.workspaceNameLabel,
+	.activitySpinner {
 		display: none;
 	}
 }
@@ -16,11 +20,16 @@
 	display: flex;
 	align-items: center;
 	min-width: 0;
+	/* Shrinking stops at the contents' minimum; clip past it rather than
+	   painting over the action icons. */
+	overflow: hidden;
 	gap: 4px;
 }
 
 .workspaceControlsActions {
 	display: flex;
+	/* The icons are the row's controls; the name side gives ground first. */
+	flex-shrink: 0;
 	align-items: center;
 	margin-inline-start: auto;
 	gap: 2px;

--- a/apps/lite/ui/src/routes/project/$id/workspace/SidebarHeader.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/SidebarHeader.tsx
@@ -10,7 +10,7 @@ import { Button, Tooltip } from "@base-ui/react";
 import type { ProjectForFrontend } from "@gitbutler/but-sdk";
 import { useIsFetching, useIsMutating } from "@tanstack/react-query";
 import { Match } from "effect";
-import { type FC, useState } from "react";
+import { type FC, type ReactNode, useState } from "react";
 import styles from "./SidebarHeader.module.css";
 
 const ActivitySpinner: FC<{
@@ -30,7 +30,12 @@ const ActivitySpinner: FC<{
 		Match.orElse(() => null),
 	);
 
-	return !p.suppressed && status !== null && <Icon name="spinner" aria-label={status} />;
+	return (
+		!p.suppressed &&
+		status !== null && (
+			<Icon name="spinner" aria-label={status} className={styles.activitySpinner} />
+		)
+	);
 };
 
 const FetchFromRemotesButton: FC<{
@@ -85,6 +90,8 @@ export const SidebarHeader: FC<{
 	canOpenSettings: boolean;
 	onOpenSettings: () => void;
 	onOpenProjectPicker: () => void;
+	/** The notification bell, which decides its own visibility. */
+	bell?: ReactNode;
 }> = (p) => (
 	<header className={styles.workspaceControls}>
 		<TopLeftControls />
@@ -142,6 +149,7 @@ export const SidebarHeader: FC<{
 					</Tooltip.Positioner>
 				</Tooltip.Portal>
 			</Tooltip.Root>
+			{p.bell}
 		</div>
 	</header>
 );

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/BranchRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/BranchRow.tsx
@@ -20,6 +20,7 @@ import {
 	listCIChecksQueryOptions,
 	listReviewsQueryOptions,
 } from "#ui/api/queries.ts";
+import { usePrNotificationsLevel, useReviewUnread } from "#ui/review-seen.ts";
 import { decodeBytes } from "#ui/api/bytes.ts";
 import { Button, Toast, Toolbar, Tooltip } from "@base-ui/react";
 import type {
@@ -163,7 +164,14 @@ export const BranchRow: FC<
 		...listReviewsQueryOptions({ projectId, cacheConfig: "noCache" }),
 		enabled: !!forgeInfo?.capabilities.prService,
 	});
-	const openPullRequest = reviews?.reviewsBySourceBranch.get(refName.displayName)?.number ?? null;
+	const openReview = reviews?.reviewsBySourceBranch.get(refName.displayName);
+	const openPullRequest = openReview?.number ?? null;
+	const notificationsLevel = usePrNotificationsLevel();
+	const reviewUnread = useReviewUnread(
+		projectId,
+		{ number: openPullRequest ?? 0, modifiedAt: openReview?.modifiedAt ?? null },
+		openPullRequest !== null && !!forgeInfo?.capabilities.prService && notificationsLevel !== "off",
+	);
 	// The chip renders the recorded number as-is: the projection only records
 	// display-worthy reviews, the chip must survive being offline, and a
 	// per-row verification fetch is not worth it. The details pane does verify
@@ -540,9 +548,19 @@ export const BranchRow: FC<
 						{pullRequest !== null && (
 							<>
 								<RowMetaSeparator />
-								<span className={classes(rowStyles.fadedText, rowStyles.metaItem)}>
+								<span
+									className={classes(rowStyles.fadedText, rowStyles.metaItem)}
+									title={reviewUnread ? "New activity on this pull request" : undefined}
+								>
 									<Icon size={14} name="pr" />
 									PR
+									{reviewUnread && (
+										<span className={rowStyles.unreadDot}>
+											<span className={rowStyles.unreadLabel}>
+												New activity on this pull request
+											</span>
+										</span>
+									)}
 								</span>
 
 								{ciChecks?.aggregate &&

--- a/apps/lite/ui/src/settings.ts
+++ b/apps/lite/ui/src/settings.ts
@@ -24,6 +24,9 @@ export const defaultSettings = {
 	minimap: false,
 	// Lite has always led with the file name; desktop leads with the path.
 	pathFirst: false,
+	// Loud = the notification bell and unread dots; quiet = dots only;
+	// off = no PR-activity tracking in the UI at all.
+	prNotifications: "loud",
 	terminalId: "",
 	// Pierre doesn't re-export BundledTheme from Shiki and it's not possible to extract it from the
 	// union, hence importing from Shiki. See also:

--- a/apps/lite/ui/src/time.ts
+++ b/apps/lite/ui/src/time.ts
@@ -23,6 +23,21 @@ const stdRelativeTimeFormatter = new Intl.RelativeTimeFormat(undefined, {
 export const formatRelativeTime: (timestamp: number, now?: number) => string =
 	formatRelativeTimeWith(stdRelativeTimeFormatter);
 
+/** The tightest reading — "26m", "1h", "3d" — for dense rows. */
+export const formatCompactRelativeTime = (timestamp: number, now = Date.now()): string => {
+	const seconds = Math.max(1, Math.round(Math.abs(now - timestamp) / 1000));
+	if (seconds < 60) return `${seconds}s`;
+	const minutes = Math.round(seconds / 60);
+	if (minutes < 60) return `${minutes}m`;
+	const hours = Math.round(minutes / 60);
+	if (hours < 24) return `${hours}h`;
+	const days = Math.round(hours / 24);
+	if (days < 30) return `${days}d`;
+	const months = Math.round(days / 30);
+	if (months < 12) return `${months}mo`;
+	return `${Math.round(days / 365)}y`;
+};
+
 /** @public */
 export const formatDurationWith =
 	(df: Intl.DurationFormat) =>


### PR DESCRIPTION
Draws the eye to pull requests with new activity, remembers what has been seen, and files what happened into a notification bell.

**The bell** sits in the window's top-right corner with a red dot while unread notifications wait. Its panel lists entries richly, newest first — a comment with author and snippet reads differently from "pushed 3 commits" or an approval. Clicking an entry marks it read and jumps to the PR tab (or the forge page when the branch isn't local); opening the panel alone marks nothing read.

One axis decides what files: **is a human waiting on you?** Someone else's comment, a verdict, a review request naming you, and `@you` mentions — loud on any open PR, applied or not. Commits are quieter facts the bell still carries; requests naming someone else, dismissed verdicts and your own actions are silence. A kind's items on one review coalesce into one entry per poll.

Seen state is per-review watermarks in local storage — deliberately disposable and per-machine:

- Reviews are stamped seen the first time they are listed, so a wiped store reads as "everything is read" rather than a wall of stale dots, and only activity after a review first appeared can be unread.
- Marks never move backwards; viewing a PR tab advances one after a short dwell, re-armed on window focus so an unfocused view doesn't count. Quiet surfaces stay: dots on the branch row's PR chip and the Details PR tab, a count on the Workspace sidebar tab.
- Each new conversation entry wears a small `New` marker, and the markers are **per-item**: an entry counts as looked at only once it has sat in the focused viewport for a beat. Items the dwell advances past unseen are recorded as *skips* — the complement is stored on purpose, since a list of read items would grow with everything ever read once one stubborn item pinned the mark — so their markers and the dot survive until each is actually seen. Skips are capped; dropping one merely reads as seen.
- It started as a `review_seen` table in but-db; [krlvi's review](https://github.com/gitbutlerapp/gitbutler/pull/15645#discussion_r3886170014) pointed out that disposable per-machine state doesn't need a migration or a round trip, so the table, its endpoints and its cache tag are gone.

Detection rides the existing 60s review-listing poll: a `modifiedAt` bump past the watermark triggers one targeted comments/submissions/timeline fetch for that PR only, and the detector baselines from the stored watermarks, so activity that landed while the app was closed still announces itself once. One dial in Settings → General: `Pull request activity: loud | quiet | off` (loud shows the bell, quiet keeps only the dots, off hides it all).

Testable without a forge: the classifier and the stores are pure modules driven by fabricated events in vitest, and the harness panel mounts the real detector so `panel.test.tsx` runs the whole loop — poll, classify, file, dot — against fake forge handlers. Also verified live against real GitHub data.

Landing the click on the exact comment rides the stacked diff-comments PR, where inline comments become addressable. OS notifications and a dock badge for the unfocused window are deliberately left for a later follow-up.
