### PR TITLE
Stop polling inaccessible review listings

### DIFF
--- a/apps/desktop/src/components/branchesPage/BranchExplorer.svelte
+++ b/apps/desktop/src/components/branchesPage/BranchExplorer.svelte
@@ -81,9 +81,7 @@
 	const listServiceEnabled = $derived(!!forgeInfo?.capabilities.listService);
 	const reviewUnitAbbr = $derived(forgeInfo?.unit.abbr ?? "PR");
 
-	const prs = $derived(
-		listServiceEnabled ? listingService.list(projectId, 15 * 60 * 1000) : undefined,
-	);
+	const prs = $derived(listServiceEnabled ? listingService.list(projectId) : undefined);
 
 	const branchesQuery = $derived(branchService.list(projectId));
 	const combined = $derived(

--- a/apps/desktop/src/lib/error/errorClassification.ts
+++ b/apps/desktop/src/lib/error/errorClassification.ts
@@ -214,16 +214,15 @@ Your GitHub token appears expired. Please log out and back in to refresh it. (Se
 			"This GitHub organization requires SAML SSO. Authorize the GitButler OAuth app on the organization's SSO page, or authorize your personal access token in GitHub's token SSO settings, then try again.",
 	},
 	/**
-	 * The GitHub token can't read the requested resource — a fine-grained
-	 * PAT missing a read permission such as Checks. Terminal until the
-	 * user grants it or reconnects.
+	 * GitHub denied or hid the requested repository resource. Terminal until
+	 * the user grants access, reconnects, or updates the repository configuration.
 	 */
 	GitHubInsufficientPermissions: {
 		severity: "error",
 		terminal: true,
 		title: "GitHub Permissions Error",
 		userMessage: `
-Your GitHub token doesn't have permission to read part of this repository (for example CI checks). Grant the token the missing read permission on GitHub, or reconnect GitHub under Settings → Integrations.
+GitHub could not access this repository or part of it (for example CI checks). Check that the repository still exists, grant the missing read permission, or reconnect GitHub under Settings → Integrations.
 		`,
 	},
 	/**

--- a/apps/desktop/src/lib/forge/shared/pollErrorBackoff.svelte.test.ts
+++ b/apps/desktop/src/lib/forge/shared/pollErrorBackoff.svelte.test.ts
@@ -1,0 +1,63 @@
+import { createPollBackoff } from "$lib/forge/shared/pollErrorBackoff.svelte";
+import { QueryStatus } from "@reduxjs/toolkit/query";
+import { flushSync } from "svelte";
+import { describe, expect, test } from "vitest";
+
+const INITIAL = 5 * 1000;
+const SHORT = 30 * 1000;
+const MEDIUM = 5 * 60 * 1000;
+
+const terminal = { code: "GitHubInsufficientPermissions", message: "no access" };
+const transient = { code: "Unknown", message: "flaky" };
+
+/** An unkeyed consumer, like the PR and checks cards, recording each interval change. */
+function unkeyed() {
+	let result = $state.raw<any>(undefined);
+	const intervals: number[] = [];
+	const dispose = $effect.root(() => {
+		const backoff = createPollBackoff({
+			getResult: () => result,
+			getElapsedMs: () => 0,
+			getShouldStop: () => false,
+		});
+		$effect(() => {
+			const interval = backoff.pollingInterval;
+			if (intervals.at(-1) !== interval) intervals.push(interval);
+		});
+	});
+	flushSync();
+	return {
+		intervals,
+		dispose,
+		set(status: QueryStatus, startedTimeStamp: number, error?: unknown) {
+			result = { status, startedTimeStamp, error };
+			flushSync();
+		},
+	};
+}
+
+describe("createPollBackoff", () => {
+	test("keeps escalating across in-flight polls that keep failing", () => {
+		const backoff = unkeyed();
+		backoff.set(QueryStatus.rejected, 1, transient);
+		backoff.set(QueryStatus.pending, 2);
+		backoff.set(QueryStatus.rejected, 2, transient);
+		backoff.set(QueryStatus.pending, 3);
+		backoff.set(QueryStatus.rejected, 3, transient);
+		// Each pending poll would otherwise clear the count, flipping the interval
+		// back and forth once per completion instead of settling at medium.
+		expect(backoff.intervals).toEqual([INITIAL, SHORT, MEDIUM]);
+		backoff.dispose();
+	});
+
+	test("stays stopped after a terminal failure until a success", () => {
+		const backoff = unkeyed();
+		backoff.set(QueryStatus.rejected, 1, terminal);
+		backoff.set(QueryStatus.pending, 2);
+		backoff.set(QueryStatus.rejected, 2, transient);
+		expect(backoff.intervals).toEqual([INITIAL, 0]);
+		backoff.set(QueryStatus.fulfilled, 3);
+		expect(backoff.intervals.at(-1)).toBe(INITIAL);
+		backoff.dispose();
+	});
+});

--- a/apps/desktop/src/lib/forge/shared/pollErrorBackoff.svelte.ts
+++ b/apps/desktop/src/lib/forge/shared/pollErrorBackoff.svelte.ts
@@ -1,8 +1,8 @@
 import { classify } from "$lib/error/errorClassification";
 import { getPollingInterval } from "$lib/forge/shared/progressivePolling";
+import { QueryStatus } from "@reduxjs/toolkit/query";
 
-/** The bits of a query result the backoff cares about. */
-type PollResult = { isError?: boolean; error?: unknown; startedTimeStamp?: number } | undefined;
+type PollResult = { status: QueryStatus; error?: unknown; startedTimeStamp?: number } | undefined;
 
 /**
  * Progressive polling that backs off as a query keeps failing.
@@ -18,6 +18,13 @@ type PollResult = { isError?: boolean; error?: unknown; startedTimeStamp?: numbe
  * — no interval will fix it. Refetch-on-focus and manual retries still
  * probe, and a success clears the stop.
  *
+ * A pending result (a poll or retry in flight) changes nothing: only the
+ * request's outcome does. Treating it as healthy would clear the backoff on
+ * every poll and re-count the same failure once it completes, so the interval
+ * would flip on each completion instead of settling.
+ *
+ * `getKey` scopes the state: a key change (e.g. a new project) starts over.
+ *
  * The failure count is `$state` written from an `$effect`, not a `$derived` off
  * the query: `pollingInterval` feeds the query's own subscription, so deriving
  * the error straight back out of the query would form a reactive cycle. The
@@ -31,28 +38,28 @@ export function createPollBackoff(deps: {
 	getResult: () => PollResult;
 	getElapsedMs: () => number;
 	getShouldStop: () => boolean;
+	getKey?: () => unknown;
 }) {
 	let consecutiveErrors = $state(0);
 	let terminalError = $state(false);
-	// Not reactive: just remembers which poll we last counted, so a re-running
-	// effect doesn't double-count a single failed request.
-	let lastPolledStamp: number | undefined = undefined;
+	let lastKey = deps.getKey?.();
+	let lastPolledStamp: number | undefined;
 
 	$effect(() => {
+		const key = deps.getKey?.();
+		if (lastKey !== key) [lastKey, consecutiveErrors, terminalError] = [key, 0, false];
 		const result = deps.getResult();
-		const errored = result?.isError ?? false;
+		const status = result?.status;
 		const stamp = result?.startedTimeStamp;
 
-		if (!errored) {
-			// A healthy (or absent) result clears the backoff.
+		if (status === QueryStatus.pending) return;
+		if (!result || status !== QueryStatus.rejected) {
 			if (consecutiveErrors !== 0) consecutiveErrors = 0;
 			if (terminalError) terminalError = false;
 			lastPolledStamp = stamp;
 			return;
 		}
-
-		const terminal = result?.error ? (classify(result.error).terminal ?? false) : false;
-		if (terminal !== terminalError) terminalError = terminal;
+		if (!terminalError && result.error && classify(result.error).terminal) terminalError = true;
 
 		if (consecutiveErrors === 0) {
 			// First failed poll: step out to the short interval.

--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -16,6 +16,7 @@
 	import { FORGE_INFO_SERVICE } from "$lib/forge/forgeInfo.svelte";
 	import { GITLAB_USER_SERVICE } from "$lib/forge/gitlab/gitlabUserService.svelte";
 	import { LISTING_SERVICE } from "$lib/forge/listingService.svelte";
+	import { createPollBackoff } from "$lib/forge/shared/pollErrorBackoff.svelte";
 	import { GIT_SERVICE } from "$lib/git/gitService";
 	import { MODE_SERVICE } from "$lib/mode/modeService";
 	import { showInfo, showWarning } from "$lib/notifications/toasts";
@@ -91,18 +92,23 @@
 	const canListReviews = $derived(
 		projectForgeInfoQuery.response?.capabilities.listService ?? false,
 	);
-	const forgeReviews = $derived(
-		canListReviews ? listingService.list(projectId, 15 * 60 * 1000) : undefined,
-	);
-
 	// Keep one project-level subscription alive so a cold workspace populates
-	// the backend forge cache even when the Branches view is never opened.
-	// Reading the result makes the lazy derived query part of this component's
-	// reactive graph; cache-write completion invalidates head_info in the service.
-	$effect(() => {
-		const result = forgeReviews?.result;
-		void result;
+	// the backend forge cache even when the Branches view is never opened. The
+	// backoff's effect reads the result, which makes the lazy derived query
+	// part of this component's reactive graph.
+	const POLL_INTERVAL = 15 * 60 * 1000;
+	const reviewListBackoff = createPollBackoff({
+		getKey: () => projectId,
+		getResult: () => forgeReviews?.result,
+		getElapsedMs: () => 0,
+		getShouldStop: () => false,
 	});
+	const reviewListPollingInterval = $derived(
+		reviewListBackoff.pollingInterval === 0 ? 0 : POLL_INTERVAL,
+	);
+	const forgeReviews = $derived(
+		canListReviews ? listingService.list(projectId, reviewListPollingInterval) : undefined,
+	);
 
 	// Migrate stored GitLab access token from the legacy location to the
 	// per-account secrets entry on app load. Safe no-op when already done.

--- a/apps/desktop/src/routes/[projectId]/projectLayout.svelte.test.ts
+++ b/apps/desktop/src/routes/[projectId]/projectLayout.svelte.test.ts
@@ -1,0 +1,327 @@
+import ProjectLayout from "./+layout.svelte";
+import { BACKEND } from "$lib/backend";
+import { BASE_BRANCH_SERVICE } from "$lib/baseBranch/baseBranchService.svelte";
+import { BRANCH_SERVICE } from "$lib/branches/branchService.svelte";
+import { FORGE_INFO_SERVICE } from "$lib/forge/forgeInfo.svelte";
+import { GITLAB_USER_SERVICE } from "$lib/forge/gitlab/gitlabUserService.svelte";
+import { LISTING_SERVICE, ListingService } from "$lib/forge/listingService.svelte";
+import { GIT_SERVICE } from "$lib/git/gitService";
+import { MODE_SERVICE } from "$lib/mode/modeService";
+import { PROJECTS_SERVICE } from "$lib/project/projectsService";
+import { FILE_SELECTION_MANAGER } from "$lib/selection/fileSelectionManager.svelte";
+import { UNCOMMITTED_SERVICE } from "$lib/selection/uncommittedService.svelte";
+import { SETTINGS_SERVICE } from "$lib/settings/appSettings";
+import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
+import { butlerModule } from "$lib/state/butlerModule";
+import { CLIENT_STATE } from "$lib/state/clientState.svelte";
+import { ReduxTag } from "$lib/state/tags";
+import { POSTHOG_WRAPPER } from "$lib/telemetry/posthog";
+import { WORKTREE_SERVICE } from "$lib/worktree/worktreeService.svelte";
+import { configureStore } from "@reduxjs/toolkit";
+import { buildCreateApi, coreModule, QueryStatus } from "@reduxjs/toolkit/query";
+import { render } from "@testing-library/svelte";
+import { flushSync } from "svelte";
+import { writable } from "svelte/store";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import type { HookContext } from "$lib/state/context";
+
+vi.mock("$app/navigation", () => ({ goto: vi.fn() }));
+vi.mock("$lib/error/showError", () => ({ showError: vi.fn() }));
+vi.mock("$components/settings/ProjectSettingsShortcutHandler.svelte", () => ({
+	default: () => {},
+}));
+vi.mock("$components/shared/AnalyticsMonitor.svelte", () => ({ default: () => {} }));
+vi.mock("$components/shared/FullviewLoading.svelte", () => ({ default: () => {} }));
+vi.mock("$components/shared/NotOnGitButlerBranch.svelte", () => ({ default: () => {} }));
+vi.mock("$components/shared/ProjectShortcutHandler.svelte", () => ({ default: () => {} }));
+vi.mock("$components/shared/ReduxResult.svelte", () => ({ default: () => {} }));
+vi.mock("$components/views/AppLayout.svelte", () => ({ default: () => {} }));
+vi.mock("$components/views/NoBaseBranch.svelte", () => ({ default: () => {} }));
+vi.mock("$components/views/ProblemLoadingRepo.svelte", () => ({ default: () => {} }));
+
+const PROJECT_ID = "project";
+const POLL_INTERVAL = 15 * 60 * 1000;
+
+const review = {
+	htmlUrl: "https://example.invalid/review/1",
+	number: 1,
+	title: "Cached review",
+	body: null,
+	author: null,
+	labels: [],
+	draft: false,
+	sourceBranch: "topic",
+	targetBranch: "main",
+	sha: "deadbeef",
+	createdAt: null,
+	modifiedAt: null,
+	mergedAt: null,
+	closedAt: null,
+	repositorySshUrl: null,
+	repositoryHttpsUrl: null,
+	repoOwner: null,
+	headRepoIsFork: false,
+	reviewers: [],
+};
+
+const success = { data: [review] };
+const terminalError = {
+	error: {
+		origin: "ipc" as const,
+		name: "API error: (list_reviews)",
+		message: "The repository is unavailable to this account.",
+		code: "GitHubInsufficientPermissions" as const,
+	},
+};
+const nonterminalError = {
+	error: {
+		origin: "ipc" as const,
+		name: "API error: (list_reviews)",
+		message: "Temporary forge failure.",
+		code: "Unknown" as const,
+	},
+};
+
+class ReactiveStoreState {
+	root = $state.raw<any>();
+	readonly unsubscribe: () => void;
+
+	constructor(private readonly store: ReturnType<typeof configureStore>) {
+		this.root = store.getState();
+		this.unsubscribe = store.subscribe(() => (this.root = store.getState()));
+	}
+}
+
+function query(response?: unknown) {
+	return {
+		response,
+		result: {
+			status: response === undefined ? QueryStatus.uninitialized : QueryStatus.fulfilled,
+			data: response,
+		},
+	};
+}
+
+type Response = typeof success | typeof terminalError | typeof nonterminalError;
+
+function setup(
+	responses: Array<Response | Promise<Response>>,
+	listingServiceOverride?: Pick<ListingService, "list">,
+) {
+	let calls = 0;
+	const storeRef = {} as {
+		state: ReactiveStoreState;
+		store: ReturnType<typeof configureStore>;
+	};
+	const context: HookContext = {
+		getState: () => storeRef.state.root,
+		getDispatch: () => storeRef.store.dispatch,
+	};
+	const api = buildCreateApi(
+		coreModule(),
+		butlerModule(context),
+	)({
+		reducerPath: "backend",
+		tagTypes: Object.values(ReduxTag),
+		baseQuery: async () => await responses[Math.min(calls++, responses.length - 1)]!,
+		endpoints: () => ({}),
+	});
+	const store = configureStore({
+		reducer: { [api.reducerPath]: api.reducer },
+		middleware: (defaults) => defaults().concat(api.middleware),
+	});
+	const storeState = new ReactiveStoreState(store);
+	storeRef.store = store;
+	storeRef.state = storeState;
+	const listingService =
+		listingServiceOverride ?? new ListingService(api as never, store.dispatch as never);
+	const forgeInfo = { capabilities: { listService: true } };
+	function noop() {}
+	async function asyncNoop() {}
+	const contextMap = new Map<any, any>([
+		[
+			BACKEND._key,
+			{
+				getAppInfo: async () => ({ name: "GitButler" }),
+				getWindowTitle: async () => "GitButler",
+				setWindowTitle: noop,
+				listen: () => noop,
+			},
+		],
+		[
+			BASE_BRANCH_SERVICE._key,
+			{
+				repo: () => query(),
+				baseBranch: () => query(),
+				refreshBaseBranch: asyncNoop,
+				fetchFromRemotes: asyncNoop,
+			},
+		],
+		[BRANCH_SERVICE._key, { refresh: asyncNoop }],
+		[FORGE_INFO_SERVICE._key, { get: () => query(forgeInfo) }],
+		[GITLAB_USER_SERVICE._key, { migrate: noop }],
+		[LISTING_SERVICE._key, listingService],
+		[GIT_SERVICE._key, { onFetch: () => noop }],
+		[MODE_SERVICE._key, { mode: () => query(), head: () => query() }],
+		[POSTHOG_WRAPPER._key, { setPostHogRepo: noop, captureOnboarding: noop }],
+		[PROJECTS_SERVICE._key, { projects: () => query([]), setActiveProject: async () => undefined }],
+		[FILE_SELECTION_MANAGER._key, { retain: noop }],
+		[UNCOMMITTED_SERVICE._key, { updateData: noop }],
+		[SETTINGS_SERVICE._key, { appSettings: writable({ fetch: { autoFetchIntervalMinutes: -1 } }) }],
+		[STACK_SERVICE._key, { invalidateStacksAndDetails: noop }],
+		[
+			CLIENT_STATE._key,
+			{
+				dispatch: store.dispatch,
+				backendApi: { util: { resetApiState: () => ({ type: "test/noop" }) } },
+			},
+		],
+		[WORKTREE_SERVICE._key, { worktreeData: () => query() }],
+	]);
+	const rendered = render(ProjectLayout, {
+		props: { data: { projectId: PROJECT_ID } } as never,
+		context: contextMap,
+	});
+
+	return {
+		api,
+		store,
+		storeState,
+		rendered,
+		get calls() {
+			return calls;
+		},
+	};
+}
+
+async function settle() {
+	flushSync();
+	await vi.advanceTimersByTimeAsync(0);
+	flushSync();
+}
+
+afterEach(() => {
+	vi.useRealTimers();
+	vi.restoreAllMocks();
+});
+
+describe("project review-list polling", () => {
+	test("keeps cached reviews, stops terminal polling, and recovers through explicit retries", async () => {
+		vi.useFakeTimers();
+		const harness = setup([success, terminalError, terminalError, success, success]);
+		await settle();
+		expect(harness.calls).toBe(1);
+
+		await vi.advanceTimersByTimeAsync(POLL_INTERVAL);
+		const failed = (harness.api.endpoints as any).listPrs.select(PROJECT_ID)(
+			harness.store.getState(),
+		);
+		expect(failed.data.ids).toEqual(["topic"]);
+		expect(failed.isError).toBe(true);
+
+		await vi.advanceTimersByTimeAsync(POLL_INTERVAL);
+		expect(harness.calls, "terminal failure scheduled another interval request").toBe(2);
+
+		harness.store.dispatch(harness.api.internalActions.onFocusLost());
+		harness.store.dispatch(harness.api.internalActions.onFocus());
+		await settle();
+		expect(harness.calls).toBe(3);
+		await vi.advanceTimersByTimeAsync(POLL_INTERVAL);
+		expect(harness.calls).toBe(3);
+
+		harness.store.dispatch(harness.api.internalActions.onFocusLost());
+		harness.store.dispatch(harness.api.internalActions.onFocus());
+		await settle();
+		expect(harness.calls).toBe(4);
+
+		await vi.advanceTimersByTimeAsync(POLL_INTERVAL - 1);
+		expect(harness.calls).toBe(4);
+		await vi.advanceTimersByTimeAsync(1);
+		expect(harness.calls).toBe(5);
+
+		harness.rendered.unmount();
+		harness.storeState.unsubscribe();
+	});
+
+	test("keeps terminal polling stopped after a nonterminal failed retry", async () => {
+		vi.useFakeTimers();
+		let failRetry!: (result: typeof nonterminalError) => void;
+		const retry = new Promise<typeof nonterminalError>((resolve) => (failRetry = resolve));
+		const harness = setup([success, terminalError, retry]);
+		await settle();
+		expect(harness.calls).toBe(1);
+		await vi.advanceTimersByTimeAsync(POLL_INTERVAL);
+		expect(harness.calls).toBe(2);
+		await vi.advanceTimersByTimeAsync(POLL_INTERVAL);
+		expect(harness.calls).toBe(2);
+
+		harness.store.dispatch(harness.api.internalActions.onFocusLost());
+		harness.store.dispatch(harness.api.internalActions.onFocus());
+		await settle();
+		expect(harness.calls).toBe(3);
+		const pending = (harness.api.endpoints as any).listPrs.select(PROJECT_ID)(
+			harness.store.getState(),
+		);
+		expect(pending.isLoading).toBe(true);
+		expect(pending.isError).toBe(false);
+
+		failRetry(nonterminalError);
+		await settle();
+
+		await vi.advanceTimersByTimeAsync(POLL_INTERVAL);
+		expect(harness.calls, "failed focus retry restarted terminal polling").toBe(3);
+
+		harness.rendered.unmount();
+		harness.storeState.unsubscribe();
+	});
+
+	test("resets terminal polling when the project changes", async () => {
+		vi.useFakeTimers();
+		let result = $state.raw<any>({
+			status: QueryStatus.rejected,
+			error: terminalError.error,
+			startedTimeStamp: 1,
+		});
+		const intervals: Array<[string, number | undefined]> = [];
+		const listingService = {
+			list(projectId: string, pollingInterval?: number) {
+				intervals.push([projectId, pollingInterval]);
+				return {
+					get result() {
+						return result;
+					},
+				} as never;
+			},
+		};
+		const harness = setup([], listingService);
+		await settle();
+		expect(intervals.at(-1)).toEqual([PROJECT_ID, 0]);
+
+		result = { status: QueryStatus.pending, startedTimeStamp: 2 };
+		await harness.rendered.rerender({ data: { projectId: "project-b" } } as never);
+		await settle();
+		result = {
+			status: QueryStatus.rejected,
+			error: nonterminalError.error,
+			startedTimeStamp: 2,
+		};
+		await settle();
+
+		expect(intervals.at(-1), "new project inherited terminal polling state").toEqual([
+			"project-b",
+			POLL_INTERVAL,
+		]);
+		harness.rendered.unmount();
+		harness.storeState.unsubscribe();
+	});
+
+	test("keeps the 15-minute cadence after a nonterminal failure", async () => {
+		vi.useFakeTimers();
+		const harness = setup([success, nonterminalError]);
+		await settle();
+		await vi.advanceTimersByTimeAsync(POLL_INTERVAL * 2);
+		expect(harness.calls).toBe(3);
+		harness.rendered.unmount();
+		harness.storeState.unsubscribe();
+	});
+});

--- a/crates/but-github/src/pr.rs
+++ b/crates/but-github/src/pr.rs
@@ -12,8 +12,24 @@ pub async fn list(
     GitHubClient::from_storage(storage, preferred_account)?
         .list_open_pulls(owner, repo)
         .await
-        .map_err(classify_forge_error)
+        .map_err(classify_review_list_error)
         .context("Failed to list open pull requests")
+}
+
+/// A 404 on the open-PR listing means the repository is gone or invisible to
+/// this account, so retrying cannot succeed: it is tagged as a permission
+/// problem right here. Every other error goes through [`classify_forge_error`].
+fn classify_review_list_error(err: anyhow::Error) -> anyhow::Error {
+    if err
+        .downcast_ref::<HttpStatusError>()
+        .is_some_and(|http_err| http_err.status == reqwest::StatusCode::NOT_FOUND)
+    {
+        return err.context(but_error::Context::new_static(
+            but_error::Code::GitHubInsufficientPermissions,
+            "GitHub could not find this repository. Check that it still exists and that your account can access it.",
+        ));
+    }
+    classify_forge_error(err)
 }
 pub async fn list_recently_closed(
     preferred_account: Option<&crate::GithubAccountIdentifier>,
@@ -574,6 +590,30 @@ mod tests {
             ctx.map(|c| c.code),
             Some(but_error::Code::GitHubInsufficientPermissions),
             "a PAT permission 403 is terminal and needs its remediation surfaced"
+        );
+    }
+
+    #[test]
+    fn review_list_404_classification_is_operation_local() {
+        let list_err = classify_review_list_error(http_error(
+            reqwest::StatusCode::NOT_FOUND,
+            r#"404 Not Found: {"message":"Not Found"}"#,
+        ));
+        assert_eq!(
+            list_err
+                .downcast_ref::<but_error::Context>()
+                .map(|ctx| ctx.code),
+            Some(but_error::Code::GitHubInsufficientPermissions),
+            "a review-list 404 needs repository access before retrying can succeed"
+        );
+
+        let other_err = classify_forge_error(http_error(
+            reqwest::StatusCode::NOT_FOUND,
+            r#"404 Not Found: {"message":"Not Found"}"#,
+        ));
+        assert!(
+            other_err.downcast_ref::<but_error::Context>().is_none(),
+            "other GitHub read operations keep their existing 404 semantics"
         );
     }
 


### PR DESCRIPTION
## Context
When a configured GitHub repository is removed or becomes inaccessible, the project-level review subscription keeps retrying on its normal interval. That repeatedly resurfaces the same failure even though the last successful review list is still useful.

## Change
Use the existing poll-backoff path as the single project-level review timer owner, stop interval polling for terminal repository-access failures, and keep cached reviews available. Explicit and focus retries remain available; a successful retry restores the 15-minute cadence. Project switches reset the terminal state.

Pending requests now preserve the current backoff state for every consumer. This prevents unkeyed consumers such as PR cards and checks badges from oscillating between their initial and escalated intervals while a retry is in flight.

Review-list 404 classification is scoped to that GitHub operation, and Branch Explorer no longer contributes a competing timer. Polling mechanics have focused unit coverage; the project-layout tests retain only the mounted behavior contracts.

FYI @PavelLaptev
