### PR TITLE
fix: repair broken username in codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,11 +1,11 @@
 /CODEOWNERS @krlvi @schacon
 /.github @krlvi @schacon @Caleb-T-Owens @mtsgrd @slarse
-/crates/but-core @krlvi @Caleb-T-Owens @jonathantanmy2, @davidpdrsn
-/crates/but-ctx @krlvi @Caleb-T-Owens @jonathantanmy2, @davidpdrsn
-/crates/but-db @krlvi @Caleb-T-Owens @jonathantanmy2, @davidpdrsn
-/crates/but-fs @krlvi @Caleb-T-Owens @jonathantanmy2, @davidpdrsn
-/crates/but-graph @krlvi @Caleb-T-Owens @jonathantanmy2, @davidpdrsn
-/crates/but-rebase @krlvi @Caleb-T-Owens @jonathantanmy2, @davidpdrsn
-/crates/but-meta @krlvi @Caleb-T-Owens @jonathantanmy2, @davidpdrsn
-/crates/but-secret @krlvi @Caleb-T-Owens @jonathantanmy2, @davidpdrsn
-/crates/but-update @krlvi @Caleb-T-Owens @jonathantanmy2, @davidpdrsn
+/crates/but-core @krlvi @Caleb-T-Owens @jonathantanmy2 @davidpdrsn
+/crates/but-ctx @krlvi @Caleb-T-Owens @jonathantanmy2 @davidpdrsn
+/crates/but-db @krlvi @Caleb-T-Owens @jonathantanmy2 @davidpdrsn
+/crates/but-fs @krlvi @Caleb-T-Owens @jonathantanmy2 @davidpdrsn
+/crates/but-graph @krlvi @Caleb-T-Owens @jonathantanmy2 @davidpdrsn
+/crates/but-rebase @krlvi @Caleb-T-Owens @jonathantanmy2 @davidpdrsn
+/crates/but-meta @krlvi @Caleb-T-Owens @jonathantanmy2 @davidpdrsn
+/crates/but-secret @krlvi @Caleb-T-Owens @jonathantanmy2 @davidpdrsn
+/crates/but-update @krlvi @Caleb-T-Owens @jonathantanmy2 @davidpdrsn


### PR DESCRIPTION
The trailing comma wrecks @jonathantanmy2's username