### PR TITLE
Link each Next nightly to its commit on the website

### DIFF
--- a/.github/workflows/lite.yml
+++ b/.github/workflows/lite.yml
@@ -88,7 +88,11 @@ jobs:
           APPLE_TEAM_ID: ${{ runner.os == 'macOS' && secrets.APPLE_PROVIDER_SHORT_NAME || '' }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        run: pnpm exec electron-builder --publish always
+          RELEASE_SHA: ${{ github.sha }}
+        shell: bash
+        # The commit lands in the updater manifest under `vendor.sha`, where the
+        # website's nightly page reads it back to link each build to its commit.
+        run: pnpm exec electron-builder --publish always --config.releaseInfo.vendor.sha="$RELEASE_SHA"
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         name: Upload artifacts
         with:

--- a/apps/web/src/routes/nightly/+page.server.ts
+++ b/apps/web/src/routes/nightly/+page.server.ts
@@ -24,7 +24,13 @@ async function fetchNextBuild(fetch: typeof globalThis.fetch, path: string, mani
 			if (label && url.href.startsWith(base)) downloads.push({ url: url.href, label });
 		}
 		const releasedAt = typeof data.releaseDate === "string" ? data.releaseDate : null;
-		return downloads.length ? { version: data.version as string, releasedAt, downloads } : null;
+		// The Lite workflow publishes the build's commit under the manifest's `vendor.sha`.
+		const vendorSha = data.vendor?.sha;
+		const sha =
+			typeof vendorSha === "string" && /^[0-9a-f]{40}$/.test(vendorSha) ? vendorSha : null;
+		return downloads.length
+			? { version: data.version as string, releasedAt, sha, downloads }
+			: null;
 	} catch (error) {
 		console.error(`Failed to fetch Next nightly for ${path}:`, error);
 		return null;

--- a/apps/web/src/routes/nightly/+page.svelte
+++ b/apps/web/src/routes/nightly/+page.svelte
@@ -30,6 +30,7 @@
 	);
 	const nextVersion = $derived(nextMac?.version ?? nextLinux?.version);
 	const nextReleasedAt = $derived(nextMac?.releasedAt ?? nextLinux?.releasedAt);
+	const nextSha = $derived(nextMac?.sha ?? nextLinux?.sha);
 
 	let linuxArch = $state<"x86-64" | "ARM64">("x86-64");
 	let expandedRelease: string | null = $state(null);
@@ -250,6 +251,17 @@
 						{#if nextReleasedAt}
 							<span> • </span>
 							<span>{formatReleaseDate(nextReleasedAt)}</span>
+						{/if}
+						{#if nextSha}
+							<span> • </span>
+							<a
+								href="https://github.com/gitbutlerapp/gitbutler/commit/{nextSha}"
+								target="_blank"
+								rel="noopener noreferrer"
+								class="sha-link"
+							>
+								{nextSha.substring(0, 7)}
+							</a>
 						{/if}
 					</div>
 					<p class="nightly-hero__description">
@@ -598,6 +610,15 @@
 
 		& .download-card-link:hover {
 			text-decoration-color: #c0e4ff;
+		}
+
+		& .sha-link {
+			color: inherit;
+
+			&:hover {
+				color: #c0e4ff;
+				text-decoration-color: #c0e4ff;
+			}
 		}
 
 		& .linux-arch-select {


### PR DESCRIPTION
The Next Nightly block on /nightly shows the build's version and release date, but unlike the stable hero above it there is no link to the commit the build came from, because the Lite updater manifests do not carry one.

<img width="1908" height="786" alt="Screenshot 2026-09-09 at 23-01-08" src="https://github.com/user-attachments/assets/ea2b2da2-6f96-4f3e-8960-0f81d797bb1d" />

This wires that up end to end:

- The Lite workflow passes the run's commit to electron-builder as `releaseInfo.releaseNotes`, which electron-builder writes into every updater manifest as a `releaseNotes` field. The step also gets `shell: bash` so the env var expands on the Windows runner.
- The nightly page's server load reads that field back, accepting it only when it is a full 40-character sha.
- The Next meta line ends with the short sha linked to the commit on GitHub, using the same link styling as the hero with a white override for the blue background.

The link stays hidden until a nightly built after this change has published a manifest carrying the sha, so nothing changes on the page until the next Lite nightly run.

Stacked on #15857, which restyles the section this builds on.
