### PR TITLE
Write down Lite's design language

### DIFF
--- a/apps/lite/AGENTS.md
+++ b/apps/lite/AGENTS.md
@@ -27,6 +27,51 @@ export const MyComponent: FC<Props> = (p) => {
 };
 ```
 
+# Design
+
+The visual language — how icons, color, and composition should look — is in
+`apps/lite/DESIGN.md`. Read it before changing anything users see. This section
+covers the tooling that enforces it.
+
+## Icons
+
+There are two icon sets with two separate scripts, and each script only walks
+its own directory:
+
+| Path                                      | Owner                                  | Script                                    |
+| ----------------------------------------- | -------------------------------------- | ----------------------------------------- |
+| `apps/lite/ui/src/components/icons/*.svg` | Lite                                   | `pnpm -F @gitbutler/lite optimize-icons`  |
+| `packages/ui/src/lib/icons/svg/*.svg`     | shared Svelte UI package (desktop/web) | `pnpm -F @gitbutler/ui optimize-ui-icons` |
+
+Running `optimize-ui-icons` will **not** touch a Lite icon, and vice versa.
+Dropping an SVG into the wrong folder is the most common reason an icon "won't
+optimize". File icons (`ui/src/components/file-icons/`) are deliberately not
+run through either script — recoloring them to `currentColor` would destroy
+them.
+
+To add an icon to Lite:
+
+1. Export it from Figma at 16×16 (⚛️ Lite Core library) as SVG.
+2. Save it to `ui/src/components/icons/` with a kebab-case name — the filename
+   _is_ the icon name (`folder-lock.svg` → `<Icon name="folder-lock" />`).
+3. Run:
+
+   ```console
+   $ pnpm -F @gitbutler/lite optimize-icons
+   ```
+
+4. Commit both the SVG and the regenerated `ui/src/components/iconNames.ts`.
+
+The script is `apps/lite/scripts/optimize-icons.mjs`; its header comment
+documents each transform and the export problems it can't fix. It is
+idempotent, so it's safe to run any time. `iconNames.ts` is generated — never
+hand-edit it; add or remove the SVG and re-run. Icons are inlined into the
+bundle as raw strings and injected with `dangerouslySetInnerHTML`, which is why
+the script minifies them.
+
+After running the script, render the icon in the app (or in `Icon.stories.tsx`)
+at both 16px and a larger size before committing.
+
 # State
 
 Share machinery, not state: when a new surface (a tab, pane, or mode) has its

--- a/apps/lite/DESIGN.md
+++ b/apps/lite/DESIGN.md
@@ -176,3 +176,66 @@ same place stay in the panel header's controls rather than crowding the block.
 committing with no branches creates one — the button is a shortcut and should
 read as one, and a body line promising the automatic path shouldn't sit under a
 highlighted button arguing the opposite.
+
+## Toasts and snackbars
+
+Two ways of saying what just happened, and the choice between them is about
+**where the news belongs**, not how bad it is.
+
+**A snackbar is a sentence next to the thing it is about.** One glyph, one
+line, floated over the surface that caused it — `Snackbar.tsx`, ⚛️ Lite Core
+node `1706-1682`. It has no title and no room for one: if the news won't fit in
+a line the reader can take in without stopping, it isn't a snackbar. The
+workspace uses it for a refused operation, seated in the toolbox lane where the
+operation's own controls stood, so the answer arrives where the user was
+already looking.
+
+**A toast is a card in the corner of the window.** A title, a description that
+can hold real content — a list of rejected paths, an error message — and
+buttons, in a 250px stack at the bottom right. It's the surface for news that
+outlives the place that produced it: a background failure, an operation that
+half-succeeded, an uncaught error from anywhere in the app.
+
+**Pick by whether the surface is still there.** If the user is standing in
+front of the thing that failed, say it there — a snackbar keeps the cause and
+the consequence in one glance. If the news would land on a screen that has
+moved on, or the user could reasonably be somewhere else by now, it needs the
+corner and it needs a title to say what it is about. Errors from mutations and
+from the React root take the corner for exactly this reason: nothing else knows
+where they came from.
+
+**Pick by whether it needs reading twice.** A snackbar states an outcome and
+goes; five seconds is the workspace's measure, and a click anywhere on it ends
+it early. A toast can hold a paragraph, a bulleted breakdown, and a retry, and
+it waits. Anything the user may want to copy, act on, or read a second time is
+a toast.
+
+**Nothing routine gets either one.** A success the UI already shows — the
+commit that appeared in the list, the branch that is now on screen — needs no
+announcement. Reach for one of these only when the result is invisible, partial,
+or refused.
+
+**The verdict is carried by the glyph, not the surface.** All three snackbar
+variants wear the same ground and the same border; `info`, `danger` and `safe`
+differ only in the leading icon, so a run of them reads as a row of statements
+rather than a traffic light. Don't add a colored fill to make one louder — if
+it needs more weight than a line, it needs to be a toast.
+
+**A snackbar's way out is optional; a toast's is not.** Give a snackbar
+`onDismiss` only when it will sit there until dealt with — it then grows a
+divider and a close button, and the row grows with it. One that leaves on a
+timer carries no close button at all: the only close button on screen should
+belong to whatever the user still has in hand. Toasts always carry Dismiss,
+plus at most one action beside it.
+
+**Say it the way the rest of Lite says it.** Same plain, warm wording as
+tooltips and empty states. A snackbar is one sentence, sentence case, no full
+stop. A toast title names what happened in a short line — "Some changes were
+not committed" — and the description carries the detail; don't split one
+thought across the two.
+
+**Both announce themselves to screen readers, differently.** A snackbar is
+`role="status"` and waits its turn, except `danger`, which is `role="alert"`
+and interrupts. Toasts get theirs from the toast viewport. Neither is the only
+way to know something: a state the user must act on belongs in the UI itself,
+not in a surface that leaves.

--- a/apps/lite/DESIGN.md
+++ b/apps/lite/DESIGN.md
@@ -79,3 +79,46 @@ language/filetype glyphs that carry their own brand colors (the Rust gear, the
 TypeScript square). They are deliberately full-color and are the only icons
 that don't inherit `currentColor`. Use them for files and file-shaped things
 only — never as general-purpose UI icons.
+
+## Tooltips
+
+**Short.** A tooltip is a label, not a sentence. Aim for two to five words,
+sentence case, no full stop. The popup caps at 240px and wraps, but a tooltip
+that needs two lines of prose is usually explaining something the UI should
+have made obvious on its own — or it belongs in a popup, an empty state, or the
+docs.
+
+**Never repeat the trigger's own label.** A tooltip that says "Commit" over a
+button reading _Commit_ is noise on every hover. If a control already says what
+it does, the tooltip has to add something — a shortcut, the reason it is
+disabled, the full value behind a truncation — or not exist. The Commit button
+does this literally: its tooltip is disabled while its label is visible and
+turns back on only when the button collapses to an icon.
+
+**What a tooltip is for.** Three jobs, and not much else:
+
+- **Naming an icon-only control.** The icon carries the meaning, the tooltip
+  spells it out. Use the imperative — "Copy branch name", "Hide form", "Toggle
+  line wrapping".
+- **Revealing what didn't fit.** The truncated path, the branch name, the
+  absolute time behind "3h ago", the counts behind a stats badge. Here the
+  tooltip is the value itself, not a description of it.
+- **Saying why something is disabled.** A disabled control can't explain
+  itself, so its tooltip does: "No changes to commit", "Set up AI in Settings →
+  Application → AI". Swap the hint in for the normal tooltip while the reason
+  applies.
+
+**Shortcuts go in the `kbd` slot, not the text.** Don't write "Fetch (⌘R)" —
+pass the hotkey and let `TooltipPopup` render the keycaps. Pass `kbdScope`
+alongside it when the hotkey is bound to a pane: a shortcut that does nothing
+from where the user is standing is worse than no shortcut at all.
+
+**A tooltip is never the only way to know.** It needs hover, so it doesn't
+exist for keyboard or screen readers, and it's out of reach of touch. An
+icon-only button gets an `aria-label` as well — the tooltip repeats that name,
+it doesn't supply it. Nothing a user must read to proceed lives only in a
+tooltip, and nothing inside one is clickable.
+
+**Say it the way the rest of Lite says it.** Tooltips get the same plain, warm
+wording as every other string — the friendly word over git's own term, and the
+same wording as the menu item or button elsewhere that does the same thing.

--- a/apps/lite/DESIGN.md
+++ b/apps/lite/DESIGN.md
@@ -5,6 +5,55 @@ an on-brand choice without opening Figma. Rules here are about how the UI
 should look and read. The tooling that enforces them — scripts, generated
 files, commands — lives in `apps/lite/AGENTS.md`.
 
+## Emphasis
+
+**Gray highlights, pop points.** Gray is the workhorse: when a control needs to
+read as interactive, or one button needs to sit above its neighbours, give it a
+solid gray ground. Pop is the accent, and it is the rarest color in the app —
+it doesn't mean "important", it means "this one, out of all of these". Spend it
+only when a surface carries many actions and one of them is _the_ action.
+
+**At most one pop per surface.** If two things pop, neither does. A screen that
+seems to need a second one usually needs its first one demoted to gray.
+
+**Semantic color is chosen by meaning, not by weight.** Danger, warn and safe
+say what a thing _is_, so they sit outside the gray-to-pop ladder entirely — a
+danger button can be the only button on screen.
+
+### Button variants
+
+Ghost and outline are the two quiet buttons and sit at the same level as each
+other; gray and pop are the two ways to raise one above the rest. Reach for a
+quiet one unless there is a reason not to.
+
+- **`ghost`** — no ground, no border. The default, and by far the most used.
+  For actions inside something that is already a container: a row, a toolbar,
+  a card header, a popup.
+- **`outline`** — a ghost with an edge. For a button on open ground, where
+  nothing else marks it as a target.
+- **`gray`** — solid gray ground. Lifts one button above the ones around it
+  without spending color. This is how you highlight; it is not a primary
+  action.
+- **`pop`** — the accent ground. The primary action of the whole surface, and
+  at most one of them. See above.
+- **`danger`** — for an act the user cannot take back: deleting, discarding,
+  hard-resetting. Chosen by consequence, so it is not part of the ladder.
+
+**Mixing the quiet two.** Ghost and outline can sit side by side in one group,
+and the difference then tells kinds of control apart rather than ranking them.
+The pull request toolbar does this: Edit and the overflow menu are ghosts, the
+Auto-merge toggle is an outline, and Merge is the single pop — the outline
+marks the control that holds state, not a louder action. It works in either
+direction; whichever of the two is rarer in that group is the one that reads as
+distinct. Use it to separate kinds, never to imply one action matters more.
+
+**The inverted pair.** `ghost-inverted` and `outline-inverted` are the same two
+buttons for a button sitting on an inverted ground — a selected row, where the
+fill flips and the text turns to `--text-1-invert`. They are not a dark-mode
+thing; dark mode is handled by the tokens. Note that selected rows reach these
+styles through CSS in `Row.module.css` rather than by passing the variant, so
+selection can restyle without a re-render.
+
 ## Icons
 
 **Source.** Icons come from the ⚛️ Lite Core Figma library. Don't draw new

--- a/apps/lite/DESIGN.md
+++ b/apps/lite/DESIGN.md
@@ -122,3 +122,54 @@ tooltip, and nothing inside one is clickable.
 **Say it the way the rest of Lite says it.** Tooltips get the same plain, warm
 wording as every other string — the friendly word over git's own term, and the
 same wording as the menu item or button elsewhere that does the same thing.
+
+## Empty states
+
+**One component, in ⚛️ Lite Core: "Empty state".** An illustration slot, a
+title, a body line, and an actions slot. Its description in Figma carries the
+same rules as this section; change one and change the other.
+
+**It is for a surface that is genuinely empty, at rest.** Not a loading state —
+"not loaded" is not the same as "nothing to report", and a panel that claims an
+emptiness it hasn't checked yet will flash the wrong words on every open. Not a
+filter that matched nothing either: that belongs in a line where the list would
+be, next to the filter that caused it.
+
+**Centred, and only in a panel with room for it.** A short strip — the
+uncommitted list above its commit form — takes a single muted line inset to the
+column its rows would occupy, not this. Panels resize, so a centred block needs
+`justify-content: safe center`: plain centring pushes the top of the block out
+of reach above the scroll origin when the splitter comes down.
+
+**Centred optically, which is not the same as centred.** The block's weight
+sits low — two lines of type and a row of buttons under a light illustration —
+so centring it on its geometry reads as sitting below the middle. The component
+carries 60px of bottom padding to correct for it, and the frontend carries the
+same: padding rather than a margin, so that centring the box moves the ink,
+lifting what you see by half of what you add. Keep the two in step; if the
+block's proportions change, the counterweight is what changes with them.
+
+**The title names the state; the body says what happens next.** One short line
+each, sentence case, no full stop. The body's job is the thing the user can't
+see — what the next action will do, or the live answer behind the emptiness: a
+count, a branch name, a time. "You have 5 branches to pick from" earns its
+place; "There is nothing here" repeats the title and the picture both.
+
+**Both lines wrap balanced.** They get `text-balance`, and the block's measure
+is capped around 32 characters so there is something to balance. Centred text
+with a long line and a two-word orphan under it reads as broken, and the cap is
+the other half of the same rule: past about 32 characters a line stops being
+scannable at a glance, and evening out a line that ran the whole panel would
+only tidy something already too wide. Figma has no equivalent, so lines there
+are broken by hand — the component's description says so.
+
+**At most two buttons, and never `pop`.** The surface's accent is already spent
+on its primary action elsewhere — Start commit sits directly above the stacks
+panel — and if two things pop, neither does. Gray marks the likelier of two,
+outline takes the other; a button on its own stays outline. Rarer routes to the
+same place stay in the panel header's controls rather than crowding the block.
+
+**A button is not always owed.** Where the app handles the state on its own —
+committing with no branches creates one — the button is a shortcut and should
+read as one, and a body line promising the automatic path shouldn't sit under a
+highlighted button arguing the opposite.

--- a/apps/lite/DESIGN.md
+++ b/apps/lite/DESIGN.md
@@ -155,13 +155,16 @@ see — what the next action will do, or the live answer behind the emptiness: a
 count, a branch name, a time. "You have 5 branches to pick from" earns its
 place; "There is nothing here" repeats the title and the picture both.
 
-**Both lines wrap balanced.** They get `text-balance`, and the block's measure
-is capped around 32 characters so there is something to balance. Centred text
-with a long line and a two-word orphan under it reads as broken, and the cap is
-the other half of the same rule: past about 32 characters a line stops being
-scannable at a glance, and evening out a line that ran the whole panel would
-only tidy something already too wide. Figma has no equivalent, so lines there
-are broken by hand — the component's description says so.
+**The block caps at 320px.** It is a block, not a banner, and the details pane
+it can land in is over a thousand pixels wide. The cap is on the component, so
+no host has to remember it, and it is the measure the copy is set in — nothing
+inside sets a narrower one.
+
+**Both lines wrap balanced.** They get `text-balance`, and 320 is what gives
+them something to balance within. Centred text with a full line and a two-word
+orphan under it reads as broken, which is the whole reason for the rule. Figma
+has no equivalent, so lines there are broken by hand — the component's
+description says so.
 
 **At most two buttons, and never `pop`.** The surface's accent is already spent
 on its primary action elsewhere — Start commit sits directly above the stacks

--- a/apps/lite/DESIGN.md
+++ b/apps/lite/DESIGN.md
@@ -1,0 +1,32 @@
+# Lite design notes
+
+The visual language of Lite (`apps/lite/ui`): the conventions you need to make
+an on-brand choice without opening Figma. Rules here are about how the UI
+should look and read. The tooling that enforces them — scripts, generated
+files, commands — lives in `apps/lite/AGENTS.md`.
+
+## Icons
+
+**Source.** Icons come from the ⚛️ Lite Core Figma library. Don't draw new
+ones, and don't borrow from 💎 Core or the shared Svelte UI package — those are
+a different set for a different app.
+
+**Grid and weight.** Icons are drawn 16×16 on a 16px grid with 1.5px strokes.
+Stroke width is constant in screen pixels, so a 16px icon and a 24px icon read
+at the same visual weight and sit correctly next to text of any size. Keep
+coordinates on the pixel grid; keep all geometry inside the `0 0 16 16` frame.
+
+**Color.** Icons are monochrome and inherit the text color of whatever they sit
+in — one asset works in light and dark, in hover and disabled states, and in
+accent-colored buttons. Never give an icon a color of its own. If an icon needs
+to look different in a state, change the color of its container.
+
+**Sizing.** Size is owned by CSS (`--icon-size`, default 16px), not by the
+asset, so an icon scales with the row, button, or type it belongs to. Don't
+size an icon by editing the SVG.
+
+**The exception: file icons.** `ui/src/components/file-icons/` holds
+language/filetype glyphs that carry their own brand colors (the Rust gear, the
+TypeScript square). They are deliberately full-color and are the only icons
+that don't inherit `currentColor`. Use them for files and file-shaped things
+only — never as general-purpose UI icons.

--- a/apps/lite/scripts/optimize-icons.mjs
+++ b/apps/lite/scripts/optimize-icons.mjs
@@ -1,12 +1,41 @@
 #!/usr/bin/env node
 
 /**
- * Icon optimization script.
+ * Icon optimization script for apps/lite/ui/src/components/icons.
  *
- * - Normalizes width/height to "100%"
- * - Replaces color values in fill/stroke with "currentColor"
- * - Minifies SVG markup
- * - Regenerates iconNames.ts
+ * Each transform exists for a concrete reason:
+ *
+ * - width/height -> "100%". Figma exports fixed pixels (width="16"), but
+ *   sizing is owned by CSS: Icon.module.css sets a --icon-size box and the SVG
+ *   fills it. A hardcoded width would ignore <Icon size={20} />. viewBox is
+ *   kept — that preserves aspect ratio and makes percentage sizing meaningful.
+ * - fill/stroke colors -> "currentColor", so one asset works on light and dark
+ *   themes and in accent-colored containers. "none" is preserved: it's a
+ *   structural value (an unfilled outline shape), not a color.
+ * - vector-effect="non-scaling-stroke" on shape elements. Icons are drawn on a
+ *   16px grid with 1.5px strokes; without this, a scaled-up icon reads heavier
+ *   than its neighbours.
+ * - Minification. Icons are inlined into the bundle as raw strings and
+ *   injected via dangerouslySetInnerHTML, so Figma's indentation would ship to
+ *   the user and land in the DOM. It also gives icons a canonical single-line
+ *   form, so a re-export produces a clean diff instead of a whitespace-only one.
+ * - iconNames.ts regeneration. IconName is a generated union of the filenames
+ *   on disk, which is what makes <Icon name="folder-lock" /> compile-time
+ *   checked. Never hand-edit it.
+ *
+ * This is a text transform, not a geometry pass. It won't clean up what Figma
+ * leaves behind — check the export by hand for:
+ *
+ * - Stray placeholder or mask shapes. A leftover rectangle exported as
+ *   fill="#D9D9D9" becomes fill="currentColor" and paints a solid block over
+ *   the icon.
+ * - Geometry outside the viewBox. Anything beyond "0 0 16 16" is clipped or
+ *   overflows unpredictably.
+ * - clipPath ids. Figma emits ids like clip0_1800_10322. Several icons are
+ *   inlined into the same document, so ids must stay unique — keep Figma's
+ *   generated suffix rather than renaming to something generic like "clip0".
+ * - Off-grid coordinates. 13.999999 instead of 14 means the frame wasn't
+ *   aligned to the pixel grid in Figma; fix it at the source.
  */
 
 import fs from "node:fs";

