### PR TITLE
refactor(but-api): create snapshots when checking out branches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -844,7 +844,6 @@ dependencies = [
  "but-installer",
  "but-llm",
  "but-meta",
- "but-oplog",
  "but-path",
  "but-project-handle",
  "but-rebase",

--- a/crates/but-api/src/branch.rs
+++ b/crates/but-api/src/branch.rs
@@ -1033,7 +1033,7 @@ pub fn branch_create_with_perm(
         WorkspaceState::from_workspace_with_db(&ws, &mut meta, &repo, BTreeMap::new(), &mut db)?;
     drop((ws, repo, db, meta));
     if checkout_after_create {
-        let checkout = branch_checkout_with_perm(ctx, new_ref.clone(), perm)?;
+        let checkout = branch_checkout_with_perm_only(ctx, new_ref.clone(), perm)?;
         return Ok(BranchCreateResult {
             workspace: checkout.workspace,
             new_ref,
@@ -1146,7 +1146,7 @@ pub fn branch_remove_with_perm(
     if let Some(below) = move_head_to {
         // Land `HEAD` on the reference underneath. The old tip now sits above
         // the entrypoint and is no longer part of the downward projection.
-        branch_checkout_with_perm(ctx, below, perm)?;
+        branch_checkout_with_perm_only(ctx, below, perm)?;
     }
 
     let mut meta = ctx.meta()?;
@@ -1578,7 +1578,7 @@ pub fn branch_checkout_new_with_perm(
         branch
     };
 
-    branch_checkout_with_perm(ctx, branch, perm)
+    branch_checkout_with_perm_only(ctx, branch, perm)
 }
 
 /// Switch to the workspace reference
@@ -1589,41 +1589,75 @@ pub fn workspace_checkout(ctx: &mut but_ctx::Context) -> anyhow::Result<BranchCh
     workspace_checkout_with_perm(ctx, guard.write_permission())
 }
 
-/// Checks out the GitButler workspace reference under caller-held exclusive repository access.
+/// Switch to the workspace reference under caller-held exclusive repository access.
 pub fn workspace_checkout_with_perm(
     ctx: &mut but_ctx::Context,
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<BranchCheckoutResult> {
+    let snapshot_details = SnapshotDetails::new(OperationKind::SwitchToWorkspace);
+    let maybe_oplog_entry = but_oplog::UnmaterializedOplogSnapshot::from_details_with_perm(
+        ctx,
+        snapshot_details,
+        perm.read_permission(),
+        but_core::DryRun::No,
+    );
+
+    let result = workspace_checkout_with_perm_only(ctx, perm)?;
+
+    if let Some(snapshot) = maybe_oplog_entry {
+        _ = snapshot.commit(ctx, perm);
+    }
+
+    Ok(result)
+}
+
+/// Checks out the GitButler workspace reference under caller-held exclusive repository access.
+pub fn workspace_checkout_with_perm_only(
+    ctx: &mut but_ctx::Context,
+    perm: &mut RepoExclusive,
+) -> anyhow::Result<BranchCheckoutResult> {
     let workspace_ref: gix::refs::FullName = WORKSPACE_REF_NAME.try_into()?;
-    checkout_ref_with_perm(ctx, workspace_ref, perm)
+    branch_checkout_with_perm_only(ctx, workspace_ref, perm)
 }
 
 /// Checks out an existing local branch under caller-held exclusive repository
 /// access.
-///
-/// TODO: Decide whether branch checkout should record an oplog snapshot. For
-/// now this deliberately performs only the Git checkout and workspace
-/// projection rebuild.
 pub fn branch_checkout_with_perm(
     ctx: &mut but_ctx::Context,
     branch: gix::refs::FullName,
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<BranchCheckoutResult> {
-    if !branch.as_bstr().starts_with_str("refs/heads/") {
-        bail!(
-            "Can only check out local branches under refs/heads, got '{}'",
-            branch.as_bstr()
-        );
+    let snapshot_details = SnapshotDetails::new(OperationKind::SwitchBranch);
+    let maybe_oplog_entry = but_oplog::UnmaterializedOplogSnapshot::from_details_with_perm(
+        ctx,
+        snapshot_details,
+        perm.read_permission(),
+        but_core::DryRun::No,
+    );
+
+    let result = branch_checkout_with_perm_only(ctx, branch, perm)?;
+
+    if let Some(snapshot) = maybe_oplog_entry {
+        _ = snapshot.commit(ctx, perm);
     }
 
-    checkout_ref_with_perm(ctx, branch, perm)
+    Ok(result)
 }
 
-fn checkout_ref_with_perm(
+/// Checks out an existing local branch under caller-held exclusive repository
+/// access without creating an oplog entry.
+pub fn branch_checkout_with_perm_only(
     ctx: &mut but_ctx::Context,
     reference_name: gix::refs::FullName,
     perm: &mut RepoExclusive,
 ) -> anyhow::Result<BranchCheckoutResult> {
+    if !reference_name.as_bstr().starts_with_str("refs/heads/") {
+        bail!(
+            "Can only check out local branches under refs/heads, got '{}'",
+            reference_name.as_bstr()
+        );
+    }
+
     {
         let repo = ctx.repo.get()?;
         let current_head = repo
@@ -1914,7 +1948,7 @@ pub fn move_branch_with_perm(
     if let Some(new_tip) = new_tip
         && !is_dry_run
     {
-        let checkout = branch_checkout_with_perm(ctx, new_tip, perm)?;
+        let checkout = branch_checkout_with_perm_only(ctx, new_tip, perm)?;
         return Ok(MoveBranchResult {
             workspace: checkout.workspace,
         });

--- a/crates/but-api/tests/api/branch_checkout.rs
+++ b/crates/but-api/tests/api/branch_checkout.rs
@@ -99,13 +99,13 @@ fn checkout_returns_head_info_matching_fresh_head_info() -> anyhow::Result<()> {
 
         snapbox::assert_data_eq!(
             crate::support::repository_graph(&repo)?,
-            snapbox::str![["
+            snapbox::str![[r#"
 * b720e1f (sibling) sibling
 | * edd8381 (HEAD -> feature) feature
 |/  
-* 5374caf (origin/main, main) main
+* 5374caf (origin/main, main, gitbutler/target) main
 
-"]]
+"#]]
         );
     }
 

--- a/crates/but/Cargo.toml
+++ b/crates/but/Cargo.toml
@@ -74,8 +74,6 @@ but-comments.workspace = true
 but-db.workspace = true
 but-error.workspace = true
 
-but-oplog.workspace = true
-
 # What follows is *basically* newly written crates that are built on top of legacy,
 # so need some refactoring/rethinking to become usable.
 but-action = { workspace = true, optional = true }

--- a/crates/but/src/command/legacy/branch/new.rs
+++ b/crates/but/src/command/legacy/branch/new.rs
@@ -234,7 +234,7 @@ impl NewUnstackedBranchOperation {
         )?;
 
         if switch {
-            but_api::branch::branch_checkout_with_perm(ctx, new_ref.clone(), perm)?;
+            but_api::branch::branch_checkout_with_perm_only(ctx, new_ref.clone(), perm)?;
         }
 
         Ok(NewOutcome {
@@ -301,7 +301,7 @@ impl NewUnstackedBranchOperation {
                 },
             )?;
 
-            but_api::branch::branch_checkout_with_perm(ctx, new_ref.clone(), perm)?;
+            but_api::branch::branch_checkout_with_perm_only(ctx, new_ref.clone(), perm)?;
         } else if switch {
             drop(repo);
 
@@ -325,7 +325,7 @@ impl NewUnstackedBranchOperation {
                 },
             )?;
 
-            but_api::branch::branch_checkout_with_perm(ctx, new_ref.clone(), perm)?;
+            but_api::branch::branch_checkout_with_perm_only(ctx, new_ref.clone(), perm)?;
         } else {
             // if we're not on the target then enter a workspace and create the branch
 
@@ -469,7 +469,7 @@ impl NewStackedBranchOperation {
         )?;
 
         if checkout_after_create || switch {
-            but_api::branch::branch_checkout_with_perm(ctx, new_ref.clone(), perm)?;
+            but_api::branch::branch_checkout_with_perm_only(ctx, new_ref.clone(), perm)?;
         }
 
         Ok(NewOutcome {

--- a/crates/but/src/command/legacy/commit.rs
+++ b/crates/but/src/command/legacy/commit.rs
@@ -369,7 +369,7 @@ pub fn run(
     };
     if checkout_after_create && let Some(BranchNameTarget::New(branch_name)) = &outcome.branch_name
     {
-        but_api::branch::branch_checkout_with_perm(ctx, branch_name.clone(), perm)?;
+        but_api::branch::branch_checkout_with_perm_only(ctx, branch_name.clone(), perm)?;
     }
 
     Ok((outcome, ws))

--- a/crates/but/src/command/legacy/switch.rs
+++ b/crates/but/src/command/legacy/switch.rs
@@ -3,7 +3,6 @@ use but_core::{
     sync::{RepoExclusive, RepoShared},
 };
 use but_ctx::Context;
-use gitbutler_oplog::entry::{OperationKind, SnapshotDetails};
 use gix::refs::FullName;
 use serde::Serialize;
 
@@ -82,20 +81,7 @@ pub fn run(
                 repo.try_find_reference(WORKSPACE_REF_NAME)?.is_some()
             };
             if workspace_exists {
-                // TODO(david): why does `workspace_checkout_with_perm` not do this?
-                let snapshot_details = SnapshotDetails::new(OperationKind::SwitchToWorkspace);
-                let maybe_oplog_entry =
-                    but_oplog::UnmaterializedOplogSnapshot::from_details_with_perm(
-                        ctx,
-                        snapshot_details,
-                        perm.read_permission(),
-                        but_core::DryRun::No,
-                    );
                 but_api::branch::workspace_checkout_with_perm(ctx, perm)?;
-
-                if let Some(snapshot) = maybe_oplog_entry {
-                    _ = snapshot.commit(ctx, perm);
-                }
             } else {
                 but_api::legacy::virtual_branches::switch_back_to_workspace_with_perm(ctx, perm)?;
             }
@@ -103,20 +89,7 @@ pub fn run(
             Ok(SwitchOutcome::Workspace)
         }
         SwitchOperation::Branch { branch } => {
-            // TODO(david): why does `branch_checkout_with_perm` not do this?
-            let snapshot_details = SnapshotDetails::new(OperationKind::SwitchBranch);
-            let maybe_oplog_entry = but_oplog::UnmaterializedOplogSnapshot::from_details_with_perm(
-                ctx,
-                snapshot_details,
-                perm.read_permission(),
-                but_core::DryRun::No,
-            );
-
             but_api::branch::branch_checkout_with_perm(ctx, branch.clone(), perm)?;
-
-            if let Some(snapshot) = maybe_oplog_entry {
-                _ = snapshot.commit(ctx, perm);
-            }
 
             Ok(SwitchOutcome::Branch { branch })
         }

--- a/packages/but-sdk/src/generated/graph/index.d.ts
+++ b/packages/but-sdk/src/generated/graph/index.d.ts
@@ -136,7 +136,7 @@ export declare function apply(projectId: string, existingBranch: string): Promis
  * `dry_run` is enabled, the returned workspace previews the integration
  * result and no oplog entry is persisted.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1788}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1822}
  */
 export declare function applyBranchIntegration(projectId: string, branch: string, integration: InteractiveIntegration, dryRun: boolean): Promise<IntegrateBranchResult>
 
@@ -216,7 +216,7 @@ export declare function branchDetails(projectId: string, branchName: string, rem
  * diff is computed against the current workspace state. For lower-level
  * implementation details, see [`but_workspace::ui::diff::changes_in_branch()`].
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1685}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1719}
  */
 export declare function branchDiff(projectId: string, branch: string): Promise<TreeChanges>
 
@@ -249,7 +249,7 @@ export declare function branchLand(projectId: string, branch: string, noFf: bool
  * workspace-related ones. Ahead-counts are relative to the
  * project's configured target branch, which clients know from the project APIs.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1702}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1736}
  */
 export declare function branchList(projectId: string): Promise<Array<ListedStack>>
 
@@ -818,7 +818,7 @@ export declare function getGlUser(account: GitlabAccountIdentifier): Promise<Git
 /**
  * Get the initial upstream integration script for `branch`.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1764}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1798}
  */
 export declare function getInitialBranchIntegration(projectId: string, branch: string, strategy: BranchIntegrationStrategy | null): Promise<InitialBranchIntegration>
 
@@ -1132,7 +1132,7 @@ export declare function mergeReview(projectId: string, reviewId: number, mergeMe
  * `dry_run` is enabled, the returned workspace previews the move and no oplog
  * entry is persisted.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1845}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1879}
  */
 export declare function moveBranch(projectId: string, subjectBranch: string, targetBranch: string, dryRun: boolean): Promise<MoveBranchResult>
 
@@ -1476,7 +1476,7 @@ export declare function storeGitlabPat(accessToken: string): Promise<GitlabAuthS
  * `dry_run` is enabled, the returned workspace previews the tear-off and no
  * oplog entry is persisted.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1932}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1966}
  */
 export declare function tearOffBranch(projectId: string, subjectBranch: string, dryRun: boolean): Promise<MoveBranchResult>
 

--- a/packages/but-sdk/src/generated/linear/index.d.ts
+++ b/packages/but-sdk/src/generated/linear/index.d.ts
@@ -136,7 +136,7 @@ export declare function apply(projectId: string, existingBranch: string): Promis
  * `dry_run` is enabled, the returned workspace previews the integration
  * result and no oplog entry is persisted.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1788}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1822}
  */
 export declare function applyBranchIntegration(projectId: string, branch: string, integration: InteractiveIntegration, dryRun: boolean): Promise<IntegrateBranchResult>
 
@@ -216,7 +216,7 @@ export declare function branchDetails(projectId: string, branchName: string, rem
  * diff is computed against the current workspace state. For lower-level
  * implementation details, see [`but_workspace::ui::diff::changes_in_branch()`].
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1685}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1719}
  */
 export declare function branchDiff(projectId: string, branch: string): Promise<TreeChanges>
 
@@ -249,7 +249,7 @@ export declare function branchLand(projectId: string, branch: string, noFf: bool
  * workspace-related ones. Ahead-counts are relative to the
  * project's configured target branch, which clients know from the project APIs.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1702}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1736}
  */
 export declare function branchList(projectId: string): Promise<Array<ListedStack>>
 
@@ -818,7 +818,7 @@ export declare function getGlUser(account: GitlabAccountIdentifier): Promise<Git
 /**
  * Get the initial upstream integration script for `branch`.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1764}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1798}
  */
 export declare function getInitialBranchIntegration(projectId: string, branch: string, strategy: BranchIntegrationStrategy | null): Promise<InitialBranchIntegration>
 
@@ -1132,7 +1132,7 @@ export declare function mergeReview(projectId: string, reviewId: number, mergeMe
  * `dry_run` is enabled, the returned workspace previews the move and no oplog
  * entry is persisted.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1845}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1879}
  */
 export declare function moveBranch(projectId: string, subjectBranch: string, targetBranch: string, dryRun: boolean): Promise<MoveBranchResult>
 
@@ -1476,7 +1476,7 @@ export declare function storeGitlabPat(accessToken: string): Promise<GitlabAuthS
  * `dry_run` is enabled, the returned workspace previews the tear-off and no
  * oplog entry is persisted.
  *
- * {@link ../../../../../crates/but-api/src/branch.rs:1932}
+ * {@link ../../../../../crates/but-api/src/branch.rs:1966}
  */
 export declare function tearOffBranch(projectId: string, subjectBranch: string, dryRun: boolean): Promise<MoveBranchResult>
 


### PR DESCRIPTION
Instead of manually creating snapshots in the CLI this now does it in but-api instead. That way Lite gets the same behavior.