### PR TITLE
Fix Lite branch mutation feedback

### DIFF
--- a/apps/lite/e2e/tests/branches.spec.ts
+++ b/apps/lite/e2e/tests/branches.spec.ts
@@ -68,7 +68,7 @@ test.describe("branches", () => {
 			).lite.watcherStopAll(),
 		);
 		await branch.click();
-		await appWindow.keyboard.press("ControlOrMeta+Backspace");
+		await appWindow.keyboard.press(process.platform === "darwin" ? "Meta+Backspace" : "Delete");
 
 		await expect(branch).toHaveCount(0);
 	});

--- a/apps/lite/e2e/tests/branches.spec.ts
+++ b/apps/lite/e2e/tests/branches.spec.ts
@@ -1,4 +1,20 @@
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import type { Page } from "@playwright/test";
 import { expect, test } from "../test.ts";
+
+const applyBranch = async (appWindow: Page, name: string) => {
+	const picker = appWindow.getByRole("dialog", { name: "Apply branch" });
+	await expect(async () => {
+		await appWindow.keyboard.press("ControlOrMeta+Shift+A");
+		await expect(picker).toBeVisible({ timeout: 500 });
+	}).toPass({ timeout: 5_000 });
+
+	const search = picker.getByRole("combobox", { name: /search for branches/i });
+	await search.fill(name);
+	await picker.getByRole("option", { name: new RegExp(`^${name} `) }).click();
+	await expect(picker).toBeHidden();
+};
 
 test.describe("branches", () => {
 	test.use({ scenario: "project-with-remote-branches.sh" });
@@ -13,20 +29,47 @@ test.describe("branches", () => {
 		await expect(secondCommit).toHaveCount(0);
 		await expect(firstCommit).toHaveCount(0);
 
-		const picker = appWindow.getByRole("dialog", { name: "Apply branch" });
-		// Hotkeys register in a passive effect, so retry the keypress if the workspace renders first.
-		await expect(async () => {
-			await appWindow.keyboard.press("ControlOrMeta+Shift+A");
-			await expect(picker).toBeVisible({ timeout: 500 });
-		}).toPass({ timeout: 5_000 });
-
-		const search = picker.getByRole("combobox", { name: /search for branches/i });
-		await search.fill("branch1");
-		await picker.getByRole("option", { name: /^branch1 / }).click();
-
-		await expect(picker).toBeHidden();
+		await applyBranch(appWindow, "branch1");
 		await expect(branch).toBeVisible();
 		await expect(secondCommit).toBeVisible();
 		await expect(firstCommit).toBeVisible();
+	});
+
+	test("shows one error when renaming onto an existing branch", async ({ appWindow }) => {
+		await applyBranch(appWindow, "branch1");
+
+		const branch = appWindow.getByRole("treeitem", { name: "branch1", exact: true });
+		await branch.getByTitle("branch1").click();
+		await appWindow.keyboard.press("F2");
+		const editor = appWindow.getByRole("textbox", { name: "Branch name" });
+		await editor.fill("master");
+		await editor.press("Enter");
+
+		// Base UI renders each title once in the toast and once in its live region.
+		await expect(appWindow.getByText("Failed to rename branch", { exact: true })).toHaveCount(2);
+		await expect(branch).toBeVisible();
+	});
+
+	test("removes a deleted branch from the branches view", async ({
+		appWindow,
+		testEnvironment,
+	}) => {
+		const repositoryPath = path.join(testEnvironment.workdir, "local-clone");
+		execFileSync("git", ["-C", repositoryPath, "branch", "delete-me", "origin/branch2"]);
+
+		const pages = appWindow.getByRole("group", { name: "Pages" });
+		await pages.getByRole("button", { name: "Branches" }).click();
+		const branch = appWindow.getByRole("treeitem", { name: "delete-me", exact: true });
+		await expect(branch).toBeVisible();
+
+		await appWindow.evaluate(() =>
+			(
+				window as unknown as { lite: { watcherStopAll: () => Promise<number> } }
+			).lite.watcherStopAll(),
+		);
+		await branch.click();
+		await appWindow.keyboard.press("ControlOrMeta+Backspace");
+
+		await expect(branch).toHaveCount(0);
 	});
 });

--- a/apps/lite/ui/src/api/mutations.ts
+++ b/apps/lite/ui/src/api/mutations.ts
@@ -1135,9 +1135,10 @@ export const useWorkspaceIntegrateUpstream = () => {
 	});
 };
 
