### PR TITLE
Draw the stacks section as a graph

### DIFF
--- a/apps/lite/harness/browser/Panel.tsx
+++ b/apps/lite/harness/browser/Panel.tsx
@@ -3,14 +3,11 @@ import { useParams } from "@tanstack/react-router";
 import { useHotkeys } from "@tanstack/react-hotkeys";
 import { Match } from "effect";
 import type { FC } from "react";
-import {
-	absorptionPlanQueryOptions,
-	changesInWorktreeQueryOptions,
-	headInfoQueryOptions,
-} from "#ui/api/queries.ts";
+import { absorptionPlanQueryOptions, changesInWorktreeQueryOptions } from "#ui/api/queries.ts";
 import { focusScope } from "#ui/focus-scopes.ts";
 import { projectSlice } from "#ui/projects/state.ts";
 import { buildAppliedAddressSpace } from "#ui/routes/project/$id/workspace/applied-address-space.ts";
+import { usePlan } from "#ui/routes/project/$id/workspace/Graph/usePlan.ts";
 import { buildUncommittedFileRows } from "#ui/routes/project/$id/workspace/file-row.ts";
 import { fileTreeAddressSpace } from "#ui/routes/project/$id/workspace/file-tree.ts";
 import { useFileDisplayMode } from "#ui/routes/project/$id/workspace/useFileDisplayMode.ts";
@@ -39,7 +36,6 @@ export const Panel: FC = () => {
 		Match.tags({ Absorb: ({ sourceTarget }) => sourceTarget }),
 		Match.orElse(() => null),
 	);
