### PR TITLE
Fix branch squash message order

### DIFF
--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -253,6 +253,9 @@ committed-change sources reuse the target's message and need no flag:
 --use-source-message      # Keep the sources' message, drop the target's
 ```
 
+With branch sources, `--use-source-message` combines messages newest first within each
+branch and includes each source commit only once.
+
 None of the message flags may be used when the target is `@`.
 
 For multiple independent squash groups, prefer newer/top groups first; change-ID refs from

--- a/crates/but/src/command/legacy/squash.rs
+++ b/crates/but/src/command/legacy/squash.rs
@@ -1281,8 +1281,7 @@ pub fn run(
             target,
             reword,
         }) => {
-            sources.sort();
-            sources.dedup();
+            sources = sources.into_iter().unique_by(|c| c.commit_id).collect();
 
             branches_to_remove.sort();
             branches_to_remove.dedup();

--- a/crates/but/tests/but/command/squash.rs
+++ b/crates/but/tests/but/command/squash.rs
@@ -591,6 +591,7 @@ Squashed branch 'a-branch-1' into unl
 
 "#]]);
 
+    // Keep the target message first, followed by sources in newest-first branch order.
     env.but("status -fv")
         .assert()
         .success()
@@ -598,8 +599,8 @@ Squashed branch 'a-branch-1' into unl
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ br [a-branch-1]
-┊● unl author 2000-01-01 00:00:00 +0000 (sha 9269bbf)
-┊│     add one  add two  add three
+┊● unl author 2000-01-01 00:00:00 +0000 (sha 615f4cb)
+┊│     add one  add three  add two
 ┊│     unl:k A one
 ┊│     unl:o A three
 ┊│     unl:t A two
@@ -921,7 +922,7 @@ Hint: run `but help` for all commands
 fn squash_with_duplicate_branch_sources() {
     let env = two_branches();
 
-    env.but("squash one one -t uqr -u")
+    env.but("squash one one -t uqr --use-source-message")
         .assert()
         .success()
         .stdout_eq(snapbox::str![[r#"
@@ -936,7 +937,7 @@ Squashed branch 'one' into uqr
 ╭┄ @ [uncommitted] (no changes)
 ┊
 ┊╭┄ se [second]
-┊●   uqr add four
+┊●   uqr add two
 ┊│     uqr:q A four
 ┊│     uqr:k A one
 ┊│     uqr:t A two
@@ -949,6 +950,11 @@ Squashed branch 'one' into uqr
 Hint: run `but help` for all commands
 
 "#]]);
+    // Repeated branch arguments must preserve source order without repeating messages.
+    snapbox::assert_data_eq!(
+        env.invoke_git("log -1 --format=%B second"),
+        str!["add two\n\nadd one"]
+    );
 }
 
 #[test]


### PR DESCRIPTION
Fixes GB-1989
https://linear.app/gitbutler/issue/GB-1989/branch-squash-orders-combined-commit-messages-by-commit-sha

## Context

When you squash a branch containing multiple commits, combined messages follow commit SHA instead of branch history. A metadata-only change can therefore reorder the combined message even when the commits remain in the same history order.

## Change

Preserve branch order while deduplicating source commit IDs. The target message stays first, followed by source commits newest first. Message-selection flags and branch removal retain their existing behavior.
