### PR TITLE
Keep the commit form in reach and survive hot reloads

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.module.css
@@ -90,11 +90,12 @@
 }
 
 /* The card's head, header and filter, stays at the scroller's top while the
-   rows scroll under it, so the filter stays in reach. */
+   rows scroll under it, so the filter stays in reach. Over the commit form,
+   which passes under it as the card's foot leaves. */
 .cardHead {
 	container-type: scroll-state;
 
-	z-index: 1;
+	z-index: 2;
 	position: sticky;
 	top: 0;
 	background-color: var(--bg-1);
@@ -118,6 +119,24 @@
 	flex: 1;
 	min-width: 0;
 	margin-block: 8px;
+}
+
+/* The commit form keeps to the scroller's foot while the card's own foot is
+   below it, over the docked merge base row when there is one (its `bottom`),
+   so a long list still commits. A hairline while stuck says the rows pass
+   beneath; a shadow, so the form's height does not change as it sticks. */
+.commitFoot {
+	container-type: scroll-state;
+
+	z-index: 1;
+	position: sticky;
+	background-color: var(--bg-1);
+}
+
+.commitFootRow {
+	@container scroll-state(stuck: bottom) {
+		box-shadow: 0 -1px 0 var(--border-section);
+	}
 }
 
 /* With no stacks, the one block is centred in the room under the uncommitted

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.tsx
@@ -116,19 +116,23 @@ const uncommittedChangesHeadingId = "uncommitted-changes-heading";
 const DryRunWorkspaceContext = createContext<WorkspaceState | null>(null);
 DryRunWorkspaceContext.displayName = "DryRunWorkspaceContext";
 
-/** An element's height, kept current as it resizes. */
-const useHeight = (ref: RefObject<HTMLElement | null>): number => {
+/**
+ * An element's height, kept current as it resizes: give the element the ref.
+ * Keyed on the element, not a ref object, so a replaced node (a hot reload
+ * swaps them) is measured afresh rather than watched after it is gone.
+ */
+const useHeight = (): [ref: (element: HTMLElement | null) => void, height: number] => {
+	const [element, setElement] = useState<HTMLElement | null>(null);
 	const [height, setHeight] = useState(0);
 	useLayoutEffect(() => {
-		const element = ref.current;
 		if (element === null) return;
 		const measure = () => setHeight(element.offsetHeight);
 		measure();
 		const observer = new ResizeObserver(measure);
 		observer.observe(element);
 		return () => observer.disconnect();
-	}, [ref]);
-	return height;
+	}, [element]);
+	return [setElement, height];
 };
 
 const TreeItem: FC<
@@ -290,9 +294,10 @@ const UncommittedChanges: FC<
 		selectActiveFile: (selection: string) => void;
 		spillEdge: (offset: -1 | 1) => void;
 		worktreeChanges: WorktreeChanges | undefined;
-		/** The graph's scroller, which the card heads, and the room a row scrolled into view keeps clear at its foot. */
+		/** The graph's scroller, which the card heads. */
 		scrollElementRef: RefObject<HTMLDivElement | null>;
