### PR TITLE
Simplify the Lite graph: run the trunk along the panel's edge

### DIFF
--- a/apps/lite/ui/src/components/GraphSegment.module.css
+++ b/apps/lite/ui/src/components/GraphSegment.module.css
@@ -71,9 +71,32 @@
 	}
 }
 
+/* The first column is the trunk's. It sits one column left of the row's inset,
+   which layout.ts's ROW_INSET sizes to land its line on the panel's edge. No
+   glyph ever sits in it: a row the trunk enters hooks it into the glyph column
+   beside it, drawing left of the canvas. */
+.edgePass,
+.gap > svg:first-child {
+	margin-inline-start: -12px;
+}
+
+/* The trunk itself rather than a line behind a lane, so it keeps the weight
+   the gaps draw it at; translucent like the other passes, as it crosses row
+   fills. */
+.edgePass {
+	flex-shrink: 0;
+	width: 12px;
+	stroke: color-mix(in srgb, var(--commit-local) 40%, transparent);
+}
+
 .glyph {
 	display: flex;
 	flex-direction: column;
+}
+
+/* The trunk's own column, GraphEdge's, drawn on an 8px canvas. */
+.edge {
+	width: 8px;
 }
 
 .mainSegment {
@@ -84,6 +107,8 @@
 	visibility: var(--graph-segment-glyph-visibility, visible);
 	flex-shrink: 0;
 	height: 28px;
+	/* The hooks off the edge draw left of the canvas. */
+	overflow: visible;
 }
 
 /* The group glyph is drawn on a shorter canvas so its bottom tail ends sooner;

--- a/apps/lite/ui/src/components/GraphSegment.stories.tsx
+++ b/apps/lite/ui/src/components/GraphSegment.stories.tsx
@@ -62,8 +62,7 @@ export const AllGlyphs = meta.story({
 					"joinBoth",
 					"commit",
 					"group",
-					"control",
-					"controlHead",
+					"hook",
 					"space",
 				] satisfies Array<GraphSegmentGlyph>
 			).map((glyph) => (

--- a/apps/lite/ui/src/components/GraphSegment.tsx
+++ b/apps/lite/ui/src/components/GraphSegment.tsx
@@ -19,27 +19,58 @@ const glyphPaths = {
 	joinLeft: "M8 14H0M8 14V0M8 14V28",
 	joinRight: "M16 14H8M8 14V0M8 14V28",
 	joinBoth: "M16 14L8 14M0 14H8M8 0V14M8 28V14",
-	// The rail around a disclosure control on the row: into it, and out of it.
-	control: "M8 0V4M8 24V28",
-	/** Out of the control only, for a row that starts a rail under it. */
-	controlHead: "M8 24V28",
 };
 
 /** A stretch of the rail in another status's colour, or the glyph's own when none is given. */
