### PR TITLE
Correct folded branch commit rings

### DIFF
--- a/apps/lite/ui/src/components/GraphSegment.test.tsx
+++ b/apps/lite/ui/src/components/GraphSegment.test.tsx
@@ -1,0 +1,44 @@
+/** @vitest-environment jsdom */
+
+import { GraphSegment } from "./GraphSegment.tsx";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+const render = (groupCount?: number) => {
+	const container = document.createElement("div");
+	container.innerHTML = renderToStaticMarkup(
+		<GraphSegment glyph="group" status="LocalOnly" groupCount={groupCount} />,
+	);
+	return container;
+};
+
+describe("folded commit groups", () => {
+	it.each([
+		[1, 1, "9.78571"],
+		[2, 2, "6.28571"],
+		[3, 3, "2.78571"],
+		[8, 3, "2.78571"],
+	] as const)("shows the rings for %i hidden commits", (count, rings, railEnd) => {
+		const container = render(count);
+		const svg = container.querySelector("svg");
+		const paths = container.querySelectorAll("svg:first-child path");
+		expect(paths[1]?.getAttribute("d")?.match(/M/g)).toHaveLength(rings);
+		expect(paths[0]?.getAttribute("d")).toBe(`M8 0V${railEnd}M8 17.0038V26`);
+		expect(svg?.getAttribute("viewBox")).toBe("0 0 16 26");
+		expect(container.querySelectorAll("svg")).toHaveLength(2);
+		expect(container.querySelector("svg:last-child path")?.getAttribute("d")).toBe("M8 0V28");
+	});
+
+	it("keeps three rings when no count is supplied", () => {
+		expect(render().innerHTML).toBe(render(3).innerHTML);
+	});
+
+	it.each(["commit", "groupHead", "forkRight", "joinRight"] as const)(
+		"leaves the %s glyph unchanged",
+		(glyph) => {
+			expect(
+				renderToStaticMarkup(<GraphSegment glyph={glyph} status="LocalOnly" groupCount={1} />),
+			).toBe(renderToStaticMarkup(<GraphSegment glyph={glyph} status="LocalOnly" />));
+		},
+	);
+});

--- a/apps/lite/ui/src/components/GraphSegment.tsx
+++ b/apps/lite/ui/src/components/GraphSegment.tsx
@@ -37,21 +37,28 @@ const commitGlyph = (
 	</>
 );
 
-const groupRingsPath =
-	"M11.0862 8.1524C11.3502 7.6602 11.5 7.0976 11.5 6.5C11.5 4.567 9.933 3 8 3C6.067 3 4.5 4.567 4.5 6.5C4.5 7.0976 4.64977 7.6602 4.91382 8.1524M5 11.8038C4.68259 11.277 4.5 10.6598 4.5 10C4.5 8.067 6.067 6.5 8 6.5C9.933 6.5 11.5 8.067 11.5 10C11.5 10.6598 11.3174 11.277 11 11.8038M11.5 13.5C11.5 15.433 9.933 17 8 17C6.067 17 4.5 15.433 4.5 13.5C4.5 11.567 6.067 10 8 10C9.933 10 11.5 11.567 11.5 13.5Z";
+const groupRingPaths = [
+	"M11.0862 8.1524C11.3502 7.6602 11.5 7.0976 11.5 6.5C11.5 4.567 9.933 3 8 3C6.067 3 4.5 4.567 4.5 6.5C4.5 7.0976 4.64977 7.6602 4.91382 8.1524",
+	"M5 11.8038C4.68259 11.277 4.5 10.6598 4.5 10C4.5 8.067 6.067 6.5 8 6.5C9.933 6.5 11.5 8.067 11.5 10C11.5 10.6598 11.3174 11.277 11 11.8038",
+	"M11.5 13.5C11.5 15.433 9.933 17 8 17C6.067 17 4.5 15.433 4.5 13.5C4.5 11.567 6.067 10 8 10C9.933 10 11.5 11.567 11.5 13.5Z",
+];
 