--- a/apps/lite/ui/src/components/Badge.module.css
+++ b/apps/lite/ui/src/components/Badge.module.css
@@ -83,13 +83,3 @@
 	background-color: color-mix(in srgb, var(--_bg) var(--badge-bg-opacity), transparent);
 	color: var(--text-pop);
 }
-
-/* Matches the graph's integrated commit color, so the pill and the glyphs
-   telling the same story share a hue. */
-.integrated {
-	background-color: var(
-		--badge-integrated-bg,
-		color-mix(in srgb, var(--commit-integrated) 18%, var(--bg-1))
-	);
-	color: var(--badge-integrated-fg, var(--commit-integrated));
-}

--- a/apps/lite/ui/src/components/Badge.stories.tsx
+++ b/apps/lite/ui/src/components/Badge.stories.tsx
@@ -4,6 +4,12 @@ import { Icon } from "./Icon.tsx";
 
 const meta = preview.meta({
 	component: Badge,
+	parameters: {
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/cqdnAotT8n9op8WGYLOHg4/%E2%9A%9B%EF%B8%8F-Lite-Core?node-id=706-453",
+		},
+	},
 	argTypes: {
 		variant: {
 			control: "select",

--- a/apps/lite/ui/src/components/Badge.tsx
+++ b/apps/lite/ui/src/components/Badge.tsx
@@ -11,8 +11,7 @@ export type BadgeVariant =
 	| "danger"
 	| "purple"
 	| "blue"
-	| "pop"
-	| "integrated";
+	| "pop";
 
 /** @public */
 export type BadgeSize = "regular" | "large";
@@ -59,7 +58,6 @@ export const Badge: FC<{ variant: BadgeVariant; size?: BadgeSize } & ComponentPr
 				Match.when("purple", () => styles.purple),
 				Match.when("blue", () => styles.blue),
 				Match.when("pop", () => styles.pop),
-				Match.when("integrated", () => styles.integrated),
 				Match.exhaustive,
 			),
 		)}

