### PR TITLE
Gracefully handle bad forge auth

### DIFF
--- a/apps/lite/ui/src/api/mutations.ts
+++ b/apps/lite/ui/src/api/mutations.ts
@@ -1,3 +1,4 @@
+import { forgeAuthTags } from "#ui/forge.ts";
 import { decodeBytes, encodeBytes } from "#ui/api/bytes.ts";
 import { remapSearchBranch, remapSearchCommits, setCursor } from "#ui/use-cursor.ts";
 import { getHeadInfoIndex } from "#ui/api/ref-info.ts";
@@ -863,6 +864,7 @@ export const useForgetGithubAccount = () =>
 		mutationKey: ["forgetGithubAccount"],
 		mutationFn: window.lite.forgetGithubAccount,
 		meta: { failureTitle: "Failed to forget account" },
+		onSuccess: (_data, _variables, _context, { client }) => invalidateTags(client, forgeAuthTags),
 	});
 
 export const useForgetGitlabAccount = () =>
@@ -870,6 +872,7 @@ export const useForgetGitlabAccount = () =>
 		mutationKey: ["forgetGitlabAccount"],
 		mutationFn: window.lite.forgetGitlabAccount,
 		meta: { failureTitle: "Failed to forget account" },
+		onSuccess: (_data, _variables, _context, { client }) => invalidateTags(client, forgeAuthTags),
 	});
 
 export const useForgetBitbucketAccount = () =>
@@ -877,6 +880,7 @@ export const useForgetBitbucketAccount = () =>
 		mutationKey: ["forgetBitbucketAccount"],
 		mutationFn: window.lite.forgetBitbucketAccount,
 		meta: { failureTitle: "Failed to forget account" },
+		onSuccess: (_data, _variables, _context, { client }) => invalidateTags(client, forgeAuthTags),
 	});
 
 export const useStoreGithubPat = () =>
@@ -884,6 +888,7 @@ export const useStoreGithubPat = () =>
 		mutationKey: ["storeGithubPat"],
 		mutationFn: window.lite.storeGithubPat,
 		meta: { failureTitle: "Failed to add GitHub account" },
+		onSuccess: (_data, _variables, _context, { client }) => invalidateTags(client, forgeAuthTags),
 	});
 
 export const useStoreGitlabPat = () =>
@@ -891,6 +896,7 @@ export const useStoreGitlabPat = () =>
 		mutationKey: ["storeGitlabPat"],
 		mutationFn: window.lite.storeGitlabPat,
 		meta: { failureTitle: "Failed to add GitLab account" },
+		onSuccess: (_data, _variables, _context, { client }) => invalidateTags(client, forgeAuthTags),
 	});
 
 export const useStoreBitbucketApiToken = () =>
@@ -898,6 +904,7 @@ export const useStoreBitbucketApiToken = () =>
 		mutationKey: ["storeBitbucketApiToken"],
 		mutationFn: window.lite.storeBitbucketApiToken,
 		meta: { failureTitle: "Failed to add Bitbucket account" },
+		onSuccess: (_data, _variables, _context, { client }) => invalidateTags(client, forgeAuthTags),
 	});
 
 export const useDeleteProject = (projectId: string) =>

--- a/apps/lite/ui/src/api/queries.ts
+++ b/apps/lite/ui/src/api/queries.ts
@@ -1,12 +1,14 @@
+import { forgeAuthFailure } from "#ui/forge.ts";
 import type { PayloadFor } from "#electron/ipc.ts";
 import { type AggregateCIChecks, aggregateCIChecks } from "#ui/ci.ts";
 import { clampAutoFetch, defaultSettings } from "#ui/settings.ts";
