### PR TITLE
Keep ambient background sync out of e2e runs

### DIFF
--- a/e2e/playwright/src/setup.ts
+++ b/e2e/playwright/src/setup.ts
@@ -176,6 +176,12 @@ class GitButlerManager implements GitButler {
 		const envVars = {
 			E2E_TEST_APP_DATA_DIR: this.configDir,
 			GIT_CONFIG_GLOBAL: this.gitConfigGlobal,
+			// No ambient background sync (fetch/PR/CI refresh): the detached
+			// child it spawns outlives the script and keeps writing while the
+			// test's dirs are torn down. The Rust CLI tests set this too; the
+			// sync-vs-mutation race itself is covered deterministically in
+			// but-db's transaction tests.
+			NO_BG_TASKS: "1",
 			...this.env,
 			...env,
 		};


### PR DESCRIPTION
Any `but` invocation past a never-synced fetch interval spawns a detached `refresh-remote-data` child (fetch, PR listing, CI checks, update check). In e2e that child outlives the fixture script that triggered it:

- it keeps writing while the test's workdir and its trap-deleted remote are torn down (observed as `rm: Directory not empty` during cleanup, and fetches against already-deleted remotes)
- its `fetch_status` / cache commits race whatever `but` command the script runs next

That race was the root cause of the `Command failed with exit code 1` flake cluster: the next command's mutation died with `Error code 5: database is locked` — a deferred-savepoint read-then-write hitting `SQLITE_BUSY_SNAPSHOT`, which the busy timeout cannot wait out. #15653 carries the full diagnosis and a product-side fix; it was closed in favor of removing the trigger from tests.

## The change

Set `NO_BG_TASKS=1` for fixture scripts in the playwright harness — the same switch every Rust CLI test already uses. None of the ambient sync's work is anything an e2e test asserts on; it is just nondeterministic concurrent activity.

The race mechanism itself keeps deterministic coverage in but-db (`deferred_savepoint_write_after_concurrent_commit_returns_busy_snapshot`).

## Verification

Full suite with the switch: **174 passed, 0 failed**, and zero `Initiated a background sync` lines in the output — confirming both that the switch takes effect and that nothing depended on the sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)