### PR TITLE
Share one section heading between the lite pickers

### DIFF
--- a/apps/lite/ui/src/components/PickerDialog.module.css
+++ b/apps/lite/ui/src/components/PickerDialog.module.css
@@ -31,39 +31,6 @@
 	position: relative;
 }
 
-/* The same heading a `PopupSection` gives its rows; the virtualizer renders it as a row of its
-   own, so it carries its own box rather than wrapping what it names. */
-.groupLabel {
-	display: flex;
-	align-items: center;
-	min-height: 23px;
-	padding: 8px 12px 0;
-	outline: 0;
-	color: var(--text-3);
-	font-size: 12px;
-	line-height: 1;
-	cursor: default;
-	user-select: none;
-}
-
-/* Sections divide from one another, so every section but the last is followed by a hairline — the
-   line a `PopupSection` draws with a border. Rows here are absolutely positioned, so the heading
-   below the line hosts it inside its own box rather than either section spacing itself off the
-   other. */
-.groupLabelDivided {
-	position: relative;
-	padding-top: 16px;
-	padding-bottom: 4px;
-
-	&:before {
-		position: absolute;
-		inset-inline: 0;
-		top: 4px;
-		border-top: 1px solid var(--border-3);
-		content: "";
-	}
-}
-
 /* A `PopupItem`'s metrics, laid out as a grid because the type sits at the far end of the row. */
 .item {
 	box-sizing: border-box;

--- a/apps/lite/ui/src/components/PickerDialog.tsx
+++ b/apps/lite/ui/src/components/PickerDialog.tsx
@@ -3,7 +3,7 @@
  */
 
 import { Autocomplete, Dialog } from "@base-ui/react";
-import { Modal, PopupSearch } from "#ui/components/Popup.tsx";
+import { Modal, PopupSearch, PopupSectionLabel } from "#ui/components/Popup.tsx";
 import { getRangeExtractorWithIndices } from "#ui/virtual.ts";
 import { type Range, useVirtualizer } from "@tanstack/react-virtual";
 import {
@@ -218,19 +218,16 @@ const VirtualizedListArea = <T,>({
 
 								if (row._tag === "Group") {
 									return (
-										<div
+										<PopupSectionLabel
 											key={virtualItem.key}
 											ref={virtualizer.measureElement}
 											data-index={virtualItem.index}
 											role="presentation"
-											className={classes(
-												styles.groupLabel,
-												virtualItem.index > 0 && styles.groupLabelDivided,
-											)}
+											divided={virtualItem.index > 0}
 											style={style}
 										>
 											{row.group.value}
-										</div>
+										</PopupSectionLabel>
 									);
 								}
 

--- a/apps/lite/ui/src/components/PickerDialog.tsx
+++ b/apps/lite/ui/src/components/PickerDialog.tsx
@@ -114,7 +114,9 @@ const VirtualizedListArea = <T,>({
 		directDomUpdatesMode: "transform",
 		count: virtualRows.length,
 		getScrollElement: () => scrollElementRef.current,
-		estimateSize: () => 28,
+		// A heading is its 8px and 4px around one line of 12px type; a divided one adds the 5px
+		// of divider and inset above. Measured after the first paint, so close is enough.
+		estimateSize: (index) => (virtualRows[index]?._tag === "Group" ? (index > 0 ? 31 : 26) : 28),
 		getItemKey: getVirtualRowKey,
 		rangeExtractor: rangeExtractorWithHighlighted,
 		// The list opens on a section heading, which carries the 8px a section puts above its
@@ -206,14 +208,15 @@ const VirtualizedListArea = <T,>({
 								const row = virtualRows[virtualItem.index];
 								if (row === undefined) return null;
 
-								// Only what the virtualizer decides. A row spans the list, and how far it
-								// insets itself from the edge is the row's own styling.
+								// Only where the row sits. A row spans the list, insets itself as its own
+								// styling says, and is as tall as its content: the virtualizer measures the
+								// rendered box, so pinning a height here would only hand its own estimate
+								// back to it.
 								const style: CSSProperties = {
 									position: "absolute",
 									top: 0,
 									left: 0,
 									right: 0,
-									height: virtualItem.size,
 								};
 
 								if (row._tag === "Group") {

--- a/apps/lite/ui/src/components/Popup.module.css
+++ b/apps/lite/ui/src/components/Popup.module.css
@@ -159,15 +159,38 @@
 	border-top: 1px solid var(--border-3);
 }
 
+/* The heading carries the 4px its rows open with, so it is the same box whether a section wraps
+   it or a virtualised list renders it as a row of its own. */
 .sectionLabel {
-	padding: 8px 10px 0;
+	padding: 8px 10px 4px;
 	color: var(--text-3);
+}
+
+/* A row of its own has no section to draw the divider on, so the heading below the line hosts it
+   inside its own box. The previous section's inset, the divider, then this heading's own inset:
+   4px + 1px + 8px. */
+.sectionLabelDivided {
+	position: relative;
+	padding-top: 13px;
+
+	&::before {
+		position: absolute;
+		inset-inline: 0;
+		top: 4px;
+		border-top: 1px solid var(--border-3);
+		content: "";
+	}
 }
 
 .sectionItems {
 	display: flex;
 	flex-direction: column;
 	padding: 4px;
+}
+
+/* A heading above already opens the rows by the 4px. */
+.sectionLabel + .sectionItems {
+	padding-top: 0;
 }
 
 .item {

--- a/apps/lite/ui/src/components/Popup.tsx
+++ b/apps/lite/ui/src/components/Popup.tsx
@@ -269,6 +269,25 @@ export const PopupSection: FC<{ label?: ReactNode } & useRender.ComponentProps<"
 	});
 
 /**
+ * A section's heading on its own, for a list whose rows a virtualiser positions one by one and so
+ * cannot wrap in a {@link PopupSection}. The same heading a section draws; `divided` adds the
+ * hairline the section before it would otherwise have drawn.
+ *
+ * @public
+ */
+export const PopupSectionLabel: FC<{ divided?: boolean } & useRender.ComponentProps<"div">> = ({
+	divided = false,
+	render,
+	...props
+}) =>
+	useRender({
+		render: render ?? <div />,
+		props: mergeProps<"div">(props, {
+			className: classes("text-12", styles.sectionLabel, divided && styles.sectionLabelDivided),
+		}),
+	});
+
+/**
  * One row of a popup: an optional glyph, the label, and — at the far end — a shortcut and a
  * trailing glyph marking what the row is or where it leads.
  *

--- a/apps/lite/ui/src/routes/project/$id/workspace/ProjectPicker.module.css
+++ b/apps/lite/ui/src/routes/project/$id/workspace/ProjectPicker.module.css
@@ -31,25 +31,6 @@
 	width: 100%;
 }
 
-.groupLabel {
-	padding: 8px 10px 4px;
-	color: var(--text-3);
-}
-
-.groupLabelDivided {
-	position: relative;
-	/* Previous section inset, divider, then the next heading's inset: 4px + 1px + 8px. */
-	padding-top: 13px;
-
-	&::before {
-		position: absolute;
-		inset-inline: 0;
-		top: 4px;
-		border-top: 1px solid var(--border-3);
-		content: "";
-	}
-}
-
 .projectItem {
 	width: calc(100% - 8px);
 	margin-inline: 4px;

--- a/apps/lite/ui/src/routes/project/$id/workspace/ProjectPicker.tsx
+++ b/apps/lite/ui/src/routes/project/$id/workspace/ProjectPicker.tsx
@@ -1,7 +1,13 @@
 import { getButtonClassName } from "#ui/components/Button.tsx";
 import { classes } from "#ui/components/classes.ts";
 import { FolderIcon } from "#ui/components/FolderIcon.tsx";
-import { Popup, PopupItem, PopupSearch, PopupSection } from "#ui/components/Popup.tsx";
+import {
+	Popup,
+	PopupItem,
+	PopupSearch,
+	PopupSection,
+	PopupSectionLabel,
+} from "#ui/components/Popup.tsx";
 import { TooltipPopup } from "#ui/components/Tooltip.tsx";
 import { useAddLocalRepository } from "#ui/components/useAddLocalRepository.ts";
 import { globalHotkeys } from "#ui/hotkeys.ts";
@@ -181,17 +187,13 @@ const VirtualizedProjectList: FC<{
 								className={styles.virtualProject}
 							>
 								{row.isFirstInGroup && (
-									<div
+									<PopupSectionLabel
 										id={`${groupDescriptionId}-${row.groupIndex}`}
 										aria-hidden="true"
-										className={classes(
-											"text-12",
-											styles.groupLabel,
-											row.groupIndex > 0 && styles.groupLabelDivided,
-										)}
+										divided={row.groupIndex > 0}
 									>
 										{group.value}
-									</div>
+									</PopupSectionLabel>
 								)}
 
 								<PopupItem


### PR DESCRIPTION
Two things:
- Used the same styles for headings
- Fixed a bug with incorrect heading padding. Looks like the fix works, but @samhh feel free to tweak it

<img width="1003" height="375" alt="image" src="https://github.com/user-attachments/assets/39211d6d-e5dc-4a24-bf17-495fd3ed0f1e" />
