### PR TITLE
fix(lite): let the stacks and branches lists scroll past the selected row

### DIFF
--- a/apps/lite/e2e/tests/branches-list.spec.ts
+++ b/apps/lite/e2e/tests/branches-list.spec.ts
@@ -1,0 +1,97 @@
+import { expect, test } from "../test.ts";
+
+test.describe("branches list", () => {
+	test.use({ scenario: "project-with-many-unapplied-branches.sh" });
+
+	// Each unfolded branch runs a commit virtualizer on the borrowed list
+	// scroller, so with the selected branch scrolled away from, they used to
+	// stamp the offset they last remembered back over the scroll the user made.
+	test("scrolls to the last branch while the first one is selected", async ({ appWindow }) => {
+		// Seeding a project this size and then unfolding and driving it by hand
+		// costs more than the default budget allows for on a loaded CI runner.
+		test.slow();
+
+		await appWindow
+			.getByRole("group", { name: "Pages" })
+			.getByRole("button", { name: "Branches" })
+			.click();
+
+		const branches = appWindow.getByRole("treeitem", { name: /^branch-\d+$/ });
+		await expect(branches.first()).toBeVisible();
+
+		// `unfold` asks every branch the list currently has mounted to show its
+		// commits, which is what puts a commit virtualizer on the shared scroller.
+		// It rides along with the scroll reading because both need the same
+		// element and each round trip costs the same as the whole batch.
+		const scroll = (unfold = false): Promise<{ offset: number; end: number }> =>
+			appWindow.evaluate((unfoldMounted) => {
+				// Anchored on a branch row: the hidden sidebar tabs are still in the
+				// document, and they look just like this list from the outside.
+				const row = document.querySelector('[role="treeitem"][aria-label^="branch-"]');
+				const tree = row?.closest('[role="tree"]');
+				const scroller = tree?.parentElement;
+				if (!tree || !scroller) throw new Error("Branches list has no scroller");
+
+				if (unfoldMounted) {
+					for (const toggle of tree.querySelectorAll<HTMLElement>(
+						'button[aria-label="Unfold commits"]',
+					))
+						toggle.click();
+				}
+
+				return {
+					offset: Math.round(scroller.scrollTop),
+					end: Math.round(scroller.scrollHeight - scroller.clientHeight),
+				};
+			}, unfold);
+
+		const start = await branches.first().boundingBox();
+		if (start === null) throw new Error("Branch row has no bounding box");
+		await appWindow.mouse.move(start.x + start.width / 2, start.y + start.height / 2);
+
+		// The list virtualises, so unfolding what is mounted stages more rows to
+		// unfold: walk down it until the last of them is showing its commits.
+		for (let pass = 0; pass < 10; pass++) {
+			const { offset, end } = await scroll(true);
+			if (offset >= end) break;
+			await appWindow.mouse.wheel(0, 600);
+		}
+
+		await appWindow.evaluate(() => {
+			const row = document.querySelector('[role="treeitem"][aria-label^="branch-"]');
+			row?.closest('[role="tree"]')?.parentElement?.scrollTo({ top: 0 });
+		});
+
+		await expect(branches.first()).toBeVisible();
+		// Pin the branch by name: which one the list puts first is its own
+		// business, and every locator below has to keep meaning that same one.
+		const firstName = await branches.first().getAttribute("aria-label");
+		if (firstName === null) throw new Error("Branch row has no name");
+
+		const first = appWindow.getByRole("treeitem", { name: firstName, exact: true });
+		// The tree item spans the branch row and the commits under it, so aim at
+		// the name rather than the item's middle, which is a commit row.
+		await first.getByTitle(firstName, { exact: true }).click();
+		await expect(first).toHaveAttribute("aria-selected", "true");
+
+		// The branches have to outgrow their panel for any of this to mean anything.
+		expect((await scroll()).end).toBeGreaterThan(0);
+
+		const box = await first.boundingBox();
+		if (box === null) throw new Error("Branch row has no bounding box");
+		await appWindow.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+
+		// Enough wheel to cross the whole list several times over; the scroller
+		// stops at its end. Few, large steps rather than many small ones: each one
+		// is a round trip, and a stuck list stays stuck however finely it is asked
+		// to move.
+		for (let step = 0; step < 16; step++) await appWindow.mouse.wheel(0, 400);
+
+		await expect
+			.poll(async () => {
+				const { offset, end } = await scroll();
+				return offset >= end;
+			})
+			.toBe(true);
+	});
+});

