### PR TITLE
follow-up to 15612 (committer fallback)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4215,7 +4215,7 @@ dependencies = [
 [[package]]
 name = "gix"
 version = "0.87.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "gix-actor",
  "gix-attributes",
@@ -4279,7 +4279,7 @@ dependencies = [
 [[package]]
 name = "gix-actor"
 version = "0.42.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "bstr",
  "gix-date",
@@ -4290,7 +4290,7 @@ dependencies = [
 [[package]]
 name = "gix-attributes"
 version = "0.35.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "bstr",
  "gix-features",
@@ -4307,7 +4307,7 @@ dependencies = [
 [[package]]
 name = "gix-bitmap"
 version = "0.4.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "gix-error",
 ]
@@ -4315,7 +4315,7 @@ dependencies = [
 [[package]]
 name = "gix-chunk"
 version = "0.8.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "gix-error",
 ]
@@ -4323,19 +4323,18 @@ dependencies = [
 [[package]]
 name = "gix-command"
 version = "0.10.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "bstr",
  "gix-path 0.12.5",
  "gix-quote",
  "gix-trace 0.1.21",
- "shell-words",
 ]
 
 [[package]]
 name = "gix-commitgraph"
 version = "0.39.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "bstr",
  "gix-chunk",
@@ -4349,7 +4348,7 @@ dependencies = [
 [[package]]
 name = "gix-config"
 version = "0.60.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "bstr",
  "gix-config-value",
@@ -4367,7 +4366,7 @@ dependencies = [
 [[package]]
 name = "gix-config-value"
 version = "0.19.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "bitflags 2.13.0",
  "bstr",
@@ -4379,7 +4378,7 @@ dependencies = [
 [[package]]
 name = "gix-credentials"
 version = "0.40.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "bstr",
  "gix-command",
@@ -4398,7 +4397,7 @@ dependencies = [
 [[package]]
 name = "gix-date"
 version = "0.16.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "bstr",
  "gix-error",
@@ -4410,7 +4409,7 @@ dependencies = [
 [[package]]
 name = "gix-diff"
 version = "0.67.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "bstr",
  "gix-attributes",
@@ -4433,7 +4432,7 @@ dependencies = [
 [[package]]
 name = "gix-dir"
 version = "0.29.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "bstr",
  "gix-discover",
@@ -4452,7 +4451,7 @@ dependencies = [
 [[package]]
 name = "gix-discover"
 version = "0.55.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "bstr",
  "dunce",
@@ -4466,7 +4465,7 @@ dependencies = [
 [[package]]
 name = "gix-error"
 version = "0.3.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "bstr",
 ]
@@ -4474,7 +4473,7 @@ dependencies = [
 [[package]]
 name = "gix-features"
 version = "0.49.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -4492,7 +4491,7 @@ dependencies = [
 [[package]]
 name = "gix-filter"
 version = "0.34.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "bstr",
  "encoding_rs",
@@ -4512,7 +4511,7 @@ dependencies = [
 [[package]]
 name = "gix-fs"
 version = "0.22.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "bstr",
  "gix-features",
@@ -4524,7 +4523,7 @@ dependencies = [
 [[package]]
 name = "gix-glob"
 version = "0.27.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "bitflags 2.13.0",
  "bstr",
@@ -4536,7 +4535,7 @@ dependencies = [
 [[package]]
 name = "gix-hash"
 version = "0.26.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "faster-hex",
  "gix-features",
@@ -4549,7 +4548,7 @@ dependencies = [
 [[package]]
 name = "gix-hashtable"
 version = "0.16.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "gix-hash",
  "hashbrown 0.17.1",
@@ -4559,7 +4558,7 @@ dependencies = [
 [[package]]
 name = "gix-ignore"
 version = "0.22.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "bstr",
  "gix-glob",
@@ -4572,16 +4571,16 @@ dependencies = [
 [[package]]
 name = "gix-imara-diff"
 version = "0.2.5"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "bstr",
- "hashbrown 0.17.1",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
 name = "gix-index"
 version = "0.55.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "bitflags 2.13.0",
  "bstr",
@@ -4609,7 +4608,7 @@ dependencies = [
 [[package]]
 name = "gix-lock"
 version = "24.0.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "gix-tempfile",
  "gix-utils",
@@ -4619,7 +4618,7 @@ dependencies = [
 [[package]]
 name = "gix-macros"
 version = "0.1.6"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4629,7 +4628,7 @@ dependencies = [
 [[package]]
 name = "gix-mailmap"
 version = "0.34.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "bstr",
  "gix-actor",
@@ -4641,7 +4640,7 @@ dependencies = [
 [[package]]
 name = "gix-merge"
 version = "0.20.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "bstr",
  "gix-command",
@@ -4666,7 +4665,7 @@ dependencies = [
 [[package]]
 name = "gix-negotiate"
 version = "0.35.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "bitflags 2.13.0",
  "gix-commitgraph",
@@ -4679,7 +4678,7 @@ dependencies = [
 [[package]]
 name = "gix-note"
 version = "0.1.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "gix-error",
  "gix-hash",
@@ -4690,7 +4689,7 @@ dependencies = [
 [[package]]
 name = "gix-object"
 version = "0.64.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "bstr",
  "gix-actor",
@@ -4711,7 +4710,7 @@ dependencies = [
 [[package]]
 name = "gix-odb"
 version = "0.84.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "arc-swap",
  "gix-features",
@@ -4733,7 +4732,7 @@ dependencies = [
 [[package]]
 name = "gix-pack"
 version = "0.74.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "clru",
  "crossbeam-deque",
@@ -4757,7 +4756,7 @@ dependencies = [
 [[package]]
 name = "gix-packetline"
 version = "0.22.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "bstr",
  "faster-hex",
@@ -4780,7 +4779,7 @@ dependencies = [
 [[package]]
 name = "gix-path"
 version = "0.12.5"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "bstr",
  "gix-trace 0.1.21",
@@ -4791,7 +4790,7 @@ dependencies = [
 [[package]]
 name = "gix-pathspec"
 version = "0.20.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "bitflags 2.13.0",
  "bstr",
@@ -4805,7 +4804,7 @@ dependencies = [
 [[package]]
 name = "gix-prompt"
 version = "0.17.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -4817,7 +4816,7 @@ dependencies = [
 [[package]]
 name = "gix-protocol"
 version = "0.65.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "bstr",
  "gix-credentials",
@@ -4843,7 +4842,7 @@ dependencies = [
 [[package]]
 name = "gix-quote"
 version = "0.8.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "bstr",
  "gix-error",
@@ -4853,7 +4852,7 @@ dependencies = [
 [[package]]
 name = "gix-ref"
 version = "0.67.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "gix-actor",
  "gix-features",
@@ -4873,7 +4872,7 @@ dependencies = [
 [[package]]
 name = "gix-refspec"
 version = "0.45.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "bstr",
  "gix-hash",
@@ -4885,7 +4884,7 @@ dependencies = [
 [[package]]
 name = "gix-revision"
 version = "0.49.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "bitflags 2.13.0",
  "bstr",
@@ -4904,7 +4903,7 @@ dependencies = [
 [[package]]
 name = "gix-revwalk"
 version = "0.35.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "gix-commitgraph",
  "gix-date",
@@ -4919,7 +4918,7 @@ dependencies = [
 [[package]]
 name = "gix-sec"
 version = "0.14.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "bitflags 2.13.0",
  "gix-path 0.12.5",
@@ -4931,7 +4930,7 @@ dependencies = [
 [[package]]
 name = "gix-shallow"
 version = "0.13.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "bstr",
  "gix-hash",
@@ -4944,7 +4943,7 @@ dependencies = [
 [[package]]
 name = "gix-status"
 version = "0.34.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "bstr",
  "filetime",
@@ -4968,7 +4967,7 @@ dependencies = [
 [[package]]
 name = "gix-submodule"
 version = "0.34.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "bstr",
  "gix-config",
@@ -4982,7 +4981,7 @@ dependencies = [
 [[package]]
 name = "gix-tempfile"
 version = "24.0.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "dashmap",
  "gix-fs",
@@ -4996,7 +4995,7 @@ dependencies = [
 [[package]]
 name = "gix-testtools"
 version = "0.20.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "bstr",
  "crc",
@@ -5031,7 +5030,7 @@ checksum = "44dc45eae785c0eb14173e0f152e6e224dcf4d45b6a6999a3aed22af541ad678"
 [[package]]
 name = "gix-trace"
 version = "0.1.21"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "tracing",
 ]
@@ -5039,7 +5038,7 @@ dependencies = [
 [[package]]
 name = "gix-transport"
 version = "0.59.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "base64 0.22.1",
  "bstr",
@@ -5060,7 +5059,7 @@ dependencies = [
 [[package]]
 name = "gix-traverse"
 version = "0.61.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "bitflags 2.13.0",
  "gix-commitgraph",
@@ -5076,7 +5075,7 @@ dependencies = [
 [[package]]
 name = "gix-url"
 version = "0.38.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "bstr",
  "gix-path 0.12.5",
@@ -5089,7 +5088,7 @@ dependencies = [
 [[package]]
 name = "gix-utils"
 version = "0.3.6"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "bstr",
  "fastrand",
@@ -5109,7 +5108,7 @@ dependencies = [
 [[package]]
 name = "gix-validate"
 version = "0.11.4"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "bstr",
 ]
@@ -5117,7 +5116,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree"
 version = "0.56.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "bstr",
  "gix-attributes",
@@ -5136,7 +5135,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree-state"
 version = "0.34.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "bstr",
  "gix-features",
@@ -5153,7 +5152,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree-stream"
 version = "0.36.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "gix-attributes",
  "gix-error",
@@ -5170,7 +5169,7 @@ dependencies = [
 [[package]]
 name = "gix-zlib"
 version = "0.1.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=dda600d7ee29a6bda4cf1047d0d1782e76b16f98#dda600d7ee29a6bda4cf1047d0d1782e76b16f98"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
 dependencies = [
  "serde",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -207,11 +207,11 @@ bstr = "1.12.1"
 zip = { version = "4", default-features = false, features = ["bzip2"] }
 # Add the `tracing` or `tracing-detail` features to see more of gitoxide in the logs. Useful to see which programs it invokes.
 # When adjusting this, update `gix-testtools` as well!
-gix = { version = "0.87.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "dda600d7ee29a6bda4cf1047d0d1782e76b16f98", default-features = false, features = [
+gix = { version = "0.87.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "ab66595c079832218a60f823d12e571512ffce9d", default-features = false, features = [
     "sha1",
     "sha256",
 ] }
-gix-testtools = { version = "0.20.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "dda600d7ee29a6bda4cf1047d0d1782e76b16f98" }
+gix-testtools = { version = "0.20.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "ab66595c079832218a60f823d12e571512ffce9d" }
 
 
 git2 = { version = "0.21.0", features = [
@@ -312,7 +312,7 @@ sapling-renderdag = "0.1.0"
 [patch.crates-io]
 # Keep workspace crates that use the `gix 0.87` line on the same git revision.
 # This was relevant to force `git-meta` to use our version.
-gix = { git = "https://github.com/GitoxideLabs/gitoxide", rev = "dda600d7ee29a6bda4cf1047d0d1782e76b16f98" }
+gix = { git = "https://github.com/GitoxideLabs/gitoxide", rev = "ab66595c079832218a60f823d12e571512ffce9d" }
 git2 = { git = "https://github.com/gitbutlerapp/git2-rs", rev = "a87a7bb3f6843504339fe7434ee0732a3e968f3e" }
 
 [workspace.lints.clippy]

--- a/crates/but-ctx/src/lib.rs
+++ b/crates/but-ctx/src/lib.rs
@@ -17,6 +17,7 @@ use but_core::{
 use but_path::AppChannel;
 use but_settings::AppSettings;
 use but_utils::OnDemandCache;
+use gix::config::tree::Key as _;
 use tracing::instrument;
 
 /// Legacy types that shouldn't be used.
@@ -1057,10 +1058,17 @@ fn new_ondemand_repo(gitdir: PathBuf, repo_open_mode: RepoOpenMode) -> OnDemand<
 }
 
 fn open_repo(gitdir: &Path, repo_open_mode: RepoOpenMode) -> anyhow::Result<gix::Repository> {
-    match repo_open_mode {
-        RepoOpenMode::Standard => Ok(gix::open(gitdir)?),
-        RepoOpenMode::Isolated => Ok(gix::open_opts(gitdir, gix::open::Options::isolated())?),
+    let options = match repo_open_mode {
+        RepoOpenMode::Standard => gix::open::Options::default(),
+        RepoOpenMode::Isolated => gix::open::Options::isolated(),
     }
+    .config_overrides([
+        gix::config::tree::gitoxide::Committer::NAME_FALLBACK
+            .validated_assignment("GitButler".into())?,
+        gix::config::tree::gitoxide::Committer::EMAIL_FALLBACK
+            .validated_assignment("gitbutler@gitbutler.com".into())?,
+    ]);
+    Ok(gix::open_opts(gitdir, options)?)
 }
 
 #[instrument(level = "trace")]

--- a/crates/but-workspace/tests/workspace/commit/commit_create.rs
+++ b/crates/but-workspace/tests/workspace/commit/commit_create.rs
@@ -5,6 +5,7 @@ use but_rebase::graph_rebase::{
     mutate::{InsertSide, RelativeToRef},
 };
 use but_workspace::commit::{ChangeSource, commit_create};
+use but_workspace::commit_engine::{Destination, create_commit};
 
 use crate::ref_info::with_workspace_commit::utils::named_writable_scenario_with_description_and_graph as writable_scenario;
 
@@ -14,6 +15,43 @@ fn worktree_changes_as_specs(repo: &gix::Repository) -> Result<Vec<DiffSpec>> {
         .into_iter()
         .map(DiffSpec::from)
         .collect())
+}
+
+#[test]
+fn new_commit_uses_configured_user_as_committer() -> Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let repo = gix::init(tmp.path())?;
+    but_core::git_config::edit_repo_config(&repo, gix::config::Source::Local, |config| {
+        but_core::git_config::set_config_value(config, "user.name", "Configured User")?;
+        but_core::git_config::set_config_value(config, "user.email", "configured@example.com")
+    })?;
+    std::fs::write(tmp.path().join("file"), "content")?;
+
+    but_testsupport::isolated_app_data_dir(|| -> Result<()> {
+        let ctx = but_ctx::Context::open_with_repo_open_mode(
+            tmp.path(),
+            but_ctx::RepoOpenMode::Isolated,
+        )?;
+        let repo = ctx.repo.get()?;
+        let outcome = create_commit(
+            &repo,
+            Destination::NewCommit {
+                parent_commit_id: None,
+                stack_segment: None,
+                message: "new commit".into(),
+            },
+            worktree_changes_as_specs(&repo)?,
+            0,
+        )?;
+        let commit = repo.find_commit(outcome.new_commit.expect("a commit was created"))?;
+        let committer = commit.committer()?;
+        assert_eq!(
+            (committer.name.to_owned(), committer.email.to_owned()),
+            ("Configured User".into(), "configured@example.com".into()),
+            "a fallback committer must not override the configured user identity"
+        );
+        Ok(())
+    })
 }
 
 #[test]

--- a/crates/gitbutler-branch-actions/src/base.rs
+++ b/crates/gitbutler-branch-actions/src/base.rs
@@ -12,7 +12,7 @@ use but_error::{Code, bail_precondition};
 use but_graph::FirstParent;
 use gitbutler_project::{FetchResult, Project};
 use gitbutler_reference::{Refname, RemoteRefname};
-use gitbutler_repo::{SignaturePurpose, first_parent_commit_ids_until, signature_gix};
+use gitbutler_repo::first_parent_commit_ids_until;
 use serde::Serialize;
 use tracing::instrument;
 
@@ -246,10 +246,10 @@ pub(crate) fn set_base_branch(
 
             let stack_ref_name = if branch_matches_target {
                 let stack_ref_name = but_core::branch::unique_canned_refname(&repo)?;
-                create_internal_reference(
-                    &repo,
-                    stack_ref_name.clone(),
+                repo.reference(
+                    stack_ref_name.as_ref(),
                     current_head_commit,
+                    gix::refs::transaction::PreviousValue::MustNotExist,
                     "initialize stack",
                 )?;
                 stack_ref_name
@@ -268,10 +268,10 @@ pub(crate) fn set_base_branch(
             meta.set_workspace(&workspace)?;
             drop((workspace, meta));
             if !branch_matches_target {
-                create_internal_reference(
-                    &repo,
-                    WORKSPACE_REF_NAME.try_into()?,
+                repo.reference(
+                    WORKSPACE_REF_NAME,
                     current_head_commit,
+                    gix::refs::transaction::PreviousValue::MustNotExist,
                     "initialize workspace",
                 )?;
                 workspace_to_initialize = Some(ctx.workspace_from_ref_uncached(
@@ -291,41 +291,6 @@ pub(crate) fn set_base_branch(
     }
 
     get_base_branch_data(ctx, perm.read_permission())
-}
-
-fn create_internal_reference(
-    repo: &gix::Repository,
-    name: gix::refs::FullName,
-    target: gix::ObjectId,
-    message: &str,
-) -> Result<()> {
-    let configured_committer = repo.committer().transpose()?;
-    let fallback_committer;
-    let mut fallback_time = gix::date::parse::TimeBuf::default();
-    let committer = match configured_committer {
-        Some(committer) => committer,
-        None => {
-            fallback_committer = signature_gix(SignaturePurpose::Committer);
-            fallback_committer.to_ref(&mut fallback_time)
-        }
-    };
-    repo.edit_references_as(
-        [gix::refs::transaction::RefEdit {
-            change: gix::refs::transaction::Change::Update {
-                log: gix::refs::transaction::LogChange {
-                    mode: gix::refs::transaction::RefLog::AndReference,
-                    force_create_reflog: false,
-                    message: message.into(),
-                },
-                expected: gix::refs::transaction::PreviousValue::MustNotExist,
-                new: gix::refs::Target::Object(target),
-            },
-            name,
-            deref: false,
-        }],
-        Some(committer),
-    )?;
-    Ok(())
 }
 
 fn set_exclude_decoration(ctx: &Context) -> Result<()> {

--- a/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/set_base_branch.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/set_base_branch.rs
@@ -30,10 +30,8 @@ fn uses_configured_committer_for_reflog() {
 
     std::fs::write(repo.path().join("feature.txt"), "feature").unwrap();
 
-    let repo = ctx.repo.get().unwrap();
-    let committer = repo.committer().transpose().unwrap().unwrap();
-    let expected_committer_identity = (committer.name.to_owned(), committer.email.to_owned());
-    drop(repo);
+    let expected_committer_identity =
+        ("gitbutler-test".into(), "gitbutler-test@example.com".into());
 
     let mut guard = ctx.exclusive_worktree_access();
     gitbutler_branch_actions::set_base_branch(
@@ -84,13 +82,20 @@ fn works_without_git_identity() {
             },
         )
         .unwrap();
-        let mut context_repo = ctx.repo.get_mut().unwrap();
-        context_repo.reload().unwrap();
-        assert!(
-            context_repo.committer().is_none(),
-            "the repository has no Git identity"
+        let fallback_committer_identity = {
+            let mut context_repo = ctx.repo.get_mut().unwrap();
+            context_repo.reload().unwrap();
+            let committer = context_repo.committer().transpose().unwrap().unwrap();
+            (committer.name.to_owned(), committer.email.to_owned())
+        };
+        assert_eq!(
+            fallback_committer_identity,
+            (
+                gitbutler_repo::GITBUTLER_COMMIT_AUTHOR_NAME.into(),
+                gitbutler_repo::GITBUTLER_COMMIT_AUTHOR_EMAIL.into(),
+            ),
+            "the context provides GitButler's fallback committer"
         );
-        drop(context_repo);
 
         let mut guard = ctx.exclusive_worktree_access();
         gitbutler_branch_actions::set_base_branch(
@@ -125,10 +130,7 @@ fn works_without_git_identity() {
                     "initialize workspace"
                 },
             ),
-            (
-                gitbutler_repo::GITBUTLER_COMMIT_AUTHOR_NAME.into(),
-                gitbutler_repo::GITBUTLER_COMMIT_AUTHOR_EMAIL.into(),
-            ),
+            fallback_committer_identity,
             "identity-free onboarding uses GitButler for its reflog"
         );
     }


### PR DESCRIPTION
Follow-up to https://github.com/gitbutlerapp/gitbutler/pull/15612.

### Tasks

* [x] refackiew
* [x] update `gix` to make CI green here thanks to new regression test

Restore repository-level committer fallbacks and assert that a configured user
identity remains in onboarding reflogs. The regression stays red until gitoxide
treats these values as true fallbacks.

### Notes for the Reviewer

Better test this by hand just once, as I am still relying on the two added integration tests (and similar tests in `gix`).