### PR TITLE
Take the keychain prompt off Lite's launch path

### DIFF
--- a/apps/lite/electron/src/main.ts
+++ b/apps/lite/electron/src/main.ts
@@ -49,7 +49,9 @@ import { type GUISettings, readSettings, writeSettings } from "./settings.js";
 import { initMetrics, metricsOnLogin, shutdownMetrics, withApiCommandCapture } from "./metrics.js";
 import { apiParamNames } from "@gitbutler/but-sdk/api-param-names";
 
-Object.assign(process.env, interactiveLoginShellEnvironment());
+// Started now so the shell's startup overlaps with Electron's; applied once ready, before
+// anything that could spawn a process.
+const shellEnvironment = interactiveLoginShellEnvironment();
 
 const isHeadless = process.env.GITBUTLER_LITE_HEADLESS === "true";
 if (isHeadless && process.platform === "darwin") app.setActivationPolicy("accessory");
@@ -590,6 +592,7 @@ if (!app.requestSingleInstanceLock()) {
 
 void app.whenReady().then(async () => {
 	initLogging();
+	Object.assign(process.env, await shellEnvironment);
 	applyGUISettings(await readSettings());
 	await initApplicationNamespace(null);
 	configureAskpass();

--- a/apps/lite/electron/src/main.ts
+++ b/apps/lite/electron/src/main.ts
@@ -128,6 +128,8 @@ protocol.registerSchemesAsPrivileged([
 			standard: true,
 			secure: true,
 			supportFetchAPI: true,
+			// Lets Chromium keep the renderer bundle's compiled bytecode between launches.
+			codeCache: true,
 		},
 	},
 ]);
@@ -530,6 +532,8 @@ const createMainWindow = async (initialUrl?: string): Promise<void> => {
 			contextIsolation: true,
 			nodeIntegration: false,
 			preload: path.join(currentDirPath, "preload.cjs"),
+			// Cache every script's bytecode, not only what Chromium's heuristics deem hot.
+			v8CacheOptions: "bypassHeatCheck",
 		},
 	});
 	registerEditingContextMenu(mainWindow);

--- a/apps/lite/electron/src/metrics.ts
+++ b/apps/lite/electron/src/metrics.ts
@@ -105,9 +105,9 @@ export const initMetrics = async (version: string): Promise<void> => {
 		const profile = await getUserProfileLocal();
 		if (profile !== null) await metricsOnLogin(profile);
 		else if (distinctId !== telemetry.appDistinctId) await updateTelemetryDistinctId(distinctId);
-		// Bound the remote lookup so IPC capture starts with one stable policy
-		// without making app startup depend on PostHog being reachable.
-		await configureFailureLimit(client);
+		// Not awaited: the window must not wait for PostHog. The built-in
+		// default applies until the remote limit lands.
+		void configureFailureLimit(client);
 	} catch (error) {
 		// oxlint-disable-next-line no-console
 		console.error("Failed to initialize metrics", error);

--- a/apps/lite/harness/tests/metrics.test.ts
+++ b/apps/lite/harness/tests/metrics.test.ts
@@ -46,6 +46,9 @@ const initMetrics = async (failureLimit?: {
 	mocks.client.getFeatureFlagPayload.mockResolvedValue(failureLimit);
 	const metrics = await import("../../electron/src/metrics.ts");
 	await metrics.initMetrics("1.2.3");
+	// The failure limit lands a few microtasks after init returns; a tick drains
+	// them, and unlike a timer it still fires under fake timers.
+	await new Promise((resolve) => process.nextTick(resolve));
 	return metrics;
 };
 

--- a/crates/but-api/src/legacy/users.rs
+++ b/crates/but-api/src/legacy/users.rs
@@ -114,10 +114,13 @@ impl From<User> for UserProfile {
 }
 
 /// The signed-in account, or `None`. Credentials stay in this process.
+///
+/// Only the stored profile is read: the keychain, which may prompt on macOS, is left to the
+/// first call that needs the token.
 #[but_api(napi)]
 #[instrument(err(Debug))]
 pub fn get_user_profile_local() -> Result<Option<UserProfile>> {
-    Ok(get_user()?.map(Into::into))
+    Ok(gitbutler_user::get_user()?.map(Into::into))
 }
 
 /// Change the profile on gitbutler.com and keep the stored account in step.

--- a/crates/but-napi/src/lib.rs
+++ b/crates/but-napi/src/lib.rs
@@ -223,17 +223,23 @@ impl From<but_askpass::PromptEvent<but_askpass::Context>> for AskpassPromptEvent
 /// Return the interactive login shell environment for GUI launches.
 ///
 /// Returns an empty map when launched from a terminal or on Windows, where shell startup may block.
+/// Async so the shell can start while Electron boots instead of before it.
 #[napi]
-pub fn interactive_login_shell_environment() -> HashMap<String, String> {
+pub async fn interactive_login_shell_environment() -> napi::Result<HashMap<String, String>> {
     if cfg!(windows) || std::env::var_os("TERM").is_some() {
-        return HashMap::new();
+        return Ok(HashMap::new());
     }
 
-    but_core::cmd::extract_interactive_login_shell_environment()
-        .unwrap_or_default()
-        .into_iter()
-        .filter_map(|(key, value)| Some((key.into_string().ok()?, value.into_string().ok()?)))
-        .collect()
+    let vars: HashMap<String, String> = tokio::task::spawn_blocking(|| {
+        but_core::cmd::extract_interactive_login_shell_environment()
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|(key, value)| Some((key.into_string().ok()?, value.into_string().ok()?)))
+            .collect()
+    })
+    .await
+    .map_err(|err| napi::Error::from_reason(err.to_string()))?;
+    Ok(vars)
 }
 
 /// Initialize the process-global askpass broker and forward prompt events to JavaScript.

--- a/packages/but-sdk/src/generated/graph/index.d.ts
+++ b/packages/but-sdk/src/generated/graph/index.d.ts
@@ -614,7 +614,7 @@ export declare function deleteProject(projectId: ProjectHandleOrLegacyProjectId)
 export declare function deleteReviewComment(projectId: string, commentId: number): Promise<void>
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/users.rs:226}
+ * {@link ../../../../../crates/but-api/src/legacy/users.rs:229}
  */
 export declare function deleteUser(): Promise<void>
 
@@ -822,7 +822,7 @@ export declare function getGlUser(account: GitlabAccountIdentifier): Promise<Git
 export declare function getInitialBranchIntegration(projectId: string, branch: string, strategy: BranchIntegrationStrategy | null): Promise<InitialBranchIntegration>
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/users.rs:232}
+ * {@link ../../../../../crates/but-api/src/legacy/users.rs:235}
  */
 export declare function getLoginToken(): Promise<LoginToken>
 
