### PR TITLE
Suggest collaborators as an @ is typed on the Lite PR page

### DIFF
--- a/apps/lite/ui/src/components/MentionSuggestions.module.css
+++ b/apps/lite/ui/src/components/MentionSuggestions.module.css
@@ -1,0 +1,37 @@
+.popup {
+	min-width: 220px;
+	max-width: 320px;
+}
+
+.list {
+	display: flex;
+	flex-direction: column;
+	padding: 4px;
+}
+
+.row {
+	display: flex;
+	align-items: center;
+	min-width: 0;
+	gap: 8px;
+}
+
+.avatar {
+	flex: none;
+	width: 16px;
+	height: 16px;
+	object-fit: cover;
+	border-radius: 50%;
+	background-color: var(--bg-2);
+}
+
+.login {
+	flex: none;
+}
+
+.name {
+	min-width: 0;
+	overflow: hidden;
+	color: var(--text-3);
+	text-overflow: ellipsis;
+}

--- a/apps/lite/ui/src/components/MentionSuggestions.tsx
+++ b/apps/lite/ui/src/components/MentionSuggestions.tsx
@@ -1,0 +1,221 @@
+import { reviewerCandidatesQueryOptions } from "#ui/api/queries.ts";
+import { Popup, PopupItem } from "#ui/components/Popup.tsx";
+import { applyToTextarea } from "#ui/markdown-textarea.ts";
+import { completeMention, matchMentions, mentionAtCaret } from "#ui/mentions.ts";
+import { Popover } from "@base-ui/react";
+import type { ForgeReviewUser } from "@gitbutler/but-sdk";
+import { useQuery } from "@tanstack/react-query";
+import {
+	type ChangeEvent,
+	type KeyboardEvent,
+	type RefObject,
+	type SyntheticEvent,
+	useId,
+	useMemo,
+	useState,
+} from "react";
+import styles from "./MentionSuggestions.module.css";
+
+type Props = {
+	projectId: string;
+	targetRef: RefObject<HTMLTextAreaElement | null>;
+	value: string;
+	onInput: (value: string) => void;
+};
+
+/** The textarea styles that decide where its text wraps. */
+const LAYOUT_STYLES = [
+	"box-sizing",
+	"width",
+	"padding",
+	"border-width",
+	"font-family",
+	"font-size",
+	"font-weight",
+	"font-style",
+	"line-height",
+	"letter-spacing",
+	"tab-size",
+];
+
+/**
+ * Where the character at `index` sits on screen. A textarea does not expose
+ * the layout of its text, so a hidden copy is laid out the same way with that
+ * character wrapped in a span, and the span is measured instead.
+ */
+const characterRect = (textarea: HTMLTextAreaElement, index: number): DOMRect => {
+	const mirror = document.createElement("div");
+	const computed = getComputedStyle(textarea);
+	for (const property of LAYOUT_STYLES)
+		mirror.style.setProperty(property, computed.getPropertyValue(property));
+	mirror.style.position = "absolute";
+	mirror.style.visibility = "hidden";
+	mirror.style.whiteSpace = "pre-wrap";
+	mirror.style.overflowWrap = "break-word";
+	mirror.textContent = textarea.value.slice(0, index);
+	const marker = document.createElement("span");
+	const char = textarea.value.charAt(index);
+	marker.textContent = char === "" ? " " : char;
+	// Full line height, so the popup hangs under the line rather than the glyph.
+	marker.style.display = "inline-block";
+	mirror.append(marker);
+	document.body.append(mirror);
+
+	const host = textarea.getBoundingClientRect();
+	const rect = new DOMRect(
+		host.left + textarea.clientLeft + marker.offsetLeft - textarea.scrollLeft,
+		host.top + textarea.clientTop + marker.offsetTop - textarea.scrollTop,
+		marker.offsetWidth,
+		marker.offsetHeight,
+	);
+	mirror.remove();
+	return rect;
+};
+
+/**
+ * Offer collaborators as an `@` is typed and complete the one chosen. The
+ * returned props go on the textarea, which keeps focus throughout; `onKeyDown`
+ * returns whether the popup took the key, so the owner can handle the rest.
+ */
+export const useMentionSuggestions = ({ projectId, targetRef, value, onInput }: Props) => {
+	// Tracked from onChange as well as onSelect: onSelect fires a task later,
+	// and a render in between would pair the new text with the old caret.
+	const [selectionStart, setSelectionStart] = useState(0);
+	const [selectionEnd, setSelectionEnd] = useState(0);
+	// Escape closes the popup for this `@` until the caret backs out past it.
+	const [dismissedAt, setDismissedAt] = useState<number | null>(null);
+	const [highlighted, setHighlighted] = useState(0);
+	const listId = useId();
+
+	// By hand: the compiler cannot tell `mentionAtCaret` is pure, and without
+	// this it rebuilds every closure below on each render, the query's `select` too.
+	const mention = useMemo(
+		() => mentionAtCaret({ text: value, start: selectionStart, end: selectionEnd }),
+		[value, selectionStart, selectionEnd],
+	);
+	const at = mention?.at ?? null;
+	const query = mention?.query ?? null;
+	const { data: matches = [] } = useQuery({
+		...reviewerCandidatesQueryOptions(projectId),
+		select: (candidates) => (query === null ? [] : matchMentions(candidates, query)),
+	});
+	const open = at !== null && at !== dismissedAt && matches.length > 0;
+	const highlightedUser = matches[highlighted];
+	const optionId = (user: ForgeReviewUser) => `${listId}-${user.id}`;
+
+	const track = (target: HTMLTextAreaElement) => {
+		setSelectionStart(target.selectionStart);
+		setSelectionEnd(target.selectionEnd);
+		setHighlighted(0);
+		if (dismissedAt !== null && target.selectionEnd <= dismissedAt) setDismissedAt(null);
+	};
+
+	const accept = (user: ForgeReviewUser) => {
+		const target = targetRef.current;
+		if (target === null || at === null) return;
+		onInput(applyToTextarea(target, completeMention(at, user.login)));
+		track(target);
+	};
+
+	const onKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>): boolean => {
+		if (at === null || !open || event.metaKey || event.ctrlKey || event.altKey || event.shiftKey)
+			return false;
+		switch (event.key) {
+			case "ArrowDown":
+				setHighlighted((highlighted + 1) % matches.length);
+				break;
+			case "ArrowUp":
+				setHighlighted((highlighted + matches.length - 1) % matches.length);
+				break;
+			case "Enter":
+			case "Tab":
+				if (highlightedUser === undefined) return false;
+				accept(highlightedUser);
+				break;
+			case "Escape":
+				setDismissedAt(at);
+				break;
+			default:
+				return false;
+		}
+		event.preventDefault();
+		// Keeps the window's own Escape and hotkeys out of it.
+		event.stopPropagation();
+		return true;
+	};
+
+	// Anchored on the `@` rather than the caret, so the popup holds still as the query grows.
+	const anchor = () => {
+		const target = targetRef.current;
+		return target === null || at === null
+			? null
+			: { contextElement: target, getBoundingClientRect: () => characterRect(target, at) };
+	};
+
+	const popup = (
+		<Popover.Root
+			open={open}
+			onOpenChange={(next) => {
+				if (!next && at !== null) setDismissedAt(at);
+			}}
+		>
+			{/* Unmounted rather than closed: a closing animation would play over an emptied list. */}
+			{open && (
+				<Popover.Portal>
+					<Popover.Positioner anchor={anchor} side="bottom" align="start" sideOffset={4}>
+						<Popup
+							anchored
+							className={styles.popup}
+							render={<Popover.Popup initialFocus={false} finalFocus={false} />}
+						>
+							{/* oxlint-disable-next-line jsx-a11y/prefer-tag-over-role -- No native list floats under a textarea. */}
+							<div aria-label="Mention someone" className={styles.list} id={listId} role="listbox">
+								{matches.map((user, index) => (
+									<PopupItem
+										aria-selected={index === highlighted}
+										data-highlighted={index === highlighted || undefined}
+										id={optionId(user)}
+										key={user.id}
+										onClick={() => accept(user)}
+										// Keeps focus, and so the caret, in the textarea.
+										onMouseDown={(event) => event.preventDefault()}
+										onPointerMove={() => setHighlighted(index)}
+										// oxlint-disable-next-line jsx-a11y/prefer-tag-over-role -- Same as the listbox.
+										role="option"
+										tabIndex={-1}
+									>
+										<span className={styles.row}>
+											{user.avatarUrl !== null ? (
+												<img src={user.avatarUrl} className={styles.avatar} alt="" />
+											) : (
+												<span className={styles.avatar} />
+											)}
+											<span className={styles.login}>{user.login}</span>
+											{user.name !== null && <span className={styles.name}>{user.name}</span>}
+										</span>
+									</PopupItem>
+								))}
+							</div>
+						</Popup>
+					</Popover.Positioner>
+				</Popover.Portal>
+			)}
+		</Popover.Root>
+	);
+
+	return {
+		textareaProps: {
+			onChange: (event: ChangeEvent<HTMLTextAreaElement>) => {
+				onInput(event.currentTarget.value);
+				track(event.currentTarget);
+			},
+			onSelect: (event: SyntheticEvent<HTMLTextAreaElement>) => track(event.currentTarget),
+			"aria-autocomplete": "list" as const,
+			"aria-controls": open ? listId : undefined,
+			"aria-activedescendant":
+				open && highlightedUser !== undefined ? optionId(highlightedUser) : undefined,
+		},
+		onKeyDown,
+		popup,
+	};
+};

