### PR TITLE
refactor: one popup container for every overlay in Lite

### DIFF
--- a/apps/lite/package.json
+++ b/apps/lite/package.json
@@ -136,7 +136,7 @@
 		"@base-ui/react": "^1.6.0",
 		"@base-ui/utils": "^0.3.1",
 		"@gitbutler/but-sdk": "workspace:*",
-		"@gitbutler/design-core": "3.13.2",
+		"@gitbutler/design-core": "3.15.2",
 		"@pierre/diffs": "^1.3.5",
 		"@pierre/theming": "^1.0.1",
 		"@reduxjs/toolkit": "catalog:redux",

--- a/apps/lite/ui/src/AskpassPromptDialog.module.css
+++ b/apps/lite/ui/src/AskpassPromptDialog.module.css
@@ -1,11 +1,8 @@
-.popup {
-	width: min(420px, calc(100vw - 32px));
-}
-
 .form {
 	display: flex;
 	row-gap: 12px;
 	flex-direction: column;
+	padding: 16px;
 }
 
 .prompt {

--- a/apps/lite/ui/src/AskpassPromptDialog.tsx
+++ b/apps/lite/ui/src/AskpassPromptDialog.tsx
@@ -1,9 +1,8 @@
-import { AlertDialog } from "@base-ui/react";
+import { Dialog } from "@base-ui/react";
 import { useEffect, useRef, useState } from "react";
 import type { FC, SyntheticEvent } from "react";
 import { getButtonClassName } from "#ui/components/Button.tsx";
-import { classes } from "#ui/components/classes.ts";
-import uiStyles from "#ui/components/ui.module.css";
+import { Modal } from "#ui/components/Popup.tsx";
 import styles from "./AskpassPromptDialog.module.css";
 import type { AskpassPromptEvent } from "@gitbutler/but-sdk";
 
@@ -75,55 +74,52 @@ export const AskpassPromptDialog: FC = () => {
 	};
 
 	return (
-		<AlertDialog.Root
+		<Modal
+			alert
+			size="small"
 			open={currentPrompt !== undefined}
 			onOpenChange={(open) => {
 				if (!open && currentPrompt && !submitting) void respond(currentPrompt, null);
 			}}
 		>
-			<AlertDialog.Portal>
-				<AlertDialog.Backdrop />
-				<AlertDialog.Popup className={classes(uiStyles.popup, uiStyles.dialogPopup, styles.popup)}>
-					{currentPrompt !== undefined && (
-						<form className={styles.form} onSubmit={submit}>
-							<AlertDialog.Title>Git credentials required</AlertDialog.Title>
-							<AlertDialog.Description className={styles.prompt}>
-								{getDescription(currentPrompt)}
-							</AlertDialog.Description>
-							<input
-								className={styles.input}
-								type={isSecretPrompt(currentPrompt.prompt) ? "password" : "text"}
-								value={currentResponse}
-								onChange={(event) =>
-									setResponse({ promptId: currentPrompt.id, value: event.target.value })
-								}
-								disabled={submitting}
-								aria-label="Credential response"
-							/>
-							{currentSubmitError !== null && (
-								<p className={styles.error}>Failed to send response: {currentSubmitError}</p>
-							)}
-							<div className={styles.actions}>
-								<button
-									type="button"
-									className={getButtonClassName({ variant: "ghost" })}
-									disabled={submitting}
-									onClick={() => void respond(currentPrompt, null)}
-								>
-									Cancel
-								</button>
-								<button
-									type="submit"
-									className={getButtonClassName({ variant: "pop" })}
-									disabled={submitting}
-								>
-									Continue
-								</button>
-							</div>
-						</form>
+			{currentPrompt !== undefined && (
+				<form className={styles.form} onSubmit={submit}>
+					<Dialog.Title>Git credentials required</Dialog.Title>
+					<Dialog.Description className={styles.prompt}>
+						{getDescription(currentPrompt)}
+					</Dialog.Description>
+					<input
+						className={styles.input}
+						type={isSecretPrompt(currentPrompt.prompt) ? "password" : "text"}
+						value={currentResponse}
+						onChange={(event) =>
+							setResponse({ promptId: currentPrompt.id, value: event.target.value })
+						}
+						disabled={submitting}
+						aria-label="Credential response"
+					/>
+					{currentSubmitError !== null && (
+						<p className={styles.error}>Failed to send response: {currentSubmitError}</p>
 					)}
-				</AlertDialog.Popup>
-			</AlertDialog.Portal>
-		</AlertDialog.Root>
+					<div className={styles.actions}>
+						<button
+							type="button"
+							className={getButtonClassName({ variant: "ghost" })}
+							disabled={submitting}
+							onClick={() => void respond(currentPrompt, null)}
+						>
+							Cancel
+						</button>
+						<button
+							type="submit"
+							className={getButtonClassName({ variant: "pop" })}
+							disabled={submitting}
+						>
+							Continue
+						</button>
+					</div>
+				</form>
+			)}
+		</Modal>
 	);
 };

--- a/apps/lite/ui/src/components/Dropdown.stories.tsx
+++ b/apps/lite/ui/src/components/Dropdown.stories.tsx
@@ -1,0 +1,96 @@
+import preview from "#storybook/preview";
+import { getButtonClassName } from "#ui/components/Button.tsx";
+import { Icon } from "#ui/components/Icon.tsx";
+import { Dropdown, PopupItem, PopupSearch, PopupSection } from "./Popup.tsx";
+
+const meta = preview.meta({
+	component: Dropdown,
+	parameters: {
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/EBuHQGUcCaSw4Ln5uVpWkn/Lite?node-id=4518-292100",
+		},
+	},
+	args: {
+		side: "bottom",
+		align: "start",
+		sideOffset: 4,
+	},
+	argTypes: {
+		side: { control: "inline-radio", options: ["top", "bottom", "left", "right"] },
+		align: { control: "inline-radio", options: ["start", "center", "end"] },
+	},
+	decorators: [
+		(Story) => (
+			<div style={{ display: "flex", justifyContent: "center", padding: "120px 48px" }}>
+				<Story />
+			</div>
+		),
+	],
+});
+
+export const Playground = meta.story({
+	args: {
+		"aria-label": "Dropdown playground",
+		style: { width: 240 },
+		trigger: (
+			<button type="button" className={getButtonClassName({})}>
+				Open dropdown
+			</button>
+		),
+		children: (
+			<PopupSection>
+				<PopupItem icon="branch">Switch branch</PopupItem>
+				<PopupItem icon="commit">Amend commit</PopupItem>
+				<PopupItem icon="bin">Discard changes</PopupItem>
+			</PopupSection>
+		),
+	},
+});
+
+/** The target selector: a filter over a short list, anchored under the control that opened it. */
+export const WithSearch = meta.story({
+	args: {
+		"aria-label": "Select target",
+		style: { width: 256 },
+		trigger: (
+			<button type="button" className={getButtonClassName({})}>
+				Select target
+			</button>
+		),
+		children: (
+			<>
+				<PopupSearch placeholder="Search targets..." aria-label="Search targets" />
+				<PopupSection>
+					<PopupItem icon="branch" trailing="bullseye">
+						rocketFlasher
+					</PopupItem>
+					<PopupItem icon="branch">Fliege-mono</PopupItem>
+					<PopupItem icon="branch">brutalism</PopupItem>
+				</PopupSection>
+			</>
+		),
+	},
+});
+
+/** A panel rather than a list — what the notifications bell opens. */
+export const Panel = meta.story({
+	args: {
+		"aria-label": "Notifications",
+		style: { width: 380 },
+		trigger: (
+			<button type="button" className={getButtonClassName({ iconOnly: true })}>
+				<Icon name="bell" />
+			</button>
+		),
+		children: (
+			<div style={{ display: "flex", flexDirection: "column", gap: 8, padding: 12 }}>
+				<strong className="text-12 text-semibold">Notifications</strong>
+				<span className="text-13">
+					A dropdown carries anchored panels as readily as it carries rows — the container does not
+					care what fills it.
+				</span>
+			</div>
+		),
+	},
+});

--- a/apps/lite/ui/src/components/MarkdownAttachments.module.css
+++ b/apps/lite/ui/src/components/MarkdownAttachments.module.css
@@ -13,10 +13,8 @@
 }
 
 .popup {
-	display: flex;
 	row-gap: 12px;
-	flex-direction: column;
-	width: min(420px, calc(100vw - 32px));
+	padding: 16px;
 }
 
 .description {

--- a/apps/lite/ui/src/components/MarkdownAttachments.tsx
+++ b/apps/lite/ui/src/components/MarkdownAttachments.tsx
@@ -1,14 +1,13 @@
 import { getButtonClassName } from "#ui/components/Button.tsx";
 import { Icon } from "#ui/components/Icon.tsx";
 import { TooltipPopup } from "#ui/components/Tooltip.tsx";
-import { classes } from "#ui/components/classes.ts";
-import uiStyles from "#ui/components/ui.module.css";
+import { Modal } from "#ui/components/Popup.tsx";
 import { useUploadFiles } from "#ui/api/mutations.ts";
 import { userProfileQueryOptions } from "#ui/api/queries.ts";
 import * as md from "#ui/markdown-editing.ts";
 import { applyToTextarea } from "#ui/markdown-textarea.ts";
 import { ACCEPTED_FILE_TYPES, filesFromTransfer, uploadsToMarkdown } from "#ui/uploads.ts";
-import { AlertDialog, Tooltip } from "@base-ui/react";
+import { Dialog, Tooltip } from "@base-ui/react";
 import { useQuery } from "@tanstack/react-query";
 import { type FC, type RefObject, useEffect, useRef, useState } from "react";
 import styles from "./MarkdownAttachments.module.css";
@@ -129,46 +128,45 @@ export const MarkdownAttachments: FC<Props> = (p) => {
 				</Tooltip.Portal>
 			</Tooltip.Root>
 
-			<AlertDialog.Root open={pending.length > 0} onOpenChange={(open) => open || setPending([])}>
-				<AlertDialog.Portal>
-					<AlertDialog.Backdrop />
-					<AlertDialog.Popup
-						className={classes(uiStyles.popup, uiStyles.dialogPopup, styles.popup)}
+			<Modal
+				alert
+				size="small"
+				className={styles.popup}
+				open={pending.length > 0}
+				onOpenChange={(open) => open || setPending([])}
+			>
+				<Dialog.Title>
+					{pending.length === 1 ? "Upload this file?" : `Upload these ${pending.length} files?`}
+				</Dialog.Title>
+				<Dialog.Description className={styles.description}>
+					They are uploaded to gitbutler.com and anyone with the link can open them, which is what
+					lets the forge show them in your description.
+				</Dialog.Description>
+				<ul className={styles.files}>
+					{pending.map((file, index) => (
+						// Names repeat — two pasted images are both "pasted-image" —
+						// and the list is fixed while the dialog is open.
+						// oxlint-disable-next-line react/no-array-index-key
+						<li key={index}>{file.name}</li>
+					))}
+				</ul>
+				<div className={styles.actions}>
+					<button
+						className={getButtonClassName({ variant: "ghost" })}
+						onClick={() => setPending([])}
+						type="button"
 					>
-						<AlertDialog.Title>
-							{pending.length === 1 ? "Upload this file?" : `Upload these ${pending.length} files?`}
-						</AlertDialog.Title>
-						<AlertDialog.Description className={styles.description}>
-							They are uploaded to gitbutler.com and anyone with the link can open them, which is
-							what lets the forge show them in your description.
-						</AlertDialog.Description>
-						<ul className={styles.files}>
-							{pending.map((file, index) => (
-								// Names repeat — two pasted images are both "pasted-image" —
-								// and the list is fixed while the dialog is open.
-								// oxlint-disable-next-line react/no-array-index-key
-								<li key={index}>{file.name}</li>
-							))}
-						</ul>
-						<div className={styles.actions}>
-							<button
-								className={getButtonClassName({ variant: "ghost" })}
-								onClick={() => setPending([])}
-								type="button"
-							>
-								Cancel
-							</button>
-							<button
-								className={getButtonClassName({ variant: "pop" })}
-								onClick={confirm}
-								type="button"
-							>
-								Yes, upload
-							</button>
-						</div>
-					</AlertDialog.Popup>
-				</AlertDialog.Portal>
-			</AlertDialog.Root>
+						Cancel
+					</button>
+					<button
+						className={getButtonClassName({ variant: "pop" })}
+						onClick={confirm}
+						type="button"
+					>
+						Yes, upload
+					</button>
+				</div>
+			</Modal>
 		</>
 	);
 };

