### PR TITLE
Remove the Workspace activity badge in Lite

### DIFF
--- a/apps/lite/e2e/tests/sidebar.spec.ts
+++ b/apps/lite/e2e/tests/sidebar.spec.ts
@@ -1,0 +1,130 @@
+import type { LiteElectronApi } from "../../electron/src/ipc.ts";
+import type { ForgeInfo, ForgeReview, TargetCommitPage } from "@gitbutler/but-sdk";
+import { expect, test } from "../test.ts";
+
+test.use({ scenario: "project-in-single-branch-three-branch-stack.sh" });
+
+test("keeps unread PR activity off the Workspace tab", async ({ appWindow, electronApp }) => {
+	const settings = await appWindow.evaluate(() =>
+		(window as unknown as { lite: LiteElectronApi }).lite.readGUISettings(),
+	);
+	const review: ForgeReview = {
+		number: 1,
+		title: "Update C",
+		sourceBranch: "C",
+		targetBranch: "master",
+		htmlUrl: "https://example.com/repo/pull/1",
+		body: null,
+		author: null,
+		labels: [],
+		draft: false,
+		sha: "0000000000000000000000000000000000000001",
+		integrationCommitShas: [],
+		createdAt: "2026-08-01T00:00:00Z",
+		modifiedAt: "2026-08-02T00:00:00Z",
+		mergedAt: null,
+		closedAt: null,
+		repositorySshUrl: null,
+		repositoryHttpsUrl: null,
+		repoOwner: null,
+		headRepoIsFork: false,
+		reviewers: [],
+		autoMergeEnabled: false,
+		unitSymbol: "#",
+		lastSyncAt: "2026-08-02T00:00:00Z",
+	};
+	await electronApp.evaluate(
+		({ ipcMain }, { settings, review }) => {
+			ipcMain.removeHandler("readGUISettings");
+			ipcMain.handle("readGUISettings", () => ({ ...settings, prNotifications: "loud" }));
+			ipcMain.removeHandler("forgeInfo");
+			ipcMain.handle(
+				"forgeInfo",
+				() =>
+					({
+						name: "github",
+						baseUrl: "https://example.com/repo",
+						commitUrlPath: "/commit/",
+						prUrlPath: "/pull/",
+						unit: { symbol: "#", name: "pull request", abbr: "PR" },
+						posthogLabel: "",
+						capabilities: {
+							prService: true,
+							checks: false,
+							repoInfo: false,
+							listService: false,
+							reviewComments: false,
+							reviewManagement: false,
+						},
+					}) satisfies ForgeInfo,
+			);
+			ipcMain.removeHandler("listReviews");
+			ipcMain.handle("listReviews", () => [review]);
+			ipcMain.removeHandler("workspaceTargetCommits");
+			ipcMain.handle(
+				"workspaceTargetCommits",
+				() =>
+					({
+						commits: [
+							{
+								commit: {
+									id: "0000000000000000000000000000000000000002",
+									message: "Incoming commit",
+									author: { name: "Test", email: "test@example.com", gravatarUrl: "" },
+									authoredAt: 0,
+									committedAt: 0,
+									changeId: null,
+								},
+								review: null,
+								inWorkspace: false,
+							},
+						],
+						hasMore: false,
+					}) satisfies TargetCommitPage,
+			);
+		},
+		{ settings, review },
+	);
+	await appWindow.evaluate((review) => {
+		const projectId = location.pathname.split("/")[2];
+		if (projectId === undefined) throw new Error("No project in the URL");
+		localStorage.setItem(
+			`pr_activity_seen:v1:${projectId}`,
+			JSON.stringify({ [review.number]: review.createdAt }),
+		);
+		localStorage.setItem(
+			`pr_activity_inbox:v1:${projectId}`,
+			JSON.stringify([
+				{
+					id: "comment-1",
+					kind: "comment",
+					review: review.number,
+					reviewTitle: review.title,
+					unitSymbol: review.unitSymbol,
+					sourceBranch: review.sourceBranch,
+					htmlUrl: review.htmlUrl,
+					author: null,
+					count: 1,
+					snippet: "Please take a look",
+					at: review.modifiedAt,
+					seen: false,
+				},
+			]),
+		);
+	}, review);
+	await appWindow.reload();
+
+	await expect(appWindow.getByRole("button", { name: "Notifications, 1 unread" })).toBeVisible();
+	await expect(
+		appWindow
+			.getByRole("treeitem", { name: "C", exact: true })
+			.getByTitle("New activity on this pull request"),
+	).toBeVisible();
+	const pages = appWindow.getByRole("group", { name: "Pages" });
+	await expect(pages.getByRole("button", { name: "Upstream", exact: true })).toHaveText(
+		/^Upstream\s*1$/,
+	);
+	await expect(pages.getByRole("button", { name: "Workspace", exact: true })).toHaveText(
+		"Workspace",
+	);
+});

