### PR TITLE
Let Escape leave an inline edit from anywhere in Lite

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/InlineEditor.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/InlineEditor.tsx
@@ -35,10 +35,11 @@ export const InlineEditor: FC<{
 		target: textFieldRef,
 	});
 
+	// Not scoped to the text field: the other rows are inert while an edit is pending, but a
+	// click on one still moves focus into the tree, and Escape has to keep working from there.
 	useHotkey("Escape", onExit, {
 		conflictBehavior: "allow",
 		ignoreInputs: false,
-		target: textFieldRef,
 	});
 
 	const allTextFieldRefs = useMergedRefs(textFieldRef, (el) => {


### PR DESCRIPTION
Select a commit, press `r`, click another commit, press Escape: the editor stayed open and only the Cancel button worked.

- The editor bound Escape to its own text field.
- Other rows are inert during an edit, but clicking one still moves focus into the tree, so Escape never reached the editor.
- Escape is now bound at the document level while the editor is mounted. Enter stays scoped to the text field.

Verified in the running dev app over CDP with the exact sequence; Escape from inside the field still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)