### PR TITLE
Run the Lite graph's trunk straight past a folded base with nothing upstream

### DIFF
--- a/apps/lite/ui/src/components/GraphSegment.tsx
+++ b/apps/lite/ui/src/components/GraphSegment.tsx
@@ -40,9 +40,10 @@ const Tone: FC<{ status: GraphSegmentStatus | undefined; d: string; dashed?: boo
 /**
  * The columns the main line runs through behind a row or gap. The first is
  * the trunk's on the panel's edge, drawn the way the gaps draw it so the two
- * land on the same pixels: an SVG antialiases where a CSS box snaps.
+ * land on the same pixels: an SVG antialiases where a CSS box snaps. Folded
+ * below the row, the trunk's tail is dashed like a glyph's.
  */
-const passes = (behind: number) =>
+const passes = (behind: number, folded = false) =>
 	Array.from({ length: behind }, (_, column) =>
 		column === 0 ? (
 			<svg
@@ -55,7 +56,14 @@ const passes = (behind: number) =>
 				aria-hidden="true"
 				focusable="false"
 			>
-				<path d="M8 0V28" strokeWidth="1.5" />
+				{folded ? (
+					<>
+						<path d="M8 0V14" strokeWidth="1.5" />
+						<path d="M8 14V28" strokeWidth="1.5" strokeDasharray="1.5 2.5" />
+					</>
+				) : (
+					<path d="M8 0V28" strokeWidth="1.5" />
+				)}
 			</svg>
 		) : (
 			<span key={column} className={styles.pass} aria-hidden />
@@ -192,7 +200,7 @@ interface GraphSegmentProps extends ComponentProps<"span"> {
 	status: GraphSegmentStatus;
 	/** The rail ends on this row: no tail below the icon, nothing stretched under a taller row. */
 	railEnds?: boolean;
-	/** The rail below the row is folded away: its tail is dashed, a hint of what the fold holds. */
+	/** The rail below the row is folded away: its tail, or the trunk's behind it, is dashed, a hint of what the fold holds. */
 	folded?: boolean;
 	/** The rings sit on the row's centre line, for a single-line row of their own. */
 	centered?: boolean;
@@ -217,7 +225,7 @@ export const GraphSegment: FC<GraphSegmentProps> = ({
 }) => (
 	// Spans throughout: the segment sits in buttons and spans, which take phrasing content only.
 	<span {...props} className={classes(className, styles.container)} data-status={status}>
-		{passes(behind)}
+		{passes(behind, folded)}
 		<span className={styles.glyph}>
 			<svg
 				className={classes(

--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/Section.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/Section.tsx
@@ -286,6 +286,11 @@ export const Section: FC<{
 					<span className={styles.chevron}>
 						<Icon name={plan.baseExpanded ? "chevron-down" : "chevron-right"} />
 					</span>
+				) : plan.refOnBase && !plan.baseExpanded ? (
+					// Nothing above the base and its history folded: nothing needs the
+					// column, so the trunk runs on past the row on the edge, its tail the
+					// hint of the fold.
+					<GraphSegment glyph="space" status="LocalOnly" behind={1} folded />
 				) : (
 					<GraphSegment
 						// The trunk hooks in from the edge, meeting the target's leg coming down


### PR DESCRIPTION
Follow-up to #15837. When the ref's tip is the base itself and its history is folded, nothing needs the column, so the hook off the edge was a bend to nowhere. The trunk now runs on past the row on the edge, with its tail dashed as the hint of the fold; hovering still shows the chevron, and unfolding brings the hook back for the base commits.