### PR TITLE
Classify terminal GitHub device-flow failures with typed codes

### DIFF
--- a/apps/desktop/src/components/settings/GithubIntegration.oauth.test.ts
+++ b/apps/desktop/src/components/settings/GithubIntegration.oauth.test.ts
@@ -1,0 +1,200 @@
+import GithubIntegration from "$components/settings/GithubIntegration.svelte";
+import { CLIPBOARD_SERVICE } from "$lib/backend/clipboard";
+import { URL_SERVICE } from "$lib/backend/url";
+import { GITHUB_USER_SERVICE } from "$lib/forge/github/githubUserService.svelte";
+import { OnboardingEvent, POSTHOG_WRAPPER } from "$lib/telemetry/posthog";
+import { chipToasts } from "@gitbutler/ui";
+import { render, screen, waitFor } from "@testing-library/svelte";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import type { GitHubUserService } from "$lib/forge/github/githubUserService.svelte";
+import type { PostHogWrapper } from "$lib/telemetry/posthog";
+
+// jsdom has no PointerEvent; ContextMenu.onMount does `target instanceof PointerEvent`.
+(globalThis as any).PointerEvent ??= MouseEvent;
+
+const DEVICE_CODE = "3584d274e7d7ec4aa8b2d9c2f6c0b1c7device";
+const USER_CODE = "WDJB-MJHT";
+const VERIFICATION_URL = "https://github.com/login/device";
+/**
+ * A `tauriBaseQuery` rejection for a terminal refusal. The backend sends a static
+ * message for this code; the fixture carries raw detail anyway to prove the
+ * component forwards nothing from the message.
+ */
+const rejection = {
+	origin: "ipc",
+	name: "API error: (check_github_auth_status)",
+	message: `GitHub returned an error: access_denied (denied for device_code ${DEVICE_CODE}, user_code ${USER_CODE}; see ${VERIFICATION_URL})\n\nCaused by:\n    1: POST https://github.com/login/oauth/access_token params: {"deviceCode":"${DEVICE_CODE}"} Authorization: Bearer gho_fakeTokenValue at /home/kiril/.config/gitbutler`,
+	code: "GitHubDeviceAccessDenied",
+	fingerprint: ["ipc", "check_github_auth_status", "GitHub returned an error: access_denied"],
+};
+const rawFields = [
+	"access_denied",
+	DEVICE_CODE,
+	USER_CODE,
+	VERIFICATION_URL,
+	"https://",
+	"params",
+	"Authorization:",
+	"Bearer",
+	"gho_",
+	"/home/",
+	"fingerprint",
+	"origin",
+	"API error",
+	"\n",
+];
+const idle = { current: { isLoading: false } };
+
+function renderIntegration(
+	checkAuthStatus: () => Promise<unknown>,
+	initDeviceOauth: () => Promise<unknown> = async () => ({
+		user_code: USER_CODE,
+		device_code: DEVICE_CODE,
+	}),
+) {
+	const githubUserService = {
+		initDeviceOauth: vi.fn(initDeviceOauth),
+		checkAuthStatus: vi.fn(checkAuthStatus),
+		deleteAllGitHubAccounts: () => [vi.fn(), idle],
+		storeGitHubPat: [vi.fn(), idle],
+		storeGithuibEnterprisePat: [vi.fn(), idle],
+		accounts: () => ({ result: { data: [], status: "fulfilled" } }),
+	} as unknown as GitHubUserService;
+	const posthog = { capture: vi.fn(), captureOnboarding: vi.fn() } as unknown as PostHogWrapper;
+	const context = new Map<any, any>([
+		[GITHUB_USER_SERVICE._key, githubUserService],
+		[POSTHOG_WRAPPER._key, posthog],
+		[URL_SERVICE._key, { openExternalUrl: vi.fn(async () => {}) }],
+		[CLIPBOARD_SERVICE._key, { write: vi.fn(async () => {}) }],
+	]);
+	const errorToast = vi.spyOn(chipToasts, "error").mockReturnValue("toast");
+	const warningToast = vi.spyOn(chipToasts, "warning").mockReturnValue("toast");
+	const successToast = vi.spyOn(chipToasts, "success").mockReturnValue("toast");
+	const errorLog = vi.spyOn(console, "error").mockImplementation(() => {});
+	render(GithubIntegration, { context });
+	return { githubUserService, posthog, errorToast, warningToast, successToast, errorLog };
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+async function driveDeviceFlowToStatusCheck() {
+	const user = userEvent.setup();
+	await user.click(screen.getByRole("button", { name: /add account/i }));
+	await user.click(await screen.findByText("Authorize GitHub Account"));
+	await user.click(await screen.findByRole("button", { name: /copy to clipboard/i }));
+	await user.click(await screen.findByRole("button", { name: /open github activation page/i }));
+	// The status button is revealed 500ms after the activation page is opened.
+	await user.click(
+		await screen.findByRole("button", { name: /check the status/i }, { timeout: 3000 }),
+	);
+}
+
+function expectFlowClosed() {
+	expect(screen.queryByRole("button", { name: /check the status/i })).not.toBeInTheDocument();
+	expect(screen.getByRole("button", { name: /add account/i })).toBeEnabled();
+}
+
+describe("GithubIntegration device OAuth failure", () => {
+	test("shows and reports only the classifier's guidance for a terminal refusal", async () => {
+		const { githubUserService, posthog, errorToast, warningToast, errorLog } = renderIntegration(
+			async () => {
+				throw rejection;
+			},
+		);
+
+		await driveDeviceFlowToStatusCheck();
+
+		await waitFor(() =>
+			expect(githubUserService.checkAuthStatus).toHaveBeenCalledWith({ deviceCode: DEVICE_CODE }),
+		);
+		const payload = {
+			name: "GitHub OAuth failed",
+			message:
+				"The authorization request was denied on GitHub. Start again and approve GitButler on the device activation page.",
+			code: "GitHubDeviceAccessDenied",
+		};
+		await waitFor(() =>
+			expect(posthog.captureOnboarding).toHaveBeenCalledWith(
+				OnboardingEvent.GitHubOAuthFailed,
+				payload,
+			),
+		);
+		expect(posthog.captureOnboarding).toHaveBeenCalledTimes(2);
+		// A denied request is a user state, so it toasts as a warning.
+		expect(warningToast).toHaveBeenCalledTimes(1);
+		expect(warningToast).toHaveBeenCalledWith(payload.message);
+		expect(errorToast).not.toHaveBeenCalled();
+		expect(errorLog).toHaveBeenCalledTimes(1);
+		expect(errorLog.mock.calls.flat()).not.toContain(rejection);
+		const serialized = JSON.stringify([
+			vi.mocked(posthog.captureOnboarding).mock.calls,
+			warningToast.mock.calls,
+			errorLog.mock.calls,
+		]);
+		for (const raw of rawFields) expect(serialized).not.toContain(raw);
+		expectFlowClosed();
+	});
+
+	test("reports an initialization refusal the same way and never opens the flow", async () => {
+		const initRejection = {
+			...rejection,
+			name: "API error: (init_github_device_oauth)",
+			message: rejection.message.replace("access_denied", "device_flow_disabled"),
+			code: "GitHubDeviceFlowRejected",
+		};
+		const { posthog, errorToast, warningToast, errorLog } = renderIntegration(
+			async () => ({ login: "octocat" }),
+			async () => {
+				throw initRejection;
+			},
+		);
+		const user = userEvent.setup();
+
+		await user.click(screen.getByRole("button", { name: /add account/i }));
+		await user.click(await screen.findByText("Authorize GitHub Account"));
+
+		const payload = {
+			name: "GitHub OAuth failed",
+			message:
+				"GitHub rejected the device authorization request. Start again, or connect with a personal access token instead.",
+			code: "GitHubDeviceFlowRejected",
+		};
+		await waitFor(() =>
+			expect(posthog.captureOnboarding).toHaveBeenCalledWith(
+				OnboardingEvent.GitHubOAuthFailed,
+				payload,
+			),
+		);
+		expect(vi.mocked(posthog.captureOnboarding).mock.calls).toEqual([
+			[OnboardingEvent.GitHubInitiateOAuth],
+			[OnboardingEvent.GitHubOAuthFailed, payload],
+		]);
+		expect(errorToast).toHaveBeenCalledTimes(1);
+		expect(errorToast).toHaveBeenCalledWith(payload.message);
+		expect(warningToast).not.toHaveBeenCalled();
+		expect(errorLog).toHaveBeenCalledTimes(1);
+		const serialized = JSON.stringify([
+			vi.mocked(posthog.captureOnboarding).mock.calls,
+			errorToast.mock.calls,
+			errorLog.mock.calls,
+		]);
+		for (const raw of [...rawFields, "device_flow_disabled"]) expect(serialized).not.toContain(raw);
+		expect(screen.queryByRole("button", { name: /copy to clipboard/i })).not.toBeInTheDocument();
+		expect(screen.getByRole("button", { name: /add account/i })).toBeEnabled();
+	});
+
+	test("keeps the success path unchanged", async () => {
+		const { posthog, errorToast, successToast } = renderIntegration(async () => ({
+			login: "octocat",
+		}));
+
+		await driveDeviceFlowToStatusCheck();
+
+		await waitFor(() => expectFlowClosed());
+		expect(successToast).toHaveBeenCalledWith("GitHub authenticated");
+		expect(errorToast).not.toHaveBeenCalled();
+		expect(posthog.captureOnboarding).toHaveBeenCalledTimes(1);
+		expect(posthog.captureOnboarding).toHaveBeenCalledWith(OnboardingEvent.GitHubInitiateOAuth);
+	});
+});

--- a/apps/desktop/src/components/settings/GithubIntegration.svelte
+++ b/apps/desktop/src/components/settings/GithubIntegration.svelte
@@ -4,6 +4,7 @@
 	import githubLogoSvg from "$lib/assets/unsized-logos/github.svg?raw";
 	import { CLIPBOARD_SERVICE } from "$lib/backend/clipboard";
 	import { URL_SERVICE } from "$lib/backend/url";
+	import { classifyGitHubDeviceOAuthFailure } from "$lib/error/errorClassification";
 	import { GITHUB_USER_SERVICE } from "$lib/forge/github/githubUserService.svelte";
 	import { OnboardingEvent, POSTHOG_WRAPPER } from "$lib/telemetry/posthog";
 	import { inject } from "@gitbutler/core/context";
@@ -71,17 +72,29 @@
 		gheHostError = undefined;
 	}
 
