### PR TITLE
Show and resolve branch divergence in lite

### DIFF
--- a/apps/lite/e2e/diverge.ts
+++ b/apps/lite/e2e/diverge.ts
@@ -1,0 +1,79 @@
+import { execFileSync } from "node:child_process";
+import { appendFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { paths, processEnvironment, type LiteTestEnvironment } from "./setup.ts";
+
+/**
+ * branch1 applied and diverged: one commit only here, two only on the remote,
+ * both sides editing `a_file` so a rebase conflicts. Reload the app afterwards.
+ */
+export const divergeBranch1 = (environment: LiteTestEnvironment): void => {
+	const but = process.env.BUT ?? path.join(paths.repoRoot, "target/debug/but");
+	const env = processEnvironment({
+		BUT: but,
+		E2E_TEST_APP_DATA_DIR: environment.appDataDir,
+		GIT_CONFIG_GLOBAL: environment.gitConfig,
+	});
+	const clone = path.join(environment.workdir, "local-clone");
+	const remote = path.join(environment.workdir, "remote-project");
+	const git = (cwd: string, ...args: Array<string>) => execFileSync("git", args, { cwd, env });
+
+	execFileSync(but, ["apply", "branch1"], { cwd: clone, env });
+
+	// branch1 is not checked out in the remote, so it can be rewritten in place.
+	git(remote, "checkout", "branch1");
+	git(remote, "reset", "--hard", "HEAD~1");
+	appendFileSync(path.join(remote, "a_file"), "reworked upstream\n");
+	git(remote, "commit", "-am", "Rework the parser entry point");
+	writeFileSync(path.join(remote, "upstream_docs.md"), "docs for the rework\n");
+	git(remote, "add", ".");
+	git(remote, "commit", "-m", "Document the reworked entry point");
+	git(remote, "checkout", "master");
+
+	git(clone, "fetch", "origin");
+};
+
+/**
+ * The amend-shaped divergence: branch1's tip reworded locally. Head info prunes
+ * the remote's twin, so only the push status shows it.
+ */
+export const rewriteBranch1Tip = (environment: LiteTestEnvironment): void => {
+	const but = process.env.BUT ?? path.join(paths.repoRoot, "target/debug/but");
+	const env = processEnvironment({
+		BUT: but,
+		E2E_TEST_APP_DATA_DIR: environment.appDataDir,
+		GIT_CONFIG_GLOBAL: environment.gitConfig,
+	});
+	const clone = path.join(environment.workdir, "local-clone");
+
+	execFileSync(but, ["apply", "branch1"], { cwd: clone, env });
+	const tip = execFileSync("git", ["-C", clone, "rev-parse", "refs/heads/branch1"], {
+		encoding: "utf8",
+	}).trim();
+	execFileSync(but, ["reword", tip, "-m", "Reworded locally"], { cwd: clone, env });
+};
+
+/**
+ * Both kinds: the tip reworded locally while the remote gained a commit on top
+ * of the original, so combining must not land the rewritten one twice.
+ */
+export const divergeBoth = (environment: LiteTestEnvironment): void => {
+	rewriteBranch1Tip(environment);
+
+	const env = processEnvironment({
+		E2E_TEST_APP_DATA_DIR: environment.appDataDir,
+		GIT_CONFIG_GLOBAL: environment.gitConfig,
+	});
+	const clone = path.join(environment.workdir, "local-clone");
+	const remote = path.join(environment.workdir, "remote-project");
+	const git = (cwd: string, ...args: Array<string>) => execFileSync("git", args, { cwd, env });
+
+	// The collaborator adds on top of the tip as the remote still has it.
+	git(remote, "checkout", "branch1");
+	writeFileSync(path.join(remote, "upstream_notes.md"), "notes from upstream\n");
+	git(remote, "add", ".");
+	git(remote, "commit", "-m", "Add upstream notes");
+	git(remote, "checkout", "master");
+
+	git(clone, "fetch", "origin");
+};

--- a/apps/lite/e2e/tests/branch-update.spec.ts
+++ b/apps/lite/e2e/tests/branch-update.spec.ts
@@ -1,0 +1,253 @@
+// The update-from-remote flow applied for real with every answer, against the
+// divergences diverge.ts builds, asserting the resulting git history.
+
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import type { Page } from "@playwright/test";
+import { divergeBoth, divergeBranch1, rewriteBranch1Tip } from "../diverge.ts";
+import { expect, test } from "../test.ts";
+
+const dialog = '[aria-labelledby="branch-update-heading"]';
+
+const logSubjects = (clone: string): Array<string> =>
+	execFileSync("git", ["-C", clone, "log", "--format=%s", "refs/heads/branch1"], {
+		encoding: "utf8",
+	})
+		.trim()
+		.split("\n");
+
+const openUpdateDialog = async (appWindow: Page): Promise<void> => {
+	await appWindow.reload();
+	await appWindow.getByRole("main").waitFor();
+	await appWindow.getByLabel("Integrate origin/branch1 into branch1").click();
+	// The summary renders once the dry-run preview for the default answer is in.
+	await expect(appWindow.getByText(/incoming commit/)).toBeVisible();
+};
+
+const applyChoice = async (
+	appWindow: Page,
+	choice: "Keep mine" | "Combine both" | "Take theirs",
+	action: "Force push" | "Integrate" | "Replace branch",
+): Promise<void> => {
+	const chip = appWindow.locator(dialog).getByRole("button", { name: choice, exact: true });
+	// A pressed toggle does not take another click.
+	if ((await chip.getAttribute("aria-pressed")) !== "true") await chip.click();
+	const button = appWindow.locator(dialog).getByRole("button", { name: action, exact: true });
+	// Disabled while the outline still shows the previous choice's data.
+	await expect(button).toBeEnabled();
+	await button.click();
+	await expect(
+		appWindow.getByText(
+			action === "Integrate"
+				? "Branch updated."
+				: action === "Force push"
+					? "Branch published."
+					: "Branch replaced.",
+		),
+	).toBeVisible();
+};
+
+const finishWith = async (
+	appWindow: Page,
+	action: "Done" | "Push" | "Force push",
+): Promise<void> => {
+	if (action !== "Done") {
+		await appWindow.locator(dialog).getByRole("button", { name: action, exact: true }).click();
+		await expect(appWindow.getByText("Branch published.")).toBeVisible();
+	}
+	await appWindow.locator(dialog).getByRole("button", { name: "Done", exact: true }).click();
+	await expect(appWindow.locator(dialog)).toBeHidden();
+};
+
+const expectIncomingGone = async (appWindow: Page): Promise<void> => {
+	await expect(appWindow.getByRole("button", { name: /incoming commit/ })).toHaveCount(0);
+};
+
+test.describe("update from remote", () => {
+	// Each test launches Electron and runs a real integration; 30s is not enough.
+	test.describe.configure({ timeout: 180_000 });
+	test.use({ scenario: "project-with-remote-branches.sh" });
+
+	test("a rewritten branch says so in its row and has nothing to bring in", async ({
+		appWindow,
+		testEnvironment,
+	}) => {
+		rewriteBranch1Tip(testEnvironment);
+		await appWindow.reload();
+		await appWindow.getByRole("main").waitFor();
+
+		// Head info prunes the remote twin, so nothing is new: the word carries the state.
+		await expect(appWindow.getByText("Rewritten", { exact: true })).toBeVisible();
+		await expect(appWindow.getByRole("button", { name: /incoming commit/ })).toHaveCount(0);
+		await expect(appWindow.getByLabel("Integrate origin/branch1 into branch1")).toHaveCount(0);
+	});
+
+	test("keep mine force-pushes the rewritten branch over their additions", async ({
+		appWindow,
+		testEnvironment,
+	}) => {
+		divergeBoth(testEnvironment);
+		await openUpdateDialog(appWindow);
+
+		// Keep mine with a twin and an addition to drop: the action is the push itself.
+		await applyChoice(appWindow, "Keep mine", "Force push");
+		await finishWith(appWindow, "Done");
+
+		const clone = path.join(testEnvironment.workdir, "local-clone");
+		const local = execFileSync("git", ["-C", clone, "rev-parse", "refs/heads/branch1"], {
+			encoding: "utf8",
+		}).trim();
+		const remote = execFileSync("git", ["-C", clone, "ls-remote", "origin", "refs/heads/branch1"], {
+			encoding: "utf8",
+		}).split("\t")[0];
+		expect(remote).toBe(local);
+		await expectIncomingGone(appWindow);
+	});
+
+	test("combine both puts their new commits under your work", async ({
+		appWindow,
+		testEnvironment,
+	}) => {
+		divergeBranch1(testEnvironment);
+		await openUpdateDialog(appWindow);
+		await appWindow.keyboard.press("Escape");
+		await expect(appWindow.locator(dialog)).toBeHidden();
+
+		const chip = appWindow.getByRole("button", {
+			name: "Show 2 incoming commits from origin/branch1",
+		});
+		await chip.click();
+		await expect(appWindow.getByText("Rework the parser entry point")).toBeVisible();
+		await expect(appWindow.getByText("Document the reworked entry point")).toBeVisible();
+		await appWindow
+			.getByRole("button", { name: "Hide 2 incoming commits from origin/branch1" })
+			.click();
+
+		await appWindow.getByLabel("Integrate origin/branch1 into branch1").click();
+		await expect(appWindow.getByText(/incoming commit/)).toBeVisible();
+
+		// Only additions, so Combine is preselected; the preview names the a_file conflict.
+		await expect(appWindow.getByText("origin/branch1 has 2 new commits.")).toBeVisible();
+		await expect(appWindow.getByText("1 commit will need conflict resolution.")).toBeVisible();
+		// The result sits on the remote's tip: a plain push, said before and offered after.
+		await expect(appWindow.getByText("Push afterwards to publish.")).toBeVisible();
+		await applyChoice(appWindow, "Combine both", "Integrate");
+		await expect(appWindow.locator(dialog).getByRole("button", { name: "Push" })).toBeVisible();
+		await finishWith(appWindow, "Done");
+		await expectIncomingGone(appWindow);
+
+		// Your commit, rebased onto their rework, conflicts, and its subject says so.
+		const clone = path.join(testEnvironment.workdir, "local-clone");
+		expect(logSubjects(clone).slice(0, 4)).toEqual([
+			"[conflict] branch1: second commit",
+			"Document the reworked entry point",
+			"Rework the parser entry point",
+			"branch1: first commit",
+		]);
+	});
+
+	test("unticking an incoming commit leaves it out of the integration", async ({
+		appWindow,
+		testEnvironment,
+	}) => {
+		divergeBranch1(testEnvironment);
+		await openUpdateDialog(appWindow);
+
+		// Pick: their additions each carry a checkbox, ticked by default.
+		await appWindow.getByLabel("Keep Document the reworked entry point").click();
+		await expect(appWindow.getByText("1 of 2 incoming commits")).toBeVisible();
+		// The remote keeps the commit left out, so publishing means a force push.
+		await expect(
+			appWindow.getByText("Rewrites the branch; force push afterwards to publish."),
+		).toBeVisible();
+		await applyChoice(appWindow, "Combine both", "Integrate");
+		await finishWith(appWindow, "Done");
+
+		const clone = path.join(testEnvironment.workdir, "local-clone");
+		const subjects = logSubjects(clone);
+		expect(subjects).toContain("Rework the parser entry point");
+		expect(subjects).not.toContain("Document the reworked entry point");
+		expect(subjects[0]).toBe("[conflict] branch1: second commit");
+	});
+
+	test("combine both never lands a rewritten commit twice", async ({
+		appWindow,
+		testEnvironment,
+	}) => {
+		divergeBoth(testEnvironment);
+		await openUpdateDialog(appWindow);
+
+		// Both kinds: a new commit to take, and an older version of the reworded one to leave out.
+		await expect(
+			appWindow.getByText(
+				"origin/branch1 has 1 new commit, and a different version of one of yours.",
+			),
+		).toBeVisible();
+		await expect(
+			appWindow.getByText("Rewrites the branch; force push afterwards to publish."),
+		).toBeVisible();
+		await applyChoice(appWindow, "Combine both", "Integrate");
+		// The remote still holds the superseded version, so the done state offers the force push.
+		await finishWith(appWindow, "Force push");
+		await expectIncomingGone(appWindow);
+
+		const clone = path.join(testEnvironment.workdir, "local-clone");
+		const subjects = logSubjects(clone);
+		const remote = execFileSync("git", ["-C", clone, "ls-remote", "origin", "refs/heads/branch1"], {
+			encoding: "utf8",
+		}).split("\t")[0];
+		const local = execFileSync("git", ["-C", clone, "rev-parse", "refs/heads/branch1"], {
+			encoding: "utf8",
+		}).trim();
+		expect(remote).toBe(local);
+		expect(subjects.slice(0, 3)).toEqual([
+			"Reworded locally",
+			"Add upstream notes",
+			"branch1: first commit",
+		]);
+		expect(subjects).not.toContain("branch1: second commit");
+		expect(subjects.filter((subject) => subject.endsWith("Reworded locally"))).toHaveLength(1);
+	});
+
+	test("keep mine with additions force-pushes the branch as it is", async ({
+		appWindow,
+		testEnvironment,
+	}) => {
+		divergeBranch1(testEnvironment);
+		await openUpdateDialog(appWindow);
+		await applyChoice(appWindow, "Keep mine", "Force push");
+		await finishWith(appWindow, "Done");
+		await expectIncomingGone(appWindow);
+
+		const clone = path.join(testEnvironment.workdir, "local-clone");
+		const subjects = logSubjects(clone);
+		expect(subjects.slice(0, 2)).toEqual(["branch1: second commit", "branch1: first commit"]);
+		const remote = execFileSync("git", ["-C", clone, "ls-remote", "origin", "refs/heads/branch1"], {
+			encoding: "utf8",
+		}).split("\t")[0];
+		const local = execFileSync("git", ["-C", clone, "rev-parse", "refs/heads/branch1"], {
+			encoding: "utf8",
+		}).trim();
+		expect(remote).toBe(local);
+	});
+
+	test("take theirs replaces the branch with the remote", async ({
+		appWindow,
+		testEnvironment,
+	}) => {
+		divergeBranch1(testEnvironment);
+		await openUpdateDialog(appWindow);
+		await applyChoice(appWindow, "Take theirs", "Replace branch");
+		await finishWith(appWindow, "Done");
+		await expectIncomingGone(appWindow);
+
+		const clone = path.join(testEnvironment.workdir, "local-clone");
+		const subjects = logSubjects(clone);
+		expect(subjects.slice(0, 3)).toEqual([
+			"Document the reworked entry point",
+			"Rework the parser entry point",
+			"branch1: first commit",
+		]);
+		expect(subjects).not.toContain("branch1: second commit");
+	});
+});

--- a/apps/lite/ui/src/api/mutations.ts
+++ b/apps/lite/ui/src/api/mutations.ts
@@ -188,6 +188,17 @@ export const useApply = () => {
 	});
 };
 
