### PR TITLE
Fix absorb recreating gitbutler/workspace in single-branch mode

### DIFF
--- a/crates/but-api/src/legacy/absorb.rs
+++ b/crates/but-api/src/legacy/absorb.rs
@@ -34,8 +34,7 @@ use but_core::DryRun;
 /// This acquires exclusive worktree access from `ctx` before creating the
 /// snapshot and rewriting commits.
 ///
-/// Before applying the plan, this records an `Absorb` oplog snapshot and refreshes the
-/// synthetic workspace commit after the rewritten commits are in place.
+/// Before applying the plan, this records an `Absorb` oplog snapshot.
 #[but_api(napi)]
 #[instrument(err(Debug))]
 pub fn absorb(ctx: &mut Context, absorption_plan: Vec<CommitAbsorption>) -> anyhow::Result<usize> {
@@ -49,18 +48,7 @@ pub fn absorb(ctx: &mut Context, absorption_plan: Vec<CommitAbsorption>) -> anyh
         )
         .ok(); // Ignore errors for snapshot creation
 
-    let total_rejected = absorb_with_perm(ctx, absorption_plan, guard.write_permission())?;
-
-    // Refresh the workspace commit so `gitbutler/workspace` HEAD stays in sync
-    // with the rewritten branch commits. Without this, tools that inspect HEAD
-    // (e.g. pre-push hooks that stash against it) see a stale synthetic commit.
-    gitbutler_branch_actions::update_workspace_commit_with_perm(
-        ctx,
-        false,
-        guard.write_permission(),
-    )?;
-
-    Ok(total_rejected)
+    absorb_with_perm(ctx, absorption_plan, guard.write_permission())
 }
 
 /// Absorb the changes described by `absorption_plan` using the exclusive repository

