### PR TITLE
Separate human and agent notifications in Lite

### DIFF
--- a/apps/lite/e2e/tests/sidebar.spec.ts
+++ b/apps/lite/e2e/tests/sidebar.spec.ts
@@ -97,4 +97,56 @@ test("keeps unread PR activity off the Workspace tab", async ({ appWindow, elect
 	await expect(pages.getByRole("button", { name: "Workspace", exact: true })).toHaveText(
 		"Workspace",
 	);
+	await appWindow.evaluate(() => {
+		const projectId = location.pathname.split("/")[2];
+		if (projectId === undefined) throw new Error("No project in the URL");
+		const key = `pr_activity_inbox:v1:${projectId}`;
+		const entries = JSON.parse(localStorage.getItem(key) ?? "[]") as Array<{
+			id: string;
+			author: string | null;
+			snippet: string | null;
+		}>;
+		const first = entries[0];
+		if (first === undefined) throw new Error("No seeded notification");
+		entries.push({
+			...first,
+			id: "bot-1",
+			author: "copilot-pull-request-reviewer",
+			snippet: "Bot review",
+		});
+		localStorage.setItem(key, JSON.stringify(entries));
+	});
+	await appWindow.reload();
+	await appWindow.getByRole("button", { name: "Notifications, 2 unread" }).click();
+	const humanTab = appWindow.getByRole("tab", { name: "Humans (1)", exact: true });
+	const agentTab = appWindow.getByRole("tab", { name: "Agents (1)", exact: true });
+	const humanPanel = appWindow.getByRole("tabpanel", { name: "Humans (1)", exact: true });
+	const agentPanel = appWindow.getByRole("tabpanel", { name: "Agents (1)", exact: true });
+	await expect(humanTab).toHaveAttribute("aria-selected", "true");
+	await expect(humanPanel).toContainText("Please take a look");
+	await expect(humanPanel).not.toContainText("Bot review");
+	// Keep the outgoing panel mounted long enough to inspect a tab transition.
+	const transitionStyle = await appWindow.addStyleTag({
+		content: `
+		@keyframes hold-panel { from { opacity: 1; } to { opacity: 0.99; } }
+		[role="tabpanel"][data-ending-style] { animation: hold-panel 60s linear; }
+	`,
+	});
+	await humanTab.focus();
+	await appWindow.keyboard.press("ArrowRight");
+	await expect(agentTab).toBeFocused();
+	await agentTab.click();
+	await expect(agentPanel).toContainText("Bot review");
+	await expect(agentPanel).not.toContainText("Please take a look");
+	await expect(humanPanel).toContainText("Please take a look");
+	await expect(humanPanel).not.toContainText("Bot review");
+	await transitionStyle.evaluate((element) => {
+		element.parentNode?.removeChild(element);
+	});
+	await appWindow.getByRole("button", { name: "Mark all read", exact: true }).click();
+	await expect(appWindow.getByRole("tab", { name: "Agents", exact: true })).toBeVisible();
+	await expect(humanTab).toBeVisible();
+	await expect(appWindow.getByRole("button", { name: "Notifications, 1 unread" })).toBeVisible();
+	await humanTab.click();
+	await expect(humanPanel).toContainText("Please take a look");
 });

--- a/apps/lite/ui/src/review-activity.test.ts
+++ b/apps/lite/ui/src/review-activity.test.ts
@@ -265,6 +265,15 @@ describe("activityItems", () => {
 		];
 		const items = activityItems([], submissions, [], events, 0);
 		expect(items.map((item) => item.kind)).toEqual(["verdict", "reviewRequested", "committed"]);
+		const automated = activityItems(
+			[],
+			submissions.map((item) => ({ ...item, author: { ...user("review-agent"), isBot: true } })),
+			[],
+			events.map((event) => ({ ...event, actor: user("ci[bot]") })),
+			0,
+		);
+		expect(automated.map((item) => item.authorIsBot)).toEqual([true, true, true]);
+		expect(items.map((item) => item.authorIsBot)).toEqual([false, false, false]);
 	});
 
 	it("reads diff-anchored comments as comments, mention and all", () => {
@@ -307,6 +316,21 @@ describe("activityItems", () => {
 		expect(items[0]).toMatchObject({ kind: "comment", author: "alice" });
 		// A mention left on a diff line waits for the user like any other.
 		expect(items.filter((item) => itemMentions(item, "me"))).toHaveLength(1);
+		const automated = activityItems(
+			[],
+			[],
+			threads.map((thread) => ({
+				...thread,
+				comments: thread.comments.map((comment) => ({
+					...comment,
+					author: { ...user("review-agent"), isBot: true },
+				})),
+			})),
+			[],
+			at("2026-08-28T10:00:00Z"),
+		);
+		expect(automated.map((item) => item.authorIsBot)).toEqual([true]);
+		expect(items[0]?.authorIsBot).toBe(false);
 	});
 });
 
