### PR TITLE
Keep Apply integration clickable through a background refetch

### DIFF
--- a/apps/desktop/src/components/branch/BranchIntegrationModalContent.svelte
+++ b/apps/desktop/src/components/branch/BranchIntegrationModalContent.svelte
@@ -167,13 +167,11 @@
 	}
 
 	$effect(() => {
-		// A forced refetch may expose cached data while the request is in flight.
-		// Wait for the fresh plan before building drafts or enabling Apply.
+		// Don't wipe the plan while a background refetch is in flight: Apply
+		// goes disabled for the round trip and the browser swallows the click.
+		// `selectTemplate` already clears it when the key changes.
 		const query = initialBranchIntegration.result;
-		if (query.status !== "fulfilled") {
-			preparedIntegration = undefined;
-			return;
-		}
+		if (query.status !== "fulfilled") return;
 
 		const initial = query.data;
 		if (!initial || query.requestId === initializedRequestId) return;

--- a/apps/lite/ui/src/components/Toasts.module.css
+++ b/apps/lite/ui/src/components/Toasts.module.css
@@ -27,6 +27,9 @@
 	display: flex;
 	flex-direction: column;
 	gap: 12px;
+	/* Error messages carry URLs and identifiers longer than any word the
+	   250px card can hold; break them rather than overflow the card. */
+	overflow-wrap: anywhere;
 }
 
 .actions {

--- a/crates/but-github/src/client.rs
+++ b/crates/but-github/src/client.rs
@@ -1194,8 +1194,20 @@ impl GitHubClient {
 
         let response = self.client.put(&url).json(&body).send().await?;
 
-        if !response.status().is_success() {
-            bail!("Failed to merge pull request: {}", response.status());
+        let status = response.status();
+        if !status.is_success() {
+            // The body carries GitHub's reason. Only its `message` reads well in
+            // a toast; the raw envelope drags a documentation URL along.
+            let body = response.text().await.unwrap_or_default();
+            let reason = serde_json::from_str::<serde_json::Value>(&body)
+                .ok()
+                .and_then(|value| {
+                    value
+                        .get("message")
+                        .and_then(|m| m.as_str().map(String::from))
+                })
+                .unwrap_or(body);
+            bail!("GitHub refused the merge ({status}): {reason}");
         }
 
         Ok(())

--- a/crates/but-github/src/pr.rs
+++ b/crates/but-github/src/pr.rs
@@ -483,7 +483,6 @@ pub async fn merge(
     GitHubClient::from_storage(storage, preferred_account)?
         .merge_pull_request(&params)
         .await
-        .context("Failed to merge PR")
 }
 
 pub async fn set_draft_state(

--- a/e2e/playwright/src/expect.ts
+++ b/e2e/playwright/src/expect.ts
@@ -21,19 +21,10 @@ import { expect as base, type Locator, type Page } from "@playwright/test";
  */
 
 /**
- * Attempts are bounded so the loop regains control to ask whether the app is
- * still working. Short enough that a failure is reported promptly after the app
- * goes quiet, long enough that a passing assertion rarely needs a second one.
+ * Floor for an attempt's deadline, so an assertion started against an
+ * already-quiet app still gets one real retry window.
  */
-const ATTEMPT_MS = 1_000;
-
-/**
- * `configure` sets the attempt deadline without touching the call's arguments —
- * matchers take their options in varying positions (and some take an object as
- * the expected value), so injecting a `timeout` into the arguments would have
- * to guess which is which.
- */
-const bounded = base.configure({ timeout: ATTEMPT_MS });
+const MIN_ATTEMPT_MS = 1_000;
 
 /** Chain of modifiers (`not`, `resolves`, `rejects`) applied before the matcher. */
 type Modifiers = readonly string[];
@@ -50,17 +41,21 @@ function pageOf(subject: unknown): Page | undefined {
 	return undefined;
 }
 
-/** Build a fresh bounded assertion, so each attempt starts its own retry window. */
+/**
+ * One assertion attempt bounded at `timeoutMs`; the deadline is what makes an
+ * uncancelable Playwright assertion abandonable. `configure` sets it without
+ * touching the arguments, whose option position varies per matcher.
+ */
 function attempt(
 	subject: unknown,
 	modifiers: Modifiers,
 	matcher: string,
 	args: unknown[],
+	timeoutMs: number,
 ): unknown {
 	// The matcher surface is dynamic by nature; this is the one place that has
 	// to reach through it untyped.
-
-	let node: any = bounded(subject as any);
+	let node: any = base.configure({ timeout: timeoutMs })(subject as any);
 	for (const modifier of modifiers) node = node[modifier];
 	return node[matcher](...args);
 }
@@ -74,20 +69,32 @@ function retryWhileAppWorks(
 ): unknown {
 	watchIdle(page);
 	const startedAt = Date.now();
-	const first = attempt(subject, modifiers, matcher, args);
+	// Each attempt spans the remaining idle budget: while the app is active,
+	// idleness cannot reach the budget sooner, so the expiry check at the
+	// boundary is never late and a passing assertion needs one or two attempts.
+	function remaining() {
+		return IDLE_BUDGET_MS - idleSince(page, startedAt);
+	}
+	const first = attempt(subject, modifiers, matcher, args, Math.max(remaining(), MIN_ATTEMPT_MS));
 	// A matcher on a plain value resolves or throws synchronously; nothing to retry.
 	if (!(first instanceof Promise)) return first;
 
 	return (async () => {
 		let pending = first;
-		for (;;) {
+		let failure: unknown;
+		let remainingMs: number;
+		do {
 			try {
 				return await pending;
 			} catch (error) {
-				if (idleSince(page, startedAt) >= IDLE_BUDGET_MS) throw error;
-				pending = attempt(subject, modifiers, matcher, args) as Promise<unknown>;
+				failure = error;
 			}
-		}
+			remainingMs = remaining();
+			if (remainingMs > 0) {
+				pending = attempt(subject, modifiers, matcher, args, remainingMs) as Promise<unknown>;
+			}
+		} while (remainingMs > 0);
+		throw failure;
 	})();
 }
 
@@ -103,14 +110,29 @@ function wrapAssertion(
 			if (property === "not" || property === "resolves" || property === "rejects") {
 				return wrapAssertion(value as object, subject, page, [...modifiers, property]);
 			}
-			if (typeof value !== "function") return value;
-			return (...args: unknown[]) =>
-				retryWhileAppWorks(subject, page, modifiers, property as string, args);
+			// Matchers are string-named; symbol-named functions belong to
+			// Node/inspect plumbing and must pass through untouched.
+			if (typeof value !== "function" || typeof property !== "string") return value;
+			return (...args: unknown[]) => retryWhileAppWorks(subject, page, modifiers, property, args);
 		},
 	});
 }
 
 export const expect = new Proxy(base, {
+	get(target, property, receiver) {
+		const value = Reflect.get(target, property, receiver);
+		// Bind own helpers (`poll`, `configure`, …) to the real expect, which
+		// otherwise run with the proxy as `this`; inherited `call`/`apply`/`bind`
+		// stay unbound.
+		if (
+			typeof value === "function" &&
+			typeof property === "string" &&
+			Object.prototype.hasOwnProperty.call(target, property)
+		) {
+			return value.bind(target);
+		}
+		return value;
+	},
 	apply(target, thisArg, args: unknown[]) {
 		const assertion = Reflect.apply(target, thisArg, args) as object;
 		const page = pageOf(args[0]);

--- a/e2e/playwright/src/util.ts
+++ b/e2e/playwright/src/util.ts
@@ -40,7 +40,7 @@ export function stack(page: Page, branchName?: string): Locator {
 	});
 }
 
-/** How often the watchdog samples; small enough to be precise, large enough to be free. */
+/** Pacing between retry attempts (the watchdog itself sleeps adaptively). */
 const IDLE_POLL_MS = 250;
 
 /**
@@ -64,21 +64,28 @@ async function untilTheAppGoesQuiet<T>(
 	// The watchdog may win the race; keep its loser from surfacing as an
 	// unhandled rejection.
 	acting.catch(() => {});
+	// For racing sleeps below: settles when the action does, never rejects.
+	const settled = acting.then(
+		() => undefined,
+		() => undefined,
+	);
 
 	const watchdog = (async (): Promise<T> => {
-		for (;;) {
-			await new Promise((resolve) => setTimeout(resolve, IDLE_POLL_MS));
-			// Stop counting the moment the action settles, so the loop cannot
-			// outlive it — `acting` has already resolved or rejected here.
+		// Sleep exactly until the budget could expire (idleness cannot reach it
+		// sooner while the app is active), waking early if the action settles:
+		// expiry lands on time, not a poll interval late.
+		let idleFor: number;
+		while ((idleFor = idleSince(page, startedAt)) < idleBudgetMs) {
+			await Promise.race([
+				settled,
+				new Promise((resolve) => setTimeout(resolve, idleBudgetMs - idleFor)),
+			]);
 			if (done) return await acting;
-			const idleFor = idleSince(page, startedAt);
-			if (idleFor >= idleBudgetMs) {
-				throw new Error(
-					`Timed out ${describe}: the app made no request for ` +
-						`${Math.round(idleFor / 1000)}s, so it is not still working on it.`,
-				);
-			}
 		}
+		throw new Error(
+			`Timed out ${describe}: the app made no request for ` +
+				`${Math.round(idleFor / 1000)}s, so it is not still working on it.`,
+		);
 	})();
 
 	return await Promise.race([acting, watchdog]);
@@ -218,21 +225,40 @@ export async function fillByTestId(
 	// sticks — under the idle budget like every other wait. A function-subject
 	// `toPass()` would bypass src/expect.ts and burn the per-test timeout on a
 	// real failure.
-	await untilTheAppGoesQuiet(
-		page,
-		`filling getByTestId(${JSON.stringify(testId)})`,
-		IDLE_BUDGET_MS,
-		async () => {
-			// timeout: 0 on the inner calls too — the watchdog is the boundary
-			// here, and a 15s actionTimeout inside the loop would reintroduce a
-			// wall-clock failure while the app is still visibly working.
-			for (;;) {
-				await element.fill(value, { timeout: 0 });
-				if ((await element.inputValue({ timeout: 0 })) === value) return;
-				await new Promise((resolve) => setTimeout(resolve, IDLE_POLL_MS));
-			}
-		},
-	);
+	let lastError: unknown;
+	try {
+		await untilTheAppGoesQuiet(
+			page,
+			`filling getByTestId(${JSON.stringify(testId)})`,
+			IDLE_BUDGET_MS,
+			async () => {
+				// timeout: 0 on the inner calls too — the watchdog is the boundary
+				// here, and a 15s actionTimeout inside the loop would reintroduce a
+				// wall-clock failure while the app is still visibly working.
+				let filled: string | undefined;
+				while (filled !== value) {
+					try {
+						await element.fill(value, { timeout: 0 });
+						filled = await element.inputValue({ timeout: 0 });
+					} catch (error) {
+						// A re-render can detach the node mid-action or make the locator
+						// briefly ambiguous: the app changing, not a verdict. The watchdog
+						// stays the only failure boundary; the last error is appended to it.
+						lastError = error;
+						filled = undefined;
+					}
+					if (filled !== value) {
+						await new Promise((resolve) => setTimeout(resolve, IDLE_POLL_MS));
+					}
+				}
+			},
+		);
+	} catch (error) {
+		if (error instanceof Error && lastError instanceof Error) {
+			error.message += `\nlast attempt failed with: ${lastError.message}`;
+		}
+		throw error;
+	}
 	return element;
 }
 

--- a/e2e/playwright/tests/branches.spec.ts
+++ b/e2e/playwright/tests/branches.spec.ts
@@ -426,6 +426,9 @@ test("should be able to apply a remote branch and integrate the remote changes -
 	await fillByTestId(page, "commit-drawer-title-input", newCommitMessage);
 	await textEditorFillByTestId(page, "commit-drawer-description-input", "CCCCCCC");
 	await clickByTestId(page, "commit-drawer-action-button");
+	// The commit must land before integrate races it. Lost in rebases twice
+	// before (42b0b4c86b): keep it.
+	await expect(commitRow(page)).toHaveCount(3);
 
 	// Integrate upstream commits on top
 	await clickByTestId(page, "upstream-commits-integrate-button");


### PR DESCRIPTION
Keep Apply integration clickable through a background refetch

The last live e2e flake after #15650/#15654: the integrate tests failed with the modal open and the app idle — Playwright clicked Apply, no request followed, no error anywhere. The trace's network log shows why, with 15ms to spare:

```
25212  get_initial_branch_integration   plan fulfilled → Apply enabled
25620  head_info                        invalidation wave lands
25621  get_initial_branch_integration   refetch → query re-pends → Apply DISABLED
25636  click                            natively swallowed: disabled buttons dispatch no events
25696  apply_branch_integration         preview re-runs → modal pristine
```

The modal's effect wiped `preparedIntegration` on any non-fulfilled query status, so a background refetch — any workspace invalidation lands there — flipped Apply disabled for the round trip. A disabled button dispatches no events at all, so the click vanished without a trace. **A real user clicking Apply the instant a periodic fetch lands loses the click the same way.**

## The fix

Delete the wipe. It turns out to be needed in no case at all: the plan starts unset, the forced refetch on open initiates before anything could be initialized, and `selectTemplate` already clears the plan when the query key changes — the only situation where the wipe ever changed anything was this bug.

Also restores the one-line wait in the create-commit variant (the commit must land before integrate races it) — this fix has now been lost in rebases twice (42b0b4c86b); the comment says so.

## Evidence

- reproduced under load: 1 failure in 80 executions, diagnosed from the trace + last video frame
- after: **304/304** across four rounds of identical load
- svelte-check: 2715 files, 0 errors

## Also: idle-helper hardening

A second commit carries the two review follow-ups that missed #15650's merge (their threads are resolved there):

- `fillByTestId` retries transient errors (mid-action detach, strict-mode ambiguity during re-render) under the idle watchdog, carrying the last error on the final failure so a permanent problem is still named
- `expect` proxy hygiene: base helpers bound so `this` is never the proxy; symbol-named properties pass through unwrapped
- the idle watchdog and the assertion retry both sleep/size adaptively — exactly the remaining idle budget, since idleness cannot reach it sooner — instead of fixed-cadence chunks: expiry lands on time, nothing keeps ticking once the action settles, and a typical assertion needs one or two attempts instead of ten

## Also: say why GitHub refused a merge

A third commit, oldest on the branch: the merge endpoint's failure now carries GitHub's `message` (a refused endpoint, a branch restriction) instead of a bare status, and long error toasts wrap in Lite instead of overflowing the card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

