### PR TITLE
Project the integrated workspace against the new target

### DIFF
--- a/apps/lite/ui/src/api/mutations.ts
+++ b/apps/lite/ui/src/api/mutations.ts
@@ -1273,6 +1273,11 @@ export const useWorkspaceIntegrateUpstream = () => {
 		mutationFn: window.lite.workspaceIntegrateUpstream,
 		onSuccess: (response, input, _context, mutation) => {
 			syncCoreCaches(mutation.client, dispatch, input.projectId, response);
+			// The base moved with the stacks: re-read the target line now rather
+			// than showing the old incoming commits until the watcher delivers.
+			void mutation.client.invalidateQueries({
+				queryKey: [input.projectId, "workspaceTargetCommits"],
+			});
 		},
 		onError: (error, input) => {
 			toastManager.add({

--- a/crates/but-api/src/workspace.rs
+++ b/crates/but-api/src/workspace.rs
@@ -652,6 +652,7 @@ pub fn workspace_integrate_upstream_only_with_perm(
                 Vec::new()
             }
         };
+        let cached_target = ws.graph.project_meta.target_commit_id;
         let IntegrateUpstreamOutcome {
             mut rebase,
             ws_meta,
@@ -672,6 +673,9 @@ pub fn workspace_integrate_upstream_only_with_perm(
             let replaced_commits = rebase.history.commit_mappings();
             let workspace_state =
                 WorkspaceState::from_rebase_preview(&mut rebase, replaced_commits)?;
+            // The preview was projected against the new target; the cached workspace,
+            // which the next caller of this context reuses, has not moved.
+            rebase.project_meta_mut().target_commit_id = cached_target;
             return Ok(WorkspaceIntegrateUpstreamOutcome {
                 workspace_state,
                 worktree_conflicts,

--- a/crates/but-rebase/src/graph_rebase/mod.rs
+++ b/crates/but-rebase/src/graph_rebase/mod.rs
@@ -346,6 +346,13 @@ impl<'ws, 'meta, M: RefMetadata> SuccessfulRebase<'ws, 'meta, M> {
         (&self.repo, self.meta, self.db)
     }
 
+    /// The project metadata the workspace is projected from, both by
+    /// [`Self::overlayed_graph`] and when materializing. A rewrite that moved the
+    /// target records the new tip here so the projection sits on it.
+    pub fn project_meta_mut(&mut self) -> &mut but_core::ref_metadata::ProjectMeta {
+        &mut self.workspace.graph.project_meta
+    }
+
     fn checkout_target(
         &self,
         selector: Selector,

--- a/crates/but-workspace/src/upstream_integration.rs
+++ b/crates/but-workspace/src/upstream_integration.rs
@@ -556,10 +556,15 @@ pub fn integrate_upstream_with_hints<'ws, 'meta, M: RefMetadata>(
 
     let mut project_meta = project_meta;
     project_meta.target_commit_id = Some(target_ref_commit.detach());
+    let mut rebase = editor.rebase()?;
+    // Materializing re-projects the workspace from the graph's own project meta, and the
+    // dry-run overlay reads its target from there too. Without this the outcome is projected
+    // against the old base, with the target's commits folded into the stacks as integrated.
+    rebase.project_meta_mut().target_commit_id = project_meta.target_commit_id;
     Ok(IntegrateUpstreamOutcome {
         ws_meta,
         project_meta,
-        rebase: editor.rebase()?,
+        rebase,
     })
 }
 

--- a/crates/but-workspace/tests/workspace/upstream_integration.rs
+++ b/crates/but-workspace/tests/workspace/upstream_integration.rs
@@ -252,7 +252,11 @@ fn diamond_partially_content_integrated_rebase() -> Result<()> {
 "#]]
     );
     let project_meta = workspace.graph.project_meta.clone();
-    let but_workspace::IntegrateUpstreamOutcome { rebase, .. } = integrate_upstream(
+    let but_workspace::IntegrateUpstreamOutcome {
+        rebase,
+        project_meta,
+        ..
+    } = integrate_upstream(
         &mut workspace,
         &mut meta,
         project_meta,
@@ -264,7 +268,7 @@ fn diamond_partially_content_integrated_rebase() -> Result<()> {
         }],
     )?;
 
-    rebase.materialize(Default::default())?;
+    let materialized = rebase.materialize(Default::default())?;
 
     snapbox::assert_data_eq!(
         visualize_commit_graph_all(&repo)?,
@@ -285,6 +289,27 @@ fn diamond_partially_content_integrated_rebase() -> Result<()> {
         .raw()
     );
 
+    // The workspace handed back is what callers render right after the
+    // integration: it must sit on the target's new tip, not the old base with
+    // the just-integrated target commits folded into the stack.
+    let o4_id = repo.rev_parse_single("origin/master")?.detach();
+    assert_eq!(project_meta.target_commit_id, Some(o4_id));
+    assert_eq!(
+        materialized.workspace.graph.project_meta.target_commit_id,
+        Some(o4_id)
+    );
+    snapbox::assert_data_eq!(
+        graph_workspace(materialized.workspace).to_string(),
+        snapbox::str![[r#"
+📕🏘️:gitbutler/workspace[🌳] <> ✓refs/remotes/origin/master on 162b064
+└── ≡📙:E on 162b064 {1}
+    ├── 📙:E
+    │   └── ·cb866ec (🏘️)
+    └── :C
+        └── ·c7b32b8 (🏘️)
+
+"#]]
+    );
     Ok(())
 }
 


### PR DESCRIPTION
In Lite, updating the workspace base briefly showed the incoming target commits inside the work-in-progress stack, marked as integrated, before the view snapped to the correct state.

`integrate_upstream_with_hints` hands back a `project_meta` pointing at the target's new tip, but the rebase keeps re-projecting from the workspace graph's own `project_meta`, which still holds the old target. `materialize` and the dry-run overlay both read from there, so the workspace state returned by the mutation sits on the old base with the just-integrated target commits folded into the stacks. Lite renders that response directly, and only the watcher-triggered refetch of head info reads the persisted meta.

The graph's `project_meta` is now moved to the target's tip before the editor is created, so the returned workspace, and the dry-run preview, are projected against the new base. The sibling test that already materializes this scenario asserts the resulting workspace.

Lite additionally refetches the target line when the update succeeds, so the base section does not keep showing the old incoming commits until the watcher delivers.