### PR TITLE
Classify unrelated branch histories as a precondition

### DIFF
--- a/crates/but-workspace/src/divergence.rs
+++ b/crates/but-workspace/src/divergence.rs
@@ -2,6 +2,7 @@
 
 use anyhow::{Context as _, Result};
 use but_core::RefMetadata;
+use but_error::bail_precondition;
 use but_rebase::graph_rebase::{Editor, LookupStep, Pick, Selector, Step, ToSelector};
 use std::{
     borrow::Cow,
@@ -64,12 +65,12 @@ pub(crate) fn get_commits_until_merge_base<'a, M: RefMetadata>(
             format!("Could not determine tip commit for upstream '{upstream_ref_name}'")
         })?;
     let upstream_ancestor_ids = traverse_pick_ancestor_ids(editor, upstream_tip)?;
-    let merge_base = find_first_parent_merge_base(editor, local_tip, &upstream_ancestor_ids)?
-        .ok_or_else(|| {
-            anyhow::anyhow!(
-                "No merge-base found between '{ref_name}' and its tracking branch '{upstream_ref_name}'"
-            )
-        })?;
+    let Some(merge_base) = find_first_parent_merge_base(editor, local_tip, &upstream_ancestor_ids)?
+    else {
+        bail_precondition!(
+            "'{ref_name}' has no first-parent history shared with its tracking branch '{upstream_ref_name}'. Fetch the missing history or choose a branch with shared first-parent history."
+        );
+    };
     let merge_base_selector = editor.select_commit(merge_base)?;
     let local_commits = first_parent_path_until(editor, local_tip, |selector| {
         editor.lookup_pick(*selector).ok() == Some(merge_base)

--- a/crates/but-workspace/tests/workspace/branch/integrate_branch_upstream.rs
+++ b/crates/but-workspace/tests/workspace/branch/integrate_branch_upstream.rs
@@ -294,6 +294,50 @@ fn errors_when_branch_has_no_tracking_branch() -> Result<()> {
 }
 
 #[test]
+fn unrelated_tracking_history_is_an_actionable_precondition_failure() -> Result<()> {
+    // A writable copy: the unrelated root and the retargeted remote ref are written to disk
+    // and must not leak into the shared read-only fixture.
+    let tmp = but_testsupport::gix_testtools::scripted_fixture_writable(
+        "scenario/with-remotes-no-workspace.sh",
+    )
+    .map_err(anyhow::Error::from_boxed)?;
+    let mut repo = but_testsupport::open_repo(&tmp.path().join("remote-diverged"))?;
+    configure_tracking_for_branch_a(&mut repo)?;
+    let unrelated = repo.commit(
+        "refs/heads/unrelated",
+        "unrelated root",
+        repo.object_hash().empty_tree(),
+        std::iter::empty::<gix::ObjectId>(),
+    )?;
+    repo.reference(
+        "refs/remotes/origin/A",
+        unrelated,
+        gix::refs::transaction::PreviousValue::Any,
+        "test",
+    )?;
+
+    let err = initial_integration_for_branch(
+        r("refs/heads/A"),
+        &repo,
+        Some(r("refs/remotes/origin/main")),
+    )
+    .expect_err("unrelated tracking history must fail before integration");
+
+    assert_eq!(
+        err.custom_context().map(|context| context.code),
+        Some(Code::PreconditionFailed),
+        "the caller needs a typed, recoverable precondition failure: {err:#}"
+    );
+    assert!(
+        err.to_string().contains(
+            "Fetch the missing history or choose a branch with shared first-parent history"
+        ),
+        "the error must name the missing first-parent boundary and how to recover: {err:#}"
+    );
+    Ok(())
+}
+
+#[test]
 fn partitions_diverged_branch_into_application_order() -> Result<()> {
     let mut repo =
         read_only_in_memory_scenario_named("with-remotes-no-workspace", "remote-diverged")?;


### PR DESCRIPTION
Classify unrelated branch histories as a precondition

## Context

After a tracked remote branch is rewritten onto unrelated history, branch integration currently fails with a generic no-merge-base error. The caller cannot distinguish that recoverable repository topology from an internal failure or guide the user toward a valid target.

## Change

Classify the missing common-history boundary as `PreconditionFailed` and include actionable fetch-or-select guidance. Normal divergence planning, no-tracking errors, integration strategies, and persisted workspace state stay unchanged.

Related: https://github.com/gitbutlerapp/gitbutler/issues/14415
