### PR TITLE
Keep the target history pages through workspace activity

### DIFF
--- a/apps/lite/ui/src/api/mutations.ts
+++ b/apps/lite/ui/src/api/mutations.ts
@@ -1354,6 +1354,10 @@ export const useWorkspaceIntegrateUpstream = () => {
 				predicate: (query) =>
 					response.targetCommits == null || query.queryKey.length > queryKey.length,
 			});
+			// The older pages hang off their own key, so the invalidation above cannot reach them.
+			void mutation.client.invalidateQueries({
+				queryKey: [input.projectId, "olderTargetCommits"],
+			});
 		},
 		onError: (error, input) => {
 			toastManager.add({

--- a/apps/lite/ui/src/api/queries.ts
+++ b/apps/lite/ui/src/api/queries.ts
@@ -237,12 +237,13 @@ const olderTargetCommitsPageSize = 25;
  * when the user asks, so nothing below the workspace's fork points loads
  * unbidden.
  *
- * Keyed under the base listing's own root, so whatever invalidates the target
- * line — a fetch, a workspace update — reaches the pages hanging off it too.
+ * Keyed apart from the base listing so ordinary workspace activity cannot drop
+ * the pages the user loaded. What does move these commits — a fetch, an
+ * upstream integration — has to invalidate this key explicitly.
  */
 export const olderTargetCommitsInfiniteQueryOptions = (projectId: string, from: string) =>
 	infiniteQueryOptions({
-		queryKey: [projectId, "workspaceTargetCommits", { olderThan: from }],
+		queryKey: [projectId, "olderTargetCommits", { olderThan: from }],
 		queryFn: ({ pageParam }) =>
 			window.lite.workspaceTargetCommits({
 				projectId,

--- a/apps/lite/ui/src/api/query-keys.ts
+++ b/apps/lite/ui/src/api/query-keys.ts
@@ -23,7 +23,9 @@ export type GlobalQueryKey =
 	| "markdownTokens";
 
 /**
- * Client state kept in the query cache, so nothing declares for them. `dryRun`
+ * Keys nothing declares for in Rust, so no event refreshes them by tag. Mostly
+ * client state, but `olderTargetCommits` is server data held out on purpose, so
+ * only the handlers naming it can drop the pages the user loaded. `dryRun`
  * memoizes an imperative preview: its key carries the operation and changes it
  * was measured against, and nothing refreshes it in place. `branchIntegration`
  * is the update flow's plan and preview, refetched each time the flow asks.
@@ -35,7 +37,8 @@ type LocalQueryKey =
 	| "prMergeMethod"
 	| "prDraft"
 	| "projectAiSettings"
-	| "reviewedFiles";
+	| "reviewedFiles"
+	| "olderTargetCommits";
 
 export type QueryKeyPrefix =
 	| [projectId: string, ProjectQueryKey]

--- a/apps/lite/ui/src/project-events.test.ts
+++ b/apps/lite/ui/src/project-events.test.ts
@@ -1,8 +1,12 @@
+import {
+	olderTargetCommitsInfiniteQueryOptions,
+	workspaceTargetCommitsQueryOptions,
+} from "#ui/api/queries.ts";
 import { projectQueryKeys } from "#ui/api/query-keys.ts";
 import { handleProjectEvent } from "#ui/project-events.ts";
 import type { WatcherEvent } from "@gitbutler/but-sdk";
 import { apiProvides, watcherInvalidates } from "@gitbutler/but-sdk/cache-tags";
-import type { QueryClient } from "@tanstack/react-query";
+import { QueryClient } from "@tanstack/react-query";
 import { describe, expect, it } from "vitest";
 
 const provides: Record<string, ReadonlyArray<string> | undefined> = apiProvides;
@@ -79,5 +83,34 @@ describe("handled separately", () => {
 		expect(invalidated).not.toContain("workspaceTargetCommits");
 		await new Promise((resolve) => setTimeout(resolve, 0));
 		expect(invalidated).toContain("workspaceTargetCommits");
+	});
+
+	it("keeps the older target pages through activity, dropping them only on a fetch", async () => {
+		// A real client, because the regression was React Query matching the older
+		// pages by key prefix — something a recording double cannot see.
+		const baseKey = workspaceTargetCommitsQueryOptions("p1").queryKey;
+		const olderKey = olderTargetCommitsInfiniteQueryOptions("p1", "cursor").queryKey;
+		const seeded = (event: string) => {
+			const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+			client.setQueryData(baseKey, { commits: [], hasMore: true });
+			client.setQueryData(olderKey, { pages: [], pageParams: [] });
+			handleProjectEvent(
+				{ name: event, payload: { type: event, subject: null } } as WatcherEvent,
+				"p1",
+				client,
+			);
+			return client;
+		};
+
+		for (const event of ["gitActivity", "workspaceActivity"] as const) {
+			const client = seeded(event);
+			await new Promise((resolve) => setTimeout(resolve, 0));
+			expect(client.getQueryState(baseKey)?.isInvalidated, `after ${event}`).toBe(true);
+			expect(client.getQueryState(olderKey)?.isInvalidated, `after ${event}`).toBe(false);
+		}
+
+		const client = seeded("gitFetch");
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(client.getQueryState(olderKey)?.isInvalidated).toBe(true);
 	});
 });

--- a/apps/lite/ui/src/project-events.ts
+++ b/apps/lite/ui/src/project-events.ts
@@ -142,6 +142,7 @@ export const handleProjectEvent = (
 				void client.invalidateQueries({
 					queryKey: [projectId, "workspaceTargetCommits"],
 				});
+				void client.invalidateQueries({ queryKey: [projectId, "olderTargetCommits"] });
 			});
 	}
 };


### PR DESCRIPTION
Load some older target history in Lite, then touch the workspace, and everything you loaded disappears.

- the infinite-scroll pages below the base listing shared its query-key root, so any workspace edit invalidated them along with the base
- they get their own key now, which workspace activity never touches; the fetch handler and the upstream-integration handler drop them explicitly
- that split is safe because these commits sit below the workspace's fork points: only a fetch or an integration moves them
- no backend or desktop change, `workspace_target_commits` already paginates with `from` and it is the same command apps/desktop uses to browse the target branch

### Verified
- lite UI suite 447/447 and `tsgo` clean
- the new `project-events` test runs against a real `QueryClient`, so it sees the prefix matching that caused the bug: it asserts activity invalidates the base listing and leaves the pages alone. Put the old key root back and it fails
- the existing `useWorkspaceIntegrateUpstream` tests cover the new key, since its old invalidation reached the pages only through the shared root

🤖 Generated with [Claude Code](https://claude.com/claude-code)