@@ -882,7 +882,10 @@ export declare function getUndoTargetSnapshot(projectId: string): Promise<Snapsh
 /**
  * The signed-in account, or `None`. Credentials stay in this process.
  *
- * {@link ../../../../../crates/but-api/src/legacy/users.rs:117}
+ * Only the stored profile is read: the keychain, which may prompt on macOS, is left to the
+ * first call that needs the token.
+ *
+ * {@link ../../../../../crates/but-api/src/legacy/users.rs:120}
  */
 export declare function getUserProfileLocal(): Promise<UserProfile | null>
 
@@ -1112,7 +1115,7 @@ export declare function listSnapshots(projectId: string, limit: number, sha: str
 /**
  * Complete a login and persist the account, so the token never leaves this process.
  *
- * {@link ../../../../../crates/but-api/src/legacy/users.rs:192}
+ * {@link ../../../../../crates/but-api/src/legacy/users.rs:195}
  */
 export declare function loginAndPersist(token: string): Promise<UserProfile>
 
@@ -1515,7 +1518,7 @@ export declare function updateAiConfiguration(update: AiConfigurationUpdate): Pr
  * The API call alone would leave the local copy stale, so the name shown next to the
  * picture would still be the old one until the next sign-in.
  *
- * {@link ../../../../../crates/but-api/src/legacy/users.rs:127}
+ * {@link ../../../../../crates/but-api/src/legacy/users.rs:130}
  */
 export declare function updateProfileAndPersist(params: UpdateUserParams): Promise<UserProfile>
 
@@ -1555,7 +1558,7 @@ export declare function updateReviewFooters(projectId: string, reviews: Array<Fo
  * here rather than in the frontend because the account token never leaves this
  * process, so a renderer cannot make the authenticated call itself.
  *
- * {@link ../../../../../crates/but-api/src/legacy/users.rs:183}
+ * {@link ../../../../../crates/but-api/src/legacy/users.rs:186}
  */
 export declare function uploadFile(params: UploadFileParams): Promise<Upload>
 

--- a/packages/but-sdk/src/generated/graph/index.d.ts
+++ b/packages/but-sdk/src/generated/graph/index.d.ts
@@ -1765,8 +1765,9 @@ export declare function initTracing(identifier: string, alsoToStderr: boolean): 
  * Return the interactive login shell environment for GUI launches.
  *
  * Returns an empty map when launched from a terminal or on Windows, where shell startup may block.
+ * Async so the shell can start while Electron boots instead of before it.
  */
-export declare function interactiveLoginShellEnvironment(): Record<string, string>
+export declare function interactiveLoginShellEnvironment(): Promise<Record<string, string>>
 
 /** Any left fork link line. */
 export const LEFT_FORK: number

--- a/packages/but-sdk/src/generated/linear/index.d.ts
+++ b/packages/but-sdk/src/generated/linear/index.d.ts
@@ -614,7 +614,7 @@ export declare function deleteProject(projectId: ProjectHandleOrLegacyProjectId)
 export declare function deleteReviewComment(projectId: string, commentId: number): Promise<void>
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/users.rs:226}
+ * {@link ../../../../../crates/but-api/src/legacy/users.rs:229}
  */
 export declare function deleteUser(): Promise<void>
 
@@ -822,7 +822,7 @@ export declare function getGlUser(account: GitlabAccountIdentifier): Promise<Git
 export declare function getInitialBranchIntegration(projectId: string, branch: string, strategy: BranchIntegrationStrategy | null): Promise<InitialBranchIntegration>
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/users.rs:232}
+ * {@link ../../../../../crates/but-api/src/legacy/users.rs:235}
  */
 export declare function getLoginToken(): Promise<LoginToken>
 
