### PR TITLE
Hand the uncommitted files row over to its dock without a jump

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.tsx
@@ -660,11 +660,12 @@ const FilesTreeVirtualList: FC<{
 	const renderInteractiveRows =
 		hasPendingOperationSources || (!rowVirtualizer.isScrolling && !deferredIsScrolling);
 
-	// Virtualisation-friendly equivalent to Row's own scrollIntoView.
+	// Virtualisation-friendly equivalent to Row's own scrollIntoView. Again as
+	// the head and foot to clear are measured or grow; auto is a no-op once clear.
 	useLayoutEffect(() => {
 		if (selectedRowIndex !== null)
 			rowVirtualizer.scrollToIndex(selectedRowIndex, { align: "auto" });
-	}, [rowVirtualizer, selectedRowIndex]);
+	}, [rowVirtualizer, selectedRowIndex, scrollPaddingStart, scrollPaddingEnd]);
 
 	return (
 		<div

--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/layout.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/layout.ts
@@ -21,6 +21,8 @@ export const CARD_GAP = 20;
 export const LEG_GAP = 12;
 /** The stuck merge base row's height, hairline and air included, which a row scrolled into view clears. Keep in sync with Section.module.css. */
 export const DOCKED_HEIGHT = 1 + 4 + 28 + 4;
+/** The stuck uncommitted files row's height: the card's head room, a row and a hairline. Keep in sync with WorkspaceLists.module.css. */
+export const HEAD_DOCKED_HEIGHT = 6 + 28 + 1;
 /** A long list, a run or the older history, shows this much at first, and this much more with each ask. */
 export const FIRST = 10;
 export const MORE = 20;

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.module.css
@@ -28,14 +28,17 @@
 
 /* Stands in for the uncommitted files card once it has scrolled out above: a
    sticky mark of no height at the card's foot, whose row shows only while the
-   mark is stuck. It takes over as the card's own stuck head is pushed out.
-   Keep in sync with layout.ts's DOCKED_HEIGHT. */
+   mark is stuck. The mark sticks a head's height down and the row sits that
+   much back up, so it takes over the moment the card's own stuck head starts
+   to be pushed out, never showing it half gone. Keep in sync with layout.ts's
+   HEAD_DOCKED_HEIGHT. */
 .dock {
+	--dock-offset: 0px;
 	container-type: scroll-state;
 
 	z-index: 2;
 	position: sticky;
-	top: 0;
+	top: var(--dock-offset);
 	height: 0;
 }
 
@@ -59,7 +62,6 @@
 }
 
 .dockRow {
-	--air: 4px;
 	/* The glyph sets its own visibility (GraphSegment.module.css), so hiding
 	   the row alone leaves it showing through. */
 	--graph-segment-glyph-visibility: hidden;
@@ -68,8 +70,10 @@
 	visibility: hidden;
 	position: absolute;
 	inset-inline: 0;
-	top: 0;
-	padding-block: var(--air);
+	top: calc(-1 * var(--dock-offset));
+	/* The card's head room and no air below, so the label and the curve's tail
+	   stay put as the row takes over. */
+	padding-block-start: 6px;
 	border-block-end: 1px solid var(--border-section);
 	background-color: var(--bg-2);
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.tsx
@@ -63,7 +63,14 @@ import {
 import styles from "./WorkspaceLists.module.css";
 import { Row, RowLabel, RowLabelContainer, SectionHeaderRow } from "../Row.tsx";
 import { type MoreBelow, Section } from "../Graph/Section.tsx";
-import { CARD_GAP, DOCKED_HEIGHT, ROW_INSET, foldAddresses, foldAt } from "../Graph/layout.ts";
+import {
+	CARD_GAP,
+	DOCKED_HEIGHT,
+	HEAD_DOCKED_HEIGHT,
+	ROW_INSET,
+	foldAddresses,
+	foldAt,
+} from "../Graph/layout.ts";
 import type { Graph } from "../Graph/usePlan.ts";
 import { StackCard } from "../StackCard.tsx";
 import stackCardStyles from "../StackCard.module.css";
@@ -298,6 +305,9 @@ const UncommittedChanges: FC<
 		scrollElementRef: RefObject<HTMLDivElement | null>;
 		/** The docked merge base row's height at the scroller's foot, or 0: the commit form sticks above it. */
 		footDock: number;
+		/** The card's head, measured by the parent, which docks a stand-in as soon as the head is pushed. */
+		headRef: (element: HTMLElement | null) => void;
+		headHeight: number;
 	} & Omit<ComponentProps<"div">, "children">
 > = ({
 	addressSpace,
@@ -312,6 +322,8 @@ const UncommittedChanges: FC<
 	worktreeChanges,
 	scrollElementRef,
 	footDock,
+	headRef,
+	headHeight,
 	...props
 }) => {
 	const dispatch = useAppDispatch();
@@ -355,7 +367,6 @@ const UncommittedChanges: FC<
 	const fileListRef = useRef<HTMLDivElement>(null);
 	// The head sticks at the scroller's top and the commit form at its foot, so a row
 	// scrolled into view clears both.
-	const [headRef, headHeight] = useHeight();
 	const [formRef, formHeight] = useHeight();
 	// The list's start in the scroller, which the card heads: the rows above the
 	// list come and go with the filter and the worktree, so the card's size says
@@ -1136,6 +1147,8 @@ const Stacks: FC<{
 	head: ReactNode;
 	/** Stands in for the card at the scroller's head while the card is scrolled out above. */
 	dock: ReactNode;
+	/** How far down the dock's mark sticks: the card's head height, so the stand-in takes over as the head is pushed. */
+	dockOffset: number;
 	scrollElementRef: RefObject<HTMLDivElement | null>;
 	scrollPaddingEnd: number;
 }> = ({
@@ -1148,6 +1161,7 @@ const Stacks: FC<{
 	onEdgeSpill,
 	head,
 	dock,
+	dockOffset,
 	scrollElementRef,
 	scrollPaddingEnd,
 }) => {
@@ -1305,7 +1319,7 @@ const Stacks: FC<{
 		rangeExtractor: rangeExtractorWithSelected,
 		scrollMargin,
 		// The head clears the docked uncommitted files row, the foot the docked merge base row.
-		scrollPaddingStart: DOCKED_HEIGHT,
+		scrollPaddingStart: HEAD_DOCKED_HEIGHT,
 		scrollPaddingEnd,
 	});
 
@@ -1382,7 +1396,9 @@ const Stacks: FC<{
 				{/* Its own tree: the files walk with their own cursor, and the arrow
 				    keys spill into the cards' tree at its edge. */}
 				<div ref={headRef}>{head}</div>
-				<div className={styles.dock}>{dock}</div>
+				<div className={styles.dock} style={{ "--dock-offset": `${dockOffset}px` }}>
+					{dock}
+				</div>
 				<GraphGap height={CARD_GAP} />
 				{/* One tree: the cards and the upstream section below them share the
 				    applied list's cursor, and arrow keys walk them in reading order. */}
@@ -1617,6 +1633,8 @@ export const WorkspaceLists: FC<
 	// scrolled into view clears it, else the foot's gradient.
 	const footDock = graph.plan.base !== null && !graph.plan.baseExpanded ? DOCKED_HEIGHT : 0;
 	const scrollPaddingEnd = Math.max(footDock, 14);
+	// The card's head, whose height says when its docked stand-in takes over.
+	const [cardHeadRef, cardHeadHeight] = useHeight();
 	const uncommitted = (
 		<OperationSourceC
 			projectId={projectId}
@@ -1643,6 +1661,8 @@ export const WorkspaceLists: FC<
 							worktreeChanges={worktreeChanges}
 							scrollElementRef={scrollElementRef}
 							footDock={footDock}
+							headRef={cardHeadRef}
+							headHeight={cardHeadHeight}
 						/>
 					}
 				/>
@@ -1670,6 +1690,7 @@ export const WorkspaceLists: FC<
 					canAmendCommit={canAmendCommit}
 					onEdgeSpill={spillIntoUncommittedChanges}
 					head={uncommitted}
+					dockOffset={cardHeadHeight}
 					dock={
 						<UncommittedChangesRow
 							changes={worktreeChanges?.changes ?? []}


### PR DESCRIPTION
**Follow-up to #15790, which merged before the rest of its work was pushed.** These changes were made on that branch after its first commit and were missed by the merge; they are the remainder of the same work, not a new design.

## What changed

- The dock's mark sticks a head's height down and the stand-in sits that much back up, so it takes over the moment the card's stuck head starts to be pushed out, never showing it half gone. The card's head is measured by the parent, which hands the height to the card and to the dock.
- The stand-in takes the card's head room above and no air below, as the stuck head has, so the label and the curve's tail stay where they were as it takes over. The stacks' head padding is that row's own height.
- The file list's scroll-into-view effect runs again as the stuck head and commit form are measured or grow. It ran once per selection, before either had a height, so a selection restored on load could land under the stuck form. Align auto leaves a row alone once it is clear.

## Verification

- Lite typecheck, oxlint, prettier, and unit tests pass.
- Checked live: the stand-in appears once the card's foot is within a head's height of the top; the label sits at the same height in the stuck head and the docked row, and the curve's tail meets the hairline in both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
