### PR TITLE
Lite: fix accidental re-render blasts in the workspace view

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.tsx
@@ -62,7 +62,7 @@ import {
 } from "./Row-utils.ts";
 import { StackCard } from "./StackCard.tsx";
 import stackCardStyles from "./StackCard.module.css";
-import { emptyBranchesListContent, type BranchesListQueryResult } from "./useBranchesList.ts";
+import { emptyBranchesListContent, type BranchesListContent } from "./useBranchesList.ts";
 import {
 	startKeyboardTransfer,
 	setCursor,
@@ -468,23 +468,21 @@ const BranchItem: FC<{
 export const BranchesList: FC<
 	{
 		projectId: string;
-		list: BranchesListQueryResult;
+		branches: BranchesListContent | undefined;
+		isPending: boolean;
+		isError: boolean;
 		/**
 		 * Owned by the sidebar and shared with its unapplied header, so both `+`
 		 * buttons offer the same menu and see the same create in flight.
 		 */
 		newBranch: NewBranchActions;
 	} & ComponentProps<"div">
-> = ({ projectId, list, newBranch, ...restProps }) => {
+> = ({ projectId, branches, isPending, isError, newBranch, ...restProps }) => {
 	const dispatch = useAppDispatch();
 
-	// WorkspacePage resolves selection from this query result and passes the same result down, so
-	// selection and rendering consume the same data snapshot.
-	const {
-		data: { stacks, stackIndexByAddressIndex, addressSpace } = emptyBranchesListContent,
-		isPending,
-		isError,
-	} = list;
+	// WorkspacePage resolves selection from this query data and passes the same data down, so
+	// selection and rendering consume the same snapshot.
+	const { stacks, stackIndexByAddressIndex, addressSpace } = branches ?? emptyBranchesListContent;
 	const filters = useAppSelector((state) =>
 		projectSlice.selectors.selectBranchFilters(state, projectId),
 	);

--- a/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
@@ -390,8 +390,11 @@ export const CommitForm: FC<{
 			},
 		);
 	};
-	const commitMenuItems: Array<NativeMenuItem> = [
-		// oxlint-disable-next-line react-hooks-js/refs -- The ref is only read by the onSelect callback.
+	// Built when the menu opens rather than during render: the callbacks close
+	// over the textarea ref, and handing them to a function in render is a ref
+	// read as far as React Compiler is concerned, which left this whole
+	// component uncompiled.
+	const commitMenuItems = (): Array<NativeMenuItem> => [
 		nativeMenuItem({
 			label: "Commit",
 			enabled: canCommit,
@@ -542,7 +545,7 @@ export const CommitForm: FC<{
 					menuLabel="Commit options"
 					menuDisabled={!(canAmend || canCommit)}
 					onMenuTrigger={(trigger) => {
-						void showNativeMenuFromTrigger(trigger, commitMenuItems);
+						void showNativeMenuFromTrigger(trigger, commitMenuItems());
 					}}
 				>
 					Start commit

--- a/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.tsx
@@ -349,6 +349,324 @@ const DirectoryOperationSource: FC<
 	/>
 );
 
+/**
+ * What every row gets from the tree, bundled so a row's props stay few and
+ * stable: the bundle only changes identity when one of its members does.
+ */
+type RowShared = {
+	projectId: string;
+	fileParent: FileParent;
+	focusScope: FocusScope;
+	tooltipHandle: Tooltip.Handle<FileRowTooltipPayload>;
+	ageBadgeNow: number | null;
+	pathDisplay: "lead" | "trail" | "hidden";
+	canCheck: boolean;
+	canUncommit: boolean;
+	uncommit?: (change: TreeChange, extendToCheckedFiles: boolean) => void;
+	checkFile: (evt: { path: string; shiftKey: boolean }) => void;
+	checkDirectory: (evt: { path: string; checked: boolean }) => void;
+	onRowSelection: (selection: string) => void;
+	onToggleDirectoryCollapsed: (path: string) => void;
+	branchNameByCommitId: (commitId: string) => string | undefined;
+};
+
+/**
+ * One virtualised row. Its own component so that a re-render of the list
+ * leaves the row's element tree cached when nothing about the row changed:
+ * the list itself is left uncompiled by its virtualizer, so anything built
+ * inline there would be rebuilt, and re-render every row, on every render.
+ */
+const FilesTreeRow: FC<{
+	row: FileTreeRow<FileRowItem>;
+	index: number;
+	height: number;
+	measureElement: (element: HTMLDivElement | null) => void;
+	shared: RowShared;
+	isSelected: boolean;
+	inert: boolean;
+	/** A file row's own checked state, or a directory row's aggregate over its files. */
+	checkedState: DirectoryCheckedState;
+	isReviewed: boolean;
+	isCollapsed: boolean;
+	/** Whether the selection sits on or under this directory row. */
+	holdsSelection: boolean;
+	/** See `renderInteractiveRows` in {@link FilesTreeVirtualList}. */
+	interactive: boolean;
+}> = ({
+	row,
+	index,
+	height,
+	measureElement,
+	shared,
+	isSelected,
+	inert,
+	checkedState,
+	isReviewed,
+	isCollapsed,
+	holdsSelection,
+	interactive,
+}) => {
+	const {
+		projectId,
+		fileParent,
+		focusScope,
+		tooltipHandle,
+		ageBadgeNow,
+		pathDisplay,
+		canCheck,
+		canUncommit,
+		uncommit,
+		checkFile,
+		checkDirectory,
+		onRowSelection,
+		onToggleDirectoryCollapsed,
+		branchNameByCommitId,
+	} = shared;
+	const virtStyle: CSSProperties = { position: "absolute", top: 0, left: 0, width: "100%", height };
+
+	if (row._tag === "Directory") {
+		const directoryRow = (
+			<DirectoryRow
+				projectId={projectId}
+				path={row.path}
+				name={row.name}
+				fileCount={row.filePaths.length}
+				depth={row.depth}
+				isCollapsed={isCollapsed}
+				scrollSelectedIntoView={false}
+				onToggleCollapsed={() => {
+					// Collapsing over the selection hides it, and it would
+					// fall back to the first row: hand it to the directory
+					// row, as the z hotkey does. Other toggles leave the
+					// selection (and the details pane it drives) alone.
+					if (!isCollapsed && holdsSelection) onRowSelection(row.path);
+					onToggleDirectoryCollapsed(row.path);
+				}}
+				isSelected={isSelected}
+				canCheck={canCheck}
+				checkedState={checkedState}
+				checkDirectory={checkDirectory}
+				focusScope={focusScope}
+				inert={inert}
+				onSelect={() => onRowSelection(row.path)}
+			/>
+		);
+
+		return (
+			<TreeItem
+				data-index={index}
+				ref={measureElement}
+				row={row}
+				isSelected={isSelected}
+				isExpanded={!isCollapsed}
+				aria-label={`Directory ${row.path}`}
+				style={virtStyle}
+				render={
+					interactive ? (
+						<DirectoryOperationSource
+							projectId={projectId}
+							fileParent={fileParent}
+							filePaths={row.filePaths}
+							render={directoryRow}
+						/>
+					) : (
+						directoryRow
+					)
+				}
+			/>
+		);
+	}
+
+	const item = row.item;
+	const address = fileAddress({ parent: fileParent, path: row.path });
+	const isChecked = checkedState === "checked";
+
+	return (
+		<TreeItem
+			data-index={index}
+			ref={measureElement}
+			row={row}
+			isSelected={isSelected}
+			style={virtStyle}
+			aria-label={
+				item._tag === "Change"
+					? `${item.change.status.type} ${item.change.path}`
+					: `Conflict ${item.path}`
+			}
+			render={
+				interactive ? (
+					<OperationSourceC
+						projectId={projectId}
+						sources={[address]}
+						respectChecked
+						outline="outside"
+						acceptOriginDrop
+						render={
+							<FileRow
+								item={item}
+								depth={row.depth}
+								pathDisplay={pathDisplay}
+								inert={inert}
+								isSelected={isSelected}
+								scrollSelectedIntoView={false}
+								isChecked={isChecked}
+								isReviewed={isReviewed}
+								onSelect={() => onRowSelection(row.path)}
+								canCheck={canCheck && item._tag === "Change"}
+								checkFile={checkFile}
+								projectId={projectId}
+								fileParent={fileParent}
+								canUncommit={canUncommit}
+								uncommit={uncommit}
+								focusScope={focusScope}
+								tooltipHandle={tooltipHandle}
+								ageBadgeNow={ageBadgeNow}
+								branchNameByCommitId={branchNameByCommitId}
+							/>
+						}
+					/>
+				) : (
+					<FileRowPresentational
+						item={item}
+						depth={row.depth}
+						pathDisplay={pathDisplay}
+						inert={inert}
+						isSelected={isSelected}
+						scrollSelectedIntoView={false}
+						isChecked={isChecked}
+						isReviewed={isReviewed}
+						onSelect={() => onRowSelection(row.path)}
+						canCheck={false}
+						checkFile={() => {}}
+						projectId={projectId}
+						fileParent={fileParent}
+						focusScope={focusScope}
+						tooltipHandle={tooltipHandle}
+						ageBadgeNow={ageBadgeNow}
+						branchNameByCommitId={() => undefined}
+						anyOperationPending
+						menuItems={[]}
+					/>
+				)
+			}
+		/>
+	);
+};
+
+/**
+ * The virtualised rows. Kept apart from {@link FilesTree} because React
+ * Compiler leaves any component calling `useVirtualizer` uncompiled
+ * (https://github.com/TanStack/virtual/issues/1119), so this one holds as
+ * little as possible: everything the rows need is derived, and memoised, in
+ * the tree and arrives here already stable.
+ */
+const FilesTreeVirtualList: FC<{
+	rows: Array<FileTreeRow<FileRowItem>>;
+	addressSpace: AddressSpace<string>;
+	selection: string | null;
+	hasPendingOperationSources: boolean;
+	collapsedDirectories: Record<string, true>;
+	reviewedPaths: ReadonlySet<string>;
+	isFileChecked: (path: string) => boolean;
+	directoryCheckedState: (filePaths: Array<string>) => DirectoryCheckedState;
+	shared: RowShared;
+}> = ({
+	rows,
+	addressSpace,
+	selection,
+	hasPendingOperationSources,
+	collapsedDirectories,
+	reviewedPaths,
+	isFileChecked,
+	directoryCheckedState,
+	shared,
+}) => {
+	const selectedRowIndex =
+		selection !== null ? (addressSpace.indexByKey.get(selection) ?? null) : null;
+	const rangeExtractorWithSelected = useCallback(
+		(range: Range) =>
+			getRangeExtractorWithIndices(range, selectedRowIndex === null ? [] : [selectedRowIndex]),
+		[selectedRowIndex],
+	);
+
+	// The list scrolls in the tree's parent, reached from this component's own
+	// element: the tree's ref belongs to the parent component and is not attached
+	// yet when the virtualizer first asks, which would leave the list empty until
+	// something else re-rendered it.
+	const groupRef = useRef<HTMLDivElement>(null);
+	// oxlint-disable-next-line react-hooks-js/incompatible-library -- https://github.com/TanStack/virtual/issues/1119#issuecomment-4648268095
+	const rowVirtualizer = useVirtualizer({
+		directDomUpdates: true,
+		directDomUpdatesMode: "transform",
+		count: rows.length,
+		getScrollElement: () => groupRef.current?.parentElement?.parentElement ?? null,
+		// Keep in sync with --single-line-row-height.
+		estimateSize: () => 28,
+		getItemKey: (index) => rows[index]?.path ?? index,
+		rangeExtractor: rangeExtractorWithSelected,
+		// Matches --scroll-gradient-height.
+		scrollPaddingStart: 14,
+		scrollPaddingEnd: 14,
+	});
+	const deferredIsScrolling = useDeferredValue(rowVirtualizer.isScrolling, true);
+	// Keep OperationSourceC mounted while an operation refers to its rows, especially while a
+	// pointer transfer auto-scrolls. Otherwise render the cheap rows immediately on scroll and
+	// wait for deferredIsScrolling to catch up before upgrading them in an interruptible render.
+	const renderInteractiveRows =
+		hasPendingOperationSources || (!rowVirtualizer.isScrolling && !deferredIsScrolling);
+
+	// Virtualisation-friendly equivalent to Row's own scrollIntoView.
+	useLayoutEffect(() => {
+		if (selectedRowIndex !== null)
+			rowVirtualizer.scrollToIndex(selectedRowIndex, { align: "auto" });
+	}, [rowVirtualizer, selectedRowIndex]);
+
+	return (
+		<div
+			// oxlint-disable-next-line jsx-a11y/prefer-tag-over-role -- Tree items need ARIA group semantics.
+			role="group"
+			ref={useMergedRefs(rowVirtualizer.containerRef, groupRef)}
+			style={{ position: "relative" }}
+		>
+			{rowVirtualizer.getVirtualItems().map((virtualRow) => {
+				const row = rows[virtualRow.index];
+				if (row === undefined) return null;
+
+				const isDirectory = row._tag === "Directory";
+				return (
+					<FilesTreeRow
+						key={row.path}
+						row={row}
+						index={virtualRow.index}
+						height={virtualRow.size}
+						measureElement={rowVirtualizer.measureElement}
+						shared={shared}
+						isSelected={selection !== null && selection === row.path}
+						inert={!addressSpaceIncludes(addressSpace, row.path, (path) => path)}
+						checkedState={
+							isDirectory
+								? directoryCheckedState(row.filePaths)
+								: isFileChecked(row.path)
+									? "checked"
+									: "unchecked"
+						}
+						isReviewed={
+							!isDirectory && row.item._tag === "Change" && reviewedPaths.has(row.item.change.path)
+						}
+						isCollapsed={isDirectory && collapsedDirectories[row.path] === true}
+						holdsSelection={
+							isDirectory &&
+							selection !== null &&
+							(selection === row.path || selection.startsWith(`${row.path}/`))
+						}
+						interactive={renderInteractiveRows}
+					/>
+				);
+			})}
+		</div>
+	);
+};
+
 export const FilesTree: FC<
 	{
 		projectId: string;
@@ -426,34 +744,6 @@ export const FilesTree: FC<
 	const [tooltipHandle] = useState(() => Tooltip.createHandle<FileRowTooltipPayload>());
 
 	const ref = useRef<HTMLDivElement>(null);
-	const selectedRowIndex =
-		selection !== null ? (addressSpace.indexByKey.get(selection) ?? null) : null;
-	const rangeExtractorWithSelected = useCallback(
-		(range: Range) =>
-			getRangeExtractorWithIndices(range, selectedRowIndex === null ? [] : [selectedRowIndex]),
-		[selectedRowIndex],
-	);
-
-	// oxlint-disable-next-line react-hooks-js/incompatible-library -- https://github.com/TanStack/virtual/issues/1119#issuecomment-4648268095
-	const rowVirtualizer = useVirtualizer({
-		directDomUpdates: true,
-		directDomUpdatesMode: "transform",
-		count: rows.length,
-		getScrollElement: () => ref.current?.parentElement ?? null,
-		// Keep in sync with --single-line-row-height.
-		estimateSize: () => 28,
-		getItemKey: (index) => rows[index]?.path ?? index,
-		rangeExtractor: rangeExtractorWithSelected,
-		// Matches --scroll-gradient-height.
-		scrollPaddingStart: 14,
-		scrollPaddingEnd: 14,
-	});
-	const deferredIsScrolling = useDeferredValue(rowVirtualizer.isScrolling, true);
-	// Keep OperationSourceC mounted while an operation refers to its rows, especially while a
-	// pointer transfer auto-scrolls. Otherwise render the cheap rows immediately on scroll and
-	// wait for deferredIsScrolling to catch up before upgrading them in an interruptible render.
-	const renderInteractiveRows =
-		hasPendingOperationSources || (!rowVirtualizer.isScrolling && !deferredIsScrolling);
 
 	const fileCheckRangeAnchor = useRef<string>(null);
 	const fileCheckRangeEnd = useRef<string>(null);
@@ -600,11 +890,23 @@ export const FilesTree: FC<
 		toggleDirectoryCollapsed: onToggleDirectoryCollapsed,
 	});
 
-	// Virtualisation-friendly equivalent to Row's own scrollIntoView.
-	useLayoutEffect(() => {
-		if (selectedRowIndex !== null)
-			rowVirtualizer.scrollToIndex(selectedRowIndex, { align: "auto" });
-	}, [rowVirtualizer, selectedRowIndex]);
+	const shared: RowShared = {
+		projectId,
+		fileParent,
+		focusScope,
+		tooltipHandle,
+		ageBadgeNow,
+		pathDisplay,
+		canCheck,
+		canUncommit,
+		uncommit,
+		checkFile,
+		checkDirectory,
+		onRowSelection,
+		onToggleDirectoryCollapsed,
+		branchNameByCommitId: (commitId) =>
+			headInfoIndex?.commitContextByCommitId(commitId)?.segment.refName?.displayName,
+	};
 
 	return (
 		<div
@@ -624,161 +926,17 @@ export const FilesTree: FC<
 					</RowLabelContainer>
 				</Row>
 			) : (
-				// oxlint-disable-next-line jsx-a11y/prefer-tag-over-role -- Tree items need ARIA group semantics.
-				<div role="group" ref={rowVirtualizer.containerRef} style={{ position: "relative" }}>
-					{rowVirtualizer.getVirtualItems().map((virtualRow) => {
-						const row = rows[virtualRow.index];
-						if (row === undefined) return null;
-
-						const isSelected = selection !== null && selection === row.path;
-						const inert = !addressSpaceIncludes(addressSpace, row.path, (path) => path);
-						const virtStyle: CSSProperties = {
-							position: "absolute",
-							top: 0,
-							left: 0,
-							width: "100%",
-							height: virtualRow.size,
-						};
-
-						if (row._tag === "Directory") {
-							const isCollapsed = collapsedDirectories[row.path] === true;
-							const directoryRow = (
-								<DirectoryRow
-									projectId={projectId}
-									path={row.path}
-									name={row.name}
-									fileCount={row.filePaths.length}
-									depth={row.depth}
-									isCollapsed={isCollapsed}
-									scrollSelectedIntoView={false}
-									onToggleCollapsed={() => {
-										// Collapsing over the selection hides it, and it would
-										// fall back to the first row: hand it to the directory
-										// row, as the z hotkey does. Other toggles leave the
-										// selection (and the details pane it drives) alone.
-										if (
-											!isCollapsed &&
-											selection !== null &&
-											(selection === row.path || selection.startsWith(`${row.path}/`))
-										)
-											onRowSelection(row.path);
-										onToggleDirectoryCollapsed(row.path);
-									}}
-									isSelected={isSelected}
-									canCheck={canCheck}
-									checkedState={directoryCheckedState(row.filePaths)}
-									checkDirectory={checkDirectory}
-									focusScope={focusScope}
-									inert={inert}
-									onSelect={() => onRowSelection(row.path)}
-								/>
-							);
-
-							return (
-								<TreeItem
-									key={row.path}
-									data-index={virtualRow.index}
-									ref={rowVirtualizer.measureElement}
-									row={row}
-									isSelected={isSelected}
-									isExpanded={!isCollapsed}
-									aria-label={`Directory ${row.path}`}
-									style={virtStyle}
-									render={
-										renderInteractiveRows ? (
-											<DirectoryOperationSource
-												projectId={projectId}
-												fileParent={fileParent}
-												filePaths={row.filePaths}
-												render={directoryRow}
-											/>
-										) : (
-											directoryRow
-										)
-									}
-								/>
-							);
-						}
-
-						const item = row.item;
-						const address = fileAddress({ parent: fileParent, path: row.path });
-
-						return (
-							<TreeItem
-								key={row.path}
-								data-index={virtualRow.index}
-								ref={rowVirtualizer.measureElement}
-								row={row}
-								isSelected={isSelected}
-								style={virtStyle}
-								aria-label={
-									item._tag === "Change"
-										? `${item.change.status.type} ${item.change.path}`
-										: `Conflict ${item.path}`
-								}
-								render={
-									renderInteractiveRows ? (
-										<OperationSourceC
-											projectId={projectId}
-											sources={[address]}
-											respectChecked
-											outline="outside"
-											acceptOriginDrop
-											render={
-												<FileRow
-													item={item}
-													depth={row.depth}
-													pathDisplay={pathDisplay}
-													inert={inert}
-													isSelected={isSelected}
-													scrollSelectedIntoView={false}
-													isChecked={checkedAddressKeys.has(addressIdentityKey(address))}
-													isReviewed={item._tag === "Change" && reviewedPaths.has(item.change.path)}
-													onSelect={() => onRowSelection(row.path)}
-													canCheck={canCheck && item._tag === "Change"}
-													checkFile={checkFile}
-													projectId={projectId}
-													fileParent={fileParent}
-													canUncommit={canUncommit}
-													uncommit={uncommit}
-													focusScope={focusScope}
-													tooltipHandle={tooltipHandle}
-													ageBadgeNow={ageBadgeNow}
-													branchNameByCommitId={(commitId) =>
-														headInfoIndex?.commitContextByCommitId(commitId)?.segment.refName
-															?.displayName
-													}
-												/>
-											}
-										/>
-									) : (
-										<FileRowPresentational
-											item={item}
-											depth={row.depth}
-											pathDisplay={pathDisplay}
-											inert={inert}
-											isSelected={isSelected}
-											scrollSelectedIntoView={false}
-											isChecked={checkedAddressKeys.has(addressIdentityKey(address))}
-											isReviewed={item._tag === "Change" && reviewedPaths.has(item.change.path)}
-											onSelect={() => onRowSelection(row.path)}
-											canCheck={false}
-											checkFile={() => {}}
-											projectId={projectId}
-											fileParent={fileParent}
-											focusScope={focusScope}
-											tooltipHandle={tooltipHandle}
-											ageBadgeNow={ageBadgeNow}
-											branchNameByCommitId={() => undefined}
-											anyOperationPending
-											menuItems={[]}
-										/>
-									)
-								}
-							/>
-						);
-					})}
-				</div>
+				<FilesTreeVirtualList
+					rows={rows}
+					addressSpace={addressSpace}
+					selection={selection}
+					hasPendingOperationSources={hasPendingOperationSources}
+					collapsedDirectories={collapsedDirectories}
+					reviewedPaths={reviewedPaths}
+					isFileChecked={isFileChecked}
+					directoryCheckedState={directoryCheckedState}
+					shared={shared}
+				/>
 			)}
 		</div>
 	);

--- a/apps/lite/ui/src/routes/project/$id/workspace/Page.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Page.tsx
@@ -417,11 +417,16 @@ const PageBody: FC<{ projectId: string }> = ({ projectId }) => {
 	});
 
 	const page = usePage();
-	const branchesList = useBranchesList(projectId);
+	// Destructured here: the result object itself is a new identity every render.
+	const {
+		data: branches,
+		isPending: branchesPending,
+		isError: branchesError,
+	} = useBranchesList(projectId);
 	const upstreamList = useUpstreamList(projectId);
 
 	const appliedSelection = useSelection("applied", appliedAddressSpace);
-	const branchesSelection = useSelection("unapplied", branchesList.data?.addressSpace);
+	const branchesSelection = useSelection("unapplied", branches?.addressSpace);
 	const upstreamSelection = useSelection("upstream", upstreamList.addressSpace);
 
 	const { data: worktreeChanges } = useQuery(changesInWorktreeQueryOptions(projectId));
@@ -659,7 +664,9 @@ const PageBody: FC<{ projectId: string }> = ({ projectId }) => {
 							<Sidebar
 								projectId={projectId}
 								project={selectedProject}
-								branchesList={branchesList}
+								branches={branches}
+								branchesPending={branchesPending}
+								branchesError={branchesError}
 								upstreamList={upstreamList}
 								addressSpace={appliedAddressSpace}
 								uncommittedAddressSpace={uncommittedAddressSpace}

--- a/apps/lite/ui/src/routes/project/$id/workspace/Page.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Page.tsx
@@ -387,11 +387,19 @@ const PageBody: FC<{ projectId: string }> = ({ projectId }) => {
 		},
 	]);
 
+	// These two hooks sit above the derivation below on purpose. The compiler
+	// cannot memoize a value whose mutable range spans a hook call, and a hook
+	// between `new Set(...)` and `buildAppliedAddressSpace(...)` left both
+	// unmemoized: every render rebuilt the address space and re-rendered every
+	// row that reads it through context.
+	const { data: headInfo } = useQuery(headInfoQueryOptions(projectId));
+	const foldedSegments = useAppSelector((state) =>
+		projectSlice.selectors.selectFoldedSegments(state, projectId),
+	);
 	const absorptionPlanTarget = Match.value(pendingOperation).pipe(
 		Match.tags({ Absorb: ({ sourceTarget }) => sourceTarget }),
 		Match.orElse(() => null),
 	);
-	const { data: headInfo } = useQuery(headInfoQueryOptions(projectId));
 	const [absorptionPlanQuery] = useQueries({
 		queries: (absorptionPlanTarget ? [absorptionPlanTarget] : []).map((target) =>
 			absorptionPlanQueryOptions({ projectId, target }),
@@ -401,9 +409,6 @@ const PageBody: FC<{ projectId: string }> = ({ projectId }) => {
 		absorptionPlanQuery?.data?.map(({ commitId }) => commitId),
 	);
 
-	const foldedSegments = useAppSelector((state) =>
-		projectSlice.selectors.selectFoldedSegments(state, projectId),
-	);
 	const appliedAddressSpace = buildAppliedAddressSpace({
 		headInfo,
 		pendingOperation,

--- a/apps/lite/ui/src/routes/project/$id/workspace/Sidebar.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Sidebar.tsx
@@ -28,7 +28,7 @@ import { Activity, type FC, useRef } from "react";
 import { ToggleGroupStyles, ToggleStyles } from "#ui/components/ToggleGroup.tsx";
 import { WorkspaceLists } from "#ui/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.tsx";
 import { BranchesList } from "#ui/routes/project/$id/workspace/BranchesList.tsx";
-import type { BranchesListQueryResult } from "#ui/routes/project/$id/workspace/useBranchesList.ts";
+import type { BranchesListContent } from "#ui/routes/project/$id/workspace/useBranchesList.ts";
 import { UpstreamList } from "#ui/routes/project/$id/workspace/UpstreamList.tsx";
 import type { UpstreamListData } from "#ui/routes/project/$id/workspace/useUpstreamList.ts";
 import { assert } from "#ui/assert.ts";
@@ -91,7 +91,9 @@ const WorkspaceActivityBadge: FC<{ projectId: string }> = ({ projectId }) => {
 
 export const Sidebar: FC<{
 	absorptionTargetCommitIds: ReadonlySet<string>;
-	branchesList: BranchesListQueryResult;
+	branches: BranchesListContent | undefined;
+	branchesPending: boolean;
+	branchesError: boolean;
 	upstreamList: UpstreamListData;
 	addressSpace: AddressSpace<Address>;
 	uncommittedAddressSpace: AddressSpace<string>;
@@ -100,7 +102,9 @@ export const Sidebar: FC<{
 	projectId: string;
 }> = ({
 	absorptionTargetCommitIds,
-	branchesList,
+	branches,
+	branchesPending,
+	branchesError,
 	upstreamList,
 	addressSpace,
 	uncommittedAddressSpace,
@@ -310,7 +314,9 @@ export const Sidebar: FC<{
 				<BranchesList
 					className={styles.page}
 					projectId={projectId}
-					list={branchesList}
+					branches={branches}
+					isPending={branchesPending}
+					isError={branchesError}
 					newBranch={newBranch}
 				/>
 			</Activity>

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.tsx
@@ -152,7 +152,14 @@ const OperationTarget: FC<
 	const addressSpace = useAddressSpace();
 
 	type ActiveOperation = { placement: Placement; tooltip?: string | undefined };
-	const selection = useSelection("applied", addressSpace);
+	// The cursor only picks the target of a keyboard transfer, so follow it only
+	// then: a target that tracks the cursor at all times re-renders, along with
+	// the whole row it wraps, on every cursor move.
+	const keyboardTransferPending = useAppSelector((state) => {
+		const pendingOperation = projectSlice.selectors.selectPendingOperation(state, projectId);
+		return pendingOperation._tag === "Transfer" && pendingOperation.value._tag === "Keyboard";
+	});
+	const selection = useSelection("applied", keyboardTransferPending ? addressSpace : null);
 	const activeList = useActiveList();
 	const activeOperation = useAppSelector((state) => {
 		const pendingOperation = projectSlice.selectors.selectPendingOperation(state, projectId);

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.tsx
@@ -266,10 +266,17 @@ const UncommittedChanges: FC<
 		projectId: string;
 		targetComboboxItems: Array<CommitTargetComboboxItem>;
 		hasNoBranches: boolean;
-		onAmendCommit: (commitId: string) => void;
+		/**
+		 * Not `on*`-named on purpose, nor are the two callbacks below: this
+		 * component is the `render` element of an operation target, and base-ui's
+		 * `mergeProps` wraps every `on*` function prop it passes through in a new
+		 * function. Callbacks that arrive wrapped change identity on every render,
+		 * and everything below that keys on them re-renders with them.
+		 */
+		amendCommit: (commitId: string) => void;
 		canAmendCommit: boolean;
-		onActiveFileSelection: (selection: string) => void;
-		onEdgeSpill: (offset: -1 | 1) => void;
+		selectActiveFile: (selection: string) => void;
+		spillEdge: (offset: -1 | 1) => void;
 		worktreeChanges: WorktreeChanges | undefined;
 	} & Omit<ComponentProps<"div">, "children">
 > = ({
@@ -278,10 +285,10 @@ const UncommittedChanges: FC<
 	projectId,
 	targetComboboxItems,
 	hasNoBranches,
-	onAmendCommit,
+	amendCommit,
 	canAmendCommit,
-	onActiveFileSelection,
-	onEdgeSpill,
+	selectActiveFile,
+	spillEdge,
 	worktreeChanges,
 	...props
 }) => {
@@ -333,7 +340,7 @@ const UncommittedChanges: FC<
 		selectionKey: fileSelection,
 		firstKey: fileRows[0]?.path,
 		onEnterList: () => {
-			if (fileSelection !== null) onActiveFileSelection(fileSelection);
+			if (fileSelection !== null) selectActiveFile(fileSelection);
 		},
 		panelRef,
 		listRef: fileListRef,
@@ -404,8 +411,8 @@ const UncommittedChanges: FC<
 								)
 							}
 							addressSpace={addressSpace}
-							onRowSelection={onActiveFileSelection}
-							onEdgeSpill={onEdgeSpill}
+							onRowSelection={selectActiveFile}
+							onEdgeSpill={spillEdge}
 							projectId={projectId}
 							ref={useMergedRefs(fileListRef, useAutofocusScope(activeList === "uncommitted"))}
 							selection={fileSelection}
@@ -421,7 +428,7 @@ const UncommittedChanges: FC<
 					startCommitButtonId={startCommitButtonId}
 					commitMessageInputId={commitMessageInputId}
 					className={styles.commitForm}
-					onAmendCommit={onAmendCommit}
+					onAmendCommit={amendCommit}
 					canAmendCommit={canAmendCommit}
 					worktreeChanges={worktreeChanges}
 				/>
@@ -1422,10 +1429,10 @@ export const WorkspaceLists: FC<
 										projectId={projectId}
 										targetComboboxItems={commitTargetComboboxItems}
 										hasNoBranches={hasNoBranches}
-										onAmendCommit={amendCommit}
+										amendCommit={amendCommit}
 										canAmendCommit={canAmendCommit}
-										onActiveFileSelection={onActiveFileSelection}
-										onEdgeSpill={spillIntoStacks}
+										selectActiveFile={onActiveFileSelection}
+										spillEdge={spillIntoStacks}
 										worktreeChanges={worktreeChanges}
 									/>
 								}

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.tsx
@@ -1168,9 +1168,11 @@ export const WorkspaceLists: FC<
 }) => {
 	const { data: headInfo } = useQuery(headInfoQueryOptions(projectId));
 	const { data: worktreeChanges } = useQuery(changesInWorktreeQueryOptions(projectId));
-	const headInfoIndex = headInfo ? getHeadInfoIndex(headInfo) : undefined;
-
 	const appliedSelection = useSelection("applied", addressSpace);
+	// After the hook on purpose: a hook call between the index and the commit
+	// target derivation below stops the compiler from memoizing that derivation,
+	// and a fresh commit target every render re-renders the uncommitted list.
+	const headInfoIndex = headInfo ? getHeadInfoIndex(headInfo) : undefined;
 	const commitTargetComboboxItems = buildCommitTargetComboboxItems({
 		headInfo,
 		headInfoIndex,

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.tsx
@@ -33,6 +33,7 @@ import { ResizeHandle } from "#ui/components/ResizeHandle.tsx";
 import uiStyles from "#ui/components/ui.module.css";
 import type {
 	BranchReference,
+	Commit,
 	Segment,
 	Stack,
 	PushStatus,
@@ -48,6 +49,7 @@ import {
 	Activity,
 	type ComponentProps,
 	createContext,
+	type CSSProperties,
 	type FC,
 	Fragment,
 	type RefObject,
@@ -55,6 +57,7 @@ import {
 	use,
 	useCallback,
 	useLayoutEffect,
+	useMemo,
 	useRef,
 	useState,
 } from "react";
@@ -671,54 +674,107 @@ const SegmentContent: FC<{
 				const commit = segment.commits[virtualRow.index];
 				if (commit === undefined) return null;
 
-				const address = commitAddress({ commitId: commit.id, changeId: commit.changeId });
 				const dryRunCommitId = dryRunWorkspace?.replacedCommits[commit.id];
 				const dryRunCommit =
 					dryRunCommitId !== undefined
 						? (dryRunHeadInfoIndex?.commitContextByCommitId(dryRunCommitId)?.commit ?? null)
 						: null;
 				return (
-					<div
+					<CommitItem
 						key={commit.id}
-						data-index={virtualRow.index}
-						ref={rowVirtualizer.measureElement}
-						// We can't set fixed height here as an optimisation due to inline reword.
-						style={{
-							position: "absolute",
-							top: 0,
-							left: 0,
-							width: "100%",
-						}}
-					>
-						<TreeItem
-							address={address}
-							aria-label={commitTitle(commit.message) ?? "(no message)"}
-							aria-level={ariaLevel}
-							aria-posinset={positionOffset + virtualRow.index + 1}
-							aria-setsize={setSize}
-							render={
-								<AddressC
-									projectId={projectId}
-									address={address}
-									outline="outside"
-									render={
-										<CommitRow
-											commit={commit}
-											stackId={stackId}
-											checkCommit={checkCommit}
-											amendCommit={() => onAmendCommit(commit.id)}
-											canAmendCommit={canAmendCommit}
-											projectId={projectId}
-											dryRunCommit={dryRunCommit}
-											scrollSelectedIntoView={false}
-										/>
-									}
-								/>
-							}
-						/>
-					</div>
+						index={virtualRow.index}
+						measureElement={rowVirtualizer.measureElement}
+						commit={commit}
+						projectId={projectId}
+						stackId={stackId}
+						checkCommit={checkCommit}
+						onAmendCommit={onAmendCommit}
+						canAmendCommit={canAmendCommit}
+						dryRunCommit={dryRunCommit}
+						ariaLevel={ariaLevel}
+						positionInSet={positionOffset + virtualRow.index + 1}
+						setSize={setSize}
+					/>
 				);
 			})}
+		</div>
+	);
+};
+
+/**
+ * One virtualised commit row. Its own component so that a re-render of the
+ * segment leaves the row's element tree cached when nothing about the commit
+ * changed: {@link SegmentContent} is left uncompiled by its virtualizer, so
+ * anything built inline there is rebuilt, and re-renders every row, on every
+ * render.
+ */
+const CommitItem: FC<{
+	index: number;
+	measureElement: (element: HTMLDivElement | null) => void;
+	commit: Commit;
+	projectId: string;
+	stackId: string | null;
+	checkCommit: (evt: { commitId: string; shiftKey: boolean }) => void;
+	onAmendCommit: (commitId: string) => void;
+	canAmendCommit: boolean;
+	dryRunCommit: Commit | null;
+	ariaLevel: number;
+	positionInSet: number;
+	setSize: number;
+}> = ({
+	index,
+	measureElement,
+	commit,
+	projectId,
+	stackId,
+	checkCommit,
+	onAmendCommit,
+	canAmendCommit,
+	dryRunCommit,
+	ariaLevel,
+	positionInSet,
+	setSize,
+}) => {
+	const address = commitAddress({ commitId: commit.id, changeId: commit.changeId });
+
+	return (
+		<div
+			data-index={index}
+			ref={measureElement}
+			// We can't set fixed height here as an optimisation due to inline reword.
+			style={{
+				position: "absolute",
+				top: 0,
+				left: 0,
+				width: "100%",
+			}}
+		>
+			<TreeItem
+				address={address}
+				aria-label={commitTitle(commit.message) ?? "(no message)"}
+				aria-level={ariaLevel}
+				aria-posinset={positionInSet}
+				aria-setsize={setSize}
+				render={
+					<AddressC
+						projectId={projectId}
+						address={address}
+						outline="outside"
+						render={
+							<CommitRow
+								commit={commit}
+								stackId={stackId}
+								checkCommit={checkCommit}
+								amendCommit={() => onAmendCommit(commit.id)}
+								canAmendCommit={canAmendCommit}
+								projectId={projectId}
+								dryRunCommit={dryRunCommit}
+								scrollSelectedIntoView={false}
+							/>
+						}
+					/>
+				}
+			/>
 		</div>
 	);
 };
@@ -808,7 +864,21 @@ const StackC: FC<
 	...props
 }) => {
 	const canTearOffBranch = stack.segments.length > 1;
-	const downstackPushStatuses = downstackPushStatusesFromSegments(stack.segments);
+	// Manual memo: the compiler folds this into the props scope, where it is rebuilt
+	// on every render and hands each branch row a fresh status.
+	const downstackPushStatuses = useMemo(
+		() => downstackPushStatusesFromSegments(stack.segments),
+		[stack.segments],
+	);
+	// Built here rather than passed in: the uncompiled parent would rebuild the object,
+	// and with it this whole card, on every render.
+	const style: CSSProperties = {
+		position: "absolute",
+		top: 0,
+		left: 0,
+		width: "100%",
+		transform: `translateY(${stackScrollStart}px)`,
+	};
 	const topmostPendingPushIndex = stack.segments.findIndex(
 		(segment) =>
 			segment.refName && pendingPushBranches.has(decodeBytes(segment.refName.fullNameBytes)),
@@ -825,6 +895,7 @@ const StackC: FC<
 	return (
 		<StackCard
 			{...props}
+			style={style}
 			className={classes(props.className, styles.virtualStack)}
 			// oxlint-disable-next-line jsx-a11y/prefer-tag-over-role -- This is a group of treeitems.
 			role="group"
@@ -966,15 +1037,19 @@ const Stacks: FC<{
 	const foldedSegments = useAppSelector((state) =>
 		projectSlice.selectors.selectFoldedSegments(state, projectId),
 	);
-	const pendingPushBranches = new Set(
-		useMutationState({
-			filters: {
-				mutationKey: [projectId, "workspaceBranchAndAncestorsPush"],
-				status: "pending",
-			},
-			select: (mutation) =>
-				(mutation.state.variables as PayloadFor<"workspaceBranchAndAncestorsPush">).branch,
-		}),
+	const pendingPushBranchList = useMutationState({
+		filters: {
+			mutationKey: [projectId, "workspaceBranchAndAncestorsPush"],
+			status: "pending",
+		},
+		select: (mutation) =>
+			(mutation.state.variables as PayloadFor<"workspaceBranchAndAncestorsPush">).branch,
+	});
+	// React Compiler leaves components using useVirtualizer uncompiled, hence manual memo:
+	// a fresh Set every render would re-render every stack.
+	const pendingPushBranches = useMemo(
+		() => new Set(pendingPushBranchList),
+		[pendingPushBranchList],
 	);
 	const scrollElementRef = useRef<HTMLDivElement>(null);
 	const retainScrollElement = useCallback((element: HTMLDivElement | null) => {
@@ -1113,13 +1188,6 @@ const Stacks: FC<{
 								key={stack.id ?? virtualRow.index}
 								data-index={virtualRow.index}
 								ref={rowVirtualizer.measureElement}
-								style={{
-									position: "absolute",
-									top: 0,
-									left: 0,
-									width: "100%",
-									transform: `translateY(${virtualRow.start}px)`,
-								}}
 								projectId={projectId}
 								stack={stack}
 								checkCommit={checkCommit}

--- a/apps/lite/ui/src/routes/project/$id/workspace/useBranchesList.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/useBranchesList.ts
@@ -31,13 +31,11 @@ type BranchesListStack = {
 	commitCount: number;
 };
 
-type BranchesListContent = {
+export type BranchesListContent = {
 	stacks: Array<BranchesListStack>;
 	stackIndexByAddressIndex: Array<number>;
 	addressSpace: AddressSpace<Address>;
 };
-
-export type BranchesListQueryResult = UseQueryResult<BranchesListContent>;
 
 export const emptyBranchesListContent: BranchesListContent = {
 	stacks: [],
@@ -52,7 +50,7 @@ export const emptyBranchesListContent: BranchesListContent = {
  * rendering and the selection resolution in the workspace page consume it, so
  * filtering and fold state cannot drift between the two.
  */
-export const useBranchesList = (projectId: string): BranchesListQueryResult => {
+export const useBranchesList = (projectId: string): UseQueryResult<BranchesListContent> => {
 	const active = usePage() === "branches";
 	const filters = useAppSelector((state) =>
 		projectSlice.selectors.selectBranchFilters(state, projectId),

--- a/apps/lite/ui/src/use-cursor.ts
+++ b/apps/lite/ui/src/use-cursor.ts
@@ -93,30 +93,43 @@ const resolveCursorParam = <L extends UrlCursorName>(
 	addressSpace.items[0] ??
 	null;
 
-/** The cursor resolved against what the list currently shows. */
+/**
+ * The cursor resolved against what the list currently shows. Without an
+ * address space there is nothing to resolve against, so the selector reads
+ * nothing either: a caller that passes `null` while it has no use for the
+ * cursor is not re-rendered by cursor moves.
+ */
 export const useSelection = <L extends UrlCursorName>(
 	list: L,
 	addressSpace: AddressSpace<CursorItem[L]> | null | undefined,
 ): CursorItem[L] | null => {
 	const param = useSearch({
 		from: WORKSPACE_ROUTE,
-		select: (params: UrlQueryParams): string | undefined => params[list],
+		select: (params: UrlQueryParams): string | undefined =>
+			addressSpace == null ? undefined : params[list],
 	});
 
 	return addressSpace == null ? null : resolveCursorParam(list, param, addressSpace);
 };
 
 /**
- * Whether the resolved cursor rests on `item`. A primitive, so a cursor move
- * re-renders the two affected rows rather than the whole list.
+ * Whether the resolved cursor rests on `item`. Resolved inside the selector so
+ * the subscription is to a primitive: a cursor move re-renders the two
+ * affected rows rather than the whole list.
  */
 export const useIsCursorAt = <L extends UrlCursorName>(
 	list: L,
 	addressSpace: AddressSpace<CursorItem[L]>,
 	item: CursorItem[L],
 ): boolean => {
-	const resolved = useSelection(list, addressSpace);
-	return resolved !== null && cursorKey[list](resolved) === cursorKey[list](item);
+	const key = cursorKey[list](item);
+	return useSearch({
+		from: WORKSPACE_ROUTE,
+		select: (params: UrlQueryParams): boolean => {
+			const resolved = resolveCursorParam(list, params[list], addressSpace);
+			return resolved !== null && cursorKey[list](resolved) === key;
+		},
+	});
 };
 
 /**


### PR DESCRIPTION
Eight small fixes for interactions in the workspace view that re-rendered every row instead of the few affected ones. Each commit is one fix; measured in the dev app against a repo with 238 dirty files, three stacks and ~1800 remote branches.

| Interaction | Before | After |
|---|---|---|
| Click a file row | 2 × ~25ms, ~450 components | ~6ms, ~65 |
| Click a commit row | ~30ms, ~330 | ~10-16ms, ~110 |
| Hover a file row | 22ms, 130 | 3ms, 4 |
| Toggle a file checkbox | 43-57ms, ~360 | ~30ms, ~250 |

What was going wrong, in commit order:

1. **PageBody** — two hook calls sat inside the derivation chain that builds the applied address space, so React Compiler left the Set and the address space unmemoized. Every render handed the sidebar a fresh address space and the WorkspaceLists context re-rendered every row. Hoisting the hooks lets the compiler memoize it.
2. **WorkspaceLists** — same mechanism between `getHeadInfoIndex` and the commit target derivation; a fresh commit target re-rendered the uncommitted panel on every stack cursor move.
3. **FilesTree** — the compiler refuses to compile any component that calls `useVirtualizer`, so the tree rebuilt every callback and row element per render. The virtualizer now lives in a small inner list, each row is its own compiled component, and the tree passes rows a memoized bundle of shared inputs.
4. **Stacks / SegmentContent** — same virtualizer problem. The pending-push Set and downstack push statuses are memoized by hand, StackC positions itself from its scroll offset, and each commit row is its own compiled component.
5. **Cursor subscriptions** — every row's tree item and operation target subscribed to the raw applied cursor param. `useIsCursorAt` now resolves inside the router selector and returns a boolean, and operation targets follow the cursor only while a keyboard transfer is pending.
6. **UncommittedChanges callbacks** — base-ui's `mergeProps` wraps every `on*`-named function prop in a new function, so callbacks on a `render=` target changed identity on every render of the chain. The three callbacks are renamed so `mergeProps` leaves them alone.
7. **CommitForm** — building native menu items in render with a ref-closing callback made the compiler bail on the whole form. The items are built when the menu opens.
8. **Branches list props** — a `useQuery` result object is a new identity every render; the page now destructures the three fields the list reads and passes them down as separate props, so Sidebar and the hidden Branches list no longer re-render on every page render.
