### PR TITLE
fix: don't start operation drags from the commit box

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
@@ -22,6 +22,7 @@ import { changesHotkeys, sidebarHotkeys, toElectronAccelerator } from "#ui/hotke
 import { nativeMenuItem, showNativeMenuFromTrigger, type NativeMenuItem } from "#ui/native-menu.ts";
 import { addressEquals, addressIdentityKey, type Address } from "#ui/addresses.ts";
 import { createDiffSpec } from "#ui/operations/diff-specs.ts";
+import { NO_DRAG_ATTRIBUTE } from "#ui/routes/project/$id/workspace/DragData.ts";
 import { projectSlice } from "#ui/projects/state.ts";
 import { projectAiSettingsQueryOptions } from "#ui/project-ai-settings.ts";
 import { focusScope } from "#ui/focus-scopes.ts";
@@ -397,7 +398,7 @@ export const CommitForm: FC<{
 
 	if (!isExpanded) {
 		return (
-			<div className={classes(styles.startCommitRow, className)}>
+			<div {...{ [NO_DRAG_ATTRIBUTE]: "" }} className={classes(styles.startCommitRow, className)}>
 				<CommitTargetCombobox
 					items={targetComboboxItems}
 					value={commitTarget ?? null}
@@ -476,6 +477,7 @@ export const CommitForm: FC<{
 	return (
 		// oxlint-disable-next-line jsx-a11y/no-noninteractive-element-interactions -- Used for persistence, not UI per se.
 		<form
+			{...{ [NO_DRAG_ATTRIBUTE]: "" }}
 			ref={formRef}
 			onSubmit={submit}
 			onBlur={(e) => {

--- a/apps/lite/ui/src/routes/project/$id/workspace/DragData.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DragData.ts
@@ -8,3 +8,9 @@ export const parseDragData = (data: unknown): DragData | null => {
 	if (typeof data !== "object" || data === null || !("sources" in data)) return null;
 	return data as DragData;
 };
+
+/**
+ * Marks a subtree that should never start an operation drag, so pointer gestures inside it keep
+ * their native behaviour (text selection in the commit message, for instance).
+ */
+export const NO_DRAG_ATTRIBUTE = "data-gitbutler-no-drag";

--- a/apps/lite/ui/src/routes/project/$id/workspace/OperationSourceC.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OperationSourceC.tsx
@@ -18,7 +18,7 @@ import { mergeProps, useRender } from "@base-ui/react";
 import { useQuery } from "@tanstack/react-query";
 import { type FC, type ReactNode, useEffect, useEffectEvent, useRef } from "react";
 import { createRoot } from "react-dom/client";
-import type { DragData } from "./DragData.ts";
+import { NO_DRAG_ATTRIBUTE, type DragData } from "./DragData.ts";
 import { Match } from "effect";
 
 export const DragPreview: FC<{ children: ReactNode }> = ({ children }) => (
@@ -90,7 +90,14 @@ export const OperationSourceC: FC<
 				},
 			});
 		});
-	const canDrag = useEffectEvent(() => pendingOperation._tag !== "InlineEdit");
+	const canDrag: Parameters<typeof draggable>[0]["canDrag"] = useEffectEvent(({ input }) => {
+		if (pendingOperation._tag === "InlineEdit") return false;
+
+		// Regions like the commit box own their pointer gestures (text selection, mostly), so a drag
+		// starting inside one must not become an operation drag.
+		const over = document.elementFromPoint(input.clientX, input.clientY);
+		return over?.closest(`[${NO_DRAG_ATTRIBUTE}]`) == null;
+	});
 	const onDragStart = useEffectEvent(() => {
 		const dragSources = resolveDragSources();
 


### PR DESCRIPTION
Selecting text in the commit message box started an operation drag instead of selecting.

The whole "Uncommitted" panel is wrapped in `OperationSourceC`, which registers it as a pragmatic-dnd `draggable`. That sets `draggable="true"` on an ancestor of the commit form, so Chromium hands a press-and-drag inside the textarea to the native drag rather than to text selection. `canDrag` previously only bailed out for `InlineEdit`.

## Changes

- `DragData.ts`: new `NO_DRAG_ATTRIBUTE` (`data-gitbutler-no-drag`) marking a subtree that keeps its native pointer behaviour.
- `OperationSourceC.tsx`: `canDrag` resolves the element under the pointer and refuses the drag when it sits inside such a region — pdnd then `preventDefault`s the dragstart, so selection proceeds normally.
- `CommitForm.tsx`: both roots carry the attribute — the collapsed "Start commit" row and the expanded message form.

## Testing

`pnpm --filter lite check` (tsgo) and prettier pass. Not yet exercised in the running app: worth confirming that dragging file rows into a stack still works while text selection in the commit box behaves.


https://github.com/user-attachments/assets/15723523-053e-4366-82a0-6201f8239057

