### PR TITLE
fix: let the gutter card follow the numbers

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/addressLabel.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/addressLabel.ts
@@ -5,7 +5,7 @@ import type { Address } from "#ui/addresses.ts";
 import { assert } from "#ui/assert.ts";
 
 /** What a set of hunk lines amounts to: "+3 -1 lines", the words a drag of them carries. */
-export const hunkAddressesLabel = (addresses: Array<Extract<Address, { _tag: "Hunk" }>>) => {
+const hunkAddressesLabel = (addresses: Array<Extract<Address, { _tag: "Hunk" }>>) => {
 	const add = addresses.reduce(
 		(sum, address) =>
 			sum +

--- a/apps/lite/ui/src/routes/project/$id/workspace/diff-gutter.test.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/diff-gutter.test.tsx
@@ -1,0 +1,107 @@
+/** @vitest-environment jsdom */
+
+import { hunkAddress, type HunkAddress } from "#ui/addresses.ts";
+import { store } from "#ui/store.ts";
+import type { CodeViewDiffItem } from "@pierre/diffs";
+import { act, createRef, forwardRef, type RefObject, useImperativeHandle } from "react";
+import { Provider } from "react-redux";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useDiffGutterCheckboxes } from "./diff-gutter.ts";
+
+declare global {
+	var IS_REACT_ACT_ENVIRONMENT: boolean | undefined;
+}
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+// jsdom ships no CSS object; the gutter only ever escapes line indices with it.
+Reflect.set(globalThis, "CSS", { escape: (value: string) => value });
+
+const ITEM = { type: "diff", id: "file.ts", version: 1 } as unknown as CodeViewDiffItem<unknown>;
+
+const HUNK: HunkAddress = {
+	parent: { parent: { _tag: "UncommittedChanges" }, path: "file.ts" },
+	isResultOfBinaryToTextConversion: false,
+	hunkHeader: { oldStart: 1, oldLines: 1, newStart: 1, newLines: 1 },
+	lineGroups: [{ side: "additions", start: 2, lines: 1 }],
+} as unknown as HunkAddress;
+
+type GutterHandle = ReturnType<typeof useDiffGutterCheckboxes<unknown>>;
+
+const Probe = forwardRef<GutterHandle>((_props, ref) => {
+	const result = useDiffGutterCheckboxes<unknown>(
+		vi.fn(),
+		() => hunkAddress(HUNK),
+		() => hunkAddress(HUNK),
+		"project",
+		vi.fn(),
+		vi.fn(),
+	);
+	useImperativeHandle(ref, () => result, [result]);
+	return result.portals;
+});
+
+/** A number cell and the code beside it, the two halves the pointer crosses between. */
+const createHost = (): { host: HTMLElement; cell: HTMLElement; code: HTMLElement } => {
+	const host = document.createElement("div");
+	const shadowRoot = host.attachShadow({ mode: "open" });
+	const cell = document.createElement("span");
+	cell.setAttribute("data-column-number", "2");
+	cell.setAttribute("data-line-type", "change-addition");
+	cell.setAttribute("data-line-index", "0");
+	const code = document.createElement("span");
+	code.setAttribute("data-line", "2");
+	code.setAttribute("data-line-type", "change-addition");
+	code.setAttribute("data-line-index", "0");
+	shadowRoot.append(cell, code);
+	return { host, cell, code };
+};
+
+const pointerOver = (element: HTMLElement) =>
+	act(() => {
+		element.dispatchEvent(new Event("pointerover", { bubbles: true, composed: true }));
+	});
+
+describe("useDiffGutterCheckboxes", () => {
+	let container: HTMLDivElement;
+	let root: Root;
+	let handleRef: RefObject<GutterHandle | null>;
+
+	const handle = (): GutterHandle => {
+		if (!handleRef.current) throw new Error("Probe did not expose the gutter handle");
+		return handleRef.current;
+	};
+
+	beforeEach(() => {
+		container = document.createElement("div");
+		document.body.append(container);
+		root = createRoot(container);
+		handleRef = createRef<GutterHandle>();
+		act(() =>
+			root.render(
+				<Provider store={store}>
+					<Probe ref={handleRef} />
+				</Provider>,
+			),
+		);
+	});
+
+	afterEach(() => {
+		act(() => root.unmount());
+		container.remove();
+	});
+
+	it("takes the actions card back when the pointer moves off the numbers onto the code", async () => {
+		const { host, cell, code } = createHost();
+		const context = { type: "diff", item: ITEM, element: host, version: ITEM.version };
+		await act(async () => {
+			Reflect.apply(handle().onPostRender, undefined, [host, {}, "mount", context]);
+		});
+
+		pointerOver(cell);
+		expect(cell.querySelector("[data-gitbutler-diff-actions]")).not.toBeNull();
+
+		pointerOver(code);
+		expect(host.shadowRoot?.querySelector("[data-gitbutler-diff-actions]")).toBeNull();
+	});
+});

--- a/apps/lite/ui/src/routes/project/$id/workspace/diff-gutter.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/diff-gutter.ts
@@ -681,6 +681,12 @@ const createGutterStore = <T>(
 	const ensureHoverListeners = (host: HTMLElement, shadowRoot: ShadowRoot): void => {
 		if (removeHoverListenersByHost.has(host)) return;
 
+		/** The card stands for one line-number cell, so it goes wherever that cell is not. */
+		const hideActions = () => {
+			commentTargetsByHost.delete(host);
+			actionCardsByHost.get(host)?.card.remove();
+		};
+
 		// CSS can see the hovered column, but cannot match its dynamic hunk key to the rest of the
 		// hunk's own band or to the checkbox at the top of it. The line checkbox stays local to :hover.
 		const handlePointerOver = (event: Event) => {
@@ -693,11 +699,13 @@ const createGutterStore = <T>(
 						target instanceof HTMLElement && target.hasAttribute("data-column-number"),
 				);
 			const itemId = itemIdsByHost.get(host);
-			if (!cell || itemId === undefined) return;
+			// The code beside the numbers is still inside the view, so leaving the view is not what
+			// takes the card back. A pointer anywhere off the cells is already off the line it named.
+			if (!cell || itemId === undefined) return hideActions();
 
 			const target = diffLineTargetFromElement({ element: cell, itemId });
 			const actions = actionCardsByHost.get(host);
-			if (!target || !actions) return;
+			if (!target || !actions) return hideActions();
 
 			commentTargetsByHost.set(host, target);
 			// A context line has no hunk to hand over, so the card arrives there without its grip.
@@ -709,8 +717,7 @@ const createGutterStore = <T>(
 		};
 		const handlePointerLeave = () => {
 			setHoveredGroup(host, undefined);
-			commentTargetsByHost.delete(host);
-			actionCardsByHost.get(host)?.card.remove();
+			hideActions();
 		};
 		shadowRoot.addEventListener("pointerover", handlePointerOver);
 		host.addEventListener("pointerleave", handlePointerLeave);

--- a/apps/lite/ui/src/routes/project/$id/workspace/diff-gutter.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/diff-gutter.ts
@@ -29,7 +29,6 @@ const ACTIONS_ATTRIBUTE = "data-gitbutler-diff-actions";
 const ACTIONS_FILLED_ATTRIBUTE = "data-gitbutler-diff-actions-filled";
 const ACTIONS_DRAGGABLE_ATTRIBUTE = "data-gitbutler-diff-actions-draggable";
 const DRAG_PREVIEW_ATTRIBUTE = "data-gitbutler-diff-drag-preview";
-const DRAG_COUNT_ATTRIBUTE = "data-gitbutler-diff-drag-count";
 const HUNK_BAND_ATTRIBUTE = "data-gitbutler-diff-hunk-band";
 const HUNK_BAND_CHECKED_ATTRIBUTE = "data-checked";
 const COMMENT_SLOT_ATTRIBUTE = "data-gitbutler-diff-comment-slot";
@@ -54,7 +53,7 @@ export const diffGutterUnsafeCSS = `
 		   controls sit over it — so it is painted in the surface the other break reveals, which is
 		   Pierre's own and not the app's, since the two part ways in the dark theme. */
 		--gitbutler-diff-gutter-seam: 2px;
-		/* The inset of the card's first control, which the count above it lines up with. */
+		/* The inset the card keeps around the controls it carries. */
 		--gitbutler-diff-actions-padding: 2px;
 		--gitbutler-diff-gutter-seam-color: var(--diffs-background, var(--bg-1));
 	}
@@ -207,30 +206,6 @@ export const diffGutterUnsafeCSS = `
 		height: 16px;
 	}
 
-	/* What the grip is holding, in the words its drag preview will repeat. It floats clear of the
-	   card rather than sitting in it, so reaching the grip never moves what the pointer is aiming
-	   at. Only a hovered grip fills it, and an empty one is not there at all. */
-	[${DRAG_COUNT_ATTRIBUTE}] {
-		position: absolute;
-		inset-block-end: calc(100% + 4px);
-		/* Clear of the card's own padding, so the count and the grip share a leading edge. */
-		inset-inline-start: var(--gitbutler-diff-actions-padding);
-		z-index: 1;
-		padding: 2px 6px;
-		border-radius: var(--radius-card);
-		background-color: var(--bg-1);
-		box-shadow: var(--shadow-tooltip);
-		color: var(--text-1);
-		font-size: 11px;
-		line-height: 1.4;
-		white-space: nowrap;
-		pointer-events: none;
-	}
-
-	[${DRAG_COUNT_ATTRIBUTE}]:empty {
-		display: none;
-	}
-
 	/* The grip and whatever the annotate slot brings are separate acts, so a rule stands between
 	   them. It belongs to the grip, and so is gone on any line the grip itself is gone from. */
 	[${ACTIONS_ATTRIBUTE}][${ACTIONS_FILLED_ATTRIBUTE}] > [${GUTTER_DRAG_HANDLE_ATTRIBUTE}] {
@@ -332,7 +307,6 @@ const sourcesKey = (sources: Array<Address> | null): string =>
 	sources?.map(addressIdentityKey).join("|") ?? "";
 
 const dragPreviewSourcesByHost = new Map<HTMLElement, Array<Address>>();
-const dragPreviewLabelsByHost = new Map<HTMLElement, string>();
 const dragPreviewKeysByHost = new Map<HTMLElement, string>();
 const dragPreviewSyncByHost = new Map<HTMLElement, () => void>();
 
@@ -346,7 +320,6 @@ const dragPreviewSyncByHost = new Map<HTMLElement, () => void>();
 export const setDiffDragPreviewSources = (
 	host: HTMLElement,
 	sources: Array<Address> | null,
-	label?: string,
 ): void => {
 	const key = sourcesKey(sources);
 	if ((dragPreviewKeysByHost.get(host) ?? "") === key) return;
@@ -354,12 +327,9 @@ export const setDiffDragPreviewSources = (
 	if (sources === null || sources.length === 0) {
 		dragPreviewSourcesByHost.delete(host);
 		dragPreviewKeysByHost.delete(host);
-		dragPreviewLabelsByHost.delete(host);
 	} else {
 		dragPreviewSourcesByHost.set(host, sources);
 		dragPreviewKeysByHost.set(host, key);
-		if (label === undefined) dragPreviewLabelsByHost.delete(host);
-		else dragPreviewLabelsByHost.set(host, label);
 	}
 	dragPreviewSyncByHost.get(host)?.();
 };
@@ -367,7 +337,6 @@ export const setDiffDragPreviewSources = (
 const forgetDragPreview = (host: HTMLElement): void => {
 	dragPreviewSourcesByHost.delete(host);
 	dragPreviewKeysByHost.delete(host);
-	dragPreviewLabelsByHost.delete(host);
 	dragPreviewSyncByHost.delete(host);
 };
 
@@ -380,7 +349,6 @@ const keepPointerDownOutOfLineSelection = (event: PointerEvent): void => {
 
 type ActionsCard = {
 	card: HTMLElement;
-	count: HTMLElement;
 	slot: HTMLSlotElement;
 };
 
@@ -397,10 +365,6 @@ const createActionsCard = (slotName: string): ActionsCard => {
 	// Bundled app asset, same source the Icon component draws from.
 	dragHandle.innerHTML = assert(icons.get("drag-vertical"));
 
-	const count = document.createElement("span");
-	count.setAttribute(DRAG_COUNT_ATTRIBUTE, "");
-	count.setAttribute("aria-hidden", "true");
-
 	const slot = document.createElement("slot");
 	slot.name = slotName;
 	slot.setAttribute(COMMENT_SLOT_ATTRIBUTE, "");
@@ -409,8 +373,8 @@ const createActionsCard = (slotName: string): ActionsCard => {
 		card.toggleAttribute(ACTIONS_FILLED_ATTRIBUTE, slot.assignedNodes().length > 0);
 	});
 
-	card.append(dragHandle, count, slot);
-	return { card, count, slot };
+	card.append(dragHandle, slot);
+	return { card, slot };
 };
 
 const ensureHunkBand = (
@@ -771,7 +735,6 @@ const createGutterStore = <T>(
 				slotName: actions.slot.name,
 				getTarget: () => commentTargetsByHost.get(host),
 			} satisfies GutterTarget["comment"]);
-		actions.count.textContent = dragPreviewLabelsByHost.get(host) ?? "";
 		const groupsByKey = new Map<string, GutterCheckboxGroup>();
 		const controlsByGroup = new Map<string, Array<HTMLElement>>();
 		const bandsByGroup = new Map<string, Array<HTMLElement>>();

--- a/apps/lite/ui/src/routes/project/$id/workspace/diff-hunk-drag.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/diff-hunk-drag.ts
@@ -21,7 +21,7 @@ import { createRoot } from "react-dom/client";
 import type { DragData } from "./DragData.ts";
 import { parseDragData } from "./DragData.ts";
 import { DragPreview } from "./OperationSourceC.tsx";
-import { addressesLabel, hunkAddressesLabel } from "./addressLabel.ts";
+import { addressesLabel } from "./addressLabel.ts";
 import { setDiffDragPreviewSources } from "./diff-gutter.ts";
 import { diffLineTargetFromElement, type DiffLineTarget } from "./diff-line-target.ts";
 
@@ -126,7 +126,7 @@ export const useDiffHunkDrag = <T>({
 				: [hunkAddress(hunk)];
 		};
 
-		// The grip says what it holds before it is pressed: the same lines the drop would move,
+		// The grip marks what it holds before it is pressed: the same lines the drop would move,
 		// which is the containing hunk unless checked lines or the selection widen it.
 		const handlePointerOver = (event: Event) => {
 			const overHandle = event
@@ -139,17 +139,7 @@ export const useDiffHunkDrag = <T>({
 				overHandle && event instanceof PointerEvent && configRef.current.canDrag()
 					? resolveSources(event)
 					: null;
-			// The same words the drag preview will carry, so the grip answers before it is pressed.
-			// Checked sources can reach past hunks, and those are only ever counted.
-			let label: string | undefined;
-			if (sources) {
-				const hunks = sources.flatMap((source) => (source._tag === "Hunk" ? [source] : []));
-				label =
-					hunks.length === sources.length
-						? hunkAddressesLabel(hunks)
-						: `${sources.length.toLocaleString()} items`;
-			}
-			setDiffDragPreviewSources(host, sources, label);
+			setDiffDragPreviewSources(host, sources);
 		};
 		const handlePointerLeave = () => setDiffDragPreviewSources(host, null);
 		const shadowRoot = host.shadowRoot;


### PR DESCRIPTION
## 🧢 Changes

Two commits.

**Fix the stuck handle.** The gutter actions card (grip + annotate button) is one element moved into whichever `[data-column-number]` cell the pointer is over. Its `pointerover` handler bailed with a bare `return` whenever the composed path held no number cell, and the only thing that ever took the card back off was `pointerleave` on the *whole* diff view. Moving right onto the code beside the numbers is neither, so the card stayed parked on the last line it was hovered over, however far the pointer travelled afterwards. There is now one `hideActions` helper, called both on `pointerleave` and on any `pointerover` that lands off the number cells.

**Drop the count above the grip.** The floating "+1 −1 lines" bubble is gone, along with the label the drag module composed for it and the store the gutter kept it in.

## ☕️ Reasoning

The card belongs to a line, so it should follow the cells that name lines rather than the view that contains them. Hovering a number cell and then reading code should not leave a control hanging over a line the pointer left minutes ago.

The count was the same answer twice: the grip already marks the lines it would take, and the dashed marks say so on the lines themselves. It also reached above the line it belonged to, which is a lot of furniture for a hover.

The dashed source marks and the drag preview that follows the cursor during an actual drag are both untouched — the preview composes its own label from `addressesLabel`.

Covered by a new regression test in `diff-gutter.test.tsx`: it hovers a number cell, then the code beside it, and asserts the card is gone. Confirmed it fails against the old `return`.

## 🎫 Affected issues

Fixes: GB-1963

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Screenshots

Before:

https://github.com/user-attachments/assets/b40324c7-a529-4457-932f-2560408cc075


After:

https://github.com/user-attachments/assets/e638702e-ebed-446d-a59b-a0c9e1ea7c83

