### PR TITLE
Call the merge base row Base, and count what it is behind

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/Section.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/Section.tsx
@@ -266,19 +266,19 @@ export const Section: FC<{
 	/** The ref's tip on the base: one row for both. Moved on: the row says how far. */
 	const baseHeader = (className?: string) => (
 		<Header
-			label={plan.refOnBase ? plan.header.label : "Merge base"}
+			label={plan.refOnBase ? plan.header.label : "Base"}
 			caption={
 				plan.refOnBase ? (
-					<span className={classes("text-12", styles.caption)}>merge base</span>
+					<span className={classes("text-12", styles.caption)}>base</span>
 				) : branched ? (
-					<span className={classes("text-12", styles.incoming)}>{plan.header.incoming} new</span>
+					<span className={classes("text-12", styles.incoming)}>{plan.header.incoming} behind</span>
 				) : undefined
 			}
 			heading={plan.refOnBase}
 			fold={{
 				open: plan.baseExpanded,
 				onToggle: toggleBase,
-				name: "the merge base's history",
+				name: "the base's history",
 			}}
 			rail={<GraphSegment glyph="control" status="LocalOnly" railEnds={!plan.baseExpanded} />}
 			className={className}


### PR DESCRIPTION
Wording only, on the graph's foot row.

- The row reads **Base**, or the ref name with a quiet **base** caption when the ref sits on the base.
- A moved-on target says **3 behind** rather than **3 new**.
- The fold's accessible name follows: "Unfold the base's history".

🤖 Generated with [Claude Code](https://claude.com/claude-code)