### PR TITLE
Take the write lock before a mutation reads

### DIFF
--- a/crates/but-db/src/lib.rs
+++ b/crates/but-db/src/lib.rs
@@ -214,6 +214,46 @@ pub struct DbHandle {
     pub cache: OnDemand<CacheHandle>,
 }
 
+/// The write scope of a mutation handle.
+///
+/// Handles obtained from a [`DbHandle`] begin an *immediate* transaction, taking
+/// the write lock before anything is read. They have to: a mutation reads the
+/// rows it is about to replace, and a *deferred* transaction that reads first
+/// has its later write rejected with `SQLITE_BUSY` the moment another connection
+/// commits in between. SQLite does not run the busy handler for that case, so
+/// [`BUSY_TIMEOUT`](migration::BUSY_TIMEOUT) cannot wait it out and the caller
+/// just sees "database is locked". Holding the write lock from the start leaves
+/// no snapshot to invalidate.
+///
+/// Handles obtained from a [`Transaction`] nest a savepoint in it instead — the
+/// caller already decided how that transaction takes its locks.
+pub(crate) enum WriteScope<'conn> {
+    /// Begun by the handle itself, holding the write lock for its lifetime.
+    Owned(rusqlite::Transaction<'conn>),
+    /// Nested inside a transaction the caller already holds.
+    Nested(rusqlite::Savepoint<'conn>),
+}
+
+impl WriteScope<'_> {
+    pub(crate) fn commit(self) -> rusqlite::Result<()> {
+        match self {
+            WriteScope::Owned(transaction) => transaction.commit(),
+            WriteScope::Nested(savepoint) => savepoint.commit(),
+        }
+    }
+}
+
+impl std::ops::Deref for WriteScope<'_> {
+    type Target = rusqlite::Connection;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            WriteScope::Owned(transaction) => transaction,
+            WriteScope::Nested(savepoint) => savepoint,
+        }
+    }
+}
+
 /// A wrapper for a [`rusqlite::Transaction`] to allow ORM handles to be created more easily,
 /// and make sure multiple dependent calls to the ORM can be consistent.
 pub struct Transaction<'conn> {

--- a/crates/but-db/src/table/branch_order.rs
+++ b/crates/but-db/src/table/branch_order.rs
@@ -25,7 +25,7 @@ pub struct BranchOrderHandle<'conn> {
 
 /// Mutating accessor for ad-hoc branch ordering metadata.
 pub struct BranchOrderHandleMut<'conn> {
-    sp: rusqlite::Savepoint<'conn>,
+    trans: crate::WriteScope<'conn>,
 }
 
 impl DbHandle {
@@ -37,7 +37,10 @@ impl DbHandle {
     /// Return a mutating handle for ad-hoc branch ordering metadata.
     pub fn branch_order_mut(&mut self) -> rusqlite::Result<BranchOrderHandleMut<'_>> {
         Ok(BranchOrderHandleMut {
-            sp: self.conn.savepoint()?,
+            trans: crate::WriteScope::Owned(
+                self.conn
+                    .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?,
+            ),
         })
     }
 }
@@ -51,7 +54,7 @@ impl<'conn> Transaction<'conn> {
     /// Return a mutating handle for ad-hoc branch ordering metadata.
     pub fn branch_order_mut(&mut self) -> rusqlite::Result<BranchOrderHandleMut<'_>> {
         Ok(BranchOrderHandleMut {
-            sp: self.inner_mut().savepoint()?,
+            trans: crate::WriteScope::Nested(self.inner_mut().savepoint()?),
         })
     }
 }
@@ -143,14 +146,14 @@ fn is_missing_branch_order_table(err: &rusqlite::Error) -> bool {
 impl BranchOrderHandleMut<'_> {
     /// Convert this mutating handle into a read-only view on the same savepoint.
     pub fn to_ref(&self) -> BranchOrderHandle<'_> {
-        BranchOrderHandle { conn: &self.sp }
+        BranchOrderHandle { conn: &self.trans }
     }
 
     /// Replace the persisted chain containing `branches` with `branches` in tip-to-base order.
     pub fn set_order(self, branches: &[String]) -> rusqlite::Result<()> {
-        let sp = self.sp;
+        let trans = self.trans;
         if branches.is_empty() {
-            sp.commit()?;
+            trans.commit()?;
             return Ok(());
         }
 
@@ -161,7 +164,7 @@ impl BranchOrderHandleMut<'_> {
             }
         }
 
