### PR TITLE
Signal a mutation's declared cache invalidations across processes

### DIFF
--- a/apps/lite/ui/src/api/tags.ts
+++ b/apps/lite/ui/src/api/tags.ts
@@ -50,6 +50,12 @@ for (const query of projectQueryKeys)
 for (const [tag, query] of globalProviders) provide(tag, { query, projectScoped: false });
 
 /**
+ * Whether `name` is a tag some query provides. External invalidations arrive
+ * from a file any process can write, so their names are checked, not trusted.
+ */
+export const providedTag = (name: string): name is CacheTag => providers.has(name as CacheTag);
+
+/**
  * Drop every cache providing the given tags. Without a project id,
  * project-scoped queries are matched by endpoint across all projects.
  */

--- a/apps/lite/ui/src/project-events.test.ts
+++ b/apps/lite/ui/src/project-events.test.ts
@@ -21,7 +21,12 @@ const react = (event: string) => {
 		fetchQuery: () => Promise.reject(new Error("offline")),
 	} as unknown as QueryClient;
 
-	const subject = event === "worktreeChanges" ? { changes: {} } : null;
+	const subject =
+		event === "worktreeChanges"
+			? { changes: {} }
+			: event === "externalInvalidation"
+				? { tags: ["Reviews", "NotATag"] }
+				: null;
 	handleProjectEvent(
 		{ name: event, payload: { type: event, subject } } as WatcherEvent,
 		"p1",
@@ -56,6 +61,13 @@ describe("tags declared in Rust", () => {
 });
 
 describe("handled separately", () => {
+	it("drops the caches an external invalidation names, and only those", async () => {
+		const { invalidated } = react("externalInvalidation");
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(invalidated).toContain("listReviews");
+		expect(invalidated).not.toContain("headInfo");
+	});
+
 	it("pushes worktree changes rather than invalidating them", () => {
 		const { invalidated, pushed } = react("worktreeChanges");
 		expect(pushed).toEqual(["changesInWorktree"]);

--- a/apps/lite/ui/src/project-events.ts
+++ b/apps/lite/ui/src/project-events.ts
@@ -4,13 +4,14 @@
  * Each event says what happened in the repository, never what the UI should do
  * about it. What it should do is derived: the event declares the tags it makes
  * stale, each query declares the tags it provides, and where they meet, the
- * query is refreshed. The two cases where invalidating is not the best move
- * are handled separately below.
+ * query is refreshed. Handled separately below: two cases where invalidating
+ * is not the best move, and the event whose tags arrive in its payload.
  */
 
 import { projectQueryKeys, type ProjectQueryKey } from "#ui/api/query-keys.ts";
 import { getReviewQueryOptions } from "#ui/api/queries.ts";
 import { recordedPullRequest } from "#ui/api/ref-info.ts";
+import { invalidateTags, providedTag } from "#ui/api/tags.ts";
 import type { ForgeReview, WatcherEvent } from "@gitbutler/but-sdk";
 import { apiProvides, watcherInvalidates, type CacheTag } from "@gitbutler/but-sdk/cache-tags";
 import type { QueryClient } from "@tanstack/react-query";
@@ -125,6 +126,11 @@ export const handleProjectEvent = (
 
 	for (const query of invalidateOn.get(payload.type) ?? [])
 		void client.invalidateQueries({ queryKey: [projectId, query] });
+
+	// Another process's mutation, with the tags it declared: the event table
+	// has nothing to add.
+	if (payload.type === "externalInvalidation")
+		void invalidateTags(client, payload.subject.tags.filter(providedTag), projectId);
 
 	// The annotations read the backend's review cache, so integrated reviews have
 	// to land before the listing is re-read. A failed refresh degrades to

--- a/crates/but-api-macros/src/lib.rs
+++ b/crates/but-api-macros/src/lib.rs
@@ -33,6 +33,10 @@ use syn::{FnArg, ItemFn, Pat, parse_macro_input};
 ///     - Only for state the repository watcher cannot observe: forge, app, and config writes. A
 ///       mutation that writes to the repository declares nothing — the watcher reports the change
 ///       and the event carries the invalidation.
+///     - A successful call also records the tags in the project's invalidation sentinel, so the
+///       watcher of another process — the desktop app, after a `but` command — drops the same
+///       caches. `<FN_NAME>_INVALIDATES` names the list for a primitive that stands in for the
+///       endpoint out of process.
 ///
 /// An endpoint either provides or invalidates, never both. Naming a tag that does not exist in
 /// `crate::tags::CacheTag` is a compile error. The SDK exports both maps (`apiProvides`,
@@ -115,6 +119,26 @@ pub fn but_api(attr: TokenStream, item: TokenStream) -> TokenStream {
             Ok(opts) => opts,
             Err(err) => return err.into_compile_error().into(),
         }
+    };
+
+    let sanitized_input_fn = match &opts.invalidates {
+        Some(tags) if !tags.is_empty() => signal_invalidation_on_success(sanitized_input_fn, tags),
+        _ => sanitized_input_fn,
+    };
+    let invalidates_const = match &opts.invalidates {
+        Some(tags) if !tags.is_empty() => {
+            let ident = format_ident!("{}_INVALIDATES", fn_name.to_string().to_uppercase());
+            let names: Vec<String> = tags.iter().map(|tag| tag.to_string()).collect();
+            let doc = format!(
+                "The tags `{fn_name}` declares stale, for a primitive that stands in for it out of process."
+            );
+            quote! {
+                #[doc = #doc]
+                #[allow(dead_code)]
+                #vis const #ident: &[&str] = &[#(#names),*];
+            }
+        }
+        _ => quote! {},
     };
 
     let wrapper_params = match build_wrapper_params(input.iter()) {
@@ -419,6 +443,8 @@ pub fn but_api(attr: TokenStream, item: TokenStream) -> TokenStream {
         // Original function stays
         #sanitized_input_fn
 
+        #invalidates_const
+
         const _: () = {
             #[expect(dead_code)]
             fn keep_json(_json: #json_ty) {}
@@ -461,6 +487,50 @@ pub fn but_api(attr: TokenStream, item: TokenStream) -> TokenStream {
     };
 
     expanded.into()
+}
+
+/// Wrap the body so a successful call records its declared tags in the
+/// project's invalidation sentinel, for the watchers of other processes. The
+/// storage directory comes from the context parameter; an endpoint without
+/// one is left alone.
+fn signal_invalidation_on_success(mut input_fn: ItemFn, tags: &[syn::Ident]) -> ItemFn {
+    let Some(ctx_ident) = input_fn.sig.inputs.iter().find_map(|arg| {
+        let FnArg::Typed(pat_ty) = arg else {
+            return None;
+        };
+        context_param_kind(&pat_ty.ty)?;
+        match &*pat_ty.pat {
+            Pat::Ident(pat) => Some(pat.ident.clone()),
+            _ => None,
+        }
+    }) else {
+        return input_fn;
+    };
+    let syn::ReturnType::Type(_, output_ty) = &input_fn.sig.output else {
+        return input_fn;
+    };
+    let names: Vec<String> = tags.iter().map(|tag| tag.to_string()).collect();
+    let body = &input_fn.block;
+    // A closure or async block keeps `?` and `return` inside the body meaning
+    // what they did, with the fn's own return type.
+    let run_body = if input_fn.sig.asyncness.is_some() {
+        quote! { let __but_api_result: #output_ty = async move #body.await; }
+    } else {
+        quote! {
+            #[allow(clippy::redundant_closure_call)]
+            let __but_api_result = (move || -> #output_ty #body)();
+        }
+    };
+    let block: syn::Block = syn::parse_quote! {{
+        let __but_api_project_data_dir = #ctx_ident.project_data_dir.clone();
+        #run_body
+        if __but_api_result.is_ok() {
+            crate::tags::signal_invalidation(&__but_api_project_data_dir, &[#(#names),*]);
+        }
+        __but_api_result
+    }};
+    input_fn.block = Box::new(block);
+    input_fn
 }
 
 struct WrapperParamsInfo {

--- a/crates/but-api-macros/tests/src/lib.rs
+++ b/crates/but-api-macros/tests/src/lib.rs
@@ -20,6 +20,10 @@ pub mod tags {
         Reviews,
         Checks,
     }
+
+    /// Stand-in for `but_api::tags::signal_invalidation`, which the
+    /// `invalidates` expansion calls after a successful mutation.
+    pub fn signal_invalidation(_project_data_dir: &std::path::Path, _tags: &[&str]) {}
 }
 
 pub mod panic_capture {

--- a/crates/but-api-macros/tests/tests/ui/pass/napi_invalidates_signal.rs
+++ b/crates/but-api-macros/tests/tests/ui/pass/napi_invalidates_signal.rs
@@ -1,0 +1,47 @@
+// Case: `invalidates` wraps the body so a successful call signals its tags.
+// It verifies:
+// - sync `&Context` / `&mut Context` and async `ThreadSafeContext` bodies still compile
+//   with `?` and early `return` inside the wrapper
+// - `<FN_NAME>_INVALIDATES` carries the declared names
+// - an endpoint without a context is left unwrapped
+// Extend when: the signalling expansion or the constant's shape changes.
+
+use but_api_macros::but_api;
+
+pub use but_api_macros_tests::{json, panic_capture, tags};
+
+#[but_api(napi, invalidates = [Reviews])]
+pub fn sync_signal(_ctx: &but_ctx::Context, value: i32) -> anyhow::Result<i32> {
+    if value < 0 {
+        return Err(anyhow::anyhow!("negative"));
+    }
+    let one: i32 = "1".parse()?;
+    Ok(value + one)
+}
+
+#[but_api(napi, invalidates = [Reviews, Checks])]
+pub fn sync_signal_mut(ctx: &mut but_ctx::Context, value: i32) -> anyhow::Result<i32> {
+    let _ = &ctx.project_data_dir;
+    Ok(value)
+}
+
+#[but_api(napi, invalidates = [Checks])]
+pub async fn async_signal(ctx: but_ctx::ThreadSafeContext, value: i32) -> anyhow::Result<i32> {
+    let _ = ctx.project_data_dir;
+    let one: i32 = "1".parse()?;
+    Ok(value + one)
+}
+
+#[but_api(napi, invalidates = [Checks])]
+pub fn signal_without_context(value: i32) -> anyhow::Result<i32> {
+    Ok(value)
+}
+
+fn main() {
+    assert_eq!(SYNC_SIGNAL_INVALIDATES, &["Reviews"]);
+    assert_eq!(SYNC_SIGNAL_MUT_INVALIDATES, &["Reviews", "Checks"]);
+    assert_eq!(ASYNC_SIGNAL_INVALIDATES, &["Checks"]);
+    assert_eq!(SIGNAL_WITHOUT_CONTEXT_INVALIDATES, &["Checks"]);
+    let _ = sync_signal_napi;
+    let _ = async_signal_napi;
+}

--- a/crates/but-api/src/legacy/forge.rs
+++ b/crates/but-api/src/legacy/forge.rs
@@ -1358,6 +1358,8 @@ pub async fn publish_review_only(
             let _guard = ctx.exclusive_worktree_access();
             persist_review_association(&ctx, local_branch.as_ref(), review_number).ok();
         }
+        // Not an endpoint, so the batch path signals what `publish_review` declares.
+        crate::tags::signal_invalidation(&ctx.project_data_dir, PUBLISH_REVIEW_INVALIDATES);
     }
 
     Ok(review)

--- a/crates/but-api/src/tags.rs
+++ b/crates/but-api/src/tags.rs
@@ -30,6 +30,14 @@ macro_rules! cache_tags {
                     $(CacheTag::$name => stringify!($name),)+
                 }
             }
+
+            /// The tag a client-facing name spells, or `None` for a name no tag has.
+            pub fn from_name(name: &str) -> Option<Self> {
+                match name {
+                    $(stringify!($name) => Some(CacheTag::$name),)+
+                    _ => None,
+                }
+            }
         }
     };
 }
@@ -96,4 +104,56 @@ cache_tags! {
     /// Which mode the repository is in (open workspace, edit mode, ...) and
     /// the edit session's own state.
     OperatingMode,
+}
+
+/// Record that a successful mutation made `tags` stale, for the watchers of
+/// other processes: a `but` command reaches the desktop app this way. The
+/// `#[but_api]` expansion calls this for every endpoint declaring
+/// `invalidates` and taking a context; a primitive the CLI runs in place of
+/// an endpoint passes the endpoint's `*_INVALIDATES` constant by hand.
+pub fn signal_invalidation(project_data_dir: &std::path::Path, tags: &[&str]) {
+    but_project_handle::write_invalidation_sentinel(project_data_dir, tags);
+}
+
+#[cfg(test)]
+mod tests {
+    use but_api_macros::but_api;
+    use but_testsupport::{CommandExt, git_at_dir, open_repo};
+
+    #[but_api(napi, invalidates = [Reviews, Checks])]
+    pub fn probe(_ctx: &but_ctx::Context, succeed: bool) -> anyhow::Result<()> {
+        if succeed {
+            Ok(())
+        } else {
+            Err(anyhow::anyhow!("the mutation failed"))
+        }
+    }
+
+    #[test]
+    fn a_declared_mutation_records_its_tags_only_on_success() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        git_at_dir(tmp.path()).args(["init"]).run();
+        let ctx = but_ctx::Context::from_repo_for_testing(open_repo(tmp.path())?)?;
+        let sentinel = ctx.project_data_dir.join("INVALIDATE");
+
+        probe(&ctx, false).unwrap_err();
+        assert!(!sentinel.exists(), "a failed mutation made nothing stale");
+
+        probe(&ctx, true)?;
+        let content = std::fs::read_to_string(&sentinel)?;
+        assert_eq!(
+            but_project_handle::invalidation_by_others(&content, ""),
+            ["Reviews", "Checks"]
+        );
+        assert!(
+            but_project_handle::invalidation_by_others(
+                &content,
+                &but_project_handle::process_sentinel_token()
+            )
+            .is_empty(),
+            "the writer signs the sentinel so its own watcher can skip it"
+        );
+        assert_eq!(PROBE_INVALIDATES, &["Reviews", "Checks"]);
+        Ok(())
+    }
 }

--- a/crates/but-api/src/watcher.rs
+++ b/crates/but-api/src/watcher.rs
@@ -23,6 +23,9 @@ pub enum WatcherPayload {
     /// External activity requiring the UI to re-read workspace state (stacks,
     /// branches, PR numbers) — remote-ref updates or external metadata writes.
     WorkspaceActivity(WatcherWorkspaceActivityPayload),
+    /// Another process's mutation declared cache tags stale — see
+    /// [`crate::tags::signal_invalidation`].
+    ExternalInvalidation(WatcherExternalInvalidationPayload),
 }
 
 #[cfg(feature = "export-schema")]
@@ -44,6 +47,8 @@ pub enum WatcherEventKind {
     WorktreeChanges,
     /// See [`WatcherPayload::WorkspaceActivity`].
     WorkspaceActivity,
+    /// See [`WatcherPayload::ExternalInvalidation`].
+    ExternalInvalidation,
 }
 
 impl WatcherEventKind {
@@ -54,6 +59,7 @@ impl WatcherEventKind {
         WatcherEventKind::GitActivity,
         WatcherEventKind::WorktreeChanges,
         WatcherEventKind::WorkspaceActivity,
+        WatcherEventKind::ExternalInvalidation,
     ];
 
     /// The event's name as clients see it, matching the payload's serde tag.
@@ -64,6 +70,7 @@ impl WatcherEventKind {
             WatcherEventKind::GitActivity => "gitActivity",
             WatcherEventKind::WorktreeChanges => "worktreeChanges",
             WatcherEventKind::WorkspaceActivity => "workspaceActivity",
+            WatcherEventKind::ExternalInvalidation => "externalInvalidation",
         }
     }
 
@@ -94,6 +101,8 @@ impl WatcherEventKind {
             WatcherEventKind::WorktreeChanges => {
                 &[T::Diffs, T::WorktreeChanges, T::AbsorptionPlan, T::Comments]
             }
+            // The tags ride in the payload; the table cannot know them.
+            WatcherEventKind::ExternalInvalidation => &[],
         }
     }
 }
@@ -137,6 +146,17 @@ pub struct WatcherWorkspaceActivityPayload;
 
 #[cfg(feature = "export-schema")]
 but_schemars::register_sdk_type!(WatcherWorkspaceActivityPayload);
+
+/// Cache tags another process declared stale, spelled as `cache-tags` exports them.
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct WatcherExternalInvalidationPayload {
+    /// A client drops every cache providing one of these.
+    pub tags: Vec<String>,
+}
+
+#[cfg(feature = "export-schema")]
+but_schemars::register_sdk_type!(WatcherExternalInvalidationPayload);
 
 /// Worktree files changes.
 #[derive(Debug, Clone, Serialize, JsonSchema)]

--- a/crates/but-napi/src/lib.rs
+++ b/crates/but-napi/src/lib.rs
@@ -25,8 +25,9 @@ use napi_derive::napi;
 use but_api::{
     self as _,
     watcher::{
-        WatcherGitActivityPayload, WatcherGitFetchPayload, WatcherGitHeadPayload, WatcherPayload,
-        WatcherWorkspaceActivityPayload, WatcherWorktreeChangesPayload,
+        WatcherExternalInvalidationPayload, WatcherGitActivityPayload, WatcherGitFetchPayload,
+        WatcherGitHeadPayload, WatcherPayload, WatcherWorkspaceActivityPayload,
+        WatcherWorktreeChangesPayload,
     },
 };
 
@@ -320,6 +321,18 @@ fn event_from_change(change: gitbutler_watcher::Change) -> WatcherEvent {
             name: format!("project://{project_id}/workspace-activity"),
             payload: serde_json::json!(WatcherPayload::WorkspaceActivity(
                 WatcherWorkspaceActivityPayload
+            )),
+        },
+        gitbutler_watcher::Change::ExternalInvalidation { project_id, tags } => WatcherEvent {
+            name: format!("project://{project_id}/external-invalidation"),
+            payload: serde_json::json!(WatcherPayload::ExternalInvalidation(
+                WatcherExternalInvalidationPayload {
+                    // The sentinel is a file anyone can write; only names a tag has get through.
+                    tags: tags
+                        .into_iter()
+                        .filter(|tag| but_api::tags::CacheTag::from_name(tag).is_some())
+                        .collect(),
+                }
             )),
         },
         gitbutler_watcher::Change::WorktreeChanges {

--- a/crates/but-project-handle/src/lib.rs
+++ b/crates/but-project-handle/src/lib.rs
@@ -19,7 +19,8 @@ pub use legacy_project_id::LegacyProjectId;
 
 pub use project_handle::{ProjectHandle, ProjectHandleOrLegacyProjectId};
 pub use storage_path::{
-    DEFAULT_STORAGE_DIR_NAME, REFRESH_SENTINEL_PATH, gitbutler_storage_path,
-    gitbutler_storage_path_for_channel, process_sentinel_token, storage_path_config_key,
-    storage_path_config_key_for_app_channel, write_refresh_sentinel,
+    DEFAULT_STORAGE_DIR_NAME, INVALIDATION_SENTINEL_PATH, REFRESH_SENTINEL_PATH,
+    gitbutler_storage_path, gitbutler_storage_path_for_channel, invalidation_by_others,
+    process_sentinel_token, storage_path_config_key, storage_path_config_key_for_app_channel,
+    write_invalidation_sentinel, write_refresh_sentinel,
 };

--- a/crates/but-project-handle/src/storage_path.rs
+++ b/crates/but-project-handle/src/storage_path.rs
@@ -144,10 +144,98 @@ pub fn write_refresh_sentinel(metadata_file: &Path) {
     }
 }
 
+/// Git-dir-relative path of the invalidation sentinel, `gitbutler/INVALIDATE`.
+///
+/// Where a successful mutation records the cache tags it declared stale, for
+/// the watchers of other processes. Kept apart from [`REFRESH_SENTINEL_PATH`],
+/// which every metadata flush overwrites.
+pub const INVALIDATION_SENTINEL_PATH: &str = "gitbutler/INVALIDATE";
+
+/// Best-effort write of `tags` to the invalidation sentinel in
+/// `project_data_dir`, signed with this process's [`process_sentinel_token`]
+/// and replacing whatever was there. A write the watcher did not get to read
+/// before the next one is lost, and the clients' polls cover that; a log to
+/// replay is not worth its bookkeeping. Errors are logged and swallowed,
+/// never failing the mutation.
+pub fn write_invalidation_sentinel(project_data_dir: &Path, tags: &[&str]) {
+    if tags.is_empty() {
+        return;
+    }
+    let Some(filename) = Path::new(INVALIDATION_SENTINEL_PATH).file_name() else {
+        return;
+    };
+    let sentinel = project_data_dir.join(filename);
+    let content = format!("{} {}", process_sentinel_token(), tags.join(","));
+    let written =
+        std::fs::create_dir_all(project_data_dir).and_then(|()| std::fs::write(&sentinel, content));
+    if let Err(err) = written {
+        tracing::warn!(?sentinel, %err, "failed to write the invalidation sentinel");
+    }
+}
+
+/// The tags the sentinel `content` names, unless `own_token` wrote them.
+pub fn invalidation_by_others(content: &str, own_token: &str) -> Vec<String> {
+    let mut fields = content.split_whitespace();
+    let Some(token) = fields.next() else {
+        return Vec::new();
+    };
+    if token == own_token {
+        return Vec::new();
+    }
+    fields
+        .next()
+        .map(|tags| {
+            tags.split(',')
+                .filter(|tag| !tag.is_empty())
+                .map(str::to_owned)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 fn storage_path_config_key_for_channel(channel: &AppChannel) -> &'static str {
     match channel {
         AppChannel::Release => "gitbutler.storagePath",
         AppChannel::Nightly => "gitbutler.nightly.storagePath",
         AppChannel::Dev => "gitbutler.dev.storagePath",
+    }
+}
+
+#[cfg(test)]
+mod invalidation_tests {
+    use super::*;
+
+    fn tempdir() -> but_testsupport::gix_testtools::tempfile::TempDir {
+        but_testsupport::gix_testtools::tempfile::TempDir::new().unwrap()
+    }
+
+    #[test]
+    fn tags_by_others_are_read_and_own_writes_are_not() {
+        assert_eq!(
+            invalidation_by_others("1 Reviews,Checks", "2"),
+            ["Reviews", "Checks"]
+        );
+        assert!(invalidation_by_others("1 Reviews", "1").is_empty());
+        assert!(invalidation_by_others("", "1").is_empty());
+        assert!(invalidation_by_others("1", "2").is_empty());
+    }
+
+    #[test]
+    fn each_write_replaces_the_last() {
+        let dir = tempdir();
+        write_invalidation_sentinel(dir.path(), &["Reviews"]);
+        write_invalidation_sentinel(dir.path(), &["Checks", "MergeStatus"]);
+        let content = std::fs::read_to_string(dir.path().join("INVALIDATE")).unwrap();
+        assert_eq!(
+            content,
+            format!("{} Checks,MergeStatus", process_sentinel_token())
+        );
+    }
+
+    #[test]
+    fn nothing_to_declare_writes_nothing() {
+        let dir = tempdir();
+        write_invalidation_sentinel(dir.path(), &[]);
+        assert!(!dir.path().join("INVALIDATE").exists());
     }
 }

--- a/crates/but-server/src/projects.rs
+++ b/crates/but-server/src/projects.rs
@@ -77,6 +77,10 @@ impl ActiveProjects {
                         name: format!("project://{project_id}/workspace-activity"),
                         payload: serde_json::json!({}),
                     },
+                    Change::ExternalInvalidation { project_id, tags } => FrontendEvent {
+                        name: format!("project://{project_id}/external-invalidation"),
+                        payload: serde_json::json!({ "tags": tags }),
+                    },
                     Change::WorktreeChanges {
                         project_id,
                         ref changes,

--- a/crates/but/src/command/legacy/status/tui/app/mod.rs
+++ b/crates/but/src/command/legacy/status/tui/app/mod.rs
@@ -1238,6 +1238,9 @@ impl App {
                     ));
                 }
             }
+            gitbutler_watcher::Change::ExternalInvalidation { .. } => {
+                // The TUI keeps no forge caches; workspace changes reach it as activity.
+            }
             gitbutler_watcher::Change::WorkspaceActivity { .. } => {
                 // TODO: We currently dont have a good way of detecting changes made by external
                 // processes and only then reloading. Always reloading here would result in double

--- a/crates/gitbutler-filemonitor/src/file_monitor.rs
+++ b/crates/gitbutler-filemonitor/src/file_monitor.rs
@@ -5,7 +5,9 @@ use std::{
 };
 
 use anyhow::{Context as _, Result, anyhow};
-use but_project_handle::{ProjectHandleOrLegacyProjectId, REFRESH_SENTINEL_PATH};
+use but_project_handle::{
+    INVALIDATION_SENTINEL_PATH, ProjectHandleOrLegacyProjectId, REFRESH_SENTINEL_PATH,
+};
 use gitbutler_notify_debouncer::{Debouncer, NoCache, new_debouncer};
 use gix::bstr::BStr;
 use notify::{RecommendedWatcher, Watcher};
@@ -618,6 +620,7 @@ fn classify_file(git_dir: &Path, file_path: &Path) -> FileKind {
             || check_file_path == Path::new(GB_FLUSH)
             || check_file_path == Path::new(INDEX)
             || check_file_path == Path::new(REFRESH_SENTINEL_PATH)
+            || check_file_path == Path::new(INVALIDATION_SENTINEL_PATH)
             || check_file_path.starts_with(LOCAL_REFS_DIR)
             || check_file_path.starts_with(REMOTE_REFS_DIR)
         {
@@ -694,6 +697,14 @@ mod tests {
     fn classify_refresh_sentinel() {
         assert_eq!(
             classify_file(git_dir(), Path::new("/repo/.git/gitbutler/REFRESH")),
+            FileKind::Git
+        );
+    }
+
+    #[test]
+    fn classify_invalidation_sentinel() {
+        assert_eq!(
+            classify_file(git_dir(), Path::new("/repo/.git/gitbutler/INVALIDATE")),
             FileKind::Git
         );
     }

--- a/crates/gitbutler-tauri/src/window.rs
+++ b/crates/gitbutler-tauri/src/window.rs
@@ -48,6 +48,10 @@ pub(crate) mod state {
                         name: format!("project://{project_id}/workspace-activity"),
                         payload: serde_json::json!({}),
                     },
+                    Change::ExternalInvalidation { project_id, tags } => ChangeForFrontend {
+                        name: format!("project://{project_id}/external-invalidation"),
+                        payload: serde_json::json!({ "tags": tags }),
+                    },
                     Change::WorktreeChanges {
                         project_id,
                         changes,

--- a/crates/gitbutler-watcher/src/events.rs
+++ b/crates/gitbutler-watcher/src/events.rs
@@ -26,6 +26,12 @@ pub enum Change {
     WorkspaceActivity {
         project_id: ProjectHandleOrLegacyProjectId,
     },
+    /// Emitted when another process writes the invalidation sentinel: a mutation of its made
+    /// cache tags stale. Carries the tag names as the SDK spells them.
+    ExternalInvalidation {
+        project_id: ProjectHandleOrLegacyProjectId,
+        tags: Vec<String>,
+    },
     /// Emitted after worktree files or the index change. Carries freshly computed file diffs
     /// together with hunk assignment and dependency information.
     WorktreeChanges {

--- a/crates/gitbutler-watcher/src/handler.rs
+++ b/crates/gitbutler-watcher/src/handler.rs
@@ -6,7 +6,10 @@ use but_ctx::{Context, ProjectHandleOrLegacyProjectId};
 use but_db::HunkAssignmentsHandleMut;
 use but_hunk_assignment::HunkAssignment;
 use but_hunk_dependency::ui::hunk_dependencies_for_workspace_changes_by_worktree_dir;
-use but_project_handle::{REFRESH_SENTINEL_PATH, process_sentinel_token};
+use but_project_handle::{
+    INVALIDATION_SENTINEL_PATH, REFRESH_SENTINEL_PATH, invalidation_by_others,
+    process_sentinel_token,
+};
 use but_settings::{AppSettings, AppSettingsWithDiskSync};
 use gitbutler_filemonitor::{
     FETCH_HEAD, HEAD, HEAD_ACTIVITY, INDEX, InternalEvent, LOCAL_REFS_DIR, REMOTE_REFS_DIR,
@@ -181,6 +184,17 @@ impl Handler {
                         .unwrap_or(false);
                     if !wrote_by_us {
                         saw_workspace_activity = true;
+                    }
+                }
+                INVALIDATION_SENTINEL_PATH => {
+                    let sentinel = ctx.repo.get()?.path().join(file_name);
+                    let content = std::fs::read_to_string(sentinel).unwrap_or_default();
+                    let tags = invalidation_by_others(&content, &process_sentinel_token());
+                    if !tags.is_empty() {
+                        self.emit_app_event(Change::ExternalInvalidation {
+                            project_id: project_id.clone(),
+                            tags,
+                        })?;
                     }
                 }
                 HEAD_ACTIVITY => {

--- a/packages/but-sdk/src/generated/graph/cacheTags.d.ts
+++ b/packages/but-sdk/src/generated/graph/cacheTags.d.ts
@@ -90,6 +90,7 @@ export declare const apiInvalidates: {
 };
 
 export declare const watcherInvalidates: {
+	readonly externalInvalidation: readonly [];
 	readonly gitActivity: readonly ["Branches", "TargetCommits", "Workspace", "Commits", "Diffs", "WorktreeChanges", "Worktrees", "AbsorptionPlan", "Comments"];
 	readonly gitFetch: readonly ["Branches", "TargetCommits", "FetchStatus", "Reviews"];
 	readonly gitHead: readonly ["OperatingMode"];

--- a/packages/but-sdk/src/generated/graph/cacheTags.js
+++ b/packages/but-sdk/src/generated/graph/cacheTags.js
@@ -88,6 +88,7 @@ export const apiInvalidates = {
 };
 
 export const watcherInvalidates = {
+	externalInvalidation: [],
 	gitActivity: ["Branches", "TargetCommits", "Workspace", "Commits", "Diffs", "WorktreeChanges", "Worktrees", "AbsorptionPlan", "Comments"],
 	gitFetch: ["Branches", "TargetCommits", "FetchStatus", "Reviews"],
 	gitHead: ["OperatingMode"],

--- a/packages/but-sdk/src/generated/graph/index.d.ts
+++ b/packages/but-sdk/src/generated/graph/index.d.ts
@@ -1088,7 +1088,7 @@ export declare function listReviewReactions(projectId: string, reviewId: number)
 export declare function listReviews(projectId: string, cacheConfig: CacheConfig | null): Promise<Array<ForgeReview>>
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:2207}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:2209}
  */
 export declare function listReviewsForBranch(projectId: string, branch: string, filter: ForgeReviewFilter | null): Promise<Array<ForgeReview>>
 
@@ -1142,7 +1142,7 @@ export declare function loginAndPersist(token: string): Promise<UserProfile>
 /**
  * Merge a review on the forge.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1381}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1383}
  */
 export declare function mergeReview(projectId: string, reviewId: number, mergeMethod: ReviewMergeMethod | null): Promise<void>
 
@@ -1405,14 +1405,14 @@ export declare function setPushRemote(projectId: string, pushRemote: string): Pr
 /**
  * Enable or disable a review's auto-merge.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1401}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1403}
  */
 export declare function setReviewAutoMerge(projectId: string, reviewId: number, enable: boolean): Promise<void>
 
 /**
  * Set a review to draft or ready-for-review
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1421}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1423}
  */
 export declare function setReviewDraftiness(projectId: string, reviewId: number, draft: boolean): Promise<void>
 
@@ -1571,7 +1571,7 @@ export declare function updateProjectSettings(projectId: ProjectHandleOrLegacyPr
  * Update arbitrary fields of a single review (title, body, state, target base).
  * Each `None` leaves that field unchanged on the forge.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1453}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1455}
  */
 export declare function updateReview(projectId: string, reviewId: number, title: string | null, body: string | null, state: ReviewState | null, targetBase: string | null): Promise<void>
 
@@ -1585,7 +1585,7 @@ export declare function updateReviewComment(projectId: string, commentId: number
 /**
  * Update stacked reviews: description footers and, optionally, target branches.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1477}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1479}
  */
 export declare function updateReviewFooters(projectId: string, reviews: Array<ForgeReviewUpdate>): Promise<void>
 
@@ -1607,7 +1607,7 @@ export declare function uploadFile(params: UploadFileParams): Promise<Upload>
  * Additionally, it cleans up stale CI check entries for references that are no longer
  * part of any applied stack.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:2241}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:2243}
  */
 export declare function warmCiChecksCache(projectId: string): Promise<void>
 
@@ -4669,6 +4669,12 @@ export type Verification = {
   device_code: string;
 };
 
+/** Cache tags another process declared stale, spelled as `cache-tags` exports them. */
+export type WatcherExternalInvalidationPayload = {
+  /** A client drops every cache providing one of these. */
+  tags: Array<string>;
+};
+
 /** Git files activity. Supplies the head sha */
 export type WatcherGitActivityPayload = {
   /** The SHA of the repository's HEAD. */
@@ -4702,6 +4708,9 @@ export type WatcherPayload = {
 } | {
   type: "workspaceActivity";
   subject: WatcherWorkspaceActivityPayload;
+} | {
+  type: "externalInvalidation";
+  subject: WatcherExternalInvalidationPayload;
 };
 
 /** Workspace activity that requires the UI to re-read branch/stack state. */

--- a/packages/but-sdk/src/generated/linear/cacheTags.d.ts
+++ b/packages/but-sdk/src/generated/linear/cacheTags.d.ts
@@ -90,6 +90,7 @@ export declare const apiInvalidates: {
 };
 
 export declare const watcherInvalidates: {
+	readonly externalInvalidation: readonly [];
 	readonly gitActivity: readonly ["Branches", "TargetCommits", "Workspace", "Commits", "Diffs", "WorktreeChanges", "Worktrees", "AbsorptionPlan", "Comments"];
 	readonly gitFetch: readonly ["Branches", "TargetCommits", "FetchStatus", "Reviews"];
 	readonly gitHead: readonly ["OperatingMode"];

--- a/packages/but-sdk/src/generated/linear/cacheTags.js
+++ b/packages/but-sdk/src/generated/linear/cacheTags.js
@@ -88,6 +88,7 @@ export const apiInvalidates = {
 };
 
 export const watcherInvalidates = {
+	externalInvalidation: [],
 	gitActivity: ["Branches", "TargetCommits", "Workspace", "Commits", "Diffs", "WorktreeChanges", "Worktrees", "AbsorptionPlan", "Comments"],
 	gitFetch: ["Branches", "TargetCommits", "FetchStatus", "Reviews"],
 	gitHead: ["OperatingMode"],

--- a/packages/but-sdk/src/generated/linear/index.d.ts
+++ b/packages/but-sdk/src/generated/linear/index.d.ts
@@ -1088,7 +1088,7 @@ export declare function listReviewReactions(projectId: string, reviewId: number)
 export declare function listReviews(projectId: string, cacheConfig: CacheConfig | null): Promise<Array<ForgeReview>>
 
 /**
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:2207}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:2209}
  */
 export declare function listReviewsForBranch(projectId: string, branch: string, filter: ForgeReviewFilter | null): Promise<Array<ForgeReview>>
 
@@ -1142,7 +1142,7 @@ export declare function loginAndPersist(token: string): Promise<UserProfile>
 /**
  * Merge a review on the forge.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1381}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1383}
  */
 export declare function mergeReview(projectId: string, reviewId: number, mergeMethod: ReviewMergeMethod | null): Promise<void>
 
@@ -1405,14 +1405,14 @@ export declare function setPushRemote(projectId: string, pushRemote: string): Pr
 /**
  * Enable or disable a review's auto-merge.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1401}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1403}
  */
 export declare function setReviewAutoMerge(projectId: string, reviewId: number, enable: boolean): Promise<void>
 
 /**
  * Set a review to draft or ready-for-review
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1421}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1423}
  */
 export declare function setReviewDraftiness(projectId: string, reviewId: number, draft: boolean): Promise<void>
 
@@ -1571,7 +1571,7 @@ export declare function updateProjectSettings(projectId: ProjectHandleOrLegacyPr
  * Update arbitrary fields of a single review (title, body, state, target base).
  * Each `None` leaves that field unchanged on the forge.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1453}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1455}
  */
 export declare function updateReview(projectId: string, reviewId: number, title: string | null, body: string | null, state: ReviewState | null, targetBase: string | null): Promise<void>
 
@@ -1585,7 +1585,7 @@ export declare function updateReviewComment(projectId: string, commentId: number
 /**
  * Update stacked reviews: description footers and, optionally, target branches.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1477}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:1479}
  */
 export declare function updateReviewFooters(projectId: string, reviews: Array<ForgeReviewUpdate>): Promise<void>
 
@@ -1607,7 +1607,7 @@ export declare function uploadFile(params: UploadFileParams): Promise<Upload>
  * Additionally, it cleans up stale CI check entries for references that are no longer
  * part of any applied stack.
  *
- * {@link ../../../../../crates/but-api/src/legacy/forge.rs:2241}
+ * {@link ../../../../../crates/but-api/src/legacy/forge.rs:2243}
  */
 export declare function warmCiChecksCache(projectId: string): Promise<void>
 
@@ -4669,6 +4669,12 @@ export type Verification = {
   device_code: string;
 };
 
+/** Cache tags another process declared stale, spelled as `cache-tags` exports them. */
+export type WatcherExternalInvalidationPayload = {
+  /** A client drops every cache providing one of these. */
+  tags: Array<string>;
+};
+
 /** Git files activity. Supplies the head sha */
 export type WatcherGitActivityPayload = {
   /** The SHA of the repository's HEAD. */
@@ -4702,6 +4708,9 @@ export type WatcherPayload = {
 } | {
   type: "workspaceActivity";
   subject: WatcherWorkspaceActivityPayload;
+} | {
+  type: "externalInvalidation";
+  subject: WatcherExternalInvalidationPayload;
 };
 
 /** Workspace activity that requires the UI to re-read branch/stack state. */


### PR DESCRIPTION
Linear GB-2009.

A `but` command runs the same but-api mutation the app does, but the app only learned "something changed" from the refresh sentinel, which deliberately leaves forge tags alone. So `but pr new`, `set-draft`, `set-ready`, `auto-merge` and `merge` left Lite waiting for its polls.

- After a successful call, the `#[but_api]` expansion writes the endpoint's declared `invalidates` tags to `gitbutler/INVALIDATE`, pid-signed and replacing the last write. A missed write is covered by the polls.
- The watcher turns another process's write into `externalInvalidation`, carrying the tags in its payload; Lite applies them through the table it uses for its own mutations.
- `<FN>_INVALIDATES` names each endpoint's list, so the CLI's batch review creation signals `publish_review`'s declaration.

Older releases are unaffected: an old app ignores the new file and keeps its workspace activity; a new app beside an old CLI, or an unknown tag, falls back to the polls.

A live check needs the dev app restarted, since the watcher lives in the loaded Rust module.
