### PR TITLE
Update agent skills for CLI changes since 0.22.3

### DIFF
--- a/crates/but/skill/SKILL.md
+++ b/crates/but/skill/SKILL.md
@@ -40,11 +40,11 @@ but commit -b <branch> -m "<msg>" <id> <id>
 
 ## IDs
 
-The first token on each `but diff` / `but status` line is that line's ID. When a command needs an ID, copy it exactly from the current output; never hardcode or invent one. IDs may be a single character when unambiguous, and their lifetimes differ by entity:
+The first token on each `but diff` / `but status` line is that line's ID. When a command needs an ID, copy it exactly from the current output; never hardcode or invent one. ID lifetimes differ by entity:
 
-- Changes and sources are **positional, space-separated** IDs (`but commit -b feat -m "msg" qs:5 uo`). An uncommitted hunk ID is written `<file-id>:<hunk-id>` (e.g. `qs:5`, copied from bare `but diff`) — the part after the colon is the hunk's ID, **not** a line range (`qs:16-40` is invalid). Do not invent flags like `--changes` / `--hunk` / `--ids`, pass a line range, or comma-separate IDs — `nk,pn` is parsed as one ID and fails.
+- Changes and sources are **positional, space-separated** IDs (`but commit -b feat -m "msg" uvw:2e4 uvw:e2c`). An uncommitted hunk ID is written `<file-id>:<hunk-id>` (e.g. `uvw:2e4`, copied from bare `but diff`) — the part after the colon is the hunk's ID, **not** a line range (`uvw:16-40` is invalid). Do not invent flags like `--changes` / `--hunk` / `--ids`, pass a line range, or comma-separate IDs — `uvw,qyo` is parsed as one ID and fails.
 - `but diff` is the exception: it accepts at most **one** target. Bare `but diff` shows all uncommitted files; inspect committed files or other entities one target at a time — never `but diff <id> <id>`.
-- A committed file is `<commit-id>:<file-id>` (e.g. `uyr:n`, shown under each commit). A committed hunk is `<commit-id>:<file-id>:<hunk-id>` and is shown by `but diff <commit-id>`. `@` means the uncommitted area.
+- A committed file is `<commit-id>:<file-id>` (e.g. `mzm:uvw`, shown under each commit). A committed hunk is `<commit-id>:<file-id>:<hunk-id>` and is shown by `but diff <commit-id>`. `@` means the uncommitted area.
 - Commit IDs are stable change IDs that survive history edits (`amend`, `squash`, `move`, `uncommit`, `reword`). Commits without a change ID (e.g. upstream-only) lead with a sha prefix instead, and `#N`-suffixed refs disambiguate duplicates — both go stale after history edits, and a stale sha can silently resolve to the wrong commit. The `(sha …)` on verbose commit lines is informational — do not pass it to commands.
 - Branch short IDs are snapshot-local selectors. Use full branch names for branch-targeting mutations; short IDs are safe only for immediate read-only inspection.
 - File/hunk IDs copied from one diff read generally remain usable across chained commits. If one stops resolving, re-read `but diff` and retry.

--- a/crates/but/skill/references/concepts.md
+++ b/crates/but/skill/references/concepts.md
@@ -78,12 +78,11 @@ active worktree gets its own ID and is drawn in `but status` as a lane — a bra
 `{<branch>}` heading (the worktree name when its `HEAD` is detached) nested above the commit the
 worktree rests on — another worktree's commit included, lanes nest recursively — or standing on
 its own below the stacks when it rests outside the workspace.
