### PR TITLE
Dock the merge base row, not the target's card

### DIFF
--- a/apps/lite/ui/src/components/GraphSegment.module.css
+++ b/apps/lite/ui/src/components/GraphSegment.module.css
@@ -16,8 +16,7 @@
 	}
 }
 
-/* A stretch of the rail in another status's colour, given by its own status;
-   without one it keeps the glyph's. */
+/* A stretch of the rail in another status's colour; without one, the glyph's. */
 .tone {
 	color: var(--commit-status-color);
 }
@@ -45,11 +44,9 @@
 	}
 }
 
-/* The rail is the glyph colour faded back into the card, so it reads as a
-   quieter companion to the node without needing a token of its own. Blended
-   rather than translucent, so it is one colour wherever it runs; the
-   selection inversion above flips the card colour with the rest. Keep in
-   sync with Rails.module.css and Section.module.css. */
+/* The glyph colour faded into the card. Blended, not translucent, so it is
+   one colour wherever it runs; the inversion above flips the card colour
+   too. Keep in sync with Rails.module.css and Section.module.css. */
 .line {
 	stroke: color-mix(in srgb, currentColor 40%, var(--bg-1));
 }

--- a/apps/lite/ui/src/components/GraphSegment.tsx
+++ b/apps/lite/ui/src/components/GraphSegment.tsx
@@ -26,11 +26,7 @@ const glyphPaths = {
 	joinBoth: "M16 14L8 14M0 14H8M8 0V14M8 28V14",
 };
 
-/**
- * A stretch of the rail in another status's colour, or the glyph's own when
- * none is given: the line past an icon, where it belongs to the icon at its
- * other end.
- */
+/** A stretch of the rail in another status's colour, or the glyph's own when none is given. */
 const Tone: FC<{ status: GraphSegmentStatus | undefined; d: string }> = ({ status, d }) => (
 	<g className={styles.tone} data-status={status}>
 		<path className={styles.line} d={d} strokeWidth="1.5" />
@@ -154,22 +150,11 @@ export type GraphSegmentStatus = "Diverged" | "Upstream" | CommitState["type"];
 interface GraphSegmentProps extends ComponentProps<"div"> {
 	glyph: GraphSegmentGlyph;
 	status: GraphSegmentStatus;
-	/**
-	 * The rail ends on this row: the commit glyph and the centred group glyph
-	 * lose their tail below, and nothing stretches on under a taller row.
-	 */
+	/** The rail ends on this row: no tail below the icon, nothing stretched under a taller row. */
 	railEnds?: boolean;
-	/**
-	 * The group's rings sit on the row's centre line, for a single-line row
-	 * of their own; otherwise they head a folded indicator from a row's
-	 * second line down, on a shorter canvas.
-	 */
+	/** The rings sit on the row's centre line, for a single-line row of their own. */
 	centered?: boolean;
-	/**
-	 * The rail above or below the glyph's icon in another status's colour.
-	 * A stretch between two icons is the lower icon's; above a branch's tick,
-	 * and below a card's last icon, the rail is plain.
-	 */
+	/** The rail above or below the icon in another status's colour; a stretch between two icons is the lower one's. */
 	above?: GraphSegmentStatus;
 	below?: GraphSegmentStatus;
 }

--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/Rails.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/Rails.module.css
@@ -6,9 +6,8 @@
 	pointer-events: none;
 }
 
