### PR TITLE
Widen a failing poll's interval without resubscribing

### DIFF
--- a/apps/desktop/src/components/forge/CIChecksBadge.svelte
+++ b/apps/desktop/src/components/forge/CIChecksBadge.svelte
@@ -70,11 +70,11 @@
 	});
 	const pollingInterval = $derived(backoff.pollingInterval);
 
-	const checksQuery = $derived(
-		enabled
-			? checksService?.get(projectId, branchName, { subscriptionOptions: { pollingInterval } })
-			: undefined,
-	);
+	const checksQuery = $derived(enabled ? checksService?.get(projectId, branchName) : undefined);
+	// In place rather than by re-creating the query: see `SubscribedQuery`.
+	$effect(() => {
+		checksQuery?.updateSubscriptionOptions({ pollingInterval });
+	});
 
 	const loading = $derived(checksQuery?.result.isLoading);
 

--- a/apps/desktop/src/components/forge/PullRequestCard.svelte
+++ b/apps/desktop/src/components/forge/PullRequestCard.svelte
@@ -90,12 +90,11 @@
 	});
 	const prPollingInterval = $derived(poll ? prBackoff.pollingInterval : undefined);
 
-	const prQuery = $derived(
-		prService.get(projectId, prNumber, {
-			forceRefetch: true,
-			subscriptionOptions: { pollingInterval: prPollingInterval },
-		}),
-	);
+	const prQuery = $derived(prService.get(projectId, prNumber, { forceRefetch: true }));
+	// In place rather than by re-creating the query: see `SubscribedQuery`.
+	$effect(() => {
+		prQuery.updateSubscriptionOptions({ pollingInterval: prPollingInterval });
+	});
 	const pr = $derived(prQuery.response);
 	// The merge-status endpoint hits the forge fresh on every call and can fail
 	// while the PR query is fine, so it needs its own error backoff — sharing the
@@ -110,11 +109,10 @@
 	);
 	// GitHub computes `mergeable_state` lazily: the first read after a push says
 	// `unknown`, so it needs re-reading or Merge stays disabled.
