### PR TITLE
test(but): add profiler to `but` performance suite

### DIFF
--- a/crates/but/tests/performance/README.md
+++ b/crates/but/tests/performance/README.md
@@ -91,6 +91,47 @@ Use the saved payload unchanged; replaying an accepted upload won't duplicate re
 For local testing, use a separate suite token and a loopback URL such as
 `http://127.0.0.1:6979`; other URLs require HTTPS.
 
+## Profiling one scenario
+
+`profile.sh <backend> <scenario>` reuses benchmark scenarios, profiling only `but`:
+compilation and setup stay outside capture.
+
+```sh
+./crates/but/tests/performance/profile.sh samply status-many-uncommitted-changes
+./crates/but/tests/performance/profile.sh perf squash-10-committed-hunks
+./crates/but/tests/performance/profile.sh flamegraph diff-many-uncommitted-changes
+```
+
+Requires Git, shell utilities, selected profiler, and Cargo unless supplying `BUT_BIN`.
+Install samply/flamegraph with `cargo install --locked samply` / `cargo install --locked flamegraph`.
+Linux perf/flamegraph also require kernel-compatible perf package.
+
+| Backend | Platforms | View capture |
+| --- | --- | --- |
+| `samply` | Linux, macOS | `samply load <profile.json>` |
+| `perf` | Linux | `perf report -i <perf.data>` |
+| `flamegraph` | Linux, macOS with full Xcode/xctrace | Open `flamegraph.svg` in browser |
+
+Configuration uses environment variables, not flags:
+
+- `BUT_BIN`: existing binary; otherwise build optimized native binary with debug symbols.
+- `PERF_PROFILE_OUTPUT_DIR`: new output directory; defaults beneath `target/performance-profiles/<scenario>/`.
+- `PERF_SHOW_OUTPUT=1`: show command stdout.
+- `DEVELOPER_DIR`: optional Xcode selection.
+
+Captures, logs, metadata, and binary/debug symbols are retained; temporary fixtures
+are removed. Keep captures at recorded path for symbol lookup. Benchmark timing,
+upload, and download settings are unsupported.
+
+**macOS:** prefer samply with locally built binary; full Xcode needed only for
+flamegraph.
+
+**Linux:** samply may need `perf_event_paranoid <= 1` and higher
+`perf_event_mlock_kb` (e.g. 2048) for buffer allocation. Harness never changes these
+machine-wide settings. See [samply](https://github.com/mstange/samply) and
+[flamegraph](https://github.com/flamegraph-rs/flamegraph) docs for permissions and
+symbolization troubleshooting (including lld/mold's `--no-rosegment` requirement).
+
 ## Included scenarios
 
 - `diff-many-uncommitted-changes`: time `but diff` after uncommitting real GitButler commit `c9d8e3a7ff59f2ddabed16a6fa1d66ea054f0215`, which formatted the codebase and changes 1,167 files, with 21,636 insertions and 21,620 deletions.
@@ -107,8 +148,9 @@ process startup and output generation. Downloads, compilation, fixture creation,
 and selector discovery stay outside timing.
 
 Each sample gets fresh workspace, bare remote, and isolated configuration, sharing
-only immutable historical objects from pinned GitButler fixture. See [run.sh](run.sh)
-for environment allowlist and [lib.sh](lib.sh) for fixture/setup details.
+only immutable historical objects from pinned GitButler fixture. See [lib.sh](lib.sh)
+for shared environment allowlist and fixture/setup details; [run.sh](run.sh) adds
+benchmark-specific variables.
 
 Scenario scripts may mutate anything under `$PERF_RUN_ROOT`, but must not write to
 `$PERF_FIXTURE_REPO` or `$PERF_SOURCE_REPO`. Fixtures use `git clone --shared`: do not
@@ -232,7 +274,8 @@ perf_state_load
 perf_exec_but squash "$SOURCE_ID" --target "$TARGET_COMMIT" --use-target-message
 ```
 
-`perf_exec_but` replaces script process with configured `but` binary. It sends output
+`perf_exec_but` replaces script process with configured `but` binary (or profiling
+entrypoint's recorder when explicitly enabled for capture). It sends output
 to `/dev/null` normally and preserves it when `PERF_SHOW_OUTPUT=1`. Do not add
 scenario-local output redirection. Keep `test.sh` limited to loading prepared state,
 validating required values, and executing operation under study.

--- a/crates/but/tests/performance/README.md
+++ b/crates/but/tests/performance/README.md
@@ -126,9 +126,19 @@ upload, and download settings are unsupported.
 **macOS:** prefer samply with locally built binary; full Xcode needed only for
 flamegraph.
 
-**Linux:** samply may need `perf_event_paranoid <= 1` and higher
-`perf_event_mlock_kb` (e.g. 2048) for buffer allocation. Harness never changes these
-machine-wide settings. See [samply](https://github.com/mstange/samply) and
+**Linux:** samply and perf may need `kernel.perf_event_paranoid=1` to allow
+recording and a larger perf buffer allowance (`kernel.perf_event_mlock_kb=2048`,
+in KiB). If recording fails due to permissions or buffer allocation, an administrator
+can apply these machine-wide settings:
+
+```sh
+sudo sysctl -w kernel.perf_event_paranoid=1
+sudo sysctl -w kernel.perf_event_mlock_kb=2048
+```
+
+These changes normally last until reboot and relax profiling restrictions for other
+users too. Harness never changes these settings automatically. See
+[samply](https://github.com/mstange/samply) and
 [flamegraph](https://github.com/flamegraph-rs/flamegraph) docs for permissions and
 symbolization troubleshooting (including lld/mold's `--no-rosegment` requirement).
 

--- a/crates/but/tests/performance/lib.sh
+++ b/crates/but/tests/performance/lib.sh
@@ -32,6 +32,15 @@ perf_create_session() {
 }
 
 perf_cleanup_session() {
+    # EXIT traps must not touch unexpected paths if session state was changed.
+    case "${PERF_SESSION_ROOT:-}" in
+        /*/but-performance.[a-zA-Z0-9][a-zA-Z0-9][a-zA-Z0-9][a-zA-Z0-9][a-zA-Z0-9][a-zA-Z0-9]) ;;
+        *)
+            printf 'performance test error: refusing to clean up unexpected session root: %s\n' \
+                "${PERF_SESSION_ROOT:-<unset or empty>}" >&2
+            return 0
+            ;;
+    esac
     chmod -R u+w "$PERF_SESSION_ROOT" 2>/dev/null || true
     rm -rf "$PERF_SESSION_ROOT"
 }

--- a/crates/but/tests/performance/lib.sh
+++ b/crates/but/tests/performance/lib.sh
@@ -24,7 +24,12 @@ perf_assert_full_oid() {
 
 # Outer entrypoints own this session; artifacts must live elsewhere.
 perf_create_session() {
-    PERF_SESSION_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/but-performance.XXXXXX")
+    session_tmpdir=$(CDPATH='' cd "${TMPDIR:-/tmp}" && pwd -P) ||
+        perf_die 'TMPDIR must resolve to an existing directory'
+    case "$session_tmpdir" in
+        /|//) perf_die 'TMPDIR must not resolve to /' ;;
+    esac
+    PERF_SESSION_ROOT=$(mktemp -d "$session_tmpdir/but-performance.XXXXXX")
     PERF_SESSION_ROOT=$(CDPATH='' cd "$PERF_SESSION_ROOT" && pwd)
     trap 'perf_cleanup_session' EXIT
     trap 'exit 130' INT

--- a/crates/but/tests/performance/lib.sh
+++ b/crates/but/tests/performance/lib.sh
@@ -22,6 +22,74 @@ perf_assert_full_oid() {
         perf_die "fixture revision must be a full lowercase 40-character object ID: $1"
 }
 
+# Outer entrypoints own this session; artifacts must live elsewhere.
+perf_create_session() {
+    PERF_SESSION_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/but-performance.XXXXXX")
+    PERF_SESSION_ROOT=$(CDPATH='' cd "$PERF_SESSION_ROOT" && pwd)
+    trap 'perf_cleanup_session' EXIT
+    trap 'exit 130' INT
+    trap 'exit 143' HUP TERM
+}
+
+perf_cleanup_session() {
+    chmod -R u+w "$PERF_SESSION_ROOT" 2>/dev/null || true
+    rm -rf "$PERF_SESSION_ROOT"
+}
+
+perf_resolve_binary() {
+    case "$BUT_BIN" in
+        /*) ;;
+        *) BUT_BIN=$(CDPATH='' cd "$(dirname "$BUT_BIN")" && pwd)/$(basename "$BUT_BIN") ;;
+    esac
+    [ -x "$BUT_BIN" ] || perf_die "BUT_BIN is not executable: $BUT_BIN"
+}
+
+perf_validate_scenario() (
+    case "$1" in
+        ''|*/*|.*|-*) perf_die "invalid scenario name: $1" ;;
+    esac
+    scenario_dir=$PERF_ROOT/scenarios/$1
+    setup_script=$scenario_dir/setup.sh
+    test_script=$scenario_dir/test.sh
+    [ -x "$setup_script" ] || perf_die "scenario setup is not executable: $setup_script"
+    [ -x "$test_script" ] || perf_die "scenario test is not executable: $test_script"
+)
+
+# First argument launches command ("command", or profiler's signal-aware wait).
+# Remaining arguments: explicit NAME=value additions followed by command argv.
+# Never inherit arbitrary caller state (including profiling dispatch state).
+perf_run_isolated() {
+    isolation_launcher=$1
+    shift
+    "$isolation_launcher" env -i \
+        PATH="$PATH" \
+        PERF_ENV_ISOLATED=1 \
+        PERF_ROOT="$PERF_ROOT" \
+        PERF_SOURCE_REPO="$REPO_ROOT" \
+        PERF_SESSION_ROOT="$PERF_SESSION_ROOT" \
+        PERF_FIXTURE_REPO="$PERF_SESSION_ROOT/fixture.git" \
+        PERF_FIXTURE_COMMIT="$PERF_FIXTURE_COMMIT" \
+        BUT_BIN="$BUT_BIN" \
+        GIT_BIN="$GIT_BIN" \
+        HOME="$PERF_SESSION_ROOT/harness-home" \
+        E2E_TEST_APP_DATA_DIR="$PERF_SESSION_ROOT/harness-app-data" \
+        GIT_CONFIG_NOSYSTEM=1 \
+        GIT_CONFIG_GLOBAL=/dev/null \
+        GIT_ATTR_NOSYSTEM=1 \
+        GIT_TERMINAL_PROMPT=0 \
+        GIT_CONFIG_COUNT=4 \
+        GIT_CONFIG_KEY_0=commit.gpgsign \
+        GIT_CONFIG_VALUE_0=false \
+        GIT_CONFIG_KEY_1=tag.gpgsign \
+        GIT_CONFIG_VALUE_1=false \
+        GIT_CONFIG_KEY_2=init.defaultBranch \
+        GIT_CONFIG_VALUE_2=main \
+        GIT_CONFIG_KEY_3=protocol.file.allow \
+        GIT_CONFIG_VALUE_3=always \
+        TZ=UTC LANG=C LC_ALL=C NO_BG_TASKS=1 NOPAGER=1 \
+        "$@"
+}
+
 perf_use_run_environment() {
     : "${PERF_RUN_ROOT:?PERF_RUN_ROOT is not set}"
 
@@ -147,6 +215,10 @@ perf_but() {
 
 perf_exec_but() {
     : "${PERF_REPO:?PERF_REPO is not set}"
+    if [ "${PERF_PROFILE_EXEC:-}" = 1 ]; then
+        # Launch profiler around actual binary, not a system shell (macOS SIP).
+        exec "$PERF_ROOT/profile.sh" "$BUT_BIN" -C "$PERF_REPO" "$@"
+    fi
     if [ "${PERF_SHOW_OUTPUT:-0}" = 1 ]; then
         exec "$BUT_BIN" -C "$PERF_REPO" "$@"
     else

--- a/crates/but/tests/performance/profile.sh
+++ b/crates/but/tests/performance/profile.sh
@@ -97,6 +97,10 @@ if [ "${PERF_ENV_ISOLATED:-}" != 1 ]; then
     PERF_PROFILER_BIN=$(command -v "$backend")
     # Make relative PATH entries safe across fixture/output directory changes.
     PERF_PROFILER_BIN=$(CDPATH='' cd "$(dirname "$PERF_PROFILER_BIN")" && pwd)/$(basename "$PERF_PROFILER_BIN")
+    # Outer fixture checks and metadata run before perf_run_isolated.
+    # Keep caller repository overrides from redirecting these Git commands.
+    unset GIT_DIR GIT_INDEX_FILE GIT_OBJECT_DIRECTORY
+    unset GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_WORK_TREE GIT_COMMON_DIR
     "$GIT_BIN" -C "$REPO_ROOT" cat-file -e "$PERF_FIXTURE_COMMIT^{commit}" ||
         perf_die "fixture commit missing from source checkout: $PERF_FIXTURE_COMMIT"
     if [ "$backend" = flamegraph ]; then

--- a/crates/but/tests/performance/profile.sh
+++ b/crates/but/tests/performance/profile.sh
@@ -1,0 +1,231 @@
+#!/bin/sh
+set -eu
+
+PERF_ROOT=$(CDPATH='' cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(CDPATH='' cd "$PERF_ROOT/../../../.." && pwd)
+# shellcheck disable=SC1091
+. "$PERF_ROOT/lib.sh"
+
+# Only perf_exec_but enables this mode, after scenario state/argv are resolved.
+if [ "${PERF_ENV_ISOLATED:-}" = 1 ] && [ "${PERF_PROFILE_EXEC:-}" = 1 ]; then
+    : "${PERF_PROFILE_OUTPUT_DIR:?}"
+    : "${PERF_PROFILER_BIN:?}"
+    printf '%s\n' "$@" >"$PERF_PROFILE_OUTPUT_DIR/command.txt"
+    cd "$PERF_PROFILE_OUTPUT_DIR"
+    case "$PERF_PROFILE_BACKEND" in
+        samply)
+            set -- "$PERF_PROFILER_BIN" record --save-only -o "$PWD/profile.json" -- "$@"
+            ;;
+        perf)
+            set -- "$PERF_PROFILER_BIN" record -o "$PWD/perf.data" --call-graph dwarf -- "$@"
+            ;;
+        flamegraph)
+            if [ "${PERF_PROFILE_PREFLIGHT:-}" = 1 ]; then
+                # A --version process may yield zero samples: test recording access,
+                # not SVG conversion, which correctly rejects an empty profile.
+                case "$(uname -s)" in
+                    Linux) set -- perf record -o "$PWD/perf.data" --call-graph dwarf -- "$@" ;;
+                    Darwin) set -- xcrun xctrace record --template 'Time Profiler' \
+                        --output "$PWD/preflight.trace" --target-stdout - --launch -- "$@" ;;
+                esac
+            else
+                set -- "$PERF_PROFILER_BIN" -o "$PWD/flamegraph.svg" -- "$@"
+            fi
+            ;;
+        *) perf_die "unknown profiling backend: $PERF_PROFILE_BACKEND" ;;
+    esac
+    # No target wrapper: macOS samply must inject directly into locally built but.
+    # Profiler diagnostics and target stderr are retained and printed by parent.
+    if [ "$PERF_SHOW_OUTPUT" = 1 ]; then
+        exec "$@" 2>"$PERF_PROFILE_OUTPUT_DIR/profiler.log"
+    else
+        exec "$@" >/dev/null 2>"$PERF_PROFILE_OUTPUT_DIR/profiler.log"
+    fi
+fi
+
+[ "$#" -eq 2 ] || perf_die 'usage: profile.sh <samply|perf|flamegraph> <scenario>'
+backend=$1
+scenario_name=$2
+case "$backend" in
+    samply|perf|flamegraph) ;;
+    *) perf_die "unknown profiling backend: $backend (expected samply, perf, or flamegraph)" ;;
+esac
+perf_validate_scenario "$scenario_name"
+setup_script=$PERF_ROOT/scenarios/$scenario_name/setup.sh
+test_script=$PERF_ROOT/scenarios/$scenario_name/test.sh
+
+# Not every profiler forwards termination (flamegraph also launches a recorder).
+# Stop descendants first, while parents can still reap them. Subshell keeps each
+# recursive PID local; only this runner's active child tree is affected.
+profile_stop() (
+    for descendant in $(ps -e -o pid= -o ppid= | awk -v parent="$1" '$2 == parent { print $1 }'); do
+        profile_stop "$descendant"
+    done
+    kill -TERM "$1" 2>/dev/null || true
+)
+
+# Wait explicitly so signals to entrypoint reach active setup/recording child before
+# outer EXIT trap removes its fixture. TERM also stops shells launched asynchronously,
+# which POSIX permits to inherit ignored SIGINT.
+profile_wait() {
+    "$@" &
+    profile_child=$!
+    trap 'trap "" INT HUP TERM; profile_stop "$profile_child"; wait "$profile_child" || true; exit 130' INT
+    trap 'trap "" INT HUP TERM; profile_stop "$profile_child"; wait "$profile_child" || true; exit 143' HUP TERM
+    profile_status=0
+    wait "$profile_child" || profile_status=$?
+    trap 'exit 130' INT
+    trap 'exit 143' HUP TERM
+    return "$profile_status"
+}
+
+if [ "${PERF_ENV_ISOLATED:-}" != 1 ]; then
+    case "$(uname -s):$backend" in
+        Linux:*|Darwin:samply|Darwin:flamegraph) ;;
+        *) perf_die "$backend is not supported on $(uname -s); use samply on macOS" ;;
+    esac
+    case "${PERF_SHOW_OUTPUT:-0}" in
+        0|1) ;;
+        *) perf_die 'PERF_SHOW_OUTPUT must be 0 or 1' ;;
+    esac
+    [ -z "${PERF_CHANNEL:-}${PERF_VERSION:-}${PERF_UPLOAD_URL:-}${PERF_UPLOAD_TOKEN:-}${PERF_RESULTS_DIR:-}${PERF_WARMUP:-}${PERF_MIN_RUNS:-}${PERF_RUNS:-}" ] ||
+        perf_die 'benchmark download/upload/timing settings are not supported; use BUT_BIN and PERF_PROFILE_OUTPUT_DIR'
+    perf_require_command git
+    GIT_BIN=$(command -v git)
+    GIT_BIN=$(CDPATH='' cd "$(dirname "$GIT_BIN")" && pwd)/$(basename "$GIT_BIN")
+    perf_require_command "$backend"
+    PERF_PROFILER_BIN=$(command -v "$backend")
+    # Make relative PATH entries safe across fixture/output directory changes.
+    PERF_PROFILER_BIN=$(CDPATH='' cd "$(dirname "$PERF_PROFILER_BIN")" && pwd)/$(basename "$PERF_PROFILER_BIN")
+    "$GIT_BIN" -C "$REPO_ROOT" cat-file -e "$PERF_FIXTURE_COMMIT^{commit}" ||
+        perf_die "fixture commit missing from source checkout: $PERF_FIXTURE_COMMIT"
+    if [ "$backend" = flamegraph ]; then
+        case "$(uname -s)" in
+            Linux) perf_require_command perf ;;
+            Darwin)
+                perf_require_command xcrun
+                xcrun xctrace version || perf_die 'install/select full Xcode with Instruments, or use samply'
+                xcrun xctrace list templates | grep -q 'Time Profiler' ||
+                    perf_die 'Xcode Time Profiler template unavailable; use samply'
+                ;;
+        esac
+    fi
+
+    if [ -n "${PERF_PROFILE_OUTPUT_DIR:-}" ]; then
+        # Require new directory: no partial overwrite of an earlier capture.
+        mkdir -p "$(dirname "$PERF_PROFILE_OUTPUT_DIR")"
+        mkdir "$PERF_PROFILE_OUTPUT_DIR" || perf_die 'profile output directory must not already exist'
+    else
+        output_parent=$REPO_ROOT/target/performance-profiles/$scenario_name
+        mkdir -p "$output_parent"
+        PERF_PROFILE_OUTPUT_DIR=$(mktemp -d "$output_parent/$backend.XXXXXX")
+    fi
+    PERF_PROFILE_OUTPUT_DIR=$(CDPATH='' cd "$PERF_PROFILE_OUTPUT_DIR" && pwd)
+    printf 'Profile artifacts: %s\n' "$PERF_PROFILE_OUTPUT_DIR" >&2
+    perf_create_session
+
+    build_description='supplied binary; build settings/revision unknown'
+    if [ -n "${BUT_BIN:-}" ]; then
+        perf_resolve_binary
+    else
+        perf_require_command cargo
+        perf_require_command rustc
+        # Explicit native target/path avoids assumptions about Cargo target-dir or
+        # configured cross-compilation targets; no JSON parser dependency needed.
+        host=$(rustc -vV | awk '/^host:/ { print $2 }')
+        [ -n "$host" ] || perf_die 'could not determine native Rust target'
+        build_dir=$REPO_ROOT/target/profiling-build
+        build_description="bench profile, debug=true, strip=none, native target=$host"
+        printf 'Building optimized, symbolized but binary...\n' >&2
+        (
+            cd "$REPO_ROOT"
+            export CARGO_PROFILE_BENCH_DEBUG=true CARGO_PROFILE_BENCH_STRIP=none
+            if [ "$(uname -s)" = Darwin ]; then
+                export CARGO_PROFILE_BENCH_SPLIT_DEBUGINFO=packed
+            fi
+            cargo build --profile bench -p but --bin but --target "$host" --target-dir "$build_dir"
+        )
+        BUT_BIN=$build_dir/$host/release/but
+        perf_resolve_binary
+    fi
+    original_binary=$BUT_BIN
+    # Record the retained executable itself so viewers resolve symbols even after
+    # another build replaces target/profiling-build. Keep adjacent dSYM on macOS.
+    mkdir "$PERF_PROFILE_OUTPUT_DIR/binary"
+    cp "$BUT_BIN" "$PERF_PROFILE_OUTPUT_DIR/binary/but"
+    if [ -d "$BUT_BIN.dSYM" ]; then
+        cp -R "$BUT_BIN.dSYM" "$PERF_PROFILE_OUTPUT_DIR/binary/but.dSYM"
+    fi
+    BUT_BIN=$PERF_PROFILE_OUTPUT_DIR/binary/but
+    {
+        printf 'scenario: %s\nbackend: %s\nfixture: %s\n' "$scenario_name" "$backend" "$PERF_FIXTURE_COMMIT"
+        printf 'harness: %s\n' "$("$GIT_BIN" -C "$REPO_ROOT" rev-parse HEAD)"
+        printf 'os: %s\narchitecture: %s\n' "$(uname -sr)" "$(uname -m)"
+        printf 'original binary: %s\nretained binary: %s\nbuild: %s\n' "$original_binary" "$BUT_BIN" "$build_description"
+        printf 'binary checksum (cksum): '; cksum "$BUT_BIN"
+        printf 'caller RUSTFLAGS: %s\ncaller CARGO_ENCODED_RUSTFLAGS: %s\n' "${RUSTFLAGS:-}" "${CARGO_ENCODED_RUSTFLAGS:-}"
+        printf 'show output: %s\n' "${PERF_SHOW_OUTPUT:-0}"
+        printf 'profiler: '; "$PERF_PROFILER_BIN" --version
+        printf 'harness worktree changes:\n'; "$GIT_BIN" -C "$REPO_ROOT" status --short
+    } >"$PERF_PROFILE_OUTPUT_DIR/metadata.txt"
+
+    trap 'status=$?; printf "runner exit status: %s\n" "$status" >>"$PERF_PROFILE_OUTPUT_DIR/metadata.txt"; perf_cleanup_session' EXIT
+    # Backend children may resolve perf/xctrace through PATH. Keep resolved absolute
+    # tool directory first, including when caller used a relative PATH entry.
+    PATH="$(dirname "$PERF_PROFILER_BIN"):$PATH"
+    set --
+    if [ -n "${DEVELOPER_DIR:-}" ]; then
+        set -- "DEVELOPER_DIR=$DEVELOPER_DIR"
+    fi
+    status=0
+    perf_run_isolated profile_wait "$@" \
+        PERF_SHOW_OUTPUT="${PERF_SHOW_OUTPUT:-0}" \
+        PERF_PROFILE_BACKEND="$backend" \
+        PERF_PROFILER_BIN="$PERF_PROFILER_BIN" \
+        PERF_PROFILE_OUTPUT_DIR="$PERF_PROFILE_OUTPUT_DIR" \
+        "$PERF_ROOT/profile.sh" "$backend" "$scenario_name" || status=$?
+    printf 'Artifacts retained: %s\n' "$PERF_PROFILE_OUTPUT_DIR" >&2
+    [ "$status" -eq 0 ] || exit "$status"
+    case "$backend" in
+        samply) printf 'View: samply load "%s/profile.json"\n' "$PERF_PROFILE_OUTPUT_DIR" ;;
+        perf) printf 'View: perf report -i "%s/perf.data"\n' "$PERF_PROFILE_OUTPUT_DIR" ;;
+        flamegraph) printf 'Open in browser: %s/flamegraph.svg\n' "$PERF_PROFILE_OUTPUT_DIR" ;;
+    esac
+    exit 0
+fi
+
+mkdir -p "$HOME" "$E2E_TEST_APP_DATA_DIR"
+# Launch a tiny native operation before expensive fixture setup. This checks actual
+# recording permissions (including macOS injection), not merely tool installation.
+printf 'Checking profiler access...\n' >&2
+mkdir "$PERF_PROFILE_OUTPUT_DIR/preflight"
+status=0
+PERF_PROFILE_EXEC=1 PERF_PROFILE_PREFLIGHT=1 PERF_PROFILE_OUTPUT_DIR="$PERF_PROFILE_OUTPUT_DIR/preflight" \
+    profile_wait "$PERF_ROOT/profile.sh" "$BUT_BIN" --version || status=$?
+[ ! -f "$PERF_PROFILE_OUTPUT_DIR/preflight/profiler.log" ] || cat "$PERF_PROFILE_OUTPUT_DIR/preflight/profiler.log" >&2
+[ "$status" -eq 0 ] || perf_die 'profiler preflight failed; check recording permissions/tool version (macOS: prefer samply); no security settings were changed'
+
+printf 'Creating immutable GitButler history fixture...\n' >&2
+profile_wait perf_create_gitbutler_fixture "$PERF_FIXTURE_REPO" "$PERF_SOURCE_REPO" "$PERF_FIXTURE_COMMIT"
+PERF_RUN_ROOT=$PERF_SESSION_ROOT/runs/$scenario_name
+export PERF_RUN_ROOT
+printf 'Smoke-testing %s...\n' "$scenario_name" >&2
+profile_wait "$setup_script"
+profile_wait "$test_script"
+printf 'Preparing fresh profiling state...\n' >&2
+profile_wait "$setup_script"
+printf 'Profiling %s with %s...\n' "$scenario_name" "$backend" >&2
+status=0
+PERF_PROFILE_EXEC=1 profile_wait "$test_script" || status=$?
+[ ! -f "$PERF_PROFILE_OUTPUT_DIR/profiler.log" ] || cat "$PERF_PROFILE_OUTPUT_DIR/profiler.log" >&2
+printf 'profiler exit status: %s\n' "$status" >>"$PERF_PROFILE_OUTPUT_DIR/metadata.txt"
+[ "$status" -eq 0 ] || exit "$status"
+case "$backend" in
+    samply) artifact=profile.json ;;
+    perf) artifact=perf.data ;;
+    flamegraph) artifact=flamegraph.svg ;;
+esac
+[ -s "$PERF_PROFILE_OUTPUT_DIR/$artifact" ] || perf_die "profiler produced no $artifact; inspect profiler.log"
+# This is recorder success, not an independent assertion about child exit status:
+# tools differ in how they report failed/signalled targets (notably xctrace).
+

--- a/crates/but/tests/performance/run.sh
+++ b/crates/but/tests/performance/run.sh
@@ -25,17 +25,7 @@ if [ "${PERF_ENV_ISOLATED:-}" != 1 ]; then
     HYPERFINE_BIN=$(command -v hyperfine)
     perf_assert_full_oid "$PERF_FIXTURE_COMMIT"
 
-    PERF_SESSION_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/but-performance.XXXXXX")
-    PERF_SESSION_ROOT=$(CDPATH='' cd "$PERF_SESSION_ROOT" && pwd)
-    # Invoked by EXIT trap in outer runner.
-    # shellcheck disable=SC2329
-    cleanup() {
-        chmod -R u+w "$PERF_SESSION_ROOT" 2>/dev/null || true
-        rm -rf "$PERF_SESSION_ROOT"
-    }
-    trap cleanup EXIT
-    trap 'exit 130' INT
-    trap 'exit 143' HUP TERM
+    perf_create_session
 
     BINARY_VERSION=
     BINARY_CHANNEL=
@@ -63,11 +53,7 @@ if [ "${PERF_ENV_ISOLATED:-}" != 1 ]; then
         if [ "$UPLOAD_ENABLED" = 1 ]; then
             : "${PERF_BINARY_COMMIT:?set PERF_BINARY_COMMIT to supplied binary revision for upload}"
         fi
-        case "$BUT_BIN" in
-            /*) ;;
-            *) BUT_BIN=$(CDPATH='' cd "$(dirname "$BUT_BIN")" && pwd)/$(basename "$BUT_BIN") ;;
-        esac
-        [ -x "$BUT_BIN" ] || perf_die "BUT_BIN is not executable: $BUT_BIN"
+        perf_resolve_binary
     else
         perf_require_command cargo
         printf 'Building optimized but binary...\n' >&2
@@ -93,7 +79,6 @@ if [ "${PERF_ENV_ISOLATED:-}" != 1 ]; then
         CPU=${PERF_CPU:-$ARCH}
         HYPERFINE_VERSION=$("$HYPERFINE_BIN" --version)
     fi
-    PATH_VALUE=$PATH
     WARMUP_VALUE=${PERF_WARMUP:-3}
     MIN_RUNS_VALUE=${PERF_MIN_RUNS:-20}
     RUNS_VALUE=${PERF_RUNS:-}
@@ -148,42 +133,13 @@ if [ "${PERF_ENV_ISOLATED:-}" != 1 ]; then
     fi
 
     set +e
-    env -i \
-        PATH="$PATH_VALUE" \
-        PERF_ENV_ISOLATED=1 \
-        PERF_ROOT="$PERF_ROOT" \
-        PERF_SOURCE_REPO="$REPO_ROOT" \
-        PERF_SESSION_ROOT="$PERF_SESSION_ROOT" \
-        PERF_FIXTURE_REPO="$PERF_SESSION_ROOT/fixture.git" \
-        PERF_FIXTURE_COMMIT="$PERF_FIXTURE_COMMIT" \
+    perf_run_isolated command \
         PERF_WARMUP="$WARMUP_VALUE" \
         PERF_MIN_RUNS="$MIN_RUNS_VALUE" \
         PERF_RUNS="$RUNS_VALUE" \
         PERF_SHOW_OUTPUT="$SHOW_OUTPUT_VALUE" \
         PERF_RESULTS_DIR="$BENCHMARK_RESULTS_DIR" \
-        BUT_BIN="$BUT_BIN" \
-        GIT_BIN="$GIT_BIN" \
         HYPERFINE_BIN="$HYPERFINE_BIN" \
-        HOME="$PERF_SESSION_ROOT/harness-home" \
-        E2E_TEST_APP_DATA_DIR="$PERF_SESSION_ROOT/harness-app-data" \
-        GIT_CONFIG_NOSYSTEM=1 \
-        GIT_CONFIG_GLOBAL=/dev/null \
-        GIT_ATTR_NOSYSTEM=1 \
-        GIT_TERMINAL_PROMPT=0 \
-        GIT_CONFIG_COUNT=4 \
-        GIT_CONFIG_KEY_0=commit.gpgsign \
-        GIT_CONFIG_VALUE_0=false \
-        GIT_CONFIG_KEY_1=tag.gpgsign \
-        GIT_CONFIG_VALUE_1=false \
-        GIT_CONFIG_KEY_2=init.defaultBranch \
-        GIT_CONFIG_VALUE_2=main \
-        GIT_CONFIG_KEY_3=protocol.file.allow \
-        GIT_CONFIG_VALUE_3=always \
-        TZ=UTC \
-        LANG=C \
-        LC_ALL=C \
-        NO_BG_TASKS=1 \
-        NOPAGER=1 \
         "$0" "$@"
     benchmark_status=$?
     set -e
@@ -250,15 +206,9 @@ fi
 [ "$#" -gt 0 ] || perf_die "no performance scenarios found"
 
 for scenario_name in "$@"; do
-    case "$scenario_name" in
-        ''|*/*|.*) perf_die "invalid scenario name: $scenario_name" ;;
-    esac
-
-    scenario_dir=$scenario_root/$scenario_name
-    setup_script=$scenario_dir/setup.sh
-    test_script=$scenario_dir/test.sh
-    [ -x "$setup_script" ] || perf_die "scenario setup is not executable: $setup_script"
-    [ -x "$test_script" ] || perf_die "scenario test is not executable: $test_script"
+    perf_validate_scenario "$scenario_name"
+    setup_script=$scenario_root/$scenario_name/setup.sh
+    test_script=$scenario_root/$scenario_name/test.sh
 
     PERF_RUN_ROOT=$PERF_SESSION_ROOT/runs/$scenario_name
     export PERF_RUN_ROOT


### PR DESCRIPTION
Adds an AI-generated profiler shell script to the performance suite. The shell scripting here is getting a bit silly so I might migrate this to Rust soon, but right now it's just really nice not to require the Rust toolchain on the benchmark machine.