### PR TITLE
feat(cli): add `but split` command

### DIFF
--- a/crates/but/src/args/metrics.rs
+++ b/crates/but/src/args/metrics.rs
@@ -13,6 +13,7 @@ pub enum CommandName {
     Amend,
     Squash,
     Move,
+    Split,
     Diff,
     Edit,
     Show,

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -285,6 +285,10 @@ pub enum Subcommands {
 
     #[cfg(feature = "legacy")]
     #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
+    Split(split::Platform),
+
+    #[cfg(feature = "legacy")]
+    #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     #[clap(hide = true, name = "_reword2")]
     _Reword2(reword2::Platform),
 
@@ -1021,6 +1025,8 @@ pub mod redo;
 #[cfg(feature = "legacy")]
 pub mod reword2;
 pub mod skill;
+#[cfg(feature = "legacy")]
+pub mod split;
 #[cfg(feature = "legacy")]
 pub mod squash;
 #[cfg(feature = "legacy")]

--- a/crates/but/src/args/split.rs
+++ b/crates/but/src/args/split.rs
@@ -1,0 +1,16 @@
+use crate::args::atoms::{AllowMergedArg, CliIdArg};
+
+/// Split a commit in two.
+///
+/// Sources must all be committed files from the same commit.
+#[derive(Debug, clap::Parser)]
+#[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
+pub struct Platform {
+    /// The committed files to move into a new commit.
+    #[clap(required = true)]
+    pub sources: Vec<CliIdArg>,
+
+    #[clap(flatten)]
+    #[allow(missing_docs)]
+    pub allow_merged: AllowMergedArg,
+}

--- a/crates/but/src/command/help.rs
+++ b/crates/but/src/command/help.rs
@@ -165,6 +165,8 @@ fn print_grouped_with_truncation(
                 SubcommandDiscriminant::Squash => Group::EditingCommits,
                 #[cfg(feature = "legacy")]
                 SubcommandDiscriminant::Move => Group::EditingCommits,
+                #[cfg(feature = "legacy")]
+                SubcommandDiscriminant::Split => Group::EditingCommits,
 
                 #[cfg(feature = "legacy")]
                 SubcommandDiscriminant::Oplog => Group::OperationHistory,
@@ -389,6 +391,7 @@ Branching and Committing:
 Editing Commits:
   squash       Squash commits, branches, or changes
   move         Move commits and changes around
+  split        Split a commit in two
   absorb       Amends changes into the appropriate commits where they belong
   reword       Edit the commit message of the specified commit
   uncommit     Uncommit commits, branches, or committed files

--- a/crates/but/src/command/legacy/mod.rs
+++ b/crates/but/src/command/legacy/mod.rs
@@ -29,6 +29,7 @@ pub mod reword;
 pub mod reword2;
 pub mod setup;
 pub mod show;
+pub mod split;
 pub mod squash;
 pub mod status;
 pub mod r#switch;

--- a/crates/but/src/command/legacy/move.rs
+++ b/crates/but/src/command/legacy/move.rs
@@ -244,7 +244,7 @@ pub fn r#move(
 /// and [`MoveOperation::UnstackBranch`]) stay allowed: they re-anchor commits
 /// without changing their content, so upstream-integration detection still
 /// recognizes them.
-fn ensure_not_touching_merged_upstream(
+pub fn ensure_not_touching_merged_upstream(
     op: &MoveOperation,
     merged: &MergedUpstream,
 ) -> CliResult<()> {
@@ -628,7 +628,7 @@ fn resolve(
                 }
                 (
                     BranchTargetIsh::Workspace(target),
-                    ResolvedSources::CommittedChanges((source_commit, changes)),
+                    ResolvedSources::CommittedChanges(source_commit, changes),
                 ) => Ok(MoveOperation::ChangesRelativeTo(
                     MoveChangesRelativeToOperation {
                         source_commit,
@@ -640,7 +640,7 @@ fn resolve(
                 )),
                 (
                     BranchTargetIsh::WorktreeTip(name),
-                    ResolvedSources::CommittedChanges((source_commit, changes)),
+                    ResolvedSources::CommittedChanges(source_commit, changes),
                 ) => Ok(MoveOperation::ChangesRelativeTo(
                     MoveChangesRelativeToOperation {
                         source_commit,
@@ -650,7 +650,7 @@ fn resolve(
                 )),
                 (
                     BranchTargetIsh::Missing,
-                    ResolvedSources::CommittedChanges((source_commit, changes)),
+                    ResolvedSources::CommittedChanges(source_commit, changes),
                 ) => {
                     let branch_name =
                         BranchArg(branch.to_string()).resolve_for_creation(&repo, &ws)?;
@@ -679,7 +679,7 @@ fn resolve(
                     branch_name: None,
                 },
             )),
-            ResolvedSources::CommittedChanges((source_commit, changes)) => Ok(
+            ResolvedSources::CommittedChanges(source_commit, changes) => Ok(
                 MoveOperation::ChangesToNewBranch(MoveChangesToNewBranchOperation {
                     source_commit,
                     changes,
@@ -708,7 +708,7 @@ fn resolve(
                     branch_name: None,
                 },
             )),
-            ResolvedSources::CommittedChanges((source_commit, changes)) => Ok(
+            ResolvedSources::CommittedChanges(source_commit, changes) => Ok(
                 MoveOperation::ChangesToNewBranch(MoveChangesToNewBranchOperation {
                     source_commit,
                     changes,
@@ -798,7 +798,7 @@ fn create_move_above_or_below_op(
                 },
             ))
         }
-        ResolvedSources::CommittedChanges((source_commit, changes)) => Ok(
+        ResolvedSources::CommittedChanges(source_commit, changes) => Ok(
             MoveOperation::ChangesRelativeTo(MoveChangesRelativeToOperation {
                 changes,
                 source_commit,
@@ -815,7 +815,7 @@ enum ResolvedSources {
         /// order as the resolved commits - access by index!
         args: NonEmpty<CliIdArg>,
     },
-    CommittedChanges((CommitId, NonEmpty<DiffSpec>)),
+    CommittedChanges(CommitId, NonEmpty<DiffSpec>),
     Branch(FullName),
 }
 
@@ -899,7 +899,7 @@ fn resolve_sources(
             let changes = NonEmpty::from_vec(builder.into_diff_specs())
                 .expect("BUG: Cannot possibly not have any changes here");
 
-            Ok(ResolvedSources::CommittedChanges((source_commit, changes)))
+            Ok(ResolvedSources::CommittedChanges(source_commit, changes))
         }
         (None, None, Some(branches)) => {
             if !branches.tail.is_empty() {

--- a/crates/but/src/command/legacy/split.rs
+++ b/crates/but/src/command/legacy/split.rs
@@ -1,0 +1,110 @@
+use but_api::WorkspaceState;
+use but_ctx::Context;
+use nonempty::NonEmpty;
+
+use crate::{
+    CliResult, IdMap,
+    args::{
+        atoms::{Purpose, ResolvedCliIdArg},
+        split::Platform,
+    },
+    bad_input,
+    command::legacy::r#move::{self, MoveChangesRelativeToOperation, MoveOperation, MoveTarget},
+    id::CommittedFileId,
+    theme,
+    utils::{
+        IntermediateChannel, diff_specs::DiffSpecBuilder, merged_upstream::MergedUpstream,
+        targeting::Side,
+    },
+};
+
+pub fn split(
+    ctx: &mut Context,
+    _out: IntermediateChannel<'_>,
+    args: Platform,
+) -> CliResult<(r#move::MoveOutcome, WorkspaceState)> {
+    let mut guard = ctx.exclusive_worktree_access();
+    let mut meta = ctx.meta()?;
+    let id_map = IdMap::new_from_context(ctx, guard.read_permission())?;
+
+    let allow_merged = args.allow_merged;
+    let move_op = resolve(args, ctx, &id_map)?;
+    r#move::ensure_not_touching_merged_upstream(
+        &move_op,
+        &MergedUpstream::from_ctx(ctx, allow_merged)?,
+    )?;
+
+    Ok(r#move::run(
+        ctx,
+        &mut meta,
+        guard.write_permission(),
+        move_op,
+    )?)
+}
+
+fn resolve(args: Platform, ctx: &Context, id_map: &IdMap) -> CliResult<MoveOperation> {
+    let Platform {
+        sources,
+        allow_merged: _,
+    } = args;
+
+    let context_lines = ctx.settings.context_lines;
+    let repo = ctx.repo.get()?;
+
+    let mut resolved_sources = Vec::<CommittedFileId>::new();
+    let mut builder = DiffSpecBuilder::new(&repo, context_lines);
+    for source in sources {
+        match source.resolve_in_workspace(&repo, id_map, Purpose::Source, None)? {
+            ResolvedCliIdArg::CommittedFile(committed_file) => {
+                if let Some(first) = resolved_sources.first()
+                    && first.commit_id != committed_file.commit_id
+                {
+                    return Err(bad_input(format!(
+                        "Can only split files from one commit. Got {} and {}",
+                        theme::Commit(first.as_commit_ref()),
+                        theme::Commit(committed_file.as_commit_ref())
+                    ))
+                    .into());
+                }
+                builder.push_changes_from_committed_file(
+                    committed_file.commit_id,
+                    committed_file.path.as_ref(),
+                )?;
+                resolved_sources.push(committed_file);
+            }
+            other @ (ResolvedCliIdArg::Commit(..)
+            | ResolvedCliIdArg::CommittedHunk(..)
+            | ResolvedCliIdArg::Branch(..)
+            | ResolvedCliIdArg::UncommittedHunkOrFile(..)
+            | ResolvedCliIdArg::Uncommitted
+            | ResolvedCliIdArg::Worktree(..)
+            | ResolvedCliIdArg::PathPrefix { .. }
+            | ResolvedCliIdArg::Stack { .. }) => {
+                return Err(bad_input(format!(
+                    "Expected a committed file, got {}",
+                    other.kind_for_humans()
+                ))
+                .into());
+            }
+        }
+    }
+
+    let resolved_sources = NonEmpty::from_vec(resolved_sources)
+        .expect("sources is required in the clap args so they'll never be empty");
+
+    let changes = NonEmpty::from_vec(builder.into_diff_specs())
+        .expect("BUG: Cannot possibly not have any changes here");
+
+    let source_commit = resolved_sources.head.as_commit_ref().to_owned();
+
+    Ok(MoveOperation::ChangesRelativeTo(
+        MoveChangesRelativeToOperation {
+            source_commit: source_commit.clone(),
+            changes,
+            target: MoveTarget::Commit {
+                commit: source_commit,
+                side: Side::Above,
+            },
+        },
+    ))
+}

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -2115,6 +2115,13 @@ impl CommittedFileId {
             change_id: self.change_id.as_ref(),
         }
     }
+
+    pub fn as_commit_ref(&self) -> CommitIdRef<'_> {
+        CommitIdRef {
+            commit_id: self.commit_id,
+            change_id: self.change_id.as_ref(),
+        }
+    }
 }
 
 impl PartialEq for CommittedFileId {

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -855,6 +855,7 @@ async fn dispatch_subcommand(
         | Subcommands::Commit(..)
         | Subcommands::Squash(..)
         | Subcommands::Move(..)
+        | Subcommands::Split(..)
         | Subcommands::_Reword2(..)
         | Subcommands::Reword { .. }
         | Subcommands::Absorb { .. }
@@ -1272,6 +1273,20 @@ async fn dispatch_subcommand(
                 IntermediateChannel::new(out),
                 move_args,
             )?;
+            out.print_cli_output(outcome)?;
+            Some(ws)
+        }
+        #[cfg(feature = "legacy")]
+        Subcommands::Split(split_args) => {
+            use crate::utils::IntermediateChannel;
+
+            let status_after = args.status_after;
+            out.begin_status_after(status_after);
+            status_after_data = Some(status_after);
+
+            newly_conflicted_data = Some(command::legacy::conflict_notice::snapshot(&ctx));
+            let (outcome, ws) =
+                command::legacy::split::split(&mut ctx, IntermediateChannel::new(out), split_args)?;
             out.print_cli_output(outcome)?;
             Some(ws)
         }

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -193,6 +193,8 @@ impl Subcommands {
             #[cfg(feature = "legacy")]
             Subcommands::Move(..) => Move,
             #[cfg(feature = "legacy")]
+            Subcommands::Split(..) => Split,
+            #[cfg(feature = "legacy")]
             Subcommands::Land { .. } => Land,
             #[cfg(feature = "legacy")]
             Subcommands::Pick(..) => Pick,

--- a/crates/but/tests/but/command/mod.rs
+++ b/crates/but/tests/but/command/mod.rs
@@ -52,6 +52,8 @@ mod reword2;
 mod setup;
 mod skill;
 #[cfg(feature = "legacy")]
+mod split;
+#[cfg(feature = "legacy")]
 mod squash;
 #[cfg(feature = "legacy")]
 mod status;

--- a/crates/but/tests/but/command/split.rs
+++ b/crates/but/tests/but/command/split.rs
@@ -1,0 +1,96 @@
+use crate::utils::Sandbox;
+
+#[test]
+fn split_commit() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
+
+    env.file("one", "contents of one");
+    env.file("two", "contents of two");
+
+    env.but("commit -m original").assert().success();
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ br [a-branch-1]
+┊●   1 original
+┊│     1:k A one
+┊│     1:t A two
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("split 1:k")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Moved 1 change from 1 to new commit 1 above commit 1
+
+"#]]);
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ br [a-branch-1]
+┊●   1#0 (no commit message)
+┊│     1#0:k A one
+┊●   1#1 original
+┊│     1#1:t A two
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn cannot_split_sources_from_multiple_commits() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
+
+    env.file("one", "contents of one");
+    env.file("two", "contents of two");
+
+    env.but("commit -m original one").assert().success();
+    env.but("commit -m original two").assert().success();
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ br [a-branch-1]
+┊●   1#0 original
+┊│     1#0:t A two
+┊●   1#1 original
+┊│     1#1:k A one
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("split 1#0:t 1#1:k")
+        .assert()
+        .failure()
+        .stderr_eq(snapbox::str![[r#"
+Error: Can only split files from one commit. Got 1 and 1
+
+"#]]);
+}


### PR DESCRIPTION
Example:

```
but split commit:file-1 commit:file-2
```

Will move file-1 and file-2 to a new commit above.

Which internally calls the same path as

```
but move commit:file-1 commit:file-2 --above commit
```