-        let order = BranchOrderHandle { conn: &sp };
+        let order = BranchOrderHandle { conn: &trans };
         let mut refs_to_replace = BTreeSet::new();
         for branch in branches {
             refs_to_replace.insert(branch.as_str().to_owned());
@@ -171,13 +174,13 @@ impl BranchOrderHandleMut<'_> {
         }
 
         for branch in refs_to_replace {
-            sp.execute(
+            trans.execute(
                 "DELETE FROM branch_order WHERE branch_ref_name = ?1",
                 [branch],
             )?;
         }
 
-        let mut insert = sp.prepare(
+        let mut insert = trans.prepare(
             "INSERT INTO branch_order (branch_ref_name, parent_ref_name) VALUES (?1, ?2)",
         )?;
         for (idx, branch) in branches.iter().enumerate() {
@@ -186,76 +189,76 @@ impl BranchOrderHandleMut<'_> {
         }
         drop(insert);
 
-        sp.commit()
+        trans.commit()
     }
 
     /// Remove `ref_name` from its chain, connecting its child directly to its parent if needed.
     pub fn remove_reference(self, ref_name: &str) -> rusqlite::Result<()> {
-        let sp = self.sp;
-        remove_reference_in_savepoint(&sp, ref_name)?;
-        sp.commit()
+        let trans = self.trans;
+        remove_reference_in_savepoint(&trans, ref_name)?;
+        trans.commit()
     }
 
     /// Rename `old_ref_name` to `new_ref_name` everywhere it appears in branch-order metadata.
     pub fn rename_reference(self, old_ref_name: &str, new_ref_name: &str) -> rusqlite::Result<()> {
-        let sp = self.sp;
+        let trans = self.trans;
         if old_ref_name == new_ref_name {
-            sp.commit()?;
+            trans.commit()?;
             return Ok(());
         }
 
-        let order = BranchOrderHandle { conn: &sp };
+        let order = BranchOrderHandle { conn: &trans };
         let has_old = order.has_reference(old_ref_name)? || order.child_of(old_ref_name)?.is_some();
         if !has_old {
-            sp.commit()?;
+            trans.commit()?;
             return Ok(());
         }
         if order.has_reference(new_ref_name)? || order.child_of(new_ref_name)?.is_some() {
             return Err(rusqlite::Error::InvalidQuery);
         }
 
-        sp.execute(
+        trans.execute(
             "UPDATE branch_order SET parent_ref_name = ?1 WHERE parent_ref_name = ?2",
             [new_ref_name, old_ref_name],
         )?;
-        sp.execute(
+        trans.execute(
             "UPDATE branch_order SET branch_ref_name = ?1 WHERE branch_ref_name = ?2",
             [new_ref_name, old_ref_name],
         )?;
 
-        sp.commit()
+        trans.commit()
     }
 
     /// Remove branch-order rows for references not present in `existing_ref_names`.
     pub fn remove_missing_references(self, existing_ref_names: &[String]) -> rusqlite::Result<()> {
-        let sp = self.sp;
+        let trans = self.trans;
         let existing = existing_ref_names
             .iter()
             .map(String::as_str)
             .collect::<BTreeSet<_>>();
-        let refs = BranchOrderHandle { conn: &sp }.all_references()?;
+        let refs = BranchOrderHandle { conn: &trans }.all_references()?;
         for ref_name in refs {
             if !existing.contains(ref_name.as_str()) {
-                remove_reference_in_savepoint(&sp, &ref_name)?;
+                remove_reference_in_savepoint(&trans, &ref_name)?;
             }
         }
-        sp.commit()
+        trans.commit()
     }
 }
 
 fn remove_reference_in_savepoint(
-    sp: &rusqlite::Savepoint<'_>,
+    conn: &rusqlite::Connection,
     ref_name: &str,
 ) -> rusqlite::Result<()> {
-    let parent = BranchOrderHandle { conn: sp }.parent_of(ref_name)?;
-    let child = BranchOrderHandle { conn: sp }.child_of(ref_name)?;
+    let parent = BranchOrderHandle { conn }.parent_of(ref_name)?;
+    let child = BranchOrderHandle { conn }.child_of(ref_name)?;
 
-    sp.execute(
+    conn.execute(
         "DELETE FROM branch_order WHERE branch_ref_name = ?1",
         [ref_name],
     )?;
     if let Some(child) = child.as_ref() {
-        sp.execute(
+        conn.execute(
             "UPDATE branch_order SET parent_ref_name = ?1 WHERE branch_ref_name = ?2",
             rusqlite::params![parent, child],
         )?;
@@ -266,9 +269,9 @@ fn remove_reference_in_savepoint(
         _ => None,
     };
     if let Some(singleton) = singleton {
-        let order = BranchOrderHandle { conn: sp };
+        let order = BranchOrderHandle { conn };
         if order.parent_of(singleton)?.is_none() && order.child_of(singleton)?.is_none() {
-            sp.execute(
+            conn.execute(
                 "DELETE FROM branch_order WHERE branch_ref_name = ?1",
                 [singleton],
             )?;

--- a/crates/but-db/src/table/ci_checks.rs
+++ b/crates/but-db/src/table/ci_checks.rs
@@ -59,7 +59,10 @@ impl DbHandle {
 
     pub fn ci_checks_mut(&mut self) -> rusqlite::Result<CiChecksHandleMut<'_>> {
         Ok(CiChecksHandleMut {
-            sp: self.conn.savepoint()?,
+            trans: crate::WriteScope::Owned(
+                self.conn
+                    .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?,
+            ),
         })
     }
 }
@@ -71,7 +74,7 @@ impl<'conn> Transaction<'conn> {
 
     pub fn ci_checks_mut(&mut self) -> rusqlite::Result<CiChecksHandleMut<'_>> {
         Ok(CiChecksHandleMut {
-            sp: self.inner_mut().savepoint()?,
+            trans: crate::WriteScope::Nested(self.inner_mut().savepoint()?),
         })
     }
 }
@@ -82,7 +85,7 @@ pub struct CiChecksHandle<'conn> {
 
 pub struct CiChecksHandleMut<'conn> {
     // Use savepoint as transaction, otherwise use `Connection`.
-    sp: rusqlite::Savepoint<'conn>,
+    trans: crate::WriteScope<'conn>,
 }
 
 impl CiChecksHandle<'_> {
@@ -136,7 +139,7 @@ impl CiChecksHandle<'_> {
 impl CiChecksHandleMut<'_> {
     /// Enable read-only access functions.
     pub fn to_ref(&self) -> CiChecksHandle<'_> {
-        CiChecksHandle { conn: &self.sp }
+        CiChecksHandle { conn: &self.trans }
     }
 
     /// Sets the ci_checks table for a specific reference to the provided values.
@@ -145,14 +148,14 @@ impl CiChecksHandleMut<'_> {
     /// Consumes this handle because it commits the internal savepoint/transaction,
     /// which is also consuming.
     pub fn set_for_reference(self, ref_name: &str, checks: Vec<CiCheck>) -> rusqlite::Result<()> {
-        let sp = self.sp;
+        let trans = self.trans;
 
         // Delete existing entries for this reference
-        sp.execute("DELETE FROM ci_checks WHERE reference = ?1", [ref_name])?;
+        trans.execute("DELETE FROM ci_checks WHERE reference = ?1", [ref_name])?;
 
         // Insert new entries
         if !checks.is_empty() {
-            let mut stmt = sp.prepare(
+            let mut stmt = trans.prepare(
                 "INSERT INTO ci_checks (id, name, output_summary, output_text, output_title,
                                        started_at, status_type, status_conclusion, status_completed_at,
                                        head_sha, url, html_url, details_url, pull_requests,
@@ -183,15 +186,15 @@ impl CiChecksHandleMut<'_> {
             }
         }
 
-        sp.commit()?;
+        trans.commit()?;
         Ok(())
     }
 
     /// Deletes all CI check entries for a specific reference.
     pub fn delete_for_reference(self, ref_name: &str) -> rusqlite::Result<()> {
-        self.sp
+        self.trans
             .execute("DELETE FROM ci_checks WHERE reference = ?1", [ref_name])?;
-        self.sp.commit()?;
+        self.trans.commit()?;
         Ok(())
     }
 }

--- a/crates/but-db/src/table/forge_reviews.rs
+++ b/crates/but-db/src/table/forge_reviews.rs
@@ -87,7 +87,10 @@ impl DbHandle {
 
     pub fn forge_reviews_mut(&mut self) -> rusqlite::Result<ForgeReviewsHandleMut<'_>> {
         Ok(ForgeReviewsHandleMut {
-            sp: self.conn.savepoint()?,
+            trans: crate::WriteScope::Owned(
+                self.conn
+                    .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?,
+            ),
         })
     }
 }
@@ -99,7 +102,7 @@ impl<'conn> Transaction<'conn> {
 
     pub fn forge_reviews_mut(&mut self) -> rusqlite::Result<ForgeReviewsHandleMut<'_>> {
         Ok(ForgeReviewsHandleMut {
-            sp: self.inner_mut().savepoint()?,
+            trans: crate::WriteScope::Nested(self.inner_mut().savepoint()?),
         })
     }
 }
@@ -109,7 +112,7 @@ pub struct ForgeReviewsHandle<'conn> {
 }
 
 pub struct ForgeReviewsHandleMut<'conn> {
-    sp: rusqlite::Savepoint<'conn>,
+    trans: crate::WriteScope<'conn>,
 }
 
 impl ForgeReviewsHandle<'_> {
@@ -158,19 +161,19 @@ impl ForgeReviewsHandle<'_> {
 impl ForgeReviewsHandleMut<'_> {
     /// Enable read-only access functions.
     pub fn to_ref(&self) -> ForgeReviewsHandle<'_> {
-        ForgeReviewsHandle { conn: &self.sp }
+        ForgeReviewsHandle { conn: &self.trans }
     }
 
     /// Sets the forge_reviews table to the provided values.
     /// Any existing entries that are not in the provided values are deleted.
     pub fn set_all(self, reviews: Vec<ForgeReview>) -> rusqlite::Result<()> {
-        self.sp.execute("DELETE FROM forge_reviews", [])?;
+        self.trans.execute("DELETE FROM forge_reviews", [])?;
 
         for review in reviews {
             self.upsert_without_commit(review)?;
         }
 
-        self.sp.commit()?;
+        self.trans.commit()?;
         Ok(())
     }
 
