### PR TITLE
Fit the header, commit form and branch actions in a 260px sidebar

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.module.css
@@ -97,10 +97,22 @@
 	column-gap: 4px;
 }
 
-/* When the panel is too narrow to fit the commit button label, hide it. */
+/* The cross stands in for the label when the form is too narrow for it;
+   doubled to outrank the icon's own display. */
+.cancelIcon.cancelIcon {
+	display: none;
+}
+
+/* Too narrow for the buttons' labels: the commit button keeps its key,
+   and Cancel its cross. */
 @container (max-width: 280px) {
-	.commitButtonLabel {
+	.commitButtonLabel,
+	.cancelLabel {
 		display: none;
+	}
+
+	.cancelIcon.cancelIcon {
+		display: inline-grid;
 	}
 }
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/CommitForm.tsx
@@ -627,6 +627,7 @@ export const CommitForm: FC<{
 					<div className={styles.commitActions}>
 						<Tooltip.Root>
 							<Tooltip.Trigger
+								aria-label="Cancel"
 								className={getButtonClassName({ variant: "outline" })}
 								onClick={() => {
 									// Persist the draft before the textarea unmounts.
@@ -646,7 +647,8 @@ export const CommitForm: FC<{
 									/>
 								}
 							>
-								Cancel
+								<span className={styles.cancelLabel}>Cancel</span>
+								<Icon name="cross" className={styles.cancelIcon} />
 							</Tooltip.Trigger>
 							<Tooltip.Portal>
 								<Tooltip.Positioner sideOffset={4}>

--- a/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Row.module.css
@@ -235,6 +235,7 @@
 
 /* A row's second line: small, muted facts about the row's subject. */
 .meta {
+	container-type: inline-size;
 	display: flex;
 	align-items: center;
 	gap: 6px;
@@ -259,6 +260,13 @@
    follows, since no separator dot divides them. */
 .metaButton {
 	margin-left: 4px;
+}
+
+/* Push beside Integrate outgrows a narrow row; their arrows say it alone. */
+@container (max-width: 330px) {
+	.meta:has(> .metaButton ~ .metaButton) .metaButtonLabel {
+		display: none;
+	}
 }
 
 /* Item that yields space to its siblings by truncating its text. */

--- a/apps/lite/ui/src/routes/project/$id/workspace/SidebarHeader.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/SidebarHeader.module.css
@@ -8,6 +8,12 @@
 	.activitySpinner {
 		display: none;
 	}
+
+	/* On macOS the window controls leave the folder mark no room at the
+	   narrowest sidebar unless the gaps pull in too. */
+	.workspaceControls {
+		column-gap: 8px;
+	}
 }
 
 .workspaceControls {

--- a/apps/lite/ui/src/routes/project/$id/workspace/TopLeftControls.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/TopLeftControls.module.css
@@ -15,3 +15,10 @@
 	flex-shrink: 0;
 	width: 64px;
 }
+
+/* The header's folder mark needs the divider's room at the narrowest sidebar. */
+@container (max-width: 275px) {
+	.container::after {
+		display: none;
+	}
+}

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/BranchRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/BranchRow.tsx
@@ -659,7 +659,7 @@ export const BranchRow: FC<
 												/>
 											}
 										>
-											Push
+											<span className={rowStyles.metaButtonLabel}>Push</span>
 											{pushActivity === "pushing" ? (
 												<Icon name="spinner" />
 											) : pushesMultipleBranches ? (
@@ -698,7 +698,7 @@ export const BranchRow: FC<
 								)}
 								onClick={() => openUpdateFromRemote(dispatch, refName.fullNameBytes)}
 							>
-								Integrate
+								<span className={rowStyles.metaButtonLabel}>Integrate</span>
 								<Icon size={12} name="arrow-down" />
 							</Button>
 						)}


### PR DESCRIPTION
Fixes GB-2030: three things broke at the narrowest sidebar (260px), one screenshot each in the issue.

- **Header.** On macOS the project picker was clipped to a 7px sliver. At that width the header pulls its gaps in and drops the divider after the window controls, which leaves the folder mark its room.
- **Commit form.** Generate touched, or overlapped, Cancel. Cancel keeps a cross when the form is too narrow for labels, the way Commit already keeps only its key.
- **Branch row.** Push beside Integrate overflowed the card. A row's meta line is a size container now; when it is narrow and holds both buttons they keep their arrows alone, named by their tooltips. A row with one button keeps its label.

<table>
<tr><th></th><th width="50%">Before</th><th width="50%">After</th></tr>
<tr><td>Header</td><td><img src="https://raw.githubusercontent.com/gitbutlerapp/gitbutler/pr-screenshots/pr-15872/3eed4a510b/header-before.png" width="260"></td><td><img src="https://raw.githubusercontent.com/gitbutlerapp/gitbutler/pr-screenshots/pr-15872/3eed4a510b/header-after.png" width="260"></td></tr>
<tr><td>Commit form</td><td><img src="https://raw.githubusercontent.com/gitbutlerapp/gitbutler/pr-screenshots/pr-15872/3eed4a510b/commit-form-before.png" width="242"></td><td><img src="https://raw.githubusercontent.com/gitbutlerapp/gitbutler/pr-screenshots/pr-15872/3eed4a510b/commit-form-after.png" width="242"></td></tr>
<tr><td>Branch row</td><td><img src="https://raw.githubusercontent.com/gitbutlerapp/gitbutler/pr-screenshots/pr-15872/3eed4a510b/branch-row-before.png" width="260"></td><td><img src="https://raw.githubusercontent.com/gitbutlerapp/gitbutler/pr-screenshots/pr-15872/3eed4a510b/branch-row-after.png" width="260"></td></tr>
</table>

Captured in the dev app at 260px. No branch in that workspace had incoming commits, so the Integrate button in the branch row shots is a copy of Push with its label and arrow changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
