### PR TITLE
Use "reviewed" consistently in the Lite diff toolbar

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -2674,7 +2674,7 @@ const Diff: FC<{
 								}
 								onClick={toggleAllFilesReviewed}
 							>
-								{allFilesReviewed ? "Mark all unviewed" : "Mark all viewed"}
+								{allFilesReviewed ? "Mark all unreviewed" : "Mark all reviewed"}
 							</Toolbar.Button>
 							<ToggleGroupStyles>
 								<Toolbar.Button


### PR DESCRIPTION
The bulk button in the diff toolbar said "Mark all viewed" / "Mark all unviewed", while every other surface in Lite uses "reviewed": the per-file "Reviewed" checkbox, the "Reviewed" / "Not reviewed" tooltip, and the reviewed mark on file rows. The button now reads "Mark all reviewed" and "Mark all unreviewed".

Fixes GB-2003.

🤖 Generated with [Claude Code](https://claude.com/claude-code)