-	const mergeStatusQuery = $derived(
-		prService.getMergeStatus(projectId, prNumber, {
-			subscriptionOptions: { pollingInterval: mergeStatusPollingInterval },
-		}),
-	);
+	const mergeStatusQuery = $derived(prService.getMergeStatus(projectId, prNumber));
+	$effect(() => {
+		mergeStatusQuery.updateSubscriptionOptions({ pollingInterval: mergeStatusPollingInterval });
+	});
 	const prMergeStatus = $derived(mergeStatusQuery.response);
 
 	$effect(() => {

--- a/apps/desktop/src/lib/forge/listingService.svelte.ts
+++ b/apps/desktop/src/lib/forge/listingService.svelte.ts
@@ -32,10 +32,10 @@ export class ListingService {
 		this.backendApi = injectBackendEndpoints(backendApi);
 	}
 
-	list(projectId: string, pollingInterval?: number) {
+	list(projectId: string) {
 		return this.backendApi.endpoints.listPrs.useQuery(projectId, {
 			transform: (result) => prSelectors.selectAll(result),
-			subscriptionOptions: { ...catchUpOnReturn, pollingInterval },
+			subscriptionOptions: catchUpOnReturn,
 		});
 	}
 

--- a/apps/desktop/src/lib/state/butlerModule.ts
+++ b/apps/desktop/src/lib/state/butlerModule.ts
@@ -19,6 +19,7 @@ import {
 	type ApiModules,
 	type QueryActionCreatorResult,
 	type StartQueryActionCreatorOptions,
+	type SubscriptionOptions,
 } from "@reduxjs/toolkit/query";
 import type { TauriBaseQueryFn } from "$lib/state/backendQuery";
 import type { HookContext } from "$lib/state/context";
@@ -183,6 +184,15 @@ export type ReactiveQuery<
 	readonly result: CustomResult<CustomQuery<T>> & Extensions;
 	readonly response: T | undefined;
 };
+
+/**
+ * A `useQuery` result: reading it subscribes. Change the subscription's options
+ * here rather than by re-creating the query: a fresh subscription re-runs a
+ * query that has never fulfilled, which for a failing poll defeats its backoff.
+ */
+export type SubscribedQuery<T> = ReactiveQuery<T, QueryExtensions> & {
+	updateSubscriptionOptions: (options: SubscriptionOptions) => void;
+};
 export type AsyncResult<T> = Promise<CustomResult<CustomQuery<T>>>;
 
 /**
@@ -242,7 +252,7 @@ type QueryHooks<D extends CustomQuery<unknown>> = {
 	useQuery: <T extends Transformer<D> | undefined = DefaultTransformer<D>>(
 		args: QueryArgFrom<D>,
 		options?: { transform?: T } & StartQueryActionCreatorOptions,
-	) => ReactiveQuery<T extends Transformer<D> ? ReturnType<T> : ResultTypeFrom<D>, QueryExtensions>;
+	) => SubscribedQuery<T extends Transformer<D> ? ReturnType<T> : ResultTypeFrom<D>>;
 	/** Execute query on existing state. */
 	useQueryState: <T extends Transformer<D> | undefined = DefaultTransformer<D>>(
 		args: QueryArgFrom<D>,

--- a/apps/desktop/src/lib/state/customHooks.svelte.test.ts
+++ b/apps/desktop/src/lib/state/customHooks.svelte.test.ts
@@ -2,6 +2,7 @@ import { butlerModule } from "$lib/state/butlerModule";
 import { ReduxTag } from "$lib/state/tags";
 import { configureStore } from "@reduxjs/toolkit";
 import { buildCreateApi, coreModule } from "@reduxjs/toolkit/query";
+import { flushSync } from "svelte";
 import { describe, expect, test, vi } from "vitest";
 import type { TauriBaseQueryFn } from "$lib/state/backendQuery";
 import type { HookContext } from "$lib/state/context";
@@ -9,8 +10,12 @@ import type { PostHogWrapper } from "$lib/telemetry/posthog";
 
 function setup() {
 	const capture = vi.fn();
+	const baseQueryCalls = vi.fn();
+	// Mirrors the store into a signal, as the app's client state does, so a
+	// query's derived result follows the store.
+	let state = $state.raw<unknown>(undefined);
 	const ctx: HookContext = {
-		getState: () => store.getState(),
+		getState: () => state as ReturnType<typeof store.getState>,
 		getDispatch: () => store.dispatch,
 		posthog: { capture } as unknown as PostHogWrapper,
 	};
@@ -19,6 +24,7 @@ function setup() {
 		_api: Parameters<TauriBaseQueryFn>[1],
 		_extraOptions: Parameters<TauriBaseQueryFn>[2],
 	): Promise<Awaited<ReturnType<TauriBaseQueryFn>>> {
+		baseQueryCalls();
 		if ((args as { fail?: boolean } | undefined)?.fail) {
 			return { error: { origin: "ipc", name: "API error", message: "it broke" } };
 		}
@@ -40,13 +46,21 @@ function setup() {
 				extraOptions: { command: "some_command", actionName: "Some Action" },
 				query: (args) => args,
 			}),
+			query: build.query<void, { fail?: boolean }>({
+				extraOptions: { command: "some_query" },
+				query: (args) => args,
+			}),
 		}),
 	});
 	const store = configureStore({
 		reducer: { [api.reducerPath]: api.reducer },
 		middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(api.middleware),
 	});
