### PR TITLE
Onboarding: explain unrelated target histories

### DIFF
--- a/apps/desktop/src/components/onboarding/ProjectSetup.svelte
+++ b/apps/desktop/src/components/onboarding/ProjectSetup.svelte
@@ -5,6 +5,7 @@
 	import ReduxResult from "$components/shared/ReduxResult.svelte";
 	import newZenSvg from "$lib/assets/illustrations/new-zen.svg?raw";
 	import { BASE_BRANCH_SERVICE } from "$lib/baseBranch/baseBranchService.svelte";
+	import { showError } from "$lib/error/showError";
 	import { PROJECTS_SERVICE } from "$lib/project/projectsService";
 	import { SETTINGS_SERVICE } from "$lib/settings/appSettings";
 	import { OnboardingEvent, POSTHOG_WRAPPER } from "$lib/telemetry/posthog";
@@ -27,28 +28,40 @@
 	const [setBaseBranchTarget] = baseService.setTarget;
 	const [setBaseBranchTargetRef] = baseService.setTargetRef;
 
-	async function setTarget(branch: string[]) {
-		if (!branch[0] || branch[0] === "") return;
+	async function setTarget([branchName, pushRemote]: [branchName: string, pushRemote: string]) {
+		if (!branchName) return;
 
 		try {
 			if ($settingsStore?.featureFlags.singleBranch) {
 				// Only set the target; the user keeps working on their current branch.
 				await setBaseBranchTargetRef({
 					projectId: projectId,
-					targetRef: `refs/remotes/${branch[0]}`,
-					pushRemote: branch[1],
+					targetRef: `refs/remotes/${branchName}`,
+					pushRemote,
 				});
 			} else {
 				await setBaseBranchTarget({
 					projectId: projectId,
-					branch: branch[0],
-					pushRemote: branch[1],
+					branch: branchName,
+					pushRemote,
 				});
 			}
-			posthog.captureOnboarding(OnboardingEvent.SetTargetBranch);
-			goto(`/${projectId}/`, { invalidateAll: true });
 		} catch (e: unknown) {
 			posthog.captureOnboarding(OnboardingEvent.SetTargetBranchFailed, e);
+			throw e;
+		}
+
+		posthog.captureOnboarding(OnboardingEvent.SetTargetBranch);
+	}
+
+	async function openProject(): Promise<boolean> {
+		const destination = `/${projectId}/`;
+		try {
+			await goto(destination, { invalidateAll: true });
+			return true;
+		} catch (error) {
+			showError("The target was set, but the project could not be opened", error);
+			return false;
 		}
 	}
 
@@ -67,9 +80,8 @@
 				{projectId}
 				projectName={project.title}
 				{remoteBranches}
-				onBranchSelected={async (branch) => {
-					await setTarget(branch);
-				}}
+				onBranchSelected={setTarget}
+				onOpenProject={openProject}
 			/>
 		{/snippet}
 	</ReduxResult>

--- a/apps/desktop/src/components/onboarding/ProjectSetupTarget.svelte
+++ b/apps/desktop/src/components/onboarding/ProjectSetupTarget.svelte
@@ -6,6 +6,7 @@
 	import { getBestBranch, getBestRemote, getBranchRemoteFromRef } from "$lib/branches/branchUtils";
 	import { projectLandDirectly } from "$lib/config/config";
 	import { GIT_CONFIG_SERVICE } from "$lib/config/gitConfigService";
+	import { classify, type ClassifiedError } from "$lib/error/errorClassification";
 	import { PROJECTS_SERVICE } from "$lib/project/projectsService";
 	import { SETTINGS_SERVICE } from "$lib/settings/appSettings";
 	import { combineResults } from "$lib/state/helpers";
@@ -17,6 +18,7 @@
 		CardGroup,
 		Checkbox,
 		Icon,
+		InfoMessage,
 		Link,
 		Select,
 		SelectItem,
@@ -30,10 +32,12 @@
 		projectId: string;
 		projectName: string;
 		remoteBranches: RemoteBranchInfo[];
-		onBranchSelected?: (branch: string[]) => void;
+		onBranchSelected: (branch: [branchName: string, pushRemote: string]) => Promise<void>;
+		onOpenProject: () => Promise<boolean>;
 	}
 