--- a/apps/lite/e2e/tests/stacks-list.spec.ts
+++ b/apps/lite/e2e/tests/stacks-list.spec.ts
@@ -1,0 +1,75 @@
+import { expect, test } from "../test.ts";
+
+/** Kept in sync with the argument the scenario script defaults to. */
+const stackCount = 12;
+
+test.describe("stacks list", () => {
+	test.use({ scenario: "project-with-many-independent-stacks.sh" });
+
+	// The selected stack stays mounted wherever the list is scrolled to, so with
+	// it selected and scrolled away from, every other stack's commit virtualizer
+	// used to stamp the offset it last remembered back onto the shared scroller:
+	// the list snapped back to the same place on every frame and went no further.
+	test("scrolls to the last stack while the first one is selected", async ({ appWindow }) => {
+		// Seeding a workspace this size and then driving it by hand costs more than
+		// the default budget allows for on a loaded CI runner.
+		test.slow();
+
+		await expect(appWindow.getByRole("treeitem", { name: /^stack-\d+$/ }).first()).toBeVisible();
+
+		const stackNames = await appWindow.getByRole("treeitem").evaluateAll((rows) =>
+			rows.flatMap((row) => {
+				const name = row.getAttribute("aria-label");
+				return name !== null && name.startsWith("stack-") ? [name] : [];
+			}),
+		);
+
+		const topStack = stackNames[0];
+		if (topStack === undefined) throw new Error("Workspace shows no stacks");
+		// Which end of the range the list starts at is the workspace's business.
+		const bottomStack = topStack === "stack-1" ? `stack-${stackCount}` : "stack-1";
+
+		const top = appWindow.getByRole("treeitem", { name: topStack, exact: true });
+		// The tree item spans the branch row and the commits under it, so aim at
+		// the name rather than the item's middle, which is a commit row.
+		await top.getByText(topStack, { exact: true }).click();
+		await expect(top).toHaveAttribute("aria-selected", "true");
+
+		const scroll = (): Promise<{ offset: number; end: number }> =>
+			appWindow.evaluate(() => {
+				// Anchored on a stack row: the hidden sidebar tabs are still in the
+				// document, and they look just like this list from the outside.
+				const row = document.querySelector('[role="treeitem"][aria-label^="stack-"]');
+				const scroller = row?.closest('[role="tree"]')?.parentElement;
+				if (!scroller) throw new Error("Stacks list has no scroller");
+
+				return {
+					offset: Math.round(scroller.scrollTop),
+					end: Math.round(scroller.scrollHeight - scroller.clientHeight),
+				};
+			});
+
+		// The stacks have to outgrow their panel for any of this to mean anything.
+		expect((await scroll()).end).toBeGreaterThan(0);
+
+		const box = await top.boundingBox();
+		if (box === null) throw new Error("Stack row has no bounding box");
+		await appWindow.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+
+		// Enough wheel to cross the whole list several times over; the scroller
+		// stops at its end. Few, large steps rather than many small ones: each one
+		// is a round trip, and a stuck list stays stuck however finely it is asked
+		// to move.
+		for (let step = 0; step < 16; step++) await appWindow.mouse.wheel(0, 400);
+
+		await expect
+			.poll(async () => {
+				const { offset, end } = await scroll();
+				return offset >= end;
+			})
+			.toBe(true);
+		await expect(
+			appWindow.getByRole("treeitem", { name: bottomStack, exact: true }),
+		).toBeInViewport();
+	});
+});

--- a/apps/lite/ui/src/virtual.test.ts
+++ b/apps/lite/ui/src/virtual.test.ts
@@ -1,0 +1,31 @@
+import { getRangeExtractorWithIndices } from "./virtual.ts";
+import { describe, expect, it } from "vitest";
+
+// The default extractor's range: `overscan` rows either side of `startIndex`..`endIndex`.
+const range = { startIndex: 10, endIndex: 12, overscan: 1, count: 100 };
+
+describe("getRangeExtractorWithIndices", () => {
+	it("returns the default range when nothing is pinned", () => {
+		expect(getRangeExtractorWithIndices(range, [])).toEqual([9, 10, 11, 12, 13]);
+	});
+
+	it("leaves a pin already inside the default range alone", () => {
+		expect(getRangeExtractorWithIndices(range, [11])).toEqual([9, 10, 11, 12, 13]);
+	});
+
+	it("orders a pin below the default range before it", () => {
+		expect(getRangeExtractorWithIndices(range, [2])).toEqual([2, 9, 10, 11, 12, 13]);
+	});
+
+	it("orders a pin above the default range after it", () => {
+		expect(getRangeExtractorWithIndices(range, [42])).toEqual([9, 10, 11, 12, 13, 42]);
+	});
+
+	it("orders pins on both sides", () => {
+		expect(getRangeExtractorWithIndices(range, [42, 2])).toEqual([2, 9, 10, 11, 12, 13, 42]);
+	});
+
+	it("drops pins outside the item set", () => {
+		expect(getRangeExtractorWithIndices(range, [-1, 100])).toEqual([9, 10, 11, 12, 13]);
+	});
+});

