### PR TITLE
Keep the PR meta line inline beside the author

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.module.css
@@ -92,11 +92,17 @@
 
 .user {
 	display: flex;
-	flex: 1;
 	align-items: center;
 	min-width: 0;
 	gap: 8px;
 	color: var(--text-1);
+}
+
+/* Only in a reviewer row does the user fill the line, so the verdict icon and
+   remove button sit at the end and the login truncates before them. The
+   description's meta line reuses this component and must flow inline. */
+.reviewerRow > .user {
+	flex: 1;
 }
 
 /* A long login truncates rather than wrapping the row to two lines; the row's


### PR DESCRIPTION
The reviewer picker change in #15846 gave the shared user row `flex: 1` so a long login truncates before the new remove button. The PR description's meta line reuses that same row, so the author grew to fill the whole line and pushed the commit count and updated time to the far edge.

<img width="789" height="355" alt="A1CF3F4F-2840-4EDA-A7B9-2956D30D2E02" src="https://github.com/user-attachments/assets/f5ae0ec1-f0ac-4b12-9491-92719fcd3a9a" />