### PR TITLE
Find the project picker by its combobox role in the screenshot helpers

### DIFF
--- a/apps/lite/e2e/screenshot-helpers.ts
+++ b/apps/lite/e2e/screenshot-helpers.ts
@@ -49,7 +49,7 @@ export const shoot = async (appWindow: Page, name: string, selector: string): Pr
 
 export const openProject = async (appWindow: Page): Promise<void> => {
 	await expect(appWindow).toHaveURL(/\/project\/[^/]+\/workspace/);
-	await expect(appWindow.getByRole("button", { name: /select project/i })).toBeVisible();
+	await expect(appWindow.getByRole("combobox", { name: /select project/i })).toBeVisible();
 	await appWindow.setViewportSize(VIEWPORT);
 
 	// On CI the renderer the window starts with sometimes never produces a frame
@@ -57,7 +57,7 @@ export const openProject = async (appWindow: Page): Promise<void> => {
 	// waits for a paint that never arrives. Reloading gets a renderer that works.
 	await appWindow.reload();
 	await appWindow.getByRole("main").waitFor();
-	await expect(appWindow.getByRole("button", { name: /select project/i })).toBeVisible();
+	await expect(appWindow.getByRole("combobox", { name: /select project/i })).toBeVisible();
 };
 
 // Under a bare X server the renderer only paints a capturable frame on load: a
@@ -75,7 +75,7 @@ export const goToTab = async (appWindow: Page, tab: "workspace" | "branches"): P
 	// only an explicit reload reliably produces one.
 	await appWindow.reload();
 	await appWindow.getByRole("main").waitFor();
-	await expect(appWindow.getByRole("button", { name: /select project/i })).toBeVisible();
+	await expect(appWindow.getByRole("combobox", { name: /select project/i })).toBeVisible();
 
 	// Assert the tab actually changed. Every other post-condition here is present
 	// on both tabs, so without this a navigation that silently stayed put


### PR DESCRIPTION
The Lite screenshot helpers wait for the project picker before every capture, looking for a `button` named "Select project". The picker became a base-ui `Combobox` in #15685, so that wait never resolves and every capture times out.

- the three lookups in `screenshot-helpers.ts` now ask for the `combobox` role
- these helpers back the `lite-screenshots` skill and `screenshots.spec.ts`, which the CI reminder points Lite UI PRs at; the spec is opt-in, so CI does not catch this

### Verified
- the before/after screenshots on #15783 were captured with this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)