### PR TITLE
Poll merge status faster while a pull request is blocked

### DIFF
--- a/apps/lite/ui/src/api/queries.test.ts
+++ b/apps/lite/ui/src/api/queries.test.ts
@@ -1,17 +1,30 @@
-import { listCIChecksQueryOptions, treeChangesDiffsQueryOptions } from "#ui/api/queries.ts";
-import type { CiCheck, TreeChange } from "@gitbutler/but-sdk";
-import { QueryClient } from "@tanstack/react-query";
-import { describe, expect, it, vi } from "vitest";
+import {
+	getReviewMergeStatusQueryOptions,
+	listCIChecksQueryOptions,
+	treeChangesDiffsQueryOptions,
+} from "#ui/api/queries.ts";
+import type { CiCheck, ReviewMergeStatus, TreeChange } from "@gitbutler/but-sdk";
+import { QueryClient, QueryObserver } from "@tanstack/react-query";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// The settle burst leaves timers pending, and `window` is stubbed per test;
+// neither may outlive its test.
+afterEach(() => {
+	vi.clearAllTimers();
+	vi.useRealTimers();
+	vi.unstubAllGlobals();
+});
 
 const check = (status: CiCheck["status"]): CiCheck =>
 	({ name: "ci", status }) as unknown as CiCheck;
 const running = check("inProgress");
 const passed = check({ complete: { conclusion: "success", completed_at: null } });
 
