### PR TITLE
Repair stale commit selection before detail queries

### DIFF
--- a/apps/desktop/src/components/test/stale-selection-ordering/WorkspacePageHarness.svelte
+++ b/apps/desktop/src/components/test/stale-selection-ordering/WorkspacePageHarness.svelte
@@ -1,0 +1,69 @@
+<script lang="ts">
+	import WorkspacePage from "../../../routes/[projectId]/workspace/+page.svelte";
+	import { MODE_SERVICE } from "$lib/mode/modeService";
+	import { transformWorkspaceDetails } from "$lib/stacks/headInfoAdapters";
+	import { STACK_SERVICE, StackService } from "$lib/stacks/stackService.svelte";
+	import { UI_STATE, type StackSelection, type UiState } from "$lib/state/uiState.svelte";
+	import { provide } from "@gitbutler/core/context";
+	import type { BackendApi } from "$lib/state/backendApi";
+	import type { RefInfo, Stack } from "@gitbutler/but-sdk";
+
+	type SelectionStore = {
+		readonly current: StackSelection | undefined;
+		set(value: StackSelection | undefined): void;
+	};
+
+	type Props = {
+		initialSelection: StackSelection;
+		stack: Stack;
+		onQuery: (commitId: string) => void;
+		onStore: (store: SelectionStore) => void;
+	};
+
+	let { initialSelection, stack, onQuery, onStore }: Props = $props();
+	function readInitialSelection() {
+		return initialSelection;
+	}
+	let selection = $state<StackSelection | undefined>(readInitialSelection());
+	const selectionStore: SelectionStore = {
+		get current() {
+			return selection;
+		},
+		set(value) {
+			selection = value;
+		},
+	};
+	const uiState = {
+		lane: () => ({ selection: selectionStore }),
+		project: () => ({ exclusiveAction: { current: undefined, set: () => {} } }),
+	} as unknown as UiState;
+	const workspaceDetails = $derived(transformWorkspaceDetails({ stacks: [stack] } as RefInfo));
+	const backendApi = {
+		endpoints: {
+			workspaceDetails: {
+				useQuery: (_args: unknown, options: { transform: (value: unknown) => unknown }) => ({
+					get response() {
+						return options.transform(workspaceDetails);
+					},
+				}),
+			},
+			commitDetails: {
+				useQuery: (args: { commitId: string }) => {
+					onQuery(args.commitId);
+					return { result: { status: "pending" } };
+				},
+			},
+		},
+	} as unknown as BackendApi;
+	const stackService = new StackService(backendApi, {} as never, uiState);
+
+	provide(STACK_SERVICE, stackService);
+	provide(UI_STATE, uiState);
+	provide(MODE_SERVICE, { mode: () => ({ response: undefined }) } as never);
+	function publishStore() {
+		onStore(selectionStore);
+	}
+	publishStore();
+</script>
+
+<WorkspacePage />

