### PR TITLE
Hold the PR button while the branch has no commits

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestForm.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestForm.tsx
@@ -167,6 +167,12 @@ export const PullRequestForm: FC<{
 
 	const isNew = reviewId === null;
 	const isAnyPending = isPushPending || isPublishReviewPending || isUpdateReviewPending;
+	// A forge refuses a PR whose head adds nothing to its base, so an empty
+	// branch cannot open one — and pushing it first would only leave an empty
+	// branch on the remote. The form stays live for drafting ahead of the
+	// commits; only the button waits. Unknown while the details load: not
+	// loaded is not the same as empty.
+	const noCommits = isNew && branchDetails !== undefined && branchDetails.commits.length === 0;
 	const hasChanges =
 		localDocument.title !== remoteOrEmptyDocument.title ||
 		localDocument.body !== remoteOrEmptyDocument.body ||
@@ -267,7 +273,7 @@ export const PullRequestForm: FC<{
 
 	const handleSubmit = async (evt: SubmitEvent<HTMLFormElement>): Promise<void> => {
 		evt.preventDefault();
-		if (!canSubmit || isAnyPending || localDocument.title.trim() === "") return;
+		if (!canSubmit || noCommits || isAnyPending || localDocument.title.trim() === "") return;
 
 		if (reviewId === null) {
 			// A forge only opens a review on a branch it has, so the branch and
@@ -446,14 +452,19 @@ export const PullRequestForm: FC<{
 
 								<button
 									className={getButtonClassName({ variant: "gray" })}
-									disabled={!canSubmit || isAnyPending || !hasChanges}
+									disabled={!canSubmit || noCommits || isAnyPending || !hasChanges}
 									type="submit"
 								>
-									{isNew
-										? pushFirst !== null
-											? "Push and create a PR"
-											: "Create a PR"
-										: "Save changes"}
+									{/* The reason rides in the label, not a tooltip: it is the
+									    form's whole story, so it has to be readable without hover
+									    (DESIGN.md → Empty states). */}
+									{!isNew
+										? "Save changes"
+										: noCommits
+											? "No commits yet"
+											: pushFirst !== null
+												? "Push and create a PR"
+												: "Create a PR"}
 									{/* Creating opens a PR; saving only confirms an edit. */}
 									<Icon name={isAnyPending ? "spinner" : isNew ? "pr" : "tick"} />
 								</button>


### PR DESCRIPTION
Stacked on #15768.

A forge refuses a pull request whose head adds nothing to its base, so an empty branch cannot open one. Nothing gated on that before, and once the form pushes first (#15768) a click on such a branch would push an empty branch to the remote and then fail on the forge's refusal, leaving a stray remote branch and a failure toast.

## What changed

- On an applied branch with no PR and no commits, the create button is disabled and reads "No commits yet". The reason rides in the label because a disabled button takes no pointer events, so a tooltip on it would never open. This mirrors the tab toggle's "No pull request" on unapplied branches.
- The rest of the form stays live: title, description, draft toggle, labels and reviewers. Lite persists PR drafts per branch, so writing the description ahead of the commits is a legitimate thing to do, which is why the form is kept rather than replaced by an empty state.
- The submit handler refuses too, so the keyboard shortcut cannot bypass the disabled button.
- The gate reads the branch details query the form already holds for its description generator. It is unknown while those load, since not loaded is not the same as empty.

## Verification

Typecheck, prettier and oxlint are clean. Checked in the dev app on a freshly created branch with no commits: the button is disabled and reads "No commits yet" while the title, description and draft toggle stay editable. On a branch with commits the button is unchanged.

Related: GB-1959.

## Screenshots

<img width="663" height="375" alt="image" src="https://github.com/user-attachments/assets/775a36d2-783d-44fd-8ba9-d80d076229cd" />

