### PR TITLE
Fix mark-all review activity state

### DIFF
--- a/apps/lite/ui/src/review-inbox.test.ts
+++ b/apps/lite/ui/src/review-inbox.test.ts
@@ -71,3 +71,92 @@ describe("addInboxEntries", () => {
 		expect(kept[99]?.id).toBe("e5");
 	});
 });
+
+const marksOf = (projectId: string): Record<string, string> =>
+	JSON.parse(localStorage.getItem(`pr_activity_seen:v1:${projectId}`) ?? "{}") as Record<
+		string,
+		string
+	>;
+const unseenOf = (projectId: string): Record<string, unknown> =>
+	JSON.parse(localStorage.getItem(`pr_activity_unseen:v1:${projectId}`) ?? "{}") as Record<
+		string,
+		unknown
+	>;
+
+describe("markInboxSeen without ids", () => {
+	it("advances each review's watermark to its newest inbox entry, clearing its skips", () => {
+		const projectId = freshProject();
+		localStorage.setItem(
+			`pr_activity_seen:v1:${projectId}`,
+			JSON.stringify({ 7: at(0), 8: at(0) }),
+		);
+		localStorage.setItem(
+			`pr_activity_unseen:v1:${projectId}`,
+			JSON.stringify({ 7: [["c:1", at(3)]], 9: [["c:2", at(3)]] }),
+		);
+		addInboxEntries(projectId, [entry("a", 5), entry("b", 10), entry("c", 20, { review: 8 })]);
+
+		markInboxSeen(projectId);
+
+		expect(stored(projectId).every((e) => e.seen)).toBe(true);
+		expect(marksOf(projectId)).toEqual({ 7: at(10), 8: at(20) });
+		// Activity after the newest entry is not what the reader declared read.
+		expect(Date.parse(marksOf(projectId)[7] ?? "")).toBeLessThan(Date.parse(at(12)));
+		// Review 9 has no entry in the inbox: its skip is not this action's to clear.
+		expect(unseenOf(projectId)).toEqual({ 9: [["c:2", at(3)]] });
+	});
+
+	it("still advances a stale watermark when every entry is already seen", () => {
+		const projectId = freshProject();
+		localStorage.setItem(`pr_activity_seen:v1:${projectId}`, JSON.stringify({ 7: at(0) }));
+		addInboxEntries(projectId, [entry("a", 10, { seen: true })]);
+
+		markInboxSeen(projectId);
+
+		expect(marksOf(projectId)[7]).toBe(at(10));
+	});
+
+	it("never moves a watermark backwards", () => {
+		const projectId = freshProject();
+		localStorage.setItem(`pr_activity_seen:v1:${projectId}`, JSON.stringify({ 7: at(30) }));
+		addInboxEntries(projectId, [entry("a", 10)]);
+
+		markInboxSeen(projectId);
+
+		expect(marksOf(projectId)[7]).toBe(at(30));
+	});
+
+	it("leaves other projects alone", () => {
+		const projectId = freshProject();
+		const other = freshProject();
+		localStorage.setItem(`pr_activity_seen:v1:${other}`, JSON.stringify({ 7: at(0) }));
+		addInboxEntries(other, [entry("a", 10)]);
+		addInboxEntries(projectId, [entry("a", 10)]);
+
+		markInboxSeen(projectId);
+
+		expect(marksOf(other)[7]).toBe(at(0));
+		expect(stored(other)[0]?.seen).toBe(false);
+	});
+});
+
+describe("markInboxSeen with ids", () => {
+	it("marks only those entries, leaving review watermarks and skips as they were", () => {
+		const projectId = freshProject();
+		localStorage.setItem(`pr_activity_seen:v1:${projectId}`, JSON.stringify({ 7: at(0) }));
+		localStorage.setItem(
+			`pr_activity_unseen:v1:${projectId}`,
+			JSON.stringify({ 7: [["c:1", at(3)]] }),
+		);
+		addInboxEntries(projectId, [entry("a", 5), entry("b", 10)]);
+
+		markInboxSeen(projectId, ["b"]);
+
+		expect(stored(projectId).map((e) => [e.id, e.seen])).toEqual([
+			["b", true],
+			["a", false],
+		]);
+		expect(marksOf(projectId)).toEqual({ 7: at(0) });
+		expect(unseenOf(projectId)).toEqual({ 7: [["c:1", at(3)]] });
+	});
+});

