### PR TITLE
`gix` upgrade for SHA-256 signing support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,7 +183,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -207,7 +207,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2172,7 +2172,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2628,7 +2628,7 @@ dependencies = [
  "openssl-sys",
  "schannel",
  "socket2",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2643,7 +2643,7 @@ dependencies = [
  "openssl-sys",
  "pkg-config",
  "vcpkg",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2929,7 +2929,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3173,7 +3173,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4218,7 +4218,7 @@ dependencies = [
 [[package]]
 name = "gix"
 version = "0.87.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "gix-actor",
  "gix-attributes",
@@ -4247,7 +4247,7 @@ dependencies = [
  "gix-object",
  "gix-odb",
  "gix-pack",
- "gix-path 0.12.5",
+ "gix-path 0.12.6",
  "gix-pathspec",
  "gix-prompt",
  "gix-protocol",
@@ -4282,7 +4282,7 @@ dependencies = [
 [[package]]
 name = "gix-actor"
 version = "0.42.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "bstr",
  "gix-date",
@@ -4293,12 +4293,12 @@ dependencies = [
 [[package]]
 name = "gix-attributes"
 version = "0.35.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "bstr",
  "gix-features",
  "gix-glob",
- "gix-path 0.12.5",
+ "gix-path 0.12.6",
  "gix-quote",
  "gix-trace 0.1.21",
  "serde",
@@ -4310,7 +4310,7 @@ dependencies = [
 [[package]]
 name = "gix-bitmap"
 version = "0.4.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "gix-error",
 ]
@@ -4318,18 +4318,18 @@ dependencies = [
 [[package]]
 name = "gix-chunk"
 version = "0.8.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "gix-error",
 ]
 
 [[package]]
 name = "gix-command"
-version = "0.10.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+version = "0.10.1"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "bstr",
- "gix-path 0.12.5",
+ "gix-path 0.12.6",
  "gix-quote",
  "gix-trace 0.1.21",
 ]
@@ -4337,7 +4337,7 @@ dependencies = [
 [[package]]
 name = "gix-commitgraph"
 version = "0.39.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "bstr",
  "gix-chunk",
@@ -4351,13 +4351,13 @@ dependencies = [
 [[package]]
 name = "gix-config"
 version = "0.60.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "bstr",
  "gix-config-value",
  "gix-features",
  "gix-glob",
- "gix-path 0.12.5",
+ "gix-path 0.12.6",
  "gix-ref",
  "gix-sec",
  "gix-utils",
@@ -4369,11 +4369,11 @@ dependencies = [
 [[package]]
 name = "gix-config-value"
 version = "0.19.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "bitflags 2.13.0",
  "bstr",
- "gix-path 0.12.5",
+ "gix-path 0.12.6",
  "libc",
  "thiserror 2.0.18",
 ]
@@ -4381,13 +4381,13 @@ dependencies = [
 [[package]]
 name = "gix-credentials"
 version = "0.40.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "bstr",
  "gix-command",
  "gix-config-value",
  "gix-date",
- "gix-path 0.12.5",
+ "gix-path 0.12.6",
  "gix-prompt",
  "gix-quote",
  "gix-sec",
@@ -4400,7 +4400,7 @@ dependencies = [
 [[package]]
 name = "gix-date"
 version = "0.16.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "bstr",
  "gix-error",
@@ -4412,7 +4412,7 @@ dependencies = [
 [[package]]
 name = "gix-diff"
 version = "0.67.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "bstr",
  "gix-attributes",
@@ -4423,7 +4423,7 @@ dependencies = [
  "gix-imara-diff",
  "gix-index",
  "gix-object",
- "gix-path 0.12.5",
+ "gix-path 0.12.6",
  "gix-pathspec",
  "gix-tempfile",
  "gix-trace 0.1.21",
@@ -4435,7 +4435,7 @@ dependencies = [
 [[package]]
 name = "gix-dir"
 version = "0.29.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "bstr",
  "gix-discover",
@@ -4443,7 +4443,7 @@ dependencies = [
  "gix-ignore",
  "gix-index",
  "gix-object",
- "gix-path 0.12.5",
+ "gix-path 0.12.6",
  "gix-pathspec",
  "gix-trace 0.1.21",
  "gix-utils",
@@ -4454,12 +4454,12 @@ dependencies = [
 [[package]]
 name = "gix-discover"
 version = "0.55.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "bstr",
  "dunce",
  "gix-fs",
- "gix-path 0.12.5",
+ "gix-path 0.12.6",
  "gix-ref",
  "gix-sec",
  "thiserror 2.0.18",
@@ -4467,8 +4467,8 @@ dependencies = [
 
 [[package]]
 name = "gix-error"
-version = "0.3.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+version = "0.3.2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "bstr",
 ]
@@ -4476,12 +4476,12 @@ dependencies = [
 [[package]]
 name = "gix-features"
 version = "0.49.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "bytes",
  "crc32fast",
  "crossbeam-channel",
- "gix-path 0.12.5",
+ "gix-path 0.12.6",
  "gix-trace 0.1.21",
  "gix-utils",
  "libc",
@@ -4494,7 +4494,7 @@ dependencies = [
 [[package]]
 name = "gix-filter"
 version = "0.34.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "bstr",
  "encoding_rs",
@@ -4503,7 +4503,7 @@ dependencies = [
  "gix-hash",
  "gix-object",
  "gix-packetline",
- "gix-path 0.12.5",
+ "gix-path 0.12.6",
  "gix-quote",
  "gix-trace 0.1.21",
  "gix-utils",
@@ -4514,11 +4514,11 @@ dependencies = [
 [[package]]
 name = "gix-fs"
 version = "0.22.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "bstr",
  "gix-features",
- "gix-path 0.12.5",
+ "gix-path 0.12.6",
  "gix-utils",
  "thiserror 2.0.18",
 ]
@@ -4526,19 +4526,19 @@ dependencies = [
 [[package]]
 name = "gix-glob"
 version = "0.27.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "bitflags 2.13.0",
  "bstr",
  "gix-features",
- "gix-path 0.12.5",
+ "gix-path 0.12.6",
  "serde",
 ]
 
 [[package]]
 name = "gix-hash"
 version = "0.26.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "faster-hex",
  "gix-features",
@@ -4551,7 +4551,7 @@ dependencies = [
 [[package]]
 name = "gix-hashtable"
 version = "0.16.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "gix-hash",
  "hashbrown 0.17.1",
@@ -4561,11 +4561,11 @@ dependencies = [
 [[package]]
 name = "gix-ignore"
 version = "0.22.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "bstr",
  "gix-glob",
- "gix-path 0.12.5",
+ "gix-path 0.12.6",
  "gix-trace 0.1.21",
  "serde",
  "unicode-bom",
@@ -4574,7 +4574,7 @@ dependencies = [
 [[package]]
 name = "gix-imara-diff"
 version = "0.2.5"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "bstr",
  "hashbrown 0.15.5",
@@ -4583,7 +4583,7 @@ dependencies = [
 [[package]]
 name = "gix-index"
 version = "0.55.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "bitflags 2.13.0",
  "bstr",
@@ -4611,7 +4611,7 @@ dependencies = [
 [[package]]
 name = "gix-lock"
 version = "24.0.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "gix-tempfile",
  "gix-utils",
@@ -4621,7 +4621,7 @@ dependencies = [
 [[package]]
 name = "gix-macros"
 version = "0.1.6"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4631,7 +4631,7 @@ dependencies = [
 [[package]]
 name = "gix-mailmap"
 version = "0.34.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "bstr",
  "gix-actor",
@@ -4643,7 +4643,7 @@ dependencies = [
 [[package]]
 name = "gix-merge"
 version = "0.20.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "bstr",
  "gix-command",
@@ -4654,7 +4654,7 @@ dependencies = [
  "gix-imara-diff",
  "gix-index",
  "gix-object",
- "gix-path 0.12.5",
+ "gix-path 0.12.6",
  "gix-quote",
  "gix-revision",
  "gix-revwalk",
@@ -4668,7 +4668,7 @@ dependencies = [
 [[package]]
 name = "gix-negotiate"
 version = "0.35.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "bitflags 2.13.0",
  "gix-commitgraph",
@@ -4681,18 +4681,17 @@ dependencies = [
 [[package]]
 name = "gix-note"
 version = "0.1.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "gix-error",
  "gix-hash",
- "gix-hashtable",
  "gix-object",
 ]
 
 [[package]]
 name = "gix-object"
 version = "0.64.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "bstr",
  "gix-actor",
@@ -4701,6 +4700,7 @@ dependencies = [
  "gix-features",
  "gix-hash",
  "gix-hashtable",
+ "gix-path 0.12.6",
  "gix-tempfile",
  "gix-utils",
  "gix-validate 0.11.4",
@@ -4713,7 +4713,7 @@ dependencies = [
 [[package]]
 name = "gix-odb"
 version = "0.84.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "arc-swap",
  "gix-features",
@@ -4722,7 +4722,7 @@ dependencies = [
  "gix-hashtable",
  "gix-object",
  "gix-pack",
- "gix-path 0.12.5",
+ "gix-path 0.12.6",
  "gix-quote",
  "gix-zlib",
  "memmap2",
@@ -4735,7 +4735,7 @@ dependencies = [
 [[package]]
 name = "gix-pack"
 version = "0.74.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "clru",
  "crossbeam-deque",
@@ -4745,7 +4745,7 @@ dependencies = [
  "gix-hash",
  "gix-hashtable",
  "gix-object",
- "gix-path 0.12.5",
+ "gix-path 0.12.6",
  "gix-tempfile",
  "gix-zlib",
  "memmap2",
@@ -4759,7 +4759,7 @@ dependencies = [
 [[package]]
 name = "gix-packetline"
 version = "0.22.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "bstr",
  "faster-hex",
@@ -4781,8 +4781,8 @@ dependencies = [
 
 [[package]]
 name = "gix-path"
-version = "0.12.5"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+version = "0.12.6"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "bstr",
  "gix-trace 0.1.21",
@@ -4793,21 +4793,21 @@ dependencies = [
 [[package]]
 name = "gix-pathspec"
 version = "0.20.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "bitflags 2.13.0",
  "bstr",
  "gix-attributes",
  "gix-config-value",
  "gix-glob",
- "gix-path 0.12.5",
+ "gix-path 0.12.6",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-prompt"
 version = "0.17.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -4819,7 +4819,7 @@ dependencies = [
 [[package]]
 name = "gix-protocol"
 version = "0.65.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "bstr",
  "gix-credentials",
@@ -4845,7 +4845,7 @@ dependencies = [
 [[package]]
 name = "gix-quote"
 version = "0.8.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "bstr",
  "gix-error",
@@ -4855,7 +4855,7 @@ dependencies = [
 [[package]]
 name = "gix-ref"
 version = "0.67.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "gix-actor",
  "gix-features",
@@ -4863,7 +4863,7 @@ dependencies = [
  "gix-hash",
  "gix-lock",
  "gix-object",
- "gix-path 0.12.5",
+ "gix-path 0.12.6",
  "gix-tempfile",
  "gix-utils",
  "gix-validate 0.11.4",
@@ -4875,7 +4875,7 @@ dependencies = [
 [[package]]
 name = "gix-refspec"
 version = "0.45.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "bstr",
  "gix-hash",
@@ -4887,7 +4887,7 @@ dependencies = [
 [[package]]
 name = "gix-revision"
 version = "0.49.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "bitflags 2.13.0",
  "bstr",
@@ -4906,7 +4906,7 @@ dependencies = [
 [[package]]
 name = "gix-revwalk"
 version = "0.35.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "gix-commitgraph",
  "gix-date",
@@ -4921,10 +4921,10 @@ dependencies = [
 [[package]]
 name = "gix-sec"
 version = "0.14.2"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "bitflags 2.13.0",
- "gix-path 0.12.5",
+ "gix-path 0.12.6",
  "libc",
  "serde",
  "windows-sys 0.61.2",
@@ -4933,7 +4933,7 @@ dependencies = [
 [[package]]
 name = "gix-shallow"
 version = "0.13.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "bstr",
  "gix-hash",
@@ -4946,7 +4946,7 @@ dependencies = [
 [[package]]
 name = "gix-status"
 version = "0.34.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "bstr",
  "filetime",
@@ -4958,7 +4958,7 @@ dependencies = [
  "gix-hash",
  "gix-index",
  "gix-object",
- "gix-path 0.12.5",
+ "gix-path 0.12.6",
  "gix-pathspec",
  "gix-worktree",
  "hashbrown 0.16.1",
@@ -4970,11 +4970,11 @@ dependencies = [
 [[package]]
 name = "gix-submodule"
 version = "0.34.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "bstr",
  "gix-config",
- "gix-path 0.12.5",
+ "gix-path 0.12.6",
  "gix-pathspec",
  "gix-refspec",
  "gix-url",
@@ -4984,7 +4984,7 @@ dependencies = [
 [[package]]
 name = "gix-tempfile"
 version = "24.0.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "dashmap",
  "gix-fs",
@@ -4993,12 +4993,13 @@ dependencies = [
  "signal-hook 0.4.4",
  "signal-hook-registry",
  "tempfile",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "gix-testtools"
 version = "0.20.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "bstr",
  "crc",
@@ -5012,7 +5013,7 @@ dependencies = [
  "gix-lock",
  "gix-object",
  "gix-odb",
- "gix-path 0.12.5",
+ "gix-path 0.12.6",
  "gix-ref",
  "gix-shallow",
  "gix-tempfile",
@@ -5033,15 +5034,15 @@ checksum = "44dc45eae785c0eb14173e0f152e6e224dcf4d45b6a6999a3aed22af541ad678"
 [[package]]
 name = "gix-trace"
 version = "0.1.21"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "gix-transport"
-version = "0.59.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+version = "0.59.2"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "base64 0.22.1",
  "bstr",
@@ -5049,7 +5050,7 @@ dependencies = [
  "gix-credentials",
  "gix-features",
  "gix-packetline",
- "gix-path 0.12.5",
+ "gix-path 0.12.6",
  "gix-quote",
  "gix-sec",
  "gix-url",
@@ -5062,7 +5063,7 @@ dependencies = [
 [[package]]
 name = "gix-traverse"
 version = "0.61.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "bitflags 2.13.0",
  "gix-commitgraph",
@@ -5078,10 +5079,10 @@ dependencies = [
 [[package]]
 name = "gix-url"
 version = "0.38.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "bstr",
- "gix-path 0.12.5",
+ "gix-path 0.12.6",
  "gix-utils",
  "percent-encoding",
  "serde",
@@ -5091,7 +5092,7 @@ dependencies = [
 [[package]]
 name = "gix-utils"
 version = "0.3.6"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "bstr",
  "fastrand",
@@ -5111,7 +5112,7 @@ dependencies = [
 [[package]]
 name = "gix-validate"
 version = "0.11.4"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "bstr",
 ]
@@ -5119,7 +5120,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree"
 version = "0.56.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "bstr",
  "gix-attributes",
@@ -5130,7 +5131,7 @@ dependencies = [
  "gix-ignore",
  "gix-index",
  "gix-object",
- "gix-path 0.12.5",
+ "gix-path 0.12.6",
  "gix-validate 0.11.4",
  "serde",
 ]
@@ -5138,7 +5139,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree-state"
 version = "0.34.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "bstr",
  "gix-features",
@@ -5146,7 +5147,7 @@ dependencies = [
  "gix-fs",
  "gix-index",
  "gix-object",
- "gix-path 0.12.5",
+ "gix-path 0.12.6",
  "gix-worktree",
  "io-close",
  "thiserror 2.0.18",
@@ -5155,7 +5156,7 @@ dependencies = [
 [[package]]
 name = "gix-worktree-stream"
 version = "0.36.1"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "gix-attributes",
  "gix-error",
@@ -5164,7 +5165,7 @@ dependencies = [
  "gix-fs",
  "gix-hash",
  "gix-object",
- "gix-path 0.12.5",
+ "gix-path 0.12.6",
  "gix-traverse",
  "parking_lot",
 ]
@@ -5172,7 +5173,7 @@ dependencies = [
 [[package]]
 name = "gix-zlib"
 version = "0.1.0"
-source = "git+https://github.com/GitoxideLabs/gitoxide?rev=ab66595c079832218a60f823d12e571512ffce9d#ab66595c079832218a60f823d12e571512ffce9d"
+source = "git+https://github.com/GitoxideLabs/gitoxide?rev=283937b39df72dfcf87d2f4b25748b6fc4432d29#283937b39df72dfcf87d2f4b25748b6fc4432d29"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -5927,7 +5928,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6614,7 +6615,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6870,7 +6871,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7387,7 +7388,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -8660,7 +8661,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8718,7 +8719,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9408,7 +9409,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10285,7 +10286,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10317,7 +10318,7 @@ dependencies = [
  "parking_lot",
  "rustix 1.1.4",
  "signal-hook 0.3.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10353,7 +10354,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10972,7 +10973,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11060,7 +11061,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11706,7 +11707,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1167,7 +1167,6 @@ dependencies = [
  "serde_json",
  "smallvec",
  "snapbox",
- "tempfile",
  "toml 0.9.12+spec-1.1.0",
  "tracing",
  "unicode-segmentation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -207,11 +207,11 @@ bstr = "1.12.1"
 zip = { version = "4", default-features = false, features = ["bzip2"] }
 # Add the `tracing` or `tracing-detail` features to see more of gitoxide in the logs. Useful to see which programs it invokes.
 # When adjusting this, update `gix-testtools` as well!
-gix = { version = "0.87.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "ab66595c079832218a60f823d12e571512ffce9d", default-features = false, features = [
+gix = { version = "0.87.1", git = "https://github.com/GitoxideLabs/gitoxide", rev = "283937b39df72dfcf87d2f4b25748b6fc4432d29", default-features = false, features = [
     "sha1",
     "sha256",
 ] }
-gix-testtools = { version = "0.20.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "ab66595c079832218a60f823d12e571512ffce9d" }
+gix-testtools = { version = "0.20.0", git = "https://github.com/GitoxideLabs/gitoxide", rev = "283937b39df72dfcf87d2f4b25748b6fc4432d29" }
 
 
 git2 = { version = "0.21.0", features = [
@@ -312,7 +312,7 @@ sapling-renderdag = "0.1.0"
 [patch.crates-io]
 # Keep workspace crates that use the `gix 0.87` line on the same git revision.
 # This was relevant to force `git-meta` to use our version.
-gix = { git = "https://github.com/GitoxideLabs/gitoxide", rev = "ab66595c079832218a60f823d12e571512ffce9d" }
+gix = { git = "https://github.com/GitoxideLabs/gitoxide", rev = "283937b39df72dfcf87d2f4b25748b6fc4432d29" }
 git2 = { git = "https://github.com/gitbutlerapp/git2-rs", rev = "a87a7bb3f6843504339fe7434ee0732a3e968f3e" }
 
 [workspace.lints.clippy]

--- a/crates/but-api/src/ai.rs
+++ b/crates/but-api/src/ai.rs
@@ -101,7 +101,7 @@ fn has_secret(handle: &str, namespace: secret::Namespace) -> Result<bool> {
 }
 
 fn get_configuration() -> Result<AiConfiguration> {
-    let config = gix::config::File::from_globals()?;
+    let config = gix::config(None, &gix::open::Options::default())?;
     let configuration = DomainConfiguration::from_git_config(&config)?;
 
     let openai_has_api_key = has_secret(AI_OPENAI_SECRET_HANDLE, secret::Namespace::Global)?;
@@ -237,7 +237,7 @@ pub fn update_ai_configuration(update: AiConfigurationUpdate) -> Result<AiConfig
         )?;
     }
 
-    let config = gix::config::File::from_globals()?;
+    let config = gix::config(None, &gix::open::Options::default())?;
     let configuration =
         domain_configuration(&update, DomainConfiguration::from_git_config(&config)?)?;
     edit_config(None, gix::config::Source::User, |config| {

--- a/crates/but-api/src/branch.rs
+++ b/crates/but-api/src/branch.rs
@@ -1150,13 +1150,13 @@ pub fn branch_remove_with_perm(
     }
 
     let mut meta = ctx.meta()?;
-    let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
+    let (mut repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
     let new_ws = if moved_head {
         None
     } else {
         but_workspace::branch::remove_reference(
             ref_name.as_ref(),
-            &repo,
+            &mut repo,
             &ws,
             &mut meta,
             but_workspace::branch::remove_reference::Options {
@@ -1171,18 +1171,10 @@ pub fn branch_remove_with_perm(
     } else {
         // Standalone branches are intentionally absent from the workspace
         // projection, as is a checked-out tip after moving HEAD below it.
-        let deleted_ref = if let Some(reference) = repo.try_find_reference(ref_name.as_ref())? {
-            let safe_delete = but_core::branch::SafeDelete::new(&repo)?;
-            let out = safe_delete.delete_reference(&reference)?;
-            if let Some(paths) = out.checked_out_in_worktree_dirs {
-                bail_precondition!(
-                    "Refusing to delete a branch that is checked out. Worktrees are: {paths:?}"
-                );
-            }
-            true
-        } else {
-            false
-        };
+        let deleted_ref = but_workspace::branch::remove_reference::delete_local_branch(
+            &mut repo,
+            ref_name.as_ref(),
+        )?;
         let deleted_meta = meta.remove(ref_name.as_ref())?;
         if deleted_ref || deleted_meta {
             let new_ws = ws

--- a/crates/but-api/src/land/deliver.rs
+++ b/crates/but-api/src/land/deliver.rs
@@ -8,10 +8,7 @@
 use anyhow::bail;
 use but_ctx::Context;
 use gitbutler_git::GitContextExt as _;
-use gix::refs::{
-    Target,
-    transaction::{Change, LogChange, PreviousValue, RefEdit, RefLog},
-};
+use gix::refs::transaction::{PreviousValue, RefEdit};
 
 /// Self-remote (`gb-local`) path: move `refs/heads/<target>` and the remote-tracking ref to the
 /// landed commit in a single transaction, guarded by a compare-and-swap on the previous target.
@@ -40,26 +37,21 @@ pub(super) fn update_local_target_refs(
     }
 
     // Advance both refs to the landed commit in one transaction, failing if either moved meanwhile.
-    let advance = Change::Update {
-        log: LogChange {
-            mode: RefLog::AndReference,
-            force_create_reflog: false,
-            message: "GitButler land".into(),
-        },
-        expected: PreviousValue::ExistingMustMatch(expected_target_oid.into()),
-        new: Target::Object(new_target_oid),
-    };
+    let expected = PreviousValue::ExistingMustMatch(expected_target_oid.into());
+    let ref_log_message = "GitButler land";
     let edits = [
-        RefEdit {
-            change: advance.clone(),
-            name: head_ref.try_into()?,
-            deref: false,
-        },
-        RefEdit {
-            change: advance,
-            name: tracking_ref.try_into()?,
-            deref: false,
-        },
+        RefEdit::update(
+            head_ref.try_into()?,
+            new_target_oid,
+            expected.clone(),
+            ref_log_message,
+        ),
+        RefEdit::update(
+            tracking_ref.try_into()?,
+            new_target_oid,
+            expected,
+            ref_log_message,
+        ),
     ];
 
     match repo.edit_references(edits) {

--- a/crates/but-api/src/legacy/forge.rs
+++ b/crates/but-api/src/legacy/forge.rs
@@ -437,11 +437,10 @@ fn ensure_review_remote(
 fn find_remote_by_url(repo: &gix::Repository, remote_url: &str) -> Result<Option<String>> {
     for name in repo.remote_names().iter() {
         let remote = repo.find_remote(name)?;
-        let Some(url) = remote.url(gix::remote::Direction::Fetch) else {
-            continue;
-        };
-        let configured = url.to_bstring().to_str_lossy().into_owned();
-        if remote_urls_match(&configured, remote_url) {
+        if remote
+            .urls(gix::remote::Direction::Fetch)
+            .any(|url| remote_urls_match(url.to_bstring().to_str_lossy().as_ref(), remote_url))
+        {
             return Ok(Some(name.to_string()));
         }
     }
@@ -711,6 +710,32 @@ mod tests {
             find_remote_by_url(&repo, "/tmp/alice/widgets.git")?,
             Some("alice".to_string()),
             "existing exact-url fork remotes should be reused"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn review_remote_reuses_matching_secondary_url() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        git_at_dir(tmp.path()).args(["init"]).run();
+        git_at_dir(tmp.path())
+            .args(["remote", "add", "alice", "/tmp/alice/primary.git"])
+            .run();
+        git_at_dir(tmp.path())
+            .args([
+                "remote",
+                "set-url",
+                "--add",
+                "alice",
+                "/tmp/alice/widgets.git",
+            ])
+            .run();
+        let repo = open_repo(tmp.path())?;
+
+        assert_eq!(
+            find_remote_by_url(&repo, "/tmp/alice/widgets.git")?,
+            Some("alice".to_string()),
+            "all configured fetch URLs should identify an existing review remote"
         );
         Ok(())
     }

--- a/crates/but-api/src/legacy/git.rs
+++ b/crates/but-api/src/legacy/git.rs
@@ -2,9 +2,7 @@
 use anyhow::{Context as _, Result, bail};
 use bstr::ByteSlice;
 use but_api_macros::but_api;
-use but_core::git_config::{
-    edit_config, open_global_config_for_reading, remove_config_value, set_config_value,
-};
+use but_core::git_config::{edit_config, remove_config_value, set_config_value};
 use gitbutler_git::GitContextExt as _;
 use gitbutler_reference::RemoteRefname;
 use tracing::instrument;
@@ -102,7 +100,7 @@ pub fn git_remove_global_config(key: String) -> Result<()> {
 #[but_api]
 #[instrument(err(Debug))]
 pub fn git_get_global_config(key: String) -> Result<Option<String>> {
-    let config = open_global_config_for_reading()?;
+    let config = gix::config(None, &gix::open::Options::default())?;
     Ok(get_config_string(&config, &key))
 }
 

--- a/crates/but-api/src/legacy/stack.rs
+++ b/crates/but-api/src/legacy/stack.rs
@@ -89,10 +89,10 @@ pub fn remove_branch_only(
         .to_full_name(branch_name)
         .map_err(anyhow::Error::from)?;
     let mut meta = ctx.meta()?;
-    let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
+    let (mut repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
     let new_ws = but_workspace::branch::remove_reference(
         ref_name.as_ref(),
-        &repo,
+        &mut repo,
         &ws,
         &mut meta,
         but_workspace::branch::remove_reference::Options {

--- a/crates/but-api/src/legacy/virtual_branches.rs
+++ b/crates/but-api/src/legacy/virtual_branches.rs
@@ -108,7 +108,7 @@ pub fn delete_local_branch(
     let branch_refname = local_branch_refname(refname, &given_name)?;
     let mut guard = ctx.exclusive_worktree_access();
     let mut meta = ctx.legacy_meta_mut(guard.write_permission())?;
-    let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(guard.write_permission())?;
+    let (mut repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(guard.write_permission())?;
 
     if ws
         .metadata
@@ -123,7 +123,7 @@ pub fn delete_local_branch(
 
     if let Some(new_ws) = but_workspace::branch::remove_reference(
         branch_refname.as_ref(),
-        &repo,
+        &mut repo,
         &ws,
         &mut meta,
         but_workspace::branch::remove_reference::Options {
@@ -133,15 +133,10 @@ pub fn delete_local_branch(
     )? {
         *ws = new_ws;
     } else {
-        if let Some(reference) = repo.try_find_reference(branch_refname.as_ref())? {
-            let safe_delete = but_core::branch::SafeDelete::new(&repo)?;
-            let outcome = safe_delete.delete_reference(&reference)?;
-            if let Some(paths) = outcome.checked_out_in_worktree_dirs {
-                bail_precondition!(
-                    "Refusing to delete a branch that is checked out. Worktrees are: {paths:?}"
-                );
-            }
-        }
+        but_workspace::branch::remove_reference::delete_local_branch(
+            &mut repo,
+            branch_refname.as_ref(),
+        )?;
         meta.remove(branch_refname.as_ref())?;
         if let Some(metadata) = &mut ws.metadata {
             metadata.remove_segment(branch_refname.as_ref());
@@ -561,9 +556,10 @@ fn unapply_stack_v3_with_perm(
 
     commit_assigned_diffspec(ctx, branch_to_unapply.as_ref(), assigned_diffspec, perm)?;
 
+    let single_branch = ctx.settings.feature_flags.single_branch;
     let mut meta = ctx.legacy_meta_mut(perm)?;
     let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
-    let workspace_disposition = if ctx.settings.feature_flags.single_branch {
+    let workspace_disposition = if single_branch {
         WorkspaceDisposition::PreventUnnecessaryWorkspaceReferencesKeepWorkspaceCommit
     } else {
         WorkspaceDisposition::KeepWorkspaceCommit

--- a/crates/but-api/src/workspace.rs
+++ b/crates/but-api/src/workspace.rs
@@ -732,7 +732,7 @@ mod tests {
         git_at_dir(tmp.path()).args(["commit", "-m", "one"]).run();
         git_at_dir(tmp.path()).args(["branch", "feature"]).run();
         git_at_dir(tmp.path())
-            .args(["config", "remote.origin.url", "../origin"])
+            .args(["remote", "add", "origin", "../origin"])
             .run();
         git_at_dir(tmp.path())
             .args(["update-ref", "refs/remotes/origin/main", "HEAD"])

--- a/crates/but-api/tests/api/support.rs
+++ b/crates/but-api/tests/api/support.rs
@@ -23,7 +23,7 @@ pub fn repo_with_feature_branch() -> anyhow::Result<(gix::Repository, tempfile::
     git_at_dir(tmp.path()).args(["commit", "-m", "one"]).run();
     git_at_dir(tmp.path()).args(["branch", "feature"]).run();
     git_at_dir(tmp.path())
-        .args(["config", "remote.origin.url", "../origin"])
+        .args(["remote", "add", "origin", "../origin"])
         .run();
     git_at_dir(tmp.path())
         .args(["update-ref", "refs/remotes/origin/main", "HEAD"])

--- a/crates/but-api/tests/api/target_commits.rs
+++ b/crates/but-api/tests/api/target_commits.rs
@@ -180,7 +180,7 @@ fn merge_integrated_stack_bounds_the_walk_at_its_base() -> anyhow::Result<()> {
         .args(["merge", "--no-ff", "feature", "-m", "merge feature"])
         .run();
     git_at_dir(tmp.path())
-        .args(["config", "remote.origin.url", "../origin"])
+        .args(["remote", "add", "origin", "../origin"])
         .run();
     git_at_dir(tmp.path())
         .args(["update-ref", "refs/remotes/origin/main", "HEAD"])

--- a/crates/but-core/Cargo.toml
+++ b/crates/but-core/Cargo.toml
@@ -29,7 +29,6 @@ bstr.workspace = true
 tracing.workspace = true
 anyhow.workspace = true
 unicode-segmentation.workspace = true
-tempfile.workspace = true
 gix = { workspace = true, features = [
     "dirwalk",
     "credentials",

--- a/crates/but-core/src/cmd.rs
+++ b/crates/but-core/src/cmd.rs
@@ -3,23 +3,6 @@ use std::{ffi::OsString, path::PathBuf, process::Stdio};
 use bstr::BStr;
 use tracing::instrument;
 
-/// Prepare `program` for invocation with a Git-compatible shell to help it pick up more of the usual environment on Windows.
-///
-/// On Windows, this specifically uses the Git-bundled shell, further increasing compatibility.
-pub fn prepare_with_shell_on_windows(program: impl Into<OsString>) -> gix::command::Prepare {
-    if cfg!(windows) {
-        gix::command::prepare(program)
-            // On Windows, this means a shell will always be used.
-            .command_may_be_shell_script_disallow_manual_argument_splitting()
-            // force using a shell, we want access to additional programs here
-            .with_shell()
-            // We know `program` is a path, so quote it.
-            .with_quoted_command()
-    } else {
-        gix::command::prepare(program)
-    }
-}
-
 /// Launch the login shell and try to extract their environment variables, or `None` if the shell couldn't be determined,
 /// or if it couldn't be launched, or if the environment extraction failed.
 #[instrument()]

--- a/crates/but-core/src/commit/mod.rs
+++ b/crates/but-core/src/commit/mod.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, io::Write, path::Path, path::PathBuf, process::Stdio};
+use std::{collections::HashSet, path::PathBuf};
 
 use anyhow::{Context as _, bail};
 use bstr::{BStr, BString, ByteSlice};
@@ -11,7 +11,7 @@ use smallvec::{SmallVec, smallvec};
 
 use crate::{
     ChangeId, Commit, CommitOwned, GitConfigSettings, RepositoryExt,
-    cmd::prepare_with_shell_on_windows, commit::tree_expression::TreeExpression,
+    commit::tree_expression::TreeExpression,
 };
 
 /// A collection of all the extra information we keep in the headers of a commit.
@@ -255,27 +255,23 @@ pub fn create(
     update_ref: Option<&gix::refs::FullNameRef>,
     sign_commit: SignCommit,
 ) -> anyhow::Result<gix::ObjectId> {
-    if let Some(pos) = commit
-        .extra_headers()
-        .find_pos(gix::objs::commit::SIGNATURE_FIELD_NAME)
-    {
+    let signature_field = gix::objs::commit::signature_field_name(commit.tree.kind());
+    if let Some(pos) = commit.extra_headers().find_pos(signature_field) {
         commit.extra_headers.remove(pos);
     }
 
     resolve_content_hash_change_id(repo, &mut commit)?;
 
-    if (sign_commit == SignCommit::IfSignCommitsEnabled
+    let commit = if (sign_commit == SignCommit::IfSignCommitsEnabled
         && repo.git_settings()?.gitbutler_sign_commits.unwrap_or(false))
         || sign_commit == SignCommit::Yes
     {
-        let mut buf = Vec::new();
-        commit.write_to(&mut buf)?;
-        match sign_buffer(repo, &buf) {
-            Ok(signature) => {
-                commit
-                    .extra_headers
-                    .push((gix::objs::commit::SIGNATURE_FIELD_NAME.into(), signature));
-            }
+        let signed = repo
+            .commit_signing_options()
+            .map_err(anyhow::Error::from)
+            .and_then(|opts| commit.sign(opts).map_err(anyhow::Error::from));
+        match signed {
+            Ok(commit) => commit,
             Err(err) => {
                 tracing::warn!("Commit signing failed with sign_commit={sign_commit:?}");
                 if sign_commit == SignCommit::IfSignCommitsEnabled {
@@ -301,7 +297,9 @@ pub fn create(
                     .context(Code::CommitSigningFailed));
             }
         }
-    }
+    } else {
+        commit
+    };
 
     let oid = repo.write_object(&commit)?.detach();
     if let Some(update_ref) = update_ref {
@@ -334,142 +332,6 @@ fn resolve_content_hash_change_id(
     let change_id = Headers::synthetic_change_id_from_commit_id(content_id);
     commit.extra_headers[pos].1 = change_id.as_bstr().to_owned();
     Ok(())
-}
-
-/// Sign `buffer` using repository configuration as obtained through `repo`,
-/// similarly to Git's commit signing behavior.
-pub fn sign_buffer(repo: &gix::Repository, buffer: &[u8]) -> anyhow::Result<BString> {
-    fn into_command(prepare: gix::command::Prepare) -> std::process::Command {
-        let cmd: std::process::Command = prepare.into();
-        tracing::debug!(?cmd, "command to produce commit signature");
-        cmd
-    }
-
-    fn as_literal_key(maybe_key: &BStr) -> Option<&BStr> {
-        if let Some(key) = maybe_key.strip_prefix(b"key::") {
-            return Some(key.into());
-        }
-        if maybe_key.starts_with(b"ssh-") {
-            return Some(maybe_key);
-        }
-        None
-    }
-
-    fn signing_key(repo: &gix::Repository) -> anyhow::Result<BString> {
-        if let Some(key) = repo.config_snapshot().string("user.signingkey") {
-            return Ok(key);
-        }
-        tracing::info!("Falling back to committer identity as user.signingKey isn't configured.");
-        let mut buf = Vec::<u8>::new();
-        repo.committer()
-            .transpose()?
-            .context("user.signingKey isn't configured and no committer is available either")?
-            .actor()
-            .trim()
-            .write_to(&mut buf)?;
-        Ok(buf.into())
-    }
-
-    let config = repo.config_snapshot();
-    let signing_key = signing_key(repo)?;
-    let sign_format = config.string("gpg.format");
-    let is_ssh = sign_format.is_some_and(|value| value == "ssh");
-
-    if is_ssh {
-        let mut signature_storage = tempfile::NamedTempFile::new()?;
-        signature_storage.write_all(buffer)?;
-        let buffer_file_to_sign_path = signature_storage.into_temp_path();
-
-        let gpg_program = match config.trusted_path("gpg.ssh.program")? {
-            Some(program) if !program.as_os_str().is_empty() => program,
-            _ => Path::new("ssh-keygen").into(),
-        };
-
-        let mut signing_cmd =
-            prepare_with_shell_on_windows(gpg_program).args(["-Y", "sign", "-n", "git", "-f"]);
-
-        let _key_storage;
-        signing_cmd = if let Some(signing_key) = as_literal_key(signing_key.as_bstr()) {
-            let mut keyfile = tempfile::NamedTempFile::new()?;
-            keyfile.write_all(signing_key.as_bytes())?;
-
-            #[cfg(unix)]
-            {
-                use std::os::unix::prelude::PermissionsExt;
-
-                let mut permissions = keyfile.as_file().metadata()?.permissions();
-                permissions.set_mode(0o600);
-                keyfile.as_file().set_permissions(permissions)?;
-            }
-
-            let keyfile_path = keyfile.path().to_owned();
-            _key_storage = keyfile.into_temp_path();
-            signing_cmd
-                .arg(keyfile_path)
-                .arg("-U")
-                .arg(buffer_file_to_sign_path.to_path_buf())
-        } else {
-            let signing_key = config
-                .trusted_path("user.signingkey")?
-                .with_context(|| format!("Didn't trust 'user.signingKey': {signing_key}"))?;
-            signing_cmd
-                .arg(signing_key)
-                .arg(buffer_file_to_sign_path.to_path_buf())
-        };
-        let output = into_command(signing_cmd)
-            .stderr(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stdin(Stdio::null())
-            .output()?;
-
-        if output.status.success() {
-            let signature_path = buffer_file_to_sign_path.with_extension("sig");
-            let sig_data = std::fs::read(signature_path)?;
-            Ok(BString::new(sig_data))
-        } else {
-            let stderr = BString::new(output.stderr);
-            let stdout = BString::new(output.stdout);
-            bail!("Failed to sign SSH: {stdout} {stderr}");
-        }
-    } else {
-        let gpg_program = match config.trusted_path("gpg.program")? {
-            Some(program) if !program.as_os_str().is_empty() => program,
-            _ => Path::new("gpg").into(),
-        };
-
-        let mut cmd = into_command(
-            prepare_with_shell_on_windows(&gpg_program)
-                .args(["--status-fd=2", "-bsau"])
-                .arg(gix::path::from_bstring(signing_key))
-                .arg("-"),
-        );
-        cmd.stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .stdin(Stdio::piped());
-
-        let mut child = match cmd.spawn() {
-            Ok(child) => child,
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-                bail!(
-                    "Could not find '{}'. Please make sure it is in your `PATH` or configure the full path using `gpg.program` in the Git configuration",
-                    gpg_program.display()
-                )
-            }
-            Err(err) => {
-                return Err(err).context(format!("Could not execute GPG program using {cmd:?}"));
-            }
-        };
-        child.stdin.take().expect("configured").write_all(buffer)?;
-
-        let output = child.wait_with_output()?;
-        if output.status.success() {
-            Ok(BString::new(output.stdout))
-        } else {
-            let stderr = BString::new(output.stderr);
-            let stdout = BString::new(output.stdout);
-            bail!("Failed to sign GPG: {stdout} {stderr}");
-        }
-    }
 }
 
 /// When commits are in conflicting state, they store various trees which to help deal with the conflict.

--- a/crates/but-core/src/git_config.rs
+++ b/crates/but-core/src/git_config.rs
@@ -7,51 +7,11 @@ use bstr::ByteSlice as _;
 use gix::config::AsKey as _;
 
 fn config_path(repo: Option<&gix::Repository>, source: gix::config::Source) -> Result<PathBuf> {
-    let path = source
-        .storage_location(&mut |name| std::env::var_os(name))
-        .with_context(|| format!("failed to determine {source:?} git config location"))?;
-    let path = if path.is_relative() {
-        let repo = repo.with_context(|| {
-            format!("determining the {source:?} git config location requires a repository")
-        })?;
-        if source == gix::config::Source::Local {
-            repo.common_dir().join(&path)
-        } else {
-            repo.git_dir().join(&path)
-        }
-    } else {
-        path
-    };
-    Ok(path)
-}
-
-fn open_config_for_editing(
-    repo: Option<&gix::Repository>,
-    source: gix::config::Source,
-) -> Result<(gix::config::File, gix::lock::File)> {
-    let path = config_path(repo, source)?;
-    std::fs::create_dir_all(path.parent().context("git config path has no parent")?)?;
-    let mut lock = gix::lock::File::acquire_to_update_resource_following_symlinks(
-        &path,
-        gix::lock::acquire::Fail::AfterDurationWithBackoff(std::time::Duration::from_secs(1)),
-        None,
-    )?;
-    // TODO(ST): replace this entire function with `gix::config::FileTransaction` once it can be
-    //           created without repository.
-    let path = lock.resource_path().to_owned();
-    let config = match std::fs::metadata(&path) {
-        Ok(meta) => {
-            lock.with_mut(|file| file.set_permissions(meta.permissions()))?;
-            gix::config::File::from_path_no_includes(path.clone(), source).with_context(|| {
-                format!("failed to open {source:?} git config at {}", path.display())
-            })?
-        }
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-            gix::config::File::new(gix::config::file::Metadata::from(source).at(path))
-        }
-        Err(err) => return Err(err.into()),
-    };
-    Ok((config, lock))
+    match repo {
+        Some(repo) => repo.config_path(source),
+        None => gix::config_path(source, &gix::open::Options::default()),
+    }
+    .with_context(|| format!("failed to determine {source:?} git config location"))
 }
 
 /// Open the repository-local Git config of `repo` for reading without acquiring a write lock,
@@ -71,45 +31,39 @@ pub fn open_repo_local_config_for_reading(repo: &gix::Repository) -> Result<gix:
         .with_context(|| format!("failed to open {source:?} git config at {}", path.display()))
 }
 
-fn commit_standalone_config(config: &gix::config::File, mut lock: gix::lock::File) -> Result<()> {
-    let path = lock.resource_path();
-    config
-        .write_to(&mut lock)
-        .with_context(|| format!("failed to serialize git config at {}", path.display()))?;
-    std::io::Write::flush(&mut lock)
-        .with_context(|| format!("failed to flush git config at {}", path.display()))?;
-    lock.commit()
-        .map_err(|err| err.error)
-        .with_context(|| format!("failed to commit git config at {}", path.display()))?;
-    Ok(())
-}
-
 /// Open the Git config for `source` using `repo` when needed, let `edit` mutate it, and
 /// write it back if the edited configuration differs from its original state.
 /// Return `true` if the file changed and was written, `false` otherwise.
 ///
-/// `repo` supplies the base directory when `source` resolves to a relative path, including
-/// relative paths from environment overrides. Local config is resolved against `repo.common_dir()`;
-/// worktree config and other relative paths are resolved against `repo.git_dir()`.
-/// Pass `None` when the configuration path is absolute, as is usual for user-global config.
-/// A relative path with `repo: None` is an error. Editing does not refresh `repo`'s cached configuration.
+/// With `repo`, paths are resolved by [`gix::Repository::config_path()`], honoring its open options
+/// and the current directory captured when it was opened. Otherwise [`gix::config_path()`] resolves
+/// non-repository sources against the current directory. Local and worktree config require `repo`.
+/// Editing does not refresh `repo`'s cached configuration.
 pub fn edit_config(
     repo: Option<&gix::Repository>,
     source: gix::config::Source,
     edit: impl FnOnce(&mut gix::config::File) -> Result<()>,
 ) -> Result<bool> {
-    let (mut config, lock) = open_config_for_editing(repo, source)?;
+    let path = config_path(repo, source)?;
+    std::fs::create_dir_all(path.parent().context("git config path has no parent")?)?;
+    let mut config = match repo {
+        Some(repo) => repo.config_file_mut(&path),
+        None => gix::config_mut(source, &gix::open::Options::default()),
+    }
+    .with_context(|| format!("failed to open {source:?} git config at {}", path.display()))?;
     let previous_contents = config.to_bstring();
     edit(&mut config)?;
     let changed = config.to_bstring() != previous_contents;
     if changed {
-        commit_standalone_config(&config, lock)?;
+        config
+            .commit()
+            .with_context(|| format!("failed to commit git config at {}", path.display()))?;
     }
     Ok(changed)
 }
 
-/// Open the Git config for `source` relative to `repo`, let `edit` mutate it, and write it back
-/// if the edited configuration differs from its original state.
+/// Edit the Git config for `source` using `repo`, resolving its path as described in [`edit_config()`].
+/// Write it back if the edited configuration differs from its original state.
 pub fn edit_repo_config(
     repo: &gix::Repository,
     source: gix::config::Source,

--- a/crates/but-core/src/git_config.rs
+++ b/crates/but-core/src/git_config.rs
@@ -25,26 +25,32 @@ fn config_path(repo: Option<&gix::Repository>, source: gix::config::Source) -> R
     Ok(path)
 }
 
-/// Open the Git config for `source` for editing, creating it first if needed.
-/// `repo` is used to resolve repo-local paths, depending on `source`.
-/// Return `(config, lock)`.
-/// Write it back with [`write_locked_config()`].
-pub fn open_config_for_editing(
+fn open_config_for_editing(
     repo: Option<&gix::Repository>,
     source: gix::config::Source,
 ) -> Result<(gix::config::File, gix::lock::File)> {
     let path = config_path(repo, source)?;
     std::fs::create_dir_all(path.parent().context("git config path has no parent")?)?;
-    let lock = gix::lock::File::acquire_to_update_resource(
+    let mut lock = gix::lock::File::acquire_to_update_resource_following_symlinks(
         &path,
         gix::lock::acquire::Fail::AfterDurationWithBackoff(std::time::Duration::from_secs(1)),
         None,
     )?;
-    if !path.exists() {
-        std::fs::File::create(&path)?;
-    }
-    let config = gix::config::File::from_path_no_includes(path.clone(), source)
-        .with_context(|| format!("failed to open {source:?} git config at {}", path.display()))?;
+    // TODO(ST): replace this entire function with `gix::config::FileTransaction` once it can be
+    //           created without repository.
+    let path = lock.resource_path().to_owned();
+    let config = match std::fs::metadata(&path) {
+        Ok(meta) => {
+            lock.with_mut(|file| file.set_permissions(meta.permissions()))?;
+            gix::config::File::from_path_no_includes(path.clone(), source).with_context(|| {
+                format!("failed to open {source:?} git config at {}", path.display())
+            })?
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            gix::config::File::new(gix::config::file::Metadata::from(source).at(path))
+        }
+        Err(err) => return Err(err.into()),
+    };
     Ok((config, lock))
 }
 
@@ -65,22 +71,7 @@ pub fn open_repo_local_config_for_reading(repo: &gix::Repository) -> Result<gix:
         .with_context(|| format!("failed to open {source:?} git config at {}", path.display()))
 }
 
-/// Open the user-global Git config for reading without acquiring a write lock.
-///
-/// If the config file doesn't exist yet, an empty in-memory config is returned.
-pub fn open_global_config_for_reading() -> Result<gix::config::File> {
-    let path = config_path(None, gix::config::Source::User)?;
-    if !path.exists() {
-        return Ok(gix::config::File::new(gix::config::file::Metadata::from(
-            gix::config::Source::User,
-        )));
-    }
-    gix::config::File::from_path_no_includes(path.clone(), gix::config::Source::User)
-        .with_context(|| format!("failed to open User git config at {}", path.display()))
-}
-
-/// Serialize a Git `config` file back to disk at `lock`.
-pub fn write_locked_config(config: &gix::config::File, mut lock: gix::lock::File) -> Result<()> {
+fn commit_standalone_config(config: &gix::config::File, mut lock: gix::lock::File) -> Result<()> {
     let path = lock.resource_path();
     config
         .write_to(&mut lock)
@@ -96,6 +87,12 @@ pub fn write_locked_config(config: &gix::config::File, mut lock: gix::lock::File
 /// Open the Git config for `source` using `repo` when needed, let `edit` mutate it, and
 /// write it back if the edited configuration differs from its original state.
 /// Return `true` if the file changed and was written, `false` otherwise.
+///
+/// `repo` supplies the base directory when `source` resolves to a relative path, including
+/// relative paths from environment overrides. Local config is resolved against `repo.common_dir()`;
+/// worktree config and other relative paths are resolved against `repo.git_dir()`.
+/// Pass `None` when the configuration path is absolute, as is usual for user-global config.
+/// A relative path with `repo: None` is an error. Editing does not refresh `repo`'s cached configuration.
 pub fn edit_config(
     repo: Option<&gix::Repository>,
     source: gix::config::Source,
@@ -106,7 +103,7 @@ pub fn edit_config(
     edit(&mut config)?;
     let changed = config.to_bstring() != previous_contents;
     if changed {
-        write_locked_config(&config, lock)?;
+        commit_standalone_config(&config, lock)?;
     }
     Ok(changed)
 }

--- a/crates/but-core/src/repo_ext.rs
+++ b/crates/but-core/src/repo_ext.rs
@@ -6,7 +6,7 @@ use gix::{
     prelude::ObjectIdExt,
     refs::{
         Target,
-        transaction::{Change, LogChange, PreviousValue, RefEdit, RefLog},
+        transaction::{PreviousValue, RefEdit},
     },
 };
 use std::path::PathBuf;
@@ -31,21 +31,17 @@ pub fn update_head_reference(
     message: &BStr,
     num_parents: usize,
 ) -> anyhow::Result<Vec<RefEdit>> {
-    Ok(repo.edit_reference(RefEdit {
-        change: Change::Update {
-            log: LogChange {
-                mode: RefLog::AndReference,
-                force_create_reflog: false,
-                message: gix::reference::log::message(operation, message, num_parents),
-            },
+    Ok(repo.edit_reference(
+        RefEdit::update(
+            "HEAD".try_into().expect("root refs are always valid"),
+            new_target,
             // We use this helper only under higher-level repository coordination, so we intentionally
             // keep the expected value loose here and rely on ref locking for the actual write.
-            expected: PreviousValue::Any,
-            new: new_target,
-        },
-        name: "HEAD".try_into().expect("root refs are always valid"),
-        deref,
-    })?)
+            PreviousValue::Any,
+            gix::reference::log::message(operation, message, num_parents),
+        )
+        .with_deref(deref),
+    )?)
 }
 
 /// Easy access of settings relevant to GitButler for retrieval and storage in Git settings.

--- a/crates/but-core/src/repo_ext.rs
+++ b/crates/but-core/src/repo_ext.rs
@@ -70,20 +70,6 @@ pub trait RepositoryExt: Sized {
     /// Return all signatures that would be needed to perform a commit as configured in Git: `(author, committer)`.
     fn commit_signatures(&self) -> anyhow::Result<(gix::actor::Signature, gix::actor::Signature)>;
 
-    /// Return the configuration freshly loaded from `.git/config` together with an acquired lock
-    /// for that file so it can be changed in memory and safely written back without another writer
-    /// racing the read-modify-write cycle.
-    fn local_common_config_for_editing(
-        &self,
-    ) -> anyhow::Result<(gix::config::File, gix::lock::File)>;
-    /// Write the given `local_config` to the file at `lock` of the while consuming
-    /// the lock previously acquired with [`Self::local_common_config_for_editing()`].
-    /// Note that only local configuraiton is written, so it's safe to use it with `repo.config_snapshot_mut()`.
-    fn write_locked_config(
-        &self,
-        local_config: &gix::config::File,
-        lock: gix::lock::File,
-    ) -> anyhow::Result<()>;
     /// Cherry-pick the changes in the tree of `to_rebase_commit_id` onto `new_base_commit_id`.
     /// This method deals with the presence of conflicting commits to select the correct trees
     /// for the cheery-pick merge.
@@ -186,30 +172,6 @@ impl RepositoryExt for gix::Repository {
         };
 
         Ok((author.into(), committer))
-    }
-
-    fn local_common_config_for_editing(
-        &self,
-    ) -> anyhow::Result<(gix::config::File, gix::lock::File)> {
-        let local_config_path = self.common_dir().join("config");
-        let lock = gix::lock::File::acquire_to_update_resource(
-            &local_config_path,
-            gix::lock::acquire::Fail::Immediately,
-            None,
-        )?;
-        let config = gix::config::File::from_path_no_includes(
-            local_config_path.clone(),
-            gix::config::Source::Local,
-        )?;
-        Ok((config, lock))
-    }
-
-    fn write_locked_config(
-        &self,
-        local_config: &gix::config::File,
-        lock: gix::lock::File,
-    ) -> anyhow::Result<()> {
-        crate::git_config::write_locked_config(local_config, lock)
     }
 
     fn cherry_pick_commits_to_tree(

--- a/crates/but-core/tests/core/git_config.rs
+++ b/crates/but-core/tests/core/git_config.rs
@@ -6,6 +6,10 @@ mod local {
     fn writes_back_local_config_when_requested() -> anyhow::Result<()> {
         let (mut repo, _tmp) = writable_scenario("git-config-empty");
 
+        assert!(
+            !edit_repo_config(&repo, gix::config::Source::Local, |_| Ok(()))?,
+            "an unchanged edit is reported as a no-op"
+        );
         assert!(edit_repo_config(
             &repo,
             gix::config::Source::Local,

--- a/crates/but-ctx/src/lib.rs
+++ b/crates/but-ctx/src/lib.rs
@@ -547,19 +547,20 @@ impl Context {
 /// Trampolines that create new uncached instances of major types.
 impl Context {
     /// Create a cached workspace as seen from the current HEAD for editing, and return it,
-    /// along with `(&repo, &mut ws, &mut db)`.
-    /// `perm` ensures exclusive process-wide access to the repository.
+    /// along with `(guard, &mut repo, &mut ws, &mut db)`.
+    /// The guard ensures exclusive process-wide access to the repository.
     /// Once the repository is changed, the cached workspace should be updated.
     ///
     /// # IMPORTANT
     /// * if the workspace was changed, write the new workspace back into `&mut ws`.
+    /// * Keep the guard alive like `let (_guard, …) = …`!
     #[instrument(name = "Context::workspace_mut_and_db_mut", level = "debug", skip_all)]
     #[expect(clippy::type_complexity)]
     pub fn workspace_mut_and_db_mut(
         &mut self,
     ) -> anyhow::Result<(
         RepoExclusiveGuard,
-        cell::Ref<'_, gix::Repository>,
+        cell::RefMut<'_, gix::Repository>,
         cell::RefMut<'_, but_graph::Workspace>,
         cell::RefMut<'_, but_db::DbHandle>,
     )> {
@@ -569,13 +570,12 @@ impl Context {
     }
 
     /// Create a cached workspace as seen from the current HEAD for editing, and return it,
-    /// along with `(&repo, &mut ws, &mut db)`.
+    /// along with `(&mut repo, &mut ws, &mut db)`.
     /// `perm` ensures exclusive process-wide access to the repository.
     /// Once the repository is changed, the cached workspace should be updated.
     ///
     /// # IMPORTANT
     /// * if the workspace was changed, write it back into `&mut ws`.
-    /// * Keep the guard alive like `let (_guard, …) = …`!
     #[instrument(
         name = "Context::workspace_mut_and_db_mut_with_perm",
         level = "debug",
@@ -585,16 +585,14 @@ impl Context {
         &mut self,
         _perm: &mut RepoExclusive,
     ) -> anyhow::Result<(
-        cell::Ref<'_, gix::Repository>,
+        cell::RefMut<'_, gix::Repository>,
         cell::RefMut<'_, but_graph::Workspace>,
         cell::RefMut<'_, but_db::DbHandle>,
     )> {
-        let repo = self.repo.get()?;
         if let Ok(cached) =
             cell::RefMut::filter_map(self.workspace.try_borrow_mut()?, |opt| opt.as_mut())
         {
-            let db = self.db.get_cache_mut()?;
-            return Ok((repo, cached, db));
+            return Ok((self.repo.get_mut()?, cached, self.db.get_cache_mut()?));
         }
         let ws = self.workspace_from_head()?;
         {
@@ -603,17 +601,15 @@ impl Context {
         }
         let ws = cell::RefMut::filter_map(self.workspace.borrow_mut(), |opt| opt.as_mut())
             .unwrap_or_else(|_| unreachable!("just set the value"));
-        let db = self.db.get_cache_mut()?;
-        Ok((repo, ws, db))
+        Ok((self.repo.get_mut()?, ws, self.db.get_cache_mut()?))
     }
 
     /// Create a new cached workspace as seen from the current HEAD for *reading* and return it,
-    /// along with `(guard, &repo, &mut ws, &mut db)`.
+    /// along with `(guard, &repo, &ws, &mut db)`.
     /// The `db` is writable as this is more useful and naturally synced.
     /// The guard is for shared access to the repository.
     ///
     /// # IMPORTANT
-    /// * if the workspace was changed, write it back into `&mut ws`.
     /// * Keep the guard alive like `let (_guard, …) = …`!
     #[instrument(name = "Context::workspace_and_db_mut", level = "debug", skip_all)]
     #[expect(clippy::type_complexity)]
@@ -631,13 +627,8 @@ impl Context {
     }
 
     /// Create a new cached workspace as seen from the current HEAD for *reading* and return it,
-    /// along with `(&repo, &mut ws, &mut db)`, given a read-`perm`ission.
+    /// along with `(&repo, &ws, &mut db)`, given a read-`perm`ission.
     /// The `db` is writable as this is more useful and naturally synced.
-    /// The guard is for shared access to the repository.
-    ///
-    /// # IMPORTANT
-    /// * if the workspace was changed, write it back into `&mut ws`.
-    /// * Keep the guard alive like `let (_guard, …) = …`!
     #[instrument(
         name = "Context::workspace_and_db_mut_with_perm",
         level = "debug",
@@ -666,7 +657,7 @@ impl Context {
     }
 
     /// Create a new cached workspace as seen from the current HEAD for *writing* and return it,
-    /// along with `(guard, &repo, &mut ws, &db)`.
+    /// along with `(guard, &mut repo, &mut ws, &db)`.
     /// The `db` is read-only.
     /// The guard is for exclusive access to the repository.
     ///
@@ -679,7 +670,7 @@ impl Context {
         &mut self,
     ) -> anyhow::Result<(
         RepoExclusiveGuard,
-        cell::Ref<'_, gix::Repository>,
+        cell::RefMut<'_, gix::Repository>,
         cell::RefMut<'_, but_graph::Workspace>,
         cell::Ref<'_, but_db::DbHandle>,
     )> {
@@ -688,8 +679,8 @@ impl Context {
         Ok((guard, repo, ws, db))
     }
 
-    /// Create a new cached workspace as seen from the current HEAD for *reading* and return it,
-    /// along with `(&repo, &mut ws, &db)`, given a read-`perm`ission.
+    /// Create a new cached workspace as seen from the current HEAD for *writing* and return it,
+    /// along with `(&mut repo, &mut ws, &db)`, given a write-`perm`ission.
     /// The `db` is read-only.
     ///
     /// # IMPORTANT
@@ -700,17 +691,17 @@ impl Context {
         skip_all
     )]
     pub fn workspace_mut_and_db_with_perm(
-        &self,
+        &mut self,
         _perm: &RepoExclusive,
     ) -> anyhow::Result<(
-        cell::Ref<'_, gix::Repository>,
+        cell::RefMut<'_, gix::Repository>,
         cell::RefMut<'_, but_graph::Workspace>,
         cell::Ref<'_, but_db::DbHandle>,
     )> {
         if let Ok(cached) =
             cell::RefMut::filter_map(self.workspace.try_borrow_mut()?, |opt| opt.as_mut())
         {
-            return Ok((self.repo.get()?, cached, self.db.get_cache()?));
+            return Ok((self.repo.get_mut()?, cached, self.db.get_cache()?));
         }
         let ws = self.workspace_from_head()?;
         {
@@ -719,7 +710,7 @@ impl Context {
         }
         let ws = cell::RefMut::filter_map(self.workspace.borrow_mut(), |opt| opt.as_mut())
             .unwrap_or_else(|_| unreachable!("just set the value"));
-        Ok((self.repo.get()?, ws, self.db.get_cache()?))
+        Ok((self.repo.get_mut()?, ws, self.db.get_cache()?))
     }
 
     /// Create a new cached workspace as seen from the current HEAD for *reading* and return it,

--- a/crates/but-ctx/tests/ctx/main.rs
+++ b/crates/but-ctx/tests/ctx/main.rs
@@ -73,6 +73,40 @@ fn new_from_project_handle_keeps_repo_cached() -> anyhow::Result<()> {
 }
 
 #[test]
+fn writable_workspace_accessors_return_mutable_repositories() -> anyhow::Result<()> {
+    let (repo, _tmp) = but_testsupport::writable_scenario("unborn-empty");
+    let mut ctx = Context::from_repo_for_testing(repo)?;
+
+    for mutable_db in [false, true] {
+        ctx.invalidate_workspace_cache()?;
+        // The first call constructs the workspace; the second reuses its cache.
+        for value in ["uncached", "cached"] {
+            {
+                let (_guard, mut repo, _ws) = if mutable_db {
+                    let (guard, repo, ws, _db) = ctx.workspace_mut_and_db_mut()?;
+                    (guard, repo, ws)
+                } else {
+                    let (guard, repo, ws, _db) = ctx.workspace_mut_and_db()?;
+                    (guard, repo, ws)
+                };
+                repo.config_snapshot_mut()
+                    .set_raw_value("but.contextTest", value)?;
+            }
+            let (_guard, repo, _ws, _db) = ctx.workspace_and_db()?;
+            assert_eq!(
+                repo.config_snapshot()
+                    .string("but.contextTest")
+                    .expect("the writable accessor updated the cached repository")
+                    .to_string(),
+                value,
+                "read access sees the repository update from either writable accessor"
+            );
+        }
+    }
+    Ok(())
+}
+
+#[test]
 fn project_data_dir_comes_from_git_config() -> anyhow::Result<()> {
     let repo_dir = TempDir::new()?;
     let repo = gix::init(repo_dir.path())?;
@@ -598,40 +632,48 @@ fn worktree_adoption_with_zero_worktrees_is_persisted() -> anyhow::Result<()> {
 }
 
 #[test]
-fn pruned_worktrees_are_adopted_but_not_returned() -> anyhow::Result<()> {
+fn pruned_or_inaccessible_worktrees_are_adopted_but_not_returned() -> anyhow::Result<()> {
     let root = TempDir::new()?;
     gix::init(root.path().join("main"))?;
     let repo = open_repo(&root.path().join("main"))?;
     but_testsupport::invoke_bash(
         "git commit --allow-empty -m M
-         git worktree add -b feat ../wt-gone",
+         git worktree add -b feat-gone ../wt-gone
+         git worktree add -b feat-broken ../wt-broken",
         &repo,
     );
     std::fs::remove_dir_all(root.path().join("wt-gone"))?;
+    std::fs::write(
+        repo.common_dir().join("worktrees/wt-gone/locked"),
+        "temporarily unavailable",
+    )?;
+    std::fs::remove_file(root.path().join("wt-broken/.git"))?;
 
     let mut ctx = Context::from_repo_for_testing(repo)?;
     ctx.settings.feature_flags.worktree_manipulation = true;
     assert_eq!(
         active_names(&ctx)?,
         Vec::<String>::new(),
-        "a deleted checkout directory makes the worktree prunable, not active"
+        "prunable and locked-but-inaccessible worktrees aren't active"
     );
     {
         let mut db = ctx.db.get_cache_mut()?;
-        assert_eq!(
-            db.worktree_meta().get(b"wt-gone")?.map(|row| row.archived),
-            Some(true),
-            "the unusable worktree was still archived at adoption"
-        );
-        db.worktree_meta_mut().upsert(but_db::WorktreeMeta {
-            name: b"wt-gone".to_vec(),
-            archived: false,
-        })?;
+        for name in [b"wt-gone".as_slice(), b"wt-broken".as_slice()] {
+            assert_eq!(
+                db.worktree_meta().get(name)?.map(|row| row.archived),
+                Some(true),
+                "the unusable worktree was still archived at adoption"
+            );
+            db.worktree_meta_mut().upsert(but_db::WorktreeMeta {
+                name: name.to_vec(),
+                archived: false,
+            })?;
+        }
     }
     assert_eq!(
         active_names(&ctx)?,
         Vec::<String>::new(),
-        "even unarchived, a pruned checkout is excluded - it is unusable, not merely hidden"
+        "even unarchived, prunable or locked-but-inaccessible worktrees are excluded"
     );
     Ok(())
 }

--- a/crates/but-db/src/worktrees.rs
+++ b/crates/but-db/src/worktrees.rs
@@ -116,10 +116,7 @@ pub fn worktrees_with_state(
     repo: &gix::Repository,
     db: &mut DbHandle,
 ) -> Result<Vec<WorktreeEntry>> {
-    // The `commondir` redirect only exists in linked-worktree git dirs; unlike
-    // `Kind::LinkedWorkTree`, which is a path heuristic requiring a literal
-    // `.git` component, this also catches worktrees of bare repositories.
-    if repo.git_dir() != repo.common_dir() {
+    if repo.kind() == gix::repository::Kind::LinkedWorkTree {
         anyhow::bail!(
             "worktree state must be read from the main worktree - \
              a linked-worktree context has its own database, letting adoption \
@@ -152,12 +149,11 @@ fn enumerate_worktrees(repo: &gix::Repository) -> Result<(Vec<BString>, Vec<Work
     for proxy in repo.worktrees()? {
         let name: BString = proxy.id().to_owned();
         all_names.push(name.clone());
+        if proxy.is_prunable() {
+            continue;
+        }
         let path = match proxy.base() {
             Ok(path) => path,
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-                // Missing administrative data - the worktree is prunable.
-                continue;
-            }
             Err(err) => {
                 tracing::warn!(%name, ?err, "Skipping linked worktree whose checkout location cannot be read");
                 continue;
@@ -166,11 +162,11 @@ fn enumerate_worktrees(repo: &gix::Repository) -> Result<(Vec<BString>, Vec<Work
         match std::fs::metadata(&path) {
             Ok(meta) if meta.is_dir() => {}
             Ok(_) => {
-                // The `gitdir` file points at something that is not a directory - prunable.
+                // The `gitdir` file points at something that is not a directory.
                 continue;
             }
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-                // The checkout was deleted without `git worktree remove` - prunable.
+                // A locked worktree may be unavailable without being prunable.
                 continue;
             }
             Err(err) => {

--- a/crates/but-graph/tests/graph/init/mod.rs
+++ b/crates/but-graph/tests/graph/init/mod.rs
@@ -2472,15 +2472,12 @@ fn ad_hoc_branch_at_target_tip_rests_on_the_target_tip() -> anyhow::Result<()> {
     .to_thread_local();
     let m1 = commit(&repo, "M1")?;
     create_branches(&repo, m1, ["refs/heads/feature"])?;
-    repo.edit_reference(gix::refs::transaction::RefEdit {
-        change: gix::refs::transaction::Change::Update {
-            log: gix::refs::transaction::LogChange::default(),
-            expected: gix::refs::transaction::PreviousValue::Any,
-            new: gix::refs::Target::Symbolic(ref_name("refs/heads/feature")),
-        },
-        name: ref_name("HEAD"),
-        deref: false,
-    })?;
+    repo.edit_reference(gix::refs::transaction::RefEdit::update(
+        ref_name("HEAD"),
+        ref_name("refs/heads/feature"),
+        gix::refs::transaction::PreviousValue::Any,
+        "",
+    ))?;
     let f1 = commit_with_parent(&repo, "F1", m1)?;
     // The checked-out branch and the target both point at F1, while the target's local
     // tracking branch `main` stayed behind at M1.

--- a/crates/but-napi/src/ai.rs
+++ b/crates/but-napi/src/ai.rs
@@ -22,7 +22,7 @@ pub async fn stream_ai_response(
     on_token: ThreadsafeFunction<String, ()>,
 ) -> napi::Result<String> {
     let response = tokio::task::spawn_blocking(move || -> Result<String> {
-        let config = gix::config::File::from_globals()?;
+        let config = gix::config(None, &gix::open::Options::default())?;
         let provider = LLMProvider::from_git_config(&config)
             .context("AI provider is not completely configured")?;
         let model = provider.model_or_default();

--- a/crates/but-rebase/src/commit.rs
+++ b/crates/but-rebase/src/commit.rs
@@ -18,7 +18,7 @@ pub enum DateMode {
 }
 
 /// Set `user.name` to `name` if unset and `user.email` to `email` if unset, or error if both are already set
-/// as per `repo` configuration, and write the changes back to the file at `destination`, keeping
+/// as per `repo` configuration, and write the changes back to `destination`, keeping
 /// user comments and custom formatting.
 pub fn save_author_if_unset_in_repo<'a, 'b>(
     repo: &gix::Repository,
@@ -35,47 +35,19 @@ pub fn save_author_if_unset_in_repo<'a, 'b>(
         .string(gix::config::tree::User::EMAIL)
         .is_none()
         .then_some(email.into());
-    let config_path = destination
-        .storage_location(&mut |name| std::env::var_os(name))
-        .context("Failed to determine storage location for Git user configuration")?;
-    // TODO(gix): there should be a `gix::Repository` version of this that takes care of this detail.
-    let config_path = if config_path.is_relative() {
-        if destination == gix::config::Source::Local {
-            repo.common_dir().join(config_path)
-        } else {
-            repo.git_dir().join(config_path)
-        }
-    } else {
-        config_path
-    };
-
-    if !config_path.exists() {
-        std::fs::create_dir_all(config_path.parent().context("Git user config is never /")?)?;
-        std::fs::File::create(&config_path)?;
-    }
-
-    let mut config = gix::config::File::from_path_no_includes(config_path.clone(), destination)?;
-    let mut something_was_set = false;
-    if let Some(name) = name {
-        config.set_raw_value(gix::config::tree::User::NAME, name)?;
-        something_was_set = true;
-    }
-    if let Some(email) = email {
-        config.set_raw_value(gix::config::tree::User::EMAIL, email)?;
-        something_was_set = true;
-    }
-
-    if !something_was_set {
+    if name.is_none() && email.is_none() {
         bail!("Refusing to overwrite an existing user.name and user.email");
     }
 
-    config.write_to(
-        &mut std::fs::OpenOptions::new()
-            .write(true)
-            .create(false)
-            .truncate(true)
-            .open(config_path)?,
-    )?;
+    but_core::git_config::edit_config(Some(repo), destination, |config| {
+        if let Some(name) = name {
+            config.set_raw_value(gix::config::tree::User::NAME, name)?;
+        }
+        if let Some(email) = email {
+            config.set_raw_value(gix::config::tree::User::EMAIL, email)?;
+        }
+        Ok(())
+    })?;
 
     Ok(())
 }

--- a/crates/but-rebase/src/graph_rebase/materialize.rs
+++ b/crates/but-rebase/src/graph_rebase/materialize.rs
@@ -8,7 +8,7 @@ use gix::{
     bstr::{BString, ByteSlice as _},
     refs::{
         Target,
-        transaction::{Change, LogChange, PreviousValue, RefEdit, RefLog},
+        transaction::{PreviousValue, RefEdit},
     },
 };
 
@@ -58,19 +58,12 @@ fn detached_worktree_head_edits(specs: &[LinkedCheckoutSpec]) -> Result<Vec<RefE
                         spec.name
                     )
                 })?;
-            Ok(RefEdit {
-                change: Change::Update {
-                    log: LogChange {
-                        mode: RefLog::AndReference,
-                        force_create_reflog: false,
-                        message: gix::reference::log::message("rebase", "HEAD".into(), 1),
-                    },
-                    expected: PreviousValue::MustExistAndMatch(Target::Object(spec.initial_head)),
-                    new: Target::Object(spec.target),
-                },
+            Ok(RefEdit::update(
                 name,
-                deref: false,
-            })
+                spec.target,
+                PreviousValue::MustExistAndMatch(Target::Object(spec.initial_head)),
+                gix::reference::log::message("rebase", "HEAD".into(), 1),
+            ))
         })
         .collect()
 }
@@ -264,23 +257,12 @@ impl<'ws, 'graph, M: RefMetadata> SuccessfulRebase<'ws, 'graph, M> {
             && repo.head_name()?.as_ref() != Some(&refname)
         {
             let ref_short_name = refname.shorten().to_owned();
-            ref_edits.push(RefEdit {
-                change: Change::Update {
-                    log: LogChange {
-                        mode: RefLog::AndReference,
-                        force_create_reflog: false,
-                        message: gix::reference::log::message(
-                            "safe checkout",
-                            ref_short_name.as_ref(),
-                            0,
-                        ),
-                    },
-                    expected: PreviousValue::Any,
-                    new: Target::Symbolic(refname),
-                },
-                name: "HEAD".try_into().expect("root refs are always valid"),
-                deref: false,
-            });
+            ref_edits.push(RefEdit::update(
+                "HEAD".try_into().expect("root refs are always valid"),
+                refname,
+                PreviousValue::Any,
+                gix::reference::log::message("safe checkout", ref_short_name.as_ref(), 0),
+            ));
         }
 
         repo.edit_references(ref_edits)?;

--- a/crates/but-rebase/src/graph_rebase/rebase.rs
+++ b/crates/but-rebase/src/graph_rebase/rebase.rs
@@ -4,10 +4,7 @@ use std::{collections::HashMap, fmt::Write as _};
 
 use anyhow::{Context, Result, bail};
 use but_core::RefMetadata;
-use gix::refs::{
-    Target,
-    transaction::{Change, LogChange, PreviousValue, RefEdit},
-};
+use gix::refs::transaction::{PreviousValue, RefEdit};
 use petgraph::{algo::toposort, visit::EdgeRef};
 
 use crate::graph_rebase::{
@@ -134,17 +131,12 @@ impl<'ws, 'graph, M: RefMetadata> Editor<'ws, 'graph, M> {
                                     if id == to_reference {
                                         unchanged_references.push(refname.clone());
                                     } else {
-                                        ref_edits.push(RefEdit {
-                                            name: refname.clone(),
-                                            change: Change::Update {
-                                                log: LogChange::default(),
-                                                expected: PreviousValue::MustExistAndMatch(
-                                                    target.into(),
-                                                ),
-                                                new: Target::Object(to_reference),
-                                            },
-                                            deref: false,
-                                        });
+                                        ref_edits.push(RefEdit::update(
+                                            refname.clone(),
+                                            to_reference,
+                                            PreviousValue::MustExistAndMatch(target.into()),
+                                            "",
+                                        ));
                                     }
                                 }
                                 gix::refs::TargetRef::Symbolic(name) => {
@@ -152,15 +144,12 @@ impl<'ws, 'graph, M: RefMetadata> Editor<'ws, 'graph, M> {
                                 }
                             }
                         } else {
-                            ref_edits.push(RefEdit {
-                                name: refname.clone(),
-                                change: Change::Update {
-                                    log: LogChange::default(),
-                                    expected: PreviousValue::MustNotExist,
-                                    new: Target::Object(to_reference),
-                                },
-                                deref: false,
-                            });
+                            ref_edits.push(RefEdit::update(
+                                refname.clone(),
+                                to_reference,
+                                PreviousValue::MustNotExist,
+                                "",
+                            ));
                         }
                     }
 
@@ -193,14 +182,7 @@ impl<'ws, 'graph, M: RefMetadata> Editor<'ws, 'graph, M> {
             if !ref_edits.iter().any(|e| e.name == *reference)
                 && !unchanged_references.iter().any(|e| e == reference)
             {
-                ref_edits.push(RefEdit {
-                    name: reference.clone(),
-                    change: Change::Delete {
-                        log: gix::refs::transaction::RefLog::AndReference,
-                        expected: PreviousValue::MustExist,
-                    },
-                    deref: false,
-                });
+                ref_edits.push(RefEdit::delete(reference.clone(), PreviousValue::MustExist));
             }
         }
 

--- a/crates/but-rebase/tests/rebase/main.rs
+++ b/crates/but-rebase/tests/rebase/main.rs
@@ -71,6 +71,37 @@ value=foo #value comment
             );
             Ok(())
         }
+
+        #[test]
+        fn does_not_truncate_a_locked_config() -> anyhow::Result<()> {
+            let (mut repo, _tmp, _meta, _db) = fixture_writable("four-commits")?;
+            repo.config_snapshot_mut()
+                .set_raw_value(gix::config::tree::Core::CONFIG_LOCK_TIMEOUT, "0")?;
+            let config_path = repo.path().join("config");
+            let original = br#"# keep this configuration intact
+[special]
+value = original
+"#;
+            std::fs::write(&config_path, original)?;
+            let lock_path = repo.path().join("config.lock");
+            std::fs::write(&lock_path, b"held")?;
+
+            let result = commit::save_author_if_unset_in_repo(
+                &repo,
+                gix::config::Source::Local,
+                "user",
+                "email",
+            );
+            std::fs::remove_file(lock_path)?;
+
+            result.expect_err("the existing config lock must prevent the write");
+            assert_eq!(
+                std::fs::read(config_path)?,
+                original,
+                "a failed transaction leaves the existing configuration untouched"
+            );
+            Ok(())
+        }
     }
 }
 

--- a/crates/but-secret/src/secret.rs
+++ b/crates/but-secret/src/secret.rs
@@ -152,14 +152,9 @@ pub mod git_credentials {
     pub(super) struct Store(gix::config::File);
 
     impl Store {
-        /// Create an instance by resolving the global environment just well enough.
-        ///
-        /// # Limitation
-        ///
-        /// This does not fully resolve includes, so it's not truly production ready but should be
-        /// fine for developer setups.
+        /// Create an instance from the effective global Git configuration.
         fn from_globals() -> Result<Self> {
-            Ok(Store(gix::config::File::from_globals()?))
+            Ok(Store(gix::config(None, &gix::open::Options::default())?))
         }
 
         /// Provide credentials preconfigured for the given secrets `handle`.

--- a/crates/but-transaction/src/lib.rs
+++ b/crates/but-transaction/src/lib.rs
@@ -29,7 +29,7 @@ use gix::{
     ObjectId,
     refs::{
         FullName, FullNameRef, Target,
-        transaction::{Change, PreviousValue, RefEdit},
+        transaction::{PreviousValue, RefEdit},
     },
 };
 
@@ -1083,26 +1083,11 @@ impl PendingRefChanges {
         let EagerlyCreatedRef { name, previous } = created_ref;
         match previous {
             Some(target) => {
-                repo.edit_references([RefEdit {
-                    name,
-                    change: Change::Update {
-                        log: Default::default(),
-                        expected: PreviousValue::Any,
-                        new: target,
-                    },
-                    deref: false,
-                }])?;
+                repo.edit_references([RefEdit::update(name, target, PreviousValue::Any, "")])?;
             }
             None => {
                 if repo.try_find_reference(name.as_ref())?.is_some() {
-                    repo.edit_references([RefEdit {
-                        name,
-                        change: Change::Delete {
-                            log: gix::refs::transaction::RefLog::AndReference,
-                            expected: PreviousValue::MustExist,
-                        },
-                        deref: false,
-                    }])?;
+                    repo.edit_references([RefEdit::delete(name, PreviousValue::MustExist)])?;
                 }
             }
         }

--- a/crates/but-workspace/src/branch/apply.rs
+++ b/crates/but-workspace/src/branch/apply.rs
@@ -17,7 +17,7 @@ use gix::{
     reference::Category,
     refs::{
         FullNameRef, Target,
-        transaction::{Change, LogChange, PreviousValue, RefEdit, RefLog},
+        transaction::{PreviousValue, RefEdit},
     },
 };
 use tracing::instrument;
@@ -1073,52 +1073,30 @@ fn set_head_to_reference(
     new_ref: Option<&gix::refs::FullNameRef>,
 ) -> anyhow::Result<()> {
     let edits = match new_ref {
-        None => {
-            let head_message = "GitButler checkout workspace during apply-branch".into();
-            vec![RefEdit {
-                change: Change::Update {
-                    log: LogChange {
-                        mode: RefLog::AndReference,
-                        force_create_reflog: false,
-                        message: head_message,
-                    },
-                    expected: PreviousValue::Any,
-                    new: Target::Object(new_ref_target),
-                },
-                name: "HEAD".try_into().expect("well-formed root ref"),
-                deref: true,
-            }]
-        }
+        None => vec![
+            RefEdit::update(
+                "HEAD".try_into().expect("well-formed root ref"),
+                new_ref_target,
+                PreviousValue::Any,
+                "GitButler checkout workspace during apply-branch",
+            )
+            .with_deref(true),
+        ],
         Some(new_ref) => {
             // This also means we want HEAD to point to it.
-            let head_message = "GitButler switch to workspace during apply-branch".into();
             vec![
-                RefEdit {
-                    change: Change::Update {
-                        log: LogChange {
-                            mode: RefLog::AndReference,
-                            force_create_reflog: false,
-                            message: head_message,
-                        },
-                        expected: PreviousValue::Any,
-                        new: Target::Symbolic(new_ref.to_owned()),
-                    },
-                    name: "HEAD".try_into().expect("well-formed root ref"),
-                    deref: false,
-                },
-                RefEdit {
-                    change: Change::Update {
-                        log: LogChange {
-                            mode: RefLog::AndReference,
-                            force_create_reflog: false,
-                            message: "created by GitButler during apply-branch".into(),
-                        },
-                        expected: PreviousValue::Any,
-                        new: Target::Object(new_ref_target),
-                    },
-                    name: new_ref.to_owned(),
-                    deref: false,
-                },
+                RefEdit::update(
+                    "HEAD".try_into().expect("well-formed root ref"),
+                    new_ref.to_owned(),
+                    PreviousValue::Any,
+                    "GitButler switch to workspace during apply-branch",
+                ),
+                RefEdit::update(
+                    new_ref.to_owned(),
+                    new_ref_target,
+                    PreviousValue::Any,
+                    "created by GitButler during apply-branch",
+                ),
             ]
         }
     };

--- a/crates/but-workspace/src/branch/apply.rs
+++ b/crates/but-workspace/src/branch/apply.rs
@@ -1,7 +1,6 @@
 use anyhow::{Context as _, bail};
-use bstr::ByteSlice as _;
 use but_core::{
-    ObjectStorageExt, RefMetadata, RepositoryExt, extract_remote_name_and_short_name, ref_metadata,
+    ObjectStorageExt, RefMetadata, RepositoryExt, ref_metadata,
     ref_metadata::{
         Workspace,
         WorkspaceCommitRelation::{Merged, Outside},
@@ -469,7 +468,7 @@ pub fn apply(
     let (local_tracking_config_and_ref_info, commit_to_create_branch_at) =
         if incoming_branch_is_remote_tracking_without_local_tracking {
             setup_local_tracking_configuration(repo, branch.as_ref(), branch_orig)?
-                .map(|(config, lock, commit)| (Some((config, lock)), Some(commit)))
+                .map(|(config, commit)| (Some(config), Some(commit)))
                 .unwrap_or_default()
         } else {
             (None, None)
@@ -504,12 +503,11 @@ pub fn apply(
             .is_some_and(|(_stack, segment)| !segment.is_projected_from_outside(&ws.graph))
     });
     let needs_ws_ref_creation = !ws_ref_exists;
-    let local_tracking_config_and_ref_info = local_tracking_config_and_ref_info
-        .zip(commit_to_create_branch_at.map({
+    let local_tracking_config_and_ref_info =
+        local_tracking_config_and_ref_info.zip(commit_to_create_branch_at.map({
             let branch = branch.clone();
             |commit| (branch, branch_orig, commit.attach(repo))
-        }))
-        .map(|((config, lock), ref_info)| (config, lock, ref_info));
+        }));
     let applied_branches = branches_to_apply
         .iter()
         .map(|rn| (*rn).to_owned())
@@ -967,41 +965,41 @@ fn find_superseded_stacks(
     superseded
 }
 
-/// Setup `local_tracking_ref` to track `remote_tracking_ref` using the typical pattern, and prepare the configuration file
-/// so that it can replace `.git/config` of `repo` when written back, with everything the same but the branch configuration added.
+/// Setup `local_tracking_ref` to track `remote_tracking_ref`, and prepare a locked configuration
+/// transaction with the branch configuration added.
 /// We also return the commit at which `local_tracking_ref` should be placed, which is assumed to not exist.
 fn setup_local_tracking_configuration(
     repo: &gix::Repository,
     local_tracking_ref: &FullNameRef,
     remote_tracking_ref: &FullNameRef,
-) -> anyhow::Result<Option<(gix::config::File, gix::lock::File, gix::ObjectId)>> {
+) -> anyhow::Result<Option<(gix::config::FileTransaction, gix::ObjectId)>> {
     let remote_tracking_commit_id = repo
         .find_reference(remote_tracking_ref)?
         .peel_to_commit()?
         .id();
 
-    // TODO(gix): Make config refreshes possible, and use the higher level API, and add a way
-    //       to only write back what changed and of course to add local sections more obviously.
-    //       Make it way easier to work with sections.
-    let (mut config, lock) = repo.local_common_config_for_editing()?;
+    let mut config = repo.config_file_mut(repo.common_dir().join("config"))?;
     let mut section =
         config.section_mut_or_create_new("branch", Some(local_tracking_ref.shorten()))?;
     // Only edit the configuration if truly empty, let's not overwrite user data.
     if section.num_values() == 0
-        && let Some((remote_name, _short_name)) =
-            extract_remote_name_and_short_name(remote_tracking_ref, &repo.remote_names())
+        && let Some((upstream_branch, remote)) =
+            repo.upstream_branch_and_remote_for_tracking_branch(remote_tracking_ref)?
     {
+        let remote_name = remote
+            .name()
+            .expect("a remote loaded by name is never anonymous");
         section
             .push(
                 gix::config::tree::Branch::REMOTE.name,
-                Some(remote_name.as_bytes().as_bstr()),
+                Some(remote_name.as_bstr()),
             )?
             .push(
                 gix::config::tree::Branch::MERGE.name,
-                Some(local_tracking_ref.as_bstr()),
+                Some(upstream_branch.as_bstr()),
             )?;
     }
-    Ok(Some((config, lock, remote_tracking_commit_id.into())))
+    Ok(Some((config, remote_tracking_commit_id.into())))
 }
 
 #[expect(clippy::indexing_slicing)]
@@ -1035,8 +1033,7 @@ fn persist_metadata_and_gitconfig<T: RefMetadata>(
     branches_to_apply: &[gix::refs::FullName],
     ws_md: &T::Handle<Workspace>,
     config_and_ref: Option<(
-        gix::config::File,
-        gix::lock::File,
+        gix::config::FileTransaction,
         (gix::refs::FullName, &gix::refs::FullNameRef, gix::Id),
     )>,
 ) -> anyhow::Result<()> {
@@ -1050,11 +1047,9 @@ fn persist_metadata_and_gitconfig<T: RefMetadata>(
         meta.set_branch(&md)?;
     }
 
-    if let Some((config, lock, (ref_to_create, remote_tracking_ref, ref_target_id))) =
-        config_and_ref
-    {
+    if let Some((config, (ref_to_create, remote_tracking_ref, ref_target_id))) = config_and_ref {
         let repo = ref_target_id.repo;
-        repo.write_locked_config(&config, lock)?;
+        config.commit()?;
 
         repo.reference(
             ref_to_create,

--- a/crates/but-workspace/src/branch/remove_reference.rs
+++ b/crates/but-workspace/src/branch/remove_reference.rs
@@ -17,6 +17,48 @@ use but_core::RefMetadata;
 use but_error::bail_precondition;
 use gix::refs::transaction::PreviousValue;
 
+/// Delete `ref_name` and its local branch configuration, returning whether the ref existed.
+///
+/// Use this for local branch removal when the corresponding `branch.<name>` configuration
+/// should also be removed. Missing refs are accepted and still have their configuration cleaned
+/// up; the return value reflects the initial ref lookup, not whether configuration changed.
+/// A branch checked out in any worktree causes a precondition error. Configuration-cleanup
+/// failures after ref deletion are logged and treated as success; use
+/// [`gix::Repository::delete_local_branches()`] directly to handle those failures explicitly.
+///
+/// Use [`but_core::branch::SafeDelete`] for ref-only deletion, including non-branch refs,
+/// or for a checkout preflight. It leaves branch configuration intact and reports a checked-out
+/// ref through its outcome rather than an error. Its worktree information is captured at
+/// construction, whereas this function checks worktrees on each call.
+///
+/// Unlike `SafeDelete`, which requires the ref's target to match the supplied reference,
+/// this function deletes by name even if the target has changed since the caller inspected it.
+/// Use [`remove_reference()`] when workspace eligibility, metadata cleanup, and rebuilding the
+/// workspace are also required.
+pub fn delete_local_branch(
+    repo: &mut gix::Repository,
+    ref_name: &gix::refs::FullNameRef,
+) -> anyhow::Result<bool> {
+    let existed = repo.try_find_reference(ref_name)?.is_some();
+    // TODO(gix): use the rval of `delete_local_branches` to figure out `existed` when available.
+    match repo.delete_local_branches([ref_name.to_owned()]) {
+        Ok(()) => {}
+        Err(err @ gix::repository::branch::delete::Error::Cleanup { .. }) => {
+            tracing::warn!(
+                ?err,
+                "branch was deleted but its local configuration remains"
+            );
+        }
+        Err(gix::repository::branch::delete::Error::CheckedOut { worktree_dirs, .. }) => {
+            bail_precondition!(
+                "Refusing to delete a branch that is checked out. Worktrees are: {worktree_dirs:?}"
+            )
+        }
+        Err(err) => return Err(err.into()),
+    }
+    Ok(existed)
+}
+
 /// Remove the workspace reference `ref_name` (if it still exists),
 /// possibly along with its `meta`-data.
 /// The `workspace` is used to assure the `ref_name` is eligible for deletion in the first place.
@@ -26,7 +68,7 @@ use gix::refs::transaction::PreviousValue;
 /// Return the updated graph that reflects this change, or `None` if nothing changed.
 pub fn remove_reference(
     ref_name: &gix::refs::FullNameRef,
-    repo: &gix::Repository,
+    repo: &mut gix::Repository,
     workspace: &but_graph::Workspace,
     meta: &mut impl RefMetadata,
     Options {
@@ -59,18 +101,7 @@ pub fn remove_reference(
         );
     }
 
-    let deleted_ref = if let Some(r) = repo.try_find_reference(ref_name)? {
-        let safe = but_core::branch::SafeDelete::new(repo)?;
-        let out = safe.delete_reference(&r)?;
-        if let Some(paths) = out.checked_out_in_worktree_dirs {
-            bail_precondition!(
-                "Refusing to delete a branch that is checked out. Worktrees are: {paths:?}"
-            );
-        }
-        true
-    } else {
-        false
-    };
+    let deleted_ref = delete_local_branch(repo, ref_name)?;
 
     let deleted_meta = if keep_metadata {
         false

--- a/crates/but-workspace/src/branch/remove_reference.rs
+++ b/crates/but-workspace/src/branch/remove_reference.rs
@@ -21,7 +21,8 @@ use gix::refs::transaction::PreviousValue;
 ///
 /// Use this for local branch removal when the corresponding `branch.<name>` configuration
 /// should also be removed. Missing refs are accepted and still have their configuration cleaned
-/// up; the return value reflects the initial ref lookup, not whether configuration changed.
+/// up; the return value reflects whether the ref existed when locked for deletion,
+/// not whether configuration changed.
 /// A branch checked out in any worktree causes a precondition error. Configuration-cleanup
 /// failures after ref deletion are logged and treated as success; use
 /// [`gix::Repository::delete_local_branches()`] directly to handle those failures explicitly.
@@ -39,15 +40,17 @@ pub fn delete_local_branch(
     repo: &mut gix::Repository,
     ref_name: &gix::refs::FullNameRef,
 ) -> anyhow::Result<bool> {
-    let existed = repo.try_find_reference(ref_name)?.is_some();
-    // TODO(gix): use the rval of `delete_local_branches` to figure out `existed` when available.
-    match repo.delete_local_branches([ref_name.to_owned()]) {
-        Ok(()) => {}
-        Err(err @ gix::repository::branch::delete::Error::Cleanup { .. }) => {
+    let deleted = match repo.delete_local_branches([ref_name.to_owned()]) {
+        Ok(deleted) => deleted,
+        Err(gix::repository::branch::delete::Error::Cleanup {
+            deleted, source, ..
+        }) => {
             tracing::warn!(
-                ?err,
+                ?source,
+                ?ref_name,
                 "branch was deleted but its local configuration remains"
             );
+            deleted
         }
         Err(gix::repository::branch::delete::Error::CheckedOut { worktree_dirs, .. }) => {
             bail_precondition!(
@@ -55,8 +58,8 @@ pub fn delete_local_branch(
             )
         }
         Err(err) => return Err(err.into()),
-    }
-    Ok(existed)
+    };
+    Ok(!deleted.is_empty())
 }
 
 /// Remove the workspace reference `ref_name` (if it still exists),

--- a/crates/but-workspace/src/branch/unapply.rs
+++ b/crates/but-workspace/src/branch/unapply.rs
@@ -132,7 +132,7 @@ pub(crate) mod function {
         prelude::ObjectIdExt,
         refs::{
             FullName, FullNameRef, Target,
-            transaction::{Change, LogChange, PreviousValue, RefEdit, RefLog},
+            transaction::{PreviousValue, RefEdit},
         },
     };
 
@@ -421,19 +421,12 @@ pub(crate) mod function {
             "BUG: workspace ref '{}' points to {actual_workspace_ref_id}, expected {expected_workspace_ref_id}",
             workspace_ref_name.shorten()
         );
-        repo.edit_reference(RefEdit {
-            change: Change::Update {
-                log: LogChange {
-                    mode: RefLog::AndReference,
-                    force_create_reflog: false,
-                    message: "GitButler switch to workspace during unapply-branch".into(),
-                },
-                expected: PreviousValue::Any,
-                new: Target::Symbolic(workspace_ref_name.to_owned()),
-            },
-            name: "HEAD".try_into().expect("well-formed root ref"),
-            deref: false,
-        })?;
+        repo.edit_reference(RefEdit::update(
+            "HEAD".try_into().expect("well-formed root ref"),
+            workspace_ref_name.to_owned(),
+            PreviousValue::Any,
+            "GitButler switch to workspace during unapply-branch",
+        ))?;
         Ok(())
     }
 
@@ -791,19 +784,12 @@ pub(crate) mod function {
                 ..Default::default()
             },
         )?;
-        repo.edit_reference(RefEdit {
-            change: Change::Update {
-                log: LogChange {
-                    mode: RefLog::AndReference,
-                    force_create_reflog: false,
-                    message: "GitButler update workspace during unapply-branch".into(),
-                },
-                expected: PreviousValue::Any,
-                new: Target::Object(new_head_id),
-            },
-            name: workspace_ref_name.to_owned(),
-            deref: false,
-        })?;
+        repo.edit_reference(RefEdit::update(
+            workspace_ref_name.to_owned(),
+            new_head_id,
+            PreviousValue::Any,
+            "GitButler update workspace during unapply-branch",
+        ))?;
         Ok(())
     }
 
@@ -925,30 +911,16 @@ pub(crate) mod function {
         workspace_ref_commit_id: gix::ObjectId,
     ) -> anyhow::Result<()> {
         repo.edit_references([
-            RefEdit {
-                change: Change::Delete {
-                    log: RefLog::AndReference,
-                    expected: PreviousValue::MustExistAndMatch(Target::Object(
-                        workspace_ref_commit_id,
-                    )),
-                },
-                name: workspace_ref_name.to_owned(),
-                deref: false,
-            },
-            RefEdit {
-                change: Change::Update {
-                    log: LogChange {
-                        mode: RefLog::AndReference,
-                        force_create_reflog: false,
-                        message: "GitButler switch away from workspace during unapply-branch"
-                            .into(),
-                    },
-                    expected: PreviousValue::Any,
-                    new: Target::Symbolic(target_ref.to_owned()),
-                },
-                name: "HEAD".try_into().expect("well-formed root ref"),
-                deref: false,
-            },
+            RefEdit::delete(
+                workspace_ref_name.to_owned(),
+                PreviousValue::MustExistAndMatch(Target::Object(workspace_ref_commit_id)),
+            ),
+            RefEdit::update(
+                "HEAD".try_into().expect("well-formed root ref"),
+                target_ref.to_owned(),
+                PreviousValue::Any,
+                "GitButler switch away from workspace during unapply-branch",
+            ),
         ])?;
         Ok(())
     }

--- a/crates/but-workspace/src/init.rs
+++ b/crates/but-workspace/src/init.rs
@@ -156,25 +156,18 @@ pub fn set_target_ref_and_init_project(
 
     // Reject targets whose remote isn't configured - reads like the base-branch data
     // would fail on them later.
-    let remote_names = repo.remote_names();
-    let (remote_name, _short_name) =
-        but_core::extract_remote_name_and_short_name(target_ref, &remote_names).with_context(
-            || {
-                format!(
-                    "failed to determine remote for branch '{}'",
-                    target_ref.as_bstr()
-                )
-            },
-        )?;
-    repo.find_remote(remote_name.as_str())
+    let (_upstream_ref, remote) = repo
+        .upstream_branch_and_remote_for_tracking_branch(target_ref)?
         .with_context(|| {
             format!(
-                "failed to find remote for branch '{}'",
+                "failed to determine remote for branch '{}'",
                 target_ref.as_bstr()
             )
-        })?
+        })?;
+    let remote_name = remote.name().expect("a configured remote is named");
+    remote
         .url(gix::remote::Direction::Fetch)
-        .with_context(|| format!("failed to get remote url for '{remote_name}'"))?;
+        .with_context(|| format!("failed to get remote url for '{}'", remote_name.as_bstr()))?;
 
     let head = repo.head_id().context("Failed to resolve HEAD")?.detach();
     let sha = resolve_target_commit(repo, head, target_head, repaired.target_commit_id)?;

--- a/crates/but-workspace/tests/workspace/branch/apply_unapply.rs
+++ b/crates/but-workspace/tests/workspace/branch/apply_unapply.rs
@@ -978,6 +978,25 @@ fn main_with_advanced_remote_tracking_branch() -> anyhow::Result<()> {
 "#]]
     );
 
+    // Applying origin/feature must use the fetch refspec to create review/feature and set its
+    // upstream merge ref to refs/heads/review/feature, instead of guessing feature from the name.
+    // Replace the wildcard mapping so it cannot mask this renamed mapping, while keeping main
+    // mapped for the already-tracked branch checked below.
+    but_core::git_config::edit_repo_config(&repo, gix::config::Source::Local, |config| {
+        but_core::git_config::set_config_value(
+            config,
+            "remote.origin.fetch",
+            "+refs/heads/main:refs/remotes/origin/main",
+        )?;
+        but_core::git_config::ensure_config_value(
+            config,
+            "remote.origin.fetch",
+            "+refs/heads/review/feature:refs/remotes/origin/feature",
+        )?;
+        Ok(())
+    })?;
+    repo.reload()?;
+
     let mut meta = InMemoryRefMetadata::default();
     meta.workspaces.push((
         "refs/heads/gitbutler/workspace".try_into()?,
@@ -1038,7 +1057,7 @@ Outcome {
 Outcome {
     workspace_changed: true,
     workspace_ref_created: true,
-    applied_branches: "[refs/heads/main, refs/heads/feature]",
+    applied_branches: "[refs/heads/main, refs/heads/review/feature]",
 }
 
 "#]]
@@ -1049,8 +1068,8 @@ Outcome {
         graph_workspace(&ws).to_string(),
         snapbox::str![[r#"
 📕🏘️:gitbutler/workspace[🌳] <> ✓!
-└── ≡📙:feature {2ec}
-    ├── 📙:feature
+└── ≡📙:review/feature {5ad}
+    ├── 📙:review/feature
     │   └── ·6b40b15 (🏘️)
     └── 📙:main
         └── ·3183e43 (🏘️)
@@ -1062,8 +1081,8 @@ Outcome {
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
         snapbox::str![[r#"
-* 3d23cfb (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-* 6b40b15 (origin/feature, feature) without-local-tracking
+* 95baf27 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+* 6b40b15 (origin/feature, review/feature) without-local-tracking
 | * 552e7dc (origin/main) only-on-remote
 |/  
 * 3183e43 (main) M1
@@ -1073,13 +1092,13 @@ Outcome {
 
     repo.reload()?;
     let config = repo.config_snapshot();
-    let section = config.section("branch", Some("feature".into()))?;
+    let section = config.section("branch", Some("review/feature".into()))?;
     snapbox::assert_data_eq!(
         section.to_bstring().to_string(),
         snapbox::str![[r#"
-[branch "feature"]
+[branch "review/feature"]
 	remote = origin
-	merge = refs/heads/feature
+	merge = refs/heads/review/feature
 
 "#]]
     );

--- a/crates/but-workspace/tests/workspace/branch/remove_reference.rs
+++ b/crates/but-workspace/tests/workspace/branch/remove_reference.rs
@@ -14,7 +14,7 @@ use crate::{
 
 #[test]
 fn no_errors_due_to_idempotency_in_empty_workspace() -> anyhow::Result<()> {
-    let (_tmp, graph, repo, mut meta, desc, _db) =
+    let (_tmp, graph, mut repo, mut meta, desc, _db) =
         named_writable_scenario_with_args_and_description_and_graph(
             "single-branch-no-ws-commit-no-target",
             ["A", "B"],
@@ -49,7 +49,7 @@ Single commit, no main remote/target, no ws commit, but ws-reference
         assert!(
             but_workspace::branch::remove_reference(
                 Category::LocalBranch.to_full_name(name)?.as_ref(),
-                &repo,
+                &mut repo,
                 &ws,
                 &mut meta,
                 remove_reference::Options {
@@ -63,7 +63,7 @@ Single commit, no main remote/target, no ws commit, but ws-reference
         assert!(
             but_workspace::branch::remove_reference(
                 Category::LocalBranch.to_full_name(name)?.as_ref(),
-                &repo,
+                &mut repo,
                 &ws,
                 &mut meta,
                 remove_reference::Options {
@@ -97,7 +97,7 @@ Single commit, no main remote/target, no ws commit, but ws-reference
 
 #[test]
 fn journey_single_branch_no_ws_commit_no_target() -> anyhow::Result<()> {
-    let (_tmp, graph, repo, mut meta, desc, _db) =
+    let (_tmp, graph, mut repo, mut meta, desc, _db) =
         named_writable_scenario_with_description_and_graph(
             "single-branch-3-commits-no-ws-commit-more-branches",
             |meta| {
@@ -140,7 +140,7 @@ Single commit, target, no ws commit, but ws-reference and a named segment, and b
         let r = Category::LocalBranch.to_full_name(name)?;
         ws = but_workspace::branch::remove_reference(
             r.as_ref(),
-            &repo,
+            &mut repo,
             &ws,
             &mut meta,
             remove_reference::Options {
@@ -170,7 +170,7 @@ Single commit, target, no ws commit, but ws-reference and a named segment, and b
 
 #[test]
 fn journey_single_branch_ws_commit_no_target() -> anyhow::Result<()> {
-    let (_tmp, graph, repo, mut meta, desc, _db) =
+    let (_tmp, graph, mut repo, mut meta, desc, _db) =
         named_writable_scenario_with_description_and_graph(
             "single-branch-4-commits-more-branches",
             |meta| {
@@ -226,7 +226,7 @@ Two commits in main, target setup, ws commit, many more usable branches
         let r = Category::LocalBranch.to_full_name(name)?;
         ws = but_workspace::branch::remove_reference(
             r.as_ref(),
-            &repo,
+            &mut repo,
             &ws,
             &mut meta,
             remove_reference::Options {
@@ -255,7 +255,7 @@ Two commits in main, target setup, ws commit, many more usable branches
         let r = Category::LocalBranch.to_full_name(name)?;
         ws = but_workspace::branch::remove_reference(
             r.as_ref(),
-            &repo,
+            &mut repo,
             &ws,
             &mut meta,
             remove_reference::Options {
@@ -280,7 +280,7 @@ Two commits in main, target setup, ws commit, many more usable branches
 
     let err = but_workspace::branch::remove_reference(
         r("refs/heads/A1-3"),
-        &repo,
+        &mut repo,
         &ws,
         &mut meta,
         remove_reference::Options {
@@ -300,7 +300,7 @@ Two commits in main, target setup, ws commit, many more usable branches
 
 #[test]
 fn journey_no_ws_commit_no_target() -> anyhow::Result<()> {
-    let (_tmp, graph, repo, mut meta, desc, _db) =
+    let (_tmp, graph, mut repo, mut meta, desc, _db) =
         named_writable_scenario_with_args_and_description_and_graph(
             "single-branch-no-ws-commit-no-target",
             ["A", "B", "C", "D", "E"],
@@ -340,10 +340,14 @@ Single commit, no main remote/target, no ws commit, but ws-reference
 "#]]
     );
 
+    but_core::git_config::edit_repo_config(&repo, gix::config::Source::Local, |config| {
+        but_core::git_config::set_config_value(config, "branch.A.remote", "origin")
+    })?;
+
     let ref_name = r("refs/heads/A");
     let ws = but_workspace::branch::remove_reference(
         ref_name,
-        &repo,
+        &mut repo,
         &ws,
         &mut meta,
         remove_reference::Options {
@@ -352,6 +356,12 @@ Single commit, no main remote/target, no ws commit, but ws-reference
         },
     )?
     .expect("we deleted something");
+    assert!(
+        but_core::git_config::open_repo_local_config_for_reading(&repo)?
+            .string("branch.A.remote")
+            .is_none(),
+        "deleting a local branch removes its local branch configuration"
+    );
 
     snapbox::assert_data_eq!(
         graph_workspace(&ws).to_string(),
@@ -367,7 +377,7 @@ Single commit, no main remote/target, no ws commit, but ws-reference
 "#]]
     );
 
-    let main_id = repo.head_id()?;
+    let main_id = repo.head_id()?.detach();
     repo.reference(
         ref_name,
         main_id,
@@ -393,7 +403,7 @@ Single commit, no main remote/target, no ws commit, but ws-reference
 
     let mut ws = but_workspace::branch::remove_reference(
         ref_name,
-        &repo,
+        &mut repo,
         &ws,
         &mut meta,
         remove_reference::Options::default(),
@@ -424,7 +434,7 @@ Single commit, no main remote/target, no ws commit, but ws-reference
     assert!(
         but_workspace::branch::remove_reference(
             ref_name,
-            &repo,
+            &mut repo,
             &ws,
             &mut meta,
             remove_reference::Options::default(),
@@ -441,7 +451,7 @@ Single commit, no main remote/target, no ws commit, but ws-reference
         let r = Category::LocalBranch.to_full_name(name)?;
         ws = but_workspace::branch::remove_reference(
             r.as_ref(),
-            &repo,
+            &mut repo,
             &ws,
             &mut meta,
             remove_reference::Options {

--- a/crates/but-workspace/tests/workspace/branch/remove_reference.rs
+++ b/crates/but-workspace/tests/workspace/branch/remove_reference.rs
@@ -13,6 +13,38 @@ use crate::{
 };
 
 #[test]
+fn deletion_result_distinguishes_missing_refs_from_configuration_cleanup() -> anyhow::Result<()> {
+    let (_tmp, _, mut repo, _, _, _) = named_writable_scenario_with_args_and_description_and_graph(
+        "single-branch-no-ws-commit-no-target",
+        ["A"],
+        |_| {},
+    )?;
+    let ref_name = r("refs/heads/A");
+
+    for existed in [true, false] {
+        but_core::git_config::edit_repo_config(&repo, gix::config::Source::Local, |config| {
+            but_core::git_config::set_config_value(config, "branch.A.remote", "origin")
+        })?;
+        assert_eq!(
+            remove_reference::delete_local_branch(&mut repo, ref_name)?,
+            existed,
+            "configuration cleanup alone must not report a deleted reference"
+        );
+        assert!(
+            repo.try_find_reference(ref_name)?.is_none(),
+            "the requested branch is absent after either call"
+        );
+        assert!(
+            but_core::git_config::open_repo_local_config_for_reading(&repo)?
+                .string("branch.A.remote")
+                .is_none(),
+            "branch configuration is removed even when the reference was already missing"
+        );
+    }
+    Ok(())
+}
+
+#[test]
 fn no_errors_due_to_idempotency_in_empty_workspace() -> anyhow::Result<()> {
     let (_tmp, graph, mut repo, mut meta, desc, _db) =
         named_writable_scenario_with_args_and_description_and_graph(

--- a/crates/but-workspace/tests/workspace/init.rs
+++ b/crates/but-workspace/tests/workspace/init.rs
@@ -47,19 +47,12 @@ fn create_remote_branch(repo: &gix::Repository, name: &str) -> anyhow::Result<()
 }
 
 fn set_remote_head(repo: &gix::Repository, target: &str) -> anyhow::Result<()> {
-    repo.edit_reference(gix::refs::transaction::RefEdit {
-        change: gix::refs::transaction::Change::Update {
-            log: gix::refs::transaction::LogChange {
-                mode: gix::refs::transaction::RefLog::AndReference,
-                force_create_reflog: false,
-                message: "test remote HEAD".into(),
-            },
-            expected: PreviousValue::Any,
-            new: gix::refs::Target::Symbolic(target.try_into()?),
-        },
-        name: "refs/remotes/origin/HEAD".try_into()?,
-        deref: false,
-    })?;
+    repo.edit_reference(gix::refs::transaction::RefEdit::update(
+        "refs/remotes/origin/HEAD".try_into()?,
+        gix::refs::FullName::try_from(target)?,
+        PreviousValue::Any,
+        "test remote HEAD",
+    ))?;
     Ok(())
 }
 

--- a/crates/but/src/alias.rs
+++ b/crates/but/src/alias.rs
@@ -43,13 +43,16 @@ pub fn expand_alias(potential_alias: &str) -> Result<Vec<OsString>> {
         )
     }
 
-    // Try to read from git config: but.alias.<name>
-    // And try to discover a git repository from the current directory, way before we have a context.
-    let repo = gix::discover(".").ok();
-    let alias_value = match repo
-        .as_ref()
-        .and_then(|repo| read_git_config_alias(repo, potential_alias))
-    {
+    // Try to discover a git repository from the current directory, way before we have a context.
+    // Outside a repository, aliases can still come from global configuration.
+    let alias_value = match gix::discover(".") {
+        Ok(repo) => read_git_config_alias(&repo.config_snapshot(), potential_alias),
+        Err(_) => read_git_config_alias(
+            &gix::config(None, &gix::open::Options::default())?,
+            potential_alias,
+        ),
+    };
+    let alias_value = match alias_value {
         Some(value) => value,
         None => {
             // Check for default aliases that can be overridden
@@ -112,7 +115,7 @@ pub fn get_default_alias(alias_name: &str) -> Option<String> {
         .map(|(_, value)| value.to_string())
 }
 
-/// Reads a git config alias value from `repo`.
+/// Reads a git config alias value from `config`.
 ///
 /// Looks for the config key `but.alias.<name>` in the git configuration.
 ///
@@ -123,10 +126,8 @@ pub fn get_default_alias(alias_name: &str) -> Option<String> {
 /// # Returns
 ///
 /// The alias value if found, or `None` if not found or on error
-fn read_git_config_alias(repo: &gix::Repository, alias_name: &str) -> Option<String> {
-    // Get the config snapshot and look for but.alias.<name>
+fn read_git_config_alias(config: &gix::config::File, alias_name: &str) -> Option<String> {
     let config_key = format!("but.alias.{alias_name}");
-    let config = repo.config_snapshot();
 
     // Try to read the string value from config
     config.string(&config_key).map(|v| v.to_string())

--- a/crates/but/src/args/config.rs
+++ b/crates/but/src/args/config.rs
@@ -333,7 +333,7 @@ impl From<AiKeyOption> for but_llm::CredentialsKeyOption {
 }
 
 /// Subcommands for `but config user`
-#[derive(Debug, clap::Subcommand)]
+#[derive(Debug, Clone, clap::Subcommand)]
 pub enum UserSubcommand {
     /// Set a user configuration value.
     ///

--- a/crates/but/src/command/alias.rs
+++ b/crates/but/src/command/alias.rs
@@ -15,36 +15,22 @@ use crate::{
     utils::OutputChannel,
 };
 
-/// Represents where an alias is configured
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "lowercase")]
-pub enum AliasScope {
-    Local,
-    Global,
-    Both,
-}
-
-impl std::fmt::Display for AliasScope {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            AliasScope::Local => write!(f, "local"),
-            AliasScope::Global => write!(f, "global"),
-            AliasScope::Both => write!(f, "both"),
-        }
-    }
-}
-
-/// An alias entry with its name, value, and scope
+/// An alias entry with its name, effective value, and all contributing scopes.
 #[derive(Debug, Clone, Serialize)]
 pub struct AliasEntry {
     pub name: String,
     pub value: String,
-    pub scope: AliasScope,
+    /// Unique scopes in configuration traversal order; user and XDG config share `global`.
+    pub scopes: Vec<&'static str>,
 }
 
 /// List all configured `but` aliases
-pub fn list(repo: &gix::Repository, out: &mut OutputChannel) -> Result<()> {
-    let user_aliases = get_all_aliases(repo)?;
+pub fn list(ctx: Option<&Context>, out: &mut OutputChannel) -> Result<()> {
+    let repo = ctx.map(|ctx| ctx.repo.get()).transpose()?;
+    let user_aliases = match repo.as_deref() {
+        Some(repo) => get_all_aliases(&repo.config_snapshot()),
+        None => get_all_aliases(&gix::config(None, &gix::open::Options::default())?),
+    };
 
     // Get default aliases
     let default_aliases = get_default_aliases();
@@ -81,11 +67,7 @@ pub fn list(repo: &gix::Repository, out: &mut OutputChannel) -> Result<()> {
             writeln!(out)?;
 
             for alias in &user_aliases {
-                let scope_indicator = match alias.scope {
-                    AliasScope::Local => t.hint.paint("(local)"),
-                    AliasScope::Global => t.hint.paint("(global)"),
-                    AliasScope::Both => t.hint.paint("(local+global)"),
-                };
+                let scope_indicator = t.hint.paint(format!("({})", alias.scopes.join("+")));
                 writeln!(
                     out,
                     "  {:<width$}  {}  {} {}",
@@ -136,24 +118,13 @@ pub fn list(repo: &gix::Repository, out: &mut OutputChannel) -> Result<()> {
             }
         }
     } else if let Some(out) = out.for_json() {
-        let user_json: Vec<serde_json::Value> = user_aliases
-            .iter()
-            .map(|a| {
-                serde_json::json!({
-                    "name": a.name,
-                    "value": a.value,
-                    "scope": a.scope
-                })
-            })
-            .collect();
-
         let default_json: serde_json::Map<String, serde_json::Value> = default_aliases
             .into_iter()
             .map(|(k, v)| (k, serde_json::Value::String(v)))
             .collect();
 
         out.write_value(serde_json::json!({
-            "user": user_json,
+            "user": user_aliases,
             "default": default_json
         }))?;
     }
@@ -161,12 +132,10 @@ pub fn list(repo: &gix::Repository, out: &mut OutputChannel) -> Result<()> {
     Ok(())
 }
 
-/// Get all user-configured aliases from local and global git config and defaults
-fn get_all_aliases(repo: &gix::Repository) -> Result<Vec<AliasEntry>> {
+/// Get configured aliases from every source, preserving the last value for each name.
+fn get_all_aliases(cfg: &gix::config::File) -> Vec<AliasEntry> {
     // Track aliases by name with their scopes
-    let mut alias_map: HashMap<String, (String, bool, bool)> = HashMap::new(); // name -> (value, is_local, is_global)
-
-    let cfg = repo.config_snapshot();
+    let mut alias_map: HashMap<String, (String, Vec<&'static str>)> = HashMap::new();
 
     for section in cfg.sections() {
         let header = section.header();
@@ -175,13 +144,17 @@ fn get_all_aliases(repo: &gix::Repository) -> Result<Vec<AliasEntry>> {
             continue;
         }
 
-        // Determine if this section is from local or global config
-        let source = section.meta().source;
-        let is_local = matches!(
-            source,
-            gix::config::Source::Local | gix::config::Source::Worktree
-        );
-        let is_global = matches!(source, gix::config::Source::User | gix::config::Source::Git);
+        let scope = match section.meta().source {
+            gix::config::Source::GitInstallation => "git-installation",
+            gix::config::Source::System => "system",
+            gix::config::Source::Git | gix::config::Source::User => "global",
+            gix::config::Source::Local => "local",
+            gix::config::Source::Worktree => "worktree",
+            gix::config::Source::Env => "env",
+            gix::config::Source::Cli => "cli",
+            gix::config::Source::Api => "api",
+            gix::config::Source::EnvOverride => "env-override",
+        };
 
         let subsection = header.subsection_name().map(|s| s.to_str_lossy());
 
@@ -206,35 +179,28 @@ fn get_all_aliases(repo: &gix::Repository) -> Result<Vec<AliasEntry>> {
 
                 alias_map
                     .entry(alias_name)
-                    .and_modify(|(v, local, global)| {
+                    .and_modify(|(v, scopes)| {
                         *v = value.clone(); // Last value wins
-                        if is_local {
-                            *local = true;
-                        }
-                        if is_global {
-                            *global = true;
+                        if !scopes.contains(&scope) {
+                            scopes.push(scope);
                         }
                     })
-                    .or_insert((value, is_local, is_global));
+                    .or_insert((value, vec![scope]));
             }
         }
     }
 
     let mut user_aliases: Vec<AliasEntry> = alias_map
         .into_iter()
-        .map(|(name, (value, is_local, is_global))| {
-            let scope = match (is_local, is_global) {
-                (true, true) => AliasScope::Both,
-                (true, false) => AliasScope::Local,
-                (false, true) => AliasScope::Global,
-                (false, false) => AliasScope::Local, // Shouldn't happen, but default to local
-            };
-            AliasEntry { name, value, scope }
+        .map(|(name, (value, scopes))| AliasEntry {
+            name,
+            value,
+            scopes,
         })
         .collect();
 
     user_aliases.sort_by(|a, b| a.name.cmp(&b.name));
-    Ok(user_aliases)
+    user_aliases
 }
 
 /// Get all default aliases
@@ -244,7 +210,7 @@ fn get_default_aliases() -> Vec<(String, String)> {
 
 /// Add a new alias
 pub fn add(
-    ctx: &mut Context,
+    ctx: Option<&Context>,
     out: &mut OutputChannel,
     name: &str,
     value: &str,
@@ -256,8 +222,8 @@ pub fn add(
     }
 
     let is_global: bool = global.into();
-    let repo = ctx.repo.get()?;
-    edit_git_config(&repo, global, |config| {
+    let repo = ctx.map(|ctx| ctx.repo.get()).transpose()?;
+    edit_git_config(repo.as_deref(), global, |config| {
         set_alias(config, name, value)?;
         Ok(())
     })?;
@@ -288,14 +254,14 @@ pub fn add(
 
 /// Remove an alias
 pub fn remove(
-    ctx: &mut Context,
+    ctx: Option<&Context>,
     out: &mut OutputChannel,
     name: &str,
     global: EditGlobalConfig,
 ) -> Result<()> {
     let is_global: bool = global.into();
-    let repo = ctx.repo.get()?;
-    let success = edit_git_config(&repo, global, |config| {
+    let repo = ctx.map(|ctx| ctx.repo.get()).transpose()?;
+    let success = edit_git_config(repo.as_deref(), global, |config| {
         remove_alias(config, name);
         Ok(())
     })?;
@@ -340,4 +306,48 @@ fn set_alias(config: &mut gix::config::File, name: &str, value: &str) -> Result<
         .set(name, value)
         .with_context(|| format!("invalid alias name for git config: {name}"))?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn alias_scopes_preserve_all_sources_and_precedence() -> Result<()> {
+        use gix::config::{File, Source, file::Metadata};
+
+        let mut combined = File::new(Metadata::from(Source::Api));
+        for (source, scope) in [
+            (Source::GitInstallation, "git-installation"),
+            (Source::System, "system"),
+            (Source::Git, "global"),
+            (Source::User, "global"),
+            (Source::Local, "local"),
+            (Source::Worktree, "worktree"),
+            (Source::Env, "env"),
+            (Source::Cli, "cli"),
+            (Source::Api, "api"),
+            (Source::EnvOverride, "env-override"),
+        ] {
+            let mut config = File::new(Metadata::from(source));
+            set_alias(&mut config, "example", scope)?;
+            // Every source is reported accurately even when it is the only source.
+            snapbox::assert_data_eq!(
+                serde_json::to_string(&get_all_aliases(&config))?,
+                serde_json::json!([{"name": "example", "value": scope, "scopes": [scope]}])
+                    .to_string()
+            );
+            combined.append(config)?;
+        }
+        // Repeated scopes are deduplicated, and the last source still supplies the value.
+        snapbox::assert_data_eq!(
+            serde_json::to_string(&get_all_aliases(&combined))?,
+            serde_json::json!([{
+                "name": "example",
+                "value": "env-override",
+                "scopes": ["git-installation", "system", "global", "local", "worktree", "env", "cli", "api", "env-override"]
+            }]).to_string()
+        );
+        Ok(())
+    }
 }

--- a/crates/but/src/command/config.rs
+++ b/crates/but/src/command/config.rs
@@ -84,7 +84,7 @@ pub async fn exec(
     cmd: Option<Subcommands>,
 ) -> Result<()> {
     match cmd {
-        Some(Subcommands::User { cmd }) => user_config(ctx, out, cmd).await,
+        Some(Subcommands::User { cmd }) => user_config(Some(ctx), out, cmd).await,
         Some(Subcommands::Target {
             branch,
             push_remote,
@@ -460,7 +460,7 @@ struct UserConfigInfo {
 }
 
 /// Get user configuration info from git config
-fn get_user_config_info(config: &gix::config::Snapshot<'_>) -> UserConfigInfo {
+fn get_user_config_info(config: &gix::config::File) -> UserConfigInfo {
     let (name, name_scope) = get_config_string_and_scope(config, "user.name");
     let (email, email_scope) = get_config_string_and_scope(config, "user.email");
     let (_editor, editor_scope) = get_config_string_and_scope(config, "core.editor");
@@ -512,19 +512,21 @@ fn write_user_config_human(out: &mut dyn std::fmt::Write, info: &UserConfigInfo)
 }
 
 /// Handle user config subcommand
-async fn user_config(
-    ctx: &mut Context,
+pub(crate) async fn user_config(
+    ctx: Option<&Context>,
     out: &mut OutputChannel,
     cmd: Option<UserSubcommand>,
 ) -> Result<()> {
     let t = theme::get();
-    let repo = ctx.repo.get()?;
+    let repo = ctx.map(|ctx| ctx.repo.get()).transpose()?;
 
     match cmd {
         // View user config
         None => {
-            let config = repo.config_snapshot();
-            let user_info = get_user_config_info(&config);
+            let user_info = match repo.as_deref() {
+                Some(repo) => get_user_config_info(&repo.config_snapshot()),
+                None => get_user_config_info(&gix::config(None, &gix::open::Options::default())?),
+            };
 
             if let Some(out) = out.for_human() {
                 writeln!(out, "{}:", t.important.paint("\nUser Configuration"))?;
@@ -550,7 +552,7 @@ async fn user_config(
         // Set user config
         Some(UserSubcommand::Set { key, value, global }) => {
             let git_key = key.to_git_key();
-            edit_git_config(&repo, global.into(), |config| {
+            edit_git_config(repo.as_deref(), global.into(), |config| {
                 set_config_value(config, git_key, &value)?;
                 Ok(())
             })?;
@@ -578,7 +580,7 @@ async fn user_config(
         // Unset user config
         Some(UserSubcommand::Unset { key, global }) => {
             let git_key = key.to_git_key();
-            edit_git_config(&repo, global.into(), |config| {
+            edit_git_config(repo.as_deref(), global.into(), |config| {
                 remove_config_value(config, git_key)?;
                 Ok(())
             })?;
@@ -1703,7 +1705,7 @@ fn edit_ai_git_config(
         }
         AiScope::Local => {
             let repo = repo.context("Local AI configuration requires a git repository")?;
-            edit_git_config(repo, false.into(), edit)?;
+            edit_git_config(Some(repo), false.into(), edit)?;
             Ok(())
         }
     }
@@ -1789,7 +1791,7 @@ fn apply_openrouter_config(
 fn get_ai_config_info(repo: Option<&gix::Repository>, scope: AiScope) -> Result<AiConfigInfo> {
     match scope {
         AiScope::Global => {
-            let file = gix::config::File::from_globals()?;
+            let file = gix::config(None, &gix::open::Options::default())?;
             Ok(AiConfigInfo::from_git_config(&file))
         }
         AiScope::Local => {
@@ -1990,7 +1992,7 @@ fn push_remote_config(
 }
 
 fn get_config_string_and_scope(
-    config: &gix::config::Snapshot<'_>,
+    config: &gix::config::File,
     key: &str,
 ) -> (Option<String>, Option<gix::config::Source>) {
     let mut scope = None;

--- a/crates/but/src/command/git_config.rs
+++ b/crates/but/src/command/git_config.rs
@@ -1,21 +1,25 @@
 //! Shared helpers for editing Git configuration files.
 
-use anyhow::Result;
-use but_core::git_config::edit_repo_config;
+use anyhow::{Context as _, Result};
+use but_core::git_config::{edit_config, edit_repo_config};
 
 boolean_enums::gen_boolean_enum!(pub EditGlobalConfig);
 
 /// `edit` either the `repo`-local or user-global Git config, depending on `global`.
 /// It compares the edited config to its previous value to determine whether to persist it.
+/// A repository is required only for local edits.
 pub(crate) fn edit_git_config(
-    repo: &gix::Repository,
+    repo: Option<&gix::Repository>,
     global: EditGlobalConfig,
     edit: impl FnOnce(&mut gix::config::File) -> Result<()>,
 ) -> Result<bool> {
-    let source = if global.into() {
-        gix::config::Source::User
+    if global.into() {
+        edit_config(None, gix::config::Source::User, edit)
     } else {
-        gix::config::Source::Local
-    };
-    edit_repo_config(repo, source, edit)
+        edit_repo_config(
+            repo.context("Local Git configuration requires a git repository")?,
+            gix::config::Source::Local,
+            edit,
+        )
+    }
 }

--- a/crates/but/src/command/legacy/branch/show.rs
+++ b/crates/but/src/command/legacy/branch/show.rs
@@ -54,7 +54,7 @@ pub fn show(
 
     // Generate AI summary if requested
     let ai_summary = if generate_ai_summary {
-        let git_config = gix::config::File::from_globals()?;
+        let git_config = gix::config(None, &gix::open::Options::default())?;
         Some(generate_branch_summary(branch_name, &commits, &git_config)?)
     } else {
         None

--- a/crates/but/src/command/legacy/setup.rs
+++ b/crates/but/src/command/legacy/setup.rs
@@ -631,19 +631,12 @@ fn setup_local_remote(repo: &gix::Repository, out: &mut OutputChannel) -> anyhow
 
     // Create refs/remotes/gb-local/HEAD as a symbolic reference
     let head_ref_name: gix::refs::FullName = "refs/remotes/gb-local/HEAD".try_into()?;
-    repo.edit_reference(gix::refs::transaction::RefEdit {
-        change: gix::refs::transaction::Change::Update {
-            log: gix::refs::transaction::LogChange {
-                mode: gix::refs::transaction::RefLog::AndReference,
-                force_create_reflog: false,
-                message: "GitButler local remote HEAD".into(),
-            },
-            expected: gix::refs::transaction::PreviousValue::Any,
-            new: gix::refs::Target::Symbolic(branch_ref_name),
-        },
-        name: head_ref_name,
-        deref: false,
-    })?;
+    repo.edit_reference(gix::refs::transaction::RefEdit::update(
+        head_ref_name,
+        branch_ref_name,
+        gix::refs::transaction::PreviousValue::Any,
+        "GitButler local remote HEAD",
+    ))?;
 
     if let Some(out) = out.for_human() {
         writeln!(

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -683,6 +683,18 @@ async fn dispatch_subcommand(
                 Some(args::config::Subcommands::Feature { flag, status }) => {
                     command::config::feature_config(out, *flag, *status).map_err(CliError::from)
                 }
+                Some(args::config::Subcommands::User { cmd }) => {
+                    let ctx = match cmd {
+                        Some(
+                            args::config::UserSubcommand::Set { global: true, .. }
+                            | args::config::UserSubcommand::Unset { global: true, .. },
+                        ) => None,
+                        _ => discover_optional_context(&args.current_dir)?,
+                    };
+                    command::config::user_config(ctx.as_ref(), out, cmd.clone())
+                        .await
+                        .map_err(CliError::from)
+                }
                 #[cfg(feature = "legacy")]
                 Some(args::config::Subcommands::Forge {
                     cmd: Some(args::config::ForgeSubcommand::GithubStacks { .. }),
@@ -735,18 +747,35 @@ async fn dispatch_subcommand(
             })
             .map(|()| DispatchOutcome::Return);
         }
+        Subcommands::Alias(alias_args::Platform { cmd }) => {
+            let ctx = match &cmd {
+                Some(
+                    alias_args::Subcommands::Add { global: true, .. }
+                    | alias_args::Subcommands::Remove { global: true, .. },
+                ) => None,
+                _ => discover_optional_context(&args.current_dir)?,
+            };
+            return (match cmd {
+                Some(alias_args::Subcommands::List) | None => {
+                    command::alias::list(ctx.as_ref(), out)
+                }
+                Some(alias_args::Subcommands::Add {
+                    name,
+                    value,
+                    global,
+                }) => command::alias::add(ctx.as_ref(), out, &name, &value, global.into()),
+                Some(alias_args::Subcommands::Remove { name, global }) => {
+                    command::alias::remove(ctx.as_ref(), out, &name, global.into())
+                }
+            })
+            .map(|()| DispatchOutcome::Return)
+            .map_err(CliError::from);
+        }
         Subcommands::Skill(args::skill::Platform { cmd }) => {
             // Skill commands use repository context when available, but can run
             // without one. Subcommand handlers produce tailored guidance when a
             // local repository is actually required.
-            let ctx = but_ctx::Context::discover(&args.current_dir);
-            let mut ctx = match ctx {
-                Ok(ctx) => Some(ctx),
-                Err(err) if is_not_in_git_repository_error(&err) => None,
-                Err(err) => {
-                    return Err(CliError::Internal(err));
-                }
-            };
+            let mut ctx = discover_optional_context(&args.current_dir)?;
             return command::skill::handle(ctx.as_mut(), out, cmd)
                 .map(|()| DispatchOutcome::Return)
                 .map_err(CliError::from);
@@ -808,9 +837,7 @@ async fn dispatch_subcommand(
             },
             out,
         ),
-        Subcommands::_Expand { .. } | Subcommands::Alias(..) => {
-            but_ctx::Context::discover(&args.current_dir)
-        }
+        Subcommands::_Expand { .. } => but_ctx::Context::discover(&args.current_dir),
         Subcommands::Branch(branch::Platform { ref cmd }) => setup::init_ctx(
             &args,
             match cmd {
@@ -921,6 +948,7 @@ async fn dispatch_subcommand(
         | Subcommands::Help { .. }
         | Subcommands::Onboarding
         | Subcommands::Config(..)
+        | Subcommands::Alias(..)
         | Subcommands::Skill(..)
         | Subcommands::Agent(..)
         | Subcommands::Mcp(..)
@@ -972,24 +1000,6 @@ async fn dispatch_subcommand(
             }
             None
         }
-        Subcommands::Alias(alias_args::Platform { cmd }) => match cmd {
-            Some(alias_args::Subcommands::List) | None => {
-                command::alias::list(&*ctx.repo.get()?, out)?;
-                None
-            }
-            Some(alias_args::Subcommands::Add {
-                name,
-                value,
-                global,
-            }) => {
-                command::alias::add(&mut ctx, out, &name, &value, global.into())?;
-                None
-            }
-            Some(alias_args::Subcommands::Remove { name, global }) => {
-                command::alias::remove(&mut ctx, out, &name, global.into())?;
-                None
-            }
-        },
         Subcommands::Branch(branch::Platform { cmd }) => match cmd {
             #[cfg(not(feature = "legacy"))]
             None => todo!("implement list and call recursively"),
@@ -1763,6 +1773,14 @@ fn is_not_in_git_repository_error(err: &anyhow::Error) -> bool {
                 | gix::discover::upwards::Error::NoGitRepositoryWithinFs { .. }
         ))
     )
+}
+
+fn discover_optional_context(path: &std::path::Path) -> CliResult<Option<but_ctx::Context>> {
+    match but_ctx::Context::discover(path) {
+        Ok(ctx) => Ok(Some(ctx)),
+        Err(err) if is_not_in_git_repository_error(&err) => Ok(None),
+        Err(err) => Err(CliError::Internal(err)),
+    }
 }
 
 #[cfg(feature = "legacy")]

--- a/crates/but/tests/but/command/alias.rs
+++ b/crates/but/tests/but/command/alias.rs
@@ -26,32 +26,44 @@ fn local_alias_roundtrip_uses_repo_config() {
 }
 
 #[test]
-fn global_alias_roundtrip_uses_global_config() {
+fn global_aliases_work_outside_a_repository() {
     let env = Sandbox::empty();
-    env.invoke_bash("git init repo");
     let global_config = env.projects_root().join("global.gitconfig");
 
-    env.but("-C repo alias add st status --global")
+    env.but("alias add features 'config feature' --global")
         .env("GIT_CONFIG_GLOBAL", &global_config)
         .assert()
         .success();
     assert_eq!(
-        env.invoke_git("config --file global.gitconfig --get but.alias.st"),
-        "status"
-    );
-    env.invoke_git_fails(
-        "-C repo config --local --get but.alias.st",
-        "global alias should not touch the repo-local config",
+        env.invoke_git("config --file global.gitconfig --get but.alias.features"),
+        "config feature"
     );
 
-    env.but("-C repo alias remove st --global")
+    env.but("alias list")
+        .env("GIT_CONFIG_GLOBAL", &global_config)
+        .assert()
+        .success();
+
+    env.but("features")
+        .env("GIT_CONFIG_GLOBAL", &global_config)
+        .assert()
+        .success();
+
+    env.but("alias remove features --global")
         .env("GIT_CONFIG_GLOBAL", &global_config)
         .assert()
         .success();
     env.invoke_git_fails(
-        "config --file global.gitconfig --get but.alias.st",
+        "config --file global.gitconfig --get but.alias.features",
         "global alias should be removed from the configured global file",
     );
+    env.but("alias add mine status")
+        .assert()
+        .failure()
+        .stderr_eq(snapbox::str![[r#"
+Error: Local Git configuration requires a git repository
+
+"#]]);
 }
 
 #[cfg(feature = "legacy")]

--- a/crates/but/tests/but/command/config.rs
+++ b/crates/but/tests/but/command/config.rs
@@ -256,6 +256,21 @@ Error: Local Git configuration requires a git repository
 }
 
 #[test]
+fn global_user_configuration_creates_parent_for_relative_path() {
+    let env = Sandbox::empty();
+
+    env.but("config user set --global name 'Ada Lovelace'")
+        .env("GIT_CONFIG_GLOBAL", "nested/global.gitconfig")
+        .assert()
+        .success();
+    assert_eq!(
+        env.invoke_git("config --file nested/global.gitconfig --get user.name"),
+        "Ada Lovelace",
+        "relative global config paths are resolved against the command's working directory"
+    );
+}
+
+#[test]
 fn ai_openai_defaults_to_global_config() {
     let env = Sandbox::empty();
     env.invoke_bash("git init repo");

--- a/crates/but/tests/but/command/config.rs
+++ b/crates/but/tests/but/command/config.rs
@@ -192,6 +192,70 @@ fn feature_config_json_output_uses_stable_key() {
 }
 
 #[test]
+fn global_user_configuration_works_outside_a_repository() {
+    let env = Sandbox::empty();
+    let global_config = env.projects_root().join("global.gitconfig");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        let target = env.projects_root().join("actual.gitconfig");
+        std::fs::write(&target, "").unwrap();
+        std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o600)).unwrap();
+        std::os::unix::fs::symlink(&target, &global_config).unwrap();
+    }
+
+    env.but("config user set --global name 'Ada Lovelace'")
+        .env("GIT_CONFIG_GLOBAL", &global_config)
+        .assert()
+        .success();
+    assert_eq!(
+        env.invoke_git("config --file global.gitconfig --get user.name"),
+        "Ada Lovelace"
+    );
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        assert!(
+            std::fs::symlink_metadata(&global_config)
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "editing global config preserves its symlink"
+        );
+        assert_eq!(
+            std::fs::metadata(env.projects_root().join("actual.gitconfig"))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600,
+            "editing global config preserves its target's permissions"
+        );
+    }
+
+    env.but("config user")
+        .env("GIT_CONFIG_GLOBAL", &global_config)
+        .assert()
+        .success();
+
+    env.but("config user unset --global name")
+        .env("GIT_CONFIG_GLOBAL", &global_config)
+        .assert()
+        .success();
+    env.invoke_git_fails(
+        "config --file global.gitconfig --get user.name",
+        "global user name should be removed from the configured global file",
+    );
+    env.but("config user set name Byron")
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
+Error: Local Git configuration requires a git repository
+
+"#]]);
+}
+
+#[test]
 fn ai_openai_defaults_to_global_config() {
     let env = Sandbox::empty();
     env.invoke_bash("git init repo");

--- a/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/mod.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/mod.rs
@@ -252,36 +252,22 @@ fn update_current_head(repo: &gix::Repository, target: gix::ObjectId, message: &
 }
 
 fn set_head_symbolic(repo: &gix::Repository, target: &str) {
-    repo.edit_reference(gix::refs::transaction::RefEdit {
-        change: gix::refs::transaction::Change::Update {
-            log: gix::refs::transaction::LogChange {
-                mode: gix::refs::transaction::RefLog::AndReference,
-                force_create_reflog: false,
-                message: b"test: set HEAD".into(),
-            },
-            expected: PreviousValue::Any,
-            new: gix::refs::Target::Symbolic(target.try_into().unwrap()),
-        },
-        name: "HEAD".try_into().unwrap(),
-        deref: false,
-    })
+    repo.edit_reference(gix::refs::transaction::RefEdit::update(
+        "HEAD".try_into().unwrap(),
+        gix::refs::FullName::try_from(target).unwrap(),
+        PreviousValue::Any,
+        b"test: set HEAD".as_slice(),
+    ))
     .expect("HEAD can be set");
 }
 
 fn set_head_detached(repo: &gix::Repository, target: gix::ObjectId) {
-    repo.edit_reference(gix::refs::transaction::RefEdit {
-        change: gix::refs::transaction::Change::Update {
-            log: gix::refs::transaction::LogChange {
-                mode: gix::refs::transaction::RefLog::AndReference,
-                force_create_reflog: false,
-                message: b"test: detach HEAD".into(),
-            },
-            expected: PreviousValue::Any,
-            new: gix::refs::Target::Object(target),
-        },
-        name: "HEAD".try_into().unwrap(),
-        deref: false,
-    })
+    repo.edit_reference(gix::refs::transaction::RefEdit::update(
+        "HEAD".try_into().unwrap(),
+        target,
+        PreviousValue::Any,
+        b"test: detach HEAD".as_slice(),
+    ))
     .expect("HEAD can be detached");
 }
 

--- a/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/set_base_branch.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/set_base_branch.rs
@@ -721,7 +721,7 @@ mod behind_count {
             "branch C must be applied for the multi-stack behind-count scenario"
         );
         *workspace = outcome.workspace;
-        drop(workspace);
+        drop((repo, workspace));
         drop(guard);
 
         // Stack A is farthest behind (3 commits behind origin/master).

--- a/crates/gitbutler-edit-mode/tests/edit_mode.rs
+++ b/crates/gitbutler-edit-mode/tests/edit_mode.rs
@@ -233,19 +233,15 @@ fn multiple_commits_created_during_edit_mode() -> Result<()> {
         parents: [first_id.detach()].into(),
         ..commit
     })?;
-    repo.edit_reference(gix::refs::transaction::RefEdit {
-        change: gix::refs::transaction::Change::Update {
-            log: gix::refs::transaction::LogChange {
-                mode: gix::refs::transaction::RefLog::AndReference,
-                force_create_reflog: false,
-                message: b"arbitrary message".into(),
-            },
-            expected: gix::refs::transaction::PreviousValue::Any,
-            new: gix::refs::Target::Object(second_id.detach()),
-        },
-        name: "HEAD".try_into().unwrap(),
-        deref: true,
-    })?;
+    repo.edit_reference(
+        gix::refs::transaction::RefEdit::update(
+            "HEAD".try_into().unwrap(),
+            second_id.detach(),
+            gix::refs::transaction::PreviousValue::Any,
+            b"arbitrary message".as_slice(),
+        )
+        .with_deref(true),
+    )?;
     drop(repo);
 
     std::fs::write(worktree_dir.join("file"), "edited during edit mode\n")?;
@@ -309,19 +305,15 @@ fn apply_commit_on_itself() -> Result<()> {
         .find_reference("refs/heads/gitbutler/workspace")?
         .peel_to_commit()?
         .id;
-    repo.edit_reference(gix::refs::transaction::RefEdit {
-        change: gix::refs::transaction::Change::Update {
-            log: gix::refs::transaction::LogChange {
-                mode: gix::refs::transaction::RefLog::AndReference,
-                force_create_reflog: false,
-                message: b"arbitrary message".into(),
-            },
-            expected: gix::refs::transaction::PreviousValue::Any,
-            new: gix::refs::Target::Object(workspace_commit_id),
-        },
-        name: "HEAD".try_into().unwrap(),
-        deref: true,
-    })?;
+    repo.edit_reference(
+        gix::refs::transaction::RefEdit::update(
+            "HEAD".try_into().unwrap(),
+            workspace_commit_id,
+            gix::refs::transaction::PreviousValue::Any,
+            b"arbitrary message".as_slice(),
+        )
+        .with_deref(true),
+    )?;
     drop(repo);
 
     save_and_return_to_workspace(&mut ctx, guard.write_permission())?;
@@ -560,19 +552,12 @@ fn enter_edit_mode_works_with_only_integration_ref_present() -> Result<()> {
             gix::refs::transaction::PreviousValue::Any,
             "",
         )?;
-        repo.edit_reference(gix::refs::transaction::RefEdit {
-            change: gix::refs::transaction::Change::Update {
-                log: gix::refs::transaction::LogChange {
-                    mode: gix::refs::transaction::RefLog::AndReference,
-                    force_create_reflog: false,
-                    message: b"arbitrary message".into(),
-                },
-                expected: gix::refs::transaction::PreviousValue::Any,
-                new: gix::refs::Target::Symbolic(INTEGRATION_BRANCH_REF.try_into()?),
-            },
-            name: "HEAD".try_into().unwrap(),
-            deref: false,
-        })?;
+        repo.edit_reference(gix::refs::transaction::RefEdit::update(
+            "HEAD".try_into().unwrap(),
+            gix::refs::FullName::try_from(INTEGRATION_BRANCH_REF)?,
+            gix::refs::transaction::PreviousValue::Any,
+            b"arbitrary message".as_slice(),
+        ))?;
         repo.find_reference("refs/heads/gitbutler/workspace")?
             .delete()
             .context("expected workspace ref to exist")?;

--- a/crates/gitbutler-operating-modes/tests/operating_modes.rs
+++ b/crates/gitbutler-operating-modes/tests/operating_modes.rs
@@ -4,10 +4,7 @@ use but_testsupport::{
     open_repo,
 };
 use gitbutler_operating_modes::{EditModeMetadata, write_edit_mode_metadata};
-use gix::refs::{
-    Target,
-    transaction::{Change, LogChange, PreviousValue, RefEdit, RefLog},
-};
+use gix::refs::transaction::{PreviousValue, RefEdit};
 
 struct Case {
     ctx: Context,
@@ -40,19 +37,12 @@ fn create_and_checkout_branch(ctx: &Context, branch_name: &str) {
         "test branch creation",
     )
     .unwrap();
-    repo.edit_reference(RefEdit {
-        change: Change::Update {
-            log: LogChange {
-                mode: RefLog::AndReference,
-                force_create_reflog: false,
-                message: gix::reference::log::message("test", "switch HEAD".into(), 0),
-            },
-            expected: PreviousValue::Any,
-            new: Target::Symbolic(branch_ref),
-        },
-        name: "HEAD".try_into().unwrap(),
-        deref: false,
-    })
+    repo.edit_reference(RefEdit::update(
+        "HEAD".try_into().unwrap(),
+        branch_ref,
+        PreviousValue::Any,
+        gix::reference::log::message("test", "switch HEAD".into(), 0),
+    ))
     .unwrap();
 }
 

--- a/crates/gitbutler-project/src/controller.rs
+++ b/crates/gitbutler-project/src/controller.rs
@@ -65,7 +65,7 @@ fn resolve_project_repo_exact(
 fn resolve_project_repo_by_discovery(
     path: &Path,
 ) -> std::result::Result<ResolvedProjectRepo, AddProjectOutcome> {
-    let repo = match gix::discover(path) {
+    let repo = match gix::discover_opts(path, Default::default(), gix::open::Options::isolated()) {
         Ok(repo) => repo,
         Err(err) => return Err(AddProjectOutcome::NotAGitRepository(err.to_string())),
     };

--- a/crates/gitbutler-project/tests/project/main.rs
+++ b/crates/gitbutler-project/tests/project/main.rs
@@ -28,10 +28,11 @@ fn set_storage_path_config(
 ) -> anyhow::Result<gix::Repository> {
     let mut repo = but_testsupport::open_repo(repo_path)?;
     let key = but_project_handle::storage_path_config_key();
-    repo.config_snapshot_mut()
-        .set_raw_value(key, gix::path::os_str_into_bstr(value.as_ref())?)?;
-    let (_config, lock) = repo.local_common_config_for_editing()?;
-    repo.write_locked_config(&repo.config_snapshot(), lock)?;
+    but_core::git_config::edit_repo_config(&repo, gix::config::Source::Local, |config| {
+        config.set_raw_value(key, gix::path::os_str_into_bstr(value.as_ref())?)?;
+        Ok(())
+    })?;
+    repo.reload()?;
     Ok(repo)
 }
 

--- a/crates/gitbutler-repo/src/commands.rs
+++ b/crates/gitbutler-repo/src/commands.rs
@@ -3,7 +3,6 @@ use std::{path::Path, sync::Mutex};
 use anyhow::{Result, bail};
 use base64::engine::Engine as _;
 use bstr::ByteSlice as _;
-use but_core::commit::sign_buffer;
 use but_core::git_config::{edit_repo_config, ensure_config_value};
 use but_ctx::Context;
 use fuzzy_matcher::{FuzzyMatcher, skim::SkimMatcherV2};
@@ -217,9 +216,20 @@ pub trait RepoCommands {
 impl RepoCommands for Context {
     fn check_signing_settings(&self) -> Result<bool> {
         let repo = self.repo.get()?;
-        match sign_buffer(&repo, b"test") {
+        let opts = repo.commit_signing_options()?;
+        let null = repo.object_hash().null();
+        let res = gix::objs::Tag {
+            target: null,
+            target_kind: gix::objs::Kind::Commit,
+            name: "test".into(),
+            tagger: None,
+            message: "test message".into(),
+            signature: None,
+        }
+        .sign(opts);
+        match res {
             Ok(_) => Ok(true),
-            Err(e) => Err(e),
+            Err(e) => Err(e.into()),
         }
     }
 

--- a/packages/but-sdk/src/generated/graph/index.d.ts
+++ b/packages/but-sdk/src/generated/graph/index.d.ts
@@ -29,7 +29,7 @@ export declare function absorptionPlan(projectId: string, target: AbsorptionTarg
 /**
  * Add the caller's reaction to one comment.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:863}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:888}
  */
 export declare function addCommentReaction(projectId: string, commentId: number, kind: string): Promise<ForgeReviewReaction>
 
@@ -44,14 +44,14 @@ export declare function addProject(path: string): Promise<AddProjectOutcome>
 /**
  * Add labels to a review; returns the resulting label set.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:991}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1016}
  */
 export declare function addReviewLabels(projectId: string, reviewId: number, labels: Array<string>): Promise<Array<ForgeReviewLabel>>
 
 /**
  * Add the caller's reaction to a review itself.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:825}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:850}
  */
 export declare function addReviewReaction(projectId: string, reviewId: number, kind: string): Promise<ForgeReviewReaction>
 
@@ -135,7 +135,7 @@ export declare function apply(projectId: string, existingBranch: string): Promis
  * `dry_run` is enabled, the returned workspace previews the integration
  * result and no oplog entry is persisted.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1822}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1814}
  */
 export declare function applyBranchIntegration(projectId: string, branch: string, integration: InteractiveIntegration, dryRun: boolean): Promise<IntegrateBranchResult>
 
@@ -174,7 +174,7 @@ export declare function branchCannedName(projectId: string): Promise<string>
  * symbolically at `branch`. The branch must be an existing full local branch
  * name under `refs/heads/`.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1523}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1515}
  */
 export declare function branchCheckout(projectId: string, branch: FullNameBytes): Promise<BranchCheckoutResult>
 
@@ -186,7 +186,7 @@ export declare function branchCheckout(projectId: string, branch: FullNameBytes)
  * before creating `refs/heads/<name>`. If omitted, a unique canned branch name
  * is generated. The resulting branch must not already exist.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1539}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1531}
  */
 export declare function branchCheckoutNew(projectId: string, name: string | null): Promise<BranchCheckoutResult>
 
@@ -215,7 +215,7 @@ export declare function branchDetails(projectId: string, branchName: string, rem
  * diff is computed against the current workspace state. For lower-level
  * implementation details, see [`but_workspace::ui::diff::changes_in_branch()`].
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1719}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1711}
  */
 export declare function branchDiff(projectId: string, branch: string): Promise<TreeChanges>
 
@@ -248,7 +248,7 @@ export declare function branchLand(projectId: string, branch: string, noFf: bool
  * workspace-related ones. Ahead-counts are relative to the
  * project's configured target branch, which clients know from the project APIs.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1736}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1728}
  */
 export declare function branchList(projectId: string): Promise<Array<ListedStack>>
 
@@ -281,7 +281,7 @@ export declare function branchRemove(projectId: string, refName: FullNameBytes):
  * It requires no stack id and works in both managed and ad-hoc/single-branch
  * workspaces.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1222}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1214}
  */
 export declare function branchRename(projectId: string, refName: FullNameBytes, newName: string): Promise<BranchRenameResult>
 
@@ -577,14 +577,14 @@ export declare function commitUncommitChangesFromCommits(projectId: string, sour
 /**
  * Post a top-level conversation comment on a review.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1077}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1102}
  */
 export declare function createReviewComment(projectId: string, reviewId: number, body: string): Promise<ForgeReviewComment>
 
 /**
  * Reply into one of a review's diff-anchored comment threads.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:777}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:802}
  */
 export declare function createReviewThreadReply(projectId: string, threadId: string, body: string): Promise<ForgeReviewThreadComment>
 
@@ -592,12 +592,12 @@ export declare function createReviewThreadReply(projectId: string, threadId: str
  * The login this project's forge calls authenticate as, if any account is
  * configured. Resolved from stored accounts; no network.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:964}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:989}
  */
 export declare function currentForgeLogin(projectId: string): Promise<string | null>
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/git.rs:68}
+ * {@link ../../../../../crates/but-api/src/legacy/git.rs:66}
  */
 export declare function deleteAllData(): Promise<void>
 
@@ -609,7 +609,7 @@ export declare function deleteProject(projectId: ProjectHandleOrLegacyProjectId)
 /**
  * Delete a top-level conversation comment on a review.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:949}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:974}
  */
 export declare function deleteReviewComment(projectId: string, commentId: number): Promise<void>
 
@@ -817,7 +817,7 @@ export declare function getGlUser(account: GitlabAccountIdentifier): Promise<Git
 /**
  * Get the initial upstream integration script for `branch`.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1798}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1790}
  */
 export declare function getInitialBranchIntegration(projectId: string, branch: string, strategy: BranchIntegrationStrategy | null): Promise<InitialBranchIntegration>
 
@@ -836,22 +836,22 @@ export declare function getLoginToken(): Promise<LoginToken>
 export declare function getRedoTargetSnapshot(projectId: string): Promise<Snapshot | null>
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1132}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1157}
  */
 export declare function getRepoInfo(projectId: string): Promise<RepoInfo>
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1106}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1131}
  */
 export declare function getReview(projectId: string, reviewId: number): Promise<ForgeReview>
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:736}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:761}
  */
 export declare function getReviewBaseRepoUrl(projectId: string, reviewId: number): Promise<string | null>
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1095}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1120}
  */
 export declare function getReviewMergeStatus(projectId: string, reviewId: number): Promise<ReviewMergeStatus>
 
@@ -902,12 +902,12 @@ export declare function getWorkspace(projectId: string): Promise<DetailedGraphWo
 export declare function getWorkspaceFile(projectId: string, relativePath: string): Promise<FileInfo>
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/git.rs:41}
+ * {@link ../../../../../crates/but-api/src/legacy/git.rs:39}
  */
 export declare function gitTestFetch(projectId: string, remoteName: string, action: string | null): Promise<void>
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/git.rs:30}
+ * {@link ../../../../../crates/but-api/src/legacy/git.rs:28}
  */
 export declare function gitTestPush(projectId: string, remoteName: string, branchName: string): Promise<void>
 
@@ -954,19 +954,19 @@ export declare function initGithubDeviceOauth(): Promise<Verification>
 export declare function listAvailableReviewTemplates(projectId: string): Promise<Array<string>>
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/virtual_branches.rs:682}
+ * {@link ../../../../../crates/but-api/src/legacy/virtual_branches.rs:678}
  */
 export declare function listBranches(projectId: string, filter: BranchListingFilter | null): Promise<Array<BranchListing>>
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1155}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1180}
  */
 export declare function listCiChecks(projectId: string, reference: string, cacheConfig: CacheConfig | null): Promise<Array<CiCheck>>
 
 /**
  * List the individual reactions (with who reacted) on one comment.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:808}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:833}
  */
 export declare function listCommentReactions(projectId: string, commentId: number): Promise<Array<ForgeReviewReaction>>
 
@@ -1034,28 +1034,28 @@ export declare function listProjectsStateless(): Promise<Array<ProjectForFronten
 /**
  * List the labels defined on the repository backing this project's reviews.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:983}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1008}
  */
 export declare function listRepoLabels(projectId: string): Promise<Array<ForgeReviewLabel>>
 
 /**
  * List the top-level conversation comments on a review, oldest first.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:753}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:778}
  */
 export declare function listReviewComments(projectId: string, reviewId: number): Promise<Array<ForgeReviewComment>>
 
 /**
  * List users who can be requested to review on this project's repository.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1029}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1054}
  */
 export declare function listReviewerCandidates(projectId: string): Promise<Array<ForgeReviewUser>>
 
 /**
  * List the individual reactions (with who reacted) on a review itself.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:796}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:821}
  */
 export declare function listReviewReactions(projectId: string, reviewId: number): Promise<Array<ForgeReviewReaction>>
 
@@ -1065,28 +1065,28 @@ export declare function listReviewReactions(projectId: string, reviewId: number)
 export declare function listReviews(projectId: string, cacheConfig: CacheConfig | null): Promise<Array<ForgeReview>>
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:2140}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:2165}
  */
 export declare function listReviewsForBranch(projectId: string, branch: string, filter: ForgeReviewFilter | null): Promise<Array<ForgeReview>>
 
 /**
  * List the submitted reviews (approvals, change requests) on a review.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:918}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:943}
  */
 export declare function listReviewSubmissions(projectId: string, reviewId: number): Promise<Array<ForgeReviewSubmission>>
 
 /**
  * List the diff-anchored comment threads on a review, oldest first.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:765}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:790}
  */
 export declare function listReviewThreads(projectId: string, reviewId: number): Promise<Array<ForgeReviewThread>>
 
 /**
  * List the pushed commits and review requests on a review's timeline.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:901}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:926}
  */
 export declare function listReviewTimelineEvents(projectId: string, reviewId: number): Promise<Array<ForgeReviewTimelineEvent>>
 
@@ -1119,7 +1119,7 @@ export declare function loginAndPersist(token: string): Promise<UserProfile>
 /**
  * Merge a review on the forge.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1314}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1339}
  */
 export declare function mergeReview(projectId: string, reviewId: number, mergeMethod: ReviewMergeMethod | null): Promise<void>
 
@@ -1131,7 +1131,7 @@ export declare function mergeReview(projectId: string, reviewId: number, mergeMe
  * `dry_run` is enabled, the returned workspace previews the move and no oplog
  * entry is persisted.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1879}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1871}
  */
 export declare function moveBranch(projectId: string, subjectBranch: string, targetBranch: string, dryRun: boolean): Promise<MoveBranchResult>
 
@@ -1244,7 +1244,7 @@ export declare const enum ProgramCategory {
 }
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1193}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1218}
  */
 export declare function publishReview(projectId: string, params: PublishReviewInput): Promise<PublishReviewOutcome>
 
@@ -1264,28 +1264,28 @@ export declare function removeBranch(projectId: string, stackId: string, branchN
 /**
  * Remove one of the caller's reactions from one comment.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:882}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:907}
  */
 export declare function removeCommentReaction(projectId: string, commentId: number, reactionId: number): Promise<void>
 
 /**
  * Remove one label from a review.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1010}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1035}
  */
 export declare function removeReviewLabel(projectId: string, reviewId: number, label: string): Promise<void>
 
 /**
  * Remove one of the caller's reactions from a review itself.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:844}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:869}
  */
 export declare function removeReviewReaction(projectId: string, reviewId: number, reactionId: number): Promise<void>
 
 /**
  * Request reviews from the given users on a review.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1039}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1064}
  */
 export declare function requestReview(projectId: string, reviewId: number, logins: Array<string>): Promise<void>
 
@@ -1375,14 +1375,14 @@ export declare function setPushRemote(projectId: string, pushRemote: string): Pr
 /**
  * Enable or disable a review's auto-merge.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1334}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1359}
  */
 export declare function setReviewAutoMerge(projectId: string, reviewId: number, enable: boolean): Promise<void>
 
 /**
  * Set a review to draft or ready-for-review
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1354}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1379}
  */
 export declare function setReviewDraftiness(projectId: string, reviewId: number, draft: boolean): Promise<void>
 
@@ -1475,7 +1475,7 @@ export declare function storeGitlabPat(accessToken: string): Promise<GitlabAuthS
  * `dry_run` is enabled, the returned workspace previews the tear-off and no
  * oplog entry is persisted.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1966}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1958}
  */
 export declare function tearOffBranch(projectId: string, subjectBranch: string, dryRun: boolean): Promise<MoveBranchResult>
 
@@ -1498,7 +1498,7 @@ export declare function treeChangeDiffs(projectId: string, change: TreeChange): 
  * See [`unapply_stack_with_perm()`] for how assigned changes are collected before
  * delegating to the underlying mutation.
  *
- * {@link ../../../../../crates/but-api/src/legacy/virtual_branches.rs:468}
+ * {@link ../../../../../crates/but-api/src/legacy/virtual_branches.rs:463}
  */
 export declare function unapplyStack(projectId: string, stackId: string): Promise<void>
 
@@ -1530,21 +1530,21 @@ export declare function updateProjectSettings(projectId: ProjectHandleOrLegacyPr
  * Update arbitrary fields of a single review (title, body, state, target base).
  * Each `None` leaves that field unchanged on the forge.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1386}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1411}
  */
 export declare function updateReview(projectId: string, reviewId: number, title: string | null, body: string | null, state: ReviewState | null, targetBase: string | null): Promise<void>
 
 /**
  * Edit a top-level conversation comment on a review.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:930}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:955}
  */
 export declare function updateReviewComment(projectId: string, commentId: number, body: string): Promise<ForgeReviewComment>
 
 /**
  * Update stacked reviews: description footers and, optionally, target branches.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1410}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1435}
  */
 export declare function updateReviewFooters(projectId: string, reviews: Array<ForgeReviewUpdate>): Promise<void>
 
@@ -1566,14 +1566,14 @@ export declare function uploadFile(params: UploadFileParams): Promise<Upload>
  * Additionally, it cleans up stale CI check entries for references that are no longer
  * part of any applied stack.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:2174}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:2199}
  */
 export declare function warmCiChecksCache(projectId: string): Promise<void>
 
 /**
  * Withdraw review requests for the given users on a review.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1058}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1083}
  */
 export declare function withdrawReviewRequest(projectId: string, reviewId: number, logins: Array<string>): Promise<void>
 
@@ -1587,7 +1587,7 @@ export declare function workspaceBranchAndAncestorsPush(projectId: string, withF
 /**
  * Switch to the workspace reference
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1585}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1577}
  */
 export declare function workspaceCheckout(projectId: string): Promise<BranchCheckoutResult>
 

--- a/packages/but-sdk/src/generated/linear/index.d.ts
+++ b/packages/but-sdk/src/generated/linear/index.d.ts
@@ -29,7 +29,7 @@ export declare function absorptionPlan(projectId: string, target: AbsorptionTarg
 /**
  * Add the caller's reaction to one comment.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:863}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:888}
  */
 export declare function addCommentReaction(projectId: string, commentId: number, kind: string): Promise<ForgeReviewReaction>
 
@@ -44,14 +44,14 @@ export declare function addProject(path: string): Promise<AddProjectOutcome>
 /**
  * Add labels to a review; returns the resulting label set.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:991}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1016}
  */
 export declare function addReviewLabels(projectId: string, reviewId: number, labels: Array<string>): Promise<Array<ForgeReviewLabel>>
 
 /**
  * Add the caller's reaction to a review itself.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:825}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:850}
  */
 export declare function addReviewReaction(projectId: string, reviewId: number, kind: string): Promise<ForgeReviewReaction>
 
@@ -135,7 +135,7 @@ export declare function apply(projectId: string, existingBranch: string): Promis
  * `dry_run` is enabled, the returned workspace previews the integration
  * result and no oplog entry is persisted.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1822}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1814}
  */
 export declare function applyBranchIntegration(projectId: string, branch: string, integration: InteractiveIntegration, dryRun: boolean): Promise<IntegrateBranchResult>
 
@@ -174,7 +174,7 @@ export declare function branchCannedName(projectId: string): Promise<string>
  * symbolically at `branch`. The branch must be an existing full local branch
  * name under `refs/heads/`.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1523}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1515}
  */
 export declare function branchCheckout(projectId: string, branch: FullNameBytes): Promise<BranchCheckoutResult>
 
@@ -186,7 +186,7 @@ export declare function branchCheckout(projectId: string, branch: FullNameBytes)
  * before creating `refs/heads/<name>`. If omitted, a unique canned branch name
  * is generated. The resulting branch must not already exist.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1539}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1531}
  */
 export declare function branchCheckoutNew(projectId: string, name: string | null): Promise<BranchCheckoutResult>
 
@@ -215,7 +215,7 @@ export declare function branchDetails(projectId: string, branchName: string, rem
  * diff is computed against the current workspace state. For lower-level
  * implementation details, see [`but_workspace::ui::diff::changes_in_branch()`].
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1719}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1711}
  */
 export declare function branchDiff(projectId: string, branch: string): Promise<TreeChanges>
 
@@ -248,7 +248,7 @@ export declare function branchLand(projectId: string, branch: string, noFf: bool
  * workspace-related ones. Ahead-counts are relative to the
  * project's configured target branch, which clients know from the project APIs.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1736}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1728}
  */
 export declare function branchList(projectId: string): Promise<Array<ListedStack>>
 
@@ -281,7 +281,7 @@ export declare function branchRemove(projectId: string, refName: FullNameBytes):
  * It requires no stack id and works in both managed and ad-hoc/single-branch
  * workspaces.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1222}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1214}
  */
 export declare function branchRename(projectId: string, refName: FullNameBytes, newName: string): Promise<BranchRenameResult>
 
@@ -577,14 +577,14 @@ export declare function commitUncommitChangesFromCommits(projectId: string, sour
 /**
  * Post a top-level conversation comment on a review.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1077}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1102}
  */
 export declare function createReviewComment(projectId: string, reviewId: number, body: string): Promise<ForgeReviewComment>
 
 /**
  * Reply into one of a review's diff-anchored comment threads.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:777}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:802}
  */
 export declare function createReviewThreadReply(projectId: string, threadId: string, body: string): Promise<ForgeReviewThreadComment>
 
@@ -592,12 +592,12 @@ export declare function createReviewThreadReply(projectId: string, threadId: str
  * The login this project's forge calls authenticate as, if any account is
  * configured. Resolved from stored accounts; no network.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:964}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:989}
  */
 export declare function currentForgeLogin(projectId: string): Promise<string | null>
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/git.rs:68}
+ * {@link ../../../../../crates/but-api/src/legacy/git.rs:66}
  */
 export declare function deleteAllData(): Promise<void>
 
@@ -609,7 +609,7 @@ export declare function deleteProject(projectId: ProjectHandleOrLegacyProjectId)
 /**
  * Delete a top-level conversation comment on a review.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:949}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:974}
  */
 export declare function deleteReviewComment(projectId: string, commentId: number): Promise<void>
 
@@ -817,7 +817,7 @@ export declare function getGlUser(account: GitlabAccountIdentifier): Promise<Git
 /**
  * Get the initial upstream integration script for `branch`.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1798}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1790}
  */
 export declare function getInitialBranchIntegration(projectId: string, branch: string, strategy: BranchIntegrationStrategy | null): Promise<InitialBranchIntegration>
 
@@ -836,22 +836,22 @@ export declare function getLoginToken(): Promise<LoginToken>
 export declare function getRedoTargetSnapshot(projectId: string): Promise<Snapshot | null>
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1132}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1157}
  */
 export declare function getRepoInfo(projectId: string): Promise<RepoInfo>
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1106}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1131}
  */
 export declare function getReview(projectId: string, reviewId: number): Promise<ForgeReview>
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:736}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:761}
  */
 export declare function getReviewBaseRepoUrl(projectId: string, reviewId: number): Promise<string | null>
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1095}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1120}
  */
 export declare function getReviewMergeStatus(projectId: string, reviewId: number): Promise<ReviewMergeStatus>
 
@@ -902,12 +902,12 @@ export declare function getWorkspace(projectId: string): Promise<DetailedGraphWo
 export declare function getWorkspaceFile(projectId: string, relativePath: string): Promise<FileInfo>
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/git.rs:41}
+ * {@link ../../../../../crates/but-api/src/legacy/git.rs:39}
  */
 export declare function gitTestFetch(projectId: string, remoteName: string, action: string | null): Promise<void>
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/git.rs:30}
+ * {@link ../../../../../crates/but-api/src/legacy/git.rs:28}
  */
 export declare function gitTestPush(projectId: string, remoteName: string, branchName: string): Promise<void>
 
@@ -954,19 +954,19 @@ export declare function initGithubDeviceOauth(): Promise<Verification>
 export declare function listAvailableReviewTemplates(projectId: string): Promise<Array<string>>
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/virtual_branches.rs:682}
+ * {@link ../../../../../crates/but-api/src/legacy/virtual_branches.rs:678}
  */
 export declare function listBranches(projectId: string, filter: BranchListingFilter | null): Promise<Array<BranchListing>>
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1155}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1180}
  */
 export declare function listCiChecks(projectId: string, reference: string, cacheConfig: CacheConfig | null): Promise<Array<CiCheck>>
 
 /**
  * List the individual reactions (with who reacted) on one comment.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:808}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:833}
  */
 export declare function listCommentReactions(projectId: string, commentId: number): Promise<Array<ForgeReviewReaction>>
 
@@ -1034,28 +1034,28 @@ export declare function listProjectsStateless(): Promise<Array<ProjectForFronten
 /**
  * List the labels defined on the repository backing this project's reviews.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:983}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1008}
  */
 export declare function listRepoLabels(projectId: string): Promise<Array<ForgeReviewLabel>>
 
 /**
  * List the top-level conversation comments on a review, oldest first.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:753}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:778}
  */
 export declare function listReviewComments(projectId: string, reviewId: number): Promise<Array<ForgeReviewComment>>
 
 /**
  * List users who can be requested to review on this project's repository.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1029}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1054}
  */
 export declare function listReviewerCandidates(projectId: string): Promise<Array<ForgeReviewUser>>
 
 /**
  * List the individual reactions (with who reacted) on a review itself.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:796}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:821}
  */
 export declare function listReviewReactions(projectId: string, reviewId: number): Promise<Array<ForgeReviewReaction>>
 
@@ -1065,28 +1065,28 @@ export declare function listReviewReactions(projectId: string, reviewId: number)
 export declare function listReviews(projectId: string, cacheConfig: CacheConfig | null): Promise<Array<ForgeReview>>
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:2140}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:2165}
  */
 export declare function listReviewsForBranch(projectId: string, branch: string, filter: ForgeReviewFilter | null): Promise<Array<ForgeReview>>
 
 /**
  * List the submitted reviews (approvals, change requests) on a review.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:918}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:943}
  */
 export declare function listReviewSubmissions(projectId: string, reviewId: number): Promise<Array<ForgeReviewSubmission>>
 
 /**
  * List the diff-anchored comment threads on a review, oldest first.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:765}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:790}
  */
 export declare function listReviewThreads(projectId: string, reviewId: number): Promise<Array<ForgeReviewThread>>
 
 /**
  * List the pushed commits and review requests on a review's timeline.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:901}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:926}
  */
 export declare function listReviewTimelineEvents(projectId: string, reviewId: number): Promise<Array<ForgeReviewTimelineEvent>>
 
@@ -1119,7 +1119,7 @@ export declare function loginAndPersist(token: string): Promise<UserProfile>
 /**
  * Merge a review on the forge.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1314}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1339}
  */
 export declare function mergeReview(projectId: string, reviewId: number, mergeMethod: ReviewMergeMethod | null): Promise<void>
 
@@ -1131,7 +1131,7 @@ export declare function mergeReview(projectId: string, reviewId: number, mergeMe
  * `dry_run` is enabled, the returned workspace previews the move and no oplog
  * entry is persisted.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1879}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1871}
  */
 export declare function moveBranch(projectId: string, subjectBranch: string, targetBranch: string, dryRun: boolean): Promise<MoveBranchResult>
 
@@ -1244,7 +1244,7 @@ export declare const enum ProgramCategory {
 }
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1193}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1218}
  */
 export declare function publishReview(projectId: string, params: PublishReviewInput): Promise<PublishReviewOutcome>
 
@@ -1264,28 +1264,28 @@ export declare function removeBranch(projectId: string, stackId: string, branchN
 /**
  * Remove one of the caller's reactions from one comment.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:882}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:907}
  */
 export declare function removeCommentReaction(projectId: string, commentId: number, reactionId: number): Promise<void>
 
 /**
  * Remove one label from a review.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1010}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1035}
  */
 export declare function removeReviewLabel(projectId: string, reviewId: number, label: string): Promise<void>
 
 /**
  * Remove one of the caller's reactions from a review itself.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:844}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:869}
  */
 export declare function removeReviewReaction(projectId: string, reviewId: number, reactionId: number): Promise<void>
 
 /**
  * Request reviews from the given users on a review.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1039}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1064}
  */
 export declare function requestReview(projectId: string, reviewId: number, logins: Array<string>): Promise<void>
 
@@ -1375,14 +1375,14 @@ export declare function setPushRemote(projectId: string, pushRemote: string): Pr
 /**
  * Enable or disable a review's auto-merge.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1334}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1359}
  */
 export declare function setReviewAutoMerge(projectId: string, reviewId: number, enable: boolean): Promise<void>
 
 /**
  * Set a review to draft or ready-for-review
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1354}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1379}
  */
 export declare function setReviewDraftiness(projectId: string, reviewId: number, draft: boolean): Promise<void>
 
@@ -1475,7 +1475,7 @@ export declare function storeGitlabPat(accessToken: string): Promise<GitlabAuthS
  * `dry_run` is enabled, the returned workspace previews the tear-off and no
  * oplog entry is persisted.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1966}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1958}
  */
 export declare function tearOffBranch(projectId: string, subjectBranch: string, dryRun: boolean): Promise<MoveBranchResult>
 
@@ -1498,7 +1498,7 @@ export declare function treeChangeDiffs(projectId: string, change: TreeChange): 
  * See [`unapply_stack_with_perm()`] for how assigned changes are collected before
  * delegating to the underlying mutation.
  *
- * {@link ../../../../../crates/but-api/src/legacy/virtual_branches.rs:468}
+ * {@link ../../../../../crates/but-api/src/legacy/virtual_branches.rs:463}
  */
 export declare function unapplyStack(projectId: string, stackId: string): Promise<void>
 
@@ -1530,21 +1530,21 @@ export declare function updateProjectSettings(projectId: ProjectHandleOrLegacyPr
  * Update arbitrary fields of a single review (title, body, state, target base).
  * Each `None` leaves that field unchanged on the forge.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1386}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1411}
  */
 export declare function updateReview(projectId: string, reviewId: number, title: string | null, body: string | null, state: ReviewState | null, targetBase: string | null): Promise<void>
 
 /**
  * Edit a top-level conversation comment on a review.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:930}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:955}
  */
 export declare function updateReviewComment(projectId: string, commentId: number, body: string): Promise<ForgeReviewComment>
 
 /**
  * Update stacked reviews: description footers and, optionally, target branches.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1410}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1435}
  */
 export declare function updateReviewFooters(projectId: string, reviews: Array<ForgeReviewUpdate>): Promise<void>
 
@@ -1566,14 +1566,14 @@ export declare function uploadFile(params: UploadFileParams): Promise<Upload>
  * Additionally, it cleans up stale CI check entries for references that are no longer
  * part of any applied stack.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:2174}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:2199}
  */
 export declare function warmCiChecksCache(projectId: string): Promise<void>
 
 /**
  * Withdraw review requests for the given users on a review.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1058}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1083}
  */
 export declare function withdrawReviewRequest(projectId: string, reviewId: number, logins: Array<string>): Promise<void>
 
@@ -1587,7 +1587,7 @@ export declare function workspaceBranchAndAncestorsPush(projectId: string, withF
 /**
  * Switch to the workspace reference
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1585}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1577}
  */
 export declare function workspaceCheckout(projectId: string): Promise<BranchCheckoutResult>
 


### PR DESCRIPTION
This also adds support for all other signing options and settings, allowing GB to sign like Git.

### Tasks

* [x] SHA-256 signing
* [x] RefEdit simplification
* [x] [bring in Windows signing fix](https://github.com/GitoxideLabs/gitoxide/pull/2958)
* [x] review most recent commit
* [x] one more `gix` update for an important performance fix and some improvements

### Notes for the Reviewer

* I noticed that we ignored `commit.gpgSign` entirely, which is bad if users need signed commit and expect GB to do the same. It's easy to fix by using `repo.commit_signing_options_if_enabled()`. It's not done here though but can be done in a follow-up commit.
* I made sure specifically that this also (still) works on Windows, but this time implemented properly. This codebase used a hacky fix which wasn't equivalent to what Git does.
* `but alias` now works without a Git repository underneath.
* multiple remote URLs are now handled properly