### PR TITLE
Compare reviewer logins case-insensitively

### DIFF
--- a/apps/lite/ui/src/review-users.ts
+++ b/apps/lite/ui/src/review-users.ts
@@ -9,9 +9,10 @@ export const isAgent = (user: ForgeReviewUser): boolean =>
 	user.isBot || user.login.endsWith("[bot]");
 
 /**
- * Whether two logins name the same account. GitHub spells a bot's login with
- * the `[bot]` suffix in REST and without it in GraphQL, and both reach the app.
+ * Whether two logins name the same account. GitHub logins are
+ * case-insensitive, and a bot's carries the `[bot]` suffix in REST but not
+ * in GraphQL; both spellings reach the app.
  */
 export const sameLogin = (a: string, b: string): boolean => bare(a) === bare(b);
 
-const bare = (login: string): string => login.replace(/\[bot\]$/, "");
+const bare = (login: string): string => login.toLowerCase().replace(/\[bot\]$/, "");

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.tsx
@@ -252,7 +252,8 @@ export const NewPullRequestPanel: FC<{
 					// already is listed above with a way off.
 					.filter(
 						(candidate) =>
-							candidate.login !== currentLogin && !extras.reviewers.includes(candidate.login),
+							!(currentLogin != null && sameLogin(candidate.login, currentLogin)) &&
+							!extras.reviewers.some((login) => sameLogin(login, candidate.login)),
 					)
 					.map((candidate) =>
 						nativeMenuItem({
@@ -268,7 +269,7 @@ export const NewPullRequestPanel: FC<{
 
 	const pickedReviewers = extras.reviewers.map((login) => ({
 		login,
-		user: reviewerCandidates?.find((candidate) => candidate.login === login),
+		user: reviewerCandidates?.find((candidate) => sameLogin(candidate.login, login)),
 	}));
 	const pickedLabels = extras.labels.map(
 		(name) =>
@@ -626,7 +627,7 @@ export const PullRequestPanel: FC<{
 					// already has been asked.
 					.filter(
 						(candidate) =>
-							candidate.login !== review.author?.login &&
+							!(review.author !== null && sameLogin(candidate.login, review.author.login)) &&
 							!reviewerList.some(({ user }) => sameLogin(user.login, candidate.login)),
 					)
 					.map((candidate) =>


### PR DESCRIPTION
Follow-up to #15846, from Copilot's review of it.

- `sameLogin` now ignores case as well as the `[bot]` suffix, since GitHub logins are case-insensitive.
- The pull request form's reviewer picker uses it too, both to skip names already picked and to resolve a picked login back to its user, instead of strict string equality. Picked logins are persisted across sessions, so a change in how a source spells a login must not re-offer someone or drop their avatar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)