-The lane lists that worktree's uncommitted files and the commits the worktree owns; in `--json`
-they appear in a top-level `worktrees` array. The worktree ID on the heading names its whole
-uncommitted area the way `@` names the main worktree's, and `<worktree-name>:<path>` scopes a
-filename to that worktree — `@:<path>` keeps meaning the main worktree. A filename dirty in
-several worktrees at once is ambiguous; the error suggests the scoped forms. A worktree file or
-heading ID — like `@` for the main worktree — works as a `but commit` change and a `but amend`
+The lane lists that worktree's uncommitted files and commits. The heading ID names the worktree;
+`<worktree>:@` (ID or name) names its uncommitted area. `<worktree>:<path>` scopes a
+filename to it — `@:<path>` keeps meaning the main worktree. A filename dirty in several
+worktrees at once is ambiguous; the error suggests the scoped forms. A worktree file ID or
+`<worktree>:@` works as a `but commit` change and a `but amend`
 source: the change lands on the target and leaves that worktree's uncommitted area. Without a
 target flag, worktree changes commit to the tip of the worktree's own branch; an explicit target
 commit or branch does not have to be the worktree's own. One operation reads from one worktree

--- a/crates/but/skill/references/concepts.md
+++ b/crates/but/skill/references/concepts.md
@@ -44,18 +44,18 @@ workspace (gitbutler/workspace)
 Every object gets a short, human-readable CLI ID shown in `but status` or `but diff`. IDs are generated per-session and are unique across all entity types (no two objects share an ID) — always read them from current command output.
 
 ```
-Commits:          1, kyn, mpq#0  (short change-ID prefix when the commit has one, sha prefix otherwise;
+Commits:          1, ton, mpq#0       (short change-ID prefix when the commit has one, sha prefix otherwise;
                                    a #N suffix disambiguates commits sharing a change ID)
-Branches:         fe, bu, ui     (unique 2–3 char substring of the branch name, e.g. "fe" from "feature-x";
+Branches:         fe, bu, ui          (unique 2–3 char substring of the branch name, e.g. "fe" from "feature-x";
                                    falls back to auto-generated ID if no unique substring exists)
-Files:            g, qs, uo      (derived from the file path, long enough to be unique)
-Hunks:            g:5, uo:d      (<file-id>:<hunk-id>; uncommitted hunks shown by bare `but diff`)
-Committed files:  kyn:n          (<commit-id>:<file-id>, shown under each commit in `but status -fv`)
-Committed hunks:  kyn:n:5        (<commit-id>:<file-id>:<hunk-id>, shown by `but diff <commit-id>`)
-Stacks:           m0, n0         (auto-generated, 2–3 chars)
+Files:            uvw, qyo            (derived from the file path, long enough to be unique)
+Hunks:            uvw:2e4, uvw:e2c    (<file-id>:<hunk-id>; uncommitted hunks shown by bare `but diff`)
+Committed files:  mzm:uvw             (<commit-id>:<file-id>, shown under each commit in `but status -fv`)
+Committed hunks:  mzm:uvw:2e4         (<commit-id>:<file-id>:<hunk-id>, shown by `but diff <commit-id>`)
+Stacks:           m0, n0              (auto-generated, 2–3 chars)
 ```
 
-**Why?** Git commit SHAs are long (40 chars). CLI IDs are short, variable-length, and unique within your current workspace context. Commits, files, and hunks may use a single character when that is unambiguous.
+**ID lengths:** When an agent is detected, shortened change-ID, file, and hunk prefixes have a three-character minimum; SHA prefixes and branch/worktree IDs can be shorter.
 
 **Reading status output:** the first token on each line is that line's ID. Verbose commit lines append an informational `(sha …)` after the timestamp — it changes on every amend; do not pass it to commands.
 

--- a/crates/but/skill/references/examples.md
+++ b/crates/but/skill/references/examples.md
@@ -2,7 +2,7 @@
 
 Real-world examples of common workflows.
 
-**Note on CLI IDs:** Examples below use full branch names for branch-targeting mutations. Illustrative IDs like `nn` and `a1` keep other commands readable; in practice, **always read actual IDs from `but status -fv`** because they are generated for the current workspace snapshot. Commit IDs are short change-ID prefixes that stay stable across history edits (e.g., `kyn`; commits without a change ID fall back to a sha prefix), and file/hunk/stack IDs are auto-generated (e.g., `r`, `r:c`, `h0`). All IDs are unique across entity types within one snapshot.
+**Note on CLI IDs:** Examples use illustrative IDs such as `nn` and `a1`; copy actual IDs from current `but status` or `but diff` output. Real output may use longer IDs (e.g., `mzm:uvw:2e4`). Use full branch names for mutations. Commit change-ID prefixes survive history edits; SHA prefixes can go stale.
 
 ## Example 1: Starting Independent Parallel Work
 

