### PR TITLE
Stop polling reviews after an expired GitHub token

### DIFF
--- a/apps/desktop/src/lib/error/errorClassification.ts
+++ b/apps/desktop/src/lib/error/errorClassification.ts
@@ -200,6 +200,7 @@ With \`seahorse\` or equivalent, create a \`Login\` password store, right click 
 	},
 	GitHubTokenExpired: {
 		severity: "error",
+		terminal: true,
 		userMessage: `
 Your GitHub token appears expired. Please log out and back in to refresh it. (Settings -> Integrations -> Forget)
 	`,

--- a/apps/desktop/src/routes/[projectId]/projectLayout.svelte.test.ts
+++ b/apps/desktop/src/routes/[projectId]/projectLayout.svelte.test.ts
@@ -74,6 +74,15 @@ const terminalError = {
 		code: "GitHubInsufficientPermissions" as const,
 	},
 };
+// What `list_reviews` returns when GitHub answers 401.
+const expiredTokenError = {
+	error: {
+		origin: "ipc" as const,
+		name: "API error: (list_reviews)",
+		message: "GitHub authentication failed.",
+		code: "GitHubTokenExpired" as const,
+	},
+};
 const nonterminalError = {
 	error: {
 		origin: "ipc" as const,
@@ -115,6 +124,7 @@ function query(response?: unknown) {
 type Response =
 	| typeof success
 	| typeof terminalError
+	| typeof expiredTokenError
 	| typeof nonterminalError
 	| typeof unrecognizedForgeError;
 
@@ -226,42 +236,48 @@ afterEach(() => {
 });
 
 describe("project review-list polling", () => {
-	test("keeps cached reviews, stops terminal polling, and recovers through explicit retries", async () => {
-		vi.useFakeTimers();
-		const harness = setup([success, terminalError, terminalError, success, success]);
-		await settle();
-		expect(harness.calls).toBe(1);
+	test.each([
+		["GitHubInsufficientPermissions", terminalError],
+		["GitHubTokenExpired", expiredTokenError],
+	])(
+		"keeps cached reviews, stops terminal polling, and recovers through explicit retries (%s)",
+		async (_code, terminal) => {
+			vi.useFakeTimers();
+			const harness = setup([success, terminal, terminal, success, success]);
+			await settle();
+			expect(harness.calls).toBe(1);
 
-		await vi.advanceTimersByTimeAsync(POLL_INTERVAL);
-		const failed = (harness.api.endpoints as any).listPrs.select(PROJECT_ID)(
-			harness.store.getState(),
-		);
-		expect(failed.data.ids).toEqual(["topic"]);
-		expect(failed.isError).toBe(true);
+			await vi.advanceTimersByTimeAsync(POLL_INTERVAL);
+			const failed = (harness.api.endpoints as any).listPrs.select(PROJECT_ID)(
+				harness.store.getState(),
+			);
+			expect(failed.data.ids).toEqual(["topic"]);
+			expect(failed.isError).toBe(true);
 
-		await vi.advanceTimersByTimeAsync(POLL_INTERVAL);
-		expect(harness.calls, "terminal failure scheduled another interval request").toBe(2);
+			await vi.advanceTimersByTimeAsync(POLL_INTERVAL);
+			expect(harness.calls, "terminal failure scheduled another interval request").toBe(2);
 
-		harness.store.dispatch(harness.api.internalActions.onFocusLost());
-		harness.store.dispatch(harness.api.internalActions.onFocus());
-		await settle();
-		expect(harness.calls).toBe(3);
-		await vi.advanceTimersByTimeAsync(POLL_INTERVAL);
-		expect(harness.calls).toBe(3);
+			harness.store.dispatch(harness.api.internalActions.onFocusLost());
+			harness.store.dispatch(harness.api.internalActions.onFocus());
+			await settle();
+			expect(harness.calls).toBe(3);
+			await vi.advanceTimersByTimeAsync(POLL_INTERVAL);
+			expect(harness.calls).toBe(3);
 
-		harness.store.dispatch(harness.api.internalActions.onFocusLost());
-		harness.store.dispatch(harness.api.internalActions.onFocus());
-		await settle();
-		expect(harness.calls).toBe(4);
+			harness.store.dispatch(harness.api.internalActions.onFocusLost());
+			harness.store.dispatch(harness.api.internalActions.onFocus());
+			await settle();
+			expect(harness.calls).toBe(4);
 
-		await vi.advanceTimersByTimeAsync(POLL_INTERVAL - 1);
-		expect(harness.calls).toBe(4);
-		await vi.advanceTimersByTimeAsync(1);
-		expect(harness.calls).toBe(5);
+			await vi.advanceTimersByTimeAsync(POLL_INTERVAL - 1);
+			expect(harness.calls).toBe(4);
+			await vi.advanceTimersByTimeAsync(1);
+			expect(harness.calls).toBe(5);
 
-		harness.rendered.unmount();
-		harness.storeState.unsubscribe();
-	});
+			harness.rendered.unmount();
+			harness.storeState.unsubscribe();
+		},
+	);
 
 	test("keeps terminal polling stopped after a nonterminal failed retry", async () => {
 		vi.useFakeTimers();


### PR DESCRIPTION
Stop polling reviews after an expired GitHub token

## Context

When GitHub rejects a stored token during automatic pull-request listing, the mounted project subscription keeps its 15-minute polling interval active. Cached reviews remain available, but each interval can repeat the same authentication failure until the account is reconnected.

## Change

Mark the existing `GitHubTokenExpired` classification as terminal so the shared polling backoff stops interval requests while retaining cached data and explicit recovery. Keep the existing insufficient-permissions lifecycle coverage, add the expired-token lifecycle case, and use the same terminal classification for once-per-session error deduplication.

FYI @PavelLaptev
