### PR TITLE
Disable impossible parallel branch creation outside workspace

### DIFF
--- a/apps/lite/e2e/tests/branches.spec.ts
+++ b/apps/lite/e2e/tests/branches.spec.ts
@@ -1,7 +1,58 @@
 import { execFileSync } from "node:child_process";
 import path from "node:path";
-import type { Page } from "@playwright/test";
+import type { HeadAndMode } from "@gitbutler/but-sdk";
+import type { ElectronApplication, Page } from "@playwright/test";
 import { expect, test } from "../test.ts";
+
+type NativeMenuItem = {
+	_tag: "Item" | "Separator";
+	enabled?: boolean;
+	itemId?: string;
+	label?: string;
+};
+
+const checkedOutBranchName = async (appWindow: Page): Promise<string | null> =>
+	appWindow.evaluate(async () => {
+		const projectId = location.pathname.split("/")[2];
+		if (projectId === undefined) return null;
+		const lite = (
+			window as unknown as {
+				lite: { operatingMode: (projectId: string) => Promise<HeadAndMode> };
+			}
+		).lite;
+		const { operatingMode } = await lite.operatingMode(projectId);
+		return operatingMode.type === "OutsideWorkspace" ? operatingMode.subject.branchName : null;
+	});
+
+const chooseNewBranchAction = async (
+	electronApp: ElectronApplication,
+	appWindow: Page,
+	label: string,
+): Promise<Array<NativeMenuItem>> => {
+	await electronApp.evaluate(({ ipcMain }, selectedLabel) => {
+		const state = globalThis as typeof globalThis & {
+			newBranchMenuItems?: Array<NativeMenuItem>;
+		};
+		delete state.newBranchMenuItems;
+		ipcMain.removeHandler("showNativeMenu");
+		ipcMain.handle("showNativeMenu", (_event, params: { items: Array<NativeMenuItem> }) => {
+			state.newBranchMenuItems = params.items;
+			const item = params.items.find((item) => item.label === selectedLabel);
+			return item?.enabled === false ? null : (item?.itemId ?? null);
+		});
+	}, label);
+
+	await appWindow.getByRole("button", { name: "New branch" }).click();
+	const readItems = () =>
+		electronApp.evaluate(() => {
+			const state = globalThis as typeof globalThis & {
+				newBranchMenuItems?: Array<NativeMenuItem>;
+			};
+			return state.newBranchMenuItems ?? [];
+		});
+	await expect.poll(readItems).not.toEqual([]);
+	return readItems();
+};
 
 const applyBranch = async (appWindow: Page, name: string) => {
 	const picker = appWindow.getByRole("dialog", { name: "Apply branch" });
@@ -15,6 +66,34 @@ const applyBranch = async (appWindow: Page, name: string) => {
 	await picker.getByRole("option", { name: new RegExp(`^${name} `) }).click();
 	await expect(picker).toBeHidden();
 };
+
+test.describe("new branch outside the workspace", () => {
+	test.use({ scenario: "project-with-master-checked-out.sh" });
+
+	test("only offers branch checkout when master is checked out", async ({
+		appWindow,
+		electronApp,
+	}) => {
+		await expect.poll(() => checkedOutBranchName(appWindow)).toBe("refs/heads/master");
+		const menuItems = await chooseNewBranchAction(
+			electronApp,
+			appWindow,
+			"New Branch in Workspace",
+		);
+		expect(menuItems.find((item) => item.label === "New Branch in Workspace")?.enabled).toBe(false);
+		expect(menuItems.find((item) => item.label === "New Branch and Switch to It")?.enabled).toBe(
+			true,
+		);
+
+		await chooseNewBranchAction(electronApp, appWindow, "New Branch and Switch to It");
+		await expect
+			.poll(async () => {
+				const checkedOut = await checkedOutBranchName(appWindow);
+				return checkedOut !== null && checkedOut !== "" && checkedOut !== "refs/heads/master";
+			})
+			.toBe(true);
+	});
+});
 
 test.describe("branches", () => {
 	test.use({ scenario: "project-with-remote-branches.sh" });
@@ -71,5 +150,27 @@ test.describe("branches", () => {
 		await appWindow.keyboard.press(process.platform === "darwin" ? "Meta+Backspace" : "Delete");
 
 		await expect(branch).toHaveCount(0);
+	});
+});
+
+test.describe("workspace branch creation", () => {
+	test.use({ scenario: "project-with-diverged-branch-and-parallel-empty-branch.sh" });
+
+	test("creates an independent branch in an ordinary workspace", async ({
+		appWindow,
+		electronApp,
+	}) => {
+		await expect(
+			appWindow.getByRole("treeitem", { name: "empty-branch", exact: true }),
+		).toBeVisible();
+		const stacks = appWindow.getByRole("group", { name: "Stack" });
+		const initialStackCount = await stacks.count();
+		const menuItems = await chooseNewBranchAction(
+			electronApp,
+			appWindow,
+			"New Branch in Workspace",
+		);
+		expect(menuItems.find((item) => item.label === "New Branch in Workspace")?.enabled).toBe(true);
+		await expect(stacks).toHaveCount(initialStackCount + 1);
 	});
 });

--- a/apps/lite/ui/src/routes/project/$id/workspace/Sidebar.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Sidebar.tsx
@@ -197,7 +197,7 @@ export const Sidebar: FC<{
 			callback: newBranch.createInWorkspace,
 			options: {
 				conflictBehavior: "allow",
-				enabled: canCreateBranch,
+				enabled: newBranch.canCreateInWorkspace,
 				meta: workspaceHotkeys.createIndependentBranch.meta,
 				requireReset: true,
 			},

--- a/apps/lite/ui/src/routes/project/$id/workspace/useNewBranch.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/useNewBranch.ts
@@ -1,4 +1,5 @@
 import { useBranchCheckoutNew, useBranchCreate } from "#ui/api/mutations.ts";
+import { operatingModeQueryOptions } from "#ui/api/queries.ts";
 import { toElectronAccelerator, workspaceHotkeys } from "#ui/hotkeys.ts";
 import { nativeMenuItem, type NativeMenuItem } from "#ui/native-menu.ts";
 import { branchAddress } from "#ui/addresses.ts";
@@ -6,6 +7,7 @@ import { focusScope } from "#ui/focus-scopes.ts";
 import { setCursor, setPage } from "#ui/use-cursor.ts";
 import { projectSlice } from "#ui/projects/state.ts";
 import { useAppSelector } from "#ui/store.ts";
+import { useQuery } from "@tanstack/react-query";
 
 export type NewBranchActions = {
 	menuItems: Array<NativeMenuItem>;
@@ -13,6 +15,8 @@ export type NewBranchActions = {
 	isPending: boolean;
 	/** Whether a branch can be started at all, for the trigger's disabled state. */
 	enabled: boolean;
+	/** Whether the current workspace can accept another independent branch. */
+	canCreateInWorkspace: boolean;
 	/** The plain create, for the hotkey that skips the menu. */
 	createInWorkspace: () => void;
 	createAndSwitch: () => void;
@@ -30,6 +34,10 @@ export type NewBranchActions = {
  * while a menu's is still landing.
  */
 export const useNewBranch = (projectId: string): NewBranchActions => {
+	const { data: isOpenWorkspace } = useQuery({
+		...operatingModeQueryOptions(projectId),
+		select: (headAndMode) => headAndMode.operatingMode.type === "OpenWorkspace",
+	});
 	// Read here rather than taken from callers: a sidebar busy with a transfer
 	// or an absorb is no place to start a branch from, and that is true of every
 	// trigger rather than something each one should have to remember.
@@ -38,6 +46,9 @@ export const useNewBranch = (projectId: string): NewBranchActions => {
 	);
 	const { isPending: isCreatePending, mutate: branchCreate } = useBranchCreate();
 	const { isPending: isCheckoutPending, mutate: branchCheckoutNew } = useBranchCheckoutNew();
+	const isPending = isCreatePending || isCheckoutPending;
+	const enabled = noOperationPending && !isPending;
+	const canCreateInWorkspace = isOpenWorkspace === true && enabled;
 
 	const createInWorkspace = () => {
 		branchCreate(
@@ -65,7 +76,7 @@ export const useNewBranch = (projectId: string): NewBranchActions => {
 		menuItems: [
 			nativeMenuItem({
 				label: "New Branch in Workspace",
-				enabled: noOperationPending && !isCreatePending,
+				enabled: canCreateInWorkspace,
 				accelerator: toElectronAccelerator(workspaceHotkeys.createIndependentBranch.hotkey),
 				onSelect: createInWorkspace,
 			}),
@@ -76,8 +87,9 @@ export const useNewBranch = (projectId: string): NewBranchActions => {
 				onSelect: createAndSwitch,
 			}),
 		],
-		isPending: isCreatePending || isCheckoutPending,
-		enabled: noOperationPending && !isCreatePending && !isCheckoutPending,
+		isPending,
+		enabled,
+		canCreateInWorkspace,
 		createInWorkspace,
 		createAndSwitch,
 	};

--- a/e2e/playwright/scripts/project-with-master-checked-out.sh
+++ b/e2e/playwright/scripts/project-with-master-checked-out.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -euo pipefail
+
+bash "$(dirname "$0")/project-with-remote-branches.sh"
+git -C local-clone checkout master


### PR DESCRIPTION
## Context

With master checked out, "New Branch in Workspace" remained enabled even though it cannot add a parallel branch. Choosing it failed with "target commit already belongs to another branch in the workspace". The only workaround was "New Branch and Switch to It", which leaves the workspace and succeeds.

## Change

Gate "New Branch in Workspace" and its shortcut on OpenWorkspace mode. "New Branch and Switch to It" stays available outside the workspace, while ordinary workspaces can still create independent branches.

FYI @PavelLaptev