### PR TITLE
fix(lite): a folded branch stays folded when renamed

### DIFF
--- a/apps/lite/ui/src/projects/project.test.ts
+++ b/apps/lite/ui/src/projects/project.test.ts
@@ -1,0 +1,31 @@
+import { encodeBytes } from "#ui/api/bytes.ts";
+import { createInitialProjectState, projectReducers } from "#ui/projects/project.ts";
+import { describe, expect, test } from "vitest";
+
+describe("updateRewrittenBranchReferences", () => {
+	const rename = (from: string, to: string, folded: Array<string>) => {
+		const state = createInitialProjectState();
+		for (const ref of folded) state.workspace.foldedSegments[ref] = true;
+		projectReducers.updateRewrittenBranchReferences(state, {
+			oldBranch: { branchRef: encodeBytes(from) },
+			newBranch: { branchRef: encodeBytes(to) },
+		});
+		return state.workspace.foldedSegments;
+	};
+
+	test("a folded segment stays folded under its new ref after a rename", () => {
+		expect(rename("refs/heads/old", "refs/heads/new", ["refs/heads/old"])).toEqual({
+			"refs/heads/new": true,
+		});
+	});
+
+	test("renaming an unfolded segment leaves it unfolded", () => {
+		expect(rename("refs/heads/old", "refs/heads/new", [])).toEqual({});
+	});
+
+	test("unrelated folded segments are untouched", () => {
+		expect(rename("refs/heads/old", "refs/heads/new", ["refs/heads/other"])).toEqual({
+			"refs/heads/other": true,
+		});
+	});
+});

--- a/apps/lite/ui/src/projects/project.ts
+++ b/apps/lite/ui/src/projects/project.ts
@@ -196,6 +196,12 @@ export const projectReducers = {
 		)
 			workspaceState.pendingOperation = pendingInlineEdit({ address: branchAddress(newBranch) });
 
+		const oldRef = decodeBytes(oldBranch.branchRef);
+		if (workspaceState.foldedSegments[oldRef]) {
+			delete workspaceState.foldedSegments[oldRef];
+			workspaceState.foldedSegments[decodeBytes(newBranch.branchRef)] = true;
+		}
+
 		const oldFileParent = branchFileParent(oldBranch);
 		const newFileParent = branchFileParent(newBranch);
 		for (const [key, address] of Object.entries(workspaceState.checkedAddresses)) {


### PR DESCRIPTION
When renaming a folded branch, it would become unfolded; when renaming it back to the original name, it would become folded again. Fix this by migrating the folded state to the new branch name upon successfully renaming a branch.

Resolves [my comment about this on Discord from this morning](https://discord.com/channels/1060193121130000425/1481308709001891961/1545032628095426640) 