### PR TITLE
Show a linked worktree's stacked branches in Lite

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/layout.test.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/layout.test.ts
@@ -63,7 +63,7 @@ const worktree = (name: string, base: Worktree["base"], commits: Array<string>):
 	refName: null,
 	head: commits[0] ?? "",
 	base,
-	commits: commits.map(ownCommit),
+	segments: [{ refName: null, commits: commits.map(ownCommit) }],
 });
 
 const folded: Folds = {

--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/layout.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/layout.ts
@@ -159,7 +159,9 @@ const placeWorktrees = (
 		...stacks.flatMap((stack) =>
 			stack.segments.flatMap((segment) => segment.commits.map((commit) => commit.id)),
 		),
-		...worktrees.flatMap((worktree) => worktree.commits.map((commit) => commit.id)),
+		...worktrees.flatMap((worktree) =>
+			worktree.segments.flatMap((segment) => segment.commits.map((commit) => commit.id)),
+		),
 	]);
 	const on = new Map<string, Array<Worktree>>();
 	const standalone: Array<Worktree> = [];

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorktreeLane.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorktreeLane.tsx
@@ -16,6 +16,7 @@ import {
 	type FileParent,
 } from "#ui/addresses.ts";
 import { useWorktreeRemove, useWorktreeSetArchived } from "#ui/api/mutations.ts";