-	return { api, capture };
+	state = store.getState();
+	store.subscribe(() => {
+		state = store.getState();
+	});
+	return { api, capture, baseQueryCalls };
 }
 
 function capturedEventNames(capture: ReturnType<typeof vi.fn>) {
@@ -90,5 +104,52 @@ describe("mutation tracking", () => {
 			"tauri_command",
 			"Some Action Failed",
 		]);
+	});
+});
+
+describe("useQuery subscriptions", () => {
+	test("changing the subscription options of a failed query does not re-run it", async () => {
+		const { api, baseQueryCalls } = setup();
+		const args = { fail: true };
+
+		let query: ReturnType<typeof api.endpoints.query.useQuery> | undefined;
+		let subscribed = false;
+		const dispose = $effect.root(() => {
+			query = api.endpoints.query.useQuery(args, {
+				subscriptionOptions: { pollingInterval: 60_000 },
+			});
+			// Reading the result inside an effect is what subscribes.
+			$effect(() => {
+				subscribed = query?.result !== undefined;
+			});
+		});
+		flushSync();
+		expect(subscribed).toBe(true);
+		await vi.waitFor(() => expect(query?.result.isError).toBe(true));
+		expect(baseQueryCalls).toHaveBeenCalledTimes(1);
+
+		// Widening the interval in place leaves the failed request alone...
+		query?.updateSubscriptionOptions({ pollingInterval: 300_000 });
+		flushSync();
+		await new Promise((resolve) => setTimeout(resolve, 50));
+		expect(baseQueryCalls).toHaveBeenCalledTimes(1);
+
+		// ...while a fresh subscription re-runs a never-fulfilled query, which
+		// is what re-creating the query with new options did.
+		let resubscribed = false;
+		const disposeResubscribe = $effect.root(() => {
+			const recreated = api.endpoints.query.useQuery(args, {
+				subscriptionOptions: { pollingInterval: 300_000 },
+			});
+			$effect(() => {
+				resubscribed = recreated.result !== undefined;
+			});
+		});
+		flushSync();
+		expect(resubscribed).toBe(true);
+		await vi.waitFor(() => expect(baseQueryCalls).toHaveBeenCalledTimes(2));
+
+		disposeResubscribe();
+		dispose();
 	});
 });