--- a/apps/lite/ui/src/mentions.test.ts
+++ b/apps/lite/ui/src/mentions.test.ts
@@ -1,0 +1,133 @@
+import { completeMention, matchMentions, mentionAtCaret } from "#ui/mentions.ts";
+import type { ForgeReviewUser } from "@gitbutler/but-sdk";
+import { describe, expect, test } from "vitest";
+
+/** Spells a case as one string: `|` is the caret, `[` and `]` fence a selection. */
+const parse = (spec: string) => {
+	if (spec.includes("|")) {
+		const start = spec.indexOf("|");
+		return { text: spec.replace("|", ""), start, end: start };
+	}
+	const start = spec.indexOf("[");
+	const end = spec.indexOf("]") - 1;
+	return { text: spec.replace("[", "").replace("]", ""), start, end };
+};
+
+const user = (login: string, name: string | null = null): ForgeReviewUser => ({
+	id: 0,
+	login,
+	name,
+	email: null,
+	avatarUrl: null,
+	isBot: false,
+});
+
+describe("mentionAtCaret", () => {
+	test("finds the mention being typed", () => {
+		expect(mentionAtCaret(parse("hello @bo|"))).toEqual({ at: 6, query: "bo" });
+	});
+
+	test("opens on a bare @", () => {
+		expect(mentionAtCaret(parse("@|"))).toEqual({ at: 0, query: "" });
+		expect(mentionAtCaret(parse("line\n@|"))).toEqual({ at: 5, query: "" });
+	});
+
+	test("allows punctuation before the @", () => {
+		expect(mentionAtCaret(parse("(@bo|"))).toEqual({ at: 1, query: "bo" });
+	});
+
+	test("takes hyphens as part of a login", () => {
+		expect(mentionAtCaret(parse("@my-bot|"))).toEqual({ at: 0, query: "my-bot" });
+	});
+
+	test("leaves an email address alone", () => {
+		expect(mentionAtCaret(parse("mail me@bo|"))).toBeNull();
+	});
+
+	test("ignores a caret that is not at the end of the word", () => {
+		expect(mentionAtCaret(parse("@bo|b"))).toBeNull();
+		expect(mentionAtCaret(parse("@|bob"))).toBeNull();
+	});
+
+	test("ignores a finished mention", () => {
+		expect(mentionAtCaret(parse("hi @bob |"))).toBeNull();
+	});
+
+	test("ignores text without a mention", () => {
+		expect(mentionAtCaret(parse("hi |"))).toBeNull();
+		expect(mentionAtCaret(parse("|"))).toBeNull();
+	});
+
+	test("ignores a selection", () => {
+		expect(mentionAtCaret(parse("@[bo]"))).toBeNull();
+	});
+});
+
+describe("matchMentions", () => {
+	const candidates = [
+		user("xseb"),
+		user("bob", "Bob Sebastian"),
+		user("sebastian", "Seb"),
+		user("alice"),
+	];
+
+	test("puts logins starting with the query first", () => {
+		expect(matchMentions(candidates, "seb").map((u) => u.login)).toEqual([
+			"sebastian",
+			"xseb",
+			"bob",
+		]);
+	});
+
+	test("ignores case", () => {
+		expect(matchMentions(candidates, "SEB").map((u) => u.login)).toEqual([
+			"sebastian",
+			"xseb",
+			"bob",
+		]);
+	});
+
+	test("offers everyone to a bare @", () => {
+		expect(matchMentions(candidates, "").map((u) => u.login)).toEqual([
+			"xseb",
+			"bob",
+			"sebastian",
+			"alice",
+		]);
+	});
+
+	test("caps the list", () => {
+		const many = Array.from({ length: 12 }, (_, i) => user(`user${i}`));
+		expect(matchMentions(many, "user")).toHaveLength(8);
+	});
+
+	test("finds no one for a stranger", () => {
+		expect(matchMentions(candidates, "zed")).toEqual([]);
+	});
+});
+
+describe("completeMention", () => {
+	test("replaces the partial with the login and a space", () => {
+		expect(completeMention(3, "bob")(parse("hi @bo|"))).toEqual({
+			text: "hi @bob ",
+			start: 8,
+			end: 8,
+		});
+	});
+
+	test("reuses a space that already follows the caret", () => {
+		expect(completeMention(0, "bob")(parse("@bo| there"))).toEqual({
+			text: "@bob there",
+			start: 5,
+			end: 5,
+		});
+	});
+
+	test("keeps what follows the caret", () => {
+		expect(completeMention(0, "bob")(parse("@bo|."))).toEqual({
+			text: "@bob .",
+			start: 5,
+			end: 5,
+		});
+	});
+});

