### PR TITLE
Serve the but skill from the CLI

### DIFF
--- a/crates/but/skill/AGENTS.md
+++ b/crates/but/skill/AGENTS.md
@@ -3,7 +3,8 @@
 `SKILL.md` and `references/` are installed verbatim into users' agents — a wrong
 line here misdirects every agent in every user repo. Only the files in
 `SKILL_FILES` in `crates/but/src/command/skill/mod.rs` ship, so register any new
-reference file there.
+reference file there. `stub.md` is the body of the single-file stub install and
+must only point at `but skill` commands; it carries no facts about `but`.
 
 - **Never document anything that can block on a TTY.** An editor or interactive
   picker hangs an agent forever. Give the non-interactive form (`-m`,

--- a/crates/but/skill/README.md
+++ b/crates/but/skill/README.md
@@ -40,6 +40,18 @@ but skill install
 
 This will overwrite the existing skill files with the latest version.
 
+## Printing the skill from the CLI
+
+The same content is embedded in the binary and can be read without installing anything:
+
+```bash
+but skill                # SKILL.md body
+but skill --full         # plus every reference file
+but skill reference      # one reference: reference | concepts | examples
+```
+
+Pointers inside the skill files use these commands rather than file paths, so they resolve whether the agent loaded an installed copy or read the CLI output.
+
 ## Skill Structure
 
 The skill directory contains both distributable skill files and development documentation:

--- a/crates/but/skill/SKILL.md
+++ b/crates/but/skill/SKILL.md
@@ -57,7 +57,7 @@ The first token on each `but diff` / `but status` line is that line's ID. When a
 2. Mutation commands print their result without appending workspace status. Add `--status-after` only when the next step needs resulting workspace IDs or details; otherwise trust the mutation result and do not run a verification status/diff.
 3. Branches marked `(merged upstream)` have landed; run `but pull` to remove them, or start new work on another branch. `push` and mutations (`commit`, `amend`, `squash`, `uncommit`, `reword`, `move`) refuse landed branches and commits, `absorb` skips them with a notice, and `commit` skips them when picking a default target.
 4. In non-interactive CLI workflows, do not narrate progress between routine commands. Execute the needed `but` commands and give a concise final summary.
-5. Prefer this skill and `references/reference.md` over exploratory help calls. Use `<command> --help` when required syntax is missing or a command fails; use top-level help only when you genuinely need to discover an undocumented command.
+5. Prefer this skill and `but skill reference` over exploratory help calls. Use `<command> --help` when required syntax is missing or a command fails; use top-level help only when you genuinely need to discover an undocumented command.
 
 ## Command Patterns
 
@@ -158,7 +158,7 @@ To make one existing branch depend on another: `but move <child-branch-name> --a
 
 `but pr new <branch-name>` pushes the selected branch and its ancestors, then creates the PR in one step — no prior `but push`. Provide `-F pr_message.txt`, `-t`, or `-m` with real newlines (zsh/bash: `-m $'Title\n\nBody'`) so no editor opens. If forge auth is missing, run `but config forge auth`.
 
-If you do create a PR for a stacked branch, use `but pr` — not `gh pr create` (only `but pr` sets PR bases and stack metadata; `gh pr create` breaks that). To publish a whole stack: `but pr new <top-branch-name> -t`. Manage with `but pr auto-merge|set-draft|set-ready <selector>`; selectors can be a branch name, current branch/stack CLI ID, or numeric review ID. See `references/reference.md` for details.
+If you do create a PR for a stacked branch, use `but pr` — not `gh pr create` (only `but pr` sets PR bases and stack metadata; `gh pr create` breaks that). To publish a whole stack: `but pr new <top-branch-name> -t`. Manage with `but pr auto-merge|set-draft|set-ready <selector>`; selectors can be a branch name, current branch/stack CLI ID, or numeric review ID. See `but skill reference` for details.
 
 ### Dependency conflict with another branch
 
@@ -215,6 +215,6 @@ A wrong resolution is reverted with `but undo`.
 
 - Read-only git inspection (`git log`, `git blame`, `git show --stat`) is allowed.
 - If `but` prints an `AGENT ACTION REQUIRED` skill warning, run the suggested command once, then reload/use the GitButler skill. If it repeats, report it instead of retrying.
-- For command syntax and flags: `references/reference.md`
-- For workspace model: `references/concepts.md`
-- For workflow examples: `references/examples.md`
+- For command syntax and flags: `but skill reference`
+- For workspace model: `but skill concepts`
+- For workflow examples: `but skill examples`

--- a/crates/but/skill/references/reference.md
+++ b/crates/but/skill/references/reference.md
@@ -204,7 +204,7 @@ Running `but commit` from inside a worktree acts on the main workspace, exactly 
 
 **Placing commits:** Use `--above <target>` or `--below <target>` when the new commit should be inserted at a specific position in existing history. Change-ID refs of existing commits remain valid after an insertion; sha and `#N`-suffixed refs may go stale — add `--status-after` when subsequent history edits need fresh refs.
 
-**Several commits from one diff:** Chain `but commit` calls with `&&` to split a broad uncommitted change into several semantic commits: `but commit -b <branch> -m "msg1" a1 b2 && but commit -b <branch> -m "msg2" c3 d4`. Mutation output is concise by default. Add `--status-after` only when the next step needs workspace IDs or details that the mutation result does not provide. The commits stack in the order you write them — the first `but commit` is the oldest of the new commits and each later one goes on top (newest). File/hunk IDs copied from the original output generally remain usable across commits; if an ID stops resolving, re-read the diff and continue. History edits (`amend`, `squash`, `move`, `uncommit`, `reword`) may run in sequence off one status read when every commit ref involved is a change-ID ref; run them one at a time with `--status-after` when a ref is sha-based or `#N`-suffixed, or when the next command needs freshly issued IDs. Bare `but diff` needs no ID from the preceding command, so `but uncommit <id> && but diff` is safe. If commits from that branch must stay *above* the new ones, see "Split an existing commit" in SKILL.md: commit the replacements, then move the preserved block together with `but move <preserved-id> [<preserved-id>...] -b <branch>` so its internal order stays intact.
+**Several commits from one diff:** Chain `but commit` calls with `&&` to split a broad uncommitted change into several semantic commits: `but commit -b <branch> -m "msg1" a1 b2 && but commit -b <branch> -m "msg2" c3 d4`. Mutation output is concise by default. Add `--status-after` only when the next step needs workspace IDs or details that the mutation result does not provide. The commits stack in the order you write them — the first `but commit` is the oldest of the new commits and each later one goes on top (newest). File/hunk IDs copied from the original output generally remain usable across commits; if an ID stops resolving, re-read the diff and continue. History edits (`amend`, `squash`, `move`, `uncommit`, `reword`) may run in sequence off one status read when every commit ref involved is a change-ID ref; run them one at a time with `--status-after` when a ref is sha-based or `#N`-suffixed, or when the next command needs freshly issued IDs. Bare `but diff` needs no ID from the preceding command, so `but uncommit <id> && but diff` is safe. If commits from that branch must stay *above* the new ones, see "Split an existing commit" in `but skill`: commit the replacements, then move the preserved block together with `but move <preserved-id> [<preserved-id>...] -b <branch>` so its internal order stays intact.
 
 Example: `but commit -b my-branch -m "Fix bug" ab cd` commits files/hunks `ab` and `cd`.
 
@@ -627,9 +627,14 @@ but update install [nightly|release|0.18.7]
 
 ### `but skill`
 
-Manage installed GitButler skill files.
+Print this skill from the CLI, or manage installed skill files.
 
 ```bash
+but skill                     # Core guide (this skill's SKILL.md body)
+but skill --full              # Core guide plus every reference
+but skill reference           # Command syntax and flags
+but skill concepts            # Workspace model
+but skill examples            # Workflow examples
 but skill check
 but skill check --update
 but skill install --detect

--- a/crates/but/skill/stub.md
+++ b/crates/but/skill/stub.md
@@ -1,0 +1,16 @@
+# GitButler CLI Skill
+
+This file is a discovery stub, not the usage guide. Before your first `but` command, load the guide from the CLI so it always matches the installed version:
+
+```bash
+but skill                       # the loop, IDs, rules, task recipes
+but skill --full                # plus command reference, concepts, examples
+```
+
+Load one reference directly when you know what you need:
+
+```bash
+but skill reference             # command syntax and flags
+but skill concepts              # workspace model
+but skill examples              # workflows
+```

--- a/crates/but/src/args/agent.rs
+++ b/crates/but/src/args/agent.rs
@@ -32,5 +32,9 @@ pub enum Subcommands {
         /// Print the default generated steering text without prompting or modifying files.
         #[clap(long)]
         print: bool,
+        /// Install discovery stubs that point agents at `but skill` instead of
+        /// the full skill files. Team-internal while the approach is evaluated.
+        #[clap(long, hide = true)]
+        stub: bool,
     },
 }

--- a/crates/but/src/args/metrics.rs
+++ b/crates/but/src/args/metrics.rs
@@ -76,6 +76,7 @@ pub enum CommandName {
     Onboarding,
     AgentLog,
     Actions,
+    Skill,
     SkillInstall,
     SkillCheck,
     AgentSetup,

--- a/crates/but/src/args/skill.rs
+++ b/crates/but/src/args/skill.rs
@@ -1,12 +1,36 @@
 /// Arguments for skill management commands
 #[derive(Debug, clap::Parser)]
+#[clap(args_conflicts_with_subcommands = true)]
 pub struct Platform {
+    /// Running `but skill` with no subcommand prints the core skill guide.
     #[clap(subcommand)]
-    pub cmd: Subcommands,
+    pub cmd: Option<Subcommands>,
+    /// Also print every reference document after the core guide.
+    #[clap(long)]
+    pub full: bool,
+}
+
+impl Platform {
+    /// The embedded document a read-only invocation prints, if this is one.
+    pub fn doc(&self) -> Option<&'static str> {
+        match self.cmd {
+            None => Some("core"),
+            Some(Subcommands::Reference) => Some("reference"),
+            Some(Subcommands::Concepts) => Some("concepts"),
+            Some(Subcommands::Examples) => Some("examples"),
+            Some(Subcommands::Install { .. } | Subcommands::Check { .. }) => None,
+        }
+    }
 }
 
 #[derive(Debug, clap::Subcommand)]
 pub enum Subcommands {
+    /// Print the command reference: syntax and flags for every `but` command
+    Reference,
+    /// Print the concepts guide: the workspace model behind `but`
+    Concepts,
+    /// Print the workflow examples
+    Examples,
     /// Install the GitButler CLI skill files for Coding agents
     ///
     /// By default, the command prompts you to choose installation scope first
@@ -63,6 +87,10 @@ pub enum Subcommands {
         /// found in the current scope (local before global)
         #[clap(long, short = 'd')]
         detect: bool,
+        /// Install a discovery stub that points agents at `but skill` instead of
+        /// the full skill files. Team-internal while the approach is evaluated.
+        #[clap(long, hide = true)]
+        stub: bool,
     },
     /// Check if installed GitButler skills are up to date with the CLI version
     ///

--- a/crates/but/src/args/tests.rs
+++ b/crates/but/src/args/tests.rs
@@ -170,7 +170,7 @@ mod agent_setup {
 
         match cmd {
             Subcommands::Agent(AgentPlatform {
-                cmd: Some(AgentCmd::Setup { print }),
+                cmd: Some(AgentCmd::Setup { print, .. }),
             }) => assert!(!print),
             _ => panic!("unexpected command shape"),
         }
@@ -183,7 +183,7 @@ mod agent_setup {
 
         match cmd {
             Subcommands::Agent(AgentPlatform {
-                cmd: Some(AgentCmd::Setup { print }),
+                cmd: Some(AgentCmd::Setup { print, .. }),
             }) => assert!(print),
             _ => panic!("unexpected command shape"),
         }

--- a/crates/but/src/command/agent/mod.rs
+++ b/crates/but/src/command/agent/mod.rs
@@ -8,7 +8,10 @@ use nonempty::NonEmpty;
 
 use crate::{
     args::agent,
-    command::{CommandOutcome, skill},
+    command::{
+        CommandOutcome,
+        skill::{self, SkillLayout},
+    },
     theme::{self, Paint},
     utils::{InputOutputChannel, OutputChannel, PromptLine, detect_agent},
 };
@@ -48,12 +51,24 @@ pub fn handle(
 ) -> Result<CommandOutcome> {
     match cmd {
         // Bare `but agent` runs the setup wizard, same as `but agent setup`.
-        None => setup(current_dir, out, false),
-        Some(agent::Subcommands::Setup { print }) => setup(current_dir, out, print),
+        None => setup(current_dir, out, false, SkillLayout::Full),
+        Some(agent::Subcommands::Setup { print, stub }) => {
+            let layout = if stub {
+                SkillLayout::Stub
+            } else {
+                SkillLayout::Full
+            };
+            setup(current_dir, out, print, layout)
+        }
     }
 }
 
-fn setup(current_dir: &Path, out: &mut OutputChannel, print_only: bool) -> Result<CommandOutcome> {
+fn setup(
+    current_dir: &Path,
+    out: &mut OutputChannel,
+    print_only: bool,
+    skill_layout: SkillLayout,
+) -> Result<CommandOutcome> {
     if print_only {
         let default_policy = render_managed_policy_block(&WizardAnswers::default());
         print_policy(out, &default_policy)?;
@@ -76,7 +91,7 @@ fn setup(current_dir: &Path, out: &mut OutputChannel, print_only: bool) -> Resul
     drop(input);
 
     match plan {
-        Some(plan) => apply_plan(out, current_dir, &plan),
+        Some(plan) => apply_plan(out, current_dir, &plan, skill_layout),
         None => {
             print_cancelled(out)?;
             Ok(CommandOutcome::AgentSetupCancelled)
@@ -713,7 +728,12 @@ fn write_policy_preview(writer: &mut impl fmt::Write, policy: &str) -> fmt::Resu
     Ok(())
 }
 
-fn apply_plan(out: &mut OutputChannel, current_dir: &Path, plan: &Plan) -> Result<CommandOutcome> {
+fn apply_plan(
+    out: &mut OutputChannel,
+    current_dir: &Path,
+    plan: &Plan,
+    skill_layout: SkillLayout,
+) -> Result<CommandOutcome> {
     // Run `but setup` first: it is the step most likely to fail (it needs a
     // discoverable repo + project registration) and aborts before any file is
     // written, keeping the intro's "nothing is written until you confirm"
@@ -724,7 +744,7 @@ fn apply_plan(out: &mut OutputChannel, current_dir: &Path, plan: &Plan) -> Resul
     }
 
     for install in &plan.skill_installs {
-        skill::write_skill_files(&install.path)
+        skill::write_skill_files(&install.path, skill_layout)
             .with_context(|| format!("Failed to install skill at {}", install.path.display()))?;
     }
 

--- a/crates/but/src/command/skill/freshness.rs
+++ b/crates/but/src/command/skill/freshness.rs
@@ -5,8 +5,9 @@
 use std::path::PathBuf;
 
 use super::{
-    check_skill_status, find_format_installations, home_dir, is_current_skill_installation,
-    skill_format_for_agent, skill_format_for_name, write_skill_files,
+    SkillLayout, check_skill_status, find_format_installations, home_dir,
+    is_current_skill_installation, skill_format_for_agent, skill_format_for_name,
+    write_skill_files,
 };
 use crate::{
     theme,
@@ -79,7 +80,7 @@ fn agent_skill_freshness_check() -> Option<AgentSkillNotice> {
     }
     let mut update_error = None;
     for path in outdated {
-        if let Err(err) = write_skill_files(&path) {
+        if let Err(err) = write_skill_files(&path, SkillLayout::Full) {
             tracing::debug!(?err, ?path, "failed to update the agent skill");
             if update_error.is_none() {
                 update_error = Some(err);
@@ -261,7 +262,7 @@ mod tests {
         let local = skill_format_for_agent(Agent::Codex, false)
             .unwrap()
             .get_install_path(dir.path());
-        write_skill_files(&local).unwrap();
+        write_skill_files(&local, SkillLayout::Full).unwrap();
 
         assert!(
             !agent_skill_installations(Agent::Codex, None)

--- a/crates/but/src/command/skill/mod.rs
+++ b/crates/but/src/command/skill/mod.rs
@@ -34,6 +34,8 @@ const SKILL_MD: &[u8] = include_bytes!("../../../skill/SKILL.md");
 const CONCEPTS_MD: &[u8] = include_bytes!("../../../skill/references/concepts.md");
 const EXAMPLES_MD: &[u8] = include_bytes!("../../../skill/references/examples.md");
 const REFERENCE_MD: &[u8] = include_bytes!("../../../skill/references/reference.md");
+/// Body of a stub SKILL.md: the full skill's frontmatter followed by this.
+const STUB_MD: &str = include_str!("../../../skill/stub.md");
 
 /// Metadata for a skill file to be installed
 struct SkillFile {
@@ -41,8 +43,8 @@ struct SkillFile {
     path_components: &'static [&'static str],
     /// Embedded content
     content: &'static [u8],
-    /// Display name for output
-    display_name: &'static str,
+    /// Name of the document as `but skill <name>` prints it.
+    name: &'static str,
 }
 
 impl SkillFile {
@@ -62,34 +64,48 @@ impl SkillFile {
     }
 }
 
-/// All skill files to be installed
+/// All skill files to be installed, in the order `but skill --full` prints them.
 const SKILL_FILES: &[SkillFile] = &[
     SkillFile {
         path_components: &["SKILL.md"],
         content: SKILL_MD,
-        display_name: "SKILL.md",
-    },
-    SkillFile {
-        path_components: &["references", "concepts.md"],
-        content: CONCEPTS_MD,
-        display_name: "concepts.md",
-    },
-    SkillFile {
-        path_components: &["references", "examples.md"],
-        content: EXAMPLES_MD,
-        display_name: "examples.md",
+        name: "core",
     },
     SkillFile {
         path_components: &["references", "reference.md"],
         content: REFERENCE_MD,
-        display_name: "reference.md",
+        name: "reference",
+    },
+    SkillFile {
+        path_components: &["references", "concepts.md"],
+        content: CONCEPTS_MD,
+        name: "concepts",
+    },
+    SkillFile {
+        path_components: &["references", "examples.md"],
+        content: EXAMPLES_MD,
+        name: "examples",
     },
 ];
 
-fn skill_files_in_write_order() -> impl Iterator<Item = &'static SkillFile> {
+/// Which files an installation carries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SkillLayout {
+    /// SKILL.md plus every reference file.
+    Full,
+    /// A single SKILL.md whose body tells the agent to run `but skill`. Carries
+    /// the same frontmatter as the full skill plus `stub: true` and a
+    /// pre-approval for the `but skill` read so the redirect never waits on
+    /// a permission prompt.
+    Stub,
+}
+
+/// The files a layout consists of, SKILL.md last so a partial write never
+/// looks like a complete installation.
+fn skill_files_in_write_order(layout: SkillLayout) -> impl Iterator<Item = &'static SkillFile> {
     SKILL_FILES
         .iter()
-        .filter(|file| !file.is_main_skill_file())
+        .filter(move |file| layout == SkillLayout::Full && !file.is_main_skill_file())
         .chain(SKILL_FILES.iter().filter(|file| file.is_main_skill_file()))
 }
 
@@ -372,27 +388,90 @@ pub struct SkillCheckResult {
     pub outdated_count: usize,
 }
 
-/// Handle skill subcommands
+/// Handle skill subcommands. Bare `but skill` prints the core guide.
 pub fn handle(
     ctx: Option<&mut Context>,
     out: &mut OutputChannel,
-    cmd: skill::Subcommands,
+    platform: skill::Platform,
 ) -> Result<()> {
-    match cmd {
-        skill::Subcommands::Install {
+    if let Some(doc) = platform.doc() {
+        return print_doc(out, doc, platform.full);
+    }
+    match platform.cmd {
+        Some(skill::Subcommands::Install {
             global,
             path,
             detect,
-        } => match install_skill(ctx, out, global, path, detect) {
-            Err(error) if error.downcast_ref::<UserCancelled>().is_some() => Ok(()),
-            result => result,
-        },
-        skill::Subcommands::Check {
+            stub,
+        }) => {
+            let layout = if stub {
+                SkillLayout::Stub
+            } else {
+                SkillLayout::Full
+            };
+            match install_skill(ctx, out, global, path, detect, layout) {
+                Err(error) if error.downcast_ref::<UserCancelled>().is_some() => Ok(()),
+                result => result,
+            }
+        }
+        Some(skill::Subcommands::Check {
             global,
             local,
             update,
-        } => check_skills(ctx, out, global, local, update),
+        }) => check_skills(ctx, out, global, local, update),
+        None
+        | Some(
+            skill::Subcommands::Reference
+            | skill::Subcommands::Concepts
+            | skill::Subcommands::Examples,
+        ) => unreachable!("read-only invocations are handled by Platform::doc"),
     }
+}
+
+/// Print one embedded skill document, with every reference appended when
+/// `full` is set. Content goes straight to the output channel with no pager so
+/// an agent can read it in one call.
+fn print_doc(out: &mut OutputChannel, name: &str, full: bool) -> Result<()> {
+    let file = SKILL_FILES
+        .iter()
+        .find(|file| file.name == name)
+        .expect("every doc subcommand names an embedded skill file");
+    let content = std::str::from_utf8(file.content)
+        .with_context(|| format!("{} is not valid UTF-8", file.display_path()))?;
+    // The frontmatter is trigger text for the harness, not guidance. Only
+    // SKILL.md carries one; a `---` rule inside a reference must stay.
+    let body = match frontmatter_close(content) {
+        Some(close) if file.is_main_skill_file() => &content[close.end..],
+        _ => content,
+    };
+    let references: Vec<&SkillFile> = if full {
+        SKILL_FILES
+            .iter()
+            .filter(|file| !file.is_main_skill_file())
+            .collect()
+    } else {
+        Vec::new()
+    };
+    if let Some(writer) = out.for_human() {
+        write!(writer, "{body}")?;
+        for reference in &references {
+            writeln!(writer, "\n--- {} ---\n", reference.display_path())?;
+            write!(writer, "{}", String::from_utf8_lossy(reference.content))?;
+        }
+    }
+    if let Some(out) = out.for_json() {
+        let files: Vec<serde_json::Value> = references
+            .iter()
+            .map(|reference| {
+                serde_json::json!({
+                    "path": reference.display_path(),
+                    "content": String::from_utf8_lossy(reference.content),
+                })
+            })
+            .collect();
+        out.write_value(serde_json::json!({ "name": name, "content": body, "files": files }))?;
+    }
+    Ok(())
 }
 
 /// Expand tilde in path to home directory
@@ -427,23 +506,29 @@ fn get_base_dir(ctx: Option<&mut Context>, global: bool) -> Result<PathBuf> {
     }
 }
 
+/// Byte range of the frontmatter's closing `---` line plus the blank line
+/// after it, for any line ending (Unix, Windows, or old Mac).
+fn frontmatter_close(content: &str) -> Option<std::ops::Range<usize>> {
+    ["---\n\n", "---\r\n\r\n", "---\r\r"]
+        .into_iter()
+        .find_map(|delimiter| {
+            content
+                .find(delimiter)
+                .map(|start| start..start + delimiter.len())
+        })
+}
+
 /// Replace version in SKILL.md content
 fn inject_version(content: &str, version: &str) -> String {
-    // Handle different line endings (Unix \n, Windows \r\n, or old Mac \r)
-    let frontmatter_end = content
-        .find("---\n\n")
-        .or_else(|| content.find("---\r\n\r\n"))
-        .or_else(|| content.find("---\r\r"));
-
-    if let Some(end_pos) = frontmatter_end {
-        let frontmatter = &content[..end_pos];
-        let rest = &content[end_pos..];
-        let updated_frontmatter =
-            frontmatter.replace("version: 0.0.0", &format!("version: {version}"));
-        format!("{updated_frontmatter}{rest}")
-    } else {
+    let replace = |text: &str| text.replace("version: 0.0.0", &format!("version: {version}"));
+    match frontmatter_close(content) {
+        Some(close) => format!(
+            "{}{}",
+            replace(&content[..close.start]),
+            &content[close.start..]
+        ),
         // Fallback if frontmatter format is unexpected
-        content.replace("version: 0.0.0", &format!("version: {version}"))
+        None => replace(content),
     }
 }
 
@@ -477,6 +562,22 @@ fn is_gitbutler_skill(skill_md_path: &std::path::Path) -> bool {
         .and_then(|content| frontmatter_value(&content, "name:"))
         .as_deref()
         == Some("but")
+}
+
+/// The layout of the SKILL.md at `skill_md_path`: a stub written by `--stub`
+/// carries `stub: true` in its frontmatter; anything else, including no file
+/// at all, counts as the full layout.
+fn installed_layout(skill_md_path: &std::path::Path) -> SkillLayout {
+    let is_stub = std::fs::read_to_string(skill_md_path)
+        .ok()
+        .and_then(|content| frontmatter_value(&content, "stub:"))
+        .as_deref()
+        == Some("true");
+    if is_stub {
+        SkillLayout::Stub
+    } else {
+        SkillLayout::Full
+    }
 }
 
 /// Extract the version from an installed SKILL.md file's YAML frontmatter.
@@ -560,9 +661,9 @@ fn find_format_installations(format: &SkillFormat, base_dir: &std::path::Path) -
 }
 
 fn is_complete_skill_installation(path: &std::path::Path) -> bool {
-    is_gitbutler_skill(&path.join("SKILL.md"))
-        && SKILL_FILES
-            .iter()
+    let skill_md = path.join("SKILL.md");
+    is_gitbutler_skill(&skill_md)
+        && skill_files_in_write_order(installed_layout(&skill_md))
             .all(|file| file.get_install_path(path).is_file())
 }
 
@@ -711,7 +812,14 @@ fn check_skills(
 
         for path_str in &outdated_paths {
             // Pass None for ctx since the paths are already absolute and don't require repo context
-            install_skill(None, out, false, Some(path_str.clone()), false)?;
+            install_skill(
+                None,
+                out,
+                false,
+                Some(path_str.clone()),
+                false,
+                SkillLayout::Full,
+            )?;
         }
     }
 
@@ -981,9 +1089,13 @@ fn prepare_skill_content(version: &str) -> Result<String> {
 }
 
 /// Write the bundled skill files into `install_path`, creating the directory
-/// structure as needed and injecting the CLI version into SKILL.md. Returns the
-/// version that was written.
-pub(crate) fn write_skill_files(install_path: &std::path::Path) -> Result<&'static str> {
+/// structure as needed and injecting the CLI version into SKILL.md. An existing
+/// stub stays a stub on every rewrite, so refreshes never upgrade a layout by
+/// accident. Returns the version that was written.
+pub(crate) fn write_skill_files(
+    install_path: &std::path::Path,
+    layout: SkillLayout,
+) -> Result<&'static str> {
     if SKILL_FILES.iter().any(|f| f.content.is_empty()) {
         anyhow::bail!(
             "Skill files were not properly embedded at build time. Please report this as a bug."
@@ -992,17 +1104,32 @@ pub(crate) fn write_skill_files(install_path: &std::path::Path) -> Result<&'stat
 
     // Prepare all content before writing (validate UTF-8 and inject version)
     let version = option_env!("VERSION").unwrap_or("dev");
-    let skill_md_content = prepare_skill_content(version)?;
-
-    let references_dir = install_path.join("references");
-    std::fs::create_dir_all(&references_dir).with_context(|| {
+    let full_skill_md = prepare_skill_content(version)?;
+    let layout = match installed_layout(&install_path.join("SKILL.md")) {
+        SkillLayout::Stub => SkillLayout::Stub,
+        SkillLayout::Full => layout,
+    };
+    let (skill_md_content, content_dir) = match layout {
+        SkillLayout::Full => (full_skill_md, install_path.join("references")),
+        SkillLayout::Stub => {
+            let close = frontmatter_close(&full_skill_md)
+                .context("SKILL.md has no frontmatter to build a stub from")?;
+            let stub = format!(
+                "{}stub: true\nallowed-tools: Bash(but skill:*)\n{}{STUB_MD}",
+                &full_skill_md[..close.start],
+                &full_skill_md[close]
+            );
+            (stub, install_path.to_path_buf())
+        }
+    };
+    std::fs::create_dir_all(&content_dir).with_context(|| {
         format!(
             "Failed to create skill directory at {}. Check that you have write permissions for this location.",
             install_path.display()
         )
     })?;
 
-    for file in skill_files_in_write_order() {
+    for file in skill_files_in_write_order(layout) {
         let file_path = file.get_install_path(install_path);
         let content = if file.is_main_skill_file() {
             // Use the version-injected content for SKILL.md
@@ -1010,20 +1137,17 @@ pub(crate) fn write_skill_files(install_path: &std::path::Path) -> Result<&'stat
         } else {
             file.content
         };
-        write_skill_file(&file_path, content, file.display_name)?;
+        write_skill_file(&file_path, content)?;
     }
     Ok(version)
 }
 
 /// Write a skill file with proper error context
-fn write_skill_file(path: &std::path::Path, content: &[u8], name: &str) -> Result<()> {
+fn write_skill_file(path: &std::path::Path, content: &[u8]) -> Result<()> {
     std::fs::write(path, content).with_context(|| {
         format!(
-            "Failed to write {} to {}. Check write permissions.",
-            name,
-            path.parent()
-                .map(|p| p.display().to_string())
-                .unwrap_or_else(|| path.display().to_string())
+            "Failed to write {}. Check write permissions.",
+            path.display()
         )
     })
 }
@@ -1035,6 +1159,7 @@ fn install_skill(
     global: bool,
     custom_path: Option<String>,
     detect: bool,
+    layout: SkillLayout,
 ) -> Result<()> {
     let t = theme::get();
     let driving_agent = (!out.can_prompt())
@@ -1136,8 +1261,13 @@ fn install_skill(
             writeln!(writer)?;
         }
 
-        version = write_skill_files(install_path)?;
+        version = write_skill_files(install_path, layout)?;
     }
+    // An existing stub is kept as a stub, so list what was actually written.
+    let layout = install_paths
+        .last()
+        .map(|path| installed_layout(&path.join("SKILL.md")))
+        .unwrap_or(layout);
 
     if let Some(writer) = out.for_human() {
         writeln!(writer)?;
@@ -1165,7 +1295,7 @@ fn install_skill(
         }
         writeln!(writer)?;
         writeln!(writer, "  Files installed:")?;
-        for file in SKILL_FILES {
+        for file in skill_files_in_write_order(layout) {
             writeln!(writer, "    • {}", file.display_path())?;
         }
         writeln!(writer)?;
@@ -1184,7 +1314,9 @@ fn install_skill(
     }
 
     if let Some(out) = out.for_json() {
-        let file_paths: Vec<String> = SKILL_FILES.iter().map(|f| f.display_path()).collect();
+        let file_paths: Vec<String> = skill_files_in_write_order(layout)
+            .map(|f| f.display_path())
+            .collect();
         let paths: Vec<String> = install_paths
             .iter()
             .map(|p| p.display().to_string())
@@ -1420,7 +1552,7 @@ mod tests {
     #[test]
     fn skill_file_display_path_is_derived_from_components() {
         assert_eq!(SKILL_FILES[0].display_path(), "SKILL.md");
-        assert_eq!(SKILL_FILES[1].display_path(), "references/concepts.md");
+        assert_eq!(SKILL_FILES[1].display_path(), "references/reference.md");
     }
 
     #[test]
@@ -1591,7 +1723,8 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let install_path = dir.path().join(".claude").join("skills").join("gitbutler");
 
-        let version = write_skill_files(&install_path).expect("a writable path accepts the bundle");
+        let version = write_skill_files(&install_path, SkillLayout::Full)
+            .expect("a writable path accepts the bundle");
 
         let skill_md = std::fs::read_to_string(install_path.join("SKILL.md")).unwrap();
         assert!(
@@ -1610,7 +1743,7 @@ mod tests {
     #[test]
     fn skill_entrypoint_is_written_last() {
         assert!(
-            skill_files_in_write_order()
+            skill_files_in_write_order(SkillLayout::Full)
                 .last()
                 .is_some_and(SkillFile::is_main_skill_file),
             "a partial bundle must not look installed"
@@ -1731,7 +1864,7 @@ mod tests {
     #[test]
     fn skill_installation_requires_every_embedded_file() {
         let temp_dir = tempfile::tempdir().unwrap();
-        write_skill_files(temp_dir.path()).unwrap();
+        write_skill_files(temp_dir.path(), SkillLayout::Full).unwrap();
         std::fs::remove_file(temp_dir.path().join("references/concepts.md")).unwrap();
 
         assert!(!is_complete_skill_installation(temp_dir.path()));

--- a/crates/but/src/lib.rs
+++ b/crates/but/src/lib.rs
@@ -771,12 +771,12 @@ async fn dispatch_subcommand(
             .map(|()| DispatchOutcome::Return)
             .map_err(CliError::from);
         }
-        Subcommands::Skill(args::skill::Platform { cmd }) => {
+        Subcommands::Skill(platform) => {
             // Skill commands use repository context when available, but can run
             // without one. Subcommand handlers produce tailored guidance when a
             // local repository is actually required.
             let mut ctx = discover_optional_context(&args.current_dir)?;
-            return command::skill::handle(ctx.as_mut(), out, cmd)
+            return command::skill::handle(ctx.as_mut(), out, platform)
                 .map(|()| DispatchOutcome::Return)
                 .map_err(CliError::from);
         }

--- a/crates/but/src/utils/metrics.rs
+++ b/crates/but/src/utils/metrics.rs
@@ -199,9 +199,10 @@ impl Subcommands {
             Subcommands::Merge { .. } => Land,
             #[cfg(feature = "legacy")]
             Subcommands::Pick(..) => Pick,
-            Subcommands::Skill(skill::Platform { cmd }) => match cmd {
-                skill::Subcommands::Install { .. } => SkillInstall,
-                skill::Subcommands::Check { .. } => SkillCheck,
+            Subcommands::Skill(skill::Platform { cmd, .. }) => match cmd {
+                Some(skill::Subcommands::Install { .. }) => SkillInstall,
+                Some(skill::Subcommands::Check { .. }) => SkillCheck,
+                _ => Skill,
             },
             // Bare `but agent` (None) runs the setup wizard, same as `agent setup`.
             Subcommands::Agent(agent::Platform { cmd }) => match cmd {
@@ -273,9 +274,19 @@ impl Subcommands {
                 push_prop(&mut props, "sourceKind", "commitOrBranch");
                 push_prop(&mut props, "targetKind", "commitOrBranchOrUnassigned");
             }
-            Subcommands::Skill(skill::Platform {
-                cmd: skill::Subcommands::Check { update, .. },
-            }) => push_prop(&mut props, "skillCheckUpdate", *update),
+            Subcommands::Skill(platform) => match (&platform.cmd, platform.doc()) {
+                (_, Some(doc)) => {
+                    push_prop(&mut props, "skillDoc", doc);
+                    push_prop(&mut props, "skillFull", platform.full);
+                }
+                (Some(skill::Subcommands::Check { update, .. }), None) => {
+                    push_prop(&mut props, "skillCheckUpdate", *update)
+                }
+                (Some(skill::Subcommands::Install { stub, .. }), None) => {
+                    push_prop(&mut props, "skillStub", *stub)
+                }
+                (_, None) => {}
+            },
             Subcommands::External(extra) => {
                 if let Some(command_name) = extra.first() {
                     push_prop(

--- a/crates/but/src/utils/metrics/tests.rs
+++ b/crates/but/src/utils/metrics/tests.rs
@@ -39,7 +39,10 @@ fn metrics_use_invoked_command_names() {
     );
     assert_command(
         Subcommands::Agent(agent::Platform {
-            cmd: Some(agent::Subcommands::Setup { print: false }),
+            cmd: Some(agent::Subcommands::Setup {
+                print: false,
+                stub: false,
+            }),
         }),
         "agentSetup",
     );

--- a/crates/but/tests/but/command/skill/mod.rs
+++ b/crates/but/tests/but/command/skill/mod.rs
@@ -1,8 +1,10 @@
 use snapbox::str;
 
+mod serve;
+
 use crate::utils::{CommandExt, Sandbox};
 
-fn relative_agent_skill_path(agent_dir: &str) -> std::path::PathBuf {
+pub(super) fn relative_agent_skill_path(agent_dir: &str) -> std::path::PathBuf {
     std::path::PathBuf::from(agent_dir)
         .join("skills")
         .join("gitbutler")

--- a/crates/but/tests/but/command/skill/serve.rs
+++ b/crates/but/tests/but/command/skill/serve.rs
@@ -1,0 +1,217 @@
+//! `but skill` printing the embedded guide, and the hidden `--stub` install
+//! layout that points agents at it.
+
+use snapbox::str;
+
+use super::relative_agent_skill_path;
+use crate::utils::{CommandExt, Sandbox};
+
+#[test]
+fn skill_prints_the_core_guide_without_frontmatter() {
+    let env = Sandbox::empty();
+
+    // The frontmatter is trigger text for the harness, not guidance; the body
+    // starts at the title and ends on the pointers to the other docs.
+    env.but("skill").assert().success().stdout_eq(str![[r#"
+# GitButler CLI Skill
+
+Use GitButler CLI (`but`) as the default version-control interface.
+...
+- For command syntax and flags: `but skill reference`
+- For workspace model: `but skill concepts`
+- For workflow examples: `but skill examples`
+
+"#]]);
+}
+
+#[test]
+fn skill_full_appends_every_reference_with_separators() {
+    let env = Sandbox::empty();
+
+    env.but("skill --full")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+# GitButler CLI Skill
+...
+--- references/reference.md ---
+
+# GitButler CLI Command Reference
+...
+--- references/concepts.md ---
+...
+--- references/examples.md ---
+...
+"#]]);
+}
+
+#[test]
+fn skill_doc_subcommands_print_one_reference_each() {
+    let env = Sandbox::empty();
+
+    env.but("skill reference")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+# GitButler CLI Command Reference
+...
+"#]]);
+    // `--full` only makes sense for the core guide.
+    env.but("skill reference --full")
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
+error: unexpected argument '--full' found
+
+Usage: but skill reference [OPTIONS]
+
+For more information, try '--help'.
+
+"#]]);
+}
+
+#[test]
+fn skill_json_carries_the_doc_and_full_references() {
+    let env = Sandbox::empty();
+
+    let output = env
+        .but("skill --full --json")
+        .allow_json()
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let json: serde_json::Value = serde_json::from_slice(&output).unwrap();
+    assert_eq!(json["name"], "core");
+    assert!(
+        json["content"]
+            .as_str()
+            .is_some_and(|content| content.starts_with("# GitButler CLI Skill")),
+        "content is the frontmatter-free body"
+    );
+    let paths: Vec<&str> = json["files"]
+        .as_array()
+        .expect("--full lists the reference files")
+        .iter()
+        .map(|file| file["path"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        paths,
+        [
+            "references/reference.md",
+            "references/concepts.md",
+            "references/examples.md"
+        ]
+    );
+}
+
+#[test]
+fn skill_install_stub_writes_one_marked_file_that_check_accepts() {
+    let env = Sandbox::open_with_default_settings("repo-no-remote");
+    let install_path = relative_agent_skill_path(".agents");
+
+    env.but("")
+        .arg("skill")
+        .arg("install")
+        .arg("--stub")
+        .arg("--path")
+        .arg(&install_path)
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+
+✓ GitButler skill installed successfully!
+
+  Location: ./.agents/skills/gitbutler
+
+  Files installed:
+    • SKILL.md
+
+
+"#]]);
+
+    let install_dir = env.projects_root().join(&install_path);
+    let skill_md = std::fs::read_to_string(install_dir.join("SKILL.md")).unwrap();
+    assert!(
+        skill_md.starts_with("---\nname: but\n"),
+        "the stub keeps the full skill's frontmatter so triggering is unchanged"
+    );
+    assert!(
+        skill_md.contains("\nstub: true\nallowed-tools: Bash(but skill:*)\n---\n"),
+        "the stub is marked and pre-approves the read it asks for, got: {skill_md}"
+    );
+    assert!(
+        skill_md.contains("run `but skill`") || skill_md.contains("but skill  "),
+        "the stub body points at the CLI, got: {skill_md}"
+    );
+    assert!(
+        !install_dir.join("references").exists(),
+        "a stub carries no reference files"
+    );
+
+    // A stub is a complete installation, not an incomplete bundle.
+    let output = env
+        .but("skill check --local --json")
+        .allow_json()
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let json: serde_json::Value = serde_json::from_slice(&output).unwrap();
+    assert_eq!(json["outdated_count"], 0);
+}
+
+#[test]
+fn skill_check_update_keeps_a_stale_stub_a_stub() {
+    let env = Sandbox::open_with_default_settings("repo-no-remote");
+    let install_path = relative_agent_skill_path(".agents");
+    env.but("")
+        .arg("skill")
+        .arg("install")
+        .arg("--stub")
+        .arg("--path")
+        .arg(&install_path)
+        .assert()
+        .success();
+    let skill_md_path = env.projects_root().join(&install_path).join("SKILL.md");
+    let stale = std::fs::read_to_string(&skill_md_path)
+        .unwrap()
+        .replace("version: dev", "version: 0.0.1");
+    std::fs::write(&skill_md_path, stale).unwrap();
+
+    env.but("skill check --local --update").assert().success();
+
+    let refreshed = std::fs::read_to_string(&skill_md_path).unwrap();
+    assert!(
+        refreshed.contains("version: dev") && refreshed.contains("\nstub: true\n"),
+        "an outdated stub is rewritten as a current stub, never upgraded to the full bundle"
+    );
+    assert!(
+        !env.projects_root()
+            .join(&install_path)
+            .join("references")
+            .exists()
+    );
+}
+
+#[test]
+fn agent_skill_notice_accepts_a_stub_install() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
+    env.but("skill install --stub --path .agents/skills/gitbutler")
+        .assert()
+        .success();
+
+    let output = env
+        .but("alias list")
+        .env("AI_AGENT", "opencode")
+        .output()
+        .expect("alias list runs");
+    assert!(output.status.success());
+    assert!(
+        !String::from_utf8_lossy(&output.stdout).contains("AGENT ACTION REQUIRED"),
+        "a stub counts as an installed, current skill"
+    );
+}


### PR DESCRIPTION
Bare `but skill` prints the skill guide embedded in the binary, with
`reference`, `concepts`, and `examples` subcommands for the reference
files and `--full` to print everything. The content is always the one
matching the installed binary, so agents can read it without an
installed copy going stale.

A hidden `--stub` flag on `skill install` and `agent setup` writes a
single SKILL.md that keeps the trigger frontmatter and tells the agent
to run `but skill`. Stubs carry `stub: true`, count as complete
installations, and are refreshed as stubs. The flag is team-internal
while the approach is evaluated against the full install.

Pointers inside the skill files now name `but skill <doc>` instead of
file paths, so they resolve for both installed and served copies.