### PR TITLE
But acts as if it was run in the main worktree

### DIFF
--- a/crates/but-ctx/src/lib.rs
+++ b/crates/but-ctx/src/lib.rs
@@ -352,7 +352,7 @@ impl Context {
         repo_open_mode: RepoOpenMode,
     ) -> anyhow::Result<Context> {
         let directory = directory.as_ref();
-        let gitdir = gix::discover(directory)?.git_dir().to_owned();
+        let gitdir = discover_main_repo(directory)?.git_dir().to_owned();
         let repo = open_repo(&gitdir, repo_open_mode)?;
         Self::from_repo_with_legacy_support(repo, repo_open_mode)
     }
@@ -365,7 +365,7 @@ impl Context {
         repo_open_mode: RepoOpenMode,
     ) -> anyhow::Result<Context> {
         let directory = directory.as_ref();
-        let gitdir = gix::discover(directory)?.git_dir().to_owned();
+        let gitdir = discover_main_repo(directory)?.git_dir().to_owned();
         let repo = open_repo(&gitdir, repo_open_mode)?;
         Self::from_repo_with_legacy_support_and_channel(repo, repo_open_mode, channel)
     }
@@ -1055,6 +1055,16 @@ fn new_ondemand_repo(gitdir: PathBuf, repo_open_mode: RepoOpenMode) -> OnDemand<
             repo
         })
     })