--- a/apps/lite/ui/src/review-inbox.ts
+++ b/apps/lite/ui/src/review-inbox.ts
@@ -7,6 +7,7 @@
  * in-memory snapshots.
  */
 
+import { markReviewsSeenUpTo } from "#ui/review-seen.ts";
 import { useSyncExternalStore } from "react";
 
 export type InboxKind =
@@ -167,9 +168,20 @@ export const addInboxEntries = (projectId: string, entries: Array<InboxEntry>): 
 	writeEntries(projectId, next);
 };
 
-/** Mark the given entries seen; without ids, everything. */
+/**
+ * Mark the given entries seen; without ids, everything — which also
+ * declares each represented review read up to its newest entry.
+ */
 export const markInboxSeen = (projectId: string, ids?: ReadonlyArray<string>): void => {
 	const entries = readEntries(projectId);
+	// Every current entry, seen or not: a watermark can lag entries already
+	// seen, and the declaration must cover it.
+	if (ids === undefined) {
+		markReviewsSeenUpTo(
+			projectId,
+			entries.map((entry) => [entry.review, entry.at] as const),
+		);
+	}
 	const wanted = ids === undefined ? null : new Set(ids);
 	if (!entries.some((entry) => !entry.seen && (wanted === null || wanted.has(entry.id)))) return;
 	writeEntries(

--- a/apps/lite/ui/src/review-seen.test.ts
+++ b/apps/lite/ui/src/review-seen.test.ts
@@ -1,5 +1,11 @@
 /** @vitest-environment jsdom */
-import { isItemSkipped, markItemSeen, markReviewSeen, registerReviewItems } from "./review-seen.ts";
+import {
+	isItemSkipped,
+	markItemSeen,
+	markReviewSeen,
+	markReviewsSeenUpTo,
+	registerReviewItems,
+} from "./review-seen.ts";
 import { describe, expect, it } from "vitest";
 
 /**
@@ -104,5 +110,80 @@ describe("markItemSeen", () => {
 
 		markItemSeen(projectId, 7, "c:2");
 		expect(unseenOf(projectId)[7]).toBeUndefined();
+	});
+});
+
+describe("markReviewsSeenUpTo", () => {
+	it("advances each watermark monotonically and drops the review's skips", () => {
+		const projectId = freshProject();
+		localStorage.setItem(
+			`pr_activity_seen:v1:${projectId}`,
+			JSON.stringify({ 7: at(0), 8: at(30), 9: at(0) }),
+		);
+		localStorage.setItem(
+			`pr_activity_unseen:v1:${projectId}`,
+			JSON.stringify({ 7: [["c:1", at(5)]], 9: [["c:2", at(5)]] }),
+		);
+
+		markReviewsSeenUpTo(
+			projectId,
+			new Map([
+				[7, at(10)],
+				[8, at(10)],
+			]),
+		);
+
+		expect(marksOf(projectId)).toEqual({ 7: at(10), 8: at(30), 9: at(0) });
+		expect(isItemSkipped(projectId, 7, "c:1")).toBe(false);
+		expect(isItemSkipped(projectId, 9, "c:2")).toBe(true);
+	});
+
+	it("clears skips at or before the cutoff and keeps those after it", () => {
+		const projectId = freshProject();
+		localStorage.setItem(`pr_activity_seen:v1:${projectId}`, JSON.stringify({ 7: at(0) }));
+		localStorage.setItem(
+			`pr_activity_unseen:v1:${projectId}`,
+			JSON.stringify({
+				7: [
+					["c:1", at(5)],
+					["c:2", at(10)],
+					["c:3", at(15)],
+				],
+			}),
+		);
+
+		// Repeated stamps settle on the newest as the cutoff, in either order.
+		markReviewsSeenUpTo(projectId, [
+			[7, at(10)],
+			[7, at(5)],
+		]);
+
+		expect(marksOf(projectId)[7]).toBe(at(10));
+		expect(unseenOf(projectId)[7]?.map(([key]) => key)).toEqual(["c:3"]);
+	});
+
+	it("settles repeated stamps on the newest, and writes nothing when nothing changes", () => {
+		const projectId = freshProject();
+		localStorage.setItem(`pr_activity_seen:v1:${projectId}`, JSON.stringify({ 7: at(0) }));
+
+		markReviewsSeenUpTo(projectId, [
+			[7, at(10)],
+			[7, at(5)],
+		]);
+		expect(marksOf(projectId)[7]).toBe(at(10));
+
+		localStorage.removeItem(`pr_activity_seen:v1:${projectId}`);
+		markReviewsSeenUpTo(projectId, [[7, at(5)]]);
+		// The cached mark was already past at(5): no write, so storage stays clear.
+		expect(localStorage.getItem(`pr_activity_seen:v1:${projectId}`)).toBeNull();
+
+		// A skip-only change writes the skips, not the marks.
+		localStorage.setItem(
+			`pr_activity_unseen:v1:${projectId}`,
+			JSON.stringify({ 7: [["c:1", at(5)]] }),
+		);
+		markReviewsSeenUpTo(projectId, [[7, at(10)]]);
+		expect(isItemSkipped(projectId, 7, "c:1")).toBe(false);
+		expect(localStorage.getItem(`pr_activity_seen:v1:${projectId}`)).toBeNull();
 	});
 });

--- a/apps/lite/ui/src/review-seen.ts
+++ b/apps/lite/ui/src/review-seen.ts
@@ -391,6 +391,43 @@ export const markReviewSeen = (projectId: string, number: number, modifiedAt: st
 	writeMarks(projectId, { ...readMarks(projectId), [number]: modifiedAt });
 };
 
+/**
+ * Declare activity read up to `latest`, one or more stamps per review:
+ * each watermark advances to the newest given — never backwards, a dwell
+ * may already have moved it further — and the review's skips at or before
+ * that newest stamp are dropped. A skip after it is still unread.
+ */
+export const markReviewsSeenUpTo = (
+	projectId: string,
+	latest: Iterable<readonly [number, string]>,
+): void => {
+	const marks = { ...readMarks(projectId) };
+	const unseen = { ...readUnseen(projectId) };
+	let marksChanged = false;
+	let unseenChanged = false;
+	// Order-free: the advance is monotonic and the skip filters compose, so
+	// repeated stamps for a review settle on the newest whichever comes first.
+	for (const [number, at] of latest) {
+		const atMs = Date.parse(at);
+		const seen = marks[number];
+		if (seen === undefined || atMs > Date.parse(seen)) {
+			marks[number] = at;
+			marksChanged = true;
+		}
+		const skipped = unseen[number];
+		if (skipped === undefined) continue;
+		const kept = skipped.filter(([, skippedAt]) => Date.parse(skippedAt) > atMs);
+		if (kept.length === skipped.length) continue;
+		if (kept.length > 0) unseen[number] = kept;
+		else delete unseen[number];
+		unseenChanged = true;
+	}
+	// One notify for both writes, as in `markReviewSeen`.
+	if (unseenChanged) setUnseen(projectId, unseen);
+	if (marksChanged) writeMarks(projectId, marks);
+	else if (unseenChanged) notify();
+};
+
 /** A beat, so flicking past a review does not eat its unread state. */
 const dwellMs = 1000;
 


### PR DESCRIPTION
Fix mark-all review activity state

## Context

Trigger: select Mark all read from the review inbox notification bell.

Impact: the inbox count clears but workspace review badges remain lit, so the same activity still appears unread.

Source: https://linear.app/gitbutler/issue/GB-1997/marking-all-notifications-read-does-not-update-workspace-badge

## Change

- Advance each represented review's seen watermark to its newest inbox event during bulk mark-all.
- Clear skipped activity for those reviews while preserving later watermarks and activity from other projects.
- Keep single-entry inbox marking inbox-only.
- Avoid storage writes and subscriber notifications when review-seen state is already current.

Validation: focused and full Lite tests, typecheck, build, lint, knip, oxfmt, and prettier passed.

Fixes GB-1997

FYI @PavelLaptev
