### PR TITLE
Make the hand cursor an appearance setting in Lite

### DIFF
--- a/apps/lite/DESIGN.md
+++ b/apps/lite/DESIGN.md
@@ -58,11 +58,18 @@ selection can restyle without a re-render.
 
 **No pointer cursors.** Lite is a desktop app, and desktop apps keep the arrow
 over buttons, menus and rows; the hand is a web convention for links out to a
-page. Don't set `cursor: pointer` on a control, and don't reintroduce it by
-resetting a `<button>` — the browser default for buttons is already the arrow.
-Interactivity is shown by the hover state, not the cursor. The cursors that do
-change are the ones that describe a gesture: `text` over editable text, `grab`
-and `grabbing` while dragging, and the resize cursors on a splitter.
+page. Whoever wants the hand anyway turns it on in Appearance, and the harness
+panel takes it always, being part of a web page. Both go through one property:
+the host sets `--control-cursor` on its root, and `control-cursor.css` puts it
+on buttons, links, `summary` and the button, menu-item and option roles. Don't
+set `cursor: pointer` on a control, and don't pin `cursor: default` on one
+either — both defeat the setting. Don't reintroduce the hand by resetting a
+`<button>`: the browser default for buttons is already the arrow. A clickable
+that is none of those elements (a folded card, a minimap badge) takes
+`cursor: var(--control-cursor)` itself. Interactivity is shown by the hover
+state, not the cursor. The cursors that do change are the ones that describe a
+gesture: `text` over editable text, `grab` and `grabbing` while dragging, the
+resize cursors on a splitter, and `not-allowed` on a disabled control.
 
 ## Motion
 