-import type { CiCheck, ForgeReview, TreeChange, UnifiedPatch } from "@gitbutler/but-sdk";
+import type { CiCheck, ForgeName, ForgeReview, TreeChange, UnifiedPatch } from "@gitbutler/but-sdk";
 import {
 	experimental_streamedQuery,
 	hashKey,
 	infiniteQueryOptions,
 	queryOptions,
+	skipToken,
 } from "@tanstack/react-query";
 import * as ms from "ms";
 import pMap from "p-map";
@@ -427,12 +429,7 @@ export const listReviewsQueryOptions = ({ projectId, ...params }: PayloadFor<"li
 			};
 		},
 		staleTime: 60_000,
-		// Review state changes on the forge side too (closed/reopened/merged
-		// on the website, labels, review requests). Poll while the app is
-		// focused; refetchIntervalInBackground defaults off, so an
-		// unfocused app goes quiet and the focusManager wiring in main.tsx
-		// refetches on return instead.
-		refetchInterval: 60_000,
+		refetchInterval: (query) => (forgeAuthFailure(query.state.error) === null ? 60_000 : false),
 	});
 
 /**
@@ -473,6 +470,31 @@ export const bitbucketAccountsQueryOptions = queryOptions({
 	queryKey: ["forgeAccounts", "bitbucket"],
 	queryFn: () => window.lite.listKnownBitbucketAccounts(),
 });
+
+// Conditional queries are very awkward, hence the duplication and oddities. This retains maximum
+// downstream flexibility e.g. with select.
+export const forgeAccountsQueryOptions = (provider: ForgeName | null | undefined) => {
+	let queryFn;
+	switch (provider) {
+		case "github":
+			queryFn = () => window.lite.listKnownGithubAccounts();
+			break;
+		case "gitlab":
+			queryFn = () => window.lite.listKnownGitlabAccounts();
+			break;
+		case "bitbucket":
+			queryFn = () => window.lite.listKnownBitbucketAccounts();
+			break;
+		default:
+			queryFn = skipToken;
+			break;
+	}
+
+	return queryOptions({
+		queryKey: ["forgeAccounts", queryFn === skipToken ? "unsupported" : provider],
+		queryFn: queryFn === skipToken ? skipToken : async () => queryFn(),
+	});
+};
 
 export const listProjectsQueryOptions = queryOptions({
 	queryKey: ["projects"],

--- a/apps/lite/ui/src/forge.test.ts
+++ b/apps/lite/ui/src/forge.test.ts
@@ -1,0 +1,53 @@
+import { assert } from "#ui/assert.ts";
+import { describe, expect, it } from "vitest";
+import type { ForgeInfo } from "@gitbutler/but-sdk";
+import { forgeAuthFailure, forgeDestination, isCloudForge } from "./forge.ts";
+
+const info = { name: "github", baseUrl: "https://github.com/acme/repo" } as ForgeInfo;
+describe("forge", () => {
+	it("uses the project's forge and the review's host", () => {
+		expect(forgeDestination(info, "https://git.example.com/acme/repo/-/merge_requests/5")).toEqual({
+			name: "github",
+			label: "GitHub",
+			host: "git.example.com",
+		});
+	});
+	it("does not identify an enterprise host as a cloud forge", () => {
+		const destination = assert(forgeDestination(info, "https://git.example.com/acme/repo/pull/5"));
+		expect(isCloudForge(destination)).toBe(false);
+	});
+	it("recognizes GitHub cloud", () => {
+		expect(isCloudForge(assert(forgeDestination(info)))).toBe(true);
+	});
+	it("recognizes Bitbucket cloud", () => {
+		const destination = assert(
+			forgeDestination(
+				{ ...info, name: "bitbucket" },
+				"https://bitbucket.org/acme/repo/pull-requests/5",
+			),
+		);
+		expect(isCloudForge(destination)).toBe(true);
+	});
+	it("distinguishes backend login failures from network and permission errors", () => {
+		expect(
+			forgeAuthFailure(
+				new Error(
+					"Error invoking remote method 'listReviews': Error: GitHub authentication failed.",
+				),
+			),
+		).toBe("rejected");
+		expect(
+			forgeAuthFailure(
+				new Error(
+					"Not authenticated with GitLab. Connect your account under Settings → Integrations.",
+				),
+			),
+		).toBe("missing");
+		expect(forgeAuthFailure(new Error("Unable to connect to GitHub."))).toBeNull();
+		expect(
+			forgeAuthFailure(
+				new Error("A GitHub organization has restricted access for the GitButler OAuth app."),
+			),
+		).toBeNull();
+	});
+});

--- a/apps/lite/ui/src/forge.ts
+++ b/apps/lite/ui/src/forge.ts
@@ -1,0 +1,78 @@
+import type { ForgeInfo, ForgeUser } from "@gitbutler/but-sdk";
+import type { CacheTag } from "@gitbutler/but-sdk/cache-tags";
+
+/** Cached forge data that depends on the configured accounts and their access. */
+export const forgeAuthTags: ReadonlyArray<CacheTag> = [
+	"ForgeAccounts",
+	"ForgeInfo",
+	"ForgeLogin",
+	"RepoInfo",
+	"Reviews",
+	"ReviewComments",
+	"ReviewThreads",
+	"ReviewTimeline",
+	"ReviewSubmissions",
+	"ReviewReactions",
+	"CommentReactions",
+	"MergeStatus",
+	"Checks",
+	"RepoLabels",
+	"ReviewerCandidates",
+];
+
+export type ForgeDestination = { name: ForgeUser["provider"]; label: string; host: string };
+
+export const forgeDestination = (
+	info: ForgeInfo | null | undefined,
+	reviewUrl?: string,
+): ForgeDestination | null => {
+	const url = reviewUrl ?? info?.baseUrl;
+	if (url === undefined) return null;
+
+	const name = info?.name;
+
+	let label: string;
+	switch (name) {
+		case "github":
+			label = "GitHub";
+			break;
+		case "gitlab":
+			label = "GitLab";
+			break;
+		case "bitbucket":
+			label = "Bitbucket";
+			break;
+		default:
+			return null;
+	}
+
+	return { name, label, host: new URL(url).host };
+};
+
+export const isCloudForge = (destination: ForgeDestination): boolean => {
+	let cloudHost: string;
+	switch (destination.name) {
+		case "github":
+			cloudHost = "github.com";
+			break;
+		case "gitlab":
+			cloudHost = "gitlab.com";
+			break;
+		case "bitbucket":
+			cloudHost = "bitbucket.org";
+			break;
+	}
+
+	return cloudHost === destination.host;
+};
+
+// https://linear.app/gitbutler/issue/GB-1479/use-error-codes-to-improve-displayhandling-of-backend-errors
+export const forgeAuthFailure = (error: unknown): "missing" | "rejected" | null => {
+	const msg = error instanceof Error ? error.message : typeof error === "string" ? error : null;
+	if (msg === null) return null;
+
+	if (msg.startsWith("Not authenticated with")) return "missing";
+	if (msg.endsWith("authentication failed.")) return "rejected";
+
+	return null;
+};

