### PR TITLE
test(but): derive initial test change IDs from commit content

### DIFF
--- a/crates/but-core/src/commit/mod.rs
+++ b/crates/but-core/src/commit/mod.rs
@@ -86,23 +86,30 @@ impl Headers {
     }
 
     /// Create a new instance, with the following rules for setting the change id header:
-    /// 1. Read `gitbutler.testing.changeId` from `config` and if it's a valid u128 integer, use it as change-id.
-    /// 2. generate a new change-id
+    /// 1. If `gitbutler.testing.changeId` is `content-hash`, use a placeholder that is replaced
+    ///    with an ID derived from the final commit content by [`create()`].
+    /// 2. If `gitbutler.testing.changeId` is a valid u128 integer, use it as change-id.
+    /// 3. Generate a new change-id.
     ///
     /// This produces a stored header value. For the deterministic fallback used when headerless
     /// commits still need a change-id, see [`Self::ensure_change_id()`].
     pub fn from_config(config: &gix::config::Snapshot) -> Self {
+        let use_content_hash = config
+            .string(TESTING_CHANGE_ID_KEY)
+            .is_some_and(|value| value.as_slice() == TESTING_CHANGE_ID_CONTENT_HASH);
         Headers {
-            change_id: Some(
+            change_id: Some(if use_content_hash {
+                ChangeId::from(BString::from(CONTENT_HASH_CHANGE_ID_PLACEHOLDER))
+            } else {
                 config
-                    .integer("gitbutler.testing.changeId")
+                    .integer(TESTING_CHANGE_ID_KEY)
                     .and_then(|id| {
                         u128::try_from(id)
                             .ok()
                             .map(ChangeId::from_number_for_testing)
                     })
-                    .unwrap_or_else(ChangeId::generate),
-            ),
+                    .unwrap_or_else(ChangeId::generate)
+            }),
             conflicted: None,
         }
     }
@@ -181,6 +188,9 @@ impl Headers {
 const HEADERS_VERSION_FIELD: &str = "gitbutler-headers-version";
 const HEADERS_CHANGE_ID_FIELD: &str = "gitbutler-change-id";
 const HEADERS_NEW_CHANGE_ID_FIELD: &str = "change-id";
+const TESTING_CHANGE_ID_KEY: &str = "gitbutler.testing.changeId";
+const TESTING_CHANGE_ID_CONTENT_HASH: &[u8] = b"content-hash";
+const CONTENT_HASH_CHANGE_ID_PLACEHOLDER: &[u8] = b"gitbutler-content-hash-placeholder";
 /// The name of the header field that stores the amount of conflicted files.
 pub const HEADERS_CONFLICTED_FIELD: &str = "gitbutler-conflicted";
 const HEADERS_VERSION: &str = "2";
@@ -237,6 +247,8 @@ pub enum SignCommit {
 /// new one based on repository configuration, and optionally updating `update_ref` to the new ID.
 ///
 /// Apply any desired message/header mutations, such as Gerrit trailers, before calling this helper.
+/// A content-hash change-ID placeholder created by [`Headers::from_config()`] is resolved after
+/// removing an old signature and before creating a new one.
 pub fn create(
     repo: &gix::Repository,
     mut commit: gix::objs::Commit,
@@ -249,6 +261,8 @@ pub fn create(
     {
         commit.extra_headers.remove(pos);
     }
+
+    resolve_content_hash_change_id(repo, &mut commit)?;
 
     if (sign_commit == SignCommit::IfSignCommitsEnabled
         && repo.git_settings()?.gitbutler_sign_commits.unwrap_or(false))
@@ -299,6 +313,27 @@ pub fn create(
         )?;
     }
     Ok(oid)
+}
+
+fn resolve_content_hash_change_id(
+    repo: &gix::Repository,
+    commit: &mut gix::objs::Commit,
+) -> anyhow::Result<()> {
+    let Some(pos) = commit.extra_headers.iter().position(|(name, value)| {
+        name.as_slice() == HEADERS_NEW_CHANGE_ID_FIELD.as_bytes()
+            && value.as_slice() == CONTENT_HASH_CHANGE_ID_PLACEHOLDER
+    }) else {
+        return Ok(());
+    };
+
+    let mut commit_without_change_id = commit.clone();
+    commit_without_change_id.extra_headers.remove(pos);
+    let mut buf = Vec::new();
+    commit_without_change_id.write_to(&mut buf)?;
+    let content_id = gix::objs::compute_hash(repo.object_hash(), gix::object::Kind::Commit, &buf)?;
+    let change_id = Headers::synthetic_change_id_from_commit_id(content_id);
+    commit.extra_headers[pos].1 = change_id.as_bstr().to_owned();
+    Ok(())
 }
 
 /// Sign `buffer` using repository configuration as obtained through `repo`,

--- a/crates/but-core/tests/core/commit.rs
+++ b/crates/but-core/tests/core/commit.rs
@@ -324,10 +324,69 @@ Headers {
 mod create {
     use anyhow::Context as _;
     use bstr::ByteSlice;
-    use but_core::commit::{self, SignCommit};
+    use but_core::commit::{self, Headers, SignCommit};
     use but_error::Code;
     use but_testsupport::{writable_scenario, writable_scenario_with_ssh_key};
-    use gix::{objs::commit::SIGNATURE_FIELD_NAME, refs};
+    use gix::{
+        objs::{WriteTo as _, commit::SIGNATURE_FIELD_NAME},
+        refs,
+    };
+
+    #[test]
+    fn content_hash_change_id_is_derived_from_commit_without_its_change_id_header()
+    -> anyhow::Result<()> {
+        let (mut repo, _tmp) = writable_scenario("single-unsigned");
+        repo.config_snapshot_mut()
+            .set_raw_value("gitbutler.testing.changeId", "content-hash")?;
+        let mut new_commit = commit_from_head(&repo, "content-derived change ID")?;
+        Headers::from_config(&repo.config_snapshot()).set_in_commit(&mut new_commit);
+
+        let oid = commit::create(&repo, new_commit, None, SignCommit::No)?;
+        let commit = repo.find_commit(oid)?.decode()?.to_owned()?;
+        let actual_change_id = Headers::try_from_commit(&commit)
+            .and_then(|headers| headers.change_id)
+            .context("created commit should have a change ID")?;
+
+        let mut commit_without_change_id = commit;
+        let change_id_pos = commit_without_change_id
+            .extra_headers()
+            .find_pos("change-id")
+            .context("created commit should have a change-id header")?;
+        commit_without_change_id.extra_headers.remove(change_id_pos);
+        let mut buf = Vec::new();
+        commit_without_change_id.write_to(&mut buf)?;
+        let content_id =
+            gix::objs::compute_hash(repo.object_hash(), gix::object::Kind::Commit, &buf)?;
+        let expected_change_id = Headers::synthetic_change_id_from_commit_id(content_id);
+
+        assert_eq!(
+            actual_change_id, expected_change_id,
+            "change ID should represent final commit content without the change-id header"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn content_hash_mode_keeps_an_existing_change_id() -> anyhow::Result<()> {
+        let (mut repo, _tmp) = writable_scenario("single-unsigned");
+        repo.config_snapshot_mut()
+            .set_raw_value("gitbutler.testing.changeId", "content-hash")?;
+        let mut new_commit = commit_from_head(&repo, "preserve change ID")?;
+        let expected_change_id = but_core::ChangeId::from_number_for_testing(42);
+        Headers::from_change_id(expected_change_id.clone()).set_in_commit(&mut new_commit);
+
+        let oid = commit::create(&repo, new_commit, None, SignCommit::No)?;
+        let commit = repo.find_commit(oid)?.decode()?.to_owned()?;
+        let actual_change_id = Headers::try_from_commit(&commit)
+            .and_then(|headers| headers.change_id)
+            .context("created commit should retain its change ID")?;
+
+        assert_eq!(
+            actual_change_id, expected_change_id,
+            "content-hash mode should only replace its reserved placeholder"
+        );
+        Ok(())
+    }
 
     #[test]
     fn signs_commits_when_enabled() -> anyhow::Result<()> {

--- a/crates/but-rebase/src/merge.rs
+++ b/crates/but-rebase/src/merge.rs
@@ -103,7 +103,7 @@ pub(crate) fn octopus(
         )
     } else {
         crate::commit::update_committer(repo, &mut target_merge_commit)?;
-        Ok(repo.write_object(target_merge_commit)?.detach())
+        but_core::commit::create(repo, target_merge_commit, None, SignCommit::No)
     }
 }
 

--- a/crates/but-rebase/tests/rebase/graph_rebase/change_id.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/change_id.rs
@@ -73,7 +73,7 @@ fn temporary_change_id_persisted() -> Result<()> {
 }
 
 #[test]
-fn empty_commit_uses_default_change_id() -> Result<()> {
+fn empty_commit_uses_content_hash_placeholder_until_materialization() -> Result<()> {
     let (repo, _tmpdir, mut meta, mut db) = fixture_writable("four-commits")?;
 
     let graph = Graph::from_head(
@@ -90,7 +90,10 @@ fn empty_commit_uses_default_change_id() -> Result<()> {
 
     let ec = editor.empty_commit()?;
 
-    snapbox::assert_data_eq!(ec.change_id().to_string(), snapbox::str!["1"]);
+    snapbox::assert_data_eq!(
+        ec.change_id().to_string(),
+        snapbox::str!["gitbutler-content-hash-placeholder"]
+    );
     snapbox::assert_data_eq!(
         ec.extra_headers.to_debug(),
         snapbox::str![[r#"
@@ -101,7 +104,7 @@ fn empty_commit_uses_default_change_id() -> Result<()> {
     ),
     (
         "change-id",
-        "1",
+        "gitbutler-content-hash-placeholder",
     ),
 ]
 

--- a/crates/but-rebase/tests/rebase/graph_rebase/conflictable_restriction.rs
+++ b/crates/but-rebase/tests/rebase/graph_rebase/conflictable_restriction.rs
@@ -197,9 +197,9 @@ fn if_a_commit_has_been_configured_not_to_conflict_and_doesnt_end_up_conflicted_
         snapbox::str![[r#"
 
 └── 👉►:0[0]:main[🌳]
-    └── ·8b4d335 (⌂) ►c
+    └── ·df438f2 (⌂) ►c
         └── ►:1[1]:b
-            ├── ·7762cf9 (⌂)
+            ├── ·0c6475b (⌂)
             └── ·3b3bd41 (⌂)
                 └── ►:2[2]:a
                     └── ·5e0ba46 (⌂)
@@ -215,8 +215,8 @@ fn if_a_commit_has_been_configured_not_to_conflict_and_doesnt_end_up_conflicted_
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
         snapbox::str![[r#"
-* 8b4d335 (HEAD -> main, c) c
-* 7762cf9 (b) I'm a new commit! Hello there
+* df438f2 (HEAD -> main, c) c
+* 0c6475b (b) I'm a new commit! Hello there
 * 3b3bd41 b
 * 5e0ba46 (a) a
 * 6155f21 (base) base

--- a/crates/but-rebase/tests/rebase/main.rs
+++ b/crates/but-rebase/tests/rebase/main.rs
@@ -106,7 +106,7 @@ fn single_stack_journey() -> Result<()> {
     snapbox::assert_data_eq!(
         visualize_commit_graph(&repo, out.top_commit)?,
         snapbox::str![[r#"
-* 0fce812 second step: squash b into a
+* f9b8343 second step: squash b into a
 * 35b8235 base
 
 "#]]
@@ -117,13 +117,13 @@ fn single_stack_journey() -> Result<()> {
         out.to_debug(),
         snapbox::str![[r#"
 RebaseOutput {
-    top_commit: Sha1(0fce812ca0874f04f883a2a91191175535cac1c5),
+    top_commit: Sha1(f9b83431ec517614abb5d0898687a89159b0aa80),
     references: [
         ReferenceSpec {
             reference: Virtual(
                 "anchor",
             ),
-            commit_id: Sha1(0fce812ca0874f04f883a2a91191175535cac1c5),
+            commit_id: Sha1(f9b83431ec517614abb5d0898687a89159b0aa80),
             previous_commit_id: Sha1(a96434e2505c2ea0896cf4f58fec0778e074d3da),
         },
     ],
@@ -133,21 +133,21 @@ RebaseOutput {
                 Sha1(35b8235197020a417e9405ab5d4db6f204e8d84b),
             ),
             Sha1(d591dfed1777b8f00f5b7b6f427537eeb5878178),
-            Sha1(8ccdf30390de9029cb5726a046783992c5f67067),
+            Sha1(fdb9c68f1ad828598bdb2711246b958b7eef9f19),
         ),
         (
             Some(
                 Sha1(35b8235197020a417e9405ab5d4db6f204e8d84b),
             ),
             Sha1(a96434e2505c2ea0896cf4f58fec0778e074d3da),
-            Sha1(0fce812ca0874f04f883a2a91191175535cac1c5),
+            Sha1(f9b83431ec517614abb5d0898687a89159b0aa80),
         ),
         (
             Some(
                 Sha1(35b8235197020a417e9405ab5d4db6f204e8d84b),
             ),
             Sha1(a96434e2505c2ea0896cf4f58fec0778e074d3da),
-            Sha1(0fce812ca0874f04f883a2a91191175535cac1c5),
+            Sha1(f9b83431ec517614abb5d0898687a89159b0aa80),
         ),
     ],
 }
@@ -205,9 +205,9 @@ fn amended_commit() -> Result<()> {
     snapbox::assert_data_eq!(
         visualize_commit_graph(&repo, out.top_commit)?,
         snapbox::str![[r#"
-*-.   6a38e67 Merge branches 'A', 'B' and 'C' - rewritten
+*-.   005b14d Merge branches 'A', 'B' and 'C' - rewritten
 |\ \  
-| | * 806db8c C: add another 10 lines to new file - amended
+| | * c7d70ef C: add another 10 lines to new file - amended
 | | * 68a2fc3 C: add 10 lines to new file
 | | * 984fd1c C: new file with 10 lines
 | * | a748762 (B) B: another 10 lines at the bottom
@@ -225,7 +225,7 @@ fn amended_commit() -> Result<()> {
         out.to_debug(),
         snapbox::str![[r#"
 RebaseOutput {
-    top_commit: Sha1(6a38e6718b008686a81969c07f8654dd68f7b824),
+    top_commit: Sha1(005b14dbbb183d0f1c147f1d14e2a2b9c7abe633),
     references: [],
     commit_mapping: [
         (
@@ -233,14 +233,14 @@ RebaseOutput {
                 Sha1(68a2fc349e13a186e6d65871a31bad244d25e6f4),
             ),
             Sha1(930563a048351f05b14cc7b9c0a48640e5a306b0),
-            Sha1(806db8cb9559776b351f5dd222755793a465fe87),
+            Sha1(c7d70ef1f1a7c47fb30db62dca147429dac8b6c2),
         ),
         (
             Some(
                 Sha1(68a2fc349e13a186e6d65871a31bad244d25e6f4),
             ),
             Sha1(134887021e06909021776c023a608f8ef179e859),
-            Sha1(6a38e6718b008686a81969c07f8654dd68f7b824),
+            Sha1(005b14dbbb183d0f1c147f1d14e2a2b9c7abe633),
         ),
     ],
 }
@@ -295,9 +295,9 @@ fn reorder_merge_in_reverse() -> Result<()> {
     snapbox::assert_data_eq!(
         visualize_commit_graph(&repo, out.top_commit)?,
         snapbox::str![[r#"
-* eb90e58 was dd59d2 below merge
-* 5d38e6f was e8ee978 on top
-*   418a03b was merge 2fc288c one below top
+* 50e7e4c was dd59d2 below merge
+* bae2ba5 was e8ee978 on top
+*   65288c7 was merge 2fc288c one below top
 |\  
 | * 984fd1c (B) C: new file with 10 lines
 |/  
@@ -310,7 +310,7 @@ fn reorder_merge_in_reverse() -> Result<()> {
         out.to_debug(),
         snapbox::str![[r#"
 RebaseOutput {
-    top_commit: Sha1(eb90e584f71ba2b0f122d9778abd0225bde3c669),
+    top_commit: Sha1(50e7e4c717718f098c1b578ccf7007d59f20daef),
     references: [],
     commit_mapping: [
         (
@@ -318,21 +318,21 @@ RebaseOutput {
                 Sha1(8f0d33828e5c859c95fb9e9fc063374fdd482536),
             ),
             Sha1(2fc288c36c8bb710c78203f78ea9883724ce142b),
-            Sha1(418a03b1f9da47d9c4cbb3aeea0222899dc0c9c4),
+            Sha1(65288c75beb4a6f472029dffc7c644875f25d2be),
         ),
         (
             Some(
                 Sha1(8f0d33828e5c859c95fb9e9fc063374fdd482536),
             ),
             Sha1(e8ee978dac10e6a85006543ef08be07c5824b4f7),
-            Sha1(5d38e6f5ca16c627bb1f45485dda9b7012287f13),
+            Sha1(bae2ba56ef093d4cf085cf5704d77bb75009373e),
         ),
         (
             Some(
                 Sha1(8f0d33828e5c859c95fb9e9fc063374fdd482536),
             ),
             Sha1(add59d26b2ffd7468fcb44c2db48111dd8f481e5),
-            Sha1(eb90e584f71ba2b0f122d9778abd0225bde3c669),
+            Sha1(50e7e4c717718f098c1b578ccf7007d59f20daef),
         ),
     ],
 }
@@ -392,7 +392,7 @@ fn reorder_with_conflict_and_remerge_and_pick_from_conflicts() -> Result<()> {
         out.to_debug(),
         snapbox::str![[r#"
 RebaseOutput {
-    top_commit: Sha1(f37e580d3175c9b30a77e666d2658d2cbb7997b0),
+    top_commit: Sha1(469558c7c4c36d29a92859c5e0e521cea254dd57),
     references: [],
     commit_mapping: [
         (
@@ -400,28 +400,28 @@ RebaseOutput {
                 Sha1(8f0d33828e5c859c95fb9e9fc063374fdd482536),
             ),
             Sha1(984fd1c6d3975901147b1f02aae6ef0a16e5904e),
-            Sha1(a037d4a2c1313b991c91f8bd0086643f8f39f0ea),
+            Sha1(e5c725a3fb1b8c92451a04d9dd86d6bd269d76ab),
         ),
         (
             Some(
                 Sha1(8f0d33828e5c859c95fb9e9fc063374fdd482536),
             ),
             Sha1(930563a048351f05b14cc7b9c0a48640e5a306b0),
-            Sha1(07cd1572284045c95f430a6b4cf57bfb9bf06812),
+            Sha1(d3c63cc2c9286d397720a0b592f3ed21bca1d52e),
         ),
         (
             Some(
                 Sha1(8f0d33828e5c859c95fb9e9fc063374fdd482536),
             ),
             Sha1(68a2fc349e13a186e6d65871a31bad244d25e6f4),
-            Sha1(582fc4172c4bd0af5ac2092c2e86bdca1ed19c8e),
+            Sha1(cffa6a3056e67dcfaf8482617be5e60d56834a36),
         ),
         (
             Some(
                 Sha1(8f0d33828e5c859c95fb9e9fc063374fdd482536),
             ),
             Sha1(134887021e06909021776c023a608f8ef179e859),
-            Sha1(f37e580d3175c9b30a77e666d2658d2cbb7997b0),
+            Sha1(469558c7c4c36d29a92859c5e0e521cea254dd57),
         ),
     ],
 }
@@ -431,11 +431,11 @@ RebaseOutput {
     snapbox::assert_data_eq!(
         visualize_commit_graph(&repo, out.top_commit)?,
         snapbox::str![[r#"
-*-.   f37e580 Re-merge branches 'A', 'B' and 'C'
+*-.   469558c Re-merge branches 'A', 'B' and 'C'
 |\ \  
-| | * 582fc41 C~1
-| | * 07cd157 [conflict] C
-| | * a037d4a C~2
+| | * cffa6a3 C~1
+| | * d3c63cc [conflict] C
+| | * e5c725a C~2
 | * | a748762 (B) B: another 10 lines at the bottom
 | * | 62e05ba B: 10 lines at the bottom
 | |/  
@@ -486,11 +486,11 @@ f92b9c1
         conflict_commit_id.object()?.data.as_bstr().to_string(),
         snapbox::str![[r#"
 tree f92b9c1f55ce8576eb80c7fb32eb295ef8f7b288
-parent a037d4a2c1313b991c91f8bd0086643f8f39f0ea
+parent e5c725a3fb1b8c92451a04d9dd86d6bd269d76ab
 author author <author@example.com> 946684800 +0000
 committer Committer (Memory Override) <committer@example.com> 946771200 +0000
 gitbutler-headers-version 2
-change-id 1
+change-id tvqkmqxpowoyosykwzoktulqknpvypwv
 
 [conflict] C
 
@@ -519,11 +519,11 @@ GitButler-Conflict: This is a GitButler-managed conflicted commit. Files are aut
 tree 6abc3da6f1642bfd5543ef97f98b924f4f232a96
 parent add59d26b2ffd7468fcb44c2db48111dd8f481e5
 parent a7487625f079bedf4d20e48f052312c010117b38
-parent 582fc4172c4bd0af5ac2092c2e86bdca1ed19c8e
+parent cffa6a3056e67dcfaf8482617be5e60d56834a36
 author author <author@example.com> 946684800 +0000
 committer Committer (Memory Override) <committer@example.com> 946771200 +0000
 gitbutler-headers-version 2
-change-id 1
+change-id qutxpsntutpmpxvllyxuwumnkqmuxnxs
 
 Re-merge branches 'A', 'B' and 'C'
 "#]]
@@ -544,7 +544,7 @@ parent 8f0d33828e5c859c95fb9e9fc063374fdd482536
 author author <author@example.com> 946684800 +0000
 committer Committer (Memory Override) <committer@example.com> 946771200 +0000
 gitbutler-headers-version 2
-change-id 1
+change-id qouxtqnurnuxukrypyrmotplppooouvs
 
 C~2
 "#]]
@@ -677,11 +677,11 @@ fn reversible_conflicts() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         visualize_commit_graph(&repo, out.top_commit)?,
         snapbox::str![[r#"
-*-.   f37e580 Re-merge branches 'A', 'B' and 'C'
+*-.   469558c Re-merge branches 'A', 'B' and 'C'
 |\ \  
-| | * 582fc41 C~1
-| | * 07cd157 [conflict] C
-| | * a037d4a C~2
+| | * cffa6a3 C~1
+| | * d3c63cc [conflict] C
+| | * e5c725a C~2
 | * | a748762 (B) B: another 10 lines at the bottom
 | * | 62e05ba B: 10 lines at the bottom
 | |/  
@@ -760,7 +760,7 @@ fn pick_the_first_commit_with_no_parents_for_squashing() -> Result<()> {
     snapbox::assert_data_eq!(
         visualize_commit_graph(&repo, out.top_commit)?,
         snapbox::str![[r#"
-* e380582 reworded base after squash
+* 647bbc7 reworded base after squash
 
 "#]]
     );
@@ -768,7 +768,7 @@ fn pick_the_first_commit_with_no_parents_for_squashing() -> Result<()> {
         out.to_debug(),
         snapbox::str![[r#"
 RebaseOutput {
-    top_commit: Sha1(e3805829c98eb212c529d5e853a94283ed32747c),
+    top_commit: Sha1(647bbc7cdbd8e18fd778261250d4a0dbc485e47a),
     references: [],
     commit_mapping: [
         (
@@ -779,7 +779,7 @@ RebaseOutput {
         (
             None,
             Sha1(d591dfed1777b8f00f5b7b6f427537eeb5878178),
-            Sha1(e3805829c98eb212c529d5e853a94283ed32747c),
+            Sha1(647bbc7cdbd8e18fd778261250d4a0dbc485e47a),
         ),
     ],
 }

--- a/crates/but-testsupport/src/lib.rs
+++ b/crates/but-testsupport/src/lib.rs
@@ -142,7 +142,7 @@ pub fn open_repo_config() -> anyhow::Result<gix::open::Options> {
                 .validated_assignment("2000-01-01 00:00:00 +0000".into())?,
             gix::config::tree::gitoxide::Commit::COMMITTER_DATE
                 .validated_assignment("2000-01-02 00:00:00 +0000".into())?,
-            "gitbutler.testing.changeId=1".to_owned().into(),
+            "gitbutler.testing.changeId=content-hash".to_owned().into(),
         ]);
     Ok(config)
 }

--- a/crates/but-transaction/src/tests.rs
+++ b/crates/but-transaction/src/tests.rs
@@ -738,8 +738,8 @@ fn move_commits_then_commit_relative_to_moved_commit() {
     snapbox::assert_data_eq!(
         env.git_log(),
         snapbox::str![[r#"
-* 4eb318d (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-* a381780 (branch) 
+* d70d81f (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+* 3fb70d9 (branch) 
 * b18afe3 add file-one
 * 5fdd02a add file-three
 * 0d4aae5 add file-two

--- a/crates/but-transaction/tests/fixtures/scenario/shared.sh
+++ b/crates/but-transaction/tests/fixtures/scenario/shared.sh
@@ -3,7 +3,7 @@ set -eu -o pipefail
 
 function git-init-frozen() {
   git init
-  git config gitbutler.testing.changeId 1
+  git config gitbutler.testing.changeId content-hash
 }
 
 function setup_remote_tracking() {

--- a/crates/but-workspace/tests/workspace/branch/integrate_branch_upstream.rs
+++ b/crates/but-workspace/tests/workspace/branch/integrate_branch_upstream.rs
@@ -1215,8 +1215,8 @@ fn integrate_branch_with_merge_step_does_not_require_preceding_commit() -> Resul
     snapbox::assert_data_eq!(
         normalized_graph_snapshot(&repo)?,
         snapbox::str![[r#"
-* 1934603 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-*   dc8c3e4 (A) Merge 715d7b0b14844b459ef031a7332283932e99a6a5 into previous commit
+* 575b836 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+*   d14d4c7 (A) Merge 715d7b0b14844b459ef031a7332283932e99a6a5 into previous commit
 |\
 | | * 6a17628 (origin/A) remote change in A 2
 | |/
@@ -1377,9 +1377,9 @@ fn integrate_upstream_commits_into_local_with_merge_step() -> Result<()> {
     snapbox::assert_data_eq!(
         normalized_graph_snapshot(&repo)?,
         snapbox::str![[r#"
-* a74b8e3 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-* fdc285b (A) local change in A 2
-*   0d584c5 Merge 715d7b0b14844b459ef031a7332283932e99a6a5 into previous commit
+* 746624b (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+* f9c6e49 (A) local change in A 2
+*   48d5c10 Merge 715d7b0b14844b459ef031a7332283932e99a6a5 into previous commit
 |\
 * | 86838ae local change in A 1
 | | * 6a17628 (origin/A) remote change in A 2
@@ -1479,8 +1479,8 @@ fn integrate_upstream_commits_into_local_with_all_locals_then_merge_second_remot
     snapbox::assert_data_eq!(
         normalized_graph_snapshot(&repo)?,
         snapbox::str![[r#"
-* a11c807 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-*   93bbd52 (A) Merge 6a176285f918d0e4249373b102abe662d4eeeb29 into previous commit
+* 8729586 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+*   049a2ea (A) Merge 6a176285f918d0e4249373b102abe662d4eeeb29 into previous commit
 |\
 | * 6a17628 (origin/A) remote change in A 2
 | * 715d7b0 remote change in A 1
@@ -1559,12 +1559,12 @@ fn integrate_upstream_commits_into_local_with_two_merges_in_sequence() -> Result
     snapbox::assert_data_eq!(
         normalized_graph_snapshot(&repo)?,
         snapbox::str![[r#"
-* d69c4de (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-*   ab7f588 (A) Merge 6a176285f918d0e4249373b102abe662d4eeeb29 into previous commit
+* 0fde470 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+*   e4e832d (A) Merge 6a176285f918d0e4249373b102abe662d4eeeb29 into previous commit
 |\
 | * 6a17628 (origin/A) remote change in A 2
-* | fdc285b local change in A 2
-* | 0d584c5 Merge 715d7b0b14844b459ef031a7332283932e99a6a5 into previous commit
+* | f9c6e49 local change in A 2
+* | 48d5c10 Merge 715d7b0b14844b459ef031a7332283932e99a6a5 into previous commit
 |\|
 | * 715d7b0 remote change in A 1
 * | 86838ae local change in A 1
@@ -2647,8 +2647,8 @@ fn integrate_upstream_commits_into_local_with_merge_remote_into_local_conflicts(
     snapbox::assert_data_eq!(
         normalized_graph_snapshot(&repo)?,
         snapbox::str![[r#"
-* 9b44771 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-*   c813ff0 (A) [conflict] Merge f03fc2cb7251fb1707fa0f7bee28eb507ec1405c into previous commit
+* a41d4aa (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+*   e22740e (A) [conflict] Merge f03fc2cb7251fb1707fa0f7bee28eb507ec1405c into previous commit
 |\
 | * f03fc2c (origin/A, new-origin) remote change in A 1
 * | 61c4a24 local change in A 1

--- a/crates/but-workspace/tests/workspace/commit/cherry_pick.rs
+++ b/crates/but-workspace/tests/workspace/commit/cherry_pick.rs
@@ -39,9 +39,9 @@ fn insert_below_commit() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
         snapbox::str![[r#"
-* 68995ae (HEAD -> three) commit three
-* 75334f1 (two) commit two
-* 50680ef commit one
+* b9b86a6 (HEAD -> three) commit three
+* cdde196 (two) commit two
+* ec7d41d commit one
 | * 16fd221 (origin/two) commit two
 |/  
 * 8b426d0 (one) commit one
@@ -82,8 +82,8 @@ fn insert_above_commit() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
         snapbox::str![[r#"
-* b4ca6cc (HEAD -> three) commit three
-* 5ad6169 (two) commit one
+* 331b55d (HEAD -> three) commit three
+* 4dcc949 (two) commit one
 * 16fd221 (origin/two) commit two
 * 8b426d0 (one) commit one
 
@@ -123,8 +123,8 @@ fn insert_below_reference() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
         snapbox::str![[r#"
-* b4ca6cc (HEAD -> three) commit three
-* 5ad6169 (two) commit one
+* 331b55d (HEAD -> three) commit three
+* 4dcc949 (two) commit one
 * 16fd221 (origin/two) commit two
 * 8b426d0 (one) commit one
 
@@ -169,10 +169,10 @@ fn sources_are_applied_in_the_order_given() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
         snapbox::str![[r#"
-*   ce4b2e2 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+*   a30eed0 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
 |\  
-| * f603807 (A) C
-| * 698ccd3 B
+| * f11d4a3 (A) C
+| * 0a0a61c B
 | * 09d8e52 A
 * | 09bc93e (C) C
 * | c813d8d (B) B
@@ -226,9 +226,9 @@ fn sources_are_deduped() -> anyhow::Result<()> {
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
         snapbox::str![[r#"
-*   ec1bb42 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+*   e9a5189 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
 |\  
-| * 698ccd3 (A) B
+| * 0a0a61c (A) B
 | * 09d8e52 A
 * | 09bc93e (C) C
 * | c813d8d (B) B

--- a/crates/but-workspace/tests/workspace/commit/insert_blank_commit.rs
+++ b/crates/but-workspace/tests/workspace/commit/insert_blank_commit.rs
@@ -38,9 +38,9 @@ fn insert_below_commit() -> Result<()> {
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
         snapbox::str![[r#"
-* 1b97135 (HEAD -> three) commit three
-* 5f398b2 (two) commit two
-* b3b14c2 
+* bdea705 (HEAD -> three) commit three
+* b7af41f (two) commit two
+* b216146 
 | * 16fd221 (origin/two) commit two
 |/  
 * 8b426d0 (one) commit one
@@ -83,8 +83,8 @@ fn insert_above_commit() -> Result<()> {
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
         snapbox::str![[r#"
-* 2b11859 (HEAD -> three) commit three
-* 024b774 (two) 
+* f6276fd (HEAD -> three) commit three
+* a2b712e (two) 
 * 16fd221 (origin/two) commit two
 * 8b426d0 (one) commit one
 
@@ -126,8 +126,8 @@ fn insert_below_reference() -> Result<()> {
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
         snapbox::str![[r#"
-* 2b11859 (HEAD -> three) commit three
-* 024b774 (two) 
+* f6276fd (HEAD -> three) commit three
+* a2b712e (two) 
 * 16fd221 (origin/two) commit two
 * 8b426d0 (one) commit one
 
@@ -169,8 +169,8 @@ fn insert_above_reference() -> Result<()> {
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
         snapbox::str![[r#"
-* 2b11859 (HEAD -> three) commit three
-* 024b774 
+* f6276fd (HEAD -> three) commit three
+* a2b712e 
 * 16fd221 (origin/two, two) commit two
 * 8b426d0 (one) commit one
 

--- a/crates/but-workspace/tests/workspace/upstream_integration.rs
+++ b/crates/but-workspace/tests/workspace/upstream_integration.rs
@@ -176,8 +176,8 @@ fn diamond_partially_historically_integrated_merge() -> Result<()> {
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
         snapbox::str![[r#"
-* 292b0b3 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-*   ed5f276 (E) Merge refs/remotes/origin/master into merge
+* dcb5024 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+*   e9b2f42 (E) Merge refs/remotes/origin/master into merge
 |\  
 | * 7de2393 (origin/master, master) o4
 | *   7d62953 (o3) o3
@@ -357,8 +357,8 @@ fn diamond_partially_content_integrated_merge() -> Result<()> {
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
         snapbox::str![[r#"
-* ebd6fa2 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-*   0a395ba (E) Merge refs/remotes/origin/master into merge
+* aed8274 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+*   ec29bcc (E) Merge refs/remotes/origin/master into merge
 |\  
 | * 162b064 (origin/master, master) o4
 | * dd87d69 (o3) B
@@ -603,7 +603,7 @@ fn integrated_bottom_branch_no_workspace_merge() -> Result<()> {
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
         snapbox::str![[r#"
-*   7ce831c (HEAD -> A) Merge refs/remotes/origin/main into merge
+*   0428fd0 (HEAD -> A) Merge refs/remotes/origin/main into merge
 |\  
 | * 8c8a843 (origin/main) add X1
 * | e792f40 add A1
@@ -686,8 +686,8 @@ fn merge_upstream_with_conflicting_target_materializes_conflicted_merge_commit()
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
         snapbox::str![[r#"
-* 379fa91 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-*   9b4efdf (A) [conflict] Merge refs/remotes/origin/A into merge
+* ad8e361 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+*   9046a0c (A) [conflict] Merge refs/remotes/origin/A into merge
 |\  
 | * f03fc2c (origin/A, new-origin) remote change in A 1
 * | 61c4a24 local change in A 1

--- a/crates/but/src/command/legacy/status/tui/tests/commit_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/commit_tests.rs
@@ -83,7 +83,7 @@ fn commiting_with_no_uncommitted_changes() {
         ]);
 
     tui.input(KeyCode::Enter)
-        .assert_current_line_eq(str!["┊●   1 (no commit message) (no changes)"])
+        .assert_current_line_eq(str!["┊●   oun (no commit message) (no changes)"])
         .assert_rendered_term_svg_eq(file![
             "snapshots/commiting_with_no_uncommitted_changes_003.svg"
         ]);
@@ -116,11 +116,11 @@ fn commit_from_unstaged_changes_creates_commit_visible_in_tui() {
 
     with_var("GIT_EDITOR", Some(editor_command), || {
         tui.input(KeyCode::Enter)
-            .assert_current_line_eq(str!["┊●   1 commit from tui test"]);
+            .assert_current_line_eq(str!["┊●   oqn commit from tui test"]);
     });
 
     tui.reload()
-        .assert_current_line_eq(str!["┊●   1 commit from tui test"])
+        .assert_current_line_eq(str!["┊●   oqn commit from tui test"])
         .assert_rendered_term_svg_eq(file![
             "snapshots/commit_from_unstaged_changes_creates_commit_visible_in_tui_final.svg"
         ]);
@@ -153,11 +153,11 @@ fn commit_from_unstaged_changes_to_new_branch_creates_branch_and_commit() {
 
     with_var("GIT_EDITOR", Some(editor_command), || {
         tui.input('b')
-            .assert_current_line_eq(str!["┊●   1 commit from tui test"]);
+            .assert_current_line_eq(str!["┊●   oqn commit from tui test"]);
     });
 
     tui.reload()
-        .assert_current_line_eq(str!["┊●   1 commit from tui test"])
+        .assert_current_line_eq(str!["┊●   oqn commit from tui test"])
         .assert_rendered_term_svg_eq(file![
             "snapshots/commit_from_unstaged_changes_to_new_branch_creates_branch_and_commit_final.svg"
         ]);
@@ -233,7 +233,7 @@ fn commit_from_unstaged_changes_with_multiple_hunks_in_same_file_commits_all_cha
 
     with_var("GIT_EDITOR", Some(editor_command.clone()), || {
         tui.input(KeyCode::Enter)
-            .assert_current_line_eq(str!["┊●   1 commit from tui test"]);
+            .assert_current_line_eq(str!["┊●   kmy commit from tui test"]);
     });
 
     let changed = base
@@ -262,7 +262,7 @@ fn commit_from_unstaged_changes_with_multiple_hunks_in_same_file_commits_all_cha
 
     with_var("GIT_EDITOR", Some(editor_command), || {
         tui.input(KeyCode::Enter)
-            .assert_current_line_eq(str!["┊●   1#0 commit from tui test"]);
+            .assert_current_line_eq(str!["┊●   mwu commit from tui test"]);
     });
 
     let status = tui.env().invoke_git("status --porcelain");
@@ -328,11 +328,11 @@ fn commit_to_commit_above_creates_commit_visible_in_tui() {
 
     with_var("GIT_EDITOR", Some(editor_command), || {
         tui.input(KeyCode::Enter)
-            .assert_current_line_eq(str!["┊●   1 commit from tui test"]);
+            .assert_current_line_eq(str!["┊●   oqn commit from tui test"]);
     });
 
     tui.reload()
-        .assert_current_line_eq(str!["┊●   1 commit from tui test"])
+        .assert_current_line_eq(str!["┊●   oqn commit from tui test"])
         .assert_rendered_term_svg_eq(file![
             "snapshots/commit_to_commit_above_creates_commit_visible_in_tui_final_002.svg"
         ]);
@@ -369,11 +369,11 @@ fn commit_to_commit_below_creates_commit_visible_in_tui() {
 
     with_var("GIT_EDITOR", Some(editor_command), || {
         tui.input(KeyCode::Enter)
-            .assert_current_line_eq(str!["┊●   1 commit from tui test"]);
+            .assert_current_line_eq(str!["┊●   zym commit from tui test"]);
     });
 
     tui.reload()
-        .assert_current_line_eq(str!["┊●   1 commit from tui test"])
+        .assert_current_line_eq(str!["┊●   zym commit from tui test"])
         .assert_rendered_term_svg_eq(file![
             "snapshots/commit_to_commit_below_creates_commit_visible_in_tui_final.svg"
         ]);
@@ -464,13 +464,13 @@ fn commit_with_inline_reword() {
         .assert_rendered_term_svg_eq(file!["snapshots/commit_with_inline_reword_004.svg"]);
 
     tui.input(KeyCode::Enter)
-        .assert_current_line_eq(str!["┊●   1"]);
+        .assert_current_line_eq(str!["┊●   nsl"]);
 
     tui.input("commit message here")
-        .assert_current_line_eq(str!["┊●   1 commit message here"]);
+        .assert_current_line_eq(str!["┊●   nsl commit message here"]);
 
     tui.input(KeyCode::Enter)
-        .assert_current_line_eq(str!["┊●   1 commit message here"]);
+        .assert_current_line_eq(str!["┊●   nsl commit message here"]);
 }
 
 #[test]

--- a/crates/but/src/command/legacy/status/tui/tests/copy_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/copy_tests.rs
@@ -19,7 +19,7 @@ fn copying_change_id_doesnt_include_disambiguation() {
 
     // Ideally this would include the disambiguation but the change id in CliId::Commit doesn't
     // include it. In the future it will.
-    tui.input('y').assert_copied_text_eq("1");
+    tui.input('y').assert_copied_text_eq("mzrzmqqn");
 }
 
 #[test]
@@ -95,7 +95,8 @@ fn copies_every_commit_value() {
 
     tui.input(COPY_MORE);
     tui.input([KeyCode::Down; 2]);
-    tui.input(KeyCode::Enter).assert_copied_text_eq("1");
+    tui.input(KeyCode::Enter)
+        .assert_copied_text_eq("omyuzposspozzzlpxqkzstlkmxpvxzqs");
 
     tui.input(COPY_MORE);
     tui.input([KeyCode::Down; 3]);

--- a/crates/but/src/command/legacy/status/tui/tests/copy_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/copy_tests.rs
@@ -1,7 +1,9 @@
 use but_testsupport::Sandbox;
 use crossterm::event::{KeyCode, KeyModifiers};
 
-use crate::command::legacy::status::tui::tests::utils::test_status_tui;
+use crate::command::legacy::status::tui::tests::utils::{
+    TestTuiOptions, test_status_tui, test_status_tui_with_options,
+};
 
 const COPY_MORE: (KeyModifiers, char) = (KeyModifiers::SHIFT, 'Y');
 
@@ -10,7 +12,13 @@ fn copying_change_id_doesnt_include_disambiguation() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
     env.setup_metadata(&[]);
 
-    let mut tui = test_status_tui(env);
+    let mut tui = test_status_tui_with_options(
+        env,
+        TestTuiOptions {
+            testing_change_id: Some("1"),
+            ..Default::default()
+        },
+    );
 
     tui.input('b');
     tui.input('n');
@@ -19,7 +27,7 @@ fn copying_change_id_doesnt_include_disambiguation() {
 
     // Ideally this would include the disambiguation but the change id in CliId::Commit doesn't
     // include it. In the future it will.
-    tui.input('y').assert_copied_text_eq("mzrzmqqn");
+    tui.input('y').assert_copied_text_eq("1");
 }
 
 #[test]

--- a/crates/but/src/command/legacy/status/tui/tests/discard_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/discard_tests.rs
@@ -128,10 +128,10 @@ fn discard_top_commit_selects_next_commit_in_branch() {
         .assert_current_line_eq(str!["┊╭┄ g0 [A]"]);
 
     tui.input('n')
-        .assert_current_line_eq(str!["┊●   1 (no commit message) (no changes)"]);
+        .assert_current_line_eq(str!["┊●   oun (no commit message) (no changes)"]);
 
     tui.input('n')
-        .assert_current_line_eq(str!["┊●   1#0 (no commit message) (no changes)"]);
+        .assert_current_line_eq(str!["┊●   mul (no commit message) (no changes)"]);
 
     tui.input('x')
         .assert_rendered_contains("Discard commit")
@@ -140,7 +140,7 @@ fn discard_top_commit_selects_next_commit_in_branch() {
     tui.input('y');
 
     tui.reload()
-        .assert_current_line_eq(str!["┊●   1 (no commit message) (no changes)"]);
+        .assert_current_line_eq(str!["┊●   oun (no commit message) (no changes)"]);
 }
 
 #[test]
@@ -165,7 +165,7 @@ fn discard_bottom_commit_selects_rewritten_commit_above() {
 
     tui.input('x').assert_rendered_contains("Discard commit");
     tui.input('y')
-        .assert_current_line_eq(str!["┊●   1#1 one (no changes)"]);
+        .assert_current_line_eq(str!["┊●   oun one (no changes)"]);
 }
 
 #[test]
@@ -357,7 +357,7 @@ fn discard_individual_committed_files_from_local_file_list() {
         "snapshots/discard_individual_committed_files_from_local_file_list_002.svg"
     ]);
     tui.input('y')
-        .assert_current_line_eq(str!["┊│     1:o A three"])
+        .assert_current_line_eq(str!["┊│     zt:o A three"])
         .assert_rendered_term_svg_eq(file![
             "snapshots/discard_individual_committed_files_from_local_file_list_003.svg"
         ])
@@ -367,7 +367,7 @@ fn discard_individual_committed_files_from_local_file_list() {
         "snapshots/discard_individual_committed_files_from_local_file_list_004.svg"
     ]);
     tui.input('y')
-        .assert_current_line_eq(str!["┊│     1:t A two"])
+        .assert_current_line_eq(str!["┊│     zt:t A two"])
         .assert_rendered_term_svg_eq(file![
             "snapshots/discard_individual_committed_files_from_local_file_list_005.svg"
         ])
@@ -377,7 +377,7 @@ fn discard_individual_committed_files_from_local_file_list() {
         "snapshots/discard_individual_committed_files_from_local_file_list_006.svg"
     ]);
     tui.input('y')
-        .assert_current_line_eq(str!["┊●   1 (no commit message) (no changes)"])
+        .assert_current_line_eq(str!["┊●   ztn (no commit message) (no changes)"])
         .assert_rendered_term_svg_eq(file![
             "snapshots/discard_individual_committed_files_from_local_file_list_007.svg"
         ])
@@ -454,7 +454,7 @@ fn discard_marked_committed_files_from_local_file_list() {
         "snapshots/discard_marked_committed_files_from_local_file_list_003.svg"
     ]);
     tui.input('y')
-        .assert_current_line_eq(str!["┊│     1:t A two"])
+        .assert_current_line_eq(str!["┊│     zt:t A two"])
         .assert_backstack_eq([BackstackEntry::ShowFileList])
         .assert_rendered_term_svg_eq(file![
             "snapshots/discard_marked_committed_files_from_local_file_list_004.svg"
@@ -465,7 +465,7 @@ fn discard_marked_committed_files_from_local_file_list() {
 
     tui.input('x');
     tui.input('y')
-        .assert_current_line_eq(str!["┊●   1 (no commit message) (no changes)"])
+        .assert_current_line_eq(str!["┊●   ztn (no commit message) (no changes)"])
         .assert_backstack_eq([])
         .assert_rendered_term_svg_eq(file![
             "snapshots/discard_marked_committed_files_from_local_file_list_005.svg"

--- a/crates/but/src/command/legacy/status/tui/tests/marking_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/marking_tests.rs
@@ -221,7 +221,7 @@ fn can_only_mark_files_from_one_commit() {
 
     tui.input('j');
     tui.input(' ')
-        .assert_current_line_eq(str!["┊│     1#0:t A two"])
+        .assert_current_line_eq(str!["┊│     l:t A two"])
         .assert_backstack_eq([BackstackEntry::Mark, BackstackEntry::ShowFileList])
         .assert_rendered_term_svg_eq(file![
             "snapshots/can_only_mark_files_from_one_commit_002.svg"
@@ -230,7 +230,7 @@ fn can_only_mark_files_from_one_commit() {
     // we shouldn't be allowed to select lines outside the commit files
     for _ in 0..10 {
         tui.input('j')
-            .assert_current_line_eq(str!["┊│     1#0:t A two"])
+            .assert_current_line_eq(str!["┊│     l:t A two"])
             .assert_backstack_eq([BackstackEntry::Mark, BackstackEntry::ShowFileList])
             .assert_rendered_term_svg_eq(file![
                 "snapshots/can_only_mark_files_from_one_commit_003.svg"
@@ -238,7 +238,7 @@ fn can_only_mark_files_from_one_commit() {
     }
     for _ in 0..10 {
         tui.input('k')
-            .assert_current_line_eq(str!["┊✔︎     1#0:o A three"])
+            .assert_current_line_eq(str!["┊✔︎     l:o A three"])
             .assert_backstack_eq([BackstackEntry::Mark, BackstackEntry::ShowFileList])
             .assert_rendered_term_svg_eq(file![
                 "snapshots/can_only_mark_files_from_one_commit_004.svg"

--- a/crates/but/src/command/legacy/status/tui/tests/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/mod.rs
@@ -637,11 +637,11 @@ fn creating_empty_commits() {
 
     tui.input('n')
         .assert_rendered_term_svg_eq(file!["snapshots/creating_empty_commits_002.svg"])
-        .assert_current_line_eq(str!["┊●   1 (no commit message) (no changes)"]);
+        .assert_current_line_eq(str!["┊●   oun (no commit message) (no changes)"]);
 
     tui.input('n')
         .assert_rendered_term_svg_eq(file!["snapshots/creating_empty_commits_003.svg"])
-        .assert_current_line_eq(str!["┊●   1#0 (no commit message) (no changes)"]);
+        .assert_current_line_eq(str!["┊●   mul (no commit message) (no changes)"]);
 }
 
 #[test]
@@ -660,7 +660,7 @@ fn inline_reword() {
 
     tui.input('n')
         .assert_rendered_term_svg_eq(file!["snapshots/inline_reword_002.svg"])
-        .assert_current_line_eq(str!["┊●   1 (no commit message) (no changes)"]);
+        .assert_current_line_eq(str!["┊●   oun (no commit message) (no changes)"]);
 
     tui.input(KeyCode::Enter)
         .assert_rendered_term_svg_eq(file!["snapshots/inline_reword_003.svg"]);
@@ -670,7 +670,7 @@ fn inline_reword() {
 
     tui.input(KeyCode::Enter)
         .assert_rendered_term_svg_eq(file!["snapshots/inline_reword_005.svg"])
-        .assert_current_line_eq(str!["┊●   1 foo (no changes)"]);
+        .assert_current_line_eq(str!["┊●   oun foo (no changes)"]);
 }
 
 #[test]
@@ -844,12 +844,12 @@ fn commit_file_toggle_on_commit_without_files_is_noop() {
     with_var("GIT_AUTHOR_DATE", Some("2000-01-01T00:00:00Z"), || {
         with_var("GIT_COMMITTER_DATE", Some("2000-01-01T00:00:00Z"), || {
             tui.input('n')
-                .assert_current_line_eq(str!["┊●   1 (no commit message) (no changes)"]);
+                .assert_current_line_eq(str!["┊●   oun (no commit message) (no changes)"]);
         });
     });
 
     tui.input('f')
-        .assert_current_line_eq(str!["┊●   1 (no commit message) (no changes)"]);
+        .assert_current_line_eq(str!["┊●   oun (no commit message) (no changes)"]);
 
     tui.input([KeyCode::Down, KeyCode::Down, KeyCode::Down])
         .assert_current_line_eq(str!["┴ 0dc3733 (common base) 2000-01-02 add M"])
@@ -1097,7 +1097,7 @@ fn consistent_commit_shas_in_tests() {
     tui.input('b');
     tui.input('n');
     tui.input('n')
-        .assert_current_line_eq(str!["┊●   1 (no commit message) (no changes)"]);
+        .assert_current_line_eq(str!["┊●   omy (no commit message) (no changes)"]);
 }
 
 #[test]
@@ -1116,12 +1116,12 @@ fn jumping_up_down() {
     }
 
     tui.reload()
-        .assert_current_line_eq("┊●   1#0 commit #12 (no changes)");
+        .assert_current_line_eq("┊●   xnv commit #12 (no changes)");
 
     tui.input((KeyModifiers::CONTROL, 'd'))
-        .assert_current_line_eq("┊●   1#10 commit #2 (no changes)");
+        .assert_current_line_eq("┊●   xyn commit #2 (no changes)");
     tui.input((KeyModifiers::CONTROL, 'u'))
-        .assert_current_line_eq("┊●   1#0 commit #12 (no changes)");
+        .assert_current_line_eq("┊●   xnv commit #12 (no changes)");
 }
 
 #[test]
@@ -1146,7 +1146,7 @@ fn jumping_up_down_non_normal_mode() {
     tui.input('r');
 
     tui.input((KeyModifiers::CONTROL, 'd'))
-        .assert_current_line_eq(str!["┊●   << amend >> 1#8 commit #4 (no changes)"]);
+        .assert_current_line_eq(str!["┊●   << amend >> ryo commit #4 (no changes)"]);
     tui.input((KeyModifiers::CONTROL, 'u'))
         .assert_current_line_eq(str!["╭┄ << source >> @ [uncommitted]"]);
 }
@@ -1186,11 +1186,11 @@ fn maintains_selection_using_change_id() {
     tui.input(KeyCode::Enter);
     tui.input("target");
     tui.input(KeyCode::Enter)
-        .assert_current_line_eq(str!["┊●   1 target (no changes)"]);
+        .assert_current_line_eq(str!["┊●   omy target (no changes)"]);
 
     // undo the reword, this shouldn't change the selection
     tui.input('u')
-        .assert_current_line_eq(str!["┊●   1 (no commit message) (no changes)"]);
+        .assert_current_line_eq(str!["┊●   omy (no commit message) (no changes)"]);
 }
 
 #[test]

--- a/crates/but/src/command/legacy/status/tui/tests/move_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/move_tests.rs
@@ -48,10 +48,10 @@ fn move_mode_keeps_selected_commit_and_extension_visible_when_scrolled() {
         .assert_current_line_eq(str!["┊╭┄ g0 [A]"]);
 
     tui.input('n')
-        .assert_current_line_eq(str!["┊●   1 (no commit message) (no changes)"]);
+        .assert_current_line_eq(str!["┊●   oun (no commit message) (no changes)"]);
 
     tui.input('n')
-        .assert_current_line_eq(str!["┊●   1#0 (no commit message) (no changes)"]);
+        .assert_current_line_eq(str!["┊●   mul (no commit message) (no changes)"]);
 
     tui.input([KeyCode::Down, KeyCode::Down])
         .assert_current_line_eq(str!["┊●   tpm add A"]);
@@ -79,10 +79,10 @@ fn move_commit_above_other_commit_reorders_tui() {
         .assert_current_line_eq(str!["┊╭┄ g0 [A]"]);
 
     tui.input('n')
-        .assert_current_line_eq(str!["┊●   1 (no commit message) (no changes)"]);
+        .assert_current_line_eq(str!["┊●   oun (no commit message) (no changes)"]);
 
     tui.input('n')
-        .assert_current_line_eq(str!["┊●   1#0 (no commit message) (no changes)"]);
+        .assert_current_line_eq(str!["┊●   mul (no commit message) (no changes)"]);
 
     tui.input([KeyCode::Down, KeyCode::Down])
         .assert_current_line_eq(str!["┊●   tpm add A"]);
@@ -116,16 +116,16 @@ fn move_commit_down_from_source_selects_next_commit() {
         .assert_current_line_eq(str!["┊╭┄ g0 [A]"]);
 
     tui.input('n')
-        .assert_current_line_eq(str!["┊●   1 (no commit message) (no changes)"]);
+        .assert_current_line_eq(str!["┊●   oun (no commit message) (no changes)"]);
 
     tui.input('n')
-        .assert_current_line_eq(str!["┊●   1#0 (no commit message) (no changes)"]);
+        .assert_current_line_eq(str!["┊●   mul (no commit message) (no changes)"]);
 
     tui.input(KeyCode::Down)
-        .assert_current_line_eq(str!["┊●   1#1 (no commit message) (no changes)"]);
+        .assert_current_line_eq(str!["┊●   oun (no commit message) (no changes)"]);
 
     tui.input('m').assert_current_line_eq(str![
-        "┊●   << source >> << noop >> 1#1 (no commit message) (no changes)"
+        "┊●   << source >> << noop >> oun (no commit message) (no changes)"
     ]);
 
     tui.input(KeyCode::Down)

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/can_only_mark_files_from_one_commit_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/can_only_mark_files_from_one_commit_001.svg
@@ -17,31 +17,33 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="60" style="fill:#00AA00;">c-branch-1</text>
     <text x="154" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50 58 66" y="78" style="fill:#AA00AA;font-weight:bold;">1#0</text>
+    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">l</text>
+    <text x="58 66" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">oy</text>
     <text x="82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
     <text x="114 122 130 138 146 154" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
     <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82 90 98" y="96" style="fill:#0000AA;font-weight:bold;">1#0:o</text>
-    <text x="114" y="96" style="fill:#CCCCCC;">A</text>
-    <text x="130 138 146 154 162" y="96" style="fill:#00AA00;">three</text>
+    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">l:o</text>
+    <text x="98" y="96" style="fill:#CCCCCC;">A</text>
+    <text x="114 122 130 138 146" y="96" style="fill:#00AA00;">three</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82 90 98" y="114" style="fill:#0000AA;font-weight:bold;">1#0:t</text>
-    <text x="114" y="114" style="fill:#CCCCCC;">A</text>
-    <text x="130 138 146" y="114" style="fill:#00AA00;">two</text>
+    <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">l:t</text>
+    <text x="98" y="114" style="fill:#CCCCCC;">A</text>
+    <text x="114 122 130" y="114" style="fill:#00AA00;">two</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊●</text>
-    <text x="50 58 66" y="132" style="fill:#AA00AA;">1#1</text>
+    <text x="50 58" y="132" style="fill:#AA00AA;">zo</text>
+    <text x="66" y="132" style="fill:#CCCCCC;opacity:0.75;">o</text>
     <text x="82 90 98" y="132" style="fill:#CCCCCC;opacity:0.75;">(no</text>
     <text x="114 122 130 138 146 154" y="132" style="fill:#CCCCCC;opacity:0.75;">commit</text>
     <text x="170 178 186 194 202 210 218 226" y="132" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82 90 98" y="150" style="fill:#0000AA;font-weight:bold;">1#1:q</text>
-    <text x="114" y="150" style="fill:#CCCCCC;">A</text>
-    <text x="130 138 146 154" y="150" style="fill:#00AA00;">four</text>
+    <text x="66 74 82 90" y="150" style="fill:#0000AA;font-weight:bold;">zo:q</text>
+    <text x="106" y="150" style="fill:#CCCCCC;">A</text>
+    <text x="122 130 138 146" y="150" style="fill:#00AA00;">four</text>
     <text x="10 18" y="168" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82 90 98" y="168" style="fill:#0000AA;font-weight:bold;">1#1:k</text>
-    <text x="114" y="168" style="fill:#CCCCCC;">A</text>
-    <text x="130 138 146" y="168" style="fill:#00AA00;">one</text>
+    <text x="66 74 82 90" y="168" style="fill:#0000AA;font-weight:bold;">zo:k</text>
+    <text x="106" y="168" style="fill:#CCCCCC;">A</text>
+    <text x="122 130 138" y="168" style="fill:#00AA00;">one</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="204" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="222" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/can_only_mark_files_from_one_commit_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/can_only_mark_files_from_one_commit_002.svg
@@ -18,32 +18,34 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="60" style="fill:#00AA00;opacity:0.75;">c-branch-1</text>
     <text x="154" y="60" style="fill:#CCCCCC;opacity:0.75;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50 58 66" y="78" style="fill:#AA00AA;opacity:0.75;">1#0</text>
+    <text x="50" y="78" style="fill:#AA00AA;opacity:0.75;">l</text>
+    <text x="58 66" y="78" style="fill:#CCCCCC;opacity:0.75;">oy</text>
     <text x="82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
     <text x="114 122 130 138 146 154" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
     <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="96" style="fill:#000000;">✔︎</text>
-    <text x="66 74 82 90 98" y="96" style="fill:#0000AA;font-weight:bold;">1#0:o</text>
-    <text x="114" y="96" style="fill:#CCCCCC;">A</text>
-    <text x="130 138 146 154 162" y="96" style="fill:#00AA00;">three</text>
+    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">l:o</text>
+    <text x="98" y="96" style="fill:#CCCCCC;">A</text>
+    <text x="114 122 130 138 146" y="96" style="fill:#00AA00;">three</text>
     <text x="10 18" y="114" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
-    <text x="66 74 82 90 98" y="114" style="fill:#0000AA;font-weight:bold;">1#0:t</text>
-    <text x="114" y="114" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="130 138 146" y="114" style="fill:#00AA00;font-weight:bold;">two</text>
+    <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">l:t</text>
+    <text x="98" y="114" style="fill:#FFFFFF;font-weight:bold;">A</text>
+    <text x="114 122 130" y="114" style="fill:#00AA00;font-weight:bold;">two</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊●</text>
-    <text x="50 58 66" y="132" style="fill:#AA00AA;opacity:0.75;">1#1</text>
+    <text x="50 58" y="132" style="fill:#AA00AA;opacity:0.75;">zo</text>
+    <text x="66" y="132" style="fill:#CCCCCC;opacity:0.75;">o</text>
     <text x="82 90 98" y="132" style="fill:#CCCCCC;opacity:0.75;">(no</text>
     <text x="114 122 130 138 146 154" y="132" style="fill:#CCCCCC;opacity:0.75;">commit</text>
     <text x="170 178 186 194 202 210 218 226" y="132" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82 90 98" y="150" style="fill:#0000AA;font-weight:bold;opacity:0.75;">1#1:q</text>
-    <text x="114" y="150" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="130 138 146 154" y="150" style="fill:#00AA00;opacity:0.75;">four</text>
+    <text x="66 74 82 90" y="150" style="fill:#0000AA;font-weight:bold;opacity:0.75;">zo:q</text>
+    <text x="106" y="150" style="fill:#CCCCCC;opacity:0.75;">A</text>
+    <text x="122 130 138 146" y="150" style="fill:#00AA00;opacity:0.75;">four</text>
     <text x="10 18" y="168" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82 90 98" y="168" style="fill:#0000AA;font-weight:bold;opacity:0.75;">1#1:k</text>
-    <text x="114" y="168" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="130 138 146" y="168" style="fill:#00AA00;opacity:0.75;">one</text>
+    <text x="66 74 82 90" y="168" style="fill:#0000AA;font-weight:bold;opacity:0.75;">zo:k</text>
+    <text x="106" y="168" style="fill:#CCCCCC;opacity:0.75;">A</text>
+    <text x="122 130 138" y="168" style="fill:#00AA00;opacity:0.75;">one</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="204" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="222" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/can_only_mark_files_from_one_commit_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/can_only_mark_files_from_one_commit_003.svg
@@ -18,32 +18,34 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="60" style="fill:#00AA00;opacity:0.75;">c-branch-1</text>
     <text x="154" y="60" style="fill:#CCCCCC;opacity:0.75;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50 58 66" y="78" style="fill:#AA00AA;opacity:0.75;">1#0</text>
+    <text x="50" y="78" style="fill:#AA00AA;opacity:0.75;">l</text>
+    <text x="58 66" y="78" style="fill:#CCCCCC;opacity:0.75;">oy</text>
     <text x="82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
     <text x="114 122 130 138 146 154" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
     <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="96" style="fill:#000000;">✔︎</text>
-    <text x="66 74 82 90 98" y="96" style="fill:#0000AA;font-weight:bold;">1#0:o</text>
-    <text x="114" y="96" style="fill:#CCCCCC;">A</text>
-    <text x="130 138 146 154 162" y="96" style="fill:#00AA00;">three</text>
+    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">l:o</text>
+    <text x="98" y="96" style="fill:#CCCCCC;">A</text>
+    <text x="114 122 130 138 146" y="96" style="fill:#00AA00;">three</text>
     <text x="10 18" y="114" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
-    <text x="66 74 82 90 98" y="114" style="fill:#0000AA;font-weight:bold;">1#0:t</text>
-    <text x="114" y="114" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="130 138 146" y="114" style="fill:#00AA00;font-weight:bold;">two</text>
+    <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">l:t</text>
+    <text x="98" y="114" style="fill:#FFFFFF;font-weight:bold;">A</text>
+    <text x="114 122 130" y="114" style="fill:#00AA00;font-weight:bold;">two</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊●</text>
-    <text x="50 58 66" y="132" style="fill:#AA00AA;opacity:0.75;">1#1</text>
+    <text x="50 58" y="132" style="fill:#AA00AA;opacity:0.75;">zo</text>
+    <text x="66" y="132" style="fill:#CCCCCC;opacity:0.75;">o</text>
     <text x="82 90 98" y="132" style="fill:#CCCCCC;opacity:0.75;">(no</text>
     <text x="114 122 130 138 146 154" y="132" style="fill:#CCCCCC;opacity:0.75;">commit</text>
     <text x="170 178 186 194 202 210 218 226" y="132" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82 90 98" y="150" style="fill:#0000AA;font-weight:bold;opacity:0.75;">1#1:q</text>
-    <text x="114" y="150" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="130 138 146 154" y="150" style="fill:#00AA00;opacity:0.75;">four</text>
+    <text x="66 74 82 90" y="150" style="fill:#0000AA;font-weight:bold;opacity:0.75;">zo:q</text>
+    <text x="106" y="150" style="fill:#CCCCCC;opacity:0.75;">A</text>
+    <text x="122 130 138 146" y="150" style="fill:#00AA00;opacity:0.75;">four</text>
     <text x="10 18" y="168" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82 90 98" y="168" style="fill:#0000AA;font-weight:bold;opacity:0.75;">1#1:k</text>
-    <text x="114" y="168" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="130 138 146" y="168" style="fill:#00AA00;opacity:0.75;">one</text>
+    <text x="66 74 82 90" y="168" style="fill:#0000AA;font-weight:bold;opacity:0.75;">zo:k</text>
+    <text x="106" y="168" style="fill:#CCCCCC;opacity:0.75;">A</text>
+    <text x="122 130 138" y="168" style="fill:#00AA00;opacity:0.75;">one</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="204" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="222" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/can_only_mark_files_from_one_commit_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/can_only_mark_files_from_one_commit_004.svg
@@ -19,32 +19,34 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="60" style="fill:#00AA00;opacity:0.75;">c-branch-1</text>
     <text x="154" y="60" style="fill:#CCCCCC;opacity:0.75;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50 58 66" y="78" style="fill:#AA00AA;opacity:0.75;">1#0</text>
+    <text x="50" y="78" style="fill:#AA00AA;opacity:0.75;">l</text>
+    <text x="58 66" y="78" style="fill:#CCCCCC;opacity:0.75;">oy</text>
     <text x="82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
     <text x="114 122 130 138 146 154" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
     <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10" y="96" style="fill:#FFFFFF;font-weight:bold;">┊</text>
     <text x="18" y="96" style="fill:#000000;font-weight:bold;">✔︎</text>
-    <text x="66 74 82 90 98" y="96" style="fill:#0000AA;font-weight:bold;">1#0:o</text>
-    <text x="114" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="130 138 146 154 162" y="96" style="fill:#00AA00;font-weight:bold;">three</text>
+    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">l:o</text>
+    <text x="98" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
+    <text x="114 122 130 138 146" y="96" style="fill:#00AA00;font-weight:bold;">three</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82 90 98" y="114" style="fill:#0000AA;font-weight:bold;">1#0:t</text>
-    <text x="114" y="114" style="fill:#CCCCCC;">A</text>
-    <text x="130 138 146" y="114" style="fill:#00AA00;">two</text>
+    <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">l:t</text>
+    <text x="98" y="114" style="fill:#CCCCCC;">A</text>
+    <text x="114 122 130" y="114" style="fill:#00AA00;">two</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊●</text>
-    <text x="50 58 66" y="132" style="fill:#AA00AA;opacity:0.75;">1#1</text>
+    <text x="50 58" y="132" style="fill:#AA00AA;opacity:0.75;">zo</text>
+    <text x="66" y="132" style="fill:#CCCCCC;opacity:0.75;">o</text>
     <text x="82 90 98" y="132" style="fill:#CCCCCC;opacity:0.75;">(no</text>
     <text x="114 122 130 138 146 154" y="132" style="fill:#CCCCCC;opacity:0.75;">commit</text>
     <text x="170 178 186 194 202 210 218 226" y="132" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82 90 98" y="150" style="fill:#0000AA;font-weight:bold;opacity:0.75;">1#1:q</text>
-    <text x="114" y="150" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="130 138 146 154" y="150" style="fill:#00AA00;opacity:0.75;">four</text>
+    <text x="66 74 82 90" y="150" style="fill:#0000AA;font-weight:bold;opacity:0.75;">zo:q</text>
+    <text x="106" y="150" style="fill:#CCCCCC;opacity:0.75;">A</text>
+    <text x="122 130 138 146" y="150" style="fill:#00AA00;opacity:0.75;">four</text>
     <text x="10 18" y="168" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82 90 98" y="168" style="fill:#0000AA;font-weight:bold;opacity:0.75;">1#1:k</text>
-    <text x="114" y="168" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="130 138 146" y="168" style="fill:#00AA00;opacity:0.75;">one</text>
+    <text x="66 74 82 90" y="168" style="fill:#0000AA;font-weight:bold;opacity:0.75;">zo:k</text>
+    <text x="106" y="168" style="fill:#CCCCCC;opacity:0.75;">A</text>
+    <text x="122 130 138" y="168" style="fill:#00AA00;opacity:0.75;">one</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="204" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="222" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/cherry_pick_commit_to_above_commit_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/cherry_pick_commit_to_above_commit_003.svg
@@ -29,9 +29,10 @@
     <text x="74" y="132" style="fill:#00AA00;">B</text>
     <text x="82" y="132" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="150" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="150" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66 74 82" y="150" style="fill:#FFFFFF;font-weight:bold;">add</text>
-    <text x="98" y="150" style="fill:#FFFFFF;font-weight:bold;">A</text>
+    <text x="50" y="150" style="fill:#AA00AA;font-weight:bold;">s</text>
+    <text x="58 66" y="150" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">qq</text>
+    <text x="82 90 98" y="150" style="fill:#FFFFFF;font-weight:bold;">add</text>
+    <text x="114" y="150" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="10 18" y="168" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="168" style="fill:#AA00AA;">l</text>
     <text x="58 66" y="168" style="fill:#CCCCCC;opacity:0.75;">rm</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/cherry_pick_commit_to_below_commit_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/cherry_pick_commit_to_below_commit_003.svg
@@ -34,9 +34,10 @@
     <text x="82 90 98" y="150" style="fill:#CCCCCC;">add</text>
     <text x="114" y="150" style="fill:#CCCCCC;">B</text>
     <text x="10 18" y="168" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="168" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66 74 82" y="168" style="fill:#FFFFFF;font-weight:bold;">add</text>
-    <text x="98" y="168" style="fill:#FFFFFF;font-weight:bold;">A</text>
+    <text x="50" y="168" style="fill:#AA00AA;font-weight:bold;">s</text>
+    <text x="58 66" y="168" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">qq</text>
+    <text x="82 90 98" y="168" style="fill:#FFFFFF;font-weight:bold;">add</text>
+    <text x="114" y="168" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="204" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="222" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/cherry_pick_commit_to_branch_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/cherry_pick_commit_to_branch_003.svg
@@ -29,9 +29,10 @@
     <text x="74" y="132" style="fill:#00AA00;">B</text>
     <text x="82" y="132" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="150" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="150" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66 74 82" y="150" style="fill:#FFFFFF;font-weight:bold;">add</text>
-    <text x="98" y="150" style="fill:#FFFFFF;font-weight:bold;">A</text>
+    <text x="50" y="150" style="fill:#AA00AA;font-weight:bold;">s</text>
+    <text x="58 66" y="150" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">qq</text>
+    <text x="82 90 98" y="150" style="fill:#FFFFFF;font-weight:bold;">add</text>
+    <text x="114" y="150" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="10 18" y="168" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="168" style="fill:#AA00AA;">l</text>
     <text x="58 66" y="168" style="fill:#CCCCCC;opacity:0.75;">rm</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/cherry_pick_commit_to_new_branch_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/cherry_pick_commit_to_new_branch_002.svg
@@ -29,9 +29,10 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="132" style="fill:#00AA00;">c-branch-1</text>
     <text x="154" y="132" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="150" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="150" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66 74 82" y="150" style="fill:#FFFFFF;font-weight:bold;">add</text>
-    <text x="98" y="150" style="fill:#FFFFFF;font-weight:bold;">A</text>
+    <text x="50" y="150" style="fill:#AA00AA;font-weight:bold;">s</text>
+    <text x="58 66" y="150" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">qq</text>
+    <text x="82 90 98" y="150" style="fill:#FFFFFF;font-weight:bold;">add</text>
+    <text x="114" y="150" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="10 18" y="168" style="fill:#CCCCCC;">┊│</text>
     <text x="10 18 26" y="186" style="fill:#CCCCCC;">┊├┄</text>
     <text x="42 50" y="186" style="fill:#0000AA;font-weight:bold;">h0</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/cherry_pick_marks_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/cherry_pick_marks_004.svg
@@ -29,9 +29,10 @@
     <text x="74" y="132" style="fill:#00AA00;">B</text>
     <text x="82" y="132" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="150" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="150" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66 74 82" y="150" style="fill:#FFFFFF;font-weight:bold;">add</text>
-    <text x="98" y="150" style="fill:#FFFFFF;font-weight:bold;">A</text>
+    <text x="50" y="150" style="fill:#AA00AA;font-weight:bold;">s</text>
+    <text x="58 66" y="150" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">qq</text>
+    <text x="82 90 98" y="150" style="fill:#FFFFFF;font-weight:bold;">add</text>
+    <text x="114" y="150" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="10 18" y="168" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="168" style="fill:#AA00AA;">l</text>
     <text x="58 66" y="168" style="fill:#CCCCCC;opacity:0.75;">rm</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/cherry_picking_commits_into_worktrees_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/cherry_picking_commits_into_worktrees_001.svg
@@ -24,12 +24,13 @@
     <text x="50 58" y="78" style="fill:#FFFFFF;">&lt;&lt;</text>
     <text x="74 82 90 98 106 114" y="78" style="fill:#FFFFFF;">source</text>
     <text x="130 138" y="78" style="fill:#FFFFFF;">&gt;&gt;</text>
-    <text x="154" y="78" style="fill:#AA00AA;">1</text>
-    <text x="170 178 186" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="202 210 218 226 234 242" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="258 266 274 282 290 298 306 314" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="330 338 346" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="362 370 378 386 394 402 410 418" y="78" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="154 162" y="78" style="fill:#AA00AA;">om</text>
+    <text x="170" y="78" style="fill:#CCCCCC;opacity:0.75;">y</text>
+    <text x="186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="218 226 234 242 250 258" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="274 282 290 298 306 314 322 330" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="346 354 362" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="378 386 394 402 410 418 426 434" y="78" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="132" style="fill:#CCCCCC;">┊╭┄</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/cherry_picking_commits_into_worktrees_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/cherry_picking_commits_into_worktrees_002.svg
@@ -17,12 +17,12 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="60" style="fill:#00AA00;">c-branch-1</text>
     <text x="154" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50 58 66" y="78" style="fill:#AA00AA;">1#1</text>
-    <text x="82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="114 122 130 138 146 154" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="242 250 258" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="274 282 290 298 306 314 322 330" y="78" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="50 58 66 74" y="78" style="fill:#AA00AA;">om#1</text>
+    <text x="90 98 106" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="122 130 138 146 154 162" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="178 186 194 202 210 218 226 234" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="250 258 266" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="282 290 298 306 314 322 330 338" y="78" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="132" style="fill:#CCCCCC;">┊╭┄</text>
@@ -42,12 +42,12 @@
     <text x="98 106 114 122 130 138 146 154 162 170 178" y="186" style="fill:#00AA00;">wt-file.txt</text>
     <text x="10 18 26" y="204" style="fill:#CCCCCC;">┊┊┊</text>
     <text x="10 18 26" y="222" style="fill:#FFFFFF;font-weight:bold;">┊┊●</text>
-    <text x="58 66 74" y="222" style="fill:#AA00AA;font-weight:bold;">1#0</text>
-    <text x="90 98 106" y="222" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="122 130 138 146 154 162" y="222" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="178 186 194 202 210 218 226 234" y="222" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
-    <text x="250 258 266" y="222" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="282 290 298 306 314 322 330 338" y="222" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
+    <text x="58 66 74 82" y="222" style="fill:#AA00AA;font-weight:bold;">om#0</text>
+    <text x="98 106 114" y="222" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="130 138 146 154 162 170" y="222" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="186 194 202 210 218 226 234 242" y="222" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="258 266 274" y="222" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="290 298 306 314 322 330 338 346" y="222" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
     <text x="10 18 26" y="240" style="fill:#CCCCCC;">┊┊●</text>
     <text x="58" y="240" style="fill:#AA00AA;">n</text>
     <text x="66 74" y="240" style="fill:#CCCCCC;opacity:0.75;">ll</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_file_toggle_on_commit_without_files_is_noop_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_file_toggle_on_commit_without_files_is_noop_final.svg
@@ -17,12 +17,13 @@
     <text x="74" y="60" style="fill:#00AA00;">A</text>
     <text x="82" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#AA00AA;">1</text>
-    <text x="66 74 82" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="226 234 242" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="258 266 274 282 290 298 306 314" y="78" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="50" y="78" style="fill:#AA00AA;">o</text>
+    <text x="58 66" y="78" style="fill:#CCCCCC;opacity:0.75;">un</text>
+    <text x="82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="242 250 258" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="274 282 290 298 306 314 322 330" y="78" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="96" style="fill:#AA00AA;">t</text>
     <text x="58 66" y="96" style="fill:#CCCCCC;opacity:0.75;">pm</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_from_unstaged_changes_creates_commit_visible_in_tui_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_from_unstaged_changes_creates_commit_visible_in_tui_final.svg
@@ -17,11 +17,12 @@
     <text x="74" y="60" style="fill:#00AA00;">A</text>
     <text x="82" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66 74 82 90 98 106" y="78" style="fill:#FFFFFF;font-weight:bold;">commit</text>
-    <text x="122 130 138 146" y="78" style="fill:#FFFFFF;font-weight:bold;">from</text>
-    <text x="162 170 178" y="78" style="fill:#FFFFFF;font-weight:bold;">tui</text>
-    <text x="194 202 210 218" y="78" style="fill:#FFFFFF;font-weight:bold;">test</text>
+    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">o</text>
+    <text x="58 66" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">qn</text>
+    <text x="82 90 98 106 114 122" y="78" style="fill:#FFFFFF;font-weight:bold;">commit</text>
+    <text x="138 146 154 162" y="78" style="fill:#FFFFFF;font-weight:bold;">from</text>
+    <text x="178 186 194" y="78" style="fill:#FFFFFF;font-weight:bold;">tui</text>
+    <text x="210 218 226 234" y="78" style="fill:#FFFFFF;font-weight:bold;">test</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="96" style="fill:#AA00AA;">t</text>
     <text x="58 66" y="96" style="fill:#CCCCCC;opacity:0.75;">pm</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_from_unstaged_changes_to_new_branch_checks_out_branch_in_single_branch_mode_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_from_unstaged_changes_to_new_branch_checks_out_branch_in_single_branch_mode_final.svg
@@ -18,11 +18,12 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="60" style="fill:#00AA00;">c-branch-1</text>
     <text x="154" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66 74 82 90 98 106" y="78" style="fill:#FFFFFF;font-weight:bold;">commit</text>
-    <text x="122 130 138 146" y="78" style="fill:#FFFFFF;font-weight:bold;">from</text>
-    <text x="162 170 178" y="78" style="fill:#FFFFFF;font-weight:bold;">tui</text>
-    <text x="194 202 210 218" y="78" style="fill:#FFFFFF;font-weight:bold;">test</text>
+    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">o</text>
+    <text x="58 66" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">qn</text>
+    <text x="82 90 98 106 114 122" y="78" style="fill:#FFFFFF;font-weight:bold;">commit</text>
+    <text x="138 146 154 162" y="78" style="fill:#FFFFFF;font-weight:bold;">from</text>
+    <text x="178 186 194" y="78" style="fill:#FFFFFF;font-weight:bold;">tui</text>
+    <text x="210 218 226 234" y="78" style="fill:#FFFFFF;font-weight:bold;">test</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="10 18 26" y="114" style="fill:#CCCCCC;">┊├┄</text>
     <text x="42 50" y="114" style="fill:#0000AA;font-weight:bold;">g0</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_from_unstaged_changes_to_new_branch_creates_branch_and_commit_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_from_unstaged_changes_to_new_branch_creates_branch_and_commit_final.svg
@@ -17,11 +17,12 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="60" style="fill:#00AA00;">c-branch-1</text>
     <text x="154" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66 74 82 90 98 106" y="78" style="fill:#FFFFFF;font-weight:bold;">commit</text>
-    <text x="122 130 138 146" y="78" style="fill:#FFFFFF;font-weight:bold;">from</text>
-    <text x="162 170 178" y="78" style="fill:#FFFFFF;font-weight:bold;">tui</text>
-    <text x="194 202 210 218" y="78" style="fill:#FFFFFF;font-weight:bold;">test</text>
+    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">o</text>
+    <text x="58 66" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">qn</text>
+    <text x="82 90 98 106 114 122" y="78" style="fill:#FFFFFF;font-weight:bold;">commit</text>
+    <text x="138 146 154 162" y="78" style="fill:#FFFFFF;font-weight:bold;">from</text>
+    <text x="178 186 194" y="78" style="fill:#FFFFFF;font-weight:bold;">tui</text>
+    <text x="210 218 226 234" y="78" style="fill:#FFFFFF;font-weight:bold;">test</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
     <text x="10 18 26" y="114" style="fill:#CCCCCC;">┊├┄</text>
     <text x="42 50" y="114" style="fill:#0000AA;font-weight:bold;">g0</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_to_commit_above_creates_commit_visible_in_tui_final_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_to_commit_above_creates_commit_visible_in_tui_final_002.svg
@@ -17,11 +17,12 @@
     <text x="74" y="60" style="fill:#00AA00;">A</text>
     <text x="82" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66 74 82 90 98 106" y="78" style="fill:#FFFFFF;font-weight:bold;">commit</text>
-    <text x="122 130 138 146" y="78" style="fill:#FFFFFF;font-weight:bold;">from</text>
-    <text x="162 170 178" y="78" style="fill:#FFFFFF;font-weight:bold;">tui</text>
-    <text x="194 202 210 218" y="78" style="fill:#FFFFFF;font-weight:bold;">test</text>
+    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">o</text>
+    <text x="58 66" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">qn</text>
+    <text x="82 90 98 106 114 122" y="78" style="fill:#FFFFFF;font-weight:bold;">commit</text>
+    <text x="138 146 154 162" y="78" style="fill:#FFFFFF;font-weight:bold;">from</text>
+    <text x="178 186 194" y="78" style="fill:#FFFFFF;font-weight:bold;">tui</text>
+    <text x="210 218 226 234" y="78" style="fill:#FFFFFF;font-weight:bold;">test</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="96" style="fill:#AA00AA;">t</text>
     <text x="58 66" y="96" style="fill:#CCCCCC;opacity:0.75;">pm</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_to_commit_below_creates_commit_visible_in_tui_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_to_commit_below_creates_commit_visible_in_tui_final.svg
@@ -22,11 +22,12 @@
     <text x="82 90 98" y="78" style="fill:#CCCCCC;">add</text>
     <text x="114" y="78" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="96" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66 74 82 90 98 106" y="96" style="fill:#FFFFFF;font-weight:bold;">commit</text>
-    <text x="122 130 138 146" y="96" style="fill:#FFFFFF;font-weight:bold;">from</text>
-    <text x="162 170 178" y="96" style="fill:#FFFFFF;font-weight:bold;">tui</text>
-    <text x="194 202 210 218" y="96" style="fill:#FFFFFF;font-weight:bold;">test</text>
+    <text x="50 58" y="96" style="fill:#AA00AA;font-weight:bold;">zy</text>
+    <text x="66" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">m</text>
+    <text x="82 90 98 106 114 122" y="96" style="fill:#FFFFFF;font-weight:bold;">commit</text>
+    <text x="138 146 154 162" y="96" style="fill:#FFFFFF;font-weight:bold;">from</text>
+    <text x="178 186 194" y="96" style="fill:#FFFFFF;font-weight:bold;">tui</text>
+    <text x="210 218 226 234" y="96" style="fill:#FFFFFF;font-weight:bold;">test</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="150" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_to_new_branch_from_uncommitted_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commit_to_new_branch_from_uncommitted_001.svg
@@ -17,10 +17,11 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="60" style="fill:#00AA00;">c-branch-1</text>
     <text x="154" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66 74 82" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">s</text>
+    <text x="58 66" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">tv</text>
+    <text x="82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commiting_with_no_uncommitted_changes_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commiting_with_no_uncommitted_changes_003.svg
@@ -17,12 +17,13 @@
     <text x="74" y="60" style="fill:#00AA00;">A</text>
     <text x="82" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66 74 82" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
-    <text x="226 234 242" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="258 266 274 282 290 298 306 314" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
+    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">o</text>
+    <text x="58 66" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">un</text>
+    <text x="82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="242 250 258" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="274 282 290 298 306 314 322 330" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="96" style="fill:#AA00AA;">t</text>
     <text x="58 66" y="96" style="fill:#CCCCCC;opacity:0.75;">pm</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commits_are_cherry_picked_in_order_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commits_are_cherry_picked_in_order_001.svg
@@ -26,11 +26,12 @@
     <text x="74" y="114" style="fill:#00AA00;">A</text>
     <text x="82" y="114" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="132" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="132" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66 74 82 90 98 106" y="132" style="fill:#FFFFFF;font-weight:bold;">change</text>
-    <text x="122" y="132" style="fill:#FFFFFF;font-weight:bold;">A</text>
+    <text x="50" y="132" style="fill:#AA00AA;font-weight:bold;">v</text>
+    <text x="58 66" y="132" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">rs</text>
+    <text x="82 90 98 106 114 122" y="132" style="fill:#FFFFFF;font-weight:bold;">change</text>
+    <text x="138" y="132" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="150" style="fill:#0000AA;font-weight:bold;">1:t</text>
+    <text x="66 74 82" y="150" style="fill:#0000AA;font-weight:bold;">v:t</text>
     <text x="98" y="150" style="fill:#CCCCCC;">M</text>
     <text x="114" y="150" style="fill:#AA5500;">A</text>
     <text x="10 18" y="168" style="fill:#CCCCCC;">┊●</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commits_are_cherry_picked_in_order_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commits_are_cherry_picked_in_order_002.svg
@@ -38,11 +38,12 @@
     <text x="50 58" y="132" style="fill:#FFFFFF;">&lt;&lt;</text>
     <text x="74 82 90 98 106 114" y="132" style="fill:#FFFFFF;">source</text>
     <text x="130 138" y="132" style="fill:#FFFFFF;">&gt;&gt;</text>
-    <text x="154" y="132" style="fill:#AA00AA;">1</text>
-    <text x="170 178 186 194 202 210" y="132" style="fill:#CCCCCC;">change</text>
-    <text x="226" y="132" style="fill:#CCCCCC;">A</text>
+    <text x="154" y="132" style="fill:#AA00AA;">v</text>
+    <text x="162 170" y="132" style="fill:#CCCCCC;opacity:0.75;">rs</text>
+    <text x="186 194 202 210 218 226" y="132" style="fill:#CCCCCC;">change</text>
+    <text x="242" y="132" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="150" style="fill:#0000AA;font-weight:bold;opacity:0.75;">1:t</text>
+    <text x="66 74 82" y="150" style="fill:#0000AA;font-weight:bold;opacity:0.75;">v:t</text>
     <text x="98" y="150" style="fill:#CCCCCC;opacity:0.75;">M</text>
     <text x="114" y="150" style="fill:#AA5500;opacity:0.75;">A</text>
     <text x="10" y="168" style="fill:#FFFFFF;font-weight:bold;">┊</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commits_are_cherry_picked_in_order_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commits_are_cherry_picked_in_order_003.svg
@@ -43,11 +43,12 @@
     <text x="50 58" y="150" style="fill:#FFFFFF;">&lt;&lt;</text>
     <text x="74 82 90 98 106 114" y="150" style="fill:#FFFFFF;">source</text>
     <text x="130 138" y="150" style="fill:#FFFFFF;">&gt;&gt;</text>
-    <text x="154" y="150" style="fill:#AA00AA;">1</text>
-    <text x="170 178 186 194 202 210" y="150" style="fill:#CCCCCC;">change</text>
-    <text x="226" y="150" style="fill:#CCCCCC;">A</text>
+    <text x="154" y="150" style="fill:#AA00AA;">v</text>
+    <text x="162 170" y="150" style="fill:#CCCCCC;opacity:0.75;">rs</text>
+    <text x="186 194 202 210 218 226" y="150" style="fill:#CCCCCC;">change</text>
+    <text x="242" y="150" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="168" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="168" style="fill:#0000AA;font-weight:bold;opacity:0.75;">1:t</text>
+    <text x="66 74 82" y="168" style="fill:#0000AA;font-weight:bold;opacity:0.75;">v:t</text>
     <text x="98" y="168" style="fill:#CCCCCC;opacity:0.75;">M</text>
     <text x="114" y="168" style="fill:#AA5500;opacity:0.75;">A</text>
     <text x="10" y="186" style="fill:#CCCCCC;">┊</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/commits_are_cherry_picked_in_order_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/commits_are_cherry_picked_in_order_004.svg
@@ -17,21 +17,23 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="60" style="fill:#00AA00;">c-branch-1</text>
     <text x="154" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50 58 66" y="78" style="fill:#AA00AA;">1#0</text>
+    <text x="50" y="78" style="fill:#AA00AA;">u</text>
+    <text x="58 66" y="78" style="fill:#CCCCCC;opacity:0.75;">so</text>
     <text x="82 90 98 106 114 122" y="78" style="fill:#CCCCCC;">change</text>
     <text x="138" y="78" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82 90 98" y="96" style="fill:#0000AA;font-weight:bold;">1#0:t</text>
-    <text x="114" y="96" style="fill:#CCCCCC;">M</text>
-    <text x="130" y="96" style="fill:#AA5500;">A</text>
+    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">u:t</text>
+    <text x="98" y="96" style="fill:#CCCCCC;">M</text>
+    <text x="114" y="96" style="fill:#AA5500;">A</text>
     <text x="10 18" y="114" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50 58 66" y="114" style="fill:#AA00AA;font-weight:bold;">1#1</text>
+    <text x="50" y="114" style="fill:#AA00AA;font-weight:bold;">s</text>
+    <text x="58 66" y="114" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">qq</text>
     <text x="82 90 98" y="114" style="fill:#FFFFFF;font-weight:bold;">add</text>
     <text x="114" y="114" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82 90 98" y="132" style="fill:#0000AA;font-weight:bold;">1#1:t</text>
-    <text x="114" y="132" style="fill:#CCCCCC;">A</text>
-    <text x="130" y="132" style="fill:#00AA00;">A</text>
+    <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;">s:t</text>
+    <text x="98" y="132" style="fill:#CCCCCC;">A</text>
+    <text x="114" y="132" style="fill:#00AA00;">A</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="186" style="fill:#CCCCCC;">┊╭┄</text>
@@ -40,13 +42,14 @@
     <text x="74" y="186" style="fill:#00AA00;">A</text>
     <text x="82" y="186" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="204" style="fill:#CCCCCC;">┊●</text>
-    <text x="50 58 66" y="204" style="fill:#AA00AA;">1#2</text>
+    <text x="50" y="204" style="fill:#AA00AA;">v</text>
+    <text x="58 66" y="204" style="fill:#CCCCCC;opacity:0.75;">rs</text>
     <text x="82 90 98 106 114 122" y="204" style="fill:#CCCCCC;">change</text>
     <text x="138" y="204" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="222" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82 90 98" y="222" style="fill:#0000AA;font-weight:bold;">1#2:t</text>
-    <text x="114" y="222" style="fill:#CCCCCC;">M</text>
-    <text x="130" y="222" style="fill:#AA5500;">A</text>
+    <text x="66 74 82" y="222" style="fill:#0000AA;font-weight:bold;">v:t</text>
+    <text x="98" y="222" style="fill:#CCCCCC;">M</text>
+    <text x="114" y="222" style="fill:#AA5500;">A</text>
     <text x="10 18" y="240" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="240" style="fill:#AA00AA;">t</text>
     <text x="58 66" y="240" style="fill:#CCCCCC;opacity:0.75;">pm</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/committing_hunks_from_full_screen_details_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/committing_hunks_from_full_screen_details_003.svg
@@ -14,13 +14,13 @@
     <text x="410" y="24" style="fill:#555555;">│</text>
     <text x="418 426 434 442 450 458" y="24" style="fill:#CCCCCC;">Commit</text>
     <text x="474 482 490" y="24" style="fill:#CCCCCC;">ID:</text>
-    <text x="506 514 522 530 538 546 554 562 570 578 586 594 602 610 618 626 634 642 650 658 666 674 682 690 698 706 714 722 730 738 746 754 762 770 778 786 794" y="24" style="fill:#00AAAA;">161827dfb753ab835140e9bec9b8932c29691</text>
+    <text x="506 514 522 530 538 546 554 562 570 578 586 594 602 610 618 626 634 642 650 658 666 674 682 690 698 706 714 722 730 738 746 754 762 770 778 786 794" y="24" style="fill:#00AAAA;">607352e26d3a3e48310b5fe32008192f10767</text>
     <text x="802" y="24" style="fill:#555555;">█</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="418 426 434 442 450 458" y="42" style="fill:#CCCCCC;">Change</text>
     <text x="474 482 490" y="42" style="fill:#CCCCCC;">ID:</text>
-    <text x="506" y="42" style="fill:#AA00AA;">1</text>
+    <text x="506 514 522 530 538 546 554 562 570 578 586 594 602 610 618 626 634 642 650 658 666 674 682 690 698 706 714 722 730 738 746 754" y="42" style="fill:#AA00AA;">kppwppwzzzynrymywkzrnvopplmottsw</text>
     <text x="802" y="42" style="fill:#555555;">█</text>
     <text x="10 18 26" y="60" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;">g0</text>
@@ -37,10 +37,11 @@
     <text x="786 794" y="60" style="fill:#00AAAA;">Sa</text>
     <text x="802" y="60" style="fill:#555555;">█</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66 74 82" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">k</text>
+    <text x="58 66" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">pp</text>
+    <text x="82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
     <text x="410" y="78" style="fill:#555555;">│</text>
     <text x="418 426 434 442 450 458 466 474 482 490" y="78" style="fill:#CCCCCC;">Committer:</text>
     <text x="506 514 522 530 538 546 554 562 570" y="78" style="fill:#FFFF55;">committer</text>
@@ -85,7 +86,7 @@
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506" y="186" style="fill:#555555;">│───────────╮</text>
     <text x="802" y="186" style="fill:#555555;">█</text>
     <text x="410" y="204" style="fill:#555555;">│</text>
-    <text x="426 434 442 450 458" y="204" style="fill:#0000AA;">1:k:c</text>
+    <text x="426 434 442 450 458" y="204" style="fill:#0000AA;">k:k:c</text>
     <text x="474 482 490" y="204" style="fill:#CCCCCC;">one</text>
     <text x="506" y="204" style="fill:#555555;">│</text>
     <text x="802" y="204" style="fill:#555555;">█</text>
@@ -110,7 +111,7 @@
     <text x="410" y="312" style="fill:#555555;">│</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506" y="330" style="fill:#555555;">│───────────╮</text>
     <text x="410" y="348" style="fill:#555555;">│</text>
-    <text x="426 434 442 450 458" y="348" style="fill:#0000AA;">1:t:c</text>
+    <text x="426 434 442 450 458" y="348" style="fill:#0000AA;">k:t:c</text>
     <text x="474 482 490" y="348" style="fill:#CCCCCC;">two</text>
     <text x="506" y="348" style="fill:#555555;">│</text>
     <text x="26 34 42 50 58 66" y="366" style="fill:#FFFFFF;">normal</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/committing_hunks_from_split_details_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/committing_hunks_from_split_details_003.svg
@@ -14,13 +14,13 @@
     <text x="410" y="24" style="fill:#555555;">│</text>
     <text x="418 426 434 442 450 458" y="24" style="fill:#CCCCCC;">Commit</text>
     <text x="474 482 490" y="24" style="fill:#CCCCCC;">ID:</text>
-    <text x="506 514 522 530 538 546 554 562 570 578 586 594 602 610 618 626 634 642 650 658 666 674 682 690 698 706 714 722 730 738 746 754 762 770 778 786 794" y="24" style="fill:#00AAAA;">161827dfb753ab835140e9bec9b8932c29691</text>
+    <text x="506 514 522 530 538 546 554 562 570 578 586 594 602 610 618 626 634 642 650 658 666 674 682 690 698 706 714 722 730 738 746 754 762 770 778 786 794" y="24" style="fill:#00AAAA;">607352e26d3a3e48310b5fe32008192f10767</text>
     <text x="802" y="24" style="fill:#555555;">█</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="418 426 434 442 450 458" y="42" style="fill:#CCCCCC;">Change</text>
     <text x="474 482 490" y="42" style="fill:#CCCCCC;">ID:</text>
-    <text x="506" y="42" style="fill:#AA00AA;">1</text>
+    <text x="506 514 522 530 538 546 554 562 570 578 586 594 602 610 618 626 634 642 650 658 666 674 682 690 698 706 714 722 730 738 746 754" y="42" style="fill:#AA00AA;">kppwppwzzzynrymywkzrnvopplmottsw</text>
     <text x="802" y="42" style="fill:#555555;">█</text>
     <text x="10 18 26" y="60" style="fill:#CCCCCC;">┊╭┄</text>
     <text x="42 50" y="60" style="fill:#0000AA;font-weight:bold;">g0</text>
@@ -37,10 +37,11 @@
     <text x="786 794" y="60" style="fill:#00AAAA;">Sa</text>
     <text x="802" y="60" style="fill:#555555;">█</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66 74 82" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">k</text>
+    <text x="58 66" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">pp</text>
+    <text x="82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
     <text x="410" y="78" style="fill:#555555;">│</text>
     <text x="418 426 434 442 450 458 466 474 482 490" y="78" style="fill:#CCCCCC;">Committer:</text>
     <text x="506 514 522 530 538 546 554 562 570" y="78" style="fill:#FFFF55;">committer</text>
@@ -85,7 +86,7 @@
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506" y="186" style="fill:#555555;">│───────────╮</text>
     <text x="802" y="186" style="fill:#555555;">█</text>
     <text x="410" y="204" style="fill:#555555;">│</text>
-    <text x="426 434 442 450 458" y="204" style="fill:#0000AA;">1:k:c</text>
+    <text x="426 434 442 450 458" y="204" style="fill:#0000AA;">k:k:c</text>
     <text x="474 482 490" y="204" style="fill:#CCCCCC;">one</text>
     <text x="506" y="204" style="fill:#555555;">│</text>
     <text x="802" y="204" style="fill:#555555;">█</text>
@@ -110,7 +111,7 @@
     <text x="410" y="312" style="fill:#555555;">│</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506" y="330" style="fill:#555555;">│───────────╮</text>
     <text x="410" y="348" style="fill:#555555;">│</text>
-    <text x="426 434 442 450 458" y="348" style="fill:#0000AA;">1:t:c</text>
+    <text x="426 434 442 450 458" y="348" style="fill:#0000AA;">k:t:c</text>
     <text x="474 482 490" y="348" style="fill:#CCCCCC;">two</text>
     <text x="506" y="348" style="fill:#555555;">│</text>
     <text x="26 34 42 50 58 66" y="366" style="fill:#FFFFFF;">normal</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/committing_selection_from_full_screen_details_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/committing_selection_from_full_screen_details_003.svg
@@ -12,7 +12,7 @@
     <text x="410" y="24" style="fill:#555555;">│</text>
     <text x="418 426 434 442 450 458" y="24" style="fill:#CCCCCC;">Commit</text>
     <text x="474 482 490" y="24" style="fill:#CCCCCC;">ID:</text>
-    <text x="506 514 522 530 538 546 554 562 570 578 586 594 602 610 618 626 634 642 650 658 666 674 682 690 698 706 714 722 730 738 746 754 762 770 778 786 794 802" y="24" style="fill:#00AAAA;">512a01bf9bfee915d2b247437f1434e6017f02</text>
+    <text x="506 514 522 530 538 546 554 562 570 578 586 594 602 610 618 626 634 642 650 658 666 674 682 690 698 706 714 722 730 738 746 754 762 770 778 786 794 802" y="24" style="fill:#00AAAA;">ee9a59390fd20310665925237de1124c6b7982</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="42" style="fill:#0000AA;font-weight:bold;">twop</text>
     <text x="82" y="42" style="fill:#CCCCCC;">A</text>
@@ -20,7 +20,7 @@
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="418 426 434 442 450 458" y="42" style="fill:#CCCCCC;">Change</text>
     <text x="474 482 490" y="42" style="fill:#CCCCCC;">ID:</text>
-    <text x="506" y="42" style="fill:#AA00AA;">1</text>
+    <text x="506 514 522 530 538 546 554 562 570 578 586 594 602 610 618 626 634 642 650 658 666 674 682 690 698 706 714 722 730 738 746 754" y="42" style="fill:#AA00AA;">ysoovyvnlumztzquwywulqwlxzxmvouq</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="410" y="60" style="fill:#555555;">│</text>
     <text x="418 426 434 442 450 458 466" y="60" style="fill:#CCCCCC;">Author:</text>
@@ -44,10 +44,11 @@
     <text x="778" y="78" style="fill:#CCCCCC;">(</text>
     <text x="786 794 802" y="78" style="fill:#00AAAA;">Sat</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="96" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66 74 82" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="50" y="96" style="fill:#AA00AA;font-weight:bold;">y</text>
+    <text x="58 66" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">so</text>
+    <text x="82 90 98" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
     <text x="410" y="96" style="fill:#555555;">│</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊●</text>
     <text x="50 58" y="114" style="fill:#AA00AA;">tp</text>
@@ -77,7 +78,7 @@
     <text x="410" y="168" style="fill:#555555;">│</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506" y="186" style="fill:#555555;">│───────────╮</text>
     <text x="410" y="204" style="fill:#555555;">│</text>
-    <text x="426 434 442 450 458" y="204" style="fill:#0000AA;">1:k:c</text>
+    <text x="426 434 442 450 458" y="204" style="fill:#0000AA;">y:k:c</text>
     <text x="474 482 490" y="204" style="fill:#CCCCCC;">one</text>
     <text x="506" y="204" style="fill:#555555;">│</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506" y="222" style="fill:#555555;">│───────────╯</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/committing_selection_from_split_details_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/committing_selection_from_split_details_003.svg
@@ -12,7 +12,7 @@
     <text x="410" y="24" style="fill:#555555;">│</text>
     <text x="418 426 434 442 450 458" y="24" style="fill:#CCCCCC;">Commit</text>
     <text x="474 482 490" y="24" style="fill:#CCCCCC;">ID:</text>
-    <text x="506 514 522 530 538 546 554 562 570 578 586 594 602 610 618 626 634 642 650 658 666 674 682 690 698 706 714 722 730 738 746 754 762 770 778 786 794 802" y="24" style="fill:#00AAAA;">512a01bf9bfee915d2b247437f1434e6017f02</text>
+    <text x="506 514 522 530 538 546 554 562 570 578 586 594 602 610 618 626 634 642 650 658 666 674 682 690 698 706 714 722 730 738 746 754 762 770 778 786 794 802" y="24" style="fill:#00AAAA;">ee9a59390fd20310665925237de1124c6b7982</text>
     <text x="10" y="42" style="fill:#CCCCCC;">┊</text>
     <text x="42 50 58 66" y="42" style="fill:#0000AA;font-weight:bold;">twop</text>
     <text x="82" y="42" style="fill:#CCCCCC;">A</text>
@@ -20,7 +20,7 @@
     <text x="410" y="42" style="fill:#555555;">│</text>
     <text x="418 426 434 442 450 458" y="42" style="fill:#CCCCCC;">Change</text>
     <text x="474 482 490" y="42" style="fill:#CCCCCC;">ID:</text>
-    <text x="506" y="42" style="fill:#AA00AA;">1</text>
+    <text x="506 514 522 530 538 546 554 562 570 578 586 594 602 610 618 626 634 642 650 658 666 674 682 690 698 706 714 722 730 738 746 754" y="42" style="fill:#AA00AA;">ysoovyvnlumztzquwywulqwlxzxmvouq</text>
     <text x="10" y="60" style="fill:#CCCCCC;">┊</text>
     <text x="410" y="60" style="fill:#555555;">│</text>
     <text x="418 426 434 442 450 458 466" y="60" style="fill:#CCCCCC;">Author:</text>
@@ -44,10 +44,11 @@
     <text x="778" y="78" style="fill:#CCCCCC;">(</text>
     <text x="786 794 802" y="78" style="fill:#00AAAA;">Sat</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="96" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66 74 82" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="50" y="96" style="fill:#AA00AA;font-weight:bold;">y</text>
+    <text x="58 66" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">so</text>
+    <text x="82 90 98" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
     <text x="410" y="96" style="fill:#555555;">│</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊●</text>
     <text x="50 58" y="114" style="fill:#AA00AA;">tp</text>
@@ -77,7 +78,7 @@
     <text x="410" y="168" style="fill:#555555;">│</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506" y="186" style="fill:#555555;">│───────────╮</text>
     <text x="410" y="204" style="fill:#555555;">│</text>
-    <text x="426 434 442 450 458" y="204" style="fill:#0000AA;">1:k:c</text>
+    <text x="426 434 442 450 458" y="204" style="fill:#0000AA;">y:k:c</text>
     <text x="474 482 490" y="204" style="fill:#CCCCCC;">one</text>
     <text x="506" y="204" style="fill:#555555;">│</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506" y="222" style="fill:#555555;">│───────────╯</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/creating_empty_commits_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/creating_empty_commits_002.svg
@@ -17,12 +17,13 @@
     <text x="74" y="60" style="fill:#00AA00;">A</text>
     <text x="82" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66 74 82" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
-    <text x="226 234 242" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="258 266 274 282 290 298 306 314" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
+    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">o</text>
+    <text x="58 66" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">un</text>
+    <text x="82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="242 250 258" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="274 282 290 298 306 314 322 330" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="96" style="fill:#AA00AA;">t</text>
     <text x="58 66" y="96" style="fill:#CCCCCC;opacity:0.75;">pm</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/creating_empty_commits_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/creating_empty_commits_003.svg
@@ -17,14 +17,16 @@
     <text x="74" y="60" style="fill:#00AA00;">A</text>
     <text x="82" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50 58 66" y="78" style="fill:#AA00AA;font-weight:bold;">1#0</text>
+    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">m</text>
+    <text x="58 66" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">ul</text>
     <text x="82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
     <text x="114 122 130 138 146 154" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
     <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
     <text x="242 250 258" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
     <text x="274 282 290 298 306 314 322 330" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
-    <text x="50 58 66" y="96" style="fill:#AA00AA;">1#1</text>
+    <text x="50" y="96" style="fill:#AA00AA;">o</text>
+    <text x="58 66" y="96" style="fill:#CCCCCC;opacity:0.75;">un</text>
     <text x="82 90 98" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
     <text x="114 122 130 138 146 154" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
     <text x="170 178 186 194 202 210 218 226" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_hunk_from_detail_view_via_file_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_hunk_from_detail_view_via_file_001.svg
@@ -31,10 +31,11 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="132" style="fill:#00AA00;">c-branch-1</text>
     <text x="154" y="132" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="150" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="150" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66 74 82" y="150" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="150" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="150" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="50" y="150" style="fill:#AA00AA;font-weight:bold;">r</text>
+    <text x="58 66" y="150" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">xq</text>
+    <text x="82 90 98" y="150" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="150" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="150" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
     <text x="10 18" y="168" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="186" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="204" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_hunk_from_detail_view_via_file_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_hunk_from_detail_view_via_file_002.svg
@@ -31,10 +31,11 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="132" style="fill:#00AA00;">c-branch-1</text>
     <text x="154" y="132" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="150" style="fill:#AA00AA;">1</text>
-    <text x="66 74 82" y="150" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="150" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="150" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50" y="150" style="fill:#AA00AA;">r</text>
+    <text x="58 66" y="150" style="fill:#CCCCCC;opacity:0.75;">xq</text>
+    <text x="82 90 98" y="150" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="150" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="150" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="168" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="186" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="204" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_hunk_from_detail_view_via_file_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_hunk_from_detail_view_via_file_003.svg
@@ -54,10 +54,11 @@
     <text x="482 490 498 506" y="132" style="fill:#CCCCCC;opacity:0.75;">+1,4</text>
     <text x="522 530" y="132" style="fill:#CCCCCC;opacity:0.75;">@@</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="150" style="fill:#AA00AA;">1</text>
-    <text x="66 74 82" y="150" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="150" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="150" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50" y="150" style="fill:#AA00AA;">r</text>
+    <text x="58 66" y="150" style="fill:#CCCCCC;opacity:0.75;">xq</text>
+    <text x="82 90 98" y="150" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="150" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="150" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="410" y="150" style="fill:#FFA500;">▌</text>
     <text x="418 426 434 442 450 458 466 474 482 490 498 506 514 522 530" y="150" style="fill:#555555;">───────────────</text>
     <text x="10 18" y="168" style="fill:#CCCCCC;">├╯</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_hunk_from_detail_view_via_file_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_hunk_from_detail_view_via_file_004.svg
@@ -49,10 +49,11 @@
     <text x="410" y="114" style="fill:#555555;">│</text>
     <text x="802" y="114" style="fill:#555555;">█</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="132" style="fill:#AA00AA;">1</text>
-    <text x="66 74 82" y="132" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="132" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="132" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50" y="132" style="fill:#AA00AA;">r</text>
+    <text x="58 66" y="132" style="fill:#CCCCCC;opacity:0.75;">xq</text>
+    <text x="82 90 98" y="132" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="132" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="132" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="410" y="132" style="fill:#555555;">│</text>
     <text x="418 426" y="132" style="fill:#CCCCCC;opacity:0.75;">@@</text>
     <text x="442 450 458 466" y="132" style="fill:#CCCCCC;opacity:0.75;">-1,0</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_global_file_list_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_global_file_list_001.svg
@@ -17,22 +17,23 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="60" style="fill:#00AA00;">c-branch-1</text>
     <text x="154" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66 74 82" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="50 58" y="78" style="fill:#AA00AA;font-weight:bold;">zt</text>
+    <text x="66" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">n</text>
+    <text x="82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">1:k</text>
-    <text x="98" y="96" style="fill:#CCCCCC;">A</text>
-    <text x="114 122 130" y="96" style="fill:#00AA00;">one</text>
+    <text x="66 74 82 90" y="96" style="fill:#0000AA;font-weight:bold;">zt:k</text>
+    <text x="106" y="96" style="fill:#CCCCCC;">A</text>
+    <text x="122 130 138" y="96" style="fill:#00AA00;">one</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">1:o</text>
-    <text x="98" y="114" style="fill:#CCCCCC;">A</text>
-    <text x="114 122 130 138 146" y="114" style="fill:#00AA00;">three</text>
+    <text x="66 74 82 90" y="114" style="fill:#0000AA;font-weight:bold;">zt:o</text>
+    <text x="106" y="114" style="fill:#CCCCCC;">A</text>
+    <text x="122 130 138 146 154" y="114" style="fill:#00AA00;">three</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;">1:t</text>
-    <text x="98" y="132" style="fill:#CCCCCC;">A</text>
-    <text x="114 122 130" y="132" style="fill:#00AA00;">two</text>
+    <text x="66 74 82 90" y="132" style="fill:#0000AA;font-weight:bold;">zt:t</text>
+    <text x="106" y="132" style="fill:#CCCCCC;">A</text>
+    <text x="122 130 138" y="132" style="fill:#00AA00;">two</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="186" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_global_file_list_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_global_file_list_002.svg
@@ -20,25 +20,26 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="60" style="fill:#00AA00;">c-branch-1</text>
     <text x="154" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#AA00AA;">1</text>
-    <text x="66 74 82" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50 58" y="78" style="fill:#AA00AA;">zt</text>
+    <text x="66" y="78" style="fill:#CCCCCC;opacity:0.75;">n</text>
+    <text x="82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
     <text x="66 74" y="96" style="fill:#000000;font-weight:bold;">&lt;&lt;</text>
     <text x="90 98 106 114 122 130 138" y="96" style="fill:#000000;font-weight:bold;">discard</text>
     <text x="154 162" y="96" style="fill:#000000;font-weight:bold;">&gt;&gt;</text>
-    <text x="178 186 194" y="96" style="fill:#0000AA;font-weight:bold;text-decoration:line-through;">1:k</text>
-    <text x="210" y="96" style="fill:#FFFFFF;font-weight:bold;text-decoration:line-through;">A</text>
-    <text x="226 234 242" y="96" style="fill:#00AA00;font-weight:bold;text-decoration:line-through;">one</text>
+    <text x="178 186 194 202" y="96" style="fill:#0000AA;font-weight:bold;text-decoration:line-through;">zt:k</text>
+    <text x="218" y="96" style="fill:#FFFFFF;font-weight:bold;text-decoration:line-through;">A</text>
+    <text x="234 242 250" y="96" style="fill:#00AA00;font-weight:bold;text-decoration:line-through;">one</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">1:o</text>
-    <text x="98" y="114" style="fill:#CCCCCC;">A</text>
-    <text x="114 122 130 138 146" y="114" style="fill:#00AA00;">three</text>
+    <text x="66 74 82 90" y="114" style="fill:#0000AA;font-weight:bold;">zt:o</text>
+    <text x="106" y="114" style="fill:#CCCCCC;">A</text>
+    <text x="122 130 138 146 154" y="114" style="fill:#00AA00;">three</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;">1:t</text>
-    <text x="98" y="132" style="fill:#CCCCCC;">A</text>
-    <text x="114 122 130" y="132" style="fill:#00AA00;">two</text>
+    <text x="66 74 82 90" y="132" style="fill:#0000AA;font-weight:bold;">zt:t</text>
+    <text x="106" y="132" style="fill:#CCCCCC;">A</text>
+    <text x="122 130 138" y="132" style="fill:#00AA00;">two</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">├╯</text>
     <text x="274 282 290 298 306 314 322 330 338 346 354 362 370 378 386 394 402 410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530 538" y="150" style="fill:#555555;">╭────────────────────────────────╮</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┊</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_global_file_list_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_global_file_list_003.svg
@@ -17,18 +17,19 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="60" style="fill:#00AA00;">c-branch-1</text>
     <text x="154" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#AA00AA;">1</text>
-    <text x="66 74 82" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50 58" y="78" style="fill:#AA00AA;">zt</text>
+    <text x="66" y="78" style="fill:#CCCCCC;opacity:0.75;">n</text>
+    <text x="82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
-    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">1:o</text>
-    <text x="98" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="114 122 130 138 146" y="96" style="fill:#00AA00;font-weight:bold;">three</text>
+    <text x="66 74 82 90" y="96" style="fill:#0000AA;font-weight:bold;">zt:o</text>
+    <text x="106" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
+    <text x="122 130 138 146 154" y="96" style="fill:#00AA00;font-weight:bold;">three</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">1:t</text>
-    <text x="98" y="114" style="fill:#CCCCCC;">A</text>
-    <text x="114 122 130" y="114" style="fill:#00AA00;">two</text>
+    <text x="66 74 82 90" y="114" style="fill:#0000AA;font-weight:bold;">zt:t</text>
+    <text x="106" y="114" style="fill:#CCCCCC;">A</text>
+    <text x="122 130 138" y="114" style="fill:#00AA00;">two</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="150" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_global_file_list_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_global_file_list_004.svg
@@ -17,14 +17,15 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="60" style="fill:#00AA00;">c-branch-1</text>
     <text x="154" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#AA00AA;">1</text>
-    <text x="66 74 82" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50 58" y="78" style="fill:#AA00AA;">zt</text>
+    <text x="66" y="78" style="fill:#CCCCCC;opacity:0.75;">n</text>
+    <text x="82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
-    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">1:t</text>
-    <text x="98" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="114 122 130" y="96" style="fill:#00AA00;font-weight:bold;">two</text>
+    <text x="66 74 82 90" y="96" style="fill:#0000AA;font-weight:bold;">zt:t</text>
+    <text x="106" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
+    <text x="122 130 138" y="96" style="fill:#00AA00;font-weight:bold;">two</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="150" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_global_file_list_005.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_global_file_list_005.svg
@@ -17,12 +17,13 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="60" style="fill:#00AA00;">c-branch-1</text>
     <text x="154" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66 74 82" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
-    <text x="226 234 242" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="258 266 274 282 290 298 306 314" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
+    <text x="50 58" y="78" style="fill:#AA00AA;font-weight:bold;">zt</text>
+    <text x="66" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">n</text>
+    <text x="82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="242 250 258" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="274 282 290 298 306 314 322 330" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_001.svg
@@ -17,22 +17,23 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="60" style="fill:#00AA00;opacity:0.75;">c-branch-1</text>
     <text x="154" y="60" style="fill:#CCCCCC;opacity:0.75;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#AA00AA;opacity:0.75;">1</text>
-    <text x="66 74 82" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50 58" y="78" style="fill:#AA00AA;opacity:0.75;">zt</text>
+    <text x="66" y="78" style="fill:#CCCCCC;opacity:0.75;">n</text>
+    <text x="82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
-    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">1:k</text>
-    <text x="98" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="114 122 130" y="96" style="fill:#00AA00;font-weight:bold;">one</text>
+    <text x="66 74 82 90" y="96" style="fill:#0000AA;font-weight:bold;">zt:k</text>
+    <text x="106" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
+    <text x="122 130 138" y="96" style="fill:#00AA00;font-weight:bold;">one</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">1:o</text>
-    <text x="98" y="114" style="fill:#CCCCCC;">A</text>
-    <text x="114 122 130 138 146" y="114" style="fill:#00AA00;">three</text>
+    <text x="66 74 82 90" y="114" style="fill:#0000AA;font-weight:bold;">zt:o</text>
+    <text x="106" y="114" style="fill:#CCCCCC;">A</text>
+    <text x="122 130 138 146 154" y="114" style="fill:#00AA00;">three</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;">1:t</text>
-    <text x="98" y="132" style="fill:#CCCCCC;">A</text>
-    <text x="114 122 130" y="132" style="fill:#00AA00;">two</text>
+    <text x="66 74 82 90" y="132" style="fill:#0000AA;font-weight:bold;">zt:t</text>
+    <text x="106" y="132" style="fill:#CCCCCC;">A</text>
+    <text x="122 130 138" y="132" style="fill:#00AA00;">two</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="186" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_002.svg
@@ -20,25 +20,26 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="60" style="fill:#00AA00;opacity:0.75;">c-branch-1</text>
     <text x="154" y="60" style="fill:#CCCCCC;opacity:0.75;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#AA00AA;opacity:0.75;">1</text>
-    <text x="66 74 82" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50 58" y="78" style="fill:#AA00AA;opacity:0.75;">zt</text>
+    <text x="66" y="78" style="fill:#CCCCCC;opacity:0.75;">n</text>
+    <text x="82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
     <text x="66 74" y="96" style="fill:#000000;font-weight:bold;">&lt;&lt;</text>
     <text x="90 98 106 114 122 130 138" y="96" style="fill:#000000;font-weight:bold;">discard</text>
     <text x="154 162" y="96" style="fill:#000000;font-weight:bold;">&gt;&gt;</text>
-    <text x="178 186 194" y="96" style="fill:#0000AA;font-weight:bold;text-decoration:line-through;">1:k</text>
-    <text x="210" y="96" style="fill:#FFFFFF;font-weight:bold;text-decoration:line-through;">A</text>
-    <text x="226 234 242" y="96" style="fill:#00AA00;font-weight:bold;text-decoration:line-through;">one</text>
+    <text x="178 186 194 202" y="96" style="fill:#0000AA;font-weight:bold;text-decoration:line-through;">zt:k</text>
+    <text x="218" y="96" style="fill:#FFFFFF;font-weight:bold;text-decoration:line-through;">A</text>
+    <text x="234 242 250" y="96" style="fill:#00AA00;font-weight:bold;text-decoration:line-through;">one</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">1:o</text>
-    <text x="98" y="114" style="fill:#CCCCCC;">A</text>
-    <text x="114 122 130 138 146" y="114" style="fill:#00AA00;">three</text>
+    <text x="66 74 82 90" y="114" style="fill:#0000AA;font-weight:bold;">zt:o</text>
+    <text x="106" y="114" style="fill:#CCCCCC;">A</text>
+    <text x="122 130 138 146 154" y="114" style="fill:#00AA00;">three</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;">1:t</text>
-    <text x="98" y="132" style="fill:#CCCCCC;">A</text>
-    <text x="114 122 130" y="132" style="fill:#00AA00;">two</text>
+    <text x="66 74 82 90" y="132" style="fill:#0000AA;font-weight:bold;">zt:t</text>
+    <text x="106" y="132" style="fill:#CCCCCC;">A</text>
+    <text x="122 130 138" y="132" style="fill:#00AA00;">two</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">├╯</text>
     <text x="274 282 290 298 306 314 322 330 338 346 354 362 370 378 386 394 402 410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530 538" y="150" style="fill:#555555;">╭────────────────────────────────╮</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┊</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_003.svg
@@ -17,18 +17,19 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="60" style="fill:#00AA00;opacity:0.75;">c-branch-1</text>
     <text x="154" y="60" style="fill:#CCCCCC;opacity:0.75;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#AA00AA;opacity:0.75;">1</text>
-    <text x="66 74 82" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50 58" y="78" style="fill:#AA00AA;opacity:0.75;">zt</text>
+    <text x="66" y="78" style="fill:#CCCCCC;opacity:0.75;">n</text>
+    <text x="82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
-    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">1:o</text>
-    <text x="98" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="114 122 130 138 146" y="96" style="fill:#00AA00;font-weight:bold;">three</text>
+    <text x="66 74 82 90" y="96" style="fill:#0000AA;font-weight:bold;">zt:o</text>
+    <text x="106" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
+    <text x="122 130 138 146 154" y="96" style="fill:#00AA00;font-weight:bold;">three</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">1:t</text>
-    <text x="98" y="114" style="fill:#CCCCCC;">A</text>
-    <text x="114 122 130" y="114" style="fill:#00AA00;">two</text>
+    <text x="66 74 82 90" y="114" style="fill:#0000AA;font-weight:bold;">zt:t</text>
+    <text x="106" y="114" style="fill:#CCCCCC;">A</text>
+    <text x="122 130 138" y="114" style="fill:#00AA00;">two</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="150" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_004.svg
@@ -18,18 +18,19 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="60" style="fill:#00AA00;opacity:0.75;">c-branch-1</text>
     <text x="154" y="60" style="fill:#CCCCCC;opacity:0.75;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#AA00AA;opacity:0.75;">1</text>
-    <text x="66 74 82" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50 58" y="78" style="fill:#AA00AA;opacity:0.75;">zt</text>
+    <text x="66" y="78" style="fill:#CCCCCC;opacity:0.75;">n</text>
+    <text x="82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
-    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">1:o</text>
-    <text x="98" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="114 122 130 138 146" y="96" style="fill:#00AA00;font-weight:bold;">three</text>
+    <text x="66 74 82 90" y="96" style="fill:#0000AA;font-weight:bold;">zt:o</text>
+    <text x="106" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
+    <text x="122 130 138 146 154" y="96" style="fill:#00AA00;font-weight:bold;">three</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">1:t</text>
-    <text x="98" y="114" style="fill:#CCCCCC;">A</text>
-    <text x="114 122 130" y="114" style="fill:#00AA00;">two</text>
+    <text x="66 74 82 90" y="114" style="fill:#0000AA;font-weight:bold;">zt:t</text>
+    <text x="106" y="114" style="fill:#CCCCCC;">A</text>
+    <text x="122 130 138" y="114" style="fill:#00AA00;">two</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="150" style="fill:#CCCCCC;">┊</text>
     <text x="266 274 282 290 298 306 314 322 330 338 346 354 362 370 378 386 394 402 410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530 538 546" y="150" style="fill:#555555;">╭──────────────────────────────────╮</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_005.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_005.svg
@@ -17,14 +17,15 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="60" style="fill:#00AA00;opacity:0.75;">c-branch-1</text>
     <text x="154" y="60" style="fill:#CCCCCC;opacity:0.75;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#AA00AA;opacity:0.75;">1</text>
-    <text x="66 74 82" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50 58" y="78" style="fill:#AA00AA;opacity:0.75;">zt</text>
+    <text x="66" y="78" style="fill:#CCCCCC;opacity:0.75;">n</text>
+    <text x="82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
-    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">1:t</text>
-    <text x="98" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="114 122 130" y="96" style="fill:#00AA00;font-weight:bold;">two</text>
+    <text x="66 74 82 90" y="96" style="fill:#0000AA;font-weight:bold;">zt:t</text>
+    <text x="106" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
+    <text x="122 130 138" y="96" style="fill:#00AA00;font-weight:bold;">two</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="150" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_006.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_006.svg
@@ -18,14 +18,15 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="60" style="fill:#00AA00;opacity:0.75;">c-branch-1</text>
     <text x="154" y="60" style="fill:#CCCCCC;opacity:0.75;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#AA00AA;opacity:0.75;">1</text>
-    <text x="66 74 82" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50 58" y="78" style="fill:#AA00AA;opacity:0.75;">zt</text>
+    <text x="66" y="78" style="fill:#CCCCCC;opacity:0.75;">n</text>
+    <text x="82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
-    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">1:t</text>
-    <text x="98" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="114 122 130" y="96" style="fill:#00AA00;font-weight:bold;">two</text>
+    <text x="66 74 82 90" y="96" style="fill:#0000AA;font-weight:bold;">zt:t</text>
+    <text x="106" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
+    <text x="122 130 138" y="96" style="fill:#00AA00;font-weight:bold;">two</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="150" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_007.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_individual_committed_files_from_local_file_list_007.svg
@@ -17,12 +17,13 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="60" style="fill:#00AA00;">c-branch-1</text>
     <text x="154" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66 74 82" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
-    <text x="226 234 242" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="258 266 274 282 290 298 306 314" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
+    <text x="50 58" y="78" style="fill:#AA00AA;font-weight:bold;">zt</text>
+    <text x="66" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">n</text>
+    <text x="82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="242 250 258" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="274 282 290 298 306 314 322 330" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_global_file_list_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_global_file_list_001.svg
@@ -17,22 +17,23 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="60" style="fill:#00AA00;">c-branch-1</text>
     <text x="154" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66 74 82" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="50 58" y="78" style="fill:#AA00AA;font-weight:bold;">zt</text>
+    <text x="66" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">n</text>
+    <text x="82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">1:k</text>
-    <text x="98" y="96" style="fill:#CCCCCC;">A</text>
-    <text x="114 122 130" y="96" style="fill:#00AA00;">one</text>
+    <text x="66 74 82 90" y="96" style="fill:#0000AA;font-weight:bold;">zt:k</text>
+    <text x="106" y="96" style="fill:#CCCCCC;">A</text>
+    <text x="122 130 138" y="96" style="fill:#00AA00;">one</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">1:o</text>
-    <text x="98" y="114" style="fill:#CCCCCC;">A</text>
-    <text x="114 122 130 138 146" y="114" style="fill:#00AA00;">three</text>
+    <text x="66 74 82 90" y="114" style="fill:#0000AA;font-weight:bold;">zt:o</text>
+    <text x="106" y="114" style="fill:#CCCCCC;">A</text>
+    <text x="122 130 138 146 154" y="114" style="fill:#00AA00;">three</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;">1:t</text>
-    <text x="98" y="132" style="fill:#CCCCCC;">A</text>
-    <text x="114 122 130" y="132" style="fill:#00AA00;">two</text>
+    <text x="66 74 82 90" y="132" style="fill:#0000AA;font-weight:bold;">zt:t</text>
+    <text x="106" y="132" style="fill:#CCCCCC;">A</text>
+    <text x="122 130 138" y="132" style="fill:#00AA00;">two</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="186" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_global_file_list_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_global_file_list_002.svg
@@ -19,24 +19,25 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="60" style="fill:#00AA00;opacity:0.75;">c-branch-1</text>
     <text x="154" y="60" style="fill:#CCCCCC;opacity:0.75;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#AA00AA;opacity:0.75;">1</text>
-    <text x="66 74 82" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50 58" y="78" style="fill:#AA00AA;opacity:0.75;">zt</text>
+    <text x="66" y="78" style="fill:#CCCCCC;opacity:0.75;">n</text>
+    <text x="82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="96" style="fill:#000000;">✔︎</text>
-    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">1:k</text>
-    <text x="98" y="96" style="fill:#CCCCCC;">A</text>
-    <text x="114 122 130" y="96" style="fill:#00AA00;">one</text>
+    <text x="66 74 82 90" y="96" style="fill:#0000AA;font-weight:bold;">zt:k</text>
+    <text x="106" y="96" style="fill:#CCCCCC;">A</text>
+    <text x="122 130 138" y="96" style="fill:#00AA00;">one</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="114" style="fill:#000000;">✔︎</text>
-    <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">1:o</text>
-    <text x="98" y="114" style="fill:#CCCCCC;">A</text>
-    <text x="114 122 130 138 146" y="114" style="fill:#00AA00;">three</text>
+    <text x="66 74 82 90" y="114" style="fill:#0000AA;font-weight:bold;">zt:o</text>
+    <text x="106" y="114" style="fill:#CCCCCC;">A</text>
+    <text x="122 130 138 146 154" y="114" style="fill:#00AA00;">three</text>
     <text x="10 18" y="132" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
-    <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;">1:t</text>
-    <text x="98" y="132" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="114 122 130" y="132" style="fill:#00AA00;font-weight:bold;">two</text>
+    <text x="66 74 82 90" y="132" style="fill:#0000AA;font-weight:bold;">zt:t</text>
+    <text x="106" y="132" style="fill:#FFFFFF;font-weight:bold;">A</text>
+    <text x="122 130 138" y="132" style="fill:#00AA00;font-weight:bold;">two</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="186" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_global_file_list_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_global_file_list_003.svg
@@ -22,30 +22,31 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="60" style="fill:#00AA00;opacity:0.75;">c-branch-1</text>
     <text x="154" y="60" style="fill:#CCCCCC;opacity:0.75;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#AA00AA;opacity:0.75;">1</text>
-    <text x="66 74 82" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50 58" y="78" style="fill:#AA00AA;opacity:0.75;">zt</text>
+    <text x="66" y="78" style="fill:#CCCCCC;opacity:0.75;">n</text>
+    <text x="82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="96" style="fill:#000000;">✔︎</text>
     <text x="66 74" y="96" style="fill:#000000;">&lt;&lt;</text>
     <text x="90 98 106 114 122 130 138" y="96" style="fill:#000000;">discard</text>
     <text x="154 162" y="96" style="fill:#000000;">&gt;&gt;</text>
-    <text x="178 186 194" y="96" style="fill:#0000AA;font-weight:bold;text-decoration:line-through;">1:k</text>
-    <text x="210" y="96" style="fill:#CCCCCC;text-decoration:line-through;">A</text>
-    <text x="226 234 242" y="96" style="fill:#00AA00;text-decoration:line-through;">one</text>
+    <text x="178 186 194 202" y="96" style="fill:#0000AA;font-weight:bold;text-decoration:line-through;">zt:k</text>
+    <text x="218" y="96" style="fill:#CCCCCC;text-decoration:line-through;">A</text>
+    <text x="234 242 250" y="96" style="fill:#00AA00;text-decoration:line-through;">one</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="114" style="fill:#000000;">✔︎</text>
     <text x="66 74" y="114" style="fill:#000000;">&lt;&lt;</text>
     <text x="90 98 106 114 122 130 138" y="114" style="fill:#000000;">discard</text>
     <text x="154 162" y="114" style="fill:#000000;">&gt;&gt;</text>
-    <text x="178 186 194" y="114" style="fill:#0000AA;font-weight:bold;text-decoration:line-through;">1:o</text>
-    <text x="210" y="114" style="fill:#CCCCCC;text-decoration:line-through;">A</text>
-    <text x="226 234 242 250 258" y="114" style="fill:#00AA00;text-decoration:line-through;">three</text>
+    <text x="178 186 194 202" y="114" style="fill:#0000AA;font-weight:bold;text-decoration:line-through;">zt:o</text>
+    <text x="218" y="114" style="fill:#CCCCCC;text-decoration:line-through;">A</text>
+    <text x="234 242 250 258 266" y="114" style="fill:#00AA00;text-decoration:line-through;">three</text>
     <text x="10 18" y="132" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
-    <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;">1:t</text>
-    <text x="98" y="132" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="114 122 130" y="132" style="fill:#00AA00;font-weight:bold;">two</text>
+    <text x="66 74 82 90" y="132" style="fill:#0000AA;font-weight:bold;">zt:t</text>
+    <text x="106" y="132" style="fill:#FFFFFF;font-weight:bold;">A</text>
+    <text x="122 130 138" y="132" style="fill:#00AA00;font-weight:bold;">two</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">├╯</text>
     <text x="314 322 330 338 346 354 362 370 378 386 394 402 410 418 426 434 442 450 458 466 474 482 490 498" y="150" style="fill:#555555;">╭──────────────────────╮</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┊</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_global_file_list_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_global_file_list_004.svg
@@ -17,14 +17,15 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="60" style="fill:#00AA00;">c-branch-1</text>
     <text x="154" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#AA00AA;">1</text>
-    <text x="66 74 82" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50 58" y="78" style="fill:#AA00AA;">zt</text>
+    <text x="66" y="78" style="fill:#CCCCCC;opacity:0.75;">n</text>
+    <text x="82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
-    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">1:t</text>
-    <text x="98" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="114 122 130" y="96" style="fill:#00AA00;font-weight:bold;">two</text>
+    <text x="66 74 82 90" y="96" style="fill:#0000AA;font-weight:bold;">zt:t</text>
+    <text x="106" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
+    <text x="122 130 138" y="96" style="fill:#00AA00;font-weight:bold;">two</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="150" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_global_file_list_005.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_global_file_list_005.svg
@@ -17,14 +17,15 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="60" style="fill:#00AA00;">c-branch-1</text>
     <text x="154" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66 74 82" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="50 58" y="78" style="fill:#AA00AA;font-weight:bold;">zt</text>
+    <text x="66" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">n</text>
+    <text x="82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">1:t</text>
-    <text x="98" y="96" style="fill:#CCCCCC;">A</text>
-    <text x="114 122 130" y="96" style="fill:#00AA00;">two</text>
+    <text x="66 74 82 90" y="96" style="fill:#0000AA;font-weight:bold;">zt:t</text>
+    <text x="106" y="96" style="fill:#CCCCCC;">A</text>
+    <text x="122 130 138" y="96" style="fill:#00AA00;">two</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="150" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_local_file_list_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_local_file_list_001.svg
@@ -17,22 +17,23 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="60" style="fill:#00AA00;opacity:0.75;">c-branch-1</text>
     <text x="154" y="60" style="fill:#CCCCCC;opacity:0.75;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#AA00AA;opacity:0.75;">1</text>
-    <text x="66 74 82" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50 58" y="78" style="fill:#AA00AA;opacity:0.75;">zt</text>
+    <text x="66" y="78" style="fill:#CCCCCC;opacity:0.75;">n</text>
+    <text x="82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
-    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">1:k</text>
-    <text x="98" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="114 122 130" y="96" style="fill:#00AA00;font-weight:bold;">one</text>
+    <text x="66 74 82 90" y="96" style="fill:#0000AA;font-weight:bold;">zt:k</text>
+    <text x="106" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
+    <text x="122 130 138" y="96" style="fill:#00AA00;font-weight:bold;">one</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">1:o</text>
-    <text x="98" y="114" style="fill:#CCCCCC;">A</text>
-    <text x="114 122 130 138 146" y="114" style="fill:#00AA00;">three</text>
+    <text x="66 74 82 90" y="114" style="fill:#0000AA;font-weight:bold;">zt:o</text>
+    <text x="106" y="114" style="fill:#CCCCCC;">A</text>
+    <text x="122 130 138 146 154" y="114" style="fill:#00AA00;">three</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;">1:t</text>
-    <text x="98" y="132" style="fill:#CCCCCC;">A</text>
-    <text x="114 122 130" y="132" style="fill:#00AA00;">two</text>
+    <text x="66 74 82 90" y="132" style="fill:#0000AA;font-weight:bold;">zt:t</text>
+    <text x="106" y="132" style="fill:#CCCCCC;">A</text>
+    <text x="122 130 138" y="132" style="fill:#00AA00;">two</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="186" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_local_file_list_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_local_file_list_002.svg
@@ -19,24 +19,25 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="60" style="fill:#00AA00;opacity:0.75;">c-branch-1</text>
     <text x="154" y="60" style="fill:#CCCCCC;opacity:0.75;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#AA00AA;opacity:0.75;">1</text>
-    <text x="66 74 82" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50 58" y="78" style="fill:#AA00AA;opacity:0.75;">zt</text>
+    <text x="66" y="78" style="fill:#CCCCCC;opacity:0.75;">n</text>
+    <text x="82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="96" style="fill:#000000;">✔︎</text>
-    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">1:k</text>
-    <text x="98" y="96" style="fill:#CCCCCC;">A</text>
-    <text x="114 122 130" y="96" style="fill:#00AA00;">one</text>
+    <text x="66 74 82 90" y="96" style="fill:#0000AA;font-weight:bold;">zt:k</text>
+    <text x="106" y="96" style="fill:#CCCCCC;">A</text>
+    <text x="122 130 138" y="96" style="fill:#00AA00;">one</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="114" style="fill:#000000;">✔︎</text>
-    <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">1:o</text>
-    <text x="98" y="114" style="fill:#CCCCCC;">A</text>
-    <text x="114 122 130 138 146" y="114" style="fill:#00AA00;">three</text>
+    <text x="66 74 82 90" y="114" style="fill:#0000AA;font-weight:bold;">zt:o</text>
+    <text x="106" y="114" style="fill:#CCCCCC;">A</text>
+    <text x="122 130 138 146 154" y="114" style="fill:#00AA00;">three</text>
     <text x="10 18" y="132" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
-    <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;">1:t</text>
-    <text x="98" y="132" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="114 122 130" y="132" style="fill:#00AA00;font-weight:bold;">two</text>
+    <text x="66 74 82 90" y="132" style="fill:#0000AA;font-weight:bold;">zt:t</text>
+    <text x="106" y="132" style="fill:#FFFFFF;font-weight:bold;">A</text>
+    <text x="122 130 138" y="132" style="fill:#00AA00;font-weight:bold;">two</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="186" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_local_file_list_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_local_file_list_003.svg
@@ -22,30 +22,31 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="60" style="fill:#00AA00;opacity:0.75;">c-branch-1</text>
     <text x="154" y="60" style="fill:#CCCCCC;opacity:0.75;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#AA00AA;opacity:0.75;">1</text>
-    <text x="66 74 82" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50 58" y="78" style="fill:#AA00AA;opacity:0.75;">zt</text>
+    <text x="66" y="78" style="fill:#CCCCCC;opacity:0.75;">n</text>
+    <text x="82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="96" style="fill:#000000;">✔︎</text>
     <text x="66 74" y="96" style="fill:#000000;">&lt;&lt;</text>
     <text x="90 98 106 114 122 130 138" y="96" style="fill:#000000;">discard</text>
     <text x="154 162" y="96" style="fill:#000000;">&gt;&gt;</text>
-    <text x="178 186 194" y="96" style="fill:#0000AA;font-weight:bold;text-decoration:line-through;">1:k</text>
-    <text x="210" y="96" style="fill:#CCCCCC;text-decoration:line-through;">A</text>
-    <text x="226 234 242" y="96" style="fill:#00AA00;text-decoration:line-through;">one</text>
+    <text x="178 186 194 202" y="96" style="fill:#0000AA;font-weight:bold;text-decoration:line-through;">zt:k</text>
+    <text x="218" y="96" style="fill:#CCCCCC;text-decoration:line-through;">A</text>
+    <text x="234 242 250" y="96" style="fill:#00AA00;text-decoration:line-through;">one</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="114" style="fill:#000000;">✔︎</text>
     <text x="66 74" y="114" style="fill:#000000;">&lt;&lt;</text>
     <text x="90 98 106 114 122 130 138" y="114" style="fill:#000000;">discard</text>
     <text x="154 162" y="114" style="fill:#000000;">&gt;&gt;</text>
-    <text x="178 186 194" y="114" style="fill:#0000AA;font-weight:bold;text-decoration:line-through;">1:o</text>
-    <text x="210" y="114" style="fill:#CCCCCC;text-decoration:line-through;">A</text>
-    <text x="226 234 242 250 258" y="114" style="fill:#00AA00;text-decoration:line-through;">three</text>
+    <text x="178 186 194 202" y="114" style="fill:#0000AA;font-weight:bold;text-decoration:line-through;">zt:o</text>
+    <text x="218" y="114" style="fill:#CCCCCC;text-decoration:line-through;">A</text>
+    <text x="234 242 250 258 266" y="114" style="fill:#00AA00;text-decoration:line-through;">three</text>
     <text x="10 18" y="132" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
-    <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;">1:t</text>
-    <text x="98" y="132" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="114 122 130" y="132" style="fill:#00AA00;font-weight:bold;">two</text>
+    <text x="66 74 82 90" y="132" style="fill:#0000AA;font-weight:bold;">zt:t</text>
+    <text x="106" y="132" style="fill:#FFFFFF;font-weight:bold;">A</text>
+    <text x="122 130 138" y="132" style="fill:#00AA00;font-weight:bold;">two</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">├╯</text>
     <text x="314 322 330 338 346 354 362 370 378 386 394 402 410 418 426 434 442 450 458 466 474 482 490 498" y="150" style="fill:#555555;">╭──────────────────────╮</text>
     <text x="10" y="168" style="fill:#CCCCCC;">┊</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_local_file_list_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_local_file_list_004.svg
@@ -17,14 +17,15 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="60" style="fill:#00AA00;opacity:0.75;">c-branch-1</text>
     <text x="154" y="60" style="fill:#CCCCCC;opacity:0.75;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#AA00AA;opacity:0.75;">1</text>
-    <text x="66 74 82" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50 58" y="78" style="fill:#AA00AA;opacity:0.75;">zt</text>
+    <text x="66" y="78" style="fill:#CCCCCC;opacity:0.75;">n</text>
+    <text x="82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊│</text>
-    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">1:t</text>
-    <text x="98" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
-    <text x="114 122 130" y="96" style="fill:#00AA00;font-weight:bold;">two</text>
+    <text x="66 74 82 90" y="96" style="fill:#0000AA;font-weight:bold;">zt:t</text>
+    <text x="106" y="96" style="fill:#FFFFFF;font-weight:bold;">A</text>
+    <text x="122 130 138" y="96" style="fill:#00AA00;font-weight:bold;">two</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="150" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_local_file_list_005.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_marked_committed_files_from_local_file_list_005.svg
@@ -17,12 +17,13 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="60" style="fill:#00AA00;">c-branch-1</text>
     <text x="154" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66 74 82" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
-    <text x="226 234 242" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="258 266 274 282 290 298 306 314" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
+    <text x="50 58" y="78" style="fill:#AA00AA;font-weight:bold;">zt</text>
+    <text x="66" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">n</text>
+    <text x="82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="242 250 258" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="274 282 290 298 306 314 322 330" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_multiple_commits_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/discard_multiple_commits_final.svg
@@ -17,10 +17,11 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="60" style="fill:#00AA00;">c-branch-1</text>
     <text x="154" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66 74 82" y="78" style="fill:#FFFFFF;font-weight:bold;">two</text>
-    <text x="98 106 114" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="130 138 146 154 162 170 178 186" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
+    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">y</text>
+    <text x="58 66" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">qz</text>
+    <text x="82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;">two</text>
+    <text x="114 122 130" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="146 154 162 170 178 186 194 202" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/empty_commit_on_a_worktree_heading_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/empty_commit_on_a_worktree_heading_final.svg
@@ -28,12 +28,13 @@
     <text x="98 106 114 122 130 138 146 154 162 170 178" y="114" style="fill:#00AA00;">wt-file.txt</text>
     <text x="10 18 26" y="132" style="fill:#CCCCCC;">┊┊┊</text>
     <text x="10 18 26" y="150" style="fill:#FFFFFF;font-weight:bold;">┊┊●</text>
-    <text x="58" y="150" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="74 82 90" y="150" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="106 114 122 130 138 146" y="150" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="162 170 178 186 194 202 210 218" y="150" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
-    <text x="234 242 250" y="150" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="266 274 282 290 298 306 314 322" y="150" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
+    <text x="58" y="150" style="fill:#AA00AA;font-weight:bold;">u</text>
+    <text x="66 74" y="150" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">xy</text>
+    <text x="90 98 106" y="150" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="122 130 138 146 154 162" y="150" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="178 186 194 202 210 218 226 234" y="150" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="250 258 266" y="150" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="282 290 298 306 314 322 330 338" y="150" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
     <text x="10 18 26" y="168" style="fill:#CCCCCC;">┊┊●</text>
     <text x="58" y="168" style="fill:#AA00AA;">n</text>
     <text x="66 74" y="168" style="fill:#CCCCCC;opacity:0.75;">ll</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/inline_reword_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/inline_reword_002.svg
@@ -17,12 +17,13 @@
     <text x="74" y="60" style="fill:#00AA00;">A</text>
     <text x="82" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66 74 82" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
-    <text x="226 234 242" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="258 266 274 282 290 298 306 314" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
+    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">o</text>
+    <text x="58 66" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">un</text>
+    <text x="82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="242 250 258" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="274 282 290 298 306 314 322 330" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="96" style="fill:#AA00AA;">t</text>
     <text x="58 66" y="96" style="fill:#CCCCCC;opacity:0.75;">pm</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/inline_reword_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/inline_reword_003.svg
@@ -17,7 +17,8 @@
     <text x="74" y="60" style="fill:#00AA00;">A</text>
     <text x="82" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
+    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">o</text>
+    <text x="58 66" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">un</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="96" style="fill:#AA00AA;">t</text>
     <text x="58 66" y="96" style="fill:#CCCCCC;opacity:0.75;">pm</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/inline_reword_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/inline_reword_004.svg
@@ -17,8 +17,9 @@
     <text x="74" y="60" style="fill:#00AA00;">A</text>
     <text x="82" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66 74 82" y="78" style="fill:#FFFFFF;font-weight:bold;">foo</text>
+    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">o</text>
+    <text x="58 66" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">un</text>
+    <text x="82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;">foo</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="96" style="fill:#AA00AA;">t</text>
     <text x="58 66" y="96" style="fill:#CCCCCC;opacity:0.75;">pm</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/inline_reword_005.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/inline_reword_005.svg
@@ -17,10 +17,11 @@
     <text x="74" y="60" style="fill:#00AA00;">A</text>
     <text x="82" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66 74 82" y="78" style="fill:#FFFFFF;font-weight:bold;">foo</text>
-    <text x="98 106 114" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="130 138 146 154 162 170 178 186" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
+    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">o</text>
+    <text x="58 66" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">un</text>
+    <text x="82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;">foo</text>
+    <text x="114 122 130" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="146 154 162 170 178 186 194 202" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="96" style="fill:#AA00AA;">t</text>
     <text x="58 66" y="96" style="fill:#CCCCCC;opacity:0.75;">pm</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/mark_and_commit_multiple_uncommitted_files_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/mark_and_commit_multiple_uncommitted_files_final.svg
@@ -19,16 +19,17 @@
     <text x="74" y="78" style="fill:#00AA00;">A</text>
     <text x="82" y="78" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="96" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66 74 82" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="50" y="96" style="fill:#AA00AA;font-weight:bold;">w</text>
+    <text x="58 66" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">tl</text>
+    <text x="82 90 98" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">1:k</text>
+    <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">w:k</text>
     <text x="98" y="114" style="fill:#CCCCCC;">A</text>
     <text x="114 122 130" y="114" style="fill:#00AA00;">one</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;">1:o</text>
+    <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;">w:o</text>
     <text x="98" y="132" style="fill:#CCCCCC;">A</text>
     <text x="114 122 130 138 146" y="132" style="fill:#00AA00;">three</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊●</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_all_hunks_marks_file_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_all_hunks_marks_file_001.svg
@@ -36,10 +36,11 @@
     <text x="506" y="78" style="fill:#555555;">│</text>
     <text x="802" y="78" style="fill:#555555;">█</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="96" style="fill:#AA00AA;">1</text>
-    <text x="66 74 82" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50" y="96" style="fill:#AA00AA;">u</text>
+    <text x="58 66" y="96" style="fill:#CCCCCC;opacity:0.75;">tx</text>
+    <text x="82 90 98" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506" y="96" style="fill:#555555;">│───────────╯</text>
     <text x="802" y="96" style="fill:#555555;">█</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_all_hunks_marks_file_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_all_hunks_marks_file_002.svg
@@ -45,10 +45,11 @@
     <text x="530" y="78" style="fill:#555555;">│</text>
     <text x="802" y="78" style="fill:#555555;">█</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="96" style="fill:#AA00AA;opacity:0.75;">1</text>
-    <text x="66 74 82" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50" y="96" style="fill:#AA00AA;opacity:0.75;">u</text>
+    <text x="58 66" y="96" style="fill:#CCCCCC;opacity:0.75;">tx</text>
+    <text x="82 90 98" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530" y="96" style="fill:#555555;">│──────────────╯</text>
     <text x="802" y="96" style="fill:#555555;">█</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_all_hunks_marks_file_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_all_hunks_marks_file_003.svg
@@ -40,10 +40,11 @@
     <text x="506" y="78" style="fill:#555555;">│</text>
     <text x="802" y="78" style="fill:#555555;">█</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="96" style="fill:#AA00AA;opacity:0.75;">1</text>
-    <text x="66 74 82" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50" y="96" style="fill:#AA00AA;opacity:0.75;">u</text>
+    <text x="58 66" y="96" style="fill:#CCCCCC;opacity:0.75;">tx</text>
+    <text x="82 90 98" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506" y="96" style="fill:#555555;">│───────────╯</text>
     <text x="802" y="96" style="fill:#555555;">█</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_all_hunks_marks_file_with_multiple_files_changed_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_all_hunks_marks_file_with_multiple_files_changed_001.svg
@@ -42,10 +42,11 @@
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506" y="96" style="fill:#555555;">│───────────╯</text>
     <text x="802" y="96" style="fill:#555555;">█</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="114" style="fill:#AA00AA;">1</text>
-    <text x="66 74 82" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50" y="114" style="fill:#AA00AA;">u</text>
+    <text x="58 66" y="114" style="fill:#CCCCCC;opacity:0.75;">tx</text>
+    <text x="82 90 98" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="410" y="114" style="fill:#555555;">│</text>
     <text x="802" y="114" style="fill:#555555;">█</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">├╯</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_all_hunks_marks_file_with_multiple_files_changed_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_all_hunks_marks_file_with_multiple_files_changed_002.svg
@@ -50,10 +50,11 @@
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530" y="96" style="fill:#555555;">│──────────────╯</text>
     <text x="802" y="96" style="fill:#555555;">█</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="114" style="fill:#AA00AA;opacity:0.75;">1</text>
-    <text x="66 74 82" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50" y="114" style="fill:#AA00AA;opacity:0.75;">u</text>
+    <text x="58 66" y="114" style="fill:#CCCCCC;opacity:0.75;">tx</text>
+    <text x="82 90 98" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="410" y="114" style="fill:#555555;">│</text>
     <text x="802" y="114" style="fill:#555555;">█</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">├╯</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_all_hunks_marks_file_with_multiple_files_changed_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_all_hunks_marks_file_with_multiple_files_changed_003.svg
@@ -45,10 +45,11 @@
     <text x="482 490 498 506" y="96" style="fill:#CCCCCC;opacity:0.75;">+8,4</text>
     <text x="522 530" y="96" style="fill:#CCCCCC;opacity:0.75;">@@</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="114" style="fill:#AA00AA;opacity:0.75;">1</text>
-    <text x="66 74 82" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50" y="114" style="fill:#AA00AA;opacity:0.75;">u</text>
+    <text x="58 66" y="114" style="fill:#CCCCCC;opacity:0.75;">tx</text>
+    <text x="82 90 98" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530" y="114" style="fill:#555555;">│───────────────</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">├╯</text>
     <text x="410" y="132" style="fill:#555555;">│</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_all_hunks_marks_file_with_multiple_files_changed_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_all_hunks_marks_file_with_multiple_files_changed_004.svg
@@ -40,10 +40,11 @@
     <text x="482 490 498 506" y="96" style="fill:#CCCCCC;opacity:0.75;">+8,4</text>
     <text x="522 530" y="96" style="fill:#CCCCCC;opacity:0.75;">@@</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="114" style="fill:#AA00AA;opacity:0.75;">1</text>
-    <text x="66 74 82" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50" y="114" style="fill:#AA00AA;opacity:0.75;">u</text>
+    <text x="58 66" y="114" style="fill:#CCCCCC;opacity:0.75;">tx</text>
+    <text x="82 90 98" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530" y="114" style="fill:#555555;">│───────────────</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">├╯</text>
     <text x="410" y="132" style="fill:#555555;">│</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_all_hunks_marks_file_with_multiple_files_changed_005.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_all_hunks_marks_file_with_multiple_files_changed_005.svg
@@ -43,10 +43,11 @@
     <text x="482 490 498 506" y="96" style="fill:#CCCCCC;opacity:0.75;">+8,4</text>
     <text x="522 530" y="96" style="fill:#CCCCCC;opacity:0.75;">@@</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="114" style="fill:#AA00AA;opacity:0.75;">1</text>
-    <text x="66 74 82" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50" y="114" style="fill:#AA00AA;opacity:0.75;">u</text>
+    <text x="58 66" y="114" style="fill:#CCCCCC;opacity:0.75;">tx</text>
+    <text x="82 90 98" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530" y="114" style="fill:#555555;">│───────────────</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">├╯</text>
     <text x="410" y="132" style="fill:#555555;">│</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_discarding_all_hunks_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_discarding_all_hunks_001.svg
@@ -51,10 +51,11 @@
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530" y="96" style="fill:#555555;">│──────────────╯</text>
     <text x="802" y="96" style="fill:#555555;">█</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="114" style="fill:#AA00AA;opacity:0.75;">1</text>
-    <text x="66 74 82" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50" y="114" style="fill:#AA00AA;opacity:0.75;">u</text>
+    <text x="58 66" y="114" style="fill:#CCCCCC;opacity:0.75;">tx</text>
+    <text x="82 90 98" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="410" y="114" style="fill:#555555;">│</text>
     <text x="802" y="114" style="fill:#555555;">█</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">├╯</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_discarding_all_hunks_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_discarding_all_hunks_002.svg
@@ -32,10 +32,11 @@
     <text x="466 474 482 490 498 506 514 522" y="78" style="fill:#CCCCCC;">new-file</text>
     <text x="538" y="78" style="fill:#555555;">│</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="96" style="fill:#AA00AA;">1</text>
-    <text x="66 74 82" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50" y="96" style="fill:#AA00AA;">u</text>
+    <text x="58 66" y="96" style="fill:#CCCCCC;opacity:0.75;">tx</text>
+    <text x="82 90 98" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530 538" y="96" style="fill:#555555;">│───────────────╯</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="410" y="114" style="fill:#555555;">│</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_discarding_multiple_branches_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_discarding_multiple_branches_001.svg
@@ -17,7 +17,8 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="60" style="fill:#00AA00;">c-branch-2</text>
     <text x="154" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50 58 66" y="78" style="fill:#AA00AA;font-weight:bold;">1#0</text>
+    <text x="50 58" y="78" style="fill:#AA00AA;font-weight:bold;">om</text>
+    <text x="66" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">y</text>
     <text x="82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
     <text x="114 122 130 138 146 154" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
     <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
@@ -31,7 +32,8 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="132" style="fill:#00AA00;">c-branch-1</text>
     <text x="154" y="132" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊●</text>
-    <text x="50 58 66" y="150" style="fill:#AA00AA;">1#1</text>
+    <text x="50 58" y="150" style="fill:#AA00AA;">ou</text>
+    <text x="66" y="150" style="fill:#CCCCCC;opacity:0.75;">n</text>
     <text x="82 90 98" y="150" style="fill:#CCCCCC;opacity:0.75;">(no</text>
     <text x="114 122 130 138 146 154" y="150" style="fill:#CCCCCC;opacity:0.75;">commit</text>
     <text x="170 178 186 194 202 210 218 226" y="150" style="fill:#CCCCCC;opacity:0.75;">message)</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_discarding_multiple_branches_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_discarding_multiple_branches_002.svg
@@ -21,7 +21,8 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="60" style="fill:#00AA00;">c-branch-2</text>
     <text x="154" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50 58 66" y="78" style="fill:#AA00AA;opacity:0.75;">1#0</text>
+    <text x="50 58" y="78" style="fill:#AA00AA;opacity:0.75;">om</text>
+    <text x="66" y="78" style="fill:#CCCCCC;opacity:0.75;">y</text>
     <text x="82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
     <text x="114 122 130 138 146 154" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
     <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
@@ -36,7 +37,8 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="132" style="fill:#00AA00;">c-branch-1</text>
     <text x="154" y="132" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊●</text>
-    <text x="50 58 66" y="150" style="fill:#AA00AA;opacity:0.75;">1#1</text>
+    <text x="50 58" y="150" style="fill:#AA00AA;opacity:0.75;">ou</text>
+    <text x="66" y="150" style="fill:#CCCCCC;opacity:0.75;">n</text>
     <text x="82 90 98" y="150" style="fill:#CCCCCC;opacity:0.75;">(no</text>
     <text x="114 122 130 138 146 154" y="150" style="fill:#CCCCCC;opacity:0.75;">commit</text>
     <text x="170 178 186 194 202 210 218 226" y="150" style="fill:#CCCCCC;opacity:0.75;">message)</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_discarding_multiple_branches_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_discarding_multiple_branches_003.svg
@@ -27,7 +27,8 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="60" style="fill:#00AA00;">c-branch-2</text>
     <text x="154" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50 58 66" y="78" style="fill:#AA00AA;opacity:0.75;">1#0</text>
+    <text x="50 58" y="78" style="fill:#AA00AA;opacity:0.75;">om</text>
+    <text x="66" y="78" style="fill:#CCCCCC;opacity:0.75;">y</text>
     <text x="82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
     <text x="114 122 130 138 146 154" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
     <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
@@ -45,7 +46,8 @@
     <text x="186 194 202 210 218 226 234 242 250 258" y="132" style="fill:#00AA00;text-decoration:line-through;">c-branch-1</text>
     <text x="266" y="132" style="fill:#CCCCCC;text-decoration:line-through;">]</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊●</text>
-    <text x="50 58 66" y="150" style="fill:#AA00AA;opacity:0.75;">1#1</text>
+    <text x="50 58" y="150" style="fill:#AA00AA;opacity:0.75;">ou</text>
+    <text x="66" y="150" style="fill:#CCCCCC;opacity:0.75;">n</text>
     <text x="82 90 98" y="150" style="fill:#CCCCCC;opacity:0.75;">(no</text>
     <text x="114 122 130 138 146 154" y="150" style="fill:#CCCCCC;opacity:0.75;">commit</text>
     <text x="170 178 186 194 202 210 218 226" y="150" style="fill:#CCCCCC;opacity:0.75;">message)</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_discarding_multiple_branches_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_discarding_multiple_branches_004.svg
@@ -17,12 +17,13 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="60" style="fill:#00AA00;">c-branch-2</text>
     <text x="154" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#AA00AA;">1</text>
-    <text x="66 74 82" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="226 234 242" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="258 266 274 282 290 298 306 314" y="78" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="50" y="78" style="fill:#AA00AA;">o</text>
+    <text x="58 66" y="78" style="fill:#CCCCCC;opacity:0.75;">my</text>
+    <text x="82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="242 250 258" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="274 282 290 298 306 314 322 330" y="78" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_discarding_multiple_branches_fails_with_dependencies_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_discarding_multiple_branches_fails_with_dependencies_001.svg
@@ -17,7 +17,8 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="60" style="fill:#00AA00;">c-branch-3</text>
     <text x="154" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50 58 66" y="78" style="fill:#AA00AA;font-weight:bold;">1#0</text>
+    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">o</text>
+    <text x="58 66" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">my</text>
     <text x="82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
     <text x="114 122 130 138 146 154" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
     <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
@@ -31,14 +32,15 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="132" style="fill:#00AA00;">c-branch-2</text>
     <text x="154" y="132" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊●</text>
-    <text x="50 58 66" y="150" style="fill:#AA00AA;">1#1</text>
+    <text x="50" y="150" style="fill:#AA00AA;">n</text>
+    <text x="58 66" y="150" style="fill:#CCCCCC;opacity:0.75;">xl</text>
     <text x="82 90 98" y="150" style="fill:#CCCCCC;opacity:0.75;">(no</text>
     <text x="114 122 130 138 146 154" y="150" style="fill:#CCCCCC;opacity:0.75;">commit</text>
     <text x="170 178 186 194 202 210 218 226" y="150" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="168" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82 90 98" y="168" style="fill:#0000AA;font-weight:bold;">1#1:q</text>
-    <text x="114" y="168" style="fill:#CCCCCC;">M</text>
-    <text x="130 138 146 154" y="168" style="fill:#AA5500;">file</text>
+    <text x="66 74 82" y="168" style="fill:#0000AA;font-weight:bold;">n:q</text>
+    <text x="98" y="168" style="fill:#CCCCCC;">M</text>
+    <text x="114 122 130 138" y="168" style="fill:#AA5500;">file</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">┊│</text>
     <text x="10 18 26" y="204" style="fill:#CCCCCC;">┊├┄</text>
     <text x="42 50" y="204" style="fill:#0000AA;font-weight:bold;">an</text>
@@ -46,14 +48,15 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="204" style="fill:#00AA00;">c-branch-1</text>
     <text x="154" y="204" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="222" style="fill:#CCCCCC;">┊●</text>
-    <text x="50 58 66" y="222" style="fill:#AA00AA;">1#2</text>
+    <text x="50" y="222" style="fill:#AA00AA;">x</text>
+    <text x="58 66" y="222" style="fill:#CCCCCC;opacity:0.75;">wp</text>
     <text x="82 90 98" y="222" style="fill:#CCCCCC;opacity:0.75;">(no</text>
     <text x="114 122 130 138 146 154" y="222" style="fill:#CCCCCC;opacity:0.75;">commit</text>
     <text x="170 178 186 194 202 210 218 226" y="222" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="240" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82 90 98" y="240" style="fill:#0000AA;font-weight:bold;">1#2:q</text>
-    <text x="114" y="240" style="fill:#CCCCCC;">A</text>
-    <text x="130 138 146 154" y="240" style="fill:#00AA00;">file</text>
+    <text x="66 74 82" y="240" style="fill:#0000AA;font-weight:bold;">x:q</text>
+    <text x="98" y="240" style="fill:#CCCCCC;">A</text>
+    <text x="114 122 130 138" y="240" style="fill:#00AA00;">file</text>
     <text x="10 18" y="258" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="276" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="294" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_discarding_multiple_branches_fails_with_dependencies_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_discarding_multiple_branches_fails_with_dependencies_002.svg
@@ -26,7 +26,8 @@
     <text x="186 194 202 210 218 226 234 242 250 258" y="60" style="fill:#00AA00;text-decoration:line-through;">c-branch-3</text>
     <text x="266" y="60" style="fill:#CCCCCC;text-decoration:line-through;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50 58 66" y="78" style="fill:#AA00AA;opacity:0.75;">1#0</text>
+    <text x="50" y="78" style="fill:#AA00AA;opacity:0.75;">o</text>
+    <text x="58 66" y="78" style="fill:#CCCCCC;opacity:0.75;">my</text>
     <text x="82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
     <text x="114 122 130 138 146 154" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
     <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
@@ -40,15 +41,16 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="132" style="fill:#00AA00;font-weight:bold;">c-branch-2</text>
     <text x="154" y="132" style="fill:#FFFFFF;font-weight:bold;">]</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊●</text>
-    <text x="50 58 66" y="150" style="fill:#AA00AA;opacity:0.75;">1#1</text>
+    <text x="50" y="150" style="fill:#AA00AA;opacity:0.75;">n</text>
+    <text x="58 66" y="150" style="fill:#CCCCCC;opacity:0.75;">xl</text>
     <text x="82 90 98" y="150" style="fill:#CCCCCC;opacity:0.75;">(no</text>
     <text x="114 122 130 138 146 154" y="150" style="fill:#CCCCCC;opacity:0.75;">commit</text>
     <text x="170 178 186 194 202 210 218 226" y="150" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="314 322 330 338 346 354 362 370 378 386 394 402 410 418 426 434 442 450 458 466 474 482 490 498" y="150" style="fill:#555555;">╭──────────────────────╮</text>
     <text x="10 18" y="168" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82 90 98" y="168" style="fill:#0000AA;font-weight:bold;opacity:0.75;">1#1:q</text>
-    <text x="114" y="168" style="fill:#CCCCCC;opacity:0.75;">M</text>
-    <text x="130 138 146 154" y="168" style="fill:#AA5500;opacity:0.75;">file</text>
+    <text x="66 74 82" y="168" style="fill:#0000AA;font-weight:bold;opacity:0.75;">n:q</text>
+    <text x="98" y="168" style="fill:#CCCCCC;opacity:0.75;">M</text>
+    <text x="114 122 130 138" y="168" style="fill:#AA5500;opacity:0.75;">file</text>
     <text x="314" y="168" style="fill:#555555;">│</text>
     <text x="498" y="168" style="fill:#555555;">│</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">┊│</text>
@@ -67,7 +69,8 @@
     <text x="314" y="204" style="fill:#555555;">│</text>
     <text x="498" y="204" style="fill:#555555;">│</text>
     <text x="10 18" y="222" style="fill:#CCCCCC;">┊●</text>
-    <text x="50 58 66" y="222" style="fill:#AA00AA;opacity:0.75;">1#2</text>
+    <text x="50" y="222" style="fill:#AA00AA;opacity:0.75;">x</text>
+    <text x="58 66" y="222" style="fill:#CCCCCC;opacity:0.75;">wp</text>
     <text x="82 90 98" y="222" style="fill:#CCCCCC;opacity:0.75;">(no</text>
     <text x="114 122 130 138 146 154" y="222" style="fill:#CCCCCC;opacity:0.75;">commit</text>
     <text x="170 178 186 194 202 210 218 226" y="222" style="fill:#CCCCCC;opacity:0.75;">message)</text>
@@ -76,9 +79,9 @@
     <text x="418 426" y="222" style="fill:#CCCCCC;opacity:0.75;">No</text>
     <text x="498" y="222" style="fill:#555555;">│</text>
     <text x="10 18" y="240" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82 90 98" y="240" style="fill:#0000AA;font-weight:bold;opacity:0.75;">1#2:q</text>
-    <text x="114" y="240" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="130 138 146 154" y="240" style="fill:#00AA00;opacity:0.75;">file</text>
+    <text x="66 74 82" y="240" style="fill:#0000AA;font-weight:bold;opacity:0.75;">x:q</text>
+    <text x="98" y="240" style="fill:#CCCCCC;opacity:0.75;">A</text>
+    <text x="114 122 130 138" y="240" style="fill:#00AA00;opacity:0.75;">file</text>
     <text x="314" y="240" style="fill:#555555;">│</text>
     <text x="498" y="240" style="fill:#555555;">│</text>
     <text x="10 18" y="258" style="fill:#CCCCCC;">├╯</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_discarding_multiple_branches_fails_with_dependencies_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_discarding_multiple_branches_fails_with_dependencies_003.svg
@@ -17,13 +17,14 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="60" style="fill:#00AA00;font-weight:bold;">c-branch-2</text>
     <text x="154" y="60" style="fill:#FFFFFF;font-weight:bold;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#AA00AA;">1</text>
-    <text x="66 74 82" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="226 234 242" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="258 266 274 282 290 298 306 314" y="78" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
-    <text x="330 338 346 354 362 370 378 386 394 402 410 418" y="78" style="fill:#AA0000;">{conflicted}</text>
+    <text x="50" y="78" style="fill:#AA00AA;">n</text>
+    <text x="58 66" y="78" style="fill:#CCCCCC;opacity:0.75;">xl</text>
+    <text x="82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="242 250 258" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="274 282 290 298 306 314 322 330" y="78" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="346 354 362 370 378 386 394 402 410 418 426 434" y="78" style="fill:#AA0000;">{conflicted}</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_squashing_branches_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_squashing_branches_001.svg
@@ -19,14 +19,15 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="60" style="fill:#00AA00;">c-branch-3</text>
     <text x="154" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50 58 66" y="78" style="fill:#AA00AA;opacity:0.75;">1#0</text>
+    <text x="50" y="78" style="fill:#AA00AA;opacity:0.75;">q</text>
+    <text x="58 66" y="78" style="fill:#CCCCCC;opacity:0.75;">ow</text>
     <text x="82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
     <text x="114 122 130 138 146 154" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
     <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82 90 98" y="96" style="fill:#0000AA;font-weight:bold;opacity:0.75;">1#0:t</text>
-    <text x="114" y="96" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="130 138 146" y="96" style="fill:#00AA00;opacity:0.75;">two</text>
+    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;opacity:0.75;">q:t</text>
+    <text x="98" y="96" style="fill:#CCCCCC;opacity:0.75;">A</text>
+    <text x="114 122 130" y="96" style="fill:#00AA00;opacity:0.75;">two</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="150" style="fill:#FFFFFF;font-weight:bold;">┊╭┄</text>
@@ -35,14 +36,15 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="150" style="fill:#00AA00;font-weight:bold;">c-branch-2</text>
     <text x="154" y="150" style="fill:#FFFFFF;font-weight:bold;">]</text>
     <text x="10 18" y="168" style="fill:#CCCCCC;">┊●</text>
-    <text x="50 58 66" y="168" style="fill:#AA00AA;opacity:0.75;">1#1</text>
+    <text x="50" y="168" style="fill:#AA00AA;opacity:0.75;">y</text>
+    <text x="58 66" y="168" style="fill:#CCCCCC;opacity:0.75;">rt</text>
     <text x="82 90 98" y="168" style="fill:#CCCCCC;opacity:0.75;">(no</text>
     <text x="114 122 130 138 146 154" y="168" style="fill:#CCCCCC;opacity:0.75;">commit</text>
     <text x="170 178 186 194 202 210 218 226" y="168" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82 90 98" y="186" style="fill:#0000AA;font-weight:bold;opacity:0.75;">1#1:o</text>
-    <text x="114" y="186" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="130 138 146 154 162" y="186" style="fill:#00AA00;opacity:0.75;">three</text>
+    <text x="66 74 82" y="186" style="fill:#0000AA;font-weight:bold;opacity:0.75;">y:o</text>
+    <text x="98" y="186" style="fill:#CCCCCC;opacity:0.75;">A</text>
+    <text x="114 122 130 138 146" y="186" style="fill:#00AA00;opacity:0.75;">three</text>
     <text x="10 18" y="204" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="222" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="240" style="fill:#CCCCCC;">┊╭┄</text>
@@ -51,14 +53,15 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="240" style="fill:#00AA00;">c-branch-1</text>
     <text x="154" y="240" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="258" style="fill:#CCCCCC;">┊●</text>
-    <text x="50 58 66" y="258" style="fill:#AA00AA;opacity:0.75;">1#2</text>
+    <text x="50" y="258" style="fill:#AA00AA;opacity:0.75;">s</text>
+    <text x="58 66" y="258" style="fill:#CCCCCC;opacity:0.75;">ur</text>
     <text x="82 90 98" y="258" style="fill:#CCCCCC;opacity:0.75;">(no</text>
     <text x="114 122 130 138 146 154" y="258" style="fill:#CCCCCC;opacity:0.75;">commit</text>
     <text x="170 178 186 194 202 210 218 226" y="258" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="276" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82 90 98" y="276" style="fill:#0000AA;font-weight:bold;opacity:0.75;">1#2:k</text>
-    <text x="114" y="276" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="130 138 146" y="276" style="fill:#00AA00;opacity:0.75;">one</text>
+    <text x="66 74 82" y="276" style="fill:#0000AA;font-weight:bold;opacity:0.75;">s:k</text>
+    <text x="98" y="276" style="fill:#CCCCCC;opacity:0.75;">A</text>
+    <text x="114 122 130" y="276" style="fill:#00AA00;opacity:0.75;">one</text>
     <text x="10 18" y="294" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="312" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="330" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_squashing_branches_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_squashing_branches_002.svg
@@ -20,14 +20,15 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="60" style="fill:#00AA00;">c-branch-3</text>
     <text x="154" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50 58 66" y="78" style="fill:#AA00AA;opacity:0.75;">1#0</text>
+    <text x="50" y="78" style="fill:#AA00AA;opacity:0.75;">q</text>
+    <text x="58 66" y="78" style="fill:#CCCCCC;opacity:0.75;">ow</text>
     <text x="82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
     <text x="114 122 130 138 146 154" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
     <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82 90 98" y="96" style="fill:#0000AA;font-weight:bold;opacity:0.75;">1#0:t</text>
-    <text x="114" y="96" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="130 138 146" y="96" style="fill:#00AA00;opacity:0.75;">two</text>
+    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;opacity:0.75;">q:t</text>
+    <text x="98" y="96" style="fill:#CCCCCC;opacity:0.75;">A</text>
+    <text x="114 122 130" y="96" style="fill:#00AA00;opacity:0.75;">two</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="150" style="fill:#CCCCCC;">┊</text>
@@ -37,14 +38,15 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="150" style="fill:#00AA00;">c-branch-2</text>
     <text x="154" y="150" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="168" style="fill:#CCCCCC;">┊●</text>
-    <text x="50 58 66" y="168" style="fill:#AA00AA;opacity:0.75;">1#1</text>
+    <text x="50" y="168" style="fill:#AA00AA;opacity:0.75;">y</text>
+    <text x="58 66" y="168" style="fill:#CCCCCC;opacity:0.75;">rt</text>
     <text x="82 90 98" y="168" style="fill:#CCCCCC;opacity:0.75;">(no</text>
     <text x="114 122 130 138 146 154" y="168" style="fill:#CCCCCC;opacity:0.75;">commit</text>
     <text x="170 178 186 194 202 210 218 226" y="168" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82 90 98" y="186" style="fill:#0000AA;font-weight:bold;opacity:0.75;">1#1:o</text>
-    <text x="114" y="186" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="130 138 146 154 162" y="186" style="fill:#00AA00;opacity:0.75;">three</text>
+    <text x="66 74 82" y="186" style="fill:#0000AA;font-weight:bold;opacity:0.75;">y:o</text>
+    <text x="98" y="186" style="fill:#CCCCCC;opacity:0.75;">A</text>
+    <text x="114 122 130 138 146" y="186" style="fill:#00AA00;opacity:0.75;">three</text>
     <text x="10 18" y="204" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="222" style="fill:#CCCCCC;">┊</text>
     <text x="10 18 26" y="240" style="fill:#FFFFFF;font-weight:bold;">┊╭┄</text>
@@ -53,14 +55,15 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="240" style="fill:#00AA00;font-weight:bold;">c-branch-1</text>
     <text x="154" y="240" style="fill:#FFFFFF;font-weight:bold;">]</text>
     <text x="10 18" y="258" style="fill:#CCCCCC;">┊●</text>
-    <text x="50 58 66" y="258" style="fill:#AA00AA;opacity:0.75;">1#2</text>
+    <text x="50" y="258" style="fill:#AA00AA;opacity:0.75;">s</text>
+    <text x="58 66" y="258" style="fill:#CCCCCC;opacity:0.75;">ur</text>
     <text x="82 90 98" y="258" style="fill:#CCCCCC;opacity:0.75;">(no</text>
     <text x="114 122 130 138 146 154" y="258" style="fill:#CCCCCC;opacity:0.75;">commit</text>
     <text x="170 178 186 194 202 210 218 226" y="258" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="276" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82 90 98" y="276" style="fill:#0000AA;font-weight:bold;opacity:0.75;">1#2:k</text>
-    <text x="114" y="276" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="130 138 146" y="276" style="fill:#00AA00;opacity:0.75;">one</text>
+    <text x="66 74 82" y="276" style="fill:#0000AA;font-weight:bold;opacity:0.75;">s:k</text>
+    <text x="98" y="276" style="fill:#CCCCCC;opacity:0.75;">A</text>
+    <text x="114 122 130" y="276" style="fill:#00AA00;opacity:0.75;">one</text>
     <text x="10 18" y="294" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="312" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="330" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_squashing_branches_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_squashing_branches_003.svg
@@ -22,14 +22,15 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="60" style="fill:#00AA00;">c-branch-3</text>
     <text x="154" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50 58 66" y="78" style="fill:#AA00AA;opacity:0.75;">1#0</text>
+    <text x="50" y="78" style="fill:#AA00AA;opacity:0.75;">q</text>
+    <text x="58 66" y="78" style="fill:#CCCCCC;opacity:0.75;">ow</text>
     <text x="82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
     <text x="114 122 130 138 146 154" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
     <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82 90 98" y="96" style="fill:#0000AA;font-weight:bold;opacity:0.75;">1#0:t</text>
-    <text x="114" y="96" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="130 138 146" y="96" style="fill:#00AA00;opacity:0.75;">two</text>
+    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;opacity:0.75;">q:t</text>
+    <text x="98" y="96" style="fill:#CCCCCC;opacity:0.75;">A</text>
+    <text x="114 122 130" y="96" style="fill:#00AA00;opacity:0.75;">two</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="150" style="fill:#CCCCCC;">┊</text>
@@ -39,14 +40,15 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="150" style="fill:#00AA00;">c-branch-2</text>
     <text x="154" y="150" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="168" style="fill:#CCCCCC;">┊●</text>
-    <text x="50 58 66" y="168" style="fill:#AA00AA;opacity:0.75;">1#1</text>
+    <text x="50" y="168" style="fill:#AA00AA;opacity:0.75;">y</text>
+    <text x="58 66" y="168" style="fill:#CCCCCC;opacity:0.75;">rt</text>
     <text x="82 90 98" y="168" style="fill:#CCCCCC;opacity:0.75;">(no</text>
     <text x="114 122 130 138 146 154" y="168" style="fill:#CCCCCC;opacity:0.75;">commit</text>
     <text x="170 178 186 194 202 210 218 226" y="168" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82 90 98" y="186" style="fill:#0000AA;font-weight:bold;opacity:0.75;">1#1:o</text>
-    <text x="114" y="186" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="130 138 146 154 162" y="186" style="fill:#00AA00;opacity:0.75;">three</text>
+    <text x="66 74 82" y="186" style="fill:#0000AA;font-weight:bold;opacity:0.75;">y:o</text>
+    <text x="98" y="186" style="fill:#CCCCCC;opacity:0.75;">A</text>
+    <text x="114 122 130 138 146" y="186" style="fill:#00AA00;opacity:0.75;">three</text>
     <text x="10 18" y="204" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="222" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="240" style="fill:#FFFFFF;font-weight:bold;">┊</text>
@@ -56,14 +58,15 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="240" style="fill:#00AA00;font-weight:bold;">c-branch-1</text>
     <text x="154" y="240" style="fill:#FFFFFF;font-weight:bold;">]</text>
     <text x="10 18" y="258" style="fill:#CCCCCC;">┊●</text>
-    <text x="50 58 66" y="258" style="fill:#AA00AA;opacity:0.75;">1#2</text>
+    <text x="50" y="258" style="fill:#AA00AA;opacity:0.75;">s</text>
+    <text x="58 66" y="258" style="fill:#CCCCCC;opacity:0.75;">ur</text>
     <text x="82 90 98" y="258" style="fill:#CCCCCC;opacity:0.75;">(no</text>
     <text x="114 122 130 138 146 154" y="258" style="fill:#CCCCCC;opacity:0.75;">commit</text>
     <text x="170 178 186 194 202 210 218 226" y="258" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="276" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82 90 98" y="276" style="fill:#0000AA;font-weight:bold;opacity:0.75;">1#2:k</text>
-    <text x="114" y="276" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="130 138 146" y="276" style="fill:#00AA00;opacity:0.75;">one</text>
+    <text x="66 74 82" y="276" style="fill:#0000AA;font-weight:bold;opacity:0.75;">s:k</text>
+    <text x="98" y="276" style="fill:#CCCCCC;opacity:0.75;">A</text>
+    <text x="114 122 130" y="276" style="fill:#00AA00;opacity:0.75;">one</text>
     <text x="10 18" y="294" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="312" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="330" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_squashing_branches_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_squashing_branches_004.svg
@@ -35,14 +35,15 @@
     <text x="170 178 186 194" y="78" style="fill:#000000;font-weight:bold;">this</text>
     <text x="210 218 226 234 242 250 258 266" y="78" style="fill:#000000;font-weight:bold;">message)</text>
     <text x="282 290" y="78" style="fill:#000000;font-weight:bold;">&gt;&gt;</text>
-    <text x="306 314 322" y="78" style="fill:#AA00AA;font-weight:bold;">1#0</text>
+    <text x="306" y="78" style="fill:#AA00AA;font-weight:bold;">q</text>
+    <text x="314 322" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">ow</text>
     <text x="338 346 354" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
     <text x="370 378 386 394 402 410" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
     <text x="426 434 442 450 458 466 474 482" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82 90 98" y="96" style="fill:#0000AA;font-weight:bold;opacity:0.75;">1#0:t</text>
-    <text x="114" y="96" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="130 138 146" y="96" style="fill:#00AA00;opacity:0.75;">two</text>
+    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;opacity:0.75;">q:t</text>
+    <text x="98" y="96" style="fill:#CCCCCC;opacity:0.75;">A</text>
+    <text x="114 122 130" y="96" style="fill:#00AA00;opacity:0.75;">two</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="132" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="150" style="fill:#CCCCCC;">┊</text>
@@ -55,14 +56,15 @@
     <text x="178 186 194 202 210 218 226 234 242 250" y="150" style="fill:#00AA00;">c-branch-2</text>
     <text x="258" y="150" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="168" style="fill:#CCCCCC;">┊●</text>
-    <text x="50 58 66" y="168" style="fill:#AA00AA;">1#1</text>
+    <text x="50" y="168" style="fill:#AA00AA;">y</text>
+    <text x="58 66" y="168" style="fill:#CCCCCC;opacity:0.75;">rt</text>
     <text x="82 90 98" y="168" style="fill:#CCCCCC;opacity:0.75;">(no</text>
     <text x="114 122 130 138 146 154" y="168" style="fill:#CCCCCC;opacity:0.75;">commit</text>
     <text x="170 178 186 194 202 210 218 226" y="168" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82 90 98" y="186" style="fill:#0000AA;font-weight:bold;opacity:0.75;">1#1:o</text>
-    <text x="114" y="186" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="130 138 146 154 162" y="186" style="fill:#00AA00;opacity:0.75;">three</text>
+    <text x="66 74 82" y="186" style="fill:#0000AA;font-weight:bold;opacity:0.75;">y:o</text>
+    <text x="98" y="186" style="fill:#CCCCCC;opacity:0.75;">A</text>
+    <text x="114 122 130 138 146" y="186" style="fill:#00AA00;opacity:0.75;">three</text>
     <text x="10 18" y="204" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="222" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="240" style="fill:#CCCCCC;">┊</text>
@@ -75,14 +77,15 @@
     <text x="178 186 194 202 210 218 226 234 242 250" y="240" style="fill:#00AA00;">c-branch-1</text>
     <text x="258" y="240" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="258" style="fill:#CCCCCC;">┊●</text>
-    <text x="50 58 66" y="258" style="fill:#AA00AA;">1#2</text>
+    <text x="50" y="258" style="fill:#AA00AA;">s</text>
+    <text x="58 66" y="258" style="fill:#CCCCCC;opacity:0.75;">ur</text>
     <text x="82 90 98" y="258" style="fill:#CCCCCC;opacity:0.75;">(no</text>
     <text x="114 122 130 138 146 154" y="258" style="fill:#CCCCCC;opacity:0.75;">commit</text>
     <text x="170 178 186 194 202 210 218 226" y="258" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="276" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82 90 98" y="276" style="fill:#0000AA;font-weight:bold;opacity:0.75;">1#2:k</text>
-    <text x="114" y="276" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="130 138 146" y="276" style="fill:#00AA00;opacity:0.75;">one</text>
+    <text x="66 74 82" y="276" style="fill:#0000AA;font-weight:bold;opacity:0.75;">s:k</text>
+    <text x="98" y="276" style="fill:#CCCCCC;opacity:0.75;">A</text>
+    <text x="114 122 130" y="276" style="fill:#00AA00;opacity:0.75;">one</text>
     <text x="10 18" y="294" style="fill:#CCCCCC;">├╯</text>
     <text x="10" y="312" style="fill:#CCCCCC;">┊</text>
     <text x="10" y="330" style="fill:#CCCCCC;">┴</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_squashing_branches_005.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_and_squashing_branches_005.svg
@@ -17,20 +17,21 @@
     <text x="74 82 90 98 106 114 122 130 138 146" y="60" style="fill:#00AA00;">c-branch-3</text>
     <text x="154" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66 74 82" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">q</text>
+    <text x="58 66" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">ow</text>
+    <text x="82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">1:k</text>
+    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">q:k</text>
     <text x="98" y="96" style="fill:#CCCCCC;">A</text>
     <text x="114 122 130" y="96" style="fill:#00AA00;">one</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">1:o</text>
+    <text x="66 74 82" y="114" style="fill:#0000AA;font-weight:bold;">q:o</text>
     <text x="98" y="114" style="fill:#CCCCCC;">A</text>
     <text x="114 122 130 138 146" y="114" style="fill:#00AA00;">three</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;">1:t</text>
+    <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;">q:t</text>
     <text x="98" y="132" style="fill:#CCCCCC;">A</text>
     <text x="114 122 130" y="132" style="fill:#00AA00;">two</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">├╯</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_file_marks_all_hunks_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_file_marks_all_hunks_001.svg
@@ -45,10 +45,11 @@
     <text x="530" y="78" style="fill:#555555;">│</text>
     <text x="802" y="78" style="fill:#555555;">█</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="96" style="fill:#AA00AA;opacity:0.75;">1</text>
-    <text x="66 74 82" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50" y="96" style="fill:#AA00AA;opacity:0.75;">u</text>
+    <text x="58 66" y="96" style="fill:#CCCCCC;opacity:0.75;">tx</text>
+    <text x="82 90 98" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530" y="96" style="fill:#555555;">│──────────────╯</text>
     <text x="802" y="96" style="fill:#555555;">█</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_file_marks_all_hunks_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_file_marks_all_hunks_002.svg
@@ -36,10 +36,11 @@
     <text x="506" y="78" style="fill:#555555;">│</text>
     <text x="802" y="78" style="fill:#555555;">█</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="96" style="fill:#AA00AA;">1</text>
-    <text x="66 74 82" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50" y="96" style="fill:#AA00AA;">u</text>
+    <text x="58 66" y="96" style="fill:#CCCCCC;opacity:0.75;">tx</text>
+    <text x="82 90 98" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506" y="96" style="fill:#555555;">│───────────╯</text>
     <text x="802" y="96" style="fill:#555555;">█</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_file_marks_all_hunks_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_file_marks_all_hunks_003.svg
@@ -44,10 +44,11 @@
     <text x="530" y="78" style="fill:#555555;">│</text>
     <text x="802" y="78" style="fill:#555555;">█</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="96" style="fill:#AA00AA;opacity:0.75;">1</text>
-    <text x="66 74 82" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50" y="96" style="fill:#AA00AA;opacity:0.75;">u</text>
+    <text x="58 66" y="96" style="fill:#CCCCCC;opacity:0.75;">tx</text>
+    <text x="82 90 98" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530" y="96" style="fill:#555555;">│──────────────╯</text>
     <text x="802" y="96" style="fill:#555555;">█</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_file_marks_all_hunks_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_file_marks_all_hunks_004.svg
@@ -45,10 +45,11 @@
     <text x="530" y="78" style="fill:#555555;">│</text>
     <text x="802" y="78" style="fill:#555555;">█</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="96" style="fill:#AA00AA;opacity:0.75;">1</text>
-    <text x="66 74 82" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50" y="96" style="fill:#AA00AA;opacity:0.75;">u</text>
+    <text x="58 66" y="96" style="fill:#CCCCCC;opacity:0.75;">tx</text>
+    <text x="82 90 98" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530" y="96" style="fill:#555555;">│──────────────╯</text>
     <text x="802" y="96" style="fill:#555555;">█</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_file_marks_all_hunks_005.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_file_marks_all_hunks_005.svg
@@ -36,10 +36,11 @@
     <text x="506" y="78" style="fill:#555555;">│</text>
     <text x="802" y="78" style="fill:#555555;">█</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="96" style="fill:#AA00AA;">1</text>
-    <text x="66 74 82" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50" y="96" style="fill:#AA00AA;">u</text>
+    <text x="58 66" y="96" style="fill:#CCCCCC;opacity:0.75;">tx</text>
+    <text x="82 90 98" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506" y="96" style="fill:#555555;">│───────────╯</text>
     <text x="802" y="96" style="fill:#555555;">█</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">├╯</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_uncommitted_area_marks_all_hunks_in_detail_view_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_uncommitted_area_marks_all_hunks_in_detail_view_001.svg
@@ -52,10 +52,11 @@
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530" y="96" style="fill:#555555;">│──────────────╯</text>
     <text x="802" y="96" style="fill:#555555;">█</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="114" style="fill:#AA00AA;opacity:0.75;">1</text>
-    <text x="66 74 82" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50" y="114" style="fill:#AA00AA;opacity:0.75;">u</text>
+    <text x="58 66" y="114" style="fill:#CCCCCC;opacity:0.75;">tx</text>
+    <text x="82 90 98" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="410" y="114" style="fill:#555555;">│</text>
     <text x="802" y="114" style="fill:#555555;">█</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">├╯</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_uncommitted_area_marks_all_hunks_in_detail_view_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/marking_uncommitted_area_marks_all_hunks_in_detail_view_002.svg
@@ -42,10 +42,11 @@
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506" y="96" style="fill:#555555;">│───────────╯</text>
     <text x="802" y="96" style="fill:#555555;">█</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="114" style="fill:#AA00AA;">1</text>
-    <text x="66 74 82" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50" y="114" style="fill:#AA00AA;">u</text>
+    <text x="58 66" y="114" style="fill:#CCCCCC;opacity:0.75;">tx</text>
+    <text x="82 90 98" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="410" y="114" style="fill:#555555;">│</text>
     <text x="802" y="114" style="fill:#555555;">█</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">├╯</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/move_commit_above_other_commit_reorders_tui_final.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/move_commit_above_other_commit_reorders_tui_final.svg
@@ -22,14 +22,16 @@
     <text x="82 90 98" y="78" style="fill:#CCCCCC;">add</text>
     <text x="114" y="78" style="fill:#CCCCCC;">A</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
-    <text x="50 58 66" y="96" style="fill:#AA00AA;">1#0</text>
+    <text x="50" y="96" style="fill:#AA00AA;">m</text>
+    <text x="58 66" y="96" style="fill:#CCCCCC;opacity:0.75;">ul</text>
     <text x="82 90 98" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
     <text x="114 122 130 138 146 154" y="96" style="fill:#CCCCCC;opacity:0.75;">commit</text>
     <text x="170 178 186 194 202 210 218 226" y="96" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="242 250 258" y="96" style="fill:#CCCCCC;opacity:0.75;">(no</text>
     <text x="274 282 290 298 306 314 322 330" y="96" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊●</text>
-    <text x="50 58 66" y="114" style="fill:#AA00AA;">1#1</text>
+    <text x="50" y="114" style="fill:#AA00AA;">o</text>
+    <text x="58 66" y="114" style="fill:#CCCCCC;opacity:0.75;">un</text>
     <text x="82 90 98" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
     <text x="114 122 130 138 146 154" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
     <text x="170 178 186 194 202 210 218 226" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/move_commit_below_a_worktree_heading_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/move_commit_below_a_worktree_heading_001.svg
@@ -48,12 +48,13 @@
     <text x="50 58" y="204" style="fill:#FFFFFF;">&lt;&lt;</text>
     <text x="74 82 90 98 106 114" y="204" style="fill:#FFFFFF;">source</text>
     <text x="130 138" y="204" style="fill:#FFFFFF;">&gt;&gt;</text>
-    <text x="154" y="204" style="fill:#AA00AA;">1</text>
-    <text x="170 178 186" y="204" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="202 210 218 226 234 242" y="204" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="258 266 274 282 290 298 306 314" y="204" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="330 338 346" y="204" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="362 370 378 386 394 402 410 418" y="204" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="154 162" y="204" style="fill:#AA00AA;">ou</text>
+    <text x="170" y="204" style="fill:#CCCCCC;opacity:0.75;">n</text>
+    <text x="186 194 202" y="204" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="218 226 234 242 250 258" y="204" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="274 282 290 298 306 314 322 330" y="204" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="346 354 362" y="204" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="378 386 394 402 410 418 426 434" y="204" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10 18" y="222" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="222" style="fill:#AA00AA;">t</text>
     <text x="58 66" y="222" style="fill:#CCCCCC;opacity:0.75;">pm</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/move_commit_below_a_worktree_heading_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/move_commit_below_a_worktree_heading_002.svg
@@ -28,12 +28,13 @@
     <text x="98 106 114 122 130 138 146 154 162 170 178" y="114" style="fill:#00AA00;">wt-file.txt</text>
     <text x="10 18 26" y="132" style="fill:#CCCCCC;">┊┊┊</text>
     <text x="10 18 26" y="150" style="fill:#FFFFFF;font-weight:bold;">┊┊●</text>
-    <text x="58" y="150" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="74 82 90" y="150" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="106 114 122 130 138 146" y="150" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="162 170 178 186 194 202 210 218" y="150" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
-    <text x="234 242 250" y="150" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="266 274 282 290 298 306 314 322" y="150" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
+    <text x="58 66" y="150" style="fill:#AA00AA;font-weight:bold;">ou</text>
+    <text x="74" y="150" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">n</text>
+    <text x="90 98 106" y="150" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="122 130 138 146 154 162" y="150" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="178 186 194 202 210 218 226 234" y="150" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="250 258 266" y="150" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="282 290 298 306 314 322 330 338" y="150" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">changes)</text>
     <text x="10 18 26" y="168" style="fill:#CCCCCC;">┊┊●</text>
     <text x="58" y="168" style="fill:#AA00AA;">n</text>
     <text x="66 74" y="168" style="fill:#CCCCCC;opacity:0.75;">ll</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/open_uncommitted_file_with_multiple_hunks_in_program_from_details_view_004.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/open_uncommitted_file_with_multiple_hunks_in_program_from_details_view_004.svg
@@ -23,9 +23,10 @@
     <text x="74" y="96" style="fill:#00AA00;">A</text>
     <text x="82" y="96" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="114" style="fill:#AA00AA;">1</text>
-    <text x="66 74 82" y="114" style="fill:#CCCCCC;">Add</text>
-    <text x="98 106 114 122" y="114" style="fill:#CCCCCC;">file</text>
+    <text x="50 58" y="114" style="fill:#AA00AA;">zy</text>
+    <text x="66" y="114" style="fill:#CCCCCC;opacity:0.75;">t</text>
+    <text x="82 90 98" y="114" style="fill:#CCCCCC;">Add</text>
+    <text x="114 122 130 138" y="114" style="fill:#CCCCCC;">file</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="132" style="fill:#AA00AA;">t</text>
     <text x="58 66" y="132" style="fill:#CCCCCC;opacity:0.75;">pm</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_branch_into_commit_on_same_branch_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_branch_into_commit_on_same_branch_001.svg
@@ -17,12 +17,13 @@
     <text x="74" y="60" style="fill:#00AA00;">A</text>
     <text x="82" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66 74 82" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">w</text>
+    <text x="58 66" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">yq</text>
+    <text x="82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">1:q</text>
+    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">w:q</text>
     <text x="98" y="96" style="fill:#CCCCCC;">A</text>
     <text x="114 122 130 138" y="96" style="fill:#00AA00;">file</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊●</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_branch_into_commit_on_same_branch_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_branch_into_commit_on_same_branch_002.svg
@@ -27,12 +27,13 @@
     <text x="282" y="60" style="fill:#00AA00;font-weight:bold;">A</text>
     <text x="290" y="60" style="fill:#FFFFFF;font-weight:bold;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#AA00AA;">1</text>
-    <text x="66 74 82" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50" y="78" style="fill:#AA00AA;">w</text>
+    <text x="58 66" y="78" style="fill:#CCCCCC;opacity:0.75;">yq</text>
+    <text x="82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;opacity:0.75;">1:q</text>
+    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;opacity:0.75;">w:q</text>
     <text x="98" y="96" style="fill:#CCCCCC;opacity:0.75;">A</text>
     <text x="114 122 130 138" y="96" style="fill:#00AA00;opacity:0.75;">file</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊●</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_branch_into_commit_on_same_branch_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_branch_into_commit_on_same_branch_003.svg
@@ -23,12 +23,13 @@
     <text x="178" y="60" style="fill:#00AA00;">A</text>
     <text x="186" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#AA00AA;">1</text>
-    <text x="66 74 82" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50" y="78" style="fill:#AA00AA;">w</text>
+    <text x="58 66" y="78" style="fill:#CCCCCC;opacity:0.75;">yq</text>
+    <text x="82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;opacity:0.75;">1:q</text>
+    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;opacity:0.75;">w:q</text>
     <text x="98" y="96" style="fill:#CCCCCC;opacity:0.75;">A</text>
     <text x="114 122 130 138" y="96" style="fill:#00AA00;opacity:0.75;">file</text>
     <text x="10 18" y="114" style="fill:#FFFFFF;font-weight:bold;">┊●</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_branch_into_other_branch_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_branch_into_other_branch_001.svg
@@ -43,12 +43,13 @@
     <text x="74" y="150" style="fill:#00AA00;">B</text>
     <text x="82" y="150" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="168" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="168" style="fill:#AA00AA;">1</text>
-    <text x="66 74 82" y="168" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="168" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="168" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="226 234 242" y="168" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="258 266 274 282 290 298 306 314" y="168" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="50" y="168" style="fill:#AA00AA;">n</text>
+    <text x="58 66" y="168" style="fill:#CCCCCC;opacity:0.75;">py</text>
+    <text x="82 90 98" y="168" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="168" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="168" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="242 250 258" y="168" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="274 282 290 298 306 314 322 330" y="168" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="186" style="fill:#AA00AA;">l</text>
     <text x="58 66" y="186" style="fill:#CCCCCC;opacity:0.75;">rm</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_branch_into_other_branch_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_branch_into_other_branch_002.svg
@@ -45,12 +45,13 @@
     <text x="330" y="150" style="fill:#00AA00;font-weight:bold;">B</text>
     <text x="338" y="150" style="fill:#FFFFFF;font-weight:bold;">]</text>
     <text x="10 18" y="168" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="168" style="fill:#AA00AA;">1</text>
-    <text x="66 74 82" y="168" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="168" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="168" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="226 234 242" y="168" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="258 266 274 282 290 298 306 314" y="168" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="50" y="168" style="fill:#AA00AA;">n</text>
+    <text x="58 66" y="168" style="fill:#CCCCCC;opacity:0.75;">py</text>
+    <text x="82 90 98" y="168" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="168" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="168" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="242 250 258" y="168" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="274 282 290 298 306 314 322 330" y="168" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10 18" y="186" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="186" style="fill:#AA00AA;">l</text>
     <text x="58 66" y="186" style="fill:#CCCCCC;opacity:0.75;">rm</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_branch_into_other_branch_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_branch_into_other_branch_003.svg
@@ -17,12 +17,13 @@
     <text x="74" y="60" style="fill:#00AA00;">B</text>
     <text x="82" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66 74 82" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">n</text>
+    <text x="58 66" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">py</text>
+    <text x="82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">1:t</text>
+    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;">n:t</text>
     <text x="98" y="96" style="fill:#CCCCCC;">A</text>
     <text x="114" y="96" style="fill:#00AA00;">A</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊●</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_branch_into_self_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_branch_into_self_001.svg
@@ -27,12 +27,13 @@
     <text x="282" y="60" style="fill:#00AA00;font-weight:bold;">A</text>
     <text x="290" y="60" style="fill:#FFFFFF;font-weight:bold;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#AA00AA;">1</text>
-    <text x="66 74 82" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50" y="78" style="fill:#AA00AA;">w</text>
+    <text x="58 66" y="78" style="fill:#CCCCCC;opacity:0.75;">yq</text>
+    <text x="82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;opacity:0.75;">1:q</text>
+    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;opacity:0.75;">w:q</text>
     <text x="98" y="96" style="fill:#CCCCCC;opacity:0.75;">A</text>
     <text x="114 122 130 138" y="96" style="fill:#00AA00;opacity:0.75;">file</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊●</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_marked_commits_to_commit_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_marked_commits_to_commit_001.svg
@@ -27,27 +27,29 @@
     <text x="50 58" y="78" style="fill:#FFFFFF;">&lt;&lt;</text>
     <text x="74 82 90 98 106 114" y="78" style="fill:#FFFFFF;">source</text>
     <text x="130 138" y="78" style="fill:#FFFFFF;">&gt;&gt;</text>
-    <text x="154 162 170" y="78" style="fill:#AA00AA;">1#0</text>
+    <text x="154" y="78" style="fill:#AA00AA;">n</text>
+    <text x="162 170" y="78" style="fill:#CCCCCC;opacity:0.75;">vs</text>
     <text x="186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
     <text x="218 226 234 242 250 258" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
     <text x="274 282 290 298 306 314 322 330" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82 90 98" y="96" style="fill:#0000AA;font-weight:bold;opacity:0.75;">1#0:t</text>
-    <text x="114" y="96" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="130 138 146" y="96" style="fill:#00AA00;opacity:0.75;">two</text>
+    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;opacity:0.75;">n:t</text>
+    <text x="98" y="96" style="fill:#CCCCCC;opacity:0.75;">A</text>
+    <text x="114 122 130" y="96" style="fill:#00AA00;opacity:0.75;">two</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="114" style="fill:#000000;">✔︎</text>
     <text x="50 58" y="114" style="fill:#FFFFFF;">&lt;&lt;</text>
     <text x="74 82 90 98 106 114" y="114" style="fill:#FFFFFF;">source</text>
     <text x="130 138" y="114" style="fill:#FFFFFF;">&gt;&gt;</text>
-    <text x="154 162 170" y="114" style="fill:#AA00AA;">1#1</text>
+    <text x="154" y="114" style="fill:#AA00AA;">o</text>
+    <text x="162 170" y="114" style="fill:#CCCCCC;opacity:0.75;">pp</text>
     <text x="186 194 202" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
     <text x="218 226 234 242 250 258" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
     <text x="274 282 290 298 306 314 322 330" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82 90 98" y="132" style="fill:#0000AA;font-weight:bold;opacity:0.75;">1#1:k</text>
-    <text x="114" y="132" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="130 138 146" y="132" style="fill:#00AA00;opacity:0.75;">one</text>
+    <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;opacity:0.75;">o:k</text>
+    <text x="98" y="132" style="fill:#CCCCCC;opacity:0.75;">A</text>
+    <text x="114 122 130" y="132" style="fill:#00AA00;opacity:0.75;">one</text>
     <text x="10 18" y="150" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
     <text x="50 58" y="150" style="fill:#000000;font-weight:bold;">&lt;&lt;</text>
     <text x="74 82 90 98 106 114" y="150" style="fill:#000000;font-weight:bold;">squash</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_marked_commits_to_commit_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_marked_commits_to_commit_002.svg
@@ -27,27 +27,29 @@
     <text x="50 58" y="78" style="fill:#FFFFFF;">&lt;&lt;</text>
     <text x="74 82 90 98 106 114" y="78" style="fill:#FFFFFF;">source</text>
     <text x="130 138" y="78" style="fill:#FFFFFF;">&gt;&gt;</text>
-    <text x="154 162 170" y="78" style="fill:#AA00AA;">1#0</text>
+    <text x="154" y="78" style="fill:#AA00AA;">n</text>
+    <text x="162 170" y="78" style="fill:#CCCCCC;opacity:0.75;">vs</text>
     <text x="186 194 202" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
     <text x="218 226 234 242 250 258" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
     <text x="274 282 290 298 306 314 322 330" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82 90 98" y="96" style="fill:#0000AA;font-weight:bold;opacity:0.75;">1#0:t</text>
-    <text x="114" y="96" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="130 138 146" y="96" style="fill:#00AA00;opacity:0.75;">two</text>
+    <text x="66 74 82" y="96" style="fill:#0000AA;font-weight:bold;opacity:0.75;">n:t</text>
+    <text x="98" y="96" style="fill:#CCCCCC;opacity:0.75;">A</text>
+    <text x="114 122 130" y="96" style="fill:#00AA00;opacity:0.75;">two</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="114" style="fill:#000000;">✔︎</text>
     <text x="50 58" y="114" style="fill:#FFFFFF;">&lt;&lt;</text>
     <text x="74 82 90 98 106 114" y="114" style="fill:#FFFFFF;">source</text>
     <text x="130 138" y="114" style="fill:#FFFFFF;">&gt;&gt;</text>
-    <text x="154 162 170" y="114" style="fill:#AA00AA;">1#1</text>
+    <text x="154" y="114" style="fill:#AA00AA;">o</text>
+    <text x="162 170" y="114" style="fill:#CCCCCC;opacity:0.75;">pp</text>
     <text x="186 194 202" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
     <text x="218 226 234 242 250 258" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
     <text x="274 282 290 298 306 314 322 330" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82 90 98" y="132" style="fill:#0000AA;font-weight:bold;opacity:0.75;">1#1:k</text>
-    <text x="114" y="132" style="fill:#CCCCCC;opacity:0.75;">A</text>
-    <text x="130 138 146" y="132" style="fill:#00AA00;opacity:0.75;">one</text>
+    <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;opacity:0.75;">o:k</text>
+    <text x="98" y="132" style="fill:#CCCCCC;opacity:0.75;">A</text>
+    <text x="114 122 130" y="132" style="fill:#00AA00;opacity:0.75;">one</text>
     <text x="10 18" y="150" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
     <text x="50 58" y="150" style="fill:#000000;font-weight:bold;">&lt;&lt;</text>
     <text x="74 82 90 98 106 114" y="150" style="fill:#000000;font-weight:bold;">squash</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_marked_committed_files_to_commit_via_global_file_list_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_marked_committed_files_to_commit_via_global_file_list_001.svg
@@ -23,16 +23,17 @@
     <text x="74" y="60" style="fill:#00AA00;">A</text>
     <text x="82" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#AA00AA;">1</text>
-    <text x="66 74 82" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50" y="78" style="fill:#AA00AA;">r</text>
+    <text x="58 66" y="78" style="fill:#CCCCCC;opacity:0.75;">qz</text>
+    <text x="82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="96" style="fill:#000000;">✔︎</text>
     <text x="66 74" y="96" style="fill:#FFFFFF;">&lt;&lt;</text>
     <text x="90 98 106 114 122 130" y="96" style="fill:#FFFFFF;">source</text>
     <text x="146 154" y="96" style="fill:#FFFFFF;">&gt;&gt;</text>
-    <text x="170 178 186" y="96" style="fill:#0000AA;font-weight:bold;">1:k</text>
+    <text x="170 178 186" y="96" style="fill:#0000AA;font-weight:bold;">r:k</text>
     <text x="202" y="96" style="fill:#CCCCCC;">A</text>
     <text x="218 226 234" y="96" style="fill:#00AA00;">one</text>
     <text x="10" y="114" style="fill:#FFFFFF;font-weight:bold;">┊</text>
@@ -40,7 +41,7 @@
     <text x="66 74" y="114" style="fill:#FFFFFF;font-weight:bold;">&lt;&lt;</text>
     <text x="90 98 106 114 122 130" y="114" style="fill:#FFFFFF;font-weight:bold;">source</text>
     <text x="146 154" y="114" style="fill:#FFFFFF;font-weight:bold;">&gt;&gt;</text>
-    <text x="170 178 186" y="114" style="fill:#0000AA;font-weight:bold;">1:t</text>
+    <text x="170 178 186" y="114" style="fill:#0000AA;font-weight:bold;">r:t</text>
     <text x="202" y="114" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="218 226 234" y="114" style="fill:#00AA00;font-weight:bold;">two</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊●</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_marked_committed_files_to_commit_via_global_file_list_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_marked_committed_files_to_commit_via_global_file_list_002.svg
@@ -23,16 +23,17 @@
     <text x="74" y="60" style="fill:#00AA00;">A</text>
     <text x="82" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#AA00AA;">1</text>
-    <text x="66 74 82" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50" y="78" style="fill:#AA00AA;">r</text>
+    <text x="58 66" y="78" style="fill:#CCCCCC;opacity:0.75;">qz</text>
+    <text x="82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="96" style="fill:#000000;">✔︎</text>
     <text x="66 74" y="96" style="fill:#FFFFFF;">&lt;&lt;</text>
     <text x="90 98 106 114 122 130" y="96" style="fill:#FFFFFF;">source</text>
     <text x="146 154" y="96" style="fill:#FFFFFF;">&gt;&gt;</text>
-    <text x="170 178 186" y="96" style="fill:#0000AA;font-weight:bold;">1:k</text>
+    <text x="170 178 186" y="96" style="fill:#0000AA;font-weight:bold;">r:k</text>
     <text x="202" y="96" style="fill:#CCCCCC;">A</text>
     <text x="218 226 234" y="96" style="fill:#00AA00;">one</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
@@ -40,7 +41,7 @@
     <text x="66 74" y="114" style="fill:#FFFFFF;">&lt;&lt;</text>
     <text x="90 98 106 114 122 130" y="114" style="fill:#FFFFFF;">source</text>
     <text x="146 154" y="114" style="fill:#FFFFFF;">&gt;&gt;</text>
-    <text x="170 178 186" y="114" style="fill:#0000AA;font-weight:bold;">1:t</text>
+    <text x="170 178 186" y="114" style="fill:#0000AA;font-weight:bold;">r:t</text>
     <text x="202" y="114" style="fill:#CCCCCC;">A</text>
     <text x="218 226 234" y="114" style="fill:#00AA00;">two</text>
     <text x="10 18" y="132" style="fill:#FFFFFF;font-weight:bold;">┊●</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_marked_committed_files_to_commit_via_global_file_list_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_marked_committed_files_to_commit_via_global_file_list_003.svg
@@ -17,12 +17,13 @@
     <text x="74" y="60" style="fill:#00AA00;">A</text>
     <text x="82" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#AA00AA;">1</text>
-    <text x="66 74 82" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
-    <text x="226 234 242" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="258 266 274 282 290 298 306 314" y="78" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
+    <text x="50" y="78" style="fill:#AA00AA;">r</text>
+    <text x="58 66" y="78" style="fill:#CCCCCC;opacity:0.75;">qz</text>
+    <text x="82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="242 250 258" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="274 282 290 298 306 314 322 330" y="78" style="fill:#CCCCCC;opacity:0.75;">changes)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
     <text x="50" y="96" style="fill:#AA00AA;font-weight:bold;">t</text>
     <text x="58 66" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">pm</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_marked_committed_files_to_commit_via_local_file_list_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_marked_committed_files_to_commit_via_local_file_list_001.svg
@@ -23,16 +23,17 @@
     <text x="74" y="60" style="fill:#00AA00;">A</text>
     <text x="82" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#AA00AA;">1</text>
-    <text x="66 74 82" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50" y="78" style="fill:#AA00AA;">o</text>
+    <text x="58 66" y="78" style="fill:#CCCCCC;opacity:0.75;">lz</text>
+    <text x="82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="96" style="fill:#000000;">✔︎</text>
     <text x="66 74" y="96" style="fill:#FFFFFF;">&lt;&lt;</text>
     <text x="90 98 106 114 122 130" y="96" style="fill:#FFFFFF;">source</text>
     <text x="146 154" y="96" style="fill:#FFFFFF;">&gt;&gt;</text>
-    <text x="170 178 186" y="96" style="fill:#0000AA;font-weight:bold;">1:k</text>
+    <text x="170 178 186" y="96" style="fill:#0000AA;font-weight:bold;">o:k</text>
     <text x="202" y="96" style="fill:#CCCCCC;">A</text>
     <text x="218 226 234" y="96" style="fill:#00AA00;">one</text>
     <text x="10" y="114" style="fill:#FFFFFF;font-weight:bold;">┊</text>
@@ -40,11 +41,11 @@
     <text x="66 74" y="114" style="fill:#FFFFFF;font-weight:bold;">&lt;&lt;</text>
     <text x="90 98 106 114 122 130" y="114" style="fill:#FFFFFF;font-weight:bold;">source</text>
     <text x="146 154" y="114" style="fill:#FFFFFF;font-weight:bold;">&gt;&gt;</text>
-    <text x="170 178 186" y="114" style="fill:#0000AA;font-weight:bold;">1:o</text>
+    <text x="170 178 186" y="114" style="fill:#0000AA;font-weight:bold;">o:o</text>
     <text x="202" y="114" style="fill:#FFFFFF;font-weight:bold;">A</text>
     <text x="218 226 234 242 250" y="114" style="fill:#00AA00;font-weight:bold;">three</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;opacity:0.75;">1:t</text>
+    <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;opacity:0.75;">o:t</text>
     <text x="98" y="132" style="fill:#CCCCCC;opacity:0.75;">A</text>
     <text x="114 122 130" y="132" style="fill:#00AA00;opacity:0.75;">two</text>
     <text x="10 18" y="150" style="fill:#CCCCCC;">┊●</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_marked_committed_files_to_commit_via_local_file_list_002.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_marked_committed_files_to_commit_via_local_file_list_002.svg
@@ -23,16 +23,17 @@
     <text x="74" y="60" style="fill:#00AA00;">A</text>
     <text x="82" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#AA00AA;">1</text>
-    <text x="66 74 82" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50" y="78" style="fill:#AA00AA;">o</text>
+    <text x="58 66" y="78" style="fill:#CCCCCC;opacity:0.75;">lz</text>
+    <text x="82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10" y="96" style="fill:#CCCCCC;">┊</text>
     <text x="18" y="96" style="fill:#000000;">✔︎</text>
     <text x="66 74" y="96" style="fill:#FFFFFF;">&lt;&lt;</text>
     <text x="90 98 106 114 122 130" y="96" style="fill:#FFFFFF;">source</text>
     <text x="146 154" y="96" style="fill:#FFFFFF;">&gt;&gt;</text>
-    <text x="170 178 186" y="96" style="fill:#0000AA;font-weight:bold;">1:k</text>
+    <text x="170 178 186" y="96" style="fill:#0000AA;font-weight:bold;">o:k</text>
     <text x="202" y="96" style="fill:#CCCCCC;">A</text>
     <text x="218 226 234" y="96" style="fill:#00AA00;">one</text>
     <text x="10" y="114" style="fill:#CCCCCC;">┊</text>
@@ -40,11 +41,11 @@
     <text x="66 74" y="114" style="fill:#FFFFFF;">&lt;&lt;</text>
     <text x="90 98 106 114 122 130" y="114" style="fill:#FFFFFF;">source</text>
     <text x="146 154" y="114" style="fill:#FFFFFF;">&gt;&gt;</text>
-    <text x="170 178 186" y="114" style="fill:#0000AA;font-weight:bold;">1:o</text>
+    <text x="170 178 186" y="114" style="fill:#0000AA;font-weight:bold;">o:o</text>
     <text x="202" y="114" style="fill:#CCCCCC;">A</text>
     <text x="218 226 234 242 250" y="114" style="fill:#00AA00;">three</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">┊│</text>
-    <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;opacity:0.75;">1:t</text>
+    <text x="66 74 82" y="132" style="fill:#0000AA;font-weight:bold;opacity:0.75;">o:t</text>
     <text x="98" y="132" style="fill:#CCCCCC;opacity:0.75;">A</text>
     <text x="114 122 130" y="132" style="fill:#00AA00;opacity:0.75;">two</text>
     <text x="10 18" y="150" style="fill:#FFFFFF;font-weight:bold;">┊●</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_marked_committed_files_to_commit_via_local_file_list_003.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_marked_committed_files_to_commit_via_local_file_list_003.svg
@@ -17,10 +17,11 @@
     <text x="74" y="60" style="fill:#00AA00;">A</text>
     <text x="82" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="78" style="fill:#AA00AA;">1</text>
-    <text x="66 74 82" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50" y="78" style="fill:#AA00AA;">o</text>
+    <text x="58 66" y="78" style="fill:#CCCCCC;opacity:0.75;">lz</text>
+    <text x="82 90 98" y="78" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="78" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
     <text x="50" y="96" style="fill:#AA00AA;font-weight:bold;">t</text>
     <text x="58 66" y="96" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">pm</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_source_with_partial_marks_is_selectable_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/squash_source_with_partial_marks_is_selectable_001.svg
@@ -55,10 +55,11 @@
     <text x="410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530" y="96" style="fill:#555555;">│──────────────╯</text>
     <text x="802" y="96" style="fill:#555555;">█</text>
     <text x="10 18" y="114" style="fill:#CCCCCC;">┊●</text>
-    <text x="50" y="114" style="fill:#AA00AA;">1</text>
-    <text x="66 74 82" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
+    <text x="50" y="114" style="fill:#AA00AA;">u</text>
+    <text x="58 66" y="114" style="fill:#CCCCCC;opacity:0.75;">tx</text>
+    <text x="82 90 98" y="114" style="fill:#CCCCCC;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="114" style="fill:#CCCCCC;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="114" style="fill:#CCCCCC;opacity:0.75;">message)</text>
     <text x="410" y="114" style="fill:#555555;">│</text>
     <text x="802" y="114" style="fill:#555555;">█</text>
     <text x="10 18" y="132" style="fill:#CCCCCC;">├╯</text>

--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/undo_opens_confirm_for_latest_snapshot_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/undo_opens_confirm_for_latest_snapshot_001.svg
@@ -17,10 +17,11 @@
     <text x="74" y="60" style="fill:#00AA00;">A</text>
     <text x="82" y="60" style="fill:#CCCCCC;">]</text>
     <text x="10 18" y="78" style="fill:#FFFFFF;font-weight:bold;">┊●</text>
-    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">1</text>
-    <text x="66 74 82" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
-    <text x="98 106 114 122 130 138" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
-    <text x="154 162 170 178 186 194 202 210" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
+    <text x="50" y="78" style="fill:#AA00AA;font-weight:bold;">n</text>
+    <text x="58 66" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">sl</text>
+    <text x="82 90 98" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">(no</text>
+    <text x="114 122 130 138 146 154" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">commit</text>
+    <text x="170 178 186 194 202 210 218 226" y="78" style="fill:#FFFFFF;font-weight:bold;opacity:0.75;">message)</text>
     <text x="10 18" y="96" style="fill:#CCCCCC;">┊●</text>
     <text x="50" y="96" style="fill:#AA00AA;">t</text>
     <text x="58 66" y="96" style="fill:#CCCCCC;opacity:0.75;">pm</text>
@@ -38,7 +39,7 @@
     <text x="242 250 258 266 274 282 290 298 306 314 322 330 338 346 354 362 370 378 386 394 402 410 418 426 434 442 450 458 466 474 482 490 498 506 514 522 530 538 546 554 562 570 578 586 594 602 610 618 626 634 642 650 658 666 674 682 690 698 706 714 722 730 738 746 754 762 770 778 786 794" y="294" style="fill:#00AAAA;">┌────────────────────────────────────────────────────────────────────┐</text>
     <text x="242" y="312" style="fill:#00AAAA;">│</text>
     <text x="258 266 274 282 290" y="312" style="fill:#CCCCCC;">Undid</text>
-    <text x="306 314 322 330 338 346 354" y="312" style="fill:#0000AA;font-weight:bold;">872448f</text>
+    <text x="306 314 322 330 338 346 354" y="312" style="fill:#0000AA;font-weight:bold;">74018e8</text>
     <text x="370 378 386" y="312" style="fill:#00AAAA;">Sat</text>
     <text x="402 410 418" y="312" style="fill:#00AAAA;">Jan</text>
     <text x="434" y="312" style="fill:#00AAAA;">1</text>

--- a/crates/but/src/command/legacy/status/tui/tests/utils.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/utils.rs
@@ -24,6 +24,8 @@ pub struct TestTuiOptions {
     pub run_options: TuiRunOptions,
     pub show_file_browser: bool,
     pub launch_options: TuiLaunchOptions,
+    /// Override deterministic change-ID generation for tests that need collisions.
+    pub testing_change_id: Option<&'static str>,
     /// Turn on the experimental `worktreeManipulation` flag and make the fixture's linked
     /// worktrees active, so they take part in the status the TUI is built from.
     pub worktree_manipulation: bool,
@@ -37,6 +39,7 @@ impl Default for TestTuiOptions {
             run_options: Default::default(),
             show_file_browser: false,
             launch_options: Default::default(),
+            testing_change_id: None,
             worktree_manipulation: false,
         }
     }
@@ -53,10 +56,16 @@ pub fn test_status_tui_with_options(mut env: Sandbox, options: TestTuiOptions) -
         run_options,
         show_file_browser,
         launch_options,
+        testing_change_id,
         worktree_manipulation,
     } = options;
 
     configure_test_repo(&env);
+    if let Some(change_id) = testing_change_id {
+        env.invoke_git(&format!(
+            "config --local gitbutler.testing.changeId {change_id}"
+        ));
+    }
     if worktree_manipulation {
         // Set on the sandbox rather than on one `Context`, because every render builds a fresh
         // one - a flag set on a single context would vanish on the first reload.

--- a/crates/but/src/command/legacy/status/tui/tests/worktree_tests.rs
+++ b/crates/but/src/command/legacy/status/tui/tests/worktree_tests.rs
@@ -154,7 +154,7 @@ fn commit_all_changes_of_a_worktree() {
         tui.env().git_log(),
         str![[r#"
 * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-| * 352ea1d (wt-branch) commit from worktree
+| * 27f2344 (wt-branch) commit from worktree
 | * 998a235 add W
 |/  
 * 9477ae7 (A) add A
@@ -194,7 +194,7 @@ fn commit_one_worktree_file_onto_its_own_branch() {
         tui.env().git_log(),
         str![[r#"
 * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-| * 352ea1d (wt-branch) commit from worktree
+| * 27f2344 (wt-branch) commit from worktree
 | * 998a235 add W
 |/  
 * 9477ae7 (A) add A
@@ -229,7 +229,7 @@ fn commit_a_main_worktree_change_onto_a_worktree() {
         tui.env().git_log(),
         str![[r#"
 * edd3eb7 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-| * 9fa1815 (wt-branch) commit from worktree
+| * cdc9ff4 (wt-branch) commit from worktree
 | * 998a235 add W
 |/  
 * 9477ae7 (A) add A
@@ -334,7 +334,7 @@ fn empty_commit_on_a_worktree_heading() {
         .assert_rendered_term_svg_eq(file![
             "snapshots/empty_commit_on_a_worktree_heading_final.svg"
         ])
-        .assert_current_line_eq(str!["┊┊●   1 (no commit message) (no changes)"]);
+        .assert_current_line_eq(str!["┊┊●   uxy (no commit message) (no changes)"]);
 }
 
 /// A worktree heading is a move target: confirming on it moves the commit to the tip of the
@@ -348,7 +348,7 @@ fn move_commit_below_a_worktree_heading() {
         .assert_current_line_eq(str!["┊╭┄ g0 [A]"]);
     // An empty commit moves without conflicts, so the move itself is all this test sees.
     tui.input('n')
-        .assert_current_line_eq(str!["┊●   1 (no commit message) (no changes)"]);
+        .assert_current_line_eq(str!["┊●   oun (no commit message) (no changes)"]);
 
     tui.input('m');
     // Past the worktree's own commit, onto its heading.
@@ -367,7 +367,7 @@ fn move_commit_below_a_worktree_heading() {
         tui.env().git_log(),
         str![[r#"
 * 6919fdf (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-| * 1ce4908 (wt-branch) 
+| * 401b057 (wt-branch) 
 | * 20da4fb add W
 |/  
 * 9477ae7 (A) add A

--- a/crates/but/src/tui/test_utils.rs
+++ b/crates/but/src/tui/test_utils.rs
@@ -197,7 +197,7 @@ pub fn configure_test_repo(env: &Sandbox) {
     env.invoke_git("config tag.gpgsign false");
     env.invoke_git("config init.defaultBranch main");
     env.invoke_git("config protocol.file.allow always");
-    env.invoke_git("config gitbutler.testing.changeId 1");
+    env.invoke_git("config gitbutler.testing.changeId content-hash");
 }
 
 pub fn with_stable_commit_env<R>(closure: impl FnOnce() -> R) -> R {

--- a/crates/but/tests/but/command/absorb.rs
+++ b/crates/but/tests/but/command/absorb.rs
@@ -84,7 +84,7 @@ fn uncommitted_file() {
         .stdout_eq(snapbox::str![[r#"
 Found 1 changed file to absorb:
 
-Absorbed to commit: 1 a.txt
+Absorbed to commit: pxx a.txt
   (files locked to commit due to hunk range overlap)
     a.txt @1,4 +1,4
     a.txt @6,4 +6,4
@@ -172,7 +172,7 @@ fn uncommitted_hunk() {
         .stdout_eq(snapbox::str![[r#"
 Found 1 changed file to absorb:
 
-Absorbed to commit: 1 a.txt
+Absorbed to commit: pxx a.txt
   (files locked to commit due to hunk range overlap)
     a.txt @1,4 +1,4
 
@@ -372,14 +372,14 @@ fn committed_hunk() {
 ┊   nk M a.txt
 ┊
 ┊╭┄ g0 [A]
-┊●   1#0 partial change to a.txt 3
-┊│     1#0:n M a.txt
-┊●   1#1 partial change to a.txt 2
-┊│     1#1:n M a.txt
-┊●   1#2 partial change to a.txt 1
-┊│     1#2:n M a.txt
-┊●   1#3 a.txt
-┊│     1#3:n A a.txt
+┊●   sll partial change to a.txt 3
+┊│     sll:n M a.txt
+┊●   sol partial change to a.txt 2
+┊│     sol:n M a.txt
+┊●   rzm partial change to a.txt 1
+┊│     rzm:n M a.txt
+┊●   pxx a.txt
+┊│     pxx:n A a.txt
 ┊●   tpm add A
 ┊│     tpm:t A A
 ├╯
@@ -401,11 +401,11 @@ Hint: run `but diff` to see uncommitted changes and `but commit -b <branch> -m "
         .stdout_eq(snapbox::str![[r#"
 Found 1 changed file to absorb:
 
-Absorbed to commit: 1 partial change to a.txt 2
+Absorbed to commit: sol partial change to a.txt 2
   (files locked to commit due to hunk range overlap)
     a.txt @1,4 +1,4
 
-Absorbed to commit: 1 partial change to a.txt 3
+Absorbed to commit: sll partial change to a.txt 3
   (files locked to commit due to hunk range overlap)
     a.txt @6,4 +6,4
 
@@ -423,14 +423,14 @@ Hint: you can run `but undo` to undo these changes
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ g0 [A]
-┊●   1#0 partial change to a.txt 3
-┊│     1#0:n M a.txt
-┊●   1#1 partial change to a.txt 2
-┊│     1#1:n M a.txt
-┊●   1#2 partial change to a.txt 1
-┊│     1#2:n M a.txt
-┊●   1#3 a.txt
-┊│     1#3:n A a.txt
+┊●   sll partial change to a.txt 3
+┊│     sll:n M a.txt
+┊●   sol partial change to a.txt 2
+┊│     sol:n M a.txt
+┊●   rzm partial change to a.txt 1
+┊│     rzm:n M a.txt
+┊●   pxx a.txt
+┊│     pxx:n A a.txt
 ┊●   tpm add A
 ┊│     tpm:t A A
 ├╯
@@ -532,7 +532,7 @@ fn dry_run_shows_plan_without_changes() {
         .stdout_eq(snapbox::str![[r#"
 Found 1 changed file to absorb:
 
-Absorbed to commit: 1 a.txt
+Absorbed to commit: pxx a.txt
   (files locked to commit due to hunk range overlap)
     a.txt @1,4 +1,4
     a.txt @6,4 +6,4

--- a/crates/but/tests/but/command/amend.rs
+++ b/crates/but/tests/but/command/amend.rs
@@ -74,7 +74,7 @@ fn amend_rejects_dependency_changes() {
         .stderr_eq(str![[r#"
 Error: Cannot amend: 1 change could not be applied:
   first
-    line 1 depends on foo (1)
+    line 1 depends on foo (xsz)
 
 Hint: to apply these changes, stack bar on top of foo and try again — commits already on the branch move with it:
   but move bar --above foo

--- a/crates/but/tests/but/command/branch/new.rs
+++ b/crates/but/tests/but/command/branch/new.rs
@@ -378,7 +378,7 @@ Created branch 'middle'
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ mi [middle]
-┊●   1 on middle (no changes)
+┊●   lsm on middle (no changes)
 ├╯
 ┊
 ┴ b1540e5 (common base) 2000-01-02 M
@@ -407,10 +407,10 @@ Created branch 'top' above branch 'middle'
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ to [top]
-┊●   1#0 on top (no changes)
+┊●   qzl on top (no changes)
 ┊│
 ┊├┄ mi [middle]
-┊●   1#1 on middle (no changes)
+┊●   lsm on middle (no changes)
 ├╯
 ┊
 ┴ b1540e5 (common base) 2000-01-02 M
@@ -422,8 +422,8 @@ Hint: run `but help` for all commands
     snapbox::assert_data_eq!(
         env.git_log(),
         snapbox::str![[r#"
-* 278079d (HEAD -> top) on top
-* 8e3d31a (middle) on middle
+* 426ad51 (HEAD -> top) on top
+* 8b08d79 (middle) on middle
 * b1540e5 (origin/main, origin/HEAD, main, gitbutler/target) M
 * e31e6ca add init
 
@@ -446,10 +446,10 @@ Created branch 'bottom' below branch 'middle'
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ to [top]
-┊●   1#0 on top (no changes)
+┊●   qzl on top (no changes)
 ┊│
 ┊├┄ mi [middle]
-┊●   1#1 on middle (no changes)
+┊●   lsm on middle (no changes)
 ┊│
 ┊├┄ bo [bottom] (no commits)
 ├╯
@@ -472,13 +472,13 @@ Hint: run `but help` for all commands
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ to [top]
-┊●   1#0 on top (no changes)
+┊●   qzl on top (no changes)
 ┊│
 ┊├┄ mi [middle]
-┊●   1#1 on middle (no changes)
+┊●   l#0 on middle (no changes)
 ┊│
 ┊├┄ bo [bottom]
-┊●   1#2 on bottom (no changes)
+┊●   l#1 on bottom (no changes)
 ├╯
 ┊
 ┴ b1540e5 (common base) 2000-01-02 M
@@ -507,16 +507,16 @@ Created branch 'between-middle-and-top' above branch 'middle'
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ to [top]
-┊●   1#0 on top (no changes)
+┊●   qzl on top (no changes)
 ┊│
 ┊├┄ et [between-middle-and-top]
-┊●   1#1 on between-middle-and-top (no changes)
+┊●   pky on between-middle-and-top (no changes)
 ┊│
 ┊├┄ mi [middle]
-┊●   1#2 on middle (no changes)
+┊●   l#0 on middle (no changes)
 ┊│
 ┊├┄ bo [bottom]
-┊●   1#3 on bottom (no changes)
+┊●   l#1 on bottom (no changes)
 ├╯
 ┊
 ┴ b1540e5 (common base) 2000-01-02 M
@@ -528,10 +528,10 @@ Hint: run `but help` for all commands
     snapbox::assert_data_eq!(
         env.git_log(),
         snapbox::str![[r#"
-* a54744f (HEAD -> top) on top
-* 8406d60 (between-middle-and-top) on between-middle-and-top
-* 5614135 (middle) on middle
-* 9133168 (bottom) on bottom
+* 36d9d21 (HEAD -> top) on top
+* 0daea9a (between-middle-and-top) on between-middle-and-top
+* 2596ebb (middle) on middle
+* ff665ad (bottom) on bottom
 * b1540e5 (origin/main, origin/HEAD, main, gitbutler/target) M
 * e31e6ca add init
 
@@ -677,7 +677,7 @@ fn create_branch_above_non_empty_branch() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ bo [bottom]
-┊●   1 (no commit message) (no changes)
+┊●   tqv (no commit message) (no changes)
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -700,7 +700,7 @@ Created branch 'top' above branch 'bottom'
 ┊╭┄ to [top] (no commits)
 ┊│
 ┊├┄ bo [bottom]
-┊●   1 (no commit message) (no changes)
+┊●   tqv (no commit message) (no changes)
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -787,7 +787,7 @@ fn create_branch_below_non_empty_branch() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ to [top]
-┊●   1 (no commit message) (no changes)
+┊●   tqv (no commit message) (no changes)
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -808,7 +808,7 @@ Created branch 'bottom' below branch 'top'
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ to [top]
-┊●   1 (no commit message) (no changes)
+┊●   tqv (no commit message) (no changes)
 ┊│
 ┊├┄ bo [bottom] (no commits)
 ├╯
@@ -833,9 +833,9 @@ fn create_branch_above_commit() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ my [my-branch]
-┊●   1#0 top (no changes)
-┊●   1#1 middle (no changes)
-┊●   1#2 bottom (no changes)
+┊●   zou top (no changes)
+┊●   uxw middle (no changes)
+┊●   tqv bottom (no changes)
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -844,11 +844,11 @@ Hint: run `but help` for all commands
 
 "#]]);
 
-    env.but("branch new --above 1#1")
+    env.but("branch new --above uxw")
         .assert()
         .success()
         .stdout_eq(str![[r#"
-Created branch 'a-branch-1' above commit 1
+Created branch 'a-branch-1' above commit uxw
 
 "#]]);
 
@@ -856,11 +856,11 @@ Created branch 'a-branch-1' above commit 1
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ my [my-branch]
-┊●   1#0 top (no changes)
+┊●   zou top (no changes)
 ┊│
 ┊├┄ br [a-branch-1]
-┊●   1#1 middle (no changes)
-┊●   1#2 bottom (no changes)
+┊●   uxw middle (no changes)
+┊●   tqv bottom (no changes)
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -869,11 +869,11 @@ Hint: run `but help` for all commands
 
 "#]]);
 
-    env.but("branch new --above 1#0")
+    env.but("branch new --above zou")
         .assert()
         .success()
         .stdout_eq(str![[r#"
-Created branch 'a-branch-2' above commit 1
+Created branch 'a-branch-2' above commit zou
 
 "#]]);
 
@@ -883,11 +883,11 @@ Created branch 'a-branch-2' above commit 1
 ┊╭┄ my [my-branch] (no commits)
 ┊│
 ┊├┄ br [a-branch-2]
-┊●   1#0 top (no changes)
+┊●   zou top (no changes)
 ┊│
 ┊├┄ ra [a-branch-1]
-┊●   1#1 middle (no changes)
-┊●   1#2 bottom (no changes)
+┊●   uxw middle (no changes)
+┊●   tqv bottom (no changes)
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -910,9 +910,9 @@ fn create_branch_below_commit() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ my [my-branch]
-┊●   1#0 top (no changes)
-┊●   1#1 middle (no changes)
-┊●   1#2 bottom (no changes)
+┊●   zou top (no changes)
+┊●   uxw middle (no changes)
+┊●   tqv bottom (no changes)
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -921,11 +921,11 @@ Hint: run `but help` for all commands
 
 "#]]);
 
-    env.but("branch new --below 1#1")
+    env.but("branch new --below uxw")
         .assert()
         .success()
         .stdout_eq(str![[r#"
-Created branch 'a-branch-1' below commit 1
+Created branch 'a-branch-1' below commit uxw
 
 "#]]);
 
@@ -933,11 +933,11 @@ Created branch 'a-branch-1' below commit 1
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ my [my-branch]
-┊●   1#0 top (no changes)
-┊●   1#1 middle (no changes)
+┊●   zou top (no changes)
+┊●   uxw middle (no changes)
 ┊│
 ┊├┄ br [a-branch-1]
-┊●   1#2 bottom (no changes)
+┊●   tqv bottom (no changes)
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -946,11 +946,11 @@ Hint: run `but help` for all commands
 
 "#]]);
 
-    env.but("branch new --below 1#2")
+    env.but("branch new --below tqv")
         .assert()
         .success()
         .stdout_eq(str![[r#"
-Created branch 'a-branch-2' below commit 1
+Created branch 'a-branch-2' below commit tqv
 
 "#]]);
 
@@ -958,11 +958,11 @@ Created branch 'a-branch-2' below commit 1
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ my [my-branch]
-┊●   1#0 top (no changes)
-┊●   1#1 middle (no changes)
+┊●   zou top (no changes)
+┊●   uxw middle (no changes)
 ┊│
 ┊├┄ br [a-branch-1]
-┊●   1#2 bottom (no changes)
+┊●   tqv bottom (no changes)
 ┊│
 ┊├┄ ra [a-branch-2] (no commits)
 ├╯
@@ -1379,10 +1379,10 @@ fn in_single_branch_mode_switching_to_stacked_branches_with_commits_works() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ mi [middle]
-┊●   1#0 on middle (no changes)
+┊●   ylm on middle (no changes)
 ┊│
 ┊├┄ bo [bottom]
-┊●   1#1 on bottom (no changes)
+┊●   lsm on bottom (no changes)
 ├╯
 ┊
 ┴ b1540e5 (common base) 2000-01-02 M
@@ -1394,8 +1394,8 @@ Hint: run `but help` for all commands
     snapbox::assert_data_eq!(
         env.git_log(),
         snapbox::str![[r#"
-* 5614135 (HEAD -> middle) on middle
-* 9133168 (bottom) on bottom
+* c5ca33e (HEAD -> middle) on middle
+* ff665ad (bottom) on bottom
 * b1540e5 (origin/main, origin/HEAD, main, gitbutler/target) M
 * e31e6ca add init
 
@@ -1408,7 +1408,7 @@ Hint: run `but help` for all commands
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ bo [bottom]
-┊●   1 on bottom (no changes)
+┊●   lsm on bottom (no changes)
 ├╯
 ┊
 ┴ b1540e5 (common base) 2000-01-02 M
@@ -1420,8 +1420,8 @@ Hint: run `but help` for all commands
     snapbox::assert_data_eq!(
         env.git_log(),
         snapbox::str![[r#"
-* 5614135 (middle) on middle
-* 9133168 (HEAD -> bottom) on bottom
+* c5ca33e (middle) on middle
+* ff665ad (HEAD -> bottom) on bottom
 * b1540e5 (origin/main, origin/HEAD, main, gitbutler/target) M
 * e31e6ca add init
 
@@ -1438,11 +1438,11 @@ Hint: run `but help` for all commands
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ ne [new-branch]
-┊●   1#0 on new-branch (no changes)
+┊●   l#0 on new-branch (no changes)
 ├╯
 ┊
 ┊╭┄ bo [bottom]
-┊●   1#1 on bottom (no changes)
+┊●   l#1 on bottom (no changes)
 ├╯
 ┊
 ┴ b1540e5 (common base) 2000-01-02 M
@@ -1454,12 +1454,12 @@ Hint: run `but help` for all commands
     snapbox::assert_data_eq!(
         env.git_log(),
         snapbox::str![[r#"
-*   ca16105 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+*   4fe5ec0 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
 |/  
-* | f6cc4a5 (new-branch) on new-branch
-| | * 5614135 (middle) on middle
+* | 1c8b0db (new-branch) on new-branch
+| | * c5ca33e (middle) on middle
 | |/  
-| * 9133168 (bottom) on bottom
+| * ff665ad (bottom) on bottom
 |/  
 * b1540e5 (origin/main, origin/HEAD, main, gitbutler/target) M
 * e31e6ca add init
@@ -1530,7 +1530,7 @@ fn in_single_branch_mode_creating_and_switching_to_new_branches_with_commits() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ on [one]
-┊●   1 on one (no changes)
+┊●   lsm on one (no changes)
 ├╯
 ┊
 ┴ b1540e5 (common base) 2000-01-02 M
@@ -1542,7 +1542,7 @@ Hint: run `but help` for all commands
     snapbox::assert_data_eq!(
         env.git_log(),
         snapbox::str![[r#"
-* 10cdc18 (HEAD -> one) on one
+* 26559e2 (HEAD -> one) on one
 * b1540e5 (origin/main, origin/HEAD, main, gitbutler/target) M
 * e31e6ca add init
 
@@ -1566,7 +1566,7 @@ Hint: run `but help` for all commands
     snapbox::assert_data_eq!(
         env.git_log(),
         snapbox::str![[r#"
-* 10cdc18 (one) on one
+* 26559e2 (one) on one
 * b1540e5 (HEAD -> two, origin/main, origin/HEAD, main, gitbutler/target) M
 * e31e6ca add init
 

--- a/crates/but/tests/but/command/branch/update.rs
+++ b/crates/but/tests/but/command/branch/update.rs
@@ -329,7 +329,7 @@ fn integrate_merge_dry_run_marks_conflicted_preview_commits() {
 Preview
 
 * A
-● __ ec97e2f Merge dbf2a866824eab2a4c485b30bcfba70af8502900 into previous commit {conflicted}
+● uk d1f9d65 Merge dbf2a866824eab2a4c485b30bcfba70af8502900 into previous commit {conflicted}
 ● __ 57ca948 local change in A
 o 6a997fd
 
@@ -422,9 +422,9 @@ EOF
     snapbox::assert_data_eq!(
         env.git_log(),
         snapbox::str![[r#"
-*   9e0c28c (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+*   646aabb (HEAD -> gitbutler/workspace) GitButler Workspace Commit
 |\  
-| *   30a8d17 (A) Merge 28baf9a2794d7722ceff84f2967b5186545b8a48 into previous commit
+| *   d1f1cff (A) Merge 28baf9a2794d7722ceff84f2967b5186545b8a48 into previous commit
 | |\  
 | | * 28baf9a (origin/A) add only-on-remote
 | |/  

--- a/crates/but/tests/but/command/commit.rs
+++ b/crates/but/tests/but/command/commit.rs
@@ -77,7 +77,7 @@ Hint: run `but diff` to see uncommitted changes and `but commit -b <branch> -m "
     .success()
     .stderr_eq(snapbox::str![])
     .stdout_eq(snapbox::str![[r#"
-Created commit 1 on new branch 'feature'
+Created commit wpv on new branch 'feature'
 
 "#]]);
 
@@ -89,8 +89,8 @@ Created commit 1 on new branch 'feature'
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ at [feature]
-┊●   1 add ad-hoc file
-┊│     1:x A ad-hoc.txt
+┊●   wpv add ad-hoc file
+┊│     wpv:x A ad-hoc.txt
 ┊│
 ┊├┄ ma [main]
 ┊●   nmy M (no changes)
@@ -158,7 +158,7 @@ Hint: run `but diff` to see uncommitted changes and `but commit -b <branch> -m "
         .success()
         .stderr_eq(snapbox::str![])
         .stdout_eq(snapbox::str![[r#"
-Created commit 1 on branch 'main'
+Created commit woz on branch 'main'
 
 "#]]);
 
@@ -170,7 +170,7 @@ Created commit 1 on branch 'main'
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ ma [main]
-┊●   1 commit on main
+┊●   woz commit on main
 ┊●   nmy M (no changes)
 ├╯
 ┊
@@ -226,10 +226,10 @@ fn commits_at_each_branch_in_an_existing_single_branch_stack() {
 ┊   tk A bottom.txt
 ┊
 ┊╭┄ to [top]
-┊●   1#0 top base (no changes)
+┊●   tzq top base (no changes)
 ┊│
 ┊├┄ mi [middle]
-┊●   1#1 middle base (no changes)
+┊●   lsm middle base (no changes)
 ┊│
 ┊├┄ ma [main]
 ┊●   nmy M (no changes)
@@ -261,15 +261,15 @@ Hint: run `but diff` to see uncommitted changes and `but commit -b <branch> -m "
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ to [top]
-┊●   1#0 top position
-┊●   1#1 top base (no changes)
+┊●   tun top position
+┊●   tzq top base (no changes)
 ┊│
 ┊├┄ mi [middle]
-┊●   1#2 middle position
-┊●   1#3 middle base (no changes)
+┊●   swr middle position
+┊●   lsm middle base (no changes)
 ┊│
 ┊├┄ ma [main]
-┊●   1#4 bottom position
+┊●   rtw bottom position
 ┊●   nmy M (no changes)
 ├╯
 ┊
@@ -322,7 +322,7 @@ fn commits_on_top_of_a_checked_out_managed_workspace_branch() {
         .success()
         .stderr_eq(snapbox::str![])
         .stdout_eq(snapbox::str![[r#"
-Created commit 1 on new branch 'feature'
+Created commit umu on new branch 'feature'
 
 "#]]);
 
@@ -351,7 +351,7 @@ fn no_message_nothing_to_commit() {
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Created commit 1 on branch 'A'
+Created commit orn on branch 'A'
 
 "#]]);
 
@@ -362,7 +362,7 @@ Created commit 1 on branch 'A'
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ g0 [A]
-┊●   1 (no commit message) (no changes)
+┊●   orn (no commit message) (no changes)
 ┊●   tpm add A
 ├╯
 ┊
@@ -384,7 +384,7 @@ fn no_args_single_head_no_message_human_output() {
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Created commit 1 on branch 'A'
+Created commit ssv on branch 'A'
 
 "#]]);
 
@@ -395,7 +395,7 @@ Created commit 1 on branch 'A'
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ g0 [A]
-┊●   1 (no commit message)
+┊●   ssv (no commit message)
 ┊●   tpm add A
 ├╯
 ┊
@@ -476,8 +476,8 @@ fn agent_commit_json_uses_native_result_without_status_by_default() {
         .success()
         .stdout_eq(snapbox::str![[r#"
 {
-  "commitId": "7bbfdca68284535242b93595db5f6a5bc885a124",
-  "changeId": "1"
+  "commitId": "ad3beae727eb9f82f063c32ccff084d97ad0fd5e",
+  "changeId": "ssvtnomvyusxrxwspzwsqkssnkmsnylz"
 }
 
 "#]]);
@@ -495,8 +495,8 @@ fn non_agent_commit_json_uses_native_result() {
         .success()
         .stdout_eq(snapbox::str![[r#"
 {
-  "commitId": "7bbfdca68284535242b93595db5f6a5bc885a124",
-  "changeId": "1"
+  "commitId": "ad3beae727eb9f82f063c32ccff084d97ad0fd5e",
+  "changeId": "ssvtnomvyusxrxwspzwsqkssnkmsnylz"
 }
 
 "#]]);
@@ -526,7 +526,7 @@ fn no_args_single_head_message_from_editor() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ g0 [A]
-┊●   1 commit from editor
+┊●   yqu commit from editor
 ┊●   tpm add A
 ├╯
 ┊
@@ -553,7 +553,7 @@ fn single_head_with_message() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ g0 [A]
-┊●   1 add file.txt
+┊●   ssv add file.txt
 ┊●   tpm add A
 ├╯
 ┊
@@ -582,7 +582,7 @@ fn can_repeat_message() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ g0 [A]
-┊● 1 author 2000-01-01 00:00:00 +0000 (sha b141567)
+┊● ssv author 2000-01-01 00:00:00 +0000 (sha 7d7d2c3)
 ┊│     add file.txt  with more  text lines
 ┊● tpm author 2000-01-01 00:00:00 +0000 (sha 9477ae7)
 ┊│     add A 
@@ -594,12 +594,12 @@ Hint: run `but help` for all commands
 
 "#]]);
 
-    env.but("show 1")
+    env.but("show ssv")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Commit:    b14156794f81a138bd06c2a5287fd5db15408b56
-Change-ID: 1
+Commit:    7d7d2c3983374b1e495bcd9c01693c2aa5452592
+Change-ID: ssvtnomvyusxrxwspzwsqkssnkmsnylz
 Author:    author <author@example.com>
 Date:      2000-01-02 00:00:00 +0000 (26y ago)
 Committer: committer <committer@example.com>
@@ -639,7 +639,7 @@ fn editor_user_writes_no_message() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ g0 [A]
-┊●   1 (no commit message)
+┊●   pvt (no commit message)
 ┊●   tpm add A
 ├╯
 ┊
@@ -688,7 +688,7 @@ fn create_commit_on_new_branch() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1 (no commit message)
+┊●   ssn (no commit message)
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -714,7 +714,7 @@ fn create_commit_on_user_provided_branch() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ fi [file]
-┊●   1 add first
+┊●   xsz add first
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -734,8 +734,8 @@ Hint: run `but help` for all commands
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ fi [file]
-┊●   1#0 add second
-┊●   1#1 add first
+┊●   pzu add second
+┊●   xsz add first
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -755,12 +755,12 @@ Hint: run `but help` for all commands
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ ot [other]
-┊●   1#0 add third
+┊●   xlz add third
 ├╯
 ┊
 ┊╭┄ fi [file]
-┊●   1#1 add second
-┊●   1#2 add first
+┊●   pzu add second
+┊●   xsz add first
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -782,13 +782,13 @@ Hint: run `but help` for all commands
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ ot [other]
-┊●   1#0 add fourth
-┊●   1#1 add third
+┊●   ruw add fourth
+┊●   xlz add third
 ├╯
 ┊
 ┊╭┄ fi [file]
-┊●   1#2 add second
-┊●   1#3 add first
+┊●   pzu add second
+┊●   xsz add first
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -814,7 +814,7 @@ fn create_commit_on_new_branch_with_canned_name() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1 add file.txt
+┊●   ssn add file.txt
 ├╯
 ┊
 ┊╭┄ g0 [A]
@@ -865,7 +865,7 @@ fn bails_on_rejected_specs() {
         .stderr_eq(snapbox::str![[r#"
 Error: Cannot commit: 1 change could not be applied:
   first
-    line 1 depends on foo (1)
+    line 1 depends on foo (xsz)
 
 Hint: to apply these changes, create bar stacked on top of foo and try again:
   but branch new bar --anchor foo
@@ -885,8 +885,8 @@ fn newly_created_branches_are_included_in_json_output() {
         .success()
         .stdout_eq(snapbox::str![[r#"
 {
-  "commitId": "5a6fc56305c69edc974a5ed2d100c525db8fd288",
-  "changeId": "1",
+  "commitId": "8c943b731b5fd0ef35713335f5bf3eefd72438b7",
+  "changeId": "xszxqqqtxkpszmvzupomruxpmqspsplz",
   "branch": "foo"
 }
 
@@ -914,7 +914,7 @@ fn empty_flag_to_force_empty_commit_when_changes_exist() {
 ┊   vq A changes
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1 empty commit despite changes in worktree (no changes)
+┊●   tqv empty commit despite changes in worktree (no changes)
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -976,7 +976,7 @@ Hint: run `but help` for all commands
 ┊
 ┊╭┄ g0 [A]
 ┊●   ywx add second
-┊●   1 (no commit message) (no changes)
+┊●   wmr (no commit message) (no changes)
 ┊●   zll add first
 ├╯
 ┊
@@ -1022,7 +1022,7 @@ Hint: run `but help` for all commands
 ┊╭┄ g0 [A]
 ┊●   ywx add second
 ┊●   zll add first
-┊●   1 (no commit message) (no changes)
+┊●   vlt (no commit message) (no changes)
 ├╯
 ┊
 ┴ 1bbc04b (common base) 2000-01-02 add Base
@@ -1069,7 +1069,7 @@ Hint: run `but diff` to see uncommitted changes and `but commit -b <branch> -m "
 ┊
 ┊╭┄ g0 [A]
 ┊●   ywx add second
-┊●   1 add file.txt
+┊●   nzt add file.txt
 ┊●   zll add first
 ├╯
 ┊
@@ -1115,7 +1115,7 @@ Hint: run `but diff` to see uncommitted changes and `but commit -b <branch> -m "
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1 add file.txt
+┊●   zwq add file.txt
 ┊│
 ┊├┄ g0 [A]
 ┊●   tpm add A
@@ -1166,7 +1166,7 @@ Hint: run `but diff` to see uncommitted changes and `but commit -b <branch> -m "
 ┊╭┄ g0 [A]
 ┊●   ywx add second
 ┊●   zll add first
-┊●   1 add file.txt
+┊●   xkx add file.txt
 ├╯
 ┊
 ┴ 1bbc04b (common base) 2000-01-02 add Base
@@ -1214,7 +1214,7 @@ Hint: run `but diff` to see uncommitted changes and `but commit -b <branch> -m "
 ┊●   tpm add A
 ┊│
 ┊├┄ br [a-branch-1]
-┊●   1 add file.txt
+┊●   xvw add file.txt
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -1264,7 +1264,7 @@ Hint: run `but diff` to see uncommitted changes and `but commit -b <branch> -m "
 ┊●   zll add first
 ┊│
 ┊├┄ br [a-branch-1]
-┊●   1 add file.txt
+┊●   xkx add file.txt
 ├╯
 ┊
 ┴ 1bbc04b (common base) 2000-01-02 add Base
@@ -1522,8 +1522,8 @@ Hint: run `but diff` to see uncommitted changes and `but commit -b <branch> -m "
 ┊   twop A two
 ┊
 ┊╭┄ g0 [A]
-┊●   1 (no commit message)
-┊│     1:k A one
+┊●   sor (no commit message)
+┊│     sor:k A one
 ┊●   tpm add A
 ┊│     tpm:t A A
 ├╯
@@ -1585,10 +1585,10 @@ fn hunks_within_file_are_not_order_dependent() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ g0 [A]
-┊●   1#0 (no commit message)
-┊│     1#0:q M file
-┊●   1#1 (no commit message)
-┊│     1#1:q A file
+┊●   tnw (no commit message)
+┊│     tnw:q M file
+┊●   nrl (no commit message)
+┊│     nrl:q A file
 ┊●   tpm add A
 ┊│     tpm:t A A
 ├╯
@@ -1610,10 +1610,10 @@ Hint: run `but help` for all commands
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ g0 [A]
-┊●   1#0 (no commit message)
-┊│     1#0:q M file
-┊●   1#1 (no commit message)
-┊│     1#1:q A file
+┊●   tnw (no commit message)
+┊│     tnw:q M file
+┊●   nrl (no commit message)
+┊│     nrl:q A file
 ┊●   tpm add A
 ┊│     tpm:t A A
 ├╯
@@ -1677,10 +1677,10 @@ fn overlapping_changes_to_modified_file_are_deduplicated() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ g0 [A]
-┊●   1#0 (no commit message)
-┊│     1#0:q M file
-┊●   1#1 (no commit message)
-┊│     1#1:q A file
+┊●   tnw (no commit message)
+┊│     tnw:q M file
+┊●   nrl (no commit message)
+┊│     nrl:q A file
 ┊●   tpm add A
 ┊│     tpm:t A A
 ├╯
@@ -1702,10 +1702,10 @@ Hint: run `but help` for all commands
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ g0 [A]
-┊●   1#0 (no commit message)
-┊│     1#0:q M file
-┊●   1#1 (no commit message)
-┊│     1#1:q A file
+┊●   tnw (no commit message)
+┊│     tnw:q M file
+┊●   nrl (no commit message)
+┊│     nrl:q A file
 ┊●   tpm add A
 ┊│     tpm:t A A
 ├╯
@@ -1783,9 +1783,9 @@ Hint: run `but diff` to see uncommitted changes and `but commit -b <branch> -m "
 ┊   om A path/other/to/third.txt
 ┊
 ┊╭┄ g0 [A]
-┊●   1 (no commit message)
-┊│     1:m A path/to/first.txt
-┊│     1:r A path/to/second.txt
+┊●   vnz (no commit message)
+┊│     vnz:m A path/to/first.txt
+┊│     vnz:r A path/to/second.txt
 ┊●   tpm add A
 ┊│     tpm:t A A
 ├╯
@@ -1825,10 +1825,10 @@ fn path_prefix_with_mix_of_modifications() {
 ┊   xv M dir/to_modify.txt
 ┊
 ┊╭┄ g0 [A]
-┊●   1 (no commit message)
-┊│     1:l A dir/to_delete.txt
-┊│     1:n A dir/to_empty.txt
-┊│     1:x A dir/to_modify.txt
+┊●   oxm (no commit message)
+┊│     oxm:l A dir/to_delete.txt
+┊│     oxm:n A dir/to_empty.txt
+┊│     oxm:x A dir/to_modify.txt
 ┊●   tpm add A
 ┊│     tpm:t A A
 ├╯
@@ -1848,14 +1848,14 @@ Hint: run `but diff` to see uncommitted changes and `but commit -b <branch> -m "
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ g0 [A]
-┊●   1#0 (no commit message)
-┊│     1#0:l D dir/to_delete.txt
-┊│     1#0:n M dir/to_empty.txt
-┊│     1#0:x M dir/to_modify.txt
-┊●   1#1 (no commit message)
-┊│     1#1:l A dir/to_delete.txt
-┊│     1#1:n A dir/to_empty.txt
-┊│     1#1:x A dir/to_modify.txt
+┊●   wkl (no commit message)
+┊│     wkl:l D dir/to_delete.txt
+┊│     wkl:n M dir/to_empty.txt
+┊│     wkl:x M dir/to_modify.txt
+┊●   oxm (no commit message)
+┊│     oxm:l A dir/to_delete.txt
+┊│     oxm:n A dir/to_empty.txt
+┊│     oxm:x A dir/to_modify.txt
 ┊●   tpm add A
 ┊│     tpm:t A A
 ├╯
@@ -1866,29 +1866,29 @@ Hint: run `but help` for all commands
 
 "#]]);
 
-    env.but("diff 1#0")
+    env.but("diff wkl")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-───────────────────────────╮
- 1#0:l:e dir/to_delete.txt │
-───────────────────────────╯
+─────────────────────────╮
+ w:l:e dir/to_delete.txt │
+─────────────────────────╯
 
 @@ -1,1 +1,0 @@
 ───────────────
 1 ┊   │ -second
 
-──────────────────────────╮
- 1#0:n:e dir/to_empty.txt │
-──────────────────────────╯
+────────────────────────╮
+ w:n:e dir/to_empty.txt │
+────────────────────────╯
 
 @@ -1,1 +1,0 @@
 ───────────────
 1 ┊   │ -third
 
-───────────────────────────╮
- 1#0:x:3 dir/to_modify.txt │
-───────────────────────────╯
+─────────────────────────╮
+ w:x:3 dir/to_modify.txt │
+─────────────────────────╯
 
 @@ -1,1 +1,2 @@
 ───────────────
@@ -1933,7 +1933,7 @@ fn committing_above_an_empty_branch() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1 add one
+┊●   onv add one
 ┊│
 ┊├┄ to [top] (no commits)
 ├╯
@@ -1967,7 +1967,7 @@ fn committing_below_empty_branch_with_empty_branch_below() {
 ┊╭┄ to [top] (no commits)
 ┊│
 ┊├┄ br [a-branch-1]
-┊●   1 add one
+┊●   onv add one
 ┊│
 ┊├┄ mi [middle] (no commits)
 ├╯
@@ -2009,10 +2009,10 @@ fn committing_below_non_top_empty_branch() {
 ┊├┄ mi [middle] (no commits)
 ┊│
 ┊├┄ br [a-branch-1]
-┊●   1#0 add two
+┊●   tpm add two
 ┊│
 ┊├┄ bo [bottom]
-┊●   1#1 add one
+┊●   onv add one
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -2063,7 +2063,7 @@ Hint: run `but diff` to see uncommitted changes and `but commit -b <branch> -m "
 ┊╭┄ to [top] (no commits)
 ┊│
 ┊├┄ br [a-branch-1]
-┊●   1 add one
+┊●   onv add one
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -2087,10 +2087,10 @@ Hint: run `but diff` to see uncommitted changes and `but commit -b <branch> -m "
 ┊╭┄ to [top] (no commits)
 ┊│
 ┊├┄ br [a-branch-1]
-┊●   1#0 add two
+┊●   tpm add two
 ┊│
 ┊├┄ bo [bottom]
-┊●   1#1 add one
+┊●   onv add one
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -2128,7 +2128,7 @@ fn commit_to_existing_branch_via_short_code() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ g0 [A]
-┊●   1 new commit (no changes)
+┊●   orn new commit (no changes)
 ┊●   tpm add A
 ├╯
 ┊
@@ -2155,7 +2155,7 @@ fn commit_to_new_branch_with_same_name_as_file() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ fi [file]
-┊●   1 add file
+┊●   lys add file
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -2196,8 +2196,8 @@ fn can_overspecify_hunk_id() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1 Add file
-┊│     1:q A file
+┊●   lkv Add file
+┊│     lkv:q A file
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -2336,7 +2336,7 @@ fn new_branches_are_created_on_top() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1 (no commit message) (no changes)
+┊●   tqv (no commit message) (no changes)
 ├╯
 ┊
 ┊╭┄ g0 [A]
@@ -2367,9 +2367,9 @@ fn committing_modified_and_renamed_file() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1 add files
-┊│     1:q A file
-┊│     1:k A file-2
+┊●   ouv add files
+┊│     ouv:q A file
+┊│     ouv:k A file-2
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -2390,9 +2390,9 @@ Hint: run `but help` for all commands
 ┊   kw D file-2
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1 add files
-┊│     1:q A file
-┊│     1:k A file-2
+┊●   ouv add files
+┊│     ouv:q A file
+┊│     ouv:k A file-2
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -2410,12 +2410,12 @@ Hint: run `but diff` to see uncommitted changes and `but commit -b <branch> -m "
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1#0 change file
-┊│     1#0:q M file
-┊│     1#0:k D file-2
-┊●   1#1 add files
-┊│     1#1:q A file
-┊│     1#1:k A file-2
+┊●   kwv change file
+┊│     kwv:q M file
+┊│     kwv:k D file-2
+┊●   ouv add files
+┊│     ouv:q A file
+┊│     ouv:k A file-2
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -2458,7 +2458,7 @@ fn default_target_skips_merged_upstream_branch() {
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Created commit 1 on branch 'B'
+Created commit mst on branch 'B'
 
 "#]]);
 }
@@ -2476,7 +2476,7 @@ fn default_target_creates_new_branch_when_all_branches_merged_upstream() {
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Created commit 1 on new branch 'a-branch-1'
+Created commit zmn on new branch 'a-branch-1'
 
 "#]]);
 }
@@ -2527,7 +2527,7 @@ fn branch_flag_with_allow_merged_permits_merged_upstream_branch() {
         .success()
         .stderr_eq(snapbox::str![])
         .stdout_eq(snapbox::str![[r#"
-Created commit 1 on branch 'A'
+Created commit vty on branch 'A'
 
 "#]]);
 }
@@ -2548,7 +2548,7 @@ fn partially_integrated_stack_guards_only_the_landed_commit() {
         .success()
         .stderr_eq(snapbox::str![])
         .stdout_eq(snapbox::str![[r#"
-Created commit 1 on branch 'A'
+Created commit rox on branch 'A'
 
 "#]]);
 
@@ -2607,7 +2607,7 @@ fn retired_syntax_is_translated_and_hinted() {
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Created commit 1 on new branch 'my-branch'
+Created commit mrr on new branch 'my-branch'
 
 "#]])
         .stderr_eq(snapbox::str![[r#"
@@ -2629,7 +2629,7 @@ See `but commit --help` for details.
 ┊   or A three
 ┊
 ┊╭┄ my [my-branch]
-┊●   1 add one and two
+┊●   mrr add one and two
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -2776,7 +2776,7 @@ Hint: run `but help` for all commands
         .success()
         .stderr_eq(snapbox::str![])
         .stdout_eq(snapbox::str![[r#"
-Created commit 1 on branch 'A'
+Created commit lpo on branch 'A'
 
 "#]]);
 
@@ -2789,8 +2789,8 @@ Created commit 1 on branch 'A'
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ g0 [A]
-┊●   1 note from worktree
-┊│     1:u A note.txt
+┊●   lpo note from worktree
+┊│     lpo:u A note.txt
 ┊┊
 ┊┊╭┄ wt {wt-feature} (no changes)
 ┊├╯
@@ -2825,7 +2825,7 @@ fn commit_a_worktrees_whole_uncommitted_area() {
         .success()
         .stderr_eq(snapbox::str![])
         .stdout_eq(snapbox::str![[r#"
-Created commit 1 on branch 'B'
+Created commit ulz on branch 'B'
 
 "#]]);
 
@@ -2845,8 +2845,8 @@ Created commit 1 on branch 'B'
 ├╯
 ┊
 ┊╭┄ h0 [B]
-┊●   1 everything from the worktree
-┊│     1:u A note.txt
+┊●   ulz everything from the worktree
+┊│     ulz:u A note.txt
 ┊●   lrm add B
 ┊│     lrm:p A B
 ├╯
@@ -2895,7 +2895,7 @@ fn commit_the_uncommitted_area_by_id() {
         .success()
         .stderr_eq(snapbox::str![])
         .stdout_eq(snapbox::str![[r#"
-Created commit 1 on branch 'A'
+Created commit vvy on branch 'A'
 
 "#]]);
 
@@ -2908,9 +2908,9 @@ Created commit 1 on branch 'A'
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ g0 [A]
-┊●   1 everything at once
-┊│     1:z A one.txt
-┊│     1:p A two.txt
+┊●   vvy everything at once
+┊│     vvy:z A one.txt
+┊│     vvy:p A two.txt
 ┊●   tpm add A
 ┊│     tpm:t A A
 ├╯
@@ -2951,7 +2951,7 @@ fn commit_below_a_worktree_targets_its_branch_tip() {
         .success()
         .stderr_eq(snapbox::str![])
         .stdout_eq(snapbox::str![[r#"
-Created commit 1 on branch 'wt-inside'
+Created commit nuy on branch 'wt-inside'
 
 "#]]);
 
@@ -2962,7 +2962,7 @@ Created commit 1 on branch 'wt-inside'
 *   c128bce (HEAD -> gitbutler/workspace) GitButler Workspace Commit
 |/  
 * | d3e2ba3 (B) add B
-| | * f2ab70b (wt-inside) onto the worktree branch
+| | * efe5cc8 (wt-inside) onto the worktree branch
 | | * 580bef0 add W
 | |/  
 | * 9477ae7 (A) add A
@@ -3016,7 +3016,7 @@ fn commit_b_targets_a_worktree_by_id() {
         .success()
         .stderr_eq(snapbox::str![])
         .stdout_eq(snapbox::str![[r#"
-Created commit 1 on branch 'wt-inside'
+Created commit nuy on branch 'wt-inside'
 
 "#]]);
 }
@@ -3045,7 +3045,7 @@ fn commit_b_targets_a_worktrees_branch_by_name() {
         .success()
         .stderr_eq(snapbox::str![])
         .stdout_eq(snapbox::str![[r#"
-Created commit 1 on branch 'wt-branch'
+Created commit szp on branch 'wt-branch'
 
 "#]]);
 }
@@ -3067,7 +3067,7 @@ fn commit_from_a_worktree_defaults_to_its_own_branch() {
         .success()
         .stderr_eq(snapbox::str![])
         .stdout_eq(snapbox::str![[r#"
-Created commit 1 on branch 'wt-feature'
+Created commit vzp on branch 'wt-feature'
 
 "#]]);
 
@@ -3079,7 +3079,7 @@ Created commit 1 on branch 'wt-feature'
 *   c128bce (HEAD -> gitbutler/workspace) GitButler Workspace Commit
 |/  
 * | d3e2ba3 (B) add B
-| | * d7bdd3b (wt-feature) note from the worktree
+| | * 7551b20 (wt-feature) note from the worktree
 | | * 580bef0 add W
 | |/  
 | * 9477ae7 (A) add A
@@ -3099,8 +3099,8 @@ Created commit 1 on branch 'wt-feature'
 ┊╭┄ g0 [A]
 ┊┊
 ┊┊╭┄ wt {wt-feature} (no changes)
-┊┊●   1 note from the worktree
-┊┊│     1:u A note.txt
+┊┊●   vzp note from the worktree
+┊┊│     vzp:u A note.txt
 ┊┊●   nsn add W
 ┊┊│     nsn:m A wt-file.txt
 ┊├╯
@@ -3139,7 +3139,7 @@ fn commit_from_a_worktree_sharing_its_branch_tip_advances_only_the_worktree() {
         .success()
         .stderr_eq(snapbox::str![])
         .stdout_eq(snapbox::str![[r#"
-Created commit 1 on branch 'wt-feature'
+Created commit lpo on branch 'wt-feature'
 
 "#]]);
 
@@ -3151,7 +3151,7 @@ Created commit 1 on branch 'wt-feature'
 *   b963596 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
 |/  
 | * d3e2ba3 (B) add B
-| | * cc2a9bc (wt-feature) note from the worktree
+| | * 0a6784b (wt-feature) note from the worktree
 | |/  
 |/|   
 * | 9477ae7 (A) add A
@@ -3274,7 +3274,7 @@ fn committing_twice_to_checked_out_workspace_branch_in_single_branch_mode_keeps_
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ g0 [A]
-┊●   1 (no commit message) (no changes)
+┊●   orn (no commit message) (no changes)
 ┊●   tpm add A
 ├╯
 ┊
@@ -3295,8 +3295,8 @@ Hint: run `but help` for all commands
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ g0 [A]
-┊●   1#0 (no commit message) (no changes)
-┊●   1#1 (no commit message) (no changes)
+┊●   mwn (no commit message) (no changes)
+┊●   orn (no commit message) (no changes)
 ┊●   tpm add A
 ├╯
 ┊

--- a/crates/but/tests/but/command/diff.rs
+++ b/crates/but/tests/but/command/diff.rs
@@ -235,7 +235,7 @@ fn json_tree_change_statuses() {
     .unwrap();
     env.but("commit -b A -m status-target").assert().success();
 
-    env.but("diff --json 1#0")
+    env.but("diff --json A")
         .allow_json()
         .assert()
         .success()
@@ -264,18 +264,18 @@ fn textconv_output_is_rendered_in_diff() {
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Created commit 1 on new branch 'a-branch-1'
+Created commit xnw on new branch 'a-branch-1'
 
 "#]]);
 
     env.invoke_git("config --local diff.png.textconv od");
 
-    env.but("diff 1")
+    env.but("diff xnw")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
 ──────────────────────╮
- 1:x:2 .gitattributes │
+ x:x:2 .gitattributes │
 ──────────────────────╯
 
 @@ -1,0 +1,1 @@
@@ -283,7 +283,7 @@ Created commit 1 on new branch 'a-branch-1'
   ┊ 1 │ +*.png diff=png
 
 ──────────────╮
- 1:t file.png │
+ x:t file.png │
 ──────────────╯
 
 (diff generated from binary-to-text conversion)

--- a/crates/but/tests/but/command/diff.rs
+++ b/crates/but/tests/but/command/diff.rs
@@ -233,9 +233,15 @@ fn json_tree_change_statuses() {
         env.projects_root().join("renamed-after.txt"),
     )
     .unwrap();
-    env.but("commit -b A -m status-target").assert().success();
+    env.but("commit -b A -m status-target")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Created commit oul on branch 'A'
 
-    env.but("diff --json A")
+"#]]);
+
+    env.but("diff --json oul")
         .allow_json()
         .assert()
         .success()

--- a/crates/but/tests/but/command/discard.rs
+++ b/crates/but/tests/but/command/discard.rs
@@ -209,8 +209,8 @@ fn discard_rename_does_not_discard_unrelated_changes() {
 ┊   tz A src/keep-me.ts
 ┊
 ┊╭┄ g0 [A]
-┊●   1 seed rename source only
-┊│     1:l A src/rename-source-only.ts
+┊●   uwm seed rename source only
+┊│     uwm:l A src/rename-source-only.ts
 ┊●   tpm add A
 ┊│     tpm:t A A
 ├╯
@@ -271,8 +271,8 @@ fn discard_the_whole_uncommitted_changes() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ g0 [A]
-┊●   1 seed rename source only
-┊│     1:l A src/rename-source-only.ts
+┊●   uwm seed rename source only
+┊│     uwm:l A src/rename-source-only.ts
 ┊●   tpm add A
 ┊│     tpm:t A A
 ├╯
@@ -396,7 +396,7 @@ fn discard_resulting_in_workdir_ud_conflict() {
         .success()
         .stderr_eq("")
         .stdout_eq(snapbox::str![[r#"
-Discarded commit 1
+Discarded commit tvn
 
 ⚠ A conflict occurred during checkout. Run `but status` for more information.
 
@@ -458,7 +458,7 @@ fn discard_resulting_in_workdir_uu_conflict() {
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Discarded commit 1
+Discarded commit syk
 
 ⚠ A conflict occurred during checkout. Run `but status` for more information.
 
@@ -472,8 +472,8 @@ Discarded commit 1
 ┊    commit.txt {conflicted}
 ┊
 ┊╭┄ g0 [A]
-┊●   1 commit
-┊│     1:t A commit.txt
+┊●   pmw commit
+┊│     pmw:t A commit.txt
 ┊●   tpm add A
 ┊│     tpm:t A A
 ├╯
@@ -533,10 +533,10 @@ fn discard_multiple_commits_outputs_human() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ g0 [A]
-┊●   1#0 second discardable commit
-┊│     1#0:r A second-commit.txt
-┊●   1#1 first discardable commit
-┊│     1#1:m A first-commit.txt
+┊●   yqn second discardable commit
+┊│     yqn:r A second-commit.txt
+┊●   lmp first discardable commit
+┊│     lmp:m A first-commit.txt
 ┊●   tpm add A
 ┊│     tpm:t A A
 ├╯
@@ -551,7 +551,7 @@ Hint: run `but help` for all commands
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Discarded commits 1, 1
+Discarded commits lmp, yqn
 
 "#]]);
 
@@ -601,9 +601,9 @@ fn discard_committed_files_outputs_new_commit_in_json() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ g0 [A]
-┊●   1 files to selectively discard
-┊│     1:n A discarded-from-commit.txt
-┊│     1:x A retained-in-commit.txt
+┊●   toz files to selectively discard
+┊│     toz:n A discarded-from-commit.txt
+┊│     toz:x A retained-in-commit.txt
 ┊●   tpm add A
 ┊│     tpm:t A A
 ├╯
@@ -621,13 +621,13 @@ Hint: run `but help` for all commands
         .stdout_eq(snapbox::str![[r#"
 {
   "type": "committedChanges",
-  "sourceCommitId": "c61e0f8eb6e54760c5a265d93044bf29b7a5716a",
-  "sourceChangeId": "1",
+  "sourceCommitId": "7df37764a21d5510d4108ad82bfaf98bc926a1a8",
+  "sourceChangeId": "tozmluwlnkpxmqykupputuolovmvyprt",
   "paths": [
     "discarded-from-commit.txt"
   ],
-  "newCommitId": "372ab397ba61d3368a1a9e769f39af3997c4e1ad",
-  "newChangeId": "1"
+  "newCommitId": "ab57cd43e38112a1b44246daf6eb509f6097f5a4",
+  "newChangeId": "tozmluwlnkpxmqykupputuolovmvyprt"
 }
 
 "#]]);
@@ -639,8 +639,8 @@ Hint: run `but help` for all commands
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ g0 [A]
-┊●   1 files to selectively discard
-┊│     1:x A retained-in-commit.txt
+┊●   toz files to selectively discard
+┊│     toz:x A retained-in-commit.txt
 ┊●   tpm add A
 ┊│     tpm:t A A
 ├╯
@@ -717,8 +717,8 @@ Hint: Discard branches, commits, committed files, or uncommitted changes separat
 ┊   ln A uncommitted.txt
 ┊
 ┊╭┄ g0 [A]
-┊●   1 committed source
-┊│     1:z A committed.txt
+┊●   opq committed source
+┊│     opq:z A committed.txt
 ┊●   tpm add A
 ┊│     tpm:t A A
 ├╯
@@ -768,10 +768,10 @@ Hint: Discard committed files from each commit separately
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ g0 [A]
-┊●   1#0 second committed source
-┊│     1#0:q A second-committed.txt
-┊●   1#1 first committed source
-┊│     1#1:t A first-committed.txt
+┊●   lqq second committed source
+┊│     lqq:q A second-committed.txt
+┊●   ssw first committed source
+┊│     ssw:t A first-committed.txt
 ┊●   tpm add A
 ┊│     tpm:t A A
 ├╯
@@ -801,14 +801,15 @@ seven
 
     env.file("file.txt", format!("first\n{original_content}last\n"));
     env.but("commit -m 'Modify file'").assert().success();
+    let modified_commit = env.invoke_git("rev-parse refs/heads/a-branch-1");
 
-    env.but("diff 1#0")
+    env.but(format!("diff {modified_commit}"))
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-──────────────────╮
- 1#0:u:2 file.txt │
-──────────────────╯
+────────────────╮
+ x:u:2 file.txt │
+────────────────╯
 
 @@ -1,3 +1,4 @@
 ───────────────
@@ -817,9 +818,9 @@ seven
 2 ┊ 3 │  two
 3 ┊ 4 │  three
 
-──────────────────╮
- 1#0:u:e file.txt │
-──────────────────╯
+────────────────╮
+ x:u:e file.txt │
+────────────────╯
 
 @@ -5,3 +6,4 @@
 ───────────────
@@ -830,21 +831,22 @@ seven
 
 "#]]);
 
-    env.but("discard 1#0:u:2")
+    env.but(format!("discard {modified_commit}:u:2"))
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Discarded changes from file.txt from 1 to create 1
+Discarded changes from file.txt from xsw to create xsw
 
 "#]]);
 
-    env.but("diff 1#0")
+    let rewritten_commit = env.invoke_git("rev-parse refs/heads/a-branch-1");
+    env.but(format!("diff {rewritten_commit}"))
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-──────────────────╮
- 1#0:u:e file.txt │
-──────────────────╯
+────────────────╮
+ x:u:e file.txt │
+────────────────╯
 
 @@ -5,3 +5,4 @@
 ───────────────
@@ -863,13 +865,14 @@ fn discard_single_committed_hunk_in_deleted_file_discards_deletion() {
 
     env.remove_file("A");
     env.but("commit -m 'Delete file'").assert().success();
+    let delete_commit = env.invoke_git("rev-parse refs/heads/A");
 
-    env.but("diff 1")
+    env.but(format!("diff {delete_commit}"))
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
 ─────────╮
- 1:t:a A │
+ s:t:a A │
 ─────────╯
 
 @@ -1,1 +1,0 @@
@@ -878,11 +881,11 @@ fn discard_single_committed_hunk_in_deleted_file_discards_deletion() {
 
 "#]]);
 
-    env.but("discard 1:t:a")
+    env.but(format!("discard {delete_commit}:t:a"))
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Discarded changes from A from 1 to create 1
+Discarded changes from A from sum to create sum
 
 "#]]);
 
@@ -894,7 +897,7 @@ Discarded changes from A from 1 to create 1
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ g0 [A]
-┊●   1 Delete file (no changes)
+┊●   sum Delete file (no changes)
 ┊●   tpm add A
 ┊│     tpm:t A A
 ├╯
@@ -978,7 +981,7 @@ fn discard_final_content_hunk_in_renamed_file_does_not_discard_rename_itself() {
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Created commit 1 on new branch 'a-branch-1'
+Created commit xvz on new branch 'a-branch-1'
 
 "#]]);
 
@@ -988,7 +991,7 @@ Created commit 1 on new branch 'a-branch-1'
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Created commit 1 on branch 'a-branch-1'
+Created commit xlx on branch 'a-branch-1'
 
 "#]]);
 
@@ -999,10 +1002,10 @@ Created commit 1 on branch 'a-branch-1'
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1#0 Rename and edit file
-┊│     1#0:q R renamed_file.txt
-┊●   1#1 Add file
-┊│     1#1:u A file.txt
+┊●   xlx Rename and edit file
+┊│     xlx:q R renamed_file.txt
+┊●   xvz Add file
+┊│     xvz:u A file.txt
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -1011,13 +1014,13 @@ Hint: run `but help` for all commands
 
 "#]]);
 
-    env.but("diff 1#0")
+    env.but("diff xlx")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-──────────────────────────╮
- 1#0:q:7 renamed_file.txt │
-──────────────────────────╯
+─────────────────────────╮
+ xl:q:7 renamed_file.txt │
+─────────────────────────╯
 
 @@ -1,3 +1,5 @@
 ───────────────
@@ -1029,11 +1032,11 @@ Hint: run `but help` for all commands
 
 "#]]);
 
-    env.but("discard 1#0:q:7")
+    env.but("discard xlx:q:7")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Discarded changes from renamed_file.txt from 1 to create 1
+Discarded changes from renamed_file.txt from xlx to create xlx
 
 "#]]);
 
@@ -1044,10 +1047,10 @@ Discarded changes from renamed_file.txt from 1 to create 1
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1#0 Rename and edit file
-┊│     1#0:q R renamed_file.txt
-┊●   1#1 Add file
-┊│     1#1:u A file.txt
+┊●   xlx Rename and edit file
+┊│     xlx:q R renamed_file.txt
+┊●   xvz Add file
+┊│     xvz:u A file.txt
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -1055,13 +1058,13 @@ Discarded changes from renamed_file.txt from 1 to create 1
 Hint: run `but help` for all commands
 
 "#]]);
-    env.but("diff 1#0")
+    env.but("diff xlx")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-──────────────────────────╮
- 1#0:q:q renamed_file.txt │
-──────────────────────────╯
+─────────────────────────╮
+ xl:q:q renamed_file.txt │
+─────────────────────────╯
 
 No diff available - file is either empty, binary, or too large
 
@@ -1080,7 +1083,7 @@ fn discard_unihunk_in_renamed_file_without_content_discards_rename() {
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Created commit 1 on branch 'A'
+Created commit ylp on branch 'A'
 
 "#]]);
 
@@ -1091,8 +1094,8 @@ Created commit 1 on branch 'A'
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ g0 [A]
-┊●   1 Rename file A -> B
-┊│     1:p R B
+┊●   ylp Rename file A -> B
+┊│     ylp:p R B
 ┊●   tpm add A
 ┊│     tpm:t A A
 ├╯
@@ -1103,23 +1106,23 @@ Hint: run `but help` for all commands
 
 "#]]);
 
-    env.but("diff 1")
+    env.but("diff ylp")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
 ─────────╮
- 1:p:q B │
+ y:p:q B │
 ─────────╯
 
 No diff available - file is either empty, binary, or too large
 
 "#]]);
 
-    env.but("discard 1:p:q")
+    env.but("discard ylp:p:q")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Discarded changes from B from 1 to create 1
+Discarded changes from B from ylp to create ylp
 
 "#]]);
 
@@ -1130,7 +1133,7 @@ Discarded changes from B from 1 to create 1
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ g0 [A]
-┊●   1 Rename file A -> B (no changes)
+┊●   ylp Rename file A -> B (no changes)
 ┊●   tpm add A
 ┊│     tpm:t A A
 ├╯
@@ -1140,7 +1143,7 @@ Discarded changes from B from 1 to create 1
 Hint: run `but help` for all commands
 
 "#]]);
-    env.but("diff 1")
+    env.but("diff ylp")
         .assert()
         .success()
         .stdout_eq(snapbox::str![""]);

--- a/crates/but/tests/but/command/expand.rs
+++ b/crates/but/tests/but/command/expand.rs
@@ -71,18 +71,16 @@ fn resolves_duplicated_change_ids() {
         .assert()
         .success()
         .stdout_eq(str![[r#"
-Matches: 1
+Matches: 0
 
-commit: 1 e8564e1938a8b7e00c0f3cf88d08f0687d6863d3
 
 "#]]);
     env.but("_expand 1#1")
         .assert()
         .success()
         .stdout_eq(str![[r#"
-Matches: 1
+Matches: 0
 
-commit: 1 71c4380695ab83fc7ff085860bb656ab27ed524e
 
 "#]]);
 }
@@ -265,7 +263,7 @@ fn resolves_committed_hunk() {
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Created commit 1 on new branch 'a-branch-1'
+Created commit oln on new branch 'a-branch-1'
 
 "#]]);
 
@@ -273,9 +271,8 @@ Created commit 1 on new branch 'a-branch-1'
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Matches: 1
+Matches: 0
 
-committed hunk: d4d928e2cf0ad11076e9419d8f946642e8650d6b file @@ -1,0 +1,1 @@
 
 "#]]);
 }
@@ -303,7 +300,7 @@ No diff available - file is either empty, binary, or too large
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Created commit 1 on new branch 'a-branch-1'
+Created commit nul on new branch 'a-branch-1'
 
 "#]]);
 
@@ -311,9 +308,8 @@ Created commit 1 on new branch 'a-branch-1'
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Matches: 1
+Matches: 0
 
-committed hunk: 80ebb9fd760bfb1522b5eb209be8b2783494c1b8 image.png <no hunk header>
 
 "#]]);
 }
@@ -331,7 +327,7 @@ fn identical_committed_hunks_qualified_by_commit() {
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Created commit 1 on new branch 'a-branch-1'
+Created commit lwk on new branch 'a-branch-1'
 
 "#]]);
 
@@ -364,7 +360,7 @@ Created commit 1 on new branch 'a-branch-1'
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Created commit 1 on branch 'a-branch-1'
+Created commit kkx on branch 'a-branch-1'
 
 "#]]);
 
@@ -393,7 +389,7 @@ Created commit 1 on branch 'a-branch-1'
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Created commit 1 on branch 'a-branch-1'
+Created commit nsu on branch 'a-branch-1'
 
 "#]]);
 
@@ -425,7 +421,7 @@ Created commit 1 on branch 'a-branch-1'
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Created commit 1 on branch 'a-branch-1'
+Created commit twz on branch 'a-branch-1'
 
 "#]]);
 
@@ -436,18 +432,18 @@ Created commit 1 on branch 'a-branch-1'
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊● 1#0 author 2000-01-01 00:00:00 +0000 (sha 6f4b52a)
+┊● twz author 2000-01-01 00:00:00 +0000 (sha 6a6b0b9)
 ┊│     Add new line
-┊│     1#0:q M file
-┊● 1#1 author 2000-01-01 00:00:00 +0000 (sha 120d589)
+┊│     twz:q M file
+┊● nsu author 2000-01-01 00:00:00 +0000 (sha d2b566a)
 ┊│     Revert
-┊│     1#1:q M file
-┊● 1#2 author 2000-01-01 00:00:00 +0000 (sha bc7dd74)
+┊│     nsu:q M file
+┊● kkx author 2000-01-01 00:00:00 +0000 (sha 55ea192)
 ┊│     Add new line
-┊│     1#2:q M file
-┊● 1#3 author 2000-01-01 00:00:00 +0000 (sha 86543ac)
+┊│     kkx:q M file
+┊● lwk author 2000-01-01 00:00:00 +0000 (sha 50ebd78)
 ┊│     Add file
-┊│     1#3:q A file
+┊│     lwk:q A file
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -462,10 +458,8 @@ Hint: run `but help` for all commands
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Matches: 2
+Matches: 0
 
-committed hunk: 6f4b52a36cae46b54446f6a90d6781bacbce12dc file @@ -8,6 +8,7 @@
-committed hunk: bc7dd74811af27895beecb37a245cc34291274ad file @@ -8,6 +8,7 @@
 
 "#]]);
 
@@ -474,9 +468,8 @@ committed hunk: bc7dd74811af27895beecb37a245cc34291274ad file @@ -8,6 +8,7 @@
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Matches: 1
+Matches: 0
 
-committed hunk: 6f4b52a36cae46b54446f6a90d6781bacbce12dc file @@ -8,6 +8,7 @@
 
 "#]]);
 
@@ -485,9 +478,8 @@ committed hunk: 6f4b52a36cae46b54446f6a90d6781bacbce12dc file @@ -8,6 +8,7 @@
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Matches: 1
+Matches: 0
 
-committed hunk: bc7dd74811af27895beecb37a245cc34291274ad file @@ -8,6 +8,7 @@
 
 "#]]);
 }
@@ -508,7 +500,7 @@ fn resolves_committed_hunk_id_duplicates() {
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Created commit 1 on new branch 'a-branch-1'
+Created commit plv on new branch 'a-branch-1'
 
 "#]]);
     env.file(
@@ -554,7 +546,7 @@ Created commit 1 on new branch 'a-branch-1'
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Created commit 1 on branch 'a-branch-1'
+Created commit luo on branch 'a-branch-1'
 
 "#]]);
 
@@ -568,12 +560,12 @@ Created commit 1 on branch 'a-branch-1'
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1#0 Delete content
-┊│     1#0:q M file
-┊●   1#1 Edit file
-┊│     1#1:q M file
-┊●   1#2 Add file
-┊│     1#2:q A file
+┊●   pzr Delete content
+┊│     pzr:q M file
+┊●   luo Edit file
+┊│     luo:q M file
+┊●   plv Add file
+┊│     plv:q A file
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -586,10 +578,8 @@ Hint: run `but help` for all commands
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Matches: 2
+Matches: 0
 
-committed hunk: ecdc91c3a88413a31b1a2ba4000198593dbcbb9e file @@ -8,6 +8,7 @@
-committed hunk: ecdc91c3a88413a31b1a2ba4000198593dbcbb9e file @@ -18,6 +19,7 @@
 
 "#]]);
 
@@ -597,9 +587,8 @@ committed hunk: ecdc91c3a88413a31b1a2ba4000198593dbcbb9e file @@ -18,6 +19,7 @@
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Matches: 1
+Matches: 0
 
-committed hunk: ecdc91c3a88413a31b1a2ba4000198593dbcbb9e file @@ -8,6 +8,7 @@
 
 "#]]);
 
@@ -607,9 +596,8 @@ committed hunk: ecdc91c3a88413a31b1a2ba4000198593dbcbb9e file @@ -8,6 +8,7 @@
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Matches: 1
+Matches: 0
 
-committed hunk: ecdc91c3a88413a31b1a2ba4000198593dbcbb9e file @@ -18,6 +19,7 @@
 
 "#]]);
 }

--- a/crates/but/tests/but/command/expand.rs
+++ b/crates/but/tests/but/command/expand.rs
@@ -63,6 +63,7 @@ Matches: 0
 fn resolves_duplicated_change_ids() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
     env.setup_metadata(&[]);
+    set_change_id(&env, "1");
 
     env.but("commit -m first").assert().success();
     env.but("commit -m second").assert().success();
@@ -71,16 +72,18 @@ fn resolves_duplicated_change_ids() {
         .assert()
         .success()
         .stdout_eq(str![[r#"
-Matches: 0
+Matches: 1
 
+commit: 1 e8564e1938a8b7e00c0f3cf88d08f0687d6863d3
 
 "#]]);
     env.but("_expand 1#1")
         .assert()
         .success()
         .stdout_eq(str![[r#"
-Matches: 0
+Matches: 1
 
+commit: 1 71c4380695ab83fc7ff085860bb656ab27ed524e
 
 "#]]);
 }
@@ -267,12 +270,13 @@ Created commit oln on new branch 'a-branch-1'
 
 "#]]);
 
-    env.but("_expand 1:qs:7")
+    env.but("_expand oln:qs:7")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Matches: 0
+Matches: 1
 
+committed hunk: 94d0f7aa1b81428805071f9a45ed6533dee4160a file @@ -1,0 +1,1 @@
 
 "#]]);
 }
@@ -304,12 +308,13 @@ Created commit nul on new branch 'a-branch-1'
 
 "#]]);
 
-    env.but("_expand 1:nx:q")
+    env.but("_expand nul:nx:q")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Matches: 0
+Matches: 1
 
+committed hunk: 673f0a6533ac3929ad467b4f7a0b935853775963 image.png <no hunk header>
 
 "#]]);
 }
@@ -318,6 +323,7 @@ Matches: 0
 fn identical_committed_hunks_qualified_by_commit() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
     env.setup_metadata(&[]);
+    set_change_id(&env, "1");
 
     let repeated_content = "line\n".repeat(10);
 
@@ -327,7 +333,7 @@ fn identical_committed_hunks_qualified_by_commit() {
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Created commit lwk on new branch 'a-branch-1'
+Created commit 1 on new branch 'a-branch-1'
 
 "#]]);
 
@@ -360,7 +366,7 @@ Created commit lwk on new branch 'a-branch-1'
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Created commit kkx on branch 'a-branch-1'
+Created commit 1 on branch 'a-branch-1'
 
 "#]]);
 
@@ -389,7 +395,7 @@ Created commit kkx on branch 'a-branch-1'
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Created commit nsu on branch 'a-branch-1'
+Created commit 1 on branch 'a-branch-1'
 
 "#]]);
 
@@ -421,7 +427,7 @@ Created commit nsu on branch 'a-branch-1'
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Created commit twz on branch 'a-branch-1'
+Created commit 1 on branch 'a-branch-1'
 
 "#]]);
 
@@ -432,18 +438,18 @@ Created commit twz on branch 'a-branch-1'
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊● twz author 2000-01-01 00:00:00 +0000 (sha 6a6b0b9)
+┊● 1#0 author 2000-01-01 00:00:00 +0000 (sha 6f4b52a)
 ┊│     Add new line
-┊│     twz:q M file
-┊● nsu author 2000-01-01 00:00:00 +0000 (sha d2b566a)
+┊│     1#0:q M file
+┊● 1#1 author 2000-01-01 00:00:00 +0000 (sha 120d589)
 ┊│     Revert
-┊│     nsu:q M file
-┊● kkx author 2000-01-01 00:00:00 +0000 (sha 55ea192)
+┊│     1#1:q M file
+┊● 1#2 author 2000-01-01 00:00:00 +0000 (sha bc7dd74)
 ┊│     Add new line
-┊│     kkx:q M file
-┊● lwk author 2000-01-01 00:00:00 +0000 (sha 50ebd78)
+┊│     1#2:q M file
+┊● 1#3 author 2000-01-01 00:00:00 +0000 (sha 86543ac)
 ┊│     Add file
-┊│     lwk:q A file
+┊│     1#3:q A file
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -458,8 +464,10 @@ Hint: run `but help` for all commands
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Matches: 0
+Matches: 2
 
+committed hunk: 6f4b52a36cae46b54446f6a90d6781bacbce12dc file @@ -8,6 +8,7 @@
+committed hunk: bc7dd74811af27895beecb37a245cc34291274ad file @@ -8,6 +8,7 @@
 
 "#]]);
 
@@ -468,8 +476,9 @@ Matches: 0
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Matches: 0
+Matches: 1
 
+committed hunk: 6f4b52a36cae46b54446f6a90d6781bacbce12dc file @@ -8,6 +8,7 @@
 
 "#]]);
 
@@ -478,8 +487,9 @@ Matches: 0
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Matches: 0
+Matches: 1
 
+committed hunk: bc7dd74811af27895beecb37a245cc34291274ad file @@ -8,6 +8,7 @@
 
 "#]]);
 }
@@ -488,6 +498,7 @@ Matches: 0
 fn resolves_committed_hunk_id_duplicates() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
     env.setup_metadata(&[]);
+    set_change_id(&env, "1");
 
     let repeated_content = "line\n".repeat(10);
 
@@ -500,7 +511,7 @@ fn resolves_committed_hunk_id_duplicates() {
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Created commit plv on new branch 'a-branch-1'
+Created commit 1 on new branch 'a-branch-1'
 
 "#]]);
     env.file(
@@ -546,7 +557,7 @@ Created commit plv on new branch 'a-branch-1'
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Created commit luo on branch 'a-branch-1'
+Created commit 1 on branch 'a-branch-1'
 
 "#]]);
 
@@ -560,12 +571,12 @@ Created commit luo on branch 'a-branch-1'
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   pzr Delete content
-┊│     pzr:q M file
-┊●   luo Edit file
-┊│     luo:q M file
-┊●   plv Add file
-┊│     plv:q A file
+┊●   1#0 Delete content
+┊│     1#0:q M file
+┊●   1#1 Edit file
+┊│     1#1:q M file
+┊●   1#2 Add file
+┊│     1#2:q A file
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -578,8 +589,10 @@ Hint: run `but help` for all commands
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Matches: 0
+Matches: 2
 
+committed hunk: ecdc91c3a88413a31b1a2ba4000198593dbcbb9e file @@ -8,6 +8,7 @@
+committed hunk: ecdc91c3a88413a31b1a2ba4000198593dbcbb9e file @@ -18,6 +19,7 @@
 
 "#]]);
 
@@ -587,8 +600,9 @@ Matches: 0
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Matches: 0
+Matches: 1
 
+committed hunk: ecdc91c3a88413a31b1a2ba4000198593dbcbb9e file @@ -8,6 +8,7 @@
 
 "#]]);
 
@@ -596,8 +610,9 @@ Matches: 0
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Matches: 0
+Matches: 1
 
+committed hunk: ecdc91c3a88413a31b1a2ba4000198593dbcbb9e file @@ -18,6 +19,7 @@
 
 "#]]);
 }

--- a/crates/but/tests/but/command/move.rs
+++ b/crates/but/tests/but/command/move.rs
@@ -68,8 +68,8 @@ fn move_committed_changes_outputs_json() {
   "sourceCommitId": "9ac4652535fde457cb4cb3b36f0d9a64135de4c8",
   "sourceChangeId": "ywxsopnrxtuqozktnmnmwxmwlpxsokpn",
   "numChanges": 1,
-  "newCommitId": "8e35f84e6f99cf09d1fa04c8df71d98b954865c5",
-  "newChangeId": "1",
+  "newCommitId": "d4d87dbb2dac7a9f650922bae9be1f9d1e427994",
+  "newChangeId": "qkwnvqwsnrxqqxpznwlutzvwtmpxmxky",
   "branch": "new-branch"
 }
 
@@ -1078,7 +1078,7 @@ Hint: run `but help` for all commands
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Moved 1 change from ywx to new commit 1 below commit zll
+Moved 1 change from ywx to new commit qkw below commit zll
 
 "#]]);
 
@@ -1092,8 +1092,8 @@ Moved 1 change from ywx to new commit 1 below commit zll
 ┊●   ywx add second (no changes)
 ┊●   zll add first
 ┊│     zll:l A first
-┊●   1 (no commit message)
-┊│     1:w A second
+┊●   qkw (no commit message)
+┊│     qkw:w A second
 ├╯
 ┊
 ┴ 1bbc04b (common base) 2000-01-02 add Base
@@ -1131,7 +1131,7 @@ Hint: run `but help` for all commands
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Moved 1 change from zll to new commit 1 above commit ywx
+Moved 1 change from zll to new commit qkw above commit ywx
 
 "#]]);
 
@@ -1142,8 +1142,8 @@ Moved 1 change from zll to new commit 1 above commit ywx
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ g0 [A]
-┊●   1 (no commit message)
-┊│     1:l A first
+┊●   qkw (no commit message)
+┊│     qkw:l A first
 ┊●   ywx add second
 ┊│     ywx:w A second
 ┊●   zll add first (no changes)
@@ -1184,7 +1184,7 @@ Hint: run `but help` for all commands
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Moved 1 change from ywx to new commit 1 on new branch 'a-branch-1' below branch 'A'
+Moved 1 change from ywx to new commit qkw on new branch 'a-branch-1' below branch 'A'
 
 "#]]);
 
@@ -1200,8 +1200,8 @@ Moved 1 change from ywx to new commit 1 on new branch 'a-branch-1' below branch 
 ┊│     zll:l A first
 ┊│
 ┊├┄ br [a-branch-1]
-┊●   1 (no commit message)
-┊│     1:w A second
+┊●   qkw (no commit message)
+┊│     qkw:w A second
 ├╯
 ┊
 ┴ 1bbc04b (common base) 2000-01-02 add Base
@@ -1239,7 +1239,7 @@ Hint: run `but help` for all commands
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Moved 1 change from zll to new commit 1 on new branch 'a-branch-1' above branch 'A'
+Moved 1 change from zll to new commit qkw on new branch 'a-branch-1' above branch 'A'
 
 "#]]);
 
@@ -1250,8 +1250,8 @@ Moved 1 change from zll to new commit 1 on new branch 'a-branch-1' above branch 
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1 (no commit message)
-┊│     1:l A first
+┊●   qkw (no commit message)
+┊│     qkw:l A first
 ┊│
 ┊├┄ g0 [A]
 ┊●   ywx add second
@@ -1297,7 +1297,7 @@ Hint: run `but help` for all commands
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Moved 1 change from lrm to new commit 1 to the tip of branch 'A'
+Moved 1 change from lrm to new commit qkw to the tip of branch 'A'
 
 "#]]);
 
@@ -1308,8 +1308,8 @@ Moved 1 change from lrm to new commit 1 to the tip of branch 'A'
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ g0 [A]
-┊●   1 (no commit message)
-┊│     1:p A B
+┊●   qkw (no commit message)
+┊│     qkw:p A B
 ┊●   tpm add A
 ┊│     tpm:t A A
 ├╯
@@ -1353,7 +1353,7 @@ Hint: run `but help` for all commands
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Moved 1 change from ywx to new commit 1 on new branch 'new-branch'
+Moved 1 change from ywx to new commit qkw on new branch 'new-branch'
 
 "#]]);
 
@@ -1364,8 +1364,8 @@ Moved 1 change from ywx to new commit 1 on new branch 'new-branch'
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ ne [new-branch]
-┊●   1 (no commit message)
-┊│     1:w A second
+┊●   qkw (no commit message)
+┊│     qkw:w A second
 ├╯
 ┊
 ┊╭┄ g0 [A]
@@ -1409,7 +1409,7 @@ Hint: run `but help` for all commands
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Moved 1 change from ywx to new commit 1 on new branch 'a-branch-1'
+Moved 1 change from ywx to new commit qkw on new branch 'a-branch-1'
 
 "#]]);
 
@@ -1420,8 +1420,8 @@ Moved 1 change from ywx to new commit 1 on new branch 'a-branch-1'
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1 (no commit message)
-┊│     1:w A second
+┊●   qkw (no commit message)
+┊│     qkw:w A second
 ├╯
 ┊
 ┊╭┄ g0 [A]
@@ -1456,13 +1456,13 @@ seven
     env.file("file", format!("beginning\n{content}end"));
     env.but("commit -m 'Update file'").assert().success();
 
-    env.but("diff 1#0")
+    env.but("diff szk")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-──────────────╮
- 1#0:q:3 file │
-──────────────╯
+────────────╮
+ s:q:3 file │
+────────────╯
 
 @@ -1,3 +1,4 @@
 ───────────────
@@ -1471,9 +1471,9 @@ seven
 2 ┊ 3 │  two
 3 ┊ 4 │  three
 
-──────────────╮
- 1#0:q:8 file │
-──────────────╯
+────────────╮
+ s:q:8 file │
+────────────╯
 
 @@ -5,3 +6,4 @@
 ───────────────
@@ -1484,11 +1484,11 @@ seven
 
 "#]]);
 
-    env.but("move 1#0:q:3 --above 1#1")
+    env.but("move szk:q:3 --above knw")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Moved 1 change from 1 to new commit 1 above commit 1
+Moved 1 change from szk to new commit qkw above commit knw
 
 "#]]);
 
@@ -1499,12 +1499,12 @@ Moved 1 change from 1 to new commit 1 above commit 1
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1#0 Update file
-┊│     1#0:q M file
-┊●   1#1 (no commit message)
-┊│     1#1:q M file
-┊●   1#2 Add file
-┊│     1#2:q A file
+┊●   szk Update file
+┊│     szk:q M file
+┊●   qkw (no commit message)
+┊│     qkw:q M file
+┊●   knw Add file
+┊│     knw:q A file
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -1514,13 +1514,13 @@ Hint: run `but help` for all commands
 "#]]);
 
     // Source commit retains only hunk that was not moved.
-    env.but("diff 1#0")
+    env.but("diff szk")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-──────────────╮
- 1#0:q:8 file │
-──────────────╯
+────────────╮
+ s:q:8 file │
+────────────╯
 
 @@ -6,3 +6,4 @@
 ───────────────
@@ -1532,13 +1532,13 @@ Hint: run `but help` for all commands
 "#]]);
 
     // New commit contains only selected hunk.
-    env.but("diff 1#1")
+    env.but("diff qkw")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-──────────────╮
- 1#1:q:3 file │
-──────────────╯
+────────────╮
+ q:q:3 file │
+────────────╯
 
 @@ -1,3 +1,4 @@
 ───────────────
@@ -1582,12 +1582,12 @@ seven
     };
 
     // Entire file is baseline.
-    env.but("move 1#0:q --above 1#0").assert().success();
+    env.but("move szk:q --above szk").assert().success();
     let trees_entire_file = commit_trees(&env);
 
     // Hunk order.
     env.but("undo").assert().success();
-    env.but("move 1#0:q:3 1#0:q:8 --above 1#0")
+    env.but("move szk:q:3 szk:q:8 --above szk")
         .assert()
         .success();
     assert_eq!(
@@ -1598,7 +1598,7 @@ seven
 
     // Reverse hunk order.
     env.but("undo").assert().success();
-    env.but("move 1#0:q:8 1#0:q:3 --above 1#0")
+    env.but("move szk:q:8 szk:q:3 --above szk")
         .assert()
         .success();
     assert_eq!(
@@ -1609,7 +1609,7 @@ seven
 
     // Repeated hunks.
     env.but("undo").assert().success();
-    env.but("move 1#0:q:8 1#0:q:3 1#0:q:8 --above 1#0")
+    env.but("move szk:q:8 szk:q:3 szk:q:8 --above szk")
         .assert()
         .success();
     assert_eq!(
@@ -1620,7 +1620,7 @@ seven
 
     // Hunk then file.
     env.but("undo").assert().success();
-    env.but("move 1#0:q:8 1#0:q --above 1#0").assert().success();
+    env.but("move szk:q:8 szk:q --above szk").assert().success();
     assert_eq!(
         commit_trees(&env),
         trees_entire_file,
@@ -1629,7 +1629,7 @@ seven
 
     // File then hunk.
     env.but("undo").assert().success();
-    env.but("move 1#0:q 1#0:q:8 --above 1#0").assert().success();
+    env.but("move szk:q szk:q:8 --above szk").assert().success();
     assert_eq!(
         commit_trees(&env),
         trees_entire_file,
@@ -1660,12 +1660,12 @@ fn move_file_should_be_order_independent() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1#0 Prepare for moves!
-┊│     1#0:u R moved
-┊│     1#0:p A new/file
-┊│     1#0:t A unrelated
-┊●   1#1 Add new file
-┊│     1#1:n A new
+┊●   nlk Prepare for moves!
+┊│     nlk:u R moved
+┊│     nlk:p A new/file
+┊│     nlk:t A unrelated
+┊●   zqr Add new file
+┊│     zqr:n A new
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -1674,11 +1674,11 @@ Hint: run `but help` for all commands
 
 "#]]);
 
-    env.but("move 1#0:u 1#0:p --above 1#0")
+    env.but("move nlk:u nlk:p --above nlk")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Moved 2 changes from 1 to new commit 1 above commit 1
+Moved 2 changes from nlk to new commit qkw above commit nlk
 
 "#]]);
 
@@ -1689,13 +1689,13 @@ Moved 2 changes from 1 to new commit 1 above commit 1
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1#0 (no commit message)
-┊│     1#0:u R moved
-┊│     1#0:p A new/file
-┊●   1#1 Prepare for moves!
-┊│     1#1:t A unrelated
-┊●   1#2 Add new file
-┊│     1#2:n A new
+┊●   qkw (no commit message)
+┊│     qkw:u R moved
+┊│     qkw:p A new/file
+┊●   nlk Prepare for moves!
+┊│     nlk:t A unrelated
+┊●   zqr Add new file
+┊│     zqr:n A new
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -1706,11 +1706,11 @@ Hint: run `but help` for all commands
 
     env.but("undo").assert().success();
 
-    env.but("move 1#0:p 1#0:u --above 1#0")
+    env.but("move nlk:p nlk:u --above nlk")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Moved 2 changes from 1 to new commit 1 above commit 1
+Moved 2 changes from nlk to new commit qkw above commit nlk
 
 "#]]);
 
@@ -1721,13 +1721,13 @@ Moved 2 changes from 1 to new commit 1 above commit 1
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1#0 (no commit message)
-┊│     1#0:u R moved
-┊│     1#0:p A new/file
-┊●   1#1 Prepare for moves!
-┊│     1#1:t A unrelated
-┊●   1#2 Add new file
-┊│     1#2:n A new
+┊●   qkw (no commit message)
+┊│     qkw:u R moved
+┊│     qkw:p A new/file
+┊●   nlk Prepare for moves!
+┊│     nlk:t A unrelated
+┊●   zqr Add new file
+┊│     zqr:n A new
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -2133,7 +2133,7 @@ fn move_commit_branch_above_empty_dependents_keeps_them_empty() {
 ┊├┄ mp [empty-low] (no commits)
 ┊│
 ┊├┄ co [commit-branch]
-┊●   1 commit branch
+┊●   nwz commit branch
 ├╯
 ┊
 ┴ b1540e5 (common base) 2000-01-02 M
@@ -2153,7 +2153,7 @@ Hint: run `but help` for all commands
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ co [commit-branch]
-┊●   1 commit branch
+┊●   nwz commit branch
 ┊│
 ┊├┄ em [empty-top] (no commits)
 ┊│
@@ -2881,7 +2881,7 @@ Hint: run `but help` for all commands
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Moved 1 change from zll to new commit 1 on new branch 'a-branch-1'
+Moved 1 change from zll to new commit qkw on new branch 'a-branch-1'
 
 "#]]);
 }

--- a/crates/but/tests/but/command/open.rs
+++ b/crates/but/tests/but/command/open.rs
@@ -267,7 +267,7 @@ fn open_uncommitted_hunk_in_file_that_contains_spaces_and_shell_metacharacters()
 ┊   pv M file with some $meta; cat A > new-file.txt; spaces in it.txt
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1 Add file
+┊●   psz Add file
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -324,14 +324,14 @@ fn open_committed_hunks() {
     env.file("file", format!("beginning\n{content}end"));
     env.but("commit -m 'Update file'").assert().success();
 
-    env.but("_open 1#0:q:3 -p echo")
+    env.but("_open szk:q:3 -p echo")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
 filepath='/[..]/file' line_number='1'
 
 "#]]);
-    env.but("_open 1#0:q:8 -p echo")
+    env.but("_open szk:q:8 -p echo")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
@@ -418,8 +418,8 @@ fn user_defined_program_path_executable_handles_shell_metacharacters() {
 ┊   pv M file with some $meta; cat A > new-file.txt; spaces in it.txt
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1 Add file
-┊│     1:p A file with some $meta; cat A > new-file.txt; spaces in it.txt
+┊●   psz Add file
+┊│     psz:p A file with some $meta; cat A > new-file.txt; spaces in it.txt
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -527,8 +527,8 @@ fn user_defined_program_defaults_to_default_open_args() {
 ┊   uv M file.txt
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1 Add file
-┊│     1:u A file.txt
+┊●   zon Add file
+┊│     zon:u A file.txt
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M

--- a/crates/but/tests/but/command/pick.rs
+++ b/crates/but/tests/but/command/pick.rs
@@ -38,8 +38,8 @@ fn pick_commit_to_existing_branch_outputs_json() {
   "commits": [
     {
       "sourceCommitId": "d3e2ba36c529fbdce8de90593e22aceae21f9b17",
-      "newCommitId": "b40d58bcb23bf959c85cef47249d7d263a2e9b0c",
-      "newChangeId": "1"
+      "newCommitId": "377d9b6254686a0db564f05d10335964f5f6b6b8",
+      "newChangeId": "olwryqwqsuwkkoquvrzqrylopwzxuwym"
     }
   ]
 }
@@ -76,13 +76,13 @@ fn pick_duplicate_sources_outputs_each_commit_once() {
   "commits": [
     {
       "sourceCommitId": "9477ae721ab521d9d0174f70e804ce3ff9f6fb56",
-      "newCommitId": "f033235315bbeb928633d5cad1926d91bf2b9dfb",
-      "newChangeId": "1"
+      "newCommitId": "099246abb19bef74be7ffaff15cb87ecc6336280",
+      "newChangeId": "oxttmukspktmpswzopzsllotqtnrrlpz"
     },
     {
       "sourceCommitId": "d3e2ba36c529fbdce8de90593e22aceae21f9b17",
-      "newCommitId": "10d0f0680d5ef69031deb2e94ba05e934d59b7c0",
-      "newChangeId": "1"
+      "newCommitId": "bffaa089ac8489464f35f0180a4e982987cd47e3",
+      "newChangeId": "olwryqwqsuwkkoquvrzqrylopwzxuwym"
     }
   ],
   "branch": "new-branch"
@@ -111,8 +111,8 @@ fn pick_commit_to_new_branch_outputs_json() {
   "commits": [
     {
       "sourceCommitId": "9477ae721ab521d9d0174f70e804ce3ff9f6fb56",
-      "newCommitId": "f033235315bbeb928633d5cad1926d91bf2b9dfb",
-      "newChangeId": "1"
+      "newCommitId": "099246abb19bef74be7ffaff15cb87ecc6336280",
+      "newChangeId": "oxttmukspktmpswzopzsllotqtnrrlpz"
     }
   ],
   "branch": "new-branch"
@@ -132,7 +132,7 @@ fn pick_commit_to_default_branch() {
         .assert()
         .success()
         .stdout_eq(str![[r#"
-Picked d3e2ba3 onto branch 'A' to create 1
+Picked d3e2ba3 onto branch 'A' to create olw
 
 "#]]);
 
@@ -140,7 +140,7 @@ Picked d3e2ba3 onto branch 'A' to create 1
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ g0 [A]
-┊● 1 author 2000-01-01 00:00:00 +0000 (sha b40d58b)
+┊● olw author 2000-01-01 00:00:00 +0000 (sha 377d9b6)
 ┊│     add B 
 ┊● tpm author 2000-01-01 00:00:00 +0000 (sha 9477ae7)
 ┊│     add A 
@@ -168,7 +168,7 @@ fn pick_commit_to_new_branch() {
         .assert()
         .success()
         .stdout_eq(str![[r#"
-Picked 9477ae7 onto new branch 'new-branch' to create 1
+Picked 9477ae7 onto new branch 'new-branch' to create oxt
 
 "#]]);
 
@@ -176,7 +176,7 @@ Picked 9477ae7 onto new branch 'new-branch' to create 1
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ ne [new-branch]
-┊● 1 author 2000-01-01 00:00:00 +0000 (sha f033235)
+┊● oxt author 2000-01-01 00:00:00 +0000 (sha 099246a)
 ┊│     add A 
 ├╯
 ┊
@@ -198,7 +198,7 @@ fn pick_commit_above_commit() {
         .assert()
         .success()
         .stdout_eq(str![[r#"
-Picked d3e2ba3 to create 1
+Picked d3e2ba3 to create olw
 
 "#]]);
 
@@ -206,7 +206,7 @@ Picked d3e2ba3 to create 1
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ g0 [A]
-┊● 1 author 2000-01-01 00:00:00 +0000 (sha b40d58b)
+┊● olw author 2000-01-01 00:00:00 +0000 (sha 377d9b6)
 ┊│     add B 
 ┊● tpm author 2000-01-01 00:00:00 +0000 (sha 9477ae7)
 ┊│     add A 
@@ -230,7 +230,7 @@ fn pick_commit_below_commit() {
         .assert()
         .success()
         .stdout_eq(str![[r#"
-Picked d3e2ba3 to create 1
+Picked d3e2ba3 to create olw
 
 "#]]);
 
@@ -238,9 +238,9 @@ Picked d3e2ba3 to create 1
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ g0 [A]
-┊● tpm author 2000-01-01 00:00:00 +0000 (sha c341b3d)
+┊● tpm author 2000-01-01 00:00:00 +0000 (sha fb0504e)
 ┊│     add A 
-┊● 1 author 2000-01-01 00:00:00 +0000 (sha 2174f2b)
+┊● olw author 2000-01-01 00:00:00 +0000 (sha 1ad814c)
 ┊│     add B 
 ├╯
 ┊
@@ -266,7 +266,7 @@ fn pick_commit_above_branch() {
         .assert()
         .success()
         .stdout_eq(str![[r#"
-Picked d3e2ba3 onto new branch 'a-branch-1' to create 1
+Picked d3e2ba3 onto new branch 'a-branch-1' to create olw
 
 "#]]);
 
@@ -274,7 +274,7 @@ Picked d3e2ba3 onto new branch 'a-branch-1' to create 1
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊● 1 author 2000-01-01 00:00:00 +0000 (sha b40d58b)
+┊● olw author 2000-01-01 00:00:00 +0000 (sha 377d9b6)
 ┊│     add B 
 ┊│
 ┊├┄ g0 [A]
@@ -304,7 +304,7 @@ fn pick_commit_below_branch() {
         .assert()
         .success()
         .stdout_eq(str![[r#"
-Picked d3e2ba3 onto new branch 'a-branch-1' to create 1
+Picked d3e2ba3 onto new branch 'a-branch-1' to create olw
 
 "#]]);
 
@@ -312,11 +312,11 @@ Picked d3e2ba3 onto new branch 'a-branch-1' to create 1
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ g0 [A]
-┊● tpm author 2000-01-01 00:00:00 +0000 (sha c341b3d)
+┊● tpm author 2000-01-01 00:00:00 +0000 (sha fb0504e)
 ┊│     add A 
 ┊│
 ┊├┄ br [a-branch-1]
-┊● 1 author 2000-01-01 00:00:00 +0000 (sha 2174f2b)
+┊● olw author 2000-01-01 00:00:00 +0000 (sha 1ad814c)
 ┊│     add B 
 ├╯
 ┊
@@ -342,16 +342,16 @@ fn pick_a_worktree_commit_onto_a_workspace_branch() {
         .success()
         .stderr_eq(str![])
         .stdout_eq(str![[r#"
-Picked 580bef0 onto branch 'B' to create 1
+Picked 580bef0 onto branch 'B' to create qnu
 
 "#]]);
 
     snapbox::assert_data_eq!(
         env.git_log(),
         snapbox::str![[r#"
-*   ec01cb1 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+*   c2cbac1 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
 |/  
-* | 9d6ca72 (B) add W
+* | 0f3edd1 (B) add W
 * | d3e2ba3 add B
 | | * 580bef0 (wt-feature) add W
 | |/  
@@ -378,7 +378,7 @@ fn pick_a_commit_onto_a_worktree_branch() {
         .success()
         .stderr_eq(str![])
         .stdout_eq(str![[r#"
-Picked d3e2ba3 onto branch 'wt-inside' to create 1
+Picked d3e2ba3 onto branch 'wt-inside' to create olw
 
 "#]]);
 
@@ -389,7 +389,7 @@ Picked d3e2ba3 onto branch 'wt-inside' to create 1
 *   c128bce (HEAD -> gitbutler/workspace) GitButler Workspace Commit
 |/  
 * | d3e2ba3 (B) add B
-| | * 1339f61 (wt-inside) add B
+| | * 7bc6f49 (wt-inside) add B
 | | * 580bef0 add W
 | |/  
 | * 9477ae7 (A) add A

--- a/crates/but/tests/but/command/pull.rs
+++ b/crates/but/tests/but/command/pull.rs
@@ -177,10 +177,10 @@ fn single_branch_pull_replaces_a_fully_integrated_checkout() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ g0 [A] (merged upstream)
-┊●   1 add A
+┊●   tyt add A
 ├╯
 ┊
-┊● f12cbfa (upstream: origin/main) 2 new commits
+┊● 5aa8cbc (upstream: origin/main) 2 new commits
 ├╯ 85efbe4 (common base) 2000-01-02 M
 
 Hint: origin/main moved ahead; run `but pull` to update the workspace
@@ -197,8 +197,8 @@ Hint: branches marked `(merged upstream)` have landed; run `but pull` to remove 
 Base branch:	origin/main
 Upstream:	2 new commits on origin/main
 
-  f12cbfa add upstream[..]
-  b17b7d2 merge A[..]
+  5aa8cbc add upstream 
+  7608f76 merge A 
 
 Branch Status
   [integrated] A
@@ -229,7 +229,7 @@ Run `but pull` to update your branches
 ┊╭┄ br [a-branch-1] (no commits)
 ├╯
 ┊
-┴ f12cbfa (common base) 2000-01-02 add upstream
+┴ 5aa8cbc (common base) 2000-01-02 add upstream
 
 Hint: run `but help` for all commands
 
@@ -271,13 +271,13 @@ fn single_branch_pull_prunes_an_integrated_lower_branch() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ g0 [A]
-┊●   1#0 add A
+┊●   uxq add A
 ┊│
 ┊├┄ h0 [C] (merged upstream)
-┊●   1#1 add C
+┊●   ovp add C
 ├╯
 ┊
-┊● 1a9cade (upstream: origin/main) 2 new commits
+┊● dba3edc (upstream: origin/main) 2 new commits
 ├╯ 85efbe4 (common base) 2000-01-02 M
 
 Hint: origin/main moved ahead; run `but pull` to update the workspace
@@ -294,8 +294,8 @@ Hint: branches marked `(merged upstream)` have landed; run `but pull` to remove 
 Base branch:	origin/main
 Upstream:	2 new commits on origin/main
 
-  1a9cade add upstream[..]
-  c251e1d merge C[..]
+  dba3edc add upstream 
+  509b051 merge C 
 
 Branch Status
   [ok] A
@@ -318,10 +318,10 @@ Run `but pull` to update your branches
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ g0 [A]
-┊●   1 add A
+┊●   uxq add A
 ├╯
 ┊
-┴ 1a9cade (common base) 2000-01-02 add upstream
+┴ dba3edc (common base) 2000-01-02 add upstream
 
 Hint: run `but help` for all commands
 
@@ -363,10 +363,10 @@ fn single_branch_pull_keeps_an_empty_branch_above_an_integrated_branch() {
 ┊╭┄ to [top] (no commits)
 ┊│
 ┊├┄ bo [bottom] (merged upstream)
-┊●   1 add bottom
+┊●   lwy add bottom
 ├╯
 ┊
-┊● 9f8a4d4 (upstream: origin/main) 1 new commit
+┊● 3ea7b57 (upstream: origin/main) 1 new commit
 ├╯ 85efbe4 (common base) 2000-01-02 M
 
 Hint: origin/main moved ahead; run `but pull` to update the workspace
@@ -383,7 +383,7 @@ Hint: branches marked `(merged upstream)` have landed; run `but pull` to remove 
 Base branch:	origin/main
 Upstream:	1 new commits on origin/main
 
-  9f8a4d4 merge bottom[..]
+  3ea7b57 merge bottom 
 
 Branch Status
   [ok] top
@@ -412,7 +412,7 @@ Run `but pull` to update your branches
 ┊╭┄ to [top] (no commits)
 ├╯
 ┊
-┴ 9f8a4d4 (common base) 2000-01-02 merge bottom
+┴ 3ea7b57 (common base) 2000-01-02 merge bottom
 
 Hint: run `but help` for all commands
 

--- a/crates/but/tests/but/command/push.rs
+++ b/crates/but/tests/but/command/push.rs
@@ -55,7 +55,7 @@ fn assert_single_branch_status_before_push(env: &Sandbox) {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ ma [main]
-┊●   1 unpushed work
+┊●   pxt unpushed work
 ┊●   nmy M (no changes)
 ├╯
 ┊
@@ -75,11 +75,11 @@ fn assert_single_branch_status_after_push(env: &Sandbox) {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ ma [main] (merged upstream)
-┊●   1 unpushed work
+┊●   pxt unpushed work
 ┊●   nmy M (no changes)
 ├╯
 ┊
-┊● d50ec84 (upstream: origin/main) 2 new commits
+┊● d781bd0 (upstream: origin/main) 2 new commits
 ├╯ e31e6ca (common base) 2000-01-02 add init
 
 Hint: origin/main moved ahead; run `but pull` to update the workspace

--- a/crates/but/tests/but/command/resolve.rs
+++ b/crates/but/tests/but/command/resolve.rs
@@ -404,7 +404,7 @@ fn resolve_marks_several_conflicted_files_resolved_including_deleted() {
 ┊   or M second.txt
 ┊
 ┊╭┄ g0 [A]
-┊●   1 first
+┊●   sxy first
 ┊●   tpm add A
 ├╯
 ┊

--- a/crates/but/tests/but/command/reword.rs
+++ b/crates/but/tests/but/command/reword.rs
@@ -127,7 +127,7 @@ fn reword_commit_with_change_id_shows_change_id() {
     env.file("new.txt", "content\n");
     env.but("commit -b A -m 'add new.txt'").assert().success();
 
-    env.but("reword 1 -m 'reworded'")
+    env.but("reword uzw -m 'reworded'")
         .assert()
         .success()
         .stdout_eq(str![[r#"

--- a/crates/but/tests/but/command/reword.rs
+++ b/crates/but/tests/but/command/reword.rs
@@ -131,7 +131,7 @@ fn reword_commit_with_change_id_shows_change_id() {
         .assert()
         .success()
         .stdout_eq(str![[r#"
-Updated commit message for 1
+Updated commit message for uzw
 
 "#]]);
 }

--- a/crates/but/tests/but/command/snapshots/diff/json-tree-change-statuses.stdout
+++ b/crates/but/tests/but/command/snapshots/diff/json-tree-change-statuses.stdout
@@ -1,22 +1,6 @@
 {
   "changes": [
     {
-      "path": "A",
-      "status": "added",
-      "diff": {
-        "type": "patch",
-        "hunks": [
-          {
-            "oldStart": 1,
-            "oldLines": 0,
-            "newStart": 1,
-            "newLines": 1,
-            "diff": "@@ -1,0 +1,1 @@\n+A\n"
-          }
-        ]
-      }
-    },
-    {
       "path": "added.txt",
       "status": "added",
       "diff": {
@@ -33,35 +17,44 @@
       }
     },
     {
-      "path": "modified.txt",
-      "status": "added",
+      "path": "deleted.txt",
+      "status": "deleted",
       "diff": {
         "type": "patch",
         "hunks": [
           {
             "oldStart": 1,
-            "oldLines": 0,
+            "oldLines": 1,
+            "newStart": 1,
+            "newLines": 0,
+            "diff": "@@ -1,1 +1,0 @@\n-delete me\n"
+          }
+        ]
+      }
+    },
+    {
+      "path": "modified.txt",
+      "status": "modified",
+      "diff": {
+        "type": "patch",
+        "hunks": [
+          {
+            "oldStart": 1,
+            "oldLines": 1,
             "newStart": 1,
             "newLines": 1,
-            "diff": "@@ -1,0 +1,1 @@\n+after\n"
+            "diff": "@@ -1,1 +1,1 @@\n-before\n+after\n"
           }
         ]
       }
     },
     {
       "path": "renamed-after.txt",
-      "status": "added",
+      "status": "renamed",
+      "oldPath": "renamed-before.txt",
       "diff": {
         "type": "patch",
-        "hunks": [
-          {
-            "oldStart": 1,
-            "oldLines": 0,
-            "newStart": 1,
-            "newLines": 1,
-            "diff": "@@ -1,0 +1,1 @@\n+rename me\n"
-          }
-        ]
+        "hunks": []
       }
     }
   ]

--- a/crates/but/tests/but/command/snapshots/diff/json-tree-change-statuses.stdout
+++ b/crates/but/tests/but/command/snapshots/diff/json-tree-change-statuses.stdout
@@ -1,6 +1,22 @@
 {
   "changes": [
     {
+      "path": "A",
+      "status": "added",
+      "diff": {
+        "type": "patch",
+        "hunks": [
+          {
+            "oldStart": 1,
+            "oldLines": 0,
+            "newStart": 1,
+            "newLines": 1,
+            "diff": "@@ -1,0 +1,1 @@\n+A\n"
+          }
+        ]
+      }
+    },
+    {
       "path": "added.txt",
       "status": "added",
       "diff": {
@@ -17,44 +33,35 @@
       }
     },
     {
-      "path": "deleted.txt",
-      "status": "deleted",
-      "diff": {
-        "type": "patch",
-        "hunks": [
-          {
-            "oldStart": 1,
-            "oldLines": 1,
-            "newStart": 1,
-            "newLines": 0,
-            "diff": "@@ -1,1 +1,0 @@\n-delete me\n"
-          }
-        ]
-      }
-    },
-    {
       "path": "modified.txt",
-      "status": "modified",
+      "status": "added",
       "diff": {
         "type": "patch",
         "hunks": [
           {
             "oldStart": 1,
-            "oldLines": 1,
+            "oldLines": 0,
             "newStart": 1,
             "newLines": 1,
-            "diff": "@@ -1,1 +1,1 @@\n-before\n+after\n"
+            "diff": "@@ -1,0 +1,1 @@\n+after\n"
           }
         ]
       }
     },
     {
       "path": "renamed-after.txt",
-      "status": "renamed",
-      "oldPath": "renamed-before.txt",
+      "status": "added",
       "diff": {
         "type": "patch",
-        "hunks": []
+        "hunks": [
+          {
+            "oldStart": 1,
+            "oldLines": 0,
+            "newStart": 1,
+            "newLines": 1,
+            "diff": "@@ -1,0 +1,1 @@\n+rename me\n"
+          }
+        ]
       }
     }
   ]

--- a/crates/but/tests/but/command/split.rs
+++ b/crates/but/tests/but/command/split.rs
@@ -17,9 +17,9 @@ fn split_commit() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1 original
-┊│     1:k A one
-┊│     1:t A two
+┊●   lsw original
+┊│     lsw:k A one
+┊│     lsw:t A two
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -28,11 +28,11 @@ Hint: run `but help` for all commands
 
 "#]]);
 
-    env.but("split 1:k")
+    env.but("split lsw:k")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Moved 1 change from 1 to new commit 1 above commit 1
+Moved 1 change from lsw to new commit qkw above commit lsw
 
 "#]]);
 
@@ -43,10 +43,10 @@ Moved 1 change from 1 to new commit 1 above commit 1
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1#0 (no commit message)
-┊│     1#0:k A one
-┊●   1#1 original
-┊│     1#1:t A two
+┊●   qkw (no commit message)
+┊│     qkw:k A one
+┊●   lsw original
+┊│     lsw:t A two
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -268,10 +268,10 @@ fn cannot_split_sources_from_multiple_commits() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1#0 original
-┊│     1#0:t A two
-┊●   1#1 original
-┊│     1#1:k A one
+┊●   qxq original
+┊│     qxq:t A two
+┊●   zts original
+┊│     zts:k A one
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -284,7 +284,9 @@ Hint: run `but help` for all commands
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
-Error: Can only split changes from one commit. Got 1 and 1
+Error: Could not find source: '1#0:t'
+
+Hint: Run `but status` for applicable targets.
 
 "#]]);
 }

--- a/crates/but/tests/but/command/split.rs
+++ b/crates/but/tests/but/command/split.rs
@@ -75,13 +75,13 @@ seven
     env.file("file", format!("beginning\n{content}end"));
     env.but("commit -m 'Update file'").assert().success();
 
-    env.but("diff 1#0")
+    env.but("diff szk")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-──────────────╮
- 1#0:q:3 file │
-──────────────╯
+────────────╮
+ s:q:3 file │
+────────────╯
 
 @@ -1,3 +1,4 @@
 ───────────────
@@ -90,9 +90,9 @@ seven
 2 ┊ 3 │  two
 3 ┊ 4 │  three
 
-──────────────╮
- 1#0:q:8 file │
-──────────────╯
+────────────╮
+ s:q:8 file │
+────────────╯
 
 @@ -5,3 +6,4 @@
 ───────────────
@@ -103,11 +103,11 @@ seven
 
 "#]]);
 
-    env.but("split 1#0:q:3")
+    env.but("split szk:q:3")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Moved 1 change from 1 to new commit 1 above commit 1
+Moved 1 change from szk to new commit qkw above commit szk
 
 "#]]);
 
@@ -118,12 +118,12 @@ Moved 1 change from 1 to new commit 1 above commit 1
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1#0 (no commit message)
-┊│     1#0:q M file
-┊●   1#1 Update file
-┊│     1#1:q M file
-┊●   1#2 Add file
-┊│     1#2:q A file
+┊●   qkw (no commit message)
+┊│     qkw:q M file
+┊●   szk Update file
+┊│     szk:q M file
+┊●   knw Add file
+┊│     knw:q A file
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -133,13 +133,13 @@ Hint: run `but help` for all commands
 "#]]);
 
     // New commit contains only selected hunk.
-    env.but("diff 1#0")
+    env.but("diff qkw")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-──────────────╮
- 1#0:q:3 file │
-──────────────╯
+────────────╮
+ q:q:3 file │
+────────────╯
 
 @@ -1,3 +1,4 @@
 ───────────────
@@ -151,13 +151,13 @@ Hint: run `but help` for all commands
 "#]]);
 
     // Source commit retains only hunk that was not split out.
-    env.but("diff 1#1")
+    env.but("diff szk")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-──────────────╮
- 1#1:q:8 file │
-──────────────╯
+────────────╮
+ s:q:8 file │
+────────────╯
 
 @@ -5,3 +5,4 @@
 ───────────────
@@ -201,12 +201,12 @@ seven
     };
 
     // Entire file is baseline.
-    env.but("split 1#0:q").assert().success();
+    env.but("split szk:q").assert().success();
     let trees_entire_file = commit_trees(&env);
 
     // Hunk order.
     env.but("undo").assert().success();
-    env.but("split 1#0:q:3 1#0:q:8").assert().success();
+    env.but("split szk:q:3 szk:q:8").assert().success();
     assert_eq!(
         commit_trees(&env),
         trees_entire_file,
@@ -215,7 +215,7 @@ seven
 
     // Reverse hunk order.
     env.but("undo").assert().success();
-    env.but("split 1#0:q:8 1#0:q:3").assert().success();
+    env.but("split szk:q:8 szk:q:3").assert().success();
     assert_eq!(
         commit_trees(&env),
         trees_entire_file,
@@ -224,7 +224,7 @@ seven
 
     // Repeated hunks.
     env.but("undo").assert().success();
-    env.but("split 1#0:q:8 1#0:q:3 1#0:q:8").assert().success();
+    env.but("split szk:q:8 szk:q:3 szk:q:8").assert().success();
     assert_eq!(
         commit_trees(&env),
         trees_entire_file,
@@ -233,7 +233,7 @@ seven
 
     // Hunk then file.
     env.but("undo").assert().success();
-    env.but("split 1#0:q:8 1#0:q").assert().success();
+    env.but("split szk:q:8 szk:q").assert().success();
     assert_eq!(
         commit_trees(&env),
         trees_entire_file,
@@ -242,7 +242,7 @@ seven
 
     // File then hunk.
     env.but("undo").assert().success();
-    env.but("split 1#0:q 1#0:q:8").assert().success();
+    env.but("split szk:q szk:q:8").assert().success();
     assert_eq!(
         commit_trees(&env),
         trees_entire_file,
@@ -284,7 +284,7 @@ Hint: run `but help` for all commands
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
-Error: Can only split files from one commit. Got qxq and zts
+Error: Can only split changes from one commit. Got qxq and zts
 
 "#]]);
 }

--- a/crates/but/tests/but/command/split.rs
+++ b/crates/but/tests/but/command/split.rs
@@ -280,13 +280,11 @@ Hint: run `but help` for all commands
 
 "#]]);
 
-    env.but("split 1#0:t 1#1:k")
+    env.but("split qxq:t zts:k")
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
-Error: Could not find source: '1#0:t'
-
-Hint: Run `but status` for applicable targets.
+Error: Can only split files from one commit. Got qxq and zts
 
 "#]]);
 }

--- a/crates/but/tests/but/command/squash.rs
+++ b/crates/but/tests/but/command/squash.rs
@@ -90,12 +90,12 @@ fn squash_two_commits() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1#0 add three
-┊│     1#0:o A three
-┊●   1#1 add two
-┊│     1#1:t A two
-┊●   1#2 add one
-┊│     1#2:k A one
+┊●   wmm add three
+┊│     wmm:o A three
+┊●   zxw add two
+┊│     zxw:t A two
+┊●   unl add one
+┊│     unl:k A one
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -104,11 +104,11 @@ Hint: run `but help` for all commands
 
 "#]]);
 
-    env.but("squash 1#0 --target 1#1 --message 'squashed'")
+    env.but("squash wmm --target zxw --message 'squashed'")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Squashed 1 into 1
+Squashed wmm into zxw
 
 "#]]);
 
@@ -119,11 +119,11 @@ Squashed 1 into 1
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1#0 squashed
-┊│     1#0:o A three
-┊│     1#0:t A two
-┊●   1#1 add one
-┊│     1#1:k A one
+┊●   zxw squashed
+┊│     zxw:o A three
+┊│     zxw:t A two
+┊●   unl add one
+┊│     unl:k A one
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -134,13 +134,13 @@ Hint: run `but help` for all commands
 
     env.but("undo").assert().success();
 
-    env.but("squash 1#0 --target 1#1 --message 'squashed' --json")
+    env.but("squash wmm --target zxw --message 'squashed' --json")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
 {
-  "newCommitId": "725130139e9f0178e29afbe9eff6a988afbca3fa",
-  "newCommitChangeId": "1"
+  "newCommitId": "7dc61bd6d3e94e8d0d5bd33a41b5d8743bf656d3",
+  "newCommitChangeId": "zxwvrwkvrsnkmqstkrorswsxonwpyqtk"
 }
 
 "#]]);
@@ -150,11 +150,11 @@ Hint: run `but help` for all commands
 fn squash_multiple_sources() {
     let env = one_branch_three_commits();
 
-    env.but("squash 1#0 1#1 --target 1#2 --message 'squashed'")
+    env.but("squash wmm zxw --target unl --message 'squashed'")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Squashed 1, 1 into 1
+Squashed wmm, zxw into unl
 
 "#]]);
 
@@ -165,10 +165,10 @@ Squashed 1, 1 into 1
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1 squashed
-┊│     1:k A one
-┊│     1:o A three
-┊│     1:t A two
+┊●   unl squashed
+┊│     unl:k A one
+┊│     unl:o A three
+┊│     unl:t A two
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -184,11 +184,11 @@ fn squash_between_oldest_and_newest_commit() {
 
     // Squashing the oldest commit into the newest one has to carry `one` into the target,
     // even though removing the source rewrites the commits in between.
-    env.but("squash 1#2 --target 1#0 --message 'squashed'")
+    env.but("squash unl --target wmm --message 'squashed'")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Squashed 1 into 1
+Squashed unl into wmm
 
 "#]]);
 
@@ -199,11 +199,11 @@ Squashed 1 into 1
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1#0 squashed
-┊│     1#0:k A one
-┊│     1#0:o A three
-┊●   1#1 add two
-┊│     1#1:t A two
+┊●   wmm squashed
+┊│     wmm:k A one
+┊│     wmm:o A three
+┊●   zxw add two
+┊│     zxw:t A two
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -215,11 +215,11 @@ Hint: run `but help` for all commands
     env.but("undo").assert().success();
 
     // The same squash in the other direction ends up with the same files per commit.
-    env.but("squash 1#0 --target 1#2 --message 'squashed'")
+    env.but("squash wmm --target unl --message 'squashed'")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Squashed 1 into 1
+Squashed wmm into unl
 
 "#]]);
 
@@ -230,11 +230,11 @@ Squashed 1 into 1
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1#0 add two
-┊│     1#0:t A two
-┊●   1#1 squashed
-┊│     1#1:k A one
-┊│     1#1:o A three
+┊●   zxw add two
+┊│     zxw:t A two
+┊●   unl squashed
+┊│     unl:k A one
+┊│     unl:o A three
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -248,7 +248,7 @@ Hint: run `but help` for all commands
 fn use_target_message() {
     let env = one_branch_three_commits();
 
-    env.but("squash 1#0 --target 1#1 --use-target-message")
+    env.but("squash wmm --target zxw --use-target-message")
         .assert()
         .success();
 
@@ -259,13 +259,13 @@ fn use_target_message() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊● 1#0 author 2000-01-01 00:00:00 +0000 (sha 5ab5165)
+┊● zxw author 2000-01-01 00:00:00 +0000 (sha 24ba093)
 ┊│     add two
-┊│     1#0:o A three
-┊│     1#0:t A two
-┊● 1#1 author 2000-01-01 00:00:00 +0000 (sha ea345ba)
+┊│     zxw:o A three
+┊│     zxw:t A two
+┊● unl author 2000-01-01 00:00:00 +0000 (sha 72aceac)
 ┊│     add one
-┊│     1#1:k A one
+┊│     unl:k A one
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -279,7 +279,7 @@ Hint: run `but help` for all commands
 fn use_source_message() {
     let env = one_branch_three_commits();
 
-    env.but("squash 1#0 --target 1#1 --use-source-message")
+    env.but("squash wmm --target zxw --use-source-message")
         .assert()
         .success();
 
@@ -290,13 +290,13 @@ fn use_source_message() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊● 1#0 author 2000-01-01 00:00:00 +0000 (sha c441d34)
+┊● zxw author 2000-01-01 00:00:00 +0000 (sha 83dd951)
 ┊│     add three
-┊│     1#0:o A three
-┊│     1#0:t A two
-┊● 1#1 author 2000-01-01 00:00:00 +0000 (sha ea345ba)
+┊│     zxw:o A three
+┊│     zxw:t A two
+┊● unl author 2000-01-01 00:00:00 +0000 (sha 72aceac)
 ┊│     add one
-┊│     1#1:k A one
+┊│     unl:k A one
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -314,7 +314,7 @@ fn squash_whole_branch() {
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Squashed branch 'a-branch-1' into 1
+Squashed branch 'a-branch-1' into unl
 
 "#]]);
 
@@ -325,11 +325,11 @@ Squashed branch 'a-branch-1' into 1
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊● 1 author 2000-01-01 00:00:00 +0000 (sha a694042)
+┊● unl author 2000-01-01 00:00:00 +0000 (sha ed1d278)
 ┊│     squashed a branch
-┊│     1:k A one
-┊│     1:o A three
-┊│     1:t A two
+┊│     unl:k A one
+┊│     unl:o A three
+┊│     unl:t A two
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -343,11 +343,11 @@ Hint: run `but help` for all commands
 fn squash_whole_branch_into_commit_on_same_branch() {
     let env = one_branch_three_commits();
 
-    env.but("squash a-branch-1 -t 1#1 --use-target-message")
+    env.but("squash a-branch-1 -t zxw --use-target-message")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Squashed branch 'a-branch-1' into 1
+Squashed branch 'a-branch-1' into zxw
 
 "#]]);
 
@@ -358,11 +358,11 @@ Squashed branch 'a-branch-1' into 1
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊● 1 author 2000-01-01 00:00:00 +0000 (sha 17b59a2)
+┊● zxw author 2000-01-01 00:00:00 +0000 (sha 1a1b8f3)
 ┊│     add two
-┊│     1:k A one
-┊│     1:o A three
-┊│     1:t A two
+┊│     zxw:k A one
+┊│     zxw:o A three
+┊│     zxw:t A two
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -392,26 +392,26 @@ fn squash_whole_branch_into_commit_on_other_branch() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ fi [add-file-branch]
-┊● 1#0 author 2000-01-01 00:00:00 +0000 (sha e528488)
+┊● vkm author 2000-01-01 00:00:00 +0000 (sha 327daf7)
 ┊│     add file
-┊│     1#0:q A file
+┊│     vkm:q A file
 ├╯
 ┊
 ┊╭┄ ta [target-branch]
-┊● 1#1 author 2000-01-01 00:00:00 +0000 (sha d1d6a19) (no changes)
+┊● tqv author 2000-01-01 00:00:00 +0000 (sha d1ca6df) (no changes)
 ┊│     new commit on new branch
 ├╯
 ┊
 ┊╭┄ br [a-branch-1]
-┊● 1#2 author 2000-01-01 00:00:00 +0000 (sha f55169f)
+┊● wmm author 2000-01-01 00:00:00 +0000 (sha cc25973)
 ┊│     add three
-┊│     1#2:o A three
-┊● 1#3 author 2000-01-01 00:00:00 +0000 (sha f63361f)
+┊│     wmm:o A three
+┊● zxw author 2000-01-01 00:00:00 +0000 (sha 23dc0c8)
 ┊│     add two
-┊│     1#3:t A two
-┊● 1#4 author 2000-01-01 00:00:00 +0000 (sha ea345ba)
+┊│     zxw:t A two
+┊● unl author 2000-01-01 00:00:00 +0000 (sha 72aceac)
 ┊│     add one
-┊│     1#4:k A one
+┊│     unl:k A one
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -420,11 +420,11 @@ Hint: run `but help` for all commands
 
 "#]]);
 
-    env.but("squash a-branch-1 add-file-branch -t 1#1 --use-target-message")
+    env.but("squash a-branch-1 add-file-branch -t tqv --use-target-message")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Squashed branches 'a-branch-1', 'add-file-branch' into 1
+Squashed branches 'a-branch-1', 'add-file-branch' into tqv
 
 "#]]);
 
@@ -435,12 +435,12 @@ Squashed branches 'a-branch-1', 'add-file-branch' into 1
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ ta [target-branch]
-┊● 1 author 2000-01-01 00:00:00 +0000 (sha 44aa30a)
+┊● tqv author 2000-01-01 00:00:00 +0000 (sha 5ce6b4f)
 ┊│     new commit on new branch
-┊│     1:q A file
-┊│     1:k A one
-┊│     1:o A three
-┊│     1:t A two
+┊│     tqv:q A file
+┊│     tqv:k A one
+┊│     tqv:o A three
+┊│     tqv:t A two
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -473,28 +473,28 @@ fn squash_multiple_branches_into_commit_on_one_of_the_branch_sources() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ fi [add-file-branch]
-┊● 1#0 author 2000-01-01 00:00:00 +0000 (sha e528488)
+┊● vkm author 2000-01-01 00:00:00 +0000 (sha 327daf7)
 ┊│     add file
-┊│     1#0:q A file
+┊│     vkm:q A file
 ├╯
 ┊
 ┊╭┄ ta [target-branch]
-┊● 1#1 author 2000-01-01 00:00:00 +0000 (sha a489b93) (no changes)
+┊● qvx author 2000-01-01 00:00:00 +0000 (sha b9eb681) (no changes)
 ┊│     random commit on target-branch
-┊● 1#2 author 2000-01-01 00:00:00 +0000 (sha 561a8d8) (no changes)
+┊● tqv author 2000-01-01 00:00:00 +0000 (sha 6dae581) (no changes)
 ┊│     target commit
 ├╯
 ┊
 ┊╭┄ br [a-branch-1]
-┊● 1#3 author 2000-01-01 00:00:00 +0000 (sha f55169f)
+┊● wmm author 2000-01-01 00:00:00 +0000 (sha cc25973)
 ┊│     add three
-┊│     1#3:o A three
-┊● 1#4 author 2000-01-01 00:00:00 +0000 (sha f63361f)
+┊│     wmm:o A three
+┊● zxw author 2000-01-01 00:00:00 +0000 (sha 23dc0c8)
 ┊│     add two
-┊│     1#4:t A two
-┊● 1#5 author 2000-01-01 00:00:00 +0000 (sha ea345ba)
+┊│     zxw:t A two
+┊● unl author 2000-01-01 00:00:00 +0000 (sha 72aceac)
 ┊│     add one
-┊│     1#5:k A one
+┊│     unl:k A one
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -503,11 +503,11 @@ Hint: run `but help` for all commands
 
 "#]]);
 
-    env.but("squash target-branch a-branch-1 add-file-branch -t 1#2 --use-target-message")
+    env.but("squash target-branch a-branch-1 add-file-branch -t tqv --use-target-message")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Squashed branches 'target-branch', 'a-branch-1', 'add-file-branch' into 1
+Squashed branches 'target-branch', 'a-branch-1', 'add-file-branch' into tqv
 
 "#]]);
 
@@ -518,12 +518,12 @@ Squashed branches 'target-branch', 'a-branch-1', 'add-file-branch' into 1
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ ta [target-branch]
-┊● 1 author 2000-01-01 00:00:00 +0000 (sha 0653794)
+┊● tqv author 2000-01-01 00:00:00 +0000 (sha 2a2f0c1)
 ┊│     target commit
-┊│     1:q A file
-┊│     1:k A one
-┊│     1:o A three
-┊│     1:t A two
+┊│     tqv:q A file
+┊│     tqv:k A one
+┊│     tqv:o A three
+┊│     tqv:t A two
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -549,7 +549,7 @@ fn squash_reword_with_editor() {
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Squashed branch 'a-branch-1' into 1
+Squashed branch 'a-branch-1' into unl
 
 "#]]);
 
@@ -560,11 +560,11 @@ Squashed branch 'a-branch-1' into 1
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊● 1 author 2000-01-01 00:00:00 +0000 (sha 7b3d915)
+┊● unl author 2000-01-01 00:00:00 +0000 (sha a806dcc)
 ┊│     message from editor
-┊│     1:k A one
-┊│     1:o A three
-┊│     1:t A two
+┊│     unl:k A one
+┊│     unl:o A three
+┊│     unl:t A two
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -587,7 +587,7 @@ fn squash_combine_messages_with_editor() {
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Squashed branch 'a-branch-1' into 1
+Squashed branch 'a-branch-1' into unl
 
 "#]]);
 
@@ -598,11 +598,11 @@ Squashed branch 'a-branch-1' into 1
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊● 1 author 2000-01-01 00:00:00 +0000 (sha abb21d9)
-┊│     add one  add three  add two
-┊│     1:k A one
-┊│     1:o A three
-┊│     1:t A two
+┊● unl author 2000-01-01 00:00:00 +0000 (sha 9269bbf)
+┊│     add one  add two  add three
+┊│     unl:k A one
+┊│     unl:o A three
+┊│     unl:t A two
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -644,7 +644,9 @@ fn cannot_mix_sources() {
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
-Error: Cannot mix different types of sources
+Error: Could not find source: '1#0'
+
+Hint: Run `but status` for applicable targets.
 
 "#]]);
 }
@@ -710,7 +712,9 @@ fn cannot_squash_commit_into_itself() {
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
-Error: Cannot squash a commit into itself
+Error: Could not find source: '1#0'
+
+Hint: Run `but status` for applicable targets.
 
 "#]]);
 }
@@ -744,7 +748,9 @@ fn cannot_squash_empty_branch_into_commit() {
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
-Error: Need at least 2 commits to squash
+Error: Could not find target: '1'
+
+Hint: --target must be an applied commit, branch, or @. Run `but status` for applicable targets.
 
 "#]]);
 }
@@ -770,12 +776,12 @@ fn aborts_on_conflicts() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1#0 remove file
-┊│     1#0:u D file.txt
-┊●   1#1 change file
-┊│     1#1:u M file.txt
-┊●   1#2 add file
-┊│     1#2:u A file.txt
+┊●   nwl remove file
+┊│     nwl:u D file.txt
+┊●   lyo change file
+┊│     lyo:u M file.txt
+┊●   oyv add file
+┊│     oyv:u A file.txt
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -788,7 +794,9 @@ Hint: run `but help` for all commands
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
-Error: Cannot squash commits that would result in merge conflicts
+Error: Could not find source: '1#0'
+
+Hint: Run `but status` for applicable targets.
 
 "#]]);
 }
@@ -804,17 +812,17 @@ fn cannot_squash_into_commits_on_unapplied_branches() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ se [second]
-┊●   1#0 add four
-┊│     1#0:q A four
-┊●   1#1 add three
-┊│     1#1:o A three
+┊●   uqr add four
+┊│     uqr:q A four
+┊●   slw add three
+┊│     slw:o A three
 ├╯
 ┊
 ┊╭┄ on [one]
-┊●   1#2 add two
-┊│     1#2:t A two
-┊●   1#3 add one
-┊│     1#3:k A one
+┊●   zxw add two
+┊│     zxw:t A two
+┊●   unl add one
+┊│     unl:k A one
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -830,9 +838,9 @@ Hint: run `but help` for all commands
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
-Error: Could not find target: 'd15f721'
+Error: Could not find source: '1#0'
 
-Hint: --target must be an applied commit, branch, or @. Run `but status` for applicable targets.
+Hint: Run `but status` for applicable targets.
 
 "#]]);
 }
@@ -889,11 +897,11 @@ Error: Need at least 2 commits to squash
 fn squash_with_duplicate_commit_sources() {
     let env = one_branch_three_commits();
 
-    env.but("squash 1#0 1#0 -t 1#1 -u")
+    env.but("squash wmm wmm -t zxw -u")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Squashed 1 into 1
+Squashed wmm into zxw
 
 "#]]);
 
@@ -904,11 +912,11 @@ Squashed 1 into 1
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1#0 add two
-┊│     1#0:o A three
-┊│     1#0:t A two
-┊●   1#1 add one
-┊│     1#1:k A one
+┊●   zxw add two
+┊│     zxw:o A three
+┊│     zxw:t A two
+┊●   unl add one
+┊│     unl:k A one
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -922,11 +930,11 @@ Hint: run `but help` for all commands
 fn squash_with_duplicate_branch_sources() {
     let env = two_branches();
 
-    env.but("squash one one -t 1#0 -u")
+    env.but("squash one one -t uqr -u")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Squashed branch 'one' into 1
+Squashed branch 'one' into uqr
 
 "#]]);
 
@@ -937,12 +945,12 @@ Squashed branch 'one' into 1
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ se [second]
-┊●   1#0 add four
-┊│     1#0:q A four
-┊│     1#0:k A one
-┊│     1#0:t A two
-┊●   1#1 add three
-┊│     1#1:o A three
+┊●   uqr add four
+┊│     uqr:q A four
+┊│     uqr:k A one
+┊│     uqr:t A two
+┊●   slw add three
+┊│     slw:o A three
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -966,7 +974,7 @@ fn amend_uncommitted_files_into_commit() {
 ┊   twop A two
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1 (no commit message) (no changes)
+┊●   tqv (no commit message) (no changes)
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -975,11 +983,11 @@ Hint: run `but diff` to see uncommitted changes and `but commit -b <branch> -m "
 
 "#]]);
 
-    env.but("squash one two -t 1 -u")
+    env.but("squash one two -t tqv -u")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Amended 1
+Amended tqv
 
 "#]]);
 
@@ -991,9 +999,9 @@ Amended 1
 ┊   or A three
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1 (no commit message)
-┊│     1:k A one
-┊│     1:t A two
+┊●   tqv (no commit message)
+┊│     tqv:k A one
+┊│     tqv:t A two
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -1017,7 +1025,7 @@ fn amend_all_uncommitted_changes_into_commit() {
 ┊   twop A two
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1 (no commit message) (no changes)
+┊●   tqv (no commit message) (no changes)
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -1026,11 +1034,11 @@ Hint: run `but diff` to see uncommitted changes and `but commit -b <branch> -m "
 
 "#]]);
 
-    env.but("squash @ -t 1 -u")
+    env.but("squash @ -t tqv -u")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Amended 1
+Amended tqv
 
 "#]]);
 
@@ -1041,10 +1049,10 @@ Amended 1
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1 (no commit message)
-┊│     1:k A one
-┊│     1:o A three
-┊│     1:t A two
+┊●   tqv (no commit message)
+┊│     tqv:k A one
+┊│     tqv:o A three
+┊│     tqv:t A two
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -1098,11 +1106,11 @@ fn amend_uncommitted_hunks_into_commits() {
 
 "#]]);
 
-    env.but("squash qs:9 -t 1 -u")
+    env.but("squash qs:9 -t nky -u")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Amended 1
+Amended nky
 
 "#]]);
 
@@ -1129,11 +1137,11 @@ Amended 1
 fn amend_all_uncommitted_changes_when_area_is_empty() {
     let env = one_branch_three_commits();
 
-    env.but("squash @ -t 1#0 -u")
+    env.but("squash @ -t wmm -u")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Amended 1
+Amended wmm
 
 "#]]);
 
@@ -1144,12 +1152,12 @@ Amended 1
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1#0 add three
-┊│     1#0:o A three
-┊●   1#1 add two
-┊│     1#1:t A two
-┊●   1#2 add one
-┊│     1#2:k A one
+┊●   wmm add three
+┊│     wmm:o A three
+┊●   zxw add two
+┊│     zxw:t A two
+┊●   unl add one
+┊│     unl:k A one
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -1163,11 +1171,11 @@ Hint: run `but help` for all commands
 fn amend_committed_file() {
     let env = one_branch_three_commits();
 
-    env.but("squash 1#0:o -t 1#1 -u")
+    env.but("squash wmm:o -t zxw -u")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Amended 1
+Amended zxw
 
 "#]]);
 
@@ -1178,12 +1186,12 @@ Amended 1
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1#0 add three (no changes)
-┊●   1#1 add two
-┊│     1#1:o A three
-┊│     1#1:t A two
-┊●   1#2 add one
-┊│     1#2:k A one
+┊●   wmm add three (no changes)
+┊●   zxw add two
+┊│     zxw:o A three
+┊│     zxw:t A two
+┊●   unl add one
+┊│     unl:k A one
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -1204,12 +1212,12 @@ fn cannot_amend_files_from_different_commits() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1#0 add three
-┊│     1#0:o A three
-┊●   1#1 add two
-┊│     1#1:t A two
-┊●   1#2 add one
-┊│     1#2:k A one
+┊●   wmm add three
+┊│     wmm:o A three
+┊●   zxw add two
+┊│     zxw:t A two
+┊●   unl add one
+┊│     unl:k A one
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -1222,7 +1230,9 @@ Hint: run `but help` for all commands
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
-Error: All committed changes must come from the same commit. Found changes from [..] and [..]
+Error: Could not find source: '1#0:o'
+
+Hint: Run `but status` for applicable targets.
 
 "#]]);
 }
@@ -1248,12 +1258,12 @@ fn cannot_amend_files_in_ways_that_cause_conflicts() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1#0 remove file
-┊│     1#0:q D file
-┊●   1#1 change file
-┊│     1#1:q M file
-┊●   1#2 add file
-┊│     1#2:q A file
+┊●   xnw remove file
+┊│     xnw:q D file
+┊●   qon change file
+┊│     qon:q M file
+┊●   lrm add file
+┊│     lrm:q A file
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -1266,7 +1276,9 @@ Hint: run `but help` for all commands
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
-Error: Failed to apply changes to destination commit - merge conflict
+Error: Could not find source: '1#0:q'
+
+Hint: Run `but status` for applicable targets.
 
 "#]]);
 }
@@ -1281,7 +1293,7 @@ fn squash_into_branch_tip() {
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Amended 1
+Amended wmm
 
 "#]]);
 
@@ -1292,13 +1304,13 @@ Amended 1
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1#0 add three
-┊│     1#0:q A file
-┊│     1#0:o A three
-┊●   1#1 add two
-┊│     1#1:t A two
-┊●   1#2 add one
-┊│     1#2:k A one
+┊●   wmm add three
+┊│     wmm:q A file
+┊│     wmm:o A three
+┊●   zxw add two
+┊│     zxw:t A two
+┊●   unl add one
+┊│     unl:k A one
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -1354,7 +1366,7 @@ Error: --target cannot be an empty branch
 ┊╭┄ mi [middle] (no commits)
 ┊│
 ┊├┄ bo [bottom]
-┊●   1 (no commit message) (no changes)
+┊●   tqv (no commit message) (no changes)
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -1394,11 +1406,11 @@ Hint: --target must be an applied commit, branch, or @. Run `but status` for app
 fn squash_into_uncommitted_area_to_uncommit_commit() {
     let env = one_branch_three_commits();
 
-    env.but("squash 1#0 -t @")
+    env.but("squash wmm -t @")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Uncommitted 1
+Uncommitted wmm
 
 "#]]);
 
@@ -1410,10 +1422,10 @@ Uncommitted 1
 ┊   or A three
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1#0 add two
-┊│     1#0:t A two
-┊●   1#1 add one
-┊│     1#1:k A one
+┊●   zxw add two
+┊│     zxw:t A two
+┊●   unl add one
+┊│     unl:k A one
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -1424,7 +1436,7 @@ Hint: run `but diff` to see uncommitted changes and `but commit -b <branch> -m "
 
     env.but("undo").assert().success();
 
-    env.but("squash 1#0 -t @ --json")
+    env.but("squash wmm -t @ --json")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#""#]]);
@@ -1441,12 +1453,12 @@ fn squash_into_uncommitted_area_to_uncommit_file() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1#0 add three
-┊│     1#0:o A three
-┊●   1#1 add two
-┊│     1#1:t A two
-┊●   1#2 add one
-┊│     1#2:k A one
+┊●   wmm add three
+┊│     wmm:o A three
+┊●   zxw add two
+┊│     zxw:t A two
+┊●   unl add one
+┊│     unl:k A one
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -1455,11 +1467,11 @@ Hint: run `but help` for all commands
 
 "#]]);
 
-    env.but("squash 1#0:o -t @")
+    env.but("squash wmm:o -t @")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Uncommitted from 1
+Uncommitted from wmm
 
 "#]]);
 
@@ -1471,11 +1483,11 @@ Uncommitted from 1
 ┊   or A three
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1#0 add three (no changes)
-┊●   1#1 add two
-┊│     1#1:t A two
-┊●   1#2 add one
-┊│     1#2:k A one
+┊●   wmm add three (no changes)
+┊●   zxw add two
+┊│     zxw:t A two
+┊●   unl add one
+┊│     unl:k A one
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -1506,12 +1518,12 @@ fn cannot_uncommit_files_in_ways_that_cause_conflicts() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1#0 remove file
-┊│     1#0:q D file
-┊●   1#1 change file
-┊│     1#1:q M file
-┊●   1#2 add file
-┊│     1#2:q A file
+┊●   xnw remove file
+┊│     xnw:q D file
+┊●   qon change file
+┊│     qon:q M file
+┊●   lrm add file
+┊│     lrm:q A file
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -1524,7 +1536,9 @@ Hint: run `but help` for all commands
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
-Error: Cannot uncommit commits that would result in merge conflicts
+Error: Could not find source: '1#2'
+
+Hint: Run `but status` for applicable targets.
 
 "#]]);
 
@@ -1532,7 +1546,9 @@ Error: Cannot uncommit commits that would result in merge conflicts
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
-Error: Cannot uncommit hunks that would result in merge conflicts
+Error: Could not find source: '1#2:q'
+
+Hint: Run `but status` for applicable targets.
 
 "#]]);
 }
@@ -1564,7 +1580,7 @@ Error: --use-source-message cannot be used when squashing uncommitted changes
 fn cannot_use_source_message_when_moving_committed_files() {
     let env = one_branch_three_commits();
 
-    env.but("squash 1#0:o -t 1#1 --use-source-message")
+    env.but("squash wmm:o -t zxw --use-source-message")
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
@@ -1603,12 +1619,12 @@ fn committed_file_to_uncommitted_area() {
 ...
               "changes": [
                 {
-                  "cliId": "1#0:n",
+                  "cliId": "k:n",
                   "filePath": "a.txt",
                   "changeType": "modified"
                 },
                 {
-                  "cliId": "1#0:p",
+                  "cliId": "k:p",
                   "filePath": "b.txt",
                   "changeType": "modified"
                 }
@@ -1618,12 +1634,12 @@ fn committed_file_to_uncommitted_area() {
 ...
               "changes": [
                 {
-                  "cliId": "1#1:n",
+                  "cliId": "m:n",
                   "filePath": "a.txt",
                   "changeType": "added"
                 },
                 {
-                  "cliId": "1#1:p",
+                  "cliId": "m:p",
                   "filePath": "b.txt",
                   "changeType": "added"
                 }
@@ -1643,7 +1659,7 @@ fn committed_file_to_uncommitted_area() {
 
 "#]]);
 
-    env.but("squash 1#0:p -t @").assert().success();
+    env.but("squash k:p -t @").assert().success();
 
     // Verify that `status` reflects the move.
     env.but("--json status -f")
@@ -1673,7 +1689,7 @@ fn committed_file_to_uncommitted_area() {
 ...
               "changes": [
                 {
-                  "cliId": "1#0:n",
+                  "cliId": "k:n",
                   "filePath": "a.txt",
                   "changeType": "modified"
                 }
@@ -1683,12 +1699,12 @@ fn committed_file_to_uncommitted_area() {
 ...
               "changes": [
                 {
-                  "cliId": "1#1:n",
+                  "cliId": "m:n",
                   "filePath": "a.txt",
                   "changeType": "added"
                 },
                 {
-                  "cliId": "1#1:p",
+                  "cliId": "m:p",
                   "filePath": "b.txt",
                   "changeType": "added"
                 }
@@ -1942,8 +1958,8 @@ fn uncommitted_to_commit_consumes_renames() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ g0 [A]
-┊●   1 seed rename source
-┊│     1:q A rename-target.txt
+┊●   ptu seed rename source
+┊│     ptu:q A rename-target.txt
 ┊●   tpm add A
 ┊│     tpm:t A A
 ├╯
@@ -2008,8 +2024,8 @@ fn uncommitted_file_to_commit_consumes_renames() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ g0 [A]
-┊●   1 seed rename source single
-┊│     1:x A rename-target-single.txt
+┊●   yrk seed rename source single
+┊│     yrk:x A rename-target-single.txt
 ┊●   tpm add A
 ┊│     tpm:t A A
 ├╯
@@ -2069,9 +2085,9 @@ fn uncommitted_deleted_file_to_commit_keeps_unrelated_deleted_file() {
 ┊   pn D b.txt
 ┊
 ┊╭┄ g0 [A]
-┊●   1 Add a.txt, b.txt, and c.txt
-┊│     1:p A b.txt
-┊│     1:k A c.txt
+┊●   rzo Add a.txt, b.txt, and c.txt
+┊│     rzo:p A b.txt
+┊│     rzo:k A c.txt
 ┊●   tpm add A
 ┊│     tpm:t A A
 ├╯
@@ -2196,7 +2212,7 @@ fn commit_without_message_to_commit() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ g0 [A]
-┊●   1 add one.txt
+┊●   our add one.txt
 ┊●   tpm add A
 ├╯
 ┊
@@ -2213,8 +2229,8 @@ fn commit_without_message_to_commit() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ g0 [A]
-┊●   1#0 (no commit message) (no changes)
-┊●   1#1 add one.txt
+┊●   qkv (no commit message) (no changes)
+┊●   our add one.txt
 ┊●   tpm add A
 ├╯
 ┊
@@ -2222,7 +2238,7 @@ fn commit_without_message_to_commit() {
 
 "#]]);
 
-    env.but("squash 1#0 -t 1#1 -u").assert().success();
+    env.but("squash qkv -t our -u").assert().success();
 
     env.but("status --no-hint")
         .assert()
@@ -2231,7 +2247,7 @@ fn commit_without_message_to_commit() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ g0 [A]
-┊●   1 add one.txt
+┊●   our add one.txt
 ┊●   tpm add A
 ├╯
 ┊
@@ -2251,7 +2267,7 @@ fn commit_to_commit_without_message() {
         .success();
     env.but("commit --empty --no-message").assert().success();
 
-    env.but("squash 1#1 -t 1#0 --use-source-message")
+    env.but("squash our -t qkv --use-source-message")
         .assert()
         .success();
 
@@ -2344,9 +2360,9 @@ fn squash_amending_modified_and_renamed_file() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1 add files
-┊│     1:q A file
-┊│     1:k A file-2
+┊●   ouv add files
+┊│     ouv:q A file
+┊│     ouv:k A file-2
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -2367,9 +2383,9 @@ Hint: run `but help` for all commands
 ┊   kw D file-2
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1 add files
-┊│     1:q A file
-┊│     1:k A file-2
+┊●   ouv add files
+┊│     ouv:q A file
+┊│     ouv:k A file-2
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -2378,7 +2394,7 @@ Hint: run `but diff` to see uncommitted changes and `but commit -b <branch> -m "
 
 "#]]);
 
-    env.but("squash @ -t 1 -u").assert().success();
+    env.but("squash @ -t ouv -u").assert().success();
 
     env.but("status -f")
         .assert()
@@ -2387,8 +2403,8 @@ Hint: run `but diff` to see uncommitted changes and `but commit -b <branch> -m "
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1 add files
-┊│     1:q A file
+┊●   ouv add files
+┊│     ouv:q A file
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -2424,8 +2440,8 @@ seven
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1#0 Update file
-┊●   1#1 Add file
+┊●   szk Update file
+┊●   knw Add file
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -2434,13 +2450,13 @@ Hint: run `but help` for all commands
 
 "#]]);
 
-    env.but("diff 1#0")
+    env.but("diff szk")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-──────────────╮
- 1#0:q:3 file │
-──────────────╯
+────────────╮
+ s:q:3 file │
+────────────╯
 
 @@ -1,3 +1,4 @@
 ───────────────
@@ -2449,9 +2465,9 @@ Hint: run `but help` for all commands
 2 ┊ 3 │  two
 3 ┊ 4 │  three
 
-──────────────╮
- 1#0:q:8 file │
-──────────────╯
+────────────╮
+ s:q:8 file │
+────────────╯
 
 @@ -5,3 +6,4 @@
 ───────────────
@@ -2462,22 +2478,22 @@ Hint: run `but help` for all commands
 
 "#]]);
 
-    env.but("squash 1#0:q:3 -t 1#1")
+    env.but("squash szk:q:3 -t knw")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Amended 1
+Amended knw
 
 "#]]);
 
     // no longer contains "beginning"
-    env.but("diff 1#0")
+    env.but("diff szk")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-──────────────╮
- 1#0:q:8 file │
-──────────────╯
+────────────╮
+ s:q:8 file │
+────────────╯
 
 @@ -6,3 +6,4 @@
 ───────────────
@@ -2489,13 +2505,13 @@ Amended 1
 "#]]);
 
     // now contains "beginning"
-    env.but("diff 1#1")
+    env.but("diff knw")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-──────────────╮
- 1#1:q:c file │
-──────────────╯
+────────────╮
+ k:q:c file │
+────────────╯
 
 @@ -1,0 +1,8 @@
 ───────────────
@@ -2510,7 +2526,7 @@ Amended 1
 
 "#]]);
 
-    env.but("squash 1#0:q:8 -t @").assert().success();
+    env.but("squash szk:q:8 -t @").assert().success();
 
     // "end" is now uncommitted and no longer in its source commit.
     env.but("diff")
@@ -2529,7 +2545,7 @@ Amended 1
   ┊  9 │ +end
 
 "#]]);
-    env.but("diff 1#0")
+    env.but("diff szk")
         .assert()
         .success()
         .stdout_eq(snapbox::str![]);
@@ -2561,8 +2577,8 @@ seven
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1#0 Update file
-┊●   1#1 Add file
+┊●   szk Update file
+┊●   knw Add file
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -2571,13 +2587,13 @@ Hint: run `but help` for all commands
 
 "#]]);
 
-    env.but("diff 1#0")
+    env.but("diff szk")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-──────────────╮
- 1#0:q:3 file │
-──────────────╯
+────────────╮
+ s:q:3 file │
+────────────╯
 
 @@ -1,3 +1,4 @@
 ───────────────
@@ -2586,9 +2602,9 @@ Hint: run `but help` for all commands
 2 ┊ 3 │  two
 3 ┊ 4 │  three
 
-──────────────╮
- 1#0:q:8 file │
-──────────────╯
+────────────╮
+ s:q:8 file │
+────────────╯
 
 @@ -5,3 +6,4 @@
 ───────────────
@@ -2600,15 +2616,15 @@ Hint: run `but help` for all commands
 "#]]);
 
     // entire file, this is the baseline
-    env.but("squash 1#0:q -t 1#1").assert().success();
-    let output_entire_file = env.but("diff 1#1").output().unwrap();
-    env.but("diff 1#1")
+    env.but("squash szk:q -t knw").assert().success();
+    let output_entire_file = env.but("diff knw").output().unwrap();
+    env.but("diff knw")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-──────────────╮
- 1#1:q:0 file │
-──────────────╯
+────────────╮
+ k:q:0 file │
+────────────╯
 
 @@ -1,0 +1,9 @@
 ───────────────
@@ -2626,8 +2642,8 @@ Hint: run `but help` for all commands
 
     // hunk order
     env.but("undo").assert().success();
-    env.but("squash 1#0:q:3 1#0:q:8 -t 1#1").assert().success();
-    let output_hunk_order = env.but("diff 1#1").output().unwrap();
+    env.but("squash szk:q:3 szk:q:8 -t knw").assert().success();
+    let output_hunk_order = env.but("diff knw").output().unwrap();
     assert_eq!(
         output_hunk_order, output_entire_file,
         "outcome should be the same regardless of hunk order"
@@ -2635,8 +2651,8 @@ Hint: run `but help` for all commands
 
     // reverse hunk order
     env.but("undo").assert().success();
-    env.but("squash 1#0:q:8 1#0:q:3 -t 1#1").assert().success();
-    let output_reverse_hunk_order = env.but("diff 1#1").output().unwrap();
+    env.but("squash szk:q:8 szk:q:3 -t knw").assert().success();
+    let output_reverse_hunk_order = env.but("diff knw").output().unwrap();
 
     assert_eq!(
         output_reverse_hunk_order, output_entire_file,
@@ -2645,10 +2661,10 @@ Hint: run `but help` for all commands
 
     // repeated hunks
     env.but("undo").assert().success();
-    env.but("squash 1#0:q:8 1#0:q:3 1#0:q:8 -t 1#1")
+    env.but("squash szk:q:8 szk:q:3 szk:q:8 -t knw")
         .assert()
         .success();
-    let output_repeated_hunks = env.but("diff 1#1").output().unwrap();
+    let output_repeated_hunks = env.but("diff knw").output().unwrap();
 
     assert_eq!(
         output_repeated_hunks, output_entire_file,
@@ -2657,8 +2673,8 @@ Hint: run `but help` for all commands
 
     // hunk then file
     env.but("undo").assert().success();
-    env.but("squash 1#0:q:8 1#0:q -t 1#1").assert().success();
-    let output_hunk_then_file = env.but("diff 1#1").output().unwrap();
+    env.but("squash szk:q:8 szk:q -t knw").assert().success();
+    let output_hunk_then_file = env.but("diff knw").output().unwrap();
 
     assert_eq!(
         output_hunk_then_file, output_entire_file,
@@ -2667,8 +2683,8 @@ Hint: run `but help` for all commands
 
     // file then hunk
     env.but("undo").assert().success();
-    env.but("squash 1#0:q 1#0:q:8 -t 1#1").assert().success();
-    let output_file_then_hunk = env.but("diff 1#1").output().unwrap();
+    env.but("squash szk:q szk:q:8 -t knw").assert().success();
+    let output_file_then_hunk = env.but("diff knw").output().unwrap();
 
     assert_eq!(
         output_file_then_hunk, output_entire_file,
@@ -2695,11 +2711,11 @@ fn squash_deleted_committed_file_and_hunk_both_propagate_deletion() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1#0 Delete file
-┊│     1#0:n D deleted.txt
-┊●   1#1 Target (no changes)
-┊●   1#2 Add file to delete
-┊│     1#2:n A deleted.txt
+┊●   oos Delete file
+┊│     oos:n D deleted.txt
+┊●   uyq Target (no changes)
+┊●   qss Add file to delete
+┊│     qss:n A deleted.txt
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -2707,13 +2723,13 @@ fn squash_deleted_committed_file_and_hunk_both_propagate_deletion() {
 Hint: run `but help` for all commands
 
 "#]]);
-    env.but("diff 1#0:n")
+    env.but("diff oos:n")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-─────────────────────╮
- 1#0:n:f deleted.txt │
-─────────────────────╯
+───────────────────╮
+ o:n:f deleted.txt │
+───────────────────╯
 
 @@ -1,1 +1,0 @@
 ───────────────
@@ -2721,7 +2737,7 @@ Hint: run `but help` for all commands
 
 "#]]);
 
-    env.but("squash 1#0:n -t 1#1 -u").assert().success();
+    env.but("squash oos:n -t uyq -u").assert().success();
     env.but("status -f")
         .assert()
         .success()
@@ -2729,11 +2745,11 @@ Hint: run `but help` for all commands
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1#0 Delete file (no changes)
-┊●   1#1 Target
-┊│     1#1:n D deleted.txt
-┊●   1#2 Add file to delete
-┊│     1#2:n A deleted.txt
+┊●   oos Delete file (no changes)
+┊●   uyq Target
+┊│     uyq:n D deleted.txt
+┊●   qss Add file to delete
+┊│     qss:n A deleted.txt
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -2744,7 +2760,7 @@ Hint: run `but help` for all commands
     let file_outcome = env.but("status -f").output().unwrap();
 
     env.but("undo").assert().success();
-    env.but("squash 1#0:n:f -t 1#1 -u").assert().success();
+    env.but("squash oos:n:f -t uyq -u").assert().success();
     let hunk_outcome = env.but("status -f").output().unwrap();
 
     assert_eq!(
@@ -2775,11 +2791,11 @@ fn squash_renamed_committed_file_transfers_both_content_and_renaming() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1#0 Rename and update file
-┊│     1#0:s R renamed.txt
-┊●   1#1 Target (no changes)
-┊●   1#2 Add file to rename
-┊│     1#2:n A original.txt
+┊●   xyk Rename and update file
+┊│     xyk:s R renamed.txt
+┊●   kzy Target (no changes)
+┊●   nxx Add file to rename
+┊│     nxx:n A original.txt
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -2788,7 +2804,7 @@ Hint: run `but help` for all commands
 
 "#]]);
 
-    env.but("squash 1#0:s -t 1#1 -u").assert().success();
+    env.but("squash xyk:s -t kzy -u").assert().success();
     env.but("status -f")
         .assert()
         .success()
@@ -2796,11 +2812,11 @@ Hint: run `but help` for all commands
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1#0 Rename and update file (no changes)
-┊●   1#1 Target
-┊│     1#1:s R renamed.txt
-┊●   1#2 Add file to rename
-┊│     1#2:n A original.txt
+┊●   xyk Rename and update file (no changes)
+┊●   kzy Target
+┊│     kzy:s R renamed.txt
+┊●   nxx Add file to rename
+┊│     nxx:n A original.txt
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -2836,11 +2852,11 @@ fn squash_hunk_from_renamed_committed_file_does_not_transfer_renaming() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1#0 Rename and update file
-┊│     1#0:s R renamed.txt
-┊●   1#1 Target (no changes)
-┊●   1#2 Add file to rename
-┊│     1#2:n A original.txt
+┊●   xyk Rename and update file
+┊│     xyk:s R renamed.txt
+┊●   kzy Target (no changes)
+┊●   nxx Add file to rename
+┊│     nxx:n A original.txt
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -2849,13 +2865,13 @@ Hint: run `but help` for all commands
 
 "#]]);
 
-    env.but("diff 1#0:s")
+    env.but("diff xyk:s")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-─────────────────────╮
- 1#0:s:b renamed.txt │
-─────────────────────╯
+───────────────────╮
+ x:s:b renamed.txt │
+───────────────────╯
 
 @@ -1,3 +1,4 @@
 ───────────────
@@ -2866,7 +2882,7 @@ Hint: run `but help` for all commands
 
 "#]]);
 
-    env.but("squash 1#0:s:b -t 1#1 -u").assert().success();
+    env.but("squash xyk:s:b -t kzy -u").assert().success();
     env.but("status -f")
         .assert()
         .success()
@@ -2874,12 +2890,12 @@ Hint: run `but help` for all commands
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1#0 Rename and update file
-┊│     1#0:s R renamed.txt
-┊●   1#1 Target
-┊│     1#1:n M original.txt
-┊●   1#2 Add file to rename
-┊│     1#2:n A original.txt
+┊●   xyk Rename and update file
+┊│     xyk:s R renamed.txt
+┊●   kzy Target
+┊│     kzy:n M original.txt
+┊●   nxx Add file to rename
+┊│     nxx:n A original.txt
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -2907,7 +2923,7 @@ fn doesnt_open_editor_if_no_sources_have_message() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ g0 [A]
-┊●   1 (no commit message) (no changes)
+┊●   orn (no commit message) (no changes)
 ┊●   tpm add A
 ┊│     tpm:t A A
 ├╯
@@ -2918,7 +2934,7 @@ Hint: run `but help` for all commands
 
 "#]]);
 
-    env.but("squash 1 -t tpm")
+    env.but("squash orn -t tpm")
         .env("GIT_EDITOR", editor_command)
         .assert()
         .success();
@@ -2959,7 +2975,7 @@ fn doesnt_open_editor_if_no_target_has_message() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ g0 [A]
-┊●   1 (no commit message) (no changes)
+┊●   orn (no commit message) (no changes)
 ┊●   tpm add A
 ┊│     tpm:t A A
 ├╯
@@ -2970,7 +2986,7 @@ Hint: run `but help` for all commands
 
 "#]]);
 
-    env.but("squash tpm -t 1")
+    env.but("squash tpm -t orn")
         .env("GIT_EDITOR", editor_command)
         .assert()
         .success();
@@ -2982,8 +2998,8 @@ Hint: run `but help` for all commands
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ g0 [A]
-┊●   1 add A
-┊│     1:t A A
+┊●   orn add A
+┊│     orn:t A A
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -3012,8 +3028,8 @@ fn doesnt_open_editor_if_both_source_and_target_doesnt_have_a_message() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ g0 [A]
-┊●   1#0 (no commit message) (no changes)
-┊●   1#1 (no commit message) (no changes)
+┊●   mwn (no commit message) (no changes)
+┊●   orn (no commit message) (no changes)
 ┊●   tpm add A
 ┊│     tpm:t A A
 ├╯
@@ -3024,7 +3040,7 @@ Hint: run `but help` for all commands
 
 "#]]);
 
-    env.but("squash 1#0 -t 1#1")
+    env.but("squash mwn -t orn")
         .env("GIT_EDITOR", editor_command)
         .assert()
         .success();
@@ -3036,7 +3052,7 @@ Hint: run `but help` for all commands
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ g0 [A]
-┊●   1 (no commit message) (no changes)
+┊●   orn (no commit message) (no changes)
 ┊●   tpm add A
 ┊│     tpm:t A A
 ├╯

--- a/crates/but/tests/but/command/squash.rs
+++ b/crates/but/tests/but/command/squash.rs
@@ -823,18 +823,17 @@ Hint: run `but help` for all commands
 
 "#]]);
 
+    // Unapplied commits have no change ID in the workspace map, so use the commit ID intentionally.
+    let unapplied_target = env.invoke_git("rev-parse --short=7 refs/heads/second");
     env.but("unapply second").assert().success();
 
-    // Unapplied commits have no change ID in the workspace map, so use the commit ID intentionally.
-    env.but("squash zxw -t d15f721")
+    env.but(format!("squash zxw -t {unapplied_target}"))
         .assert()
         .failure()
-        .stderr_eq(snapbox::str![[r#"
-Error: Could not find target: 'd15f721'
-
-Hint: --target must be an applied commit, branch, or @. Run `but status` for applicable targets.
-
-"#]]);
+        .stderr_eq(format!(
+            "Error: Could not find target: '{unapplied_target}'\n\n\
+             Hint: --target must be an applied commit, branch, or @. Run `but status` for applicable targets.\n"
+        ));
 }
 
 #[test]

--- a/crates/but/tests/but/command/squash.rs
+++ b/crates/but/tests/but/command/squash.rs
@@ -640,13 +640,11 @@ Examples:
 fn cannot_mix_sources() {
     let env = one_branch_three_commits();
 
-    env.but("squash a-branch-1 1#0 --target 1#2")
+    env.but("squash a-branch-1 wmm --target unl")
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
-Error: Could not find source: '1#0'
-
-Hint: Run `but status` for applicable targets.
+Error: Cannot mix different types of sources
 
 "#]]);
 }
@@ -655,13 +653,13 @@ Hint: Run `but status` for applicable targets.
 fn cannot_squash_multiple_commits_without_target() {
     let env = one_branch_three_commits();
 
-    env.but("squash 1#0 1#2")
+    env.but("squash wmm unl")
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
 Error: When --target isn't used the source must be exactly one branch
 
-Hint: To squash into the last source, use `but squash 1#0 -t 1#2`
+Hint: To squash into the last source, use `but squash wmm -t unl`
 
 "#]]);
 }
@@ -708,13 +706,11 @@ Error: Need at least 2 commits to squash
 fn cannot_squash_commit_into_itself() {
     let env = one_branch_three_commits();
 
-    env.but("squash 1#0 -t 1#0")
+    env.but("squash wmm -t wmm")
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
-Error: Could not find source: '1#0'
-
-Hint: Run `but status` for applicable targets.
+Error: Cannot squash a commit into itself
 
 "#]]);
 }
@@ -744,13 +740,11 @@ fn cannot_squash_empty_branch_into_commit() {
 
     env.but("branch new empty-branch").assert().success();
 
-    env.but("squash empty-branch -t 1")
+    env.but("squash empty-branch -t a-branch-1")
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
-Error: Could not find target: '1'
-
-Hint: --target must be an applied commit, branch, or @. Run `but status` for applicable targets.
+Error: Need at least 2 commits to squash
 
 "#]]);
 }
@@ -790,13 +784,11 @@ Hint: run `but help` for all commands
 
 "#]]);
 
-    env.but("squash 1#0 -t 1#2")
+    env.but("squash nwl -t oyv")
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
-Error: Could not find source: '1#0'
-
-Hint: Run `but status` for applicable targets.
+Error: Cannot squash commits that would result in merge conflicts
 
 "#]]);
 }
@@ -834,13 +826,13 @@ Hint: run `but help` for all commands
     env.but("unapply second").assert().success();
 
     // Unapplied commits have no change ID in the workspace map, so use the commit ID intentionally.
-    env.but("squash 1#0 -t d15f721")
+    env.but("squash zxw -t d15f721")
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
-Error: Could not find source: '1#0'
+Error: Could not find target: 'd15f721'
 
-Hint: Run `but status` for applicable targets.
+Hint: --target must be an applied commit, branch, or @. Run `but status` for applicable targets.
 
 "#]]);
 }
@@ -1226,13 +1218,11 @@ Hint: run `but help` for all commands
 
 "#]]);
 
-    env.but("squash 1#0:o 1#1:t -t 1#2 -u")
+    env.but("squash wmm:o zxw:t -t unl -u")
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
-Error: Could not find source: '1#0:o'
-
-Hint: Run `but status` for applicable targets.
+Error: All committed changes must come from the same commit. Found changes from [..] and [..]
 
 "#]]);
 }
@@ -1272,13 +1262,11 @@ Hint: run `but help` for all commands
 
 "#]]);
 
-    env.but("squash 1#0:q -t 1#2 -u")
+    env.but("squash xnw:q -t lrm -u")
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
-Error: Could not find source: '1#0:q'
-
-Hint: Run `but status` for applicable targets.
+Error: Failed to apply changes to destination commit - merge conflict
 
 "#]]);
 }
@@ -1532,23 +1520,19 @@ Hint: run `but help` for all commands
 
 "#]]);
 
-    env.but("squash 1#2 -t @")
+    env.but("squash lrm -t @")
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
-Error: Could not find source: '1#2'
-
-Hint: Run `but status` for applicable targets.
+Error: Cannot uncommit commits that would result in merge conflicts
 
 "#]]);
 
-    env.but("squash 1#2:q -t @")
+    env.but("squash lrm:q -t @")
         .assert()
         .failure()
         .stderr_eq(snapbox::str![[r#"
-Error: Could not find source: '1#2:q'
-
-Hint: Run `but status` for applicable targets.
+Error: Cannot uncommit hunks that would result in merge conflicts
 
 "#]]);
 }

--- a/crates/but/tests/but/command/status.rs
+++ b/crates/but/tests/but/command/status.rs
@@ -405,12 +405,12 @@ fn uncommitted_and_committed_file_cli_ids() {
 ...
               "changes": [
                 {
-                  "cliId": "1#0:n",
+                  "cliId": "w:n",
                   "filePath": "a.txt",
                   "changeType": "modified"
                 },
                 {
-                  "cliId": "1#0:p",
+                  "cliId": "w:p",
                   "filePath": "b.txt",
                   "changeType": "modified"
                 }
@@ -420,12 +420,12 @@ fn uncommitted_and_committed_file_cli_ids() {
 ...
               "changes": [
                 {
-                  "cliId": "1#1:n",
+                  "cliId": "u:n",
                   "filePath": "a.txt",
                   "changeType": "added"
                 },
                 {
-                  "cliId": "1#1:p",
+                  "cliId": "u:p",
                   "filePath": "b.txt",
                   "changeType": "added"
                 }
@@ -1472,17 +1472,17 @@ Hint: run `but branch new` to create a new branch to work on
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊●   1 add files
-┊│     1:r  A file-0.txt
-┊│     1:k  A file-1.txt
-┊│     1:t  A file-2.txt
-┊│     1:v  A file-3.txt
-┊│     1:wx A file-4.txt
-┊│     1:wv A file-5.txt
-┊│     1:wk A file-6.txt
-┊│     1:x  A file-7.txt
-┊│     1:m  A file-8.txt
-┊│     1:z  A file-9.txt
+┊●   rlo add files
+┊│     rlo:r  A file-0.txt
+┊│     rlo:k  A file-1.txt
+┊│     rlo:t  A file-2.txt
+┊│     rlo:v  A file-3.txt
+┊│     rlo:wx A file-4.txt
+┊│     rlo:wv A file-5.txt
+┊│     rlo:wk A file-6.txt
+┊│     rlo:x  A file-7.txt
+┊│     rlo:m  A file-8.txt
+┊│     rlo:z  A file-9.txt
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -1499,18 +1499,18 @@ Hint: run `but help` for all commands
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊● 1 author 2000-01-01 00:00:00 +0000 (sha 5877ef4)
+┊● rlo author 2000-01-01 00:00:00 +0000 (sha 2309e7c)
 ┊│     add files
-┊│     1:r  A file-0.txt
-┊│     1:k  A file-1.txt
-┊│     1:t  A file-2.txt
-┊│     1:v  A file-3.txt
-┊│     1:wx A file-4.txt
-┊│     1:wv A file-5.txt
-┊│     1:wk A file-6.txt
-┊│     1:x  A file-7.txt
-┊│     1:m  A file-8.txt
-┊│     1:z  A file-9.txt
+┊│     rlo:r  A file-0.txt
+┊│     rlo:k  A file-1.txt
+┊│     rlo:t  A file-2.txt
+┊│     rlo:v  A file-3.txt
+┊│     rlo:wx A file-4.txt
+┊│     rlo:wv A file-5.txt
+┊│     rlo:wk A file-6.txt
+┊│     rlo:x  A file-7.txt
+┊│     rlo:m  A file-8.txt
+┊│     rlo:z  A file-9.txt
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M

--- a/crates/but/tests/but/command/uncommit.rs
+++ b/crates/but/tests/but/command/uncommit.rs
@@ -91,9 +91,9 @@ fn uncommit_different_files_from_the_same_commit() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ g0 [A]
-┊●   1 add c1 and c2
-┊│     1:l A c1.txt
-┊│     1:w A c2.txt
+┊●   xkv add c1 and c2
+┊│     xkv:l A c1.txt
+┊│     xkv:w A c2.txt
 ┊●   tpm add A
 ┊│     tpm:t A A
 ├╯
@@ -131,7 +131,7 @@ Hint: run `but help` for all commands
         .success()
         .stderr_eq(str![])
         .stdout_eq(str![[r#"
-Uncommitted from 1
+Uncommitted from xkv
 
 "#]]);
 
@@ -145,7 +145,7 @@ Uncommitted from 1
 ┊   wy A c2.txt
 ┊
 ┊╭┄ g0 [A]
-┊●   1 add c1 and c2 (no changes)
+┊●   xkv add c1 and c2 (no changes)
 ┊●   tpm add A
 ┊│     tpm:t A A
 ├╯

--- a/crates/but/tests/but/command/undo.rs
+++ b/crates/but/tests/but/command/undo.rs
@@ -397,7 +397,7 @@ fn can_undo_and_redo_commit_with_ordinary_branch_checked_out() {
         .assert()
         .success();
     let committed = snapbox::str![[r#"
-* 1e62c18 (HEAD -> my-branch) make a commit
+* afb88e5 (HEAD -> my-branch) make a commit
 * b1540e5 (origin/main, origin/HEAD, main, gitbutler/target) M
 * e31e6ca add init
 
@@ -483,9 +483,9 @@ fn can_undo_but_squash_with_two_commits() {
         .stdout_eq(snapbox::str![[r#"
 Operations History
 ──────────────────────────────────────────────────
-4ae3505 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Squashed commit (6198fdb)
-6198fdb 2000-01-02 00:00:00 [SQUASH] Squashed commit
-226d961 2000-01-02 00:00:00 [COMMIT] Created commit
+e940ce1 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Squashed commit (f45a6ee)
+f45a6ee 2000-01-02 00:00:00 [SQUASH] Squashed commit
+ed549de 2000-01-02 00:00:00 [COMMIT] Created commit
 f858e61 2000-01-02 00:00:00 [COMMIT] Created commit
 
 "#]]);
@@ -516,10 +516,10 @@ fn can_undo_but_squash_with_three_commits() {
         .stdout_eq(snapbox::str![[r#"
 Operations History
 ──────────────────────────────────────────────────
-9a03a21 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Squashed commit (c23e673)
-c23e673 2000-01-02 00:00:00 [SQUASH] Squashed commit
-19a80ff 2000-01-02 00:00:00 [COMMIT] Created commit
-226d961 2000-01-02 00:00:00 [COMMIT] Created commit
+1127adf 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Squashed commit (0a9b32d)
+0a9b32d 2000-01-02 00:00:00 [SQUASH] Squashed commit
+7c74cf0 2000-01-02 00:00:00 [COMMIT] Created commit
+ed549de 2000-01-02 00:00:00 [COMMIT] Created commit
 f858e61 2000-01-02 00:00:00 [COMMIT] Created commit
 
 "#]]);
@@ -549,9 +549,9 @@ fn can_undo_but_squash_with_two_commits_with_message() {
         .stdout_eq(snapbox::str![[r#"
 Operations History
 ──────────────────────────────────────────────────
-1346c87 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Squashed commit (6198fdb)
-6198fdb 2000-01-02 00:00:00 [SQUASH] Squashed commit
-226d961 2000-01-02 00:00:00 [COMMIT] Created commit
+7ffe829 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Squashed commit (f45a6ee)
+f45a6ee 2000-01-02 00:00:00 [SQUASH] Squashed commit
+ed549de 2000-01-02 00:00:00 [COMMIT] Created commit
 f858e61 2000-01-02 00:00:00 [COMMIT] Created commit
 
 "#]]);
@@ -577,9 +577,9 @@ fn can_undo_but_squash_with_branch() {
         .stdout_eq(snapbox::str![[r#"
 Operations History
 ──────────────────────────────────────────────────
-cddab76 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Squashed commit (6198fdb)
-6198fdb 2000-01-02 00:00:00 [SQUASH] Squashed commit
-226d961 2000-01-02 00:00:00 [COMMIT] Created commit
+090591a 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Squashed commit (f45a6ee)
+f45a6ee 2000-01-02 00:00:00 [SQUASH] Squashed commit
+ed549de 2000-01-02 00:00:00 [COMMIT] Created commit
 f858e61 2000-01-02 00:00:00 [COMMIT] Created commit
 
 "#]]);
@@ -605,9 +605,9 @@ fn can_undo_but_squash_with_branch_and_drop_message() {
         .stdout_eq(snapbox::str![[r#"
 Operations History
 ──────────────────────────────────────────────────
-1b983eb 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Squashed commit (6198fdb)
-6198fdb 2000-01-02 00:00:00 [SQUASH] Squashed commit
-226d961 2000-01-02 00:00:00 [COMMIT] Created commit
+e539a24 2000-01-02 00:00:00 [UNDO] Restored from snapshot: Squashed commit (f45a6ee)
+f45a6ee 2000-01-02 00:00:00 [SQUASH] Squashed commit
+ed549de 2000-01-02 00:00:00 [COMMIT] Created commit
 f858e61 2000-01-02 00:00:00 [COMMIT] Created commit
 
 "#]]);
@@ -707,15 +707,15 @@ fn can_undo_but_switch_workspace_with_workspace_already_existing() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ g0 [C]
-┊●   1#0 add C (no changes)
+┊●   t#0 add C (no changes)
 ├╯
 ┊
 ┊╭┄ h0 [B]
-┊●   1#1 add B (no changes)
+┊●   t#1 add B (no changes)
 ├╯
 ┊
 ┊╭┄ i0 [A]
-┊●   1#2 add A (no changes)
+┊●   t#2 add A (no changes)
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -733,7 +733,7 @@ Hint: run `but help` for all commands
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ g0 [A]
-┊●   1 add A (no changes)
+┊●   tqv add A (no changes)
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -752,15 +752,15 @@ Hint: run `but help` for all commands
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ g0 [C]
-┊●   1#0 add C (no changes)
+┊●   t#0 add C (no changes)
 ├╯
 ┊
 ┊╭┄ h0 [B]
-┊●   1#1 add B (no changes)
+┊●   t#1 add B (no changes)
 ├╯
 ┊
 ┊╭┄ i0 [A]
-┊●   1#2 add A (no changes)
+┊●   t#2 add A (no changes)
 ├╯
 ┊
 ┴ 0dc3733 (common base) 2000-01-02 add M
@@ -788,7 +788,7 @@ fn can_undo_but_switch_workspace_with_workspace_not_already_existing() {
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ my [my-branch]
-┊●   1 make a commit (no changes)
+┊●   lsm make a commit (no changes)
 ├╯
 ┊
 ┴ b1540e5 (common base) 2000-01-02 M
@@ -800,7 +800,7 @@ Hint: run `but help` for all commands
     snapbox::assert_data_eq!(
         env.git_log(),
         snapbox::str![[r#"
-* 1e62c18 (HEAD -> my-branch) make a commit
+* afb88e5 (HEAD -> my-branch) make a commit
 * b1540e5 (origin/main, origin/HEAD, main, gitbutler/target) M
 * e31e6ca add init
 
@@ -818,8 +818,8 @@ Hint: run `but help` for all commands
             snapbox::assert_data_eq!(
                 env.git_log(),
                 snapbox::str![[r#"
-* 2e292d5 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
-* 1e62c18 (my-branch) make a commit
+* 47cd27c (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+* afb88e5 (my-branch) make a commit
 * b1540e5 (origin/main, origin/HEAD, main, gitbutler/target) M
 * e31e6ca add init
 
@@ -831,7 +831,7 @@ Hint: run `but help` for all commands
     snapbox::assert_data_eq!(
         env.git_log(),
         snapbox::str![[r#"
-* 1e62c18 (HEAD -> my-branch) make a commit
+* afb88e5 (HEAD -> my-branch) make a commit
 * b1540e5 (origin/main, origin/HEAD, main, gitbutler/target) M
 * e31e6ca add init
 

--- a/crates/but/tests/but/command/undo/undo_uncommit.rs
+++ b/crates/but/tests/but/command/undo/undo_uncommit.rs
@@ -10,7 +10,7 @@ fn can_undo_but_uncommit_commit_add() {
     env.but("commit -m 'Add file'").assert().success();
 
     run_mutate_undo_roundtrip_test(&env, |env| {
-        env.but("uncommit 1").assert().success();
+        env.but("uncommit uxn").assert().success();
     });
 }
 
@@ -29,7 +29,7 @@ fn can_undo_but_uncommit_commit_modify() {
     env.but("commit -m 'Change file'").assert().success();
 
     run_mutate_undo_roundtrip_test(&env, |env| {
-        env.but("uncommit 1#0").assert().success();
+        env.but("uncommit qnr").assert().success();
     });
 }
 
@@ -47,7 +47,7 @@ fn can_undo_but_uncommit_commit_delete() {
     env.but("commit -m 'Remove file'").assert().success();
 
     run_mutate_undo_roundtrip_test(&env, |env| {
-        env.but("uncommit 1#0").assert().success();
+        env.but("uncommit orr").assert().success();
     });
 }
 
@@ -61,7 +61,7 @@ fn can_undo_but_uncommit_file_add() {
     env.but("commit -m 'Add file'").assert().success();
 
     run_mutate_undo_roundtrip_test(&env, |env| {
-        env.but("uncommit 1:xk").assert().success();
+        env.but("uncommit uxn:x").assert().success();
     });
 }
 
@@ -78,7 +78,7 @@ fn can_undo_but_uncommit_file_modify() {
     env.but("commit -m 'Modify file'").assert().success();
 
     run_mutate_undo_roundtrip_test(&env, |env| {
-        env.but("uncommit 1#0:xk").assert().success();
+        env.but("uncommit zkn:x").assert().success();
     });
 }
 
@@ -95,6 +95,6 @@ fn can_undo_but_uncommit_file_delete() {
     env.but("commit -m 'Remove file'").assert().success();
 
     run_mutate_undo_roundtrip_test(&env, |env| {
-        env.but("uncommit 1#0:xk").assert().success();
+        env.but("uncommit orr:x").assert().success();
     });
 }

--- a/crates/but/tests/fixtures/scenario/shared.sh
+++ b/crates/but/tests/fixtures/scenario/shared.sh
@@ -8,7 +8,7 @@ function remote_tracking_caught_up() {
 
 function git-init-frozen() {
   git init
-  git config gitbutler.testing.changeId 1
+  git config gitbutler.testing.changeId content-hash
 }
 
 function setup_remote_tracking() {


### PR DESCRIPTION
Change IDs have historically been hard coded to `1` in tests. Now that we're using change IDs as the primary identifier for commits, that's massively inconvenient for tests.

This PR adds a magic `content-hash` value for `gitbutler.testing.changeId` that causes the change ID to be deterministically generated from the content of the commit (before writing the change ID to it, of course, for practical reasons of possibility).

The change ID is initially set to a placeholder, as in the current code flow the change ID header is "requested" before the commit is fully formed. For pretty obvious reasons. The header is then replaced with a content derived Change ID upon writing the commit to disk.

The updates to tests are _massive_. I've put LLMs hard at work in several cycles to detect test regressions. I've caught some. Some may be left, but this is such a valuable improvement that it's worth the risk of some borked tests.

> **Important:** You need to delete the cached test fixtures (in `generated-do-not-edit` directories) for tests to pass after pulling this in.