### PR TITLE
Announce and close test runs on tests.but.dev

### DIFF
--- a/.github/actions/test-run-lifecycle/action.yaml
+++ b/.github/actions/test-run-lifecycle/action.yaml
@@ -1,0 +1,45 @@
+name: test-run-lifecycle
+description: >-
+  Announce (phase: start) or close (phase: finish) a test run on
+  tests.but.dev, so the dashboard shows the run while it executes. Computes
+  the normalized run identity shared by every suite's uploads. Best effort by
+  design: pair with `continue-on-error: true` at the call site — this must
+  never fail or slow a test job.
+inputs:
+  token:
+    description: The suite's ingest token (a TEST_RESULTS_TOKEN_* secret)
+    required: true
+  phase:
+    description: start or finish
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: POST run ${{ inputs.phase }}
+      shell: bash
+      env:
+        TEST_RESULTS_TOKEN: ${{ inputs.token }}
+        PHASE: ${{ inputs.phase }}
+        RUN_KEY: ${{ github.run_id }}-${{ github.run_attempt }}
+        RUN_BRANCH: ${{ github.head_ref || github.ref_name }}
+        RUN_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        RUN_NUMBER: ${{ github.run_number }}
+        RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      run: |
+        case "$PHASE" in
+          start)
+            URL="https://tests.but.dev/v1/runs/start"
+            BODY="{\"run_env\":{\"key\":\"$RUN_KEY\",\"branch\":\"$RUN_BRANCH\",\"commit_sha\":\"$RUN_COMMIT_SHA\",\"number\":\"$RUN_NUMBER\",\"url\":\"$RUN_URL\",\"ci\":\"github_actions\"}}"
+            ;;
+          finish)
+            URL="https://tests.but.dev/v1/runs/finish"
+            BODY="{\"run_env\":{\"key\":\"$RUN_KEY\"}}"
+            ;;
+          *)
+            echo "unknown phase: $PHASE" >&2; exit 0
+            ;;
+        esac
+        curl -sS --max-time 10 -X POST \
+          -H "Authorization: Token $TEST_RESULTS_TOKEN" \
+          -H "Content-Type: application/json" \
+          -d "$BODY" "$URL" || true

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -150,6 +150,12 @@ jobs:
           key: ${{ runner.os }}-playwright-${{ steps.get_playwright_version.outputs.playwright-version }}
       - run: pnpm ui:playwright:install:unit
         if: ${{ steps.playwright-cache.outputs.cache-hit != 'true' }}
+      - name: Announce test run on tests.but.dev
+        continue-on-error: true
+        uses: ./.github/actions/test-run-lifecycle
+        with:
+          token: ${{ secrets.TEST_RESULTS_TOKEN_VITEST }}
+          phase: start
       - run: pnpm test
         env:
           BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.TEST_RESULTS_TOKEN_VITEST }}
@@ -159,6 +165,13 @@ jobs:
           BUILDKITE_ANALYTICS_KEY: ${{ github.run_id }}-${{ github.run_attempt }}
           BUILDKITE_ANALYTICS_BRANCH: ${{ github.head_ref || github.ref_name }}
           BUILDKITE_ANALYTICS_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Close test run on tests.but.dev
+        if: ${{ always() && !cancelled() }}
+        continue-on-error: true
+        uses: ./.github/actions/test-run-lifecycle
+        with:
+          token: ${{ secrets.TEST_RESULTS_TOKEN_VITEST }}
+          phase: finish
 
   but-sdk-build-check:
     needs: changes
@@ -327,6 +340,12 @@ jobs:
           echo "a9f992321e8759818400d93abb9477b4b11422d18d216e8d208505bd73454103 cargo-nextest.tar.gz" | sha256sum -c -
           tar -xzf cargo-nextest.tar.gz -C ${CARGO_HOME:-~/.cargo}/bin
           rm cargo-nextest.tar.gz
+      - name: Announce test run on tests.but.dev
+        continue-on-error: true
+        uses: ./.github/actions/test-run-lifecycle
+        with:
+          token: ${{ secrets.TEST_RESULTS_TOKEN_CARGO }}
+          phase: start
       - name: Run workspace tests
         run: cargo nextest run --workspace --exclude gitbutler-tauri --exclude but-api-macros-tests --profile ci
       - name: Run doctests
@@ -356,6 +375,13 @@ jobs:
             -F "tags[language]=rust" \
             -F "tags[type]=unit" \
             https://tests.but.dev/v1/uploads
+      - name: Close test run on tests.but.dev
+        if: ${{ always() && !cancelled() }}
+        continue-on-error: true
+        uses: ./.github/actions/test-run-lifecycle
+        with:
+          token: ${{ secrets.TEST_RESULTS_TOKEN_CARGO }}
+          phase: finish
       # It's intentional to use 'name equals run-script' so it's easy to re-run locally on failure.
       - run: make test-modern-but
       - name: test vendored
@@ -728,6 +754,12 @@ jobs:
           key: ${{ runner.os }}-playwright-with-webkit-${{ steps.get_playwright_version.outputs.playwright-version }}
       - run: pnpm ui:playwright:install:ct
         if: ${{ steps.playwright-cache.outputs.cache-hit != 'true' }}