-/** Runs the checks query once per response, on the same client, and lists what it invalidated. */
-const pollChecks = async (responses: Array<Array<CiCheck>>) => {
+/** Runs the checks query once per response, on the same client, and lists what it refetched. */
+const pollChecks = async (responses: Array<Array<CiCheck> | Error>) => {
+	vi.useFakeTimers();
 	const client = new QueryClient();
-	const invalidated = vi.spyOn(client, "invalidateQueries").mockResolvedValue();
+	const refetched = vi.spyOn(client, "refetchQueries").mockResolvedValue();
 	const listCiChecks = vi.fn();
 	vi.stubGlobal("window", { lite: { listCiChecks } });
 	const options = listCIChecksQueryOptions({
@@ -20,10 +33,13 @@ const pollChecks = async (responses: Array<Array<CiCheck>>) => {
 		polling: "priority",
 	});
 	for (const response of responses) {
-		listCiChecks.mockResolvedValueOnce(response);
+		if (response instanceof Error) listCiChecks.mockRejectedValueOnce(response);
+		else listCiChecks.mockResolvedValueOnce(response);
 		await client.fetchQuery({ ...options, staleTime: 0 });
 	}
-	return invalidated.mock.calls.map(([filters]) => filters?.queryKey);
+	// The merge-status burst starts on a timer.
+	await vi.advanceTimersByTimeAsync(0);
+	return refetched.mock.calls.map(([filters]) => filters?.queryKey);
 };
 
 describe("listCIChecksQueryOptions", () => {
@@ -37,6 +53,87 @@ describe("listCIChecksQueryOptions", () => {
 		expect(await pollChecks([[running], [running]])).toEqual([]);
 		expect(await pollChecks([[passed], [passed]])).toEqual([]);
 		expect(await pollChecks([[passed], [running]])).toEqual([]);
+		// A failed listing is not a verdict.
+		expect(await pollChecks([[running], new Error("422")])).toEqual([]);
+	});
+});
+
+describe("getReviewMergeStatusQueryOptions", () => {
+	it("polls briskly only while the forge is still computing", () => {
+		const { refetchInterval } = getReviewMergeStatusQueryOptions({ projectId: "p1", reviewId: 1 });
+		if (typeof refetchInterval !== "function") throw new Error("refetchInterval is a constant");
+		const intervalFor = (mergeableState: string | null) =>
+			refetchInterval({
+				state: { data: { mergeableState, commentsCount: 0, isMergeable: false } },
+			} as unknown as Parameters<typeof refetchInterval>[0]);
+		expect(intervalFor("unknown")).toBe(10_000);
+		expect(intervalFor("checking")).toBe(10_000);
+		expect(intervalFor(null)).toBe(10_000);
+		expect(intervalFor("blocked")).toBe(60_000);
+		expect(intervalFor("clean")).toBe(60_000);
+	});
+});
+
+describe("settling the merge status", () => {
+	it("keeps asking on a backoff until the forge reports it mergeable", async () => {
+		vi.useFakeTimers();
+		const client = new QueryClient();
+		const blocked: ReviewMergeStatus = {
+			mergeableState: "blocked",
+			commentsCount: 0,
+			isMergeable: false,
+		};
+		const clean: ReviewMergeStatus = { ...blocked, mergeableState: "clean", isMergeable: true };
+		const getReviewMergeStatus = vi
+			.fn()
+			.mockResolvedValueOnce(blocked)
+			.mockResolvedValueOnce(blocked)
+			.mockResolvedValueOnce(blocked)
+			.mockResolvedValue(clean);
+		const listCiChecks = vi
+			.fn()
+			.mockResolvedValueOnce([running])
+			.mockResolvedValueOnce([passed])
+			.mockResolvedValueOnce([running])
+			.mockResolvedValueOnce([passed]);
+		vi.stubGlobal("window", { lite: { listCiChecks, getReviewMergeStatus } });
+
+		// An observer keeps the merge-status query active, as the PR page does.
+		const observer = new QueryObserver(
+			client,
+			getReviewMergeStatusQueryOptions({ projectId: "p1", reviewId: 1 }),
+		);
+		const unsubscribe = observer.subscribe(() => {});
+		await vi.advanceTimersByTimeAsync(0);
+		expect(getReviewMergeStatus).toHaveBeenCalledTimes(1);
+
+		const checks = listCIChecksQueryOptions({
+			projectId: "p1",
+			reference: "feature",
+			polling: "priority",
+		});
+		await client.fetchQuery({ ...checks, staleTime: 0 });
+		await client.fetchQuery({ ...checks, staleTime: 0 });
+		// A second branch settling in the same window joins the burst under way.
+		const other = listCIChecksQueryOptions({
+			projectId: "p1",
+			reference: "other",
+			polling: "priority",
+		});
+		await client.fetchQuery({ ...other, staleTime: 0 });
+		await client.fetchQuery({ ...other, staleTime: 0 });
+
+		await vi.advanceTimersByTimeAsync(0);
+		expect(getReviewMergeStatus).toHaveBeenCalledTimes(2);
+		await vi.advanceTimersByTimeAsync(3_000);
+		expect(getReviewMergeStatus).toHaveBeenCalledTimes(3);
+		await vi.advanceTimersByTimeAsync(8_000);
+		expect(getReviewMergeStatus).toHaveBeenCalledTimes(4);
+		// Mergeable now, so the last look never happens.
+		await vi.advanceTimersByTimeAsync(20_000);
+		expect(getReviewMergeStatus).toHaveBeenCalledTimes(4);
+
+		unsubscribe();
 	});
 });
 

--- a/apps/lite/ui/src/api/queries.ts
+++ b/apps/lite/ui/src/api/queries.ts
@@ -2,8 +2,16 @@ import { forgeAuthFailure } from "#ui/forge.ts";
 import type { PayloadFor } from "#electron/ipc.ts";
 import { type AggregateCIChecks, aggregateCIChecks } from "#ui/ci.ts";
 import { clampAutoFetch, defaultSettings } from "#ui/settings.ts";
-import type { CiCheck, ForgeName, ForgeReview, TreeChange, UnifiedPatch } from "@gitbutler/but-sdk";
+import type {
+	CiCheck,
+	ForgeName,
+	ForgeReview,
+	ReviewMergeStatus,
+	TreeChange,
+	UnifiedPatch,
+} from "@gitbutler/but-sdk";
 import {
+	type QueryClient,
 	experimental_streamedQuery,
 	hashKey,
 	infiniteQueryOptions,
@@ -400,6 +408,10 @@ export const listCommentReactionsQueryOptions = ({
 		staleTime: 60_000,
 	});
 
+/** The forge has not settled the merge state yet: GitHub's `unknown`, GitLab's `checking`, or nothing at all. */
+const stillComputing = (mergeableState: string | null): boolean =>
+	mergeableState === null || mergeableState === "unknown" || mergeableState === "checking";
+
 export const getReviewMergeStatusQueryOptions = ({
 	projectId,
 	reviewId,
@@ -409,10 +421,12 @@ export const getReviewMergeStatusQueryOptions = ({
 		queryFn: () => window.lite.getReviewMergeStatus({ projectId, reviewId }),
 		staleTime: ({ state: { data } }) => (data?.isMergeable ? 30_000 : 10_000),
 		// Mergeability flips from the forge side (checks finish, approvals
-		// land); poll while the tab is open. Pauses when the app is unfocused
+		// land); poll while the tab is open, and briskly while the forge says
+		// it is still working the answer out. Pauses when the app is unfocused
 		// (refetchIntervalInBackground defaults off), and the focusManager
 		// wiring in main.tsx catches up on refocus.
-		refetchInterval: 60_000,
+		refetchInterval: ({ state: { data } }) =>
+			data !== undefined && stillComputing(data.mergeableState) ? 10_000 : 60_000,
 	});
 
 /** This query should be gated by PR capability lest it fail. */
@@ -523,6 +537,34 @@ export const listEditorsQueryOptions = queryOptions({
 
 type CIChecksQueryData = { data: Array<CiCheck>; aggregate: AggregateCIChecks | null };
 
+/**
+ * Refetch the merge status until the forge reports it mergeable: at once,
+ * then after waits of 3, 8 and 20 seconds, half a minute in all. The forge
+ * recomputes mergeability some seconds after the last check lands, so the
+ * refetch a finished check triggers can still read the old answer. One
+ * burst per project at a time: every branch's checks poll can start one,
+ * and they would all ask after the same status on screen.
+ */
+const settling = new Map<string, Promise<void>>();
+const settleMergeStatus = (client: QueryClient, projectId: string): Promise<void> => {
+	let burst = settling.get(projectId);
+	if (burst === undefined) {
+		burst = settleMergeStatusOnce(client, projectId).finally(() => settling.delete(projectId));
+		settling.set(projectId, burst);
+	}
+	return burst;
+};
+
+const settleMergeStatusOnce = async (client: QueryClient, projectId: string): Promise<void> => {
+	const shown = { queryKey: [projectId, "getReviewMergeStatus"], type: "active" } as const;
+	for (const delay of [0, 3_000, 8_000, 20_000]) {
+		await new Promise((resolve) => setTimeout(resolve, delay));
+		await client.refetchQueries(shown);
+		const statuses = client.getQueriesData<ReviewMergeStatus>(shown);
+		if (statuses.every(([, status]) => status?.isMergeable === true)) return;
+	}
+};
+
 /** This query should be gated by checks capability. */
 // There is no watcher event that could invalidate this query.
 export const listCIChecksQueryOptions = ({
@@ -551,10 +593,13 @@ export const listCIChecksQueryOptions = ({
 				checks = { data: [], aggregate: null };
 			}
 			// The verdict is what flips the forge's mergeability, and this poll
-			// notices it long before the merge-status poll would; refetch now so
-			// the Merge button doesn't stay disabled for up to a minute.
-			if (previousStatus === "in_progress" && checks.aggregate?.status !== "in_progress")
-				void client.invalidateQueries({ queryKey: [projectId, "getReviewMergeStatus"] });
+			// notices it long before the merge-status poll would.
+			if (
+				previousStatus === "in_progress" &&
+				checks.aggregate !== null &&
+				checks.aggregate.status !== "in_progress"
+			)
+				void settleMergeStatus(client, projectId);
 			return checks;
 		},
 		// Refetch periodically, being mindful of rate limiting. Similarly tweak stale time for

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestForm.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestForm.tsx
@@ -663,6 +663,7 @@ const mergeBlockedReason = (mergeStatus: ReviewMergeStatus | undefined): string 
 		case "draft":
 			return "Draft pull requests cannot be merged";
 		case "unknown":
+		case "checking":
 		case null:
 			return "Mergeability not yet determined by the forge";
 		default:


### PR DESCRIPTION
The Merge button could stay disabled for up to a minute after the checks section already showed every check done.

- GitHub recomputes a pull request's merge state some seconds after its last check lands. The checks poll notices the checks finishing first and refetched the merge status right away, which can still read the old `blocked` answer; the next refetch was a full minute later.
- Now, once the checks poll sees the checks finish, it refetches the merge status on screen in a short burst with backoff: at once, then after waits of 3, 8 and 20 seconds, half a minute in all. It stops as soon as the forge reports the pull request mergeable, and runs one burst per project at a time, since every branch's checks poll can start one. The plain poll stays at a minute.
- While the forge reports the state as still computing (GitHub's `unknown`, GitLab's `checking`, or none yet), that case polls every 10 seconds until it settles.
- Tests pin both halves: that finishing checks start the burst, and that the burst asks at 0, 3 and 8 seconds and stops once the answer flips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
