### PR TITLE
Refuse safe checkout while the index has unresolved conflicts

### DIFF
--- a/crates/but-core/src/worktree/checkout/function.rs
+++ b/crates/but-core/src/worktree/checkout/function.rs
@@ -1,5 +1,5 @@
 use anyhow::bail;
-use bstr::BStr;
+use bstr::{BStr, ByteSlice as _};
 use but_error::bail_precondition;
 use but_oxidize::{ObjectIdExt, OidExt as _};
 use gix::{
@@ -73,6 +73,7 @@ pub fn safe_checkout_from_head(
         .peel_to_tree()?;
     let mut conflict_occurred = false;
     if old_tree.id() != new_tree.id() {
+        ensure_index_has_no_conflicts(&git2_repo)?;
         // Reopen to ensure that there is no "object memory" (i.e. all object
         // writes actually happen on disk).
         let mut repo = gix::open(repo.git_dir())?;
@@ -191,4 +192,35 @@ pub fn safe_checkout_from_head(
         head_update,
         conflict_occurred,
     })
+}
+
+/// Refuse to check out while `.git/index` still holds unresolved stage 1/2/3 entries.
+///
+/// Such entries are left behind by a checkout that was allowed to conflict with
+/// uncommitted changes, or by a merge run outside GitButler. libgit2 would reject the
+/// checkout anyway with a raw `Conflict` error; failing here keeps worktree, index and
+/// `HEAD` untouched and classifies the error as a precondition the user can act on.
+///
+/// This runs after the merge-base override's index rewrite on purpose: when that
+/// rewrite falls back to overwriting the index with the override tree, the stages are
+/// gone and the checkout may proceed — the intended steamroll semantic for restoring a
+/// snapshot or committing the conflicted file itself.
+fn ensure_index_has_no_conflicts(git2_repo: &git2::Repository) -> anyhow::Result<()> {
+    let index = git2_repo.index()?;
+    if !index.has_conflicts() {
+        return Ok(());
+    }
+    let mut paths = Vec::new();
+    for conflict in index.conflicts()? {
+        let conflict = conflict?;
+        if let Some(entry) = conflict.our.or(conflict.their).or(conflict.ancestor) {
+            paths.push(format!("{:?}", entry.path.as_slice().as_bstr()));
+        }
+    }
+    paths.sort();
+    paths.dedup();
+    bail_precondition!(
+        "Cannot update the worktree while files have unresolved conflicts: {}. Resolve the conflicts, then mark each file as resolved, e.g. with `but resolve <path>`.",
+        paths.join(", ")
+    );
 }

--- a/crates/but-core/tests/core/worktree/checkout.rs
+++ b/crates/but-core/tests/core/worktree/checkout.rs
@@ -144,6 +144,59 @@ fn conflicted_commits_cannot_be_checked_out() -> anyhow::Result<()> {
 }
 
 #[test]
+fn unresolved_index_conflicts_refuse_checkout_before_mutation() -> anyhow::Result<()> {
+    let (repo, _tmp) = writable_scenario("merge-with-two-branches-conflict");
+    let index_before = visualize_index(&*repo.index()?);
+    snapbox::assert_data_eq!(
+        index_before.as_str(),
+        snapbox::str![[r#"
+100644:e69de29 file:1
+100644:e6c4914 file:2
+100644:e33f5e9 file:3
+
+"#]]
+    );
+    let status_before = git_status(&repo)?;
+    snapbox::assert_data_eq!(
+        status_before.as_str(),
+        snapbox::str![[r#"
+UU file
+
+"#]]
+    );
+
+    // A no-op checkout of the current head doesn't touch index or worktree,
+    // so it may proceed - materializations that keep the head tree (e.g. a reword)
+    // must still work while conflicts are unresolved.
+    let head_commit = repo.head_commit()?;
+    safe_checkout_from_head(head_commit.id, &repo, Default::default())
+        .expect("no-op checkouts succeed despite index conflicts");
+
+    let target = repo.rev_parse_single("A")?.detach();
+    let err = safe_checkout_from_head(target, &repo, Default::default())
+        .expect_err("a real checkout must refuse while the index has unresolved conflicts");
+    assert_eq!(
+        err.to_string(),
+        "Cannot update the worktree while files have unresolved conflicts: \"file\". Resolve the conflicts, then mark each file as resolved, e.g. with `but resolve <path>`.",
+    );
+
+    // Nothing changed: worktree, index and HEAD are preserved.
+    assert_eq!(visualize_index(&*repo.index()?), index_before);
+    assert_eq!(git_status(&repo)?, status_before);
+    snapbox::assert_data_eq!(
+        visualize_commit_graph_all(&repo)?,
+        snapbox::str![[r#"
+* 88d7acc (A) 10 to 20
+| * 47334c6 (HEAD -> merge, B) 20 to 30
+|/  
+* 15bcd1b (main) init
+
+"#]]
+    );
+    Ok(())
+}
+
+#[test]
 fn pure_deletion_checkout_does_not_restore_unrelated_worktree_deletions() -> anyhow::Result<()> {
     let (repo, _tmp) = writable_scenario_slow("all-file-types-renamed-and-modified");
     snapbox::assert_data_eq!(
@@ -1150,6 +1203,69 @@ fn cancelling_consumed_changes_keeps_a_concurrent_edit() -> anyhow::Result<()> {
         std::fs::read_to_string(&file_path)?,
         "line1\nunchanged\nadded-b\nline2\nline3\nappended\n",
         "the snapshot is taken live, so the concurrent edit survives the cancellation"
+    );
+    Ok(())
+}
+
+/// The merge-base override path must keep working while the index has unresolved
+/// conflicts: snapshot restore (undo) always passes an override and is the escape
+/// hatch from exactly this state. The override's index rewrite falls back to
+/// overwriting the index with the override tree (patching a conflicted index fails),
+/// which clears the stages before the conflict guard runs, and the checkout then
+/// persists the conflict-free index.
+#[test]
+fn merge_base_override_steamrolls_stale_index_conflicts() -> anyhow::Result<()> {
+    let (repo, _tmp) = writable_scenario("merge-with-two-branches-conflict");
+    assert!(
+        git2::Repository::open(repo.git_dir())?
+            .index()?
+            .has_conflicts(),
+        "the fixture starts out mid-merge with unresolved index stages"
+    );
+
+    // Restore-shaped call: the override is the current workdir tree (like the
+    // pre-restore snapshot's), so uncommitted content cancels out in the merge and
+    // the destination tree is checked out as-is.
+    let wd_blob = repo.write_blob(std::fs::read(repo.workdir_path("file").expect("non-bare"))?)?;
+    let mut editor = repo.empty_tree().edit()?;
+    editor.upsert("file", EntryKind::Blob, wd_blob.detach())?;
+    let wd_tree = editor.write()?.detach();
+
+    let target = repo.rev_parse_single("A")?.detach();
+    safe_checkout_from_head(
+        target,
+        &repo,
+        checkout::Options {
+            merge_base_override: Some(wd_tree),
+            ..Default::default()
+        },
+    )
+    .expect("an override checkout succeeds despite index conflicts");
+
+    // The conflict stages are gone from the on-disk index and everything matches `A`.
+    assert!(
+        !git2::Repository::open(repo.git_dir())?
+            .index()?
+            .has_conflicts(),
+        "the override checkout persistently cleared the conflict stages"
+    );
+    snapbox::assert_data_eq!(
+        visualize_index(&*repo.index()?),
+        snapbox::str![[r#"
+100644:e33f5e9 file
+
+"#]]
+    );
+    snapbox::assert_data_eq!(git_status(&repo)?, snapbox::str![""]);
+    snapbox::assert_data_eq!(
+        visualize_commit_graph_all(&repo)?,
+        snapbox::str![[r#"
+* 88d7acc (HEAD -> merge, A) 10 to 20
+| * 47334c6 (B) 20 to 30
+|/  
+* 15bcd1b (main) init
+
+"#]]
     );
     Ok(())
 }


### PR DESCRIPTION
Fixes GB-1937

## The problem

Updating the workspace while `.git/index` still holds unresolved stage 1/2/3 entries died deep inside libgit2's checkout with the raw error `unresolved conflicts exist in the index; class=Checkout; code=Conflict` — surfaced verbatim to the user with no recovery guidance. Telemetry shows this on both macOS and Windows on stable 0.22.3.

## How the state arises

libgit2 refuses any non-force checkout while the *repository* index has conflict entries — even though GitButler passes its own already-safety-merged in-memory index. Two ways users end up there:

- **GitButler's own conflicted checkout**: when a workspace update is allowed to conflict with uncommitted changes, libgit2 writes the conflict stages into `.git/index` (that is how the conflicted-uncommitted-files state is represented). Until the user marks those files resolved, every subsequent workspace update hit the raw error.
- **A merge run outside GitButler**: an unresolved `git merge` / `git cherry-pick` in the terminal leaves the same stage entries.

## The fix

`safe_checkout_from_head` now checks for unresolved index entries before the checkout mutates anything and fails with a typed `PreconditionFailed` naming the conflicted files and pointing at the resolution path (`but resolve <path>`; desktop/Lite show conflicted uncommitted files with a resolve affordance). Since the checkout runs before any ref edits during materialization, refusing there preserves worktree, index, HEAD, and workspace metadata. This covers all checkout-based operations (workspace update, apply, unapply, …), not just upstream integration.

Two paths deliberately keep working while conflicts are unresolved, and are pinned by tests:

- **No-op checkouts** (head tree unchanged, e.g. a reword) never touch the index or worktree.
- **Merge-base-override checkouts**: their index rewrite clears the stages before the guard runs. Snapshot restore (undo) always passes an override — it is the escape hatch from exactly this state — and committing the conflicted file itself legitimately resolves it.