-	const { projectId, projectName, remoteBranches, onBranchSelected }: Props = $props();
+	const { projectId, projectName, remoteBranches, onBranchSelected, onOpenProject }: Props =
+		$props();
 
 	const posthog = inject(POSTHOG_WRAPPER);
 	const gitConfig = inject(GIT_CONFIG_SERVICE);
@@ -45,6 +49,8 @@
 	const landDirectly = $derived(projectLandDirectly(projectId));
 
 	let loading = $state<boolean>(false);
+	let targetWasSet = $state(false);
+	let targetError = $state<ClassifiedError>();
 	let showMoreInfo = $state<boolean>(false);
 
 	// split all the branches by the first '/' and gather the unique remote names
@@ -66,11 +72,25 @@
 	const remote = $derived(selectedRemote ?? defaultRemote);
 
 	async function onSetTargetClick() {
-		if (!branch || !remote) return;
-		posthog.captureOnboarding(OnboardingEvent.ProjectSetupContinue, undefined, {
-			landDirectly: $landDirectly,
-		});
-		onBranchSelected?.([branch.name, remote]);
+		if (!branch || !remote || loading) return;
+		loading = true;
+		targetError = undefined;
+		if (!targetWasSet) {
+			posthog.captureOnboarding(OnboardingEvent.ProjectSetupContinue, undefined, {
+				landDirectly: $landDirectly,
+			});
+			try {
+				await onBranchSelected([branch.name, remote]);
+				targetWasSet = true;
+			} catch (error) {
+				const classified = classify(error);
+				if (classified.severity !== "silent") targetError = classified;
+				loading = false;
+				return;
+			}
+		}
+		if (await onOpenProject()) return;
+		loading = false;
 	}
 
 	const projectsService = inject(PROJECTS_SERVICE);
@@ -95,6 +115,7 @@
 			<Select
 				value={branch?.name}
 				options={remoteBranches.map((b) => ({ label: b.name, value: b.name }))}