--- a/apps/desktop/src/lib/state/customHooks.svelte.ts
+++ b/apps/desktop/src/lib/state/customHooks.svelte.ts
@@ -16,6 +16,7 @@ import {
 	type QueryArgFrom,
 	type ResultTypeFrom,
 	type StartQueryActionCreatorOptions,
+	type SubscriptionOptions,
 } from "@reduxjs/toolkit/query";
 import { createSubscriber } from "svelte/reactivity";
 import type {
@@ -23,8 +24,8 @@ import type {
 	Transformer,
 	CustomResult,
 	ExtensionDefinitions,
-	QueryExtensions,
 	ReactiveQuery,
+	SubscribedQuery,
 } from "$lib/state/butlerModule";
 import type { HookContext } from "$lib/state/context";
 import type { Prettify } from "@gitbutler/shared/utils/typeUtils";
@@ -96,25 +97,34 @@ export function buildQueryHooks<Definitions extends ExtensionDefinitions>({
 	function useQuery<T extends TransformerFn>(
 		queryArg: unknown,
 		options?: { transform?: T } & StartQueryActionCreatorOptions,
-	): ReactiveQuery<T extends Transformer<ReturnType<T>> ? ReturnType<T> : T, QueryExtensions> {
+	): SubscribedQuery<T extends Transformer<ReturnType<T>> ? ReturnType<T> : T> {
 		// const startTime = Date.now();
 		const dispatch = getDispatch();
 		let query: QueryActionCreatorResult<any> | undefined;
+		// Kept current by `updateSubscriptionOptions`, so a later resubscribe
+		// starts from the latest options rather than the ones passed at creation.
+		let subscriptionOptions = options?.subscriptionOptions;
 		const subscribe = createSubscriber(() => {
 			query = dispatch(
 				initiate(queryArg, {
 					subscribe: options?.subscribe,
-					subscriptionOptions: options?.subscriptionOptions,
+					subscriptionOptions,
 					forceRefetch: options?.forceRefetch,
 				}),
 			);
 			return () => {
 				query?.unsubscribe();
+				query = undefined;
 			};
 		});
 
 		async function refetch() {
 			await query?.refetch();
+		}
+
+		function updateSubscriptionOptions(update: SubscriptionOptions) {
+			subscriptionOptions = { ...subscriptionOptions, ...update };
+			query?.updateSubscriptionOptions(subscriptionOptions);
 		}
 
 		const selector = $derived(select(queryArg));
@@ -155,6 +165,7 @@ export function buildQueryHooks<Definitions extends ExtensionDefinitions>({
 				subscribe();
 				return output.data;
 			},
+			updateSubscriptionOptions,
 		};
 	}
 

--- a/apps/desktop/src/routes/[projectId]/+layout.svelte
+++ b/apps/desktop/src/routes/[projectId]/+layout.svelte
@@ -106,9 +106,11 @@
 	const reviewListPollingInterval = $derived(
 		reviewListBackoff.pollingInterval === 0 ? 0 : POLL_INTERVAL,
 	);
-	const forgeReviews = $derived(
-		canListReviews ? listingService.list(projectId, reviewListPollingInterval) : undefined,
-	);
+	const forgeReviews = $derived(canListReviews ? listingService.list(projectId) : undefined);
+	// In place rather than by re-creating the query: see `SubscribedQuery`.
+	$effect(() => {
+		forgeReviews?.updateSubscriptionOptions({ pollingInterval: reviewListPollingInterval });
+	});
 
 	// Migrate stored GitLab access token from the legacy location to the
 	// per-account secrets entry on app load. Safe no-op when already done.

--- a/apps/desktop/src/routes/[projectId]/projectLayout.svelte.test.ts
+++ b/apps/desktop/src/routes/[projectId]/projectLayout.svelte.test.ts
@@ -320,11 +320,13 @@ describe("project review-list polling", () => {
 		});
 		const intervals: Array<[string, number | undefined]> = [];
 		const listingService = {
-			list(projectId: string, pollingInterval?: number) {
-				intervals.push([projectId, pollingInterval]);
+			list(projectId: string) {
 				return {
 					get result() {
 						return result;
+					},
+					updateSubscriptionOptions({ pollingInterval }: { pollingInterval?: number }) {
+						intervals.push([projectId, pollingInterval]);
 					},
 				} as never;
 			},

--- a/e2e/playwright/tests/forge.spec.ts
+++ b/e2e/playwright/tests/forge.spec.ts
@@ -173,9 +173,8 @@ test("a failing checks poll backs off instead of hammering the endpoint", async 
 	await expect(badge).toContainText("Error");
 
 	const afterFirstError = checkRequests;
-	// Longer than the fast 5s interval, shorter than the 30s back-off: a
-	// hammering poller would fire ~2 more times in this window, a backed-off
-	// one ~0.
+	// Longer than the fast 5s interval, shorter than the 30s back-off. A backed-
+	// off poller fires exactly once more (see the merge-status test below).
 	await page.waitForTimeout(13_000);
 	expect(checkRequests - afterFirstError).toBeLessThanOrEqual(1);
 });
@@ -366,9 +365,9 @@ test("a failing merge-status poll backs off instead of hammering the endpoint", 
 	await expect.poll(() => statusRequests).toBeGreaterThan(0);
 
 	const afterFirstError = statusRequests;
-	// Longer than the fast 5s interval, shorter than the 30s back-off: a
-	// hammering poller would fire ~2 more times in this window, a backed-off
-	// one ~0.
+	// Longer than the fast 5s interval, shorter than the 30s back-off. A backed-
+	// off poller fires exactly once more: RTKQ never reschedules an armed timer
+	// to fire later, so the 5s poll armed before the error still runs.
 	await page.waitForTimeout(13_000);
 	expect(statusRequests - afterFirstError).toBeLessThanOrEqual(1);
 });


### PR DESCRIPTION
Fixes the "backs off instead of hammering" e2e flake (`Received: 2`, 8 fail-then-pass runs in 14 days). It was a real bug: the first failed poll fired two immediate retries.

- each backoff step re-created the polled query inside a `$derived` with the new interval
- a fresh subscription re-runs a query that has never fulfilled (RTKQ only serves from cache after a success), so every interval step was an instant refetch of the failing request
- `useQuery` results now carry `updateSubscriptionOptions`; the PR, merge-status, checks and review-listing pollers change their interval through it from an effect
- the one request still following a failure is the poll RTKQ had already armed: it reschedules a timer to fire sooner, never later

Requests after the first error in the merge-status e2e, 13s window:

| before | after |
|---|---|
| +76ms, +138ms | +5.0s |

The CI flake was the test sampling its counter between the burst's requests on a slow runner.

### Verified
- new unit test in `customHooks.svelte.test.ts`; svelte-check and eslint clean
- merge-status e2e 4/4 locally with the fix, 3/3 without (burst visible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)