@@ -178,7 +181,7 @@ impl ForgeReviewsHandleMut<'_> {
     pub fn upsert(self, review: ForgeReview) -> rusqlite::Result<()> {
         self.upsert_without_commit(review)?;
 
-        self.sp.commit()?;
+        self.trans.commit()?;
         Ok(())
     }
 
@@ -210,7 +213,7 @@ impl ForgeReviewsHandleMut<'_> {
         merged_cutoff: chrono::NaiveDateTime,
         absent_open_cutoff: chrono::NaiveDateTime,
     ) -> rusqlite::Result<()> {
-        self.sp.execute(
+        self.trans.execute(
             "DELETE FROM forge_reviews WHERE struct_version != ?1",
             [struct_version],
         )?;
@@ -225,7 +228,7 @@ impl ForgeReviewsHandleMut<'_> {
         self.delete_open_reviews_absent_from_list(&listed_numbers, absent_open_cutoff)?;
         self.prune_merged_before(merged_cutoff)?;
 
-        self.sp.commit()?;
+        self.trans.commit()?;
         Ok(())
     }
 
@@ -245,7 +248,7 @@ impl ForgeReviewsHandleMut<'_> {
         absent_open_cutoff: chrono::NaiveDateTime,
     ) -> rusqlite::Result<()> {
         if listed_numbers.is_empty() {
-            self.sp.execute(
+            self.trans.execute(
                 "DELETE FROM forge_reviews \
                  WHERE merged_at IS NULL AND closed_at IS NULL \
                  AND last_sync_at <= ?1",
@@ -265,7 +268,7 @@ impl ForgeReviewsHandleMut<'_> {
         }
         params.push(&absent_open_cutoff);
 
-        self.sp.execute(
+        self.trans.execute(
             &format!(
                 "DELETE FROM forge_reviews \
                  WHERE merged_at IS NULL AND closed_at IS NULL \
@@ -280,7 +283,7 @@ impl ForgeReviewsHandleMut<'_> {
     /// Delete merged reviews whose `merged_at` is at or before `cutoff`. Does not
     /// commit; the caller owns the surrounding savepoint.
     fn prune_merged_before(&self, cutoff: chrono::NaiveDateTime) -> rusqlite::Result<()> {
-        self.sp.execute(
+        self.trans.execute(
             "DELETE FROM forge_reviews WHERE merged_at IS NOT NULL AND merged_at <= ?1",
             [cutoff],
         )?;
@@ -288,7 +291,7 @@ impl ForgeReviewsHandleMut<'_> {
     }
 
     fn upsert_without_commit(&self, review: ForgeReview) -> rusqlite::Result<()> {
-        self.sp.execute(
+        self.trans.execute(
             "INSERT INTO forge_reviews (html_url, number, title, body, author, labels, draft, \
              source_branch, target_branch, sha, integration_commit_shas, created_at, modified_at, merged_at, closed_at, \
              repository_ssh_url, repository_https_url, repo_owner, head_repo_is_fork, reviewers, \
@@ -351,7 +354,7 @@ impl ForgeReviewsHandleMut<'_> {
     /// Deletes reviews with a merge timestamp at or before `cutoff`.
     pub fn delete_merged_before(self, cutoff: chrono::NaiveDateTime) -> rusqlite::Result<()> {
         self.prune_merged_before(cutoff)?;
-        self.sp.commit()?;
+        self.trans.commit()?;
         Ok(())
     }
 }

--- a/crates/but-db/src/table/hunk_assignments.rs
+++ b/crates/but-db/src/table/hunk_assignments.rs
@@ -52,7 +52,14 @@ impl DbHandle {
 
     pub fn hunk_assignments_mut(&mut self) -> rusqlite::Result<HunkAssignmentsHandleMut<'_>> {
         Ok(HunkAssignmentsHandleMut {
-            sp: self.conn.savepoint()?,
+            // Deferred on purpose, unlike the other mutation handles. Callers
+            // hold this one across the hunk-assignment computation (the file
+            // watcher, `but-action`, `but clean`), so taking the write lock up
+            // front would block every other writer for as long as that takes.
+            // The cost is that a concurrent commit can still fail this handle's
+            // write with `SQLITE_BUSY`; the fix is to stop holding it across
+            // that work, not to widen the lock.
+            trans: crate::WriteScope::Nested(self.conn.savepoint()?),
         })
     }
 }
@@ -64,7 +71,7 @@ impl<'conn> Transaction<'conn> {
 
     pub fn hunk_assignments_mut(&mut self) -> rusqlite::Result<HunkAssignmentsHandleMut<'_>> {
         Ok(HunkAssignmentsHandleMut {
-            sp: self.inner_mut().savepoint()?,
+            trans: crate::WriteScope::Nested(self.inner_mut().savepoint()?),
         })
     }
 }
@@ -74,7 +81,7 @@ pub struct HunkAssignmentsHandle<'conn> {
 }
 
 pub struct HunkAssignmentsHandleMut<'conn> {
-    sp: rusqlite::Savepoint<'conn>,
+    trans: crate::WriteScope<'conn>,
 }
 
 impl HunkAssignmentsHandle<'_> {
@@ -102,17 +109,17 @@ impl HunkAssignmentsHandle<'_> {
 impl HunkAssignmentsHandleMut<'_> {
     /// Enable read-only access functions.
     pub fn to_ref(&self) -> HunkAssignmentsHandle<'_> {
-        HunkAssignmentsHandle { conn: &self.sp }
+        HunkAssignmentsHandle { conn: &self.trans }
     }
 
     /// Sets the hunk assignments table to the provided values.
     /// Any existing entries that are not in the provided values are deleted.
     /// `stack_id` is preserved only for reads of legacy rows and is no longer written.
     pub fn set_all(self, assignments: Vec<HunkAssignment>) -> rusqlite::Result<()> {
-        self.sp.execute("DELETE FROM hunk_assignments", [])?;
+        self.trans.execute("DELETE FROM hunk_assignments", [])?;
 
         for assignment in assignments {
-            self.sp.execute(
+            self.trans.execute(
                 "INSERT INTO hunk_assignments (id, hunk_header, path, path_bytes, branch_ref) \
                  VALUES (?1, ?2, ?3, ?4, ?5)",
                 rusqlite::params![
@@ -125,7 +132,7 @@ impl HunkAssignmentsHandleMut<'_> {
             )?;
         }
 
-        self.sp.commit()?;
+        self.trans.commit()?;
         Ok(())
     }
 }

--- a/crates/but-db/src/table/virtual_branches.rs
+++ b/crates/but-db/src/table/virtual_branches.rs
@@ -152,7 +152,10 @@ impl DbHandle {
     /// Mutating methods on [`VirtualBranchesHandleMut`] consume the handle and commit automatically.
     pub fn virtual_branches_mut(&mut self) -> rusqlite::Result<VirtualBranchesHandleMut<'_>> {
         Ok(VirtualBranchesHandleMut {
-            sp: self.conn.savepoint()?,
+            trans: crate::WriteScope::Owned(
+                self.conn
+                    .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?,
+            ),
         })
     }
 }
@@ -168,7 +171,7 @@ impl<'conn> Transaction<'conn> {
     /// Mutating methods on [`VirtualBranchesHandleMut`] consume the handle and commit automatically.
     pub fn virtual_branches_mut(&mut self) -> rusqlite::Result<VirtualBranchesHandleMut<'_>> {
         Ok(VirtualBranchesHandleMut {
-            sp: self.inner_mut().savepoint()?,
+            trans: crate::WriteScope::Nested(self.inner_mut().savepoint()?),
         })
     }
 }
@@ -185,7 +188,7 @@ pub struct VirtualBranchesHandle<'conn> {
 /// Created from [`DbHandle::virtual_branches_mut`] or [`Transaction::virtual_branches_mut`].
 /// Methods on this type consume the handle and commit on success.
 pub struct VirtualBranchesHandleMut<'conn> {
-    sp: rusqlite::Savepoint<'conn>,
+    trans: crate::WriteScope<'conn>,
 }
 
 impl VirtualBranchesHandle<'_> {
@@ -310,12 +313,12 @@ impl VirtualBranchesHandle<'_> {
 impl VirtualBranchesHandleMut<'_> {
     /// Convert this mutating handle into a read-only view on the same savepoint.
     pub fn to_ref(&self) -> VirtualBranchesHandle<'_> {
-        VirtualBranchesHandle { conn: &self.sp }
+        VirtualBranchesHandle { conn: &self.trans }
     }
 
     /// Caller must call commit on the transaction.
     fn set_state_in_place(&mut self, state: &VbState) -> rusqlite::Result<()> {
-        self.sp.execute(
+        self.trans.execute(
             "INSERT INTO vb_state (
                 id,
                 initialized,
@@ -343,7 +346,7 @@ impl VirtualBranchesHandleMut<'_> {
     /// Insert or update the singleton `vb_state` row (`id = 1`) and commit the savepoint.
     pub fn set_state(mut self, state: &VbState) -> rusqlite::Result<()> {
         self.set_state_in_place(state)?;
-        self.sp.commit()
+        self.trans.commit()
     }
 
     /// Replace all VB tables with the provided normalized snapshot.
@@ -352,10 +355,10 @@ impl VirtualBranchesHandleMut<'_> {
     pub fn replace_snapshot(mut self, snapshot: &VirtualBranchesSnapshot) -> rusqlite::Result<()> {
         self.set_state_in_place(&snapshot.state)?;
 
-        self.sp.execute("DELETE FROM vb_stacks", [])?;
+        self.trans.execute("DELETE FROM vb_stacks", [])?;
 
         {
-            let mut insert_stack = self.sp.prepare(
+            let mut insert_stack = self.trans.prepare(
                 "INSERT INTO vb_stacks (
                     id,
                     source_refname,
@@ -396,7 +399,7 @@ impl VirtualBranchesHandleMut<'_> {
         }
 
         {
-            let mut insert_head = self.sp.prepare(
+            let mut insert_head = self.trans.prepare(
                 "INSERT INTO vb_stack_heads (
                     stack_id,
                     position,
@@ -420,6 +423,6 @@ impl VirtualBranchesHandleMut<'_> {
             }
         }
 
-        self.sp.commit()
+        self.trans.commit()
     }
 }

--- a/crates/but-db/tests/db/transaction.rs
+++ b/crates/but-db/tests/db/transaction.rs
@@ -196,3 +196,34 @@ fn two_handles_same_db() -> anyhow::Result<(DbHandle, DbHandle, tempfile::TempDi
     let db2 = DbHandle::new_in_directory(tmp.path())?;
     Ok((db1, db2, tmp))
 }
+
+/// A mutation handle from a [`DbHandle`] takes the write lock the moment it is
+/// created, before it reads anything.
+///
+/// It has to: a mutation reads the rows it is about to replace, and a *deferred*
+/// transaction that reads first has its later write rejected with `SQLITE_BUSY`
+/// as soon as another connection commits in between. SQLite does not run the
+/// busy handler for that case, so `busy_timeout` cannot wait it out and the
+/// caller just sees "database is locked". Holding the lock from the start leaves
+/// no snapshot to invalidate.
+#[test]
+fn a_mutation_takes_the_write_lock_before_it_reads() -> anyhow::Result<()> {
+    let (mut db1, mut db2, _tmp) = two_handles_same_db()?;
+
+    // Merely creating the handle must already exclude other writers.
+    let _mutation = db1.branch_order_mut()?;
+
+    let mut other = db2.transaction()?;
+    other.set_nonblocking()?;
+    let err = other
+        .branch_order_mut()?
+        .set_order(&["refs/heads/a".to_owned(), "refs/heads/b".to_owned()])
+        .unwrap_err();
+    assert_eq!(
+        err.sqlite_error_code(),
+        Some(ErrorCode::DatabaseBusy),
+        "another connection cannot commit while the mutation holds the write lock, \
+         so the mutation's read can never go stale under it"
+    );
+    Ok(())
+}


### PR DESCRIPTION
`but apply` spawns its background sync as a **detached child**, so it outlives the command and races the next one for SQLite. That next command died with `database is locked` — reproduced outside Playwright at **2 in 64** runs of `but setup` / `but apply` / `but branch new`.

## Why the busy timeout could not help

This is not plain lock contention. A mutation reads the rows it is about to replace (`set_order` looks up the refs it will rewrite) and writes after, and the handles were built on `conn.savepoint()` — which, with no transaction already open, begins a *deferred* one.

When another connection commits between that read and the write, SQLite rejects the write with `SQLITE_BUSY` and **deliberately does not run the busy handler**, so the five second timeout cannot wait it out. `deferred_savepoint_write_after_concurrent_commit_returns_busy_snapshot` has documented that behaviour all along — it was just never connected to the crash.

## The change

Mutation handles from a `DbHandle` now begin an immediate transaction, taking the write lock before anything is read, so there is no snapshot left to invalidate. Handles from a caller's `Transaction` still nest a savepoint — that caller already chose how its transaction takes locks.

`hunk_assignments` keeps the deferred behaviour **on purpose**: the watcher, `but-action` and `but clean` hold that handle across the whole hunk-assignment computation, so taking the write lock up front would block every other writer for as long as that takes. Fixing that means not holding it across the work, rather than widening the lock.

## Verification

- the new test **fails on the old constructor and passes on this one** — checked by reverting it, since a test that passes both ways proves nothing
- standalone repro: **2/64 failures before, 0/356 after**
- `cargo build --workspace` clean, all 153 but-db tests pass

This is a product bug, not just a CI one: any command run right after `but apply` can hit it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)