### PR TITLE
Import the row styles Details.tsx already uses

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -133,6 +133,7 @@ import {
 } from "react";
 import { Group, Panel, useDefaultLayout } from "react-resizable-panels";
 import styles from "./Details.module.css";
+import rowStyles from "./Row.module.css";
 import { diffHotkeys, workspaceHotkeys } from "#ui/hotkeys.ts";
 import { useHotkeys } from "@tanstack/react-hotkeys";
 import {


### PR DESCRIPTION
Master no longer typechecks: `Details.tsx` uses `rowStyles.fadedText` without importing `Row.module.css`.

- #15830 dropped the import along with the unread-dot markup that used it.
- The linked-worktrees change added a new `rowStyles.fadedText` use in the same file.
- Each was green on its own; merged together they leave the reference undefined, which fails `check-node` and `lint-node` on every pull request since.

This puts the import back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)