### PR TITLE
Tell stub installs to read the guide whole and alone

### DIFF
--- a/crates/but/skill/AGENTS.md
+++ b/crates/but/skill/AGENTS.md
@@ -3,8 +3,10 @@
 `SKILL.md` and `references/` are installed verbatim into users' agents — a wrong
 line here misdirects every agent in every user repo. Only the files in
 `SKILL_FILES` in `crates/but/src/command/skill/mod.rs` ship, so register any new
-reference file there. `stub.md` is the body of the single-file stub install and
-must only point at `but skill` commands; it carries no facts about `but`.
+reference file there. `stub.md` is the body of the single-file stub install. It
+points only at `but skill` commands and says what each prints and how to read
+it; command syntax and behavior stay in the served guide, where they cannot go
+stale.
 
 - **Never document anything that can block on a TTY.** An editor or interactive
   picker hangs an agent forever. Give the non-interactive form (`-m`,

--- a/crates/but/skill/stub.md
+++ b/crates/but/skill/stub.md
@@ -1,16 +1,9 @@
 # GitButler CLI Skill
 
-This file is a discovery stub, not the usage guide. Before your first `but` command, load the guide from the CLI so it always matches the installed version:
+This file is a discovery stub. The usage guide is printed by the CLI, so it always matches the installed version. Before your first `but` command, run it on its own and read all of it; it is about 200 lines, and other commands in the same call get buried under it:
 
 ```bash
-but skill                       # the loop, IDs, rules, task recipes
-but skill --full                # plus command reference, concepts, examples
+but skill
 ```
 
-Load one reference directly when you know what you need:
-
-```bash
-but skill reference             # command syntax and flags
-but skill concepts              # workspace model
-but skill examples              # workflows
-```
+The guide covers the loop, IDs, rules, and task recipes. When you need a flag it does not mention, `but skill reference` prints each command's syntax and flags.

--- a/crates/but/tests/but/command/skill/serve.rs
+++ b/crates/but/tests/but/command/skill/serve.rs
@@ -160,7 +160,7 @@ fn skill_install_stub_writes_one_marked_file_that_check_accepts() {
         "the stub is marked and pre-approves the read it asks for, got: {skill_md}"
     );
     assert!(
-        skill_md.contains("run `but skill`") || skill_md.contains("but skill  "),
+        skill_md.contains("\n```bash\nbut skill\n```\n"),
         "the stub body points at the CLI, got: {skill_md}"
     );
     assert!(


### PR DESCRIPTION
The stub is the only text an agent sees before deciding how to call the CLI, and its menu was steering that call badly: `but skill` got piped through `head` and cut off before the task recipes, `--full` produced a guide too long to arrive intact and then got searched for sections that were not in the slice, and the guide was run in the same call as `but status`, burying the status output.

The stub now names the guide's size, asks for a call of its own, and offers `but skill reference` as the one conditional second read. `--full`, `concepts`, and `examples` are no longer advertised; they remain available. Stub installs only; the full install is untouched.