@@ -882,7 +882,10 @@ export declare function getUndoTargetSnapshot(projectId: string): Promise<Snapsh
 /**
  * The signed-in account, or `None`. Credentials stay in this process.
  *
- * {@link ../../../../../crates/but-api/src/legacy/users.rs:117}
+ * Only the stored profile is read: the keychain, which may prompt on macOS, is left to the
+ * first call that needs the token.
+ *
+ * {@link ../../../../../crates/but-api/src/legacy/users.rs:120}
  */
 export declare function getUserProfileLocal(): Promise<UserProfile | null>
 
@@ -1112,7 +1115,7 @@ export declare function listSnapshots(projectId: string, limit: number, sha: str
 /**
  * Complete a login and persist the account, so the token never leaves this process.
  *
- * {@link ../../../../../crates/but-api/src/legacy/users.rs:192}
+ * {@link ../../../../../crates/but-api/src/legacy/users.rs:195}
  */
 export declare function loginAndPersist(token: string): Promise<UserProfile>
 
@@ -1515,7 +1518,7 @@ export declare function updateAiConfiguration(update: AiConfigurationUpdate): Pr
  * The API call alone would leave the local copy stale, so the name shown next to the
  * picture would still be the old one until the next sign-in.
  *
- * {@link ../../../../../crates/but-api/src/legacy/users.rs:127}
+ * {@link ../../../../../crates/but-api/src/legacy/users.rs:130}
  */
 export declare function updateProfileAndPersist(params: UpdateUserParams): Promise<UserProfile>
 
@@ -1555,7 +1558,7 @@ export declare function updateReviewFooters(projectId: string, reviews: Array<Fo
  * here rather than in the frontend because the account token never leaves this
  * process, so a renderer cannot make the authenticated call itself.
  *
- * {@link ../../../../../crates/but-api/src/legacy/users.rs:183}
+ * {@link ../../../../../crates/but-api/src/legacy/users.rs:186}
  */
 export declare function uploadFile(params: UploadFileParams): Promise<Upload>
 

--- a/packages/but-sdk/src/generated/linear/index.d.ts
+++ b/packages/but-sdk/src/generated/linear/index.d.ts
@@ -1765,8 +1765,9 @@ export declare function initTracing(identifier: string, alsoToStderr: boolean): 
  * Return the interactive login shell environment for GUI launches.
  *
  * Returns an empty map when launched from a terminal or on Windows, where shell startup may block.
+ * Async so the shell can start while Electron boots instead of before it.
  */
-export declare function interactiveLoginShellEnvironment(): Record<string, string>
+export declare function interactiveLoginShellEnvironment(): Promise<Record<string, string>>
 
 /** Any left fork link line. */
 export const LEFT_FORK: number


### PR DESCRIPTION
Lite nightly took 8.5 s to show its window on the first launch of each build. The tracing log and `securityd` show why: `initMetrics` is awaited before the window is created, it read the profile through `get_user`, and that checks the token in the keychain. The shared token item trusted only the desktop nightly, so each new Lite build got a keychain prompt and the window waited behind it.

- `getUserProfileLocal` reads the stored profile only; the token is checked by the first call that needs it
- the remote failure-limit fetch is no longer awaited before the window
- the login-shell environment is fetched async while Electron boots, instead of synchronously at module load (about 0.5 s of zsh startup)
- the `but` scheme gets `codeCache` and the window `bypassHeatCheck`, so the 3 MB renderer bundle is not recompiled from source on every launch

Measured on a local packaged build of this branch, warm launch, spawn to event:

| Stage | Before | After |
|---|---|---|
| Page loaded | 1.6 s, plus the prompt when it appears | 0.78 s |
| Window visible | | 0.74 s |
| Keychain prompt at launch | on each build the item does not trust | none |

The workspace stays empty until `changes_in_worktree` returns, 1.9 to 5 s on a large dirty tree here. That is separate work on the Rust side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)