### PR TITLE
Push before creating a pull request in Lite

### DIFF
--- a/apps/lite/ui/src/api/mutations.ts
+++ b/apps/lite/ui/src/api/mutations.ts
@@ -52,9 +52,7 @@ import type {
 	TreeChange,
 } from "@gitbutler/but-sdk";
 import { type QueryClient, useMutation, useQueryClient } from "@tanstack/react-query";
-import type { PayloadFor } from "#electron/ipc.ts";
 import type { GUISettings } from "#electron/settings.ts";
-import { invalidateDeclared } from "#ui/api/tags.ts";
 import { moveDraftPR } from "#ui/pr.ts";
 import { presentableOperation } from "#ui/snapshot.ts";
 
@@ -220,67 +218,12 @@ export const useBranchCheckoutNew = () => {
 /** The push a new pull request has to wait for: the branch, and whether it needs force. */
 export type PushBeforePublish = { branch: string; withForce: boolean };
 
-/** Tells a failed push apart from a failed creation, so the toast can say which. */
-class PushBeforePublishError extends Error {
-	constructor(cause: unknown) {
-		super(errorMessageForToast(cause), { cause });
-	}
-}
-
-/**
- * Creates a pull request, pushing the branch and its ancestors first when
- * `push` says any of them still has something to push — a forge can only
- * open a review on a branch it has. The PR's source is then the name the
- * branch landed under on the remote, which differs from the local one when
- * the branch tracks another remote.
- */
-export const usePublishReview = (projectId: string) => {
-	const toastManager = Toast.useToastManager();
-	return useMutation({
+export const usePublishReview = (projectId: string) =>
+	useMutation({
 		mutationKey: [projectId, "publishReview"],
-		mutationFn: async ({
-			push,
-			...input
-		}: PayloadFor<"publishReview"> & { push: PushBeforePublish | null }) => {
-			if (push === null) return window.lite.publishReview(input);
-
-			const pushed = await window.lite
-				.workspaceBranchAndAncestorsPush({
-					projectId: input.projectId,
-					branch: push.branch,
-					withForce: push.withForce,
-					skipForcePushProtection: false,
-					runHooks: true,
-					pushOpts: [],
-				})
-				.catch((error: unknown) => {
-					throw new PushBeforePublishError(error);
-				});
-			const sourceBranch =
-				pushed.branchToRemote.find(([branch]) => branch === input.params.sourceBranch)?.[2] ??
-				input.params.sourceBranch;
-			return window.lite.publishReview({ ...input, params: { ...input.params, sourceBranch } });
-		},
-		// The push moved more than the review list, so its own endpoint's
-		// caches go stale too. Returned so success waits for them, as the
-		// cache-level invalidation does.
-		onSuccess: (_outcome, input, _context, mutation) =>
-			input.push === null
-				? undefined
-				: invalidateDeclared(mutation.client, [input.projectId, "workspaceBranchAndAncestorsPush"]),
-		onError: (error) => {
-			toastManager.add({
-				type: "error",
-				title:
-					error instanceof PushBeforePublishError
-						? "Failed to push"
-						: "Failed to create pull request",
-				description: errorMessageForToast(error),
-				priority: "high",
-			});
-		},
+		mutationFn: window.lite.publishReview,
+		meta: { failureTitle: "Failed to create pull request" },
 	});
-};
 
 type GeneratePrDescriptionInput = {
 	projectId: string;

--- a/apps/lite/ui/src/api/mutations.ts
+++ b/apps/lite/ui/src/api/mutations.ts
@@ -52,7 +52,9 @@ import type {
 	TreeChange,
 } from "@gitbutler/but-sdk";
 import { type QueryClient, useMutation, useQueryClient } from "@tanstack/react-query";
+import type { PayloadFor } from "#electron/ipc.ts";
 import type { GUISettings } from "#electron/settings.ts";
+import { invalidateDeclared } from "#ui/api/tags.ts";
 import { moveDraftPR } from "#ui/pr.ts";
 import { presentableOperation } from "#ui/snapshot.ts";
 
@@ -215,12 +217,70 @@ export const useBranchCheckoutNew = () => {
 	});
 };
 
-export const usePublishReview = (projectId: string) =>
-	useMutation({
+/** The push a new pull request has to wait for: the branch, and whether it needs force. */
+export type PushBeforePublish = { branch: string; withForce: boolean };
+
+/** Tells a failed push apart from a failed creation, so the toast can say which. */
+class PushBeforePublishError extends Error {
+	constructor(cause: unknown) {
+		super(errorMessageForToast(cause), { cause });
+	}
+}
+
+/**
+ * Creates a pull request, pushing the branch and its ancestors first when
+ * `push` says any of them still has something to push — a forge can only
+ * open a review on a branch it has. The PR's source is then the name the
+ * branch landed under on the remote, which differs from the local one when
+ * the branch tracks another remote.
+ */
+export const usePublishReview = (projectId: string) => {
+	const toastManager = Toast.useToastManager();
+	return useMutation({
 		mutationKey: [projectId, "publishReview"],
-		mutationFn: window.lite.publishReview,
-		meta: { failureTitle: "Failed to create pull request" },
+		mutationFn: async ({
+			push,
+			...input
+		}: PayloadFor<"publishReview"> & { push: PushBeforePublish | null }) => {
+			if (push === null) return window.lite.publishReview(input);
+
+			const pushed = await window.lite
+				.workspaceBranchAndAncestorsPush({
+					projectId: input.projectId,
+					branch: push.branch,
+					withForce: push.withForce,
+					skipForcePushProtection: false,
+					runHooks: true,
+					pushOpts: [],
+				})
+				.catch((error: unknown) => {
+					throw new PushBeforePublishError(error);
+				});
+			const sourceBranch =
+				pushed.branchToRemote.find(([branch]) => branch === input.params.sourceBranch)?.[2] ??
+				input.params.sourceBranch;
+			return window.lite.publishReview({ ...input, params: { ...input.params, sourceBranch } });
+		},
+		// The push moved more than the review list, so its own endpoint's
+		// caches go stale too. Returned so success waits for them, as the
+		// cache-level invalidation does.
+		onSuccess: (_outcome, input, _context, mutation) =>
+			input.push === null
+				? undefined
+				: invalidateDeclared(mutation.client, [input.projectId, "workspaceBranchAndAncestorsPush"]),
+		onError: (error) => {
+			toastManager.add({
+				type: "error",
+				title:
+					error instanceof PushBeforePublishError
+						? "Failed to push"
+						: "Failed to create pull request",
+				description: errorMessageForToast(error),
+				priority: "high",
+			});
+		},
 	});
+};
 
 type GeneratePrDescriptionInput = {
 	projectId: string;

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -3,6 +3,7 @@ import { startAbsorb, setCursor, useCanShowFiles, useSelection } from "#ui/use-c
 import uiStyles from "#ui/components/ui.module.css";
 import { SuspenseQuery } from "@suspensive/react-query";
 import {
+	type PushBeforePublish,
 	useAddReviewLabels,
 	useCommitUncommitChanges,
 	useOpenInProgram,
@@ -10,6 +11,7 @@ import {
 	useResolveCommitConflictHunks,
 	useSaveGUISettings,
 } from "#ui/api/mutations.ts";
+import { downstackPushStatusFromSegments } from "#ui/segment.ts";
 import {
 	type DraftPRExtras,
 	draftPRQueryOptions,
@@ -3251,7 +3253,8 @@ const NewPullRequestView: FC<{
 	branchName: string;
 	targetBranch: string | undefined;
 	canSubmit: boolean;
-}> = ({ projectId, branchName, targetBranch, canSubmit }) => {
+	pushFirst: PushBeforePublish | null;
+}> = ({ projectId, branchName, targetBranch, canSubmit, pushFirst }) => {
 	// Same record the form persists its title and body to, read here for the
 	// fields the panel owns. Both writers merge, so neither wipes the other.
 	const { data: draft } = useSuspenseQuery(draftPRQueryOptions({ projectId, branchName }));
@@ -3291,6 +3294,7 @@ const NewPullRequestView: FC<{
 					sourceBranch={branchName}
 					title={null}
 					canSubmit={canSubmit}
+					pushFirst={pushFirst}
 					afterPublish={applyExtras}
 				/>
 			</div>
@@ -3482,9 +3486,17 @@ const AppliedBranchDetails: FC<BranchDetailsProps> = ({
 	const targetBranch =
 		!parentSegment || parentSegment.pushStatus === "integrated"
 			? headInfo?.target?.remoteTrackingRef.displayName
-			: parentSegment.pushStatus === "completelyUnpushed"
-				? undefined
-				: parentSegment.refName?.displayName;
+			: parentSegment.refName?.displayName;
+	// A forge only opens a review on a branch it has, so a new PR pushes the
+	// branch and its ancestors first when any of them still has something to
+	// push. Conflicted commits cannot be pushed, and so cannot be reviewed yet.
+	const downstack = branchCtx
+		? downstackPushStatusFromSegments(branchCtx.stack.segments.slice(branchCtx.segmentIndex))
+		: null;
+	const pushFirst: PushBeforePublish | null = downstack?.anyRequiresPush
+		? { branch: branchRef, withForce: downstack.anyPushRequiresForce }
+		: null;
+	const canSubmit = pushFirst === null || !downstack?.anyHasConflicts;
 
 	// The open listing already carries everything an open review needs, so the
 	// verification fetch is spent only when the listing has nothing for this
@@ -3564,6 +3576,7 @@ const AppliedBranchDetails: FC<BranchDetailsProps> = ({
 									branchName={branchName}
 									targetBranch={targetBranch}
 									canSubmit={false}
+									pushFirst={null}
 								/>
 							) : (
 								<SuspenseQuery
@@ -3574,19 +3587,17 @@ const AppliedBranchDetails: FC<BranchDetailsProps> = ({
 								>
 									{({ data }) => {
 										const review = data.reviewsBySourceBranch.get(branchName);
-										const canSubmit =
-											targetBranch !== undefined &&
-											branchCtx?.segment.pushStatus !== "completelyUnpushed";
 
 										if (!review && landedReviewId !== null)
 											return <LandedReviewView projectId={projectId} reviewId={landedReviewId} />;
 
-										return !review || !canSubmit ? (
+										return !review ? (
 											<NewPullRequestView
 												projectId={projectId}
 												branchName={branchName}
 												targetBranch={targetBranch}
 												canSubmit={canSubmit}
+												pushFirst={pushFirst}
 											/>
 										) : (
 											<ReviewView

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestForm.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestForm.tsx
@@ -1,4 +1,5 @@
 import {
+	type PushBeforePublish,
 	useAddReviewReaction,
 	useGeneratePrDescription,
 	useMergeReview,
@@ -92,6 +93,11 @@ export const PullRequestForm: FC<{
 	title: string | null;
 	body: string | null;
 	canSubmit: boolean;
+	/**
+	 * For a new PR, the push it has to wait for, or null when the branch is
+	 * already on the remote. Never read when editing an existing PR.
+	 */
+	pushFirst?: PushBeforePublish | null;
 	onAfterSubmit?: () => void;
 	/** Adds a Cancel button that discards edits and calls this. */
 	onCancel?: () => void;
@@ -108,6 +114,7 @@ export const PullRequestForm: FC<{
 	title,
 	body,
 	canSubmit,
+	pushFirst = null,
 	onAfterSubmit,
 	onCancel,
 	afterPublish,
@@ -263,6 +270,7 @@ export const PullRequestForm: FC<{
 			publishReview(
 				{
 					projectId,
+					push: pushFirst,
 					params: {
 						title: localDocument.title,
 						body: localDocument.body,
@@ -414,7 +422,11 @@ export const PullRequestForm: FC<{
 									disabled={!canSubmit || isAnyPending || !hasChanges}
 									type="submit"
 								>
-									{isNew ? "Create a PR" : "Save changes"}
+									{isNew
+										? pushFirst !== null
+											? "Push and create a PR"
+											: "Create a PR"
+										: "Save changes"}
 									{/* Creating opens a PR; saving only confirms an edit. */}
 									<Icon name={isAnyPending ? "spinner" : isNew ? "pr" : "tick"} />
 								</button>

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestForm.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestForm.tsx
@@ -8,6 +8,7 @@ import {
 	useSetReviewAutoMerge,
 	useSetReviewDraftiness,
 	useUpdateReview,
+	useWorkspaceBranchAndAncestorsPush,
 } from "#ui/api/mutations.ts";
 import {
 	aiConfigurationQueryOptions,
@@ -59,7 +60,7 @@ import type {
 } from "@gitbutler/but-sdk";
 import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { useHotkey } from "@tanstack/react-hotkeys";
-import { type FC, type SubmitEventHandler, Suspense, useEffect, useRef, useState } from "react";
+import { type FC, type SubmitEvent, Suspense, useEffect, useRef, useState } from "react";
 import styles from "./PullRequestForm.module.css";
 
 /**
@@ -119,6 +120,8 @@ export const PullRequestForm: FC<{
 	onCancel,
 	afterPublish,
 }) => {
+	const { isPending: isPushPending, mutateAsync: pushBranchAndAncestors } =
+		useWorkspaceBranchAndAncestorsPush(projectId);
 	const { isPending: isPublishReviewPending, mutate: publishReview } = usePublishReview(projectId);
 	const { isPending: isUpdateReviewPending, mutate: updateReview } = useUpdateReview(projectId);
 	const formRef = useRef<HTMLFormElement | null>(null);
@@ -163,7 +166,7 @@ export const PullRequestForm: FC<{
 	const { mutate: deleteDraftPR } = useDeleteDraftPR();
 
 	const isNew = reviewId === null;
-	const isAnyPending = isPublishReviewPending || isUpdateReviewPending;
+	const isAnyPending = isPushPending || isPublishReviewPending || isUpdateReviewPending;
 	const hasChanges =
 		localDocument.title !== remoteOrEmptyDocument.title ||
 		localDocument.body !== remoteOrEmptyDocument.body ||
@@ -262,21 +265,40 @@ export const PullRequestForm: FC<{
 		);
 	};
 
-	const handleSubmit: SubmitEventHandler<HTMLFormElement> = (evt) => {
+	const handleSubmit = async (evt: SubmitEvent<HTMLFormElement>): Promise<void> => {
 		evt.preventDefault();
 		if (!canSubmit || isAnyPending || localDocument.title.trim() === "") return;
 
 		if (reviewId === null) {
+			// A forge only opens a review on a branch it has, so the branch and
+			// its ancestors go up first when any still has something to push.
+			// The PR's source is then the name the branch landed under on the
+			// remote, which differs from the local one when the branch tracks
+			// another remote.
+			let remoteSourceBranch = sourceBranch;
+			if (pushFirst !== null) {
+				// The push hook already toasts its own failure.
+				const pushed = await pushBranchAndAncestors({
+					projectId,
+					branch: pushFirst.branch,
+					withForce: pushFirst.withForce,
+					skipForcePushProtection: false,
+					runHooks: true,
+					pushOpts: [],
+				}).catch(() => null);
+				if (pushed === null) return;
+				remoteSourceBranch =
+					pushed.branchToRemote.find(([branch]) => branch === sourceBranch)?.[2] ?? sourceBranch;
+			}
 			publishReview(
 				{
 					projectId,
-					push: pushFirst,
 					params: {
 						title: localDocument.title,
 						body: localDocument.body,
 						draft: localDocument.isDraft,
 						localBranch: sourceBranch,
-						sourceBranch,
+						sourceBranch: remoteSourceBranch,
 					},
 				},
 				{
@@ -314,7 +336,12 @@ export const PullRequestForm: FC<{
 
 	return (
 		// oxlint-disable-next-line jsx-a11y/no-noninteractive-element-interactions -- Used for persistence, not UI per se.
-		<form ref={formRef} className={styles.prForm} onBlur={handleBlur} onSubmit={handleSubmit}>
+		<form
+			ref={formRef}
+			className={styles.prForm}
+			onBlur={handleBlur}
+			onSubmit={(evt) => void handleSubmit(evt)}
+		>
 			{/* Both fields name themselves in the placeholder, as designed, so
 			    they carry an aria-label instead of a visible one. */}
 			<Field.Root render={<FieldRootStyles />}>


### PR DESCRIPTION
A forge can only open a review on a branch it has. Lite's create-PR form used to answer that by disabling its button whenever the branch or its parent had never been pushed, with nothing saying why. Desktop and the CLI both push first and then create; Lite now does the same.

## What changed

- The publish mutation takes the push the PR has to wait for and runs it ahead of the forge call when any branch down the stack still has something to push. This matches the desktop rule rather than only covering the first push, so the PR always opens against the current commits. Force is used when any of those branches needs it, the same way the sidebar's Push button decides.
- The PR source is the name the branch landed under on the remote, which differs from the local name when the branch tracks another remote.
- A failed push toasts as "Failed to push" rather than "Failed to create pull request", and the push endpoint's caches are invalidated alongside the review ones.
- The button reads "Push and create a PR" while a push is pending, so the extra step is visible before it happens.
- The only remaining disable here is conflicted commits, which cannot be pushed. The target branch now shows the parent by name even before that parent is pushed, since the push covers it.

One case this opens up is handled in the stacked follow-up #15771: a branch with no commits cannot open a PR, since a forge refuses a PR whose head adds nothing to its base, and pushing first would only leave an empty branch on the remote. That PR holds the button on such a branch with the reason in its label.

## Verification

Typecheck, unit tests, oxlint, oxfmt, prettier, and knip are clean. Checked in the dev app on a branch that had never been pushed: the button is enabled and labelled "Push and create a PR", with the target shown as the project's base branch. The push-then-publish path is the same Rust path `but pr new` and the sidebar's Push button already use.

Related: GB-1959, which lists "PR panel, no pull request" as an empty state to design. With the gate gone there is no such state left on applied branches.

## Screenshots

This button

<img width="574" height="397" alt="Screenshot 2026-09-07 at 13 22 38" src="https://github.com/user-attachments/assets/73b07f5e-5ffa-4d4b-b3b1-a172c7888f10" />


