### PR TITLE
Preserve indexed executable modes when fileMode is disabled

### DIFF
--- a/crates/but-core/src/tree/mod.rs
+++ b/crates/but-core/src/tree/mod.rs
@@ -191,6 +191,25 @@ pub fn apply_worktree_changes<'repo>(
     let base_tree = actual_base_tree.attach(repo).object()?.peel_to_tree()?;
     let mut base_tree_editor = base_tree.edit()?;
     let (mut pipeline, index) = repo.filter_pipeline(None)?;
+    let trust_executable_bit = repo.filesystem_options()?.executable_bit;
+    let entry_kind = |path: &bstr::BStr, disk_kind: EntryKind| {
+        if !trust_executable_bit && matches!(disk_kind, EntryKind::Blob | EntryKind::BlobExecutable)
+        {
+            // On filesystems without executable bits, Git keeps the index mode,
+            // as it can be manipulated in a platform independent way.
+            index
+                .entry_by_path(path)
+                // If ours is absent, prefer the base over theirs, like Git.
+                .or_else(|| index.entry_by_path_and_stage(path, gix::index::entry::Stage::Base))
+                .or_else(|| index.entry_by_path_and_stage(path, gix::index::entry::Stage::Theirs))
+                .and_then(|entry| entry.mode.to_tree_entry_mode())
+                .map(|mode| mode.kind())
+                .filter(|kind| matches!(kind, EntryKind::Blob | EntryKind::BlobExecutable))
+                .unwrap_or(EntryKind::Blob)
+        } else {
+            disk_kind
+        }
+    };
     let has_changes_with_hunks = changes
         .iter()
         .filter_map(|c| c.as_ref().ok())
