### PR TITLE
Skip object database lookups for the null id when diffing

### DIFF
--- a/crates/but-core/src/unified_diff.rs
+++ b/crates/but-core/src/unified_diff.rs
@@ -132,7 +132,7 @@ impl UnifiedPatch {
             ),
             path.as_bstr(),
             ResourceKind::NewOrDestination,
-            repo,
+            &NullIdIsMissing(repo),
         ) {
             Ok(()) => {}
             Err(
@@ -157,7 +157,7 @@ impl UnifiedPatch {
             ),
             actual_previous_path,
             ResourceKind::OldOrSource,
-            repo,
+            &NullIdIsMissing(repo),
         ) {
             Ok(()) => {}
             Err(
@@ -274,6 +274,37 @@ fn detect_and_convert_to_utf8(content: BString) -> BString {
 
 fn compute_line_changes(diff: &gix::diff::blob::Diff) -> (u32, u32) {
     (diff.count_additions(), diff.count_removals())
+}
+
+/// Worktree-side resources are handed to the diff platform with the null id. The end-of-line
+/// filter still asks the object database for that id to compare against the index version,
+/// and every such miss makes the database rescan its pack directory. Answer null ids here
+/// so the object database is never consulted for them.
+struct NullIdIsMissing<'a>(&'a gix::Repository);
+
+impl gix::objs::Find for NullIdIsMissing<'_> {
+    fn try_find<'a>(
+        &self,
+        id: &gix::oid,
+        buffer: &'a mut Vec<u8>,
+    ) -> Result<Option<gix::objs::Data<'a>>, gix::objs::find::Error> {
+        if id.is_null() {
+            return Ok(None);
+        }
+        gix::objs::Find::try_find(self.0, id, buffer)
+    }
+}
+
+impl gix::objs::FindHeader for NullIdIsMissing<'_> {
+    fn try_header(
+        &self,
+        id: &gix::oid,
+    ) -> Result<Option<gix::objs::Header>, gix::objs::find::Error> {
+        if id.is_null() {
+            return Ok(None);
+        }
+        gix::objs::FindHeader::try_header(self.0, id)
+    }
 }
 
 /// Produce a filter from `repo` and `state` using `mode` that is able to perform diffs of `state`.


### PR DESCRIPTION
## The performance story

`but status` took **5.4 seconds** in a sandbox clone of this repository with ~240 changed files, while `git status` took 0.09s in the same checkout. Sampling the process showed 85% of wall time inside `gix_odb::Store::consolidate_with_disk_state`: readdir plus a `stat()` of every file in `.git/objects/pack`, repeated once per changed file. That checkout has 555 packs, so each rescan touched ~1900 files.

The chain that gets there:

1. but-core hands the diff platform the **null id** for worktree-side resources (`filter_from_state` only sets `new_root` when the id is null).
2. With `core.autocrlf=input` (or a `text=auto` attribute), gix's end-of-line filter runs in auto-text mode and asks the object database for the index version of the file, using that id, to decide whether CRLF conversion is safe.
3. A null id can never be found. After all pack indices are loaded, a miss under the default `RefreshMode::AfterAllIndicesLoaded` makes gix rescan the pack directory in case a new pack appeared.

So the cost is roughly `changed files × pack files` in `stat()` calls, all system time, and it scales with how fragmented the object store is. `core.autocrlf=input` is a common global setting on macOS and Linux, so this is not specific to the sandbox.

## The fix

`compute_with_filter` now wraps the repository in a small `Find`/`FindHeader` shim that answers null ids with "not found" without consulting the object database. Every other lookup passes through unchanged. The desktop app's worktree diffs share this code path, so it benefits as well.

The proper long-term fix belongs in gix-diff's `convert_to_diffable`, which should skip the lookup when the id is null; this shim is harmless to keep either way.

## Benchmark

Sandbox: gitbutler clone, 555 packs, 1852 refs, 238 uncommitted files, `core.autocrlf=input`. Debug build, warm cache, best of three.

| `but status --json` | real | user | sys |
|---|---|---|---|
| before | 5.41s | 0.70s | 2.39s |
| after | 0.41s | 0.23s | 0.22s |

Output is byte-identical before and after. What remains is graph traversal over the sandbox's 36k commits and ordinary diffing.