--- a/apps/lite/ui/src/mentions.ts
+++ b/apps/lite/ui/src/mentions.ts
@@ -1,0 +1,54 @@
+/** `@mention` completion for a plain textarea. Pure and DOM-free, like `markdown-editing.ts`. */
+
+import type { MarkdownCommand, MarkdownSelection } from "#ui/markdown-editing.ts";
+import type { ForgeReviewUser } from "@gitbutler/but-sdk";
+
+/** Where a mention's `@` sits and what has been typed after it. */
+type MentionDraft = { readonly at: number; readonly query: string };
+
+const isLoginChar = (char: string): boolean => /[\w-]/.test(char);
+
+/**
+ * The mention being typed at the caret, if any: a collapsed caret at the end
+ * of an `@word` whose `@` starts the word, so an email address does not count.
+ */
+export const mentionAtCaret = ({ text, start, end }: MarkdownSelection): MentionDraft | null => {
+	if (start !== end || isLoginChar(text.charAt(end))) return null;
+	let at = end;
+	while (at > 0 && isLoginChar(text.charAt(at - 1))) at -= 1;
+	if (text.charAt(at - 1) !== "@" || isLoginChar(text.charAt(at - 2))) return null;
+	return { at: at - 1, query: text.slice(at, end) };
+};
+
+const LIMIT = 8;
+
+/** Who the query could mean: logins starting with it first, then anyone whose login or name contains it. */
+export const matchMentions = (
+	candidates: ReadonlyArray<ForgeReviewUser>,
+	query: string,
+): Array<ForgeReviewUser> => {
+	const needle = query.toLowerCase();
+	const contains = (text: string | null) => text?.toLowerCase().includes(needle) ?? false;
+	const leads = (user: ForgeReviewUser) => user.login.toLowerCase().startsWith(needle);
+	return candidates
+		.filter((user) => contains(user.login) || contains(user.name))
+		.sort((a, b) => Number(leads(b)) - Number(leads(a)))
+		.slice(0, LIMIT);
+};
+
+/**
+ * Replace the mention at `at`, up to the caret, with `@login` and leave the
+ * caret after a following space, reusing one already there.
+ */
+export const completeMention =
+	(at: number, login: string): MarkdownCommand =>
+	({ text, end }) => {
+		const mention = `@${login}`;
+		const tail = text.slice(end);
+		const after = at + mention.length + 1;
+		return {
+			text: `${text.slice(0, at)}${mention}${tail.startsWith(" ") ? "" : " "}${tail}`,
+			start: after,
+			end: after,
+		};
+	};

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestComments.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestComments.tsx
@@ -45,6 +45,7 @@ import type { IconName } from "#ui/components/iconNames.ts";
 import { Markdown } from "#ui/components/Markdown.tsx";
 import { MarkdownAttachments } from "#ui/components/MarkdownAttachments.tsx";
 import { MarkdownToolbar } from "#ui/components/MarkdownToolbar.tsx";