+}
+
+/// Discover the Git repository containing `directory`, resolving a linked worktree to the repository
+/// of its main worktree so that callers see the same workspace no matter which checkout they run in.
+pub fn discover_main_repo(directory: impl AsRef<Path>) -> anyhow::Result<gix::Repository> {
+    let repo = gix::discover(directory)?;
+    if repo.git_dir() == repo.common_dir() {
+        return Ok(repo);
+    }
+    Ok(repo.main_repo()?)
 }
 
 fn open_repo(gitdir: &Path, repo_open_mode: RepoOpenMode) -> anyhow::Result<gix::Repository> {

--- a/crates/but/skill/SKILL.md
+++ b/crates/but/skill/SKILL.md
@@ -53,7 +53,7 @@ The first token on each `but diff` / `but status` line is that line's ID. When a
 
 ## Non-Negotiable Rules
 
-1. Use `but` for all write operations. Never run `git add`, `git commit`, `git push`, `git checkout`, `git merge`, `git rebase`, `git stash`, or `git cherry-pick`. If the user says a `git` write command, translate it to `but` and run that. Exception: a worktree-local Git commit when `but commit` reports that linked worktrees are unsupported. Never run `but setup` from a linked worktree.
+1. Use `but` for all write operations. Never run `git add`, `git commit`, `git push`, `git checkout`, `git merge`, `git rebase`, `git stash`, or `git cherry-pick`. If the user says a `git` write command, translate it to `but` and run that. Running from a linked worktree acts on the main workspace, the same as running from the main checkout; address that worktree's own changes as `<worktree>:@`. Never run `but setup` from a linked worktree.
 2. Mutation commands print their result without appending workspace status. Add `--status-after` only when the next step needs resulting workspace IDs or details; otherwise trust the mutation result and do not run a verification status/diff.
 3. Branches marked `(merged upstream)` have landed; run `but pull` to remove them, or start new work on another branch. `push` and mutations (`commit`, `amend`, `squash`, `uncommit`, `reword`, `move`) refuse landed branches and commits, `absorb` skips them with a notice, and `commit` skips them when picking a default target.
 4. In non-interactive CLI workflows, do not narrate progress between routine commands. Execute the needed `but` commands and give a concise final summary.

--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -195,7 +195,7 @@ but commit --empty -b <branch> -m "message"  # Insert an empty commit
 
 **Important:** `but commit -b <branch> -m "msg"` with no IDs commits ALL uncommitted changes. Pass IDs to commit only specific files or hunks.
 
-`but commit` is not supported from linked worktrees. Use Git directly for the worktree-local commit, and do not run `but setup` there.
+Running `but commit` from inside a linked worktree acts on the main workspace, exactly as from the main checkout: bare `but commit` takes the main worktree's changes, and `but commit <worktree>:@` takes that worktree's own (experimental worktree flag). Do not run `but setup` from a linked worktree.
 
 **Committing specific files or hunks:** Start with `but diff` for selective dirty commits, then pass CLI IDs as positional arguments:
 - **File IDs** from `but diff` or `but status -fv`: commits entire files

--- a/crates/but/src/command/agent/mod.rs
+++ b/crates/but/src/command/agent/mod.rs
@@ -244,7 +244,7 @@ struct RepoInfo {
 }
 
 fn discover_repo(current_dir: &Path) -> Option<RepoInfo> {
-    let repo = gix::discover(current_dir).ok()?;
+    let repo = but_ctx::discover_main_repo(current_dir).ok()?;
     let root = repo.workdir()?.to_path_buf();
     let needs_setup = repo_needs_setup(&root);
     Some(RepoInfo { root, needs_setup })
@@ -776,7 +776,8 @@ fn print_setup_complete(out: &mut OutputChannel) -> Result<()> {
 
 #[cfg(feature = "legacy")]
 fn run_but_setup(current_dir: &Path, out: &mut OutputChannel) -> Result<()> {
-    let repo = gix::discover(current_dir).context("No git repository found for `but setup`.")?;
+    let repo = but_ctx::discover_main_repo(current_dir)
+        .context("No git repository found for `but setup`.")?;
     let mut ctx = but_ctx::Context::from_repo_with_settings(repo, crate::app_settings()?.clone())?;
     let mut guard = ctx.exclusive_worktree_access();
     crate::command::legacy::setup::repo(&mut ctx, current_dir, out, guard.write_permission())

--- a/crates/but/src/command/skill/freshness.rs
+++ b/crates/but/src/command/skill/freshness.rs
@@ -99,7 +99,7 @@ fn agent_skill_freshness_check() -> Option<AgentSkillNotice> {
 /// Report a missing skill before normal agent-driven commands.
 fn agent_skill_install_hint(current_dir: &std::path::Path) -> Option<AgentSkillNotice> {
     let agent = detect_agent::detect()?;
-    let workdir = gix::discover(current_dir)
+    let workdir = but_ctx::discover_main_repo(current_dir)
         .ok()
         .and_then(|repo| repo.workdir().map(std::path::Path::to_path_buf));
     let installations = agent_skill_installations(agent, workdir.as_deref())?;

--- a/crates/but/src/setup.rs
+++ b/crates/but/src/setup.rs
@@ -106,7 +106,7 @@ pub fn init_ctx(
 ) -> anyhow::Result<Context> {
     let app_settings = crate::app_settings()?;
     // lets try to get the repo from the current directory
-    let repo = match gix::discover(&args.current_dir) {
+    let repo = match but_ctx::discover_main_repo(&args.current_dir) {
         Ok(repo) => repo,
         Err(_) => anyhow::bail!(
             "No git repository found at {}\nPlease run 'but setup' to initialize the project.",

--- a/crates/but/tests/but/command/status.rs
+++ b/crates/but/tests/but/command/status.rs
@@ -1803,12 +1803,10 @@ second work
 "#]]);
 }
 
-/// `but status` refuses to run from inside a linked worktree. This gate is what keeps the
-/// lane rendering sound: IDs are minted from the main checkout only, so a status that ran
-/// here would list worktrees without IDs and have to skip their lanes. Whoever lifts this
-/// restriction must revisit how [`worktree_lanes`] get their IDs.
+/// Running from inside a linked worktree resolves to the main worktree, so the workspace and
+/// its IDs are the same as they are from the main checkout.
 #[test]
-fn status_from_inside_a_linked_worktree_is_refused() {
+fn status_from_inside_a_linked_worktree_shows_the_main_workspace() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
     env.setup_metadata(&["A", "B"]);
     enable_worktree_manipulation(&env);
@@ -1832,10 +1830,26 @@ fn status_from_inside_a_linked_worktree_is_refused() {
     env.but("status")
         .current_dir(wt.join("wt-inside"))
         .assert()
-        .failure()
-        .stdout_eq(snapbox::str![])
-        .stderr_eq(snapbox::str![[r#"
-Error: non-main worktrees are not supported
+        .success()
+        .stderr_eq(snapbox::str![])
+        .stdout_eq(snapbox::str![[r#"
+╭┄ @ [uncommitted] (no changes)
+┊
+┊╭┄ g0 [A]
+┊┊
+┊┊╭┄ wt:@ {worktree uncommitted} (no changes)
+┊┊├┄ wt {wt-inside}
+┊├╯
+┊●   tpm add A
+├╯
+┊
+┊╭┄ h0 [B]
+┊●   lrm add B
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
 
 "#]]);
 }


### PR DESCRIPTION
<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #15703 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #15702
<!-- GitButler Footer Boundary Bottom -->