### PR TITLE
fix(but): add reword escape hatch to anonymous segment

### DIFF
--- a/crates/but/src/args/atoms/cli_id.rs
+++ b/crates/but/src/args/atoms/cli_id.rs
@@ -7,7 +7,10 @@ use crate::{
     CliError, CliId, CliResult, IdMap,
     args::atoms::BranchArg,
     bad_input,
-    id::{CommitId, CommitIdRef, CommittedFileId, CommittedHunk, IdAndHunk, UncommittedHunkOrFile},
+    id::{
+        AnonymousSegmentId, CommitId, CommitIdRef, CommittedFileId, CommittedHunk, IdAndHunk,
+        UncommittedHunkOrFile,
+    },
     theme,
     utils::change_source::ChangeSourceId,
 };
@@ -86,6 +89,7 @@ impl CliIdArg {
         };
         Ok(Some(match id {
             CliId::Branch(branch) => ResolvedCliIdArg::Branch(BranchArg(branch.name)),
+            CliId::AnonymousSegment(segment) => ResolvedCliIdArg::AnonymousSegment(segment),
             CliId::Commit { commit, .. } => ResolvedCliIdArg::Commit(commit),
             CliId::UncommittedHunkOrFile(uncommitted) => {
                 ResolvedCliIdArg::UncommittedHunkOrFile(Box::new(uncommitted))
@@ -185,6 +189,7 @@ impl CliIdArg {
         };
         match id {
             CliId::Branch(branch) => Ok(Some(BranchArg(branch.name))),
+            CliId::AnonymousSegment(segment) => Err(anonymous_segment_error(&segment.id)),
             _ => Ok(None),
         }
     }
@@ -346,6 +351,7 @@ impl CliIdArg {
     fn wrong_kind_error(&self, id: &CliId, expected: &'static str) -> CliError {
         let kind = match id {
             CliId::Branch(..) => "a branch",
+            CliId::AnonymousSegment(..) => "an anonymous branch",
             CliId::Commit { .. } => "a commit",
             CliId::UncommittedHunkOrFile(..) => "an uncommitted change",
             CliId::PathPrefix { .. } => "a path",
@@ -357,6 +363,14 @@ impl CliIdArg {
         };
         bad_input(format!("Invalid {expected}. '{self}' is {kind}")).into()
     }
+}
+
+pub(crate) fn anonymous_segment_error(id: &str) -> CliError {
+    bad_input(format!("Cannot operate on anonymous branch '{id}'"))
+        .hint(format!(
+            "Name it with `but reword {id}` first! Note that the short ID is likely to change when the branch is named."
+        ))
+        .into()
 }
 
 /// Which kinds of objects id resolution should prioritize in the event of ambiguity.
@@ -414,6 +428,7 @@ fn try_resolve_cli_id(
                 | CliId::CommittedHunk { .. }
                 | CliId::Uncommitted { .. }
                 | CliId::Worktree { .. }
+                | CliId::AnonymousSegment(..)
                 | CliId::Stack { .. } => {}
             }
         }
@@ -493,6 +508,7 @@ impl std::fmt::Display for Purpose {
 pub enum ResolvedCliIdArg {
     Commit(CommitId),
     Branch(BranchArg),
+    AnonymousSegment(AnonymousSegmentId),
     UncommittedHunkOrFile(Box<UncommittedHunkOrFile>),
     CommittedFile(CommittedFileId),
     CommittedHunk(Box<CommittedHunk>),
@@ -517,6 +533,9 @@ impl ResolvedCliIdArg {
                 return Ok(BranchOrCommit::Commit(commit));
             }
             ResolvedCliIdArg::Branch(branch) => return Ok(BranchOrCommit::Branch(branch)),
+            ResolvedCliIdArg::AnonymousSegment(segment) => {
+                return Err(anonymous_segment_error(&segment.id));
+            }
             other => other.kind_for_humans(),
         };
         Err(bad_input(format!("Expected a commit or a branch, got {kind}")).into())
@@ -526,6 +545,9 @@ impl ResolvedCliIdArg {
     pub fn into_branch_or_stack(self) -> CliResult<BranchOrStack> {
         let kind = match self {
             ResolvedCliIdArg::Branch(branch) => return Ok(BranchOrStack::Branch(branch)),
+            ResolvedCliIdArg::AnonymousSegment(segment) => {
+                return Err(anonymous_segment_error(&segment.id));
+            }
             ResolvedCliIdArg::Stack { id, stack_id } => {
                 return Ok(BranchOrStack::Stack { id, stack_id });
             }
@@ -542,6 +564,7 @@ impl ResolvedCliIdArg {
             ResolvedCliIdArg::CommittedFile { .. } => "a committed file",
             ResolvedCliIdArg::CommittedHunk { .. } => "a committed hunk",
             ResolvedCliIdArg::Branch { .. } => "a branch",
+            ResolvedCliIdArg::AnonymousSegment { .. } => "an anonymous branch",
             ResolvedCliIdArg::Commit { .. } => "a commit",
             ResolvedCliIdArg::Uncommitted => "uncommitted changes",
             ResolvedCliIdArg::Worktree(..) => "a worktree",
@@ -554,6 +577,9 @@ impl ResolvedCliIdArg {
         match self {
             ResolvedCliIdArg::Commit(commit) => ResolvedCliIdArgRef::Commit(commit.as_ref()),
             ResolvedCliIdArg::Branch(branch_arg) => ResolvedCliIdArgRef::Branch(&branch_arg.0),
+            ResolvedCliIdArg::AnonymousSegment(segment) => {
+                ResolvedCliIdArgRef::AnonymousSegment(segment)
+            }
             ResolvedCliIdArg::UncommittedHunkOrFile(hunk) => {
                 ResolvedCliIdArgRef::UncommittedHunkOrFile(hunk)
             }
@@ -592,6 +618,11 @@ impl PartialEq<CliId> for ResolvedCliIdArg {
             ResolvedCliIdArg::Branch(lhs) => {
                 if let CliId::Branch(rhs) = other {
                     return lhs.0 == rhs.name;
+                }
+            }
+            ResolvedCliIdArg::AnonymousSegment(lhs) => {
+                if let CliId::AnonymousSegment(rhs) = other {
+                    return lhs == rhs;
                 }
             }
             ResolvedCliIdArg::UncommittedHunkOrFile(lhs) => {
@@ -651,6 +682,9 @@ impl std::fmt::Display for ResolvedCliIdArg {
         match self {
             ResolvedCliIdArg::Commit(commit) => theme::Commit(commit.as_ref()).fmt(f),
             ResolvedCliIdArg::Branch(inner) => inner.fmt(f),
+            ResolvedCliIdArg::AnonymousSegment(segment) => {
+                write!(f, "anonymous branch {}", segment.id)
+            }
             ResolvedCliIdArg::UncommittedHunkOrFile(..) => f.write_str("uncommitted file or hunk"),
             ResolvedCliIdArg::PathPrefix { .. } => f.write_str("path"),
             ResolvedCliIdArg::CommittedFile(..) => f.write_str("committed file"),
@@ -668,6 +702,7 @@ impl std::fmt::Display for ResolvedCliIdArg {
 pub enum ResolvedCliIdArgRef<'a> {
     Commit(CommitIdRef<'a>),
     Branch(&'a str),
+    AnonymousSegment(&'a AnonymousSegmentId),
     UncommittedHunkOrFile(&'a UncommittedHunkOrFile),
     CommittedFile(&'a CommittedFileId),
     CommittedHunk(&'a CommittedHunk),

--- a/crates/but/src/args/mod.rs
+++ b/crates/but/src/args/mod.rs
@@ -526,12 +526,13 @@ pub enum Subcommands {
     /// This will recreate the commit with the new message and then rebase any
     /// dependent commits on top of it.
     ///
-    /// You can also use `but reword <branch-id>` to rename the branch.
+    /// You can also use `but reword <branch-id>` to rename the branch, or
+    /// `but reword <anonymous-branch-id>` to give an anonymous branch a name.
     ///
     #[cfg(feature = "legacy")]
     #[cfg_attr(feature = "raw-clap-docs", clap(verbatim_doc_comment))]
     Reword {
-        /// Commit ID to edit the message for, or branch ID to rename
+        /// Commit ID to edit, branch ID to rename, or anonymous branch ID to name
         target: CliIdArg,
         /// The new commit message or branch name. If not provided, opens an editor.
         #[clap(short = 'm', long = "message", conflicts_with = "fix_formatting")]

--- a/crates/but/src/command/comment.rs
+++ b/crates/but/src/command/comment.rs
@@ -285,6 +285,9 @@ fn resolve(ctx: &Context, args: Platform, perm: &RepoShared) -> CliResult<Commen
                     let value = commit.to_string();
                     match commit.resolve_in_workspace(&repo, &id_map, Purpose::Target, None)? {
                         ResolvedCliIdArg::Commit(commit) => Ok(commit.commit_id),
+                        ResolvedCliIdArg::AnonymousSegment(segment) => {
+                            Err(crate::args::atoms::anonymous_segment_error(&segment.id))
+                        }
                         _ => Err(bad_input("Only commits can be commented on")
                             .arg_name("--commit")
                             .arg_value(value)

--- a/crates/but/src/command/expand.rs
+++ b/crates/but/src/command/expand.rs
@@ -129,6 +129,12 @@ pub fn handle(ctx: &but_ctx::Context, cli_id: CliIdArg) -> CliResult<ExpandOutco
     let id_map = IdMap::new_from_context(ctx, guard.read_permission())?;
     let repo = ctx.repo.get()?;
     let matches = cli_id.parse(&repo, &id_map)?;
+    if let Some(segment) = matches.iter().find_map(|id| match id {
+        CliId::AnonymousSegment(segment) => Some(segment),
+        _ => None,
+    }) {
+        return Err(crate::args::atoms::anonymous_segment_error(&segment.id));
+    }
     let resources = matches
         .into_iter()
         .flat_map(resources_from_cli_id)
@@ -155,6 +161,9 @@ fn resources_from_cli_id(cli_id: CliId) -> Vec<Resource> {
             short_id: branch.id,
             name: branch.name,
         }],
+        CliId::AnonymousSegment(_) => {
+            unreachable!("anonymous segments are rejected before resource conversion")
+        }
         CliId::UncommittedHunkOrFile(uncommitted) if uncommitted.is_entire_file => {
             vec![Resource::UncommittedFile {
                 path: uncommitted.hunks.first().hunk.path.to_string(),

--- a/crates/but/src/command/legacy/amend.rs
+++ b/crates/but/src/command/legacy/amend.rs
@@ -104,6 +104,9 @@ fn resolve(
                     bad_input("--target cannot be an empty branch").into()
                 }
                 ResolveTargetError::NotFound => bad_input("target not found").hint(hint).into(),
+                ResolveTargetError::AnonymousSegment(id) => {
+                    crate::args::atoms::anonymous_segment_error(&id)
+                }
                 ResolveTargetError::UseTargetMessageUnavailable
                 | ResolveTargetError::UseSourceMessageUnavailable
                 | ResolveTargetError::NoMessageUnavailable

--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -627,6 +627,9 @@ fn route_commit_above_or_below(
             merged.ensure_branch_not_merged(name.as_ref())?;
             CommitRelativeToTarget::BranchTip { name }
         }
+        ResolvedCliIdArg::AnonymousSegment(segment) => {
+            return Err(crate::args::atoms::anonymous_segment_error(&segment.id));
+        }
         resolved => match resolved
             .into_branch_or_commit()
             .hint("Run `but status` to show applicable targets")?

--- a/crates/but/src/command/legacy/diff.rs
+++ b/crates/but/src/command/legacy/diff.rs
@@ -450,6 +450,9 @@ fn resolve(ctx: &Context, id_map: &IdMap, args: Platform) -> CliResult<DiffOpera
             let branch = branch.resolve_local_branch_name()?;
             Ok(DiffOperation::Branch { branch })
         }
+        ResolvedCliIdArg::AnonymousSegment(segment) => {
+            Err(crate::args::atoms::anonymous_segment_error(&segment.id))
+        }
         ResolvedCliIdArg::UncommittedHunkOrFile(hunk) => {
             Ok(DiffOperation::UncommittedHunkOrFile { hunk })
         }

--- a/crates/but/src/command/legacy/discard.rs
+++ b/crates/but/src/command/legacy/discard.rs
@@ -289,6 +289,9 @@ fn resolve(repo: &gix::Repository, id_map: &IdMap, args: Platform) -> CliResult<
         let value = change.to_string();
         match change.resolve_in_workspace(repo, id_map, Purpose::Source, None)? {
             ResolvedCliIdArg::Branch(branch) => branch_sources.push(branch),
+            ResolvedCliIdArg::AnonymousSegment(segment) => {
+                return Err(crate::args::atoms::anonymous_segment_error(&segment.id));
+            }
             ResolvedCliIdArg::Commit(commit) => commit_sources.push(commit),
             ResolvedCliIdArg::CommittedFile(committed_file) => {
                 committed_file_sources.push(committed_file)

--- a/crates/but/src/command/legacy/move.rs
+++ b/crates/but/src/command/legacy/move.rs
@@ -854,6 +854,9 @@ fn resolve_sources(
             ResolvedCliIdArg::Branch(branch) => {
                 branch_sources.push(branch.resolve_local_branch_name()?);
             }
+            ResolvedCliIdArg::AnonymousSegment(segment) => {
+                return Err(crate::args::atoms::anonymous_segment_error(&segment.id));
+            }
             resolved => {
                 return Err(bad_input(format!("Cannot pass {resolved} as source"))
                     .arg_value(source_str)

--- a/crates/but/src/command/legacy/pick.rs
+++ b/crates/but/src/command/legacy/pick.rs
@@ -179,6 +179,9 @@ fn resolve(
                 {
                     match resolved {
                         ResolvedCliIdArg::Commit(commit_id) => Ok(commit_id.commit_id),
+                        ResolvedCliIdArg::AnonymousSegment(segment) => {
+                            Err(crate::args::atoms::anonymous_segment_error(&segment.id))
+                        }
                         ResolvedCliIdArg::Branch(..)
                         | ResolvedCliIdArg::UncommittedHunkOrFile(..)
                         | ResolvedCliIdArg::CommittedFile(..)

--- a/crates/but/src/command/legacy/reword.rs
+++ b/crates/but/src/command/legacy/reword.rs
@@ -1,8 +1,10 @@
 use anyhow::{Result, bail};
 use bstr::{BString, ByteSlice};
 use but_api::diff::ComputeLineStats;
-use but_core::{DryRun, sync::RepoExclusive};
+use but_core::{DryRun, ref_metadata::StackId, sync::RepoExclusive};
 use but_ctx::Context;
+use but_workspace::branch::create_reference::{Anchor, Position};
+use gitbutler_oplog::entry::{OperationKind, SnapshotDetails};
 
 use super::{
     ShowDiffInEditor,
@@ -42,18 +44,43 @@ pub(crate) fn reword_target(
         let repo = ctx.repo.get()?;
         target.resolve_in_workspace(&repo, &id_map, Purpose::Target, None)?
     };
-
-    match target.into_branch_or_commit()? {
-        BranchOrCommit::Branch(BranchArg(name)) => {
+    let target = match target {
+        crate::args::atoms::ResolvedCliIdArg::AnonymousSegment(segment) => {
             if format {
-                return Err(anyhow::anyhow!(
-                    "--fix-formatting flag can only be used with commits, not branches"
+                return Err(bad_input(
+                    "--fix-formatting flag can only be used with commits, not anonymous branches",
                 )
                 .into());
             }
             if !matches!(show_diff_in_editor, ShowDiffInEditor::Unspecified) {
-                return Err(anyhow::anyhow!(
-                    "--diff and --no-diff flags can only be used with commits, not branches"
+                return Err(bad_input(
+                    "--diff and --no-diff flags can only be used with commits, not anonymous branches"
+                )
+                .into());
+            }
+            create_branch_for_anonymous_segment(
+                ctx,
+                out,
+                segment,
+                message,
+                guard.write_permission(),
+            )?;
+            return Ok(());
+        }
+        target => target,
+    };
+
+    match target.into_branch_or_commit()? {
+        BranchOrCommit::Branch(BranchArg(name)) => {
+            if format {
+                return Err(bad_input(
+                    "--fix-formatting flag can only be used with commits, not branches",
+                )
+                .into());
+            }
+            if !matches!(show_diff_in_editor, ShowDiffInEditor::Unspecified) {
+                return Err(bad_input(
+                    "--diff and --no-diff flags can only be used with commits, not branches",
                 )
                 .into());
             }
@@ -76,6 +103,58 @@ pub(crate) fn reword_target(
         }
     }
 
+    Ok(())
+}
+
+fn create_branch_for_anonymous_segment(
+    ctx: &mut Context,
+    out: &mut OutputChannel,
+    segment: crate::id::AnonymousSegmentId,
+    message: Option<&str>,
+    perm: &mut RepoExclusive,
+) -> CliResult<()> {
+    let non_validated_new_name = prepare_provided_message(message, "branch name")
+        .unwrap_or_else(|| get_branch_name_from_editor(""))?;
+    let new_ref = {
+        let (repo, ws, _db) = ctx.workspace_and_db_with_perm(perm.read_permission())?;
+        BranchArg(non_validated_new_name).resolve_for_creation(&repo, &ws)?
+    };
+
+    let cli_id = segment.id;
+    let anchor_commit_id = segment.anchor_commit_id.ok_or_else(|| {
+        bad_input(format!(
+            "Cannot name anonymous branch '{cli_id}' because it has no anchor commit"
+        ))
+    })?;
+    let snapshot_details = SnapshotDetails::new(OperationKind::CreateBranch);
+    let mut meta = ctx.meta()?;
+    let (new_ref, _ws) = but_transaction::with_transaction_with_perm(
+        ctx,
+        &mut meta,
+        perm,
+        snapshot_details,
+        DryRun::No,
+        |mut tx| {
+            tx.create_reference(
+                new_ref.as_ref(),
+                Anchor::AtCommit {
+                    commit_id: anchor_commit_id,
+                    position: Position::Above,
+                },
+                |_| StackId::generate(),
+                Some(0),
+            )?;
+            Ok(but_transaction::Commit(new_ref))
+        },
+    )?;
+
+    if let Some(out) = out.for_human() {
+        writeln!(
+            out,
+            "Named anonymous branch '{cli_id}' as '{}'",
+            new_ref.shorten()
+        )?;
+    }
     Ok(())
 }
 

--- a/crates/but/src/command/legacy/split.rs
+++ b/crates/but/src/command/legacy/split.rs
@@ -72,6 +72,9 @@ fn resolve(args: Platform, ctx: &Context, id_map: &IdMap) -> CliResult<MoveOpera
                 )?;
                 resolved_sources.push(committed_file);
             }
+            ResolvedCliIdArg::AnonymousSegment(segment) => {
+                return Err(crate::args::atoms::anonymous_segment_error(&segment.id));
+            }
             other @ (ResolvedCliIdArg::Commit(..)
             | ResolvedCliIdArg::CommittedHunk(..)
             | ResolvedCliIdArg::Branch(..)

--- a/crates/but/src/command/legacy/squash.rs
+++ b/crates/but/src/command/legacy/squash.rs
@@ -235,6 +235,9 @@ fn resolve_args(
                     ResolveTargetError::MessageUnavailable => {
                         bad_input("--message cannot be used when uncommitting").into()
                     }
+                    ResolveTargetError::AnonymousSegment(id) => {
+                        crate::args::atoms::anonymous_segment_error(&id)
+                    }
                     ResolveTargetError::InvalidTarget => bad_input(target_kind_hint)
                         .hint(CliIdArg::TARGET_MISSING_HINT)
                         .into(),
@@ -876,6 +879,9 @@ pub fn resolve_target(
 
             Ok(SquashTarget::Uncommitted)
         }
+        ResolvedCliIdArgRef::AnonymousSegment(segment) => {
+            Err(ResolveTargetError::AnonymousSegment(segment.id.clone()))
+        }
         ResolvedCliIdArgRef::UncommittedHunkOrFile(..)
         | ResolvedCliIdArgRef::CommittedFile { .. }
         | ResolvedCliIdArgRef::CommittedHunk { .. }
@@ -894,6 +900,7 @@ pub enum ResolveTargetError {
     NoMessageUnavailable,
     MessageUnavailable,
     InvalidTarget,
+    AnonymousSegment(String),
     Other(anyhow::Error),
 }
 
@@ -1071,6 +1078,9 @@ impl<'a> Squashable<'a> {
             ResolvedCliIdArgRef::Commit(commit) => return Ok(Self::Commit(commit.to_owned())),
             ResolvedCliIdArgRef::Branch(branch_name) => {
                 return Ok(Self::Branch(BranchArg(branch_name.to_owned())));
+            }
+            ResolvedCliIdArgRef::AnonymousSegment(segment) => {
+                return Err(crate::args::atoms::anonymous_segment_error(&segment.id));
             }
             ResolvedCliIdArgRef::UncommittedHunkOrFile(hunk) => {
                 return Ok(Self::UncommittedChange(

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -1651,11 +1651,15 @@ fn print_group(
             };
 
             let branch = segment.branch_name().unwrap_or(BStr::new("")).to_string();
+            let is_anonymous = segment.branch_name().is_none();
             let branch_cli_id = lookup_cli_id_for_short_id(
                 &status_ctx.id_map,
                 &repo,
                 &segment.short_id,
-                |id| matches!(id, CliId::Branch(..)),
+                |id| {
+                    matches!(id, CliId::AnonymousSegment(..)) == is_anonymous
+                        && matches!(id, CliId::Branch(..) | CliId::AnonymousSegment(..))
+                },
                 "branch",
             )?;
             let mut branch_suffix = Vec::new();

--- a/crates/but/src/command/legacy/status/tui/app/cherry_pick_mode.rs
+++ b/crates/but/src/command/legacy/status/tui/app/cherry_pick_mode.rs
@@ -158,7 +158,8 @@ impl App {
 
                     let source = match &**selection {
                         CliId::Commit { commit, .. } => CherryPickSource::Commit(commit.clone()),
-                        CliId::UncommittedHunkOrFile(..)
+                        CliId::AnonymousSegment(..)
+                        | CliId::UncommittedHunkOrFile(..)
                         | CliId::PathPrefix { .. }
                         | CliId::CommittedFile { .. }
                         | CliId::CommittedHunk { .. }
@@ -244,7 +245,8 @@ impl App {
                     }))
                 }
 
-                CliId::UncommittedHunkOrFile(..)
+                CliId::AnonymousSegment(..)
+                | CliId::UncommittedHunkOrFile(..)
                 | CliId::PathPrefix { .. }
                 | CliId::CommittedFile { .. }
                 | CliId::CommittedHunk(..)
@@ -273,7 +275,8 @@ impl App {
                     order_commits_by_parentage: true,
                 }))
             }
-            CliId::Commit { .. }
+            CliId::AnonymousSegment(..)
+            | CliId::Commit { .. }
             | CliId::UncommittedHunkOrFile(..)
             | CliId::PathPrefix { .. }
             | CliId::CommittedFile { .. }

--- a/crates/but/src/command/legacy/status/tui/app/commit_mode.rs
+++ b/crates/but/src/command/legacy/status/tui/app/commit_mode.rs
@@ -166,7 +166,8 @@ impl CommitSource {
             // A worktree heading names that checkout's uncommitted area, so it is a source in
             // exactly the way `zz` is one for the main worktree.
             CliId::Worktree { name, .. } => Some(CommitSource::Worktree(name.clone())),
-            CliId::PathPrefix { .. }
+            CliId::AnonymousSegment(..)
+            | CliId::PathPrefix { .. }
             | CliId::CommittedFile { .. }
             | CliId::CommittedHunk { .. }
             | CliId::Stack { .. } => None,
@@ -385,7 +386,8 @@ impl App {
                     name: worktree_branch(&repo, name.as_ref())?,
                 }
             }
-            CliId::UncommittedHunkOrFile(..)
+            CliId::AnonymousSegment(..)
+            | CliId::UncommittedHunkOrFile(..)
             | CliId::PathPrefix { .. }
             | CliId::CommittedFile { .. }
             | CliId::CommittedHunk { .. }
@@ -434,7 +436,8 @@ impl App {
                 },
             }),
 
-            CliId::PathPrefix { .. }
+            CliId::AnonymousSegment(..)
+            | CliId::PathPrefix { .. }
             | CliId::CommittedFile { .. }
             | CliId::CommittedHunk { .. }
             | CliId::Commit { .. }

--- a/crates/but/src/command/legacy/status/tui/app/discard.rs
+++ b/crates/but/src/command/legacy/status/tui/app/discard.rs
@@ -230,7 +230,8 @@ impl App {
                         },
                     )
                 }
-                CliId::CommittedHunk(..)
+                CliId::AnonymousSegment(..)
+                | CliId::CommittedHunk(..)
                 | CliId::Stack { .. }
                 | CliId::PathPrefix { .. }
                 | CliId::Worktree { .. } => return Ok(()),

--- a/crates/but/src/command/legacy/status/tui/app/jump_mode.rs
+++ b/crates/but/src/command/legacy/status/tui/app/jump_mode.rs
@@ -124,6 +124,7 @@ fn jump_id_has_prefix(line: &StatusOutputLine, query: &str) -> bool {
         | CliId::Worktree { id, .. }
         | CliId::Stack { id, .. } => id.starts_with(query),
         CliId::Branch(branch) => branch.id.starts_with(query),
+        CliId::AnonymousSegment(segment) => segment.id.starts_with(query),
         CliId::CommittedHunk(..) => false,
     }
 }

--- a/crates/but/src/command/legacy/status/tui/app/mark.rs
+++ b/crates/but/src/command/legacy/status/tui/app/mark.rs
@@ -697,7 +697,8 @@ impl App {
                     | Mode::Stack(..) => {}
                 }
             }
-            CliId::CommittedHunk(..)
+            CliId::AnonymousSegment(..)
+            | CliId::CommittedHunk(..)
             | CliId::PathPrefix { .. }
             | CliId::Stack { .. }
             | CliId::Worktree { .. } => {}

--- a/crates/but/src/command/legacy/status/tui/app/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/app/mod.rs
@@ -334,7 +334,8 @@ impl App {
             ResolvedCliIdArg::UncommittedHunkOrFile(hunk) if !hunk.is_entire_file => {
                 Some(CliId::UncommittedHunkOrFile((**hunk).clone()))
             }
-            ResolvedCliIdArg::Commit(..)
+            ResolvedCliIdArg::AnonymousSegment(..)
+            | ResolvedCliIdArg::Commit(..)
             | ResolvedCliIdArg::Branch(..)
             | ResolvedCliIdArg::UncommittedHunkOrFile(..)
             | ResolvedCliIdArg::CommittedFile(..)
@@ -1159,7 +1160,8 @@ impl App {
                                             CliId::UncommittedHunkOrFile(uncommitted) => {
                                                 Some(&uncommitted.hunks)
                                             }
-                                            CliId::PathPrefix { .. }
+                                            CliId::AnonymousSegment(..)
+                                            | CliId::PathPrefix { .. }
                                             | CliId::CommittedFile { .. }
                                             | CliId::CommittedHunk { .. }
                                             | CliId::Branch(..)
@@ -1207,7 +1209,8 @@ impl App {
                                 },
                             ));
                         }
-                        CliId::PathPrefix { .. }
+                        CliId::AnonymousSegment(..)
+                        | CliId::PathPrefix { .. }
                         | CliId::CommittedFile { .. }
                         | CliId::CommittedHunk { .. }
                         | CliId::Branch(..)
@@ -1592,7 +1595,8 @@ impl App {
                 uncommitted.hunks.first().hunk.path.to_str_lossy()
             }
             CliId::Worktree { name, .. } => name.to_str_lossy(),
-            CliId::CommittedHunk(..)
+            CliId::AnonymousSegment(..)
+            | CliId::CommittedHunk(..)
             | CliId::PathPrefix { .. }
             | CliId::Uncommitted { .. }
             | CliId::Stack { .. } => return Ok(()),
@@ -1646,7 +1650,8 @@ impl App {
             CliId::Worktree { id, name } => {
                 copy_selection_picker::worktree_picker(name.to_owned(), id.to_owned(), self.theme)
             }
-            CliId::CommittedHunk(..)
+            CliId::AnonymousSegment(..)
+            | CliId::CommittedHunk(..)
             | CliId::PathPrefix { .. }
             | CliId::Uncommitted { .. }
             | CliId::Stack { .. } => return Ok(()),
@@ -1682,7 +1687,8 @@ impl App {
                         committed_file: CommittedFileId { path, .. },
                         id: _,
                     } => Openable::try_from_relpath(&*ctx.repo.get()?, path.as_bstr()).map(Some),
-                    CliId::CommittedHunk(..)
+                    CliId::AnonymousSegment(..)
+                    | CliId::CommittedHunk(..)
                     | CliId::Commit { .. }
                     | CliId::Branch(_)
                     | CliId::PathPrefix { .. }

--- a/crates/but/src/command/legacy/status/tui/app/move_mode.rs
+++ b/crates/but/src/command/legacy/status/tui/app/move_mode.rs
@@ -151,7 +151,8 @@ impl MoveSource {
         match id {
             CliId::Branch(branch) => Some(Self::Branch(branch.clone())),
             CliId::Commit { commit, .. } => Some(Self::Commit(commit.clone())),
-            CliId::UncommittedHunkOrFile(..)
+            CliId::AnonymousSegment(..)
+            | CliId::UncommittedHunkOrFile(..)
             | CliId::PathPrefix { .. }
             | CliId::CommittedFile { .. }
             | CliId::CommittedHunk { .. }

--- a/crates/but/src/command/legacy/status/tui/app/reword.rs
+++ b/crates/but/src/command/legacy/status/tui/app/reword.rs
@@ -163,7 +163,8 @@ impl App {
                     textarea: Box::new(textarea),
                 }
             }
-            CliId::UncommittedHunkOrFile(..)
+            CliId::AnonymousSegment(..)
+            | CliId::UncommittedHunkOrFile(..)
             | CliId::PathPrefix { .. }
             | CliId::CommittedFile { .. }
             | CliId::CommittedHunk { .. }

--- a/crates/but/src/command/legacy/status/tui/app/squash_mode.rs
+++ b/crates/but/src/command/legacy/status/tui/app/squash_mode.rs
@@ -426,7 +426,8 @@ impl App {
             } => {
                 self.squash_start_with_source(SquashSource::CommittedFile(committed_file.clone()));
             }
-            CliId::CommittedHunk(..)
+            CliId::AnonymousSegment(..)
+            | CliId::CommittedHunk(..)
             | CliId::PathPrefix { .. }
             | CliId::Stack { .. }
             | CliId::Worktree { .. } => {}

--- a/crates/but/src/command/legacy/status/tui/app/stack_mode.rs
+++ b/crates/but/src/command/legacy/status/tui/app/stack_mode.rs
@@ -105,7 +105,8 @@ impl ReorderStackSource {
     pub fn matches(&self, id: &CliId) -> bool {
         match id {
             CliId::Branch(branch) => self.branch == *branch,
-            CliId::Stack { .. }
+            CliId::AnonymousSegment(..)
+            | CliId::Stack { .. }
             | CliId::UncommittedHunkOrFile(..)
             | CliId::PathPrefix { .. }
             | CliId::CommittedFile { .. }
@@ -241,7 +242,8 @@ fn stack_id_for_cli_id(cli_id: &CliId, status_lines: &[StatusOutputLine]) -> Opt
             id: _,
         } => other.commit_id == *commit_id,
         CliId::Commit { commit, id: _ } => other == commit,
-        CliId::UncommittedHunkOrFile(..)
+        CliId::AnonymousSegment(..)
+        | CliId::UncommittedHunkOrFile(..)
         | CliId::PathPrefix { .. }
         | CliId::Branch(..)
         | CliId::Uncommitted { .. }
@@ -257,7 +259,8 @@ fn stack_id_for_cli_id(cli_id: &CliId, status_lines: &[StatusOutputLine]) -> Opt
                     cli_id, stack_id, ..
                 } => match &**cli_id {
                     CliId::Commit { commit, id: _ } if commit_matches(commit) => *stack_id,
-                    CliId::UncommittedHunkOrFile(..)
+                    CliId::AnonymousSegment(..)
+                    | CliId::UncommittedHunkOrFile(..)
                     | CliId::PathPrefix { .. }
                     | CliId::CommittedFile { .. }
                     | CliId::CommittedHunk { .. }
@@ -287,6 +290,7 @@ fn stack_id_for_cli_id(cli_id: &CliId, status_lines: &[StatusOutputLine]) -> Opt
             })
         }
         CliId::Branch(branch) => branch.stack_id,
+        CliId::AnonymousSegment(segment) => segment.stack_id,
         CliId::Stack { stack_id, .. } => Some(*stack_id),
         CliId::UncommittedHunkOrFile(..)
         | CliId::PathPrefix { .. }
@@ -466,7 +470,8 @@ impl App {
                 };
                 (stack_id, &branch.name)
             }
-            CliId::UncommittedHunkOrFile(..)
+            CliId::AnonymousSegment(..)
+            | CliId::UncommittedHunkOrFile(..)
             | CliId::PathPrefix { .. }
             | CliId::CommittedFile { .. }
             | CliId::CommittedHunk { .. }
@@ -753,7 +758,8 @@ fn row_stack_ids(lines: &[StatusOutputLine]) -> Vec<Option<StackId>> {
                     stack_id
                 }
                 CliId::UncommittedHunkOrFile(..) | CliId::PathPrefix { .. } => current_stack_id,
-                CliId::Branch(..)
+                CliId::AnonymousSegment(..)
+                | CliId::Branch(..)
                 | CliId::Commit { .. }
                 | CliId::Uncommitted { .. }
                 | CliId::Worktree { .. }
@@ -802,6 +808,7 @@ fn row_stack_ids(lines: &[StatusOutputLine]) -> Vec<Option<StackId>> {
 fn stack_id_from_cli_id(cli_id: &CliId) -> Option<StackId> {
     match cli_id {
         CliId::Branch(branch) => branch.stack_id,
+        CliId::AnonymousSegment(segment) => segment.stack_id,
         CliId::Stack { stack_id, .. } => Some(*stack_id),
         CliId::UncommittedHunkOrFile(..)
         | CliId::PathPrefix { .. }

--- a/crates/but/src/command/legacy/status/tui/cursor/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/cursor/mod.rs
@@ -86,7 +86,8 @@ impl Cursor {
     ) -> CliResult<Option<Self>> {
         let hint = "`TARGET` can be a commit, branch, committed file, uncommitted file, or uncommitted hunk";
         match &target {
-            ResolvedCliIdArg::Commit(..)
+            ResolvedCliIdArg::AnonymousSegment(..)
+            | ResolvedCliIdArg::Commit(..)
             | ResolvedCliIdArg::Branch(..)
             | ResolvedCliIdArg::Worktree(..)
             | ResolvedCliIdArg::Uncommitted
@@ -114,7 +115,8 @@ impl Cursor {
                 ResolvedCliIdArg::UncommittedHunkOrFile(hunk) if !hunk.is_entire_file => {
                     match &**cli_id {
                         CliId::UncommittedHunkOrFile(file) => hunk_is_child_of(file, hunk),
-                        CliId::PathPrefix { .. }
+                        CliId::AnonymousSegment(..)
+                        | CliId::PathPrefix { .. }
                         | CliId::CommittedFile { .. }
                         | CliId::CommittedHunk { .. }
                         | CliId::Branch(..)
@@ -124,7 +126,8 @@ impl Cursor {
                         | CliId::Stack { .. } => false,
                     }
                 }
-                ResolvedCliIdArg::Commit(..)
+                ResolvedCliIdArg::AnonymousSegment(..)
+                | ResolvedCliIdArg::Commit(..)
                 | ResolvedCliIdArg::Branch(..)
                 | ResolvedCliIdArg::UncommittedHunkOrFile(..)
                 | ResolvedCliIdArg::CommittedFile(..)
@@ -469,7 +472,8 @@ impl Cursor {
                     committed_file: CommittedFileId { commit_id, .. },
                     id: _,
                 }) => show_files.show_files_for(*commit_id),
-                Some(CliId::UncommittedHunkOrFile(..))
+                Some(CliId::AnonymousSegment(..))
+                | Some(CliId::UncommittedHunkOrFile(..))
                 | Some(CliId::PathPrefix { .. })
                 | Some(CliId::Branch(..))
                 | Some(CliId::Commit { .. })
@@ -1026,6 +1030,9 @@ pub(super) fn same_entity_for_reload(previous: &CliId, current: &CliId) -> bool 
             }
         }
         CliId::CommittedHunk(..) => false,
+        CliId::AnonymousSegment(previous) => {
+            matches!(current, CliId::AnonymousSegment(current) if previous == current)
+        }
         CliId::Branch(previous) => {
             if let CliId::Branch(current) = current {
                 previous == current
@@ -1102,7 +1109,8 @@ fn select_after_reload_for_cli_id(cli_id: &Arc<CliId>) -> SelectAfterReload {
             committed_file: CommittedFileId { commit_id, .. },
             id: _,
         } => SelectAfterReload::FirstFileInCommit(*commit_id),
-        CliId::CommittedHunk(..)
+        CliId::AnonymousSegment(..)
+        | CliId::CommittedHunk(..)
         | CliId::Uncommitted { .. }
         | CliId::UncommittedHunkOrFile(..)
         | CliId::PathPrefix { .. }
@@ -1373,7 +1381,8 @@ pub fn is_selectable_in_mode(
             if let Some(cli_id) = line.data.cli_id() {
                 match &**cli_id {
                     CliId::UncommittedHunkOrFile(..) | CliId::Uncommitted { .. } => true,
-                    CliId::PathPrefix { .. }
+                    CliId::AnonymousSegment(..)
+                    | CliId::PathPrefix { .. }
                     | CliId::CommittedFile { .. }
                     | CliId::CommittedHunk { .. }
                     | CliId::Branch(..)

--- a/crates/but/src/command/legacy/status/tui/cursor/tests.rs
+++ b/crates/but/src/command/legacy/status/tui/cursor/tests.rs
@@ -145,7 +145,8 @@ fn uncommitted_source(cli_ids: &[Arc<CliId>]) -> CommitSource {
             CliId::UncommittedHunkOrFile(uncommitted) => {
                 CommitSource::UncommittedHunk(uncommitted.clone())
             }
-            CliId::Uncommitted { .. }
+            CliId::AnonymousSegment(..)
+            | CliId::Uncommitted { .. }
             | CliId::PathPrefix { .. }
             | CliId::CommittedFile { .. }
             | CliId::CommittedHunk { .. }

--- a/crates/but/src/command/legacy/status/tui/details.rs
+++ b/crates/but/src/command/legacy/status/tui/details.rs
@@ -381,6 +381,10 @@ impl Details {
                     },
                 )
             }
+            CliId::AnonymousSegment(..) => {
+                self.diff_not_supported("(anonymous branches must be named with `but reword` before viewing their diff)");
+                Ok(true)
+            }
             CliId::Stack { .. } => {
                 self.diff_not_supported("(viewing diffs for stacks is not supported)");
                 Ok(true)
@@ -1261,7 +1265,8 @@ impl Details {
         };
         match status_selection {
             CliId::UncommittedHunkOrFile(..) | CliId::Uncommitted { .. } => true,
-            CliId::PathPrefix { .. }
+            CliId::AnonymousSegment(..)
+            | CliId::PathPrefix { .. }
             | CliId::CommittedFile { .. }
             | CliId::CommittedHunk { .. }
             | CliId::Branch(..)

--- a/crates/but/src/command/legacy/status/tui/file_browser.rs
+++ b/crates/but/src/command/legacy/status/tui/file_browser.rs
@@ -63,7 +63,8 @@ impl FileBrowser {
             .into_iter()
             .map(|change| change.path_bytes.to_vec().into_path_buf_lossy())
             .collect::<Vec<_>>(),
-            CliId::UncommittedHunkOrFile(..)
+            CliId::AnonymousSegment(..)
+            | CliId::UncommittedHunkOrFile(..)
             | CliId::PathPrefix { .. }
             | CliId::CommittedFile { .. }
             | CliId::CommittedHunk { .. }

--- a/crates/but/src/command/legacy/status/tui/key_bind/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/key_bind/mod.rs
@@ -1587,7 +1587,8 @@ impl KeyBindCondition {
                 };
                 match selection {
                     CliId::UncommittedHunkOrFile(..) | CliId::Uncommitted { .. } => true,
-                    CliId::PathPrefix { .. }
+                    CliId::AnonymousSegment(..)
+                    | CliId::PathPrefix { .. }
                     | CliId::CommittedFile { .. }
                     | CliId::CommittedHunk { .. }
                     | CliId::Branch(..)

--- a/crates/but/src/command/legacy/status/tui/remember_selection.rs
+++ b/crates/but/src/command/legacy/status/tui/remember_selection.rs
@@ -74,6 +74,12 @@ fn line_id(id: &CliId) -> Option<String> {
             format!("hunk:{}", hunk.hunks.head.hunk.path)
         }
         CliId::Branch(branch) => format!("branch:{}", branch.name),
+        CliId::AnonymousSegment(segment) => format!(
+            "anonymous:{}",
+            segment
+                .anchor_commit_id
+                .map_or_else(|| segment.id.clone(), |id| id.to_string())
+        ),
         CliId::CommittedFile {
             committed_file:
                 CommittedFileId {

--- a/crates/but/src/command/legacy/status/tui/tests/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/mod.rs
@@ -1352,7 +1352,8 @@ fn open_tui_on_uncommitted_hunk(show_diff: bool) -> TestTui<App> {
             .into_iter()
             .find_map(|cli_id| match cli_id {
                 CliId::UncommittedHunkOrFile(file) if file.is_entire_file => Some(file),
-                CliId::UncommittedHunkOrFile(..)
+                CliId::AnonymousSegment(..)
+                | CliId::UncommittedHunkOrFile(..)
                 | CliId::PathPrefix { .. }
                 | CliId::CommittedFile { .. }
                 | CliId::CommittedHunk { .. }

--- a/crates/but/src/command/open.rs
+++ b/crates/but/src/command/open.rs
@@ -205,6 +205,9 @@ fn resolve_source(
         ResolvedCliIdArg::UncommittedHunkOrFile(uncommitted) => {
             Ok(Openable::try_from_uncommitted(repo, &uncommitted)?)
         }
+        ResolvedCliIdArg::AnonymousSegment(segment) => {
+            Err(crate::args::atoms::anonymous_segment_error(&segment.id))
+        }
         resolved_id => Err(unexpected_source_kind(resolved_id)),
     }
 }
@@ -230,6 +233,9 @@ fn resolve_file_source(
                     unreachable!("entire-file source must resolve to one file")
                 }
             }
+        }
+        ResolvedCliIdArg::AnonymousSegment(segment) => {
+            Err(crate::args::atoms::anonymous_segment_error(&segment.id))
         }
         resolved_id => Err(unexpected_source_kind(resolved_id)),
     }

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -661,11 +661,21 @@ impl<'a> Node<'a> for &'a SegmentWithId {
         _short_id: &str,
         _id_map: &IdMap,
     ) -> anyhow::Result<Option<CliId>> {
-        Ok(Some(CliId::Branch(BranchId {
-            name: self.branch_name().unwrap_or_default().to_string(),
-            id: self.short_id.clone(),
-            stack_id: self.stack_id,
-        })))
+        Ok(Some(match self.branch_name() {
+            Some(name) => CliId::Branch(BranchId {
+                name: name.to_string(),
+                id: self.short_id.clone(),
+                stack_id: self.stack_id,
+            }),
+            None => CliId::AnonymousSegment(AnonymousSegmentId {
+                id: self.short_id.clone(),
+                stack_id: self.stack_id,
+                anchor_commit_id: self
+                    .workspace_commits
+                    .first()
+                    .map(WorkspaceCommitWithId::commit_id),
+            }),
+        }))
     }
 }
 
@@ -1781,6 +1791,7 @@ fn cli_ids_refer_to_same_entity(lhs: &CliId, rhs: &CliId) -> bool {
         ) => l == r,
         (CliId::CommittedHunk(l), CliId::CommittedHunk(r)) => l == r,
         (CliId::Branch(l), CliId::Branch(r)) => l == r,
+        (CliId::AnonymousSegment(l), CliId::AnonymousSegment(r)) => l == r,
         (
             CliId::Stack {
                 stack_id: lhs_stack_id,
@@ -1917,6 +1928,8 @@ pub enum CliId {
     CommittedHunk(CommittedHunk),
     /// A branch.
     Branch(BranchId),
+    /// A segment in workspace metadata without a corresponding branch reference.
+    AnonymousSegment(AnonymousSegmentId),
     /// A commit in the workspace identified by its SHA.
     Commit {
         /// The commit identifier.
@@ -1965,6 +1978,7 @@ impl PartialEq for CliId {
             ) => l == r,
             (CliId::CommittedHunk(l), CliId::CommittedHunk(r)) => l == r,
             (Self::Branch(l), Self::Branch(r)) => l == r,
+            (Self::AnonymousSegment(l), Self::AnonymousSegment(r)) => l == r,
             (Self::Commit { commit: l, id: _ }, Self::Commit { commit: r, id: _ }) => l == r,
             (Self::Stack { id: l_id, .. }, Self::Stack { id: r_id, .. }) => l_id == r_id,
             (Self::Uncommitted { .. }, Self::Uncommitted { .. }) => true,
@@ -1986,6 +2000,7 @@ impl CliId {
             CliId::CommittedFile { .. } => "a committed file",
             CliId::CommittedHunk { .. } => "a committed file or hunk",
             CliId::Branch(..) => "a branch",
+            CliId::AnonymousSegment(..) => "an anonymous branch",
             CliId::Commit { .. } => "a commit",
             CliId::Uncommitted { .. } => "the uncommitted area",
             CliId::Worktree { .. } => "a worktree",
@@ -2001,6 +2016,7 @@ impl CliId {
             | CliId::CommittedFile { id, .. }
             | CliId::CommittedHunk(CommittedHunk { id, .. })
             | CliId::Branch(BranchId { id, .. })
+            | CliId::AnonymousSegment(AnonymousSegmentId { id, .. })
             | CliId::Commit { id, .. }
             | CliId::Stack { id, .. }
             | CliId::Worktree { id, .. }
@@ -2011,7 +2027,8 @@ impl CliId {
     /// Get the stack id, if any.
     pub fn stack_id(&self) -> Option<StackId> {
         match self {
-            CliId::Branch(BranchId { stack_id, .. }) => *stack_id,
+            CliId::Branch(BranchId { stack_id, .. })
+            | CliId::AnonymousSegment(AnonymousSegmentId { stack_id, .. }) => *stack_id,
             CliId::Stack { stack_id, .. } => Some(*stack_id),
             CliId::PathPrefix { .. }
             | CliId::UncommittedHunkOrFile(..)
@@ -2224,6 +2241,28 @@ impl PartialEq for CommittedFileIdRef<'_> {
             change_id: _,
         } = self;
         *commit_id == other.commit_id && path == &other.path
+    }
+}
+
+/// CLI identity and naming anchor for a segment without a branch reference.
+#[derive(Debug, Clone, Eq)]
+pub struct AnonymousSegmentId {
+    /// Short CLI ID displayed by status.
+    pub id: ShortId,
+    /// Stack containing this segment, when backed by workspace metadata.
+    pub stack_id: Option<StackId>,
+    /// Top commit where a branch can be created to name this segment.
+    pub anchor_commit_id: Option<gix::ObjectId>,
+}
+
+impl PartialEq for AnonymousSegmentId {
+    fn eq(&self, other: &Self) -> bool {
+        self.stack_id == other.stack_id
+            && match (self.anchor_commit_id, other.anchor_commit_id) {
+                (Some(lhs), Some(rhs)) => lhs == rhs,
+                (None, None) => self.id == other.id,
+                (Some(_), None) | (None, Some(_)) => false,
+            }
     }
 }
 

--- a/crates/but/src/id/tests.rs
+++ b/crates/but/src/id/tests.rs
@@ -1241,10 +1241,10 @@ worktrees: [ or worktree-01 ]
     Ok(())
 }
 
-/// Generated IDs for named and anonymous branch segments remain reserved when
-/// worktree IDs are allocated later.
+/// Generated IDs for named and anonymous segments remain reserved when worktree IDs are allocated
+/// later, while retaining their distinct CLI ID kinds.
 #[test]
-fn generated_branch_ids_do_not_collide_with_worktree_names() -> anyhow::Result<()> {
+fn generated_segment_ids_do_not_collide_with_worktree_names() -> anyhow::Result<()> {
     let mut anonymous_segment = segment("unused", [], None, []);
     anonymous_segment.ref_info = None;
     let id_map = IdMap::new(
@@ -1281,6 +1281,29 @@ fn generated_branch_ids_do_not_collide_with_worktree_names() -> anyhow::Result<(
      -> anyhow::Result<Vec<but_core::TreeChange>> {
         bail!("unexpected IDs {commit_id} {parent_id:?}");
     };
+    let segment_ids = branch_ids
+        .iter()
+        .map(|id| id_map.parse(id, &TestChanges(changed_paths_fn)))
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    assert_eq!(
+        segment_ids
+            .iter()
+            .flatten()
+            .filter(|id| matches!(id, CliId::Branch(_)))
+            .count(),
+        1,
+        "named segment resolves as branch"
+    );
+    assert_eq!(
+        segment_ids
+            .iter()
+            .flatten()
+            .filter(|id| matches!(id, CliId::AnonymousSegment(_)))
+            .count(),
+        1,
+        "anonymous segment resolves as its own CLI ID kind"
+    );
+
     for worktree in id_map.worktrees.values() {
         assert_eq!(
             id_map.parse(&worktree.short_id, &TestChanges(changed_paths_fn))?,

--- a/crates/but/src/utils/diff_rendering.rs
+++ b/crates/but/src/utils/diff_rendering.rs
@@ -1533,7 +1533,8 @@ mod tests {
                     ..
                 } => match &**cli_id {
                     CliId::UncommittedHunkOrFile(hunk) => Some(hunk.id.as_str()),
-                    CliId::PathPrefix { .. }
+                    CliId::AnonymousSegment(..)
+                    | CliId::PathPrefix { .. }
                     | CliId::CommittedFile { .. }
                     | CliId::CommittedHunk { .. }
                     | CliId::Branch(..)

--- a/crates/but/src/utils/diff_specs.rs
+++ b/crates/but/src/utils/diff_specs.rs
@@ -4,6 +4,7 @@ use but_core::{DiffSpec, HunkHeader};
 
 use crate::{
     CliId,
+    args::atoms::anonymous_segment_error,
     id::{CommitId, CommittedFileId, IdAndHunk, UncommittedHunkOrFile},
     utils::change_source::{ChangeSourceId, ChangeSourceRepo},
 };
@@ -69,6 +70,9 @@ impl<'a> DiffSpecBuilder<'a> {
             } => self.push_changes_from_committed_file(*commit_id, path.as_ref()),
             CliId::Branch(branch) => {
                 anyhow::bail!("Cannot compute diff specs for branch `{}`", branch.name)
+            }
+            CliId::AnonymousSegment(segment) => {
+                anyhow::bail!("{}", anonymous_segment_error(&segment.id))
             }
             CliId::Commit {
                 commit:

--- a/crates/but/tests/but/command/amend.rs
+++ b/crates/but/tests/but/command/amend.rs
@@ -8,6 +8,25 @@ use crate::{
     utils::Sandbox,
 };
 
+#[test]
+fn rejects_unnamed_segment_as_target() {
+    let env =
+        Sandbox::init_scenario_with_target_and_default_settings("one-stack-anonymous-segment");
+    env.setup_metadata(&["A"]);
+    env.file("new.txt", "content\n");
+
+    env.but("amend -t g0")
+        .assert()
+        .failure()
+        .stdout_eq(str![])
+        .stderr_eq(str![[r#"
+Error: Cannot operate on anonymous branch 'g0'
+
+Hint: Name it with `but reword g0` first! Note that the short ID is likely to change when the branch is named.
+
+"#]]);
+}
+
 fn uncommitted_contains_file(status: &serde_json::Value, file_path: &str) -> bool {
     status["uncommittedChanges"]
         .as_array()

--- a/crates/but/tests/but/command/branch/new.rs
+++ b/crates/but/tests/but/command/branch/new.rs
@@ -3,6 +3,26 @@ use snapbox::str;
 use crate::utils::{CommandExt, Sandbox};
 
 #[test]
+fn rejects_unnamed_segment_as_anchor() {
+    let env =
+        Sandbox::init_scenario_with_target_and_default_settings("one-stack-anonymous-segment");
+    env.setup_metadata(&["A"]);
+
+    for command in ["branch new recovered -A g0", "branch new recovered -B g0"] {
+        env.but(command)
+            .assert()
+            .failure()
+            .stdout_eq(str![])
+            .stderr_eq(str![[r#"
+Error: Cannot operate on anonymous branch 'g0'
+
+Hint: Name it with `but reword g0` first! Note that the short ID is likely to change when the branch is named.
+
+"#]]);
+    }
+}
+
+#[test]
 fn outputs_branch_name() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
     snapbox::assert_data_eq!(

--- a/crates/but/tests/but/command/branch/unapply.rs
+++ b/crates/but/tests/but/command/branch/unapply.rs
@@ -18,9 +18,9 @@ fn anonymous_segment_reports_recovery_workflow() {
         .assert()
         .failure()
         .stderr_eq(str![[r#"
-Error: Cannot unapply segment 'g0' because it has no branch reference
+Error: Cannot operate on anonymous branch 'g0'
 
-Hint: Run `but branch new <name> --above <commit-id>` with the segment's top commit ID from `but status`, then run `but unapply <name>`.
+Hint: Name it with `but reword g0` first! Note that the short ID is likely to change when the branch is named.
 
 "#]])
         .stdout_eq(str![]);

--- a/crates/but/tests/but/command/commit.rs
+++ b/crates/but/tests/but/command/commit.rs
@@ -4,6 +4,31 @@ use super::util::{
 use crate::utils::{CommandExt as _, Sandbox};
 
 #[test]
+fn rejects_unnamed_segment_as_target() {
+    let env =
+        Sandbox::init_scenario_with_target_and_default_settings("one-stack-anonymous-segment");
+    env.setup_metadata(&["A"]);
+    env.file("new.txt", "content\n");
+
+    for command in [
+        "commit -b g0 -m test",
+        "commit -A g0 -m test",
+        "commit -B g0 -m test",
+    ] {
+        env.but(command)
+            .assert()
+            .failure()
+            .stdout_eq(snapbox::str![])
+            .stderr_eq(snapbox::str![[r#"
+Error: Cannot operate on anonymous branch 'g0'
+
+Hint: Name it with `but reword g0` first! Note that the short ID is likely to change when the branch is named.
+
+"#]]);
+    }
+}
+
+#[test]
 fn commits_a_dirty_file_on_a_new_branch_in_single_branch_mode() {
     let env = Sandbox::open_with_default_settings("one-fork");
     env.but("config feature single-branch enable")

--- a/crates/but/tests/but/command/diff.rs
+++ b/crates/but/tests/but/command/diff.rs
@@ -6,6 +6,24 @@ use crate::{
 };
 
 #[test]
+fn rejects_unnamed_segment_as_target() {
+    let env =
+        Sandbox::init_scenario_with_target_and_default_settings("one-stack-anonymous-segment");
+    env.setup_metadata(&["A"]);
+
+    env.but("diff g0")
+        .assert()
+        .failure()
+        .stdout_eq(snapbox::str![])
+        .stderr_eq(snapbox::str![[r#"
+Error: Cannot operate on anonymous branch 'g0'
+
+Hint: Name it with `but reword g0` first! Note that the short ID is likely to change when the branch is named.
+
+"#]]);
+}
+
+#[test]
 fn uncommitted() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
     env.setup_metadata(&[]);

--- a/crates/but/tests/but/command/discard.rs
+++ b/crates/but/tests/but/command/discard.rs
@@ -6,6 +6,24 @@ use crate::{
 };
 
 #[test]
+fn rejects_unnamed_segment_as_source() {
+    let env =
+        Sandbox::init_scenario_with_target_and_default_settings("one-stack-anonymous-segment");
+    env.setup_metadata(&["A"]);
+
+    env.but("discard g0")
+        .assert()
+        .failure()
+        .stdout_eq(snapbox::str![])
+        .stderr_eq(snapbox::str![[r#"
+Error: Cannot operate on anonymous branch 'g0'
+
+Hint: Name it with `but reword g0` first! Note that the short ID is likely to change when the branch is named.
+
+"#]]);
+}
+
+#[test]
 fn discard_removes_selected_change() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
     env.setup_metadata(&["A"]);

--- a/crates/but/tests/but/command/move.rs
+++ b/crates/but/tests/but/command/move.rs
@@ -9,6 +9,26 @@ use crate::{
 };
 
 #[test]
+fn rejects_unnamed_segment_as_source_or_target() {
+    let env =
+        Sandbox::init_scenario_with_target_and_default_settings("one-stack-anonymous-segment");
+    env.setup_metadata(&["A"]);
+
+    for command in ["move g0 -A tpm", "move tpm -A g0", "move tpm -B g0"] {
+        env.but(command)
+            .assert()
+            .failure()
+            .stdout_eq(snapbox::str![])
+            .stderr_eq(snapbox::str![[r#"
+Error: Cannot operate on anonymous branch 'g0'
+
+Hint: Name it with `but reword g0` first! Note that the short ID is likely to change when the branch is named.
+
+"#]]);
+    }
+}
+
+#[test]
 fn move_commits_outputs_json() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack-two-commits");
     env.setup_metadata(&["A"]);

--- a/crates/but/tests/but/command/pick.rs
+++ b/crates/but/tests/but/command/pick.rs
@@ -3,6 +3,26 @@ use snapbox::str;
 use crate::utils::{CommandExt as _, Sandbox};
 
 #[test]
+fn rejects_unnamed_segment_as_source_or_target() {
+    let env =
+        Sandbox::init_scenario_with_target_and_default_settings("one-stack-anonymous-segment");
+    env.setup_metadata(&["A"]);
+
+    for command in ["pick g0 -A tpm", "pick tpm -A g0", "pick tpm -B g0"] {
+        env.but(command)
+            .assert()
+            .failure()
+            .stdout_eq(str![])
+            .stderr_eq(str![[r#"
+Error: Cannot operate on anonymous branch 'g0'
+
+Hint: Name it with `but reword g0` first! Note that the short ID is likely to change when the branch is named.
+
+"#]]);
+    }
+}
+
+#[test]
 fn pick_commit_to_existing_branch_outputs_json() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
     env.setup_metadata(&["A", "B"]);

--- a/crates/but/tests/but/command/reword.rs
+++ b/crates/but/tests/but/command/reword.rs
@@ -4,6 +4,85 @@ use snapbox::str;
 use crate::utils::Sandbox;
 
 #[test]
+fn names_an_anonymous_segment() {
+    let env =
+        Sandbox::init_scenario_with_target_and_default_settings("one-stack-anonymous-segment");
+    env.setup_metadata(&["A"]);
+    let anonymous_tip = env.invoke_git("rev-parse gitbutler/workspace^");
+
+    env.but("reword g0 -m recovered")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+Named anonymous branch 'g0' as 'recovered'
+
+"#]]);
+
+    assert_eq!(
+        env.invoke_git("rev-parse recovered"),
+        anonymous_tip,
+        "new branch reference names the anonymous segment tip"
+    );
+    env.but("status").assert().success().stdout_eq(str![[r#"
+╭┄ zz [uncommitted] (no changes)
+┊
+┊╭┄ re [recovered]
+┊●   sxu anonymous (no changes)
+┊│
+┊├┄ g0 [A]
+┊●   tpm add A
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn rejects_naming_an_anonymous_segment_after_an_existing_branch() {
+    let env =
+        Sandbox::init_scenario_with_target_and_default_settings("one-stack-anonymous-segment");
+    env.setup_metadata(&["A"]);
+
+    env.but("reword g0 -m A")
+        .assert()
+        .failure()
+        .stdout_eq(str![])
+        .stderr_eq(str![[r#"
+Error: A branch named 'A' is already applied
+
+"#]]);
+}
+
+#[test]
+fn names_an_anonymous_segment_from_editor() {
+    let env =
+        Sandbox::init_scenario_with_target_and_default_settings("one-stack-anonymous-segment");
+    env.setup_metadata(&["A"]);
+    env.file(
+        "editor.sh",
+        "#!/usr/bin/env bash\nprintf 'from-editor\\n' > \"$1\"\n",
+    );
+
+    env.but("reword g0")
+        .env("GIT_EDITOR", "bash editor.sh")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Named anonymous branch 'g0' as 'from-editor'
+
+"#]]);
+    assert_eq!(
+        env.invoke_git("rev-parse from-editor"),
+        env.invoke_git("rev-parse gitbutler/workspace^"),
+        "editor-provided name creates a reference at the segment tip"
+    );
+}
+
+#[test]
 fn reword_commit_with_message_flag() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
     snapbox::assert_data_eq!(

--- a/crates/but/tests/but/command/squash.rs
+++ b/crates/but/tests/but/command/squash.rs
@@ -9,6 +9,26 @@ use crate::{
     utils::{CommandExt, Sandbox},
 };
 
+#[test]
+fn rejects_unnamed_segment_as_source_or_target() {
+    let env =
+        Sandbox::init_scenario_with_target_and_default_settings("one-stack-anonymous-segment");
+    env.setup_metadata(&["A"]);
+
+    for command in ["squash g0 -m test", "squash tpm -t g0 -m test"] {
+        env.but(command)
+            .assert()
+            .failure()
+            .stdout_eq(str![])
+            .stderr_eq(str![[r#"
+Error: Cannot operate on anonymous branch 'g0'
+
+Hint: Name it with `but reword g0` first! Note that the short ID is likely to change when the branch is named.
+
+"#]]);
+    }
+}
+
 fn one_branch_three_commits() -> Sandbox {
     let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
     env.setup_metadata(&[]);

--- a/crates/but/tests/but/command/uncommit.rs
+++ b/crates/but/tests/but/command/uncommit.rs
@@ -13,6 +13,24 @@ use crate::{
     utils::{CommandExt, Sandbox},
 };
 
+#[test]
+fn rejects_unnamed_segment_as_source() {
+    let env =
+        Sandbox::init_scenario_with_target_and_default_settings("one-stack-anonymous-segment");
+    env.setup_metadata(&["A"]);
+
+    env.but("uncommit g0")
+        .assert()
+        .failure()
+        .stdout_eq(str![])
+        .stderr_eq(str![[r#"
+Error: Cannot operate on anonymous branch 'g0'
+
+Hint: Name it with `but reword g0` first! Note that the short ID is likely to change when the branch is named.
+
+"#]]);
+}
+
 /// Return the committed-file CLI id (e.g. `e8:nk`) for `file_path` in the commit
 /// at `commit_index` (newest-first) on `branch_name`.
 fn committed_file_id_in_commit(


### PR DESCRIPTION
We don't really know to what extent we want to support anonymous segments. This PR adds a guided escape hatch to when you end up with an anonymous segment s.t. the user is told to first name it with `but reword`.

Two important notes:

* This does _not_ port the functionality to the `_reword2` command, which is necessary to also incorporate this escape hatch into the TUI. @davidpdrsn Would you like me to do that, too, and allow the TUI to fixup anonymous segments?
* User-facing messages added in this PR do not say "anonymous segment", but rather talk about "anonymous branches". We haven't really landed on what user facing terminology to use, but I think "segment" is a word we should stay well clear of. The internal representations are called anonymous segments as that more closely matches the current model.

Fixes #15596

Replaces #15603, #15604