### PR TITLE
Lite: show active branch filters and list all branches by default

### DIFF
--- a/apps/lite/ui/src/branch.test.ts
+++ b/apps/lite/ui/src/branch.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+	activeBranchFilterCount,
 	branchDetailsParams,
 	branchIsEmpty,
 	branchOwnCommits,
@@ -37,6 +38,14 @@ const names = (stacks: Array<ListedStack>): Array<Array<string>> =>
 	stacks.map((s) => s.branches.map((b) => b.displayName));
 
 const allFilters = { showEmpty: false, onlyLocal: false, onlyStacks: false };
+
+describe("activeBranchFilterCount", () => {
+	it("counts the options switched on", () => {
+		expect(activeBranchFilterCount(allFilters)).toBe(0);
+		expect(activeBranchFilterCount({ ...allFilters, onlyLocal: true })).toBe(1);
+		expect(activeBranchFilterCount({ showEmpty: true, onlyLocal: true, onlyStacks: true })).toBe(3);
+	});
+});
 
 describe("branchIsEmpty", () => {
 	it("is empty only at exactly zero commits", () => {

--- a/apps/lite/ui/src/branch.ts
+++ b/apps/lite/ui/src/branch.ts
@@ -39,6 +39,13 @@ export type BranchFilters = {
 };
 
 /**
+ * How many filter options are switched on. Every option is off at rest, so
+ * this is what the header's badge shows and what "any filter active" means.
+ */
+export const activeBranchFilterCount = (filters: BranchFilters): number =>
+	Object.values(filters).filter(Boolean).length;
+
+/**
  * The stacks from the branch listing that are not applied to the workspace,
  * keeping the listing's most-recent-first order. `showEmpty`/`onlyLocal` prune
  * branches within each stack; `onlyStacks` then keeps just the multi-branch

--- a/apps/lite/ui/src/projects/branches.test.ts
+++ b/apps/lite/ui/src/projects/branches.test.ts
@@ -1,0 +1,50 @@
+/** @vitest-environment jsdom */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+	createInitialBranchesState,
+	readStoredBranchFilters,
+	writeStoredBranchFilters,
+} from "./branches.ts";
+
+describe("branch filters", () => {
+	beforeEach(() => window.localStorage.clear());
+
+	it("start with nothing switched on", () => {
+		expect(createInitialBranchesState().filters).toEqual({
+			showEmpty: false,
+			onlyLocal: false,
+			onlyStacks: false,
+		});
+	});
+
+	it("are stored per project", () => {
+		writeStoredBranchFilters("one", { showEmpty: true, onlyLocal: false, onlyStacks: false });
+		writeStoredBranchFilters("two", { showEmpty: false, onlyLocal: true, onlyStacks: true });
+
+		expect(readStoredBranchFilters()).toEqual({
+			one: { showEmpty: true, onlyLocal: false, onlyStacks: false },
+			two: { showEmpty: false, onlyLocal: true, onlyStacks: true },
+		});
+	});
+
+	it("ignore entries that are not filters, keeping the rest", () => {
+		writeStoredBranchFilters("good", { showEmpty: false, onlyLocal: true, onlyStacks: false });
+		window.localStorage.setItem("branch_filters:v1:junk", "{not json");
+		window.localStorage.setItem("branch_filters:v1:partial", JSON.stringify({ onlyLocal: true }));
+		window.localStorage.setItem(
+			"branch_filters:v1:typed",
+			JSON.stringify({ showEmpty: "yes", onlyLocal: true, onlyStacks: false }),
+		);
+		window.localStorage.setItem("pr_activity_seen:v1:good", "{}");
+
+		expect(readStoredBranchFilters()).toEqual({
+			good: { showEmpty: false, onlyLocal: true, onlyStacks: false },
+		});
+	});
+
+	it("seed a project's initial state", () => {
+		const filters = { showEmpty: true, onlyLocal: true, onlyStacks: false };
+		expect(createInitialBranchesState(filters)).toEqual({ filters, search: null, unfolded: {} });
+	});
+});

--- a/apps/lite/ui/src/projects/branches.ts
+++ b/apps/lite/ui/src/projects/branches.ts
@@ -18,11 +18,70 @@ export type BranchesState = {
 	unfolded: Record<string, true>;
 };
 
+/**
+ * Nothing narrows the list until the user opts in: hiding remote-only
+ * branches by default helped only the few repositories with hundreds of them,
+ * and made everyone else's remote branches look missing.
+ */
+const defaultFilters = (): BranchFilters => ({
+	showEmpty: false,
+	onlyLocal: false,
+	onlyStacks: false,
+});
+
 const initialState = (): BranchesState => ({
-	filters: { showEmpty: false, onlyLocal: true, onlyStacks: false },
+	filters: defaultFilters(),
 	search: null,
 	unfolded: {},
 });
+
+const filtersStorageKeyPrefix = "branch_filters:v1:";
+
+const isBranchFilters = (value: unknown): value is BranchFilters =>
+	typeof value === "object" &&
+	value !== null &&
+	(["showEmpty", "onlyLocal", "onlyStacks"] as const).every(
+		(key) => typeof (value as Record<string, unknown>)[key] === "boolean",
+	);
+
+/**
+ * The filters each project was last left with, by project id, so a reload
+ * keeps the list narrowed the way the user set it. Storage can throw or hold
+ * junk; either reads as a project at its defaults.
+ */
+export const readStoredBranchFilters = (): Record<string, BranchFilters> => {
+	const filtersByProject: Record<string, BranchFilters> = {};
+	try {
+		for (let index = 0; index < window.localStorage.length; index++) {
+			const key = window.localStorage.key(index);
+			if (key === null || !key.startsWith(filtersStorageKeyPrefix)) continue;
+			try {
+				const stored: unknown = JSON.parse(window.localStorage.getItem(key) ?? "null");
+				if (isBranchFilters(stored)) {
+					const { showEmpty, onlyLocal, onlyStacks } = stored;
+					filtersByProject[key.slice(filtersStorageKeyPrefix.length)] = {
+						showEmpty,
+						onlyLocal,
+						onlyStacks,
+					};
+				}
+			} catch {
+				// One unparseable entry should not cost the other projects theirs.
+			}
+		}
+	} catch {
+		// Storage disabled or partitioned: every project starts at its defaults.
+	}
+	return filtersByProject;
+};
+
+export const writeStoredBranchFilters = (projectId: string, filters: BranchFilters): void => {
+	try {
+		window.localStorage.setItem(filtersStorageKeyPrefix + projectId, JSON.stringify(filters));
+	} catch {
+		// The in-memory copy still serves this session.
+	}
+};
 
 const branchesSlice = createSlice({
 	name: "branches",
@@ -65,7 +124,9 @@ const branchesSlice = createSlice({
 	},
 });
 
-export const createInitialBranchesState = (): BranchesState => branchesSlice.getInitialState();
+export const createInitialBranchesState = (
+	filters: BranchFilters = defaultFilters(),
+): BranchesState => ({ ...branchesSlice.getInitialState(), filters });
 
 export const branchesReducers = {
 	toggleUnfolded: (state: BranchesState, payload: { branchRef: string }) => {

--- a/apps/lite/ui/src/projects/state.ts
+++ b/apps/lite/ui/src/projects/state.ts
@@ -1,3 +1,4 @@
+import { createInitialBranchesState, readStoredBranchFilters } from "#ui/projects/branches.ts";
 import {
 	createInitialProjectState,
 	projectReducers,
@@ -10,8 +11,16 @@ type ProjectSliceState = {
 	byProjectId: Record<string, ProjectState>;
 };
 
+// Branch filters are the one piece of project state that outlives the session,
+// so projects with stored filters start out holding them; every other project
+// materializes at the defaults on its first action.
 const initialState: ProjectSliceState = {
-	byProjectId: {},
+	byProjectId: Object.fromEntries(
+		Object.entries(readStoredBranchFilters()).map(([projectId, filters]) => [
+			projectId,
+			{ ...createInitialProjectState(), branches: createInitialBranchesState(filters) },
+		]),
+	),
 };
 
 const ensureProjectState = (state: ProjectSliceState, projectId: string): ProjectState => {

--- a/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.module.css
@@ -20,6 +20,13 @@
 	align-items: center;
 }
 
+/* With the badge beside the icon the button is no longer icon-only, so it
+   takes the regular button's padding; this pulls it back in to the icon-only
+   rhythm the search button beside it keeps. */
+.filterButtonActive {
+	--button-padding-inline: 6px;
+}
+
 .headerSeparator {
 	align-self: center;
 	width: 1px;

--- a/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/BranchesList.tsx
@@ -3,8 +3,9 @@ import uiStyles from "#ui/components/ui.module.css";
 import { useBranchRemove } from "#ui/api/mutations.ts";
 import { decodeBytes, encodeBytes } from "#ui/api/bytes.ts";
 import { assert } from "#ui/assert.ts";
-import { branchIsEmpty, type BranchFilters } from "#ui/branch.ts";
+import { activeBranchFilterCount, branchIsEmpty, type BranchFilters } from "#ui/branch.ts";
 import { commitIsDiverged, commitTitle } from "#ui/commit.ts";
+import { Badge } from "#ui/components/Badge.tsx";
 import { classes } from "#ui/components/classes.ts";
 import { EmptyState } from "#ui/components/EmptyState.tsx";
 import {
@@ -493,11 +494,11 @@ export const BranchesList: FC<
 		(state) => projectSlice.selectors.selectPendingOperation(state, projectId)._tag === "None",
 	);
 
-	// `onlyStacks` is the one filter that hides branches the resting list would
-	// show — the other two default to narrowing and only ever widen from there —
-	// so it, and a search, are what make an empty list a no-match rather than a
-	// state at rest.
-	const isNarrowed = (search ?? "").trim() !== "" || filters.onlyStacks;
+	// `onlyLocal` and `onlyStacks` hide branches the resting list would show —
+	// `showEmpty` only ever widens it — so they, and a search, are what make an
+	// empty list a no-match rather than a state at rest.
+	const isNarrowed = (search ?? "").trim() !== "" || filters.onlyLocal || filters.onlyStacks;
+	const activeFilterCount = activeBranchFilterCount(filters);
 	const isEmptyAtRest = stacks.length === 0 && !isPending && !isError && !isNarrowed;
 
 	const selection = useSelection("unapplied", addressSpace);
@@ -680,12 +681,26 @@ export const BranchesList: FC<
 					actions={
 						<Toolbar.Root aria-label="Branch list actions" render={<RowToolbar forceVisible />}>
 							<Toolbar.Group className={styles.headerGroup}>
+								{/* The menu is native, so the button is the only place the list
+								    can say it is being narrowed: a count of the options switched
+								    on, and nothing at all while none are. */}
 								<Toolbar.Button
-									aria-label="Branch filters"
-									className={getRowButtonClassName({ size: "regular", iconOnly: true })}
+									aria-label={
+										activeFilterCount === 0
+											? "Branch filters"
+											: `Branch filters, ${activeFilterCount} active`
+									}
+									className={classes(
+										getRowButtonClassName({
+											size: "regular",
+											iconOnly: activeFilterCount === 0,
+										}),
+										activeFilterCount > 0 && styles.filterButtonActive,
+									)}
 									onClick={(evt) => showFilterMenu(evt.currentTarget)}
 								>
 									<Icon name="filter" />
+									{activeFilterCount > 0 && <Badge variant="lightGray">{activeFilterCount}</Badge>}
 								</Toolbar.Button>
 
 								<Toolbar.Button

--- a/apps/lite/ui/src/store.ts
+++ b/apps/lite/ui/src/store.ts
@@ -1,13 +1,29 @@
-import { configureStore } from "@reduxjs/toolkit";
+import { configureStore, createListenerMiddleware } from "@reduxjs/toolkit";
 import { useDispatch, useSelector, useStore } from "react-redux";
 import { interfaceSlice } from "#ui/interface/state.ts";
+import { writeStoredBranchFilters } from "#ui/projects/branches.ts";
 import { projectSlice } from "#ui/projects/state.ts";
+
+// Branch filters survive a reload (the slice seeds itself from what is stored),
+// so each toggle writes the project's filters back as soon as it lands.
+const persistBranchFilters = createListenerMiddleware();
+persistBranchFilters.startListening({
+	actionCreator: projectSlice.actions.toggleBranchFilter,
+	effect: ({ payload: { projectId } }, api) => {
+		writeStoredBranchFilters(
+			projectId,
+			projectSlice.selectors.selectBranchFilters(api.getState() as RootState, projectId),
+		);
+	},
+});
 
 export const store = configureStore({
 	reducer: {
 		interface: interfaceSlice.reducer,
 		project: projectSlice.reducer,
 	},
+	middleware: (getDefaultMiddleware) =>
+		getDefaultMiddleware().prepend(persistBranchFilters.middleware),
 });
 
 /* Without this a hot update rebuilds the store under still-mounted components,


### PR DESCRIPTION
Addresses [GB-2025](https://linear.app/gitbutler/issue/GB-2025/branches-page-indicate-active-filters-and-default-to-showing-all).

The branches page hid remote-only branches by default, and the filter button looked the same whether or not anything was filtering, so remote branches simply looked missing.

- Every filter option now starts off, so the list shows all branches until the user opts into a filter.
- When any option is on, the filter button shows a light gray count badge beside the icon, per the [Figma design](https://www.figma.com/design/EBuHQGUcCaSw4Ln5uVpWkn/Lite?node-id=4114-167907). The button's accessible name reports the count too.
- Filters are persisted per project in localStorage. A toggle writes them back through a listener middleware, and the project slice seeds itself from stored values on startup, so there is no flash of the unfiltered list after a reload.
- Local-only now counts as a narrowing filter, so an empty list under it says "No matching branches" instead of the resting empty state.
- The empty workspace's "You have N branches to pick from" count already followed these filters, so with the local-only default gone it now counts every branch.

Verified with unit tests for the count helper and the stored-filter read/write (including junk and partial entries), the full Lite UI suite, the branches e2e spec, and by driving the running app over CDP with stored filters.

## Screenshots


https://github.com/user-attachments/assets/74e4821e-7577-45e3-88cd-c03df048dcd9



## Notes

There probably need more human testing. But at the moment I think the issues is closed.