@@ -357,4 +381,29 @@ describe("mentions", () => {
 	it("stays silent for a mention in the user's own text", () => {
 		expect(attentionOf(comment("me", 1, "note to @me"), "me")).toBe("silent");
 	});
+});
+
+it("preserves forge bot flags and bot suffixes when reducing comments", () => {
+	const comments = [
+		user("alice"),
+		{ ...user("copilot"), isBot: true },
+		user("renovate[bot]"),
+		null,
+	].map(
+		(author, id): ForgeReviewComment => ({
+			id,
+			author,
+			body: "Hello",
+			createdAt: "2026-08-28T11:00:00Z",
+			modifiedAt: null,
+			htmlUrl: "",
+			reactions: [],
+		}),
+	);
+	expect(activityItems(comments, [], [], [], 0).map((item) => item.authorIsBot)).toEqual([
+		false,
+		true,
+		true,
+		false,
+	]);
 });

--- a/apps/lite/ui/src/review-activity.ts
+++ b/apps/lite/ui/src/review-activity.ts
@@ -6,6 +6,8 @@
  * it live listings and turns its verdicts into toasts.
  */
 
+import { isAgent } from "#ui/review-users.ts";
+
 import type {
 	ForgeReview,
 	ForgeReviewComment,
@@ -20,7 +22,7 @@ import type {
  *
  * @public exported for the fabricated events in the test suite.
  */
-export type ReviewActivityItem =
+export type ReviewActivityItem = { authorIsBot?: boolean } & (
 	| { kind: "comment"; id: number; author: string | null; body: string; atMs: number }
 	| {
 			kind: "verdict";
@@ -36,7 +38,8 @@ export type ReviewActivityItem =
 			requestedReviewer: string | null;
 			atMs: number;
 	  }
-	| { kind: "committed"; author: string | null; atMs: number };
+	| { kind: "committed"; author: string | null; atMs: number }
+);
 
 type Attention = "loud" | "quiet" | "silent";
 
@@ -187,6 +190,7 @@ export const activityItems = (
 				kind: "comment",
 				id: comment.id,
 				author: comment.author?.login ?? null,
+				authorIsBot: comment.author != null && isAgent(comment.author),
 				body: comment.body,
 				atMs,
 			});
@@ -202,6 +206,7 @@ export const activityItems = (
 					kind: "comment",
 					id: comment.id,
 					author: comment.author?.login ?? null,
+					authorIsBot: comment.author != null && isAgent(comment.author),
 					body: comment.body,
 					atMs,
 				});
@@ -215,6 +220,7 @@ export const activityItems = (
 				kind: "verdict",
 				id: submission.id,
 				author: submission.author?.login ?? null,
+				authorIsBot: submission.author != null && isAgent(submission.author),
 				state: submission.state,
 				body: submission.body,
 				atMs,
@@ -225,15 +231,17 @@ export const activityItems = (
 		const atMs = parseMs(event.createdAt);
 		if (atMs <= sinceMs) continue;
 		const author = event.actor?.login ?? null;
+		const authorIsBot = event.actor != null && isAgent(event.actor);
 		if (event.kind === "reviewRequested") {
 			items.push({
 				kind: "reviewRequested",
 				author,
+				authorIsBot,
 				requestedReviewer: event.requestedReviewer?.login ?? null,
 				atMs,
 			});
 		} else {
-			items.push({ kind: "committed", author, atMs });
+			items.push({ kind: "committed", author, authorIsBot, atMs });
 		}
 	}
 	return items;

--- a/apps/lite/ui/src/review-inbox-bell.module.css
+++ b/apps/lite/ui/src/review-inbox-bell.module.css
@@ -49,7 +49,43 @@
 	text-align: center;
 }
 
+.tabs {
+	display: flex;
+	flex-direction: column;
+	min-height: 0;
+}
+
+.tabList {
+	display: flex;
+	flex-shrink: 0;
+	padding: 0 12px;
+	gap: 16px;
+	border-bottom: 1px solid var(--border-3);
+}
+
+.tab {
+	padding: 10px 0;
+	border: none;
+	border-bottom: 2px solid transparent;
+	background: none;
+	color: var(--text-3);
+
+	&[data-active] {
+		border-bottom-color: var(--text-1);
+		color: var(--text-1);
+	}
+
+	&:hover {
+		color: var(--text-1);
+	}
+
+	&:focus-visible {
+		outline: var(--focus-ring);
+	}
+}
+
 .list {
+	min-height: 0;
 	overflow-y: auto;
 }
 

--- a/apps/lite/ui/src/review-inbox-bell.tsx
+++ b/apps/lite/ui/src/review-inbox-bell.tsx
@@ -8,6 +8,7 @@
  */
 
 import { forgeInfoOptions, headInfoQueryOptions } from "#ui/api/queries.ts";
+import { Tabs } from "@base-ui/react/tabs";
 import { Icon } from "#ui/components/Icon.tsx";
 import type { IconName } from "#ui/components/iconNames.ts";
 import { RelativeTime } from "#ui/components/RelativeTime.tsx";
