### PR TITLE
Return target commits with upstream integration

### DIFF
--- a/apps/desktop/src/lib/stacks/stackInvalidation.test.ts
+++ b/apps/desktop/src/lib/stacks/stackInvalidation.test.ts
@@ -33,6 +33,7 @@ const headInfo = {
 const integrationResult = {
 	workspaceState: { headInfo, replacedCommits: {}, checkoutConflictOccurred: false },
 	worktreeConflicts: [],
+	targetCommits: null,
 } satisfies WorkspaceIntegrateUpstreamOutcome;
 
 type TestBaseQuery = BaseQueryFn<unknown, unknown, string, { command?: string }>;

--- a/apps/lite/ui/src/api/mutations.test.tsx
+++ b/apps/lite/ui/src/api/mutations.test.tsx
@@ -1,0 +1,100 @@
+/** @vitest-environment jsdom */
+
+import { useWorkspaceIntegrateUpstream } from "#ui/api/mutations.ts";
+import {
+	olderTargetCommitsInfiniteQueryOptions,
+	workspaceTargetCommitsQueryOptions,
+} from "#ui/api/queries.ts";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("#ui/store.ts", () => ({ useAppDispatch: () => vi.fn() }));
+vi.mock("#ui/use-cursor.ts", () => ({}));
+vi.mock("@base-ui/react", () => ({ Toast: { useToastManager: () => ({ add: vi.fn() }) } }));
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const baseKey = workspaceTargetCommitsQueryOptions("project").queryKey;
+const olderKey = olderTargetCommitsInfiniteQueryOptions("project", "cursor").queryKey;
+const otherKey = workspaceTargetCommitsQueryOptions("other-project").queryKey;
+const original = { commits: [], hasMore: true };
+const updated = { commits: [], hasMore: false };
+
+describe("useWorkspaceIntegrateUpstream", () => {
+	let client: QueryClient;
+	let root: Root;
+	let integrate: ReturnType<typeof useWorkspaceIntegrateUpstream>["mutateAsync"];
+	const workspaceIntegrateUpstream = vi.fn();
+
+	beforeEach(() => {
+		vi.stubGlobal("lite", { workspaceIntegrateUpstream });
+		client = new QueryClient();
+		client.setQueryData(baseKey, original);
+		client.setQueryData(olderKey, { pages: [original], pageParams: ["cursor"] });
+		client.setQueryData(otherKey, original);
+		const container = document.createElement("div");
+		root = createRoot(container);
+		const Probe = () => {
+			const mutation = useWorkspaceIntegrateUpstream();
+			return (
+				<button
+					type="button"
+					onClick={() => {
+						integrate = mutation.mutateAsync;
+					}}
+				>
+					Connect
+				</button>
+			);
+		};
+		act(() =>
+			root.render(
+				<QueryClientProvider client={client}>
+					<Probe />
+				</QueryClientProvider>,
+			),
+		);
+		act(() => container.querySelector("button")?.click());
+	});
+
+	afterEach(() => {
+		act(() => root.unmount());
+		client.clear();
+		vi.unstubAllGlobals();
+	});
+
+	const run = async (targetCommits: typeof updated | null | undefined, dryRun = false) => {
+		workspaceIntegrateUpstream.mockResolvedValue({ workspace: null, targetCommits });
+		await act(async () => {
+			await integrate({ projectId: "project", updates: [], dryRun });
+		});
+	};
+
+	it("seeds the base listing and invalidates older pages without invalidating the base", async () => {
+		await run(updated);
+		expect(client.getQueryData(baseKey)).toEqual(updated);
+		expect(client.getQueryState(baseKey)?.isInvalidated).toBe(false);
+		expect(client.getQueryState(olderKey)?.isInvalidated).toBe(true);
+		expect(client.getQueryState(otherKey)?.isInvalidated).toBe(false);
+	});
+
+	it.each([null, undefined])(
+		"invalidates all target pages when the listing is %s",
+		async (listing) => {
+			await run(listing);
+			expect(client.getQueryData(baseKey)).toEqual(original);
+			expect(client.getQueryState(baseKey)?.isInvalidated).toBe(true);
+			expect(client.getQueryState(olderKey)?.isInvalidated).toBe(true);
+			expect(client.getQueryState(otherKey)?.isInvalidated).toBe(false);
+		},
+	);
+
+	it("leaves cached listings untouched for a dry run", async () => {
+		await run(updated, true);
+		expect(client.getQueryData(baseKey)).toEqual(original);
+		expect(client.getQueryState(baseKey)?.isInvalidated).toBe(false);
+		expect(client.getQueryState(olderKey)?.isInvalidated).toBe(false);
+	});
+});

--- a/apps/lite/ui/src/api/mutations.ts
+++ b/apps/lite/ui/src/api/mutations.ts
@@ -15,6 +15,7 @@ import {
 	listReviewReactionsQueryOptions,
 	treeChangeDiffsQueryOptions,
 	workspaceFetchQueryOptions,
+	workspaceTargetCommitsQueryOptions,
 } from "#ui/api/queries.ts";
 import { shortCommitId } from "#ui/commit.ts";
 import {
@@ -1275,11 +1276,16 @@ export const useWorkspaceIntegrateUpstream = () => {
 	return useMutation({
 		mutationFn: window.lite.workspaceIntegrateUpstream,
 		onSuccess: (response, input, _context, mutation) => {
+			if (input.dryRun) return;
 			syncCoreCaches(mutation.client, dispatch, input.projectId, response);
-			// The base moved with the stacks: re-read the target line now rather
-			// than showing the old incoming commits until the watcher delivers.
+			const queryKey = workspaceTargetCommitsQueryOptions(input.projectId).queryKey;
+			if (response.targetCommits != null)
+				mutation.client.setQueryData(queryKey, response.targetCommits);
+
 			void mutation.client.invalidateQueries({
-				queryKey: [input.projectId, "workspaceTargetCommits"],
+				queryKey,
+				predicate: (query) =>
+					response.targetCommits == null || query.queryKey.length > queryKey.length,
 			});
 		},
 		onError: (error, input) => {

--- a/crates/but-api/src/target_commits.rs
+++ b/crates/but-api/src/target_commits.rs
@@ -47,7 +47,18 @@ pub fn workspace_target_commits(
     from: Option<HexHash>,
     limit: Option<u32>,
 ) -> anyhow::Result<TargetCommitPage> {
-    let (_guard, repo, ws, db) = ctx.workspace_and_db()?;
+    let guard = ctx.shared_worktree_access();
+    workspace_target_commits_with_perm(ctx, from, limit, guard.read_permission())
+}
+
+/// List target commits while reusing the caller's repository access permission.
+pub(crate) fn workspace_target_commits_with_perm(
+    ctx: &but_ctx::Context,
+    from: Option<HexHash>,
+    limit: Option<u32>,
+    perm: &but_core::sync::RepoShared,
+) -> anyhow::Result<TargetCommitPage> {
+    let (repo, ws, db) = ctx.workspace_and_db_with_perm(perm)?;
     let Some(target_ref) = ws.target_ref.as_ref() else {
         return Ok(TargetCommitPage::default());
     };
@@ -186,7 +197,7 @@ fn natural_end_of_line(
 }
 
 /// One bounded page of target commits and the state needed to continue it.
-#[derive(Debug, Default, Serialize)]
+#[derive(Debug, Clone, Default, Serialize)]
 #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct TargetCommitPage {
@@ -201,7 +212,7 @@ but_schemars::register_sdk_type!(TargetCommitPage);
 
 /// A commit on the target branch's first-parent line, its relation to the
 /// workspace, and the merged review it landed, if known.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct TargetCommit {
@@ -222,7 +233,7 @@ but_schemars::register_sdk_type!(TargetCommit);
 /// available from the per-review APIs. The source branch lets clients match
 /// workspace branches to the commit that landed them; it is empty when
 /// unknown.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 #[cfg_attr(feature = "export-schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct TargetCommitReview {

--- a/crates/but-api/src/workspace.rs
+++ b/crates/but-api/src/workspace.rs
@@ -337,6 +337,8 @@ pub fn resolve_worktree_conflicts(
 pub struct WorkspaceIntegrateUpstreamOutcome {
     /// The post-operation or preview workspace state.
     pub workspace_state: WorkspaceState,
+    /// The updated default target-commit page, or `None` for a dry run or a failed page read.
+    pub target_commits: Option<crate::target_commits::TargetCommitPage>,
     /// Dirty worktree paths that would conflict when applied onto the resulting workspace head.
     pub worktree_conflicts: Vec<BStringForFrontend>,
 }
@@ -400,6 +402,8 @@ pub mod json {
     pub struct WorkspaceIntegrateUpstreamOutcome {
         /// The post-operation or preview workspace state.
         pub workspace_state: crate::json::WorkspaceState,
+        /// The updated default target-commit page, or `None` for a dry run or a failed page read.
+        pub target_commits: Option<crate::target_commits::TargetCommitPage>,
         /// Dirty worktree paths that would conflict when applied onto the resulting workspace head.
         #[cfg_attr(feature = "export-schema", schemars(with = "Vec<String>"))]
         pub worktree_conflicts: Vec<BStringForFrontend>,
@@ -414,6 +418,7 @@ pub mod json {
         fn try_from(value: super::WorkspaceIntegrateUpstreamOutcome) -> Result<Self, Self::Error> {
             Ok(Self {
                 workspace_state: value.workspace_state.try_into()?,
+                target_commits: value.target_commits,
                 worktree_conflicts: value.worktree_conflicts,
             })
         }
@@ -678,6 +683,7 @@ pub fn workspace_integrate_upstream_only_with_perm(
             rebase.project_meta_mut().target_commit_id = cached_target;
             return Ok(WorkspaceIntegrateUpstreamOutcome {
                 workspace_state,
+                target_commits: None,
                 worktree_conflicts,
             });
         }
@@ -708,6 +714,19 @@ pub fn workspace_integrate_upstream_only_with_perm(
 
     Ok(WorkspaceIntegrateUpstreamOutcome {
         workspace_state,
+        target_commits: crate::target_commits::workspace_target_commits_with_perm(
+            ctx,
+            None,
+            None,
+            perm.read_permission(),
+        )
+        .inspect_err(|err| {
+            warn!(
+                ?err,
+                "failed to read target commits after upstream integration"
+            )
+        })
+        .ok(),
         worktree_conflicts,
     })
 }

--- a/crates/but-api/tests/api/target_commits.rs
+++ b/crates/but-api/tests/api/target_commits.rs
@@ -71,6 +71,117 @@ fn reports_clipping_and_accepts_a_zero_limit() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[test]
+fn integration_returns_the_updated_target_page_only_after_materializing() -> anyhow::Result<()> {
+    let (mut ctx, _tmp) = incoming_target()?;
+    let before = but_api::target_commits::workspace_target_commits(&ctx, None, None)?;
+    assert!(
+        before.commits.iter().any(|entry| !entry.in_workspace),
+        "the fixture has incoming target commits"
+    );
+
+    let preview = but_api::workspace::workspace_integrate_upstream_only(
+        &mut ctx,
+        vec![],
+        but_core::DryRun::Yes,
+    )?;
+    let preview = serde_json::to_value(
+        but_api::workspace::json::WorkspaceIntegrateUpstreamOutcome::try_from(preview)?,
+    )?;
+    assert_eq!(
+        preview.get("targetCommits"),
+        Some(&serde_json::Value::Null),
+        "a dry run must not supply a page for the live target cache"
+    );
+    assert_eq!(
+        serde_json::to_value(but_api::target_commits::workspace_target_commits(
+            &ctx, None, None
+        )?)?,
+        serde_json::to_value(&before)?,
+        "previewing leaves the persisted target listing unchanged"
+    );
+
+    let outcome = but_api::workspace::workspace_integrate_upstream_only(
+        &mut ctx,
+        vec![],
+        but_core::DryRun::No,
+    )?;
+    let outcome = serde_json::to_value(
+        but_api::workspace::json::WorkspaceIntegrateUpstreamOutcome::try_from(outcome)?,
+    )?;
+    let after = but_api::target_commits::workspace_target_commits(&ctx, None, None)?;
+    assert!(
+        !after.commits.is_empty() && after.commits.iter().all(|entry| entry.in_workspace),
+        "integration marks the target commits as part of the workspace"
+    );
+    assert_eq!(
+        outcome.get("targetCommits"),
+        Some(&serde_json::to_value(after)?),
+        "the mutation returns the same page as a fresh target query"
+    );
+    Ok(())
+}
+
+#[test]
+fn target_page_failure_preserves_integration_and_its_undo_entry() -> anyhow::Result<()> {
+    use gix::prelude::Write;
+
+    let (mut ctx, _tmp) = incoming_target()?;
+    let target_id = {
+        let repo = ctx.repo.get()?;
+        let target = repo
+            .find_reference("refs/remotes/origin/main")?
+            .peel_to_commit()?;
+        // Keep the signature structurally valid so graph loading and integration succeed.
+        // Overflow fails only when the target page decodes the author's time; non-numeric text fails earlier.
+        let data = format!(
+            "tree {}\nparent {}\nauthor Broken <broken@example.com> 999999999999999999999 +0000\ncommitter GitButler <gitbutler@example.com> 1000000000 +0000\n\nbroken author time\n",
+            target.tree_id()?,
+            target.id
+        );
+        let id = repo
+            .write_buf(gix::objs::Kind::Commit, data.as_bytes())
+            .map_err(anyhow::Error::from_boxed)?;
+        repo.reference(
+            "refs/remotes/origin/main",
+            id,
+            gix::refs::transaction::PreviousValue::Any,
+            "test malformed target author",
+        )?;
+        id
+    };
+    ctx.invalidate_workspace_cache()?;
+    assert!(
+        but_api::target_commits::workspace_target_commits(&ctx, None, None).is_err(),
+        "the target page cannot decode the malformed author time"
+    );
+
+    let outcome =
+        but_api::workspace::workspace_integrate_upstream(&mut ctx, vec![], but_core::DryRun::No)?;
+    assert!(
+        outcome.target_commits.is_none(),
+        "an unreadable cache payload is omitted"
+    );
+    assert_eq!(
+        ctx.project_meta()?.target_commit_id,
+        Some(target_id),
+        "integration still advances the workspace target"
+    );
+    let snapshots = but_api::legacy::oplog::list_snapshots(
+        &ctx,
+        10,
+        None,
+        None,
+        Some(vec![but_oplog::legacy::OperationKind::MergeUpstream]),
+    )?;
+    assert_eq!(
+        snapshots.len(),
+        1,
+        "the completed integration retains its undo entry"
+    );
+    Ok(())
+}
+
 /// Without a forge cache entry, a GitHub merge-button commit still names the
 /// pull request it landed, read from its own message.
 #[test]

--- a/packages/but-sdk/src/generated/graph/index.d.ts
+++ b/packages/but-sdk/src/generated/graph/index.d.ts
@@ -1662,7 +1662,7 @@ export declare function workspaceFetchStatus(projectId: string): Promise<Workspa
  * workspace previews the integration and no oplog entry is persisted. See
  * [`workspace_integrate_upstream_with_perm()`] for lower-level details.
  *
- * {@link ../../../../../crates/but-api/src/workspace.rs:555}
+ * {@link ../../../../../crates/but-api/src/workspace.rs:560}
  */
 export declare function workspaceIntegrateUpstream(projectId: string, updates: Array<BottomUpdate>, dryRun: boolean): Promise<WorkspaceIntegrateUpstreamOutcome>
 
@@ -4722,6 +4722,8 @@ export type WorkspaceFetchStatus = {
 export type WorkspaceIntegrateUpstreamOutcome = {
   /** The post-operation or preview workspace state. */
   workspaceState: WorkspaceState;
+  /** The updated default target-commit page, or `None` for a dry run or a failed page read. */
+  targetCommits: TargetCommitPage | null;
   /** Dirty worktree paths that would conflict when applied onto the resulting workspace head. */
   worktreeConflicts: Array<string>;
 };

--- a/packages/but-sdk/src/generated/linear/index.d.ts
+++ b/packages/but-sdk/src/generated/linear/index.d.ts
@@ -1662,7 +1662,7 @@ export declare function workspaceFetchStatus(projectId: string): Promise<Workspa
  * workspace previews the integration and no oplog entry is persisted. See
  * [`workspace_integrate_upstream_with_perm()`] for lower-level details.
  *
- * {@link ../../../../../crates/but-api/src/workspace.rs:555}
+ * {@link ../../../../../crates/but-api/src/workspace.rs:560}
  */
 export declare function workspaceIntegrateUpstream(projectId: string, updates: Array<BottomUpdate>, dryRun: boolean): Promise<WorkspaceIntegrateUpstreamOutcome>
 
@@ -4722,6 +4722,8 @@ export type WorkspaceFetchStatus = {
 export type WorkspaceIntegrateUpstreamOutcome = {
   /** The post-operation or preview workspace state. */
   workspaceState: WorkspaceState;
+  /** The updated default target-commit page, or `None` for a dry run or a failed page read. */
+  targetCommits: TargetCommitPage | null;
   /** Dirty worktree paths that would conflict when applied onto the resulting workspace head. */
   worktreeConflicts: Array<string>;
 };


### PR DESCRIPTION
Upstream integration returns the updated target-commit page, letting Lite update its target cache alongside the workspace without another SDK request. Older cached pages are refreshed; if the page cannot be read, integration still succeeds and records its undo entry while Lite falls back to refetching. Dry-run previews leave the live caches untouched.

Follow-up to #15825 addressing https://github.com/gitbutlerapp/gitbutler/pull/15825#discussion_r3966731034.
