### PR TITLE
Virtualise branches tab

### DIFF
--- a/apps/lite/e2e/tests/workspace-focus.spec.ts
+++ b/apps/lite/e2e/tests/workspace-focus.spec.ts
@@ -79,7 +79,7 @@ test.describe("workspace focus", () => {
 		const toggleFiles = appWindow.getByRole("button", { name: "Toggle files" });
 		if ((await toggleFiles.getAttribute("aria-pressed")) !== "true") await toggleFiles.click();
 
-		const sidebar = appWindow.locator('[data-focus-scope="sidebar"]');
+		const sidebar = appWindow.locator('[data-focus-scope="sidebar"]:visible');
 		const files = appWindow.locator('[data-focus-scope="files"]');
 		const diff = appWindow.locator('[data-focus-scope="diff"]');
 		const selectedFile = files.locator('[role="treeitem"][aria-selected="true"]');
@@ -88,7 +88,9 @@ test.describe("workspace focus", () => {
 		const selectedFileBackground = () =>
 			selectedFile.evaluate((element) => getComputedStyle(element).backgroundColor);
 
-		await sidebar.focus();
+		await diff.focus();
+		await appWindow.keyboard.press("2");
+		await expect(sidebar).toBeFocused();
 		let blurredBackground = "";
 		// Capture inside the successful poll so a virtualized row replacement cannot empty the baseline.
 		await expect

--- a/apps/lite/ui/src/focus-scopes.ts
+++ b/apps/lite/ui/src/focus-scopes.ts
@@ -47,18 +47,22 @@ const paneNavigationAllowed = (): boolean => {
 };
 
 const findFocusTarget = (parent: ParentNode, scope: FocusScope): HTMLElement | null => {
-	const root = parent.querySelector<HTMLElement>(`[data-focus-scope="${scope}"]`);
-	if (!root) return null;
+	for (const root of parent.querySelectorAll<HTMLElement>(`[data-focus-scope="${scope}"]`)) {
+		// Activity retains hidden panes in the DOM, but they must not intercept focus restoration.
+		if (!root.checkVisibility()) continue;
 
-	const children = focusScopeChildren[scope];
-	if (children) {
-		for (const childScope of children) {
-			const target = findFocusTarget(root, childScope);
-			if (target) return target;
+		const children = focusScopeChildren[scope];
+		if (children) {
+			for (const childScope of children) {
+				const target = findFocusTarget(root, childScope);
+				if (target) return target;
+			}
 		}
+
+		return root;
 	}
 
-	return root;
+	return null;
 };
 
 export const focusScope = (scope: FocusScope) => {

--- a/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.module.css
@@ -40,13 +40,19 @@
 /* One card's floor divides it from the next, so they sit together without a
    gap. */
 .tree {
-	display: flex;
-	flex-direction: column;
+	/* Its explicit virtual height defines the scroll extent. The absolutely positioned cards have no
+	   intrinsic height, so allowing this flex child to shrink would size the scrollbar only to the
+	   furthest currently rendered card. */
+	flex-shrink: 0;
 
 	&:focus {
 		/* The focus state is displayed on the item row instead. */
 		outline: none;
 	}
+}
+
+.virtualContainer {
+	position: relative;
 }
 
 .heading {

--- a/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.tsx
@@ -60,7 +60,7 @@ import {
 } from "./Row-utils.ts";
 import { StackCard } from "./StackCard.tsx";
 import stackCardStyles from "./StackCard.module.css";
-import type { BranchesListData } from "./useBranchesList.ts";
+import { emptyBranchesListContent, type BranchesListQueryResult } from "./useBranchesList.ts";
 import {
 	startKeyboardTransfer,
 	setCursor,
@@ -439,7 +439,7 @@ const BranchItem: FC<{
 export const BranchesList: FC<
 	{
 		projectId: string;
-		list: BranchesListData;
+		list: BranchesListQueryResult;
 		/**
 		 * Owned by the sidebar and shared with its unapplied header, so both `+`
 		 * buttons offer the same menu and see the same create in flight.
@@ -448,9 +448,14 @@ export const BranchesList: FC<
 	} & ComponentProps<"div">
 > = ({ projectId, list, newBranch, ...restProps }) => {
 	const dispatch = useAppDispatch();
-	// Derived once in WorkspacePage and passed down, so the rendered list and the
-	// address space that resolves selection are the same object.
-	const { stacks, stackIndexByAddressIndex, addressSpace, isPending, isError } = list;
+
+	// WorkspacePage resolves selection from this query result and passes the same result down, so
+	// selection and rendering consume the same data snapshot.
+	const {
+		data: { stacks, stackIndexByAddressIndex, addressSpace } = emptyBranchesListContent,
+		isPending,
+		isError,
+	} = list;
 	const filters = useAppSelector((state) =>
 		projectSlice.selectors.selectBranchFilters(state, projectId),
 	);

--- a/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.tsx
@@ -1,15 +1,9 @@
 import rowStyles from "./Row.module.css";
 import uiStyles from "#ui/components/ui.module.css";
 import { useBranchRemove } from "#ui/api/mutations.ts";
-import { branchDetailsQueryOptions } from "#ui/api/queries.ts";
 import { decodeBytes, encodeBytes } from "#ui/api/bytes.ts";
 import { assert } from "#ui/assert.ts";
-import {
-	branchDetailsParams,
-	branchIsEmpty,
-	branchOwnCommits,
-	type BranchFilters,
-} from "#ui/branch.ts";
+import { branchIsEmpty, type BranchFilters } from "#ui/branch.ts";
 import { commitIsDiverged, commitTitle } from "#ui/commit.ts";
 import { classes } from "#ui/components/classes.ts";
 import {
@@ -34,9 +28,18 @@ import { RelativeTime } from "#ui/components/RelativeTime.tsx";
 import type { Commit, ListedBranch } from "@gitbutler/but-sdk";
 import { Toolbar } from "@base-ui/react";
 import { useMergedRefs } from "@base-ui/utils/useMergedRefs";
-import { useQuery } from "@tanstack/react-query";
 import { useHotkey } from "@tanstack/react-hotkeys";
-import { type ComponentProps, type FC, Fragment, useRef, useState } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import {
+	type ComponentProps,
+	type FC,
+	Fragment,
+	type RefObject,
+	useCallback,
+	useLayoutEffect,
+	useRef,
+	useState,
+} from "react";
 import {
 	Row,
 	RowFoldToggle,
@@ -116,6 +119,7 @@ const CommitItem: FC<{ commit: Commit }> = ({ commit }) => {
 			aria-label={title ?? "(no message)"}
 			aria-selected={isSelected}
 			isSelected={isSelected}
+			scrollSelectedIntoView={false}
 			onSelect={() => setCursor("unapplied", address)}
 			onContextMenu={(event) => void showNativeContextMenu(event, menuItems)}
 		>
@@ -132,17 +136,105 @@ const CommitItem: FC<{ commit: Commit }> = ({ commit }) => {
 	);
 };
 
-const BranchCommits: FC<{ projectId: string; branch: ListedBranch }> = ({ projectId, branch }) => {
-	const { data: branchDetails } = useQuery(
-		branchDetailsQueryOptions({ projectId, ...branchDetailsParams(branch.refName.full) }),
-	);
+const BranchCommits: FC<{
+	branch: ListedBranch;
+	commits: Array<Commit> | undefined;
+	scrollElementRef: RefObject<HTMLDivElement | null>;
+	stackScrollStart: number;
+	stackSize: number;
+	branchAddressIndex: number;
+	selectedCommitIndex: number | undefined;
+}> = ({
+	branch,
+	commits,
+	scrollElementRef,
+	stackScrollStart,
+	stackSize,
+	branchAddressIndex,
+	selectedCommitIndex,
+}) => {
+	const getCommitKey = useCallback((index: number) => commits?.[index]?.id ?? index, [commits]);
 
-	if (!branchDetails) return <InertRow branch={branch} label="Loading…" />;
+	const commitListRef = useRef<HTMLDivElement>(null);
+	const [scrollMargin, setScrollMargin] = useState(stackScrollStart);
 
-	const commits = branchOwnCommits(branch, branchDetails.commits);
+	// oxlint-disable-next-line react-hooks-js/incompatible-library -- https://github.com/TanStack/virtual/issues/1119#issuecomment-4648268095
+	const rowVirtualizer = useVirtualizer({
+		directDomUpdates: true,
+		directDomUpdatesMode: "transform",
+		count: commits?.length ?? 0,
+		getScrollElement: () => scrollElementRef.current,
+		initialOffset: () => scrollElementRef.current?.scrollTop ?? 0,
+		// Keep in sync with --single-line-row-height.
+		estimateSize: () => 28,
+		getItemKey: getCommitKey,
+		scrollMargin,
+		// Matches --scroll-gradient-height.
+		scrollPaddingStart: 14,
+		scrollPaddingEnd: 14,
+	});
+
+	const containerRef = useMergedRefs(rowVirtualizer.containerRef, commitListRef);
+
+	// Nested commit lists share the outer scroller, so the virtualizer needs this list's start in
+	// scroller coordinates. A mounted list can move when an earlier branch changes without its own
+	// DOM node changing; remeasure only when the stack moves or resizes, or when visible rows before
+	// this branch change. This avoids forcing layout on ordinary virtualizer renders.
+	useLayoutEffect(() => {
+		const element = commitListRef.current;
+		if (!element) return;
+
+		const nextScrollMargin = stackScrollStart + element.offsetTop;
+		setScrollMargin((currentScrollMargin) =>
+			currentScrollMargin === nextScrollMargin ? currentScrollMargin : nextScrollMargin,
+		);
+	}, [branchAddressIndex, stackScrollStart, stackSize]);
+
+	// Reveal the selected commit before paint when its resolved index changes. Activity reconnects
+	// layout effects on reveal without changing that index, so remembering it preserves manual
+	// scroll.
+	const lastRevealedCommitIndexRef = useRef<number>(undefined);
+
+	useLayoutEffect(() => {
+		if (
+			selectedCommitIndex !== undefined &&
+			selectedCommitIndex !== lastRevealedCommitIndexRef.current
+		)
+			rowVirtualizer.scrollToIndex(selectedCommitIndex, { align: "auto" });
+
+		lastRevealedCommitIndexRef.current = selectedCommitIndex;
+	}, [rowVirtualizer, selectedCommitIndex]);
+
+	if (commits === undefined) return <InertRow branch={branch} label="Loading…" />;
+
 	if (commits.length === 0) return <InertRow branch={branch} label="No commits." />;
 
-	return commits.map((commit) => <CommitItem key={commit.id} commit={commit} />);
+	return (
+		// oxlint-disable-next-line jsx-a11y/prefer-tag-over-role -- Tree items need ARIA group semantics.
+		<div ref={containerRef} role="group" className={styles.virtualContainer}>
+			{rowVirtualizer.getVirtualItems().map((virtualRow) => {
+				const commit = commits[virtualRow.index];
+				if (commit === undefined) return null;
+
+				return (
+					<div
+						key={commit.id}
+						data-index={virtualRow.index}
+						ref={rowVirtualizer.measureElement}
+						style={{
+							position: "absolute",
+							top: 0,
+							left: 0,
+							width: "100%",
+							height: virtualRow.size,
+						}}
+					>
+						<CommitItem commit={commit} />
+					</div>
+				);
+			})}
+		</div>
+	);
 };
 
 const BranchItem: FC<{
@@ -150,7 +242,24 @@ const BranchItem: FC<{
 	branch: ListedBranch;
 	isTopBranch: boolean;
 	isStacked: boolean;
-}> = ({ projectId, branch, isTopBranch, isStacked }) => {
+	commits: Array<Commit> | undefined;
+	scrollElementRef: RefObject<HTMLDivElement | null>;
+	stackScrollStart: number;
+	stackSize: number;
+	branchAddressIndex: number;
+	selectedCommitIndex: number | undefined;
+}> = ({
+	projectId,
+	branch,
+	isTopBranch,
+	isStacked,
+	commits,
+	scrollElementRef,
+	stackScrollStart,
+	stackSize,
+	branchAddressIndex,
+	selectedCommitIndex,
+}) => {
 	const dispatch = useAppDispatch();
 	const branchRef = branch.refName.full;
 	const address = branchAddress({ branchRef: encodeBytes(branchRef) });
@@ -313,10 +422,15 @@ const BranchItem: FC<{
 			</Row>
 
 			{unfolded && (
-				// oxlint-disable-next-line jsx-a11y/prefer-tag-over-role -- Tree items need ARIA group semantics.
-				<div role="group">
-					<BranchCommits projectId={projectId} branch={branch} />
-				</div>
+				<BranchCommits
+					branch={branch}
+					commits={commits}
+					scrollElementRef={scrollElementRef}
+					stackScrollStart={stackScrollStart}
+					stackSize={stackSize}
+					branchAddressIndex={branchAddressIndex}
+					selectedCommitIndex={selectedCommitIndex}
+				/>
 			)}
 		</div>
 	);
@@ -336,7 +450,7 @@ export const BranchesList: FC<
 	const dispatch = useAppDispatch();
 	// Derived once in WorkspacePage and passed down, so the rendered list and the
 	// address space that resolves selection are the same object.
-	const { unapplied, addressSpace, isPending, isError } = list;
+	const { stacks, stackIndexByAddressIndex, addressSpace, isPending, isError } = list;
 	const filters = useAppSelector((state) =>
 		projectSlice.selectors.selectBranchFilters(state, projectId),
 	);
@@ -351,7 +465,84 @@ export const BranchesList: FC<
 	useCursorWriteBack("unapplied", addressSpace);
 
 	const panelRef = useRef<HTMLDivElement>(null);
-	const hotkeysRef = useRef<HTMLDivElement>(null);
+	const treeRef = useRef<HTMLDivElement>(null);
+	const scrollElementRef = useRef<HTMLDivElement>(null);
+
+	// Activity preserves the scroller DOM but temporarily clears its ref; nested virtualizer
+	// effects reconnect before that ref is restored. Keep the last node available to them. A real
+	// unmount discards this ref, and the stable callback avoids ref churn on virtualizer renders.
+	const retainScrollElement = useCallback((element: HTMLDivElement | null) => {
+		if (element) scrollElementRef.current = element;
+	}, []);
+
+	// The virtualiser treats getItemKey identity as part of its measurement model. Keep it stable
+	// across selection renders, but refresh estimates when either stack identity or commit counts
+	// change.
+	const getStackKey = useCallback(
+		(index: number) => stacks[index]?.branches[0]?.branch.refName.full ?? index,
+		[stacks],
+	);
+
+	// oxlint-disable-next-line react-hooks-js/incompatible-library -- https://github.com/TanStack/virtual/issues/1119#issuecomment-4648268095
+	const rowVirtualizer = useVirtualizer({
+		count: stacks.length,
+		getScrollElement: () => scrollElementRef.current,
+		estimateSize: (index) => {
+			// Keep in sync with Row.module.css and StackCard.module.css.
+			const singleLineRowHeight = 28;
+			const branchMetaLineHeight = 20;
+			const branchMetaPaddingEnd = 6;
+			const stackBodyPaddingStart = 6;
+			const stackBorderHeight = 1;
+			const stackFinalConnectorHeight = 8;
+			const stackBetweenBranchConnectorHeight = 14;
+
+			const branchCount = stacks[index]?.branches.length ?? 0;
+			const commitCount = stacks[index]?.commitCount ?? 0;
+
+			return (
+				stackBodyPaddingStart +
+				stackBorderHeight +
+				stackFinalConnectorHeight +
+				branchCount * (singleLineRowHeight + branchMetaLineHeight + branchMetaPaddingEnd) +
+				commitCount * singleLineRowHeight +
+				Math.max(0, branchCount - 1) * stackBetweenBranchConnectorHeight
+			);
+		},
+		getItemKey: getStackKey,
+		// Matches --scroll-gradient-height.
+		scrollPaddingStart: 14,
+		scrollPaddingEnd: 14,
+	});
+
+	const selectedAddressKey = selection === null ? undefined : addressIdentityKey(selection);
+	const selectedAddressIndex =
+		selectedAddressKey === undefined ? undefined : addressSpace.indexByKey.get(selectedAddressKey);
+	const selectedStackIndex =
+		selectedAddressIndex === undefined ? undefined : stackIndexByAddressIndex[selectedAddressIndex];
+
+	// Activity reconnects layout effects on reveal without changing the selection. Remember the
+	// handled address so revealing the tab preserves manual scroll.
+	const lastRevealedAddressKeyRef = useRef<string>(undefined);
+
+	// If the selected row's stack is not rendered, scroll the outer virtualizer to it. The row or
+	// nested virtualizer then handles precise alignment.
+	useLayoutEffect(() => {
+		const selectedStackIsMounted = rowVirtualizer
+			.getVirtualItems()
+			.some((virtualRow) => virtualRow.index === selectedStackIndex);
+
+		if (
+			selectedAddressKey !== undefined &&
+			selectedAddressKey !== lastRevealedAddressKeyRef.current &&
+			selectedStackIndex !== undefined &&
+			!selectedStackIsMounted
+		)
+			rowVirtualizer.scrollToIndex(selectedStackIndex, { align: "auto" });
+
+		lastRevealedAddressKeyRef.current = selectedAddressKey;
+	}, [rowVirtualizer, selectedAddressKey, selectedStackIndex]);
+
 	const { isPending: isBranchRemovePending, mutate: branchRemove } = useBranchRemove(projectId);
 	const selectedBranchIsLocal =
 		selection?._tag === "Branch" && decodeBytes(selection.branchRef).startsWith("refs/heads/");
@@ -366,7 +557,7 @@ export const BranchesList: FC<
 		select: (newItem) => setCursor("unapplied", newItem),
 		selection,
 		selectSectionPredicate: (address) => address._tag === "Branch",
-		ref: hotkeysRef,
+		ref: treeRef,
 		getKey: addressIdentityKey,
 	});
 
@@ -381,7 +572,7 @@ export const BranchesList: FC<
 			enabled: noOperationPending && selection?._tag === "Commit",
 			ignoreInputs: true,
 			meta: branchesHotkeys.copy.meta,
-			target: hotkeysRef,
+			target: treeRef,
 		},
 	);
 
@@ -393,11 +584,11 @@ export const BranchesList: FC<
 		{
 			enabled: selectedBranchIsLocal && !isBranchRemovePending,
 			meta: branchesHotkeys.deleteBranchRef.meta,
-			target: hotkeysRef,
+			target: treeRef,
 		},
 	);
 
-	const firstBranch = unapplied[0]?.branches[0];
+	const firstBranch = stacks[0]?.branches[0]?.branch;
 	const branchFilter = useListFilter({
 		filter: search,
 		setFilter: (search) => dispatch(projectSlice.actions.setBranchSearch({ projectId, search })),
@@ -413,7 +604,7 @@ export const BranchesList: FC<
 			if (selection !== null) setCursor("unapplied", selection);
 		},
 		panelRef,
-		listRef: hotkeysRef,
+		listRef: treeRef,
 	});
 
 	const showFilterMenu = (trigger: HTMLElement) => {
@@ -475,8 +666,8 @@ export const BranchesList: FC<
 				<ListFilterRow {...branchFilter.rowProps} />
 			)}
 
-			<div className={classes(uiStyles.scroller, styles.list)}>
-				{unapplied.length === 0 && (
+			<div ref={retainScrollElement} className={classes(uiStyles.scroller, styles.list)}>
+				{stacks.length === 0 && (
 					<p className={classes("text-13", styles.msg)}>
 						{isPending
 							? "Loading branches…"
@@ -494,35 +685,65 @@ export const BranchesList: FC<
 					aria-label="Branches"
 					aria-activedescendant={selection ? treeItemId(selection) : undefined}
 					data-focus-scope={"sidebar" satisfies FocusScope}
-					className={styles.tree}
-					ref={useMergedRefs(hotkeysRef, useAutofocusScope())}
+					className={classes(styles.tree, styles.virtualContainer)}
+					style={{ height: rowVirtualizer.getTotalSize() }}
+					ref={useMergedRefs(treeRef, useAutofocusScope())}
 				>
-					{unapplied.map((stack) => (
-						<StackCard
-							key={assert(stack.branches[0]).refName.full}
-							// oxlint-disable-next-line jsx-a11y/prefer-tag-over-role -- A stack is an ARIA group of tree items.
-							role="group"
-							aria-label="Stack"
-						>
-							{stack.branches.map((branch, index) => (
-								<Fragment key={branch.refName.full}>
-									<BranchItem
-										projectId={projectId}
-										branch={branch}
-										isTopBranch={index === 0}
-										isStacked={stack.branches.length > 1}
-									/>
+					{rowVirtualizer.getVirtualItems().map((virtualRow) => {
+						const stack = stacks[virtualRow.index];
+						if (stack === undefined) return null;
 
-									{/* Carries the rail down to the next branch, and past the
-									    last one as the card's floor — as the workspace card's
-									    segment connectors do. */}
-									<Row interactive={false} className={stackCardStyles.railConnector}>
-										<GraphSegment glyph="parent" status={branchGraphStatus(branch)} />
-									</Row>
-								</Fragment>
-							))}
-						</StackCard>
-					))}
+						return (
+							<StackCard
+								key={assert(stack.branches[0]).branch.refName.full}
+								data-index={virtualRow.index}
+								ref={rowVirtualizer.measureElement}
+								style={{
+									position: "absolute",
+									top: 0,
+									left: 0,
+									width: "100%",
+									transform: `translateY(${virtualRow.start}px)`,
+								}}
+								// oxlint-disable-next-line jsx-a11y/prefer-tag-over-role -- A stack is an ARIA group of tree items.
+								role="group"
+								aria-label="Stack"
+							>
+								{stack.branches.map(({ branch, addressIndex, commits }, index) => {
+									const selectedCommitIndex =
+										selectedAddressIndex !== undefined &&
+										selectedAddressIndex > addressIndex &&
+										selectedAddressIndex <= addressIndex + (commits?.length ?? 0)
+											? selectedAddressIndex - addressIndex - 1
+											: undefined;
+
+									return (
+										<Fragment key={branch.refName.full}>
+											<BranchItem
+												projectId={projectId}
+												branch={branch}
+												isTopBranch={index === 0}
+												isStacked={stack.branches.length > 1}
+												commits={commits}
+												scrollElementRef={scrollElementRef}
+												stackScrollStart={virtualRow.start}
+												stackSize={virtualRow.size}
+												branchAddressIndex={addressIndex}
+												selectedCommitIndex={selectedCommitIndex}
+											/>
+
+											{/* Carries the rail down to the next branch, and past the
+											    last one as the card's floor — as the workspace card's
+											    segment connectors do. */}
+											<Row interactive={false} className={stackCardStyles.railConnector}>
+												<GraphSegment glyph="parent" status={branchGraphStatus(branch)} />
+											</Row>
+										</Fragment>
+									);
+								})}
+							</StackCard>
+						);
+					})}
 				</div>
 			</div>
 		</div>

--- a/apps/lite/ui/src/routes/project/$id/workspace/Page.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Page.tsx
@@ -482,7 +482,7 @@ const PageBody: FC<{ projectId: string }> = ({ projectId }) => {
 	const upstreamList = useUpstreamList(projectId);
 
 	const appliedSelection = useSelection("applied", appliedAddressSpace);
-	const branchesSelection = useSelection("unapplied", branchesList.addressSpace);
+	const branchesSelection = useSelection("unapplied", branchesList.data?.addressSpace);
 	const upstreamSelection = useSelection("upstream", upstreamList.addressSpace);
 
 	const { data: worktreeChanges } = useQuery(changesInWorktreeQueryOptions(projectId));

--- a/apps/lite/ui/src/routes/project/$id/workspace/Row.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Row.tsx
@@ -59,12 +59,23 @@ export const Row: FC<
 	const rowRef = useRef<HTMLDivElement | null>(null);
 	const mergedRef = useMergedRefs(rowRef, refProp);
 
+	// Activity reconnects layout effects on reveal without changing `isSelected`. Only scroll for a
+	// new selection so revealing a tab preserves manual scroll.
+	const selectionWasRevealedRef = useRef(false);
+
 	useLayoutEffect(() => {
-		if (!isSelected || !scrollSelectedIntoView) return;
+		if (!isSelected) {
+			selectionWasRevealedRef.current = false;
+			return;
+		}
+		if (!scrollSelectedIntoView || selectionWasRevealedRef.current) return;
+
 		rowRef.current?.scrollIntoView({
 			block: "nearest",
 			inline: "nearest",
 		});
+
+		selectionWasRevealedRef.current = true;
 	}, [isSelected, scrollSelectedIntoView]);
 
 	return (

--- a/apps/lite/ui/src/routes/project/$id/workspace/Sidebar.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Sidebar.tsx
@@ -28,7 +28,7 @@ import { Activity, type FC, useRef } from "react";
 import { ToggleGroupStyles, ToggleStyles } from "#ui/components/ToggleGroup.tsx";
 import { WorkspaceLists } from "#ui/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.tsx";
 import { BranchesList } from "#ui/routes/project/$id/workspace/BranchesList.tsx";
-import type { BranchesListData } from "#ui/routes/project/$id/workspace/useBranchesList.ts";
+import type { BranchesListQueryResult } from "#ui/routes/project/$id/workspace/useBranchesList.ts";
 import { UpstreamList } from "#ui/routes/project/$id/workspace/UpstreamList.tsx";
 import type { UpstreamListData } from "#ui/routes/project/$id/workspace/useUpstreamList.ts";
 import { assert } from "#ui/assert.ts";
@@ -91,7 +91,7 @@ const WorkspaceActivityBadge: FC<{ projectId: string }> = ({ projectId }) => {
 
 export const Sidebar: FC<{
 	absorptionTargetCommitIds: ReadonlySet<string>;
-	branchesList: BranchesListData;
+	branchesList: BranchesListQueryResult;
 	upstreamList: UpstreamListData;
 	addressSpace: AddressSpace<Address>;
 	uncommittedAddressSpace: AddressSpace<string>;

--- a/apps/lite/ui/src/routes/project/$id/workspace/Sidebar.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Sidebar.tsx
@@ -24,7 +24,7 @@ import { Button, Toast, Toggle, ToggleGroup, Tooltip } from "@base-ui/react";
 import type { BottomUpdate, ProjectForFrontend } from "@gitbutler/but-sdk";
 import { useQuery } from "@tanstack/react-query";
 import { useHotkeys } from "@tanstack/react-hotkeys";
-import { type FC, useRef } from "react";
+import { Activity, type FC, useRef } from "react";
 import { ToggleGroupStyles, ToggleStyles } from "#ui/components/ToggleGroup.tsx";
 import { WorkspaceLists } from "#ui/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.tsx";
 import { BranchesList } from "#ui/routes/project/$id/workspace/BranchesList.tsx";
@@ -311,14 +311,16 @@ export const Sidebar: FC<{
 				</ToggleGroup>
 			</div>
 
-			{page === "branches" ? (
+			<Activity mode={page === "branches" ? "visible" : "hidden"}>
 				<BranchesList
 					className={styles.page}
 					projectId={projectId}
 					list={branchesList}
 					newBranch={newBranch}
 				/>
-			) : page === "upstream" ? (
+			</Activity>
+
+			{page === "upstream" && (
 				<UpstreamList
 					className={styles.page}
 					projectId={projectId}
@@ -327,7 +329,9 @@ export const Sidebar: FC<{
 					isUpdatePending={isWorkspaceIntegrateUpstreamPending}
 					onUpdateWorkspace={updateWorkspace}
 				/>
-			) : (
+			)}
+
+			{page === "workspace" && (
 				<WorkspaceLists
 					className={styles.page}
 					addressSpace={addressSpace}

--- a/apps/lite/ui/src/routes/project/$id/workspace/useBranchesList.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/useBranchesList.ts
@@ -12,12 +12,24 @@ import { branchAddress, commitAddress, addressIdentityKey, type Address } from "
 import { projectSlice } from "#ui/projects/state.ts";
 import { useAppSelector } from "#ui/store.ts";
 import { buildIndexByKey, type AddressSpace } from "#ui/workspace/address-space.ts";
-import type { ListedStack } from "@gitbutler/but-sdk";
+import type { Commit, ListedBranch } from "@gitbutler/but-sdk";
 import { useQueries, useQuery } from "@tanstack/react-query";
 import { useDeferredValue } from "react";
 
+type BranchesListBranch = {
+	branch: ListedBranch;
+	addressIndex: number;
+	commits: Array<Commit> | undefined;
+};
+
+type BranchesListStack = {
+	branches: Array<BranchesListBranch>;
+	commitCount: number;
+};
+
 export type BranchesListData = {
-	unapplied: Array<ListedStack>;
+	stacks: Array<BranchesListStack>;
+	stackIndexByAddressIndex: Array<number>;
 	addressSpace: AddressSpace<Address>;
 	/**
 	 * The listing query's state, so the page can tell a genuinely empty result
@@ -27,10 +39,14 @@ export type BranchesListData = {
 	isError: boolean;
 };
 
-type BranchesListContent = Pick<BranchesListData, "unapplied" | "addressSpace">;
+type BranchesListContent = Pick<
+	BranchesListData,
+	"stacks" | "stackIndexByAddressIndex" | "addressSpace"
+>;
 
 const emptyContent: BranchesListContent = {
-	unapplied: [],
+	stacks: [],
+	stackIndexByAddressIndex: [],
 	addressSpace: { items: [], indexByKey: new Map() },
 };
 
@@ -56,20 +72,14 @@ export const useBranchesList = (projectId: string): BranchesListData => {
 		projectSlice.selectors.selectUnfoldedBranches(state, projectId),
 	);
 
-	const unfoldedBranchRefs = active ? Object.keys(unfoldedBranches) : [];
+	const unfoldedBranchRefs = Object.keys(unfoldedBranches);
 	const commitsByRef = useQueries({
-		queries: unfoldedBranchRefs.map((refName) =>
-			branchDetailsQueryOptions({ projectId, ...branchDetailsParams(refName) }),
-		),
+		queries: unfoldedBranchRefs.map((refName) => ({
+			...branchDetailsQueryOptions({ projectId, ...branchDetailsParams(refName) }),
+			enabled: active,
+		})),
 		combine: (results) =>
-			new Map(
-				unfoldedBranchRefs.map((refName, index) => [
-					refName,
-					results[index]?.data?.commits.map((commit) =>
-						commitAddress({ commitId: commit.id, changeId: commit.changeId }),
-					) ?? [],
-				]),
-			),
+			new Map(unfoldedBranchRefs.map((refName, index) => [refName, results[index]?.data?.commits])),
 	});
 
 	// The whole derivation lives in `select` so its result keeps a stable
@@ -88,22 +98,40 @@ export const useBranchesList = (projectId: string): BranchesListData => {
 		enabled: active,
 		select: (listedStacks): BranchesListContent => {
 			const unapplied = searchStacks(unappliedStacks(listedStacks, filters), search);
-			const items = unapplied.flatMap((stack) =>
-				stack.branches.flatMap(
-					(branch): Array<Address> => [
-						branchAddress({ branchRef: encodeBytes(branch.refName.full) }),
-						// Matches what BranchesList renders: a branch with no commits of
-						// its own cannot be unfolded, and an unfolded one shows only the
-						// commits it contributes itself.
-						...(unfoldedBranches[branch.refName.full] && !branchIsEmpty(branch)
-							? branchOwnCommits(branch, commitsByRef.get(branch.refName.full) ?? [])
-							: []),
-					],
-				),
-			);
+			const items: Array<Address> = [];
+			const stackIndexByAddressIndex: Array<number> = [];
+			const stacks = unapplied.map((stack, stackIndex): BranchesListStack => {
+				let commitCount = 0;
+				const branches = stack.branches.map((branch): BranchesListBranch => {
+					const addressIndex = items.length;
+					items.push(branchAddress({ branchRef: encodeBytes(branch.refName.full) }));
+					stackIndexByAddressIndex.push(stackIndex);
+
+					const branchCommits = commitsByRef.get(branch.refName.full);
+					const commits =
+						unfoldedBranches[branch.refName.full] &&
+						!branchIsEmpty(branch) &&
+						branchCommits !== undefined
+							? branchOwnCommits(branch, branchCommits)
+							: undefined;
+
+					if (commits !== undefined) {
+						commitCount += commits.length;
+						for (const commit of commits) {
+							items.push(commitAddress({ commitId: commit.id, changeId: commit.changeId }));
+							stackIndexByAddressIndex.push(stackIndex);
+						}
+					}
+
+					return { branch, addressIndex, commits };
+				});
+
+				return { branches, commitCount };
+			});
 
 			return {
-				unapplied,
+				stacks,
+				stackIndexByAddressIndex,
 				addressSpace: { items, indexByKey: buildIndexByKey(items, addressIdentityKey) },
 			};
 		},

--- a/apps/lite/ui/src/routes/project/$id/workspace/useBranchesList.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/useBranchesList.ts
@@ -13,12 +13,16 @@ import { projectSlice } from "#ui/projects/state.ts";
 import { useAppSelector } from "#ui/store.ts";
 import { buildIndexByKey, type AddressSpace } from "#ui/workspace/address-space.ts";
 import type { Commit, ListedBranch } from "@gitbutler/but-sdk";
-import { useQueries, useQuery } from "@tanstack/react-query";
+import { useQueries, useQuery, type UseQueryResult } from "@tanstack/react-query";
 import { useDeferredValue } from "react";
 
 type BranchesListBranch = {
 	branch: ListedBranch;
 	addressIndex: number;
+	/**
+	 * `undefined` means that the branch is folded, or that it's unfolded and that the query is either
+	 * loading or failed.
+	 */
 	commits: Array<Commit> | undefined;
 };
 
@@ -27,24 +31,15 @@ type BranchesListStack = {
 	commitCount: number;
 };
 
-export type BranchesListData = {
+type BranchesListContent = {
 	stacks: Array<BranchesListStack>;
 	stackIndexByAddressIndex: Array<number>;
 	addressSpace: AddressSpace<Address>;
-	/**
-	 * The listing query's state, so the page can tell a genuinely empty result
-	 * apart from one that has not arrived or failed.
-	 */
-	isPending: boolean;
-	isError: boolean;
 };
 
-type BranchesListContent = Pick<
-	BranchesListData,
-	"stacks" | "stackIndexByAddressIndex" | "addressSpace"
->;
+export type BranchesListQueryResult = UseQueryResult<BranchesListContent>;
 
-const emptyContent: BranchesListContent = {
+export const emptyBranchesListContent: BranchesListContent = {
 	stacks: [],
 	stackIndexByAddressIndex: [],
 	addressSpace: { items: [], indexByKey: new Map() },
@@ -57,7 +52,7 @@ const emptyContent: BranchesListContent = {
  * rendering and the selection resolution in the workspace page consume it, so
  * filtering and fold state cannot drift between the two.
  */
-export const useBranchesList = (projectId: string): BranchesListData => {
+export const useBranchesList = (projectId: string): BranchesListQueryResult => {
 	const active = usePage() === "branches";
 	const filters = useAppSelector((state) =>
 		projectSlice.selectors.selectBranchFilters(state, projectId),
@@ -89,11 +84,7 @@ export const useBranchesList = (projectId: string): BranchesListData => {
 	// input like `search` or `showEmpty` does. Deriving in render instead would
 	// rebuild the address space every pass and re-render every row that reads
 	// it through context.
-	const {
-		data: content = emptyContent,
-		isPending,
-		isError,
-	} = useQuery({
+	return useQuery({
 		...branchListQueryOptions(projectId),
 		enabled: active,
 		select: (listedStacks): BranchesListContent => {
@@ -136,6 +127,4 @@ export const useBranchesList = (projectId: string): BranchesListData => {
 			};
 		},
 	});
-
-	return { ...content, isPending, isError };
 };

--- a/apps/lite/ui/src/use-cursor.ts
+++ b/apps/lite/ui/src/use-cursor.ts
@@ -96,14 +96,14 @@ const resolveCursorParam = <L extends UrlCursorName>(
 /** The cursor resolved against what the list currently shows. */
 export const useSelection = <L extends UrlCursorName>(
 	list: L,
-	addressSpace: AddressSpace<CursorItem[L]>,
+	addressSpace: AddressSpace<CursorItem[L]> | null | undefined,
 ): CursorItem[L] | null => {
 	const param = useSearch({
 		from: WORKSPACE_ROUTE,
 		select: (params: UrlQueryParams): string | undefined => params[list],
 	});
 
-	return resolveCursorParam(list, param, addressSpace);
+	return addressSpace == null ? null : resolveCursorParam(list, param, addressSpace);
 };
 
 /**
@@ -436,6 +436,7 @@ export const useCursorWriteBack = <L extends UrlCursorName>(
 		resolved !== null && storedParam !== encodeUnion(list, resolved) ? resolved : null;
 
 	useEffect(() => {
+		// oxlint-disable-next-line react-you-might-not-need-an-effect/no-event-handler -- Reconcile the URL cursor when the address space changes; this is not an event response.
 		if (outOfSync !== null) setCursor(list, outOfSync);
 	}, [outOfSync, list]);
 };


### PR DESCRIPTION
Towards GB-1574.

Experimentally takes the approach of nested virtualisation. We can alternatively tackle this by flattening the hierarchy down to one virtualised list. In either case we should use the same approach elsewhere, which I'll be tackling shortly (e.g. workspace tab).

My current feeling is that keeping nested virtualisation instances in sync is a lesser evil than the impact that flattening will have on styling and other hierarchical concerns, particularly given the latter is what will be iterated upon and modified far more often in the future. Switching to a single, flat virtualiser would be a straightforward change from here; its minimal impact on component design is one of the advantages of this nested approach.