+				disabled={loading || targetWasSet}
 				wide
 				onselect={(value) => {
 					selectedBranch = { name: value };
@@ -122,6 +143,7 @@
 				<Select
 					value={remote}
 					options={remotes.map((r) => ({ label: r, value: r }))}
+					disabled={loading || targetWasSet}
 					onselect={(value) => {
 						const newSelectedRemote = remotes.find((r) => r === value);
 						selectedRemote = newSelectedRemote ?? remote;
@@ -242,8 +264,17 @@
 		</div>
 	{/if}
 
+	{#if targetError}
+		{@const error = targetError}
+		<InfoMessage style={error.severity === "warning" ? "warning" : "danger"}>
+			{#snippet content()}
+				{error.userMessage ?? error.message}
+			{/snippet}
+		</InfoMessage>
+	{/if}
+
 	<div class="action-buttons">
-		<Button kind="outline" onclick={deleteProjectAndGoBack}>Cancel</Button>
+		<Button kind="outline" disabled={loading} onclick={deleteProjectAndGoBack}>Cancel</Button>
 		<Button
 			style="pop"
 			{loading}
@@ -252,7 +283,7 @@
 			testId={TestId.ProjectSetupPageTargetContinueButton}
 			id="set-base-branch"
 		>
-			Let's go
+			{targetWasSet ? "Open project" : "Let's go"}
 		</Button>
 	</div>
 </div>

--- a/apps/desktop/src/components/onboarding/ProjectSetupTarget.svelte.test.ts
+++ b/apps/desktop/src/components/onboarding/ProjectSetupTarget.svelte.test.ts
@@ -1,0 +1,105 @@
+import ProjectSetupTarget from "$components/onboarding/ProjectSetupTarget.svelte";
+import { GIT_CONFIG_SERVICE } from "$lib/config/gitConfigService";
+import { PROJECTS_SERVICE } from "$lib/project/projectsService";
+import { SETTINGS_SERVICE } from "$lib/settings/appSettings";
+import { POSTHOG_WRAPPER } from "$lib/telemetry/posthog";
+import { render, screen, waitFor } from "@testing-library/svelte";
+import userEvent from "@testing-library/user-event";
+import { writable } from "svelte/store";
+import { expect, test, vi } from "vitest";
+
+function renderTarget(
+	onBranchSelected: (branch: [branchName: string, pushRemote: string]) => Promise<void>,
+	onOpenProject = vi.fn(async () => false),
+) {
+	const context = new Map<any, any>([
+		[
+			GIT_CONFIG_SERVICE._key,
+			{
+				gbConfig: () => ({ response: { gitbutlerGerritMode: false } }),
+				setGerritMode: vi.fn(),
+			},
+		],
+		[
+			PROJECTS_SERVICE._key,
+			{
+				areYouGerritKiddingMe: () => ({ result: { data: false, status: "fulfilled" } }),
+				isGerritProject: () => ({ result: { data: false, status: "fulfilled" } }),
+				deleteProject: vi.fn(),
+				fetchProjects: vi.fn(),
+			},
+		],
+		[SETTINGS_SERVICE._key, { appSettings: writable(undefined) }],
+		[POSTHOG_WRAPPER._key, { captureOnboarding: vi.fn() }],
+	]);
+
+	return render(ProjectSetupTarget, {
+		props: {
+			projectId: "project-id",
+			projectName: "Repository",
+			remoteBranches: [{ name: "origin/main" }],
+			onBranchSelected,
+			onOpenProject,
+		},
+		context,
+	});
+}
+
+test("allows only one target submission while the request is pending", async () => {
+	let resolvePending!: () => void;
+	const pending = new Promise<void>((resolve) => {
+		resolvePending = resolve;
+	});
+	const onBranchSelected = vi.fn(async () => await pending);
+	const onOpenProject = vi.fn(async () => false);
+	const user = userEvent.setup();
+	renderTarget(onBranchSelected, onOpenProject);
+
+	const submit = screen.getByRole("button", { name: "Let's go" });
+	const cancel = screen.getByRole("button", { name: "Cancel" });
+	await user.click(submit);
+	await user.click(submit);
+
+	expect(onBranchSelected).toHaveBeenCalledTimes(1);
+	expect(submit).toBeDisabled();
+	expect(cancel).toBeDisabled();
+
+	resolvePending();
+	await pending;
+	await waitFor(() => {
+		expect(screen.getByRole("button", { name: "Open project" })).toBeEnabled();
+		expect(cancel).toBeEnabled();
+	});
+	expect(onOpenProject).toHaveBeenCalledTimes(1);
+
+	await user.click(screen.getByRole("button", { name: "Open project" }));
+	expect(onBranchSelected).toHaveBeenCalledTimes(1);
+	expect(onOpenProject).toHaveBeenCalledTimes(2);
+});
+
+test("shows an actionable target error and permits a retry", async () => {
+	const message =
+		"The selected target has no common history with HEAD. Fetch more history or choose another branch.";
+	const onBranchSelected = vi
+		.fn<(_: [branchName: string, pushRemote: string]) => Promise<void>>()
+		.mockRejectedValueOnce(
+			Object.assign(new Error(message), {
+				code: "PreconditionFailed",
+			}),
+		)
+		.mockResolvedValueOnce();
+	const user = userEvent.setup();
+	const { container } = renderTarget(onBranchSelected);
+
+	const submit = screen.getByRole("button", { name: "Let's go" });
+	await user.click(submit);
+
+	expect(await screen.findByText(message)).toBeVisible();
+	expect(screen.getAllByText(message)).toHaveLength(1);
+	expect(container.querySelector(".info-message.warning")).toBeTruthy();
+	expect(container.querySelector(".info-message.danger")).toBeNull();
+	expect(submit).toBeEnabled();
+
+	await user.click(submit);
+	expect(onBranchSelected).toHaveBeenCalledTimes(2);
+});

--- a/crates/but-api/src/workspace.rs
+++ b/crates/but-api/src/workspace.rs
@@ -266,10 +266,10 @@ pub fn get_workspace(
 /// managed workspace mode.
 ///
 /// This acquires exclusive worktree access from `ctx` before updating project metadata.
-/// See [`but_workspace::init::set_target_ref_and_init_project()`] for details; notably the
-/// target commit id is only computed when it wasn't set before, and an omitted
-/// `push_remote` keeps the currently configured one. It deliberately records no oplog
-/// snapshot - only project metadata changes, no repository state.
+/// See [`but_workspace::init::set_target_ref_and_init_project()`] for details. The target is always
+/// validated against `HEAD`; an unreachable stored target commit is replaced by their merge-base.
+/// An omitted `push_remote` preserves its current value. It deliberately records no oplog snapshot
+/// because only project metadata changes, not repository state.
 #[but_api(napi)]
 #[instrument(err(Debug))]
 pub fn set_target_ref_and_init_project(

--- a/crates/but-workspace/src/init.rs
+++ b/crates/but-workspace/src/init.rs
@@ -10,6 +10,7 @@ use but_core::{
     git_config::{edit_repo_config, ensure_config_value},
     ref_metadata::ProjectMeta,
 };
+use but_error::bail_precondition;
 
 /// Infer a default remote-tracking target from repository configuration without changing state.
 ///
@@ -60,6 +61,58 @@ fn is_existing_branch_on_remote(
         .is_some_and(|mut reference| reference.peel_to_commit().is_ok()))
 }
 
+/// Return the merge-base of `head` and `target_head`, or an actionable precondition failure when
+/// their histories are unrelated or incomplete.
+fn merge_base_with_target(
+    repo: &gix::Repository,
+    head: gix::ObjectId,
+    target_head: gix::ObjectId,
+) -> Result<gix::ObjectId> {
+    match repo.merge_base(head, target_head) {
+        Ok(id) => Ok(id.detach()),
+        Err(gix::repository::merge_base::Error::FindMergeBase(_))
+        | Err(gix::repository::merge_base::Error::NotFound { .. }) => bail_precondition!(
+            "The selected target has no common history with HEAD. Fetch more history or choose another branch."
+        ),
+        Err(err) => Err(err).context(format!(
+            "Failed to calculate merge base between {head} and {target_head}"
+        )),
+    }
+}
+
+/// Return whether `commit` exists and is reachable from `target_head`.
+fn target_contains_commit(
+    repo: &gix::Repository,
+    target_head: gix::ObjectId,
+    commit: gix::ObjectId,
+) -> Result<bool> {
+    if repo.try_find_object(commit)?.is_none() {
+        return Ok(false);
+    }
+    match repo.merge_base(commit, target_head) {
+        Ok(id) => Ok(id.detach() == commit),
+        Err(gix::repository::merge_base::Error::FindMergeBase(_))
+        | Err(gix::repository::merge_base::Error::NotFound { .. }) => Ok(false),
+        Err(err) => Err(err).context(format!(
+            "Failed to validate existing target commit {commit} against {target_head}"
+        )),
+    }
+}
+
+/// Resolve the target commit from stable `head` and target-tip snapshots.
+pub fn resolve_target_commit(
+    repo: &gix::Repository,
+    head: gix::ObjectId,
+    target_head: gix::ObjectId,
+    existing: Option<gix::ObjectId>,
+) -> Result<gix::ObjectId> {
+    let merge_base = merge_base_with_target(repo, head, target_head)?;
+    match existing {
+        Some(existing) if target_contains_commit(repo, target_head, existing)? => Ok(existing),
+        _ => Ok(merge_base),
+    }
+}
+
 /// Make `target_ref` the project's default target and initialize project metadata,
 /// without changing the currently checked out branch.
 ///
@@ -69,8 +122,9 @@ fn is_existing_branch_on_remote(
 /// * store the target as [`ProjectMeta`] via [`ProjectMeta::persist()`],
 /// * set `log.excludeDecoration = refs/gitbutler` in the repository-local Git config.
 ///
-/// The target commit id is only computed - as the merge-base between `HEAD` and
-/// `target_ref` - if it isn't already set; an existing value is never overwritten.
+/// The selected target ref is always stored. An existing target commit id is retained when it is
+/// reachable from that target; otherwise it is replaced by the merge-base with `HEAD`. The target
+/// is always validated against `HEAD` before metadata is persisted.
 /// `push_remote`, if `Some`, is validated and stored; if `None`, an existing push remote
 /// is kept as is.
 ///
@@ -122,24 +176,8 @@ pub fn set_target_ref_and_init_project(
         .url(gix::remote::Direction::Fetch)
         .with_context(|| format!("failed to get remote url for '{remote_name}'"))?;
 
-    let sha = match repaired.target_commit_id {
-        Some(existing) => existing,
-        None => {
-            let head_commit = repo
-                .head()
-                .context("Failed to get HEAD reference")?
-                .peel_to_commit()
-                .context("Failed to peel HEAD reference to commit")?
-                .id;
-            repo.merge_base(head_commit, target_head)
-                .with_context(|| {
-                    format!(
-                        "Failed to calculate merge base between {head_commit} and {target_head}"
-                    )
-                })?
-                .detach()
-        }
-    };
+    let head = repo.head_id().context("Failed to resolve HEAD")?.detach();
+    let sha = resolve_target_commit(repo, head, target_head, repaired.target_commit_id)?;
 
     let push_remote = match push_remote {
         Some(name) => {

--- a/crates/but-workspace/tests/workspace/init.rs
+++ b/crates/but-workspace/tests/workspace/init.rs
@@ -289,7 +289,42 @@ fn changing_the_target_ref_preserves_the_target_commit_id() {
     assert_eq!(
         project_meta.target_commit_id,
         Some(initial_target_id),
-        "the stored id is kept verbatim even for a different target branch"
+        "the stored id is kept verbatim when it remains reachable from the new target"
+    );
+}
+
+#[test]
+fn changing_to_a_diverged_target_recomputes_the_target_commit_id() {
+    let (repo, _tmp) = scenario();
+    let root = repo.head_id().unwrap().detach();
+    let old_target = empty_commit_on_top(&repo, root, "old target");
+    let head = empty_commit_on_top(&repo, old_target, "head");
+    repo.reference(
+        "refs/remotes/origin/main",
+        old_target,
+        PreviousValue::Any,
+        "test",
+    )
+    .unwrap();
+    repo.reference("refs/heads/main", head, PreviousValue::Any, "test")
+        .unwrap();
+    set_target_ref(&repo, "refs/remotes/origin/main", None).unwrap();
+
+    let diverged_target = empty_commit_on_top(&repo, root, "diverged target");
+    repo.reference(
+        "refs/remotes/origin/other",
+        diverged_target,
+        PreviousValue::Any,
+        "test",
+    )
+    .unwrap();
+    set_target_ref(&repo, "refs/remotes/origin/other", None).unwrap();
+
+    let project_meta = stored_meta(&repo);
+    assert_eq!(
+        project_meta.target_commit_id,
+        Some(root),
+        "the stored target commit must be reachable from the replacement target"
     );
 }
 
@@ -309,8 +344,7 @@ fn fills_missing_target_commit_id_from_existing_target_ref() {
     .unwrap();
 
     // Advance only the remote-tracking ref, leaving `HEAD` behind, so the target tip
-    // (which migration repair fills in) differs from `merge_base(HEAD, target)`
-    // (which the fresh-init fallback would compute).
+    // (which migration repair fills in) differs from `merge_base(HEAD, target)`.
     let old_tip = repo
         .find_reference(target_ref)
         .unwrap()
@@ -326,7 +360,7 @@ fn fills_missing_target_commit_id_from_existing_target_ref() {
     assert_eq!(
         stored_meta(&repo).target_commit_id,
         Some(new_target_tip),
-        "a missing id is filled from the stored target ref's tip, not the merge-base"
+        "a missing id is filled from the stored target ref's tip after validating its history"
     );
 }
 
@@ -364,6 +398,107 @@ fn push_remote_changes_without_changing_target() {
 
 mod error {
     use super::*;
+    use but_error::{AnyhowContextExt, Code};
+
+    #[test]
+    fn unrelated_target_is_an_actionable_precondition_failure() {
+        let (repo, _tmp) = scenario();
+        let meta_before = stored_meta(&repo);
+        let exclude_decoration_before = repo
+            .config_snapshot()
+            .string("log.excludeDecoration")
+            .map(|value| value.to_owned());
+        repo.commit(
+            "refs/remotes/origin/unrelated",
+            "unrelated root",
+            repo.object_hash().empty_tree(),
+            std::iter::empty::<gix::ObjectId>(),
+        )
+        .unwrap();
+
+        let err = set_target_ref(&repo, "refs/remotes/origin/unrelated", None).unwrap_err();
+
+        assert_eq!(
+            err.custom_context().map(|ctx| ctx.code),
+            Some(Code::PreconditionFailed),
+            "an unrelated target is a recoverable selection problem"
+        );
+        assert!(
+            err.to_string()
+                .contains("Fetch more history or choose another branch"),
+            "the error tells onboarding how the user can recover"
+        );
+        assert_eq!(
+            stored_meta(&repo),
+            meta_before,
+            "rejecting an unrelated target must not write project metadata"
+        );
+        assert_eq!(
+            repo.config_snapshot()
+                .string("log.excludeDecoration")
+                .map(|value| value.to_owned()),
+            exclude_decoration_before,
+            "rejecting an unrelated target must not finish project initialization"
+        );
+    }
+
+    #[test]
+    fn stale_commit_without_target_ref_does_not_bypass_validation() {
+        let (repo, _tmp) = scenario();
+        let meta_before = ProjectMeta {
+            target_ref: None,
+            target_commit_id: Some(repo.head_id().unwrap().detach()),
+            push_remote: None,
+        };
+        meta_before.persist(&repo).unwrap();
+        repo.commit(
+            "refs/remotes/origin/unrelated",
+            "unrelated root",
+            repo.object_hash().empty_tree(),
+            std::iter::empty::<gix::ObjectId>(),
+        )
+        .unwrap();
+
+        let err = set_target_ref(&repo, "refs/remotes/origin/unrelated", None).unwrap_err();
+
+        assert_eq!(
+            err.custom_context().map(|ctx| ctx.code),
+            Some(Code::PreconditionFailed),
+            "an orphaned target id must not authorize an unrelated target"
+        );
+        assert_eq!(
+            stored_meta(&repo),
+            meta_before,
+            "rejecting the target must preserve the incomplete metadata for recovery"
+        );
+    }
+
+    #[test]
+    fn existing_target_does_not_bypass_unrelated_target_validation() {
+        let (repo, _tmp) = scenario();
+        set_target_ref(&repo, "refs/remotes/origin/main", None).unwrap();
+        let meta_before = stored_meta(&repo);
+        repo.commit(
+            "refs/remotes/origin/unrelated",
+            "unrelated root",
+            repo.object_hash().empty_tree(),
+            std::iter::empty::<gix::ObjectId>(),
+        )
+        .unwrap();
+
+        let err = set_target_ref(&repo, "refs/remotes/origin/unrelated", None).unwrap_err();
+
+        assert_eq!(
+            err.custom_context().map(|ctx| ctx.code),
+            Some(Code::PreconditionFailed),
+            "an existing target pair must not authorize an unrelated replacement"
+        );
+        assert_eq!(
+            stored_meta(&repo),
+            meta_before,
+            "rejecting the replacement target must preserve existing metadata"
+        );
+    }
 
     #[test]
     fn missing_remote_branch() {
@@ -373,6 +508,41 @@ mod error {
                 .unwrap_err()
                 .to_string(),
             "remote branch 'refs/remotes/origin/missing' not found"
+        );
+    }
+
+    #[test]
+    fn missing_stored_target_commit_is_recomputed() {
+        let (repo, _tmp) = scenario();
+        let missing = gix::ObjectId::from_hex(b"1111111111111111111111111111111111111111").unwrap();
+        ProjectMeta {
+            target_ref: Some("refs/remotes/origin/main".try_into().unwrap()),
+            target_commit_id: Some(missing),
+            push_remote: None,
+        }
+        .persist(&repo)
+        .unwrap();
+
+        set_target_ref(&repo, "refs/remotes/origin/main", None).unwrap();
+
+        let stored = stored_meta(&repo).target_commit_id.unwrap();
+        assert_ne!(
+            stored, missing,
+            "the missing stored object must not be retained"
+        );
+        assert_eq!(
+            stored,
+            repo.merge_base(
+                repo.head_id().unwrap().detach(),
+                repo.find_reference("refs/remotes/origin/main")
+                    .unwrap()
+                    .peel_to_commit()
+                    .unwrap()
+                    .id
+            )
+            .unwrap()
+            .detach(),
+            "the missing stored object is replaced by the validated merge-base"
         );
     }
 

--- a/crates/gitbutler-branch-actions/src/base.rs
+++ b/crates/gitbutler-branch-actions/src/base.rs
@@ -197,12 +197,12 @@ pub(crate) fn set_base_branch(
         .id;
 
     // calculate the commit as the merge-base between HEAD in ctx and this target commit
-    let target_commit_oid = repo
-        .merge_base(current_head_commit, target_branch_head)
-        .map(|id| id.detach())
-        .context(format!(
-            "Failed to calculate merge base between {current_head_commit} and {target_branch_head}"
-        ))?;
+    let target_commit_oid = but_workspace::init::resolve_target_commit(
+        &repo,
+        current_head_commit,
+        target_branch_head,
+        None,
+    )?;
 
     let project_meta = ProjectMeta {
         target_ref: Some(target_branch_ref.to_string().try_into()?),

--- a/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/set_base_branch.rs
+++ b/crates/gitbutler-branch-actions/tests/branch-actions/virtual_branches/set_base_branch.rs
@@ -61,6 +61,47 @@ fn uses_configured_committer_for_reflog() {
 }
 
 #[test]
+fn unrelated_target_is_an_actionable_precondition_failure() {
+    let Test { repo, ctx, .. } = &mut Test::default();
+    let gix_repo = repo.open();
+    gix_repo
+        .commit(
+            "refs/remotes/origin/unrelated",
+            "unrelated root",
+            gix_repo.object_hash().empty_tree(),
+            std::iter::empty::<gix::ObjectId>(),
+        )
+        .unwrap();
+
+    let mut guard = ctx.exclusive_worktree_access();
+    let err = gitbutler_branch_actions::set_base_branch(
+        ctx,
+        &"refs/remotes/origin/unrelated".parse().unwrap(),
+        guard.write_permission(),
+    )
+    .unwrap_err();
+    drop(guard);
+
+    assert!(
+        gix_repo
+            .try_find_reference(but_core::WORKSPACE_REF_NAME)
+            .unwrap()
+            .is_none(),
+        "rejecting an unrelated target must not initialize the workspace"
+    );
+    assert_eq!(
+        err.custom_context().map(|ctx| ctx.code),
+        Some(Code::PreconditionFailed),
+        "an unrelated target is a recoverable selection problem"
+    );
+    assert!(
+        err.to_string()
+            .contains("Fetch more history or choose another branch"),
+        "the error tells onboarding how the user can recover"
+    );
+}
+
+#[test]
 fn works_without_git_identity() {
     for branch_matches_target in [true, false] {
         let Test { repo, ctx, .. } = &mut Test::default();
@@ -385,7 +426,8 @@ fn fills_missing_target_commit_id_from_existing_target_ref() {
 
     assert_eq!(
         ctx.project_meta().unwrap().target_commit_id,
-        Some(expected_target_id)
+        Some(expected_target_id),
+        "the missing target commit is repaired from the configured target"
     );
 }
 

--- a/packages/but-sdk/src/generated/graph/index.d.ts
+++ b/packages/but-sdk/src/generated/graph/index.d.ts
@@ -1400,10 +1400,10 @@ export declare function setReviewTemplate(projectId: string, templatePath: strin
  * managed workspace mode.
  *
  * This acquires exclusive worktree access from `ctx` before updating project metadata.
- * See [`but_workspace::init::set_target_ref_and_init_project()`] for details; notably the
- * target commit id is only computed when it wasn't set before, and an omitted
- * `push_remote` keeps the currently configured one. It deliberately records no oplog
- * snapshot - only project metadata changes, no repository state.
+ * See [`but_workspace::init::set_target_ref_and_init_project()`] for details. The target is always
+ * validated against `HEAD`; an unreachable stored target commit is replaced by their merge-base.
+ * An omitted `push_remote` preserves its current value. It deliberately records no oplog snapshot
+ * because only project metadata changes, not repository state.
  *
  * {@link ../../../../../crates/but-api/src/workspace.rs:273}
  */

--- a/packages/but-sdk/src/generated/linear/index.d.ts
+++ b/packages/but-sdk/src/generated/linear/index.d.ts
@@ -1400,10 +1400,10 @@ export declare function setReviewTemplate(projectId: string, templatePath: strin
  * managed workspace mode.
  *
  * This acquires exclusive worktree access from `ctx` before updating project metadata.
- * See [`but_workspace::init::set_target_ref_and_init_project()`] for details; notably the
- * target commit id is only computed when it wasn't set before, and an omitted
- * `push_remote` keeps the currently configured one. It deliberately records no oplog
- * snapshot - only project metadata changes, no repository state.
+ * See [`but_workspace::init::set_target_ref_and_init_project()`] for details. The target is always
+ * validated against `HEAD`; an unreachable stored target commit is replaced by their merge-base.
+ * An omitted `push_remote` preserves its current value. It deliberately records no oplog snapshot
+ * because only project metadata changes, not repository state.
  *
  * {@link ../../../../../crates/but-api/src/workspace.rs:273}
  */


### PR DESCRIPTION
## Context

Trigger: Desktop onboarding accepts a remote target whose history is unrelated to HEAD.

Impact: Initialization fails without actionable recovery and repeated clicks can resubmit the same target.

Fixes GB-1966

## Change

- classify missing or incomplete target history as an actionable precondition failure before initialization writes
- render that failure inline and keep target submission single-flight
- separate target mutation from navigation so a failed route transition can be retried without repeating the mutation
- preserve migration repair and existing target-commit behavior

FYI @PavelLaptev
