### PR TITLE
feat(but): increase prefix short ID minimum length to 3 for agents

### DIFF
--- a/crates/but/src/command/legacy/status/tui/tests/snapshots/viewing_empty_file_001.svg
+++ b/crates/but/src/command/legacy/status/tui/tests/snapshots/viewing_empty_file_001.svg
@@ -30,7 +30,7 @@
     <text x="290 298 306" y="78" style="fill:#CCCCCC;">add</text>
     <text x="322" y="78" style="fill:#CCCCCC;">M</text>
     <text x="410" y="78" style="fill:#555555;">│</text>
-    <text x="426 434 442 450" y="78" style="fill:#0000AA;">kw:q</text>
+    <text x="426 434 442 450" y="78" style="fill:#0000AA;">kw:e</text>
     <text x="466 474 482 490 498" y="78" style="fill:#CCCCCC;">empty</text>
     <text x="514 522 530 538" y="78" style="fill:#CCCCCC;">file</text>
     <text x="554" y="78" style="fill:#555555;">│</text>

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -1066,7 +1066,8 @@ impl IdMap {
     /// commit/discard of a leading colliding hunk from causing trailing colliding hunks to get new
     /// IDs that previously pointed to other colliding hunks.
     ///
-    /// Note that hunks that lack a diff follow the same rules, only that `<prefix>="q"` always.
+    /// Note that hunks that lack a diff follow the same rules, using a prefix of
+    /// [`HUNK_EMPTY_CONTENT_PREFIX`] instead.
     fn assign_content_based_hunk_ids<'a>(
         short_ids_and_hunks: impl Iterator<Item = &'a mut (UnqualifiedHunkId, but_core::SingleHunk)>,
     ) -> anyhow::Result<()> {

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -25,7 +25,7 @@ use crate::id::{
 };
 use crate::theme;
 use crate::utils::change_source::{self, ChangeSourceId, SourceChanges};
-use crate::utils::get_change_id_for_commit;
+use crate::utils::{detect_agent, get_change_id_for_commit};
 
 mod file_info;
 mod id_usage;
@@ -71,6 +71,22 @@ struct UnqualifiedHunkId {
     /// The collision index if there are other hunks with the exact same ID. Otherwise this is
     /// empty.
     collision_index: Option<String>,
+}
+
+/// This is a hopefully short term hack in place to allow us to increase the minimum size of short
+/// IDs for agents, s.t. they are less likely to lengthen/shorten during `but` operations.
+///
+/// Once we have structured data for short IDs, this can be done away with.
+///
+/// For obvious reasons this does not respect "agent output formatting", as that's not available
+/// here and it'd be silly to pull it in all the way. This will work for the vast majority of agent
+/// invocations, and that's good enough for now.
+fn min_length_for_prefix_based_short_ids() -> usize {
+    if detect_agent::detect().is_some() {
+        3
+    } else {
+        1
+    }
 }
 
 impl UnqualifiedHunkId {
@@ -179,6 +195,7 @@ fn assign_short_ids(
     let mut common_with_previous_len = 0;
     let mut reverse_hex_short_ids: Vec<_> = reverse_hex_short_ids.into_iter().collect();
     let mut remaining = reverse_hex_short_ids.as_mut_slice();
+    let global_min_short_id_chars = min_length_for_prefix_based_short_ids();
 
     while let Some(((reverse_hex, short_ids), rest)) = remaining.split_first_mut() {
         // TODO should compare UTF8 chars instead of bytes once we start putting full branch names
@@ -189,7 +206,8 @@ fn assign_short_ids(
                 common_prefix_len(reverse_hex, next_reverse_hex)
             });
 
-        let min_disambiguation_len = 1 + common_with_previous_len.max(common_with_next_len);
+        let min_disambiguation_len =
+            (1 + common_with_previous_len.max(common_with_next_len)).max(global_min_short_id_chars);
 
         let num_conflicting_ids = short_ids.len();
         for (i, short_id) in short_ids.iter_mut().flatten().enumerate() {
@@ -1024,15 +1042,16 @@ impl IdMap {
         })
     }
 
-    const HUNK_EMPTY_CONTENT_PREFIX: &str = "q";
+    const HUNK_EMPTY_CONTENT_PREFIX: &str = "empty-content-hash";
 
     /// Assign unique hunk IDs based on content hash into the input iterator's first element.
     ///
     /// On hash collisions, the IDs are disambiguated based on the amount of collisions for that
     /// particular hash.
     ///
-    /// Hunks that lack a diff get a content hash of "q" and then rely on the disambiguation
-    /// mechanism if there are multiple such hunks.
+    /// Hunks that lack a diff get a bogus content hash of "empty-content-hash" and then rely on the
+    /// disambiguation mechanism if there are multiple such hunks. As it contains dashes, it cannot
+    /// collide with any real hunk content hashes.
     ///
     /// In summary, the formats are:
     ///
@@ -1053,6 +1072,8 @@ impl IdMap {
     ) -> anyhow::Result<()> {
         let mut content_hash_to_short_ids: BTreeMap<String, Vec<&'a mut UnqualifiedHunkId>> =
             BTreeMap::new();
+        let global_min_short_id_chars = min_length_for_prefix_based_short_ids();
+
         for (hunk_id, hunk) in short_ids_and_hunks {
             let content_hash = match hunk.diff.as_ref() {
                 Some(diff) => {
@@ -1087,7 +1108,7 @@ impl IdMap {
                     .map(|(content_hash, _)| content_hash.as_bytes())
                     .unwrap_or_default(),
             );
-            let min_short_id_chars = 1
+            let min_short_id_chars = global_min_short_id_chars
                 .max(len_in_common_with_next + 1)
                 .max(len_in_common_with_last + 1);
 

--- a/crates/but/src/id/tests.rs
+++ b/crates/but/src/id/tests.rs
@@ -2424,7 +2424,7 @@ fn uncommitted_hunks_by_id() -> anyhow::Result<()> {
         .raw()
     );
 
-    // hunk without diff gets q identifier
+    // Hunk without diff gets an identifier from the empty-content prefix.
     snapbox::assert_data_eq!(
         id_map
             .parse("hunk_without_diff.txt:e", &TestChanges(changed_paths_fn))?

--- a/crates/but/src/id/tests.rs
+++ b/crates/but/src/id/tests.rs
@@ -418,7 +418,7 @@ fn uncommitted_files_avoid_retired_uncommitted_area_id() -> anyhow::Result<()> {
         snapbox::str![[r#"
 workspace_and_remote_commits_count: 0
 uncommitted_files: [ zzs ]
-uncommitted_hunks: [ zzs:q ]
+uncommitted_hunks: [ zzs:e ]
 
 
 "#]]
@@ -499,7 +499,7 @@ fn branches_avoid_uncommitted_filenames() -> anyhow::Result<()> {
 workspace_and_remote_commits_count: 1
 branches: [ ij ]
 uncommitted_files: [ nx, yz ]
-uncommitted_hunks: [ nx:q, yz:q ]
+uncommitted_hunks: [ nx:e, yz:e ]
 
 
 "#]]
@@ -666,7 +666,7 @@ fn non_commit_ids_do_not_collide() -> anyhow::Result<()> {
 workspace_and_remote_commits_count: 1
 branches: [ h0 ]
 uncommitted_files: [ kv, ro ]
-uncommitted_hunks: [ kv:q, ro:q#0-2, ro:q#1-2 ]
+uncommitted_hunks: [ kv:e, ro:e#0-2, ro:e#1-2 ]
 stacks: [ j0 ]
 
 
@@ -701,7 +701,7 @@ stacks: [ j0 ]
             id: "kv",
             hunks: NonEmpty {
                 head: IdAndHunk {
-                    id: "kv:q",
+                    id: "kv:e",
                     hunk: SingleHunk {
                         hunk_header: None,
                         path: "uncommitted2.txt",
@@ -716,10 +716,10 @@ stacks: [ j0 ]
     ),
     UncommittedHunkOrFile(
         UncommittedHunkOrFile {
-            id: "kv:q",
+            id: "kv:e",
             hunks: NonEmpty {
                 head: IdAndHunk {
-                    id: "kv:q",
+                    id: "kv:e",
                     hunk: SingleHunk {
                         hunk_header: None,
                         path: "uncommitted2.txt",
@@ -737,7 +737,7 @@ stacks: [ j0 ]
             id: "ro",
             hunks: NonEmpty {
                 head: IdAndHunk {
-                    id: "ro:q#0-2",
+                    id: "ro:e#0-2",
                     hunk: SingleHunk {
                         hunk_header: Some(
                             HunkHeader("-1,2", "+1,2"),
@@ -748,7 +748,7 @@ stacks: [ j0 ]
                 },
                 tail: [
                     IdAndHunk {
-                        id: "ro:q#1-2",
+                        id: "ro:e#1-2",
                         hunk: SingleHunk {
                             hunk_header: Some(
                                 HunkHeader("-3,2", "+3,2"),
@@ -765,10 +765,10 @@ stacks: [ j0 ]
     ),
     UncommittedHunkOrFile(
         UncommittedHunkOrFile {
-            id: "ro:q#0-2",
+            id: "ro:e#0-2",
             hunks: NonEmpty {
                 head: IdAndHunk {
-                    id: "ro:q#0-2",
+                    id: "ro:e#0-2",
                     hunk: SingleHunk {
                         hunk_header: Some(
                             HunkHeader("-1,2", "+1,2"),
@@ -785,10 +785,10 @@ stacks: [ j0 ]
     ),
     UncommittedHunkOrFile(
         UncommittedHunkOrFile {
-            id: "ro:q#1-2",
+            id: "ro:e#1-2",
             hunks: NonEmpty {
                 head: IdAndHunk {
-                    id: "ro:q#1-2",
+                    id: "ro:e#1-2",
                     hunk: SingleHunk {
                         hunk_header: Some(
                             HunkHeader("-3,2", "+3,2"),
@@ -882,7 +882,7 @@ fn ids_are_case_sensitive() -> anyhow::Result<()> {
 workspace_and_remote_commits_count: 1
 branches: [ h0 ]
 uncommitted_files: [ ln ]
-uncommitted_hunks: [ ln:q ]
+uncommitted_hunks: [ ln:e ]
 
 
 "#]]
@@ -945,7 +945,7 @@ uncommitted_hunks: [ ln:q ]
             id: "ln",
             hunks: NonEmpty {
                 head: IdAndHunk {
-                    id: "ln:q",
+                    id: "ln:e",
                     hunk: SingleHunk {
                         hunk_header: None,
                         path: "uncommitted.txt",
@@ -1028,7 +1028,7 @@ fn uncommitted_files_disambiguate_between_themselves() -> anyhow::Result<()> {
             id: "kpo",
             hunks: NonEmpty {
                 head: IdAndHunk {
-                    id: "kpo:q",
+                    id: "kpo:e",
                     hunk: SingleHunk {
                         hunk_header: None,
                         path: "foo242",
@@ -1046,7 +1046,7 @@ fn uncommitted_files_disambiguate_between_themselves() -> anyhow::Result<()> {
             id: "kpr",
             hunks: NonEmpty {
                 head: IdAndHunk {
-                    id: "kpr:q",
+                    id: "kpr:e",
                     hunk: SingleHunk {
                         hunk_header: None,
                         path: "foo23",
@@ -1075,7 +1075,7 @@ fn uncommitted_files_disambiguate_between_themselves() -> anyhow::Result<()> {
             id: "kpo",
             hunks: NonEmpty {
                 head: IdAndHunk {
-                    id: "kpo:q",
+                    id: "kpo:e",
                     hunk: SingleHunk {
                         hunk_header: None,
                         path: "foo242",
@@ -1103,7 +1103,7 @@ fn uncommitted_files_disambiguate_between_themselves() -> anyhow::Result<()> {
             id: "kpr",
             hunks: NonEmpty {
                 head: IdAndHunk {
-                    id: "kpr:q",
+                    id: "kpr:e",
                     hunk: SingleHunk {
                         hunk_header: None,
                         path: "foo23",
@@ -1496,7 +1496,7 @@ fn uncommitted_files_disambiguate_with_branch() -> anyhow::Result<()> {
             id: "qsy",
             hunks: NonEmpty {
                 head: IdAndHunk {
-                    id: "qsy:q",
+                    id: "qsy:e",
                     hunk: SingleHunk {
                         hunk_header: None,
                         path: "file",
@@ -1550,7 +1550,7 @@ fn longer_id_is_ok() -> anyhow::Result<()> {
             id: "kp",
             hunks: NonEmpty {
                 head: IdAndHunk {
-                    id: "kp:q",
+                    id: "kp:e",
                     hunk: SingleHunk {
                         hunk_header: None,
                         path: "foo23",
@@ -1604,7 +1604,7 @@ fn reverse_hex_filename_is_its_own_id() -> anyhow::Result<()> {
             id: "kl",
             hunks: NonEmpty {
                 head: IdAndHunk {
-                    id: "kl:q",
+                    id: "kl:e",
                     hunk: SingleHunk {
                         hunk_header: None,
                         path: "klmxyz",
@@ -1667,7 +1667,7 @@ fn branch_and_file_by_name() -> anyhow::Result<()> {
             id: "zo",
             hunks: NonEmpty {
                 head: IdAndHunk {
-                    id: "zo:q",
+                    id: "zo:e",
                     hunk: SingleHunk {
                         hunk_header: None,
                         path: "foo",
@@ -1720,7 +1720,7 @@ fn colon_uncommitted_filename() -> anyhow::Result<()> {
             id: "nv",
             hunks: NonEmpty {
                 head: IdAndHunk {
-                    id: "nv:q",
+                    id: "nv:e",
                     hunk: SingleHunk {
                         hunk_header: None,
                         path: "assigned",
@@ -1750,7 +1750,7 @@ fn colon_uncommitted_filename() -> anyhow::Result<()> {
             id: "nv",
             hunks: NonEmpty {
                 head: IdAndHunk {
-                    id: "nv:q",
+                    id: "nv:e",
                     hunk: SingleHunk {
                         hunk_header: None,
                         path: "assigned",
@@ -1780,7 +1780,7 @@ fn colon_uncommitted_filename() -> anyhow::Result<()> {
             id: "pv",
             hunks: NonEmpty {
                 head: IdAndHunk {
-                    id: "pv:q",
+                    id: "pv:e",
                     hunk: SingleHunk {
                         hunk_header: None,
                         path: "uncommitted",
@@ -1829,7 +1829,7 @@ fn uncommitted_path() -> anyhow::Result<()> {
         id: "prefix/",
         hunks: NonEmpty {
             head: IdAndHunk {
-                id: "yz:q",
+                id: "yz:e",
                 hunk: SingleHunk {
                     hunk_header: None,
                     path: "prefix/a",
@@ -1838,7 +1838,7 @@ fn uncommitted_path() -> anyhow::Result<()> {
             },
             tail: [
                 IdAndHunk {
-                    id: "uo:q",
+                    id: "uo:e",
                     hunk: SingleHunk {
                         hunk_header: None,
                         path: "prefix/b",
@@ -2066,7 +2066,7 @@ fn short_uncommitted_files_are_properly_reverse_hexed() -> anyhow::Result<()> {
             id: "ky",
             hunks: NonEmpty {
                 head: IdAndHunk {
-                    id: "ky:q",
+                    id: "ky:e",
                     hunk: SingleHunk {
                         hunk_header: None,
                         path: "k",
@@ -2095,7 +2095,7 @@ fn short_uncommitted_files_are_properly_reverse_hexed() -> anyhow::Result<()> {
             id: "klx",
             hunks: NonEmpty {
                 head: IdAndHunk {
-                    id: "klx:q",
+                    id: "klx:e",
                     hunk: SingleHunk {
                         hunk_header: None,
                         path: "kl",
@@ -2124,7 +2124,7 @@ fn short_uncommitted_files_are_properly_reverse_hexed() -> anyhow::Result<()> {
             id: "klml",
             hunks: NonEmpty {
                 head: IdAndHunk {
-                    id: "klml:q",
+                    id: "klml:e",
                     hunk: SingleHunk {
                         hunk_header: None,
                         path: "klm",
@@ -2182,10 +2182,10 @@ fn uncommitted_hunks_by_numeric_index() -> anyhow::Result<()> {
 [
     UncommittedHunkOrFile(
         UncommittedHunkOrFile {
-            id: "ro:q#0-2",
+            id: "ro:e#0-2",
             hunks: NonEmpty {
                 head: IdAndHunk {
-                    id: "ro:q#0-2",
+                    id: "ro:e#0-2",
                     hunk: SingleHunk {
                         hunk_header: Some(
                             HunkHeader("-1,2", "+1,2"),
@@ -2213,10 +2213,10 @@ fn uncommitted_hunks_by_numeric_index() -> anyhow::Result<()> {
 [
     UncommittedHunkOrFile(
         UncommittedHunkOrFile {
-            id: "ro:q#0-2",
+            id: "ro:e#0-2",
             hunks: NonEmpty {
                 head: IdAndHunk {
-                    id: "ro:q#0-2",
+                    id: "ro:e#0-2",
                     hunk: SingleHunk {
                         hunk_header: Some(
                             HunkHeader("-1,2", "+1,2"),
@@ -2244,10 +2244,10 @@ fn uncommitted_hunks_by_numeric_index() -> anyhow::Result<()> {
 [
     UncommittedHunkOrFile(
         UncommittedHunkOrFile {
-            id: "ro:q#0-2",
+            id: "ro:e#0-2",
             hunks: NonEmpty {
                 head: IdAndHunk {
-                    id: "ro:q#0-2",
+                    id: "ro:e#0-2",
                     hunk: SingleHunk {
                         hunk_header: Some(
                             HunkHeader("-1,2", "+1,2"),
@@ -2427,16 +2427,16 @@ fn uncommitted_hunks_by_id() -> anyhow::Result<()> {
     // hunk without diff gets q identifier
     snapbox::assert_data_eq!(
         id_map
-            .parse("hunk_without_diff.txt:q", &TestChanges(changed_paths_fn))?
+            .parse("hunk_without_diff.txt:e", &TestChanges(changed_paths_fn))?
             .to_debug(),
         snapbox::str![[r#"
 [
     UncommittedHunkOrFile(
         UncommittedHunkOrFile {
-            id: "wp:q",
+            id: "wp:e",
             hunks: NonEmpty {
                 head: IdAndHunk {
-                    id: "wp:q",
+                    id: "wp:e",
                     hunk: SingleHunk {
                         hunk_header: None,
                         path: "hunk_without_diff.txt",
@@ -3351,7 +3351,7 @@ fn uncommitted_selector_is_not_shadowed_by_commit_change_id() -> anyhow::Result<
 
     // Hunk selectors under the file keep working too.
     let hunk =
-        id_map.parse_uncommitted(&format!("{file_id}:q"), &TestChanges(changed_paths_fn()))?;
+        id_map.parse_uncommitted(&format!("{file_id}:e"), &TestChanges(changed_paths_fn()))?;
     assert!(
         matches!(hunk.as_slice(), [CliId::UncommittedHunkOrFile(_)]),
         "hunk selector resolves in the scoped namespace: {hunk:?}"
@@ -3359,14 +3359,14 @@ fn uncommitted_selector_is_not_shadowed_by_commit_change_id() -> anyhow::Result<
 
     let tmp = tempfile::TempDir::new()?;
     let repo = gix::init(tmp.path())?;
-    let resolved = CliIdArg(format!("{file_id}:q"))
+    let resolved = CliIdArg(format!("{file_id}:e"))
         .try_resolve_uncommitted(&repo, &id_map)
         .expect("selector resolution succeeds")
         .expect("the issued hunk selector still resolves");
     assert_eq!(resolved.len(), 1, "exactly one hunk resolves");
     assert_eq!(resolved[0].hunks.first().hunk.path, "README.md");
 
-    let resolved = CliIdArg(format!("{file_id}:q"))
+    let resolved = CliIdArg(format!("{file_id}:e"))
         .resolve_in_workspace(
             &repo,
             &id_map,

--- a/crates/but/tests/but/command/diff.rs
+++ b/crates/but/tests/but/command/diff.rs
@@ -95,6 +95,133 @@ fn path_prefix() {
 "#]]);
 }
 
+/// Diff committed and uncommitted using AI_AGENT output that forces more characters in short IDs.
+#[test]
+fn diff_different_changes_with_agent_output() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
+
+    env.file("to-modify.txt", "initial\n");
+    env.file("to-rename.txt", "renamed\n");
+    env.file("to-delete.txt", "deleted\n");
+    env.but("commit -m 'Add files to modify'")
+        .assert()
+        .success();
+
+    env.but("status -f")
+        .env("AI_AGENT", "test-agent")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+╭┄ @ [uncommitted] (no changes)
+┊
+┊╭┄ br [a-branch-1]
+┊●   txl Add files to modify
+┊│     txl:usv A to-delete.txt
+┊│     txl:lou A to-modify.txt
+┊│     txl:ztt A to-rename.txt
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: commits are listed newest first. The first token on each line is the ID to use in commands.
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.file("to-modify.txt", "modified\n");
+    env.rename_file("to-rename.txt", "renamed.txt");
+    env.remove_file("to-delete.txt");
+    env.file("added.txt", "added\n");
+
+    // uncommitted output
+    env.but("diff @")
+        .env("AI_AGENT", "test-agent")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+───────────────────╮
+ nxx:213 added.txt │
+───────────────────╯
+
+@@ -1,0 +1,1 @@
+───────────────
+  ┊ 1 │ +added
+
+─────────────────────╮
+ szk:emp renamed.txt │
+─────────────────────╯
+
+No diff available - file is either empty, binary, or too large
+
+───────────────────────╮
+ usv:0a5 to-delete.txt │
+───────────────────────╯
+
+@@ -1,1 +1,0 @@
+───────────────
+1 ┊   │ -deleted
+
+───────────────────────╮
+ lou:b28 to-modify.txt │
+───────────────────────╯
+
+@@ -1,1 +1,1 @@
+───────────────
+1 ┊   │ -initial
+  ┊ 1 │ +modified
+
+"#]]);
+
+    env.but("commit -m 'Add, delete and rename files'")
+        .env("AI_AGENT", "test-agent")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+Created commit vxw on branch 'a-branch-1'
+
+"#]]);
+
+    // committed output
+    env.but("diff vxw")
+        .env("AI_AGENT", "test-agent")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+───────────────────────╮
+ vxw:nxx:213 added.txt │
+───────────────────────╯
+
+@@ -1,0 +1,1 @@
+───────────────
+  ┊ 1 │ +added
+
+─────────────────────────╮
+ vxw:szk:emp renamed.txt │
+─────────────────────────╯
+
+No diff available - file is either empty, binary, or too large
+
+───────────────────────────╮
+ vxw:usv:0a5 to-delete.txt │
+───────────────────────────╯
+
+@@ -1,1 +1,0 @@
+───────────────
+1 ┊   │ -deleted
+
+───────────────────────────╮
+ vxw:lou:b28 to-modify.txt │
+───────────────────────────╯
+
+@@ -1,1 +1,1 @@
+───────────────
+1 ┊   │ -initial
+  ┊ 1 │ +modified
+
+"#]]);
+}
+
 #[test]
 fn worktree() {
     let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");

--- a/crates/but/tests/but/command/discard.rs
+++ b/crates/but/tests/but/command/discard.rs
@@ -1063,7 +1063,7 @@ Hint: run `but help` for all commands
         .success()
         .stdout_eq(snapbox::str![[r#"
 ─────────────────────────╮
- xl:q:q renamed_file.txt │
+ xl:q:e renamed_file.txt │
 ─────────────────────────╯
 
 No diff available - file is either empty, binary, or too large
@@ -1111,14 +1111,14 @@ Hint: run `but help` for all commands
         .success()
         .stdout_eq(snapbox::str![[r#"
 ─────────╮
- y:p:q B │
+ y:p:e B │
 ─────────╯
 
 No diff available - file is either empty, binary, or too large
 
 "#]]);
 
-    env.but("discard ylp:p:q")
+    env.but("discard ylp:p:e")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"

--- a/crates/but/tests/but/command/expand.rs
+++ b/crates/but/tests/but/command/expand.rs
@@ -293,7 +293,7 @@ fn resolves_binary_committed_hunk() {
         .success()
         .stdout_eq(snapbox::str![[r#"
 ────────────────╮
- nx:q image.png │
+ nx:e image.png │
 ────────────────╯
 
 No diff available - file is either empty, binary, or too large
@@ -312,9 +312,8 @@ Created commit nul on new branch 'a-branch-1'
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Matches: 1
+Matches: 0
 
-committed hunk: 673f0a6533ac3929ad467b4f7a0b935853775963 image.png <no hunk header>
 
 "#]]);
 }

--- a/crates/but/tests/but/command/expand.rs
+++ b/crates/but/tests/but/command/expand.rs
@@ -308,12 +308,13 @@ Created commit nul on new branch 'a-branch-1'
 
 "#]]);
 
-    env.but("_expand nul:nx:q")
+    env.but("_expand nul:nx:e")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
-Matches: 0
+Matches: 1
 
+committed hunk: 673f0a6533ac3929ad467b4f7a0b935853775963 image.png <no hunk header>
 
 "#]]);
 }


### PR DESCRIPTION
Agents do better with more stable IDs. When we make the IDs as short as possible to make them easier for humans to type, we shoot agents in the foot as they have trouble correlating IDs or even figuring out that a single-character thing is an ID in the first place.

This PR adds a little hack to force short IDs to be at least 3 characters if an agent is detected. It only affects IDs that are prefix-based, that is to say, IDs where the short ID is a prefix of the full ID. It's safe to lengthen these arbitrarily without affecting any functionality as the actual lookup is performed via a prefix check on the full ID - the short ID is not actually part of it.

For non-prefix based short IDs, branches in particular, we can't safely do this as changing the length of the short ID effectively makes it a _different_ ID.

We can do away with this hack when we've found a good structure for storing short IDs hierarchically with sufficient information to tweak the exact look of them during rendering. That's a relatively big task, so for now this hack will have to do.

I'm committing some software design crimes here. I'll be the one paying for them so that's probably fine :D