--- a/apps/lite/electron/src/settings.ts
+++ b/apps/lite/electron/src/settings.ts
@@ -28,6 +28,7 @@ const guiSettingsV1 = type({
 	"editorId?": "string",
 	"fileDisplayMode?": "'list' | 'tree'",
 	"filesPanelRight?": "boolean",
+	"handCursor?": "boolean",
 	"lineDiffType?": "'word-alt' | 'word' | 'char' | 'none'",
 	"minimap?": "boolean",
 	"pathFirst?": "boolean",

--- a/apps/lite/harness/browser/panel-globals.css
+++ b/apps/lite/harness/browser/panel-globals.css
@@ -1,6 +1,7 @@
 /* The component CSS modules use the design tokens. The app loads them via
    global.css; the panel loads them here, without the app's window styling. */
 @import "@gitbutler/design-core/core";
+@import "../../ui/src/control-cursor.css";
 
 /* The app's `:root` custom properties (global.css) — the panel has no
    global.css, so the components' `var(--panel-padding-*)` references would
@@ -8,6 +9,8 @@
    the scrollbar gutter its background. */
 :root {
 	color-scheme: light dark;
+	/* The panel sits in a web page, so its controls take the hand the page does. */
+	--control-cursor: pointer;
 
 	--list-item-hover-bg: color-mix(var(--fill-gray-bg) var(--opacity-bg-hover), transparent);
 	--focus-ring: 1.5px solid color-mix(in srgb, var(--fill-gray-bg) 70%, transparent);

--- a/apps/lite/ui/src/App.tsx
+++ b/apps/lite/ui/src/App.tsx
@@ -36,6 +36,20 @@ const SyntaxThemeSync: FC = () => {
 	return null;
 };
 
+// The stylesheet reads the choice off the root element (see control-cursor.css).
+const HandCursorSync: FC = () => {
+	const { data: handCursor } = useQuery({
+		...guiSettingsQueryOptions,
+		select: (cfg) => cfg.handCursor ?? defaultSettings.handCursor,
+	});
+
+	useEffect(() => {
+		document.documentElement.toggleAttribute("data-hand-cursor", handCursor === true);
+	}, [handCursor]);
+
+	return null;
+};
+
 export const App: FC<{
 	queryClient: QueryClient;
 	toastManager: ToastManager;
@@ -51,6 +65,7 @@ export const App: FC<{
 							highlighterOptions={{ preferredHighlighter: "shiki-wasm" }}
 						>
 							<SyntaxThemeSync />
+							<HandCursorSync />
 							<RouterProvider router={router} />
 							<AskpassPromptDialog />
 							<Toasts />

--- a/apps/lite/ui/src/components/Clamped.module.css
+++ b/apps/lite/ui/src/components/Clamped.module.css
@@ -83,7 +83,7 @@
 	border-radius: var(--radius-card);
 	background-color: var(--card-bg);
 	/* The whole folded card opens, not only its chevron. */
-	cursor: pointer;
+	cursor: var(--control-cursor);
 	transition: background-color var(--transition-fast);
 
 	/* The fade clears to the card's ground, not the page's, and with no label

--- a/apps/lite/ui/src/components/Markdown.module.css
+++ b/apps/lite/ui/src/components/Markdown.module.css
@@ -235,8 +235,4 @@
 		font-size: 12px;
 		font-family: var(--text-fontfamily-mono);
 	}
-
-	summary {
-		cursor: pointer;
-	}
 }

--- a/apps/lite/ui/src/components/PickerDialog.module.css
+++ b/apps/lite/ui/src/components/PickerDialog.module.css
@@ -80,7 +80,7 @@
 	border-radius: var(--radius-button);
 	outline: 0;
 	font-size: 13px;
-	cursor: default;
+	cursor: var(--control-cursor);
 	scroll-margin-block: 4px;
 	user-select: none;
 

--- a/apps/lite/ui/src/components/Popup.module.css
+++ b/apps/lite/ui/src/components/Popup.module.css
@@ -141,7 +141,6 @@
 	flex: none;
 	align-items: center;
 	color: var(--text-2);
-	cursor: default;
 
 	&:hover {
 		color: var(--text-1);
@@ -184,7 +183,7 @@
 	background: none;
 	color: var(--text-1);
 	text-align: start;
-	cursor: default;
+	cursor: var(--control-cursor);
 
 	/* `data-highlighted` is what Base UI's list primitives set as the keyboard walks them, so
 	   pointer and keyboard land on the same tint. */

--- a/apps/lite/ui/src/control-cursor.css
+++ b/apps/lite/ui/src/control-cursor.css
@@ -1,0 +1,13 @@
+/* The cursor over a control. Desktop apps keep the arrow there and web pages
+   the hand (DESIGN.md, Cursors), so each host sets --control-cursor on its
+   root: the app from the appearance setting, the harness panel to the hand of
+   the page it sits in. Imported right after design-core, whose reset gives
+   links the hand. */
+button,
+a,
+summary,
+[role="button"],
+[role="menuitem"],
+[role="option"] {
+	cursor: var(--control-cursor);
+}

--- a/apps/lite/ui/src/global.css
+++ b/apps/lite/ui/src/global.css
@@ -1,4 +1,5 @@
 @import "@gitbutler/design-core/core";
+@import "./control-cursor.css";
 
 /*
     color-scheme isn't yet respected by prefers-color-scheme, so where we can't use light-dark() we
@@ -12,6 +13,9 @@
 
 :root {
 	color-scheme: light dark;
+
+	/* The arrow over controls until the appearance setting asks for the hand (control-cursor.css). */
+	--control-cursor: default;
 
 	--list-item-hover-bg: color-mix(var(--fill-gray-bg) var(--opacity-bg-hover), transparent);
 	--focus-ring: 1.5px solid color-mix(in srgb, var(--fill-gray-bg) 70%, transparent);
@@ -27,6 +31,10 @@
 	   that sit on another background (popups) restate these on themselves. */
 	--scrollbar-track-bg: var(--bg-2);
 	--scrollbar-track-border: var(--border-section);
+}
+
+:root[data-hand-cursor] {
+	--control-cursor: pointer;
 }
 
 body {
@@ -95,7 +103,6 @@ button {
 a {
 	color: unset;
 	text-decoration: unset;
-	cursor: default;
 
 	&:focus-visible {
 		outline: var(--focus-ring);

--- a/apps/lite/ui/src/review-inbox-bell.module.css
+++ b/apps/lite/ui/src/review-inbox-bell.module.css
@@ -41,7 +41,6 @@
 	color: var(--text-2);
 	text-decoration: underline dotted;
 	text-underline-position: from-font;
-	cursor: pointer;
 }
 
 .empty {
@@ -66,7 +65,6 @@
 	/* The list reads as a murmur; the red dots and kind icons carry it. */
 	color: var(--text-2);
 	text-align: start;
-	cursor: pointer;
 }
 
 .entry:last-child {

--- a/apps/lite/ui/src/routes/project/$id/workspace/ConflictedFiles.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/ConflictedFiles.module.css
@@ -52,7 +52,6 @@
 	color: var(--diffs-fg-number);
 	font: inherit;
 	font-style: normal;
-	cursor: pointer;
 
 	&:hover:not(:disabled) {
 		color: var(--diffs-fg);

--- a/apps/lite/ui/src/routes/project/$id/workspace/DiffMinimap.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DiffMinimap.module.css
@@ -159,7 +159,7 @@
 	/* Clear the rule itself, so it runs unbroken behind the badge. */
 	margin-top: 1px;
 	background: var(--bg-1);
-	cursor: pointer;
+	cursor: var(--control-cursor);
 
 	& > svg {
 		width: 12px;

--- a/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/FilesTree.module.css
@@ -47,7 +47,6 @@
 	border: none;
 	background: none;
 	color: var(--text-3);
-	cursor: pointer;
 
 	&:hover,
 	&:focus-visible {

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestComments.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestComments.module.css
@@ -479,5 +479,4 @@
 	color: var(--text-2);
 	text-decoration: underline dotted;
 	text-underline-position: from-font;
-	cursor: pointer;
 }

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestForm.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestForm.module.css
@@ -167,7 +167,6 @@
 	/* The designed link treatment: dotted, on the font's own underline. */
 	text-decoration: underline dotted;
 	text-underline-position: from-font;
-	cursor: pointer;
 
 	&:hover {
 		color: var(--text-1);

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestReactions.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestReactions.module.css
@@ -58,7 +58,6 @@
 	border-radius: var(--radius-button);
 	background: none;
 	font-size: 14px;
-	cursor: pointer;
 
 	&:hover {
 		background-color: var(--fill-gray-bg);

--- a/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
@@ -130,7 +130,6 @@
 	border: none;
 	background: none;
 	color: inherit;
-	cursor: pointer;
 
 	.container:hover &,
 	.container:focus-within &,

--- a/apps/lite/ui/src/routes/project/$id/workspace/Settings/Appearance.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Settings/Appearance.tsx
@@ -92,6 +92,18 @@ export const Appearance: FC = () => {
 						))}
 					</select>
 				</Row>
+
+				<Row
+					label="Hand cursor"
+					labelId="hand-cursor"
+					hint="Show the hand over buttons and links, as a web page does. Off keeps the arrow, as desktop apps do."
+				>
+					<Switch
+						aria-labelledby="hand-cursor"
+						checked={settings.handCursor ?? defaultSettings.handCursor}
+						onCheckedChange={(handCursor) => saveGUISettings({ handCursor })}
+					/>
+				</Row>
 			</Section>
 
 			<Section heading="Files">

--- a/apps/lite/ui/src/routes/project/$id/workspace/Settings/Settings.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Settings/Settings.module.css
@@ -47,7 +47,6 @@
 	border-radius: var(--radius-button);
 	color: var(--text-2);
 	text-align: left;
-	cursor: default;
 	transition: background-color var(--transition-fast);
 
 	/* Slides in from the sidebar's inner edge, so the selection reads even at a glance. */

--- a/apps/lite/ui/src/settings.ts
+++ b/apps/lite/ui/src/settings.ts
@@ -22,6 +22,8 @@ export const defaultSettings = {
 	// Show the folder tree until the user chooses a display mode.
 	fileDisplayMode: "tree",
 	filesPanelRight: false,
+	// Desktop apps keep the arrow over controls; the hand is a web convention (DESIGN.md, Cursors).
+	handCursor: false,
 	// Pierre's own default, named here so the setting has somewhere to fall back to.
 	lineDiffType: "word-alt",
 	// Experimental; opt in from the Experimental settings.


### PR DESCRIPTION
Lite keeps the arrow over its controls, as desktop apps do. The harness panel showed the hand on links only because the app's `global.css` is not loaded there, and a dozen component modules still set their own `cursor: pointer`.

- `handCursor` GUI setting, off by default, with a "Hand cursor" switch on the Appearance page
- one `--control-cursor` property per host: the app sets it from the setting through a root attribute, the harness panel pins the hand since it sits in a web page
- `control-cursor.css`, imported right after design-core by both hosts, puts it on buttons, links, `summary` and the button, menu-item and option roles
- component modules stop setting `cursor: pointer` or pinning `cursor: default` on controls, so the setting reaches them; disabled controls keep `not-allowed`, rows keep the arrow
- DESIGN.md's Cursors section describes the property and the setting

Behaviour change: buttons that showed the hand before (the row fold toggle, the "add description" link in the PR form) now follow the setting and default to the arrow.

Verified in the running dev app over CDP: flipping the switch moves every button and link between `default` and `pointer`, and the value persists across reloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)