### PR TITLE
Fix PR comment composer shortcut

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
@@ -412,7 +412,9 @@ export const CommitForm: FC<{
 		},
 		{
 			hotkey: changesHotkeys.commit.hotkey,
-			callback: createCommit,
+			callback: (event) => {
+				if (!event.repeat) createCommit();
+			},
 			options: {
 				conflictBehavior: "allow",
 				enabled: canCommit,

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestComments.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestComments.tsx
@@ -64,8 +64,8 @@ import { forgeHunkPatch, threadStillAnchoredInFile } from "#ui/review-threads.ts
 import { defaultSettings } from "#ui/settings.ts";
 import { pullRequestHotkeys } from "#ui/hotkeys.ts";
 import { FreshBadge, RegisterFreshItems } from "#ui/review-arrival.tsx";
-import { useHotkey } from "@tanstack/react-hotkeys";
 import { PatchDiff } from "@pierre/diffs/react";
+import { matchesKeyboardEvent } from "@tanstack/react-hotkeys";
 import { useQuery } from "@tanstack/react-query";
 import { clearReviewFocus, useRequestedComment } from "#ui/review-focus.ts";
 import {
@@ -992,7 +992,6 @@ const Composer: FC<{
 	const [engaged, setEngaged] = useState(false);
 	const empty = draft.trim() === "";
 	const expanded = engaged || !empty;
-	const composerRef = useRef<HTMLDivElement | null>(null);
 	// Stable, so it runs on real mount only — and the box only ever mounts by
 	// being unfolded, whatever asked for it, so focus follows.
 	const attachInput = useCallback(
@@ -1010,14 +1009,6 @@ const Composer: FC<{
 		setEngaged(false);
 	};
 
-	// Scoped to the composer, so the same chord on the description form below
-	// still submits that instead.
-	useHotkey(pullRequestHotkeys.comment.hotkey, submit, {
-		conflictBehavior: "allow",
-		enabled: !empty,
-		target: composerRef,
-	});
-
 	if (!expanded) {
 		return (
 			<button
@@ -1033,14 +1024,20 @@ const Composer: FC<{
 	}
 
 	return (
+		// oxlint-disable-next-line jsx-a11y/no-static-element-interactions -- The composer owns its advertised shortcut while any child control is focused.
 		<div
 			className={styles.composer}
 			data-body-scrolled={scrolled || undefined}
+			onKeyDown={(evt) => {
+				if (!matchesKeyboardEvent(evt.nativeEvent, pullRequestHotkeys.comment.hotkey)) return;
+				evt.preventDefault();
+				evt.stopPropagation();
+				if (!evt.repeat && !empty) submit();
+			}}
 			// Leaving the whole composer with nothing written folds it back.
 			onBlur={(evt) => {
 				if (empty && !evt.currentTarget.contains(evt.relatedTarget)) setEngaged(false);
 			}}
-			ref={composerRef}
 		>
 			<MarkdownToolbar
 				className={styles.composerToolbar}

--- a/apps/lite/ui/src/routes/project/$id/workspace/comment-shortcut.test.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/comment-shortcut.test.tsx
@@ -1,0 +1,178 @@
+/** @vitest-environment jsdom */
+
+import type { ForgeReview, WorktreeChanges } from "@gitbutler/but-sdk";
+import { getHotkeyManager } from "@tanstack/react-hotkeys";
+import type * as ReactQuery from "@tanstack/react-query";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+declare global {
+	var IS_REACT_ACT_ENVIRONMENT: boolean | undefined;
+}
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+globalThis.window.lite = { platform: "linux" } as typeof window.lite;
+
+const mutations = vi.hoisted(() => ({ commit: vi.fn(), comment: vi.fn() }));
+
+vi.mock("#ui/api/mutations.ts", () => ({
+	useBranchCreate: () => ({ isPending: false, mutate: vi.fn() }),
+	useCommitCreate: () => ({ isPending: false, mutate: mutations.commit }),
+	useCreateReviewComment: () => ({ mutate: mutations.comment }),
+	useGenerateCommitMessage: () => ({ isPending: false, mutate: vi.fn() }),
+	useUploadFiles: () => vi.fn(),
+}));
+vi.mock("#ui/commit.ts", () => ({
+	draftCommitMessageQueryOptions: () => ({}),
+	usePersistDraftCommitMessage: () => ({ mutate: vi.fn() }),
+}));
+vi.mock("#ui/projects/state.ts", () => ({
+	projectSlice: {
+		selectors: {
+			selectCheckedUncommittedFilePaths: () => new Set(),
+			selectPendingOperation: () => ({ _tag: "None" }),
+		},
+	},
+}));
+vi.mock("#ui/store.ts", () => ({
+	useAppSelector: (selector: (state: object) => unknown) => selector({}),
+	useAppStore: () => ({ getState: () => ({}) }),
+}));
+vi.mock("#ui/use-cursor.ts", () => ({ setCursor: vi.fn() }));
+vi.mock("#ui/review-arrival.tsx", () => ({
+	FreshBadge: () => null,
+	RegisterFreshItems: () => null,
+}));
+vi.mock("@tanstack/react-query", async (importOriginal) => ({
+	...(await importOriginal<typeof ReactQuery>()),
+	useIsMutating: () => 0,
+	useQuery: () => ({ data: undefined, isPending: false }),
+}));
+
+const [{ CommitForm }, { PullRequestComments }] = await Promise.all([
+	import("./CommitForm.tsx"),
+	import("./PullRequestComments.tsx"),
+]);
+
+const review = {
+	number: 7,
+	sourceBranch: "review-branch",
+	createdAt: null,
+} as ForgeReview;
+const worktreeChanges = {
+	changes: [],
+} as unknown as WorktreeChanges;
+
+const Fixture = () => (
+	<>
+		<CommitForm
+			projectId="project-id"
+			commitTarget={{
+				label: "main",
+				address: { _tag: "Branch", branchRef: [] },
+				relativeTo: { type: "referenceBytes", subject: [] },
+			}}
+			targetComboboxItems={[]}
+			hasNoBranches={false}
+			startCommitButtonId="start-commit"
+			commitMessageInputId="commit-message"
+			onAmendCommit={vi.fn()}
+			canAmendCommit={false}
+			worktreeChanges={worktreeChanges}
+		/>
+		<PullRequestComments projectId="project-id" review={review} />
+	</>
+);
+
+const pressModEnter = (target: Element, repeat = false) =>
+	act(() => {
+		target.dispatchEvent(
+			new KeyboardEvent("keydown", {
+				bubbles: true,
+				cancelable: true,
+				ctrlKey: true,
+				key: "Enter",
+				repeat,
+			}),
+		);
+	});
+
+const enterComment = (composer: HTMLTextAreaElement, value: string) =>
+	act(() => {
+		// oxlint-disable-next-line typescript/unbound-method -- Invoked with the textarea receiver below.
+		const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value")?.set;
+		if (!setter) throw new Error("Textarea value setter is unavailable");
+		Reflect.apply(setter, composer, [value]);
+		composer.dispatchEvent(new Event("input", { bubbles: true }));
+	});
+
+describe("pull request comment shortcut", () => {
+	let container: HTMLDivElement;
+	let root: Root;
+
+	beforeEach(() => {
+		mutations.commit.mockReset();
+		mutations.comment.mockReset();
+		container = document.createElement("div");
+		document.body.append(container);
+		root = createRoot(container);
+		act(() => root.render(<Fixture />));
+	});
+
+	afterEach(() => {
+		act(() => root.unmount());
+		container.remove();
+		getHotkeyManager().destroy();
+	});
+
+	it("posts one focused comment without creating a workspace commit", () => {
+		const collapsed = container.querySelector<HTMLButtonElement>('[aria-label="Write a comment"]');
+		if (!collapsed) throw new Error("Comment composer did not render");
+		act(() => collapsed.focus());
+
+		const composer = container.querySelector<HTMLTextAreaElement>('[aria-label="Write a comment"]');
+		if (!composer) throw new Error("Comment input did not expand");
+		enterComment(composer, "Ship this");
+		pressModEnter(composer, true);
+		expect(mutations.comment).not.toHaveBeenCalled();
+		expect(mutations.commit).not.toHaveBeenCalled();
+		pressModEnter(composer);
+		pressModEnter(document.body, true);
+
+		expect(mutations.comment).toHaveBeenCalledTimes(1);
+		expect(mutations.commit).not.toHaveBeenCalled();
+		const cleared = container.querySelector<HTMLButtonElement>('[aria-label="Write a comment"]');
+		if (!cleared) throw new Error("Cleared composer did not collapse");
+		act(() => cleared.focus());
+		expect(
+			container.querySelector<HTMLTextAreaElement>('[aria-label="Write a comment"]')?.value,
+		).toBe("");
+	});
+
+	it("keeps Mod+Enter with the composer when a footer control is focused", () => {
+		const collapsed = container.querySelector<HTMLButtonElement>('[aria-label="Write a comment"]');
+		if (!collapsed) throw new Error("Comment composer did not render");
+		act(() => collapsed.focus());
+
+		const composer = container.querySelector<HTMLTextAreaElement>('[aria-label="Write a comment"]');
+		if (!composer) throw new Error("Comment input did not expand");
+		enterComment(composer, "Ship this");
+		const commentButton = [...container.querySelectorAll("button")].find((button) =>
+			button.textContent.startsWith("Comment"),
+		);
+		if (!commentButton) throw new Error("Comment button did not render");
+		act(() => commentButton.focus());
+		pressModEnter(commentButton);
+
+		expect(mutations.comment).toHaveBeenCalledTimes(1);
+		expect(mutations.commit).not.toHaveBeenCalled();
+	});
+
+	it("commits when Mod+Enter is pressed outside the composer", () => {
+		pressModEnter(document.body);
+
+		expect(mutations.commit).toHaveBeenCalledTimes(1);
+		expect(mutations.comment).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Context

In the PR comment composer, pressing Mod+Enter could create “(no message) commits” while the comment draft remained instead of posting the review comment.

## Change

Handle the advertised shortcut at the focused composer input and stop it before the workspace commit action. A focused UI regression test covers one review-comment mutation, zero commit mutations, a cleared composer, and the unchanged commit shortcut outside the composer.

FYI @PavelLaptev