### PR TITLE
Lite: drop the unread dots from the pull request tab and branch row

### DIFF
--- a/apps/lite/e2e/tests/sidebar.spec.ts
+++ b/apps/lite/e2e/tests/sidebar.spec.ts
@@ -93,11 +93,6 @@ test("keeps unread PR activity off the Workspace tab", async ({ appWindow, elect
 	await appWindow.reload();
 
 	await expect(appWindow.getByRole("button", { name: "Notifications, 1 unread" })).toBeVisible();
-	await expect(
-		appWindow
-			.getByRole("treeitem", { name: "C", exact: true })
-			.getByTitle("New activity on this pull request"),
-	).toBeVisible();
 	const pages = appWindow.getByRole("group", { name: "Pages" });
 	await expect(pages.getByRole("button", { name: "Workspace", exact: true })).toHaveText(
 		"Workspace",

--- a/apps/lite/harness/tests/panel.test.tsx
+++ b/apps/lite/harness/tests/panel.test.tsx
@@ -181,10 +181,10 @@ test("someone else's review activity files one coalesced inbox entry and the unr
 		listReviewTimelineEvents: () => [],
 	});
 
-	// The PR chip proves the baseline listing landed, and that nothing is
-	// unread yet — history must never replay as notifications.
+	// The PR chip proves the baseline listing landed; nothing is filed yet —
+	// history must never replay as notifications.
 	await vi.waitFor(() => expect(panel.container.textContent).toContain("PR"), settle);
-	expect(document.querySelector('[title="New activity on this pull request"]')).toBeNull();
+	expect(inboxEntries()).toHaveLength(0);
 
 	// Someone comments; the forge bumps the review and a fetch notices.
 	review = { ...review, modifiedAt: "2026-01-01T11:00:00Z" };
@@ -204,14 +204,9 @@ test("someone else's review activity files one coalesced inbox entry and the unr
 	const event: WatcherEvent = { name: "gitFetch", payload: { type: "gitFetch", subject: null } };
 	panel.push(eventChannel, event);
 
-	// One coalesced, attributed inbox entry — and the unread dot alongside it.
+	// One coalesced, attributed inbox entry.
 	await vi.waitFor(() => expect(inboxEntries()).toHaveLength(1), settle);
 	expect(inboxEntries()[0]).toMatchObject({ kind: "comment", review: 7, author: "alice" });
-	await vi.waitFor(
-		() =>
-			expect(document.querySelector('[title="New activity on this pull request"]')).not.toBeNull(),
-		settle,
-	);
 
 	panel.unmount();
 });

--- a/apps/lite/ui/src/review-notifications.ts
+++ b/apps/lite/ui/src/review-notifications.ts
@@ -2,9 +2,9 @@
  * @file Turning review activity into inbox entries.
  *
  * The decisions are pure and live in `review-activity.ts`; the hook here
- * feeds them the listing the app polls anyway. The unread dots stay the
- * record — the bell is the cross-review view of the same facts, and the
- * desktop hears the loud ones while the window is elsewhere.
+ * feeds them the listing the app polls anyway. The per-review seen marks
+ * stay the record — the bell is the cross-review view of the same facts, and
+ * the desktop hears the loud ones while the window is elsewhere.
  */
 
 import {

--- a/apps/lite/ui/src/review-seen.ts
+++ b/apps/lite/ui/src/review-seen.ts
@@ -19,7 +19,7 @@ import { createContext, useEffect, useEffectEvent, useState, useSyncExternalStor
 
 /**
  * The PR-notifications dial: loud files activity into the bell, quiet
- * keeps only the unread dots, off hides the tracking UI entirely.
+ * tracks what was seen without showing it, off hides the tracking UI entirely.
  */
 export const usePrNotificationsLevel = (): "loud" | "quiet" | "off" => {
 	const { data: level } = useQuery({
@@ -276,7 +276,7 @@ const isUnread = (
  * Whether one review has unread activity — a boolean, so a watermark moving
  * on another review leaves this subscriber alone.
  */
-export const useReviewUnread = (
+const useReviewUnread = (
 	projectId: string,
 	review: { number: number; modifiedAt: string | null },
 	enabled: boolean,

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -40,10 +40,8 @@ import {
 	SeenOnArrivalContext,
 	useMarkReviewSeenOnView,
 	usePrNotificationsLevel,
-	useReviewUnread,
 	useSeenOnArrival,
 } from "#ui/review-seen.ts";
-import rowStyles from "./Row.module.css";
 import { decodeBytes } from "#ui/api/bytes.ts";
 import type { ForgeReview, TargetCommitReview, UnifiedPatch } from "@gitbutler/but-sdk";
 import { branchDetailsParams } from "#ui/branch.ts";
@@ -3241,10 +3239,8 @@ const BranchTabToggle: FC<{
 	branchTab: BranchTab;
 	setBranchTab: (tab: BranchTab) => void;
 	prDisabled?: boolean;
-	/** Marks the Pull Request tab with an unread-activity dot. */
-	prUnread?: boolean;
 	className?: string;
-}> = ({ branchTab, setBranchTab, prDisabled = false, prUnread = false, className }) => (
+}> = ({ branchTab, setBranchTab, prDisabled = false, className }) => (
 	<ToggleGroup
 		render={<ToggleGroupStyles className={className} />}
 		value={[branchTab]}
@@ -3260,11 +3256,6 @@ const BranchTabToggle: FC<{
 		</Toggle>
 		<Toggle render={<ToggleStyles />} value={"pr" satisfies BranchTab} disabled={prDisabled}>
 			{prDisabled ? "No pull request" : "Pull Request"}
-			{!prDisabled && prUnread && (
-				<span className={rowStyles.unreadDot}>
-					<span className={rowStyles.unreadLabel}>New activity</span>
-				</span>
-			)}
 		</Toggle>
 	</ToggleGroup>
 );
@@ -3498,13 +3489,6 @@ const UnappliedBranchDetails: FC<BranchDetailsProps> = ({
 		<LandedReviewView projectId={projectId} reviewId={landedReviewId} />
 	) : null;
 
-	const notificationsLevel = usePrNotificationsLevel();
-	const prUnread = useReviewUnread(
-		projectId,
-		{ number: review?.number ?? 0, modifiedAt: review?.modifiedAt ?? null },
-		review != null && forgeInfo?.capabilities.prService === true && notificationsLevel !== "off",
-	);
-
 	const chosenTab = useAppSelector((state) =>
 		projectSlice.selectors.selectBranchTab(state, projectId, branchName),
 	);
@@ -3532,7 +3516,6 @@ const UnappliedBranchDetails: FC<BranchDetailsProps> = ({
 						branchTab={branchTab}
 						setBranchTab={setBranchTab}
 						prDisabled={reviewTab === null}
-						prUnread={prUnread}
 					/>
 
 					<div className={styles.tabsRowRight}>
@@ -3642,27 +3625,13 @@ const AppliedBranchDetails: FC<BranchDetailsProps> = ({
 		branchTab === "pr" && hasOpenReview === false,
 	);
 
-	// Subscribed regardless of the chosen tab: the dot on the toggle is what
-	// tells a reader parked on the diff that the review moved.
-	const notificationsLevel = usePrNotificationsLevel();
-	const { data: openReview } = useQuery({
-		...listReviewsQueryOptions({ projectId, cacheConfig: "noCache" }),
-		enabled: !!forgeInfo?.capabilities.prService && notificationsLevel !== "off",
-		select: (reviews) => reviews.find((review) => review.sourceBranch === branchName) ?? null,
-	});
-	const prUnread = useReviewUnread(
-		projectId,
-		{ number: openReview?.number ?? 0, modifiedAt: openReview?.modifiedAt ?? null },
-		!!openReview && !!forgeInfo?.capabilities.prService && notificationsLevel !== "off",
-	);
-
 	return (
 		<div className={styles.container} ref={ref}>
 			<div className={styles.headerWrap}>
 				<BranchTitleRow branchName={branchName} />
 
 				<div className={styles.tabsRow}>
-					<BranchTabToggle branchTab={branchTab} setBranchTab={setBranchTab} prUnread={prUnread} />
+					<BranchTabToggle branchTab={branchTab} setBranchTab={setBranchTab} />
 
 					{branchTab === "pr" && !!forgeInfo?.capabilities.prService && (
 						<Suspense>

--- a/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
@@ -255,28 +255,6 @@
 	opacity: 0.4;
 }
 
-/* Unread-activity dot on a meta item such as the PR chip. */
-.unreadDot {
-	/* Anchors the hidden label; unanchored it would land at the document's
-	   own coordinates and stretch the page. */
-	position: relative;
-	flex-shrink: 0;
-	width: 6px;
-	height: 6px;
-	border-radius: 50%;
-	background-color: var(--fill-pop-bg);
-}
-
-/* What the dot means, for readers the dot cannot reach. Lives inside the
-   dot so the pair costs one flex slot and the label stays anchored. */
-.unreadLabel {
-	position: absolute;
-	width: 1px;
-	height: 1px;
-	overflow: hidden;
-	clip: rect(0, 0, 0, 0);
-}
-
 /* Button sitting in a meta row: stands a little further off from the facts it
    follows, since no separator dot divides them. */
 .metaButton {

--- a/apps/lite/ui/src/routes/project/$id/workspace/Settings/General.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Settings/General.tsx
@@ -98,7 +98,7 @@ export const General: FC = () => {
 				<Row
 					label="Pull request activity"
 					htmlFor="pr-notifications"
-					hint="Loud collects notifications in the bell; quiet keeps just the unread dots."
+					hint="Loud collects notifications in the bell; quiet and off keep it hidden."
 				>
 					<select
 						id="pr-notifications"

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/BranchRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/BranchRow.tsx
@@ -20,7 +20,6 @@ import {
 	listCIChecksQueryOptions,
 	listReviewsQueryOptions,
 } from "#ui/api/queries.ts";
-import { usePrNotificationsLevel, useReviewUnread } from "#ui/review-seen.ts";
 import { decodeBytes } from "#ui/api/bytes.ts";
 import { Button, Toolbar, Tooltip } from "@base-ui/react";
 import type {
@@ -181,12 +180,6 @@ export const BranchRow: FC<
 	});
 	const openReview = reviews?.reviewsBySourceBranch.get(refName.displayName);
 	const openPullRequest = openReview?.number ?? null;
-	const notificationsLevel = usePrNotificationsLevel();
-	const reviewUnread = useReviewUnread(
-		projectId,
-		{ number: openPullRequest ?? 0, modifiedAt: openReview?.modifiedAt ?? null },
-		openPullRequest !== null && !!forgeInfo?.capabilities.prService && notificationsLevel !== "off",
-	);
 	// The chip renders the recorded number as-is: the projection only records
 	// display-worthy reviews, the chip must survive being offline, and a
 	// per-row verification fetch is not worth it. The details pane does verify
@@ -611,19 +604,9 @@ export const BranchRow: FC<
 						{pullRequest !== null && (
 							<>
 								<RowMetaSeparator />
-								<span
-									className={classes(rowStyles.fadedText, rowStyles.metaItem)}
-									title={reviewUnread ? "New activity on this pull request" : undefined}
-								>
+								<span className={classes(rowStyles.fadedText, rowStyles.metaItem)}>
 									<Icon size={14} name="pr" />
 									PR
-									{reviewUnread && (
-										<span className={rowStyles.unreadDot}>
-											<span className={rowStyles.unreadLabel}>
-												New activity on this pull request
-											</span>
-										</span>
-									)}
 								</span>
 
 								{ciChecks?.aggregate &&

--- a/apps/lite/ui/src/settings.ts
+++ b/apps/lite/ui/src/settings.ts
@@ -28,7 +28,7 @@ export const defaultSettings = {
 	minimap: false,
 	// Lite has always led with the file name; desktop leads with the path.
 	pathFirst: false,
-	// Loud = the notification bell and unread dots; quiet = dots only;
+	// Loud = the notification bell; quiet = tracked but nothing shown;
 	// off = no PR-activity tracking in the UI at all.
 	prNotifications: "loud",
 	terminalId: "",


### PR DESCRIPTION
Removes the teal dot from the Pull Request tab and from the PR chip in the branch row. The notification bell stays.

## Motivation

**It is not clear what the dot means.** There is no label and no hint. A new user sees a colored dot and has to guess whether it means new comments, a failed check, or something else.

**Clicking it leads nowhere.** A dot promises that something new is waiting behind it. So when you click the tab or the row, you expect to be taken to that thing, or at least to see it highlighted. Right now nothing happens. The tab opens as usual and you have to scan the whole page to find what changed. Showing the dot without that second half is doing half the job, and half a feature is worse than none.

**It is flaky.** The dot lights up for your own pushes and comments, because it only compares the PR's last-modified time against a timestamp saved on this machine. It goes away only after the tab has been open and focused for a second, so a quick look leaves it on. And two computers disagree about what is new.

<img width="1044" height="269" alt="Screenshot 2026-09-09 at 01-07-27" src="https://github.com/user-attachments/assets/aa9381c3-e8b3-4c28-ad2d-2a14f64b0cac" />

On the video below I can make the dot disappear.

https://github.com/user-attachments/assets/f1a9a914-be31-4a9d-bac9-a3bf4c7a6613

**In the branch row it competes with the CI tick.** There may be room for an unread marker in the row, but a green dot is not it. The tick is green and the dot is green, so they look like one thing and neither reads clearly. And the row can already hold several buttons, so one more indicator squeezed in next to them is not a good idea without a design that decides what belongs there.

<img width="961" height="142" alt="Screenshot 2026-09-09 at 01-07-14" src="https://github.com/user-attachments/assets/2a14cf5c-d1d8-4cb2-bbed-b8934476bfc1" />

The bell still lists the same activity, so nothing is lost. If we bring unread markers back, they should come with a proper design: a clear meaning, a look that does not clash with the checks, and a click that takes you to what is new.

## Changes

- The Diff / Pull Request toggle and both of its call sites drop the unread flag, the dot, and the subscriptions and extra review query that fed it.
- The branch row drops the dot, its hover title, and the now-unused CSS classes.
- Seen tracking stays, since the bell rests on it.
- With the dots gone the "Quiet" level shows nothing, so the settings hint and code comments say so. Folding Quiet into Off changes stored settings and is left for a separate decision.
- The harness test checks the inbox directly instead of the dot; the e2e sidebar test drops its dot assertion.
