### PR TITLE
Classify rejected GitLab tokens on review and CI reads

### DIFF
--- a/apps/desktop/src/components/forge/CIChecksBadge.svelte.test.ts
+++ b/apps/desktop/src/components/forge/CIChecksBadge.svelte.test.ts
@@ -1,0 +1,220 @@
+import CIChecksBadge from "$components/forge/CIChecksBadge.svelte";
+import { CHECKS_MONITOR, ChecksMonitor } from "$lib/forge/checksMonitor.svelte";
+import { FORGE_INFO_SERVICE } from "$lib/forge/forgeInfo.svelte";
+import { injectBackendEndpoints as injectGitLabEndpoints } from "$lib/forge/gitlab/gitlabUserService.svelte";
+import { butlerModule } from "$lib/state/butlerModule";
+import { ReduxTag } from "$lib/state/tags";
+import { UI_STATE } from "$lib/state/uiState.svelte";
+import { configureStore } from "@reduxjs/toolkit";
+import { buildCreateApi, coreModule, QueryStatus } from "@reduxjs/toolkit/query";
+import { render } from "@testing-library/svelte";
+import { flushSync } from "svelte";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import type { HookContext } from "$lib/state/context";
+
+const PROJECT_ID = "project";
+const BRANCH = "topic";
+// The initial progressive interval while checks are still running.
+const POLL_INTERVAL = 5 * 1000;
+
+// A check that is still running, so completion never stops the poller and
+// only the error classification can.
+const runningCheck = {
+	data: [
+		{
+			id: 1,
+			name: "build",
+			output: { summary: "", text: "", title: "" },
+			startedAt: null,
+			status: "inProgress",
+			headSha: "deadbeef",
+			url: "",
+			htmlUrl: "",
+			detailsUrl: "",
+			pullRequests: [],
+			reference: BRANCH,
+			lastSyncAt: "",
+		},
+	],
+};
+// What `list_ci_checks` returns when GitLab answers 401 on the pipeline read.
+const rejectedGitLabTokenError = {
+	error: {
+		origin: "ipc" as const,
+		name: "API error: (list_ci_checks)",
+		message: "GitLab did not accept the token.",
+		code: "GitLabUnauthorized" as const,
+	},
+};
+const rejectedTokenStore = {
+	error: {
+		origin: "ipc" as const,
+		name: "API error: (store_gitlab_selfhosted_pat)",
+		message: "GitLab did not accept the token.",
+		code: "GitLabUnauthorized" as const,
+	},
+};
+const acceptedTokenStore = {
+	data: { username: "alice", name: null, email: null, host: "https://gitlab.example" },
+};
+
+class ReactiveStoreState {
+	root = $state.raw<any>();
+	readonly unsubscribe: () => void;
+
+	constructor(private readonly store: ReturnType<typeof configureStore>) {
+		this.root = store.getState();
+		this.unsubscribe = store.subscribe(() => (this.root = store.getState()));
+	}
+}
+
+function setup(
+	responses: Array<typeof runningCheck | typeof rejectedGitLabTokenError>,
+	tokenStores: Array<typeof rejectedTokenStore | typeof acceptedTokenStore>,
+) {
+	let calls = 0;
+	const storeRef = {} as {
+		state: ReactiveStoreState;
+		store: ReturnType<typeof configureStore>;
+	};
+	const context: HookContext = {
+		getState: () => storeRef.state.root,
+		getDispatch: () => storeRef.store.dispatch,
+	};
+	const api = buildCreateApi(
+		coreModule(),
+		butlerModule(context),
+	)({
+		reducerPath: "backend",
+		tagTypes: Object.values(ReduxTag),
+		baseQuery: async (_args: unknown, _api: unknown, extra: any) => {
+			if (extra?.command === "list_ci_checks") {
+				return responses[Math.min(calls++, responses.length - 1)]!;
+			}
+			if (extra?.command === "store_gitlab_selfhosted_pat") {
+				return tokenStores.shift() ?? { data: null };
+			}
+			return { data: null };
+		},
+		endpoints: () => ({}),
+	});
+	const store = configureStore({
+		reducer: { [api.reducerPath]: api.reducer },
+		middleware: (defaults) => defaults().concat(api.middleware),
+	});
+	const storeState = new ReactiveStoreState(store);
+	storeRef.store = store;
+	storeRef.state = storeState;
+	const gitlab = injectGitLabEndpoints(api as never);
+
+	// The branches the badge is allowed to poll, kept reactive so the
+	// component's own stop/restart bookkeeping works as in the app.
+	let branchesToPoll = $state.raw([BRANCH]);
+	const uiState = {
+		project: () => ({
+			branchesToPoll: {
+				get current() {
+					return branchesToPoll;
+				},
+				add: (name: string) => (branchesToPoll = [...branchesToPoll, name]),
+				remove: (name: string) => (branchesToPoll = branchesToPoll.filter((b) => b !== name)),
+			},
+		}),
+	};
+	const forgeInfo = { capabilities: { checks: true } };
+	const contextMap = new Map<any, any>([
+		[CHECKS_MONITOR._key, new ChecksMonitor(api as never)],
+		[
+			FORGE_INFO_SERVICE._key,
+			{ get: () => ({ response: forgeInfo, result: { status: QueryStatus.fulfilled } }) },
+		],
+		[UI_STATE._key, uiState],
+	]);
+	const rendered = render(CIChecksBadge, {
+		props: { projectId: PROJECT_ID, branchName: BRANCH },
+		context: contextMap,
+	});
+	function badge() {
+		return rendered.getByTestId("pr-checks-badge");
+	}
+
+	return {
+		api,
+		gitlab,
+		store,
+		storeState,
+		rendered,
+		badge,
+		get calls() {
+			return calls;
+		},
+	};
+}
+
+// A store update reaches the badge a short moment later, well inside one
+// polling interval.
+const SETTLE_MS = 100;
+
+async function settle() {
+	flushSync();
+	await vi.advanceTimersByTimeAsync(SETTLE_MS);
+	flushSync();
+}
+
+afterEach(() => {
+	vi.useRealTimers();
+	vi.restoreAllMocks();
+});
+
+describe("CIChecksBadge polling", () => {
+	test("stops on a rejected GitLab token and resumes once a replacement is stored", async () => {
+		vi.useFakeTimers();
+		const harness = setup(
+			[runningCheck, rejectedGitLabTokenError, runningCheck],
+			[rejectedTokenStore, acceptedTokenStore],
+		);
+		function badgeText() {
+			return harness.badge().querySelector("[data-pr-text]")?.textContent?.trim();
+		}
+		await settle();
+		expect(harness.calls).toBe(1);
+		expect(badgeText()).toBe("Running");
+
+		await vi.advanceTimersByTimeAsync(POLL_INTERVAL);
+		await settle();
+		expect(harness.calls).toBe(2);
+		expect(badgeText()).toBe("Error");
+		await vi.advanceTimersByTimeAsync(POLL_INTERVAL * 100);
+		await settle();
+		expect(harness.calls, "a rejected token kept polling the checks").toBe(2);
+
+		async function store() {
+			await harness.store.dispatch(
+				harness.gitlab.endpoints.storeGitLabEnterprisePat.initiate({
+					host: "https://gitlab.example",
+					accessToken: "synthetic",
+				}),
+			);
+		}
+		// A token GitLab also rejects invalidates nothing: the checks would
+		// only fail the same way again.
+		await store();
+		await settle();
+		expect(harness.calls, "a failed token store refetched the checks").toBe(2);
+		expect(badgeText()).toBe("Error");
+
+		await store();
+		await settle();
+		expect(harness.calls, "an accepted token did not refetch the checks").toBe(3);
+		expect(badgeText()).toBe("Running");
+
+		await vi.advanceTimersByTimeAsync(POLL_INTERVAL - 3 * SETTLE_MS);
+		expect(harness.calls).toBe(3);
+		await vi.advanceTimersByTimeAsync(6 * SETTLE_MS);
+		await settle();
+		expect(harness.calls, "polling did not resume after the token was replaced").toBe(4);
+
+		harness.rendered.unmount();
+		harness.storeState.unsubscribe();
+	});
+});