-export const useBranchRemove = () => {
+export const useBranchRemove = (projectId: string) => {
 	const dispatch = useAppDispatch();
 	return useMutation({
+		mutationKey: [projectId, "branchRemove"],
 		mutationFn: window.lite.branchRemove,
 		onSuccess: (response, input, _context, mutation) => {
 			syncCoreCaches(mutation.client, dispatch, input.projectId, response);
@@ -1229,9 +1230,10 @@ export const useUnapplyStack = () =>
 		meta: { failureTitle: "Failed to unapply stack" },
 	});
 
-export const useBranchRename = () => {
+export const useBranchRename = (projectId: string) => {
 	const dispatch = useAppDispatch();
 	return useMutation({
+		mutationKey: [projectId, "branchRename"],
 		mutationFn: window.lite.branchRename,
 		onSuccess: async (response, input, _context, mutation) => {
 			syncCoreCaches(mutation.client, dispatch, input.projectId, response);

--- a/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.tsx
@@ -173,7 +173,7 @@ const BranchItem: FC<{
 	const review = branch.review;
 
 	const { isPending: isApplyPending, apply } = useApplyToWorkspace(projectId);
-	const { isPending: isBranchRemovePending, mutate: branchRemove } = useBranchRemove();
+	const { isPending: isBranchRemovePending, mutate: branchRemove } = useBranchRemove(projectId);
 
 	const toggleUnfolded = () => {
 		dispatch(projectSlice.actions.toggleBranchUnfolded({ projectId, branchRef }));
@@ -352,7 +352,7 @@ export const BranchesList: FC<
 
 	const panelRef = useRef<HTMLDivElement>(null);
 	const hotkeysRef = useRef<HTMLDivElement>(null);
-	const { isPending: isBranchRemovePending, mutate: branchRemove } = useBranchRemove();
+	const { isPending: isBranchRemovePending, mutate: branchRemove } = useBranchRemove(projectId);
 	const selectedBranchIsLocal =
 		selection?._tag === "Branch" && decodeBytes(selection.branchRef).startsWith("refs/heads/");
 	const removeBranch = (branchRef: Array<number>) => {

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/BranchRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/BranchRow.tsx
@@ -22,7 +22,7 @@ import {
 } from "#ui/api/queries.ts";
 import { usePrNotificationsLevel, useReviewUnread } from "#ui/review-seen.ts";
 import { decodeBytes } from "#ui/api/bytes.ts";
-import { Button, Toast, Toolbar, Tooltip } from "@base-ui/react";
+import { Button, Toolbar, Tooltip } from "@base-ui/react";
 import type {
 	BranchReference,
 	InsertSide,
@@ -37,7 +37,6 @@ import { classes } from "#ui/components/classes.ts";
 import { GraphSegment, type GraphSegmentStatus } from "#ui/components/GraphSegment.tsx";
 import { Icon } from "#ui/components/Icon.tsx";
 import { TooltipPopup } from "#ui/components/Tooltip.tsx";
-import { errorMessageForToast } from "#ui/errors.ts";
 import { sidebarHotkeys, selectionOperationHotkeys, toElectronAccelerator } from "#ui/hotkeys.ts";
 import {
 	nativeMenuItem,
@@ -221,7 +220,7 @@ export const BranchRow: FC<
 	);
 	const [isRenamePending, startRenameTransition] = useTransition();
 
-	const { mutateAsync: branchRename } = useBranchRename();
+	const { mutateAsync: branchRename } = useBranchRename(projectId);
 
 	const startEditing = () => {
 		startInlineEdit(address);
@@ -233,12 +232,10 @@ export const BranchRow: FC<
 		focusScope("sidebar");
 	};
 
-	const toastManager = Toast.useToastManager();
-
 	const { mutate: workspaceBranchAndAncestorsPush } = useWorkspaceBranchAndAncestorsPush(projectId);
 	const { mutate: commitInsertBlank } = useCommitInsertBlank();
 	const { isPending: isTearOffBranchPending, mutate: tearOffBranch } = useTearOffBranch();
-	const { isPending: isBranchRemovePending, mutate: branchRemove } = useBranchRemove();
+	const { isPending: isBranchRemovePending, mutate: branchRemove } = useBranchRemove(projectId);
 	const { mutate: branchCreate } = useBranchCreate();
 
 	const pushesMultipleBranches = downstackPushStatus.downstackBranches > 1;
@@ -248,23 +245,11 @@ export const BranchRow: FC<
 		if (trimmed === "" || trimmed === refName.displayName) return;
 		startRenameTransition(async () => {
 			setOptimisticBranchDisplayName(trimmed);
-			try {
-				await branchRename({
-					projectId,
-					refName: refName.fullNameBytes,
-					newName: trimmed,
-				});
-			} catch (error) {
-				// oxlint-disable-next-line no-console
-				console.error(error);
-
-				toastManager.add({
-					type: "error",
-					title: "Failed to rename branch",
-					description: errorMessageForToast(error),
-					priority: "high",
-				});
-			}
+			await branchRename({
+				projectId,
+				refName: refName.fullNameBytes,
+				newName: trimmed,
+			}).catch(() => undefined);
 		});
 	};
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/hotkeys.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/hotkeys.ts
@@ -133,7 +133,7 @@ export const useActiveListsHotkeys = ({
 	const { isPending: isWorkspaceIntegrateUpstreamPending, mutate: workspaceIntegrateUpstream } =
 		useWorkspaceIntegrateUpstream();
 	const { mutate: branchCreate } = useBranchCreate();
-	const { isPending: isBranchRemovePending, mutate: branchRemove } = useBranchRemove();
+	const { isPending: isBranchRemovePending, mutate: branchRemove } = useBranchRemove(projectId);
 
 	const openBranchPicker = () => {
 		dispatch(interfaceSlice.actions.openDialog({ dialog: { _tag: "BranchPicker" } }));

--- a/crates/but-api/src/branch.rs
+++ b/crates/but-api/src/branch.rs
@@ -1053,7 +1053,11 @@ pub fn branch_create_with_perm(
 /// reverse of creating an empty branch above the checked-out one). For
 /// lower-level implementation details, see
 /// [`but_workspace::branch::remove_reference()`].
-#[but_api(napi, try_from = json::BranchRemoveResult)]
+#[but_api(
+    napi,
+    try_from = json::BranchRemoveResult,
+    invalidates = [Branches, Workspace]
+)]
 #[instrument(err(Debug))]
 pub fn branch_remove(
     ctx: &mut but_ctx::Context,
@@ -1215,7 +1219,11 @@ pub fn branch_remove_with_perm(
 /// an oplog snapshot on success, and returns the post-operation workspace view.
 /// It requires no stack id and works in both managed and ad-hoc/single-branch
 /// workspaces.
-#[but_api(napi, try_from = json::BranchRenameResult)]
+#[but_api(
+    napi,
+    try_from = json::BranchRenameResult,
+    invalidates = [Branches, Workspace]
+)]
 #[instrument(err(Debug))]
 pub fn branch_rename(
     ctx: &mut but_ctx::Context,

--- a/packages/but-sdk/src/generated/graph/cacheTags.d.ts
+++ b/packages/but-sdk/src/generated/graph/cacheTags.d.ts
@@ -48,6 +48,8 @@ export declare const apiInvalidates: {
 	readonly addProject: readonly ["Projects"];
 	readonly addReviewLabels: readonly ["Reviews"];
 	readonly addReviewReaction: readonly ["ReviewReactions"];
+	readonly branchRemove: readonly ["Branches", "Workspace"];
+	readonly branchRename: readonly ["Branches", "Workspace"];
 	readonly createReviewComment: readonly ["ReviewComments"];
 	readonly deleteAllData: readonly ["Projects"];
 	readonly deleteProject: readonly ["Projects"];

--- a/packages/but-sdk/src/generated/graph/cacheTags.js
+++ b/packages/but-sdk/src/generated/graph/cacheTags.js
@@ -46,6 +46,8 @@ export const apiInvalidates = {
 	addProject: ["Projects"],
 	addReviewLabels: ["Reviews"],
 	addReviewReaction: ["ReviewReactions"],
+	branchRemove: ["Branches", "Workspace"],
+	branchRename: ["Branches", "Workspace"],
 	createReviewComment: ["ReviewComments"],
 	deleteAllData: ["Projects"],
 	deleteProject: ["Projects"],

--- a/packages/but-sdk/src/generated/graph/index.d.ts
+++ b/packages/but-sdk/src/generated/graph/index.d.ts
@@ -136,7 +136,7 @@ export declare function apply(projectId: string, existingBranch: string): Promis
  * `dry_run` is enabled, the returned workspace previews the integration
  * result and no oplog entry is persisted.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1780}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1788}
  */
 export declare function applyBranchIntegration(projectId: string, branch: string, integration: InteractiveIntegration, dryRun: boolean): Promise<IntegrateBranchResult>
 
@@ -175,7 +175,7 @@ export declare function branchCannedName(projectId: string): Promise<string>
  * symbolically at `branch`. The branch must be an existing full local branch
  * name under `refs/heads/`.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1515}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1523}
  */
 export declare function branchCheckout(projectId: string, branch: FullNameBytes): Promise<BranchCheckoutResult>
 
@@ -187,7 +187,7 @@ export declare function branchCheckout(projectId: string, branch: FullNameBytes)
  * before creating `refs/heads/<name>`. If omitted, a unique canned branch name
  * is generated. The resulting branch must not already exist.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1531}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1539}
  */
 export declare function branchCheckoutNew(projectId: string, name: string | null): Promise<BranchCheckoutResult>
 
@@ -216,7 +216,7 @@ export declare function branchDetails(projectId: string, branchName: string, rem
  * diff is computed against the current workspace state. For lower-level
  * implementation details, see [`but_workspace::ui::diff::changes_in_branch()`].
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1677}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1685}
  */
 export declare function branchDiff(projectId: string, branch: string): Promise<TreeChanges>
 
@@ -249,7 +249,7 @@ export declare function branchLand(projectId: string, branch: string, noFf: bool
  * workspace-related ones. Ahead-counts are relative to the
  * project's configured target branch, which clients know from the project APIs.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1694}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1702}
  */
 export declare function branchList(projectId: string): Promise<Array<ListedStack>>
 
@@ -282,7 +282,7 @@ export declare function branchRemove(projectId: string, refName: FullNameBytes):
  * It requires no stack id and works in both managed and ad-hoc/single-branch
  * workspaces.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1218}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1222}
  */
 export declare function branchRename(projectId: string, refName: FullNameBytes, newName: string): Promise<BranchRenameResult>
 
@@ -811,7 +811,7 @@ export declare function getGlUser(account: GitlabAccountIdentifier): Promise<Git
 /**
  * Get the initial upstream integration script for `branch`.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1756}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1764}
  */
 export declare function getInitialBranchIntegration(projectId: string, branch: string, strategy: BranchIntegrationStrategy | null): Promise<InitialBranchIntegration>
 
@@ -1118,7 +1118,7 @@ export declare function mergeReview(projectId: string, reviewId: number, mergeMe
  * `dry_run` is enabled, the returned workspace previews the move and no oplog
  * entry is persisted.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1837}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1845}
  */
 export declare function moveBranch(projectId: string, subjectBranch: string, targetBranch: string, dryRun: boolean): Promise<MoveBranchResult>
 
@@ -1462,7 +1462,7 @@ export declare function storeGitlabPat(accessToken: string): Promise<GitlabAuthS
  * `dry_run` is enabled, the returned workspace previews the tear-off and no
  * oplog entry is persisted.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1924}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1932}
  */
 export declare function tearOffBranch(projectId: string, subjectBranch: string, dryRun: boolean): Promise<MoveBranchResult>
 
@@ -1574,7 +1574,7 @@ export declare function workspaceBranchAndAncestorsPush(projectId: string, withF
 /**
  * Switch to the workspace reference
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1577}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1585}
  */
 export declare function workspaceCheckout(projectId: string): Promise<BranchCheckoutResult>
 

--- a/packages/but-sdk/src/generated/linear/cacheTags.d.ts
+++ b/packages/but-sdk/src/generated/linear/cacheTags.d.ts
@@ -48,6 +48,8 @@ export declare const apiInvalidates: {
 	readonly addProject: readonly ["Projects"];
 	readonly addReviewLabels: readonly ["Reviews"];
 	readonly addReviewReaction: readonly ["ReviewReactions"];
+	readonly branchRemove: readonly ["Branches", "Workspace"];
+	readonly branchRename: readonly ["Branches", "Workspace"];
 	readonly createReviewComment: readonly ["ReviewComments"];
 	readonly deleteAllData: readonly ["Projects"];
 	readonly deleteProject: readonly ["Projects"];

--- a/packages/but-sdk/src/generated/linear/cacheTags.js
+++ b/packages/but-sdk/src/generated/linear/cacheTags.js
@@ -46,6 +46,8 @@ export const apiInvalidates = {
 	addProject: ["Projects"],
 	addReviewLabels: ["Reviews"],
 	addReviewReaction: ["ReviewReactions"],
+	branchRemove: ["Branches", "Workspace"],
+	branchRename: ["Branches", "Workspace"],
 	createReviewComment: ["ReviewComments"],
 	deleteAllData: ["Projects"],
 	deleteProject: ["Projects"],

--- a/packages/but-sdk/src/generated/linear/index.d.ts
+++ b/packages/but-sdk/src/generated/linear/index.d.ts
@@ -136,7 +136,7 @@ export declare function apply(projectId: string, existingBranch: string): Promis
  * `dry_run` is enabled, the returned workspace previews the integration
  * result and no oplog entry is persisted.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1780}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1788}
  */
 export declare function applyBranchIntegration(projectId: string, branch: string, integration: InteractiveIntegration, dryRun: boolean): Promise<IntegrateBranchResult>
 
@@ -175,7 +175,7 @@ export declare function branchCannedName(projectId: string): Promise<string>
  * symbolically at `branch`. The branch must be an existing full local branch
  * name under `refs/heads/`.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1515}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1523}
  */
 export declare function branchCheckout(projectId: string, branch: FullNameBytes): Promise<BranchCheckoutResult>
 
@@ -187,7 +187,7 @@ export declare function branchCheckout(projectId: string, branch: FullNameBytes)
  * before creating `refs/heads/<name>`. If omitted, a unique canned branch name
  * is generated. The resulting branch must not already exist.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1531}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1539}
  */
 export declare function branchCheckoutNew(projectId: string, name: string | null): Promise<BranchCheckoutResult>
 
@@ -216,7 +216,7 @@ export declare function branchDetails(projectId: string, branchName: string, rem
  * diff is computed against the current workspace state. For lower-level
  * implementation details, see [`but_workspace::ui::diff::changes_in_branch()`].
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1677}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1685}
  */
 export declare function branchDiff(projectId: string, branch: string): Promise<TreeChanges>
 
@@ -249,7 +249,7 @@ export declare function branchLand(projectId: string, branch: string, noFf: bool
  * workspace-related ones. Ahead-counts are relative to the
  * project's configured target branch, which clients know from the project APIs.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1694}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1702}
  */
 export declare function branchList(projectId: string): Promise<Array<ListedStack>>
 
@@ -282,7 +282,7 @@ export declare function branchRemove(projectId: string, refName: FullNameBytes):
  * It requires no stack id and works in both managed and ad-hoc/single-branch
  * workspaces.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1218}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1222}
  */
 export declare function branchRename(projectId: string, refName: FullNameBytes, newName: string): Promise<BranchRenameResult>
 
