### PR TITLE
Classify GitHub organization SAML restrictions

### DIFF
--- a/apps/desktop/src/components/projectSettings/ForgeForm.svelte
+++ b/apps/desktop/src/components/projectSettings/ForgeForm.svelte
@@ -3,6 +3,7 @@
 	import GitHubAccountBadge from "$components/forge/GitHubAccountBadge.svelte";
 	import GitLabAccountBadge from "$components/forge/GitLabAccountBadge.svelte";
 	import ForgeAccountConfig from "$components/projectSettings/ForgeAccountConfig.svelte";
+	import GitHubOrgRestrictionNotice from "$components/projectSettings/GitHubOrgRestrictionNotice.svelte";
 	import { GIT_CONFIG_SERVICE } from "$lib/config/gitConfigService";
 	import { isNormalizedError } from "$lib/error/normalizedError";
 	import {
@@ -25,7 +26,7 @@
 	import { PROJECTS_SERVICE } from "$lib/project/projectsService";
 	import { inject } from "@gitbutler/core/context";
 	import { reactive } from "@gitbutler/shared/reactiveUtils.svelte";
-	import { CardGroup, InfoMessage, Link, Select, SelectItem } from "@gitbutler/ui";
+	import { CardGroup, Select, SelectItem } from "@gitbutler/ui";
 
 	import type { Project } from "$lib/project/project";
 	import type {
@@ -79,8 +80,8 @@
 	const listingService = inject(LISTING_SERVICE);
 	const listingState = $derived(listingService.listingState(projectId));
 	const listingError = $derived(listingState.result.error);
-	const githubOrgRestricted = $derived(
-		isNormalizedError(listingError) && listingError.code === "GitHubOrgOAuthRestricted",
+	const listingErrorCode = $derived(
+		isNormalizedError(listingError) ? listingError.code : undefined,
 	);
 
 	// GitLab hooks
@@ -261,22 +262,7 @@
 			requestType="pull request"
 		>
 			{#snippet notice()}
-				{#if githubOrgRestricted}
-					<InfoMessage style="warning" filled outlined={false}>
-						{#snippet title()}
-							Restricted by a GitHub organization
-						{/snippet}
-						{#snippet content()}
-							An organization that owns this repository has blocked the GitButler OAuth app, so pull
-							requests can't be listed or created right now. Ask an organization owner to approve
-							the app, or connect an account that uses a personal access token — see the
-							<Link
-								href="https://docs.gitbutler.com/features/forge-integration/github-integration?utm_source=gitbutler-app&utm_medium=settings-banner&utm_campaign=org-oauth-restriction#connect-a-github-account"
-								>docs</Link
-							>.
-						{/snippet}
-					</InfoMessage>
-				{/if}
+				<GitHubOrgRestrictionNotice errorCode={listingErrorCode} />
 			{/snippet}
 		</ForgeAccountConfig>
 	{/if}

--- a/apps/desktop/src/components/projectSettings/GitHubOrgRestrictionNotice.svelte
+++ b/apps/desktop/src/components/projectSettings/GitHubOrgRestrictionNotice.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+	import { InfoMessage, Link } from "@gitbutler/ui";
+
+	import type { Code } from "@gitbutler/but-sdk";
+
+	const { errorCode }: { errorCode: Code | undefined } = $props();
+</script>
+
+{#if errorCode === "GitHubOrgOAuthRestricted"}
+	<InfoMessage style="warning" filled outlined={false}>
+		{#snippet title()}
+			Restricted by a GitHub organization
+		{/snippet}
+		{#snippet content()}
+			An organization that owns this repository has blocked the GitButler OAuth app, so pull
+			requests can't be listed or created right now. Ask an organization owner to approve the app,
+			or connect an account that uses a personal access token — see the
+			<Link
+				href="https://docs.gitbutler.com/features/forge-integration/github-integration?utm_source=gitbutler-app&utm_medium=settings-banner&utm_campaign=org-oauth-restriction#connect-a-github-account"
+				>docs</Link
+			>.
+		{/snippet}
+	</InfoMessage>
+{:else if errorCode === "GitHubOrgSamlRestricted"}
+	<InfoMessage style="warning" filled outlined={false}>
+		{#snippet title()}
+			GitHub organization requires SAML SSO
+		{/snippet}
+		{#snippet content()}
+			This repository's organization requires SAML SSO, but the selected GitHub credential isn't
+			authorized for it. In GitHub, authorize the GitButler OAuth app or your personal access token
+			for the organization, then try again.
+		{/snippet}
+	</InfoMessage>
+{/if}

--- a/apps/desktop/src/components/projectSettings/GitHubOrgRestrictionNotice.svelte.test.ts
+++ b/apps/desktop/src/components/projectSettings/GitHubOrgRestrictionNotice.svelte.test.ts
@@ -1,0 +1,39 @@
+import GitHubOrgRestrictionNotice from "$components/projectSettings/GitHubOrgRestrictionNotice.svelte";
+import { cleanup, render, screen } from "@testing-library/svelte";
+import { afterEach, describe, expect, test } from "vitest";
+
+import type { Code } from "@gitbutler/but-sdk";
+
+afterEach(cleanup);
+
+function renderNotice(errorCode: Code | undefined) {
+	return render(GitHubOrgRestrictionNotice, { props: { errorCode } });
+}
+
+describe("GitHubOrgRestrictionNotice", () => {
+	test("preserves the OAuth restriction notice and docs link", () => {
+		renderNotice("GitHubOrgOAuthRestricted");
+
+		expect(screen.getByText("Restricted by a GitHub organization")).toBeTruthy();
+		expect(screen.getByRole("link", { name: /docs/ }).getAttribute("href")).toContain(
+			"utm_campaign=org-oauth-restriction",
+		);
+		expect(screen.queryByText("GitHub organization requires SAML SSO")).toBeNull();
+	});
+
+	test("renders actionable SAML guidance for the dedicated code", () => {
+		renderNotice("GitHubOrgSamlRestricted");
+
+		expect(screen.getByText("GitHub organization requires SAML SSO")).toBeTruthy();
+		expect(
+			screen.getByText(/authorize the GitButler OAuth app or your personal access token/),
+		).toBeTruthy();
+		expect(screen.queryByText("Restricted by a GitHub organization")).toBeNull();
+	});
+
+	test("renders no organization notice for unrelated errors", () => {
+		const { container } = renderNotice("Unknown");
+
+		expect(container.textContent).toBe("");
+	});
+});

--- a/apps/desktop/src/lib/error/errorClassification.test.ts
+++ b/apps/desktop/src/lib/error/errorClassification.test.ts
@@ -141,6 +141,25 @@ describe("classify", () => {
 			expect(result.terminal).toBe(true);
 			expect(result.userMessage).toContain("permission");
 		});
+
+		test("GitHubOrgSamlRestricted is terminal with credential-neutral SSO guidance", () => {
+			const error = new IpcError(
+				{
+					message: "This GitHub organization requires SAML SSO authorization.",
+					code: "GitHubOrgSamlRestricted",
+				},
+				"list_reviews",
+			);
+			const result = classify(error);
+
+			expect(result.code).toBe("GitHubOrgSamlRestricted");
+			expect(result.severity).toBe("error");
+			expect(result.terminal).toBe(true);
+			expect(result.title).toBe("GitHub SAML SSO Authorization Required");
+			expect(result.userMessage).toContain("OAuth app");
+			expect(result.userMessage).toContain("personal access token");
+			expect(result.userMessage).toContain("then try again");
+		});
 	});
 
 	describe("default severity", () => {

--- a/apps/desktop/src/lib/error/errorClassification.ts
+++ b/apps/desktop/src/lib/error/errorClassification.ts
@@ -157,6 +157,13 @@ Your GitHub token appears expired. Please log out and back in to refresh it. (Se
 	`,
 	},
 	GitHubOrgOAuthRestricted: GH_ORG_AUTH_CLASSIFICATION,
+	GitHubOrgSamlRestricted: {
+		severity: "error",
+		terminal: true,
+		title: "GitHub SAML SSO Authorization Required",
+		userMessage:
+			"This GitHub organization requires SAML SSO. Authorize the GitButler OAuth app on the organization's SSO page, or authorize your personal access token in GitHub's token SSO settings, then try again.",
+	},
 	/**
 	 * The GitHub token can't read the requested resource — a fine-grained
 	 * PAT missing a read permission such as Checks. Terminal until the

--- a/crates/but-api/src/json.rs
+++ b/crates/but-api/src/json.rs
@@ -395,6 +395,22 @@ mod error {
         }
 
         #[test]
+        fn static_context_hides_saml_authorization_url() {
+            const MESSAGE: &str = "Authorize this GitHub credential for SAML SSO, then try again.";
+            let err = anyhow!("HTTP 403 Forbidden")
+                .context(r#"Resource protected by organization SAML enforcement. Visit https://example.invalid/orgs/example/sso?authorization_request=redacted"#)
+                .context(Context::new_static(Code::GitHubOrgSamlRestricted, MESSAGE))
+                .context("Failed to load a pull request");
+            let serialized = json(err);
+            let expected = format!(r#"{{"code":"GitHubOrgSamlRestricted","message":"{MESSAGE}"}}"#);
+            assert_eq!(serialized, expected, "the API sends only static guidance");
+            let leaked = ["authorization_request", "/sso?"]
+                .iter()
+                .any(|detail| serialized.contains(detail));
+            assert!(!leaked, "per-request SSO details must stay private");
+        }
+
+        #[test]
         fn find_context_without_message() {
             let err = anyhow!("err msg").context(Context::from(Code::Validation));
             assert_eq!(

--- a/crates/but-error/src/lib.rs
+++ b/crates/but-error/src/lib.rs
@@ -179,6 +179,10 @@ pub enum Code {
     /// blocked the GitButler OAuth app. Terminal until the org approves the
     /// app or the user switches credentials — retrying won't help.
     GitHubOrgOAuthRestricted,
+    /// A GitHub organization requires SAML SSO authorization for the
+    /// current OAuth or personal access token. Terminal until the user
+    /// authorizes the credential for the organization.
+    GitHubOrgSamlRestricted,
     /// GitHub returned 403 "Resource not accessible by personal access
     /// token" — the token works but lacks a read permission such as Checks.
     /// Terminal until the user grants the permission or reconnects with

--- a/crates/but-github/src/pr.rs
+++ b/crates/but-github/src/pr.rs
@@ -2,6 +2,7 @@ use anyhow::{Context as _, Result};
 
 use crate::client::{GitHubClient, HttpStatusError};
 
+const GITHUB_ORG_SAML_RESTRICTION_MESSAGE: &str = "This GitHub organization requires SAML SSO. Authorize the GitButler OAuth app on the organization's SSO page, or authorize your personal access token in GitHub's token SSO settings, then try again.";
 pub async fn list(
     preferred_account: Option<&crate::GithubAccountIdentifier>,
     owner: &str,
@@ -55,9 +56,8 @@ pub async fn list_for_commit(
         .context("Failed to list pull requests for commit")
 }
 
-/// Tag transport / auth failures with a `but_error::Code` so the desktop
-/// can present them appropriately (silent for offline, re-auth hint for 401).
-/// Only applied to read paths — mutations should still surface failures.
+/// Tag selected transport, auth, and permission failures with a
+/// `but_error::Code` so callers can present actionable guidance.
 pub(crate) fn classify_forge_error(err: anyhow::Error) -> anyhow::Error {
     if let Some(reqwest_err) = err.downcast_ref::<reqwest::Error>()
         && crate::is_network_error(reqwest_err)
@@ -74,35 +74,31 @@ pub(crate) fn classify_forge_error(err: anyhow::Error) -> anyhow::Error {
                 "GitHub authentication failed.",
             ));
         }
-        // GitHub explains an organization-level OAuth App block in the 403
-        // body, which `ensure_success` keeps as context in the chain.
-        if http_err.status == reqwest::StatusCode::FORBIDDEN
-            && err
-                .chain()
-                .any(|cause| cause.to_string().contains("OAuth App access restrictions"))
-        {
-            return err.context(but_error::Context::new_static(
-                but_error::Code::GitHubOrgOAuthRestricted,
-                "A GitHub organization has restricted access for the GitButler OAuth app. Ask an organization owner to approve it, or authenticate with a personal access token instead.",
-            ));
-        }
-        // "Resource not accessible by personal access token": the token
-        // works but lacks a permission, e.g. a fine-grained PAT without
-        // Checks read access. Terminal until the user grants it. Other
-        // permission-shaped 403 wordings (integration tokens, SAML
-        // enforcement) deliberately stay `Unknown` until telemetry shows
-        // they actually occur.
-        if http_err.status == reqwest::StatusCode::FORBIDDEN
-            && err.chain().any(|cause| {
-                cause
-                    .to_string()
-                    .contains("Resource not accessible by personal access token")
-            })
-        {
-            return err.context(but_error::Context::new_static(
-                but_error::Code::GitHubInsufficientPermissions,
-                "Your GitHub token doesn't have permission to read this. Grant the token the missing repository read permission (such as Checks), or reconnect GitHub with different credentials.",
-            ));
+        if http_err.status == reqwest::StatusCode::FORBIDDEN {
+            // `ensure_success` keeps GitHub's response body in the chain.
+            let contains =
+                |needle: &str| err.chain().any(|cause| cause.to_string().contains(needle));
+            let context = if contains("OAuth App access restrictions") {
+                Some(but_error::Context::new_static(
+                    but_error::Code::GitHubOrgOAuthRestricted,
+                    "A GitHub organization has restricted access for the GitButler OAuth app. Ask an organization owner to approve it, or authenticate with a personal access token instead.",
+                ))
+            } else if contains("Resource protected by organization SAML enforcement") {
+                Some(but_error::Context::new_static(
+                    but_error::Code::GitHubOrgSamlRestricted,
+                    GITHUB_ORG_SAML_RESTRICTION_MESSAGE,
+                ))
+            } else if contains("Resource not accessible by personal access token") {
+                Some(but_error::Context::new_static(
+                    but_error::Code::GitHubInsufficientPermissions,
+                    "Your GitHub token doesn't have permission to read this. Grant the token the missing repository read permission (such as Checks), or reconnect GitHub with different credentials.",
+                ))
+            } else {
+                None
+            };
+            if let Some(context) = context {
+                return err.context(context);
+            }
         }
     }
     err
@@ -511,6 +507,63 @@ mod tests {
     }
 
     #[test]
+    fn saml_enforcement_403_gets_dedicated_code_and_static_message() {
+        let bodies = [
+            r#"403 Forbidden: {"message":"Resource protected by organization SAML enforcement. You must grant your OAuth token access to this organization."}"#,
+            r#"403 Forbidden: {"message":"Resource protected by organization SAML enforcement. You must grant your OAuth token access to an organization within this enterprise. Visit https://example.invalid/orgs/example/sso?authorization_request=redacted and try again."}"#,
+            // Compatibility fixture for GitHub's PAT-token wording.
+            r#"403 Forbidden: {"message":"Resource protected by organization SAML enforcement. You must grant your Personal Access token access to this organization."}"#,
+        ];
+        for body in bodies {
+            let err = classify_forge_error(http_error(reqwest::StatusCode::FORBIDDEN, body));
+            let ctx = err
+                .downcast_ref::<but_error::Context>()
+                .expect("a SAML enforcement 403 needs a frontend context");
+            assert_eq!(
+                (ctx.code, ctx.message.as_deref()),
+                (
+                    but_error::Code::GitHubOrgSamlRestricted,
+                    Some(GITHUB_ORG_SAML_RESTRICTION_MESSAGE)
+                ),
+                "SAML responses need a dedicated code and static guidance"
+            );
+            let message = ctx.message.as_deref().expect("SAML guidance is present");
+            assert!(
+                !["authorization_request", "/sso?"]
+                    .iter()
+                    .any(|detail| message.contains(detail)),
+                "the classifier must discard per-request SSO details"
+            );
+        }
+    }
+
+    #[test]
+    fn saml_phrase_requires_reqwest_http_403() {
+        let body = r#"Resource protected by organization SAML enforcement. You must authorize this credential."#;
+        let code = |err: anyhow::Error| {
+            classify_forge_error(err)
+                .downcast_ref::<but_error::Context>()
+                .map(|ctx| ctx.code)
+        };
+        assert_eq!(
+            code(http_error(reqwest::StatusCode::UNAUTHORIZED, body)),
+            Some(but_error::Code::GitHubTokenExpired),
+            "401 retains its authentication classification"
+        );
+        assert_eq!(
+            code(http_error(reqwest::StatusCode::NOT_FOUND, body)),
+            None,
+            "a phrase-bearing 404 stays unclassified"
+        );
+        // GraphQL errors returned with HTTP 200 have no HttpStatusError.
+        assert_eq!(
+            code(anyhow::anyhow!(body)),
+            None,
+            "GraphQL 200 errors stay outside the status classifier"
+        );
+    }
+
+    #[test]
     fn pat_permission_403_gets_dedicated_code() {
         let err = classify_forge_error(http_error(
             reqwest::StatusCode::FORBIDDEN,
@@ -531,6 +584,7 @@ mod tests {
         for body in [
             r#"403 Forbidden: {"message":"Resource not accessible by integration"}"#,
             r#"403 Forbidden: {"message":"API rate limit exceeded for user ID 1."}"#,
+            r#"403 Forbidden: {"message":"See the SAML setup guide","documentation_url":"https://example.invalid/docs/saml-enforcement"}"#,
             r#"403 Forbidden: {"message":"Repository access blocked"}"#,
         ] {
             let err = classify_forge_error(http_error(reqwest::StatusCode::FORBIDDEN, body));

--- a/packages/but-sdk/src/generated/graph/index.d.ts
+++ b/packages/but-sdk/src/generated/graph/index.d.ts
@@ -2388,7 +2388,7 @@ export type Claude = {
  *
  * In practice, it should match its [frontend counterpart](https://github.com/gitbutlerapp/gitbutler/blob/fa973fd8f1ae8807621f47601803d98b8a9cf348/app/src/lib/backend/ipc.ts#L5).
  */
-export type Code = "Validation" | "RepoOwnership" | "ProjectGitAuth" | "DefaultTargetNotFound" | "CommitSigningFailed" | "CommitMergeConflictFailure" | "ProjectMissing" | "AuthorMissing" | "BranchNotFound" | "SecretKeychainNotFound" | "MissingLoginKeychain" | "GitForcePushProtection" | "NetworkError" | "ProjectDatabaseIncompatible" | "DefaultTerminalNotFound" | "Unknown" | "GitNonFastForward" | "CliInstallCancelled" | "GitHubTokenExpired" | "GitLabUnauthorized" | "GitLabForbidden" | "GitHubOrgOAuthRestricted" | "GitHubInsufficientPermissions" | "ForgeNotAuthenticated" | "PreconditionFailed" | "EditorExitedWithNonZeroStatus";
+export type Code = "Validation" | "RepoOwnership" | "ProjectGitAuth" | "DefaultTargetNotFound" | "CommitSigningFailed" | "CommitMergeConflictFailure" | "ProjectMissing" | "AuthorMissing" | "BranchNotFound" | "SecretKeychainNotFound" | "MissingLoginKeychain" | "GitForcePushProtection" | "NetworkError" | "ProjectDatabaseIncompatible" | "DefaultTerminalNotFound" | "Unknown" | "GitNonFastForward" | "CliInstallCancelled" | "GitHubTokenExpired" | "GitLabUnauthorized" | "GitLabForbidden" | "GitHubOrgOAuthRestricted" | "GitHubOrgSamlRestricted" | "GitHubInsufficientPermissions" | "ForgeNotAuthenticated" | "PreconditionFailed" | "EditorExitedWithNonZeroStatus";
 
 /** Commit that is part of a legacy stack branch and contains state derived in relation to it. */
 export type Commit = {

--- a/packages/but-sdk/src/generated/linear/index.d.ts
+++ b/packages/but-sdk/src/generated/linear/index.d.ts
@@ -2388,7 +2388,7 @@ export type Claude = {
  *
  * In practice, it should match its [frontend counterpart](https://github.com/gitbutlerapp/gitbutler/blob/fa973fd8f1ae8807621f47601803d98b8a9cf348/app/src/lib/backend/ipc.ts#L5).
  */
-export type Code = "Validation" | "RepoOwnership" | "ProjectGitAuth" | "DefaultTargetNotFound" | "CommitSigningFailed" | "CommitMergeConflictFailure" | "ProjectMissing" | "AuthorMissing" | "BranchNotFound" | "SecretKeychainNotFound" | "MissingLoginKeychain" | "GitForcePushProtection" | "NetworkError" | "ProjectDatabaseIncompatible" | "DefaultTerminalNotFound" | "Unknown" | "GitNonFastForward" | "CliInstallCancelled" | "GitHubTokenExpired" | "GitLabUnauthorized" | "GitLabForbidden" | "GitHubOrgOAuthRestricted" | "GitHubInsufficientPermissions" | "ForgeNotAuthenticated" | "PreconditionFailed" | "EditorExitedWithNonZeroStatus";
+export type Code = "Validation" | "RepoOwnership" | "ProjectGitAuth" | "DefaultTargetNotFound" | "CommitSigningFailed" | "CommitMergeConflictFailure" | "ProjectMissing" | "AuthorMissing" | "BranchNotFound" | "SecretKeychainNotFound" | "MissingLoginKeychain" | "GitForcePushProtection" | "NetworkError" | "ProjectDatabaseIncompatible" | "DefaultTerminalNotFound" | "Unknown" | "GitNonFastForward" | "CliInstallCancelled" | "GitHubTokenExpired" | "GitLabUnauthorized" | "GitLabForbidden" | "GitHubOrgOAuthRestricted" | "GitHubOrgSamlRestricted" | "GitHubInsufficientPermissions" | "ForgeNotAuthenticated" | "PreconditionFailed" | "EditorExitedWithNonZeroStatus";
 
 /** Commit that is part of a legacy stack branch and contains state derived in relation to it. */
 export type Commit = {


### PR DESCRIPTION
## Context

Trigger: open GitHub review details for a repository whose organization enforces SAML SSO while the selected OAuth or personal access token is not authorized for that organization.

Symptom: review reads stay unclassified, repeat generic failures, and can carry a per-request SSO authorization URL through the error boundary instead of presenting stable remediation.

## Change

Classify GitHub's SAML-enforcement 403 response with a dedicated error code and URL-free backend message. Desktop now presents terminal, token-agnostic SSO guidance while preserving the existing OAuth-restriction and permission-error behavior.

FYI @PavelLaptev
