### PR TITLE
Put the sidebar's grab area past its scrollbar

### DIFF
--- a/apps/lite/ui/src/components/ResizeHandle.module.css
+++ b/apps/lite/ui/src/components/ResizeHandle.module.css
@@ -15,3 +15,29 @@
 		background-color: var(--border-1);
 	}
 }
+
+/* The grab area after the hairline only: a 10px box laid over the next
+   panel's edge, since what lies before the hairline is the previous panel's
+   scrollbar, which takes a press before the page sees it. Pair with a group
+   whose resizeTargetMinimumSize is 1, or the library widens the area both ways. */
+.resizeHandle.grabAfter[aria-orientation="vertical"] {
+	z-index: 2;
+	position: relative;
+	width: 10px;
+	margin-inline-end: -9px;
+	background-color: transparent;
+
+	&::before {
+		position: absolute;
+		width: 1px;
+		inset-block: 0;
+		inset-inline-start: 0;
+		background-color: var(--border-section);
+		content: "";
+	}
+
+	&[data-separator="hover"]::before,
+	&[data-separator="active"]::before {
+		background-color: var(--border-1);
+	}
+}

--- a/apps/lite/ui/src/components/ResizeHandle.tsx
+++ b/apps/lite/ui/src/components/ResizeHandle.tsx
@@ -6,8 +6,12 @@ import styles from "./ResizeHandle.module.css";
 /**
  * The hairline divider between resizable panels. It picks its own axis from
  * the separator's `aria-orientation`, so the same handle works in both
- * horizontal and vertical `Group`s.
+ * horizontal and vertical `Group`s. `grab="after"` puts the whole grab area
+ * past the hairline, for a previous panel whose scrollbar meets it.
  */
-export const ResizeHandle: FC<SeparatorProps> = (p) => (
-	<Separator {...p} className={classes(styles.resizeHandle, p.className)} />
+export const ResizeHandle: FC<SeparatorProps & { grab?: "after" }> = ({ grab, ...p }) => (
+	<Separator
+		{...p}
+		className={classes(styles.resizeHandle, grab === "after" && styles.grabAfter, p.className)}
+	/>
 );

--- a/apps/lite/ui/src/routes/project/$id/workspace/Page.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Page.tsx
@@ -594,6 +594,8 @@ const PageBody: FC<{ projectId: string }> = ({ projectId }) => {
 				{...selectionFocus}
 				id={layoutId}
 				className={styles.page}
+				// The handle's own box is the grab area; see ResizeHandle's grab="after".
+				resizeTargetMinimumSize={{ coarse: 1, fine: 1 }}
 				defaultLayout={workspaceLayout.defaultLayout}
 				onLayoutChanged={workspaceLayout.onLayoutChanged}
 				data-selection-focus-styles={
@@ -625,7 +627,7 @@ const PageBody: FC<{ projectId: string }> = ({ projectId }) => {
 							/>
 						</ErrorBoundary>
 					</Panel>
-					<ResizeHandle />
+					<ResizeHandle grab="after" />
 				</Activity>
 
 				<Panel


### PR DESCRIPTION
With a scrollable sidebar, the resize cursor showed over the right half of its scrollbar, but a press there dragged the scroll thumb instead. The taller the thumb, the more of the boundary behaved that way.

## Cause

react-resizable-panels finds a handle geometrically, on the document: it widens the 1px handle's box to 10px both ways and adds a second region at the neighbouring panel's edge, widened the same. The sidebar's half of that lies on its scrollbar, and a press on a scrollbar never reaches the page.

## What changed

- `ResizeHandle` takes `grab="after"`: the handle's own box is 10px wide, laid over the next panel's edge with a negative margin so nothing moves, transparent, with the hairline drawn at its start.
- The page group sets `resizeTargetMinimumSize` to 1, so that box alone is the grab area. The handles inside the details pane keep the default.

## Verification

- Real input events over CDP: a press 3px or 6px left of the hairline scrolls with a plain cursor; a press 3px or 8px right of it resizes.
- Lite typecheck, oxlint, prettier, and unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)