--- a/apps/lite/ui/src/virtual.ts
+++ b/apps/lite/ui/src/virtual.ts
@@ -3,29 +3,45 @@ import { defaultRangeExtractor, type Range } from "@tanstack/react-virtual";
 /**
  * Get a virtualisation range extractor which includes the provided indices, if any.
  *
- * Returned extractor order is unspecified; callers whose DOM order is semantic must sort it.
+ * The returned indices are ascending. The virtualiser positions items independently of
+ * extractor order, but the rows it renders are DOM siblings, and in a `role="tree"` DOM
+ * order is what a screen reader reads and what sequential navigation follows — a pinned
+ * row appended after the range would be announced last among its siblings.
+ *
+ * Ordering also keeps the rows still: a pin that moves between the end of the list and
+ * its place in it as the range slides past re-orders React's keyed children on every
+ * render, and React answers a re-order by tearing each moved row's layout effects down
+ * and setting them up again. A row that virtualises its own contents against a shared
+ * scroller then re-attaches to it that often, and each re-attachment writes an offset
+ * back onto it — which is what used to leave these lists unable to scroll past the
+ * selected row.
  */
 export const getRangeExtractorWithIndices = (
 	range: Range,
 	idxs: ReadonlyArray<number>,
 ): Array<number> => {
-	// The default range is contiguous.
+	// The default range is contiguous and ascending.
 	const defIdxs = defaultRangeExtractor(range);
 
 	if (idxs.length === 0) return defIdxs;
 
 	const fstIdx = defIdxs[0];
 	const lastIdx = defIdxs.at(-1);
+	let appended = false;
 
 	for (const idx of idxs) {
 		// Only indices in the virtualiser's current item set can be pinned.
 		if (idx < 0 || idx >= range.count) continue;
 
-		// The virtualiser positions items independently of extractor order, so an out-of-range index
-		// can be safely appended in O(1). Callers that require DOM order sort the result afterward.
-		if (fstIdx === undefined || lastIdx === undefined || idx < fstIdx || idx > lastIdx)
+		if (fstIdx === undefined || lastIdx === undefined || idx < fstIdx || idx > lastIdx) {
 			defIdxs.push(idx);
+			appended = true;
+		}
 	}
+
+	// Only what fell outside the default range was appended, so this is a nearly sorted array
+	// of a few dozen numbers at most.
+	if (appended) defIdxs.sort((a, b) => a - b);
 
 	return defIdxs;
 };

--- a/e2e/playwright/scripts/project-with-many-independent-stacks.sh
+++ b/e2e/playwright/scripts/project-with-many-independent-stacks.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "GIT CONFIG $GIT_CONFIG_GLOBAL"
+echo "DATA DIR $E2E_TEST_APP_DATA_DIR"
+echo "BUT $BUT"
+
+stack_count="${1:-12}"
+
+# Setup a remote project. GitButler currently requires projects to have a remote.
+mkdir remote-project
+pushd remote-project
+git init -b master --object-format=sha1
+echo "base" > base.txt
+git add base.txt
+git commit -m "base: initial commit"
+popd
+
+# Clone the remote, register the project with GitButler, configure the target,
+# then fill the workspace with enough independent stacks that the list of them
+# is taller than the panel showing it and has to scroll. Committing to a branch
+# that does not exist yet creates it unstacked, so each one is its own stack.
+git clone remote-project local-clone
+pushd local-clone
+git checkout master
+target_branch="$(git rev-parse --symbolic-full-name @{u})"
+target_branch="${target_branch#refs/remotes/}"
+"$BUT" setup
+"$BUT" config target "$target_branch"
+
+for index in $(seq 1 "$stack_count"); do
+  echo "stack $index" > "stack-$index.txt"
+  "$BUT" commit -m "stack-$index: first commit" --branch "stack-$index"
+  echo "stack $index again" >> "stack-$index.txt"
+  "$BUT" commit -m "stack-$index: second commit" --branch "stack-$index"
+done
+popd

