### PR TITLE
Lite: pull request tab — description card, meta line, reactions and layout

### DIFF
--- a/apps/lite/DESIGN.md
+++ b/apps/lite/DESIGN.md
@@ -337,3 +337,50 @@ thought across the two.
 and interrupts. Toasts get theirs from the toast viewport. Neither is the only
 way to know something: a state the user must act on belongs in the UI itself,
 not in a surface that leaves.
+
+## Markdown
+
+**One kit, in ⚛️ Lite Core: the `Markdown/` components.** A component per
+block — Heading with its three levels, Paragraph, List and List item, Link,
+Inline code, and Block, which wraps a code block, blockquote, table, image or
+rule chosen by its swap — and "Markdown / slot", whose default content is a
+sample description built from them. `Markdown.stories.tsx` renders the same
+document, so compare the two when either side changes. Each component's
+description in Figma names the CSS selector it stands for; change one and
+change the other.
+
+**The rhythm is 12, 16, 4.** 12px between text blocks. 16px around anything
+with an edge — a table, a code block, a quote bar, an image, a rule — because
+text carries its own leading and a box doesn't. 4px between the items of a
+list, and a nested list keeps the item rhythm rather than the block one. A
+heading takes twice the text gap above it, 24px, and a little less for h3 and
+below, 20px, so a section reads as a section rather than as one more
+paragraph; 8px below, which collapses into the next block's own margin. In
+Figma the same numbers are the slot's 12px gap plus each block's own padding:
+4 on Block, 12 on H2, 8 on H3. Margins collapse in CSS, so a box next to a
+paragraph gets 16, not 28.
+
+**Type.** Body/13 on a 160% line. H1 is 18, H2 16, H3 14, all semibold.
+Levels four to six stay at the body size and only go semibold; Figma has no
+component for them, and a description that needs a fourth level needs fewer
+levels.
+
+**Every link leaves the app, and the arrow says so.** Links open in the
+browser, never in Lite, and each carries `arrow-up-right` at 12px after its
+text, hung off the anchor without a space so the underline stops at the word.
+Figma writes ↗.
+
+**A box gets an edge.** Code blocks and inline code sit on `--bg-2`, at
+`--radius-card` and `--radius-button` respectively, in mono 12. A blockquote
+is a 3px `--border-2` bar with `--text-2` text. An image takes a 1px
+`--card-border` ring inset inside `--radius-card` corners, so a white
+screenshot has an edge on a white panel, and opens externally on click. A
+table's cells are bordered in `--border-3` under a `--bg-2` header row.
+
+**Inline pieces Figma can't run.** Inline code, keycaps and folds sit inside a
+text line in the app. Figma has no way to flow a chip through text, so the
+kit's sample puts the chip between two text nodes in a row. That is a limit of
+the mockup, not a layout: don't design around where the chip breaks.
+
+**The measure is 480.** A description is set at the details pane's width, the
+story sets the same, and every block component in the kit is 480 wide.

--- a/apps/lite/package.json
+++ b/apps/lite/package.json
@@ -137,7 +137,7 @@
 		"@base-ui/react": "^1.6.0",
 		"@base-ui/utils": "^0.3.1",
 		"@gitbutler/but-sdk": "workspace:*",
-		"@gitbutler/design-core": "3.17.0",
+		"@gitbutler/design-core": "3.17.1",
 		"@pierre/diffs": "^1.3.5",
 		"@pierre/theming": "^1.0.1",
 		"@reduxjs/toolkit": "catalog:redux",

--- a/apps/lite/ui/src/components/Badge.module.css
+++ b/apps/lite/ui/src/components/Badge.module.css
@@ -27,7 +27,7 @@
 }
 
 .large {
-	height: 20px;
+	height: var(--size-tag);
 	padding-inline: 6px;
 	gap: 3px;
 }

--- a/apps/lite/ui/src/components/Badge.module.css
+++ b/apps/lite/ui/src/components/Badge.module.css
@@ -28,7 +28,7 @@
 
 .large {
 	height: var(--size-tag);
-	padding-inline: 6px;
+	padding-inline: 7px;
 	gap: 3px;
 }
 

--- a/apps/lite/ui/src/components/Button.module.css
+++ b/apps/lite/ui/src/components/Button.module.css
@@ -58,7 +58,7 @@
 
 :where(.small) {
 	--button-gap: 4px;
-	--button-height: 20px;
+	--button-height: var(--size-tag);
 	--button-padding-inline: 6px;
 	--icon-size: 14px;
 

--- a/apps/lite/ui/src/components/Clamped.module.css
+++ b/apps/lite/ui/src/components/Clamped.module.css
@@ -52,3 +52,63 @@
 .toggleInline {
 	margin-block-start: 8px;
 }
+
+/* The card variant: folded, a quiet ground with the chevron seated at the
+   bottom corner beside the faded last line; unfolded, no ground at all, with
+   the chevron up at the first line so it stays where it was clicked. The
+   chevron keeps its own column in both states so the text wraps at the same
+   width folded and unfolded. */
+.card {
+	display: flex;
+	column-gap: 8px;
+	align-items: flex-start;
+}
+
+/* Folded or unfolded, the content keeps the card's inset, so the text does
+   not shift when the ground comes and goes: pulled out by its own inset so
+   the text stays on the column's left edge with the title and everything
+   under it; the card is a wash just wider than the text, not a box the text
+   moved into. */
+.cardFramed {
+	margin-inline: -8px;
+	padding: 6px 8px;
+}
+
+.cardFolded {
+	/* Halfway from the page to the first gray step, the way the button hover
+	   ground sits between its two steps: a whole step reads as a panel, and
+	   this is a passage of the description, not a panel. */
+	--card-bg: color-mix(in srgb, var(--bg-2) 50%, var(--bg-1));
+	align-items: flex-end;
+	border-radius: var(--radius-card);
+	background-color: var(--card-bg);
+	/* The whole folded card opens, not only its chevron. */
+	cursor: pointer;
+	transition: background-color var(--transition-fast);
+
+	/* The fade clears to the card's ground, not the page's, and with no label
+	   to seat it can be a plain ramp over the last line and a half. Painted as
+	   the ground color under a mask rather than as a gradient to it, so it
+	   transitions with the card on hover instead of jumping ahead of it. */
+	& .overflowing::after {
+		height: 30px;
+		background: var(--card-bg);
+		mask-image: linear-gradient(to bottom, transparent, black);
+		transition: background-color var(--transition-fast);
+	}
+
+	&:hover {
+		--card-bg: var(--bg-2);
+	}
+}
+
+.cardContent {
+	flex: 1;
+	/* Without this a long code span holds the column at its widest content
+	   and pushes the chevron out of the card. */
+	min-width: 0;
+}
+
+.cardToggle {
+	flex: none;
+}

--- a/apps/lite/ui/src/components/Clamped.stories.tsx
+++ b/apps/lite/ui/src/components/Clamped.stories.tsx
@@ -52,6 +52,25 @@ export const BarelyOverflowing = meta.story({
 	),
 });
 
