### PR TITLE
Rename .commentsEmpty to .commentsLoading in lite

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestComments.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestComments.module.css
@@ -8,7 +8,7 @@
 	border-block-start: 1px solid var(--border-section);
 }
 
-.commentsEmpty {
+.commentsLoading {
 	color: var(--text-3);
 }
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestComments.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestComments.tsx
@@ -1202,7 +1202,7 @@ export const ReviewTimeline: FC<{ projectId: string; review: ForgeReview }> = ({
 		[review, events],
 	);
 
-	if (isPending) return <div className={classes("text-13", styles.commentsEmpty)}>Loading…</div>;
+	if (isPending) return <div className={classes("text-13", styles.commentsLoading)}>Loading…</div>;
 	const shown = expanded ? items : items.slice(0, collapsedTimelineCount);
 	const hidden = items.length - shown.length;
 
@@ -1389,7 +1389,7 @@ export const PullRequestComments: FC<{ projectId: string; review: ForgeReview }>
 				textareaRef={composerRef}
 			/>
 			{loading ? (
-				<div className={classes("text-13", styles.commentsEmpty)}>Loading…</div>
+				<div className={classes("text-13", styles.commentsLoading)}>Loading…</div>
 			) : (
 				<div className={styles.commentList}>
 					{items.map((item) =>


### PR DESCRIPTION
The class only ever styled the "Loading…" placeholder in the PR
comments feed and collapsed timeline; there has never been a "no
comments" empty state for it to style. The old name misread as one
and ended up listed as an empty-state surface in GB-1959.