--- a/e2e/playwright/scripts/project-with-many-unapplied-branches.sh
+++ b/e2e/playwright/scripts/project-with-many-unapplied-branches.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "GIT CONFIG $GIT_CONFIG_GLOBAL"
+echo "DATA DIR $E2E_TEST_APP_DATA_DIR"
+echo "BUT $BUT"
+
+branch_count="${1:-12}"
+
+# Setup a remote project. GitButler currently requires projects to have a remote.
+mkdir remote-project
+pushd remote-project
+git init -b master --object-format=sha1
+echo "base" > base.txt
+git add base.txt
+git commit -m "base: initial commit"
+popd
+
+# Clone the remote, then give it enough local branches that the branches view is
+# taller than the panel showing it and has to scroll. They are made before the
+# workspace exists and never applied to it, so they all land in that view. The
+# view's default filter is local-only, which is why these are not remote
+# branches.
+git clone remote-project local-clone
+pushd local-clone
+git checkout master
+
+for index in $(seq 1 "$branch_count"); do
+  git checkout -b "branch-$index" master
+  echo "branch $index" > "branch-$index.txt"
+  git add "branch-$index.txt"
+  git commit -m "branch-$index: first commit"
+  echo "branch $index again" >> "branch-$index.txt"
+  git commit -am "branch-$index: second commit"
+done
+
+git checkout master
+target_branch="$(git rev-parse --symbolic-full-name @{u})"
+target_branch="${target_branch#refs/remotes/}"
+"$BUT" setup
+"$BUT" config target "$target_branch"
+popd


### PR DESCRIPTION
The workspace stacks list would reach a point it could not scroll past: it moved for one frame, snapped back, and stayed there for as long as you kept scrolling. The branches list does the same once a few branches are unfolded.

## Cause

Both lists pin the selected row into the virtual range so it stays mounted wherever the list is scrolled to, and `getRangeExtractorWithIndices` appended that pin *after* the range instead of putting it in its place. So once the range slid past the pinned row, the row moved between the end of React's keyed children and its place among them on every render — and React answers a re-order by tearing the moved rows' layout effects down and setting them up again.

That matters because those rows virtualise their own commits against the list's single scroller. `@tanstack/react-virtual` assumes a virtualizer *owns* its scroller: whenever its effects re-attach, `_willUpdate` writes the offset it last remembered back onto the element.

```js
if (this.scrollElement !== scrollElement) {
  this.cleanup();
  ...
  this._scrollToOffset(this.getScrollOffset(), { adjustments: undefined, behavior: undefined });
}
```

Re-attaching on every render, each mounted row stamped an offset the user had already scrolled away from. And because a frame's scroll writes coalesce into a single scroll event, the stamped offset was the one every virtualizer read back as the truth — so none of them ever learned where the user actually scrolled, and they kept re-stamping the same number.

Measured in the running app at the stuck point: nine `scrollTo({top: 264})` calls per frame from `Virtualizer._willUpdate → _scrollToOffset`, while the element had just been set to 276.

## The fix ~, and the follow-up~

**`fix(lite): keep a pinned virtual row in its place in the list`** is the fix. Ordering the extractor's indices removes the per-render re-order, and with it the effect churn that drove the whole thing. Instrumenting every virtualizer bound to the stacks scroller afterwards, a scroll produces **zero** re-attachments and zero writes, where before it produced one per mounted row per frame.

DOM order is semantic in these lists anyway — they are `role="tree"`, so it is what a screen reader reads and what sequential navigation follows, and a pinned row appended after the range was announced last among its siblings.

~The `refactor` commit on top is not needed to unstick the lists, and is worth having anyway. A borrowed scroller with several virtualizers on it is only safe while nothing re-attaches their effects mid-scroll, and when that happens is not something these lists decide — `Activity` tears them down and sets them up again on every tab switch. So the nested virtualizers are given a `scrollToFn` that does nothing: they read the scroller, and only the virtualizer that owns it moves it.~

~That also lets the one write they made on purpose go. A selected commit row now reveals itself through `Row`, the way a branch row already did and every unvirtualised row does, which the extractor's pin makes reliable by keeping it mounted — so the hand-rolled `scrollToIndex` effects and the refs that remembered whether `Activity` had already replayed them are gone. Net, the two commits remove more code than they add.~

## Tests

`getRangeExtractorWithIndices` gets unit coverage for where a pin lands, and two e2e tests drive a list taller than its panel with the first row selected. Both fail on `master` and pass on the first commit alone — they cover the behaviour, not either mechanism, so they stay honest if the ordering fix is ever revisited.

Not affected, checked: the upstream list, `FilesTree`, `PickerDialog` and `ProjectPicker` each run a single virtualizer that owns its own scroller.

Fixes the regression from #15692 (stacks) and the same shape in #15682 (branches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
