### PR TITLE
Lite: keep one watcher subscription per window across project switches

### DIFF
--- a/apps/lite/harness/tests/fake-transport.ts
+++ b/apps/lite/harness/tests/fake-transport.ts
@@ -64,7 +64,9 @@ export const createWatcherHandlers = () => {
 				counter += 1;
 				const eventChannel = `workspace:watcher-event:${counter}`;
 				channels.push(eventChannel);
-				return { subscriptionId: `subscription-${counter}`, eventChannel };
+				// Unique across panels, as the host's are: a panel releasing its
+				// predecessor's id must not hit its own.
+				return { subscriptionId: crypto.randomUUID(), eventChannel };
 			},
 			watcherUnsubscribe: () => true,
 		} satisfies FakeHandlers,

--- a/apps/lite/ui/src/routes.test.tsx
+++ b/apps/lite/ui/src/routes.test.tsx
@@ -1,0 +1,122 @@
+/** @vitest-environment jsdom */
+
+import type { LiteElectronApi } from "#electron/ipc.ts";
+import type { ProjectForFrontend } from "@gitbutler/but-sdk";
+import { QueryClient } from "@tanstack/react-query";
+import { createMemoryHistory } from "@tanstack/react-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The project route arms the window's watcher subscription in its loader.
+ * Switching projects reruns that loader without an `onLeave` in between, so
+ * the tests here pin the invariant the host cannot enforce: one live
+ * subscription, for the project on screen.
+ */
+
+// Only the ids are read on the way to the workspace.
+let projects: Array<ProjectForFrontend> = [];
+/** Live subscriptions by id, each with the project it watches. */
+const live = new Map<string, string>();
+let counter = 0;
+/** Whether the window was ever left with no subscription at all. */
+let wentDark = false;
+
+/** Projects whose subscribe call hangs until `release` runs. */
+const stalled = new Set<string>();
+const released: Array<() => void> = [];
+const release = () => released.splice(0).forEach((resolve) => resolve());
+
+const lite = {
+	listProjectsStateless: () => Promise.resolve(projects),
+	watcherSubscribe: (projectId: string) =>
+		new Promise<string>((resolve) => {
+			counter += 1;
+			const id = `subscription-${counter}`;
+			const subscribe = () => {
+				live.set(id, projectId);
+				resolve(id);
+			};
+			if (stalled.has(projectId)) released.push(subscribe);
+			else subscribe();
+		}),
+	watcherUnsubscribe: (id: string) => {
+		const removed = live.delete(id);
+		if (live.size === 0) wentDark = true;
+		return Promise.resolve(removed);
+	},
+} satisfies Partial<LiteElectronApi>;
+Object.assign(window, { lite });
+
+const openProject = async (id: string) => {
+	// The route objects, and the subscription kept beside them, are module
+	// singletons: fresh modules keep one test's subscription out of the next.
+	const [{ createAppRouter }, { createRouteTree }] = await Promise.all([
+		import("#ui/router.ts"),
+		import("#ui/routes.tsx"),
+	]);
+	const router = createAppRouter(
+		new QueryClient(),
+		createRouteTree({ workspace: () => null }),
+		createMemoryHistory({ initialEntries: [`/project/${id}/workspace`] }),
+	);
+	await router.load();
+	return router;
+};
+
+const watching = () => [...live.values()];
+
+// A cold runner spends most of a test's time on the fresh module graph.
+describe("project watcher subscription", { timeout: 15_000 }, () => {
+	beforeEach(() => {
+		vi.resetModules();
+		projects = [{ id: "a" }, { id: "b" }] as Array<ProjectForFrontend>;
+		live.clear();
+		counter = 0;
+		wentDark = false;
+		stalled.clear();
+		released.length = 0;
+	});
+
+	it("follows the project across switches, one subscription at a time", async () => {
+		const router = await openProject("a");
+		expect(watching()).toEqual(["a"]);
+
+		for (const id of ["b", "a", "b"]) {
+			await router.navigate({ to: "/project/$id/workspace", params: { id } });
+			await vi.waitFor(() => expect(watching()).toEqual([id]));
+		}
+	});
+
+	it("keeps one subscription when the current project is opened again", async () => {
+		const router = await openProject("a");
+		await router.navigate({ to: "/project/$id/workspace", params: { id: "a" } });
+		await router.navigate({ to: "/project/$id/workspace", params: { id: "a" } });
+		await vi.waitFor(() => expect(watching()).toEqual(["a"]));
+		// The watcher was handed over, never stopped and restarted.
+		expect(wentDark).toBe(false);
+	});
+
+	it("settles on the project on screen when switches overlap", async () => {
+		const router = await openProject("a");
+
+		// B's watcher is slow to start; the user is back on A before it has.
+		stalled.add("b");
+		const toB = router.navigate({ to: "/project/$id/workspace", params: { id: "b" } });
+		await vi.waitFor(() => expect(released).toHaveLength(1));
+		const toA = router.navigate({ to: "/project/$id/workspace", params: { id: "a" } });
+		release();
+		await Promise.allSettled([toB, toA]);
+
+		await vi.waitFor(() => expect(watching()).toEqual(["a"]));
+	});
+
+	it("drops the subscription on leaving the project", async () => {
+		const router = await openProject("a");
+		expect(watching()).toEqual(["a"]);
+
+		// With no projects the index page stays put instead of redirecting back.
+		projects = [];
+		await router.navigate({ to: "/" });
+		await vi.waitFor(() => expect(watching()).toEqual([]));
+	});
+});