--- a/apps/lite/ui/src/components/Button.tsx
+++ b/apps/lite/ui/src/components/Button.tsx
@@ -2,14 +2,31 @@ import styles from "./Button.module.css";
 import { classes } from "#ui/components/classes.ts";
 import { Match } from "effect";
 
-/** @public */
+/**
+ * Ghost and outline are the two quiet buttons and rank equally; gray and pop are the two ways to
+ * raise one above the rest. Reach for a quiet one unless there is a reason not to. Gray is how you
+ * highlight, pop is how you point — see "Emphasis" in `apps/lite/DESIGN.md`.
+ *
+ * @public
+ */
 export type ButtonVariant =
+	/** The primary action of the whole surface. At most one per surface: if two things pop, neither does. */
 	| "pop"
+	/** Solid gray ground. Lifts a button above the ones around it without spending color — a highlight, not a primary action. */
 	| "gray"
+	/**
+	 * A ghost with an edge, for a button on open ground where nothing else marks it as a target.
+	 * Ranks equally with `ghost`: mixing the two in one group separates kinds of control (the PR
+	 * toolbar outlines its Auto-merge toggle among ghost actions), never levels of importance.
+	 */
 	| "outline"
+	/** `outline` for a button on an inverted ground — a selected row, not dark mode. */
 	| "outline-inverted"
