### PR TITLE
Lite: switch a PR's status from its badge

### DIFF
--- a/apps/lite/DESIGN.md
+++ b/apps/lite/DESIGN.md
@@ -54,6 +54,16 @@ thing; dark mode is handled by the tokens. Note that selected rows reach these
 styles through CSS in `Row.module.css` rather than by passing the variant, so
 selection can restyle without a re-render.
 
+## Cursors
+
+**No pointer cursors.** Lite is a desktop app, and desktop apps keep the arrow
+over buttons, menus and rows; the hand is a web convention for links out to a
+page. Don't set `cursor: pointer` on a control, and don't reintroduce it by
+resetting a `<button>` — the browser default for buttons is already the arrow.
+Interactivity is shown by the hover state, not the cursor. The cursors that do
+change are the ones that describe a gesture: `text` over editable text, `grab`
+and `grabbing` while dragging, and the resize cursors on a splitter.
+
 ## Icons
 
 **Source.** Icons come from the ⚛️ Lite Core Figma library. Don't draw new

--- a/apps/lite/DESIGN.md
+++ b/apps/lite/DESIGN.md
@@ -148,6 +148,13 @@ emptiness it hasn't checked yet will flash the wrong words on every open. Not a
 filter that matched nothing either: that belongs in a line where the list would
 be, next to the filter that caused it.
 
+**Never a stand-in that looks like content.** Gray avatar circles and text
+bars where the reviewers would go are what every app draws while it is still
+loading, so a section that draws them at rest reads as stuck, not empty. The PR
+panel's Reviewers and Labels used to do this, and lost the shapes for an "Add
+reviewers" button: the empty section says what fills it, and a control is the
+one thing a skeleton never shows.
+
 **Centred, and only in a panel with room for it.** A short strip — the
 uncommitted list above its commit form — takes a single muted line inset to the
 column its rows would occupy, not this. Panels resize, so a centred block needs

--- a/apps/lite/ui/src/components/Badge.module.css
+++ b/apps/lite/ui/src/components/Badge.module.css
@@ -43,8 +43,14 @@
 	color: var(--fill-gray-fg);
 }
 
+/* Tracks the shared opacity so a hover or inverted ground lifts it like the
+   colored variants, just from a lighter resting tint. */
 .lightGray {
-	background-color: color-mix(in srgb, var(--fill-gray-bg) 16%, transparent);
+	background-color: color-mix(
+		in srgb,
+		var(--fill-gray-bg) calc(var(--badge-bg-opacity) * 0.8),
+		transparent
+	);
 	color: var(--text-1);
 }
 

--- a/apps/lite/ui/src/components/Button.module.css
+++ b/apps/lite/ui/src/components/Button.module.css
@@ -16,9 +16,7 @@
 	white-space: nowrap;
 
 	&:not(.disableTransition) {
-		transition:
-			background-color var(--transition-fast),
-			color var(--transition-fast);
+		transition: var(--transition-button);
 	}
 
 	&[data-pressed] {

--- a/apps/lite/ui/src/components/Switch.module.css
+++ b/apps/lite/ui/src/components/Switch.module.css
@@ -12,7 +12,6 @@
 	border: none;
 	border-radius: 100px;
 	background-color: var(--border-2);
-	cursor: pointer;
 	transition: background-color 120ms ease;
 
 	&[data-checked] {
@@ -21,7 +20,6 @@
 
 	&:disabled,
 	&[data-disabled] {
-		cursor: default;
 		opacity: var(--disabled-opacity);
 	}
 }

--- a/apps/lite/ui/src/components/SwitchButton.module.css
+++ b/apps/lite/ui/src/components/SwitchButton.module.css
@@ -5,8 +5,6 @@
 	--button-padding-inline: 10px;
 	--button-gap: 8px;
 
-	cursor: pointer;
-
 	/* base-ui renders the switch as a <span role="switch"> plus a hidden
 	   checkbox, never a <button>, so these match the role rather than the tag.
 	   It also calls preventDefault on the switch's own click, which is what
@@ -23,8 +21,6 @@
 	   data-disabled, never the native attribute. */
 	&:has([role="switch"][data-disabled]) {
 		--disabled-opacity: 100%;
-		cursor: default;
-
 		opacity: 0.5;
 	}
 }