-		scrollPaddingEnd: number;
+		/** The docked merge base row's height at the scroller's foot, or 0: the commit form sticks above it. */
+		footDock: number;
 	} & Omit<ComponentProps<"div">, "children">
 > = ({
 	addressSpace,
@@ -306,7 +311,7 @@ const UncommittedChanges: FC<
 	spillEdge,
 	worktreeChanges,
 	scrollElementRef,
-	scrollPaddingEnd,
+	footDock,
 	...props
 }) => {
 	const dispatch = useAppDispatch();
@@ -348,9 +353,10 @@ const UncommittedChanges: FC<
 
 	const cardRef = useRef<HTMLDivElement>(null);
 	const fileListRef = useRef<HTMLDivElement>(null);
-	// The head sticks at the scroller's top, so a row scrolled into view clears it.
-	const headRef = useRef<HTMLDivElement>(null);
-	const headHeight = useHeight(headRef);
+	// The head sticks at the scroller's top and the commit form at its foot, so a row
+	// scrolled into view clears both.
+	const [headRef, headHeight] = useHeight();
+	const [formRef, formHeight] = useHeight();
 	// The list's start in the scroller, which the card heads: the rows above the
 	// list come and go with the filter and the worktree, so the card's size says
 	// when to measure again.
@@ -471,27 +477,29 @@ const UncommittedChanges: FC<
 						scrollElementRef={scrollElementRef}
 						scrollMargin={listOffset}
 						scrollPaddingStart={headHeight}
-						scrollPaddingEnd={scrollPaddingEnd}
+						scrollPaddingEnd={footDock + formHeight}
 						// The rows sit on the trunk, at the graph's inset rather than the tree's own.
 						style={{ "--row-padding-inline-start": `${ROW_INSET}px` }}
 					/>
 				</Activity>
 
-				<Row interactive={false}>
-					{trunk}
-					<CommitForm
-						projectId={projectId}
-						commitTarget={commitTarget}
-						targetComboboxItems={targetComboboxItems}
-						hasNoBranches={hasNoBranches}
-						startCommitButtonId={startCommitButtonId}
-						commitMessageInputId={commitMessageInputId}
-						className={styles.commitForm}
-						onAmendCommit={amendCommit}
-						canAmendCommit={canAmendCommit}
-						worktreeChanges={worktreeChanges}
-					/>
-				</Row>
+				<div ref={formRef} className={styles.commitFoot} style={{ bottom: footDock }}>
+					<Row interactive={false} className={styles.commitFootRow}>
+						{trunk}
+						<CommitForm
+							projectId={projectId}
+							commitTarget={commitTarget}
+							targetComboboxItems={targetComboboxItems}
+							hasNoBranches={hasNoBranches}
+							startCommitButtonId={startCommitButtonId}
+							commitMessageInputId={commitMessageInputId}
+							className={styles.commitForm}
+							onAmendCommit={amendCommit}
+							canAmendCommit={canAmendCommit}
+							worktreeChanges={worktreeChanges}
+						/>
+					</Row>
+				</div>
 			</Activity>
 
 			<Row interactive={false} className={styles.stub}>
@@ -1222,8 +1230,8 @@ const Stacks: FC<{
 		[scrollElementRef],
 	);
 	// The cards start under the uncommitted files card and the gap below it.
-	const headRef = useRef<HTMLDivElement>(null);
-	const scrollMargin = useHeight(headRef) + CARD_GAP;
+	const [headRef, headHeight] = useHeight();
+	const scrollMargin = headHeight + CARD_GAP;
 	// The scroller's foot, for the merge base row's stand-in. State, not a ref: it is portalled into.
 	const [footDock, setFootDock] = useState<HTMLDivElement | null>(null);
 	const getStackKey = useCallback((index: number) => stacks[index]?.id ?? index, [stacks]);
@@ -1605,9 +1613,10 @@ export const WorkspaceLists: FC<
 		focusScope("uncommitted-files");
 	};
 	const scrollElementRef = useRef<HTMLDivElement>(null);
-	// A row scrolled into view clears the docked merge base row, else the foot's gradient.
-	const scrollPaddingEnd =
-		graph.plan.base !== null && !graph.plan.baseExpanded ? DOCKED_HEIGHT : 14;
+	// The docked merge base row's height, which the card's commit form sticks above; a row
+	// scrolled into view clears it, else the foot's gradient.
+	const footDock = graph.plan.base !== null && !graph.plan.baseExpanded ? DOCKED_HEIGHT : 0;
+	const scrollPaddingEnd = Math.max(footDock, 14);
 	const uncommitted = (
 		<OperationSourceC
 			projectId={projectId}
@@ -1633,7 +1642,7 @@ export const WorkspaceLists: FC<
 							spillEdge={spillIntoStacks}
 							worktreeChanges={worktreeChanges}
 							scrollElementRef={scrollElementRef}
-							scrollPaddingEnd={scrollPaddingEnd}
+							footDock={footDock}
 						/>
 					}
 				/>


### PR DESCRIPTION
Two follow-ups to #15783 that were amended locally after it merged.

## What changed

- The commit form sticks at the scroller's foot while the card's own foot is below it, above the docked merge base row, so a long list still commits without a scroll. A hairline while stuck says the rows pass beneath, and the card's head paints over the form as the foot leaves.
- The file list scrolls rows clear of the stuck form as well as the stuck head.
- The height hook keys its resize observer on the element, handed out as a callback ref, rather than on a ref object. A hot reload swaps the head's node; the old observer went on watching the dead one, reported 0 once, and the stacks virtualiser then ran with a scroll margin of 20 instead of the card's height, leaving a card-sized blank after a scroll.

## Verification

- Lite typecheck, oxlint, prettier, and unit tests pass.
- Hot reload reproduced and checked live: the head height now tracks the fold after a reload, and no blank appears at any scroll position.
- Captured at the previous tip: the form stuck above the docked merge base row under a long list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)