### PR TITLE
Warn before workspace updates cause conflicts

### DIFF
--- a/apps/desktop/src/lib/stacks/stackInvalidation.test.ts
+++ b/apps/desktop/src/lib/stacks/stackInvalidation.test.ts
@@ -33,6 +33,7 @@ const headInfo = {
 const integrationResult = {
 	workspaceState: { headInfo, replacedCommits: {}, checkoutConflictOccurred: false },
 	worktreeConflicts: [],
+	commitConflicts: {},
 	targetCommits: null,
 } satisfies WorkspaceIntegrateUpstreamOutcome;
 

--- a/apps/lite/e2e/tests/base-update.spec.ts
+++ b/apps/lite/e2e/tests/base-update.spec.ts
@@ -1,0 +1,79 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fixtureEnvironment, paths, seedScenario } from "../setup.ts";
+import { expect, test } from "../test.ts";
+
+test.use({ scenario: "project-with-remote-branches.sh" });
+test("previews conflicted files within commits and the dirty worktree", async ({
+	appWindow,
+	electronApp,
+	testEnvironment,
+}) => {
+	test.slow();
+	execFileSync(paths.but, ["apply", "branch1"], {
+		cwd: path.join(testEnvironment.workdir, "local-clone"),
+		env: fixtureEnvironment(testEnvironment),
+	});
+	await seedScenario(
+		"project-with-remote-branches__add-conflicting-base-and-dirty-worktree.sh",
+		testEnvironment,
+	);
+	const clone = path.join(testEnvironment.workdir, "local-clone");
+	execFileSync("git", ["fetch", "origin"], {
+		cwd: clone,
+		env: fixtureEnvironment(testEnvironment),
+	});
+	const head = () =>
+		execFileSync("git", ["rev-parse", "HEAD"], { cwd: clone, encoding: "utf8" }).trim();
+	const before = head();
+	const dirty = readFileSync(path.join(clone, "a_file"), "utf8");
+	await appWindow.reload();
+	const warning = appWindow.getByRole("button", { name: "Update will cause conflicts" });
+	await expect(warning).toBeVisible();
+	await expect(appWindow.getByRole("button", { name: "Pull latest", exact: true })).toBeEnabled();
+	await warning.focus();
+	await appWindow.keyboard.press("Tab");
+	await appWindow.keyboard.press("Shift+Tab");
+	await appWindow.keyboard.press("Enter");
+	await expect(appWindow.getByRole("dialog", { name: "Base update conflicts" })).toBeVisible();
+	await expect(
+		appWindow.getByText("These files will conflict after the update", { exact: true }),
+	).toBeVisible();
+	const dialog = appWindow.getByRole("dialog", { name: "Base update conflicts" });
+	const commits = dialog.getByRole("list", { name: "Conflicted files", exact: true });
+	await expect(commits).toHaveCount(2);
+	for (const commit of await commits.all())
+		await expect(commit.getByText("a_file", { exact: true })).toBeVisible();
+
+	await expect(dialog.getByText("a_file", { exact: true })).toHaveCount(3);
+	await expect(dialog.getByRole("button")).toHaveCount(1);
+	await expect(dialog.getByText("Select a commit", { exact: false })).toHaveCount(0);
+	await appWindow.keyboard.press("Escape");
+	await expect(appWindow.getByRole("dialog", { name: "Base update conflicts" })).toBeHidden();
+	await warning.click();
+	await expect(dialog).toBeVisible();
+	await dialog.getByRole("button", { name: "Close conflict details" }).click();
+	await expect(dialog).toBeHidden();
+	// The target row and its docked copy must use the same preview and mutation.
+	await expect(
+		appWindow.getByRole("button", { name: "Update will cause conflicts", includeHidden: true }),
+	).toHaveCount(2);
+	expect(head()).toBe(before);
+	expect(readFileSync(path.join(clone, "a_file"), "utf8")).toBe(dirty);
+
+	await electronApp.evaluate(({ ipcMain }) => {
+		ipcMain.removeHandler("workspaceIntegrateUpstream");
+		ipcMain.handle(
+			"workspaceIntegrateUpstream",
+			() => new Promise((resolve) => setTimeout(resolve, 60_000)),
+		);
+	});
+	await appWindow.getByRole("button", { name: "Pull latest", exact: true }).click();
+	const pulling = appWindow.getByRole("button", { name: "Pulling…", includeHidden: true });
+	await expect(pulling).toHaveCount(2);
+	for (const button of await pulling.all()) await expect(button).toBeDisabled();
+	await expect(
+		appWindow.getByRole("button", { name: "Update will cause conflicts", includeHidden: true }),
+	).toHaveCount(0);
+});

--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/Integrate.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/Integrate.module.css
@@ -1,0 +1,110 @@
+.warning {
+	--button-fg: var(--text-warn);
+	--button-hover-fg: var(--text-warn);
+	--button-icon-opacity: 1;
+	--button-hover-icon-opacity: 1;
+}
+
+.popup {
+	width: 380px;
+	max-width: calc(100vw - 24px);
+}
+.header {
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	padding: 12px;
+	gap: 12px;
+	border-bottom: 1px solid var(--border-3);
+}
+.heading {
+	margin: 0;
+	font-weight: 600;
+	font-size: 13px;
+}
+.description {
+	margin: 4px 0 0;
+	color: var(--text-3);
+	font-size: 12px;
+	overflow-wrap: anywhere;
+}
+.target {
+	color: var(--text-2);
+}
+.details {
+	max-height: min(360px, 60vh);
+	overflow-y: auto;
+}
+.group {
+	padding: 8px 6px;
+}
+.group + .group {
+	border-top: 1px solid var(--border-3);
+}
+.branch {
+	display: flex;
+	align-items: center;
+	margin: 0;
+	padding: 4px 6px;
+	gap: 6px;
+	font-weight: 600;
+	font-size: 12px;
+}
+.branchName {
+	flex: 1;
+	min-width: 0;
+	overflow-wrap: anywhere;
+}
+.count {
+	color: var(--text-3);
+	font-weight: 400;
+}
+.list {
+	margin: 0;
+	padding: 0;
+	list-style: none;
+}
+.commit,
+.file {
+	display: flex;
+	align-items: center;
+	width: 100%;
+	padding: 7px 6px;
+	gap: 8px;
+	color: var(--text-1);
+	font-size: 12px;
+	text-align: left;
+	overflow-wrap: anywhere;
+	& [data-icon] {
+		flex-shrink: 0;
+		color: var(--text-3);
+	}
+	& code {
+		flex-shrink: 0;
+		color: var(--text-3);
+		font-size: 11px;
+	}
+}
+.commitTitle {
+	flex: 1;
+	min-width: 0;
+}
+.close:focus-visible {
+	outline: none;
+	background-color: var(--list-item-hover-bg);
+}
+.fileDescription {
+	margin: 0 6px 4px;
+	color: var(--text-3);
+	font-size: 12px;
+}
+.commitFiles {
+	margin: 0 0 6px 22px;
+}
+.file {
+	padding-block: 4px;
+	color: var(--text-2);
+	& i {
+		flex-shrink: 0;
+	}
+}