--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -352,6 +352,7 @@ but discard <hunk-id>              # Discard a single hunk
 but discard @                      # Discard all uncommitted changes
 but discard <commit-id>            # Drop a commit
 but discard <commit-id>:<file-id>  # Drop one file's changes from its commit
+but discard <commit-id>:<file-id>:<hunk-id> # Drop one hunk from its commit
 but discard <branch>               # Drop a branch and its commits
 ```
 

--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -61,7 +61,7 @@ but diff <commit-id>    # Diff for specific commit
 inspect committed files or other entities one target at a time. Unlike `commit`,
 `amend`, and `discard`, it does not accept several positional IDs.
 
-**Hunk IDs:** For uncommitted changes, bare `but diff` shows each hunk with an ID (e.g., `qs:5`, `uo:d`). Pass these IDs to `but commit` for fine-grained, hunk-level commits.
+**Hunk IDs:** For uncommitted changes, bare `but diff` shows each hunk with an ID (e.g., `uvw:2e4`, `uvw:e2c`). Pass these IDs to `but commit` for fine-grained, hunk-level commits.
 
 `but diff <commit-id>` also shows committed hunk IDs in the form `<commit-id>:<file-id>:<hunk-id>`. A committed file ID uses the shorter `<commit-id>:<file-id>` form. When passing several committed changes to an operation, select them from the same commit.
 

--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -324,8 +324,11 @@ Reword commit message or rename branch.
 ```bash
 but reword <id> -m "new"          # Always pass -m; without it an editor opens and blocks
 but reword <branch> -m "new-name" # Rename a branch (applied branches only)
+but reword <anonymous-id> -m "new-name" # Name an anonymous branch
 but reword <id> --fix-formatting  # Format to 72-char wrapping
 ```
+
+Retry other operations using the new name; the short ID may change.
 
 ### `but discard <CHANGES>...`
 

--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -7,7 +7,7 @@ Agent-focused reference for useful `but` commands.
 - [Inspection](#inspection-understanding-state) - `status`, `show`, `diff`, `open`
 - [Branching](#branching) - `branch new`, `apply`, `unapply`, `branch delete`, `pick`
 - [Committing](#committing) - `commit`
-- [Editing History](#editing-history) - `squash`, `amend`, `move`, `uncommit`, `reword`, `discard`
+- [Editing History](#editing-history) - `squash`, `amend`, `move`, `split`, `uncommit`, `reword`, `discard`
 - [Conflict Resolution](#conflict-resolution) - `resolve`
 - [Remote Operations](#remote-operations) - `push`, `pull`, `pr`, `merge`
 - [Workspace Maintenance](#workspace-maintenance) - `clean`, `worktree`
@@ -298,6 +298,18 @@ branch may be moved at a time. Source order does not matter. For a branch source
 with no value is equivalent to `--unstack`. With the experimental worktree flag on, `-b` also
 accepts a worktree or the branch checked out in it, moving commit or committed-change
 sources onto that branch's tip (nothing is created); a branch source is refused there.
+
+### `but split <SOURCES>...`
+
+Move selected committed files/hunks into a new commit immediately above their source.
+Files and hunks may be mixed, but must come from one commit. The new commit has no message;
+unselected changes stay in the source.
+
+```bash
+but diff <commit-id>                              # Read committed file/hunk IDs
+but split <commit-id>:<file-id>                    # Split a file
+but split <commit-id>:<file-id>:<hunk-id>           # Split a hunk
+```
 
 ### `but uncommit <SOURCES>...`
 


### PR DESCRIPTION
Correct worktree change selectors and ID-length guidance, and document anonymous-branch recovery, direct commit splitting, and committed-hunk discard. Keep the changes focused on existing skill sections.