### PR TITLE
Ask about usage metrics on the Lite welcome page

### DIFF
--- a/apps/lite/e2e/tests/onboarding.spec.ts
+++ b/apps/lite/e2e/tests/onboarding.spec.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import type { LiteElectronApi } from "../../electron/src/ipc.ts";
 import { LiteTestId } from "../../ui/src/testIds.ts";
 import { expect, test } from "../test.ts";
 import { assertHeadBranch } from "../utils.ts";
@@ -19,9 +20,19 @@ test("adds a local repository without changing its branch", async ({
 	}, repositoryPath);
 
 	await expect(appWindow.getByTestId(LiteTestId.OnboardingPage)).toBeVisible();
+	// The consent sits on the welcome page, and adding a repository confirms it.
+	await expect(appWindow.getByRole("switch", { name: "Usage metrics" })).toBeVisible();
 	await appWindow.getByRole("button", { name: "Add local repository" }).click();
 
 	await expect(appWindow.getByTestId(/project=.*:workspace/)).toBeVisible();
+	await expect
+		.poll(async () => {
+			const settings = await appWindow.evaluate(() =>
+				(window as unknown as { lite: LiteElectronApi }).lite.getAppSettings(),
+			);
+			return settings.onboardingComplete;
+		})
+		.toBe(true);
 	const projectPicker = appWindow.getByRole("combobox", { name: /Select project/ });
 	await expect(projectPicker).toBeVisible();
 

--- a/apps/lite/electron/src/ipc.ts
+++ b/apps/lite/electron/src/ipc.ts
@@ -1,6 +1,8 @@
 import type {
 	AiConfiguration,
 	AiConfigurationUpdate,
+	AppSettings,
+	TelemetryUpdate,
 	WatcherEvent,
 	AskpassPromptEvent,
 } from "@gitbutler/but-sdk";
@@ -28,6 +30,8 @@ export type LiteElectronApi = SDK & {
 	/** A `but://app/...` link the app was asked to open, as an in-app path. */
 	onDeepLink: (callback: (path: string) => void) => () => void;
 	getAiConfiguration: () => Promise<AiConfiguration>;
+	/** The settings shared with the other surfaces through the settings file. */
+	getAppSettings: () => Promise<AppSettings>;
 	getVersion: () => Promise<string>;
 	isFullScreen: () => Promise<boolean>;
 	onFullScreenChange: (callback: (fullScreen: boolean) => void) => () => void;
@@ -51,6 +55,9 @@ export type LiteElectronApi = SDK & {
 		onToken: (token: string) => void,
 	) => Promise<string>;
 	updateAiConfiguration: (update: AiConfigurationUpdate) => Promise<AiConfiguration>;
+	updateOnboardingComplete: (complete: boolean) => Promise<void>;
+	/** Persists the choice and starts or stops metrics to match, so it holds without a relaunch. */
+	updateTelemetry: (update: TelemetryUpdate) => Promise<void>;
 	watcherSubscribe: (projectId: string, callback: (event: WatcherEvent) => void) => Promise<string>;
 	watcherUnsubscribe: (subscriptionId: string) => Promise<boolean>;
 	watcherStopAll: () => Promise<number>;
@@ -74,6 +81,7 @@ export const localEndpoints = [
 	"clipboardWriteText",
 	"deepLink",
 	"fullScreenChange",
+	"getAppSettings",
 	"getVersion",
 	"isFullScreen",
 	"notificationClick",
@@ -85,6 +93,8 @@ export const localEndpoints = [
 	"showNativeMenu",
 	"showNotification",
 	"streamAiResponse",
+	"updateOnboardingComplete",
+	"updateTelemetry",
 	"watcherStopAll",
 	"watcherSubscribe",
 	"watcherUnsubscribe",

--- a/apps/lite/electron/src/main.ts
+++ b/apps/lite/electron/src/main.ts
@@ -46,7 +46,13 @@ import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { initLogging } from "./logging.js";
 import { type GUISettings, readSettings, writeSettings } from "./settings.js";
-import { initMetrics, metricsOnLogin, shutdownMetrics, withApiCommandCapture } from "./metrics.js";
+import {
+	initMetrics,
+	metricsOnLogin,
+	shutdownMetrics,
+	syncMetrics,
+	withApiCommandCapture,
+} from "./metrics.js";
 import { apiParamNames } from "@gitbutler/but-sdk/api-param-names";
 
 const isHeadless = process.env.GITBUTLER_LITE_HEADLESS === "true";
@@ -300,6 +306,7 @@ const newUrlOrNull = (url: string): URL | null => {
 const electronHandlerOverrides = {
 	askpassSubmitPromptResponse: ({ id, response }) => askpassSubmitPromptResponse(id, response),
 	clipboardWriteText: (text) => clipboard.writeText(text),
+	getAppSettings: () => sdk.getAppSettings(),
 	getVersion: () => app.getVersion(),
 	openInWebBrowser: (url) => {
 		// shell.openExternal() is powerful and dangerous. For example, on macOS you can launch a
@@ -346,6 +353,11 @@ const electronHandlerOverrides = {
 	},
 	watcherStopAll: () => WatcherManager.getInstance().stopAllWatchersForShutdown(),
 	readGUISettings: () => readSettings(),
+	updateOnboardingComplete: (complete) => sdk.updateOnboardingComplete(complete),
+	updateTelemetry: async (update) => {
+		await sdk.updateTelemetry(update);
+		await syncMetrics(app.getVersion());
+	},
 	writeGUISettings: async (settings) => {
 		applyGUISettings(settings);
 		await writeSettings(settings);

--- a/apps/lite/electron/src/metrics.ts
+++ b/apps/lite/electron/src/metrics.ts
@@ -114,6 +114,17 @@ export const initMetrics = async (version: string): Promise<void> => {
 	}
 };
 
+/**
+ * Brings the client in step with the settings after they change: started when
+ * metrics were just enabled, flushed and dropped when they were just disabled.
+ */
+export const syncMetrics = async (version: string): Promise<void> => {
+	if (shutdownPromise !== null) await shutdownPromise;
+	const { appMetricsEnabled } = (await getAppSettings()).telemetry;
+	if (!appMetricsEnabled) await shutdownMetrics();
+	else if (client === null) await initMetrics(version);
+};
+
 const capture = (event: string, properties: Record<string, unknown>): void => {
 	client?.capture({
 		distinctId,

--- a/apps/lite/ui/src/api/mutations.ts
+++ b/apps/lite/ui/src/api/mutations.ts
@@ -6,6 +6,7 @@ import {
 	currentForgeLoginQueryOptions,
 	getReviewQueryOptions,
 	headInfoQueryOptions,
+	appSettingsQueryOptions,
 	guiSettingsQueryOptions,
 	listCommentReactionsQueryOptions,
 	listReviewCommentsQueryOptions,
@@ -51,6 +52,7 @@ import type {
 	ForgeReviewReaction,
 	ForgeReviewUser,
 	Snapshot,
+	TelemetryUpdate,
 	TreeChange,
 } from "@gitbutler/but-sdk";
 import { type QueryClient, useMutation, useQueryClient } from "@tanstack/react-query";
@@ -1419,6 +1421,26 @@ export const useBranchRename = (projectId: string) => {
 /**
  * Save GUI settings mutation with partial keys. Settings are spread (shallow).
  */
+export const useUpdateTelemetry = () =>
+	useMutation({
+		scope: { id: "appSettings" },
+		mutationFn: async (update: TelemetryUpdate, ctx) => {
+			await window.lite.updateTelemetry(update);
+			await ctx.client.invalidateQueries({ queryKey: appSettingsQueryOptions.queryKey });
+		},
+		meta: { failureTitle: "Failed to save the telemetry setting" },
+	});
+
+export const useUpdateOnboardingComplete = () =>
+	useMutation({
+		scope: { id: "appSettings" },
+		mutationFn: async (complete: boolean, ctx) => {
+			await window.lite.updateOnboardingComplete(complete);
+			await ctx.client.invalidateQueries({ queryKey: appSettingsQueryOptions.queryKey });
+		},
+		meta: { failureTitle: "Failed to record the onboarding step" },
+	});
+
 export const useSaveGUISettings = () =>
 	useMutation({
 		scope: { id: "guiSettings" },

--- a/apps/lite/ui/src/api/queries.ts
+++ b/apps/lite/ui/src/api/queries.ts
@@ -610,3 +610,8 @@ export const guiSettingsQueryOptions = queryOptions({
 	queryKey: ["guiSettings"],
 	queryFn: () => window.lite.readGUISettings(),
 });
+
+export const appSettingsQueryOptions = queryOptions({
+	queryKey: ["appSettings"],
+	queryFn: () => window.lite.getAppSettings(),
+});

--- a/apps/lite/ui/src/api/query-keys.ts
+++ b/apps/lite/ui/src/api/query-keys.ts
@@ -13,6 +13,7 @@ export const projectQueryKeys = Object.keys(apiProvides) as ReadonlyArray<Projec
 /** Keyed without a project id, so no project event can invalidate them. */
 export type GlobalQueryKey =
 	| "aiConfiguration"
+	| "appSettings"
 	| "editors"
 	| "terminals"
 	| "forgeAccounts"

--- a/apps/lite/ui/src/components/useAddLocalRepository.ts
+++ b/apps/lite/ui/src/components/useAddLocalRepository.ts
@@ -30,13 +30,14 @@ const failureMessage = (failure: AddProjectFailure): string => {
 
 // Must be called from a component that outlives the button: the flow spans a
 // native dialog and a mutation, and the picker-dialog footer hosting the
-// button unmounts as soon as the dialog closes.
+// button unmounts as soon as the dialog closes. Resolves to whether a project
+// was opened: a cancelled picker or a failed add resolves false.
 export const useAddLocalRepository = () => {
 	const navigate = useNavigate();
 	const toastManager = Toast.useToastManager();
 	const { isPending, mutateAsync } = useAddProject();
 
-	const addLocalRepository = async () => {
+	const addLocalRepository = async (): Promise<boolean> => {
 		let path: string | null;
 		try {
 			path = await window.lite.pickDirectory();
@@ -46,16 +47,16 @@ export const useAddLocalRepository = () => {
 				title: "Failed to open repository picker",
 				description: errorMessageForToast(error),
 			});
-			return;
+			return false;
 		}
 
-		if (path === null) return;
+		if (path === null) return false;
 
 		let outcome: AddProjectOutcome;
 		try {
 			outcome = await mutateAsync(path);
 		} catch {
-			return;
+			return false;
 		}
 
 		if (outcome.type === "added" || outcome.type === "alreadyExists") {
@@ -64,7 +65,7 @@ export const useAddLocalRepository = () => {
 				to: "/project/$id/workspace",
 				params: { id: outcome.subject.id },
 			});
-			return;
+			return true;
 		}
 
 		toastManager.add({
@@ -72,6 +73,7 @@ export const useAddLocalRepository = () => {
 			title: "Could not add project",
 			description: failureMessage(outcome),
 		});
+		return false;
 	};
 
 	return { addLocalRepository, isPending };

--- a/apps/lite/ui/src/routes/IndexPage.module.css
+++ b/apps/lite/ui/src/routes/IndexPage.module.css
@@ -17,3 +17,17 @@
 		color: var(--text-2);
 	}
 }
+
+/* A filled card holding one settings row: the row's grid, without a settings card's border. */
+.consent {
+	display: grid;
+	grid-template-columns: auto 1fr;
+	width: 100%;
+	max-width: 360px;
+	margin-block: 0.75rem;
+	padding: 10px 12px;
+	gap: 10px 12px;
+	border-radius: var(--radius-card);
+	background-color: var(--bg-2);
+	text-align: start;
+}

--- a/apps/lite/ui/src/routes/IndexPage.tsx
+++ b/apps/lite/ui/src/routes/IndexPage.tsx
@@ -1,17 +1,37 @@
+import { useQuery } from "@tanstack/react-query";
 import type { FC } from "react";
+import { useUpdateOnboardingComplete } from "#ui/api/mutations.ts";
+import { appSettingsQueryOptions } from "#ui/api/queries.ts";
 import { AddProjectButton } from "#ui/components/AddProjectButton.tsx";
 import { useAddLocalRepository } from "#ui/components/useAddLocalRepository.ts";
+import { UsageMetricsRow } from "#ui/routes/project/$id/workspace/Settings/Telemetry.tsx";
 import { LiteTestId } from "#ui/testIds.ts";
 import styles from "./IndexPage.module.css";
 
 export const IndexPage: FC = () => {
 	const { addLocalRepository, isPending } = useAddLocalRepository();
+	const { data: settings } = useQuery(appSettingsQueryOptions);
+	const { mutate: updateOnboardingComplete } = useUpdateOnboardingComplete();
+	// Shown until the first repository is added: that is the confirmation.
+	const confirming = settings !== undefined && !settings.onboardingComplete;
 
 	return (
 		<section className={styles.page} data-testid={LiteTestId.OnboardingPage}>
 			<h1>Welcome to GitButler Lite</h1>
 			<p>Add a local Git repository to get started.</p>
-			<AddProjectButton isPending={isPending} onClick={() => void addLocalRepository()} />
+			{confirming && (
+				<div className={styles.consent}>
+					<UsageMetricsRow settings={settings} />
+				</div>
+			)}
+			<AddProjectButton
+				isPending={isPending}
+				onClick={() =>
+					void addLocalRepository().then((opened) => {
+						if (opened && confirming) updateOnboardingComplete(true);
+					})
+				}
+			/>
 		</section>
 	);
 };

--- a/apps/lite/ui/src/routes/project/$id/workspace/Settings/General.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Settings/General.tsx
@@ -2,6 +2,7 @@ import { useSuspenseQueries } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { useState, type FC } from "react";
 import {
+	appSettingsQueryOptions,
 	guiSettingsQueryOptions,
 	listEditorsQueryOptions,
 	listProjectsQueryOptions,
@@ -15,6 +16,7 @@ import { Switch } from "#ui/components/Switch.tsx";
 import { defaultSettings } from "#ui/settings.ts";
 import styles from "./General.module.css";
 import { Row, Section } from "./Section.tsx";
+import { UsageMetricsRow } from "./Telemetry.tsx";
 
 export const General: FC = () => {
 	const [
@@ -23,6 +25,7 @@ export const General: FC = () => {
 		{ data: settings },
 		{ data: projects },
 		{ data: profile },
+		{ data: appSettings },
 	] = useSuspenseQueries({
 		queries: [
 			listEditorsQueryOptions,
@@ -30,6 +33,7 @@ export const General: FC = () => {
 			guiSettingsQueryOptions,
 			listProjectsQueryOptions,
 			userProfileQueryOptions,
+			appSettingsQueryOptions,
 		],
 	});
 	const { mutate: saveGUISettings } = useSaveGUISettings();
@@ -127,6 +131,10 @@ export const General: FC = () => {
 						onCheckedChange={(desktopNotifications) => saveGUISettings({ desktopNotifications })}
 					/>
 				</Row>
+			</Section>
+
+			<Section heading="Telemetry">
+				<UsageMetricsRow settings={appSettings} />
 			</Section>
 
 			<Section heading="Danger zone">

--- a/apps/lite/ui/src/routes/project/$id/workspace/Settings/Telemetry.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Settings/Telemetry.module.css
@@ -1,0 +1,5 @@
+.link {
+	color: var(--text-2);
+	text-decoration: underline;
+	text-underline-offset: 2px;
+}

--- a/apps/lite/ui/src/routes/project/$id/workspace/Settings/Telemetry.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Settings/Telemetry.tsx
@@ -1,0 +1,39 @@
+import type { FC } from "react";
+import type { AppSettings } from "@gitbutler/but-sdk";
+import { useUpdateTelemetry } from "#ui/api/mutations.ts";
+import { Switch } from "#ui/components/Switch.tsx";
+import { Row } from "./Section.tsx";
+import styles from "./Telemetry.module.css";
+
+/** The one telemetry choice Lite acts on: it sends usage metrics and reports no errors. */
+export const UsageMetricsRow: FC<{ settings: AppSettings }> = ({ settings }) => {
+	const { mutate: updateTelemetry } = useUpdateTelemetry();
+
+	return (
+		<Row
+			label="Usage metrics"
+			labelId="usage-metrics"
+			hint={
+				<>
+					Counts of what the app does. Never file contents or sensitive data.{" "}
+					<a
+						href="https://gitbutler.com/privacy"
+						className={styles.link}
+						onClick={(event) => {
+							event.preventDefault();
+							void window.lite.openInWebBrowser(event.currentTarget.href);
+						}}
+					>
+						Privacy policy
+					</a>
+				</>
+			}
+		>
+			<Switch
+				aria-labelledby="usage-metrics"
+				checked={settings.telemetry.appMetricsEnabled}
+				onCheckedChange={(appMetricsEnabled) => updateTelemetry({ appMetricsEnabled })}
+			/>
+		</Row>
+	);
+};


### PR DESCRIPTION
The desktop app asks before it starts collecting; Lite started with the shared default and never asked. The welcome page now carries the question, and adding the first repository is the answer.

- A **Usage metrics** switch on the welcome page, shown until onboarding is marked complete. Adding the first repository marks it.
- The switch writes the shared setting straight away through three new local endpoints (`getAppSettings`, `updateTelemetry`, `updateOnboardingComplete`), and the main process starts or stops collection to match, so no relaunch is needed.
- The same row sits under a **Telemetry** heading in General settings, so the choice can be revisited.
- The onboarding e2e spec now checks the switch is there and that the add marks onboarding complete.