-/* The grey the row glyphs draw their rails in: the local commit colour at
-   40% into the card, one colour wherever it runs; keep in sync with
-   GraphSegment.module.css, Section.module.css and WorkspaceLists.module.css. */
+/* The row glyphs' rail grey; keep in sync with GraphSegment.module.css,
+   Section.module.css and WorkspaceLists.module.css. */
 .lane {
 	fill: none;
 	stroke: color-mix(in srgb, var(--commit-local) 40%, var(--bg-1));

--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/Rails.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/Rails.tsx
@@ -4,19 +4,12 @@ import styles from "./Rails.module.css";
 import { CARD_GAP, type Card, rails } from "./layout.ts";
 
 /*
- * One SVG behind the cards, drawing the rails through the gaps between them
- * from the virtualiser's measurements, so the gaps beside cards scrolled out
- * of the DOM get theirs too. Every card draws its own rails to its edges,
- * and the upstream section draws its own from its first row, in
- * Section.module.css.
+ * One SVG behind the cards, drawing the gaps between them from the
+ * virtualiser's measurements, so gaps beside unmounted cards are drawn too.
+ * Cards and the section draw their own rails.
  */
 export const Rails: FC<{
-	/**
-	 * The cards' measurements in plan order: the virtualiser's own cache,
-	 * replaced as cards are measured. Read after its total, which refreshes
-	 * it, and by index: it is a lazy view whose items exist once read, so
-	 * anything that skips holes, `map` included, misses the unread ones.
-	 */
+	/** The virtualiser's measurement cache. Read after its total, and by index: it is a lazy view, and `map` skips the unread. */
 	cards: ArrayLike<VirtualItem>;
 	/** Where the cards end; null without a base, when there is nothing to fork off and nothing is drawn. */
 	cardsEnd: number | null;

--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/Section.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/Section.module.css
@@ -4,8 +4,7 @@
 	color: var(--text-2);
 }
 
-/* How many commits the target has that the workspace does not: beside the
-   merge base's label, in the incoming rows' colour. */
+/* The count of new commits, in the incoming rows' colour. */
 .incoming {
 	flex-shrink: 0;
 	margin-inline-start: 8px;
@@ -31,20 +30,19 @@
 	overflow: hidden;
 }
 
-/* The section's colours: the grey the row glyphs draw their rails in, and
-   the incoming rows' colour, each at the glyphs' 40%; keep in sync with
+/* The rail greys, at the glyphs' 40%; keep in sync with
    GraphSegment.module.css and Rails.module.css. */
 .card,
+.ref,
 .base,
 .history {
 	--rail: color-mix(in srgb, var(--commit-local) 40%, var(--bg-1));
 	--leg: color-mix(in srgb, var(--commit-upstream) 40%, var(--bg-1));
 }
 
-/* The section's rails, on the line its rows' glyphs sit on (half a glyph
-   into the row inset): each element draws the line over its own stretch,
-   where its rows' glyphs do not. */
+/* Each element's stretch of the main line, on the row glyphs' x. */
 .card::after,
+.ref::after,
 .base::before,
 .history[data-open="true"]::before {
 	position: absolute;
@@ -54,34 +52,22 @@
 	content: "";
 }
 
-/* The target's card, a card gap under the last stack's: a forked stack
-   card's look, bordered top and bottom, its rows between a little air above
-   and below, a header row alone when folded. It sits a gap right of the
-   main line, which passes behind it, with the incoming commits on a leg of
-   their own that bends onto the line under the card (see .bend). Over
-   whatever the rails draw under it, docked or in its place. Keep in sync
-   with StackCard.module.css and WorkspaceLists.module.css. */
+/* The target's card, drawn like a forked stack card: a gap right of the
+   main line, which passes behind it, its incoming commits on a leg that
+   bends onto the line under the card (.gap). Keep in sync with
+   StackCard.module.css and WorkspaceLists.module.css. */
 .card {
 	--air: 4px;
-
-	z-index: 2;
 	position: relative;
 	margin-block-start: 20px;
 	padding-block: var(--air);
 	border-block: 1px solid var(--border-section);
 	background-color: var(--bg-1);
 
-	/* Folded, it docks at the scroller's foot while its place is below it,
-	   so the news of what is incoming stays in view. Unfolded it keeps its
-	   place: a docked card's toggle scrolls there before opening it. */
-	&[data-folded="true"] {
-		position: sticky;
-		bottom: 0;
-	}
+	isolation: isolate;
 
-	/* The main line passing behind the card, quieter, between its borders,
-	   above the rows and translucent over their fills: the line a forked
-	   stack card draws behind itself, in WorkspaceLists.module.css. */
+	/* The main line behind the card, as WorkspaceLists.module.css draws it
+	   behind a forked stack card; keep in sync. */
 	&::before {
 		z-index: 1;
 		position: absolute;
@@ -93,10 +79,8 @@
 		pointer-events: none;
 	}
 
-	/* The leg: the target's line from under the header's chevron, clear of it
-	   by its 10px (the air and 24px into the row, whose centre is 14px in),
-	   down the rows, which draw the same colour over their own stretch, and
-	   on over the card's floor to the bend under it. */
+	/* The leg, from under the chevron (the air and 24px into the row) down
+	   over the floor; the rows paint the same colour over it. */
 	&::after {
 		--out-of-chevron: calc(var(--air) + 24px);
 
@@ -109,33 +93,44 @@
 	}
 }
 
-/* The leg's bend, drawn against the base header in the gap above it: from
-   the target card's floor, a gap right of the main line, onto the line at
-   the header's top; the main line runs straight through the same gap. Keep
-   in sync with layout.ts's LEG_BEND. */
-.bend {
+/* The gap under the card: the leg bends onto the main line, which runs
+   straight through. Keep in sync with layout.ts's LEG_GAP and LEG_BEND. */
+.gap {
 	position: absolute;
-	top: calc(-1 * var(--gap));
+	/* Past the bottom border. */
+	top: calc(100% + 1px);
 	left: 0;
 	width: 32px;
-	height: var(--gap);
+	height: 12px;
 	overflow: visible;
 	fill: none;
-	stroke: var(--leg);
 	stroke-linecap: round;
 	stroke-linejoin: round;
 	stroke-width: 1.5;
 	pointer-events: none;
 }
 
-/* The ref row, a card gap under the last stack's. */
+.leg {
+	stroke: var(--leg);
+}
+
+.main {
+	stroke: var(--rail);
+}
+
+/* The ref row, a card gap under the last stack's; it draws the gap under itself. */
 .ref {
+	position: relative;
 	margin-block-start: 20px;
 }
 
-/* The base header sits a card gap below the last stack's card, where a
-   fork has to bend, and a smaller gap below the target's card or the ref
-   row. Positioned, so its rail piece is placed against it. */
+.ref::after {
+	top: 100%;
+	height: 12px;
+}
+
+/* A card gap below the last stack card, where a fork bends; a smaller gap
+   below the target's card or the ref row. */
 .base {
 	--gap: 20px;
 
@@ -152,13 +147,44 @@
 	position: relative;
 }
 
-/* The gap above the base header, from the row or card above it, and into
-   its chevron: half a row less the chevron's 10px of clearance. When the
-   base header comes first, the SVG's own run through the gap under the
-   cards coincides with it. Out of the chevron into the rows while unfolded. */
+/* Folded, the merge base row docks at the scroller's foot, keeping the
+   count and Update in view; its toggle scrolls to its place before opening.
+   Stuck, it gets air, a hairline, and no line into its chevron, which would
+   claim a line above that is not there. Keep in sync with layout.ts's
+   DOCKED_HEIGHT. */
+.docked {
+	--air: 4px;
+	container-type: scroll-state;
+
+	z-index: 2;
+	position: sticky;
+	bottom: var(--air);
+
+	&::after {
+		z-index: -1;
+		position: absolute;
+		inset: 0;
+		background-color: var(--bg-2);
+		content: "";
+	}
+
+	@container scroll-state(stuck: bottom) {
+		&::before {
+			display: none;
+		}
+
+		&::after {
+			inset: calc(-1 * var(--air) - 1px) 0 calc(-1 * var(--air));
+			border-block-start: 1px solid var(--border-section);
+		}
+	}
+}
+
+/* Into the chevron; what sits above draws the gap down to the header. Out
+   of the chevron into the rows while unfolded. */
 .base::before {
-	top: calc(-1 * var(--gap));
-	height: calc(var(--gap) + 4px);
+	top: 0;
+	height: 4px;
 }
 
 .history[data-open="true"]::before {
@@ -173,8 +199,7 @@
 	font-weight: 400;
 }
 
-/* A control in the label's line: centred on it, whatever its height, so the
-   row keeps its height. */
+/* Centred on the label line, so the row keeps its height. */
 .action {
 	display: flex;
 	align-items: center;

--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/Section.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/Section.tsx
@@ -33,6 +33,8 @@ import styles from "./Section.module.css";
 import {
 	CARD_X,
 	LEG_BEND,
+	LEG_GAP,
+	MAIN_X,
 	type Plan,
 	rowInsetFor,
 	type Run,
@@ -40,17 +42,13 @@ import {
 } from "./layout.ts";
 
 /*
- * The upstream section under the stacks: the target's header row, folding
- * the commits incoming from it, then the base header, folding the rows below
- * the base and the older history with the "show more" row at its foot. The
- * commit rows are values on the applied list's cursor, and the Upstream
- * tab's own, so they carry review titles; the headers are not values.
+ * The upstream section under the stacks: the target's row or card, folding
+ * the incoming commits, then the merge base header, folding the history
+ * below it. Commit rows are values on the applied cursor; headers are not.
  */
 
-// Rows on the main line are the base the stacks sit on and take the integrated
-// colour; rows on the incoming leg are ahead of it and take the upstream's.
-// A pending operation drops them from the applied list, and then they are
-// inert, as a card's rows are.
+// Base rows take the integrated colour, incoming rows the upstream's. Rows a
+// pending operation drops from the list are inert.
 const commitRow = (
 	commit: TargetCommit,
 	status: "Integrated" | "Upstream",
@@ -72,11 +70,7 @@ const commitRow = (
 	);
 };
 
-/**
- * A header row: not a value, so nothing selects it. With a fold, the whole
- * row toggles it; the toggle on its rail is the control assistive
- * technology sees, and other controls in the row keep their own clicks.
- */
+/** A header row: not a value. With a fold, the whole row toggles it; the rail toggle is the control assistive technology sees. */
 const Header: FC<{
 	label: string;
 	/** Beside the label, in the label's own line: a count, an id. */
@@ -87,19 +81,16 @@ const Header: FC<{
 	fold?: { open: boolean; onToggle: () => void; name: string };
 	/** After the label, in its line: a control of the row's own. */
 	glyph: ReactNode;
-	/** A rail piece of the row's own, drawn against it out of its flow. */
-	rail?: ReactNode;
 	className?: string;
 	style?: CSSProperties;
 	children?: ReactNode;
-}> = ({ label, caption, heading = false, fold, glyph, rail, className, style, children }) => (
+}> = ({ label, caption, heading = false, fold, glyph, className, style, children }) => (
 	<Row
 		interactive={fold !== undefined}
 		onSelect={fold?.onToggle}
 		className={className}
 		style={style}
 	>
-		{rail}
 		{fold === undefined ? (
 			glyph
 		) : (
@@ -169,11 +160,7 @@ const runRows = (
 	);
 };
 
-/**
- * Updates the workspace onto the target's tip, the sidebar's own action:
- * rebases every stack onto it. The tip is what was fetched; this does not
- * fetch.
- */
+/** Rebases every stack onto the target's fetched tip; this does not fetch. */
 const Update: FC<{ projectId: string }> = ({ projectId }) => {
 	const { data: headInfo } = useQuery(headInfoQueryOptions(projectId));
 	const noOperationPending = useAppSelector(
@@ -237,7 +224,7 @@ export const Section: FC<{
 	onShowMoreRun: (runId: string) => void;
 	onFoldRun: (runId: string) => void;
 	onShowMore: () => void;
-	/** The scroller the section is in, for the docked card's toggle to scroll to its place. */
+	/** The scroller, for the docked merge base row's toggle to scroll to its place. */
 	scrollElementRef: RefObject<HTMLDivElement | null>;
 }> = ({
 	projectId,
@@ -253,15 +240,14 @@ export const Section: FC<{
 }) => {
 	const branched = plan.header.incoming > 0;
 	const addressSpace = useAddressSpace();
-	// A docked card stays folded. Its toggle scrolls to the bottom and opens
-	// it, holding the bottom while the fold grows, so the rows open in view.
-	const incomingFold = useRef<HTMLDivElement>(null);
-	const incomingRows = useRef<HTMLDivElement>(null);
-	const toggleIncoming = () => {
+	// Opening from docked: scroll to the bottom and hold it while the fold grows.
+	const baseFold = useRef<HTMLDivElement>(null);
+	const baseRows = useRef<HTMLDivElement>(null);
+	const toggleBase = () => {
 		const scroller = scrollElementRef.current;
-		const fold = incomingFold.current;
-		const rows = incomingRows.current;
-		if (!plan.incomingExpanded && scroller !== null && fold !== null && rows !== null) {
+		const fold = baseFold.current;
+		const rows = baseRows.current;
+		if (!plan.baseExpanded && scroller !== null && fold !== null && rows !== null) {
 			scroller.scrollTop = scroller.scrollHeight;
 			let height = 0;
 			const hold = new ResizeObserver(() => {
@@ -272,7 +258,7 @@ export const Section: FC<{
 			});
 			hold.observe(fold);
 		}
-		onToggleIncoming();
+		onToggleBase();
 	};
 	// The line ends on the last row shown: the "show more" row, else the
 	// last commit once the history is shown to its start.
@@ -285,14 +271,10 @@ export const Section: FC<{
 			{plan.base !== null &&
 				!plan.refOnBase &&
 				(branched ? (
-					// The target has moved on from the workspace's history: a card
-					// like a forked stack's, a gap right of the main line, its header
-					// row folding the incoming commits on their leg. Folded, the card
-					// docks at the scroller's foot while its place is below it, so the
-					// news stays in view.
+					// The target has moved on: a card like a forked stack's, its
+					// incoming commits on a leg.
 					<div
 						className={styles.card}
-						data-folded={!plan.incomingExpanded}
 						style={{ "--row-padding-inline-start": `${rowInsetFor(CARD_X)}px` }}
 					>
 						<Header
@@ -300,13 +282,13 @@ export const Section: FC<{
 							heading
 							fold={{
 								open: plan.incomingExpanded,
-								onToggle: toggleIncoming,
+								onToggle: onToggleIncoming,
 								name: "incoming commits",
 							}}
 							glyph={chevron(plan.incomingExpanded)}
 						/>
-						<Fold open={plan.incomingExpanded} ref={incomingFold}>
-							<div ref={incomingRows} className={styles.rows}>
+						<Fold open={plan.incomingExpanded}>
+							<div className={styles.rows}>
 								{plan.incoming.map((run) =>
 									runRows(
 										run,
@@ -318,6 +300,10 @@ export const Section: FC<{
 								)}
 							</div>
 						</Fold>
+						<svg className={styles.gap} aria-hidden>
+							<path className={styles.main} d={`M ${MAIN_X} 0 V ${LEG_GAP}`} />
+							<path className={styles.leg} d={LEG_BEND} />
+						</svg>
 					</div>
 				) : (
 					// The target sits above the base with nothing incoming: a row on
@@ -331,9 +317,7 @@ export const Section: FC<{
 				))}
 			{plan.base !== null && (
 				<>
-					{/* The target's tip is the merge base itself: one row, the ref's name
-					    on the base commit, so the two do not read as two commits. With
-					    the target moved on, the row says how far: what Update brings. */}
+					{/* The ref's tip on the base: one row for both. Moved on: the row says how far. */}
 					<Header
 						label={plan.refOnBase ? plan.header.label : "Merge base"}
 						caption={
@@ -348,48 +332,42 @@ export const Section: FC<{
 						heading={plan.refOnBase}
 						fold={{
 							open: plan.baseExpanded,
-							onToggle: onToggleBase,
+							onToggle: toggleBase,
 							name: "the merge base's history",
 						}}
 						glyph={chevron(plan.baseExpanded)}
-						// The leg's bend, from the target's card above onto the main line.
-						rail={
-							branched && (
-								<svg className={styles.bend} aria-hidden>
-									<path d={LEG_BEND} />
-								</svg>
-							)
-						}
-						className={styles.base}
+						className={classes(styles.base, !plan.baseExpanded && styles.docked)}
 					>
 						{branched && <Update projectId={projectId} />}
 					</Header>
-					<Fold open={plan.baseExpanded} className={styles.history}>
-						{plan.belowBase.map((item, index) =>
-							item.kind === "fork"
-								? commitRow(
-										item.commit,
-										"Integrated",
-										addressSpace,
-										endsOnBase && index === plan.belowBase.length - 1,
-									)
-								: runRows(
-										item,
-										"Integrated",
-										addressSpace,
-										() => onShowMoreRun(item.id),
-										() => onFoldRun(item.id),
-									),
-						)}
-						{plan.older.map((commit, index) =>
-							commitRow(
-								commit,
-								"Integrated",
-								addressSpace,
-								historyEnds && index === plan.older.length - 1,
-							),
-						)}
-						{moreBelow !== "hidden" && <ShowMore state={moreBelow} onSelect={onShowMore} />}
+					<Fold open={plan.baseExpanded} className={styles.history} ref={baseFold}>
+						<div ref={baseRows} className={styles.rows}>
+							{plan.belowBase.map((item, index) =>
+								item.kind === "fork"
+									? commitRow(
+											item.commit,
+											"Integrated",
+											addressSpace,
+											endsOnBase && index === plan.belowBase.length - 1,
+										)
+									: runRows(
+											item,
+											"Integrated",
+											addressSpace,
+											() => onShowMoreRun(item.id),
+											() => onFoldRun(item.id),
+										),
+							)}
+							{plan.older.map((commit, index) =>
+								commitRow(
+									commit,
+									"Integrated",
+									addressSpace,
+									historyEnds && index === plan.older.length - 1,
+								),
+							)}
+							{moreBelow !== "hidden" && <ShowMore state={moreBelow} onSelect={onShowMore} />}
+						</div>
 					</Fold>
 				</>
 			)}

--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/layout.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/layout.ts
@@ -4,27 +4,20 @@ import { remoteTrackingLabel } from "#ui/branch.ts";
 import type { RefInfo, Stack, TargetCommit, TargetCommitPage } from "@gitbutler/but-sdk";
 
 /*
- * The stacks section as a graph: the order the cards come in, which rows
- * the upstream section shows, and the rail paths between them. Pure: pixels
- * come in as measured anchors and go out as SVG path strings.
+ * The stacks section as a graph: card order, which section rows show, and
+ * the rail paths between the cards. Pure: measured pixels in, SVG paths out.
  *
- * The rules: one main line runs up the left, from the last row of the
- * upstream section through the section and on past every card, on the
- * card's left, into the top card, which sits on it. Every other card forks
- * off it to the right in the gap under the card: its rows sit one gap right
- * of the main line, and its rail bends down onto the main line below its
- * floor. A target that has moved on gets a card like that too: its incoming
- * commits sit on a leg beside the main line, which bends onto it under the
- * card, at the merge base. Nothing else is drawn. The SVG draws only the
- * gaps between the stack cards: every card draws its own rails to its
- * edges, and the section draws its own, in Section.module.css.
+ * One main line runs up the left into the top card. Every other card, and a
+ * moved-on target's, sits a gap to its right and bends onto the line in the
+ * gap under it. The SVG draws only the gaps between stack cards; cards and
+ * the section draw their own rails (Section.module.css).
  */
 
-/** The forked cards' rail sits this far right of the main line, which runs on behind them. */
+/** How far right of the main line the forked cards' rail sits. */
 const COLUMN_GAP = 12;
-/** The main line's x, a gap and a half in from the edge. */
+/** The main line's x. */
 export const MAIN_X = 18;
-/** The forked cards' rail, and a moved-on target's: where their row glyphs sit; the top card's sit on the main line. */
+/** The forked cards' rail, and a moved-on target's. */
 export const CARD_X = MAIN_X + COLUMN_GAP;
 /** A rail's x inside a row: the row inset plus half the glyph. Keep in sync with Row.module.css. */
 const GLYPH_X = 20;
@@ -34,19 +27,10 @@ const ROW_INSET = 12;
 export const rowInsetFor = (x: number): number => x - (GLYPH_X - ROW_INSET);
 /** Every turn is a quarter circle of this radius. */
 const CORNER_R = 4;
-/**
- * Vertical gap between cards, where a card's rail bends onto its line. Every
- * stretch the lines bend through is this tall: the room above the upstream
- * header, the room under it while folded, and the room around the incoming
- * card. Keep in sync with Section.module.css.
- */
+/** The gap between cards, tall enough for a rail to bend through. Keep in sync with Section.module.css. */
 export const CARD_GAP = 20;
-/**
- * The folded target card's height, which a row scrolled into view clears
- * while the card docks: its borders, its air, its header row and its air.
- * Keep in sync with Section.module.css.
- */
-export const DOCKED_HEIGHT = 2 + 4 + 28 + 4;
+/** The stuck merge base row's height, hairline and air included, which a row scrolled into view clears. Keep in sync with Section.module.css. */
+export const DOCKED_HEIGHT = 1 + 4 + 28 + 4;
 /** A long list, a run or the older history, shows this much at first, and this much more with each ask. */
 export const FIRST = 10;
 export const MORE = 20;
@@ -62,11 +46,7 @@ type Folds = {
 	moreOlder: number;
 };
 
-/**
- * A target commit as a value: the address the graph, the Upstream tab and the
- * applied list agree on. The change id falls back to the commit id, which
- * should be revisited.
- */
+/** A target commit as a value, shared with the Upstream tab. The change id falls back to the commit id; revisit. */
 export const targetCommitAddress = (commit: TargetCommit): Address =>
 	commitAddress({
 		commitId: commit.commit.id,
@@ -92,45 +72,28 @@ export type Plan = {
 	order: Array<number>;
 	/** The target's row: its label and how many commits are incoming. Not a value: nothing selects it. */
 	header: { label: string; incoming: number };
-	/**
-	 * The target's tip is the base itself, with nothing incoming: one row
-	 * stands for both, the base commit under the ref's name.
-	 */
+	/** The target's tip is the base itself: one row stands for both. */
 	refOnBase: boolean;
 	incomingExpanded: boolean;
 	baseExpanded: boolean;
-	/**
-	 * The commit the stacks nearest the tip sit on, named by the base header
-	 * and left out of the rows under it. Not a value either: the header only
-	 * folds. Null while unknown.
-	 */
+	/** The commit the stacks nearest the tip sit on; the base header names it. Null while unknown. */
 	base: TargetCommit | null;
-	/**
-	 * Commits on the target the workspace does not have yet: they sit ahead of
-	 * the base on their own leg beside the main line. Empty while folded.
-	 */
+	/** Commits on the target the workspace lacks, on their leg. Empty while folded. */
 	incoming: Array<Run>;
 	/** Below the base, on the main line; empty while the base is folded. */
 	belowBase: Array<Item>;
-	/** Older history below the deepest fork point, as much of it as is shown: what the listing holds, then the pages fetched; plain rows. Empty while the base is folded. */
+	/** Older history below the deepest fork point, as much as is shown. Empty while the base is folded. */
 	older: Array<TargetCommit>;
 	/** Older history loaded but not shown yet: what the next ask reveals before any page is fetched. */
 	olderHidden: number;
 };
 
-/**
- * A stretch of the target line: a commit a workspace stack forks from, or
- * the run of commits between such fork points.
- */
+/** A stretch of the target line: a stack's base, or the run between such forks. */
 type TargetItem =
 	| { type: "fork"; commit: TargetCommit }
 	| { type: "run"; commits: Array<TargetCommit>; inWorkspace: boolean };
 
-/**
- * Cut the target line at the workspace's fork points: each stack's base
- * stands on its own, and the commits between them group into maximal runs
- * sharing one relation to the workspace.
- */
+/** Cut the target line at the stacks' bases; between them, maximal runs with one relation to the workspace. */
 const segmentAtForks = (
 	commits: ReadonlyArray<TargetCommit>,
 	stacks: ReadonlyArray<Stack>,
@@ -153,9 +116,8 @@ const segmentAtForks = (
 const foldRuns = (line: ReadonlyArray<TargetItem>, folds: Folds): Array<Item> =>
 	line.slice(0, line.findLastIndex((item) => item.type === "fork") + 1).map((item) => {
 		if (item.type === "fork") return { kind: "fork", commit: item.commit };
-		// Incoming runs keep their newest in view; runs the workspace already
-		// has fold entirely. Each ask reveals more. A fold hiding a single row
-		// is not worth the row.
+		// Incoming runs show their newest; runs the workspace has fold entirely.
+		// A fold hiding one row is not worth it.
 		const incoming = !item.inWorkspace;
 		const id = assert(item.commits[0]).commit.id;
 		const asked = folds.moreRuns[id] ?? 0;
@@ -182,8 +144,7 @@ export const layout = (
 	const commits = listing?.commits ?? [];
 	const line = segmentAtForks(commits, stacks);
 	const items = foldRuns(line, folds);
-	// What the listing holds below the deepest fork point heads the older
-	// history, before the pages fetched for it.
+	// The listing's tail below the deepest fork heads the older history.
 	const trailing = line
 		.slice(line.findLastIndex((item) => item.type === "fork") + 1)
 		.flatMap((item) => (item.type === "fork" ? [item.commit] : item.commits));
@@ -195,9 +156,8 @@ export const layout = (
 		(item) => item.kind !== "fork" || item.commit.commit.id !== base?.commit.id,
 	);
 
-	// Deeper bases first, nearest their own history's end; a base the listing
-	// does not reach is deeper than any listed, all of them equally, so they
-	// keep the order given.
+	// Deeper bases first; a base the listing does not reach counts as deepest,
+	// keeping the order given.
 	const forkOrder = items.flatMap((item) => (item.kind === "fork" ? [item.commit.commit.id] : []));
 	const depth = (stack: Stack): number => {
 		const index = stack.base === null ? -1 : forkOrder.indexOf(stack.base);
@@ -273,10 +233,7 @@ export type Card = { topY: number; bottomY: number };
 const ARC_K = 0.5523;
 const n = (value: number): string => String(Math.round(value * 100) / 100);
 
-/**
- * An S-bend from one line to another: straight, a quarter-turn toward the
- * other line, straight across, a quarter-turn back down, straight on.
- */
+/** An S-bend from one line to another: two quarter-turns joined by a straight. */
 const sBend = (x0: number, y0: number, x1: number, y1: number): string => {
 	const dir = x1 > x0 ? 1 : -1;
 	const r = CORNER_R;
@@ -292,7 +249,7 @@ const sBend = (x0: number, y0: number, x1: number, y1: number): string => {
 };
 
 /** The gap under the target's card, which its leg bends through. Keep in sync with Section.module.css. */
-const LEG_GAP = 12;
+export const LEG_GAP = 12;
 /** The leg's bend under the target's card: off the card's floor, onto the main line at the merge base header's top. */
 export const LEG_BEND = `M ${n(CARD_X)} 0 ${sBend(CARD_X, 0, MAIN_X, LEG_GAP)}`;
 
@@ -302,12 +259,8 @@ const runDown = (rails: Array<string>, x: number, from: number, to: number): voi
 };
 
 /**
- * The rails through the gaps between the cards, as SVG paths; every card
- * draws its own to its edges. The top card sits on the main line, which runs
- * on from its floor, through each gap into the card below, and through the
- * gap under the last card to the upstream section's first row; from there
- * the section carries it itself. Every other card's rail bends off its
- * floor onto the main line in the gap below it.
+ * The rails through the gaps between the cards: the main line from the top
+ * card's floor down to the section, and each other card's bend onto it.
  */
 export const rails = (cards: ReadonlyArray<Card>, cardsEnd: number): Array<string> => {
 	const paths: Array<string> = [];

--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/usePlan.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/usePlan.ts
@@ -14,11 +14,9 @@ import { FIRST, layout, MORE, type Plan } from "./layout.ts";
 export type Graph = ReturnType<typeof usePlan>;
 
 /**
- * The stacks graph's plan from the workspace's data and the fold state, with
- * the cards in the order the plan draws them. Called once per host, the page
- * and the harness panel, which build the applied address space from it and
- * hand it to the stacks to render: a second call would page the older
- * history twice.
+ * The stacks graph's plan and the cards in its order. Called once per host,
+ * which hands it to the stacks: a second call would page the older history
+ * twice.
  */
 export const usePlan = (projectId: string) => {
 	const { data: headInfo } = useQuery(headInfoQueryOptions(projectId));
@@ -26,17 +24,14 @@ export const usePlan = (projectId: string) => {
 	const folds = useAppSelector((state) =>
 		projectSlice.selectors.selectGraphFolds(state, projectId),
 	);
-	// Older history below the deepest fork point: the listing's own tail first,
-	// then pages shared with the Upstream tab, the first of them fetched as
-	// the base opens and the rest on demand.
+	// Older history: pages shared with the Upstream tab, fetched as the base opens and on demand.
 	const olderFrom = listing?.commits.at(-1)?.commit.id ?? "";
 	const olderOptions = olderTargetCommitsInfiniteQueryOptions(projectId, olderFrom);
 	const olderQuery = useInfiniteQuery({
 		...olderOptions,
 		enabled: folds.baseExpanded && olderFrom !== "",
 	});
-	// Folding the base forgets the pages it loaded, so it opens from scratch
-	// next time rather than as long as it was left.
+	// Folding the base forgets its pages, so it reopens from scratch.
 	const queryClient = useQueryClient();
 	const forgetOlder = () => queryClient.removeQueries({ queryKey: olderOptions.queryKey });
 	const olderPagesData = olderQuery.data;
@@ -46,14 +41,12 @@ export const usePlan = (projectId: string) => {
 	);
 	const listOrder = useMemo(() => (headInfo?.stacks ?? []).toReversed(), [headInfo]);
 	const target = headInfo?.target ?? null;
-	// Explicit: the compiler does not memoise calls to imported functions, and
-	// the rails re-measure whenever the plan's identity changes.
+	// Explicit: the compiler does not memoise imported calls, and the rails re-measure on every new plan.
 	const plan: Plan = useMemo(
 		() => layout(listOrder, target, listing, folds, olderPages),
 		[listOrder, target, listing, folds, olderPages],
 	);
-	// Pages come as the rows shown ask for them: the first as the base opens,
-	// and another whenever an ask outruns what is loaded.
+	// Fetch a page whenever an ask outruns what is loaded.
 	const { fetchNextPage, hasNextPage, isFetching } = olderQuery;
 	const loaded = plan.older.length + plan.olderHidden;
 	const wanted = folds.baseExpanded ? FIRST + folds.moreOlder * MORE : 0;

--- a/apps/lite/ui/src/routes/project/$id/workspace/StackCard.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/StackCard.module.css
@@ -32,9 +32,8 @@
 	overflow: hidden;
 }
 
-/* In the stacks graph a rail runs on from the card's floor: the stub runs
-   over the border to the card's edge, and the rail picks it up there rather
-   than crossing the border. */
+/* In the graph the stub runs over the border to the card's edge, where the
+   rail below picks it up. */
 .card[data-graph] .railConnector:last-child {
 	height: 9px;
 	margin-block-end: -1px;

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.module.css
@@ -141,10 +141,8 @@
 	position: relative;
 }
 
-/* The positioned box the rails SVG covers: the cards and the upstream section
-   below them, with the room under the column: the base header's gap again,
-   constant across fold states, so opening a fold does not shift the scroll,
-   and there while the section has nothing to show. */
+/* The box the rails SVG covers: the cards and the section. The room below
+   is constant across fold states, so a fold does not shift the scroll. */
 .content {
 	position: relative;
 	padding-block-end: 12px;
@@ -154,14 +152,9 @@
 	border-block-start: 1px solid var(--border-section);
 }
 
-/* A forked card sits a gap right of the main line, which runs on behind it.
-   The card carries it across itself, quieter, between its borders, which
-   stay whole over it: the line passes under the card's edge, and the rails
-   between the cards only ever draw in the gaps. Above the rows, whose fills
-   it crosses in their inset, and translucent where the other rails are
-   blended into the card: a mid grey darkens a selected row's light fill and
-   lightens a focused row's dark one, where a fixed light grey vanished on
-   the one and glared on the other. */
+/* The main line behind a forked card, between its borders, above the rows.
+   Translucent, unlike the other rails: it crosses row fills, and a mid grey
+   stays visible on a selected row's light fill and a focused row's dark one. */
 .virtualStack[data-forked="true"]::after {
 	z-index: 1;
 	position: absolute;

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.tsx
@@ -666,7 +666,7 @@ const SegmentContent: FC<{
 		getItemKey: getCommitKey,
 		rangeExtractor: rangeExtractorWithSelected,
 		scrollMargin,
-		// Matches --scroll-gradient-height; the foot also clears the target's docked card.
+		// Matches --scroll-gradient-height; the foot also clears the docked merge base row.
 		scrollPaddingStart: 14,
 		scrollPaddingEnd,
 	});
@@ -1081,9 +1081,7 @@ const Stacks: FC<{
 		operation: dryRunOperation,
 	});
 	const dryRunWorkspace = dryRunOperationResult?.workspace ?? null;
-	// Cards in the graph's order, the upstream section below, and the rails
-	// between them drawn in one SVG over both. The host computed the plan once
-	// and built the address space from it.
+	// Cards in the graph's order, the section below, the rails between them in one SVG.
 	const { plan, stacks, olderQuery, olderFrom, forgetOlder } = graph;
 	const olderPagesData = olderQuery.data;
 	// Shown to its start: everything loaded is shown, and a page came back
@@ -1104,10 +1102,8 @@ const Stacks: FC<{
 	// Undefined `headInfo` is still loading, which is not the same as "empty" —
 	// treating it as empty would flash the empty state on every open.
 	const isEmpty = headInfo !== undefined && stacks.length === 0;
-	// Docked, the target's folded card lies over what scrolls past under it:
-	// a row scrolled into view clears it, as it clears the gradient at the
-	// foot otherwise.
-	const scrollPaddingEnd = plan.header.incoming > 0 && !plan.incomingExpanded ? DOCKED_HEIGHT : 14;
+	// A row scrolled into view clears the docked merge base row, else the foot's gradient.
+	const scrollPaddingEnd = plan.base !== null && !plan.baseExpanded ? DOCKED_HEIGHT : 14;
 	const foldedSegments = useAppSelector((state) =>
 		projectSlice.selectors.selectFoldedSegments(state, projectId),
 	);
@@ -1148,9 +1144,8 @@ const Stacks: FC<{
 			: undefined;
 
 	// Pin the containing stack too, otherwise the nested selected row can still be unmounted.
-	// In index order: a pinned index that sits appended while off-range and in place once the
-	// range reaches it would move every card's node on each flip, and the scroller re-anchors on
-	// every move, snapping the scroll back at that boundary.
+	// In index order: a pinned index flipping between appended and in place would move every
+	// card's node, and the scroller re-anchors on each move.
 	const rangeExtractorWithSelected = useCallback(
 		(range: Range) =>
 			getRangeExtractorWithIndices(
@@ -1201,7 +1196,7 @@ const Stacks: FC<{
 		getItemKey: getStackKey,
 		rangeExtractor: rangeExtractorWithSelected,
 		gap: CARD_GAP,
-		// Matches --scroll-gradient-height; the foot also clears the target's docked card.
+		// Matches --scroll-gradient-height; the foot also clears the docked merge base row.
 		scrollPaddingStart: 14,
 		scrollPaddingEnd,
 	});
@@ -1286,10 +1281,8 @@ const Stacks: FC<{
 					role="tree"
 					aria-activedescendant={selection ? treeItemId(selection) : undefined}
 					className={classes(styles.tree, styles.content)}
-					// The merge base and its history sit on the main line; the stack
-					// cards and a moved-on target's set their own inset, and those a
-					// gap right of the line draw it behind themselves. A row is
-					// indented only where the line runs behind it.
+					// Section rows sit on the main line; the cards set their own inset.
+					// A row is indented only where the line runs behind it.
 					style={{
 						"--row-padding-inline-start": `${rowInsetFor(MAIN_X)}px`,
 						"--main-line-x": `${MAIN_X}px`,

--- a/apps/lite/ui/src/routes/project/$id/workspace/applied-address-space.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/applied-address-space.ts
@@ -20,11 +20,9 @@ const hasAnyOperation = (sources: Array<Address>, target: Address, kind: Transfe
 };
 
 /**
- * The applied list's address space: everything the stacks column shows, top
- * to bottom, as values. Cards in the graph's order, then the upstream
- * section's rows as its folds show them. While an operation waits for its
- * target only the workspace's own rows stay: what the target holds can be
- * looked at, not acted on.
+ * The applied list's address space: the cards' rows, then the section's rows
+ * as its folds show them. While an operation waits for its target only the
+ * workspace's own rows stay.
  */
 export const buildAppliedAddressSpace = ({
 	stacks,


### PR DESCRIPTION
Follow-up to #15736. The merge base row now says how many commits are new and carries Update, so it is the row to keep in view while the stacks scroll.

- The merge base row is sticky while its history is folded. Stuck at the scroller's foot it gets 4px of air all round, a hairline on top, and no line into its chevron, since what scrolls past above is not the line it would claim to come from. At its place it is unchanged. Its toggle scrolls to its place before opening, as the target's card did.
- The target's card stays in flow. It draws the gap under itself, the leg's bend and the main line through it, as a small inline SVG, and the ref row draws its gap the same way. The docked row carries nothing outside its box, so docking needs no scroll tracking: a scroll-state container query tells the row's own pseudo-elements whether it is stuck.
- A row scrolled into view clears the docked row's height.

Verified in a fixture with master five commits ahead: docked over the cards, opened from docked with the scroll landing at the bottom, at its place under the card, and with the incoming card open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)