@@ -228,7 +247,7 @@ pub fn apply_worktree_changes<'repo>(
             let rela_path = change_request.path.as_bstr();
             match pipeline.worktree_file_to_object(rela_path, &index)? {
                 Some((id, kind, _fs_metadata)) => {
-                    base_tree_editor.upsert(rela_path, kind, id)?;
+                    base_tree_editor.upsert(rela_path, entry_kind(rela_path, kind), id)?;
                 }
                 None => into_err_spec(
                     possible_change,
@@ -342,7 +361,7 @@ pub fn apply_worktree_changes<'repo>(
             let blob_with_selected_patches = repo.write_blob(base_with_patches.as_slice())?;
             base_tree_editor.upsert(
                 change_request.path.as_bstr(),
-                current_entry_kind,
+                entry_kind(change_request.path.as_bstr(), current_entry_kind),
                 blob_with_selected_patches,
             )?;
         } else {

--- a/crates/but-core/tests/core/tree.rs
+++ b/crates/but-core/tests/core/tree.rs
@@ -2,6 +2,142 @@ use but_core::DiffSpec;
 use but_testsupport::writable_scenario;
 use gix::object::tree::EntryKind;
 
+#[test]
+fn filemode_disabled_preserves_conflict_stage_modes() -> anyhow::Result<()> {
+    let (repo, _tmp) = writable_scenario("filemode-disabled");
+    let base = repo.head_tree_id()?.detach();
+    for (path, expected_kind, reason) in [
+        (
+            "modify-delete.sh",
+            EntryKind::BlobExecutable,
+            "ours is absent, so the executable mode from the remaining stages must be preserved",
+        ),
+        (
+            "base-preferred.sh",
+            EntryKind::Blob,
+            "ours is absent, so the non-executable base must take precedence over executable theirs",
+        ),
+        (
+            "ours-preferred.sh",
+            EntryKind::Blob,
+            "non-executable ours must take precedence over executable base and theirs",
+        ),
+        (
+            "theirs-only.sh",
+            EntryKind::BlobExecutable,
+            "only theirs is available, so its executable mode must be preserved",
+        ),
+        (
+            "untracked.sh",
+            EntryKind::Blob,
+            "no index entry exists, so the mode must default to non-executable despite the worktree executable bit",
+        ),
+    ] {
+        let mut changes = vec![Ok(spec(None, path))];
+        let (tree, _) = but_core::tree::apply_worktree_changes(base, &repo, &mut changes, 0)?;
+        assert!(
+            changes.iter().all(Result::is_ok),
+            "the edit must be accepted"
+        );
+        let tree = tree.object()?.into_tree();
+        let entry = tree.lookup_entry_by_path(path)?.expect("script exists");
+        assert_eq!(entry.mode().kind(), expected_kind, "{path}: {reason}");
+        assert_eq!(
+            entry.object()?.into_blob().data,
+            b"after\n",
+            "the worktree content must be preserved"
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn filemode_disabled_preserves_executable() -> anyhow::Result<()> {
+    filemode_disabled_preserves_executable_inner(false)
+}
+
+#[test]
+fn filemode_disabled_preserves_executable_with_hunks() -> anyhow::Result<()> {
+    filemode_disabled_preserves_executable_inner(true)
+}
+
+fn filemode_disabled_preserves_executable_inner(with_hunks: bool) -> anyhow::Result<()> {
+    let (repo, _tmp) = writable_scenario("filemode-disabled");
+    let base = repo.head_tree_id()?.detach();
+    for (path, expected_kind) in [
+        ("script.sh", EntryKind::BlobExecutable),
+        ("added.sh", EntryKind::BlobExecutable),
+        ("removed.sh", EntryKind::Blob),
+    ] {
+        let mut changes = vec![Ok(spec(None, path))];
+        if with_hunks {
+            changes[0]
+                .as_mut()
+                .expect("valid spec")
+                .hunk_headers
+                .push(but_core::HunkHeader {
+                    old_start: 1,
+                    old_lines: 1,
+                    new_start: 1,
+                    new_lines: 1,
+                });
+        }
+        let (tree, _) = but_core::tree::apply_worktree_changes(base, &repo, &mut changes, 0)?;
+        assert!(
+            changes.iter().all(Result::is_ok),
+            "the edit must be accepted"
+        );
+        let tree = tree.object()?.into_tree();
+        let entry = tree.lookup_entry_by_path(path)?.expect("script exists");
+        assert_eq!(
+            entry.mode().kind(),
+            expected_kind,
+            "core.fileMode=false must preserve the indexed executable bit for {path}"
+        );
+        assert_eq!(
+            entry.object()?.into_blob().data,
+            b"after\n",
+            "the edited content must be committed"
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn filemode_disabled_commits_index_only_mode_change() -> anyhow::Result<()> {
+    let (repo, _tmp) = writable_scenario("filemode-disabled");
+    let base = repo.head_tree_id()?.detach();
+    let status = but_core::diff::worktree_changes(&repo)?;
+    assert!(
+        status
+            .changes
+            .iter()
+            .any(|change| change.path == "mode-only.sh"),
+        "the staged mode-only change must be visible"
+    );
+    let mut changes = vec![Ok(spec(None, "mode-only.sh"))];
+    let (tree, _) = but_core::tree::apply_worktree_changes(base, &repo, &mut changes, 0)?;
+    assert!(
+        changes.iter().all(Result::is_ok),
+        "the mode change must be accepted"
+    );
+    let tree = tree.object()?.into_tree();
+    let entry = tree
+        .lookup_entry_by_path("mode-only.sh")?
+        .expect("script exists");
+    assert_eq!(
+        entry.mode().kind(),
+        EntryKind::BlobExecutable,
+        "the index-only executable bit must be committed"
+    );
+    assert_eq!(
+        entry.object()?.into_blob().data,
+        b"before\n",
+        "a mode-only change must preserve content"
+    );
+    Ok(())
+}
+
 /// Regression test for data loss when a file is renamed and a *new directory* is committed at the
 /// file's old path in the same commit.
 ///

--- a/crates/but-core/tests/fixtures/scenario/filemode-disabled.sh
+++ b/crates/but-core/tests/fixtures/scenario/filemode-disabled.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+git init
+git config core.fileMode false
+printf 'before\n' >script.sh
+printf 'before\n' >added.sh
+printf 'before\n' >removed.sh
+printf 'before\n' >mode-only.sh
+git add .
+git update-index --chmod=+x script.sh
+git update-index --chmod=+x removed.sh
+git commit -m executable
+git update-index --chmod=+x added.sh mode-only.sh
+git update-index --chmod=-x removed.sh
+printf 'after\n' >script.sh
+printf 'after\n' >added.sh
+printf 'after\n' >removed.sh
+
+blob=$(git rev-parse HEAD:script.sh)
+git update-index --index-info <<EOF
+100755 $blob 1	modify-delete.sh
+100755 $blob 3	modify-delete.sh
+100644 $blob 1	base-preferred.sh
+100755 $blob 3	base-preferred.sh
+100755 $blob 1	ours-preferred.sh
+100644 $blob 2	ours-preferred.sh
+100755 $blob 3	ours-preferred.sh
+100755 $blob 3	theirs-only.sh
+EOF
+for path in modify-delete.sh base-preferred.sh ours-preferred.sh theirs-only.sh untracked.sh; do
+    printf 'after\n' >"$path"
+    chmod +x "$path"
+done


### PR DESCRIPTION
### Tasks

* [x] refackiew

this fix was produced on Windows originally and validated there, matching the platform most likely to suffer from #7961.

### Codex

Editing executable files on Windows stripped their executable bit when
building trees for commits and amendments. Whole-file and hunk regression
tests reproduced the loss, including a staged mode-only change.

Honor core.fileMode in the existing tree builder and retain regular-file
modes from the index when disk executable bits are not trusted. This follows
ce_mode_from_stat in read-cache.h from the Git reference checkout at
cf5497b14c5a24f10c13f7e0ee85cb95af13ea6a (v2.55.0 baseline).
