### PR TITLE
Name the remote branch on the incoming chip where it differs

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/BranchUpdatePanel.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/BranchUpdatePanel.tsx
@@ -308,9 +308,15 @@ const BranchUpdatePanel: FC<{
 			: [],
 	);
 	const restore = (commitId: string) =>
-		setEdits(edits.filter((edit) => edit.commitId !== commitId));
+		setEdits((current) => current.filter((edit) => edit.commitId !== commitId));
+	// Once each: a drop landing twice would count twice in Reset.
 	const dropRow = (row: PreviewRow) =>
-		setEdits([...edits, ...row.tracedIds.map((commitId) => ({ commitId }))]);
+		setEdits((current) => [
+			...current,
+			...row.tracedIds
+				.filter((commitId) => !current.some((edit) => edit.commitId === commitId))
+				.map((commitId) => ({ commitId })),
+		]);
 	const upstreamIds = new Set(plan.divergence.upstreamOnly.map((commit) => commit.id));
 	const leftOutIncoming = dropped.filter((entry) => upstreamIds.has(entry.commitId)).length;
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/BranchRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/BranchRow.tsx
@@ -354,6 +354,12 @@ export const BranchRow: FC<
 	const toggleIncoming = () =>
 		dispatch(projectSlice.actions.toggleIncomingExpanded({ projectId, branchRef }));
 	const remoteLabel = remote === null ? null : `${remote.remoteName}/${remote.displayName}`;
+	// The chip names the remote's branch only where it is not this branch's own
+	// name, which the row already shows.
+	const incomingLabel =
+		remote !== null && remote.displayName !== refName.displayName
+			? remoteLabel
+			: remote?.remoteName;
 	// Why a force push is needed, on hover, since the word alone says little.
 	const forcePushReason = (label: string): string =>
 		incoming > 0
@@ -552,11 +558,14 @@ export const BranchRow: FC<
 									className={classes(
 										getRowButtonClassName({ variant: "ghost" }),
 										rowStyles.metaItem,
+										rowStyles.metaItemShrinkable,
 									)}
 									onClick={toggleIncoming}
 								>
 									<Icon size={12} name={incomingExpanded ? "chevron-down" : "chevron-right"} />
-									{remote.remoteName} +{incoming}
+									<span className={rowStyles.metaItemText}>{incomingLabel}</span>
+									{/* Its own flex item: the chip's gap, not a space, parts it from the label. */}
+									<span>+{incoming}</span>
 								</button>
 								<RowMetaSeparator />
 							</>


### PR DESCRIPTION
Two small follow-ups from the review of #15679.

- The incoming chip read `origin +2` whatever the remote branch was called. It now names the branch, `origin/topic +2`, when that name is not the row's own, which the row already shows, and truncates a long one rather than squeezing the rest of the line.
- In the branch update panel, restore and dropRow set the edits from the render's captured value, so two quick unticks could lose one under batched updates. They compose functional updates now, each with the state as it stands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)