### PR TITLE
Fold the unapply-v3-pgm feature flag into single-branch mode

### DIFF
--- a/crates/but-api/src/legacy/virtual_branches.rs
+++ b/crates/but-api/src/legacy/virtual_branches.rs
@@ -516,9 +516,10 @@ fn assigned_diffspec_for_stack(
 
 /// Unapply a stack through the newer workspace metadata implementation.
 ///
-/// This deliberately keeps the workspace reference and workspace merge commit in
-/// place for compatibility with the legacy API surface while using the workspace
-/// metadata unapply implementation.
+/// Outside single branch mode this deliberately keeps the workspace reference and
+/// workspace merge commit in place for compatibility with the legacy API surface.
+/// In single branch mode the workspace reference is dropped once it is no longer
+/// needed, so unapplying the second-to-last stack checks out the remaining branch.
 /// We implement plumbing here, particularly relative to assignment handling,
 /// to facilitate the eventual removal of `gitbutler-branch-actions`.
 ///
@@ -562,7 +563,7 @@ fn unapply_stack_v3_with_perm(
 
     let mut meta = ctx.legacy_meta_mut(perm)?;
     let (repo, mut ws, _) = ctx.workspace_mut_and_db_with_perm(perm)?;
-    let workspace_disposition = if ctx.settings.feature_flags.unapply_v3_pgm {
+    let workspace_disposition = if ctx.settings.feature_flags.single_branch {
         WorkspaceDisposition::PreventUnnecessaryWorkspaceReferencesKeepWorkspaceCommit
     } else {
         WorkspaceDisposition::KeepWorkspaceCommit

--- a/crates/but-settings/assets/defaults.jsonc
+++ b/crates/but-settings/assets/defaults.jsonc
@@ -21,8 +21,6 @@
 		"oauthClientId": "cd51880daa675d9e6452"
 	},
 	"featureFlags": {
-		/// Use the V3 unapply compatibility mode that keeps workspace commits unless deleting the workspace ref.
-		"unapplyV3Pgm": false,
 		/// Enable single branch mode.
 		"singleBranch": false,
 		/// Control how the filesystem watch should be established.

--- a/crates/but-settings/src/api.rs
+++ b/crates/but-settings/src/api.rs
@@ -22,7 +22,6 @@ but_schemars::register_sdk_type!(TelemetryUpdate);
 #[schemars(extend("x-input" = true))]
 /// Update request for [`crate::app_settings::FeatureFlags`].
 pub struct FeatureFlagsUpdate {
-    pub unapply_v3_pgm: Option<bool>,
     pub single_branch: Option<bool>,
     pub worktree_manipulation: Option<bool>,
 }
@@ -91,15 +90,11 @@ impl AppSettingsWithDiskSync {
     pub fn update_feature_flags(
         &self,
         FeatureFlagsUpdate {
-            unapply_v3_pgm,
             single_branch,
             worktree_manipulation,
         }: FeatureFlagsUpdate,
     ) -> Result<()> {
         let mut settings = self.get_mut_enforce_save()?;
-        if let Some(unapply_v3_pgm) = unapply_v3_pgm {
-            settings.feature_flags.unapply_v3_pgm = unapply_v3_pgm;
-        }
         if let Some(single_branch) = single_branch {
             settings.feature_flags.single_branch = single_branch;
         }
@@ -152,45 +147,45 @@ mod tests {
     }
 
     #[test]
-    fn update_feature_flags_updates_unapply_v3_pgm_and_persists() {
+    fn update_feature_flags_updates_single_branch_and_persists() {
         let (dir, settings) = create_test_settings();
-        let original_single_branch = settings.get().unwrap().feature_flags.single_branch;
+        let original_worktree_manipulation =
+            settings.get().unwrap().feature_flags.worktree_manipulation;
 
         settings
             .update_feature_flags(FeatureFlagsUpdate {
-                unapply_v3_pgm: Some(true),
-                single_branch: None,
+                single_branch: Some(true),
                 worktree_manipulation: None,
             })
             .unwrap();
 
         let s = settings.get().unwrap();
         assert!(
-            s.feature_flags.unapply_v3_pgm,
-            "the API should be able to enable the Unapply v3 PGM flag"
+            s.feature_flags.single_branch,
+            "the API should be able to enable the single branch flag"
         );
         assert_eq!(
-            s.feature_flags.single_branch, original_single_branch,
+            s.feature_flags.worktree_manipulation, original_worktree_manipulation,
             "partial updates should leave unrelated feature flags untouched"
         );
         drop(s);
 
         let reloaded = AppSettingsWithDiskSync::new_with_customization(dir.path(), None).unwrap();
         assert!(
-            reloaded.get().unwrap().feature_flags.unapply_v3_pgm,
-            "the Unapply v3 PGM flag should be readable after reload"
+            reloaded.get().unwrap().feature_flags.single_branch,
+            "the single branch flag should be readable after reload"
         );
     }
 
     #[test]
-    fn feature_flags_update_deserializes_unapply_v3_pgm_from_api_payload() {
+    fn feature_flags_update_deserializes_single_branch_from_api_payload() {
         let update: FeatureFlagsUpdate =
-            serde_json::from_value(serde_json::json!({ "unapplyV3Pgm": true })).unwrap();
+            serde_json::from_value(serde_json::json!({ "singleBranch": true })).unwrap();
 
         assert_eq!(
-            update.unapply_v3_pgm,
+            update.single_branch,
             Some(true),
-            "the API payload should map unapplyV3Pgm to the settings update"
+            "the API payload should map singleBranch to the settings update"
         );
     }
 }

--- a/crates/but-settings/src/app_settings.rs
+++ b/crates/but-settings/src/app_settings.rs
@@ -36,8 +36,6 @@ but_schemars::register_sdk_type!(GitHubOAuthAppSettings);
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, schemars::JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct FeatureFlags {
-    /// Use the V3 unapply compatibility mode that keeps workspace commits unless deleting the workspace ref.
-    pub unapply_v3_pgm: bool,
     /// Enable single branch mode.
     pub single_branch: bool,
     /// Control how the filesystem watch should be established.

--- a/crates/but-settings/src/persistence.rs
+++ b/crates/but-settings/src/persistence.rs
@@ -23,7 +23,14 @@ fn remove_deprecated_settings(customizations: &mut serde_json::Value) -> bool {
         .get_mut("featureFlags")
         .and_then(serde_json::Value::as_object_mut)
     {
-        for deprecated in ["apply3", "unapplyV3", "undo", "rules", "cv3"] {
+        for deprecated in [
+            "apply3",
+            "unapplyV3",
+            "unapplyV3Pgm",
+            "undo",
+            "rules",
+            "cv3",
+        ] {
             if feature_flags.remove(deprecated).is_some() {
                 removed = true;
             }
@@ -216,6 +223,7 @@ mod tests {
                     "undo": true,
                     "rules": true,
                     "cv3": true,
+                    "unapplyV3Pgm": true,
                     "singleBranch": true
                 }
             }"#,
@@ -234,6 +242,7 @@ mod tests {
         assert_eq!(saved["featureFlags"].get("undo"), None);
         assert_eq!(saved["featureFlags"].get("rules"), None);
         assert_eq!(saved["featureFlags"].get("cv3"), None);
+        assert_eq!(saved["featureFlags"].get("unapplyV3Pgm"), None);
     }
 
     #[test]

--- a/crates/but-testsupport/src/sandbox.rs
+++ b/crates/but-testsupport/src/sandbox.rs
@@ -505,7 +505,6 @@ impl Sandbox {
                 oauth_client_id: "but journey tests won't use github".to_string(),
             },
             feature_flags: FeatureFlags {
-                unapply_v3_pgm: false,
                 single_branch: true,
                 watch_mode: "auto".into(),
                 write_commit_evolution: true,

--- a/crates/but/src/args/config.rs
+++ b/crates/but/src/args/config.rs
@@ -391,8 +391,6 @@ pub enum MetricsStatus {
 /// Feature flags that can be managed through `but config feature`.
 #[derive(Debug, Clone, Copy, clap::ValueEnum)]
 pub enum FeatureFlag {
-    /// Use the V3 unapply compatibility mode.
-    UnapplyV3Pgm,
     /// Enable single-branch mode.
     SingleBranch,
 }
@@ -400,14 +398,12 @@ pub enum FeatureFlag {
 impl FeatureFlag {
     pub fn as_str(self) -> &'static str {
         match self {
-            FeatureFlag::UnapplyV3Pgm => "unapply-v3-pgm",
             FeatureFlag::SingleBranch => "single-branch",
         }
     }
 
     pub fn as_json_key(self) -> &'static str {
         match self {
-            FeatureFlag::UnapplyV3Pgm => "unapply_v3_pgm",
             FeatureFlag::SingleBranch => "single_branch",
         }
     }

--- a/crates/but/src/args/tests.rs
+++ b/crates/but/src/args/tests.rs
@@ -615,7 +615,6 @@ mod config_feature {
 
     #[test]
     fn json_keys_use_snake_case() {
-        assert_eq!(FeatureFlag::UnapplyV3Pgm.as_json_key(), "unapply_v3_pgm");
         assert_eq!(FeatureFlag::SingleBranch.as_json_key(), "single_branch");
     }
 }

--- a/crates/but/src/command/config.rs
+++ b/crates/but/src/command/config.rs
@@ -383,16 +383,10 @@ pub(crate) fn feature_config(
         return Ok(());
     }
 
-    let flags = [
-        (
-            FeatureFlag::UnapplyV3Pgm,
-            settings.feature_flags.unapply_v3_pgm,
-        ),
-        (
-            FeatureFlag::SingleBranch,
-            settings.feature_flags.single_branch,
-        ),
-    ];
+    let flags = [(
+        FeatureFlag::SingleBranch,
+        settings.feature_flags.single_branch,
+    )];
     if let Some(out) = out.for_human() {
         writeln!(out, "\n{}:", t.important.paint("Feature Flags"))?;
         writeln!(out)?;
@@ -410,7 +404,6 @@ pub(crate) fn feature_config(
         }
     } else if let Some(out) = out.for_json() {
         out.write_value(serde_json::json!({
-            "unapply_v3_pgm": settings.feature_flags.unapply_v3_pgm,
             "single_branch": settings.feature_flags.single_branch,
         }))?;
     }
@@ -420,19 +413,16 @@ pub(crate) fn feature_config(
 
 fn feature_flag_value(flags: &but_settings::app_settings::FeatureFlags, flag: FeatureFlag) -> bool {
     match flag {
-        FeatureFlag::UnapplyV3Pgm => flags.unapply_v3_pgm,
         FeatureFlag::SingleBranch => flags.single_branch,
     }
 }
 
 fn feature_flag_update(flag: FeatureFlag, enabled: bool) -> FeatureFlagsUpdate {
     let mut update = FeatureFlagsUpdate {
-        unapply_v3_pgm: None,
         single_branch: None,
         worktree_manipulation: None,
     };
     match flag {
-        FeatureFlag::UnapplyV3Pgm => update.unapply_v3_pgm = Some(enabled),
         FeatureFlag::SingleBranch => update.single_branch = Some(enabled),
     }
     update

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/unapply_stack_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/unapply_stack_004.svg
@@ -1,7 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="820" height="380" viewBox="0 0 820 380">
   <rect x="0" y="0" width="820" height="380" fill="#000000" />
   <rect x="10" y="82" width="800" height="18" fill="#45475A" />
-  <rect x="10" y="352" width="80" height="18" fill="#555555" />
+  <rect x="10" y="334" width="80" height="18" fill="#555555" />
+  <rect x="10" y="352" width="800" height="18" fill="#555555" />
   <g font-family="Menlo, Monaco, 'Courier New', monospace" font-size="14" xml:space="preserve">
     <text x="10 18" y="24" style="fill:#CCCCCC;">╭┄</text>
     <text x="34" y="24" style="fill:#0000AA;font-weight:bold;">@</text>
@@ -38,38 +39,41 @@
     <text x="202 210 218 226 234 242 250 258 266 274" y="168" style="fill:#CCCCCC;opacity:0.75;">2000-01-02</text>
     <text x="290 298 306" y="168" style="fill:#CCCCCC;">add</text>
     <text x="322" y="168" style="fill:#CCCCCC;">M</text>
-    <text x="594 602 610 618 626 634 642 650 658 666 674 682 690 698 706 714 722 730 738 746 754 762 770 778 786 794" y="294" style="fill:#00AAAA;">┌────────────────────────┐</text>
-    <text x="594" y="312" style="fill:#00AAAA;">│</text>
-    <text x="610 618 626 634 642 650 658 666 674" y="312" style="fill:#CCCCCC;">Unapplied</text>
-    <text x="690 698 706 714 722 730 738 746 754 762 770 778" y="312" style="fill:#00AA00;">'c-branch-2'</text>
-    <text x="794" y="312" style="fill:#00AAAA;">│</text>
-    <text x="594 602 610 618 626 634 642 650 658 666 674 682 690 698 706 714 722 730 738 746 754 762 770 778 786 794" y="330" style="fill:#00AAAA;">└────────────────────────┘</text>
-    <text x="26 34 42 50 58 66" y="366" style="fill:#FFFFFF;">normal</text>
-    <text x="98 106 114" y="366" style="fill:#0000AA;">↑/k</text>
-    <text x="130 138" y="366" style="fill:#CCCCCC;opacity:0.75;">up</text>
-    <text x="154" y="366" style="fill:#CCCCCC;opacity:0.75;">•</text>
-    <text x="170 178 186" y="366" style="fill:#0000AA;">↓/j</text>
-    <text x="202 210 218 226" y="366" style="fill:#CCCCCC;opacity:0.75;">down</text>
-    <text x="242" y="366" style="fill:#CCCCCC;opacity:0.75;">•</text>
-    <text x="258" y="366" style="fill:#0000AA;">c</text>
-    <text x="274 282 290 298 306 314" y="366" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="330" y="366" style="fill:#CCCCCC;opacity:0.75;">•</text>
-    <text x="346" y="366" style="fill:#0000AA;">r</text>
-    <text x="362 370 378 386 394 402" y="366" style="fill:#CCCCCC;opacity:0.75;">squash</text>
-    <text x="418" y="366" style="fill:#CCCCCC;opacity:0.75;">•</text>
-    <text x="434" y="366" style="fill:#0000AA;">m</text>
-    <text x="450 458 466 474" y="366" style="fill:#CCCCCC;opacity:0.75;">move</text>
-    <text x="490" y="366" style="fill:#CCCCCC;opacity:0.75;">•</text>
-    <text x="506" y="366" style="fill:#0000AA;">b</text>
-    <text x="522 530 538 546 554 562" y="366" style="fill:#CCCCCC;opacity:0.75;">branch</text>
-    <text x="578" y="366" style="fill:#CCCCCC;opacity:0.75;">•</text>
-    <text x="594" y="366" style="fill:#0000AA;">s</text>
-    <text x="610 618 626 634 642" y="366" style="fill:#CCCCCC;opacity:0.75;">stack</text>
-    <text x="658" y="366" style="fill:#CCCCCC;opacity:0.75;">•</text>
-    <text x="674" y="366" style="fill:#0000AA;">?</text>
-    <text x="690 698 706 714" y="366" style="fill:#CCCCCC;opacity:0.75;">help</text>
-    <text x="730" y="366" style="fill:#CCCCCC;opacity:0.75;">•</text>
-    <text x="746" y="366" style="fill:#0000AA;">q</text>
-    <text x="762 770 778 786" y="366" style="fill:#CCCCCC;opacity:0.75;">quit</text>
+    <text x="594 602 610 618 626 634 642 650 658 666 674 682 690 698 706 714 722 730 738 746 754 762 770 778 786 794" y="276" style="fill:#00AAAA;">┌────────────────────────┐</text>
+    <text x="594" y="294" style="fill:#00AAAA;">│</text>
+    <text x="610 618 626 634 642 650 658 666 674" y="294" style="fill:#CCCCCC;">Unapplied</text>
+    <text x="690 698 706 714 722 730 738 746 754 762 770 778" y="294" style="fill:#00AA00;">'c-branch-2'</text>
+    <text x="794" y="294" style="fill:#00AAAA;">│</text>
+    <text x="594 602 610 618 626 634 642 650 658 666 674 682 690 698 706 714 722 730 738 746 754 762 770 778 786 794" y="312" style="fill:#00AAAA;">└────────────────────────┘</text>
+    <text x="26 34 42 50 58 66" y="348" style="fill:#FFFFFF;">normal</text>
+    <text x="98 106 114" y="348" style="fill:#0000AA;">↑/k</text>
+    <text x="130 138" y="348" style="fill:#CCCCCC;opacity:0.75;">up</text>
+    <text x="154" y="348" style="fill:#CCCCCC;opacity:0.75;">•</text>
+    <text x="170 178 186" y="348" style="fill:#0000AA;">↓/j</text>
+    <text x="202 210 218 226" y="348" style="fill:#CCCCCC;opacity:0.75;">down</text>
+    <text x="242" y="348" style="fill:#CCCCCC;opacity:0.75;">•</text>
+    <text x="258" y="348" style="fill:#0000AA;">c</text>
+    <text x="274 282 290 298 306 314" y="348" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="330" y="348" style="fill:#CCCCCC;opacity:0.75;">•</text>
+    <text x="346" y="348" style="fill:#0000AA;">r</text>
+    <text x="362 370 378 386 394 402" y="348" style="fill:#CCCCCC;opacity:0.75;">squash</text>
+    <text x="418" y="348" style="fill:#CCCCCC;opacity:0.75;">•</text>
+    <text x="434" y="348" style="fill:#0000AA;">m</text>
+    <text x="450 458 466 474" y="348" style="fill:#CCCCCC;opacity:0.75;">move</text>
+    <text x="490" y="348" style="fill:#CCCCCC;opacity:0.75;">•</text>
+    <text x="506" y="348" style="fill:#0000AA;">b</text>
+    <text x="522 530 538 546 554 562" y="348" style="fill:#CCCCCC;opacity:0.75;">branch</text>
+    <text x="578" y="348" style="fill:#CCCCCC;opacity:0.75;">•</text>
+    <text x="594" y="348" style="fill:#0000AA;">s</text>
+    <text x="610 618 626 634 642" y="348" style="fill:#CCCCCC;opacity:0.75;">stack</text>
+    <text x="658" y="348" style="fill:#CCCCCC;opacity:0.75;">•</text>
+    <text x="674" y="348" style="fill:#0000AA;">?</text>
+    <text x="690 698 706 714" y="348" style="fill:#CCCCCC;opacity:0.75;">help</text>
+    <text x="730" y="348" style="fill:#CCCCCC;opacity:0.75;">•</text>
+    <text x="746" y="348" style="fill:#0000AA;">q</text>
+    <text x="762 770 778 786" y="348" style="fill:#CCCCCC;opacity:0.75;">quit</text>
+    <text x="338 346 354 362 370 378" y="366" style="fill:#FFFFFF;">single</text>
+    <text x="394 402 410 418 426 434" y="366" style="fill:#FFFFFF;">branch</text>
+    <text x="450 458 466 474" y="366" style="fill:#FFFFFF;">mode</text>
   </g>
 </svg>

--- a/crates/but/src/command/legacy/status/tui/tests/stack_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/stack_tests.rs
@@ -111,8 +111,11 @@ fn moving_stacks() {
 
 #[test]
 fn applying_stacks() {
-    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    let mut env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
     env.setup_metadata(&[]);
+    // Unapplying every stack should leave an empty managed workspace to apply into.
+    // In single branch mode the second-to-last unapply checks out the remaining branch instead.
+    env.app_settings_mut().feature_flags.single_branch = false;
 
     let mut tui = test_status_tui(env);
 

--- a/crates/but/tests/but/command/branch/unapply.rs
+++ b/crates/but/tests/but/command/branch/unapply.rs
@@ -87,9 +87,8 @@ Unapplied stack with 'feature-branch' from workspace
     snapbox::assert_data_eq!(
         env.git_log(),
         snapbox::str![[r#"
-* 9f9d5a6 (feature-branch) Add feature
-| * 0bbfbfd (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-| * 9477ae7 (A) add A
+* 9477ae7 (HEAD -> A) add A
+| * 9f9d5a6 (feature-branch) Add feature
 |/  
 * 0dc3733 (origin/main, origin/HEAD, main, gitbutler/target) add M
 
@@ -129,9 +128,8 @@ fn unapply_with_json_output() {
     snapbox::assert_data_eq!(
         env.git_log(),
         snapbox::str![[r#"
-* 9f9d5a6 (feature-branch) Add feature
-| * 0bbfbfd (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-| * 9477ae7 (A) add A
+* 9477ae7 (HEAD -> A) add A
+| * 9f9d5a6 (feature-branch) Add feature
 |/  
 * 0dc3733 (origin/main, origin/HEAD, main, gitbutler/target) add M
 
@@ -272,8 +270,7 @@ Unapplied stack with 'remote-feature' from workspace
     snapbox::assert_data_eq!(
         env.git_log(),
         snapbox::str![[r#"
-* 0bbfbfd (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-* 9477ae7 (A) add A
+* 9477ae7 (HEAD -> A) add A
 | * ba02e5f (origin/remote-feature, remote-feature) Add remote feature
 |/  
 * 0dc3733 (origin/main, origin/HEAD, main, gitbutler/target) add M
@@ -285,6 +282,10 @@ Unapplied stack with 'remote-feature' from workspace
 #[test]
 fn concurrent_unapply_of_independent_branches_succeeds() {
     let env = Sandbox::open_or_init_scenario_with_target_and_default_settings("one-stack");
+    // Keep the managed workspace: in single-branch mode unapply would check out a plain branch.
+    env.but("config feature single-branch disable")
+        .assert()
+        .success();
     env.setup_metadata(&["A"]);
 
     create_local_branch_with_commit(&env, "feature-branch-a");

--- a/crates/but/tests/but/command/config.rs
+++ b/crates/but/tests/but/command/config.rs
@@ -170,7 +170,6 @@ fn feature_config_shell_output_uses_valid_identifiers() {
 
 Feature Flags:
 
-  unapply-v3-pgm: disabled
   single-branch: enabled
 
 "#]]);

--- a/crates/but/tests/but/command/pick.rs
+++ b/crates/but/tests/but/command/pick.rs
@@ -94,6 +94,10 @@ fn pick_duplicate_sources_outputs_each_commit_once() {
 #[test]
 fn pick_commit_to_new_branch_outputs_json() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    // Keep the managed workspace: in single-branch mode unapply would check out a plain branch.
+    env.but("config feature single-branch disable")
+        .assert()
+        .success();
     env.setup_metadata(&["A"]);
 
     env.but("unapply A").assert().success();
@@ -152,6 +156,10 @@ Hint: run `but help` for all commands
 #[test]
 fn pick_commit_to_new_branch() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    // Keep the managed workspace: in single-branch mode unapply would check out a plain branch.
+    env.but("config feature single-branch disable")
+        .assert()
+        .success();
     env.setup_metadata(&["A"]);
 
     env.but("unapply A").assert().success();
@@ -246,6 +254,10 @@ Hint: run `but help` for all commands
 #[test]
 fn pick_commit_above_branch() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    // Keep the managed workspace: in single-branch mode unapply would check out a plain branch.
+    env.but("config feature single-branch disable")
+        .assert()
+        .success();
     env.setup_metadata(&["A", "B"]);
 
     env.but("unapply B").assert().success();
@@ -280,6 +292,10 @@ Hint: run `but help` for all commands
 #[test]
 fn pick_commit_below_branch() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    // Keep the managed workspace: in single-branch mode unapply would check out a plain branch.
+    env.but("config feature single-branch disable")
+        .assert()
+        .success();
     env.setup_metadata(&["A", "B"]);
 
     env.but("unapply B").assert().success();

--- a/crates/but/tests/but/command/status.rs
+++ b/crates/but/tests/but/command/status.rs
@@ -569,6 +569,10 @@ fn status_hint_clean_workspace() {
 #[test]
 fn status_hint_when_no_branches() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    // Keep the managed workspace: in single-branch mode unapply would check out a plain branch.
+    env.but("config feature single-branch disable")
+        .assert()
+        .success();
     env.setup_metadata(&["A"]);
 
     env.but("unapply A").assert().success();

--- a/crates/but/tests/but/command/teardown.rs
+++ b/crates/but/tests/but/command/teardown.rs
@@ -255,6 +255,10 @@ fn json_output_with_dangling_commits() {
 #[test]
 fn teardown_informs_of_checkout_to_when_there_are_no_stacks() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    // Keep the managed workspace: in single-branch mode unapply would check out a plain branch.
+    env.but("config feature single-branch disable")
+        .assert()
+        .success();
     env.setup_metadata(&["A"]);
     env.but("unapply A").assert().success();
 
@@ -270,6 +274,10 @@ Error: Failed to determine checkout target branch. Specify a target branch with 
 #[test]
 fn teardown_checks_out_to_branch_override() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    // Keep the managed workspace: in single-branch mode unapply would check out a plain branch.
+    env.but("config feature single-branch disable")
+        .assert()
+        .success();
     env.setup_metadata(&["A"]);
     env.but("unapply A").assert().success();
 
@@ -302,6 +310,10 @@ fn teardown_checks_out_to_branch_override() {
 #[test]
 fn teardown_checks_out_to_branch_override_with_qualified_ref_name() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    // Keep the managed workspace: in single-branch mode unapply would check out a plain branch.
+    env.but("config feature single-branch disable")
+        .assert()
+        .success();
     env.setup_metadata(&["A"]);
     env.but("unapply A").assert().success();
 

--- a/e2e/playwright/tests/singleBranch/commitActions.spec.ts
+++ b/e2e/playwright/tests/singleBranch/commitActions.spec.ts
@@ -43,7 +43,7 @@ test.use({
 	gitbutlerOptions: {
 		config: {
 			onboardingComplete: true,
-			featureFlags: { singleBranch: true, unapplyV3Pgm: false },
+			featureFlags: { singleBranch: true },
 		},
 	},
 });
@@ -583,16 +583,7 @@ async function openManagedWorkspace(
 	return gitbutler.pathInWorkdir("local-clone");
 }
 
-test.describe("unapply-v3-pgm enabled", () => {
-	test.use({
-		gitbutlerOptions: {
-			config: {
-				onboardingComplete: true,
-				featureFlags: { singleBranch: true, unapplyV3Pgm: true },
-			},
-		},
-	});
-
+test.describe("unapplying stacks", () => {
 	test("stays managed with two stacks, then moves to a single checkout", async ({
 		page,
 		gitbutler,
@@ -733,15 +724,26 @@ test.describe("unapply-v3-pgm enabled", () => {
 	});
 });
 
-test("keeps the managed workspace when unapply-v3-pgm is disabled", async ({ page, gitbutler }) => {
-	const localClone = await openManagedWorkspace(page, gitbutler, "branch1", "branch3");
+test.describe("single-branch mode disabled", () => {
+	test.use({
+		gitbutlerOptions: {
+			config: {
+				onboardingComplete: true,
+				featureFlags: { singleBranch: false },
+			},
+		},
+	});
 
-	await unapplyStack(page, "branch3");
+	test("keeps the managed workspace when a stack is unapplied", async ({ page, gitbutler }) => {
+		const localClone = await openManagedWorkspace(page, gitbutler, "branch1", "branch3");
 
-	await assertSymbolicHead("gitbutler/workspace", localClone);
-	await expectCurrentBranchChip(page, "gitbutler/workspace");
-	await expect(stack(page)).toHaveCount(1);
-	await expect(stack(page, "branch1")).toBeVisible();
+		await unapplyStack(page, "branch3");
+
+		// The current-branch chip only renders in single-branch mode, so assert on the repository.
+		await assertSymbolicHead("gitbutler/workspace", localClone);
+		await expect(stack(page)).toHaveCount(1);
+		await expect(stack(page, "branch1")).toBeVisible();
+	});
 });
 
 test("rebuilds an enclosed ad-hoc workspace around the current and applied branches", async ({

--- a/packages/but-sdk/src/generated/graph/index.d.ts
+++ b/packages/but-sdk/src/generated/graph/index.d.ts
@@ -955,7 +955,7 @@ export declare function initGithubDeviceOauth(): Promise<Verification>
 export declare function listAvailableReviewTemplates(projectId: string): Promise<Array<string>>
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/virtual_branches.rs:681}
+ * {@link ../../../../../crates/but-api/src/legacy/virtual_branches.rs:682}
  */
 export declare function listBranches(projectId: string, filter: BranchListingFilter | null): Promise<Array<BranchListing>>
 
@@ -2799,8 +2799,6 @@ export type ExtraCsp = {
 };
 
 export type FeatureFlags = {
-  /** Use the V3 unapply compatibility mode that keeps workspace commits unless deleting the workspace ref. */
-  unapplyV3Pgm: boolean;
   /** Enable single branch mode. */
   singleBranch: boolean;
   /**
@@ -2821,7 +2819,6 @@ export type FeatureFlags = {
 
 /** Update request for [`crate::app_settings::FeatureFlags`]. */
 export type FeatureFlagsUpdate = {
-  unapplyV3Pgm?: boolean | null;
   singleBranch?: boolean | null;
   worktreeManipulation?: boolean | null;
 };

--- a/packages/but-sdk/src/generated/linear/index.d.ts
+++ b/packages/but-sdk/src/generated/linear/index.d.ts
@@ -955,7 +955,7 @@ export declare function initGithubDeviceOauth(): Promise<Verification>
 export declare function listAvailableReviewTemplates(projectId: string): Promise<Array<string>>
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/virtual_branches.rs:681}
+ * {@link ../../../../../crates/but-api/src/legacy/virtual_branches.rs:682}
  */
 export declare function listBranches(projectId: string, filter: BranchListingFilter | null): Promise<Array<BranchListing>>
 
@@ -2799,8 +2799,6 @@ export type ExtraCsp = {
 };
 
 export type FeatureFlags = {
-  /** Use the V3 unapply compatibility mode that keeps workspace commits unless deleting the workspace ref. */
-  unapplyV3Pgm: boolean;
   /** Enable single branch mode. */
   singleBranch: boolean;
   /**
@@ -2821,7 +2819,6 @@ export type FeatureFlags = {
 
 /** Update request for [`crate::app_settings::FeatureFlags`]. */
 export type FeatureFlagsUpdate = {
-  unapplyV3Pgm?: boolean | null;
   singleBranch?: boolean | null;
   worktreeManipulation?: boolean | null;
 };


### PR DESCRIPTION
Unapplying a stack only moved to a single-branch checkout when the separate `unapplyV3Pgm` flag was on, so enabling `singleBranch` alone left users in the managed workspace. There is no reason for these to be two switches.

- The unapply workspace disposition now keys off `singleBranch` directly.
- `unapplyV3Pgm` is removed from settings, defaults, the settings update API, `but config feature`, the SDK types and the e2e config. Stale entries in existing settings files are pruned on save like the other retired flags.
- CLI tests that only used unapply to shrink a managed workspace now run `but config feature single-branch disable` first, since the test sandbox defaults to single-branch mode.

User-visible change for anyone with `singleBranch` enabled: unapplying down to one stack now leaves you on that branch instead of in the managed workspace, which is what the flag is meant to do.

Two pre-existing single-branch gaps become easier to hit and are left for follow-up: unapplying the checked-out branch from a single-branch checkout errors with "requires open workspace mode", and `but pick --branch` while on the target branch errors with "commit already belongs to another branch".

Fixes GB-1971