### PR TITLE
fix(lite): let Esc close the commit form without dropping the selection

### DIFF
--- a/apps/lite/e2e/tests/commit-form.spec.ts
+++ b/apps/lite/e2e/tests/commit-form.spec.ts
@@ -1,0 +1,34 @@
+import { writeFileSync } from "node:fs";
+import path from "node:path";
+import { expect, test } from "../test.ts";
+
+test.describe("commit form", () => {
+	test.use({ scenario: "project-in-single-branch-three-branch-stack.sh" });
+
+	test("Escape closes the form and keeps the checked files", async ({
+		appWindow,
+		testEnvironment,
+	}) => {
+		const clone = path.join(testEnvironment.workdir, "local-clone");
+		writeFileSync(path.join(clone, "added.txt"), "an uncommitted file\n");
+		await appWindow.reload();
+		await appWindow.getByRole("main").waitFor();
+
+		const uncommittedFiles = appWindow.getByRole("tree", { name: "Uncommitted" });
+		const checkbox = uncommittedFiles.getByRole("checkbox", { name: "Check file added.txt" });
+		await checkbox.click();
+		await expect(checkbox).toBeChecked();
+
+		const startCommit = appWindow.getByRole("button", { name: /start commit/i });
+		await startCommit.click();
+
+		const message = appWindow.getByRole("textbox", { name: "Compose commit message" });
+		await expect(message).toBeFocused();
+		await appWindow.keyboard.press("Escape");
+
+		// The form is the only thing Escape was asked to close. The selection it was opened to
+		// commit outlives it, so reopening doesn't mean re-checking everything.
+		await expect(startCommit).toBeVisible();
+		await expect(checkbox).toBeChecked();
+	});
+});

--- a/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
@@ -24,6 +24,7 @@ import { changesHotkeys, sidebarHotkeys, toElectronAccelerator } from "#ui/hotke
 import { nativeMenuItem, showNativeMenuFromTrigger, type NativeMenuItem } from "#ui/native-menu.ts";
 import { addressIdentityKey, type Address } from "#ui/addresses.ts";
 import { createDiffSpec } from "#ui/operations/diff-specs.ts";
+import { COMMIT_FORM_ATTRIBUTE } from "#ui/routes/project/$id/workspace/commitFormEvent.ts";
 import { NO_DRAG_ATTRIBUTE } from "#ui/routes/project/$id/workspace/DragData.ts";
 import { projectSlice } from "#ui/projects/state.ts";
 import { projectAiSettingsQueryOptions } from "#ui/project-ai-settings.ts";
@@ -554,7 +555,7 @@ export const CommitForm: FC<{
 	return (
 		// oxlint-disable-next-line jsx-a11y/no-noninteractive-element-interactions -- Used for persistence, not UI per se.
 		<form
-			{...{ [NO_DRAG_ATTRIBUTE]: "" }}
+			{...{ [NO_DRAG_ATTRIBUTE]: "", [COMMIT_FORM_ATTRIBUTE]: "" }}
 			ref={formRef}
 			onSubmit={submit}
 			onBlur={(e) => {

--- a/apps/lite/ui/src/routes/project/$id/workspace/OperationControls.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/OperationControls.tsx
@@ -32,6 +32,7 @@ import {
 	type TransferKind,
 } from "#ui/operations/operation.ts";
 import { projectSlice } from "#ui/projects/state.ts";
+import { isCommitFormKeyEvent } from "#ui/routes/project/$id/workspace/commitFormEvent.ts";
 import { addressLabel, addressesLabel } from "#ui/routes/project/$id/workspace/addressLabel.ts";
 import { useCheckedActions } from "#ui/routes/project/$id/workspace/useCheckedActions.ts";
 import { useAppDispatch, useAppSelector } from "#ui/store.ts";
@@ -111,7 +112,7 @@ const useControlHotkeys = ({
 	onCancel,
 	confirm,
 }: {
-	onCancel: () => void;
+	onCancel: UseHotkeyDefinition["callback"];
 	confirm?: Confirm;
 }): void => {
 	const confirmHotkeys: Array<Omit<UseHotkeyDefinition, "callback">> = [
@@ -201,7 +202,14 @@ const CheckedAddressOperationControls: FC<{
 	const cancel = () => {
 		dispatch(projectSlice.actions.clearCheckedAddresses({ projectId }));
 	};
-	useControlHotkeys({ onCancel: cancel });
+	useControlHotkeys({
+		// The commit form closes on the same press, and the files checked for it to commit are the
+		// one thing that has to outlive it.
+		onCancel: (event) => {
+			if (isCommitFormKeyEvent(event)) return;
+			cancel();
+		},
+	});
 
 	if (checkedContext === null) return;
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/commitFormEvent.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/commitFormEvent.ts
@@ -1,0 +1,14 @@
+/** Marks the expanded commit form, so a peer handler can tell that a press was made inside it. */
+export const COMMIT_FORM_ATTRIBUTE = "data-commit-form";
+
+/**
+ * Whether a key press was made inside the expanded commit form.
+ *
+ * Escape is claimed by more than one handler at once, each registered with
+ * `conflictBehavior: "allow"`. A press made in the form is the form's: the checked-file toolbox has
+ * to leave the selection alone, or closing the form would mean re-checking everything the form was
+ * opened to commit. Asked of the event's target rather than `document.activeElement`, because the
+ * form's own handler moves focus out and either handler may run first.
+ */
+export const isCommitFormKeyEvent = (event: KeyboardEvent): boolean =>
+	event.target instanceof Element && event.target.closest(`[${COMMIT_FORM_ATTRIBUTE}]`) !== null;


### PR DESCRIPTION
Closes [GB-1990](https://linear.app/gitbutler/issue/GB-1990/lite-esc-in-the-commit-form-should-only-close-the-form-not-uncheck).

## The bug

Check a few uncommitted files, start a commit, then press `Esc` in the message input: the form closes *and* every file is unchecked. Reopening the form means re-checking all of them.

## Cause

`Escape` is claimed by two handlers at once, each registered with `conflictBehavior: "allow"`, so one press runs both:

- `CommitForm` persists the draft and collapses the form.
- The checked-file toolbox in `OperationControls` treats it as `operationHotkeys.cancel` and dispatches `clearCheckedAddresses`.

## Fix

The expanded form carries a `data-commit-form` marker, and the toolbox stands down for a press made inside it. The close button still clears the selection — only the hotkey path is guarded.

The guard asks the `KeyboardEvent`'s `target` rather than `document.activeElement`. The form's own handler calls `focusScope("uncommitted-files")` synchronously, so by the time the toolbox handler runs focus has already left the form; the event target is fixed for the whole dispatch and so is order-independent. `useControlHotkeys`' `onCancel` is now typed as the hotkey callback to receive it.

## Testing

New `apps/lite/e2e/tests/commit-form.spec.ts` checks a file, opens the form, presses `Esc`, and asserts the form collapsed *and* the box is still checked. It fails against the unfixed behavior and passes now.

`pnpm -F @gitbutler/lite check`, `test`, and the full Playwright suite are green, as are oxlint, knip, oxfmt and prettier.