+export const useApplyBranchIntegration = () => {
+	const dispatch = useAppDispatch();
+	return useMutation({
+		mutationFn: window.lite.applyBranchIntegration,
+		onSuccess: async (response, input, _context, mutation) => {
+			syncCoreCaches(mutation.client, dispatch, input.projectId, response);
+		},
+		meta: { failureTitle: "Failed to update the branch" },
+	});
+};
+
 export const useBranchCreate = () => {
 	const dispatch = useAppDispatch();
 	return useMutation({

--- a/apps/lite/ui/src/api/query-keys.ts
+++ b/apps/lite/ui/src/api/query-keys.ts
@@ -24,9 +24,11 @@ export type GlobalQueryKey =
 /**
  * Client state kept in the query cache, so nothing declares for them. `dryRun`
  * memoizes an imperative preview: its key carries the operation and changes it
- * was measured against, and nothing refreshes it in place.
+ * was measured against, and nothing refreshes it in place. `branchIntegration`
+ * is the update flow's plan and preview, refetched each time the flow asks.
  */
 type LocalQueryKey =
+	| "branchIntegration"
 	| "commitMessageDraft"
 	| "dryRun"
 	| "prMergeMethod"

--- a/apps/lite/ui/src/branch-integration.ts
+++ b/apps/lite/ui/src/branch-integration.ts
@@ -1,0 +1,161 @@
+/**
+ * @file The update-from-remote flow's data: the plan, the dry-run preview,
+ * and what the panel derives from them.
+ */
+
+import { decodeBytes } from "#ui/api/bytes.ts";
+import type { PayloadFor } from "#electron/ipc.ts";
+import type {
+	Commit,
+	IntegrationDivergenceDisplay,
+	InteractiveIntegration,
+	InteractiveIntegrationStep,
+	WorkspaceState,
+} from "@gitbutler/but-sdk";
+import { queryOptions } from "@tanstack/react-query";
+
+export const integrationPlanQueryOptions = ({
+	projectId,
+	branch,
+	strategy,
+}: PayloadFor<"getInitialBranchIntegration">) =>
+	queryOptions({
+		queryKey: [projectId, "branchIntegration", "plan", branch, strategy],
+		queryFn: () => window.lite.getInitialBranchIntegration({ projectId, branch, strategy }),
+		// Nothing invalidates this: refetch when the flow opens, but not on refocus,
+		// which would swap the plan under staged edits.
+		staleTime: 0,
+		refetchOnWindowFocus: false,
+		gcTime: 10_000,
+	});
+
+export const integrationPreviewQueryOptions = ({
+	projectId,
+	branch,
+	integration,
+}: Omit<PayloadFor<"applyBranchIntegration">, "dryRun" | "integration"> & {
+	integration: InteractiveIntegration | undefined;
+}) =>
+	queryOptions({
+		enabled: integration !== undefined,
+		queryKey: [projectId, "branchIntegration", "preview", branch, integration],
+		queryFn: () => {
+			if (integration === undefined) return null;
+			return window.lite.applyBranchIntegration({ projectId, branch, integration, dryRun: true });
+		},
+		staleTime: 0,
+		// The dry run takes the worktree lock; a refocus must not re-run it.
+		refetchOnWindowFocus: false,
+		gcTime: 10_000,
+	});
+
+/** A commit left out of the plan, by its pre-rewrite id. */
+export type PlanEdit = { commitId: string };
+
+export const stepCommitIds = (step: InteractiveIntegrationStep): Array<string> =>
+	step.kind === "squash" ? step.commits : [step.commitId];
+
+/**
+ * Dropping a commit removes it, and its step once empty. A commit no longer in
+ * the plan is skipped; merge steps are left alone, their commit a range marker.
+ */
+export const applyPlanEdits = (
+	steps: Array<InteractiveIntegrationStep>,
+	edits: ReadonlyArray<PlanEdit>,
+): Array<InteractiveIntegrationStep> => {
+	let out = steps;
+	for (const edit of edits) {
+		const index = out.findIndex((step) => stepCommitIds(step).includes(edit.commitId));
+		const step = out[index];
+		if (step === undefined || step.kind === "merge") continue;
+
+		const remaining = stepCommitIds(step).filter((id) => id !== edit.commitId);
+		const head = remaining[0];
+		out =
+			head === undefined
+				? out.toSpliced(index, 1)
+				: remaining.length === 1
+					? // A squash of one commit is that commit, kept as itself.
+						out.toSpliced(index, 1, { kind: "pick", commitId: head })
+					: out.toSpliced(index, 1, {
+							kind: "squash",
+							commits: remaining,
+							// The shrunken step keeps its squash message.
+							message: step.kind === "squash" ? step.message : null,
+						});
+	}
+	return out;
+};
+
+/** A previewed commit and which side of the divergence it came from. */
+export type PreviewRow = {
+	commit: Commit;
+	/** `shared`: history both sides had, plus commits the plan created, like a merge. */
+	origin: "incoming" | "local" | "shared";
+	/** The pre-rewrite ids the plan's steps use; a squash-produced commit carries every constituent. */
+	tracedIds: Array<string>;
+};
+
+/**
+ * The previewed branch as rows traced to their side: a previewed id is
+ * followed through `replacedCommits`, then matched by change id. `null`
+ * while the previewed workspace lacks the branch.
+ */
+export const buildPreviewRows = ({
+	workspace,
+	branch,
+	divergence,
+}: {
+	workspace: WorkspaceState;
+	branch: string;
+	divergence: IntegrationDivergenceDisplay;
+}): Array<PreviewRow> | null => {
+	// A surviving incoming commit keeps its remote-tracking ref, a segment of its
+	// own below the branch's; fold segments in until another branch takes over.
+	let commits: Array<Commit> | undefined;
+	stacks: for (const stack of workspace.headInfo.stacks) {
+		for (const [index, segment] of stack.segments.entries()) {
+			if (segment.refName === null || decodeBytes(segment.refName.fullNameBytes) !== branch)
+				continue;
+			commits = [...segment.commits];
+			for (const below of stack.segments.slice(index + 1)) {
+				const belowRef = below.refName === null ? null : decodeBytes(below.refName.fullNameBytes);
+				if (belowRef !== null && belowRef.startsWith("refs/heads/")) break;
+				commits.push(...below.commits);
+			}
+			break stacks;
+		}
+	}
+	if (commits === undefined) return null;
+
+	// A squash maps several old ids onto one commit; collect them all.
+	const originsById = new Map<string, Array<string>>();
+	for (const [oldId, newId] of Object.entries(workspace.replacedCommits)) {
+		const origins = originsById.get(newId);
+		if (origins === undefined) originsById.set(newId, [oldId]);
+		else origins.push(oldId);
+	}
+
+	const upstreamIds = new Set(divergence.upstreamOnly.map((commit) => commit.id));
+	const localIds = new Set(divergence.localOnly.map((commit) => commit.id));
+	const upstreamChangeIds = new Set(
+		divergence.upstreamOnly.flatMap((commit) =>
+			commit.changeId !== null ? [commit.changeId] : [],
+		),
+	);
+	const localChangeIds = new Set(
+		divergence.localOnly.flatMap((commit) => (commit.changeId !== null ? [commit.changeId] : [])),
+	);
+
+	return commits.map((commit) => {
+		const tracedIds = originsById.get(commit.id) ?? [commit.id];
+		// A commit folding both sides counts as local; only pure incoming history is incoming.
+		const hasLocal =
+			tracedIds.some((id) => localIds.has(id)) || localChangeIds.has(commit.changeId);
+		const hasUpstream =
+			tracedIds.some((id) => upstreamIds.has(id)) || upstreamChangeIds.has(commit.changeId);
+		const origin: PreviewRow["origin"] =
+			hasUpstream && !hasLocal ? "incoming" : hasLocal ? "local" : "shared";
+		return { commit, origin, tracedIds };
+	});
+};

--- a/apps/lite/ui/src/commit.ts
+++ b/apps/lite/ui/src/commit.ts
@@ -1,3 +1,4 @@
+import { formatAbsoluteTime } from "#ui/time.ts";
 import type { Commit, ForgeInfo } from "@gitbutler/but-sdk";
 import { queryOptions, useMutation } from "@tanstack/react-query";
 import * as idb from "idb-keyval";
@@ -24,6 +25,12 @@ export const usePersistDraftCommitMessage = () =>
 	});
 
 export const shortCommitId = (commitId: string): string => commitId.slice(0, 7);
+
+/** Who and when, in the house absolute format; an empty name leaves the time. */
+export const authorTooltip = (author: { name: string }, timestamp: number): string => {
+	const when = formatAbsoluteTime(timestamp);
+	return author.name === "" ? when : `${author.name} · ${when}`;
+};
 
 export const commitTitle = (input: string): string | undefined => {
 	const trimmed = input.trim();

--- a/apps/lite/ui/src/interface/state.ts
+++ b/apps/lite/ui/src/interface/state.ts
@@ -7,7 +7,9 @@ type Dialog =
 	| { _tag: "CommandPalette" }
 	| { _tag: "OperationsLogPicker" }
 	| { _tag: "ProjectPicker" }
-	| { _tag: "Settings" };
+	| { _tag: "Settings" }
+	/** The update-from-remote flow, for the applied branch named by full ref. */
+	| { _tag: "UpdateFromRemote"; branchRef: string };
 
 type InterfaceState = {
 	detailsFullWindow: boolean;

--- a/apps/lite/ui/src/projects/project.ts
+++ b/apps/lite/ui/src/projects/project.ts
@@ -89,6 +89,11 @@ type WorkspaceState = {
 	 * hiding them that is the exception worth recording.
 	 */
 	foldedSegments: Record<string, true>;
+	/**
+	 * Remote legs shown, by the local branch's full ref. Expanded rather than
+	 * folded, unlike `foldedSegments`: a leg starts collapsed.
+	 */
+	expandedIncoming: Record<string, true>;
 	dependencyCommitIds: Array<string>;
 	pendingOperation: PendingOperation;
 	/**
@@ -134,6 +139,7 @@ const createInitialWorkspaceState = (): WorkspaceState => ({
 	checkedAddresses: {},
 	checkedConflicts: {},
 	foldedSegments: {},
+	expandedIncoming: {},
 	dependencyCommitIds: [],
 	pendingOperation: noPendingOperation,
 	notice: null,
@@ -521,6 +527,11 @@ export const projectReducers = {
 		if (state.workspace.foldedSegments[branchRef]) delete state.workspace.foldedSegments[branchRef];
 		else state.workspace.foldedSegments[branchRef] = true;
 	},
+	toggleIncomingExpanded: (state: ProjectState, { branchRef }: { branchRef: string }) => {
+		if (state.workspace.expandedIncoming[branchRef])
+			delete state.workspace.expandedIncoming[branchRef];
+		else state.workspace.expandedIncoming[branchRef] = true;
+	},
 	/**
 	 * Folds or unfolds several segments at once, for acting on a whole stack.
 	 * Toggling each of them instead would invert a partly folded stack rather
@@ -707,6 +718,8 @@ export const projectSelectors = {
 	selectFoldedSegments: (state: ProjectState) => state.workspace.foldedSegments,
 	selectSegmentFolded: (state: ProjectState, branchRef: string) =>
 		state.workspace.foldedSegments[branchRef] === true,
+	selectIncomingExpanded: (state: ProjectState, branchRef: string) =>
+		state.workspace.expandedIncoming[branchRef] === true,
 	selectDependencyCommitIds,
 	selectAddressChecked: (state: ProjectState, address: CheckableAddress) =>
 		state.workspace.checkedAddresses[addressIdentityKey(address)] !== undefined,

--- a/apps/lite/ui/src/routes/project/$id/workspace/BranchUpdatePanel.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/BranchUpdatePanel.module.css
@@ -1,0 +1,148 @@
+.backdrop {
+	position: fixed;
+	inset: 0;
+	background-color: var(--bg-overlay);
+}
+
+.viewport {
+	display: flex;
+	position: fixed;
+	inset: 0;
+	padding: 4.5rem 1rem;
+}
+
+.popup {
+	display: flex;
+	flex-direction: column;
+	width: min(680px, 100%);
+	max-height: min(76vh, 900px);
+	margin: auto;
+	overflow: hidden;
+	border: 1px solid var(--border-2);
+	border-radius: var(--radius-lg);
+	/* The dialog receives initial focus; the ring belongs on its controls. */
+	outline: none;
+	background-color: var(--bg-1);
+	box-shadow:
+		0 0.5px 1px rgb(0 0 0 / 0.12),
+		0 1px 3px -1px rgb(0 0 0 / 0.04),
+		0 2px 4px -1px rgb(0 0 0 / 0.04),
+		0 4px 8px -2px rgb(0 0 0 / 0.04),
+		0 12px 14px -4px rgb(0 0 0 / 0.04),
+		0 24px 64px -8px rgb(0 0 0 / 0.04),
+		0 40px 48px -32px rgb(0 0 0 / 0.04);
+}
+
+.dialogHeader {
+	display: flex;
+	column-gap: 8px;
+	flex-shrink: 0;
+	align-items: center;
+	padding: 12px;
+	border-block-end: 1px solid var(--border-section);
+}
+
+.panel {
+	display: flex;
+	flex-grow: 1;
+	flex-direction: column;
+	min-height: 0;
+}
+
+.controls {
+	display: flex;
+	row-gap: 8px;
+	flex-shrink: 0;
+	flex-direction: column;
+	padding: 12px;
+	border-block-end: 1px solid var(--border-section);
+}
+
+.viewRow {
+	display: flex;
+	column-gap: 8px;
+	align-items: center;
+	/* Keeps its line while empty, so picking a strategy does not reflow. */
+	min-height: 24px;
+}
+
+.summary {
+	margin-inline-start: auto;
+}
+
+.outline {
+	flex-grow: 1;
+	padding-block: 6px;
+
+	/* The previous plan's rows, held while the next preview computes. */
+	&[data-stale] {
+		opacity: 0.5;
+	}
+}
+
+.conflictIcon {
+	flex-shrink: 0;
+	margin-right: 2px;
+}
+
+.dropped {
+	margin-block-start: 8px;
+	padding-block-start: 4px;
+	border-block-start: 1px solid var(--border-section);
+}
+
+.droppedHeading {
+	padding-inline: var(--row-padding-inline-start, 12px);
+	padding-block: 2px;
+}
+
+.droppedLabel {
+	text-decoration: line-through;
+}
+
+.message {
+	padding: 12px;
+	color: var(--text-2);
+}
+
+.footer {
+	display: flex;
+	column-gap: 10px;
+	flex-shrink: 0;
+	align-items: center;
+	justify-content: flex-end;
+	padding: 12px;
+	border-block-start: 1px solid var(--border-section);
+}
+
+.footerNotes {
+	display: flex;
+	row-gap: 2px;
+	flex-direction: column;
+	margin-inline-end: auto;
+}
+
+.conflictNote {
+	display: flex;
+	column-gap: 6px;
+	align-items: center;
+	color: var(--text-2);
+}
+
+.appliedBody {
+	display: flex;
+	row-gap: 6px;
+	flex-grow: 1;
+	flex-direction: column;
+	padding: 16px 12px;
+}
+
+.strategyRow {
+	display: flex;
+	column-gap: 8px;
+	align-items: center;
+}
+
+.diagnosis {
+	flex-grow: 1;
+}

--- a/apps/lite/ui/src/routes/project/$id/workspace/BranchUpdatePanel.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/BranchUpdatePanel.tsx
@@ -1,0 +1,573 @@
+import rowStyles from "./Row.module.css";
+import uiStyles from "#ui/components/ui.module.css";
+import {
+	applyPlanEdits,
+	buildPreviewRows,
+	integrationPlanQueryOptions,
+	integrationPreviewQueryOptions,
+	stepCommitIds,
+	type PlanEdit,
+	type PreviewRow,
+} from "#ui/branch-integration.ts";
+import {
+	useApplyBranchIntegration,
+	useWorkspaceBranchAndAncestorsPush,
+} from "#ui/api/mutations.ts";
+import { headInfoQueryOptions } from "#ui/api/queries.ts";
+import { decodeBytes } from "#ui/api/bytes.ts";
+import { classes } from "#ui/components/classes.ts";
+import { ConflictIcon } from "#ui/components/ConflictIcon.tsx";
+import { getButtonClassName } from "#ui/components/Button.tsx";
+import { GraphSegment, type GraphSegmentStatus } from "#ui/components/GraphSegment.tsx";
+import { Icon } from "#ui/components/Icon.tsx";
+import { ToggleGroupStyles, ToggleStyles } from "#ui/components/ToggleGroup.tsx";
+import { authorTooltip, commitIsDiverged, commitTitle, shortCommitId } from "#ui/commit.ts";
+import { errorMessageForToast } from "#ui/errors.ts";
+import type { BranchIntegrationStrategy, FullRefName } from "@gitbutler/but-sdk";
+import { Dialog, Toggle, ToggleGroup } from "@base-ui/react";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import { type FC, useState } from "react";
+import { Row, RowCheckbox, RowLabel, RowLabelContainer } from "./Row.tsx";
+import styles from "./BranchUpdatePanel.module.css";
+
+/** Whose version wins where the two sides differ, or both sides kept. */
+type Choice = "mine" | "combine" | "theirs";
+
+const pluralRules = new Intl.PluralRules("en");
+const count = (n: number, noun: string): string =>
+	`${n} ${noun}${pluralRules.select(n) === "one" ? "" : "s"}`;
+
+const shortRefName = (refName: FullRefName): string => {
+	const full = refName.full;
+	if (full.startsWith("refs/heads/")) return full.slice("refs/heads/".length);
+	if (full.startsWith("refs/remotes/")) return full.slice("refs/remotes/".length);
+	return full;
+};
+
+/** A leg's head: the ref's name where its rail begins. */
+const LegHeadRow: FC<{
+	label: string;
+	status: GraphSegmentStatus;
+}> = ({ label, status }) => (
+	<Row interactive={false}>
+		<GraphSegment glyph="forkRight" status={status} />
+		<RowLabelContainer>
+			<RowLabel heading singleLine title={label} className={rowStyles.fadedText}>
+				{label}
+			</RowLabel>
+		</RowLabelContainer>
+	</Row>
+);
+
+/** A commit unticked, held on screen so it can be ticked back. */
+type DroppedRow = { commitId: string; subject: string };
+
+/**
+ * The previewed result: each commit coloured by its side, flagged where the
+ * preview reports a conflict.
+ */
+const AfterOutline: FC<{
+	branchLabel: string;
+	rows: Array<PreviewRow>;
+	dropped: Array<DroppedRow>;
+	/** Pick: an incoming row unticked leaves the plan, and comes back ticked below. */
+	pickable: boolean;
+	onDrop: (row: PreviewRow) => void;
+	onRestore: (commitId: string) => void;
+}> = ({ branchLabel, rows, dropped, pickable, onDrop, onRestore }) => (
+	<div>
+		<LegHeadRow label={branchLabel} status="LocalOnly" />
+		{rows.length === 0 && (
+			<Row interactive={false}>
+				<GraphSegment glyph="parent" status="LocalOnly" />
+				<RowLabelContainer>
+					<RowLabel className={rowStyles.fadedText}>No commits.</RowLabel>
+				</RowLabelContainer>
+			</Row>
+		)}
+		{rows.map((row) => {
+			const { commit, origin } = row;
+			return (
+				<Row
+					key={commit.id}
+					interactive={false}
+					title={authorTooltip(commit.author, commit.authoredAt)}
+				>
+					<GraphSegment
+						glyph="commit"
+						status={
+							origin === "incoming"
+								? "Upstream"
+								: origin === "local"
+									? "LocalOnly"
+									: "LocalAndRemote"
+						}
+					/>
+					{/* Their additions are each a choice; nothing else here is. */}
+					{pickable && origin === "incoming" && (
+						<RowCheckbox
+							checked
+							nativeButton
+							aria-label={`Keep ${commitTitle(commit.message) ?? "(no message)"}`}
+							onCheckedChange={() => onDrop(row)}
+						/>
+					)}
+					<RowLabelContainer>
+						{commit.hasConflicts && (
+							<ConflictIcon
+								variant="conflict"
+								className={styles.conflictIcon}
+								aria-label="Conflicted"
+							/>
+						)}
+						<RowLabel singleLine>{commitTitle(commit.message) ?? "(no message)"}</RowLabel>
+					</RowLabelContainer>
+				</Row>
+			);
+		})}
+
+		{dropped.length > 0 && (
+			<div className={styles.dropped}>
+				<p className={classes("text-12", rowStyles.fadedText, styles.droppedHeading)}>Left out</p>
+				{dropped.map(({ commitId, subject }) => (
+					<Row key={commitId} interactive={false}>
+						<GraphSegment glyph="space" status="LocalOnly" />
+						<RowCheckbox
+							checked={false}
+							nativeButton
+							aria-label={`Keep ${subject}`}
+							onCheckedChange={() => onRestore(commitId)}
+						/>
+						<RowLabelContainer>
+							<RowLabel singleLine className={classes(rowStyles.fadedText, styles.droppedLabel)}>
+								{subject}
+							</RowLabel>
+						</RowLabelContainer>
+					</Row>
+				))}
+			</div>
+		)}
+	</div>
+);
+
+/**
+ * The update-from-remote flow, led by a diagnosis: the dialog states what the
+ * remote has and offers three answers, Keep mine, Combine both, Take theirs,
+ * over one outline of the previewed outcome.
+ */
+const BranchUpdatePanel: FC<{
+	projectId: string;
+	/** The applied branch's full ref name. */
+	branch: string;
+	onApplied: () => void;
+}> = ({ projectId, branch, onApplied }) => {
+	/** `null` until the user picks: the default depends on what the remote has. */
+	const [pickedChoice, setPickedChoice] = useState<Choice | null>(null);
+	// The commits unticked, in pre-rewrite ids so they survive the preview
+	// changing under them; picking a choice clears them.
+	const [edits, setEdits] = useState<Array<PlanEdit>>([]);
+
+	const pickChoice = (next: Choice) => {
+		setPickedChoice(next);
+		setEdits([]);
+	};
+
+	// Remote versions of rewritten local commits, as head info names them; the
+	// plan's change ids cover the rest below.
+	const { data: divergedSubjects } = useQuery({
+		...headInfoQueryOptions(projectId),
+		select: (headInfo) => {
+			for (const stack of headInfo.stacks) {
+				for (const segment of stack.segments) {
+					if (segment.refName === null || decodeBytes(segment.refName.fullNameBytes) !== branch)
+						continue;
+					return segment.commits.flatMap((commit) =>
+						commitIsDiverged(commit) && commit.state.type === "LocalAndRemote"
+							? [commit.state.subject]
+							: [],
+					);
+				}
+			}
+			return [];
+		},
+	});
+
+	// Keep mine and Combine both share the rebase plan and differ only in
+	// what gets dropped from it; Take theirs replaces outright.
+	const strategy: BranchIntegrationStrategy =
+		pickedChoice === "theirs" ? "pickRemote" : "pullRebase";
+	const {
+		data: plan,
+		isError: isPlanError,
+		isPlaceholderData: isPlanStale,
+	} = useQuery({
+		...integrationPlanQueryOptions({ projectId, branch, strategy }),
+		// The previous plan stays on screen, dimmed, while a strategy switch refetches.
+		placeholderData: keepPreviousData,
+	});
+	// What the remote has: twins of rewritten local commits, matched by change
+	// id and by head info, and genuinely new commits.
+	const localChangeIds = new Set(
+		(plan?.divergence.localOnly ?? []).flatMap((commit) =>
+			commit.changeId === null ? [] : [commit.changeId],
+		),
+	);
+	const twinIds = new Set([
+		...(plan?.divergence.upstreamOnly ?? []).flatMap((commit) =>
+			commit.changeId !== null && localChangeIds.has(commit.changeId) ? [commit.id] : [],
+		),
+		...(divergedSubjects ?? []),
+	]);
+	const upstreamOnlyIds = (plan?.divergence.upstreamOnly ?? []).map((commit) => commit.id);
+	const additions = upstreamOnlyIds.filter((id) => !twinIds.has(id)).length;
+	const rewritten = upstreamOnlyIds.filter((id) => twinIds.has(id)).length;
+	// With nothing new to take, keeping mine is the default.
+	const choice: Choice = pickedChoice ?? (additions > 0 ? "combine" : "mine");
+
+	// Keep mine leaves every remote commit out; Combine both leaves out only
+	// the remote's versions of rewritten commits.
+	const baselineEdits: Array<PlanEdit> =
+		choice === "mine"
+			? upstreamOnlyIds.map((commitId) => ({ commitId }))
+			: choice === "combine"
+				? [...twinIds].map((commitId) => ({ commitId }))
+				: [];
+	const allEdits = [...baselineEdits, ...edits];
+	const integration =
+		plan === undefined
+			? undefined
+			: allEdits.length === 0
+				? plan.integration
+				: { ...plan.integration, steps: applyPlanEdits(plan.integration.steps, allEdits) };
+	const {
+		data: previewResult,
+		isError: isPreviewError,
+		isPlaceholderData: isPreviewStale,
+	} = useQuery({
+		...integrationPreviewQueryOptions({ projectId, branch, integration }),
+		placeholderData: keepPreviousData,
+	});
+
+	const previewRows =
+		previewResult != null && plan !== undefined
+			? buildPreviewRows({
+					workspace: previewResult.workspace,
+					branch,
+					divergence: plan.divergence,
+				})
+			: null;
+
+	const { isPending: isApplying, mutate: applyIntegration } = useApplyBranchIntegration();
+	const {
+		isPending: isPushing,
+		mutate: pushBranch,
+		error: pushError,
+	} = useWorkspaceBranchAndAncestorsPush(projectId);
+	// Done state: offers the push the integration now needs, rather than leaving it to the sidebar.
+	const [applied, setApplied] = useState<{
+		/** What landed: an integration still to publish, a push, or a replace. */
+		kind: "integrated" | "pushed" | "replaced";
+		force: boolean;
+		remoteName: string;
+	} | null>(null);
+
+	if (isPlanError) {
+		return (
+			<p className={classes("text-13", styles.message)}>
+				Could not compute the update. The upstream may have moved; try again after a fetch.
+			</p>
+		);
+	}
+	if (plan === undefined)
+		return <p className={classes("text-13", styles.message)}>Computing the update…</p>;
+
+	const localTotal = plan.divergence.localOnly.length;
+	const incomingCount = previewRows?.filter((row) => row.origin === "incoming").length ?? null;
+	const keptCount = previewRows?.filter((row) => row.origin === "local").length ?? null;
+	const conflictCount = previewRows?.filter((row) => row.commit.hasConflicts).length ?? 0;
+	const branchLabel = shortRefName(plan.divergence.branchRefName);
+	const remoteName = shortRefName(plan.divergence.upstreamRefName);
+
+	const allDivergenceCommits = [
+		...plan.divergence.localOnly,
+		...plan.divergence.upstreamOnly,
+		plan.divergence.mergeBase,
+	];
+	// Only drops the current plan still holds: one orphaned by a refetched plan is not a removal.
+	const planIds = new Set(plan.integration.steps.flatMap(stepCommitIds));
+	const dropped = edits.flatMap((edit) =>
+		planIds.has(edit.commitId)
+			? [
+					{
+						commitId: edit.commitId,
+						subject:
+							allDivergenceCommits.find((commit) => commit.id === edit.commitId)?.subject ??
+							shortCommitId(edit.commitId),
+					},
+				]
+			: [],
+	);
+	const restore = (commitId: string) =>
+		setEdits(edits.filter((edit) => edit.commitId !== commitId));
+	const dropRow = (row: PreviewRow) =>
+		setEdits([...edits, ...row.tracedIds.map((commitId) => ({ commitId }))]);
+	const upstreamIds = new Set(plan.divergence.upstreamOnly.map((commit) => commit.id));
+	const leftOutIncoming = dropped.filter((entry) => upstreamIds.has(entry.commitId)).length;
+
+	// Combining rewrites the branch; a force push is needed only while the
+	// remote still holds commits the result lacks.
+	const needsForce = choice === "combine" && (rewritten > 0 || leftOutIncoming > 0);
+	const apply = () => {
+		if (choice === "mine") {
+			// Keeping mine needs no integration: the remote just has to catch up.
+			pushBranch(
+				{
+					projectId,
+					branch,
+					withForce: true,
+					skipForcePushProtection: false,
+					runHooks: true,
+					pushOpts: [],
+				},
+				{ onSuccess: () => setApplied({ kind: "pushed", force: true, remoteName }) },
+			);
+			return;
+		}
+		if (integration === undefined) return;
+		applyIntegration(
+			{ projectId, branch, integration, dryRun: false },
+			{
+				// Taking theirs leaves nothing to push; combining offers the push in place.
+				onSuccess: () =>
+					setApplied(
+						choice === "theirs"
+							? { kind: "replaced", force: false, remoteName }
+							: { kind: "integrated", force: needsForce, remoteName },
+					),
+			},
+		);
+	};
+	const pushApplied = () => {
+		if (applied === null) return;
+		pushBranch(
+			{
+				projectId,
+				branch,
+				withForce: applied.force,
+				skipForcePushProtection: false,
+				runHooks: true,
+				pushOpts: [],
+			},
+			{ onSuccess: () => setApplied({ ...applied, kind: "pushed" }) },
+		);
+	};
+
+	if (applied !== null) {
+		return (
+			<div className={styles.panel}>
+				<div className={styles.appliedBody}>
+					<p className={classes("text-13", "text-semibold")}>
+						{applied.kind === "integrated"
+							? "Branch updated."
+							: applied.kind === "pushed"
+								? "Branch published."
+								: "Branch replaced."}
+					</p>
+					<p className={classes("text-13", rowStyles.fadedText)}>
+						{applied.kind === "integrated"
+							? applied.force
+								? `${applied.remoteName} still holds the previous versions of your commits; force push to publish the result.`
+								: `${applied.remoteName} is behind; push to publish the result.`
+							: applied.kind === "pushed"
+								? `${applied.remoteName} now matches this branch.`
+								: `This branch now matches ${applied.remoteName}.`}
+					</p>
+				</div>
+				<div className={styles.footer}>
+					{pushError !== null && (
+						<span className={classes("text-12", styles.conflictNote)}>
+							<ConflictIcon variant="conflict" aria-hidden />
+							{errorMessageForToast(pushError)}
+						</span>
+					)}
+					<button
+						type="button"
+						className={getButtonClassName({
+							variant: applied.kind === "integrated" ? "outline" : "pop",
+						})}
+						onClick={onApplied}
+					>
+						Done
+					</button>
+					{applied.kind === "integrated" && (
+						<button
+							type="button"
+							className={getButtonClassName({ variant: "pop" })}
+							disabled={isPushing}
+							onClick={pushApplied}
+						>
+							{isPushing && <Icon name="spinner" />}
+							{applied.force ? "Force push" : "Push"}
+						</button>
+					)}
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className={styles.panel}>
+			<div className={styles.controls}>
+				<div className={styles.strategyRow}>
+					<p className={classes("text-13", styles.diagnosis)}>
+						{additions > 0 && rewritten > 0
+							? `${remoteName} has ${count(additions, "new commit")}, and a different version of ${rewritten === 1 ? "one" : rewritten} of yours.`
+							: additions > 0
+								? `${remoteName} has ${count(additions, "new commit")}.`
+								: rewritten > 0
+									? `${remoteName} holds a different version of ${rewritten === 1 ? "one" : rewritten} of your commits.`
+									: `${remoteName} and this branch have diverged.`}
+					</p>
+				</div>
+
+				<ToggleGroup
+					render={<ToggleGroupStyles />}
+					value={[choice]}
+					onValueChange={(value: Array<Choice>) => {
+						const head = value[0];
+						if (head !== undefined) pickChoice(head);
+					}}
+					aria-label="How to resolve the divergence"
+				>
+					<Toggle render={<ToggleStyles />} value="mine">
+						Keep mine
+					</Toggle>
+					{/* Always in the row, so the three answers read as one set. */}
+					<Toggle render={<ToggleStyles />} value="combine" disabled={additions === 0}>
+						Combine both
+					</Toggle>
+					<Toggle render={<ToggleStyles />} value="theirs">
+						Take theirs
+					</Toggle>
+				</ToggleGroup>
+
+				<div className={styles.viewRow}>
+					{edits.length > 0 && (
+						<button
+							type="button"
+							className={getButtonClassName({ variant: "outline", size: "small" })}
+							onClick={() => setEdits([])}
+						>
+							Reset {count(edits.length, "edit")}
+						</button>
+					)}
+
+					{incomingCount !== null && keptCount !== null && (
+						<span className={classes("text-12", rowStyles.fadedText, styles.summary)}>
+							{leftOutIncoming > 0
+								? `${incomingCount} of ${count(incomingCount + leftOutIncoming, "incoming commit")}`
+								: count(incomingCount, "incoming commit")}{" "}
+							· {keptCount} of {count(localTotal, "local commit")} kept
+						</span>
+					)}
+				</div>
+			</div>
+
+			{/* Only the outcome: the sidebar already shows the current state. */}
+			<div
+				className={classes(uiStyles.scroller, styles.outline)}
+				data-stale={isPreviewStale || isPlanStale ? true : undefined}
+			>
+				{isPreviewError ? (
+					<p className={classes("text-13", styles.message)}>Could not preview this plan.</p>
+				) : previewRows === null ? (
+					<p className={classes("text-13", styles.message)}>Computing the preview…</p>
+				) : (
+					<AfterOutline
+						branchLabel={branchLabel}
+						rows={previewRows}
+						dropped={dropped}
+						pickable={choice === "combine"}
+						onDrop={dropRow}
+						onRestore={restore}
+					/>
+				)}
+			</div>
+
+			<div className={styles.footer}>
+				<div className={styles.footerNotes}>
+					{conflictCount > 0 && (
+						<span className={classes("text-12", styles.conflictNote)}>
+							<ConflictIcon variant="conflict" aria-hidden />
+							{count(conflictCount, "commit")} will need conflict resolution.
+						</span>
+					)}
+					{pushError !== null && (
+						<span className={classes("text-12", styles.conflictNote)}>
+							<ConflictIcon variant="conflict" aria-hidden />
+							{errorMessageForToast(pushError)}
+						</span>
+					)}
+					{choice === "combine" && (
+						<span className={classes("text-12", rowStyles.fadedText)}>
+							{needsForce
+								? "Rewrites the branch; force push afterwards to publish."
+								: "Push afterwards to publish."}
+						</span>
+					)}
+				</div>
+				<button
+					type="button"
+					className={getButtonClassName({ variant: "pop" })}
+					// Held while either query still serves the previous key's data: applying then
+					// would run a plan the outline is about to replace.
+					disabled={
+						choice === "mine"
+							? isPushing
+							: isApplying ||
+								isPreviewError ||
+								previewRows === null ||
+								isPlanStale ||
+								isPreviewStale
+					}
+					onClick={apply}
+				>
+					{(isApplying || isPushing) && <Icon name="spinner" />}
+					{choice === "mine" ? "Force push" : choice === "theirs" ? "Replace branch" : "Integrate"}
+				</button>
+			</div>
+		</div>
+	);
+};
+
+/**
+ * The flow in a modal. Mounted only while open, so every open starts fresh
+ * on the recommended strategy with no edits.
+ */
+export const BranchUpdateDialog: FC<{
+	projectId: string;
+	branchRef: string;
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+}> = ({ projectId, branchRef, open, onOpenChange }) => (
+	<Dialog.Root open={open} onOpenChange={onOpenChange}>
+		<Dialog.Portal>
+			<Dialog.Backdrop className={styles.backdrop} />
+			<Dialog.Viewport className={styles.viewport}>
+				<Dialog.Popup aria-labelledby="branch-update-heading" className={styles.popup}>
+					<div className={styles.dialogHeader}>
+						<Icon name="branch" />
+						<h1 id="branch-update-heading" className={classes("text-14", "text-bold")}>
+							Update {shortRefName({ full: branchRef })} from remote
+						</h1>
+					</div>
+					<BranchUpdatePanel
+						projectId={projectId}
+						branch={branchRef}
+						onApplied={() => onOpenChange(false)}
+					/>
+				</Dialog.Popup>
+			</Dialog.Viewport>
+		</Dialog.Portal>
+	</Dialog.Root>
+);

--- a/apps/lite/ui/src/routes/project/$id/workspace/Page.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Page.tsx
@@ -70,6 +70,7 @@ import { Sidebar } from "./Sidebar.tsx";
 import { OperationControls } from "#ui/routes/project/$id/workspace/OperationControls.tsx";
 import { ErrorBoundary } from "#ui/components/ErrorBoundary.tsx";
 import { Settings } from "./Settings/Settings.tsx";
+import { BranchUpdateDialog } from "./BranchUpdatePanel.tsx";
 import { useBranchesList } from "./useBranchesList.ts";
 import { upstreamCommitReview, useUpstreamList } from "./useUpstreamList.ts";
 import { useStateReconciler as useReconcileState } from "#ui/reconcile.ts";
@@ -723,6 +724,16 @@ const PageBody: FC<{ projectId: string }> = ({ projectId }) => {
 							projectId={projectId}
 							projectName={projectName}
 							onOpenChange={setSettingsOpen}
+						/>
+					),
+					UpdateFromRemote: ({ branchRef }) => (
+						<BranchUpdateDialog
+							open
+							projectId={projectId}
+							branchRef={branchRef}
+							onOpenChange={(open) => {
+								if (!open) dispatch(interfaceSlice.actions.closeDialog());
+							}}
 						/>
 					),
 				}),

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/BranchRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/BranchRow.tsx
@@ -28,6 +28,7 @@ import type {
 	InsertSide,
 	PushStatus,
 	RelativeTo,
+	RemoteTrackingReference,
 	Stack,
 } from "@gitbutler/but-sdk";
 import { useQuery } from "@tanstack/react-query";
@@ -46,6 +47,7 @@ import {
 	type NativeMenuItem,
 } from "#ui/native-menu.ts";
 import { branchAddress, addressEquals, type BranchAddress } from "#ui/addresses.ts";
+import { openUpdateFromRemote } from "./update-from-remote.ts";
 import { projectSlice } from "#ui/projects/state.ts";
 import { focusScope } from "#ui/focus-scopes.ts";
 import { getHeadInfoIndex } from "#ui/api/ref-info.ts";
@@ -129,6 +131,10 @@ export const BranchRow: FC<
 		downstackPushStatus: DownstackPushStatus;
 		pushActivity: PushActivity;
 		pushStatus: PushStatus;
+		canUpdateFromRemote: boolean;
+		remote: RemoteTrackingReference | null;
+		/** How many commits the remote has that the branch does not. */
+		incoming: number;
 		/** The segment's projection-recorded review number, if any. */
 		recordedPullRequest: number | null;
 		graphStatus: GraphSegmentStatus;
@@ -148,6 +154,9 @@ export const BranchRow: FC<
 	downstackPushStatus,
 	pushActivity,
 	pushStatus,
+	canUpdateFromRemote,
+	remote,
+	incoming,
 	recordedPullRequest,
 	graphStatus,
 	bottomRelativeTo,
@@ -336,6 +345,22 @@ export const BranchRow: FC<
 			: "Push Branch";
 
 	const foldLabel = isFolded ? "Unfold commits" : "Fold commits";
+	const incomingExpanded = useAppSelector((state) =>
+		projectSlice.selectors.selectIncomingExpanded(state, projectId, branchRef),
+	);
+	const toggleIncoming = () =>
+		dispatch(projectSlice.actions.toggleIncomingExpanded({ projectId, branchRef }));
+	const remoteLabel = remote === null ? null : `${remote.remoteName}/${remote.displayName}`;
+	// Why a force push is needed, on hover, since the word alone says little.
+	const forcePushReason = (label: string): string =>
+		incoming > 0
+			? `${label} has ${incoming === 1 ? "a commit" : `${String(incoming)} commits`} this branch does not. Integrate brings them in; Push would force over them.`
+			: `The branch's history differs from ${label}, which has nothing new. Push force-updates it.`;
+	const pushStatusTooltip =
+		pushStatus === "unpushedCommitsRequiringForce" && remoteLabel !== null
+			? forcePushReason(remoteLabel)
+			: undefined;
+
 	const toggleFolded = () => {
 		// Hand the selection over only when folding would hide it — the selected
 		// commit sits in this segment. Unrelated selections (and the details pane
@@ -374,6 +399,11 @@ export const BranchRow: FC<
 			enabled: !workspaceBranchAndAncestorsPushDisabled,
 			accelerator: toElectronAccelerator(sidebarHotkeys.workspaceBranchAndAncestorsPush.hotkey),
 			onSelect: pushBranch,
+		}),
+		nativeMenuItem({
+			label: "Update From Remote",
+			enabled: canUpdateFromRemote,
+			onSelect: () => openUpdateFromRemote(dispatch, refName.fullNameBytes),
 		}),
 		nativeMenuSeparator,
 		nativeMenuItem({
@@ -507,6 +537,26 @@ export const BranchRow: FC<
 					</RowLabelContainer>
 
 					<RowMeta>
+						{/* The remote's news in the row itself; the chip opens the commits. */}
+						{remote !== null && incoming > 0 && (
+							<>
+								<button
+									type="button"
+									aria-expanded={incomingExpanded}
+									aria-label={`${incomingExpanded ? "Hide" : "Show"} ${String(incoming)} incoming ${incoming === 1 ? "commit" : "commits"} from ${remote.remoteName}/${remote.displayName}`}
+									className={classes(
+										getRowButtonClassName({ variant: "ghost" }),
+										rowStyles.metaItem,
+									)}
+									onClick={toggleIncoming}
+								>
+									<Icon size={12} name={incomingExpanded ? "chevron-down" : "chevron-right"} />
+									{remote.remoteName} +{incoming}
+								</button>
+								<RowMetaSeparator />
+							</>
+						)}
+
 						{/* Only while folded: the count stands in for the commits it hides,
 						    so showing it alongside them would just be noise. */}
 						{isFolded && commitCount > 0 && (
@@ -526,12 +576,15 @@ export const BranchRow: FC<
 								rowStyles.metaItemShrinkable,
 							)}
 						>
-							<span className={rowStyles.metaItemText}>
+							<span className={rowStyles.metaItemText} title={pushStatusTooltip}>
 								{Match.value(pushStatus).pipe(
 									Match.when("nothingToPush", () => "Nothing to push"),
 									Match.when("unpushedCommits", () => "Some unpushed"),
 									Match.when("completelyUnpushed", () => "Unpushed branch"),
-									Match.when("unpushedCommitsRequiringForce", () => "Some unpushed"),
+									// Both need a force push; the one with nothing to bring in is named for its cause.
+									Match.when("unpushedCommitsRequiringForce", () =>
+										incoming > 0 ? "Diverged" : "Rewritten",
+									),
 									Match.when("integrated", () => "Integrated"),
 									Match.exhaustive,
 								)}
@@ -634,6 +687,23 @@ export const BranchRow: FC<
 									</Tooltip.Root>
 								);
 							})()}
