### PR TITLE
Use neutral badges for automated PR comments

### DIFF
--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestComments.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestComments.module.css
@@ -477,13 +477,6 @@
 	}
 }
 
-/* A card by an agent (any bot author): tinted so automated feedback reads
-   apart from human conversation at a glance. */
-.cardAgent {
-	border-color: color-mix(in srgb, var(--fill-purple-bg) 35%, var(--border-3));
-	background-color: color-mix(in srgb, var(--fill-purple-bg) 4%, var(--bg-1));
-}
-
 /* The Activity section's reveal, in the app's designed link treatment. */
 .timelineMore {
 	align-self: flex-start;

--- a/apps/lite/ui/src/routes/project/$id/workspace/PullRequestComments.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/PullRequestComments.tsx
@@ -97,11 +97,11 @@ type Quotable = { body: string | null; author: ForgeReviewUser | null };
  * agent author carries a chip so automated feedback reads apart from human
  * conversation.
  */
-const Author: FC<{ user: ForgeReviewUser; compact?: boolean }> = ({ user, compact = false }) => (
+const Author: FC<{ user: ForgeReviewUser }> = ({ user }) => (
 	<>
 		<Avatar src={user.avatarUrl} />
 		<span className={classes("text-13", "text-semibold", styles.authorLogin)}>{user.login}</span>
-		{isAgent(user) && <Badge variant={compact ? "lightGray" : "purple"}>Agent</Badge>}
+		{isAgent(user) && <Badge variant="lightGray">Agent</Badge>}
 	</>
 );
 
@@ -145,14 +145,7 @@ const Card: FC<{
 	id,
 	children,
 }) => (
-	<div
-		id={id}
-		className={classes(
-			styles.card,
-			author !== null && isAgent(author) && styles.cardAgent,
-			className,
-		)}
-	>
+	<div id={id} className={classes(styles.card, className)}>
 		<div className={styles.cardBody}>
 			<div className={styles.cardHeader}>
 				<div className={styles.cardIdentity}>
@@ -407,7 +400,7 @@ export const ThreadComment: FC<{ comment: ForgeReviewThreadComment; compact?: bo
 			id={comment.id > 0 ? commentAnchorId(comment.id) : undefined}
 		>
 			<div className={styles.cardIdentity}>
-				{comment.author !== null && <Author user={comment.author} compact={compact} />}
+				{comment.author !== null && <Author user={comment.author} />}
 				{createdAtMs !== null && (
 					<RelativeTime timestamp={createdAtMs} className={classes("text-12", styles.cardTime)} />
 				)}


### PR DESCRIPTION
Replace purple Agent badges with the existing light-gray variant and remove the purple card background and border tint. Automated comments remain identifiable by a single Agent badge, with circular avatars and standard card styling.

Validation: Lite typecheck, oxlint, Knip, formatting checks, and inspection of React Compiler output for the author component. The PR comment feed is not covered by the screenshot catalogue; screenshots have not been captured.