-const Tone: FC<{ status: GraphSegmentStatus | undefined; d: string }> = ({ status, d }) => (
+const Tone: FC<{ status: GraphSegmentStatus | undefined; d: string; dashed?: boolean }> = ({
+	status,
+	d,
+	dashed = false,
+}) => (
 	<g className={styles.tone} data-status={status}>
-		<path className={styles.line} d={d} strokeWidth="1.5" />
+		<path
+			className={styles.line}
+			d={d}
+			strokeWidth="1.5"
+			strokeDasharray={dashed ? "1.5 2.5" : undefined}
+		/>
 	</g>
 );
+
+/**
+ * The columns the main line runs through behind a row or gap. The first is
+ * the trunk's on the panel's edge, drawn the way the gaps draw it so the two
+ * land on the same pixels: an SVG antialiases where a CSS box snaps.
+ */
+const passes = (behind: number) =>
+	Array.from({ length: behind }, (_, column) =>
+		column === 0 ? (
+			<svg
+				key={column}
+				className={styles.edgePass}
+				viewBox="0 0 12 28"
+				preserveAspectRatio="none"
+				fill="none"
+				xmlns="http://www.w3.org/2000/svg"
+				aria-hidden="true"
+				focusable="false"
+			>
+				<path d="M8 0V28" strokeWidth="1.5" />
+			</svg>
+		) : (
+			<span key={column} className={styles.pass} aria-hidden />
+		),
+	);
+
+const ringPath =
+	"M11.5 14C11.5 15.933 9.933 17.5 8 17.5C6.067 17.5 4.5 15.933 4.5 14C4.5 12.067 6.067 10.5 8 10.5C9.933 10.5 11.5 12.067 11.5 14Z";
+
+const ring = <path d={ringPath} stroke="currentColor" strokeWidth="1.5" />;
 
 const commitGlyph = (below: GraphSegmentStatus | undefined) => (
 	<>
 		<path className={styles.line} d="M8 0V11" strokeWidth="1.5" />
-		<path
-			d="M11.5 14C11.5 15.933 9.933 17.5 8 17.5C6.067 17.5 4.5 15.933 4.5 14C4.5 12.067 6.067 10.5 8 10.5C9.933 10.5 11.5 12.067 11.5 14Z"
-			stroke="currentColor"
-			strokeWidth="1.5"
-		/>
+		{ring}
 		<Tone status={below} d="M8 17V28" />
 	</>
 );
@@ -58,16 +89,9 @@ const groupGlyph = (
 const commitFootGlyph = (
 	<>
 		<path className={styles.line} d="M8 0V11" strokeWidth="1.5" />
-		<path
-			d="M11.5 14C11.5 15.933 9.933 17.5 8 17.5C6.067 17.5 4.5 15.933 4.5 14C4.5 12.067 6.067 10.5 8 10.5C9.933 10.5 11.5 12.067 11.5 14Z"
-			stroke="currentColor"
-			strokeWidth="1.5"
-		/>
+		{ring}
 	</>
 );
-
-/** The rail into the control, for the row a rail ends on. */
-const controlFootGlyph = <path className={styles.line} d="M8 0V4" strokeWidth="1.5" />;
 
 /** A branch's tick on a rail that continues above: the stretch above and below it in others' colours. */
 const joinRightGlyph = (
@@ -78,6 +102,36 @@ const joinRightGlyph = (
 		<Tone status={above} d="M8 14V0" />
 		<path className={styles.line} d="M16 14H8" strokeWidth="1.5" />
 		<Tone status={below} d="M8 14V28" />
+	</>
+);
+
+/**
+ * The trunk hooking off the panel's edge, 4px left of the canvas, into the
+ * column: two quarter turns of radius 4 through the row's centre line, as a
+ * card's line bends in a gap. A line in another's colour may come down the
+ * column to the join, and on down below it.
+ */
+const hookGlyph = (
+	above: GraphSegmentStatus | undefined,
+	below: GraphSegmentStatus | undefined,
+	folded: boolean,
+) => (
+	<>
+		{above !== undefined && <Tone status={above} d="M8 0V18" />}
+		<path
+			className={styles.line}
+			d="M-4 0V10C-4 12.2091 -2.2091 14 0 14H4C6.2091 14 8 15.7909 8 18"
+			strokeWidth="1.5"
+		/>
+		<Tone status={below} d="M8 18V28" dashed={folded} />
+	</>
+);
+
+/** A plain rail through the row, the stretch below its centre in another's colour. */
+const parentGlyph = (below: GraphSegmentStatus | undefined, folded: boolean) => (
+	<>
+		<path className={styles.line} d="M8 0V14" strokeWidth="1.5" />
+		<Tone status={below} d="M8 14V28" dashed={folded} />
 	</>
 );
 
@@ -110,7 +164,7 @@ const groupCenteredFootGlyph = (
 );
 
 /** @public */
-export type GraphSegmentGlyph = keyof typeof glyphPaths | "commit" | "group";
+export type GraphSegmentGlyph = keyof typeof glyphPaths | "commit" | "group" | "hook";
 
 /** Glyphs whose rail carries on past the drawing, so a taller row goes on drawing it. */
 const stretchableGlyphs = new Set<GraphSegmentGlyph>([
@@ -123,7 +177,7 @@ const stretchableGlyphs = new Set<GraphSegmentGlyph>([
 	"joinLeft",
 	"joinRight",
 	"joinBoth",
-	"control",
+	"hook",
 ]);
 
 /**
@@ -138,6 +192,8 @@ interface GraphSegmentProps extends ComponentProps<"span"> {
 	status: GraphSegmentStatus;
 	/** The rail ends on this row: no tail below the icon, nothing stretched under a taller row. */
 	railEnds?: boolean;
+	/** The rail below the row is folded away: its tail is dashed, a hint of what the fold holds. */
+	folded?: boolean;
 	/** The rings sit on the row's centre line, for a single-line row of their own. */
 	centered?: boolean;
 	/** The rail above or below the icon in another status's colour; a stretch between two icons is the lower one's. */
@@ -152,6 +208,7 @@ export const GraphSegment: FC<GraphSegmentProps> = ({
 	className,
 	status,
 	railEnds = false,
+	folded = false,
 	centered = false,
 	above,
 	below,
@@ -160,9 +217,7 @@ export const GraphSegment: FC<GraphSegmentProps> = ({
 }) => (
 	// Spans throughout: the segment sits in buttons and spans, which take phrasing content only.
 	<span {...props} className={classes(className, styles.container)} data-status={status}>
-		{Array.from({ length: behind }, (_, column) => (
-			<span key={column} className={styles.pass} aria-hidden />
-		))}
+		{passes(behind)}
 		<span className={styles.glyph}>
 			<svg
 				className={classes(
@@ -179,12 +234,14 @@ export const GraphSegment: FC<GraphSegmentProps> = ({
 					commitFootGlyph
 				) : railEnds && glyph === "group" && centered ? (
 					groupCenteredFootGlyph
-				) : railEnds && glyph === "control" ? (
-					controlFootGlyph
 				) : glyph === "commit" ? (
 					commitGlyph(below)
 				) : glyph === "joinRight" ? (
 					joinRightGlyph(above, below)
+				) : glyph === "hook" ? (
+					hookGlyph(above, below, folded)
+				) : glyph === "parent" ? (
+					parentGlyph(below, folded)
 				) : glyph === "forkRight" ? (
 					forkRightGlyph(below)
 				) : glyph === "group" ? (
@@ -236,10 +293,50 @@ const bendPath = (height: number): string => {
 	].join(" ");
 };
 
+const edgePaths = {
+	parent: "M1 0V28",
+	/** The trunk's head: the row's tick bending down onto the line. */
+	forkRight: "M8 14C4.134 14 1 17.134 1 21V28",
+};
+
+/**
+ * The trunk's own column at the panel's edge, for the rows it runs down as
+ * their rail: 8px wide, its line hugging the border, with room for a straight
+ * run or the bend at its head and no glyph. Rows on it carry no inset.
+ */
+export const GraphEdge: FC<{ glyph: keyof typeof edgePaths }> = ({ glyph }) => (
+	<span className={styles.container} data-status="LocalOnly">
+		<span className={classes(styles.glyph, styles.edge)}>
+			<svg
+				className={styles.mainSegment}
+				viewBox="0 0 8 28"
+				fill="none"
+				xmlns="http://www.w3.org/2000/svg"
+				aria-hidden="true"
+				focusable="false"
+			>
+				<path className={styles.line} d={edgePaths[glyph]} strokeWidth="1.5" />
+			</svg>
+			<svg
+				viewBox="0 0 8 28"
+				preserveAspectRatio="none"
+				fill="none"
+				xmlns="http://www.w3.org/2000/svg"
+				className={styles.stretchSegment}
+				aria-hidden="true"
+				focusable="false"
+			>
+				<path className={styles.line} d={edgePaths.parent} strokeWidth="1.5" />
+			</svg>
+		</span>
+	</span>
+);
+
 /**
  * The gutter of the gap under a card: the main line runs through it, and the
  * card's own line, a column to the right, may bend onto it. With columns
- * `behind`, the gap sits that far right, the lines behind it passing through.
+ * `behind`, the gap sits that far right, the lines behind it passing through;
+ * with none, the main line is the trunk on the panel's edge.
  */
 export const GraphGap: FC<{ height: number; bend?: GraphSegmentStatus; behind?: number }> = ({
 	height,
@@ -247,9 +344,7 @@ export const GraphGap: FC<{ height: number; bend?: GraphSegmentStatus; behind?: 
 	behind = 0,
 }) => (
 	<div className={styles.gap} style={{ height }} aria-hidden>
-		{Array.from({ length: behind }, (_, column) => (
-			<span key={column} className={styles.pass} />
-		))}
+		{passes(behind)}
 		<svg
 			viewBox={`0 0 28 ${height}`}
 			width="28"

--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/Section.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/Section.module.css
@@ -1,23 +1,10 @@
-/* A fold header's disclosure control: the chevron on the rail's glyph. The
-   glyph stays while the row is hovered, unlike a branch row's, since the rail
-   into the chevron is the line from above. */
-.control {
-	--graph-segment-glyph-visibility: visible;
-
-	display: flex;
-	position: relative;
-}
-
-/* On the glyph's own column, the last 16px, and the glyph's own line. */
+/* The docked stand-in's chevron, in the glyph's column on its line. */
 .chevron {
 	display: flex;
-	position: absolute;
 	align-items: center;
 	justify-content: center;
 	width: 16px;
 	height: var(--single-line-row-height);
-	inset-block-start: 0;
-	inset-inline-end: 0;
 	color: var(--text-2);
 }
 
@@ -62,7 +49,7 @@
 }
 
 /* The air under its rows, run over the floor to the card's edge, where the
-   gap below picks the leg up. */
+   leg row below picks the leg up. */
 .stub {
 	height: 5px;
 	min-height: auto;
@@ -70,16 +57,23 @@
 	overflow: hidden;
 }
 
+/* The air under the target's card or the ref's row, which the column's line
+   runs straight through to the base's. A row of gutter rather than a gap: the
+   line goes on down the column instead of bending onto the trunk. */
+.leg {
+	height: 12px;
+	min-height: auto;
+	overflow: hidden;
+}
+
 /* Folded, the merge base row's stand-in docks at the scroller's foot while
    the row is out of view below, keeping the count and Update in view; its
    toggle scrolls to the row's place before opening. It shows only while its
-   mark (WorkspaceLists' footDock) is stuck: air, a hairline, and no line into
-   its chevron, which would claim a line above that is not there. The glyph
-   sets its own visibility, so the row hiding is not enough. Keep in sync with
-   layout.ts's DOCKED_HEIGHT. */
+   mark (WorkspaceLists' footDock) is stuck: air, a hairline, and a chevron in
+   place of the glyph, whose lines would claim a line above that is not there.
+   Keep in sync with layout.ts's DOCKED_HEIGHT. */
 .docked {
 	--air: 4px;
-	--graph-segment-rail-visibility: hidden;
 
 	visibility: hidden;
 	position: absolute;
@@ -88,10 +82,6 @@
 	padding-block: var(--air);
 	border-block-start: 1px solid var(--border-section);
 	background-color: var(--bg-2);
-
-	.control {
-		--graph-segment-glyph-visibility: hidden;
-	}
 
 	@container scroll-state(stuck: bottom) {
 		visibility: visible;

--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/Section.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/Section.tsx
@@ -1,4 +1,4 @@
-import { GraphGap, GraphSegment } from "#ui/components/GraphSegment.tsx";
+import { GraphSegment } from "#ui/components/GraphSegment.tsx";
 import { Icon } from "#ui/components/Icon.tsx";
 import { classes } from "#ui/components/classes.ts";
 import { getRowButtonClassName } from "#ui/routes/project/$id/workspace/Row-utils.ts";
@@ -24,12 +24,15 @@ import { type FC, type ReactNode, type Ref, type RefObject, useRef } from "react
 import { createPortal } from "react-dom";
 import styles from "./Section.module.css";
 import { TargetCommitRow } from "./TargetCommitRow.tsx";
-import { LEG_GAP, type Plan, type Run, targetCommitAddress } from "./layout.ts";
+import { type Plan, type Run, targetCommitAddress } from "./layout.ts";
 
 /*
  * The upstream section under the stacks: the target's row or card, folding
  * the incoming commits, then the merge base header, folding the history
  * below it. Commit rows are values on the applied cursor; headers are not.
+ *
+ * The trunk runs down the panel's edge and hooks into the first row here
+ * that draws a glyph, the ref's or the base's, since no glyph fits on the edge.
  */
 
 // Base rows take the integrated colour, incoming rows the upstream's. Rows a
@@ -63,9 +66,9 @@ const Header: FC<{
 	caption?: ReactNode;
 	/** The ref's row reads as a heading; the base's a step under it, being the ref's history. */
 	heading?: boolean;
-	/** The fold the header opens; none for a plain row. */
-	fold?: { open: boolean; onToggle: () => void; name: string };
-	/** The row's gutter; with a fold, its chevron sits on the glyph. */
+	/** The fold the header opens; none for a plain row. Its chevron swaps in for the glyph on hover, unless the glyph is one. */
+	fold?: { open: boolean; onToggle: () => void; name: string; hoverChevron?: boolean };
+	/** The row's gutter. */
 	rail: ReactNode;
 	className?: string;
 	children?: ReactNode;
@@ -76,17 +79,10 @@ const Header: FC<{
 		) : (
 			<RowFoldToggle
 				folded={!fold.open}
-				glyph={
-					<span className={styles.control}>
-						{rail}
-						<span className={styles.chevron}>
-							<Icon name={fold.open ? "chevron-down" : "chevron-right"} />
-						</span>
-					</span>
-				}
+				glyph={rail}
 				aria-label={`${fold.open ? "Fold" : "Unfold"} ${fold.name}`}
 				onClick={fold.onToggle}
-				hoverChevron={false}
+				hoverChevron={fold.hoverChevron}
 			/>
 		)}
 		<RowLabelContainer>
@@ -263,8 +259,12 @@ export const Section: FC<{
 	// The line ends on the last row shown: the "show more" row, else the
 	// last commit once the history is shown to its start.
 	const endsOnBase = historyEnds && moreBelow === "hidden" && plan.older.length === 0;
-	/** The ref's tip on the base: one row for both. Moved on: the row says how far. */
-	const baseHeader = (className?: string) => (
+	/**
+	 * The ref's tip on the base: one row for both. Moved on: the row says how
+	 * far. The docked stand-in, with no line to show, wears the chevron instead
+	 * of a glyph.
+	 */
+	const baseHeader = (docked = false) => (
 		<Header
 			label={plan.refOnBase ? plan.header.label : "Base"}
 			caption={
@@ -279,9 +279,28 @@ export const Section: FC<{
 				open: plan.baseExpanded,
 				onToggle: toggleBase,
 				name: "the base's history",
+				hoverChevron: !docked,
 			}}
-			rail={<GraphSegment glyph="control" status="LocalOnly" railEnds={!plan.baseExpanded} />}
-			className={className}
+			rail={
+				docked ? (
+					<span className={styles.chevron}>
+						<Icon name={plan.baseExpanded ? "chevron-down" : "chevron-right"} />
+					</span>
+				) : (
+					<GraphSegment
+						// The trunk hooks in from the edge, meeting the target's leg coming down
+						// the column, unless the ref's row above brought it into the column. No
+						// mark of its own: the row is a label on the line, not a commit.
+						glyph={plan.refOnBase || branched ? "hook" : "parent"}
+						above={branched ? "Upstream" : undefined}
+						// Folded, the hint of the history below stays in the trunk's own grey.
+						below={plan.baseExpanded ? "Integrated" : undefined}
+						status="LocalOnly"
+						folded={!plan.baseExpanded}
+					/>
+				)
+			}
+			className={docked ? styles.docked : undefined}
 		>
 			{branched && <Update projectId={projectId} />}
 		</Header>
@@ -291,9 +310,9 @@ export const Section: FC<{
 			{plan.base !== null &&
 				!plan.refOnBase &&
 				(branched ? (
-					// The target has moved on: a card like a forked stack's, the main
-					// line behind its rows and its incoming commits on a leg that
-					// starts under the chevron and bends onto the line in the gap below.
+					// The target has moved on: a card like a forked stack's, the trunk
+					// behind its rows at the edge and its incoming commits on a leg that
+					// starts at its row and runs straight down into the base's.
 					<>
 						<div className={styles.card}>
 							<Row interactive={false} className={styles.air}>
@@ -307,7 +326,7 @@ export const Section: FC<{
 									onToggle: onToggleIncoming,
 									name: "incoming commits",
 								}}
-								rail={<GraphSegment glyph="controlHead" status="Upstream" behind={1} />}
+								rail={<GraphSegment glyph="forkRight" status="Upstream" behind={1} />}
 							/>
 							<Fold open={plan.incomingExpanded}>
 								<div className={styles.rows}>
@@ -327,18 +346,23 @@ export const Section: FC<{
 								<GraphSegment glyph="parent" status="Upstream" behind={1} />
 							</Row>
 						</div>
-						<GraphGap height={LEG_GAP} bend="Upstream" />
+						<Row interactive={false} className={styles.leg}>
+							<GraphSegment glyph="parent" status="Upstream" behind={1} />
+						</Row>
 					</>
 				) : (
-					// The target sits above the base with nothing incoming: a row on
-					// the main line, marked the way a branch is marked on its rail.
+					// The target sits above the base with nothing incoming: the trunk
+					// hooks in from the edge onto its row and runs on down the column
+					// to the base.
 					<>
 						<Header
 							label={plan.header.label}
 							heading
-							rail={<GraphSegment glyph="joinRight" status="LocalOnly" />}
+							rail={<GraphSegment glyph="hook" status="LocalOnly" />}
 						/>
-						<GraphGap height={LEG_GAP} />
+						<Row interactive={false} className={styles.leg}>
+							<GraphSegment glyph="parent" status="LocalOnly" />
+						</Row>
 					</>
 				))}
 			{plan.base !== null && (
@@ -347,9 +371,7 @@ export const Section: FC<{
 					{/* Folded, the row's stand-in docks at the scroller's foot while the row is out
 					    of view below. A portal: the foot is outside the tree, and only there can it
 					    stick over the uncommitted files card, which is outside the tree as well. */}
-					{!plan.baseExpanded &&
-						footDock !== null &&
-						createPortal(baseHeader(styles.docked), footDock)}
+					{!plan.baseExpanded && footDock !== null && createPortal(baseHeader(true), footDock)}
 					<Fold open={plan.baseExpanded} className={styles.history} ref={baseFold}>
 						<div ref={baseRows} className={styles.rows}>
 							{plan.belowBase.map((item, index) =>

--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/layout.test.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/layout.test.ts
@@ -208,17 +208,6 @@ describe("layout", () => {
 		]);
 	});
 
-	it("puts the sole stack on the trunk when there is no target", () => {
-		const target = {
-			remoteTrackingRef: { fullNameBytes: [], displayName: "origin/main", remoteName: "origin" },
-			commitsAhead: 0,
-			isCurrent: true,
-		};
-		expect(layout([stack(null)], null, undefined, folded).stackOnTrunk).toBe(true);
-		expect(layout([stack(null), stack(null)], null, undefined, folded).stackOnTrunk).toBe(false);
-		expect(layout([stack(null)], target, undefined, folded).stackOnTrunk).toBe(false);
-	});
-
 	it("knows when the target's tip is the base itself", () => {
 		const current: TargetCommitPage = { commits: [commit("shallow", true)], hasMore: false };
 		expect(layout([stack("shallow")], null, current, folded).refOnBase).toBe(true);

--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/layout.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/layout.ts
@@ -6,18 +6,27 @@ import type { RefInfo, Stack, TargetCommit, TargetCommitPage, Worktree } from "@
 /*
  * The stacks section as a graph: card order and which section rows show. Pure.
  *
- * One main line, the trunk, runs up the left from the merge base to the
- * uncommitted files. Every stack card, and a moved-on target's, sits a column
- * to its right and bends onto it in the gap under it. Rows draw their own
- * gutters, a column each for the lines behind them and the glyph
- * (GraphSegment); a card draws the gap under it.
+ * One main line, the trunk, runs up the panel's edge from the merge base to
+ * the uncommitted files. Every stack card, and a moved-on target's, sits in
+ * the column beside it and bends onto it in the gap under it; the base's own
+ * rows sit in that column too, hooking the trunk off the edge into them, since
+ * no glyph fits on the edge. Rows draw their own gutters, a column each for
+ * the lines behind them and the glyph (GraphSegment); a card draws the gap
+ * under it.
  */
 
-/** The rows' inset in the graph: the first column's line, 8px in, at x = 18. */
-export const ROW_INSET = 10;
+/**
+ * The rows' inset in the graph. The trunk's column sits one 12px column left
+ * of it, so its line, 8px in, is centred at x = 1 on the panel's edge, and the
+ * first glyph column starts here. Whole pixels throughout: SVGs snap to them
+ * where CSS boxes do not, and a fractional inset puts the two out of step. The
+ * uncommitted files card carries no inset: the edge column is its whole
+ * gutter (GraphEdge).
+ */
+export const ROW_INSET = 12 - 8 + 1;
 /** The gap under a card, tall enough for a line to bend through. */
 export const CARD_GAP = 20;
-/** The gap under the target's card and the ref row, which the leg bends through. */
+/** The gap under a worktree lane, which its line bends through. */
 export const LEG_GAP = 12;
 /** The connector between a worktree on a branch's tip and the branch row under it. */
 export const TIP_GAP = 8;
@@ -80,8 +89,6 @@ export type Plan = {
 	header: { label: string; incoming: number };
 	/** The target's tip is the base itself: one row stands for both. */
 	refOnBase: boolean;
-	/** No target: the sole stack is the main line, so it runs on the trunk instead of a column off it. */
-	stackOnTrunk: boolean;
 	incomingExpanded: boolean;
 	baseExpanded: boolean;
 	/** The commit the stacks nearest the tip sit on; the base header names it. Null while unknown. */
@@ -228,7 +235,6 @@ export const layout = (
 			base !== null &&
 			commits[0]?.commit.id === base.commit.id &&
 			commits.every((entry) => entry.inWorkspace),
-		stackOnTrunk: target === null && stacks.length === 1,
 		incomingExpanded: folds.incomingExpanded,
 		baseExpanded: folds.baseExpanded,
 		base,

--- a/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
@@ -150,11 +150,12 @@
 		align-items: center;
 		justify-content: center;
 		/* Occupies exactly the glyph segment it stands in for: the glyph's own
-		   column, the last one, since the main line may run in columns left of it. */
+		   column, the last one, since the main line may run in columns left of it.
+		   On the trunk's narrower edge column it overhangs to the right instead. */
 		width: 16px;
 		height: var(--single-line-row-height);
 		inset-block-start: 0;
-		inset-inline-end: 0;
+		inset-inline-start: max(0px, calc(100% - 16px));
 		color: var(--text-3);
 	}
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/CommitRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/CommitRow.tsx
@@ -62,8 +62,6 @@ export const CommitRow: FC<
 		below?: GraphSegmentStatus;
 		/** Columns of the main line running behind the row, left of its rail. */
 		behind?: number;
-		/** The rail ends on this commit: a root, with nothing below to run on to. */
-		railEnds?: boolean;
 		/**
 		 * The linked worktree whose lane the commit is drawn in. Such a commit is
 		 * outside the workspace, so the actions that rewrite it stay off.
@@ -81,7 +79,6 @@ export const CommitRow: FC<
 	worktree,
 	below,
 	behind,
-	railEnds,
 	...restProps
 }) => {
 	const { data: forgeInfo } = useQuery(forgeInfoOptions(projectId));
@@ -410,7 +407,6 @@ export const CommitRow: FC<
 					status={commitIsDiverged(commit) ? "Diverged" : commit.state.type}
 					below={below}
 					behind={behind}
-					railEnds={railEnds}
 				/>
 				<Tooltip.Root
 					// This gets in the way when the user tries to move their hover to a

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/UncommittedChangesRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/UncommittedChangesRow.tsx
@@ -25,7 +25,7 @@ import { getRowButtonClassName } from "../Row-utils.ts";
 import { ChangeStats } from "../ChangeStats.tsx";
 import { Row, RowFoldToggle, RowLabel, RowLabelContainer, RowToolbar } from "../Row.tsx";
 import { useFileDisplayModeMenuItems } from "../useFileDisplayModeMenuItems.ts";
-import { GraphSegment } from "#ui/components/GraphSegment.tsx";
+import { GraphEdge } from "#ui/components/GraphSegment.tsx";
 import { classes } from "#ui/components/classes.ts";
 import { useQuery } from "@tanstack/react-query";
 import styles from "./UncommittedChangesRow.module.css";
@@ -157,7 +157,7 @@ export const UncommittedChangesRow: FC<{
 				}}
 				className={className}
 			>
-				<GraphSegment glyph="forkRight" status="LocalOnly" />
+				<GraphEdge glyph="forkRight" />
 				<RowLabelContainer>
 					<RowLabel heading singleLine>
 						Uncommitted files
@@ -180,7 +180,7 @@ export const UncommittedChangesRow: FC<{
 		>
 			<RowFoldToggle
 				folded={mode.folded}
-				glyph={<GraphSegment glyph="forkRight" status="LocalOnly" />}
+				glyph={<GraphEdge glyph="forkRight" />}
 				aria-label={`${mode.folded ? "Unfold" : "Fold"} uncommitted files`}
 				onClick={mode.onToggleFolded}
 			/>

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.module.css
@@ -88,6 +88,12 @@
 /* The uncommitted files card heads the trunk, which runs down it as its own
    line: the same head room as a stack card, and a stub over its floor where
    the gap below picks the trunk up. */
+.uncommittedCard,
+.dockRow {
+	/* The trunk's edge column is the rows' whole gutter: no inset. */
+	--row-padding-inline-start: 0px;
+}
+
 .uncommittedCard {
 	border-block-end: 1px solid var(--border-section);
 	background-color: var(--bg-1);

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.tsx
@@ -76,7 +76,12 @@ import { treeItemId } from "../Row-utils.ts";
 import { useAddressSpace, WorkspaceListsProvider } from "./context.tsx";
 import { getOperation, useDryRunOperation } from "#ui/operations/operation.ts";
 import { createDiffSpec } from "#ui/operations/diff-specs.ts";
-import { GraphGap, GraphSegment, type GraphSegmentStatus } from "#ui/components/GraphSegment.tsx";
+import {
+	GraphEdge,
+	GraphGap,
+	GraphSegment,
+	type GraphSegmentStatus,
+} from "#ui/components/GraphSegment.tsx";
 import { useNow } from "#ui/components/useNow.ts";
 import { segmentBottomRelativeTo } from "#ui/api/stack.ts";
 import { assert } from "#ui/assert.ts";
@@ -259,7 +264,7 @@ const UncommittedChanges: FC<
 		enabled: !folded && (worktreeChanges?.changes.length ?? 0) > 0,
 	});
 	// The trunk runs down the card as its own line, the rows' rail.
-	const trunk = <GraphSegment glyph="parent" status="LocalOnly" />;
+	const trunk = <GraphEdge glyph="parent" />;
 
 	return (
 		<div
@@ -344,8 +349,8 @@ const UncommittedChanges: FC<
 						scrollMargin={listOffset}
 						scrollPaddingStart={headHeight}
 						scrollPaddingEnd={footDock + formHeight}
-						// The rows sit on the trunk, at the graph's inset rather than the tree's own.
-						style={{ "--row-padding-inline-start": `${ROW_INSET}px` }}
+						// The rows sit on the trunk, whose edge column is their whole gutter: no inset, the tree's own included.
+						style={{ "--row-padding-inline-start": "0px" }}
 					/>
 				</Activity>
 
@@ -404,8 +409,6 @@ const BranchSegment: FC<{
 	pushActivity: PushActivity;
 	startsRail: boolean;
 	behind: number;
-	/** The rail ends on this segment's last commit. */
-	railEnds: boolean;
 	worktrees: WorktreePlacement;
 	checkCommit: (evt: { commitId: string; shiftKey: boolean }) => void;
 	onAmendCommit: (commitId: string) => void;
@@ -429,7 +432,6 @@ const BranchSegment: FC<{
 	pushActivity,
 	startsRail,
 	behind,
-	railEnds,
 	worktrees,
 	checkCommit,
 	onAmendCommit,
@@ -501,7 +503,6 @@ const BranchSegment: FC<{
 					segment={segment}
 					stackId={stack.id}
 					behind={behind}
-					railEnds={railEnds}
 					worktrees={worktrees}
 					checkCommit={checkCommit}
 					onAmendCommit={onAmendCommit}
@@ -565,8 +566,6 @@ const SegmentContent: FC<{
 	positionOffset: number;
 	setSize: number;
 	behind: number;
-	/** The rail ends on the segment's last commit. */
-	railEnds: boolean;
 	worktrees: WorktreePlacement;
 }> = ({
 	projectId,
@@ -586,7 +585,6 @@ const SegmentContent: FC<{
 	positionOffset,
 	setSize,
 	behind,
-	railEnds,
 	worktrees,
 }) => {
 	const getCommitKey = useCallback(
@@ -702,7 +700,6 @@ const SegmentContent: FC<{
 						commit={commit}
 						below={next === undefined ? "LocalOnly" : commitGraphStatus(next)}
 						behind={behind}
-						railEnds={railEnds && next === undefined}
 						lanes={lanesOn(commit, virtualRow.index)}
 						worktrees={worktrees}
 						projectId={projectId}
@@ -734,7 +731,6 @@ const CommitItem: FC<{
 	commit: Commit;
 	below: GraphSegmentStatus;
 	behind: number;
-	railEnds: boolean;
 	/** The worktree lanes drawn above this commit, resting on it. */
 	lanes: ReadonlyArray<Worktree>;
 	worktrees: WorktreePlacement;
@@ -753,7 +749,6 @@ const CommitItem: FC<{
 	commit,
 	below,
 	behind,
-	railEnds,
 	lanes,
 	worktrees,
 	projectId,
@@ -806,7 +801,6 @@ const CommitItem: FC<{
 								commit={commit}
 								below={below}
 								behind={behind}
-								railEnds={railEnds}
 								stackId={stackId}
 								checkCommit={checkCommit}
 								amendCommit={() => onAmendCommit(commit.id)}
@@ -839,9 +833,7 @@ const SegmentRailConnector: FC<{
 	projectId: string;
 	segment: Segment;
 	behind: number;
-	/** The rail ended on the segment's last commit: the connector is only the card's floor. */
-	railEnds: boolean;
-}> = ({ projectId, segment, behind, railEnds }) => {
+}> = ({ projectId, segment, behind }) => {
 	const addressSpace = useAddressSpace();
 
 	// A plain boolean, so this re-renders only when this segment's own fold
@@ -869,7 +861,7 @@ const SegmentRailConnector: FC<{
 			inert={!addressSpaceIncludes(addressSpace, standsFor, addressIdentityKey)}
 		>
 			{/* Plain: a branch's colour runs from its tick down to its commits, not past them. */}
-			<GraphSegment glyph={railEnds ? "space" : "parent"} status="LocalOnly" behind={behind} />
+			<GraphSegment glyph="parent" status="LocalOnly" behind={behind} />
 		</Row>
 	);
 };
@@ -888,8 +880,6 @@ const StackC: FC<
 		stackSize: number;
 		/** The list's start in the scroller, which the card's own position is from. */
 		scrollMargin: number;
-		/** The stack is the main line itself, with no target to fork from: see the layout's plan. */
-		onTrunk: boolean;
 		worktrees: WorktreePlacement;
 		selectedSegmentIndex: number | undefined;
 		selectedCommitIndex: number | undefined;
@@ -906,7 +896,6 @@ const StackC: FC<
 	stackScrollStart,
 	stackSize,
 	scrollMargin,
-	onTrunk,
 	worktrees,
 	selectedSegmentIndex,
 	selectedCommitIndex,
@@ -928,12 +917,8 @@ const StackC: FC<
 		width: "100%",
 		transform: `translateY(${stackScrollStart - scrollMargin}px)`,
 	};
-	// A card is a lane off the trunk, which runs behind it, unless it is the trunk.
-	const behind = onTrunk ? 0 : 1;
-	// The trunk's rail ends where the history does. A traversal cut short leaves a
-	// commit with parents, and the line runs on past it as it does under any card.
-	const lastCommit = stack.segments.at(-1)?.commits.at(-1);
-	const railEnds = onTrunk && lastCommit !== undefined && lastCommit.parentIds.length === 0;
+	// A card is a lane off the trunk, which runs behind it at the edge.
+	const behind = 1;
 	const topmostPendingPushIndex = stack.segments.findIndex(
 		(segment) =>
 			segment.refName && pendingPushBranches.has(decodeBytes(segment.refName.fullNameBytes)),
@@ -961,7 +946,7 @@ const StackC: FC<
 				aria-label="Stack"
 			>
 				<Row interactive={false} className={styles.pad}>
-					<GraphSegment glyph={onTrunk ? "parent" : "space"} status="LocalOnly" behind={behind} />
+					<GraphSegment glyph="space" status="LocalOnly" behind={behind} />
 				</Row>
 				{onTip.map((worktree) => (
 					<WorktreeOnTip
@@ -970,7 +955,6 @@ const StackC: FC<
 						worktree={worktree}
 						worktrees={worktrees}
 						behind={behind}
-						onTrunk={onTrunk}
 					/>
 				))}
 				{stack.segments.map((segment, index) => {
@@ -1006,9 +990,8 @@ const StackC: FC<
 										canRemoveBranch={canRemoveBranchReference(stack, index)}
 										downstackPushStatus={downstackPushStatus}
 										pushActivity={pushActivity}
-										startsRail={index === 0 && !onTrunk && onTip.length === 0}
+										startsRail={index === 0 && onTip.length === 0}
 										behind={behind}
-										railEnds={railEnds && index === stack.segments.length - 1}
 										worktrees={worktrees}
 										checkCommit={checkCommit}
 										onAmendCommit={onAmendCommit}
@@ -1031,7 +1014,6 @@ const StackC: FC<
 										positionOffset={segmentPositionOffset}
 										setSize={rootSetSize}
 										behind={behind}
-										railEnds={railEnds && index === stack.segments.length - 1}
 										worktrees={worktrees}
 										projectId={projectId}
 										segment={segment}
@@ -1050,21 +1032,12 @@ const StackC: FC<
 									/>
 								)}
 							</div>
-							<SegmentRailConnector
-								projectId={projectId}
-								segment={segment}
-								behind={behind}
-								railEnds={railEnds && index === stack.segments.length - 1}
-							/>
+							<SegmentRailConnector projectId={projectId} segment={segment} behind={behind} />
 						</Fragment>
 					);
 				})}
 			</StackCard>
-			{railEnds ? (
-				<div style={{ height: CARD_GAP }} aria-hidden />
-			) : (
-				<GraphGap height={CARD_GAP} bend={onTrunk ? undefined : "LocalOnly"} />
-			)}
+			<GraphGap height={CARD_GAP} bend="LocalOnly" />
 		</div>
 	);
 };
@@ -1383,7 +1356,6 @@ const Stacks: FC<{
 									stackScrollStart={virtualRow.start}
 									stackSize={virtualRow.size}
 									scrollMargin={scrollMargin}
-									onTrunk={plan.stackOnTrunk}
 									worktrees={plan.worktrees}
 									selectedSegmentIndex={
 										selectedStackIndex === virtualRow.index ? selectedSegmentIndex : undefined

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorktreeLane.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorktreeLane.tsx
@@ -422,16 +422,14 @@ export const WorktreeOnTip: FC<{
 	worktree: Worktree;
 	worktrees: WorktreePlacement;
 	behind: number;
-	/** The card is the main line itself, so the trunk runs into the lane from above. */
-	onTrunk: boolean;
-}> = ({ projectId, worktree, worktrees, behind, onTrunk }) => (
+}> = ({ projectId, worktree, worktrees, behind }) => (
 	<>
 		<WorktreeRows
 			projectId={projectId}
 			worktree={worktree}
 			worktrees={worktrees}
 			behind={behind}
-			startsRail={!onTrunk}
+			startsRail
 		/>
 		<GraphGap height={TIP_GAP} behind={behind} />
 	</>


### PR DESCRIPTION
The workspace graph read as busy: the main line sat 18px in, every card another column right of it, and the section headers carried permanent chevrons that competed with the lines for space.

Also made the expand/collapse buttons for the base and upstream be on-hover

<img width="833" height="975" alt="Screenshot 2026-09-09 at 12 52 06" src="https://github.com/user-attachments/assets/453a8be8-7caf-4a9c-965b-8189be5e6a7a" />

<img width="859" height="404" alt="Screenshot 2026-09-09 at 12 52 55" src="https://github.com/user-attachments/assets/c3e9424d-169c-454d-ba24-2dbf1aaf6cc9" />
