### PR TITLE
Tighten the Lite sidebar and toolbox spacing

### DIFF
--- a/apps/lite/ui/src/components/Toolbox.module.css
+++ b/apps/lite/ui/src/components/Toolbox.module.css
@@ -102,6 +102,6 @@
 .separator {
 	align-self: stretch;
 	width: 1px;
-	margin-inline: 4px;
+	margin-inline: 6px;
 	background-color: var(--border-3);
 }

--- a/apps/lite/ui/src/routes/project/$id/workspace/Sidebar.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Sidebar.module.css
@@ -14,7 +14,7 @@
 }
 
 /* When the panel is too narrow to fit the tab labels, show icons only. */
-@container (max-width: 320px) {
+@container (max-width: 340px) {
 	.tabLabel {
 		display: none;
 	}


### PR DESCRIPTION
## 🧢 Changes

### Collapse the sidebar tab labels sooner

The workspace sidebar's container-query breakpoint moves from **320px to 340px**, so the tabs drop to icon-only before their labels get cramped. The old breakpoint left just enough room to look broken rather than tight — most visible once the upstream counter is in the row:

<img width="510" alt="Sidebar tabs cramped at the old breakpoint" src="https://github.com/user-attachments/assets/a493e157-bc74-4186-ad42-c89110636ead" />

### Give the toolbox separator some air

The separator's horizontal margin goes from **4px to 6px**, so grouped controls read as groups instead of running together.

| Before | After |
| :--- | :--- |
| <img width="403" height="136" alt="Toolbox separator at 4px margin" src="https://github.com/user-attachments/assets/d6b108dc-e13e-40dd-9870-b286cf2c90f4" /> | <img width="411" height="134" alt="Toolbox separator at 6px margin" src="https://github.com/user-attachments/assets/305928cb-7345-4a3b-bb58-4c729e9e88a5" /> |

## ☕️ Reasoning

Two small chrome tweaks in Lite, both about breathing room. The sidebar tabs were
overflowing awkwardly in the last stretch before the old breakpoint kicked in, and the
toolbox separator sat tight enough against its neighbours that the grouping it was
meant to signal didn't come through.

CSS-only — no behaviour or markup changes.