--- a/apps/lite/ui/src/global.css
+++ b/apps/lite/ui/src/global.css
@@ -16,6 +16,10 @@
 	--list-item-hover-bg: color-mix(var(--fill-gray-bg) var(--opacity-bg-hover), transparent);
 	--focus-ring: 1.5px solid color-mix(in srgb, var(--fill-gray-bg) 70%, transparent);
 	--transition-fast: 0.08s ease;
+	/* How a control's ground and text respond to hover and press. Shared by Button and
+	   by anything that behaves like one without being one, such as a badge that opens a
+	   menu, so all controls settle at the same speed. */
+	--transition-button: background-color var(--transition-fast), color var(--transition-fast);
 	/* How anything that opens over the app arrives: modals, dropdowns and the backdrop behind
 	   them, which are rendered as siblings and so cannot inherit it from one another. */
 	--transition-popup: 150ms cubic-bezier(0.45, 1.005, 0, 1.005);

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.module.css
@@ -48,11 +48,34 @@
 	color: var(--text-3);
 }
 
-.statusRow {
+/* The Status section is its header alone: the badge and the PR link sit
+   opposite the heading. */
+.statusActions {
 	display: flex;
-	flex-wrap: wrap;
 	align-items: center;
-	gap: 8px;
+	gap: 12px;
+}
+
+/* The badge is the menu trigger, so the button is invisible around it; the
+   hover deepens the badge's own tint rather than adding a ground of its own. */
+.statusTrigger {
+	display: flex;
+	padding: 0;
+	border: none;
+	border-radius: 30px;
+	background: none;
+
+	& > span {
+		transition: var(--transition-button);
+	}
+
+	&:hover:not(:disabled) > span {
+		--badge-bg-opacity: 28%;
+	}
+
+	&:disabled {
+		opacity: 0.6;
+	}
 }
 
 .link {
@@ -67,6 +90,11 @@
 	text-decoration: underline;
 	text-decoration-color: color-mix(in srgb, currentcolor 40%, transparent);
 	text-underline-position: from-font;
+
+	&:hover {
+		color: var(--text-1);
+		text-decoration-color: currentcolor;
+	}
 }
 
 .user {

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.module.css
@@ -238,17 +238,22 @@
 	color: var(--text-3);
 }
 
+/* Long branch names truncate instead of shattering mid-word; the arrow and
+   target wrap under the source as one unit when the panel is too narrow to
+   hold both. The copy tooltip and the target's title carry the full names. */
 .branches {
 	display: flex;
+	flex-wrap: wrap;
 	align-items: center;
-	gap: 4px;
-	word-break: break-all;
+	gap: 6px;
 }
 
 /* Dotted underline is the app's copy-a-reference affordance, as on the commit
    SHA in the details header. */
 .sourceBranch {
+	max-width: 100%;
 	padding: 0;
+	overflow: hidden;
 	border: none;
 	background: none;
 	color: var(--text-1);
@@ -257,18 +262,32 @@
 	text-decoration: underline;
 	text-decoration-style: dotted;
 	text-underline-position: from-font;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 
 	&:hover {
 		color: var(--text-2);
 	}
 }
 
+.branchTarget {
+	display: flex;
+	align-items: center;
+	min-width: 0;
+	max-width: 100%;
+	gap: 6px;
+}
+
 .branchArrow {
+	flex-shrink: 0;
 	color: var(--text-3);
 }
 
 .targetBranch {
+	overflow: hidden;
 	color: var(--text-2);
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 .created {

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.module.css
@@ -120,57 +120,6 @@
 	color: color-mix(in oklab, var(--label-color) 60%, var(--text-1));
 }
 
-/* Empty Reviewers and Labels keep their shape with muted stand-ins, so a
-   freshly opened pull request doesn't read as a broken panel. */
-.placeholderShape {
-	border-radius: 30px;
-	background-color: color-mix(in srgb, var(--fill-gray-bg) 6%, transparent);
-}
-
-.placeholderPeople {
-	display: flex;
-	position: relative;
-	flex-direction: column;
-	gap: 6px;
-}
-
-/* Fades the last stand-in row out, hinting the list is a suggestion of
-   content rather than content. */
-.placeholderPeople::after {
-	position: absolute;
-	right: 0;
-	bottom: 0;
-	left: 0;
-	height: 20px;
-	background: linear-gradient(to bottom, transparent, var(--bg-1));
-	content: "";
-}
-
-.placeholderRow {
-	display: flex;
-	align-items: center;
-	gap: 6px;
-}
-
-.placeholderAvatar {
-	width: 16px;
-	height: 16px;
-}
-
-.placeholderBar {
-	height: 16px;
-}
-
-.placeholderLabels {
-	display: flex;
-	flex-wrap: wrap;
-	gap: 4px;
-}
-
-.placeholderLabel {
-	height: 16px;
-}
-
 .checks {
 	display: flex;
 	flex-direction: column;

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.tsx
@@ -152,6 +152,16 @@ const CopyableBranch: FC<{ name: string }> = ({ name }) => {
 	);
 };
 
+/** The arrow and the target branch travel together when the row wraps. */
+const TargetBranch: FC<{ name: string }> = ({ name }) => (
+	<span className={styles.branchTarget}>
+		<span className={styles.branchArrow}>→</span>
+		<span className={styles.targetBranch} title={name}>
+			{name}
+		</span>
+	</span>
+);
+
 /**
  * The side panel while a PR is still being drafted: what the PR would be made
  * of, so the summary the form asks for can be written against something.
@@ -286,12 +296,7 @@ export const NewPullRequestPanel: FC<{
 			<Section heading="Branches">
 				<div className={classes("text-13", styles.branches)}>
 					<CopyableBranch name={sourceBranch} />
-					{targetBranch !== undefined && (
-						<>
-							<span className={styles.branchArrow}>→</span>
-							<span className={styles.targetBranch}>{targetBranch}</span>
-						</>
-					)}
+					{targetBranch !== undefined && <TargetBranch name={targetBranch} />}
 				</div>
 			</Section>
 		</aside>
@@ -671,8 +676,7 @@ export const PullRequestPanel: FC<{
 			<Section heading="Branches">
 				<div className={classes("text-13", styles.branches)}>
 					<CopyableBranch name={review.sourceBranch} />
-					<span className={styles.branchArrow}>→</span>
-					<span className={styles.targetBranch}>{review.targetBranch}</span>
+					<TargetBranch name={review.targetBranch} />
 				</div>
 			</Section>
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.tsx
@@ -3,6 +3,7 @@ import {
 	useRemoveReviewLabel,
 	useRequestReview,
 	useSetReviewDraftiness,
+	useUpdateReview,
 	useWithdrawReviewRequest,
 } from "#ui/api/mutations.ts";
 import {
@@ -47,6 +48,16 @@ const reviewStatus = (review: ForgeReview): ReviewStatus =>
 			: review.draft
 				? "draft"
 				: "open";
+
+const statusBits = (status: ReviewStatus): [string, BadgeVariant, IconName] =>
+	Match.value(status).pipe(
+		Match.withReturnType<[string, BadgeVariant, IconName]>(),
+		Match.when("open", () => ["Open", "safe", "pr"]),
+		Match.when("draft", () => ["Draft", "lightGray", "pr-draft"]),
+		Match.when("merged", () => ["Merged", "purple", "branch-merge"]),
+		Match.when("closed", () => ["Closed", "danger", "pr-close"]),
+		Match.exhaustive,
+	);
 
 const Section: FC<{
 	heading: string;
@@ -508,9 +519,53 @@ export const PullRequestPanel: FC<{
 	const { mutate: withdrawReviewRequest } = useWithdrawReviewRequest(projectId);
 	const { isPending: isDraftinessPending, mutate: setReviewDraftiness } =
 		useSetReviewDraftiness(projectId);
+	const { isPending: isUpdateReviewPending, mutate: updateReview } = useUpdateReview(projectId);
 
-	// Neither a merged nor a closed review can change draftiness.
-	const canToggleDraft = review.mergedAt === null && review.closedAt === null;
+	const status = reviewStatus(review);
+	// A merged review is final; anything else can move between open, draft and
+	// closed from the status badge.
+	const canSwitchStatus = status !== "merged";
+	const isStatusPending = isDraftinessPending || isUpdateReviewPending;
+
+	const setDraft = (draft: boolean) =>
+		setReviewDraftiness({ projectId, reviewId: review.number, draft });
+	const setState = (state: "open" | "closed", onSuccess?: () => void) =>
+		updateReview(
+			{ projectId, reviewId: review.number, state, title: null, body: null, targetBase: null },
+			{ onSuccess },
+		);
+
+	// Reopening restores the draftiness the review was closed with, so landing
+	// on the other of open/draft takes a second step once it is open again.
+	const switchStatus = (target: Exclude<ReviewStatus, "merged">) =>
+		Match.value(target).pipe(
+			Match.when("closed", () => setState("closed")),
+			Match.when("open", () =>
+				status === "closed"
+					? setState("open", () => review.draft && setDraft(false))
+					: setDraft(false),
+			),
+			Match.when("draft", () =>
+				status === "closed"
+					? setState("open", () => !review.draft && setDraft(true))
+					: setDraft(true),
+			),
+			Match.exhaustive,
+		);
+
+	const openStatusMenu = (evt: MouseEvent<HTMLButtonElement>) =>
+		void showNativeMenuFromTrigger(
+			evt.currentTarget,
+			(["open", "draft", "closed"] as const).map((target) =>
+				nativeMenuItem({
+					label: statusBits(target)[0],
+					checked: status === target,
+					onSelect: () => {
+						if (status !== target) switchStatus(target);
+					},
+				}),
+			),
+		);
 
 	// The queries stop fetching when canManage flips off, but cached data
 	// still reads — gate the pickers on manageability, not cache presence.
@@ -564,13 +619,13 @@ export const PullRequestPanel: FC<{
 		);
 	};
 
-	const [statusLabel, statusVariant, statusIcon] = Match.value(reviewStatus(review)).pipe(
-		Match.withReturnType<[string, BadgeVariant, IconName]>(),
-		Match.when("open", () => ["Open", "safe", "pr"]),
-		Match.when("draft", () => ["Draft", "lightGray", "pr-draft"]),
-		Match.when("merged", () => ["Merged", "purple", "branch-merge"]),
-		Match.when("closed", () => ["Closed", "danger", "pr-close"]),
-		Match.exhaustive,
+	const [statusLabel, statusVariant, statusIcon] = statusBits(status);
+	const statusBadge = (
+		<Badge variant={statusVariant} size="large">
+			<Icon name={statusIcon} size={12} />
+			{statusLabel}
+			{canSwitchStatus && <Icon name="chevron-down" size={12} />}
+		</Badge>
 	);
 
 	const createdAtMs = review.createdAt === null ? null : Date.parse(review.createdAt);
@@ -590,39 +645,33 @@ export const PullRequestPanel: FC<{
 			<Section
 				heading="Status"
 				action={
-					<a
-						href={review.htmlUrl}
-						onClick={handleOpen}
-						className={classes("text-12", styles.link, styles.prLink)}
-					>
-						{review.unitSymbol}
-						{review.number}
-						<Icon name="arrow-up-right" size={12} />
-					</a>
+					<div className={styles.statusActions}>
+						{canSwitchStatus ? (
+							<button
+								aria-label="Change status"
+								className={styles.statusTrigger}
+								disabled={isStatusPending}
+								onClick={openStatusMenu}
+								type="button"
+							>
+								{statusBadge}
+							</button>
+						) : (
+							statusBadge
+						)}
+						<a
+							href={review.htmlUrl}
+							onClick={handleOpen}
+							className={classes("text-12", styles.link, styles.prLink)}
+						>
+							{review.unitSymbol}
+							{review.number}
+							<Icon name="arrow-up-right" size={12} />
+						</a>
+					</div>
 				}
 			>
-				<div className={styles.statusRow}>
-					<Badge variant={statusVariant} size="large">
-						<Icon name={statusIcon} size={12} />
-						{statusLabel}
-					</Badge>
-					{canToggleDraft && (
-						<button
-							className={getButtonClassName({ variant: "outline", size: "small" })}
-							disabled={isDraftinessPending}
-							onClick={() =>
-								setReviewDraftiness({
-									projectId,
-									reviewId: review.number,
-									draft: !review.draft,
-								})
-							}
-							type="button"
-						>
-							{review.draft ? "Mark as ready" : "Convert to draft"}
-						</button>
-					)}
-				</div>
+				{null}
 			</Section>
 
 			<Section

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.tsx
@@ -72,43 +72,36 @@ const Section: FC<{
 const orEmptyNotice = (items: Array<NativeMenuItem>, notice: string): Array<NativeMenuItem> =>
 	items.length > 0 ? items : [nativeMenuItem({ label: notice, enabled: false })];
 
-const pickerButton = (label: string, onClick: (evt: MouseEvent<HTMLButtonElement>) => void) => (
-	<button
-		aria-label={label}
-		className={getButtonClassName({ variant: "ghost", size: "small", iconOnly: true })}
-		onClick={onClick}
-		type="button"
-	>
-		<Icon name="plus" />
-	</button>
-);
-
-/** Muted stand-ins shown while a section has nothing in it yet. */
-const PeoplePlaceholder: FC = () => (
-	<div className={styles.placeholderPeople}>
-		{[100, 160].map((width) => (
-			<div key={width} className={styles.placeholderRow}>
-				<span className={classes(styles.placeholderShape, styles.placeholderAvatar)} />
-				<span
-					className={classes(styles.placeholderShape, styles.placeholderBar)}
-					style={{ width }}
-				/>
-			</div>
-		))}
-	</div>
-);
-
-const LabelsPlaceholder: FC = () => (
-	<div className={styles.placeholderLabels}>
-		{[70, 50, 90].map((width) => (
-			<span
-				key={width}
-				className={classes(styles.placeholderShape, styles.placeholderLabel)}
-				style={{ width }}
-			/>
-		))}
-	</div>
-);
+/**
+ * The header control for a pickable section. While the section is empty it
+ * spells out what the picker adds so the section doesn't read as a bare
+ * heading; once something is picked, a plus is enough.
+ */
+const pickerButton = (p: {
+	label: string;
+	icon: IconName;
+	empty: boolean;
+	onClick: (evt: MouseEvent<HTMLButtonElement>) => void;
+}) =>
+	p.empty ? (
+		<button
+			className={getButtonClassName({ variant: "outline", size: "small" })}
+			onClick={p.onClick}
+			type="button"
+		>
+			{p.label}
+			<Icon name={p.icon} />
+		</button>
+	) : (
+		<button
+			aria-label={p.label}
+			className={getButtonClassName({ variant: "ghost", size: "small", iconOnly: true })}
+			onClick={p.onClick}
+			type="button"
+		>
+			<Icon name="plus" />
+		</button>
+	);
 
 const ReviewUser: FC<{ user: ForgeReviewUser }> = ({ user }) => (
 	<div className={classes("text-13", styles.user)} title={user.name ?? user.login}>
@@ -248,30 +241,40 @@ export const NewPullRequestPanel: FC<{
 		<aside className={styles.panel}>
 			<Section
 				heading="Reviewers"
-				action={canPickReviewers && pickerButton("Request a review", openReviewerMenu)}
+				action={
+					canPickReviewers &&
+					pickerButton({
+						label: "Add reviewers",
+						icon: "user",
+						empty: pickedReviewers.length === 0,
+						onClick: openReviewerMenu,
+					})
+				}
 			>
-				{pickedReviewers.length === 0 ? (
-					<PeoplePlaceholder />
-				) : (
-					pickedReviewers.map(({ login, user }) =>
-						user === undefined ? (
-							<span key={login} className="text-13">
-								{login}
-							</span>
-						) : (
-							<ReviewUser key={login} user={user} />
-						),
-					)
+				{pickedReviewers.map(({ login, user }) =>
+					user === undefined ? (
+						<span key={login} className="text-13">
+							{login}
+						</span>
+					) : (
+						<ReviewUser key={login} user={user} />
+					),
 				)}
 			</Section>
 
 			<Section
 				heading="Labels"
-				action={canPickLabels && pickerButton("Edit labels", openLabelMenu)}
+				action={
+					canPickLabels &&
+					pickerButton({
+						label: "Add labels",
+						icon: "tag",
+						empty: pickedLabels.length === 0,
+						onClick: openLabelMenu,
+					})
+				}
 			>
-				{pickedLabels.length === 0 ? (
-					<LabelsPlaceholder />
-				) : (
+				{pickedLabels.length > 0 && (
 					<div className={styles.labels}>
 						{pickedLabels.map((label) => (
 							<Label key={label.name} label={label} />
@@ -619,30 +622,40 @@ export const PullRequestPanel: FC<{
 
 			<Section
 				heading="Reviewers"
-				action={canPickReviewers && pickerButton("Request a review", openReviewerMenu)}
-			>
-				{reviewerList.length === 0 ? (
-					<PeoplePlaceholder />
-				) : (
-					reviewerList.map(({ user, verdict }) => {
-						const [icon, color, label] = verdictBits(verdict);
-						return (
-							<div key={user.id} className={styles.reviewerRow} title={label}>
-								<ReviewUser user={user} />
-								<Icon name={icon} style={{ color }} size={15} />
-							</div>
-						);
+				action={
+					canPickReviewers &&
+					pickerButton({
+						label: "Add reviewers",
+						icon: "user",
+						empty: reviewerList.length === 0,
+						onClick: openReviewerMenu,
 					})
-				)}
+				}
+			>
+				{reviewerList.map(({ user, verdict }) => {
+					const [icon, color, label] = verdictBits(verdict);
+					return (
+						<div key={user.id} className={styles.reviewerRow} title={label}>
+							<ReviewUser user={user} />
+							<Icon name={icon} style={{ color }} size={15} />
+						</div>
+					);
+				})}
 			</Section>
 
 			<Section
 				heading="Labels"
-				action={canPickLabels && pickerButton("Edit labels", openLabelMenu)}
+				action={
+					canPickLabels &&
+					pickerButton({
+						label: "Add labels",
+						icon: "tag",
+						empty: review.labels.length === 0,
+						onClick: openLabelMenu,
+					})
+				}
 			>
-				{review.labels.length === 0 ? (
-					<LabelsPlaceholder />
-				) : (
+				{review.labels.length > 0 && (
 					<div className={styles.labels}>
 						{review.labels.map((label) => (
 							<Label key={label.name} label={label} />


### PR DESCRIPTION
Updates the PR panel's Status row to match the [design](<https://www.figma.com/design/EBuHQGUcCaSw4Ln5uVpWkn/Lite?node-id=4855-52769>): the status badge sits in the section header next to the PR link and doubles as the status switcher.

* The badge grows a chevron and opens a native menu with **Open**, **Draft** and **Closed**, the current one checked. Draft and Open use the draftiness mutation, Closed uses the review update the toolbar menu already used to close and reopen. Reopening restores the draftiness the PR was closed with, so landing on the other of Open and Draft chains a second step once the PR is open again. A merged PR keeps a plain badge with no chevron.
* The standalone "Convert to draft" / "Mark as ready" button is gone; the menu replaces it.
* Both the badge and the PR link get hover states. The badge deepens its own tint using the same transition as buttons, now shared as a `--transition-button` token. The light gray Badge variant derives its tint from the shared opacity variable so it can lift on hover; its resting look is unchanged, though on an inverted selected row it now lifts along with the colored variants.
* No pointer cursors

Also includes the two earlier commits on this branch for the empty Reviewers and Labels sections and the Branches row. The gray stand-in shapes in the empty sections went partly because they looked like a skeleton loader: gray circles and bars where the content would be are what every app draws while loading, so the section read as stuck rather than empty. An "Add reviewers" button says what fills it instead, and a control is the one thing a skeleton never shows. That rule is now in `DESIGN.md` under Empty states.

## Screenshots

Before:

<img src="https://github.com/user-attachments/assets/e3d51de0-4f48-431d-86d2-19d95e87a2ec " alt="image" width="337" data-linear-height="345" />

After:

<img src="https://github.com/user-attachments/assets/aef262f8-3242-4f71-93e0-b6779b482c6f " alt="image" width="335" data-linear-height="248" />