### PR TITLE
Drop the formatting toolbar from the Lite PR comment composer

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestComments.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestComments.module.css
@@ -244,8 +244,8 @@
 
 /* ---- Composer ---------------------------------------------------------- */
 
-/* Toolbar, source, and action footer share one card surface, so the focus
-   ring belongs to the card. */
+/* Source and action footer share one card surface, so the focus ring
+   belongs to the card. */
 .composer {
 	display: flex;
 	flex-direction: column;
@@ -290,17 +290,6 @@
 
 .composerPrompt {
 	color: var(--text-3);
-}
-
-.composerToolbar {
-	padding: 8px 8px 2px;
-	/* Transparent until the body scrolls, so revealing it shifts no layout. */
-	border-bottom: 1px solid transparent;
-	transition: border-color var(--transition-fast);
-
-	[data-body-scrolled] > & {
-		border-bottom-color: var(--border-3);
-	}
 }
 
 .composerBody {

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestComments.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestComments.tsx
@@ -44,7 +44,6 @@ import { Kbd } from "#ui/components/Kbd.tsx";
 import type { IconName } from "#ui/components/iconNames.ts";
 import { Markdown } from "#ui/components/Markdown.tsx";
 import { MarkdownAttachments } from "#ui/components/MarkdownAttachments.tsx";
-import { MarkdownToolbar } from "#ui/components/MarkdownToolbar.tsx";
 import { useMentionSuggestions } from "#ui/components/MentionSuggestions.tsx";
 import { RelativeTime } from "#ui/components/RelativeTime.tsx";
 import {
@@ -1043,7 +1042,7 @@ const ForgeInserts: FC<{
 	);
 };
 
-/** The bottom composer: toolbar, avatar + source, then the action footer. */
+/** The bottom composer: avatar + source, then the action footer. */
 const Composer: FC<{
 	draft: string;
 	setDraft: (update: string | ((current: string) => string)) => void;
@@ -1052,7 +1051,6 @@ const Composer: FC<{
 	avatarUrl: string | null | undefined;
 	projectId: string;
 }> = ({ draft, setDraft, onSubmit, textareaRef, avatarUrl, projectId }) => {
-	const [scrolled, setScrolled] = useState(false);
 	// Folded to one quiet row until engaged; a draft arriving from outside —
 	// a reply quote, a failed submit restoring its text — unfolds it too.
 	const [engaged, setEngaged] = useState(false);
@@ -1114,19 +1112,12 @@ const Composer: FC<{
 	return (
 		<div
 			className={styles.composer}
-			data-body-scrolled={scrolled || undefined}
 			// Leaving the whole composer with nothing written folds it back.
 			onBlur={(evt) => {
 				if (empty && !evt.currentTarget.contains(evt.relatedTarget)) setEngaged(false);
 			}}
 			ref={composerRef}
 		>
-			<MarkdownToolbar
-				className={styles.composerToolbar}
-				onInput={setDraft}
-				targetRef={textareaRef}
-			/>
-
 			<div className={styles.composerBody}>
 				<Avatar src={avatarUrl} />
 				<textarea
@@ -1140,8 +1131,6 @@ const Composer: FC<{
 							setEngaged(false);
 						}
 					}}
-					// Only the flip re-renders: React bails out of an unchanged state.
-					onScroll={(evt) => setScrolled(evt.currentTarget.scrollTop > 0)}
 					placeholder="Write a comment…"
 					ref={attachInput}
 					value={draft}


### PR DESCRIPTION
The row of bold/italic/list/heading buttons sat on top of the comment box and took a lot of vertical space for something that is rarely needed when writing a quick comment. This removes it from the composer.

The scroll-tracking state on the textarea goes with it, since its only job was to reveal the divider under the toolbar once the body scrolled. The attachment, mention, and issue-reference buttons in the footer are untouched, and the PR creation form keeps its toolbar, so the shared `MarkdownToolbar` component stays.

---

## Screenshot

Before:

<img width="669" height="275" alt="Screenshot 2026-09-09 at 13 51 14" src="https://github.com/user-attachments/assets/47b7adc2-16f5-435a-bfc2-5fcaf7fd560c" />


After:

<img width="670" height="239" alt="image" src="https://github.com/user-attachments/assets/ac710822-9e84-464e-967b-c707c63c286a" />