--- a/apps/lite/ui/src/interface/state.ts
+++ b/apps/lite/ui/src/interface/state.ts
@@ -1,3 +1,4 @@
+import type { SettingsPageKey } from "#ui/routes/project/$id/workspace/Settings/pages.ts";
 import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
 
 type Dialog =
@@ -7,7 +8,7 @@ type Dialog =
 	| { _tag: "CommandPalette" }
 	| { _tag: "OperationsLogPicker" }
 	| { _tag: "ProjectPicker" }
-	| { _tag: "Settings" }
+	| { _tag: "Settings"; page?: SettingsPageKey }
 	/** The update-from-remote flow, for the applied branch named by full ref. */
 	| { _tag: "UpdateFromRemote"; branchRef: string };
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Details.tsx
@@ -1,3 +1,5 @@
+import { forgeAuthFailure, forgeDestination, isCloudForge } from "#ui/forge.ts";
+import { ForgeAuthPrompt } from "./ForgeAuthPrompt.tsx";
 import { ResizeHandle } from "#ui/components/ResizeHandle.tsx";
 import { startAbsorb, setCursor, useCanShowFiles, useSelection } from "#ui/use-cursor.ts";
 import uiStyles from "#ui/components/ui.module.css";
@@ -26,6 +28,7 @@ import {
 	commentsQueryOptions,
 	commitConflictsQueryOptions,
 	commitDetailsWithLineStatsQueryOptions,
+	forgeAccountsQueryOptions,
 	forgeInfoOptions,
 	getReviewQueryOptions,
 	guiSettingsQueryOptions,
@@ -3158,7 +3161,27 @@ const CommitDetails: FC<{
  * an integrated applied branch's stored identity.
  */
 const LandedReviewView: FC<{ projectId: string; reviewId: number }> = ({ projectId, reviewId }) => {
-	const { data: review, isError } = useQuery(getReviewQueryOptions({ projectId, reviewId }));
+	const { data: review, isError, error } = useQuery(getReviewQueryOptions({ projectId, reviewId }));
+	const { data: forgeInfo } = useQuery(forgeInfoOptions(projectId));
+	const destination = forgeDestination(forgeInfo, review?.htmlUrl);
+	const {
+		data: hasAccount,
+		isError: accountsError,
+		isPending: accountsPending,
+	} = useQuery({
+		...forgeAccountsQueryOptions(destination?.name),
+		select: (accounts) => destination !== null && isCloudForge(destination) && accounts.length > 0,
+	});
+	if (destination && accountsError) {
+		return (
+			<div className={classes(styles.loadingTab, "text-13")}>Could not load the pull request.</div>
+		);
+	}
+	if (destination && accountsPending)
+		return <div className={classes(styles.loadingTab, "text-13")}>Loading…</div>;
+	const authFailure = hasAccount === false ? "missing" : forgeAuthFailure(error);
+	if (authFailure !== null)
+		return <ForgeAuthPrompt destination={destination} hasAccount={hasAccount === true} />;
 	if (isError) {
 		return (
 			<div className={classes(styles.loadingTab, "text-13")}>Could not load the pull request.</div>
@@ -3467,7 +3490,7 @@ const UnappliedBranchDetails: FC<BranchDetailsProps> = ({
 	// Same query key as the applied branch's, so the two share one listing
 	// rather than polling the forge twice. Reviews are keyed by branch name,
 	// which says nothing about whether the branch is applied.
-	const { data: review } = useQuery({
+	const { data: review, error: reviewError } = useQuery({
 		...listReviewsQueryOptions({ projectId, cacheConfig: "noCache" }),
 		enabled: forgeInfo?.capabilities.prService === true,
 		select: (reviews) => reviews.find((review) => review.sourceBranch === branchName) ?? null,
@@ -3487,8 +3510,26 @@ const UnappliedBranchDetails: FC<BranchDetailsProps> = ({
 				?.review?.number ?? null,
 	});
 	const landedReviewId = listedLandedNumber ?? null;
+	const destination = forgeDestination(forgeInfo, review?.htmlUrl);
+	const {
+		data: hasAccount,
+		isError: accountsError,
+		isPending: accountsPending,
+	} = useQuery({
+		...forgeAccountsQueryOptions(destination?.name),
+		select: (accounts) => destination !== null && isCloudForge(destination) && accounts.length > 0,
+	});
 
-	const reviewTab = review ? (
+	const authFailure = hasAccount === false ? "missing" : forgeAuthFailure(reviewError);
+
+	const needsAuth = forgeInfo?.capabilities.prService && authFailure !== null;
+	const reviewTab = needsAuth ? (
+		<ForgeAuthPrompt destination={destination} hasAccount={hasAccount === true} />
+	) : review && destination && accountsError ? (
+		<div className={classes(styles.loadingTab, "text-13")}>Could not load the pull request.</div>
+	) : review && destination && accountsPending ? (
+		<p className="text-13">Loading…</p>
+	) : review ? (
 		<ReviewView
 			key={review.number}
 			projectId={projectId}
@@ -3504,7 +3545,7 @@ const UnappliedBranchDetails: FC<BranchDetailsProps> = ({
 	);
 	// The review is what the branch is judged by, so a branch that has one —
 	// open or landed — opens on it; without one only the diff is on offer.
-	const branchTab = chosenTab ?? (reviewTab !== null ? "pr" : "diff");
+	const branchTab = chosenTab ?? (review || landedReviewId !== null ? "pr" : "diff");
 	const setBranchTab = (tab: BranchTab) => {
 		dispatch(projectSlice.actions.setSelectedBranchTab({ projectId, branchName, tab }));
 	};
@@ -3592,6 +3633,24 @@ const AppliedBranchDetails: FC<BranchDetailsProps> = ({
 	const dispatch = useAppDispatch();
 	const branchRef = decodeBytes(branch.branchRef);
 	const branchName = branchDetailsParams(branchRef).branchName;
+	const { data: reviews, error: reviewError } = useQuery({
+		...listReviewsQueryOptions({ projectId, cacheConfig: "noCache" }),
+		enabled: !!forgeInfo?.capabilities.prService,
+	});
+	const review = reviews?.reviewsBySourceBranch.get(branchName);
+	const destination = forgeDestination(forgeInfo, review?.htmlUrl);
+	const {
+		data: hasAccount,
+		isError: accountsError,
+		isPending: accountsPending,
+		isSuccess: accountsSuccess,
+	} = useQuery({
+		...forgeAccountsQueryOptions(destination?.name),
+		select: (accounts) => destination !== null && isCloudForge(destination) && accounts.length > 0,
+	});
+	const authFailure = hasAccount === false ? "missing" : forgeAuthFailure(reviewError);
+	const canUseForge = accountsSuccess && hasAccount && authFailure === null;
+
 	const chosenTab = useAppSelector((state) =>
 		projectSlice.selectors.selectBranchTab(state, projectId, branchName),
 	);
@@ -3649,7 +3708,7 @@ const AppliedBranchDetails: FC<BranchDetailsProps> = ({
 	const landedReviewId = useLandedReviewId(
 		projectId,
 		branchCtx ? recordedPullRequest(branchCtx.segment) : null,
-		branchTab === "pr" && hasOpenReview === false,
+		branchTab === "pr" && hasOpenReview === false && canUseForge,
 	);
 
 	return (
@@ -3660,7 +3719,7 @@ const AppliedBranchDetails: FC<BranchDetailsProps> = ({
 				<div className={styles.tabsRow}>
 					<BranchTabToggle branchTab={branchTab} setBranchTab={setBranchTab} />
 
-					{branchTab === "pr" && !!forgeInfo?.capabilities.prService && (
+					{branchTab === "pr" && !!forgeInfo?.capabilities.prService && canUseForge && (
 						<Suspense>
 							<SuspenseQuery
 								{...listReviewsQueryOptions({
@@ -3693,7 +3752,13 @@ const AppliedBranchDetails: FC<BranchDetailsProps> = ({
 				{branchTab === "pr" ? (
 					<div className={styles.prTabScroll}>
 						<div className={styles.prTab}>
-							{!forgeInfo?.capabilities.prService ? (
+							{destination && accountsError ? (
+								<div className={classes(styles.loadingTab, "text-13")}>
+									Could not load the pull request.
+								</div>
+							) : destination && accountsPending ? (
+								<p className="text-13">Loading…</p>
+							) : !forgeInfo?.capabilities.prService ? (
 								<NewPullRequestView
 									projectId={projectId}
 									branchName={branchName}
@@ -3701,6 +3766,8 @@ const AppliedBranchDetails: FC<BranchDetailsProps> = ({
 									canSubmit={false}
 									pushFirst={null}
 								/>
+							) : authFailure !== null ? (
+								<ForgeAuthPrompt destination={destination} hasAccount={hasAccount === true} />
 							) : (
 								<SuspenseQuery
 									{...listReviewsQueryOptions({

--- a/apps/lite/ui/src/routes/project/$id/workspace/ForgeAuthPrompt.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/ForgeAuthPrompt.module.css
@@ -1,0 +1,3 @@
+.empty {
+	padding: 32px 16px;
+}

--- a/apps/lite/ui/src/routes/project/$id/workspace/ForgeAuthPrompt.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/ForgeAuthPrompt.tsx
@@ -1,0 +1,39 @@
+import type { ForgeDestination } from "#ui/forge.ts";
+import { getButtonClassName } from "#ui/components/Button.tsx";
+import { EmptyState } from "#ui/components/EmptyState.tsx";
+import { useAppDispatch } from "#ui/store.ts";
+import { interfaceSlice } from "#ui/interface/state.ts";
+import type { FC } from "react";
+import styles from "./ForgeAuthPrompt.module.css";
+
+type Props = {
+	destination: ForgeDestination | null;
+	hasAccount: boolean;
+};
+
+export const ForgeAuthPrompt: FC<Props> = ({ destination, hasAccount }) => {
+	const dispatch = useAppDispatch();
+
+	const title = `${hasAccount ? "Reconnect" : "Connect"} ${destination?.label ?? "forge"}`;
+	const description = `${hasAccount ? "Reconnect your account" : "Connect an account"} to view and manage PRs`;
+
+	return (
+		<div className={styles.empty}>
+			<EmptyState title={title} description={description}>
+				<button
+					type="button"
+					className={getButtonClassName({})}
+					onClick={() =>
+						dispatch(
+							interfaceSlice.actions.openDialog({
+								dialog: { _tag: "Settings", page: "global:integrations" },
+							}),
+						)
+					}
+				>
+					{title}
+				</button>
+			</EmptyState>
+		</div>
+	);
+};

--- a/apps/lite/ui/src/routes/project/$id/workspace/Page.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Page.tsx
@@ -699,8 +699,9 @@ const PageBody: FC<{ projectId: string }> = ({ projectId }) => {
 					// The picker is an anchored dropdown living with the project name in the header, so
 					// this state only tells it to open — there is nothing for the switch to render.
 					ProjectPicker: () => null,
-					Settings: () => (
+					Settings: ({ page }) => (
 						<Settings
+							page={page}
 							open
 							projectId={projectId}
 							projectName={projectName}

--- a/apps/lite/ui/src/routes/project/$id/workspace/Settings/github-oauth.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Settings/github-oauth.ts
@@ -1,3 +1,4 @@
+import { forgeAuthTags } from "#ui/forge.ts";
 import { invalidateTags } from "#ui/api/tags.ts";
 import type { QueryClient } from "@tanstack/react-query";
 import { pollUntilSuccess } from "./poll.ts";
@@ -52,5 +53,5 @@ export const signInWithGithub = async ({
 		isRetryable: worthRetrying,
 	});
 
-	await invalidateTags(client, ["ForgeAccounts"]);
+	await invalidateTags(client, forgeAuthTags);
 };


### PR DESCRIPTION
Fixes GB-1672 for the majority of cases. Enterprise & self-hosted support remains missing for now as per another ticket.

Here's an example of how this looks. The button takes you straight to the relevant settings pane.

<img width="1007" height="374" alt="Screenshot 2026-09-09 at 14 00 44" src="https://github.com/user-attachments/assets/e23c6a34-5606-42af-8ae5-737ecfdd4b89" />
