### PR TITLE
Replace the base row with the target's row in the Lite graph

### DIFF
--- a/apps/lite/ui/src/api/mutations.test.tsx
+++ b/apps/lite/ui/src/api/mutations.test.tsx
@@ -7,7 +7,6 @@ import {
 } from "#ui/api/mutations.ts";
 import {
 	getReviewQueryOptions,
-	olderTargetCommitsInfiniteQueryOptions,
 	reviewerCandidatesQueryOptions,
 	workspaceTargetCommitsQueryOptions,
 } from "#ui/api/queries.ts";
@@ -24,7 +23,6 @@ vi.mock("@base-ui/react", () => ({ Toast: { useToastManager: () => ({ add: vi.fn
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
 const baseKey = workspaceTargetCommitsQueryOptions("project").queryKey;
-const olderKey = olderTargetCommitsInfiniteQueryOptions("project", "cursor").queryKey;
 const otherKey = workspaceTargetCommitsQueryOptions("other-project").queryKey;
 const original = { commits: [], hasMore: true };
 const updated = { commits: [], hasMore: false };
@@ -39,7 +37,6 @@ describe("useWorkspaceIntegrateUpstream", () => {
 		vi.stubGlobal("lite", { workspaceIntegrateUpstream });
 		client = new QueryClient();
 		client.setQueryData(baseKey, original);
-		client.setQueryData(olderKey, { pages: [original], pageParams: ["cursor"] });
 		client.setQueryData(otherKey, original);
 		const container = document.createElement("div");
 		root = createRoot(container);
@@ -79,30 +76,24 @@ describe("useWorkspaceIntegrateUpstream", () => {
 		});
 	};
 
-	it("seeds the base listing and invalidates older pages without invalidating the base", async () => {
+	it("seeds the listing without invalidating it", async () => {
 		await run(updated);
 		expect(client.getQueryData(baseKey)).toEqual(updated);
 		expect(client.getQueryState(baseKey)?.isInvalidated).toBe(false);
-		expect(client.getQueryState(olderKey)?.isInvalidated).toBe(true);
 		expect(client.getQueryState(otherKey)?.isInvalidated).toBe(false);
 	});
 
-	it.each([null, undefined])(
-		"invalidates all target pages when the listing is %s",
-		async (listing) => {
-			await run(listing);
-			expect(client.getQueryData(baseKey)).toEqual(original);
-			expect(client.getQueryState(baseKey)?.isInvalidated).toBe(true);
-			expect(client.getQueryState(olderKey)?.isInvalidated).toBe(true);
-			expect(client.getQueryState(otherKey)?.isInvalidated).toBe(false);
-		},
-	);
+	it.each([null, undefined])("invalidates the listing when it is %s", async (listing) => {
+		await run(listing);
+		expect(client.getQueryData(baseKey)).toEqual(original);
+		expect(client.getQueryState(baseKey)?.isInvalidated).toBe(true);
+		expect(client.getQueryState(otherKey)?.isInvalidated).toBe(false);
+	});
 
 	it("leaves cached listings untouched for a dry run", async () => {
 		await run(updated, true);
 		expect(client.getQueryData(baseKey)).toEqual(original);
 		expect(client.getQueryState(baseKey)?.isInvalidated).toBe(false);
-		expect(client.getQueryState(olderKey)?.isInvalidated).toBe(false);
 	});
 });
 

--- a/apps/lite/ui/src/api/mutations.ts
+++ b/apps/lite/ui/src/api/mutations.ts
@@ -1348,12 +1348,7 @@ export const useWorkspaceIntegrateUpstream = () => {
 			const queryKey = workspaceTargetCommitsQueryOptions(input.projectId).queryKey;
 			if (response.targetCommits != null)
 				mutation.client.setQueryData(queryKey, response.targetCommits);
-
-			void mutation.client.invalidateQueries({
-				queryKey,
-				predicate: (query) =>
-					response.targetCommits == null || query.queryKey.length > queryKey.length,
-			});
+			else void mutation.client.invalidateQueries({ queryKey });
 		},
 		onError: (error, input) => {
 			toastManager.add({

--- a/apps/lite/ui/src/api/queries.ts
+++ b/apps/lite/ui/src/api/queries.ts
@@ -221,40 +221,6 @@ export const workspaceTargetCommitsQueryOptions = (projectId: string) =>
 		queryFn: () => window.lite.workspaceTargetCommits({ projectId, from: null, limit: null }),
 	});
 
-/**
- * What each "load older commits" adds. Asking is deliberate, so a page should
- * cover ground rather than need pressing repeatedly.
- */
-const olderTargetCommitsPageSize = 25;
-
-/**
- * Target history continuing below where the base listing stops, walked from a
- * commit-id cursor. `from` is exclusive: the backend starts at that commit's
- * first parent, so passing the base listing's last commit continues the line
- * without repeating it.
- *
- * Fetched only on demand: consumers keep it disabled and call `fetchNextPage`
- * when the user asks, so nothing below the workspace's fork points loads
- * unbidden.
- *
- * Keyed under the base listing's own root, so whatever invalidates the target
- * line — a fetch, a workspace update — reaches the pages hanging off it too.
- */
-export const olderTargetCommitsInfiniteQueryOptions = (projectId: string, from: string) =>
-	infiniteQueryOptions({
-		queryKey: [projectId, "workspaceTargetCommits", { olderThan: from }],
-		queryFn: ({ pageParam }) =>
-			window.lite.workspaceTargetCommits({
-				projectId,
-				from: pageParam,
-				limit: olderTargetCommitsPageSize,
-			}),
-		enabled: false,
-		initialPageParam: from,
-		getNextPageParam: (lastPage) =>
-			lastPage.hasMore ? lastPage.commits.at(-1)?.commit.id : undefined,
-	});
-
 export const workspaceFetchStatusQueryOptions = (projectId: string) =>
 	queryOptions({
 		queryKey: [projectId, "workspaceFetchStatus"],

--- a/apps/lite/ui/src/components/GraphSegment.module.css
+++ b/apps/lite/ui/src/components/GraphSegment.module.css
@@ -89,6 +89,11 @@
 	stroke: color-mix(in srgb, var(--commit-local) 40%, transparent);
 }
 
+/* The trunk's tail below the row's centre line fades to nothing. */
+.edgePassFading {
+	mask-image: linear-gradient(to bottom, black 50%, transparent);
+}
+
 .glyph {
 	display: flex;
 	flex-direction: column;

--- a/apps/lite/ui/src/components/GraphSegment.stories.tsx
+++ b/apps/lite/ui/src/components/GraphSegment.stories.tsx
@@ -12,6 +12,7 @@ const meta = preview.meta({
 				"space",
 				"forkLeft",
 				"forkRight",
+				"notch",
 				"forkBoth",
 				"mergeLeft",
 				"mergeRight",
@@ -53,6 +54,7 @@ export const AllGlyphs = meta.story({
 					"horizontal",
 					"forkLeft",
 					"forkRight",
+					"notch",
 					"forkBoth",
 					"mergeLeft",
 					"mergeRight",
@@ -62,7 +64,6 @@ export const AllGlyphs = meta.story({
 					"joinBoth",
 					"commit",
 					"group",
-					"hook",
 					"space",
 				] satisfies Array<GraphSegmentGlyph>
 			).map((glyph) => (

--- a/apps/lite/ui/src/components/GraphSegment.tsx
+++ b/apps/lite/ui/src/components/GraphSegment.tsx
@@ -10,6 +10,8 @@ const glyphPaths = {
 	// Forks
 	forkLeft: "M-5.96046e-08 14H2C5.31371 14 8 16.6863 8 20V28",
 	forkRight: "M16 14H14C10.6863 14 8 16.6863 8 20V28",
+	/** A tick off the trunk on the panel's edge, 4px left of the canvas, as a stacked branch's off its rail. */
+	notch: "M-4 14H4",
 	forkBoth: "M0 14H8M16 14H8M8 28L8 14",
 	// Merges
 	mergeLeft: "M-5.96046e-08 14H2C5.31371 14 8 11.3137 8 8V2.38419e-07",
@@ -22,32 +24,24 @@ const glyphPaths = {
 };
 
 /** A stretch of the rail in another status's colour, or the glyph's own when none is given. */
-const Tone: FC<{ status: GraphSegmentStatus | undefined; d: string; dashed?: boolean }> = ({
-	status,
-	d,
-	dashed = false,
-}) => (
+const Tone: FC<{ status: GraphSegmentStatus | undefined; d: string }> = ({ status, d }) => (
 	<g className={styles.tone} data-status={status}>
-		<path
-			className={styles.line}
-			d={d}
-			strokeWidth="1.5"
-			strokeDasharray={dashed ? "1.5 2.5" : undefined}
-		/>
+		<path className={styles.line} d={d} strokeWidth="1.5" />
 	</g>
 );
 
 /**
  * The columns the main line runs through behind a row or gap. The first is
  * the trunk's on the panel's edge, drawn the way the gaps draw it so the two
- * land on the same pixels: an SVG antialiases where a CSS box snaps.
+ * land on the same pixels: an SVG antialiases where a CSS box snaps. Folded
+ * below the row, the trunk's tail fades out, a hint of what lies below.
  */
-const passes = (behind: number) =>
+const passes = (behind: number, folded = false) =>
 	Array.from({ length: behind }, (_, column) =>
 		column === 0 ? (
 			<svg
 				key={column}
-				className={styles.edgePass}
+				className={classes(styles.edgePass, folded && styles.edgePassFading)}
 				viewBox="0 0 12 28"
 				preserveAspectRatio="none"
 				fill="none"
@@ -105,33 +99,11 @@ const joinRightGlyph = (
 	</>
 );
 
-/**
- * The trunk hooking off the panel's edge, 4px left of the canvas, into the
- * column: two quarter turns of radius 4 through the row's centre line, as a
- * card's line bends in a gap. A line in another's colour may come down the
- * column to the join, and on down below it.
- */
-const hookGlyph = (
-	above: GraphSegmentStatus | undefined,
-	below: GraphSegmentStatus | undefined,
-	folded: boolean,
-) => (
-	<>
-		{above !== undefined && <Tone status={above} d="M8 0V18" />}
-		<path
-			className={styles.line}
-			d="M-4 0V10C-4 12.2091 -2.2091 14 0 14H4C6.2091 14 8 15.7909 8 18"
-			strokeWidth="1.5"
-		/>
-		<Tone status={below} d="M8 18V28" dashed={folded} />
-	</>
-);
-
 /** A plain rail through the row, the stretch below its centre in another's colour. */
-const parentGlyph = (below: GraphSegmentStatus | undefined, folded: boolean) => (
+const parentGlyph = (below: GraphSegmentStatus | undefined) => (
 	<>
 		<path className={styles.line} d="M8 0V14" strokeWidth="1.5" />
-		<Tone status={below} d="M8 14V28" dashed={folded} />
+		<Tone status={below} d="M8 14V28" />
 	</>
 );
 
@@ -164,7 +136,7 @@ const groupCenteredFootGlyph = (
 );
 
 /** @public */
-export type GraphSegmentGlyph = keyof typeof glyphPaths | "commit" | "group" | "hook";
+export type GraphSegmentGlyph = keyof typeof glyphPaths | "commit" | "group";
 
 /** Glyphs whose rail carries on past the drawing, so a taller row goes on drawing it. */
 const stretchableGlyphs = new Set<GraphSegmentGlyph>([
@@ -177,7 +149,6 @@ const stretchableGlyphs = new Set<GraphSegmentGlyph>([
 	"joinLeft",
 	"joinRight",
 	"joinBoth",
-	"hook",
 ]);
 
 /**
@@ -192,7 +163,7 @@ interface GraphSegmentProps extends ComponentProps<"span"> {
 	status: GraphSegmentStatus;
 	/** The rail ends on this row: no tail below the icon, nothing stretched under a taller row. */
 	railEnds?: boolean;
-	/** The rail below the row is folded away: its tail is dashed, a hint of what the fold holds. */
+	/** What lies below the row is folded away: the trunk's tail behind the row fades out, a hint of it. */
 	folded?: boolean;
 	/** The rings sit on the row's centre line, for a single-line row of their own. */
 	centered?: boolean;
@@ -217,7 +188,7 @@ export const GraphSegment: FC<GraphSegmentProps> = ({
 }) => (
 	// Spans throughout: the segment sits in buttons and spans, which take phrasing content only.
 	<span {...props} className={classes(className, styles.container)} data-status={status}>
-		{passes(behind)}
+		{passes(behind, folded)}
 		<span className={styles.glyph}>
 			<svg
 				className={classes(
@@ -238,10 +209,8 @@ export const GraphSegment: FC<GraphSegmentProps> = ({
 					commitGlyph(below)
 				) : glyph === "joinRight" ? (
 					joinRightGlyph(above, below)
-				) : glyph === "hook" ? (
-					hookGlyph(above, below, folded)
 				) : glyph === "parent" ? (
-					parentGlyph(below, folded)
+					parentGlyph(below)
 				) : glyph === "forkRight" ? (
 					forkRightGlyph(below)
 				) : glyph === "group" ? (

--- a/apps/lite/ui/src/projects/graph.ts
+++ b/apps/lite/ui/src/projects/graph.ts
@@ -5,21 +5,15 @@ import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
  * shows. Its rows share the applied list's cursor.
  */
 export type GraphState = {
-	/** The upstream header's fold: the commits incoming from the target. */
+	/** The target header's fold: the commits incoming from the target. */
 	incomingExpanded: boolean;
-	/** The base header's fold: the base rows and the older history. */
-	baseExpanded: boolean;
 	/** How many times more of each run was asked for, keyed by the run's newest commit id. */
 	moreRuns: Record<string, number>;
-	/** How many times more of the older history was asked for since the base opened. */
-	moreOlder: number;
 };
 
 const initialState = (): GraphState => ({
 	incomingExpanded: false,
-	baseExpanded: false,
 	moreRuns: {},
-	moreOlder: 0,
 });
 
 const graphSlice = createSlice({
@@ -28,14 +22,6 @@ const graphSlice = createSlice({
 	reducers: {
 		toggleIncoming: (state) => {
 			state.incomingExpanded = !state.incomingExpanded;
-		},
-		// Either way the history starts over: what one look asked for, the next does not.
-		toggleBase: (state) => {
-			state.baseExpanded = !state.baseExpanded;
-			state.moreOlder = 0;
-		},
-		showMoreOlder: (state) => {
-			state.moreOlder += 1;
 		},
 		showMoreRun: (state, { payload: { runId } }: PayloadAction<{ runId: string }>) => {
 			state.moreRuns[runId] = (state.moreRuns[runId] ?? 0) + 1;
@@ -55,17 +41,11 @@ export const graphReducers = {
 	toggleIncoming: (state: GraphState) => {
 		graphSlice.caseReducers.toggleIncoming(state);
 	},
-	toggleBase: (state: GraphState) => {
-		graphSlice.caseReducers.toggleBase(state);
-	},
 	showMoreRun: (state: GraphState, payload: { runId: string }) => {
 		graphSlice.caseReducers.showMoreRun(state, graphSlice.actions.showMoreRun(payload));
 	},
 	foldRun: (state: GraphState, payload: { runId: string }) => {
 		graphSlice.caseReducers.foldRun(state, graphSlice.actions.foldRun(payload));
-	},
-	showMoreOlder: (state: GraphState) => {
-		graphSlice.caseReducers.showMoreOlder(state);
 	},
 };
 

--- a/apps/lite/ui/src/projects/project.ts
+++ b/apps/lite/ui/src/projects/project.ts
@@ -183,12 +183,6 @@ export const projectReducers = {
 	toggleGraphIncoming: (state: ProjectState) => {
 		graphReducers.toggleIncoming(state.graph);
 	},
-	toggleGraphBase: (state: ProjectState) => {
-		graphReducers.toggleBase(state.graph);
-	},
-	showMoreGraphOlder: (state: ProjectState) => {
-		graphReducers.showMoreOlder(state.graph);
-	},
 	showMoreGraphRun: (state: ProjectState, { runId }: { runId: string }) => {
 		graphReducers.showMoreRun(state.graph, { runId });
 	},

--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/Section.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/Section.module.css
@@ -34,8 +34,8 @@
 	overflow: hidden;
 }
 
-/* The target's card, drawn like a forked stack card. Keep in sync with
-   StackCard.module.css. */
+/* A card like a forked stack card's, for the worktree cards under the stacks
+   (WorktreeLane). Keep in sync with StackCard.module.css. */
 .card {
 	border-block: 1px solid var(--border-section);
 	background-color: var(--bg-1);
@@ -49,7 +49,7 @@
 }
 
 /* The air under its rows, run over the floor to the card's edge, where the
-   leg row below picks the leg up. */
+   gap below picks the line up. */
 .stub {
 	height: 5px;
 	min-height: auto;
@@ -57,29 +57,28 @@
 	overflow: hidden;
 }
 
-/* The air under the target's card or the ref's row, which the column's line
-   runs straight through to the base's. A row of gutter rather than a gap: the
-   line goes on down the column instead of bending onto the trunk. */
-.leg {
-	height: 12px;
-	min-height: auto;
-	overflow: hidden;
+/* The target row's stand-in docks at the scroller's foot while the row is out
+   of view below, keeping the target, its count and its fold in reach; the
+   fold's toggle scrolls to the row's place before opening. A sticky mark of
+   no height right after the row, whose row shows only while the mark is
+   stuck: air and a hairline around the row, and a chevron in place of the
+   rail, whose lines would claim a line above that is not there. Keep in sync
+   with layout.ts's DOCKED_HEIGHT. */
+.dock {
+	container-type: scroll-state;
+
+	z-index: 2;
+	position: sticky;
+	bottom: 0;
+	height: 0;
 }
 
-/* Folded, the merge base row's stand-in docks at the scroller's foot while
-   the row is out of view below, keeping the base's fold reachable; its
-   toggle scrolls to the row's place before opening. It shows only while its
-   mark (WorkspaceLists' footDock) is stuck: air, a hairline, and a chevron in
-   place of the glyph, whose lines would claim a line above that is not there.
-   Keep in sync with layout.ts's DOCKED_HEIGHT. */
 .docked {
-	--air: 4px;
-
 	visibility: hidden;
 	position: absolute;
 	inset-inline: 0;
 	bottom: 0;
-	padding-block: var(--air);
+	padding-block: 4px;
 	border-block-start: 1px solid var(--border-section);
 	background-color: var(--bg-2);
 

--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/Section.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/Section.tsx
@@ -1,13 +1,17 @@
-import { GraphSegment } from "#ui/components/GraphSegment.tsx";
-import { Icon } from "#ui/components/Icon.tsx";
+import { GraphGap, GraphSegment } from "#ui/components/GraphSegment.tsx";
 import { classes } from "#ui/components/classes.ts";
+import { Icon } from "#ui/components/Icon.tsx";
 import { getRowButtonClassName } from "#ui/routes/project/$id/workspace/Row-utils.ts";
 import {
 	Row,
 	RowFoldToggle,
 	RowLabel,
 	RowLabelContainer,
+	RowToolbar,
 } from "#ui/routes/project/$id/workspace/Row.tsx";
+import { useFetchFromRemotes } from "#ui/routes/project/$id/workspace/useFetchFromRemotes.ts";
+import { workspaceHotkeys } from "#ui/hotkeys.ts";
+import { formatRelativeTime } from "#ui/time.ts";
 import { useAddressSpace } from "#ui/routes/project/$id/workspace/WorkspaceLists/context.tsx";
 import { addressIdentityKey, type Address } from "#ui/addresses.ts";
 import type { AddressSpace } from "#ui/workspace/address-space.ts";
@@ -21,30 +25,27 @@ import { TooltipPopup } from "#ui/components/Tooltip.tsx";
 import { Button, Tooltip } from "@base-ui/react";
 import type { BottomUpdate } from "@gitbutler/but-sdk";
 import { useQuery } from "@tanstack/react-query";
-import { type FC, type ReactNode, type Ref, type RefObject, useRef } from "react";
-import { createPortal } from "react-dom";
+import { type FC, type ReactNode, type RefObject, useRef, useState } from "react";
 import styles from "./Section.module.css";
 import { TargetCommitRow } from "./TargetCommitRow.tsx";
-import { type Plan, type Run, targetCommitAddress } from "./layout.ts";
+import { LEG_GAP, type Plan, type Run, targetCommitAddress } from "./layout.ts";
 
 /*
- * The upstream section under the stacks: the target's row or card, folding
- * the incoming commits, then the merge base header, folding the history
- * below it. Commit rows are values on the applied cursor; headers are not.
+ * The upstream section under the stacks: the target's row, standing for the
+ * workspace's base, folding the incoming commits when the target has moved
+ * on. No card around it: the target is not in the workspace, and its rows
+ * sit on the panel itself to say so. Commit rows are values on the applied
+ * cursor; the header is not.
  *
- * The trunk runs down the panel's edge and hooks into the first row here
- * that draws a glyph, the ref's or the base's, since no glyph fits on the edge.
+ * The trunk runs down the panel's edge past the target's row, its tail
+ * fading below it, or to where the target's leg rejoins it. Scrolled out of
+ * view below, a stand-in for the row docks at the scroller's foot, so the
+ * target is always in reach: a sticky mark of no height right after the row,
+ * stuck exactly while the row is below the viewport.
  */
 
-// Base rows take the integrated colour, incoming rows the upstream's. Rows a
-// pending operation drops from the list are inert.
-const commitRow = (
-	commit: TargetCommit,
-	status: "Integrated" | "Upstream",
-	addressSpace: AddressSpace<Address>,
-	behind: number,
-	railEnds = false,
-) => {
+// The rows sit in the column beside the trunk. Rows a pending operation drops from the list are inert.
+const commitRow = (commit: TargetCommit, addressSpace: AddressSpace<Address>) => {
 	const index = addressSpace.indexByKey.get(addressIdentityKey(targetCommitAddress(commit)));
 	return (
 		<TargetCommitRow
@@ -52,29 +53,45 @@ const commitRow = (
 			commit={commit}
 			positionInSet={(index ?? -1) + 1}
 			setSize={addressSpace.items.length}
-			status={status}
-			railEnds={railEnds}
-			behind={behind}
+			behind={1}
 			inert={index === undefined}
 		/>
 	);
 };
 
-/** A header row: not a value. With a fold, the whole row toggles it; the rail toggle is the control assistive technology sees. */
+/** A note beside the header's label, explaining itself on hover. */
+const Caption: FC<{ className?: string; hint: ReactNode; children: ReactNode }> = ({
+	className,
+	hint,
+	children,
+}) => (
+	<Tooltip.Root>
+		<Tooltip.Trigger render={<span className={classes("text-12", className)} />}>
+			{children}
+		</Tooltip.Trigger>
+		<Tooltip.Portal>
+			<Tooltip.Positioner sideOffset={4}>
+				<Tooltip.Popup render={<TooltipPopup />}>{hint}</Tooltip.Popup>
+			</Tooltip.Positioner>
+		</Tooltip.Portal>
+	</Tooltip.Root>
+);
+
+/** A header row: not a value. With a fold, the rail's toggle opens it, as on the rows above. */
 const Header: FC<{
 	label: string;
-	/** Beside the label, in the label's own line: a count, an id. */
+	/** Beside the label, in the label's own line: a count, or a note. */
 	caption?: ReactNode;
-	/** The ref's row reads as a heading; the base's a step under it, being the ref's history. */
-	heading?: boolean;
 	/** The fold the header opens; none for a plain row. Its chevron swaps in for the glyph on hover, unless the glyph is one. */
 	fold?: { open: boolean; onToggle: () => void; name: string; hoverChevron?: boolean };
 	/** The row's gutter. */
 	rail: ReactNode;
+	/** At the row's end, past the label. */
+	toolbar?: ReactNode;
 	className?: string;
 	children?: ReactNode;
-}> = ({ label, caption, heading = false, fold, rail, className, children }) => (
-	<Row interactive={fold !== undefined} onSelect={fold?.onToggle} className={className}>
+}> = ({ label, caption, fold, rail, toolbar, className, children }) => (
+	<Row interactive={false} className={className}>
 		{fold === undefined ? (
 			rail
 		) : (
@@ -87,37 +104,32 @@ const Header: FC<{
 			/>
 		)}
 		<RowLabelContainer>
-			<RowLabel heading={heading} singleLine className={heading ? undefined : "text-bold"}>
+			<RowLabel heading singleLine>
 				{label}
 				{caption}
 			</RowLabel>
 			{children !== undefined && <span className={styles.action}>{children}</span>}
 		</RowLabelContainer>
+		{toolbar !== undefined && <RowToolbar forceVisible>{toolbar}</RowToolbar>}
 	</Row>
 );
 
-const Elided: FC<{
-	run: Run;
-	status: "Integrated" | "Upstream";
-	behind: number;
-	onMore: () => void;
-	onFold: () => void;
-}> = ({ run, status, behind, onMore, onFold }) => (
+const Elided: FC<{ run: Run; onMore: () => void; onFold: () => void }> = ({
+	run,
+	onMore,
+	onFold,
+}) => (
 	// oxlint-disable-next-line jsx-a11y/prefer-tag-over-role -- A row that reveals or folds, styled as the rows around it.
 	<Row role="button" onSelect={run.hidden > 0 ? onMore : onFold} aria-expanded={run.expanded}>
 		<GraphSegment
 			glyph={run.hidden > 0 ? "group" : "parent"}
-			status={status}
+			status="Upstream"
 			centered
-			behind={behind}
+			behind={1}
 		/>
 		<RowLabelContainer>
 			<RowLabel singleLine className={styles.elided}>
-				{run.hidden === 0
-					? "Show fewer"
-					: run.incoming
-						? `${run.hidden} more`
-						: `${run.hidden} ${run.hidden === 1 ? "commit" : "commits"} already in the workspace`}
+				{run.hidden === 0 ? "Show fewer" : `${run.hidden} more`}
 			</RowLabel>
 		</RowLabelContainer>
 	</Row>
@@ -125,20 +137,17 @@ const Elided: FC<{
 
 const Fold: FC<{
 	open: boolean;
-	className?: string;
-	ref?: Ref<HTMLDivElement>;
+	ref?: RefObject<HTMLDivElement | null>;
 	children: ReactNode;
-}> = ({ open, className, ref, children }) => (
-	<div ref={ref} className={classes(styles.fold, className)} data-open={open}>
+}> = ({ open, ref, children }) => (
+	<div ref={ref} className={styles.fold} data-open={open}>
 		<div className={styles.foldInner}>{children}</div>
 	</div>
 );
 
 const runRows = (
 	run: Run,
-	status: "Integrated" | "Upstream",
 	addressSpace: AddressSpace<Address>,
-	behind: number,
 	onMore: () => void,
 	onFold: () => void,
 ) => {
@@ -146,22 +155,87 @@ const runRows = (
 	const elided = run.hidden > 0 || run.expanded;
 	return (
 		<div key={run.id}>
-			{run.shown.map((commit) => commitRow(commit, status, addressSpace, behind))}
-			{elided && (
-				<Elided run={run} status={status} behind={behind} onMore={onMore} onFold={onFold} />
-			)}
+			{run.shown.map((commit) => commitRow(commit, addressSpace))}
+			{elided && <Elided run={run} onMore={onMore} onFold={onFold} />}
 		</div>
 	);
 };
 
+/** Fetches from the remotes: the target's row is what a fetch moves. */
+const Fetch: FC<{ projectId: string }> = ({ projectId }) => {
+	const { fetch, isPending, enabled, lastSuccessfulMs } = useFetchFromRemotes(projectId);
+	const [tooltipNow, setTooltipNow] = useState(() => Date.now());
+	return (
+		<Tooltip.Root
+			onOpenChange={(open) => {
+				if (open) setTooltipNow(Date.now());
+			}}
+		>
+			<Tooltip.Trigger
+				aria-label={workspaceHotkeys.fetchFromRemotes.meta.name}
+				className={getRowButtonClassName({ iconOnly: true })}
+				onClick={fetch}
+				// `disabled` goes on the button so the tooltip still opens over it.
+				render={<Button focusableWhenDisabled disabled={!enabled} />}
+			>
+				<Icon name={isPending ? "spinner" : "refresh"} />
+			</Tooltip.Trigger>
+			<Tooltip.Portal>
+				<Tooltip.Positioner sideOffset={4}>
+					<Tooltip.Popup render={<TooltipPopup kbd={workspaceHotkeys.fetchFromRemotes.hotkey} />}>
+						{workspaceHotkeys.fetchFromRemotes.meta.name}
+						{lastSuccessfulMs != null && ` (${formatRelativeTime(lastSuccessfulMs, tooltipNow)})`}
+					</Tooltip.Popup>
+				</Tooltip.Positioner>
+			</Tooltip.Portal>
+		</Tooltip.Root>
+	);
+};
+
 /** Rebases every stack onto the target's fetched tip; this does not fetch. */
-const Integrate: FC<{ projectId: string; target: string }> = ({ projectId, target }) => {
+const Pull: FC<{ target: string; enabled: boolean; isPending: boolean; onPull: () => void }> = ({
+	target,
+	enabled,
+	isPending,
+	onPull,
+}) => (
+	<Tooltip.Root>
+		<Tooltip.Trigger
+			className={getRowButtonClassName({ variant: "outline" })}
+			onClick={onPull}
+			// `disabled` goes on the button so the tooltip still opens over it.
+			render={<Button focusableWhenDisabled disabled={!enabled} />}
+		>
+			{isPending ? "Pulling…" : "Pull latest"}
+		</Tooltip.Trigger>
+		<Tooltip.Portal>
+			<Tooltip.Positioner sideOffset={4}>
+				<Tooltip.Popup render={<TooltipPopup />}>
+					Pull the latest from {target} into the workspace base
+				</Tooltip.Popup>
+			</Tooltip.Positioner>
+		</Tooltip.Portal>
+	</Tooltip.Root>
+);
+
+export const Section: FC<{
+	projectId: string;
+	plan: Plan;
+	onToggleIncoming: () => void;
+	onShowMoreRun: (runId: string) => void;
+	onFoldRun: (runId: string) => void;
+	/** The scroller, for the docked row's toggle to scroll to its place. */
+	scrollElementRef: RefObject<HTMLDivElement | null>;
+}> = ({ projectId, plan, onToggleIncoming, onShowMoreRun, onFoldRun, scrollElementRef }) => {
+	const addressSpace = useAddressSpace();
+	// One mutation for the row and its docked stand-in: each rendering its own
+	// would leave the other's button enabled while a pull runs.
 	const { data: headInfo } = useQuery(headInfoQueryOptions(projectId));
 	const noOperationPending = useAppSelector(
 		(state) => projectSlice.selectors.selectPendingOperation(state, projectId)._tag === "None",
 	);
-	const { isPending, mutate: integrate } = useWorkspaceIntegrateUpstream();
-	const rebase = () => {
+	const { isPending: isPulling, mutate: integrate } = useWorkspaceIntegrateUpstream();
+	const pull = () => {
 		const updates = (headInfo?.stacks ?? [])
 			.values()
 			.map(stackBottomRelativeTo)
@@ -170,91 +244,14 @@ const Integrate: FC<{ projectId: string; target: string }> = ({ projectId, targe
 			.toArray();
 		integrate({ projectId, updates, dryRun: false });
 	};
-	const enabled = noOperationPending && headInfo?.target?.isCurrent === false && !isPending;
-	return (
-		<Tooltip.Root>
-			<Tooltip.Trigger
-				className={getRowButtonClassName({ variant: "outline" })}
-				onClick={rebase}
-				// `disabled` goes on the button so the tooltip still opens over it.
-				render={<Button focusableWhenDisabled disabled={!enabled} />}
-			>
-				{isPending ? "Integrating…" : "Integrate"}
-			</Tooltip.Trigger>
-			<Tooltip.Portal>
-				<Tooltip.Positioner sideOffset={4}>
-					<Tooltip.Popup render={<TooltipPopup />}>
-						Integrate the latest from {target} into the base
-					</Tooltip.Popup>
-				</Tooltip.Positioner>
-			</Tooltip.Portal>
-		</Tooltip.Root>
-	);
-};
-
-/** The "show more" row's state: hidden when nothing older can be asked for. */
-export type MoreBelow = "hidden" | "idle" | "loading" | "failed";
-
-/** The foot of the section: one click lengthens the history below the base. */
-const ShowMore: FC<{ state: MoreBelow; onSelect: () => void }> = ({ state, onSelect }) => (
-	<Row
-		// oxlint-disable-next-line jsx-a11y/prefer-tag-over-role -- A row that acts, styled as the rows around it.
-		role="button"
-		// Not selectable while loading: a second select would restart the fetch.
-		onSelect={state === "loading" ? undefined : onSelect}
-		interactive={state !== "loading"}
-	>
-		<GraphSegment glyph="group" status="Integrated" railEnds centered />
-		<RowLabelContainer>
-			<RowLabel singleLine className={styles.elided}>
-				{state === "loading"
-					? "Loading…"
-					: state === "failed"
-						? "Could not load older commits; try again"
-						: "Show more"}
-			</RowLabel>
-		</RowLabelContainer>
-	</Row>
-);
-
-export const Section: FC<{
-	projectId: string;
-	plan: Plan;
-	moreBelow: MoreBelow;
-	/** The shown history reaches its start: the line ends on the last row. */
-	historyEnds: boolean;
-	onToggleIncoming: () => void;
-	onToggleBase: () => void;
-	onShowMoreRun: (runId: string) => void;
-	onFoldRun: (runId: string) => void;
-	onShowMore: () => void;
-	/** The scroller, for the docked merge base row's toggle to scroll to its place. */
-	scrollElementRef: RefObject<HTMLDivElement | null>;
-	/** The scroller's foot, where a stand-in for the merge base row docks while the row is out of view. */
-	footDock: HTMLDivElement | null;
-}> = ({
-	projectId,
-	plan,
-	moreBelow,
-	historyEnds,
-	onToggleIncoming,
-	onToggleBase,
-	onShowMoreRun,
-	onFoldRun,
-	onShowMore,
-	scrollElementRef,
-	footDock,
-}) => {
-	const branched = plan.header.incoming > 0;
-	const addressSpace = useAddressSpace();
 	// Opening from docked: scroll to the bottom and hold it while the fold grows.
-	const baseFold = useRef<HTMLDivElement>(null);
-	const baseRows = useRef<HTMLDivElement>(null);
-	const toggleBase = () => {
+	const incomingFold = useRef<HTMLDivElement>(null);
+	const incomingRows = useRef<HTMLDivElement>(null);
+	const toggleIncoming = () => {
 		const scroller = scrollElementRef.current;
-		const fold = baseFold.current;
-		const rows = baseRows.current;
-		if (!plan.baseExpanded && scroller !== null && fold !== null && rows !== null) {
+		const fold = incomingFold.current;
+		const rows = incomingRows.current;
+		if (!plan.incomingExpanded && scroller !== null && fold !== null && rows !== null) {
 			scroller.scrollTop = scroller.scrollHeight;
 			let height = 0;
 			const hold = new ResizeObserver(() => {
@@ -265,159 +262,93 @@ export const Section: FC<{
 			});
 			hold.observe(fold);
 		}
-		onToggleBase();
+		onToggleIncoming();
 	};
-	// The line ends on the last row shown: the "show more" row, else the
-	// last commit once the history is shown to its start.
-	const endsOnBase = historyEnds && moreBelow === "hidden" && plan.older.length === 0;
-	/**
-	 * The ref's tip on the base: one row for both. The docked stand-in, with
-	 * no line to show, wears the chevron instead of a glyph.
-	 */
-	const baseHeader = (docked = false) => (
+	const target = plan.header;
+	if (target === null) return null;
+	const branched = target.incoming > 0;
+	/** The target's row. The docked stand-in, with no line to show, wears a chevron instead of the rail. */
+	const header = (docked = false) => (
 		<Header
-			label={plan.refOnBase ? plan.header.label : "Base"}
+			label={target.label}
 			caption={
-				plan.refOnBase ? (
-					<span className={classes("text-12", styles.caption)}>base</span>
-				) : undefined
+				branched ? (
+					<Caption
+						className={styles.incoming}
+						hint={`${target.incoming === 1 ? "A commit" : "Commits"} on ${target.label} not yet in the workspace`}
+					>
+						{target.incoming} new
+					</Caption>
+				) : (
+					// Nothing incoming, yet the base may still trail the target: a lane can
+					// already hold the target's newest commits.
+					<Caption
+						className={styles.caption}
+						hint={target.current ? "Up to date" : `Behind ${target.label}`}
+					>
+						Workspace base
+					</Caption>
+				)
 			}
-			heading={plan.refOnBase}
-			fold={{
-				open: plan.baseExpanded,
-				onToggle: toggleBase,
-				name: "the base's history",
-				hoverChevron: !docked,
-			}}
+			fold={
+				branched
+					? {
+							open: plan.incomingExpanded,
+							onToggle: toggleIncoming,
+							name: "incoming commits",
+							hoverChevron: !docked,
+						}
+					: undefined
+			}
 			rail={
 				docked ? (
 					<span className={styles.chevron}>
-						<Icon name={plan.baseExpanded ? "chevron-down" : "chevron-right"} />
+						<Icon name={plan.incomingExpanded ? "chevron-down" : "chevron-right"} />
 					</span>
+				) : branched ? (
+					// The incoming commits' leg forks off the row, the trunk running on behind.
+					<GraphSegment glyph="forkRight" status="Upstream" behind={1} />
 				) : (
-					<GraphSegment
-						// The trunk hooks in from the edge, meeting the target's leg coming down
-						// the column, unless the ref's row above brought it into the column. No
-						// mark of its own: the row is a label on the line, not a commit.
-						glyph={plan.refOnBase || branched ? "hook" : "parent"}
-						above={branched ? "Upstream" : undefined}
-						// Folded, the hint of the history below stays in the trunk's own grey.
-						below={plan.baseExpanded ? "Integrated" : undefined}
-						status="LocalOnly"
-						folded={!plan.baseExpanded}
-					/>
+					// The trunk runs on past the row with a tick at it, its tail fading out:
+					// the history below is not shown, but this is not where it starts.
+					<GraphSegment glyph="notch" status="LocalOnly" behind={1} folded />
 				)
 			}
+			toolbar={<Fetch projectId={projectId} />}
 			className={docked ? styles.docked : undefined}
-		/>
+		>
+			{!target.current && (
+				<Pull
+					target={target.label}
+					enabled={noOperationPending && !isPulling}
+					isPending={isPulling}
+					onPull={pull}
+				/>
+			)}
+		</Header>
 	);
+	// With the target moved on, its incoming commits sit on a leg that starts
+	// at its row and bends onto the trunk in the gap below; its row says how
+	// many are new and pulls them, so seeing and acting sit together.
 	return (
 		<>
-			{plan.base !== null &&
-				!plan.refOnBase &&
-				(branched ? (
-					// The target has moved on: a card like a forked stack's, the trunk
-					// behind its rows at the edge and its incoming commits on a leg that
-					// starts at its row and runs straight down into the base's. Its row
-					// says how many are new and integrates them: seeing and acting sit together.
-					<>
-						<div className={styles.card}>
-							<Row interactive={false} className={styles.air}>
-								<GraphSegment glyph="space" status="LocalOnly" behind={1} />
-							</Row>
-							<Header
-								label={plan.header.label}
-								caption={
-									<span className={classes("text-12", styles.incoming)}>
-										{plan.header.incoming} new
-									</span>
-								}
-								heading
-								fold={{
-									open: plan.incomingExpanded,
-									onToggle: onToggleIncoming,
-									name: "incoming commits",
-								}}
-								rail={<GraphSegment glyph="forkRight" status="Upstream" behind={1} />}
-							>
-								<Integrate projectId={projectId} target={plan.header.label} />
-							</Header>
-							<Fold open={plan.incomingExpanded}>
-								<div className={styles.rows}>
-									{plan.incoming.map((run) =>
-										runRows(
-											run,
-											"Upstream",
-											addressSpace,
-											1,
-											() => onShowMoreRun(run.id),
-											() => onFoldRun(run.id),
-										),
-									)}
-								</div>
-							</Fold>
-							<Row interactive={false} className={styles.stub}>
-								<GraphSegment glyph="parent" status="Upstream" behind={1} />
-							</Row>
-						</div>
-						<Row interactive={false} className={styles.leg}>
-							<GraphSegment glyph="parent" status="Upstream" behind={1} />
-						</Row>
-					</>
-				) : (
-					// The target sits above the base with nothing incoming: the trunk
-					// hooks in from the edge onto its row and runs on down the column
-					// to the base.
-					<>
-						<Header
-							label={plan.header.label}
-							heading
-							rail={<GraphSegment glyph="hook" status="LocalOnly" />}
-						/>
-						<Row interactive={false} className={styles.leg}>
-							<GraphSegment glyph="parent" status="LocalOnly" />
-						</Row>
-					</>
-				))}
-			{plan.base !== null && (
+			{header()}
+			<div className={styles.dock}>{header(true)}</div>
+			{branched && (
 				<>
-					{baseHeader()}
-					{/* Folded, the row's stand-in docks at the scroller's foot while the row is out
-					    of view below. A portal: the foot is outside the tree, and only there can it
-					    stick over the uncommitted files card, which is outside the tree as well. */}
-					{!plan.baseExpanded && footDock !== null && createPortal(baseHeader(true), footDock)}
-					<Fold open={plan.baseExpanded} className={styles.history} ref={baseFold}>
-						<div ref={baseRows} className={styles.rows}>
-							{plan.belowBase.map((item, index) =>
-								item.kind === "fork"
-									? commitRow(
-											item.commit,
-											"Integrated",
-											addressSpace,
-											0,
-											endsOnBase && index === plan.belowBase.length - 1,
-										)
-									: runRows(
-											item,
-											"Integrated",
-											addressSpace,
-											0,
-											() => onShowMoreRun(item.id),
-											() => onFoldRun(item.id),
-										),
-							)}
-							{plan.older.map((commit, index) =>
-								commitRow(
-									commit,
-									"Integrated",
+					<Fold open={plan.incomingExpanded} ref={incomingFold}>
+						<div ref={incomingRows} className={styles.rows}>
+							{plan.incoming.map((run) =>
+								runRows(
+									run,
 									addressSpace,
-									0,
-									historyEnds && index === plan.older.length - 1,
+									() => onShowMoreRun(run.id),
+									() => onFoldRun(run.id),
 								),
 							)}
-							{moreBelow !== "hidden" && <ShowMore state={moreBelow} onSelect={onShowMore} />}
 						</div>
 					</Fold>
+					<GraphGap height={LEG_GAP} bend="Upstream" />
 				</>
 			)}
 		</>

--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/TargetCommitRow.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/TargetCommitRow.tsx
@@ -2,7 +2,7 @@ import rowStyles from "../Row.module.css";
 import { setCursor } from "#ui/use-cursor.ts";
 import { commitTitle } from "#ui/commit.ts";
 import { classes } from "#ui/components/classes.ts";
-import { GraphSegment, type GraphSegmentStatus } from "#ui/components/GraphSegment.tsx";
+import { GraphSegment } from "#ui/components/GraphSegment.tsx";
 import { Icon } from "#ui/components/Icon.tsx";
 import { RelativeTime } from "#ui/components/RelativeTime.tsx";
 import type { TargetCommit } from "@gitbutler/but-sdk";
@@ -17,15 +17,11 @@ export const TargetCommitRow: FC<{
 	commit: TargetCommit;
 	positionInSet: number;
 	setSize: number;
-	/** Base rows take the integrated colour, incoming rows the upstream's. */
-	status: GraphSegmentStatus;
-	/** The rail ends on this row: the history has no commit below it. */
-	railEnds?: boolean;
 	/** Out of its list for now, as a pending operation leaves it: not a value to move to. */
 	inert?: boolean;
 	/** Columns of the main line running behind the row, left of its rail. */
 	behind?: number;
-}> = ({ commit: targetCommit, positionInSet, setSize, status, railEnds, inert, behind }) => {
+}> = ({ commit: targetCommit, positionInSet, setSize, inert, behind }) => {
 	const { commit, review } = targetCommit;
 	const address = targetCommitAddress(targetCommit);
 	const isSelected = useIsSelected(address, "applied");
@@ -50,7 +46,7 @@ export const TargetCommitRow: FC<{
 			scrollSelectedIntoView
 			onSelect={() => setCursor("applied", address)}
 		>
-			<GraphSegment glyph="commit" status={status} railEnds={railEnds} behind={behind} />
+			<GraphSegment glyph="commit" status="Upstream" behind={behind} />
 			<div className={styles.label}>
 				<RowLabelContainer>
 					<RowLabel singleLine>

--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/layout.test.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/layout.test.ts
@@ -1,17 +1,25 @@
-import type { Commit, Stack, TargetCommit, TargetCommitPage, Worktree } from "@gitbutler/but-sdk";
+import type {
+	Commit,
+	Stack,
+	Target,
+	TargetCommit,
+	TargetCommitPage,
+	Worktree,
+} from "@gitbutler/but-sdk";
 import { describe, expect, it } from "vitest";
 import type { Address } from "#ui/addresses.ts";
 import {
-	foldAt,
+	inSection,
 	layout,
-	FIRST,
-	MORE,
 	sectionAddresses,
 	targetCommitAddress,
 	worktreesOnTip,
 } from "./layout.ts";
 
 type Folds = Parameters<typeof layout>[3];
+
+/** How much of a long run shows at first, as layout.ts has it. */
+const FIRST = 10;
 
 const commit = (id: string, inWorkspace: boolean): TargetCommit => ({
 	commit: {
@@ -76,13 +84,14 @@ const worktree = (name: string, base: Worktree["base"], commits: Array<string>):
 	],
 });
 
-const folded: Folds = {
-	incomingExpanded: false,
-	baseExpanded: false,
-	moreRuns: {},
-	moreOlder: 0,
-};
-const expanded: Folds = { ...folded, incomingExpanded: true, baseExpanded: true };
+const target = (isCurrent: boolean): Target => ({
+	remoteTrackingRef: { fullNameBytes: [], displayName: "master", remoteName: "origin" },
+	commitsAhead: 0,
+	isCurrent,
+});
+
+const folded: Folds = { incomingExpanded: false, moreRuns: {} };
+const expanded: Folds = { ...folded, incomingExpanded: true };
 
 // Newest first: two incoming, a shallow base, three had, a deep base.
 const listing: TargetCommitPage = {
@@ -104,38 +113,7 @@ const incomingAbove = (ids: Array<string>): TargetCommitPage => ({
 	hasMore: false,
 });
 
-// The listing with two commits below the deepest fork point.
-const listingWithTail: TargetCommitPage = {
-	commits: [...listing.commits, commit("t1", true), commit("t2", true)],
-	hasMore: false,
-};
-
 describe("layout", () => {
-	it("shows the listing's tail and the pages fetched below the base once it is open", () => {
-		const stacks = [stack("deep"), stack("shallow")];
-		const pages = [commit("o1", true), commit("o2", true)];
-		const shown = layout(stacks, null, listingWithTail, expanded, pages);
-		// The base heads the section itself; the rows under it start below it.
-		expect(shown.base?.commit.id).toBe("shallow");
-		expect(shown.belowBase.map((item) => item.kind)).toEqual(["run", "fork"]);
-		expect(shown.older.map((c) => c.commit.id)).toEqual(["t1", "t2", "o1", "o2"]);
-		// The base's fold hides them with the rows above.
-		expect(layout(stacks, null, listingWithTail, folded, pages).older).toEqual([]);
-	});
-
-	it("shows the older history a first helping at a time, and more with each ask", () => {
-		const stacks = [stack("deep"), stack("shallow")];
-		const pages = Array.from({ length: 40 }, (_, i) => commit(`o${i}`, true));
-		const all = layout(stacks, null, listingWithTail, { ...expanded, moreOlder: 99 }, pages).older;
-		expect(all.length).toBeGreaterThan(FIRST + MORE);
-		const first = layout(stacks, null, listingWithTail, expanded, pages);
-		expect(first.older).toEqual(all.slice(0, FIRST));
-		expect(first.olderHidden).toBe(all.length - FIRST);
-		const more = layout(stacks, null, listingWithTail, { ...expanded, moreOlder: 1 }, pages);
-		expect(more.older).toHaveLength(FIRST + MORE);
-		expect(more.olderHidden).toBe(all.length - FIRST - MORE);
-	});
-
 	it("orders cards by base depth, deepest first, then as given", () => {
 		const plan = layout([stack("deep"), stack("shallow"), stack("deep")], null, listing, folded);
 		expect(plan.order).toEqual([0, 2, 1]);
@@ -148,79 +126,57 @@ describe("layout", () => {
 		).toEqual([1, 2, 0]);
 	});
 
-	it("folds the incoming leg under the upstream header and the base rows under the base's", () => {
-		const plan = layout([stack("deep")], null, listing, folded);
-		expect(plan.belowBase).toEqual([]);
+	it("folds the incoming leg under the target's header", () => {
+		const plan = layout([stack("deep")], target(true), listing, folded);
 		expect(plan.incoming).toEqual([]);
-		// The base header names the fork point nearest the tip either way.
-		expect(plan.base?.commit.id).toBe("deep");
-		expect(layout([stack("deep"), stack("shallow")], null, listing, folded).base?.commit.id).toBe(
-			"shallow",
-		);
-		expect(
-			layout([stack("deep")], null, listing, { ...folded, baseExpanded: true }).belowBase.map(
-				(item) => item.kind,
-			),
-		).toEqual(["run"]);
+		expect(plan.header?.incoming).toBe(2);
 	});
 
-	it("puts the incoming commits on their own leg, ahead of the base", () => {
+	it("puts the incoming commits on their own leg", () => {
 		const plan = layout([stack("deep"), stack("shallow")], null, listing, expanded);
 		expect(plan.incoming.map((run) => run.shown.map((c) => c.commit.id))).toEqual([["i1", "i2"]]);
-		expect(plan.belowBase.map((item) => item.kind)).toEqual(["run", "fork"]);
 	});
 
-	it("lists the section's rows as values and knows which fold each sits in", () => {
+	it("lists the section's rows as values and knows which sit in it", () => {
 		const plan = layout([stack("deep"), stack("shallow")], null, listing, expanded);
 		const ids = (addresses: Array<Address>) =>
 			addresses.map((address) => (address._tag === "Commit" ? address.commitId : address._tag));
-		// Incoming commits, then what lies below the base; the workspace's own
-		// run folds entirely, and the headers, the base's included, are not values.
-		expect(ids(sectionAddresses(plan))).toEqual(["i1", "i2", "deep"]);
-		const at = (id: string) => foldAt(plan, targetCommitAddress(commit(id, true)));
-		expect(at("i1")).toBe("incoming");
-		expect(at("deep")).toBe("base");
-		expect(at("shallow")).toBeNull();
-		expect(at("h1")).toBeNull();
+		// The incoming commits only: the workspace's own commits and the header are not values.
+		expect(ids(sectionAddresses(plan))).toEqual(["i1", "i2"]);
+		const at = (id: string) => inSection(plan, targetCommitAddress(commit(id, true)));
+		expect(at("i1")).toBe(true);
+		expect(at("deep")).toBe(false);
+		expect(at("h1")).toBe(false);
 	});
 
 	it("shows an incoming run's newest first, more with each ask, unless a fold would hide one row", () => {
 		const ids = Array.from({ length: 25 }, (_, i) => `c${i}`);
 		const many = incomingAbove(ids);
 		const run = layout([stack("base")], null, many, expanded).incoming[0];
-		expect(run?.kind === "run" && run.shown.length).toBe(FIRST);
-		expect(run?.kind === "run" && run.hidden).toBe(25 - FIRST);
-		expect(run?.kind === "run" && run.expanded).toBe(false);
+		expect(run?.shown.length).toBe(FIRST);
+		expect(run?.hidden).toBe(25 - FIRST);
+		expect(run?.expanded).toBe(false);
 		const asked = { ...expanded, moreRuns: { c0: 1 } };
 		const more = layout([stack("base")], null, many, asked).incoming[0];
-		expect(more?.kind === "run" && more.shown.length).toBe(25);
-		expect(more?.kind === "run" && more.hidden).toBe(0);
-		expect(more?.kind === "run" && more.expanded).toBe(true);
+		expect(more?.shown.length).toBe(25);
+		expect(more?.hidden).toBe(0);
+		expect(more?.expanded).toBe(true);
 
 		const eleven = incomingAbove(ids.slice(0, FIRST + 1));
 		const whole = layout([stack("base")], null, eleven, expanded).incoming[0];
-		expect(whole?.kind === "run" && whole.shown.length).toBe(FIRST + 1);
-		expect(whole?.kind === "run" && whole.hidden).toBe(0);
+		expect(whole?.shown.length).toBe(FIRST + 1);
+		expect(whole?.hidden).toBe(0);
 	});
 
-	it("folds a run the workspace already has entirely, and reveals it on asking", () => {
-		const items = layout([stack("deep"), stack("shallow")], null, listing, expanded).belowBase;
-		expect(items.map((item) => item.kind)).toEqual(["run", "fork"]);
-		const had = items[0];
-		expect(had?.kind === "run" && had.shown.length).toBe(0);
-		expect(had?.kind === "run" && had.hidden).toBe(3);
-		const asked = { ...expanded, moreRuns: { h1: 1 } };
-		const shown = layout([stack("deep"), stack("shallow")], null, listing, asked).belowBase[0];
-		expect(shown?.kind === "run" && shown.shown.map((c) => c.commit.id)).toEqual([
-			"h1",
-			"h2",
-			"h3",
-		]);
-	});
-
-	it("knows when the target's tip is the base itself", () => {
-		const current: TargetCommitPage = { commits: [commit("shallow", true)], hasMore: false };
-		expect(layout([stack("shallow")], null, current, folded).refOnBase).toBe(true);
+	it("names the target's row once its commits are known, and says whether the base is at its tip", () => {
+		expect(layout([], target(true), undefined, folded).header).toBeNull();
+		expect(layout([], null, listing, folded).header).toBeNull();
+		expect(layout([], target(true), listing, folded).header).toEqual({
+			label: "origin/master",
+			incoming: 2,
+			current: true,
+		});
+		expect(layout([], target(false), listing, folded).header?.current).toBe(false);
 	});
 
 	it("nests a worktree above the shown commit it rests on, and stands the rest alone", () => {
@@ -228,14 +184,12 @@ describe("layout", () => {
 		const onWorktree = worktree("stacked", { type: "InWorkspace", subject: "w1" }, ["w2"]);
 		const below = worktree("below", { type: "Outside", subject: "deep" }, ["o1"]);
 		const unknown = worktree("unknown", null, []);
-		const { worktrees } = layout(
-			[stackWith("shallow", ["a1", "a2"])],
-			null,
-			listing,
-			folded,
-			[],
-			[inside, onWorktree, below, unknown],
-		);
+		const { worktrees } = layout([stackWith("shallow", ["a1", "a2"])], null, listing, folded, [
+			inside,
+			onWorktree,
+			below,
+			unknown,
+		]);
 		expect(worktrees.on.get("a1")).toEqual([inside]);
 		// A worktree's own commits count as shown, so one resting on them nests inside its lane.
 		expect(worktrees.on.get("w1")).toEqual([onWorktree]);
@@ -246,7 +200,7 @@ describe("layout", () => {
 		const onTip = worktree("tip", { type: "InWorkspace", subject: "a1" }, ["w1"]);
 		const below = worktree("below", { type: "InWorkspace", subject: "a2" }, ["w2"]);
 		const named = stackWith("shallow", ["a1", "a2"], "A");
-		const { worktrees } = layout([named], null, listing, folded, [], [onTip, below]);
+		const { worktrees } = layout([named], null, listing, folded, [onTip, below]);
 		expect(worktreesOnTip(worktrees, named)).toEqual([onTip]);
 		// An unnamed top segment has no branch row to sit above.
 		expect(worktreesOnTip(worktrees, stackWith("shallow", ["a1", "a2"]))).toEqual([]);
@@ -255,14 +209,10 @@ describe("layout", () => {
 	it("keeps worktrees resting on one commit in the order given", () => {
 		const first = worktree("first", { type: "InWorkspace", subject: "a1" }, []);
 		const second = worktree("second", { type: "InWorkspace", subject: "a1" }, []);
-		const { worktrees } = layout(
-			[stackWith("shallow", ["a1"])],
-			null,
-			listing,
-			folded,
-			[],
-			[first, second],
-		);
+		const { worktrees } = layout([stackWith("shallow", ["a1"])], null, listing, folded, [
+			first,
+			second,
+		]);
 		expect(worktrees.on.get("a1")).toEqual([first, second]);
 	});
 });

--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/layout.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/layout.ts
@@ -6,13 +6,11 @@ import type { RefInfo, Stack, TargetCommit, TargetCommitPage, Worktree } from "@
 /*
  * The stacks section as a graph: card order and which section rows show. Pure.
  *
- * One main line, the trunk, runs up the panel's edge from the merge base to
- * the uncommitted files. Every stack card, and a moved-on target's, sits in
- * the column beside it and bends onto it in the gap under it; the base's own
- * rows sit in that column too, hooking the trunk off the edge into them, since
- * no glyph fits on the edge. Rows draw their own gutters, a column each for
- * the lines behind them and the glyph (GraphSegment); a card draws the gap
- * under it.
+ * One main line, the trunk, runs up the panel's edge from below the target's
+ * row to the uncommitted files. Every stack card, and a moved-on target's, sits in
+ * the column beside it and bends onto it in the gap under it. Rows draw their
+ * own gutters, a column each for the lines behind them and the glyph
+ * (GraphSegment); a card draws the gap under it.
  */
 
 /**
@@ -30,23 +28,19 @@ export const CARD_GAP = 20;
 export const LEG_GAP = 12;
 /** The connector between a worktree on a branch's tip and the branch row under it. */
 export const TIP_GAP = 8;
-/** The stuck merge base row's height, hairline and air included, which a row scrolled into view clears. Keep in sync with Section.module.css. */
+/** The stuck target row's height, hairline and air included, which a row scrolled into view clears. Keep in sync with Section.module.css. */
 export const DOCKED_HEIGHT = 1 + 4 + 28 + 4;
 /** The stuck uncommitted files row's height: the card's head room, a row and a hairline. Keep in sync with WorkspaceLists.module.css. */
 export const HEAD_DOCKED_HEIGHT = 6 + 28 + 1;
-/** A long list, a run or the older history, shows this much at first, and this much more with each ask. */
-export const FIRST = 10;
-export const MORE = 20;
+/** A long run shows this much at first, and this much more with each ask. */
+const FIRST = 10;
+const MORE = 20;
 
 type Folds = {
-	/** The upstream header's fold: the commits incoming from the target. */
+	/** The target header's fold: the commits incoming from the target. */
 	incomingExpanded: boolean;
-	/** The base header's fold: the base rows and the older history. */
-	baseExpanded: boolean;
 	/** How many times more of each run was asked for, by the run's id. */
 	moreRuns: Readonly<Record<string, number>>;
-	/** How many times more of the older history was asked for since the base opened. */
-	moreOlder: number;
 };
 
 /** A target commit as a value. The change id falls back to the commit id; revisit. */
@@ -56,10 +50,9 @@ export const targetCommitAddress = (commit: TargetCommit): Address =>
 		changeId: commit.commit.changeId ?? commit.commit.id,
 	});
 
+/** A run of commits on the target the workspace lacks. */
 export type Run = {
-	kind: "run";
 	id: string;
-	incoming: boolean;
 	/** The commits shown, newest first. */
 	shown: Array<TargetCommit>;
 	/** How many more it holds, folded away below them. */
@@ -67,8 +60,6 @@ export type Run = {
 	/** Whether an ask revealed more than shows at first. */
 	expanded: boolean;
 };
-
-export type Item = { kind: "fork"; commit: TargetCommit } | Run;
 
 /**
  * Where the linked worktrees go, the way `but status` places them: a lane
@@ -85,22 +76,16 @@ export type WorktreePlacement = {
 export type Plan = {
 	/** Card order as indices into the stacks given: by base depth, deepest first, then as given. */
 	order: Array<number>;
-	/** The target's row: its label and how many commits are incoming. Not a value: nothing selects it. */
-	header: { label: string; incoming: number };
-	/** The target's tip is the base itself: one row stands for both. */
-	refOnBase: boolean;
+	/**
+	 * The target's row, standing for the workspace's base: its label, how many
+	 * commits are incoming, and whether the base is at the target's tip. Null
+	 * without a target, and until its commits are known. Not a value: nothing
+	 * selects it.
+	 */
+	header: { label: string; incoming: number; current: boolean } | null;
 	incomingExpanded: boolean;
-	baseExpanded: boolean;
-	/** The commit the stacks nearest the tip sit on; the base header names it. Null while unknown. */
-	base: TargetCommit | null;
 	/** Commits on the target the workspace lacks, on their leg. Empty while folded. */
 	incoming: Array<Run>;
-	/** Below the base, on the main line; empty while the base is folded. */
-	belowBase: Array<Item>;
-	/** Older history below the deepest fork point, as much as is shown. Empty while the base is folded. */
-	older: Array<TargetCommit>;
-	/** Older history loaded but not shown yet: what the next ask reveals before any page is fetched. */
-	olderHidden: number;
 	worktrees: WorktreePlacement;
 };
 
@@ -128,25 +113,22 @@ const segmentAtForks = (
 	return items;
 };
 
-/** The line down to the deepest fork point, its runs folded as the fold state says. */
-const foldRuns = (line: ReadonlyArray<TargetItem>, folds: Folds): Array<Item> =>
-	line.slice(0, line.findLastIndex((item) => item.type === "fork") + 1).map((item) => {
-		if (item.type === "fork") return { kind: "fork", commit: item.commit };
-		// Incoming runs show their newest; runs the workspace has fold entirely.
-		// A fold hiding one row is not worth it.
-		const incoming = !item.inWorkspace;
+/** The runs the workspace lacks, each showing its newest and more with each ask. A fold hiding one row is not worth it. */
+const incomingRuns = (line: ReadonlyArray<TargetItem>, folds: Folds): Array<Run> =>
+	line.flatMap((item) => {
+		if (item.type === "fork" || item.inWorkspace) return [];
 		const id = assert(item.commits[0]).commit.id;
 		const asked = folds.moreRuns[id] ?? 0;
-		const asFar = (incoming ? FIRST : 0) + asked * MORE;
+		const asFar = FIRST + asked * MORE;
 		const count = item.commits.length - asFar <= 1 ? item.commits.length : asFar;
-		return {
-			kind: "run",
-			id,
-			incoming,
-			shown: item.commits.slice(0, count),
-			hidden: item.commits.length - count,
-			expanded: asked > 0,
-		};
+		return [
+			{
+				id,
+				shown: item.commits.slice(0, count),
+				hidden: item.commits.length - count,
+				expanded: asked > 0,
+			},
+		];
 	});
 
 const placeWorktrees = (
@@ -194,28 +176,14 @@ export const layout = (
 	target: RefInfo["target"],
 	listing: TargetCommitPage | undefined,
 	folds: Folds,
-	/** Pages of history below the listing, in order, as loaded. */
-	olderPages: ReadonlyArray<TargetCommit> = [],
 	worktrees: ReadonlyArray<Worktree> = [],
 ): Plan => {
 	const commits = listing?.commits ?? [];
 	const line = segmentAtForks(commits, stacks);
-	const items = foldRuns(line, folds);
-	// The listing's tail below the deepest fork heads the older history.
-	const trailing = line
-		.slice(line.findLastIndex((item) => item.type === "fork") + 1)
-		.flatMap((item) => (item.type === "fork" ? [item.commit] : item.commits));
-	const older = folds.baseExpanded ? [...trailing, ...olderPages] : [];
-	const olderShown = FIRST + folds.moreOlder * MORE;
-	const baseItems = items.filter((item) => item.kind !== "run" || !item.incoming);
-	const base = baseItems.find((item) => item.kind === "fork")?.commit ?? null;
-	const belowBase = baseItems.filter(
-		(item) => item.kind !== "fork" || item.commit.commit.id !== base?.commit.id,
-	);
+	const forkOrder = line.flatMap((item) => (item.type === "fork" ? [item.commit.commit.id] : []));
 
 	// Deeper bases first; a base the listing does not reach counts as deepest,
 	// keeping the order given.
-	const forkOrder = items.flatMap((item) => (item.kind === "fork" ? [item.commit.commit.id] : []));
 	const depth = (stack: Stack): number => {
 		const index = stack.base === null ? -1 : forkOrder.indexOf(stack.base);
 		return index === -1 ? forkOrder.length : index;
@@ -229,56 +197,31 @@ export const layout = (
 
 	return {
 		order: order.map((entry) => entry.index),
-		header: {
-			label: target ? remoteTrackingLabel(target.remoteTrackingRef) : "target",
-			incoming: commits.filter((entry) => !entry.inWorkspace).length,
-		},
-		refOnBase:
-			base !== null &&
-			commits[0]?.commit.id === base.commit.id &&
-			commits.every((entry) => entry.inWorkspace),
+		header:
+			target === null || listing === undefined
+				? null
+				: {
+						label: remoteTrackingLabel(target.remoteTrackingRef),
+						incoming: commits.filter((entry) => !entry.inWorkspace).length,
+						// The stored target trails the fetched tip exactly while there is work
+						// to do; counting incoming commits misses the case where a lane already
+						// holds them.
+						current: target.isCurrent,
+					},
 		incomingExpanded: folds.incomingExpanded,
-		baseExpanded: folds.baseExpanded,
-		base,
-		incoming: folds.incomingExpanded
-			? items.flatMap((item) => (item.kind === "run" && item.incoming ? [item] : []))
-			: [],
-		belowBase: folds.baseExpanded ? belowBase : [],
-		older: older.slice(0, olderShown),
-		olderHidden: Math.max(0, older.length - olderShown),
+		incoming: folds.incomingExpanded ? incomingRuns(line, folds) : [],
 		worktrees: placeWorktrees(stacks, worktrees),
 	};
 };
 
-const runCommits = (run: Run): Array<TargetCommit> => run.shown;
+/** The section's rows as values, top to bottom, as the fold state shows them. The header is not a value. */
+export const sectionAddresses = (plan: Plan): Array<Address> =>
+	plan.incoming.flatMap((run) => run.shown.map(targetCommitAddress));
 
-const itemCommits = (item: Item): Array<TargetCommit> =>
-	item.kind === "fork" ? [item.commit] : runCommits(item);
+/** The review a commit on the target line landed, by commit id; null when none or not on the line. */
+export const targetCommitReview = (listing: TargetCommitPage | undefined, commitId: string) =>
+	listing?.commits.find((commit) => commit.commit.id === commitId)?.review ?? null;
 
-/** The rows a fold shows, as values, top to bottom. The headers are not values. */
-export const foldAddresses = (plan: Plan, fold: "incoming" | "base"): Array<Address> =>
-	(fold === "incoming"
-		? plan.incoming.flatMap(runCommits)
-		: [...plan.belowBase.flatMap(itemCommits), ...plan.older]
-	).map(targetCommitAddress);
-
-/** The section's rows as values, top to bottom, as the fold state shows them. */
-export const sectionAddresses = (plan: Plan): Array<Address> => [
-	...foldAddresses(plan, "incoming"),
-	...foldAddresses(plan, "base"),
-];
-
-/** The review a shown target commit landed, by commit id; null when none or not shown. */
-export const planCommitReview = (plan: Plan, commitId: string) =>
-	[
-		...plan.incoming.flatMap(runCommits),
-		...plan.belowBase.flatMap(itemCommits),
-		...plan.older,
-	].find((commit) => commit.commit.id === commitId)?.review ?? null;
-
-/** Which of the section's folds a row sits in, so a fold key on the row can close it; null off the section. */
-export const foldAt = (plan: Plan, address: Address): "incoming" | "base" | null => {
-	const inFold = (fold: "incoming" | "base") =>
-		foldAddresses(plan, fold).some((other) => addressEquals(address, other));
-	return inFold("incoming") ? "incoming" : inFold("base") ? "base" : null;
-};
+/** Whether a row sits in the section's fold, so a fold key on the row can close it. */
+export const inSection = (plan: Plan, address: Address): boolean =>
+	sectionAddresses(plan).some((other) => addressEquals(address, other));

--- a/apps/lite/ui/src/routes/project/$id/workspace/Graph/usePlan.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Graph/usePlan.ts
@@ -1,61 +1,31 @@
-import {
-	headInfoQueryOptions,
-	olderTargetCommitsInfiniteQueryOptions,
-	workspaceTargetCommitsQueryOptions,
-} from "#ui/api/queries.ts";
+import { headInfoQueryOptions, workspaceTargetCommitsQueryOptions } from "#ui/api/queries.ts";
 import { projectSlice } from "#ui/projects/state.ts";
 import { useAppSelector } from "#ui/store.ts";
 import type { Stack, Worktree } from "@gitbutler/but-sdk";
-import { useInfiniteQuery, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useMemo } from "react";
-import { FIRST, layout, MORE, type Plan } from "./layout.ts";
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+import { layout, type Plan } from "./layout.ts";
 
 const noWorktrees: ReadonlyArray<Worktree> = [];
 
-/** The stacks graph as its host computes it once: the plan, the cards in its order, the linked worktrees, and the older history's paging. */
+/** The stacks graph as its host computes it once: the plan, the cards in its order, the linked worktrees, and the target line. */
 export type Graph = ReturnType<typeof usePlan>;
 
-/**
- * The stacks graph's plan and the cards in its order. Called once per host,
- * which hands it to the stacks: a second call would page the older history
- * twice.
- */
+/** The stacks graph's plan and the cards in its order. Called once per host, which hands it to the stacks. */
 export const usePlan = (projectId: string) => {
 	const { data: headInfo } = useQuery(headInfoQueryOptions(projectId));
 	const { data: listing } = useQuery(workspaceTargetCommitsQueryOptions(projectId));
 	const folds = useAppSelector((state) =>
 		projectSlice.selectors.selectGraphFolds(state, projectId),
 	);
-	// Older history: pages shared with the Upstream tab, fetched as the base opens and on demand.
-	const olderFrom = listing?.commits.at(-1)?.commit.id ?? "";
-	const olderOptions = olderTargetCommitsInfiniteQueryOptions(projectId, olderFrom);
-	const olderQuery = useInfiniteQuery({
-		...olderOptions,
-		enabled: folds.baseExpanded && olderFrom !== "",
-	});
-	// Folding the base forgets its pages, so it reopens from scratch.
-	const queryClient = useQueryClient();
-	const forgetOlder = () => queryClient.removeQueries({ queryKey: olderOptions.queryKey });
-	const olderPagesData = olderQuery.data;
-	const olderPages = useMemo(
-		() => olderPagesData?.pages.flatMap((page) => page.commits) ?? [],
-		[olderPagesData],
-	);
 	const listOrder = useMemo(() => headInfo?.stacks ?? [], [headInfo]);
 	const target = headInfo?.target ?? null;
 	const worktrees = headInfo?.worktrees ?? noWorktrees;
 	// Explicit: the compiler does not memoise imported calls, and the rails re-measure on every new plan.
 	const plan: Plan = useMemo(
-		() => layout(listOrder, target, listing, folds, olderPages, worktrees),
-		[listOrder, target, listing, folds, olderPages, worktrees],
+		() => layout(listOrder, target, listing, folds, worktrees),
+		[listOrder, target, listing, folds, worktrees],
 	);
-	// Fetch a page whenever an ask outruns what is loaded.
-	const { fetchNextPage, hasNextPage, isFetching } = olderQuery;
-	const loaded = plan.older.length + plan.olderHidden;
-	const wanted = folds.baseExpanded ? FIRST + folds.moreOlder * MORE : 0;
-	useEffect(() => {
-		if (loaded < wanted && hasNextPage && !isFetching) void fetchNextPage();
-	}, [loaded, wanted, hasNextPage, isFetching, fetchNextPage]);
 	const stacks: Array<Stack> = useMemo(
 		() =>
 			plan.order.flatMap((index) => {
@@ -64,5 +34,5 @@ export const usePlan = (projectId: string) => {
 			}),
 		[plan, listOrder],
 	);
-	return { plan, stacks, worktrees, olderQuery, olderFrom, forgetOlder };
+	return { plan, stacks, worktrees, listing };
 };

--- a/apps/lite/ui/src/routes/project/$id/workspace/Page.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Page.tsx
@@ -62,7 +62,7 @@ import {
 } from "#ui/addresses.ts";
 import { Details, type DiffViewerHandle, UncommittedFilesDetails } from "./Details.tsx";
 import { buildAppliedAddressSpace } from "./applied-address-space.ts";
-import { planCommitReview } from "./Graph/layout.ts";
+import { targetCommitReview } from "./Graph/layout.ts";
 import { usePlan } from "./Graph/usePlan.ts";
 import { buildUncommittedFileRows } from "./file-row.ts";
 import { fileTreeAddressSpace, selectedFilePath } from "./file-tree.ts";
@@ -488,10 +488,10 @@ const PageBody: FC<{ projectId: string }> = ({ projectId }) => {
 	// because `useDeferredValue` compares by identity, so a freshly built element
 	// every render would defer every render. Looked up outside the memo so the
 	// details only rebuild when the review itself changes, not on every list rerun.
-	// A target commit selected in the stacks graph carries the review it landed.
+	// A commit on the target line, selected anywhere in the graph, carries the review it landed.
 	const appliedReview =
 		appliedSelection?._tag === "Commit"
-			? planCommitReview(graph.plan, appliedSelection.commitId)
+			? targetCommitReview(graph.listing, appliedSelection.commitId)
 			: null;
 	const details = useMemo(() => {
 		const viewProps = { projectId, onActiveFileSelection, viewerRef, didScrollToViaFileRef };

--- a/apps/lite/ui/src/routes/project/$id/workspace/Sidebar.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/Sidebar.tsx
@@ -1,14 +1,8 @@
 import { useWorkspaceIntegrateUpstream } from "#ui/api/mutations.ts";
 import { setPage, usePage } from "#ui/use-cursor.ts";
-import {
-	guiSettingsQueryOptions,
-	headInfoQueryOptions,
-	workspaceFetchQueryOptions,
-	workspaceFetchStatusQueryOptions,
-} from "#ui/api/queries.ts";
+import { headInfoQueryOptions } from "#ui/api/queries.ts";
 import { NotificationBell } from "#ui/review-inbox-bell.tsx";
 import { stackBottomRelativeTo } from "#ui/api/stack.ts";
-import { errorMessageForToast } from "#ui/errors.ts";
 import { Icon } from "#ui/components/Icon.tsx";
 import { TooltipPopup } from "#ui/components/Tooltip.tsx";
 import { workspaceHotkeys } from "#ui/hotkeys.ts";
@@ -17,7 +11,7 @@ import { projectSlice } from "#ui/projects/state.ts";
 import { interfaceSlice } from "#ui/interface/state.ts";
 import { useAppDispatch, useAppSelector } from "#ui/store.ts";
 import type { AddressSpace } from "#ui/workspace/address-space.ts";
-import { Button, Toast, Toggle, ToggleGroup, Tooltip } from "@base-ui/react";
+import { Button, Toggle, ToggleGroup, Tooltip } from "@base-ui/react";
 import type { BottomUpdate, ProjectForFrontend } from "@gitbutler/but-sdk";
 import { useQuery } from "@tanstack/react-query";
 import { useHotkeys } from "@tanstack/react-hotkeys";
@@ -27,6 +21,7 @@ import { WorkspaceLists } from "#ui/routes/project/$id/workspace/WorkspaceLists/
 import type { Graph } from "#ui/routes/project/$id/workspace/Graph/usePlan.ts";
 import { BranchesList } from "#ui/routes/project/$id/workspace/BranchesList.tsx";
 import type { BranchesListContent } from "#ui/routes/project/$id/workspace/useBranchesList.ts";
+import { useFetchFromRemotes } from "#ui/routes/project/$id/workspace/useFetchFromRemotes.ts";
 import { assert } from "#ui/assert.ts";
 import type { PageId } from "#ui/projects/project.ts";
 import styles from "./Sidebar.module.css";
@@ -68,7 +63,6 @@ export const Sidebar: FC<{
 	projectId,
 }) => {
 	const dispatch = useAppDispatch();
-	const toastManager = Toast.useToastManager();
 	const noOperationPending = useAppSelector(
 		(state) => projectSlice.selectors.selectPendingOperation(state, projectId)._tag === "None",
 	);
@@ -92,29 +86,9 @@ export const Sidebar: FC<{
 	const newBranch = useNewBranch(projectId);
 
 	const { data: headInfo } = useQuery(headInfoQueryOptions(projectId));
-	const { data: autoFetchFrequency } = useQuery({
-		...guiSettingsQueryOptions,
-		select: (cfg) => cfg.autoFetchFrequency,
-	});
-	const { data: workspaceFetchStatus } = useQuery(workspaceFetchStatusQueryOptions(projectId));
 	const { isPending: isWorkspaceIntegrateUpstreamPending, mutate: workspaceIntegrateUpstream } =
 		useWorkspaceIntegrateUpstream();
-	const { isFetching: isWorkspaceFetchFromRemotesPending, refetch: workspaceFetchFromRemotes } =
-		useQuery(workspaceFetchQueryOptions(projectId, autoFetchFrequency));
-	const fetchFromRemotes = () => {
-		void workspaceFetchFromRemotes().then(({ error }) => {
-			if (!error) return;
-
-			// oxlint-disable-next-line no-console
-			console.error(error);
-			toastManager.add({
-				type: "error",
-				title: "Failed to fetch",
-				description: errorMessageForToast(error),
-				priority: "high",
-			});
-		});
-	};
+	const fetchFromRemotes = useFetchFromRemotes(projectId);
 	const updateWorkspace = () => {
 		const rebaseUpdates = (headInfo?.stacks ?? [])
 			.values()
@@ -132,8 +106,6 @@ export const Sidebar: FC<{
 		noOperationPending &&
 		headInfo?.target?.isCurrent === false &&
 		!isWorkspaceIntegrateUpstreamPending;
-	const canFetchFromRemotes = noOperationPending && !isWorkspaceFetchFromRemotesPending;
-
 	const canCreateBranch = newBranch.enabled;
 
 	const ref = useRef<HTMLDivElement>(null);
@@ -173,9 +145,9 @@ export const Sidebar: FC<{
 		},
 		{
 			hotkey: workspaceHotkeys.fetchFromRemotes.hotkey,
-			callback: fetchFromRemotes,
+			callback: fetchFromRemotes.fetch,
 			options: {
-				enabled: canFetchFromRemotes,
+				enabled: fetchFromRemotes.enabled,
 				meta: workspaceHotkeys.fetchFromRemotes.meta,
 			},
 		},
@@ -216,10 +188,7 @@ export const Sidebar: FC<{
 				<SidebarHeader
 					bell={<NotificationBell projectId={projectId} />}
 					project={project}
-					canFetch={canFetchFromRemotes}
-					isFetchPending={isWorkspaceFetchFromRemotesPending}
-					lastSuccessfulFetchMs={workspaceFetchStatus?.lastSuccessfulMs}
-					onFetch={fetchFromRemotes}
+					isFetchPending={fetchFromRemotes.isPending}
 					canOpenSettings={noOperationPending}
 					onOpenSettings={openSettings}
 				/>

--- a/apps/lite/ui/src/routes/project/$id/workspace/SidebarHeader.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/SidebarHeader.tsx
@@ -4,12 +4,11 @@ import { TooltipPopup } from "#ui/components/Tooltip.tsx";
 import { workspaceHotkeys } from "#ui/hotkeys.ts";
 import { ProjectPicker } from "#ui/routes/project/$id/workspace/ProjectPicker.tsx";
 import { TopLeftControls } from "#ui/routes/project/$id/workspace/TopLeftControls.tsx";
-import { formatRelativeTime } from "#ui/time.ts";
 import { Button, Tooltip } from "@base-ui/react";
 import type { ProjectForFrontend } from "@gitbutler/but-sdk";
 import { useIsFetching, useIsMutating } from "@tanstack/react-query";
 import { Match } from "effect";
-import { type FC, type ReactNode, useState } from "react";
+import type { FC, ReactNode } from "react";
 import styles from "./SidebarHeader.module.css";
 
 const ActivitySpinner: FC<{
@@ -37,55 +36,14 @@ const ActivitySpinner: FC<{
 	);
 };
 
-const FetchFromRemotesButton: FC<{
-	canFetch: boolean;
-	isPending: boolean;
-	lastSuccessfulMs?: number | null;
-	onFetch: () => void;
-}> = (p) => {
-	const [tooltipNow, setTooltipNow] = useState(() => Date.now());
-
-	return (
-		<Tooltip.Root
-			onOpenChange={(open) => {
-				if (open) setTooltipNow(Date.now());
-			}}
-		>
-			<Tooltip.Trigger
-				aria-label={workspaceHotkeys.fetchFromRemotes.meta.name}
-				className={getButtonClassName({ iconOnly: true, variant: "ghost" })}
-				onClick={p.onFetch}
-				// We pass `disabled` here because we want to disable the button, not
-				// the tooltip.
-				render={<Button focusableWhenDisabled disabled={!p.canFetch} />}
-			>
-				<Icon name={p.isPending ? "spinner" : "refresh"} />
-			</Tooltip.Trigger>
-			<Tooltip.Portal>
-				<Tooltip.Positioner sideOffset={4}>
-					<Tooltip.Popup render={<TooltipPopup kbd={workspaceHotkeys.fetchFromRemotes.hotkey} />}>
-						{workspaceHotkeys.fetchFromRemotes.meta.name}
-						{p.lastSuccessfulMs != null &&
-							` (${formatRelativeTime(p.lastSuccessfulMs, tooltipNow)})`}
-					</Tooltip.Popup>
-				</Tooltip.Positioner>
-			</Tooltip.Portal>
-		</Tooltip.Root>
-	);
-};
-
 /**
  * The app chrome at the top of the sidebar: window controls, the project
- * picker, activity, fetch and settings. Purely presentational — the
- * fetch/update wiring stays with the Sidebar, which also feeds it to the
- * upstream list and the hotkeys.
+ * picker, activity and settings. Purely presentational.
  */
 export const SidebarHeader: FC<{
 	project: ProjectForFrontend;
-	canFetch: boolean;
+	/** A fetch in flight shows its own spinner on the target's row, so the ambient one stands down. */
 	isFetchPending: boolean;
-	lastSuccessfulFetchMs?: number | null;
-	onFetch: () => void;
 	canOpenSettings: boolean;
 	onOpenSettings: () => void;
 	/** The notification bell, which decides its own visibility. */
@@ -100,13 +58,6 @@ export const SidebarHeader: FC<{
 		</div>
 
 		<div className={styles.workspaceControlsActions}>
-			<FetchFromRemotesButton
-				canFetch={p.canFetch}
-				isPending={p.isFetchPending}
-				lastSuccessfulMs={p.lastSuccessfulFetchMs}
-				onFetch={p.onFetch}
-			/>
-
 			<Tooltip.Root>
 				<Tooltip.Trigger
 					aria-label={workspaceHotkeys.settings.meta.name}

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.module.css
@@ -42,21 +42,10 @@
 	height: 0;
 }
 
-/* The merge base row's stand-in docks at the foot the same way: a mark after
-   everything, stuck while the row is out of view below. Its row is Section's. */
-.footDock {
-	container-type: scroll-state;
-
-	z-index: 2;
-	position: sticky;
-	bottom: 0;
-	height: 0;
-}
-
-/* The room below is constant across fold states, so a fold does not shift
-   the scroll. An element after the foot dock's mark rather than padding on
-   the scroller: the mark unsticks exactly as the merge base row comes into
-   view, and sticky insets stop at the scroller's padding. */
+/* The target row's stand-in docks at the foot the same way, with a mark of
+   Section's own right after its row. The room below is constant across fold
+   states, so a fold does not shift the scroll. An element rather than
+   padding on the scroller: sticky insets stop at the scroller's padding. */
 .foot {
 	height: 12px;
 }
@@ -132,7 +121,7 @@
 }
 
 /* The commit form keeps to the scroller's foot while the card's own foot is
-   below it, over the docked merge base row when there is one (its `bottom`),
+   below it, over the docked target row when there is one (its `bottom`),
    so a long list still commits. A hairline while stuck says the rows pass
    beneath; a shadow, so the form's height does not change as it sticks. */
 .commitFoot {

--- a/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/WorkspaceLists/WorkspaceLists.tsx
@@ -58,14 +58,14 @@ import {
 } from "react";
 import styles from "./WorkspaceLists.module.css";
 import { Row, RowLabel, RowLabelContainer, SectionHeaderRow } from "../Row.tsx";
-import { type MoreBelow, Section } from "../Graph/Section.tsx";
+import { Section } from "../Graph/Section.tsx";
 import {
 	CARD_GAP,
 	DOCKED_HEIGHT,
 	HEAD_DOCKED_HEIGHT,
 	ROW_INSET,
-	foldAddresses,
-	foldAt,
+	inSection,
+	sectionAddresses,
 	type WorktreePlacement,
 	worktreesOnTip,
 } from "../Graph/layout.ts";
@@ -163,7 +163,7 @@ const UncommittedChanges: FC<
 		worktreeChanges: WorktreeChanges | undefined;
 		/** The graph's scroller, which the card heads. */
 		scrollElementRef: RefObject<HTMLDivElement | null>;
-		/** The docked merge base row's height at the scroller's foot, or 0: the commit form sticks above it. */
+		/** The docked target row's height at the scroller's foot, or 0: the commit form sticks above it. */
 		footDock: number;
 		/** The card's head, measured by the parent, which docks a stand-in as soon as the head is pushed. */
 		headRef: (element: HTMLElement | null) => void;
@@ -617,7 +617,7 @@ const SegmentContent: FC<{
 		getItemKey: getCommitKey,
 		rangeExtractor: rangeExtractorWithSelected,
 		scrollMargin,
-		// Matches --scroll-gradient-height; the foot also clears the docked merge base row.
+		// Matches --scroll-gradient-height; the foot also clears the docked target row.
 		scrollPaddingStart: 14,
 		scrollPaddingEnd,
 	});
@@ -1118,23 +1118,7 @@ const Stacks: FC<{
 	});
 	const dryRunWorkspace = dryRunOperationResult?.workspace ?? null;
 	// Cards in the graph's order, the section below.
-	const { plan, stacks, olderQuery, olderFrom, forgetOlder } = graph;
-	const olderPagesData = olderQuery.data;
-	// Shown to its start: everything loaded is shown, and a page came back
-	// with nothing older behind it.
-	const historyEnds =
-		olderPagesData !== undefined && !olderQuery.hasNextPage && plan.olderHidden === 0;
-	const moreBelow: MoreBelow =
-		olderFrom === ""
-			? "hidden"
-			: olderQuery.isFetching
-				? "loading"
-				: olderQuery.isError
-					? "failed"
-					: historyEnds
-						? "hidden"
-						: "idle";
-	const showMore = () => dispatch(projectSlice.actions.showMoreGraphOlder({ projectId }));
+	const { plan, stacks } = graph;
 	// Undefined `headInfo` is still loading, which is not the same as "empty" —
 	// treating it as empty would flash the empty state on every open.
 	const isEmpty = headInfo !== undefined && stacks.length === 0;
@@ -1164,8 +1148,6 @@ const Stacks: FC<{
 	// The cards start under the uncommitted files card and the gap below it.
 	const [headRef, headHeight] = useHeight();
 	const scrollMargin = headHeight + CARD_GAP;
-	// The scroller's foot, for the merge base row's stand-in. State, not a ref: it is portalled into.
-	const [footDock, setFootDock] = useState<HTMLDivElement | null>(null);
 	const getStackKey = useCallback((index: number) => stacks[index]?.id ?? index, [stacks]);
 	const headInfoIndex = headInfo ? getHeadInfoIndex(headInfo) : undefined;
 	const selectedContext =
@@ -1236,16 +1218,16 @@ const Stacks: FC<{
 		getItemKey: getStackKey,
 		rangeExtractor: rangeExtractorWithSelected,
 		scrollMargin,
-		// The head clears the docked uncommitted files row, the foot the docked merge base row.
+		// The head clears the docked uncommitted files row, the foot the docked target row.
 		scrollPaddingStart: HEAD_DOCKED_HEIGHT,
 		scrollPaddingEnd,
 	});
 
 	const selectedAddressKey = selection === null ? undefined : addressIdentityKey(selection);
-	// The fold the selection sits in, looked up once per selection or plan:
-	// the hotkeys ask on every render.
-	const selectedFold = useMemo(
-		() => (selection === null ? null : foldAt(plan, selection)),
+	// Whether the selection sits in the section's fold, looked up once per
+	// selection or plan: the hotkeys ask on every render.
+	const selectedInSection = useMemo(
+		() => selection !== null && inSection(plan, selection),
 		[plan, selection],
 	);
 	const lastRevealedAddressKeyRef = useRef<string>(undefined);
@@ -1269,10 +1251,6 @@ const Stacks: FC<{
 	}, [rowVirtualizer, selectedAddressKey, selectedStackIndex]);
 
 	const toggleIncoming = () => dispatch(projectSlice.actions.toggleGraphIncoming({ projectId }));
-	const toggleBase = () => {
-		if (plan.baseExpanded) forgetOlder();
-		dispatch(projectSlice.actions.toggleGraphBase({ projectId }));
-	};
 	const showMoreRun = (runId: string) =>
 		dispatch(projectSlice.actions.showMoreGraphRun({ projectId, runId }));
 	const foldRun = (runId: string) =>
@@ -1286,22 +1264,20 @@ const Stacks: FC<{
 		focusCommitMessageInput,
 		onEdgeSpill,
 		pendingPushBranches,
-		// The fold key on a section row closes the fold it sits in and parks the
-		// cursor on the row above the fold, since the headers are not values.
-		sectionToggle:
-			selectedFold === null
-				? null
-				: () => {
-						const first = foldAddresses(plan, selectedFold)[0];
-						const index =
-							first === undefined
-								? undefined
-								: addressSpace.indexByKey.get(addressIdentityKey(first));
-						const above = index === undefined ? undefined : addressSpace.items[index - 1];
-						if (above !== undefined) setCursor("applied", above);
-						if (selectedFold === "incoming") toggleIncoming();
-						else toggleBase();
-					},
+		// The fold key on a section row closes the fold and parks the cursor on
+		// the row above it, since the header is not a value.
+		sectionToggle: selectedInSection
+			? () => {
+					const first = sectionAddresses(plan)[0];
+					const index =
+						first === undefined
+							? undefined
+							: addressSpace.indexByKey.get(addressIdentityKey(first));
+					const above = index === undefined ? undefined : addressSpace.items[index - 1];
+					if (above !== undefined) setCursor("applied", above);
+					toggleIncoming();
+				}
+			: null,
 	});
 
 	return (
@@ -1378,15 +1354,10 @@ const Stacks: FC<{
 					<Section
 						projectId={projectId}
 						plan={plan}
-						moreBelow={moreBelow}
-						historyEnds={historyEnds}
 						onToggleIncoming={toggleIncoming}
-						onToggleBase={toggleBase}
 						onShowMoreRun={showMoreRun}
 						onFoldRun={foldRun}
-						onShowMore={showMore}
 						scrollElementRef={scrollElementRef}
-						footDock={footDock}
 					/>
 				</div>
 
@@ -1395,7 +1366,6 @@ const Stacks: FC<{
 						<NoStacks projectId={projectId} newBranch={newBranch} />
 					</div>
 				)}
-				<div className={styles.footDock} ref={setFootDock} />
 				<div className={styles.foot} />
 			</div>
 		</DryRunWorkspaceContext>
@@ -1556,9 +1526,9 @@ export const WorkspaceLists: FC<
 		focusScope("uncommitted-files");
 	};
 	const scrollElementRef = useRef<HTMLDivElement>(null);
-	// The docked merge base row's height, which the card's commit form sticks above; a row
+	// The docked target row's height, which the card's commit form sticks above; a row
 	// scrolled into view clears it, else the foot's gradient.
-	const footDock = graph.plan.base !== null && !graph.plan.baseExpanded ? DOCKED_HEIGHT : 0;
+	const footDock = graph.plan.header !== null ? DOCKED_HEIGHT : 0;
 	const scrollPaddingEnd = Math.max(footDock, 14);
 	// The card's head, whose height says when its docked stand-in takes over.
 	const [cardHeadRef, cardHeadHeight] = useHeight();

--- a/apps/lite/ui/src/routes/project/$id/workspace/useFetchFromRemotes.ts
+++ b/apps/lite/ui/src/routes/project/$id/workspace/useFetchFromRemotes.ts
@@ -1,0 +1,50 @@
+import {
+	guiSettingsQueryOptions,
+	workspaceFetchQueryOptions,
+	workspaceFetchStatusQueryOptions,
+} from "#ui/api/queries.ts";
+import { errorMessageForToast } from "#ui/errors.ts";
+import { projectSlice } from "#ui/projects/state.ts";
+import { useAppSelector } from "#ui/store.ts";
+import { Toast } from "@base-ui/react";
+import { useQuery } from "@tanstack/react-query";
+
+/**
+ * Fetching from the remotes: the target's row has the button, the sidebar the
+ * hotkey. Both call this; the query behind it is shared, so each sees the
+ * other's fetch in flight.
+ */
+export const useFetchFromRemotes = (projectId: string) => {
+	const toastManager = Toast.useToastManager();
+	const noOperationPending = useAppSelector(
+		(state) => projectSlice.selectors.selectPendingOperation(state, projectId)._tag === "None",
+	);
+	const { data: autoFetchFrequency } = useQuery({
+		...guiSettingsQueryOptions,
+		select: (cfg) => cfg.autoFetchFrequency,
+	});
+	const { data: status } = useQuery(workspaceFetchStatusQueryOptions(projectId));
+	const { isFetching, refetch } = useQuery(
+		workspaceFetchQueryOptions(projectId, autoFetchFrequency),
+	);
+	const fetch = () => {
+		void refetch().then(({ error }) => {
+			if (!error) return;
+
+			// oxlint-disable-next-line no-console
+			console.error(error);
+			toastManager.add({
+				type: "error",
+				title: "Failed to fetch",
+				description: errorMessageForToast(error),
+				priority: "high",
+			});
+		});
+	};
+	return {
+		fetch,
+		isPending: isFetching,
+		enabled: noOperationPending && !isFetching,
+		lastSuccessfulMs: status?.lastSuccessfulMs,
+	};
+};


### PR DESCRIPTION
The upstream section under the stacks no longer folds the merge base and its older history: browsing history is not this panel's job. The target's row (`origin/master`) stands for the workspace base instead.

**Up to date**: the row reads "Workspace base" (hover: "Up to date"). The trunk runs on past it with a small tick, its tail fading out below to say the history goes on unseen.

**Moved on**: the row counts the new commits (hover explains they are not in the workspace yet), folds them on a leg that bends back onto the trunk in the gap below, and offers **Pull latest** (was "Integrate"). Only the chevron toggles the fold, like the rows above.

No card in either state: the target is not in the workspace, and sitting directly on the panel says so.

**Fetch** moves from the header onto this row's right edge, since the target is what a fetch moves. The wiring is a shared `useFetchFromRemotes` hook used by the button and the hotkey.

**Docking**: the row sticks to the scroller's foot whenever it scrolls out of view, fold open or not (the base only docked while folded). It has its own sticky mark right after it, and the stuck stand-in wears a chevron in place of the rail.

Removed with the base: the older-history query and paging, the `baseExpanded`/`moreOlder` state, the `hook` glyph and dashed rails in `GraphSegment`, and the fork/run item union in `layout.ts`.