-const groupGlyph = (
+const groupGlyphs = [1, 2, 3].map((count) => (
 	<>
-		<path className={styles.line} d="M8 0V2.78571M8 17.0038V26" strokeWidth="1.5" />
-		<path d={groupRingsPath} stroke="currentColor" strokeWidth="1.5" />
+		<path
+			className={styles.line}
+			d={`M8 0V${2.78571 + (3 - count) * 3.5}M8 17.0038V26`}
+			strokeWidth="1.5"
+		/>
+		<path d={groupRingPaths.slice(-count).join("")} stroke="currentColor" strokeWidth="1.5" />
 	</>
-);
+));
 
 /** The rings without the tail above them, for a row that starts a rail. */
 const groupHeadGlyph = (
 	<>
 		<path className={styles.line} d="M8 17.0038V26" strokeWidth="1.5" />
-		<path d={groupRingsPath} stroke="currentColor" strokeWidth="1.5" />
+		<path d={groupRingPaths.join("")} stroke="currentColor" strokeWidth="1.5" />
 	</>
 );
 
@@ -90,9 +97,17 @@ export type GraphSegmentStatus = "Diverged" | "Upstream" | CommitState["type"];
 interface GraphSegmentProps extends ComponentProps<"div"> {
 	glyph: GraphSegmentGlyph;
 	status: GraphSegmentStatus;
+	/** Hidden commits for the group glyph; counts above two use three rings. */
+	groupCount?: number;
 }
 
-export const GraphSegment: FC<GraphSegmentProps> = ({ glyph, className, status, ...props }) => (
+export const GraphSegment: FC<GraphSegmentProps> = ({
+	glyph,
+	className,
+	status,
+	groupCount = 3,
+	...props
+}) => (
 	<div {...props} className={classes(className, styles.container)} data-status={status}>
 		<svg
 			className={classes(styles.mainSegment, isGroupGlyph(glyph) && styles.groupSegment)}
@@ -105,7 +120,7 @@ export const GraphSegment: FC<GraphSegmentProps> = ({ glyph, className, status, 
 			{glyph === "commit" ? (
 				commitGlyph
 			) : glyph === "group" ? (
-				groupGlyph
+				groupGlyphs[groupCount === 1 ? 0 : groupCount === 2 ? 1 : 2]
 			) : glyph === "groupHead" ? (
 				groupHeadGlyph
 			) : (

--- a/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.tsx
@@ -377,7 +377,13 @@ const BranchItem: FC<{
 						aria-label={unfolded ? "Fold commits" : "Unfold commits"}
 						onClick={toggleUnfolded}
 						glyph={<GraphSegment glyph={railGlyph} status={branchGraphStatus(branch)} />}
-						foldedIndicator={<GraphSegment glyph="group" status={branchGraphStatus(branch)} />}
+						foldedIndicator={
+							<GraphSegment
+								glyph="group"
+								status={branchGraphStatus(branch)}
+								groupCount={branch.commitCount ?? undefined}
+							/>
+						}
 					/>
 				) : (
 					<GraphSegment glyph={railGlyph} status={branchGraphStatus(branch)} />

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/BranchRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/BranchRow.tsx
@@ -456,7 +456,9 @@ export const BranchRow: FC<
 										status={graphStatus}
 									/>
 								}
-								foldedIndicator={<GraphSegment glyph="group" status={graphStatus} />}
+								foldedIndicator={
+									<GraphSegment glyph="group" status={graphStatus} groupCount={commitCount} />
+								}
 							/>
 						}
 					/>


### PR DESCRIPTION
FYI @PavelLaptev

## Context

In Lite's branch lists, a folded branch containing one or two commits always shows three circles despite the commit count. The rail overstates how many commits are hidden, so users have to rely on the numeric count or unfold the branch.

## Change

Show one ring for one hidden commit, two for two, and the compact three-ring group for larger counts. Both workspace and unapplied branch lists supply their existing commit count. Preserve numeric counts, unfolding, colors, graph connectors, and the three-ring fallback when the count is unknown.