--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/Integrate.test.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/Integrate.test.tsx
@@ -1,0 +1,640 @@
+/** @vitest-environment jsdom */
+import {
+	headInfoQueryOptions,
+	workspaceTargetCommitsQueryOptions,
+	changesInWorktreeQueryOptions,
+} from "#ui/api/queries.ts";
+import type { RefInfo, WorkspaceIntegrateUpstreamOutcome } from "@gitbutler/but-sdk";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { Integrate, IntegrationStatus } from "./Integrate.tsx";
+import { useWorkspaceIntegrationPreview } from "./useWorkspaceIntegrationPreview.ts";
+import { assert } from "#ui/assert.ts";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+vi.mock("#ui/components/Kbd.tsx", () => ({ Kbd: () => null }));
+vi.mock("#ui/components/Tooltip.tsx", () => ({
+	TooltipPopup: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+const state = vi.hoisted(() => ({ pending: false, integrate: vi.fn() }));
+vi.mock("#ui/api/mutations.ts", () => ({
+	useWorkspaceIntegrateUpstream: () => ({ isPending: false, mutate: state.integrate }),
+}));
+vi.mock("#ui/projects/state.ts", () => ({
+	projectSlice: {
+		selectors: { selectPendingOperation: () => ({ _tag: state.pending ? "Some" : "None" }) },
+	},
+}));
+vi.mock("#ui/store.ts", () => ({
+	useAppSelector: (select: (state: object) => unknown) => select({}),
+}));
+
+const projectId = "test-project";
+const head = {
+	stacks: [
+		{
+			id: "stack",
+			base: "base",
+			segments: [
+				{
+					refName: { displayName: "feature/login" },
+					commits: [{ id: "local", changeId: "change", message: "Refresh sessions" }],
+					base: "base",
+				},
+			],
+		},
+	],
+	target: { isCurrent: false },
+	worktrees: [],
+} as unknown as RefInfo;
+const outcome = (conflict: boolean, worktreeConflicts: Array<string> = []) =>
+	({
+		workspaceState: {
+			headInfo: {
+				stacks: [
+					{
+						segments: [
+							{ commits: [{ id: "preview", message: "Refresh sessions", hasConflicts: conflict }] },
+						],
+					},
+				],
+			},
+			checkoutConflictOccurred: false,
+			replacedCommits: { local: "preview" },
+		},
+		commitConflicts: conflict ? { preview: ["src/session.ts", "assets/logo.png"] } : {},
+		worktreeConflicts,
+		targetCommits: null,
+	}) as unknown as WorkspaceIntegrateUpstreamOutcome;
+let client: QueryClient;
+let root: Root;
+let container: HTMLDivElement;
+const preview = vi.fn();
+const warning = () => container.querySelector('[aria-label="Update will cause conflicts"]');
+const action = () =>
+	assert(
+		Array.from(container.querySelectorAll("button")).find(
+			(button) => button.textContent === "Pull latest",
+		),
+	);
+const Control = ({ projectId }: { projectId: string }) => {
+	const preview = useWorkspaceIntegrationPreview(projectId);
+	return (
+		<>
+			<IntegrationStatus target="origin/main" preview={preview} />
+			<Integrate target="origin/main" preview={preview} />
+		</>
+	);
+};
+const render = async (id = projectId) => {
+	await act(async () => {
+		root.render(
+			<QueryClientProvider client={client}>
+				<Control projectId={id} />
+			</QueryClientProvider>,
+		);
+	});
+};
+const flush = async (ms = 350) => {
+	await act(async () => {
+		await vi.advanceTimersByTimeAsync(ms);
+	});
+};
+const reviseHead = async (id: string) => {
+	const current = structuredClone(head);
+	assert(assert(assert(current.stacks[0]).segments[0]).commits[0]).id = id;
+	await act(async () => {
+		client.setQueryData(headInfoQueryOptions(projectId).queryKey, current, {
+			updatedAt: Date.now() + 1,
+		});
+	});
+	await flush(0);
+};
+beforeEach(() => {
+	vi.useFakeTimers();
+	state.pending = false;
+	state.integrate.mockReset();
+	preview.mockReset().mockResolvedValue(outcome(true));
+	vi.stubGlobal("lite", {
+		headInfo: () => head,
+		workspaceTargetCommits: () => ({ commits: [], hasMore: false }),
+		changesInWorktree: () => ({
+			changes: [],
+			ignoredChanges: [],
+			modificationTimes: {},
+			assignments: [],
+			assignmentsError: null,
+			dependencies: null,
+			dependenciesError: null,
+		}),
+		workspaceIntegrateUpstream: preview,
+	});
+	client = new QueryClient({ defaultOptions: { queries: { retry: false, staleTime: Infinity } } });
+	client.setQueryData(headInfoQueryOptions(projectId).queryKey, head);
+	client.setQueryData(workspaceTargetCommitsQueryOptions(projectId).queryKey, {
+		commits: [],
+		hasMore: false,
+	});
+	client.setQueryData(changesInWorktreeQueryOptions(projectId).queryKey, {
+		changes: [],
+		ignoredChanges: [],
+		modificationTimes: {},
+		assignments: [],
+		assignmentsError: null,
+		dependencies: null,
+		dependenciesError: null,
+	});
+	container = document.createElement("div");
+	document.body.append(container);
+	root = createRoot(container);
+});
+afterEach(() => {
+	act(() => root.unmount());
+	client.clear();
+	container.remove();
+	vi.restoreAllMocks();
+	vi.unstubAllGlobals();
+	vi.useRealTimers();
+});
+it("warns about predicted commit conflicts without applying the update", async () => {
+	await render();
+	await flush();
+	expect(warning()).not.toBeNull();
+	expect(preview).toHaveBeenCalledWith({
+		projectId,
+		updates: [{ kind: "rebase", selector: { type: "commit", subject: "local" } }],
+		dryRun: true,
+	});
+	expect(state.integrate).not.toHaveBeenCalled();
+	act(() =>
+		Array.from(container.querySelectorAll("button"))
+			.find((button) => button.textContent === "Pull latest")
+			?.click(),
+	);
+	expect(state.integrate).toHaveBeenCalledWith({
+		projectId,
+		updates: [{ kind: "rebase", selector: { type: "commit", subject: "local" } }],
+		dryRun: false,
+	});
+});
+it("warns about predicted conflicts in dirty files", async () => {
+	preview.mockResolvedValue(outcome(false, ["file.txt"]));
+	await render();
+	await flush();
+	expect(warning()).not.toBeNull();
+});
+it("does not warn for a clean preview", async () => {
+	preview.mockResolvedValue(outcome(false));
+	await render();
+	await flush();
+	expect(warning()).toBeNull();
+});
+it.each([false, true])(
+	"allows integration without an indicator while the preview is pending (conflicts: %s)",
+	async (conflict) => {
+		let resolve!: (value: WorkspaceIntegrateUpstreamOutcome) => void;
+		preview.mockImplementation(
+			() =>
+				new Promise((done) => {
+					resolve = done;
+				}),
+		);
+		await render();
+		await flush();
+		expect(container.querySelector("output")).toBeNull();
+		expect(warning()).toBeNull();
+		expect(action().getAttribute("aria-disabled")).not.toBe("true");
+		await act(async () => resolve(outcome(conflict)));
+		await flush();
+		expect(action().textContent).toBe("Pull latest");
+		expect(action().getAttribute("aria-disabled")).not.toBe("true");
+		expect(warning() !== null).toBe(conflict);
+		expect(container.querySelector("output")).toBeNull();
+		act(() => action().click());
+		expect(state.integrate).toHaveBeenCalledOnce();
+	},
+);
+it.each(["head", "target", "worktree"] as const)(
+	"allows integration while the %s source refreshes",
+	async (source) => {
+		await render();
+		await flush();
+		const options =
+			source === "head"
+				? headInfoQueryOptions(projectId)
+				: source === "target"
+					? workspaceTargetCommitsQueryOptions(projectId)
+					: changesInWorktreeQueryOptions(projectId);
+		let resolve!: () => void;
+		const pending = new Promise<void>((done) => {
+			resolve = done;
+		});
+		if (source === "head") {
+			vi.spyOn(window.lite, "headInfo").mockReturnValue(
+				pending.then(() => assert(client.getQueryData(headInfoQueryOptions(projectId).queryKey))),
+			);
+		} else if (source === "target") {
+			vi.spyOn(window.lite, "workspaceTargetCommits").mockReturnValue(
+				pending.then(() =>
+					assert(client.getQueryData(workspaceTargetCommitsQueryOptions(projectId).queryKey)),
+				),
+			);
+		} else {
+			vi.spyOn(window.lite, "changesInWorktree").mockReturnValue(
+				pending.then(() =>
+					assert(client.getQueryData(changesInWorktreeQueryOptions(projectId).queryKey)),
+				),
+			);
+		}
+		act(() => {
+			void client.invalidateQueries({ queryKey: options.queryKey });
+		});
+		await flush();
+		expect(container.querySelector("output")).toBeNull();
+		expect(warning()).toBeNull();
+		expect(action().getAttribute("aria-disabled")).not.toBe("true");
+		act(() => action().click());
+		expect(state.integrate).toHaveBeenCalledOnce();
+		expect(preview).toHaveBeenCalledOnce();
+		await act(async () => resolve());
+		await flush();
+		expect(action().textContent).toBe("Pull latest");
+		expect(action().getAttribute("aria-disabled")).not.toBe("true");
+		expect(preview).toHaveBeenCalledTimes(2);
+	},
+);
+it("does not run previews when the base is current or an operation is pending", async () => {
+	state.pending = true;
+	await render();
+	await flush();
+	expect(preview).not.toHaveBeenCalled();
+	state.pending = false;
+	client.setQueryData(headInfoQueryOptions(projectId).queryKey, {
+		...head,
+		target: {
+			remoteTrackingRef: { fullNameBytes: [], displayName: "origin/main", remoteName: "origin" },
+			commitsAhead: 0,
+			isCurrent: true,
+		},
+	});
+	await render();
+	await flush();
+	expect(preview).not.toHaveBeenCalled();
+});
+it.each(["target", "head", "worktree"])(
+	"rechecks after %s changes and hides the old warning while waiting",
+	async (source) => {
+		await render();
+		await flush();
+		expect(warning()).not.toBeNull();
+		let resolve!: (value: WorkspaceIntegrateUpstreamOutcome) => void;
+		preview.mockImplementation(
+			() =>
+				new Promise((r) => {
+					resolve = r;
+				}),
+		);
+		await act(async () => {
+			const key =
+				source === "target"
+					? workspaceTargetCommitsQueryOptions(projectId).queryKey
+					: source === "head"
+						? headInfoQueryOptions(projectId).queryKey
+						: changesInWorktreeQueryOptions(projectId).queryKey;
+			client.setQueryData(key, (value) => value, { updatedAt: Date.now() + 100 });
+		});
+		await flush();
+		expect(warning()).toBeNull();
+		expect(container.querySelector("output")).toBeNull();
+		act(() => action().click());
+		expect(state.integrate).toHaveBeenCalledOnce();
+		await act(async () => resolve(outcome(false)));
+		await flush();
+		expect(warning()).toBeNull();
+		expect(action().textContent).toBe("Pull latest");
+		expect(action().getAttribute("aria-disabled")).not.toBe("true");
+		expect(preview).toHaveBeenCalledTimes(2);
+	},
+);
+it("shows no indicator and allows integration if the preview fails", async () => {
+	preview.mockRejectedValue(new Error("preview failed"));
+	await render();
+	await flush();
+	expect(warning()).toBeNull();
+	expect(container.querySelector("output")).toBeNull();
+	expect(action().getAttribute("aria-disabled")).not.toBe("true");
+	act(() => action().click());
+	expect(state.integrate).toHaveBeenCalledOnce();
+});
+
+it("lists each commit's predicted conflicts without offering navigation", async () => {
+	await render();
+	await flush();
+	act(() => {
+		warning()?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+	});
+	await flush();
+	const dialog = document.querySelector('[role="dialog"]');
+	expect(dialog?.textContent).toContain("feature/login");
+	const commit = Array.from(dialog?.querySelectorAll("li") ?? []).find((item) =>
+		item.textContent.includes("Refresh sessions"),
+	);
+	expect(commit?.textContent).toContain("local");
+	expect(commit?.textContent).toContain("src/session.ts");
+	expect(commit?.textContent).toContain("assets/logo.png");
+	expect(commit?.querySelector("button, a, [tabindex]")).toBeNull();
+	expect(dialog?.textContent).not.toContain("Select a commit");
+	expect(state.integrate).not.toHaveBeenCalled();
+});
+it("lists the uncommitted files that will conflict", async () => {
+	preview.mockResolvedValue(outcome(false, ["src/config.ts"]));
+	await render();
+	await flush();
+	act(() =>
+		container
+			.querySelector<HTMLButtonElement>('[aria-label="Update will cause conflicts"]')
+			?.click(),
+	);
+	await flush();
+	expect(document.body.textContent).toContain("These files will conflict after the update");
+	expect(document.body.textContent).toContain("src/config.ts");
+});
+
+it("keeps branches separate and omits clean commits", async () => {
+	const result = outcome(true);
+	const segment = result.workspaceState.headInfo.stacks[0]?.segments[0];
+	if (!segment) throw new Error("Missing fixture segment");
+	result.workspaceState.headInfo.stacks[0]?.segments.push({
+		...segment,
+		refName: { fullNameBytes: [], displayName: "fix/settings" },
+		commits: [
+			{ ...segment.commits[0], id: "unmapped", message: "Save preferences", hasConflicts: true },
+			{ ...segment.commits[0], id: "clean", message: "Clean commit", hasConflicts: false },
+		],
+	} as typeof segment);
+	result.commitConflicts = { ...result.commitConflicts, unmapped: ["src/settings.json"] };
+	preview.mockResolvedValue(result);
+	await render();
+	await flush();
+	act(() =>
+		container
+			.querySelector<HTMLButtonElement>('[aria-label="Update will cause conflicts"]')
+			?.click(),
+	);
+	await flush();
+	const groups = Array.from(document.querySelectorAll("section"));
+	expect(
+		groups.find((group) => group.textContent.includes("feature/login"))?.textContent,
+	).toContain("Refresh sessions");
+	expect(groups.find((group) => group.textContent.includes("fix/settings"))?.textContent).toContain(
+		"Save preferences",
+	);
+	const settings = groups.find((group) => group.textContent.includes("fix/settings"));
+	expect(settings?.textContent).toContain("src/settings.json");
+	expect(settings?.textContent).not.toContain("src/session.ts");
+	expect(document.body.textContent).not.toContain("Clean commit");
+	expect(
+		Array.from(document.querySelectorAll("button")).some((button) =>
+			button.textContent.includes("Save preferences"),
+		),
+	).toBe(false);
+});
+
+it.each(["head", "target", "worktree"] as const)(
+	"hides cached conflicts after a failed %s refresh and recovers on success",
+	async (source) => {
+		await render();
+		await flush();
+		expect(warning()).not.toBeNull();
+		const endpoint =
+			source === "head"
+				? "headInfo"
+				: source === "target"
+					? "workspaceTargetCommits"
+					: "changesInWorktree";
+		const options =
+			source === "head"
+				? headInfoQueryOptions(projectId)
+				: source === "target"
+					? workspaceTargetCommitsQueryOptions(projectId)
+					: changesInWorktreeQueryOptions(projectId);
+		const failure = vi
+			.spyOn(window.lite, endpoint)
+			.mockRejectedValue(new Error("Source refresh failed"));
+		await act(async () => {
+			await client.invalidateQueries({ queryKey: options.queryKey });
+		});
+		await flush();
+		expect(client.getQueryState(options.queryKey)?.status).toBe("error");
+		expect(client.getQueryData(options.queryKey)).toBeDefined();
+		expect(warning()).toBeNull();
+		expect(container.querySelector("output")).toBeNull();
+		expect(action().getAttribute("aria-disabled")).not.toBe("true");
+		failure.mockRestore();
+		await act(async () => {
+			await client.invalidateQueries({ queryKey: options.queryKey });
+		});
+		await flush();
+		expect(warning()).not.toBeNull();
+		expect(action().textContent).toBe("Pull latest");
+	},
+);
+
+it("keeps the popup closed after refreshing an open conflict preview", async () => {
+	await render();
+	await flush();
+	act(() => {
+		(warning() as HTMLButtonElement).click();
+	});
+	await flush();
+	expect(document.querySelector('[role="dialog"]')).not.toBeNull();
+	let resolve!: (value: WorkspaceIntegrateUpstreamOutcome) => void;
+	preview.mockImplementation(
+		() =>
+			new Promise((r) => {
+				resolve = r;
+			}),
+	);
+	await act(async () => {
+		client.setQueryData(headInfoQueryOptions(projectId).queryKey, (value) => value, {
+			updatedAt: Date.now() + 100,
+		});
+	});
+	await flush();
+	expect(warning()).toBeNull();
+	expect(document.querySelector('[role="dialog"]')).toBeNull();
+	await act(async () => resolve(outcome(true)));
+	await flush();
+	expect(warning()).not.toBeNull();
+	expect(document.querySelector('[role="dialog"]')).toBeNull();
+	act(() => {
+		(warning() as HTMLButtonElement).click();
+	});
+	await flush();
+	expect(document.querySelector('[role="dialog"]')).not.toBeNull();
+	act(() => {
+		document.querySelector<HTMLButtonElement>('[aria-label="Close conflict details"]')?.click();
+	});
+	await flush();
+	expect(document.querySelector('[role="dialog"]')).toBeNull();
+});
+
+it.each(["current", "preview"] as const)(
+	"attributes anonymous %s segments to the next named branch below",
+	async (source) => {
+		const current = structuredClone(head);
+		const result = outcome(true);
+		if (source === "preview") result.workspaceState.replacedCommits = {};
+		const stack = (source === "current" ? current : result.workspaceState.headInfo).stacks[0];
+		const segment = stack?.segments[0];
+		if (!stack || !segment) throw new Error("Missing fixture segment");
+		stack.segments = [
+			{ ...segment, refName: { fullNameBytes: [], displayName: "unrelated/above" }, commits: [] },
+			{ ...segment, refName: null },
+			{ ...segment, refName: null, commits: [] },
+			{ ...segment, refName: { fullNameBytes: [], displayName: "feature/login" }, commits: [] },
+		];
+		client.setQueryData(headInfoQueryOptions(projectId).queryKey, current);
+		preview.mockResolvedValue(result);
+		await render();
+		await flush();
+		act(() => {
+			(warning() as HTMLButtonElement).click();
+		});
+		await flush();
+		const dialog = document.querySelector('[role="dialog"]');
+		expect(dialog?.textContent).toContain("feature/login");
+		expect(dialog?.textContent).toContain("Refresh sessions");
+		expect(dialog?.textContent).not.toContain("Unnamed branch");
+		expect(dialog?.textContent).not.toContain("unrelated/above");
+	},
+);
+
+it("combines rapid revisions into one preview of the latest state", async () => {
+	await render();
+	for (const id of ["first", "second", "latest"]) {
+		await flush(50);
+		await reviseHead(id);
+	}
+	expect(preview).not.toHaveBeenCalled();
+	await flush();
+	expect(preview).toHaveBeenCalledOnce();
+	expect(preview).toHaveBeenLastCalledWith({
+		projectId,
+		updates: [{ kind: "rebase", selector: { type: "commit", subject: "latest" } }],
+		dryRun: true,
+	});
+});
+
+it.each([false, true])(
+	"runs only the newest waiting preview after the active call settles (failure: %s)",
+	async (failed) => {
+		const active = Promise.withResolvers<WorkspaceIntegrateUpstreamOutcome>();
+		preview.mockImplementationOnce(() => active.promise);
+		try {
+			await render();
+			await flush();
+			expect(preview).toHaveBeenCalledOnce();
+			for (const id of ["first", "second", "latest"]) {
+				await reviseHead(id);
+				await flush();
+			}
+			expect(preview).toHaveBeenCalledOnce();
+			expect(warning()).toBeNull();
+			await act(async () => {
+				if (failed) active.reject(new Error("Old preview failed"));
+				else active.resolve(outcome(false));
+			});
+			await flush();
+			expect(preview).toHaveBeenCalledTimes(2);
+			expect(preview).toHaveBeenLastCalledWith({
+				projectId,
+				updates: [{ kind: "rebase", selector: { type: "commit", subject: "latest" } }],
+				dryRun: true,
+			});
+			expect(warning()).not.toBeNull();
+		} finally {
+			await act(async () => active.resolve(outcome(false)));
+		}
+	},
+);
+
+it("drops a waiting preview when a source refresh starts", async () => {
+	const source = Promise.withResolvers<RefInfo>();
+	vi.spyOn(window.lite, "headInfo").mockReturnValue(source.promise);
+	await render();
+	await flush(50);
+	act(() => {
+		void client.invalidateQueries({ queryKey: headInfoQueryOptions(projectId).queryKey });
+	});
+	await flush();
+	expect(preview).not.toHaveBeenCalled();
+	await act(async () => source.resolve(head));
+	await flush();
+	expect(preview).toHaveBeenCalledOnce();
+});
+
+it.each(["unmount", "operation", "integrate"] as const)(
+	"drops a waiting preview on %s",
+	async (reason) => {
+		await render();
+		await flush(50);
+		if (reason === "unmount") {
+			act(() => root.render(null));
+		} else if (reason === "operation") {
+			state.pending = true;
+			await render();
+		} else {
+			act(() => action().click());
+			expect(state.integrate).toHaveBeenCalledOnce();
+		}
+		await flush();
+		expect(preview).not.toHaveBeenCalled();
+	},
+);
+
+it("drops queued previews when Integrate is clicked during an active check", async () => {
+	const active = Promise.withResolvers<WorkspaceIntegrateUpstreamOutcome>();
+	preview.mockImplementationOnce(() => active.promise);
+	try {
+		await render();
+		await flush();
+		await reviseHead("latest");
+		await flush();
+		act(() => action().click());
+		expect(state.integrate).toHaveBeenCalledOnce();
+		await act(async () => active.resolve(outcome(false)));
+		await flush();
+		expect(preview).toHaveBeenCalledOnce();
+	} finally {
+		await act(async () => active.resolve(outcome(false)));
+	}
+});
+
+it("keeps active checks across project switches without blocking other projects", async () => {
+	const active = Promise.withResolvers<WorkspaceIntegrateUpstreamOutcome>();
+	preview.mockImplementationOnce(() => active.promise);
+	try {
+		await render();
+		await flush();
+		expect(preview).toHaveBeenCalledOnce();
+		await render("other-project");
+		await flush();
+		await flush();
+		expect(preview).toHaveBeenCalledTimes(2);
+		expect(preview).toHaveBeenLastCalledWith(
+			expect.objectContaining({ projectId: "other-project" }),
+		);
+		await render();
+		await flush();
+		expect(preview).toHaveBeenCalledTimes(2);
+		await act(async () => active.resolve(outcome(false)));
+		await flush();
+		expect(preview).toHaveBeenCalledTimes(3);
+		expect(preview).toHaveBeenLastCalledWith(expect.objectContaining({ projectId }));
+	} finally {
+		await act(async () => active.resolve(outcome(false)));
+	}
+});

--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/Integrate.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/Integrate.tsx
@@ -1,0 +1,143 @@
+import { TooltipPopup } from "#ui/components/Tooltip.tsx";
+import { getRowButtonClassName } from "#ui/routes/project/$id/workspace/Row-utils.ts";
+import { Button, Popover, Tooltip } from "@base-ui/react";
+import type { FC } from "react";
+import { Dropdown } from "#ui/components/Popup.tsx";
+import { FileIcon } from "#ui/components/FileIcon.tsx";
+import { classes } from "#ui/components/classes.ts";
+import { getButtonClassName } from "#ui/components/Button.tsx";
+import { Icon } from "#ui/components/Icon.tsx";
+import styles from "./Integrate.module.css";
+import type { useWorkspaceIntegrationPreview } from "./useWorkspaceIntegrationPreview.ts";
+
+export const IntegrationStatus: FC<{
+	target: string;
+	preview: ReturnType<typeof useWorkspaceIntegrationPreview>;
+}> = ({ target, preview }) => {
+	const { conflicts } = preview;
+	if (
+		conflicts === undefined ||
+		(conflicts.files.length === 0 && conflicts.branches.length === 0 && !conflicts.checkoutConflict)
+	)
+		return null;
+	return (
+		<Dropdown
+			className={styles.popup}
+			aria-label="Base update conflicts"
+			trigger={
+				<button
+					type="button"
+					className={classes(
+						getRowButtonClassName({ variant: "ghost", iconOnly: true }),
+						styles.warning,
+					)}
+					aria-label="Update will cause conflicts"
+				>
+					<Icon name="warning" />
+				</button>
+			}
+		>
+			<div className={styles.header}>
+				<div>
+					<h3 className={styles.heading}>Update conflicts</h3>
+					<p className={styles.description}>
+						From <span className={styles.target}>{target}</span>
+					</p>
+				</div>
+				<Popover.Close
+					type="button"
+					aria-label="Close conflict details"
+					className={classes(
+						getButtonClassName({ variant: "ghost", size: "small", iconOnly: true }),
+						styles.close,
+					)}
+				>
+					<Icon name="cross" />
+				</Popover.Close>
+			</div>
+			<div className={styles.details}>
+				{conflicts.branches.map((branch) => (
+					<section key={branch.name} className={styles.group}>
+						<h4 className={styles.branch}>
+							<Icon name="branch" />
+							<span className={styles.branchName}>{branch.name}</span>
+							<span className={styles.count}>{branch.commits.length}</span>
+						</h4>
+						<ul className={styles.list}>
+							{branch.commits.map((commit) => (
+								<li key={commit.id}>
+									<div className={styles.commit}>
+										<Icon name="commit" />
+										<span className={styles.commitTitle}>{commit.title}</span>
+										<code>{commit.id.slice(0, 7)}</code>
+									</div>
+									<ul
+										className={classes(styles.list, styles.commitFiles)}
+										aria-label="Conflicted files"
+									>
+										{commit.files.map((file) => (
+											<li className={styles.file} key={file}>
+												<FileIcon fileName={file.slice(file.lastIndexOf("/") + 1)} />
+												<span>{file}</span>
+											</li>
+										))}
+									</ul>
+								</li>
+							))}
+						</ul>
+					</section>
+				))}
+				{conflicts.files.length > 0 && (
+					<section className={styles.group}>
+						<h4 className={styles.branch}>
+							<Icon name="file" />
+							<span className={styles.branchName}>Uncommitted files</span>
+							<span className={styles.count}>{conflicts.files.length}</span>
+						</h4>
+						<p className={styles.fileDescription}>These files will conflict after the update</p>
+						<ul className={styles.list}>
+							{conflicts.files.map((file) => (
+								<li className={styles.file} key={file}>
+									<FileIcon fileName={file.slice(file.lastIndexOf("/") + 1)} />
+									<span>{file}</span>
+								</li>
+							))}
+						</ul>
+					</section>
+				)}
+				{conflicts.checkoutConflict && (
+					<p className={styles.description}>
+						The updated branches also conflict when combined in the workspace
+					</p>
+				)}
+			</div>
+		</Dropdown>
+	);
+};
+
+/** Rebases every stack onto the target's fetched tip; this does not fetch. */
+export const Integrate: FC<{
+	target: string;
+	preview: ReturnType<typeof useWorkspaceIntegrationPreview>;
+}> = ({ target, preview }) => {
+	const { enabled, isPending, rebase } = preview;
+	return (
+		<Tooltip.Root>
+			<Tooltip.Trigger
+				className={getRowButtonClassName({ variant: "outline" })}
+				onClick={rebase}
+				// `disabled` goes on the button so the tooltip still opens over it.
+				render={<Button focusableWhenDisabled disabled={!enabled} />}
+			>
+				{isPending ? "Pulling…" : "Pull latest"}
+			</Tooltip.Trigger>
+			<Tooltip.Portal>
+				<Tooltip.Positioner sideOffset={4}>
+					<Tooltip.Popup render={<TooltipPopup />}>
+						Pull the latest from {target} into the workspace base
+					</Tooltip.Popup>
+				</Tooltip.Positioner>
+			</Tooltip.Portal>
+		</Tooltip.Root>
+	);
+};

--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/Section.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/Section.tsx
@@ -16,17 +16,12 @@ import { useAddressSpace } from "#ui/routes/project/$id/workspace/WorkspaceLists
 import { addressIdentityKey, type Address } from "#ui/addresses.ts";
 import type { AddressSpace } from "#ui/workspace/address-space.ts";
 import type { TargetCommit } from "@gitbutler/but-sdk";
-import { useWorkspaceIntegrateUpstream } from "#ui/api/mutations.ts";
-import { headInfoQueryOptions } from "#ui/api/queries.ts";
-import { stackBottomRelativeTo } from "#ui/api/stack.ts";
-import { projectSlice } from "#ui/projects/state.ts";
-import { useAppSelector } from "#ui/store.ts";
 import { TooltipPopup } from "#ui/components/Tooltip.tsx";
 import { Button, Tooltip } from "@base-ui/react";
-import type { BottomUpdate } from "@gitbutler/but-sdk";
-import { useQuery } from "@tanstack/react-query";
 import { type FC, type ReactNode, type RefObject, useRef, useState } from "react";
 import styles from "./Section.module.css";
+import { Integrate, IntegrationStatus } from "./Integrate.tsx";
+import { useWorkspaceIntegrationPreview } from "./useWorkspaceIntegrationPreview.ts";
 import { TargetCommitRow } from "./TargetCommitRow.tsx";
 import { LEG_GAP, type Plan, type Run, targetCommitAddress } from "./layout.ts";
 
@@ -80,6 +75,7 @@ const Caption: FC<{ className?: string; hint: ReactNode; children: ReactNode }> 
 /** A header row: not a value. With a fold, the rail's toggle opens it, as on the rows above. */
 const Header: FC<{
 	label: string;
+	status?: ReactNode;
 	/** Beside the label, in the label's own line: a count, or a note. */
 	caption?: ReactNode;
 	/** The fold the header opens; none for a plain row. Its chevron swaps in for the glyph on hover, unless the glyph is one. */
@@ -90,7 +86,7 @@ const Header: FC<{
 	toolbar?: ReactNode;
 	className?: string;
 	children?: ReactNode;
-}> = ({ label, caption, fold, rail, toolbar, className, children }) => (
+}> = ({ label, status, caption, fold, rail, toolbar, className, children }) => (
 	<Row interactive={false} className={className}>
 		{fold === undefined ? (
 			rail
@@ -104,6 +100,7 @@ const Header: FC<{
 			/>
 		)}
 		<RowLabelContainer>
+			{status}
 			<RowLabel heading singleLine>
 				{label}
 				{caption}
@@ -192,32 +189,6 @@ const Fetch: FC<{ projectId: string }> = ({ projectId }) => {
 	);
 };
 
-/** Rebases every stack onto the target's fetched tip; this does not fetch. */
-const Pull: FC<{ target: string; enabled: boolean; isPending: boolean; onPull: () => void }> = ({
-	target,
-	enabled,
-	isPending,
-	onPull,
-}) => (
-	<Tooltip.Root>
-		<Tooltip.Trigger
-			className={getRowButtonClassName({ variant: "outline" })}
-			onClick={onPull}
-			// `disabled` goes on the button so the tooltip still opens over it.
-			render={<Button focusableWhenDisabled disabled={!enabled} />}
-		>
-			{isPending ? "Pulling…" : "Pull latest"}
-		</Tooltip.Trigger>
-		<Tooltip.Portal>
-			<Tooltip.Positioner sideOffset={4}>
-				<Tooltip.Popup render={<TooltipPopup />}>
-					Pull the latest from {target} into the workspace base
-				</Tooltip.Popup>
-			</Tooltip.Positioner>
-		</Tooltip.Portal>
-	</Tooltip.Root>
-);
-
 export const Section: FC<{
 	projectId: string;
 	plan: Plan;
@@ -228,22 +199,7 @@ export const Section: FC<{
 	scrollElementRef: RefObject<HTMLDivElement | null>;
 }> = ({ projectId, plan, onToggleIncoming, onShowMoreRun, onFoldRun, scrollElementRef }) => {
 	const addressSpace = useAddressSpace();
-	// One mutation for the row and its docked stand-in: each rendering its own
-	// would leave the other's button enabled while a pull runs.
-	const { data: headInfo } = useQuery(headInfoQueryOptions(projectId));
-	const noOperationPending = useAppSelector(
-		(state) => projectSlice.selectors.selectPendingOperation(state, projectId)._tag === "None",
-	);
-	const { isPending: isPulling, mutate: integrate } = useWorkspaceIntegrateUpstream();
-	const pull = () => {
-		const updates = (headInfo?.stacks ?? [])
-			.values()
-			.map(stackBottomRelativeTo)
-			.filter((relativeTo) => relativeTo != null)
-			.map((relativeTo): BottomUpdate => ({ kind: "rebase", selector: relativeTo }))
-			.toArray();
-		integrate({ projectId, updates, dryRun: false });
-	};
+	const preview = useWorkspaceIntegrationPreview(projectId);
 	// Opening from docked: scroll to the bottom and hold it while the fold grows.
 	const incomingFold = useRef<HTMLDivElement>(null);
 	const incomingRows = useRef<HTMLDivElement>(null);
@@ -271,6 +227,7 @@ export const Section: FC<{
 	const header = (docked = false) => (
 		<Header
 			label={target.label}
+			status={!target.current && <IntegrationStatus target={target.label} preview={preview} />}
 			caption={
 				branched ? (
 					<Caption
@@ -317,14 +274,7 @@ export const Section: FC<{
 			toolbar={<Fetch projectId={projectId} />}
 			className={docked ? styles.docked : undefined}
 		>
-			{!target.current && (
-				<Pull
-					target={target.label}
-					enabled={noOperationPending && !isPulling}
-					isPending={isPulling}
-					onPull={pull}
-				/>
-			)}
+			{!target.current && <Integrate target={target.label} preview={preview} />}
 		</Header>
 	);
 	// With the target moved on, its incoming commits sit on a leg that starts

--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/useWorkspaceIntegrationPreview.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/useWorkspaceIntegrationPreview.ts
@@ -1,0 +1,177 @@
+import { useWorkspaceIntegrateUpstream } from "#ui/api/mutations.ts";
+import {
+	changesInWorktreeQueryOptions,
+	workspaceTargetCommitsQueryOptions,
+	headInfoQueryOptions,
+} from "#ui/api/queries.ts";
+import { stackBottomRelativeTo } from "#ui/api/stack.ts";
+import { projectSlice } from "#ui/projects/state.ts";
+import { useAppSelector } from "#ui/store.ts";
+import type { BottomUpdate, RefInfo, WorkspaceIntegrateUpstreamOutcome } from "@gitbutler/but-sdk";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { commitTitle } from "#ui/commit.ts";
+
+type ConflictCommit = { id: string; title: string; files: Array<string> };
+
+// IPC cannot cancel a running native call. Keep it registered until it settles,
+// even if its query has been cancelled, so later revisions don't queue native work.
+const activePreviews = new Map<string, Promise<WorkspaceIntegrateUpstreamOutcome>>();
+const previewUpstreamConflicts = async (
+	projectId: string,
+	updates: Array<BottomUpdate>,
+	signal: AbortSignal,
+) => {
+	signal.throwIfAborted();
+	await new Promise<void>((resolve, reject) => {
+		const onAbort = () => {
+			clearTimeout(timer);
+			reject(signal.reason);
+		};
+		const timer = setTimeout(() => {
+			signal.removeEventListener("abort", onAbort);
+			resolve();
+		}, 200);
+		signal.addEventListener("abort", onAbort, { once: true });
+	});
+	let active = activePreviews.get(projectId);
+	while (active !== undefined) {
+		await active.catch(() => undefined);
+		signal.throwIfAborted();
+		active = activePreviews.get(projectId);
+	}
+	signal.throwIfAborted();
+	const request = window.lite.workspaceIntegrateUpstream({ projectId, updates, dryRun: true });
+	activePreviews.set(projectId, request);
+	try {
+		return await request;
+	} finally {
+		activePreviews.delete(projectId);
+	}
+};
+
+const conflictSummary = (result: WorkspaceIntegrateUpstreamOutcome, head: RefInfo | undefined) => {
+	const current = new Map<string, { branch: string; commit: Omit<ConflictCommit, "files"> }>();
+	for (const stack of head?.stacks ?? []) {
+		for (const [index, segment] of stack.segments.entries()) {
+			if (segment.commits.length === 0) continue;
+			const named = segment.refName
+				? segment
+				: stack.segments.slice(index + 1).find((below) => below.refName !== null);
+			const branchName = named?.refName?.displayName ?? "Unnamed branch";
+			for (const commit of segment.commits) {
+				current.set(result.workspaceState.replacedCommits[commit.id] ?? commit.id, {
+					branch: branchName,
+					commit: {
+						id: commit.id,
+						title: commitTitle(commit.message) ?? "(no message)",
+					},
+				});
+			}
+		}
+	}
+	const branches = new Map<string, Array<ConflictCommit>>();
+	for (const stack of result.workspaceState.headInfo.stacks) {
+		for (const [index, segment] of stack.segments.entries()) {
+			if (segment.commits.length === 0) continue;
+			const named = segment.refName
+				? segment
+				: stack.segments.slice(index + 1).find((below) => below.refName !== null);
+			const branchName = named?.refName?.displayName ?? "Unnamed branch";
+			for (const commit of segment.commits) {
+				if (!commit.hasConflicts) continue;
+				const original = current.get(commit.id);
+				const branch = original?.branch ?? branchName;
+				const commits = branches.get(branch) ?? [];
+				commits.push({
+					...(original?.commit ?? {
+						id: commit.id,
+						title: commitTitle(commit.message) ?? "(no message)",
+					}),
+					files: result.commitConflicts[commit.id] ?? [],
+				});
+				branches.set(branch, commits);
+			}
+		}
+	}
+	return {
+		branches: Array.from(branches, ([name, commits]) => ({ name, commits })),
+		files: result.worktreeConflicts,
+		checkoutConflict: result.workspaceState.checkoutConflictOccurred,
+	};
+};
+
+/** Share the preview and mutation between the target row and its docked copy. */
+export const useWorkspaceIntegrationPreview = (projectId: string) => {
+	const client = useQueryClient();
+	const {
+		data: headInfo,
+		dataUpdatedAt: headRevision,
+		isFetching: headFetching,
+		isError: headFailed,
+	} = useQuery(headInfoQueryOptions(projectId));
+	const {
+		dataUpdatedAt: targetRevision,
+		isFetching: targetFetching,
+		isError: targetFailed,
+	} = useQuery(workspaceTargetCommitsQueryOptions(projectId));
+	const {
+		dataUpdatedAt: worktreeRevision,
+		isFetching: worktreeFetching,
+		isError: worktreeFailed,
+	} = useQuery(changesInWorktreeQueryOptions(projectId));
+	const noOperationPending = useAppSelector(
+		(state) => projectSlice.selectors.selectPendingOperation(state, projectId)._tag === "None",
+	);
+	const { isPending, mutate: integrate } = useWorkspaceIntegrateUpstream();
+	const updates = (headInfo?.stacks ?? [])
+		.map(stackBottomRelativeTo)
+		.filter((relativeTo) => relativeTo != null)
+		.map((relativeTo): BottomUpdate => ({ kind: "rebase", selector: relativeTo }));
+	const enabled = noOperationPending && headInfo?.target?.isCurrent === false && !isPending;
+	const sourcesFetching = headFetching || targetFetching || worktreeFetching;
+	const sourcesFailed = headFailed || targetFailed || worktreeFailed;
+	const previewEnabled =
+		enabled &&
+		headRevision > 0 &&
+		targetRevision > 0 &&
+		worktreeRevision > 0 &&
+		!sourcesFetching &&
+		!sourcesFailed;
+	const {
+		data: conflicts,
+		isFetching: previewFetching,
+		isError: previewFailed,
+	} = useQuery({
+		queryKey: [
+			projectId,
+			"dryRun",
+			"workspaceIntegrateUpstream",
+			updates,
+			headRevision,
+			targetRevision,
+			worktreeRevision,
+			// Detach and abort waiting work when a source refresh or an operation starts.
+			previewEnabled,
+		],
+		queryFn: ({ signal }) => previewUpstreamConflicts(projectId, updates, signal),
+		enabled: previewEnabled,
+		// The preview takes the repository lock. Recheck when source data changes, not on focus.
+		staleTime: Infinity,
+		refetchOnWindowFocus: false,
+		retry: false,
+		gcTime: 10_000,
+		select: (result) => conflictSummary(result, headInfo),
+	});
+	const previewReady =
+		previewEnabled && !previewFetching && !previewFailed && conflicts !== undefined;
+	const rebase = () => {
+		void client.cancelQueries({ queryKey: [projectId, "dryRun", "workspaceIntegrateUpstream"] });
+		integrate({ projectId, updates, dryRun: false });
+	};
+	return {
+		conflicts: previewReady ? conflicts : undefined,
+		enabled,
+		isPending,
+		rebase,
+	};
+};

--- a/crates/but-api/src/workspace.rs
+++ b/crates/but-api/src/workspace.rs
@@ -1,7 +1,7 @@
 //! Functions that operate on the workspace.
 
 use std::{
-    collections::HashSet,
+    collections::{BTreeMap, HashSet},
     time::{SystemTime, UNIX_EPOCH},
 };
 
@@ -495,6 +495,8 @@ pub struct WorkspaceIntegrateUpstreamOutcome {
     pub target_commits: Option<crate::target_commits::TargetCommitPage>,
     /// Dirty worktree paths that would conflict when applied onto the resulting workspace head.
     pub worktree_conflicts: Vec<BStringForFrontend>,
+    /// Conflicted paths by resulting commit ID, for both previews and applied updates.
+    pub commit_conflicts: BTreeMap<gix::ObjectId, Vec<BStringForFrontend>>,
 }
 
 /// JSON transport types for workspace APIs.
@@ -595,6 +597,13 @@ pub mod json {
         /// Dirty worktree paths that would conflict when applied onto the resulting workspace head.
         #[cfg_attr(feature = "export-schema", schemars(with = "Vec<String>"))]
         pub worktree_conflicts: Vec<BStringForFrontend>,
+        /// Conflicted paths by resulting commit ID, for both previews and applied updates.
+        #[cfg_attr(
+            feature = "export-schema",
+            schemars(with = "std::collections::BTreeMap<String, Vec<String>>")
+        )]
+        pub commit_conflicts:
+            std::collections::BTreeMap<crate::json::HexHash, Vec<BStringForFrontend>>,
     }
 
     #[cfg(feature = "export-schema")]
@@ -608,6 +617,11 @@ pub mod json {
                 workspace_state: value.workspace_state.try_into()?,
                 target_commits: value.target_commits,
                 worktree_conflicts: value.worktree_conflicts,
+                commit_conflicts: value
+                    .commit_conflicts
+                    .into_iter()
+                    .map(|(id, paths)| (id.into(), paths))
+                    .collect(),
             })
         }
     }
@@ -832,7 +846,7 @@ pub fn workspace_integrate_upstream_only_with_perm(
 ) -> anyhow::Result<WorkspaceIntegrateUpstreamOutcome> {
     let mut meta = ctx.meta()?;
     let single_branch_mode = ctx.settings.feature_flags.single_branch;
-    let (workspace_state, worktree_conflicts) = {
+    let (workspace_state, worktree_conflicts, commit_conflicts) = {
         let project_meta = ctx.project_meta()?;
         let (repo, mut ws, mut db) = ctx.workspace_mut_and_db_mut_with_perm(perm)?;
         let review_hints = match forge_review_integration_hints(&ws, &project_meta, &db) {
@@ -869,9 +883,11 @@ pub fn workspace_integrate_upstream_only_with_perm(
             // The preview was projected against the new target; the cached workspace,
             // which the next caller of this context reuses, has not moved.
             rebase.project_meta_mut().target_commit_id = cached_target;
+            let commit_conflicts = workspace_commit_conflicts(rebase.repo(), &workspace_state)?;
             return Ok(WorkspaceIntegrateUpstreamOutcome {
                 workspace_state,
                 target_commits: None,
+                commit_conflicts,
                 worktree_conflicts,
             });
         }
@@ -896,7 +912,8 @@ pub fn workspace_integrate_upstream_only_with_perm(
         }
 
         let workspace_state = WorkspaceState::from_materialized(materialized, &repo)?;
-        (workspace_state, worktree_conflicts)
+        let commit_conflicts = workspace_commit_conflicts(&repo, &workspace_state)?;
+        (workspace_state, worktree_conflicts, commit_conflicts)
     };
     ctx.invalidate_workspace_cache()?;
 
@@ -916,7 +933,62 @@ pub fn workspace_integrate_upstream_only_with_perm(
         })
         .ok(),
         worktree_conflicts,
+        commit_conflicts,
     })
+}
+
+/// Read conflicted paths from the resulting workspace, while any preview objects are still available.
+fn workspace_commit_conflicts(
+    repo: &gix::Repository,
+    workspace: &WorkspaceState,
+) -> anyhow::Result<BTreeMap<gix::ObjectId, Vec<BStringForFrontend>>> {
+    use gix::prelude::ObjectIdExt;
+
+    #[cfg(not(feature = "graph-workspace"))]
+    let commits = workspace
+        .head_info
+        .stacks
+        .iter()
+        .flat_map(|stack| &stack.segments)
+        .flat_map(|segment| &segment.commits)
+        .filter(|commit| commit.has_conflicts)
+        .map(|commit| commit.id);
+    #[cfg(feature = "graph-workspace")]
+    let commits = workspace
+        .graph_workspace
+        .stacks
+        .iter()
+        .flat_map(|stack| &stack.rows)
+        .filter_map(|row| match &row.data {
+            but_workspace::ui::workspace::DetailedGraphRowData::Commit(commit)
+                if commit.has_conflicts =>
+            {
+                Some(commit.id)
+            }
+            _ => None,
+        });
+
+    let mut conflicts = BTreeMap::new();
+    for id in commits {
+        if conflicts.contains_key(&id) {
+            continue;
+        }
+        let Some(entries) = but_core::Commit::from_id(id.attach(repo))?.conflict_entries()? else {
+            continue;
+        };
+        // Include every stage: delete and rename conflicts may have no path on one side.
+        let mut paths: Vec<BStringForFrontend> = entries
+            .ancestor_entries
+            .into_iter()
+            .chain(entries.our_entries)
+            .chain(entries.their_entries)
+            .map(|path| gix::path::into_bstr(path).into_owned().into())
+            .collect();
+        paths.sort();
+        paths.dedup();
+        conflicts.insert(id, paths);
+    }
+    Ok(conflicts)
 }
 
 #[cfg(test)]

--- a/crates/but-api/tests/api/main.rs
+++ b/crates/but-api/tests/api/main.rs
@@ -18,4 +18,5 @@ mod resolve_ai;
 mod resolve_hunks;
 mod support;
 mod target_commits;
+mod workspace_integrate;
 mod worktrees;

--- a/crates/but-api/tests/api/workspace_integrate.rs
+++ b/crates/but-api/tests/api/workspace_integrate.rs
@@ -1,0 +1,125 @@
+use but_core::{DryRun, ref_metadata::ProjectMeta};
+use but_testsupport::{CommandExt, git_at_dir, open_repo};
+
+use crate::support::write_file;
+
+#[test]
+fn integration_reports_conflicted_files_before_preview_objects_disappear() -> anyhow::Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let dir = tmp.path();
+    git_at_dir(dir).args(["init", "-b", "main"]).run();
+    for (path, content) in [
+        ("session.ts", "base\n"),
+        ("logo.png", "base\0image"),
+        ("deleted.md", "Original documentation\nSecond paragraph\n"),
+    ] {
+        write_file(dir, path, content)?;
+    }
+    git_at_dir(dir).args(["add", "."]).run();
+    git_at_dir(dir).args(["commit", "-m", "base"]).run();
+    git_at_dir(dir)
+        .args(["update-ref", "refs/remotes/origin/main", "HEAD"])
+        .run();
+    let repo = open_repo(dir)?;
+    let base = repo.head_id()?.detach();
+    ProjectMeta {
+        target_ref: Some("refs/remotes/origin/main".try_into()?),
+        target_commit_id: Some(base),
+        push_remote: Some("origin".into()),
+    }
+    .persist(&repo)?;
+    git_at_dir(dir).args(["switch", "-c", "feature"]).run();
+    for (path, content) in [
+        ("session.ts", "feature\n"),
+        ("logo.png", "feature\0image"),
+        ("deleted.md", "Edited documentation\nSecond paragraph\n"),
+        ("clean.txt", "clean\n"),
+    ] {
+        write_file(dir, path, content)?;
+    }
+    git_at_dir(dir).args(["add", "."]).run();
+    git_at_dir(dir).args(["commit", "-m", "feature"]).run();
+    let original = repo.head_id()?.detach();
+    git_at_dir(dir).args(["switch", "main"]).run();
+    write_file(dir, "session.ts", "upstream\n")?;
+    write_file(dir, "logo.png", "upstream\0image")?;
+    git_at_dir(dir).args(["rm", "deleted.md"]).run();
+    git_at_dir(dir).args(["commit", "-am", "upstream"]).run();
+    git_at_dir(dir)
+        .args(["update-ref", "refs/remotes/origin/main", "HEAD"])
+        .run();
+    git_at_dir(dir).args(["switch", "feature"]).run();
+    let mut ctx = but_ctx::Context::from_repo_for_testing(repo)?.with_memory_app_cache();
+    let updates = vec![but_api::workspace::json::BottomUpdate {
+        kind: but_api::workspace::json::BottomUpdateKind::Rebase,
+        selector: but_api::commit::json::RelativeTo::Commit(original),
+    }];
+    let preview = but_api::workspace::workspace_integrate_upstream_only(
+        &mut ctx,
+        updates.clone(),
+        DryRun::Yes,
+    )?;
+    let preview_id = preview.workspace_state.replaced_commits[&original];
+    let preview = serde_json::to_value(
+        but_api::workspace::json::WorkspaceIntegrateUpstreamOutcome::try_from(preview)?,
+    )?;
+    assert_eq!(
+        preview["commitConflicts"][preview_id.to_string()],
+        serde_json::json!(["deleted.md", "logo.png", "session.ts"]),
+        "the preview includes unique paths for text, binary, and delete conflicts, excluding clean files"
+    );
+    assert_eq!(
+        ctx.repo.get()?.head_id()?.detach(),
+        original,
+        "previewing leaves HEAD unchanged"
+    );
+    assert!(
+        !ctx.repo.get()?.has_object(preview_id),
+        "preview commits are not persisted for later file queries"
+    );
+    assert_eq!(
+        ctx.project_meta()?.target_commit_id,
+        Some(base),
+        "previewing does not advance the target"
+    );
+    assert_eq!(
+        std::fs::read_to_string(dir.join("session.ts"))?,
+        "feature\n",
+        "previewing leaves worktree contents unchanged"
+    );
+    let actual =
+        but_api::workspace::workspace_integrate_upstream_only(&mut ctx, updates, DryRun::No)?;
+    let actual_id = actual.workspace_state.replaced_commits[&original];
+    let actual = serde_json::to_value(
+        but_api::workspace::json::WorkspaceIntegrateUpstreamOutcome::try_from(actual)?,
+    )?;
+    assert_eq!(
+        actual["commitConflicts"][actual_id.to_string()],
+        preview["commitConflicts"][preview_id.to_string()],
+        "both modes report the same conflicted files under their resulting commit IDs"
+    );
+    use gix::prelude::ObjectIdExt;
+    let repo = ctx.repo.get()?;
+    let entries = but_core::Commit::from_id(actual_id.attach(&repo))?
+        .conflict_entries()?
+        .expect("the applied commit is conflicted");
+    // Keep staged paths first, append tree-only conflicts once, and retain each side's order.
+    snapbox::assert_data_eq!(
+        format!("{entries:?}"),
+        snapbox::str![[
+            r#"ConflictEntries { ancestor_entries: ["logo.png", "session.ts"], our_entries: ["logo.png", "session.ts", "deleted.md"], their_entries: ["logo.png", "session.ts", "deleted.md"] }"#
+        ]],
+    );
+    let paths: std::collections::BTreeSet<_> = entries
+        .ancestor_entries
+        .into_iter()
+        .chain(entries.our_entries)
+        .chain(entries.their_entries)
+        .collect();
+    assert_eq!(
+        serde_json::to_value(paths)?,
+        preview["commitConflicts"][preview_id.to_string()],
+        "the preview paths match the applied update"
+    );
+    Ok(())
+}

--- a/crates/but-core/src/commit/mod.rs
+++ b/crates/but-core/src/commit/mod.rs
@@ -660,9 +660,9 @@ impl ConflictEntries {
 /// This is the shared translation used when a merge is auto-resolved but still
 /// has unresolved conflicts that must be persisted in a conflicted commit/tree.
 /// It first asks `gix` to materialize conflict stages into an index view of the
-/// merged tree. If that yields no staged conflict paths, it falls back to the
-/// unresolved conflict list from the merge outcome itself, which is important
-/// for force-resolved merges where Git would otherwise omit index stages.
+/// merged tree, then includes paths from the unresolved conflicts themselves.
+/// This covers force-resolved tree conflicts that Git omits from index stages,
+/// including when the same merge also has staged content conflicts.
 ///
 /// - `repo` - is the repository that owns `merged_tree_id` and provides the index
 ///   machinery used to derive stage entries from the merge result.
@@ -708,23 +708,29 @@ pub fn conflict_entries_from_merge_outcome(
         their_entries,
     };
 
-    if !out.has_entries() {
-        fn push_unique(v: &mut Vec<PathBuf>, change: &gix::diff::tree_with_rewrites::Change) {
-            let path = gix::path::from_bstr(change.location()).into_owned();
-            if !v.contains(&path) {
-                v.push(path);
-            }
+    // Some forced tree resolutions (for example modify/delete) don't produce
+    // index stages even when other conflicts do. Include their paths as well.
+    fn push_unique(
+        paths: &mut Vec<PathBuf>,
+        seen: &mut HashSet<PathBuf>,
+        change: &gix::diff::tree_with_rewrites::Change,
+    ) {
+        let path = gix::path::from_bstr(change.location()).into_owned();
+        if seen.insert(path.clone()) {
+            paths.push(path);
         }
+    }
+    let mut seen_ours = out.our_entries.iter().cloned().collect();
+    let mut seen_theirs = out.their_entries.iter().cloned().collect();
 
-        for conflict in merge_result
-            .conflicts
-            .iter()
-            .filter(|c| c.is_unresolved(treat_as_unresolved))
-        {
-            let (ours, theirs) = conflict.changes_in_resolution();
-            push_unique(&mut out.our_entries, ours);
-            push_unique(&mut out.their_entries, theirs);
-        }
+    for conflict in merge_result
+        .conflicts
+        .iter()
+        .filter(|c| c.is_unresolved(treat_as_unresolved))
+    {
+        let (ours, theirs) = conflict.changes_in_resolution();
+        push_unique(&mut out.our_entries, &mut seen_ours, ours);
+        push_unique(&mut out.their_entries, &mut seen_theirs, theirs);
     }
 
     assert_eq!(

--- a/packages/but-sdk/src/generated/graph/index.d.ts
+++ b/packages/but-sdk/src/generated/graph/index.d.ts
@@ -1681,7 +1681,7 @@ export declare function workspaceFetchStatus(projectId: string): Promise<Workspa
  * workspace previews the integration and no oplog entry is persisted. See
  * [`workspace_integrate_upstream_with_perm()`] for lower-level details.
  *
- * {@link ../../../../../crates/but-api/src/workspace.rs:748}
+ * {@link ../../../../../crates/but-api/src/workspace.rs:762}
  */
 export declare function workspaceIntegrateUpstream(projectId: string, updates: Array<BottomUpdate>, dryRun: boolean): Promise<WorkspaceIntegrateUpstreamOutcome>
 
@@ -4772,6 +4772,8 @@ export type WorkspaceIntegrateUpstreamOutcome = {
   targetCommits: TargetCommitPage | null;
   /** Dirty worktree paths that would conflict when applied onto the resulting workspace head. */
   worktreeConflicts: Array<string>;
+  /** Conflicted paths by resulting commit ID, for both previews and applied updates. */
+  commitConflicts: Record<string, Array<string>>;
 };
 
 /** JSON transport type returned by workspace recreation. */

--- a/packages/but-sdk/src/generated/linear/index.d.ts
+++ b/packages/but-sdk/src/generated/linear/index.d.ts
@@ -1681,7 +1681,7 @@ export declare function workspaceFetchStatus(projectId: string): Promise<Workspa
  * workspace previews the integration and no oplog entry is persisted. See
  * [`workspace_integrate_upstream_with_perm()`] for lower-level details.
  *
- * {@link ../../../../../crates/but-api/src/workspace.rs:748}
+ * {@link ../../../../../crates/but-api/src/workspace.rs:762}
  */
 export declare function workspaceIntegrateUpstream(projectId: string, updates: Array<BottomUpdate>, dryRun: boolean): Promise<WorkspaceIntegrateUpstreamOutcome>
 
@@ -4772,6 +4772,8 @@ export type WorkspaceIntegrateUpstreamOutcome = {
   targetCommits: TargetCommitPage | null;
   /** Dirty worktree paths that would conflict when applied onto the resulting workspace head. */
   worktreeConflicts: Array<string>;
+  /** Conflicted paths by resulting commit ID, for both previews and applied updates. */
+  commitConflicts: Record<string, Array<string>>;
 };
 
 /** JSON transport type returned by workspace recreation. */


### PR DESCRIPTION
- Show a warning triangle before the target ref when pulling would cause conflicts.
- List affected branches, commits, and files in a popup.
- Show no preview indicator during checks or after failures. Keep `Pull latest` available.
- Combine rapid changes and run one check at a time. Skip stale checks that haven't started.
- Share the preview and pull state between the target row and its docked copy.
- Preview conflicts without changing commits or working files.
- Return conflicted files for both previews and applied updates.

Local checks passed:

```text
Rust core/rebase tests + API regression in both SDK modes
31 focused UI tests + 31 Electron tests (9 skipped)
Full Lite tests and typecheck
Lint, format, Knip, and React Compiler checks
```

Fixes GB-2029.

