### PR TITLE
fix(but): remove git-url-parse dep and fix .git behavior

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1279,7 +1279,7 @@ dependencies = [
  "but-schemars",
  "but-utils",
  "chrono",
- "git-url-parse",
+ "gix",
  "schemars 1.2.1",
  "serde",
  "serde_json",
@@ -3744,17 +3744,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getset"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cf442baaabe4213ce7d1239afc26c039180b6456da2cededa316ae2c8a77a77"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
 name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3804,18 +3793,6 @@ dependencies = [
  "sha1",
  "thiserror 2.0.18",
  "time",
-]
-
-[[package]]
-name = "git-url-parse"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8df306e4dfc91752e89b74c88ee876c8518890600f82255254828f9192dd003c"
-dependencies = [
- "getset",
- "nom 8.0.0",
- "thiserror 2.0.18",
- "url",
 ]
 
 [[package]]

--- a/crates/but-forge/Cargo.toml
+++ b/crates/but-forge/Cargo.toml
@@ -33,7 +33,7 @@ but-schemars = { workspace = true, optional = true }
 chrono.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 
-git-url-parse = "0.6.0"
+gix = { workspace = true }
 urlencoding.workspace = true
 serde.workspace = true
 serde_json = { workspace = true, features = ["arbitrary_precision"] }

--- a/crates/but-forge/src/forge_info.rs
+++ b/crates/but-forge/src/forge_info.rs
@@ -117,46 +117,35 @@ fn build_base_url(remote_url: &str, repo_info: &ForgeRepoInfo, accounts: &[Forge
     } else {
         repo_info.protocol.as_str()
     };
-    let parsed = git_url_parse::GitUrl::parse(remote_url).ok();
+    let parsed = crate::remote_url::RemoteUrl::parse(remote_url);
     let host = parsed
         .as_ref()
-        .and_then(|u| u.host().map(|h| h.to_string()))
+        .map(|url| url.host.clone())
         .unwrap_or_else(|| match repo_info.forge {
             ForgeName::GitHub => "github.com".into(),
             ForgeName::GitLab => "gitlab.com".into(),
             ForgeName::Bitbucket => "bitbucket.org".into(),
             ForgeName::Azure => "dev.azure.com".into(),
         });
-    let host = match parsed.as_ref().and_then(|u| u.port()) {
+    let host = match parsed.as_ref().and_then(|url| url.port) {
         Some(port) if !rewrote_scheme => format!("{host}:{port}"),
         _ => host,
     };
+    // Owners may contain namespace separators (GitLab groups or Azure org/project).
+    let owner = repo_info
+        .owner
+        .split('/')
+        .map(urlencoding::encode)
+        .collect::<Vec<_>>()
+        .join("/");
+    let repo = urlencoding::encode(&repo_info.repo);
     match repo_info.forge {
         ForgeName::Azure => {
-            // `derive_forge_repo_info` uses git-url-parse's GenericProvider,
-            // which mangles Azure's org/project/repo triple into a single
-            // owner/repo pair — dropping the repo name (and for SSH remotes
-            // the org too). Re-parse with the Azure-specific provider.
             // Web URLs are {host}/{org}/{project}/_git/{repo}; the browser
             // host is always dev.azure.com (the ssh.* host can't open in a
-            // browser).
+            // browser). Azure repository owners include both org and project.
             let host = host.strip_prefix("ssh.").unwrap_or(&host);
-            match git_url_parse::GitUrl::parse(remote_url).ok().and_then(|u| {
-                u.provider_info::<git_url_parse::types::provider::AzureDevOpsProvider>()
-                    .ok()
-            }) {
-                Some(az) => format!(
-                    "{scheme}://{host}/{}/{}/_git/{}",
-                    az.org(),
-                    az.project(),
-                    az.repo()
-                ),
-                // Fallback: best-effort with the generic owner/repo.
-                None => format!(
-                    "{scheme}://{host}/{}/_git/{}",
-                    repo_info.owner, repo_info.repo
-                ),
-            }
+            format!("{scheme}://{host}/{owner}/_git/{repo}")
         }
         _ => {
             // An http(s) remote's own origin is authoritative; only rewritten
@@ -165,8 +154,6 @@ fn build_base_url(remote_url: &str, repo_info: &ForgeRepoInfo, accounts: &[Forge
                 .then(|| account_web_origin(accounts, &repo_info.forge, &host))
                 .flatten()
                 .unwrap_or_else(|| format!("{scheme}://{host}"));
-            let owner = &repo_info.owner;
-            let repo = &repo_info.repo;
             format!("{origin}/{owner}/{repo}")
         }
     }
@@ -288,6 +275,31 @@ mod tests {
     }
 
     #[test]
+    fn azure_browser_url_preserves_path_escaping() {
+        for remote in [
+            "https://dev.azure.com/org/My%20Project/_git/repo",
+            "https://dev.azure.com/org/project/_git/repo%25one",
+            "https://dev.azure.com/org/project/_git/repo%23one",
+        ] {
+            let info = forge_info(remote, &[]).unwrap();
+            assert_eq!(
+                info.base_url, remote,
+                "browser URLs must preserve encoded path characters in {remote}"
+            );
+        }
+    }
+
+    #[test]
+    fn azure_https_v3_organization_browser_url() {
+        let remote = "https://dev.azure.com/v3/project/_git/repo";
+        let info = forge_info(remote, &[]).unwrap();
+        assert_eq!(
+            info.base_url, remote,
+            "an organization named v3 must remain part of the browser URL"
+        );
+    }
+
+    #[test]
     fn azure_ssh_base_url_uses_browsable_https_host() {
         let info = forge_info("git@ssh.dev.azure.com:v3/myorg/myproject/myrepo", &[]).unwrap();
         assert_eq!(info.name, ForgeName::Azure);
@@ -315,6 +327,12 @@ mod tests {
     }
 
     #[test]
+    fn github_repository_name_can_contain_dot_git() {
+        let info = forge_info("git@github.com:owner/example.github.io.git", &[]).unwrap();
+        assert_eq!(info.base_url, "https://github.com/owner/example.github.io");
+    }
+
+    #[test]
     fn github_ssh_base_url_and_fork_compare() {
         let info = forge_info("git@github.com:owner/repo.git", &[]).unwrap();
         assert_eq!(info.name, ForgeName::GitHub);
@@ -332,6 +350,12 @@ mod tests {
             url,
             "https://github.com/owner/repo/compare/main...fork:feat"
         );
+    }
+
+    #[test]
+    fn gitlab_nested_group_base_url() {
+        let info = forge_info("https://gitlab.com/group/subgroup/repo.git", &[]).unwrap();
+        assert_eq!(info.base_url, "https://gitlab.com/group/subgroup/repo");
     }
 
     #[test]

--- a/crates/but-forge/src/lib.rs
+++ b/crates/but-forge/src/lib.rs
@@ -1,5 +1,3 @@
-use git_url_parse::{GitUrl, types::provider::GenericProvider};
-
 mod forge;
 pub use crate::forge::{ForgeName, ForgeRepoInfo, ForgeUser, deserialize_preferred_forge_user_opt};
 
@@ -10,6 +8,7 @@ pub use db::{cached_review_states, list_cached_forge_reviews};
 mod forge_info;
 mod merge_message;
 pub use merge_message::{MergedReviewFromMessage, merged_review_from_message};
+mod remote_url;
 mod repo;
 mod review;
 pub use association::{
@@ -61,24 +60,21 @@ fn determine_forge_from_host(host: &str) -> Option<ForgeName> {
 /// Looking at the known accounts involves retrieving data from storage, so that is a bit more expensive
 /// and that's why it's a fallback mechanism.
 pub fn derive_forge_repo_info(url: &str) -> Option<ForgeRepoInfo> {
-    let git_url = GitUrl::parse(url).ok()?;
-    let host = git_url.host()?;
-    let protocol = git_url.scheme()?;
-
-    let provider_info: GenericProvider = git_url.provider_info().ok()?;
+    let remote = remote_url::RemoteUrl::parse(url)?;
     // Attempt to figure out the forge by looking at the host string and
     // falling back to matching it to the known accounts custom host URL.
-    let forge = determine_forge_from_host(host).or_else(|| {
+    let forge = determine_forge_from_host(&remote.host).or_else(|| {
         // Only fetch the accounts if it can't determine the forge type from the repository's host.
         let accounts = get_all_forge_accounts().unwrap_or_default();
-        match_host_to_accounts_custom_host(host, &accounts)
+        match_host_to_accounts_custom_host(&remote.host, &accounts)
     })?;
+    let (owner, repo) = remote.repository_parts(&forge)?;
 
     Some(ForgeRepoInfo {
         forge,
-        owner: provider_info.owner().to_string(),
-        repo: provider_info.repo().to_string(),
-        protocol: protocol.to_string(),
+        owner,
+        repo,
+        protocol: remote.protocol,
     })
 }
 
@@ -194,9 +190,142 @@ pub fn get_all_forge_accounts() -> anyhow::Result<Vec<ForgeUser>> {
 #[cfg(test)]
 mod tests {
     use super::{
-        ForgeName, ForgeRepoInfo, ForgeUser, current_forge_login,
+        ForgeName, ForgeRepoInfo, ForgeUser, current_forge_login, derive_forge_repo_info,
         match_host_to_accounts_custom_host, normalize_host_for_comparison,
     };
+
+    #[test]
+    fn derives_supported_forge_repository_urls() {
+        let cases = [
+            (
+                "git@github.com:owner/example.github.io.git",
+                ForgeName::GitHub,
+                "owner",
+                "example.github.io",
+                "ssh",
+            ),
+            (
+                "https://github.com/owner/example.github.io.git",
+                ForgeName::GitHub,
+                "owner",
+                "example.github.io",
+                "https",
+            ),
+            (
+                "https://github.com/owner/repository.git.git",
+                ForgeName::GitHub,
+                "owner",
+                "repository.git",
+                "https",
+            ),
+            (
+                "https://github.com/owner/repo/",
+                ForgeName::GitHub,
+                "owner",
+                "repo",
+                "https",
+            ),
+            (
+                "https://gitlab.com/group/subgroup/repo.git",
+                ForgeName::GitLab,
+                "group/subgroup",
+                "repo",
+                "https",
+            ),
+            (
+                "git@bitbucket.org:owner/repo.git",
+                ForgeName::Bitbucket,
+                "owner",
+                "repo",
+                "ssh",
+            ),
+            (
+                "https://dev.azure.com/org/project/_git/repo",
+                ForgeName::Azure,
+                "org/project",
+                "repo",
+                "https",
+            ),
+            (
+                "git@ssh.dev.azure.com:v3/org/project/repo.git",
+                ForgeName::Azure,
+                "org/project",
+                "repo",
+                "ssh",
+            ),
+        ];
+
+        for (url, forge, owner, repo, protocol) in cases {
+            let actual = derive_forge_repo_info(url).unwrap();
+            assert_eq!(actual.forge, forge, "forge should be derived from {url}");
+            assert_eq!(actual.owner, owner, "owner should be derived from {url}");
+            assert_eq!(actual.repo, repo, "repository should be derived from {url}");
+            assert_eq!(
+                actual.protocol, protocol,
+                "protocol should be derived from {url}"
+            );
+        }
+    }
+
+    #[test]
+    fn azure_encoded_path_characters_are_not_url_delimiters() {
+        for (url, expected_repo) in [
+            (
+                "https://dev.azure.com/org/project/_git/repo%23one",
+                "repo#one",
+            ),
+            (
+                "https://dev.azure.com/org/project/_git/repo%3Fone",
+                "repo?one",
+            ),
+            (
+                "https://dev.azure.com/org/project/_git/repo%23one?query=value#fragment",
+                "repo#one",
+            ),
+            (
+                "https://dev.azure.com/org/project/_git/repo%2523one",
+                "repo%23one",
+            ),
+            ("git@ssh.dev.azure.com:v3/org/project/repo#one", "repo#one"),
+            ("git@ssh.dev.azure.com:v3/org/project/repo?one", "repo?one"),
+            (
+                "ssh://git@ssh.dev.azure.com/v3/org/project/repo%23one",
+                "repo#one",
+            ),
+        ] {
+            let actual = derive_forge_repo_info(url).unwrap();
+            assert_eq!(actual.owner, "org/project", "owner should survive in {url}");
+            assert_eq!(
+                actual.repo, expected_repo,
+                "encoded path characters are not query or fragment delimiters in {url}"
+            );
+        }
+    }
+
+    #[test]
+    fn azure_https_organization_can_be_named_v3() {
+        let actual = derive_forge_repo_info("https://dev.azure.com/v3/project/_git/repo").unwrap();
+        assert_eq!(actual.forge, ForgeName::Azure, "host identifies Azure");
+        assert_eq!(
+            actual.owner, "v3/project",
+            "v3 is an HTTPS organization, not an SSH path marker"
+        );
+        assert_eq!(actual.repo, "repo", "repository name should survive");
+    }
+
+    #[test]
+    fn rejects_non_forge_and_malformed_repository_urls() {
+        for url in [
+            "../local-repo",
+            "file:///tmp/repo",
+            "https://github.com/owner",
+        ] {
+            assert!(
+                derive_forge_repo_info(url).is_none(),
+                "{url} does not identify a hosted forge repository"
+            );
+        }
+    }
 
     fn github_repo_info() -> ForgeRepoInfo {
         ForgeRepoInfo {

--- a/crates/but-forge/src/remote_url.rs
+++ b/crates/but-forge/src/remote_url.rs
@@ -1,0 +1,78 @@
+use gix::url::Scheme;
+
+use crate::ForgeName;
+
+/// Parsed parts of a remote URL needed to identify a forge repository.
+pub(crate) struct RemoteUrl {
+    pub(crate) protocol: String,
+    pub(crate) host: String,
+    pub(crate) port: Option<u16>,
+    path: String,
+}
+
+impl RemoteUrl {
+    pub(crate) fn parse(input: &str) -> Option<Self> {
+        let parsed = gix::url::parse(input.as_bytes()).ok()?;
+        if !matches!(
+            parsed.scheme,
+            Scheme::Git | Scheme::Ssh | Scheme::Http | Scheme::Https
+        ) {
+            return None;
+        }
+
+        let path = if matches!(parsed.scheme, Scheme::Http | Scheme::Https) {
+            // Strip URL delimiters before decoding: %23 and %3F are path characters.
+            let path = std::str::from_utf8(parsed.original_path().as_ref()).ok()?;
+            urlencoding::decode(path.split(['?', '#']).next()?)
+                .ok()?
+                .into_owned()
+        } else {
+            // SSH paths have no query or fragment; gix already decoded URL-form paths.
+            std::str::from_utf8(parsed.path.as_ref()).ok()?.to_owned()
+        };
+        let path = path.trim_matches('/');
+        let path = path.strip_suffix(".git").unwrap_or(path).to_string();
+
+        Some(Self {
+            protocol: parsed.scheme.as_str().to_string(),
+            host: parsed.host?,
+            port: parsed.port,
+            path,
+        })
+    }
+
+    pub(crate) fn repository_parts(&self, forge: &ForgeName) -> Option<(String, String)> {
+        match forge {
+            ForgeName::GitHub | ForgeName::Bitbucket => {
+                let (owner, repo) = self.path.split_once('/')?;
+                (!owner.is_empty() && !repo.is_empty() && !repo.contains('/'))
+                    .then(|| (owner.to_string(), repo.to_string()))
+            }
+            ForgeName::GitLab => {
+                let (owner, repo) = self.path.rsplit_once('/')?;
+                (!owner.is_empty() && !repo.is_empty())
+                    .then(|| (owner.to_string(), repo.to_string()))
+            }
+            ForgeName::Azure => self.azure_repository_parts(),
+        }
+    }
+
+    fn azure_repository_parts(&self) -> Option<(String, String)> {
+        let mut segments = self.path.split('/');
+        let parts = (
+            segments.next()?,
+            segments.next()?,
+            segments.next()?,
+            segments.next()?,
+        );
+        let (org, project, repo) = match (self.protocol.as_str(), parts) {
+            ("ssh", ("v3", org, project, repo)) => (org, project, repo),
+            ("http" | "https", (org, project, "_git", repo)) => (org, project, repo),
+            _ => return None,
+        };
+        if org.is_empty() || project.is_empty() || repo.is_empty() || segments.next().is_some() {
+            return None;
+        }
+        Some((format!("{org}/{project}"), repo.to_string()))
+    }
+}


### PR DESCRIPTION
git-url-parse has several quirks we need to work around, and is currently unmaintained. We only use a tiny subset of its functionality, and `gix` already provides Git URL parsing, so there's very little reason to keep it around.

This PR also fixes #15302 where URLs containing `.git` _somewhere_ in the name (e.g. `<username>.github.io`) parse incorrectly.