### PR TITLE
Show the uncommitted list fade whenever rows are cut off

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.module.css
@@ -64,9 +64,9 @@
 
 	flex-grow: 1;
 
-	/* Gradient ramp that fades out the scrolling items, shown only once the
-	   list has been scrolled away from the top and there is still more content
-	   below. An untouched list shows no ramp. */
+	/* Gradient ramp that fades out the scrolling items, shown whenever there
+	   is more content below the fold, scrolled or not. It goes once the list
+	   reaches its end, when there is nothing left to hint at. */
 	&::after {
 		display: block;
 		z-index: 1;
@@ -82,7 +82,7 @@
 		pointer-events: none;
 		transition: opacity 120ms ease;
 
-		@container scroll-state((scrollable: top) and (scrollable: bottom)) {
+		@container scroll-state(scrollable: bottom) {
 			opacity: 1;
 		}
 	}


### PR DESCRIPTION
The bottom gradient on the uncommitted file list in Lite was gated on `scroll-state((scrollable: top) and (scrollable: bottom))`, so it only appeared after the list had been scrolled away from the top. A freshly loaded list with rows hidden under the commit button showed no fade at all, even though the last visible row was clipped.

This keys the fade on `scrollable: bottom` alone. It now shows whenever there is more content below the fold, scrolled or not, and still disappears once the list reaches its end. The comment above the rule is updated to match.

 ## Screenshots

Before:

<img width="473" alt="Screenshot 2026-09-07 at 11-51-30" src="https://github.com/user-attachments/assets/c91f5c2f-9ad0-4bb4-b1e1-07770456b23c" />

After:

<img width="473" alt="image" src="https://github.com/user-attachments/assets/7dcf968c-21b7-4bb9-bf1d-6126e8d721da" />
