### PR TITLE
Direct stub readers to applicable guide recipes

### DIFF
--- a/crates/but/skill/stub.md
+++ b/crates/but/skill/stub.md
@@ -7,3 +7,5 @@ but skill
 ```
 
 The guide covers the loop, IDs, rules, and task recipes. When you need a flag it does not mention, `but skill reference` prints each command's syntax and flags.
+
+Follow the guide's applicable recipes and stopping rules.


### PR DESCRIPTION
## 🧢 Changes

Add one sentence to the discovery stub: "Follow the guide's applicable recipes and stopping rules."

## ☕️ Reasoning

Make following the loaded guide explicit while keeping command and workflow guidance in the served skill.