--- a/apps/lite/ui/src/components/Modal.stories.tsx
+++ b/apps/lite/ui/src/components/Modal.stories.tsx
@@ -1,0 +1,109 @@
+import preview from "#storybook/preview";
+import { getButtonClassName } from "#ui/components/Button.tsx";
+import { Modal, PopupItem, PopupSearch, PopupSection } from "./Popup.tsx";
+
+const meta = preview.meta({
+	component: Modal,
+	parameters: {
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/EBuHQGUcCaSw4Ln5uVpWkn/Lite?node-id=4518-292100",
+		},
+	},
+	args: {
+		size: "small",
+		align: "center",
+		alert: false,
+		trigger: (
+			<button type="button" className={getButtonClassName({})}>
+				Open modal
+			</button>
+		),
+	},
+	argTypes: {
+		size: { control: "inline-radio", options: ["small", "medium", "large"] },
+		align: { control: "inline-radio", options: ["center", "top"] },
+		alert: { control: "boolean" },
+	},
+	decorators: [
+		(Story) => (
+			<div style={{ display: "flex", justifyContent: "center", padding: "48px" }}>
+				<Story />
+			</div>
+		),
+	],
+});
+
+export const Playground = meta.story({
+	args: {
+		"aria-label": "Modal playground",
+		children: (
+			<div style={{ display: "flex", flexDirection: "column", gap: 12, padding: 16 }}>
+				<strong className="text-15 text-semibold">Git credentials required</strong>
+				<span className="text-13">
+					An alert modal takes the `alertdialog` role and refuses Escape and backdrop clicks — the
+					question has to be answered rather than dismissed.
+				</span>
+				<div style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}>
+					<button type="button" className={getButtonClassName({ variant: "ghost" })}>
+						Cancel
+					</button>
+					<button type="button" className={getButtonClassName({ variant: "pop" })}>
+						Continue
+					</button>
+				</div>
+			</div>
+		),
+	},
+});
+
+/** A picker: top-aligned so its list grows downward, and filled with the popup's own parts. */
+export const Picker = meta.story({
+	args: {
+		size: "small",
+		align: "top",
+		"aria-label": "Select project",
+		trigger: (
+			<button type="button" className={getButtonClassName({})}>
+				Select project
+			</button>
+		),
+		children: (
+			<>
+				<PopupSearch placeholder="Search projects..." aria-label="Search projects" />
+				<PopupSection label="Recent projects">
+					<PopupItem icon="folder-tree" trailing="tick">
+						rocketFlasher
+					</PopupItem>
+					<PopupItem icon="lock">Fliege-mono</PopupItem>
+					<PopupItem icon="folder-tree">brutalism</PopupItem>
+				</PopupSection>
+				<PopupSection>
+					<PopupItem trailing="plus">Add local repository</PopupItem>
+					<PopupItem trailing="copy">Clone repository</PopupItem>
+				</PopupSection>
+			</>
+		),
+	},
+});
+
+/** The settings-sized pane: the modal supplies the chrome, the caller lays out everything inside. */
+export const Large = meta.story({
+	args: {
+		size: "large",
+		"aria-label": "Resolve conflicts",
+		trigger: (
+			<button type="button" className={getButtonClassName({})}>
+				Resolve conflicts
+			</button>
+		),
+		children: (
+			<div style={{ height: 400, padding: 16 }}>
+				<span className="text-13">
+					A pane this size lays out its own header, body and sidebar. The modal only carries the
+					surface, the backdrop and the placement.
+				</span>
+			</div>
+		),
+	},
+});

--- a/apps/lite/ui/src/components/PickerDialog.module.css
+++ b/apps/lite/ui/src/components/PickerDialog.module.css
@@ -1,90 +1,5 @@
-.backdrop {
-	position: fixed;
-	inset: 0;
-	background-color: var(--bg-overlay);
-	opacity: --light-dark(1, 0.7);
-	transition: opacity 150ms cubic-bezier(0.45, 1.005, 0, 1.005);
-
-	&[data-starting-style],
-	&[data-ending-style] {
-		opacity: 0;
-	}
-}
-
-.viewport {
-	display: flex;
-	position: fixed;
-	align-items: flex-start;
-	justify-content: center;
-	inset: 0;
-	padding: 4.5rem 0.5rem 0.5rem;
-	overflow: hidden;
-}
-
 .popup {
-	--popup-bg: light-dark(white, oklch(20% 0.5% 264deg));
-
-	/* The list scroller spans the whole popup, so the gutter takes the popup's
-	   own background and there is no content beside it to divide from. */
-	--scrollbar-track-bg: var(--popup-bg);
-	--scrollbar-track-border: transparent;
-
-	box-sizing: border-box;
-	display: flex;
-	position: relative;
-	flex-direction: column;
-	width: calc(100vw - 1rem);
-	max-width: 28rem;
 	max-height: min(36rem, calc(100dvh - 5rem));
-	overflow: hidden;
-	border-radius: 1rem;
-
-	outline: 1px solid light-dark(rgb(0 0 0 / 0.04), rgb(255 255 255 / 0.25));
-	background-color: var(--popup-bg);
-	box-shadow:
-		0 0.5px 1px rgb(0 0 0 / 0.12),
-		0 1px 3px -1px rgb(0 0 0 / 0.04),
-		0 2px 4px -1px rgb(0 0 0 / 0.04),
-		0 4px 8px -2px rgb(0 0 0 / 0.04),
-		0 12px 14px -4px rgb(0 0 0 / 0.04),
-		0 24px 64px -8px rgb(0 0 0 / 0.04),
-		0 40px 48px -32px rgb(0 0 0 / 0.04);
-	color: var(--color-text-1);
-	transition:
-		transform 150ms,
-		opacity 150ms;
-
-	&[data-starting-style],
-	&[data-ending-style] {
-		transform: translateY(-1rem) scale(0.95);
-		opacity: 0;
-	}
-}
-
-.input {
-	box-sizing: border-box;
-	width: 100%;
-	height: auto;
-	margin: 0;
-	padding: 1rem;
-	border: none;
-	border-bottom: 1px solid var(--border-2);
-	border-radius: 0;
-	outline: none;
-	background-color: transparent;
-	color: var(--text-1);
-	font-size: 1rem;
-	font-family: inherit;
-	letter-spacing: 0.016em;
-
-	&::placeholder {
-		color: var(--text-3);
-		font-weight: 400;
-	}
-
-	&:focus {
-		outline: none;
-	}
 }
 
 .listArea {
@@ -94,7 +9,7 @@
 	scroll-padding-block: 0.25rem;
 
 	&:focus-visible {
-		outline: 1px solid var(--color-blue);
+		outline: var(--focus-ring);
 		outline-offset: -1px;
 	}
 }
@@ -116,37 +31,36 @@
 	position: relative;
 }
 
+/* The same heading a `PopupSection` gives its rows; the virtualizer renders it as a row of its
+   own, so it carries its own box rather than wrapping what it names. */
 .groupLabel {
 	display: flex;
 	align-items: center;
-	min-height: 2rem;
-	padding: 0 0.875rem;
+	min-height: 23px;
+	padding: 8px 10px 0;
 	outline: 0;
-	color: var(--color-gray-600);
-	font-weight: 400;
-	font-size: 0.9375rem;
+	color: var(--text-2);
+	font-size: 12px;
 	line-height: 1;
-	letter-spacing: 0.00625em;
 	cursor: default;
 	user-select: none;
 }
 
