### PR TITLE
Add an optional setting to put the file list right of the diff

### DIFF
--- a/apps/lite/electron/src/settings.ts
+++ b/apps/lite/electron/src/settings.ts
@@ -26,6 +26,7 @@ const guiSettingsV1 = type({
 	"dryRunOperations?": "boolean",
 	"editorId?": "string",
 	"fileDisplayMode?": "'list' | 'tree'",
+	"filesPanelRight?": "boolean",
 	"lineDiffType?": "'word-alt' | 'word' | 'char' | 'none'",
 	"minimap?": "boolean",
 	"pathFirst?": "boolean",

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -2712,6 +2712,55 @@ const Diff: FC<{
 		);
 	}
 
+	const filesOnRight = fileParent._tag !== "UncommittedChanges";
+	const filesPanel = filesVisible ? (
+		<Panel
+			id={"files-panel" satisfies PanelId}
+			className={styles.panel}
+			defaultSize={320}
+			minSize={220}
+			groupResizeBehavior="preserve-pixel-size"
+		>
+			<div className={styles.filesPanelContent} ref={filesPanelRef}>
+				{fileFilter.rowProps === null ? (
+					<ChangesHeaderRow
+						projectId={projectId}
+						fileParent={fileParent}
+						changes={changes}
+						lineStats={lineStats}
+						onOpenFilter={fileFilter.open}
+					/>
+				) : (
+					<ListFilterRow {...fileFilter.rowProps} />
+				)}
+				<div
+					className={classes(uiStyles.scroller, uiStyles.scrollerWithSeparator, styles.diffFiles)}
+				>
+					<FilesTree
+						focusScope="files"
+						onRowSelection={activateRow}
+						projectId={projectId}
+						rows={filesRows}
+						collapsedDirectories={filesCollapsedDirectories}
+						onToggleDirectoryCollapsed={(path) =>
+							dispatch(projectSlice.actions.toggleFilesDirectoryCollapsed({ projectId, path }))
+						}
+						selection={filesSelection}
+						addressSpace={filesAddressSpace}
+						fileParent={fileParent}
+						reviewedPaths={reviewedFilePaths}
+						canUncommit={!isCommitUncommitChangesPending}
+						uncommit={uncommit}
+						emptyLabel={
+							filesFilter !== null && filesItems.length > 0 ? "No matching files." : undefined
+						}
+						ref={filesTreeRef}
+					/>
+				</div>
+			</div>
+		</Panel>
+	) : null;
+
 	return (
 		<div className={styles.diffTab}>
 			<Group
@@ -2719,61 +2768,9 @@ const Diff: FC<{
 				defaultLayout={diffLayout.defaultLayout}
 				onLayoutChanged={diffLayout.onLayoutChanged}
 			>
-				{filesVisible && (
+				{filesPanel !== null && !filesOnRight && (
 					<>
-						<Panel
-							id={"files-panel" satisfies PanelId}
-							className={styles.panel}
-							defaultSize={320}
-							minSize={220}
-							groupResizeBehavior="preserve-pixel-size"
-						>
-							<div className={styles.filesPanelContent} ref={filesPanelRef}>
-								{fileFilter.rowProps === null ? (
-									<ChangesHeaderRow
-										projectId={projectId}
-										fileParent={fileParent}
-										changes={changes}
-										lineStats={lineStats}
-										onOpenFilter={fileFilter.open}
-									/>
-								) : (
-									<ListFilterRow {...fileFilter.rowProps} />
-								)}
-								<div
-									className={classes(
-										uiStyles.scroller,
-										uiStyles.scrollerWithSeparator,
-										styles.diffFiles,
-									)}
-								>
-									<FilesTree
-										focusScope="files"
-										onRowSelection={activateRow}
-										projectId={projectId}
-										rows={filesRows}
-										collapsedDirectories={filesCollapsedDirectories}
-										onToggleDirectoryCollapsed={(path) =>
-											dispatch(
-												projectSlice.actions.toggleFilesDirectoryCollapsed({ projectId, path }),
-											)
-										}
-										selection={filesSelection}
-										addressSpace={filesAddressSpace}
-										fileParent={fileParent}
-										reviewedPaths={reviewedFilePaths}
-										canUncommit={!isCommitUncommitChangesPending}
-										uncommit={uncommit}
-										emptyLabel={
-											filesFilter !== null && filesItems.length > 0
-												? "No matching files."
-												: undefined
-										}
-										ref={filesTreeRef}
-									/>
-								</div>
-							</div>
-						</Panel>
+						{filesPanel}
 						<ResizeHandle />
 					</>
 				)}
@@ -2885,6 +2882,13 @@ const Diff: FC<{
 						</div>
 					</div>
 				</Panel>
+
+				{filesPanel !== null && filesOnRight && (
+					<>
+						<ResizeHandle />
+						{filesPanel}
+					</>
+				)}
 			</Group>
 		</div>
 	);

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -2562,6 +2562,7 @@ const Diff: FC<{
 			diffOverflow: cfg.diffOverflow,
 			diffStyle: cfg.diffStyle,
 			diffTabSize: cfg.diffTabSize,
+			filesPanelRight: cfg.filesPanelRight,
 			minimap: cfg.minimap,
 		}),
 	});
@@ -2712,7 +2713,7 @@ const Diff: FC<{
 		);
 	}
 
-	const filesOnRight = fileParent._tag !== "UncommittedChanges";
+	const filesOnRight = diffSettings?.filesPanelRight ?? defaultSettings.filesPanelRight;
 	const filesPanel = filesVisible ? (
 		<Panel
 			id={"files-panel" satisfies PanelId}

--- a/apps/lite/ui/src/routes/project/$id/workspace/Settings/Appearance.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Settings/Appearance.tsx
@@ -106,6 +106,18 @@ export const Appearance: FC = () => {
 						onCheckedChange={(pathFirst) => saveGUISettings({ pathFirst })}
 					/>
 				</Row>
+
+				<Row
+					label="File list right of the diff"
+					labelId="files-panel-right"
+					hint="Keeps the details pane's file list away from the sidebar's, so two lists don't sit side by side."
+				>
+					<Switch
+						aria-labelledby="files-panel-right"
+						checked={settings.filesPanelRight ?? defaultSettings.filesPanelRight}
+						onCheckedChange={(filesPanelRight) => saveGUISettings({ filesPanelRight })}
+					/>
+				</Row>
 			</Section>
 
 			<Section heading="Diff">

--- a/apps/lite/ui/src/settings.ts
+++ b/apps/lite/ui/src/settings.ts
@@ -18,6 +18,7 @@ export const defaultSettings = {
 	dryRunOperations: false,
 	// Show the folder tree until the user chooses a display mode.
 	fileDisplayMode: "tree",
+	filesPanelRight: false,
 	// Pierre's own default, named here so the setting has somewhere to fall back to.
 	lineDiffType: "word-alt",
 	// Experimental; opt in from the Experimental settings.


### PR DESCRIPTION
I think it would feel more natural to have the changes file list on the right?

This adds a switch under Appearance → Files, "File list right of the diff". It defaults to off, so nothing changes until it is turned on. On, the commit, branch and uncommitted views show the diff first with the file list to its right, keeping it away from the sidebar's own file list.
