### PR TITLE
Show a requested reviewer in Lite before the forge answers

### DIFF
--- a/apps/lite/ui/src/api/mutations.test.tsx
+++ b/apps/lite/ui/src/api/mutations.test.tsx
@@ -1,14 +1,21 @@
 /** @vitest-environment jsdom */
 
-import { useWorkspaceIntegrateUpstream } from "#ui/api/mutations.ts";
 import {
+	useRequestReview,
+	useWithdrawReviewRequest,
+	useWorkspaceIntegrateUpstream,
+} from "#ui/api/mutations.ts";
+import {
+	getReviewQueryOptions,
 	olderTargetCommitsInfiniteQueryOptions,
+	reviewerCandidatesQueryOptions,
 	workspaceTargetCommitsQueryOptions,
 } from "#ui/api/queries.ts";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { act } from "react";
+import type { ForgeReview, ForgeReviewUser } from "@gitbutler/but-sdk";
+import { QueryClient, QueryClientProvider, useQuery } from "@tanstack/react-query";
+import { act, type FC } from "react";
 import { createRoot, type Root } from "react-dom/client";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from "vitest";
 
 vi.mock("#ui/store.ts", () => ({ useAppDispatch: () => vi.fn() }));
 vi.mock("#ui/use-cursor.ts", () => ({}));
@@ -96,5 +103,150 @@ describe("useWorkspaceIntegrateUpstream", () => {
 		expect(client.getQueryData(baseKey)).toEqual(original);
 		expect(client.getQueryState(baseKey)?.isInvalidated).toBe(false);
 		expect(client.getQueryState(olderKey)?.isInvalidated).toBe(false);
+	});
+});
+
+const projectId = "project-id";
+const reviewId = 7;
+const reviewKey = getReviewQueryOptions({ projectId, reviewId }).queryKey;
+
+const user = (id: number, login: string): ForgeReviewUser => ({
+	id,
+	login,
+	name: null,
+	email: null,
+	avatarUrl: null,
+	isBot: false,
+});
+const bob = user(1, "bob");
+const alice = user(2, "alice");
+const reviewWith = (reviewers: Array<ForgeReviewUser>) =>
+	({ number: reviewId, reviewers }) as ForgeReview;
+
+/** Shows the cached review's reviewers as `login:id`, with a button per mutation. */
+const Probe: FC<{ request: Array<string>; withdraw: Array<string> }> = (props) => {
+	const { data: review } = useQuery(getReviewQueryOptions({ projectId, reviewId }));
+	const { mutate: request } = useRequestReview(projectId);
+	const { mutate: withdraw } = useWithdrawReviewRequest(projectId);
+	return (
+		<>
+			<output>{review?.reviewers.map((each) => `${each.login}:${each.id}`).join(" ")}</output>
+			<button
+				id="request"
+				onClick={() => request({ projectId, reviewId, logins: props.request })}
+				type="button"
+			>
+				request
+			</button>
+			<button
+				id="withdraw"
+				onClick={() => withdraw({ projectId, reviewId, logins: props.withdraw })}
+				type="button"
+			>
+				withdraw
+			</button>
+		</>
+	);
+};
+
+describe("reviewer request mutations", () => {
+	let container: HTMLDivElement;
+	let queryClient: QueryClient;
+	let root: Root;
+	let lite: { requestReview: Mock; withdrawReviewRequest: Mock; getReview: Mock };
+
+	beforeEach(() => {
+		lite = { requestReview: vi.fn(), withdrawReviewRequest: vi.fn(), getReview: vi.fn() };
+		vi.stubGlobal("lite", lite);
+		container = document.createElement("div");
+		document.body.append(container);
+		queryClient = new QueryClient({
+			defaultOptions: { queries: { retry: false, staleTime: Number.POSITIVE_INFINITY } },
+		});
+		queryClient.setQueryData(reviewKey, reviewWith([bob]));
+		queryClient.setQueryData(reviewerCandidatesQueryOptions(projectId).queryKey, [bob, alice]);
+		root = createRoot(container);
+	});
+
+	afterEach(() => {
+		act(() => root.unmount());
+		queryClient.clear();
+		container.remove();
+		vi.unstubAllGlobals();
+	});
+
+	const reviewers = () => container.querySelector("output")?.textContent;
+	const render = (props: { request?: Array<string>; withdraw?: Array<string> } = {}) =>
+		act(() =>
+			root.render(
+				<QueryClientProvider client={queryClient}>
+					<Probe request={props.request ?? []} withdraw={props.withdraw ?? []} />
+				</QueryClientProvider>,
+			),
+		);
+	const click = (id: string) => container.querySelector<HTMLButtonElement>(`#${id}`)?.click();
+
+	it("shows a requested reviewer before the forge answers", async () => {
+		lite.requestReview.mockReturnValue(new Promise(() => {}));
+		render({ request: ["alice"] });
+		expect(reviewers()).toBe("bob:1");
+
+		await act(async () => {
+			click("request");
+			await vi.waitFor(() => expect(reviewers()).toBe("bob:1 alice:2"));
+		});
+		expect(lite.requestReview.mock.calls[0]?.[0]).toEqual({
+			projectId,
+			reviewId,
+			logins: ["alice"],
+		});
+	});
+
+	it("adds a login once however often it is named", async () => {
+		lite.requestReview.mockReturnValue(new Promise(() => {}));
+		render({ request: ["alice", "alice", "bob"] });
+
+		await act(async () => {
+			click("request");
+			await vi.waitFor(() => expect(reviewers()).toBe("bob:1 alice:2"));
+		});
+	});
+
+	it("stands in for a login the candidate listing does not know", async () => {
+		lite.requestReview.mockReturnValue(new Promise(() => {}));
+		render({ request: ["carol"] });
+
+		await act(async () => {
+			click("request");
+			await vi.waitFor(() => expect(reviewers()).toMatch(/^bob:1 carol:-\d+$/));
+		});
+	});
+
+	it("drops the reviewer again and refetches when the forge refuses", async () => {
+		lite.requestReview.mockRejectedValue(new Error("forge said no"));
+		lite.getReview.mockReturnValue(new Promise(() => {}));
+		render({ request: ["alice"] });
+
+		await act(async () => {
+			click("request");
+			await vi.waitFor(() => expect(lite.getReview).toHaveBeenCalled());
+		});
+		expect(queryClient.getQueryData(reviewKey)).toEqual(reviewWith([bob]));
+		await act(() => vi.waitFor(() => expect(reviewers()).toBe("bob:1")));
+	});
+
+	it("hides a withdrawn reviewer before the forge answers", async () => {
+		lite.withdrawReviewRequest.mockReturnValue(new Promise(() => {}));
+		render({ withdraw: ["bob"] });
+
+		await act(async () => {
+			click("withdraw");
+			await vi.waitFor(() => expect(reviewers()).toBe(""));
+		});
+		expect(lite.withdrawReviewRequest.mock.calls[0]?.[0]).toEqual({
+			projectId,
+			reviewId,
+			logins: ["bob"],
+		});
 	});
 });