+	/** One safe label serves the console, the toast, and telemetry; the raw rejection is never shown. */
+	function reportOAuthFailure(err: unknown) {
+		const { message, code, severity } = classifyGitHubDeviceOAuthFailure(err);
+		const failure = { name: "GitHub OAuth failed", message, ...(code && { code }) };
+		console.error("GitHub device OAuth failed", failure);
+		(severity === "warning" ? toasts.warning : toasts.error)(message);
+		posthog.captureOnboarding(OnboardingEvent.GitHubOAuthFailed, failure);
+	}
+
 	function gitHubStartOauth() {
 		posthog.captureOnboarding(OnboardingEvent.GitHubInitiateOAuth);
-		githubUserService.initDeviceOauth().then((verification) => {
-			userCode = verification.user_code;
-			deviceCode = verification.device_code;
-			showingFlow = "oauthFlow";
-			// Reset all step flags for a fresh auth flow
-			codeCopied = false;
-			GhActivationLinkPressed = false;
-			GhActivationPageOpened = false;
-		});
+		githubUserService
+			.initDeviceOauth()
+			.then((verification) => {
+				userCode = verification.user_code;
+				deviceCode = verification.device_code;
+				showingFlow = "oauthFlow";
+				// Reset all step flags for a fresh auth flow
+				codeCopied = false;
+				GhActivationLinkPressed = false;
+				GhActivationPageOpened = false;
+			})
+			.catch(reportOAuthFailure);
 	}
 
 	async function gitHubOauthCheckStatus(deviceCode: string) {
@@ -89,10 +102,8 @@
 		try {
 			await githubUserService.checkAuthStatus({ deviceCode });
 			toasts.success("GitHub authenticated");
-		} catch (err: any) {
-			console.error(err);
-			toasts.error("GitHub authentication failed");
-			posthog.captureOnboarding(OnboardingEvent.GitHubOAuthFailed);
+		} catch (err: unknown) {
+			reportOAuthFailure(err);
 		} finally {
 			// Reset the auth flow on completion
 			cleanupAuthFlow();

--- a/apps/desktop/src/lib/error/errorClassification.test.ts
+++ b/apps/desktop/src/lib/error/errorClassification.test.ts
@@ -1,8 +1,9 @@
 import { persistSwallowGitHubOrgAuthErrors } from "$lib/config/config";
 import { SilentError } from "$lib/error/error";
-import { classify } from "$lib/error/errorClassification";
+import { classify, classifyGitHubDeviceOAuthFailure } from "$lib/error/errorClassification";
 import { IpcError } from "$lib/error/normalizedError";
 import { describe, expect, test } from "vitest";
+import type { Code } from "@gitbutler/but-sdk";
 
 /**
  * The classifier owns "how should this error show up to the user?"
@@ -159,6 +160,73 @@ describe("classify", () => {
 			expect(result.userMessage).toContain("OAuth app");
 			expect(result.userMessage).toContain("personal access token");
 			expect(result.userMessage).toContain("then try again");
+		});
+	});
+
+	describe("GitHub device-flow codes", () => {
+		test.each<[Code, string, RegExp]>([
+			["GitHubDeviceCodeExpired", "warning", /device code has expired/],
+			["GitHubDeviceAccessDenied", "warning", /was denied on GitHub/],
+			["GitHubDeviceFlowRejected", "error", /rejected the device authorization/],
+		])("%s carries %s severity and recovery guidance", (code, severity, guidance) => {
+			const error = new IpcError({ message: "static", code }, "check_github_auth_status");
+			const result = classify(error);
+			expect(result.code).toBe(code);
+			expect(result.severity).toBe(severity);
+			expect(result.userMessage).toMatch(guidance);
+		});
+
+		test("pending statuses and arbitrary codes get no guidance", () => {
+			const pending = new IpcError(
+				{
+					message:
+						"GitHub returned an error: authorization_pending (The authorization request is still pending.)",
+					code: "Unknown",
+				},
+				"check_github_auth_status",
+			);
+			expect(classify(pending).userMessage).toBeUndefined();
+			const arbitrary = { message: "failure", code: "constructor" };
+			expect(classify(arbitrary).userMessage).toBeUndefined();
+		});
+	});
+
+	describe("classifyGitHubDeviceOAuthFailure", () => {
+		const generic = { message: "GitHub authentication failed", severity: "error" };
+		const raw =
+			"GitHub returned an error: access_denied (device_code 3584d274 https://github.com/login/device)";
+
+		test.each<[Code, string, RegExp]>([
+			["GitHubDeviceCodeExpired", "warning", /device code has expired/],
+			["GitHubDeviceAccessDenied", "warning", /was denied on GitHub/],
+			["GitHubDeviceFlowRejected", "error", /rejected the device authorization/],
+		])("%s yields its static guidance, code, and %s severity", (code, severity, guidance) => {
+			const result = classifyGitHubDeviceOAuthFailure({ message: raw, code });
+			expect(result).toEqual({ message: expect.stringMatching(guidance), code, severity });
+			expect(result.message).not.toContain("3584d274");
+		});
+
+		test.each([
+			[
+				"a pending status",
+				{ message: raw.replace("access_denied", "authorization_pending"), code: "Unknown" },
+			],
+			["a code that is only an inherited key", { message: raw, code: "constructor" }],
+			["a code that is a prototype key", { message: raw, code: "__proto__" }],
+			["a secret-rich code string", { message: raw, code: "gho_secret" }],
+			["a thrown string", raw],
+			["undefined", undefined],
+			["a bigint", 1n],
+			[
+				"a cyclic object",
+				(() => {
+					const c: Record<string, unknown> = {};
+					c.self = c;
+					return c;
+				})(),
+			],
+		])("%s falls back to the generic label without a code", (_, error) => {
+			expect(classifyGitHubDeviceOAuthFailure(error)).toEqual(generic);
 		});
 	});
 

--- a/apps/desktop/src/lib/error/errorClassification.ts
+++ b/apps/desktop/src/lib/error/errorClassification.ts
@@ -82,6 +82,54 @@ A GitHub organization has restricted access for the GitButler OAuth app. Ask an 
 };
 
 /**
+ * Terminal GitHub device-flow outcomes, tagged by `but-github` with a
+ * static message. The settings OAuth flow shows this guidance verbatim
+ * through `classifyGitHubDeviceOAuthFailure`; pending statuses are not
+ * tagged and keep the generic fallback.
+ */
+const GITHUB_DEVICE_OAUTH_CLASSIFICATIONS = {
+	GitHubDeviceCodeExpired: {
+		severity: "warning",
+		userMessage:
+			"The GitHub device code has expired. Start the authorization again to get a new code.",
+	},
+	GitHubDeviceAccessDenied: {
+		severity: "warning",
+		userMessage:
+			"The authorization request was denied on GitHub. Start again and approve GitButler on the device activation page.",
+	},
+	GitHubDeviceFlowRejected: {
+		severity: "error",
+		userMessage:
+			"GitHub rejected the device authorization request. Start again, or connect with a personal access token instead.",
+	},
+} satisfies Partial<Record<Code, Classification & { userMessage: string }>>;
+
+export type GitHubDeviceOAuthFailure = { message: string; code?: Code; severity: Severity };
+
+/**
+ * A fixed, safe description of a failed device-OAuth step: the static guidance
+ * for one of the device-flow codes above, or a generic label with no code.
+ * Total over any throwable — the parser is not — and never echoes the raw
+ * message, which can carry device codes or request detail.
+ */
+export function classifyGitHubDeviceOAuthFailure(error: unknown): GitHubDeviceOAuthFailure {
+	try {
+		const { code } = classify(error);
+		if (code && Object.hasOwn(GITHUB_DEVICE_OAUTH_CLASSIFICATIONS, code)) {
+			const { userMessage, severity } =
+				GITHUB_DEVICE_OAUTH_CLASSIFICATIONS[
+					code as keyof typeof GITHUB_DEVICE_OAUTH_CLASSIFICATIONS
+				];
+			return { message: userMessage, code, severity };
+		}
+	} catch {
+		// Fall through to the generic label.
+	}
+	return { message: "GitHub authentication failed", severity: "error" };
+}
+
+/**
  * Per-`Code` presentation rules. This table is the single source of
  * truth for "how should a backend error code show up to users?" — add
  * a code-keyed entry here rather than special-casing inside callers
@@ -156,6 +204,7 @@ With \`seahorse\` or equivalent, create a \`Login\` password store, right click 
 Your GitHub token appears expired. Please log out and back in to refresh it. (Settings -> Integrations -> Forget)
 	`,
 	},
+	...GITHUB_DEVICE_OAUTH_CLASSIFICATIONS,
 	GitHubOrgOAuthRestricted: GH_ORG_AUTH_CLASSIFICATION,
 	GitHubOrgSamlRestricted: {
 		severity: "error",

--- a/crates/but-error/src/lib.rs
+++ b/crates/but-error/src/lib.rs
@@ -192,6 +192,16 @@ pub enum Code {
     /// authenticated or logged out. Cached forge data stays valid; retrying
     /// without re-authenticating won't help.
     ForgeNotAuthenticated,
+    /// The GitHub device-flow code expired before the user authorized it.
+    /// Terminal for that code; starting the flow again issues a new one.
+    GitHubDeviceCodeExpired,
+    /// The user denied the GitHub device-flow authorization request.
+    /// Terminal for that code; starting the flow again is the only recovery.
+    GitHubDeviceAccessDenied,
+    /// GitHub refused the device-flow request for any other terminal reason
+    /// (bad client credentials or device code, unsupported grant type, the
+    /// device flow being disabled for the app). Retrying the same code won't help.
+    GitHubDeviceFlowRejected,
     /// The operation was rejected because the current state doesn't allow it.
     /// Not a bug — the user's request simply can't be fulfilled right now.
     /// The frontend should present this as a warning rather than an error.

--- a/crates/but-github/src/lib.rs
+++ b/crates/but-github/src/lib.rs
@@ -38,13 +38,39 @@ fn parse_github_oauth_response<T: serde::de::DeserializeOwned>(body: &str) -> Re
         let description = value
             .get("error_description")
             .and_then(serde_json::Value::as_str);
-        anyhow::bail!(
+        let err = anyhow::anyhow!(
             "GitHub returned an error: {} ({})",
             error,
             description.unwrap_or("no description"),
         );
+        return Err(match device_flow_context(error) {
+            Some(context) => err.context(context),
+            None => err,
+        });
     }
     serde_json::from_value(value).context("Response body did not match expected schema")
+}
+
+/// A static, code-bearing context for terminal device-flow statuses, so the API serializes
+/// guidance instead of GitHub's description. Pending statuses stay as they are: callers poll
+/// through them, and the provider text remains the inner error for the CLI and Lite.
+fn device_flow_context(status: &str) -> Option<but_error::Context> {
+    use but_error::{Code, Context};
+    match status {
+        "authorization_pending" | "slow_down" => None,
+        "expired_token" => Some(Context::new_static(
+            Code::GitHubDeviceCodeExpired,
+            "The GitHub device code has expired",
+        )),
+        "access_denied" => Some(Context::new_static(
+            Code::GitHubDeviceAccessDenied,
+            "Authorization was denied on GitHub",
+        )),
+        _ => Some(Context::new_static(
+            Code::GitHubDeviceFlowRejected,
+            "GitHub rejected the device authorization request",
+        )),
+    }
 }
 
 pub async fn init_github_device_oauth() -> Result<Verification> {
@@ -508,6 +534,83 @@ mod tests {
             );
         } else {
             panic!("Expected a network error but request succeeded");
+        }
+    }
+
+    #[test]
+    fn device_flow_statuses_carry_static_context_but_keep_provider_text() {
+        use but_error::{AnyhowContextExt as _, Code};
+        let secret = "device_code=3584d274 user_code=WDJB-MJHT https://github.com/login/device";
+        let rejected = Some((
+            Code::GitHubDeviceFlowRejected,
+            "GitHub rejected the device authorization request",
+        ));
+        let cases: [(&str, Option<(Code, &str)>); 9] = [
+            ("authorization_pending", None),
+            ("slow_down", None),
+            (
+                "expired_token",
+                Some((
+                    Code::GitHubDeviceCodeExpired,
+                    "The GitHub device code has expired",
+                )),
+            ),
+            (
+                "access_denied",
+                Some((
+                    Code::GitHubDeviceAccessDenied,
+                    "Authorization was denied on GitHub",
+                )),
+            ),
+            ("incorrect_client_credentials", rejected),
+            ("incorrect_device_code", rejected),
+            ("unsupported_grant_type", rejected),
+            ("device_flow_disabled", rejected),
+            ("brand_new_status", rejected),
+        ];
+        for (status, expected) in cases {
+            let body = format!(r#"{{"error":"{status}","error_description":"{secret}"}}"#);
+            let err = parse_github_oauth_response::<serde_json::Value>(&body)
+                .expect_err("an OAuth error status is a failure");
+            match (err.custom_context(), expected) {
+                (None, None) => {}
+                (Some(ctx), Some((code, message))) => {
+                    assert_eq!(ctx.code, code, "{status}");
+                    assert_eq!(ctx.message.as_deref(), Some(message), "{status}");
+                }
+                (ctx, expected) => panic!("{status}: got {ctx:?}, expected {expected:?}"),
+            }
+            // `but_api::json::Error` serializes the context message when present, else the chain.
+            let api_message = err
+                .custom_context_or_error_chain()
+                .message
+                .expect("always a message");
+            if expected.is_some() {
+                assert!(
+                    !api_message.contains(secret) && !api_message.contains(status),
+                    "{status}: provider detail must not reach the API: {api_message}"
+                );
+            } else {
+                assert!(
+                    api_message.contains(status),
+                    "{status}: pending statuses keep today's message"
+                );
+            }
+            // Alternate display (Lite, CLI) keeps the provider status as the inner error.
+            let display = format!("{err:#}");
+            assert!(
+                display.contains(&format!("GitHub returned an error: {status} (")),
+                "{status}: {display}"
+            );
+        }
+    }
+
+    #[test]
+    fn non_provider_parse_failures_are_not_contextualized() {
+        use but_error::AnyhowContextExt as _;
+        for body in ["not json", r#"{"unexpected":"shape"}"#] {
+            let err = parse_github_oauth_response::<Verification>(body).expect_err("bad body");
+            assert!(err.custom_context().is_none(), "{body:?}: {err:#}");
         }
     }
 }

--- a/packages/but-sdk/src/generated/graph/index.d.ts
+++ b/packages/but-sdk/src/generated/graph/index.d.ts
@@ -2387,7 +2387,7 @@ export type Claude = {
  *
  * In practice, it should match its [frontend counterpart](https://github.com/gitbutlerapp/gitbutler/blob/fa973fd8f1ae8807621f47601803d98b8a9cf348/app/src/lib/backend/ipc.ts#L5).
  */
-export type Code = "Validation" | "RepoOwnership" | "ProjectGitAuth" | "DefaultTargetNotFound" | "CommitSigningFailed" | "CommitMergeConflictFailure" | "ProjectMissing" | "AuthorMissing" | "BranchNotFound" | "SecretKeychainNotFound" | "MissingLoginKeychain" | "GitForcePushProtection" | "NetworkError" | "ProjectDatabaseIncompatible" | "DefaultTerminalNotFound" | "Unknown" | "GitNonFastForward" | "CliInstallCancelled" | "GitHubTokenExpired" | "GitLabUnauthorized" | "GitLabForbidden" | "GitHubOrgOAuthRestricted" | "GitHubOrgSamlRestricted" | "GitHubInsufficientPermissions" | "ForgeNotAuthenticated" | "PreconditionFailed" | "EditorExitedWithNonZeroStatus";
+export type Code = "Validation" | "RepoOwnership" | "ProjectGitAuth" | "DefaultTargetNotFound" | "CommitSigningFailed" | "CommitMergeConflictFailure" | "ProjectMissing" | "AuthorMissing" | "BranchNotFound" | "SecretKeychainNotFound" | "MissingLoginKeychain" | "GitForcePushProtection" | "NetworkError" | "ProjectDatabaseIncompatible" | "DefaultTerminalNotFound" | "Unknown" | "GitNonFastForward" | "CliInstallCancelled" | "GitHubTokenExpired" | "GitLabUnauthorized" | "GitLabForbidden" | "GitHubOrgOAuthRestricted" | "GitHubOrgSamlRestricted" | "GitHubInsufficientPermissions" | "ForgeNotAuthenticated" | "GitHubDeviceCodeExpired" | "GitHubDeviceAccessDenied" | "GitHubDeviceFlowRejected" | "PreconditionFailed" | "EditorExitedWithNonZeroStatus";
 
 /** Commit that is part of a legacy stack branch and contains state derived in relation to it. */
 export type Commit = {

--- a/packages/but-sdk/src/generated/linear/index.d.ts
+++ b/packages/but-sdk/src/generated/linear/index.d.ts
@@ -2387,7 +2387,7 @@ export type Claude = {
  *
  * In practice, it should match its [frontend counterpart](https://github.com/gitbutlerapp/gitbutler/blob/fa973fd8f1ae8807621f47601803d98b8a9cf348/app/src/lib/backend/ipc.ts#L5).
  */
-export type Code = "Validation" | "RepoOwnership" | "ProjectGitAuth" | "DefaultTargetNotFound" | "CommitSigningFailed" | "CommitMergeConflictFailure" | "ProjectMissing" | "AuthorMissing" | "BranchNotFound" | "SecretKeychainNotFound" | "MissingLoginKeychain" | "GitForcePushProtection" | "NetworkError" | "ProjectDatabaseIncompatible" | "DefaultTerminalNotFound" | "Unknown" | "GitNonFastForward" | "CliInstallCancelled" | "GitHubTokenExpired" | "GitLabUnauthorized" | "GitLabForbidden" | "GitHubOrgOAuthRestricted" | "GitHubOrgSamlRestricted" | "GitHubInsufficientPermissions" | "ForgeNotAuthenticated" | "PreconditionFailed" | "EditorExitedWithNonZeroStatus";
+export type Code = "Validation" | "RepoOwnership" | "ProjectGitAuth" | "DefaultTargetNotFound" | "CommitSigningFailed" | "CommitMergeConflictFailure" | "ProjectMissing" | "AuthorMissing" | "BranchNotFound" | "SecretKeychainNotFound" | "MissingLoginKeychain" | "GitForcePushProtection" | "NetworkError" | "ProjectDatabaseIncompatible" | "DefaultTerminalNotFound" | "Unknown" | "GitNonFastForward" | "CliInstallCancelled" | "GitHubTokenExpired" | "GitLabUnauthorized" | "GitLabForbidden" | "GitHubOrgOAuthRestricted" | "GitHubOrgSamlRestricted" | "GitHubInsufficientPermissions" | "ForgeNotAuthenticated" | "GitHubDeviceCodeExpired" | "GitHubDeviceAccessDenied" | "GitHubDeviceFlowRejected" | "PreconditionFailed" | "EditorExitedWithNonZeroStatus";
 
 /** Commit that is part of a legacy stack branch and contains state derived in relation to it. */
 export type Commit = {


### PR DESCRIPTION
## Context

GitHub device-OAuth failures reached Desktop as concrete errors, but status-check onboarding telemetry dropped the error and users saw only a generic message. Initialization rejections were not handled by the component. The fix preserves a safe redacted diagnostic category and actionable recovery guidance without forwarding provider details.

## Change

- classify terminal provider statuses in `but-github` with three typed, static, redacted contexts while preserving existing pending and non-provider behavior
- keep device-flow guidance, code membership, and severity in one canonical Desktop classifier map
- route initialization and status-check failures through one reporter that uses the same safe payload for the severity-aware toast, diagnostic log, and onboarding telemetry
- add Rust, classifier, and component regression coverage, including secret-bearing provider details that must not reach presentation or onboarding telemetry

Validated with 37 `but-github` tests, 12 `but-api` serialization tests, 65 focused Desktop tests, Rust clippy/fmt, Desktop type-checking, Prettier, ESLint, and `git diff --check`.

Fixes GB-1992