+import { useMentionSuggestions } from "#ui/components/MentionSuggestions.tsx";
 import { RelativeTime } from "#ui/components/RelativeTime.tsx";
 import {
 	groupReactors,
@@ -186,6 +187,7 @@ const Card: FC<{
  * row, so the surrounding card chrome stays put while editing.
  */
 const BodyEditor: FC<{
+	projectId: string;
 	value: string;
 	onChange: (value: string) => void;
 	onCancel: () => void;
@@ -193,31 +195,49 @@ const BodyEditor: FC<{
 	saving: boolean;
 	label: string;
 	saveLabel: string;
-}> = ({ value, onChange, onCancel, onSave, saving, label, saveLabel }) => (
-	<div className={styles.editor}>
-		<textarea
-			aria-label={label}
-			className={classes("text-13", "text-body", styles.editorInput)}
-			disabled={saving}
-			onChange={(evt) => onChange(evt.currentTarget.value)}
-			value={value}
-		/>
-		<div className={styles.editorActions}>
-			<button className={getButtonClassName({})} disabled={saving} onClick={onCancel} type="button">
-				Cancel
-			</button>
-			<button
-				className={getButtonClassName({ variant: "gray" })}
-				disabled={saving || value.trim() === ""}
-				onClick={onSave}
-				type="button"
-			>
-				{saveLabel}
-				<Icon name={saving ? "spinner" : "tick"} />
-			</button>
+}> = ({ projectId, value, onChange, onCancel, onSave, saving, label, saveLabel }) => {
+	const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+	const mentions = useMentionSuggestions({
+		projectId,
+		targetRef: textareaRef,
+		value,
+		onInput: onChange,
+	});
+
+	return (
+		<div className={styles.editor}>
+			<textarea
+				{...mentions.textareaProps}
+				aria-label={label}
+				className={classes("text-13", "text-body", styles.editorInput)}
+				disabled={saving}
+				onKeyDown={mentions.onKeyDown}
+				ref={textareaRef}
+				value={value}
+			/>
+			{mentions.popup}
+			<div className={styles.editorActions}>
+				<button
+					className={getButtonClassName({})}
+					disabled={saving}
+					onClick={onCancel}
+					type="button"
+				>
+					Cancel
+				</button>
+				<button
+					className={getButtonClassName({ variant: "gray" })}
+					disabled={saving || value.trim() === ""}
+					onClick={onSave}
+					type="button"
+				>
+					{saveLabel}
+					<Icon name={saving ? "spinner" : "tick"} />
+				</button>
+			</div>
 		</div>
-	</div>
-);
+	);
+};
 
 const Comment: FC<{
 	projectId: string;
@@ -336,6 +356,7 @@ const Comment: FC<{
 			{editing ? (
 				<BodyEditor
 					label="Edit comment"
+					projectId={projectId}
 					onCancel={() => setEditing(false)}
 					onChange={setEditBody}
 					onSave={handleSave}
@@ -938,6 +959,35 @@ const ownForgeAvatar = (
 const orEmptyNotice = (items: Array<NativeMenuItem>, notice: string): Array<NativeMenuItem> =>
 	items.length > 0 ? items : [nativeMenuItem({ label: notice, enabled: false })];
 
+/** An icon button that opens a native menu of things to insert. */
+const InsertButton: FC<{
+	label: string;
+	icon: IconName;
+	/** Built on click, so the menu lists whatever has loaded by then. */
+	items: () => Array<NativeMenuItem>;
+	notice: string;
+}> = ({ label, icon, items, notice }) => (
+	<Tooltip.Root>
+		<Tooltip.Trigger
+			className={getButtonClassName({ variant: "ghost", iconOnly: true })}
+			render={<button aria-label={label} type="button" />}
+			// Keeps the caret in the textarea: a plain click would blur it
+			// first, so the insert would have no position to act on.
+			onMouseDown={(evt) => evt.preventDefault()}
+			onClick={(evt) =>
+				void showNativeMenuFromTrigger(evt.currentTarget, orEmptyNotice(items(), notice))
+			}
+		>
+			<Icon name={icon} />
+		</Tooltip.Trigger>
+		<Tooltip.Portal>
+			<Tooltip.Positioner sideOffset={4}>
+				<Tooltip.Popup render={<TooltipPopup />}>{label}</Tooltip.Popup>
+			</Tooltip.Positioner>
+		</Tooltip.Portal>
+	</Tooltip.Root>
+);
+
 /**
  * Insert an `@mention` or a `#reference` at the caret. Candidates come from
  * the forge — collaborators and open reviews — and are picked from a native
@@ -961,59 +1011,34 @@ const ForgeInserts: FC<{
 		if (target !== null) onInput(applyToTextarea(target, md.insert(snippet)));
 	};
 
-	const button = (
-		label: string,
-		icon: IconName,
-		items: () => Array<NativeMenuItem>,
-		notice: string,
-	) => (
-		<Tooltip.Root>
-			<Tooltip.Trigger
-				className={getButtonClassName({ variant: "ghost", iconOnly: true })}
-				render={<button aria-label={label} type="button" />}
-				// Keeps the caret in the textarea: a plain click would blur it
-				// first, so the insert would have no position to act on.
-				onMouseDown={(evt) => evt.preventDefault()}
-				onClick={(evt) =>
-					void showNativeMenuFromTrigger(evt.currentTarget, orEmptyNotice(items(), notice))
-				}
-			>
-				<Icon name={icon} />
-			</Tooltip.Trigger>
-			<Tooltip.Portal>
-				<Tooltip.Positioner sideOffset={4}>
-					<Tooltip.Popup render={<TooltipPopup />}>{label}</Tooltip.Popup>
-				</Tooltip.Positioner>
-			</Tooltip.Portal>
-		</Tooltip.Root>
-	);
-
 	return (
 		<>
-			{button(
-				"Mention someone",
-				"user",
-				() =>
+			<InsertButton
+				label="Mention someone"
+				icon="user"
+				items={() =>
 					(candidates ?? []).map((candidate) =>
 						nativeMenuItem({
 							label: candidate.login,
 							onSelect: () => insert(`@${candidate.login} `),
 						}),
-					),
-				"No one to mention",
-			)}
-			{button(
-				"Reference a pull request",
-				"hash",
-				() =>
+					)
+				}
+				notice="No one to mention"
+			/>
+			<InsertButton
+				label="Reference a pull request"
+				icon="hash"
+				items={() =>
 					(reviews?.reviews ?? []).map((review) =>
 						nativeMenuItem({
 							label: `#${review.number} ${review.title}`,
 							onSelect: () => insert(`#${review.number} `),
 						}),
-					),
-				"No pull requests to reference",
-			)}
+					)
+				}
+				notice="No pull requests to reference"
+			/>
 		</>
 	);
 };
@@ -1043,6 +1068,13 @@ const Composer: FC<{
 		},
 		[textareaRef],
 	);
+
+	const mentions = useMentionSuggestions({
+		projectId,
+		targetRef: textareaRef,
+		value: draft,
+		onInput: setDraft,
+	});
 
 	const submit = () => {
 		onSubmit();
@@ -1098,10 +1130,11 @@ const Composer: FC<{
 			<div className={styles.composerBody}>
 				<Avatar src={avatarUrl} />
 				<textarea
+					{...mentions.textareaProps}
 					aria-label="Write a comment"
 					className={classes("text-13", "text-body", styles.composerInput)}
-					onChange={(evt) => setDraft(evt.currentTarget.value)}
 					onKeyDown={(evt) => {
+						if (mentions.onKeyDown(evt)) return;
 						if (evt.key === "Escape" && empty) {
 							evt.preventDefault();
 							setEngaged(false);
@@ -1113,6 +1146,7 @@ const Composer: FC<{
 					ref={attachInput}
 					value={draft}
 				/>
+				{mentions.popup}
 			</div>
 
 			<div className={styles.composerFooter}>
@@ -1248,31 +1282,28 @@ export const PullRequestComments: FC<{ projectId: string; review: ForgeReview }>
 	const composerRef = useRef<HTMLTextAreaElement | null>(null);
 
 	// What the dwell may record as skipped: the conversation's own unread-
-	// eligible items. Memoized: this component re-renders per draft
-	// keystroke, and the derivation walks every listing.
-	const freshItems = useMemo(() => {
-		const own = (login: string | null | undefined) =>
-			currentLogin != null && login != null && login.toLowerCase() === currentLogin.toLowerCase();
-		return [
-			...(comments ?? [])
-				.filter(
-					(comment) => comment.id > 0 && comment.createdAt !== null && !own(comment.author?.login),
-				)
-				.map((comment) => ({ key: `c:${comment.id}`, atMs: Date.parse(comment.createdAt ?? "") })),
-			...(submissions ?? [])
-				.filter((submission) => submission.submittedAt !== null && !own(submission.author?.login))
-				.map((submission) => ({
-					key: `s:${submission.id}`,
-					atMs: Date.parse(submission.submittedAt ?? ""),
-				})),
-			...(threads ?? [])
-				.flatMap((thread) => thread.comments)
-				.filter(
-					(comment) => comment.id > 0 && comment.createdAt !== null && !own(comment.author?.login),
-				)
-				.map((comment) => ({ key: `tc:${comment.id}`, atMs: Date.parse(comment.createdAt ?? "") })),
-		];
-	}, [comments, submissions, threads, currentLogin]);
+	// eligible items.
+	const own = (login: string | null | undefined) =>
+		currentLogin != null && login != null && login.toLowerCase() === currentLogin.toLowerCase();
+	const freshItems = [
+		...(comments ?? [])
+			.filter(
+				(comment) => comment.id > 0 && comment.createdAt !== null && !own(comment.author?.login),
+			)
+			.map((comment) => ({ key: `c:${comment.id}`, atMs: Date.parse(comment.createdAt ?? "") })),
+		...(submissions ?? [])
+			.filter((submission) => submission.submittedAt !== null && !own(submission.author?.login))
+			.map((submission) => ({
+				key: `s:${submission.id}`,
+				atMs: Date.parse(submission.submittedAt ?? ""),
+			})),
+		...(threads ?? [])
+			.flatMap((thread) => thread.comments)
+			.filter(
+				(comment) => comment.id > 0 && comment.createdAt !== null && !own(comment.author?.login),
+			)
+			.map((comment) => ({ key: `tc:${comment.id}`, atMs: Date.parse(comment.createdAt ?? "") })),
+	];
 
 	const handleSubmit = () => {
 		const body = draft.trim();
@@ -1303,8 +1334,9 @@ export const PullRequestComments: FC<{ projectId: string; review: ForgeReview }>
 		composerRef.current?.focus();
 	};
 
-	// Memoized like `freshItems`: this component re-renders per composer
-	// keystroke, and a fresh grouping would re-render every card below.
+	// By hand: the compiler cannot tell these two calls are pure, and this
+	// component re-renders per composer keystroke, so a fresh grouping would
+	// re-render every card below.
 	const { filed, loose } = useMemo(
 		() => fileThreadsUnderSubmissions(submissions, threads),
 		[submissions, threads],
@@ -1334,7 +1366,7 @@ export const PullRequestComments: FC<{ projectId: string; review: ForgeReview }>
 		let target: HTMLElement | null = null;
 		let lastTop = Number.NaN;
 		const aim = () => {
-			target ??= document.getElementById(commentAnchorId(requestedComment));
+			if (target === null) target = document.getElementById(commentAnchorId(requestedComment));
 			if (target === null) return;
 			const top = target.getBoundingClientRect().top;
 			if (top !== lastTop) target.scrollIntoView({ block: "center" });

--- a/apps/lite/ui/src/routes/project/$id/workspace/ReviewThreadReply.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/ReviewThreadReply.tsx
@@ -2,6 +2,7 @@ import { useCreateReviewThreadReply } from "#ui/api/mutations.ts";
 import { getButtonClassName } from "#ui/components/Button.tsx";
 import { classes } from "#ui/components/classes.ts";
 import { FieldTextareaStyles } from "#ui/components/Field.tsx";
+import { useMentionSuggestions } from "#ui/components/MentionSuggestions.tsx";
 import { type FC, type KeyboardEvent, useRef, useState } from "react";
 import styles from "./ReviewThreadReply.module.css";
 
@@ -22,7 +23,14 @@ export const ReviewThreadReply: FC<Props> = ({ projectId, reviewId, threadId }) 
 	const [body, setBody] = useState("");
 	/** One-shot: the box takes focus when unfolded, not on every re-render. */
 	const wantsFocusRef = useRef(false);
+	const textareaRef = useRef<HTMLTextAreaElement | null>(null);
 	const { mutate: reply } = useCreateReviewThreadReply(projectId, reviewId);
+	const mentions = useMentionSuggestions({
+		projectId,
+		targetRef: textareaRef,
+		value: body,
+		onInput: setBody,
+	});
 
 	const submit = () => {
 		const text = body.trim();
@@ -43,6 +51,7 @@ export const ReviewThreadReply: FC<Props> = ({ projectId, reviewId, threadId }) 
 	};
 
 	const onKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+		if (mentions.onKeyDown(event)) return;
 		if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
 			event.preventDefault();
 			submit();
@@ -72,12 +81,13 @@ export const ReviewThreadReply: FC<Props> = ({ projectId, reviewId, threadId }) 
 	return (
 		<div className={styles.composer}>
 			<FieldTextareaStyles
+				{...mentions.textareaProps}
 				aria-label="Reply to this thread"
 				className={styles.input}
-				onChange={(event) => setBody(event.currentTarget.value)}
 				onKeyDown={onKeyDown}
 				placeholder="Write a reply…"
 				ref={(textarea) => {
+					textareaRef.current = textarea;
 					if (textarea && wantsFocusRef.current) {
 						wantsFocusRef.current = false;
 						textarea.focus();
@@ -86,6 +96,7 @@ export const ReviewThreadReply: FC<Props> = ({ projectId, reviewId, threadId }) 
 				rows={3}
 				value={body}
 			/>
+			{mentions.popup}
 			<div className={styles.actions}>
 				<button
 					className={getButtonClassName({ variant: "ghost" })}


### PR DESCRIPTION
Typing `@` in a comment box on the pull request page opens a popup of the repository's collaborators, filtered as you type. It works in the conversation composer, in thread replies (wherever a thread is shown), and in the box for editing your own comment.

- Arrow keys move the highlight, Enter or Tab complete the login with a trailing space, a click does the same. Escape dismisses the popup until the next `@`; backing the caret out past a dismissed `@` lets it open again.
- Ranking: logins starting with the query first, then anyone whose login or name contains it. Case-insensitive, capped at eight rows.
- The popup hangs off the `@` itself rather than the caret, so it holds still while the query grows. It is measured off a hidden mirror of the textarea. It never takes focus, and completion goes through the existing undo-preserving textarea rewrite, so Cmd+Z undoes it.
- Finding the mention at the caret, ranking, and completion are pure functions in `mentions.ts` with their own tests. The popup is a `useMentionSuggestions` hook returning textarea props, a key handler, and the popup element, so any textarea can adopt it in a few lines.

Decisions

- The popup is mounted only while open, so there is no exit animation; a suggestions list that lingers while its rows empty out reads as a glitch.
- The candidate list is the reviewer-candidates query the footer's "Mention someone" button already uses. That button stays.
- Two React Compiler traps surfaced and are worked around in the hook: optional chaining inside a logical test bails the whole hook out, and the result of the pure `mentionAtCaret` call has to be memoized by hand or every closure reading from it stays unmemoized. Both are commented at the site.
- Two pre-existing React Compiler bailouts in the same file are fixed along the way: `ForgeInserts` built its buttons through an inner arrow helper (now a module-level `InsertButton`), and `PullRequestComments` used `??=`. With the latter compiled, the hand memo around `freshItems` is redundant and removed; the two around module-level calls stay, since the compiler does not memoize those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