--- a/apps/lite/ui/src/api/mutations.ts
+++ b/apps/lite/ui/src/api/mutations.ts
@@ -13,6 +13,7 @@ import {
 	listReviewSubmissionsQueryOptions,
 	listReviewThreadsQueryOptions,
 	listReviewReactionsQueryOptions,
+	reviewerCandidatesQueryOptions,
 	treeChangeDiffsQueryOptions,
 	workspaceFetchQueryOptions,
 	workspaceTargetCommitsQueryOptions,
@@ -633,11 +634,43 @@ export const useRemoveSubmissionReaction = (projectId: string) =>
 		},
 	});
 
+/**
+ * The requested reviewer joins the single-review cache the panel renders
+ * from. The candidate listing the picker was built from supplies the full
+ * user, so the row carries the real id and avatar before the forge answers.
+ */
 export const useRequestReview = (projectId: string) =>
 	useMutation({
 		mutationKey: [projectId, "requestReview"],
 		mutationFn: window.lite.requestReview,
 		meta: { failureTitle: "Failed to request review" },
+		onMutate: async (input, ctx) => {
+			const key = getReviewQueryOptions(input).queryKey;
+			await ctx.client.cancelQueries({ queryKey: key });
+
+			const prev = ctx.client.getQueryData(key);
+			const candidates =
+				ctx.client.getQueryData(reviewerCandidatesQueryOptions(input.projectId).queryKey) ?? [];
+			ctx.client.setQueryData(key, (review) => {
+				if (review === undefined) return undefined;
+				const added = [...new Set(input.logins)]
+					.filter((login) => !review.reviewers.some((reviewer) => reviewer.login === login))
+					.map(
+						(login) =>
+							candidates.find((candidate) => candidate.login === login) ?? ghostForgeUser(login),
+					);
+				return { ...review, reviewers: review.reviewers.concat(added) };
+			});
+
+			return prev;
+		},
+		onError: (error, input, prev, ctx) => {
+			// Roll the optimistic write back, then refetch: the rollback snapshot
+			// may itself be stale by now.
+			const key = getReviewQueryOptions(input).queryKey;
+			if (prev) ctx.client.setQueryData(key, prev);
+			void ctx.client.invalidateQueries({ queryKey: key });
+		},
 	});
 
 export const useWithdrawReviewRequest = (projectId: string) =>
@@ -645,6 +678,31 @@ export const useWithdrawReviewRequest = (projectId: string) =>
 		mutationKey: [projectId, "withdrawReviewRequest"],
 		mutationFn: window.lite.withdrawReviewRequest,
 		meta: { failureTitle: "Failed to withdraw review request" },
+		onMutate: async (input, ctx) => {
+			const key = getReviewQueryOptions(input).queryKey;
+			await ctx.client.cancelQueries({ queryKey: key });
+
+			const prev = ctx.client.getQueryData(key);
+			ctx.client.setQueryData(key, (review) =>
+				review === undefined
+					? undefined
+					: {
+							...review,
+							reviewers: review.reviewers.filter(
+								(reviewer) => !input.logins.includes(reviewer.login),
+							),
+						},
+			);
+
+			return prev;
+		},
+		onError: (error, input, prev, ctx) => {
+			// Roll the optimistic write back, then refetch: the rollback snapshot
+			// may itself be stale by now.
+			const key = getReviewQueryOptions(input).queryKey;
+			if (prev) ctx.client.setQueryData(key, prev);
+			void ctx.client.invalidateQueries({ queryKey: key });
+		},
 	});
 
 export const useCreateReviewComment = (projectId: string) =>


### PR DESCRIPTION
Picking a reviewer in the pull request panel now updates the Reviewers section immediately, with the forge request settling in the background.

- `useRequestReview` and `useWithdrawReviewRequest` patch the single-review cache on mutate and roll it back on error, the same way the reaction and comment mutations do.
- The added row takes its user from the cached reviewer-candidate listing, so it shows the real id and avatar. A login the listing lacks gets the same placeholder user the comment ghosts use.
- The failure toast is unchanged, and the settle refetch (both endpoints invalidate `Reviews`) replaces the optimistic entry with the forge's truth as before.
- A jsdom hook test covers the add, the placeholder, the rollback with refetch, and the withdrawal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)