+	/** For an act the user cannot take back: deleting, discarding, hard-resetting. Chosen by consequence, so it sits outside the ladder. */
 	| "danger"
+	/** No ground, no border. The default, for actions inside something already a container: a row, a toolbar, a popup. */
 	| "ghost"
+	/** `ghost` for a button on an inverted ground — a selected row, not dark mode. */
 	| "ghost-inverted";
 /** @public */
 export type ButtonSize = "regular" | "small";

--- a/apps/lite/ui/src/components/Checkbox.stories.tsx
+++ b/apps/lite/ui/src/components/Checkbox.stories.tsx
@@ -1,0 +1,64 @@
+import preview from "#storybook/preview";
+import { Checkbox } from "./Checkbox.tsx";
+import { useState } from "react";
+
+const meta = preview.meta({
+	component: Checkbox,
+	parameters: {
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/cqdnAotT8n9op8WGYLOHg4/%E2%9A%9B%EF%B8%8F-Lite-Core?node-id=699-584",
+		},
+	},
+});
+
+const Toggleable = ({ disabled = false }: { disabled?: boolean }) => {
+	const [checked, setChecked] = useState(true);
+	return <Checkbox checked={checked} disabled={disabled} onCheckedChange={setChecked} />;
+};
+
+export const Default = meta.story({
+	render: () => <Toggleable />,
+});
+
+/**
+ * Indeterminate stands for a folder with some of its files checked, so it is filled like a checked
+ * box rather than shown as a third, emptier state.
+ */
+export const Indeterminate = meta.story({
+	render: () => <Checkbox indeterminate />,
+});
+
+export const Disabled = meta.story({
+	render: () => (
+		<div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+			<Checkbox checked disabled />
+			<Checkbox checked={false} disabled />
+			<Checkbox indeterminate disabled />
+		</div>
+	),
+});
+
+/**
+ * The box takes its ground from `--checkbox-bg`, left undeclared so a row can set it without a
+ * specificity fight. Here the row is tinted to show the checkbox following it.
+ */
+export const OnATintedRow = meta.story({
+	render: () => (
+		<div
+			style={{
+				["--checkbox-bg" as string]: "var(--bg-2)",
+				display: "flex",
+				gap: 8,
+				alignItems: "center",
+				padding: 8,
+				borderRadius: 6,
+				backgroundColor: "var(--bg-2)",
+			}}
+		>
+			<Checkbox checked={false} />
+			<Checkbox checked />
+			<Checkbox indeterminate />
+		</div>
+	),
+});

