### PR TITLE
Fail e2e tests on app silence, not on a wall clock

### DIFF
--- a/e2e/playwright/playwright.config.ts
+++ b/e2e/playwright/playwright.config.ts
@@ -27,19 +27,40 @@ export default defineConfig({
 	workers: AMOUNT_OF_WORKERS,
 	/* Reporter to use. See https://playwright.dev/docs/test-reporters */
 	reporter: process.env.CI ? [["github"], ["buildkite-test-collector/playwright/reporter"]] : "dot",
-	/* Per-test timeout. The default 30s is too tight for tests that perform
-	   multiple commits in CI, where backend operations are slower. */
+	/* A backstop, not the deadline that normally fails a test. Waits and
+	   assertions give up 10s after the app falls silent (see src/idle.ts),
+	   which covers anything that is simply never arriving. What reaches this
+	   timeout is the case idleness cannot see — the app busy but not
+	   progressing, e.g. a poll that keeps firing while the awaited state never
+	   comes, or a request that never settles — plus `expect.poll` and the
+	   deliberate `waitForTimeout` sleeps in the poll-backoff tests.
+
+	   Sized from CI, which averages ~9s per test against ~4.9s locally. The
+	   slowest test is 18.1s locally, but 13s of that is a fixed sleep that does
+	   not scale, so it lands near 22s there; the slowest test with no fixed
+	   sleep lands near 28s. 120s keeps roughly 4x headroom, so a runner having
+	   a bad day still passes. Trimming it would only speed up genuinely stuck
+	   tests, which are now rare, at the cost of the margin that keeps slow
+	   runners green. */
 	timeout: 120_000,
-	/* Assertion timeout. The default 5s is too tight for CI where backend
-	   operations (commits, rebases, upstream integration) are slower. */
-	expect: { timeout: 15_000 },
+	/* Playwright's own assertion deadline is disabled: a fixed sub-deadline is
+	   a guess at how slow a runner is, and guessing low is what made a slow
+	   runner look like a broken one. Assertions are bounded by src/expect.ts
+	   instead, which retries while the app is still making requests and gives
+	   up once it has been idle for IDLE_BUDGET_MS, keeping Playwright's usual
+	   expected/received report. What still runs under this zero — expect.poll —
+	   is bounded only by the per-test timeout above. */
+	expect: { timeout: 0 },
 	/* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
 	use: {
 		/* Base URL to use in actions like `await page.goto('/')`. */
 		baseURL: `http://localhost:${DESKTOP_PORT}`,
 
 		/* Individual actions (click, fill, etc.) fail after 15s so a stuck
-		   action surfaces quickly instead of burning the full test timeout. */
+		   action surfaces quickly instead of burning the full test timeout.
+		   Waiting for the app to reach a state is deliberately not covered:
+		   the wait helpers and hoverPatiently in src/util.ts run under the
+		   idle budget in src/idle.ts instead. */
 		actionTimeout: 15_000,
 
 		/* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */

--- a/e2e/playwright/src/branch.ts
+++ b/e2e/playwright/src/branch.ts
@@ -1,5 +1,6 @@
+import { expect } from "./expect.ts";
 import { clickByTestId, getByTestId, waitForTestId } from "./util.ts";
-import { expect, Page } from "@playwright/test";
+import { Page } from "@playwright/test";
 import { execFileSync } from "child_process";
 
 export async function openBranchContextMenu(page: Page, branchName: string) {

--- a/e2e/playwright/src/commit.ts
+++ b/e2e/playwright/src/commit.ts
@@ -1,3 +1,4 @@
+import { expect } from "./expect.ts";
 import {
 	fillByTestId,
 	getByTestId,
@@ -5,7 +6,7 @@ import {
 	waitForElementToStabilize,
 	waitForTestId,
 } from "./util.ts";
-import { expect, Locator, Page } from "@playwright/test";
+import { Locator, Page } from "@playwright/test";
 
 /**
  * Open a commit drawer by clicking on the commit row.

--- a/e2e/playwright/src/expect.ts
+++ b/e2e/playwright/src/expect.ts
@@ -1,0 +1,120 @@
+import { IDLE_BUDGET_MS, idleSince, watchIdle } from "./idle.ts";
+import { expect as base, type Locator, type Page } from "@playwright/test";
+
+/**
+ * `expect` that tolerates a slow runner but not a silent app.
+ *
+ * Playwright's assertions already retry until they pass; the only question is
+ * how long they may take, and `playwright.config.ts` deliberately gives them no
+ * deadline of its own. That makes them tolerate any slowness, but it also means
+ * a genuinely wrong assertion runs until the per-test timeout.
+ *
+ * So each assertion is retried in bounded attempts, and gives up only once the
+ * app has been idle for {@link IDLE_BUDGET_MS} — the same rule the wait helpers
+ * in `util.ts` use. While the app is working the assertion keeps retrying, so a
+ * slow round trip costs nothing; once it goes quiet, the failure surfaces in
+ * seconds, carrying Playwright's own expected/received message because the
+ * error thrown is the last attempt's.
+ *
+ * Assertions on plain values are untouched: they cannot wait on anything, and
+ * there is no page whose activity would say when to give up.
+ */
+
+/**
+ * Attempts are bounded so the loop regains control to ask whether the app is
+ * still working. Short enough that a failure is reported promptly after the app
+ * goes quiet, long enough that a passing assertion rarely needs a second one.
+ */
+const ATTEMPT_MS = 1_000;
+
+/**
+ * `configure` sets the attempt deadline without touching the call's arguments —
+ * matchers take their options in varying positions (and some take an object as
+ * the expected value), so injecting a `timeout` into the arguments would have
+ * to guess which is which.
+ */
+const bounded = base.configure({ timeout: ATTEMPT_MS });
+
+/** Chain of modifiers (`not`, `resolves`, `rejects`) applied before the matcher. */
+type Modifiers = readonly string[];
+
+function pageOf(subject: unknown): Page | undefined {
+	if (!subject || typeof subject !== "object") return undefined;
+	const candidate = subject as Partial<Locator> & Partial<Page>;
+	if (typeof candidate.elementHandle === "function" && typeof candidate.page === "function") {
+		return (subject as Locator).page();
+	}
+	if (typeof candidate.goto === "function" && typeof candidate.context === "function") {
+		return subject as Page;
+	}
+	return undefined;
+}
+
+/** Build a fresh bounded assertion, so each attempt starts its own retry window. */
+function attempt(
+	subject: unknown,
+	modifiers: Modifiers,
+	matcher: string,
+	args: unknown[],
+): unknown {
+	// The matcher surface is dynamic by nature; this is the one place that has
+	// to reach through it untyped.
+
+	let node: any = bounded(subject as any);
+	for (const modifier of modifiers) node = node[modifier];
+	return node[matcher](...args);
+}
+
+function retryWhileAppWorks(
+	subject: unknown,
+	page: Page,
+	modifiers: Modifiers,
+	matcher: string,
+	args: unknown[],
+): unknown {
+	watchIdle(page);
+	const startedAt = Date.now();
+	const first = attempt(subject, modifiers, matcher, args);
+	// A matcher on a plain value resolves or throws synchronously; nothing to retry.
+	if (!(first instanceof Promise)) return first;
+
+	return (async () => {
+		let pending = first;
+		for (;;) {
+			try {
+				return await pending;
+			} catch (error) {
+				if (idleSince(page, startedAt) >= IDLE_BUDGET_MS) throw error;
+				pending = attempt(subject, modifiers, matcher, args) as Promise<unknown>;
+			}
+		}
+	})();
+}
+
+function wrapAssertion(
+	assertion: object,
+	subject: unknown,
+	page: Page,
+	modifiers: Modifiers,
+): object {
+	return new Proxy(assertion, {
+		get(target, property, receiver) {
+			const value = Reflect.get(target, property, receiver);
+			if (property === "not" || property === "resolves" || property === "rejects") {
+				return wrapAssertion(value as object, subject, page, [...modifiers, property]);
+			}
+			if (typeof value !== "function") return value;
+			return (...args: unknown[]) =>
+				retryWhileAppWorks(subject, page, modifiers, property as string, args);
+		},
+	});
+}
+
+export const expect = new Proxy(base, {
+	apply(target, thisArg, args: unknown[]) {
+		const assertion = Reflect.apply(target, thisArg, args) as object;
+		const page = pageOf(args[0]);
+		if (!page) return assertion;
+		return wrapAssertion(assertion, args[0], page, []);
+	},
+});

--- a/e2e/playwright/src/file.ts
+++ b/e2e/playwright/src/file.ts
@@ -1,5 +1,6 @@
+import { expect } from "./expect.ts";
 import { clickByTestId, getByTestId, waitForTestId } from "./util.ts";
-import { expect, Page } from "@playwright/test";
+import { Page } from "@playwright/test";
 import fs from "node:fs";
 import path from "node:path";
 

--- a/e2e/playwright/src/idle.ts
+++ b/e2e/playwright/src/idle.ts
@@ -1,0 +1,71 @@
+import type { Page, Request } from "@playwright/test";
+
+/**
+ * How long the app may sit completely idle — nothing in flight — while a wait
+ * or assertion is still unsatisfied, before we call it broken.
+ *
+ * A wall-clock deadline can only ever be a guess at how slow a runner is, and
+ * guessing low is what turns "this machine was busy" into a failed test. This
+ * budget measures something the machine's speed cannot inflate instead: how
+ * long the app has done *nothing at all*. A slow round trip keeps a request in
+ * flight, so the clock does not run and the wait tolerates it for as long as it
+ * takes. State that is never coming leaves the app quiet, and that is reported
+ * in seconds rather than at the test's deadline.
+ */
+export const IDLE_BUDGET_MS = 10_000;
+
+type Activity = {
+	pending: Set<Request>;
+	lastActiveAt: number;
+};
+
+/**
+ * Requests in flight per page, tracked once and shared by every wait and
+ * assertion.
+ *
+ * A set rather than a counter so a duplicated terminal event cannot drift it
+ * below zero. If a request somehow never settles, the set stays non-empty and
+ * the budget simply never expires — waiting then falls back to the per-test
+ * timeout, which is the safe direction: a lost event can delay a failure, never
+ * manufacture one.
+ */
+const activityByPage = new WeakMap<Page, Activity>();
+
+function activityOf(page: Page): Activity {
+	const existing = activityByPage.get(page);
+	if (existing) return existing;
+
+	const activity: Activity = { pending: new Set(), lastActiveAt: Date.now() };
+	activityByPage.set(page, activity);
+	function started(request: Request) {
+		activity.pending.add(request);
+		activity.lastActiveAt = Date.now();
+	}
+	function settled(request: Request) {
+		activity.pending.delete(request);
+		activity.lastActiveAt = Date.now();
+	}
+	page.on("request", started);
+	page.on("requestfinished", settled);
+	page.on("requestfailed", settled);
+	return activity;
+}
+
+/**
+ * How long the app has been idle, counting only from `since`.
+ *
+ * Idleness accumulated before we started waiting says nothing about the wait:
+ * a test spends whole seconds in `runScript` shelling out to git, and the app
+ * is legitimately quiet throughout. Measuring from `since` means the budget
+ * always answers "has the app done anything since we started waiting for this".
+ */
+export function idleSince(page: Page, since: number): number {
+	const activity = activityOf(page);
+	if (activity.pending.size > 0) return 0;
+	return Date.now() - Math.max(activity.lastActiveAt, since);
+}
+
+/** Start tracking now, so activity is not missed between here and the first check. */
+export function watchIdle(page: Page): void {
+	activityOf(page);
+}

--- a/e2e/playwright/src/setup.ts
+++ b/e2e/playwright/src/setup.ts
@@ -264,6 +264,15 @@ async function checkPort(port: number, host = "localhost") {
 
 const VITE_HOST = "localhost";
 
+/** Lines of a failed script's output carried in the rejection. */
+const TAIL_LINES = 40;
+
+/**
+ * Retained output, in UTF-16 code units (what `String.length`/`slice` count) —
+ * comfortably more than TAIL_LINES of any sane script.
+ */
+const TAIL_CHARS = 64 * 1024;
+
 // Colors for console output
 const colors = {
 	reset: "\x1b[0m",
@@ -288,7 +297,9 @@ function spawnProcess(
 ) {
 	const child = spawn(command, args, {
 		cwd,
-		stdio: "inherit",
+		// Piped rather than inherited so a failing script's output can ride
+		// along in the rejection; `runCommand` still echoes it live.
+		stdio: ["inherit", "pipe", "pipe"],
 		env: {
 			...process.env,
 			ELECTRON_ENV: "development",
@@ -352,15 +363,47 @@ async function runCommand(
 
 		const child = spawnProcess(command, args, cwd, env);
 
+		// Keep the tail of the output so a failure names the script and why it
+		// failed; without it CI only ever reports the bare exit code. Compacted
+		// as it grows, so a chatty script cannot hold its whole output in
+		// memory for the sake of a 40-line error tail.
+		const output: string[] = [];
+		let buffered = 0;
+		for (const [stream, sink] of [
+			[child.stdout, process.stdout],
+			[child.stderr, process.stderr],
+		] as const) {
+			stream?.setEncoding("utf8");
+			stream?.on("data", (chunk: string) => {
+				output.push(chunk);
+				buffered += chunk.length;
+				if (buffered > TAIL_CHARS * 2) {
+					const tail = output.join("").slice(-TAIL_CHARS);
+					output.length = 0;
+					output.push(tail);
+					buffered = tail.length;
+				}
+				sink.write(chunk);
+			});
+		}
+
 		child.on("message", (message) => {
 			log(`Child process message: ${message}`, colors.blue);
 		});
 
-		child.on("close", (code) => {
+		child.on("close", (code, signal) => {
 			if (code === 0) {
 				resolve();
 			} else {
-				reject(new Error(`Command failed with exit code ${code}`));
+				// A signal death reports null as the code; name the signal instead.
+				const cause = code === null ? `signal ${signal}` : `exit code ${code}`;
+				const tail = output.join("").trimEnd().split("\n").slice(-TAIL_LINES).join("\n");
+				reject(
+					new Error(
+						`Command failed with ${cause}: ${command} ${args.join(" ")}` +
+							(tail ? `\n${tail}` : ""),
+					),
+				);
 			}
 		});
 

--- a/e2e/playwright/src/test.ts
+++ b/e2e/playwright/src/test.ts
@@ -3,6 +3,7 @@ import {
 	type FakeGitHubOptions,
 	type FakeGitHubServer,
 } from "./fakeGithub.ts";
+import { watchIdle } from "./idle.ts";
 import { serverLogSink } from "./serverLog.ts";
 import { startGitButler, type GitButler } from "./setup.ts";
 import { test as base } from "@playwright/test";
@@ -67,6 +68,12 @@ export const test = base.extend<{
 	},
 	_autoArtifacts: [
 		async ({ page }, use, testInfo) => {
+			// Track in-flight requests from before the first request can start.
+			// Installed lazily instead, a request already in flight when the
+			// first wait begins would be invisible to the idle budget, and the
+			// watchdog could fire while the app is still working.
+			watchIdle(page);
+
 			const logs: string[] = [];
 			serverLogSink.length = 0;
 

--- a/e2e/playwright/src/util.ts
+++ b/e2e/playwright/src/util.ts
@@ -1,5 +1,6 @@
+import { IDLE_BUDGET_MS, idleSince, watchIdle } from "./idle.ts";
 import { TestId } from "@gitbutler/ui/utils/testIds";
-import { expect, type Locator, type Page } from "@playwright/test";
+import { type Locator, type Page } from "@playwright/test";
 
 type TestIdValues = `${TestId}`;
 
@@ -39,15 +40,101 @@ export function stack(page: Page, branchName?: string): Locator {
 	});
 }
 
-export async function waitForTestId(page: Page, testId: TestIdValues): Promise<Locator> {
+/** How often the watchdog samples; small enough to be precise, large enough to be free. */
+const IDLE_POLL_MS = 250;
+
+/**
+ * Run `act` with no deadline of its own, failing once the app has been idle for
+ * `idleBudgetMs` without it finishing. See `idle.ts` for why idleness rather
+ * than a wall clock decides.
+ */
+async function untilTheAppGoesQuiet<T>(
+	page: Page,
+	describe: string,
+	idleBudgetMs: number,
+	act: () => Promise<T>,
+): Promise<T> {
+	watchIdle(page);
+	const startedAt = Date.now();
+	let done = false;
+
+	const acting = act().finally(() => {
+		done = true;
+	});
+	// The watchdog may win the race; keep its loser from surfacing as an
+	// unhandled rejection.
+	acting.catch(() => {});
+
+	const watchdog = (async (): Promise<T> => {
+		for (;;) {
+			await new Promise((resolve) => setTimeout(resolve, IDLE_POLL_MS));
+			// Stop counting the moment the action settles, so the loop cannot
+			// outlive it — `acting` has already resolved or rejected here.
+			if (done) return await acting;
+			const idleFor = idleSince(page, startedAt);
+			if (idleFor >= idleBudgetMs) {
+				throw new Error(
+					`Timed out ${describe}: the app made no request for ` +
+						`${Math.round(idleFor / 1000)}s, so it is not still working on it.`,
+				);
+			}
+		}
+	})();
+
+	return await Promise.race([acting, watchdog]);
+}
+
+/**
+ * Hover, bounded by app silence rather than by `actionTimeout`.
+ *
+ * Playwright waits for an element to be stable before hovering it, and a list
+ * still reflowing as its data arrives is not stable yet. That is the app being
+ * slow, not the action being stuck, so it gets the same rule as the waits.
+ */
+export async function hoverPatiently(
+	page: Page,
+	locator: Locator,
+	options?: { force?: boolean; position?: { x: number; y: number }; idleBudgetMs?: number },
+): Promise<void> {
+	await untilTheAppGoesQuiet(
+		page,
+		"hovering",
+		options?.idleBudgetMs ?? IDLE_BUDGET_MS,
+		async () =>
+			await locator.hover({
+				force: options?.force,
+				position: options?.position,
+				timeout: 0,
+			}),
+	);
+}
+
+export async function waitForTestId(
+	page: Page,
+	testId: TestIdValues,
+	options?: { idleBudgetMs?: number },
+): Promise<Locator> {
 	const element = getByTestId(page, testId);
-	await element.waitFor();
+	await untilTheAppGoesQuiet(
+		page,
+		`waiting for getByTestId(${JSON.stringify(testId)}) to be visible`,
+		options?.idleBudgetMs ?? IDLE_BUDGET_MS,
+		async () => await element.waitFor({ state: "visible", timeout: 0 }),
+	);
 	return element;
 }
 
-export async function waitForTestIdToNotExist(page: Page, testId: TestIdValues): Promise<void> {
-	const element = getByTestId(page, testId);
-	await element.waitFor({ state: "detached" });
+export async function waitForTestIdToNotExist(
+	page: Page,
+	testId: TestIdValues,
+	options?: { idleBudgetMs?: number },
+): Promise<void> {
+	await untilTheAppGoesQuiet(
+		page,
+		`waiting for getByTestId(${JSON.stringify(testId)}) to be detached`,
+		options?.idleBudgetMs ?? IDLE_BUDGET_MS,
+		async () => await getByTestId(page, testId).waitFor({ state: "detached", timeout: 0 }),
+	);
 }
 
 /**
@@ -84,10 +171,10 @@ export async function dragAndDropByTestId(
 	const source = await waitForTestId(page, sourceId);
 	const target = await waitForTestId(page, targetId);
 
-	await source.hover();
+	await hoverPatiently(page, source);
 	await page.mouse.down();
-	await target.hover();
-	await target.hover({ force: true });
+	await hoverPatiently(page, target);
+	await hoverPatiently(page, target, { force: true });
 	await page.mouse.up();
 }
 
@@ -108,11 +195,11 @@ export async function dragAndDropByLocator(
 	target: Locator,
 	options: DropOptions = {},
 ) {
-	await source.hover();
+	await hoverPatiently(page, source);
 	await page.mouse.down();
 	// Always wait a bit in case CSS causes content shift.
 	await page.waitForTimeout(100);
-	await target.hover({ force: options.force, position: options.position });
+	await hoverPatiently(page, target, { force: options.force, position: options.position });
 	// The drag system uses requestAnimationFrame to detect dropzones via
 	// document.elementFromPoint. Wait for at least one animation frame so the
 	// dropzone is detected as hovered before we release the mouse button.
@@ -127,10 +214,25 @@ export async function fillByTestId(
 	value: string,
 ): Promise<Locator> {
 	const element = await waitForTestId(page, testId);
-	await expect(async () => {
-		await element.fill(value);
-		await expect(element).toHaveValue(value);
-	}).toPass();
+	// Fill can race a re-render that resets the field, so retry until the value
+	// sticks — under the idle budget like every other wait. A function-subject
+	// `toPass()` would bypass src/expect.ts and burn the per-test timeout on a
+	// real failure.
+	await untilTheAppGoesQuiet(
+		page,
+		`filling getByTestId(${JSON.stringify(testId)})`,
+		IDLE_BUDGET_MS,
+		async () => {
+			// timeout: 0 on the inner calls too — the watchdog is the boundary
+			// here, and a 15s actionTimeout inside the loop would reintroduce a
+			// wall-clock failure while the app is still visibly working.
+			for (;;) {
+				await element.fill(value, { timeout: 0 });
+				if ((await element.inputValue({ timeout: 0 })) === value) return;
+				await new Promise((resolve) => setTimeout(resolve, IDLE_POLL_MS));
+			}
+		},
+	);
 	return element;
 }
 

--- a/e2e/playwright/tests/absorb.spec.ts
+++ b/e2e/playwright/tests/absorb.spec.ts
@@ -1,8 +1,8 @@
+import { expect } from "../src/expect.ts";
 import { assertFileContent, writeToFile } from "../src/file.ts";
 import { applyUpstream, openWorkspace } from "../src/setup.ts";
 import { test } from "../src/test.ts";
 import { clickByTestId, waitForTestId } from "../src/util.ts";
-import { expect } from "@playwright/test";
 
 test("should be able to absorb a file to a commit - simple", async ({ page, gitbutler }) => {
 	const filePath = gitbutler.pathInWorkdir("local-clone/a_file");

--- a/e2e/playwright/tests/addingAProject.spec.ts
+++ b/e2e/playwright/tests/addingAProject.spec.ts
@@ -1,3 +1,4 @@
+import { expect } from "../src/expect.ts";
 import { gotoOnboarding, openWorkspace } from "../src/setup.ts";
 import { test } from "../src/test.ts";
 import {
@@ -7,7 +8,6 @@ import {
 	stack,
 	waitForTestId,
 } from "../src/util.ts";
-import { expect } from "@playwright/test";
 
 test("should handle gracefully adding an existing project", async ({ page, gitbutler }) => {
 	const projectPath = gitbutler.pathInWorkdir("local-clone-2/");

--- a/e2e/playwright/tests/branches.spec.ts
+++ b/e2e/playwright/tests/branches.spec.ts
@@ -1,4 +1,5 @@
 import { assertBranch, createNewBranch, deleteBranch, unapplyStack } from "../src/branch.ts";
+import { expect } from "../src/expect.ts";
 import { startFakeGitHubServer, type FakeGitHubServer } from "../src/fakeGithub.ts";
 import { applyUpstream, getButlerPort, openWorkspace, type GitButler } from "../src/setup.ts";
 import { test } from "../src/test.ts";
@@ -12,7 +13,7 @@ import {
 	waitForTestId,
 	waitForTestIdToNotExist,
 } from "../src/util.ts";
-import { expect, type Page, type Request } from "@playwright/test";
+import { type Page, type Request } from "@playwright/test";
 import { execFileSync } from "child_process";
 import { existsSync, readFileSync, writeFileSync } from "fs";
 

--- a/e2e/playwright/tests/commitActions.spec.ts
+++ b/e2e/playwright/tests/commitActions.spec.ts
@@ -6,6 +6,7 @@ import {
 	verifyCommitMessageEditor,
 	verifyCommitPlaceholderPosition,
 } from "../src/commit.ts";
+import { expect } from "../src/expect.ts";
 import { stageFirstFile, unstageAllFiles, writeFiles } from "../src/file.ts";
 import { applyUpstream, openWorkspace } from "../src/setup.ts";
 import { test } from "../src/test.ts";
@@ -17,7 +18,7 @@ import {
 	stack,
 	waitForTestIdToNotExist,
 } from "../src/util.ts";
-import { expect, type Page } from "@playwright/test";
+import { type Page } from "@playwright/test";
 import { execFileSync } from "child_process";
 import { copyFileSync, writeFileSync } from "fs";
 import { join } from "path";

--- a/e2e/playwright/tests/commitHooks.spec.ts
+++ b/e2e/playwright/tests/commitHooks.spec.ts
@@ -1,7 +1,8 @@
+import { expect } from "../src/expect.ts";
 import { getButlerPort, type GitButler } from "../src/setup.ts";
 import { test } from "../src/test.ts";
 import { clickByTestId, commitRow, fillByTestId, getByTestId, waitForTestId } from "../src/util.ts";
-import { expect, type Page } from "@playwright/test";
+import { type Page } from "@playwright/test";
 import { existsSync } from "node:fs";
 
 /**

--- a/e2e/playwright/tests/dragToCommit.spec.ts
+++ b/e2e/playwright/tests/dragToCommit.spec.ts
@@ -1,4 +1,5 @@
 import { updateCommitMessage, verifyCommitMessageEditor } from "../src/commit.ts";
+import { expect } from "../src/expect.ts";
 import {
 	assertFileContent,
 	assertFileIsStaged,
@@ -8,7 +9,6 @@ import {
 import { applyUpstream, openWorkspace } from "../src/setup.ts";
 import { test } from "../src/test.ts";
 import { clickByTestId, commitRow, dragAndDropByLocator, waitForTestId } from "../src/util.ts";
-import { expect } from "@playwright/test";
 import { writeFileSync } from "fs";
 
 test("should be able to start a commit by dragging a file", async ({ page, gitbutler }) => {

--- a/e2e/playwright/tests/dropResult.spec.ts
+++ b/e2e/playwright/tests/dropResult.spec.ts
@@ -1,7 +1,7 @@
+import { expect } from "../src/expect.ts";
 import { applyUpstream, openWorkspace } from "../src/setup.ts";
 import { test } from "../src/test.ts";
 import { clickByTestId, commitRow, dragAndDropByLocator, getByTestId } from "../src/util.ts";
-import { expect } from "@playwright/test";
 import { writeFileSync } from "fs";
 
 test("should show commit-failed modal when amending causes a conflict", async ({

--- a/e2e/playwright/tests/editMode.spec.ts
+++ b/e2e/playwright/tests/editMode.spec.ts
@@ -1,7 +1,7 @@
+import { expect } from "../src/expect.ts";
 import { applyUpstream, openWorkspace } from "../src/setup.ts";
 import { test } from "../src/test.ts";
 import { clickByTestId, commitRow, waitForTestId } from "../src/util.ts";
-import { expect } from "@playwright/test";
 import { readFileSync, writeFileSync } from "fs";
 
 test("should be able to edit a commit through the edit mode", async ({ page, gitbutler }) => {

--- a/e2e/playwright/tests/fetch.spec.ts
+++ b/e2e/playwright/tests/fetch.spec.ts
@@ -1,8 +1,9 @@
+import { expect } from "../src/expect.ts";
 import { forgeErrorBody, githubForgeInfo, mockForge } from "../src/forge.ts";
 import { openWorkspace } from "../src/setup.ts";
 import { test } from "../src/test.ts";
 import { clickByTestId, getByTestId } from "../src/util.ts";
-import { expect, type Page, type Request } from "@playwright/test";
+import { type Page, type Request } from "@playwright/test";
 import { execFileSync } from "node:child_process";
 
 function git(pathToRepo: string, args: string[]): string {

--- a/e2e/playwright/tests/forge.spec.ts
+++ b/e2e/playwright/tests/forge.spec.ts
@@ -1,3 +1,4 @@
+import { expect } from "../src/expect.ts";
 import {
 	ciCheck,
 	ciCheckRunning,
@@ -13,7 +14,7 @@ import {
 import { applyUpstream, openWorkspace } from "../src/setup.ts";
 import { test } from "../src/test.ts";
 import { waitForTestId } from "../src/util.ts";
-import { expect, type Page, type Route } from "@playwright/test";
+import { type Page, type Route } from "@playwright/test";
 import type { ForgeInfo, ForgeReview } from "@gitbutler/but-sdk";
 
 const PR_NUMBER = 42;

--- a/e2e/playwright/tests/moveBranch.spec.ts
+++ b/e2e/playwright/tests/moveBranch.spec.ts
@@ -1,7 +1,7 @@
+import { expect } from "../src/expect.ts";
 import { applyUpstream, openWorkspace } from "../src/setup.ts";
 import { test } from "../src/test.ts";
 import { dragAndDropByLocator, stack, waitForTestId } from "../src/util.ts";
-import { expect } from "@playwright/test";
 
 test("move branch to top of other stack and tear it off", async ({ page, gitbutler }) => {
 	await gitbutler.runScript("project-with-stacks.sh");

--- a/e2e/playwright/tests/moveCommitToNewStack.spec.ts
+++ b/e2e/playwright/tests/moveCommitToNewStack.spec.ts
@@ -1,7 +1,8 @@
+import { expect } from "../src/expect.ts";
 import { applyUpstream, openWorkspace, type GitButler } from "../src/setup.ts";
 import { test } from "../src/test.ts";
 import { dragAndDropByLocator, MOD_KEY, stack, waitForTestId } from "../src/util.ts";
-import { expect, type Page } from "@playwright/test";
+import { type Page } from "@playwright/test";
 
 /**
  * Apply branch2 (modifies b_file) and branch3 (modifies c_file) — two

--- a/e2e/playwright/tests/moveMultipleCommits.spec.ts
+++ b/e2e/playwright/tests/moveMultipleCommits.spec.ts
@@ -1,7 +1,7 @@
+import { expect } from "../src/expect.ts";
 import { applyUpstream, openWorkspace } from "../src/setup.ts";
 import { test } from "../src/test.ts";
 import { dragAndDropByLocator, MOD_KEY, stack } from "../src/util.ts";
-import { expect } from "@playwright/test";
 
 test("should move multiple selected commits to a different branch via drag and drop", async ({
 	page,

--- a/e2e/playwright/tests/multiCommitSelection.spec.ts
+++ b/e2e/playwright/tests/multiCommitSelection.spec.ts
@@ -1,3 +1,4 @@
+import { expect } from "../src/expect.ts";
 import { applyUpstream, openWorkspace, type GitButler } from "../src/setup.ts";
 import { test } from "../src/test.ts";
 import {
@@ -7,7 +8,7 @@ import {
 	waitForElementToStabilize,
 	waitForTestId,
 } from "../src/util.ts";
-import { expect, type Page } from "@playwright/test";
+import { type Page } from "@playwright/test";
 
 /**
  * Apply branch1 (4 commits) and open the workspace.

--- a/e2e/playwright/tests/prAssociation.spec.ts
+++ b/e2e/playwright/tests/prAssociation.spec.ts
@@ -1,8 +1,9 @@
+import { expect } from "../src/expect.ts";
 import { forgeReview, githubForgeInfo, mergeStatus, mockForge, repoInfo } from "../src/forge.ts";
 import { applyUpstream, getButlerPort, openWorkspace, type GitButler } from "../src/setup.ts";
 import { test } from "../src/test.ts";
 import { waitForTestId } from "../src/util.ts";
-import { expect, type Page } from "@playwright/test";
+import { type Page } from "@playwright/test";
 import type { FakeGitHubOptions, FakeGitHubServer } from "../src/fakeGithub.ts";
 
 const PR_NUMBER = 42;

--- a/e2e/playwright/tests/reviewStackingDescription.spec.ts
+++ b/e2e/playwright/tests/reviewStackingDescription.spec.ts
@@ -1,4 +1,5 @@
 import { assertGitConfigValue } from "../src/branch.ts";
+import { expect } from "../src/expect.ts";
 import { mergeStatus, mockForge, repoInfo } from "../src/forge.ts";
 import { applyUpstream, getButlerPort, openWorkspace, type GitButler } from "../src/setup.ts";
 import { test } from "../src/test.ts";
@@ -9,7 +10,7 @@ import {
 	textEditorFillByTestId,
 	waitForTestId,
 } from "../src/util.ts";
-import { expect, type Page } from "@playwright/test";
+import { type Page } from "@playwright/test";
 import { execFileSync } from "node:child_process";
 import { readFileSync, writeFileSync } from "node:fs";
 import type { FakeGitHubReview, FakeGitHubServer } from "../src/fakeGithub.ts";

--- a/e2e/playwright/tests/singleBranch/addingAProject.spec.ts
+++ b/e2e/playwright/tests/singleBranch/addingAProject.spec.ts
@@ -6,10 +6,10 @@ import {
 	assertGitConfigValue,
 	assertRefDoesNotExist,
 } from "../../src/branch.ts";
+import { expect } from "../../src/expect.ts";
 import { gotoOnboarding } from "../../src/setup.ts";
 import { test } from "../../src/test.ts";
 import { clickByTestId, getByTestId, mockPickDirectory, waitForTestId } from "../../src/util.ts";
-import { expect } from "@playwright/test";
 
 test.use({
 	gitbutlerOptions: {

--- a/e2e/playwright/tests/singleBranch/commitActions.spec.ts
+++ b/e2e/playwright/tests/singleBranch/commitActions.spec.ts
@@ -24,6 +24,7 @@ import {
 	verifyCommitMessageEditor,
 	verifyCommitPlaceholderPosition,
 } from "../../src/commit.ts";
+import { expect } from "../../src/expect.ts";
 import { assertFileContent, unstageAllFiles, writeToFile } from "../../src/file.ts";
 import { applyUpstream, type GitButler } from "../../src/setup.ts";
 import { test } from "../../src/test.ts";
@@ -35,7 +36,7 @@ import {
 	stack,
 	waitForTestId,
 } from "../../src/util.ts";
-import { expect, type Page } from "@playwright/test";
+import { type Page } from "@playwright/test";
 import { execFileSync } from "node:child_process";
 
 test.use({

--- a/e2e/playwright/tests/singleBranch/commitSelection.spec.ts
+++ b/e2e/playwright/tests/singleBranch/commitSelection.spec.ts
@@ -1,5 +1,6 @@
 import { setupSingleBranchProject, SINGLE_BRANCH_NAME } from "./helpers.ts";
 import { assertBranch, assertCommitSubjects, assertDirtyWorktree } from "../../src/branch.ts";
+import { expect } from "../../src/expect.ts";
 import { assertFileIsUncommitted } from "../../src/file.ts";
 import { test } from "../../src/test.ts";
 import {
@@ -9,7 +10,6 @@ import {
 	waitForElementToStabilize,
 	waitForTestId,
 } from "../../src/util.ts";
-import { expect } from "@playwright/test";
 
 test.use({
 	gitbutlerOptions: {

--- a/e2e/playwright/tests/singleBranch/dragAndDrop.spec.ts
+++ b/e2e/playwright/tests/singleBranch/dragAndDrop.spec.ts
@@ -1,8 +1,8 @@
 import { setupSingleBranchProject, SINGLE_BRANCH_NAME } from "./helpers.ts";
 import { assertBranch, assertCleanWorktree, assertCommitSubjects } from "../../src/branch.ts";
+import { expect } from "../../src/expect.ts";
 import { test } from "../../src/test.ts";
 import { commitRow, dragAndDropByLocator, getByTestId } from "../../src/util.ts";
-import { expect } from "@playwright/test";
 
 test.use({
 	gitbutlerOptions: {

--- a/e2e/playwright/tests/singleBranch/helpers.ts
+++ b/e2e/playwright/tests/singleBranch/helpers.ts
@@ -1,6 +1,7 @@
+import { expect } from "../../src/expect.ts";
 import { openWorkspace } from "../../src/setup.ts";
 import { clickByTestId, getByTestId, stack, waitForTestId } from "../../src/util.ts";
-import { expect, type Locator, type Page } from "@playwright/test";
+import { type Locator, type Page } from "@playwright/test";
 import type { GitButler } from "../../src/setup.ts";
 
 export const SINGLE_BRANCH_NAME = "single-branch-fixture";

--- a/e2e/playwright/tests/singleBranch/mode.spec.ts
+++ b/e2e/playwright/tests/singleBranch/mode.spec.ts
@@ -5,10 +5,10 @@ import {
 	SINGLE_BRANCH_NAME,
 } from "./helpers.ts";
 import { assertBranch, assertCommitSubjects, branchTip } from "../../src/branch.ts";
+import { expect } from "../../src/expect.ts";
 import { openWorkspace } from "../../src/setup.ts";
 import { test } from "../../src/test.ts";
 import { getByTestId, waitForTestId, waitForTestIdToNotExist } from "../../src/util.ts";
-import { expect } from "@playwright/test";
 
 test.describe("single-branch mode disabled", () => {
 	test("does not show the current-branch chip after leaving gitbutler/workspace", async ({

--- a/e2e/playwright/tests/singleBranch/moveBranch.spec.ts
+++ b/e2e/playwright/tests/singleBranch/moveBranch.spec.ts
@@ -15,6 +15,7 @@ import {
 	createNewBranch,
 } from "../../src/branch.ts";
 import { updateCommitMessage } from "../../src/commit.ts";
+import { expect } from "../../src/expect.ts";
 import { writeToFile } from "../../src/file.ts";
 import { test } from "../../src/test.ts";
 import {
@@ -24,7 +25,7 @@ import {
 	getByTestId,
 	stack,
 } from "../../src/util.ts";
-import { expect, type Page } from "@playwright/test";
+import { type Page } from "@playwright/test";
 import { execFileSync } from "node:child_process";
 import type { GitButler } from "../../src/setup.ts";
 

--- a/e2e/playwright/tests/singleBranch/upstreamIntegration.spec.ts
+++ b/e2e/playwright/tests/singleBranch/upstreamIntegration.spec.ts
@@ -9,6 +9,7 @@ import {
 	assertCommitSubjects,
 	assertRefDoesNotExist,
 } from "../../src/branch.ts";
+import { expect } from "../../src/expect.ts";
 import { applyUpstream } from "../../src/setup.ts";
 import { test } from "../../src/test.ts";
 import {
@@ -19,7 +20,7 @@ import {
 	waitForTestId,
 	waitForTestIdToNotExist,
 } from "../../src/util.ts";
-import { expect, type Page } from "@playwright/test";
+import { type Page } from "@playwright/test";
 import { execFileSync } from "node:child_process";
 
 const FULLY_INTEGRATED_BRANCH = "fully-integrated-branch";

--- a/e2e/playwright/tests/startTheApp.spec.ts
+++ b/e2e/playwright/tests/startTheApp.spec.ts
@@ -1,4 +1,5 @@
 import { GIT_CONFIG_GLOBAL } from "../src/env.ts";
+import { expect } from "../src/expect.ts";
 import { writeToFile } from "../src/file.ts";
 import { gotoOnboarding, startGitButler } from "../src/setup.ts";
 import { test } from "../src/test.ts";
@@ -11,7 +12,7 @@ import {
 	textEditorFillByTestId,
 	waitForTestId,
 } from "../src/util.ts";
-import { expect, type Page } from "@playwright/test";
+import { type Page } from "@playwright/test";
 
 async function addProjectAndOpenWorkspace(
 	page: Page,

--- a/e2e/playwright/tests/unifiedDiffView.spec.ts
+++ b/e2e/playwright/tests/unifiedDiffView.spec.ts
@@ -1,3 +1,4 @@
+import { expect } from "../src/expect.ts";
 import { discardFile } from "../src/file.ts";
 import { getHunkHeaderSelector, getHunkLineSelector } from "../src/hunk.ts";
 import { openWorkspace, type GitButler } from "../src/setup.ts";
@@ -10,7 +11,7 @@ import {
 	waitForTestId,
 	waitForTestIdToNotExist,
 } from "../src/util.ts";
-import { expect, type Locator, type Page } from "@playwright/test";
+import { type Locator, type Page } from "@playwright/test";
 import { existsSync, readFileSync, writeFileSync } from "fs";
 import { join, resolve } from "path";
 

--- a/e2e/playwright/tests/upstreamIntegration.spec.ts
+++ b/e2e/playwright/tests/upstreamIntegration.spec.ts
@@ -1,4 +1,5 @@
 import { createNewBranch } from "../src/branch.ts";
+import { expect } from "../src/expect.ts";
 import { applyUpstream, openWorkspace } from "../src/setup.ts";
 import { test } from "../src/test.ts";
 import {
@@ -9,7 +10,7 @@ import {
 	waitForTestId,
 	waitForTestIdToNotExist,
 } from "../src/util.ts";
-import { expect, type Page } from "@playwright/test";
+import { type Page } from "@playwright/test";
 import { execFileSync } from "node:child_process";
 
 async function syncAndIntegrate(page: Page) {


### PR DESCRIPTION
Every one of the 23 recorded playwright flakes failed on attempt 0 and passed on retry — a cold-runner signature, not 15 separate bugs.

Reproduced with **pure latency and no errors**: delaying `list_reviews` by 20s gives exactly the CI failure, and the awaited badge then arrives at 18.8s.

```
locator.waitFor: Timeout 15000ms exceeded   (at 15006ms)
badge eventually present at 18830ms
```

Nothing was broken. The test gave up 3.8s early.

## Why not a bigger timeout

A wall-clock deadline can only guess how slow a runner is, and guessing low is what turns "this machine was busy" into a failed test. This measures something the machine's speed cannot inflate instead: **how long the app has done nothing at all.** A slow round trip keeps a request in flight, so the clock does not run; state that is never coming leaves the app quiet and is reported in seconds.

Waits and assertions now give up 10s after the app falls silent:

- `waitForTestId` / `waitForTestIdToNotExist` race the wait against an idle watchdog
- `expect` on a Locator or Page retries in bounded attempts and rethrows the last attempt's error, so Playwright's expected/received message survives
- `actionTimeout` stays 15s, so a stuck click still fails fast

## Measured

| case | before | after |
|---|---|---|
| 20s stall | failed at 15.0s | wait 19.1s, assertion 22.0s ✅ |
| state never arrives | 120s test timeout | fails at 10.3s |
| wrong assertion | 120s test timeout | fails at 11.1s with `Expected: 5` |
| full suite | — | 172 passed, 4.1m |

345 test executions across two full-suite runs, zero false fires from the idle budget.

## Decisions worth knowing

- **Scoped to each wait, never global.** A test spends seconds in `runScript` shelling out to git while the app is legitimately quiet; a global watchdog would kill healthy tests during fixture setup.
- **No quiet-period heuristic.** Gaps between chained requests are milliseconds, so the 10s budget is its own debounce. `networkidle` is discouraged by Playwright itself and not used.
- **Requests tracked in a set, not a counter.** A lost terminal event leaves the set non-empty, so the budget never expires and the wait falls back to the per-test timeout — a dropped event can delay a failure, never manufacture one.
- **Attempts rebuilt via `expect.configure`**, not by injecting a `timeout` argument: matchers take options in varying positions and some take an object as the expected value.
- **The per-test timeout stays 120s** and its comment now says why. CI averages ~9s per test against ~4.9s locally (~1.8x); the slowest test lands near 30s there, so 120s keeps ~4x headroom. It is now a backstop for the case idleness cannot see — the app busy but not progressing.

## Also

`runCommand` spawned setup scripts with inherited stdio and rejected with a bare `Command failed with exit code 1`, naming neither the script nor the reason — the failure mode shared by `branches.spec.ts` and `singleBranch/upstreamIntegration.spec.ts`. It now carries the command line and the last 40 lines of output.

`expect.poll` (4 uses) still falls back to the per-test timeout: its subject is test-side state, with no page activity to judge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)