### PR TITLE
Make inline review comments compact and preserve literal tags

### DIFF
--- a/apps/lite/ui/src/components/Markdown.test.tsx
+++ b/apps/lite/ui/src/components/Markdown.test.tsx
@@ -11,6 +11,35 @@ const render = (markdown: string): string =>
 	);
 
 describe("Markdown safety", () => {
+	it("preserves HTML-looking inline code in review prose", () => {
+		expect(render("its wrapper `<div>` is currently exposed")).toContain(
+			"<p>its wrapper <code>&lt;div&gt;</code> is currently exposed</p>",
+		);
+	});
+
+	it("preserves lone HTML tags mentioned in prose", () => {
+		expect(render("its wrapper <div> is currently exposed")).toContain(
+			"<p>its wrapper <code>&lt;div&gt;</code> is currently exposed</p>",
+		);
+	});
+
+	it("keeps paired inline HTML as markup", () => {
+		expect(render("Press <kbd>Enter</kbd> to continue")).toContain(
+			"<p>Press <kbd>Enter</kbd> to continue</p>",
+		);
+	});
+
+	it("keeps inline HTML attributes and void elements", () => {
+		const html = render('Press <span title="key">Enter</span><br>to continue');
+		expect(html).toContain('<span title="key">Enter</span><br/>to continue');
+	});
+
+	it("preserves lone closing tags and tags inside emphasis", () => {
+		expect(render("close with </div> and use *a <span> wrapper*")).toContain(
+			"<p>close with <code>&lt;/div&gt;</code> and use <em>a <code>&lt;span&gt;</code> wrapper</em></p>",
+		);
+	});
+
 	it("renders GitHub's safe HTML subset", () => {
 		const html = render("<details><summary>More</summary>\n\nhidden *body*\n\n</details>");
 		expect(html).toContain("<details>");

--- a/apps/lite/ui/src/components/Markdown.tsx
+++ b/apps/lite/ui/src/components/Markdown.tsx
@@ -141,6 +141,41 @@ const CodeBlock: FC<{ language: string; code: string }> = ({ language, code }) =
 const fencedLanguage = (className: string | undefined): string | undefined =>
 	/language-([\w+#-]+)/.exec(className ?? "")?.[1];
 
+type MarkdownNode = {
+	type: string;
+	value?: string;
+	children?: Array<MarkdownNode>;
+};
+
+// Review prose sometimes mentions a tag without backticks. Preserve a lone
+// tag inside a paragraph before the HTML parser can split the sentence around it.
+const remarkLiteralTags = () => {
+	const visit = (node: MarkdownNode): void => {
+		if (["paragraph", "emphasis", "strong", "delete", "link"].includes(node.type)) {
+			const html = node.children?.filter((child) => child.type === "html") ?? [];
+			const markup = html.map((child) => child.value).join("");
+			for (const child of html) {
+				const match = /^<(\/?)([a-z][a-z0-9-]*)>$/i.exec(child.value ?? "");
+				if (!match) continue;
+				const [, closing, tag] = match;
+				if (
+					tag === undefined ||
+					/^(area|base|br|col|embed|hr|img|input|link|meta|param|source|track|wbr)$/i.test(tag)
+				)
+					continue;
+
+				const counterpart = new RegExp(
+					closing === "/" ? `<${tag}(?:\\s[^>]*|)>` : `</${tag}\\s*>`,
+					"i",
+				);
+				if (!counterpart.test(markup)) child.type = "inlineCode";
+			}
+		}
+		for (const child of node.children ?? []) visit(child);
+	};
+	return visit;
+};
+
 /**
  * Renders forge-flavored markdown with GitHub-parity restrictions:
  *
@@ -157,7 +192,7 @@ const fencedLanguage = (className: string | undefined): string | undefined =>
 export const Markdown: FC<{ children: string }> = ({ children }) => (
 	<div className={classes("text-13", "text-body", styles.markdown)}>
 		<ReactMarkdown
-			remarkPlugins={[remarkGfm, remarkGemoji]}
+			remarkPlugins={[remarkGfm, remarkGemoji, remarkLiteralTags]}
 			rehypePlugins={[rehypeRaw, [rehypeSanitize, sanitizeSchema]]}
 			components={{
 				a: ({ node: _node, children, ...props }) => (

--- a/apps/lite/ui/src/review-threads.test.ts
+++ b/apps/lite/ui/src/review-threads.test.ts
@@ -6,6 +6,7 @@ import {
 } from "./review-threads.ts";
 import { branchFileParent, commitFileParent } from "#ui/addresses.ts";
 import type { ForgeReviewThread } from "@gitbutler/but-sdk";
+import { DiffHunksRenderer, parsePatchFiles } from "@pierre/diffs";
 import { describe, expect, it } from "vitest";
 
 const thread = (overrides: Partial<ForgeReviewThread> = {}): ForgeReviewThread => ({
@@ -22,6 +23,61 @@ const thread = (overrides: Partial<ForgeReviewThread> = {}): ForgeReviewThread =
 });
 
 const branch = branchFileParent({ branchRef: [] });
+
+describe("inline thread row order", () => {
+	it.each(["unified", "split"] as const)(
+		"keeps %s code rows in sequence around a thread",
+		async (diffStyle) => {
+			const [patch] = parsePatchFiles(
+				[
+					"diff --git a/view.tsx b/view.tsx",
+					"--- a/view.tsx",
+					"+++ b/view.tsx",
+					"@@ -150,4 +241,5 @@",
+					" context",
+					"-old one",
+					"-old two",
+					"+new one",
+					"+new two",
+					"+<div className={styles.gap}>",
+					" end",
+					"",
+				].join("\n"),
+			);
+			const diff = patch?.files[0];
+			if (diff === undefined) throw new Error("Missing fixture diff");
+			const renderer = new DiffHunksRenderer({ diffStyle });
+			try {
+				const before = await renderer.asyncRender(diff);
+				renderer.setLineAnnotations([{ side: "additions", lineNumber: 244, metadata: undefined }]);
+				const after = await renderer.asyncRender(diff);
+				for (const key of [
+					"unifiedGutterAST",
+					"deletionsGutterAST",
+					"additionsGutterAST",
+				] as const) {
+					const codeRows = (result: typeof after) =>
+						result[key]?.filter(
+							(node) =>
+								node.type === "element" && node.properties["data-column-number"] !== undefined,
+						);
+					expect(codeRows(after)).toEqual(codeRows(before));
+				}
+				const gutter = diffStyle === "unified" ? after.unifiedGutterAST : after.additionsGutterAST;
+				if (gutter === undefined) throw new Error("Missing rendered gutter");
+				const anchor = gutter.findIndex(
+					(node) => node.type === "element" && node.properties["data-column-number"] === 244,
+				);
+				expect(gutter[anchor + 1]).toMatchObject({
+					properties: { "data-gutter-buffer": "annotation" },
+				});
+				expect(gutter[anchor + 2]).toMatchObject({ properties: { "data-column-number": 245 } });
+			} finally {
+				renderer.cleanUp();
+			}
+		},
+	);
+});
 
 describe("threadsByPathForScope", () => {
 	it("anchors an open thread on the side the forge left it", () => {

--- a/apps/lite/ui/src/routes/project/$id/workspace/DiffThreadCard.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DiffThreadCard.module.css
@@ -1,41 +1,30 @@
-/* Sits between two code lines, whose row is as wide as the widest line in
-   the file — hence the cap, which is also what the local comment card uses
-   so the two line up as siblings in the same diff. */
 .card {
 	display: flex;
 	flex-direction: column;
-	max-width: 100ch;
-	margin: 12px;
+	max-width: 640px;
+	margin: 8px 12px;
 	overflow: hidden;
-	/* The padding moved onto the sections so the header band can span the
-	   full width, the way a forge renders a review comment. */
 	border: 1px solid var(--border-3);
 	border-radius: var(--radius-card);
-	border-top-left-radius: 0;
 	background-color: var(--bg-1);
 }
 
-/* The comments, inset from the card edge the header band spans. */
 .comments {
 	display: flex;
 	flex-direction: column;
-	padding: 14px;
-	gap: 12px;
+	padding: 10px 12px 4px;
+	gap: 8px;
 }
 
-/* Reply here, everything else on the forge — the composer takes the width
-   when it unfolds, so the link stays pinned to the top of the row. */
 .footer {
 	display: flex;
-	align-items: flex-start;
-	justify-content: space-between;
-	padding: 10px 14px;
-	gap: 12px;
-	border-block-start: 1px solid var(--border-3);
-	background-color: var(--bg-2);
+	flex-wrap: wrap;
+	align-items: center;
+	padding: 0 12px 6px;
+	gap: 8px;
 
-	& > *:first-child {
-		flex: 1;
+	& > div:first-child {
+		flex-basis: 100%;
 	}
 }
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/DiffThreadCard.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/DiffThreadCard.tsx
@@ -23,7 +23,11 @@ export const DiffThreadCard: FC<Props> = ({ projectId, reviewId, thread }) => (
 	<div className={styles.card}>
 		<div className={styles.comments}>
 			{thread.comments.map((comment) => (
-				<ThreadComment comment={comment} key={comment.id !== 0 ? comment.id : comment.htmlUrl} />
+				<ThreadComment
+					compact
+					comment={comment}
+					key={comment.id !== 0 ? comment.id : comment.htmlUrl}
+				/>
 			))}
 		</div>
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestComments.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestComments.module.css
@@ -462,6 +462,21 @@
 	color: var(--text-1);
 }
 
+.compactComment {
+	gap: 4px;
+
+	& .authorLogin {
+		color: var(--text-2);
+		font-weight: normal;
+		font-size: 12px;
+	}
+
+	& .avatar {
+		width: 14px;
+		height: 14px;
+	}
+}
+
 /* A card by an agent (any bot author): tinted so automated feedback reads
    apart from human conversation at a glance. */
 .cardAgent {

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestComments.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestComments.tsx
@@ -96,11 +96,11 @@ type Quotable = { body: string | null; author: ForgeReviewUser | null };
  * agent author carries a chip so automated feedback reads apart from human
  * conversation.
  */
-const Author: FC<{ user: ForgeReviewUser }> = ({ user }) => (
+const Author: FC<{ user: ForgeReviewUser; compact?: boolean }> = ({ user, compact = false }) => (
 	<>
 		<Avatar src={user.avatarUrl} />
 		<span className={classes("text-13", "text-semibold", styles.authorLogin)}>{user.login}</span>
-		{isAgent(user) && <Badge variant="purple">Agent</Badge>}
+		{isAgent(user) && <Badge variant={compact ? "lightGray" : "purple"}>Agent</Badge>}
 	</>
 );
 
@@ -394,16 +394,19 @@ const ThreadAnchor: FC<{ thread: ForgeReviewThread }> = ({ thread }) => {
 	);
 };
 
-export const ThreadComment: FC<{ comment: ForgeReviewThreadComment }> = ({ comment }) => {
+export const ThreadComment: FC<{ comment: ForgeReviewThreadComment; compact?: boolean }> = ({
+	comment,
+	compact = false,
+}) => {
 	const createdAtMs = comment.createdAt === null ? null : Date.parse(comment.createdAt);
 
 	return (
 		<div
-			className={styles.threadComment}
+			className={classes(styles.threadComment, compact && styles.compactComment)}
 			id={comment.id > 0 ? commentAnchorId(comment.id) : undefined}
 		>
 			<div className={styles.cardIdentity}>
-				{comment.author !== null && <Author user={comment.author} />}
+				{comment.author !== null && <Author user={comment.author} compact={compact} />}
 				{createdAtMs !== null && (
 					<RelativeTime timestamp={createdAtMs} className={classes("text-12", styles.cardTime)} />
 				)}


### PR DESCRIPTION
Inline review threads now use a compact card with quieter author metadata and adjacent footer actions. Lone HTML tags in markdown prose, such as the `<div>` in the reported Copilot comment, remain visible as inline code; paired HTML and collapsible sections retain their rendering.

Adds markdown regressions and checks that annotations preserve row order in unified and split diffs. The reported ordering problem was not reproduced in the current renderer, including virtual scrolling.

Fixes GB-2016.

Validation: 42 targeted tests, 43 harness tests, and 30 E2E tests passed (9 skipped); lint, formatting, and both Knip checks passed. Full UI tests have three failures in upstream cache invalidation, and typechecking is blocked by the workspace's generated externalInvalidation watcher-type mismatch, outside this change.