+/* A `PopupItem`'s metrics, laid out as a grid because the type sits at the far end of the row. */
 .item {
 	box-sizing: border-box;
 	display: grid;
 	grid-template-columns: minmax(0, 1fr) auto;
 	align-items: center;
-	min-height: 2rem;
-	padding: 0 0.75rem 0 2.25rem;
-	gap: 0.5rem;
-	border-radius: 0.375rem;
+	min-height: 28px;
+	margin-inline: 4px;
+	padding-inline: 8px;
+	gap: 8px;
+	border-radius: var(--radius-button);
 	outline: 0;
-	font-weight: 400;
-	font-size: 0.9375rem;
-	line-height: 1.25;
-	letter-spacing: 0.016em;
+	font-size: 13px;
 	cursor: default;
-	scroll-margin-block: 0.25rem;
+	scroll-margin-block: 4px;
 	user-select: none;
 
 	&[data-highlighted] {
@@ -157,15 +71,13 @@
 .itemLabel {
 	min-width: 0;
 	overflow: hidden;
-	font-weight: 400;
 	text-overflow: ellipsis;
 	white-space: nowrap;
 }
 
 .itemType {
 	color: var(--text-3);
-	font-size: 0.875rem;
-	letter-spacing: 0.00625em;
+	font-size: 12px;
 	white-space: nowrap;
 }
 
@@ -176,9 +88,8 @@
 	justify-content: center;
 	min-height: 8rem;
 	padding: 1rem;
-	color: var(--color-gray-600);
-	font-size: 0.925rem;
-	line-height: 1rem;
+	color: var(--text-2);
+	font-size: 13px;
 }
 
 .footer {
@@ -186,11 +97,10 @@
 	align-items: center;
 	justify-content: space-between;
 	padding: 0.625rem 0.75rem;
-	border-top: 1px solid var(--border-section);
-	border-radius: 0 0 1rem 1rem;
+	border-top: 1px solid var(--border-3);
 	background-color: var(--bg-2);
 	color: var(--text-2);
-	font-size: 0.75rem;
+	font-size: 12px;
 }
 
 .footerLeft {

--- a/apps/lite/ui/src/components/PickerDialog.tsx
+++ b/apps/lite/ui/src/components/PickerDialog.tsx
@@ -3,6 +3,7 @@
  */
 
 import { Autocomplete, Dialog } from "@base-ui/react";
+import { Modal, PopupSearch } from "#ui/components/Popup.tsx";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import {
 	type CSSProperties,
@@ -97,7 +98,7 @@ const VirtualizedListArea = <T,>({
 		directDomUpdatesMode: "transform",
 		count: virtualRows.length,
 		getScrollElement: () => scrollElementRef.current,
-		estimateSize: () => 32,
+		estimateSize: () => 28,
 		getItemKey: getVirtualRowKey,
 		overscan: 4,
 		paddingStart: 8,
@@ -277,91 +278,96 @@ export const PickerDialog = <T,>({
 	const deferredInputValue = useDeferredValue(inputValue);
 
 	return (
-		<Dialog.Root open={open} onOpenChange={onOpenChange}>
-			<Dialog.Portal>
-				<Dialog.Backdrop className={styles.backdrop} />
-				<Dialog.Viewport className={styles.viewport}>
-					<Dialog.Popup className={styles.popup} aria-label={ariaLabel} initialFocus={inputRef}>
-						<Autocomplete.Root
-							items={items}
-							inline
-							open
-							value={deferredInputValue}
-							onValueChange={setInputValue}
-							virtualized
-							onItemHighlighted={(_, { reason, index }) => {
-								highlightedItemIndexRef.current = index < 0 ? null : index;
-								const virtualizer = virtualizerRef.current;
-								if (!virtualizer || index < 0) return;
+		<Modal
+			size="small"
+			align="top"
+			open={open}
+			onOpenChange={onOpenChange}
+			aria-label={ariaLabel}
+			initialFocus={inputRef}
+			className={styles.popup}
+		>
+			<Autocomplete.Root
+				items={items}
+				inline
+				open
+				value={deferredInputValue}
+				onValueChange={setInputValue}
+				virtualized
+				onItemHighlighted={(_, { reason, index }) => {
+					highlightedItemIndexRef.current = index < 0 ? null : index;
+					const virtualizer = virtualizerRef.current;
+					if (!virtualizer || index < 0) return;
 
-								const isStart = index === 0;
-								const isEnd = index === virtualizer.itemCount - 1;
-								const shouldScroll =
-									reason === "none" || (reason === "keyboard" && (isStart || isEnd));
-								if (shouldScroll) {
-									queueMicrotask(() => {
-										virtualizerRef.current?.scrollToItemIndex(index, {
-											align: isEnd ? "start" : "end",
-										});
-									});
+					const isStart = index === 0;
+					const isEnd = index === virtualizer.itemCount - 1;
+					const shouldScroll = reason === "none" || (reason === "keyboard" && (isStart || isEnd));
+					if (shouldScroll) {
+						queueMicrotask(() => {
+							virtualizerRef.current?.scrollToItemIndex(index, {
+								align: isEnd ? "start" : "end",
+							});
+						});
+					}
+				}}
+				autoHighlight="always"
+				keepHighlight
+				itemToStringValue={itemToStringValue ?? getItemLabel}
+			>
+				<PopupSearch
+					placeholder={placeholder}
+					aria-label={placeholder}
+					render={
+						// The key handling reaches for Base UI's own event extensions, so it belongs on
+						// the autocomplete's input rather than on the row that dresses it.
+						<Autocomplete.Input
+							ref={inputRef}
+							value={inputValue}
+							onKeyDown={(event) => {
+								const virtualizer = virtualizerRef.current;
+								if (!virtualizer) return;
+
+								if (event.metaKey && event.key === "ArrowUp") {
+									event.preventDefault();
+									event.preventBaseUIHandler();
+									virtualizer.highlightEdgeItem("start");
+								} else if (event.metaKey && event.key === "ArrowDown") {
+									event.preventDefault();
+									event.preventBaseUIHandler();
+									virtualizer.highlightEdgeItem("end");
+								} else if (event.key === "PageUp") {
+									event.preventDefault();
+									event.preventBaseUIHandler();
+									virtualizer.highlightPageItem(highlightedItemIndexRef.current, -1);
+								} else if (event.key === "PageDown") {
+									event.preventDefault();
+									event.preventBaseUIHandler();
+									virtualizer.highlightPageItem(highlightedItemIndexRef.current, 1);
 								}
 							}}
-							autoHighlight="always"
-							keepHighlight
-							itemToStringValue={itemToStringValue ?? getItemLabel}
-						>
-							<Autocomplete.Input
-								ref={inputRef}
-								value={inputValue}
-								onKeyDown={(event) => {
-									const virtualizer = virtualizerRef.current;
-									if (!virtualizer) return;
+						/>
+					}
+				/>
+				<Dialog.Close className={styles.visuallyHiddenClose}>{closeLabel}</Dialog.Close>
 
-									if (event.metaKey && event.key === "ArrowUp") {
-										event.preventDefault();
-										event.preventBaseUIHandler();
-										virtualizer.highlightEdgeItem("start");
-									} else if (event.metaKey && event.key === "ArrowDown") {
-										event.preventDefault();
-										event.preventBaseUIHandler();
-										virtualizer.highlightEdgeItem("end");
-									} else if (event.key === "PageUp") {
-										event.preventDefault();
-										event.preventBaseUIHandler();
-										virtualizer.highlightPageItem(highlightedItemIndexRef.current, -1);
-									} else if (event.key === "PageDown") {
-										event.preventDefault();
-										event.preventBaseUIHandler();
-										virtualizer.highlightPageItem(highlightedItemIndexRef.current, 1);
-									}
-								}}
-								className={styles.input}
-								placeholder={placeholder}
-								aria-label={placeholder}
-							/>
-							<Dialog.Close className={styles.visuallyHiddenClose}>{closeLabel}</Dialog.Close>
+				<VirtualizedListArea
+					emptyLabel={emptyLabel}
+					getItemKey={getItemKey}
+					getItemLabel={getItemLabel}
+					getItemType={getItemType}
+					onSelectItem={onSelectItem}
+					statusLabel={statusLabel}
+					virtualizerRef={virtualizerRef}
+				/>
 
-							<VirtualizedListArea
-								emptyLabel={emptyLabel}
-								getItemKey={getItemKey}
-								getItemLabel={getItemLabel}
-								getItemType={getItemType}
-								onSelectItem={onSelectItem}
-								statusLabel={statusLabel}
-								virtualizerRef={virtualizerRef}
-							/>
-
-							<div className={styles.footer}>
-								<div className={styles.footerLeft}>
-									<span>Activate</span>
-									<kbd className={styles.kbd}>Enter</kbd>
-								</div>
-								{footerAction}
-							</div>
-						</Autocomplete.Root>
-					</Dialog.Popup>
-				</Dialog.Viewport>
-			</Dialog.Portal>
-		</Dialog.Root>
+				<div className={styles.footer}>
+					<div className={styles.footerLeft}>
+						<span>Activate</span>
+						<kbd className={styles.kbd}>Enter</kbd>
+					</div>
+					{footerAction}
+				</div>
+			</Autocomplete.Root>
+		</Modal>
 	);
 };

--- a/apps/lite/ui/src/components/Popup.module.css
+++ b/apps/lite/ui/src/components/Popup.module.css
@@ -33,7 +33,7 @@
 	position: fixed;
 	inset: 0;
 	background-color: var(--bg-overlay);
-	transition: opacity 150ms cubic-bezier(0.45, 1.005, 0, 1.005);
+	transition: opacity var(--transition-popup);
 
 	&[data-starting-style],
 	&[data-ending-style] {
@@ -67,9 +67,12 @@
 	max-width: 100%;
 	max-height: 100%;
 	transition:
-		transform 150ms cubic-bezier(0.45, 1.005, 0, 1.005),
-		opacity 150ms;
+		transform var(--transition-popup),
+		opacity var(--transition-popup);
 
+	/* Only reached when the caller keeps the modal mounted and toggles `open`. A caller that
+	   renders it already open — `{shown && <Picker open />}` — mounts past the starting state, and
+	   the modal appears without animating. */
 	&[data-starting-style],
 	&[data-ending-style] {
 		transform: translateY(-0.5rem) scale(0.97);
@@ -93,8 +96,8 @@
 .dropdown {
 	transform-origin: var(--transform-origin);
 	transition:
-		transform 150ms cubic-bezier(0.45, 1.005, 0, 1.005),
-		opacity 150ms;
+		transform var(--transition-popup),
+		opacity var(--transition-popup);
 
 	&[data-starting-style],
 	&[data-ending-style] {

--- a/apps/lite/ui/src/components/Popup.module.css
+++ b/apps/lite/ui/src/components/Popup.module.css
@@ -1,0 +1,199 @@
+/* The one surface every overlay in Lite wears — modals, dropdowns and the toolbox alike. A modal
+   adds a backdrop and centres itself in the window; a dropdown anchors to its trigger. Nothing
+   else about the container differs between them. */
+.popup {
+	/* A popup's scroller spans the whole popup, so the gutter takes the popup's own background and
+	   there is no content beside it to divide from. */
+	--scrollbar-track-bg: var(--bg-1);
+	--scrollbar-track-border: transparent;
+
+	display: flex;
+	flex-direction: column;
+	/* The border is the container's edge, so content clips to it rather than squaring off the
+	   corners it sits in. */
+	overflow: hidden;
+	border: 1px solid var(--border-2);
+	border-radius: var(--radius-popup);
+	background-color: var(--bg-1);
+	box-shadow: var(--shadow-lg);
+}
+
+.backdrop {
+	position: fixed;
+	inset: 0;
+	background-color: var(--bg-overlay);
+	transition: opacity 150ms cubic-bezier(0.45, 1.005, 0, 1.005);
+
+	&[data-starting-style],
+	&[data-ending-style] {
+		opacity: 0;
+	}
+}
+
+/* Holds the modal off the window edges at any size, and is what a modal's own height maxes out
+   against. */
+.viewport {
+	display: flex;
+	position: fixed;
+	justify-content: center;
+	inset: 0;
+	padding: 1rem;
+	overflow: hidden;
+}
+
+.viewportCenter {
+	align-items: center;
+}
+
+/* A picker opens under the pointer's resting height rather than dead centre, so the list grows
+   downward into the window the way a command palette does. */
+.viewportTop {
+	align-items: flex-start;
+	padding-top: 4.5rem;
+}
+
+.modal {
+	max-width: 100%;
+	max-height: 100%;
+	transition:
+		transform 150ms cubic-bezier(0.45, 1.005, 0, 1.005),
+		opacity 150ms;
+
+	&[data-starting-style],
+	&[data-ending-style] {
+		transform: translateY(-0.5rem) scale(0.97);
+		opacity: 0;
+	}
+}
+
+.sizeSmall {
+	width: 420px;
+}
+
+.sizeMedium {
+	width: 820px;
+}
+
+.sizeLarge {
+	width: 1100px;
+}
+
+/* Grows out of the corner it is anchored to, rather than from its own middle. */
+.dropdown {
+	transform-origin: var(--transform-origin);
+	transition:
+		transform 150ms cubic-bezier(0.45, 1.005, 0, 1.005),
+		opacity 150ms;
+
+	&[data-starting-style],
+	&[data-ending-style] {
+		transform: scale(0.96);
+		opacity: 0;
+	}
+}
+
+/* A full-bleed row at the popup's top edge: no border of its own, just the hairline dividing it
+   from the list it filters. */
+.search {
+	display: flex;
+	flex: none;
+	align-items: center;
+	height: 32px;
+	padding-inline: 10px;
+	gap: 8px;
+	border-bottom: 1px solid var(--border-3);
+}
+
+.searchInput {
+	flex: 1;
+	min-width: 0;
+	border: none;
+	background: none;
+	color: var(--text-1);
+
+	&::placeholder {
+		color: var(--text-3);
+	}
+
+	/* The popup is already the focus ring; a second one around a borderless input reads as
+	   clutter. */
+	&:focus {
+		outline: none;
+	}
+}
+
+.searchIcon {
+	flex: none;
+	color: var(--text-3);
+}
+
+.section {
+	display: flex;
+	flex: none;
+	flex-direction: column;
+}
+
+/* Sections divide from each other rather than closing themselves off, so the last one in a popup
+   never draws a line against the container's own edge. */
+.section + .section {
+	border-top: 1px solid var(--border-3);
+}
+
+.sectionLabel {
+	padding: 8px 10px 0;
+	color: var(--text-2);
+}
+
+.sectionItems {
+	display: flex;
+	flex-direction: column;
+	padding: 4px;
+}
+
+.item {
+	display: flex;
+	flex: none;
+	align-items: center;
+	width: 100%;
+	height: 28px;
+	padding-inline: 8px;
+	gap: 8px;
+	border: none;
+	border-radius: var(--radius-button);
+	background: none;
+	color: var(--text-1);
+	text-align: start;
+	cursor: default;
+
+	/* `data-highlighted` is what Base UI's list primitives set as the keyboard walks them, so
+	   pointer and keyboard land on the same tint. */
+	&:hover:not(:disabled, [data-disabled]),
+	&[data-highlighted] {
+		background-color: var(--list-item-hover-bg);
+	}
+
+	&:disabled,
+	&[data-disabled] {
+		cursor: not-allowed;
+		opacity: var(--opacity-disabled);
+	}
+}
+
+/* The label is what the row is about, so it takes the width and gives it back last. */
+.itemLabel {
+	flex: 1;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.itemIcon {
+	flex: none;
+	color: var(--text-2);
+}
+
+.itemKbd {
+	flex: none;
+	color: var(--text-3);
+}

--- a/apps/lite/ui/src/components/Popup.module.css
+++ b/apps/lite/ui/src/components/Popup.module.css
@@ -14,8 +14,19 @@
 	overflow: hidden;
 	border: 1px solid var(--border-2);
 	border-radius: var(--radius-popup);
+	/* A popup takes focus as it opens, and the browser would paint its own accent-coloured ring on
+	   a container no app rule covers. What is inside shows the focus instead. */
+	outline: none;
 	background-color: var(--bg-1);
 	box-shadow: var(--shadow-lg);
+}
+
+/* Recessed, so what sits on it reads as cards rather than sections — the arrangement a pane uses
+   once it holds more than one group of things. */
+.recessed {
+	--scrollbar-track-bg: var(--bg-2);
+
+	background-color: var(--bg-2);
 }
 
 .backdrop {

--- a/apps/lite/ui/src/components/Popup.stories.tsx
+++ b/apps/lite/ui/src/components/Popup.stories.tsx
@@ -1,0 +1,113 @@
+import preview from "#storybook/preview";
+import { Popup, PopupItem, PopupSearch, PopupSection } from "./Popup.tsx";
+
+const meta = preview.meta({
+	component: Popup,
+	parameters: {
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/EBuHQGUcCaSw4Ln5uVpWkn/Lite?node-id=4518-292100",
+		},
+	},
+	decorators: [
+		(Story) => (
+			<div style={{ display: "flex", justifyContent: "center", padding: "48px" }}>
+				<Story />
+			</div>
+		),
+	],
+});
+
+/** The bare container — what a modal, a dropdown and the toolbox all sit in. */
+export const Container = meta.story({
+	args: {
+		style: { width: 320, padding: 16 },
+		className: "text-13",
+		children:
+			"All modals, dropdowns and the toolbox use this same container. A modal adds a backdrop.",
+	},
+});
+
+/** Every combination of the row's slots, and the tint it takes from pointer or keyboard alike. */
+export const Items = meta.story({
+	args: { style: { width: 248 } },
+	render: (args) => (
+		<Popup {...args}>
+			<PopupSection label="Item variants">
+				<PopupItem>Bare label</PopupItem>
+				<PopupItem icon="plus">Leading glyph</PopupItem>
+				<PopupItem trailing="plus">Trailing glyph</PopupItem>
+				<PopupItem icon="folder-tree" trailing="tick">
+					Both
+				</PopupItem>
+			</PopupSection>
+			<PopupSection label="Shortcuts and submenus">
+				<PopupItem kbd="Mod+B">With a shortcut</PopupItem>
+				<PopupItem icon="branch" trailing="chevron-right">
+					Steps further in
+				</PopupItem>
+				<PopupItem icon="branch" kbd="Mod+B" trailing="chevron-right">
+					Both again
+				</PopupItem>
+			</PopupSection>
+			<PopupSection label="States">
+				<PopupItem data-highlighted>Highlighted</PopupItem>
+				<PopupItem disabled>Disabled</PopupItem>
+			</PopupSection>
+		</Popup>
+	),
+});
+
+/** The project selector, as drawn in the Figma file. */
+export const ProjectSelector = meta.story({
+	args: { style: { width: 256 } },
+	render: (args) => (
+		<Popup {...args}>
+			<PopupSearch placeholder="Search projects..." aria-label="Search projects" />
+			<PopupSection label="Recent projects">
+				<PopupItem icon="folder-tree" trailing="tick">
+					rocketFlasher
+				</PopupItem>
+				<PopupItem icon="lock">Fliege-mono</PopupItem>
+				<PopupItem icon="folder-tree">brutalism</PopupItem>
+			</PopupSection>
+			<PopupSection label="Older">
+				<PopupItem icon="folder-tree">but-dev</PopupItem>
+				<PopupItem icon="lock">clock-demo</PopupItem>
+				<PopupItem icon="folder-tree">blogerator</PopupItem>
+			</PopupSection>
+			<PopupSection>
+				<PopupItem trailing="plus">Add local repository</PopupItem>
+				<PopupItem trailing="copy">Clone repository</PopupItem>
+			</PopupSection>
+		</Popup>
+	),
+});
+
+/** The hotkeys palette: a search, grouped rows, and a body that scrolls under a capped height. */
+export const HotkeysPalette = meta.story({
+	args: { style: { width: 420, maxHeight: 360 } },
+	render: (args) => (
+		<Popup {...args}>
+			<PopupSearch placeholder="Search hotkeys..." aria-label="Search hotkeys" />
+			<div style={{ minHeight: 0, overflow: "auto" }}>
+				<PopupSection>
+					<PopupItem kbd="F">Toggle files</PopupItem>
+				</PopupSection>
+				<PopupSection label="Global">
+					<PopupItem kbd="Mod+Shift+P">Select project</PopupItem>
+					<PopupItem kbd="Mod+.">Toggle sidebar</PopupItem>
+				</PopupSection>
+				<PopupSection label="Operations log">
+					<PopupItem kbd="Mod+Z">Undo</PopupItem>
+					<PopupItem kbd="Mod+Shift+O">Show operations log</PopupItem>
+					<PopupItem kbd="Mod+Shift+Z">Redo</PopupItem>
+				</PopupSection>
+				<PopupSection label="Uncommitted changes">
+					<PopupItem kbd="Mod+Alt+Enter">Amend</PopupItem>
+					<PopupItem kbd="Mod+Enter">Commit</PopupItem>
+				</PopupSection>
+			</div>
+		</Popup>
+	),
+});

--- a/apps/lite/ui/src/components/Popup.tsx
+++ b/apps/lite/ui/src/components/Popup.tsx
@@ -1,0 +1,220 @@
+import { classes } from "#ui/components/classes.ts";
+import { Icon } from "#ui/components/Icon.tsx";
+import type { IconName } from "#ui/components/iconNames.ts";
+import { Kbd } from "#ui/components/Kbd.tsx";
+import styles from "./Popup.module.css";
+import { AlertDialog, Dialog, mergeProps, Popover, useRender } from "@base-ui/react";
+import type { HotkeySequence } from "@tanstack/react-hotkeys";
+import type { ComponentProps, FC, ReactElement, ReactNode } from "react";
+
+/**
+ * The container every overlay in Lite is built from: modals, dropdowns and the toolbox all wear
+ * this one surface. Use it directly only for something that floats without opening — a toolbox, a
+ * hover card. Anything that opens over the app wants {@link Modal} or {@link Dropdown}, which wrap
+ * this in the Base UI primitive carrying the focus and dismissal behaviour.
+ *
+ * @public
+ */
+export const Popup: FC<ComponentProps<"div">> = (props) => (
+	<div {...props} className={classes(props.className, styles.popup)} />
+);
+
+/**
+ * How wide a modal opens. The steps are the three widths the app already uses — a prompt, a
+ * settings-sized pane, and a working surface — rather than a free measurement per caller.
+ *
+ * @public
+ */
+export type ModalSize = "small" | "medium" | "large";
+
+const sizeClassName = (size: ModalSize): string | undefined =>
+	size === "small" ? styles.sizeSmall : size === "medium" ? styles.sizeMedium : styles.sizeLarge;
+
+/** @public */
+export type ModalProps = {
+	/** Omit to leave the modal uncontrolled and drive it from `trigger` alone. */
+	open?: boolean;
+	onOpenChange?: (open: boolean) => void;
+	/** Rendered as the modal's trigger. Omit for a modal opened from elsewhere in the app. */
+	trigger?: ReactElement;
+	/**
+	 * Takes the `alertdialog` role and refuses to close on Escape or a backdrop click: the question
+	 * has to be answered rather than dismissed. For credentials and destructive confirmations.
+	 *
+	 * @default false
+	 */
+	alert?: boolean;
+	/** @default "medium" */
+	size?: ModalSize;
+	/**
+	 * Where the modal sits in the window. A picker opens `top`, so its list grows downward the way a
+	 * command palette does; everything else centres.
+	 *
+	 * @default "center"
+	 */
+	align?: "center" | "top";
+} & ComponentProps<"div">;
+
+/**
+ * A popup that opens over the whole window, dimming what it covers. The backdrop is the only thing
+ * separating it from a {@link Dropdown} — the container beneath is the same.
+ *
+ * The modal owns its chrome and placement, not its insides: a confirmation stacks its own prompt
+ * and buttons, a picker fills itself with {@link PopupSearch} and {@link PopupSection}, and a pane
+ * as involved as settings lays itself out entirely.
+ *
+ * @public
+ */
+export const Modal: FC<ModalProps> = ({
+	open,
+	onOpenChange,
+	trigger,
+	alert = false,
+	size = "medium",
+	align = "center",
+	children,
+	...props
+}) => {
+	// AlertDialog re-exports Dialog's portal, backdrop, viewport and popup unchanged — only the root
+	// and the trigger carry the different role and dismissal behaviour.
+	const Root = alert ? AlertDialog.Root : Dialog.Root;
+	const Trigger = alert ? AlertDialog.Trigger : Dialog.Trigger;
+
+	return (
+		<Root open={open} onOpenChange={onOpenChange}>
+			{trigger !== undefined && <Trigger render={trigger} />}
+			<Dialog.Portal>
+				<Dialog.Backdrop className={styles.backdrop} />
+				<Dialog.Viewport
+					className={classes(
+						styles.viewport,
+						align === "top" ? styles.viewportTop : styles.viewportCenter,
+					)}
+				>
+					<Dialog.Popup
+						{...props}
+						className={classes(props.className, styles.popup, styles.modal, sizeClassName(size))}
+					>
+						{children}
+					</Dialog.Popup>
+				</Dialog.Viewport>
+			</Dialog.Portal>
+		</Root>
+	);
+};
+
+/** @public */
+export type DropdownProps = {
+	/** Omit to leave the dropdown uncontrolled and drive it from `trigger` alone. */
+	open?: boolean;
+	onOpenChange?: (open: boolean) => void;
+	/** Rendered as the dropdown's trigger, and what it anchors to. */
+	trigger: ReactElement;
+	/** @default "bottom" */
+	side?: "top" | "bottom" | "left" | "right";
+	/** @default "start" */
+	align?: "start" | "center" | "end";
+	/** @default 4 */
+	sideOffset?: number;
+} & ComponentProps<"div">;
+
+/**
+ * A popup anchored to the control that opened it, with nothing dimmed behind it. Wears the same
+ * container as {@link Modal}, minus the backdrop.
+ *
+ * This is for anchored *panels* — a notification list, a reaction picker, a filter. Menus in Lite
+ * are Electron's own, raised through `native-menu.ts`; a dropdown is not the place to rebuild one.
+ *
+ * @public
+ */
+export const Dropdown: FC<DropdownProps> = ({
+	open,
+	onOpenChange,
+	trigger,
+	side = "bottom",
+	align = "start",
+	sideOffset = 4,
+	children,
+	...props
+}) => (
+	<Popover.Root open={open} onOpenChange={onOpenChange}>
+		<Popover.Trigger render={trigger} />
+		<Popover.Portal>
+			<Popover.Positioner side={side} align={align} sideOffset={sideOffset}>
+				<Popover.Popup
+					{...props}
+					className={classes(props.className, styles.popup, styles.dropdown)}
+				>
+					{children}
+				</Popover.Popup>
+			</Popover.Positioner>
+		</Popover.Portal>
+	</Popover.Root>
+);
+
+/**
+ * The filter row a popup leads with. Full-bleed against the container's top edge, divided from the
+ * list below by a hairline rather than fenced off in a field of its own — the popup is already the
+ * box the query sits in.
+ *
+ * @public
+ */
+export const PopupSearch: FC<ComponentProps<"input">> = (props) => (
+	<div className={styles.search}>
+		<input {...props} className={classes(props.className, "text-13", styles.searchInput)} />
+		<Icon name="search" className={styles.searchIcon} />
+	</div>
+);
+
+/**
+ * A run of {@link PopupItem}s under an optional heading. Sections divide from one another, so a
+ * popup can group its rows without the last group drawing a line against the container's edge.
+ *
+ * @public
+ */
+export const PopupSection: FC<{ label?: ReactNode } & ComponentProps<"div">> = ({
+	label,
+	children,
+	...props
+}) => (
+	<div {...props} className={classes(props.className, styles.section)}>
+		{label !== undefined && <div className={classes("text-12", styles.sectionLabel)}>{label}</div>}
+		<div className={styles.sectionItems}>{children}</div>
+	</div>
+);
+
+/**
+ * One row of a popup: an optional glyph, the label, and — at the far end — a shortcut and a
+ * trailing glyph marking what the row is or where it leads.
+ *
+ * A button by default. Pass `render` to make it whatever a list primitive needs it to be, which is
+ * how a picker's rows become `Combobox.Item`s without restating the row's chrome.
+ *
+ * @public
+ */
+export const PopupItem: FC<
+	{
+		/** Leads the row — what kind of thing it is. */
+		icon?: IconName;
+		/** Closes the row — a tick for the current choice, a chevron for a step further in. */
+		trailing?: IconName;
+		/** The shortcut that does what the row does, sat before any trailing glyph. */
+		kbd?: string | HotkeySequence;
+		children: ReactNode;
+	} & useRender.ComponentProps<"button">
+> = ({ icon, trailing, kbd, children, render, ...props }) =>
+	useRender({
+		// oxlint-disable-next-line jsx_a11y/control-has-associated-label -- Labelled by its children.
+		render: render ?? <button type="button" />,
+		props: mergeProps<"button">(props, {
+			className: classes("text-13", styles.item),
+			children: (
+				<>
+					{icon !== undefined && <Icon name={icon} className={styles.itemIcon} />}
+					<span className={styles.itemLabel}>{children}</span>
+					{kbd !== undefined && <Kbd hotkey={kbd} className={styles.itemKbd} />}
+					{trailing !== undefined && <Icon name={trailing} className={styles.itemIcon} />}
+				</>
+			),
+		}),
+	});

--- a/apps/lite/ui/src/components/Popup.tsx
+++ b/apps/lite/ui/src/components/Popup.tsx
@@ -53,6 +53,15 @@ export type ModalProps = {
 	 * @default "center"
 	 */
 	align?: "center" | "top";
+	/**
+	 * Recesses the modal's own ground so the groups inside it read as cards sitting on it, rather
+	 * than as sections of one sheet. For a pane holding more than one group — settings, a resolver.
+	 *
+	 * @default false
+	 */
+	recessed?: boolean;
+	/** What takes focus as the modal opens, when the first tabbable element is not the right one. */
+	initialFocus?: ComponentProps<typeof Dialog.Popup>["initialFocus"];
 } & ComponentProps<"div">;
 
 /**
@@ -72,6 +81,8 @@ export const Modal: FC<ModalProps> = ({
 	alert = false,
 	size = "medium",
 	align = "center",
+	recessed = false,
+	initialFocus,
 	children,
 	...props
 }) => {
@@ -93,7 +104,14 @@ export const Modal: FC<ModalProps> = ({
 				>
 					<Dialog.Popup
 						{...props}
-						className={classes(props.className, styles.popup, styles.modal, sizeClassName(size))}
+						initialFocus={initialFocus}
+						className={classes(
+							props.className,
+							styles.popup,
+							styles.modal,
+							sizeClassName(size),
+							recessed && styles.recessed,
+						)}
 					>
 						{children}
 					</Dialog.Popup>
@@ -157,11 +175,19 @@ export const Dropdown: FC<DropdownProps> = ({
  * list below by a hairline rather than fenced off in a field of its own — the popup is already the
  * box the query sits in.
  *
+ * A plain input by default. Pass `render` when the query drives a list primitive and the input has
+ * to be that primitive's own — a picker's `Autocomplete.Input`, say.
+ *
  * @public
  */
-export const PopupSearch: FC<ComponentProps<"input">> = (props) => (
+export const PopupSearch: FC<useRender.ComponentProps<"input">> = ({ render, ...props }) => (
 	<div className={styles.search}>
-		<input {...props} className={classes(props.className, "text-13", styles.searchInput)} />
+		{useRender({
+			render: render ?? <input />,
+			props: mergeProps<"input">(props, {
+				className: classes("text-13", styles.searchInput),
+			}),
+		})}
 		<Icon name="search" className={styles.searchIcon} />
 	</div>
 );

--- a/apps/lite/ui/src/components/Toasts.tsx
+++ b/apps/lite/ui/src/components/Toasts.tsx
@@ -3,7 +3,7 @@ import type { FC } from "react";
 import { classes } from "#ui/components/classes.ts";
 import { getButtonClassName } from "#ui/components/Button.tsx";
 import styles from "./Toasts.module.css";
-import uiStyles from "#ui/components/ui.module.css";
+import popupStyles from "#ui/components/Popup.module.css";
 
 export const Toasts: FC = () => {
 	const { toasts } = Toast.useToastManager();
@@ -12,7 +12,11 @@ export const Toasts: FC = () => {
 		<Toast.Portal>
 			<Toast.Viewport className={styles.viewport}>
 				{toasts.map((toast) => (
-					<Toast.Root key={toast.id} toast={toast} className={classes(uiStyles.popup, styles.root)}>
+					<Toast.Root
+						key={toast.id}
+						toast={toast}
+						className={classes(popupStyles.popup, styles.root)}
+					>
 						<Toast.Content className={styles.content}>
 							<Toast.Title render={<strong />} className="text-15 text-semibold" />
 							<Toast.Description

--- a/apps/lite/ui/src/components/Toolbox.module.css
+++ b/apps/lite/ui/src/components/Toolbox.module.css
@@ -7,14 +7,9 @@
 	align-items: stretch;
 }
 
+/* Chrome comes from the shared popup container; only what makes this one a toolbox lives here. */
 .toolbox {
-	display: flex;
-	flex-direction: column;
-	overflow: hidden;
-	border: 1px solid var(--border-2);
-	border-radius: var(--radius-popup);
-	background-color: var(--bg-1);
-	box-shadow: var(--shadow-md);
+	flex: none;
 }
 
 .meta {

--- a/apps/lite/ui/src/components/Toolbox.module.css
+++ b/apps/lite/ui/src/components/Toolbox.module.css
@@ -12,8 +12,7 @@
 	flex-direction: column;
 	overflow: hidden;
 	border: 1px solid var(--border-2);
-	/* The design names `--radius-m`; the token set spells that size `--radius-lg`. */
-	border-radius: var(--radius-lg);
+	border-radius: var(--radius-popup);
 	background-color: var(--bg-1);
 	box-shadow: var(--shadow-md);
 }

--- a/apps/lite/ui/src/components/Toolbox.module.css
+++ b/apps/lite/ui/src/components/Toolbox.module.css
@@ -10,6 +10,18 @@
 /* Chrome comes from the shared popup container; only what makes this one a toolbox lives here. */
 .toolbox {
 	flex: none;
+	transition:
+		transform var(--transition-popup),
+		opacity var(--transition-popup);
+
+	/* A modal and a dropdown animate against the states Base UI stamps on them as it opens and
+	   closes one. Nothing manages this bar's lifecycle — it is rendered while a selection exists
+	   and unmounted when it stops — so its entrance is the browser's own first-style transition
+	   instead. It rises, because it stands at the bottom of the window. */
+	@starting-style {
+		transform: translateY(0.5rem);
+		opacity: 0;
+	}
 }
 
 .meta {

--- a/apps/lite/ui/src/components/Toolbox.tsx
+++ b/apps/lite/ui/src/components/Toolbox.tsx
@@ -1,6 +1,7 @@
 import { classes } from "#ui/components/classes.ts";
 import { Icon } from "./Icon.tsx";
 import type { IconName } from "./iconNames.ts";
+import { Popup } from "#ui/components/Popup.tsx";
 import styles from "./Toolbox.module.css";
 import type { ComponentProps, FC, ReactNode } from "react";
 
@@ -23,7 +24,7 @@ export const ToolboxStack: FC<ComponentProps<"div">> = (props) => (
  * @public
  */
 export const Toolbox: FC<ComponentProps<"div">> = (props) => (
-	<div {...props} className={classes(props.className, styles.toolbox)} />
+	<Popup {...props} className={classes(props.className, styles.toolbox)} />
 );
 
 /**

--- a/apps/lite/ui/src/components/icons/folder-lock.svg
+++ b/apps/lite/ui/src/components/icons/folder-lock.svg
@@ -1,0 +1,8 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M14 6.50001L14 5.3829H7.45454L6.1958 3.00001H1.99999L1.99999 13H6.50001" stroke="#1C1917"
+    stroke-width="1.5" />
+  <path d="M9.00001 11.5H15V14.5H9.00001V11.5Z" fill="#D9D9D9" stroke="#1C1917" stroke-width="1.5" />
+  <path
+    d="M14 11V10.4049C14 9.30033 13.1046 8.4049 12 8.4049C10.8954 8.4049 10 9.30033 10 10.4049V11"
+    stroke="#1C1917" stroke-width="1.5" />
+</svg>

--- a/apps/lite/ui/src/components/icons/folder.svg
+++ b/apps/lite/ui/src/components/icons/folder.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M14 13H1.99998V3.00001H6.19579L7.45453 5.3829H14V13Z" stroke="#1C1917" stroke-width="1.5" />
+</svg>

--- a/apps/lite/ui/src/components/ui.module.css
+++ b/apps/lite/ui/src/components/ui.module.css
@@ -1,26 +1,3 @@
-.popup {
-	/* A popup's scroller spans the whole popup, so the gutter takes the popup's
-	   own background and there is no content beside it to divide from. */
-	--scrollbar-track-bg: var(--bg-1);
-	--scrollbar-track-border: transparent;
-
-	border-radius: 8px;
-	outline: 1px solid light-dark(rgb(0 0 0 / 0.2), rgb(255 255 255 / 0.16));
-	background-color: var(--bg-1);
-	box-shadow: 0 12px 16px -8px light-dark(rgb(0 0 0 / 0.08), rgb(0 0 0 / 0.4));
-}
-
-.dialogPopup {
-	display: flex;
-	position: fixed;
-	top: 50%;
-	left: 50%;
-	row-gap: 12px;
-	flex-direction: column;
-	padding: 16px;
-	transform: translate(-50%, -50%);
-}
-
 /* Utility class for a pane's scroll container: it scrolls within the flex
    layout that holds it rather than growing it, and keeps its scrolling to
    itself. The scrollbar it shows is the app's, styled globally. */

--- a/apps/lite/ui/src/global.css
+++ b/apps/lite/ui/src/global.css
@@ -16,6 +16,9 @@
 	--list-item-hover-bg: color-mix(var(--fill-gray-bg) var(--opacity-bg-hover), transparent);
 	--focus-ring: 1.5px solid color-mix(in srgb, var(--fill-gray-bg) 70%, transparent);
 	--transition-fast: 0.08s ease;
+	/* How anything that opens over the app arrives: modals, dropdowns and the backdrop behind
+	   them, which are rendered as siblings and so cannot inherit it from one another. */
+	--transition-popup: 150ms cubic-bezier(0.45, 1.005, 0, 1.005);
 	--panel-padding-block: 12px;
 	--panel-padding-inline: 12px;
 

--- a/apps/lite/ui/src/review-inbox-bell.module.css
+++ b/apps/lite/ui/src/review-inbox-bell.module.css
@@ -22,18 +22,8 @@
 }
 
 .panel {
-	display: flex;
-	flex-direction: column;
 	width: 380px;
 	max-height: min(60vh, 560px);
-	overflow: hidden;
-	border: 1px solid var(--border-2);
-	border-radius: 8px;
-	/* The popup takes focus on open; the browser would paint its own
-	   accent-colored ring on a div no app rule covers. */
-	outline: none;
-	background-color: var(--bg-1);
-	box-shadow: 0 8px 24px rgb(0 0 0 / 15%);
 }
 
 .panelHeader {

--- a/apps/lite/ui/src/review-inbox-bell.tsx
+++ b/apps/lite/ui/src/review-inbox-bell.tsx
@@ -27,7 +27,7 @@ import { usePrNotificationsLevel } from "#ui/review-seen.ts";
 import { store } from "#ui/store.ts";
 import { requestReviewFocus } from "#ui/review-focus.ts";
 import { setActiveList, setCursor, setPage } from "#ui/use-cursor.ts";
-import { Popover } from "@base-ui/react";
+import { Dropdown } from "#ui/components/Popup.tsx";
 import { useQuery } from "@tanstack/react-query";
 import { useState, type FC } from "react";
 import styles from "./review-inbox-bell.module.css";
@@ -154,47 +154,49 @@ export const NotificationBell: FC<{ projectId: string }> = ({ projectId }) => {
 	if (!shown) return null;
 
 	return (
-		<Popover.Root open={open} onOpenChange={setOpen}>
-			<Popover.Trigger
-				aria-label={unseen > 0 ? `Notifications, ${unseen} unread` : "Notifications"}
-				className={classes(getButtonClassName({ iconOnly: true, variant: "ghost" }), styles.bell)}
-			>
-				<Icon name="bell" />
-				{unseen > 0 && <span aria-hidden className={styles.bellDot} />}
-			</Popover.Trigger>
-			<Popover.Portal>
-				<Popover.Positioner align="start" sideOffset={6}>
-					<Popover.Popup className={styles.panel}>
-						<div className={styles.panelHeader}>
-							<span className={classes("text-12", "text-semibold")}>Notifications</span>
-							{unseen > 0 && (
-								<button
-									className={classes("text-12", styles.markAll)}
-									onClick={() => markInboxSeen(projectId)}
-									type="button"
-								>
-									Mark all read
-								</button>
-							)}
-						</div>
-						{entries.length === 0 ? (
-							<div className={classes("text-12", styles.empty)}>Nothing yet</div>
-						) : (
-							<div className={styles.list}>
-								{entries.map((entry) => (
-									<Entry
-										key={entry.id}
-										projectId={projectId}
-										entry={entry}
-										appliedRefs={appliedRefs}
-										onNavigate={() => setOpen(false)}
-									/>
-								))}
-							</div>
-						)}
-					</Popover.Popup>
-				</Popover.Positioner>
-			</Popover.Portal>
-		</Popover.Root>
+		<Dropdown
+			open={open}
+			onOpenChange={setOpen}
+			sideOffset={6}
+			className={styles.panel}
+			trigger={
+				<button
+					type="button"
+					aria-label={unseen > 0 ? `Notifications, ${unseen} unread` : "Notifications"}
+					className={classes(getButtonClassName({ iconOnly: true, variant: "ghost" }), styles.bell)}
+				>
+					<Icon name="bell" />
+					{unseen > 0 && <span aria-hidden className={styles.bellDot} />}
+				</button>
+			}
+		>
+			<div className={styles.panelHeader}>
+				<span className={classes("text-12", "text-semibold")}>Notifications</span>
+				{unseen > 0 && (
+					<button
+						className={classes("text-12", styles.markAll)}
+						onClick={() => markInboxSeen(projectId)}
+						type="button"
+					>
+						Mark all read
+					</button>
+				)}
+			</div>
+			{entries.length === 0 ? (
+				<div className={classes("text-12", styles.empty)}>Nothing yet</div>
+			) : (
+				<div className={styles.list}>
+					{entries.map((entry) => (
+						<Entry
+							key={entry.id}
+							projectId={projectId}
+							entry={entry}
+							appliedRefs={appliedRefs}
+							onNavigate={() => setOpen(false)}
+						/>
+					))}
+				</div>
+			)}
+		</Dropdown>
 	);
 };

--- a/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.module.css
@@ -146,46 +146,24 @@
 }
 
 .targetPopup {
-	display: flex;
-	flex-direction: column;
 	width: max(var(--anchor-width), 200px);
 }
 
-.targetInput {
-	padding-inline: 10px;
-	padding-block: 4px;
-	border-bottom: 1px solid var(--border-2);
-
-	&:focus {
-		outline: none;
-	}
-}
-
+/* The list is the scroller, so its inset sits inside the scrolled area and the scrollbar keeps
+   the container's own edge. */
 .targetList {
-	--approx-input-height: 50px;
-	max-height: min(300px, calc(var(--available-height) - var(--approx-input-height)));
+	--search-row-height: 32px;
+
+	max-height: min(300px, calc(var(--available-height) - var(--search-row-height)));
 	overflow: auto;
 
 	&:not(:empty) {
-		padding-block: 4px;
-	}
-}
-
-.targetItem {
-	padding-inline: 10px;
-	padding-block: 4px;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-	cursor: default;
-
-	&[data-highlighted] {
-		background-color: var(--bg-2);
+		padding: 4px;
 	}
 }
 
 .targetEmpty {
 	padding-inline: 10px;
-	padding-block: 4px;
-	color: var(--color-text-secondary);
+	padding-block: 8px;
+	color: var(--text-2);
 }

--- a/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
@@ -52,7 +52,9 @@ export type CommitTargetComboboxItem = {
 const CommitTargetComboboxPopup: FC<{ current: CommitTargetComboboxItem | null }> = ({
 	current,
 }) => (
-	<Combobox.Popup className={classes(popupStyles.popup, styles.targetPopup)}>
+	// Base UI's combobox owns its own popup part, so this cannot go through `Dropdown` — it wears
+	// the anchored-popup classes directly to open the way every other dropdown does.
+	<Combobox.Popup className={classes(popupStyles.popup, popupStyles.dropdown, styles.targetPopup)}>
 		<PopupSearch
 			aria-label="Search targets"
 			placeholder="Search targets..."

--- a/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
@@ -1,4 +1,4 @@
-import uiStyles from "#ui/components/ui.module.css";
+import popupStyles from "#ui/components/Popup.module.css";
 import { setCursor } from "#ui/use-cursor.ts";
 import { useBranchCreate, useCommitCreate, useGenerateCommitMessage } from "#ui/api/mutations.ts";
 import {
@@ -49,7 +49,7 @@ export type CommitTargetComboboxItem = {
 };
 
 const CommitTargetComboboxPopup: FC = () => (
-	<Combobox.Popup className={classes(uiStyles.popup, "text-13", styles.targetPopup)}>
+	<Combobox.Popup className={classes(popupStyles.popup, "text-13", styles.targetPopup)}>
 		<Combobox.Input
 			aria-label="Search targets"
 			placeholder="Search targets..."

--- a/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
@@ -1,4 +1,5 @@
 import popupStyles from "#ui/components/Popup.module.css";
+import { PopupItem, PopupSearch } from "#ui/components/Popup.tsx";
 import { setCursor } from "#ui/use-cursor.ts";
 import { useBranchCreate, useCommitCreate, useGenerateCommitMessage } from "#ui/api/mutations.ts";
 import {
@@ -48,25 +49,34 @@ export type CommitTargetComboboxItem = {
 	relativeTo: RelativeTo;
 };
 
-const CommitTargetComboboxPopup: FC = () => (
-	<Combobox.Popup className={classes(popupStyles.popup, "text-13", styles.targetPopup)}>
-		<Combobox.Input
+const CommitTargetComboboxPopup: FC<{ current: CommitTargetComboboxItem | null }> = ({
+	current,
+}) => (
+	<Combobox.Popup className={classes(popupStyles.popup, styles.targetPopup)}>
+		<PopupSearch
 			aria-label="Search targets"
 			placeholder="Search targets..."
-			className={styles.targetInput}
+			render={<Combobox.Input />}
 		/>
 		<Combobox.Empty>
-			<div className={styles.targetEmpty}>No targets found.</div>
+			<div className={classes("text-13", styles.targetEmpty)}>No targets found.</div>
 		</Combobox.Empty>
 		<Combobox.List className={styles.targetList}>
 			{(item: CommitTargetComboboxItem) => (
-				<Combobox.Item
+				<PopupItem
 					key={addressIdentityKey(item.address)}
-					value={item}
-					className={styles.targetItem}
+					icon={item.address._tag === "Commit" ? "commit" : "branch"}
+					// The bullseye marks where a commit would land, so it rides only the row that is
+					// the target now — the rest of the list is where it could go instead.
+					trailing={
+						current !== null && addressEquals(item.address, current.address)
+							? "bullseye"
+							: undefined
+					}
+					render={<Combobox.Item value={item} />}
 				>
 					{item.label}
-				</Combobox.Item>
+				</PopupItem>
 			)}
 		</Combobox.List>
 	</Combobox.Popup>
@@ -102,7 +112,7 @@ const CommitTargetCombobox: FC<{
 		{children}
 		<Combobox.Portal>
 			<Combobox.Positioner align="start" sideOffset={4}>
-				<CommitTargetComboboxPopup />
+				<CommitTargetComboboxPopup current={value} />
 			</Combobox.Positioner>
 		</Combobox.Portal>
 	</Combobox.Root>

--- a/apps/lite/ui/src/routes/project/$id/workspace/ConflictBar.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/ConflictBar.module.css
@@ -36,42 +36,11 @@
 	gap: 8px;
 }
 
-.backdrop {
-	position: fixed;
-	inset: 0;
-	background-color: var(--bg-overlay);
-}
-
-.viewport {
-	display: flex;
-	position: fixed;
-	inset: 0;
-	/* Keeps a clear band of backdrop around the popup at any size, and is
-	   what the popup's resize maxes out against. */
-	padding: 3rem;
-}
-
 .popup {
-	display: flex;
-	flex-direction: column;
-	width: min(1100px, 100%);
 	/* The minimums yield to narrow or tiled windows rather than overflow them. */
 	min-width: min(520px, 100%);
-	max-width: 100%;
 	height: min(80vh, 1200px);
 	min-height: min(360px, 100%);
-	max-height: 100%;
-	margin: auto;
-	overflow: hidden;
-	border: 1px solid var(--border-2);
-	border-radius: var(--radius-lg);
-	background-color: var(--bg-2);
-	box-shadow:
-		0 0.5px 1px rgb(0 0 0 / 0.12),
-		0 1px 3px -1px rgb(0 0 0 / 0.04),
-		0 2px 4px -1px rgb(0 0 0 / 0.04),
-		0 4px 8px -2px rgb(0 0 0 / 0.04),
-		0 12px 14px -4px rgb(0 0 0 / 0.04);
 	/* Native grip in the bottom-right corner; the viewport padding bounds it. */
 	resize: both;
 }

--- a/apps/lite/ui/src/routes/project/$id/workspace/ConflictBar.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/ConflictBar.tsx
@@ -6,6 +6,7 @@ import { Icon } from "#ui/components/Icon.tsx";
 import { projectSlice } from "#ui/projects/state.ts";
 import { useAppDispatch, useAppSelector } from "#ui/store.ts";
 import { Dialog } from "@base-ui/react";
+import { Modal } from "#ui/components/Popup.tsx";
 import { useQuery } from "@tanstack/react-query";
 import type { FC } from "react";
 import styles from "./ConflictBar.module.css";
@@ -117,87 +118,86 @@ export const ConflictBar: FC<Props> = (p) => {
 			</button>
 
 			{total > 0 && (
-				<Dialog.Root>
-					<Dialog.Trigger
-						className={classes(
-							getButtonClassName({ variant: "outline", size: "small" }),
-							styles.resolve,
+				<Modal
+					size="large"
+					recessed
+					aria-labelledby="resolve-conflicts-heading"
+					className={styles.popup}
+					trigger={
+						<button
+							type="button"
+							className={classes(
+								getButtonClassName({ variant: "outline", size: "small" }),
+								styles.resolve,
+							)}
+						>
+							Resolve conflicts
+						</button>
+					}
+				>
+					<header className={styles.header}>
+						<Icon name="warning" />
+						<h1
+							id="resolve-conflicts-heading"
+							className={classes("text-14", "text-bold", styles.heading)}
+						>
+							{checkedLive.length > 0
+								? `${checkedLive.length} of ${total} conflict${total === 1 ? "" : "s"} selected`
+								: `Resolve ${total} conflict${total === 1 ? "" : "s"}`}
+						</h1>
+
+						{checkedLive.length > 0 && (
+							<div className={styles.actions}>
+								<button
+									type="button"
+									className={getButtonClassName({ variant: "outline", size: "small" })}
+									disabled={p.busy}
+									onClick={() => apply({ type: "theirs" })}
+								>
+									Accept incoming
+								</button>
+								<button
+									type="button"
+									className={getButtonClassName({ variant: "outline", size: "small" })}
+									disabled={p.busy}
+									onClick={() => apply({ type: "ours" })}
+								>
+									Accept current
+								</button>
+								<button
+									type="button"
+									className={getButtonClassName({ variant: "ghost", size: "small" })}
+									onClick={() =>
+										dispatch(projectSlice.actions.clearCheckedConflicts({ projectId: p.projectId }))
+									}
+								>
+									Clear
+								</button>
+							</div>
 						)}
-					>
-						Resolve conflicts
-					</Dialog.Trigger>
-					<Dialog.Portal>
-						<Dialog.Backdrop className={styles.backdrop} />
-						<Dialog.Viewport className={styles.viewport}>
-							<Dialog.Popup aria-labelledby="resolve-conflicts-heading" className={styles.popup}>
-								<header className={styles.header}>
-									<Icon name="warning" />
-									<h1
-										id="resolve-conflicts-heading"
-										className={classes("text-14", "text-bold", styles.heading)}
-									>
-										{checkedLive.length > 0
-											? `${checkedLive.length} of ${total} conflict${total === 1 ? "" : "s"} selected`
-											: `Resolve ${total} conflict${total === 1 ? "" : "s"}`}
-									</h1>
 
-									{checkedLive.length > 0 && (
-										<div className={styles.actions}>
-											<button
-												type="button"
-												className={getButtonClassName({ variant: "outline", size: "small" })}
-												disabled={p.busy}
-												onClick={() => apply({ type: "theirs" })}
-											>
-												Accept incoming
-											</button>
-											<button
-												type="button"
-												className={getButtonClassName({ variant: "outline", size: "small" })}
-												disabled={p.busy}
-												onClick={() => apply({ type: "ours" })}
-											>
-												Accept current
-											</button>
-											<button
-												type="button"
-												className={getButtonClassName({ variant: "ghost", size: "small" })}
-												onClick={() =>
-													dispatch(
-														projectSlice.actions.clearCheckedConflicts({ projectId: p.projectId }),
-													)
-												}
-											>
-												Clear
-											</button>
-										</div>
-									)}
+						<Dialog.Close
+							aria-label="Close"
+							className={getButtonClassName({
+								variant: "ghost",
+								size: "small",
+								iconOnly: true,
+							})}
+						>
+							<Icon name="cross" />
+						</Dialog.Close>
+					</header>
 
-									<Dialog.Close
-										aria-label="Close"
-										className={getButtonClassName({
-											variant: "ghost",
-											size: "small",
-											iconOnly: true,
-										})}
-									>
-										<Icon name="cross" />
-									</Dialog.Close>
-								</header>
-
-								<div className={styles.body}>
-									<ConflictedFiles
-										projectId={p.projectId}
-										commitId={p.commitId}
-										conflicts={p.conflicts}
-										busy={p.busy}
-										onResolve={p.onResolve}
-									/>
-								</div>
-							</Dialog.Popup>
-						</Dialog.Viewport>
-					</Dialog.Portal>
-				</Dialog.Root>
+					<div className={styles.body}>
+						<ConflictedFiles
+							projectId={p.projectId}
+							commitId={p.commitId}
+							conflicts={p.conflicts}
+							busy={p.busy}
+							onResolve={p.onResolve}
+						/>
+					</div>
+				</Modal>
 			)}
 		</div>
 	);

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestReactions.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestReactions.module.css
@@ -33,25 +33,11 @@
 	}
 }
 
-/* Horizontal emoji row, with the same chrome as the tooltip popup. */
+/* A horizontal row rather than the popup's usual stack of rows. */
 .reactionPicker {
-	display: flex;
+	flex-direction: row;
 	padding: 4px;
 	gap: 2px;
-	/* Grow out of the anchored corner, same curve as the picker dialog. */
-	transform-origin: var(--transform-origin);
-	border-radius: var(--radius-button);
-	background-color: var(--bg-1);
-	box-shadow: var(--shadow-tooltip);
-	transition:
-		transform 150ms cubic-bezier(0.45, 1.005, 0, 1.005),
-		opacity 150ms;
-
-	&[data-starting-style],
-	&[data-ending-style] {
-		transform: scale(0.9);
-		opacity: 0;
-	}
 }
 
 .pickerItem {

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestReactions.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestReactions.tsx
@@ -2,7 +2,8 @@ import { getButtonClassName } from "#ui/components/Button.tsx";
 import { classes } from "#ui/components/classes.ts";
 import { Icon } from "#ui/components/Icon.tsx";
 import { TooltipPopup } from "#ui/components/Tooltip.tsx";
-import { Popover, Tooltip } from "@base-ui/react";
+import { Tooltip } from "@base-ui/react";
+import { Dropdown } from "#ui/components/Popup.tsx";
 import type { ForgeReviewReaction, ForgeReviewReactionCount } from "@gitbutler/but-sdk";
 import { type FC, useState } from "react";
 import styles from "./PullRequestReactions.module.css";
@@ -140,46 +141,39 @@ export const Reactions: FC<{
 			})}
 
 			{onToggle !== undefined && (
-				<Popover.Root open={pickerOpen} onOpenChange={setPickerOpen}>
-					<Popover.Trigger
-						render={
+				<Dropdown
+					open={pickerOpen}
+					onOpenChange={setPickerOpen}
+					className={styles.reactionPicker}
+					trigger={
+						<button
+							aria-label="Add reaction"
+							className={getButtonClassName({ variant: "ghost", iconOnly: true })}
+							type="button"
+						>
+							<Icon name="smiley" />
+						</button>
+					}
+				>
+					{reactionGlyphs.map(([kind, glyph]) => {
+						const mine = mineFor(kind);
+						return (
 							<button
-								aria-label="Add reaction"
-								className={getButtonClassName({ variant: "ghost", iconOnly: true })}
+								key={kind}
+								aria-label={`React with ${reactionName(kind)}`}
+								aria-pressed={mine !== undefined}
+								className={classes(styles.pickerItem, mine !== undefined && styles.pickerItemMine)}
+								onClick={() => {
+									toggle(kind, mine);
+									setPickerOpen(false);
+								}}
 								type="button"
-							/>
-						}
-					>
-						<Icon name="smiley" />
-					</Popover.Trigger>
-					<Popover.Portal>
-						<Popover.Positioner align="start" sideOffset={4}>
-							<Popover.Popup className={styles.reactionPicker}>
-								{reactionGlyphs.map(([kind, glyph]) => {
-									const mine = mineFor(kind);
-									return (
-										<button
-											key={kind}
-											aria-label={`React with ${reactionName(kind)}`}
-											aria-pressed={mine !== undefined}
-											className={classes(
-												styles.pickerItem,
-												mine !== undefined && styles.pickerItemMine,
-											)}
-											onClick={() => {
-												toggle(kind, mine);
-												setPickerOpen(false);
-											}}
-											type="button"
-										>
-											{glyph}
-										</button>
-									);
-								})}
-							</Popover.Popup>
-						</Popover.Positioner>
-					</Popover.Portal>
-				</Popover.Root>
+							>
+								{glyph}
+							</button>
+						);
+					})}
+				</Dropdown>
 			)}
 		</div>
 	);

--- a/apps/lite/ui/src/routes/project/$id/workspace/Settings/Settings.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Settings/Settings.module.css
@@ -1,37 +1,8 @@
-.backdrop {
-	position: fixed;
-	inset: 0;
-	background-color: var(--bg-overlay);
-}
-
-.viewport {
-	display: flex;
-	position: fixed;
-	inset: 0;
-	padding: 4.5rem 1rem;
-}
-
-/*
- * Recessed, so the sidebar and each group of settings read as cards sitting on it —
- * the arrangement desktop's settings use, on the tokens both apps share.
- */
+/* The sidebar sits beside the content rather than above it, so this pane lays itself out in a row
+   where the container stacks. Its recessed ground is the `recessed` modal variant. */
 .popup {
-	display: flex;
-	width: min(820px, 100%);
+	flex-direction: row;
 	height: min(76vh, 1000px);
-	margin: auto;
-	overflow: hidden;
-	border: 1px solid var(--border-2);
-	border-radius: var(--radius-lg);
-	background-color: var(--bg-2);
-	box-shadow:
-		0 0.5px 1px rgb(0 0 0 / 0.12),
-		0 1px 3px -1px rgb(0 0 0 / 0.04),
-		0 2px 4px -1px rgb(0 0 0 / 0.04),
-		0 4px 8px -2px rgb(0 0 0 / 0.04),
-		0 12px 14px -4px rgb(0 0 0 / 0.04),
-		0 24px 64px -8px rgb(0 0 0 / 0.04),
-		0 40px 48px -32px rgb(0 0 0 / 0.04);
 }
 
 .sidebar {

--- a/apps/lite/ui/src/routes/project/$id/workspace/Settings/Settings.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Settings/Settings.tsx
@@ -1,4 +1,4 @@
-import { Dialog } from "@base-ui/react";
+import { Modal } from "#ui/components/Popup.tsx";
 import { Suspense, useState, type FC } from "react";
 import { classes } from "#ui/components/classes.ts";
 import { Icon } from "#ui/components/Icon.tsx";
@@ -64,72 +64,72 @@ export const Settings: FC<Props> = (p) => {
 	const Content = pageContent[selected];
 
 	return (
-		<Dialog.Root open={p.open} onOpenChange={p.onOpenChange}>
-			<Dialog.Portal>
-				<Dialog.Backdrop className={styles.backdrop} />
-				<Dialog.Viewport className={styles.viewport}>
-					<Dialog.Popup aria-labelledby="settings-heading" className={styles.popup}>
-						<nav aria-label="Settings pages" className={styles.sidebar}>
-							<h1 id="settings-heading" className={classes("text-14", "text-bold", styles.heading)}>
-								Settings
-							</h1>
+		<Modal
+			size="medium"
+			recessed
+			open={p.open}
+			onOpenChange={p.onOpenChange}
+			aria-labelledby="settings-heading"
+			className={styles.popup}
+		>
+			<nav aria-label="Settings pages" className={styles.sidebar}>
+				<h1 id="settings-heading" className={classes("text-14", "text-bold", styles.heading)}>
+					Settings
+				</h1>
 
-							{groups.map((group) => (
-								<div key={group.scope} className={styles.group}>
-									{showHeadings && (
-										<h2 className={classes("text-12", styles.groupHeading)}>
-											{group.scope === "global" ? "Application" : p.projectName}
-										</h2>
-									)}
+				{groups.map((group) => (
+					<div key={group.scope} className={styles.group}>
+						{showHeadings && (
+							<h2 className={classes("text-12", styles.groupHeading)}>
+								{group.scope === "global" ? "Application" : p.projectName}
+							</h2>
+						)}
 
-									{group.pages.map((page) => (
-										<button
-											key={page.key}
-											type="button"
-											aria-current={page.key === selected ? "page" : undefined}
-											className={classes(
-												"text-13",
-												"text-semibold",
-												styles.link,
-												page.key === selected && styles.linkSelected,
-											)}
-											onClick={() => setSelected(page.key)}
-										>
-											<Icon name={page.icon} className={styles.linkIcon} />
-											<span>{page.label}</span>
-										</button>
-									))}
-								</div>
-							))}
+						{group.pages.map((page) => (
+							<button
+								key={page.key}
+								type="button"
+								aria-current={page.key === selected ? "page" : undefined}
+								className={classes(
+									"text-13",
+									"text-semibold",
+									styles.link,
+									page.key === selected && styles.linkSelected,
+								)}
+								onClick={() => setSelected(page.key)}
+							>
+								<Icon name={page.icon} className={styles.linkIcon} />
+								<span>{page.label}</span>
+							</button>
+						))}
+					</div>
+				))}
 
-							<div className={styles.social}>
-								{externalLinks.map((link) => (
-									<button
-										key={link.label}
-										type="button"
-										className={classes("text-13", "text-semibold", styles.link)}
-										onClick={() => void window.lite.openInWebBrowser(link.url)}
-									>
-										<Icon name={link.icon} className={styles.linkIcon} />
-										<span>{link.label}</span>
-										<span aria-hidden className={styles.linkExternal}>
-											↗
-										</span>
-									</button>
-								))}
-							</div>
-						</nav>
+				<div className={styles.social}>
+					{externalLinks.map((link) => (
+						<button
+							key={link.label}
+							type="button"
+							className={classes("text-13", "text-semibold", styles.link)}
+							onClick={() => void window.lite.openInWebBrowser(link.url)}
+						>
+							<Icon name={link.icon} className={styles.linkIcon} />
+							<span>{link.label}</span>
+							<span aria-hidden className={styles.linkExternal}>
+								↗
+							</span>
+						</button>
+					))}
+				</div>
+			</nav>
 
-						<div className={styles.content}>
-							<div className={styles.contentColumn}>
-								<Suspense fallback={<div className="text-13">Loading…</div>}>
-									<Content projectId={p.projectId} />
-								</Suspense>
-							</div>
-						</div>
-					</Dialog.Popup>
-				</Dialog.Viewport>
-			</Dialog.Portal>
-		</Dialog.Root>
+			<div className={styles.content}>
+				<div className={styles.contentColumn}>
+					<Suspense fallback={<div className="text-13">Loading…</div>}>
+						<Content projectId={p.projectId} />
+					</Suspense>
+				</div>
+			</div>
+		</Modal>
 	);
 };

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -21,7 +21,6 @@
 				"ui/src/electron.d.ts!",
 				"ui/src/react-css-properties.d.ts!",
 				"ui/src/components/ToggleGroup.tsx!",
-				"ui/src/components/Popup.tsx!",
 			],
 			"project": [
 				"electron/src/**!",

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -21,6 +21,7 @@
 				"ui/src/electron.d.ts!",
 				"ui/src/react-css-properties.d.ts!",
 				"ui/src/components/ToggleGroup.tsx!",
+				"ui/src/components/Popup.tsx!",
 			],
 			"project": [
 				"electron/src/**!",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -423,8 +423,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/but-sdk
       '@gitbutler/design-core':
-        specifier: 3.13.2
-        version: 3.13.2
+        specifier: 3.15.2
+        version: 3.15.2
       '@pierre/diffs':
         specifier: ^1.3.5
         version: 1.3.5(@shikijs/themes@4.3.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -2066,8 +2066,8 @@ packages:
   '@gitbutler/design-core@2.2.2':
     resolution: {integrity: sha512-oPPnYjwsKxwoTY6wK/fT9ylwhSIBgQxCOGJzYefbM8WFr2OuJePH9MnDnZ3K9UQlb94p+NR7m/QCFzhbDVRwxw==}
 
-  '@gitbutler/design-core@3.13.2':
-    resolution: {integrity: sha512-YJngSkGzpoWBQFw2R9a4efl6d2m8x6rZKeuSYWsjQK6TKpYR0oPuA6WF2BY+t7atCgEgZ8GienThZzM2qSPBow==}
+  '@gitbutler/design-core@3.15.2':
+    resolution: {integrity: sha512-+f7D0cE+5GHK6tbwePG/UFW2pzgF4Q/znvjzXXOiZujW7QdmPa51gpVs+Rw2y4LZD2nrPNfoI1in6gnw+ykfFA==}
 
   '@gitbutler/design-core@3.9.1':
     resolution: {integrity: sha512-kLkZ1+pqeqpBntBOSV53kYVCmY/ZFemjxsWc78GTGLgn1Op8p7bWCNxCUSU822MKLJrzmjUg99MpqdHpXGcNAQ==}
@@ -11390,7 +11390,7 @@ snapshots:
 
   '@gitbutler/design-core@2.2.2': {}
 
-  '@gitbutler/design-core@3.13.2': {}
+  '@gitbutler/design-core@3.15.2': {}
 
   '@gitbutler/design-core@3.9.1': {}
 


### PR DESCRIPTION
Every overlay in Lite — modals, dropdowns, the toolbox, toasts — was building its own surface. Each one repeated the portal, the backdrop, the positioner and some subset of `ui.module.css`'s popup classes, and they had drifted: different radii, different shadows, no shared open animation.

This puts them all on one container.

<img width="1073" height="600" alt="Popups and dropdowns components" src="https://github.com/user-attachments/assets/18b9fb43-f328-4855-88ee-eabf99cd5efe" />
<img width="1056" height="510" alt="Popups and dropdowns examples" src="https://github.com/user-attachments/assets/3f282611-e9ce-44b8-95d3-76449c03fc0e" />

Figma: https://www.figma.com/design/EBuHQGUcCaSw4Ln5uVpWkn/Lite?node-id=930-11981&t=pDpTIAgumuOJxyJF-1

### The container

`Popup.tsx` holds the whole set:

- **`Popup`** — the surface itself. Border, radius, shadow, clipping. Used directly only by something that floats without opening.
- **`Modal`** — `Popup` plus a backdrop, in three sizes. `alert` takes the `alertdialog` role and refuses Escape and backdrop clicks, for credentials and destructive confirmations. `recessed` sinks the ground so the groups inside read as cards, which is what a pane like settings wants.
- **`Dropdown`** — the same container anchored to its trigger, with nothing dimmed behind it. The backdrop is the only thing separating it from `Modal`.
- **`PopupSearch` / `PopupSection` / `PopupItem`** — the insides a popup is usually made of: the filter row, a divided run of rows, and the row itself with its glyph, label, shortcut and trailing mark.

`Modal` and `Dropdown` are thin: they wrap `Popup` in whichever Base UI primitive carries the focus and dismissal behaviour, and add nothing else.

### Converted

`AskpassPromptDialog`, `ConflictBar`, `Settings`, `MarkdownAttachments`, `PullRequestReactions`, `review-inbox-bell`, `Toasts`, the commit target selector and `PickerDialog`. `ui.module.css` is down to its two scroller classes.

Base UI's combobox owns its own popup part, so the commit target selector cannot be handed a `Dropdown` — `Popup` dresses the combobox's own popup instead, via the same `render` escape hatch the row and search parts use.

### Animation

`--transition-popup` is defined once in `global.css`, because a modal, its backdrop and a dropdown are rendered as siblings and cannot inherit it from one another. Modals fade and lift; dropdowns grow out of the corner they are anchored to. The toolbox has no Base UI lifecycle to animate against — it is rendered while a selection exists and unmounted when it stops — so its entrance comes from `@starting-style` on the same timing.

### Notes for review

- Bumps `@gitbutler/design-core` to 3.15.2 for `--radius-popup`.
- Base UI only plays the open animation when `open` turns true *after* mount, and the app mounts some modals already open (`{shown && <Picker open />}`). `Modal` holds the first frame closed to give it the change it animates from. The better fix is to stop conditionally mounting them; that is a follow-up, not this PR.
- Stories added for `Popup`, `Modal` and `Dropdown`.
