### PR TITLE
Fill the lines a fast checkbox drag skips in the Lite diff gutter

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/diff-gutter.test.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/diff-gutter.test.tsx
@@ -28,13 +28,19 @@ const HUNK: HunkAddress = {
 
 type GutterHandle = ReturnType<typeof useDiffGutterCheckboxes<unknown>>;
 
+/** One line per number, so a drag can be asked which lines it painted. */
+const lineAddress = ({ lineNumber }: { lineNumber: number }) =>
+	hunkAddress({ ...HUNK, lineGroups: [{ side: "additions", start: lineNumber, lines: 1 }] });
+
+const onCheckLine = vi.fn<(address: HunkAddress, shiftKey: boolean) => void>();
+
 const Probe = forwardRef<GutterHandle>((_props, ref) => {
 	const result = useDiffGutterCheckboxes<unknown>(
 		vi.fn(),
-		() => hunkAddress(HUNK),
+		lineAddress,
 		() => hunkAddress(HUNK),
 		"project",
-		vi.fn(),
+		onCheckLine,
 		vi.fn(),
 	);
 	useImperativeHandle(ref, () => result, [result]);
@@ -62,6 +68,58 @@ const pointerOver = (element: HTMLElement) =>
 		element.dispatchEvent(new Event("pointerover", { bubbles: true, composed: true }));
 	});
 
+type ColumnLine = { number: number; type?: "change-addition" | "context" };
+
+/**
+ * A column of number cells laid out the way Pierre renders one: a code element holding a gutter
+ * whose children are the cells. jsdom has no layout, so the cell under a point is whichever one
+ * the test last said it was.
+ */
+const createColumn = (
+	lines: Array<ColumnLine>,
+): {
+	host: HTMLElement;
+	cells: Array<HTMLElement>;
+	pointAt: (cell: HTMLElement) => void;
+	/** Rebuilds every cell from scratch, as a re-render of the diff does. */
+	rerender: () => Array<HTMLElement>;
+} => {
+	const host = document.createElement("div");
+	const shadowRoot = host.attachShadow({ mode: "open" });
+	const column = document.createElement("code");
+	column.setAttribute("data-code", "");
+	column.setAttribute("data-unified", "");
+	const gutter = document.createElement("div");
+	gutter.setAttribute("data-gutter", "");
+	column.append(gutter);
+	shadowRoot.append(column);
+	const build = (): Array<HTMLElement> =>
+		lines.map(({ number, type = "change-addition" }, index) => {
+			const cell = document.createElement("div");
+			cell.setAttribute("data-column-number", `${number}`);
+			cell.setAttribute("data-line-type", type);
+			cell.setAttribute("data-line-index", `${index},${index}`);
+			return cell;
+		});
+	const cells = build();
+	gutter.append(...cells);
+	let under: HTMLElement | null = null;
+	Reflect.set(shadowRoot, "elementFromPoint", () => under);
+	return {
+		host,
+		cells,
+		pointAt: (cell) => void (under = cell),
+		rerender: () => {
+			const next = build();
+			gutter.replaceChildren(...next);
+			return next;
+		},
+	};
+};
+
+const pointer = (type: string, init: PointerEventInit = {}): PointerEvent =>
+	new PointerEvent(type, { bubbles: true, composed: true, button: 0, ...init });
+
 describe("useDiffGutterCheckboxes", () => {
 	let container: HTMLDivElement;
 	let root: Root;
@@ -73,6 +131,7 @@ describe("useDiffGutterCheckboxes", () => {
 	};
 
 	beforeEach(() => {
+		onCheckLine.mockReset();
 		container = document.createElement("div");
 		document.body.append(container);
 		root = createRoot(container);
@@ -103,5 +162,87 @@ describe("useDiffGutterCheckboxes", () => {
 
 		pointerOver(code);
 		expect(host.shadowRoot?.querySelector("[data-gitbutler-diff-actions]")).toBeNull();
+	});
+
+	describe("checkbox drag", () => {
+		/** Mounts the column and presses the checkbox on `cell`. */
+		const press = async (host: HTMLElement, cell: HTMLElement): Promise<void> => {
+			const context = { type: "diff", item: ITEM, element: host, version: ITEM.version };
+			await act(async () => {
+				Reflect.apply(handle().onPostRender, undefined, [host, {}, "mount", context]);
+			});
+			const slot = cell.querySelector("slot[data-gitbutler-diff-gutter-slot-kind='line']");
+			if (!(slot instanceof HTMLElement)) throw new Error("expected a line slot");
+			slot.dispatchEvent(pointer("pointerdown"));
+		};
+
+		const paintedLines = (): Array<number | undefined> =>
+			onCheckLine.mock.calls.map(([address]) => address.lineGroups[0]?.start);
+
+		const cellAt = (cells: Array<HTMLElement>, index: number): HTMLElement => {
+			const cell = cells[index];
+			if (!cell) throw new Error(`expected a cell at ${index}`);
+			return cell;
+		};
+
+		it("paints every line a fast drag jumps over", async () => {
+			const { host, cells, pointAt } = createColumn([1, 2, 3, 4].map((number) => ({ number })));
+			pointAt(cellAt(cells, 0));
+			await press(host, cellAt(cells, 0));
+
+			// The pointer outran the sampling, so the only move lands three lines down.
+			pointAt(cellAt(cells, 3));
+			window.dispatchEvent(pointer("pointermove"));
+			window.dispatchEvent(pointer("pointerup"));
+
+			expect(paintedLines()).toEqual([1, 2, 3, 4]);
+		});
+
+		it("paints an upward drag in the order it travelled", async () => {
+			const { host, cells, pointAt } = createColumn([1, 2, 3, 4].map((number) => ({ number })));
+			pointAt(cellAt(cells, 3));
+			await press(host, cellAt(cells, 3));
+
+			pointAt(cellAt(cells, 0));
+			window.dispatchEvent(pointer("pointermove"));
+			window.dispatchEvent(pointer("pointerup"));
+
+			expect(paintedLines()).toEqual([4, 3, 2, 1]);
+		});
+
+		it("keeps a press that drifts onto a context line as a click", async () => {
+			const { host, cells, pointAt } = createColumn([
+				{ number: 1 },
+				{ number: 2, type: "context" },
+			]);
+			pointAt(cellAt(cells, 0));
+			await press(host, cellAt(cells, 0));
+
+			pointAt(cellAt(cells, 1));
+			window.dispatchEvent(pointer("pointermove"));
+			window.dispatchEvent(pointer("pointerup"));
+
+			expect(paintedLines()).toEqual([]);
+			expect(host.hasAttribute("data-gitbutler-diff-check-drag")).toBe(false);
+		});
+
+		it("carries on filling after the column is re-rendered mid-drag", async () => {
+			const { host, cells, pointAt, rerender } = createColumn(
+				[1, 2, 3, 4].map((number) => ({ number })),
+			);
+			pointAt(cellAt(cells, 0));
+			await press(host, cellAt(cells, 0));
+
+			pointAt(cellAt(cells, 1));
+			window.dispatchEvent(pointer("pointermove"));
+			expect(paintedLines()).toEqual([1, 2]);
+
+			const fresh = rerender();
+			pointAt(cellAt(fresh, 3));
+			window.dispatchEvent(pointer("pointermove"));
+			window.dispatchEvent(pointer("pointerup"));
+
+			expect(paintedLines()).toEqual([1, 2, 3, 4]);
+		});
 	});
 });

--- a/apps/lite/ui/src/routes/project/$id/workspace/diff-gutter.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/diff-gutter.ts
@@ -524,38 +524,79 @@ const createGutterStore = <T>(
 	 */
 	let checkDrag: {
 		host: HTMLElement;
-		startAddress: Extract<Address, { _tag: "Hunk" }>;
 		startKey: string;
+		/** The cell the drag last reached; the next sample paints from there. */
+		lastCell: HTMLElement;
 		checked: boolean;
 		painted: Set<string>;
 		moved: boolean;
 	} | null = null;
 
-	const lineAddressAtPoint = (
+	const lineCellAtPoint = (
 		host: HTMLElement,
 		clientX: number,
 		clientY: number,
-	): Extract<Address, { _tag: "Hunk" }> | null => {
-		const shadowRoot = host.shadowRoot;
-		const itemId = itemIdsByHost.get(host);
-		if (!shadowRoot || itemId === undefined) return null;
-
-		const element = shadowRoot.elementFromPoint(clientX, clientY);
+	): HTMLElement | null => {
+		const element = host.shadowRoot?.elementFromPoint(clientX, clientY);
 		if (!(element instanceof HTMLElement)) return null;
 
 		// A checkbox is the host's own child assigned to a slot, so the cell holding it is only an
 		// ancestor of the slot, never of the checkbox.
-		const cell =
+		return (
 			element.closest<HTMLElement>("[data-column-number]") ??
 			element.assignedSlot?.closest<HTMLElement>("[data-column-number]") ??
-			null;
-		if (!cell) return null;
+			null
+		);
+	};
+
+	const lineAddressFromCell = (
+		host: HTMLElement,
+		cell: HTMLElement,
+	): Extract<Address, { _tag: "Hunk" }> | null => {
+		const itemId = itemIdsByHost.get(host);
+		if (itemId === undefined) return null;
 
 		const target = diffLineTargetFromElement({ element: cell, itemId });
 		if (target?.lineType !== "change") return null;
 
 		const address = getLineAddress()(target);
 		return address ? hunkAddress(address) : null;
+	};
+
+	/** The cell in the same column as `beside` that stands for the line `cell` stood for. */
+	const sameLineCell = (beside: HTMLElement, cell: HTMLElement): HTMLElement | null => {
+		const lineNumber = cell.getAttribute("data-column-number");
+		const lineType = cell.getAttribute("data-line-type");
+		if (lineNumber === null || lineType === null) return null;
+
+		return (
+			beside.parentElement?.querySelector<HTMLElement>(
+				`[data-column-number="${CSS.escape(lineNumber)}"][data-line-type="${CSS.escape(lineType)}"]`,
+			) ?? null
+		);
+	};
+
+	/**
+	 * The number cells from one to another in travel order, both included. A pointer sample can
+	 * land several lines past the one before it — the browser reports at most one a frame, and a
+	 * quick flick outruns the mouse's own rate — so the lines between come from this walk rather
+	 * than from a sample each. The cells of a column are siblings, so the walk stops at the
+	 * column's edge: if the two are in different columns, only the two of them are returned.
+	 */
+	const lineCellsBetween = (from: HTMLElement, to: HTMLElement): Array<HTMLElement> => {
+		// A re-render replaces the cells wholesale; the line the drag last reached is still there.
+		const start = from.isConnected ? from : (sameLineCell(to, from) ?? from);
+		const forward = Boolean(start.compareDocumentPosition(to) & Node.DOCUMENT_POSITION_FOLLOWING);
+		const cells: Array<HTMLElement> = [];
+		for (
+			let cell: Element | null = start;
+			cell;
+			cell = forward ? cell.nextElementSibling : cell.previousElementSibling
+		) {
+			if (cell instanceof HTMLElement && cell.hasAttribute("data-column-number")) cells.push(cell);
+			if (cell === to) return cells;
+		}
+		return [from, to];
 	};
 
 	const paintCheckDragLine = (address: Extract<Address, { _tag: "Hunk" }>): void => {
@@ -572,19 +613,22 @@ const createGutterStore = <T>(
 	const handleCheckDragMove = (event: PointerEvent): void => {
 		if (!checkDrag) return;
 
-		const address = lineAddressAtPoint(checkDrag.host, event.clientX, event.clientY);
-		if (!address) return;
+		const { host, startKey } = checkDrag;
+		const cell = lineCellAtPoint(host, event.clientX, event.clientY);
+		if (!cell || cell === checkDrag.lastCell) return;
 
-		const key = addressIdentityKey(address);
-		// Until the press reaches another line it is still a click, and the checkbox answers it.
-		if (!checkDrag.moved && key === checkDrag.startKey) return;
-
+		// Context lines sit in the column too; the drag passes over them without painting.
+		const crossed = lineCellsBetween(checkDrag.lastCell, cell).flatMap(
+			(crossedCell) => lineAddressFromCell(host, crossedCell) ?? [],
+		);
 		if (!checkDrag.moved) {
+			// Until the press reaches another line it is still a click, and the checkbox answers it.
+			if (crossed.every((address) => addressIdentityKey(address) === startKey)) return;
 			checkDrag.moved = true;
-			checkDrag.host.setAttribute(CHECK_DRAG_ATTRIBUTE, "");
-			paintCheckDragLine(checkDrag.startAddress);
+			host.setAttribute(CHECK_DRAG_ATTRIBUTE, "");
 		}
-		paintCheckDragLine(address);
+		for (const address of crossed) paintCheckDragLine(address);
+		checkDrag.lastCell = cell;
 	};
 
 	/**
@@ -602,15 +646,17 @@ const createGutterStore = <T>(
 		const host = root instanceof ShadowRoot ? root.host : null;
 		if (!(host instanceof HTMLElement)) return;
 
-		const address = lineAddressAtPoint(host, event.clientX, event.clientY);
+		const cell = lineCellAtPoint(host, event.clientX, event.clientY);
+		if (!cell) return;
+		const address = lineAddressFromCell(host, cell);
 		if (!address) return;
 
 		event.stopPropagation();
 		endCheckDrag();
 		checkDrag = {
 			host,
-			startAddress: address,
 			startKey: addressIdentityKey(address),
+			lastCell: cell,
 			checked: !isAddressChecked(address),
 			painted: new Set(),
 			moved: false,


### PR DESCRIPTION
Fixes [GB-1982](https://linear.app/gitbutler/issue/GB-1982/fast-range-checking-lines-with-mouse-can-skip-lines).

## Problem

Dragging down the line checkboxes painted only the line under each pointer sample. The browser reports at most one sample per frame, and a quick flick outruns even the mouse's own report rate, so a fast drag landed several lines past the previous sample and the lines in between were never checked. A slow drag hit every line, which is why it looked intermittent.

## Fix

The drag now remembers the last cell it reached and, on each sample, walks the number cells from there to the cell under the pointer, painting every change line on the way. The walk goes over siblings inside the column's gutter, so it stays within one column of a split diff and costs only the lines actually crossed. It also survives a re-render of the gutter mid-drag by re-finding the last line by its attributes, paints in travel order so an upward drag leaves the shift-click anchor where the pointer ended, and treats a press that only drifts onto a context line as the click it still is.

## Tests

`diff-gutter.test.tsx` gains a fixture shaped like Pierre's real gutter and four drag cases: a fast downward drag, an upward drag, a drift onto a context line, and a re-render mid-drag.

Verified in the dev app over CDP with real mouse input: one move sample from line 933 to 945 checks all thirteen lines, the same upward unchecks them, and a drag from 936 to 940 touches only those five.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Screenshots

Before:

https://github.com/user-attachments/assets/0b127576-bbb5-4afe-a36a-0da20e1eb641

After:

https://github.com/user-attachments/assets/101d5264-a1d6-4f7b-bcde-1a640cc113c5