@@ -19,7 +20,7 @@ import {
 	inboxKindAttention,
 	markInboxSeen,
 	useInboxEntries,
-	useInboxUnseenCount,
+	isBotEntry,
 	type InboxEntry,
 	type InboxKind,
 } from "#ui/review-inbox.ts";
@@ -28,6 +29,8 @@ import { Dropdown } from "#ui/components/Popup.tsx";
 import { useQuery } from "@tanstack/react-query";
 import { useState, type FC } from "react";
 import styles from "./review-inbox-bell.module.css";
+
+const notificationTypes = ["humans", "agents"] as const;
 
 const kindIcon: Record<InboxKind, IconName> = {
 	comment: "text-block",
@@ -105,12 +108,19 @@ const Entry: FC<{
  */
 export const NotificationBell: FC<{ projectId: string }> = ({ projectId }) => {
 	const [open, setOpen] = useState(false);
+	const [tab, setTab] = useState<"humans" | "agents">("humans");
 	const { data: forgeInfo } = useQuery(forgeInfoOptions(projectId));
 	// Unconditional: behind `&&` the hook count would change mid-mount.
 	const level = usePrNotificationsLevel();
 	const shown = level === "loud" && !!forgeInfo?.capabilities.prService;
-	const entries = useInboxEntries(projectId, shown);
-	const unseen = useInboxUnseenCount(projectId, shown);
+	const allEntries = useInboxEntries(projectId, shown);
+	const humanEntries = allEntries.filter((entry) => !isBotEntry(entry));
+	const agentEntries = allEntries.filter(isBotEntry);
+	const humanUnseen = humanEntries.filter((entry) => !entry.seen).length;
+	const agentUnseen = agentEntries.filter((entry) => !entry.seen).length;
+	const unseen = humanUnseen + agentUnseen;
+	const entries = tab === "agents" ? agentEntries : humanEntries;
+	const tabUnseen = tab === "agents" ? agentUnseen : humanUnseen;
 	const { data: appliedRefs } = useQuery({
 		...headInfoQueryOptions(projectId),
 		select: appliedRefsByName,
@@ -138,31 +148,53 @@ export const NotificationBell: FC<{ projectId: string }> = ({ projectId }) => {
 		>
 			<div className={styles.panelHeader}>
 				<span className={classes("text-12", "text-semibold")}>Notifications</span>
-				{unseen > 0 && (
+				{tabUnseen > 0 && (
 					<button
 						className={classes("text-12", styles.markAll)}
-						onClick={() => markInboxSeen(projectId)}
+						onClick={() =>
+							markInboxSeen(
+								projectId,
+								entries.map((entry) => entry.id),
+							)
+						}
 						type="button"
 					>
 						Mark all read
 					</button>
 				)}
 			</div>
-			{entries.length === 0 ? (
-				<div className={classes("text-12", styles.empty)}>Nothing yet</div>
-			) : (
-				<div className={styles.list}>
-					{entries.map((entry) => (
-						<Entry
-							key={entry.id}
-							projectId={projectId}
-							entry={entry}
-							appliedRefs={appliedRefs}
-							onNavigate={() => setOpen(false)}
-						/>
-					))}
-				</div>
-			)}
+			<Tabs.Root value={tab} onValueChange={setTab} className={styles.tabs}>
+				<Tabs.List aria-label="Notification type" className={styles.tabList}>
+					<Tabs.Tab value="humans" className={classes("text-12", styles.tab)}>
+						Humans{humanUnseen > 0 && ` (${humanUnseen})`}
+					</Tabs.Tab>
+					<Tabs.Tab value="agents" className={classes("text-12", styles.tab)}>
+						Agents{agentUnseen > 0 && ` (${agentUnseen})`}
+					</Tabs.Tab>
+				</Tabs.List>
+				{notificationTypes.map((type) => {
+					const panelEntries = type === "humans" ? humanEntries : agentEntries;
+					return (
+						<Tabs.Panel key={type} value={type} className={styles.list}>
+							{panelEntries.length === 0 ? (
+								<div className={classes("text-12", styles.empty)}>
+									{type === "agents" ? "No agent notifications yet" : "No human notifications yet"}
+								</div>
+							) : (
+								panelEntries.map((entry) => (
+									<Entry
+										key={entry.id}
+										projectId={projectId}
+										entry={entry}
+										appliedRefs={appliedRefs}
+										onNavigate={() => setOpen(false)}
+									/>
+								))
+							)}
+						</Tabs.Panel>
+					);
+				})}
+			</Tabs.Root>
 		</Dropdown>
 	);
 };

--- a/apps/lite/ui/src/review-inbox.test.ts
+++ b/apps/lite/ui/src/review-inbox.test.ts
@@ -3,6 +3,8 @@ import {
 	addInboxEntries,
 	desktopNotices,
 	entryHeadline,
+	findInboxEntry,
+	isBotEntry,
 	markInboxSeen,
 	summaryNoticeId,
 	type InboxEntry,
@@ -84,6 +86,48 @@ describe("addInboxEntries", () => {
 		expect(kept).toHaveLength(100);
 		expect(kept[0]?.id).toBe("e104");
 		expect(kept[99]?.id).toBe("e5");
+	});
+});
+
+describe("retention per notification type", () => {
+	const batch = (authorIsBot: boolean, offset: number) =>
+		Array.from({ length: 105 }, (_, i) =>
+			entry(`${authorIsBot ? "agent" : "human"}-${i}`, 0, {
+				authorIsBot,
+				at: new Date(1756500000000 + (offset + i) * 60000).toISOString(),
+			}),
+		);
+
+	it.each([false, true])(
+		"keeps older notifications when the other type floods the inbox (agents first: %s)",
+		(agentsFirst) => {
+			const projectId = freshProject();
+			addInboxEntries(projectId, batch(agentsFirst, 0));
+			addInboxEntries(projectId, batch(!agentsFirst, 200));
+			const kept = stored(projectId);
+			expect(kept).toHaveLength(200);
+			expect(kept.filter(isBotEntry)).toHaveLength(100);
+			expect(kept.filter((item) => !isBotEntry(item))).toHaveLength(100);
+			expect(kept.some((item) => item.id.endsWith("-0"))).toBe(false);
+			expect(kept.every((item, i) => i === 0 || item.at <= (kept[i - 1]?.at ?? item.at))).toBe(
+				true,
+			);
+		},
+	);
+
+	it("retains both types when reading persisted entries", () => {
+		const projectId = freshProject();
+		localStorage.setItem(
+			`pr_activity_inbox:v1:${projectId}`,
+			JSON.stringify([...batch(false, 0), ...batch(true, 200)]),
+		);
+		markInboxSeen(projectId);
+		const kept = stored(projectId);
+		expect(kept).toHaveLength(200);
+		expect(kept.filter(isBotEntry)).toHaveLength(100);
+		expect(kept.every((item) => item.seen)).toBe(true);
+		expect(kept[0]?.id).toBe("agent-104");
+		expect(kept[199]?.id).toBe("human-5");
 	});
 });
 
@@ -221,4 +265,139 @@ describe("desktopNotices", () => {
 	it("says nothing for quiet news", () => {
 		expect(desktopNotices([entry("a", 0, { kind: "merged" })])).toEqual([]);
 	});
+});
+
+describe("bot notifications", () => {
+	it("recognizes forge flags and legacy bot logins without hiding unknown authors", () => {
+		expect(isBotEntry(entry("flagged", 1, { author: "copilot", authorIsBot: true }))).toBe(true);
+		expect(isBotEntry(entry("legacy", 1, { author: "renovate[bot]" }))).toBe(true);
+		expect(isBotEntry(entry("reviewer", 1, { author: "copilot-pull-request-reviewer" }))).toBe(
+			true,
+		);
+		expect(isBotEntry(entry("copilot", 1, { author: "Copilot" }))).toBe(true);
+		expect(
+			isBotEntry(entry("copilot-unflagged", 1, { author: "copilot", authorIsBot: false })),
+		).toBe(true);
+		expect(isBotEntry(entry("unknown", 1, { author: null }))).toBe(false);
+		expect(isBotEntry(entry("human", 1))).toBe(false);
+	});
+
+	it("retains bot metadata in persisted entries", () => {
+		const projectId = freshProject();
+		addInboxEntries(projectId, [entry("bot", 1, { authorIsBot: true })]);
+		expect(stored(projectId)[0]?.authorIsBot).toBe(true);
+	});
+});
+
+describe("rediscovered activity", () => {
+	it.each([false, true])(
+		"deduplicates a legacy agent entry without changing its seen state (%s)",
+		(seen) => {
+			const projectId = freshProject();
+			const id = `7:comment:${at(1)}`;
+			localStorage.setItem(
+				`pr_activity_inbox:v1:${projectId}`,
+				JSON.stringify([entry(id, 1, { author: "copilot-pull-request-reviewer", seen })]),
+			);
+			expect(
+				addInboxEntries(projectId, [
+					entry(`${id}:bot`, 1, { author: "copilot-pull-request-reviewer", authorIsBot: true }),
+				]),
+			).toEqual([]);
+			addInboxEntries(projectId, [entry("unrelated", 2)]);
+			addInboxEntries(freshProject(), [entry("other", 1)]);
+			expect(findInboxEntry(projectId, id)?.seen).toBe(seen);
+		},
+	);
+
+	it("does not confuse a human entry with an agent entry at the same timestamp", () => {
+		const projectId = freshProject();
+		const id = `7:comment:${at(1)}`;
+		addInboxEntries(projectId, [entry(id, 1)]);
+		expect(addInboxEntries(projectId, [entry(`${id}:bot`, 1, { authorIsBot: true })])).toHaveLength(
+			1,
+		);
+		expect(stored(projectId)).toHaveLength(2);
+	});
+
+	it("does not announce replayed activity that falls outside the retained history", () => {
+		const projectId = freshProject();
+		const old = entry("old", 0);
+		addInboxEntries(projectId, [old]);
+		markInboxSeen(projectId, [old.id]);
+		addInboxEntries(
+			projectId,
+			Array.from({ length: 100 }, (_, i) =>
+				entry(`new-${i}`, 1, { at: new Date(Date.parse(at(1)) + i * 60000).toISOString() }),
+			),
+		);
+		// Reading another project evicts the in-memory cache, as a reload would.
+		addInboxEntries(freshProject(), [entry("other", 1)]);
+		expect(addInboxEntries(projectId, [old])).toEqual([]);
+		expect(stored(projectId).some((item) => item.id === old.id)).toBe(false);
+	});
+});
+
+it("keeps a human notification that shares a legacy agent timestamp", () => {
+	const projectId = freshProject();
+	const id = `7:comment:${at(1)}`;
+	localStorage.setItem(
+		`pr_activity_inbox:v1:${projectId}`,
+		JSON.stringify([entry(id, 1, { author: "copilot-pull-request-reviewer", seen: true })]),
+	);
+	expect(addInboxEntries(projectId, [entry(id, 1)])).toHaveLength(1);
+	expect(stored(projectId)).toHaveLength(2);
+	expect(findInboxEntry(projectId, id)?.author).toBe("alice");
+	expect(findInboxEntry(projectId, `${id}:bot`)?.seen).toBe(true);
+	addInboxEntries(freshProject(), [entry("other", 1)]);
+	expect(findInboxEntry(projectId, `${id}:bot`)?.seen).toBe(true);
+});
+
+it("merges already duplicated legacy agent entries without losing read state", () => {
+	const projectId = freshProject();
+	const id = `7:comment:${at(1)}`;
+	localStorage.setItem(
+		`pr_activity_inbox:v1:${projectId}`,
+		JSON.stringify([
+			entry(`${id}:bot`, 1, { author: "copilot-pull-request-reviewer", authorIsBot: true }),
+			entry(id, 1, { author: "copilot-pull-request-reviewer", seen: true }),
+		]),
+	);
+	addInboxEntries(projectId, [entry("another", 2)]);
+	expect(stored(projectId)).toHaveLength(2);
+	expect(findInboxEntry(projectId, id)?.seen).toBe(true);
+	expect(findInboxEntry(projectId, id)?.authorIsBot).toBe(true);
+});
+
+it("does not resolve an evicted human desktop notice to an agent", () => {
+	const projectId = freshProject();
+	const id = `7:comment:${at(0)}`;
+	addInboxEntries(projectId, [entry(id, 0), entry(`${id}:bot`, 0, { authorIsBot: true })]);
+	addInboxEntries(
+		projectId,
+		Array.from({ length: 100 }, (_, i) =>
+			entry(`human-${i}`, 1, { at: new Date(Date.parse(at(1)) + i * 60000).toISOString() }),
+		),
+	);
+	expect(findInboxEntry(projectId, id)).toBeUndefined();
+	expect(findInboxEntry(projectId, `${id}:bot`)).toBeDefined();
+});
+
+it("retires a migrated alias when a human entry claims its ID", () => {
+	const projectId = freshProject();
+	const id = `7:comment:${at(0)}`;
+	localStorage.setItem(
+		`pr_activity_inbox:v1:${projectId}`,
+		JSON.stringify([entry(id, 0, { author: "copilot-pull-request-reviewer" })]),
+	);
+	addInboxEntries(projectId, [entry(id, 0)]);
+	addInboxEntries(
+		projectId,
+		Array.from({ length: 100 }, (_, i) =>
+			entry(`human-${i}`, 1, { at: new Date(Date.parse(at(1)) + i * 60000).toISOString() }),
+		),
+	);
+	addInboxEntries(freshProject(), [entry("other", 1)]);
+	expect(findInboxEntry(projectId, id)).toBeUndefined();
+	expect(findInboxEntry(projectId, `${id}:bot`)).toBeDefined();
 });

--- a/apps/lite/ui/src/review-inbox.ts
+++ b/apps/lite/ui/src/review-inbox.ts
@@ -7,6 +7,7 @@
  * in-memory snapshots.
  */
 
+import { isAgent } from "#ui/review-users.ts";
 import type { ShowNotificationParams } from "#electron/ipc.ts";
 import { markReviewsSeenUpTo } from "#ui/review-seen.ts";
 import { useSyncExternalStore } from "react";
@@ -23,6 +24,7 @@ export type InboxKind =
 
 export type InboxEntry = {
 	id: string;
+	legacyId?: string;
 	kind: InboxKind;
 	review: number;
 	reviewTitle: string;
@@ -30,6 +32,7 @@ export type InboxEntry = {
 	sourceBranch: string;
 	htmlUrl: string;
 	author: string | null;
+	authorIsBot?: boolean;
 	/** How many items this entry coalesces — "3 comments". */
 	count: number;
 	/** The comment a click should land on, when the entry is about comments. */
@@ -126,10 +129,21 @@ export const desktopNotices = (fresh: ReadonlyArray<InboxEntry>): Array<ShowNoti
 	];
 };
 
+export const isBotEntry = (entry: InboxEntry): boolean =>
+	isAgent({ login: entry.author ?? "", isBot: entry.authorIsBot === true });
+
 const storageKey = (projectId: string) => `pr_activity_inbox:v1:${projectId}`;
 
-/** Newest kept; the overflow was old news nobody opened. */
-const inboxCap = 100;
+/** Each tab keeps its own history so agent traffic cannot crowd out humans. */
+const inboxCapPerType = 100;
+
+const capEntries = (entries: Array<InboxEntry>): Array<InboxEntry> => {
+	let humans = 0;
+	let agents = 0;
+	return entries.filter((entry) =>
+		isBotEntry(entry) ? ++agents <= inboxCapPerType : ++humans <= inboxCapPerType,
+	);
+};
 
 const listeners = new Set<() => void>();
 let cached: { key: string; entries: Array<InboxEntry> } | null = null;
@@ -151,6 +165,34 @@ const storageSet = (key: string, value: string): void => {
 	}
 };
 
+const migrateEntries = (entries: Array<InboxEntry>): Array<InboxEntry> => {
+	const byId = new Map<string, InboxEntry>();
+	for (const stored of entries) {
+		const legacyAgent =
+			stored.authorIsBot === undefined &&
+			isBotEntry(stored) &&
+			stored.id === `${stored.review}:${stored.kind}:${stored.at}`;
+		const entry = legacyAgent ? { ...stored, id: `${stored.id}:bot`, legacyId: stored.id } : stored;
+		const previous = byId.get(entry.id);
+		byId.set(
+			entry.id,
+			previous
+				? {
+						...entry,
+						seen: previous.seen || entry.seen,
+						authorIsBot: entry.authorIsBot ?? previous.authorIsBot,
+						legacyId: entry.legacyId ?? previous.legacyId,
+					}
+				: entry,
+		);
+	}
+	return [...byId.values()].map((entry) =>
+		entry.legacyId !== undefined && byId.has(entry.legacyId)
+			? { ...entry, legacyId: undefined }
+			: entry,
+	);
+};
+
 const parseEntries = (raw: string | null): Array<InboxEntry> => {
 	if (raw === null) return [];
 	try {
@@ -158,30 +200,35 @@ const parseEntries = (raw: string | null): Array<InboxEntry> => {
 		if (!Array.isArray(stored)) return [];
 		// Ordered here, not just at write time: a list stored by an older
 		// build keeps whatever order it had until something new files.
-		return stored
-			.filter((entry): entry is InboxEntry => {
-				if (typeof entry !== "object" || entry === null) return false;
-				const e = entry as Record<string, unknown>;
-				return (
-					typeof e.id === "string" &&
-					typeof e.kind === "string" &&
-					inboxKinds.includes(e.kind) &&
-					typeof e.review === "number" &&
-					typeof e.reviewTitle === "string" &&
-					typeof e.unitSymbol === "string" &&
-					typeof e.sourceBranch === "string" &&
-					typeof e.htmlUrl === "string" &&
-					(e.author === null || typeof e.author === "string") &&
-					typeof e.count === "number" &&
-					(e.commentId === undefined || e.commentId === null || typeof e.commentId === "number") &&
-					(e.snippet === null || typeof e.snippet === "string") &&
-					typeof e.at === "string" &&
-					!Number.isNaN(Date.parse(e.at)) &&
-					typeof e.seen === "boolean"
-				);
-			})
-			.sort((a, b) => Date.parse(b.at) - Date.parse(a.at))
-			.slice(0, inboxCap);
+		return capEntries(
+			migrateEntries(
+				stored.filter((entry): entry is InboxEntry => {
+					if (typeof entry !== "object" || entry === null) return false;
+					const e = entry as Record<string, unknown>;
+					return (
+						typeof e.id === "string" &&
+						(e.legacyId === undefined || typeof e.legacyId === "string") &&
+						typeof e.kind === "string" &&
+						inboxKinds.includes(e.kind) &&
+						typeof e.review === "number" &&
+						typeof e.reviewTitle === "string" &&
+						typeof e.unitSymbol === "string" &&
+						typeof e.sourceBranch === "string" &&
+						typeof e.htmlUrl === "string" &&
+						(e.author === null || typeof e.author === "string") &&
+						(e.authorIsBot === undefined || typeof e.authorIsBot === "boolean") &&
+						typeof e.count === "number" &&
+						(e.commentId === undefined ||
+							e.commentId === null ||
+							typeof e.commentId === "number") &&
+						(e.snippet === null || typeof e.snippet === "string") &&
+						typeof e.at === "string" &&
+						!Number.isNaN(Date.parse(e.at)) &&
+						typeof e.seen === "boolean"
+					);
+				}),
+			).sort((a, b) => Date.parse(b.at) - Date.parse(a.at)),
+		);
 	} catch {
 		return [];
 	}
@@ -232,7 +279,8 @@ const subscribeNothing = (): (() => void) => () => {};
  * File the poll's entries, keeping the list ordered by each entry's own
  * time. An id already filed is left exactly where it is, seen state and
  * all — a review bumping again must not resurface an old entry as new.
- * Returns the entries that were actually new.
+ * Returns new entries that survive retention, so replaying evicted history
+ * cannot announce stale activity again.
  */
 export const addInboxEntries = (
 	projectId: string,
@@ -243,11 +291,20 @@ export const addInboxEntries = (
 	const known = new Set(existing.map((entry) => entry.id));
 	const fresh = entries.filter((entry) => !known.has(entry.id));
 	if (fresh.length === 0) return [];
-	const next = [...fresh, ...existing]
-		.sort((a, b) => Date.parse(b.at) - Date.parse(a.at))
-		.slice(0, inboxCap);
+	const claimedIds = new Set(fresh.map((entry) => entry.id));
+	const retainedExisting = existing.map((entry) =>
+		entry.legacyId !== undefined && claimedIds.has(entry.legacyId)
+			? { ...entry, legacyId: undefined }
+			: entry,
+	);
+	const next = capEntries(
+		[...fresh, ...retainedExisting].sort((a, b) => Date.parse(b.at) - Date.parse(a.at)),
+	);
+	const retained = new Set(next);
+	const filed = fresh.filter((entry) => retained.has(entry));
+	if (filed.length === 0) return [];
 	writeEntries(projectId, next);
-	return fresh;
+	return filed;
 };
 
 /**
@@ -275,8 +332,11 @@ export const markInboxSeen = (projectId: string, ids?: ReadonlyArray<string>): v
 };
 
 /** The entry a desktop notification was shown for, if it is still filed. */
-export const findInboxEntry = (projectId: string, id: string): InboxEntry | undefined =>
-	readEntries(projectId).find((entry) => entry.id === id);
+export const findInboxEntry = (projectId: string, id: string): InboxEntry | undefined => {
+	const entries = readEntries(projectId);
+	// Only migrated entries can answer to an old desktop notification ID.
+	return entries.find((entry) => entry.id === id) ?? entries.find((entry) => entry.legacyId === id);
+};
 
 /** The inbox, newest first — a stable array identity between writes. */
 export const useInboxEntries = (projectId: string, enabled: boolean): Array<InboxEntry> =>
@@ -285,9 +345,3 @@ export const useInboxEntries = (projectId: string, enabled: boolean): Array<Inbo
 	);
 
 const emptyInbox: Array<InboxEntry> = [];
-
-/** How many entries are unseen — the bell's dot. */
-export const useInboxUnseenCount = (projectId: string, enabled: boolean): number =>
-	useSyncExternalStore(enabled ? subscribeInbox : subscribeNothing, () =>
-		enabled ? readEntries(projectId).filter((entry) => !entry.seen).length : 0,
-	);

--- a/apps/lite/ui/src/review-notifications.test.ts
+++ b/apps/lite/ui/src/review-notifications.test.ts
@@ -1,0 +1,76 @@
+/** @vitest-environment jsdom */
+import { describe, expect, it } from "vitest";
+import type { ForgeReview } from "@gitbutler/but-sdk";
+import { coalesceInboxEntries } from "./review-notifications.ts";
+import { addInboxEntries } from "./review-inbox.ts";
+
+const review = (overrides: Partial<ForgeReview> = {}): ForgeReview => ({
+	htmlUrl: "https://forge.example/pr/7",
+	number: 7,
+	title: "A change",
+	body: null,
+	author: null,
+	labels: [],
+	draft: false,
+	sourceBranch: "feature",
+	targetBranch: "main",
+	sha: "abc",
+	integrationCommitShas: [],
+	createdAt: "2026-08-28T09:00:00Z",
+	modifiedAt: "2026-08-28T10:00:00Z",
+	mergedAt: null,
+	closedAt: null,
+	repositorySshUrl: null,
+	repositoryHttpsUrl: null,
+	repoOwner: null,
+	headRepoIsFork: false,
+	reviewers: [],
+	autoMergeEnabled: false,
+	unitSymbol: "#",
+	lastSyncAt: "2026-08-28T10:00:00Z",
+	...overrides,
+});
+
+describe("coalesceInboxEntries", () => {
+	it("files human and agent comments from one poll separately, even at the same timestamp", () => {
+		const atMs = Date.parse("2026-08-28T11:00:00Z");
+		const items = coalesceInboxEntries(
+			review(),
+			[
+				{ kind: "comment", id: 1, author: "alice", authorIsBot: false, body: "Human note", atMs },
+				{ kind: "comment", id: 2, author: "copilot", authorIsBot: true, body: "Agent note", atMs },
+				{
+					kind: "comment",
+					id: 3,
+					author: "alice",
+					authorIsBot: false,
+					body: "Earlier human note",
+					atMs: atMs - 1000,
+				},
+			],
+			null,
+		);
+		expect(items).toHaveLength(2);
+		expect(items[0]).toMatchObject({
+			id: "7:comment:2026-08-28T11:00:00.000Z",
+			author: "alice",
+			authorIsBot: false,
+			count: 2,
+			commentId: 1,
+			snippet: "Human note",
+		});
+		expect(items[1]).toMatchObject({
+			id: "7:comment:2026-08-28T11:00:00.000Z:bot",
+			author: "copilot",
+			authorIsBot: true,
+			count: 1,
+			commentId: 2,
+			snippet: "Agent note",
+		});
+		const projectId = "coalescing-test";
+		expect(addInboxEntries(projectId, items)).toHaveLength(2);
+		expect(
+			JSON.parse(localStorage.getItem(`pr_activity_inbox:v1:${projectId}`) ?? "[]"),
+		).toHaveLength(2);
+	});
+});

--- a/apps/lite/ui/src/review-notifications.ts
+++ b/apps/lite/ui/src/review-notifications.ts
@@ -138,7 +138,7 @@ const entryOf = (
 			? (review.modifiedAt ?? new Date().toISOString())
 			: new Date(newest.atMs).toISOString();
 	return {
-		id: `${review.number}:${kind}:${at}`,
+		id: `${review.number}:${kind}:${at}${newest?.authorIsBot ? ":bot" : ""}`,
 		// Where a click should land, when the entry is about comments.
 		commentId: newestCommentId(bucket),
 		kind,
@@ -148,6 +148,7 @@ const entryOf = (
 		sourceBranch: review.sourceBranch,
 		htmlUrl: review.htmlUrl,
 		author: newest?.author ?? null,
+		authorIsBot: newest?.authorIsBot ?? false,
 		count: Math.max(bucket.length, 1),
 		snippet:
 			newest !== null && (newest.kind === "comment" || newest.kind === "verdict")
@@ -156,6 +157,26 @@ const entryOf = (
 		at,
 		seen: false,
 	};
+};
+
+/**
+ * Coalesce one poll by kind and actor type, retaining each type's own target.
+ * @public exported for the test suite.
+ */
+export const coalesceInboxEntries = (
+	review: ForgeReview,
+	items: Array<ReviewActivityItem>,
+	login: string | null,
+): Array<InboxEntry> => {
+	const buckets = new Map<string, { kind: InboxKind; items: Array<ReviewActivityItem> }>();
+	for (const item of items) {
+		const kind = inboxKindOf(item, login);
+		const key = `${kind}:${item.authorIsBot === true}`;
+		const bucket = buckets.get(key);
+		if (bucket) bucket.items.push(item);
+		else buckets.set(key, { kind, items: [item] });
+	}
+	return [...buckets.values()].map(({ kind, items }) => entryOf(review, kind, items));
 };
 
 /**
@@ -241,14 +262,7 @@ export const useReviewActivityInbox = (projectId: string): void => {
 				return true;
 			},
 		);
-		const buckets = new Map<InboxKind, Array<ReviewActivityItem>>();
-		for (const item of items) {
-			const kind = inboxKindOf(item, login);
-			const bucket = buckets.get(kind);
-			if (bucket) bucket.push(item);
-			else buckets.set(kind, [item]);
-		}
-		return [...buckets].map(([kind, bucket]) => entryOf(change.review, kind, bucket));
+		return coalesceInboxEntries(change.review, items, login);
 	});
 
 	const observe = useEffectEvent(async (listing: Array<ForgeReview>) => {

--- a/apps/lite/ui/src/review-users.ts
+++ b/apps/lite/ui/src/review-users.ts
@@ -3,10 +3,10 @@ import type { ForgeReviewUser } from "@gitbutler/but-sdk";
 /**
  * Whether the user is an agent of any kind — Copilot, CI, a review bot.
  * The forge's own flag when it survives the trip, else the `[bot]` login
- * suffix every GitHub App carries.
+ * suffix and Copilot logins used by older cached GraphQL responses.
  */
-export const isAgent = (user: ForgeReviewUser): boolean =>
-	user.isBot || user.login.endsWith("[bot]");
+export const isAgent = (user: Pick<ForgeReviewUser, "isBot" | "login">): boolean =>
+	user.isBot || /(?:\[bot\]$|^copilot$|^copilot-pull-request-reviewer$)/i.test(user.login);
 
 /**
  * Whether two logins name the same account. GitHub logins are


### PR DESCRIPTION
Split the bell popup into Humans and Agents tabs, with independent unread counts and mark-all-read actions. Keep the newest 100 entries of each type so agent traffic cannot evict human notifications.

Preserve forge bot metadata, recognize legacy Copilot logins, and coalesce human and agent activity separately.

Validation: Lite typecheck, lint/formatting, Knip, 514 unit tests, and 31 E2E tests passed (9 skipped). Regression tests cover retention on writes and reloads; the sidebar E2E test covers tab navigation and independent read state. Verified the popup in the running app and checked React Compiler memoization.