+
+						{/* Beside Push rather than in its place: a plain push cannot land
+						    while the remote is ahead, and forcing would drop theirs. */}
+						{remoteLabel !== null && incoming > 0 && (
+							<Button
+								aria-label={`Integrate ${remoteLabel} into ${refName.displayName}`}
+								title={`Bring ${remoteLabel}'s commits into ${refName.displayName}`}
+								className={classes(
+									getRowButtonClassName({ variant: "outline" }),
+									rowStyles.metaButton,
+								)}
+								onClick={() => openUpdateFromRemote(dispatch, refName.fullNameBytes)}
+							>
+								Integrate
+								<Icon size={12} name="arrow-down" />
+							</Button>
+						)}
 					</RowMeta>
 				</RowLabelGroup>
 			)}

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/IncomingRows.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/IncomingRows.tsx
@@ -1,0 +1,52 @@
+import rowStyles from "../Row.module.css";
+import { decodeBytes } from "#ui/api/bytes.ts";
+import { branchAddress, addressIdentityKey } from "#ui/addresses.ts";
+import { authorTooltip, commitTitle } from "#ui/commit.ts";
+import { GraphSegment } from "#ui/components/GraphSegment.tsx";
+import { projectSlice } from "#ui/projects/state.ts";
+import { useAppSelector } from "#ui/store.ts";
+import { addressSpaceIncludes } from "#ui/workspace/address-space.ts";
+import type { BranchReference, Segment } from "@gitbutler/but-sdk";
+import type { FC } from "react";
+import { Row, RowLabel, RowLabelContainer } from "../Row.tsx";
+import { useAddressSpace } from "./context.tsx";
+
+/**
+ * The remote's commits the branch lacks, opened from the branch row's chip:
+ * ghosted rows on the branch's own rail. Not in the address space, so they
+ * dim with the branch like its other addressless rows.
+ */
+export const IncomingRows: FC<{
+	projectId: string;
+	segment: Segment;
+	refName: BranchReference;
+}> = ({ projectId, segment, refName }) => {
+	const addressSpace = useAddressSpace();
+	const branchRef = decodeBytes(refName.fullNameBytes);
+	const expanded = useAppSelector((state) =>
+		projectSlice.selectors.selectIncomingExpanded(state, projectId, branchRef),
+	);
+	if (!expanded) return null;
+
+	const inert = !addressSpaceIncludes(
+		addressSpace,
+		branchAddress({ branchRef: refName.fullNameBytes }),
+		addressIdentityKey,
+	);
+
+	return segment.commitsOnRemote.map((commit) => (
+		<Row
+			key={commit.id}
+			interactive={false}
+			inert={inert}
+			title={authorTooltip(commit.author, commit.committedAt)}
+		>
+			<GraphSegment glyph="commit" status="Upstream" />
+			<RowLabelContainer>
+				<RowLabel singleLine className={rowStyles.fadedText}>
+					{commitTitle(commit.message) ?? "(no message)"}
+				</RowLabel>
+			</RowLabelContainer>
+		</Row>
+	));
+};

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.tsx
@@ -91,6 +91,7 @@ import { useNow } from "#ui/components/useNow.ts";
 import { segmentBottomRelativeTo } from "#ui/api/stack.ts";
 import { assert } from "#ui/assert.ts";
 import { CommitRow } from "./CommitRow.tsx";