--- a/crates/but/src/command/legacy/absorb.rs
+++ b/crates/but/src/command/legacy/absorb.rs
@@ -152,10 +152,6 @@ fn absorb_assignments(
     skipped_merged: Vec<String>,
 ) -> anyhow::Result<()> {
     let total_rejected = but_api::legacy::absorb::absorb_with_perm(ctx, absorption_plan, perm)?;
-    // Refresh the workspace commit so `gitbutler/workspace` HEAD stays in sync
-    // with the rewritten branch commits. Without this, tools that inspect HEAD
-    // (e.g. pre-push hooks that stash against it) see a stale synthetic commit.
-    gitbutler_branch_actions::update_workspace_commit_with_perm(ctx, false, perm)?;
 
     // Display completion message
     let t = theme::get();

--- a/crates/but/tests/but/command/absorb.rs
+++ b/crates/but/tests/but/command/absorb.rs
@@ -637,6 +637,21 @@ fn workspace_head_is_refreshed_after_absorb() {
         ws_before, ws_after,
         "gitbutler/workspace HEAD should be refreshed after absorb"
     );
+    // The refreshed workspace commit merges the rewritten stack tips.
+    let mut parents: Vec<_> = repo
+        .find_commit(ws_after)
+        .unwrap()
+        .parent_ids()
+        .map(|id| id.detach())
+        .collect();
+    let mut tips =
+        ["A", "B"].map(|branch| repo.rev_parse_single(branch.as_bytes()).unwrap().detach());
+    parents.sort();
+    tips.sort();
+    assert_eq!(
+        parents, tips,
+        "workspace commit parents must be the current stack tips"
+    );
     // The workspace tree carries the absorbed content, so tools inspecting
     // HEAD see the amended state rather than a stale one.
     let blob = repo

--- a/crates/but/tests/but/command/absorb.rs
+++ b/crates/but/tests/but/command/absorb.rs
@@ -637,6 +637,28 @@ fn workspace_head_is_refreshed_after_absorb() {
         ws_before, ws_after,
         "gitbutler/workspace HEAD should be refreshed after absorb"
     );
+    // The workspace tree carries the absorbed content, so tools inspecting
+    // HEAD see the amended state rather than a stale one.
+    let blob = repo
+        .rev_parse_single(b"gitbutler/workspace:a.txt")
+        .unwrap()
+        .object()
+        .unwrap();
+    snapbox::assert_data_eq!(
+        blob.data.as_bstr().to_string(),
+        snapbox::str![[r#"
+firsta
+line
+line
+line
+line
+line
+line
+line
+lasta
+
+"#]]
+    );
 }
 
 #[test]
@@ -736,4 +758,46 @@ fn absorb_json_reports_partially_skipped_merged_upstream_commits() {
 warning: skipped absorbing into 1 merged-upstream commit(s): 756ee31. Run `but pull` to update the workspace, or pass --allow-merged to absorb anyway.
 
 "#]]);
+}
+
+/// Regression test for GB-1534: in single-branch mode absorb must amend the
+/// checked-out branch without recreating `gitbutler/workspace` and moving
+/// `HEAD` onto it.
+#[test]
+fn single_branch_absorb_keeps_head_on_branch() {
+    let env = Sandbox::open_with_default_settings("single-branch-mode");
+    env.but("branch new feature").assert().success();
+    env.file("file.txt", "a\nb\nc\n");
+    env.but("commit -m 'change b'").assert().success();
+    env.file("file.txt", "a\nB\nc\n");
+
+    env.but("absorb").assert().success().stderr_eq(str![""]);
+
+    let repo = env.open_repo();
+    let blob = repo
+        .rev_parse_single(b"feature:file.txt")
+        .unwrap()
+        .object()
+        .unwrap();
+    // The change was absorbed into the branch commit.
+    snapbox::assert_data_eq!(
+        blob.data.as_bstr().to_string(),
+        snapbox::str![[r#"
+a
+B
+c
+
+"#]]
+    );
+    assert_eq!(
+        env.invoke_git("symbolic-ref --short HEAD"),
+        "feature",
+        "absorb must leave HEAD on the checked-out branch"
+    );
+    assert!(
+        repo.try_find_reference("refs/heads/gitbutler/workspace")
+            .unwrap()
+            .is_none(),
+        "absorb must not create a workspace ref in single-branch mode"
+    );
 }

--- a/packages/but-sdk/src/generated/graph/index.d.ts
+++ b/packages/but-sdk/src/generated/graph/index.d.ts
@@ -12,10 +12,9 @@ export declare function abortEditAndReturnToWorkspace(projectId: string, force: 
  * This acquires exclusive worktree access from `ctx` before creating the
  * snapshot and rewriting commits.
  *
- * Before applying the plan, this records an `Absorb` oplog snapshot and refreshes the
- * synthetic workspace commit after the rewritten commits are in place.
+ * Before applying the plan, this records an `Absorb` oplog snapshot.
  *
- * {@link ../../../../../crates/but-api/src/legacy/absorb.rs:39}
+ * {@link ../../../../../crates/but-api/src/legacy/absorb.rs:38}
  */
 export declare function absorb(projectId: string, absorptionPlan: Array<CommitAbsorption>): Promise<number>
 
@@ -23,7 +22,7 @@ export declare function absorb(projectId: string, absorptionPlan: Array<CommitAb
  * Build an absorption plan for `target` using the behavior documented by
  * [`absorption_plan_with_perm()`].
  *
- * {@link ../../../../../crates/but-api/src/legacy/absorb.rs:105}
+ * {@link ../../../../../crates/but-api/src/legacy/absorb.rs:93}
  */
 export declare function absorptionPlan(projectId: string, target: AbsorptionTarget): Promise<Array<CommitAbsorption>>
 

--- a/packages/but-sdk/src/generated/linear/index.d.ts
+++ b/packages/but-sdk/src/generated/linear/index.d.ts
@@ -12,10 +12,9 @@ export declare function abortEditAndReturnToWorkspace(projectId: string, force: 
  * This acquires exclusive worktree access from `ctx` before creating the
  * snapshot and rewriting commits.
  *
- * Before applying the plan, this records an `Absorb` oplog snapshot and refreshes the
- * synthetic workspace commit after the rewritten commits are in place.
+ * Before applying the plan, this records an `Absorb` oplog snapshot.
  *
- * {@link ../../../../../crates/but-api/src/legacy/absorb.rs:39}
+ * {@link ../../../../../crates/but-api/src/legacy/absorb.rs:38}
  */
 export declare function absorb(projectId: string, absorptionPlan: Array<CommitAbsorption>): Promise<number>
 
@@ -23,7 +22,7 @@ export declare function absorb(projectId: string, absorptionPlan: Array<CommitAb
  * Build an absorption plan for `target` using the behavior documented by
  * [`absorption_plan_with_perm()`].
  *
- * {@link ../../../../../crates/but-api/src/legacy/absorb.rs:105}
+ * {@link ../../../../../crates/but-api/src/legacy/absorb.rs:93}
  */
 export declare function absorptionPlan(projectId: string, target: AbsorptionTarget): Promise<Array<CommitAbsorption>>
 


### PR DESCRIPTION
## Context

In single-branch mode, running `but absorb` correctly rewrote the selected branch commit but then created `gitbutler/workspace` and moved `HEAD` onto it. This silently switched the repository back into managed workspace mode and disrupted subsequent branch-oriented work.

Both absorb entry points performed a legacy workspace refresh after graph materialization. That extra refresh was redundant in managed mode and unconditional in single-branch mode.

## Change

- rely on graph materialization to update refs after absorb
- remove the redundant legacy refresh from the API and CLI paths
- cover the single-branch `HEAD`/ref invariant
- strengthen managed two-stack coverage to verify both workspace parents and absorbed tree content

Absorption behavior, snapshots, output contracts, locking, and legitimate workspace initialization paths are unchanged.

Fixes GB-1534
