### PR TITLE
Classify stale GitLab credentials

### DIFF
--- a/apps/desktop/src/lib/error/errorClassification.test.ts
+++ b/apps/desktop/src/lib/error/errorClassification.test.ts
@@ -178,6 +178,25 @@ describe("classify", () => {
 			expect(result.userMessage).toContain("personal access token");
 			expect(result.userMessage).toContain("then try again");
 		});
+
+		test.each<[Code, RegExp]>([
+			["GitLabUnauthorized", /new personal access token/],
+			["GitLabForbidden", /token scopes.*account permissions/],
+		])("%s is terminal with static reauthentication guidance", (code, guidance) => {
+			// `get_gl_user` tags a stored-token 401/403; the raw message carries
+			// no useful detail, so the static copy must say what to change.
+			const error = new IpcError(
+				{ message: "Failed to get authenticated user", code },
+				"get_gl_user",
+			);
+			const result = classify(error);
+			expect(result.code).toBe(code);
+			expect(result.severity).toBe("error");
+			// Terminal: telemetry captures it once per session (see the
+			// terminal-code dedup test in error.test.ts).
+			expect(result.terminal).toBe(true);
+			expect(result.userMessage).toMatch(guidance);
+		});
 	});
 
 	describe("GitHub device-flow codes", () => {

--- a/apps/desktop/src/lib/error/errorClassification.ts
+++ b/apps/desktop/src/lib/error/errorClassification.ts
@@ -205,6 +205,25 @@ With \`seahorse\` or equivalent, create a \`Login\` password store, right click 
 Your GitHub token appears expired. Please log out and back in to refresh it. (Settings -> Integrations -> Forget)
 	`,
 	},
+	/**
+	 * GitLab rejected a stored token (401) or refused the account behind it
+	 * (403). Both are terminal until the user stores a different token; a 403
+	 * needs scopes or permissions, not the same token typed again.
+	 */
+	GitLabUnauthorized: {
+		severity: "error",
+		terminal: true,
+		title: "GitLab Token Rejected",
+		userMessage:
+			"GitLab did not accept your stored token; it may have expired or been revoked. Store a new personal access token under Settings → Integrations.",
+	},
+	GitLabForbidden: {
+		severity: "error",
+		terminal: true,
+		title: "GitLab Access Refused",
+		userMessage:
+			"GitLab refused access for your stored token. Check the token scopes and your account permissions, then store a new token under Settings → Integrations.",
+	},
 	...GITHUB_DEVICE_OAUTH_CLASSIFICATIONS,
 	GitHubOrgOAuthRestricted: GH_ORG_AUTH_CLASSIFICATION,
 	GitHubOrgSamlRestricted: {

--- a/apps/desktop/src/lib/forge/gitlab/gitlabUserService.svelte.ts
+++ b/apps/desktop/src/lib/forge/gitlab/gitlabUserService.svelte.ts
@@ -156,7 +156,7 @@ export class GitLabUserService {
 	}
 }
 
-function injectBackendEndpoints(api: BackendApi) {
+export function injectBackendEndpoints(api: BackendApi) {
 	return api.injectEndpoints({
 		endpoints: (build) => ({
 			forgetGitLabAccount: build.mutation<void, GitlabAccountIdentifier>({
@@ -181,8 +181,12 @@ function injectBackendEndpoints(api: BackendApi) {
 					command: "get_gl_user",
 				},
 				query: (args) => args,
+				// The account list tag is what every credential mutation
+				// invalidates, so a mounted lookup the old token failed with
+				// refetches once a replacement token is stored.
 				providesTags: (_result, _error, username) => [
 					...providesItem(ReduxTag.ForgeUser, `gitlab:${username}`),
+					providesList(ReduxTag.GitLabUserList),
 				],
 			}),
 			listKnownGitLabAccounts: build.query<GitlabAccountIdentifier[], void>({
@@ -210,11 +214,7 @@ function injectBackendEndpoints(api: BackendApi) {
 					actionName: "Store GitLab PAT",
 				},
 				query: (args) => args,
-				invalidatesTags: [
-					providesList(ReduxTag.GitLabUserList),
-					invalidatesList(ReduxTag.PullRequests),
-					invalidatesList(ReduxTag.Checks),
-				],
+				invalidatesTags: invalidatesAfterStoredToken,
 			}),
 			storeGitLabEnterprisePat: build.mutation<
 				GitlabAuthStatusResponse,
@@ -225,12 +225,21 @@ function injectBackendEndpoints(api: BackendApi) {
 					actionName: "Store GitLab Enterprise PAT",
 				},
 				query: (args) => args,
-				invalidatesTags: [
-					providesList(ReduxTag.GitLabUserList),
-					invalidatesList(ReduxTag.PullRequests),
-					invalidatesList(ReduxTag.Checks),
-				],
+				invalidatesTags: invalidatesAfterStoredToken,
 			}),
 		}),
 	});
+}
+
+/**
+ * A static tag list is also applied when the mutation fails, which would
+ * refetch the user lookup with the unchanged, still-rejected credentials.
+ */
+function invalidatesAfterStoredToken(_result: unknown, error: unknown) {
+	if (error) return [];
+	return [
+		providesList(ReduxTag.GitLabUserList),
+		invalidatesList(ReduxTag.PullRequests),
+		invalidatesList(ReduxTag.Checks),
+	];
 }

