### PR TITLE
Revive the review-listing invalidation a cold workspace drops

### DIFF
--- a/apps/desktop/src/lib/forge/listingService.svelte.ts
+++ b/apps/desktop/src/lib/forge/listingService.svelte.ts
@@ -98,18 +98,24 @@ function injectBackendEndpoints(api: BackendApi) {
 					const prs = response.map((pr) => mapForgeReviewToPullRequest(pr));
 					return prAdapter.addMany(prAdapter.getInitialState(), prs);
 				},
-				async onQueryStarted(_projectId, { dispatch, queryFulfilled }) {
+				async onQueryStarted(projectId, { dispatch, getState, queryFulfilled }) {
 					try {
 						// `list_reviews` updates the backend forge cache. Workspace PR
 						// associations are projected from that cache, so rebuild the
 						// workspace view only after the cache-writing request succeeds.
 						await queryFulfilled;
-						dispatch(
-							api.util.invalidateTags([
-								invalidatesList(ReduxTag.Stacks),
-								invalidatesList(ReduxTag.StackDetails),
-							]),
-						);
+						const workspaceTags = [
+							invalidatesList(ReduxTag.Stacks),
+							invalidatesList(ReduxTag.StackDetails),
+						];
+						dispatch(api.util.invalidateTags(workspaceTags));
+						// RTKQ registers providesTags only on fulfilment, so a cold workspace
+						// query still in flight matches nothing. Wait for it and invalidate
+						// again, or the badges stay absent until the 15-minute re-poll.
+						if (api.util.selectInvalidatedBy(getState(), workspaceTags).length === 0) {
+							await dispatch(api.util.getRunningQueryThunk("workspaceDetails", { projectId }));
+							dispatch(api.util.invalidateTags(workspaceTags));
+						}
 					} catch {
 						// Keep the last cache-derived workspace view when the forge is
 						// unavailable. The query exposes the listing error separately.


### PR DESCRIPTION
Fixes the top three flakes on tests.but.dev (prAssociation.spec.ts, 45 fail-then-pass runs in 14 days). They are one bug: on a cold workspace open the PR badges can stay absent until the 15-minute re-poll.

- PR associations are projected from the forge cache, which only the first `list_reviews` sync fills
- the listing invalidates `Stacks`/`StackDetails` when it fulfils, but RTKQ registers `providesTags` only on fulfilment, so a `head_info` still in flight matches nothing and the invalidation is dropped
- now: invalidate, and if nothing matched (the tell for a cold query mid-flight) wait for the in-flight `workspaceDetails` query, the only provider of those tags, and invalidate once more; warm workspaces match first time and skip it
- `invalidationBehavior: "delayed"` looked like the cure and is not: condition-aborted duplicate initiations dispatch `rejected` without `pending`, so RTKQ's pending count hits zero early and the delayed queue flushes into the empty registry

### Verified
- deterministic probe: hold `head_info` so the listing fulfils mid-flight; badge stranded before, healed after
- prAssociation.spec.ts 12/12 under `--repeat-each=3` on today's master

🤖 Generated with [Claude Code](https://claude.com/claude-code)
