### PR TITLE
Run a target-less stack on the trunk

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/layout.test.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/layout.test.ts
@@ -162,6 +162,17 @@ describe("layout", () => {
 		]);
 	});
 
+	it("puts the sole stack on the trunk when there is no target", () => {
+		const target = {
+			remoteTrackingRef: { fullNameBytes: [], displayName: "origin/main", remoteName: "origin" },
+			commitsAhead: 0,
+			isCurrent: true,
+		};
+		expect(layout([stack(null)], null, undefined, folded).stackOnTrunk).toBe(true);
+		expect(layout([stack(null), stack(null)], null, undefined, folded).stackOnTrunk).toBe(false);
+		expect(layout([stack(null)], target, undefined, folded).stackOnTrunk).toBe(false);
+	});
+
 	it("knows when the target's tip is the base itself", () => {
 		const current: TargetCommitPage = { commits: [commit("shallow", true)], hasMore: false };
 		expect(layout([stack("shallow")], null, current, folded).refOnBase).toBe(true);

--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/layout.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/layout.ts
@@ -66,6 +66,8 @@ export type Plan = {
 	header: { label: string; incoming: number };
 	/** The target's tip is the base itself: one row stands for both. */
 	refOnBase: boolean;
+	/** No target: the sole stack is the main line, so it runs on the trunk instead of a column off it. */
+	stackOnTrunk: boolean;
 	incomingExpanded: boolean;
 	baseExpanded: boolean;
 	/** The commit the stacks nearest the tip sit on; the base header names it. Null while unknown. */
@@ -172,6 +174,7 @@ export const layout = (
 			base !== null &&
 			commits[0]?.commit.id === base.commit.id &&
 			commits.every((entry) => entry.inWorkspace),
+		stackOnTrunk: target === null && stacks.length === 1,
 		incomingExpanded: folds.incomingExpanded,
 		baseExpanded: folds.baseExpanded,
 		base,

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/BranchRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/BranchRow.tsx
@@ -139,7 +139,8 @@ export const BranchRow: FC<
 		recordedPullRequest: number | null;
 		graphStatus: GraphSegmentStatus;
 		bottomRelativeTo: RelativeTo | null;
-		isTopSegment: boolean;
+		/** The tick starts the rail, with nothing above it: a lower branch's, or the trunk's, runs on up. */
+		startsRail: boolean;
 		commitCount: number;
 		/** The rail below the branch's tick: its first commit's colour, or plain without one. */
 		railBelow: GraphSegmentStatus;
@@ -162,7 +163,7 @@ export const BranchRow: FC<
 	recordedPullRequest,
 	graphStatus,
 	bottomRelativeTo,
-	isTopSegment,
+	startsRail,
 	commitCount,
 	railBelow,
 	behind,
@@ -494,7 +495,7 @@ export const BranchRow: FC<
 									// The glyph describes where the branch sits in the stack, so it
 									// does not change with fold state.
 									<GraphSegment
-										glyph={isTopSegment ? "forkRight" : "joinRight"}
+										glyph={startsRail ? "forkRight" : "joinRight"}
 										status={graphStatus}
 										above="LocalOnly"
 										below={railBelow}
@@ -519,7 +520,7 @@ export const BranchRow: FC<
 				</Tooltip.Root>
 			) : (
 				<GraphSegment
-					glyph={isTopSegment ? "forkRight" : "joinRight"}
+					glyph={startsRail ? "forkRight" : "joinRight"}
 					status={graphStatus}
 					above="LocalOnly"
 					below={railBelow}

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/CommitRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/CommitRow.tsx
@@ -62,6 +62,8 @@ export const CommitRow: FC<
 		below?: GraphSegmentStatus;
 		/** Columns of the main line running behind the row, left of its rail. */
 		behind?: number;
+		/** The rail ends on this commit: a root, with nothing below to run on to. */
+		railEnds?: boolean;
 	} & ComponentProps<"div">
 > = ({
 	commit,
@@ -73,6 +75,7 @@ export const CommitRow: FC<
 	canAmendCommit,
 	below,
 	behind,
+	railEnds,
 	...restProps
 }) => {
 	const { data: forgeInfo } = useQuery(forgeInfoOptions(projectId));
@@ -395,6 +398,7 @@ export const CommitRow: FC<
 					status={commitIsDiverged(commit) ? "Diverged" : commit.state.type}
 					below={below}
 					behind={behind}
+					railEnds={railEnds}
 				/>
 				<Tooltip.Root
 					// This gets in the way when the user tries to move their hover to a

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.tsx
@@ -547,8 +547,10 @@ const BranchSegment: FC<{
 	canRemoveBranch: boolean;
 	downstackPushStatus: DownstackPushStatus;
 	pushActivity: PushActivity;
-	isTopSegment: boolean;
+	startsRail: boolean;
 	behind: number;
+	/** The rail ends on this segment's last commit. */
+	railEnds: boolean;
 	checkCommit: (evt: { commitId: string; shiftKey: boolean }) => void;
 	onAmendCommit: (commitId: string) => void;
 	canAmendCommit: boolean;
@@ -569,8 +571,9 @@ const BranchSegment: FC<{
 	canRemoveBranch,
 	downstackPushStatus,
 	pushActivity,
-	isTopSegment,
+	startsRail,
 	behind,
+	railEnds,
 	checkCommit,
 	onAmendCommit,
 	canAmendCommit,
@@ -619,7 +622,7 @@ const BranchSegment: FC<{
 				recordedPullRequest={recordedPullRequest(segment)}
 				graphStatus={segmentPushStatusToGraphSegmentStatus(segment.pushStatus)}
 				bottomRelativeTo={segmentBottomRelativeTo(segment)}
-				isTopSegment={isTopSegment}
+				startsRail={startsRail}
 				commitCount={segment.commits.length}
 				railBelow={railBelow}
 				behind={behind}
@@ -641,6 +644,7 @@ const BranchSegment: FC<{
 					segment={segment}
 					stackId={stack.id}
 					behind={behind}
+					railEnds={railEnds}
 					checkCommit={checkCommit}
 					onAmendCommit={onAmendCommit}
 					canAmendCommit={canAmendCommit}
@@ -703,6 +707,8 @@ const SegmentContent: FC<{
 	positionOffset: number;
 	setSize: number;
 	behind: number;
+	/** The rail ends on the segment's last commit. */
+	railEnds: boolean;
 }> = ({
 	projectId,
 	segment,
@@ -721,6 +727,7 @@ const SegmentContent: FC<{
 	positionOffset,
 	setSize,
 	behind,
+	railEnds,
 }) => {
 	const getCommitKey = useCallback(
 		(index: number) => segment.commits[index]?.id ?? index,
@@ -815,6 +822,7 @@ const SegmentContent: FC<{
 						commit={commit}
 						below={next === undefined ? "LocalOnly" : commitGraphStatus(next)}
 						behind={behind}
+						railEnds={railEnds && next === undefined}
 						projectId={projectId}
 						stackId={stackId}
 						checkCommit={checkCommit}
@@ -844,6 +852,7 @@ const CommitItem: FC<{
 	commit: Commit;
 	below: GraphSegmentStatus;
 	behind: number;
+	railEnds: boolean;
 	projectId: string;
 	stackId: string | null;
 	checkCommit: (evt: { commitId: string; shiftKey: boolean }) => void;
@@ -859,6 +868,7 @@ const CommitItem: FC<{
 	commit,
 	below,
 	behind,
+	railEnds,
 	projectId,
 	stackId,
 	checkCommit,
@@ -899,6 +909,7 @@ const CommitItem: FC<{
 								commit={commit}
 								below={below}
 								behind={behind}
+								railEnds={railEnds}
 								stackId={stackId}
 								checkCommit={checkCommit}
 								amendCommit={() => onAmendCommit(commit.id)}
@@ -931,7 +942,9 @@ const SegmentRailConnector: FC<{
 	projectId: string;
 	segment: Segment;
 	behind: number;
-}> = ({ projectId, segment, behind }) => {
+	/** The rail ended on the segment's last commit: the connector is only the card's floor. */
+	railEnds: boolean;
+}> = ({ projectId, segment, behind, railEnds }) => {
 	const addressSpace = useAddressSpace();
 
 	// A plain boolean, so this re-renders only when this segment's own fold
@@ -959,7 +972,7 @@ const SegmentRailConnector: FC<{
 			inert={!addressSpaceIncludes(addressSpace, standsFor, addressIdentityKey)}
 		>
 			{/* Plain: a branch's colour runs from its tick down to its commits, not past them. */}
-			<GraphSegment glyph="parent" status="LocalOnly" behind={behind} />
+			<GraphSegment glyph={railEnds ? "space" : "parent"} status="LocalOnly" behind={behind} />
 		</Row>
 	);
 };
@@ -978,6 +991,8 @@ const StackC: FC<
 		stackSize: number;
 		/** The list's start in the scroller, which the card's own position is from. */
 		scrollMargin: number;
+		/** The stack is the main line itself, with no target to fork from: see the layout's plan. */
+		onTrunk: boolean;
 		selectedSegmentIndex: number | undefined;
 		selectedCommitIndex: number | undefined;
 	} & ComponentProps<"div">
@@ -993,6 +1008,7 @@ const StackC: FC<
 	stackScrollStart,
 	stackSize,
 	scrollMargin,
+	onTrunk,
 	selectedSegmentIndex,
 	selectedCommitIndex,
 	...props
@@ -1013,8 +1029,12 @@ const StackC: FC<
 		width: "100%",
 		transform: `translateY(${stackScrollStart - scrollMargin}px)`,
 	};
-	// Every card is a lane off the trunk, which runs behind it.
-	const behind = 1;
+	// A card is a lane off the trunk, which runs behind it, unless it is the trunk.
+	const behind = onTrunk ? 0 : 1;
+	// The trunk's rail ends where the history does. A traversal cut short leaves a
+	// commit with parents, and the line runs on past it as it does under any card.
+	const lastCommit = stack.segments.at(-1)?.commits.at(-1);
+	const railEnds = onTrunk && lastCommit !== undefined && lastCommit.parentIds.length === 0;
 	const topmostPendingPushIndex = stack.segments.findIndex(
 		(segment) =>
 			segment.refName && pendingPushBranches.has(decodeBytes(segment.refName.fullNameBytes)),
@@ -1039,7 +1059,7 @@ const StackC: FC<
 				aria-label="Stack"
 			>
 				<Row interactive={false} className={styles.pad}>
-					<GraphSegment glyph="space" status="LocalOnly" behind={behind} />
+					<GraphSegment glyph={onTrunk ? "parent" : "space"} status="LocalOnly" behind={behind} />
 				</Row>
 				{stack.segments.map((segment, index) => {
 					// oxlint-disable-next-line typescript/no-non-null-assertion -- Equivalent iteration above.
@@ -1074,8 +1094,9 @@ const StackC: FC<
 										canRemoveBranch={canRemoveBranchReference(stack, index)}
 										downstackPushStatus={downstackPushStatus}
 										pushActivity={pushActivity}
-										isTopSegment={index === 0}
+										startsRail={index === 0 && !onTrunk}
 										behind={behind}
+										railEnds={railEnds && index === stack.segments.length - 1}
 										checkCommit={checkCommit}
 										onAmendCommit={onAmendCommit}
 										canAmendCommit={canAmendCommit}
@@ -1097,6 +1118,7 @@ const StackC: FC<
 										positionOffset={segmentPositionOffset}
 										setSize={rootSetSize}
 										behind={behind}
+										railEnds={railEnds && index === stack.segments.length - 1}
 										projectId={projectId}
 										segment={segment}
 										stackId={stack.id}
@@ -1114,12 +1136,21 @@ const StackC: FC<
 									/>
 								)}
 							</div>
-							<SegmentRailConnector projectId={projectId} segment={segment} behind={behind} />
+							<SegmentRailConnector
+								projectId={projectId}
+								segment={segment}
+								behind={behind}
+								railEnds={railEnds && index === stack.segments.length - 1}
+							/>
 						</Fragment>
 					);
 				})}
 			</StackCard>
-			<GraphGap height={CARD_GAP} bend="LocalOnly" />
+			{railEnds ? (
+				<div style={{ height: CARD_GAP }} aria-hidden />
+			) : (
+				<GraphGap height={CARD_GAP} bend={onTrunk ? undefined : "LocalOnly"} />
+			)}
 		</div>
 	);
 };
@@ -1438,6 +1469,7 @@ const Stacks: FC<{
 									stackScrollStart={virtualRow.start}
 									stackSize={virtualRow.size}
 									scrollMargin={scrollMargin}
+									onTrunk={plan.stackOnTrunk}
 									selectedSegmentIndex={
 										selectedStackIndex === virtualRow.index ? selectedSegmentIndex : undefined
 									}


### PR DESCRIPTION

A repository with no target (a fresh `git init`, or a remote never fetched) got drawn as if it forked off something: the branch a column to the right, a bend under it, and a stub of main line leading nowhere.

- The layout plan now marks the sole stack as the trunk itself when there is no target.
- The card sits in the first column, its branch tick joins the line running up to the uncommitted files, and the rail ends on the root commit.
- A traversal cut short leaves a commit with parents, so the line runs on past it instead of claiming a root.
- `isTopSegment` on the branch row becomes `startsRail`, which is the only thing it decided.

Repositories with a target draw exactly as before.

## Screenshots

A freshly initialised repository with one commit, captured ad hoc at 415841d.

### Before

![no-target-before](https://raw.githubusercontent.com/gitbutlerapp/gitbutler/pr-screenshots/pr-15819/415841d/no-target-before.png)

### After

![no-target-after](https://raw.githubusercontent.com/gitbutlerapp/gitbutler/pr-screenshots/pr-15819/415841d/no-target-after.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