@@ -811,7 +811,7 @@ export declare function getGlUser(account: GitlabAccountIdentifier): Promise<Git
 /**
  * Get the initial upstream integration script for `branch`.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1756}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1764}
  */
 export declare function getInitialBranchIntegration(projectId: string, branch: string, strategy: BranchIntegrationStrategy | null): Promise<InitialBranchIntegration>
 
@@ -1118,7 +1118,7 @@ export declare function mergeReview(projectId: string, reviewId: number, mergeMe
  * `dry_run` is enabled, the returned workspace previews the move and no oplog
  * entry is persisted.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1837}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1845}
  */
 export declare function moveBranch(projectId: string, subjectBranch: string, targetBranch: string, dryRun: boolean): Promise<MoveBranchResult>
 
@@ -1462,7 +1462,7 @@ export declare function storeGitlabPat(accessToken: string): Promise<GitlabAuthS
  * `dry_run` is enabled, the returned workspace previews the tear-off and no
  * oplog entry is persisted.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1924}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1932}
  */
 export declare function tearOffBranch(projectId: string, subjectBranch: string, dryRun: boolean): Promise<MoveBranchResult>
 
@@ -1574,7 +1574,7 @@ export declare function workspaceBranchAndAncestorsPush(projectId: string, withF
 /**
  * Switch to the workspace reference
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1577}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1585}
  */
 export declare function workspaceCheckout(projectId: string): Promise<BranchCheckoutResult>
 


### PR DESCRIPTION
Some lite fixes

## 🧢 Changes

- surface branch rename failures through the global mutation error handler only
- invalidate branch and workspace caches after branch rename or removal
- scope branch mutation keys by project
- add Lite E2E coverage for duplicate-name rename errors and reactive branch deletion

## ☕️ Reasoning

Branch rename failures were toasted both locally in `BranchRow` and by the global mutation cache. Branch removal synchronized the returned workspace data but did not invalidate the branch list query, so the branches view remained stale until a watcher event refreshed it.

The deletion regression test stops the filesystem watcher before deleting, ensuring the UI update comes from mutation invalidation rather than an eventual watcher refresh.
