### PR TITLE
Refetch the PR merge status when checks reach a verdict

### DIFF
--- a/apps/lite/ui/src/api/queries.test.ts
+++ b/apps/lite/ui/src/api/queries.test.ts
@@ -1,0 +1,41 @@
+import { listCIChecksQueryOptions } from "#ui/api/queries.ts";
+import type { CiCheck } from "@gitbutler/but-sdk";
+import { QueryClient } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+
+const check = (status: CiCheck["status"]): CiCheck =>
+	({ name: "ci", status }) as unknown as CiCheck;
+const running = check("inProgress");
+const passed = check({ complete: { conclusion: "success", completed_at: null } });
+
+/** Runs the checks query once per response, on the same client, and lists what it invalidated. */
+const pollChecks = async (responses: Array<Array<CiCheck>>) => {
+	const client = new QueryClient();
+	const invalidated = vi.spyOn(client, "invalidateQueries").mockResolvedValue();
+	const listCiChecks = vi.fn();
+	vi.stubGlobal("window", { lite: { listCiChecks } });
+	const options = listCIChecksQueryOptions({
+		projectId: "p1",
+		reference: "feature",
+		polling: "priority",
+	});
+	for (const response of responses) {
+		listCiChecks.mockResolvedValueOnce(response);
+		await client.fetchQuery({ ...options, staleTime: 0 });
+	}
+	return invalidated.mock.calls.map(([filters]) => filters?.queryKey);
+};
+
+describe("listCIChecksQueryOptions", () => {
+	it("refetches the merge status once the checks reach a verdict", async () => {
+		expect(await pollChecks([[running], [running], [passed]])).toEqual([
+			["p1", "getReviewMergeStatus"],
+		]);
+	});
+
+	it("leaves the merge status alone while checks are still running or already settled", async () => {
+		expect(await pollChecks([[running], [running]])).toEqual([]);
+		expect(await pollChecks([[passed], [passed]])).toEqual([]);
+		expect(await pollChecks([[passed], [running]])).toEqual([]);
+	});
+});

--- a/apps/lite/ui/src/api/queries.ts
+++ b/apps/lite/ui/src/api/queries.ts
@@ -1,7 +1,7 @@
 import type { PayloadFor } from "#electron/ipc.ts";
-import { aggregateCIChecks } from "#ui/ci.ts";
+import { type AggregateCIChecks, aggregateCIChecks } from "#ui/ci.ts";
 import { clampAutoFetch, defaultSettings } from "#ui/settings.ts";
-import type { ForgeReview, TreeChange, UnifiedPatch } from "@gitbutler/but-sdk";
+import type { CiCheck, ForgeReview, TreeChange, UnifiedPatch } from "@gitbutler/but-sdk";
 import {
 	experimental_streamedQuery,
 	hashKey,
@@ -463,6 +463,8 @@ export const listEditorsQueryOptions = queryOptions({
 	queryFn: () => window.lite.listEditors(),
 });
 
+type CIChecksQueryData = { data: Array<CiCheck>; aggregate: AggregateCIChecks | null };
+
 /** This query should be gated by checks capability. */
 // There is no watcher event that could invalidate this query.
 export const listCIChecksQueryOptions = ({
@@ -474,10 +476,11 @@ export const listCIChecksQueryOptions = ({
 }) =>
 	queryOptions({
 		queryKey: [projectId, "listCiChecks", reference],
-		queryFn: async () => {
+		queryFn: async ({ client, queryKey }): Promise<CIChecksQueryData> => {
 			// Aggregated data is needed in queryFn to adjust refetching behaviour. Aggregating here, for
 			// use as mentioned and also at call sites, is more efficient.
-			//
+			const previousStatus = client.getQueryData<CIChecksQueryData>(queryKey)?.aggregate?.status;
+			let checks: CIChecksQueryData;
 			// listCiChecks will reject with a message citing HTTP 422 once the branch is merged.
 			try {
 				const data = await window.lite.listCiChecks({
@@ -485,10 +488,16 @@ export const listCIChecksQueryOptions = ({
 					reference,
 					cacheConfig: "noCache",
 				});
-				return { data, aggregate: aggregateCIChecks(data) };
+				checks = { data, aggregate: aggregateCIChecks(data) };
 			} catch {
-				return { data: [], aggregate: null };
+				checks = { data: [], aggregate: null };
 			}
+			// The verdict is what flips the forge's mergeability, and this poll
+			// notices it long before the merge-status poll would; refetch now so
+			// the Merge button doesn't stay disabled for up to a minute.
+			if (previousStatus === "in_progress" && checks.aggregate?.status !== "in_progress")
+				void client.invalidateQueries({ queryKey: [projectId, "getReviewMergeStatus"] });
+			return checks;
 		},
 		// Refetch periodically, being mindful of rate limiting. Similarly tweak stale time for
 		// prioritised queries so that fresh data is likely fetched when the user would see/expect it


### PR DESCRIPTION
The Merge button on the pull request tab often stayed disabled after checks had finished.

- The button reads the merge-status query, polled every 60s
- The checks query polls every 5s while a run is in progress, so the panel showed green checks up to a minute before the button caught up
- The checks query now invalidates the merge-status query when its aggregate leaves `in_progress`, so the button reflects the verdict on the next poll
- Invalidating an inactive query only marks it stale, so the branch row's passive checks poll adds no forge traffic while the PR tab is closed

Unit test covers the transitions: running → passed invalidates, running → running, passed → passed and passed → running do not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)