--- a/apps/desktop/src/lib/forge/gitlab/gitlabUserService.test.ts
+++ b/apps/desktop/src/lib/forge/gitlab/gitlabUserService.test.ts
@@ -1,12 +1,109 @@
 import {
 	gitLabEnterprisePatError,
 	gitlabAccountIdentifierToString,
+	injectBackendEndpoints,
 	stringToGitLabAccountIdentifier,
 } from "$lib/forge/gitlab/gitlabUserService.svelte";
-import { describe, expect, test } from "vitest";
+import { ReduxTag } from "$lib/state/tags";
+import { configureStore } from "@reduxjs/toolkit";
+import { createApi, QueryStatus } from "@reduxjs/toolkit/query";
+import { describe, expect, test, vi } from "vitest";
+import type { BackendApi } from "$lib/state/backendApi";
 import type { GitlabAccountIdentifier } from "@gitbutler/but-sdk";
 
 const UNIT_SEP = "\u001F";
+
+describe("storing a replacement PAT", () => {
+	const account: GitlabAccountIdentifier = {
+		type: "selfHosted",
+		info: { host: "gitlab.example.com", username: "alice" },
+	};
+	const user = { accessToken: "new", username: "alice", avatarUrl: null, name: null, email: null };
+
+	const rejected = { error: { code: "GitLabUnauthorized", message: "rejected" } };
+
+	/**
+	 * The service's real endpoint definitions on a plain RTK store. The user
+	 * lookup is rejected once, the way a revoked token is, and answered after;
+	 * every other command answers with `storeOutcome`.
+	 */
+	function setup(storeOutcome: { data: unknown } | { error: unknown }) {
+		const lookups = vi.fn().mockResolvedValueOnce(rejected).mockResolvedValue({ data: user });
+		const api = createApi({
+			reducerPath: "backend",
+			tagTypes: Object.values(ReduxTag),
+			invalidationBehavior: "immediately",
+			baseQuery: async (_args: unknown, _api: unknown, extraOptions?: { command?: string }) =>
+				extraOptions?.command === "get_gl_user" ? lookups() : storeOutcome,
+			endpoints: () => ({}),
+		});
+		const { endpoints } = injectBackendEndpoints(api as unknown as BackendApi);
+		const store = configureStore({
+			reducer: { [api.reducerPath]: api.reducer },
+			middleware: (getDefault) => getDefault().concat(api.middleware),
+		});
+		function userQuery() {
+			return endpoints.getGitLabUser.select({ account })(store.getState());
+		}
+		return { endpoints, store, userQuery, lookups };
+	}
+	type Harness = ReturnType<typeof setup>;
+
+	/** Subscribes the user query, as a mounted settings card does, and lets it reject. */
+	async function mountRejectedUserQuery({ store, endpoints, userQuery }: Harness) {
+		await store.dispatch(endpoints.getGitLabUser.initiate({ account }));
+		expect(userQuery().status).toBe(QueryStatus.rejected);
+	}
+
+	const mutations: [string, (harness: Harness) => Promise<void>][] = [
+		[
+			"storeGitLabPat",
+			async ({ store, endpoints }) => {
+				await store.dispatch(endpoints.storeGitLabPat.initiate({ accessToken: "new" }));
+			},
+		],
+		[
+			"storeGitLabEnterprisePat",
+			async ({ store, endpoints }) => {
+				await store.dispatch(
+					endpoints.storeGitLabEnterprisePat.initiate({
+						host: "gitlab.example.com",
+						accessToken: "new",
+					}),
+				);
+			},
+		],
+	];
+
+	test.each(mutations)(
+		"%s refetches a still-mounted rejected getGitLabUser query",
+		async (_, storePat) => {
+			const harness = setup({ data: {} });
+			await mountRejectedUserQuery(harness);
+
+			await storePat(harness);
+
+			await vi.waitFor(() => expect(harness.userQuery().status).toBe(QueryStatus.fulfilled));
+			expect(harness.userQuery().data).toEqual(user);
+			expect(harness.lookups).toHaveBeenCalledTimes(2);
+		},
+	);
+
+	test.each(mutations)(
+		"%s leaves the rejected query alone when the token was not stored",
+		async (_, storePat) => {
+			const harness = setup(rejected);
+			await mountRejectedUserQuery(harness);
+
+			await storePat(harness);
+
+			// An invalidation refetch would already have started by now.
+			await new Promise((resolve) => setTimeout(resolve, 20));
+			expect(harness.lookups).toHaveBeenCalledTimes(1);
+			expect(harness.userQuery().status).toBe(QueryStatus.rejected);
+		},
+	);
+});
 
 describe("GitLab Enterprise PAT errors", () => {
 	test.each([

--- a/crates/but-gitlab/src/lib.rs
+++ b/crates/but-gitlab/src/lib.rs
@@ -196,7 +196,8 @@ pub async fn get_gl_user(
                 {
                     tracing::warn!("Failed to clear cached GitLab profile: {err}");
                 }
-                Err(client_err.context("Failed to get authenticated user"))
+                Err(classify_pat_validation_error(client_err)
+                    .context("Failed to get authenticated user"))
             }
         }
     } else {

--- a/crates/but-gitlab/tests/gitlab_auth.rs
+++ b/crates/but-gitlab/tests/gitlab_auth.rs
@@ -2,8 +2,74 @@ use std::io::{Read as _, Write as _};
 use std::net::TcpListener;
 
 use but_error::AnyhowContextExt as _;
-use but_gitlab::{list_known_gitlab_accounts, store_selfhosted_pat};
+use but_gitlab::{
+    GitlabAccountIdentifier, get_gl_user, list_known_gitlab_accounts, store_selfhosted_pat,
+};
 use but_secret::Sensitive;
+
+/// A process-wide in-memory keyring, so a token persisted by one call can be
+/// read back by the next. `keyring::mock` keeps data per entry, which cannot.
+mod memory_keyring {
+    use std::any::Any;
+    use std::collections::BTreeMap;
+    use std::sync::{LazyLock, Mutex, Once};
+
+    use keyring::credential::{CredentialApi, CredentialBuilderApi};
+
+    static STORE: LazyLock<Mutex<BTreeMap<String, Vec<u8>>>> = LazyLock::new(Default::default);
+
+    struct Entry(String);
+
+    impl CredentialApi for Entry {
+        fn set_secret(&self, secret: &[u8]) -> keyring::Result<()> {
+            STORE
+                .lock()
+                .unwrap()
+                .insert(self.0.clone(), secret.to_vec());
+            Ok(())
+        }
+
+        fn get_secret(&self) -> keyring::Result<Vec<u8>> {
+            STORE
+                .lock()
+                .unwrap()
+                .get(&self.0)
+                .cloned()
+                .ok_or(keyring::Error::NoEntry)
+        }
+
+        fn delete_credential(&self) -> keyring::Result<()> {
+            STORE.lock().unwrap().remove(&self.0);
+            Ok(())
+        }
+
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+    }
+
+    struct Builder;
+
+    impl CredentialBuilderApi for Builder {
+        fn build(
+            &self,
+            _target: Option<&str>,
+            service: &str,
+            user: &str,
+        ) -> keyring::Result<Box<keyring::Credential>> {
+            Ok(Box::new(Entry(format!("{service}\0{user}"))))
+        }
+
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+    }
+
+    pub fn install() {
+        static ONCE: Once = Once::new();
+        ONCE.call_once(|| keyring::set_default_credential_builder(Box::new(Builder)));
+    }
+}
 
 struct MockServer(std::thread::JoinHandle<()>);
 
@@ -13,34 +79,40 @@ impl MockServer {
     }
 }
 
-fn mock_gitlab(status: u16, body: &'static str) -> (String, MockServer) {
+/// Serve `responses` in order, one per connection, to `GET /api/v4/user`.
+fn mock_gitlab(responses: Vec<(u16, &'static str)>) -> (String, MockServer) {
     let listener = TcpListener::bind("127.0.0.1:0").expect("mock server should bind");
     let address = listener
         .local_addr()
         .expect("mock server should have an address");
     let handle = std::thread::spawn(move || {
-        let (mut stream, _) = listener.accept().expect("mock server should accept");
-        let mut request = Vec::new();
-        let mut chunk = [0; 1024];
-        while !request.windows(4).any(|window| window == b"\r\n\r\n") {
-            let read = stream.read(&mut chunk).expect("request should be readable");
-            assert_ne!(read, 0, "request should include complete HTTP headers");
-            request.extend_from_slice(&chunk[..read]);
+        for (status, body) in responses {
+            let (mut stream, _) = listener.accept().expect("mock server should accept");
+            let mut request = Vec::new();
+            let mut chunk = [0; 1024];
+            while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+                let read = stream.read(&mut chunk).expect("request should be readable");
+                assert_ne!(read, 0, "request should include complete HTTP headers");
+                request.extend_from_slice(&chunk[..read]);
+            }
+            let request = String::from_utf8(request).expect("request should be valid UTF-8");
+            assert!(
+                request.starts_with("GET /api/v4/user "),
+                "PAT validation should request the authenticated user"
+            );
+            write!(
+                stream,
+                "HTTP/1.1 {status} Mock\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            )
+            .expect("mock response should be writable");
         }
-        let request = String::from_utf8(request).expect("request should be valid UTF-8");
-        assert!(
-            request.starts_with("GET /api/v4/user "),
-            "PAT validation should request the authenticated user"
-        );
-        write!(
-            stream,
-            "HTTP/1.1 {status} Mock\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
-            body.len()
-        )
-        .expect("mock response should be writable");
     });
     (format!("http://{address}"), MockServer(handle))
 }
+
+const ALICE: &str = r#"{"username":"alice","name":"Alice","email":null,"avatar_url":null}"#;
+const REJECTED: &str = r#"{"message":"rejected"}"#;
 
 fn mock_tls_failure() -> (String, MockServer) {
     let listener = TcpListener::bind("127.0.0.1:0").expect("mock server should bind");
@@ -83,11 +155,11 @@ fn assert_no_credentials(storage: &but_forge_storage::Controller) {
 
 #[test]
 fn self_hosted_pat_validation_distinguishes_auth_transport_and_success() {
-    keyring::set_default_credential_builder(keyring::mock::default_credential_builder());
+    memory_keyring::install();
 
     run(async {
         for (status, expected_code) in [(401, "GitLabUnauthorized"), (403, "GitLabForbidden")] {
-            let (host, server) = mock_gitlab(status, r#"{"message":"rejected"}"#);
+            let (host, server) = mock_gitlab(vec![(status, REJECTED)]);
             let dir = tempfile::tempdir().expect("temporary storage should be created");
             let storage = but_forge_storage::Controller::from_path(dir.path());
             let error = store_selfhosted_pat(&host, &Sensitive("bad-token".into()), &storage)
@@ -117,8 +189,7 @@ fn self_hosted_pat_validation_distinguishes_auth_transport_and_success() {
         );
         assert_no_credentials(&storage);
 
-        let body = r#"{"username":"alice","name":"Alice","email":null,"avatar_url":null}"#;
-        let (host, server) = mock_gitlab(200, body);
+        let (host, server) = mock_gitlab(vec![(200, ALICE)]);
         let dir = tempfile::tempdir().expect("temporary storage should be created");
         let storage = but_forge_storage::Controller::from_path(dir.path());
         let response = store_selfhosted_pat(&host, &Sensitive("good-token".into()), &storage)
@@ -136,5 +207,45 @@ fn self_hosted_pat_validation_distinguishes_auth_transport_and_success() {
             1,
             "successful validation should store credentials"
         );
+    });
+}
+
+#[test]
+fn stored_account_refresh_classifies_auth_rejection_and_clears_cache() {
+    memory_keyring::install();
+
+    run(async {
+        for (status, expected_code) in [(401, "GitLabUnauthorized"), (403, "GitLabForbidden")] {
+            let (host, server) = mock_gitlab(vec![(200, ALICE), (status, REJECTED)]);
+            let dir = tempfile::tempdir().expect("temporary storage should be created");
+            let storage = but_forge_storage::Controller::from_path(dir.path());
+            store_selfhosted_pat(&host, &Sensitive("token".into()), &storage)
+                .await
+                .expect("valid PAT should be stored");
+            let account = GitlabAccountIdentifier::selfhosted("alice", &host);
+            let cached_profile = || {
+                storage
+                    .cached_profile(&account.cache_key())
+                    .expect("cached profile should be readable")
+            };
+            assert!(
+                cached_profile().is_some(),
+                "successful validation should cache the profile"
+            );
+
+            let error = get_gl_user(&account, &storage)
+                .await
+                .expect_err("rejected stored token should fail the refresh");
+            server.finish();
+            assert_eq!(
+                error.custom_context_or_error_chain().code.to_string(),
+                expected_code,
+                "a stored-token rejection should carry the same code as PAT validation"
+            );
+            assert!(
+                cached_profile().is_none(),
+                "auth rejection should clear the cached profile"
+            );
+        }
     });
 }


### PR DESCRIPTION
## Context

A stored GitLab token can become invalid after its profile has already been cached. When GitLab then returns 401 or 403 from the user endpoint, GitButler clears the stale profile but currently reports the failure as `Unknown`. That leaves Desktop without a stable terminal authentication state and allows repeated query-error reporting.

Trigger: a previously valid stored GitLab token later receives 401 or 403 from the authenticated-user endpoint.

Impact: Desktop cleared the stale profile but reported Unknown, repeated query-error telemetry, and did not automatically recover after credentials changed.

Source: [GB-2006](https://linear.app/gitbutler/issue/GB-2006/stored-gitlab-credentials-returning-401-stay-unknown-and-repeat)

## Change

- reuse the existing safe GitLab 401/403 classifier when refreshing stored accounts while preserving profile-cache clearing and network fallbacks
- classify the existing GitLab auth codes as terminal in Desktop, with static replacement-token and scope guidance
- invalidate rejected GitLab account queries only after replacement credentials are stored successfully, so failed stores do not immediately retry unchanged credentials
- cover sequential success-to-rejection behavior, terminal classification, and successful versus failed credential-update recovery

Fixes GB-2006

FYI @PavelLaptev
