### PR TITLE
Let the pull request column give ground

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
@@ -251,6 +251,10 @@
 
 .prMain {
 	flex: 1;
+	/* Without this the automatic minimum size holds the column at its widest
+	   content — a quoted hunk, a long code span — so it never gives ground and
+	   the fixed panel beside it is pushed off the edge instead. */
+	min-width: 0;
 }
 
 .fileHeader {


### PR DESCRIPTION
`.prMain` is `flex: 1` with no `min-width: 0`, so its automatic minimum size
holds the column at its widest content — a quoted hunk, a long code span — and
drags the layout past the `max-width: 1000px` that `.prTab` sets for the
centred view. The side panel beside it already carries this guard, with a
comment explaining the same trap.

Measured on a pull request whose comments quote code:

| viewport | centred view before | after |
| --- | --- | --- |
| 2272 | 1365 | 1000 (its cap) |
| 1600 | 1365 | 1000 |
| 1100 | held | 584 |
| 900 | held | 488 |

The column now gives ground as the window narrows (645 → 229 → 133) instead of
holding fast.

## Not fixed here

The left sidebar holds 505px at every viewport width, down to 620, so below
about 1000px the details pane is crushed to its floor and the pull request's
side panel is pushed off the right edge. That is the shell's resizable split
rather than this layout, and wants its own change — deciding the sidebar's real
minimum, and whether its content truncates or scrolls there.