+import { IncomingRows } from "./IncomingRows.tsx";
 import { BranchRow, type PushActivity } from "./BranchRow.tsx";
 import { useActiveListsHotkeys } from "./hotkeys.ts";
 import { UncommittedChangesRow } from "./UncommittedChangesRow.tsx";
@@ -104,6 +105,7 @@ import { useListFilter } from "../useListFilter.ts";
 import { buildUncommittedFileRows } from "../file-row.ts";
 import { useFileDisplayMode } from "../useFileDisplayMode.ts";
 import {
+	canIntegrateUpstream,
 	canRemoveBranchReference,
 	downstackPushStatusesFromSegments,
 	type DownstackPushStatus,
@@ -540,6 +542,9 @@ const BranchSegment: FC<{
 				downstackPushStatus={downstackPushStatus}
 				pushActivity={pushActivity}
 				pushStatus={segment.pushStatus}
+				canUpdateFromRemote={canIntegrateUpstream(segment)}
+				remote={segment.remoteTrackingRefName}
+				incoming={segment.commitsOnRemote.length}
 				recordedPullRequest={recordedPullRequest(segment)}
 				graphStatus={segmentPushStatusToGraphSegmentStatus(segment.pushStatus)}
 				bottomRelativeTo={segmentBottomRelativeTo(segment)}
@@ -551,6 +556,10 @@ const BranchSegment: FC<{
 
 			{/* oxlint-disable-next-line jsx-a11y/prefer-tag-over-role -- Tree items need ARIA group semantics. */}
 			<div role="group">
+				{/* Gated here so the common case pays no mount; folding hides them with the commits. */}
+				{!isFolded && segment.commitsOnRemote.length > 0 && (
+					<IncomingRows projectId={projectId} segment={segment} refName={refName} />
+				)}
 				<SegmentContent
 					ariaLevel={2}
 					isFolded={isFolded}

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/update-from-remote.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/update-from-remote.ts
@@ -1,0 +1,21 @@
+import { decodeBytes } from "#ui/api/bytes.ts";
+import { branchAddress } from "#ui/addresses.ts";
+import { interfaceSlice } from "#ui/interface/state.ts";
+import { setCursor } from "#ui/use-cursor.ts";
+import type { AppDispatch } from "#ui/store.ts";
+
+/**
+ * Every entry point opens the dialog through here, so the select-branch-first
+ * step cannot diverge between them.
+ */
+export const openUpdateFromRemote = (
+	dispatch: AppDispatch,
+	branchRefBytes: Array<number>,
+): void => {
+	setCursor("applied", branchAddress({ branchRef: branchRefBytes }));
+	dispatch(
+		interfaceSlice.actions.openDialog({
+			dialog: { _tag: "UpdateFromRemote", branchRef: decodeBytes(branchRefBytes) },
+		}),
+	);
+};

--- a/apps/lite/ui/src/segment.ts
+++ b/apps/lite/ui/src/segment.ts
@@ -12,6 +12,14 @@ export const canRemoveBranchReference = (stack: Stack, segmentIndex: number): bo
 	return segmentIndex !== topBranchIndex;
 };
 
+/**
+ * Whether the update-from-remote flow has anything to do: an upstream with
+ * commits the branch lacks, or rewritten history it still holds.
+ */
+export const canIntegrateUpstream = (segment: Segment): boolean =>
+	segment.remoteTrackingRefName !== null &&
+	(segment.commitsOnRemote.length > 0 || segment.pushStatus === "unpushedCommitsRequiringForce");
+
 export type DownstackPushStatus = {
 	anyRequiresPush: boolean;
 	anyPushRequiresForce: boolean;


### PR DESCRIPTION
A diverged branch shows its remote as a second rail in the workspace outline: a collapsed `origin/<name>` row with the ahead count, expandable to the remote-only commits. Head info's `commitsOnRemote` was rendered nowhere, and force push was the only resolution on offer.

- A branch whose history was only rewritten, nothing new either side, reads "Rewritten" with no button: the branch row's force push is the whole answer.
- Integrate on the leg and Update From Remote in the branch menu open a dialog led by a diagnosis of what the remote has, with three answers over one outline of the previewed outcome (a dry-run `applyBranchIntegration`): **Keep mine** force-pushes the branch as it is; **Combine both** rebases your work onto the remote's new commits, leaving out the remote's versions of commits you rewrote so neither side lands twice; **Take theirs** replaces the branch with the remote. Conflicts are flagged before anything applies.
- Under Combine both every incoming commit carries a checkbox; unticking one leaves it out and parks it under "Left out".
- Integrating is not publishing, and the dialog says so: the footer states whether a plain or force push follows, and once the integration lands the dialog offers that push in place, with Done to leave it for later.

Verified by `branch-update.spec.ts`, which applies every answer against seeded divergences and asserts the resulting git history, conflict markers included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
