### PR TITLE
Offer Copilot as a reviewer in Lite

### DIFF
--- a/apps/lite/ui/src/components/MentionSuggestions.tsx
+++ b/apps/lite/ui/src/components/MentionSuggestions.tsx
@@ -2,6 +2,7 @@ import { reviewerCandidatesQueryOptions } from "#ui/api/queries.ts";
 import { Popup, PopupItem } from "#ui/components/Popup.tsx";
 import { applyToTextarea } from "#ui/markdown-textarea.ts";
 import { completeMention, matchMentions, mentionAtCaret } from "#ui/mentions.ts";
+import { isAgent } from "#ui/review-users.ts";
 import { Popover } from "@base-ui/react";
 import type { ForgeReviewUser } from "@gitbutler/but-sdk";
 import { useQuery } from "@tanstack/react-query";
@@ -97,7 +98,14 @@ export const useMentionSuggestions = ({ projectId, targetRef, value, onInput }: 
 	const query = mention?.query ?? null;
 	const { data: matches = [] } = useQuery({
 		...reviewerCandidatesQueryOptions(projectId),
-		select: (candidates) => (query === null ? [] : matchMentions(candidates, query)),
+		// Bots are offered as reviewers, not as people to address.
+		select: (candidates) =>
+			query === null
+				? []
+				: matchMentions(
+						candidates.filter((user) => !isAgent(user)),
+						query,
+					),
 	});
 	const open = at !== null && at !== dismissedAt && matches.length > 0;
 	const highlightedUser = matches[highlighted];

--- a/apps/lite/ui/src/review-users.ts
+++ b/apps/lite/ui/src/review-users.ts
@@ -1,0 +1,9 @@
+import type { ForgeReviewUser } from "@gitbutler/but-sdk";
+
+/**
+ * Whether the user is an agent of any kind — Copilot, CI, a review bot.
+ * The forge's own flag when it survives the trip, else the `[bot]` login
+ * suffix every GitHub App carries.
+ */
+export const isAgent = (user: ForgeReviewUser): boolean =>
+	user.isBot || user.login.endsWith("[bot]");

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestComments.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestComments.tsx
@@ -65,6 +65,7 @@ import { ReviewThreadReply } from "#ui/routes/project/$id/workspace/ReviewThread
 import { encodeBytes } from "#ui/api/bytes.ts";
 import { getHeadInfoIndex } from "#ui/api/ref-info.ts";
 import { forgeHunkPatch, threadStillAnchoredInFile } from "#ui/review-threads.ts";
+import { isAgent } from "#ui/review-users.ts";
 import { defaultSettings } from "#ui/settings.ts";
 import { pullRequestHotkeys } from "#ui/hotkeys.ts";
 import { FreshBadge, RegisterFreshItems } from "#ui/review-arrival.tsx";
@@ -90,13 +91,6 @@ const commentAnchorId = (commentId: number): string => `review-comment-${comment
 
 /** What a reply picks up from the card it answers. */
 type Quotable = { body: string | null; author: ForgeReviewUser | null };
-
-/**
- * Whether the author is an agent of any kind — Copilot, CI, a review bot.
- * The forge's own flag when it survives the trip, else the `[bot]` login
- * suffix every GitHub App carries.
- */
-const isAgent = (user: ForgeReviewUser): boolean => user.isBot || user.login.endsWith("[bot]");
 
 /**
  * The card header's identity: round avatar plus the login, as designed. An
@@ -1017,12 +1011,14 @@ const ForgeInserts: FC<{
 				label="Mention someone"
 				icon="user"
 				items={() =>
-					(candidates ?? []).map((candidate) =>
-						nativeMenuItem({
-							label: candidate.login,
-							onSelect: () => insert(`@${candidate.login} `),
-						}),
-					)
+					(candidates ?? [])
+						.filter((candidate) => !isAgent(candidate))
+						.map((candidate) =>
+							nativeMenuItem({
+								label: candidate.login,
+								onSelect: () => insert(`@${candidate.login} `),
+							}),
+						)
 				}
 				notice="No one to mention"
 			/>

--- a/crates/but-github/src/client.rs
+++ b/crates/but-github/src/client.rs
@@ -812,6 +812,33 @@ impl GitHubClient {
             .collect())
     }
 
+    /// Copilot's reviewer account, or `None` where the forge has none. It can
+    /// be asked to review like a collaborator, but being an app it is never
+    /// among the assignees.
+    pub async fn get_copilot_reviewer(&self) -> Result<Option<GitHubUser>> {
+        let url = format!(
+            "{}/users/copilot-pull-request-reviewer%5Bbot%5D",
+            self.base_url
+        );
+
+        let response = self.client.get(&url).send().await?;
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        let profile: GitHubApiUser = ensure_success(response).await?.json().await?;
+
+        // The profile spells the login `Copilot`, but a review request only
+        // resolves the bot login, so the login moves to the display name
+        // unless the profile already carries one.
+        let mut copilot = GitHubUser::from(profile);
+        if copilot.name.is_none() {
+            copilot.name = Some(copilot.login.clone());
+        }
+        copilot.login = "copilot-pull-request-reviewer[bot]".to_string();
+        copilot.is_bot = true;
+        Ok(Some(copilot))
+    }
+
     pub async fn request_reviewers(
         &self,
         owner: &str,

--- a/crates/but-github/src/pr.rs
+++ b/crates/but-github/src/pr.rs
@@ -373,11 +373,18 @@ pub async fn list_reviewer_candidates(
     repo: &str,
     storage: &but_forge_storage::Controller,
 ) -> Result<Vec<crate::client::GitHubUser>> {
-    GitHubClient::from_storage(storage, preferred_account)?
+    let client = GitHubClient::from_storage(storage, preferred_account)?;
+    let mut users = client
         .list_assignable_users(owner, repo)
         .await
         .map_err(classify_forge_error)
-        .context("Failed to list reviewer candidates")
+        .context("Failed to list reviewer candidates")?;
+    // Best effort: a failed profile lookup must not take the collaborators with it.
+    match client.get_copilot_reviewer().await {
+        Ok(copilot) => users.extend(copilot),
+        Err(err) => tracing::warn!("Skipping Copilot as a reviewer candidate: {err:#}"),
+    }
+    Ok(users)
 }
 
 pub async fn request_reviewers(


### PR DESCRIPTION
Lite's "Add reviewers" picker lists GitHub's assignable users, and Copilot is an app, never an assignee, so it could not be requested from Lite even though the request endpoint accepts it.

- The GitHub client now fetches Copilot's reviewer account and appends it to the reviewer candidates, under the bot login the requested-reviewers endpoint resolves (`copilot-pull-request-reviewer[bot]`), with the display name Copilot and its avatar. Where the forge has no such account, as on GitHub Enterprise, nothing is added.
- The request path is unchanged. That endpoint was verified to accept the bot login against a real pull request.
- Bots stay out of the two `@mention` lists on the PR page. A bot is someone to request, not someone to address.

Known limits

- GitHub's REST API never lists a bot among a pull request's requested reviewers, so the panel shows Copilot only once its review exists, and the picker cannot show it as checked while the request is pending. Requesting it again while pending is a no-op on GitHub's side.
- Withdrawing a Copilot request fails on GitHub's side with a 422.
- Copilot is offered on every github.com repository. There is no API that says whether Copilot code review is enabled, so on a repository without it the request fails with the forge's error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)