+/**
+ * The card variant, as the PR description uses it: four lines on a quiet
+ * card with a chevron, folding only past six so a click always reveals
+ * more than a line or two.
+ */
+export const Card = meta.story({
+	args: { maxHeight: "4lh", foldOver: "6lh", variant: "card" },
+	render: (args) => (
+		<div style={{ maxWidth: 480, display: "flex", flexDirection: "column", rowGap: 12 }}>
+			<Clamped {...args}>
+				<div className="text-13 text-body">{paragraphs(3)}</div>
+			</Clamped>
+			<Clamped {...args}>
+				<div className="text-13 text-body">{paragraphs(1)}</div>
+			</Clamped>
+		</div>
+	),
+});
+
 const LateGrowth = ({ maxHeight }: { maxHeight: string }) => {
 	const [grown, setGrown] = useState(false);
 	useEffect(() => {

--- a/apps/lite/ui/src/components/Clamped.tsx
+++ b/apps/lite/ui/src/components/Clamped.tsx
@@ -1,32 +1,63 @@
+import { getButtonClassName } from "#ui/components/Button.tsx";
 import { classes } from "#ui/components/classes.ts";
-import type { CSSProperties, FC, ReactNode } from "react";
+import { Icon } from "#ui/components/Icon.tsx";
+import type { CSSProperties, FC, MouseEvent, ReactNode } from "react";
 import { useLayoutEffect, useRef, useState } from "react";
 import styles from "./Clamped.module.css";
 
-/** Resolve the supported clamp lengths ("240px", "80vh") to pixels. */
-const resolveLength = (length: string): number => {
-	const match = /^(\d+(?:\.\d+)?)(px|vh)$/.exec(length);
+/**
+ * Resolve the supported clamp lengths ("240px", "80vh", "3lh") to pixels.
+ * `lh` reads the line-height off `text`, so it must be the element that
+ * carries the content's text style; a `normal` line-height resolves to NaN,
+ * which never folds.
+ */
+const resolveLength = (length: string, text: Element): number => {
+	const match = /^(\d+(?:\.\d+)?)(px|vh|lh)$/.exec(length);
 	if (match === null) return Number.POSITIVE_INFINITY;
 	const value = Number(match[1]);
-	return match[2] === "vh" ? (value * window.innerHeight) / 100 : value;
+	if (match[2] === "vh") return (value * window.innerHeight) / 100;
+	if (match[2] === "lh") return value * Number.parseFloat(getComputedStyle(text).lineHeight);
+	return value;
 };
 
 /**
- * Caps content at `maxHeight` with a fade and a Show more/less toggle,
- * folding only when content is actually taller than the cap. Content that
- * changes size after mount (lazy images, async syntax highlighting)
- * re-measures via a ResizeObserver on the inner wrapper, and viewport
- * resizes re-measure the vh-based caps.
+ * Caps content at `maxHeight` with a fade and a toggle, folding only when
+ * content is actually taller than the cap (or than `foldOver`, when given).
+ * Content that changes size after mount (lazy images, async syntax
+ * highlighting) re-measures via a ResizeObserver on the inner wrapper, and
+ * viewport resizes re-measure the vh-based caps.
  */
 export const Clamped: FC<{
-	/** A px or vh length, e.g. `"240px"` or `"80vh"`. */
+	/** A px, vh or lh length, e.g. `"240px"`, `"80vh"` or `"3lh"`. */
 	maxHeight: string;
+	/**
+	 * Fold only once the content is taller than this, so that a fold never
+	 * hides just a line or two behind a click. Defaults to `maxHeight`.
+	 */
+	foldOver?: string;
 	/** Don't fold when the full content already fits within the viewport. */
 	skipWhenViewportFits?: boolean;
+	/**
+	 * `text` (the default) seats a Show more link on the fade and a Show less
+	 * link under the unfolded content. `card` sets the folded content on a
+	 * quiet card with a chevron at its corner; unfolded, the content lies flat
+	 * with the chevron at its top right, where the eye was left.
+	 */
+	variant?: "text" | "card";
 	children: ReactNode;
-}> = ({ maxHeight, skipWhenViewportFits = false, children }) => {
+}> = ({
+	maxHeight,
+	foldOver = maxHeight,
+	skipWhenViewportFits = false,
+	variant = "text",
+	children,
+}) => {
 	const [expanded, setExpanded] = useState(false);
 	const [folded, setFolded] = useState(false);
+	// The cap in pixels, so the CSS clamp and the fold decision agree even
+	// when `maxHeight` is in lh, which the outer box would otherwise resolve
+	// against its own line-height rather than the content's.
+	const [capPx, setCapPx] = useState<number | null>(null);
 	const innerRef = useRef<HTMLDivElement | null>(null);
 
 	useLayoutEffect(() => {
@@ -37,9 +68,16 @@ export const Clamped: FC<{
 		// The inner wrapper always has its natural height (only the outer box
 		// is clamped), so this needs no unfold-and-measure dance.
 		const measure = () => {
+			// The content's root (a Markdown block, say) carries the text style
+			// the `lh` unit reads; the wrapper itself is unstyled.
+			const text = inner.firstElementChild ?? inner;
 			const contentHeight = inner.offsetHeight;
 			const fitsViewport = skipWhenViewportFits && contentHeight <= window.innerHeight;
-			setFolded(contentHeight > resolveLength(maxHeight) + 1 && !fitsViewport);
+			setCapPx(resolveLength(maxHeight, text));
+			// Only ever folds, never unfolds on its own: folding can narrow the
+			// content (the card's inset, a page scrollbar coming or going), and a
+			// measurement that could undo the fold would chase its own layout.
+			if (contentHeight > resolveLength(foldOver, text) + 1 && !fitsViewport) setFolded(true);
 		};
 		measure();
 		const observer = new ResizeObserver(measure);
@@ -49,29 +87,82 @@ export const Clamped: FC<{
 			observer.disconnect();
 			window.removeEventListener("resize", measure);
 		};
-	}, [expanded, maxHeight, skipWhenViewportFits]);
+	}, [expanded, maxHeight, foldOver, skipWhenViewportFits]);
 
 	const isFolded = !expanded && folded;
 
-	return (
-		<>
+	const clamp = (
+		<div
+			style={
+				{
+					"--clamp-max-height":
+						capPx === null || !Number.isFinite(capPx) ? maxHeight : `${capPx}px`,
+				} as CSSProperties
+			}
+			className={classes(
+				isFolded && styles.clamped,
+				isFolded && styles.overflowing,
+				variant === "card" && styles.cardContent,
+			)}
+		>
+			<div ref={innerRef}>{children}</div>
+			{/* Folded, the trigger rides on the fade instead of sitting under it,
+			    so it costs the clamp no extra row. */}
+			{isFolded && variant === "text" && (
+				<button
+					className={classes("text-13", "text-body", styles.toggle, styles.toggleOverlay)}
+					onClick={() => setExpanded(true)}
+					type="button"
+				>
+					Show more
+				</button>
+			)}
+		</div>
+	);
+
+	if (variant === "card") {
+		// The same tree in every state, with only classes and the chevron
+		// changing: were the card wrapper added and removed around the content,
+		// React would reuse the outer divs and remount the content, moving the
+		// measured wrapper out from under the observer and flickering between
+		// folded and flat. Short content simply gets no card and no chevron.
+		const framed = isFolded || expanded;
+		// Folded, the whole card is the target, not just its chevron. A link or
+		// control inside keeps its own click, and a drag that selected text is
+		// not a click on the card.
+		const expandFromCard = (event: MouseEvent<HTMLDivElement>) => {
+			if (!(event.target instanceof Element) || event.target.closest("a, button, summary")) return;
+			if (window.getSelection()?.isCollapsed === false) return;
+			setExpanded(true);
+		};
+		return (
+			// oxlint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions -- a pointer convenience; the chevron button is the keyboard path.
 			<div
-				style={{ "--clamp-max-height": maxHeight } as CSSProperties}
-				className={classes(isFolded && styles.clamped, isFolded && styles.overflowing)}
+				className={classes(styles.card, framed && styles.cardFramed, isFolded && styles.cardFolded)}
+				onClick={isFolded ? expandFromCard : undefined}
 			>
-				<div ref={innerRef}>{children}</div>
-				{/* Folded, the trigger rides on the fade instead of sitting under it,
-				    so it costs the clamp no extra row. */}
-				{isFolded && (
+				{clamp}
+				{framed && (
 					<button
-						className={classes("text-13", "text-body", styles.toggle, styles.toggleOverlay)}
-						onClick={() => setExpanded(true)}
+						aria-expanded={expanded}
+						aria-label={expanded ? "Show less" : "Show more"}
+						className={classes(
+							getButtonClassName({ variant: "ghost", iconOnly: true, size: "small" }),
+							styles.cardToggle,
+						)}
+						onClick={() => setExpanded(!expanded)}
 						type="button"
 					>
-						Show more
+						<Icon name={expanded ? "chevron-up" : "chevron-down"} />
 					</button>
 				)}
 			</div>
+		);
+	}
+
+	return (
+		<>
+			{clamp}
 			{expanded && (
 				<button
 					className={classes("text-13", "text-body", styles.toggle, styles.toggleInline)}

--- a/apps/lite/ui/src/components/Markdown.module.css
+++ b/apps/lite/ui/src/components/Markdown.module.css
@@ -10,13 +10,20 @@
 		margin-block-end: 0;
 	}
 
+	/* The rhythm, in step with the Markdown kit in ⚛️ Lite Core:
+	   12px between text blocks, 16px around anything with an edge (a table,
+	   a code block, a quote bar, an image) because text carries its own
+	   leading and a box doesn't, 4px within a list, and a heading takes
+	   twice the text gap above it (a little less for h3 and below) so a
+	   section reads as a section rather than as one more paragraph.
+	   Adjacent margins collapse, so a box next to a paragraph gets 16. */
 	h1,
 	h2,
 	h3,
 	h4,
 	h5,
 	h6 {
-		margin-block: 16px 8px;
+		margin-block: 24px 8px;
 		font-weight: 600;
 	}
 
@@ -26,6 +33,13 @@
 
 	h2 {
 		font-size: 16px;
+	}
+
+	h3,
+	h4,
+	h5,
+	h6 {
+		margin-block-start: 20px;
 	}
 
 	h3 {
@@ -40,10 +54,15 @@
 
 	p,
 	ul,
-	ol,
+	ol {
+		margin-block: 12px;
+	}
+
 	table,
-	blockquote {
-		margin-block: 8px;
+	blockquote,
+	pre,
+	p:has(> a:only-child > .image) {
+		margin-block: 16px;
 	}
 
 	/* The design-core reset drops `list-style` app-wide, which suits the
@@ -79,17 +98,17 @@
 	}
 
 	li + li {
-		margin-block-start: 2px;
+		margin-block-start: 4px;
 	}
 
 	/* A nested list belongs to its parent item, so it keeps the item-to-item
-	   rhythm instead of the 8px that separates top-level blocks. */
+	   rhythm instead of the 12px that separates top-level blocks. */
 	li > ul,
 	li > ol {
-		margin-block: 2px;
+		margin-block: 4px;
 	}
 
-	/* A loose list wraps every item in a paragraph; those inherit the 8px
+	/* A loose list wraps every item in a paragraph; those inherit the 12px
 	   block margin and blow the list open. Interior paragraphs keep it, so a
 	   genuinely multi-paragraph item still reads as one. */
 	li > p:first-child {
@@ -124,7 +143,6 @@
 	}
 
 	pre {
-		margin-block: 8px;
 		padding: 10px 12px;
 		overflow-x: auto;
 		border-radius: var(--radius-card);
@@ -155,15 +173,30 @@
 		text-decoration: underline;
 	}
 
+	/* Every link leaves the app, and the arrow says so. It hangs off the
+	   anchor without a space so the underline stops at the text. */
+	.externalIcon {
+		margin-inline-start: 3px;
+		vertical-align: middle;
+	}
+
 	.imageLink {
 		display: inline-flex;
 		align-items: center;
 		gap: 4px;
 	}
 
+	/* The ring is what gives a white screenshot an edge on a white panel;
+	   an outline rather than a border so it follows the radius without
+	   changing the image's box. */
 	.image {
 		max-width: 100%;
 		border-radius: var(--radius-card);
+		outline: 1px solid var(--card-border);
+		outline-offset: -1px;
+		/* Inline by default, which leaves a descender gap under a screenshot
+		   that sits alone on its line. */
+		vertical-align: middle;
 	}
 
 	table {
@@ -187,7 +220,7 @@
 	}
 
 	hr {
-		margin-block: 12px;
+		margin-block: 16px;
 		border: none;
 		border-top: 1px solid var(--border-3);
 	}

--- a/apps/lite/ui/src/components/Markdown.stories.tsx
+++ b/apps/lite/ui/src/components/Markdown.stories.tsx
@@ -1,0 +1,113 @@
+import preview from "#storybook/preview";
+import type { GUISettings } from "#electron/settings.ts";
+import { guiSettingsQueryOptions } from "#ui/api/queries.ts";
+import { defaultSettings } from "#ui/settings.ts";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { Markdown } from "./Markdown.tsx";
+
+// The code block reads the syntax theme through the settings query, which
+// the Electron bridge answers in the app. Seeding the client with the
+// defaults keeps the story offline and quiet.
+const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+queryClient.setQueryData(guiSettingsQueryOptions.queryKey, defaultSettings as GUISettings);
+
+const meta = preview.meta({
+	component: Markdown,
+	parameters: {
+		design: {
+			type: "figma",
+			url: "https://www.figma.com/design/cqdnAotT8n9op8WGYLOHg4/%E2%9A%9B%EF%B8%8F-Lite-Core?node-id=1930-1729",
+		},
+	},
+	decorators: [
+		// The width a PR description gets in the details pane; the blocks in
+		// Figma are set to the same measure.
+		(Story) => (
+			<QueryClientProvider client={queryClient}>
+				<div style={{ width: 480, padding: 24 }}>
+					<Story />
+				</div>
+			</QueryClientProvider>
+		),
+	],
+});
+
+/**
+ * The same document as the default content of "Markdown / slot" in ⚛️ Lite
+ * Core: every block the kit has a component for, in the app's rhythm.
+ * Compare the two when either side changes.
+ */
+export const Sample = meta.story({
+	args: {
+		children: `# Summary
+
+Adds a description editor to the PR create form. When the body is empty, the editor offers a one-line prompt instead of a blank field, so a short description is one click away.
+
+## What changed
+
+- The empty state is a button that opens the editor with the commit messages pasted in
+- Existing descriptions open as before
+
+Run it locally with the CLI:
+
+\`\`\`sh
+$ but commit -m "Add description editor"
+$ but push
+\`\`\`
+
+### Notes for reviewers
+
+> Reviewers asked for a shorter first paragraph, so the summary now leads with what changed.
+
+| File | Change | Status |
+| --- | --- | --- |
+| Markdown.tsx | Description editor | Done |
+| Field.tsx | Empty prompt | In review |
+
+- [ ] Update the screenshots in the PR
+- [ ] Add the DESIGN.md section
+
+![App preview](https://raw.githubusercontent.com/gitbutlerapp/gitbutler/master/apps/web/static/images/app-preview-light.png)
+
+---
+
+[See the design notes](https://github.com/gitbutlerapp/gitbutler/blob/master/apps/lite/DESIGN.md)
+
+Then run \`but status\` to check.`,
+	},
+});
+
+/** The three heading levels next to body text, and the levels below them that share the body size. */
+export const Headings = meta.story({
+	args: {
+		children: `# Heading 1
+
+Body text at 13px on a 160% line.
+
+## Heading 2
+
+Body text at 13px on a 160% line.
+
+### Heading 3
+
+Body text at 13px on a 160% line.
+
+#### Heading 4
+
+Levels four to six stay at the body size and only go semibold.`,
+	},
+});
+
+/** Inline chips, a keycap, and a fold: the pieces Figma can't run inside a text line. */
+export const Inline = meta.story({
+	args: {
+		children: `Press <kbd>⌘</kbd> <kbd>Enter</kbd> to commit, or run \`but commit\` from a shell.
+
+<details>
+<summary>Why a fold?</summary>
+
+Long logs and stack traces go behind a fold so the description stays readable.
+
+</details>`,
+	},
+});

--- a/apps/lite/ui/src/components/Markdown.tsx
+++ b/apps/lite/ui/src/components/Markdown.tsx
@@ -13,10 +13,14 @@ import remarkGfm from "remark-gfm";
 import { codeToTokens, type BundledLanguage } from "shiki";
 import styles from "./Markdown.module.css";
 
+/** The links that leave the app — the only ones that open at all. */
+const isExternalUrl = (url: string | undefined): url is string =>
+	url !== undefined && (url.startsWith("http://") || url.startsWith("https://"));
+
 const openExternally = (evt: MouseEvent<HTMLAnchorElement>): void => {
 	evt.preventDefault();
 	const url = evt.currentTarget.href;
-	if (url.startsWith("http://") || url.startsWith("https://")) {
+	if (isExternalUrl(url)) {
 		window.lite.openInWebBrowser(url).catch((error: unknown) => {
 			// oxlint-disable-next-line no-console
 			console.error(error);
@@ -156,8 +160,15 @@ export const Markdown: FC<{ children: string }> = ({ children }) => (
 			remarkPlugins={[remarkGfm, remarkGemoji]}
 			rehypePlugins={[rehypeRaw, [rehypeSanitize, sanitizeSchema]]}
 			components={{
-				// oxlint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions -- href and children arrive via the spread; it stays a real anchor.
-				a: ({ node: _node, ...props }) => <a {...props} onClick={openExternally} />,
+				a: ({ node: _node, children, ...props }) => (
+					// oxlint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions -- href arrives via the spread; it stays a real anchor.
+					<a {...props} onClick={openExternally}>
+						{children}
+						{isExternalUrl(props.href) && (
+							<Icon name="arrow-up-right" size={12} className={styles.externalIcon} />
+						)}
+					</a>
+				),
 				code: ({ node: _node, className, children, ...props }) => {
 					const language = fencedLanguage(className);
 					return language !== undefined && typeof children === "string" ? (

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.module.css
@@ -1,10 +1,7 @@
 .container {
-	/* The PR layout's columns. They live up here because .prLayout caps itself
-	   at their sum, and because the panel — a separate module, so no literal to
-	   share — reads --pr-panel-width for its own flex-basis. */
-	--pr-main-max: 900px;
+	/* The PR panel's column. It lives up here because the panel — a separate
+	   module, so no literal to share — reads it for its own flex-basis. */
 	--pr-panel-width: 315px;
-	--pr-layout-gap: 16px;
 
 	display: grid;
 	grid-template-rows: auto minmax(0, 1fr);
@@ -276,17 +273,28 @@
    content overflows all the way up to the page pane, which carries the
    details header out of view with it. */
 .prTabScroll {
+	/* The tab's inset and column gap scale with this width (see .prTab). */
+	container-type: inline-size;
 	overflow-y: auto;
 }
 
 .prTab {
+	/* Both breathe with the pane: the panel padding while it is narrow enough
+	   that every pixel goes to the columns, growing to a generous margin as
+	   the window is stretched wide. */
+	--pr-tab-inset: clamp(var(--panel-padding-inline), 4cqi - 16px, 40px);
+	--pr-layout-gap: clamp(16px, 2.5cqi - 4px, 32px);
+
 	width: 100%;
-	max-width: 1000px;
+	/* Caps the columns, not the inset: with border-box sizing a fixed cap
+	   would hand the wider inset its width out of the content. */
+	max-width: calc(1000px + 2 * var(--pr-tab-inset));
 	margin: 0 auto;
-	padding-inline: var(--panel-padding-inline);
-	/* Deeper than the panel's own block padding: the tab ends on the comment
-	   composer, which needs room under it rather than the viewport edge. */
-	padding-block: 12px 24px;
+	padding-inline: var(--pr-tab-inset);
+	/* Fixed above — the panel's sticky `top` matches it — and deeper below:
+	   the tab ends on the comment composer, which needs room under it rather
+	   than the viewport edge. */
+	padding-block: 16px 24px;
 }
 
 .prLayout {

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -87,6 +87,7 @@ import {
 } from "#ui/routes/project/$id/workspace/PullRequestPanel.tsx";
 import {
 	PullRequestDescription,
+	PullRequestMeta,
 	PullRequestForm,
 	PullRequestPrimaryAction,
 } from "#ui/routes/project/$id/workspace/PullRequestForm.tsx";
@@ -3336,6 +3337,7 @@ const ReviewLayout: FC<{
 					reviewId={review.number}
 					sourceBranch={sourceBranch}
 					title={review.title}
+					meta={<PullRequestMeta projectId={projectId} review={review} />}
 					canSubmit={editing !== undefined}
 					editing={editing?.active ?? false}
 					onDoneEditing={() => editing?.onDone()}

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -3313,7 +3313,7 @@ const ReviewLayout: FC<{
 	projectId: string;
 	sourceBranch: string;
 	review: ForgeReview;
-	editing?: { active: boolean; onDone: () => void };
+	editing?: { active: boolean; onStart: () => void; onDone: () => void };
 }> = ({ projectId, sourceBranch, review, editing }) => {
 	const { data: forgeInfo } = useQuery(forgeInfoOptions(projectId));
 	// The level is read unconditionally: behind `&&` the hook would be skipped
@@ -3339,6 +3339,7 @@ const ReviewLayout: FC<{
 					canSubmit={editing !== undefined}
 					editing={editing?.active ?? false}
 					onDoneEditing={() => editing?.onDone()}
+					onStartEditing={editing?.onStart}
 				/>
 
 				{hasConversation && <PullRequestComments projectId={projectId} review={review} />}
@@ -3729,7 +3730,11 @@ const AppliedBranchDetails: FC<BranchDetailsProps> = ({
 												projectId={projectId}
 												sourceBranch={branchName}
 												review={review}
-												editing={{ active: prEditing, onDone: () => setPrEditing(false) }}
+												editing={{
+													active: prEditing,
+													onStart: startPrEdit,
+													onDone: () => setPrEditing(false),
+												}}
 											/>
 										);
 									}}

--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/TargetCommitRow.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/TargetCommitRow.module.css
@@ -8,8 +8,8 @@
 .labelMeta {
 	display: flex;
 	align-items: center;
-	/* Keeps an empty footer holding its line, so rows stay equal height. */
-	min-height: 20px;
+	/* Keeps an empty footer holding its line at the tag-sized meta height, so rows stay equal. */
+	min-height: var(--size-tag);
 	gap: 8px;
 }
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestForm.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestForm.module.css
@@ -130,3 +130,19 @@
 .prViewEmptyBody {
 	color: var(--text-3);
 }
+
+.prViewAddDescription {
+	padding: 0;
+	border: none;
+	background: none;
+	color: var(--text-2);
+	font: inherit;
+	/* The designed link treatment: dotted, on the font's own underline. */
+	text-decoration: underline dotted;
+	text-underline-position: from-font;
+	cursor: pointer;
+
+	&:hover {
+		color: var(--text-1);
+	}
+}

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestForm.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestForm.module.css
@@ -127,6 +127,33 @@
 	flex-direction: column;
 }
 
+/* The markdown H1's face, weight and size (see Markdown.module.css), stated
+   in full rather than layered over a text utility, so the title reads as the
+   top of the description rather than as a heading in another scale. Tighter
+   leading than the body's: a title that wraps should still read as one line
+   of type, not as two paragraphs. */
+.prViewTitle {
+	font-weight: 600;
+	font-size: 18px;
+	line-height: var(--text-lineheight-default);
+	font-family: var(--fontfamily-base);
+}
+
+/* Reads as one line of facts: a dot between each, the same grey as the
+   comment timestamps. The user row inside keeps its own darker login. */
+.prViewMeta {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 6px;
+	color: var(--text-2);
+
+	& > * + *::before {
+		margin-inline-end: 6px;
+		content: "·";
+	}
+}
+
 .prViewEmptyBody {
 	color: var(--text-3);
 }

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestForm.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestForm.tsx
@@ -576,6 +576,7 @@ export const PullRequestDescription: FC<{
 					reactors={reviewReactions.reactors}
 					myLogin={currentLogin}
 					onToggle={toggleReaction}
+					suggest
 				/>
 			)}
 		</div>

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestForm.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestForm.tsx
@@ -14,8 +14,10 @@ import {
 	aiConfigurationQueryOptions,
 	branchDetailsQueryOptions,
 	currentForgeLoginQueryOptions,
+	forgeInfoOptions,
 	getReviewMergeStatusQueryOptions,
 	listReviewReactionsQueryOptions,
+	listReviewTimelineEventsQueryOptions,
 } from "#ui/api/queries.ts";
 import {
 	Reactions,
@@ -28,6 +30,8 @@ import { DropdownButton } from "#ui/components/DropdownButton.tsx";
 import { FieldControlStyles, FieldRootStyles } from "#ui/components/Field.tsx";
 import { Icon } from "#ui/components/Icon.tsx";
 import { Markdown } from "#ui/components/Markdown.tsx";
+import { ReviewUser } from "#ui/routes/project/$id/workspace/PullRequestPanel.tsx";
+import { formatAbsoluteTime, formatRelativeTime } from "#ui/time.ts";
 import { branchDetailsParams } from "#ui/branch.ts";
 import { MarkdownAttachments } from "#ui/components/MarkdownAttachments.tsx";
 import { MarkdownToolbar } from "#ui/components/MarkdownToolbar.tsx";
@@ -54,7 +58,15 @@ import type { ForgeReview, ReviewMergeMethod, ReviewMergeStatus } from "@gitbutl
 import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { useHotkey } from "@tanstack/react-hotkeys";
 import { useMergedRefs } from "@base-ui/utils/useMergedRefs";
-import { type FC, type SubmitEvent, Suspense, useEffect, useRef, useState } from "react";
+import {
+	type FC,
+	type ReactNode,
+	type SubmitEvent,
+	Suspense,
+	useEffect,
+	useRef,
+	useState,
+} from "react";
 import styles from "./PullRequestForm.module.css";
 
 /**
@@ -478,6 +490,52 @@ export const PullRequestForm: FC<{
 };
 
 /** A designed action whose backing feature does not exist yet. */
+/**
+ * The line under the title: who opened the review, how many commits it
+ * carries and, once it has moved on from opening, when it last did. The side
+ * panel keeps the opening time.
+ */
+export const PullRequestMeta: FC<{ projectId: string; review: ForgeReview }> = ({
+	projectId,
+	review,
+}) => {
+	const { data: forgeInfo } = useQuery(forgeInfoOptions(projectId));
+	// The review itself does not say how many commits it holds; the forge's
+	// timeline, one event per commit currently on the review, does. It is the
+	// same query the side panel's Activity section reads, so the count costs
+	// nothing extra — and, like that section, only forges with a conversation
+	// serve it.
+	const { data: commitCount } = useQuery({
+		...listReviewTimelineEventsQueryOptions({ projectId, reviewId: review.number }),
+		enabled: forgeInfo?.capabilities.reviewComments !== false,
+		select: (events) => events.filter((event) => event.kind === "committed").length,
+	});
+	const createdAtMs = review.createdAt === null ? null : Date.parse(review.createdAt);
+	const modifiedAtMs = review.modifiedAt === null ? null : Date.parse(review.modifiedAt);
+	// The forge stamps modified_at on any activity, so creation itself can
+	// leave the two a moment apart; only a real gap is worth mentioning.
+	const updated =
+		modifiedAtMs !== null && (createdAtMs === null || modifiedAtMs - createdAtMs > 60_000)
+			? modifiedAtMs
+			: null;
+	const commits = commitCount !== undefined && commitCount > 0 ? commitCount : null;
+	if (review.author === null && commits === null && updated === null) return null;
+
+	return (
+		<div className={classes("text-13", styles.prViewMeta)}>
+			{review.author !== null && <ReviewUser user={review.author} />}
+			{commits !== null && (
+				<span>
+					{commits} commit{commits === 1 ? "" : "s"}
+				</span>
+			)}
+			{updated !== null && (
+				<span title={formatAbsoluteTime(updated)}>updated {formatRelativeTime(updated)}</span>
+			)}
+		</div>
+	);
+};
+
 /** Rendered PR title and body; the header's Edit button flips to the form. */
 export const PullRequestDescription: FC<{
 	projectId: string;
@@ -485,6 +543,8 @@ export const PullRequestDescription: FC<{
 	reviewId: number;
 	title: string;
 	body: string | null;
+	/** Sits between the title and the body while not editing. */
+	meta?: ReactNode;
 	canSubmit: boolean;
 	editing: boolean;
 	onDoneEditing: () => void;
@@ -496,6 +556,7 @@ export const PullRequestDescription: FC<{
 	reviewId,
 	title,
 	body,
+	meta,
 	canSubmit,
 	editing,
 	onDoneEditing,
@@ -542,7 +603,9 @@ export const PullRequestDescription: FC<{
 
 	return (
 		<div className={styles.prView}>
-			<h3 className={classes("text-15", "text-semibold")}>{title}</h3>
+			<h3 className={styles.prViewTitle}>{title}</h3>
+
+			{meta}
 
 			{body !== null && body.trim() !== "" ? (
 				// Taller ceiling than comments: only truly huge descriptions fold.

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestForm.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestForm.tsx
@@ -53,6 +53,7 @@ import { Field, Tooltip } from "@base-ui/react";
 import type { ForgeReview, ReviewMergeMethod, ReviewMergeStatus } from "@gitbutler/but-sdk";
 import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { useHotkey } from "@tanstack/react-hotkeys";
+import { useMergedRefs } from "@base-ui/utils/useMergedRefs";
 import { type FC, type SubmitEvent, Suspense, useEffect, useRef, useState } from "react";
 import styles from "./PullRequestForm.module.css";
 
@@ -101,6 +102,11 @@ export const PullRequestForm: FC<{
 	 * auto-merge). Never called when editing an existing PR.
 	 */
 	afterPublish?: (reviewId: number) => void;
+	/**
+	 * Which field takes focus when the form mounts: the title by default, the
+	 * description when the user came here to add one.
+	 */
+	autofocus?: "title" | "body";
 }> = ({
 	projectId,
 	sourceBranch,
@@ -112,6 +118,7 @@ export const PullRequestForm: FC<{
 	onAfterSubmit,
 	onCancel,
 	afterPublish,
+	autofocus = "title",
 }) => {
 	const { isPending: isPushPending, mutateAsync: pushBranchAndAncestors } =
 		useWorkspaceBranchAndAncestorsPush(projectId);
@@ -348,7 +355,7 @@ export const PullRequestForm: FC<{
 					render={<FieldControlStyles />}
 					aria-label="Pull request title"
 					data-focus-scope={"pr" satisfies FocusScope}
-					ref={useAutofocusScope()}
+					ref={useAutofocusScope(autofocus === "title")}
 					name="title"
 					onChange={(evt) => setLocalDocument({ ...localDocument, title: evt.currentTarget.value })}
 					placeholder="PR title"
@@ -373,7 +380,7 @@ export const PullRequestForm: FC<{
 					// Only the flip re-renders: React bails out of an unchanged state.
 					onScroll={(evt) => setBodyScrolled(evt.currentTarget.scrollTop > 0)}
 					placeholder="PR description"
-					ref={bodyRef}
+					ref={useMergedRefs(bodyRef, useAutofocusScope(autofocus === "body"))}
 					value={localDocument.body}
 				/>
 
@@ -481,7 +488,19 @@ export const PullRequestDescription: FC<{
 	canSubmit: boolean;
 	editing: boolean;
 	onDoneEditing: () => void;
-}> = ({ projectId, sourceBranch, reviewId, title, body, canSubmit, editing, onDoneEditing }) => {
+	/** Absent where the review is read-only, so the empty body offers no edit. */
+	onStartEditing?: () => void;
+}> = ({
+	projectId,
+	sourceBranch,
+	reviewId,
+	title,
+	body,
+	canSubmit,
+	editing,
+	onDoneEditing,
+	onStartEditing,
+}) => {
 	const { data: reviewReactions } = useQuery({
 		...listReviewReactionsQueryOptions({ projectId, reviewId }),
 		select: tallyReactions,
@@ -492,6 +511,13 @@ export const PullRequestDescription: FC<{
 	const toggleReaction = (kind: string, myReactionId: number | null) => {
 		if (myReactionId === null) addReviewReaction({ projectId, reviewId, kind });
 		else removeReviewReaction({ projectId, reviewId, reactionId: myReactionId });
+	};
+	// "Add one" and the header's Edit button share one edit mode, but the
+	// former was clicked to write a description, so the form opens on it.
+	const [autofocus, setAutofocus] = useState<"title" | "body">("title");
+	const doneEditing = () => {
+		setAutofocus("title");
+		onDoneEditing();
 	};
 
 	if (editing) {
@@ -506,8 +532,9 @@ export const PullRequestDescription: FC<{
 					sourceBranch={sourceBranch}
 					title={title}
 					canSubmit={canSubmit}
-					onAfterSubmit={onDoneEditing}
-					onCancel={onDoneEditing}
+					autofocus={autofocus}
+					onAfterSubmit={doneEditing}
+					onCancel={doneEditing}
 				/>
 			</Suspense>
 		);
@@ -523,7 +550,24 @@ export const PullRequestDescription: FC<{
 					<Markdown>{body}</Markdown>
 				</Clamped>
 			) : (
-				<p className={classes("text-13", styles.prViewEmptyBody)}>No description provided.</p>
+				<p className={classes("text-14", "text-body", styles.prViewEmptyBody)}>
+					No description
+					{onStartEditing !== undefined && (
+						<>
+							{" — "}
+							<button
+								className={styles.prViewAddDescription}
+								type="button"
+								onClick={() => {
+									setAutofocus("body");
+									onStartEditing();
+								}}
+							>
+								Add one
+							</button>
+						</>
+					)}
+				</p>
 			)}
 
 			{reviewReactions !== undefined && (

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestForm.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestForm.tsx
@@ -608,8 +608,11 @@ export const PullRequestDescription: FC<{
 			{meta}
 
 			{body !== null && body.trim() !== "" ? (
-				// Taller ceiling than comments: only truly huge descriptions fold.
-				<Clamped maxHeight="80vh" skipWhenViewportFits>
+				// A long description opens as a four-line card so the conversation
+				// below is in reach: four rather than three because a body that opens
+				// with a heading spends a line and a half on it. The slack means a
+				// fold always hides at least a few lines, never just one.
+				<Clamped maxHeight="4lh" foldOver="6lh" variant="card">
 					<Markdown>{body}</Markdown>
 				</Clamped>
 			) : (

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.module.css
@@ -45,7 +45,7 @@
 }
 
 .heading {
-	color: var(--text-3);
+	color: var(--text-2);
 }
 
 /* The Status section is its header alone: the badge and the PR link sit

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.module.css
@@ -39,8 +39,8 @@
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
-	/* Keep row height stable whether or not a picker button renders. */
-	min-height: 20px;
+	/* Keep row height stable whether or not a (small, tag-sized) picker button renders. */
+	min-height: var(--size-tag);
 	gap: 8px;
 }
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.module.css
@@ -4,7 +4,7 @@
 	   own padding is what `top` matches, so it neither jumps nor drifts as it
 	   pins. */
 	position: sticky;
-	top: 12px;
+	top: 16px;
 	/* Width is set by the details container so the header can align with
 	   the panel column (see --pr-panel-width in Details.module.css). */
 	flex: 0 0 var(--pr-panel-width, 315px);

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.module.css
@@ -28,13 +28,6 @@
 	}
 }
 
-/* Sections that read as one block with the section above it — no divider,
-   no gap between the two (Created and Updated). */
-.section + .sectionJoined {
-	padding-top: 0;
-	border-top: none;
-}
-
 .sectionHeader {
 	display: flex;
 	align-items: center;

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.tsx
@@ -133,6 +133,7 @@ const Label: FC<{ label: ForgeReviewLabel }> = ({ label }) => {
 	return (
 		<Badge
 			variant="lightGray"
+			size="large"
 			className={color === null ? undefined : styles.label}
 			style={color === null ? undefined : { "--label-color": color }}
 			title={label.description ?? undefined}

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.tsx
@@ -62,12 +62,10 @@ const statusBits = (status: ReviewStatus): [string, BadgeVariant, IconName] =>
 const Section: FC<{
 	heading: string;
 	action?: ReactNode;
-	/** Reads as one block with the section above it: no divider, no gap. */
-	joined?: boolean;
 	className?: string;
 	children: ReactNode;
 }> = (p) => (
-	<div className={classes(styles.section, p.joined === true && styles.sectionJoined, p.className)}>
+	<div className={classes(styles.section, p.className)}>
 		<div className={styles.sectionHeader}>
 			<h4 className={classes("text-12", styles.heading)}>{p.heading}</h4>
 			{p.action}
@@ -114,7 +112,7 @@ const pickerButton = (p: {
 		</button>
 	);
 
-const ReviewUser: FC<{ user: ForgeReviewUser }> = ({ user }) => (
+export const ReviewUser: FC<{ user: ForgeReviewUser }> = ({ user }) => (
 	<div className={classes("text-13", styles.user)} title={user.name ?? user.login}>
 		{user.avatarUrl !== null ? (
 			<img src={user.avatarUrl} className={styles.avatar} alt="" />
@@ -356,7 +354,7 @@ const ProblemCheckRow: FC<{ problem: ProblemCheck }> = ({ problem: { check, tone
 				{duration !== null && (
 					<>
 						{duration}
-						<span>•</span>
+						<span>·</span>
 					</>
 				)}
 				<Icon name="arrow-up-right" size={14} />
@@ -630,11 +628,6 @@ export const PullRequestPanel: FC<{
 	);
 
 	const createdAtMs = review.createdAt === null ? null : Date.parse(review.createdAt);
-	const modifiedAtMs = review.modifiedAt === null ? null : Date.parse(review.modifiedAt);
-	// The forge stamps modified_at on any activity, so creation itself can
-	// leave the two a moment apart; only a real gap is worth a row.
-	const showUpdated =
-		modifiedAtMs !== null && (createdAtMs === null || modifiedAtMs - createdAtMs > 60_000);
 
 	const handleOpen = (evt: MouseEvent<HTMLAnchorElement>): void => {
 		evt.preventDefault();
@@ -730,24 +723,10 @@ export const PullRequestPanel: FC<{
 				</div>
 			</Section>
 
-			{review.author !== null && (
-				<Section heading="Author">
-					<ReviewUser user={review.author} />
-				</Section>
-			)}
-
 			{createdAtMs !== null && (
 				<Section heading="Created">
 					<span className={classes("text-13", styles.created)}>
 						{formatRelativeTime(createdAtMs)}, {formatAbsoluteTime(createdAtMs)}
-					</span>
-				</Section>
-			)}
-
-			{showUpdated && (
-				<Section heading="Updated" joined>
-					<span className={classes("text-13", styles.created)}>
-						{formatRelativeTime(modifiedAtMs)}, {formatAbsoluteTime(modifiedAtMs)}
 					</span>
 				</Section>
 			)}

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestReactions.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestReactions.module.css
@@ -8,7 +8,8 @@
 .reactionChip {
 	display: inline-flex;
 	align-items: center;
-	padding: 4px 8px;
+	height: 24px;
+	padding: 0 8px;
 	gap: 4px;
 	border: none;
 	border-radius: 14px;
@@ -22,6 +23,35 @@
 	}
 }
 
+/* A suggestion nobody has taken yet: the same pill drawn as an empty slot, so
+   it reads as an offer rather than a tally. The ring is an SVG mask rather
+   than `border-style: dashed` because the browser's dashes are ~3px and get
+   stretched to fit each edge; the kit's stroke is a steady 2px on, 2px off
+   around the whole pill. The rect insets by half the stroke so the 1px line
+   sits fully inside the box, matching an inside-aligned stroke. */
+.reactionChipGhost {
+	position: relative;
+	background-color: transparent;
+
+	&::before {
+		position: absolute;
+		inset: 0;
+		border-radius: inherit;
+		background-color: var(--border-2);
+		content: "";
+		mask-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg'><rect x='.5' y='.5' rx='11.5' style='width:calc(100%25 - 1px);height:calc(100%25 - 1px)' fill='none' stroke='%23000' stroke-dasharray='2 2'/></svg>");
+		pointer-events: none;
+	}
+
+	&:hover:not(:disabled) {
+		background-color: var(--bg-2);
+
+		&::before {
+			display: none;
+		}
+	}
+}
+
 /* The caller's own reaction inverts, so their tallies stand out from the rest
    of the row at a glance. */
 .reactionChipMine {
@@ -31,6 +61,17 @@
 	&.reactionChipButton:hover:not(:disabled) {
 		background-color: color-mix(in srgb, var(--fill-gray-bg) 85%, var(--scale-gray-0));
 	}
+}
+
+/* The picker trigger sits in the chip row, so it takes the chips' 24px and
+   rounds off to a circle instead of the button ladder's 20/28 and corner
+   radius. Nested for specificity over the button's own radius. */
+.reactions .reactionPickerTrigger {
+	--button-height: 24px;
+	--button-width: 24px;
+	--button-padding-inline: 4px;
+
+	border-radius: 50%;
 }
 
 /* A horizontal row rather than the popup's usual stack of rows. */

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestReactions.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestReactions.tsx
@@ -27,6 +27,14 @@ const reactionGlyphs: Array<[string, string]> = [
 
 const glyphByKind = new Map(reactionGlyphs);
 
+/**
+ * The kinds offered inline as dashed ghost chips, so the common reactions
+ * are one click away instead of all hiding behind the picker. A kind drops
+ * out of the suggestions once anyone has reacted with it: its tally chip
+ * takes the slot.
+ */
+const suggestedKinds = ["+1", "hooray", "eyes"];
+
 const reactionNames: Record<string, string> = {
 	"+1": "thumbs up",
 	"-1": "thumbs down",
@@ -80,7 +88,12 @@ export const Reactions: FC<{
 	 * or null to add one of `kind`. Chips are display-only without this.
 	 */
 	onToggle?: (kind: string, myReactionId: number | null) => void;
-}> = ({ reactions, reactors, myLogin, onToggle }) => {
+	/**
+	 * Offer the common kinds inline as ghost chips. Only the pull request's
+	 * own row does this: repeating the offer under every comment is noise.
+	 */
+	suggest?: boolean;
+}> = ({ reactions, reactors, myLogin, onToggle, suggest = false }) => {
 	const [pickerOpen, setPickerOpen] = useState(false);
 
 	const mineFor = (kind: string) =>
@@ -102,6 +115,11 @@ export const Reactions: FC<{
 		if (mine !== undefined && mine.id < 0) return;
 		onToggle?.(kind, mine?.id ?? null);
 	};
+
+	const suggestions =
+		suggest && onToggle !== undefined
+			? suggestedKinds.filter((kind) => !chips.some((chip) => chip.kind === kind))
+			: [];
 
 	return (
 		<div className={styles.reactions}>
@@ -153,6 +171,23 @@ export const Reactions: FC<{
 				);
 			})}
 
+			{suggestions.map((kind) => (
+				<button
+					key={kind}
+					type="button"
+					aria-label={`React with ${reactionName(kind)}`}
+					className={classes(
+						"text-12",
+						styles.reactionChip,
+						styles.reactionChipButton,
+						styles.reactionChipGhost,
+					)}
+					onClick={() => toggle(kind, undefined)}
+				>
+					{glyphByKind.get(kind)}
+				</button>
+			))}
+
 			{onToggle !== undefined && (
 				<Dropdown
 					open={pickerOpen}
@@ -161,7 +196,10 @@ export const Reactions: FC<{
 					trigger={
 						<button
 							aria-label="Add reaction"
-							className={getButtonClassName({ variant: "ghost", iconOnly: true })}
+							className={classes(
+								getButtonClassName({ variant: "ghost", iconOnly: true }),
+								styles.reactionPickerTrigger,
+							)}
 							type="button"
 						>
 							<Icon name="smiley" />

--- a/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
@@ -244,8 +244,8 @@
 	display: flex;
 	flex-shrink: 0;
 	align-items: center;
-	/* Match small button height to prevent layout shift when buttons appear/disappear. */
-	height: 20px;
+	/* Small buttons are tag-sized; matching them prevents layout shift when they appear/disappear. */
+	height: var(--size-tag);
 	gap: 4px;
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -423,8 +423,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/but-sdk
       '@gitbutler/design-core':
-        specifier: 3.17.0
-        version: 3.17.0
+        specifier: 3.17.1
+        version: 3.17.1
       '@pierre/diffs':
         specifier: ^1.3.5
         version: 1.3.5(@shikijs/themes@4.3.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -2057,8 +2057,8 @@ packages:
   '@gitbutler/design-core@2.2.2':
     resolution: {integrity: sha512-oPPnYjwsKxwoTY6wK/fT9ylwhSIBgQxCOGJzYefbM8WFr2OuJePH9MnDnZ3K9UQlb94p+NR7m/QCFzhbDVRwxw==}
 
-  '@gitbutler/design-core@3.17.0':
-    resolution: {integrity: sha512-Hit2KLnoHe7vMn+6pWXCZxScOtgbfFwfhgwZgXXpMXmy5/lbghzgQ40Sk8rsgLMm8Q6m8ay9uqsjWcl6IV4AUA==}
+  '@gitbutler/design-core@3.17.1':
+    resolution: {integrity: sha512-P3L4J+cMFf+HpXVIlIX8DCObDwGiAjOLb60mfQ6BxGaGswqQyVUCc+16fo7sGg1f5P4gCeHgVPOeMVUfso8J4Q==}
 
   '@gitbutler/design-core@3.9.1':
     resolution: {integrity: sha512-kLkZ1+pqeqpBntBOSV53kYVCmY/ZFemjxsWc78GTGLgn1Op8p7bWCNxCUSU822MKLJrzmjUg99MpqdHpXGcNAQ==}
@@ -11355,7 +11355,7 @@ snapshots:
 
   '@gitbutler/design-core@2.2.2': {}
 
-  '@gitbutler/design-core@3.17.0': {}
+  '@gitbutler/design-core@3.17.1': {}
 
   '@gitbutler/design-core@3.9.1': {}
 


### PR DESCRIPTION
Brings the Lite pull request tab up to the Figma spec, everything except the conversation feed, which GB-1941 now tracks.

## What changes

**Description.** The title is set in the markdown H1's face, and under it one line of facts joined by middle dots: who opened the review, how many commits it carries (read from the timeline the Activity section already fetches), and when it was last updated once that differs from its opening. The side panel keeps the opening time and drops its Author and Updated sections, which the meta line replaces.

**Long descriptions fold into a card.** A body only folded past 80% of the viewport, so most PRs pushed the conversation well below the fold. Past six lines the description now opens as a four-line card on a quiet ground, faded at its last line, with a chevron at the corner. The whole card opens on click and darkens on hover; opened, the body lies flat with the chevron at the top right. The card is pulled out by its own inset so the text stays on the column edge with the title in both states, and nothing reflows on toggle. Short bodies get neither card nor chevron. An empty body reads "No description — Add one", with the link flipping into the edit form where the review is editable.

**Reactions.** The pull request's own row offers thumbs up, hooray and eyes as dashed ghost chips one click from a reaction; a kind leaves the suggestions once anyone has reacted with it. Comment cards keep the compact row.

**Layout.** The tab's side inset and column gap grow with the pane through a container query, the column cap excludes the inset so it never eats into the content, and the side panel's sticky top matches the tab's block padding. Labels use the large badge size to match the status badge, tag-sized heights read the `--size-tag` token from design-core 3.17.1, and the panel headings gain contrast.

**Markdown.** Spacing follows the ⚛️ Lite Core Markdown kit (12px between text blocks, 16 around anything with an edge, 4 within a list, 24 above a heading). Every link leaves the app, so each carries a small external arrow. A Markdown story renders the kit's sample document so the two can be compared, and DESIGN.md gains a Markdown section.

## Clamped

`Clamped` gains a `card` variant, lengths in `lh` resolved against the content's own line-height, and a `foldOver` trigger above the clamp height so a fold never hides just a line or two. The tree stays identical across states and a fold only ever latches on: a fold that changed the layout under its own measurement flickered between states, which is how the first version behaved.

## Screenshots

Before:

<img width="1179" height="943" alt="image" src="https://github.com/user-attachments/assets/a09c8d62-d80c-4ff0-982e-c32303a6465f" />

After:

<img width="856" height="427" alt="image" src="https://github.com/user-attachments/assets/ff6d3700-562a-4712-aea0-678091577898" />