-	const { data: headInfo } = useQuery(headInfoQueryOptions(projectId));
 	const [absorptionPlanQuery] = useQueries({
 		queries: (absorptionPlanTarget ? [absorptionPlanTarget] : []).map((target) =>
 			absorptionPlanQueryOptions({ projectId, target }),
@@ -52,8 +48,10 @@ export const Panel: FC = () => {
 	const foldedSegments = useAppSelector((state) =>
 		projectSlice.selectors.selectFoldedSegments(state, projectId),
 	);
+	const graph = usePlan(projectId);
 	const appliedAddressSpace = buildAppliedAddressSpace({
-		headInfo,
+		stacks: graph.stacks,
+		plan: graph.plan,
 		pendingOperation,
 		absorptionTargetCommitIds,
 		foldedSegments,
@@ -107,6 +105,7 @@ export const Panel: FC = () => {
 				// instance the app's sidebar owns: two would each hold their own
 				// mutation, and neither in-flight guard would see the other's create.
 				newBranch={newBranch}
+				graph={graph}
 				addressSpace={appliedAddressSpace}
 				uncommittedAddressSpace={uncommittedAddressSpace}
 				absorptionTargetCommitIds={absorptionTargetCommitIds}

--- a/apps/lite/ui/src/branch.ts
+++ b/apps/lite/ui/src/branch.ts
@@ -1,5 +1,5 @@
 import type { PayloadFor } from "#electron/ipc.ts";
-import type { ListedBranch, ListedStack } from "@gitbutler/but-sdk";
+import type { ListedBranch, ListedStack, RemoteTrackingReference } from "@gitbutler/but-sdk";
 import Fuse from "fuse.js";
 
 /**
@@ -12,6 +12,10 @@ import Fuse from "fuse.js";
  * is unknown rather than empty.
  */
 export const branchIsEmpty = (branch: ListedBranch): boolean => branch.commitCount === 0;
+
+/** A remote-tracking ref as shown: `origin/main`. */
+export const remoteTrackingLabel = (ref: RemoteTrackingReference): string =>
+	`${ref.remoteName}/${ref.displayName}`;
 
 /**
  * The commits the branch contributes itself, taken from a branch-details commit

--- a/apps/lite/ui/src/components/GraphSegment.module.css
+++ b/apps/lite/ui/src/components/GraphSegment.module.css
@@ -4,6 +4,26 @@
 
 	color: var(--commit-status-color);
 
+	/* Selected rows set --selection-inverted; flipping to the opposite color
+	   scheme resolves the line tokens to their inverted values, so the rail
+	   stays legible against the row's inverted selection background. */
+	@container style(--selection-inverted: true) {
+		color-scheme: dark;
+
+		@media (prefers-color-scheme: dark) {
+			color-scheme: light;
+		}
+	}
+}
+
+/* A stretch of the rail in another status's colour, given by its own status;
+   without one it keeps the glyph's. */
+.tone {
+	color: var(--commit-status-color);
+}
+
+.container,
+.tone {
 	&[data-status="LocalOnly"] {
 		--commit-status-color: var(--commit-local);
 	}
@@ -23,24 +43,15 @@
 	&[data-status="Diverged"] {
 		--commit-status-color: var(--commit-local);
 	}
-
-	/* Selected rows set --selection-inverted; flipping to the opposite color
-	   scheme resolves the line tokens to their inverted values, so the rail
-	   stays legible against the row's inverted selection background. */
-	@container style(--selection-inverted: true) {
-		color-scheme: dark;
-
-		@media (prefers-color-scheme: dark) {
-			color-scheme: light;
-		}
-	}
 }
 
-/* The rail is the glyph colour faded back, so it reads as a quieter companion
-   to the node without needing a token of its own. */
+/* The rail is the glyph colour faded back into the card, so it reads as a
+   quieter companion to the node without needing a token of its own. Blended
+   rather than translucent, so it is one colour wherever it runs; the
+   selection inversion above flips the card colour with the rest. Keep in
+   sync with Rails.module.css and Section.module.css. */
 .line {
-	stroke: currentColor;
-	stroke-opacity: 0.4;
+	stroke: color-mix(in srgb, currentColor 40%, var(--bg-1));
 }
 
 .mainSegment {

--- a/apps/lite/ui/src/components/GraphSegment.tsx
+++ b/apps/lite/ui/src/components/GraphSegment.tsx
@@ -26,14 +26,26 @@ const glyphPaths = {
 	joinBoth: "M16 14L8 14M0 14H8M8 0V14M8 28V14",
 };
 
-const commitGlyph = (
+/**
+ * A stretch of the rail in another status's colour, or the glyph's own when
+ * none is given: the line past an icon, where it belongs to the icon at its
+ * other end.
+ */
+const Tone: FC<{ status: GraphSegmentStatus | undefined; d: string }> = ({ status, d }) => (
+	<g className={styles.tone} data-status={status}>
+		<path className={styles.line} d={d} strokeWidth="1.5" />
+	</g>
+);
+
+const commitGlyph = (below: GraphSegmentStatus | undefined) => (
 	<>
-		<path className={styles.line} d="M8 0V11M8 17V28" strokeWidth="1.5" />
+		<path className={styles.line} d="M8 0V11" strokeWidth="1.5" />
 		<path
 			d="M11.5 14C11.5 15.933 9.933 17.5 8 17.5C6.067 17.5 4.5 15.933 4.5 14C4.5 12.067 6.067 10.5 8 10.5C9.933 10.5 11.5 12.067 11.5 14Z"
 			stroke="currentColor"
 			strokeWidth="1.5"
 		/>
+		<Tone status={below} d="M8 17V28" />
 	</>
 );
 
@@ -52,6 +64,58 @@ const groupHeadGlyph = (
 	<>
 		<path className={styles.line} d="M8 17.0038V26" strokeWidth="1.5" />
 		<path d={groupRingsPath} stroke="currentColor" strokeWidth="1.5" />
+	</>
+);
+
+/** The commit node without the tail below it, for the row a rail ends on. */
+const commitFootGlyph = (
+	<>
+		<path className={styles.line} d="M8 0V11" strokeWidth="1.5" />
+		<path
+			d="M11.5 14C11.5 15.933 9.933 17.5 8 17.5C6.067 17.5 4.5 15.933 4.5 14C4.5 12.067 6.067 10.5 8 10.5C9.933 10.5 11.5 12.067 11.5 14Z"
+			stroke="currentColor"
+			strokeWidth="1.5"
+		/>
+	</>
+);
+
+/** A branch's tick on a rail that continues above: the stretch above and below it in others' colours. */
+const joinRightGlyph = (
+	above: GraphSegmentStatus | undefined,
+	below: GraphSegmentStatus | undefined,
+) => (
+	<>
+		<Tone status={above} d="M8 14V0" />
+		<path className={styles.line} d="M16 14H8" strokeWidth="1.5" />
+		<Tone status={below} d="M8 14V28" />
+	</>
+);
+
+/** A branch's tick starting a rail: the stretch below it in another's colour. */
+const forkRightGlyph = (below: GraphSegmentStatus | undefined) => (
+	<>
+		<path className={styles.line} d="M16 14H14C10.6863 14 8 16.6863 8 20" strokeWidth="1.5" />
+		<Tone status={below} d="M8 20V28" />
+	</>
+);
+
+/** The rings on the row's centre line, for a single-line row of their own. */
+const groupCenteredGlyph = (
+	<>
+		<path className={styles.line} d="M8 0V6.7857M8 21.0038V28" strokeWidth="1.5" />
+		<g transform="translate(0 4)">
+			<path d={groupRingsPath} stroke="currentColor" strokeWidth="1.5" />
+		</g>
+	</>
+);
+
+/** The centred rings without the tail below them, for the row a rail ends on. */
+const groupCenteredFootGlyph = (
+	<>
+		<path className={styles.line} d="M8 0V6.7857" strokeWidth="1.5" />
+		<g transform="translate(0 4)">
+			<path d={groupRingsPath} stroke="currentColor" strokeWidth="1.5" />
+		</g>
 	</>
 );
 
@@ -90,22 +154,64 @@ export type GraphSegmentStatus = "Diverged" | "Upstream" | CommitState["type"];
 interface GraphSegmentProps extends ComponentProps<"div"> {
 	glyph: GraphSegmentGlyph;
 	status: GraphSegmentStatus;
+	/**
+	 * The rail ends on this row: the commit glyph and the centred group glyph
+	 * lose their tail below, and nothing stretches on under a taller row.
+	 */
+	railEnds?: boolean;
+	/**
+	 * The group's rings sit on the row's centre line, for a single-line row
+	 * of their own; otherwise they head a folded indicator from a row's
+	 * second line down, on a shorter canvas.
+	 */
+	centered?: boolean;
+	/**
+	 * The rail above or below the glyph's icon in another status's colour.
+	 * A stretch between two icons is the lower icon's; above a branch's tick,
+	 * and below a card's last icon, the rail is plain.
+	 */
+	above?: GraphSegmentStatus;
+	below?: GraphSegmentStatus;
 }
 
-export const GraphSegment: FC<GraphSegmentProps> = ({ glyph, className, status, ...props }) => (
+export const GraphSegment: FC<GraphSegmentProps> = ({
+	glyph,
+	className,
+	status,
+	railEnds = false,
+	centered = false,
+	above,
+	below,
+	...props
+}) => (
 	<div {...props} className={classes(className, styles.container)} data-status={status}>
 		<svg
-			className={classes(styles.mainSegment, isGroupGlyph(glyph) && styles.groupSegment)}
-			viewBox={isGroupGlyph(glyph) ? "0 0 16 26" : "0 0 16 28"}
+			className={classes(
+				styles.mainSegment,
+				isGroupGlyph(glyph) && !centered && styles.groupSegment,
+			)}
+			viewBox={isGroupGlyph(glyph) && !centered ? "0 0 16 26" : "0 0 16 28"}
 			fill="none"
 			xmlns="http://www.w3.org/2000/svg"
 			aria-hidden="true"
 			focusable="false"
 		>
-			{glyph === "commit" ? (
-				commitGlyph
+			{railEnds && glyph === "commit" ? (
+				commitFootGlyph
+			) : railEnds && glyph === "group" && centered ? (
+				groupCenteredFootGlyph
+			) : glyph === "commit" ? (
+				commitGlyph(below)
+			) : glyph === "joinRight" ? (
+				joinRightGlyph(above, below)
+			) : glyph === "forkRight" ? (
+				forkRightGlyph(below)
 			) : glyph === "group" ? (
-				groupGlyph
+				centered ? (
+					groupCenteredGlyph
+				) : (
+					groupGlyph
+				)
 			) : glyph === "groupHead" ? (
 				groupHeadGlyph
 			) : (
@@ -113,7 +219,7 @@ export const GraphSegment: FC<GraphSegmentProps> = ({ glyph, className, status, 
 			)}
 		</svg>
 
-		{stretchableGlyphs.has(glyph) && (
+		{stretchableGlyphs.has(glyph) && !railEnds && (
 			<svg
 				viewBox="0 0 16 28"
 				preserveAspectRatio="none"
@@ -123,7 +229,7 @@ export const GraphSegment: FC<GraphSegmentProps> = ({ glyph, className, status, 
 				aria-hidden="true"
 				focusable="false"
 			>
-				<path className={styles.line} d={glyphPaths.parent} strokeWidth="1.5" />
+				<Tone status={below} d={glyphPaths.parent} />
 			</svg>
 		)}
 	</div>

--- a/apps/lite/ui/src/cursor-url.ts
+++ b/apps/lite/ui/src/cursor-url.ts
@@ -1,6 +1,6 @@
 import { decodeBytes } from "#ui/api/bytes.ts";
 import type { CursorItem, CursorName } from "#ui/cursors.ts";
-import type { PageId } from "#ui/projects/project.ts";
+import type { ActiveList, PageId } from "#ui/projects/project.ts";
 import type { Address } from "#ui/addresses.ts";
 
 /**
@@ -14,7 +14,7 @@ import type { Address } from "#ui/addresses.ts";
  */
 export type UrlQueryParams = {
 	page?: Exclude<PageId, "workspace">;
-	active?: "uncommitted";
+	active?: Exclude<ActiveList, "applied">;
 	applied?: string;
 	uncommitted?: string;
 	unapplied?: string;

--- a/apps/lite/ui/src/cursors.ts
+++ b/apps/lite/ui/src/cursors.ts
@@ -1,3 +1,4 @@
+import type { ActiveList } from "#ui/projects/project.ts";
 import {
 	branchFileParent,
 	commitFileParent,
@@ -44,7 +45,7 @@ export type CursorName = keyof CursorItem;
  */
 export type WorkspaceCursorSnapshot = {
 	page?: "upstream" | "branches";
-	active?: "uncommitted";
+	active?: Exclude<ActiveList, "applied">;
 	applied?: string;
 	uncommitted?: string;
 	files?: string;

--- a/apps/lite/ui/src/operations/pending-operation.ts
+++ b/apps/lite/ui/src/operations/pending-operation.ts
@@ -1,3 +1,4 @@
+import type { ActiveList } from "#ui/projects/project.ts";
 import { Match } from "effect";
 import { addressEquals, type Address, uncommittedChangesAddress } from "#ui/addresses.ts";
 import type { Placement, TransferKind } from "#ui/operations/operation.ts";
@@ -76,7 +77,7 @@ export const getTransferKind = (transfer: PendingTransfer): TransferKind =>
 export const getTransferTarget = (
 	transfer: PendingTransfer,
 	appliedSelection: Address | null,
-	activeList: "applied" | "uncommitted",
+	activeList: ActiveList,
 ): Address | null =>
 	Match.value(transfer).pipe(
 		Match.tagsExhaustive({

--- a/apps/lite/ui/src/projects/graph.ts
+++ b/apps/lite/ui/src/projects/graph.ts
@@ -1,0 +1,73 @@
+import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
+
+/**
+ * The stacks graph's fold state: what the upstream section below the cards
+ * shows. Its rows share the applied list's cursor.
+ */
+export type GraphState = {
+	/** The upstream header's fold: the commits incoming from the target. */
+	incomingExpanded: boolean;
+	/** The base header's fold: the base rows and the older history. */
+	baseExpanded: boolean;
+	/** How many times more of each run was asked for, keyed by the run's newest commit id. */
+	moreRuns: Record<string, number>;
+	/** How many times more of the older history was asked for since the base opened. */
+	moreOlder: number;
+};
+
+const initialState = (): GraphState => ({
+	incomingExpanded: false,
+	baseExpanded: false,
+	moreRuns: {},
+	moreOlder: 0,
+});
+
+const graphSlice = createSlice({
+	name: "graph",
+	initialState,
+	reducers: {
+		toggleIncoming: (state) => {
+			state.incomingExpanded = !state.incomingExpanded;
+		},
+		// Either way the history starts over: what one look asked for, the next does not.
+		toggleBase: (state) => {
+			state.baseExpanded = !state.baseExpanded;
+			state.moreOlder = 0;
+		},
+		showMoreOlder: (state) => {
+			state.moreOlder += 1;
+		},
+		showMoreRun: (state, { payload: { runId } }: PayloadAction<{ runId: string }>) => {
+			state.moreRuns[runId] = (state.moreRuns[runId] ?? 0) + 1;
+		},
+		foldRun: (state, { payload: { runId } }: PayloadAction<{ runId: string }>) => {
+			delete state.moreRuns[runId];
+		},
+	},
+	selectors: {
+		selectGraphFolds: (state) => state,
+	},
+});
+
+export const createInitialGraphState = (): GraphState => graphSlice.getInitialState();
+
+export const graphReducers = {
+	toggleIncoming: (state: GraphState) => {
+		graphSlice.caseReducers.toggleIncoming(state);
+	},
+	toggleBase: (state: GraphState) => {
+		graphSlice.caseReducers.toggleBase(state);
+	},
+	showMoreRun: (state: GraphState, payload: { runId: string }) => {
+		graphSlice.caseReducers.showMoreRun(state, graphSlice.actions.showMoreRun(payload));
+	},
+	foldRun: (state: GraphState, payload: { runId: string }) => {
+		graphSlice.caseReducers.foldRun(state, graphSlice.actions.foldRun(payload));
+	},
+	showMoreOlder: (state: GraphState) => {
+		graphSlice.caseReducers.showMoreOlder(state);
+	},
+};
+
+export const getGraphSelectors = <T>(selectState: (state: T) => GraphState) =>
+	graphSlice.getSelectors(selectState);

--- a/apps/lite/ui/src/projects/project.ts
+++ b/apps/lite/ui/src/projects/project.ts
@@ -51,9 +51,19 @@ import {
 	upstreamReducers,
 	type UpstreamState,
 } from "./upstream.ts";
+import {
+	createInitialGraphState,
+	getGraphSelectors,
+	graphReducers,
+	type GraphState,
+} from "./graph.ts";
 
-/** The workspace page's two lists; the one named here is active and drives the details pane. */
-export type ActiveList = "applied" | "uncommitted";
+/**
+ * The workspace page's lists, in the order the details pane falls back
+ * through them; the one named active drives the pane.
+ */
+export const activeLists = ["applied", "uncommitted"] as const;
+export type ActiveList = (typeof activeLists)[number];
 
 export type CheckableAddress = Extract<Address, { _tag: "Commit" | "File" | "Hunk" }>;
 
@@ -159,6 +169,7 @@ export type ProjectState = {
 	sidebarPanelFocus: SidebarPanel | "both";
 	branches: BranchesState;
 	upstream: UpstreamState;
+	graph: GraphState;
 	workspace: WorkspaceState;
 };
 
@@ -167,6 +178,7 @@ export const createInitialProjectState = (): ProjectState => ({
 	sidebarPanelFocus: "both",
 	branches: createInitialBranchesState(),
 	upstream: createInitialUpstreamState(),
+	graph: createInitialGraphState(),
 	workspace: createInitialWorkspaceState(),
 });
 
@@ -187,6 +199,21 @@ export const projectReducers = {
 	},
 	toggleUpstreamSegment: (state: ProjectState, { segmentId }: { segmentId: string }) => {
 		upstreamReducers.toggleSegment(state.upstream, { segmentId });
+	},
+	toggleGraphIncoming: (state: ProjectState) => {
+		graphReducers.toggleIncoming(state.graph);
+	},
+	toggleGraphBase: (state: ProjectState) => {
+		graphReducers.toggleBase(state.graph);
+	},
+	showMoreGraphOlder: (state: ProjectState) => {
+		graphReducers.showMoreOlder(state.graph);
+	},
+	showMoreGraphRun: (state: ProjectState, { runId }: { runId: string }) => {
+		graphReducers.showMoreRun(state.graph, { runId });
+	},
+	foldGraphRun: (state: ProjectState, { runId }: { runId: string }) => {
+		graphReducers.foldRun(state.graph, { runId });
 	},
 	startInlineEdit: (state: ProjectState, edit: PendingInlineEdit) => {
 		state.workspace.pendingOperation = pendingInlineEdit(edit);
@@ -730,4 +757,5 @@ export const projectSelectors = {
 	},
 	...getBranchesSelectors((state: ProjectState) => state.branches),
 	...getUpstreamSelectors((state: ProjectState) => state.upstream),
+	...getGraphSelectors((state: ProjectState) => state.graph),
 };

--- a/apps/lite/ui/src/routes.tsx
+++ b/apps/lite/ui/src/routes.tsx
@@ -1,4 +1,5 @@
 import type { UrlQueryParams } from "#ui/cursor-url.ts";
+import { activeLists } from "#ui/projects/project.ts";
 import { handleProjectEvent } from "#ui/project-events.ts";
 import { readLastOpenedProject, readLastPlace } from "#ui/project.ts";
 import { IndexPage } from "#ui/routes/IndexPage.tsx";
@@ -159,11 +160,11 @@ export const createRouteTree = ({ workspace }: { workspace: FC }) => {
 		// so a corrupt or stale URL opens the page at defaults.
 		validateSearch: (params: Record<string, unknown>): UrlQueryParams => {
 			const page = str(params.page);
-			const active = str(params.active);
+			const active = activeLists.find((list) => list === params.active);
 
 			return {
 				page: page === "upstream" || page === "branches" ? page : undefined,
-				active: active === "uncommitted" ? active : undefined,
+				active: active === undefined || active === "applied" ? undefined : active,
 				applied: str(params.applied),
 				uncommitted: str(params.uncommitted),
 				unapplied: str(params.unapplied),

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -73,6 +73,7 @@ import { Badge } from "#ui/components/Badge.tsx";
 import { getButtonClassName } from "#ui/components/Button.tsx";
 import { Icon } from "#ui/components/Icon.tsx";
 import { TooltipPopup } from "#ui/components/Tooltip.tsx";
+import { useCopied } from "#ui/routes/project/$id/workspace/useCopied.ts";
 import { ToggleGroupStyles, ToggleStyles } from "#ui/components/ToggleGroup.tsx";
 import { OperationSourceC } from "#ui/routes/project/$id/workspace/OperationSourceC.tsx";
 import {
@@ -2774,29 +2775,13 @@ const CopyableId: FC<{
 	displayValue: string;
 	copyValue: string;
 }> = ({ label, icon, displayValue, copyValue }) => {
-	const [copied, setCopied] = useState(false);
-	const resetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-	const handleCopy = () => {
-		void window.lite.clipboardWriteText(copyValue);
-		setCopied(true);
-
-		if (resetTimeoutRef.current !== null) clearTimeout(resetTimeoutRef.current);
-		resetTimeoutRef.current = setTimeout(() => setCopied(false), 1500);
-	};
-
-	useLayoutEffect(
-		() => () => {
-			if (resetTimeoutRef.current !== null) clearTimeout(resetTimeoutRef.current);
-		},
-		[],
-	);
+	const { copied, copy } = useCopied(copyValue);
 
 	return (
 		<Tooltip.Root>
 			<Tooltip.Trigger
 				className={styles.commitDetailsMetaSha}
-				onClick={handleCopy}
+				onClick={copy}
 				render={<button type="button" aria-label={label} />}
 			>
 				<Icon size={14} name={copied ? "tick" : icon} />

--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/Rails.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/Rails.module.css
@@ -1,0 +1,18 @@
+/* Behind the cards: it only ever draws in the gaps between them. */
+.rails {
+	position: absolute;
+	inset: 0;
+	overflow: visible;
+	pointer-events: none;
+}
+
+/* The grey the row glyphs draw their rails in: the local commit colour at
+   40% into the card, one colour wherever it runs; keep in sync with
+   GraphSegment.module.css, Section.module.css and WorkspaceLists.module.css. */
+.lane {
+	fill: none;
+	stroke: color-mix(in srgb, var(--commit-local) 40%, var(--bg-1));
+	stroke-linecap: round;
+	stroke-linejoin: round;
+	stroke-width: 1.5;
+}

--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/Rails.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/Rails.tsx
@@ -1,0 +1,43 @@
+import type { VirtualItem } from "@tanstack/react-virtual";
+import type { FC } from "react";
+import styles from "./Rails.module.css";
+import { CARD_GAP, type Card, rails } from "./layout.ts";
+
+/*
+ * One SVG behind the cards, drawing the rails through the gaps between them
+ * from the virtualiser's measurements, so the gaps beside cards scrolled out
+ * of the DOM get theirs too. Every card draws its own rails to its edges,
+ * and the upstream section draws its own from its first row, in
+ * Section.module.css.
+ */
+export const Rails: FC<{
+	/**
+	 * The cards' measurements in plan order: the virtualiser's own cache,
+	 * replaced as cards are measured. Read after its total, which refreshes
+	 * it, and by index: it is a lazy view whose items exist once read, so
+	 * anything that skips holes, `map` included, misses the unread ones.
+	 */
+	cards: ArrayLike<VirtualItem>;
+	/** Where the cards end; null without a base, when there is nothing to fork off and nothing is drawn. */
+	cardsEnd: number | null;
+}> = ({ cards, cardsEnd }) => {
+	const measured: Array<Card> = [];
+	for (let index = 0; index < cards.length; index++) {
+		const item = cards[index];
+		if (item !== undefined) measured.push({ topY: item.start, bottomY: item.end });
+	}
+	const paths = cardsEnd === null ? [] : rails(measured, cardsEnd);
+	return (
+		<svg
+			className={styles.rails}
+			width="100%"
+			height={cardsEnd === null ? 0 : cardsEnd + CARD_GAP}
+			aria-hidden
+		>
+			{paths.map((d, index) => (
+				// oxlint-disable-next-line react/no-array-index-key -- Every measure replaces the whole list.
+				<path key={index} className={styles.lane} d={d} />
+			))}
+		</svg>
+	);
+};

--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/Section.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/Section.module.css
@@ -1,0 +1,198 @@
+.chevron {
+	flex-shrink: 0;
+	align-self: center;
+	color: var(--text-2);
+}
+
+/* How many commits the target has that the workspace does not: beside the
+   merge base's label, in the incoming rows' colour. */
+.incoming {
+	flex-shrink: 0;
+	margin-inline-start: 8px;
+	color: var(--commit-upstream);
+	font-weight: 500;
+}
+
+/* A fold: rows inside collapse to nothing and open to their height. */
+.fold {
+	display: grid;
+	grid-template-rows: 0fr;
+	transition: grid-template-rows 180ms ease-out;
+}
+
+.fold[data-open="true"] {
+	grid-template-rows: 1fr;
+}
+
+.foldInner {
+	display: flex;
+	flex-direction: column;
+	min-height: 0;
+	overflow: hidden;
+}
+
+/* The section's colours: the grey the row glyphs draw their rails in, and
+   the incoming rows' colour, each at the glyphs' 40%; keep in sync with
+   GraphSegment.module.css and Rails.module.css. */
+.card,
+.base,
+.history {
+	--rail: color-mix(in srgb, var(--commit-local) 40%, var(--bg-1));
+	--leg: color-mix(in srgb, var(--commit-upstream) 40%, var(--bg-1));
+}
+
+/* The section's rails, on the line its rows' glyphs sit on (half a glyph
+   into the row inset): each element draws the line over its own stretch,
+   where its rows' glyphs do not. */
+.card::after,
+.base::before,
+.history[data-open="true"]::before {
+	position: absolute;
+	left: calc(var(--row-padding-inline-start) + 8px - 0.75px);
+	width: 1.5px;
+	background-color: var(--rail);
+	content: "";
+}
+
+/* The target's card, a card gap under the last stack's: a forked stack
+   card's look, bordered top and bottom, its rows between a little air above
+   and below, a header row alone when folded. It sits a gap right of the
+   main line, which passes behind it, with the incoming commits on a leg of
+   their own that bends onto the line under the card (see .bend). Over
+   whatever the rails draw under it, docked or in its place. Keep in sync
+   with StackCard.module.css and WorkspaceLists.module.css. */
+.card {
+	--air: 4px;
+
+	z-index: 2;
+	position: relative;
+	margin-block-start: 20px;
+	padding-block: var(--air);
+	border-block: 1px solid var(--border-section);
+	background-color: var(--bg-1);
+
+	/* Folded, it docks at the scroller's foot while its place is below it,
+	   so the news of what is incoming stays in view. Unfolded it keeps its
+	   place: a docked card's toggle scrolls there before opening it. */
+	&[data-folded="true"] {
+		position: sticky;
+		bottom: 0;
+	}
+
+	/* The main line passing behind the card, quieter, between its borders,
+	   above the rows and translucent over their fills: the line a forked
+	   stack card draws behind itself, in WorkspaceLists.module.css. */
+	&::before {
+		z-index: 1;
+		position: absolute;
+		inset-block: 0;
+		left: calc(var(--main-line-x) - 0.75px);
+		width: 1.5px;
+		background-color: color-mix(in srgb, var(--commit-local) 16%, transparent);
+		content: "";
+		pointer-events: none;
+	}
+
+	/* The leg: the target's line from under the header's chevron, clear of it
+	   by its 10px (the air and 24px into the row, whose centre is 14px in),
+	   down the rows, which draw the same colour over their own stretch, and
+	   on over the card's floor to the bend under it. */
+	&::after {
+		--out-of-chevron: calc(var(--air) + 24px);
+
+		z-index: -1;
+		inset-block: 0 -1px;
+		background: linear-gradient(
+			transparent var(--out-of-chevron),
+			var(--leg) var(--out-of-chevron)
+		);
+	}
+}
+
+/* The leg's bend, drawn against the base header in the gap above it: from
+   the target card's floor, a gap right of the main line, onto the line at
+   the header's top; the main line runs straight through the same gap. Keep
+   in sync with layout.ts's LEG_BEND. */
+.bend {
+	position: absolute;
+	top: calc(-1 * var(--gap));
+	left: 0;
+	width: 32px;
+	height: var(--gap);
+	overflow: visible;
+	fill: none;
+	stroke: var(--leg);
+	stroke-linecap: round;
+	stroke-linejoin: round;
+	stroke-width: 1.5;
+	pointer-events: none;
+}
+
+/* The ref row, a card gap under the last stack's. */
+.ref {
+	margin-block-start: 20px;
+}
+
+/* The base header sits a card gap below the last stack's card, where a
+   fork has to bend, and a smaller gap below the target's card or the ref
+   row. Positioned, so its rail piece is placed against it. */
+.base {
+	--gap: 20px;
+
+	position: relative;
+	margin-block-start: var(--gap);
+}
+
+.card + .base,
+.ref + .base {
+	--gap: 12px;
+}
+
+.history {
+	position: relative;
+}
+
+/* The gap above the base header, from the row or card above it, and into
+   its chevron: half a row less the chevron's 10px of clearance. When the
+   base header comes first, the SVG's own run through the gap under the
+   cards coincides with it. Out of the chevron into the rows while unfolded. */
+.base::before {
+	top: calc(-1 * var(--gap));
+	height: calc(var(--gap) + 4px);
+}
+
+.history[data-open="true"]::before {
+	top: -4px;
+	height: 4px;
+}
+
+/* A quiet note beside a header's label. */
+.caption {
+	margin-inline-start: 8px;
+	color: var(--text-3);
+	font-weight: 400;
+}
+
+/* A control in the label's line: centred on it, whatever its height, so the
+   row keeps its height. */
+.action {
+	display: flex;
+	align-items: center;
+	height: var(--single-line-row-label-line-height);
+}
+
+.rows {
+	display: flex;
+	flex-direction: column;
+}
+
+.elided {
+	color: var(--text-3);
+	font-style: italic;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.fold {
+		transition: none;
+	}
+}

--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/Section.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/Section.tsx
@@ -1,0 +1,398 @@
+import { GraphSegment } from "#ui/components/GraphSegment.tsx";
+import { Icon } from "#ui/components/Icon.tsx";
+import { classes } from "#ui/components/classes.ts";
+import { getRowButtonClassName } from "#ui/routes/project/$id/workspace/Row-utils.ts";
+import {
+	Row,
+	RowFoldToggle,
+	RowLabel,
+	RowLabelContainer,
+} from "#ui/routes/project/$id/workspace/Row.tsx";
+import { TargetCommitRow } from "#ui/routes/project/$id/workspace/UpstreamList.tsx";
+import { useAddressSpace } from "#ui/routes/project/$id/workspace/WorkspaceLists/context.tsx";
+import { addressIdentityKey, type Address } from "#ui/addresses.ts";
+import type { AddressSpace } from "#ui/workspace/address-space.ts";
+import type { TargetCommit } from "@gitbutler/but-sdk";
+import { useWorkspaceIntegrateUpstream } from "#ui/api/mutations.ts";
+import { headInfoQueryOptions } from "#ui/api/queries.ts";
+import { stackBottomRelativeTo } from "#ui/api/stack.ts";
+import { projectSlice } from "#ui/projects/state.ts";
+import { useAppSelector } from "#ui/store.ts";
+import { Button } from "@base-ui/react";
+import type { BottomUpdate } from "@gitbutler/but-sdk";
+import { useQuery } from "@tanstack/react-query";
+import {
+	type CSSProperties,
+	type FC,
+	type ReactNode,
+	type Ref,
+	type RefObject,
+	useRef,
+} from "react";
+import styles from "./Section.module.css";
+import {
+	CARD_X,
+	LEG_BEND,
+	type Plan,
+	rowInsetFor,
+	type Run,
+	targetCommitAddress,
+} from "./layout.ts";
+
+/*
+ * The upstream section under the stacks: the target's header row, folding
+ * the commits incoming from it, then the base header, folding the rows below
+ * the base and the older history with the "show more" row at its foot. The
+ * commit rows are values on the applied list's cursor, and the Upstream
+ * tab's own, so they carry review titles; the headers are not values.
+ */
+
+// Rows on the main line are the base the stacks sit on and take the integrated
+// colour; rows on the incoming leg are ahead of it and take the upstream's.
+// A pending operation drops them from the applied list, and then they are
+// inert, as a card's rows are.
+const commitRow = (
+	commit: TargetCommit,
+	status: "Integrated" | "Upstream",
+	addressSpace: AddressSpace<Address>,
+	railEnds = false,
+) => {
+	const index = addressSpace.indexByKey.get(addressIdentityKey(targetCommitAddress(commit)));
+	return (
+		<TargetCommitRow
+			key={commit.commit.id}
+			item={{ ...commit, type: "commit" }}
+			list="applied"
+			positionInSet={(index ?? -1) + 1}
+			setSize={addressSpace.items.length}
+			status={status}
+			railEnds={railEnds}
+			inert={index === undefined}
+		/>
+	);
+};
+
+/**
+ * A header row: not a value, so nothing selects it. With a fold, the whole
+ * row toggles it; the toggle on its rail is the control assistive
+ * technology sees, and other controls in the row keep their own clicks.
+ */
+const Header: FC<{
+	label: string;
+	/** Beside the label, in the label's own line: a count, an id. */
+	caption?: ReactNode;
+	/** The ref's row reads as a heading; the base's a step under it, being the ref's history. */
+	heading?: boolean;
+	/** The fold the header opens; none for a plain row. */
+	fold?: { open: boolean; onToggle: () => void; name: string };
+	/** After the label, in its line: a control of the row's own. */
+	glyph: ReactNode;
+	/** A rail piece of the row's own, drawn against it out of its flow. */
+	rail?: ReactNode;
+	className?: string;
+	style?: CSSProperties;
+	children?: ReactNode;
+}> = ({ label, caption, heading = false, fold, glyph, rail, className, style, children }) => (
+	<Row
+		interactive={fold !== undefined}
+		onSelect={fold?.onToggle}
+		className={className}
+		style={style}
+	>
+		{rail}
+		{fold === undefined ? (
+			glyph
+		) : (
+			<RowFoldToggle
+				folded={!fold.open}
+				glyph={glyph}
+				aria-label={`${fold.open ? "Fold" : "Unfold"} ${fold.name}`}
+				onClick={fold.onToggle}
+			/>
+		)}
+		<RowLabelContainer>
+			<RowLabel heading={heading} singleLine className={heading ? undefined : "text-bold"}>
+				{label}
+				{caption}
+			</RowLabel>
+			{children !== undefined && <span className={styles.action}>{children}</span>}
+		</RowLabelContainer>
+	</Row>
+);
+
+const Elided: FC<{
+	run: Run;
+	status: "Integrated" | "Upstream";
+	onMore: () => void;
+	onFold: () => void;
+}> = ({ run, status, onMore, onFold }) => (
+	// oxlint-disable-next-line jsx-a11y/prefer-tag-over-role -- A row that reveals or folds, styled as the rows around it.
+	<Row role="button" onSelect={run.hidden > 0 ? onMore : onFold} aria-expanded={run.expanded}>
+		<GraphSegment glyph={run.hidden > 0 ? "group" : "parent"} status={status} centered />
+		<RowLabelContainer>
+			<RowLabel singleLine className={styles.elided}>
+				{run.hidden === 0
+					? "Show fewer"
+					: run.incoming
+						? `${run.hidden} more`
+						: `${run.hidden} ${run.hidden === 1 ? "commit" : "commits"} already in the workspace`}
+			</RowLabel>
+		</RowLabelContainer>
+	</Row>
+);
+
+const Fold: FC<{
+	open: boolean;
+	className?: string;
+	ref?: Ref<HTMLDivElement>;
+	children: ReactNode;
+}> = ({ open, className, ref, children }) => (
+	<div ref={ref} className={classes(styles.fold, className)} data-open={open}>
+		<div className={styles.foldInner}>{children}</div>
+	</div>
+);
+
+const runRows = (
+	run: Run,
+	status: "Integrated" | "Upstream",
+	addressSpace: AddressSpace<Address>,
+	onMore: () => void,
+	onFold: () => void,
+) => {
+	// What is folded away is not mounted: a run can be hundreds of commits long.
+	const elided = run.hidden > 0 || run.expanded;
+	return (
+		<div key={run.id}>
+			{run.shown.map((commit) => commitRow(commit, status, addressSpace))}
+			{elided && <Elided run={run} status={status} onMore={onMore} onFold={onFold} />}
+		</div>
+	);
+};
+
+/**
+ * Updates the workspace onto the target's tip, the sidebar's own action:
+ * rebases every stack onto it. The tip is what was fetched; this does not
+ * fetch.
+ */
+const Update: FC<{ projectId: string }> = ({ projectId }) => {
+	const { data: headInfo } = useQuery(headInfoQueryOptions(projectId));
+	const noOperationPending = useAppSelector(
+		(state) => projectSlice.selectors.selectPendingOperation(state, projectId)._tag === "None",
+	);
+	const { isPending, mutate: integrate } = useWorkspaceIntegrateUpstream();
+	const rebase = () => {
+		const updates = (headInfo?.stacks ?? [])
+			.values()
+			.map(stackBottomRelativeTo)
+			.filter((relativeTo) => relativeTo != null)
+			.map((relativeTo): BottomUpdate => ({ kind: "rebase", selector: relativeTo }))
+			.toArray();
+		integrate({ projectId, updates, dryRun: false });
+	};
+	const enabled = noOperationPending && headInfo?.target?.isCurrent === false && !isPending;
+	return (
+		<Button
+			className={getRowButtonClassName({ variant: "outline" })}
+			disabled={!enabled}
+			onClick={rebase}
+		>
+			{isPending ? "Updating…" : "Update"}
+		</Button>
+	);
+};
+
+/** The "show more" row's state: hidden when nothing older can be asked for. */
+export type MoreBelow = "hidden" | "idle" | "loading" | "failed";
+
+/** The foot of the section: one click lengthens the history below the base. */
+const ShowMore: FC<{ state: MoreBelow; onSelect: () => void }> = ({ state, onSelect }) => (
+	<Row
+		// oxlint-disable-next-line jsx-a11y/prefer-tag-over-role -- A row that acts, styled as the rows around it.
+		role="button"
+		// Not selectable while loading: a second select would restart the fetch.
+		onSelect={state === "loading" ? undefined : onSelect}
+		interactive={state !== "loading"}
+	>
+		<GraphSegment glyph="group" status="Integrated" railEnds centered />
+		<RowLabelContainer>
+			<RowLabel singleLine className={styles.elided}>
+				{state === "loading"
+					? "Loading…"
+					: state === "failed"
+						? "Could not load older commits; try again"
+						: "Show more"}
+			</RowLabel>
+		</RowLabelContainer>
+	</Row>
+);
+
+export const Section: FC<{
+	projectId: string;
+	plan: Plan;
+	moreBelow: MoreBelow;
+	/** The shown history reaches its start: the line ends on the last row. */
+	historyEnds: boolean;
+	onToggleIncoming: () => void;
+	onToggleBase: () => void;
+	onShowMoreRun: (runId: string) => void;
+	onFoldRun: (runId: string) => void;
+	onShowMore: () => void;
+	/** The scroller the section is in, for the docked card's toggle to scroll to its place. */
+	scrollElementRef: RefObject<HTMLDivElement | null>;
+}> = ({
+	projectId,
+	plan,
+	moreBelow,
+	historyEnds,
+	onToggleIncoming,
+	onToggleBase,
+	onShowMoreRun,
+	onFoldRun,
+	onShowMore,
+	scrollElementRef,
+}) => {
+	const branched = plan.header.incoming > 0;
+	const addressSpace = useAddressSpace();
+	// A docked card stays folded. Its toggle scrolls to the bottom and opens
+	// it, holding the bottom while the fold grows, so the rows open in view.
+	const incomingFold = useRef<HTMLDivElement>(null);
+	const incomingRows = useRef<HTMLDivElement>(null);
+	const toggleIncoming = () => {
+		const scroller = scrollElementRef.current;
+		const fold = incomingFold.current;
+		const rows = incomingRows.current;
+		if (!plan.incomingExpanded && scroller !== null && fold !== null && rows !== null) {
+			scroller.scrollTop = scroller.scrollHeight;
+			let height = 0;
+			const hold = new ResizeObserver(() => {
+				scroller.scrollTop = scroller.scrollHeight;
+				// Lets go once the fold has grown to its rows, or shrinks: folded again midway.
+				if (fold.offsetHeight >= rows.offsetHeight || fold.offsetHeight < height) hold.disconnect();
+				height = fold.offsetHeight;
+			});
+			hold.observe(fold);
+		}
+		onToggleIncoming();
+	};
+	// The line ends on the last row shown: the "show more" row, else the
+	// last commit once the history is shown to its start.
+	const endsOnBase = historyEnds && moreBelow === "hidden" && plan.older.length === 0;
+	const chevron = (open: boolean) => (
+		<Icon className={styles.chevron} name={open ? "chevron-down" : "chevron-right"} />
+	);
+	return (
+		<>
+			{plan.base !== null &&
+				!plan.refOnBase &&
+				(branched ? (
+					// The target has moved on from the workspace's history: a card
+					// like a forked stack's, a gap right of the main line, its header
+					// row folding the incoming commits on their leg. Folded, the card
+					// docks at the scroller's foot while its place is below it, so the
+					// news stays in view.
+					<div
+						className={styles.card}
+						data-folded={!plan.incomingExpanded}
+						style={{ "--row-padding-inline-start": `${rowInsetFor(CARD_X)}px` }}
+					>
+						<Header
+							label={plan.header.label}
+							heading
+							fold={{
+								open: plan.incomingExpanded,
+								onToggle: toggleIncoming,
+								name: "incoming commits",
+							}}
+							glyph={chevron(plan.incomingExpanded)}
+						/>
+						<Fold open={plan.incomingExpanded} ref={incomingFold}>
+							<div ref={incomingRows} className={styles.rows}>
+								{plan.incoming.map((run) =>
+									runRows(
+										run,
+										"Upstream",
+										addressSpace,
+										() => onShowMoreRun(run.id),
+										() => onFoldRun(run.id),
+									),
+								)}
+							</div>
+						</Fold>
+					</div>
+				) : (
+					// The target sits above the base with nothing incoming: a row on
+					// the main line, marked the way a branch is marked on its rail.
+					<Header
+						label={plan.header.label}
+						heading
+						glyph={<GraphSegment glyph="joinRight" status="LocalOnly" />}
+						className={styles.ref}
+					/>
+				))}
+			{plan.base !== null && (
+				<>
+					{/* The target's tip is the merge base itself: one row, the ref's name
+					    on the base commit, so the two do not read as two commits. With
+					    the target moved on, the row says how far: what Update brings. */}
+					<Header
+						label={plan.refOnBase ? plan.header.label : "Merge base"}
+						caption={
+							plan.refOnBase ? (
+								<span className={classes("text-12", styles.caption)}>merge base</span>
+							) : branched ? (
+								<span className={classes("text-12", styles.incoming)}>
+									{plan.header.incoming} new
+								</span>
+							) : undefined
+						}
+						heading={plan.refOnBase}
+						fold={{
+							open: plan.baseExpanded,
+							onToggle: onToggleBase,
+							name: "the merge base's history",
+						}}
+						glyph={chevron(plan.baseExpanded)}
+						// The leg's bend, from the target's card above onto the main line.
+						rail={
+							branched && (
+								<svg className={styles.bend} aria-hidden>
+									<path d={LEG_BEND} />
+								</svg>
+							)
+						}
+						className={styles.base}
+					>
+						{branched && <Update projectId={projectId} />}
+					</Header>
+					<Fold open={plan.baseExpanded} className={styles.history}>
+						{plan.belowBase.map((item, index) =>
+							item.kind === "fork"
+								? commitRow(
+										item.commit,
+										"Integrated",
+										addressSpace,
+										endsOnBase && index === plan.belowBase.length - 1,
+									)
+								: runRows(
+										item,
+										"Integrated",
+										addressSpace,
+										() => onShowMoreRun(item.id),
+										() => onFoldRun(item.id),
+									),
+						)}
+						{plan.older.map((commit, index) =>
+							commitRow(
+								commit,
+								"Integrated",
+								addressSpace,
+								historyEnds && index === plan.older.length - 1,
+							),
+						)}
+						{moreBelow !== "hidden" && <ShowMore state={moreBelow} onSelect={onShowMore} />}
+					</Fold>
+				</>
+			)}
+		</>
+	);
+};

--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/layout.test.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/layout.test.ts
@@ -1,0 +1,218 @@
+import type { Stack, TargetCommit, TargetCommitPage } from "@gitbutler/but-sdk";
+import { describe, expect, it } from "vitest";
+import type { Address } from "#ui/addresses.ts";
+import {
+	foldAt,
+	layout,
+	FIRST,
+	LEG_BEND,
+	MORE,
+	rails,
+	sectionAddresses,
+	targetCommitAddress,
+} from "./layout.ts";
+
+type Folds = Parameters<typeof layout>[3];
+
+const commit = (id: string, inWorkspace: boolean): TargetCommit => ({
+	commit: {
+		id,
+		message: id,
+		authoredAt: 0,
+		committedAt: 0,
+		author: { name: "", email: "", gravatarUrl: "" },
+		changeId: null,
+	},
+	review: null,
+	inWorkspace,
+});
+
+const stack = (base: string | null): Stack => ({ id: null, base, segments: [] });
+
+const folded: Folds = {
+	incomingExpanded: false,
+	baseExpanded: false,
+	moreRuns: {},
+	moreOlder: 0,
+};
+const expanded: Folds = { ...folded, incomingExpanded: true, baseExpanded: true };
+
+// Newest first: two incoming, a shallow base, three had, a deep base.
+const listing: TargetCommitPage = {
+	commits: [
+		commit("i1", false),
+		commit("i2", false),
+		commit("shallow", true),
+		commit("h1", true),
+		commit("h2", true),
+		commit("h3", true),
+		commit("deep", true),
+	],
+	hasMore: false,
+};
+
+/** A page of incoming commits above one base. */
+const incomingAbove = (ids: Array<string>): TargetCommitPage => ({
+	commits: [...ids.map((id) => commit(id, false)), commit("base", true)],
+	hasMore: false,
+});
+
+// The listing with two commits below the deepest fork point.
+const listingWithTail: TargetCommitPage = {
+	commits: [...listing.commits, commit("t1", true), commit("t2", true)],
+	hasMore: false,
+};
+
+describe("layout", () => {
+	it("shows the listing's tail and the pages fetched below the base once it is open", () => {
+		const stacks = [stack("deep"), stack("shallow")];
+		const pages = [commit("o1", true), commit("o2", true)];
+		const shown = layout(stacks, null, listingWithTail, expanded, pages);
+		// The base heads the section itself; the rows under it start below it.
+		expect(shown.base?.commit.id).toBe("shallow");
+		expect(shown.belowBase.map((item) => item.kind)).toEqual(["run", "fork"]);
+		expect(shown.older.map((c) => c.commit.id)).toEqual(["t1", "t2", "o1", "o2"]);
+		// The base's fold hides them with the rows above.
+		expect(layout(stacks, null, listingWithTail, folded, pages).older).toEqual([]);
+	});
+
+	it("shows the older history a first helping at a time, and more with each ask", () => {
+		const stacks = [stack("deep"), stack("shallow")];
+		const pages = Array.from({ length: 40 }, (_, i) => commit(`o${i}`, true));
+		const all = layout(stacks, null, listingWithTail, { ...expanded, moreOlder: 99 }, pages).older;
+		expect(all.length).toBeGreaterThan(FIRST + MORE);
+		const first = layout(stacks, null, listingWithTail, expanded, pages);
+		expect(first.older).toEqual(all.slice(0, FIRST));
+		expect(first.olderHidden).toBe(all.length - FIRST);
+		const more = layout(stacks, null, listingWithTail, { ...expanded, moreOlder: 1 }, pages);
+		expect(more.older).toHaveLength(FIRST + MORE);
+		expect(more.olderHidden).toBe(all.length - FIRST - MORE);
+	});
+
+	it("orders cards by base depth, deepest first, then as given", () => {
+		const plan = layout([stack("deep"), stack("shallow"), stack("deep")], null, listing, folded);
+		expect(plan.order).toEqual([0, 2, 1]);
+		// A base the listing does not reach is the deepest; several keep their order.
+		expect(layout([stack("shallow"), stack("unlisted")], null, listing, folded).order).toEqual([
+			1, 0,
+		]);
+		expect(
+			layout([stack("shallow"), stack("unlisted"), stack("another")], null, listing, folded).order,
+		).toEqual([1, 2, 0]);
+	});
+
+	it("folds the incoming leg under the upstream header and the base rows under the base's", () => {
+		const plan = layout([stack("deep")], null, listing, folded);
+		expect(plan.belowBase).toEqual([]);
+		expect(plan.incoming).toEqual([]);
+		// The base header names the fork point nearest the tip either way.
+		expect(plan.base?.commit.id).toBe("deep");
+		expect(layout([stack("deep"), stack("shallow")], null, listing, folded).base?.commit.id).toBe(
+			"shallow",
+		);
+		expect(
+			layout([stack("deep")], null, listing, { ...folded, baseExpanded: true }).belowBase.map(
+				(item) => item.kind,
+			),
+		).toEqual(["run"]);
+	});
+
+	it("puts the incoming commits on their own leg, ahead of the base", () => {
+		const plan = layout([stack("deep"), stack("shallow")], null, listing, expanded);
+		expect(plan.incoming.map((run) => run.shown.map((c) => c.commit.id))).toEqual([["i1", "i2"]]);
+		expect(plan.belowBase.map((item) => item.kind)).toEqual(["run", "fork"]);
+	});
+
+	it("lists the section's rows as values and knows which fold each sits in", () => {
+		const plan = layout([stack("deep"), stack("shallow")], null, listing, expanded);
+		const ids = (addresses: Array<Address>) =>
+			addresses.map((address) => (address._tag === "Commit" ? address.commitId : address._tag));
+		// Incoming commits, then what lies below the base; the workspace's own
+		// run folds entirely, and the headers, the base's included, are not values.
+		expect(ids(sectionAddresses(plan))).toEqual(["i1", "i2", "deep"]);
+		const at = (id: string) => foldAt(plan, targetCommitAddress(commit(id, true)));
+		expect(at("i1")).toBe("incoming");
+		expect(at("deep")).toBe("base");
+		expect(at("shallow")).toBeNull();
+		expect(at("h1")).toBeNull();
+	});
+
+	it("shows an incoming run's newest first, more with each ask, unless a fold would hide one row", () => {
+		const ids = Array.from({ length: 25 }, (_, i) => `c${i}`);
+		const many = incomingAbove(ids);
+		const run = layout([stack("base")], null, many, expanded).incoming[0];
+		expect(run?.kind === "run" && run.shown.length).toBe(FIRST);
+		expect(run?.kind === "run" && run.hidden).toBe(25 - FIRST);
+		expect(run?.kind === "run" && run.expanded).toBe(false);
+		const asked = { ...expanded, moreRuns: { c0: 1 } };
+		const more = layout([stack("base")], null, many, asked).incoming[0];
+		expect(more?.kind === "run" && more.shown.length).toBe(25);
+		expect(more?.kind === "run" && more.hidden).toBe(0);
+		expect(more?.kind === "run" && more.expanded).toBe(true);
+
+		const eleven = incomingAbove(ids.slice(0, FIRST + 1));
+		const whole = layout([stack("base")], null, eleven, expanded).incoming[0];
+		expect(whole?.kind === "run" && whole.shown.length).toBe(FIRST + 1);
+		expect(whole?.kind === "run" && whole.hidden).toBe(0);
+	});
+
+	it("folds a run the workspace already has entirely, and reveals it on asking", () => {
+		const items = layout([stack("deep"), stack("shallow")], null, listing, expanded).belowBase;
+		expect(items.map((item) => item.kind)).toEqual(["run", "fork"]);
+		const had = items[0];
+		expect(had?.kind === "run" && had.shown.length).toBe(0);
+		expect(had?.kind === "run" && had.hidden).toBe(3);
+		const asked = { ...expanded, moreRuns: { h1: 1 } };
+		const shown = layout([stack("deep"), stack("shallow")], null, listing, asked).belowBase[0];
+		expect(shown?.kind === "run" && shown.shown.map((c) => c.commit.id)).toEqual([
+			"h1",
+			"h2",
+			"h3",
+		]);
+	});
+});
+
+describe("rails", () => {
+	// Three cards, then the upstream section a card gap below them, drawing
+	// its own rails from its first row on.
+	const cards = [
+		{ topY: 0, bottomY: 100 },
+		{ topY: 120, bottomY: 200 },
+		{ topY: 220, bottomY: 300 },
+	];
+	// A card's fork: from its floor, the S-bend through the gap below onto
+	// the main line, one card gap down.
+	const fork = (bottomY: number) => {
+		const y = (offset: number) => Math.round((bottomY + offset) * 100) / 100;
+		return `M 30 ${bottomY} L 30 ${y(6)} C 30 ${y(8.21)} 28.21 ${y(10)} 26 ${y(10)} L 22 ${y(10)} C 19.79 ${y(10)} 18 ${y(11.79)} 18 ${y(14)} L 18 ${y(20)}`;
+	};
+
+	it("runs the main line on from the top card and forks every other card off it below its floor", () => {
+		const paths = rails(cards, 300);
+		expect(paths.some((d) => d.startsWith("M 30 100"))).toBe(false);
+		expect(paths).toContain(fork(200));
+		expect(paths).toContain(fork(300));
+		// The main line through each gap only, from the top card's floor to
+		// the section's first row: the cards draw it across themselves.
+		expect(paths.filter((d) => d.startsWith("M 18"))).toEqual([
+			"M 18 100 L 18 120",
+			"M 18 200 L 18 220",
+			"M 18 300 L 18 320",
+		]);
+	});
+
+	it("runs a lone card's rail straight on as the main line", () => {
+		expect(rails([{ topY: 0, bottomY: 100 }], 100)).toEqual(["M 18 100 L 18 120"]);
+	});
+
+	it("bends the target's leg off its card's floor onto the main line through the gap under it", () => {
+		expect(LEG_BEND).toBe(
+			"M 30 0 L 30 2 C 30 4.21 28.21 6 26 6 L 22 6 C 19.79 6 18 7.79 18 10 L 18 12",
+		);
+	});
+
+	it("knows when the target's tip is the base itself", () => {
+		const current: TargetCommitPage = { commits: [commit("shallow", true)], hasMore: false };
+		expect(layout([stack("shallow")], null, current, folded).refOnBase).toBe(true);
+	});
+});

--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/layout.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/layout.ts
@@ -1,0 +1,327 @@
+import { addressEquals, commitAddress, type Address } from "#ui/addresses.ts";
+import { assert } from "#ui/assert.ts";
+import { remoteTrackingLabel } from "#ui/branch.ts";
+import type { RefInfo, Stack, TargetCommit, TargetCommitPage } from "@gitbutler/but-sdk";
+
+/*
+ * The stacks section as a graph: the order the cards come in, which rows
+ * the upstream section shows, and the rail paths between them. Pure: pixels
+ * come in as measured anchors and go out as SVG path strings.
+ *
+ * The rules: one main line runs up the left, from the last row of the
+ * upstream section through the section and on past every card, on the
+ * card's left, into the top card, which sits on it. Every other card forks
+ * off it to the right in the gap under the card: its rows sit one gap right
+ * of the main line, and its rail bends down onto the main line below its
+ * floor. A target that has moved on gets a card like that too: its incoming
+ * commits sit on a leg beside the main line, which bends onto it under the
+ * card, at the merge base. Nothing else is drawn. The SVG draws only the
+ * gaps between the stack cards: every card draws its own rails to its
+ * edges, and the section draws its own, in Section.module.css.
+ */
+
+/** The forked cards' rail sits this far right of the main line, which runs on behind them. */
+const COLUMN_GAP = 12;
+/** The main line's x, a gap and a half in from the edge. */
+export const MAIN_X = 18;
+/** The forked cards' rail, and a moved-on target's: where their row glyphs sit; the top card's sit on the main line. */
+export const CARD_X = MAIN_X + COLUMN_GAP;
+/** A rail's x inside a row: the row inset plus half the glyph. Keep in sync with Row.module.css. */
+const GLYPH_X = 20;
+/** The rows' own inset, Row.module.css's default. */
+const ROW_INSET = 12;
+/** The row inset that puts a row's glyph on the line at `x`. */
+export const rowInsetFor = (x: number): number => x - (GLYPH_X - ROW_INSET);
+/** Every turn is a quarter circle of this radius. */
+const CORNER_R = 4;
+/**
+ * Vertical gap between cards, where a card's rail bends onto its line. Every
+ * stretch the lines bend through is this tall: the room above the upstream
+ * header, the room under it while folded, and the room around the incoming
+ * card. Keep in sync with Section.module.css.
+ */
+export const CARD_GAP = 20;
+/**
+ * The folded target card's height, which a row scrolled into view clears
+ * while the card docks: its borders, its air, its header row and its air.
+ * Keep in sync with Section.module.css.
+ */
+export const DOCKED_HEIGHT = 2 + 4 + 28 + 4;
+/** A long list, a run or the older history, shows this much at first, and this much more with each ask. */
+export const FIRST = 10;
+export const MORE = 20;
+
+type Folds = {
+	/** The upstream header's fold: the commits incoming from the target. */
+	incomingExpanded: boolean;
+	/** The base header's fold: the base rows and the older history. */
+	baseExpanded: boolean;
+	/** How many times more of each run was asked for, by the run's id. */
+	moreRuns: Readonly<Record<string, number>>;
+	/** How many times more of the older history was asked for since the base opened. */
+	moreOlder: number;
+};
+
+/**
+ * A target commit as a value: the address the graph, the Upstream tab and the
+ * applied list agree on. The change id falls back to the commit id, which
+ * should be revisited.
+ */
+export const targetCommitAddress = (commit: TargetCommit): Address =>
+	commitAddress({
+		commitId: commit.commit.id,
+		changeId: commit.commit.changeId ?? commit.commit.id,
+	});
+
+export type Run = {
+	kind: "run";
+	id: string;
+	incoming: boolean;
+	/** The commits shown, newest first. */
+	shown: Array<TargetCommit>;
+	/** How many more it holds, folded away below them. */
+	hidden: number;
+	/** Whether an ask revealed more than shows at first. */
+	expanded: boolean;
+};
+
+export type Item = { kind: "fork"; commit: TargetCommit } | Run;
+
+export type Plan = {
+	/** Card order as indices into the stacks given: by base depth, deepest first, then as given. */
+	order: Array<number>;
+	/** The target's row: its label and how many commits are incoming. Not a value: nothing selects it. */
+	header: { label: string; incoming: number };
+	/**
+	 * The target's tip is the base itself, with nothing incoming: one row
+	 * stands for both, the base commit under the ref's name.
+	 */
+	refOnBase: boolean;
+	incomingExpanded: boolean;
+	baseExpanded: boolean;
+	/**
+	 * The commit the stacks nearest the tip sit on, named by the base header
+	 * and left out of the rows under it. Not a value either: the header only
+	 * folds. Null while unknown.
+	 */
+	base: TargetCommit | null;
+	/**
+	 * Commits on the target the workspace does not have yet: they sit ahead of
+	 * the base on their own leg beside the main line. Empty while folded.
+	 */
+	incoming: Array<Run>;
+	/** Below the base, on the main line; empty while the base is folded. */
+	belowBase: Array<Item>;
+	/** Older history below the deepest fork point, as much of it as is shown: what the listing holds, then the pages fetched; plain rows. Empty while the base is folded. */
+	older: Array<TargetCommit>;
+	/** Older history loaded but not shown yet: what the next ask reveals before any page is fetched. */
+	olderHidden: number;
+};
+
+/**
+ * A stretch of the target line: a commit a workspace stack forks from, or
+ * the run of commits between such fork points.
+ */
+type TargetItem =
+	| { type: "fork"; commit: TargetCommit }
+	| { type: "run"; commits: Array<TargetCommit>; inWorkspace: boolean };
+
+/**
+ * Cut the target line at the workspace's fork points: each stack's base
+ * stands on its own, and the commits between them group into maximal runs
+ * sharing one relation to the workspace.
+ */
+const segmentAtForks = (
+	commits: ReadonlyArray<TargetCommit>,
+	stacks: ReadonlyArray<Stack>,
+): Array<TargetItem> => {
+	const forks = new Set(stacks.flatMap((stack) => (stack.base === null ? [] : [stack.base])));
+	const items: Array<TargetItem> = [];
+	for (const commit of commits) {
+		if (forks.has(commit.commit.id)) {
+			items.push({ type: "fork", commit });
+			continue;
+		}
+		const last = items.at(-1);
+		if (last?.type === "run" && last.inWorkspace === commit.inWorkspace) last.commits.push(commit);
+		else items.push({ type: "run", commits: [commit], inWorkspace: commit.inWorkspace });
+	}
+	return items;
+};
+
+/** The line down to the deepest fork point, its runs folded as the fold state says. */
+const foldRuns = (line: ReadonlyArray<TargetItem>, folds: Folds): Array<Item> =>
+	line.slice(0, line.findLastIndex((item) => item.type === "fork") + 1).map((item) => {
+		if (item.type === "fork") return { kind: "fork", commit: item.commit };
+		// Incoming runs keep their newest in view; runs the workspace already
+		// has fold entirely. Each ask reveals more. A fold hiding a single row
+		// is not worth the row.
+		const incoming = !item.inWorkspace;
+		const id = assert(item.commits[0]).commit.id;
+		const asked = folds.moreRuns[id] ?? 0;
+		const asFar = (incoming ? FIRST : 0) + asked * MORE;
+		const count = item.commits.length - asFar <= 1 ? item.commits.length : asFar;
+		return {
+			kind: "run",
+			id,
+			incoming,
+			shown: item.commits.slice(0, count),
+			hidden: item.commits.length - count,
+			expanded: asked > 0,
+		};
+	});
+
+export const layout = (
+	stacks: ReadonlyArray<Stack>,
+	target: RefInfo["target"],
+	listing: TargetCommitPage | undefined,
+	folds: Folds,
+	/** Pages of history below the listing, in order, as loaded. */
+	olderPages: ReadonlyArray<TargetCommit> = [],
+): Plan => {
+	const commits = listing?.commits ?? [];
+	const line = segmentAtForks(commits, stacks);
+	const items = foldRuns(line, folds);
+	// What the listing holds below the deepest fork point heads the older
+	// history, before the pages fetched for it.
+	const trailing = line
+		.slice(line.findLastIndex((item) => item.type === "fork") + 1)
+		.flatMap((item) => (item.type === "fork" ? [item.commit] : item.commits));
+	const older = folds.baseExpanded ? [...trailing, ...olderPages] : [];
+	const olderShown = FIRST + folds.moreOlder * MORE;
+	const baseItems = items.filter((item) => item.kind !== "run" || !item.incoming);
+	const base = baseItems.find((item) => item.kind === "fork")?.commit ?? null;
+	const belowBase = baseItems.filter(
+		(item) => item.kind !== "fork" || item.commit.commit.id !== base?.commit.id,
+	);
+
+	// Deeper bases first, nearest their own history's end; a base the listing
+	// does not reach is deeper than any listed, all of them equally, so they
+	// keep the order given.
+	const forkOrder = items.flatMap((item) => (item.kind === "fork" ? [item.commit.commit.id] : []));
+	const depth = (stack: Stack): number => {
+		const index = stack.base === null ? -1 : forkOrder.indexOf(stack.base);
+		return index === -1 ? forkOrder.length : index;
+	};
+	const order = stacks
+		.map((stack, index) => ({ index, stack }))
+		.sort((a, b) => {
+			const byDepth = depth(b.stack) - depth(a.stack);
+			return byDepth === 0 ? a.index - b.index : byDepth;
+		});
+
+	return {
+		order: order.map((entry) => entry.index),
+		header: {
+			label: target ? remoteTrackingLabel(target.remoteTrackingRef) : "target",
+			incoming: commits.filter((entry) => !entry.inWorkspace).length,
+		},
+		refOnBase:
+			base !== null &&
+			commits[0]?.commit.id === base.commit.id &&
+			commits.every((entry) => entry.inWorkspace),
+		incomingExpanded: folds.incomingExpanded,
+		baseExpanded: folds.baseExpanded,
+		base,
+		incoming: folds.incomingExpanded
+			? items.flatMap((item) => (item.kind === "run" && item.incoming ? [item] : []))
+			: [],
+		belowBase: folds.baseExpanded ? belowBase : [],
+		older: older.slice(0, olderShown),
+		olderHidden: Math.max(0, older.length - olderShown),
+	};
+};
+
+const runCommits = (run: Run): Array<TargetCommit> => run.shown;
+
+const itemCommits = (item: Item): Array<TargetCommit> =>
+	item.kind === "fork" ? [item.commit] : runCommits(item);
+
+/** The rows a fold shows, as values, top to bottom. The headers are not values. */
+export const foldAddresses = (plan: Plan, fold: "incoming" | "base"): Array<Address> =>
+	(fold === "incoming"
+		? plan.incoming.flatMap(runCommits)
+		: [...plan.belowBase.flatMap(itemCommits), ...plan.older]
+	).map(targetCommitAddress);
+
+/** The section's rows as values, top to bottom, as the fold state shows them. */
+export const sectionAddresses = (plan: Plan): Array<Address> => [
+	...foldAddresses(plan, "incoming"),
+	...foldAddresses(plan, "base"),
+];
+
+/** The review a shown target commit landed, by commit id; null when none or not shown. */
+export const planCommitReview = (plan: Plan, commitId: string) =>
+	[
+		...plan.incoming.flatMap(runCommits),
+		...plan.belowBase.flatMap(itemCommits),
+		...plan.older,
+	].find((commit) => commit.commit.id === commitId)?.review ?? null;
+
+/** Which of the section's folds a row sits in, so a fold key on the row can close it; null off the section. */
+export const foldAt = (plan: Plan, address: Address): "incoming" | "base" | null => {
+	const inFold = (fold: "incoming" | "base") =>
+		foldAddresses(plan, fold).some((other) => addressEquals(address, other));
+	return inFold("incoming") ? "incoming" : inFold("base") ? "base" : null;
+};
+
+/* ------------------------------------------------------------------ rails */
+
+/** A card's edges from the virtualiser, in the scroller's content pixels. */
+export type Card = { topY: number; bottomY: number };
+
+const ARC_K = 0.5523;
+const n = (value: number): string => String(Math.round(value * 100) / 100);
+
+/**
+ * An S-bend from one line to another: straight, a quarter-turn toward the
+ * other line, straight across, a quarter-turn back down, straight on.
+ */
+const sBend = (x0: number, y0: number, x1: number, y1: number): string => {
+	const dir = x1 > x0 ? 1 : -1;
+	const r = CORNER_R;
+	const my = (y0 + y1) / 2;
+	const k = ARC_K * r;
+	return [
+		`L ${n(x0)} ${n(my - r)}`,
+		`C ${n(x0)} ${n(my - r + k)} ${n(x0 + dir * (r - k))} ${n(my)} ${n(x0 + dir * r)} ${n(my)}`,
+		`L ${n(x1 - dir * r)} ${n(my)}`,
+		`C ${n(x1 - dir * (r - k))} ${n(my)} ${n(x1)} ${n(my + r - k)} ${n(x1)} ${n(my + r)}`,
+		`L ${n(x1)} ${n(y1)}`,
+	].join(" ");
+};
+
+/** The gap under the target's card, which its leg bends through. Keep in sync with Section.module.css. */
+const LEG_GAP = 12;
+/** The leg's bend under the target's card: off the card's floor, onto the main line at the merge base header's top. */
+export const LEG_BEND = `M ${n(CARD_X)} 0 ${sBend(CARD_X, 0, MAIN_X, LEG_GAP)}`;
+
+/** A line straight down from `from` to `to`. */
+const runDown = (rails: Array<string>, x: number, from: number, to: number): void => {
+	if (to > from) rails.push(`M ${n(x)} ${n(from)} L ${n(x)} ${n(to)}`);
+};
+
+/**
+ * The rails through the gaps between the cards, as SVG paths; every card
+ * draws its own to its edges. The top card sits on the main line, which runs
+ * on from its floor, through each gap into the card below, and through the
+ * gap under the last card to the upstream section's first row; from there
+ * the section carries it itself. Every other card's rail bends off its
+ * floor onto the main line in the gap below it.
+ */
+export const rails = (cards: ReadonlyArray<Card>, cardsEnd: number): Array<string> => {
+	const paths: Array<string> = [];
+	const [top, ...rest] = cards;
+	if (top === undefined) return paths;
+
+	let y = top.bottomY;
+	for (const card of rest) {
+		paths.push(
+			`M ${n(CARD_X)} ${n(card.bottomY)} ${sBend(CARD_X, card.bottomY, MAIN_X, card.bottomY + CARD_GAP)}`,
+		);
+		runDown(paths, MAIN_X, y, card.topY);
+		y = card.bottomY;
+	}
+	runDown(paths, MAIN_X, y, cardsEnd + CARD_GAP);
+	return paths;
+};

--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/usePlan.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/usePlan.ts
@@ -1,0 +1,72 @@
+import {
+	headInfoQueryOptions,
+	olderTargetCommitsInfiniteQueryOptions,
+	workspaceTargetCommitsQueryOptions,
+} from "#ui/api/queries.ts";
+import { projectSlice } from "#ui/projects/state.ts";
+import { useAppSelector } from "#ui/store.ts";
+import type { Stack } from "@gitbutler/but-sdk";
+import { useInfiniteQuery, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useMemo } from "react";
+import { FIRST, layout, MORE, type Plan } from "./layout.ts";
+
+/** The stacks graph as its host computes it once: the plan, the cards in its order, and the older history's paging. */
+export type Graph = ReturnType<typeof usePlan>;
+
+/**
+ * The stacks graph's plan from the workspace's data and the fold state, with
+ * the cards in the order the plan draws them. Called once per host, the page
+ * and the harness panel, which build the applied address space from it and
+ * hand it to the stacks to render: a second call would page the older
+ * history twice.
+ */
+export const usePlan = (projectId: string) => {
+	const { data: headInfo } = useQuery(headInfoQueryOptions(projectId));
+	const { data: listing } = useQuery(workspaceTargetCommitsQueryOptions(projectId));
+	const folds = useAppSelector((state) =>
+		projectSlice.selectors.selectGraphFolds(state, projectId),
+	);
+	// Older history below the deepest fork point: the listing's own tail first,
+	// then pages shared with the Upstream tab, the first of them fetched as
+	// the base opens and the rest on demand.
+	const olderFrom = listing?.commits.at(-1)?.commit.id ?? "";
+	const olderOptions = olderTargetCommitsInfiniteQueryOptions(projectId, olderFrom);
+	const olderQuery = useInfiniteQuery({
+		...olderOptions,
+		enabled: folds.baseExpanded && olderFrom !== "",
+	});
+	// Folding the base forgets the pages it loaded, so it opens from scratch
+	// next time rather than as long as it was left.
+	const queryClient = useQueryClient();
+	const forgetOlder = () => queryClient.removeQueries({ queryKey: olderOptions.queryKey });
+	const olderPagesData = olderQuery.data;
+	const olderPages = useMemo(
+		() => olderPagesData?.pages.flatMap((page) => page.commits) ?? [],
+		[olderPagesData],
+	);
+	const listOrder = useMemo(() => (headInfo?.stacks ?? []).toReversed(), [headInfo]);
+	const target = headInfo?.target ?? null;
+	// Explicit: the compiler does not memoise calls to imported functions, and
+	// the rails re-measure whenever the plan's identity changes.
+	const plan: Plan = useMemo(
+		() => layout(listOrder, target, listing, folds, olderPages),
+		[listOrder, target, listing, folds, olderPages],
+	);
+	// Pages come as the rows shown ask for them: the first as the base opens,
+	// and another whenever an ask outruns what is loaded.
+	const { fetchNextPage, hasNextPage, isFetching } = olderQuery;
+	const loaded = plan.older.length + plan.olderHidden;
+	const wanted = folds.baseExpanded ? FIRST + folds.moreOlder * MORE : 0;
+	useEffect(() => {
+		if (loaded < wanted && hasNextPage && !isFetching) void fetchNextPage();
+	}, [loaded, wanted, hasNextPage, isFetching, fetchNextPage]);
+	const stacks: Array<Stack> = useMemo(
+		() =>
+			plan.order.flatMap((index) => {
+				const stack = listOrder[index];
+				return stack === undefined ? [] : [stack];
+			}),
+		[plan, listOrder],
+	);
+	return { plan, stacks, olderQuery, olderFrom, forgetOlder };
+};

--- a/apps/lite/ui/src/routes/project/$id/workspace/Page.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Page.tsx
@@ -10,7 +10,6 @@ import {
 	absorptionPlanQueryOptions,
 	changesInWorktreeQueryOptions,
 	guiSettingsQueryOptions,
-	headInfoQueryOptions,
 	listProjectsQueryOptions,
 	operatingModeQueryOptions,
 	treeChangesDiffsQueryOptions,
@@ -48,12 +47,15 @@ import {
 	useMemo,
 	useRef,
 	useState,
+	type ReactNode,
 } from "react";
 import { Group, Panel, useDefaultLayout } from "react-resizable-panels";
 import { branchAddress, type BranchAddress, uncommittedChangesFileParent } from "#ui/addresses.ts";
 import type { DiffLineSelection } from "#ui/cursors.ts";
 import { Details, type DiffViewerHandle, UncommittedFilesDetails } from "./Details.tsx";
 import { buildAppliedAddressSpace } from "./applied-address-space.ts";
+import { planCommitReview } from "./Graph/layout.ts";
+import { usePlan } from "./Graph/usePlan.ts";
 import { getDiffFileNavigation } from "./diff-view.ts";
 import { buildUncommittedFileRows } from "./file-row.ts";
 import { fileTreeAddressSpace, selectedFilePath } from "./file-tree.ts";
@@ -83,7 +85,7 @@ import {
 	useSelection,
 	useActiveList,
 } from "#ui/use-cursor.ts";
-import type { ActiveList } from "#ui/projects/project.ts";
+import { activeLists, type ActiveList } from "#ui/projects/project.ts";
 import { defaultSettings } from "#ui/settings.ts";
 import { parseDragData } from "./DragData.ts";
 
@@ -392,7 +394,7 @@ const PageBody: FC<{ projectId: string }> = ({ projectId }) => {
 	// between `new Set(...)` and `buildAppliedAddressSpace(...)` left both
 	// unmemoized: every render rebuilt the address space and re-rendered every
 	// row that reads it through context.
-	const { data: headInfo } = useQuery(headInfoQueryOptions(projectId));
+	const graph = usePlan(projectId);
 	const foldedSegments = useAppSelector((state) =>
 		projectSlice.selectors.selectFoldedSegments(state, projectId),
 	);
@@ -410,7 +412,8 @@ const PageBody: FC<{ projectId: string }> = ({ projectId }) => {
 	);
 
 	const appliedAddressSpace = buildAppliedAddressSpace({
-		headInfo,
+		stacks: graph.stacks,
+		plan: graph.plan,
 		pendingOperation,
 		absorptionTargetCommitIds,
 		foldedSegments,
@@ -483,59 +486,54 @@ const PageBody: FC<{ projectId: string }> = ({ projectId }) => {
 	const uncommittedFilesSelection = useSelection("uncommitted", uncommittedAddressSpace);
 
 	const activeList = useActiveList();
-	// Which list's cursor drives the pane. Normally the active one, but a cursor
-	// is null only when its list is empty, and an empty list has no details to
-	// give: rather than go blank beside a sibling with content in it, the pane
-	// shows the sibling. Only the pane bends — `activeList` still says where the
-	// user is standing, which is what operations and the keyboard act on.
-	const detailsList: ActiveList =
-		activeList === "applied"
-			? appliedSelection === null && uncommittedFilesSelection !== null
-				? "uncommitted"
-				: "applied"
-			: uncommittedFilesSelection === null && appliedSelection !== null
-				? "applied"
-				: "uncommitted";
-	// The page picks only which list's cursor drives the pane; one Details
-	// component then dispatches on the selection itself. The uncommitted arm is
-	// the genuine fork — its cursor is a path, not an address. Memoised because
-	// `useDeferredValue` compares by identity, so a freshly built element every
-	// render would defer every render. Looked up outside the memo so the details
-	// only rebuild when the review itself changes, not on every list rerun.
+	// One Details component dispatches on the selection itself; the uncommitted
+	// list is the genuine fork, its cursor a path, not an address. Memoised
+	// because `useDeferredValue` compares by identity, so a freshly built element
+	// every render would defer every render. Looked up outside the memo so the
+	// details only rebuild when the review itself changes, not on every list rerun.
 	const upstreamReview =
 		upstreamSelection?._tag === "Commit"
 			? upstreamCommitReview(upstreamList, upstreamSelection.commitId)
 			: null;
+	// A target commit selected in the stacks graph carries the review it landed.
+	const appliedReview =
+		appliedSelection?._tag === "Commit"
+			? planCommitReview(graph.plan, appliedSelection.commitId)
+			: null;
 	const details = useMemo(() => {
 		const viewProps = { projectId, onActiveFileSelection, viewerRef, didScrollToViaFileRef };
 
-		return Match.value(page).pipe(
-			Match.when("workspace", () =>
-				Match.value(detailsList).pipe(
-					Match.when("applied", () =>
-						appliedSelection === null ? (
-							// Both lists are empty by now: `detailsList` would have picked the
-							// uncommitted one if it had anything to show.
-							<DetailsPlaceholder
-								title="Nothing to show yet"
-								description="Details of whatever you select appear in this pane"
-							/>
-						) : (
-							<Details selection={appliedSelection} review={null} {...viewProps} />
-						),
-					),
-					Match.when("uncommitted", () =>
-						uncommittedFilesSelection === null ? (
-							<DetailsPlaceholder
-								title="Nothing to show yet"
-								description="Details of whatever you select appear in this pane"
-							/>
-						) : (
-							<UncommittedFilesDetails path={uncommittedFilesSelection} {...viewProps} />
-						),
-					),
-					Match.exhaustive,
+		// Each workspace list's details, null while its cursor is: a cursor is
+		// null only when its list is empty, and an empty list has nothing to give.
+		const detailsFor: { [L in ActiveList]: ReactNode } = {
+			applied:
+				appliedSelection === null ? null : (
+					<Details selection={appliedSelection} review={appliedReview} {...viewProps} />
 				),
+			uncommitted:
+				uncommittedFilesSelection === null ? null : (
+					<UncommittedFilesDetails path={uncommittedFilesSelection} {...viewProps} />
+				),
+		};
+		// The pane follows the active list, else the first sibling with something
+		// to show, rather than going blank beside content. Only the pane bends:
+		// `activeList` still says where the user stands, which is what operations
+		// and the keyboard act on.
+		const detailsList =
+			[activeList, ...activeLists.filter((list) => list !== activeList)].find(
+				(list) => detailsFor[list] !== null,
+			) ?? activeList;
+
+		return Match.value(page).pipe(
+			Match.when(
+				"workspace",
+				() =>
+					detailsFor[detailsList] ?? (
+						<DetailsPlaceholder
+							title="Nothing to show yet"
+							description="Details of whatever you select appear in this pane"
+						/>
+					),
 			),
 			Match.when("upstream", () =>
 				upstreamSelection === null ? (
@@ -564,11 +562,12 @@ const PageBody: FC<{ projectId: string }> = ({ projectId }) => {
 		branchesSelection,
 		onActiveFileSelection,
 		appliedSelection,
+		appliedReview,
 		page,
 		uncommittedFilesSelection,
 		upstreamReview,
 		upstreamSelection,
-		detailsList,
+		activeList,
 	]);
 
 	const deferredDetails = useDeferredValue(details);
@@ -664,6 +663,7 @@ const PageBody: FC<{ projectId: string }> = ({ projectId }) => {
 								branchesPending={branchesPending}
 								branchesError={branchesError}
 								upstreamList={upstreamList}
+								graph={graph}
 								addressSpace={appliedAddressSpace}
 								uncommittedAddressSpace={uncommittedAddressSpace}
 								absorptionTargetCommitIds={absorptionTargetCommitIds}

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.tsx
@@ -23,6 +23,7 @@ import { type NativeMenuItem, nativeMenuItem, showNativeMenuFromTrigger } from "
 import { openLinkExternally } from "#ui/external-link.ts";
 import type { DraftPRExtras } from "#ui/pr.ts";
 import { formatAbsoluteTime, formatCompactDuration, formatRelativeTime } from "#ui/time.ts";
+import { useCopied } from "#ui/routes/project/$id/workspace/useCopied.ts";
 import type {
 	CiCheck,
 	ForgeReview,
@@ -33,7 +34,7 @@ import type {
 import { Tooltip } from "@base-ui/react";
 import { useQuery } from "@tanstack/react-query";
 import { Match } from "effect";
-import { type FC, type MouseEvent, type ReactNode, useLayoutEffect, useRef, useState } from "react";
+import type { FC, MouseEvent, ReactNode } from "react";
 import styles from "./PullRequestPanel.module.css";
 
 type ReviewStatus = "open" | "draft" | "merged" | "closed";
@@ -138,29 +139,13 @@ const Label: FC<{ label: ForgeReviewLabel }> = ({ label }) => {
 };
 
 const CopyableBranch: FC<{ name: string }> = ({ name }) => {
-	const [copied, setCopied] = useState(false);
-	const resetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-	const handleCopy = () => {
-		void window.lite.clipboardWriteText(name);
-		setCopied(true);
-
-		if (resetTimeoutRef.current !== null) clearTimeout(resetTimeoutRef.current);
-		resetTimeoutRef.current = setTimeout(() => setCopied(false), 1500);
-	};
-
-	useLayoutEffect(
-		() => () => {
-			if (resetTimeoutRef.current !== null) clearTimeout(resetTimeoutRef.current);
-		},
-		[],
-	);
+	const { copied, copy } = useCopied(name);
 
 	return (
 		<Tooltip.Root>
 			<Tooltip.Trigger
 				className={styles.sourceBranch}
-				onClick={handleCopy}
+				onClick={copy}
 				render={<button type="button" aria-label="Copy branch name" />}
 			>
 				{copied ? "Copied!" : name}

--- a/apps/lite/ui/src/routes/project/$id/workspace/Sidebar.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Sidebar.tsx
@@ -27,6 +27,7 @@ import { useHotkeys } from "@tanstack/react-hotkeys";
 import { Activity, type FC, useRef } from "react";
 import { ToggleGroupStyles, ToggleStyles } from "#ui/components/ToggleGroup.tsx";
 import { WorkspaceLists } from "#ui/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.tsx";
+import type { Graph } from "#ui/routes/project/$id/workspace/Graph/usePlan.ts";
 import { BranchesList } from "#ui/routes/project/$id/workspace/BranchesList.tsx";
 import type { BranchesListContent } from "#ui/routes/project/$id/workspace/useBranchesList.ts";
 import { UpstreamList } from "#ui/routes/project/$id/workspace/UpstreamList.tsx";
@@ -95,6 +96,7 @@ export const Sidebar: FC<{
 	branchesPending: boolean;
 	branchesError: boolean;
 	upstreamList: UpstreamListData;
+	graph: Graph;
 	addressSpace: AddressSpace<Address>;
 	uncommittedAddressSpace: AddressSpace<string>;
 	onActiveFileSelection: (selection: string) => void;
@@ -106,6 +108,7 @@ export const Sidebar: FC<{
 	branchesPending,
 	branchesError,
 	upstreamList,
+	graph,
 	addressSpace,
 	uncommittedAddressSpace,
 	onActiveFileSelection,
@@ -335,6 +338,7 @@ export const Sidebar: FC<{
 			<Activity mode={page === "workspace" ? "visible" : "hidden"}>
 				<WorkspaceLists
 					className={styles.page}
+					graph={graph}
 					addressSpace={addressSpace}
 					uncommittedAddressSpace={uncommittedAddressSpace}
 					absorptionTargetCommitIds={absorptionTargetCommitIds}

--- a/apps/lite/ui/src/routes/project/$id/workspace/StackCard.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/StackCard.module.css
@@ -31,3 +31,11 @@
 	min-height: auto;
 	overflow: hidden;
 }
+
+/* In the stacks graph a rail runs on from the card's floor: the stub runs
+   over the border to the card's edge, and the rail picks it up there rather
+   than crossing the border. */
+.card[data-graph] .railConnector:last-child {
+	height: 9px;
+	margin-block-end: -1px;
+}

--- a/apps/lite/ui/src/routes/project/$id/workspace/UpstreamList.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/UpstreamList.tsx
@@ -10,7 +10,8 @@ import {
 	type GraphSegmentStatus,
 } from "#ui/components/GraphSegment.tsx";
 import { Icon } from "#ui/components/Icon.tsx";
-import { commitAddress, addressIdentityKey, type Address } from "#ui/addresses.ts";
+import { addressIdentityKey } from "#ui/addresses.ts";
+import { targetCommitAddress } from "./Graph/layout.ts";
 import { projectSlice } from "#ui/projects/state.ts";
 import { useAutofocusScope, useAddressSpaceHotkeys, type FocusScope } from "#ui/focus-scopes.ts";
 import { useAppDispatch } from "#ui/store.ts";
@@ -45,15 +46,6 @@ import styles from "./UpstreamList.module.css";
 
 const pluralRules = new Intl.PluralRules("en");
 
-const useIsSelected = (address: Address): boolean => useIsSelectedInList(address, "upstream");
-
-const upstreamCommitAddress = (item: UpstreamCommitItem): Address =>
-	commitAddress({
-		commitId: item.commit.id,
-		// This is a hack that should be revisited...
-		changeId: item.commit.changeId ?? item.commit.id,
-	});
-
 /**
  * The target branch the incoming commits below it belong to. It heads the card
  * the way a stack's own name heads a stack card, and starts the target rail
@@ -72,7 +64,8 @@ const TargetHeadRow: FC<{ label: string }> = ({ label }) => (
 	</Row>
 );
 
-const TargetCommitRow: FC<{
+/** Shared with the workspace page's stacks graph, which lists the same commits. */
+export const TargetCommitRow: FC<{
 	item: UpstreamCommitItem;
 	positionInSet: number;
 	setSize: number;
@@ -83,10 +76,16 @@ const TargetCommitRow: FC<{
 	 * which is true of every row there, and so tells the reader nothing.
 	 */
 	status?: GraphSegmentStatus;
-}> = ({ item, positionInSet, setSize, status }) => {
+	/** The rail ends on this row: the history has no commit below it. */
+	railEnds?: boolean;
+	/** The cursor the row is on: the Upstream tab's own, or the applied list's in the stacks graph. */
+	list?: "applied" | "upstream";
+	/** Out of its list for now, as a pending operation leaves it: not a value to move to. */
+	inert?: boolean;
+}> = ({ item, positionInSet, setSize, status, railEnds, list = "upstream", inert }) => {
 	const { commit, review, inWorkspace } = item;
-	const address = upstreamCommitAddress(item);
-	const isSelected = useIsSelected(address);
+	const address = targetCommitAddress(item);
+	const isSelected = useIsSelectedInList(address, list);
 	// A commit that landed a review is shown as that review: its title says
 	// what changed, where "Merge pull request #N from …" only says that it did.
 	const title = review?.title ?? commitTitle(commit.message);
@@ -100,14 +99,20 @@ const TargetCommitRow: FC<{
 			role="treeitem"
 			aria-label={title ?? "(no message)"}
 			aria-level={1}
-			aria-posinset={positionInSet}
-			aria-setsize={setSize}
+			aria-posinset={inert ? undefined : positionInSet}
+			aria-setsize={inert ? undefined : setSize}
 			aria-selected={isSelected}
 			isSelected={isSelected}
-			scrollSelectedIntoView={false}
-			onSelect={() => setCursor("upstream", address)}
+			inert={inert}
+			// The Upstream tab virtualises and scrolls for itself.
+			scrollSelectedIntoView={list === "applied"}
+			onSelect={() => setCursor(list, address)}
 		>
-			<GraphSegment glyph="commit" status={status ?? (inWorkspace ? "Integrated" : "Upstream")} />
+			<GraphSegment
+				glyph="commit"
+				status={status ?? (inWorkspace ? "Integrated" : "Upstream")}
+				railEnds={railEnds}
+			/>
 			<div className={styles.label}>
 				<RowLabelContainer>
 					{/* Commits the workspace already has are not dimmed: the row is
@@ -539,7 +544,7 @@ export const UpstreamList: FC<
 		const virtualIndexByAddressKey = new Map<string, number>();
 		for (const [index, row] of virtualRows.entries()) {
 			if (row.type !== "item" || row.item.type !== "commit") continue;
-			virtualIndexByAddressKey.set(addressIdentityKey(upstreamCommitAddress(row.item)), index);
+			virtualIndexByAddressKey.set(addressIdentityKey(targetCommitAddress(row.item)), index);
 		}
 
 		return { virtualRows, virtualIndexByAddressKey };
@@ -667,7 +672,7 @@ export const UpstreamList: FC<
 											positionInSet={
 												// oxlint-disable-next-line typescript/no-non-null-assertion
 												addressSpace.indexByKey.get(
-													addressIdentityKey(upstreamCommitAddress(row.item)),
+													addressIdentityKey(targetCommitAddress(row.item)),
 												)! + 1
 											}
 											setSize={addressSpace.items.length}

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/BranchRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/BranchRow.tsx
@@ -135,6 +135,8 @@ export const BranchRow: FC<
 		bottomRelativeTo: RelativeTo | null;
 		isTopSegment: boolean;
 		commitCount: number;
+		/** The rail below the branch's tick: its first commit's colour, or plain without one. */
+		railBelow: GraphSegmentStatus;
 		/** The stack this branch sits in, for the stack-wide menu items. */
 		stack: Stack;
 	} & ComponentProps<"div">
@@ -151,6 +153,7 @@ export const BranchRow: FC<
 	bottomRelativeTo,
 	isTopSegment,
 	commitCount,
+	railBelow,
 	stack,
 	...restProps
 }) => {
@@ -454,6 +457,8 @@ export const BranchRow: FC<
 									<GraphSegment
 										glyph={isTopSegment ? "forkRight" : "joinRight"}
 										status={graphStatus}
+										above="LocalOnly"
+										below={railBelow}
 									/>
 								}
 								foldedIndicator={<GraphSegment glyph="group" status={graphStatus} />}
@@ -473,7 +478,12 @@ export const BranchRow: FC<
 					</Tooltip.Portal>
 				</Tooltip.Root>
 			) : (
-				<GraphSegment glyph={isTopSegment ? "forkRight" : "joinRight"} status={graphStatus} />
+				<GraphSegment
+					glyph={isTopSegment ? "forkRight" : "joinRight"}
+					status={graphStatus}
+					above="LocalOnly"
+					below={railBelow}
+				/>
 			)}
 
 			{isRenaming ? (

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/CommitRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/CommitRow.tsx
@@ -12,7 +12,7 @@ import {
 import { forgeInfoOptions, headInfoQueryOptions } from "#ui/api/queries.ts";
 import { classes } from "#ui/components/classes.ts";
 import { ConflictIcon } from "#ui/components/ConflictIcon.tsx";
-import { GraphSegment } from "#ui/components/GraphSegment.tsx";
+import { GraphSegment, type GraphSegmentStatus } from "#ui/components/GraphSegment.tsx";
 import { Icon } from "#ui/components/Icon.tsx";
 import { TooltipPopup } from "#ui/components/Tooltip.tsx";
 import { commitBody, commitForgeUrl, commitIsDiverged, commitTitle } from "#ui/commit.ts";
@@ -58,6 +58,8 @@ export const CommitRow: FC<
 		amendCommit: () => void;
 		canAmendCommit: boolean;
 		scrollSelectedIntoView?: boolean;
+		/** The rail below the commit's circle: the next icon's colour, or plain under a card's last. */
+		below?: GraphSegmentStatus;
 	} & ComponentProps<"div">
 > = ({
 	commit,
@@ -67,6 +69,7 @@ export const CommitRow: FC<
 	checkCommit,
 	amendCommit,
 	canAmendCommit,
+	below,
 	...restProps
 }) => {
 	const { data: forgeInfo } = useQuery(forgeInfoOptions(projectId));
@@ -387,6 +390,7 @@ export const CommitRow: FC<
 				<GraphSegment
 					glyph="commit"
 					status={commitIsDiverged(commit) ? "Diverged" : commit.state.type}
+					below={below}
 				/>
 				<Tooltip.Root
 					// This gets in the way when the user tries to move their hover to a

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.module.css
@@ -131,16 +131,44 @@
 }
 
 /* The cards run the full width of the panel, so nothing insets them and the
-   scroll separator already spans it. */
+   scroll separator already spans it; the upstream section below supplies the
+   room under the last card. */
 .stacks {
 	box-sizing: content-box;
-	padding-bottom: var(--panel-padding-block);
 }
 
 .virtualContainer {
 	position: relative;
 }
 
+/* The positioned box the rails SVG covers: the cards and the upstream section
+   below them, with the room under the column: the base header's gap again,
+   constant across fold states, so opening a fold does not shift the scroll,
+   and there while the section has nothing to show. */
+.content {
+	position: relative;
+	padding-block-end: 12px;
+}
+
 .virtualStack:not([data-index="0"]) {
 	border-block-start: 1px solid var(--border-section);
+}
+
+/* A forked card sits a gap right of the main line, which runs on behind it.
+   The card carries it across itself, quieter, between its borders, which
+   stay whole over it: the line passes under the card's edge, and the rails
+   between the cards only ever draw in the gaps. Above the rows, whose fills
+   it crosses in their inset, and translucent where the other rails are
+   blended into the card: a mid grey darkens a selected row's light fill and
+   lightens a focused row's dark one, where a fixed light grey vanished on
+   the one and glared on the other. */
+.virtualStack[data-forked="true"]::after {
+	z-index: 1;
+	position: absolute;
+	inset-block: 0;
+	left: calc(var(--main-line-x) - 0.75px);
+	width: 1.5px;
+	background-color: color-mix(in srgb, var(--commit-local) 16%, transparent);
+	content: "";
+	pointer-events: none;
 }

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.tsx
@@ -1,5 +1,5 @@
 import rowStyles from "../Row.module.css";
-import { setCursor, useIsCursorAt, useSelection, useActiveList } from "#ui/use-cursor.ts";
+import { setCursor, useActiveList, useIsCursorAt, useSelection } from "#ui/use-cursor.ts";
 import { useCommitAmend } from "#ui/api/mutations.ts";
 import { changesInWorktreeQueryOptions, headInfoQueryOptions } from "#ui/api/queries.ts";
 import { getHeadInfoIndex, recordedPullRequest } from "#ui/api/ref-info.ts";
@@ -47,23 +47,35 @@ import type { PayloadFor } from "#electron/ipc.ts";
 import { Match } from "effect";
 import {
 	Activity,
-	type ComponentProps,
-	createContext,
 	type CSSProperties,
-	type FC,
 	Fragment,
-	type RefObject,
-	type ReactNode,
+	createContext,
 	use,
 	useCallback,
 	useLayoutEffect,
 	useMemo,
 	useRef,
 	useState,
+	type ComponentProps,
+	type FC,
+	type ReactNode,
+	type RefObject,
 } from "react";
 import { Group, Panel, useDefaultLayout } from "react-resizable-panels";
 import styles from "./WorkspaceLists.module.css";
 import { Row, RowLabel, RowLabelContainer, SectionHeaderRow } from "../Row.tsx";
+import { Rails } from "../Graph/Rails.tsx";
+import { type MoreBelow, Section } from "../Graph/Section.tsx";
+import {
+	CARD_GAP,
+	CARD_X,
+	DOCKED_HEIGHT,
+	MAIN_X,
+	foldAddresses,
+	foldAt,
+	rowInsetFor,
+} from "../Graph/layout.ts";
+import type { Graph } from "../Graph/usePlan.ts";
 import { StackCard } from "../StackCard.tsx";
 import stackCardStyles from "../StackCard.module.css";
 import { treeItemId } from "../Row-utils.ts";
@@ -451,6 +463,10 @@ const segmentPushStatusToGraphSegmentStatus = (pushStatus: PushStatus): GraphSeg
 	}
 };
 
+/** A commit's glyph colour: its state's, or the diverged one's. */
+const commitGraphStatus = (commit: Commit): GraphSegmentStatus =>
+	commitIsDiverged(commit) ? "Diverged" : commit.state.type;
+
 const BranchSegment: FC<{
 	projectId: string;
 	segment: Segment;
@@ -465,6 +481,7 @@ const BranchSegment: FC<{
 	onAmendCommit: (commitId: string) => void;
 	canAmendCommit: boolean;
 	scrollElementRef: RefObject<HTMLDivElement | null>;
+	scrollPaddingEnd: number;
 	stackScrollStart: number;
 	stackSize: number;
 	segmentIndex: number;
@@ -485,6 +502,7 @@ const BranchSegment: FC<{
 	onAmendCommit,
 	canAmendCommit,
 	scrollElementRef,
+	scrollPaddingEnd,
 	stackScrollStart,
 	stackSize,
 	segmentIndex,
@@ -493,6 +511,9 @@ const BranchSegment: FC<{
 	setSize,
 }) => {
 	const address = branchAddress({ branchRef: refName.fullNameBytes });
+	// The rail below the branch's tick is its first commit's; plain when it has none.
+	const firstCommit = segment.commits[0];
+	const railBelow = firstCommit === undefined ? "LocalOnly" : commitGraphStatus(firstCommit);
 	const isFolded = useAppSelector((state) =>
 		projectSlice.selectors.selectSegmentFolded(
 			state,
@@ -524,6 +545,7 @@ const BranchSegment: FC<{
 				bottomRelativeTo={segmentBottomRelativeTo(segment)}
 				isTopSegment={isTopSegment}
 				commitCount={segment.commits.length}
+				railBelow={railBelow}
 				stack={stack}
 			/>
 
@@ -541,6 +563,7 @@ const BranchSegment: FC<{
 					onAmendCommit={onAmendCommit}
 					canAmendCommit={canAmendCommit}
 					scrollElementRef={scrollElementRef}
+					scrollPaddingEnd={scrollPaddingEnd}
 					stackScrollStart={stackScrollStart}
 					stackSize={stackSize}
 					segmentIndex={segmentIndex}
@@ -586,6 +609,7 @@ const SegmentContent: FC<{
 	onAmendCommit: (commitId: string) => void;
 	canAmendCommit: boolean;
 	scrollElementRef: RefObject<HTMLDivElement | null>;
+	scrollPaddingEnd: number;
 	stackScrollStart: number;
 	stackSize: number;
 	segmentIndex: number;
@@ -602,6 +626,7 @@ const SegmentContent: FC<{
 	onAmendCommit,
 	canAmendCommit,
 	scrollElementRef,
+	scrollPaddingEnd,
 	stackScrollStart,
 	stackSize,
 	segmentIndex,
@@ -641,9 +666,9 @@ const SegmentContent: FC<{
 		getItemKey: getCommitKey,
 		rangeExtractor: rangeExtractorWithSelected,
 		scrollMargin,
-		// Matches --scroll-gradient-height.
+		// Matches --scroll-gradient-height; the foot also clears the target's docked card.
 		scrollPaddingStart: 14,
-		scrollPaddingEnd: 14,
+		scrollPaddingEnd,
 	});
 
 	const containerRef = useMergedRefs(rowVirtualizer.containerRef, commitListRef);
@@ -687,6 +712,8 @@ const SegmentContent: FC<{
 			{rowVirtualizer.getVirtualItems().map((virtualRow) => {
 				const commit = segment.commits[virtualRow.index];
 				if (commit === undefined) return null;
+				// The rail below the commit is the next one's; plain under the last.
+				const next = segment.commits[virtualRow.index + 1];
 
 				const dryRunCommitId = dryRunWorkspace?.replacedCommits[commit.id];
 				const dryRunCommit =
@@ -699,6 +726,7 @@ const SegmentContent: FC<{
 						index={virtualRow.index}
 						measureElement={rowVirtualizer.measureElement}
 						commit={commit}
+						below={next === undefined ? "LocalOnly" : commitGraphStatus(next)}
 						projectId={projectId}
 						stackId={stackId}
 						checkCommit={checkCommit}
@@ -726,6 +754,7 @@ const CommitItem: FC<{
 	index: number;
 	measureElement: (element: HTMLDivElement | null) => void;
 	commit: Commit;
+	below: GraphSegmentStatus;
 	projectId: string;
 	stackId: string | null;
 	checkCommit: (evt: { commitId: string; shiftKey: boolean }) => void;
@@ -739,6 +768,7 @@ const CommitItem: FC<{
 	index,
 	measureElement,
 	commit,
+	below,
 	projectId,
 	stackId,
 	checkCommit,
@@ -777,6 +807,7 @@ const CommitItem: FC<{
 						render={
 							<CommitRow
 								commit={commit}
+								below={below}
 								stackId={stackId}
 								checkCommit={checkCommit}
 								amendCommit={() => onAmendCommit(commit.id)}
@@ -835,16 +866,8 @@ const SegmentRailConnector: FC<{
 			className={stackCardStyles.railConnector}
 			inert={!addressSpaceIncludes(addressSpace, standsFor, addressIdentityKey)}
 		>
-			<GraphSegment
-				glyph="parent"
-				status={
-					lastCommit === undefined
-						? segmentPushStatusToGraphSegmentStatus(segment.pushStatus)
-						: commitIsDiverged(lastCommit)
-							? "Diverged"
-							: lastCommit.state.type
-				}
-			/>
+			{/* Plain: a branch's colour runs from its tick down to its commits, not past them. */}
+			<GraphSegment glyph="parent" status="LocalOnly" />
 		</Row>
 	);
 };
@@ -858,8 +881,11 @@ const StackC: FC<
 		canAmendCommit: boolean;
 		pendingPushBranches: Set<string>;
 		scrollElementRef: RefObject<HTMLDivElement | null>;
+		scrollPaddingEnd: number;
 		stackScrollStart: number;
 		stackSize: number;
+		/** Sits a gap right of the main line, which runs on behind it, rather than on it. */
+		forked: boolean;
 		selectedSegmentIndex: number | undefined;
 		selectedCommitIndex: number | undefined;
 	} & ComponentProps<"div">
@@ -871,8 +897,10 @@ const StackC: FC<
 	canAmendCommit,
 	pendingPushBranches,
 	scrollElementRef,
+	scrollPaddingEnd,
 	stackScrollStart,
 	stackSize,
+	forked,
 	selectedSegmentIndex,
 	selectedCommitIndex,
 	...props
@@ -892,6 +920,7 @@ const StackC: FC<
 		left: 0,
 		width: "100%",
 		transform: `translateY(${stackScrollStart}px)`,
+		"--row-padding-inline-start": `${rowInsetFor(forked ? CARD_X : MAIN_X)}px`,
 	};
 	const topmostPendingPushIndex = stack.segments.findIndex(
 		(segment) =>
@@ -911,6 +940,10 @@ const StackC: FC<
 			{...props}
 			style={style}
 			className={classes(props.className, styles.virtualStack)}
+			// In the graph the card draws its rails to its edges: see StackCard.module.css
+			// and WorkspaceLists.module.css.
+			data-graph
+			data-forked={forked}
 			// oxlint-disable-next-line jsx-a11y/prefer-tag-over-role -- This is a group of treeitems.
 			role="group"
 			aria-label="Stack"
@@ -953,6 +986,7 @@ const StackC: FC<
 									onAmendCommit={onAmendCommit}
 									canAmendCommit={canAmendCommit}
 									scrollElementRef={scrollElementRef}
+									scrollPaddingEnd={scrollPaddingEnd}
 									stackScrollStart={stackScrollStart}
 									stackSize={stackSize}
 									segmentIndex={index}
@@ -975,6 +1009,7 @@ const StackC: FC<
 									onAmendCommit={onAmendCommit}
 									canAmendCommit={canAmendCommit}
 									scrollElementRef={scrollElementRef}
+									scrollPaddingEnd={scrollPaddingEnd}
 									stackScrollStart={stackScrollStart}
 									stackSize={stackSize}
 									segmentIndex={index}
@@ -1005,16 +1040,18 @@ const focusCommitMessageInput = () => {
 
 const Stacks: FC<{
 	projectId: string;
+	graph: Graph;
 	newBranch: NewBranchActions;
 	checkCommit: (evt: { commitId: string; shiftKey: boolean }) => void;
 	onAmendCommit: (commitId: string) => void;
 	canAmendCommit: boolean;
 	onEdgeSpill: (offset: -1 | 1) => void;
-}> = ({ projectId, newBranch, checkCommit, onAmendCommit, canAmendCommit, onEdgeSpill }) => {
+}> = ({ projectId, graph, newBranch, checkCommit, onAmendCommit, canAmendCommit, onEdgeSpill }) => {
 	const addressSpace = useAddressSpace();
 	const { data: headInfo } = useQuery(headInfoQueryOptions(projectId));
 	const selection = useSelection("applied", addressSpace);
 	const activeList = useActiveList();
+	const dispatch = useAppDispatch();
 	const dryRunOperation = useAppSelector((state) => {
 		const pendingOperation = projectSlice.selectors.selectPendingOperation(state, projectId);
 
@@ -1044,10 +1081,33 @@ const Stacks: FC<{
 		operation: dryRunOperation,
 	});
 	const dryRunWorkspace = dryRunOperationResult?.workspace ?? null;
-	const stacks = (headInfo?.stacks ?? []).toReversed();
+	// Cards in the graph's order, the upstream section below, and the rails
+	// between them drawn in one SVG over both. The host computed the plan once
+	// and built the address space from it.
+	const { plan, stacks, olderQuery, olderFrom, forgetOlder } = graph;
+	const olderPagesData = olderQuery.data;
+	// Shown to its start: everything loaded is shown, and a page came back
+	// with nothing older behind it.
+	const historyEnds =
+		olderPagesData !== undefined && !olderQuery.hasNextPage && plan.olderHidden === 0;
+	const moreBelow: MoreBelow =
+		olderFrom === ""
+			? "hidden"
+			: olderQuery.isFetching
+				? "loading"
+				: olderQuery.isError
+					? "failed"
+					: historyEnds
+						? "hidden"
+						: "idle";
+	const showMore = () => dispatch(projectSlice.actions.showMoreGraphOlder({ projectId }));
 	// Undefined `headInfo` is still loading, which is not the same as "empty" —
 	// treating it as empty would flash the empty state on every open.
 	const isEmpty = headInfo !== undefined && stacks.length === 0;
+	// Docked, the target's folded card lies over what scrolls past under it:
+	// a row scrolled into view clears it, as it clears the gradient at the
+	// foot otherwise.
+	const scrollPaddingEnd = plan.header.incoming > 0 && !plan.incomingExpanded ? DOCKED_HEIGHT : 14;
 	const foldedSegments = useAppSelector((state) =>
 		projectSlice.selectors.selectFoldedSegments(state, projectId),
 	);
@@ -1077,8 +1137,10 @@ const Stacks: FC<{
 			: selection?._tag === "Commit"
 				? headInfoIndex?.commitContextByCommitId(selection.commitId)
 				: undefined;
-	const selectedStackIndex =
-		selectedContext === undefined ? undefined : stacks.length - selectedContext.stackIndex - 1;
+	const selectedStack =
+		selectedContext === undefined ? undefined : headInfo?.stacks[selectedContext.stackIndex];
+	const selectedStackIndexRaw = selectedStack === undefined ? -1 : stacks.indexOf(selectedStack);
+	const selectedStackIndex = selectedStackIndexRaw === -1 ? undefined : selectedStackIndexRaw;
 	const selectedSegmentIndex = selectedContext?.segmentIndex;
 	const selectedCommitIndex =
 		selection?._tag === "Commit"
@@ -1086,12 +1148,15 @@ const Stacks: FC<{
 			: undefined;
 
 	// Pin the containing stack too, otherwise the nested selected row can still be unmounted.
+	// In index order: a pinned index that sits appended while off-range and in place once the
+	// range reaches it would move every card's node on each flip, and the scroller re-anchors on
+	// every move, snapping the scroll back at that boundary.
 	const rangeExtractorWithSelected = useCallback(
 		(range: Range) =>
 			getRangeExtractorWithIndices(
 				range,
 				selectedStackIndex === undefined ? [] : [selectedStackIndex],
-			),
+			).sort((a, b) => a - b),
 		[selectedStackIndex],
 	);
 
@@ -1135,13 +1200,19 @@ const Stacks: FC<{
 		},
 		getItemKey: getStackKey,
 		rangeExtractor: rangeExtractorWithSelected,
-		gap: 10,
-		// Matches --scroll-gradient-height.
+		gap: CARD_GAP,
+		// Matches --scroll-gradient-height; the foot also clears the target's docked card.
 		scrollPaddingStart: 14,
-		scrollPaddingEnd: 14,
+		scrollPaddingEnd,
 	});
 
 	const selectedAddressKey = selection === null ? undefined : addressIdentityKey(selection);
+	// The fold the selection sits in, looked up once per selection or plan:
+	// the hotkeys ask on every render.
+	const selectedFold = useMemo(
+		() => (selection === null ? null : foldAt(plan, selection)),
+		[plan, selection],
+	);
 	const lastRevealedAddressKeyRef = useRef<string>(undefined);
 
 	// If the selected row's stack is not rendered, reveal the stack first. Its branch row or nested
@@ -1162,6 +1233,15 @@ const Stacks: FC<{
 		lastRevealedAddressKeyRef.current = selectedAddressKey;
 	}, [rowVirtualizer, selectedAddressKey, selectedStackIndex]);
 
+	const toggleIncoming = () => dispatch(projectSlice.actions.toggleGraphIncoming({ projectId }));
+	const toggleBase = () => {
+		if (plan.baseExpanded) forgetOlder();
+		dispatch(projectSlice.actions.toggleGraphBase({ projectId }));
+	};
+	const showMoreRun = (runId: string) =>
+		dispatch(projectSlice.actions.showMoreGraphRun({ projectId, runId }));
+	const foldRun = (runId: string) =>
+		dispatch(projectSlice.actions.foldGraphRun({ projectId, runId }));
 	const hotkeysRef = useRef<HTMLDivElement>(null);
 	useActiveListsHotkeys({
 		addressSpace,
@@ -1171,7 +1251,26 @@ const Stacks: FC<{
 		focusCommitMessageInput,
 		onEdgeSpill,
 		pendingPushBranches,
+		// The fold key on a section row closes the fold it sits in and parks the
+		// cursor on the row above the fold, since the headers are not values.
+		sectionToggle:
+			selectedFold === null
+				? null
+				: () => {
+						const first = foldAddresses(plan, selectedFold)[0];
+						const index =
+							first === undefined
+								? undefined
+								: addressSpace.indexByKey.get(addressIdentityKey(first));
+						const above = index === undefined ? undefined : addressSpace.items[index - 1];
+						if (above !== undefined) setCursor("applied", above);
+						if (selectedFold === "incoming") toggleIncoming();
+						else toggleBase();
+					},
 	});
+
+	// The total first: it refreshes the measurements the rails then read.
+	const cardsEnd = plan.base === null ? null : rowVirtualizer.getTotalSize();
 
 	return (
 		<DryRunWorkspaceContext value={dryRunWorkspace}>
@@ -1180,46 +1279,75 @@ const Stacks: FC<{
 				className={classes(uiStyles.scroller, styles.stacksScroller)}
 				data-empty={isEmpty}
 			>
+				{/* One tree: the cards and the upstream section below them share the
+				    applied list's cursor, and arrow keys walk them in reading order. */}
 				<div
 					tabIndex={0}
 					role="tree"
 					aria-activedescendant={selection ? treeItemId(selection) : undefined}
-					className={classes(styles.tree, styles.stacks, styles.virtualContainer)}
+					className={classes(styles.tree, styles.content)}
+					// The merge base and its history sit on the main line; the stack
+					// cards and a moved-on target's set their own inset, and those a
+					// gap right of the line draw it behind themselves. A row is
+					// indented only where the line runs behind it.
+					style={{
+						"--row-padding-inline-start": `${rowInsetFor(MAIN_X)}px`,
+						"--main-line-x": `${MAIN_X}px`,
+					}}
 					data-focus-scope={"sidebar" satisfies FocusScope}
 					data-preview-source={activeList === "applied"}
-					ref={useMergedRefs(
-						rowVirtualizer.containerRef,
+					ref={useMergedRefs<HTMLDivElement>(
 						hotkeysRef,
 						useAutofocusScope(activeList === "applied"),
 					)}
 				>
-					{rowVirtualizer.getVirtualItems().map((virtualRow) => {
-						const stack = stacks[virtualRow.index];
-						if (stack === undefined) return null;
+					<Rails cards={rowVirtualizer.measurementsCache} cardsEnd={cardsEnd} />
+					<div
+						className={classes(styles.stacks, styles.virtualContainer)}
+						ref={rowVirtualizer.containerRef}
+					>
+						{rowVirtualizer.getVirtualItems().map((virtualRow) => {
+							const stack = stacks[virtualRow.index];
+							if (stack === undefined) return null;
 
-						return (
-							<StackC
-								key={stack.id ?? virtualRow.index}
-								data-index={virtualRow.index}
-								ref={rowVirtualizer.measureElement}
-								projectId={projectId}
-								stack={stack}
-								checkCommit={checkCommit}
-								onAmendCommit={onAmendCommit}
-								canAmendCommit={canAmendCommit}
-								pendingPushBranches={pendingPushBranches}
-								scrollElementRef={scrollElementRef}
-								stackScrollStart={virtualRow.start}
-								stackSize={virtualRow.size}
-								selectedSegmentIndex={
-									selectedStackIndex === virtualRow.index ? selectedSegmentIndex : undefined
-								}
-								selectedCommitIndex={
-									selectedStackIndex === virtualRow.index ? selectedCommitIndex : undefined
-								}
-							/>
-						);
-					})}
+							return (
+								<StackC
+									key={stack.id ?? virtualRow.index}
+									data-index={virtualRow.index}
+									ref={rowVirtualizer.measureElement}
+									forked={virtualRow.index > 0}
+									projectId={projectId}
+									stack={stack}
+									checkCommit={checkCommit}
+									onAmendCommit={onAmendCommit}
+									canAmendCommit={canAmendCommit}
+									pendingPushBranches={pendingPushBranches}
+									scrollElementRef={scrollElementRef}
+									scrollPaddingEnd={scrollPaddingEnd}
+									stackScrollStart={virtualRow.start}
+									stackSize={virtualRow.size}
+									selectedSegmentIndex={
+										selectedStackIndex === virtualRow.index ? selectedSegmentIndex : undefined
+									}
+									selectedCommitIndex={
+										selectedStackIndex === virtualRow.index ? selectedCommitIndex : undefined
+									}
+								/>
+							);
+						})}
+					</div>
+					<Section
+						projectId={projectId}
+						plan={plan}
+						moreBelow={moreBelow}
+						historyEnds={historyEnds}
+						onToggleIncoming={toggleIncoming}
+						onToggleBase={toggleBase}
+						onShowMoreRun={showMoreRun}
+						onFoldRun={foldRun}
+						onShowMore={showMore}
+						scrollElementRef={scrollElementRef}
+					/>
 				</div>
 
 				{isEmpty && <NoStacks projectId={projectId} newBranch={newBranch} />}
@@ -1231,6 +1359,8 @@ const Stacks: FC<{
 export const WorkspaceLists: FC<
 	{
 		projectId: string;
+		/** The stacks graph, computed once by the host that built the address space. */
+		graph: Graph;
 		addressSpace: AddressSpace<Address>;
 		uncommittedAddressSpace: AddressSpace<string>;
 		absorptionTargetCommitIds: ReadonlySet<string>;
@@ -1240,6 +1370,7 @@ export const WorkspaceLists: FC<
 	} & ComponentProps<"div">
 > = ({
 	projectId,
+	graph,
 	addressSpace,
 	uncommittedAddressSpace,
 	absorptionTargetCommitIds,
@@ -1463,6 +1594,7 @@ export const WorkspaceLists: FC<
 					<Activity mode={stacksCollapsed ? "hidden" : "visible"}>
 						<Stacks
 							projectId={projectId}
+							graph={graph}
 							newBranch={newBranch}
 							checkCommit={checkCommit}
 							onAmendCommit={amendCommit}

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/hotkeys.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/hotkeys.ts
@@ -72,6 +72,7 @@ export const useActiveListsHotkeys = ({
 	focusCommitMessageInput,
 	onEdgeSpill,
 	pendingPushBranches,
+	sectionToggle,
 }: {
 	addressSpace: AddressSpace<Address>;
 	projectId: string;
@@ -80,6 +81,8 @@ export const useActiveListsHotkeys = ({
 	focusCommitMessageInput: () => void;
 	onEdgeSpill?: (offset: -1 | 1) => void;
 	pendingPushBranches: Set<string>;
+	/** The action that toggles the fold the selection sits in; null when it sits in none. */
+	sectionToggle?: (() => void) | null;
 }) => {
 	const { data: headInfoIndex } = useQuery({
 		...headInfoQueryOptions(projectId),
@@ -404,7 +407,9 @@ export const useActiveListsHotkeys = ({
 	};
 
 	const defaultSidebarHotkeysEnabled = noOperationPending;
-	const isSelectedCommit = selection?._tag === "Commit";
+	// A commit the workspace does not hold (a remote leg's, the target's) is
+	// selectable to look at, not to act on.
+	const isSelectedCommit = selectedCommit !== null;
 	const isSelectedBranch = selection?._tag === "Branch";
 	const isSelectedStackPushPending =
 		selectionStack?.segments.some(
@@ -607,10 +612,14 @@ export const useActiveListsHotkeys = ({
 		},
 		{
 			hotkey: sidebarHotkeys.toggleFoldBranch.hotkey,
-			callback: toggleFoldSelected,
+			callback: () => {
+				if (sectionToggle) sectionToggle();
+				else toggleFoldSelected();
+			},
 			options: {
 				conflictBehavior: "allow",
-				enabled: defaultSidebarHotkeysEnabled && foldableSegmentRef !== null,
+				enabled:
+					defaultSidebarHotkeysEnabled && (foldableSegmentRef !== null || sectionToggle != null),
 				target: ref,
 				meta: sidebarHotkeys.toggleFoldBranch.meta,
 			},

--- a/apps/lite/ui/src/routes/project/$id/workspace/applied-address-space.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/applied-address-space.ts
@@ -7,12 +7,12 @@ import {
 	type Address,
 } from "#ui/addresses.ts";
 import { decodeBytes } from "#ui/api/bytes.ts";
-import { reverseValues } from "#ui/iterator.ts";
 import { getOperations, type TransferKind } from "#ui/operations/operation.ts";
 import { getTransferKind, type PendingOperation } from "#ui/operations/pending-operation.ts";
 import { buildIndexByKey, type AddressSpace } from "#ui/workspace/address-space.ts";
-import type { RefInfo } from "@gitbutler/but-sdk";
+import type { Stack } from "@gitbutler/but-sdk";
 import { Match } from "effect";
+import { sectionAddresses, type Plan } from "./Graph/layout.ts";
 
 const hasAnyOperation = (sources: Array<Address>, target: Address, kind: TransferKind) => {
 	const operations = getOperations(sources, target, kind);
@@ -20,43 +20,57 @@ const hasAnyOperation = (sources: Array<Address>, target: Address, kind: Transfe
 };
 
 /**
- * The applied list's address space, shared by every host that renders the
- * workspace lists.
+ * The applied list's address space: everything the stacks column shows, top
+ * to bottom, as values. Cards in the graph's order, then the upstream
+ * section's rows as its folds show them. While an operation waits for its
+ * target only the workspace's own rows stay: what the target holds can be
+ * looked at, not acted on.
  */
 export const buildAppliedAddressSpace = ({
-	headInfo,
+	stacks,
+	plan,
 	pendingOperation,
 	absorptionTargetCommitIds,
 	foldedSegments,
 }: {
-	headInfo: RefInfo | undefined;
+	/** The cards in the graph's order, as `usePlan` gives them. */
+	stacks: ReadonlyArray<Stack>;
+	plan: Plan;
 	pendingOperation: PendingOperation;
 	absorptionTargetCommitIds: ReadonlySet<string>;
 	foldedSegments: Record<string, true>;
 }): AddressSpace<Address> => {
-	const allItems = (): Array<Address> =>
-		reverseValues(headInfo?.stacks ?? [])
-			.flatMap((stack) =>
-				stack.segments.flatMap((segment): Array<Address> => {
+	// Every row as a value, tagged with whether the workspace owns it: a card's
+	// branch and commit rows do, the section's do not.
+	const rows = (): Array<{ address: Address; owned: boolean }> => {
+		const owned = (address: Address) => ({ address, owned: true });
+		const foreign = (address: Address) => ({ address, owned: false });
+		return [
+			...stacks.flatMap((stack) =>
+				stack.segments.flatMap((segment) => {
 					// Matches what WorkspaceLists renders: a folded segment shows a stub
 					// in place of its commits, so they are not navigable.
 					const folded =
 						segment.refName !== null &&
 						foldedSegments[decodeBytes(segment.refName.fullNameBytes)] === true;
-
 					return [
 						...(segment.refName
-							? [branchAddress({ branchRef: segment.refName.fullNameBytes })]
+							? [owned(branchAddress({ branchRef: segment.refName.fullNameBytes }))]
 							: []),
 						...(folded
 							? []
 							: segment.commits.map((commit) =>
-									commitAddress({ commitId: commit.id, changeId: commit.changeId }),
+									owned(commitAddress({ commitId: commit.id, changeId: commit.changeId })),
 								)),
 					];
 				}),
-			)
-			.toArray();
+			),
+			...sectionAddresses(plan).map(foreign),
+		];
+	};
+	const allItems = (): Array<Address> => rows().map((row) => row.address);
+	const workspaceItems = (): Array<Address> =>
+		rows().flatMap((row) => (row.owned ? [row.address] : []));
 
 	/**
 	 * While an operation is waiting for its target, only its sources and the
@@ -70,7 +84,7 @@ export const buildAppliedAddressSpace = ({
 		sources: Array<Address>;
 		isCompatibleTarget: (address: Address) => boolean;
 	}): Array<Address> =>
-		allItems().filter(
+		workspaceItems().filter(
 			(address) =>
 				sources.some(
 					(source) => addressEquals(address, source) || addressContains(address, source),

--- a/apps/lite/ui/src/routes/project/$id/workspace/useCopied.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/useCopied.ts
@@ -1,0 +1,28 @@
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * Copies `value` to the clipboard on `copy`, and says so for a moment:
+ * `copied` holds for a second and a half after each copy, for the control
+ * to show in place of its usual text.
+ */
+export const useCopied = (value: string): { copied: boolean; copy: () => void } => {
+	const [copied, setCopied] = useState(false);
+	const resetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	const copy = () => {
+		void window.lite.clipboardWriteText(value);
+		setCopied(true);
+
+		if (resetTimeoutRef.current !== null) clearTimeout(resetTimeoutRef.current);
+		resetTimeoutRef.current = setTimeout(() => setCopied(false), 1500);
+	};
+
+	useEffect(
+		() => () => {
+			if (resetTimeoutRef.current !== null) clearTimeout(resetTimeoutRef.current);
+		},
+		[],
+	);
+
+	return { copied, copy };
+};


### PR DESCRIPTION
The workspace's stacks section becomes a git graph: the stack cards stay full width, and rails run around them into an upstream section below, with the target's incoming commits and the merge base's history.

**Layout**

- One main line runs up the left into the top card. Every other card, and a target that has moved on, sits one gap to the right and bends onto the line in the gap under it. A row is indented only where the line runs behind it.
- The plan is pure and unit-tested. `Graph/layout.ts` orders the cards, cuts the target line at the stacks' bases, folds long runs (10 rows, then 20 per ask) and emits the SVG paths. `Graph/usePlan.ts` feeds it from the queries and the fold state in `projects/graph.ts`.

**Drawing**

- Rows draw their own rails. `GraphSegment` is two-tone now, so the stretch between two icons takes the lower icon's colour and push states read along the rail.
- Cards draw everything inside their edges: the stub over the floor, and the main line passing behind a forked card.
- One SVG draws only the gaps between cards, from the virtualiser's measurements (`Graph/Rails.tsx`).
- The upstream section draws its own rails in CSS (`Graph/Section.module.css`): it is not virtualised, its folds animate, and the folded target card docks at the scroller's foot.

**Behaviour**

- The target's card folds the incoming commits. Folded, it docks so the news stays in view, and its toggle scrolls to its place before opening.
- The merge base row says how many commits are new, folds the history below the base (loaded a page at a time, forgotten on fold) and carries the Update button.
- Cards and section rows share the applied cursor: arrow keys walk from the cards into the upstream rows, the fold key closes the fold the cursor sits in, and a target commit opens in Details.

Verified with the unit tests in `Graph/layout.test.ts`, the lite gates, and the committed branch alone in a scratch worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
