### PR TITLE
Lead notification rows with the event, and notify the desktop

### DIFF
--- a/apps/lite/electron/src/endpoint-table.ts
+++ b/apps/lite/electron/src/endpoint-table.ts
@@ -10,7 +10,12 @@ import { exposedEndpoints, type Endpoint, type LiteElectronApi, type PayloadFor 
  */
 
 /** Members the renderer implements itself; they have no host-side handler. */
-type RendererOnlyKey = "onAskpassPrompt" | "onDeepLink" | "onFullScreenChange" | "platform";
+type RendererOnlyKey =
+	| "onAskpassPrompt"
+	| "onDeepLink"
+	| "onFullScreenChange"
+	| "onNotificationClick"
+	| "platform";
 
 /** Handlers needing the transport event itself, or taking variadic arguments. */
 type ImperativeKey =

--- a/apps/lite/electron/src/ipc.ts
+++ b/apps/lite/electron/src/ipc.ts
@@ -31,6 +31,8 @@ export type LiteElectronApi = SDK & {
 	getVersion: () => Promise<string>;
 	isFullScreen: () => Promise<boolean>;
 	onFullScreenChange: (callback: (fullScreen: boolean) => void) => () => void;
+	/** A click on a desktop notification, by the id it was shown with. */
+	onNotificationClick: (callback: (id: string) => void) => () => void;
 	openInWebBrowser: (url: string) => Promise<void>;
 	pathJoin: (...paths: Array<string>) => Promise<string>;
 	pickDirectory: () => Promise<string | null>;
@@ -38,6 +40,11 @@ export type LiteElectronApi = SDK & {
 	/** Reveal a file in the OS file manager, selected in its containing folder. */
 	showItemInFolder: (path: string) => Promise<void>;
 	showNativeMenu: (params: ShowNativeMenuParams) => Promise<string | null>;
+	/**
+	 * Show a desktop notification, unless the window is focused — the bell is
+	 * in view then. A no-op where the OS offers none.
+	 */
+	showNotification: (params: ShowNotificationParams) => Promise<void>;
 	streamAiResponse: (
 		systemMessage: string,
 		prompt: string,
@@ -69,12 +76,14 @@ export const localEndpoints = [
 	"fullScreenChange",
 	"getVersion",
 	"isFullScreen",
+	"notificationClick",
 	"openInWebBrowser",
 	"pathJoin",
 	"pickDirectory",
 	"readGUISettings",
 	"showItemInFolder",
 	"showNativeMenu",
+	"showNotification",
 	"streamAiResponse",
 	"watcherStopAll",
 	"watcherSubscribe",
@@ -145,6 +154,13 @@ export interface StreamAiResponseParams {
 export interface StreamAiResponseToken {
 	requestId: string;
 	token: string;
+}
+
+export interface ShowNotificationParams {
+	/** Handed back on click, so the renderer can land on what was announced. */
+	id: string;
+	title: string;
+	body: string;
 }
 
 export interface NativeMenuPosition {

--- a/apps/lite/electron/src/lite-api.ts
+++ b/apps/lite/electron/src/lite-api.ts
@@ -20,6 +20,7 @@ type SpecialKey =
 	| "onAskpassPrompt"
 	| "onDeepLink"
 	| "onFullScreenChange"
+	| "onNotificationClick"
 	| "platform"
 	| "streamAiResponse"
 	| "watcherSubscribe"
@@ -31,6 +32,7 @@ const specialNames = [
 	"askpassPrompt",
 	"deepLink",
 	"fullScreenChange",
+	"notificationClick",
 	"streamAiResponse",
 	"watcherSubscribe",
 	"watcherUnsubscribe",
@@ -87,6 +89,10 @@ export const createLiteApi = ({
 		onFullScreenChange: (callback) =>
 			subscribe("fullScreenChange", (payload) => {
 				callback(payload as boolean);
+			}),
+		onNotificationClick: (callback) =>
+			subscribe("notificationClick", (payload) => {
+				callback(payload as string);
 			}),
 		streamAiResponse: async (systemMessage, prompt, onToken) => {
 			const requestId = crypto.randomUUID();

--- a/apps/lite/electron/src/main.ts
+++ b/apps/lite/electron/src/main.ts
@@ -29,6 +29,7 @@ import {
 	Menu,
 	nativeTheme,
 	net,
+	Notification,
 	protocol,
 	session,
 	shell,
@@ -320,6 +321,24 @@ const electronHandlerOverrides = {
 		// Unlike shell.openExternal, this only selects the item in the file
 		// manager; it never launches it, so a path is all it takes.
 		shell.showItemInFolder(itemPath);
+	},
+	showNotification: ({ id, title, body }) => {
+		const [window] = BrowserWindow.getAllWindows();
+		// Decided here, not in the renderer: a freshly loaded document reports
+		// `document.hasFocus()` true while the window sits behind another app.
+		if (!Notification.isSupported() || window === undefined || window.isFocused()) return;
+		const notification = new Notification({ title, body });
+		notification.on("click", () => {
+			showAndFocusWindow(window);
+			window.webContents.send("notificationClick", id);
+		});
+		// macOS refuses silently when the app is not allowed to notify
+		// (UNErrorDomain error 1); the log is the only place that says so.
+		notification.on("failed", (_event, error) => {
+			// oxlint-disable-next-line no-console
+			console.error(`Desktop notification failed: ${error}`);
+		});
+		notification.show();
 	},
 	pickDirectory: async () => {
 		const { canceled, filePaths } = await dialog.showOpenDialog({ properties: ["openDirectory"] });

--- a/apps/lite/electron/src/settings.ts
+++ b/apps/lite/electron/src/settings.ts
@@ -16,6 +16,7 @@ const guiSettingsV1 = type({
 	"autoFetchFrequency?": "string",
 	"autoUpdate?": "boolean",
 	"commentAnnotations?": "boolean",
+	"desktopNotifications?": "boolean",
 	"diffBackground?": "boolean",
 	"diffFontFamily?": "string",
 	"diffFontSize?": "number",

--- a/apps/lite/harness/deepseek/cli.mjs
+++ b/apps/lite/harness/deepseek/cli.mjs
@@ -57,6 +57,8 @@ const hostOverrides = {
 	clipboardWriteText: () => undefined,
 	// No file manager to reveal into from the harness.
 	showItemInFolder: () => undefined,
+	// Nor a desktop to notify; the bell still fills.
+	showNotification: () => undefined,
 	getAiConfiguration: () => defaultAiConfiguration(),
 	updateAiConfiguration: () => defaultAiConfiguration(),
 	resetAiConfiguration: () => defaultAiConfiguration(),

--- a/apps/lite/harness/tests/fixtures.ts
+++ b/apps/lite/harness/tests/fixtures.ts
@@ -176,4 +176,6 @@ export const globalHandlers = (projectId: string): FakeHandlers => ({
 	// "No patch": good enough until a test renders a diff.
 	treeChangeDiffs: () => null,
 	branchCannedName: () => "canned-branch-name",
+	// The host decides focus; here nothing is ever shown.
+	showNotification: () => undefined,
 });

--- a/apps/lite/harness/tests/panel.test.tsx
+++ b/apps/lite/harness/tests/panel.test.tsx
@@ -35,11 +35,17 @@ const settle = { timeout: 15_000 } as const;
  * is cleared either way.
  */
 /** The inbox as the detector wrote it, straight from the store's key. */
-const inboxEntries = (): Array<{ kind: string; review: number; author: string | null }> =>
+const inboxEntries = (): Array<{
+	kind: string;
+	review: number;
+	author: string | null;
+	seen: boolean;
+}> =>
 	JSON.parse(localStorage.getItem(`pr_activity_inbox:v1:${PROJECT_ID}`) ?? "[]") as Array<{
 		kind: string;
 		review: number;
 		author: string | null;
+		seen: boolean;
 	}>;
 
 const mountPanel = (handlers: FakeHandlers, seenMarks?: Record<number, string>) => {
@@ -320,6 +326,64 @@ test("a mention toasts even when the review's branch is not in the workspace", a
 			expect(inboxEntries().find((entry) => entry.review === 8)).toMatchObject({ kind: "mention" }),
 		settle,
 	);
+
+	panel.unmount();
+});
+
+test("loud activity is offered to the desktop, and its click lands on the entry", async () => {
+	let review = fixtureForgeReview({ modifiedAt: "2026-01-01T10:00:00Z" });
+	let comments: Array<unknown> = [];
+	const shown: Array<{ id: string; title: string; body: string }> = [];
+
+	const panel = mountPanel({
+		headInfo: () =>
+			fixtureHeadInfo([[fixtureSegment({ branch: review.sourceBranch, commits: [] })]]),
+		changesInWorktree: () => fixtureWorktreeChanges([]),
+		forgeInfo: () => fixtureForgeInfo(),
+		listReviews: () => [review],
+		currentForgeLogin: () => "me",
+		listReviewComments: () => comments,
+		listReviewSubmissions: () => [],
+		listReviewThreads: () => [],
+		listReviewTimelineEvents: () => [],
+		showNotification: (notice: { id: string; title: string; body: string }) => {
+			shown.push(notice);
+		},
+	});
+	await vi.waitFor(() => expect(panel.container.textContent).toContain("PR"), settle);
+
+	review = { ...review, modifiedAt: "2026-01-01T12:00:00Z" };
+	// Its own minute: entry ids carry the time, and the inbox module keeps an
+	// in-memory copy across tests that would file a repeat id as old news.
+	comments = [
+		{
+			id: 3,
+			body: "Could this retry loop leak the handle?",
+			author: { id: 2, login: "alice", name: null, email: null, avatarUrl: null, isBot: false },
+			createdAt: "2026-01-01T11:45:00Z",
+			modifiedAt: null,
+			htmlUrl: "",
+			reactions: [],
+		},
+	];
+	const eventChannel = panel.watcher.channels.at(0);
+	if (eventChannel === undefined) throw new Error("no watcher subscription armed");
+	panel.push(eventChannel, {
+		name: "gitFetch",
+		payload: { type: "gitFetch", subject: null },
+	} satisfies WatcherEvent);
+
+	await vi.waitFor(() => expect(shown).toHaveLength(1), settle);
+	expect(shown[0]).toMatchObject({
+		title: "Comment from alice",
+		body: `${review.sourceBranch} #7\nCould this retry loop leak the handle?`,
+	});
+
+	// The click comes back by id and marks the entry seen on its way in.
+	const [notice] = shown;
+	if (notice === undefined) throw new Error("no notice shown");
+	panel.push("notificationClick", notice.id);
+	await vi.waitFor(() => expect(inboxEntries()[0]).toMatchObject({ seen: true }), settle);
 
 	panel.unmount();
 });

--- a/apps/lite/ui/src/review-inbox-bell.module.css
+++ b/apps/lite/ui/src/review-inbox-bell.module.css
@@ -83,8 +83,16 @@
 	color: var(--text-3);
 }
 
-.entryIconLoud {
+.entryIconPop {
 	color: var(--fill-pop-bg);
+}
+
+.entryIconSafe {
+	color: var(--text-safe);
+}
+
+.entryIconWarn {
+	color: var(--text-warn);
 }
 
 .entryBody {
@@ -95,15 +103,24 @@
 	gap: 2px;
 }
 
-/* Leads the row, one step above the murmur: the title is what you scan
-   for, and it wraps rather than truncates. */
-.entryTitle {
+/* Leads the row, one step above the murmur: what happened is what you
+   scan for. */
+.entryHeadline {
 	color: var(--text-1);
+}
+
+/* News rather than a request: quiet kinds sit in the murmur. */
+.entryHeadlineQuiet {
+	color: var(--text-2);
+}
+
+.entryTarget {
+	color: var(--text-3);
 	overflow-wrap: anywhere;
 }
 
-.entryAction {
-	color: var(--text-3);
+.entryBranch {
+	color: var(--text-2);
 }
 
 .entrySnippet {

--- a/apps/lite/ui/src/review-inbox-bell.tsx
+++ b/apps/lite/ui/src/review-inbox-bell.tsx
@@ -1,22 +1,22 @@
 /**
  * @file The bell: the inbox's face in the window corner.
  *
- * A red dot says entries wait unseen; the popover lists them richly, each
- * kind with its own shape, newest first. Opening the panel does not mark
- * anything seen — clicking an entry does, the same way seeing works
- * everywhere else in this feature.
+ * A red dot says entries wait unseen; the popover lists them newest first,
+ * each row answering what happened, to what, and by whom. Opening the panel
+ * does not mark anything seen — clicking an entry does, the same way seeing
+ * works everywhere else in this feature.
  */
 
 import { forgeInfoOptions, headInfoQueryOptions } from "#ui/api/queries.ts";
-import { branchAddress } from "#ui/addresses.ts";
 import { Icon } from "#ui/components/Icon.tsx";
 import type { IconName } from "#ui/components/iconNames.ts";
 import { RelativeTime } from "#ui/components/RelativeTime.tsx";
 import { classes } from "#ui/components/classes.ts";
 import { getButtonClassName } from "#ui/components/Button.tsx";
-import { projectSlice } from "#ui/projects/state.ts";
-import { appliedRefsByName } from "#ui/review-notifications.ts";
+import { appliedRefsByName, openInboxEntry, type AppliedRefs } from "#ui/review-notifications.ts";
 import {
+	entryHeadline,
+	inboxKindAttention,
 	markInboxSeen,
 	useInboxEntries,
 	useInboxUnseenCount,
@@ -24,9 +24,6 @@ import {
 	type InboxKind,
 } from "#ui/review-inbox.ts";
 import { usePrNotificationsLevel } from "#ui/review-seen.ts";
-import { store } from "#ui/store.ts";
-import { requestReviewFocus } from "#ui/review-focus.ts";
-import { setActiveList, setCursor, setPage } from "#ui/use-cursor.ts";
 import { Dropdown } from "#ui/components/Popup.tsx";
 import { useQuery } from "@tanstack/react-query";
 import { useState, type FC } from "react";
@@ -43,34 +40,18 @@ const kindIcon: Record<InboxKind, IconName> = {
 	closed: "pr-close",
 };
 
-/** The sentence fragment after the author — "commented on", "approved". */
-const kindPhrase = (entry: InboxEntry): string => {
-	const many = entry.count > 1;
-	switch (entry.kind) {
-		case "comment":
-			return many ? `left ${entry.count} comments on` : "commented on";
-		case "mention":
-			return "mentioned you on";
-		case "approved":
-			return "approved";
-		case "changesRequested":
-			return "requested changes on";
-		case "reviewRequested":
-			return "requested your review on";
-		case "committed":
-			return many ? `pushed ${entry.count} commits to` : "pushed a commit to";
-		case "merged":
-			return "merged";
-		case "closed":
-			return "closed";
-	}
+/** Semantic tints for the kinds whose meaning has a color; the rest stay gray. */
+const kindTint: Partial<Record<InboxKind, string>> = {
+	mention: styles.entryIconPop,
+	approved: styles.entryIconSafe,
+	changesRequested: styles.entryIconWarn,
 };
 
 const Entry: FC<{
 	projectId: string;
 	entry: InboxEntry;
 	/** Shared by the bell: one head-info subscription serves every row. */
-	appliedRefs: Map<string, Array<number>> | undefined;
+	appliedRefs: AppliedRefs | undefined;
 	/** The panel closes itself once a click has somewhere to go. */
 	onNavigate: () => void;
 }> = ({ projectId, entry, appliedRefs, onNavigate }) => {
@@ -79,43 +60,27 @@ const Entry: FC<{
 		// the forge for a local branch, and eat the unread mark doing it.
 		if (appliedRefs === undefined) return;
 		onNavigate();
-		markInboxSeen(projectId, [entry.id]);
-		const branchRef = appliedRefs.get(entry.sourceBranch);
-		// A review outside the workspace has no local branch to select, so
-		// it opens on the forge instead.
-		if (branchRef === undefined) {
-			void window.lite.openInWebBrowser(entry.htmlUrl);
-			return;
-		}
-		setPage("workspace");
-		// The details pane follows the active list; with the uncommitted list
-		// driving it, the cursor and tab writes below would change nothing the
-		// reader can see.
-		setActiveList("applied");
-		setCursor("applied", branchAddress({ branchRef }));
-		store.dispatch(
-			projectSlice.actions.setSelectedBranchTab({
-				projectId,
-				branchName: entry.sourceBranch,
-				tab: "pr",
-			}),
-		);
-		// Landing on the comment is what makes the click worth it when the
-		// review is already on screen.
-		if (entry.commentId != null) requestReviewFocus(entry.review, entry.commentId);
+		openInboxEntry(projectId, entry, appliedRefs);
 	};
 
 	return (
-		<button className={styles.entry} onClick={open} type="button">
+		<button className={styles.entry} onClick={open} type="button" title={entry.reviewTitle}>
 			<Icon
 				name={kindIcon[entry.kind]}
-				className={classes(styles.entryIcon, entry.kind === "mention" && styles.entryIconLoud)}
+				className={classes(styles.entryIcon, kindTint[entry.kind])}
 			/>
 			<span className={styles.entryBody}>
-				<span className={classes("text-12", styles.entryTitle)}>{entry.reviewTitle}</span>
-				<span className={classes("text-11", styles.entryAction)}>
-					{entry.author !== null && <span>{entry.author} </span>}
-					{kindPhrase(entry)} {entry.unitSymbol}
+				<span
+					className={classes(
+						"text-12",
+						styles.entryHeadline,
+						inboxKindAttention[entry.kind] === "quiet" && styles.entryHeadlineQuiet,
+					)}
+				>
+					{entryHeadline(entry)}
+				</span>
+				<span className={classes("text-11", styles.entryTarget)}>
+					<span className={styles.entryBranch}>{entry.sourceBranch}</span> {entry.unitSymbol}
 					{entry.review}
 				</span>
 				{entry.snippet !== null && (
@@ -151,6 +116,7 @@ export const NotificationBell: FC<{ projectId: string }> = ({ projectId }) => {
 		select: appliedRefsByName,
 		enabled: shown,
 	});
+
 	if (!shown) return null;
 
 	return (

--- a/apps/lite/ui/src/review-inbox.test.ts
+++ b/apps/lite/ui/src/review-inbox.test.ts
@@ -1,5 +1,12 @@
 /** @vitest-environment jsdom */
-import { addInboxEntries, markInboxSeen, type InboxEntry } from "./review-inbox.ts";
+import {
+	addInboxEntries,
+	desktopNotices,
+	entryHeadline,
+	markInboxSeen,
+	summaryNoticeId,
+	type InboxEntry,
+} from "./review-inbox.ts";
 import { describe, expect, it } from "vitest";
 
 /**
@@ -53,6 +60,14 @@ describe("addInboxEntries", () => {
 		expect(stored(projectId).map((e) => [e.id, e.seen])).toEqual([
 			["b", false],
 			["a", true],
+		]);
+	});
+
+	it("returns only the entries that were new", () => {
+		const projectId = freshProject();
+		expect(addInboxEntries(projectId, [entry("a", 10)]).map((e) => e.id)).toEqual(["a"]);
+		expect(addInboxEntries(projectId, [entry("a", 10), entry("b", 20)]).map((e) => e.id)).toEqual([
+			"b",
 		]);
 	});
 
@@ -158,5 +173,52 @@ describe("markInboxSeen with ids", () => {
 		]);
 		expect(marksOf(projectId)).toEqual({ 7: at(0) });
 		expect(unseenOf(projectId)).toEqual({ 7: [["c:1", at(3)]] });
+	});
+});
+
+describe("entryHeadline", () => {
+	it("leads with what happened, then by whom", () => {
+		expect(entryHeadline(entry("a", 0, { kind: "changesRequested" }))).toBe(
+			"Changes requested by alice",
+		);
+		expect(entryHeadline(entry("a", 0, { kind: "comment", count: 3 }))).toBe(
+			"3 comments from alice",
+		);
+		expect(entryHeadline(entry("a", 0, { kind: "mention" }))).toBe("Mentioned by alice");
+		expect(entryHeadline(entry("a", 0, { kind: "committed", count: 2 }))).toBe(
+			"2 commits pushed by alice",
+		);
+	});
+
+	it("stands alone when the actor is unknown", () => {
+		expect(entryHeadline(entry("a", 0, { kind: "merged", author: null }))).toBe("Merged");
+		expect(entryHeadline(entry("a", 0, { kind: "comment", author: null }))).toBe("Comment");
+	});
+});
+
+describe("desktopNotices", () => {
+	it("announces loud entries one by one, with the branch and snippet as the body", () => {
+		const notices = desktopNotices([
+			entry("a", 0, { kind: "approved" }),
+			entry("b", 0, { kind: "comment", snippet: "Looks off to me" }),
+			entry("c", 0, { kind: "committed" }),
+		]);
+		expect(notices).toEqual([
+			{ id: "a", title: "Approved by alice", body: "feature-one #7" },
+			{ id: "b", title: "Comment from alice", body: "feature-one #7\nLooks off to me" },
+		]);
+	});
+
+	it("collapses a catch-up into one summary", () => {
+		const notices = desktopNotices(
+			["a", "b", "c", "d"].map((id, i) => entry(id, i, { review: i % 2 === 0 ? 7 : 8 })),
+		);
+		expect(notices).toEqual([
+			{ id: summaryNoticeId, title: "4 new notifications", body: "feature-one #7, feature-one #8" },
+		]);
+	});
+
+	it("says nothing for quiet news", () => {
+		expect(desktopNotices([entry("a", 0, { kind: "merged" })])).toEqual([]);
 	});
 });

--- a/apps/lite/ui/src/review-inbox.ts
+++ b/apps/lite/ui/src/review-inbox.ts
@@ -7,6 +7,7 @@
  * in-memory snapshots.
  */
 
+import type { ShowNotificationParams } from "#electron/ipc.ts";
 import { markReviewsSeenUpTo } from "#ui/review-seen.ts";
 import { useSyncExternalStore } from "react";
 
@@ -48,6 +49,82 @@ const inboxKinds: ReadonlyArray<string> = [
 	"merged",
 	"closed",
 ];
+
+/**
+ * Loud kinds have a human waiting on the user; quiet ones are news the bell
+ * keeps. The split sets a row's weight and decides what reaches the desktop.
+ */
+export const inboxKindAttention: Record<InboxKind, "loud" | "quiet"> = {
+	comment: "loud",
+	mention: "loud",
+	approved: "loud",
+	changesRequested: "loud",
+	reviewRequested: "loud",
+	committed: "quiet",
+	merged: "quiet",
+	closed: "quiet",
+};
+
+/** What happened, and by whom — "Changes requested by alice". */
+export const entryHeadline = (entry: InboxEntry): string => {
+	const by = entry.author === null ? "" : ` by ${entry.author}`;
+	const from = entry.author === null ? "" : ` from ${entry.author}`;
+	const many = entry.count > 1;
+	switch (entry.kind) {
+		case "comment":
+			return many ? `${entry.count} comments${from}` : `Comment${from}`;
+		case "mention":
+			return `Mentioned${by}`;
+		case "approved":
+			return `Approved${by}`;
+		case "changesRequested":
+			return `Changes requested${by}`;
+		case "reviewRequested":
+			return `Review requested${by}`;
+		case "committed":
+			return many ? `${entry.count} commits pushed${by}` : `Commit pushed${by}`;
+		case "merged":
+			return `Merged${by}`;
+		case "closed":
+			return `Closed${by}`;
+	}
+};
+
+/** The branch and number, as the bell's second line shows them. */
+const entryTarget = (entry: InboxEntry): string =>
+	`${entry.sourceBranch} ${entry.unitSymbol}${entry.review}`;
+
+/**
+ * The id a summary notice carries: no entry answers to it, so its click only
+ * brings the window forward.
+ * @public exported for the test suite.
+ */
+export const summaryNoticeId = "summary";
+
+/** Beyond this many in one poll, one summary stands in for the storm. */
+const summaryAfter = 3;
+
+/**
+ * What the desktop shows for one poll's fresh entries: the loud ones, each
+ * on its own, or a single summary when a catch-up files many at once.
+ */
+export const desktopNotices = (fresh: ReadonlyArray<InboxEntry>): Array<ShowNotificationParams> => {
+	const loud = fresh.filter((entry) => inboxKindAttention[entry.kind] === "loud");
+	if (loud.length <= summaryAfter) {
+		return loud.map((entry) => ({
+			id: entry.id,
+			title: entryHeadline(entry),
+			body: entry.snippet === null ? entryTarget(entry) : `${entryTarget(entry)}\n${entry.snippet}`,
+		}));
+	}
+	return [
+		{
+			id: summaryNoticeId,
+			title: `${loud.length} new notifications`,
+			body: [...new Set(loud.map(entryTarget))].join(", "),
+		},
+	];
+};
 
 const storageKey = (projectId: string) => `pr_activity_inbox:v1:${projectId}`;
 
@@ -155,17 +232,22 @@ const subscribeNothing = (): (() => void) => () => {};
  * File the poll's entries, keeping the list ordered by each entry's own
  * time. An id already filed is left exactly where it is, seen state and
  * all — a review bumping again must not resurface an old entry as new.
+ * Returns the entries that were actually new.
  */
-export const addInboxEntries = (projectId: string, entries: Array<InboxEntry>): void => {
-	if (entries.length === 0) return;
+export const addInboxEntries = (
+	projectId: string,
+	entries: Array<InboxEntry>,
+): Array<InboxEntry> => {
+	if (entries.length === 0) return [];
 	const existing = readEntries(projectId);
 	const known = new Set(existing.map((entry) => entry.id));
 	const fresh = entries.filter((entry) => !known.has(entry.id));
-	if (fresh.length === 0) return;
+	if (fresh.length === 0) return [];
 	const next = [...fresh, ...existing]
 		.sort((a, b) => Date.parse(b.at) - Date.parse(a.at))
 		.slice(0, inboxCap);
 	writeEntries(projectId, next);
+	return fresh;
 };
 
 /**
@@ -191,6 +273,10 @@ export const markInboxSeen = (projectId: string, ids?: ReadonlyArray<string>): v
 		),
 	);
 };
+
+/** The entry a desktop notification was shown for, if it is still filed. */
+export const findInboxEntry = (projectId: string, id: string): InboxEntry | undefined =>
+	readEntries(projectId).find((entry) => entry.id === id);
 
 /** The inbox, newest first — a stable array identity between writes. */
 export const useInboxEntries = (projectId: string, enabled: boolean): Array<InboxEntry> =>

--- a/apps/lite/ui/src/review-notifications.ts
+++ b/apps/lite/ui/src/review-notifications.ts
@@ -3,7 +3,8 @@
  *
  * The decisions are pure and live in `review-activity.ts`; the hook here
  * feeds them the listing the app polls anyway. The unread dots stay the
- * record — the bell is the cross-review view of the same facts.
+ * record — the bell is the cross-review view of the same facts, and the
+ * desktop hears the loud ones while the window is elsewhere.
  */
 
 import {
@@ -27,15 +28,34 @@ import {
 	listReviewTimelineEventsQueryOptions,
 	listReviewsQueryOptions,
 } from "#ui/api/queries.ts";
-import { addInboxEntries, type InboxEntry, type InboxKind } from "#ui/review-inbox.ts";
-import { readSeenMarks, usePrNotificationsLevel } from "#ui/review-seen.ts";
+import {
+	addInboxEntries,
+	desktopNotices,
+	findInboxEntry,
+	markInboxSeen,
+	type InboxEntry,
+	type InboxKind,
+} from "#ui/review-inbox.ts";
+import { branchAddress } from "#ui/addresses.ts";
+import { projectSlice } from "#ui/projects/state.ts";
+import { requestReviewFocus } from "#ui/review-focus.ts";
+import { store } from "#ui/store.ts";
+import { setActiveList, setCursor, setPage } from "#ui/use-cursor.ts";
+import {
+	readSeenMarks,
+	useDesktopNotifications,
+	usePrNotificationsLevel,
+} from "#ui/review-seen.ts";
 import { selfMergedNumbers } from "#ui/api/mutations.ts";
 import type { ForgeReview, RefInfo } from "@gitbutler/but-sdk";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useEffectEvent, useRef } from "react";
 
+/** Applied branches by display name, each with the ref bytes a cursor needs. */
+export type AppliedRefs = Map<string, Array<number>>;
+
 /** @public shared with the bell, whose entry clicks jump the same way. */
-export const appliedRefsByName = (headInfo: RefInfo): Map<string, Array<number>> =>
+export const appliedRefsByName = (headInfo: RefInfo): AppliedRefs =>
 	new Map(
 		headInfo.stacks.flatMap((stack) =>
 			stack.segments.flatMap((segment) =>
@@ -45,6 +65,40 @@ export const appliedRefsByName = (headInfo: RefInfo): Map<string, Array<number>>
 			),
 		),
 	);
+
+/**
+ * Where an entry lands, from the bell or a desktop notification: its branch
+ * in the workspace, or the forge when the branch is not applied — a review
+ * outside the workspace has no local branch to select.
+ */
+export const openInboxEntry = (
+	projectId: string,
+	entry: InboxEntry,
+	appliedRefs: AppliedRefs,
+): void => {
+	markInboxSeen(projectId, [entry.id]);
+	const branchRef = appliedRefs.get(entry.sourceBranch);
+	if (branchRef === undefined) {
+		void window.lite.openInWebBrowser(entry.htmlUrl);
+		return;
+	}
+	setPage("workspace");
+	// The details pane follows the active list; with the uncommitted list
+	// driving it, the cursor and tab writes below would change nothing the
+	// reader can see.
+	setActiveList("applied");
+	setCursor("applied", branchAddress({ branchRef }));
+	store.dispatch(
+		projectSlice.actions.setSelectedBranchTab({
+			projectId,
+			branchName: entry.sourceBranch,
+			tab: "pr",
+		}),
+	);
+	// Landing on the comment is what makes the click worth it when the
+	// review is already on screen.
+	if (entry.commentId != null) requestReviewFocus(entry.review, entry.commentId);
+};
 
 /** The kind an item files under; mentions outrank the item's own shape. */
 const inboxKindOf = (item: ReviewActivityItem, login: string | null): InboxKind => {
@@ -109,16 +163,22 @@ const entryOf = (
  * listing observed is the baseline — nothing older is filed; the dots carry
  * that. Applied-branch reviews file everything short of silent, the rest
  * only mentions, and a kind's items on one review coalesce into one entry.
+ * Loud entries go to the desktop too; the host drops them while the window
+ * is focused.
  */
 export const useReviewActivityInbox = (projectId: string): void => {
 	const client = useQueryClient();
 	const level = usePrNotificationsLevel();
+	const desktop = useDesktopNotifications();
 
 	const { data: forgeInfo } = useQuery(forgeInfoOptions(projectId));
 	const enabled = level === "loud" && !!forgeInfo?.capabilities.prService;
 	const { data: reviews } = useQuery({
 		...listReviewsQueryOptions({ projectId, cacheConfig: "noCache" }),
 		enabled,
+		// Polling pauses in an unfocused window, which is exactly when a
+		// desktop notification is the only way to be heard.
+		refetchIntervalInBackground: desktop,
 	});
 	const { data: appliedRefs } = useQuery({
 		...headInfoQueryOptions(projectId),
@@ -215,7 +275,9 @@ export const useReviewActivityInbox = (projectId: string): void => {
 				}),
 			)
 		).flat();
-		addInboxEntries(projectId, entries);
+		const fresh = addInboxEntries(projectId, entries);
+		if (desktop)
+			for (const notice of desktopNotices(fresh)) void window.lite.showNotification(notice);
 	});
 
 	// A disabled detector forgets its baseline, so re-enabling starts from
@@ -223,6 +285,18 @@ export const useReviewActivityInbox = (projectId: string): void => {
 	useEffect(() => {
 		if (!enabled) ledger.current = null;
 	}, [enabled, projectId]);
+
+	// The main process has focused the window by now; a summary, or an entry
+	// since dropped from the inbox, leaves the reader at the lit bell.
+	const onNotificationClick = useEffectEvent((id: string) => {
+		if (appliedRefs === undefined) return;
+		const entry = findInboxEntry(projectId, id);
+		if (entry !== undefined) openInboxEntry(projectId, entry, appliedRefs);
+	});
+	useEffect(() => {
+		if (!enabled) return;
+		return window.lite.onNotificationClick(onNotificationClick);
+	}, [enabled]);
 
 	// `appliedRefs` in the deps takes the baseline as soon as both the
 	// listing and the applied set exist, whichever resolves last. The login

--- a/apps/lite/ui/src/review-seen.ts
+++ b/apps/lite/ui/src/review-seen.ts
@@ -29,6 +29,15 @@ export const usePrNotificationsLevel = (): "loud" | "quiet" | "off" => {
 	return level ?? defaultSettings.prNotifications;
 };
 
+/** Whether loud activity also reaches the desktop while the window is unfocused. */
+export const useDesktopNotifications = (): boolean => {
+	const { data: enabled } = useQuery({
+		...guiSettingsQueryOptions,
+		select: (settings) => settings.desktopNotifications ?? defaultSettings.desktopNotifications,
+	});
+	return enabled ?? defaultSettings.desktopNotifications;
+};
+
 /** Watermark by review number, as the ISO stamps the forge reports. */
 type SeenMarks = Record<number, string>;
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/Settings/General.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Settings/General.tsx
@@ -114,6 +114,19 @@ export const General: FC = () => {
 						<option value="off">Off</option>
 					</select>
 				</Row>
+
+				<Row
+					label="Desktop notifications"
+					labelId="desktop-notifications"
+					hint="Loud activity that arrives while Lite is in the background is also shown by the system."
+				>
+					<Switch
+						aria-labelledby="desktop-notifications"
+						checked={settings.desktopNotifications ?? defaultSettings.desktopNotifications}
+						disabled={(settings.prNotifications ?? defaultSettings.prNotifications) !== "loud"}
+						onCheckedChange={(desktopNotifications) => saveGUISettings({ desktopNotifications })}
+					/>
+				</Row>
 			</Section>
 
 			<Section heading="Danger zone">

--- a/apps/lite/ui/src/settings.ts
+++ b/apps/lite/ui/src/settings.ts
@@ -6,6 +6,9 @@ export const defaultSettings = {
 	autoFetchFrequency: "15 min",
 	autoUpdate: true,
 	commentAnnotations: false,
+	// Loud activity arriving while the window is unfocused also reaches the
+	// desktop; the bell alone cannot be seen from another app.
+	desktopNotifications: true,
 	diffBackground: true,
 	diffFontFamily: "Geist Mono, Menlo, monospace",
 	diffFontSize: 12,


### PR DESCRIPTION
Two changes to Lite's PR-activity notifications, both driven by actionability: what happened, to what, and by whom.

## Rows

- The first line is now the event and its actor: `Changes requested by alice`, `3 comments from dave`, `Review requested by erin`.
- The second line is the target: branch name, then `#N`. The PR title moves to the row's tooltip.
- The snippet, when there is one, stays on the third line.
- Loud kinds (comments, mentions, verdicts, review requests) take the strong text color. Quiet kinds (pushes, merges, closes) sit muted.
- Icons carry meaning: warn for changes requested, safe for approved, pop for mentions.

## Desktop notifications

- Loud entries also show as a system notification, through a new `showNotification` host member. The main process decides whether the window is focused, because a freshly loaded document reports `document.hasFocus()` true while the window sits behind another app. A click focuses the window and lands on the entry, on the same path as a bell click.
- A refused notification is logged with the OS reason. On macOS the ad-hoc signed dev Electron is always refused (`UNErrorDomain error 1`), so this can only be seen on a signed build.
- More than three loud entries in one poll collapse into one summary notification.
- The review listing stops polling in an unfocused window, which is exactly when a desktop notification is the only way to be heard. The detector polls in the background while the setting is on.
- New `desktopNotifications` setting, on by default, disabled unless PR activity is set to Loud.

## Notes

- The loud/quiet split is one table, `inboxKindAttention`, used by both the row weight and the desktop gate.
- Entry navigation moved from the bell into the detector hook so the harness panel, which mounts the hook but not the bell, exercises the notification click end to end.
- Bot comments are still loud, and your own PRs on unapplied branches still only surface mentions. Both are worth a follow-up.
- The app is expected to be running for a desktop notification to arrive: hidden or behind another app is fine, quit is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
