### PR TITLE
Tune Lite command sampling

### DIFF
--- a/apps/lite/electron/src/api-command-sampling.ts
+++ b/apps/lite/electron/src/api-command-sampling.ts
@@ -2,15 +2,25 @@ import type { Endpoint } from "./ipc.js";
 
 const API_COMMAND_SAMPLE_RATES: Readonly<Partial<Record<Endpoint, number>>> = {
 	treeChangeDiffs: 0.01,
-	branchDiff: 0.1,
-	changesInWorktree: 0.1,
-	commentsList: 0.1,
-	commitDetailsWithLineStats: 0.1,
-	headInfo: 0.1,
-	listProjectsStateless: 0.1,
-	listReviews: 0.1,
-	workspaceFetchStatus: 0.1,
-	workspaceTargetCommits: 0.1,
+	branchDiff: 0.01,
+	changesInWorktree: 0.01,
+	commentsList: 0.01,
+	commitDetailsWithLineStats: 0.01,
+	headInfo: 0.01,
+	listProjectsStateless: 0.01,
+	listReviews: 0.01,
+	workspaceFetchStatus: 0.01,
+	workspaceTargetCommits: 0.01,
+	branchDetails: 0.1,
+	branchList: 0.1,
+	getReview: 0.1,
+	getReviewMergeStatus: 0.1,
+	listCiChecks: 0.1,
+	listReviewComments: 0.1,
+	listReviewReactions: 0.1,
+	listReviewSubmissions: 0.1,
+	listReviewThreads: 0.1,
+	listReviewTimelineEvents: 0.1,
 };
 
 interface FailureLimitConfig {
@@ -36,8 +46,8 @@ interface FailureBucket {
 }
 
 const DEFAULT_FAILURE_LIMIT: FailureLimitConfig = {
-	bucketSize: 10,
-	refillIntervalMs: 10_000,
+	bucketSize: 1,
+	refillIntervalMs: 60_000,
 };
 const MAX_BUCKET_SIZE = 1_000;
 const MAX_REFILL_INTERVAL_SECONDS = 3_600;
@@ -66,10 +76,10 @@ export const createApiCommandSampler = ({
 	failureLimit = DEFAULT_FAILURE_LIMIT,
 	now = () => performance.now(),
 	random = Math.random,
-}: SamplerOptions = {}): ((command: string, failure: boolean) => CaptureDecision | null) => {
+}: SamplerOptions = {}) => {
 	const buckets = new Map<string, FailureBucket>();
 
-	return (command, failure) => {
+	const sample = (command: string, failure: boolean): CaptureDecision | null => {
 		const samplingRate = apiCommandSampleRate(command);
 		if (!failure) return random() < samplingRate ? { samplingRate } : null;
 
@@ -99,5 +109,17 @@ export const createApiCommandSampler = ({
 		const occurrenceCount = bucket.suppressed + 1;
 		bucket.suppressed = 0;
 		return { occurrenceCount, samplingRate: 1 };
+	};
+
+	return {
+		sample,
+		drainSuppressedFailures: () => {
+			const failures = Array.from(buckets, ([command, bucket]) => ({
+				command,
+				occurrenceCount: bucket.suppressed,
+			})).filter(({ occurrenceCount }) => occurrenceCount > 0);
+			buckets.clear();
+			return failures;
+		},
 	};
 };

--- a/apps/lite/electron/src/metrics.ts
+++ b/apps/lite/electron/src/metrics.ts
@@ -30,6 +30,7 @@ const POSTHOG_HOST = "https://eu.i.posthog.com";
 const APP_NAME = "gitbutler-lite";
 const CONTAINER = "electron";
 const SHUTDOWN_TIMEOUT_MS = 2000;
+const ACTIVE_API_COMMAND_SHUTDOWN_GRACE_MS = SHUTDOWN_TIMEOUT_MS / 2;
 const FAILURE_LIMIT_FLAG = "lite-api-command-failure-limit";
 const FAILURE_LIMIT_CONFIG_ID = "gitbutler-lite-failure-limit";
 const FAILURE_LIMIT_CONFIG_TIMEOUT_MS = 1_000;
@@ -38,10 +39,22 @@ let client: PostHog | null = null;
 let distinctId = "";
 let appVersion = "";
 let failureLimit = apiCommandFailureLimitConfig(undefined);
-let sampleApiCommand = createApiCommandSampler({ failureLimit });
+let apiCommandSampler = createApiCommandSampler({ failureLimit });
+let shutdownPromise: Promise<void> | null = null;
+const activeApiCommands = new Set<Promise<unknown>>();
+
+const captureSuppressedFailures = (): void => {
+	for (const failure of apiCommandSampler.drainSuppressedFailures())
+		capture("api_command", { ...failure, failure: true, samplingRate: 1 });
+};
+
+const resetApiCommandSampler = (): void => {
+	captureSuppressedFailures();
+	apiCommandSampler = createApiCommandSampler({ failureLimit });
+};
 
 const setDistinctId = (nextDistinctId: string): void => {
-	if (distinctId !== nextDistinctId) sampleApiCommand = createApiCommandSampler({ failureLimit });
+	if (distinctId !== nextDistinctId) resetApiCommandSampler();
 	distinctId = nextDistinctId;
 };
 
@@ -51,7 +64,7 @@ const configureFailureLimit = async (metricsClient: PostHog): Promise<void> => {
 			FAILURE_LIMIT_FLAG,
 			FAILURE_LIMIT_CONFIG_ID,
 		);
-		if (client !== metricsClient) return;
+		if (client !== metricsClient || shutdownPromise !== null) return;
 
 		const nextFailureLimit = apiCommandFailureLimitConfig(payload);
 		if (
@@ -61,7 +74,7 @@ const configureFailureLimit = async (metricsClient: PostHog): Promise<void> => {
 			return;
 
 		failureLimit = nextFailureLimit;
-		sampleApiCommand = createApiCommandSampler({ failureLimit });
+		resetApiCommandSampler();
 	} catch {
 		// The built-in defaults are safe when remote configuration is unavailable.
 	}
@@ -125,10 +138,12 @@ const capture = (event: string, properties: Record<string, unknown>): void => {
 export const withApiCommandCapture =
 	(command: string, handler: (params: unknown) => unknown) =>
 	async (params: unknown): Promise<unknown> => {
-		if (client === null) return handler(params);
+		const metricsClient = client;
+		if (metricsClient === null || shutdownPromise !== null) return handler(params);
 		const start = performance.now();
 		const record = (failure: boolean) => {
-			const decision = sampleApiCommand(command, failure);
+			if (client !== metricsClient) return;
+			const decision = apiCommandSampler.sample(command, failure);
 			if (decision === null) return;
 			capture("api_command", {
 				command,
@@ -137,13 +152,22 @@ export const withApiCommandCapture =
 				...decision,
 			});
 		};
+		let failure = false;
+		const invocation = (async () => {
+			try {
+				return await handler(params);
+			} catch (error) {
+				failure = true;
+				throw error;
+			} finally {
+				record(failure);
+			}
+		})();
+		activeApiCommands.add(invocation);
 		try {
-			const result = await handler(params);
-			record(false);
-			return result;
-		} catch (error) {
-			record(true);
-			throw error;
+			return await invocation;
+		} finally {
+			activeApiCommands.delete(invocation);
 		}
 	};
 
@@ -154,7 +178,7 @@ export const withApiCommandCapture =
  * desktop app, which resets it — since it is still the same person using us.
  */
 export const metricsOnLogin = async (profile: UserProfile): Promise<void> => {
-	if (client === null) return;
+	if (client === null || shutdownPromise !== null) return;
 	setDistinctId(`user_${profile.id}`);
 	try {
 		await updateTelemetryDistinctId(distinctId);
@@ -165,13 +189,36 @@ export const metricsOnLogin = async (profile: UserProfile): Promise<void> => {
 };
 
 /**
- * Flushes queued events, since the client only holds them in memory. Returns
- * null when there is nothing to flush, so quitting can proceed immediately —
- * and does so on the second call, making the quit handler reentrant.
+ * Gives active API commands half the shutdown budget, then flushes queued
+ * events with the time left. Returns null once there is nothing left to flush,
+ * making the quit handler reentrant.
  */
+const finishMetricsShutdown = async (flushing: PostHog): Promise<void> => {
+	const deadline = performance.now() + SHUTDOWN_TIMEOUT_MS;
+	if (activeApiCommands.size !== 0) {
+		let timeout: ReturnType<typeof setTimeout> | undefined;
+		await Promise.race([
+			Promise.allSettled(activeApiCommands),
+			new Promise<void>((resolve) => {
+				timeout = setTimeout(resolve, ACTIVE_API_COMMAND_SHUTDOWN_GRACE_MS);
+			}),
+		]);
+		if (timeout !== undefined) clearTimeout(timeout);
+	}
+
+	captureSuppressedFailures();
+	client = null;
+	await flushing.shutdown(Math.max(0, Math.ceil(deadline - performance.now())));
+};
+
 export const shutdownMetrics = (): Promise<void> | null => {
+	if (shutdownPromise !== null) return shutdownPromise;
 	if (client === null) return null;
 	const flushing = client;
-	client = null;
-	return flushing.shutdown(SHUTDOWN_TIMEOUT_MS).catch(() => undefined);
+	shutdownPromise = finishMetricsShutdown(flushing)
+		.catch(() => undefined)
+		.finally(() => {
+			shutdownPromise = null;
+		});
+	return shutdownPromise;
 };

--- a/apps/lite/harness/tests/api-command-sampling.test.ts
+++ b/apps/lite/harness/tests/api-command-sampling.test.ts
@@ -5,24 +5,44 @@ import {
 } from "../../electron/src/api-command-sampling.ts";
 
 describe("api command sampling", () => {
-	test("heavily samples watcher-driven diff reads", () => {
-		expect(createApiCommandSampler({ random: () => 0.009 })("treeChangeDiffs", false)).toEqual({
+	test.each([
+		"treeChangeDiffs",
+		"branchDiff",
+		"changesInWorktree",
+		"commentsList",
+		"commitDetailsWithLineStats",
+		"headInfo",
+		"listProjectsStateless",
+		"listReviews",
+		"workspaceFetchStatus",
+		"workspaceTargetCommits",
+	])("samples high-volume background read %s at 1%", (command) => {
+		expect(createApiCommandSampler({ random: () => 0.009 }).sample(command, false)).toEqual({
 			samplingRate: 0.01,
 		});
-		expect(createApiCommandSampler({ random: () => 0.01 })("treeChangeDiffs", false)).toBeNull();
+		expect(createApiCommandSampler({ random: () => 0.01 }).sample(command, false)).toBeNull();
 	});
 
-	test("samples other high-volume background reads", () => {
-		expect(createApiCommandSampler({ random: () => 0.09 })("workspaceFetchStatus", false)).toEqual({
+	test.each([
+		"branchDetails",
+		"branchList",
+		"getReview",
+		"getReviewMergeStatus",
+		"listCiChecks",
+		"listReviewComments",
+		"listReviewReactions",
+		"listReviewSubmissions",
+		"listReviewThreads",
+		"listReviewTimelineEvents",
+	])("samples automatic read %s", (command) => {
+		expect(createApiCommandSampler({ random: () => 0.09 }).sample(command, false)).toEqual({
 			samplingRate: 0.1,
 		});
-		expect(
-			createApiCommandSampler({ random: () => 0.1 })("workspaceFetchStatus", false),
-		).toBeNull();
+		expect(createApiCommandSampler({ random: () => 0.1 }).sample(command, false)).toBeNull();
 	});
 
 	test("always captures user-triggered commands", () => {
-		expect(createApiCommandSampler({ random: () => 0.99 })("commitCreate", false)).toEqual({
+		expect(createApiCommandSampler({ random: () => 0.99 }).sample("commitCreate", false)).toEqual({
 			samplingRate: 1,
 		});
 	});
@@ -31,10 +51,10 @@ describe("api command sampling", () => {
 describe("api command failure limiting", () => {
 	test("captures intermittent failures", () => {
 		let now = 0;
-		const sample = createApiCommandSampler({ now: () => now });
+		const { sample } = createApiCommandSampler({ now: () => now });
 
 		for (let index = 0; index < 20; index++) {
-			now = index * 10_000;
+			now = index * 60_000;
 			expect(sample("treeChangeDiffs", true)).toEqual({
 				occurrenceCount: 1,
 				samplingRate: 1,
@@ -44,20 +64,18 @@ describe("api command failure limiting", () => {
 
 	test("limits bursts and carries suppressed occurrences into the next event", () => {
 		let now = 0;
-		const sample = createApiCommandSampler({ now: () => now });
+		const { sample } = createApiCommandSampler({ now: () => now });
 
-		for (let index = 0; index < 10; index++)
-			expect(sample("treeChangeDiffs", true)?.occurrenceCount).toBe(1);
-
+		expect(sample("treeChangeDiffs", true)?.occurrenceCount).toBe(1);
 		expect(sample("treeChangeDiffs", true)).toBeNull();
-		now = 9_999;
+		now = 59_999;
 		expect(sample("treeChangeDiffs", true)).toBeNull();
-		now = 10_000;
+		now = 60_000;
 		expect(sample("treeChangeDiffs", true)?.occurrenceCount).toBe(3);
 	});
 
 	test("limits each command independently", () => {
-		const sample = createApiCommandSampler({
+		const { sample } = createApiCommandSampler({
 			failureLimit: { bucketSize: 1, refillIntervalMs: 10_000 },
 			now: () => 0,
 		});
@@ -70,7 +88,7 @@ describe("api command failure limiting", () => {
 	test("success sampling does not consume or reset failure tokens", () => {
 		let now = 0;
 		let random = 0;
-		const sample = createApiCommandSampler({
+		const { sample } = createApiCommandSampler({
 			failureLimit: { bucketSize: 1, refillIntervalMs: 10_000 },
 			now: () => now,
 			random: () => random,
@@ -88,7 +106,7 @@ describe("api command failure limiting", () => {
 
 	test("caps refilled tokens after a long idle", () => {
 		let now = 0;
-		const sample = createApiCommandSampler({
+		const { sample } = createApiCommandSampler({
 			failureLimit: { bucketSize: 2, refillIntervalMs: 10_000 },
 			now: () => now,
 		});
@@ -102,18 +120,34 @@ describe("api command failure limiting", () => {
 		expect(sample("treeChangeDiffs", true)).toBeNull();
 	});
 
+	test("drains suppressed failure tails once", () => {
+		const sampler = createApiCommandSampler({
+			failureLimit: { bucketSize: 1, refillIntervalMs: 60_000 },
+			now: () => 0,
+		});
+
+		const { sample } = sampler;
+		expect(sample("treeChangeDiffs", true)?.occurrenceCount).toBe(1);
+		expect(sample("treeChangeDiffs", true)).toBeNull();
+		expect(sample("treeChangeDiffs", true)).toBeNull();
+		expect(sampler.drainSuppressedFailures()).toEqual([
+			{ command: "treeChangeDiffs", occurrenceCount: 2 },
+		]);
+		expect(sampler.drainSuppressedFailures()).toEqual([]);
+	});
+
 	test("accepts a validated feature flag payload", () => {
 		expect(apiCommandFailureLimitConfig({ bucketSize: 20, refillIntervalSeconds: 5 })).toEqual({
 			bucketSize: 20,
 			refillIntervalMs: 5_000,
 		});
 		expect(apiCommandFailureLimitConfig({ bucketSize: 0, refillIntervalSeconds: "fast" })).toEqual({
-			bucketSize: 10,
-			refillIntervalMs: 10_000,
+			bucketSize: 1,
+			refillIntervalMs: 60_000,
 		});
 		expect(apiCommandFailureLimitConfig({ bucketSize: 1_001, refillIntervalSeconds: 10 })).toEqual({
-			bucketSize: 10,
-			refillIntervalMs: 10_000,
+			bucketSize: 1,
+			refillIntervalMs: 60_000,
 		});
 	});
 });

--- a/apps/lite/harness/tests/metrics.test.ts
+++ b/apps/lite/harness/tests/metrics.test.ts
@@ -80,7 +80,7 @@ describe("api command metrics", () => {
 		await metrics.shutdownMetrics();
 	});
 
-	test("applies failure limits, rethrows errors, and resets buckets on login", async () => {
+	test("applies failure limits, rethrows errors, and flushes before resetting on login", async () => {
 		const metrics = await initMetrics({ bucketSize: 1, refillIntervalSeconds: 10 });
 		const error = new Error("failed");
 		const wrapped = metrics.withApiCommandCapture(
@@ -108,10 +108,161 @@ describe("api command metrics", () => {
 		expect(mocks.client.capture).not.toHaveBeenCalled();
 
 		await metrics.metricsOnLogin(profile(2));
+		expect(mocks.client.capture).toHaveBeenCalledOnce();
+		expect(mocks.client.capture.mock.lastCall?.[0]).toMatchObject({
+			distinctId: "user_1",
+			properties: {
+				command: "treeChangeDiffs",
+				failure: true,
+				occurrenceCount: 1,
+				samplingRate: 1,
+			},
+		});
+		mocks.client.capture.mockClear();
 		await expect(wrapped(null)).rejects.toBe(error);
 		const capturedAfterLogin = mocks.client.capture.mock.lastCall?.[0];
 		expect(capturedAfterLogin?.distinctId).toBe("user_2");
 		expect(capturedAfterLogin?.properties.occurrenceCount).toBe(1);
 		await metrics.shutdownMetrics();
+	});
+
+	test("flushes suppressed failure counts on shutdown", async () => {
+		const metrics = await initMetrics({ bucketSize: 1, refillIntervalSeconds: 60 });
+		const error = new Error("failed");
+		const treeDiffs = metrics.withApiCommandCapture(
+			"treeChangeDiffs",
+			vi.fn().mockRejectedValue(error),
+		);
+		const fetchStatus = metrics.withApiCommandCapture(
+			"workspaceFetchStatus",
+			vi.fn().mockRejectedValue(error),
+		);
+
+		await expect(treeDiffs(null)).rejects.toBe(error);
+		await expect(treeDiffs(null)).rejects.toBe(error);
+		await expect(treeDiffs(null)).rejects.toBe(error);
+		await expect(fetchStatus(null)).rejects.toBe(error);
+		await expect(fetchStatus(null)).rejects.toBe(error);
+		mocks.client.capture.mockClear();
+		mocks.client.shutdown.mockImplementationOnce(() => {
+			expect(mocks.client.capture).toHaveBeenCalledTimes(2);
+			return Promise.resolve();
+		});
+
+		await metrics.shutdownMetrics();
+
+		expect(mocks.client.capture.mock.calls.map(([event]) => event.properties)).toEqual([
+			expect.objectContaining({
+				command: "treeChangeDiffs",
+				failure: true,
+				occurrenceCount: 2,
+				samplingRate: 1,
+			}),
+			expect.objectContaining({
+				command: "workspaceFetchStatus",
+				failure: true,
+				occurrenceCount: 1,
+				samplingRate: 1,
+			}),
+		]);
+	});
+
+	test("waits for all active commands before draining suppressed failures", async () => {
+		const metrics = await initMetrics({ bucketSize: 1, refillIntervalSeconds: 60 });
+		const error = new Error("failed");
+		let failPending: (error: Error) => void = () => {};
+		let finishPending: () => void = () => {};
+		const handler = vi
+			.fn()
+			.mockRejectedValueOnce(error)
+			.mockImplementationOnce(
+				() =>
+					new Promise((_, reject) => {
+						failPending = reject;
+					}),
+			);
+		const wrapped = metrics.withApiCommandCapture("treeChangeDiffs", handler);
+		const otherWrapped = metrics.withApiCommandCapture(
+			"commitCreate",
+			() =>
+				new Promise<void>((resolve) => {
+					finishPending = resolve;
+				}),
+		);
+
+		await expect(wrapped(null)).rejects.toBe(error);
+		const pending = wrapped(null);
+		const otherPending = otherWrapped(null);
+		mocks.client.capture.mockClear();
+		const shutdown = metrics.shutdownMetrics();
+
+		expect(shutdown).not.toBeNull();
+		expect(mocks.client.shutdown).not.toHaveBeenCalled();
+		failPending(error);
+		await expect(pending).rejects.toBe(error);
+		expect(mocks.client.shutdown).not.toHaveBeenCalled();
+		finishPending();
+		await otherPending;
+		await shutdown;
+
+		expect(mocks.client.capture.mock.calls.map(([event]) => event.properties)).toEqual([
+			expect.objectContaining({ command: "commitCreate", failure: false, samplingRate: 1 }),
+			expect.objectContaining({
+				command: "treeChangeDiffs",
+				failure: true,
+				occurrenceCount: 1,
+				samplingRate: 1,
+			}),
+		]);
+		expect(mocks.client.shutdown).toHaveBeenCalledOnce();
+	});
+
+	test("bounds the wait for an active command", async () => {
+		vi.useFakeTimers();
+		try {
+			const metrics = await initMetrics();
+			const error = new Error("failed");
+			let failPending: (error: Error) => void = () => {};
+			const wrapped = metrics.withApiCommandCapture(
+				"treeChangeDiffs",
+				() =>
+					new Promise((_, reject) => {
+						failPending = reject;
+					}),
+			);
+			const pending = wrapped(null);
+
+			const shutdown = metrics.shutdownMetrics();
+			expect(mocks.client.shutdown).not.toHaveBeenCalled();
+
+			await vi.advanceTimersByTimeAsync(1_000);
+			await shutdown;
+			expect(mocks.client.shutdown).toHaveBeenCalledWith(1_000);
+
+			failPending(error);
+			await expect(pending).rejects.toBe(error);
+			expect(mocks.client.capture).not.toHaveBeenCalled();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	test("keeps an in-progress shutdown reentrant until flushing finishes", async () => {
+		const metrics = await initMetrics();
+		let finishShutdown: () => void = () => {};
+		mocks.client.shutdown.mockReturnValueOnce(
+			new Promise<void>((resolve) => {
+				finishShutdown = resolve;
+			}),
+		);
+
+		const firstShutdown = metrics.shutdownMetrics();
+		const secondShutdown = metrics.shutdownMetrics();
+
+		expect(firstShutdown).toBe(secondShutdown);
+		expect(mocks.client.shutdown).toHaveBeenCalledOnce();
+		finishShutdown();
+		await firstShutdown;
+		expect(metrics.shutdownMetrics()).toBeNull();
 	});
 });


### PR DESCRIPTION
Reduce background command volume, cover automatic reads, and retain throttled failure counts through shutdown.