+      - name: Announce test run on tests.but.dev
+        continue-on-error: true
+        uses: ./.github/actions/test-run-lifecycle
+        with:
+          token: ${{ secrets.TEST_RESULTS_TOKEN_PLAYWRIGHT_CT }}
+          phase: start
       - name: run playwright tests
         run: pnpm test:ct
         env:
@@ -738,6 +770,13 @@ jobs:
           BUILDKITE_ANALYTICS_KEY: ${{ github.run_id }}-${{ github.run_attempt }}
           BUILDKITE_ANALYTICS_BRANCH: ${{ github.head_ref || github.ref_name }}
           BUILDKITE_ANALYTICS_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Close test run on tests.but.dev
+        if: ${{ always() && !cancelled() }}
+        continue-on-error: true
+        uses: ./.github/actions/test-run-lifecycle
+        with:
+          token: ${{ secrets.TEST_RESULTS_TOKEN_PLAYWRIGHT_CT }}
+          phase: finish
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ !cancelled() }}
         with:
@@ -785,6 +824,12 @@ jobs:
           electron_sandbox="$(dirname "$electron_path")/chrome-sandbox"
           sudo chown root:root "$electron_sandbox"
           sudo chmod 4755 "$electron_sandbox"
+      - name: Announce test run on tests.but.dev
+        continue-on-error: true
+        uses: ./.github/actions/test-run-lifecycle
+        with:
+          token: ${{ secrets.TEST_RESULTS_TOKEN_LITE_E2E }}
+          phase: start
       - name: Run Lite E2E tests
         # Concurrent Electron launches can fail during renderer bootstrap on GitHub's Linux runners.
         run: xvfb-run --auto-servernum pnpm --filter @gitbutler/lite test:e2e --forbid-only --workers=1
@@ -796,6 +841,13 @@ jobs:
           BUILDKITE_ANALYTICS_KEY: ${{ github.run_id }}-${{ github.run_attempt }}
           BUILDKITE_ANALYTICS_BRANCH: ${{ github.head_ref || github.ref_name }}
           BUILDKITE_ANALYTICS_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Close test run on tests.but.dev
+        if: ${{ always() && !cancelled() }}
+        continue-on-error: true
+        uses: ./.github/actions/test-run-lifecycle
+        with:
+          token: ${{ secrets.TEST_RESULTS_TOKEN_LITE_E2E }}
+          phase: finish
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -74,6 +74,13 @@ jobs:
         if: ${{ github.ref == 'refs/heads/master' }}
         run: cargo build -p but
 
+      - name: Announce test run on tests.but.dev
+        if: ${{ github.ref != 'refs/heads/master' }}
+        continue-on-error: true
+        uses: ./.github/actions/test-run-lifecycle
+        with:
+          token: ${{ secrets.TEST_RESULTS_TOKEN_BLACKBOX }}
+          phase: start
       # Run it through `xvfb-run` to have a fake display server which allows our
       # application to run headless without any changes to the code
       - name: WebdriverIO
@@ -105,6 +112,13 @@ jobs:
             -F "tags[language]=typescript" \
             -F "tags[type]=e2e" \
             https://tests.but.dev/v1/uploads
+      - name: Close test run on tests.but.dev
+        if: ${{ github.ref != 'refs/heads/master' && always() && !cancelled() }}
+        continue-on-error: true
+        uses: ./.github/actions/test-run-lifecycle
+        with:
+          token: ${{ secrets.TEST_RESULTS_TOKEN_BLACKBOX }}
+          phase: finish
       - name: Flatten test results
         if: failure()
         run: |
@@ -188,6 +202,12 @@ jobs:
           wait "$pnpm_pid" || status=1
           [ -n "$pw_pid" ] && { wait "$pw_pid" || status=1; }
           exit "$status"
+      - name: Announce test run on tests.but.dev
+        continue-on-error: true
+        uses: ./.github/actions/test-run-lifecycle
+        with:
+          token: ${{ secrets.TEST_RESULTS_TOKEN_PLAYWRIGHT }}
+          phase: start
       - name: Run Playwright tests
         run: pnpm exec turbo run test:e2e:playwright -- --shard="$PLAYWRIGHT_SHARD"
         env:
@@ -222,3 +242,19 @@ jobs:
         run: |
           test "$CHANGES_RESULT" = "success" &&
             { test "$SHOULD_RUN" != "true" || test "$SHARDS_RESULT" = "success"; }
+
+  playwright-finish:
+    needs: playwright
+    if: ${{ always() && !cancelled() }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/actions/test-run-lifecycle
+      - name: Close test run on tests.but.dev
+        continue-on-error: true
+        uses: ./.github/actions/test-run-lifecycle
+        with:
+          token: ${{ secrets.TEST_RESULTS_TOKEN_PLAYWRIGHT }}
+          phase: finish


### PR DESCRIPTION
Adds run lifecycle calls to the six test jobs so the dashboard shows runs while they execute instead of only after results land:

- `POST /v1/runs/start` before tests → the run appears as "running…" immediately (results then stream into it per upload chunk).
- `POST /v1/runs/finish` after the upload → the run reads completed. Sharded playwright closes from a `needs:` finalize job so the run stays open until every shard reported.
- Announced-but-never-closed runs show as "still running?" after 3h — died-before-upload jobs become visible for the first time.

All lifecycle calls are `continue-on-error` with `--max-time 10`: they can never fail or slow a CI job. Server side shipped in gitbutlerapp/test-results (deployed; endpoints are additive, upload-only suites keep working unchanged).