### PR TITLE
but-action: materialize only once at the end

### DIFF
--- a/crates/but-action/src/simple.rs
+++ b/crates/but-action/src/simple.rs
@@ -96,6 +96,7 @@ pub(crate) fn handle_changes(
         change_summary.to_string()
     };
 
+    let mut successful_rebase = Editor::create(ws, meta, repo, db)?.rebase()?;
     for (stack_id, diff_specs) in stack_assignments {
         if diff_specs.is_empty() {
             continue;
@@ -114,9 +115,8 @@ pub(crate) fn handle_changes(
         let full_ref_name: gix::refs::FullName =
             format!("refs/heads/{stack_branch_name}").try_into()?;
 
-        let editor = Editor::create(ws, meta, repo, db)?;
         let outcome = but_workspace::commit::commit_create(
-            editor,
+            successful_rebase.into_editor(),
             diff_specs,
             RelativeToRef::Reference(full_ref_name.as_ref()),
             InsertSide::Below,
@@ -137,14 +137,15 @@ pub(crate) fn handle_changes(
             .map(|selector| outcome.rebase.lookup_pick(selector))
             .transpose()?
         {
-            outcome.rebase.materialize(Default::default())?;
             updated_branches.push(crate::UpdatedBranch {
                 stack_id,
                 branch_name: stack_branch_name,
                 new_commits: vec![new_commit.to_string()],
             });
         }
+        successful_rebase = outcome.rebase;
     }
+    successful_rebase.materialize(Default::default())?;
 
     Ok(Outcome { updated_branches })
 }


### PR DESCRIPTION
I couldn't see if this code was tested by unit test because the tests are somehow failing on my computer for unrelated reasons (I'll take a look at that tomorrow).

If the code is not tested by unit test, could someone run this manually to see if it works?

---

Currently, editors are repeatedly created and materialized, but the appropriate way to use the rebase engine is to convert from SuccessfulRebase to Editor whenever we need to stack another change.

This change is not absolutely needed right now, but future work will make Editor take ownership of the workspace passed in, so this change also makes the code more future-proof (it only uses the workspace once).

It might be even more efficient to create all the Pick nodes for all the commits to be added in one go, performing the rebase only once, but I haven't looked into this.