--- a/apps/lite/ui/src/components/Dropdown.stories.tsx
+++ b/apps/lite/ui/src/components/Dropdown.stories.tsx
@@ -8,7 +8,7 @@ const meta = preview.meta({
 	parameters: {
 		design: {
 			type: "figma",
-			url: "https://www.figma.com/design/EBuHQGUcCaSw4Ln5uVpWkn/Lite?node-id=4518-292100",
+			url: "https://www.figma.com/design/cqdnAotT8n9op8WGYLOHg4/%E2%9A%9B%EF%B8%8F-Lite-Core?node-id=1819-3456",
 		},
 	},
 	args: {

--- a/apps/lite/ui/src/components/Field.stories.tsx
+++ b/apps/lite/ui/src/components/Field.stories.tsx
@@ -11,6 +11,12 @@ import { Field } from "@base-ui/react";
 
 const meta = preview.meta({
 	component: Field.Root,
+	parameters: {
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/cqdnAotT8n9op8WGYLOHg4/%E2%9A%9B%EF%B8%8F-Lite-Core?node-id=890-674",
+		},
+	},
 });
 
 export const Default = meta.story({

--- a/apps/lite/ui/src/components/Modal.stories.tsx
+++ b/apps/lite/ui/src/components/Modal.stories.tsx
@@ -7,7 +7,7 @@ const meta = preview.meta({
 	parameters: {
 		design: {
 			type: "figma",
-			url: "https://www.figma.com/design/EBuHQGUcCaSw4Ln5uVpWkn/Lite?node-id=4518-292100",
+			url: "https://www.figma.com/design/cqdnAotT8n9op8WGYLOHg4/%E2%9A%9B%EF%B8%8F-Lite-Core?node-id=1819-3456",
 		},
 	},
 	args: {

--- a/apps/lite/ui/src/components/Popup.stories.tsx
+++ b/apps/lite/ui/src/components/Popup.stories.tsx
@@ -6,7 +6,7 @@ const meta = preview.meta({
 	parameters: {
 		design: {
 			type: "figma",
-			url: "https://www.figma.com/design/EBuHQGUcCaSw4Ln5uVpWkn/Lite?node-id=4518-292100",
+			url: "https://www.figma.com/design/cqdnAotT8n9op8WGYLOHg4/%E2%9A%9B%EF%B8%8F-Lite-Core?node-id=1819-3456",
 		},
 	},
 	decorators: [

--- a/apps/lite/ui/src/components/Snackbar.stories.tsx
+++ b/apps/lite/ui/src/components/Snackbar.stories.tsx
@@ -3,6 +3,12 @@ import { Snackbar, type SnackbarVariant } from "./Snackbar.tsx";
 
 const meta = preview.meta({
 	component: Snackbar,
+	parameters: {
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/cqdnAotT8n9op8WGYLOHg4/%E2%9A%9B%EF%B8%8F-Lite-Core?node-id=1706-1682",
+		},
+	},
 	argTypes: {
 		variant: {
 			control: "inline-radio",

--- a/apps/lite/ui/src/components/Switch.stories.tsx
+++ b/apps/lite/ui/src/components/Switch.stories.tsx
@@ -4,6 +4,12 @@ import { useState } from "react";
 
 const meta = preview.meta({
 	component: Switch,
+	parameters: {
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/cqdnAotT8n9op8WGYLOHg4/%E2%9A%9B%EF%B8%8F-Lite-Core?node-id=699-614",
+		},
+	},
 });
 
 const Toggleable = ({ disabled = false }: { disabled?: boolean }) => {

--- a/apps/lite/ui/src/components/SwitchButton.stories.tsx
+++ b/apps/lite/ui/src/components/SwitchButton.stories.tsx
@@ -4,6 +4,12 @@ import { useState } from "react";
 
 const meta = preview.meta({
 	component: SwitchButton,
+	parameters: {
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/cqdnAotT8n9op8WGYLOHg4/%E2%9A%9B%EF%B8%8F-Lite-Core?node-id=1594-4370",
+		},
+	},
 });
 
 const variants = ["ghost", "outline"] as const satisfies ReadonlyArray<SwitchButtonVariant>;


### PR DESCRIPTION
## 🧢 Changes

`apps/lite/DESIGN.md`, new, covering the conventions that were previously only in people's heads:

- **Emphasis** — the gray-to-pop ladder, at most one pop per surface, and semantic colour chosen by meaning rather than weight. `ButtonVariant` gets the same account per variant, so the rule is in reach at the point of use.
- **Icons** — source library, the 16px grid, 1.5px strokes, `currentColor`, and why file icons are the exception.
- **Tooltips** — when one earns its hover, the three jobs it has, and that it is never the only way to know something.
- **Empty states** — what the state is for and what it is not, when a centred block beats a single inset line, the optical counterweight, the 320px measure, and why no button in one is ever `pop`.
- **Toasts and snackbars** — where feedback belongs, how long it needs to stay available, and not announcing routine successes the UI already shows.

`apps/lite/AGENTS.md` gains the tooling half: two icon sets, two scripts, each walking only its own directory — which is the usual reason an icon "won't optimize". `scripts/optimize-icons.mjs` now says why each transform exists and which export problems it cannot fix.

Two small code changes came out of writing it: the unused `integrated` badge variant is dropped (nothing rendered it, and it kept a `--commit-integrated` dependency alive for no caller), and every Lite story now links to the ⚛️ Lite Core node it was built from, so the addon panel opens the source beside the render. Checkbox had no story at all; it gets one.

## ☕️ Reasoning

These rules were being rediscovered per review. Writing them down is worth doing on its own, but the immediate reason is that the empty-state work in #15735 leans on them: it cites DESIGN.md → "Empty states" for why a short strip takes a line and a roomy surface takes a block, and that section only exists here.

Where a rule also lives in the ⚛️ Lite Core component description, the document says so and says outright that changing one means changing the other, so the two cannot quietly drift.

## 🎫 Affected issues

Supports GB-1959, whose cross-cutting "settle copy rules" item this partly answers.

## 📌 Notes for review

Paired with #15735, which is the code these rules describe. This branch is where the DESIGN.md sections that PR references actually live, so reading them together will make more sense than either alone. They touch different files and can land in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)