### PR TITLE
Drop the suggested reaction chips under the PR description

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestForm.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestForm.tsx
@@ -642,7 +642,6 @@ export const PullRequestDescription: FC<{
 					reactors={reviewReactions.reactors}
 					myLogin={currentLogin}
 					onToggle={toggleReaction}
-					suggest
 				/>
 			)}
 		</div>

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestReactions.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestReactions.module.css
@@ -23,35 +23,6 @@
 	}
 }
 
-/* A suggestion nobody has taken yet: the same pill drawn as an empty slot, so
-   it reads as an offer rather than a tally. The ring is an SVG mask rather
-   than `border-style: dashed` because the browser's dashes are ~3px and get
-   stretched to fit each edge; the kit's stroke is a steady 2px on, 2px off
-   around the whole pill. The rect insets by half the stroke so the 1px line
-   sits fully inside the box, matching an inside-aligned stroke. */
-.reactionChipGhost {
-	position: relative;
-	background-color: transparent;
-
-	&::before {
-		position: absolute;
-		inset: 0;
-		border-radius: inherit;
-		background-color: var(--border-2);
-		content: "";
-		mask-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg'><rect x='.5' y='.5' rx='11.5' style='width:calc(100%25 - 1px);height:calc(100%25 - 1px)' fill='none' stroke='%23000' stroke-dasharray='2 2'/></svg>");
-		pointer-events: none;
-	}
-
-	&:hover:not(:disabled) {
-		background-color: var(--bg-2);
-
-		&::before {
-			display: none;
-		}
-	}
-}
-
 /* The caller's own reaction inverts, so their tallies stand out from the rest
    of the row at a glance. */
 .reactionChipMine {

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestReactions.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestReactions.tsx
@@ -27,14 +27,6 @@ const reactionGlyphs: Array<[string, string]> = [
 
 const glyphByKind = new Map(reactionGlyphs);
 
-/**
- * The kinds offered inline as dashed ghost chips, so the common reactions
- * are one click away instead of all hiding behind the picker. A kind drops
- * out of the suggestions once anyone has reacted with it: its tally chip
- * takes the slot.
- */
-const suggestedKinds = ["+1", "hooray", "eyes"];
-
 const reactionNames: Record<string, string> = {
 	"+1": "thumbs up",
 	"-1": "thumbs down",
@@ -88,12 +80,7 @@ export const Reactions: FC<{
 	 * or null to add one of `kind`. Chips are display-only without this.
 	 */
 	onToggle?: (kind: string, myReactionId: number | null) => void;
-	/**
-	 * Offer the common kinds inline as ghost chips. Only the pull request's
-	 * own row does this: repeating the offer under every comment is noise.
-	 */
-	suggest?: boolean;
-}> = ({ reactions, reactors, myLogin, onToggle, suggest = false }) => {
+}> = ({ reactions, reactors, myLogin, onToggle }) => {
 	const [pickerOpen, setPickerOpen] = useState(false);
 
 	const mineFor = (kind: string) =>
@@ -115,11 +102,6 @@ export const Reactions: FC<{
 		if (mine !== undefined && mine.id < 0) return;
 		onToggle?.(kind, mine?.id ?? null);
 	};
-
-	const suggestions =
-		suggest && onToggle !== undefined
-			? suggestedKinds.filter((kind) => !chips.some((chip) => chip.kind === kind))
-			: [];
 
 	return (
 		<div className={styles.reactions}>
@@ -170,23 +152,6 @@ export const Reactions: FC<{
 					</Tooltip.Root>
 				);
 			})}
-
-			{suggestions.map((kind) => (
-				<button
-					key={kind}
-					type="button"
-					aria-label={`React with ${reactionName(kind)}`}
-					className={classes(
-						"text-12",
-						styles.reactionChip,
-						styles.reactionChipButton,
-						styles.reactionChipGhost,
-					)}
-					onClick={() => toggle(kind, undefined)}
-				>
-					{glyphByKind.get(kind)}
-				</button>
-			))}
 
 			{onToggle !== undefined && (
 				<Dropdown


### PR DESCRIPTION
The pull request description offered three dashed "suggested" reaction chips (👍 🎉 👀) next to the reaction picker. They read as reactions already left rather than as offers, and sat beside a picker that offers the same kinds anyway.

- The chips, their `suggest` flag, and their dashed style are gone. The picker is the one way to add a reaction, as it already was under comments and reviews.
- Tally chips are unchanged: they still show who reacted on hover and toggle the caller's own reaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)