### PR TITLE
Keep the but CLI's background sync out of the Lite e2e fixtures

### DIFF
--- a/apps/lite/e2e/diverge.ts
+++ b/apps/lite/e2e/diverge.ts
@@ -1,24 +1,19 @@
 import { execFileSync } from "node:child_process";
 import { appendFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
-import { paths, processEnvironment, type LiteTestEnvironment } from "./setup.ts";
+import { fixtureEnvironment, paths, type LiteTestEnvironment } from "./setup.ts";
 
 /**
  * branch1 applied and diverged: one commit only here, two only on the remote,
  * both sides editing `a_file` so a rebase conflicts. Reload the app afterwards.
  */
 export const divergeBranch1 = (environment: LiteTestEnvironment): void => {
-	const but = process.env.BUT ?? path.join(paths.repoRoot, "target/debug/but");
-	const env = processEnvironment({
-		BUT: but,
-		E2E_TEST_APP_DATA_DIR: environment.appDataDir,
-		GIT_CONFIG_GLOBAL: environment.gitConfig,
-	});
+	const env = fixtureEnvironment(environment);
 	const clone = path.join(environment.workdir, "local-clone");
 	const remote = path.join(environment.workdir, "remote-project");
 	const git = (cwd: string, ...args: Array<string>) => execFileSync("git", args, { cwd, env });
 
-	execFileSync(but, ["apply", "branch1"], { cwd: clone, env });
+	execFileSync(paths.but, ["apply", "branch1"], { cwd: clone, env });
 
 	// branch1 is not checked out in the remote, so it can be rewritten in place.
 	git(remote, "checkout", "branch1");
@@ -38,19 +33,14 @@ export const divergeBranch1 = (environment: LiteTestEnvironment): void => {
  * the remote's twin, so only the push status shows it.
  */
 export const rewriteBranch1Tip = (environment: LiteTestEnvironment): void => {
-	const but = process.env.BUT ?? path.join(paths.repoRoot, "target/debug/but");
-	const env = processEnvironment({
-		BUT: but,
-		E2E_TEST_APP_DATA_DIR: environment.appDataDir,
-		GIT_CONFIG_GLOBAL: environment.gitConfig,
-	});
+	const env = fixtureEnvironment(environment);
 	const clone = path.join(environment.workdir, "local-clone");
 
-	execFileSync(but, ["apply", "branch1"], { cwd: clone, env });
+	execFileSync(paths.but, ["apply", "branch1"], { cwd: clone, env });
 	const tip = execFileSync("git", ["-C", clone, "rev-parse", "refs/heads/branch1"], {
 		encoding: "utf8",
 	}).trim();
-	execFileSync(but, ["reword", tip, "-m", "Reworded locally"], { cwd: clone, env });
+	execFileSync(paths.but, ["reword", tip, "-m", "Reworded locally"], { cwd: clone, env });
 };
 
 /**
@@ -60,10 +50,7 @@ export const rewriteBranch1Tip = (environment: LiteTestEnvironment): void => {
 export const divergeBoth = (environment: LiteTestEnvironment): void => {
 	rewriteBranch1Tip(environment);
 
-	const env = processEnvironment({
-		E2E_TEST_APP_DATA_DIR: environment.appDataDir,
-		GIT_CONFIG_GLOBAL: environment.gitConfig,
-	});
+	const env = fixtureEnvironment(environment);
 	const clone = path.join(environment.workdir, "local-clone");
 	const remote = path.join(environment.workdir, "remote-project");
 	const git = (cwd: string, ...args: Array<string>) => execFileSync("git", args, { cwd, env });

--- a/apps/lite/e2e/setup.ts
+++ b/apps/lite/e2e/setup.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 const repoRoot = path.resolve(import.meta.dirname, "../../..");
 const fixtureScriptsDir = path.join(repoRoot, "e2e/playwright/scripts");
 const fixtureGitConfig = path.join(repoRoot, "e2e/playwright/fixtures/.gitconfig");
+const but = process.env.BUT ?? path.join(repoRoot, "target/debug/but");
 
 export type LiteTestEnvironment = {
 	appDataDir: string;
@@ -21,6 +22,19 @@ export const processEnvironment = (overrides: Record<string, string>): Record<st
 			(entry): entry is [string, string] => entry[1] !== undefined,
 		),
 	);
+
+/**
+ * Environment for the `but` and git commands a fixture runs. No ambient background
+ * sync: the detached fetch `but` spawns would race the fixture's own fetch for the
+ * remote-tracking refs, and keeps writing while the test's directories are torn down.
+ */
+export const fixtureEnvironment = (environment: LiteTestEnvironment): Record<string, string> =>
+	processEnvironment({
+		BUT: but,
+		E2E_TEST_APP_DATA_DIR: environment.appDataDir,
+		GIT_CONFIG_GLOBAL: environment.gitConfig,
+		NO_BG_TASKS: "1",
+	});
 
 export const createLiteTestEnvironment = (): LiteTestEnvironment => {
 	const rootDir = mkdtempSync(path.join(os.tmpdir(), "gitbutler-lite-e2e-"));
@@ -57,7 +71,6 @@ export const seedScenario = async (
 	const scriptPath = path.join(fixtureScriptsDir, scenario);
 	if (!existsSync(scriptPath)) throw new Error(`Fixture script does not exist: ${scriptPath}`);
 
-	const but = process.env.BUT ?? path.join(repoRoot, "target/debug/but");
 	if (!existsSync(but)) {
 		throw new Error(
 			`GitButler CLI does not exist at ${but}; build it with \`cargo build -p but\`.`,
@@ -68,11 +81,7 @@ export const seedScenario = async (
 	const child = spawn("bash", [scriptPath], {
 		cwd: environment.workdir,
 		stdio: "inherit",
-		env: processEnvironment({
-			BUT: but,
-			E2E_TEST_APP_DATA_DIR: environment.appDataDir,
-			GIT_CONFIG_GLOBAL: environment.gitConfig,
-		}),
+		env: fixtureEnvironment(environment),
 	});
 
 	child.on("error", reject);
@@ -85,6 +94,7 @@ export const seedScenario = async (
 };
 
 export const paths = {
+	but,
 	electronMain: path.join(repoRoot, "apps/lite/dist/electron/main.js"),
 	repoRoot,
 };


### PR DESCRIPTION
The Lite e2e job on #15831 failed in `branch-update.spec.ts` ("take theirs replaces the branch with the remote") during fixture setup:

```
Error: Command failed: git fetch origin
error: cannot lock ref 'refs/remotes/origin/branch1': is at 343ee1a… but expected d829887…
```

- The racer is the `but` CLI, not the app. The divergence fixtures run `but apply` and `but reword`, and each spawns a detached `refresh-remote-data --fetch`. On a slow runner that fetch was still in flight when the fixture rewrote branch1 on the remote and fetched it, so git's ref lock failed whichever fetch lost.
- Every fixture `but` and git command now runs with `NO_BG_TASKS=1`, as the desktop e2e harness already does, through one shared `fixtureEnvironment` in `apps/lite/e2e/setup.ts`.
- The fixture's own fetch stays. Lite does not fetch on reload, so that fetch is how the tests see the remote's new tip before clicking Integrate.

Proof of the mechanism, in a scratch fixture: after `but apply` the clone's `origin/branch1` moved on its own with a fresh `FETCH_HEAD`; under `NO_BG_TASKS=1` it stayed put. All 7 tests in the spec pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)