--- a/apps/desktop/src/components/test/stale-selection-ordering/WorkspacePageHarness.svelte.test.ts
+++ b/apps/desktop/src/components/test/stale-selection-ordering/WorkspacePageHarness.svelte.test.ts
@@ -1,0 +1,142 @@
+import WorkspacePageHarness from "$components/test/stale-selection-ordering/WorkspacePageHarness.svelte";
+import { render } from "@testing-library/svelte";
+import { tick } from "svelte";
+import { VERSION } from "svelte/compiler";
+import { describe, expect, test, vi } from "vitest";
+import type { StackSelection } from "$lib/state/uiState.svelte";
+import type { Commit, Segment, Stack } from "@gitbutler/but-sdk";
+
+vi.mock("$app/navigation", () => ({ goto: vi.fn() }));
+vi.mock("$app/state", () => ({
+	page: {
+		params: { projectId: "project-1" },
+		url: new URL("https://example.com/project-1/workspace"),
+	},
+}));
+vi.mock("$components/views/WorkspaceView.svelte", async () => ({
+	default: (
+		await import("$components/test/stale-selection-ordering/WorkspaceViewQueryBoundary.svelte")
+	).default,
+}));
+
+const OLD_OID = "obsolete-oid";
+const NEW_OID = "rewritten-oid";
+const KEPT_OID = "kept-oid";
+
+type SelectionStore = {
+	readonly current: StackSelection | undefined;
+	set(value: StackSelection | undefined): void;
+};
+
+function stackWith(ids: string[]): Stack {
+	return {
+		id: "stack-1",
+		base: null,
+		segments: [
+			{
+				refName: { displayName: "branch", fullNameBytes: [] },
+				remoteTrackingRefName: null,
+				commits: ids.map((id) => ({ id, state: { type: "LocalOnly" } }) as Commit),
+				commitsOnRemote: [],
+				commitsOutside: null,
+				metadata: null,
+				isEntrypoint: false,
+				pushStatus: "nothingToPush",
+				base: null,
+			} as Segment,
+		],
+	} as Stack;
+}
+
+async function settle() {
+	await tick();
+}
+
+function mount(stack: Stack) {
+	const queries: string[] = [];
+	let selection!: SelectionStore;
+	const props = {
+		initialSelection: {
+			branchName: "branch",
+			commitId: OLD_OID,
+			previewOpen: true,
+		},
+		stack,
+		onQuery: (commitId: string) => queries.push(commitId),
+		onStore: (store: SelectionStore) => (selection = store),
+	};
+	return {
+		...render(WorkspacePageHarness, { props }),
+		props,
+		queries,
+		get selection() {
+			return selection;
+		},
+	};
+}
+
+function schedulingEvidence(queries: string[]) {
+	return `Svelte ${VERSION}; detail queries: ${JSON.stringify(queries)}`;
+}
+
+describe("workspace stale-selection ordering", () => {
+	test("repairs an initial cached selection before querying commit details", async () => {
+		const mounted = mount(stackWith([NEW_OID]));
+		await settle();
+
+		expect(mounted.queries, schedulingEvidence(mounted.queries)).not.toContain(OLD_OID);
+		expect(mounted.selection.current).toEqual({ branchName: "branch", previewOpen: false });
+	});
+
+	test("queries only the replacement after a rewrite", async () => {
+		const mounted = mount(stackWith([OLD_OID]));
+		await settle();
+		mounted.queries.length = 0;
+
+		await mounted.rerender({ ...mounted.props, stack: stackWith([NEW_OID]) });
+		await settle();
+
+		expect(mounted.queries, schedulingEvidence(mounted.queries)).not.toContain(OLD_OID);
+		expect(mounted.queries).toContain(NEW_OID);
+		expect(mounted.selection.current?.commitId).toBe(NEW_OID);
+	});
+
+	test("clears a removed commit before querying details", async () => {
+		const mounted = mount(stackWith([OLD_OID, KEPT_OID]));
+		await settle();
+		mounted.queries.length = 0;
+
+		await mounted.rerender({ ...mounted.props, stack: stackWith([KEPT_OID]) });
+		await settle();
+
+		expect(mounted.queries, schedulingEvidence(mounted.queries)).not.toContain(OLD_OID);
+		expect(mounted.selection.current).toEqual({ branchName: "branch", previewOpen: false });
+	});
+
+	test("keeps a caller-selected OID while a cached stack object is retained", async () => {
+		const stack = stackWith([OLD_OID]);
+		const mounted = mount(stack);
+		await settle();
+		mounted.queries.length = 0;
+
+		mounted.selection.set({ branchName: "branch", commitId: NEW_OID, previewOpen: true });
+		await mounted.rerender({ ...mounted.props, stack });
+		await settle();
+
+		expect(mounted.selection.current?.commitId).toBe(NEW_OID);
+		expect(mounted.queries, schedulingEvidence(mounted.queries)).not.toContain(OLD_OID);
+		expect(mounted.queries).toContain(NEW_OID);
+	});
+
+	test("tears down the owner and detail consumer together", async () => {
+		const mounted = mount(stackWith([OLD_OID]));
+		await settle();
+		mounted.queries.length = 0;
+		mounted.unmount();
+
+		mounted.selection.set({ branchName: "branch", commitId: NEW_OID, previewOpen: true });
+		await settle();
+
+		expect(mounted.queries).toEqual([]);
+	});
+});

--- a/apps/desktop/src/components/test/stale-selection-ordering/WorkspaceViewQueryBoundary.svelte
+++ b/apps/desktop/src/components/test/stale-selection-ordering/WorkspaceViewQueryBoundary.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { STACK_SERVICE } from "$lib/stacks/stackService.svelte";
+	import { UI_STATE } from "$lib/state/uiState.svelte";
+	import { inject } from "@gitbutler/core/context";
+
+	type Props = {
+		projectId: string;
+	};
+
+	const { projectId }: Props = $props();
+	const stackService = inject(STACK_SERVICE);
+	const uiState = inject(UI_STATE);
+	const stack = $derived(stackService.stackById(projectId, "stack-1").response);
+	const selectedCommitId = $derived(uiState.lane("stack-1").selection.current?.commitId);
+	const details = $derived(
+		stack && selectedCommitId ? stackService.commitChanges(projectId, selectedCommitId) : undefined,
+	);
+</script>
+
+{#if details}{details.result.status}{/if}

--- a/apps/desktop/src/lib/stacks/stackService.svelte.ts
+++ b/apps/desktop/src/lib/stacks/stackService.svelte.ts
@@ -283,7 +283,7 @@ export class StackService {
 		// fires on every stack-details refresh.
 		const STALE_SELECTION_COMMIT_LIMIT = 1000;
 
-		$effect(() => {
+		$effect.pre(() => {
 			if (allCommits.length > STALE_SELECTION_COMMIT_LIMIT) {
 				console.warn(
 					`Skipping stale selection detection: commit count (${allCommits.length}) exceeds limit (${STALE_SELECTION_COMMIT_LIMIT}).`,

--- a/apps/desktop/src/routes/[projectId]/workspace/+page.svelte
+++ b/apps/desktop/src/routes/[projectId]/workspace/+page.svelte
@@ -17,7 +17,7 @@
 	let scrollToStackId = $state<string | undefined>(undefined);
 
 	// Read all local commits in the workspace for the given project
-	$effect(() => {
+	$effect.pre(() => {
 		stackService.allLocalCommits(projectId);
 	});
 


### PR DESCRIPTION
## Context
After a commit is rewritten or removed, the workspace can publish the new stack snapshot while its selection still points at the obsolete object ID. A detail consumer can then request the removed commit before the existing selection repair runs.

## Change
Run the existing workspace subscription owner and canonical selection repair in Svelte's pre-effect phase, so selection is current before ordinary detail-query consumers react. Keep the existing large-stack cutoff, identity guard, rejection fallback, and query ownership unchanged.

Add a mounted regression around the real workspace page and stack service covering cached mount, rewrite, removal, retained stack identity, and teardown. The test records query attempts at invocation time and pins the installed Svelte scheduling behavior.