+import { decodeBytes } from "#ui/api/bytes.ts";
 import {
 	guiSettingsQueryOptions,
 	treeChangesDiffsQueryOptions,
@@ -287,7 +288,7 @@ const WorktreeBranchRow: FC<
 /**
  * A linked worktree's rows, laid out like the sidebar itself: the worktree's
  * name labels the whole, then its uncommitted files head a rail that runs
- * down through its branch and the commits only it has, with any worktree
+ * down through its branches and the commits only it has, with any worktree
  * resting on one of them nested above it. The rows are the sidebar's own;
  * the address space decides which of them operations may take.
  */
@@ -300,8 +301,11 @@ const WorktreeRows: FC<{
 	/** The lane's rail starts at its uncommitted files; on the trunk, the trunk runs on through. */
 	startsRail: boolean;
 }> = ({ projectId, worktree, worktrees, behind, startsRail }) => {
-	const branch =
-		worktree.refName === null ? null : branchAddress({ branchRef: worktree.refName.fullNameBytes });
+	// The rail under a commit takes the colour of the next commit, across segments.
+	const commits = worktree.segments.flatMap((segment) => segment.commits);
+	const below = new Map(
+		commits.map((commit, index) => [commit.id, commits[index + 1]?.state.type ?? "LocalOnly"]),
+	);
 	return (
 		<>
 			<Row interactive={false}>
@@ -319,67 +323,76 @@ const WorktreeRows: FC<{
 				behind={behind}
 				startsRail={startsRail}
 			/>
-			{worktree.refName !== null && branch !== null && (
-				<TreeItem
-					address={branch}
-					aria-label={worktree.refName.displayName}
-					render={
-						<AddressC
-							projectId={projectId}
-							address={branch}
-							outline="outside"
-							render={
-								<WorktreeBranchRow
-									projectId={projectId}
-									worktree={worktree.name}
-									refName={worktree.refName}
-									behind={behind}
-								/>
-							}
-						/>
-					}
-				/>
-			)}
-			{worktree.commits.map((commit, index) => {
-				const address = commitAddress({ commitId: commit.id, changeId: commit.changeId });
-				const next = worktree.commits[index + 1];
+			{worktree.segments.map((segment) => {
+				const branch =
+					segment.refName === null
+						? null
+						: branchAddress({ branchRef: segment.refName.fullNameBytes });
 				return (
-					<Fragment key={commit.id}>
-						{worktrees.on.get(commit.id)?.map((nested) => (
-							<WorktreeLane
-								key={nested.name}
-								projectId={projectId}
-								worktree={nested}
-								worktrees={worktrees}
-								behind={behind + 1}
+					<Fragment key={segment.refName ? decodeBytes(segment.refName.fullNameBytes) : "detached"}>
+						{segment.refName !== null && branch !== null && (
+							<TreeItem
+								address={branch}
+								aria-label={segment.refName.displayName}
+								render={
+									<AddressC
+										projectId={projectId}
+										address={branch}
+										outline="outside"
+										render={
+											<WorktreeBranchRow
+												projectId={projectId}
+												worktree={worktree.name}
+												refName={segment.refName}
+												behind={behind}
+											/>
+										}
+									/>
+								}
 							/>
-						))}
-						<TreeItem
-							address={address}
-							aria-label={commitTitle(commit.message) ?? "(no message)"}
-							render={
-								<AddressC
-									projectId={projectId}
-									address={address}
-									outline="outside"
-									render={
-										<CommitRow
-											commit={commit}
+						)}
+						{segment.commits.map((commit) => {
+							const address = commitAddress({ commitId: commit.id, changeId: commit.changeId });
+							return (
+								<Fragment key={commit.id}>
+									{worktrees.on.get(commit.id)?.map((nested) => (
+										<WorktreeLane
+											key={nested.name}
 											projectId={projectId}
-											stackId={null}
-											dryRunCommit={null}
-											checkCommit={noop}
-											amendCommit={noop}
-											canAmendCommit={false}
-											below={next === undefined ? "LocalOnly" : next.state.type}
-											behind={behind}
-											worktree={worktree.name}
-											scrollSelectedIntoView={false}
+											worktree={nested}
+											worktrees={worktrees}
+											behind={behind + 1}
 										/>
-									}
-								/>
-							}
-						/>
+									))}
+									<TreeItem
+										address={address}
+										aria-label={commitTitle(commit.message) ?? "(no message)"}
+										render={
+											<AddressC
+												projectId={projectId}
+												address={address}
+												outline="outside"
+												render={
+													<CommitRow
+														commit={commit}
+														projectId={projectId}
+														stackId={null}
+														dryRunCommit={null}
+														checkCommit={noop}
+														amendCommit={noop}
+														canAmendCommit={false}
+														below={below.get(commit.id) ?? "LocalOnly"}
+														behind={behind}
+														worktree={worktree.name}
+														scrollSelectedIntoView={false}
+													/>
+												}
+											/>
+										}
+									/>
+								</Fragment>
+							);
+						})}
 					</Fragment>
 				);
 			})}

--- a/apps/lite/ui/src/routes/project/$id/workspace/applied-address-space.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/applied-address-space.ts
@@ -50,18 +50,20 @@ export const buildAppliedAddressSpace = ({
 	// worktree's branch; not the section's rows or a worktree's own commits.
 	const owned = (address: Address): Row => ({ address, owned: true });
 	const foreign = (address: Address): Row => ({ address, owned: false });
-	// A lane's rows in reading order: files, branch, then commits, each preceded
-	// by the lanes resting on it. Matches WorktreeLane.
+	// A lane's rows in reading order: files, then per branch its row and its
+	// commits, each preceded by the lanes resting on it. Matches WorktreeLane.
 	const laneRows = (worktree: Worktree): Array<Row> => [
 		...(worktreeFiles.get(worktree.name) ?? []).map((path) =>
 			owned(fileAddress({ parent: worktreeChangesFileParent(worktree.name), path })),
 		),
-		...(worktree.refName
-			? [owned(branchAddress({ branchRef: worktree.refName.fullNameBytes }))]
-			: []),
-		...worktree.commits.flatMap((commit) => [
-			...lanesOn(commit.id),
-			foreign(commitAddress({ commitId: commit.id, changeId: commit.changeId })),
+		...worktree.segments.flatMap((segment) => [
+			...(segment.refName
+				? [owned(branchAddress({ branchRef: segment.refName.fullNameBytes }))]
+				: []),
+			...segment.commits.flatMap((commit) => [
+				...lanesOn(commit.id),
+				foreign(commitAddress({ commitId: commit.id, changeId: commit.changeId })),
+			]),
 		]),
 	];
 	const lanesOn = (commitId: string): Array<Row> =>

--- a/crates/but-workspace/src/ui/ref_info.rs
+++ b/crates/but-workspace/src/ui/ref_info.rs
@@ -170,15 +170,30 @@ pub struct Worktree {
         schemars(schema_with = "but_schemars::object_id")
     )]
     pub head: gix::ObjectId,
-    /// What [`Self::commits`] are resting on, or `None` if the traversal ran out of graph
+    /// What [`Self::segments`] are resting on, or `None` if the traversal ran out of graph
     /// before reaching the workspace or the target (unrelated history, or a limit was hit).
     pub base: Option<WorktreeBase>,
-    /// The commits owned by this worktree alone, from its `HEAD` down to (excluding) its base,
-    /// along the first parent.
-    pub commits: Vec<ui::Commit>,
+    /// The commits owned by this worktree alone, from its `HEAD` down to (excluding) its base
+    /// along the first parent, split at each local branch met on the way down: the first segment
+    /// is headed by the checked-out branch, each one below by a branch stacked underneath.
+    /// Never empty.
+    pub segments: Vec<WorktreeSegment>,
 }
 #[cfg(feature = "export-schema")]
 but_schemars::register_sdk_type!(Worktree);
+
+/// The UI-clone of [`crate::worktrees::WorktreeSegment`].
+#[derive(serde::Serialize, Debug, Clone)]
+#[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "camelCase")]
+pub struct WorktreeSegment {
+    /// The branch at the top of these commits, or `None` if the worktree `HEAD` is detached.
+    pub ref_name: Option<BranchReference>,
+    /// The commits, newest first.
+    pub commits: Vec<ui::Commit>,
+}
+#[cfg(feature = "export-schema")]
+but_schemars::register_sdk_type!(WorktreeSegment);
 
 impl Worktree {
     fn for_ui(
@@ -187,7 +202,7 @@ impl Worktree {
             ref_name,
             head,
             base,
-            commits,
+            segments,
         }: crate::worktrees::WorktreeInfo,
     ) -> Self {
         Worktree {
@@ -198,7 +213,13 @@ impl Worktree {
                 crate::worktrees::WorktreeBase::InWorkspace(id) => WorktreeBase::InWorkspace(id),
                 crate::worktrees::WorktreeBase::Outside(id) => WorktreeBase::Outside(id),
             }),
-            commits: commits.iter().map(Into::into).collect(),
+            segments: segments
+                .into_iter()
+                .map(|segment| WorktreeSegment {
+                    ref_name: segment.ref_name.map(Into::into),
+                    commits: segment.commits.iter().map(Into::into).collect(),
+                })
+                .collect(),
         }
     }
 }

--- a/crates/but-workspace/src/worktrees.rs
+++ b/crates/but-workspace/src/worktrees.rs
@@ -8,7 +8,7 @@
 use std::path::Path;
 
 use anyhow::{Context as _, bail};
-use bstr::{BStr, BString};
+use bstr::{BStr, BString, ByteSlice as _};
 use but_core::{DiffSpec, RepositoryExt};
 
 /// What a linked worktree's own commits are resting on.
@@ -33,6 +33,15 @@ impl WorktreeBase {
     }
 }
 
+/// A run of the commits a linked worktree owns, headed by one branch.
+#[derive(Debug, Clone)]
+pub struct WorktreeSegment {
+    /// The branch at the top of these commits, or `None` if the worktree `HEAD` is detached.
+    pub ref_name: Option<gix::refs::FullName>,
+    /// The commits, newest first.
+    pub commits: Vec<crate::ref_info::LocalCommit>,
+}
+
 /// A non-archived linked worktree along with the commits it owns exclusively, i.e. the commits
 /// between its `HEAD` and the workspace (or the target).
 #[derive(Debug, Clone)]
@@ -43,16 +52,27 @@ pub struct WorktreeInfo {
     pub ref_name: Option<gix::refs::FullName>,
     /// The commit the worktree `HEAD` peels to, as re-resolved during traversal.
     pub head: gix::ObjectId,
-    /// What [`Self::commits`] are resting on.
+    /// What [`Self::segments`] are resting on.
     ///
     /// This is `None` only if the traversal ran out of graph before reaching the workspace or the
     /// target, which happens for worktrees on unrelated history or when a traversal limit was hit.
     pub base: Option<WorktreeBase>,
     /// The commits owned by this worktree alone, from its `HEAD` down to (excluding) its
-    /// [base](Self::base), along the first parent.
+    /// [base](Self::base) along the first parent, split at each local branch met on the way down.
     ///
-    /// Empty if the worktree `HEAD` is itself a workspace commit.
-    pub commits: Vec<crate::ref_info::LocalCommit>,
+    /// The first segment is headed by the checked-out branch, see [`Self::ref_name`], and each
+    /// segment below it by a branch stacked underneath. Never empty, but without any commits if
+    /// the worktree `HEAD` is itself a workspace commit.
+    pub segments: Vec<WorktreeSegment>,
+}
+
+impl WorktreeInfo {
+    /// All commits this worktree owns, newest first.
+    pub fn commits(&self) -> impl Iterator<Item = &crate::ref_info::LocalCommit> {
+        self.segments
+            .iter()
+            .flat_map(|segment| segment.commits.iter())
+    }
 }
 
 /// Project the linked worktrees that seeded `workspace`'s traversal into the commits they own.
@@ -98,13 +118,19 @@ pub fn worktree_infos(
             );
             continue;
         };
-        let (commits, base) = commits_and_base(graph, sidx, head, &off_limits, workspace);
-        let local_commits: Vec<_> = match commits
-            .iter()
-            .map(|commit| crate::ref_info::LocalCommit::try_from_stack_commit(commit, repo))
-            .collect()
+        let (segments, base) = commits_and_base(graph, sidx, tip, &off_limits, workspace);
+        let segments: Vec<WorktreeSegment> = match segments
+            .into_iter()
+            .map(|(ref_name, commits)| {
+                let commits = commits
+                    .iter()
+                    .map(|commit| crate::ref_info::LocalCommit::try_from_stack_commit(commit, repo))
+                    .collect::<anyhow::Result<_>>()?;
+                Ok(WorktreeSegment { ref_name, commits })
+            })
+            .collect::<anyhow::Result<_>>()
         {
-            Ok(local_commits) => local_commits,
+            Ok(segments) => segments,
             Err(err) => {
                 tracing::warn!(
                     worktree = %tip.name,
@@ -115,34 +141,51 @@ pub fn worktree_infos(
                 continue;
             }
         };
-        off_limits.extend(commits.iter().map(|commit| commit.id));
+        off_limits.extend(
+            segments
+                .iter()
+                .flat_map(|segment| segment.commits.iter().map(|commit| commit.id)),
+        );
         out.push(WorktreeInfo {
             name: tip.name.clone(),
             ref_name: tip.ref_name.clone(),
             head,
             base,
-            commits: local_commits,
+            segments,
         });
     }
     out
 }
 
-/// Walk down from `head` (owned by `sidx`) along the first parent, collecting commits until
-/// reaching a commit in `off_limits` or the target of `workspace`.
+/// The commits headed by one branch, as found in the graph.
+type BranchCommits = (
+    Option<gix::refs::FullName>,
+    Vec<but_graph::workspace::StackCommit>,
+);
+
+/// Walk down from the `HEAD` of `tip` (owned by `sidx`) along the first parent, collecting commits
+/// until reaching a commit in `off_limits` or the target of `workspace`. The commits are split at
+/// each local branch met on the way; the first run is headed by the branch `tip` has checked out.
 fn commits_and_base(
     graph: &but_graph::Graph,
     sidx: but_graph::SegmentIndex,
-    head: gix::ObjectId,
+    tip: &but_graph::init::WorktreeTip,
     off_limits: &gix::hashtable::HashSet<gix::ObjectId>,
     workspace: &but_graph::Workspace,
-) -> (Vec<but_graph::workspace::StackCommit>, Option<WorktreeBase>) {
+) -> (Vec<BranchCommits>, Option<WorktreeBase>) {
+    let head = tip.id;
     let target_commit_id = workspace.target_commit.as_ref().map(|t| t.commit_id);
 
-    let mut commits = Vec::new();
+    let mut segments = vec![(tip.ref_name.clone(), Vec::new())];
     let mut base = None;
     // `head` can sit in the middle of its segment when another tip owns the segment's first commit.
     let mut before_head = true;
+    // A branch heading a segment further down starts a new run with the first commit it owns.
+    let mut branch_below = None;
     graph.visit_segments_downward_along_first_parent_include_start(sidx, |segment| {
+        if !before_head {
+            branch_below = stacked_branch(segment);
+        }
         for commit in &segment.commits {
             if before_head {
                 if commit.id != head {
@@ -165,11 +208,27 @@ fn commits_and_base(
                 base = Some(WorktreeBase::Outside(commit.id));
                 return true;
             }
-            commits.push(but_graph::workspace::StackCommit::from_graph_commit(commit));
+            if let Some(ref_name) = branch_below.take() {
+                segments.push((Some(ref_name), Vec::new()));
+            }
+            segments
+                .last_mut()
+                .expect("starts with the checked-out branch")
+                .1
+                .push(but_graph::workspace::StackCommit::from_graph_commit(commit));
         }
         false
     });
-    (commits, base)
+    (segments, base)
+}
+
+/// The local branch heading `segment`, if any. Remote tracking branches and tags name segments
+/// too, but only a local branch is a branch of the worktree's stack.
+fn stacked_branch(segment: &but_graph::Segment) -> Option<gix::refs::FullName> {
+    let name = segment.ref_name()?;
+    (name.category() == Some(gix::refs::Category::LocalBranch)
+        && !name.as_bstr().starts_with_str("refs/heads/gitbutler/"))
+    .then(|| name.to_owned())
 }
 
 /// Open the linked worktree named `name` as a from-disk repository.

--- a/crates/but-workspace/tests/fixtures/scenario/worktree-workspace.sh
+++ b/crates/but-workspace/tests/fixtures/scenario/worktree-workspace.sh
@@ -45,6 +45,14 @@ git worktree add -b wt-below wt-below main~1
   commit U1
 )
 
+# Two branches in one checkout: wt-upper is checked out on top of wt-lower.
+git worktree add -b wt-lower wt-two main
+(cd wt-two
+  commit L1
+  git checkout -b wt-upper
+  commit T1
+)
+
 # Unrelated history - the walk can never reach the workspace or the target.
 git checkout --orphan disjoint
 commit D1

--- a/crates/but-workspace/tests/workspace/worktrees.rs
+++ b/crates/but-workspace/tests/workspace/worktrees.rs
@@ -59,9 +59,21 @@ fn worktrees_are_projected_onto_the_workspace() -> Result<()> {
         .map(|wt| {
             (
                 wt.name.to_string(),
-                wt.commits
+                wt.segments
                     .iter()
-                    .map(|c| c.message.trim().as_bstr().to_string())
+                    .map(|segment| {
+                        (
+                            segment
+                                .ref_name
+                                .as_ref()
+                                .map(|name| name.shorten().to_string()),
+                            segment
+                                .commits
+                                .iter()
+                                .map(|c| c.message.trim().as_bstr().to_string())
+                                .collect::<Vec<_>>(),
+                        )
+                    })
                     .collect::<Vec<_>>(),
                 wt.base,
             )
@@ -78,46 +90,56 @@ fn worktrees_are_projected_onto_the_workspace() -> Result<()> {
         [
             (
                 "wt-at".to_string(),
-                Vec::new(),
                 // Its `HEAD` *is* a workspace commit, so it owns nothing and rests right there.
+                vec![(None, Vec::new())],
                 Some(WorktreeBase::InWorkspace(a2))
             ),
             (
                 "wt-below".to_string(),
-                vec!["U1".to_string()],
+                vec![(Some("wt-below".to_string()), vec!["U1".to_string()])],
                 // Branches off below the target without sitting on the target commit itself -
                 // only its base being reachable from the target reveals it is outside.
                 Some(WorktreeBase::Outside(m0))
             ),
             (
                 "wt-disjoint".to_string(),
-                vec!["D1".to_string()],
+                vec![(Some("disjoint".to_string()), vec!["D1".to_string()])],
                 // Unrelated history - the walk runs out of graph without finding a base.
                 None
             ),
             (
                 "wt-inside".to_string(),
-                vec!["W1".to_string()],
+                vec![(Some("wt-inside".to_string()), vec!["W1".to_string()])],
                 // Its commit branches off a commit that stack A owns.
                 Some(WorktreeBase::InWorkspace(a1))
             ),
             (
                 "wt-outside".to_string(),
-                vec!["O1".to_string()],
+                vec![(Some("wt-outside".to_string()), vec!["O1".to_string()])],
                 // The target commit stops the walk before it can reach the workspace.
                 Some(WorktreeBase::Outside(m1))
             ),
             (
                 "wt-stacked".to_string(),
-                vec!["S1".to_string()],
+                vec![(Some("wt-stacked".to_string()), vec!["S1".to_string()])],
                 // Stacked on wt-inside, which is listed first and thus owns W1 exclusively.
                 Some(WorktreeBase::InWorkspace(w1))
+            ),
+            (
+                "wt-two".to_string(),
+                // Two branches in one checkout: the branch met below the checked-out one
+                // heads its own commits.
+                vec![
+                    (Some("wt-upper".to_string()), vec!["T1".to_string()]),
+                    (Some("wt-lower".to_string()), vec!["L1".to_string()]),
+                ],
+                Some(WorktreeBase::Outside(m1))
             ),
         ]
     );
 
     for wt in &info.worktrees {
-        for commit in &wt.commits {
+        for commit in wt.commits() {
             assert_eq!(
                 commit.relation,
                 LocalCommitRelation::LocalOnly,
@@ -164,8 +186,7 @@ fn deep_disjoint_history_is_never_mistaken_for_being_below_the_target() -> Resul
     let wt = &info.worktrees[0];
     assert_eq!(wt.name.to_string(), "wt-deep");
     assert_eq!(
-        wt.commits
-            .iter()
+        wt.commits()
             .map(|c| c.message.trim().as_bstr().to_string())
             .collect::<Vec<_>>(),
         ["D5", "D4", "D3", "D2", "D1"],

--- a/crates/but/src/command/legacy/status/mod.rs
+++ b/crates/but/src/command/legacy/status/mod.rs
@@ -483,7 +483,7 @@ fn build_status_context<'a>(
         // different disambiguation length here than everywhere else.
         let worktrees = head_info.worktrees;
         for worktree in &worktrees {
-            for local_commit in &worktree.commits {
+            for local_commit in worktree.commits() {
                 commit_id_to_change_id
                     .insert(local_commit.id, local_commit.change_id().into_owned());
                 local_commits_by_id.insert(local_commit.id, local_commit.clone());
@@ -1223,7 +1223,7 @@ fn print_worktree_status(
                         .values()
                         .any(|candidate| candidate.name == wt.name)
                 })
-                .flat_map(|wt| wt.commits.iter().map(|c| c.id)),
+                .flat_map(|wt| wt.commits().map(|c| c.id)),
         )
         .collect();
     for worktree in status_ctx.worktrees.iter().filter(|wt| {

--- a/crates/but/src/id/mod.rs
+++ b/crates/but/src/id/mod.rs
@@ -1193,7 +1193,7 @@ impl IdMap {
             .chain(
                 worktrees
                     .iter()
-                    .flat_map(|worktree| worktree.commits.iter())
+                    .flat_map(|worktree| worktree.commits())
                     .map(|c| c.id),
             );
 
@@ -1239,8 +1239,7 @@ pub(crate) fn worktree_commits_by_name(
         .iter()
         .map(|worktree| {
             let commits = worktree
-                .commits
-                .iter()
+                .commits()
                 .map(|commit| StackCommit {
                     id: commit.id,
                     parent_ids: commit.parent_ids.clone(),

--- a/crates/but/src/utils/merged_upstream.rs
+++ b/crates/but/src/utils/merged_upstream.rs
@@ -75,7 +75,7 @@ impl MergedUpstream {
         // already has it from the pass above, so a worktree sitting exactly on
         // one is exactly the merged-upstream case.
         for worktree in &head_info.worktrees {
-            if worktree.commits.is_empty()
+            if worktree.commits().next().is_none()
                 && let Some(ref_name) = &worktree.ref_name
                 && this.integrated_commits.contains(&worktree.head)
             {

--- a/crates/but/src/utils/worktrees.rs
+++ b/crates/but/src/utils/worktrees.rs
@@ -90,7 +90,7 @@ pub(crate) fn commit_owner(
     head_info
         .worktrees
         .iter()
-        .find(|worktree| worktree.commits.iter().any(|owned| owned.id == commit))
+        .find(|worktree| worktree.commits().any(|owned| owned.id == commit))
         .map_or(ChangeSourceId::Head, |worktree| {
             ChangeSourceId::Worktree(worktree.name.clone())
         })

--- a/packages/but-sdk/src/generated/graph/index.d.ts
+++ b/packages/but-sdk/src/generated/graph/index.d.ts
@@ -4751,15 +4751,17 @@ export type Worktree = {
   /** The commit the worktree `HEAD` peels to. */
   head: string;
   /**
-   * What [`Self::commits`] are resting on, or `None` if the traversal ran out of graph
+   * What [`Self::segments`] are resting on, or `None` if the traversal ran out of graph
    * before reaching the workspace or the target (unrelated history, or a limit was hit).
    */
   base: WorktreeBase | null;
   /**
-   * The commits owned by this worktree alone, from its `HEAD` down to (excluding) its base,
-   * along the first parent.
+   * The commits owned by this worktree alone, from its `HEAD` down to (excluding) its base
+   * along the first parent, split at each local branch met on the way down: the first segment
+   * is headed by the checked-out branch, each one below by a branch stacked underneath.
+   * Never empty.
    */
-  commits: Array<Commit>;
+  segments: Array<WorktreeSegment>;
 };
 
 /** What a linked worktree's own commits are resting on. */
@@ -4798,5 +4800,13 @@ export type WorktreeListing = {
   active: Array<ListedWorktree>;
   /** Archived worktrees, hidden from the workspace but still on disk. */
   archived: Array<ListedWorktree>;
+};
+
+/** The UI-clone of [`crate::worktrees::WorktreeSegment`]. */
+export type WorktreeSegment = {
+  /** The branch at the top of these commits, or `None` if the worktree `HEAD` is detached. */
+  refName: BranchReference | null;
+  /** The commits, newest first. */
+  commits: Array<Commit>;
 };
 

--- a/packages/but-sdk/src/generated/linear/index.d.ts
+++ b/packages/but-sdk/src/generated/linear/index.d.ts
@@ -4748,15 +4748,17 @@ export type Worktree = {
   /** The commit the worktree `HEAD` peels to. */
   head: string;
   /**
-   * What [`Self::commits`] are resting on, or `None` if the traversal ran out of graph
+   * What [`Self::segments`] are resting on, or `None` if the traversal ran out of graph
    * before reaching the workspace or the target (unrelated history, or a limit was hit).
    */
   base: WorktreeBase | null;
   /**
-   * The commits owned by this worktree alone, from its `HEAD` down to (excluding) its base,
-   * along the first parent.
+   * The commits owned by this worktree alone, from its `HEAD` down to (excluding) its base
+   * along the first parent, split at each local branch met on the way down: the first segment
+   * is headed by the checked-out branch, each one below by a branch stacked underneath.
+   * Never empty.
    */
-  commits: Array<Commit>;
+  segments: Array<WorktreeSegment>;
 };
 
 /** What a linked worktree's own commits are resting on. */
@@ -4795,5 +4797,13 @@ export type WorktreeListing = {
   active: Array<ListedWorktree>;
   /** Archived worktrees, hidden from the workspace but still on disk. */
   archived: Array<ListedWorktree>;
+};
+
+/** The UI-clone of [`crate::worktrees::WorktreeSegment`]. */
+export type WorktreeSegment = {
+  /** The branch at the top of these commits, or `None` if the worktree `HEAD` is detached. */
+  refName: BranchReference | null;
+  /** The commits, newest first. */
+  commits: Array<Commit>;
 };
 


### PR DESCRIPTION
Follow-up to #15828. A worktree's commits were listed flat under the branch it has checked out, so a commit sitting under a lower branch in the same checkout showed up under the wrong name and the lower branch was not shown at all.

- `WorktreeInfo::segments` splits a worktree's commits at each local branch met on the first-parent walk down from its `HEAD`. The first segment is the checked-out branch; each one below is a branch stacked underneath. Same rule as the stack projection: remote-tracking refs and tags never start a segment.
- `WorktreeInfo::commits()` is the flat view; the CLI and the ID map keep using it, so `but status` output is unchanged.
- Lite's worktree card renders a branch row per segment, selectable with the worktree branch menu. Navigation and the graph layout read commits through the segments.
- The worktree fixture gains a checkout with two branches; the projection test asserts both segments by name.

Not in this PR: a per-branch heading in the `but status` worktree lane, which needs a CLI id for the row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)