### PR TITLE
fix(but): re-create workspace when switching back to it

### DIFF
--- a/crates/but-workspace/src/branch/apply.rs
+++ b/crates/but-workspace/src/branch/apply.rs
@@ -421,10 +421,20 @@ pub fn apply(
                 )?;
             (tip, false)
         }
-        Some(mut existing_workspace_reference) => {
-            let id = existing_workspace_reference.peel_to_id()?;
-            (id.detach(), true)
-        }
+        Some(mut existing_workspace_reference) => match &ws.kind {
+            WorkspaceKind::Managed { .. } | WorkspaceKind::ManagedMissingWorkspaceCommit { .. } => {
+                let id = existing_workspace_reference.peel_to_id()?;
+                (id.detach(), true)
+            }
+            // If starting from an adhoc workspace, re-create the managed workspace from the current
+            // HEAD and not from the old workspace. Branches that were previously applied might have
+            // moved and thus the old workspace will contain out of date commits that'll become
+            // anonymous segments.
+            WorkspaceKind::AdHoc => {
+                let tip = repo.head_id()?;
+                (tip.detach(), true)
+            }
+        },
     };
 
     let mut ws_md = meta.workspace(workspace_ref_name_to_update.as_ref())?;

--- a/crates/but/src/command/legacy/apply.rs
+++ b/crates/but/src/command/legacy/apply.rs
@@ -146,7 +146,7 @@ impl std::fmt::Display for ConflictAbortedOutcome {
                 .outcome
                 .conflicting_stacks
                 .iter()
-                .map(|stack| stack.ref_name.shorten().to_string())
+                .map(|stack| theme::Branch(&stack.ref_name).to_string())
                 .collect::<Vec<_>>()
                 .join(", ");
             write!(

--- a/crates/but/src/command/legacy/branch/new.rs
+++ b/crates/but/src/command/legacy/branch/new.rs
@@ -26,7 +26,7 @@ use crate::{
     print_deprecation_warning,
     theme::{self, Theme},
     utils::{
-        CliOutput, CliOutputHuman, IntermediateChannel, WriteWithUtils,
+        CliOutput, CliOutputHuman, IntermediateChannel, WriteWithUtils, head_name,
         in_single_branch_mode_with_perm, merged_upstream::MergedUpstream, targeting::Side,
     },
 };
@@ -487,15 +487,6 @@ impl NewStackedBranchOperation {
             target: Some((target, side)),
         })
     }
-}
-
-fn head_name(repo: &gix::Repository) -> anyhow::Result<FullName> {
-    Ok(repo
-        .head()?
-        .referent_name()
-        .filter(|name| name.category() == Some(gix::refs::Category::LocalBranch))
-        .context("single-branch branch creation requires HEAD to be a local branch")?
-        .to_owned())
 }
 
 #[must_use]

--- a/crates/but/src/command/legacy/switch.rs
+++ b/crates/but/src/command/legacy/switch.rs
@@ -1,9 +1,11 @@
 use but_core::{
-    WORKSPACE_REF_NAME,
+    RefMetadata, WORKSPACE_REF_NAME,
     sync::{RepoExclusive, RepoShared},
 };
 use but_ctx::Context;
+use but_oplog::legacy::{OperationKind, SnapshotDetails};
 use gix::refs::FullName;
