### PR TITLE
Treat unrecognized forges as terminal review-listing state

### DIFF
--- a/apps/desktop/src/lib/branches/branchEndpoints.ts
+++ b/apps/desktop/src/lib/branches/branchEndpoints.ts
@@ -51,6 +51,9 @@ export function buildBranchEndpoints(build: BackendEndpointBuilder) {
 			query: (args) => args,
 			invalidatesTags: [
 				invalidatesType(ReduxTag.ForgeProvider),
+				// The review listing follows the target remote: a stopped
+				// (unrecognized-forge) listing must retry once it changes.
+				invalidatesList(ReduxTag.PullRequests),
 				invalidatesType(ReduxTag.BaseBranchData),
 				invalidatesList(ReduxTag.Stacks),
 				invalidatesList(ReduxTag.StackDetails),
@@ -66,6 +69,7 @@ export function buildBranchEndpoints(build: BackendEndpointBuilder) {
 			query: (args) => args,
 			invalidatesTags: [
 				invalidatesType(ReduxTag.ForgeProvider),
+				invalidatesList(ReduxTag.PullRequests),
 				invalidatesType(ReduxTag.BaseBranchData),
 				invalidatesList(ReduxTag.Stacks),
 				invalidatesList(ReduxTag.StackDetails),

--- a/apps/desktop/src/lib/error/errorClassification.test.ts
+++ b/apps/desktop/src/lib/error/errorClassification.test.ts
@@ -104,6 +104,23 @@ describe("classify", () => {
 			expect(result.severity).toBe("warning");
 			expect(result.userMessage).toContain("credentials");
 		});
+
+		test("ForgeUnrecognized is a terminal warning with guidance, not silence", () => {
+			// `list_reviews` tags a target remote that maps to no supported forge.
+			// Pollers must stop on it, while an explicit Sync still gets told why.
+			const error = new IpcError(
+				{
+					message: "No forge could be determined for this repository branch",
+					code: "ForgeUnrecognized",
+				},
+				"list_reviews",
+			);
+			const result = classify(error);
+			expect(result.severity).toBe("warning");
+			expect(result.terminal).toBe(true);
+			expect(result.message).toBe("No forge could be determined for this repository branch");
+			expect(result.userMessage).toContain("target branch");
+		});
 	});
 
 	describe("severity: error with userMessage", () => {

--- a/apps/desktop/src/lib/error/errorClassification.ts
+++ b/apps/desktop/src/lib/error/errorClassification.ts
@@ -237,6 +237,17 @@ GitHub could not access this repository or part of it (for example CI checks). C
 		userMessage:
 			"You are not logged in to your forge. Connect your account under Settings → Integrations to work with pull requests.",
 	},
+	/**
+	 * The target remote maps to no supported forge, so `list_reviews` has
+	 * nothing to poll. Terminal until the target or remote changes; not
+	 * silent, so an explicit Sync still explains why nothing was listed.
+	 */
+	ForgeUnrecognized: {
+		severity: "warning",
+		terminal: true,
+		userMessage:
+			"The target branch's remote isn't a GitHub, GitLab, or Bitbucket repository GitButler recognizes, so pull requests can't be listed. Pick a target branch on a supported remote in the project settings.",
+	},
 	ProjectDatabaseIncompatible: {
 		severity: "error",
 		userMessage: `

--- a/apps/desktop/src/routes/[projectId]/projectLayout.svelte.test.ts
+++ b/apps/desktop/src/routes/[projectId]/projectLayout.svelte.test.ts
@@ -1,6 +1,7 @@
 import ProjectLayout from "./+layout.svelte";
 import { BACKEND } from "$lib/backend";
 import { BASE_BRANCH_SERVICE } from "$lib/baseBranch/baseBranchService.svelte";
+import { buildBranchEndpoints } from "$lib/branches/branchEndpoints";
 import { BRANCH_SERVICE } from "$lib/branches/branchService.svelte";
 import { FORGE_INFO_SERVICE } from "$lib/forge/forgeInfo.svelte";
 import { GITLAB_USER_SERVICE } from "$lib/forge/gitlab/gitlabUserService.svelte";
@@ -81,6 +82,15 @@ const nonterminalError = {
 		code: "Unknown" as const,
 	},
 };
+// What `list_reviews` returns when the target remote maps to no supported forge.
+const unrecognizedForgeError = {
+	error: {
+		origin: "ipc" as const,
+		name: "API error: (list_reviews)",
+		message: "No forge could be determined for this repository branch",
+		code: "ForgeUnrecognized" as const,
+	},
+};
 
 class ReactiveStoreState {
 	root = $state.raw<any>();
@@ -102,7 +112,11 @@ function query(response?: unknown) {
 	};
 }
 
-type Response = typeof success | typeof terminalError | typeof nonterminalError;
+type Response =
+	| typeof success
+	| typeof terminalError
+	| typeof nonterminalError
+	| typeof unrecognizedForgeError;
 
 function setup(
 	responses: Array<Response | Promise<Response>>,
@@ -123,7 +137,12 @@ function setup(
 	)({
 		reducerPath: "backend",
 		tagTypes: Object.values(ReduxTag),
-		baseQuery: async () => await responses[Math.min(calls++, responses.length - 1)]!,
+		// Only `list_reviews` consumes scripted responses; other commands
+		// (e.g. `set_base_branch`) succeed without counting as a call.
+		baseQuery: async (_args: unknown, _api: unknown, extra: any) =>
+			extra?.command === "list_reviews"
+				? await responses[Math.min(calls++, responses.length - 1)]!
+				: { data: null },
 		endpoints: () => ({}),
 	});
 	const store = configureStore({
@@ -135,6 +154,7 @@ function setup(
 	storeRef.state = storeState;
 	const listingService =
 		listingServiceOverride ?? new ListingService(api as never, store.dispatch as never);
+	api.injectEndpoints({ endpoints: (build) => buildBranchEndpoints(build as never) });
 	const forgeInfo = { capabilities: { listService: true } };
 	function noop() {}
 	async function asyncNoop() {}
@@ -311,6 +331,42 @@ describe("project review-list polling", () => {
 			"project-b",
 			POLL_INTERVAL,
 		]);
+		harness.rendered.unmount();
+		harness.storeState.unsubscribe();
+	});
+
+	test("stops polling an unrecognized forge until a supported target retries", async () => {
+		vi.useFakeTimers();
+		const responses: Response[] = [unrecognizedForgeError];
+		const harness = setup(responses);
+		await settle();
+		expect(harness.calls).toBe(1);
+
+		// The poll owner re-subscribes once while it drops the interval to 0;
+		// from then on no interval request may be scheduled.
+		await vi.advanceTimersByTimeAsync(POLL_INTERVAL);
+		await settle();
+		const converged = harness.calls;
+		expect(converged).toBeLessThanOrEqual(2);
+		await vi.advanceTimersByTimeAsync(POLL_INTERVAL * 2);
+		expect(harness.calls, "unrecognized forge kept scheduling interval requests").toBe(converged);
+
+		// Re-targeting onto a supported remote retries immediately.
+		responses.splice(0, responses.length, success);
+		await harness.store.dispatch(
+			(harness.api.endpoints as any).setTarget.initiate({
+				projectId: PROJECT_ID,
+				branch: "origin/main",
+			}),
+		);
+		await settle();
+		expect(harness.calls, "target change did not retry the listing").toBe(converged + 1);
+		const listed = (harness.api.endpoints as any).listPrs.select(PROJECT_ID)(
+			harness.store.getState(),
+		);
+		expect(listed.isError).toBe(false);
+		expect(listed.data.ids).toEqual(["topic"]);
+
 		harness.rendered.unmount();
 		harness.storeState.unsubscribe();
 	});

--- a/crates/but-api/src/legacy/forge.rs
+++ b/crates/but-api/src/legacy/forge.rs
@@ -294,9 +294,15 @@ pub fn list_reviews(
 
     let db = &mut *ctx.db.get_cache_mut()?;
 
+    // Typed so the desktop can treat an unrecognized forge as an expected,
+    // terminal listing state instead of retrying it on a timer.
+    let forge_repo_info = forge_repo_info.context(but_error::Context::new_static(
+        but_error::Code::ForgeUnrecognized,
+        "No forge could be determined for this repository branch",
+    ))?;
     but_forge::list_forge_reviews_with_cache(
         preferred_forge_user,
-        &forge_repo_info.context("No forge could be determined for this repository branch")?,
+        &forge_repo_info,
         &storage,
         db,
         cache_config,

--- a/crates/but-api/tests/api/forge_info.rs
+++ b/crates/but-api/tests/api/forge_info.rs
@@ -53,3 +53,49 @@ fn forge_state_follows_target_initialization() -> Result<()> {
     );
     Ok(())
 }
+
+#[test]
+fn list_reviews_reports_an_unrecognized_forge_as_a_typed_state() -> Result<()> {
+    use but_api::legacy::forge::list_reviews;
+    use but_error::AnyhowContextExt as _;
+
+    let (repo, tmp) = crate::support::repo_with_feature_branch()?;
+    drop(repo);
+    git_at_dir(tmp.path())
+        .args([
+            "config",
+            "remote.origin.url",
+            "https://git.example.com/acme/widgets.git",
+        ])
+        .run();
+    let mut ctx =
+        but_ctx::Context::from_repo_for_testing(open_repo(tmp.path())?)?.with_memory_app_cache();
+    let target_ref = gix::refs::FullName::try_from("refs/remotes/origin/main")?;
+    but_api::workspace::set_target_ref_and_init_project(&mut ctx, target_ref.as_ref(), None)?;
+    assert!(
+        forge_info(&ctx)?.is_none(),
+        "the capability gate agrees that no forge is recognized"
+    );
+
+    // The stale-cache fallback must not turn a missing forge identity into
+    // "outage, serve the last listing": there is no forge to be stale about.
+    for cache_config in [
+        None,
+        Some(but_forge::CacheConfig::CacheWithFallback {
+            max_age_seconds: 300,
+        }),
+    ] {
+        let err = list_reviews(&ctx, cache_config).expect_err("no forge, no listing");
+        assert_eq!(
+            err.to_string(),
+            "No forge could be determined for this repository branch",
+            "the message the CLI and Lite print stays the same"
+        );
+        assert_eq!(
+            err.custom_context_or_error_chain().code.to_string(),
+            "ForgeUnrecognized",
+            "the wire code lets the desktop treat this as an expected, terminal state"
+        );
+    }
+    Ok(())
+}

--- a/crates/but-error/src/lib.rs
+++ b/crates/but-error/src/lib.rs
@@ -202,6 +202,9 @@ pub enum Code {
     /// (bad client credentials or device code, unsupported grant type, the
     /// device flow being disabled for the app). Retrying the same code won't help.
     GitHubDeviceFlowRejected,
+    /// The target remote maps to no supported forge, so there is nothing to
+    /// list reviews from. Terminal until the target or remote changes.
+    ForgeUnrecognized,
     /// The operation was rejected because the current state doesn't allow it.
     /// Not a bug — the user's request simply can't be fulfilled right now.
     /// The frontend should present this as a warning rather than an error.

--- a/packages/but-sdk/src/generated/graph/index.d.ts
+++ b/packages/but-sdk/src/generated/graph/index.d.ts
@@ -29,7 +29,7 @@ export declare function absorptionPlan(projectId: string, target: AbsorptionTarg
 /**
  * Add the caller's reaction to one comment.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:857}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:863}
  */
 export declare function addCommentReaction(projectId: string, commentId: number, kind: string): Promise<ForgeReviewReaction>
 
@@ -44,14 +44,14 @@ export declare function addProject(path: string): Promise<AddProjectOutcome>
 /**
  * Add labels to a review; returns the resulting label set.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:985}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:991}
  */
 export declare function addReviewLabels(projectId: string, reviewId: number, labels: Array<string>): Promise<Array<ForgeReviewLabel>>
 
 /**
  * Add the caller's reaction to a review itself.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:819}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:825}
  */
 export declare function addReviewReaction(projectId: string, reviewId: number, kind: string): Promise<ForgeReviewReaction>
 
@@ -577,14 +577,14 @@ export declare function commitUncommitChangesFromCommits(projectId: string, sour
 /**
  * Post a top-level conversation comment on a review.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1071}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1077}
  */
 export declare function createReviewComment(projectId: string, reviewId: number, body: string): Promise<ForgeReviewComment>
 
 /**
  * Reply into one of a review's diff-anchored comment threads.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:771}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:777}
  */
 export declare function createReviewThreadReply(projectId: string, threadId: string, body: string): Promise<ForgeReviewThreadComment>
 
@@ -592,7 +592,7 @@ export declare function createReviewThreadReply(projectId: string, threadId: str
  * The login this project's forge calls authenticate as, if any account is
  * configured. Resolved from stored accounts; no network.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:958}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:964}
  */
 export declare function currentForgeLogin(projectId: string): Promise<string | null>
 
@@ -609,7 +609,7 @@ export declare function deleteProject(projectId: ProjectHandleOrLegacyProjectId)
 /**
  * Delete a top-level conversation comment on a review.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:943}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:949}
  */
 export declare function deleteReviewComment(projectId: string, commentId: number): Promise<void>
 
@@ -836,22 +836,22 @@ export declare function getLoginToken(): Promise<LoginToken>
 export declare function getRedoTargetSnapshot(projectId: string): Promise<Snapshot | null>
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1126}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1132}
  */
 export declare function getRepoInfo(projectId: string): Promise<RepoInfo>
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1100}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1106}
  */
 export declare function getReview(projectId: string, reviewId: number): Promise<ForgeReview>
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:730}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:736}
  */
 export declare function getReviewBaseRepoUrl(projectId: string, reviewId: number): Promise<string | null>
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1089}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1095}
  */
 export declare function getReviewMergeStatus(projectId: string, reviewId: number): Promise<ReviewMergeStatus>
 
@@ -959,14 +959,14 @@ export declare function listAvailableReviewTemplates(projectId: string): Promise
 export declare function listBranches(projectId: string, filter: BranchListingFilter | null): Promise<Array<BranchListing>>
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1149}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1155}
  */
 export declare function listCiChecks(projectId: string, reference: string, cacheConfig: CacheConfig | null): Promise<Array<CiCheck>>
 
 /**
  * List the individual reactions (with who reacted) on one comment.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:802}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:808}
  */
 export declare function listCommentReactions(projectId: string, commentId: number): Promise<Array<ForgeReviewReaction>>
 
@@ -1034,28 +1034,28 @@ export declare function listProjectsStateless(): Promise<Array<ProjectForFronten
 /**
  * List the labels defined on the repository backing this project's reviews.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:977}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:983}
  */
 export declare function listRepoLabels(projectId: string): Promise<Array<ForgeReviewLabel>>
 
 /**
  * List the top-level conversation comments on a review, oldest first.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:747}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:753}
  */
 export declare function listReviewComments(projectId: string, reviewId: number): Promise<Array<ForgeReviewComment>>
 
 /**
  * List users who can be requested to review on this project's repository.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1023}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1029}
  */
 export declare function listReviewerCandidates(projectId: string): Promise<Array<ForgeReviewUser>>
 
 /**
  * List the individual reactions (with who reacted) on a review itself.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:790}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:796}
  */
 export declare function listReviewReactions(projectId: string, reviewId: number): Promise<Array<ForgeReviewReaction>>
 
@@ -1065,28 +1065,28 @@ export declare function listReviewReactions(projectId: string, reviewId: number)
 export declare function listReviews(projectId: string, cacheConfig: CacheConfig | null): Promise<Array<ForgeReview>>
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:2134}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:2140}
  */
 export declare function listReviewsForBranch(projectId: string, branch: string, filter: ForgeReviewFilter | null): Promise<Array<ForgeReview>>
 
 /**
  * List the submitted reviews (approvals, change requests) on a review.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:912}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:918}
  */
 export declare function listReviewSubmissions(projectId: string, reviewId: number): Promise<Array<ForgeReviewSubmission>>
 
 /**
  * List the diff-anchored comment threads on a review, oldest first.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:759}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:765}
  */
 export declare function listReviewThreads(projectId: string, reviewId: number): Promise<Array<ForgeReviewThread>>
 
 /**
  * List the pushed commits and review requests on a review's timeline.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:895}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:901}
  */
 export declare function listReviewTimelineEvents(projectId: string, reviewId: number): Promise<Array<ForgeReviewTimelineEvent>>
 
@@ -1119,7 +1119,7 @@ export declare function loginAndPersist(token: string): Promise<UserProfile>
 /**
  * Merge a review on the forge.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1308}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1314}
  */
 export declare function mergeReview(projectId: string, reviewId: number, mergeMethod: ReviewMergeMethod | null): Promise<void>
 
@@ -1244,7 +1244,7 @@ export declare const enum ProgramCategory {
 }
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1187}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1193}
  */
 export declare function publishReview(projectId: string, params: PublishReviewInput): Promise<PublishReviewOutcome>
 
@@ -1264,28 +1264,28 @@ export declare function removeBranch(projectId: string, stackId: string, branchN
 /**
  * Remove one of the caller's reactions from one comment.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:876}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:882}
  */
 export declare function removeCommentReaction(projectId: string, commentId: number, reactionId: number): Promise<void>
 
 /**
  * Remove one label from a review.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1004}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1010}
  */
 export declare function removeReviewLabel(projectId: string, reviewId: number, label: string): Promise<void>
 
 /**
  * Remove one of the caller's reactions from a review itself.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:838}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:844}
  */
 export declare function removeReviewReaction(projectId: string, reviewId: number, reactionId: number): Promise<void>
 
 /**
  * Request reviews from the given users on a review.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1033}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1039}
  */
 export declare function requestReview(projectId: string, reviewId: number, logins: Array<string>): Promise<void>
 
@@ -1338,7 +1338,7 @@ export declare function restoreSnapshotWithKind(projectId: string, restoreKind: 
  * created remote, applies the fetched remote-tracking branch, and records the
  * review number on the applied branch metadata.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:311}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:317}
  */
 export declare function reviewApply(projectId: string, reviewId: number): Promise<ApplyOutcome>
 
@@ -1375,14 +1375,14 @@ export declare function setPushRemote(projectId: string, pushRemote: string): Pr
 /**
  * Enable or disable a review's auto-merge.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1328}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1334}
  */
 export declare function setReviewAutoMerge(projectId: string, reviewId: number, enable: boolean): Promise<void>
 
 /**
  * Set a review to draft or ready-for-review
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1348}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1354}
  */
 export declare function setReviewDraftiness(projectId: string, reviewId: number, draft: boolean): Promise<void>
 
@@ -1530,21 +1530,21 @@ export declare function updateProjectSettings(projectId: ProjectHandleOrLegacyPr
  * Update arbitrary fields of a single review (title, body, state, target base).
  * Each `None` leaves that field unchanged on the forge.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1380}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1386}
  */
 export declare function updateReview(projectId: string, reviewId: number, title: string | null, body: string | null, state: ReviewState | null, targetBase: string | null): Promise<void>
 
 /**
  * Edit a top-level conversation comment on a review.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:924}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:930}
  */
 export declare function updateReviewComment(projectId: string, commentId: number, body: string): Promise<ForgeReviewComment>
 
 /**
  * Update stacked reviews: description footers and, optionally, target branches.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1404}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1410}
  */
 export declare function updateReviewFooters(projectId: string, reviews: Array<ForgeReviewUpdate>): Promise<void>
 
@@ -1566,14 +1566,14 @@ export declare function uploadFile(params: UploadFileParams): Promise<Upload>
  * Additionally, it cleans up stale CI check entries for references that are no longer
  * part of any applied stack.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:2168}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:2174}
  */
 export declare function warmCiChecksCache(projectId: string): Promise<void>
 
 /**
  * Withdraw review requests for the given users on a review.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1052}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1058}
  */
 export declare function withdrawReviewRequest(projectId: string, reviewId: number, logins: Array<string>): Promise<void>
 
@@ -2387,7 +2387,7 @@ export type Claude = {
  *
  * In practice, it should match its [frontend counterpart](https://github.com/gitbutlerapp/gitbutler/blob/fa973fd8f1ae8807621f47601803d98b8a9cf348/app/src/lib/backend/ipc.ts#L5).
  */
-export type Code = "Validation" | "RepoOwnership" | "ProjectGitAuth" | "DefaultTargetNotFound" | "CommitSigningFailed" | "CommitMergeConflictFailure" | "ProjectMissing" | "AuthorMissing" | "BranchNotFound" | "SecretKeychainNotFound" | "MissingLoginKeychain" | "GitForcePushProtection" | "NetworkError" | "ProjectDatabaseIncompatible" | "DefaultTerminalNotFound" | "Unknown" | "GitNonFastForward" | "CliInstallCancelled" | "GitHubTokenExpired" | "GitLabUnauthorized" | "GitLabForbidden" | "GitHubOrgOAuthRestricted" | "GitHubOrgSamlRestricted" | "GitHubInsufficientPermissions" | "ForgeNotAuthenticated" | "GitHubDeviceCodeExpired" | "GitHubDeviceAccessDenied" | "GitHubDeviceFlowRejected" | "PreconditionFailed" | "EditorExitedWithNonZeroStatus";
+export type Code = "Validation" | "RepoOwnership" | "ProjectGitAuth" | "DefaultTargetNotFound" | "CommitSigningFailed" | "CommitMergeConflictFailure" | "ProjectMissing" | "AuthorMissing" | "BranchNotFound" | "SecretKeychainNotFound" | "MissingLoginKeychain" | "GitForcePushProtection" | "NetworkError" | "ProjectDatabaseIncompatible" | "DefaultTerminalNotFound" | "Unknown" | "GitNonFastForward" | "CliInstallCancelled" | "GitHubTokenExpired" | "GitLabUnauthorized" | "GitLabForbidden" | "GitHubOrgOAuthRestricted" | "GitHubOrgSamlRestricted" | "GitHubInsufficientPermissions" | "ForgeNotAuthenticated" | "GitHubDeviceCodeExpired" | "GitHubDeviceAccessDenied" | "GitHubDeviceFlowRejected" | "ForgeUnrecognized" | "PreconditionFailed" | "EditorExitedWithNonZeroStatus";
 
 /** Commit that is part of a legacy stack branch and contains state derived in relation to it. */
 export type Commit = {

--- a/packages/but-sdk/src/generated/linear/index.d.ts
+++ b/packages/but-sdk/src/generated/linear/index.d.ts
@@ -29,7 +29,7 @@ export declare function absorptionPlan(projectId: string, target: AbsorptionTarg
 /**
  * Add the caller's reaction to one comment.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:857}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:863}
  */
 export declare function addCommentReaction(projectId: string, commentId: number, kind: string): Promise<ForgeReviewReaction>
 
@@ -44,14 +44,14 @@ export declare function addProject(path: string): Promise<AddProjectOutcome>
 /**
  * Add labels to a review; returns the resulting label set.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:985}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:991}
  */
 export declare function addReviewLabels(projectId: string, reviewId: number, labels: Array<string>): Promise<Array<ForgeReviewLabel>>
 
 /**
  * Add the caller's reaction to a review itself.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:819}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:825}
  */
 export declare function addReviewReaction(projectId: string, reviewId: number, kind: string): Promise<ForgeReviewReaction>
 
@@ -577,14 +577,14 @@ export declare function commitUncommitChangesFromCommits(projectId: string, sour
 /**
  * Post a top-level conversation comment on a review.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1071}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1077}
  */
 export declare function createReviewComment(projectId: string, reviewId: number, body: string): Promise<ForgeReviewComment>
 
 /**
  * Reply into one of a review's diff-anchored comment threads.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:771}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:777}
  */
 export declare function createReviewThreadReply(projectId: string, threadId: string, body: string): Promise<ForgeReviewThreadComment>
 
@@ -592,7 +592,7 @@ export declare function createReviewThreadReply(projectId: string, threadId: str
  * The login this project's forge calls authenticate as, if any account is
  * configured. Resolved from stored accounts; no network.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:958}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:964}
  */
 export declare function currentForgeLogin(projectId: string): Promise<string | null>
 
@@ -609,7 +609,7 @@ export declare function deleteProject(projectId: ProjectHandleOrLegacyProjectId)
 /**
  * Delete a top-level conversation comment on a review.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:943}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:949}
  */
 export declare function deleteReviewComment(projectId: string, commentId: number): Promise<void>
 
@@ -836,22 +836,22 @@ export declare function getLoginToken(): Promise<LoginToken>
 export declare function getRedoTargetSnapshot(projectId: string): Promise<Snapshot | null>
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1126}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1132}
  */
 export declare function getRepoInfo(projectId: string): Promise<RepoInfo>
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1100}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1106}
  */
 export declare function getReview(projectId: string, reviewId: number): Promise<ForgeReview>
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:730}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:736}
  */
 export declare function getReviewBaseRepoUrl(projectId: string, reviewId: number): Promise<string | null>
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1089}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1095}
  */
 export declare function getReviewMergeStatus(projectId: string, reviewId: number): Promise<ReviewMergeStatus>
 
@@ -959,14 +959,14 @@ export declare function listAvailableReviewTemplates(projectId: string): Promise
 export declare function listBranches(projectId: string, filter: BranchListingFilter | null): Promise<Array<BranchListing>>
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1149}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1155}
  */
 export declare function listCiChecks(projectId: string, reference: string, cacheConfig: CacheConfig | null): Promise<Array<CiCheck>>
 
 /**
  * List the individual reactions (with who reacted) on one comment.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:802}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:808}
  */
 export declare function listCommentReactions(projectId: string, commentId: number): Promise<Array<ForgeReviewReaction>>
 
@@ -1034,28 +1034,28 @@ export declare function listProjectsStateless(): Promise<Array<ProjectForFronten
 /**
  * List the labels defined on the repository backing this project's reviews.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:977}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:983}
  */
 export declare function listRepoLabels(projectId: string): Promise<Array<ForgeReviewLabel>>
 
 /**
  * List the top-level conversation comments on a review, oldest first.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:747}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:753}
  */
 export declare function listReviewComments(projectId: string, reviewId: number): Promise<Array<ForgeReviewComment>>
 
 /**
  * List users who can be requested to review on this project's repository.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1023}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1029}
  */
 export declare function listReviewerCandidates(projectId: string): Promise<Array<ForgeReviewUser>>
 
 /**
  * List the individual reactions (with who reacted) on a review itself.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:790}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:796}
  */
 export declare function listReviewReactions(projectId: string, reviewId: number): Promise<Array<ForgeReviewReaction>>
 
@@ -1065,28 +1065,28 @@ export declare function listReviewReactions(projectId: string, reviewId: number)
 export declare function listReviews(projectId: string, cacheConfig: CacheConfig | null): Promise<Array<ForgeReview>>
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:2134}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:2140}
  */
 export declare function listReviewsForBranch(projectId: string, branch: string, filter: ForgeReviewFilter | null): Promise<Array<ForgeReview>>
 
 /**
  * List the submitted reviews (approvals, change requests) on a review.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:912}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:918}
  */
 export declare function listReviewSubmissions(projectId: string, reviewId: number): Promise<Array<ForgeReviewSubmission>>
 
 /**
  * List the diff-anchored comment threads on a review, oldest first.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:759}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:765}
  */
 export declare function listReviewThreads(projectId: string, reviewId: number): Promise<Array<ForgeReviewThread>>
 
 /**
  * List the pushed commits and review requests on a review's timeline.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:895}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:901}
  */
 export declare function listReviewTimelineEvents(projectId: string, reviewId: number): Promise<Array<ForgeReviewTimelineEvent>>
 
@@ -1119,7 +1119,7 @@ export declare function loginAndPersist(token: string): Promise<UserProfile>
 /**
  * Merge a review on the forge.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1308}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1314}
  */
 export declare function mergeReview(projectId: string, reviewId: number, mergeMethod: ReviewMergeMethod | null): Promise<void>
 
@@ -1244,7 +1244,7 @@ export declare const enum ProgramCategory {
 }
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1187}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1193}
  */
 export declare function publishReview(projectId: string, params: PublishReviewInput): Promise<PublishReviewOutcome>
 
@@ -1264,28 +1264,28 @@ export declare function removeBranch(projectId: string, stackId: string, branchN
 /**
  * Remove one of the caller's reactions from one comment.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:876}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:882}
  */
 export declare function removeCommentReaction(projectId: string, commentId: number, reactionId: number): Promise<void>
 
 /**
  * Remove one label from a review.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1004}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1010}
  */
 export declare function removeReviewLabel(projectId: string, reviewId: number, label: string): Promise<void>
 
 /**
  * Remove one of the caller's reactions from a review itself.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:838}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:844}
  */
 export declare function removeReviewReaction(projectId: string, reviewId: number, reactionId: number): Promise<void>
 
 /**
  * Request reviews from the given users on a review.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1033}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1039}
  */
 export declare function requestReview(projectId: string, reviewId: number, logins: Array<string>): Promise<void>
 
@@ -1338,7 +1338,7 @@ export declare function restoreSnapshotWithKind(projectId: string, restoreKind: 
  * created remote, applies the fetched remote-tracking branch, and records the
  * review number on the applied branch metadata.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:311}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:317}
  */
 export declare function reviewApply(projectId: string, reviewId: number): Promise<ApplyOutcome>
 
@@ -1375,14 +1375,14 @@ export declare function setPushRemote(projectId: string, pushRemote: string): Pr
 /**
  * Enable or disable a review's auto-merge.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1328}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1334}
  */
 export declare function setReviewAutoMerge(projectId: string, reviewId: number, enable: boolean): Promise<void>
 
 /**
  * Set a review to draft or ready-for-review
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1348}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1354}
  */
 export declare function setReviewDraftiness(projectId: string, reviewId: number, draft: boolean): Promise<void>
 
@@ -1530,21 +1530,21 @@ export declare function updateProjectSettings(projectId: ProjectHandleOrLegacyPr
  * Update arbitrary fields of a single review (title, body, state, target base).
  * Each `None` leaves that field unchanged on the forge.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1380}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1386}
  */
 export declare function updateReview(projectId: string, reviewId: number, title: string | null, body: string | null, state: ReviewState | null, targetBase: string | null): Promise<void>
 
 /**
  * Edit a top-level conversation comment on a review.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:924}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:930}
  */
 export declare function updateReviewComment(projectId: string, commentId: number, body: string): Promise<ForgeReviewComment>
 
 /**
  * Update stacked reviews: description footers and, optionally, target branches.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1404}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1410}
  */
 export declare function updateReviewFooters(projectId: string, reviews: Array<ForgeReviewUpdate>): Promise<void>
 
@@ -1566,14 +1566,14 @@ export declare function uploadFile(params: UploadFileParams): Promise<Upload>
  * Additionally, it cleans up stale CI check entries for references that are no longer
  * part of any applied stack.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:2168}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:2174}
  */
 export declare function warmCiChecksCache(projectId: string): Promise<void>
 
 /**
  * Withdraw review requests for the given users on a review.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1052}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1058}
  */
 export declare function withdrawReviewRequest(projectId: string, reviewId: number, logins: Array<string>): Promise<void>
 
@@ -2387,7 +2387,7 @@ export type Claude = {
  *
  * In practice, it should match its [frontend counterpart](https://github.com/gitbutlerapp/gitbutler/blob/fa973fd8f1ae8807621f47601803d98b8a9cf348/app/src/lib/backend/ipc.ts#L5).
  */
-export type Code = "Validation" | "RepoOwnership" | "ProjectGitAuth" | "DefaultTargetNotFound" | "CommitSigningFailed" | "CommitMergeConflictFailure" | "ProjectMissing" | "AuthorMissing" | "BranchNotFound" | "SecretKeychainNotFound" | "MissingLoginKeychain" | "GitForcePushProtection" | "NetworkError" | "ProjectDatabaseIncompatible" | "DefaultTerminalNotFound" | "Unknown" | "GitNonFastForward" | "CliInstallCancelled" | "GitHubTokenExpired" | "GitLabUnauthorized" | "GitLabForbidden" | "GitHubOrgOAuthRestricted" | "GitHubOrgSamlRestricted" | "GitHubInsufficientPermissions" | "ForgeNotAuthenticated" | "GitHubDeviceCodeExpired" | "GitHubDeviceAccessDenied" | "GitHubDeviceFlowRejected" | "PreconditionFailed" | "EditorExitedWithNonZeroStatus";
+export type Code = "Validation" | "RepoOwnership" | "ProjectGitAuth" | "DefaultTargetNotFound" | "CommitSigningFailed" | "CommitMergeConflictFailure" | "ProjectMissing" | "AuthorMissing" | "BranchNotFound" | "SecretKeychainNotFound" | "MissingLoginKeychain" | "GitForcePushProtection" | "NetworkError" | "ProjectDatabaseIncompatible" | "DefaultTerminalNotFound" | "Unknown" | "GitNonFastForward" | "CliInstallCancelled" | "GitHubTokenExpired" | "GitLabUnauthorized" | "GitLabForbidden" | "GitHubOrgOAuthRestricted" | "GitHubOrgSamlRestricted" | "GitHubInsufficientPermissions" | "ForgeNotAuthenticated" | "GitHubDeviceCodeExpired" | "GitHubDeviceAccessDenied" | "GitHubDeviceFlowRejected" | "ForgeUnrecognized" | "PreconditionFailed" | "EditorExitedWithNonZeroStatus";
 
 /** Commit that is part of a legacy stack branch and contains state derived in relation to it. */
 export type Commit = {


### PR DESCRIPTION
## Context

[GB-2001](https://linear.app/gitbutler/issue/GB-2001/automatic-review-listing-repeats-errors-when-no-forge-is-recognized)

Trigger: Desktop project target remote is not recognized as GitHub, GitLab, or Bitbucket.

Impact: mounted automatic review listing repeats the same query failure and telemetry every refresh interval.

## Change

- tag only the `list_reviews` unavailable branch with a typed `ForgeUnrecognized` code;
- classify it as a terminal warning so automatic polling stops while explicit retries remain actionable;
- invalidate review listings when the target changes so moving back to a supported remote retries immediately and restores polling;
- preserve the existing error text, provider failures, cached-review policy, and non-Desktop surfaces;
- cover typed serialization, timer convergence, supported-target recovery, and cache behavior with focused Rust and Desktop tests.

This is stacked on #15670, which establishes the project-level review poll owner consumed by the terminal classification.

Fixes GB-2001
