### PR TITLE
Fetch a single review from GraphQL

### DIFF
--- a/apps/lite/ui/src/api/mutations.ts
+++ b/apps/lite/ui/src/api/mutations.ts
@@ -63,6 +63,7 @@ import type { GUISettings } from "#electron/settings.ts";
 import { moveDraftPR } from "#ui/pr.ts";
 import { invalidateTags } from "#ui/api/tags.ts";
 import { presentableOperation } from "#ui/snapshot.ts";
+import { sameLogin } from "#ui/review-users.ts";
 
 declare module "@tanstack/react-query" {
 	interface Register {
@@ -655,10 +656,11 @@ export const useRequestReview = (projectId: string) =>
 			ctx.client.setQueryData(key, (review) => {
 				if (review === undefined) return undefined;
 				const added = [...new Set(input.logins)]
-					.filter((login) => !review.reviewers.some((reviewer) => reviewer.login === login))
+					.filter((login) => !review.reviewers.some((reviewer) => sameLogin(reviewer.login, login)))
 					.map(
 						(login) =>
-							candidates.find((candidate) => candidate.login === login) ?? ghostForgeUser(login),
+							candidates.find((candidate) => sameLogin(candidate.login, login)) ??
+							ghostForgeUser(login),
 					);
 				return { ...review, reviewers: review.reviewers.concat(added) };
 			});

--- a/apps/lite/ui/src/review-users.ts
+++ b/apps/lite/ui/src/review-users.ts
@@ -13,6 +13,7 @@ export const isAgent = (user: ForgeReviewUser): boolean =>
  * case-insensitive, and a bot's carries the `[bot]` suffix in REST but not
  * in GraphQL; both spellings reach the app.
  */
-export const sameLogin = (a: string, b: string): boolean => bare(a) === bare(b);
+export const sameLogin = (a: string, b: string): boolean => loginKey(a) === loginKey(b);
 
-const bare = (login: string): string => login.toLowerCase().replace(/\[bot\]$/, "");
+/** The form of a login to key by, so both spellings of a bot land together. */
+export const loginKey = (login: string): string => login.toLowerCase().replace(/\[bot\]$/, "");

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestPanel.tsx
@@ -25,7 +25,7 @@ import { openLinkExternally } from "#ui/external-link.ts";
 import type { DraftPRExtras } from "#ui/pr.ts";
 import { formatAbsoluteTime, formatCompactDuration, formatRelativeTime } from "#ui/time.ts";
 import { useCopied } from "#ui/routes/project/$id/workspace/useCopied.ts";
-import { sameLogin } from "#ui/review-users.ts";
+import { loginKey, sameLogin } from "#ui/review-users.ts";
 import type {
 	CiCheck,
 	ForgeReview,
@@ -484,7 +484,7 @@ const reviewerRows = (
 	const byLogin = new Map<string, ReviewerRow>();
 	for (const submission of submissions) {
 		if (submission.author === null) continue;
-		const existing = byLogin.get(submission.author.login);
+		const existing = byLogin.get(loginKey(submission.author.login));
 		const verdict = Match.value(submission.state).pipe(
 			Match.withReturnType<ReviewerVerdict>(),
 			Match.when("approved", () => "approved"),
@@ -493,10 +493,12 @@ const reviewerRows = (
 			Match.when("dismissed", () => "commented"),
 			Match.exhaustive,
 		);
-		byLogin.set(submission.author.login, { user: submission.author, verdict });
+		byLogin.set(loginKey(submission.author.login), { user: submission.author, verdict });
 	}
-	for (const user of requested)
-		if (!byLogin.has(user.login)) byLogin.set(user.login, { user, verdict: "awaiting" });
+	for (const user of requested) {
+		const key = loginKey(user.login);
+		if (!byLogin.has(key)) byLogin.set(key, { user, verdict: "awaiting" });
+	}
 	return [...byLogin.values()];
 };
 
@@ -623,12 +625,15 @@ export const PullRequestPanel: FC<{
 			evt.currentTarget,
 			orEmptyNotice(
 				reviewerCandidates
-					// The author can't review their own PR, and whoever is listed
-					// already has been asked.
+					// The author can't review their own PR, and whoever is awaiting
+					// has been asked already; a reviewer who answered can be asked again.
 					.filter(
 						(candidate) =>
 							!(review.author !== null && sameLogin(candidate.login, review.author.login)) &&
-							!reviewerList.some(({ user }) => sameLogin(user.login, candidate.login)),
+							!reviewerList.some(
+								({ user, verdict }) =>
+									verdict === "awaiting" && sameLogin(user.login, candidate.login),
+							),
 					)
 					.map((candidate) =>
 						nativeMenuItem({

--- a/crates/but-github/src/client.rs
+++ b/crates/but-github/src/client.rs
@@ -5,8 +5,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::graphql::{
     GQL_ADD_REACTION, GQL_ADD_REVIEW_THREAD_REPLY, GQL_DISABLE_PR_AUTO_MERGE,
-    GQL_ENABLE_PR_AUTO_MERGE, GQL_GET_PR_NODE_ID, GQL_LIST_PR_REVIEW_THREADS, GQL_LIST_PR_REVIEWS,
-    GQL_LIST_PR_TIMELINE, GQL_REMOVE_REACTION, GQL_SET_PR_DRAFT, GQL_SET_PR_READY_FOR_REVIEW,
+    GQL_ENABLE_PR_AUTO_MERGE, GQL_GET_PR, GQL_GET_PR_NODE_ID, GQL_LIST_PR_REVIEW_THREADS,
+    GQL_LIST_PR_REVIEWS, GQL_LIST_PR_TIMELINE, GQL_REMOVE_REACTION, GQL_SET_PR_DRAFT,
+    GQL_SET_PR_READY_FOR_REVIEW,
 };
 
 const GITHUB_API_BASE_URL: &str = "https://api.github.com";
@@ -485,16 +486,39 @@ impl GitHubClient {
         repo: &str,
         pr_number: i64,
     ) -> Result<PullRequest> {
-        let url = format!(
-            "{}/repos/{}/{}/pulls/{}",
-            self.base_url, owner, repo, pr_number
-        );
+        #[derive(Serialize)]
+        struct Variables<'a> {
+            owner: &'a str,
+            repo: &'a str,
+            number: i64,
+        }
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Data {
+            repository: Option<Repository>,
+        }
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Repository {
+            pull_request: Option<GraphQlPullRequest>,
+        }
 
-        let response = self.client.get(&url).send().await?;
-
-        let response = ensure_success(response).await?;
-
-        let pr: GitHubPullRequest = response.json().await?;
+        let data: Data = self
+            .graphql_query(
+                GQL_GET_PR,
+                &Variables {
+                    owner,
+                    repo,
+                    number: pr_number,
+                },
+            )
+            .await?;
+        let Some(pr) = data
+            .repository
+            .and_then(|repository| repository.pull_request)
+        else {
+            bail!("GitHub GraphQL pull request {owner}/{repo}#{pr_number} not found");
+        };
         Ok(pr.into())
     }
 
@@ -2602,6 +2626,20 @@ struct GraphQlRequestedReviewer {
     name: Option<String>,
 }
 
+impl GraphQlRequestedReviewer {
+    /// The reviewer as a user; a team has no login and is dropped.
+    fn into_user(self) -> Option<GitHubUser> {
+        Some(GitHubUser {
+            id: self.database_id.unwrap_or_default(),
+            login: self.login?,
+            name: self.name,
+            email: None,
+            avatar_url: self.avatar_url,
+            is_bot: self.typename.as_deref() == Some("Bot"),
+        })
+    }
+}
+
 impl GraphQlTimelineItem {
     fn into_event(self) -> Option<PullRequestTimelineEvent> {
         match self.typename.as_str() {
@@ -2624,16 +2662,9 @@ impl GraphQlTimelineItem {
             "ReviewRequestedEvent" => Some(PullRequestTimelineEvent {
                 kind: PullRequestTimelineEventKind::ReviewRequested,
                 actor: self.actor.map(Into::into),
-                requested_reviewer: self.requested_reviewer.and_then(|reviewer| {
-                    Some(GitHubUser {
-                        id: reviewer.database_id.unwrap_or_default(),
-                        login: reviewer.login?,
-                        name: reviewer.name,
-                        email: None,
-                        avatar_url: reviewer.avatar_url,
-                        is_bot: reviewer.typename.as_deref() == Some("Bot"),
-                    })
-                }),
+                requested_reviewer: self
+                    .requested_reviewer
+                    .and_then(GraphQlRequestedReviewer::into_user),
                 commit_sha: None,
                 commit_summary: None,
                 commit_author_name: None,
@@ -2742,6 +2773,134 @@ impl From<GitHubPullRequest> for PullRequest {
             requested_reviewers,
             auto_merge_enabled: pr.auto_merge.is_some(),
         }
+    }
+}
+
+/// The single-review fetch's shape; see `GQL_GET_PR`.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GraphQlPullRequest {
+    url: String,
+    number: i64,
+    title: String,
+    body: String,
+    is_draft: bool,
+    head_ref_name: String,
+    base_ref_name: String,
+    head_ref_oid: String,
+    created_at: Option<String>,
+    updated_at: Option<String>,
+    merged_at: Option<String>,
+    closed_at: Option<String>,
+    merge_commit: Option<GraphQlCommitRef>,
+    author: Option<GraphQlActor>,
+    labels: GraphQlNodes<GraphQlLabel>,
+    head_repository: Option<GraphQlRepository>,
+    review_requests: GraphQlNodes<GraphQlReviewRequest>,
+    auto_merge_request: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GraphQlNodes<T> {
+    nodes: Vec<T>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GraphQlCommitRef {
+    oid: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GraphQlLabel {
+    name: String,
+    color: Option<String>,
+    description: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GraphQlRepository {
+    ssh_url: Option<String>,
+    url: Option<String>,
+    is_fork: bool,
+    owner: Option<GraphQlRepositoryOwner>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GraphQlRepositoryOwner {
+    login: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GraphQlReviewRequest {
+    requested_reviewer: Option<GraphQlRequestedReviewer>,
+}
+
+impl From<GraphQlPullRequest> for PullRequest {
+    fn from(pr: GraphQlPullRequest) -> Self {
+        let repo = pr.head_repository.as_ref();
+        PullRequest {
+            html_url: pr.url,
+            number: pr.number,
+            title: pr.title,
+            // REST reports a missing description as null; GraphQL as "".
+            body: Some(pr.body).filter(|body| !body.is_empty()),
+            author: pr.author.map(Into::into),
+            labels: pr
+                .labels
+                .nodes
+                .into_iter()
+                .map(|label| GitHubPrLabel {
+                    // GraphQL labels carry no numeric id, and nothing reads it.
+                    id: 0,
+                    name: label.name,
+                    description: label.description,
+                    color: label.color,
+                })
+                .collect(),
+            draft: pr.is_draft,
+            source_branch: pr.head_ref_name,
+            target_branch: pr.base_ref_name,
+            sha: pr.head_ref_oid,
+            // Only a merged pull request's merge commit counts, never the
+            // test merge GitHub keeps for an open one.
+            integration_commit_shas: if pr.merged_at.is_some() {
+                pr.merge_commit
+                    .into_iter()
+                    .map(|commit| commit.oid)
+                    .collect()
+            } else {
+                vec![]
+            },
+            created_at: pr.created_at,
+            modified_at: pr.updated_at,
+            merged_at: pr.merged_at,
+            closed_at: pr.closed_at,
+            repository_ssh_url: repo.and_then(|repo| repo.ssh_url.clone()),
+            repository_https_url: repo.and_then(|repo| repo.url.as_deref().map(clone_url)),
+            repo_owner: repo.and_then(|repo| repo.owner.as_ref().map(|owner| owner.login.clone())),
+            head_repo_is_fork: repo.is_some_and(|repo| repo.is_fork),
+            requested_reviewers: pr
+                .review_requests
+                .nodes
+                .into_iter()
+                .filter_map(|request| request.requested_reviewer)
+                .filter_map(GraphQlRequestedReviewer::into_user)
+                .collect(),
+            auto_merge_enabled: pr.auto_merge_request.is_some(),
+        }
+    }
+}
+
+/// REST's clone URL is the web URL with `.git` on the end; a forge that
+/// hands out anything but a web URL, as the e2e fake does with paths, is
+/// left alone.
+fn clone_url(url: &str) -> String {
+    if url.starts_with("https://") || url.starts_with("http://") {
+        format!("{url}.git")
+    } else {
+        url.to_string()
     }
 }
 
@@ -3108,6 +3267,92 @@ mod tests {
             pull.merged_at.as_deref(),
             Some("2026-06-24T12:00:00Z"),
             "associated-commit lookup must preserve merge state for filtering"
+        );
+    }
+
+    #[test]
+    fn graphql_pull_request_decodes_into_the_review_shape() {
+        let pr: PullRequest = serde_json::from_value::<GraphQlPullRequest>(json!({
+            "url": "https://github.com/upstream/widgets/pull/42",
+            "number": 42,
+            "title": "Integrate fork feature",
+            "body": "",
+            "isDraft": false,
+            "headRefName": "feature",
+            "baseRefName": "main",
+            "headRefOid": "1234567890abcdef1234567890abcdef12345678",
+            "createdAt": "2026-09-09T10:00:00Z",
+            "updatedAt": "2026-09-09T11:00:00Z",
+            "mergedAt": "2026-09-09T12:00:00Z",
+            "closedAt": "2026-09-09T12:00:00Z",
+            "mergeCommit": { "oid": "abcdef1234567890abcdef1234567890abcdef12" },
+            "author": {
+                "__typename": "Bot",
+                "login": "release-please[bot]",
+                "avatarUrl": null,
+                "databaseId": 7
+            },
+            "labels": { "nodes": [{ "name": "rust", "color": "b60205", "description": null }] },
+            "headRepository": {
+                "sshUrl": "git@github.com:alice/widgets.git",
+                "url": "https://github.com/alice/widgets",
+                "isFork": true,
+                "owner": { "login": "alice" }
+            },
+            "reviewRequests": { "nodes": [
+                { "requestedReviewer": {
+                    "__typename": "Bot",
+                    "databaseId": 175728472,
+                    "login": "copilot-pull-request-reviewer",
+                    "avatarUrl": "https://avatars.githubusercontent.com/in/946600?v=4"
+                } },
+                { "requestedReviewer": { "__typename": "Team" } },
+                { "requestedReviewer": null }
+            ] },
+            "autoMergeRequest": { "enabledAt": "2026-09-09T11:30:00Z" }
+        }))
+        .expect("fixture matches the query")
+        .into();
+
+        assert_eq!(pr.body, None, "an empty GraphQL body is a missing one");
+        let author = pr.author.expect("author");
+        assert!(author.is_bot);
+        assert_eq!(author.id, 7);
+        assert_eq!(pr.labels.len(), 1);
+        assert_eq!(pr.labels[0].name, "rust");
+        assert_eq!(pr.sha, "1234567890abcdef1234567890abcdef12345678");
+        assert_eq!(
+            pr.integration_commit_shas,
+            vec!["abcdef1234567890abcdef1234567890abcdef12"]
+        );
+        assert_eq!(
+            pr.repository_ssh_url.as_deref(),
+            Some("git@github.com:alice/widgets.git")
+        );
+        assert_eq!(
+            pr.repository_https_url.as_deref(),
+            Some("https://github.com/alice/widgets.git")
+        );
+        assert_eq!(pr.repo_owner.as_deref(), Some("alice"));
+        assert!(pr.head_repo_is_fork);
+        assert_eq!(pr.requested_reviewers.len(), 1, "a team has no login");
+        assert_eq!(
+            pr.requested_reviewers[0].login,
+            "copilot-pull-request-reviewer"
+        );
+        assert!(pr.requested_reviewers[0].is_bot);
+        assert!(pr.auto_merge_enabled);
+    }
+
+    #[test]
+    fn clone_url_suffixes_web_urls_only() {
+        assert_eq!(
+            clone_url("https://github.com/o/r"),
+            "https://github.com/o/r.git"
+        );
+        assert_eq!(
+            clone_url("/tmp/fixtures/fork-project-bare"),
+            "/tmp/fixtures/fork-project-bare"
         );
     }
 

--- a/crates/but-github/src/graphql.rs
+++ b/crates/but-github/src/graphql.rs
@@ -51,6 +51,80 @@ pub const GQL_GET_PR_NODE_ID: &str = r#"
 /// Commits resolve their author to a GitHub account (`author.user`), which
 /// REST's timeline never reports — without a login, "your own push" cannot
 /// be told apart from anyone else's.
+/// The single-review fetch. GraphQL is the one source that lists a bot
+/// among a pull request's requested reviewers; REST leaves them out.
+pub const GQL_GET_PR: &str = r#"
+    query PullRequest($owner: String!, $repo: String!, $number: Int!) {
+      repository(owner: $owner, name: $repo) {
+        pullRequest(number: $number) {
+          url
+          number
+          title
+          body
+          isDraft
+          headRefName
+          baseRefName
+          headRefOid
+          createdAt
+          updatedAt
+          mergedAt
+          closedAt
+          mergeCommit {
+            oid
+          }
+          author {
+            __typename
+            login
+            avatarUrl
+            ... on User {
+              databaseId
+              name
+            }
+            ... on Bot {
+              databaseId
+            }
+          }
+          labels(first: 100) {
+            nodes {
+              name
+              color
+              description
+            }
+          }
+          headRepository {
+            sshUrl
+            url
+            isFork
+            owner {
+              login
+            }
+          }
+          reviewRequests(first: 100) {
+            nodes {
+              requestedReviewer {
+                __typename
+                ... on User {
+                  databaseId
+                  login
+                  avatarUrl
+                  name
+                }
+                ... on Bot {
+                  databaseId
+                  login
+                  avatarUrl
+                }
+              }
+            }
+          }
+          autoMergeRequest {
+            enabledAt
+          }
+        }
+      }
+    }
+    "#;
+
 pub const GQL_LIST_PR_TIMELINE: &str = r#"
     query PullRequestTimeline($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
       repository(owner: $owner, name: $repo) {

--- a/e2e/playwright/src/fakeGithub.ts
+++ b/e2e/playwright/src/fakeGithub.ts
@@ -330,6 +330,23 @@ async function handleRequest(
 		return json(response, state.listed ? state.listReviews() : []);
 	}
 
+	// The single-review fetch asks GraphQL; answer it from the same record.
+	if (request.method === "POST" && url.pathname === "/api/graphql") {
+		const { query, variables } = JSON.parse(await readBody(request)) as {
+			query: string;
+			variables?: { number?: number };
+		};
+		if (!query.includes("query PullRequest(") || variables?.number === undefined) {
+			return json(response, {
+				errors: [{ message: `No fake GitHub GraphQL for ${query.slice(0, 40)}` }],
+			});
+		}
+		const review = state.getReview(variables.number);
+		return json(response, {
+			data: { repository: { pullRequest: review ? graphqlPullRequest(review) : null } },
+		});
+	}
+
 	const reviewNumber = reviewNumberFromPath(url.pathname, pullPath);
 	if (request.method === "GET" && reviewNumber !== undefined) {
 		const review = state.getReview(reviewNumber);
@@ -489,6 +506,35 @@ function pullRequestPayload(
 		merged_at: null,
 		closed_at: null,
 		requested_reviewers: [],
+	};
+}
+
+/** The REST record in the shape `GQL_GET_PR` selects. Paths stay paths. */
+function graphqlPullRequest(review: FakeGitHubReview) {
+	return {
+		url: review.html_url,
+		number: review.number,
+		title: review.title,
+		body: review.body ?? "",
+		isDraft: review.draft,
+		headRefName: review.head.ref,
+		baseRefName: review.base.ref,
+		headRefOid: review.head.sha,
+		createdAt: review.created_at,
+		updatedAt: review.updated_at,
+		mergedAt: review.merged_at,
+		closedAt: review.closed_at,
+		mergeCommit: null,
+		author: null,
+		labels: { nodes: [] },
+		headRepository: {
+			sshUrl: review.head.repo.ssh_url,
+			url: review.head.repo.clone_url,
+			isFork: review.head.repo.fork,
+			owner: { login: review.head.repo.owner.login },
+		},
+		reviewRequests: { nodes: [] },
+		autoMergeRequest: null,
 	};
 }
 


### PR DESCRIPTION
Requesting Copilot as a reviewer from Lite looked like nothing had happened: GitHub's REST API never lists a bot among a pull request's requested reviewers, so the row Lite adds when you pick someone was dropped again by the very next refetch, and Copilot only surfaced once its review arrived. GraphQL does list it.

- The single-review fetch now comes entirely from GraphQL: one query carrying everything the REST path mapped, decoded into the same review type. The listing that feeds the sidebar stays on REST.
- Mapping decisions: an empty GraphQL body is reported as missing, as REST did; the clone URL keeps REST's `.git` form; a merge commit counts only once merged; a team reviewer drops out, having no login; labels carry no numeric id in GraphQL and nothing downstream reads it. A decode test covers a bot author, a bot and a team reviewer, labels, a fork's URLs, auto-merge, a merged commit, and an empty body.
- Lite keys reviewer rows by a login form both GitHub APIs share, so the optimistic row and the fetched one are the same row, and the reviewer picker hides only reviewers still awaited, so someone who has reviewed can be asked again.

Verified against the forge through the rebuilt native module: the review for a pull request listed no reviewers, and after requesting Copilot it listed the bot, matching GitHub's own pending list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)