--- a/apps/lite/ui/src/review-seen.ts
+++ b/apps/lite/ui/src/review-seen.ts
@@ -278,19 +278,6 @@ export const useReviewUnread = (
 	);
 };
 
-/** How many of `reviews` have unread activity — again a primitive. */
-export const useUnreadReviewCount = (
-	projectId: string,
-	reviews: Array<{ number: number; modifiedAt: string | null }>,
-	enabled: boolean,
-): number =>
-	useSyncExternalStore(enabled ? subscribeMarks : subscribeNothing, () => {
-		if (!enabled) return 0;
-		const marks = readMarks(projectId);
-		return reviews.filter((review) => isUnread(projectId, review.number, review.modifiedAt, marks))
-			.length;
-	});
-
 /**
  * Stamp reviews seen when first listed and prune marks for delisted ones.
  * An absent mark reads as seen, so the stamp is what makes only activity

--- a/apps/lite/ui/src/routes/project/$id/workspace/Sidebar.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Sidebar.tsx
@@ -1,15 +1,12 @@
 import { useWorkspaceIntegrateUpstream } from "#ui/api/mutations.ts";
 import { setPage, usePage } from "#ui/use-cursor.ts";
 import {
-	forgeInfoOptions,
 	guiSettingsQueryOptions,
 	headInfoQueryOptions,
-	listReviewsQueryOptions,
 	workspaceFetchQueryOptions,
 	workspaceFetchStatusQueryOptions,
 } from "#ui/api/queries.ts";
 import { NotificationBell } from "#ui/review-inbox-bell.tsx";
-import { usePrNotificationsLevel, useUnreadReviewCount } from "#ui/review-seen.ts";
 import { stackBottomRelativeTo } from "#ui/api/stack.ts";
 import { errorMessageForToast } from "#ui/errors.ts";
 import { Icon } from "#ui/components/Icon.tsx";
@@ -57,38 +54,6 @@ const adjacentPage = (tab: PageId, offset: -1 | 1): PageId => {
  * read. The upstream page states the exact count.
  */
 const maxBadgeCount = 99;
-
-/**
- * How many applied-branch pull requests have unread activity. Its own
- * component so its subscriptions wake only this badge, not the sidebar.
- */
-const WorkspaceActivityBadge: FC<{ projectId: string }> = ({ projectId }) => {
-	const { data: forgeInfo } = useQuery(forgeInfoOptions(projectId));
-	const notificationsLevel = usePrNotificationsLevel();
-	const prService = !!forgeInfo?.capabilities.prService && notificationsLevel !== "off";
-	const { data: appliedBranches } = useQuery({
-		...headInfoQueryOptions(projectId),
-		enabled: prService,
-		select: (headInfo) =>
-			new Set(
-				headInfo.stacks.flatMap((stack) =>
-					stack.segments.flatMap((segment) => segment.refName?.displayName ?? []),
-				),
-			),
-	});
-	const { data: appliedReviews } = useQuery({
-		...listReviewsQueryOptions({ projectId, cacheConfig: "noCache" }),
-		enabled: prService,
-		select: (reviews) =>
-			reviews
-				.filter((review) => appliedBranches?.has(review.sourceBranch) === true)
-				.map((review) => ({ number: review.number, modifiedAt: review.modifiedAt })),
-	});
-	const count = useUnreadReviewCount(projectId, appliedReviews ?? [], prService);
-	if (count === 0) return null;
-
-	return <Badge variant="fillGray">{count > maxBadgeCount ? `${maxBadgeCount}+` : count}</Badge>;
-};
 
 export const Sidebar: FC<{
 	absorptionTargetCommitIds: ReadonlySet<string>;
@@ -285,7 +250,6 @@ export const Sidebar: FC<{
 					>
 						<Icon name="workbench" />
 						<span className={styles.tabLabel}>Workspace</span>
-						<WorkspaceActivityBadge projectId={projectId} />
 					</Toggle>
 					<Toggle
 						render={<ToggleStyles />}


### PR DESCRIPTION
## Context

While checking unread pull request activity on an applied branch, an unexplained numeric badge beside Workspace made its meaning ambiguous. It looked like Upstream's incoming-commit count, but counted unread PRs. The notification bell and branch/PR indicators remain, and Upstream continues to show incoming commits.

Related history: https://github.com/gitbutlerapp/gitbutler/pull/15736

## Change

Remove the Workspace badge and its unused subscriptions and count hook. Add a rendered sidebar regression test for unread PR activity and the preserved indicators.

FYI @PavelLaptev