--- a/apps/desktop/src/routes/[projectId]/projectLayout.svelte.test.ts
+++ b/apps/desktop/src/routes/[projectId]/projectLayout.svelte.test.ts
@@ -5,7 +5,10 @@ import { buildBranchEndpoints } from "$lib/branches/branchEndpoints";
 import { BRANCH_SERVICE } from "$lib/branches/branchService.svelte";
 import { FORGE_INFO_SERVICE } from "$lib/forge/forgeInfo.svelte";
 import { GitHubUserService } from "$lib/forge/github/githubUserService.svelte";
-import { GITLAB_USER_SERVICE } from "$lib/forge/gitlab/gitlabUserService.svelte";
+import {
+	GITLAB_USER_SERVICE,
+	injectBackendEndpoints as injectGitLabEndpoints,
+} from "$lib/forge/gitlab/gitlabUserService.svelte";
 import { LISTING_SERVICE, ListingService } from "$lib/forge/listingService.svelte";
 import { GIT_SERVICE } from "$lib/git/gitService";
 import { MODE_SERVICE } from "$lib/mode/modeService";
@@ -93,6 +96,15 @@ const lifetimeError = {
 		code: "GitHubTokenLifetimeRestricted" as const,
 	},
 };
+// What `list_reviews` returns when GitLab answers 401 on a read.
+const rejectedGitLabTokenError = {
+	error: {
+		origin: "ipc" as const,
+		name: "API error: (list_reviews)",
+		message: "GitLab did not accept the token.",
+		code: "GitLabUnauthorized" as const,
+	},
+};
 const nonterminalError = {
 	error: {
 		origin: "ipc" as const,
@@ -100,6 +112,18 @@ const nonterminalError = {
 		message: "Temporary forge failure.",
 		code: "Unknown" as const,
 	},
+};
+// What `store_gitlab_selfhosted_pat` returns for a rejected and an accepted token.
+const rejectedTokenStore = {
+	error: {
+		origin: "ipc" as const,
+		name: "API error: (store_gitlab_selfhosted_pat)",
+		message: "GitLab did not accept the token.",
+		code: "GitLabUnauthorized" as const,
+	},
+};
+const acceptedTokenStore = {
+	data: { username: "alice", name: null, email: null, host: "https://gitlab.example" },
 };
 // What `list_reviews` returns when the target remote maps to no supported forge.
 const unrecognizedForgeError = {
@@ -136,12 +160,14 @@ type Response =
 	| typeof terminalError
 	| typeof expiredTokenError
 	| typeof lifetimeError
+	| typeof rejectedGitLabTokenError
 	| typeof nonterminalError
 	| typeof unrecognizedForgeError;
 
 function setup(
 	responses: Array<Response | Promise<Response>>,
 	listingServiceOverride?: Pick<ListingService, "list">,
+	tokenStores: Array<typeof rejectedTokenStore | typeof acceptedTokenStore> = [],
 ) {
 	let calls = 0;
 	const storeRef = {} as {
@@ -158,12 +184,17 @@ function setup(
 	)({
 		reducerPath: "backend",
 		tagTypes: Object.values(ReduxTag),
-		// Only `list_reviews` consumes scripted responses; other commands
-		// (e.g. `set_base_branch`) succeed without counting as a call.
-		baseQuery: async (_args: unknown, _api: unknown, extra: any) =>
-			extra?.command === "list_reviews"
-				? await responses[Math.min(calls++, responses.length - 1)]!
-				: { data: null },
+		// Only `list_reviews` and the token store consume scripted responses;
+		// other commands (e.g. `set_base_branch`) succeed without counting as a call.
+		baseQuery: async (_args: unknown, _api: unknown, extra: any) => {
+			if (extra?.command === "list_reviews") {
+				return await responses[Math.min(calls++, responses.length - 1)]!;
+			}
+			if (extra?.command === "store_gitlab_selfhosted_pat") {
+				return tokenStores.shift() ?? { data: null };
+			}
+			return { data: null };
+		},
 		endpoints: () => ({}),
 	});
 	const store = configureStore({
@@ -176,6 +207,7 @@ function setup(
 	const listingService =
 		listingServiceOverride ?? new ListingService(api as never, store.dispatch as never);
 	api.injectEndpoints({ endpoints: (build) => buildBranchEndpoints(build as never) });
+	const gitlab = injectGitLabEndpoints(api as never);
 	const forgeInfo = { capabilities: { listService: true } };
 	function noop() {}
 	async function asyncNoop() {}
@@ -226,6 +258,7 @@ function setup(
 
 	return {
 		api,
+		gitlab,
 		store,
 		storeState,
 		rendered,
@@ -312,6 +345,55 @@ describe("project review-list polling", () => {
 		expect(harness.calls, "storing a token did not refetch the reviews").toBe(3);
 		await vi.advanceTimersByTimeAsync(POLL_INTERVAL);
 		expect(harness.calls, "polling did not resume after the credential was replaced").toBe(4);
+
+		harness.rendered.unmount();
+		harness.storeState.unsubscribe();
+	});
+
+	test("resumes polling a rejected GitLab token only once a replacement is stored", async () => {
+		vi.useFakeTimers();
+		const harness = setup([success, rejectedGitLabTokenError, success], undefined, [
+			rejectedTokenStore,
+			acceptedTokenStore,
+		]);
+		await settle();
+		expect(harness.calls).toBe(1);
+
+		await vi.advanceTimersByTimeAsync(POLL_INTERVAL);
+		const rejected = (harness.api.endpoints as any).listPrs.select(PROJECT_ID)(
+			harness.store.getState(),
+		);
+		expect(rejected.data.ids, "a rejected token dropped the cached reviews").toEqual(["topic"]);
+		expect(rejected.error?.code).toBe("GitLabUnauthorized");
+		await vi.advanceTimersByTimeAsync(POLL_INTERVAL);
+		expect(harness.calls, "a rejected token scheduled another interval request").toBe(2);
+
+		// Storing a token GitLab also rejects invalidates nothing: the listing
+		// would only fail the same way again.
+		async function store() {
+			await harness.store.dispatch(
+				harness.gitlab.endpoints.storeGitLabEnterprisePat.initiate({
+					host: "https://gitlab.example",
+					accessToken: "synthetic",
+				}),
+			);
+		}
+		await store();
+		await settle();
+		expect(harness.calls, "a failed token store refetched the listing").toBe(2);
+
+		await store();
+		await settle();
+		expect(harness.calls, "an accepted token did not refetch the listing").toBe(3);
+		const recovered = (harness.api.endpoints as any).listPrs.select(PROJECT_ID)(
+			harness.store.getState(),
+		);
+		expect(recovered.isError).toBe(false);
+
+		await vi.advanceTimersByTimeAsync(POLL_INTERVAL - 1);
+		expect(harness.calls).toBe(3);
+		await vi.advanceTimersByTimeAsync(1);
+		expect(harness.calls, "polling did not resume after the token was replaced").toBe(4);
 
 		harness.rendered.unmount();
 		harness.storeState.unsubscribe();

--- a/crates/but-api/src/json.rs
+++ b/crates/but-api/src/json.rs
@@ -432,6 +432,22 @@ mod error {
         }
 
         #[test]
+        fn static_context_between_operation_layers_keeps_its_code() {
+            const MESSAGE: &str = "GitLab did not accept the token.";
+            // The forge read wrappers add operation text below and above the
+            // classification, like `but_gitlab::mr::list` around its client.
+            let err = anyhow!("HTTP 401")
+                .context("Failed to list open merge requests")
+                .context(Context::new_static(Code::GitLabUnauthorized, MESSAGE))
+                .context("Failed to list open merge requests");
+            assert_eq!(
+                json(err),
+                format!(r#"{{"code":"GitLabUnauthorized","message":"{MESSAGE}"}}"#),
+                "the code survives the outer operation layer and only the static guidance is sent"
+            );
+        }
+
+        #[test]
         fn find_context_without_message() {
             let err = anyhow!("err msg").context(Context::from(Code::Validation));
             assert_eq!(

--- a/crates/but-gitlab/src/client.rs
+++ b/crates/but-gitlab/src/client.rs
@@ -218,7 +218,10 @@ impl GitLabClient {
                 .send()
                 .await?;
             if !response.status().is_success() {
-                bail!("{error_message}: {}", response.status());
+                return Err(anyhow::Error::from(HttpStatusError {
+                    status: response.status(),
+                })
+                .context(error_message.to_owned()));
             }
 
             next_page = next_page_from_headers(response.headers());
@@ -274,10 +277,10 @@ impl GitLabClient {
             .send()
             .await?;
         if !response.status().is_success() {
-            bail!(
-                "Failed to list recently {state} merge requests: {}",
-                response.status()
-            );
+            return Err(anyhow::Error::from(HttpStatusError {
+                status: response.status(),
+            })
+            .context(format!("Failed to list recently {state} merge requests")));
         }
         Ok(response.json().await?)
     }
@@ -362,7 +365,10 @@ impl GitLabClient {
         let response = self.client.get(&url).send().await?;
 
         if !response.status().is_success() {
-            bail!("Failed to get merge request: {}", response.status());
+            return Err(anyhow::Error::from(HttpStatusError {
+                status: response.status(),
+            })
+            .context("Failed to get merge request"));
         }
 
         let mr: GitLabMergeRequest = response.json().await?;
@@ -403,7 +409,10 @@ impl GitLabClient {
         );
         let response = self.client.get(&url).send().await?;
         if !response.status().is_success() {
-            bail!("Failed to get MR merge status: {}", response.status());
+            return Err(anyhow::Error::from(HttpStatusError {
+                status: response.status(),
+            })
+            .context("Failed to get MR merge status"));
         }
         let body: MrMergeStatusResponse = response.json().await?;
         let is_mergeable = matches!(body.merge_status.as_deref(), Some("can_be_merged"));
@@ -707,7 +716,8 @@ impl GitLabClient {
             {
                 return Ok(Vec::new());
             }
-            bail!("Failed to get latest pipeline for ref: {status}");
+            return Err(anyhow::Error::from(HttpStatusError { status })
+                .context("Failed to get latest pipeline for ref"));
         }
 
         let pipeline: GitLabPipelineResponse = response
@@ -747,7 +757,10 @@ impl GitLabClient {
                 })?;
 
             if !response.status().is_success() {
-                bail!("Failed to list jobs for pipeline: {}", response.status());
+                return Err(anyhow::Error::from(HttpStatusError {
+                    status: response.status(),
+                })
+                .context("Failed to list jobs for pipeline"));
             }
 
             next_page = next_page_from_headers(response.headers());

--- a/crates/but-gitlab/src/lib.rs
+++ b/crates/but-gitlab/src/lib.rs
@@ -116,15 +116,19 @@ async fn fetch_and_persist_selfhosted_user_data(
     Ok(user)
 }
 
+/// GitLab answered 401: the token was rejected. Shared by token validation
+/// and the read classifier so the desktop sees one terminal code either way.
+pub(crate) const GITLAB_UNAUTHORIZED: but_error::Context = but_error::Context::new_static(
+    but_error::Code::GitLabUnauthorized,
+    "GitLab did not accept the token.",
+);
+
 fn classify_pat_validation_error(err: anyhow::Error) -> anyhow::Error {
     let Some(http_err) = err.downcast_ref::<client::HttpStatusError>() else {
         return err;
     };
     let context = match http_err.status {
-        reqwest::StatusCode::UNAUTHORIZED => but_error::Context::new_static(
-            but_error::Code::GitLabUnauthorized,
-            "GitLab did not accept the token.",
-        ),
+        reqwest::StatusCode::UNAUTHORIZED => GITLAB_UNAUTHORIZED,
         reqwest::StatusCode::FORBIDDEN => but_error::Context::new_static(
             but_error::Code::GitLabForbidden,
             "GitLab refused access for the token.",

--- a/crates/but-gitlab/src/mr.rs
+++ b/crates/but-gitlab/src/mr.rs
@@ -54,8 +54,10 @@ pub async fn list_for_commit(
 
 /// Tag transport failures with `but_error::Code::NetworkError` so the desktop
 /// can present them appropriately (silent for offline) and cached readers can
-/// keep serving the last known data. Only applied to read paths — mutations
-/// should still surface failures.
+/// keep serving the last known data, and a rejected token (HTTP 401) with
+/// `GitLabUnauthorized` so pollers stop until a replacement token is stored.
+/// Other statuses stay unclassified: a 403 on a read may be per-project.
+/// Only applied to read paths — mutations should still surface failures.
 pub(crate) fn classify_forge_error(err: anyhow::Error) -> anyhow::Error {
     if err
         .downcast_ref::<reqwest::Error>()
@@ -65,6 +67,12 @@ pub(crate) fn classify_forge_error(err: anyhow::Error) -> anyhow::Error {
             but_error::Code::NetworkError,
             "Unable to connect to GitLab.",
         ));
+    }
+    if err
+        .downcast_ref::<crate::client::HttpStatusError>()
+        .is_some_and(|http_err| http_err.status == reqwest::StatusCode::UNAUTHORIZED)
+    {
+        return err.context(crate::GITLAB_UNAUTHORIZED);
     }
     err
 }
@@ -241,5 +249,36 @@ mod tests {
             err.downcast_ref::<but_error::Context>().is_none(),
             "a forge-side failure must not be presented as an offline network"
         );
+    }
+
+    fn http_error(status: reqwest::StatusCode) -> anyhow::Error {
+        anyhow::Error::from(crate::client::HttpStatusError { status })
+            .context("Failed to get merge request")
+    }
+
+    #[test]
+    fn rejected_token_responses_carry_the_unauthorized_code() {
+        let err = classify_forge_error(http_error(reqwest::StatusCode::UNAUTHORIZED));
+        assert_eq!(
+            err.downcast_ref::<but_error::Context>().map(|ctx| ctx.code),
+            Some(but_error::Code::GitLabUnauthorized),
+            "pollers stop on this code until a replacement token is stored"
+        );
+    }
+
+    #[test]
+    fn other_http_statuses_stay_unclassified() {
+        for status in [
+            reqwest::StatusCode::FORBIDDEN,
+            reqwest::StatusCode::NOT_FOUND,
+            reqwest::StatusCode::TOO_MANY_REQUESTS,
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+        ] {
+            let err = classify_forge_error(http_error(status));
+            assert!(
+                err.downcast_ref::<but_error::Context>().is_none(),
+                "{status} is not a rejected token and must not become terminal"
+            );
+        }
     }
 }

--- a/crates/but-gitlab/tests/gitlab_auth.rs
+++ b/crates/but-gitlab/tests/gitlab_auth.rs
@@ -3,7 +3,8 @@ use std::net::TcpListener;
 
 use but_error::AnyhowContextExt as _;
 use but_gitlab::{
-    GitlabAccountIdentifier, get_gl_user, list_known_gitlab_accounts, store_selfhosted_pat,
+    GitLabProjectId, GitlabAccountIdentifier, get_gl_user, list_known_gitlab_accounts,
+    store_selfhosted_pat,
 };
 use but_secret::Sensitive;
 
@@ -79,6 +80,24 @@ impl MockServer {
     }
 }
 
+/// Read one request's headers and return its target (path and query).
+fn request_target(stream: &mut std::net::TcpStream) -> String {
+    let mut request = Vec::new();
+    let mut chunk = [0; 1024];
+    while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+        let read = stream.read(&mut chunk).expect("request should be readable");
+        assert_ne!(read, 0, "request should include complete HTTP headers");
+        request.extend_from_slice(&chunk[..read]);
+    }
+    let request = String::from_utf8(request).expect("request should be valid UTF-8");
+    request
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .expect("request should include a target")
+        .to_owned()
+}
+
 /// Serve `responses` in order, one per connection, to `GET /api/v4/user`.
 fn mock_gitlab(responses: Vec<(u16, &'static str)>) -> (String, MockServer) {
     let listener = TcpListener::bind("127.0.0.1:0").expect("mock server should bind");
@@ -88,16 +107,9 @@ fn mock_gitlab(responses: Vec<(u16, &'static str)>) -> (String, MockServer) {
     let handle = std::thread::spawn(move || {
         for (status, body) in responses {
             let (mut stream, _) = listener.accept().expect("mock server should accept");
-            let mut request = Vec::new();
-            let mut chunk = [0; 1024];
-            while !request.windows(4).any(|window| window == b"\r\n\r\n") {
-                let read = stream.read(&mut chunk).expect("request should be readable");
-                assert_ne!(read, 0, "request should include complete HTTP headers");
-                request.extend_from_slice(&chunk[..read]);
-            }
-            let request = String::from_utf8(request).expect("request should be valid UTF-8");
-            assert!(
-                request.starts_with("GET /api/v4/user "),
+            assert_eq!(
+                request_target(&mut stream),
+                "/api/v4/user",
                 "PAT validation should request the authenticated user"
             );
             write!(
@@ -302,4 +314,377 @@ fn forget_removes_an_account_whose_token_is_missing() {
     but_gitlab::forget_gl_access_token(&account, &storage).unwrap();
 
     assert_eq!(list_known_gitlab_accounts(&storage).unwrap(), []);
+}
+
+/// One canned reply for the read mock; `next_page` is served as `X-Next-Page`.
+struct Reply {
+    status: u16,
+    body: String,
+    next_page: Option<&'static str>,
+}
+
+fn reply(status: u16, body: impl Into<String>) -> Reply {
+    Reply {
+        status,
+        body: body.into(),
+        next_page: None,
+    }
+}
+
+fn page(body: impl Into<String>, next_page: &'static str) -> Reply {
+    Reply {
+        next_page: Some(next_page),
+        ..reply(200, body)
+    }
+}
+
+struct ReadMockServer(std::thread::JoinHandle<Vec<String>>);
+
+impl ReadMockServer {
+    /// The request targets served, in order.
+    fn finish(self) -> Vec<String> {
+        self.0.join().expect("read mock server should finish")
+    }
+}
+
+/// Serve `replies` in order, one per connection, to any path. A reply the
+/// client never asks for fails the test instead of hanging it.
+fn mock_gitlab_reads(replies: Vec<Reply>) -> (String, ReadMockServer) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("mock server should bind");
+    listener
+        .set_nonblocking(true)
+        .expect("mock server should be nonblocking");
+    let address = listener
+        .local_addr()
+        .expect("mock server should have an address");
+    let handle = std::thread::spawn(move || {
+        let mut targets = Vec::new();
+        for reply in replies {
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+            let mut stream = loop {
+                match listener.accept() {
+                    Ok((stream, _)) => break stream,
+                    Err(err)
+                        if err.kind() == std::io::ErrorKind::WouldBlock
+                            && std::time::Instant::now() < deadline =>
+                    {
+                        std::thread::sleep(std::time::Duration::from_millis(5));
+                    }
+                    Err(err) => panic!("expected another request: {err}"),
+                }
+            };
+            stream
+                .set_nonblocking(false)
+                .expect("accepted stream should be blocking");
+            targets.push(request_target(&mut stream));
+            write!(
+                stream,
+                "HTTP/1.1 {} Mock\r\nContent-Type: application/json\r\nX-Next-Page: {}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                reply.status,
+                reply.next_page.unwrap_or_default(),
+                reply.body.len(),
+                reply.body
+            )
+            .expect("mock response should be writable");
+        }
+        targets
+    });
+    (format!("http://{address}"), ReadMockServer(handle))
+}
+
+const TOKEN: &str = "synthetic-token-that-must-not-leak";
+const MERGE_STATUS: &str = r#"{"merge_status":"can_be_merged","user_notes_count":0}"#;
+const PIPELINE: &str = r#"{"id":5,"status":"success","web_url":null}"#;
+const PROJECT: &str = r#"{"id":7,"path_with_namespace":"group/repo","ssh_url_to_repo":"git@gitlab.example:group/repo.git","http_url_to_repo":"https://gitlab.example/group/repo.git","default_branch":"main"}"#;
+
+fn mr(iid: i64) -> String {
+    format!(
+        r#"{{"web_url":"https://gitlab.example/mr/{iid}","iid":{iid},"title":"MR {iid}","description":null,"author":null,"labels":[],"draft":false,"source_branch":"topic-{iid}","target_branch":"main","sha":"0123456789abcdef0123456789abcdef01234567","merge_commit_sha":null,"squash_commit_sha":null,"created_at":null,"updated_at":null,"merged_at":null,"closed_at":null,"project_id":7,"source_project_id":7,"target_project_id":7,"assignees":[],"reviewers":[],"merge_when_pipeline_succeeds":false}}"#
+    )
+}
+
+fn job(id: i64) -> String {
+    format!(
+        r#"{{"id":{id},"name":"job-{id}","status":"success","allow_failure":false,"started_at":null,"finished_at":null,"web_url":null,"pipeline":{{"id":5,"web_url":null,"status":"success"}}}}"#
+    )
+}
+
+/// A self-hosted account stored against the read mock, so every read below
+/// resolves its client through the same stored-credential lookup the API uses.
+struct StoredAccount {
+    server: ReadMockServer,
+    storage: but_forge_storage::Controller,
+    account: GitlabAccountIdentifier,
+    host: String,
+    _dir: tempfile::TempDir,
+}
+
+async fn stored_account(replies: Vec<Reply>) -> StoredAccount {
+    let mut all = vec![reply(200, ALICE)];
+    all.extend(replies);
+    let (host, server) = mock_gitlab_reads(all);
+    let dir = tempfile::tempdir().expect("temporary storage should be created");
+    let storage = but_forge_storage::Controller::from_path(dir.path());
+    store_selfhosted_pat(&host, &Sensitive(TOKEN.into()), &storage)
+        .await
+        .expect("valid PAT should be stored");
+    StoredAccount {
+        server,
+        storage,
+        account: GitlabAccountIdentifier::selfhosted("alice", &host),
+        host,
+        _dir: dir,
+    }
+}
+
+/// The public read wrappers the desktop polls through `list_reviews`,
+/// `get_review` and `list_ci_checks`.
+#[derive(Debug, Clone, Copy)]
+enum Read {
+    OpenList,
+    TargetList,
+    CommitList,
+    RecentlyClosed,
+    Get,
+    MergeStatus,
+    PipelineJobs,
+}
+
+/// Perform `read` through the stored account and report how many items it returned.
+async fn perform(
+    read: Read,
+    storage: &but_forge_storage::Controller,
+    account: &GitlabAccountIdentifier,
+) -> anyhow::Result<usize> {
+    let account = Some(account);
+    let project = GitLabProjectId::new("group", "repo");
+    Ok(match read {
+        Read::OpenList => but_gitlab::mr::list(account, project, storage).await?.len(),
+        Read::TargetList => but_gitlab::mr::list_all_for_target(account, project, "main", storage)
+            .await?
+            .len(),
+        Read::CommitList => {
+            but_gitlab::mr::list_for_commit(account, project, "0123456789abcdef", storage)
+                .await?
+                .len()
+        }
+        Read::RecentlyClosed => but_gitlab::mr::list_recently_closed(account, project, storage)
+            .await?
+            .len(),
+        Read::Get => {
+            but_gitlab::mr::get(account, project, 1, storage).await?;
+            1
+        }
+        Read::MergeStatus => {
+            but_gitlab::mr::get_merge_status(account, project, 1, storage).await?;
+            1
+        }
+        Read::PipelineJobs => {
+            but_gitlab::checks::list_pipeline_jobs_for_ref(account, project, "main", storage)
+                .await?
+                .len()
+        }
+    })
+}
+
+#[test]
+fn rejected_token_on_read_paths_carries_the_unauthorized_code_on_every_seam() {
+    memory_keyring::install();
+
+    run(async {
+        let seams: Vec<(Read, Vec<Reply>)> = vec![
+            (Read::OpenList, vec![reply(401, REJECTED)]),
+            (
+                Read::OpenList,
+                vec![page(format!("[{}]", mr(1)), "2"), reply(401, REJECTED)],
+            ),
+            (Read::TargetList, vec![reply(401, REJECTED)]),
+            (Read::CommitList, vec![reply(401, REJECTED)]),
+            (Read::RecentlyClosed, vec![reply(401, REJECTED)]),
+            (
+                Read::RecentlyClosed,
+                vec![reply(200, "[]"), reply(401, REJECTED)],
+            ),
+            (Read::Get, vec![reply(401, REJECTED)]),
+            (Read::MergeStatus, vec![reply(401, REJECTED)]),
+            (Read::PipelineJobs, vec![reply(401, REJECTED)]),
+            (
+                Read::PipelineJobs,
+                vec![reply(200, PIPELINE), reply(401, REJECTED)],
+            ),
+            (
+                Read::PipelineJobs,
+                vec![
+                    reply(200, PIPELINE),
+                    page(format!("[{}]", job(1)), "2"),
+                    reply(401, REJECTED),
+                ],
+            ),
+        ];
+        for (read, replies) in seams {
+            let requests = replies.len() + 1;
+            let fixture = stored_account(replies).await;
+            let error = perform(read, &fixture.storage, &fixture.account)
+                .await
+                .expect_err("a rejected token must fail the read, never return a partial page");
+            let StoredAccount { server, host, .. } = fixture;
+            assert_eq!(
+                server.finish().len(),
+                requests,
+                "{read:?}: every page up to the rejection should have been requested"
+            );
+
+            let context = error.custom_context_or_error_chain();
+            assert_eq!(
+                context.code.to_string(),
+                "GitLabUnauthorized",
+                "{read:?}: a 401 on a read path is the same rejected token the account refresh reports: {error:#}"
+            );
+            assert_eq!(
+                context.message.as_deref(),
+                Some("GitLab did not accept the token."),
+                "{read:?}: the API sends only the static guidance"
+            );
+            let chain = format!("{error:#}");
+            assert!(
+                chain.contains("HTTP 401"),
+                "{read:?}: the status should stay in the chain for logs: {chain}"
+            );
+            let debug = format!("{error:?}");
+            assert!(
+                !debug.contains(TOKEN) && !debug.contains(&host),
+                "{read:?}: neither the token nor the host may reach the error: {debug}"
+            );
+        }
+    });
+}
+
+#[test]
+fn read_failures_other_than_a_rejected_token_stay_unclassified() {
+    memory_keyring::install();
+
+    run(async {
+        let cases: Vec<(Read, Vec<Reply>, &str)> = vec![
+            (Read::OpenList, vec![reply(403, REJECTED)], "403"),
+            (Read::OpenList, vec![reply(404, REJECTED)], "404"),
+            (Read::OpenList, vec![reply(429, REJECTED)], "429"),
+            // Auth wording in the body of another status is not a rejection.
+            (
+                Read::OpenList,
+                vec![reply(500, r#"{"message":"401 Unauthorized"}"#)],
+                "500",
+            ),
+            (
+                Read::OpenList,
+                vec![reply(200, "not json")],
+                "error decoding response body",
+            ),
+            (Read::Get, vec![reply(500, REJECTED)], "500"),
+            (Read::MergeStatus, vec![reply(403, REJECTED)], "403"),
+            (Read::PipelineJobs, vec![reply(500, REJECTED)], "500"),
+            (
+                Read::PipelineJobs,
+                vec![reply(200, PIPELINE), reply(403, REJECTED)],
+                "403",
+            ),
+        ];
+        for (read, replies, detail) in cases {
+            let fixture = stored_account(replies).await;
+            let error = perform(read, &fixture.storage, &fixture.account)
+                .await
+                .expect_err("a failed read should surface");
+            fixture.server.finish();
+            let context = error.custom_context_or_error_chain();
+            assert_eq!(
+                context.code.to_string(),
+                "Unknown",
+                "{read:?}: only a rejected token is terminal for the poller: {error:#}"
+            );
+            assert!(
+                context
+                    .message
+                    .as_deref()
+                    .is_some_and(|message| message.contains(detail)),
+                "{read:?}: an unclassified failure keeps its detail for the user: {error:#}"
+            );
+        }
+
+        // The stored account outlives its mock: the next read is refused.
+        let fixture = stored_account(vec![]).await;
+        fixture.server.finish();
+        let error = perform(Read::OpenList, &fixture.storage, &fixture.account)
+            .await
+            .expect_err("an unreachable host should fail the read");
+        assert_eq!(
+            error.custom_context_or_error_chain().code.to_string(),
+            "NetworkError",
+            "transport failures keep their existing outage classification: {error:#}"
+        );
+    });
+}
+
+#[test]
+fn ci_reads_keep_treating_a_forbidden_or_missing_pipeline_as_no_checks() {
+    memory_keyring::install();
+
+    run(async {
+        for status in [403, 404] {
+            let fixture = stored_account(vec![reply(status, REJECTED)]).await;
+            let jobs = perform(Read::PipelineJobs, &fixture.storage, &fixture.account)
+                .await
+                .expect("a pipeline GitLab hides or lacks is an empty check list");
+            fixture.server.finish();
+            assert_eq!(jobs, 0, "HTTP {status} on the latest pipeline stays empty");
+        }
+    });
+}
+
+#[test]
+fn read_paths_still_return_data_across_pages() {
+    memory_keyring::install();
+
+    run(async {
+        let cases: Vec<(Read, Vec<Reply>, usize)> = vec![
+            (
+                Read::OpenList,
+                vec![
+                    page(format!("[{}]", mr(1)), "2"),
+                    reply(200, format!("[{}]", mr(2))),
+                ],
+                2,
+            ),
+            (
+                Read::RecentlyClosed,
+                vec![
+                    reply(200, format!("[{}]", mr(3))),
+                    reply(200, format!("[{}]", mr(4))),
+                ],
+                2,
+            ),
+            (Read::Get, vec![reply(200, mr(1)), reply(200, PROJECT)], 1),
+            (Read::MergeStatus, vec![reply(200, MERGE_STATUS)], 1),
+            (
+                Read::PipelineJobs,
+                vec![
+                    reply(200, PIPELINE),
+                    page(format!("[{}]", job(1)), "2"),
+                    reply(200, format!("[{}]", job(2))),
+                ],
+                2,
+            ),
+        ];
+        for (read, replies, expected) in cases {
+            let requests = replies.len() + 1;
+            let fixture = stored_account(replies).await;
+            let items = perform(read, &fixture.storage, &fixture.account)
+                .await
+                .expect("successful reads should still return data");
+            assert_eq!(
+                fixture.server.finish().len(),
+                requests,
+                "{read:?}: every advertised page should be requested"
+            );
+            assert_eq!(items, expected, "{read:?}: all pages should be returned");
+        }
+    });
 }


### PR DESCRIPTION
## Context

When GitLab rejects a stored token, Desktop review lists, individual reviews, and CI checks report generic errors and keep retrying the same credential. GitLab documents [HTTP 401 as an authentication failure](https://docs.gitlab.com/api/rest/authentication/), but these read paths discarded the status before GitButler could classify it.

## Change

Preserve the typed HTTP status on GitLab review and CI reads and reuse the existing `GitLabUnauthorized` classification. Desktop can then show its existing token-replacement guidance and pause automatic polling until recovery. Successful credential replacement resumes the existing queries.

Keep the existing CI 403/404 empty-checks behavior, non-authentication errors, and mutation behavior unchanged.