+use itertools::Itertools as _;
 use serde::Serialize;
 
 use crate::{
@@ -15,7 +17,7 @@ use crate::{
     },
     print_deprecation_warning,
     theme::{self, Theme},
-    utils::{CliOutput, CliOutputHuman, IntermediateChannel, WriteWithUtils},
+    utils::{CliOutput, CliOutputHuman, IntermediateChannel, WriteWithUtils, head_name},
 };
 
 pub fn switch(
@@ -81,12 +83,13 @@ pub fn run(
                 repo.try_find_reference(WORKSPACE_REF_NAME)?.is_some()
             };
             if workspace_exists {
-                but_api::branch::workspace_checkout_with_perm(ctx, perm)?;
+                recreate_workspace(ctx, perm)
             } else {
                 but_api::legacy::virtual_branches::switch_back_to_workspace_with_perm(ctx, perm)?;
+                Ok(SwitchOutcome::Workspace {
+                    conflicting_stacks: Default::default(),
+                })
             }
-
-            Ok(SwitchOutcome::Workspace)
         }
         SwitchOperation::Branch { branch } => {
             but_api::branch::branch_checkout_with_perm(ctx, branch.clone(), perm)?;
@@ -120,7 +123,8 @@ pub enum SwitchOperation {
 
 #[must_use]
 pub enum SwitchOutcome {
-    Workspace,
+    Workspace { conflicting_stacks: Vec<FullName> },
+    AlreadyOnWorkspace,
     Branch { branch: FullName },
     CreatedBranch { branch: FullName },
 }
@@ -130,10 +134,30 @@ impl CliOutputHuman for SwitchOutcome {
         self,
         out: &mut dyn WriteWithUtils,
         _agent: bool,
-        _theme: &'static Theme,
+        theme: &'static Theme,
     ) -> anyhow::Result<()> {
         match self {
-            SwitchOutcome::Workspace => writeln!(out, "Switched to workspace")?,
+            SwitchOutcome::Workspace { conflicting_stacks } => {
+                writeln!(out, "Switched to workspace")?;
+
+                if !conflicting_stacks.is_empty() {
+                    writeln!(out)?;
+                    writeln!(
+                        out,
+                        "{} Failed to apply {} due to conflicts with existing {}",
+                        theme.sym().warning,
+                        conflicting_stacks.iter().map(theme::Branch).join(", "),
+                        if conflicting_stacks.len() == 1 {
+                            "stack"
+                        } else {
+                            "stacks"
+                        },
+                    )?;
+                }
+            }
+            SwitchOutcome::AlreadyOnWorkspace => {
+                writeln!(out, "Already on workspace")?;
+            }
             SwitchOutcome::Branch { branch } => {
                 writeln!(out, "Switched to branch {}", theme::Branch(branch))?
             }
@@ -149,15 +173,131 @@ impl CliOutputHuman for SwitchOutcome {
 impl CliOutput for SwitchOutcome {
     fn on_json(self) -> impl Serialize {
         #[derive(Serialize)]
-        struct Output {
-            branch: String,
+        #[serde(
+            tag = "type",
+            rename_all = "camelCase",
+            rename_all_fields = "camelCase"
+        )]
+        enum Output {
+            CreatedBranch { branch: String },
+            SwitchedToWorkspace { conflicting_branches: Vec<String> },
         }
 
         match self {
-            SwitchOutcome::Workspace | SwitchOutcome::Branch { .. } => None,
-            SwitchOutcome::CreatedBranch { branch } => Some(Output {
+            SwitchOutcome::Workspace { conflicting_stacks } => Some(Output::SwitchedToWorkspace {
+                conflicting_branches: conflicting_stacks
+                    .into_iter()
+                    .map(|b| b.shorten().to_string())
+                    .collect(),
+            }),
+            SwitchOutcome::AlreadyOnWorkspace => Some(Output::SwitchedToWorkspace {
+                conflicting_branches: Default::default(),
+            }),
+            SwitchOutcome::Branch { .. } => None,
+            SwitchOutcome::CreatedBranch { branch } => Some(Output::CreatedBranch {
                 branch: branch.shorten().to_string(),
             }),
         }
     }
+}
+
+/// Recreate the workspace by applying all previously applied branches.
+///
+/// TODO(david): move this into but-api and expose to Lite SDK.
+fn recreate_workspace(
+    ctx: &mut Context,
+    perm: &mut RepoExclusive,
+) -> anyhow::Result<SwitchOutcome> {
+    // TODO(david): only create the snapshot if we're not already on the workspace, i.e. we don't
+    // return `SwitchOutcome::AlreadyOnWorkspace`
+    let maybe_oplog_entry = but_oplog::UnmaterializedOplogSnapshot::from_details_with_perm(
+        ctx,
+        SnapshotDetails::new(OperationKind::SwitchToWorkspace),
+        perm.read_permission(),
+        but_core::DryRun::No,
+    );
+
+    let outcome = {
+        let mut meta = ctx.meta()?;
+        let (repo, mut ws, _db) = ctx.workspace_mut_and_db_with_perm(perm)?;
+
+        let previously_applied_stack_heads: Vec<FullName> = {
+            let workspace_ref: FullName = but_core::WORKSPACE_REF_NAME.try_into()?;
+            let workspace_meta = meta.workspace(workspace_ref.as_ref())?;
+            workspace_meta
+                .stack_names(but_core::ref_metadata::StackKind::Applied)
+                .map(|name| name.to_owned())
+                .collect::<Vec<_>>()
+        };
+
+        match &ws.kind {
+            but_graph::workspace::WorkspaceKind::Managed { .. }
+            | but_graph::workspace::WorkspaceKind::ManagedMissingWorkspaceCommit { .. } => {
+                return Ok(SwitchOutcome::AlreadyOnWorkspace);
+            }
+            but_graph::workspace::WorkspaceKind::AdHoc => {}
+        }
+
+        let head_name = head_name(&repo)?;
+
+        if !ws.is_branch_the_target_or_its_local_tracking_branch(head_name.as_ref()) {
+            // applying the current branch has the effect of entering the workspace with one branch applied
+            let outcome = but_workspace::branch::apply(
+                head_name.as_ref(),
+                ws.clone(),
+                &repo,
+                &mut meta,
+                but_workspace::branch::apply::Options {
+                    allow_applying_already_applied_branch_when_outside_workspace: true,
+                    ..Default::default()
+                },
+            )?;
+            if outcome.status.persisted_mutation() {
+                *ws = outcome.workspace.clone();
+            } else {
+                anyhow::bail!(
+                    "BUG: failed to apply head ref ({head_name}). Failed with {:?}",
+                    outcome.status
+                )
+            }
+        }
+
+        if previously_applied_stack_heads.is_empty() {
+            drop((repo, ws, _db));
+            but_api::branch::workspace_checkout_with_perm_only(ctx, perm)?;
+
+            SwitchOutcome::Workspace {
+                conflicting_stacks: Vec::new(),
+            }
+        } else {
+            let mut conflicting_stacks = Vec::new();
+
+            // apply all previously applied branches
+            for stack_ref in previously_applied_stack_heads {
+                let apply_outcome = but_workspace::branch::apply(
+                    stack_ref.as_ref(),
+                    ws.clone(),
+                    &repo,
+                    &mut meta,
+                    but_workspace::branch::apply::Options::default(),
+                )?;
+
+                if !apply_outcome.conflicting_stacks.is_empty() {
+                    conflicting_stacks.push(stack_ref);
+                }
+
+                if apply_outcome.status.persisted_mutation() {
+                    *ws = apply_outcome.workspace.clone();
+                }
+            }
+
+            SwitchOutcome::Workspace { conflicting_stacks }
+        }
+    };
+
+    if let Some(snapshot) = maybe_oplog_entry {
+        _ = snapshot.commit(ctx, perm);
+    }
+
+    Ok(outcome)
 }

--- a/crates/but/src/utils/mod.rs
+++ b/crates/but/src/utils/mod.rs
@@ -1,9 +1,11 @@
 use std::io::Write;
 
 mod output_channel;
+use anyhow::Context as _;
 use but_api::json::{ChangeIdString, HexHash};
 use but_core::sync::RepoShared;
 use but_ctx::Context;
+use gix::refs::FullName;
 pub(crate) use output_channel::PromptLine;
 pub use output_channel::{
     CliOutput, CliOutputHuman, Confirm, ConfirmDefault, ConfirmOrEmpty, InputOutputChannel,
@@ -120,4 +122,13 @@ pub fn in_single_branch_mode(ctx: &Context) -> anyhow::Result<bool> {
 pub fn in_single_branch_mode_with_perm(ctx: &Context, perm: &RepoShared) -> anyhow::Result<bool> {
     Ok(ctx.settings.feature_flags.single_branch
         && gitbutler_operating_modes::in_outside_workspace_mode(ctx, perm)?)
+}
+
+pub fn head_name(repo: &gix::Repository) -> anyhow::Result<FullName> {
+    Ok(repo
+        .head()?
+        .referent_name()
+        .filter(|name| name.category() == Some(gix::refs::Category::LocalBranch))
+        .context("HEAD must refer to a local branch")?
+        .to_owned())
 }

--- a/crates/but/tests/but/command/branch/apply.rs
+++ b/crates/but/tests/but/command/branch/apply.rs
@@ -608,7 +608,7 @@ fn apply_branch_conflicting_with_workspace_reports_error() {
         .assert()
         .failure()
         .stderr_eq(str![[r#"
-Failed to apply branch: 'conflicting-branch' conflicts with existing stack: A
+Failed to apply branch: 'conflicting-branch' conflicts with existing stack: 'A'
 
 "#]])
         .stdout_eq(str![""]);
@@ -618,7 +618,7 @@ Failed to apply branch: 'conflicting-branch' conflicts with existing stack: A
         .assert()
         .failure()
         .stderr_eq(str![[r#"
-Failed to apply branch: 'conflicting-branch' conflicts with existing stack: A
+Failed to apply branch: 'conflicting-branch' conflicts with existing stack: 'A'
 
 "#]])
         .stdout_eq(str![""]);

--- a/crates/but/tests/but/command/switch.rs
+++ b/crates/but/tests/but/command/switch.rs
@@ -1,16 +1,8 @@
-use snapbox::str;
+use snapbox::{assert_data_eq, str};
 
-#[cfg(feature = "legacy")]
 use crate::utils::CommandExt as _;
 use crate::utils::Sandbox;
 
-fn switch_env() -> crate::utils::Sandbox {
-    let env = crate::utils::Sandbox::init_scenario_with_target_and_default_settings("one-stack");
-    env.setup_metadata(&["A"]);
-    env
-}
-
-#[cfg(feature = "legacy")]
 fn status_json(env: &crate::utils::Sandbox) -> serde_json::Value {
     let output = env.but("--json status").allow_json().output().unwrap();
     serde_json::from_slice(&output.stdout)
@@ -18,7 +10,6 @@ fn status_json(env: &crate::utils::Sandbox) -> serde_json::Value {
         .unwrap()
 }
 
-#[cfg(feature = "legacy")]
 fn assert_workspace_status(env: &crate::utils::Sandbox) {
     env.but("status")
         .assert()
@@ -40,9 +31,9 @@ Hint: run `but help` for all commands
 
 #[test]
 fn switches_to_existing_branch_by_short_name() {
-    let env = switch_env();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
-    #[cfg(feature = "legacy")]
     assert_workspace_status(&env);
 
     env.but("switch A")
@@ -59,9 +50,9 @@ Switched to branch 'A'
 
 #[test]
 fn switches_to_existing_branch_by_full_ref() {
-    let env = switch_env();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
-    #[cfg(feature = "legacy")]
     assert_workspace_status(&env);
 
     env.but("switch refs/heads/A")
@@ -78,7 +69,9 @@ Switched to branch 'A'
 
 #[test]
 fn switches_to_existing_branch_with_remote_like_name() {
-    let env = switch_env();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
+
     env.invoke_git("branch origin/main main");
 
     env.but("switch origin/main")
@@ -96,10 +89,10 @@ Switched to branch 'origin/main'
     );
 }
 
-#[cfg(feature = "legacy")]
 #[test]
 fn switches_to_existing_branch_by_workspace_cli_id() {
-    let env = switch_env();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     assert_workspace_status(&env);
 
@@ -120,7 +113,6 @@ Switched to branch 'A'
     assert_eq!(env.invoke_git("rev-parse --abbrev-ref HEAD"), "A");
 }
 
-#[cfg(feature = "legacy")]
 #[test]
 fn switching_to_lower_branch_only_shows_it_in_single_branch_mode() {
     let env = crate::utils::Sandbox::init_scenario_with_target_and_default_settings(
@@ -171,7 +163,6 @@ Hint: run `but help` for all commands
 "#]]);
 }
 
-#[cfg(feature = "legacy")]
 #[test]
 fn switching_to_reordered_empty_branch_preserves_lower_branches() {
     let env = crate::utils::Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
@@ -235,7 +226,8 @@ Hint: run `but help` for all commands
 
 #[test]
 fn switches_back_to_workspace() {
-    let env = switch_env();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
     env.invoke_git("checkout A");
 
     env.but("switch --workspace")
@@ -252,15 +244,14 @@ Switched to workspace
         "gitbutler/workspace"
     );
 
-    #[cfg(feature = "legacy")]
     assert_workspace_status(&env);
 }
 
 #[test]
 fn creates_named_branch_and_switches_to_it() {
-    let env = switch_env();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
-    #[cfg(feature = "legacy")]
     assert_workspace_status(&env);
 
     env.but("switch --new my-feature")
@@ -284,7 +275,8 @@ Created branch 'my-feature'
 
 #[test]
 fn creates_named_branch_with_json_output() {
-    let env = switch_env();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.but("--json switch --new my-feature")
         .allow_json()
@@ -296,6 +288,7 @@ fn creates_named_branch_with_json_output() {
 "#]])
         .stdout_eq(str![[r#"
 {
+  "type": "createdBranch",
   "branch": "my-feature"
 }
 
@@ -306,9 +299,9 @@ fn creates_named_branch_with_json_output() {
 
 #[test]
 fn creates_generated_branch_and_switches_to_it() {
-    let env = switch_env();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
-    #[cfg(feature = "legacy")]
     assert_workspace_status(&env);
 
     env.but("switch --new")
@@ -332,7 +325,8 @@ Created branch 'a-branch-1'
 
 #[test]
 fn rejects_workspace_with_target() {
-    let env = switch_env();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.but("switch --workspace A")
         .assert()
@@ -350,7 +344,8 @@ For more information, try '--help'.
 
 #[test]
 fn rejects_remote_branch() {
-    let env = switch_env();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
 
     env.but("switch origin/main")
         .assert()
@@ -362,10 +357,11 @@ Error: Can only switch to local branches, got 'origin/main'
 "#]]);
 }
 
-#[cfg(feature = "legacy")]
 #[test]
 fn rejects_non_branch_cli_id() {
-    let env = switch_env();
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
+
     let status = status_json(&env);
     let commit_cli_id = status["stacks"][0]["branches"][0]["commits"][0]["cliId"]
         .as_str()
@@ -404,9 +400,9 @@ Hint: run `but help` for all commands
 "#]]);
 
     // no workspace exists
-    snapbox::assert_data_eq!(
+    assert_data_eq!(
         env.git_log(),
-        snapbox::str![[r#"
+        str![[r#"
 * b1540e5 (HEAD -> main, origin/main, origin/HEAD) M
 * e31e6ca add init
 
@@ -422,11 +418,6 @@ Switched to workspace
 
 "#]]);
 
-    assert_eq!(
-        env.invoke_git("rev-parse --abbrev-ref HEAD"),
-        "gitbutler/workspace"
-    );
-
     env.but("status")
         .assert()
         .success()
@@ -441,12 +432,431 @@ Hint: run `but branch new` to create a new branch to work on
 "#]]);
 
     // workspace exists
-    snapbox::assert_data_eq!(
+    assert_data_eq!(
         env.git_log(),
-        snapbox::str![[r#"
+        str![[r#"
 * 6c7afcb (HEAD -> gitbutler/workspace) GitButler Workspace Commit
 * b1540e5 (origin/main, origin/HEAD, main, gitbutler/target) M
 * e31e6ca add init
+
+"#]]
+    );
+}
+
+#[test]
+fn switching_back_to_workspace_after_committing_in_single_branch_mode() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("two-stacks");
+    env.setup_metadata(&["A", "B"]);
+
+    env.but("status")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+╭┄ @ [uncommitted] (no changes)
+┊
+┊╭┄ g0 [A]
+┊●   tpm add A
+├╯
+┊
+┊╭┄ h0 [B]
+┊●   lrm add B
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    env.but("switch A").assert().success();
+    env.but("commit -b A -m one").assert().success();
+    env.but("commit -b A -m two").assert().success();
+
+    env.but("status")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+╭┄ @ [uncommitted] (no changes)
+┊
+┊╭┄ g0 [A]
+┊●   ppx two (no changes)
+┊●   orn one (no changes)
+┊●   tpm add A
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    assert_data_eq!(
+        env.git_log(),
+        str![[r#"
+* e1df4fe (HEAD -> A) two
+* 4a5164c one
+| *   c128bce (gitbutler/workspace) GitButler Workspace Commit
+| |/  
+| |/  
+|/|   
+* | 9477ae7 add A
+| * d3e2ba3 (B) add B
+|/  
+* 0dc3733 (origin/main, origin/HEAD, main, gitbutler/target) add M
+
+"#]]
+    );
+
+    env.but("switch --workspace").assert().success();
+
+    env.but("status")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+╭┄ @ [uncommitted] (no changes)
+┊
+┊╭┄ g0 [A]
+┊●   ppx two (no changes)
+┊●   orn one (no changes)
+┊●   tpm add A
+├╯
+┊
+┊╭┄ h0 [B]
+┊●   lrm add B
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    assert_data_eq!(
+        env.git_log(),
+        str![[r#"
+*   6154bb8 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+|/  
+| * d3e2ba3 (B) add B
+* | e1df4fe (A) two
+* | 4a5164c one
+* | 9477ae7 add A
+|/  
+* 0dc3733 (origin/main, origin/HEAD, main, gitbutler/target) add M
+
+"#]]
+    );
+}
+
+#[test]
+fn switching_back_to_workspace_when_already_in_workspace() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
+
+    env.but("switch --workspace")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Already on workspace
+
+"#]]);
+}
+
+#[test]
+fn switching_back_to_workspace_that_conflicts_with_checked_out_branch() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
+
+    env.file("one", "one content");
+    env.but("commit -b one -m 'add one'").assert().success();
+
+    env.file("two", "two content");
+    env.but("commit -b two -m 'add two'").assert().success();
+
+    env.file("three", "three content");
+    env.but("commit -b three -m 'add three'").assert().success();
+
+    env.but("switch one").assert().success();
+    env.file("two", "different two content");
+    env.but("commit -m 'add two'").assert().success();
+
+    env.but("switch --workspace")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Switched to workspace
+
+⚠ Failed to apply 'two' due to conflicts with existing stack
+
+"#]]);
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+╭┄ @ [uncommitted] (no changes)
+┊
+┊╭┄ th [three]
+┊●   owr add three
+┊│     owr:o A three
+├╯
+┊
+┊╭┄ on [one]
+┊●   llm add two
+┊│     llm:t A two
+┊●   onv add one
+┊│     onv:k A one
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn switching_back_to_workspace_that_conflicts_with_multiple_branches() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
+
+    env.file("one", "one content");
+    env.but("commit -b one -m 'add one'").assert().success();
+
+    env.file("two", "two content");
+    env.but("commit -b two -m 'add two'").assert().success();
+
+    env.file("three", "three content");
+    env.but("commit -b three -m 'add three'").assert().success();
+
+    env.but("switch one").assert().success();
+    env.file("two", "different two content");
+    env.but("commit -m 'add two'").assert().success();
+
+    env.but("switch three").assert().success();
+    env.file("two", "different two content yet again");
+    env.but("commit -m 'add two'").assert().success();
+
+    env.but("switch --workspace")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Switched to workspace
+
+⚠ Failed to apply 'two', 'one' due to conflicts with existing stacks
+
+"#]]);
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+╭┄ @ [uncommitted] (no changes)
+┊
+┊╭┄ th [three]
+┊●   uov add two
+┊│     uov:t A two
+┊●   owr add three
+┊│     owr:o A three
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+}
+
+#[test]
+fn switching_back_to_empty_workspace() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
+
+    env.but("branch new --switch").assert().success();
+    env.but("commit --no-message").assert().success();
+
+    env.but("switch --workspace")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Switched to workspace
+
+"#]]);
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+╭┄ @ [uncommitted] (no changes)
+┊
+┊╭┄ br [a-branch-1]
+┊●   tqv (no commit message) (no changes)
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    assert_data_eq!(
+        env.git_log(),
+        str![[r#"
+* de5dad6 (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+* f41568d (a-branch-1) 
+* 0dc3733 (origin/main, origin/HEAD, main, gitbutler/target) add M
+
+"#]]
+    );
+}
+
+#[test]
+fn switching_back_to_workspace_from_main_when_workspace_exists() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("one-stack");
+    env.setup_metadata(&["A"]);
+
+    env.but("switch main").assert().success();
+
+    env.but("switch --workspace")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Switched to workspace
+
+"#]]);
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+╭┄ @ [uncommitted] (no changes)
+┊
+┊╭┄ g0 [A]
+┊●   tpm add A
+┊│     tpm:t A A
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    assert_data_eq!(
+        env.git_log(),
+        str![[r#"
+* 0bbfbfd (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+* 9477ae7 (A) add A
+* 0dc3733 (origin/main, origin/HEAD, main, gitbutler/target) add M
+
+"#]]
+    );
+}
+
+#[test]
+fn switching_back_to_workspace_from_main_with_existing_empty_workspace() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
+
+    env.but("switch main").assert().success();
+
+    env.but("switch --workspace")
+        .assert()
+        .success()
+        .stdout_eq(str![[r#"
+Switched to workspace
+
+"#]]);
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+╭┄ @ [uncommitted] (no changes)
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but branch new` to create a new branch to work on
+
+"#]]);
+
+    assert_data_eq!(
+        env.git_log(),
+        str![[r#"
+* ff4136d (HEAD -> gitbutler/workspace) GitButler Workspace Commit
+* 0dc3733 (origin/main, origin/HEAD, main, gitbutler/target) add M
+
+"#]]
+    );
+}
+
+#[test]
+fn switching_back_to_workspace_from_main_with_conflicts() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
+
+    env.file("one", "content of one");
+
+    env.but("commit -b one -m 'add one'").assert().success();
+    env.but("switch main").assert().success();
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+╭┄ @ [uncommitted] (no changes)
+┊
+┊╭┄ ma [main] (no commits)
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but help` for all commands
+
+"#]]);
+
+    // intentionally dont commit this file to cause conflicts
+    env.file("one", "different content of one");
+
+    env.but("switch --workspace")
+        .assert()
+        .failure()
+        .stderr_eq(str![[r#"
+Error: Uncommitted files would be overwritten by checkout: "one"
+
+"#]]);
+
+    env.but("status -f")
+        .assert()
+        .success()
+        .stderr_eq(str![])
+        .stdout_eq(str![[r#"
+╭┄ @ [uncommitted]
+┊   kl A one
+┊
+┊╭┄ ma [main] (no commits)
+├╯
+┊
+┴ 0dc3733 (common base) 2000-01-02 add M
+
+Hint: run `but diff` to see uncommitted changes and `but commit -b <branch> -m "message" <id>` to commit them
+
+"#]]);
+
+    assert_data_eq!(
+        env.git_log(),
+        str![[r#"
+* b34435b (gitbutler/workspace) GitButler Workspace Commit
+* 72aceac (one) add one
+* 0dc3733 (HEAD -> main, origin/main, origin/HEAD, gitbutler/target) add M
 
 "#]]
     );

--- a/crates/but/tests/but/command/undo.rs
+++ b/crates/but/tests/but/command/undo.rs
@@ -967,3 +967,43 @@ fn can_undo_single_branch_mode_but_branch_new_below() {
             .success();
     });
 }
+
+#[test]
+fn can_undo_switch_workspace_applying_multiple_branches() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
+
+    env.but("commit -b one --no-message").assert().success();
+    env.but("commit -b two --no-message").assert().success();
+    env.but("commit -b three --no-message").assert().success();
+
+    env.but("switch one").assert().success();
+
+    run_mutate_undo_roundtrip_test(&env, |env| {
+        env.but("switch --workspace").assert().success();
+    });
+}
+
+#[test]
+fn switching_to_workspace_from_workspace_doesnt_create_snapshot() {
+    let env = Sandbox::init_scenario_with_target_and_default_settings("zero-stacks");
+    env.setup_metadata(&[]);
+
+    env.but("oplog list")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+No operations found in history.
+
+"#]]);
+
+    env.but("switch --workspace").assert().success();
+
+    env.but("oplog list")
+        .assert()
+        .success()
+        .stdout_eq(snapbox::str![[r#"
+No operations found in history.
+
+"#]]);
+}


### PR DESCRIPTION
Rather than simply doing a `git switch gitbutler/workspace` we now re-create the workspace by applying all previously applied branches.