--- a/apps/lite/ui/src/routes.tsx
+++ b/apps/lite/ui/src/routes.tsx
@@ -70,6 +70,45 @@ const indexRoute = createRoute({
 	component: IndexPage,
 });
 
+/** What a project match carries that its watcher subscription needs. */
+type ProjectMatch = { params: { id: string }; context: RouteContext };
+
+/**
+ * The window's one watcher subscription and the project it was requested
+ * for, kept beside the route because the route is a module singleton.
+ * Requests are chained, so the previous subscription is dropped once the
+ * next is live however navigations overlap.
+ */
+let watched: { projectId?: string; subscription: Promise<string | undefined> } = {
+	subscription: Promise.resolve(undefined),
+};
+
+/** Replace the subscription with one for the match's project, or with none. */
+const watchProject = (match: ProjectMatch | null) => {
+	const subscription = watched.subscription.then(async (previous) => {
+		// The next one first: the host keeps a project's watcher running while
+		// any subscription holds it, so re-opening the current project neither
+		// restarts the watcher nor drops the events in between.
+		let next: string | undefined;
+		if (match !== null) {
+			const { id } = match.params;
+			next = await window.lite
+				.watcherSubscribe(id, (event) => handleProjectEvent(event, id, match.context.queryClient))
+				// Allow the route to render and handle failure via its queries.
+				.catch(() => undefined);
+		}
+		if (previous !== undefined) await window.lite.watcherUnsubscribe(previous).catch(() => false);
+		return next;
+	});
+	watched = { projectId: match?.params.id, subscription };
+	return subscription;
+};
+
+/** Hooks see the match on screen; they step in only when the loader's request was for another. */
+const settleOn = (match: ProjectMatch) => {
+	if (watched.projectId !== match.params.id) void watchProject(match);
+};
+
 const projectRoute = createRoute({
 	getParentRoute: () => rootRoute,
 	path: "project/$id",
@@ -85,21 +124,17 @@ const projectRoute = createRoute({
 		const projects = await window.lite.listProjectsStateless();
 		if (!projects.some((project) => project.id === params.id)) throw redirect({ to: "/" });
 	},
-	loader: async ({ params, context }) => {
-		// Allow the route to render and handle failure via its queries.
-		try {
-			const subscriptionId = await window.lite.watcherSubscribe(params.id, (event) =>
-				handleProjectEvent(event, params.id, context.queryClient),
-			);
-			return { subscriptionId };
-		} catch {
-			return { subscriptionId: undefined };
-		}
+	// Armed in the loader so the watcher is live before the page's queries
+	// run. Switching projects reruns the loader without an `onLeave` in
+	// between (the route id stays the same, only `$id` changes), and a switch
+	// abandoned for the project already on screen reruns nothing at all, so
+	// the hooks settle the subscription on whichever match is committed.
+	loader: async (match) => {
+		await watchProject(match);
 	},
-	onLeave: ({ loaderData }) => {
-		if (loaderData?.subscriptionId !== undefined)
-			void window.lite.watcherUnsubscribe(loaderData.subscriptionId);
-	},
+	onEnter: settleOn,
+	onStay: settleOn,
+	onLeave: () => void watchProject(null),
 });
 
 const str = (value: unknown): string | undefined =>


### PR DESCRIPTION
Fixes GB-1975 (https://linear.app/gitbutler/issue/GB-1975/lite-hits-800percent-cpu-because-project-switching-leaks-watcher)

## Problem

Switching projects in Lite leaked a watcher subscription every time. Each leaked callback still ran `handleProjectEvent`, so one `FETCH_HEAD` change fanned out into N query refreshes, and after enough switches the Electron main process pinned the CPU (~800% observed on 0.0.185). Selecting the already-current project from the picker leaked too.

## Cause

The project route armed its subscription in the `loader` and released it in `onLeave`. TanStack Router keys its lifecycle hooks by route id, not by match id, so when only `$id` changes the route counts as a *staying* match: its loader reruns for the new project, `onStay` fires, and `onLeave` never does. The old subscription id lived only in the superseded match's loader data, so nothing could release it. Same-URL navigation forces a stale reload with the same effect.

## Fix

The window's single subscription now lives beside the route singleton in `routes.tsx`, together with the project it was last requested for. Replacements go through one serialized chain, so each subscription is unsubscribed before the next is created, however navigations overlap.

- The loader still arms the subscription and awaits it, so the watcher is live before the page's queries run, as before.
- `onEnter`/`onStay` reconcile: they always see the committed match, and they only act when the loader's last request was for a different project. This covers the one case a loader cannot: switching A → B → A while B's watcher is still starting, where the router restores A's cached match without rerunning its loader.
- `onLeave` drops the subscription.

The Electron `WatcherManager` is unchanged; it deliberately fans out to every subscription because multiple windows may watch one project.

## Tests

`routes.test.tsx` drives the real route tree headlessly over a memory history with a fake `window.lite` and pins the invariant of one live subscription for the project on screen: across switches, on reopening the current project, through the overlapping switch, and on leaving. Before the fix, reopening the current project twice left five live subscriptions.