### PR TITLE
Show each branch of a linked worktree in the Lite sidebar

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorktreeLane.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorktreeLane.tsx
@@ -16,6 +16,7 @@ import {
 	type FileParent,
 } from "#ui/addresses.ts";
 import { useWorktreeRemove, useWorktreeSetArchived } from "#ui/api/mutations.ts";
+import { decodeBytes } from "#ui/api/bytes.ts";
 import {
 	guiSettingsQueryOptions,
 	treeChangesDiffsQueryOptions,
@@ -190,10 +191,10 @@ const WorktreeUncommitted: FC<{
 };
 
 /**
- * The branch a worktree has checked out, as a row of the applied tree: a
- * value that selects and takes commits, with the worktree's own actions on
- * its menu. It is outside the workspace, so the branch actions that rewrite
- * the workspace are not offered.
+ * A branch of a worktree's stack, the checked-out one or one stacked under
+ * it, as a row of the applied tree: a value that selects and takes commits,
+ * with the worktree's own actions on its menu. It is outside the workspace,
+ * so the branch actions that rewrite the workspace are not offered.
  */
 const WorktreeBranchRow: FC<
 	{
@@ -287,7 +288,7 @@ const WorktreeBranchRow: FC<
 /**
  * A linked worktree's rows, laid out like the sidebar itself: the worktree's
  * name labels the whole, then its uncommitted files head a rail that runs
- * down through its branch and the commits only it has, with any worktree
+ * down through its branches and the commits only it has, with any worktree
  * resting on one of them nested above it. The rows are the sidebar's own;
  * the address space decides which of them operations may take.
  */
@@ -300,9 +301,11 @@ const WorktreeRows: FC<{
 	/** The lane's rail starts at its uncommitted files; on the trunk, the trunk runs on through. */
 	startsRail: boolean;
 }> = ({ projectId, worktree, worktrees, behind, startsRail }) => {
-	const branch =
-		worktree.refName === null ? null : branchAddress({ branchRef: worktree.refName.fullNameBytes });
+	// The rail under a commit takes the colour of the next commit, across segments.
 	const commits = worktree.segments.flatMap((segment) => segment.commits);
+	const below = new Map(
+		commits.map((commit, index) => [commit.id, commits[index + 1]?.state.type ?? "LocalOnly"]),
+	);
 	return (
 		<>
 			<Row interactive={false}>
@@ -320,67 +323,83 @@ const WorktreeRows: FC<{
 				behind={behind}
 				startsRail={startsRail}
 			/>
-			{worktree.refName !== null && branch !== null && (
-				<TreeItem
-					address={branch}
-					aria-label={worktree.refName.displayName}
-					render={
-						<AddressC
-							projectId={projectId}
-							address={branch}
-							outline="outside"
-							render={
-								<WorktreeBranchRow
-									projectId={projectId}
-									worktree={worktree.name}
-									refName={worktree.refName}
-									behind={behind}
-								/>
-							}
-						/>
-					}
-				/>
-			)}
-			{commits.map((commit, index) => {
-				const address = commitAddress({ commitId: commit.id, changeId: commit.changeId });
-				const next = commits[index + 1];
+			{worktree.segments.map((segment) => {
+				// A detached HEAD's first segment has no branch to show a row for.
+				const branch =
+					segment.refName === null
+						? null
+						: branchAddress({ branchRef: segment.refName.fullNameBytes });
 				return (
-					<Fragment key={commit.id}>
-						{worktrees.on.get(commit.id)?.map((nested) => (
-							<WorktreeLane
-								key={nested.name}
-								projectId={projectId}
-								worktree={nested}
-								worktrees={worktrees}
-								behind={behind + 1}
+					<Fragment
+						key={
+							segment.refName
+								? decodeBytes(segment.refName.fullNameBytes)
+								: (segment.commits[0]?.id ?? "detached")
+						}
+					>
+						{segment.refName !== null && branch !== null && (
+							<TreeItem
+								address={branch}
+								aria-label={segment.refName.displayName}
+								render={
+									<AddressC
+										projectId={projectId}
+										address={branch}
+										outline="outside"
+										render={
+											<WorktreeBranchRow
+												projectId={projectId}
+												worktree={worktree.name}
+												refName={segment.refName}
+												behind={behind}
+											/>
+										}
+									/>
+								}
 							/>
-						))}
-						<TreeItem
-							address={address}
-							aria-label={commitTitle(commit.message) ?? "(no message)"}
-							render={
-								<AddressC
-									projectId={projectId}
-									address={address}
-									outline="outside"
-									render={
-										<CommitRow
-											commit={commit}
+						)}
+						{segment.commits.map((commit) => {
+							const address = commitAddress({ commitId: commit.id, changeId: commit.changeId });
+							return (
+								<Fragment key={commit.id}>
+									{worktrees.on.get(commit.id)?.map((nested) => (
+										<WorktreeLane
+											key={nested.name}
 											projectId={projectId}
-											stackId={null}
-											dryRunCommit={null}
-											checkCommit={noop}
-											amendCommit={noop}
-											canAmendCommit={false}
-											below={next === undefined ? "LocalOnly" : next.state.type}
-											behind={behind}
-											worktree={worktree.name}
-											scrollSelectedIntoView={false}
+											worktree={nested}
+											worktrees={worktrees}
+											behind={behind + 1}
 										/>
-									}
-								/>
-							}
-						/>
+									))}
+									<TreeItem
+										address={address}
+										aria-label={commitTitle(commit.message) ?? "(no message)"}
+										render={
+											<AddressC
+												projectId={projectId}
+												address={address}
+												outline="outside"
+												render={
+													<CommitRow
+														commit={commit}
+														projectId={projectId}
+														stackId={null}
+														dryRunCommit={null}
+														checkCommit={noop}
+														amendCommit={noop}
+														canAmendCommit={false}
+														below={below.get(commit.id) ?? "LocalOnly"}
+														behind={behind}
+														worktree={worktree.name}
+														scrollSelectedIntoView={false}
+													/>
+												}
+											/>
+										}
+									/>
+								</Fragment>
+							);
+						})}
 					</Fragment>
 				);
 			})}

--- a/apps/lite/ui/src/routes/project/$id/workspace/applied-address-space.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/applied-address-space.ts
@@ -47,24 +47,24 @@ export const buildAppliedAddressSpace = ({
 	foldedSegments: Record<string, true>;
 }): AddressSpace<Address> => {
 	// Operations take a card's rows, a worktree's uncommitted files, and a
-	// worktree's branch; not the section's rows or a worktree's own commits.
+	// worktree's branches; not the section's rows or a worktree's own commits.
 	const owned = (address: Address): Row => ({ address, owned: true });
 	const foreign = (address: Address): Row => ({ address, owned: false });
-	// A lane's rows in reading order: files, branch, then commits, each preceded
-	// by the lanes resting on it. Matches WorktreeLane.
+	// A lane's rows in reading order: files, then per segment its branch and its
+	// commits, each commit preceded by the lanes resting on it. Matches WorktreeLane.
 	const laneRows = (worktree: Worktree): Array<Row> => [
 		...(worktreeFiles.get(worktree.name) ?? []).map((path) =>
 			owned(fileAddress({ parent: worktreeChangesFileParent(worktree.name), path })),
 		),
-		...(worktree.refName
-			? [owned(branchAddress({ branchRef: worktree.refName.fullNameBytes }))]
-			: []),
-		...worktree.segments
-			.flatMap((segment) => segment.commits)
-			.flatMap((commit) => [
+		...worktree.segments.flatMap((segment) => [
+			...(segment.refName
+				? [owned(branchAddress({ branchRef: segment.refName.fullNameBytes }))]
+				: []),
+			...segment.commits.flatMap((commit) => [
 				...lanesOn(commit.id),
 				foreign(commitAddress({ commitId: commit.id, changeId: commit.changeId })),
 			]),
+		]),
 	];
 	const lanesOn = (commitId: string): Array<Row> =>
 		(plan.worktrees.on.get(commitId) ?? []).flatMap(laneRows);


### PR DESCRIPTION
Follows #15865, which projects a linked worktree's history into stack segments. Lite still flattened those into one branch row over every commit, so a branch stacked under the checked-out one was not shown and its commits sat under the wrong name.

- The worktree lane renders a branch row per segment, with the commits under the branch that owns them. A detached `HEAD`'s anonymous first segment has no branch row.
- Keyboard navigation lists the rows in the same order.

Not in this PR: the segments' push status and remote-only commits, which the lane does not surface yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)